### PR TITLE
Add memory care and multi-workspace handoff support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,9 +118,10 @@ A typical day has two short cross-harness summaries plus a session-review pass a
 |-----|----------|----------|
 | Nightshift standup | typical: `0 21 * * *` | `memory/cards/pipeline-standups.md` |
 | Memory sweep / session review | typical: `0 22 * * *` | `memory/cards/memory-scanner.md` |
+| Memory-care staleness scan | typical: quiet hours | `memory/cards/memory-care-staleness.md` |
 | Morning report | typical: `0 8 * * *` | `memory/cards/pipeline-standups.md` |
 
-Standups summarize state already in memory. The memory scanner promotes durable findings *into* memory from the day's sessions. Run order: standup -> scanner -> overnight ingester sweeps -> morning report next day.
+Standups summarize state already in memory. The memory scanner promotes durable findings *into* memory from the day's sessions. Memory care checks existing cards for stale facts. Run order: standup -> scanner -> overnight ingester sweeps -> memory-care scan -> morning report next day.
 
 ## Multi-Agent Workflow
 

--- a/INSTALL_FOR_AGENTS.md
+++ b/INSTALL_FOR_AGENTS.md
@@ -32,6 +32,10 @@ You may be invoked as the agent behind any of these. They are isolated sessions;
 
 See `memory/cards/pipeline-standups.md` and `memory/cards/memory-scanner.md` for the full job shape.
 
+If this workspace is one of several agent homes, read `memory/cards/multi-workspace-handoff-admin.md`. Secondary setups should inform the canonical owner through handoffs rather than keeping separate durable truth.
+
+If you are maintaining an established card set, read `memory/cards/memory-care-staleness.md` before editing stale cards. Refresh only from current source-of-truth files or route to manual review.
+
 ## If your harness loads a compact context
 
 Some harnesses load a generated `llms.txt` or `llms-full.txt` instead of every bootstrap file individually. If those exist in this workspace, follow them and rebuild via the workspace's build script when source docs change. If they do not exist, default to reading the files listed in "Start here" directly.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -54,6 +54,7 @@ Replace this with your actual agent roster. Example shape:
 | Night (~21:00) | Pipeline standup | [pipeline-standups](memory/cards/pipeline-standups.md) |
 | Night (~22:00) | Memory sweep / session review | [memory-scanner](memory/cards/memory-scanner.md) |
 | Continuous | Handoff ingester | [handoff-flow](memory/cards/handoff-flow.md) |
+| Quiet hours | Memory-care staleness scan | [memory-care-staleness](memory/cards/memory-care-staleness.md) |
 | Morning (~08:00) | Morning report | [pipeline-standups](memory/cards/pipeline-standups.md) |
 
 ## Card Categories
@@ -62,12 +63,13 @@ Build out this table as you learn the shape of your durable knowledge. Starter s
 
 | Category | Topics |
 |----------|--------|
-| foundation | memory architecture, handoff flow, content safety, memory scanner, chat-surface crawlers, pipeline standups |
+| foundation | memory architecture, handoff flow, content safety, memory scanner, memory care, chat-surface crawlers, pipeline standups |
 | system | identity, memory-search system, sub-agent patterns, agent-wrapper patterns |
 | user | personal context, communication style, preferences |
 | infrastructure | hosts, ports, deploys, mounts, local services |
 | models | subscriptions, assignment rules, benchmarks |
 | workflow | pipeline rules, content strategy, publishing checklist |
+| admin | multi-workspace handoff routing |
 | tools | local APIs, browser stacks, MCPs, skills |
 | security | hardening, audits, runbooks |
 | lessons | hard-won gotchas, corrections, prior-incident learnings |
@@ -79,6 +81,8 @@ Add categories as the workspace grows. One topic per card; one card per topic.
 - [memory-architecture](memory/cards/memory-architecture.md) - how this workspace stores durable knowledge
 - [handoff-flow](memory/cards/handoff-flow.md) - how Memory Handoffs flow into canonical memory
 - [memory-scanner](memory/cards/memory-scanner.md) - session-review pass that promotes durable findings
+- [memory-care-staleness](memory/cards/memory-care-staleness.md) - card decay scans and safe refresh rules
+- [multi-workspace-handoff-admin](memory/cards/multi-workspace-handoff-admin.md) - pulling remote setup handoffs into one canonical owner
 - [pipeline-standups](memory/cards/pipeline-standups.md) - nightshift + morning cross-harness recaps
 - [chat-surface-crawlers](memory/cards/chat-surface-crawlers.md) - discrawl-shaped local archives for Discord, Slack, WhatsApp, etc.
 - [content-safety](memory/cards/content-safety.md) - publish gates and what they block

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -84,6 +84,8 @@ solo-mise ingest --target ~/agent-kitchen
 
 The ingester is conservative. Handoffs with `Recommended memory action: create-card` and a safe filename + frontmatter become memory cards. Handoffs that route to `TOOLS.md`, `USER.md`, `rules/*.md`, or `.learnings/*.md` get appended. Anything ambiguous lands in `memory/handoff-inbox/` for manual review.
 
+If you administer multiple agent setups, keep one canonical owner and pull remote handoffs into staging directories before ingesting them. See `memory/cards/multi-workspace-handoff-admin.md`.
+
 ## 7. Scrub before publishing
 
 ```bash
@@ -106,3 +108,4 @@ The fragments are JSON files you can inspect and merge into your `openclaw.json`
 - Read [the cookbook](https://github.com/solomonneas/solos-cookbook) for the deep version of every concept here.
 - Customize `USER.md` and `TOOLS.md` with your real preferences and runbooks (kept private; do not commit personal details).
 - Wire the ingester on a cron or a manual end-of-day workflow.
+- Add a memory-care staleness scan when your card set starts to matter. See `memory/cards/memory-care-staleness.md`.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ The cookbook explains the why. This package gives you the kitchen.
 - a canonical memory layout where one configured owner holds durable knowledge
 - a shared `.claude/memory-handoffs/` inbox for Claude Code, Codex, and other side harnesses
 - starter memory cards and routing rules
+- multi-workspace handoff patterns for people administering more than one agent setup
+- memory-care staleness checks so durable cards do not quietly rot
 - content-guard publish gates so private infrastructure does not leak into public docs
 - adapter fragments for OpenClaw (tested), Hermes (stubbed), and generic harnesses
 - doctor checks that prove the system is wired before you trust it
@@ -93,6 +95,8 @@ memory/cards/*.md, TOOLS.md, USER.md, rules/*.md, .learnings/*.md
 ```
 
 The ingester is intentionally conservative. Safe card handoffs become cards. Targeted updates append to the right file. Ambiguous material gets kicked out for review instead of being trusted automatically.
+
+For users running multiple agent homes, treat the owner workspace as the hub. Remote or secondary workspaces can write handoffs into their own `.claude/memory-handoffs/` directories, then a trusted sync pulls those files into a staging inbox on the owner. That keeps agents informed about what happened elsewhere without creating multiple canonical memories.
 
 ## Related
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -73,6 +73,10 @@ See `RELEASE.md`.
 | `generic` | workspace + contract docs |
 | `publisher` | publish gate only (hook + policies + content-safety card) |
 
+## Multi-workspace memory
+
+Use `memory/cards/multi-workspace-handoff-admin.md` as the public-safe pattern for pulling handoffs from secondary agent homes into one canonical owner. Use `memory/cards/memory-care-staleness.md` for the card decay scanner and safe refresh loop.
+
 ## Where things live
 
 - Source: `src/solo_mise/`

--- a/memory/cards/handoff-flow.md
+++ b/memory/cards/handoff-flow.md
@@ -17,6 +17,12 @@ Claude Code, Codex, and other side harnesses write Memory Handoffs to `.claude/m
 5. Handoffs route to: a memory card, an appendable document, or the review inbox.
 6. Processed handoffs move to `.claude/memory-handoffs/processed/`.
 
+## Multiple Workspaces
+
+If you administer more than one agent setup, keep this flow hub-and-spoke. Secondary workspaces write local handoffs, then the canonical owner pulls them into staging directories and runs the same ingester. This lets agents on separate machines or repos inform each other about what changed without creating competing memory stores.
+
+See [multi-workspace-handoff-admin](multi-workspace-handoff-admin.md) for the full pattern.
+
 ## Auto-promotion rules
 
 Only three handoff shapes can silently mutate canonical memory. Everything else lands in `memory/handoff-inbox/` for manual review.

--- a/memory/cards/memory-architecture.md
+++ b/memory/cards/memory-architecture.md
@@ -23,6 +23,7 @@ This workspace uses a single canonical memory owner. Side harnesses may keep loc
   INSTALL_FOR_AGENTS.md
   memory/
     cards/             # durable knowledge cards (auto-promotion target)
+      decay/           # optional staleness scan output + refresh queue
     handoff-inbox/     # ambiguous handoffs land here for review
   rules/               # workflow rules (appendable target)
   .learnings/          # concrete failures + lessons (appendable target)

--- a/memory/cards/memory-care-staleness.md
+++ b/memory/cards/memory-care-staleness.md
@@ -1,0 +1,58 @@
+---
+topic: memory-care-staleness
+category: foundation
+tags: [memory, staleness, decay, refresh, maintenance]
+---
+
+# Memory Care Staleness
+
+Memory needs care after it is written. Durable cards can become wrong when services move, workflows change, models are renamed, or project priorities expire. A staleness checker gives the memory owner a queue of cards that need refresh, without letting an agent rewrite sensitive or judgment-heavy knowledge blindly.
+
+## Reference Loop
+
+```text
+memory/cards/*.md
+        |
+        v
+card decay scanner
+        |
+        v
+memory/cards/decay/scan-latest.json
+memory/cards/decay/refresh-queue.json
+        |
+        v
+safe refresh agent or manual review
+```
+
+## Scanner Output
+
+Store scan state under `memory/cards/decay/`:
+
+- `scan-latest.json` - latest full scan, counts, card statuses, decay ratios, and refresh queue size.
+- `refresh-queue.json` - small queue of cards that are stale enough to review.
+
+The scanner should report at least total cards, fresh count, aging count, stale count, critical count, and refresh queue size.
+
+## Safe Refresh Rules
+
+Only auto-refresh cards when current facts are grounded in local source-of-truth files read during the run. Good sources include `TOOLS.md`, `MEMORY.md`, recent `memory/YYYY-MM-DD.md`, local project docs, local scripts, and repo health reports.
+
+Do not auto-refresh cards that require human judgment, personal context, career decisions, school work, business strategy, or outside research. Put those in a manual queue.
+
+Never refresh by only bumping an `updated:` date. The content must change because a current source proves it should change.
+
+## Suggested Schedule
+
+- Daily scanner during quiet hours.
+- Safe auto-refresh shortly after the scanner, capped to a small number of cards.
+- Weekly deep report for manual review of sensitive or repeatedly skipped stale cards.
+
+## Verification
+
+```bash
+test -f memory/cards/decay/scan-latest.json
+test -f memory/cards/decay/refresh-queue.json
+jq '.counts, .refresh_queue_size' memory/cards/decay/scan-latest.json
+```
+
+If the queue grows for several days, either the refresh agent is too conservative, the source-of-truth files are stale, or the cards need manual pruning.

--- a/memory/cards/memory-scanner.md
+++ b/memory/cards/memory-scanner.md
@@ -86,6 +86,10 @@ Avoid promoting during active sessions because card writes invalidate prefix cac
 - the prompt should embed the skip-rules and cost controls above
 - output goes either directly to `memory/cards/*.md` (if your harness can write there) or through `.claude/memory-handoffs/` for the conservative ingester to route
 
+## Relationship to Memory Care
+
+The memory scanner captures new durable knowledge. The memory-care staleness loop reviews old cards for drift. Run both: scanner for new facts, staleness checker for old facts that may no longer be true. See [memory-care-staleness](memory-care-staleness.md).
+
 ## Anti-patterns
 
 - **Auto-promoting raw session fragments into `MEMORY.md`.** The index loads on every session; appending fragments nightly bloats it past the bootstrap budget and turns the on-load cache cost into a monthly tax. Write cards instead.

--- a/memory/cards/multi-workspace-handoff-admin.md
+++ b/memory/cards/multi-workspace-handoff-admin.md
@@ -1,0 +1,63 @@
+---
+topic: multi-workspace-handoff-admin
+category: workflow
+tags: [memory, handoff, multi-workspace, admin]
+---
+
+# Multi-Workspace Handoff Admin
+
+When one person administers multiple agent homes, only one workspace should own canonical durable memory. Other workspaces can run local sessions, keep local context, and write repo-local notes, but durable facts should flow back to the owner through Memory Handoffs.
+
+## Shape
+
+```text
+managed workspace A      managed workspace B      repo-local sessions
+  .claude/                 .claude/                 .claude/
+    memory-handoffs/         memory-handoffs/         memory-handoffs/
+          \                         |                         /
+           \                        |                        /
+            v                       v                       v
+          staging inboxes on the canonical memory owner
+                           |
+                           v
+                    solo-mise ingest
+                           |
+                           v
+              memory/cards/, TOOLS.md, USER.md, rules/, .learnings/
+```
+
+## Why
+
+Multiple active setups drift unless the agents can tell each other what happened. A secondary workspace should not silently become a second source of truth. Its job is to emit handoffs that say what changed, what evidence supports it, and what the canonical owner should remember.
+
+## Pull Pattern
+
+Run a small trusted sync from the canonical memory owner:
+
+```bash
+rsync -a --remove-source-files \
+  --include='*.md' --exclude='processed/***' --exclude='*' \
+  <remote>:<workspace>/.claude/memory-handoffs/ \
+  <canonical-workspace>/pipeline/incoming-handoffs/<remote-label>/
+```
+
+Then include each staging directory in the ingest loop. Keep remote labels generic, such as `laptop`, `homelab`, `client-a`, or `research-vm`.
+
+## Admin Rules
+
+- Pull into staging first, then ingest. Do not ingest directly over SSH.
+- Remove remote source files only after successful transfer to the canonical host.
+- Exclude `processed/` so archives do not churn forever.
+- Preserve the original handoff text for review. The canonical owner should see exactly what the remote harness wrote.
+- Use per-source labels so failures can be traced to the workspace that produced them.
+- Surface non-empty pulls to the agents that need to know. A handoff is both memory input and a coordination signal.
+
+## Verification
+
+```bash
+find pipeline/incoming-handoffs -name '*.md' -not -path '*/processed/*'
+solo-mise ingest --target . --dry-run
+ls memory/handoff-inbox/ 2>/dev/null | wc -l
+```
+
+If no remote handoffs arrive for a week while remote work is happening, the remote workspace probably lacks the closeout instruction, the sync is broken, or the files are landing in the wrong repo.

--- a/src/solo_mise/doctor.py
+++ b/src/solo_mise/doctor.py
@@ -23,6 +23,7 @@ def run(target: Path, harness: str = "generic") -> int:
 
     checks.extend(_check_workspace_files(target))
     checks.extend(_check_handoff_inbox(target))
+    checks.extend(_check_memory_care(target))
     checks.extend(_check_publish_gate(target))
 
     if harness == "openclaw":
@@ -90,6 +91,58 @@ def _check_handoff_inbox(target: Path) -> List[CheckResult]:
     return results
 
 
+def _check_memory_care(target: Path) -> List[CheckResult]:
+    results: List[CheckResult] = []
+    decay_dir = target / "memory" / "cards" / "decay"
+    scan = decay_dir / "scan-latest.json"
+    queue = decay_dir / "refresh-queue.json"
+
+    if decay_dir.is_dir():
+        results.append((OK, "memory-care: decay/", str(decay_dir)))
+    else:
+        results.append(
+            (
+                WARN,
+                "memory-care: decay/",
+                f"missing at {decay_dir}; staleness scanner not wired",
+            )
+        )
+        return results
+
+    if scan.is_file():
+        detail = str(scan)
+        try:
+            data = json.loads(scan.read_text())
+            scan_date = data.get("scan_date")
+            counts = data.get("counts", {})
+            if scan_date:
+                detail = f"{scan} (scan_date={scan_date}, stale={counts.get('stale', 'unknown')})"
+        except json.JSONDecodeError:
+            detail = f"invalid JSON: {scan}"
+            results.append((WARN, "memory-care: scan-latest", detail))
+        else:
+            results.append((OK, "memory-care: scan-latest", detail))
+    else:
+        results.append((WARN, "memory-care: scan-latest", f"missing at {scan}"))
+
+    if queue.is_file():
+        detail = str(queue)
+        try:
+            data = json.loads(queue.read_text())
+            cards = data.get("cards", [])
+            if isinstance(cards, list):
+                detail = f"{queue} ({len(cards)} queued)"
+        except json.JSONDecodeError:
+            detail = f"invalid JSON: {queue}"
+            results.append((WARN, "memory-care: refresh-queue", detail))
+        else:
+            results.append((OK, "memory-care: refresh-queue", detail))
+    else:
+        results.append((WARN, "memory-care: refresh-queue", f"missing at {queue}"))
+
+    return results
+
+
 def _check_publish_gate(target: Path) -> List[CheckResult]:
     results: List[CheckResult] = []
     hook = target / "hooks" / "pre-push"
@@ -145,7 +198,71 @@ def _check_openclaw() -> List[CheckResult]:
         results.append((OK, "openclaw: jq", "present"))
     else:
         results.append((WARN, "openclaw: jq", "missing; merge helpers will not work"))
+    results.extend(_check_openclaw_cron_jobs())
     return results
+
+
+def _check_openclaw_cron_jobs() -> List[CheckResult]:
+    results: List[CheckResult] = []
+    jobs_path = Path.home() / ".openclaw" / "cron" / "jobs.json"
+    if not jobs_path.is_file():
+        return [
+            (
+                WARN,
+                "openclaw: cron jobs",
+                f"not found at {jobs_path}; handoff ingest and memory-care schedules unknown",
+            )
+        ]
+
+    try:
+        data = json.loads(jobs_path.read_text())
+    except json.JSONDecodeError as exc:
+        return [(WARN, "openclaw: cron jobs", f"invalid JSON: {exc}")]
+
+    jobs = data.get("jobs", [])
+    if not isinstance(jobs, list):
+        return [(WARN, "openclaw: cron jobs", "jobs.json has no jobs array")]
+
+    expected = [
+        ("openclaw: handoff ingest cron", "Claude Memory Handoff Ingest"),
+        ("openclaw: card decay scanner", "Card Decay Scanner (Daily)"),
+        ("openclaw: card decay refresh", "Card Decay Auto-Refresh (Safe)"),
+    ]
+    for check_name, job_name in expected:
+        job = _find_job(jobs, job_name)
+        if job is None:
+            results.append((WARN, check_name, f"missing job named {job_name!r}"))
+            continue
+        if not job.get("enabled", False):
+            results.append((WARN, check_name, f"{job_name!r} exists but is disabled"))
+            continue
+        results.append((OK, check_name, _format_schedule(job.get("schedule"))))
+
+    weekly = _find_job(jobs, "Card Decay Deep Report (Weekly)")
+    if weekly is not None and weekly.get("enabled", False):
+        results.append((OK, "openclaw: card decay weekly", _format_schedule(weekly.get("schedule"))))
+    return results
+
+
+def _find_job(jobs: list, name: str) -> dict | None:
+    for job in jobs:
+        if isinstance(job, dict) and job.get("name") == name:
+            return job
+    return None
+
+
+def _format_schedule(schedule) -> str:
+    if not isinstance(schedule, dict):
+        return "enabled; schedule not specified"
+    kind = schedule.get("kind")
+    if kind == "cron":
+        return f"enabled; cron {schedule.get('expr', '<missing expr>')} {schedule.get('tz', '')}".strip()
+    if kind == "every":
+        every_ms = schedule.get("everyMs")
+        if isinstance(every_ms, int):
+            return f"enabled; every {every_ms // 60000} min"
+        return "enabled; every schedule"
+    return f"enabled; {kind or 'unknown'} schedule"
 
 
 def _check_hermes(target: Path) -> List[CheckResult]:

--- a/src/solo_mise/templates/memory/cards/handoff-flow.md
+++ b/src/solo_mise/templates/memory/cards/handoff-flow.md
@@ -17,6 +17,12 @@ Claude Code, Codex, and other side harnesses write Memory Handoffs to `.claude/m
 5. Handoffs route to: a memory card, an appendable document, or the review inbox.
 6. Processed handoffs move to `.claude/memory-handoffs/processed/`.
 
+## Multiple Workspaces
+
+If you administer more than one agent setup, keep this flow hub-and-spoke. Secondary workspaces write local handoffs, then the canonical owner pulls them into staging directories and runs the same ingester. This lets agents on separate machines or repos inform each other about what changed without creating competing memory stores.
+
+See [multi-workspace-handoff-admin](multi-workspace-handoff-admin.md) for the full pattern.
+
 ## Auto-promotion rules
 
 Only three handoff shapes can silently mutate canonical memory. Everything else lands in `memory/handoff-inbox/` for manual review.

--- a/src/solo_mise/templates/memory/cards/memory-architecture.md
+++ b/src/solo_mise/templates/memory/cards/memory-architecture.md
@@ -23,6 +23,7 @@ This workspace uses a single canonical memory owner. Side harnesses may keep loc
   INSTALL_FOR_AGENTS.md
   memory/
     cards/             # durable knowledge cards (auto-promotion target)
+      decay/           # optional staleness scan output + refresh queue
     handoff-inbox/     # ambiguous handoffs land here for review
   rules/               # workflow rules (appendable target)
   .learnings/          # concrete failures + lessons (appendable target)

--- a/src/solo_mise/templates/memory/cards/memory-care-staleness.md
+++ b/src/solo_mise/templates/memory/cards/memory-care-staleness.md
@@ -1,0 +1,58 @@
+---
+topic: memory-care-staleness
+category: foundation
+tags: [memory, staleness, decay, refresh, maintenance]
+---
+
+# Memory Care Staleness
+
+Memory needs care after it is written. Durable cards can become wrong when services move, workflows change, models are renamed, or project priorities expire. A staleness checker gives the memory owner a queue of cards that need refresh, without letting an agent rewrite sensitive or judgment-heavy knowledge blindly.
+
+## Reference Loop
+
+```text
+memory/cards/*.md
+        |
+        v
+card decay scanner
+        |
+        v
+memory/cards/decay/scan-latest.json
+memory/cards/decay/refresh-queue.json
+        |
+        v
+safe refresh agent or manual review
+```
+
+## Scanner Output
+
+Store scan state under `memory/cards/decay/`:
+
+- `scan-latest.json` - latest full scan, counts, card statuses, decay ratios, and refresh queue size.
+- `refresh-queue.json` - small queue of cards that are stale enough to review.
+
+The scanner should report at least total cards, fresh count, aging count, stale count, critical count, and refresh queue size.
+
+## Safe Refresh Rules
+
+Only auto-refresh cards when current facts are grounded in local source-of-truth files read during the run. Good sources include `TOOLS.md`, `MEMORY.md`, recent `memory/YYYY-MM-DD.md`, local project docs, local scripts, and repo health reports.
+
+Do not auto-refresh cards that require human judgment, personal context, career decisions, school work, business strategy, or outside research. Put those in a manual queue.
+
+Never refresh by only bumping an `updated:` date. The content must change because a current source proves it should change.
+
+## Suggested Schedule
+
+- Daily scanner during quiet hours.
+- Safe auto-refresh shortly after the scanner, capped to a small number of cards.
+- Weekly deep report for manual review of sensitive or repeatedly skipped stale cards.
+
+## Verification
+
+```bash
+test -f memory/cards/decay/scan-latest.json
+test -f memory/cards/decay/refresh-queue.json
+jq '.counts, .refresh_queue_size' memory/cards/decay/scan-latest.json
+```
+
+If the queue grows for several days, either the refresh agent is too conservative, the source-of-truth files are stale, or the cards need manual pruning.

--- a/src/solo_mise/templates/memory/cards/memory-scanner.md
+++ b/src/solo_mise/templates/memory/cards/memory-scanner.md
@@ -86,6 +86,10 @@ Avoid promoting during active sessions because card writes invalidate prefix cac
 - the prompt should embed the skip-rules and cost controls above
 - output goes either directly to `memory/cards/*.md` (if your harness can write there) or through `.claude/memory-handoffs/` for the conservative ingester to route
 
+## Relationship to Memory Care
+
+The memory scanner captures new durable knowledge. The memory-care staleness loop reviews old cards for drift. Run both: scanner for new facts, staleness checker for old facts that may no longer be true. See [memory-care-staleness](memory-care-staleness.md).
+
 ## Anti-patterns
 
 - **Auto-promoting raw session fragments into `MEMORY.md`.** The index loads on every session; appending fragments nightly bloats it past the bootstrap budget and turns the on-load cache cost into a monthly tax. Write cards instead.

--- a/src/solo_mise/templates/memory/cards/multi-workspace-handoff-admin.md
+++ b/src/solo_mise/templates/memory/cards/multi-workspace-handoff-admin.md
@@ -1,0 +1,63 @@
+---
+topic: multi-workspace-handoff-admin
+category: workflow
+tags: [memory, handoff, multi-workspace, admin]
+---
+
+# Multi-Workspace Handoff Admin
+
+When one person administers multiple agent homes, only one workspace should own canonical durable memory. Other workspaces can run local sessions, keep local context, and write repo-local notes, but durable facts should flow back to the owner through Memory Handoffs.
+
+## Shape
+
+```text
+managed workspace A      managed workspace B      repo-local sessions
+  .claude/                 .claude/                 .claude/
+    memory-handoffs/         memory-handoffs/         memory-handoffs/
+          \                         |                         /
+           \                        |                        /
+            v                       v                       v
+          staging inboxes on the canonical memory owner
+                           |
+                           v
+                    solo-mise ingest
+                           |
+                           v
+              memory/cards/, TOOLS.md, USER.md, rules/, .learnings/
+```
+
+## Why
+
+Multiple active setups drift unless the agents can tell each other what happened. A secondary workspace should not silently become a second source of truth. Its job is to emit handoffs that say what changed, what evidence supports it, and what the canonical owner should remember.
+
+## Pull Pattern
+
+Run a small trusted sync from the canonical memory owner:
+
+```bash
+rsync -a --remove-source-files \
+  --include='*.md' --exclude='processed/***' --exclude='*' \
+  <remote>:<workspace>/.claude/memory-handoffs/ \
+  <canonical-workspace>/pipeline/incoming-handoffs/<remote-label>/
+```
+
+Then include each staging directory in the ingest loop. Keep remote labels generic, such as `laptop`, `homelab`, `client-a`, or `research-vm`.
+
+## Admin Rules
+
+- Pull into staging first, then ingest. Do not ingest directly over SSH.
+- Remove remote source files only after successful transfer to the canonical host.
+- Exclude `processed/` so archives do not churn forever.
+- Preserve the original handoff text for review. The canonical owner should see exactly what the remote harness wrote.
+- Use per-source labels so failures can be traced to the workspace that produced them.
+- Surface non-empty pulls to the agents that need to know. A handoff is both memory input and a coordination signal.
+
+## Verification
+
+```bash
+find pipeline/incoming-handoffs -name '*.md' -not -path '*/processed/*'
+solo-mise ingest --target . --dry-run
+ls memory/handoff-inbox/ 2>/dev/null | wc -l
+```
+
+If no remote handoffs arrive for a week while remote work is happening, the remote workspace probably lacks the closeout instruction, the sync is broken, or the files are landing in the wrong repo.

--- a/src/solo_mise/templates/profiles/workspace.json
+++ b/src/solo_mise/templates/profiles/workspace.json
@@ -18,6 +18,8 @@
     {"src": "memory/cards/handoff-flow.md", "dst": "memory/cards/handoff-flow.md"},
     {"src": "memory/cards/content-safety.md", "dst": "memory/cards/content-safety.md"},
     {"src": "memory/cards/memory-scanner.md", "dst": "memory/cards/memory-scanner.md"},
+    {"src": "memory/cards/memory-care-staleness.md", "dst": "memory/cards/memory-care-staleness.md"},
+    {"src": "memory/cards/multi-workspace-handoff-admin.md", "dst": "memory/cards/multi-workspace-handoff-admin.md"},
     {"src": "memory/cards/chat-surface-crawlers.md", "dst": "memory/cards/chat-surface-crawlers.md"},
     {"src": "memory/cards/pipeline-standups.md", "dst": "memory/cards/pipeline-standups.md"},
     {"src": "hooks/pre-push", "dst": "hooks/pre-push", "mode": "0755"},

--- a/src/solo_mise/templates/workspace/AGENTS.md
+++ b/src/solo_mise/templates/workspace/AGENTS.md
@@ -118,9 +118,10 @@ A typical day has two short cross-harness summaries plus a session-review pass a
 |-----|----------|----------|
 | Nightshift standup | typical: `0 21 * * *` | `memory/cards/pipeline-standups.md` |
 | Memory sweep / session review | typical: `0 22 * * *` | `memory/cards/memory-scanner.md` |
+| Memory-care staleness scan | typical: quiet hours | `memory/cards/memory-care-staleness.md` |
 | Morning report | typical: `0 8 * * *` | `memory/cards/pipeline-standups.md` |
 
-Standups summarize state already in memory. The memory scanner promotes durable findings *into* memory from the day's sessions. Run order: standup -> scanner -> overnight ingester sweeps -> morning report next day.
+Standups summarize state already in memory. The memory scanner promotes durable findings *into* memory from the day's sessions. Memory care checks existing cards for stale facts. Run order: standup -> scanner -> overnight ingester sweeps -> memory-care scan -> morning report next day.
 
 ## Multi-Agent Workflow
 

--- a/src/solo_mise/templates/workspace/INSTALL_FOR_AGENTS.md
+++ b/src/solo_mise/templates/workspace/INSTALL_FOR_AGENTS.md
@@ -32,6 +32,10 @@ You may be invoked as the agent behind any of these. They are isolated sessions;
 
 See `memory/cards/pipeline-standups.md` and `memory/cards/memory-scanner.md` for the full job shape.
 
+If this workspace is one of several agent homes, read `memory/cards/multi-workspace-handoff-admin.md`. Secondary setups should inform the canonical owner through handoffs rather than keeping separate durable truth.
+
+If you are maintaining an established card set, read `memory/cards/memory-care-staleness.md` before editing stale cards. Refresh only from current source-of-truth files or route to manual review.
+
 ## If your harness loads a compact context
 
 Some harnesses load a generated `llms.txt` or `llms-full.txt` instead of every bootstrap file individually. If those exist in this workspace, follow them and rebuild via the workspace's build script when source docs change. If they do not exist, default to reading the files listed in "Start here" directly.

--- a/src/solo_mise/templates/workspace/MEMORY.md
+++ b/src/solo_mise/templates/workspace/MEMORY.md
@@ -54,6 +54,7 @@ Replace this with your actual agent roster. Example shape:
 | Night (~21:00) | Pipeline standup | [pipeline-standups](memory/cards/pipeline-standups.md) |
 | Night (~22:00) | Memory sweep / session review | [memory-scanner](memory/cards/memory-scanner.md) |
 | Continuous | Handoff ingester | [handoff-flow](memory/cards/handoff-flow.md) |
+| Quiet hours | Memory-care staleness scan | [memory-care-staleness](memory/cards/memory-care-staleness.md) |
 | Morning (~08:00) | Morning report | [pipeline-standups](memory/cards/pipeline-standups.md) |
 
 ## Card Categories
@@ -62,12 +63,13 @@ Build out this table as you learn the shape of your durable knowledge. Starter s
 
 | Category | Topics |
 |----------|--------|
-| foundation | memory architecture, handoff flow, content safety, memory scanner, chat-surface crawlers, pipeline standups |
+| foundation | memory architecture, handoff flow, content safety, memory scanner, memory care, chat-surface crawlers, pipeline standups |
 | system | identity, memory-search system, sub-agent patterns, agent-wrapper patterns |
 | user | personal context, communication style, preferences |
 | infrastructure | hosts, ports, deploys, mounts, local services |
 | models | subscriptions, assignment rules, benchmarks |
 | workflow | pipeline rules, content strategy, publishing checklist |
+| admin | multi-workspace handoff routing |
 | tools | local APIs, browser stacks, MCPs, skills |
 | security | hardening, audits, runbooks |
 | lessons | hard-won gotchas, corrections, prior-incident learnings |
@@ -79,6 +81,8 @@ Add categories as the workspace grows. One topic per card; one card per topic.
 - [memory-architecture](memory/cards/memory-architecture.md) - how this workspace stores durable knowledge
 - [handoff-flow](memory/cards/handoff-flow.md) - how Memory Handoffs flow into canonical memory
 - [memory-scanner](memory/cards/memory-scanner.md) - session-review pass that promotes durable findings
+- [memory-care-staleness](memory/cards/memory-care-staleness.md) - card decay scans and safe refresh rules
+- [multi-workspace-handoff-admin](memory/cards/multi-workspace-handoff-admin.md) - pulling remote setup handoffs into one canonical owner
 - [pipeline-standups](memory/cards/pipeline-standups.md) - nightshift + morning cross-harness recaps
 - [chat-surface-crawlers](memory/cards/chat-surface-crawlers.md) - discrawl-shaped local archives for Discord, Slack, WhatsApp, etc.
 - [content-safety](memory/cards/content-safety.md) - publish gates and what they block

--- a/src/solo_mise/templates/workspace/TOOLS.md
+++ b/src/solo_mise/templates/workspace/TOOLS.md
@@ -25,6 +25,17 @@ solo-mise ingest --target . --promote-cards --route-documents  # apply
 
 Wrap in a cron or end-of-day script. See `memory/cards/memory-scanner.md`.
 
+If you administer multiple agent homes, pull remote handoffs into staging directories on the canonical owner before ingesting. See `memory/cards/multi-workspace-handoff-admin.md`.
+
+## Memory Care
+
+```bash
+test -f memory/cards/decay/scan-latest.json
+jq '.counts, .refresh_queue_size' memory/cards/decay/scan-latest.json
+```
+
+Use a staleness scan once the card set is operationally important. See `memory/cards/memory-care-staleness.md`.
+
 ## Chat Surface Crawlers
 
 If chat surfaces feed memory, list their commands here. Examples:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import json
 
 import pytest
 
@@ -45,3 +46,87 @@ def test_doctor_hermes_flags_experimental(tmp_target: Path, capsys):
     assert "hermes:" in out
     assert "experimental" in out or "Hermes adapter" in out
     assert rc == 0
+
+
+def test_doctor_reports_memory_care_files(tmp_target: Path, capsys):
+    init_mod.run(target=tmp_target, profile_id="workspace")
+    decay = tmp_target / "memory" / "cards" / "decay"
+    decay.mkdir()
+    (decay / "scan-latest.json").write_text(
+        json.dumps({"scan_date": "2026-05-13", "counts": {"stale": 2}})
+    )
+    (decay / "refresh-queue.json").write_text(json.dumps({"cards": [{"file": "x.md"}]}))
+
+    rc = doctor_mod.run(target=tmp_target, harness="generic")
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "memory-care: scan-latest" in out
+    assert "stale=2" in out
+    assert "memory-care: refresh-queue" in out
+    assert "1 queued" in out
+
+
+def test_doctor_openclaw_reports_cron_memory_jobs(tmp_target: Path, monkeypatch, capsys):
+    init_mod.run(target=tmp_target, profile_id="workspace")
+    openclaw_dir = tmp_target / ".openclaw"
+    cron_dir = openclaw_dir / "cron"
+    cron_dir.mkdir(parents=True)
+    (openclaw_dir / "openclaw.json").write_text(
+        json.dumps(
+            {
+                "plugins": {"entries": {"memory-core": {}}},
+                "agents": {"defaults": {"model": {"primary": "openai-codex/gpt-5.5"}}},
+            }
+        )
+    )
+    (cron_dir / "jobs.json").write_text(
+        json.dumps(
+            {
+                "jobs": [
+                    {
+                        "name": "Claude Memory Handoff Ingest",
+                        "enabled": True,
+                        "schedule": {"kind": "every", "everyMs": 1800000},
+                    },
+                    {
+                        "name": "Card Decay Scanner (Daily)",
+                        "enabled": True,
+                        "schedule": {
+                            "kind": "cron",
+                            "expr": "30 5 * * *",
+                            "tz": "America/New_York",
+                        },
+                    },
+                    {
+                        "name": "Card Decay Auto-Refresh (Safe)",
+                        "enabled": True,
+                        "schedule": {
+                            "kind": "cron",
+                            "expr": "40 5 * * *",
+                            "tz": "America/New_York",
+                        },
+                    },
+                    {
+                        "name": "Card Decay Deep Report (Weekly)",
+                        "enabled": True,
+                        "schedule": {
+                            "kind": "cron",
+                            "expr": "30 5 * * 0",
+                            "tz": "America/New_York",
+                        },
+                    },
+                ]
+            }
+        )
+    )
+    monkeypatch.setenv("HOME", str(tmp_target))
+    monkeypatch.setattr(Path, "home", lambda: tmp_target)
+
+    rc = doctor_mod.run(target=tmp_target, harness="openclaw")
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "openclaw: handoff ingest cron" in out
+    assert "every 30 min" in out
+    assert "openclaw: card decay scanner" in out
+    assert "openclaw: card decay refresh" in out
+    assert "openclaw: card decay weekly" in out

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -41,6 +41,8 @@ def test_workspace_profile_includes_memory_cards(tmp_target: Path):
         "handoff-flow.md",
         "content-safety.md",
         "memory-scanner.md",
+        "memory-care-staleness.md",
+        "multi-workspace-handoff-admin.md",
         "chat-surface-crawlers.md",
         "pipeline-standups.md",
     ):


### PR DESCRIPTION
## Summary
- Add starter cards for multi-workspace handoff administration and memory-care staleness checks.
- Wire the new cards into workspace installs and update the public docs/runbooks.
- Extend `solo-mise doctor` to report memory-care decay files and OpenClaw cron-backed handoff/card-decay jobs.

## Validation
- `PYTHONPATH=src python3 -m pytest -q`
- `PYTHONPATH=$HOME/repos/content-guard/src python3 -m content_guard scan . --policy $HOME/repos/content-guard/policies/public-repo.json`
- workspace init smoke under `/tmp/solo-mise-smoke`
- live OpenClaw doctor against `~/.openclaw/workspace`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-workspace handoff administration for managing multiple agent homes with a canonical memory owner
  * Memory care staleness scanning to identify and refresh outdated memory cards
  * Enhanced diagnostic checks for memory care setup and scheduled job verification

* **Documentation**
  * Comprehensive guides for multi-workspace workflows, memory maintenance, and staleness scan procedures across installation and quickstart materials

* **Tests**
  * Added coverage for memory care diagnostics and cron job verification functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/solomonneas/solo-mise/pull/1)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->