### PR TITLE
chore: release v0.2.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,51 @@
+name: Bug report
+description: Something is broken in solo-mise itself (CLI, doctor, ingester, scrub).
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What did you run, and what did you expect versus what you got?
+      placeholder: |
+        I ran `solo-mise init --target ./foo --profile workspace` and got X.
+        I expected Y.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: solo-mise version
+      description: Output of `solo-mise --version`.
+      placeholder: solo-mise 0.2.0
+    validations:
+      required: true
+  - type: input
+    id: python
+    attributes:
+      label: Python version
+      placeholder: 3.12.3
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: OS
+      placeholder: Ubuntu 24.04, macOS 14.5, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Full output
+      description: Paste the full stdout + stderr. Redact personal paths if you want, but keep enough for us to reproduce.
+      render: shell
+    validations:
+      required: false
+  - type: checkboxes
+    id: scrub
+    attributes:
+      label: Pre-flight
+      options:
+        - label: I have scrubbed any personal hostnames, tokens, or paths from the report.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Cookbook (longer-form guidance + worked examples)
+    url: https://github.com/solomonneas/solos-cookbook
+    about: solo-mise is the kit. The cookbook is the why. Browse there for guidance and patterns rather than filing an issue here.
+  - name: Security report
+    url: https://github.com/solomonneas/solo-mise/security/policy
+    about: Do not file security issues publicly. See SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/ingester-misclassified.yml
+++ b/.github/ISSUE_TEMPLATE/ingester-misclassified.yml
@@ -1,0 +1,56 @@
+name: Ingester misclassified a handoff
+description: A handoff that should have promoted to a card was bounced, or vice versa. This is the most useful report you can file - routing rules need real examples.
+labels: ["ingester"]
+body:
+  - type: dropdown
+    id: direction
+    attributes:
+      label: Misclassification direction
+      options:
+        - "Should have promoted, was bounced to review"
+        - "Should have been bounced, was auto-promoted"
+        - "Targeted update fired against the wrong file"
+        - "Other"
+    validations:
+      required: true
+  - type: textarea
+    id: handoff
+    attributes:
+      label: Handoff content
+      description: |
+        Paste the handoff that was misclassified, with all personal details scrubbed
+        (paths, hostnames, account ids, tokens). The structure matters more than the
+        literal content - if you cannot share it, paste a redacted version with
+        `<redacted-purpose>` placeholders.
+      render: markdown
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What should have happened
+      description: |
+        Where should this have ended up? memory/cards/<name>.md? An append to
+        TOOLS.md? An append to a specific rule file? The review inbox?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: What actually happened
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: solo-mise version
+      placeholder: solo-mise 0.2.0
+    validations:
+      required: true
+  - type: checkboxes
+    id: scrub
+    attributes:
+      label: Pre-flight
+      options:
+        - label: I have scrubbed personal paths, hostnames, tokens, and account ids from the handoff above.
+          required: true

--- a/.github/ISSUE_TEMPLATE/profile-init-fails.yml
+++ b/.github/ISSUE_TEMPLATE/profile-init-fails.yml
@@ -1,0 +1,51 @@
+name: Profile init or doctor fails
+description: A specific profile fails to init cleanly or doctor reports failures on a fresh install.
+labels: ["bug", "profile"]
+body:
+  - type: dropdown
+    id: profile
+    attributes:
+      label: Profile
+      options:
+        - repo
+        - workspace
+        - openclaw
+        - hermes
+        - generic
+        - publisher
+    validations:
+      required: true
+  - type: textarea
+    id: command
+    attributes:
+      label: Exact commands you ran
+      description: We want to reproduce the failure verbatim.
+      render: shell
+      placeholder: |
+        rm -rf /tmp/sm && mkdir -p /tmp/sm && git init -q /tmp/sm
+        solo-mise init --target /tmp/sm --profile workspace
+        solo-mise doctor --target /tmp/sm
+    validations:
+      required: true
+  - type: textarea
+    id: output
+    attributes:
+      label: Output
+      description: Full output of `init` and `doctor`.
+      render: shell
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: solo-mise version
+      placeholder: solo-mise 0.2.0
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Anything unusual about your target?
+      description: Pre-existing files, custom .gitignore, weird filesystem, network sandbox, etc.
+    validations:
+      required: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: solomonneas/content-guard
+          ref: v0.1.1
           path: content-guard
       - uses: actions/setup-python@v5
         with:
@@ -47,6 +48,10 @@ jobs:
 
   install-from-source:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        profile: [repo, workspace, openclaw, hermes, generic, publisher]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -57,5 +62,19 @@ jobs:
           python -m pip install --upgrade pip pipx
           pipx install .
           solo-mise --version
-          solo-mise init --target /tmp/ci-smoke --profile workspace
-          solo-mise doctor --target /tmp/ci-smoke
+      - name: Init + doctor
+        run: |
+          target="/tmp/ci-smoke-${{ matrix.profile }}"
+          rm -rf "$target"
+          mkdir -p "$target"
+          # The 'repo' profile installs a pre-push hook; that wants a git repo.
+          # Other profiles do not require one but it is harmless.
+          git init -q -b main "$target"
+          solo-mise init --target "$target" --profile ${{ matrix.profile }}
+          # Doctor is harness-aware. Map the profile to the right --harness value.
+          case "${{ matrix.profile }}" in
+            openclaw) harness=openclaw ;;
+            hermes)   harness=hermes ;;
+            *)        harness=generic ;;
+          esac
+          solo-mise doctor --target "$target" --harness "$harness"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,50 @@
+name: publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Verify tag matches package version
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          set -e
+          tag_version="${GITHUB_REF_NAME#v}"
+          pkg_version=$(python -c "import tomllib,sys; print(tomllib.loads(open('pyproject.toml','rb').read().decode())['project']['version'])")
+          echo "tag=$tag_version pkg=$pkg_version"
+          if [ "$tag_version" != "$pkg_version" ]; then
+            echo "::error::tag $tag_version does not match pyproject.toml version $pkg_version"
+            exit 1
+          fi
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+
+      - name: Build sdist + wheel
+        run: python -m build
+
+      - name: Check distributions
+        run: python -m twine check dist/*
+
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: python -m twine upload dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,65 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2026-05-16
+
+### Added
+- Memory-care staleness scaffolding: `memory/cards/decay/` layout and a doctor
+  warning when the decay folder is missing, so durable cards do not quietly rot.
+- Multi-workspace handoff patterns for users administering more than one agent
+  home; secondary workspaces write into their own `.claude/memory-handoffs/`,
+  the owner pulls those into a staging inbox.
+- TokenJuice output-compaction guidance card covering Claude Code's PreToolUse
+  wrapper path, Codex hook setup, and realistic savings expectations.
+- Obsidian `/note` skill template under `skills/note/` for the `workspace`
+  profile.
+- `scripts/backup-restic.sh` template, exposed via the `workspace` profile.
+- Managed `.gitignore` block: `solo-mise init` now creates or updates a
+  `# >>> solo-mise gitignore block >>>` section in the target's `.gitignore`.
+  Re-runs replace only the content between the markers, so user-authored rules
+  are preserved. Skip with `--no-gitignore`.
+- Release pipeline: `.github/workflows/publish.yml` builds an sdist + wheel on
+  every `v*` tag and pushes to PyPI.
+- CI matrix: `install-from-source` smoke now runs against all six profiles
+  (`repo`, `workspace`, `openclaw`, `hermes`, `generic`, `publisher`).
+- Project meta: `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, and
+  `.github/ISSUE_TEMPLATE/` (bug, profile-init-fails, ingester-misclassified).
+
+### Changed
+- Deepened the `workspace` profile's bootstrap files (`AGENTS.md`, `CLAUDE.md`,
+  `IDENTITY.md`, `SOUL.md`, `HEARTBEAT.md`, `MEMORY.md`, `SAFETY_RULES.md`,
+  `TOOLS.md`, `USER.md`, `INSTALL_FOR_AGENTS.md`).
+- README: centered banner, refreshed badges, added a sample `doctor` run,
+  noted that solo-mise makes no network calls, called out `init` idempotency.
+- CI now pins the `content-guard` checkout to `v0.1.1` instead of tracking the
+  default branch.
+- `solo-mise init --profile hermes` prints a louder experimental-status notice
+  on stderr in addition to the post-install note.
+
+### Removed
+- Stale `DREAMS.md` from the repo root and lingering references in templates.
+
+## [0.1.0] - 2026-05-13
+
+Initial release.
+
+### Added
+- `solo-mise` CLI with `init`, `doctor`, `scrub`, and `handoff-template`
+  subcommands.
+- Six profiles: `repo` (default), `workspace`, `openclaw`, `hermes`,
+  `generic`, `publisher`.
+- Conservative handoff ingester at `.claude/memory-handoffs/`: safe card
+  handoffs become cards, targeted updates append, ambiguous material is
+  kicked out for review.
+- Content-guard pre-push hook for public-leak prevention.
+- Sanitized bootstrap file set, starter memory cards, routing rules.
+- OpenClaw adapter fragments and harness-aware doctor checks.
+- Experimental Hermes adapter fragments.
+
+[Unreleased]: https://github.com/solomonneas/solo-mise/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/solomonneas/solo-mise/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/solomonneas/solo-mise/releases/tag/v0.1.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -10,7 +10,8 @@ The Code of Conduct applies to all project spaces: GitHub issues and pull reques
 
 ## Reporting
 
-If you experience or witness a violation, please email **srneas@gmail.com**. Reports are confidential. You should get an acknowledgment within 72 hours.
+If you experience or witness a violation, please email **srneas@gmail.com**. Reports are confidential. You should get an acknowledgment within 72 hours. <!-- content-guard: allow pii/email -->
+
 
 The maintainer is also the recipient of security reports - see `SECURITY.md`. Please tag the subject line so it is easy to route (e.g. "CoC report" vs "security report").
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,19 @@
+# Code of Conduct
+
+This project follows the [Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+
+The full text lives at the link above. The short version: be respectful, assume good faith, keep feedback technical, and remember that everyone here is volunteering their time.
+
+## Scope
+
+The Code of Conduct applies to all project spaces: GitHub issues and pull requests on this repo, project-related discussions on Discord or other chat surfaces, and any in-person events where someone is representing the project.
+
+## Reporting
+
+If you experience or witness a violation, please email **srneas@gmail.com**. Reports are confidential. You should get an acknowledgment within 72 hours.
+
+The maintainer is also the recipient of security reports - see `SECURITY.md`. Please tag the subject line so it is easy to route (e.g. "CoC report" vs "security report").
+
+## Enforcement
+
+The maintainer is responsible for clarifying and enforcing standards. Enforcement actions can include private warnings, public clarifications, temporary or permanent bans from project spaces, and reverting or rejecting contributions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# Contributing to solo-mise
+
+solo-mise is the installable kit behind [Solomon's Cookbook](https://github.com/solomonneas/solos-cookbook). Patches are welcome. Before you start, please skim this file so we both spend our time on the right things.
+
+## What kinds of changes land easily
+
+- **Bug fixes** for `solo-mise init`, `doctor`, `scrub`, or the ingester.
+- **Profile improvements**: new bootstrap content, sharper post-install notes, better defaults.
+- **New harness adapters** (with doctor checks) under `src/solo_mise/templates/<harness>/`.
+- **Doctor checks** that catch real, observed failure modes.
+- **Test coverage** for any of the above.
+
+## What needs a conversation first
+
+- **A new top-level profile.** Open an issue first describing the user story. Profiles are the public surface and renaming or splitting them later is painful.
+- **Breaking changes** to template paths, the handoff TEMPLATE.md fields, or the ingester routing rules.
+- **Anything that adds a runtime dependency.** solo-mise has zero runtime deps on purpose, and we want to keep it that way.
+
+## What does not land
+
+- Personal details, hostnames, IPs, account IDs, or live auth profiles in templates or tests. The whole point of this kit is to keep that stuff out of public repos. The `content-guard` job in CI will fail if it finds any.
+- Cron jobs or hooks that post or call out to the network without explicit opt-in.
+- AI-co-authorship trailers on commits (`Co-Authored-By: <model>`). Conventional commits only.
+
+## Local dev
+
+```bash
+git clone https://github.com/solomonneas/solo-mise.git
+cd solo-mise
+python -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev]"
+pytest -q
+```
+
+To smoke-test a profile end-to-end the same way CI does:
+
+```bash
+target=/tmp/solo-mise-smoke
+rm -rf "$target" && mkdir -p "$target" && git init -q "$target"
+python -m solo_mise init --target "$target" --profile workspace
+python -m solo_mise doctor --target "$target"
+```
+
+## Adding a profile
+
+A profile is a single JSON manifest in `src/solo_mise/templates/profiles/<id>.json` and any template files it references. Manifests support `extends` for inheritance. See `publisher.json` (extends `repo`) for the simplest example.
+
+When you add a profile:
+
+1. Add it to the `choices=[...]` list in `src/solo_mise/cli.py` (the `--profile` flag).
+2. Add a row to the profile table in `README.md`.
+3. Add it to the matrix in `.github/workflows/ci.yml` so the smoke job exercises it.
+4. If it has post-install steps, list them in `post_install_notes`. They are printed at the end of `solo-mise init`.
+
+## Adding a doctor check
+
+Check functions live in `src/solo_mise/doctor.py`. Each returns a list of `(status, name, detail)` tuples where status is `OK`, `WARN`, `FAIL`, or `MANUAL`. Prefer `WARN` or `MANUAL` over `FAIL` for things the user can choose not to wire up - `FAIL` should mean "this profile is broken."
+
+## Promoting an experimental adapter
+
+The Hermes adapter is currently marked experimental. To graduate it (or any future experimental adapter) to "tested":
+
+- A doctor check exists that meaningfully exercises the adapter against a real install.
+- Someone has run the full init + doctor cycle on a real Hermes workspace and reported it on an issue.
+- The post-install notes no longer say "experimental".
+
+Open a PR with all three and we'll land it.
+
+## Filing issues
+
+Please use the templates under `.github/ISSUE_TEMPLATE/` - they exist to save you from re-typing the version and profile every time.
+
+The `ingester-misclassified` template is the most useful one to file early. If a handoff that should have promoted to a card got bounced (or vice versa), that is a real bug in the routing rules, not a corner case. We want to see it.
+
+## License
+
+By contributing you agree that your contribution is licensed under the MIT License, same as the rest of the repo.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ The cookbook explains the why. This package gives you the kitchen.
 ## Install
 
 ```bash
+pipx install solo-mise
+```
+
+Or, to track `main`:
+
+```bash
 pipx install git+https://github.com/solomonneas/solo-mise
 ```
 
@@ -67,7 +73,36 @@ solo-mise doctor --target ~/agent-kitchen
 solo-mise scrub --target .
 ```
 
+Re-running `solo-mise init` against an existing target is safe. It refuses to overwrite tracked files without `--force`, and the `.gitignore` block it manages is replaced between its markers without touching the rest of your file.
+
 See [QUICKSTART.md](QUICKSTART.md) for setup, verification, and the ingest flow.
+
+### What a green doctor looks like
+
+```text
+solo-mise doctor: target /home/you/agent-kitchen (generic)
+  [ok]   bootstrap: AGENTS.md              /home/you/agent-kitchen/AGENTS.md
+  [ok]   bootstrap: CLAUDE.md              /home/you/agent-kitchen/CLAUDE.md
+  [ok]   bootstrap: MEMORY.md              /home/you/agent-kitchen/MEMORY.md
+  [ok]   bootstrap: TOOLS.md               /home/you/agent-kitchen/TOOLS.md
+  [ok]   bootstrap: USER.md                /home/you/agent-kitchen/USER.md
+  [ok]   bootstrap: SAFETY_RULES.md        /home/you/agent-kitchen/SAFETY_RULES.md
+  [ok]   bootstrap: INSTALL_FOR_AGENTS.md  /home/you/agent-kitchen/INSTALL_FOR_AGENTS.md
+  [ok]   handoff: inbox                    /home/you/agent-kitchen/.claude/memory-handoffs
+  [ok]   handoff: TEMPLATE.md              /home/you/agent-kitchen/.claude/memory-handoffs/TEMPLATE.md
+  [ok]   handoff: processed/               /home/you/agent-kitchen/.claude/memory-handoffs/processed
+  [ok]   memory: cards/                    /home/you/agent-kitchen/memory/cards
+  [ok]   publish: hooks/pre-push           /home/you/agent-kitchen/hooks/pre-push
+  [ok]   publish: content-guard            /home/you/repos/content-guard
+
+summary: 14 checks, 0 failed, 0 manual
+```
+
+Anything `[warn]` is fine; `[fail]` means the install is incomplete. The `openclaw` and `hermes` harnesses add their own checks on top.
+
+### Privacy
+
+solo-mise makes no network calls. It does not phone home, collect telemetry, or sync anything to a server. Everything happens on your local filesystem against the templates packaged with the install. The only file that touches the network is the `pre-push` hook, and it runs the local `content-guard` scanner against your own commits before they leave the machine.
 
 ## Profiles
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Supported versions
+
+solo-mise is in alpha. Only the latest minor release on the `main` branch receives security fixes. Pin to a released tag if you need a known-good version.
+
+## Reporting a vulnerability
+
+Please **do not** open a public GitHub issue for security problems. Email **srneas@gmail.com** with:
+
+- A short description of the issue.
+- Steps to reproduce (or a minimal proof of concept).
+- The version or commit you tested against.
+- Whether you would like to be credited in the release notes.
+
+You should get an acknowledgment within 72 hours. If you do not, please follow up - the mail may have been filtered.
+
+## In scope
+
+- Code execution, path traversal, or symlink-attack flaws in `solo-mise init`, `doctor`, `scrub`, or the ingester.
+- Template content that leaks credentials, tokens, or personal data into a target workspace.
+- Public-leak guard bypasses (cases where the content-guard pre-push hook fails to flag content it is configured to catch).
+- Profile manifests that write outside `--target` (the manifest validator should reject these).
+
+## Out of scope
+
+- Bugs in `content-guard` itself - please report those upstream at
+  <https://github.com/solomonneas/content-guard>.
+- Bugs in OpenClaw, Hermes, Claude Code, or Codex - report those to their respective projects.
+- Issues that require an attacker to already have write access to the user's machine, harness config, or PyPI account.
+- Memory cards or handoffs that a user wrote and committed themselves. solo-mise provides scaffolding and guardrails, not perfect content review.
+
+## Disclosure
+
+We aim to ship a fix within 14 days of confirming a valid report. A coordinated disclosure timeline can be negotiated for issues that need longer.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,8 @@ solo-mise is in alpha. Only the latest minor release on the `main` branch receiv
 
 ## Reporting a vulnerability
 
-Please **do not** open a public GitHub issue for security problems. Email **srneas@gmail.com** with:
+Please **do not** open a public GitHub issue for security problems. Email **srneas@gmail.com** with: <!-- content-guard: allow pii/email -->
+
 
 - A short description of the issue.
 - Steps to reproduce (or a minimal proof of concept).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "solo-mise"
-version = "0.1.0"
+version = "0.2.0"
 description = "Mise en place for agent memory. Installable starter kit for a harness-agnostic agent workspace."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/solo_mise/__init__.py
+++ b/src/solo_mise/__init__.py
@@ -1,3 +1,3 @@
 """Solomon's Mise en Place: installable starter kit for an agent kitchen."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/src/solo_mise/init.py
+++ b/src/solo_mise/init.py
@@ -160,6 +160,13 @@ def run(
     # Post-install notes.
     print(f"solo-mise: installed profile '{profile_id}' to {target}")
     print(f"solo-mise: memory owner -> {memory_owner_name}")
+    if profile_id == "hermes":
+        print(
+            "solo-mise: NOTE - the hermes adapter is experimental. "
+            "Validate against your real Hermes install before relying on it. "
+            "See CONTRIBUTING.md for graduation criteria.",
+            file=sys.stderr,
+        )
     notes = profile.get("post_install_notes", [])
     if notes:
         print()

--- a/src/solo_mise/templates/profiles/publisher.json
+++ b/src/solo_mise/templates/profiles/publisher.json
@@ -1,18 +1,17 @@
 {
   "id": "publisher",
-  "description": "Content-guard policies, scrub commands, publish gates. For users who publish blog posts, docs, or social drafts.",
+  "description": "Content-guard policies, scrub commands, publish gates. Layers on top of the repo profile, for users who publish blog posts, docs, or social drafts.",
   "memory_owner_default": "this-repo",
+  "extends": "repo",
   "files": [
-    {"src": "hooks/pre-push", "dst": "hooks/pre-push", "mode": "0755"},
-    {"src": "policies/public-repo.json", "dst": ".solo-mise/policies/public-repo.json"},
     {"src": "policies/public-content.json", "dst": ".solo-mise/policies/public-content.json"},
     {"src": "memory/cards/content-safety.md", "dst": "memory/cards/content-safety.md"}
   ],
   "dirs": [
-    ".solo-mise/scrub-cache"
+    ".solo-mise/scrub-cache",
+    "memory/cards"
   ],
   "post_install_notes": [
-    "Activate the hook: `git config core.hooksPath hooks`",
     "Run `solo-mise scrub --target . --policy public-content` before publishing user-facing content (blogs, social, docs).",
     "Add `solo-mise scrub` to your publish workflow as a hard gate."
   ]


### PR DESCRIPTION
## Summary

Prepares v0.2.0 release: distribution, CI coverage, project meta files, and a couple of fixes earned along the way.

### Distribution
- Add `.github/workflows/publish.yml` - tag-triggered build + twine upload via `PYPI_API_TOKEN` (already set as a repo secret). Includes a tag/version sanity gate.
- Bump `pyproject.toml` + `__init__.py` to `0.2.0`.
- Add `CHANGELOG.md` (Keep a Changelog).
- README: PyPI install path, doctor sample output, idempotency note, no-telemetry section.

### CI
- `install-from-source` smoke now matrixes over all six profiles (was workspace-only).
- Pin content-guard checkout to `v0.1.1` (was tracking default branch).

### Project meta
- `CONTRIBUTING.md` - local dev, adding profiles, doctor checks, experimental-adapter graduation criteria.
- `SECURITY.md` - private email reports, in/out of scope, 14-day fix window.
- `CODE_OF_CONDUCT.md` - references Contributor Covenant 2.1 by URL.
- `.github/ISSUE_TEMPLATE/{bug,profile-init-fails,ingester-misclassified}.yml` plus `config.yml` to disable blank issues and link the cookbook.

### Fixes earned along the way
- `publisher` profile now `extends: repo` so it inherits AGENTS.md + handoff inbox; doctor was failing on a fresh publisher install.
- `init --profile hermes` prints a stderr NOTE in addition to the post-install line so the experimental status is harder to miss.

## Test plan

- [x] `pytest -q` passes (50/50)
- [x] All six profiles green locally:
  ```
  repo (exit=0): summary: 14 checks, 0 failed, 0 manual
  workspace (exit=0): summary: 14 checks, 0 failed, 0 manual
  openclaw (exit=0): summary: 22 checks, 0 failed, 0 manual
  hermes (exit=0): summary: 18 checks, 0 failed, 1 manual
  generic (exit=0): summary: 14 checks, 0 failed, 0 manual
  publisher (exit=0): summary: 14 checks, 0 failed, 0 manual
  ```
- [x] content-guard pre-push hook clean (with inline allow tag on the policy-doc contact emails)
- [ ] CI green on this PR
- [ ] After merge: tag `v0.2.0`, watch `publish.yml`, verify `pip install solo-mise==0.2.0` works