### PR TITLE
feat: v0.3.0 harness selection (two-axis depth+harnesses)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        profile: [repo, workspace, openclaw, hermes, generic, publisher]
+        combo:
+          - name: "repo+claude"
+            flags: "--depth repo --harnesses claude"
+          - name: "repo+codex"
+            flags: "--depth repo --harnesses codex"
+          - name: "workspace+claude+openclaw"
+            flags: "--depth workspace --harnesses claude,openclaw"
+          - name: "workspace+codex+openclaw"
+            flags: "--depth workspace --harnesses codex,openclaw"
+          - name: "kitchen-sink"
+            flags: "--depth workspace --harnesses claude,codex,openclaw,hermes"
+          - name: "workspace+none"
+            flags: "--depth workspace --harnesses none"
+          - name: "repo+claude+publisher"
+            flags: "--depth repo --harnesses claude --include publisher"
+          - name: "legacy-workspace"
+            flags: "--profile workspace"
+          - name: "legacy-openclaw"
+            flags: "--profile openclaw"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -64,17 +82,9 @@ jobs:
           solo-mise --version
       - name: Init + doctor
         run: |
-          target="/tmp/ci-smoke-${{ matrix.profile }}"
+          target="/tmp/sm-${{ matrix.combo.name }}"
           rm -rf "$target"
           mkdir -p "$target"
-          # The 'repo' profile installs a pre-push hook; that wants a git repo.
-          # Other profiles do not require one but it is harmless.
           git init -q -b main "$target"
-          solo-mise init --target "$target" --profile ${{ matrix.profile }}
-          # Doctor is harness-aware. Map the profile to the right --harness value.
-          case "${{ matrix.profile }}" in
-            openclaw) harness=openclaw ;;
-            hermes)   harness=hermes ;;
-            *)        harness=generic ;;
-          esac
-          solo-mise doctor --target "$target" --harness "$harness"
+          solo-mise init --target "$target" ${{ matrix.combo.flags }}
+          solo-mise doctor --target "$target"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-05-16
+
+### Added
+- Two-axis selection model: `--depth {repo,workspace}` + `--harnesses {claude,codex,openclaw,hermes}` + `--include publisher`. Pick any combination of harnesses.
+- Interactive prompt on bare `solo-mise init` (no flags). Defaults to claude + repo + no includes.
+- `.solo-mise/config.json` is now the per-target source of truth for selection state. Read by `doctor`, `ingest`, and `reconfigure`.
+- `solo-mise reconfigure --target . [--prune]` adjusts an existing install to a new selection. `--prune` removes orphaned files for deselected harnesses.
+- Per-writer handoff inboxes: `.codex/memory-handoffs/` for Codex (in addition to existing `.claude/memory-handoffs/`).
+- Ingester now scans all configured writer inboxes.
+- Doctor reports apparent harness shape, checks per-writer inbox, warns on orphaned inbox dirs from unselected harnesses.
+
+### Changed
+- README reframed around the two-axis model. New "Picking your harnesses" section walks through four common combos.
+- CONTRIBUTING.md "Adding a profile" replaced by "Adding a harness" + "Adding a depth" + "Adding an include".
+
+### Deprecated
+- `solo-mise init --profile <x>` still works but prints a stderr deprecation note pointing at the new flags. Will be removed in v0.4.0.
+
+### Migration
+
+If you have v0.2.0 scripts using `--profile`:
+
+| v0.2.0 | v0.3.0+ |
+|---|---|
+| `--profile repo` | `--depth repo --harnesses claude` |
+| `--profile workspace` | `--depth workspace --harnesses claude` |
+| `--profile openclaw` | `--depth workspace --harnesses claude,openclaw` |
+| `--profile hermes` | `--depth workspace --harnesses claude,hermes` |
+| `--profile generic` | `--depth workspace --harnesses none` |
+| `--profile publisher` | `--depth repo --harnesses claude --include publisher` |
+
 ## [0.2.0] - 2026-05-16
 
 ### Added
@@ -60,6 +91,7 @@ Initial release.
 - OpenClaw adapter fragments and harness-aware doctor checks.
 - Experimental Hermes adapter fragments.
 
-[Unreleased]: https://github.com/solomonneas/solo-mise/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/solomonneas/solo-mise/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/solomonneas/solo-mise/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/solomonneas/solo-mise/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/solomonneas/solo-mise/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,14 +5,14 @@ solo-mise is the installable kit behind [Solomon's Cookbook](https://github.com/
 ## What kinds of changes land easily
 
 - **Bug fixes** for `solo-mise init`, `doctor`, `scrub`, or the ingester.
-- **Profile improvements**: new bootstrap content, sharper post-install notes, better defaults.
-- **New harness adapters** (with doctor checks) under `src/solo_mise/templates/<harness>/`.
+- **Harness / depth / include improvements**: new bootstrap content, sharper post-install notes, better defaults.
+- **New harness adapters** (with doctor checks) under `src/solo_mise/templates/harnesses/<id>.json`.
 - **Doctor checks** that catch real, observed failure modes.
 - **Test coverage** for any of the above.
 
 ## What needs a conversation first
 
-- **A new top-level profile.** Open an issue first describing the user story. Profiles are the public surface and renaming or splitting them later is painful.
+- **A new top-level harness, depth, or include.** Open an issue first describing the user story. These are the public surface and renaming or splitting them later is painful.
 - **Breaking changes** to template paths, the handoff TEMPLATE.md fields, or the ingester routing rules.
 - **Anything that adds a runtime dependency.** solo-mise has zero runtime deps on purpose, and we want to keep it that way.
 
@@ -32,25 +32,36 @@ pip install -e ".[dev]"
 pytest -q
 ```
 
-To smoke-test a profile end-to-end the same way CI does:
+To smoke-test an install end-to-end the same way CI does:
 
 ```bash
 target=/tmp/solo-mise-smoke
 rm -rf "$target" && mkdir -p "$target" && git init -q "$target"
-python -m solo_mise init --target "$target" --profile workspace
+python -m solo_mise init --target "$target" --depth workspace --harnesses claude,codex,openclaw
 python -m solo_mise doctor --target "$target"
 ```
 
-## Adding a profile
+## Adding a harness
 
-A profile is a single JSON manifest in `src/solo_mise/templates/profiles/<id>.json` and any template files it references. Manifests support `extends` for inheritance. See `publisher.json` (extends `repo`) for the simplest example.
+A harness is a manifest under `src/solo_mise/templates/harnesses/<id>.json` plus any template files it references. The manifest declares `role: "writer"` (gets an inbox) or `role: "reader"` (gets adapter fragments).
 
-When you add a profile:
+To add a harness:
 
-1. Add it to the `choices=[...]` list in `src/solo_mise/cli.py` (the `--profile` flag).
-2. Add a row to the profile table in `README.md`.
-3. Add it to the matrix in `.github/workflows/ci.yml` so the smoke job exercises it.
-4. If it has post-install steps, list them in `post_install_notes`. They are printed at the end of `solo-mise init`.
+1. Create the manifest at `src/solo_mise/templates/harnesses/<id>.json`.
+2. Add template files under a harness-named directory (e.g. `src/solo_mise/templates/<id>/`).
+3. Add the harness id to `KNOWN_HARNESSES` in `src/solo_mise/selection.py`.
+4. Update `HARNESS_PRIORITY` if the new harness should be an owner candidate (readers usually want to land near OpenClaw/Hermes in the priority list).
+5. If it's a writer, add it to `_WRITER_INBOXES` in `src/solo_mise/install.py`, `src/solo_mise/doctor.py`, and `src/solo_mise/ingest.py`.
+6. Add the harness to the CI matrix in `.github/workflows/ci.yml`.
+7. Add a row to the harness table in `README.md`.
+
+## Adding a depth
+
+Depths live at `src/solo_mise/templates/depth/<id>.json` and may use `extends` to inherit from another depth. Add the id to `KNOWN_DEPTHS` in `selection.py` and to the `--depth` choices in `cli.py`.
+
+## Adding an include
+
+Includes live at `src/solo_mise/templates/includes/<id>.json`. Add the id to `KNOWN_INCLUDES` in `selection.py`.
 
 ## Adding a doctor check
 
@@ -68,7 +79,7 @@ Open a PR with all three and we'll land it.
 
 ## Filing issues
 
-Please use the templates under `.github/ISSUE_TEMPLATE/` - they exist to save you from re-typing the version and profile every time.
+Please use the templates under `.github/ISSUE_TEMPLATE/` - they exist to save you from re-typing the version and install shape every time.
 
 The `ingester-misclassified` template is the most useful one to file early. If a handoff that should have promoted to a card got bounced (or vice versa), that is a real bug in the routing rules, not a corner case. We want to see it.
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -15,96 +15,82 @@ python3 -m pip install --user pipx
 python3 -m pipx ensurepath
 ```
 
-## 2. Pick a profile
+## First install
 
-The default `repo` profile adds the handoff flow and a publish guard to an existing project.
-
-The `workspace` profile creates a home-style agent workspace from scratch.
-
-## 3. Initialize
-
-### Repo profile (lightest)
-
-In a project you already work in:
+The fastest path is to run `solo-mise init` with no flags and answer the prompts:
 
 ```bash
-cd ~/repos/your-project
-solo-mise init --target .
+$ solo-mise init --target ~/agent-kitchen
+
+Which harnesses do you use? (type numbers separated by space/comma to toggle, enter to confirm)
+  [x] 1. Claude Code
+  [ ] 2. Codex
+  [ ] 3. OpenClaw
+  [ ] 4. Hermes (experimental)
+
+Depth? (type a number, enter for default)
+  * 1. repo       (handoff flow + publish guard)
+    2. workspace  (full home: MEMORY.md, TOOLS.md, USER.md, ...)
+
+Add-ons? (type numbers separated by space/comma to toggle, enter to confirm)
+  [ ] 1. publisher  (content-guard policies for blog/social/docs)
 ```
 
-This creates:
+Defaults are claude harness, repo depth, no includes. Enter ships the install.
 
-```text
-your-project/
-  AGENTS.md
-  CLAUDE.md
-  .claude/memory-handoffs/
-    TEMPLATE.md
-  hooks/
-    pre-push
-  .gitignore     # adds a managed solo-mise block (handoffs, daily logs, review inbox)
-```
+## CI / scripted install
 
-The `.gitignore` block is bounded by `# >>> solo-mise gitignore block >>>` markers so re-running `init` is idempotent and your hand-written rules outside the block are preserved. Pass `--no-gitignore` to skip the gitignore step.
-
-Enable the pre-push hook once:
+Pass flags directly to skip the prompt:
 
 ```bash
-git config core.hooksPath hooks
+# Claude Code + Codex + OpenClaw, full workspace
+solo-mise init --target ~/agent-kitchen \
+  --depth workspace \
+  --harnesses claude,codex,openclaw
+
+# Codex-only project, minimal install
+solo-mise init --target ./my-project --depth repo --harnesses codex
+
+# Generic layout, no harness-specific files
+solo-mise init --target ./my-project --harnesses none
 ```
 
-### Workspace profile
+## Verifying
+
+After install, `solo-mise doctor --target <path>` reports the apparent harness shape and checks every configured inbox and adapter:
+
+```
+solo-mise doctor: target /home/you/agent-kitchen
+  harnesses: claude, codex, openclaw (owner=openclaw, depth=workspace)
+  [ok]   bootstrap: AGENTS.md   /home/you/agent-kitchen/AGENTS.md
+  [ok]   handoff: claude inbox  /home/you/agent-kitchen/.claude/memory-handoffs
+  [ok]   handoff: codex inbox   /home/you/agent-kitchen/.codex/memory-handoffs
+  [ok]   openclaw: config        /home/you/.openclaw/openclaw.json
+  ...
+```
+
+A `[fail]` line means the install is incomplete; `[warn]` is informational; `[todo]` means the check needs your attention (e.g. Hermes is experimental).
+
+## Reconfiguring
+
+To change which harnesses are installed on an existing target:
 
 ```bash
-solo-mise init --target ~/agent-kitchen --profile workspace
+# Add a harness
+solo-mise reconfigure --target . --harnesses claude,codex
+
+# Drop one (without removing its files)
+solo-mise reconfigure --target . --harnesses claude
+
+# Drop one and remove its files
+solo-mise reconfigure --target . --harnesses claude --prune
 ```
 
-This creates the full bootstrap file set: `AGENTS.md`, `CLAUDE.md`, `SOUL.md`, `USER.md`, `TOOLS.md`, `MEMORY.md`, `IDENTITY.md`, `HEARTBEAT.md`, `SAFETY_RULES.md`, `INSTALL_FOR_AGENTS.md`, plus `memory/cards/` with starter cards, a `.claude/memory-handoffs/` inbox, and the publish hook.
+## The handoff flow
 
-## 4. Verify
+The starter handoff template lives at `<inbox>/TEMPLATE.md`. Copy it to a new dated file (e.g. `2026-05-16-1430-fixed-X.md`), fill it in, and the ingester promotes safe card handoffs into `memory/cards/`, appends targeted updates to the right file, and kicks ambiguous material to the review inbox.
 
-```bash
-solo-mise doctor --target ~/agent-kitchen
-```
-
-The doctor checks that the bootstrap files exist, the handoff inbox is in place, and (if you chose `--profile openclaw`) the OpenClaw config can see your workspace. It prints `OK` or `MANUAL ACTION NEEDED` per check; it never edits your config.
-
-## 5. Write your first handoff
-
-```bash
-solo-mise handoff-template --target ~/agent-kitchen > \
-  ~/agent-kitchen/.claude/memory-handoffs/$(date -u +%Y-%m-%dT%H%MZ)-first-handoff.md
-```
-
-Edit the file with whatever durable knowledge your agent just produced.
-
-## 6. Ingest
-
-```bash
-solo-mise ingest --target ~/agent-kitchen --dry-run
-solo-mise ingest --target ~/agent-kitchen
-```
-
-The ingester is conservative. Handoffs with `Recommended memory action: create-card` and a safe filename + frontmatter become memory cards. Handoffs that route to `TOOLS.md`, `USER.md`, `rules/*.md`, or `.learnings/*.md` get appended. Anything ambiguous lands in `memory/handoff-inbox/` for manual review.
-
-If you administer multiple agent setups, keep one canonical owner and pull remote handoffs into staging directories before ingesting them. See `memory/cards/multi-workspace-handoff-admin.md`.
-
-## 7. Scrub before publishing
-
-```bash
-solo-mise scrub --target . --dry-run
-```
-
-If you have [content-guard](https://github.com/solomonneas/content-guard) installed, the pre-push hook will block pushes that contain private IPs, secrets, or AI attribution trailers. `solo-mise scrub` is the deterministic counterpart that runs the same scanner with the public-repo policy.
-
-## 8. OpenClaw users
-
-```bash
-solo-mise doctor --target ~/.openclaw/workspace --harness openclaw
-solo-mise openclaw-fragments --out ./openclaw-fragments
-```
-
-The fragments are JSON files you can inspect and merge into your `openclaw.json` by hand. `solo-mise` never mutates your live OpenClaw config.
+See the [Solo Cookbook](https://github.com/solomonneas/solos-cookbook) for the longer-form guidance on what makes a good handoff and when to use which routing.
 
 ## Next steps
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <img src="https://img.shields.io/github/actions/workflow/status/solomonneas/solo-mise/ci.yml?branch=main&style=for-the-badge&label=ci" alt="CI status">
   <img src="https://img.shields.io/badge/python-3.10%2B-blue?style=for-the-badge&logo=python&logoColor=white" alt="Python 3.10+">
   <img src="https://img.shields.io/badge/license-MIT-green?style=for-the-badge" alt="MIT license">
-  <img src="https://img.shields.io/badge/profiles-6-orange?style=for-the-badge" alt="6 profiles">
+  <img src="https://img.shields.io/badge/harnesses-4-orange?style=for-the-badge" alt="4 harnesses">
 </p>
 
 <p align="center">
@@ -66,12 +66,56 @@ pipx install git+https://github.com/solomonneas/solo-mise
 
 ## Quick path
 
+Run `solo-mise init` with no flags for the interactive picker:
+
 ```bash
-solo-mise init --target .                     # repo-local handoff flow + publish guard
-solo-mise init --target ~/agent-kitchen --profile workspace
-solo-mise doctor --target ~/agent-kitchen
-solo-mise scrub --target .
+solo-mise init --target ~/agent-kitchen
 ```
+
+For CI or scripts, pass flags directly:
+
+```bash
+solo-mise init --target ~/agent-kitchen --depth workspace --harnesses claude,codex,openclaw
+solo-mise init --target ./repo --depth repo --harnesses codex
+solo-mise init --target ./repo --harnesses none           # generic install
+```
+
+## Two axes: depth + harnesses
+
+solo-mise installs material on two independent axes:
+
+**Depth, how much shared baseline you want:**
+
+| Depth | Installs |
+|---|---|
+| `repo` *(default)* | `AGENTS.md`, `SAFETY_RULES.md`, `INSTALL_FOR_AGENTS.md`, `hooks/pre-push`, `.solo-mise/policies/public-repo.json` |
+| `workspace` | repo + `MEMORY.md`, `TOOLS.md`, `USER.md`, `SOUL.md`, `IDENTITY.md`, `HEARTBEAT.md`, `memory/cards/`, starter cards |
+
+**Harnesses, which tools you actually use:**
+
+| Harness | Role | Adds |
+|---|---|---|
+| `claude` | writer | `CLAUDE.md` + `.claude/memory-handoffs/` inbox |
+| `codex` | writer | `.codex/memory-handoffs/` inbox (AGENTS.md is in the baseline) |
+| `openclaw` | reader | `.solo-mise/openclaw/` config fragments + cron stubs |
+| `hermes` | reader | `.solo-mise/hermes/` adapter fragments (experimental) |
+
+**Includes, optional add-ons:**
+
+| Include | Adds |
+|---|---|
+| `publisher` | `.solo-mise/policies/public-content.json` + content-safety memory card + scrub-cache |
+
+## Picking your harnesses
+
+Four common combos:
+
+- **Claude Code only:** `--harnesses claude`, the lightest setup, just one writer.
+- **Claude Code + OpenClaw:** `--harnesses claude,openclaw`, durable memory owner (OpenClaw) plus side writer (Claude Code).
+- **Claude Code + Codex + OpenClaw:** `--harnesses claude,codex,openclaw`, both writers feed into OpenClaw as the canonical owner.
+- **Codex + OpenClaw:** `--harnesses codex,openclaw`, Codex-first user with OpenClaw as the canonical store.
+
+The canonical memory owner is picked automatically by priority (`openclaw > hermes > claude > codex > this-repo`). Override with `--owner`.
 
 Re-running `solo-mise init` against an existing target is safe. It refuses to overwrite tracked files without `--force`, and the `.gitignore` block it manages is replaced between its markers without touching the rest of your file.
 
@@ -104,39 +148,30 @@ Anything `[warn]` is fine; `[fail]` means the install is incomplete. The `opencl
 
 solo-mise makes no network calls. It does not phone home, collect telemetry, or sync anything to a server. Everything happens on your local filesystem against the templates packaged with the install. The only file that touches the network is the `pre-push` hook, and it runs the local `content-guard` scanner against your own commits before they leave the machine.
 
-## Profiles
-
-| Profile | What it installs | When to use |
-|---------|------------------|-------------|
-| `repo` *(default)* | `AGENTS.md`, `CLAUDE.md`, `.claude/memory-handoffs/`, pre-push hook | A project wants the handoff flow and a public-leak guard. |
-| `workspace` | Full bootstrap file set, memory folders, starter cards, safety files | A user wants a home agent workspace. |
-| `openclaw` | `workspace` plus OpenClaw config fragments and doctor checks | An OpenClaw user. |
-| `hermes` | `workspace` plus Hermes adapter fragments and doctor checks | A Hermes user. Experimental. |
-| `generic` | Contract docs and templates, no orchestrator config | A user wants the layout without picking a harness yet. |
-| `publisher` | content-guard policies, scrub commands, publish gates | A user who publishes blog posts, docs, or social drafts. |
-
 ## The design
 
-One memory owner stays canonical. Side harnesses keep local context, but durable findings move through a shared handoff inbox and into the right destination.
+One memory owner stays canonical (typically OpenClaw or Hermes when present, otherwise `this-repo`). Writer harnesses drop handoffs into their own inboxes; the ingester scans all of them.
 
 ```text
-Claude Code / Codex / other harness
-        |
-        v
-<repo>/.claude/memory-handoffs/*.md
-        |
-        v
-solo-mise ingest (or your harness's equivalent)
-        |
-        v
-memory/cards/*.md, TOOLS.md, USER.md, rules/*.md, .learnings/*.md
+Claude Code              Codex
+     |                     |
+     v                     v
+.claude/memory-handoffs/ .codex/memory-handoffs/
+     \                   /
+      \                 /
+       v               v
+      solo-mise ingest
+              |
+              v
+  memory/cards/*.md, TOOLS.md, USER.md,
+  rules/*.md, .learnings/*.md
 ```
 
 The ingester is intentionally conservative. Safe card handoffs become cards. Targeted updates append to the right file. Ambiguous material gets kicked out for review instead of being trusted automatically.
 
-For users running multiple agent homes, treat the owner workspace as the hub. Remote or secondary workspaces can write handoffs into their own `.claude/memory-handoffs/` directories, then a trusted sync pulls those files into a staging inbox on the owner. That keeps agents informed about what happened elsewhere without creating multiple canonical memories.
+For users running multiple agent homes, treat the owner workspace as the hub. Remote or secondary workspaces can write handoffs into their own per-harness inboxes, then a trusted sync pulls those files into a staging inbox on the owner. That keeps agents informed about what happened elsewhere without creating multiple canonical memories.
 
-Token-heavy terminal work gets the same treatment: make the wrapper explicit, make the escape hatch obvious, and tell every harness what is happening. The TokenJuice starter card documents Claude Code's PreToolUse wrapper path while the upstream PostToolUse fix is still pending, Codex's hook setup, and the savings model: observed output/context compaction can be huge, but billing-token savings depend on whether compacted output is fed into later turns.
+Token-heavy terminal work gets the same treatment: make the wrapper explicit, make the escape hatch obvious, and tell every harness what is happening. The TokenJuice starter card documents Claude Code's PreToolUse wrapper path, Codex's hook setup, and the savings model.
 
 ## Related
 

--- a/docs/plans/2026-05-16-v0.3.0-harness-selection.md
+++ b/docs/plans/2026-05-16-v0.3.0-harness-selection.md
@@ -1,0 +1,2742 @@
+# v0.3.0 Harness Selection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the single-pick profile model with a two-axis selection (`depth` + `harnesses` + `includes`) so users can pick any combination of Claude Code, Codex, OpenClaw, Hermes. Each writer harness gets its own handoff inbox; the ingester scans all of them.
+
+**Architecture:** A new `Selection` dataclass becomes the source of truth, persisted to `.solo-mise/config.json` per target. `init` builds it from CLI flags, an interactive prompt, or by translating legacy `--profile <x>` invocations through a deprecation shim. The install engine resolves a Selection into a deduped file/dir list by composing one depth manifest + N harness manifests + M include manifests, then runs the existing copy/render logic. Doctor + ingester + reconfigure all read the same config.json. Existing template files stay in place; new manifest directories (`templates/depth/`, `templates/harnesses/`, `templates/includes/`) reference them.
+
+**Tech Stack:** Python 3.10+ stdlib only (argparse, dataclasses, json, importlib.resources). Hand-rolled prompt using stdin/stdout + termios; no new runtime deps. Pytest for tests.
+
+**Spec:** `docs/specs/2026-05-16-v0.3.0-harness-selection-design.md`
+
+**Branch:** `feat/v0.3.0-harness-selection`
+
+---
+
+## File map
+
+**New source files:**
+- `src/solo_mise/selection.py` - `Selection` dataclass, `HARNESS_PRIORITY`, `resolve_owner`, `profile_to_selection`
+- `src/solo_mise/config.py` - `Config` dataclass, `load_config`, `write_config`, `config_path`
+- `src/solo_mise/install.py` - `install_selection(target, selection, ...)` install engine
+- `src/solo_mise/prompt.py` - hand-rolled interactive prompt (`prompt_for_selection`)
+- `src/solo_mise/reconfigure.py` - `reconfigure(target, prune)` for the new subcommand
+
+**Modified source files:**
+- `src/solo_mise/cli.py` - new flags + subcommand + interactive routing
+- `src/solo_mise/init.py` - delegate to install.install_selection; keep legacy `run()` for now
+- `src/solo_mise/doctor.py` - read config, harness-shape line, per-writer inbox checks, orphan warnings
+- `src/solo_mise/ingest.py` - scan inboxes from config
+- `src/solo_mise/templates.py` - add `load_depth_manifest`, `load_harness_manifest`, `load_include_manifest`
+- `src/solo_mise/__init__.py` - bump to 0.3.0
+
+**New template manifests:**
+- `src/solo_mise/templates/depth/repo.json`
+- `src/solo_mise/templates/depth/workspace.json`
+- `src/solo_mise/templates/harnesses/claude.json`
+- `src/solo_mise/templates/harnesses/codex.json`
+- `src/solo_mise/templates/harnesses/openclaw.json`
+- `src/solo_mise/templates/harnesses/hermes.json`
+- `src/solo_mise/templates/includes/publisher.json`
+
+**New template content files:**
+- `src/solo_mise/templates/codex/memory-handoffs/TEMPLATE.md` (copy of `claude/memory-handoffs/TEMPLATE.md` content)
+
+**New test files:**
+- `tests/test_selection.py`
+- `tests/test_config.py`
+- `tests/test_install.py`
+- `tests/test_prompt.py`
+- `tests/test_reconfigure.py`
+
+**Modified test files:**
+- `tests/test_init.py` - new flag combos, legacy-profile shim test
+- `tests/test_doctor.py` - config-driven checks
+- `tests/test_ingest.py` - multi-inbox scan
+- `tests/test_gitignore.py` - per-writer sections
+
+**Docs:**
+- `README.md`, `QUICKSTART.md`, `CONTRIBUTING.md`, `CHANGELOG.md`
+- `pyproject.toml` (bump to 0.3.0)
+- `.github/workflows/ci.yml` (new matrix combos)
+
+---
+
+## Phase 1: Foundation
+
+### Task 1: `Selection` data model + owner-priority resolver
+
+**Files:**
+- Create: `src/solo_mise/selection.py`
+- Test: `tests/test_selection.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_selection.py
+import pytest
+from solo_mise.selection import (
+    Selection,
+    HARNESS_PRIORITY,
+    KNOWN_HARNESSES,
+    KNOWN_DEPTHS,
+    KNOWN_INCLUDES,
+    resolve_owner,
+)
+
+
+def test_harness_priority_order():
+    assert HARNESS_PRIORITY == ["openclaw", "hermes", "claude", "codex", "this-repo"]
+
+
+def test_resolve_owner_picks_highest_priority_present():
+    assert resolve_owner(["claude", "openclaw"]) == "openclaw"
+    assert resolve_owner(["claude", "codex"]) == "claude"
+    assert resolve_owner(["codex"]) == "codex"
+    assert resolve_owner(["hermes", "claude"]) == "hermes"
+
+
+def test_resolve_owner_empty_selection_returns_this_repo():
+    assert resolve_owner([]) == "this-repo"
+
+
+def test_resolve_owner_explicit_override_wins():
+    assert resolve_owner(["claude", "openclaw"], override="claude") == "claude"
+    assert resolve_owner(["claude"], override="this-repo") == "this-repo"
+
+
+def test_resolve_owner_rejects_override_not_in_selection():
+    with pytest.raises(ValueError, match="not in selected harnesses"):
+        resolve_owner(["claude"], override="openclaw")
+
+
+def test_resolve_owner_accepts_this_repo_override_always():
+    assert resolve_owner(["openclaw"], override="this-repo") == "this-repo"
+
+
+def test_selection_dataclass_holds_fields():
+    sel = Selection(
+        depth="workspace",
+        harnesses=["claude", "codex"],
+        owner="claude",
+        includes=["publisher"],
+    )
+    assert sel.depth == "workspace"
+    assert sel.harnesses == ["claude", "codex"]
+    assert sel.owner == "claude"
+    assert sel.includes == ["publisher"]
+
+
+def test_selection_validate_rejects_unknown_depth():
+    with pytest.raises(ValueError, match="unknown depth"):
+        Selection(depth="weird", harnesses=["claude"], owner="claude", includes=[]).validate()
+
+
+def test_selection_validate_rejects_unknown_harness():
+    with pytest.raises(ValueError, match="unknown harness"):
+        Selection(depth="repo", harnesses=["claude", "weird"], owner="claude", includes=[]).validate()
+
+
+def test_selection_validate_rejects_owner_not_in_harnesses():
+    with pytest.raises(ValueError, match="owner.*not in selected harnesses"):
+        Selection(depth="repo", harnesses=["claude"], owner="openclaw", includes=[]).validate()
+
+
+def test_selection_validate_accepts_this_repo_owner_with_empty_harnesses():
+    Selection(depth="repo", harnesses=[], owner="this-repo", includes=[]).validate()
+
+
+def test_known_constants():
+    assert set(KNOWN_HARNESSES) == {"claude", "codex", "openclaw", "hermes"}
+    assert set(KNOWN_DEPTHS) == {"repo", "workspace"}
+    assert set(KNOWN_INCLUDES) == {"publisher"}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+.venv/bin/python -m pytest tests/test_selection.py -v
+```
+
+Expected: ImportError / ModuleNotFoundError for `solo_mise.selection`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# src/solo_mise/selection.py
+"""Selection data model: depth + harnesses + owner + includes."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+KNOWN_DEPTHS = ("repo", "workspace")
+KNOWN_HARNESSES = ("claude", "codex", "openclaw", "hermes")
+KNOWN_INCLUDES = ("publisher",)
+
+# Higher priority owners come first. The first harness in this list that
+# also appears in the selection becomes the canonical memory owner unless
+# the user passes --owner.
+HARNESS_PRIORITY = ["openclaw", "hermes", "claude", "codex", "this-repo"]
+
+
+@dataclass
+class Selection:
+    depth: str
+    harnesses: List[str] = field(default_factory=list)
+    owner: str = "this-repo"
+    includes: List[str] = field(default_factory=list)
+
+    def validate(self) -> None:
+        if self.depth not in KNOWN_DEPTHS:
+            raise ValueError(
+                f"unknown depth: {self.depth!r} (valid: {KNOWN_DEPTHS})"
+            )
+        for h in self.harnesses:
+            if h not in KNOWN_HARNESSES:
+                raise ValueError(
+                    f"unknown harness: {h!r} (valid: {KNOWN_HARNESSES})"
+                )
+        for inc in self.includes:
+            if inc not in KNOWN_INCLUDES:
+                raise ValueError(
+                    f"unknown include: {inc!r} (valid: {KNOWN_INCLUDES})"
+                )
+        if self.owner != "this-repo" and self.owner not in self.harnesses:
+            raise ValueError(
+                f"owner {self.owner!r} not in selected harnesses {self.harnesses}"
+            )
+
+
+def resolve_owner(harnesses: List[str], override: Optional[str] = None) -> str:
+    """Pick the canonical memory owner.
+
+    If override is provided, it must be 'this-repo' or one of the selected
+    harnesses. Otherwise the first entry in HARNESS_PRIORITY that also appears
+    in `harnesses` wins; if none match, returns 'this-repo'.
+    """
+    if override is not None:
+        if override == "this-repo":
+            return override
+        if override not in harnesses:
+            raise ValueError(
+                f"owner override {override!r} not in selected harnesses {harnesses}"
+            )
+        return override
+    for candidate in HARNESS_PRIORITY:
+        if candidate == "this-repo":
+            continue
+        if candidate in harnesses:
+            return candidate
+    return "this-repo"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+.venv/bin/python -m pytest tests/test_selection.py -v
+```
+
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/solo_mise/selection.py tests/test_selection.py
+git commit -m "feat(selection): add Selection model + owner-priority resolver"
+```
+
+---
+
+### Task 2: `.solo-mise/config.json` read/write
+
+**Files:**
+- Create: `src/solo_mise/config.py`
+- Test: `tests/test_config.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_config.py
+import json
+import pytest
+from pathlib import Path
+from solo_mise.config import (
+    Config,
+    CONFIG_REL_PATH,
+    config_path,
+    load_config,
+    write_config,
+)
+from solo_mise.selection import Selection
+
+
+def test_config_rel_path():
+    assert CONFIG_REL_PATH == ".solo-mise/config.json"
+
+
+def test_config_path_resolves_relative_to_target(tmp_path):
+    assert config_path(tmp_path) == tmp_path / ".solo-mise" / "config.json"
+
+
+def test_write_then_load_round_trip(tmp_path):
+    sel = Selection(
+        depth="workspace",
+        harnesses=["claude", "codex", "openclaw"],
+        owner="openclaw",
+        includes=["publisher"],
+    )
+    cfg = Config(version=1, selection=sel)
+    write_config(tmp_path, cfg)
+
+    loaded = load_config(tmp_path)
+    assert loaded.version == 1
+    assert loaded.selection.depth == "workspace"
+    assert loaded.selection.harnesses == ["claude", "codex", "openclaw"]
+    assert loaded.selection.owner == "openclaw"
+    assert loaded.selection.includes == ["publisher"]
+
+
+def test_write_creates_parent_dir(tmp_path):
+    sel = Selection(depth="repo", harnesses=["claude"], owner="claude", includes=[])
+    write_config(tmp_path, Config(version=1, selection=sel))
+    assert (tmp_path / ".solo-mise" / "config.json").is_file()
+
+
+def test_load_missing_returns_none(tmp_path):
+    assert load_config(tmp_path) is None
+
+
+def test_load_rejects_unknown_version(tmp_path):
+    path = tmp_path / ".solo-mise" / "config.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps({"version": 99, "depth": "repo", "harnesses": [], "owner": "this-repo", "includes": []}))
+    with pytest.raises(ValueError, match="unsupported config version"):
+        load_config(tmp_path)
+
+
+def test_load_rejects_invalid_selection(tmp_path):
+    path = tmp_path / ".solo-mise" / "config.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps({"version": 1, "depth": "weird", "harnesses": [], "owner": "this-repo", "includes": []}))
+    with pytest.raises(ValueError, match="unknown depth"):
+        load_config(tmp_path)
+
+
+def test_write_produces_pretty_json(tmp_path):
+    sel = Selection(depth="repo", harnesses=["claude"], owner="claude", includes=[])
+    write_config(tmp_path, Config(version=1, selection=sel))
+    text = (tmp_path / ".solo-mise" / "config.json").read_text()
+    assert "\n  " in text  # indented
+    assert text.endswith("\n")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+.venv/bin/python -m pytest tests/test_config.py -v
+```
+
+Expected: ImportError for `solo_mise.config`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# src/solo_mise/config.py
+"""Read/write .solo-mise/config.json - the per-target source of truth."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from .selection import Selection
+
+
+CONFIG_REL_PATH = ".solo-mise/config.json"
+SUPPORTED_VERSIONS = (1,)
+
+
+@dataclass
+class Config:
+    version: int
+    selection: Selection
+
+
+def config_path(target: Path) -> Path:
+    return target / CONFIG_REL_PATH
+
+
+def write_config(target: Path, cfg: Config) -> None:
+    cfg.selection.validate()
+    path = config_path(target)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "version": cfg.version,
+        "depth": cfg.selection.depth,
+        "harnesses": list(cfg.selection.harnesses),
+        "owner": cfg.selection.owner,
+        "includes": list(cfg.selection.includes),
+    }
+    path.write_text(json.dumps(payload, indent=2) + "\n")
+
+
+def load_config(target: Path) -> Optional[Config]:
+    path = config_path(target)
+    if not path.is_file():
+        return None
+    data = json.loads(path.read_text())
+    version = data.get("version")
+    if version not in SUPPORTED_VERSIONS:
+        raise ValueError(
+            f"unsupported config version: {version!r} (supported: {SUPPORTED_VERSIONS})"
+        )
+    sel = Selection(
+        depth=data.get("depth", ""),
+        harnesses=list(data.get("harnesses", [])),
+        owner=data.get("owner", "this-repo"),
+        includes=list(data.get("includes", [])),
+    )
+    sel.validate()
+    return Config(version=version, selection=sel)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+.venv/bin/python -m pytest tests/test_config.py -v
+```
+
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/solo_mise/config.py tests/test_config.py
+git commit -m "feat(config): add .solo-mise/config.json read/write"
+```
+
+---
+
+### Task 3: `profile_to_selection` legacy shim
+
+**Files:**
+- Modify: `src/solo_mise/selection.py` (add function)
+- Modify: `tests/test_selection.py` (add tests)
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `tests/test_selection.py`:
+
+```python
+from solo_mise.selection import profile_to_selection
+
+
+def test_profile_to_selection_repo():
+    s = profile_to_selection("repo")
+    assert s.depth == "repo"
+    assert s.harnesses == ["claude"]
+    assert s.owner == "claude"
+    assert s.includes == []
+
+
+def test_profile_to_selection_workspace():
+    s = profile_to_selection("workspace")
+    assert s.depth == "workspace"
+    assert s.harnesses == ["claude"]
+    assert s.owner == "claude"
+    assert s.includes == []
+
+
+def test_profile_to_selection_openclaw():
+    s = profile_to_selection("openclaw")
+    assert s.depth == "workspace"
+    assert s.harnesses == ["claude", "openclaw"]
+    assert s.owner == "openclaw"
+    assert s.includes == []
+
+
+def test_profile_to_selection_hermes():
+    s = profile_to_selection("hermes")
+    assert s.depth == "workspace"
+    assert s.harnesses == ["claude", "hermes"]
+    assert s.owner == "hermes"
+    assert s.includes == []
+
+
+def test_profile_to_selection_generic():
+    s = profile_to_selection("generic")
+    assert s.depth == "workspace"
+    assert s.harnesses == []
+    assert s.owner == "this-repo"
+    assert s.includes == []
+
+
+def test_profile_to_selection_publisher():
+    s = profile_to_selection("publisher")
+    assert s.depth == "repo"
+    assert s.harnesses == ["claude"]
+    assert s.owner == "claude"
+    assert s.includes == ["publisher"]
+
+
+def test_profile_to_selection_unknown_raises():
+    import pytest as _p
+    with _p.raises(ValueError, match="unknown profile"):
+        profile_to_selection("nope")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+.venv/bin/python -m pytest tests/test_selection.py -v -k profile_to_selection
+```
+
+Expected: ImportError for `profile_to_selection`.
+
+- [ ] **Step 3: Add implementation to `src/solo_mise/selection.py`**
+
+Append:
+
+```python
+_PROFILE_MAP = {
+    "repo":      Selection(depth="repo",      harnesses=["claude"],             owner="claude",    includes=[]),
+    "workspace": Selection(depth="workspace", harnesses=["claude"],             owner="claude",    includes=[]),
+    "openclaw":  Selection(depth="workspace", harnesses=["claude", "openclaw"], owner="openclaw",  includes=[]),
+    "hermes":    Selection(depth="workspace", harnesses=["claude", "hermes"],   owner="hermes",    includes=[]),
+    "generic":   Selection(depth="workspace", harnesses=[],                     owner="this-repo", includes=[]),
+    "publisher": Selection(depth="repo",      harnesses=["claude"],             owner="claude",    includes=["publisher"]),
+}
+
+
+def profile_to_selection(profile_id: str) -> Selection:
+    """Translate a legacy --profile id into a Selection. Used by the deprecation shim."""
+    if profile_id not in _PROFILE_MAP:
+        raise ValueError(
+            f"unknown profile: {profile_id!r} (valid: {sorted(_PROFILE_MAP)})"
+        )
+    sel = _PROFILE_MAP[profile_id]
+    # Return a copy to keep callers from mutating the map.
+    return Selection(
+        depth=sel.depth,
+        harnesses=list(sel.harnesses),
+        owner=sel.owner,
+        includes=list(sel.includes),
+    )
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+.venv/bin/python -m pytest tests/test_selection.py -v
+```
+
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/solo_mise/selection.py tests/test_selection.py
+git commit -m "feat(selection): add profile_to_selection legacy shim"
+```
+
+---
+
+## Phase 2: Template manifests
+
+### Task 4: Depth manifests
+
+**Files:**
+- Create: `src/solo_mise/templates/depth/repo.json`
+- Create: `src/solo_mise/templates/depth/workspace.json`
+- Modify: `src/solo_mise/templates.py` (add `load_depth_manifest`)
+- Test: `tests/test_fragments.py` (extend)
+
+The depth baseline is the harness-neutral material: AGENTS.md, SAFETY_RULES.md, INSTALL_FOR_AGENTS.md, plus depth-specific extras. Existing template files at `src/solo_mise/templates/workspace/*.md` and `src/solo_mise/templates/hooks/pre-push` are reused (no file moves).
+
+- [ ] **Step 1: Add failing test**
+
+Append to `tests/test_fragments.py`:
+
+```python
+from solo_mise.templates import load_depth_manifest, template_root
+
+
+def test_load_depth_repo():
+    m = load_depth_manifest("repo")
+    assert m["id"] == "repo"
+    dsts = [f["dst"] for f in m["files"]]
+    assert "AGENTS.md" in dsts
+    assert "SAFETY_RULES.md" in dsts
+    assert "INSTALL_FOR_AGENTS.md" in dsts
+    assert "hooks/pre-push" in dsts
+    assert ".solo-mise/policies/public-repo.json" in dsts
+    # depth baseline does NOT install harness-specific bridge files
+    assert "CLAUDE.md" not in dsts
+
+
+def test_load_depth_workspace():
+    m = load_depth_manifest("workspace")
+    assert m["id"] == "workspace"
+    dsts = [f["dst"] for f in m["files"]]
+    assert "AGENTS.md" in dsts
+    assert "MEMORY.md" in dsts
+    assert "TOOLS.md" in dsts
+    assert "USER.md" in dsts
+    assert "SOUL.md" in dsts
+    assert "IDENTITY.md" in dsts
+    assert "HEARTBEAT.md" in dsts
+    assert "CLAUDE.md" not in dsts
+
+
+def test_depth_repo_files_exist():
+    m = load_depth_manifest("repo")
+    root = template_root()
+    for entry in m["files"]:
+        assert (root / entry["src"]).is_file(), entry["src"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+.venv/bin/python -m pytest tests/test_fragments.py -v -k depth
+```
+
+Expected: `load_depth_manifest` ImportError.
+
+- [ ] **Step 3: Create `src/solo_mise/templates/depth/repo.json`**
+
+```json
+{
+  "id": "repo",
+  "description": "Repo-local baseline: harness-neutral bootstrap files + publish guard.",
+  "files": [
+    {"src": "workspace/AGENTS.md", "dst": "AGENTS.md"},
+    {"src": "workspace/SAFETY_RULES.md", "dst": "SAFETY_RULES.md"},
+    {"src": "workspace/INSTALL_FOR_AGENTS.md", "dst": "INSTALL_FOR_AGENTS.md"},
+    {"src": "hooks/pre-push", "dst": "hooks/pre-push", "mode": "0755"},
+    {"src": "policies/public-repo.json", "dst": ".solo-mise/policies/public-repo.json"}
+  ],
+  "dirs": []
+}
+```
+
+- [ ] **Step 4: Create `src/solo_mise/templates/depth/workspace.json`**
+
+```json
+{
+  "id": "workspace",
+  "description": "Full agent kitchen: extends repo baseline + memory folders + starter cards + safety files.",
+  "extends": "repo",
+  "files": [
+    {"src": "workspace/MEMORY.md", "dst": "MEMORY.md"},
+    {"src": "workspace/TOOLS.md", "dst": "TOOLS.md"},
+    {"src": "workspace/USER.md", "dst": "USER.md"},
+    {"src": "workspace/SOUL.md", "dst": "SOUL.md"},
+    {"src": "workspace/IDENTITY.md", "dst": "IDENTITY.md"},
+    {"src": "workspace/HEARTBEAT.md", "dst": "HEARTBEAT.md"},
+    {"src": "memory/cards/memory-architecture.md", "dst": "memory/cards/memory-architecture.md"},
+    {"src": "memory/cards/handoff-flow.md", "dst": "memory/cards/handoff-flow.md"},
+    {"src": "memory/cards/content-safety.md", "dst": "memory/cards/content-safety.md"},
+    {"src": "memory/cards/memory-scanner.md", "dst": "memory/cards/memory-scanner.md"},
+    {"src": "memory/cards/memory-care-staleness.md", "dst": "memory/cards/memory-care-staleness.md"},
+    {"src": "memory/cards/multi-workspace-handoff-admin.md", "dst": "memory/cards/multi-workspace-handoff-admin.md"},
+    {"src": "memory/cards/tokenjuice-output-compaction.md", "dst": "memory/cards/tokenjuice-output-compaction.md"},
+    {"src": "memory/cards/chat-surface-crawlers.md", "dst": "memory/cards/chat-surface-crawlers.md"},
+    {"src": "memory/cards/pipeline-standups.md", "dst": "memory/cards/pipeline-standups.md"},
+    {"src": "memory/cards/obsidian-notes.md", "dst": "memory/cards/obsidian-notes.md"},
+    {"src": "memory/cards/backup-restic.md", "dst": "memory/cards/backup-restic.md"},
+    {"src": "skills/note/SKILL.md", "dst": "skills/note/SKILL.md"},
+    {"src": "scripts/backup-restic.sh", "dst": "scripts/backup-restic.sh", "mode": "0755"}
+  ],
+  "dirs": [
+    "memory/cards/decay",
+    "memory/handoff-inbox"
+  ]
+}
+```
+
+- [ ] **Step 5: Add `load_depth_manifest` to `src/solo_mise/templates.py`**
+
+Add after `load_profile`:
+
+```python
+def load_depth_manifest(depth_id: str) -> Dict[str, Any]:
+    """Load and merge a depth manifest, resolving `extends` chains."""
+    return _load_layered("depth", depth_id)
+
+
+def _load_layered(kind: str, manifest_id: str) -> Dict[str, Any]:
+    base = template_root() / kind
+    path = base / f"{manifest_id}.json"
+    if not path.is_file():
+        raise FileNotFoundError(f"Unknown {kind}: {manifest_id} (looked at {path})")
+    manifest = json.loads(path.read_text())
+    parent_id = manifest.get("extends")
+    if parent_id:
+        parent = _load_layered(kind, parent_id)
+        merged_files = list(parent.get("files", [])) + list(manifest.get("files", []))
+        merged_dirs = list(parent.get("dirs", [])) + list(manifest.get("dirs", []))
+        manifest["files"] = _dedupe_files(merged_files)
+        manifest["dirs"] = sorted(set(merged_dirs))
+    return manifest
+```
+
+- [ ] **Step 6: Run tests**
+
+```bash
+.venv/bin/python -m pytest tests/test_fragments.py -v -k depth
+```
+
+Expected: all green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/solo_mise/templates/depth/ src/solo_mise/templates.py tests/test_fragments.py
+git commit -m "feat(templates): add depth manifests (repo, workspace)"
+```
+
+---
+
+### Task 5: Harness manifests + new codex inbox template
+
+**Files:**
+- Create: `src/solo_mise/templates/harnesses/claude.json`
+- Create: `src/solo_mise/templates/harnesses/codex.json`
+- Create: `src/solo_mise/templates/harnesses/openclaw.json`
+- Create: `src/solo_mise/templates/harnesses/hermes.json`
+- Create: `src/solo_mise/templates/codex/memory-handoffs/TEMPLATE.md`
+- Modify: `src/solo_mise/templates.py` (add `load_harness_manifest`)
+- Test: `tests/test_fragments.py` (extend)
+
+- [ ] **Step 1: Add failing test**
+
+Append to `tests/test_fragments.py`:
+
+```python
+from solo_mise.templates import load_harness_manifest
+
+
+def test_load_harness_claude():
+    m = load_harness_manifest("claude")
+    assert m["id"] == "claude"
+    assert m.get("role") == "writer"
+    dsts = [f["dst"] for f in m["files"]]
+    assert "CLAUDE.md" in dsts
+    assert ".claude/memory-handoffs/TEMPLATE.md" in dsts
+    assert ".claude/memory-handoffs/processed" in m.get("dirs", [])
+
+
+def test_load_harness_codex():
+    m = load_harness_manifest("codex")
+    assert m["id"] == "codex"
+    assert m.get("role") == "writer"
+    dsts = [f["dst"] for f in m["files"]]
+    # Codex has no bridge file today (reads AGENTS.md from depth baseline)
+    assert "CODEX.md" not in dsts
+    assert ".codex/memory-handoffs/TEMPLATE.md" in dsts
+    assert ".codex/memory-handoffs/processed" in m.get("dirs", [])
+
+
+def test_load_harness_openclaw():
+    m = load_harness_manifest("openclaw")
+    assert m["id"] == "openclaw"
+    assert m.get("role") == "reader"
+    dsts = [f["dst"] for f in m["files"]]
+    # Reader fragments live under .solo-mise/openclaw/
+    assert any(d.startswith(".solo-mise/openclaw/") for d in dsts)
+    # No inbox for readers
+    assert not any("/memory-handoffs/" in d for d in dsts)
+
+
+def test_load_harness_hermes():
+    m = load_harness_manifest("hermes")
+    assert m["id"] == "hermes"
+    assert m.get("role") == "reader"
+
+
+def test_codex_template_file_exists():
+    from solo_mise.templates import template_root
+    assert (template_root() / "codex" / "memory-handoffs" / "TEMPLATE.md").is_file()
+
+
+def test_all_harness_files_exist():
+    from solo_mise.templates import template_root
+    for h in ("claude", "codex", "openclaw", "hermes"):
+        m = load_harness_manifest(h)
+        for entry in m["files"]:
+            assert (template_root() / entry["src"]).is_file(), f"{h}: {entry['src']}"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+.venv/bin/python -m pytest tests/test_fragments.py -v -k harness
+```
+
+Expected: ImportError for `load_harness_manifest`.
+
+- [ ] **Step 3: Create the codex inbox template**
+
+Copy the content of `src/solo_mise/templates/claude/memory-handoffs/TEMPLATE.md` verbatim into `src/solo_mise/templates/codex/memory-handoffs/TEMPLATE.md`. Use:
+
+```bash
+mkdir -p src/solo_mise/templates/codex/memory-handoffs
+cp src/solo_mise/templates/claude/memory-handoffs/TEMPLATE.md src/solo_mise/templates/codex/memory-handoffs/TEMPLATE.md
+```
+
+- [ ] **Step 4: Create harness manifests**
+
+`src/solo_mise/templates/harnesses/claude.json`:
+
+```json
+{
+  "id": "claude",
+  "role": "writer",
+  "description": "Claude Code bridge + handoff inbox.",
+  "files": [
+    {"src": "workspace/CLAUDE.md", "dst": "CLAUDE.md"},
+    {"src": "claude/memory-handoffs/TEMPLATE.md", "dst": ".claude/memory-handoffs/TEMPLATE.md"}
+  ],
+  "dirs": [
+    ".claude/memory-handoffs/processed"
+  ]
+}
+```
+
+`src/solo_mise/templates/harnesses/codex.json`:
+
+```json
+{
+  "id": "codex",
+  "role": "writer",
+  "description": "Codex handoff inbox. (AGENTS.md is in the depth baseline; no separate bridge file today.)",
+  "files": [
+    {"src": "codex/memory-handoffs/TEMPLATE.md", "dst": ".codex/memory-handoffs/TEMPLATE.md"}
+  ],
+  "dirs": [
+    ".codex/memory-handoffs/processed"
+  ]
+}
+```
+
+`src/solo_mise/templates/harnesses/openclaw.json`:
+
+```json
+{
+  "id": "openclaw",
+  "role": "reader",
+  "description": "OpenClaw config fragments + cron stubs + doctor checks.",
+  "files": [
+    {"src": "openclaw/model-aliases.openclaw.json", "dst": ".solo-mise/openclaw/model-aliases.openclaw.json"},
+    {"src": "openclaw/ollama-memory-search.openclaw.json", "dst": ".solo-mise/openclaw/ollama-memory-search.openclaw.json"},
+    {"src": "openclaw/acp-escalation.openclaw.json", "dst": ".solo-mise/openclaw/acp-escalation.openclaw.json"},
+    {"src": "openclaw/README.md", "dst": ".solo-mise/openclaw/README.md"}
+  ],
+  "dirs": [],
+  "post_install_notes": [
+    "Inspect fragments under `.solo-mise/openclaw/` before merging into ~/.openclaw/openclaw.json.",
+    "Run `solo-mise doctor --target <workspace>` to confirm wiring.",
+    "Never let `openclaw doctor --fix` (the OpenClaw tool) rewrite provider prefixes blindly."
+  ]
+}
+```
+
+`src/solo_mise/templates/harnesses/hermes.json`:
+
+```json
+{
+  "id": "hermes",
+  "role": "reader",
+  "description": "Hermes adapter fragments + doctor checks. Experimental.",
+  "files": [
+    {"src": "hermes/workspace.harness.json", "dst": ".solo-mise/hermes/workspace.harness.json"},
+    {"src": "hermes/memory-handoff.harness.json", "dst": ".solo-mise/hermes/memory-handoff.harness.json"},
+    {"src": "hermes/model-lanes.harness.json", "dst": ".solo-mise/hermes/model-lanes.harness.json"},
+    {"src": "hermes/README.md", "dst": ".solo-mise/hermes/README.md"}
+  ],
+  "dirs": [],
+  "post_install_notes": [
+    "Hermes support is experimental. Validate against your real Hermes install before relying on it.",
+    "Open an issue with your config layout to help promote the adapter from experimental to tested."
+  ]
+}
+```
+
+- [ ] **Step 5: Add `load_harness_manifest` to `templates.py`**
+
+Append after `load_depth_manifest`:
+
+```python
+def load_harness_manifest(harness_id: str) -> Dict[str, Any]:
+    """Load a harness manifest. Harness manifests do not currently use `extends`."""
+    return _load_layered("harnesses", harness_id)
+```
+
+- [ ] **Step 6: Run tests**
+
+```bash
+.venv/bin/python -m pytest tests/test_fragments.py -v -k harness
+```
+
+Expected: all green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/solo_mise/templates/harnesses/ src/solo_mise/templates/codex/ src/solo_mise/templates.py tests/test_fragments.py
+git commit -m "feat(templates): add per-harness manifests + codex inbox template"
+```
+
+---
+
+### Task 6: Include manifests (publisher)
+
+**Files:**
+- Create: `src/solo_mise/templates/includes/publisher.json`
+- Modify: `src/solo_mise/templates.py` (add `load_include_manifest`)
+- Test: `tests/test_fragments.py` (extend)
+
+- [ ] **Step 1: Add failing test**
+
+Append:
+
+```python
+from solo_mise.templates import load_include_manifest
+
+
+def test_load_include_publisher():
+    m = load_include_manifest("publisher")
+    assert m["id"] == "publisher"
+    dsts = [f["dst"] for f in m["files"]]
+    assert ".solo-mise/policies/public-content.json" in dsts
+    assert "memory/cards/content-safety.md" in dsts
+```
+
+- [ ] **Step 2: Run, expect fail**
+
+```bash
+.venv/bin/python -m pytest tests/test_fragments.py -v -k include
+```
+
+- [ ] **Step 3: Create `src/solo_mise/templates/includes/publisher.json`**
+
+```json
+{
+  "id": "publisher",
+  "description": "content-guard policies + scrub cache for users who publish blogs, social, or docs.",
+  "files": [
+    {"src": "policies/public-content.json", "dst": ".solo-mise/policies/public-content.json"},
+    {"src": "memory/cards/content-safety.md", "dst": "memory/cards/content-safety.md"}
+  ],
+  "dirs": [
+    ".solo-mise/scrub-cache"
+  ],
+  "post_install_notes": [
+    "Run `solo-mise scrub --target . --policy public-content` before publishing user-facing content.",
+    "Add `solo-mise scrub` to your publish workflow as a hard gate."
+  ]
+}
+```
+
+- [ ] **Step 4: Add `load_include_manifest` to templates.py**
+
+```python
+def load_include_manifest(include_id: str) -> Dict[str, Any]:
+    return _load_layered("includes", include_id)
+```
+
+- [ ] **Step 5: Run, expect pass + commit**
+
+```bash
+.venv/bin/python -m pytest tests/test_fragments.py -v
+git add src/solo_mise/templates/includes/ src/solo_mise/templates.py tests/test_fragments.py
+git commit -m "feat(templates): add include manifests (publisher)"
+```
+
+---
+
+## Phase 3: Install engine
+
+### Task 7: `install_selection` install engine
+
+**Files:**
+- Create: `src/solo_mise/install.py`
+- Create: `tests/test_install.py`
+
+The engine composes one depth manifest + N harness manifests + M include manifests into a single deduped file list, then runs the existing copy/render logic. It also returns the merged `post_install_notes`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_install.py
+from pathlib import Path
+import pytest
+from solo_mise.install import resolve_manifests, install_selection
+from solo_mise.selection import Selection
+
+
+def test_resolve_manifests_repo_claude():
+    sel = Selection(depth="repo", harnesses=["claude"], owner="claude", includes=[])
+    files, dirs, notes = resolve_manifests(sel)
+    dsts = [f["dst"] for f in files]
+    assert "AGENTS.md" in dsts
+    assert "CLAUDE.md" in dsts
+    assert ".claude/memory-handoffs/TEMPLATE.md" in dsts
+    assert ".claude/memory-handoffs/processed" in dirs
+
+
+def test_resolve_manifests_workspace_claude_codex_openclaw():
+    sel = Selection(
+        depth="workspace",
+        harnesses=["claude", "codex", "openclaw"],
+        owner="openclaw",
+        includes=[],
+    )
+    files, dirs, notes = resolve_manifests(sel)
+    dsts = [f["dst"] for f in files]
+    # Baseline
+    assert "AGENTS.md" in dsts
+    assert "MEMORY.md" in dsts
+    # Claude
+    assert "CLAUDE.md" in dsts
+    assert ".claude/memory-handoffs/TEMPLATE.md" in dsts
+    # Codex
+    assert ".codex/memory-handoffs/TEMPLATE.md" in dsts
+    # OpenClaw fragments
+    assert ".solo-mise/openclaw/model-aliases.openclaw.json" in dsts
+    # Each dst appears at most once
+    assert len(dsts) == len(set(dsts))
+
+
+def test_resolve_manifests_empty_harnesses():
+    sel = Selection(depth="workspace", harnesses=[], owner="this-repo", includes=[])
+    files, dirs, notes = resolve_manifests(sel)
+    dsts = [f["dst"] for f in files]
+    assert "CLAUDE.md" not in dsts
+    assert not any(d.endswith("memory-handoffs/TEMPLATE.md") for d in dsts)
+    assert "AGENTS.md" in dsts
+
+
+def test_resolve_manifests_publisher_include():
+    sel = Selection(depth="repo", harnesses=["claude"], owner="claude", includes=["publisher"])
+    files, dirs, notes = resolve_manifests(sel)
+    dsts = [f["dst"] for f in files]
+    assert ".solo-mise/policies/public-content.json" in dsts
+    assert ".solo-mise/scrub-cache" in dirs
+
+
+def test_install_selection_writes_files(tmp_path):
+    sel = Selection(depth="repo", harnesses=["claude"], owner="claude", includes=[])
+    code = install_selection(tmp_path, sel)
+    assert code == 0
+    assert (tmp_path / "AGENTS.md").is_file()
+    assert (tmp_path / "CLAUDE.md").is_file()
+    assert (tmp_path / ".claude" / "memory-handoffs" / "TEMPLATE.md").is_file()
+    assert (tmp_path / ".claude" / "memory-handoffs" / "processed").is_dir()
+
+
+def test_install_selection_writes_config(tmp_path):
+    from solo_mise.config import load_config
+    sel = Selection(
+        depth="workspace",
+        harnesses=["claude", "codex", "openclaw"],
+        owner="openclaw",
+        includes=["publisher"],
+    )
+    install_selection(tmp_path, sel)
+    cfg = load_config(tmp_path)
+    assert cfg is not None
+    assert cfg.selection.depth == "workspace"
+    assert cfg.selection.harnesses == ["claude", "codex", "openclaw"]
+    assert cfg.selection.owner == "openclaw"
+    assert cfg.selection.includes == ["publisher"]
+
+
+def test_install_selection_refuses_overwrite_without_force(tmp_path):
+    sel = Selection(depth="repo", harnesses=["claude"], owner="claude", includes=[])
+    install_selection(tmp_path, sel)
+    code = install_selection(tmp_path, sel)
+    assert code == 3  # matches existing init refuse-overwrite exit code
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+.venv/bin/python -m pytest tests/test_install.py -v
+```
+
+Expected: ImportError for `solo_mise.install`.
+
+- [ ] **Step 3: Implement `src/solo_mise/install.py`**
+
+```python
+"""install_selection - the new install engine.
+
+Composes a depth manifest + N harness manifests + M include manifests
+into a single deduped file/dir list, then copies+renders into target.
+Persists the Selection to .solo-mise/config.json.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from pathlib import Path
+from typing import List, Tuple
+
+from .config import Config, write_config
+from .selection import Selection
+from .templates import (
+    harness_memory_owner,
+    is_text,
+    load_depth_manifest,
+    load_harness_manifest,
+    load_include_manifest,
+    render,
+    template_root,
+)
+
+
+def resolve_manifests(selection: Selection) -> Tuple[List[dict], List[str], List[str]]:
+    """Return (files, dirs, post_install_notes) for a Selection.
+
+    Files are deduped by `dst`: later manifests win, so a harness can
+    override a depth-baseline file by referencing the same dst.
+    """
+    files: List[dict] = []
+    dirs: List[str] = []
+    notes: List[str] = []
+
+    depth_manifest = load_depth_manifest(selection.depth)
+    files.extend(depth_manifest.get("files", []))
+    dirs.extend(depth_manifest.get("dirs", []))
+    notes.extend(depth_manifest.get("post_install_notes", []))
+
+    for harness_id in selection.harnesses:
+        m = load_harness_manifest(harness_id)
+        files.extend(m.get("files", []))
+        dirs.extend(m.get("dirs", []))
+        notes.extend(m.get("post_install_notes", []))
+
+    for include_id in selection.includes:
+        m = load_include_manifest(include_id)
+        files.extend(m.get("files", []))
+        dirs.extend(m.get("dirs", []))
+        notes.extend(m.get("post_install_notes", []))
+
+    # Dedupe files by dst (last-wins).
+    seen: dict[str, dict] = {}
+    for entry in files:
+        seen[entry["dst"]] = entry
+    deduped_files = list(seen.values())
+    deduped_dirs = sorted(set(dirs))
+
+    return deduped_files, deduped_dirs, notes
+
+
+def install_selection(
+    target: Path,
+    selection: Selection,
+    force: bool = False,
+    dry_run: bool = False,
+    allow_home: bool = False,
+) -> int:
+    """Install a Selection into `target`. Returns process exit code."""
+    selection.validate()
+    target = target.expanduser().resolve()
+
+    if target == Path.home() and not allow_home:
+        print(
+            f"error: refusing to install directly into $HOME ({target}).",
+            file=sys.stderr,
+        )
+        return 5
+
+    files, dirs, notes = resolve_manifests(selection)
+
+    if dry_run:
+        print(f"[dry-run] target: {target}")
+        print(f"[dry-run] depth: {selection.depth}")
+        print(f"[dry-run] harnesses: {','.join(selection.harnesses) or '(none)'}")
+        print(f"[dry-run] owner: {selection.owner}")
+        print(f"[dry-run] includes: {','.join(selection.includes) or '(none)'}")
+        print(f"[dry-run] would create {len(dirs)} dir(s) and {len(files)} file(s)")
+        for d in dirs:
+            print(f"  dir   {target / d}")
+        for entry in files:
+            print(f"  file  {target / entry['dst']}")
+        return 0
+
+    target.mkdir(parents=True, exist_ok=True)
+
+    if not force:
+        conflicts = [target / f["dst"] for f in files if (target / f["dst"]).exists()]
+        if conflicts:
+            print("error: refusing to overwrite existing files (use --force):", file=sys.stderr)
+            for c in conflicts:
+                print(f"  {c}", file=sys.stderr)
+            return 3
+
+    for d in dirs:
+        (target / d).mkdir(parents=True, exist_ok=True)
+
+    owner_label = harness_memory_owner(selection.owner, selection.owner)
+    context = {
+        "memory_owner": selection.owner,
+        "memory_owner_name": owner_label,
+        "harness": selection.owner,
+    }
+
+    root = template_root()
+    for entry in files:
+        src = root / entry["src"]
+        dst = target / entry["dst"]
+        if not src.is_file():
+            print(f"error: template missing: {src}", file=sys.stderr)
+            return 4
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        if is_text(entry["src"]):
+            dst.write_text(render(src.read_text(), context))
+        else:
+            shutil.copyfile(src, dst)
+        mode_str = entry.get("mode")
+        if mode_str:
+            os.chmod(dst, int(mode_str, 8))
+
+    # Persist config.json.
+    write_config(target, Config(version=1, selection=selection))
+
+    # Post-install output.
+    print(f"solo-mise: installed depth={selection.depth} harnesses={','.join(selection.harnesses) or '(none)'} -> {target}")
+    print(f"solo-mise: memory owner -> {owner_label}")
+    if "hermes" in selection.harnesses:
+        print(
+            "solo-mise: NOTE - the hermes adapter is experimental. "
+            "Validate against your real Hermes install before relying on it. "
+            "See CONTRIBUTING.md for graduation criteria.",
+            file=sys.stderr,
+        )
+    if notes:
+        print()
+        print("Next steps:")
+        for note in notes:
+            print(f"  - {note}")
+    return 0
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+.venv/bin/python -m pytest tests/test_install.py -v
+```
+
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/solo_mise/install.py tests/test_install.py
+git commit -m "feat(install): add install_selection engine that composes manifests"
+```
+
+---
+
+### Task 8: Managed `.gitignore` block adapts to writer harnesses
+
+**Files:**
+- Modify: `src/solo_mise/init.py` (replace `_apply_gitignore` constants/builder)
+- Modify: `src/solo_mise/install.py` (call new gitignore builder)
+- Modify: `tests/test_gitignore.py` (extend)
+
+The existing managed block hardcodes `.claude/memory-handoffs/`. The new block has one section per selected writer harness.
+
+- [ ] **Step 1: Write failing test (extend `tests/test_gitignore.py`)**
+
+```python
+from solo_mise.selection import Selection
+
+
+def test_gitignore_block_includes_claude_section_when_selected():
+    from solo_mise.install import build_gitignore_block
+    sel = Selection(depth="repo", harnesses=["claude"], owner="claude", includes=[])
+    block = build_gitignore_block(sel)
+    assert ".claude/memory-handoffs/*" in block
+    assert "!.claude/memory-handoffs/TEMPLATE.md" in block
+    assert ".codex/memory-handoffs" not in block
+
+
+def test_gitignore_block_includes_codex_section_when_selected():
+    from solo_mise.install import build_gitignore_block
+    sel = Selection(depth="repo", harnesses=["claude", "codex"], owner="claude", includes=[])
+    block = build_gitignore_block(sel)
+    assert ".claude/memory-handoffs/*" in block
+    assert ".codex/memory-handoffs/*" in block
+    assert "!.codex/memory-handoffs/TEMPLATE.md" in block
+
+
+def test_gitignore_block_no_inbox_section_for_readers_only():
+    from solo_mise.install import build_gitignore_block
+    sel = Selection(depth="workspace", harnesses=["openclaw"], owner="openclaw", includes=[])
+    block = build_gitignore_block(sel)
+    assert "memory-handoffs" not in block
+
+
+def test_install_writes_gitignore_block(tmp_path):
+    from solo_mise.install import install_selection
+    sel = Selection(depth="repo", harnesses=["claude", "codex"], owner="claude", includes=[])
+    install_selection(tmp_path, sel)
+    gi = (tmp_path / ".gitignore").read_text()
+    assert "# >>> solo-mise gitignore block >>>" in gi
+    assert ".claude/memory-handoffs/*" in gi
+    assert ".codex/memory-handoffs/*" in gi
+```
+
+- [ ] **Step 2: Run, expect fail**
+
+```bash
+.venv/bin/python -m pytest tests/test_gitignore.py -v
+```
+
+- [ ] **Step 3: Add `build_gitignore_block` to `src/solo_mise/install.py`**
+
+Add at module top:
+
+```python
+GITIGNORE_BEGIN = "# >>> solo-mise gitignore block >>>"
+GITIGNORE_END = "# <<< solo-mise gitignore block <<<"
+
+# Writer harness -> inbox-dir prefix. Only writer harnesses have an inbox.
+_WRITER_INBOX = {
+    "claude": ".claude/memory-handoffs",
+    "codex": ".codex/memory-handoffs",
+}
+
+
+def build_gitignore_block(selection: Selection) -> str:
+    lines = [
+        GITIGNORE_BEGIN,
+        "# Managed by `solo-mise init`. Edit between the markers to customize.",
+        "# Re-running `solo-mise init` replaces only the content between markers.",
+        "",
+    ]
+    for h in selection.harnesses:
+        inbox = _WRITER_INBOX.get(h)
+        if inbox:
+            lines.extend([
+                f"# {h}: handoffs are session-local and may contain private context.",
+                f"{inbox}/*",
+                f"!{inbox}/TEMPLATE.md",
+                f"!{inbox}/.gitkeep",
+                "",
+            ])
+    lines.extend([
+        "# Daily session logs are machine-local raw context.",
+        "memory/20[0-9][0-9]-[0-1][0-9]-[0-3][0-9].md",
+        "",
+        "# Review inbox: ambiguous handoffs awaiting human triage.",
+        "memory/handoff-inbox/",
+        "",
+        "# solo-mise local state (logs, scrub cache).",
+        ".solo-mise/logs/",
+        ".solo-mise/scrub-cache/",
+        GITIGNORE_END,
+        "",
+    ])
+    return "\n".join(lines)
+
+
+def apply_gitignore(target: Path, selection: Selection) -> str:
+    """Insert or replace the managed block in target's .gitignore. Returns 'created' or 'updated'."""
+    gi = target / ".gitignore"
+    block = build_gitignore_block(selection)
+    if not gi.exists():
+        gi.write_text(block)
+        return "created"
+    existing = gi.read_text()
+    if GITIGNORE_BEGIN in existing and GITIGNORE_END in existing:
+        prefix, _, rest = existing.partition(GITIGNORE_BEGIN)
+        _, _, suffix = rest.partition(GITIGNORE_END)
+        # Strip a trailing newline from prefix and a leading newline from suffix to avoid drift.
+        new_text = prefix.rstrip("\n") + ("\n\n" if prefix.strip() else "") + block + suffix.lstrip("\n")
+        gi.write_text(new_text)
+        return "updated"
+    sep = "" if existing.endswith("\n") else "\n"
+    gi.write_text(existing + sep + "\n" + block)
+    return "updated"
+```
+
+- [ ] **Step 4: Wire `apply_gitignore` into `install_selection`**
+
+In `install.py`, after `write_config(target, ...)` and before the post-install output, add:
+
+```python
+result = apply_gitignore(target, selection)
+print(f"solo-mise: gitignore {result}")
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+.venv/bin/python -m pytest tests/test_gitignore.py tests/test_install.py -v
+```
+
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/solo_mise/install.py tests/test_gitignore.py
+git commit -m "feat(install): gitignore block adapts to selected writer harnesses"
+```
+
+---
+
+## Phase 4: CLI surface
+
+### Task 9: New CLI flags + validation
+
+**Files:**
+- Modify: `src/solo_mise/cli.py`
+- Modify: `tests/test_init.py` (extend) OR create `tests/test_cli.py`
+
+- [ ] **Step 1: Write failing test (extend `tests/test_init.py`)**
+
+```python
+def test_cli_parses_depth_harnesses(monkeypatch, tmp_path):
+    from solo_mise.cli import _build_parser
+    parser = _build_parser()
+    ns = parser.parse_args([
+        "init",
+        "--target", str(tmp_path),
+        "--depth", "workspace",
+        "--harnesses", "claude,codex,openclaw",
+        "--owner", "openclaw",
+        "--include", "publisher",
+    ])
+    assert ns.depth == "workspace"
+    assert ns.harnesses == "claude,codex,openclaw"
+    assert ns.owner == "openclaw"
+    assert ns.includes == ["publisher"]
+
+
+def test_cli_rejects_unknown_harness(tmp_path):
+    from solo_mise.cli import main
+    rc = main([
+        "init", "--target", str(tmp_path),
+        "--harnesses", "claude,weird",
+    ])
+    assert rc != 0
+```
+
+- [ ] **Step 2: Run, expect fail**
+
+```bash
+.venv/bin/python -m pytest tests/test_init.py -v -k "depth_harnesses or unknown_harness"
+```
+
+- [ ] **Step 3: Update `src/solo_mise/cli.py` `init` subparser**
+
+In `_build_parser`, replace the `p_init` block additions with:
+
+```python
+    p_init.add_argument(
+        "--depth",
+        choices=["repo", "workspace"],
+        default=None,
+        help="Install depth: 'repo' (minimal) or 'workspace' (full home). "
+             "Required unless --profile is used.",
+    )
+    p_init.add_argument(
+        "--harnesses",
+        default=None,
+        help="Comma-separated harness ids: claude, codex, openclaw, hermes. "
+             "Pass 'none' for a generic install with no harness-specific files.",
+    )
+    p_init.add_argument(
+        "--owner",
+        default=None,
+        help="Override the canonical memory owner. Must be 'this-repo' or one of --harnesses.",
+    )
+    p_init.add_argument(
+        "--include",
+        dest="includes",
+        action="append",
+        default=[],
+        help="Optional add-on (currently: 'publisher'). May be repeated.",
+    )
+```
+
+- [ ] **Step 4: Add validation in cli `main`**
+
+In `main`, after parsing args for `init`, build a Selection (without invoking interactive prompt yet - that's Task 12):
+
+```python
+    if args.command == "init":
+        # Selection construction is layered: --profile is handled by Task 10 shim;
+        # interactive prompt is wired in Task 12. For now if --depth or --harnesses
+        # are provided, build directly.
+        from .selection import Selection, KNOWN_HARNESSES, resolve_owner
+        from .install import install_selection
+
+        if args.depth is not None or args.harnesses is not None:
+            depth = args.depth or "repo"
+            if args.harnesses is None or args.harnesses == "":
+                harnesses = ["claude"]
+            elif args.harnesses == "none":
+                harnesses = []
+            else:
+                harnesses = [h.strip() for h in args.harnesses.split(",") if h.strip()]
+            for h in harnesses:
+                if h not in KNOWN_HARNESSES:
+                    print(f"error: unknown harness {h!r} (valid: {KNOWN_HARNESSES})", file=sys.stderr)
+                    return 2
+            try:
+                owner = resolve_owner(harnesses, override=args.owner)
+            except ValueError as exc:
+                print(f"error: {exc}", file=sys.stderr)
+                return 2
+            sel = Selection(depth=depth, harnesses=harnesses, owner=owner, includes=list(args.includes))
+            return install_selection(
+                target=args.target,
+                selection=sel,
+                force=getattr(args, "force", False),
+                dry_run=getattr(args, "dry_run", False),
+                allow_home=getattr(args, "allow_home", False),
+            )
+        # Fall through to legacy --profile path (Task 10 wires this).
+        ...
+```
+
+The existing legacy `init.run` call stays as the fallback path for `--profile <x>`; Task 10 covers the deprecation message.
+
+- [ ] **Step 5: Run tests**
+
+```bash
+.venv/bin/python -m pytest tests/test_init.py -v
+```
+
+Expected: new tests pass; existing tests still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/solo_mise/cli.py tests/test_init.py
+git commit -m "feat(cli): add --depth, --harnesses, --owner, --include flags"
+```
+
+---
+
+### Task 10: Legacy `--profile` deprecation shim
+
+**Files:**
+- Modify: `src/solo_mise/cli.py`
+- Modify: `tests/test_init.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+def test_legacy_profile_translates_and_warns(tmp_path, capsys):
+    from solo_mise.cli import main
+    rc = main(["init", "--target", str(tmp_path), "--profile", "workspace"])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "deprecated" in captured.err.lower()
+    assert "workspace" in captured.err
+    # Workspace install includes MEMORY.md
+    assert (tmp_path / "MEMORY.md").is_file()
+    # And CLAUDE.md from the claude harness
+    assert (tmp_path / "CLAUDE.md").is_file()
+
+
+def test_legacy_profile_openclaw_translates(tmp_path):
+    from solo_mise.cli import main
+    rc = main(["init", "--target", str(tmp_path), "--profile", "openclaw"])
+    assert rc == 0
+    assert (tmp_path / ".solo-mise" / "openclaw" / "README.md").is_file()
+```
+
+- [ ] **Step 2: Run, expect fail**
+
+- [ ] **Step 3: In `cli.py` main, replace the legacy fallback with the shim**
+
+```python
+        # Legacy --profile path
+        if args.profile:
+            from .selection import profile_to_selection
+            sel = profile_to_selection(args.profile)
+            print(
+                f"warning: --profile is deprecated. The equivalent in v0.3.0+ is "
+                f"`--depth {sel.depth} --harnesses {','.join(sel.harnesses) or 'none'}"
+                + (f" --owner {sel.owner}" if sel.owner != "this-repo" and sel.owner in sel.harnesses else "")
+                + (f" --include {' --include '.join(sel.includes)}" if sel.includes else "")
+                + "`. --profile will be removed in v0.4.0.",
+                file=sys.stderr,
+            )
+            return install_selection(
+                target=args.target,
+                selection=sel,
+                force=getattr(args, "force", False),
+                dry_run=getattr(args, "dry_run", False),
+                allow_home=getattr(args, "allow_home", False),
+            )
+        # No selection and no profile: Task 12 wires interactive prompt.
+        # For now, default to repo/claude.
+        from .selection import Selection
+        sel = Selection(depth="repo", harnesses=["claude"], owner="claude", includes=[])
+        return install_selection(
+            target=args.target,
+            selection=sel,
+            force=getattr(args, "force", False),
+            dry_run=getattr(args, "dry_run", False),
+            allow_home=getattr(args, "allow_home", False),
+        )
+```
+
+- [ ] **Step 4: Run tests + the legacy-profile pytest suite**
+
+```bash
+.venv/bin/python -m pytest tests/test_init.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/solo_mise/cli.py tests/test_init.py
+git commit -m "feat(cli): --profile becomes a deprecation shim translating to new flags"
+```
+
+---
+
+### Task 11: Interactive prompt (hand-rolled, zero-dep)
+
+**Files:**
+- Create: `src/solo_mise/prompt.py`
+- Create: `tests/test_prompt.py`
+
+The prompt is intentionally simple: numbered toggle for harnesses, numbered single-pick for depth, numbered toggle for includes. No raw-mode terminal, no curses - works over any stdin/stdout that supports line-buffered IO. TTY detection: if `sys.stdin.isatty()` is false, raise an error pointing at the flags.
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# tests/test_prompt.py
+import io
+import pytest
+from solo_mise.prompt import prompt_for_selection, NonInteractiveError
+
+
+def _run_with_input(text, monkeypatch):
+    monkeypatch.setattr("sys.stdin", io.StringIO(text))
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+
+
+def test_prompt_returns_defaults_on_empty_input(monkeypatch, capsys):
+    """All defaults: claude harness, repo depth, no includes."""
+    monkeypatch.setattr("sys.stdin", io.StringIO("\n\n\n"))
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+    sel = prompt_for_selection()
+    assert sel.harnesses == ["claude"]
+    assert sel.depth == "repo"
+    assert sel.includes == []
+
+
+def test_prompt_toggles_codex_and_openclaw(monkeypatch):
+    """User types '2,3' to toggle codex and openclaw on (claude was default on)."""
+    # Default selected: claude. Toggle inputs: '2 3' -> codex on, openclaw on.
+    monkeypatch.setattr("sys.stdin", io.StringIO("2 3\n2\n\n"))
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+    sel = prompt_for_selection()
+    assert set(sel.harnesses) == {"claude", "codex", "openclaw"}
+    assert sel.depth == "workspace"  # depth choice 2
+    assert sel.owner == "openclaw"
+
+
+def test_prompt_errors_when_not_tty(monkeypatch):
+    monkeypatch.setattr("sys.stdin", io.StringIO(""))
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False, raising=False)
+    with pytest.raises(NonInteractiveError):
+        prompt_for_selection()
+```
+
+- [ ] **Step 2: Run, expect fail**
+
+- [ ] **Step 3: Implement `src/solo_mise/prompt.py`**
+
+```python
+"""Hand-rolled interactive prompt for harness/depth/include selection.
+
+No external deps. Uses stdin line input + numbered toggles, so it works
+over any TTY (no raw mode, no curses, no ANSI escape sequences required).
+"""
+from __future__ import annotations
+
+import sys
+from typing import List
+
+from .selection import (
+    KNOWN_HARNESSES,
+    KNOWN_DEPTHS,
+    KNOWN_INCLUDES,
+    Selection,
+    resolve_owner,
+)
+
+
+class NonInteractiveError(Exception):
+    """Raised when prompt_for_selection() runs without a TTY."""
+
+
+_HARNESS_ORDER = ["claude", "codex", "openclaw", "hermes"]
+_DEPTH_ORDER = ["repo", "workspace"]
+_INCLUDE_ORDER = ["publisher"]
+
+_HARNESS_LABELS = {
+    "claude": "Claude Code",
+    "codex": "Codex",
+    "openclaw": "OpenClaw",
+    "hermes": "Hermes (experimental)",
+}
+
+_DEPTH_LABELS = {
+    "repo": "repo       (handoff flow + publish guard)",
+    "workspace": "workspace  (full home: MEMORY.md, TOOLS.md, USER.md, ...)",
+}
+
+_INCLUDE_LABELS = {
+    "publisher": "publisher  (content-guard policies for blog/social/docs)",
+}
+
+
+def prompt_for_selection() -> Selection:
+    if not sys.stdin.isatty():
+        raise NonInteractiveError(
+            "solo-mise init needs a TTY for the interactive prompt. "
+            "Pass --depth and --harnesses (or --profile) for scripting."
+        )
+
+    selected_harnesses = _toggle_prompt(
+        title="Which harnesses do you use?",
+        options=_HARNESS_ORDER,
+        labels=_HARNESS_LABELS,
+        defaults=["claude"],
+    )
+    depth = _single_prompt(
+        title="Depth?",
+        options=_DEPTH_ORDER,
+        labels=_DEPTH_LABELS,
+        default="repo",
+    )
+    selected_includes = _toggle_prompt(
+        title="Add-ons?",
+        options=_INCLUDE_ORDER,
+        labels=_INCLUDE_LABELS,
+        defaults=[],
+    )
+
+    owner = resolve_owner(selected_harnesses)
+    return Selection(
+        depth=depth,
+        harnesses=selected_harnesses,
+        owner=owner,
+        includes=selected_includes,
+    )
+
+
+def _toggle_prompt(title, options, labels, defaults):
+    selected = list(defaults)
+    print()
+    print(title + " (type numbers separated by space/comma to toggle, enter to confirm)")
+    while True:
+        for i, opt in enumerate(options, start=1):
+            mark = "x" if opt in selected else " "
+            print(f"  [{mark}] {i}. {labels.get(opt, opt)}")
+        raw = sys.stdin.readline()
+        if raw == "":  # EOF
+            break
+        raw = raw.strip()
+        if not raw:
+            break
+        tokens = [t.strip() for t in raw.replace(",", " ").split() if t.strip()]
+        invalid = []
+        for t in tokens:
+            try:
+                idx = int(t)
+            except ValueError:
+                invalid.append(t)
+                continue
+            if not 1 <= idx <= len(options):
+                invalid.append(t)
+                continue
+            opt = options[idx - 1]
+            if opt in selected:
+                selected.remove(opt)
+            else:
+                selected.append(opt)
+        if invalid:
+            print(f"  (ignored invalid: {' '.join(invalid)})")
+    # Preserve canonical order rather than toggle order.
+    return [o for o in options if o in selected]
+
+
+def _single_prompt(title, options, labels, default):
+    print()
+    print(title + " (type a number, enter for default)")
+    for i, opt in enumerate(options, start=1):
+        marker = "*" if opt == default else " "
+        print(f"  {marker} {i}. {labels.get(opt, opt)}")
+    raw = sys.stdin.readline()
+    if raw == "":
+        return default
+    raw = raw.strip()
+    if not raw:
+        return default
+    try:
+        idx = int(raw)
+        if 1 <= idx <= len(options):
+            return options[idx - 1]
+    except ValueError:
+        pass
+    print(f"  (invalid; using default {default!r})")
+    return default
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+.venv/bin/python -m pytest tests/test_prompt.py -v
+```
+
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/solo_mise/prompt.py tests/test_prompt.py
+git commit -m "feat(prompt): zero-dep interactive harness/depth/include picker"
+```
+
+---
+
+### Task 12: CLI wiring - prompt vs flags
+
+**Files:**
+- Modify: `src/solo_mise/cli.py`
+- Modify: `tests/test_init.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+def test_cli_invokes_prompt_when_no_selection_flags(monkeypatch, tmp_path):
+    """init without any selection flags should call prompt_for_selection."""
+    called = {}
+    from solo_mise import cli
+    from solo_mise.selection import Selection
+
+    def fake_prompt():
+        called["yes"] = True
+        return Selection(depth="repo", harnesses=["claude"], owner="claude", includes=[])
+
+    monkeypatch.setattr(cli, "prompt_for_selection", fake_prompt)
+    rc = cli.main(["init", "--target", str(tmp_path)])
+    assert rc == 0
+    assert called.get("yes") is True
+
+
+def test_cli_skips_prompt_when_depth_given(monkeypatch, tmp_path):
+    from solo_mise import cli
+    def fail():
+        raise AssertionError("prompt should not be called")
+    monkeypatch.setattr(cli, "prompt_for_selection", fail)
+    rc = cli.main(["init", "--target", str(tmp_path), "--depth", "repo", "--harnesses", "claude"])
+    assert rc == 0
+```
+
+- [ ] **Step 2: Run, expect fail**
+
+- [ ] **Step 3: Update `cli.main` `init` branch**
+
+Replace the "No selection and no profile" fallback with:
+
+```python
+        # No flags: interactive prompt (Task 12).
+        from .prompt import prompt_for_selection, NonInteractiveError
+        try:
+            sel = prompt_for_selection()
+        except NonInteractiveError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        return install_selection(
+            target=args.target,
+            selection=sel,
+            force=getattr(args, "force", False),
+            dry_run=getattr(args, "dry_run", False),
+            allow_home=getattr(args, "allow_home", False),
+        )
+```
+
+Add at top of `cli.py`:
+
+```python
+from .prompt import prompt_for_selection  # imported here so tests can monkeypatch cli.prompt_for_selection
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+.venv/bin/python -m pytest tests/test_init.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/solo_mise/cli.py tests/test_init.py
+git commit -m "feat(cli): route to interactive prompt when no selection flags given"
+```
+
+---
+
+## Phase 5: Surrounding tools
+
+### Task 13: Doctor reads `.solo-mise/config.json`
+
+**Files:**
+- Modify: `src/solo_mise/doctor.py`
+- Modify: `tests/test_doctor.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+def test_doctor_reports_apparent_harness_shape(tmp_path, capsys):
+    from solo_mise.install import install_selection
+    from solo_mise.selection import Selection
+    from solo_mise.doctor import run as doctor_run
+    sel = Selection(depth="workspace", harnesses=["claude", "codex", "openclaw"], owner="openclaw", includes=[])
+    install_selection(tmp_path, sel)
+    doctor_run(tmp_path)
+    out = capsys.readouterr().out
+    assert "harnesses:" in out
+    assert "claude" in out
+    assert "codex" in out
+    assert "openclaw" in out
+    assert "owner=openclaw" in out
+
+
+def test_doctor_checks_codex_inbox_when_selected(tmp_path, capsys):
+    from solo_mise.install import install_selection
+    from solo_mise.selection import Selection
+    from solo_mise.doctor import run as doctor_run
+    sel = Selection(depth="repo", harnesses=["claude", "codex"], owner="claude", includes=[])
+    install_selection(tmp_path, sel)
+    doctor_run(tmp_path)
+    out = capsys.readouterr().out
+    assert ".codex/memory-handoffs" in out
+
+
+def test_doctor_warns_for_orphan_inbox(tmp_path, capsys):
+    """If config says claude only, but .codex/memory-handoffs exists, warn."""
+    from solo_mise.install import install_selection
+    from solo_mise.selection import Selection
+    from solo_mise.doctor import run as doctor_run
+    sel = Selection(depth="repo", harnesses=["claude"], owner="claude", includes=[])
+    install_selection(tmp_path, sel)
+    (tmp_path / ".codex" / "memory-handoffs").mkdir(parents=True)
+    doctor_run(tmp_path)
+    out = capsys.readouterr().out
+    assert "orphan" in out.lower() or "unselected" in out.lower()
+
+
+def test_doctor_falls_back_to_v0_2_behavior_when_no_config(tmp_path, capsys):
+    """A target without .solo-mise/config.json should still run (legacy targets)."""
+    from solo_mise.doctor import run as doctor_run
+    (tmp_path / "AGENTS.md").write_text("# Agents")
+    rc = doctor_run(tmp_path)
+    # No config = no FAIL on missing config; should still produce output.
+    out = capsys.readouterr().out
+    assert "doctor" in out
+```
+
+- [ ] **Step 2: Run, expect fail (or wrong content)**
+
+- [ ] **Step 3: Update `src/solo_mise/doctor.py` `run`**
+
+Add at top of `run`:
+
+```python
+def run(target: Path, harness: str = "generic") -> int:
+    target = target.expanduser().resolve()
+    print(f"solo-mise doctor: target {target}")
+
+    from .config import load_config
+    try:
+        cfg = load_config(target)
+    except ValueError as exc:
+        print(f"  [fail] config: {exc}")
+        cfg = None
+
+    if cfg is not None:
+        sel = cfg.selection
+        print(f"  harnesses: {', '.join(sel.harnesses) or '(none)'} (owner={sel.owner}, depth={sel.depth})")
+    else:
+        # Legacy fall-through: no config.json present.
+        sel = None
+        print(f"  harnesses: (legacy target, no .solo-mise/config.json; assuming claude)")
+
+    checks: List[CheckResult] = []
+    checks.extend(_check_workspace_files(target))
+    checks.extend(_check_handoff_inboxes(target, sel))
+    checks.extend(_check_memory_care(target))
+    checks.extend(_check_publish_gate(target))
+
+    selected_harnesses = sel.harnesses if sel else ["claude"]
+    if "openclaw" in selected_harnesses:
+        checks.extend(_check_openclaw())
+    if "hermes" in selected_harnesses:
+        checks.extend(_check_hermes(target))
+
+    # Orphan-inbox warnings.
+    checks.extend(_check_orphan_inboxes(target, selected_harnesses))
+
+    return _report(checks)
+```
+
+Replace `_check_handoff_inbox` with a multi-inbox version:
+
+```python
+_WRITER_INBOXES = {
+    "claude": ".claude/memory-handoffs",
+    "codex": ".codex/memory-handoffs",
+}
+
+
+def _check_handoff_inboxes(target: Path, sel) -> List[CheckResult]:
+    results: List[CheckResult] = []
+    writers = sel.harnesses if sel else ["claude"]
+    for h in writers:
+        rel = _WRITER_INBOXES.get(h)
+        if rel is None:
+            continue  # reader harness, no inbox
+        inbox = target / rel
+        if inbox.is_dir():
+            results.append((OK, f"handoff: {h} inbox", str(inbox)))
+        else:
+            results.append((FAIL, f"handoff: {h} inbox", f"missing at {inbox}"))
+        tmpl = inbox / "TEMPLATE.md"
+        if tmpl.is_file():
+            results.append((OK, f"handoff: {h} TEMPLATE.md", str(tmpl)))
+        else:
+            results.append((WARN, f"handoff: {h} TEMPLATE.md", f"missing at {tmpl}"))
+        processed = inbox / "processed"
+        if processed.is_dir():
+            results.append((OK, f"handoff: {h} processed/", str(processed)))
+        else:
+            results.append((WARN, f"handoff: {h} processed/", f"missing at {processed}"))
+    cards = target / "memory" / "cards"
+    if cards.is_dir():
+        results.append((OK, "memory: cards/", str(cards)))
+    else:
+        results.append((WARN, "memory: cards/", f"missing at {cards}"))
+    return results
+
+
+def _check_orphan_inboxes(target: Path, selected_harnesses) -> List[CheckResult]:
+    results: List[CheckResult] = []
+    for h, rel in _WRITER_INBOXES.items():
+        if h in selected_harnesses:
+            continue
+        inbox = target / rel
+        if inbox.is_dir():
+            results.append(
+                (
+                    WARN,
+                    f"orphan: {h} inbox",
+                    f"{inbox} exists but {h} is not in config; remove or add to config",
+                )
+            )
+    return results
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+.venv/bin/python -m pytest tests/test_doctor.py -v
+```
+
+Adjust any existing test_doctor.py tests broken by the new top-line output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/solo_mise/doctor.py tests/test_doctor.py
+git commit -m "feat(doctor): read config.json + per-writer inbox checks + orphan warnings"
+```
+
+---
+
+### Task 14: Ingester scans configured inboxes
+
+**Files:**
+- Modify: `src/solo_mise/ingest.py`
+- Modify: `tests/test_ingest.py`
+
+- [ ] **Step 1: Read current ingester to find the hardcoded inbox path**
+
+```bash
+grep -n "memory-handoffs" src/solo_mise/ingest.py
+```
+
+- [ ] **Step 2: Write failing test**
+
+Append to `tests/test_ingest.py`:
+
+```python
+def test_ingest_scans_multiple_writer_inboxes(tmp_path):
+    from solo_mise.install import install_selection
+    from solo_mise.selection import Selection
+    from solo_mise.ingest import run as ingest_run
+
+    sel = Selection(depth="workspace", harnesses=["claude", "codex"], owner="this-repo", includes=[])
+    install_selection(tmp_path, sel)
+
+    # Drop a handoff in each writer's inbox.
+    (tmp_path / ".claude/memory-handoffs/2026-01-01-claude.md").write_text(
+        "# Memory Handoff\n## Type\nsetup\n## Title\nclaude\n## Summary\nfrom claude\n## Recommended memory action\nno-card\n## Target document\nTOOLS.md\n## Suggested document content\n- claude entry\n"
+    )
+    (tmp_path / ".codex/memory-handoffs/2026-01-01-codex.md").write_text(
+        "# Memory Handoff\n## Type\nsetup\n## Title\ncodex\n## Summary\nfrom codex\n## Recommended memory action\nno-card\n## Target document\nTOOLS.md\n## Suggested document content\n- codex entry\n"
+    )
+
+    rc = ingest_run(target=tmp_path)
+    assert rc == 0
+    tools = (tmp_path / "TOOLS.md").read_text()
+    assert "- claude entry" in tools
+    assert "- codex entry" in tools
+
+
+def test_ingest_alphabetical_inbox_order(tmp_path):
+    """Same dst, two writers: alphabetical-by-harness order wins for determinism."""
+    # Detailed assertion left to the implementer based on ingester semantics.
+    pass
+```
+
+- [ ] **Step 3: Update `ingest.py`**
+
+Replace the single hardcoded inbox path with a config-driven loop:
+
+```python
+from .config import load_config
+
+def _resolve_inbox_paths(target: Path) -> list[Path]:
+    cfg = load_config(target)
+    if cfg is None:
+        # Legacy fallback.
+        return [target / ".claude" / "memory-handoffs"]
+    paths = []
+    for h in sorted(cfg.selection.harnesses):
+        rel = _WRITER_INBOXES.get(h)
+        if rel and (target / rel).is_dir():
+            paths.append(target / rel)
+    return paths
+
+
+_WRITER_INBOXES = {
+    "claude": ".claude/memory-handoffs",
+    "codex": ".codex/memory-handoffs",
+}
+```
+
+Then update the `run()` entry point to iterate `_resolve_inbox_paths(target)` instead of the single hardcoded path. Keep existing routing/promotion logic unchanged.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+.venv/bin/python -m pytest tests/test_ingest.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/solo_mise/ingest.py tests/test_ingest.py
+git commit -m "feat(ingest): scan all configured writer inboxes, not just .claude/"
+```
+
+---
+
+### Task 15: `solo-mise reconfigure` subcommand
+
+**Files:**
+- Create: `src/solo_mise/reconfigure.py`
+- Create: `tests/test_reconfigure.py`
+- Modify: `src/solo_mise/cli.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# tests/test_reconfigure.py
+from solo_mise.install import install_selection
+from solo_mise.selection import Selection
+from solo_mise.reconfigure import reconfigure
+from solo_mise.config import load_config
+
+
+def test_reconfigure_adds_new_harness(tmp_path):
+    sel = Selection(depth="repo", harnesses=["claude"], owner="claude", includes=[])
+    install_selection(tmp_path, sel)
+
+    new_sel = Selection(depth="repo", harnesses=["claude", "codex"], owner="claude", includes=[])
+    rc = reconfigure(tmp_path, new_selection=new_sel, prune=False)
+    assert rc == 0
+    assert (tmp_path / ".codex" / "memory-handoffs" / "TEMPLATE.md").is_file()
+    assert (tmp_path / ".claude" / "memory-handoffs" / "TEMPLATE.md").is_file()
+    cfg = load_config(tmp_path)
+    assert "codex" in cfg.selection.harnesses
+
+
+def test_reconfigure_prune_removes_dropped_harness(tmp_path):
+    sel = Selection(depth="repo", harnesses=["claude", "codex"], owner="claude", includes=[])
+    install_selection(tmp_path, sel)
+    assert (tmp_path / ".codex").is_dir()
+
+    new_sel = Selection(depth="repo", harnesses=["claude"], owner="claude", includes=[])
+    rc = reconfigure(tmp_path, new_selection=new_sel, prune=True)
+    assert rc == 0
+    assert not (tmp_path / ".codex").exists()
+    assert (tmp_path / ".claude").is_dir()
+    cfg = load_config(tmp_path)
+    assert cfg.selection.harnesses == ["claude"]
+
+
+def test_reconfigure_no_prune_leaves_orphan(tmp_path):
+    sel = Selection(depth="repo", harnesses=["claude", "codex"], owner="claude", includes=[])
+    install_selection(tmp_path, sel)
+
+    new_sel = Selection(depth="repo", harnesses=["claude"], owner="claude", includes=[])
+    rc = reconfigure(tmp_path, new_selection=new_sel, prune=False)
+    assert rc == 0
+    # Without --prune, codex inbox dir stays (will be flagged by doctor as orphan).
+    assert (tmp_path / ".codex" / "memory-handoffs").is_dir()
+```
+
+- [ ] **Step 2: Run, expect fail**
+
+- [ ] **Step 3: Implement `src/solo_mise/reconfigure.py`**
+
+```python
+"""solo-mise reconfigure - adjust an existing install to a new Selection."""
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+from .config import Config, load_config, write_config
+from .install import apply_gitignore, install_selection, resolve_manifests
+from .selection import Selection
+
+
+_WRITER_DIRS = {
+    "claude": ".claude",
+    "codex": ".codex",
+}
+_READER_DIRS = {
+    "openclaw": ".solo-mise/openclaw",
+    "hermes": ".solo-mise/hermes",
+}
+_HARNESS_BRIDGE_FILES = {
+    "claude": ["CLAUDE.md"],
+    "codex": [],
+}
+
+
+def reconfigure(target: Path, new_selection: Selection, prune: bool) -> int:
+    target = target.expanduser().resolve()
+    new_selection.validate()
+    existing = load_config(target)
+    old_harnesses = set(existing.selection.harnesses) if existing else set()
+    new_harnesses = set(new_selection.harnesses)
+
+    added = new_harnesses - old_harnesses
+    removed = old_harnesses - new_harnesses
+
+    # Install material for newly-added harnesses + ensure baseline is current.
+    # We re-run install_selection with --force on just the new manifests' files.
+    files, dirs, _ = resolve_manifests(new_selection)
+    # Use install_selection with force=True; it will overwrite the (small)
+    # baseline. Acceptable because re-render is idempotent for unchanged files.
+    rc = install_selection(target, new_selection, force=True)
+    if rc != 0:
+        return rc
+
+    # Prune removed harnesses if requested.
+    if prune:
+        for h in sorted(removed):
+            wdir = _WRITER_DIRS.get(h)
+            if wdir and (target / wdir).is_dir():
+                shutil.rmtree(target / wdir)
+            for bridge in _HARNESS_BRIDGE_FILES.get(h, []):
+                bp = target / bridge
+                if bp.is_file():
+                    bp.unlink()
+            rdir = _READER_DIRS.get(h)
+            if rdir and (target / rdir).is_dir():
+                shutil.rmtree(target / rdir)
+            print(f"solo-mise: pruned {h}")
+
+    print(f"solo-mise: reconfigured -> harnesses={','.join(new_selection.harnesses) or '(none)'}")
+    if added:
+        print(f"  added:   {','.join(sorted(added))}")
+    if removed:
+        verb = "pruned" if prune else "orphaned (use --prune to delete)"
+        print(f"  removed: {','.join(sorted(removed))} ({verb})")
+    return 0
+```
+
+- [ ] **Step 4: Add `reconfigure` subparser to `cli.py`**
+
+In `_build_parser`:
+
+```python
+    p_recon = sub.add_parser("reconfigure", help="Adjust an existing install to a new Selection.")
+    p_recon.add_argument("--target", "-t", type=Path, default=Path("."))
+    p_recon.add_argument("--depth", choices=["repo", "workspace"], default=None)
+    p_recon.add_argument("--harnesses", default=None)
+    p_recon.add_argument("--owner", default=None)
+    p_recon.add_argument("--include", dest="includes", action="append", default=[])
+    p_recon.add_argument("--prune", action="store_true",
+                         help="Remove files for harnesses no longer selected.")
+```
+
+In `main`:
+
+```python
+    if args.command == "reconfigure":
+        from .config import load_config
+        from .reconfigure import reconfigure
+        from .selection import Selection, KNOWN_HARNESSES, resolve_owner
+
+        existing = load_config(args.target)
+        if existing is None:
+            print("error: no .solo-mise/config.json in target. Run `solo-mise init` first.", file=sys.stderr)
+            return 2
+
+        depth = args.depth or existing.selection.depth
+        if args.harnesses is None:
+            harnesses = list(existing.selection.harnesses)
+        elif args.harnesses == "none":
+            harnesses = []
+        else:
+            harnesses = [h.strip() for h in args.harnesses.split(",") if h.strip()]
+        for h in harnesses:
+            if h not in KNOWN_HARNESSES:
+                print(f"error: unknown harness {h!r}", file=sys.stderr)
+                return 2
+        owner = resolve_owner(harnesses, override=args.owner)
+        includes = list(args.includes) if args.includes else list(existing.selection.includes)
+        new_sel = Selection(depth=depth, harnesses=harnesses, owner=owner, includes=includes)
+        return reconfigure(args.target, new_selection=new_sel, prune=args.prune)
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+.venv/bin/python -m pytest tests/test_reconfigure.py -v
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/solo_mise/reconfigure.py src/solo_mise/cli.py tests/test_reconfigure.py
+git commit -m "feat(reconfigure): add subcommand to adjust selection on existing target"
+```
+
+---
+
+## Phase 6: Polish + ship
+
+### Task 16: Docs reframe (README, QUICKSTART, CONTRIBUTING)
+
+**Files:**
+- Modify: `README.md`
+- Modify: `QUICKSTART.md`
+- Modify: `CONTRIBUTING.md`
+
+- [ ] **Step 1: Rewrite README "Install" + "Quick path" + "Profiles" sections**
+
+Replace the existing `## Quick path` block:
+
+````markdown
+## Quick path
+
+Run `solo-mise init` with no flags for the interactive picker:
+
+```bash
+solo-mise init --target ~/agent-kitchen
+```
+
+For CI or scripts, pass flags directly:
+
+```bash
+solo-mise init --target ~/agent-kitchen --depth workspace --harnesses claude,codex,openclaw
+solo-mise init --target ./repo --depth repo --harnesses codex
+solo-mise init --target ./repo --harnesses none           # generic install
+```
+
+## Two axes: depth + harnesses
+
+solo-mise installs material on two independent axes:
+
+**Depth - how much shared baseline you want:**
+
+| Depth | Installs |
+|---|---|
+| `repo` *(default)* | `AGENTS.md`, `SAFETY_RULES.md`, `INSTALL_FOR_AGENTS.md`, `hooks/pre-push`, `.solo-mise/policies/public-repo.json` |
+| `workspace` | repo + `MEMORY.md`, `TOOLS.md`, `USER.md`, `SOUL.md`, `IDENTITY.md`, `HEARTBEAT.md`, `memory/cards/`, starter cards |
+
+**Harnesses - which tools you actually use:**
+
+| Harness | Role | Adds |
+|---|---|---|
+| `claude` | writer | `CLAUDE.md` + `.claude/memory-handoffs/` inbox |
+| `codex` | writer | `.codex/memory-handoffs/` inbox (AGENTS.md is in the baseline) |
+| `openclaw` | reader | `.solo-mise/openclaw/` config fragments + cron stubs |
+| `hermes` | reader | `.solo-mise/hermes/` adapter fragments (experimental) |
+
+**Includes - optional add-ons:**
+
+| Include | Adds |
+|---|---|
+| `publisher` | `.solo-mise/policies/public-content.json` + content-safety memory card + scrub-cache |
+
+## Picking your harnesses
+
+Four common combos:
+
+- **Claude Code only:** `--harnesses claude` - the lightest setup, just one writer.
+- **Claude Code + OpenClaw:** `--harnesses claude,openclaw` - durable memory owner (OpenClaw) + side writer (Claude Code).
+- **Claude Code + Codex + OpenClaw:** `--harnesses claude,codex,openclaw` - both writers feed into OpenClaw as the canonical owner.
+- **Codex + OpenClaw:** `--harnesses codex,openclaw` - Codex-first user with OpenClaw as the canonical store.
+
+The canonical memory owner is picked automatically by priority (`openclaw > hermes > claude > codex > this-repo`). Override with `--owner`.
+````
+
+Drop the old Profiles table and Install banner mentioning the old profiles. Replace the design diagram section:
+
+````markdown
+## The design
+
+One memory owner stays canonical (typically OpenClaw or Hermes when present, otherwise `this-repo`). Writer harnesses drop handoffs into their own inboxes; the ingester scans all of them.
+
+```text
+Claude Code              Codex
+     |                     |
+     v                     v
+.claude/memory-handoffs/ .codex/memory-handoffs/
+     \                   /
+      \                 /
+       v               v
+      solo-mise ingest
+              |
+              v
+  memory/cards/*.md, TOOLS.md, USER.md,
+  rules/*.md, .learnings/*.md
+```
+````
+
+- [ ] **Step 2: Rewrite QUICKSTART.md around the interactive flow**
+
+Open `QUICKSTART.md`, replace the existing init walkthrough with one that starts with `solo-mise init` (no flags), shows the prompt, then shows the resulting layout.
+
+- [ ] **Step 3: Update CONTRIBUTING.md "Adding a profile" → "Adding a harness"**
+
+Replace the "Adding a profile" section with:
+
+```markdown
+## Adding a harness
+
+A harness is a manifest under `src/solo_mise/templates/harnesses/<id>.json` plus any template files it references. The manifest declares `role: "writer"` (gets an inbox) or `role: "reader"` (gets adapter fragments).
+
+To add a harness:
+
+1. Create the manifest at `src/solo_mise/templates/harnesses/<id>.json`.
+2. Add template files under a harness-named directory (e.g. `src/solo_mise/templates/<id>/`).
+3. Add the harness id to `KNOWN_HARNESSES` in `src/solo_mise/selection.py`.
+4. Update `HARNESS_PRIORITY` if the new harness should be an owner candidate (readers usually want to land near OpenClaw/Hermes in the priority list).
+5. If it's a writer, add it to `_WRITER_INBOXES` in `src/solo_mise/install.py`, `src/solo_mise/doctor.py`, and `src/solo_mise/ingest.py`.
+6. Add the harness to the CI matrix in `.github/workflows/ci.yml`.
+7. Add a row to the harness table in `README.md`.
+
+## Adding a depth
+
+Depths live at `src/solo_mise/templates/depth/<id>.json` and may use `extends` to inherit from another depth. Add the id to `KNOWN_DEPTHS` in `selection.py` and to the `--depth` choices in `cli.py`.
+
+## Adding an include
+
+Includes live at `src/solo_mise/templates/includes/<id>.json`. Add the id to `KNOWN_INCLUDES` in `selection.py`.
+```
+
+Drop the "Adding a profile" section (or convert it to a one-paragraph migration note pointing at the new harness/depth model).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md QUICKSTART.md CONTRIBUTING.md
+git commit -m "docs: reframe around two-axis depth + harnesses model"
+```
+
+---
+
+### Task 17: CHANGELOG entry + version bump
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `pyproject.toml`
+- Modify: `src/solo_mise/__init__.py`
+
+- [ ] **Step 1: Bump versions**
+
+In `pyproject.toml`:
+```
+version = "0.3.0"
+```
+
+In `src/solo_mise/__init__.py`:
+```python
+__version__ = "0.3.0"
+```
+
+- [ ] **Step 2: Prepend new section in CHANGELOG.md**
+
+```markdown
+## [0.3.0] - 2026-05-XX
+
+### Added
+- Two-axis selection model: `--depth {repo,workspace}` + `--harnesses {claude,codex,openclaw,hermes}` + `--include publisher`. Pick any combination of harnesses.
+- Interactive prompt on bare `solo-mise init` (no flags). Defaults to claude + repo + no includes.
+- `.solo-mise/config.json` is now the per-target source of truth for selection state. Read by `doctor`, `ingest`, and `reconfigure`.
+- `solo-mise reconfigure --target . [--prune]` adjusts an existing install to a new selection. `--prune` removes orphaned files for deselected harnesses.
+- Per-writer handoff inboxes: `.codex/memory-handoffs/` for Codex (in addition to existing `.claude/memory-handoffs/`).
+- Ingester now scans all configured writer inboxes.
+- Doctor reports apparent harness shape, checks per-writer inbox, warns on orphaned inbox dirs from unselected harnesses.
+
+### Changed
+- README reframed around the two-axis model. New "Picking your harnesses" section walks through four common combos.
+- CONTRIBUTING.md "Adding a profile" replaced by "Adding a harness" + "Adding a depth" + "Adding an include".
+
+### Deprecated
+- `solo-mise init --profile <x>` still works but prints a stderr deprecation note pointing at the new flags. Will be removed in v0.4.0.
+
+### Migration
+
+If you have v0.2.0 scripts using `--profile`:
+
+| v0.2.0 | v0.3.0+ |
+|---|---|
+| `--profile repo` | `--depth repo --harnesses claude` |
+| `--profile workspace` | `--depth workspace --harnesses claude` |
+| `--profile openclaw` | `--depth workspace --harnesses claude,openclaw` |
+| `--profile hermes` | `--depth workspace --harnesses claude,hermes` |
+| `--profile generic` | `--depth workspace --harnesses none` |
+| `--profile publisher` | `--depth repo --harnesses claude --include publisher` |
+```
+
+Replace the date `2026-05-XX` with the actual ship date when tagging.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md pyproject.toml src/solo_mise/__init__.py
+git commit -m "release: prepare v0.3.0"
+```
+
+---
+
+### Task 18: CI matrix update
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Replace `install-from-source` matrix**
+
+```yaml
+  install-from-source:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        combo:
+          - name: "repo+claude"
+            flags: "--depth repo --harnesses claude"
+          - name: "repo+codex"
+            flags: "--depth repo --harnesses codex"
+          - name: "workspace+claude+openclaw"
+            flags: "--depth workspace --harnesses claude,openclaw"
+          - name: "workspace+codex+openclaw"
+            flags: "--depth workspace --harnesses codex,openclaw"
+          - name: "kitchen-sink"
+            flags: "--depth workspace --harnesses claude,codex,openclaw,hermes"
+          - name: "workspace+none"
+            flags: "--depth workspace --harnesses none"
+          - name: "repo+claude+publisher"
+            flags: "--depth repo --harnesses claude --include publisher"
+          - name: "legacy-workspace"
+            flags: "--profile workspace"
+          - name: "legacy-openclaw"
+            flags: "--profile openclaw"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: pipx install
+        run: |
+          python -m pip install --upgrade pip pipx
+          pipx install .
+          solo-mise --version
+      - name: Init + doctor
+        run: |
+          target="/tmp/sm-${{ matrix.combo.name }}"
+          rm -rf "$target"
+          mkdir -p "$target"
+          git init -q -b main "$target"
+          solo-mise init --target "$target" ${{ matrix.combo.flags }}
+          solo-mise doctor --target "$target"
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: matrix replaces single profiles with depth+harnesses combos"
+```
+
+---
+
+### Task 19: Full local verification
+
+- [ ] **Step 1: Run the whole pytest suite**
+
+```bash
+.venv/bin/python -m pytest -q
+```
+
+Expected: all green (including the 50 from v0.2.0 plus the new tests).
+
+- [ ] **Step 2: Run the local 9-combo smoke**
+
+Run the same matrix CI uses, locally:
+
+```bash
+set -e
+for combo in \
+  "repo+claude:--depth repo --harnesses claude" \
+  "repo+codex:--depth repo --harnesses codex" \
+  "ws+claude+openclaw:--depth workspace --harnesses claude,openclaw" \
+  "ws+codex+openclaw:--depth workspace --harnesses codex,openclaw" \
+  "kitchen-sink:--depth workspace --harnesses claude,codex,openclaw,hermes" \
+  "ws+none:--depth workspace --harnesses none" \
+  "repo+claude+publisher:--depth repo --harnesses claude --include publisher" \
+  "legacy-workspace:--profile workspace" \
+  "legacy-openclaw:--profile openclaw"; do
+  name="${combo%%:*}"
+  flags="${combo#*:}"
+  target="/tmp/sm-$name"
+  rm -rf "$target" && mkdir -p "$target" && git init -q -b main "$target"
+  echo "=== $name ==="
+  .venv/bin/python -m solo_mise init --target "$target" $flags 2>&1 | tail -3
+  .venv/bin/python -m solo_mise doctor --target "$target" 2>&1 | tail -3
+done
+```
+
+Expected: every combo reports `summary: ... 0 failed` (manual checks for hermes are OK).
+
+- [ ] **Step 3: Manual prompt smoke (only run interactively, not in CI)**
+
+```bash
+rm -rf /tmp/sm-prompt && mkdir -p /tmp/sm-prompt && git init -q /tmp/sm-prompt
+.venv/bin/python -m solo_mise init --target /tmp/sm-prompt
+# Walk through: pick claude+codex (2), confirm; pick workspace (2); enter for no includes.
+ls /tmp/sm-prompt
+cat /tmp/sm-prompt/.solo-mise/config.json
+```
+
+Expected: config.json reflects the selection; both inboxes exist.
+
+- [ ] **Step 4: Reconfigure smoke**
+
+```bash
+.venv/bin/python -m solo_mise reconfigure --target /tmp/sm-prompt --harnesses claude --prune
+ls /tmp/sm-prompt/.codex 2>&1   # expect: No such file or directory
+cat /tmp/sm-prompt/.solo-mise/config.json   # expect: harnesses: ["claude"]
+```
+
+If any step fails, do not commit Phase 6. Investigate, fix, re-run.
+
+- [ ] **Step 5: Mark this task complete (no commit)**
+
+---
+
+### Task 20: PR + release
+
+- [ ] **Step 1: Push branch + open PR**
+
+```bash
+git push -u origin feat/v0.3.0-harness-selection
+gh pr create --title "feat: v0.3.0 harness selection (two-axis depth+harnesses)" \
+  --body "$(cat docs/specs/2026-05-16-v0.3.0-harness-selection-design.md | head -200)" \
+  --base main
+```
+
+- [ ] **Step 2: Wait for CI**
+
+```bash
+gh pr checks --watch
+```
+
+If any matrix combo fails, fix forward on the branch and push again.
+
+- [ ] **Step 3: Squash merge after CI green**
+
+```bash
+gh pr merge --squash --auto
+```
+
+- [ ] **Step 4: Tag + push tag**
+
+```bash
+git checkout main && git pull --ff-only
+# Update CHANGELOG date placeholder to today's date before tagging.
+git tag -a v0.3.0 -m "solo-mise v0.3.0"
+git push origin v0.3.0
+```
+
+- [ ] **Step 5: Watch publish.yml + verify PyPI**
+
+```bash
+gh run watch --workflow publish.yml
+pipx install --force solo-mise==0.3.0
+solo-mise --version   # expect: solo-mise 0.3.0
+```
+
+- [ ] **Step 6: Create GitHub release**
+
+```bash
+gh release create v0.3.0 --title "v0.3.0" --notes-file <(sed -n '/^## \[0.3.0\]/,/^## \[/p' CHANGELOG.md | sed '$d')
+```
+
+- [ ] **Step 7: Close issue #4**
+
+```bash
+gh issue close 4 -c "Shipped in v0.3.0. See release notes for migration table."
+```
+
+---
+
+## Self-review summary
+
+- **Spec coverage**: every section of the spec maps to one or more tasks (Selection model → 1, config.json → 2, profile shim → 3, manifests → 4/5/6, install engine → 7, gitignore → 8, CLI flags → 9, deprecation → 10, prompt → 11, routing → 12, doctor → 13, ingester → 14, reconfigure → 15, docs → 16, CHANGELOG → 17, CI → 18, smoke → 19, ship → 20).
+- **Placeholder scan**: clean; the only `XX` is the CHANGELOG ship date which is intentionally deferred until tagging.
+- **Type consistency**: `Selection` fields used identically across tasks; `_WRITER_INBOXES` map duplicated in install.py / doctor.py / ingest.py with the same content (acceptable - small, immutable, no risk of drift if PRs land together; could be extracted later).
+- **Open implementation questions from spec**: TUI library (settled: zero-dep hand-roll); CODEX.md (settled: no, leave room for v0.4.0); `includes` vs `add-ons` naming (settled: `includes` consistently used in flag and config).

--- a/docs/specs/2026-05-16-v0.3.0-harness-selection-design.md
+++ b/docs/specs/2026-05-16-v0.3.0-harness-selection-design.md
@@ -1,0 +1,283 @@
+# v0.3.0: Harness-aware handoff inboxes and Codex-first profile
+
+Design spec for solo-mise v0.3.0.
+
+- **Status**: approved (2026-05-16)
+- **Tracking issue**: [#4](https://github.com/solomonneas/solo-mise/issues/4)
+- **Supersedes**: the rough sketch in issue #4 body
+- **Implementation branch**: `feat/v0.3.0-harness-selection`
+
+## Why
+
+v0.2.0 assumes Claude Code is the writer of handoffs: the inbox path is hardcoded at `.claude/memory-handoffs/`, the default profile installs `CLAUDE.md` as the bridge file, and the README treats Claude Code as the primary harness. Codex-only users today get a worse experience - they have to drop handoffs in a directory named after a tool they do not use, and they ship a `CLAUDE.md` they do not need.
+
+Real user feedback: "more and more people are using codex only". The profile model also conflates two orthogonal axes (how much gets installed vs which harnesses are active), which makes it hard to express common combos like "Claude Code + Codex + OpenClaw together".
+
+## Goals
+
+- Let users pick any combination of `claude`, `codex`, `openclaw`, `hermes` at install time.
+- Each writer harness gets its own handoff inbox (`.claude/memory-handoffs/`, `.codex/memory-handoffs/`); the ingester scans all of them.
+- Reader harnesses (OpenClaw, Hermes) contribute adapter fragments and doctor checks without owning an inbox.
+- AGENTS.md is the primary, harness-neutral bootstrap file; CLAUDE.md and equivalents are bridges installed only when their harness is selected.
+- Existing `--profile <x>` invocations keep working in v0.3.0 with a deprecation notice, removed in v0.4.0.
+
+## Non-goals
+
+- Cross-harness handoff format translation. The TEMPLATE.md is already harness-agnostic; a handoff written by Codex is shape-identical to one written by Claude Code.
+- Per-harness model-lane config (lives in OpenClaw / Hermes themselves).
+- A `--with X --with Y` fully composable module system (the depth concept earns its keep).
+
+## CLI surface
+
+### Interactive (default when no selection flags are passed)
+
+```
+$ solo-mise init --target ./my-repo
+
+Which harnesses do you use? (space to toggle, enter to confirm)
+  [x] Claude Code
+  [ ] Codex
+  [ ] OpenClaw
+  [ ] Hermes
+
+Depth?
+  ( ) repo       (handoff flow + publish guard)
+  (x) workspace  (full home: MEMORY.md, TOOLS.md, USER.md, ...)
+
+Add-ons?
+  [ ] publisher  (content-guard policies for blog/social/docs)
+```
+
+Defaults: `harnesses=[claude]`, `depth=repo`, `includes=[]`. Enter ships the install. Ctrl-C aborts.
+
+### Non-interactive (CI, scripts, automation)
+
+```bash
+solo-mise init --target ./repo --depth workspace --harnesses claude,codex,openclaw
+solo-mise init --target ./repo --harnesses codex --include publisher
+solo-mise init --target ./repo --harnesses none           # legacy 'generic' equivalent
+solo-mise init --target ./repo --profile workspace        # legacy alias; prints deprecation
+```
+
+Rule: if any of `--depth`, `--harnesses`, `--include`, or `--profile` is passed, the interactive prompt is skipped. Otherwise the prompt fires.
+
+`--owner <name>` overrides the implicit memory-owner priority. Only legal values are harnesses present in `--harnesses`, plus `this-repo`.
+
+### `solo-mise reconfigure`
+
+```bash
+solo-mise reconfigure --target .              # re-runs interactive prompt against existing target
+solo-mise reconfigure --target . --prune      # also removes files for harnesses no longer selected
+```
+
+Without `--prune`, `reconfigure` is purely additive (adds files for newly-selected harnesses, updates the managed gitignore block, leaves orphaned files alone). With `--prune`, it removes the inbox + bridge file + adapter fragments for harnesses that were deselected.
+
+## Per-harness contract
+
+Each harness selection adds material on top of the depth baseline. Selecting a harness does not change the baseline; it adds the harness-specific delta.
+
+| Harness | Bridge file | Inbox | Adapter fragments | Role |
+|---|---|---|---|---|
+| `claude` | `CLAUDE.md` | `.claude/memory-handoffs/{TEMPLATE.md, processed/}` | none | writer |
+| `codex` | (none today) | `.codex/memory-handoffs/{TEMPLATE.md, processed/}` | none | writer |
+| `openclaw` | (none) | (none) | `.solo-mise/openclaw/*.json` + cron-job stubs | reader |
+| `hermes` | (none) | (none) | `.solo-mise/hermes/*.json` | reader |
+
+**Baseline (always installed, regardless of harness selection):**
+
+- `AGENTS.md` (harness-neutral; every modern harness reads it)
+- `SAFETY_RULES.md`, `INSTALL_FOR_AGENTS.md`
+- For `--depth repo`: also `hooks/pre-push`, `.solo-mise/policies/public-repo.json`
+- For `--depth workspace`: also `MEMORY.md`, `TOOLS.md`, `USER.md`, `SOUL.md`, `IDENTITY.md`, `HEARTBEAT.md`, `memory/cards/`, starter cards
+
+### Roles split (key conceptual change)
+
+- **Writers** (`claude`, `codex`) contribute an inbox they drop handoffs into.
+- **Readers** (`openclaw`, `hermes`) contribute adapter fragments + doctor checks; the harness ingests handoffs from every writer inbox.
+
+A user can pick any combination of writers and readers. Picking zero writers and zero readers (`--harnesses none`) gives a generic install with no harness-specific material; handoffs go nowhere automatically, the user wires up ingestion.
+
+### Memory owner
+
+Implicit priority order: `openclaw > hermes > claude > codex > this-repo`. The first harness in the priority list that appears in `--harnesses` becomes the owner.
+
+The owner determines:
+- The `{{memory_owner_name}}` placeholder rendered into bootstrap files
+- Which adapter's `memory/cards/` location is treated as the canonical store
+- The label shown in `solo-mise doctor`
+
+Override: `--owner openclaw|hermes|this-repo|claude|codex`. Must be a harness selected in `--harnesses` or `this-repo`.
+
+## Handoff inbox model
+
+Each writer harness gets its own inbox under its harness-namespaced directory. The inbox layout is identical:
+
+```
+<harness-dir>/memory-handoffs/
+├── TEMPLATE.md       # tracked in git
+├── processed/        # tracked dir; files inside are gitignored
+└── *.md              # gitignored; harness drops handoffs here
+```
+
+`TEMPLATE.md` content is shared across inboxes - the handoff contract is the same regardless of writer. The file is copied into each inbox (not symlinked) because users edit it locally.
+
+Managed `.gitignore` block expands to cover all configured inboxes:
+
+```gitignore
+# >>> solo-mise gitignore block >>>
+.claude/memory-handoffs/*
+!.claude/memory-handoffs/TEMPLATE.md
+.codex/memory-handoffs/*
+!.codex/memory-handoffs/TEMPLATE.md
+# (sections for hermes/etc. added when those harnesses are selected)
+memory/20[0-9][0-9]-[0-1][0-9]-[0-3][0-9].md
+memory/handoff-inbox/
+.solo-mise/logs/
+.solo-mise/scrub-cache/
+# <<< solo-mise gitignore block <<<
+```
+
+Block is fully regenerated on each `init` / `reconfigure` from `.solo-mise/config.json`.
+
+## Configuration file: `.solo-mise/config.json`
+
+New file written by `init`, read by `doctor` and `reconfigure`. Single source of truth.
+
+```json
+{
+  "version": 1,
+  "depth": "workspace",
+  "harnesses": ["claude", "codex", "openclaw"],
+  "owner": "openclaw",
+  "includes": ["publisher"]
+}
+```
+
+Schema:
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `version` | int | yes | Schema version, starts at `1` |
+| `depth` | enum | yes | `"repo"` \| `"workspace"` |
+| `harnesses` | array | yes | Subset of `["claude", "codex", "openclaw", "hermes"]`; may be empty |
+| `owner` | string | yes | Resolved owner (writes priority-default if not overridden) |
+| `includes` | array | yes | Currently only `["publisher"]` is defined; may be empty |
+
+Manually-edited config is supported. Re-running `init` against a target with an existing config picks up the file as defaults for the interactive prompt; passing flags overrides the file values.
+
+## Doctor changes
+
+`solo-mise doctor` reads `.solo-mise/config.json` to know what to expect.
+
+New behaviors:
+
+- Reports `apparent harness shape` at the top: `harnesses: claude, codex, openclaw (owner=openclaw)`.
+- Inbox checks fire for every selected writer harness (today only `.claude/memory-handoffs/` is checked).
+- Existing openclaw / hermes adapter checks fire only when those harnesses are in the config.
+- Warns when files are present for an unselected harness (e.g. `.codex/memory-handoffs/` exists but config says `["claude"]` only - probably a misconfigured re-init or a stale leftover).
+- Falls back to the v0.2.0 behavior if `.solo-mise/config.json` is missing: assume `["claude"]`, harness from `--harness` flag.
+
+The `--harness` flag on `doctor` stays for backward compat but is overridden by the config file when both are present.
+
+## Ingester changes
+
+- Scans every inbox listed in `.solo-mise/config.json` instead of hardcoded `.claude/memory-handoffs/`.
+- Promotion target is determined by the owner adapter (OpenClaw's `memory/cards/`, Hermes's equivalent, or `memory/cards/` in the target itself when owner is `this-repo`).
+- A handoff in `.codex/memory-handoffs/` is processed identically to one in `.claude/memory-handoffs/` - the TEMPLATE is shared, the routing rules are shared.
+- Order of inbox processing is deterministic (alphabetical by harness name) so concurrent writes from multiple harnesses produce stable results.
+
+## Profile migration shim
+
+Legacy `--profile <x>` continues to work in v0.3.0 with a stderr deprecation note pointing at the equivalent flags.
+
+| Legacy profile | Translates to |
+|---|---|
+| `repo` | `--depth repo --harnesses claude` |
+| `workspace` | `--depth workspace --harnesses claude` |
+| `openclaw` | `--depth workspace --harnesses claude,openclaw` |
+| `hermes` | `--depth workspace --harnesses claude,hermes` |
+| `generic` | `--depth workspace --harnesses none` |
+| `publisher` | `--depth repo --harnesses claude --include publisher` |
+
+Implementation: a `profile_to_selection(profile_id)` helper in `src/solo_mise/init.py` translates the legacy id into a `(depth, harnesses, owner, includes)` tuple before the install logic runs. The legacy profile manifests can stay on disk until v0.4.0 but they are not the source of truth in v0.3.0.
+
+Deprecation timeline:
+
+- **v0.3.0**: `--profile` works, prints stderr deprecation note with the new equivalent on every use.
+- **v0.4.0**: `--profile` removed. Manifest files for `repo`, `workspace`, etc. deleted from `src/solo_mise/templates/profiles/`.
+
+## README and docs reframe
+
+- README opens with "works with Claude Code, Codex, OpenClaw, Hermes" instead of "Claude Code is the writer of handoffs".
+- Profile table replaced by two tables: a depth table (`repo` vs `workspace`) and a harness table (what each harness contributes).
+- Design diagram updated to show multiple inboxes feeding the ingester.
+- New "Picking your harnesses" section walks through four representative combos:
+  - `claude` alone
+  - `claude + openclaw`
+  - `claude + codex + openclaw` (the case Solomon flagged)
+  - `codex + openclaw` (Codex-first user)
+- AGENTS.md framed as primary; CLAUDE.md and equivalents as bridges.
+- QUICKSTART.md rewritten around the interactive flow.
+- CONTRIBUTING.md "Adding a profile" section becomes "Adding a harness".
+
+## Test plan
+
+### Unit tests
+
+- `config.json` round-trip (load, modify, save, reload).
+- `profile_to_selection` translation for all six legacy profile ids.
+- Owner-priority resolution (every subset of harnesses produces the expected owner).
+- Managed gitignore block generation includes a section for every configured writer inbox.
+- Ingester scans multiple inboxes in deterministic order.
+- Doctor reads config and skips checks for unselected harnesses.
+
+### CI matrix
+
+Replaces today's `install-from-source` job. Cross-product is too large to run in full, so the matrix covers representative combos:
+
+| Combo | Why |
+|---|---|
+| `repo + claude` | today's default; regression guard |
+| `repo + codex` | Codex-first, repo depth |
+| `workspace + claude + openclaw` | today's `openclaw` profile shape |
+| `workspace + codex + openclaw` | Codex + OpenClaw, the gap that drove this |
+| `workspace + claude + codex + openclaw + hermes` | kitchen sink |
+| `workspace + (none)` | today's `generic` |
+| `repo + claude + publisher (include)` | today's `publisher` profile shape |
+| `legacy: --profile workspace` | confirms deprecation shim works |
+| `legacy: --profile openclaw` | confirms deprecation shim works |
+
+### Interactive prompt
+
+- Headless test stub that drives the prompt programmatically (no real TTY needed) verifies selection + confirm + writeout.
+- Manual smoke test in a real terminal before merge.
+
+### Reconfigure
+
+- Add a harness to existing target → new files appear, gitignore block updated, no other files touched.
+- `--prune` removes a harness → inbox dir gone, bridge file gone, adapter fragments gone, gitignore block updated.
+- Reconfigure with identical config → no-op (exit 0, nothing changed).
+
+## Open questions for implementation
+
+These were deferred from the brainstorm and should be decided during implementation:
+
+1. **Which TUI library?** `prompt_toolkit` is the obvious pick but adds a runtime dependency to a kit that currently has zero. Alternatives: a minimal hand-rolled prompt using `termios` (no deps, more code), or `questionary` (smaller than prompt_toolkit). Recommendation in the impl plan: stick with zero deps and hand-roll. Fallback to plain `input()` when stdout is not a TTY.
+
+2. **Does selecting `codex` install a `CODEX.md` bridge file?** Today Codex does not read one. If `codex-cli` ever adds repo-local config conventions, this changes. Recommendation: ship no `CODEX.md` in v0.3.0, leave room for one in v0.4.0 if Codex grows the convention.
+
+3. **`includes` vs `add-ons` naming.** The CLI uses `--include publisher`. The config field is `includes`. Either is fine; the impl plan should pick one and use it consistently.
+
+## Acceptance
+
+v0.3.0 ships when:
+
+- [ ] `solo-mise init` with no flags drops into the interactive prompt.
+- [ ] `solo-mise init --harnesses claude,codex,openclaw --depth workspace` installs the union of harness materials, writes `.solo-mise/config.json`, and updates the managed gitignore block to cover all writer inboxes.
+- [ ] `solo-mise reconfigure --target . --prune` adjusts an existing install to a new harness set.
+- [ ] `solo-mise doctor` reads `.solo-mise/config.json` and reports the apparent harness shape.
+- [ ] The ingester scans every configured writer inbox.
+- [ ] All legacy `--profile <x>` invocations still work and print a deprecation note.
+- [ ] CI matrix covers the representative combos listed above plus the two legacy profile smokes.
+- [ ] README, QUICKSTART, CONTRIBUTING reframed around the two-axis model.
+- [ ] CHANGELOG entry for v0.3.0 covers the breaking-warning (deprecation), the new flags, and the migration table.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "solo-mise"
-version = "0.2.0"
+version = "0.3.0"
 description = "Mise en place for agent memory. Installable starter kit for a harness-agnostic agent workspace."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/solo_mise/__init__.py
+++ b/src/solo_mise/__init__.py
@@ -1,3 +1,3 @@
 """Solomon's Mise en Place: installable starter kit for an agent kitchen."""
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/src/solo_mise/cli.py
+++ b/src/solo_mise/cli.py
@@ -127,6 +127,16 @@ def _build_parser() -> argparse.ArgumentParser:
     p_hf = sub.add_parser("hermes-fragments", help="Write Hermes adapter fragments (experimental).")
     p_hf.add_argument("--out", "-o", type=Path, required=True, help="Output directory.")
 
+    # reconfigure
+    p_recon = sub.add_parser("reconfigure", help="Adjust an existing install to a new Selection.")
+    p_recon.add_argument("--target", "-t", type=Path, default=Path("."))
+    p_recon.add_argument("--depth", choices=["repo", "workspace"], default=None)
+    p_recon.add_argument("--harnesses", default=None)
+    p_recon.add_argument("--owner", default=None)
+    p_recon.add_argument("--include", dest="includes", action="append", default=[])
+    p_recon.add_argument("--prune", action="store_true",
+                         help="Remove files for harnesses no longer selected.")
+
     return parser
 
 
@@ -233,6 +243,31 @@ def main(argv=None) -> int:
         from . import fragments as frag_mod
 
         return frag_mod.write_fragments(args.out, harness="hermes")
+    if cmd == "reconfigure":
+        from .config import load_config
+        from .reconfigure import reconfigure as _reconfigure
+        from .selection import Selection, KNOWN_HARNESSES, resolve_owner
+
+        existing = load_config(args.target)
+        if existing is None:
+            print("error: no .solo-mise/config.json in target. Run `solo-mise init` first.", file=sys.stderr)
+            return 2
+
+        depth = args.depth or existing.selection.depth
+        if args.harnesses is None:
+            harnesses = list(existing.selection.harnesses)
+        elif args.harnesses == "none":
+            harnesses = []
+        else:
+            harnesses = [h.strip() for h in args.harnesses.split(",") if h.strip()]
+        for h in harnesses:
+            if h not in KNOWN_HARNESSES:
+                print(f"error: unknown harness {h!r}", file=sys.stderr)
+                return 2
+        owner = resolve_owner(harnesses, override=args.owner)
+        includes = list(args.includes) if args.includes else list(existing.selection.includes)
+        new_sel = Selection(depth=depth, harnesses=harnesses, owner=owner, includes=includes)
+        return _reconfigure(args.target, new_selection=new_sel, prune=args.prune)
 
     parser.error(f"unknown command: {cmd}")
     return 2

--- a/src/solo_mise/cli.py
+++ b/src/solo_mise/cli.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 
 from . import __version__
+from .prompt import prompt_for_selection  # imported here so tests can monkeypatch cli.prompt_for_selection
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -188,11 +189,14 @@ def main(argv=None) -> int:
                 allow_home=getattr(args, "allow_home", False),
             )
 
-        # No flags and no --profile: default to repo+claude for now.
-        # Task 12 wires the interactive prompt here.
-        from .selection import Selection
+        # No flags and no --profile: interactive prompt.
+        from .prompt import NonInteractiveError
         from .install import install_selection
-        sel = Selection(depth="repo", harnesses=["claude"], owner="claude", includes=[])
+        try:
+            sel = prompt_for_selection()
+        except NonInteractiveError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
         return install_selection(
             target=args.target,
             selection=sel,

--- a/src/solo_mise/cli.py
+++ b/src/solo_mise/cli.py
@@ -48,6 +48,31 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Do not create or update the target's .gitignore.",
     )
     p_init.add_argument("--dry-run", action="store_true", help="Show what would happen.")
+    p_init.add_argument(
+        "--depth",
+        choices=["repo", "workspace"],
+        default=None,
+        help="Install depth: 'repo' (minimal) or 'workspace' (full home). "
+             "Required unless --profile is used.",
+    )
+    p_init.add_argument(
+        "--harnesses",
+        default=None,
+        help="Comma-separated harness ids: claude, codex, openclaw, hermes. "
+             "Pass 'none' for a generic install with no harness-specific files.",
+    )
+    p_init.add_argument(
+        "--owner",
+        default=None,
+        help="Override the canonical memory owner. Must be 'this-repo' or one of --harnesses.",
+    )
+    p_init.add_argument(
+        "--include",
+        dest="includes",
+        action="append",
+        default=[],
+        help="Optional add-on (currently: 'publisher'). May be repeated.",
+    )
 
     # doctor
     p_doctor = sub.add_parser("doctor", help="Verify a target workspace.")
@@ -110,6 +135,36 @@ def main(argv=None) -> int:
     cmd = args.command
 
     if cmd == "init":
+        # New v0.3.0 path: --depth/--harnesses build a Selection directly.
+        if getattr(args, "depth", None) is not None or getattr(args, "harnesses", None) is not None:
+            from .selection import Selection, KNOWN_HARNESSES, resolve_owner
+            from .install import install_selection
+
+            depth = args.depth or "repo"
+            if args.harnesses is None or args.harnesses == "":
+                harnesses = ["claude"]
+            elif args.harnesses == "none":
+                harnesses = []
+            else:
+                harnesses = [h.strip() for h in args.harnesses.split(",") if h.strip()]
+            for h in harnesses:
+                if h not in KNOWN_HARNESSES:
+                    print(f"error: unknown harness {h!r} (valid: {KNOWN_HARNESSES})", file=sys.stderr)
+                    return 2
+            try:
+                owner = resolve_owner(harnesses, override=args.owner)
+            except ValueError as exc:
+                print(f"error: {exc}", file=sys.stderr)
+                return 2
+            sel = Selection(depth=depth, harnesses=harnesses, owner=owner, includes=list(args.includes))
+            return install_selection(
+                target=args.target,
+                selection=sel,
+                force=getattr(args, "force", False),
+                dry_run=getattr(args, "dry_run", False),
+                allow_home=getattr(args, "allow_home", False),
+            )
+
         from . import init as init_mod
 
         return init_mod.run(

--- a/src/solo_mise/cli.py
+++ b/src/solo_mise/cli.py
@@ -25,9 +25,9 @@ def _build_parser() -> argparse.ArgumentParser:
     p_init.add_argument(
         "--profile",
         "-p",
-        default="repo",
+        default=None,
         choices=["repo", "workspace", "openclaw", "hermes", "generic", "publisher"],
-        help="Profile to install (default: repo).",
+        help="(Deprecated) Profile to install. Use --depth/--harnesses instead.",
     )
     p_init.add_argument(
         "--harness",
@@ -165,16 +165,40 @@ def main(argv=None) -> int:
                 allow_home=getattr(args, "allow_home", False),
             )
 
-        from . import init as init_mod
+        # Legacy --profile path: translate to a Selection, warn, install.
+        if args.profile:
+            from .selection import profile_to_selection
+            from .install import install_selection
+            sel = profile_to_selection(args.profile)
+            equivalent = f"--depth {sel.depth} --harnesses {','.join(sel.harnesses) or 'none'}"
+            if sel.owner != "this-repo" and sel.owner in sel.harnesses:
+                equivalent += f" --owner {sel.owner}"
+            for inc in sel.includes:
+                equivalent += f" --include {inc}"
+            print(
+                f"warning: --profile is deprecated. The v0.3.0+ equivalent is "
+                f"`{equivalent}`. --profile will be removed in v0.4.0.",
+                file=sys.stderr,
+            )
+            return install_selection(
+                target=args.target,
+                selection=sel,
+                force=getattr(args, "force", False),
+                dry_run=getattr(args, "dry_run", False),
+                allow_home=getattr(args, "allow_home", False),
+            )
 
-        return init_mod.run(
+        # No flags and no --profile: default to repo+claude for now.
+        # Task 12 wires the interactive prompt here.
+        from .selection import Selection
+        from .install import install_selection
+        sel = Selection(depth="repo", harnesses=["claude"], owner="claude", includes=[])
+        return install_selection(
             target=args.target,
-            profile_id=args.profile,
-            force=args.force,
-            dry_run=args.dry_run,
-            harness=args.harness,
-            allow_home=args.allow_home,
-            update_gitignore=args.update_gitignore,
+            selection=sel,
+            force=getattr(args, "force", False),
+            dry_run=getattr(args, "dry_run", False),
+            allow_home=getattr(args, "allow_home", False),
         )
     if cmd == "doctor":
         from . import doctor as doctor_mod

--- a/src/solo_mise/config.py
+++ b/src/solo_mise/config.py
@@ -1,0 +1,57 @@
+"""Read/write .solo-mise/config.json - the per-target source of truth."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from .selection import Selection
+
+
+CONFIG_REL_PATH = ".solo-mise/config.json"
+SUPPORTED_VERSIONS = (1,)
+
+
+@dataclass
+class Config:
+    version: int
+    selection: Selection
+
+
+def config_path(target: Path) -> Path:
+    return target / CONFIG_REL_PATH
+
+
+def write_config(target: Path, cfg: Config) -> None:
+    cfg.selection.validate()
+    path = config_path(target)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "version": cfg.version,
+        "depth": cfg.selection.depth,
+        "harnesses": list(cfg.selection.harnesses),
+        "owner": cfg.selection.owner,
+        "includes": list(cfg.selection.includes),
+    }
+    path.write_text(json.dumps(payload, indent=2) + "\n")
+
+
+def load_config(target: Path) -> Optional[Config]:
+    path = config_path(target)
+    if not path.is_file():
+        return None
+    data = json.loads(path.read_text())
+    version = data.get("version")
+    if version not in SUPPORTED_VERSIONS:
+        raise ValueError(
+            f"unsupported config version: {version!r} (supported: {SUPPORTED_VERSIONS})"
+        )
+    sel = Selection(
+        depth=data.get("depth", ""),
+        harnesses=list(data.get("harnesses", [])),
+        owner=data.get("owner", "this-repo"),
+        includes=list(data.get("includes", [])),
+    )
+    sel.validate()
+    return Config(version=version, selection=sel)

--- a/src/solo_mise/doctor.py
+++ b/src/solo_mise/doctor.py
@@ -18,18 +18,52 @@ MANUAL = "MANUAL"
 
 def run(target: Path, harness: str = "generic") -> int:
     target = target.expanduser().resolve()
-    print(f"solo-mise doctor: target {target} ({harness})")
-    checks: List[CheckResult] = []
+    print(f"solo-mise doctor: target {target}")
 
+    from .config import load_config
+
+    cfg = None
+    try:
+        cfg = load_config(target)
+    except (ValueError, json.JSONDecodeError) as exc:
+        print(f"  [fail] config: {exc}")
+
+    if cfg is not None:
+        sel = cfg.selection
+        print(
+            f"  harnesses: {', '.join(sel.harnesses) or '(none)'} "
+            f"(owner={sel.owner}, depth={sel.depth})"
+        )
+        selected_harnesses = list(sel.harnesses)
+    else:
+        # Legacy fall-through: no config.json present.
+        sel = None
+        if harness in ("openclaw", "hermes"):
+            print(
+                f"  harnesses: (legacy target, no .solo-mise/config.json; "
+                f"--harness={harness} so assuming claude + {harness})"
+            )
+            selected_harnesses = ["claude", harness]
+        else:
+            print(
+                "  harnesses: (legacy target, no .solo-mise/config.json; "
+                "assuming claude)"
+            )
+            selected_harnesses = ["claude"]
+
+    checks: List[CheckResult] = []
     checks.extend(_check_workspace_files(target))
-    checks.extend(_check_handoff_inbox(target))
+    checks.extend(_check_handoff_inboxes(target, sel, selected_harnesses))
     checks.extend(_check_memory_care(target))
     checks.extend(_check_publish_gate(target))
 
-    if harness == "openclaw":
+    if "openclaw" in selected_harnesses:
         checks.extend(_check_openclaw())
-    elif harness == "hermes":
+    if "hermes" in selected_harnesses:
         checks.extend(_check_hermes(target))
+
+    # Orphan-inbox warnings.
+    checks.extend(_check_orphan_inboxes(target, selected_harnesses))
 
     return _report(checks)
 
@@ -60,34 +94,72 @@ def _check_workspace_files(target: Path) -> List[CheckResult]:
     return results
 
 
-def _check_handoff_inbox(target: Path) -> List[CheckResult]:
+# Writer harness -> inbox-dir prefix. Only writer harnesses have an inbox.
+_WRITER_INBOXES = {
+    "claude": ".claude/memory-handoffs",
+    "codex": ".codex/memory-handoffs",
+}
+
+
+def _check_handoff_inboxes(
+    target: Path, sel, selected_harnesses: List[str]
+) -> List[CheckResult]:
     results: List[CheckResult] = []
-    inbox = target / ".claude" / "memory-handoffs"
-    template = inbox / "TEMPLATE.md"
-    processed = inbox / "processed"
-
-    if inbox.is_dir():
-        results.append((OK, "handoff: inbox", str(inbox)))
-    else:
-        results.append((FAIL, "handoff: inbox", f"missing at {inbox}"))
-
-    if template.is_file():
-        results.append((OK, "handoff: TEMPLATE.md", str(template)))
-    else:
-        results.append((WARN, "handoff: TEMPLATE.md", f"missing at {template}"))
-
-    if processed.is_dir():
-        results.append((OK, "handoff: processed/", str(processed)))
-    else:
-        results.append((WARN, "handoff: processed/", f"missing at {processed}"))
-
+    writers = selected_harnesses
+    for h in writers:
+        rel = _WRITER_INBOXES.get(h)
+        if rel is None:
+            continue  # reader harness, no inbox
+        inbox = target / rel
+        if inbox.is_dir():
+            results.append((OK, f"handoff: {h} inbox", str(inbox)))
+        else:
+            results.append((FAIL, f"handoff: {h} inbox", f"missing at {inbox}"))
+        tmpl = inbox / "TEMPLATE.md"
+        if tmpl.is_file():
+            results.append((OK, f"handoff: {h} TEMPLATE.md", str(tmpl)))
+        else:
+            results.append(
+                (WARN, f"handoff: {h} TEMPLATE.md", f"missing at {tmpl}")
+            )
+        processed = inbox / "processed"
+        if processed.is_dir():
+            results.append((OK, f"handoff: {h} processed/", str(processed)))
+        else:
+            results.append(
+                (WARN, f"handoff: {h} processed/", f"missing at {processed}")
+            )
     cards = target / "memory" / "cards"
     if cards.is_dir():
         results.append((OK, "memory: cards/", str(cards)))
     else:
         results.append(
-            (WARN, "memory: cards/", f"missing at {cards}; ingester cannot promote cards")
+            (
+                WARN,
+                "memory: cards/",
+                f"missing at {cards}; ingester cannot promote cards",
+            )
         )
+    return results
+
+
+def _check_orphan_inboxes(
+    target: Path, selected_harnesses: List[str]
+) -> List[CheckResult]:
+    results: List[CheckResult] = []
+    for h, rel in _WRITER_INBOXES.items():
+        if h in selected_harnesses:
+            continue
+        inbox = target / rel
+        if inbox.is_dir():
+            results.append(
+                (
+                    WARN,
+                    f"orphan: {h} inbox",
+                    f"{inbox} exists but {h} is not in config; "
+                    f"remove or add to config (unselected harness)",
+                )
+            )
     return results
 
 

--- a/src/solo_mise/ingest.py
+++ b/src/solo_mise/ingest.py
@@ -27,6 +27,12 @@ SAFE_SPECIAL_TARGETS = {
     ".learnings/FEATURE_REQUESTS.md",
 }
 
+# Writer harness id -> inbox dir (mirror of install._WRITER_INBOX).
+_WRITER_INBOXES = {
+    "claude": ".claude/memory-handoffs",
+    "codex": ".codex/memory-handoffs",
+}
+
 # Recognized handoff sections. Any section name outside this set is a signal
 # that the parser split content at an internal `##` heading; route to inbox.
 KNOWN_SECTIONS = {
@@ -53,6 +59,27 @@ class IngestStats:
     actions: List[str] = field(default_factory=list)
 
 
+def _resolve_inbox_paths(target: Path) -> list[Path]:
+    """Return handoff inbox directories for `target` in deterministic order.
+
+    Reads `.solo-mise/config.json` when present and returns one inbox per
+    writer harness in the selection (alphabetical by harness id). Falls back
+    to the legacy `.claude/memory-handoffs/` path for pre-v0.3.0 installs.
+    """
+    from .config import load_config
+
+    cfg = load_config(target)
+    if cfg is None:
+        legacy = target / ".claude" / "memory-handoffs"
+        return [legacy] if legacy.is_dir() else []
+    paths: list[Path] = []
+    for h in sorted(cfg.selection.harnesses):
+        rel = _WRITER_INBOXES.get(h)
+        if rel and (target / rel).is_dir():
+            paths.append(target / rel)
+    return paths
+
+
 def run(
     target: Path,
     dry_run: bool = False,
@@ -66,44 +93,45 @@ def run(
     Match the cookbook wrapper by passing both flags explicitly.
     """
     target = target.expanduser().resolve()
-    handoffs_dir = target / ".claude" / "memory-handoffs"
-    processed_dir = handoffs_dir / "processed"
     inbox_dir = target / "memory" / "handoff-inbox"
 
-    if not handoffs_dir.is_dir():
-        print(f"solo-mise ingest: no handoff inbox at {handoffs_dir}", file=sys.stderr)
+    handoff_dirs = _resolve_inbox_paths(target)
+    if not handoff_dirs:
+        legacy = target / ".claude" / "memory-handoffs"
+        print(f"solo-mise ingest: no handoff inbox at {legacy}", file=sys.stderr)
         return 2
 
     stats = IngestStats()
 
-    handoffs = _list_handoffs(handoffs_dir)
-    for path in handoffs:
-        stats.processed += 1
-        sections = parse(path)
-        outcome = decide(
-            sections,
-            target=target,
-            promote_cards=promote_cards,
-            route_documents=route_documents,
-        )
-        action = _execute(
-            outcome,
-            handoff_path=path,
-            target=target,
-            sections=sections,
-            inbox_dir=inbox_dir,
-            processed_dir=processed_dir,
-            dry_run=dry_run,
-        )
-        stats.actions.append(action.summary)
-        if action.kind == "promoted":
-            stats.promoted += 1
-        elif action.kind == "routed":
-            stats.routed += 1
-        elif action.kind == "inboxed":
-            stats.inboxed += 1
-        elif action.kind == "skipped":
-            stats.skipped += 1
+    for handoffs_dir in handoff_dirs:
+        processed_dir = handoffs_dir / "processed"
+        for path in _list_handoffs(handoffs_dir):
+            stats.processed += 1
+            sections = parse(path)
+            outcome = decide(
+                sections,
+                target=target,
+                promote_cards=promote_cards,
+                route_documents=route_documents,
+            )
+            action = _execute(
+                outcome,
+                handoff_path=path,
+                target=target,
+                sections=sections,
+                inbox_dir=inbox_dir,
+                processed_dir=processed_dir,
+                dry_run=dry_run,
+            )
+            stats.actions.append(action.summary)
+            if action.kind == "promoted":
+                stats.promoted += 1
+            elif action.kind == "routed":
+                stats.routed += 1
+            elif action.kind == "inboxed":
+                stats.inboxed += 1
+            elif action.kind == "skipped":
+                stats.skipped += 1
 
     _report(stats, dry_run=dry_run)
     return 0

--- a/src/solo_mise/install.py
+++ b/src/solo_mise/install.py
@@ -24,6 +24,68 @@ from .templates import (
     template_root,
 )
 
+GITIGNORE_BEGIN = "# >>> solo-mise gitignore block >>>"
+GITIGNORE_END = "# <<< solo-mise gitignore block <<<"
+
+# Writer harness -> inbox-dir prefix. Only writer harnesses have an inbox.
+_WRITER_INBOX = {
+    "claude": ".claude/memory-handoffs",
+    "codex": ".codex/memory-handoffs",
+}
+
+
+def build_gitignore_block(selection: Selection) -> str:
+    lines = [
+        GITIGNORE_BEGIN,
+        "# Managed by `solo-mise init`. Edit between the markers to customize.",
+        "# Re-running `solo-mise init` replaces only the content between markers.",
+        "",
+    ]
+    for h in selection.harnesses:
+        inbox = _WRITER_INBOX.get(h)
+        if inbox:
+            lines.extend([
+                f"# {h}: handoffs are session-local and may contain private context.",
+                f"{inbox}/*",
+                f"!{inbox}/TEMPLATE.md",
+                f"!{inbox}/.gitkeep",
+                "",
+            ])
+    lines.extend([
+        "# Daily session logs are machine-local raw context.",
+        "memory/20[0-9][0-9]-[0-1][0-9]-[0-3][0-9].md",
+        "",
+        "# Review inbox: ambiguous handoffs awaiting human triage.",
+        "memory/handoff-inbox/",
+        "",
+        "# solo-mise local state (logs, scrub cache).",
+        ".solo-mise/logs/",
+        ".solo-mise/scrub-cache/",
+        GITIGNORE_END,
+        "",
+    ])
+    return "\n".join(lines)
+
+
+def apply_gitignore(target: Path, selection: Selection) -> str:
+    """Insert or replace the managed block in target's .gitignore. Returns 'created' or 'updated'."""
+    gi = target / ".gitignore"
+    block = build_gitignore_block(selection)
+    if not gi.exists():
+        gi.write_text(block)
+        return "created"
+    existing = gi.read_text()
+    if GITIGNORE_BEGIN in existing and GITIGNORE_END in existing:
+        prefix, _, rest = existing.partition(GITIGNORE_BEGIN)
+        _, _, suffix = rest.partition(GITIGNORE_END)
+        # Strip a trailing newline from prefix and a leading newline from suffix to avoid drift.
+        new_text = prefix.rstrip("\n") + ("\n\n" if prefix.strip() else "") + block + suffix.lstrip("\n")
+        gi.write_text(new_text)
+        return "updated"
+    sep = "" if existing.endswith("\n") else "\n"
+    gi.write_text(existing + sep + "\n" + block)
+    return "updated"
+
 
 def resolve_manifests(selection: Selection) -> Tuple[List[dict], List[str], List[str]]:
     """Return (files, dirs, post_install_notes) for a Selection.
@@ -133,6 +195,9 @@ def install_selection(
 
     # Persist config.json.
     write_config(target, Config(version=1, selection=selection))
+
+    result = apply_gitignore(target, selection)
+    print(f"solo-mise: gitignore {result}")
 
     # Post-install output.
     print(f"solo-mise: installed depth={selection.depth} harnesses={','.join(selection.harnesses) or '(none)'} -> {target}")

--- a/src/solo_mise/install.py
+++ b/src/solo_mise/install.py
@@ -1,0 +1,152 @@
+"""install_selection - the new install engine.
+
+Composes a depth manifest + N harness manifests + M include manifests
+into a single deduped file/dir list, then copies+renders into target.
+Persists the Selection to .solo-mise/config.json.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from pathlib import Path
+from typing import List, Tuple
+
+from .config import Config, write_config
+from .selection import Selection
+from .templates import (
+    harness_memory_owner,
+    is_text,
+    load_depth_manifest,
+    load_harness_manifest,
+    load_include_manifest,
+    render,
+    template_root,
+)
+
+
+def resolve_manifests(selection: Selection) -> Tuple[List[dict], List[str], List[str]]:
+    """Return (files, dirs, post_install_notes) for a Selection.
+
+    Files are deduped by `dst`: later manifests win, so a harness can
+    override a depth-baseline file by referencing the same dst.
+    """
+    files: List[dict] = []
+    dirs: List[str] = []
+    notes: List[str] = []
+
+    depth_manifest = load_depth_manifest(selection.depth)
+    files.extend(depth_manifest.get("files", []))
+    dirs.extend(depth_manifest.get("dirs", []))
+    notes.extend(depth_manifest.get("post_install_notes", []))
+
+    for harness_id in selection.harnesses:
+        m = load_harness_manifest(harness_id)
+        files.extend(m.get("files", []))
+        dirs.extend(m.get("dirs", []))
+        notes.extend(m.get("post_install_notes", []))
+
+    for include_id in selection.includes:
+        m = load_include_manifest(include_id)
+        files.extend(m.get("files", []))
+        dirs.extend(m.get("dirs", []))
+        notes.extend(m.get("post_install_notes", []))
+
+    # Dedupe files by dst (last-wins).
+    seen: dict[str, dict] = {}
+    for entry in files:
+        seen[entry["dst"]] = entry
+    deduped_files = list(seen.values())
+    deduped_dirs = sorted(set(dirs))
+
+    return deduped_files, deduped_dirs, notes
+
+
+def install_selection(
+    target: Path,
+    selection: Selection,
+    force: bool = False,
+    dry_run: bool = False,
+    allow_home: bool = False,
+) -> int:
+    """Install a Selection into `target`. Returns process exit code."""
+    selection.validate()
+    target = target.expanduser().resolve()
+
+    if target == Path.home() and not allow_home:
+        print(
+            f"error: refusing to install directly into $HOME ({target}).",
+            file=sys.stderr,
+        )
+        return 5
+
+    files, dirs, notes = resolve_manifests(selection)
+
+    if dry_run:
+        print(f"[dry-run] target: {target}")
+        print(f"[dry-run] depth: {selection.depth}")
+        print(f"[dry-run] harnesses: {','.join(selection.harnesses) or '(none)'}")
+        print(f"[dry-run] owner: {selection.owner}")
+        print(f"[dry-run] includes: {','.join(selection.includes) or '(none)'}")
+        print(f"[dry-run] would create {len(dirs)} dir(s) and {len(files)} file(s)")
+        for d in dirs:
+            print(f"  dir   {target / d}")
+        for entry in files:
+            print(f"  file  {target / entry['dst']}")
+        return 0
+
+    target.mkdir(parents=True, exist_ok=True)
+
+    if not force:
+        conflicts = [target / f["dst"] for f in files if (target / f["dst"]).exists()]
+        if conflicts:
+            print("error: refusing to overwrite existing files (use --force):", file=sys.stderr)
+            for c in conflicts:
+                print(f"  {c}", file=sys.stderr)
+            return 3
+
+    for d in dirs:
+        (target / d).mkdir(parents=True, exist_ok=True)
+
+    owner_label = harness_memory_owner(selection.owner, selection.owner)
+    context = {
+        "memory_owner": selection.owner,
+        "memory_owner_name": owner_label,
+        "harness": selection.owner,
+    }
+
+    root = template_root()
+    for entry in files:
+        src = root / entry["src"]
+        dst = target / entry["dst"]
+        if not src.is_file():
+            print(f"error: template missing: {src}", file=sys.stderr)
+            return 4
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        if is_text(entry["src"]):
+            dst.write_text(render(src.read_text(), context))
+        else:
+            shutil.copyfile(src, dst)
+        mode_str = entry.get("mode")
+        if mode_str:
+            os.chmod(dst, int(mode_str, 8))
+
+    # Persist config.json.
+    write_config(target, Config(version=1, selection=selection))
+
+    # Post-install output.
+    print(f"solo-mise: installed depth={selection.depth} harnesses={','.join(selection.harnesses) or '(none)'} -> {target}")
+    print(f"solo-mise: memory owner -> {owner_label}")
+    if "hermes" in selection.harnesses:
+        print(
+            "solo-mise: NOTE - the hermes adapter is experimental. "
+            "Validate against your real Hermes install before relying on it. "
+            "See CONTRIBUTING.md for graduation criteria.",
+            file=sys.stderr,
+        )
+    if notes:
+        print()
+        print("Next steps:")
+        for note in notes:
+            print(f"  - {note}")
+    return 0

--- a/src/solo_mise/prompt.py
+++ b/src/solo_mise/prompt.py
@@ -1,0 +1,135 @@
+"""Hand-rolled interactive prompt for harness/depth/include selection.
+
+No external deps. Uses stdin line input + numbered toggles, so it works
+over any TTY (no raw mode, no curses, no ANSI escape sequences required).
+"""
+from __future__ import annotations
+
+import sys
+from typing import List
+
+from .selection import (
+    KNOWN_HARNESSES,
+    KNOWN_DEPTHS,
+    KNOWN_INCLUDES,
+    Selection,
+    resolve_owner,
+)
+
+
+class NonInteractiveError(Exception):
+    """Raised when prompt_for_selection() runs without a TTY."""
+
+
+_HARNESS_ORDER = ["claude", "codex", "openclaw", "hermes"]
+_DEPTH_ORDER = ["repo", "workspace"]
+_INCLUDE_ORDER = ["publisher"]
+
+_HARNESS_LABELS = {
+    "claude": "Claude Code",
+    "codex": "Codex",
+    "openclaw": "OpenClaw",
+    "hermes": "Hermes (experimental)",
+}
+
+_DEPTH_LABELS = {
+    "repo": "repo       (handoff flow + publish guard)",
+    "workspace": "workspace  (full home: MEMORY.md, TOOLS.md, USER.md, ...)",
+}
+
+_INCLUDE_LABELS = {
+    "publisher": "publisher  (content-guard policies for blog/social/docs)",
+}
+
+
+def prompt_for_selection() -> Selection:
+    if not sys.stdin.isatty():
+        raise NonInteractiveError(
+            "solo-mise init needs a TTY for the interactive prompt. "
+            "Pass --depth and --harnesses (or --profile) for scripting."
+        )
+
+    selected_harnesses = _toggle_prompt(
+        title="Which harnesses do you use?",
+        options=_HARNESS_ORDER,
+        labels=_HARNESS_LABELS,
+        defaults=["claude"],
+    )
+    depth = _single_prompt(
+        title="Depth?",
+        options=_DEPTH_ORDER,
+        labels=_DEPTH_LABELS,
+        default="repo",
+    )
+    selected_includes = _toggle_prompt(
+        title="Add-ons?",
+        options=_INCLUDE_ORDER,
+        labels=_INCLUDE_LABELS,
+        defaults=[],
+    )
+
+    owner = resolve_owner(selected_harnesses)
+    return Selection(
+        depth=depth,
+        harnesses=selected_harnesses,
+        owner=owner,
+        includes=selected_includes,
+    )
+
+
+def _toggle_prompt(title, options, labels, defaults):
+    selected = list(defaults)
+    print()
+    print(title + " (type numbers separated by space/comma to toggle, enter to confirm)")
+    while True:
+        for i, opt in enumerate(options, start=1):
+            mark = "x" if opt in selected else " "
+            print(f"  [{mark}] {i}. {labels.get(opt, opt)}")
+        raw = sys.stdin.readline()
+        if raw == "":  # EOF
+            break
+        raw = raw.strip()
+        if not raw:
+            break
+        tokens = [t.strip() for t in raw.replace(",", " ").split() if t.strip()]
+        invalid = []
+        for t in tokens:
+            try:
+                idx = int(t)
+            except ValueError:
+                invalid.append(t)
+                continue
+            if not 1 <= idx <= len(options):
+                invalid.append(t)
+                continue
+            opt = options[idx - 1]
+            if opt in selected:
+                selected.remove(opt)
+            else:
+                selected.append(opt)
+        if invalid:
+            print(f"  (ignored invalid: {' '.join(invalid)})")
+    # Preserve canonical order rather than toggle order.
+    return [o for o in options if o in selected]
+
+
+def _single_prompt(title, options, labels, default):
+    print()
+    print(title + " (type a number, enter for default)")
+    for i, opt in enumerate(options, start=1):
+        marker = "*" if opt == default else " "
+        print(f"  {marker} {i}. {labels.get(opt, opt)}")
+    raw = sys.stdin.readline()
+    if raw == "":
+        return default
+    raw = raw.strip()
+    if not raw:
+        return default
+    try:
+        idx = int(raw)
+        if 1 <= idx <= len(options):
+            return options[idx - 1]
+    except ValueError:
+        pass
+    print(f"  (invalid; using default {default!r})")
+    return default

--- a/src/solo_mise/reconfigure.py
+++ b/src/solo_mise/reconfigure.py
@@ -1,0 +1,64 @@
+"""solo-mise reconfigure - adjust an existing install to a new Selection."""
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+from .config import Config, load_config, write_config
+from .install import apply_gitignore, install_selection, resolve_manifests
+from .selection import Selection
+
+
+_WRITER_DIRS = {
+    "claude": ".claude",
+    "codex": ".codex",
+}
+_READER_DIRS = {
+    "openclaw": ".solo-mise/openclaw",
+    "hermes": ".solo-mise/hermes",
+}
+_HARNESS_BRIDGE_FILES = {
+    "claude": ["CLAUDE.md"],
+    "codex": [],
+}
+
+
+def reconfigure(target: Path, new_selection: Selection, prune: bool) -> int:
+    target = target.expanduser().resolve()
+    new_selection.validate()
+    existing = load_config(target)
+    old_harnesses = set(existing.selection.harnesses) if existing else set()
+    new_harnesses = set(new_selection.harnesses)
+
+    added = new_harnesses - old_harnesses
+    removed = old_harnesses - new_harnesses
+
+    # Re-run install with force=True to lay down baseline + new-harness files.
+    # install_selection is idempotent: unchanged files re-render identically.
+    rc = install_selection(target, new_selection, force=True)
+    if rc != 0:
+        return rc
+
+    # Prune removed harnesses if requested.
+    if prune:
+        for h in sorted(removed):
+            wdir = _WRITER_DIRS.get(h)
+            if wdir and (target / wdir).is_dir():
+                shutil.rmtree(target / wdir)
+            for bridge in _HARNESS_BRIDGE_FILES.get(h, []):
+                bp = target / bridge
+                if bp.is_file():
+                    bp.unlink()
+            rdir = _READER_DIRS.get(h)
+            if rdir and (target / rdir).is_dir():
+                shutil.rmtree(target / rdir)
+            print(f"solo-mise: pruned {h}")
+
+    print(f"solo-mise: reconfigured -> harnesses={','.join(new_selection.harnesses) or '(none)'}")
+    if added:
+        print(f"  added:   {','.join(sorted(added))}")
+    if removed:
+        verb = "pruned" if prune else "orphaned (use --prune to delete)"
+        print(f"  removed: {','.join(sorted(removed))} ({verb})")
+    return 0

--- a/src/solo_mise/selection.py
+++ b/src/solo_mise/selection.py
@@ -64,3 +64,29 @@ def resolve_owner(harnesses: List[str], override: Optional[str] = None) -> str:
         if candidate in harnesses:
             return candidate
     return "this-repo"
+
+
+_PROFILE_MAP = {
+    "repo":      Selection(depth="repo",      harnesses=["claude"],             owner="claude",    includes=[]),
+    "workspace": Selection(depth="workspace", harnesses=["claude"],             owner="claude",    includes=[]),
+    "openclaw":  Selection(depth="workspace", harnesses=["claude", "openclaw"], owner="openclaw",  includes=[]),
+    "hermes":    Selection(depth="workspace", harnesses=["claude", "hermes"],   owner="hermes",    includes=[]),
+    "generic":   Selection(depth="workspace", harnesses=[],                     owner="this-repo", includes=[]),
+    "publisher": Selection(depth="repo",      harnesses=["claude"],             owner="claude",    includes=["publisher"]),
+}
+
+
+def profile_to_selection(profile_id: str) -> Selection:
+    """Translate a legacy --profile id into a Selection. Used by the deprecation shim."""
+    if profile_id not in _PROFILE_MAP:
+        raise ValueError(
+            f"unknown profile: {profile_id!r} (valid: {sorted(_PROFILE_MAP)})"
+        )
+    sel = _PROFILE_MAP[profile_id]
+    # Return a copy to keep callers from mutating the map.
+    return Selection(
+        depth=sel.depth,
+        harnesses=list(sel.harnesses),
+        owner=sel.owner,
+        includes=list(sel.includes),
+    )

--- a/src/solo_mise/selection.py
+++ b/src/solo_mise/selection.py
@@ -1,0 +1,66 @@
+"""Selection data model: depth + harnesses + owner + includes."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+KNOWN_DEPTHS = ("repo", "workspace")
+KNOWN_HARNESSES = ("claude", "codex", "openclaw", "hermes")
+KNOWN_INCLUDES = ("publisher",)
+
+# Higher priority owners come first. The first harness in this list that
+# also appears in the selection becomes the canonical memory owner unless
+# the user passes --owner.
+HARNESS_PRIORITY = ["openclaw", "hermes", "claude", "codex", "this-repo"]
+
+
+@dataclass
+class Selection:
+    depth: str
+    harnesses: List[str] = field(default_factory=list)
+    owner: str = "this-repo"
+    includes: List[str] = field(default_factory=list)
+
+    def validate(self) -> None:
+        if self.depth not in KNOWN_DEPTHS:
+            raise ValueError(
+                f"unknown depth: {self.depth!r} (valid: {KNOWN_DEPTHS})"
+            )
+        for h in self.harnesses:
+            if h not in KNOWN_HARNESSES:
+                raise ValueError(
+                    f"unknown harness: {h!r} (valid: {KNOWN_HARNESSES})"
+                )
+        for inc in self.includes:
+            if inc not in KNOWN_INCLUDES:
+                raise ValueError(
+                    f"unknown include: {inc!r} (valid: {KNOWN_INCLUDES})"
+                )
+        if self.owner != "this-repo" and self.owner not in self.harnesses:
+            raise ValueError(
+                f"owner {self.owner!r} not in selected harnesses {self.harnesses}"
+            )
+
+
+def resolve_owner(harnesses: List[str], override: Optional[str] = None) -> str:
+    """Pick the canonical memory owner.
+
+    If override is provided, it must be 'this-repo' or one of the selected
+    harnesses. Otherwise the first entry in HARNESS_PRIORITY that also appears
+    in `harnesses` wins; if none match, returns 'this-repo'.
+    """
+    if override is not None:
+        if override == "this-repo":
+            return override
+        if override not in harnesses:
+            raise ValueError(
+                f"owner override {override!r} not in selected harnesses {harnesses}"
+            )
+        return override
+    for candidate in HARNESS_PRIORITY:
+        if candidate == "this-repo":
+            continue
+        if candidate in harnesses:
+            return candidate
+    return "this-repo"

--- a/src/solo_mise/templates.py
+++ b/src/solo_mise/templates.py
@@ -58,6 +58,11 @@ def load_harness_manifest(harness_id: str) -> Dict[str, Any]:
     return _load_layered("harnesses", harness_id)
 
 
+def load_include_manifest(include_id: str) -> Dict[str, Any]:
+    """Load an include (add-on) manifest, e.g. `publisher`."""
+    return _load_layered("includes", include_id)
+
+
 def _load_layered(kind: str, manifest_id: str) -> Dict[str, Any]:
     base = template_root() / kind
     path = base / f"{manifest_id}.json"

--- a/src/solo_mise/templates.py
+++ b/src/solo_mise/templates.py
@@ -48,6 +48,27 @@ def load_profile(profile_id: str) -> Dict[str, Any]:
     return manifest
 
 
+def load_depth_manifest(depth_id: str) -> Dict[str, Any]:
+    """Load and merge a depth manifest, resolving `extends` chains."""
+    return _load_layered("depth", depth_id)
+
+
+def _load_layered(kind: str, manifest_id: str) -> Dict[str, Any]:
+    base = template_root() / kind
+    path = base / f"{manifest_id}.json"
+    if not path.is_file():
+        raise FileNotFoundError(f"Unknown {kind}: {manifest_id} (looked at {path})")
+    manifest = json.loads(path.read_text())
+    parent_id = manifest.get("extends")
+    if parent_id:
+        parent = _load_layered(kind, parent_id)
+        merged_files = list(parent.get("files", [])) + list(manifest.get("files", []))
+        merged_dirs = list(parent.get("dirs", [])) + list(manifest.get("dirs", []))
+        manifest["files"] = _dedupe_files(merged_files)
+        manifest["dirs"] = sorted(set(merged_dirs))
+    return manifest
+
+
 def _dedupe_files(entries):
     """Keep the last occurrence per destination path."""
     seen: Dict[str, Dict[str, Any]] = {}

--- a/src/solo_mise/templates.py
+++ b/src/solo_mise/templates.py
@@ -53,6 +53,11 @@ def load_depth_manifest(depth_id: str) -> Dict[str, Any]:
     return _load_layered("depth", depth_id)
 
 
+def load_harness_manifest(harness_id: str) -> Dict[str, Any]:
+    """Load a harness manifest. Harness manifests do not currently use `extends`."""
+    return _load_layered("harnesses", harness_id)
+
+
 def _load_layered(kind: str, manifest_id: str) -> Dict[str, Any]:
     base = template_root() / kind
     path = base / f"{manifest_id}.json"

--- a/src/solo_mise/templates/codex/memory-handoffs/TEMPLATE.md
+++ b/src/solo_mise/templates/codex/memory-handoffs/TEMPLATE.md
@@ -1,0 +1,57 @@
+# Memory Handoff
+
+## Type
+
+setup | workflow | bugfix | decision | security | preference | research | project-context
+
+## Title
+
+Short, specific title. No private identifiers.
+
+## Summary
+
+2-4 sentences. What happened and why it matters for future sessions.
+
+## Durable facts
+
+- Fact 1
+- Fact 2
+- Fact 3
+
+## Evidence
+
+- files changed: `path/to/file`
+- commands run: `the exact command`
+- error strings: `verbatim error`
+
+## Recommended memory action
+
+create-card | update-card | no-card
+
+## Target card
+
+card-name-if-known.md
+
+## Suggested card content
+
+If `create-card` or `update-card`, paste the exact card content here. Must start with YAML frontmatter:
+
+```markdown
+---
+topic: ...
+category: ...
+tags: [list]
+---
+
+# Card title
+
+Card body. Use ### or deeper for subsections; ## headings parse as new handoff sections.
+```
+
+## Target document
+
+If `no-card`, name one of: `TOOLS.md` | `USER.md` | `rules/<name>.md` | `.learnings/LEARNINGS.md` | `.learnings/ERRORS.md` | `.learnings/FEATURE_REQUESTS.md`
+
+## Suggested document content
+
+If `no-card`, the exact text to append. No `##` headings (use `###` or deeper).

--- a/src/solo_mise/templates/depth/repo.json
+++ b/src/solo_mise/templates/depth/repo.json
@@ -1,0 +1,12 @@
+{
+  "id": "repo",
+  "description": "Repo-local baseline: harness-neutral bootstrap files + publish guard.",
+  "files": [
+    {"src": "workspace/AGENTS.md", "dst": "AGENTS.md"},
+    {"src": "workspace/SAFETY_RULES.md", "dst": "SAFETY_RULES.md"},
+    {"src": "workspace/INSTALL_FOR_AGENTS.md", "dst": "INSTALL_FOR_AGENTS.md"},
+    {"src": "hooks/pre-push", "dst": "hooks/pre-push", "mode": "0755"},
+    {"src": "policies/public-repo.json", "dst": ".solo-mise/policies/public-repo.json"}
+  ],
+  "dirs": []
+}

--- a/src/solo_mise/templates/depth/workspace.json
+++ b/src/solo_mise/templates/depth/workspace.json
@@ -1,0 +1,30 @@
+{
+  "id": "workspace",
+  "description": "Full agent kitchen: extends repo baseline + memory folders + starter cards + safety files.",
+  "extends": "repo",
+  "files": [
+    {"src": "workspace/MEMORY.md", "dst": "MEMORY.md"},
+    {"src": "workspace/TOOLS.md", "dst": "TOOLS.md"},
+    {"src": "workspace/USER.md", "dst": "USER.md"},
+    {"src": "workspace/SOUL.md", "dst": "SOUL.md"},
+    {"src": "workspace/IDENTITY.md", "dst": "IDENTITY.md"},
+    {"src": "workspace/HEARTBEAT.md", "dst": "HEARTBEAT.md"},
+    {"src": "memory/cards/memory-architecture.md", "dst": "memory/cards/memory-architecture.md"},
+    {"src": "memory/cards/handoff-flow.md", "dst": "memory/cards/handoff-flow.md"},
+    {"src": "memory/cards/content-safety.md", "dst": "memory/cards/content-safety.md"},
+    {"src": "memory/cards/memory-scanner.md", "dst": "memory/cards/memory-scanner.md"},
+    {"src": "memory/cards/memory-care-staleness.md", "dst": "memory/cards/memory-care-staleness.md"},
+    {"src": "memory/cards/multi-workspace-handoff-admin.md", "dst": "memory/cards/multi-workspace-handoff-admin.md"},
+    {"src": "memory/cards/tokenjuice-output-compaction.md", "dst": "memory/cards/tokenjuice-output-compaction.md"},
+    {"src": "memory/cards/chat-surface-crawlers.md", "dst": "memory/cards/chat-surface-crawlers.md"},
+    {"src": "memory/cards/pipeline-standups.md", "dst": "memory/cards/pipeline-standups.md"},
+    {"src": "memory/cards/obsidian-notes.md", "dst": "memory/cards/obsidian-notes.md"},
+    {"src": "memory/cards/backup-restic.md", "dst": "memory/cards/backup-restic.md"},
+    {"src": "skills/note/SKILL.md", "dst": "skills/note/SKILL.md"},
+    {"src": "scripts/backup-restic.sh", "dst": "scripts/backup-restic.sh", "mode": "0755"}
+  ],
+  "dirs": [
+    "memory/cards/decay",
+    "memory/handoff-inbox"
+  ]
+}

--- a/src/solo_mise/templates/harnesses/claude.json
+++ b/src/solo_mise/templates/harnesses/claude.json
@@ -1,0 +1,12 @@
+{
+  "id": "claude",
+  "role": "writer",
+  "description": "Claude Code bridge + handoff inbox.",
+  "files": [
+    {"src": "workspace/CLAUDE.md", "dst": "CLAUDE.md"},
+    {"src": "claude/memory-handoffs/TEMPLATE.md", "dst": ".claude/memory-handoffs/TEMPLATE.md"}
+  ],
+  "dirs": [
+    ".claude/memory-handoffs/processed"
+  ]
+}

--- a/src/solo_mise/templates/harnesses/codex.json
+++ b/src/solo_mise/templates/harnesses/codex.json
@@ -1,0 +1,11 @@
+{
+  "id": "codex",
+  "role": "writer",
+  "description": "Codex handoff inbox. (AGENTS.md is in the depth baseline; no separate bridge file today.)",
+  "files": [
+    {"src": "codex/memory-handoffs/TEMPLATE.md", "dst": ".codex/memory-handoffs/TEMPLATE.md"}
+  ],
+  "dirs": [
+    ".codex/memory-handoffs/processed"
+  ]
+}

--- a/src/solo_mise/templates/harnesses/hermes.json
+++ b/src/solo_mise/templates/harnesses/hermes.json
@@ -1,0 +1,16 @@
+{
+  "id": "hermes",
+  "role": "reader",
+  "description": "Hermes adapter fragments + doctor checks. Experimental.",
+  "files": [
+    {"src": "hermes/workspace.harness.json", "dst": ".solo-mise/hermes/workspace.harness.json"},
+    {"src": "hermes/memory-handoff.harness.json", "dst": ".solo-mise/hermes/memory-handoff.harness.json"},
+    {"src": "hermes/model-lanes.harness.json", "dst": ".solo-mise/hermes/model-lanes.harness.json"},
+    {"src": "hermes/README.md", "dst": ".solo-mise/hermes/README.md"}
+  ],
+  "dirs": [],
+  "post_install_notes": [
+    "Hermes support is experimental. Validate against your real Hermes install before relying on it.",
+    "Open an issue with your config layout to help promote the adapter from experimental to tested."
+  ]
+}

--- a/src/solo_mise/templates/harnesses/openclaw.json
+++ b/src/solo_mise/templates/harnesses/openclaw.json
@@ -1,0 +1,17 @@
+{
+  "id": "openclaw",
+  "role": "reader",
+  "description": "OpenClaw config fragments + cron stubs + doctor checks.",
+  "files": [
+    {"src": "openclaw/model-aliases.openclaw.json", "dst": ".solo-mise/openclaw/model-aliases.openclaw.json"},
+    {"src": "openclaw/ollama-memory-search.openclaw.json", "dst": ".solo-mise/openclaw/ollama-memory-search.openclaw.json"},
+    {"src": "openclaw/acp-escalation.openclaw.json", "dst": ".solo-mise/openclaw/acp-escalation.openclaw.json"},
+    {"src": "openclaw/README.md", "dst": ".solo-mise/openclaw/README.md"}
+  ],
+  "dirs": [],
+  "post_install_notes": [
+    "Inspect fragments under `.solo-mise/openclaw/` before merging into ~/.openclaw/openclaw.json.",
+    "Run `solo-mise doctor --target <workspace>` to confirm wiring.",
+    "Never let `openclaw doctor --fix` (the OpenClaw tool) rewrite provider prefixes blindly."
+  ]
+}

--- a/src/solo_mise/templates/includes/publisher.json
+++ b/src/solo_mise/templates/includes/publisher.json
@@ -1,0 +1,15 @@
+{
+  "id": "publisher",
+  "description": "content-guard policies + scrub cache for users who publish blogs, social, or docs.",
+  "files": [
+    {"src": "policies/public-content.json", "dst": ".solo-mise/policies/public-content.json"},
+    {"src": "memory/cards/content-safety.md", "dst": "memory/cards/content-safety.md"}
+  ],
+  "dirs": [
+    ".solo-mise/scrub-cache"
+  ],
+  "post_install_notes": [
+    "Run `solo-mise scrub --target . --policy public-content` before publishing user-facing content.",
+    "Add `solo-mise scrub` to your publish workflow as a hard gate."
+  ]
+}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,71 @@
+import json
+import pytest
+from pathlib import Path
+from solo_mise.config import (
+    Config,
+    CONFIG_REL_PATH,
+    config_path,
+    load_config,
+    write_config,
+)
+from solo_mise.selection import Selection
+
+
+def test_config_rel_path():
+    assert CONFIG_REL_PATH == ".solo-mise/config.json"
+
+
+def test_config_path_resolves_relative_to_target(tmp_path):
+    assert config_path(tmp_path) == tmp_path / ".solo-mise" / "config.json"
+
+
+def test_write_then_load_round_trip(tmp_path):
+    sel = Selection(
+        depth="workspace",
+        harnesses=["claude", "codex", "openclaw"],
+        owner="openclaw",
+        includes=["publisher"],
+    )
+    cfg = Config(version=1, selection=sel)
+    write_config(tmp_path, cfg)
+
+    loaded = load_config(tmp_path)
+    assert loaded.version == 1
+    assert loaded.selection.depth == "workspace"
+    assert loaded.selection.harnesses == ["claude", "codex", "openclaw"]
+    assert loaded.selection.owner == "openclaw"
+    assert loaded.selection.includes == ["publisher"]
+
+
+def test_write_creates_parent_dir(tmp_path):
+    sel = Selection(depth="repo", harnesses=["claude"], owner="claude", includes=[])
+    write_config(tmp_path, Config(version=1, selection=sel))
+    assert (tmp_path / ".solo-mise" / "config.json").is_file()
+
+
+def test_load_missing_returns_none(tmp_path):
+    assert load_config(tmp_path) is None
+
+
+def test_load_rejects_unknown_version(tmp_path):
+    path = tmp_path / ".solo-mise" / "config.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps({"version": 99, "depth": "repo", "harnesses": [], "owner": "this-repo", "includes": []}))
+    with pytest.raises(ValueError, match="unsupported config version"):
+        load_config(tmp_path)
+
+
+def test_load_rejects_invalid_selection(tmp_path):
+    path = tmp_path / ".solo-mise" / "config.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps({"version": 1, "depth": "weird", "harnesses": [], "owner": "this-repo", "includes": []}))
+    with pytest.raises(ValueError, match="unknown depth"):
+        load_config(tmp_path)
+
+
+def test_write_produces_pretty_json(tmp_path):
+    sel = Selection(depth="repo", harnesses=["claude"], owner="claude", includes=[])
+    write_config(tmp_path, Config(version=1, selection=sel))
+    text = (tmp_path / ".solo-mise" / "config.json").read_text()
+    assert "\n  " in text  # indented
+    assert text.endswith("\n")

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -8,6 +8,8 @@ import pytest
 
 from solo_mise import doctor as doctor_mod
 from solo_mise import init as init_mod
+from solo_mise.install import install_selection
+from solo_mise.selection import Selection
 
 
 def test_doctor_passes_against_workspace_profile(tmp_target: Path, capsys):
@@ -130,3 +132,57 @@ def test_doctor_openclaw_reports_cron_memory_jobs(tmp_target: Path, monkeypatch,
     assert "openclaw: card decay scanner" in out
     assert "openclaw: card decay refresh" in out
     assert "openclaw: card decay weekly" in out
+
+
+def test_doctor_reports_apparent_harness_shape(tmp_target: Path, capsys):
+    sel = Selection(
+        depth="workspace",
+        harnesses=["claude", "codex", "openclaw"],
+        owner="openclaw",
+        includes=[],
+    )
+    install_selection(tmp_target, sel)
+    doctor_mod.run(tmp_target)
+    out = capsys.readouterr().out
+    assert "harnesses:" in out
+    assert "claude" in out
+    assert "codex" in out
+    assert "openclaw" in out
+    assert "owner=openclaw" in out
+
+
+def test_doctor_checks_codex_inbox_when_selected(tmp_target: Path, capsys):
+    sel = Selection(
+        depth="repo",
+        harnesses=["claude", "codex"],
+        owner="claude",
+        includes=[],
+    )
+    install_selection(tmp_target, sel)
+    doctor_mod.run(tmp_target)
+    out = capsys.readouterr().out
+    assert ".codex/memory-handoffs" in out
+
+
+def test_doctor_warns_for_orphan_inbox(tmp_target: Path, capsys):
+    """If config says claude only, but .codex/memory-handoffs exists, warn."""
+    sel = Selection(
+        depth="repo",
+        harnesses=["claude"],
+        owner="claude",
+        includes=[],
+    )
+    install_selection(tmp_target, sel)
+    (tmp_target / ".codex" / "memory-handoffs").mkdir(parents=True)
+    doctor_mod.run(tmp_target)
+    out = capsys.readouterr().out
+    assert "orphan" in out.lower() or "unselected" in out.lower()
+
+
+def test_doctor_falls_back_to_v0_2_behavior_when_no_config(tmp_target: Path, capsys):
+    """A target without .solo-mise/config.json should still run (legacy targets)."""
+    tmp_target.mkdir()
+    (tmp_target / "AGENTS.md").write_text("# Agents")
+    doctor_mod.run(tmp_target)
+    out = capsys.readouterr().out
+    assert "doctor" in out

--- a/tests/test_fragments.py
+++ b/tests/test_fragments.py
@@ -5,7 +5,12 @@ import json
 from pathlib import Path
 
 from solo_mise import fragments as frag_mod
-from solo_mise.templates import load_depth_manifest, load_harness_manifest, template_root
+from solo_mise.templates import (
+    load_depth_manifest,
+    load_harness_manifest,
+    load_include_manifest,
+    template_root,
+)
 
 
 def test_openclaw_fragments(tmp_path: Path):
@@ -127,3 +132,11 @@ def test_all_harness_files_exist():
         m = load_harness_manifest(h)
         for entry in m["files"]:
             assert (template_root() / entry["src"]).is_file(), f"{h}: {entry['src']}"
+
+
+def test_load_include_publisher():
+    m = load_include_manifest("publisher")
+    assert m["id"] == "publisher"
+    dsts = [f["dst"] for f in m["files"]]
+    assert ".solo-mise/policies/public-content.json" in dsts
+    assert "memory/cards/content-safety.md" in dsts

--- a/tests/test_fragments.py
+++ b/tests/test_fragments.py
@@ -5,6 +5,7 @@ import json
 from pathlib import Path
 
 from solo_mise import fragments as frag_mod
+from solo_mise.templates import load_depth_manifest, template_root
 
 
 def test_openclaw_fragments(tmp_path: Path):
@@ -41,3 +42,37 @@ def test_hermes_fragments(tmp_path: Path):
 def test_unknown_harness_errors(tmp_path: Path):
     rc = frag_mod.write_fragments(tmp_path, harness="bogus")
     assert rc == 2
+
+
+def test_load_depth_repo():
+    m = load_depth_manifest("repo")
+    assert m["id"] == "repo"
+    dsts = [f["dst"] for f in m["files"]]
+    assert "AGENTS.md" in dsts
+    assert "SAFETY_RULES.md" in dsts
+    assert "INSTALL_FOR_AGENTS.md" in dsts
+    assert "hooks/pre-push" in dsts
+    assert ".solo-mise/policies/public-repo.json" in dsts
+    # depth baseline does NOT install harness-specific bridge files
+    assert "CLAUDE.md" not in dsts
+
+
+def test_load_depth_workspace():
+    m = load_depth_manifest("workspace")
+    assert m["id"] == "workspace"
+    dsts = [f["dst"] for f in m["files"]]
+    assert "AGENTS.md" in dsts
+    assert "MEMORY.md" in dsts
+    assert "TOOLS.md" in dsts
+    assert "USER.md" in dsts
+    assert "SOUL.md" in dsts
+    assert "IDENTITY.md" in dsts
+    assert "HEARTBEAT.md" in dsts
+    assert "CLAUDE.md" not in dsts
+
+
+def test_depth_repo_files_exist():
+    m = load_depth_manifest("repo")
+    root = template_root()
+    for entry in m["files"]:
+        assert (root / entry["src"]).is_file(), entry["src"]

--- a/tests/test_fragments.py
+++ b/tests/test_fragments.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 
 from solo_mise import fragments as frag_mod
-from solo_mise.templates import load_depth_manifest, template_root
+from solo_mise.templates import load_depth_manifest, load_harness_manifest, template_root
 
 
 def test_openclaw_fragments(tmp_path: Path):
@@ -76,3 +76,54 @@ def test_depth_repo_files_exist():
     root = template_root()
     for entry in m["files"]:
         assert (root / entry["src"]).is_file(), entry["src"]
+
+
+def test_load_harness_claude():
+    m = load_harness_manifest("claude")
+    assert m["id"] == "claude"
+    assert m.get("role") == "writer"
+    dsts = [f["dst"] for f in m["files"]]
+    assert "CLAUDE.md" in dsts
+    assert ".claude/memory-handoffs/TEMPLATE.md" in dsts
+    assert ".claude/memory-handoffs/processed" in m.get("dirs", [])
+
+
+def test_load_harness_codex():
+    m = load_harness_manifest("codex")
+    assert m["id"] == "codex"
+    assert m.get("role") == "writer"
+    dsts = [f["dst"] for f in m["files"]]
+    # Codex has no bridge file today (reads AGENTS.md from depth baseline)
+    assert "CODEX.md" not in dsts
+    assert ".codex/memory-handoffs/TEMPLATE.md" in dsts
+    assert ".codex/memory-handoffs/processed" in m.get("dirs", [])
+
+
+def test_load_harness_openclaw():
+    m = load_harness_manifest("openclaw")
+    assert m["id"] == "openclaw"
+    assert m.get("role") == "reader"
+    dsts = [f["dst"] for f in m["files"]]
+    # Reader fragments live under .solo-mise/openclaw/
+    assert any(d.startswith(".solo-mise/openclaw/") for d in dsts)
+    # No inbox for readers
+    assert not any("/memory-handoffs/" in d for d in dsts)
+
+
+def test_load_harness_hermes():
+    m = load_harness_manifest("hermes")
+    assert m["id"] == "hermes"
+    assert m.get("role") == "reader"
+
+
+def test_codex_template_file_exists():
+    from solo_mise.templates import template_root
+    assert (template_root() / "codex" / "memory-handoffs" / "TEMPLATE.md").is_file()
+
+
+def test_all_harness_files_exist():
+    from solo_mise.templates import template_root
+    for h in ("claude", "codex", "openclaw", "hermes"):
+        m = load_harness_manifest(h)
+        for entry in m["files"]:
+            assert (template_root() / entry["src"]).is_file(), f"{h}: {entry['src']}"

--- a/tests/test_gitignore.py
+++ b/tests/test_gitignore.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from solo_mise import init as init_mod
+from solo_mise.selection import Selection
 
 
 def _read_gi(target: Path) -> str:
@@ -101,3 +102,38 @@ def test_workspace_profile_also_adds_block(tmp_target: Path):
     gi = _read_gi(tmp_target)
     assert init_mod.GITIGNORE_BEGIN in gi
     assert "memory/handoff-inbox/" in gi
+
+
+def test_gitignore_block_includes_claude_section_when_selected():
+    from solo_mise.install import build_gitignore_block
+    sel = Selection(depth="repo", harnesses=["claude"], owner="claude", includes=[])
+    block = build_gitignore_block(sel)
+    assert ".claude/memory-handoffs/*" in block
+    assert "!.claude/memory-handoffs/TEMPLATE.md" in block
+    assert ".codex/memory-handoffs" not in block
+
+
+def test_gitignore_block_includes_codex_section_when_selected():
+    from solo_mise.install import build_gitignore_block
+    sel = Selection(depth="repo", harnesses=["claude", "codex"], owner="claude", includes=[])
+    block = build_gitignore_block(sel)
+    assert ".claude/memory-handoffs/*" in block
+    assert ".codex/memory-handoffs/*" in block
+    assert "!.codex/memory-handoffs/TEMPLATE.md" in block
+
+
+def test_gitignore_block_no_inbox_section_for_readers_only():
+    from solo_mise.install import build_gitignore_block
+    sel = Selection(depth="workspace", harnesses=["openclaw"], owner="openclaw", includes=[])
+    block = build_gitignore_block(sel)
+    assert "memory-handoffs" not in block
+
+
+def test_install_writes_gitignore_block(tmp_path):
+    from solo_mise.install import install_selection
+    sel = Selection(depth="repo", harnesses=["claude", "codex"], owner="claude", includes=[])
+    install_selection(tmp_path, sel)
+    gi = (tmp_path / ".gitignore").read_text()
+    assert "# >>> solo-mise gitignore block >>>" in gi
+    assert ".claude/memory-handoffs/*" in gi
+    assert ".codex/memory-handoffs/*" in gi

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -266,3 +266,26 @@ def test_missing_inbox_returns_error(tmp_target: Path):
     tmp_target.mkdir()
     rc = ingest_mod.run(target=tmp_target)
     assert rc == 2
+
+
+def test_ingest_scans_multiple_writer_inboxes(tmp_path):
+    from solo_mise.install import install_selection
+    from solo_mise.selection import Selection
+    from solo_mise.ingest import run as ingest_run
+
+    sel = Selection(depth="workspace", harnesses=["claude", "codex"], owner="this-repo", includes=[])
+    install_selection(tmp_path, sel)
+
+    # Drop a handoff in each writer's inbox.
+    (tmp_path / ".claude/memory-handoffs/2026-01-01-claude.md").write_text(
+        "# Memory Handoff\n## Type\nsetup\n## Title\nclaude\n## Summary\nfrom claude\n## Recommended memory action\nno-card\n## Target document\nTOOLS.md\n## Suggested document content\n- claude entry\n"
+    )
+    (tmp_path / ".codex/memory-handoffs/2026-01-01-codex.md").write_text(
+        "# Memory Handoff\n## Type\nsetup\n## Title\ncodex\n## Summary\nfrom codex\n## Recommended memory action\nno-card\n## Target document\nTOOLS.md\n## Suggested document content\n- codex entry\n"
+    )
+
+    rc = ingest_run(target=tmp_path, promote_cards=True, route_documents=True)
+    assert rc == 0
+    tools = (tmp_path / "TOOLS.md").read_text()
+    assert "- claude entry" in tools
+    assert "- codex entry" in tools

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -215,3 +215,28 @@ def test_legacy_profile_openclaw_translates(tmp_path):
     rc = main(["init", "--target", str(tmp_path), "--profile", "openclaw"])
     assert rc == 0
     assert (tmp_path / ".solo-mise" / "openclaw" / "README.md").is_file()
+
+
+def test_cli_invokes_prompt_when_no_selection_flags(monkeypatch, tmp_path):
+    """init without any selection flags should call prompt_for_selection."""
+    called = {}
+    from solo_mise import cli
+    from solo_mise.selection import Selection
+
+    def fake_prompt():
+        called["yes"] = True
+        return Selection(depth="repo", harnesses=["claude"], owner="claude", includes=[])
+
+    monkeypatch.setattr(cli, "prompt_for_selection", fake_prompt)
+    rc = cli.main(["init", "--target", str(tmp_path)])
+    assert rc == 0
+    assert called.get("yes") is True
+
+
+def test_cli_skips_prompt_when_depth_given(monkeypatch, tmp_path):
+    from solo_mise import cli
+    def fail():
+        raise AssertionError("prompt should not be called")
+    monkeypatch.setattr(cli, "prompt_for_selection", fail)
+    rc = cli.main(["init", "--target", str(tmp_path), "--depth", "repo", "--harnesses", "claude"])
+    assert rc == 0

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -169,3 +169,29 @@ def test_harness_override(tmp_target: Path):
     init_mod.run(target=tmp_target, profile_id="repo", harness="hermes")
     agents = (tmp_target / "AGENTS.md").read_text()
     assert "Hermes" in agents
+
+
+def test_cli_parses_depth_harnesses(monkeypatch, tmp_path):
+    from solo_mise.cli import _build_parser
+    parser = _build_parser()
+    ns = parser.parse_args([
+        "init",
+        "--target", str(tmp_path),
+        "--depth", "workspace",
+        "--harnesses", "claude,codex,openclaw",
+        "--owner", "openclaw",
+        "--include", "publisher",
+    ])
+    assert ns.depth == "workspace"
+    assert ns.harnesses == "claude,codex,openclaw"
+    assert ns.owner == "openclaw"
+    assert ns.includes == ["publisher"]
+
+
+def test_cli_rejects_unknown_harness(tmp_path):
+    from solo_mise.cli import main
+    rc = main([
+        "init", "--target", str(tmp_path),
+        "--harnesses", "claude,weird",
+    ])
+    assert rc != 0

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -195,3 +195,23 @@ def test_cli_rejects_unknown_harness(tmp_path):
         "--harnesses", "claude,weird",
     ])
     assert rc != 0
+
+
+def test_legacy_profile_translates_and_warns(tmp_path, capsys):
+    from solo_mise.cli import main
+    rc = main(["init", "--target", str(tmp_path), "--profile", "workspace"])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "deprecated" in captured.err.lower()
+    assert "workspace" in captured.err
+    # Workspace install includes MEMORY.md
+    assert (tmp_path / "MEMORY.md").is_file()
+    # And CLAUDE.md from the claude harness
+    assert (tmp_path / "CLAUDE.md").is_file()
+
+
+def test_legacy_profile_openclaw_translates(tmp_path):
+    from solo_mise.cli import main
+    rc = main(["init", "--target", str(tmp_path), "--profile", "openclaw"])
+    assert rc == 0
+    assert (tmp_path / ".solo-mise" / "openclaw" / "README.md").is_file()

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+import pytest
+from solo_mise.install import resolve_manifests, install_selection
+from solo_mise.selection import Selection
+
+
+def test_resolve_manifests_repo_claude():
+    sel = Selection(depth="repo", harnesses=["claude"], owner="claude", includes=[])
+    files, dirs, notes = resolve_manifests(sel)
+    dsts = [f["dst"] for f in files]
+    assert "AGENTS.md" in dsts
+    assert "CLAUDE.md" in dsts
+    assert ".claude/memory-handoffs/TEMPLATE.md" in dsts
+    assert ".claude/memory-handoffs/processed" in dirs
+
+
+def test_resolve_manifests_workspace_claude_codex_openclaw():
+    sel = Selection(
+        depth="workspace",
+        harnesses=["claude", "codex", "openclaw"],
+        owner="openclaw",
+        includes=[],
+    )
+    files, dirs, notes = resolve_manifests(sel)
+    dsts = [f["dst"] for f in files]
+    # Baseline
+    assert "AGENTS.md" in dsts
+    assert "MEMORY.md" in dsts
+    # Claude
+    assert "CLAUDE.md" in dsts
+    assert ".claude/memory-handoffs/TEMPLATE.md" in dsts
+    # Codex
+    assert ".codex/memory-handoffs/TEMPLATE.md" in dsts
+    # OpenClaw fragments
+    assert ".solo-mise/openclaw/model-aliases.openclaw.json" in dsts
+    # Each dst appears at most once
+    assert len(dsts) == len(set(dsts))
+
+
+def test_resolve_manifests_empty_harnesses():
+    sel = Selection(depth="workspace", harnesses=[], owner="this-repo", includes=[])
+    files, dirs, notes = resolve_manifests(sel)
+    dsts = [f["dst"] for f in files]
+    assert "CLAUDE.md" not in dsts
+    assert not any(d.endswith("memory-handoffs/TEMPLATE.md") for d in dsts)
+    assert "AGENTS.md" in dsts
+
+
+def test_resolve_manifests_publisher_include():
+    sel = Selection(depth="repo", harnesses=["claude"], owner="claude", includes=["publisher"])
+    files, dirs, notes = resolve_manifests(sel)
+    dsts = [f["dst"] for f in files]
+    assert ".solo-mise/policies/public-content.json" in dsts
+    assert ".solo-mise/scrub-cache" in dirs
+
+
+def test_install_selection_writes_files(tmp_path):
+    sel = Selection(depth="repo", harnesses=["claude"], owner="claude", includes=[])
+    code = install_selection(tmp_path, sel)
+    assert code == 0
+    assert (tmp_path / "AGENTS.md").is_file()
+    assert (tmp_path / "CLAUDE.md").is_file()
+    assert (tmp_path / ".claude" / "memory-handoffs" / "TEMPLATE.md").is_file()
+    assert (tmp_path / ".claude" / "memory-handoffs" / "processed").is_dir()
+
+
+def test_install_selection_writes_config(tmp_path):
+    from solo_mise.config import load_config
+    sel = Selection(
+        depth="workspace",
+        harnesses=["claude", "codex", "openclaw"],
+        owner="openclaw",
+        includes=["publisher"],
+    )
+    install_selection(tmp_path, sel)
+    cfg = load_config(tmp_path)
+    assert cfg is not None
+    assert cfg.selection.depth == "workspace"
+    assert cfg.selection.harnesses == ["claude", "codex", "openclaw"]
+    assert cfg.selection.owner == "openclaw"
+    assert cfg.selection.includes == ["publisher"]
+
+
+def test_install_selection_refuses_overwrite_without_force(tmp_path):
+    sel = Selection(depth="repo", harnesses=["claude"], owner="claude", includes=[])
+    install_selection(tmp_path, sel)
+    code = install_selection(tmp_path, sel)
+    assert code == 3  # matches existing init refuse-overwrite exit code

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,0 +1,39 @@
+import io
+import pytest
+from solo_mise.prompt import prompt_for_selection, NonInteractiveError
+
+
+def _run_with_input(text, monkeypatch):
+    monkeypatch.setattr("sys.stdin", io.StringIO(text))
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+
+
+def test_prompt_returns_defaults_on_empty_input(monkeypatch, capsys):
+    """All defaults: claude harness, repo depth, no includes."""
+    monkeypatch.setattr("sys.stdin", io.StringIO("\n\n\n"))
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+    sel = prompt_for_selection()
+    assert sel.harnesses == ["claude"]
+    assert sel.depth == "repo"
+    assert sel.includes == []
+
+
+def test_prompt_toggles_codex_and_openclaw(monkeypatch):
+    """User types '2 3' to toggle codex and openclaw on (claude was default on)."""
+    # Toggle loop re-prompts after each non-empty input; blank line confirms.
+    # Harness: '2 3' toggles codex+openclaw on, blank line confirms.
+    # Depth: '2' picks workspace.
+    # Includes: blank line confirms empty selection.
+    monkeypatch.setattr("sys.stdin", io.StringIO("2 3\n\n2\n\n"))
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+    sel = prompt_for_selection()
+    assert set(sel.harnesses) == {"claude", "codex", "openclaw"}
+    assert sel.depth == "workspace"  # depth choice 2
+    assert sel.owner == "openclaw"
+
+
+def test_prompt_errors_when_not_tty(monkeypatch):
+    monkeypatch.setattr("sys.stdin", io.StringIO(""))
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False, raising=False)
+    with pytest.raises(NonInteractiveError):
+        prompt_for_selection()

--- a/tests/test_reconfigure.py
+++ b/tests/test_reconfigure.py
@@ -1,0 +1,42 @@
+from solo_mise.install import install_selection
+from solo_mise.selection import Selection
+from solo_mise.reconfigure import reconfigure
+from solo_mise.config import load_config
+
+
+def test_reconfigure_adds_new_harness(tmp_path):
+    sel = Selection(depth="repo", harnesses=["claude"], owner="claude", includes=[])
+    install_selection(tmp_path, sel)
+
+    new_sel = Selection(depth="repo", harnesses=["claude", "codex"], owner="claude", includes=[])
+    rc = reconfigure(tmp_path, new_selection=new_sel, prune=False)
+    assert rc == 0
+    assert (tmp_path / ".codex" / "memory-handoffs" / "TEMPLATE.md").is_file()
+    assert (tmp_path / ".claude" / "memory-handoffs" / "TEMPLATE.md").is_file()
+    cfg = load_config(tmp_path)
+    assert "codex" in cfg.selection.harnesses
+
+
+def test_reconfigure_prune_removes_dropped_harness(tmp_path):
+    sel = Selection(depth="repo", harnesses=["claude", "codex"], owner="claude", includes=[])
+    install_selection(tmp_path, sel)
+    assert (tmp_path / ".codex").is_dir()
+
+    new_sel = Selection(depth="repo", harnesses=["claude"], owner="claude", includes=[])
+    rc = reconfigure(tmp_path, new_selection=new_sel, prune=True)
+    assert rc == 0
+    assert not (tmp_path / ".codex").exists()
+    assert (tmp_path / ".claude").is_dir()
+    cfg = load_config(tmp_path)
+    assert cfg.selection.harnesses == ["claude"]
+
+
+def test_reconfigure_no_prune_leaves_orphan(tmp_path):
+    sel = Selection(depth="repo", harnesses=["claude", "codex"], owner="claude", includes=[])
+    install_selection(tmp_path, sel)
+
+    new_sel = Selection(depth="repo", harnesses=["claude"], owner="claude", includes=[])
+    rc = reconfigure(tmp_path, new_selection=new_sel, prune=False)
+    assert rc == 0
+    # Without --prune, codex inbox dir stays (will be flagged by doctor as orphan).
+    assert (tmp_path / ".codex" / "memory-handoffs").is_dir()

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -74,3 +74,60 @@ def test_known_constants():
     assert set(KNOWN_HARNESSES) == {"claude", "codex", "openclaw", "hermes"}
     assert set(KNOWN_DEPTHS) == {"repo", "workspace"}
     assert set(KNOWN_INCLUDES) == {"publisher"}
+
+
+from solo_mise.selection import profile_to_selection
+
+
+def test_profile_to_selection_repo():
+    s = profile_to_selection("repo")
+    assert s.depth == "repo"
+    assert s.harnesses == ["claude"]
+    assert s.owner == "claude"
+    assert s.includes == []
+
+
+def test_profile_to_selection_workspace():
+    s = profile_to_selection("workspace")
+    assert s.depth == "workspace"
+    assert s.harnesses == ["claude"]
+    assert s.owner == "claude"
+    assert s.includes == []
+
+
+def test_profile_to_selection_openclaw():
+    s = profile_to_selection("openclaw")
+    assert s.depth == "workspace"
+    assert s.harnesses == ["claude", "openclaw"]
+    assert s.owner == "openclaw"
+    assert s.includes == []
+
+
+def test_profile_to_selection_hermes():
+    s = profile_to_selection("hermes")
+    assert s.depth == "workspace"
+    assert s.harnesses == ["claude", "hermes"]
+    assert s.owner == "hermes"
+    assert s.includes == []
+
+
+def test_profile_to_selection_generic():
+    s = profile_to_selection("generic")
+    assert s.depth == "workspace"
+    assert s.harnesses == []
+    assert s.owner == "this-repo"
+    assert s.includes == []
+
+
+def test_profile_to_selection_publisher():
+    s = profile_to_selection("publisher")
+    assert s.depth == "repo"
+    assert s.harnesses == ["claude"]
+    assert s.owner == "claude"
+    assert s.includes == ["publisher"]
+
+
+def test_profile_to_selection_unknown_raises():
+    import pytest as _p
+    with _p.raises(ValueError, match="unknown profile"):
+        profile_to_selection("nope")

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -1,0 +1,76 @@
+import pytest
+from solo_mise.selection import (
+    Selection,
+    HARNESS_PRIORITY,
+    KNOWN_HARNESSES,
+    KNOWN_DEPTHS,
+    KNOWN_INCLUDES,
+    resolve_owner,
+)
+
+
+def test_harness_priority_order():
+    assert HARNESS_PRIORITY == ["openclaw", "hermes", "claude", "codex", "this-repo"]
+
+
+def test_resolve_owner_picks_highest_priority_present():
+    assert resolve_owner(["claude", "openclaw"]) == "openclaw"
+    assert resolve_owner(["claude", "codex"]) == "claude"
+    assert resolve_owner(["codex"]) == "codex"
+    assert resolve_owner(["hermes", "claude"]) == "hermes"
+
+
+def test_resolve_owner_empty_selection_returns_this_repo():
+    assert resolve_owner([]) == "this-repo"
+
+
+def test_resolve_owner_explicit_override_wins():
+    assert resolve_owner(["claude", "openclaw"], override="claude") == "claude"
+    assert resolve_owner(["claude"], override="this-repo") == "this-repo"
+
+
+def test_resolve_owner_rejects_override_not_in_selection():
+    with pytest.raises(ValueError, match="not in selected harnesses"):
+        resolve_owner(["claude"], override="openclaw")
+
+
+def test_resolve_owner_accepts_this_repo_override_always():
+    assert resolve_owner(["openclaw"], override="this-repo") == "this-repo"
+
+
+def test_selection_dataclass_holds_fields():
+    sel = Selection(
+        depth="workspace",
+        harnesses=["claude", "codex"],
+        owner="claude",
+        includes=["publisher"],
+    )
+    assert sel.depth == "workspace"
+    assert sel.harnesses == ["claude", "codex"]
+    assert sel.owner == "claude"
+    assert sel.includes == ["publisher"]
+
+
+def test_selection_validate_rejects_unknown_depth():
+    with pytest.raises(ValueError, match="unknown depth"):
+        Selection(depth="weird", harnesses=["claude"], owner="claude", includes=[]).validate()
+
+
+def test_selection_validate_rejects_unknown_harness():
+    with pytest.raises(ValueError, match="unknown harness"):
+        Selection(depth="repo", harnesses=["claude", "weird"], owner="claude", includes=[]).validate()
+
+
+def test_selection_validate_rejects_owner_not_in_harnesses():
+    with pytest.raises(ValueError, match="owner.*not in selected harnesses"):
+        Selection(depth="repo", harnesses=["claude"], owner="openclaw", includes=[]).validate()
+
+
+def test_selection_validate_accepts_this_repo_owner_with_empty_harnesses():
+    Selection(depth="repo", harnesses=[], owner="this-repo", includes=[]).validate()
+
+
+def test_known_constants():
+    assert set(KNOWN_HARNESSES) == {"claude", "codex", "openclaw", "hermes"}
+    assert set(KNOWN_DEPTHS) == {"repo", "workspace"}
+    assert set(KNOWN_INCLUDES) == {"publisher"}


### PR DESCRIPTION
## Summary

v0.3.0 replaces the single-pick profile model with a two-axis selection so users can pick any combination of Claude Code, Codex, OpenClaw, and Hermes. Closes #4.

Three things change:

1. **`solo-mise init` becomes interactive by default.** No flags drops you into a checkbox-style picker (harnesses, depth, includes). Pass `--depth` / `--harnesses` / `--include` to skip the prompt for CI/scripts.
2. **Per-writer handoff inboxes.** Codex gets `.codex/memory-handoffs/`. The ingester scans every configured writer inbox.
3. **`.solo-mise/config.json`** is the per-target source of truth. `doctor`, `ingest`, and the new `reconfigure` subcommand all read it.

`--profile <x>` still works but prints a stderr deprecation note; will be removed in v0.4.0.

## Implementation

Built task-by-task from `docs/plans/2026-05-16-v0.3.0-harness-selection.md` (18 commits in this PR). Design spec at `docs/specs/2026-05-16-v0.3.0-harness-selection-design.md`.

Phases:
- Foundation: `Selection` model + `Config` schema + `profile_to_selection` shim
- Templates: depth, harnesses, includes manifests (existing template files reused, only the codex inbox `TEMPLATE.md` is new on disk)
- Install engine: `install_selection` composes manifests, writes config, manages gitignore
- CLI: `--depth/--harnesses/--owner/--include` flags + `--profile` deprecation shim + interactive prompt + `reconfigure` subcommand
- Surrounding tools: doctor reads config + per-writer inbox checks + orphan warnings; ingester scans configured inboxes
- Polish: README/QUICKSTART/CONTRIBUTING reframed; CHANGELOG entry; CI matrix replaced

## Test plan

- [x] `pytest -q`: **115 passed** (50 prior + 65 new)
- [x] 9-combo local install+doctor smoke (the same matrix CI runs):
  ```
  repo+claude               14 checks, 0 failed
  repo+codex                14 checks, 0 failed
  ws+claude+openclaw        24 checks, 0 failed
  ws+codex+openclaw         24 checks, 0 failed
  kitchen-sink              31 checks, 0 failed, 1 manual (hermes experimental)
  ws+none                   13 checks, 0 failed
  repo+claude+publisher     14 checks, 0 failed
  legacy-workspace          16 checks, 0 failed (deprecation warning fires)
  legacy-openclaw           24 checks, 0 failed (deprecation warning fires)
  ```
- [x] `reconfigure --prune` smoke: claude+codex install -> `reconfigure --harnesses claude --prune` -> `.codex/` removed, config updated
- [x] Non-TTY init guard: bare `init` with stdin redirected from /dev/null returns clean error pointing at flags
- [ ] CI matrix green on this PR
- [ ] After merge: tag v0.3.0, watch publish.yml, verify `pip install solo-mise==0.3.0` (using rotated PyPI token)

## Migration

| v0.2.0 | v0.3.0+ |
|---|---|
| `--profile repo` | `--depth repo --harnesses claude` |
| `--profile workspace` | `--depth workspace --harnesses claude` |
| `--profile openclaw` | `--depth workspace --harnesses claude,openclaw` |
| `--profile hermes` | `--depth workspace --harnesses claude,hermes` |
| `--profile generic` | `--depth workspace --harnesses none` |
| `--profile publisher` | `--depth repo --harnesses claude --include publisher` |

The deprecation warning includes the exact equivalent flags for each invocation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.3.0

* **New Features**
  * Interactive `solo-mise init` for selecting harnesses, depth, and add-ons
  * Two-axis selection model: `--depth` (repo/workspace) + `--harnesses` (claude/codex/openclaw/hermes)
  * New `reconfigure` command with optional harness pruning
  * Multi-writer inbox support with separate memory-handoff directories per harness
  * Enhanced doctor checks for harness configuration validation

* **Deprecations**
  * `--profile` flag deprecated; use `--depth` and `--harnesses` flags instead

* **Documentation**
  * Updated README, QUICKSTART, and contribution guidelines with new selection model examples

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/solomonneas/solo-mise/pull/5?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->