### PR TITLE
Managed stations: brigade add + memory/guard/tokens tools (0.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `content-guard` attached to the `guard` station.
 - New `tokens` station with `tokenjuice` for output compaction.
 - `brigade doctor` folds installed managed tools into its report and surfaces each tool's own health. Tools that are not installed are reported as non-failing `[todo]` hints, so doctor stays green on a bare host.
+- `memory-doctor` and `bootstrap-doctor` inspect the operator's canonical memory and bootstrap files (host-global), so their findings are labeled operator-scoped and treated as advisory `[warn]`, never failing a workspace `brigade doctor` run.
 
 ## [0.5.0] - 2026-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-05-24
+
+### Added
+- Managed tools: external CLIs that Brigade can install and wire per station via `brigade add <station>`. Brigade shells out to each tool, never importing it in process.
+- `memory-doctor` and `bootstrap-doctor` attached to the `memory` station.
+- `content-guard` attached to the `guard` station.
+- New `tokens` station with `tokenjuice` for output compaction.
+- `brigade doctor` folds installed managed tools into its report and surfaces each tool's own health. Tools that are not installed are reported as non-failing `[todo]` hints, so doctor stays green on a bare host.
+
 ## [0.5.0] - 2026-05-24
 
 ### Changed
@@ -115,7 +124,8 @@ Initial release.
 - OpenClaw adapter fragments and harness-aware doctor checks.
 - Experimental Hermes adapter fragments.
 
-[Unreleased]: https://github.com/solomonneas/solo-mise/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/solomonneas/solo-mise/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/solomonneas/solo-mise/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/solomonneas/solo-mise/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/solomonneas/solo-mise/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/solomonneas/solo-mise/compare/v0.2.0...v0.3.0

--- a/README.md
+++ b/README.md
@@ -124,6 +124,27 @@ Re-running `brigade init` against an existing target is safe. It refuses to over
 
 See [QUICKSTART.md](QUICKSTART.md) for setup, verification, and the ingest flow.
 
+## Managed stations
+
+Some stations can install and wire external tools for you. Run `brigade add <station>` to install any tool attached to that station that is not already on your PATH, then wire its default config. Tools are never imported in process; Brigade shells out to each CLI, so the boundary stays model-neutral and mixed-language.
+
+```bash
+brigade add memory   # memory-doctor + bootstrap-doctor
+brigade add guard    # content-guard
+brigade add tokens   # tokenjuice
+```
+
+The four managed tools:
+
+| Station | Tool | What it does |
+|---|---|---|
+| `memory` | `memory-doctor` | memory index health, dead-link lint, handoff counts |
+| `memory` | `bootstrap-doctor` | bootstrap-file size and limit audit |
+| `guard` | `content-guard` | policy-driven content scanning |
+| `tokens` | `tokenjuice` | output compaction via host hooks |
+
+`brigade doctor` folds installed tools into its report and surfaces each tool's own health. A tool that is not installed is never a failure: it shows up as a non-failing `[todo]` hint telling you to run `brigade add <station>`. That keeps doctor green on a bare host while still pointing you at what is available to add.
+
 ### What a green doctor looks like
 
 ```text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "brigade-cli"
-version = "0.5.0"
+version = "0.6.0"
 description = "Run your agent brigade: an operator-system CLI that bootstraps, checks, and operates agent workspaces across harnesses."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/brigade/__init__.py
+++ b/src/brigade/__init__.py
@@ -1,3 +1,3 @@
 """Solomon's Mise en Place: installable starter kit for an agent kitchen."""
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/src/brigade/add.py
+++ b/src/brigade/add.py
@@ -1,0 +1,38 @@
+"""`brigade add <station>` - install and wire a station's managed tools."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from . import doctor as _doctor
+from . import managed
+from .registry import resolve as resolve_station
+
+
+def run(target: Path, station: str) -> int:
+    st = resolve_station(station)
+    if st is None:
+        print(f"error: unknown station {station!r}", file=sys.stderr)
+        return 2
+
+    tools = managed.for_station(st.name)
+    if not tools:
+        print(f"station {st.name!r} has no managed tools to add.")
+        return 0
+
+    ctx = _doctor.build_context(target)
+    rc = 0
+    for tool in tools:
+        if tool.detect():
+            print(f"  [skip] {tool.name} already installed")
+        else:
+            print(f"  [install] {tool.name}: {' '.join(tool.install_args)}")
+            r = managed.proc.run(tool.install_args, timeout=300)
+            if r.code != 0:
+                print(f"  [fail] {tool.name} install exited {r.code}: {r.stderr.strip()[:120]}", file=sys.stderr)
+                rc = 1
+                continue
+        for status, name, detail in tool.wire(ctx):
+            print(f"  [{status.lower()}] {name}: {detail}")
+    print(f"\nRun `brigade doctor --target {target}` to verify.")
+    return rc

--- a/src/brigade/cli.py
+++ b/src/brigade/cli.py
@@ -76,6 +76,11 @@ def _build_parser() -> argparse.ArgumentParser:
     p_status = sub.add_parser("status", help="Show which stations are present and healthy.")
     p_status.add_argument("--target", "-t", type=Path, default=Path("."))
 
+    # add
+    p_add = sub.add_parser("add", help="Install and wire a station's managed tools.")
+    p_add.add_argument("station", help="Station to add tools for (e.g. memory, guard, tokens).")
+    p_add.add_argument("--target", "-t", type=Path, default=Path("."))
+
     # scrub
     p_scrub = sub.add_parser("scrub", help="Run content-guard against a target.")
     p_scrub.add_argument("--target", "-t", type=Path, default=Path("."))
@@ -191,6 +196,10 @@ def main(argv=None) -> int:
         from . import status as status_mod
 
         return status_mod.run(target=args.target)
+    if cmd == "add":
+        from . import add as add_mod
+
+        return add_mod.run(target=args.target, station=args.station)
     if cmd == "scrub":
         from . import scrub as scrub_mod
 

--- a/src/brigade/doctor.py
+++ b/src/brigade/doctor.py
@@ -59,6 +59,10 @@ def guard_station_checks(ctx: DoctorContext) -> List[CheckResult]:
     return _check_publish_gate(ctx.target)
 
 
+def tokens_station_checks(ctx: DoctorContext) -> List[CheckResult]:
+    return []
+
+
 def run(target: Path, harness: str = "generic") -> int:
     from .registry import all_stations
 

--- a/src/brigade/doctor.py
+++ b/src/brigade/doctor.py
@@ -65,6 +65,7 @@ def tokens_station_checks(ctx: DoctorContext) -> List[CheckResult]:
 
 def run(target: Path, harness: str = "generic") -> int:
     from .registry import all_stations
+    from . import managed
 
     ctx = build_context(target, harness)
     print(f"brigade doctor: target {ctx.target}")
@@ -83,6 +84,11 @@ def run(target: Path, harness: str = "generic") -> int:
     for station in all_stations():
         if station.doctor is not None:
             checks.extend(station.doctor(ctx))
+        for tool in managed.for_station(station.name):
+            if tool.detect():
+                checks.extend(tool.doctor(ctx))
+            else:
+                checks.append((MANUAL, f"{station.name}: {tool.name}", f"not installed; run `brigade add {station.name}`"))
     return _report(checks)
 
 

--- a/src/brigade/managed.py
+++ b/src/brigade/managed.py
@@ -1,0 +1,144 @@
+"""Managed tools: external CLIs Brigade can install, wire, and health-check.
+
+Each tool attaches to a station. The core never imports these tools; it shells
+out via brigade.proc. Absent tools are reported as MANUAL (a hint to install),
+never as a hard failure.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, List, Optional, Tuple
+
+from . import proc
+from .doctor import OK, WARN, FAIL, MANUAL
+from .station import CheckResult, DoctorContext
+
+
+@dataclass(frozen=True)
+class ManagedTool:
+    name: str            # e.g. "memory-doctor"
+    station: str         # "memory" | "guard" | "tokens"
+    command: str         # the binary name to detect on PATH
+    summary: str
+    install_args: List[str]                      # argv to install (pipx/npm/pip)
+    wire: Callable[[DoctorContext], List[CheckResult]]   # lay config; returns notes
+    doctor: Callable[[DoctorContext], List[CheckResult]] # health via proc
+
+    def detect(self) -> bool:
+        return proc.which(self.command) is not None
+
+
+# ---- adapters -------------------------------------------------------------
+
+def _noop_wire(ctx: DoctorContext) -> List[CheckResult]:
+    return []
+
+
+def _memory_doctor_doctor(ctx: DoctorContext) -> List[CheckResult]:
+    r = proc.run(["memory-doctor", "status", "--json"])
+    if r.code == 2:
+        return [(WARN, "memory-doctor", "installed but unwired (memory/handoffs dir missing)")]
+    data = r.json()
+    if data is None:
+        return [(WARN, "memory-doctor", f"unexpected output (exit {r.code})")]
+    dead = data.get("dead_links", 0)
+    status = WARN if dead else OK
+    return [(status, "memory-doctor", f"cards={data.get('cards')}, dead_links={dead}, pending={data.get('pending_handoffs')}")]
+
+
+def _bootstrap_doctor_doctor(ctx: DoctorContext) -> List[CheckResult]:
+    r = proc.run(["bootstrap-doctor", "status", "--json"])
+    data = r.json()
+    if data is None:
+        return [(WARN, "bootstrap-doctor", f"installed but unwired or errored (exit {r.code})")]
+    rows = data.get("rows", [])
+    bad = [row for row in rows if row.get("severity") in ("hard", "missing", "unreadable")]
+    soft = [row for row in rows if row.get("severity") == "soft"]
+    if bad:
+        return [(FAIL, "bootstrap-doctor", f"{len(bad)} file(s) over hard limit / missing")]
+    if soft:
+        return [(WARN, "bootstrap-doctor", f"{len(soft)} file(s) in soft band")]
+    return [(OK, "bootstrap-doctor", f"{len(rows)} bootstrap file(s) within limits")]
+
+
+def _content_guard_doctor(ctx: DoctorContext) -> List[CheckResult]:
+    # A "tool present + policy loads" check: scan this plan's own clean string.
+    r = proc.run(["content-guard", "scan", "--policy", "public-repo", "--json"], env=None)
+    data = r.json()
+    if data is None and r.code not in (0, 1):
+        return [(WARN, "content-guard", f"installed but not runnable (exit {r.code})")]
+    return [(OK, "content-guard", "installed; public-repo policy loads")]
+
+
+def _content_guard_wire(ctx: DoctorContext) -> List[CheckResult]:
+    # content-guard ships bundled policies; nothing to lay down for the default.
+    return [(OK, "content-guard: policy", "using bundled public-repo policy")]
+
+
+def _tokenjuice_doctor(ctx: DoctorContext) -> List[CheckResult]:
+    r = proc.run(["tokenjuice", "doctor", "hooks", "--format", "json"])
+    data = r.json()
+    if data is None:
+        return [(WARN, "tokenjuice", f"installed but doctor output unreadable (exit {r.code})")]
+    status = data.get("status", "unknown")
+    mapping = {"ok": OK, "warn": WARN, "disabled": MANUAL, "broken": FAIL}
+    return [(mapping.get(status, WARN), "tokenjuice", f"hook status: {status}")]
+
+
+def _tokenjuice_wire(ctx: DoctorContext) -> List[CheckResult]:
+    # Wiring installs a host hook; which host depends on the workspace's harnesses.
+    hosts = [h for h in ctx.harnesses if h in ("claude", "codex", "cursor")]
+    if not hosts:
+        return [(MANUAL, "tokenjuice: wire", "no hookable harness selected; run `tokenjuice install <host>` manually")]
+    notes: List[CheckResult] = []
+    for h in hosts:
+        host = "claude-code" if h == "claude" else h
+        r = proc.run(["tokenjuice", "install", host])
+        notes.append((OK if r.code == 0 else WARN, f"tokenjuice: install {host}", r.stderr.strip()[:80] or "installed"))
+    return notes
+
+
+# ---- registry -------------------------------------------------------------
+
+_TOOLS: Tuple[ManagedTool, ...] = (
+    ManagedTool(
+        name="memory-doctor", station="memory", command="memory-doctor",
+        summary="memory index health, dead-link lint, handoff counts",
+        install_args=["pipx", "install", "git+https://github.com/solomonneas/memory-doctor"],
+        wire=_noop_wire, doctor=_memory_doctor_doctor,
+    ),
+    ManagedTool(
+        name="bootstrap-doctor", station="memory", command="bootstrap-doctor",
+        summary="bootstrap-file size/limit audit",
+        install_args=["pipx", "install", "git+https://github.com/solomonneas/bootstrap-doctor"],
+        wire=_noop_wire, doctor=_bootstrap_doctor_doctor,
+    ),
+    ManagedTool(
+        name="content-guard", station="guard", command="content-guard",
+        summary="policy-driven content scanning",
+        install_args=["pipx", "install", "git+https://github.com/solomonneas/content-guard"],
+        wire=_content_guard_wire, doctor=_content_guard_doctor,
+    ),
+    ManagedTool(
+        name="tokenjuice", station="tokens", command="tokenjuice",
+        summary="output compaction via host hooks",
+        install_args=["npm", "install", "-g", "tokenjuice"],
+        wire=_tokenjuice_wire, doctor=_tokenjuice_doctor,
+    ),
+)
+
+
+def all_tools() -> Tuple[ManagedTool, ...]:
+    return _TOOLS
+
+
+def for_station(station: str) -> Tuple[ManagedTool, ...]:
+    return tuple(t for t in _TOOLS if t.station == station)
+
+
+def resolve(name: str) -> Optional[ManagedTool]:
+    for t in _TOOLS:
+        if t.name == name:
+            return t
+    return None

--- a/src/brigade/managed.py
+++ b/src/brigade/managed.py
@@ -35,31 +35,36 @@ def _noop_wire(ctx: DoctorContext) -> List[CheckResult]:
     return []
 
 
+# memory-doctor and bootstrap-doctor inspect the operator's canonical memory and
+# bootstrap files (host-global), not a per-target workspace, so their findings are
+# advisory: labeled operator-scoped and never FAIL a workspace doctor run.
 def _memory_doctor_doctor(ctx: DoctorContext) -> List[CheckResult]:
+    name = "memory-doctor (operator memory)"
     r = proc.run(["memory-doctor", "status", "--json"])
     if r.code == 2:
-        return [(WARN, "memory-doctor", "installed but unwired (memory/handoffs dir missing)")]
+        return [(WARN, name, "installed but unwired (memory/handoffs dir missing)")]
     data = r.json()
     if data is None:
-        return [(WARN, "memory-doctor", f"unexpected output (exit {r.code})")]
+        return [(WARN, name, f"unexpected output (exit {r.code})")]
     dead = data.get("dead_links", 0)
     status = WARN if dead else OK
-    return [(status, "memory-doctor", f"cards={data.get('cards')}, dead_links={dead}, pending={data.get('pending_handoffs')}")]
+    return [(status, name, f"cards={data.get('cards')}, dead_links={dead}, pending={data.get('pending_handoffs')}")]
 
 
 def _bootstrap_doctor_doctor(ctx: DoctorContext) -> List[CheckResult]:
+    name = "bootstrap-doctor (operator files)"
     r = proc.run(["bootstrap-doctor", "status", "--json"])
     data = r.json()
     if data is None:
-        return [(WARN, "bootstrap-doctor", f"installed but unwired or errored (exit {r.code})")]
+        return [(WARN, name, f"installed but unwired or errored (exit {r.code})")]
     rows = data.get("rows", [])
     bad = [row for row in rows if row.get("severity") in ("hard", "missing", "unreadable")]
     soft = [row for row in rows if row.get("severity") == "soft"]
     if bad:
-        return [(FAIL, "bootstrap-doctor", f"{len(bad)} file(s) over hard limit / missing")]
+        return [(WARN, name, f"{len(bad)} file(s) over hard limit / missing (advisory)")]
     if soft:
-        return [(WARN, "bootstrap-doctor", f"{len(soft)} file(s) in soft band")]
-    return [(OK, "bootstrap-doctor", f"{len(rows)} bootstrap file(s) within limits")]
+        return [(WARN, name, f"{len(soft)} file(s) in soft band")]
+    return [(OK, name, f"{len(rows)} bootstrap file(s) within limits")]
 
 
 def _content_guard_doctor(ctx: DoctorContext) -> List[CheckResult]:

--- a/src/brigade/proc.py
+++ b/src/brigade/proc.py
@@ -1,0 +1,37 @@
+"""Run external tool CLIs and capture their results. No tool is imported in-process."""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from dataclasses import dataclass
+from typing import List, Optional
+
+
+@dataclass
+class Result:
+    code: int
+    stdout: str
+    stderr: str
+
+    def json(self) -> Optional[object]:
+        try:
+            return json.loads(self.stdout)
+        except (json.JSONDecodeError, ValueError):
+            return None
+
+
+def which(cmd: str) -> Optional[str]:
+    return shutil.which(cmd)
+
+
+def run(args: List[str], timeout: float = 30.0, env: Optional[dict] = None) -> Result:
+    try:
+        cp = subprocess.run(
+            args, capture_output=True, text=True, timeout=timeout, env=env, check=False
+        )
+        return Result(code=cp.returncode, stdout=cp.stdout, stderr=cp.stderr)
+    except FileNotFoundError:
+        return Result(code=127, stdout="", stderr=f"command not found: {args[0]}")
+    except subprocess.TimeoutExpired:
+        return Result(code=124, stdout="", stderr=f"timeout after {timeout}s")

--- a/src/brigade/registry.py
+++ b/src/brigade/registry.py
@@ -17,15 +17,24 @@ MEMORY = Station(
     summary="handoff inbox, ingest, and memory-care",
     aliases=("garde",),
     doctor=_doctor.memory_station_checks,
+    tools=("memory-doctor", "bootstrap-doctor"),
 )
 GUARD = Station(
     name="guard",
     summary="publish safety and content scrub",
     aliases=("pass",),
     doctor=_doctor.guard_station_checks,
+    tools=("content-guard",),
+)
+TOKENS = Station(
+    name="tokens",
+    summary="output compaction",
+    aliases=(),
+    doctor=_doctor.tokens_station_checks,
+    tools=("tokenjuice",),
 )
 
-_BUILTIN: Tuple[Station, ...] = (CORE, MEMORY, GUARD)
+_BUILTIN: Tuple[Station, ...] = (CORE, MEMORY, GUARD, TOKENS)
 
 
 def all_stations() -> Tuple[Station, ...]:

--- a/src/brigade/station.py
+++ b/src/brigade/station.py
@@ -31,6 +31,7 @@ class Station:
     doctor: Optional[Callable[[DoctorContext], List[CheckResult]]]
     aliases: Tuple[str, ...] = ()
     kind: str = "builtin"
+    tools: Tuple[str, ...] = ()
 
     def matches(self, name_or_alias: str) -> bool:
         return name_or_alias == self.name or name_or_alias in self.aliases

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,3 +5,22 @@ import pytest
 def tmp_target(tmp_path):
     """Return a clean temp directory to act as a workspace target."""
     return tmp_path / "ws"
+
+
+@pytest.fixture(autouse=True)
+def _no_managed_tools_on_path(monkeypatch, request):
+    """Default to the bare-host baseline: no managed tool detected on PATH.
+
+    The doctor folds in installed managed tools, but a dev host may have some
+    of them globally installed. Neutralize detection so checks assert against
+    the documented bare-`$HOME` condition. Tests that exercise installed tools
+    re-patch `managed.proc.which` in their own body, which overrides this.
+
+    `tests/test_proc.py` validates `proc.which` against real binaries, so it
+    opts out (patching `managed.proc.which` would patch the same function).
+    """
+    if request.module.__name__.rsplit(".", 1)[-1] == "test_proc":
+        return
+    from brigade import managed
+
+    monkeypatch.setattr(managed.proc, "which", lambda cmd: None)

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -1,0 +1,42 @@
+# tests/test_add.py
+from pathlib import Path
+
+from brigade import add as add_mod
+from brigade import managed
+
+
+def test_add_installs_and_wires_station_tools(monkeypatch, tmp_target, capsys):
+    calls = []
+    monkeypatch.setattr(managed.proc, "which", lambda c: None)  # not yet installed
+
+    def fake_run(args, **kw):
+        calls.append(args)
+        return managed.proc.Result(0, "", "")
+
+    monkeypatch.setattr(managed.proc, "run", fake_run)
+    rc = add_mod.run(target=tmp_target, station="guard")
+    out = capsys.readouterr().out
+    assert rc == 0
+    # content-guard install args were invoked
+    assert any("content-guard" in " ".join(a) for a in calls)
+    assert "content-guard" in out
+
+
+def test_add_unknown_station_errors(tmp_target, capsys):
+    rc = add_mod.run(target=tmp_target, station="nope")
+    assert rc == 2
+    assert "unknown station" in capsys.readouterr().err.lower()
+
+
+def test_add_skips_install_when_already_present(monkeypatch, tmp_target):
+    calls = []
+    monkeypatch.setattr(managed.proc, "which", lambda c: "/x/" + c)  # already installed
+
+    def fake_run(args, **kw):
+        calls.append(args)
+        return managed.proc.Result(0, "", "")
+
+    monkeypatch.setattr(managed.proc, "run", fake_run)
+    add_mod.run(target=tmp_target, station="guard")
+    # no install argv (pipx/npm) should have run, only wire
+    assert not any(a[:1] in (["pipx"], ["npm"], ["pip"]) for a in calls)

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -210,3 +210,32 @@ def test_doctor_falls_back_to_v0_2_behavior_when_no_config(tmp_target: Path, cap
     doctor_mod.run(tmp_target)
     out = capsys.readouterr().out
     assert "doctor" in out
+
+
+def test_doctor_includes_installed_managed_tool(monkeypatch, tmp_target, capsys):
+    from brigade.install import install_selection
+    from brigade.selection import Selection
+    from brigade import managed
+    install_selection(tmp_target, Selection(depth="workspace", harnesses=["claude"], owner="claude", includes=[]))
+
+    # Pretend content-guard is installed and healthy.
+    monkeypatch.setattr(managed.proc, "which", lambda c: "/x/" + c if c == "content-guard" else None)
+    monkeypatch.setattr(managed.proc, "run", lambda args, **kw: managed.proc.Result(0, '{"ok": true}', ""))
+
+    doctor_mod.run(target=tmp_target, harness="generic")
+    out = capsys.readouterr().out
+    assert "content-guard" in out
+
+
+def test_doctor_reports_absent_tool_as_manual(monkeypatch, tmp_target, capsys):
+    from brigade.install import install_selection
+    from brigade.selection import Selection
+    from brigade import managed
+    install_selection(tmp_target, Selection(depth="workspace", harnesses=["claude"], owner="claude", includes=[]))
+    monkeypatch.setattr(managed.proc, "which", lambda c: None)  # nothing installed
+
+    rc = doctor_mod.run(target=tmp_target, harness="generic")
+    out = capsys.readouterr().out
+    # absent managed tools must not fail the run
+    assert rc == 0
+    assert "not installed" in out

--- a/tests/test_managed.py
+++ b/tests/test_managed.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+from brigade import managed
+from brigade.station import DoctorContext
+
+
+def test_all_tools_declare_required_fields():
+    for t in managed.all_tools():
+        assert t.name and t.station and t.command
+        assert callable(t.doctor)
+        assert callable(t.wire)
+        assert isinstance(t.install_args, list) and t.install_args
+
+
+def test_tools_attach_to_known_stations():
+    stations = {t.station for t in managed.all_tools()}
+    assert stations <= {"memory", "guard", "tokens"}
+
+
+def test_for_station_filters():
+    names = {t.name for t in managed.for_station("memory")}
+    assert names == {"memory-doctor", "bootstrap-doctor"}
+
+
+def test_detect_uses_which(monkeypatch):
+    t = managed.resolve("content-guard")
+    monkeypatch.setattr(managed.proc, "which", lambda c: None)
+    assert t.detect() is False
+    monkeypatch.setattr(managed.proc, "which", lambda c: "/usr/bin/" + c)
+    assert t.detect() is True
+
+
+def test_memory_doctor_doctor_parses_status(monkeypatch):
+    t = managed.resolve("memory-doctor")
+    monkeypatch.setattr(managed.proc, "which", lambda c: "/x/" + c)
+
+    def fake_run(args, **kw):
+        return managed.proc.Result(code=0, stdout='{"cards": 4, "dead_links": 0, "pending_handoffs": 1}', stderr="")
+
+    monkeypatch.setattr(managed.proc, "run", fake_run)
+    ctx = DoctorContext(target=Path("/tmp/ws"), selection=None, harnesses=[])
+    results = t.doctor(ctx)
+    assert any(status == "OK" and "memory-doctor" in name for status, name, _ in results)
+
+
+def test_tokenjuice_doctor_reads_status_field_not_exit(monkeypatch):
+    t = managed.resolve("tokenjuice")
+    monkeypatch.setattr(managed.proc, "which", lambda c: "/x/" + c)
+
+    def fake_run(args, **kw):
+        # exit 0 but status warn -> must surface as WARN, not OK
+        return managed.proc.Result(code=0, stdout='{"status": "warn", "integrations": {}}', stderr="")
+
+    monkeypatch.setattr(managed.proc, "run", fake_run)
+    ctx = DoctorContext(target=Path("/tmp/ws"), selection=None, harnesses=[])
+    results = t.doctor(ctx)
+    assert any(status == "WARN" for status, _, _ in results)

--- a/tests/test_proc.py
+++ b/tests/test_proc.py
@@ -1,0 +1,22 @@
+from brigade import proc
+
+
+def test_run_captures_exit_and_output():
+    r = proc.run(["python3", "-c", "import sys; print('hi'); sys.exit(3)"])
+    assert r.code == 3
+    assert r.stdout.strip() == "hi"
+
+
+def test_run_json_parses_stdout():
+    r = proc.run(["python3", "-c", "print('{\"a\": 1}')"])
+    assert r.json() == {"a": 1}
+
+
+def test_run_json_returns_none_on_nonjson():
+    r = proc.run(["python3", "-c", "print('not json')"])
+    assert r.json() is None
+
+
+def test_which_detects_present_and_absent():
+    assert proc.which("python3") is not None
+    assert proc.which("definitely-not-a-real-binary-xyz") is None

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -16,3 +16,13 @@ def test_resolve_by_name_and_alias():
     assert registry.resolve("garde").name == "memory"
     assert registry.resolve("pass").name == "guard"
     assert registry.resolve("nope") is None
+
+
+def test_stations_declare_attached_tools():
+    from brigade import registry
+    memory = registry.resolve("memory")
+    guard = registry.resolve("guard")
+    tokens = registry.resolve("tokens")
+    assert set(memory.tools) == {"memory-doctor", "bootstrap-doctor"}
+    assert set(guard.tools) == {"content-guard"}
+    assert tokens is not None and set(tokens.tools) == {"tokenjuice"}


### PR DESCRIPTION
## Summary
- Add a `proc` helper and a `ManagedTool` contract so Brigade can install, wire, and health-check external CLIs by shelling out (never importing them).
- Attach managed tools to stations: `memory-doctor` + `bootstrap-doctor` (memory), `content-guard` (guard), and a new `tokens` station with `tokenjuice`.
- `brigade add <station>` installs + wires a station's tools; `brigade doctor` folds installed tools into its report (absent tools are non-failing `[todo]` hints).
- `memory-doctor` / `bootstrap-doctor` inspect operator-global memory/bootstrap files, so they are labeled operator-scoped and treated as advisory `[warn]`, never failing a workspace doctor run.

## Test plan
- [x] `pytest` green (130 passing)
- [x] live `brigade doctor` folds in installed tools, operator-scoped advisories, exits 0
- [x] `brigade add <unknown>` exits 2 without installing