### PR TITLE
feat: add brigade work status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `brigade runs list` to print recent run artifact directories from `.brigade/runs`.
 - `brigade runs latest` to show the newest run summary without copying a run path from `brigade runs list`.
 - `brigade runs show <run-dir>` to print a readable summary of one run artifact directory.
+- `brigade work status` to report the current repo branch, dirty files, dogfood readiness, latest run, and extracted next step for daily work sessions.
 - Roster-level and per-agent `timeout_seconds` controls for bounded CLI calls.
 - `brigade run --read-only` prompt policy for planning and review runs that should inspect and recommend only, with native `codex exec --sandbox read-only` enforcement for Codex agents.
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ brigade dogfood status
 brigade dogfood
 brigade dogfood next
 brigade dogfood --target /path/to/repo
+brigade work status
 ```
 
 `--dry-run` prints the planned assignments as JSON and stops before worker dispatch. `--show-plan` prints assignments before a normal run. `--verbose` prints the plan, worker statuses, and synthesis status. `--cwd` sets the working directory for the agent CLI calls and defaults to the current directory. `--handoff` writes a Memory Handoff for a successful non-dry run. `--inspect` prints the same readable artifact summary as `brigade runs show` after the run completes. `--read-only` tells the orchestrator and workers to inspect and recommend only, without modifying files or external state. For `codex` agents, Brigade also passes `codex exec --sandbox read-only`; other adapters receive the prompt policy only. The `cli` values are adapters for installed command-line tools: `codex`, `claude`, and `ollama:<model>`. Pick the ones you already use. Brigade shells out to those tools and keeps no provider keys. `brigade roster doctor` validates the roster syntax and reports which CLIs are present on `PATH`.
@@ -154,6 +155,8 @@ CLI runs write artifacts by default under `.brigade/runs/<id>` below `--cwd`; do
 | `summary.md` | dogfood summary with run metadata, final answer, and extracted next step when present |
 
 Use `--output-dir <path>` to pick the artifact directory, or `--no-artifacts` for a throwaway run.
+
+Use `brigade work status` as the quick daily dashboard for a repo. It reports the current branch, dirty files, dogfood readiness, configured dogfood paths, latest dogfood run, and extracted next step without starting a new orchestration.
 
 Inspect a completed run without opening each JSON file:
 

--- a/src/brigade/cli.py
+++ b/src/brigade/cli.py
@@ -107,6 +107,14 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p_dogfood.add_argument("--timeout-seconds", type=float, default=DEFAULT_TIMEOUT_SECONDS, help="Per-agent timeout.")
 
+    # work
+    p_work = sub.add_parser("work", help="Inspect and manage a daily Brigade work session.")
+    work_sub = p_work.add_subparsers(dest="work_command", metavar="<work-command>")
+    work_sub.required = True
+    p_work_status = work_sub.add_parser("status", help="Show current repo and dogfood work state.")
+    p_work_status.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
+    p_work_status.add_argument("--limit", type=int, default=12, help="Maximum dirty file entries to show.")
+
     # run
     p_run = sub.add_parser("run", help="Run a bounded cross-model orchestration task.")
     p_run.add_argument("task", help="Task for the aboyeur to plan, dispatch, and synthesize.")
@@ -373,6 +381,13 @@ def main(argv=None) -> int:
             native_read_only_sandbox=args.native_read_only_sandbox,
             timeout_seconds=args.timeout_seconds,
         )
+    if cmd == "work":
+        from . import work_cmd
+
+        if args.work_command == "status":
+            return work_cmd.status(target=args.target, limit=args.limit)
+        parser.error(f"unknown work command: {args.work_command}")
+        return 2
     if cmd == "run":
         from . import aboyeur as aboyeur_mod
         from . import roster as roster_mod

--- a/src/brigade/work_cmd.py
+++ b/src/brigade/work_cmd.py
@@ -1,0 +1,107 @@
+"""Daily work session helpers."""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from . import dogfood_cmd
+
+
+def _git(target: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(target), *args],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def _git_value(target: Path, *args: str) -> str | None:
+    result = _git(target, *args)
+    if result.returncode != 0:
+        return None
+    value = result.stdout.strip()
+    return value or None
+
+
+def _short(text: str, limit: int = 96) -> str:
+    rendered = " ".join(text.split())
+    if len(rendered) <= limit:
+        return rendered
+    return rendered[: limit - 3].rstrip() + "..."
+
+
+def _print_dirty(lines: list[str], *, limit: int) -> None:
+    print(f"dirty_files: {len(lines)}")
+    for line in lines[:limit]:
+        print(f"  {line}")
+    remaining = len(lines) - limit
+    if remaining > 0:
+        print(f"  ... {remaining} more")
+
+
+def status(*, target: Path, limit: int = 12) -> int:
+    if limit < 1:
+        print("error: --limit must be a positive integer", file=sys.stderr)
+        return 2
+
+    target = target.expanduser().resolve()
+    if not target.is_dir():
+        print(f"error: --target is not a directory: {target}", file=sys.stderr)
+        return 2
+
+    print(f"work: {target}")
+    repo_root = _git_value(target, "rev-parse", "--show-toplevel")
+    if repo_root is None:
+        print("git: unavailable")
+    else:
+        print(f"repo: {repo_root}")
+        branch = _git_value(target, "branch", "--show-current")
+        if branch is None:
+            branch = _git_value(target, "rev-parse", "--short", "HEAD") or "unknown"
+            branch = f"detached:{branch}"
+        print(f"branch: {branch}")
+        status_out = _git_value(target, "status", "--short") or ""
+        _print_dirty(status_out.splitlines(), limit=limit)
+
+    try:
+        effective_target, artifacts_dir, cfg = dogfood_cmd._load_effective_paths(target)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"dogfood: not ready ({exc})")
+        return 0
+
+    config = dogfood_cmd.config_path(target)
+    codex_path = shutil.which("codex")
+    dogfood_ready = config.exists() and codex_path is not None and effective_target.is_dir()
+    print(f"dogfood: {'ready' if dogfood_ready else 'not ready'}")
+    print(f"dogfood_config: {config if config.exists() else str(config) + ' (missing)'}")
+    print(f"dogfood_target: {effective_target}")
+    print(f"dogfood_artifacts: {artifacts_dir}")
+    print(f"codex: {codex_path or 'missing'}")
+    if cfg and cfg.handoff:
+        handoff_inbox = cfg.handoff_inbox or effective_target / ".claude" / "memory-handoffs"
+        print(f"handoff_inbox: {handoff_inbox}")
+
+    latest = dogfood_cmd._latest_run(artifacts_dir)
+    if latest is None:
+        print("latest_run: none")
+        print("next: none")
+        return 0
+
+    latest_path, latest_meta = latest
+    print(
+        "latest_run: "
+        f"{latest_meta.get('started_at', latest_path.name)} "
+        f"[{latest_meta.get('status', 'unknown')}] {latest_path}"
+    )
+    task = _short(str(latest_meta.get("task") or ""))
+    if task:
+        print(f"latest_task: {task}")
+    next_step = dogfood_cmd.extract_next_step(dogfood_cmd._read_final(latest_path))
+    print(f"next: {_short(next_step) if next_step else 'none'}")
+    print("next_command: brigade dogfood next")
+    print("inspect_command: brigade dogfood latest")
+    return 0

--- a/tests/test_work_cmd.py
+++ b/tests/test_work_cmd.py
@@ -1,0 +1,81 @@
+import json
+import subprocess
+
+from brigade import cli
+from brigade import dogfood_cmd
+from brigade import work_cmd
+
+
+def _write_json(path, payload):
+    path.write_text(json.dumps(payload, indent=2) + "\n")
+
+
+def _init_git_repo(path):
+    subprocess.run(["git", "init"], cwd=path, check=True, stdout=subprocess.DEVNULL)
+
+
+def test_work_status_reports_repo_and_dogfood_state(tmp_path, monkeypatch, capsys):
+    _init_git_repo(tmp_path)
+    (tmp_path / "changed.txt").write_text("work\n")
+    dogfood_cmd.init(target=tmp_path, timeout_seconds=33)
+    run_dir = tmp_path / ".brigade" / "runs" / "latest"
+    run_dir.mkdir(parents=True)
+    _write_json(
+        run_dir / "run.json",
+        {
+            "started_at": "2026-05-26T12:00:00Z",
+            "status": "ok",
+            "task": "review current work",
+        },
+    )
+    (run_dir / "final.txt").write_text("Done.\n\nNext step: Build work start.\n")
+    monkeypatch.setattr(work_cmd.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    assert work_cmd.status(target=tmp_path) == 0
+    out = capsys.readouterr().out
+    assert f"work: {tmp_path.resolve()}" in out
+    assert "repo:" in out
+    assert "branch:" in out
+    assert "dirty_files:" in out
+    assert "?? changed.txt" in out
+    assert "dogfood: ready" in out
+    assert f"dogfood_config: {tmp_path / '.brigade' / 'dogfood.toml'}" in out
+    assert "codex: /usr/bin/codex" in out
+    assert "latest_run: 2026-05-26T12:00:00Z [ok]" in out
+    assert "latest_task: review current work" in out
+    assert "next: Build work start." in out
+    assert "next_command: brigade dogfood next" in out
+
+
+def test_work_status_runs_without_dogfood_config(tmp_path, monkeypatch, capsys):
+    _init_git_repo(tmp_path)
+    monkeypatch.setattr(work_cmd.shutil, "which", lambda name: None)
+
+    assert work_cmd.status(target=tmp_path) == 0
+    out = capsys.readouterr().out
+    assert "dogfood: not ready" in out
+    assert "dogfood_config:" in out
+    assert "(missing)" in out
+    assert "codex: missing" in out
+    assert "latest_run: none" in out
+    assert "next: none" in out
+
+
+def test_work_status_rejects_bad_limit(tmp_path, capsys):
+    tmp_path.mkdir(exist_ok=True)
+
+    assert work_cmd.status(target=tmp_path, limit=0) == 2
+    assert "--limit must be a positive integer" in capsys.readouterr().err
+
+
+def test_work_status_cli(tmp_path, monkeypatch):
+    seen = {}
+
+    def fake_status(**kwargs):
+        seen.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(work_cmd, "status", fake_status)
+
+    assert cli.main(["work", "status", "--target", str(tmp_path), "--limit", "3"]) == 0
+    assert seen == {"target": tmp_path, "limit": 3}


### PR DESCRIPTION
## Summary
- add the new `brigade work status` daily dashboard command
- report git branch, dirty files, dogfood readiness, latest run, and extracted next step
- document the work status command and add focused tests

## Verification
- `.venv/bin/brigade work status`
- `.venv/bin/python -m pytest tests/test_work_cmd.py tests/test_dogfood_cmd.py tests/test_runs_cmd.py tests/test_run_cli.py -q` -> 41 passed
- `.venv/bin/python -m pytest -q` -> 217 passed
- `PYTHONPATH=$HOME/repos/content-guard/src python3 -m content_guard scan . --policy $HOME/repos/content-guard/policies/public-repo.json` -> Clean. 60 file(s) checked.