### PR TITLE
feat: inspect brigade work sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `brigade work status` to report the current repo branch, dirty files, dogfood readiness, latest run, and extracted next step for daily work sessions.
 - `brigade work start` and `brigade work end` to create local `.brigade/work/` session artifacts for normal daily work loops.
 - `brigade work end --handoff` to write a Memory Handoff from closed work session artifacts.
+- `brigade work list`, `brigade work latest`, and `brigade work show` to inspect local work session artifacts.
 - Roster-level and per-agent `timeout_seconds` controls for bounded CLI calls.
 - `brigade run --read-only` prompt policy for planning and review runs that should inspect and recommend only, with native `codex exec --sandbox read-only` enforcement for Codex agents.
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ brigade dogfood --target /path/to/repo
 brigade work status
 brigade work start "next slice"
 brigade work end --note "tests passed" --handoff
+brigade work list
+brigade work latest
 ```
 
 `--dry-run` prints the planned assignments as JSON and stops before worker dispatch. `--show-plan` prints assignments before a normal run. `--verbose` prints the plan, worker statuses, and synthesis status. `--cwd` sets the working directory for the agent CLI calls and defaults to the current directory. `--handoff` writes a Memory Handoff for a successful non-dry run. `--inspect` prints the same readable artifact summary as `brigade runs show` after the run completes. `--read-only` tells the orchestrator and workers to inspect and recommend only, without modifying files or external state. For `codex` agents, Brigade also passes `codex exec --sandbox read-only`; other adapters receive the prompt policy only. The `cli` values are adapters for installed command-line tools: `codex`, `claude`, and `ollama:<model>`. Pick the ones you already use. Brigade shells out to those tools and keeps no provider keys. `brigade roster doctor` validates the roster syntax and reports which CLIs are present on `PATH`.
@@ -159,6 +161,8 @@ CLI runs write artifacts by default under `.brigade/runs/<id>` below `--cwd`; do
 Use `--output-dir <path>` to pick the artifact directory, or `--no-artifacts` for a throwaway run.
 
 Use `brigade work status` as the quick daily dashboard for a repo. It reports the current branch, dirty files, dogfood readiness, configured dogfood paths, latest dogfood run, and extracted next step without starting a new orchestration. `brigade work start "title"` opens a local work session under `.brigade/work/<id>/`, records the starting git and dogfood context, and writes `start.md`. `brigade work end --note "what happened"` closes the active session, records ending context, and writes `end.md`. Add `--handoff` to also write a Memory Handoff for the closed session; it defaults to the configured dogfood handoff inbox or `.claude/memory-handoffs`.
+
+Inspect local work sessions with `brigade work list`, `brigade work latest`, or `brigade work show <session-id-or-path>`.
 
 Inspect a completed run without opening each JSON file:
 

--- a/src/brigade/cli.py
+++ b/src/brigade/cli.py
@@ -114,6 +114,14 @@ def _build_parser() -> argparse.ArgumentParser:
     p_work_status = work_sub.add_parser("status", help="Show current repo and dogfood work state.")
     p_work_status.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
     p_work_status.add_argument("--limit", type=int, default=12, help="Maximum dirty file entries to show.")
+    p_work_list = work_sub.add_parser("list", help="List recent Brigade work sessions.")
+    p_work_list.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
+    p_work_list.add_argument("--limit", type=int, default=10, help="Maximum sessions to show.")
+    p_work_latest = work_sub.add_parser("latest", help="Show the latest Brigade work session.")
+    p_work_latest.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
+    p_work_show = work_sub.add_parser("show", help="Show one Brigade work session.")
+    p_work_show.add_argument("session", help="Session id or path.")
+    p_work_show.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
     p_work_start = work_sub.add_parser("start", help="Start a local Brigade work session.")
     p_work_start.add_argument("title", nargs="*", help="Optional session title.")
     p_work_start.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace for the session.")
@@ -400,6 +408,12 @@ def main(argv=None) -> int:
 
         if args.work_command == "status":
             return work_cmd.status(target=args.target, limit=args.limit)
+        if args.work_command == "list":
+            return work_cmd.list_sessions(target=args.target, limit=args.limit)
+        if args.work_command == "latest":
+            return work_cmd.latest(target=args.target)
+        if args.work_command == "show":
+            return work_cmd.show(target=args.target, session=args.session)
         if args.work_command == "start":
             title = " ".join(args.title) if args.title else None
             return work_cmd.start(target=args.target, title=title, force=args.force)

--- a/src/brigade/work_cmd.py
+++ b/src/brigade/work_cmd.py
@@ -112,6 +112,90 @@ def _write_json(path: Path, payload: dict[str, Any]) -> None:
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
 
 
+def _read_session(path: Path) -> dict[str, Any] | None:
+    try:
+        payload = json.loads((path / "session.json").read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _session_sort_key(item: tuple[Path, dict[str, Any]]) -> str:
+    path, payload = item
+    return str(payload.get("ended_at") or payload.get("started_at") or path.name)
+
+
+def _collect_sessions(root: Path) -> tuple[list[tuple[Path, dict[str, Any]]], int]:
+    sessions: list[tuple[Path, dict[str, Any]]] = []
+    skipped = 0
+    if not root.is_dir():
+        return sessions, skipped
+    for child in root.iterdir():
+        if not child.is_dir():
+            continue
+        payload = _read_session(child)
+        if payload is None:
+            skipped += 1
+            continue
+        sessions.append((child, payload))
+    sessions.sort(key=_session_sort_key, reverse=True)
+    return sessions, skipped
+
+
+def _resolve_session(target: Path, session: str | Path) -> Path:
+    candidate = Path(session).expanduser()
+    if candidate.is_dir():
+        return candidate
+    return _work_root(target) / str(session)
+
+
+def _dirty_count(snapshot: dict[str, Any]) -> int:
+    git = snapshot.get("git")
+    if not isinstance(git, dict):
+        return 0
+    dirty = git.get("dirty_files")
+    return len(dirty) if isinstance(dirty, list) else 0
+
+
+def _display_session(path: Path, payload: dict[str, Any]) -> None:
+    print(f"session: {path}")
+    print(f"id: {payload.get('id', path.name)}")
+    print(f"status: {payload.get('status', 'unknown')}")
+    if payload.get("title"):
+        print(f"title: {payload['title']}")
+    print(f"target: {payload.get('target', '')}")
+    print(f"started: {payload.get('started_at', '')}")
+    if payload.get("ended_at"):
+        print(f"ended: {payload['ended_at']}")
+    if payload.get("note"):
+        print(f"note: {payload['note']}")
+    if payload.get("handoff"):
+        print(f"handoff: {payload['handoff']}")
+
+    start_snapshot = payload.get("start") if isinstance(payload.get("start"), dict) else {}
+    end_snapshot = payload.get("end") if isinstance(payload.get("end"), dict) else {}
+    snapshot = end_snapshot or start_snapshot
+    git = snapshot.get("git") if isinstance(snapshot, dict) else {}
+    if isinstance(git, dict) and git.get("available"):
+        print("git:")
+        print(f"  branch: {git.get('branch')}")
+        dirty = git.get("dirty_files") if isinstance(git.get("dirty_files"), list) else []
+        print(f"  dirty_files: {len(dirty)}")
+        for item in dirty[:20]:
+            print(f"    {item}")
+    dogfood = snapshot.get("dogfood") if isinstance(snapshot, dict) else {}
+    if isinstance(dogfood, dict):
+        print("dogfood:")
+        print(f"  ready: {dogfood.get('ready')}")
+        latest = dogfood.get("latest_run")
+        if isinstance(latest, dict):
+            print(f"  latest_run: {latest.get('started_at')} [{latest.get('status')}] {latest.get('path')}")
+            if latest.get("task"):
+                print(f"  latest_task: {_short(str(latest['task']))}")
+        if dogfood.get("next"):
+            print(f"  next: {_short(str(dogfood['next']))}")
+
+
 def _write_session_markdown(path: Path, *, title: str, payload: dict[str, Any], key: str) -> None:
     snapshot = payload[key]
     git = snapshot.get("git", {})
@@ -316,6 +400,68 @@ def end(*, target: Path, note: str | None = None, handoff: bool = False, handoff
     if handoff:
         print(f"handoff: {payload['handoff']}")
     print("status: ended")
+    return 0
+
+
+def list_sessions(*, target: Path, limit: int = 10) -> int:
+    if limit < 1:
+        print("error: --limit must be a positive integer", file=sys.stderr)
+        return 2
+    target = target.expanduser().resolve()
+    if not target.is_dir():
+        print(f"error: --target is not a directory: {target}", file=sys.stderr)
+        return 2
+    root = _work_root(target)
+    sessions, skipped = _collect_sessions(root)
+    for path, payload in sessions[:limit]:
+        snapshot = payload.get("end") if isinstance(payload.get("end"), dict) else payload.get("start", {})
+        dirty = _dirty_count(snapshot) if isinstance(snapshot, dict) else 0
+        title = _short(str(payload.get("title") or ""))
+        ended = payload.get("ended_at") or "active"
+        print(
+            f"{payload.get('started_at', path.name)} [{payload.get('status', 'unknown')}] "
+            f"dirty={dirty} ended={ended} {path}"
+        )
+        if title:
+            print(f"  {title}")
+    if not sessions:
+        print(f"no work sessions found in {root}")
+    if skipped:
+        print(f"skipped {skipped} invalid work session{'s' if skipped != 1 else ''}", file=sys.stderr)
+    return 0
+
+
+def latest(*, target: Path) -> int:
+    target = target.expanduser().resolve()
+    if not target.is_dir():
+        print(f"error: --target is not a directory: {target}", file=sys.stderr)
+        return 2
+    root = _work_root(target)
+    sessions, skipped = _collect_sessions(root)
+    if skipped:
+        print(f"skipped {skipped} invalid work session{'s' if skipped != 1 else ''}", file=sys.stderr)
+    if not sessions:
+        print(f"error: no work sessions found in {root}", file=sys.stderr)
+        return 1
+    path, payload = sessions[0]
+    _display_session(path, payload)
+    return 0
+
+
+def show(*, target: Path, session: str | Path) -> int:
+    target = target.expanduser().resolve()
+    if not target.is_dir():
+        print(f"error: --target is not a directory: {target}", file=sys.stderr)
+        return 2
+    path = _resolve_session(target, session)
+    if not path.is_dir():
+        print(f"error: work session not found: {path}", file=sys.stderr)
+        return 2
+    payload = _read_session(path)
+    if payload is None:
+        print(f"error: session.json not found or invalid in {path}", file=sys.stderr)
+        return 2
+    _display_session(path, payload)
     return 0
 
 

--- a/tests/test_work_cmd.py
+++ b/tests/test_work_cmd.py
@@ -159,6 +159,73 @@ def test_work_end_reports_no_active_session(tmp_path, capsys):
     assert "no active work session" in capsys.readouterr().err
 
 
+def test_work_list_prints_recent_sessions(tmp_path, monkeypatch, capsys):
+    _init_git_repo(tmp_path)
+    times = iter(
+        [
+            datetime(2026, 5, 26, 12, 0, 0, tzinfo=timezone.utc),
+            datetime(2026, 5, 26, 12, 30, 0, tzinfo=timezone.utc),
+            datetime(2026, 5, 26, 13, 0, 0, tzinfo=timezone.utc),
+            datetime(2026, 5, 26, 13, 30, 0, tzinfo=timezone.utc),
+        ]
+    )
+    monkeypatch.setattr(work_cmd, "_now", lambda: next(times))
+    assert work_cmd.start(target=tmp_path, title="Older Session") == 0
+    assert work_cmd.end(target=tmp_path) == 0
+    assert work_cmd.start(target=tmp_path, title="Newer Session") == 0
+    assert work_cmd.end(target=tmp_path) == 0
+
+    assert work_cmd.list_sessions(target=tmp_path, limit=10) == 0
+    out = capsys.readouterr().out
+    assert out.index("Newer Session") < out.index("Older Session")
+    assert "[ended]" in out
+    assert "dirty=" in out
+
+
+def test_work_latest_shows_latest_session(tmp_path, monkeypatch, capsys):
+    _init_git_repo(tmp_path)
+    times = iter(
+        [
+            datetime(2026, 5, 26, 12, 0, 0, tzinfo=timezone.utc),
+            datetime(2026, 5, 26, 13, 0, 0, tzinfo=timezone.utc),
+        ]
+    )
+    monkeypatch.setattr(work_cmd, "_now", lambda: next(times))
+    assert work_cmd.start(target=tmp_path, title="Build Work Loop") == 0
+    assert work_cmd.end(target=tmp_path, note="done") == 0
+
+    assert work_cmd.latest(target=tmp_path) == 0
+    out = capsys.readouterr().out
+    assert "session:" in out
+    assert "title: Build Work Loop" in out
+    assert "status: ended" in out
+    assert "note: done" in out
+    assert "git:" in out
+    assert "dogfood:" in out
+
+
+def test_work_show_accepts_session_id(tmp_path, monkeypatch, capsys):
+    _init_git_repo(tmp_path)
+    monkeypatch.setattr(
+        work_cmd,
+        "_now",
+        lambda: datetime(2026, 5, 26, 12, 0, 0, tzinfo=timezone.utc),
+    )
+    assert work_cmd.start(target=tmp_path, title="Build Work Loop") == 0
+
+    assert work_cmd.show(target=tmp_path, session="20260526-120000-build-work-loop") == 0
+    out = capsys.readouterr().out
+    assert "id: 20260526-120000-build-work-loop" in out
+    assert "status: active" in out
+
+
+def test_work_latest_reports_no_sessions(tmp_path, capsys):
+    _init_git_repo(tmp_path)
+
+    assert work_cmd.latest(target=tmp_path) == 1
+    assert "no work sessions found" in capsys.readouterr().err
+
+
 def test_work_status_cli(tmp_path, monkeypatch):
     seen = {}
 
@@ -214,4 +281,33 @@ def test_work_start_and_end_cli(tmp_path, monkeypatch):
                 "handoff_inbox": tmp_path / "handoffs",
             },
         ),
+    ]
+
+
+def test_work_inspection_cli(tmp_path, monkeypatch):
+    seen = []
+
+    def fake_list(**kwargs):
+        seen.append(("list", kwargs))
+        return 0
+
+    def fake_latest(**kwargs):
+        seen.append(("latest", kwargs))
+        return 0
+
+    def fake_show(**kwargs):
+        seen.append(("show", kwargs))
+        return 0
+
+    monkeypatch.setattr(work_cmd, "list_sessions", fake_list)
+    monkeypatch.setattr(work_cmd, "latest", fake_latest)
+    monkeypatch.setattr(work_cmd, "show", fake_show)
+
+    assert cli.main(["work", "list", "--target", str(tmp_path), "--limit", "2"]) == 0
+    assert cli.main(["work", "latest", "--target", str(tmp_path)]) == 0
+    assert cli.main(["work", "show", "abc123", "--target", str(tmp_path)]) == 0
+    assert seen == [
+        ("list", {"target": tmp_path, "limit": 2}),
+        ("latest", {"target": tmp_path}),
+        ("show", {"target": tmp_path, "session": "abc123"}),
     ]


### PR DESCRIPTION
## Summary
- add `brigade work list`, `brigade work latest`, and `brigade work show`
- summarize local `.brigade/work/` session artifacts with handoff, git, dogfood, and next-step context
- document the inspection commands and add focused tests

## Verification
- `.venv/bin/brigade work list --limit 3`
- `.venv/bin/brigade work latest`
- `.venv/bin/brigade work show 20260526-171426-handoff-smoke`
- `.venv/bin/python -m pytest tests/test_work_cmd.py tests/test_dogfood_cmd.py tests/test_runs_cmd.py tests/test_run_cli.py -q` -> 52 passed
- `.venv/bin/python -m pytest -q` -> 228 passed
- `PYTHONPATH=$HOME/repos/content-guard/src python3 -m content_guard scan . --policy $HOME/repos/content-guard/policies/public-repo.json` -> Clean. 64 file(s) checked.