### PR TITLE
feat: run brigade work loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `brigade work end --handoff` to write a Memory Handoff from closed work session artifacts.
 - `brigade work list`, `brigade work latest`, and `brigade work show` to inspect local work session artifacts.
 - `brigade work recap` to summarize recent or date-filtered work sessions.
+- `brigade work run` to start a work session, run dogfood, close the session, write a work handoff, and print a recap in one command.
 - Roster-level and per-agent `timeout_seconds` controls for bounded CLI calls.
 - `brigade run --read-only` prompt policy for planning and review runs that should inspect and recommend only, with native `codex exec --sandbox read-only` enforcement for Codex agents.
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ brigade dogfood
 brigade dogfood next
 brigade dogfood --target /path/to/repo
 brigade work status
+brigade work run
+brigade work run "review today's changes"
 brigade work start "next slice"
 brigade work end --note "tests passed" --handoff
 brigade work list
@@ -161,7 +163,7 @@ CLI runs write artifacts by default under `.brigade/runs/<id>` below `--cwd`; do
 
 Use `--output-dir <path>` to pick the artifact directory, or `--no-artifacts` for a throwaway run.
 
-Use `brigade work status` as the quick daily dashboard for a repo. It reports the current branch, dirty files, dogfood readiness, configured dogfood paths, latest dogfood run, and extracted next step without starting a new orchestration. `brigade work start "title"` opens a local work session under `.brigade/work/<id>/`, records the starting git and dogfood context, and writes `start.md`. `brigade work end --note "what happened"` closes the active session, records ending context, and writes `end.md`. Add `--handoff` to also write a Memory Handoff for the closed session; it defaults to the configured dogfood handoff inbox or `.claude/memory-handoffs`.
+Use `brigade work status` as the quick daily dashboard for a repo. It reports the current branch, dirty files, dogfood readiness, configured dogfood paths, latest dogfood run, and extracted next step without starting a new orchestration. `brigade work run` is the one-command daily loop: it starts a work session, runs `brigade dogfood`, ends the session, writes a work-session Memory Handoff by default, and prints a compact recap. Pass a task to override the default next-slice review, `--title` to name the session, `--no-handoff` to skip the work handoff, or `--dogfood-handoff` to also let the underlying dogfood run write its own handoff. `brigade work start "title"` opens a local work session under `.brigade/work/<id>/`, records the starting git and dogfood context, and writes `start.md`. `brigade work end --note "what happened"` closes the active session, records ending context, and writes `end.md`. Add `--handoff` to also write a Memory Handoff for the closed session; it defaults to the configured dogfood handoff inbox or `.claude/memory-handoffs`.
 
 Inspect local work sessions with `brigade work list`, `brigade work latest`, or `brigade work show <session-id-or-path>`. Use `brigade work recap` for a compact summary of recent sessions, or add `--since YYYY-MM-DD` for a day-range recap.
 

--- a/src/brigade/cli.py
+++ b/src/brigade/cli.py
@@ -126,6 +126,26 @@ def _build_parser() -> argparse.ArgumentParser:
     p_work_recap.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
     p_work_recap.add_argument("--limit", type=int, default=5, help="Maximum sessions to include.")
     p_work_recap.add_argument("--since", default=None, help="Only include sessions since YYYY-MM-DD.")
+    p_work_run = work_sub.add_parser("run", help="Start a work session, run dogfood, end it, and recap.")
+    p_work_run.add_argument("task", nargs="*", help="Dogfood task. Defaults to the standard next-slice review.")
+    p_work_run.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace for the session.")
+    p_work_run.add_argument("--title", default=None, help="Work session title. Defaults to the task text.")
+    p_work_run.add_argument("--output-dir", type=Path, default=None, help="Directory for dogfood run artifacts.")
+    p_work_run.add_argument("--handoff-inbox", type=Path, default=None, help="Memory Handoff inbox.")
+    p_work_run.add_argument("--no-handoff", action="store_true", help="Do not write a work-session Memory Handoff.")
+    p_work_run.add_argument(
+        "--dogfood-handoff",
+        action="store_true",
+        help="Also let the underlying dogfood run write its own Memory Handoff.",
+    )
+    p_work_run.add_argument("--no-inspect", action="store_true", help="Do not print the dogfood artifact summary.")
+    p_work_run.add_argument(
+        "--native-read-only-sandbox",
+        action="store_true",
+        help="Use Codex's native read-only sandbox for the underlying dogfood run.",
+    )
+    p_work_run.add_argument("--timeout-seconds", type=float, default=DEFAULT_TIMEOUT_SECONDS, help="Per-agent timeout.")
+    p_work_run.add_argument("--recap-limit", type=int, default=1, help="Maximum sessions to include in the final recap.")
     p_work_start = work_sub.add_parser("start", help="Start a local Brigade work session.")
     p_work_start.add_argument("title", nargs="*", help="Optional session title.")
     p_work_start.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace for the session.")
@@ -420,6 +440,21 @@ def main(argv=None) -> int:
             return work_cmd.show(target=args.target, session=args.session)
         if args.work_command == "recap":
             return work_cmd.recap(target=args.target, limit=args.limit, since=args.since)
+        if args.work_command == "run":
+            task = " ".join(args.task) if args.task else None
+            return work_cmd.run(
+                task,
+                target=args.target,
+                title=args.title,
+                output_dir=args.output_dir,
+                handoff=not args.no_handoff,
+                handoff_inbox=args.handoff_inbox,
+                dogfood_handoff=args.dogfood_handoff,
+                inspect=not args.no_inspect,
+                native_read_only_sandbox=args.native_read_only_sandbox,
+                timeout_seconds=args.timeout_seconds,
+                recap_limit=args.recap_limit,
+            )
         if args.work_command == "start":
             title = " ".join(args.title) if args.title else None
             return work_cmd.start(target=args.target, title=title, force=args.force)

--- a/src/brigade/work_cmd.py
+++ b/src/brigade/work_cmd.py
@@ -576,6 +576,57 @@ def recap(*, target: Path, limit: int = 5, since: str | None = None) -> int:
     return 0
 
 
+def run(
+    task: str | None,
+    *,
+    target: Path,
+    title: str | None = None,
+    output_dir: Path | None = None,
+    handoff: bool = True,
+    handoff_inbox: Path | None = None,
+    dogfood_handoff: bool = False,
+    inspect: bool = True,
+    native_read_only_sandbox: bool = False,
+    timeout_seconds: float = dogfood_cmd.DEFAULT_TIMEOUT_SECONDS,
+    recap_limit: int = 1,
+) -> int:
+    if recap_limit < 1:
+        print("error: --recap-limit must be a positive integer", file=sys.stderr)
+        return 2
+
+    target = target.expanduser().resolve()
+    if not target.is_dir():
+        print(f"error: --target is not a directory: {target}", file=sys.stderr)
+        return 2
+
+    task_text = task or dogfood_cmd.DEFAULT_TASK
+    session_title = title or task_text
+    start_rc = start(target=target, title=session_title)
+    if start_rc != 0:
+        return start_rc
+
+    dogfood_rc = 1
+    try:
+        dogfood_rc = dogfood_cmd.run(
+            task_text,
+            target=target,
+            output_dir=output_dir,
+            handoff=dogfood_handoff,
+            handoff_inbox=handoff_inbox if dogfood_handoff else None,
+            inspect=inspect,
+            native_read_only_sandbox=native_read_only_sandbox,
+            timeout_seconds=timeout_seconds,
+        )
+    finally:
+        note = f"brigade work run completed with dogfood exit code {dogfood_rc}"
+        end_rc = end(target=target, note=note, handoff=handoff, handoff_inbox=handoff_inbox)
+
+    if end_rc != 0:
+        return end_rc if dogfood_rc == 0 else dogfood_rc
+    recap(target=target, limit=recap_limit)
+    return dogfood_rc
+
+
 def status(*, target: Path, limit: int = 12) -> int:
     if limit < 1:
         print("error: --limit must be a positive integer", file=sys.stderr)

--- a/tests/test_work_cmd.py
+++ b/tests/test_work_cmd.py
@@ -268,6 +268,92 @@ def test_work_recap_rejects_bad_since(tmp_path, capsys):
     assert "--since must use YYYY-MM-DD" in capsys.readouterr().err
 
 
+def test_work_run_wraps_dogfood_session(tmp_path, monkeypatch, capsys):
+    _init_git_repo(tmp_path)
+    artifacts_dir = tmp_path / ".brigade" / "runs"
+    dogfood_cmd.init(target=tmp_path, artifacts_dir=artifacts_dir)
+    times = iter(
+        [
+            datetime(2026, 5, 26, 12, 0, 0, tzinfo=timezone.utc),
+            datetime(2026, 5, 26, 13, 0, 0, tzinfo=timezone.utc),
+        ]
+    )
+    monkeypatch.setattr(work_cmd, "_now", lambda: next(times))
+    seen = {}
+
+    def fake_dogfood_run(task, **kwargs):
+        seen["task"] = task
+        seen.update(kwargs)
+        run_dir = kwargs["output_dir"]
+        run_dir.mkdir(parents=True)
+        _write_json(
+            run_dir / "run.json",
+            {"started_at": "2026-05-26T12:10:00Z", "status": "ok", "task": task},
+        )
+        (run_dir / "final.txt").write_text("Done.\n\nNext step: Build work run.\n")
+        return 0
+
+    monkeypatch.setattr(dogfood_cmd, "run", fake_dogfood_run)
+    run_dir = artifacts_dir / "work-run"
+
+    assert (
+        work_cmd.run(
+            "review the repo",
+            target=tmp_path,
+            title="Daily Review",
+            output_dir=run_dir,
+            handoff_inbox=tmp_path / "handoffs",
+        )
+        == 0
+    )
+    assert seen["task"] == "review the repo"
+    assert seen["target"] == tmp_path.resolve()
+    assert seen["output_dir"] == run_dir
+    assert seen["handoff"] is False
+    assert seen["handoff_inbox"] is None
+    assert seen["inspect"] is True
+    assert not (tmp_path / ".brigade" / "work" / "current").exists()
+    session_dir = tmp_path / ".brigade" / "work" / "20260526-120000-daily-review"
+    payload = json.loads((session_dir / "session.json").read_text())
+    assert payload["status"] == "ended"
+    assert payload["note"] == "brigade work run completed with dogfood exit code 0"
+    assert payload["end"]["dogfood"]["latest_run"]["path"] == str(run_dir)
+    assert payload["end"]["dogfood"]["next"] == "Build work run."
+    assert "handoff" in payload
+    out = capsys.readouterr().out
+    assert "work recap:" in out
+    assert "Daily Review" in out
+    assert "next: Build work run." in out
+
+
+def test_work_run_closes_session_when_dogfood_fails(tmp_path, monkeypatch):
+    _init_git_repo(tmp_path)
+    dogfood_cmd.init(target=tmp_path)
+    times = iter(
+        [
+            datetime(2026, 5, 26, 12, 0, 0, tzinfo=timezone.utc),
+            datetime(2026, 5, 26, 13, 0, 0, tzinfo=timezone.utc),
+        ]
+    )
+    monkeypatch.setattr(work_cmd, "_now", lambda: next(times))
+    monkeypatch.setattr(dogfood_cmd, "run", lambda task, **kwargs: 7)
+
+    assert work_cmd.run("review the repo", target=tmp_path, handoff=False) == 7
+    assert not (tmp_path / ".brigade" / "work" / "current").exists()
+    session_dir = tmp_path / ".brigade" / "work" / "20260526-120000-review-the-repo"
+    payload = json.loads((session_dir / "session.json").read_text())
+    assert payload["status"] == "ended"
+    assert payload["note"] == "brigade work run completed with dogfood exit code 7"
+    assert "handoff" not in payload
+
+
+def test_work_run_rejects_bad_recap_limit(tmp_path, capsys):
+    _init_git_repo(tmp_path)
+
+    assert work_cmd.run(None, target=tmp_path, recap_limit=0) == 2
+    assert "--recap-limit must be a positive integer" in capsys.readouterr().err
+
+
 def test_work_status_cli(tmp_path, monkeypatch):
     seen = {}
 
@@ -324,6 +410,58 @@ def test_work_start_and_end_cli(tmp_path, monkeypatch):
             },
         ),
     ]
+
+
+def test_work_run_cli(tmp_path, monkeypatch):
+    seen = {}
+
+    def fake_run(task, **kwargs):
+        seen["task"] = task
+        seen.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(work_cmd, "run", fake_run)
+
+    assert (
+        cli.main(
+            [
+                "work",
+                "run",
+                "review",
+                "repo",
+                "--target",
+                str(tmp_path),
+                "--title",
+                "Daily",
+                "--output-dir",
+                str(tmp_path / "run"),
+                "--handoff-inbox",
+                str(tmp_path / "handoffs"),
+                "--no-handoff",
+                "--dogfood-handoff",
+                "--no-inspect",
+                "--native-read-only-sandbox",
+                "--timeout-seconds",
+                "12",
+                "--recap-limit",
+                "2",
+            ]
+        )
+        == 0
+    )
+    assert seen == {
+        "task": "review repo",
+        "target": tmp_path,
+        "title": "Daily",
+        "output_dir": tmp_path / "run",
+        "handoff": False,
+        "handoff_inbox": tmp_path / "handoffs",
+        "dogfood_handoff": True,
+        "inspect": False,
+        "native_read_only_sandbox": True,
+        "timeout_seconds": 12.0,
+        "recap_limit": 2,
+    }
 
 
 def test_work_inspection_cli(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add `brigade work run` as the one-command daily dogfooding loop
- wrap dogfood with work-session start/end artifacts and a default work handoff
- close the work session even when dogfood returns nonzero, then print a final recap

## Verification
- `.venv/bin/python -m pytest tests/test_work_cmd.py -q` - 21 passed
- `.venv/bin/python -m pytest tests/test_work_cmd.py tests/test_dogfood_cmd.py tests/test_runs_cmd.py tests/test_run_cli.py -q` - 58 passed
- `.venv/bin/brigade work run --help`
- `.venv/bin/python -m pytest -q` - 234 passed
- `PYTHONPATH=$HOME/repos/content-guard/src python3 -m content_guard scan . --policy $HOME/repos/content-guard/policies/public-repo.json` - clean, 64 files checked