### PR TITLE
feat: resume brigade work sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `brigade work list`, `brigade work latest`, and `brigade work show` to inspect local work session artifacts.
 - `brigade work recap` to summarize recent or date-filtered work sessions.
 - `brigade work run` to start a work session, run dogfood, close the session, write a work handoff, and print a recap in one command.
+- `brigade work resume` to show the active or latest work session, latest dogfood run, extracted next step, and suggested command.
 - Roster-level and per-agent `timeout_seconds` controls for bounded CLI calls.
 - `brigade run --read-only` prompt policy for planning and review runs that should inspect and recommend only, with native `codex exec --sandbox read-only` enforcement for Codex agents.
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ brigade dogfood
 brigade dogfood next
 brigade dogfood --target /path/to/repo
 brigade work status
+brigade work resume
 brigade work run
 brigade work run "review today's changes"
 brigade work start "next slice"
@@ -163,7 +164,7 @@ CLI runs write artifacts by default under `.brigade/runs/<id>` below `--cwd`; do
 
 Use `--output-dir <path>` to pick the artifact directory, or `--no-artifacts` for a throwaway run.
 
-Use `brigade work status` as the quick daily dashboard for a repo. It reports the current branch, dirty files, dogfood readiness, configured dogfood paths, latest dogfood run, and extracted next step without starting a new orchestration. `brigade work run` is the one-command daily loop: it starts a work session, runs `brigade dogfood`, ends the session, writes a work-session Memory Handoff by default, and prints a compact recap. Pass a task to override the default next-slice review, `--title` to name the session, `--no-handoff` to skip the work handoff, or `--dogfood-handoff` to also let the underlying dogfood run write its own handoff. `brigade work start "title"` opens a local work session under `.brigade/work/<id>/`, records the starting git and dogfood context, and writes `start.md`. `brigade work end --note "what happened"` closes the active session, records ending context, and writes `end.md`. Add `--handoff` to also write a Memory Handoff for the closed session; it defaults to the configured dogfood handoff inbox or `.claude/memory-handoffs`.
+Use `brigade work status` as the quick daily dashboard for a repo. It reports the current branch, dirty files, dogfood readiness, configured dogfood paths, latest dogfood run, and extracted next step without starting a new orchestration. Use `brigade work resume` when returning to a repo; it shows the active or latest work session, latest dogfood run, extracted next step, and the suggested command to continue. `brigade work run` is the one-command daily loop: it starts a work session, runs `brigade dogfood`, ends the session, writes a work-session Memory Handoff by default, and prints a compact recap. Pass a task to override the default next-slice review, `--title` to name the session, `--no-handoff` to skip the work handoff, or `--dogfood-handoff` to also let the underlying dogfood run write its own handoff. `brigade work start "title"` opens a local work session under `.brigade/work/<id>/`, records the starting git and dogfood context, and writes `start.md`. `brigade work end --note "what happened"` closes the active session, records ending context, and writes `end.md`. Add `--handoff` to also write a Memory Handoff for the closed session; it defaults to the configured dogfood handoff inbox or `.codex/memory-handoffs`.
 
 Inspect local work sessions with `brigade work list`, `brigade work latest`, or `brigade work show <session-id-or-path>`. Use `brigade work recap` for a compact summary of recent sessions, or add `--since YYYY-MM-DD` for a day-range recap.
 

--- a/src/brigade/cli.py
+++ b/src/brigade/cli.py
@@ -114,6 +114,8 @@ def _build_parser() -> argparse.ArgumentParser:
     p_work_status = work_sub.add_parser("status", help="Show current repo and dogfood work state.")
     p_work_status.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
     p_work_status.add_argument("--limit", type=int, default=12, help="Maximum dirty file entries to show.")
+    p_work_resume = work_sub.add_parser("resume", help="Show the current work handoff point and next command.")
+    p_work_resume.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
     p_work_list = work_sub.add_parser("list", help="List recent Brigade work sessions.")
     p_work_list.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
     p_work_list.add_argument("--limit", type=int, default=10, help="Maximum sessions to show.")
@@ -432,6 +434,8 @@ def main(argv=None) -> int:
 
         if args.work_command == "status":
             return work_cmd.status(target=args.target, limit=args.limit)
+        if args.work_command == "resume":
+            return work_cmd.resume(target=args.target)
         if args.work_command == "list":
             return work_cmd.list_sessions(target=args.target, limit=args.limit)
         if args.work_command == "latest":

--- a/src/brigade/work_cmd.py
+++ b/src/brigade/work_cmd.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -577,6 +578,81 @@ def recap(*, target: Path, limit: int = 5, since: str | None = None) -> int:
         next_text = _next_step(snapshot)
         if next_text:
             print(f"  next: {_short(next_text)}")
+    return 0
+
+
+def _print_resume_session(label: str, path: Path, payload: dict[str, Any]) -> None:
+    print(f"{label}: {path}")
+    print(f"{label}_status: {payload.get('status', 'unknown')}")
+    if payload.get("title"):
+        print(f"{label}_title: {_short(str(payload['title']))}")
+    print(f"{label}_started: {payload.get('started_at', '')}")
+    if payload.get("ended_at"):
+        print(f"{label}_ended: {payload['ended_at']}")
+    if payload.get("note"):
+        print(f"{label}_note: {_short(str(payload['note']))}")
+    if payload.get("handoff"):
+        print(f"{label}_handoff: {payload['handoff']}")
+
+
+def resume(*, target: Path) -> int:
+    target = target.expanduser().resolve()
+    if not target.is_dir():
+        print(f"error: --target is not a directory: {target}", file=sys.stderr)
+        return 2
+
+    print(f"work resume: {target}")
+    root = _work_root(target)
+    current = _current_path(target)
+    active_payload: dict[str, Any] | None = None
+    if current.exists():
+        active_dir = root / current.read_text().strip()
+        active_payload = _read_session(active_dir)
+        if active_payload is None:
+            print(f"active_session: invalid ({active_dir})")
+        else:
+            _print_resume_session("active_session", active_dir, active_payload)
+    else:
+        print("active_session: none")
+
+    sessions, skipped = _collect_sessions(root)
+    if skipped:
+        print(f"skipped: {skipped}", file=sys.stderr)
+    if sessions:
+        latest_path, latest_payload = sessions[0]
+        if active_payload is None or latest_payload.get("id") != active_payload.get("id"):
+            _print_resume_session("latest_session", latest_path, latest_payload)
+    else:
+        print(f"latest_session: none ({root})")
+
+    dogfood = _dogfood_snapshot(target)
+    print(f"dogfood_ready: {dogfood.get('ready')}")
+    if dogfood.get("error"):
+        print(f"dogfood_error: {dogfood['error']}")
+    if dogfood.get("target"):
+        print(f"dogfood_target: {dogfood['target']}")
+    if dogfood.get("artifacts_dir"):
+        print(f"dogfood_artifacts: {dogfood['artifacts_dir']}")
+    latest_run = dogfood.get("latest_run")
+    if isinstance(latest_run, dict):
+        print(
+            "latest_run: "
+            f"{latest_run.get('started_at', '')} "
+            f"[{latest_run.get('status', 'unknown')}] {latest_run.get('path')}"
+        )
+        if latest_run.get("task"):
+            print(f"latest_task: {_short(str(latest_run['task']))}")
+    else:
+        print("latest_run: none")
+
+    next_step = dogfood.get("next") if isinstance(dogfood.get("next"), str) else None
+    print(f"next: {_short(next_step) if next_step else 'none'}")
+    if active_payload is not None:
+        print('suggested_command: brigade work end --note "..." --handoff')
+    elif next_step:
+        print(f"suggested_command: brigade work run {shlex.quote(next_step)}")
+    else:
+        print("suggested_command: brigade work run")
     return 0
 
 

--- a/tests/test_work_cmd.py
+++ b/tests/test_work_cmd.py
@@ -285,6 +285,69 @@ def test_work_recap_rejects_bad_since(tmp_path, capsys):
     assert "--since must use YYYY-MM-DD" in capsys.readouterr().err
 
 
+def test_work_resume_reports_active_session(tmp_path, monkeypatch, capsys):
+    _init_git_repo(tmp_path)
+    dogfood_cmd.init(target=tmp_path)
+    run_dir = tmp_path / ".brigade" / "runs" / "latest"
+    run_dir.mkdir(parents=True)
+    _write_json(run_dir / "run.json", {"started_at": "2026-05-26T12:10:00Z", "status": "ok", "task": "review"})
+    (run_dir / "final.txt").write_text("Done.\n\nNext step: Build resume.\n")
+    monkeypatch.setattr(
+        work_cmd,
+        "_now",
+        lambda: datetime(2026, 5, 26, 12, 0, 0, tzinfo=timezone.utc),
+    )
+    assert work_cmd.start(target=tmp_path, title="Active Work") == 0
+
+    assert work_cmd.resume(target=tmp_path) == 0
+    out = capsys.readouterr().out
+    assert "work resume:" in out
+    assert "active_session:" in out
+    assert "active_session_title: Active Work" in out
+    assert "latest_run: 2026-05-26T12:10:00Z [ok]" in out
+    assert "next: Build resume." in out
+    assert 'suggested_command: brigade work end --note "..." --handoff' in out
+
+
+def test_work_resume_suggests_work_run_from_latest_next(tmp_path, monkeypatch, capsys):
+    _init_git_repo(tmp_path)
+    dogfood_cmd.init(target=tmp_path)
+    run_dir = tmp_path / ".brigade" / "runs" / "latest"
+    run_dir.mkdir(parents=True)
+    _write_json(run_dir / "run.json", {"started_at": "2026-05-26T12:10:00Z", "status": "ok", "task": "review"})
+    (run_dir / "final.txt").write_text("Done.\n\nNext step: Build resume.\n")
+    times = iter(
+        [
+            datetime(2026, 5, 26, 12, 0, 0, tzinfo=timezone.utc),
+            datetime(2026, 5, 26, 13, 0, 0, tzinfo=timezone.utc),
+        ]
+    )
+    monkeypatch.setattr(work_cmd, "_now", lambda: next(times))
+    assert work_cmd.start(target=tmp_path, title="Ended Work") == 0
+    assert work_cmd.end(target=tmp_path, note="done", handoff=True, handoff_inbox=tmp_path / "handoffs") == 0
+
+    assert work_cmd.resume(target=tmp_path) == 0
+    out = capsys.readouterr().out
+    assert "active_session: none" in out
+    assert "latest_session:" in out
+    assert "latest_session_title: Ended Work" in out
+    assert "latest_session_handoff:" in out
+    assert "next: Build resume." in out
+    assert "suggested_command: brigade work run 'Build resume.'" in out
+
+
+def test_work_resume_empty_state(tmp_path, capsys):
+    _init_git_repo(tmp_path)
+
+    assert work_cmd.resume(target=tmp_path) == 0
+    out = capsys.readouterr().out
+    assert "active_session: none" in out
+    assert "latest_session: none" in out
+    assert "latest_run: none" in out
+    assert "next: none" in out
+    assert "suggested_command: brigade work run" in out
+
+
 def test_work_run_wraps_dogfood_session(tmp_path, monkeypatch, capsys):
     _init_git_repo(tmp_path)
     artifacts_dir = tmp_path / ".brigade" / "runs"
@@ -382,6 +445,19 @@ def test_work_status_cli(tmp_path, monkeypatch):
 
     assert cli.main(["work", "status", "--target", str(tmp_path), "--limit", "3"]) == 0
     assert seen == {"target": tmp_path, "limit": 3}
+
+
+def test_work_resume_cli(tmp_path, monkeypatch):
+    seen = {}
+
+    def fake_resume(**kwargs):
+        seen.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(work_cmd, "resume", fake_resume)
+
+    assert cli.main(["work", "resume", "--target", str(tmp_path)]) == 0
+    assert seen == {"target": tmp_path}
 
 
 def test_work_start_and_end_cli(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add `brigade work resume` as a read-only return-to-work view
- show active/latest work session, latest dogfood run, extracted next step, and suggested continuation command
- document the command and cover active, ended, empty, and CLI paths

## Verification
- `.venv/bin/python -m pytest tests/test_work_cmd.py -q` - 26 passed
- `.venv/bin/brigade work resume`
- `.venv/bin/python -m pytest tests/test_work_cmd.py tests/test_dogfood_cmd.py tests/test_runs_cmd.py tests/test_run_cli.py -q` - 64 passed
- `.venv/bin/python -m pytest -q` - 240 passed
- `PYTHONPATH=$HOME/repos/content-guard/src python3 -m content_guard scan . --policy $HOME/repos/content-guard/policies/public-repo.json` - clean, 64 files checked