### PR TITLE
feat: note brigade work sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `brigade work recap` to summarize recent or date-filtered work sessions.
 - `brigade work run` to start a work session, run dogfood, close the session, write a work handoff, and print a recap in one command.
 - `brigade work resume` to show the active or latest work session, latest dogfood run, extracted next step, and suggested command.
+- `brigade work note` to append timestamped checkpoints to the active work session without ending it.
 - Roster-level and per-agent `timeout_seconds` controls for bounded CLI calls.
 - `brigade run --read-only` prompt policy for planning and review runs that should inspect and recommend only, with native `codex exec --sandbox read-only` enforcement for Codex agents.
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ brigade work resume
 brigade work run
 brigade work run "review today's changes"
 brigade work start "next slice"
+brigade work note "wired parser and tests"
 brigade work end --note "tests passed" --handoff
 brigade work list
 brigade work latest
@@ -164,7 +165,7 @@ CLI runs write artifacts by default under `.brigade/runs/<id>` below `--cwd`; do
 
 Use `--output-dir <path>` to pick the artifact directory, or `--no-artifacts` for a throwaway run.
 
-Use `brigade work status` as the quick daily dashboard for a repo. It reports the current branch, dirty files, dogfood readiness, configured dogfood paths, latest dogfood run, and extracted next step without starting a new orchestration. Use `brigade work resume` when returning to a repo; it shows the active or latest work session, latest dogfood run, extracted next step, and the suggested command to continue. `brigade work run` is the one-command daily loop: it starts a work session, runs `brigade dogfood`, ends the session, writes a work-session Memory Handoff by default, and prints a compact recap. Pass a task to override the default next-slice review, `--title` to name the session, `--no-handoff` to skip the work handoff, or `--dogfood-handoff` to also let the underlying dogfood run write its own handoff. `brigade work start "title"` opens a local work session under `.brigade/work/<id>/`, records the starting git and dogfood context, and writes `start.md`. `brigade work end --note "what happened"` closes the active session, records ending context, and writes `end.md`. Add `--handoff` to also write a Memory Handoff for the closed session; it defaults to the configured dogfood handoff inbox or `.codex/memory-handoffs`.
+Use `brigade work status` as the quick daily dashboard for a repo. It reports the current branch, dirty files, dogfood readiness, configured dogfood paths, latest dogfood run, and extracted next step without starting a new orchestration. Use `brigade work resume` when returning to a repo; it shows the active or latest work session, latest dogfood run, extracted next step, and the suggested command to continue. `brigade work run` is the one-command daily loop: it starts a work session, runs `brigade dogfood`, ends the session, writes a work-session Memory Handoff by default, and prints a compact recap. Pass a task to override the default next-slice review, `--title` to name the session, `--no-handoff` to skip the work handoff, or `--dogfood-handoff` to also let the underlying dogfood run write its own handoff. `brigade work start "title"` opens a local work session under `.brigade/work/<id>/`, records the starting git and dogfood context, and writes `start.md`. `brigade work note "checkpoint"` appends a timestamped note to the active session without ending it. `brigade work end --note "what happened"` closes the active session, records ending context, and writes `end.md`. Add `--handoff` to also write a Memory Handoff for the closed session; it defaults to the configured dogfood handoff inbox or `.codex/memory-handoffs`.
 
 Inspect local work sessions with `brigade work list`, `brigade work latest`, or `brigade work show <session-id-or-path>`. Use `brigade work recap` for a compact summary of recent sessions, or add `--since YYYY-MM-DD` for a day-range recap.
 

--- a/src/brigade/cli.py
+++ b/src/brigade/cli.py
@@ -152,6 +152,9 @@ def _build_parser() -> argparse.ArgumentParser:
     p_work_start.add_argument("title", nargs="*", help="Optional session title.")
     p_work_start.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace for the session.")
     p_work_start.add_argument("--force", action="store_true", help="Replace an existing active session pointer.")
+    p_work_note = work_sub.add_parser("note", help="Append a note to the active Brigade work session.")
+    p_work_note.add_argument("text", nargs="+", help="Note text.")
+    p_work_note.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace for the session.")
     p_work_end = work_sub.add_parser("end", help="End the active local Brigade work session.")
     p_work_end.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace for the session.")
     p_work_end.add_argument("--note", default=None, help="Optional closing note.")
@@ -462,6 +465,8 @@ def main(argv=None) -> int:
         if args.work_command == "start":
             title = " ".join(args.title) if args.title else None
             return work_cmd.start(target=args.target, title=title, force=args.force)
+        if args.work_command == "note":
+            return work_cmd.note(target=args.target, text=" ".join(args.text))
         if args.work_command == "end":
             return work_cmd.end(
                 target=args.target,

--- a/src/brigade/work_cmd.py
+++ b/src/brigade/work_cmd.py
@@ -219,6 +219,11 @@ def _display_session(path: Path, payload: dict[str, Any]) -> None:
         print(f"ended: {payload['ended_at']}")
     if payload.get("note"):
         print(f"note: {payload['note']}")
+    notes = payload.get("notes")
+    if isinstance(notes, list):
+        print(f"notes: {len(notes)}")
+        if notes and isinstance(notes[-1], dict) and notes[-1].get("text"):
+            print(f"latest_note: {_short(str(notes[-1]['text']))}")
     if payload.get("handoff"):
         print(f"handoff: {payload['handoff']}")
 
@@ -453,6 +458,56 @@ def end(*, target: Path, note: str | None = None, handoff: bool = False, handoff
     return 0
 
 
+def note(*, target: Path, text: str) -> int:
+    target = target.expanduser().resolve()
+    if not target.is_dir():
+        print(f"error: --target is not a directory: {target}", file=sys.stderr)
+        return 2
+    rendered = text.strip()
+    if not rendered:
+        print("error: note text is required", file=sys.stderr)
+        return 2
+
+    current = _current_path(target)
+    if not current.exists():
+        print(f"error: no active work session in {_work_root(target)}", file=sys.stderr)
+        return 1
+    session_id = current.read_text().strip()
+    session_dir = _work_root(target) / session_id
+    session_json = session_dir / "session.json"
+    try:
+        payload = json.loads(session_json.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"error: invalid active work session: {exc}", file=sys.stderr)
+        return 2
+    if not isinstance(payload, dict):
+        print("error: invalid active work session: session.json must contain an object", file=sys.stderr)
+        return 2
+
+    entry = {
+        "created_at": _now().isoformat(),
+        "text": rendered,
+    }
+    notes = payload.setdefault("notes", [])
+    if not isinstance(notes, list):
+        print("error: invalid active work session: notes must be a list", file=sys.stderr)
+        return 2
+    notes.append(entry)
+    _write_json(session_json, payload)
+
+    notes_path = session_dir / "notes.md"
+    prefix = "" if notes_path.exists() and notes_path.read_text().endswith("\n") else "\n"
+    with notes_path.open("a") as handle:
+        if notes_path.stat().st_size == 0:
+            handle.write("# Brigade Work Session Notes\n")
+        else:
+            handle.write(prefix)
+        handle.write(f"\n## {entry['created_at']}\n\n{rendered}\n")
+    print(f"session: {session_dir}")
+    print(f"note: {_short(rendered)}")
+    return 0
+
+
 def list_sessions(*, target: Path, limit: int = 10) -> int:
     if limit < 1:
         print("error: --limit must be a positive integer", file=sys.stderr)
@@ -591,6 +646,11 @@ def _print_resume_session(label: str, path: Path, payload: dict[str, Any]) -> No
         print(f"{label}_ended: {payload['ended_at']}")
     if payload.get("note"):
         print(f"{label}_note: {_short(str(payload['note']))}")
+    notes = payload.get("notes")
+    if isinstance(notes, list):
+        print(f"{label}_notes: {len(notes)}")
+        if notes and isinstance(notes[-1], dict) and notes[-1].get("text"):
+            print(f"{label}_latest_note: {_short(str(notes[-1]['text']))}")
     if payload.get("handoff"):
         print(f"{label}_handoff: {payload['handoff']}")
 

--- a/tests/test_work_cmd.py
+++ b/tests/test_work_cmd.py
@@ -102,6 +102,50 @@ def test_work_start_refuses_existing_session_without_force(tmp_path, monkeypatch
     assert "already active" in capsys.readouterr().err
 
 
+def test_work_note_appends_to_active_session(tmp_path, monkeypatch, capsys):
+    _init_git_repo(tmp_path)
+    times = iter(
+        [
+            datetime(2026, 5, 26, 12, 0, 0, tzinfo=timezone.utc),
+            datetime(2026, 5, 26, 12, 30, 0, tzinfo=timezone.utc),
+            datetime(2026, 5, 26, 12, 45, 0, tzinfo=timezone.utc),
+        ]
+    )
+    monkeypatch.setattr(work_cmd, "_now", lambda: next(times))
+    assert work_cmd.start(target=tmp_path, title="Build Work Loop") == 0
+
+    assert work_cmd.note(target=tmp_path, text="wired parser") == 0
+    assert work_cmd.note(target=tmp_path, text="added tests") == 0
+    out = capsys.readouterr().out
+    assert "note: wired parser" in out
+    assert "note: added tests" in out
+    session_dir = tmp_path / ".brigade" / "work" / "20260526-120000-build-work-loop"
+    payload = json.loads((session_dir / "session.json").read_text())
+    assert payload["status"] == "active"
+    assert payload["notes"] == [
+        {"created_at": "2026-05-26T12:30:00+00:00", "text": "wired parser"},
+        {"created_at": "2026-05-26T12:45:00+00:00", "text": "added tests"},
+    ]
+    notes = (session_dir / "notes.md").read_text()
+    assert "# Brigade Work Session Notes" in notes
+    assert "wired parser" in notes
+    assert "added tests" in notes
+
+
+def test_work_note_reports_no_active_session(tmp_path, capsys):
+    _init_git_repo(tmp_path)
+
+    assert work_cmd.note(target=tmp_path, text="checkpoint") == 1
+    assert "no active work session" in capsys.readouterr().err
+
+
+def test_work_note_rejects_empty_note(tmp_path, capsys):
+    _init_git_repo(tmp_path)
+
+    assert work_cmd.note(target=tmp_path, text="  ") == 2
+    assert "note text is required" in capsys.readouterr().err
+
+
 def test_work_end_closes_active_session(tmp_path, monkeypatch, capsys):
     _init_git_repo(tmp_path)
     times = iter(
@@ -503,6 +547,19 @@ def test_work_start_and_end_cli(tmp_path, monkeypatch):
             },
         ),
     ]
+
+
+def test_work_note_cli(tmp_path, monkeypatch):
+    seen = {}
+
+    def fake_note(**kwargs):
+        seen.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(work_cmd, "note", fake_note)
+
+    assert cli.main(["work", "note", "wired", "tests", "--target", str(tmp_path)]) == 0
+    assert seen == {"target": tmp_path, "text": "wired tests"}
 
 
 def test_work_run_cli(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add `brigade work note` for checkpointing active work sessions
- persist notes in both `session.json` and `notes.md`
- show note count and latest note in work inspection/resume output

## Verification
- `.venv/bin/python -m pytest tests/test_work_cmd.py -q` - 30 passed
- temp-repo smoke with `brigade work start`, `brigade work note`, and `brigade work show`
- `.venv/bin/python -m pytest tests/test_work_cmd.py tests/test_dogfood_cmd.py tests/test_runs_cmd.py tests/test_run_cli.py -q` - 68 passed
- `.venv/bin/python -m pytest -q` - 244 passed
- `PYTHONPATH=$HOME/repos/content-guard/src python3 -m content_guard scan . --policy $HOME/repos/content-guard/policies/public-repo.json` - clean, 64 files checked