### PR TITLE
docs: add template index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Public `templates/` index that points fresh-start users at the packaged starter templates without exposing local dogfood workspace files.
 - Built-in `brigade doctor` bootstrap budget checks that fail hard when installed bootstrap files exceed conservative byte limits.
 - Built-in `brigade doctor` memory-card budget checks that fail when `memory/cards/*.md` cards become too large.
 - Built-in `brigade doctor` memory-index checks that fail when `MEMORY.md` links to missing `memory/cards/*.md` files.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ The cookbook explains the why. This package gives you the kitchen.
 - adapter fragments for OpenClaw (tested), Hermes (stubbed), and generic harnesses
 - doctor checks that prove the system is wired before you trust it
 
+Browse the public template index in [`templates/`](templates/). The installable source files live under `src/brigade/templates/`; root workspace files are local dogfood state and stay ignored.
+
 ## What you do not get
 
 - private hostnames, IPs, account IDs, or personal details

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,51 @@
+# Brigade Templates
+
+This folder is the public index for Brigade's starter templates.
+
+The canonical installable files live under [`src/brigade/templates`](../src/brigade/templates/) because the Python package loads them from there. Keep edits in that package directory so `brigade init` and release builds install the same files people see in the repo.
+
+## Fresh Workspace Templates
+
+These are the starter files for someone building an agent workspace from scratch:
+
+- [`AGENTS.md`](../src/brigade/templates/workspace/AGENTS.md)
+- [`CLAUDE.md`](../src/brigade/templates/workspace/CLAUDE.md)
+- [`MEMORY.md`](../src/brigade/templates/workspace/MEMORY.md)
+- [`TOOLS.md`](../src/brigade/templates/workspace/TOOLS.md)
+- [`USER.md`](../src/brigade/templates/workspace/USER.md)
+- [`SOUL.md`](../src/brigade/templates/workspace/SOUL.md)
+- [`SAFETY_RULES.md`](../src/brigade/templates/workspace/SAFETY_RULES.md)
+- [`INSTALL_FOR_AGENTS.md`](../src/brigade/templates/workspace/INSTALL_FOR_AGENTS.md)
+- [`IDENTITY.md`](../src/brigade/templates/workspace/IDENTITY.md)
+- [`HEARTBEAT.md`](../src/brigade/templates/workspace/HEARTBEAT.md)
+
+Run:
+
+```bash
+brigade init --depth workspace --harnesses codex
+```
+
+## Memory Cards
+
+Starter memory cards live in [`src/brigade/templates/memory/cards`](../src/brigade/templates/memory/cards/). They are public-safe examples and operating patterns, not this repo's live memory.
+
+## Harness Adapters
+
+- [Claude handoff template](../src/brigade/templates/claude/memory-handoffs/TEMPLATE.md)
+- [Codex handoff template](../src/brigade/templates/codex/memory-handoffs/TEMPLATE.md)
+- [OpenClaw fragments](../src/brigade/templates/openclaw/)
+- [Hermes fragments](../src/brigade/templates/hermes/)
+- [Generic harness contract](../src/brigade/templates/generic/memory-contract.md)
+
+## Repo Baseline
+
+Repo installs use:
+
+- [repo depth manifest](../src/brigade/templates/depth/repo.json)
+- [workspace depth manifest](../src/brigade/templates/depth/workspace.json)
+- [pre-push hook](../src/brigade/templates/hooks/pre-push)
+- [content policies](../src/brigade/templates/policies/)
+
+## Boundary
+
+Root workspace files such as `/AGENTS.md`, `/MEMORY.md`, `/TOOLS.md`, `/memory/cards/`, `.brigade/`, and `.claude/` are local dogfood state and intentionally ignored. Template source belongs under `src/brigade/templates/`.


### PR DESCRIPTION
## Summary
- add a top-level `templates/` index for people browsing starter files
- point to canonical packaged template sources under `src/brigade/templates/`
- document that root workspace files are local dogfood state and stay ignored

## Verification
- `PYTHONPATH=$HOME/repos/content-guard/src python3 -m content_guard scan . --policy $HOME/repos/content-guard/policies/public-repo.json` -> Clean, 68 files checked
- `git diff --check` -> passed
- pre-push content guard -> Clean, 68 files checked