### PR TITLE
feat: add security policy suppressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cybersecurity plugin roadmap covering broad agent-workspace security checks plus Brigade-specific scanner, doctor, import, and multi-harness security checks.
 - Built-in `security` station and `brigade security scan` for read-only agent workspace security checks.
 - `brigade security scan --import-findings` to route security findings into the local work import inbox for review.
+- `brigade security init` to write gitignored local defaults to `.brigade/security.toml`.
+- Security policy presets (`personal`, `public-repo`, `strict`), template scanning controls, stable finding fingerprints, and fingerprint suppressions.
+- Security scan secret evidence is redacted before reports or work imports are written.
 - `ROADMAP.md` covering the daily-driver path, scanner-ready inbox, chat-surface scanners, memory-card decay refresh, and portable operator setup.
 - `brigade work note` to append timestamped checkpoints to the active work session without ending it.
 - `brigade work doctor` to check dogfood config, Codex availability, local artifact paths, handoff inbox, ignore coverage, and latest run context for the daily work loop.
@@ -71,7 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `brigade work run` now consumes the oldest pending ledger task before falling back to the latest extracted dogfood next step, and marks consumed tasks done after successful runs.
 - `brigade work task add --from-next` now reuses an equivalent pending task instead of adding duplicates.
 - `brigade work brief` now includes pending local work imports and import counts in both text and JSON output.
-- The managed gitignore block now treats `.brigade/dogfood.toml` and `.brigade/runs/` as local state.
+- The managed gitignore block now treats `.brigade/dogfood.toml`, `.brigade/security.toml`, and `.brigade/runs/` as local state.
 - Live smoke docs now keep Codex agent execution in a trusted repo cwd while writing temporary roster, artifacts, and handoff output under `/tmp`.
 - Handoff write failures now preserve final run artifacts, print the final answer, return nonzero, and mark `run.json` as `handoff-failed`.
 - Dogfood runs default to prompt-level read-only plus Codex's `danger-full-access` sandbox setting for trusted-workspace use so repo inspection works on hosts where native read-only sandboxing blocks shell inspection; `--native-read-only-sandbox` opts into stricter native enforcement.

--- a/README.md
+++ b/README.md
@@ -202,7 +202,9 @@ Inspect a completed run without opening each JSON file:
 brigade runs list --cwd /path/to/repo
 brigade runs latest --cwd /path/to/repo
 brigade runs show .brigade/runs/<run-id>
+brigade security init
 brigade security scan --target .
+brigade security scan --target . --policy public-repo
 brigade security scan --target . --import-findings
 ```
 
@@ -287,7 +289,7 @@ brigade add guard    # content-guard
 brigade add tokens   # tokenjuice
 ```
 
-`security` is a built-in station with no external managed tool yet. Run `brigade security scan --target .` for a read-only agent workspace security report, or add `--import-findings` to turn findings into local `brigade work import` review items.
+`security` is a built-in station with no external managed tool yet. Run `brigade security scan --target .` for a read-only agent workspace security report, or add `--import-findings` to turn findings into local `brigade work import` review items. Secret evidence is redacted before reports or imports are written. Use `brigade security init` to write gitignored local defaults to `.brigade/security.toml`; it supports policy presets (`personal`, `public-repo`, `strict`), `fail_on`, template scanning, and fingerprint suppressions for reviewed findings.
 
 The current managed tools:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -63,17 +63,18 @@ Brigade-specific additions:
 - Integrate with `brigade doctor` as a security station and with `brigade work import` so findings can become reviewable local tasks instead of only console output.
 - Provide safe auto-fix only for narrow cases such as replacing obvious hardcoded sample secrets, tightening generated allow-list examples, or adding missing ignore rules.
 - Produce Memory Handoffs for durable security findings while keeping raw secret evidence redacted.
-- Add policy packs for personal dogfooding, public-repo release checks, CI gates, and strict enterprise workspaces.
+- Add policy packs for personal dogfooding, public-repo release checks, CI gates, and strict enterprise workspaces. Status: started with `personal`, `public-repo`, and `strict`.
 - Include dependency and package-manager hardening checks for agent plugin ecosystems, MCP packages, skills, and local tool wrappers.
 - Track false-positive taxonomy, runtime-confidence rules, suppressions, and regression fixtures as first-class project artifacts.
 
 First build slice:
 
-- Create a plugin scaffold and security scan contract. Status: started with built-in `security` station and `brigade security scan`.
+- Create a plugin scaffold and security scan contract. Status: started with built-in `security` station, `brigade security init`, and `brigade security scan`.
 - Start with config discovery and read-only reporting for Brigade, Claude Code, Codex, and MCP config files. Status: started.
 - Add core rule categories for secrets, permissions, hooks, MCP servers, supply-chain patterns, and agent instructions. Status: started.
 - Output JSON plus readable text, then route selected findings into `brigade work import`. Status: started with `--import-findings`.
 - Keep all raw findings local and gitignored unless the operator explicitly exports an evidence pack. Status: current default.
+- Add local policy defaults, stable finding fingerprints, and suppressions. Status: started with `.brigade/security.toml`.
 
 ## Later Phase: Memory Card Decay And Refresh
 

--- a/src/brigade/cli.py
+++ b/src/brigade/cli.py
@@ -388,14 +388,36 @@ def _build_parser() -> argparse.ArgumentParser:
     p_security = sub.add_parser("security", help="Scan agent workspace security posture.")
     security_sub = p_security.add_subparsers(dest="security_command", metavar="<security-command>")
     security_sub.required = True
+    p_security_init = security_sub.add_parser("init", help="Write local security scan defaults.")
+    p_security_init.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to configure.")
+    p_security_init.add_argument("--force", action="store_true", help="Overwrite an existing security config.")
     p_security_scan = security_sub.add_parser("scan", help="Run a read-only agent workspace security scan.")
     p_security_scan.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to scan.")
     p_security_scan.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
     p_security_scan.add_argument(
+        "--policy",
+        choices=["personal", "public-repo", "strict"],
+        default=None,
+        help="Policy preset. Defaults to .brigade/security.toml or personal.",
+    )
+    p_security_scan.add_argument(
         "--fail-on",
         choices=["none", "low", "medium", "high", "critical"],
-        default="critical",
+        default=None,
         help="Return nonzero when a finding at or above this severity exists.",
+    )
+    p_security_scan.add_argument(
+        "--include-templates",
+        dest="include_templates",
+        action="store_true",
+        default=None,
+        help="Include public template files in scanner findings.",
+    )
+    p_security_scan.add_argument(
+        "--no-include-templates",
+        dest="include_templates",
+        action="store_false",
+        help="Exclude public template files from scanner findings.",
     )
     p_security_scan.add_argument(
         "--import-findings",
@@ -761,11 +783,15 @@ def main(argv=None) -> int:
     if cmd == "security":
         from . import security_cmd
 
+        if args.security_command == "init":
+            return security_cmd.init(target=args.target, force=args.force)
         if args.security_command == "scan":
             return security_cmd.scan(
                 target=args.target,
                 json_output=args.json,
+                policy=args.policy,
                 fail_on=args.fail_on,
+                include_templates=args.include_templates,
                 import_findings=args.import_findings,
             )
         parser.error(f"unknown security command: {args.security_command}")

--- a/src/brigade/install.py
+++ b/src/brigade/install.py
@@ -62,6 +62,7 @@ def build_gitignore_block(selection: Selection) -> str:
         "",
         "# brigade local state (logs, scrub cache, dogfood runs, work sessions).",
         ".brigade/dogfood.toml",
+        ".brigade/security.toml",
         ".brigade/logs/",
         ".brigade/runs/",
         ".brigade/scrub-cache/",

--- a/src/brigade/security_cmd.py
+++ b/src/brigade/security_cmd.py
@@ -1,9 +1,12 @@
 """Read-only security scanner for agent workspaces."""
 from __future__ import annotations
 
+import ast
+import hashlib
 import json
 import re
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -15,6 +18,21 @@ SEVERITY_ORDER = {
     "medium": 2,
     "high": 3,
     "critical": 4,
+}
+CONFIG_REL_PATH = ".brigade/security.toml"
+POLICIES = {
+    "personal": {
+        "fail_on": "critical",
+        "include_templates": False,
+    },
+    "public-repo": {
+        "fail_on": "high",
+        "include_templates": False,
+    },
+    "strict": {
+        "fail_on": "medium",
+        "include_templates": True,
+    },
 }
 
 SKIP_DIRS = {
@@ -71,6 +89,148 @@ PROMPT_INJECTION_RE = re.compile(
 )
 
 
+@dataclass(frozen=True)
+class SecurityConfig:
+    policy: str = "personal"
+    fail_on: str | None = None
+    include_templates: bool | None = None
+    suppressions: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class EffectivePolicy:
+    policy: str
+    fail_on: str
+    include_templates: bool
+    suppressions: tuple[str, ...]
+    config_path: Path
+    config_loaded: bool
+
+
+def config_path(target: Path) -> Path:
+    return target / CONFIG_REL_PATH
+
+
+def _parse_toml_value(raw: str) -> object:
+    value = raw.strip()
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    try:
+        return ast.literal_eval(value)
+    except (SyntaxError, ValueError):
+        return value
+
+
+def _read_toml_object(path: Path) -> dict[str, object]:
+    data: dict[str, object] = {}
+    current = data
+    for line_number, raw_line in enumerate(path.read_text().splitlines(), start=1):
+        line = raw_line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            table = line[1:-1].strip()
+            if table != "suppressions":
+                raise ValueError(f"invalid security config line {line_number}: unsupported table [{table}]")
+            current = data.setdefault("suppressions", {})
+            if not isinstance(current, dict):
+                raise ValueError(f"invalid security config line {line_number}: suppressions must be a table")
+            continue
+        if "=" not in line:
+            raise ValueError(f"invalid security config line {line_number}: expected key = value")
+        key, raw_value = line.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise ValueError(f"invalid security config line {line_number}: empty key")
+        current[key] = _parse_toml_value(raw_value)
+    return data
+
+
+def load_config(target: Path) -> SecurityConfig | None:
+    path = config_path(target.expanduser().resolve())
+    if not path.is_file():
+        return None
+    data = _read_toml_object(path)
+    policy = data.get("policy", "personal")
+    if not isinstance(policy, str) or policy not in POLICIES:
+        raise ValueError("policy must be one of: personal, public-repo, strict")
+    fail_on = data.get("fail_on")
+    if fail_on is not None and (not isinstance(fail_on, str) or fail_on not in SEVERITY_ORDER and fail_on != "none"):
+        raise ValueError("fail_on must be one of: none, low, medium, high, critical")
+    include_templates = data.get("include_templates")
+    if include_templates is not None and not isinstance(include_templates, bool):
+        raise ValueError("include_templates must be true or false")
+    suppressions: tuple[str, ...] = ()
+    raw_suppressions = data.get("suppressions", {})
+    if raw_suppressions:
+        if not isinstance(raw_suppressions, dict):
+            raise ValueError("suppressions must be a table")
+        fingerprints = raw_suppressions.get("fingerprints", [])
+        if not isinstance(fingerprints, list) or not all(isinstance(item, str) for item in fingerprints):
+            raise ValueError("suppressions.fingerprints must be a list of strings")
+        suppressions = tuple(item.strip() for item in fingerprints if item.strip())
+    return SecurityConfig(
+        policy=policy,
+        fail_on=fail_on,
+        include_templates=include_templates,
+        suppressions=suppressions,
+    )
+
+
+def _effective_policy(
+    target: Path,
+    *,
+    policy: str | None,
+    fail_on: str | None,
+    include_templates: bool | None,
+) -> EffectivePolicy:
+    loaded = load_config(target)
+    policy_name = policy or (loaded.policy if loaded is not None else "personal")
+    if policy_name not in POLICIES:
+        raise ValueError("policy must be one of: personal, public-repo, strict")
+    preset = POLICIES[policy_name]
+    effective_fail_on = fail_on or (loaded.fail_on if loaded and loaded.fail_on is not None else str(preset["fail_on"]))
+    if include_templates is not None:
+        effective_include_templates = include_templates
+    elif loaded and loaded.include_templates is not None:
+        effective_include_templates = loaded.include_templates
+    else:
+        effective_include_templates = bool(preset["include_templates"])
+    if effective_fail_on not in SEVERITY_ORDER and effective_fail_on != "none":
+        raise ValueError("fail_on must be one of: none, low, medium, high, critical")
+    return EffectivePolicy(
+        policy=policy_name,
+        fail_on=effective_fail_on,
+        include_templates=effective_include_templates,
+        suppressions=loaded.suppressions if loaded is not None else (),
+        config_path=config_path(target),
+        config_loaded=loaded is not None,
+    )
+
+
+def write_default_config(target: Path, *, force: bool = False) -> Path:
+    path = config_path(target.expanduser().resolve())
+    if path.exists() and not force:
+        raise FileExistsError(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(
+            [
+                'policy = "personal"',
+                'fail_on = "critical"',
+                "include_templates = false",
+                "",
+                "[suppressions]",
+                "fingerprints = []",
+                "",
+            ]
+        )
+    )
+    return path
+
+
 def _short(text: str, limit: int = 160) -> str:
     rendered = " ".join(text.split())
     if len(rendered) <= limit:
@@ -94,6 +254,25 @@ def _is_placeholder(value: str) -> bool:
             "dummy",
         )
     )
+
+
+def _redact_secret_evidence(line: str) -> str:
+    if PRIVATE_KEY_RE.search(line):
+        return PRIVATE_KEY_RE.sub("-----BEGIN REDACTED PRIVATE KEY-----", line)
+
+    def redact_secret(match: re.Match[str]) -> str:
+        return match.group(0).replace(match.group(2), "[REDACTED]")
+
+    redacted = SECRET_VALUE_RE.sub(redact_secret, line)
+
+    def redact_env(match: re.Match[str]) -> str:
+        text = match.group(0)
+        if "=" not in text:
+            return "[REDACTED]"
+        key, _ = text.split("=", 1)
+        return f"{key}=[REDACTED]"
+
+    return ENV_ASSIGNMENT_RE.sub(redact_env, redacted)
 
 
 def _iter_scan_files(target: Path) -> list[Path]:
@@ -148,6 +327,11 @@ def _confidence_for(path: Path, target: Path) -> str:
     return "repo"
 
 
+def _fingerprint(*, category: str, title: str, rel_path: Path, evidence: str) -> str:
+    stable = "\n".join([category, title, str(rel_path), _short(evidence, limit=96)])
+    return hashlib.sha256(stable.encode()).hexdigest()[:16]
+
+
 def _finding(
     findings: list[dict[str, Any]],
     *,
@@ -162,9 +346,11 @@ def _finding(
 ) -> None:
     rel = path.relative_to(target)
     finding_id = f"security-{len(findings) + 1:04d}"
+    fingerprint = _fingerprint(category=category, title=title, rel_path=rel, evidence=evidence)
     findings.append(
         {
             "id": finding_id,
+            "fingerprint": fingerprint,
             "severity": severity,
             "category": category,
             "title": title,
@@ -189,7 +375,7 @@ def _scan_line(findings: list[dict[str, Any]], *, target: Path, path: Path, line
             severity="high",
             category="secrets",
             title="Possible hardcoded credential",
-            evidence=line,
+            evidence=_redact_secret_evidence(line),
             suggestion="Move the value into local environment or secret storage and commit only a placeholder.",
         )
     if PRIVATE_KEY_RE.search(line) or (ENV_ASSIGNMENT_RE.search(line) and not _is_placeholder(line)):
@@ -201,7 +387,7 @@ def _scan_line(findings: list[dict[str, Any]], *, target: Path, path: Path, line
             severity="high",
             category="secrets",
             title="Possible sensitive secret material",
-            evidence=line,
+            evidence=_redact_secret_evidence(line),
             suggestion="Remove secret material from the repo and rotate the credential if it was real.",
         )
     if "danger-full-access" in line or "sandbox_permissions" in line and "require_escalated" in line:
@@ -292,11 +478,13 @@ def _scan_line(findings: list[dict[str, Any]], *, target: Path, path: Path, line
         )
 
 
-def scan_target(target: Path) -> dict[str, Any]:
+def scan_target(target: Path, *, include_templates: bool = False, suppressions: tuple[str, ...] = ()) -> dict[str, Any]:
     target = target.expanduser().resolve()
     findings: list[dict[str, Any]] = []
     scanned_files: list[str] = []
     for path in _iter_scan_files(target):
+        if not include_templates and _confidence_for(path, target) == "template":
+            continue
         try:
             text = path.read_text(errors="replace")
         except OSError:
@@ -304,6 +492,8 @@ def scan_target(target: Path) -> dict[str, Any]:
         scanned_files.append(str(path.relative_to(target)))
         for line_number, line in enumerate(text.splitlines(), start=1):
             _scan_line(findings, target=target, path=path, line_number=line_number, line=line)
+    suppressed = [finding for finding in findings if finding.get("fingerprint") in suppressions]
+    findings = [finding for finding in findings if finding.get("fingerprint") not in suppressions]
     counts: dict[str, int] = {}
     for finding in findings:
         severity = str(finding["severity"])
@@ -313,8 +503,10 @@ def scan_target(target: Path) -> dict[str, Any]:
         "scanned_files": scanned_files,
         "scanned_file_count": len(scanned_files),
         "finding_count": len(findings),
+        "suppressed_count": len(suppressed),
         "severity_counts": dict(sorted(counts.items())),
         "findings": findings,
+        "suppressed_findings": suppressed,
     }
 
 
@@ -326,8 +518,21 @@ def _should_fail(findings: list[dict[str, Any]], fail_on: str) -> bool:
 
 
 def _import_findings(target: Path, findings: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    existing_fingerprints = {
+        str(item.get("metadata", {}).get("fingerprint"))
+        for item in work_cmd._pending_imports(target)
+        if isinstance(item, dict)
+        and item.get("source") == "security-scan"
+        and isinstance(item.get("metadata"), dict)
+        and item.get("metadata", {}).get("fingerprint")
+    }
     records = []
+    skipped: list[dict[str, Any]] = []
     for finding in findings:
+        fingerprint = str(finding.get("fingerprint") or "")
+        if fingerprint and fingerprint in existing_fingerprints:
+            skipped.append(finding)
+            continue
         path = finding.get("path")
         line = finding.get("line")
         title = finding.get("title")
@@ -340,6 +545,7 @@ def _import_findings(target: Path, findings: list[dict[str, Any]]) -> tuple[list
                 "source": "security-scan",
                 "metadata": {
                     "finding_id": finding.get("id"),
+                    "fingerprint": finding.get("fingerprint"),
                     "severity": severity,
                     "category": category,
                     "path": path,
@@ -350,25 +556,47 @@ def _import_findings(target: Path, findings: list[dict[str, Any]]) -> tuple[list
                 },
             }
         )
-    return work_cmd._append_import_records(target, records)
+        if fingerprint:
+            existing_fingerprints.add(fingerprint)
+    imported, duplicate_records = work_cmd._append_import_records(target, records)
+    skipped.extend(duplicate_records)
+    return imported, skipped
 
 
 def scan(
     *,
     target: Path,
     json_output: bool = False,
-    fail_on: str = "critical",
+    policy: str | None = None,
+    fail_on: str | None = None,
+    include_templates: bool | None = None,
     import_findings: bool = False,
 ) -> int:
     target = target.expanduser().resolve()
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
-    if fail_on not in SEVERITY_ORDER and fail_on != "none":
-        print("error: --fail-on must be one of: none, low, medium, high, critical", file=sys.stderr)
+    try:
+        effective = _effective_policy(
+            target,
+            policy=policy,
+            fail_on=fail_on,
+            include_templates=include_templates,
+        )
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
         return 2
 
-    report = scan_target(target)
+    report = scan_target(
+        target,
+        include_templates=effective.include_templates,
+        suppressions=effective.suppressions,
+    )
+    report["policy"] = effective.policy
+    report["fail_on"] = effective.fail_on
+    report["include_templates"] = effective.include_templates
+    report["config"] = str(effective.config_path)
+    report["config_loaded"] = effective.config_loaded
     imported: list[dict[str, Any]] = []
     skipped: list[dict[str, Any]] = []
     if import_findings and report["findings"]:
@@ -380,8 +608,12 @@ def scan(
         print(json.dumps(report, indent=2, sort_keys=True))
     else:
         print(f"security scan: {target}")
+        print(f"policy: {effective.policy}")
+        print(f"fail_on: {effective.fail_on}")
+        print(f"include_templates: {effective.include_templates}")
         print(f"scanned_files: {report['scanned_file_count']}")
         print(f"findings: {report['finding_count']}")
+        print(f"suppressed: {report['suppressed_count']}")
         for severity, count in report["severity_counts"].items():
             print(f"{severity}: {count}")
         if import_findings:
@@ -392,7 +624,23 @@ def scan(
                 f"- [{finding['severity']}] {finding['category']} "
                 f"{finding['path']}:{finding['line']} {finding['title']}"
             )
+            print(f"  fingerprint: {finding['fingerprint']}")
             print(f"  evidence: {finding['evidence']}")
             print(f"  suggestion: {finding['suggestion']}")
 
-    return 1 if _should_fail(report["findings"], fail_on) else 0
+    return 1 if _should_fail(report["findings"], effective.fail_on) else 0
+
+
+def init(*, target: Path, force: bool = False) -> int:
+    target = target.expanduser().resolve()
+    if not target.is_dir():
+        print(f"error: --target is not a directory: {target}", file=sys.stderr)
+        return 2
+    try:
+        path = write_default_config(target, force=force)
+    except FileExistsError as exc:
+        print(f"error: security config already exists: {exc.args[0]}", file=sys.stderr)
+        return 1
+    print(f"security_config: {path}")
+    print("policy: personal")
+    return 0

--- a/tests/test_gitignore.py
+++ b/tests/test_gitignore.py
@@ -26,6 +26,7 @@ def test_init_creates_gitignore_when_missing(tmp_target: Path):
     assert "!.claude/memory-handoffs/TEMPLATE.md" in gi
     assert "memory/handoff-inbox/" in gi
     assert ".brigade/dogfood.toml" in gi
+    assert ".brigade/security.toml" in gi
     assert ".brigade/runs/" in gi
     assert ".brigade/work/" in gi
 

--- a/tests/test_security_cmd.py
+++ b/tests/test_security_cmd.py
@@ -28,6 +28,76 @@ def test_security_scan_finds_agent_workspace_risks(tmp_path, capsys):
     categories = {finding["category"] for finding in payload["findings"]}
     assert {"secrets", "automation", "mcp", "prompt-injection"} <= categories
     assert payload["severity_counts"]["high"] >= 2
+    assert payload["policy"] == "personal"
+    assert payload["fail_on"] == "high"
+    assert payload["include_templates"] is False
+    assert payload["findings"][0]["fingerprint"]
+    secret_findings = [finding for finding in payload["findings"] if finding["category"] == "secrets"]
+    assert secret_findings
+    assert "[REDACTED]" in secret_findings[0]["evidence"]
+    assert "abcd1234" not in secret_findings[0]["evidence"]
+
+
+def test_security_policy_presets_and_template_inclusion(tmp_path, capsys):
+    template_dir = tmp_path / "src" / "brigade" / "templates" / "workspace"
+    template_dir.mkdir(parents=True)
+    (template_dir / "AGENTS.md").write_text("Use sandbox_permissions require_escalated for all tasks.\n")
+
+    assert security_cmd.scan(target=tmp_path, fail_on="none", json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["finding_count"] == 0
+    assert payload["include_templates"] is False
+
+    assert security_cmd.scan(target=tmp_path, policy="strict", fail_on="none", json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["policy"] == "strict"
+    assert payload["include_templates"] is True
+    assert payload["finding_count"] == 1
+    assert payload["findings"][0]["confidence"] == "template"
+
+
+def test_security_config_and_suppressions(tmp_path, capsys):
+    (tmp_path / ".env").write_text("SERVICE_TOKEN=abcd1234abcd1234abcd1234\n")
+    report = security_cmd.scan_target(tmp_path)
+    fingerprint = report["findings"][0]["fingerprint"]
+    config = tmp_path / ".brigade" / "security.toml"
+    config.parent.mkdir(parents=True)
+    config.write_text(
+        "\n".join(
+            [
+                'policy = "public-repo"',
+                'fail_on = "high"',
+                "include_templates = false",
+                "",
+                "[suppressions]",
+                f'fingerprints = ["{fingerprint}"]',
+                "",
+            ]
+        )
+    )
+
+    assert security_cmd.scan(target=tmp_path, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["config_loaded"] is True
+    assert payload["policy"] == "public-repo"
+    assert payload["finding_count"] == 0
+    assert payload["suppressed_count"] == 1
+    assert payload["suppressed_findings"][0]["fingerprint"] == fingerprint
+
+
+def test_security_init_writes_gitignored_local_config(tmp_path, capsys):
+    tmp_path.mkdir(exist_ok=True)
+
+    assert security_cmd.init(target=tmp_path) == 0
+    out = capsys.readouterr().out
+    assert "security_config:" in out
+    config = tmp_path / ".brigade" / "security.toml"
+    assert config.is_file()
+    assert 'policy = "personal"' in config.read_text()
+
+    assert security_cmd.init(target=tmp_path) == 1
+    assert "already exists" in capsys.readouterr().err
+    assert security_cmd.init(target=tmp_path, force=True) == 0
 
 
 def test_security_scan_can_import_findings(tmp_path, capsys):
@@ -41,10 +111,12 @@ def test_security_scan_can_import_findings(tmp_path, capsys):
     assert imports[0]["source"] == "security-scan"
     assert imports[0]["kind"] == "incident"
     assert imports[0]["metadata"]["category"] == "secrets"
+    assert imports[0]["metadata"]["fingerprint"]
 
     assert security_cmd.scan(target=tmp_path, import_findings=True) == 0
     out = capsys.readouterr().out
-    assert "skipped_duplicate_imports:" in out
+    assert "imported_findings: 0" in out
+    assert "skipped_duplicate_imports: 1" in out
 
 
 def test_security_scan_cli(tmp_path, monkeypatch):
@@ -63,8 +135,11 @@ def test_security_scan_cli(tmp_path, monkeypatch):
                 "--target",
                 str(tmp_path),
                 "--json",
+                "--policy",
+                "strict",
                 "--fail-on",
                 "medium",
+                "--include-templates",
                 "--import-findings",
             ]
         )
@@ -73,6 +148,20 @@ def test_security_scan_cli(tmp_path, monkeypatch):
     assert seen == {
         "target": tmp_path,
         "json_output": True,
+        "policy": "strict",
         "fail_on": "medium",
+        "include_templates": True,
         "import_findings": True,
     }
+
+
+def test_security_init_cli(tmp_path, monkeypatch):
+    seen = {}
+
+    def fake_init(**kwargs):
+        seen.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(security_cmd, "init", fake_init)
+    assert cli.main(["security", "init", "--target", str(tmp_path), "--force"]) == 0
+    assert seen == {"target": tmp_path, "force": True}


### PR DESCRIPTION
## Summary
- add local .brigade/security.toml defaults via brigade security init
- add security policy presets, fail thresholds, template scanning controls, and fingerprint suppressions
- add stable finding fingerprints and use them for security import dedupe
- redact secret-like evidence before reports and imports are written

## Verification
- .venv/bin/python -m pytest tests/test_security_cmd.py tests/test_gitignore.py -q
- .venv/bin/python -m pytest -q
- PYTHONPATH=$HOME/repos/content-guard/src python3 -m content_guard scan . --policy $HOME/repos/content-guard/policies/public-repo.json
- git diff --check
- .venv/bin/brigade security init --target "$tmpdir"
- .venv/bin/brigade security scan --target "$tmpdir" --policy public-repo --json
- .venv/bin/brigade security scan --target "$tmpdir" --json
- .venv/bin/brigade security scan --target "$tmpdir" --fail-on none --import-findings
- .venv/bin/brigade work import triage --target "$tmpdir" --limit 5