### PR TITLE
feat: add security fix command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Built-in `security` station and `brigade security scan` for read-only agent workspace security checks.
 - `brigade security scan --import-findings` to route security findings into the local work import inbox for review.
 - `brigade security init` to write gitignored local defaults to `.brigade/security.toml`.
+- `brigade security fix` to create the local security artifact directory and refresh the managed `.gitignore` block.
 - Security policy presets (`personal`, `public-repo`, `strict`), template scanning controls, stable finding fingerprints, and fingerprint suppressions.
 - `brigade security scan --output-dir <dir>` to write redacted `security-report.json` and `security-report.md` evidence bundles.
 - `brigade doctor` and `brigade work doctor` now report security config health, latest security evidence bundle status, and local security artifact ignore coverage.

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ brigade runs list --cwd /path/to/repo
 brigade runs latest --cwd /path/to/repo
 brigade runs show .brigade/runs/<run-id>
 brigade security init
+brigade security fix
 brigade security scan --target .
 brigade security scan --target . --policy public-repo
 brigade security scan --target . --output-dir .brigade/security/latest
@@ -290,7 +291,7 @@ brigade add guard    # content-guard
 brigade add tokens   # tokenjuice
 ```
 
-`security` is a built-in station with no external managed tool yet. Run `brigade security scan --target .` for a read-only agent workspace security report, add `--output-dir .brigade/security/latest` to write redacted `security-report.json` and `security-report.md` artifacts, or add `--import-findings` to turn findings into local `brigade work import` review items. `brigade doctor` and `brigade work doctor` report security config health, latest evidence bundle status, and whether local security artifacts are ignored. Secret evidence is redacted before reports, artifacts, or imports are written. Use `brigade security init` to write gitignored local defaults to `.brigade/security.toml`; it supports policy presets (`personal`, `public-repo`, `strict`), `fail_on`, template scanning, and fingerprint suppressions for reviewed findings.
+`security` is a built-in station with no external managed tool yet. Run `brigade security scan --target .` for a read-only agent workspace security report, add `--output-dir .brigade/security/latest` to write redacted `security-report.json` and `security-report.md` artifacts, or add `--import-findings` to turn findings into local `brigade work import` review items. `brigade doctor` and `brigade work doctor` report security config health, latest evidence bundle status, and whether local security artifacts are ignored. `brigade security fix` applies the narrow safe hygiene fix for that local state: it creates `.brigade/security/` and refreshes the managed `.gitignore` block. Secret evidence is redacted before reports, artifacts, or imports are written. Use `brigade security init` to write gitignored local defaults to `.brigade/security.toml`; it supports policy presets (`personal`, `public-repo`, `strict`), `fail_on`, template scanning, and fingerprint suppressions for reviewed findings.
 
 The current managed tools:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -61,7 +61,7 @@ Brigade-specific additions:
 - Understand Brigade installs: `.brigade/`, `.codex/`, `.claude/`, memory handoff inboxes, roster files, dogfood configs, run artifacts, work imports, memory-care decay files, and public template folders.
 - Treat public-template findings differently from active runtime findings so docs and starter templates do not score like live credentials or enabled tools.
 - Integrate with `brigade doctor` as a security station and with `brigade work import` so findings can become reviewable local tasks instead of only console output. Status: started with doctor checks, work doctor checks, and `--import-findings`.
-- Provide safe auto-fix only for narrow cases such as replacing obvious hardcoded sample secrets, tightening generated allow-list examples, or adding missing ignore rules.
+- Provide safe auto-fix only for narrow cases such as replacing obvious hardcoded sample secrets, tightening generated allow-list examples, or adding missing ignore rules. Status: started with `brigade security fix` for local artifact directory and managed `.gitignore` hygiene.
 - Produce Memory Handoffs for durable security findings while keeping raw secret evidence redacted.
 - Add policy packs for personal dogfooding, public-repo release checks, CI gates, and strict enterprise workspaces. Status: started with `personal`, `public-repo`, and `strict`.
 - Include dependency and package-manager hardening checks for agent plugin ecosystems, MCP packages, skills, and local tool wrappers.

--- a/src/brigade/cli.py
+++ b/src/brigade/cli.py
@@ -391,6 +391,9 @@ def _build_parser() -> argparse.ArgumentParser:
     p_security_init = security_sub.add_parser("init", help="Write local security scan defaults.")
     p_security_init.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to configure.")
     p_security_init.add_argument("--force", action="store_true", help="Overwrite an existing security config.")
+    p_security_fix = security_sub.add_parser("fix", help="Apply safe local security hygiene fixes.")
+    p_security_fix.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update.")
+    p_security_fix.add_argument("--dry-run", action="store_true", help="Show changes without writing files.")
     p_security_scan = security_sub.add_parser("scan", help="Run a read-only agent workspace security scan.")
     p_security_scan.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to scan.")
     p_security_scan.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
@@ -791,6 +794,8 @@ def main(argv=None) -> int:
 
         if args.security_command == "init":
             return security_cmd.init(target=args.target, force=args.force)
+        if args.security_command == "fix":
+            return security_cmd.fix(target=args.target, dry_run=args.dry_run)
         if args.security_command == "scan":
             return security_cmd.scan(
                 target=args.target,

--- a/src/brigade/security_cmd.py
+++ b/src/brigade/security_cmd.py
@@ -262,6 +262,49 @@ def write_default_config(target: Path, *, force: bool = False) -> Path:
     return path
 
 
+def _gitignore_selection(target: Path):
+    from .config import load_config
+    from .selection import Selection
+
+    loaded = load_config(target)
+    if loaded is not None:
+        return loaded.selection
+    return Selection(depth="repo", harnesses=[], owner="this-repo", includes=[])
+
+
+def fix(*, target: Path, dry_run: bool = False) -> int:
+    from . import dogfood_cmd
+    from .install import apply_gitignore
+
+    target = target.expanduser().resolve()
+    if not target.is_dir():
+        print(f"error: --target is not a directory: {target}", file=sys.stderr)
+        return 2
+    try:
+        selection = _gitignore_selection(target)
+    except (ValueError, json.JSONDecodeError) as exc:
+        print(f"error: invalid Brigade config: {exc}", file=sys.stderr)
+        return 2
+
+    artifacts_root = default_artifacts_dir(target).parent
+    print(f"security fix: {target}")
+    if dry_run:
+        print("dry_run: True")
+        print(f"would_create: {artifacts_root}")
+        print("would_update: .gitignore")
+        return 0
+
+    artifacts_root.mkdir(parents=True, exist_ok=True)
+    result = apply_gitignore(target, selection)
+    config_ignored = dogfood_cmd._check_git_ignored(target, config_path(target))
+    artifacts_ignored = dogfood_cmd._check_git_ignored(target, artifacts_root)
+    print(f"security_artifacts_dir: {artifacts_root}")
+    print(f"gitignore: {result}")
+    print(f"security_config_ignored: {config_ignored}")
+    print(f"security_artifacts_ignored: {artifacts_ignored}")
+    return 0
+
+
 def _short(text: str, limit: int = 160) -> str:
     rendered = " ".join(text.split())
     if len(rendered) <= limit:

--- a/tests/test_security_cmd.py
+++ b/tests/test_security_cmd.py
@@ -100,6 +100,30 @@ def test_security_init_writes_gitignored_local_config(tmp_path, capsys):
     assert security_cmd.init(target=tmp_path, force=True) == 0
 
 
+def test_security_fix_prepares_local_ignored_security_paths(tmp_path, capsys):
+    tmp_path.mkdir(exist_ok=True)
+
+    assert security_cmd.fix(target=tmp_path) == 0
+    out = capsys.readouterr().out
+    assert "security fix:" in out
+    assert "gitignore:" in out
+    assert (tmp_path / ".brigade" / "security").is_dir()
+    gitignore = (tmp_path / ".gitignore").read_text()
+    assert ".brigade/security.toml" in gitignore
+    assert ".brigade/security/" in gitignore
+
+
+def test_security_fix_dry_run_does_not_write(tmp_path, capsys):
+    tmp_path.mkdir(exist_ok=True)
+
+    assert security_cmd.fix(target=tmp_path, dry_run=True) == 0
+    out = capsys.readouterr().out
+    assert "dry_run: True" in out
+    assert "would_update: .gitignore" in out
+    assert not (tmp_path / ".gitignore").exists()
+    assert not (tmp_path / ".brigade").exists()
+
+
 def test_security_scan_can_import_findings(tmp_path, capsys):
     (tmp_path / ".env").write_text("SERVICE_TOKEN=abcd1234abcd1234abcd1234\n")
 
@@ -182,6 +206,18 @@ def test_security_scan_cli(tmp_path, monkeypatch):
         "import_findings": True,
         "output_dir": tmp_path / "security-report",
     }
+
+
+def test_security_fix_cli(tmp_path, monkeypatch):
+    seen = {}
+
+    def fake_fix(**kwargs):
+        seen.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(security_cmd, "fix", fake_fix)
+    assert cli.main(["security", "fix", "--target", str(tmp_path), "--dry-run"]) == 0
+    assert seen == {"target": tmp_path, "dry_run": True}
 
 
 def test_security_init_cli(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add `brigade security fix` for narrow local security hygiene fixes
- create the local security artifact directory and refresh the managed gitignore block
- document the first safe-fix slice in README, CHANGELOG, and ROADMAP

## Verification
- `.venv/bin/python -m pytest tests/test_security_cmd.py tests/test_gitignore.py -q`
- `.venv/bin/python -m pytest -q`
- `PYTHONPATH=$HOME/repos/content-guard/src python3 -m content_guard scan . --policy $HOME/repos/content-guard/policies/public-repo.json`
- live temp repo smoke verified `security fix --dry-run`, real fix output, and git ignore coverage