### PR TITLE
feat: add security finding lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,9 +58,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `brigade security scan --import-findings` to route security findings into the local work import inbox for review.
 - `brigade security init` to write gitignored local defaults to `.brigade/security.toml`.
 - `brigade security fix` to create the local security artifact directory and refresh the managed `.gitignore` block.
+- `brigade security review`, `brigade security suppress`, and `brigade security unsuppress` for a local finding review lifecycle with required suppression reasons.
 - Security policy presets (`personal`, `public-repo`, `strict`), template scanning controls, stable finding fingerprints, and fingerprint suppressions.
 - `brigade security scan --output-dir <dir>` to write redacted `security-report.json` and `security-report.md` evidence bundles.
 - `brigade doctor` and `brigade work doctor` now report security config health, latest security evidence bundle status, and local security artifact ignore coverage.
+- `brigade doctor` and `brigade work doctor` now warn on stale security suppressions and suppressions missing reasons.
 - Security scan secret evidence is redacted before reports or work imports are written.
 - `ROADMAP.md` covering the daily-driver path, scanner-ready inbox, chat-surface scanners, memory-card decay refresh, and portable operator setup.
 - `brigade work note` to append timestamped checkpoints to the active work session without ending it.

--- a/README.md
+++ b/README.md
@@ -207,6 +207,9 @@ brigade security fix
 brigade security scan --target .
 brigade security scan --target . --policy public-repo
 brigade security scan --target . --output-dir .brigade/security/latest
+brigade security review
+brigade security suppress <fingerprint> --reason "reviewed false positive"
+brigade security unsuppress <fingerprint>
 brigade security scan --target . --import-findings
 ```
 
@@ -291,7 +294,7 @@ brigade add guard    # content-guard
 brigade add tokens   # tokenjuice
 ```
 
-`security` is a built-in station with no external managed tool yet. Run `brigade security scan --target .` for a read-only agent workspace security report, add `--output-dir .brigade/security/latest` to write redacted `security-report.json` and `security-report.md` artifacts, or add `--import-findings` to turn findings into local `brigade work import` review items. The scanner covers secrets, permissions, hooks, supply-chain patterns, prompt-injection patterns, and MCP configs including remote transports, auto-approval, unpinned `npx`, shell metacharacters, secret-looking env values, sensitive and broad file args, high-risk local commands, large server sets, and missing timeouts. `brigade doctor` and `brigade work doctor` report security config health, latest evidence bundle status, and whether local security artifacts are ignored. `brigade security fix` applies the narrow safe hygiene fix for that local state: it creates `.brigade/security/` and refreshes the managed `.gitignore` block. Secret evidence is redacted before reports, artifacts, or imports are written. Use `brigade security init` to write gitignored local defaults to `.brigade/security.toml`; it supports policy presets (`personal`, `public-repo`, `strict`), `fail_on`, template scanning, and fingerprint suppressions for reviewed findings.
+`security` is a built-in station with no external managed tool yet. Run `brigade security scan --target .` for a read-only agent workspace security report, add `--output-dir .brigade/security/latest` to write redacted `security-report.json` and `security-report.md` artifacts, or add `--import-findings` to turn findings into local `brigade work import` review items. Run `brigade security review` to inspect the latest evidence bundle, `brigade security suppress <fingerprint> --reason "..."` to suppress reviewed noise with a required reason, and `brigade security unsuppress <fingerprint>` to remove stale suppressions. The scanner covers secrets, permissions, hooks, supply-chain patterns, prompt-injection patterns, and MCP configs including remote transports, auto-approval, unpinned `npx`, shell metacharacters, secret-looking env values, sensitive and broad file args, high-risk local commands, large server sets, and missing timeouts. `brigade doctor` and `brigade work doctor` report security config health, stale suppressions, missing suppression reasons, latest evidence bundle status, and whether local security artifacts are ignored. `brigade security fix` applies the narrow safe hygiene fix for that local state: it creates `.brigade/security/` and refreshes the managed `.gitignore` block. Secret evidence is redacted before reports, artifacts, or imports are written. Use `brigade security init` to write gitignored local defaults to `.brigade/security.toml`; it supports policy presets (`personal`, `public-repo`, `strict`), `fail_on`, template scanning, and fingerprint suppressions for reviewed findings.
 
 The current managed tools:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -65,7 +65,16 @@ Brigade-specific additions:
 - Produce Memory Handoffs for durable security findings while keeping raw secret evidence redacted.
 - Add policy packs for personal dogfooding, public-repo release checks, CI gates, and strict enterprise workspaces. Status: started with `personal`, `public-repo`, and `strict`.
 - Include dependency and package-manager hardening checks for agent plugin ecosystems, MCP packages, skills, and local tool wrappers.
-- Track false-positive taxonomy, runtime-confidence rules, suppressions, and regression fixtures as first-class project artifacts.
+- Track false-positive taxonomy, runtime-confidence rules, suppressions, and regression fixtures as first-class project artifacts. Status: started with `brigade security review`, reasoned suppressions, unsuppress, and stale-suppression doctor warnings.
+
+## Later Phase: Issue And TDD Work Loop
+
+Goal: make Brigade support a narrow issue lifecycle for daily work: pick one task, define acceptance, test first when practical, implement, review, refactor, and close.
+
+- Add task templates for vertical-slice work, bugfix work, and RED/GREEN/REFACTOR loops.
+- Let `brigade work run` consume structured acceptance criteria from the local task ledger or a GitHub issue mirror.
+- Keep repo-shareable workflow rules separate from gitignored personal/global preferences.
+- Add doctor checks for missing acceptance criteria or stale active issue context.
 
 First build slice:
 

--- a/src/brigade/cli.py
+++ b/src/brigade/cli.py
@@ -394,6 +394,17 @@ def _build_parser() -> argparse.ArgumentParser:
     p_security_fix = security_sub.add_parser("fix", help="Apply safe local security hygiene fixes.")
     p_security_fix.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update.")
     p_security_fix.add_argument("--dry-run", action="store_true", help="Show changes without writing files.")
+    p_security_review = security_sub.add_parser("review", help="Review the latest local security evidence bundle.")
+    p_security_review.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to review.")
+    p_security_review.add_argument("--output-dir", type=Path, default=None, help="Security evidence bundle directory.")
+    p_security_review.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_security_suppress = security_sub.add_parser("suppress", help="Suppress a reviewed security finding fingerprint.")
+    p_security_suppress.add_argument("fingerprint", help="Finding fingerprint to suppress.")
+    p_security_suppress.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update.")
+    p_security_suppress.add_argument("--reason", required=True, help="Required suppression reason.")
+    p_security_unsuppress = security_sub.add_parser("unsuppress", help="Remove a security finding suppression.")
+    p_security_unsuppress.add_argument("fingerprint", help="Finding fingerprint to unsuppress.")
+    p_security_unsuppress.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update.")
     p_security_scan = security_sub.add_parser("scan", help="Run a read-only agent workspace security scan.")
     p_security_scan.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to scan.")
     p_security_scan.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
@@ -796,6 +807,12 @@ def main(argv=None) -> int:
             return security_cmd.init(target=args.target, force=args.force)
         if args.security_command == "fix":
             return security_cmd.fix(target=args.target, dry_run=args.dry_run)
+        if args.security_command == "review":
+            return security_cmd.review(target=args.target, output_dir=args.output_dir, json_output=args.json)
+        if args.security_command == "suppress":
+            return security_cmd.suppress(target=args.target, fingerprint=args.fingerprint, reason=args.reason)
+        if args.security_command == "unsuppress":
+            return security_cmd.unsuppress(target=args.target, fingerprint=args.fingerprint)
         if args.security_command == "scan":
             return security_cmd.scan(
                 target=args.target,

--- a/src/brigade/doctor.py
+++ b/src/brigade/doctor.py
@@ -87,15 +87,35 @@ def security_station_checks(ctx: DoctorContext) -> List[CheckResult]:
 
     results: List[CheckResult] = [(OK, "security: built-in scanner", "available")]
     config = security_cmd.config_path(ctx.target)
+    config_valid = True
     if config.is_file():
         try:
             loaded = security_cmd.load_config(ctx.target)
         except ValueError as exc:
+            config_valid = False
             results.append((FAIL, "security: config", f"invalid {config}: {exc}"))
         else:
             results.append((OK, "security: config", f"{config} (policy={loaded.policy if loaded else 'personal'})"))
     else:
         results.append((WARN, "security: config", f"missing at {config}; run `brigade security init --target .`"))
+
+    if config_valid:
+        try:
+            suppression_health = security_cmd.suppression_health(ctx.target)
+        except ValueError as exc:
+            results.append((FAIL, "security: suppressions", f"invalid: {exc}"))
+        else:
+            suppression_count = suppression_health["suppression_count"]
+            stale = suppression_health["stale"]
+            missing_reasons = suppression_health["missing_reasons"]
+            if stale:
+                preview = ", ".join(stale[:5])
+                results.append((WARN, "security: stale suppressions", f"{len(stale)} no longer match current findings: {preview}"))
+            if missing_reasons:
+                preview = ", ".join(missing_reasons[:5])
+                results.append((WARN, "security: suppression reasons", f"{len(missing_reasons)} missing reason: {preview}"))
+            if not stale and not missing_reasons:
+                results.append((OK, "security: suppressions", f"{suppression_count} configured"))
 
     artifacts_dir = security_cmd.default_artifacts_dir(ctx.target)
     bundle = security_cmd.inspect_evidence_bundle(artifacts_dir)

--- a/src/brigade/security_cmd.py
+++ b/src/brigade/security_cmd.py
@@ -7,7 +7,7 @@ import json
 import re
 import sys
 from datetime import datetime, timezone
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -99,6 +99,7 @@ MCP_BROAD_PATHS = {"~", "$HOME", "/", "/home", "/Users"}
 MCP_HIGH_RISK_COMMANDS = {"bash", "sh", "zsh", "fish", "powershell", "pwsh", "docker", "podman", "ssh", "scp", "rsync"}
 MCP_SERVER_COUNT_WARN = 8
 MCP_SHELL_META_RE = re.compile(r"[;&|`<>]|\$\(")
+FINGERPRINT_RE = re.compile(r"^[a-f0-9]{16}$")
 
 
 @dataclass(frozen=True)
@@ -107,6 +108,7 @@ class SecurityConfig:
     fail_on: str | None = None
     include_templates: bool | None = None
     suppressions: tuple[str, ...] = ()
+    suppression_reasons: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -172,11 +174,11 @@ def _read_toml_object(path: Path) -> dict[str, object]:
             continue
         if line.startswith("[") and line.endswith("]"):
             table = line[1:-1].strip()
-            if table != "suppressions":
+            if table not in {"suppressions", "suppression_reasons"}:
                 raise ValueError(f"invalid security config line {line_number}: unsupported table [{table}]")
-            current = data.setdefault("suppressions", {})
+            current = data.setdefault(table, {})
             if not isinstance(current, dict):
-                raise ValueError(f"invalid security config line {line_number}: suppressions must be a table")
+                raise ValueError(f"invalid security config line {line_number}: {table} must be a table")
             continue
         if "=" not in line:
             raise ValueError(f"invalid security config line {line_number}: expected key = value")
@@ -211,11 +213,22 @@ def load_config(target: Path) -> SecurityConfig | None:
         if not isinstance(fingerprints, list) or not all(isinstance(item, str) for item in fingerprints):
             raise ValueError("suppressions.fingerprints must be a list of strings")
         suppressions = tuple(item.strip() for item in fingerprints if item.strip())
+    suppression_reasons: dict[str, str] = {}
+    raw_reasons = data.get("suppression_reasons", {})
+    if raw_reasons:
+        if not isinstance(raw_reasons, dict):
+            raise ValueError("suppression_reasons must be a table")
+        for fingerprint, reason in raw_reasons.items():
+            if not isinstance(fingerprint, str) or not isinstance(reason, str):
+                raise ValueError("suppression_reasons entries must be string = string")
+            if fingerprint.strip() and reason.strip():
+                suppression_reasons[fingerprint.strip()] = reason.strip()
     return SecurityConfig(
         policy=policy,
         fail_on=fail_on,
         include_templates=include_templates,
         suppressions=suppressions,
+        suppression_reasons=suppression_reasons,
     )
 
 
@@ -265,10 +278,51 @@ def write_default_config(target: Path, *, force: bool = False) -> Path:
                 "[suppressions]",
                 "fingerprints = []",
                 "",
+                "[suppression_reasons]",
+                "",
             ]
         )
     )
     return path
+
+
+def _toml_string(value: str) -> str:
+    return json.dumps(value)
+
+
+def write_config(target: Path, config: SecurityConfig) -> Path:
+    path = config_path(target.expanduser().resolve())
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fingerprints = ", ".join(_toml_string(item) for item in config.suppressions)
+    lines = [
+        f"policy = {_toml_string(config.policy)}",
+        f"fail_on = {_toml_string(config.fail_on or POLICIES[config.policy]['fail_on'])}",
+        f"include_templates = {str(config.include_templates if config.include_templates is not None else POLICIES[config.policy]['include_templates']).lower()}",
+        "",
+        "[suppressions]",
+        f"fingerprints = [{fingerprints}]",
+        "",
+        "[suppression_reasons]",
+    ]
+    reasons = config.suppression_reasons
+    for fingerprint in config.suppressions:
+        reason = reasons.get(fingerprint)
+        if reason:
+            lines.append(f"{fingerprint} = {_toml_string(reason)}")
+    lines.append("")
+    path.write_text("\n".join(lines))
+    return path
+
+
+def _load_config_or_default(target: Path) -> SecurityConfig:
+    loaded = load_config(target)
+    if loaded is not None:
+        return loaded
+    return SecurityConfig()
+
+
+def _clean_reason(reason: str) -> str:
+    return " ".join(reason.replace("#", " ").split()).strip()
 
 
 def _gitignore_selection(target: Path):
@@ -312,6 +366,194 @@ def fix(*, target: Path, dry_run: bool = False) -> int:
     print(f"security_config_ignored: {config_ignored}")
     print(f"security_artifacts_ignored: {artifacts_ignored}")
     return 0
+
+
+def _load_report(output_dir: Path) -> dict[str, Any]:
+    path = output_dir.expanduser().resolve() / "security-report.json"
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    data = json.loads(path.read_text())
+    if not isinstance(data, dict):
+        raise ValueError(f"security report must be a JSON object: {path}")
+    return data
+
+
+def _report_findings_for_review(target: Path, report: dict[str, Any]) -> list[dict[str, Any]]:
+    config = load_config(target) or SecurityConfig()
+    suppressed = set(config.suppressions)
+    reasons = config.suppression_reasons
+    records: list[dict[str, Any]] = []
+    for finding in report.get("findings", []):
+        if not isinstance(finding, dict):
+            continue
+        fingerprint = str(finding.get("fingerprint") or "")
+        record = dict(finding)
+        record["status"] = "suppressed" if fingerprint in suppressed else "open"
+        if fingerprint in reasons:
+            record["reason"] = reasons[fingerprint]
+        records.append(record)
+    for finding in report.get("suppressed_findings", []):
+        if not isinstance(finding, dict):
+            continue
+        fingerprint = str(finding.get("fingerprint") or "")
+        record = dict(finding)
+        record["status"] = "suppressed"
+        if fingerprint in reasons:
+            record["reason"] = reasons[fingerprint]
+        records.append(record)
+    records.sort(
+        key=lambda item: (
+            -SEVERITY_ORDER.get(str(item.get("severity")), 0),
+            str(item.get("category") or ""),
+            str(item.get("path") or ""),
+            int(item.get("line") or 0),
+        )
+    )
+    return records
+
+
+def review(*, target: Path, output_dir: Path | None = None, json_output: bool = False) -> int:
+    target = target.expanduser().resolve()
+    if not target.is_dir():
+        print(f"error: --target is not a directory: {target}", file=sys.stderr)
+        return 2
+    artifacts_dir = output_dir.expanduser().resolve() if output_dir is not None else default_artifacts_dir(target)
+    try:
+        report = _load_report(artifacts_dir)
+        records = _report_findings_for_review(target, report)
+    except FileNotFoundError as exc:
+        print(f"error: security report not found: {exc}", file=sys.stderr)
+        return 2
+    except (ValueError, json.JSONDecodeError) as exc:
+        print(f"error: invalid security report: {exc}", file=sys.stderr)
+        return 2
+
+    payload = {
+        "artifacts": str(artifacts_dir),
+        "generated_at": report.get("generated_at"),
+        "policy": report.get("policy"),
+        "findings": records,
+        "finding_count": len(records),
+        "open_count": len([item for item in records if item.get("status") != "suppressed"]),
+        "suppressed_count": len([item for item in records if item.get("status") == "suppressed"]),
+    }
+    if json_output:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+
+    print(f"security review: {artifacts_dir}")
+    print(f"generated_at: {payload['generated_at']}")
+    print(f"policy: {payload['policy']}")
+    print(f"findings: {payload['finding_count']}")
+    print(f"open: {payload['open_count']}")
+    print(f"suppressed: {payload['suppressed_count']}")
+    current_group: tuple[str, str] | None = None
+    for finding in records:
+        group = (str(finding.get("severity") or "unknown"), str(finding.get("category") or "unknown"))
+        if group != current_group:
+            current_group = group
+            print(f"{group[0]} / {group[1]}:")
+        print(
+            f"- {finding.get('fingerprint')} [{finding.get('status')}] "
+            f"{finding.get('path')}:{finding.get('line')} {finding.get('title')}"
+        )
+        if finding.get("reason"):
+            print(f"  reason: {finding['reason']}")
+        print(f"  suggestion: {finding.get('suggestion')}")
+    return 0
+
+
+def suppress(*, target: Path, fingerprint: str, reason: str) -> int:
+    target = target.expanduser().resolve()
+    if not target.is_dir():
+        print(f"error: --target is not a directory: {target}", file=sys.stderr)
+        return 2
+    fingerprint = fingerprint.strip()
+    cleaned_reason = _clean_reason(reason)
+    if not FINGERPRINT_RE.match(fingerprint):
+        print("error: fingerprint must be a 16-character lowercase hex value", file=sys.stderr)
+        return 2
+    if not cleaned_reason:
+        print("error: --reason is required", file=sys.stderr)
+        return 2
+    try:
+        config = _load_config_or_default(target)
+    except ValueError as exc:
+        print(f"error: invalid security config: {exc}", file=sys.stderr)
+        return 2
+    suppressions = list(config.suppressions)
+    if fingerprint not in suppressions:
+        suppressions.append(fingerprint)
+    reasons = dict(config.suppression_reasons)
+    reasons[fingerprint] = cleaned_reason
+    path = write_config(
+        target,
+        SecurityConfig(
+            policy=config.policy,
+            fail_on=config.fail_on,
+            include_templates=config.include_templates,
+            suppressions=tuple(suppressions),
+            suppression_reasons=reasons,
+        ),
+    )
+    print(f"security_config: {path}")
+    print(f"suppressed: {fingerprint}")
+    print(f"reason: {cleaned_reason}")
+    return 0
+
+
+def unsuppress(*, target: Path, fingerprint: str) -> int:
+    target = target.expanduser().resolve()
+    if not target.is_dir():
+        print(f"error: --target is not a directory: {target}", file=sys.stderr)
+        return 2
+    fingerprint = fingerprint.strip()
+    if not FINGERPRINT_RE.match(fingerprint):
+        print("error: fingerprint must be a 16-character lowercase hex value", file=sys.stderr)
+        return 2
+    try:
+        config = _load_config_or_default(target)
+    except ValueError as exc:
+        print(f"error: invalid security config: {exc}", file=sys.stderr)
+        return 2
+    if fingerprint not in config.suppressions and fingerprint not in config.suppression_reasons:
+        print(f"error: suppression not found: {fingerprint}", file=sys.stderr)
+        return 1
+    suppressions = tuple(item for item in config.suppressions if item != fingerprint)
+    reasons = dict(config.suppression_reasons)
+    reasons.pop(fingerprint, None)
+    path = write_config(
+        target,
+        SecurityConfig(
+            policy=config.policy,
+            fail_on=config.fail_on,
+            include_templates=config.include_templates,
+            suppressions=suppressions,
+            suppression_reasons=reasons,
+        ),
+    )
+    print(f"security_config: {path}")
+    print(f"unsuppressed: {fingerprint}")
+    return 0
+
+
+def suppression_health(target: Path) -> dict[str, Any]:
+    target = target.expanduser().resolve()
+    config = load_config(target)
+    if config is None:
+        return {"suppression_count": 0, "missing_reasons": [], "stale": []}
+    if not config.suppressions:
+        return {"suppression_count": 0, "missing_reasons": [], "stale": []}
+    effective = _effective_policy(target, policy=None, fail_on=None, include_templates=None)
+    report = scan_target(target, include_templates=effective.include_templates, suppressions=())
+    active = {str(item.get("fingerprint")) for item in report["findings"] if item.get("fingerprint")}
+    stale = [fingerprint for fingerprint in config.suppressions if fingerprint not in active]
+    missing_reasons = [fingerprint for fingerprint in config.suppressions if not config.suppression_reasons.get(fingerprint)]
+    return {
+        "suppression_count": len(config.suppressions),
+        "missing_reasons": missing_reasons,
+        "stale": stale,
+    }
 
 
 def _short(text: str, limit: int = 160) -> str:

--- a/src/brigade/work_cmd.py
+++ b/src/brigade/work_cmd.py
@@ -2263,10 +2263,12 @@ def doctor(*, target: Path) -> int:
         _doctor_line(OK, "dogfood_artifacts", artifacts_dir)
 
     security_config = security_cmd.config_path(effective_target)
+    security_config_valid = True
     if security_config.is_file():
         try:
             loaded_security = security_cmd.load_config(effective_target)
         except ValueError as exc:
+            security_config_valid = False
             failures += 1
             _doctor_line(FAIL, "security_config", f"invalid {security_config}: {exc}")
         else:
@@ -2274,6 +2276,22 @@ def doctor(*, target: Path) -> int:
             _doctor_line(OK, "security_config", f"{security_config} (policy={policy})")
     else:
         _doctor_line(WARN, "security_config", f"missing, run `brigade security init --target {effective_target}`")
+
+    if security_config_valid:
+        try:
+            suppression_health = security_cmd.suppression_health(effective_target)
+        except ValueError as exc:
+            failures += 1
+            _doctor_line(FAIL, "security_suppressions", f"invalid: {exc}")
+        else:
+            stale = suppression_health["stale"]
+            missing_reasons = suppression_health["missing_reasons"]
+            if stale:
+                _doctor_line(WARN, "security_stale_suppressions", f"{len(stale)} no longer match current findings: {', '.join(stale[:5])}")
+            if missing_reasons:
+                _doctor_line(WARN, "security_suppression_reasons", f"{len(missing_reasons)} missing reason: {', '.join(missing_reasons[:5])}")
+            if not stale and not missing_reasons:
+                _doctor_line(OK, "security_suppressions", f"{suppression_health['suppression_count']} configured")
 
     security_artifacts = security_cmd.default_artifacts_dir(effective_target)
     security_bundle = security_cmd.inspect_evidence_bundle(security_artifacts)

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -78,6 +78,36 @@ def test_doctor_fails_invalid_security_config(tmp_target: Path, capsys):
     assert "invalid" in out
 
 
+def test_doctor_warns_on_stale_security_suppressions(tmp_target: Path, capsys):
+    install_selection(
+        tmp_target,
+        Selection(depth="workspace", harnesses=["claude"], owner="claude", includes=[]),
+    )
+    security_config = tmp_target / ".brigade" / "security.toml"
+    security_config.parent.mkdir(exist_ok=True)
+    security_config.write_text(
+        "\n".join(
+            [
+                'policy = "personal"',
+                'fail_on = "critical"',
+                "include_templates = false",
+                "",
+                "[suppressions]",
+                'fingerprints = ["0123456789abcdef"]',
+                "",
+                "[suppression_reasons]",
+                "",
+            ]
+        )
+    )
+
+    rc = doctor_mod.run(target=tmp_target, harness="generic")
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "security: stale suppressions" in out
+    assert "security: suppression reasons" in out
+
+
 def test_doctor_fails_when_bootstrap_file_exceeds_budget(tmp_target: Path, capsys):
     install_selection(
         tmp_target,

--- a/tests/test_security_cmd.py
+++ b/tests/test_security_cmd.py
@@ -135,6 +135,72 @@ def test_security_config_and_suppressions(tmp_path, capsys):
     assert payload["suppressed_findings"][0]["fingerprint"] == fingerprint
 
 
+def test_security_review_suppress_and_unsuppress(tmp_path, capsys):
+    (tmp_path / ".env").write_text("SERVICE_TOKEN=abcd1234abcd1234abcd1234\n")
+    output_dir = tmp_path / ".brigade" / "security" / "latest"
+    assert security_cmd.scan(target=tmp_path, fail_on="none", output_dir=output_dir) == 0
+    capsys.readouterr()
+    report = json.loads((output_dir / "security-report.json").read_text())
+    fingerprint = report["findings"][0]["fingerprint"]
+
+    assert security_cmd.review(target=tmp_path, json_output=True) == 0
+    review_payload = json.loads(capsys.readouterr().out)
+    assert review_payload["open_count"] == 1
+    assert review_payload["findings"][0]["status"] == "open"
+
+    assert security_cmd.suppress(target=tmp_path, fingerprint=fingerprint, reason="reviewed local fake token") == 0
+    out = capsys.readouterr().out
+    assert f"suppressed: {fingerprint}" in out
+    loaded = security_cmd.load_config(tmp_path)
+    assert loaded is not None
+    assert fingerprint in loaded.suppressions
+    assert loaded.suppression_reasons[fingerprint] == "reviewed local fake token"
+
+    assert security_cmd.review(target=tmp_path, json_output=True) == 0
+    review_payload = json.loads(capsys.readouterr().out)
+    assert review_payload["suppressed_count"] == 1
+    assert review_payload["findings"][0]["status"] == "suppressed"
+    assert review_payload["findings"][0]["reason"] == "reviewed local fake token"
+
+    assert security_cmd.scan(target=tmp_path, fail_on="none", json_output=True) == 0
+    scan_payload = json.loads(capsys.readouterr().out)
+    assert scan_payload["finding_count"] == 0
+    assert scan_payload["suppressed_count"] == 1
+
+    assert security_cmd.unsuppress(target=tmp_path, fingerprint=fingerprint) == 0
+    out = capsys.readouterr().out
+    assert f"unsuppressed: {fingerprint}" in out
+    loaded = security_cmd.load_config(tmp_path)
+    assert loaded is not None
+    assert fingerprint not in loaded.suppressions
+    assert fingerprint not in loaded.suppression_reasons
+
+
+def test_security_suppression_health_reports_stale_and_missing_reasons(tmp_path):
+    config = tmp_path / ".brigade" / "security.toml"
+    config.parent.mkdir(parents=True)
+    config.write_text(
+        "\n".join(
+            [
+                'policy = "personal"',
+                'fail_on = "critical"',
+                "include_templates = false",
+                "",
+                "[suppressions]",
+                'fingerprints = ["0123456789abcdef"]',
+                "",
+                "[suppression_reasons]",
+                "",
+            ]
+        )
+    )
+
+    health = security_cmd.suppression_health(tmp_path)
+    assert health["suppression_count"] == 1
+    assert health["stale"] == ["0123456789abcdef"]
+    assert health["missing_reasons"] == ["0123456789abcdef"]
+
+
 def test_security_init_writes_gitignored_local_config(tmp_path, capsys):
     tmp_path.mkdir(exist_ok=True)
 
@@ -256,6 +322,42 @@ def test_security_scan_cli(tmp_path, monkeypatch):
         "import_findings": True,
         "output_dir": tmp_path / "security-report",
     }
+
+
+def test_security_review_cli(tmp_path, monkeypatch):
+    seen = {}
+
+    def fake_review(**kwargs):
+        seen.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(security_cmd, "review", fake_review)
+    assert cli.main(["security", "review", "--target", str(tmp_path), "--output-dir", str(tmp_path / "out"), "--json"]) == 0
+    assert seen == {"target": tmp_path, "output_dir": tmp_path / "out", "json_output": True}
+
+
+def test_security_suppress_cli(tmp_path, monkeypatch):
+    seen = {}
+
+    def fake_suppress(**kwargs):
+        seen.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(security_cmd, "suppress", fake_suppress)
+    assert cli.main(["security", "suppress", "0123456789abcdef", "--target", str(tmp_path), "--reason", "reviewed"]) == 0
+    assert seen == {"target": tmp_path, "fingerprint": "0123456789abcdef", "reason": "reviewed"}
+
+
+def test_security_unsuppress_cli(tmp_path, monkeypatch):
+    seen = {}
+
+    def fake_unsuppress(**kwargs):
+        seen.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(security_cmd, "unsuppress", fake_unsuppress)
+    assert cli.main(["security", "unsuppress", "0123456789abcdef", "--target", str(tmp_path)]) == 0
+    assert seen == {"target": tmp_path, "fingerprint": "0123456789abcdef"}
 
 
 def test_security_fix_cli(tmp_path, monkeypatch):

--- a/tests/test_work_cmd.py
+++ b/tests/test_work_cmd.py
@@ -116,6 +116,34 @@ def test_work_doctor_fails_invalid_security_config(tmp_path, monkeypatch, capsys
     assert "[fail] ready: 1 blocker" in out
 
 
+def test_work_doctor_warns_on_stale_security_suppressions(tmp_path, monkeypatch, capsys):
+    _init_git_repo(tmp_path)
+    dogfood_cmd.init(target=tmp_path)
+    security_config = tmp_path / ".brigade" / "security.toml"
+    security_config.write_text(
+        "\n".join(
+            [
+                'policy = "personal"',
+                'fail_on = "critical"',
+                "include_templates = false",
+                "",
+                "[suppressions]",
+                'fingerprints = ["0123456789abcdef"]',
+                "",
+                "[suppression_reasons]",
+                "",
+            ]
+        )
+    )
+    monkeypatch.setattr(work_cmd.shutil, "which", lambda name: f"/usr/bin/{name}" if name == "codex" else None)
+    monkeypatch.setattr(dogfood_cmd, "_check_git_ignored", lambda repo, path: "yes")
+
+    assert work_cmd.doctor(target=tmp_path) == 0
+    out = capsys.readouterr().out
+    assert "[warn] security_stale_suppressions:" in out
+    assert "[warn] security_suppression_reasons:" in out
+
+
 def test_work_doctor_reports_blockers(tmp_path, monkeypatch, capsys):
     _init_git_repo(tmp_path)
     monkeypatch.setattr(work_cmd.shutil, "which", lambda name: None)


### PR DESCRIPTION
## Summary
- add `brigade security review` for latest evidence bundle inspection
- add reasoned `brigade security suppress` and `brigade security unsuppress`
- warn in `brigade doctor` and `brigade work doctor` for stale suppressions and missing suppression reasons
- add roadmap note for a later issue/TDD work loop

## Verification
- `.venv/bin/python -m pytest tests/test_security_cmd.py tests/test_doctor.py::test_doctor_warns_on_stale_security_suppressions tests/test_work_cmd.py::test_work_doctor_warns_on_stale_security_suppressions -q`
- `.venv/bin/python -m pytest tests/test_work_cmd.py::test_work_doctor_fails_invalid_security_config tests/test_security_cmd.py tests/test_doctor.py::test_doctor_fails_invalid_security_config tests/test_doctor.py::test_doctor_warns_on_stale_security_suppressions -q`
- `.venv/bin/python -m pytest -q`
- `PYTHONPATH=$HOME/repos/content-guard/src python3 -m content_guard scan . --policy $HOME/repos/content-guard/policies/public-repo.json`
- live temp repo security lifecycle smoke verified scan, review, suppress, rescan, unsuppress, and config cleanup