### PR TITLE
fix: guard work import state transitions

### DIFF
--- a/src/brigade/work_cmd.py
+++ b/src/brigade/work_cmd.py
@@ -1993,6 +1993,9 @@ def import_promote(
     if item is None:
         print(f"error: import not found: {import_id}", file=sys.stderr)
         return 1
+    if item.get("status", "pending") != "pending":
+        print(f"error: import is not pending: {item.get('id')} ({item.get('status')})", file=sys.stderr)
+        return 2
     text = str(item.get("text") or "").strip()
     if not text:
         print(f"error: import has no text: {import_id}", file=sys.stderr)
@@ -2016,6 +2019,9 @@ def import_dismiss(*, target: Path, import_id: str, reason: str | None = None) -
     if item is None:
         print(f"error: import not found: {import_id}", file=sys.stderr)
         return 1
+    if item.get("status", "pending") != "pending":
+        print(f"error: import is not pending: {item.get('id')} ({item.get('status')})", file=sys.stderr)
+        return 2
     now = _now().isoformat()
     item["status"] = "dismissed"
     item["updated_at"] = now

--- a/tests/test_work_cmd.py
+++ b/tests/test_work_cmd.py
@@ -942,6 +942,46 @@ def test_work_import_dismiss_marks_import_not_pending(tmp_path, monkeypatch, cap
     assert payload["imports"][0]["dismiss_reason"] == "not actionable"
 
 
+def test_work_import_promote_rejects_non_pending_import(tmp_path, monkeypatch, capsys):
+    _init_git_repo(tmp_path)
+    monkeypatch.setattr(
+        work_cmd,
+        "_now",
+        lambda: datetime(2026, 5, 26, 12, 0, 0, tzinfo=timezone.utc),
+    )
+    assert work_cmd.import_add(target=tmp_path, text="Dismissed scanner item", source="discord") == 0
+    import_id = capsys.readouterr().out.split("import: ", 1)[1].splitlines()[0]
+    assert work_cmd.import_dismiss(target=tmp_path, import_id=import_id) == 0
+    capsys.readouterr()
+
+    assert work_cmd.import_promote(target=tmp_path, import_id=import_id) == 2
+    assert "import is not pending" in capsys.readouterr().err
+
+    imports = json.loads((tmp_path / ".brigade" / "work" / "imports" / "inbox.jsonl").read_text().splitlines()[0])
+    assert imports["status"] == "dismissed"
+    assert not (tmp_path / ".brigade" / "work" / "tasks.json").exists()
+
+
+def test_work_import_dismiss_rejects_non_pending_import(tmp_path, monkeypatch, capsys):
+    _init_git_repo(tmp_path)
+    monkeypatch.setattr(
+        work_cmd,
+        "_now",
+        lambda: datetime(2026, 5, 26, 12, 0, 0, tzinfo=timezone.utc),
+    )
+    assert work_cmd.import_add(target=tmp_path, text="Promote scanner item", source="slack") == 0
+    import_id = capsys.readouterr().out.split("import: ", 1)[1].splitlines()[0]
+    assert work_cmd.import_promote(target=tmp_path, import_id=import_id) == 0
+    capsys.readouterr()
+
+    assert work_cmd.import_dismiss(target=tmp_path, import_id=import_id, reason="late cleanup") == 2
+    assert "import is not pending" in capsys.readouterr().err
+
+    payload = json.loads((tmp_path / ".brigade" / "work" / "imports" / "inbox.jsonl").read_text().splitlines()[0])
+    assert payload["status"] == "promoted"
+    assert "dismiss_reason" not in payload
+
+
 def test_work_brief_includes_pending_imports(tmp_path, monkeypatch, capsys):
     _init_git_repo(tmp_path)
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

- prevent single-id `work import promote` from promoting dismissed or already promoted imports
- prevent single-id `work import dismiss` from dismissing promoted or dismissed imports
- add regression coverage for both non-pending state transitions

## Review Finding

The review checkpoint found that batch promotion filtered pending imports, but single-id promote/dismiss accepted any matching import id. That let stale scanner queue items mutate after review. The commands now return exit code 2 for non-pending imports.

## Validation

- `.venv/bin/python -m pytest tests/test_work_cmd.py -q`
- `.venv/bin/python -m pytest -q`
- `PYTHONPATH=$HOME/repos/content-guard/src python3 -m content_guard scan . --policy $HOME/repos/content-guard/policies/public-repo.json`
- `git diff --check`
- live CLI smoke for dismiss-then-promote rejection
