### PR TITLE
Add handoff source doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `brigade work import triage` to group pending imports by source and kind.
 - `brigade work import dismiss` to close noisy imports without promoting them.
 - `brigade work import promote --all` with optional `--source` and `--kind` filters for batch promotion.
+- `brigade handoff doctor` to compare pending `.claude` and `.codex` memory handoffs against gitignored local source config.
+- Repo installs now include `.brigade/handoff-sources.example.json` as the local handoff ingestor source-list contract.
 - `docs/import-schema.md` documenting the local import JSONL contract for scanners and wrappers.
 - Cybersecurity plugin roadmap covering broad agent-workspace security checks plus Brigade-specific scanner, doctor, import, and multi-harness security checks.
 - Built-in `security` station and `brigade security scan` for read-only agent workspace security checks.
@@ -85,6 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `brigade work task add --from-next` now reuses an equivalent pending task instead of adding duplicates.
 - `brigade work brief` now includes pending local work imports and import counts in both text and JSON output.
 - The managed gitignore block now treats `.brigade/dogfood.toml`, `.brigade/security.toml`, `.brigade/runs/`, and `.brigade/security/` as local state.
+- The managed gitignore block now treats `.brigade/handoff-sources.json` as host-local state.
 - Live smoke docs now keep Codex agent execution in a trusted repo cwd while writing temporary roster, artifacts, and handoff output under `/tmp`.
 - Handoff write failures now preserve final run artifacts, print the final answer, return nonzero, and mark `run.json` as `handoff-failed`.
 - Dogfood runs default to prompt-level read-only plus Codex's `danger-full-access` sandbox setting for trusted-workspace use so repo inspection works on hosts where native read-only sandboxing blocks shell inspection; `--native-read-only-sandbox` opts into stricter native enforcement.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ brigade init --target ./repo --harnesses none           # generic install
 ```
 
 Once installed, `brigade doctor` verifies the wiring and `brigade status` reports over the station registry.
+For machines that ingest handoffs from multiple repos, copy `.brigade/handoff-sources.example.json` to `.brigade/handoff-sources.json` and list the repo roots and writer inboxes the canonical ingestor scans.
+`brigade handoff doctor` reports pending `.claude/memory-handoffs/` and `.codex/memory-handoffs/` files that are not covered by that local source list.
 
 ## Run a brigade
 
@@ -150,6 +152,7 @@ brigade dogfood status
 brigade dogfood
 brigade dogfood next
 brigade dogfood --target /path/to/repo
+brigade handoff doctor
 brigade work bootstrap
 brigade work status
 brigade work doctor

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -110,7 +110,7 @@ Goal: prevent durable memory from silently rotting.
 - Promote refresh candidates into tasks or memory handoffs after review.
 - Auto-fix only within safe gates where source evidence is current, low-risk, and locally reviewable.
 - Treat bootstrap truncation as a hard failure. Bootstrap files stay slim, cards hold durable detail, and doctor checks enforce the boundary.
-- Add a handoff doctor that compares repo-local writer inboxes such as `.claude/memory-handoffs/` and `.codex/memory-handoffs/` against the canonical ingestor source list, warning when handoffs exist in directories the owner is not scanning.
+- Add a handoff doctor that compares repo-local writer inboxes such as `.claude/memory-handoffs/` and `.codex/memory-handoffs/` against the canonical ingestor source list, warning when handoffs exist in directories the owner is not scanning. Status: started with `brigade handoff doctor`, `.brigade/handoff-sources.example.json`, and `brigade doctor` / `brigade work doctor` integration.
 - Add handoff-ingest observability checks for hidden warning states, including unreachable remote sources, malformed handoffs that are skipped, and runs that emit `NO_REPLY` despite warnings.
 
 ## Later Phase: Portable Operator Setup

--- a/src/brigade/cli.py
+++ b/src/brigade/cli.py
@@ -107,6 +107,15 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p_dogfood.add_argument("--timeout-seconds", type=float, default=DEFAULT_TIMEOUT_SECONDS, help="Per-agent timeout.")
 
+    # handoff
+    p_handoff = sub.add_parser("handoff", help="Inspect memory handoff inbox health.")
+    handoff_sub = p_handoff.add_subparsers(dest="handoff_command", metavar="<handoff-command>")
+    handoff_sub.required = True
+    p_handoff_doctor = handoff_sub.add_parser("doctor", help="Check handoff inboxes against local source config.")
+    p_handoff_doctor.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
+    p_handoff_doctor.add_argument("--sources", type=Path, default=None, help="Override .brigade/handoff-sources.json.")
+    p_handoff_doctor.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+
     # work
     p_work = sub.add_parser("work", help="Inspect and manage a daily Brigade work session.")
     work_sub = p_work.add_subparsers(dest="work_command", metavar="<work-command>")
@@ -626,6 +635,13 @@ def main(argv=None) -> int:
             native_read_only_sandbox=args.native_read_only_sandbox,
             timeout_seconds=args.timeout_seconds,
         )
+    if cmd == "handoff":
+        from . import handoff_cmd
+
+        if args.handoff_command == "doctor":
+            return handoff_cmd.doctor(target=args.target, sources=args.sources, json_output=args.json)
+        parser.error(f"unknown handoff command: {args.handoff_command}")
+        return 2
     if cmd == "work":
         from . import work_cmd
 

--- a/src/brigade/doctor.py
+++ b/src/brigade/doctor.py
@@ -68,6 +68,7 @@ def core_station_checks(ctx: DoctorContext) -> List[CheckResult]:
 def memory_station_checks(ctx: DoctorContext) -> List[CheckResult]:
     checks: List[CheckResult] = []
     checks.extend(_check_handoff_inboxes(ctx.target, ctx.selection, ctx.harnesses))
+    checks.extend(_check_handoff_sources(ctx.target))
     checks.extend(_check_memory_cards(ctx.target))
     checks.extend(_check_memory_index(ctx.target))
     checks.extend(_check_memory_care(ctx.target))
@@ -277,6 +278,16 @@ def _check_handoff_inboxes(
             )
         )
     return results
+
+
+def _check_handoff_sources(target: Path) -> List[CheckResult]:
+    from . import handoff_cmd
+
+    mapping = {handoff_cmd.OK: OK, handoff_cmd.WARN: WARN, handoff_cmd.FAIL: FAIL}
+    return [
+        (mapping.get(status, WARN), f"handoff-source: {name}", detail)
+        for status, name, detail in handoff_cmd.doctor_checks(target)
+    ]
 
 
 def _check_memory_index(target: Path) -> List[CheckResult]:

--- a/src/brigade/handoff_cmd.py
+++ b/src/brigade/handoff_cmd.py
@@ -1,0 +1,242 @@
+"""Handoff health checks shared by CLI doctors."""
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+OK = "ok"
+WARN = "warn"
+FAIL = "fail"
+
+WRITER_INBOXES = (".claude/memory-handoffs", ".codex/memory-handoffs")
+IGNORED_HANDOFF_NAMES = {"TEMPLATE.md"}
+
+
+@dataclass(frozen=True)
+class WatchedInbox:
+    root: Path
+    inbox: str
+
+
+@dataclass(frozen=True)
+class InboxHealth:
+    inbox: str
+    path: Path
+    exists: bool
+    pending: int
+    processed: int
+    watched: bool
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "inbox": self.inbox,
+            "path": str(self.path),
+            "exists": self.exists,
+            "pending": self.pending,
+            "processed": self.processed,
+            "watched": self.watched,
+        }
+
+
+@dataclass(frozen=True)
+class HandoffHealth:
+    target: Path
+    sources_path: Path | None
+    sources_loaded: bool
+    inboxes: tuple[InboxHealth, ...]
+    warnings: tuple[str, ...]
+    failures: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "target": str(self.target),
+            "sources_path": str(self.sources_path) if self.sources_path else None,
+            "sources_loaded": self.sources_loaded,
+            "inboxes": [inbox.as_dict() for inbox in self.inboxes],
+            "warnings": list(self.warnings),
+            "failures": list(self.failures),
+        }
+
+
+def default_sources_path(target: Path) -> Path:
+    return target / ".brigade" / "handoff-sources.json"
+
+
+def inspect(target: Path, sources: Path | None = None) -> HandoffHealth:
+    target = target.expanduser().resolve()
+    sources_path = sources.expanduser().resolve() if sources is not None else default_sources_path(target)
+    watched: tuple[WatchedInbox, ...] = ()
+    failures: list[str] = []
+    sources_loaded = False
+
+    if sources_path.is_file():
+        try:
+            watched = _load_sources(target, sources_path)
+        except ValueError as exc:
+            failures.append(f"invalid handoff source config {sources_path}: {exc}")
+        else:
+            sources_loaded = True
+    elif sources is not None:
+        failures.append(f"handoff source config not found: {sources_path}")
+        sources_path = sources_path
+    else:
+        sources_path = None
+
+    inboxes = tuple(_inspect_inbox(target, rel, watched) for rel in WRITER_INBOXES)
+    warnings: list[str] = []
+    pending_total = sum(inbox.pending for inbox in inboxes)
+    if pending_total and not sources_loaded and not failures:
+        warnings.append(
+            "pending handoffs exist but no .brigade/handoff-sources.json is configured"
+        )
+    for inbox in inboxes:
+        if inbox.pending and not inbox.watched:
+            warnings.append(
+                f"{inbox.inbox} has {inbox.pending} pending handoff"
+                f"{'s' if inbox.pending != 1 else ''} but is not watched by the source config"
+            )
+
+    return HandoffHealth(
+        target=target,
+        sources_path=sources_path,
+        sources_loaded=sources_loaded,
+        inboxes=inboxes,
+        warnings=tuple(warnings),
+        failures=tuple(failures),
+    )
+
+
+def doctor_checks(target: Path, sources: Path | None = None) -> list[tuple[str, str, str]]:
+    health = inspect(target, sources=sources)
+    checks: list[tuple[str, str, str]] = []
+    if health.failures:
+        for failure in health.failures:
+            checks.append((FAIL, "handoff_sources", failure))
+    elif health.sources_loaded:
+        checks.append((OK, "handoff_sources", str(health.sources_path)))
+    else:
+        pending_total = sum(inbox.pending for inbox in health.inboxes)
+        level = WARN if pending_total else OK
+        checks.append((level, "handoff_sources", "not configured; no pending handoffs" if not pending_total else "not configured"))
+
+    for inbox in health.inboxes:
+        if inbox.pending and not inbox.watched:
+            level = WARN
+        elif not inbox.exists:
+            level = OK
+        else:
+            level = OK
+        watched = "yes" if inbox.watched else "no"
+        exists = "yes" if inbox.exists else "no"
+        detail = (
+            f"{inbox.path} "
+            f"(exists={exists}, pending={inbox.pending}, processed={inbox.processed}, watched={watched})"
+        )
+        checks.append((level, f"handoff_watch: {inbox.inbox}", detail))
+
+    for warning in health.warnings:
+        checks.append((WARN, "handoff_warning", warning))
+    return checks
+
+
+def doctor(*, target: Path, sources: Path | None = None, json_output: bool = False) -> int:
+    if not target.expanduser().exists():
+        print(f"error: target does not exist: {target}", file=sys.stderr)
+        return 2
+    health = inspect(target, sources=sources)
+    if json_output:
+        print(json.dumps(health.as_dict(), indent=2, sort_keys=True))
+    else:
+        print(f"handoff doctor: {health.target}")
+        print(f"sources: {health.sources_path if health.sources_path else '(not configured)'}")
+        for status, name, detail in doctor_checks(health.target, sources=health.sources_path):
+            print(f"[{status}] {name}: {detail}")
+    return 1 if health.failures else 0
+
+
+def _load_sources(target: Path, sources_path: Path) -> tuple[WatchedInbox, ...]:
+    try:
+        payload = json.loads(sources_path.read_text())
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("root must be a JSON object")
+    sources = payload.get("sources")
+    if not isinstance(sources, list):
+        raise ValueError("sources must be a list")
+
+    watched: list[WatchedInbox] = []
+    for index, entry in enumerate(sources):
+        if isinstance(entry, str):
+            root_value = entry
+            inbox_values = list(WRITER_INBOXES)
+        elif isinstance(entry, dict):
+            root_value = entry.get("root", ".")
+            inbox_values = entry.get("inboxes", list(WRITER_INBOXES))
+        else:
+            raise ValueError(f"sources[{index}] must be an object or string")
+        if not isinstance(root_value, str) or not root_value.strip():
+            raise ValueError(f"sources[{index}].root must be a non-empty string")
+        if not isinstance(inbox_values, list) or not all(isinstance(item, str) for item in inbox_values):
+            raise ValueError(f"sources[{index}].inboxes must be a list of strings")
+        root = _resolve_source_root(target, root_value)
+        for inbox in inbox_values:
+            normalized = _normalize_inbox(inbox)
+            if normalized:
+                watched.append(WatchedInbox(root=root, inbox=normalized))
+    return tuple(watched)
+
+
+def _resolve_source_root(target: Path, value: str) -> Path:
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        path = target / path
+    return path.resolve()
+
+
+def _normalize_inbox(value: str) -> str:
+    normalized = value.strip().replace("\\", "/").strip("/")
+    if normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized
+
+
+def _inspect_inbox(target: Path, rel: str, watched: tuple[WatchedInbox, ...]) -> InboxHealth:
+    path = target / rel
+    return InboxHealth(
+        inbox=rel,
+        path=path,
+        exists=path.is_dir(),
+        pending=_count_pending(path),
+        processed=_count_processed(path),
+        watched=_is_watched(target, rel, watched),
+    )
+
+
+def _count_pending(path: Path) -> int:
+    if not path.is_dir():
+        return 0
+    count = 0
+    for candidate in path.glob("*.md"):
+        if not candidate.is_file():
+            continue
+        if candidate.name.startswith(".") or candidate.name in IGNORED_HANDOFF_NAMES:
+            continue
+        count += 1
+    return count
+
+
+def _count_processed(path: Path) -> int:
+    processed = path / "processed"
+    if not processed.is_dir():
+        return 0
+    return len([candidate for candidate in processed.glob("*.md") if candidate.is_file()])
+
+
+def _is_watched(target: Path, rel: str, watched: tuple[WatchedInbox, ...]) -> bool:
+    resolved_target = target.resolve()
+    normalized = _normalize_inbox(rel)
+    return any(item.root == resolved_target and item.inbox == normalized for item in watched)

--- a/src/brigade/install.py
+++ b/src/brigade/install.py
@@ -62,6 +62,7 @@ def build_gitignore_block(selection: Selection) -> str:
         "",
         "# brigade local state (logs, scrub cache, dogfood runs, work sessions).",
         ".brigade/dogfood.toml",
+        ".brigade/handoff-sources.json",
         ".brigade/security.toml",
         ".brigade/logs/",
         ".brigade/runs/",

--- a/src/brigade/templates/depth/repo.json
+++ b/src/brigade/templates/depth/repo.json
@@ -5,6 +5,7 @@
     {"src": "workspace/AGENTS.md", "dst": "AGENTS.md"},
     {"src": "workspace/SAFETY_RULES.md", "dst": "SAFETY_RULES.md"},
     {"src": "workspace/INSTALL_FOR_AGENTS.md", "dst": "INSTALL_FOR_AGENTS.md"},
+    {"src": "handoff/handoff-sources.example.json", "dst": ".brigade/handoff-sources.example.json"},
     {"src": "hooks/pre-push", "dst": "hooks/pre-push", "mode": "0755"},
     {"src": "policies/public-repo.json", "dst": ".brigade/policies/public-repo.json"}
   ],

--- a/src/brigade/templates/handoff/handoff-sources.example.json
+++ b/src/brigade/templates/handoff/handoff-sources.example.json
@@ -1,0 +1,13 @@
+{
+  "_description": "Copy to .brigade/handoff-sources.json and edit for this machine. Relative roots resolve from the repo or workspace target.",
+  "canonical_owner": "openclaw",
+  "sources": [
+    {
+      "root": ".",
+      "inboxes": [
+        ".claude/memory-handoffs",
+        ".codex/memory-handoffs"
+      ]
+    }
+  ]
+}

--- a/src/brigade/work_cmd.py
+++ b/src/brigade/work_cmd.py
@@ -2344,7 +2344,7 @@ def status(*, target: Path, limit: int = 12) -> int:
 
 
 def doctor(*, target: Path) -> int:
-    from . import security_cmd
+    from . import handoff_cmd, security_cmd
 
     target = target.expanduser().resolve()
     failures = 0
@@ -2470,6 +2470,11 @@ def doctor(*, target: Path) -> int:
     _doctor_line(_doctor_ignore_level(work_ignored), "work_ignored", work_ignored)
     handoff_ignored = dogfood_cmd._check_git_ignored(effective_target, handoff_inbox)
     _doctor_line(_doctor_ignore_level(handoff_ignored), "handoff_ignored", handoff_ignored)
+
+    for status, name, detail in handoff_cmd.doctor_checks(effective_target):
+        if status == FAIL:
+            failures += 1
+        _doctor_line(status, name, detail)
 
     latest = dogfood_cmd._latest_run(artifacts_dir)
     if latest is None:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -428,6 +428,23 @@ def test_doctor_checks_codex_inbox_when_selected(tmp_target: Path, capsys):
     assert ".codex/memory-handoffs" in out
 
 
+def test_doctor_warns_when_pending_handoff_is_not_watched(tmp_target: Path, capsys):
+    sel = Selection(
+        depth="repo",
+        harnesses=["claude"],
+        owner="claude",
+        includes=[],
+    )
+    install_selection(tmp_target, sel)
+    (tmp_target / ".claude" / "memory-handoffs" / "2026-05-27-note.md").write_text("# Memory Handoff\n")
+
+    doctor_mod.run(tmp_target)
+
+    out = capsys.readouterr().out
+    assert "handoff-source: handoff_warning" in out
+    assert "pending handoff" in out
+
+
 def test_doctor_warns_for_orphan_inbox(tmp_target: Path, capsys):
     """If config says claude only, but .codex/memory-handoffs exists, warn."""
     sel = Selection(

--- a/tests/test_gitignore.py
+++ b/tests/test_gitignore.py
@@ -26,6 +26,7 @@ def test_init_creates_gitignore_when_missing(tmp_target: Path):
     assert "!.claude/memory-handoffs/TEMPLATE.md" in gi
     assert "memory/handoff-inbox/" in gi
     assert ".brigade/dogfood.toml" in gi
+    assert ".brigade/handoff-sources.json" in gi
     assert ".brigade/security.toml" in gi
     assert ".brigade/runs/" in gi
     assert ".brigade/security/" in gi
@@ -184,6 +185,7 @@ def test_gitignore_block_includes_claude_section_when_selected():
     assert ".claude/memory-handoffs/*" in block
     assert "!.claude/memory-handoffs/TEMPLATE.md" in block
     assert ".brigade/dogfood.toml" in block
+    assert ".brigade/handoff-sources.json" in block
     assert ".brigade/runs/" in block
     assert ".brigade/security/" in block
     assert ".brigade/work/" in block

--- a/tests/test_handoff_cmd.py
+++ b/tests/test_handoff_cmd.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+
+from brigade import cli
+from brigade import handoff_cmd
+
+
+def test_handoff_doctor_warns_for_pending_handoff_without_source_config(tmp_path, capsys):
+    inbox = tmp_path / ".claude" / "memory-handoffs"
+    inbox.mkdir(parents=True)
+    (inbox / "TEMPLATE.md").write_text("# Template\n")
+    (inbox / "2026-05-27-note.md").write_text("# Memory Handoff\n")
+
+    assert handoff_cmd.doctor(target=tmp_path) == 0
+
+    out = capsys.readouterr().out
+    assert "handoff doctor:" in out
+    assert "[warn] handoff_sources: not configured" in out
+    assert ".claude/memory-handoffs" in out
+    assert "pending=1" in out
+    assert "watched=no" in out
+
+
+def test_handoff_doctor_accepts_configured_claude_and_codex_inboxes(tmp_path, capsys):
+    for rel in (".claude/memory-handoffs", ".codex/memory-handoffs"):
+        inbox = tmp_path / rel
+        inbox.mkdir(parents=True)
+        (inbox / "2026-05-27-note.md").write_text("# Memory Handoff\n")
+    config = tmp_path / ".brigade" / "handoff-sources.json"
+    config.parent.mkdir()
+    config.write_text(
+        json.dumps(
+            {
+                "canonical_owner": "openclaw",
+                "sources": [
+                    {
+                        "root": ".",
+                        "inboxes": [
+                            ".claude/memory-handoffs",
+                            ".codex/memory-handoffs",
+                        ],
+                    }
+                ],
+            }
+        )
+    )
+
+    assert handoff_cmd.doctor(target=tmp_path) == 0
+
+    out = capsys.readouterr().out
+    assert "[ok] handoff_sources:" in out
+    assert "pending=1" in out
+    assert "watched=yes" in out
+    assert "handoff_warning" not in out
+
+
+def test_handoff_doctor_fails_invalid_source_config(tmp_path, capsys):
+    config = tmp_path / ".brigade" / "handoff-sources.json"
+    config.parent.mkdir()
+    config.write_text("{broken")
+
+    assert handoff_cmd.doctor(target=tmp_path) == 1
+
+    out = capsys.readouterr().out
+    assert "[fail] handoff_sources:" in out
+    assert "invalid JSON" in out
+
+
+def test_handoff_doctor_json_output(tmp_path, capsys):
+    inbox = tmp_path / ".codex" / "memory-handoffs"
+    inbox.mkdir(parents=True)
+    (inbox / "2026-05-27-note.md").write_text("# Memory Handoff\n")
+
+    assert handoff_cmd.doctor(target=tmp_path, json_output=True) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["sources_loaded"] is False
+    assert payload["inboxes"][1]["pending"] == 1
+
+
+def test_handoff_doctor_cli(tmp_path, monkeypatch):
+    seen = {}
+
+    def fake_doctor(**kwargs):
+        seen.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(handoff_cmd, "doctor", fake_doctor)
+
+    assert cli.main(["handoff", "doctor", "--target", str(tmp_path), "--json"]) == 0
+    assert seen == {"target": tmp_path, "sources": None, "json_output": True}

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -54,6 +54,7 @@ def test_repo_install_lays_down_expected_files(tmp_target: Path):
     assert (tmp_target / "AGENTS.md").is_file()
     assert (tmp_target / "CLAUDE.md").is_file()
     assert (tmp_target / ".claude" / "memory-handoffs" / "TEMPLATE.md").is_file()
+    assert (tmp_target / ".brigade" / "handoff-sources.example.json").is_file()
     assert (tmp_target / "hooks" / "pre-push").is_file()
     # pre-push must be executable
     mode = (tmp_target / "hooks" / "pre-push").stat().st_mode & 0o777
@@ -94,6 +95,7 @@ def test_workspace_install_includes_memory_cards(tmp_target: Path):
     assert (tmp_target / ".claude" / "memory-handoffs" / "processed").is_dir()
     assert (tmp_target / ".brigade" / "memory-care.example.json").is_file()
     assert (tmp_target / ".brigade" / "chat-memory-sweep.example.json").is_file()
+    assert (tmp_target / ".brigade" / "handoff-sources.example.json").is_file()
     # skill + script land at the right paths, executable bit on the script
     assert (tmp_target / "skills" / "note" / "SKILL.md").is_file()
     backup = tmp_target / "scripts" / "backup-restic.sh"


### PR DESCRIPTION
## Summary
- add `brigade handoff doctor` for `.claude` and `.codex` handoff source coverage
- install `.brigade/handoff-sources.example.json` and ignore the host-local live config
- surface handoff source health in `brigade doctor` and `brigade work doctor`

## Verification
- `.venv/bin/python -m pytest tests/test_handoff_cmd.py tests/test_doctor.py tests/test_work_cmd.py tests/test_init.py tests/test_gitignore.py -q`
- `.venv/bin/python -m pytest -q`
- `git diff --check`
- `.venv/bin/brigade handoff doctor --target .`
- `.venv/bin/brigade work doctor --target .`
- `.venv/bin/brigade doctor --target .`
- `PYTHONPATH=$HOME/repos/content-guard/src python3 -m content_guard scan . --policy $HOME/repos/content-guard/policies/public-repo.json`