### PR TITLE
Import handoff ingest issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `brigade handoff doctor` to compare pending `.claude` and `.codex` memory handoffs against gitignored local source config.
 - Repo installs now include `.brigade/handoff-sources.example.json` as the local handoff ingestor source-list contract.
 - `brigade handoff doctor` ingestor-log checks for stale latest-run logs, skipped malformed handoffs, warning summaries, and no-reply/no-update masking signals.
+- `brigade handoff issues` and `brigade handoff import-issues` to turn handoff ingest warnings into grouped repair guidance and local work imports.
 - `docs/import-schema.md` documenting the local import JSONL contract for scanners and wrappers.
 - Cybersecurity plugin roadmap covering broad agent-workspace security checks plus Brigade-specific scanner, doctor, import, and multi-harness security checks.
 - Built-in `security` station and `brigade security scan` for read-only agent workspace security checks.
@@ -87,6 +88,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `brigade work run` now consumes the oldest pending ledger task before falling back to the latest extracted dogfood next step, and marks consumed tasks done after successful runs.
 - `brigade work task add --from-next` now reuses an equivalent pending task instead of adding duplicates.
 - `brigade work brief` now includes pending local work imports and import counts in both text and JSON output.
+- `brigade work brief` now surfaces pending handoff ingest issue counts when the local handoff source config has an ingestor latest-run log.
 - The managed gitignore block now treats `.brigade/dogfood.toml`, `.brigade/security.toml`, `.brigade/runs/`, and `.brigade/security/` as local state.
 - The managed gitignore block now treats `.brigade/handoff-sources.json` as host-local state.
 - Live smoke docs now keep Codex agent execution in a trusted repo cwd while writing temporary roster, artifacts, and handoff output under `/tmp`.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Once installed, `brigade doctor` verifies the wiring and `brigade status` report
 For machines that ingest handoffs from multiple repos, copy `.brigade/handoff-sources.example.json` to `.brigade/handoff-sources.json` and list the repo roots and writer inboxes the canonical ingestor scans.
 `brigade handoff doctor` reports pending `.claude/memory-handoffs/` and `.codex/memory-handoffs/` files that are not covered by that local source list.
 If your ingestor writes a latest-run log, set `ingestor.last_run_log` in that local config so the doctor can warn on stale runs, skipped malformed handoffs, and warning summaries hidden behind no-reply cron output.
+Use `brigade handoff issues` to group those warnings with repair guidance, then `brigade handoff import-issues` to route them into the normal local work import inbox.
 
 ## Run a brigade
 
@@ -154,6 +155,8 @@ brigade dogfood
 brigade dogfood next
 brigade dogfood --target /path/to/repo
 brigade handoff doctor
+brigade handoff issues
+brigade handoff import-issues
 brigade work bootstrap
 brigade work status
 brigade work doctor

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -54,6 +54,18 @@ Goal: make backup health part of the same daily operator loop as chat, memory, a
 - Route stale snapshot, failed check, failed prune, missing mount, and restore-rehearsal overdue signals into `brigade work import` as incidents.
 - Keep real hostnames, remote names, mount paths, webhook URLs, channel ids, and backup passwords out of public templates.
 
+## Later Phase: Shared Tool Catalog And Runtime
+
+Goal: make Brigade able to reason about callable tools across agent harnesses without making each harness own separate tool config.
+
+- Build a local tool catalog abstraction with source records, tool counts, search, describe, and call surfaces.
+- Support source families such as MCP, OpenAPI, GraphQL, local scripts, and custom adapters through a registry contract.
+- Prefer schema-first tool descriptions so agents can discover by intent, inspect arguments, and produce typed calls.
+- Add a local daemon option with status, stop, restart, port tracking, and safe local auto-start for commands that need a runtime.
+- Track resumable executions for tools that pause for auth, approval, or human confirmation.
+- Keep shared auth, secrets, and policy decisions host-local and gitignored, while publishing only safe example configs.
+- Expose catalog health through `brigade doctor` and route broken source/auth/policy states into `brigade work import`.
+
 ## Later Phase: Cybersecurity Plugin
 
 Goal: ship a Brigade cybersecurity plugin with broad coverage for agent workspaces, then go deeper on Brigade's multi-harness, memory, scanner, and dogfood workflows.
@@ -112,6 +124,7 @@ Goal: prevent durable memory from silently rotting.
 - Treat bootstrap truncation as a hard failure. Bootstrap files stay slim, cards hold durable detail, and doctor checks enforce the boundary.
 - Add a handoff doctor that compares repo-local writer inboxes such as `.claude/memory-handoffs/` and `.codex/memory-handoffs/` against the canonical ingestor source list, warning when handoffs exist in directories the owner is not scanning. Status: started with `brigade handoff doctor`, `.brigade/handoff-sources.example.json`, and `brigade doctor` / `brigade work doctor` integration.
 - Add handoff-ingest observability checks for hidden warning states, including unreachable remote sources, malformed handoffs that are skipped, and runs that emit `NO_REPLY` despite warnings. Status: started with optional `ingestor.last_run_log` checks in `brigade handoff doctor`.
+- Turn handoff-ingest warnings into repairable local work. Status: started with `brigade handoff issues`, `brigade handoff import-issues`, repair guidance, and `brigade work brief` issue counts.
 
 ## Later Phase: Portable Operator Setup
 

--- a/src/brigade/cli.py
+++ b/src/brigade/cli.py
@@ -115,6 +115,16 @@ def _build_parser() -> argparse.ArgumentParser:
     p_handoff_doctor.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
     p_handoff_doctor.add_argument("--sources", type=Path, default=None, help="Override .brigade/handoff-sources.json.")
     p_handoff_doctor.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_handoff_issues = handoff_sub.add_parser("issues", help="Group actionable handoff ingest issues.")
+    p_handoff_issues.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
+    p_handoff_issues.add_argument("--sources", type=Path, default=None, help="Override .brigade/handoff-sources.json.")
+    p_handoff_issues.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_handoff_issues.add_argument("--limit", type=int, default=20, help="Maximum issue rows to print.")
+    p_handoff_import_issues = handoff_sub.add_parser("import-issues", help="Import handoff ingest issues into the work inbox.")
+    p_handoff_import_issues.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update.")
+    p_handoff_import_issues.add_argument("--sources", type=Path, default=None, help="Override .brigade/handoff-sources.json.")
+    p_handoff_import_issues.add_argument("--dry-run", action="store_true", help="Report without writing imports.")
+    p_handoff_import_issues.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
 
     # work
     p_work = sub.add_parser("work", help="Inspect and manage a daily Brigade work session.")
@@ -640,6 +650,10 @@ def main(argv=None) -> int:
 
         if args.handoff_command == "doctor":
             return handoff_cmd.doctor(target=args.target, sources=args.sources, json_output=args.json)
+        if args.handoff_command == "issues":
+            return handoff_cmd.issues(target=args.target, sources=args.sources, json_output=args.json, limit=args.limit)
+        if args.handoff_command == "import-issues":
+            return handoff_cmd.import_issues(target=args.target, sources=args.sources, dry_run=args.dry_run, json_output=args.json)
         parser.error(f"unknown handoff command: {args.handoff_command}")
         return 2
     if cmd == "work":

--- a/src/brigade/handoff_cmd.py
+++ b/src/brigade/handoff_cmd.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import hashlib
 import sys
 import time
 from dataclasses import dataclass
@@ -28,6 +29,7 @@ DEFAULT_WARNING_PATTERNS = (
     "timed out",
     "no route",
 )
+ISSUE_SOURCE = "handoff-ingest"
 
 
 @dataclass(frozen=True)
@@ -88,6 +90,45 @@ class IngestorHealth:
             "stale_after_seconds": self.stale_after_seconds,
             "stale": self.stale,
             "warnings": list(self.warnings),
+        }
+
+
+@dataclass(frozen=True)
+class HandoffIssue:
+    id: str
+    category: str
+    kind: str
+    text: str
+    repair: str
+    evidence: str
+    metadata: dict[str, Any]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "category": self.category,
+            "kind": self.kind,
+            "text": self.text,
+            "repair": self.repair,
+            "evidence": self.evidence,
+            "metadata": self.metadata,
+        }
+
+    def as_import_record(self) -> dict[str, Any]:
+        metadata = dict(self.metadata)
+        metadata.update(
+            {
+                "handoff_issue_id": self.id,
+                "handoff_issue_category": self.category,
+                "repair": self.repair,
+                "evidence": self.evidence,
+            }
+        )
+        return {
+            "text": self.text,
+            "kind": self.kind,
+            "source": ISSUE_SOURCE,
+            "metadata": metadata,
         }
 
 
@@ -219,6 +260,145 @@ def doctor_checks(target: Path, sources: Path | None = None) -> list[tuple[str, 
     return checks
 
 
+def collect_issues(target: Path, sources: Path | None = None) -> list[HandoffIssue]:
+    health = inspect(target, sources=sources)
+    issues: list[HandoffIssue] = []
+    for inbox in health.inboxes:
+        if inbox.pending and not inbox.watched:
+            issues.append(
+                _make_issue(
+                    category="untracked-inbox",
+                    kind="task",
+                    text=(
+                        f"Add {inbox.inbox} to handoff source config or move "
+                        f"{inbox.pending} pending handoff"
+                        f"{'s' if inbox.pending != 1 else ''}"
+                    ),
+                    repair=(
+                        "Add the repo root and inbox path to .brigade/handoff-sources.json, "
+                        "or move the pending files into an inbox the canonical ingestor scans."
+                    ),
+                    evidence=str(inbox.path),
+                    metadata={
+                        "inbox": inbox.inbox,
+                        "path": str(inbox.path),
+                        "pending": inbox.pending,
+                    },
+                )
+            )
+
+    ingestor = health.ingestor
+    if ingestor.configured:
+        if not ingestor.exists:
+            issues.append(
+                _make_issue(
+                    category="missing-log",
+                    kind="incident",
+                    text=f"Restore handoff ingestor latest-run log at {ingestor.log_path}",
+                    repair=(
+                        "Update ingestor.last_run_log to the actual latest-run log path, "
+                        "or adjust the ingestor wrapper to write that log after each run."
+                    ),
+                    evidence=str(ingestor.log_path),
+                    metadata={"log_path": str(ingestor.log_path)},
+                )
+            )
+        elif ingestor.stale:
+            issues.append(
+                _make_issue(
+                    category="stale-log",
+                    kind="incident",
+                    text=f"Investigate stale handoff ingestor run log at {ingestor.log_path}",
+                    repair="Run the handoff ingestor, then fix the scheduler or wrapper if the log does not refresh.",
+                    evidence=f"age={_format_seconds(ingestor.age_seconds)}, stale_after={_format_seconds(ingestor.stale_after_seconds)}",
+                    metadata={
+                        "log_path": str(ingestor.log_path),
+                        "age_seconds": ingestor.age_seconds,
+                        "stale_after_seconds": ingestor.stale_after_seconds,
+                    },
+                )
+            )
+        if ingestor.exists and ingestor.log_path is not None:
+            issues.extend(_parse_ingestor_log_issues(ingestor.log_path))
+    return _dedupe_issues(issues)
+
+
+def issues(
+    *,
+    target: Path,
+    sources: Path | None = None,
+    json_output: bool = False,
+    limit: int = 20,
+) -> int:
+    if limit < 1:
+        print("error: --limit must be a positive integer", file=sys.stderr)
+        return 2
+    target = target.expanduser().resolve()
+    if not target.is_dir():
+        print(f"error: --target is not a directory: {target}", file=sys.stderr)
+        return 2
+    found = collect_issues(target, sources=sources)
+    payload = _issues_payload(target, found)
+    if json_output:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+    print(f"handoff issues: {target}")
+    print(f"issues: {payload['count']}")
+    if not found:
+        return 0
+    print("groups:")
+    for category, count in payload["by_category"].items():
+        print(f"- {category}: {count}")
+    print("items:")
+    for issue in found[:limit]:
+        print(f"- {issue.id} [{issue.category}] {issue.kind}: {_short(issue.text)}")
+        print(f"  repair: {_short(issue.repair, 140)}")
+        print(f"  evidence: {_short(issue.evidence, 160)}")
+    if len(found) > limit:
+        print(f"... {len(found) - limit} more")
+    return 0
+
+
+def import_issues(
+    *,
+    target: Path,
+    sources: Path | None = None,
+    dry_run: bool = False,
+    json_output: bool = False,
+) -> int:
+    target = target.expanduser().resolve()
+    if not target.is_dir():
+        print(f"error: --target is not a directory: {target}", file=sys.stderr)
+        return 2
+    found = collect_issues(target, sources=sources)
+    records = [issue.as_import_record() for issue in found]
+    from . import work_cmd
+
+    imported, skipped = work_cmd._append_import_records(target, records, dry_run=dry_run)
+    payload = {
+        "target": str(target),
+        "imports_path": str(work_cmd._imports_path(target)),
+        "dry_run": dry_run,
+        "issues": len(found),
+        "imported": len(imported),
+        "skipped_duplicates": len(skipped),
+        "by_category": _issue_counts(found),
+        "imports": imported,
+    }
+    if json_output:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+    print(f"handoff issue imports: {target}")
+    print(f"imports_path: {payload['imports_path']}")
+    print(f"dry_run: {dry_run}")
+    print(f"issues: {len(found)}")
+    print(f"imported: {len(imported)}")
+    print(f"skipped_duplicates: {len(skipped)}")
+    for item in imported:
+        print(f"- {item.get('id')} [{item.get('kind')}] {_short(str(item.get('text', '')))}")
+    return 0
+
+
 def doctor(*, target: Path, sources: Path | None = None, json_output: bool = False) -> int:
     if not target.expanduser().exists():
         print(f"error: target does not exist: {target}", file=sys.stderr)
@@ -232,6 +412,166 @@ def doctor(*, target: Path, sources: Path | None = None, json_output: bool = Fal
         for status, name, detail in doctor_checks(health.target, sources=health.sources_path):
             print(f"[{status}] {name}: {detail}")
     return 1 if health.failures else 0
+
+
+def _issues_payload(target: Path, found: list[HandoffIssue]) -> dict[str, Any]:
+    return {
+        "target": str(target),
+        "count": len(found),
+        "by_category": _issue_counts(found),
+        "issues": [issue.as_dict() for issue in found],
+    }
+
+
+def _issue_counts(found: list[HandoffIssue]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for issue in found:
+        counts[issue.category] = counts.get(issue.category, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _dedupe_issues(issues: list[HandoffIssue]) -> list[HandoffIssue]:
+    seen: set[str] = set()
+    deduped: list[HandoffIssue] = []
+    for issue in issues:
+        if issue.id in seen:
+            continue
+        seen.add(issue.id)
+        deduped.append(issue)
+    return deduped
+
+
+def _make_issue(
+    *,
+    category: str,
+    kind: str,
+    text: str,
+    repair: str,
+    evidence: str,
+    metadata: dict[str, Any] | None = None,
+) -> HandoffIssue:
+    raw_id = f"{category}|{text}|{evidence}"
+    digest = hashlib.sha1(raw_id.encode("utf-8")).hexdigest()[:10]
+    return HandoffIssue(
+        id=f"handoff-{category}-{digest}",
+        category=category,
+        kind=kind,
+        text=text,
+        repair=repair,
+        evidence=evidence,
+        metadata=metadata or {},
+    )
+
+
+def _parse_ingestor_log_issues(log_path: Path) -> list[HandoffIssue]:
+    try:
+        lines = log_path.read_text(errors="replace").splitlines()
+    except OSError as exc:
+        return [
+            _make_issue(
+                category="missing-log",
+                kind="incident",
+                text=f"Read handoff ingestor log at {log_path}",
+                repair="Fix file permissions or update ingestor.last_run_log to a readable latest-run log.",
+                evidence=str(exc),
+                metadata={"log_path": str(log_path)},
+            )
+        ]
+    issues: list[HandoffIssue] = []
+    has_warning_summary = False
+    has_no_reply_or_update = False
+    for line_number, line in enumerate(lines, start=1):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("SKIP "):
+            issues.append(_issue_from_log_line("skip", "task", stripped, line_number, log_path))
+        elif stripped.startswith("PROMOTE-SKIP "):
+            issues.append(_issue_from_log_line("promote-skip", "task", stripped, line_number, log_path))
+        elif stripped.startswith("ROUTE-SKIP "):
+            issues.append(_issue_from_log_line("route-skip", "task", stripped, line_number, log_path))
+        elif stripped.startswith("Warnings:"):
+            has_warning_summary = True
+            issues.append(_issue_from_log_line("warning-summary", "incident", stripped, line_number, log_path))
+        if "NO_REPLY" in stripped or "NO_UPDATES" in stripped:
+            has_no_reply_or_update = True
+        if _looks_unreachable(stripped):
+            issues.append(_issue_from_log_line("source-unreachable", "incident", stripped, line_number, log_path))
+    if has_warning_summary and has_no_reply_or_update:
+        issues.append(
+            _make_issue(
+                category="hidden-warning",
+                kind="incident",
+                text="Fix handoff ingestor no-reply output that can hide warnings",
+                repair="Adjust the scheduler or wrapper so warning output is delivered even when the run also emits NO_REPLY or NO_UPDATES.",
+                evidence=str(log_path),
+                metadata={"log_path": str(log_path)},
+            )
+        )
+    return issues
+
+
+def _issue_from_log_line(category: str, kind: str, line: str, line_number: int, log_path: Path) -> HandoffIssue:
+    subject, detail = _split_issue_line(line)
+    repair = _repair_for_issue(category, line)
+    text = _text_for_issue(category, subject, detail)
+    return _make_issue(
+        category=category,
+        kind=kind,
+        text=text,
+        repair=repair,
+        evidence=line,
+        metadata={
+            "log_path": str(log_path),
+            "line_number": line_number,
+            "subject": subject,
+        },
+    )
+
+
+def _split_issue_line(line: str) -> tuple[str, str]:
+    if ": " not in line:
+        return line, ""
+    subject, detail = line.split(": ", 1)
+    return subject, detail
+
+
+def _text_for_issue(category: str, subject: str, detail: str) -> str:
+    item = Path(subject.split()[-1]).name if subject else "handoff ingest issue"
+    if category == "skip":
+        return f"Repair malformed handoff {item}: {detail or 'not parsed'}"
+    if category == "promote-skip":
+        return f"Fix handoff promotion target for {item}: {detail or 'promotion skipped'}"
+    if category == "route-skip":
+        return f"Fix handoff routing fields for {item}: {detail or 'route skipped'}"
+    if category == "warning-summary":
+        return f"Review handoff ingestor warning summary: {subject}"
+    if category == "source-unreachable":
+        return f"Investigate unreachable handoff source: {subject}"
+    return f"Review handoff ingest issue: {subject}"
+
+
+def _repair_for_issue(category: str, line: str) -> str:
+    if category == "skip":
+        return "Rewrite the handoff with the standard markdown sections, especially Type, Title, Summary, Recommended memory action, and the matching target section."
+    if category == "promote-skip" and "target card does not exist" in line:
+        return "Either create the target memory card first, change Recommended memory action to create-card, or correct Target card to an existing card."
+    if category == "promote-skip":
+        return "Align Recommended memory action, Target card, and Suggested card content so card promotion can succeed."
+    if category == "route-skip" and "action is not no-card" in line:
+        return "Use Recommended memory action no-card when routing to Target document, or remove Target document and provide a valid card target."
+    if category == "route-skip":
+        return "Align Recommended memory action, Target document, and Suggested document content so document routing can succeed."
+    if category == "warning-summary":
+        return "Inspect the latest ingestor log and clear the concrete warning lines before treating the run as clean."
+    if category == "source-unreachable":
+        return "Check network, SSH, mount, or source-path availability, then rerun the handoff ingestor."
+    return "Review the latest handoff ingestor log and fix the underlying source or scheduler issue."
+
+
+def _looks_unreachable(line: str) -> bool:
+    lowered = line.casefold()
+    return any(token in lowered for token in ("unreachable", "timed out", "timeout", "no route"))
 
 
 def _load_sources(target: Path, sources_path: Path) -> SourceConfig:
@@ -383,6 +723,13 @@ def _normalize_inbox(value: str) -> str:
     if normalized.startswith("./"):
         normalized = normalized[2:]
     return normalized
+
+
+def _short(text: str, limit: int = 96) -> str:
+    rendered = " ".join(text.split())
+    if len(rendered) <= limit:
+        return rendered
+    return rendered[: limit - 3].rstrip() + "..."
 
 
 def _inspect_inbox(target: Path, rel: str, watched: tuple[WatchedInbox, ...]) -> InboxHealth:

--- a/src/brigade/work_cmd.py
+++ b/src/brigade/work_cmd.py
@@ -912,6 +912,8 @@ def _suggested_command(active: dict[str, Any] | None, next_text: object, source:
 
 
 def _brief_payload(target: Path, *, limit: int = 3) -> dict[str, Any]:
+    from . import handoff_cmd
+
     target = target.expanduser().resolve()
     active = _active_session_info(target)
     sessions, skipped = _collect_sessions(_work_root(target))
@@ -923,6 +925,7 @@ def _brief_payload(target: Path, *, limit: int = 3) -> dict[str, Any]:
     pending = _pending_tasks(target)
     pending_imports = _pending_imports(target)
     pending_import_counts = _import_counts(pending_imports)
+    handoff_issues = handoff_cmd.collect_issues(target)
     return {
         "target": str(target),
         "git": git,
@@ -935,6 +938,10 @@ def _brief_payload(target: Path, *, limit: int = 3) -> dict[str, Any]:
         "imports_path": str(_imports_path(target)),
         "pending_imports": pending_imports,
         "pending_import_counts": pending_import_counts,
+        "handoff_issues": {
+            "count": len(handoff_issues),
+            "by_category": handoff_cmd._issue_counts(handoff_issues),
+        },
         "dogfood": resolved["dogfood"],
         "next_source": resolved["source"],
         "task_id": resolved.get("task_id"),
@@ -1402,6 +1409,15 @@ def brief(*, target: Path, limit: int = 3, json_output: bool = False) -> int:
             print(f"  - {item.get('id')} [{kind}] {source}: {_short(str(item.get('text', '')))}")
         if len(pending_imports) > 5:
             print(f"  ... {len(pending_imports) - 5} more")
+
+    handoff_issues = payload.get("handoff_issues")
+    if isinstance(handoff_issues, dict) and handoff_issues.get("count"):
+        print(f"handoff_ingest_issues_pending: {handoff_issues.get('count')}")
+        by_category = handoff_issues.get("by_category")
+        if isinstance(by_category, dict) and by_category:
+            print("handoff_ingest_issues_by_category:")
+            for category, count in by_category.items():
+                print(f"  {category}: {count}")
 
     recent = payload["recent_sessions"]
     if isinstance(recent, list) and recent:

--- a/tests/test_handoff_cmd.py
+++ b/tests/test_handoff_cmd.py
@@ -135,6 +135,117 @@ def test_handoff_doctor_warns_for_stale_ingestor_log(tmp_path, capsys):
     assert "handoff ingestor log is stale" in out
 
 
+def test_handoff_issues_groups_ingestor_log_warnings(tmp_path, capsys):
+    log = tmp_path / ".brigade" / "handoff-ingest" / "latest.log"
+    log.parent.mkdir(parents=True)
+    log.write_text(
+        "\n".join(
+            [
+                "SKIP /repo/.claude/memory-handoffs/bad.md: no recognizable markdown sections found",
+                "PROMOTE-SKIP card.md: target card does not exist for update",
+                "ROUTE-SKIP doc.md: action is not no-card",
+                "Warnings: 3",
+                "NO_REPLY",
+                "",
+            ]
+        )
+    )
+    config = tmp_path / ".brigade" / "handoff-sources.json"
+    config.write_text(
+        json.dumps(
+            {
+                "sources": [{"root": ".", "inboxes": [".claude/memory-handoffs"]}],
+                "ingestor": {"last_run_log": ".brigade/handoff-ingest/latest.log"},
+            }
+        )
+    )
+
+    assert handoff_cmd.issues(target=tmp_path) == 0
+
+    out = capsys.readouterr().out
+    assert "handoff issues:" in out
+    assert "- skip: 1" in out
+    assert "- promote-skip: 1" in out
+    assert "- route-skip: 1" in out
+    assert "- warning-summary: 1" in out
+    assert "- hidden-warning: 1" in out
+    assert "Rewrite the handoff with the standard markdown sections" in out
+    assert "Use Recommended memory action no-card" in out
+
+
+def test_handoff_issues_json_reports_repair_guidance(tmp_path, capsys):
+    log = tmp_path / "latest.log"
+    log.write_text("PROMOTE-SKIP note.md: target card does not exist for update\n")
+    config = tmp_path / ".brigade" / "handoff-sources.json"
+    config.parent.mkdir()
+    config.write_text(
+        json.dumps(
+            {
+                "sources": [{"root": ".", "inboxes": [".claude/memory-handoffs"]}],
+                "ingestor": {"last_run_log": "latest.log"},
+            }
+        )
+    )
+
+    assert handoff_cmd.issues(target=tmp_path, json_output=True) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["count"] == 1
+    assert payload["by_category"] == {"promote-skip": 1}
+    assert payload["issues"][0]["kind"] == "task"
+    assert "create-card" in payload["issues"][0]["repair"]
+
+
+def test_handoff_import_issues_appends_work_imports(tmp_path, capsys):
+    log = tmp_path / "latest.log"
+    log.write_text("ROUTE-SKIP note.md: action is not no-card\n")
+    config = tmp_path / ".brigade" / "handoff-sources.json"
+    config.parent.mkdir()
+    config.write_text(
+        json.dumps(
+            {
+                "sources": [{"root": ".", "inboxes": [".claude/memory-handoffs"]}],
+                "ingestor": {"last_run_log": "latest.log"},
+            }
+        )
+    )
+
+    assert handoff_cmd.import_issues(target=tmp_path) == 0
+
+    out = capsys.readouterr().out
+    assert "handoff issue imports:" in out
+    assert "imported: 1" in out
+    stored = (tmp_path / ".brigade" / "work" / "imports" / "inbox.jsonl").read_text()
+    item = json.loads(stored.splitlines()[0])
+    assert item["source"] == "handoff-ingest"
+    assert item["kind"] == "task"
+    assert item["metadata"]["handoff_issue_category"] == "route-skip"
+    assert "no-card" in item["metadata"]["repair"]
+
+
+def test_handoff_import_issues_dedupes_existing_pending_imports(tmp_path, capsys):
+    log = tmp_path / "latest.log"
+    log.write_text("SKIP bad.md: no recognizable markdown sections found\n")
+    config = tmp_path / ".brigade" / "handoff-sources.json"
+    config.parent.mkdir()
+    config.write_text(
+        json.dumps(
+            {
+                "sources": [{"root": ".", "inboxes": [".claude/memory-handoffs"]}],
+                "ingestor": {"last_run_log": "latest.log"},
+            }
+        )
+    )
+
+    assert handoff_cmd.import_issues(target=tmp_path) == 0
+    capsys.readouterr()
+    assert handoff_cmd.import_issues(target=tmp_path) == 0
+
+    out = capsys.readouterr().out
+    assert "imported: 0" in out
+    assert "skipped_duplicates: 1" in out
+
+
 def test_handoff_doctor_cli(tmp_path, monkeypatch):
     seen = {}
 
@@ -146,3 +257,29 @@ def test_handoff_doctor_cli(tmp_path, monkeypatch):
 
     assert cli.main(["handoff", "doctor", "--target", str(tmp_path), "--json"]) == 0
     assert seen == {"target": tmp_path, "sources": None, "json_output": True}
+
+
+def test_handoff_issues_cli(tmp_path, monkeypatch):
+    seen = {}
+
+    def fake_issues(**kwargs):
+        seen.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(handoff_cmd, "issues", fake_issues)
+
+    assert cli.main(["handoff", "issues", "--target", str(tmp_path), "--json", "--limit", "7"]) == 0
+    assert seen == {"target": tmp_path, "sources": None, "json_output": True, "limit": 7}
+
+
+def test_handoff_import_issues_cli(tmp_path, monkeypatch):
+    seen = {}
+
+    def fake_import_issues(**kwargs):
+        seen.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(handoff_cmd, "import_issues", fake_import_issues)
+
+    assert cli.main(["handoff", "import-issues", "--target", str(tmp_path), "--dry-run", "--json"]) == 0
+    assert seen == {"target": tmp_path, "sources": None, "dry_run": True, "json_output": True}

--- a/tests/test_work_cmd.py
+++ b/tests/test_work_cmd.py
@@ -1019,6 +1019,34 @@ def test_work_brief_includes_pending_imports(tmp_path, monkeypatch, capsys):
     assert "  finding: 1" in out
 
 
+def test_work_brief_includes_handoff_ingest_issues(tmp_path, monkeypatch, capsys):
+    _init_git_repo(tmp_path)
+    monkeypatch.setattr(work_cmd.shutil, "which", lambda name: f"/usr/bin/{name}")
+    log = tmp_path / ".brigade" / "handoff-ingest" / "latest.log"
+    log.parent.mkdir(parents=True)
+    log.write_text("SKIP bad.md: no recognizable markdown sections found\n")
+    config = tmp_path / ".brigade" / "handoff-sources.json"
+    config.write_text(
+        json.dumps(
+            {
+                "sources": [{"root": ".", "inboxes": [".claude/memory-handoffs"]}],
+                "ingestor": {"last_run_log": ".brigade/handoff-ingest/latest.log"},
+            }
+        )
+    )
+
+    assert work_cmd.brief(target=tmp_path, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["handoff_issues"]["count"] == 1
+    assert payload["handoff_issues"]["by_category"] == {"skip": 1}
+
+    assert work_cmd.brief(target=tmp_path) == 0
+    out = capsys.readouterr().out
+    assert "handoff_ingest_issues_pending: 1" in out
+    assert "handoff_ingest_issues_by_category:" in out
+    assert "  skip: 1" in out
+
+
 def test_work_next_reports_latest_next_as_default_task(tmp_path, monkeypatch, capsys):
     _init_git_repo(tmp_path)
     dogfood_cmd.init(target=tmp_path)


### PR DESCRIPTION
## Summary
- add `brigade handoff issues` to group ingest warnings with repair guidance
- add `brigade handoff import-issues` to route those repairs into the local work import inbox
- surface handoff ingest issue counts in `brigade work brief`
- add shared tool catalog/runtime feature roadmap without naming external references

## Verification
- `.venv/bin/python -m pytest tests/test_handoff_cmd.py tests/test_work_cmd.py tests/test_doctor.py -q`
- `.venv/bin/python -m pytest -q`
- `git diff --check`
- `.venv/bin/brigade handoff issues --target . --limit 5`
- `.venv/bin/brigade handoff import-issues --target . --dry-run --json`
- `.venv/bin/brigade work brief --target .`
- `PYTHONPATH=$HOME/repos/content-guard/src python3 -m content_guard scan . --policy $HOME/repos/content-guard/policies/public-repo.json`