### PR TITLE
Add import filter controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,10 +52,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `brigade work import triage` to group pending imports by source and kind.
 - `brigade work import dismiss` to close noisy imports without promoting them.
 - `brigade work import promote --all` with optional `--source` and `--kind` filters for batch promotion.
+- `brigade work import list/triage/promote/dismiss` metadata filters for scanner-specific fields such as `handoff_issue_category`.
+- `brigade work import dismiss --all` for filtered bulk dismissal of pending imports.
 - `brigade handoff doctor` to compare pending `.claude` and `.codex` memory handoffs against gitignored local source config.
 - Repo installs now include `.brigade/handoff-sources.example.json` as the local handoff ingestor source-list contract.
 - `brigade handoff doctor` ingestor-log checks for stale latest-run logs, skipped malformed handoffs, warning summaries, and no-reply/no-update masking signals.
 - `brigade handoff issues` and `brigade handoff import-issues` to turn handoff ingest warnings into grouped repair guidance and local work imports.
+- `brigade handoff issues --category` and `brigade handoff import-issues --category` for category-limited handoff issue review/import.
 - `docs/import-schema.md` documenting the local import JSONL contract for scanners and wrappers.
 - Cybersecurity plugin roadmap covering broad agent-workspace security checks plus Brigade-specific scanner, doctor, import, and multi-harness security checks.
 - Built-in `security` station and `brigade security scan` for read-only agent workspace security checks.

--- a/README.md
+++ b/README.md
@@ -177,7 +177,9 @@ brigade work import memory-care
 brigade work import triage
 brigade work import promote <import-id>
 brigade work import promote --all --source memory-care --kind task
+brigade work import promote --all --source handoff-ingest --metadata handoff_issue_category=route-skip
 brigade work import dismiss <import-id> --reason "not actionable"
+brigade work import dismiss --all --source handoff-ingest --metadata handoff_issue_category=skip --reason "historical noise"
 brigade work run
 brigade work run --queue-next
 brigade work run "review today's changes"
@@ -281,11 +283,11 @@ Import inbox commands:
 - `brigade work import ingest imports.jsonl` ingests scanner output.
 - `brigade work import memory-care` converts `memory/cards/decay/refresh-queue.json` into imports.
 - `brigade work import chat-sweep` converts `.brigade/chat-memory-sweeps/latest.json` issues into imports.
-- `brigade work import triage` groups pending imports by source and kind.
+- `brigade work import triage` groups pending imports by source and kind; use `--source`, `--kind`, and repeatable `--metadata key=value` to narrow noisy queues.
 - `brigade work import show <import-id>` inspects one import.
-- `brigade work import dismiss <import-id>` removes noise.
+- `brigade work import dismiss <import-id>` removes one noisy item, while `dismiss --all` closes filtered batches.
 - `brigade work import promote <import-id>` promotes one reviewed import into the task ledger.
-- `brigade work import promote --all --source memory-care --kind task` batch-promotes filtered imports.
+- `brigade work import promote --all --source memory-care --kind task` batch-promotes filtered imports; metadata filters also work for scanner-specific fields such as `handoff_issue_category=route-skip`.
 
 Imports are stored under `.brigade/work/imports/inbox.jsonl`, stay gitignored, and do not write memory directly.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,8 +27,8 @@ Goal: make Brigade a safe target for local automations that discover useful work
 - Let wrappers import candidate tasks, findings, decisions, preferences, incidents, links, and commands without knowing Brigade internals.
 - Convert memory-care refresh queues into local task imports.
 - Promote selected imports into the work task ledger, with source metadata preserved.
-- Dismiss noisy imports so scanners can be useful without leaving permanent queue clutter.
-- Batch-promote reviewed imports by source and kind.
+- Dismiss noisy imports so scanners can be useful without leaving permanent queue clutter. Status: started with single-item dismissal and filtered `dismiss --all`.
+- Batch-promote reviewed imports by source and kind. Status: started with source, kind, and metadata filters across list, triage, promote, and dismiss.
 - Surface pending imports and grouped counts in `brigade work brief` so discovered work appears in the daily flow.
 
 ## Later Phase: Chat Surface Scanners

--- a/src/brigade/cli.py
+++ b/src/brigade/cli.py
@@ -120,11 +120,13 @@ def _build_parser() -> argparse.ArgumentParser:
     p_handoff_issues.add_argument("--sources", type=Path, default=None, help="Override .brigade/handoff-sources.json.")
     p_handoff_issues.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
     p_handoff_issues.add_argument("--limit", type=int, default=20, help="Maximum issue rows to print.")
+    p_handoff_issues.add_argument("--category", action="append", default=[], help="Limit to one issue category. May be repeated.")
     p_handoff_import_issues = handoff_sub.add_parser("import-issues", help="Import handoff ingest issues into the work inbox.")
     p_handoff_import_issues.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update.")
     p_handoff_import_issues.add_argument("--sources", type=Path, default=None, help="Override .brigade/handoff-sources.json.")
     p_handoff_import_issues.add_argument("--dry-run", action="store_true", help="Report without writing imports.")
     p_handoff_import_issues.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_handoff_import_issues.add_argument("--category", action="append", default=[], help="Import only one issue category. May be repeated.")
 
     # work
     p_work = sub.add_parser("work", help="Inspect and manage a daily Brigade work session.")
@@ -199,6 +201,14 @@ def _build_parser() -> argparse.ArgumentParser:
     p_work_import_list.add_argument("--all", action="store_true", help="Include promoted imports.")
     p_work_import_list.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
     p_work_import_list.add_argument("--limit", type=int, default=20, help="Maximum imports to show.")
+    p_work_import_list.add_argument("--source", default=None, help="Filter by import source.")
+    p_work_import_list.add_argument(
+        "--kind",
+        choices=["task", "finding", "decision", "preference", "incident", "link", "command"],
+        default=None,
+        help="Filter by import kind.",
+    )
+    p_work_import_list.add_argument("--metadata", action="append", default=[], help="Filter by metadata key=value. May be repeated.")
     p_work_import_validate = import_sub.add_parser("validate", help="Validate a work import JSONL file.")
     p_work_import_validate.add_argument("input_path", type=Path, help="JSONL file to validate.")
     p_work_import_validate.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
@@ -232,6 +242,14 @@ def _build_parser() -> argparse.ArgumentParser:
     p_work_import_triage.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
     p_work_import_triage.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
     p_work_import_triage.add_argument("--limit", type=int, default=50, help="Maximum imports per group to show.")
+    p_work_import_triage.add_argument("--source", default=None, help="Filter by import source.")
+    p_work_import_triage.add_argument(
+        "--kind",
+        choices=["task", "finding", "decision", "preference", "incident", "link", "command"],
+        default=None,
+        help="Filter by import kind.",
+    )
+    p_work_import_triage.add_argument("--metadata", action="append", default=[], help="Filter by metadata key=value. May be repeated.")
     p_work_import_show = import_sub.add_parser("show", help="Show one work import.")
     p_work_import_show.add_argument("import_id", help="Import id or unique prefix.")
     p_work_import_show.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
@@ -246,9 +264,19 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Limit --all promotion to one kind.",
     )
     p_work_import_promote.add_argument("--source", default=None, help="Limit --all promotion to one source.")
+    p_work_import_promote.add_argument("--metadata", action="append", default=[], help="Limit --all promotion by metadata key=value. May be repeated.")
     p_work_import_dismiss = import_sub.add_parser("dismiss", help="Dismiss one pending work import.")
-    p_work_import_dismiss.add_argument("import_id", help="Import id or unique prefix.")
+    p_work_import_dismiss.add_argument("import_id", nargs="?", help="Import id or unique prefix.")
     p_work_import_dismiss.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update.")
+    p_work_import_dismiss.add_argument("--all", action="store_true", help="Dismiss all pending imports matching filters.")
+    p_work_import_dismiss.add_argument(
+        "--kind",
+        choices=["task", "finding", "decision", "preference", "incident", "link", "command"],
+        default=None,
+        help="Limit --all dismissal to one kind.",
+    )
+    p_work_import_dismiss.add_argument("--source", default=None, help="Limit --all dismissal to one source.")
+    p_work_import_dismiss.add_argument("--metadata", action="append", default=[], help="Limit --all dismissal by metadata key=value. May be repeated.")
     p_work_import_dismiss.add_argument("--reason", default=None, help="Optional dismiss reason.")
     p_work_list = work_sub.add_parser("list", help="List recent Brigade work sessions.")
     p_work_list.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
@@ -651,9 +679,21 @@ def main(argv=None) -> int:
         if args.handoff_command == "doctor":
             return handoff_cmd.doctor(target=args.target, sources=args.sources, json_output=args.json)
         if args.handoff_command == "issues":
-            return handoff_cmd.issues(target=args.target, sources=args.sources, json_output=args.json, limit=args.limit)
+            return handoff_cmd.issues(
+                target=args.target,
+                sources=args.sources,
+                json_output=args.json,
+                limit=args.limit,
+                categories=args.category,
+            )
         if args.handoff_command == "import-issues":
-            return handoff_cmd.import_issues(target=args.target, sources=args.sources, dry_run=args.dry_run, json_output=args.json)
+            return handoff_cmd.import_issues(
+                target=args.target,
+                sources=args.sources,
+                dry_run=args.dry_run,
+                json_output=args.json,
+                categories=args.category,
+            )
         parser.error(f"unknown handoff command: {args.handoff_command}")
         return 2
     if cmd == "work":
@@ -708,6 +748,9 @@ def main(argv=None) -> int:
                     all_imports=args.all,
                     json_output=args.json,
                     limit=args.limit,
+                    source=args.source,
+                    kind=args.kind,
+                    metadata=args.metadata,
                 )
             if args.import_command == "validate":
                 return work_cmd.import_validate(input_path=args.input_path, json_output=args.json)
@@ -733,7 +776,14 @@ def main(argv=None) -> int:
                     json_output=args.json,
                 )
             if args.import_command == "triage":
-                return work_cmd.import_triage(target=args.target, json_output=args.json, limit=args.limit)
+                return work_cmd.import_triage(
+                    target=args.target,
+                    json_output=args.json,
+                    limit=args.limit,
+                    source=args.source,
+                    kind=args.kind,
+                    metadata=args.metadata,
+                )
             if args.import_command == "show":
                 return work_cmd.import_show(target=args.target, import_id=args.import_id)
             if args.import_command == "promote":
@@ -743,9 +793,18 @@ def main(argv=None) -> int:
                     all_matching=args.all,
                     kind=args.kind,
                     source=args.source,
+                    metadata=args.metadata,
                 )
             if args.import_command == "dismiss":
-                return work_cmd.import_dismiss(target=args.target, import_id=args.import_id, reason=args.reason)
+                return work_cmd.import_dismiss(
+                    target=args.target,
+                    import_id=args.import_id,
+                    reason=args.reason,
+                    all_matching=args.all,
+                    kind=args.kind,
+                    source=args.source,
+                    metadata=args.metadata,
+                )
             parser.error(f"unknown import command: {args.import_command}")
             return 2
         if args.work_command == "list":

--- a/src/brigade/handoff_cmd.py
+++ b/src/brigade/handoff_cmd.py
@@ -260,7 +260,11 @@ def doctor_checks(target: Path, sources: Path | None = None) -> list[tuple[str, 
     return checks
 
 
-def collect_issues(target: Path, sources: Path | None = None) -> list[HandoffIssue]:
+def collect_issues(
+    target: Path,
+    sources: Path | None = None,
+    categories: list[str] | None = None,
+) -> list[HandoffIssue]:
     health = inspect(target, sources=sources)
     issues: list[HandoffIssue] = []
     for inbox in health.inboxes:
@@ -320,7 +324,7 @@ def collect_issues(target: Path, sources: Path | None = None) -> list[HandoffIss
             )
         if ingestor.exists and ingestor.log_path is not None:
             issues.extend(_parse_ingestor_log_issues(ingestor.log_path))
-    return _dedupe_issues(issues)
+    return _filter_issues_by_category(_dedupe_issues(issues), categories)
 
 
 def issues(
@@ -329,6 +333,7 @@ def issues(
     sources: Path | None = None,
     json_output: bool = False,
     limit: int = 20,
+    categories: list[str] | None = None,
 ) -> int:
     if limit < 1:
         print("error: --limit must be a positive integer", file=sys.stderr)
@@ -337,7 +342,7 @@ def issues(
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
-    found = collect_issues(target, sources=sources)
+    found = collect_issues(target, sources=sources, categories=categories)
     payload = _issues_payload(target, found)
     if json_output:
         print(json.dumps(payload, indent=2, sort_keys=True))
@@ -365,12 +370,13 @@ def import_issues(
     sources: Path | None = None,
     dry_run: bool = False,
     json_output: bool = False,
+    categories: list[str] | None = None,
 ) -> int:
     target = target.expanduser().resolve()
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
-    found = collect_issues(target, sources=sources)
+    found = collect_issues(target, sources=sources, categories=categories)
     records = [issue.as_import_record() for issue in found]
     from . import work_cmd
 
@@ -439,6 +445,16 @@ def _dedupe_issues(issues: list[HandoffIssue]) -> list[HandoffIssue]:
         seen.add(issue.id)
         deduped.append(issue)
     return deduped
+
+
+def _filter_issues_by_category(
+    issues: list[HandoffIssue],
+    categories: list[str] | None,
+) -> list[HandoffIssue]:
+    wanted = {category for category in categories or [] if category}
+    if not wanted:
+        return issues
+    return [issue for issue in issues if issue.category in wanted]
 
 
 def _make_issue(

--- a/src/brigade/work_cmd.py
+++ b/src/brigade/work_cmd.py
@@ -340,13 +340,49 @@ def _matching_pending_imports(
     *,
     kind: str | None = None,
     source: str | None = None,
+    metadata_filters: dict[str, str] | None = None,
 ) -> list[dict[str, Any]]:
     imports = _pending_imports(target)
     if kind:
         imports = [item for item in imports if item.get("kind") == kind]
     if source:
         imports = [item for item in imports if item.get("source") == source]
+    if metadata_filters:
+        imports = [item for item in imports if _import_metadata_matches(item, metadata_filters)]
     return imports
+
+
+def _import_metadata_matches(item: dict[str, Any], filters: dict[str, str]) -> bool:
+    metadata = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
+    for key, expected in filters.items():
+        if str(metadata.get(key, "")) != expected:
+            return False
+    return True
+
+
+def _parse_metadata_filters(values: list[str] | None) -> tuple[dict[str, str], list[str]]:
+    filters: dict[str, str] = {}
+    errors: list[str] = []
+    for raw in values or []:
+        if "=" not in raw:
+            errors.append(f"--metadata filter must be key=value: {raw}")
+            continue
+        key, value = raw.split("=", 1)
+        key = key.strip()
+        if not key:
+            errors.append(f"--metadata filter key cannot be empty: {raw}")
+            continue
+        filters[key] = value.strip()
+    return filters, errors
+
+
+def _parse_or_report_metadata_filters(values: list[str] | None) -> tuple[dict[str, str] | None, int]:
+    filters, errors = _parse_metadata_filters(values)
+    if errors:
+        for error in errors:
+            print(f"error: {error}", file=sys.stderr)
+        return None, 2
+    return filters, 0
 
 
 def _find_pending_task_by_text(target: Path, text: str) -> dict[str, Any] | None:
@@ -1579,10 +1615,25 @@ def import_add(
     return 0
 
 
-def import_list(*, target: Path, all_imports: bool = False, json_output: bool = False, limit: int = 20) -> int:
+def import_list(
+    *,
+    target: Path,
+    all_imports: bool = False,
+    json_output: bool = False,
+    limit: int = 20,
+    source: str | None = None,
+    kind: str | None = None,
+    metadata: list[str] | None = None,
+) -> int:
     if limit < 1:
         print("error: --limit must be a positive integer", file=sys.stderr)
         return 2
+    if kind is not None and kind not in IMPORT_KINDS:
+        print(f"error: --kind must be one of: {', '.join(IMPORT_KINDS)}", file=sys.stderr)
+        return 2
+    metadata_filters, rc = _parse_or_report_metadata_filters(metadata)
+    if rc:
+        return rc
     target = target.expanduser().resolve()
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
@@ -1591,6 +1642,12 @@ def import_list(*, target: Path, all_imports: bool = False, json_output: bool = 
     imports.sort(key=_import_sort_key)
     if not all_imports:
         imports = [item for item in imports if item.get("status", "pending") == "pending"]
+    if source:
+        imports = [item for item in imports if item.get("source") == source]
+    if kind:
+        imports = [item for item in imports if item.get("kind") == kind]
+    if metadata_filters:
+        imports = [item for item in imports if _import_metadata_matches(item, metadata_filters)]
     imports = imports[:limit]
 
     if json_output:
@@ -1887,15 +1944,29 @@ def import_chat_sweep(
     return 0
 
 
-def import_triage(*, target: Path, json_output: bool = False, limit: int = 50) -> int:
+def import_triage(
+    *,
+    target: Path,
+    json_output: bool = False,
+    limit: int = 50,
+    source: str | None = None,
+    kind: str | None = None,
+    metadata: list[str] | None = None,
+) -> int:
     if limit < 1:
         print("error: --limit must be a positive integer", file=sys.stderr)
         return 2
+    if kind is not None and kind not in IMPORT_KINDS:
+        print(f"error: --kind must be one of: {', '.join(IMPORT_KINDS)}", file=sys.stderr)
+        return 2
+    metadata_filters, rc = _parse_or_report_metadata_filters(metadata)
+    if rc:
+        return rc
     target = target.expanduser().resolve()
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
-    pending = _pending_imports(target)
+    pending = _matching_pending_imports(target, kind=kind, source=source, metadata_filters=metadata_filters)
     counts = _import_counts(pending)
     groups: dict[str, dict[str, list[dict[str, Any]]]] = {}
     for item in pending:
@@ -1970,6 +2041,7 @@ def import_promote(
     all_matching: bool = False,
     kind: str | None = None,
     source: str | None = None,
+    metadata: list[str] | None = None,
 ) -> int:
     target = target.expanduser().resolve()
     if not target.is_dir():
@@ -1978,12 +2050,23 @@ def import_promote(
     if kind is not None and kind not in IMPORT_KINDS:
         print(f"error: --kind must be one of: {', '.join(IMPORT_KINDS)}", file=sys.stderr)
         return 2
+    metadata_filters, rc = _parse_or_report_metadata_filters(metadata)
+    if rc:
+        return rc
     if all_matching and import_id:
         print("error: pass an import id or --all, not both", file=sys.stderr)
         return 2
     if all_matching:
         imports = _read_imports(target)
-        wanted_ids = {item.get("id") for item in _matching_pending_imports(target, kind=kind, source=source)}
+        wanted_ids = {
+            item.get("id")
+            for item in _matching_pending_imports(
+                target,
+                kind=kind,
+                source=source,
+                metadata_filters=metadata_filters,
+            )
+        }
         promoted: list[tuple[dict[str, Any], dict[str, Any], bool]] = []
         for item in imports:
             if item.get("id") not in wanted_ids:
@@ -2026,10 +2109,60 @@ def import_promote(
     return 0
 
 
-def import_dismiss(*, target: Path, import_id: str, reason: str | None = None) -> int:
+def import_dismiss(
+    *,
+    target: Path,
+    import_id: str | None = None,
+    reason: str | None = None,
+    all_matching: bool = False,
+    kind: str | None = None,
+    source: str | None = None,
+    metadata: list[str] | None = None,
+) -> int:
     target = target.expanduser().resolve()
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
+        return 2
+    if kind is not None and kind not in IMPORT_KINDS:
+        print(f"error: --kind must be one of: {', '.join(IMPORT_KINDS)}", file=sys.stderr)
+        return 2
+    metadata_filters, rc = _parse_or_report_metadata_filters(metadata)
+    if rc:
+        return rc
+    if all_matching and import_id:
+        print("error: pass an import id or --all, not both", file=sys.stderr)
+        return 2
+    if all_matching:
+        imports = _read_imports(target)
+        wanted_ids = {
+            item.get("id")
+            for item in _matching_pending_imports(
+                target,
+                kind=kind,
+                source=source,
+                metadata_filters=metadata_filters,
+            )
+        }
+        now = _now().isoformat()
+        dismissed: list[dict[str, Any]] = []
+        for item in imports:
+            if item.get("id") not in wanted_ids:
+                continue
+            item["status"] = "dismissed"
+            item["updated_at"] = now
+            item["dismissed_at"] = now
+            if reason and reason.strip():
+                item["dismiss_reason"] = reason.strip()
+            dismissed.append(item)
+        _write_imports(target, imports)
+        print(f"dismissed: {len(dismissed)}")
+        if reason and reason.strip():
+            print(f"reason: {reason.strip()}")
+        for item in dismissed:
+            print(f"- {item.get('id')} {_short(str(item.get('text', '')))}")
+        return 0
+    if not import_id:
+        print("error: import id is required unless --all is passed", file=sys.stderr)
         return 2
     item, imports = _find_import(target, import_id)
     if item is None:

--- a/tests/test_handoff_cmd.py
+++ b/tests/test_handoff_cmd.py
@@ -246,6 +246,37 @@ def test_handoff_import_issues_dedupes_existing_pending_imports(tmp_path, capsys
     assert "skipped_duplicates: 1" in out
 
 
+def test_handoff_import_issues_filters_by_category(tmp_path, capsys):
+    log = tmp_path / "latest.log"
+    log.write_text(
+        "\n".join(
+            [
+                "SKIP bad.md: no recognizable markdown sections found",
+                "ROUTE-SKIP note.md: action is not no-card",
+                "",
+            ]
+        )
+    )
+    config = tmp_path / ".brigade" / "handoff-sources.json"
+    config.parent.mkdir()
+    config.write_text(
+        json.dumps(
+            {
+                "sources": [{"root": ".", "inboxes": [".claude/memory-handoffs"]}],
+                "ingestor": {"last_run_log": "latest.log"},
+            }
+        )
+    )
+
+    assert handoff_cmd.import_issues(target=tmp_path, categories=["route-skip"]) == 0
+
+    out = capsys.readouterr().out
+    assert "issues: 1" in out
+    assert "imported: 1" in out
+    item = json.loads((tmp_path / ".brigade" / "work" / "imports" / "inbox.jsonl").read_text().splitlines()[0])
+    assert item["metadata"]["handoff_issue_category"] == "route-skip"
+
+
 def test_handoff_doctor_cli(tmp_path, monkeypatch):
     seen = {}
 
@@ -268,8 +299,23 @@ def test_handoff_issues_cli(tmp_path, monkeypatch):
 
     monkeypatch.setattr(handoff_cmd, "issues", fake_issues)
 
-    assert cli.main(["handoff", "issues", "--target", str(tmp_path), "--json", "--limit", "7"]) == 0
-    assert seen == {"target": tmp_path, "sources": None, "json_output": True, "limit": 7}
+    assert (
+        cli.main(
+            [
+                "handoff",
+                "issues",
+                "--target",
+                str(tmp_path),
+                "--json",
+                "--limit",
+                "7",
+                "--category",
+                "skip",
+            ]
+        )
+        == 0
+    )
+    assert seen == {"target": tmp_path, "sources": None, "json_output": True, "limit": 7, "categories": ["skip"]}
 
 
 def test_handoff_import_issues_cli(tmp_path, monkeypatch):
@@ -281,5 +327,19 @@ def test_handoff_import_issues_cli(tmp_path, monkeypatch):
 
     monkeypatch.setattr(handoff_cmd, "import_issues", fake_import_issues)
 
-    assert cli.main(["handoff", "import-issues", "--target", str(tmp_path), "--dry-run", "--json"]) == 0
-    assert seen == {"target": tmp_path, "sources": None, "dry_run": True, "json_output": True}
+    assert (
+        cli.main(
+            [
+                "handoff",
+                "import-issues",
+                "--target",
+                str(tmp_path),
+                "--dry-run",
+                "--json",
+                "--category",
+                "route-skip",
+            ]
+        )
+        == 0
+    )
+    assert seen == {"target": tmp_path, "sources": None, "dry_run": True, "json_output": True, "categories": ["route-skip"]}

--- a/tests/test_work_cmd.py
+++ b/tests/test_work_cmd.py
@@ -886,6 +886,62 @@ def test_work_import_triage_groups_pending_imports(tmp_path, monkeypatch, capsys
     assert payload["groups"]["slack"]["decision"][0]["text"] == "Check chat decision"
 
 
+def test_work_import_list_and_triage_filter_by_metadata(tmp_path, monkeypatch, capsys):
+    _init_git_repo(tmp_path)
+    monkeypatch.setattr(
+        work_cmd,
+        "_now",
+        lambda: datetime(2026, 5, 26, 12, 0, 0, tzinfo=timezone.utc),
+    )
+    assert (
+        work_cmd.import_add(
+            target=tmp_path,
+            text="Repair skipped handoff",
+            kind="task",
+            source="handoff-ingest",
+            metadata=["handoff_issue_category=skip"],
+        )
+        == 0
+    )
+    assert (
+        work_cmd.import_add(
+            target=tmp_path,
+            text="Repair route skip",
+            kind="task",
+            source="handoff-ingest",
+            metadata=["handoff_issue_category=route-skip"],
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    assert (
+        work_cmd.import_list(
+            target=tmp_path,
+            json_output=True,
+            source="handoff-ingest",
+            kind="task",
+            metadata=["handoff_issue_category=skip"],
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert [item["text"] for item in payload["imports"]] == ["Repair skipped handoff"]
+
+    assert (
+        work_cmd.import_triage(
+            target=tmp_path,
+            json_output=True,
+            source="handoff-ingest",
+            metadata=["handoff_issue_category=route-skip"],
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["counts"]["total"] == 1
+    assert payload["groups"]["handoff-ingest"]["task"][0]["text"] == "Repair route skip"
+
+
 def test_work_import_promote_all_filters_by_source_and_kind(tmp_path, monkeypatch, capsys):
     _init_git_repo(tmp_path)
     monkeypatch.setattr(
@@ -920,6 +976,53 @@ def test_work_import_promote_all_filters_by_source_and_kind(tmp_path, monkeypatc
     assert [item["text"] for item in payload["imports"]] == ["Review chat note", "Record decision"]
 
 
+def test_work_import_promote_all_filters_by_metadata(tmp_path, monkeypatch, capsys):
+    _init_git_repo(tmp_path)
+    monkeypatch.setattr(
+        work_cmd,
+        "_now",
+        lambda: datetime(2026, 5, 26, 12, 0, 0, tzinfo=timezone.utc),
+    )
+    assert (
+        work_cmd.import_add(
+            target=tmp_path,
+            text="Fix route skip",
+            kind="task",
+            source="handoff-ingest",
+            metadata=["handoff_issue_category=route-skip"],
+        )
+        == 0
+    )
+    assert (
+        work_cmd.import_add(
+            target=tmp_path,
+            text="Fix malformed handoff",
+            kind="task",
+            source="handoff-ingest",
+            metadata=["handoff_issue_category=skip"],
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    assert (
+        work_cmd.import_promote(
+            target=tmp_path,
+            all_matching=True,
+            source="handoff-ingest",
+            metadata=["handoff_issue_category=route-skip"],
+        )
+        == 0
+    )
+    out = capsys.readouterr().out
+    assert "promoted: 1" in out
+    ledger = json.loads((tmp_path / ".brigade" / "work" / "tasks.json").read_text())
+    assert [task["text"] for task in ledger["tasks"]] == ["Fix route skip"]
+    assert work_cmd.import_list(target=tmp_path, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert [item["text"] for item in payload["imports"]] == ["Fix malformed handoff"]
+
+
 def test_work_import_dismiss_marks_import_not_pending(tmp_path, monkeypatch, capsys):
     _init_git_repo(tmp_path)
     monkeypatch.setattr(
@@ -940,6 +1043,68 @@ def test_work_import_dismiss_marks_import_not_pending(tmp_path, monkeypatch, cap
     payload = json.loads(capsys.readouterr().out)
     assert payload["imports"][0]["status"] == "dismissed"
     assert payload["imports"][0]["dismiss_reason"] == "not actionable"
+
+
+def test_work_import_dismiss_all_filters_by_source_kind_and_metadata(tmp_path, monkeypatch, capsys):
+    _init_git_repo(tmp_path)
+    monkeypatch.setattr(
+        work_cmd,
+        "_now",
+        lambda: datetime(2026, 5, 26, 12, 0, 0, tzinfo=timezone.utc),
+    )
+    assert (
+        work_cmd.import_add(
+            target=tmp_path,
+            text="Dismiss skipped historical handoff",
+            kind="task",
+            source="handoff-ingest",
+            metadata=["handoff_issue_category=skip"],
+        )
+        == 0
+    )
+    assert (
+        work_cmd.import_add(
+            target=tmp_path,
+            text="Keep route skip",
+            kind="task",
+            source="handoff-ingest",
+            metadata=["handoff_issue_category=route-skip"],
+        )
+        == 0
+    )
+    assert work_cmd.import_add(target=tmp_path, text="Keep incident", kind="incident", source="handoff-ingest") == 0
+    capsys.readouterr()
+
+    assert (
+        work_cmd.import_dismiss(
+            target=tmp_path,
+            all_matching=True,
+            kind="task",
+            source="handoff-ingest",
+            metadata=["handoff_issue_category=skip"],
+            reason="historical noise",
+        )
+        == 0
+    )
+    out = capsys.readouterr().out
+    assert "dismissed: 1" in out
+    assert "reason: historical noise" in out
+
+    assert work_cmd.import_list(target=tmp_path, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert [item["text"] for item in payload["imports"]] == ["Keep route skip", "Keep incident"]
+    assert work_cmd.import_list(target=tmp_path, all_imports=True, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    dismissed = [item for item in payload["imports"] if item["text"] == "Dismiss skipped historical handoff"][0]
+    assert dismissed["status"] == "dismissed"
+    assert dismissed["dismiss_reason"] == "historical noise"
+
+
+def test_work_import_dismiss_all_requires_id_or_all(tmp_path, capsys):
+    _init_git_repo(tmp_path)
+
+    assert work_cmd.import_dismiss(target=tmp_path) == 2
+    assert "import id is required unless --all is passed" in capsys.readouterr().err
 
 
 def test_work_import_promote_rejects_non_pending_import(tmp_path, monkeypatch, capsys):
@@ -1592,7 +1757,28 @@ def test_work_import_cli(tmp_path, monkeypatch):
         )
         == 0
     )
-    assert cli.main(["work", "import", "list", "--target", str(tmp_path), "--all", "--json", "--limit", "3"]) == 0
+    assert (
+        cli.main(
+            [
+                "work",
+                "import",
+                "list",
+                "--target",
+                str(tmp_path),
+                "--all",
+                "--json",
+                "--limit",
+                "3",
+                "--source",
+                "handoff-ingest",
+                "--kind",
+                "task",
+                "--metadata",
+                "handoff_issue_category=skip",
+            ]
+        )
+        == 0
+    )
     assert cli.main(["work", "import", "validate", str(tmp_path / "imports.jsonl"), "--json"]) == 0
     assert (
         cli.main(
@@ -1641,7 +1827,25 @@ def test_work_import_cli(tmp_path, monkeypatch):
         )
         == 0
     )
-    assert cli.main(["work", "import", "triage", "--target", str(tmp_path), "--json", "--limit", "4"]) == 0
+    assert (
+        cli.main(
+            [
+                "work",
+                "import",
+                "triage",
+                "--target",
+                str(tmp_path),
+                "--json",
+                "--limit",
+                "4",
+                "--source",
+                "handoff-ingest",
+                "--metadata",
+                "handoff_issue_category=route-skip",
+            ]
+        )
+        == 0
+    )
     assert cli.main(["work", "import", "show", "imp123", "--target", str(tmp_path)]) == 0
     assert (
         cli.main(
@@ -1656,11 +1860,33 @@ def test_work_import_cli(tmp_path, monkeypatch):
                 "task",
                 "--source",
                 "memory-care",
+                "--metadata",
+                "handoff_issue_category=skip",
             ]
         )
         == 0
     )
-    assert cli.main(["work", "import", "dismiss", "imp123", "--target", str(tmp_path), "--reason", "noise"]) == 0
+    assert (
+        cli.main(
+            [
+                "work",
+                "import",
+                "dismiss",
+                "--target",
+                str(tmp_path),
+                "--all",
+                "--kind",
+                "task",
+                "--source",
+                "handoff-ingest",
+                "--metadata",
+                "handoff_issue_category=skip",
+                "--reason",
+                "noise",
+            ]
+        )
+        == 0
+    )
     assert seen == [
         (
             "add",
@@ -1672,7 +1898,18 @@ def test_work_import_cli(tmp_path, monkeypatch):
                 "metadata": ["channel=dev"],
             },
         ),
-        ("list", {"target": tmp_path, "all_imports": True, "json_output": True, "limit": 3}),
+        (
+            "list",
+            {
+                "target": tmp_path,
+                "all_imports": True,
+                "json_output": True,
+                "limit": 3,
+                "source": "handoff-ingest",
+                "kind": "task",
+                "metadata": ["handoff_issue_category=skip"],
+            },
+        ),
         ("validate", {"input_path": tmp_path / "imports.jsonl", "json_output": True}),
         (
             "ingest",
@@ -1701,7 +1938,17 @@ def test_work_import_cli(tmp_path, monkeypatch):
                 "json_output": True,
             },
         ),
-        ("triage", {"target": tmp_path, "json_output": True, "limit": 4}),
+        (
+            "triage",
+            {
+                "target": tmp_path,
+                "json_output": True,
+                "limit": 4,
+                "source": "handoff-ingest",
+                "kind": None,
+                "metadata": ["handoff_issue_category=route-skip"],
+            },
+        ),
         ("show", {"target": tmp_path, "import_id": "imp123"}),
         (
             "promote",
@@ -1711,9 +1958,21 @@ def test_work_import_cli(tmp_path, monkeypatch):
                 "all_matching": True,
                 "kind": "task",
                 "source": "memory-care",
+                "metadata": ["handoff_issue_category=skip"],
             },
         ),
-        ("dismiss", {"target": tmp_path, "import_id": "imp123", "reason": "noise"}),
+        (
+            "dismiss",
+            {
+                "target": tmp_path,
+                "import_id": None,
+                "reason": "noise",
+                "all_matching": True,
+                "kind": "task",
+                "source": "handoff-ingest",
+                "metadata": ["handoff_issue_category=skip"],
+            },
+        ),
     ]
 
 


### PR DESCRIPTION
## Summary
- add metadata filters to work import list, triage, promote, and dismiss
- add filtered bulk dismissal with `work import dismiss --all`
- add handoff issue category filters to `handoff issues` and `handoff import-issues`
- document batch promotion/dismissal examples for scanner-specific metadata

## Verification
- `.venv/bin/python -m pytest tests/test_work_cmd.py tests/test_handoff_cmd.py -q`
- `.venv/bin/python -m pytest -q`
- `git diff --check`
- content-guard public scan
- `brigade handoff issues --target . --category route-skip --limit 5`
- `brigade handoff import-issues --target . --category route-skip --dry-run`
- `brigade work import list --target . --source handoff-ingest --metadata handoff_issue_category=skip --limit 2`
- `brigade work import triage --target . --source handoff-ingest --metadata handoff_issue_category=route-skip --limit 3`
- dogfooded filtered promote and dismiss against local handoff-ingest imports