### PR TITLE
feat: add handoff lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `brigade handoff doctor` ingestor-log checks for stale latest-run logs, skipped malformed handoffs, warning summaries, and no-reply/no-update masking signals.
 - `brigade handoff issues` and `brigade handoff import-issues` to turn handoff ingest warnings into grouped repair guidance and local work imports.
 - `brigade handoff issues --category` and `brigade handoff import-issues --category` for category-limited handoff issue review/import.
+- `brigade handoff lint` to validate pending or explicit handoff files before ingest and catch card/document action mismatches that would be skipped later.
 - `docs/import-schema.md` documenting the local import JSONL contract for scanners and wrappers.
 - Cybersecurity plugin roadmap covering broad agent-workspace security checks plus Brigade-specific scanner, doctor, import, and multi-harness security checks.
 - Built-in `security` station and `brigade security scan` for read-only agent workspace security checks.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ brigade init --target ./repo --harnesses none           # generic install
 Once installed, `brigade doctor` verifies the wiring and `brigade status` reports over the station registry.
 For machines that ingest handoffs from multiple repos, copy `.brigade/handoff-sources.example.json` to `.brigade/handoff-sources.json` and list the repo roots and writer inboxes the canonical ingestor scans.
 `brigade handoff doctor` reports pending `.claude/memory-handoffs/` and `.codex/memory-handoffs/` files that are not covered by that local source list.
+Run `brigade handoff lint` before ingesting pending handoffs when you want to catch action/target mismatches early.
 If your ingestor writes a latest-run log, set `ingestor.last_run_log` in that local config so the doctor can warn on stale runs, skipped malformed handoffs, and warning summaries hidden behind no-reply cron output.
 Use `brigade handoff issues` to group those warnings with repair guidance, then `brigade handoff import-issues` to route them into the normal local work import inbox.
 
@@ -155,6 +156,7 @@ brigade dogfood
 brigade dogfood next
 brigade dogfood --target /path/to/repo
 brigade handoff doctor
+brigade handoff lint
 brigade handoff issues
 brigade handoff import-issues
 brigade work bootstrap
@@ -360,6 +362,7 @@ Handoff behavior:
 - By default it writes a reviewable handoff to `.claude/memory-handoffs/` under `--cwd`.
 - Use `--handoff-inbox <path>` for Codex, OpenCode, GPT, Hermes, OpenClaw, or another writer inbox.
 - The handoff targets `.learnings/LEARNINGS.md` as a `no-card` document update.
+- `brigade handoff lint` validates pending handoffs before ingest. Card actions require `Target card` plus `Suggested card content` and must omit document sections; `no-card` actions require document sections and must omit card sections.
 - The normal `brigade ingest` route can review or ingest that handoff.
 - If handoff writing fails after synthesis, Brigade still prints the final answer and keeps the final artifacts.
 - Failed handoff writes exit nonzero and mark `run.json` as `handoff-failed`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -125,6 +125,7 @@ Goal: prevent durable memory from silently rotting.
 - Add a handoff doctor that compares repo-local writer inboxes such as `.claude/memory-handoffs/` and `.codex/memory-handoffs/` against the canonical ingestor source list, warning when handoffs exist in directories the owner is not scanning. Status: started with `brigade handoff doctor`, `.brigade/handoff-sources.example.json`, and `brigade doctor` / `brigade work doctor` integration.
 - Add handoff-ingest observability checks for hidden warning states, including unreachable remote sources, malformed handoffs that are skipped, and runs that emit `NO_REPLY` despite warnings. Status: started with optional `ingestor.last_run_log` checks in `brigade handoff doctor`.
 - Turn handoff-ingest warnings into repairable local work. Status: started with `brigade handoff issues`, `brigade handoff import-issues`, repair guidance, and `brigade work brief` issue counts.
+- Catch handoff action/target mismatches before ingest. Status: started with `brigade handoff lint`, doctor warnings, issue imports, and template guidance that forces card and document handoffs into mutually exclusive branches.
 
 ## Later Phase: Portable Operator Setup
 

--- a/src/brigade/cli.py
+++ b/src/brigade/cli.py
@@ -115,6 +115,10 @@ def _build_parser() -> argparse.ArgumentParser:
     p_handoff_doctor.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
     p_handoff_doctor.add_argument("--sources", type=Path, default=None, help="Override .brigade/handoff-sources.json.")
     p_handoff_doctor.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_handoff_lint = handoff_sub.add_parser("lint", help="Validate pending or explicit memory handoff files.")
+    p_handoff_lint.add_argument("paths", nargs="*", type=Path, help="Handoff files to validate. Defaults to pending inbox files.")
+    p_handoff_lint.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
+    p_handoff_lint.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
     p_handoff_issues = handoff_sub.add_parser("issues", help="Group actionable handoff ingest issues.")
     p_handoff_issues.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
     p_handoff_issues.add_argument("--sources", type=Path, default=None, help="Override .brigade/handoff-sources.json.")
@@ -678,6 +682,8 @@ def main(argv=None) -> int:
 
         if args.handoff_command == "doctor":
             return handoff_cmd.doctor(target=args.target, sources=args.sources, json_output=args.json)
+        if args.handoff_command == "lint":
+            return handoff_cmd.lint(target=args.target, paths=args.paths, json_output=args.json)
         if args.handoff_command == "issues":
             return handoff_cmd.issues(
                 target=args.target,

--- a/src/brigade/handoff_cmd.py
+++ b/src/brigade/handoff_cmd.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import hashlib
+import re
 import sys
 import time
 from dataclasses import dataclass
@@ -17,6 +18,12 @@ WRITER_INBOXES = (".claude/memory-handoffs", ".codex/memory-handoffs")
 IGNORED_HANDOFF_NAMES = {"TEMPLATE.md"}
 DEFAULT_STALE_AFTER_MINUTES = 90
 MAX_INGESTOR_WARNING_SIGNALS = 5
+CARD_ACTIONS = ("create-card", "update-card")
+NO_CARD_ACTION = "no-card"
+HANDOFF_ACTIONS = (*CARD_ACTIONS, NO_CARD_ACTION)
+CARD_TARGET_PATTERN = re.compile(r"^[A-Za-z0-9._-]+\.md$")
+DOCUMENT_TARGETS = ("TOOLS.md", "USER.md")
+DOCUMENT_TARGET_PREFIXES = ("rules/", ".learnings/")
 DEFAULT_WARNING_PATTERNS = (
     "Warnings:",
     "SKIP ",
@@ -133,12 +140,31 @@ class HandoffIssue:
 
 
 @dataclass(frozen=True)
+class HandoffLintResult:
+    path: Path
+    action: str | None
+    valid: bool
+    errors: tuple[str, ...]
+    warnings: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "path": str(self.path),
+            "action": self.action,
+            "valid": self.valid,
+            "errors": list(self.errors),
+            "warnings": list(self.warnings),
+        }
+
+
+@dataclass(frozen=True)
 class HandoffHealth:
     target: Path
     sources_path: Path | None
     sources_loaded: bool
     inboxes: tuple[InboxHealth, ...]
     ingestor: IngestorHealth
+    lint: tuple[HandoffLintResult, ...]
     warnings: tuple[str, ...]
     failures: tuple[str, ...]
 
@@ -149,6 +175,7 @@ class HandoffHealth:
             "sources_loaded": self.sources_loaded,
             "inboxes": [inbox.as_dict() for inbox in self.inboxes],
             "ingestor": self.ingestor.as_dict(),
+            "lint": [result.as_dict() for result in self.lint],
             "warnings": list(self.warnings),
             "failures": list(self.failures),
         }
@@ -181,6 +208,7 @@ def inspect(target: Path, sources: Path | None = None) -> HandoffHealth:
     watched = source_config.watched
     inboxes = tuple(_inspect_inbox(target, rel, watched) for rel in WRITER_INBOXES)
     ingestor = _inspect_ingestor(source_config.ingestor)
+    lint_results = lint_targets(target)
     warnings: list[str] = []
     pending_total = sum(inbox.pending for inbox in inboxes)
     if pending_total and not sources_loaded and not failures:
@@ -193,6 +221,11 @@ def inspect(target: Path, sources: Path | None = None) -> HandoffHealth:
                 f"{inbox.inbox} has {inbox.pending} pending handoff"
                 f"{'s' if inbox.pending != 1 else ''} but is not watched by the source config"
             )
+    for result in lint_results:
+        if not result.valid:
+            warnings.append(
+                f"handoff lint failed for {result.path}: {result.errors[0] if result.errors else 'invalid handoff'}"
+            )
     warnings.extend(ingestor.warnings)
 
     return HandoffHealth(
@@ -201,6 +234,7 @@ def inspect(target: Path, sources: Path | None = None) -> HandoffHealth:
         sources_loaded=sources_loaded,
         inboxes=inboxes,
         ingestor=ingestor,
+        lint=lint_results,
         warnings=tuple(warnings),
         failures=tuple(failures),
     )
@@ -255,6 +289,17 @@ def doctor_checks(target: Path, sources: Path | None = None) -> list[tuple[str, 
     else:
         checks.append((OK, "handoff_ingestor", "log not configured"))
 
+    invalid_lint = [result for result in health.lint if not result.valid]
+    if not health.lint:
+        checks.append((OK, "handoff_lint", "no pending handoffs"))
+    elif invalid_lint:
+        checks.append((WARN, "handoff_lint", f"{len(invalid_lint)} invalid of {len(health.lint)} pending handoff files"))
+        for result in invalid_lint:
+            first_error = result.errors[0] if result.errors else "invalid handoff"
+            checks.append((WARN, "handoff_lint", f"{result.path}: {first_error}"))
+    else:
+        checks.append((OK, "handoff_lint", f"{len(health.lint)} pending handoff file{'s' if len(health.lint) != 1 else ''} valid"))
+
     for warning in health.warnings:
         checks.append((WARN, "handoff_warning", warning))
     return checks
@@ -291,6 +336,25 @@ def collect_issues(
                 )
             )
 
+    for result in health.lint:
+        if result.valid:
+            continue
+        first_error = result.errors[0] if result.errors else "invalid handoff"
+        issues.append(
+            _make_issue(
+                category="lint",
+                kind="task",
+                text=f"Fix pending handoff lint error in {result.path.name}: {first_error}",
+                repair=_lint_repair_for_result(result),
+                evidence=str(result.path),
+                metadata={
+                    "path": str(result.path),
+                    "action": result.action,
+                    "errors": list(result.errors),
+                },
+            )
+        )
+
     ingestor = health.ingestor
     if ingestor.configured:
         if not ingestor.exists:
@@ -325,6 +389,89 @@ def collect_issues(
         if ingestor.exists and ingestor.log_path is not None:
             issues.extend(_parse_ingestor_log_issues(ingestor.log_path))
     return _filter_issues_by_category(_dedupe_issues(issues), categories)
+
+
+def lint(
+    *,
+    target: Path,
+    paths: list[Path] | None = None,
+    json_output: bool = False,
+) -> int:
+    target = target.expanduser().resolve()
+    if not target.is_dir():
+        print(f"error: --target is not a directory: {target}", file=sys.stderr)
+        return 2
+    results = lint_targets(target, paths=paths)
+    payload = {
+        "target": str(target),
+        "count": len(results),
+        "valid": all(result.valid for result in results),
+        "results": [result.as_dict() for result in results],
+    }
+    if json_output:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0 if payload["valid"] else 1
+    print(f"handoff lint: {target}")
+    print(f"files: {len(results)}")
+    for result in results:
+        status = OK if result.valid else FAIL
+        action = f" ({result.action})" if result.action else ""
+        print(f"[{status}] {result.path}{action}")
+        for error in result.errors:
+            print(f"  - {error}")
+        for warning in result.warnings:
+            print(f"  warning: {warning}")
+    return 0 if payload["valid"] else 1
+
+
+def lint_targets(target: Path, paths: list[Path] | None = None) -> tuple[HandoffLintResult, ...]:
+    target = target.expanduser().resolve()
+    candidates = tuple(_resolve_lint_path(target, path) for path in paths) if paths else _pending_handoff_paths(target)
+    return tuple(lint_file(path) for path in candidates)
+
+
+def lint_file(path: Path) -> HandoffLintResult:
+    path = path.expanduser().resolve()
+    errors: list[str] = []
+    warnings: list[str] = []
+    action: str | None = None
+    try:
+        text = path.read_text(errors="replace")
+    except OSError as exc:
+        return HandoffLintResult(
+            path=path,
+            action=None,
+            valid=False,
+            errors=(f"cannot read handoff file: {exc}",),
+            warnings=(),
+        )
+
+    sections = _parse_markdown_sections(text)
+    for required in ("Type", "Title", "Summary", "Recommended memory action"):
+        if required not in sections or not _section_value(sections, required):
+            errors.append(f"missing required section: {required}")
+
+    action_value = _section_value(sections, "Recommended memory action")
+    if action_value:
+        action = action_value.splitlines()[0].strip().casefold()
+        if action not in HANDOFF_ACTIONS:
+            errors.append(
+                "Recommended memory action must be one of: "
+                + ", ".join(HANDOFF_ACTIONS)
+            )
+
+    if action in CARD_ACTIONS:
+        _lint_card_action(sections, errors, warnings)
+    elif action == NO_CARD_ACTION:
+        _lint_no_card_action(sections, errors)
+
+    return HandoffLintResult(
+        path=path,
+        action=action,
+        valid=not errors,
+        errors=tuple(errors),
+        warnings=tuple(warnings),
+    )
 
 
 def issues(
@@ -418,6 +565,127 @@ def doctor(*, target: Path, sources: Path | None = None, json_output: bool = Fal
         for status, name, detail in doctor_checks(health.target, sources=health.sources_path):
             print(f"[{status}] {name}: {detail}")
     return 1 if health.failures else 0
+
+
+def _resolve_lint_path(target: Path, path: Path) -> Path:
+    path = path.expanduser()
+    if not path.is_absolute():
+        path = target / path
+    return path.resolve()
+
+
+def _pending_handoff_paths(target: Path) -> tuple[Path, ...]:
+    paths: list[Path] = []
+    for rel in WRITER_INBOXES:
+        inbox = target / rel
+        if not inbox.is_dir():
+            continue
+        for candidate in inbox.glob("*.md"):
+            if not candidate.is_file():
+                continue
+            if candidate.name.startswith(".") or candidate.name in IGNORED_HANDOFF_NAMES:
+                continue
+            paths.append(candidate.resolve())
+    return tuple(sorted(paths))
+
+
+def _parse_markdown_sections(text: str) -> dict[str, str]:
+    sections: dict[str, list[str]] = {}
+    current: str | None = None
+    for line in text.splitlines():
+        if line.startswith("## "):
+            current = line[3:].strip()
+            sections.setdefault(current, [])
+            continue
+        if current is not None:
+            sections[current].append(line)
+    return {name: "\n".join(lines).strip() for name, lines in sections.items()}
+
+
+def _section_value(sections: dict[str, str], name: str) -> str:
+    raw = sections.get(name, "")
+    lines: list[str] = []
+    in_comment = False
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("<!--"):
+            in_comment = not stripped.endswith("-->")
+            continue
+        if in_comment:
+            if stripped.endswith("-->"):
+                in_comment = False
+            continue
+        lines.append(line.rstrip())
+    return "\n".join(lines).strip()
+
+
+def _lint_card_action(
+    sections: dict[str, str],
+    errors: list[str],
+    warnings: list[str],
+) -> None:
+    target_card = _section_value(sections, "Target card")
+    if not target_card:
+        errors.append("card handoffs require Target card")
+    elif not CARD_TARGET_PATTERN.fullmatch(target_card.splitlines()[0].strip()):
+        errors.append("Target card must be a filename like project-context.md with no path separators")
+
+    suggested_card = _section_value(sections, "Suggested card content")
+    if not suggested_card:
+        errors.append("card handoffs require Suggested card content")
+    elif not suggested_card.startswith("---"):
+        errors.append("Suggested card content must start with YAML frontmatter")
+
+    for prohibited in ("Target document", "Suggested document content"):
+        if prohibited in sections:
+            errors.append(f"card handoffs must omit the {prohibited} section entirely")
+
+    if "## " in suggested_card:
+        warnings.append("Suggested card content contains level-2 markdown headings, which may be parsed as handoff sections")
+
+
+def _lint_no_card_action(sections: dict[str, str], errors: list[str]) -> None:
+    target_document = _section_value(sections, "Target document")
+    if not target_document:
+        errors.append("no-card handoffs require Target document")
+    elif not _valid_document_target(target_document.splitlines()[0].strip()):
+        errors.append("Target document must be TOOLS.md, USER.md, rules/*.md, or .learnings/*.md")
+
+    suggested_document = _section_value(sections, "Suggested document content")
+    if not suggested_document:
+        errors.append("no-card handoffs require Suggested document content")
+    elif any(line.startswith("## ") for line in suggested_document.splitlines()):
+        errors.append("Suggested document content must not contain level-2 markdown headings")
+
+    for prohibited in ("Target card", "Suggested card content"):
+        if prohibited in sections:
+            errors.append(f"no-card handoffs must omit the {prohibited} section entirely")
+
+
+def _valid_document_target(value: str) -> bool:
+    if value.startswith("/") or ".." in Path(value).parts:
+        return False
+    if value in DOCUMENT_TARGETS:
+        return True
+    return any(value.startswith(prefix) and value.endswith(".md") for prefix in DOCUMENT_TARGET_PREFIXES)
+
+
+def _lint_repair_for_result(result: HandoffLintResult) -> str:
+    if result.action in CARD_ACTIONS:
+        return (
+            "Keep only the card branch in the handoff: Recommended memory action "
+            f"{result.action}, Target card, and Suggested card content. "
+            "Delete Target document and Suggested document content sections entirely."
+        )
+    if result.action == NO_CARD_ACTION:
+        return (
+            "Keep only the document branch in the handoff: Recommended memory action no-card, "
+            "Target document, and Suggested document content. Delete Target card and "
+            "Suggested card content sections entirely."
+        )
+    return "Rewrite the handoff with exactly one valid action branch before rerunning the ingestor."
 
 
 def _issues_payload(target: Path, found: list[HandoffIssue]) -> dict[str, Any]:

--- a/src/brigade/templates/claude/memory-handoffs/TEMPLATE.md
+++ b/src/brigade/templates/claude/memory-handoffs/TEMPLATE.md
@@ -28,6 +28,11 @@ Short, specific title. No private identifiers.
 
 create-card | update-card | no-card
 
+Choose exactly one branch below, then delete the other branch before saving.
+Card actions must omit document sections entirely. `no-card` actions must omit card sections entirely.
+
+<!-- CARD ACTION BRANCH: keep only for create-card or update-card. -->
+
 ## Target card
 
 card-name-if-known.md
@@ -47,6 +52,8 @@ tags: [list]
 
 Card body. Use ### or deeper for subsections; ## headings parse as new handoff sections.
 ```
+
+<!-- NO-CARD ACTION BRANCH: keep only for no-card. -->
 
 ## Target document
 

--- a/src/brigade/templates/codex/memory-handoffs/TEMPLATE.md
+++ b/src/brigade/templates/codex/memory-handoffs/TEMPLATE.md
@@ -28,6 +28,11 @@ Short, specific title. No private identifiers.
 
 create-card | update-card | no-card
 
+Choose exactly one branch below, then delete the other branch before saving.
+Card actions must omit document sections entirely. `no-card` actions must omit card sections entirely.
+
+<!-- CARD ACTION BRANCH: keep only for create-card or update-card. -->
+
 ## Target card
 
 card-name-if-known.md
@@ -47,6 +52,8 @@ tags: [list]
 
 Card body. Use ### or deeper for subsections; ## headings parse as new handoff sections.
 ```
+
+<!-- NO-CARD ACTION BRANCH: keep only for no-card. -->
 
 ## Target document
 

--- a/src/brigade/templates/memory/cards/handoff-flow.md
+++ b/src/brigade/templates/memory/cards/handoff-flow.md
@@ -31,11 +31,13 @@ Only three handoff shapes can silently mutate canonical memory. Everything else 
 - `Recommended memory action` is `create-card` or `update-card`.
 - `Target card` matches `^[A-Za-z0-9._-]+\.md$` (no path traversal).
 - `Suggested card content` starts with YAML frontmatter.
+- `Target document` and `Suggested document content` sections are omitted entirely.
 
 **Document routing:**
 - `Recommended memory action` is `no-card`.
 - `Target document` is one of: `TOOLS.md`, `USER.md`, `rules/*.md`, `.learnings/*.md`.
 - `Suggested document content` has no `##` headings (would parse as new sections).
+- `Target card` and `Suggested card content` sections are omitted entirely.
 
 ## Closeout instruction
 
@@ -56,6 +58,9 @@ find . -path "*/.claude/memory-handoffs/*.md" -not -path "*/processed/*" -mtime 
 # Ingest run
 brigade ingest --target . --dry-run
 
+# Pre-ingest lint
+brigade handoff lint --target .
+
 # Cards landed via promotion
 find memory/cards -mtime -7 -name "*.md"
 
@@ -66,5 +71,6 @@ ls memory/handoff-inbox/ 2>/dev/null | wc -l
 ## Gotchas
 
 - `##` inside `Suggested document content` parses as a new handoff section. Use `###` or deeper.
+- Mixed card and document sections can trigger route skips. Run `brigade handoff lint` and delete the unused branch before ingest.
 - Auto-promotion writes to the filesystem immediately. Ingest during quiet hours if you care about cache continuity.
 - The ingester is intentionally conservative. If your inbox grows, refine your handoff quality; do not loosen the rules.

--- a/tests/test_handoff_cmd.py
+++ b/tests/test_handoff_cmd.py
@@ -7,6 +7,120 @@ from brigade import cli
 from brigade import handoff_cmd
 
 
+CARD_HANDOFF = """# Memory Handoff
+
+## Type
+learning
+
+## Title
+Handoff lint cards
+
+## Summary
+Card handoffs should be promotable.
+
+## Recommended memory action
+create-card
+
+## Target card
+handoff-lint-cards.md
+
+## Suggested card content
+---
+topic: handoff-lint-cards
+category: foundation
+tags: [memory, handoff]
+---
+
+# Handoff lint cards
+
+Card handoffs only include card fields.
+"""
+
+
+NO_CARD_HANDOFF = """# Memory Handoff
+
+## Type
+learning
+
+## Title
+Handoff lint documents
+
+## Summary
+Document handoffs should be routable.
+
+## Recommended memory action
+no-card
+
+## Target document
+.learnings/LEARNINGS.md
+
+## Suggested document content
+### Handoff lint documents
+
+Document handoffs only include document fields.
+"""
+
+
+def test_handoff_lint_accepts_card_handoff_without_document_sections(tmp_path, capsys):
+    path = tmp_path / "note.md"
+    path.write_text(CARD_HANDOFF)
+
+    assert handoff_cmd.lint(target=tmp_path, paths=[path]) == 0
+
+    out = capsys.readouterr().out
+    assert "[ok]" in out
+    assert "(create-card)" in out
+
+
+def test_handoff_lint_rejects_card_handoff_with_empty_document_sections(tmp_path, capsys):
+    path = tmp_path / "note.md"
+    path.write_text(CARD_HANDOFF + "\n## Target document\n\n## Suggested document content\n")
+
+    assert handoff_cmd.lint(target=tmp_path, paths=[path]) == 1
+
+    out = capsys.readouterr().out
+    assert "[fail]" in out
+    assert "card handoffs must omit the Target document section entirely" in out
+    assert "card handoffs must omit the Suggested document content section entirely" in out
+
+
+def test_handoff_lint_accepts_no_card_handoff_without_card_sections(tmp_path, capsys):
+    path = tmp_path / "note.md"
+    path.write_text(NO_CARD_HANDOFF)
+
+    assert handoff_cmd.lint(target=tmp_path, paths=[path]) == 0
+
+    out = capsys.readouterr().out
+    assert "[ok]" in out
+    assert "(no-card)" in out
+
+
+def test_handoff_lint_rejects_no_card_handoff_with_card_sections(tmp_path, capsys):
+    path = tmp_path / "note.md"
+    path.write_text(NO_CARD_HANDOFF + "\n## Target card\nextra.md\n\n## Suggested card content\n---\n")
+
+    assert handoff_cmd.lint(target=tmp_path, paths=[path]) == 1
+
+    out = capsys.readouterr().out
+    assert "[fail]" in out
+    assert "no-card handoffs must omit the Target card section entirely" in out
+    assert "no-card handoffs must omit the Suggested card content section entirely" in out
+
+
+def test_handoff_lint_defaults_to_pending_inboxes(tmp_path, capsys):
+    inbox = tmp_path / ".codex" / "memory-handoffs"
+    inbox.mkdir(parents=True)
+    (inbox / "TEMPLATE.md").write_text("# template\n")
+    (inbox / "2026-05-27-note.md").write_text(CARD_HANDOFF)
+
+    assert handoff_cmd.lint(target=tmp_path) == 0
+
+    out = capsys.readouterr().out
+    assert "files: 1" in out
+    assert "2026-05-27-note.md" in out
+    assert "TEMPLATE.md" not in out
+
+
 def test_handoff_doctor_warns_for_pending_handoff_without_source_config(tmp_path, capsys):
     inbox = tmp_path / ".claude" / "memory-handoffs"
     inbox.mkdir(parents=True)
@@ -27,7 +141,7 @@ def test_handoff_doctor_accepts_configured_claude_and_codex_inboxes(tmp_path, ca
     for rel in (".claude/memory-handoffs", ".codex/memory-handoffs"):
         inbox = tmp_path / rel
         inbox.mkdir(parents=True)
-        (inbox / "2026-05-27-note.md").write_text("# Memory Handoff\n")
+        (inbox / "2026-05-27-note.md").write_text(CARD_HANDOFF)
     config = tmp_path / ".brigade" / "handoff-sources.json"
     config.parent.mkdir()
     config.write_text(
@@ -54,6 +168,32 @@ def test_handoff_doctor_accepts_configured_claude_and_codex_inboxes(tmp_path, ca
     assert "pending=1" in out
     assert "watched=yes" in out
     assert "handoff_warning" not in out
+
+
+def test_handoff_doctor_warns_for_pending_lint_error(tmp_path, capsys):
+    inbox = tmp_path / ".claude" / "memory-handoffs"
+    inbox.mkdir(parents=True)
+    (inbox / "bad.md").write_text(CARD_HANDOFF + "\n## Target document\n\n## Suggested document content\n")
+
+    assert handoff_cmd.doctor(target=tmp_path) == 0
+
+    out = capsys.readouterr().out
+    assert "[warn] handoff_lint:" in out
+    assert "card handoffs must omit the Target document section entirely" in out
+
+
+def test_handoff_issues_include_pending_lint_errors(tmp_path, capsys):
+    inbox = tmp_path / ".claude" / "memory-handoffs"
+    inbox.mkdir(parents=True)
+    (inbox / "bad.md").write_text(CARD_HANDOFF + "\n## Target document\n\n## Suggested document content\n")
+
+    assert handoff_cmd.issues(target=tmp_path, categories=["lint"], json_output=True) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["by_category"] == {"lint": 1}
+    issue = payload["issues"][0]
+    assert "Fix pending handoff lint error in bad.md" in issue["text"]
+    assert "Delete Target document and Suggested document content sections entirely" in issue["repair"]
 
 
 def test_handoff_doctor_fails_invalid_source_config(tmp_path, capsys):
@@ -288,6 +428,20 @@ def test_handoff_doctor_cli(tmp_path, monkeypatch):
 
     assert cli.main(["handoff", "doctor", "--target", str(tmp_path), "--json"]) == 0
     assert seen == {"target": tmp_path, "sources": None, "json_output": True}
+
+
+def test_handoff_lint_cli(tmp_path, monkeypatch):
+    seen = {}
+
+    def fake_lint(**kwargs):
+        seen.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(handoff_cmd, "lint", fake_lint)
+
+    path = tmp_path / "note.md"
+    assert cli.main(["handoff", "lint", "--target", str(tmp_path), "--json", str(path)]) == 0
+    assert seen == {"target": tmp_path, "paths": [path], "json_output": True}
 
 
 def test_handoff_issues_cli(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add `brigade handoff lint` for pending or explicit handoff files
- surface malformed pending handoffs in `handoff doctor` and `handoff issues`
- update handoff templates and docs so card and document branches are mutually exclusive

## Root cause
Mixed card/document handoff sections can make a card-oriented handoff look routable to a document path, which causes route skips later in the ingestor. The writer-side template needed an early validation path.

## Validation
- `.venv/bin/python -m pytest tests/test_handoff_cmd.py tests/test_doctor.py tests/test_ingest.py -q`
- `.venv/bin/python -m pytest -q`
- `git diff --check`
- `PYTHONPATH=$HOME/repos/content-guard/src .venv/bin/python -m content_guard scan . --policy $HOME/repos/content-guard/policies/public-repo.json`
- `.venv/bin/brigade handoff lint --target . --json`
