### PR TITLE
fix: avoid false handoff lint warnings

### DIFF
--- a/src/brigade/handoff_cmd.py
+++ b/src/brigade/handoff_cmd.py
@@ -642,7 +642,7 @@ def _lint_card_action(
         if prohibited in sections:
             errors.append(f"card handoffs must omit the {prohibited} section entirely")
 
-    if "## " in suggested_card:
+    if any(line.startswith("## ") for line in suggested_card.splitlines()):
         warnings.append("Suggested card content contains level-2 markdown headings, which may be parsed as handoff sections")
 
 

--- a/tests/test_handoff_cmd.py
+++ b/tests/test_handoff_cmd.py
@@ -72,6 +72,16 @@ def test_handoff_lint_accepts_card_handoff_without_document_sections(tmp_path, c
     assert "(create-card)" in out
 
 
+def test_handoff_lint_allows_level_three_card_headings_without_warning(tmp_path, capsys):
+    path = tmp_path / "note.md"
+    path.write_text(CARD_HANDOFF + "\n### Details\n\nMore durable context.\n")
+
+    assert handoff_cmd.lint(target=tmp_path, paths=[path]) == 0
+
+    out = capsys.readouterr().out
+    assert "warning:" not in out
+
+
 def test_handoff_lint_rejects_card_handoff_with_empty_document_sections(tmp_path, capsys):
     path = tmp_path / "note.md"
     path.write_text(CARD_HANDOFF + "\n## Target document\n\n## Suggested document content\n")


### PR DESCRIPTION
## Summary
- fix the card-content heading warning so `###` headings do not trigger it
- add regression coverage for level-3 card headings

## Root cause
The handoff lint warning searched for `"## "` anywhere in card content, so level-3 headings contained the same substring and produced a false warning.

## Validation
- `.venv/bin/python -m pytest tests/test_handoff_cmd.py -q`
- `.venv/bin/python -m pytest -q`
- `git diff --check`
- `PYTHONPATH=$HOME/repos/content-guard/src .venv/bin/python -m content_guard scan . --policy $HOME/repos/content-guard/policies/public-repo.json`
- `.venv/bin/brigade handoff lint --target .`
