### PR TITLE
feat: sync handoff ingest issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `brigade handoff issues` and `brigade handoff import-issues` to turn handoff ingest warnings into grouped repair guidance and local work imports.
 - `brigade handoff issues --category` and `brigade handoff import-issues --category` for category-limited handoff issue review/import.
 - `brigade handoff lint` to validate pending or explicit handoff files before ingest and catch card/document action mismatches that would be skipped later.
+- `brigade handoff sync-issues` to import new handoff-ingest issues without resurrecting dismissed ones and close stale local handoff tasks/imports.
 - `docs/import-schema.md` documenting the local import JSONL contract for scanners and wrappers.
 - Cybersecurity plugin roadmap covering broad agent-workspace security checks plus Brigade-specific scanner, doctor, import, and multi-harness security checks.
 - Built-in `security` station and `brigade security scan` for read-only agent workspace security checks.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ For machines that ingest handoffs from multiple repos, copy `.brigade/handoff-so
 `brigade handoff doctor` reports pending `.claude/memory-handoffs/` and `.codex/memory-handoffs/` files that are not covered by that local source list.
 Run `brigade handoff lint` before ingesting pending handoffs when you want to catch action/target mismatches early.
 If your ingestor writes a latest-run log, set `ingestor.last_run_log` in that local config so the doctor can warn on stale runs, skipped malformed handoffs, and warning summaries hidden behind no-reply cron output.
-Use `brigade handoff issues` to group those warnings with repair guidance, then `brigade handoff import-issues` to route them into the normal local work import inbox.
+Use `brigade handoff issues` to group those warnings with repair guidance, then `brigade handoff sync-issues` to import new issues and close stale local handoff tasks/imports once the latest scan no longer reports them.
 
 ## Run a brigade
 
@@ -159,6 +159,7 @@ brigade handoff doctor
 brigade handoff lint
 brigade handoff issues
 brigade handoff import-issues
+brigade handoff sync-issues
 brigade work bootstrap
 brigade work status
 brigade work doctor
@@ -292,6 +293,7 @@ Import inbox commands:
 - `brigade work import promote --all --source memory-care --kind task` batch-promotes filtered imports; metadata filters also work for scanner-specific fields such as `handoff_issue_category=route-skip`.
 
 Imports are stored under `.brigade/work/imports/inbox.jsonl`, stay gitignored, and do not write memory directly.
+For handoff-ingest issues, prefer `brigade handoff sync-issues` over repeated raw imports. It imports only issue ids that have not already been seen locally and marks stale handoff-ingest imports/tasks resolved when the latest log no longer contains them.
 
 Run the daily loop with `brigade work run`.
 It opens a work session, resolves the next task, runs `brigade dogfood`, and closes completed ledger tasks after successful runs.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -126,6 +126,7 @@ Goal: prevent durable memory from silently rotting.
 - Add handoff-ingest observability checks for hidden warning states, including unreachable remote sources, malformed handoffs that are skipped, and runs that emit `NO_REPLY` despite warnings. Status: started with optional `ingestor.last_run_log` checks in `brigade handoff doctor`.
 - Turn handoff-ingest warnings into repairable local work. Status: started with `brigade handoff issues`, `brigade handoff import-issues`, repair guidance, and `brigade work brief` issue counts.
 - Catch handoff action/target mismatches before ingest. Status: started with `brigade handoff lint`, doctor warnings, issue imports, and template guidance that forces card and document handoffs into mutually exclusive branches.
+- Keep the daily brief quiet after fixes land. Status: started with `brigade handoff sync-issues`, known issue suppression in `work brief`, and stale handoff-ingest task/import cleanup.
 
 ## Later Phase: Portable Operator Setup
 

--- a/src/brigade/cli.py
+++ b/src/brigade/cli.py
@@ -131,6 +131,13 @@ def _build_parser() -> argparse.ArgumentParser:
     p_handoff_import_issues.add_argument("--dry-run", action="store_true", help="Report without writing imports.")
     p_handoff_import_issues.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
     p_handoff_import_issues.add_argument("--category", action="append", default=[], help="Import only one issue category. May be repeated.")
+    p_handoff_sync_issues = handoff_sub.add_parser("sync-issues", help="Import current handoff issues and close stale local handoff work.")
+    p_handoff_sync_issues.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update.")
+    p_handoff_sync_issues.add_argument("--sources", type=Path, default=None, help="Override .brigade/handoff-sources.json.")
+    p_handoff_sync_issues.add_argument("--dry-run", action="store_true", help="Report without writing imports or closing stale items.")
+    p_handoff_sync_issues.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_handoff_sync_issues.add_argument("--category", action="append", default=[], help="Sync only one issue category. May be repeated.")
+    p_handoff_sync_issues.add_argument("--no-close-stale", action="store_true", help="Do not dismiss stale imports or close stale tasks.")
 
     # work
     p_work = sub.add_parser("work", help="Inspect and manage a daily Brigade work session.")
@@ -699,6 +706,15 @@ def main(argv=None) -> int:
                 dry_run=args.dry_run,
                 json_output=args.json,
                 categories=args.category,
+            )
+        if args.handoff_command == "sync-issues":
+            return handoff_cmd.sync_issues(
+                target=args.target,
+                sources=args.sources,
+                dry_run=args.dry_run,
+                json_output=args.json,
+                categories=args.category,
+                close_stale=not args.no_close_stale,
             )
         parser.error(f"unknown handoff command: {args.handoff_command}")
         return 2

--- a/src/brigade/handoff_cmd.py
+++ b/src/brigade/handoff_cmd.py
@@ -552,6 +552,85 @@ def import_issues(
     return 0
 
 
+def sync_issues(
+    *,
+    target: Path,
+    sources: Path | None = None,
+    dry_run: bool = False,
+    json_output: bool = False,
+    categories: list[str] | None = None,
+    close_stale: bool = True,
+) -> int:
+    target = target.expanduser().resolve()
+    if not target.is_dir():
+        print(f"error: --target is not a directory: {target}", file=sys.stderr)
+        return 2
+    found = collect_issues(target, sources=sources, categories=categories)
+    current_ids = {issue.id for issue in found}
+    known_ids = _known_local_issue_ids(target)
+    covered_summary_ids = _covered_warning_summary_ids(found, known_ids)
+    new_issues = [
+        issue
+        for issue in found
+        if issue.id not in known_ids and issue.id not in covered_summary_ids
+    ]
+    records = [issue.as_import_record() for issue in new_issues]
+    from . import work_cmd
+
+    imported, skipped = work_cmd._append_import_records(target, records, dry_run=dry_run)
+    stale = (
+        _close_stale_local_issue_work(
+            target,
+            current_ids=current_ids,
+            close_current_ids=covered_summary_ids,
+            categories=categories,
+            dry_run=dry_run,
+        )
+        if close_stale
+        else {"imports": [], "tasks": []}
+    )
+    payload = {
+        "target": str(target),
+        "imports_path": str(work_cmd._imports_path(target)),
+        "dry_run": dry_run,
+        "close_stale": close_stale,
+        "issues": len(found),
+        "known_issues": len(known_ids.intersection(current_ids)),
+        "covered_summary_issues": len(covered_summary_ids),
+        "new_issues": len(new_issues),
+        "imported": len(imported),
+        "skipped_duplicates": len(skipped),
+        "stale_imports_closed": len(stale["imports"]),
+        "stale_tasks_closed": len(stale["tasks"]),
+        "by_category": _issue_counts(found),
+        "imports": imported,
+        "stale_imports": stale["imports"],
+        "stale_tasks": stale["tasks"],
+    }
+    if json_output:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+    print(f"handoff issue sync: {target}")
+    print(f"imports_path: {payload['imports_path']}")
+    print(f"dry_run: {dry_run}")
+    print(f"close_stale: {close_stale}")
+    print(f"issues: {len(found)}")
+    print(f"known: {payload['known_issues']}")
+    print(f"covered_summary: {payload['covered_summary_issues']}")
+    print(f"new: {len(new_issues)}")
+    print(f"imported: {len(imported)}")
+    print(f"skipped_duplicates: {len(skipped)}")
+    print(f"stale_imports_closed: {len(stale['imports'])}")
+    print(f"stale_tasks_closed: {len(stale['tasks'])}")
+    for item in imported:
+        print(f"- imported {item.get('id')} [{item.get('kind')}] {_short(str(item.get('text', '')))}")
+    for item in stale["imports"]:
+        print(f"- closed import {item.get('id')} {_short(str(item.get('text', '')))}")
+    for task in stale["tasks"]:
+        print(f"- closed task {task.get('id')} {_short(str(task.get('text', '')))}")
+    return 0
+
+
 def doctor(*, target: Path, sources: Path | None = None, json_output: bool = False) -> int:
     if not target.expanduser().exists():
         print(f"error: target does not exist: {target}", file=sys.stderr)
@@ -686,6 +765,115 @@ def _lint_repair_for_result(result: HandoffLintResult) -> str:
             "Suggested card content sections entirely."
         )
     return "Rewrite the handoff with exactly one valid action branch before rerunning the ingestor."
+
+
+def _known_local_issue_ids(target: Path) -> set[str]:
+    from . import work_cmd
+
+    known: set[str] = set()
+    for item in work_cmd._read_imports(target):
+        issue_id = _handoff_issue_id(item)
+        if issue_id:
+            known.add(issue_id)
+    ledger = work_cmd._read_task_ledger(target)
+    for task in ledger.get("tasks", []):
+        issue_id = _handoff_issue_id(task) if isinstance(task, dict) else None
+        if issue_id:
+            known.add(issue_id)
+    return known
+
+
+def _close_stale_local_issue_work(
+    target: Path,
+    *,
+    current_ids: set[str],
+    close_current_ids: set[str],
+    categories: list[str] | None,
+    dry_run: bool,
+) -> dict[str, list[dict[str, Any]]]:
+    from . import work_cmd
+
+    wanted_categories = {category for category in categories or [] if category}
+    now = time.strftime("%Y-%m-%dT%H:%M:%S+00:00", time.gmtime())
+    closed_imports: list[dict[str, Any]] = []
+    imports = work_cmd._read_imports(target)
+    for item in imports:
+        if not isinstance(item, dict) or item.get("status", "pending") != "pending":
+            continue
+        if item.get("source") != ISSUE_SOURCE:
+            continue
+        issue_id = _handoff_issue_id(item)
+        if not issue_id:
+            continue
+        if issue_id in current_ids and issue_id not in close_current_ids:
+            continue
+        if wanted_categories and _handoff_issue_category(item) not in wanted_categories:
+            continue
+        updated = dict(item)
+        updated["status"] = "dismissed"
+        updated["updated_at"] = now
+        updated["dismissed_at"] = now
+        updated["dismiss_reason"] = _stale_close_reason(issue_id, close_current_ids)
+        item.update(updated)
+        closed_imports.append(updated)
+    if closed_imports and not dry_run:
+        work_cmd._write_imports(target, imports)
+
+    closed_tasks: list[dict[str, Any]] = []
+    ledger = work_cmd._read_task_ledger(target)
+    for task in ledger.get("tasks", []):
+        if not isinstance(task, dict) or task.get("status", "pending") != "pending":
+            continue
+        if task.get("source") != f"import:{ISSUE_SOURCE}":
+            continue
+        issue_id = _handoff_issue_id(task)
+        if not issue_id:
+            continue
+        if issue_id in current_ids and issue_id not in close_current_ids:
+            continue
+        if wanted_categories and _handoff_issue_category(task) not in wanted_categories:
+            continue
+        updated = dict(task)
+        updated["status"] = "done"
+        updated["updated_at"] = now
+        updated["completed_at"] = now
+        updated["completion_reason"] = _stale_close_reason(issue_id, close_current_ids)
+        task.update(updated)
+        closed_tasks.append(updated)
+    if closed_tasks and not dry_run:
+        work_cmd._write_task_ledger(target, ledger)
+
+    return {
+        "imports": closed_imports,
+        "tasks": closed_tasks,
+    }
+
+
+def _handoff_issue_id(item: dict[str, Any]) -> str | None:
+    metadata = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
+    issue_id = metadata.get("handoff_issue_id")
+    return issue_id if isinstance(issue_id, str) and issue_id else None
+
+
+def _handoff_issue_category(item: dict[str, Any]) -> str | None:
+    metadata = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
+    category = metadata.get("handoff_issue_category")
+    return category if isinstance(category, str) and category else None
+
+
+def _covered_warning_summary_ids(found: list[HandoffIssue], known_ids: set[str]) -> set[str]:
+    concrete = [issue for issue in found if issue.category not in {"warning-summary", "hidden-warning"}]
+    if not concrete:
+        return set()
+    if any(issue.id not in known_ids for issue in concrete):
+        return set()
+    return {issue.id for issue in found if issue.category == "warning-summary"}
+
+
+def _stale_close_reason(issue_id: str, close_current_ids: set[str]) -> str:
+    if issue_id in close_current_ids:
+        return "covered by known concrete handoff issue lines"
+    return "resolved or absent from latest handoff issue scan"
 
 
 def _issues_payload(target: Path, found: list[HandoffIssue]) -> dict[str, Any]:

--- a/src/brigade/work_cmd.py
+++ b/src/brigade/work_cmd.py
@@ -962,6 +962,8 @@ def _brief_payload(target: Path, *, limit: int = 3) -> dict[str, Any]:
     pending_imports = _pending_imports(target)
     pending_import_counts = _import_counts(pending_imports)
     handoff_issues = handoff_cmd.collect_issues(target)
+    known_handoff_issue_ids = handoff_cmd._known_local_issue_ids(target)
+    new_handoff_issues = [issue for issue in handoff_issues if issue.id not in known_handoff_issue_ids]
     return {
         "target": str(target),
         "git": git,
@@ -975,8 +977,13 @@ def _brief_payload(target: Path, *, limit: int = 3) -> dict[str, Any]:
         "pending_imports": pending_imports,
         "pending_import_counts": pending_import_counts,
         "handoff_issues": {
-            "count": len(handoff_issues),
-            "by_category": handoff_cmd._issue_counts(handoff_issues),
+            "count": len(new_handoff_issues),
+            "known_count": len(handoff_issues) - len(new_handoff_issues),
+            "total_count": len(handoff_issues),
+            "by_category": handoff_cmd._issue_counts(new_handoff_issues),
+            "known_by_category": handoff_cmd._issue_counts(
+                [issue for issue in handoff_issues if issue.id in known_handoff_issue_ids]
+            ),
         },
         "dogfood": resolved["dogfood"],
         "next_source": resolved["source"],
@@ -1448,12 +1455,14 @@ def brief(*, target: Path, limit: int = 3, json_output: bool = False) -> int:
 
     handoff_issues = payload.get("handoff_issues")
     if isinstance(handoff_issues, dict) and handoff_issues.get("count"):
-        print(f"handoff_ingest_issues_pending: {handoff_issues.get('count')}")
+        print(f"handoff_ingest_issues_new: {handoff_issues.get('count')}")
         by_category = handoff_issues.get("by_category")
         if isinstance(by_category, dict) and by_category:
             print("handoff_ingest_issues_by_category:")
             for category, count in by_category.items():
                 print(f"  {category}: {count}")
+    if isinstance(handoff_issues, dict) and handoff_issues.get("known_count"):
+        print(f"handoff_ingest_issues_known: {handoff_issues.get('known_count')}")
 
     recent = payload["recent_sessions"]
     if isinstance(recent, list) and recent:

--- a/tests/test_handoff_cmd.py
+++ b/tests/test_handoff_cmd.py
@@ -5,6 +5,7 @@ import os
 
 from brigade import cli
 from brigade import handoff_cmd
+from brigade import work_cmd
 
 
 CARD_HANDOFF = """# Memory Handoff
@@ -427,6 +428,177 @@ def test_handoff_import_issues_filters_by_category(tmp_path, capsys):
     assert item["metadata"]["handoff_issue_category"] == "route-skip"
 
 
+def test_handoff_sync_issues_imports_new_and_closes_stale_local_work(tmp_path, capsys):
+    log = tmp_path / "latest.log"
+    log.write_text("SKIP current.md: no recognizable markdown sections found\n")
+    config = tmp_path / ".brigade" / "handoff-sources.json"
+    config.parent.mkdir()
+    config.write_text(
+        json.dumps(
+            {
+                "sources": [{"root": ".", "inboxes": [".claude/memory-handoffs"]}],
+                "ingestor": {"last_run_log": "latest.log"},
+            }
+        )
+    )
+    stale_metadata = {
+        "handoff_issue_id": "handoff-route-skip-old",
+        "handoff_issue_category": "route-skip",
+    }
+    stale_import = work_cmd._make_import(
+        "Fix old route skip",
+        kind="task",
+        source="handoff-ingest",
+        metadata=stale_metadata,
+    )
+    work_cmd._write_imports(tmp_path, [stale_import])
+    stale_task, _ = work_cmd._add_task(
+        tmp_path,
+        "Fix old route skip",
+        source="import:handoff-ingest",
+        metadata=stale_metadata,
+    )
+
+    assert handoff_cmd.sync_issues(target=tmp_path, json_output=True) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["issues"] == 1
+    assert payload["imported"] == 1
+    assert payload["stale_imports_closed"] == 1
+    assert payload["stale_tasks_closed"] == 1
+    imports = work_cmd._read_imports(tmp_path)
+    assert imports[0]["status"] == "dismissed"
+    assert imports[0]["dismiss_reason"] == "resolved or absent from latest handoff issue scan"
+    assert imports[1]["status"] == "pending"
+    assert imports[1]["metadata"]["handoff_issue_category"] == "skip"
+    task, _ = work_cmd._find_task(tmp_path, stale_task["id"])
+    assert task is not None
+    assert task["status"] == "done"
+    assert task["completion_reason"] == "resolved or absent from latest handoff issue scan"
+
+
+def test_handoff_sync_issues_does_not_reimport_dismissed_known_issue(tmp_path, capsys):
+    log = tmp_path / "latest.log"
+    log.write_text("SKIP current.md: no recognizable markdown sections found\n")
+    config = tmp_path / ".brigade" / "handoff-sources.json"
+    config.parent.mkdir()
+    config.write_text(
+        json.dumps(
+            {
+                "sources": [{"root": ".", "inboxes": [".claude/memory-handoffs"]}],
+                "ingestor": {"last_run_log": "latest.log"},
+            }
+        )
+    )
+    issue = handoff_cmd.collect_issues(tmp_path)[0]
+    dismissed = work_cmd._make_import(
+        issue.text,
+        kind=issue.kind,
+        source="handoff-ingest",
+        metadata=issue.as_import_record()["metadata"],
+    )
+    dismissed["status"] = "dismissed"
+    work_cmd._write_imports(tmp_path, [dismissed])
+
+    assert handoff_cmd.sync_issues(target=tmp_path, json_output=True) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["issues"] == 1
+    assert payload["known_issues"] == 1
+    assert payload["new_issues"] == 0
+    assert payload["imported"] == 0
+    assert len(work_cmd._read_imports(tmp_path)) == 1
+
+
+def test_handoff_sync_issues_closes_covered_warning_summary(tmp_path, capsys):
+    log = tmp_path / "latest.log"
+    log.write_text(
+        "\n".join(
+            [
+                "SKIP current.md: no recognizable markdown sections found",
+                "Warnings: 1",
+                "",
+            ]
+        )
+    )
+    config = tmp_path / ".brigade" / "handoff-sources.json"
+    config.parent.mkdir()
+    config.write_text(
+        json.dumps(
+            {
+                "sources": [{"root": ".", "inboxes": [".claude/memory-handoffs"]}],
+                "ingestor": {"last_run_log": "latest.log"},
+            }
+        )
+    )
+    issues = handoff_cmd.collect_issues(tmp_path)
+    skip_issue = [issue for issue in issues if issue.category == "skip"][0]
+    summary_issue = [issue for issue in issues if issue.category == "warning-summary"][0]
+    dismissed_skip = work_cmd._make_import(
+        skip_issue.text,
+        kind=skip_issue.kind,
+        source="handoff-ingest",
+        metadata=skip_issue.as_import_record()["metadata"],
+    )
+    dismissed_skip["status"] = "dismissed"
+    pending_summary = work_cmd._make_import(
+        summary_issue.text,
+        kind=summary_issue.kind,
+        source="handoff-ingest",
+        metadata=summary_issue.as_import_record()["metadata"],
+    )
+    work_cmd._write_imports(tmp_path, [dismissed_skip, pending_summary])
+
+    assert handoff_cmd.sync_issues(target=tmp_path, json_output=True) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["covered_summary_issues"] == 1
+    assert payload["imported"] == 0
+    assert payload["stale_imports_closed"] == 1
+    imports = work_cmd._read_imports(tmp_path)
+    assert imports[1]["status"] == "dismissed"
+    assert imports[1]["dismiss_reason"] == "covered by known concrete handoff issue lines"
+
+
+def test_handoff_sync_issues_dry_run_does_not_write(tmp_path, capsys):
+    log = tmp_path / "latest.log"
+    log.write_text("SKIP current.md: no recognizable markdown sections found\n")
+    config = tmp_path / ".brigade" / "handoff-sources.json"
+    config.parent.mkdir()
+    config.write_text(
+        json.dumps(
+            {
+                "sources": [{"root": ".", "inboxes": [".claude/memory-handoffs"]}],
+                "ingestor": {"last_run_log": "latest.log"},
+            }
+        )
+    )
+    stale_metadata = {
+        "handoff_issue_id": "handoff-route-skip-old",
+        "handoff_issue_category": "route-skip",
+    }
+    work_cmd._write_imports(
+        tmp_path,
+        [
+            work_cmd._make_import(
+                "Fix old route skip",
+                kind="task",
+                source="handoff-ingest",
+                metadata=stale_metadata,
+            )
+        ],
+    )
+
+    assert handoff_cmd.sync_issues(target=tmp_path, dry_run=True, json_output=True) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["imported"] == 1
+    assert payload["stale_imports_closed"] == 1
+    imports = work_cmd._read_imports(tmp_path)
+    assert len(imports) == 1
+    assert imports[0]["status"] == "pending"
+
+
 def test_handoff_doctor_cli(tmp_path, monkeypatch):
     seen = {}
 
@@ -507,3 +679,38 @@ def test_handoff_import_issues_cli(tmp_path, monkeypatch):
         == 0
     )
     assert seen == {"target": tmp_path, "sources": None, "dry_run": True, "json_output": True, "categories": ["route-skip"]}
+
+
+def test_handoff_sync_issues_cli(tmp_path, monkeypatch):
+    seen = {}
+
+    def fake_sync_issues(**kwargs):
+        seen.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(handoff_cmd, "sync_issues", fake_sync_issues)
+
+    assert (
+        cli.main(
+            [
+                "handoff",
+                "sync-issues",
+                "--target",
+                str(tmp_path),
+                "--dry-run",
+                "--json",
+                "--category",
+                "route-skip",
+                "--no-close-stale",
+            ]
+        )
+        == 0
+    )
+    assert seen == {
+        "target": tmp_path,
+        "sources": None,
+        "dry_run": True,
+        "json_output": True,
+        "categories": ["route-skip"],
+        "close_stale": False,
+    }

--- a/tests/test_work_cmd.py
+++ b/tests/test_work_cmd.py
@@ -1203,13 +1203,54 @@ def test_work_brief_includes_handoff_ingest_issues(tmp_path, monkeypatch, capsys
     assert work_cmd.brief(target=tmp_path, json_output=True) == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["handoff_issues"]["count"] == 1
+    assert payload["handoff_issues"]["known_count"] == 0
+    assert payload["handoff_issues"]["total_count"] == 1
     assert payload["handoff_issues"]["by_category"] == {"skip": 1}
 
     assert work_cmd.brief(target=tmp_path) == 0
     out = capsys.readouterr().out
-    assert "handoff_ingest_issues_pending: 1" in out
+    assert "handoff_ingest_issues_new: 1" in out
     assert "handoff_ingest_issues_by_category:" in out
     assert "  skip: 1" in out
+
+
+def test_work_brief_suppresses_known_handoff_ingest_issues(tmp_path, monkeypatch, capsys):
+    _init_git_repo(tmp_path)
+    monkeypatch.setattr(work_cmd.shutil, "which", lambda name: f"/usr/bin/{name}")
+    log = tmp_path / ".brigade" / "handoff-ingest" / "latest.log"
+    log.parent.mkdir(parents=True)
+    log.write_text("SKIP bad.md: no recognizable markdown sections found\n")
+    config = tmp_path / ".brigade" / "handoff-sources.json"
+    config.write_text(
+        json.dumps(
+            {
+                "sources": [{"root": ".", "inboxes": [".claude/memory-handoffs"]}],
+                "ingestor": {"last_run_log": ".brigade/handoff-ingest/latest.log"},
+            }
+        )
+    )
+    from brigade import handoff_cmd
+
+    issue = handoff_cmd.collect_issues(tmp_path)[0]
+    dismissed = work_cmd._make_import(
+        issue.text,
+        kind=issue.kind,
+        source="handoff-ingest",
+        metadata=issue.as_import_record()["metadata"],
+    )
+    dismissed["status"] = "dismissed"
+    work_cmd._write_imports(tmp_path, [dismissed])
+
+    assert work_cmd.brief(target=tmp_path, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["handoff_issues"]["count"] == 0
+    assert payload["handoff_issues"]["known_count"] == 1
+    assert payload["handoff_issues"]["known_by_category"] == {"skip": 1}
+
+    assert work_cmd.brief(target=tmp_path) == 0
+    out = capsys.readouterr().out
+    assert "handoff_ingest_issues_new" not in out
+    assert "handoff_ingest_issues_known: 1" in out
 
 
 def test_work_next_reports_latest_next_as_default_task(tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
## Summary
- add `brigade handoff sync-issues` to import only new handoff-ingest issues
- close stale handoff-ingest imports and tasks when the latest scan no longer reports their issue id
- keep `work brief` focused on new handoff issues while counting known ones quietly

## Root cause
`handoff import-issues` could import issue records, but there was no reconciliation step after the underlying latest log changed. Resolved route-skip imports and promoted tasks stayed pending in the daily work loop even after the route-skip root cause was fixed.

## Validation
- `.venv/bin/python -m pytest tests/test_handoff_cmd.py tests/test_work_cmd.py -q`
- `.venv/bin/python -m pytest -q`
- `git diff --check`
- `PYTHONPATH=$HOME/repos/content-guard/src .venv/bin/python -m content_guard scan . --policy $HOME/repos/content-guard/policies/public-repo.json`
- `.venv/bin/brigade handoff sync-issues --target .`
- `.venv/bin/brigade work brief --target .`
