### PR TITLE
feat: detect un-ingested handoff backlog, guard bootstrap budgets, add fleet ingest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Handoff backlog detection. `brigade handoff doctor` (and the memory station in `brigade doctor`) now emits a `handoff_backlog` warning when an inbox has pending handoffs whose oldest entry is older than three days, i.e. handoffs are being written but nothing is ingesting them. `InboxHealth` gained an `oldest_pending_age_seconds` field. At the fleet level, `brigade repos scan`/`doctor` now emit a `repo_handoff_backlog` warning for any fleet repo with an un-ingested, stale handoff pile-up. This catches the silent gap where a repo's inbox is never reached by the canonical ingester (for example an uncovered repo missing from the ingest config).
+- Canonical budgets module `brigade.budgets` is now the single source of truth for bootstrap-file byte budgets, memory-card budgets, the MEMORY.md index line limit, and the handoff-backlog and memory-care staleness thresholds. `doctor`, `ingest`, `handoff`, and `repos` all consume it so preventive guards and post-hoc warnings can never disagree. Satellite tools (bootstrap-doctor, memory-doctor) are intended to depend on brigade and consume these definitions rather than redeclaring them.
+- Bootstrap budget guard in `brigade ingest`. A `no-card` handoff that would push a bootstrap file (e.g. `TOOLS.md`, `USER.md`) past its byte budget is now routed to the review inbox instead of appended, so the ingester can no longer silently bloat a session-prefix file past its truncation ceiling. Non-bootstrap targets such as `.learnings/*` are unaffected.
+- `brigade repos ingest` fleet driver. Sweeps every registered, reachable fleet repo, routing each repo's handoffs into the canonical owner's memory and archiving the processed handoffs back in the source repo. Defaults to a dry run; pass `--apply` to write. `ingest.run` gained an `owner` parameter and a reusable `ingest.ingest_into` core to support the many-writers/one-owner model.
+
 ### Changed
 - `brigade work backup init` now writes wider staleness thresholds for the `cloud` destination (`snapshot_stale_hours = 192`, `check_stale_hours`/`prune_stale_hours = 336`) so an off-site copy on a slower cadence such as a weekly backup does not report stale every day. The `nas` destination defaults are unchanged. Existing `.brigade/backups.toml` files are not modified.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -174,6 +174,35 @@ Goal: keep the system usable by the original operator while making it adaptable 
 - Keep public repo docs focused on patterns, commands, and safety contracts.
 - Leave release, tag, push-to-main, and production-impacting actions behind explicit approval gates.
 
+## Later Phase: Deep Research Lane
+
+Goal: turn open-ended research questions into durable, cited memory instead of one-shot answers, reusing the existing researcher role and the handoff -> card pipeline.
+
+- Add `brigade research run "<question>"` that drives an iterative, LLM-in-the-loop research loop (gather -> read -> extract -> synthesize) using the configured `researcher` model from the roster, not a new hardcoded provider. Status: proposed.
+- Use goal-based extraction: for each fetched source, pull only the content relevant to the research goal before synthesis, to keep context small and on-topic. Status: proposed.
+- Persist runs under `.brigade/research/` with a cancellable, resumable task registry so a long research run survives interruption and reports partial progress, mirroring the work/runs receipt model. Status: proposed.
+- Emit two artifacts per run: a self-contained visual HTML report and a structured memory handoff, so research output flows straight into the existing ingest -> cards/`.learnings` pipeline and becomes durable, cited memory. Status: proposed.
+- Treat every fetched source as untrusted context (see prompt-injection hardening below); web content and tool output are data, not instructions. Status: proposed.
+- Bound cost explicitly: per-run search count and per-page content caps, surfaced in the run receipt, with no silent truncation. Status: proposed.
+
+## Later Phase: Operator Capabilities Beyond The CLI
+
+Goal: the CLI is just the bones. It is the load-bearing skeleton, the testable, scriptable engine that every capability hangs off, but the destination is a full operator workspace, not a terminal tool. Architecture principle: every higher-level surface (including a future UI) sits on top of a CLI command plus a structured (JSON) contract, so the bones stay authoritative, automatable, and the single source of behavior. The UI becomes a view over the same commands, never a parallel implementation. Near-term items below are CLI-native; later items put a workspace on top of the same bones.
+
+Near-term, CLI-native:
+
+- Prompt-injection hardening. Add an untrusted-context policy helper that tags external content (web results, tool output, retrieved documents, saved memories, skill text) as data-not-instructions before it reaches a model. High value for the research lane and for any ingest path that reads handoffs which could carry injected instructions. Status: proposed.
+- Owner-scoped tool gating. Complement the existing tool contracts/approvals/runtime policy with owner-tier tool blocking (admin / single-user vs publicly exposed), so a publicly reachable instance refuses high-risk tools by default. Status: proposed.
+- Self-contained visual report renderer. A dependency-free styled HTML report (system fonts only, dark/light via `prefers-color-scheme`, auto table of contents, collapsible sources). Reused by the research lane and available to operator-center and release-evidence reports. No remote fonts or CDNs, consistent with the offline and content-guard ethos. Status: proposed.
+- Optional semantic memory retrieval. An opt-in local vector + keyword hybrid retrieval layer over `memory/cards/` using on-device embeddings (no external API), with import/export. Stays optional: core memory remains file-first and zero-dependency. Status: proposed.
+- Multi-channel operator notifications. A small notification-channel abstraction so backlog and release-gate warnings can reach the operator off-terminal. Status: proposed.
+
+The workspace on top of the bones:
+
+- A workspace UI that is a view over the CLI: chat against local or API models, side-by-side blind model comparison with synthesis, an assisted document editor, and a viewer for the deep-research reports. Each panel maps to an existing command and its JSON output. Status: planned direction.
+- Local-first, hardware-aware model selection and serving guidance, surfaced in the workspace and scriptable from the CLI. Status: planned direction.
+- Personal-data surfaces such as calendar and email triage as Brigade becomes a daily workspace, behind the same privacy and approval gates that already govern the CLI. Status: planned direction.
+
 ## Active Phase Queue: Roadmap Completion Hardening
 
 Status: active.

--- a/src/brigade/budgets.py
+++ b/src/brigade/budgets.py
@@ -1,0 +1,74 @@
+"""Canonical size/staleness budgets for the brigade operator system.
+
+This is the single source of truth for the numbers that govern how much content
+may live in bootstrap files and memory cards, how long handoffs may sit before
+they count as a stalled backlog, and how stale a memory-care scan may get.
+
+brigade's own `doctor`, `ingest`, `handoff`, and `repos` stations all import
+from here so the preventive guards and the post-hoc warnings can never disagree.
+Satellite tools (bootstrap-doctor, memory-doctor) are intended to depend on
+brigade and consume these definitions rather than redeclaring them, so updating
+a budget here updates every downstream consumer.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+# --- Bootstrap files -------------------------------------------------------
+# OpenClaw loads these into the session prefix every turn. There is an empirical
+# soft ceiling around 12,000 chars per file before content is silently truncated
+# mid-session. Per-file budgets stay below that with headroom.
+BOOTSTRAP_BUDGETS: dict[str, int] = {
+    "AGENTS.md": 12_000,
+    "CLAUDE.md": 6_000,
+    "MEMORY.md": 7_000,
+    "TOOLS.md": 10_000,
+    "USER.md": 8_000,
+    "SAFETY_RULES.md": 10_000,
+    "INSTALL_FOR_AGENTS.md": 8_000,
+    "SOUL.md": 8_000,
+    "IDENTITY.md": 4_000,
+    "HEARTBEAT.md": 5_000,
+}
+
+# --- Memory cards ----------------------------------------------------------
+MEMORY_CARD_BUDGET_BYTES = 8_000
+
+# --- MEMORY.md index -------------------------------------------------------
+# The flat index should stay short; detail belongs in topic cards.
+MEMORY_INDEX_MAX_LINES = 180
+
+# --- Staleness thresholds --------------------------------------------------
+# A memory-care decay scan older than this is considered stale.
+MEMORY_CARE_SCAN_STALE_DAYS = 7
+# A handoff inbox with pending files older than this is a stalled backlog:
+# handoffs are being written but nothing is ingesting them.
+HANDOFF_BACKLOG_STALE_DAYS = 3
+HANDOFF_BACKLOG_STALE_SECONDS = HANDOFF_BACKLOG_STALE_DAYS * 24 * 60 * 60
+
+
+def bootstrap_budget(name: str) -> int | None:
+    """Byte budget for a bootstrap file basename, or None if it is not tracked."""
+    return BOOTSTRAP_BUDGETS.get(name)
+
+
+def is_bootstrap_target(rel_path: str) -> bool:
+    """True if a routing target basename is a budgeted bootstrap file."""
+    return Path(rel_path).name in BOOTSTRAP_BUDGETS
+
+
+def route_would_exceed_budget(dest: Path, addition: str) -> tuple[bool, int | None]:
+    """Whether appending `addition` to a bootstrap file would exceed its budget.
+
+    Returns (would_exceed, budget). Non-bootstrap targets (e.g. .learnings/*)
+    are never guarded: (False, None).
+    """
+    budget = BOOTSTRAP_BUDGETS.get(dest.name)
+    if budget is None:
+        return False, None
+    try:
+        existing = dest.stat().st_size if dest.is_file() else 0
+    except OSError:
+        existing = 0
+    projected = existing + len(addition.encode("utf-8"))
+    return projected > budget, budget

--- a/src/brigade/cli.py
+++ b/src/brigade/cli.py
@@ -361,6 +361,12 @@ def _build_parser() -> argparse.ArgumentParser:
     p_repos_import.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
     p_repos_import.add_argument("--dry-run", action="store_true", help="Show counts without writing imports.")
     p_repos_import.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_repos_ingest = repos_sub.add_parser("ingest", help="Ingest every fleet repo's handoffs into the canonical owner.")
+    p_repos_ingest.add_argument("--target", "-t", type=Path, default=Path("."), help="Canonical memory owner (where the fleet config lives).")
+    p_repos_ingest.add_argument("--apply", action="store_true", help="Write changes. Default is a dry run.")
+    p_repos_ingest.add_argument("--no-promote-cards", action="store_true", help="Do not auto-promote cards.")
+    p_repos_ingest.add_argument("--no-route-documents", action="store_true", help="Do not auto-route documents.")
+    p_repos_ingest.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
     p_repos_health_commands = repos_sub.add_parser("health-commands", help="Inspect configured optional repo health commands.")
     p_repos_health_commands.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
     p_repos_health_commands.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
@@ -2489,6 +2495,14 @@ def main(argv=None) -> int:
             return repos_cmd.doctor(target=args.target, json_output=args.json)
         if args.repos_command == "import-issues":
             return repos_cmd.import_issues(target=args.target, dry_run=args.dry_run, json_output=args.json)
+        if args.repos_command == "ingest":
+            return repos_cmd.ingest_fleet(
+                target=args.target,
+                apply=args.apply,
+                promote_cards=not args.no_promote_cards,
+                route_documents=not args.no_route_documents,
+                json_output=args.json,
+            )
         if args.repos_command == "health-commands":
             return repos_cmd.health_commands(target=args.target, json_output=args.json)
         if args.repos_command == "discover":

--- a/src/brigade/doctor.py
+++ b/src/brigade/doctor.py
@@ -17,20 +17,11 @@ WARN = "WARN"
 FAIL = "FAIL"
 MANUAL = "MANUAL"
 
-BOOTSTRAP_BUDGETS = {
-    "AGENTS.md": 12_000,
-    "CLAUDE.md": 6_000,
-    "MEMORY.md": 7_000,
-    "TOOLS.md": 10_000,
-    "USER.md": 8_000,
-    "SAFETY_RULES.md": 10_000,
-    "INSTALL_FOR_AGENTS.md": 8_000,
-    "SOUL.md": 8_000,
-    "IDENTITY.md": 4_000,
-    "HEARTBEAT.md": 5_000,
-}
-MEMORY_CARD_BUDGET_BYTES = 8_000
-MEMORY_CARE_SCAN_STALE_DAYS = 7
+from .budgets import (
+    BOOTSTRAP_BUDGETS,
+    MEMORY_CARD_BUDGET_BYTES,
+    MEMORY_CARE_SCAN_STALE_DAYS,
+)
 
 from .station import DoctorContext
 

--- a/src/brigade/handoff_cmd.py
+++ b/src/brigade/handoff_cmd.py
@@ -19,6 +19,12 @@ WRITER_INBOXES = (".claude/memory-handoffs", ".codex/memory-handoffs")
 IGNORED_HANDOFF_NAMES = {"TEMPLATE.md"}
 DEFAULT_STALE_AFTER_MINUTES = 90
 HANDOFF_DRAFT_STALE_HOURS = 72
+# A handoff inbox with pending files whose oldest entry is older than this is
+# treated as a stalled backlog: handoffs are being written but nothing is
+# ingesting them. Catches the silent pile-up where a repo's inbox is never
+# reached by the canonical ingester (e.g. an uncovered repo in the fleet).
+# Canonical value lives in budgets.py so doctor/ingest/repos all agree.
+from .budgets import HANDOFF_BACKLOG_STALE_SECONDS as BACKLOG_STALE_SECONDS
 MAX_INGESTOR_WARNING_SIGNALS = 5
 CARD_ACTIONS = ("create-card", "update-card")
 NO_CARD_ACTION = "no-card"
@@ -68,6 +74,7 @@ class InboxHealth:
     pending: int
     processed: int
     watched: bool
+    oldest_pending_age_seconds: int | None = None
 
     def as_dict(self) -> dict[str, Any]:
         return {
@@ -77,6 +84,7 @@ class InboxHealth:
             "pending": self.pending,
             "processed": self.processed,
             "watched": self.watched,
+            "oldest_pending_age_seconds": self.oldest_pending_age_seconds,
         }
 
 
@@ -321,6 +329,29 @@ def doctor_checks(target: Path, sources: Path | None = None) -> list[tuple[str, 
             f"(exists={exists}, pending={inbox.pending}, processed={inbox.processed}, watched={watched})"
         )
         checks.append((level, f"handoff_watch: {inbox.inbox}", detail))
+
+    stale_backlog = [
+        inbox
+        for inbox in health.inboxes
+        if inbox.pending
+        and inbox.oldest_pending_age_seconds is not None
+        and inbox.oldest_pending_age_seconds >= BACKLOG_STALE_SECONDS
+    ]
+    if stale_backlog:
+        pending_total = sum(inbox.pending for inbox in stale_backlog)
+        oldest = max(
+            inbox.oldest_pending_age_seconds or 0 for inbox in stale_backlog
+        )
+        oldest_days = oldest // (24 * 60 * 60)
+        names = ", ".join(inbox.inbox for inbox in stale_backlog)
+        checks.append(
+            (
+                WARN,
+                "handoff_backlog",
+                f"{pending_total} pending handoff(s) not ingested, oldest {oldest_days}d old "
+                f"({names}); ingester is not reaching this inbox",
+            )
+        )
 
     if source_config := _source_config_for_checks(health.target, health.sources_path):
         for watched_inbox in source_config.watched:
@@ -2475,7 +2506,26 @@ def _inspect_inbox(target: Path, rel: str, watched: tuple[WatchedInbox, ...]) ->
         pending=_count_pending(path),
         processed=_count_processed(path),
         watched=_is_watched(target, rel, watched),
+        oldest_pending_age_seconds=_oldest_pending_age_seconds(path),
     )
+
+
+def _oldest_pending_age_seconds(path: Path) -> int | None:
+    """Age in seconds of the oldest pending handoff, or None if the inbox is empty."""
+    if not path.is_dir():
+        return None
+    oldest_mtime: float | None = None
+    for candidate in path.glob("*.md"):
+        if not candidate.is_file():
+            continue
+        if candidate.name.startswith(".") or candidate.name in IGNORED_HANDOFF_NAMES:
+            continue
+        mtime = candidate.stat().st_mtime
+        if oldest_mtime is None or mtime < oldest_mtime:
+            oldest_mtime = mtime
+    if oldest_mtime is None:
+        return None
+    return max(0, int(time.time() - oldest_mtime))
 
 
 def _count_pending(path: Path) -> int:

--- a/src/brigade/ingest.py
+++ b/src/brigade/ingest.py
@@ -16,6 +16,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List
 
+from . import budgets
+
 SECTION_RE = re.compile(r"^##\s+(?P<name>.+?)\s*$", re.MULTILINE)
 SAFE_CARD_NAME_RE = re.compile(r"^[A-Za-z0-9._-]+\.md$")
 SAFE_RULE_PATH_RE = re.compile(r"^rules/[A-Za-z0-9._-]+\.md$")
@@ -85,23 +87,57 @@ def run(
     dry_run: bool = False,
     promote_cards: bool = False,
     route_documents: bool = False,
+    owner: Path | None = None,
 ) -> int:
     """Process handoffs.
+
+    Reads handoffs from `target`'s writer inboxes. By default the resulting
+    cards/documents and review drafts are written back into `target` itself.
+    Pass `owner` to write them into a different canonical memory owner instead
+    (the fleet model: many writer repos, one owner); processed handoffs are
+    still archived in the source repo they came from.
 
     `promote_cards` and `route_documents` are opt-in. With neither flag,
     every handoff routes to the review inbox so a human picks the action.
     Match the cookbook wrapper by passing both flags explicitly.
     """
-    target = target.expanduser().resolve()
-    inbox_dir = target / "memory" / "handoff-inbox"
+    source = target.expanduser().resolve()
+    owner = source if owner is None else owner.expanduser().resolve()
+    stats = IngestStats()
+    rc = ingest_into(
+        source=source,
+        owner=owner,
+        stats=stats,
+        dry_run=dry_run,
+        promote_cards=promote_cards,
+        route_documents=route_documents,
+    )
+    if rc != 0:
+        return rc
+    _report(stats, dry_run=dry_run)
+    return 0
 
-    handoff_dirs = _resolve_inbox_paths(target)
+
+def ingest_into(
+    *,
+    source: Path,
+    owner: Path,
+    stats: IngestStats,
+    dry_run: bool = False,
+    promote_cards: bool = False,
+    route_documents: bool = False,
+) -> int:
+    """Ingest `source`'s handoffs into `owner`'s memory, accumulating `stats`.
+
+    Returns 0 on success, 2 if `source` has no handoff inbox. Used directly by
+    the fleet driver so it can sweep many sources into one owner and report once.
+    """
+    inbox_dir = owner / "memory" / "handoff-inbox"
+    handoff_dirs = _resolve_inbox_paths(source)
     if not handoff_dirs:
-        legacy = target / ".claude" / "memory-handoffs"
+        legacy = source / ".claude" / "memory-handoffs"
         print(f"brigade ingest: no handoff inbox at {legacy}", file=sys.stderr)
         return 2
-
-    stats = IngestStats()
 
     for handoffs_dir in handoff_dirs:
         processed_dir = handoffs_dir / "processed"
@@ -110,14 +146,14 @@ def run(
             sections = parse(path)
             outcome = decide(
                 sections,
-                target=target,
+                target=owner,
                 promote_cards=promote_cards,
                 route_documents=route_documents,
             )
             action = _execute(
                 outcome,
                 handoff_path=path,
-                target=target,
+                target=owner,
                 sections=sections,
                 inbox_dir=inbox_dir,
                 processed_dir=processed_dir,
@@ -132,8 +168,6 @@ def run(
                 stats.inboxed += 1
             elif action.kind == "skipped":
                 stats.skipped += 1
-
-    _report(stats, dry_run=dry_run)
     return 0
 
 
@@ -198,7 +232,21 @@ def decide(
                 "inboxed",
                 reason="document content contains `##` headings (would parse as new section)",
             )
-        return Outcome("routed", dest=target / document)
+        dest = target / document
+        # Bootstrap files load into the session prefix every turn and silently
+        # truncate past ~12k chars. Refuse an append that would push the file
+        # over its budget; route to the inbox so a human trims or re-homes it.
+        addition = "\n\n" + content.strip() + "\n"
+        would_exceed, budget = budgets.route_would_exceed_budget(dest, addition)
+        if would_exceed:
+            return Outcome(
+                "inboxed",
+                reason=(
+                    f"bootstrap budget guard: appending to {document} would exceed "
+                    f"its {budget}B budget; trim the file or promote to a memory card"
+                ),
+            )
+        return Outcome("routed", dest=dest)
 
     if action == "":
         return Outcome("inboxed", reason="missing `Recommended memory action`")

--- a/src/brigade/repos_cmd.py
+++ b/src/brigade/repos_cmd.py
@@ -23,6 +23,10 @@ WARN = "warn"
 FAIL = "fail"
 CONFIG_REL_PATH = ".brigade/repos.toml"
 REPORT_STALE_HOURS = 24
+# A fleet repo with pending handoffs whose oldest is older than this is flagged
+# as an un-ingested backlog (handoffs written but the ingester never reaches it).
+# Canonical value lives in budgets.py so doctor/ingest/repos all agree.
+from .budgets import HANDOFF_BACKLOG_STALE_DAYS as BACKLOG_STALE_DAYS
 HEALTH_COMMAND_RECEIPT_STALE_HOURS = 24
 ACTION_STATUSES = {"pending", "active", "done", "deferred", "archived"}
 DISPATCH_STALE_HOURS = 24
@@ -630,6 +634,31 @@ def _repo_suggested_command(repo_id: str, pending_imports: list[dict[str, Any]],
     return f"brigade repos show {repo_id}"
 
 
+def _handoff_backlog(repo: Path) -> tuple[int, int | None]:
+    """Total pending handoffs across a repo's inboxes and the oldest age in days.
+
+    Surfaces the silent pile-up where handoffs are written but never ingested,
+    e.g. a repo that is outside the canonical ingester's coverage.
+    """
+    if not repo.is_dir():
+        return 0, None
+    from . import handoff_cmd
+
+    pending = 0
+    oldest_seconds: int | None = None
+    try:
+        health = handoff_cmd.inspect(repo)
+    except (ValueError, OSError):
+        return 0, None
+    for inbox in health.inboxes:
+        pending += inbox.pending
+        age = inbox.oldest_pending_age_seconds
+        if age is not None and (oldest_seconds is None or age > oldest_seconds):
+            oldest_seconds = age
+    oldest_days = oldest_seconds // (24 * 60 * 60) if oldest_seconds is not None else None
+    return pending, oldest_days
+
+
 def _repo_summary(entry: RepoEntry) -> dict[str, Any]:
     repo = entry.path
     tracked_dirty, untracked_dirty = _dirty_counts(repo) if repo.is_dir() else (0, 0)
@@ -640,6 +669,7 @@ def _repo_summary(entry: RepoEntry) -> dict[str, Any]:
         for inbox in (".claude/memory-handoffs", ".codex/memory-handoffs")
         if (repo / inbox).is_dir()
     ]
+    handoff_pending, handoff_backlog_oldest_days = _handoff_backlog(repo)
     hooks = repo / ".git" / "hooks"
     publish_guard_hooks = [
         hook.name
@@ -663,6 +693,8 @@ def _repo_summary(entry: RepoEntry) -> dict[str, Any]:
         "has_changelog": (repo / "CHANGELOG.md").is_file(),
         "test_hints": _test_hints(repo) if repo.is_dir() else [],
         "handoff_inboxes": handoff_inboxes,
+        "handoff_pending": handoff_pending,
+        "handoff_backlog_oldest_days": handoff_backlog_oldest_days,
         "publish_guard_hooks": publish_guard_hooks,
         "has_brigade_config": (repo / ".brigade").is_dir(),
         "latest_release_readiness": _latest_json(repo / ".brigade" / "release" / "runs", "release.json"),
@@ -693,6 +725,15 @@ def _repo_checks(summary: dict[str, Any]) -> list[dict[str, Any]]:
         checks.append({"status": WARN, "name": "repo_dirty_tracked", "detail": f"{repo_id} has dirty tracked files", "repo_id": repo_id})
     if not summary.get("handoff_inboxes"):
         checks.append({"status": WARN, "name": "repo_missing_handoff_inbox", "detail": f"{repo_id} has no local handoff inbox", "repo_id": repo_id})
+    pending = int(summary.get("handoff_pending", 0) or 0)
+    oldest_days = summary.get("handoff_backlog_oldest_days")
+    if pending and isinstance(oldest_days, int) and oldest_days >= BACKLOG_STALE_DAYS:
+        checks.append({
+            "status": WARN,
+            "name": "repo_handoff_backlog",
+            "detail": f"{repo_id} has {pending} un-ingested handoff(s), oldest {oldest_days}d old; ingester is not reaching it",
+            "repo_id": repo_id,
+        })
     return checks
 
 
@@ -723,6 +764,97 @@ def scan_payload(target: Path) -> dict[str, Any]:
         "issue_count": len(issues),
         "top_issue": issues[0] if issues else None,
     }
+
+
+def ingest_fleet(
+    *,
+    target: Path,
+    apply: bool = False,
+    promote_cards: bool = True,
+    route_documents: bool = True,
+    json_output: bool = False,
+) -> int:
+    """Ingest every fleet repo's handoffs into the canonical owner (`target`).
+
+    The fleet model: many writer repos drop handoffs into their own inboxes; one
+    owner holds canonical memory. This sweeps each registered, reachable repo,
+    routing its handoffs into `target`'s memory and archiving the processed
+    handoffs back in the source repo. Defaults to a dry run; pass apply=True to
+    write. Closes the gap where each repo had to be ingested by hand.
+    """
+    from . import ingest as ingest_mod
+
+    target = target.expanduser().resolve()
+    entries, errors, config_loaded = _load_config(target)
+    if not config_loaded:
+        print(f"error: no repo fleet config at {config_path(target)}", file=sys.stderr)
+        return 2
+
+    dry_run = not apply
+    stats = ingest_mod.IngestStats()
+    per_repo: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    for entry in entries:
+        if not entry.enabled:
+            continue
+        if not entry.path.is_dir():
+            skipped.append({"repo_id": entry.repo_id, "reason": "not reachable"})
+            continue
+        before = (stats.processed, stats.promoted, stats.routed, stats.inboxed, stats.skipped)
+        rc = ingest_mod.ingest_into(
+            source=entry.path,
+            owner=target,
+            stats=stats,
+            dry_run=dry_run,
+            promote_cards=promote_cards,
+            route_documents=route_documents,
+        )
+        if rc == 2:
+            skipped.append({"repo_id": entry.repo_id, "reason": "no handoff inbox"})
+            continue
+        per_repo.append({
+            "repo_id": entry.repo_id,
+            "processed": stats.processed - before[0],
+            "promoted": stats.promoted - before[1],
+            "routed": stats.routed - before[2],
+            "inboxed": stats.inboxed - before[3],
+            "skipped": stats.skipped - before[4],
+        })
+
+    payload = {
+        "target": str(target),
+        "owner": str(target),
+        "dry_run": dry_run,
+        "config_loaded": config_loaded,
+        "config_errors": errors,
+        "repos_ingested": per_repo,
+        "skipped": skipped,
+        "totals": {
+            "processed": stats.processed,
+            "promoted": stats.promoted,
+            "routed": stats.routed,
+            "inboxed": stats.inboxed,
+            "skipped": stats.skipped,
+        },
+    }
+    if json_output:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+    mode = "DRY-RUN (pass --apply to write)" if dry_run else "applied"
+    print(f"repos ingest [{mode}] -> owner {target}")
+    for repo in per_repo:
+        print(
+            f"- {repo['repo_id']}: processed={repo['processed']} promoted={repo['promoted']} "
+            f"routed={repo['routed']} inboxed={repo['inboxed']}"
+        )
+    for item in skipped:
+        print(f"- {item['repo_id']}: skipped ({item['reason']})")
+    totals = payload["totals"]
+    print(
+        f"totals: processed={totals['processed']} promoted={totals['promoted']} "
+        f"routed={totals['routed']} inboxed={totals['inboxed']} skipped={totals['skipped']}"
+    )
+    return 0
 
 
 def init(*, target: Path, force: bool = False, update_gitignore: bool = True, json_output: bool = False) -> int:

--- a/tests/test_handoff_cmd.py
+++ b/tests/test_handoff_cmd.py
@@ -1225,3 +1225,53 @@ def test_handoff_sync_issues_cli(tmp_path, monkeypatch):
         "categories": ["route-skip"],
         "close_stale": False,
     }
+
+
+# --- Handoff backlog detection (pending AND stale) -------------------------
+
+BACKLOG_STALE_SECONDS = 3 * 24 * 60 * 60  # mirror handoff_cmd.BACKLOG_STALE_SECONDS
+
+
+def _write_handoff(tmp_path, name: str, *, age_seconds: float | None = None) -> None:
+    inbox = tmp_path / ".claude" / "memory-handoffs"
+    inbox.mkdir(parents=True, exist_ok=True)
+    path = inbox / name
+    path.write_text("# Memory Handoff\n")
+    if age_seconds is not None:
+        ts = time.time() - age_seconds
+        os.utime(path, (ts, ts))
+
+
+def test_inspect_tracks_oldest_pending_age(tmp_path):
+    _write_handoff(tmp_path, "old.md", age_seconds=BACKLOG_STALE_SECONDS + 3600)
+    _write_handoff(tmp_path, "new.md", age_seconds=10)
+
+    health = handoff_cmd.inspect(tmp_path)
+    claude_inbox = next(i for i in health.inboxes if i.inbox == ".claude/memory-handoffs")
+
+    assert claude_inbox.pending == 2
+    assert claude_inbox.oldest_pending_age_seconds is not None
+    # oldest is the stale one
+    assert claude_inbox.oldest_pending_age_seconds >= BACKLOG_STALE_SECONDS
+
+
+def test_doctor_checks_warn_on_stale_backlog(tmp_path):
+    _write_handoff(tmp_path, "stuck.md", age_seconds=BACKLOG_STALE_SECONDS + 3600)
+
+    checks = handoff_cmd.doctor_checks(tmp_path)
+    backlog = [c for c in checks if c[1] == "handoff_backlog"]
+
+    assert backlog, "expected a handoff_backlog check"
+    status, _name, detail = backlog[0]
+    assert status == handoff_cmd.WARN
+    assert "1" in detail  # one pending
+
+
+def test_doctor_checks_no_backlog_warn_for_fresh_pending(tmp_path):
+    _write_handoff(tmp_path, "fresh.md", age_seconds=30)
+
+    checks = handoff_cmd.doctor_checks(tmp_path)
+    backlog_warns = [
+        c for c in checks if c[1] == "handoff_backlog" and c[0] == handoff_cmd.WARN
+    ]
+    assert not backlog_warns, "fresh pending handoff should not trip the stale backlog warning"

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -293,3 +293,65 @@ def test_ingest_scans_multiple_writer_inboxes(tmp_path):
     tools = (tmp_path / "TOOLS.md").read_text()
     assert "- claude entry" in tools
     assert "- codex entry" in tools
+
+
+def test_no_card_route_to_bootstrap_file_over_budget_goes_to_inbox(tmp_target: Path):
+    """A route that would push a bootstrap file past its budget must inbox, not append."""
+    from brigade import budgets
+
+    inbox = _seed(tmp_target)
+    budget = budgets.BOOTSTRAP_BUDGETS["TOOLS.md"]
+    # Fill TOOLS.md to just under budget (20B headroom) so the append crosses it.
+    existing = "x" * (budget - 20)
+    (tmp_target / "TOOLS.md").write_text(existing)
+    _write_handoff(
+        inbox,
+        "2026-06-01-0100-too-big.md",
+        """\
+        # Memory Handoff
+
+        ## Recommended memory action
+        no-card
+
+        ## Target document
+        TOOLS.md
+
+        ## Suggested document content
+        a runbook line that pushes the file past its bootstrap budget
+        """,
+    )
+    rc = ingest_mod.run(target=tmp_target, dry_run=False, promote_cards=True, route_documents=True)
+    assert rc == 0
+    # TOOLS.md untouched (guard refused the append)
+    assert (tmp_target / "TOOLS.md").read_text() == existing
+    # content preserved in the review inbox instead
+    drafts = list((tmp_target / "memory" / "handoff-inbox").glob("*.md"))
+    assert drafts, "expected the oversized route to land in the inbox"
+    assert any("too-big" in d.name for d in drafts)
+
+
+def test_no_card_route_to_learnings_not_size_guarded(tmp_target: Path):
+    """.learnings/* are not bootstrap files and may grow freely."""
+    inbox = _seed(tmp_target)
+    learnings = tmp_target / ".learnings" / "LEARNINGS.md"
+    learnings.parent.mkdir(parents=True, exist_ok=True)
+    learnings.write_text("# LEARNINGS\n\n" + ("y" * 30000) + "\n")
+    _write_handoff(
+        inbox,
+        "2026-06-01-0100-learn.md",
+        """\
+        # Memory Handoff
+
+        ## Recommended memory action
+        no-card
+
+        ## Target document
+        .learnings/LEARNINGS.md
+
+        ## Suggested document content
+        another durable lesson
+        """,
+    )
+    rc = ingest_mod.run(target=tmp_target, dry_run=False, promote_cards=True, route_documents=True)
+    assert rc == 0
+    assert "another durable lesson" in learnings.read_text()

--- a/tests/test_repos_cmd.py
+++ b/tests/test_repos_cmd.py
@@ -172,3 +172,82 @@ def test_repos_cli_dispatch(tmp_path, monkeypatch):
         ("health-commands", {"target": tmp_path, "json_output": True}),
         ("discover-plan", {"target": tmp_path, "json_output": True}),
     ]
+
+
+def test_repos_doctor_warns_on_stale_handoff_backlog(tmp_path, capsys):
+    import os
+    import time
+
+    _init_git_repo(tmp_path)
+    (tmp_path / "AGENTS.md").write_text("local guidance\n")
+    inbox = tmp_path / ".claude" / "memory-handoffs"
+    inbox.mkdir(parents=True)
+    stale = inbox / "stuck.md"
+    stale.write_text("# Memory Handoff\n")
+    old = time.time() - (repos_cmd.BACKLOG_STALE_DAYS + 1) * 24 * 60 * 60
+    os.utime(stale, (old, old))
+
+    assert repos_cmd.init(target=tmp_path, json_output=True) == 0
+    capsys.readouterr()
+
+    assert repos_cmd.scan(target=tmp_path, json_output=True) == 0
+    scanned = json.loads(capsys.readouterr().out)
+    names = {c["name"] for c in scanned["checks"]}
+    assert "repo_handoff_backlog" in names
+    backlog = next(c for c in scanned["checks"] if c["name"] == "repo_handoff_backlog")
+    assert "un-ingested" in backlog["detail"]
+
+
+def test_repos_scan_no_backlog_warn_for_fresh_handoff(tmp_path, capsys):
+    _init_git_repo(tmp_path)
+    (tmp_path / "AGENTS.md").write_text("local guidance\n")
+    inbox = tmp_path / ".claude" / "memory-handoffs"
+    inbox.mkdir(parents=True)
+    (inbox / "fresh.md").write_text("# Memory Handoff\n")  # just written, not stale
+
+    assert repos_cmd.init(target=tmp_path, json_output=True) == 0
+    capsys.readouterr()
+    assert repos_cmd.scan(target=tmp_path, json_output=True) == 0
+    scanned = json.loads(capsys.readouterr().out)
+    names = {c["name"] for c in scanned["checks"]}
+    assert "repo_handoff_backlog" not in names
+
+
+def test_repos_ingest_routes_fleet_handoffs_into_owner(tmp_path, capsys):
+    """brigade repos ingest sweeps each fleet repo's handoffs into the owner."""
+    owner = tmp_path / "workspace"
+    repo = tmp_path / "writer-repo"
+    _init_git_repo(owner)
+    _init_git_repo(repo)
+    (owner / "AGENTS.md").write_text("owner guidance\n")
+    (repo / "AGENTS.md").write_text("repo guidance\n")
+    # owner registers itself + the writer repo in its fleet config
+    assert repos_cmd.init(target=owner, json_output=True) == 0
+    capsys.readouterr()
+    cfg = repos_cmd.config_path(owner)
+    cfg.write_text(
+        cfg.read_text()
+        + f'\n[[repo]]\nid = "writer-repo"\nlabel = "writer"\npath = "{repo}"\n'
+    )
+    # the writer repo has a card handoff pending
+    inbox = repo / ".claude" / "memory-handoffs"
+    inbox.mkdir(parents=True)
+    (inbox / "note.md").write_text(
+        "# Memory Handoff\n\n## Recommended memory action\ncreate-card\n\n"
+        "## Target card\nfleet-note.md\n\n## Suggested card content\n"
+        "---\ntopic: fleet\n---\n\n# Fleet note\nbody\n"
+    )
+
+    # dry run writes nothing
+    assert repos_cmd.ingest_fleet(target=owner, apply=False, json_output=True) == 0
+    dry = json.loads(capsys.readouterr().out)
+    assert dry["dry_run"] is True
+    assert not (owner / "memory" / "cards" / "fleet-note.md").exists()
+
+    # apply routes the card into the OWNER and archives the source handoff in the REPO
+    assert repos_cmd.ingest_fleet(target=owner, apply=True, json_output=True) == 0
+    applied = json.loads(capsys.readouterr().out)
+    assert applied["totals"]["promoted"] == 1
+    assert (owner / "memory" / "cards" / "fleet-note.md").is_file()
+    assert (inbox / "processed" / "note.md").is_file()
+    assert not (inbox / "note.md").exists()


### PR DESCRIPTION
## Summary

Closes the failure mode where handoffs are written but silently never ingested, and hardens the ingest path so it cannot bloat session-prefix files.

- **Handoff backlog detection.** `brigade handoff doctor` / `brigade doctor` emit `handoff_backlog` when an inbox has pending handoffs older than the staleness threshold (`InboxHealth` gains `oldest_pending_age_seconds`). `brigade repos scan`/`doctor` emit `repo_handoff_backlog` for fleet repos with a stale un-ingested pile-up.
- **Canonical `brigade.budgets` module.** Single source of truth for bootstrap byte budgets, memory-card budgets, the index line limit, and staleness thresholds. `doctor`, `ingest`, `handoff`, and `repos` all consume it, so preventive guards and post-hoc warnings can never disagree.
- **Bootstrap budget guard in ingest.** A `no-card` route that would push a bootstrap file (e.g. `TOOLS.md`, `USER.md`) past its budget is inboxed for review instead of appended. Non-bootstrap targets like `.learnings/*` are unaffected.
- **Fleet ingest driver.** `brigade repos ingest` sweeps every registered repo's handoffs into the canonical owner (`ingest.run` gains an `owner` param plus an `ingest_into` core). Dry-run by default, `--apply` to write.
- **Roadmap.** Adds a Deep Research Lane phase and an Operator Capabilities Beyond The CLI phase.

## Testing

`pytest` — 710 passing. New tests cover the per-target and fleet backlog checks, the bootstrap budget guard (over-budget inboxes, `.learnings` unaffected), and the fleet ingest routing into the owner with source-side archival. CLI smoke confirmed both the backlog warning and the budget guard.