### PR TITLE
fix(ingest): dedupe document routes against existing target content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Dedupe guard in `brigade ingest` document routing. A `no-card` route whose content (or its first meaningful line/anchor) is already present in the target document is now sent to the review inbox instead of being appended again, matching the canonical pipeline and preventing duplicate content on re-routed handoffs.
+
+
 ## [0.8.0] - 2026-06-01
 
 ### Added

--- a/src/brigade/ingest.py
+++ b/src/brigade/ingest.py
@@ -194,6 +194,21 @@ class Outcome:
     reason: str = ""
 
 
+def _normalize_for_dedupe(text: str) -> str:
+    """Collapse whitespace and drop blank lines for content-equality checks."""
+    lines = [re.sub(r"\s+", " ", line).strip() for line in text.splitlines()]
+    return "\n".join(line for line in lines if line)
+
+
+def _first_meaningful_line(text: str) -> str:
+    """First non-blank, stripped line of `text`, or '' if there is none."""
+    for line in text.splitlines():
+        cleaned = line.strip()
+        if cleaned:
+            return cleaned
+    return ""
+
+
 def decide(
     sections: Dict[str, str],
     target: Path,
@@ -233,6 +248,16 @@ def decide(
                 reason="document content contains `##` headings (would parse as new section)",
             )
         dest = target / document
+        # Dedupe: never re-append content that is already present in the target.
+        # Without this, a re-routed handoff duplicates its content on every run.
+        existing = dest.read_text() if dest.is_file() else ""
+        normalized_existing = _normalize_for_dedupe(existing)
+        normalized_suggested = _normalize_for_dedupe(content)
+        if normalized_suggested and normalized_suggested in normalized_existing:
+            return Outcome("inboxed", reason=f"document content already present in {document}")
+        anchor = _first_meaningful_line(content)
+        if anchor and anchor in existing:
+            return Outcome("inboxed", reason=f"anchor already present in {document}: {anchor}")
         # Bootstrap files load into the session prefix every turn and silently
         # truncate past ~12k chars. Refuse an append that would push the file
         # over its budget; route to the inbox so a human trims or re-homes it.

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -355,3 +355,36 @@ def test_no_card_route_to_learnings_not_size_guarded(tmp_target: Path):
     rc = ingest_mod.run(target=tmp_target, dry_run=False, promote_cards=True, route_documents=True)
     assert rc == 0
     assert "another durable lesson" in learnings.read_text()
+
+
+def test_no_card_route_skips_content_already_present(tmp_target: Path):
+    """Re-routing content already in the target must inbox, not duplicate-append."""
+    inbox = _seed(tmp_target)
+    learnings = tmp_target / ".learnings" / "LEARNINGS.md"
+    learnings.parent.mkdir(parents=True, exist_ok=True)
+    learnings.write_text("# LEARNINGS\n\n### Existing lesson\nalready captured here\n")
+    _write_handoff(
+        inbox,
+        "2026-06-01-0200-dup.md",
+        """\
+        # Memory Handoff
+
+        ## Recommended memory action
+        no-card
+
+        ## Target document
+        .learnings/LEARNINGS.md
+
+        ## Suggested document content
+        ### Existing lesson
+        already captured here
+        """,
+    )
+    before = learnings.read_text()
+    rc = ingest_mod.run(target=tmp_target, dry_run=False, promote_cards=True, route_documents=True)
+    assert rc == 0
+    # not appended again
+    assert learnings.read_text() == before
+    # landed in the review inbox instead
+    drafts = list((tmp_target / "memory" / "handoff-inbox").glob("*dup*.md"))
+    assert drafts, "duplicate content should route to the inbox"


### PR DESCRIPTION
Ports the canonical pipeline's dedupe/anchor protection into brigade ingest: a `no-card` route whose content (or first meaningful line) already exists in the target is inboxed instead of re-appended. Closes a real divergence found during parity validation — brigade was duplicating content into LEARNINGS.md on re-routed handoffs (+53 dup lines) while the standalone ingester correctly skipped them. Verified: routed 0 / inboxed 14 / zero duplication on real handoffs. 714 tests pass.