### PR TITLE
feat(handoff): first-class OpenCode handoff source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- First-class OpenCode handoff support: `.opencode/memory-handoffs/` is now a built-in writer inbox (install scaffolding, ingest, doctor, handoff doctor source coverage, fleet sweep, security skip-list, and the interactive selector), so OpenCode handoffs ingest without a manual `--handoff-inbox` flag. The writer-inbox map is now centralized in `brigade.selection.WRITER_INBOXES`.
 - Shared untrusted-context policy helper (`brigade.untrusted`): `wrap_untrusted` frames external content as data-not-instructions with a content-derived fence, and `scan_untrusted` reports injection signals. Adopted in the research extractor, and handoff ingest now routes injection-flagged content to the review inbox instead of auto-filing it into a card or document.
 - New `research` command group: local-first iterative deep research grounded in a
   trusted local corpus, with an opt-in, quarantined web tier (Playwright, no API

--- a/README.md
+++ b/README.md
@@ -790,6 +790,7 @@ brigade installs material on two independent axes:
 |---|---|---|
 | `claude` | writer | `CLAUDE.md` + `.claude/memory-handoffs/` inbox |
 | `codex` | writer | `.codex/memory-handoffs/` inbox (AGENTS.md is in the baseline) |
+| `opencode` | writer | `.opencode/memory-handoffs/` inbox |
 | `openclaw` | reader | `.brigade/openclaw/` config fragments + cron stubs |
 | `hermes` | reader | `.brigade/hermes/` adapter fragments (experimental) |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -210,7 +210,7 @@ Goal: prevent durable memory from silently rotting.
 Goal: keep the system usable by the original operator while making it adaptable by others.
 
 - Keep Codex-first defaults, with Claude Code, OpenCode, Hermes, OpenClaw, and generic harness paths supported through writer-specific inboxes.
-- Promote OpenCode to a first-class built-in handoff source. Today only `.claude/memory-handoffs/` and `.codex/memory-handoffs/` are hardcoded in the ingest, doctor, fleet sweep, and security scan source maps; OpenCode handoffs only flow through a manual `--handoff-inbox` flag. Add `.opencode/memory-handoffs/` to the same built-in source maps, ship a template scaffold, and cover it in handoff doctor source-coverage and the repo sweep so OpenCode handoffs route automatically. Status: proposed (next).
+- Promote OpenCode to a first-class built-in handoff source. Today only `.claude/memory-handoffs/` and `.codex/memory-handoffs/` are hardcoded in the ingest, doctor, fleet sweep, and security scan source maps; OpenCode handoffs only flow through a manual `--handoff-inbox` flag. Add `.opencode/memory-handoffs/` to the same built-in source maps, ship a template scaffold, and cover it in handoff doctor source-coverage and the repo sweep so OpenCode handoffs route automatically. Status: implemented with .opencode/memory-handoffs/ wired into install scaffolding, ingest, doctor, handoff doctor source coverage, the fleet sweep, the security skip-list, and the interactive selector, plus a template scaffold.
 - Make local paths configurable and gitignored.
 - Provide templates for fresh-start users without publishing private workspace state.
 - Keep public repo docs focused on patterns, commands, and safety contracts.

--- a/docs/superpowers/plans/2026-06-02-opencode-handoff-source.md
+++ b/docs/superpowers/plans/2026-06-02-opencode-handoff-source.md
@@ -1,0 +1,455 @@
+# First-Class OpenCode Handoff Source Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `.opencode/memory-handoffs/` a first-class built-in handoff source across install, ingest, doctor, fleet sweep, security skip-list, the interactive selector, and the handoff-sources example, and centralize the writer-inbox map so it stops being duplicated.
+
+**Architecture:** Add a single canonical `WRITER_INBOXES` dict (plus `opencode` in `KNOWN_HARNESSES`) to `selection.py`, then point `install.py`, `ingest.py`, `doctor.py`, `repos_cmd.py`, and `handoff_cmd.py` at it. Add an `opencode` harness manifest + handoff template, the security skip entry, the interactive selector entries, and docs.
+
+**Tech Stack:** Python 3.10+, standard library only, pytest. Use `python3` to run pytest.
+
+**Models for subagents:** opus. Never haiku.
+
+---
+
+## File Structure
+
+- Modify: `src/brigade/selection.py` - add `opencode` to `KNOWN_HARNESSES`; add canonical `WRITER_INBOXES` dict.
+- Modify: `src/brigade/install.py` - drop local `_WRITER_INBOX`, import canonical map.
+- Modify: `src/brigade/ingest.py` - drop local `_WRITER_INBOXES`, import canonical map.
+- Modify: `src/brigade/doctor.py` - drop local `_WRITER_INBOXES`, import canonical map.
+- Modify: `src/brigade/repos_cmd.py` - derive handoff scan dirs from the canonical map.
+- Modify: `src/brigade/handoff_cmd.py` - derive its `WRITER_INBOXES` tuple from the canonical map.
+- Modify: `src/brigade/security_cmd.py` - add `(".opencode", "memory-handoffs")` to `SKIP_PREFIXES`.
+- Modify: `src/brigade/prompt.py` - add `opencode` to selector order + labels.
+- Create: `src/brigade/templates/harnesses/opencode.json` - writer manifest.
+- Create: `src/brigade/templates/opencode/memory-handoffs/TEMPLATE.md` - handoff template.
+- Modify: `src/brigade/templates/handoff/handoff-sources.example.json` - add opencode inbox.
+- Modify: `ROADMAP.md`, `CHANGELOG.md`, `README.md` - docs.
+- Tests: `tests/test_selection.py`, `tests/test_install.py` (or equivalent), `tests/test_ingest.py`, `tests/test_doctor.py`, `tests/test_repos*.py`, `tests/test_security*.py`, `tests/test_handoff*.py`.
+
+---
+
+## Task 1: Canonical WRITER_INBOXES + opencode in KNOWN_HARNESSES
+
+**Files:**
+- Modify: `src/brigade/selection.py`
+- Test: `tests/test_selection.py`
+
+- [ ] **Step 1: Write/extend the failing test**
+
+Add to `tests/test_selection.py` (match existing imports; `from brigade import selection`):
+
+```python
+def test_opencode_is_a_known_harness():
+    from brigade.selection import KNOWN_HARNESSES, WRITER_INBOXES
+    assert "opencode" in KNOWN_HARNESSES
+    assert WRITER_INBOXES["opencode"] == ".opencode/memory-handoffs"
+
+
+def test_writer_inboxes_cover_known_writers():
+    from brigade.selection import WRITER_INBOXES
+    assert WRITER_INBOXES["claude"] == ".claude/memory-handoffs"
+    assert WRITER_INBOXES["codex"] == ".codex/memory-handoffs"
+```
+
+Also: if `tests/test_selection.py` has an assertion pinning `KNOWN_HARNESSES` to the exact 4-tuple `("claude","codex","openclaw","hermes")`, update it to include `"opencode"`.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python3 -m pytest tests/test_selection.py -q`
+Expected: FAIL (ImportError on `WRITER_INBOXES` or KeyError / missing opencode).
+
+- [ ] **Step 3: Implement**
+
+In `src/brigade/selection.py`, change `KNOWN_HARNESSES` to include opencode and add the map below it:
+
+```python
+KNOWN_HARNESSES = ("claude", "codex", "opencode", "openclaw", "hermes")
+
+# Writer harness id -> repo-relative handoff inbox dir. Single source of truth;
+# install, ingest, doctor, the fleet sweep, and the handoff doctor consume this.
+WRITER_INBOXES = {
+    "claude": ".claude/memory-handoffs",
+    "codex": ".codex/memory-handoffs",
+    "opencode": ".opencode/memory-handoffs",
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `python3 -m pytest tests/test_selection.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd <repo-root>
+git add src/brigade/selection.py tests/test_selection.py
+git commit -m "feat(selection): canonical WRITER_INBOXES map; register opencode harness"
+```
+
+---
+
+## Task 2: Point install/ingest/doctor at the canonical map
+
+**Files:**
+- Modify: `src/brigade/install.py`, `src/brigade/ingest.py`, `src/brigade/doctor.py`
+- Test: existing `tests/test_install.py`, `tests/test_ingest.py`, `tests/test_doctor.py`
+
+- [ ] **Step 1: Replace install's local dict**
+
+In `src/brigade/install.py`, delete:
+```python
+# Writer harness -> inbox-dir prefix. Only writer harnesses have an inbox.
+_WRITER_INBOX = {
+    "claude": ".claude/memory-handoffs",
+    "codex": ".codex/memory-handoffs",
+}
+```
+Add `WRITER_INBOXES` to the existing `from .selection import ...` line (or add `from .selection import WRITER_INBOXES`). In `build_gitignore_block`, change `inbox = _WRITER_INBOX.get(h)` to `inbox = WRITER_INBOXES.get(h)`.
+
+- [ ] **Step 2: Replace ingest's local dict**
+
+In `src/brigade/ingest.py`, delete:
+```python
+# Writer harness id -> inbox dir (mirror of install._WRITER_INBOX).
+_WRITER_INBOXES = {
+    "claude": ".claude/memory-handoffs",
+    "codex": ".codex/memory-handoffs",
+}
+```
+Add `from .selection import WRITER_INBOXES` with the other imports. In `_resolve_inbox_paths`, change `rel = _WRITER_INBOXES.get(h)` to `rel = WRITER_INBOXES.get(h)`.
+
+- [ ] **Step 3: Replace doctor's local dict**
+
+In `src/brigade/doctor.py`, delete:
+```python
+# Writer harness -> inbox-dir prefix. Only writer harnesses have an inbox.
+_WRITER_INBOXES = {
+    "claude": ".claude/memory-handoffs",
+    "codex": ".codex/memory-handoffs",
+}
+```
+Add `from .selection import WRITER_INBOXES` (or extend the existing selection import). In `_check_handoff_inboxes`, change `rel = _WRITER_INBOXES.get(h)` to `rel = WRITER_INBOXES.get(h)`.
+
+- [ ] **Step 4: Run the affected suites**
+
+Run: `python3 -m pytest tests/ -k "install or ingest or doctor" -q`
+Expected: PASS (no regression; the refactor is behavior-preserving for claude/codex).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/brigade/install.py src/brigade/ingest.py src/brigade/doctor.py
+git commit -m "refactor(handoff): consume canonical WRITER_INBOXES in install/ingest/doctor"
+```
+
+---
+
+## Task 3: OpenCode harness manifest + handoff template
+
+**Files:**
+- Create: `src/brigade/templates/harnesses/opencode.json`
+- Create: `src/brigade/templates/opencode/memory-handoffs/TEMPLATE.md`
+- Test: `tests/test_install.py` (or the install test module)
+
+- [ ] **Step 1: Write the failing install test**
+
+First inspect an existing install test to match fixtures/helpers:
+Run: `python3 -m pytest tests/ -k install -q` and open `tests/test_install.py`.
+
+Add a test (adapt the install entrypoint/fixture names to the file's conventions; the project installs via `brigade.install.install_selection` with a `Selection`):
+
+```python
+def test_opencode_install_creates_inbox_and_gitignore(tmp_path):
+    from brigade.install import install_selection, build_gitignore_block
+    from brigade.selection import Selection
+    sel = Selection(depth="repo", harnesses=["opencode"], owner="opencode", includes=[])
+    rc = install_selection(tmp_path, sel)
+    assert rc == 0
+    assert (tmp_path / ".opencode" / "memory-handoffs" / "TEMPLATE.md").is_file()
+    assert (tmp_path / ".opencode" / "memory-handoffs" / "processed").is_dir()
+    block = build_gitignore_block(sel)
+    assert ".opencode/memory-handoffs/*" in block
+    assert "!.opencode/memory-handoffs/TEMPLATE.md" in block
+```
+
+(If `Selection`'s field names or `owner` validation differ, mirror an existing passing install test for codex and swap `codex`->`opencode`.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python3 -m pytest tests/ -k opencode_install -q`
+Expected: FAIL (manifest/template missing -> `install_selection` returns nonzero "template missing", or assertion fails).
+
+- [ ] **Step 3: Create the manifest**
+
+Create `src/brigade/templates/harnesses/opencode.json`:
+
+```json
+{
+  "id": "opencode",
+  "role": "writer",
+  "description": "OpenCode handoff inbox. (AGENTS.md is in the depth baseline; no separate bridge file today.)",
+  "files": [
+    {"src": "opencode/memory-handoffs/TEMPLATE.md", "dst": ".opencode/memory-handoffs/TEMPLATE.md"}
+  ],
+  "dirs": [
+    ".opencode/memory-handoffs/processed"
+  ]
+}
+```
+
+- [ ] **Step 4: Create the template**
+
+Copy the codex handoff template verbatim:
+
+```bash
+mkdir -p src/brigade/templates/opencode/memory-handoffs
+cp src/brigade/templates/codex/memory-handoffs/TEMPLATE.md src/brigade/templates/opencode/memory-handoffs/TEMPLATE.md
+```
+
+Confirm the file is non-empty: `head -3 src/brigade/templates/opencode/memory-handoffs/TEMPLATE.md`.
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `python3 -m pytest tests/ -k "opencode_install or install" -q`
+Expected: PASS.
+
+- [ ] **Step 6: Verify packaging includes the new template**
+
+Check `MANIFEST.in` / `pyproject.toml` package-data globs already cover `templates/**`. If templates are included by a recursive glob (e.g. `recursive-include src/brigade/templates *`), nothing to do. If each harness dir is listed explicitly, add the `opencode` template path. Run:
+`grep -n "templates" MANIFEST.in pyproject.toml`
+and only edit if opencode would otherwise be excluded.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/brigade/templates/harnesses/opencode.json src/brigade/templates/opencode/ tests/
+[ -n "$(git diff --cached --name-only MANIFEST.in pyproject.toml)" ] && true
+git commit -m "feat(handoff): opencode harness manifest and handoff template"
+```
+
+---
+
+## Task 4: Fleet sweep + security skip-list coverage
+
+**Files:**
+- Modify: `src/brigade/repos_cmd.py`, `src/brigade/security_cmd.py`
+- Test: `tests/test_repos*.py`, `tests/test_security*.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Security drift guard + skip behavior (add to the security test module; match its imports):
+
+```python
+def test_skip_prefixes_cover_all_writer_inboxes():
+    from brigade.security_cmd import SKIP_PREFIXES
+    from brigade.selection import WRITER_INBOXES
+    for rel in WRITER_INBOXES.values():
+        parts = tuple(rel.split("/"))
+        assert parts in SKIP_PREFIXES, f"{rel} not skipped by security scan"
+```
+
+Repos handoff inbox detection (add to the repos test module; mirror an existing `_repo_summary` test if present):
+
+```python
+def test_repo_summary_counts_opencode_inbox(tmp_path):
+    from brigade import repos_cmd
+    (tmp_path / ".opencode" / "memory-handoffs").mkdir(parents=True)
+    # Build a RepoEntry the same way the existing repos tests do; then:
+    summary = repos_cmd._repo_summary(_make_entry(tmp_path))
+    assert ".opencode/memory-handoffs" in summary["handoff_inboxes"]
+```
+
+(If `_repo_summary`/`RepoEntry` construction differs, copy the pattern from an existing repos test; the assertion on `handoff_inboxes` is the point.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python3 -m pytest tests/ -k "skip_prefixes_cover or opencode_inbox" -q`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+In `src/brigade/repos_cmd.py` `_repo_summary`, replace the hardcoded tuple:
+```python
+    handoff_inboxes = [
+        inbox
+        for inbox in (".claude/memory-handoffs", ".codex/memory-handoffs")
+        if (repo / inbox).is_dir()
+    ]
+```
+with a derivation from the canonical map (add `from .selection import WRITER_INBOXES` if not already imported):
+```python
+    handoff_inboxes = [
+        inbox
+        for inbox in WRITER_INBOXES.values()
+        if (repo / inbox).is_dir()
+    ]
+```
+
+In `src/brigade/security_cmd.py`, add the opencode entry to `SKIP_PREFIXES`:
+```python
+SKIP_PREFIXES = (
+    (".brigade", "runs"),
+    (".brigade", "security"),
+    (".brigade", "work"),
+    (".claude", "memory-handoffs"),
+    (".codex", "memory-handoffs"),
+    (".opencode", "memory-handoffs"),
+)
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `python3 -m pytest tests/ -k "repos or security" -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/brigade/repos_cmd.py src/brigade/security_cmd.py tests/
+git commit -m "feat(handoff): cover opencode inbox in fleet sweep and security skip-list"
+```
+
+---
+
+## Task 5: Handoff doctor coverage + selector + handoff-sources example
+
+**Files:**
+- Modify: `src/brigade/handoff_cmd.py`, `src/brigade/prompt.py`, `src/brigade/templates/handoff/handoff-sources.example.json`
+- Test: `tests/test_handoff*.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to the handoff test module:
+
+```python
+def test_handoff_writer_inboxes_include_opencode():
+    from brigade import handoff_cmd
+    assert ".opencode/memory-handoffs" in handoff_cmd.WRITER_INBOXES
+
+
+def test_handoff_sources_example_lists_opencode():
+    import json
+    from brigade.templates import template_root
+    data = json.loads((template_root() / "handoff" / "handoff-sources.example.json").read_text())
+    assert ".opencode/memory-handoffs" in data["sources"][0]["inboxes"]
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python3 -m pytest tests/ -k "writer_inboxes_include_opencode or sources_example_lists_opencode" -q`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+In `src/brigade/handoff_cmd.py`, replace:
+```python
+WRITER_INBOXES = (".claude/memory-handoffs", ".codex/memory-handoffs")
+```
+with a derivation from the canonical map (add the import near the top):
+```python
+from .selection import WRITER_INBOXES as _WRITER_INBOX_MAP
+
+WRITER_INBOXES = tuple(_WRITER_INBOX_MAP.values())
+```
+Leave every existing use of `WRITER_INBOXES` in the file unchanged (it stays a tuple of path strings).
+
+In `src/brigade/templates/handoff/handoff-sources.example.json`, add `".opencode/memory-handoffs"` to `sources[0].inboxes` (after the codex entry).
+
+In `src/brigade/prompt.py`, add `opencode` to `_HARNESS_ORDER` (after `codex`) and add `"opencode": "OpenCode"` to `_HARNESS_LABELS`.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `python3 -m pytest tests/ -k "handoff or prompt or work_cmd" -q`
+Expected: PASS. If a prompt/work_cmd test pins the exact harness list, update it to include opencode.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/brigade/handoff_cmd.py src/brigade/prompt.py src/brigade/templates/handoff/handoff-sources.example.json tests/
+git commit -m "feat(handoff): opencode in handoff doctor coverage, selector, and sources example"
+```
+
+---
+
+## Task 6: End-to-end ingest test + docs
+
+**Files:**
+- Test: `tests/test_ingest.py`
+- Modify: `ROADMAP.md`, `CHANGELOG.md`, `README.md`, `docs/command-inventory.md` (if it lists harnesses)
+
+- [ ] **Step 1: Write the end-to-end ingest test**
+
+Add to `tests/test_ingest.py`, mirroring an existing codex/claude ingest test but installing opencode. The point: a handoff in `.opencode/memory-handoffs/` is promoted and archived to `processed/`.
+
+```python
+def test_opencode_handoff_is_ingested(tmp_target: Path):
+    from brigade.install import install_selection
+    from brigade.selection import Selection
+    install_selection(tmp_target, Selection(depth="workspace", harnesses=["opencode"], owner="opencode", includes=[]))
+    inbox = tmp_target / ".opencode" / "memory-handoffs"
+    _write_handoff(
+        inbox,
+        "2026-06-02-1200-opencode.md",
+        """\
+        # Memory Handoff
+
+        ## Recommended memory action
+        create-card
+
+        ## Target card
+        opencode-test.md
+
+        ## Suggested card content
+        ---
+        topic: opencode-test
+        ---
+        body line
+        """,
+    )
+    rc = ingest_mod.run(target=tmp_target, dry_run=False, promote_cards=True, route_documents=True)
+    assert rc == 0
+    assert (tmp_target / "memory" / "cards" / "opencode-test.md").is_file()
+    assert (inbox / "processed" / "2026-06-02-1200-opencode.md").is_file()
+```
+
+(Reuse the module's existing `_write_handoff` helper and `tmp_target` fixture. If `install_selection` with `owner="opencode"` is rejected by owner validation, use a valid owner the other ingest tests use and keep `harnesses=["opencode"]`.)
+
+- [ ] **Step 2: Run to verify pass**
+
+Run: `python3 -m pytest tests/test_ingest.py -k opencode -q`
+Expected: PASS (the prior tasks already wired the path).
+
+- [ ] **Step 3: Update docs**
+
+- `ROADMAP.md`: change the "Promote OpenCode to a first-class built-in handoff source" bullet's `Status: proposed (next).` to `Status: implemented with .opencode/memory-handoffs/ wired into install scaffolding, ingest, doctor, handoff doctor source coverage, the fleet sweep, the security skip-list, and the interactive selector, plus a template scaffold.`
+- `CHANGELOG.md`: under `## [Unreleased]` -> `### Added`:
+  ```
+  - First-class OpenCode handoff support: `.opencode/memory-handoffs/` is now a built-in writer inbox (install scaffolding, ingest, doctor, handoff doctor source coverage, fleet sweep, security skip-list, and the interactive selector), so OpenCode handoffs ingest without a manual `--handoff-inbox` flag. The writer-inbox map is now centralized in `brigade.selection.WRITER_INBOXES`.
+  ```
+- `README.md`: if it enumerates supported writer harnesses (search for "Codex" / "OpenClaw" near "handoff" or "harness"), add OpenCode to that list.
+
+- [ ] **Step 4: Regenerate command inventory if applicable**
+
+Run: `grep -rn "opencode\|claude\|codex" docs/command-inventory.md | head`
+If the inventory documents the harness set and a generator exists, run `python3 -m brigade roadmap commands --write` (the project's documented regenerator) and include the diff. If the inventory does not list harnesses, skip.
+
+- [ ] **Step 5: Full suite + commit**
+
+Run: `python3 -m pytest -q`
+Expected: PASS (all).
+
+```bash
+git add tests/test_ingest.py ROADMAP.md CHANGELOG.md README.md docs/
+git commit -m "feat(handoff): end-to-end opencode ingest test and docs"
+```
+
+---
+
+## Verification (no commit)
+
+- [ ] `python3 -m pytest -q` fully green.
+- [ ] `grep -rn "memory-handoffs\"" src/brigade/*.py` shows the only literal claude/codex/opencode inbox dicts live in `selection.py` (other modules import or derive from it). The security `SKIP_PREFIXES` literal is the one allowed exception (guarded by a test).
+- [ ] `python3 -m brigade init` (or the install path) with opencode selected creates `.opencode/memory-handoffs/{TEMPLATE.md,processed/}` in a scratch dir.

--- a/docs/superpowers/specs/2026-06-02-opencode-handoff-source-design.md
+++ b/docs/superpowers/specs/2026-06-02-opencode-handoff-source-design.md
@@ -1,0 +1,110 @@
+# First-Class OpenCode Handoff Source Design
+
+> **In plain terms:** OpenCode is listed as a supported writer harness, but Brigade never actually wired it in. You can only ingest OpenCode handoffs today by passing a manual `--handoff-inbox` flag. This makes `.opencode/memory-handoffs/` a built-in handoff source everywhere the other writers (Claude, Codex) already are: install scaffolding, ingest, doctor, the fleet sweep, security scan skip-list, the interactive selector, and the handoff-sources example. Along the way it removes the triplicated writer-inbox map that has already caused drift bugs this week.
+
+## Goal
+
+Promote OpenCode to a first-class writer harness for the handoff pipeline so `.opencode/memory-handoffs/` is recognized, scaffolded, ingested, doctored, swept, and skipped-by-security automatically, with no manual flag.
+
+## Background
+
+- `selection.KNOWN_HARNESSES = ("claude", "codex", "openclaw", "hermes")` does **not** include `opencode`, so `brigade init --harnesses opencode` fails validation today.
+- The writer-harness-to-inbox map is duplicated byte-for-byte in three places: `install._WRITER_INBOX`, `ingest._WRITER_INBOXES`, `doctor._WRITER_INBOXES`. Two more spots hardcode the same two inbox paths: `repos_cmd` (`_repo_summary` handoff scan) and `security_cmd.SKIP_PREFIXES`. The handoff-sources example (`templates/handoff/handoff-sources.example.json`) lists them too. This duplication is the same drift trap that produced two separate bugs this session.
+- Per-harness install scaffolding is driven by harness manifests under `templates/harnesses/<id>.json` plus template files under `templates/<id>/`. `codex.json` is the clean reference: role `writer`, one `TEMPLATE.md` file, one `processed` dir.
+
+## Non-Goals
+
+- OpenCode bootstrap-file support beyond handoffs (e.g. a dedicated bridge file). Codex itself has none ("AGENTS.md is in the depth baseline"); OpenCode follows the same pattern. AGENTS.md already comes from the depth baseline.
+- Making OpenCode a memory **owner**. It is a writer; the canonical owner is unchanged.
+- Any new dependency. Standard library and existing template machinery only.
+- Changing OpenCode's own config or models (handled separately as an environment task).
+
+## Architecture
+
+### 1. Single source of truth for the writer-inbox map
+
+Add to `selection.py` (a leaf module, no import cycles) next to `KNOWN_HARNESSES`:
+
+```python
+# Writer harness id -> repo-relative handoff inbox dir. Single source of truth;
+# install, ingest, doctor, and the fleet sweep all consume this.
+WRITER_INBOXES = {
+    "claude": ".claude/memory-handoffs",
+    "codex": ".codex/memory-handoffs",
+    "opencode": ".opencode/memory-handoffs",
+}
+```
+
+And add `"opencode"` to `KNOWN_HARNESSES`.
+
+Then replace the three local dicts with imports:
+- `install.py`: delete `_WRITER_INBOX`, `from .selection import WRITER_INBOXES`, use it in `build_gitignore_block`.
+- `ingest.py`: delete `_WRITER_INBOXES`, import and use `WRITER_INBOXES` in `_resolve_inbox_paths`.
+- `doctor.py`: delete `_WRITER_INBOXES`, import and use `WRITER_INBOXES` in `_check_handoff_inboxes`.
+
+Derive the fleet sweep from it:
+- `repos_cmd._repo_summary`: iterate `WRITER_INBOXES.values()` instead of the hardcoded 2-tuple.
+
+`security_cmd.SKIP_PREFIXES` is a mixed tuple (handoff dirs plus `.brigade/*` dirs), so it stays a literal but gains `(".opencode", "memory-handoffs")`. A focused test asserts every `WRITER_INBOXES` path is present in `SKIP_PREFIXES` so this can't silently drift.
+
+### 2. OpenCode harness manifest and template
+
+- New `templates/harnesses/opencode.json` mirroring `codex.json`: id `opencode`, role `writer`, files `[{"src": "opencode/memory-handoffs/TEMPLATE.md", "dst": ".opencode/memory-handoffs/TEMPLATE.md"}]`, dirs `[".opencode/memory-handoffs/processed"]`.
+- New `templates/opencode/memory-handoffs/TEMPLATE.md`, identical content to `templates/codex/memory-handoffs/TEMPLATE.md` (the handoff template is harness-agnostic).
+
+With these, `brigade init --harnesses opencode` creates `.opencode/memory-handoffs/TEMPLATE.md` + `processed/`, and `build_gitignore_block` emits the matching ignore lines automatically (it reads `WRITER_INBOXES`).
+
+### 3. Interactive selector
+
+`prompt.py` adds `opencode` to `_HARNESS_ORDER` and `_HARNESS_LABELS` (e.g. `"opencode": "OpenCode"`) so the numbered selector offers it like the others.
+
+### 4. Handoff-sources example and doctor coverage
+
+- `handoff_cmd.py` has its **own** `WRITER_INBOXES` (a tuple of path strings, used in ~6 places for source-coverage checks and draft scanning). Re-derive it from the canonical map to avoid a fourth divergent copy:
+  ```python
+  from .selection import WRITER_INBOXES as _WRITER_INBOX_MAP
+  WRITER_INBOXES = tuple(_WRITER_INBOX_MAP.values())
+  ```
+  This keeps the existing module-local name and its tuple-of-paths shape (so every current usage is unchanged) while flowing the opencode entry through automatically.
+- `templates/handoff/handoff-sources.example.json`: add `.opencode/memory-handoffs` to the default `sources[0].inboxes` list so a fresh config covers OpenCode.
+- A test confirms `handoff_cmd.WRITER_INBOXES` contains `.opencode/memory-handoffs`, so an `.opencode/memory-handoffs` directory is recognized as a known writer inbox (not flagged as an unknown/uncovered source).
+
+## Data Flow
+
+```
+brigade init --harnesses opencode
+   └─ install: opencode.json manifest -> .opencode/memory-handoffs/{TEMPLATE.md,processed/}
+                build_gitignore_block (reads WRITER_INBOXES) -> ignore .opencode/memory-handoffs/*
+
+OpenCode writes .opencode/memory-handoffs/<handoff>.md
+   └─ brigade ingest: _resolve_inbox_paths (reads WRITER_INBOXES) -> routes/promotes -> archives to processed/
+   └─ brigade doctor / handoff doctor: reports the opencode inbox
+   └─ brigade repos scan: counts opencode handoff backlog in the fleet
+   └─ brigade security scan: skips .opencode/memory-handoffs (untrusted handoff content not flagged as repo injection)
+```
+
+## Error Handling
+
+- Unknown harness validation is unchanged; `opencode` simply joins the valid set.
+- Installing into a repo that already has `.opencode/memory-handoffs/TEMPLATE.md` hits the existing `--force` conflict guard (no new path).
+- A repo with an `.opencode/memory-handoffs` dir but no Brigade config still falls back through `_resolve_inbox_paths`' legacy `.claude` path only when no config exists; with a config listing `opencode`, the opencode inbox resolves normally.
+
+## Testing
+
+- **selection:** `test_selection.py` - `opencode` is accepted by `validate()`; `WRITER_INBOXES` includes it. Update any assertion that pins `KNOWN_HARNESSES` to the old 4-tuple.
+- **install:** installing a selection with `harnesses=["opencode"]` creates `.opencode/memory-handoffs/TEMPLATE.md` and `processed/`, and the gitignore block contains `.opencode/memory-handoffs/*` and `!.opencode/memory-handoffs/TEMPLATE.md`.
+- **ingest:** a handoff in `.opencode/memory-handoffs/` (with a config selecting opencode) is promoted/routed like a codex one; archived to `.opencode/memory-handoffs/processed/`.
+- **doctor:** `_check_handoff_inboxes` reports an `opencode` inbox OK when present, FAIL when missing.
+- **repos:** `_repo_summary` counts an `.opencode/memory-handoffs` inbox in `handoff_inboxes`.
+- **security:** a parametrized/explicit test asserts every `WRITER_INBOXES` value appears in `SKIP_PREFIXES` (drift guard), and a file under `.opencode/memory-handoffs/` is skipped by the scanner.
+- **handoff:** `handoff_cmd.WRITER_INBOXES` includes `.opencode/memory-handoffs`; the handoff-sources example JSON lists it.
+- **prompt:** the selector lists `opencode` (covered by existing prompt/work_cmd tests if they assert the harness set; update them).
+- Full suite stays green.
+
+## Rollout
+
+- Branch `feat/opencode-handoff-source` off `main`.
+- Flip the ROADMAP "Promote OpenCode to a first-class built-in handoff source" item from `Status: proposed (next)` to implemented.
+- CHANGELOG: Unreleased / Added. README harness list updated. Regenerate `docs/command-inventory.md` if the harness set is documented there.
+- No release.
+- Live dogfood: install opencode into a scratch repo, have OpenCode (gpt-oss via ollama-cloud) write a handoff, run `brigade ingest`, confirm it routes and archives.

--- a/src/brigade/cli.py
+++ b/src/brigade/cli.py
@@ -51,7 +51,7 @@ def _build_parser() -> argparse.ArgumentParser:
     p_init.add_argument(
         "--harnesses",
         default=None,
-        help="Comma-separated harness ids: claude, codex, openclaw, hermes. "
+        help="Comma-separated harness ids: claude, codex, opencode, openclaw, hermes. "
              "Pass 'none' for a generic install with no harness-specific files.",
     )
     p_init.add_argument(

--- a/src/brigade/doctor.py
+++ b/src/brigade/doctor.py
@@ -23,6 +23,7 @@ from .budgets import (
     MEMORY_CARE_SCAN_STALE_DAYS,
 )
 
+from .selection import WRITER_INBOXES
 from .station import DoctorContext
 
 
@@ -227,20 +228,13 @@ def _check_bootstrap_budgets(target: Path) -> List[CheckResult]:
     return results
 
 
-# Writer harness -> inbox-dir prefix. Only writer harnesses have an inbox.
-_WRITER_INBOXES = {
-    "claude": ".claude/memory-handoffs",
-    "codex": ".codex/memory-handoffs",
-}
-
-
 def _check_handoff_inboxes(
     target: Path, sel, selected_harnesses: List[str]
 ) -> List[CheckResult]:
     results: List[CheckResult] = []
     writers = selected_harnesses
     for h in writers:
-        rel = _WRITER_INBOXES.get(h)
+        rel = WRITER_INBOXES.get(h)
         if rel is None:
             continue  # reader harness, no inbox
         inbox = target / rel
@@ -366,7 +360,7 @@ def _check_orphan_inboxes(
     target: Path, selected_harnesses: List[str]
 ) -> List[CheckResult]:
     results: List[CheckResult] = []
-    for h, rel in _WRITER_INBOXES.items():
+    for h, rel in WRITER_INBOXES.items():
         if h in selected_harnesses:
             continue
         inbox = target / rel

--- a/src/brigade/handoff_cmd.py
+++ b/src/brigade/handoff_cmd.py
@@ -15,7 +15,9 @@ OK = "ok"
 WARN = "warn"
 FAIL = "fail"
 
-WRITER_INBOXES = (".claude/memory-handoffs", ".codex/memory-handoffs")
+from .selection import WRITER_INBOXES as _WRITER_INBOX_MAP
+
+WRITER_INBOXES = tuple(_WRITER_INBOX_MAP.values())
 IGNORED_HANDOFF_NAMES = {"TEMPLATE.md"}
 DEFAULT_STALE_AFTER_MINUTES = 90
 HANDOFF_DRAFT_STALE_HOURS = 72

--- a/src/brigade/ingest.py
+++ b/src/brigade/ingest.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Dict, List
 
 from . import budgets
+from .selection import WRITER_INBOXES
 from .untrusted import scan_untrusted
 
 SECTION_RE = re.compile(r"^##\s+(?P<name>.+?)\s*$", re.MULTILINE)
@@ -28,12 +29,6 @@ SAFE_SPECIAL_TARGETS = {
     ".learnings/LEARNINGS.md",
     ".learnings/ERRORS.md",
     ".learnings/FEATURE_REQUESTS.md",
-}
-
-# Writer harness id -> inbox dir (mirror of install._WRITER_INBOX).
-_WRITER_INBOXES = {
-    "claude": ".claude/memory-handoffs",
-    "codex": ".codex/memory-handoffs",
 }
 
 # Recognized handoff sections. Any section name outside this set is a signal
@@ -77,7 +72,7 @@ def _resolve_inbox_paths(target: Path) -> list[Path]:
         return [legacy] if legacy.is_dir() else []
     paths: list[Path] = []
     for h in sorted(cfg.selection.harnesses):
-        rel = _WRITER_INBOXES.get(h)
+        rel = WRITER_INBOXES.get(h)
         if rel and (target / rel).is_dir():
             paths.append(target / rel)
     return paths

--- a/src/brigade/install.py
+++ b/src/brigade/install.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import List, Tuple
 
 from .config import Config, write_config
-from .selection import Selection
+from .selection import Selection, WRITER_INBOXES
 from .templates import (
     harness_memory_owner,
     is_text,
@@ -29,12 +29,6 @@ GITIGNORE_END = "# <<< brigade gitignore block <<<"
 LEGACY_GITIGNORE_BEGIN = "# >>> solo-mise gitignore block >>>"
 LEGACY_GITIGNORE_END = "# <<< solo-mise gitignore block <<<"
 
-# Writer harness -> inbox-dir prefix. Only writer harnesses have an inbox.
-_WRITER_INBOX = {
-    "claude": ".claude/memory-handoffs",
-    "codex": ".codex/memory-handoffs",
-}
-
 
 def build_gitignore_block(selection: Selection) -> str:
     lines = [
@@ -44,7 +38,7 @@ def build_gitignore_block(selection: Selection) -> str:
         "",
     ]
     for h in selection.harnesses:
-        inbox = _WRITER_INBOX.get(h)
+        inbox = WRITER_INBOXES.get(h)
         if inbox:
             lines.extend([
                 f"# {h}: handoffs are session-local and may contain private context.",

--- a/src/brigade/prompt.py
+++ b/src/brigade/prompt.py
@@ -21,13 +21,14 @@ class NonInteractiveError(Exception):
     """Raised when prompt_for_selection() runs without a TTY."""
 
 
-_HARNESS_ORDER = ["claude", "codex", "openclaw", "hermes"]
+_HARNESS_ORDER = ["claude", "codex", "opencode", "openclaw", "hermes"]
 _DEPTH_ORDER = ["repo", "workspace"]
 _INCLUDE_ORDER = ["publisher"]
 
 _HARNESS_LABELS = {
     "claude": "Claude Code",
     "codex": "Codex",
+    "opencode": "OpenCode",
     "openclaw": "OpenClaw",
     "hermes": "Hermes (experimental)",
 }

--- a/src/brigade/repos_cmd.py
+++ b/src/brigade/repos_cmd.py
@@ -15,7 +15,7 @@ from typing import Any
 from uuid import uuid4
 
 from .install import apply_gitignore
-from .selection import Selection
+from .selection import Selection, WRITER_INBOXES
 from . import toml_compat as tomllib, work_cmd
 
 OK = "ok"
@@ -666,7 +666,7 @@ def _repo_summary(entry: RepoEntry) -> dict[str, Any]:
     has_claude = (repo / "CLAUDE.md").is_file() or (repo / ".claude" / "CLAUDE.md").is_file()
     handoff_inboxes = [
         inbox
-        for inbox in (".claude/memory-handoffs", ".codex/memory-handoffs")
+        for inbox in WRITER_INBOXES.values()
         if (repo / inbox).is_dir()
     ]
     handoff_pending, handoff_backlog_oldest_days = _handoff_backlog(repo)

--- a/src/brigade/security_cmd.py
+++ b/src/brigade/security_cmd.py
@@ -71,6 +71,10 @@ SKIP_DIRS = {
     "node_modules",
 }
 
+# The `*/memory-handoffs` entries must stay in sync with
+# selection.WRITER_INBOXES (untrusted handoff content is skipped by the scanner
+# so it is not flagged as repo-author injection). test_skip_prefixes_cover_all_
+# writer_inboxes guards this hand-maintained literal against drift.
 SKIP_PREFIXES = (
     (".brigade", "runs"),
     (".brigade", "security"),

--- a/src/brigade/security_cmd.py
+++ b/src/brigade/security_cmd.py
@@ -77,6 +77,7 @@ SKIP_PREFIXES = (
     (".brigade", "work"),
     (".claude", "memory-handoffs"),
     (".codex", "memory-handoffs"),
+    (".opencode", "memory-handoffs"),
 )
 
 TEXT_SUFFIXES = {

--- a/src/brigade/selection.py
+++ b/src/brigade/selection.py
@@ -6,7 +6,14 @@ from typing import List, Optional
 
 
 KNOWN_DEPTHS = ("repo", "workspace")
-KNOWN_HARNESSES = ("claude", "codex", "openclaw", "hermes")
+KNOWN_HARNESSES = ("claude", "codex", "opencode", "openclaw", "hermes")
+# Writer harness id -> repo-relative handoff inbox dir. Single source of truth;
+# install, ingest, doctor, the fleet sweep, and the handoff doctor consume this.
+WRITER_INBOXES = {
+    "claude": ".claude/memory-handoffs",
+    "codex": ".codex/memory-handoffs",
+    "opencode": ".opencode/memory-handoffs",
+}
 KNOWN_INCLUDES = ("publisher",)
 
 # Higher priority owners come first. The first harness in this list that

--- a/src/brigade/templates/handoff/handoff-sources.example.json
+++ b/src/brigade/templates/handoff/handoff-sources.example.json
@@ -20,7 +20,8 @@
       "root": ".",
       "inboxes": [
         ".claude/memory-handoffs",
-        ".codex/memory-handoffs"
+        ".codex/memory-handoffs",
+        ".opencode/memory-handoffs"
       ]
     }
   ]

--- a/src/brigade/templates/harnesses/opencode.json
+++ b/src/brigade/templates/harnesses/opencode.json
@@ -1,0 +1,11 @@
+{
+  "id": "opencode",
+  "role": "writer",
+  "description": "OpenCode handoff inbox. (AGENTS.md is in the depth baseline; no separate bridge file today.)",
+  "files": [
+    {"src": "opencode/memory-handoffs/TEMPLATE.md", "dst": ".opencode/memory-handoffs/TEMPLATE.md"}
+  ],
+  "dirs": [
+    ".opencode/memory-handoffs/processed"
+  ]
+}

--- a/src/brigade/templates/opencode/memory-handoffs/TEMPLATE.md
+++ b/src/brigade/templates/opencode/memory-handoffs/TEMPLATE.md
@@ -1,0 +1,64 @@
+# Memory Handoff
+
+## Type
+
+setup | workflow | bugfix | decision | security | preference | research | project-context
+
+## Title
+
+Short, specific title. No private identifiers.
+
+## Summary
+
+2-4 sentences. What happened and why it matters for future sessions.
+
+## Durable facts
+
+- Fact 1
+- Fact 2
+- Fact 3
+
+## Evidence
+
+- files changed: `path/to/file`
+- commands run: `the exact command`
+- error strings: `verbatim error`
+
+## Recommended memory action
+
+create-card | update-card | no-card
+
+Choose exactly one branch below, then delete the other branch before saving.
+Card actions must omit document sections entirely. `no-card` actions must omit card sections entirely.
+
+<!-- CARD ACTION BRANCH: keep only for create-card or update-card. -->
+
+## Target card
+
+card-name-if-known.md
+
+## Suggested card content
+
+If `create-card` or `update-card`, paste the exact card content here. Must start with YAML frontmatter:
+
+```markdown
+---
+topic: ...
+category: ...
+tags: [list]
+---
+
+# Card title
+
+Card body. Use ### or deeper for subsections; ## headings parse as new handoff sections.
+```
+
+<!-- NO-CARD ACTION BRANCH: keep only for no-card. -->
+
+## Target document
+
+If `no-card`, name one of: `TOOLS.md` | `USER.md` | `rules/<name>.md` | `.learnings/LEARNINGS.md` | `.learnings/ERRORS.md` | `.learnings/FEATURE_REQUESTS.md`
+
+## Suggested document content
+
+If `no-card`, the exact text to append. No `##` headings (use `###` or deeper).

--- a/tests/test_handoff_cmd.py
+++ b/tests/test_handoff_cmd.py
@@ -1275,3 +1275,15 @@ def test_doctor_checks_no_backlog_warn_for_fresh_pending(tmp_path):
         c for c in checks if c[1] == "handoff_backlog" and c[0] == handoff_cmd.WARN
     ]
     assert not backlog_warns, "fresh pending handoff should not trip the stale backlog warning"
+
+
+def test_handoff_writer_inboxes_include_opencode():
+    from brigade import handoff_cmd
+    assert ".opencode/memory-handoffs" in handoff_cmd.WRITER_INBOXES
+
+
+def test_handoff_sources_example_lists_opencode():
+    import json
+    from brigade.templates import template_root
+    data = json.loads((template_root() / "handoff" / "handoff-sources.example.json").read_text())
+    assert ".opencode/memory-handoffs" in data["sources"][0]["inboxes"]

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -295,6 +295,36 @@ def test_ingest_scans_multiple_writer_inboxes(tmp_path):
     assert "- codex entry" in tools
 
 
+def test_opencode_handoff_is_ingested(tmp_target: Path):
+    from brigade.install import install_selection
+    from brigade.selection import Selection
+    install_selection(tmp_target, Selection(depth="workspace", harnesses=["opencode"], owner="opencode", includes=[]))
+    inbox = tmp_target / ".opencode" / "memory-handoffs"
+    _write_handoff(
+        inbox,
+        "2026-06-02-1200-opencode.md",
+        """\
+        # Memory Handoff
+
+        ## Recommended memory action
+        create-card
+
+        ## Target card
+        opencode-test.md
+
+        ## Suggested card content
+        ---
+        topic: opencode-test
+        ---
+        body line
+        """,
+    )
+    rc = ingest_mod.run(target=tmp_target, dry_run=False, promote_cards=True, route_documents=True)
+    assert rc == 0
+    assert (tmp_target / "memory" / "cards" / "opencode-test.md").is_file()
+    assert (inbox / "processed" / "2026-06-02-1200-opencode.md").is_file()
+
+
 def test_no_card_route_to_bootstrap_file_over_budget_goes_to_inbox(tmp_target: Path):
     """A route that would push a bootstrap file past its budget must inbox, not append."""
     from brigade import budgets

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -81,6 +81,19 @@ def test_install_selection_writes_config(tmp_path):
     assert cfg.selection.includes == ["publisher"]
 
 
+def test_opencode_install_creates_inbox_and_gitignore(tmp_path):
+    from brigade.install import install_selection, build_gitignore_block
+    from brigade.selection import Selection
+    sel = Selection(depth="repo", harnesses=["opencode"], owner="opencode", includes=[])
+    rc = install_selection(tmp_path, sel)
+    assert rc == 0
+    assert (tmp_path / ".opencode" / "memory-handoffs" / "TEMPLATE.md").is_file()
+    assert (tmp_path / ".opencode" / "memory-handoffs" / "processed").is_dir()
+    block = build_gitignore_block(sel)
+    assert ".opencode/memory-handoffs/*" in block
+    assert "!.opencode/memory-handoffs/TEMPLATE.md" in block
+
+
 def test_install_selection_refuses_overwrite_without_force(tmp_path):
     sel = Selection(depth="repo", harnesses=["claude"], owner="claude", includes=[])
     install_selection(tmp_path, sel)

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -21,10 +21,11 @@ def test_prompt_returns_defaults_on_empty_input(monkeypatch, capsys):
 def test_prompt_toggles_codex_and_openclaw(monkeypatch):
     """User types '2 3' to toggle codex and openclaw on (claude was default on)."""
     # Toggle loop re-prompts after each non-empty input; blank line confirms.
-    # Harness: '2 3' toggles codex+openclaw on, blank line confirms.
+    # Harness: '2 4' toggles codex+openclaw on, blank line confirms.
+    # (order is claude, codex, opencode, openclaw, hermes)
     # Depth: '2' picks workspace.
     # Includes: blank line confirms empty selection.
-    monkeypatch.setattr("sys.stdin", io.StringIO("2 3\n\n2\n\n"))
+    monkeypatch.setattr("sys.stdin", io.StringIO("2 4\n\n2\n\n"))
     monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
     sel = prompt_for_selection()
     assert set(sel.harnesses) == {"claude", "codex", "openclaw"}

--- a/tests/test_repos_cmd.py
+++ b/tests/test_repos_cmd.py
@@ -251,3 +251,12 @@ def test_repos_ingest_routes_fleet_handoffs_into_owner(tmp_path, capsys):
     assert (owner / "memory" / "cards" / "fleet-note.md").is_file()
     assert (inbox / "processed" / "note.md").is_file()
     assert not (inbox / "note.md").exists()
+
+
+def test_repo_summary_counts_opencode_inbox(tmp_path):
+    from brigade import repos_cmd
+
+    (tmp_path / ".opencode" / "memory-handoffs").mkdir(parents=True)
+    entry = repos_cmd.RepoEntry(repo_id="r1", label="R1", path=tmp_path)
+    summary = repos_cmd._repo_summary(entry)
+    assert ".opencode/memory-handoffs" in summary["handoff_inboxes"]

--- a/tests/test_security_cmd.py
+++ b/tests/test_security_cmd.py
@@ -761,3 +761,12 @@ def test_security_init_cli(tmp_path, monkeypatch):
     monkeypatch.setattr(security_cmd, "init", fake_init)
     assert cli.main(["security", "init", "--target", str(tmp_path), "--force"]) == 0
     assert seen == {"target": tmp_path, "force": True}
+
+
+def test_skip_prefixes_cover_all_writer_inboxes():
+    from brigade.security_cmd import SKIP_PREFIXES
+    from brigade.selection import WRITER_INBOXES
+
+    for rel in WRITER_INBOXES.values():
+        parts = tuple(rel.split("/"))
+        assert parts in SKIP_PREFIXES, f"{rel} not skipped by security scan"

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -5,8 +5,21 @@ from brigade.selection import (
     KNOWN_HARNESSES,
     KNOWN_DEPTHS,
     KNOWN_INCLUDES,
+    WRITER_INBOXES,
     resolve_owner,
 )
+
+
+def test_opencode_is_a_known_harness():
+    from brigade.selection import KNOWN_HARNESSES, WRITER_INBOXES
+    assert "opencode" in KNOWN_HARNESSES
+    assert WRITER_INBOXES["opencode"] == ".opencode/memory-handoffs"
+
+
+def test_writer_inboxes_cover_known_writers():
+    from brigade.selection import WRITER_INBOXES
+    assert WRITER_INBOXES["claude"] == ".claude/memory-handoffs"
+    assert WRITER_INBOXES["codex"] == ".codex/memory-handoffs"
 
 
 def test_harness_priority_order():
@@ -71,6 +84,6 @@ def test_selection_validate_accepts_this_repo_owner_with_empty_harnesses():
 
 
 def test_known_constants():
-    assert set(KNOWN_HARNESSES) == {"claude", "codex", "openclaw", "hermes"}
+    assert set(KNOWN_HARNESSES) == {"claude", "codex", "opencode", "openclaw", "hermes"}
     assert set(KNOWN_DEPTHS) == {"repo", "workspace"}
     assert set(KNOWN_INCLUDES) == {"publisher"}


### PR DESCRIPTION
## Summary

Makes `.opencode/memory-handoffs/` a first-class built-in handoff source everywhere Claude/Codex already are, so OpenCode handoffs ingest with no manual `--handoff-inbox` flag. Also centralizes the previously-triplicated writer-inbox map into `brigade.selection.WRITER_INBOXES` (the same drift trap that caused two separate bugs earlier this week).

Design spec: `docs/superpowers/specs/2026-06-02-opencode-handoff-source-design.md`
Plan: `docs/superpowers/plans/2026-06-02-opencode-handoff-source.md`

## What changed

- `selection.py`: `opencode` added to `KNOWN_HARNESSES`; new canonical `WRITER_INBOXES` dict.
- `install.py`, `ingest.py`, `doctor.py`: drop their local duplicate maps and consume the canonical one.
- `repos_cmd.py` (fleet sweep) and `handoff_cmd.py` (handoff doctor source coverage) derive their inbox lists from the canonical map.
- `security_cmd.py`: `.opencode/memory-handoffs` added to `SKIP_PREFIXES`, with a drift-guard test asserting every `WRITER_INBOXES` value is skipped.
- New `templates/harnesses/opencode.json` manifest + `templates/opencode/memory-handoffs/TEMPLATE.md`.
- `prompt.py` interactive selector + `cli.py --harnesses` help + `handoff-sources.example.json` list OpenCode.

## Testing

- Unit tests across selection, install, ingest (end-to-end), repos, security, handoff doctor, selector.
- Full suite: 775 passed.
- **Live dogfood:** `brigade init --harnesses opencode` scaffolded `.opencode/memory-handoffs/`; OpenCode (gpt-oss:120b) wrote a handoff into it; `brigade ingest --promote-cards` promoted it to a memory card and archived the handoff to `processed/`. No manual flag.

## Review

Final review: APPROVE-WITH-NITS, no correctness/centralization/regression blockers; one nit (a comment tying `SKIP_PREFIXES` to the guard test) folded in.

## Note

The roadmap item was added in a prior PR and is flipped to implemented here.