### PR TITLE
feat(pantry): add agentpantry setup planning

### DIFF
--- a/README.md
+++ b/README.md
@@ -840,8 +840,10 @@ brigade add pantry   # agentpantry
 
 `pantry` (alias `larder`) is the agent session auth sync station.
 `brigade add pantry` installs agentpantry via `go install github.com/escoffier-labs/agentpantry/cmd/agentpantry@latest`.
-`brigade doctor` and `brigade status` health-check it by shelling out to `agentpantry status --json`.
-Like the memory satellites, agentpantry inspects host-global state, so its checks are advisory and never FAIL a workspace run: an unwired install (exit 2, no config) is a `WARN`, a missing pre-shared key is a `WARN`, otherwise `OK`.
+`brigade doctor` health-checks it by shelling out to `agentpantry doctor --json` with a compatibility fallback to `agentpantry status --json`.
+Like the memory satellites, agentpantry inspects host-global state, so its checks are advisory and never FAIL a workspace run: an unwired install (exit 2, no config) is a `WARN`, and setup problems are surfaced as advisory pantry health.
+Use `brigade pantry status` for a pantry-specific status readout, `brigade pantry setup plan --role source|sink` to preview or write a reviewed setup plan, and `brigade pantry service plan --role source|sink` to preview or write service setup steps.
+These plan commands do not generate or copy PSKs, start services, or mutate browser, GitHub, OpenClaw, or other auth files.
 
 Security commands:
 
@@ -901,6 +903,7 @@ The current managed tools:
 | `memory` | `bootstrap-doctor` | bootstrap-file size and limit audit |
 | `guard` | `content-guard` | policy-driven content scanning |
 | `tokens` | `tokenjuice` | output compaction via host hooks |
+| `pantry` | `agentpantry` | browser session and secret sync for agent hosts |
 
 `brigade doctor` folds installed tools into its report and surfaces each tool's own health.
 A missing optional tool is not a failure.

--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -25,6 +25,7 @@ brigade roadmap commands --write
 - `brigade learn`: 10 command path(s)
 - `brigade memory`: 7 command path(s)
 - `brigade openclaw-fragments`: 1 command path(s)
+- `brigade pantry`: 3 command path(s)
 - `brigade projects`: 9 command path(s)
 - `brigade reconfigure`: 1 command path(s)
 - `brigade release`: 22 command path(s)
@@ -149,6 +150,9 @@ brigade roadmap commands --write
 - `brigade memory care scan`
 - `brigade memory care status`
 - `brigade openclaw-fragments`
+- `brigade pantry service plan`
+- `brigade pantry setup plan`
+- `brigade pantry status`
 - `brigade projects audit`
 - `brigade projects closeout`
 - `brigade projects closeout-show`

--- a/src/brigade/cli.py
+++ b/src/brigade/cli.py
@@ -185,6 +185,34 @@ def _build_parser() -> argparse.ArgumentParser:
     p_add.add_argument("station", help="Station to add tools for (e.g. memory, guard, tokens).")
     p_add.add_argument("--target", "-t", type=Path, default=Path("."))
 
+    # pantry
+    p_pantry = sub.add_parser("pantry", help="Inspect and plan agentpantry session-auth sync.")
+    pantry_sub = p_pantry.add_subparsers(dest="pantry_command", metavar="<pantry-command>")
+    pantry_sub.required = True
+    p_pantry_status = pantry_sub.add_parser("status", help="Show agentpantry status and advisory health.")
+    p_pantry_status.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
+    p_pantry_status.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_pantry_setup = pantry_sub.add_parser("setup", help="Plan source or sink setup without applying it.")
+    pantry_setup_sub = p_pantry_setup.add_subparsers(dest="pantry_setup_command", metavar="<setup-command>")
+    pantry_setup_sub.required = True
+    p_pantry_setup_plan = pantry_setup_sub.add_parser("plan", help="Plan agentpantry source or sink setup.")
+    p_pantry_setup_plan.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update when --write is used.")
+    p_pantry_setup_plan.add_argument("--role", choices=["source", "sink"], required=True, help="agentpantry role to plan.")
+    p_pantry_setup_plan.add_argument("--peer", default="127.0.0.1:8787", help="Peer/bind address to document in the plan.")
+    p_pantry_setup_plan.add_argument("--config-path", default="~/.config/agentpantry/config.toml", help="agentpantry config path to document.")
+    p_pantry_setup_plan.add_argument("--key-path", default="~/.config/agentpantry/psk.key", help="agentpantry PSK path to document.")
+    p_pantry_setup_plan.add_argument("--write", action="store_true", help="Write a local reviewed plan under .brigade/pantry/plans/.")
+    p_pantry_setup_plan.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_pantry_service = pantry_sub.add_parser("service", help="Plan service setup without starting services.")
+    pantry_service_sub = p_pantry_service.add_subparsers(dest="pantry_service_command", metavar="<service-command>")
+    pantry_service_sub.required = True
+    p_pantry_service_plan = pantry_service_sub.add_parser("plan", help="Plan agentpantry service installation.")
+    p_pantry_service_plan.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update when --write is used.")
+    p_pantry_service_plan.add_argument("--role", choices=["source", "sink"], required=True, help="agentpantry role to document.")
+    p_pantry_service_plan.add_argument("--config-path", default="~/.config/agentpantry/config.toml", help="agentpantry config path to document.")
+    p_pantry_service_plan.add_argument("--write", action="store_true", help="Write a local reviewed plan under .brigade/pantry/plans/.")
+    p_pantry_service_plan.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+
     # dogfood
     p_dogfood = sub.add_parser("dogfood", help="Run a safe Codex-only Brigade dogfood review.")
     p_dogfood.add_argument(
@@ -2433,6 +2461,37 @@ def main(argv=None) -> int:
         from . import add as add_mod
 
         return add_mod.run(target=args.target, station=args.station)
+    if cmd == "pantry":
+        from . import pantry_cmd
+
+        if args.pantry_command == "status":
+            return pantry_cmd.status(target=args.target, json_output=args.json)
+        if args.pantry_command == "setup":
+            if args.pantry_setup_command == "plan":
+                return pantry_cmd.setup_plan(
+                    target=args.target,
+                    role=args.role,
+                    peer=args.peer,
+                    config_path=args.config_path,
+                    key_path=args.key_path,
+                    write=args.write,
+                    json_output=args.json,
+                )
+            parser.error(f"unknown pantry setup command: {args.pantry_setup_command}")
+            return 2
+        if args.pantry_command == "service":
+            if args.pantry_service_command == "plan":
+                return pantry_cmd.service_plan(
+                    target=args.target,
+                    role=args.role,
+                    config_path=args.config_path,
+                    write=args.write,
+                    json_output=args.json,
+                )
+            parser.error(f"unknown pantry service command: {args.pantry_service_command}")
+            return 2
+        parser.error(f"unknown pantry command: {args.pantry_command}")
+        return 2
     if cmd == "dogfood":
         from . import dogfood_cmd
 

--- a/src/brigade/managed.py
+++ b/src/brigade/managed.py
@@ -97,6 +97,36 @@ def _tokenjuice_doctor(ctx: DoctorContext) -> List[CheckResult]:
 # workspace doctor run.
 def _agentpantry_doctor(ctx: DoctorContext) -> List[CheckResult]:
     name = "agentpantry (session auth sync)"
+    r = proc.run(["agentpantry", "doctor", "--json"])
+    data = r.json()
+    if data is not None:
+        if isinstance(data, dict) and data.get("configured") is False:
+            return [(WARN, name, "installed but unwired (no config)")]
+        if not isinstance(data, dict):
+            return [(WARN, name, f"unexpected doctor output (exit {r.code})")]
+        role = data.get("role") or "?"
+        peer = data.get("peer") or "?"
+        surfaces = data.get("surfaces") or []
+        fail_count = int(data.get("fail_count") or 0)
+        warn_count = int(data.get("warn_count") or 0)
+        status = WARN if fail_count or warn_count else OK
+        parts = [
+            f"role={role}",
+            f"peer={peer}",
+            f"surfaces={','.join(str(s) for s in surfaces) or 'none'}",
+            f"checks={fail_count} fail/{warn_count} warn",
+        ]
+        checks = data.get("checks")
+        if isinstance(checks, list):
+            top = next((row for row in checks if isinstance(row, dict) and row.get("status") == "FAIL"), None)
+            if top is None:
+                top = next((row for row in checks if isinstance(row, dict) and row.get("status") == "WARN"), None)
+            if top is not None:
+                parts.append(f"top={top.get('name')}: {str(top.get('detail') or '')[:80]}")
+        return [(status, name, ", ".join(parts))]
+
+    # Older agentpantry builds only expose `status --json`; keep the original
+    # shallow advisory path so Brigade remains compatible with those installs.
     r = proc.run(["agentpantry", "status", "--json"])
     if r.code == 2:
         return [(WARN, name, "installed but unwired (no config)")]

--- a/src/brigade/pantry_cmd.py
+++ b/src/brigade/pantry_cmd.py
@@ -1,0 +1,274 @@
+"""Pantry station commands for agentpantry integration.
+
+These commands deliberately plan and report. They do not generate keys, copy
+secret material, mutate auth files, or start services.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from . import proc
+
+
+DEFAULT_CONFIG_PATH = "~/.config/agentpantry/config.toml"
+DEFAULT_KEY_PATH = "~/.config/agentpantry/psk.key"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _safe_slug(value: str) -> str:
+    chars = [ch.lower() if ch.isalnum() else "-" for ch in value.strip()]
+    slug = "".join(chars).strip("-")
+    while "--" in slug:
+        slug = slug.replace("--", "-")
+    return slug or "plan"
+
+
+def _json_print(payload: dict[str, Any]) -> None:
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def _run_json(args: list[str]) -> dict[str, Any]:
+    result = proc.run(args)
+    data = result.json()
+    return {
+        "command": args,
+        "exit_code": result.code,
+        "stdout_json": data if isinstance(data, dict) else None,
+        "stdout_unparsed": None if isinstance(data, dict) else result.stdout[:500],
+        "stderr": result.stderr[:500],
+    }
+
+
+def _pantry_root(target: Path) -> Path:
+    return target / ".brigade" / "pantry"
+
+
+def status_payload(target: Path) -> dict[str, Any]:
+    installed = proc.which("agentpantry") is not None
+    payload: dict[str, Any] = {
+        "target": str(target),
+        "installed": installed,
+        "summary": "agentpantry not installed; run `brigade add pantry`",
+        "status": None,
+        "doctor": None,
+        "advisory": True,
+    }
+    if not installed:
+        return payload
+
+    status_result = _run_json(["agentpantry", "status", "--json"])
+    doctor_result = _run_json(["agentpantry", "doctor", "--json"])
+    payload["status"] = status_result
+    payload["doctor"] = doctor_result
+
+    status_data = status_result.get("stdout_json") or {}
+    doctor_data = doctor_result.get("stdout_json") or {}
+    if status_result["exit_code"] == 2 or doctor_data.get("configured") is False:
+        payload["summary"] = "agentpantry installed but unwired (no config)"
+        return payload
+    if not isinstance(status_data, dict) or not isinstance(doctor_data, dict):
+        payload["summary"] = "agentpantry installed but machine-readable output was incomplete"
+        return payload
+
+    fail_count = int(doctor_data.get("fail_count") or 0)
+    warn_count = int(doctor_data.get("warn_count") or 0)
+    role = status_data.get("role") or doctor_data.get("role") or "?"
+    peer = status_data.get("peer") or doctor_data.get("peer") or "?"
+    last_sync = status_data.get("last_sync") or "unknown"
+    payload["summary"] = (
+        f"role={role}, peer={peer}, last_sync={last_sync}, "
+        f"checks={fail_count} fail/{warn_count} warn"
+    )
+    return payload
+
+
+def status(*, target: Path, json_output: bool = False) -> int:
+    payload = status_payload(target)
+    if json_output:
+        _json_print(payload)
+        return 0
+    print(f"pantry: {payload['summary']}")
+    if not payload["installed"]:
+        return 0
+    status_data = ((payload.get("status") or {}).get("stdout_json") or {})
+    if isinstance(status_data, dict) and status_data:
+        print(f"role: {status_data.get('role') or '?'}")
+        print(f"peer: {status_data.get('peer') or '?'}")
+        print(f"surfaces: {', '.join(status_data.get('surfaces') or []) or 'none'}")
+        print(f"last_sync: {status_data.get('last_sync') or 'unknown'}")
+        print(f"last_counts: cookies={status_data.get('last_cookies', 0)} secrets={status_data.get('last_secrets', 0)}")
+    doctor_data = ((payload.get("doctor") or {}).get("stdout_json") or {})
+    if isinstance(doctor_data, dict) and doctor_data.get("checks"):
+        print("checks:")
+        for row in doctor_data.get("checks") or []:
+            if isinstance(row, dict):
+                print(f"- {row.get('status')}: {row.get('name')} - {row.get('detail')}")
+    return 0
+
+
+def setup_plan_payload(
+    *,
+    target: Path,
+    role: str,
+    peer: str,
+    config_path: str,
+    key_path: str,
+) -> dict[str, Any]:
+    commands = [
+        ["agentpantry", "init", "--role", role, "--config", config_path],
+    ]
+    if role == "sink":
+        commands.extend(
+            [
+                ["agentpantry", "keygen", "--out", key_path],
+                ["agentpantry", "doctor", "--config", config_path],
+                ["agentpantry", "sink", "--config", config_path],
+            ]
+        )
+        manual_steps = [
+            "Copy the generated PSK to the source machine over a secure channel.",
+            f"Edit {config_path}: set peer to {peer}, choose surfaces/adapters, and keep the sink bind loopback or VPN-scoped.",
+        ]
+    else:
+        commands.extend(
+            [
+                ["agentpantry", "doctor", "--config", config_path, "--no-net"],
+                ["agentpantry", "source", "--config", config_path],
+            ]
+        )
+        manual_steps = [
+            "Copy the sink-generated PSK into the configured key path on this source machine.",
+            f"Edit {config_path}: set peer to the sink address {peer}, add browser entries, and add explicit domain allow rules.",
+        ]
+    return {
+        "target": str(target),
+        "kind": "setup",
+        "created_at": _now(),
+        "role": role,
+        "peer": peer,
+        "config_path": config_path,
+        "key_path": key_path,
+        "commands": commands,
+        "manual_steps": manual_steps,
+        "boundaries": [
+            "Brigade does not generate or copy PSKs.",
+            "Brigade does not start agentpantry services.",
+            "Brigade does not mutate browser, GitHub, OpenClaw, or other auth files.",
+            "Run agentpantry doctor before starting source or sink.",
+        ],
+    }
+
+
+def service_plan_payload(*, target: Path, role: str, config_path: str) -> dict[str, Any]:
+    return {
+        "target": str(target),
+        "kind": "service",
+        "created_at": _now(),
+        "role": role,
+        "config_path": config_path,
+        "commands": [
+            ["agentpantry", "doctor", "--config", config_path],
+            ["agentpantry", "install-service", "--config", config_path],
+        ],
+        "manual_steps": [
+            "Review the systemd unit path or Windows Scheduled Task command printed by agentpantry.",
+            "Enable/start the service manually only after doctor is clean enough for your threat model.",
+        ],
+        "boundaries": [
+            "Brigade only plans service setup.",
+            "Brigade does not run systemctl, schtasks, or background services.",
+        ],
+    }
+
+
+def _render_plan_md(payload: dict[str, Any]) -> str:
+    lines = [
+        f"# agentpantry {payload['kind']} plan",
+        "",
+        f"- role: {payload.get('role')}",
+        f"- config: {payload.get('config_path')}",
+    ]
+    if payload.get("peer"):
+        lines.append(f"- peer: {payload.get('peer')}")
+    if payload.get("key_path"):
+        lines.append(f"- key: {payload.get('key_path')}")
+    lines.extend(["", "## Commands", ""])
+    for command in payload.get("commands") or []:
+        lines.append("```sh")
+        lines.append(" ".join(str(part) for part in command))
+        lines.append("```")
+        lines.append("")
+    lines.extend(["## Manual Steps", ""])
+    for step in payload.get("manual_steps") or []:
+        lines.append(f"- {step}")
+    lines.extend(["", "## Boundaries", ""])
+    for boundary in payload.get("boundaries") or []:
+        lines.append(f"- {boundary}")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _write_plan(target: Path, payload: dict[str, Any]) -> dict[str, Any]:
+    created = str(payload.get("created_at") or _now())
+    stamp = created.replace(":", "").replace("+", "Z").replace(".", "-")
+    plan_id = f"{stamp}-{_safe_slug(str(payload.get('kind')))}-{_safe_slug(str(payload.get('role')))}"
+    plan_dir = _pantry_root(target) / "plans" / plan_id
+    plan_dir.mkdir(parents=True, exist_ok=True)
+    json_path = plan_dir / "plan.json"
+    md_path = plan_dir / "PLAN.md"
+    payload = dict(payload)
+    payload["plan_id"] = plan_id
+    payload["plan_path"] = str(md_path)
+    payload["receipt_path"] = str(json_path)
+    json_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    md_path.write_text(_render_plan_md(payload))
+    return payload
+
+
+def setup_plan(
+    *,
+    target: Path,
+    role: str,
+    peer: str,
+    config_path: str = DEFAULT_CONFIG_PATH,
+    key_path: str = DEFAULT_KEY_PATH,
+    write: bool = False,
+    json_output: bool = False,
+) -> int:
+    payload = setup_plan_payload(target=target, role=role, peer=peer, config_path=config_path, key_path=key_path)
+    if write:
+        payload = _write_plan(target, payload)
+    if json_output:
+        _json_print(payload)
+        return 0
+    if write:
+        print(f"wrote pantry setup plan: {payload['plan_path']}")
+    else:
+        print(_render_plan_md(payload), end="")
+    return 0
+
+
+def service_plan(
+    *,
+    target: Path,
+    role: str,
+    config_path: str = DEFAULT_CONFIG_PATH,
+    write: bool = False,
+    json_output: bool = False,
+) -> int:
+    payload = service_plan_payload(target=target, role=role, config_path=config_path)
+    if write:
+        payload = _write_plan(target, payload)
+    if json_output:
+        _json_print(payload)
+        return 0
+    if write:
+        print(f"wrote pantry service plan: {payload['plan_path']}")
+    else:
+        print(_render_plan_md(payload), end="")
+    return 0

--- a/tests/test_managed.py
+++ b/tests/test_managed.py
@@ -62,7 +62,8 @@ def test_agentpantry_doctor_unwired(monkeypatch):
     assert t is not None and t.station == "pantry"
 
     def fake_run(args, **kw):
-        return managed.proc.Result(code=2, stdout="", stderr="unwired: no config")
+        assert args == ["agentpantry", "doctor", "--json"]
+        return managed.proc.Result(code=2, stdout='{"configured": false, "fail_count": 1, "warn_count": 0, "checks": []}', stderr="")
 
     monkeypatch.setattr(managed.proc, "run", fake_run)
     ctx = DoctorContext(target=Path("/tmp/ws"), selection=None, harnesses=[])
@@ -74,11 +75,12 @@ def test_agentpantry_doctor_parses_status(monkeypatch):
     t = managed.resolve("agentpantry")
 
     def fake_run(args, **kw):
+        assert args == ["agentpantry", "doctor", "--json"]
         return managed.proc.Result(
             code=0,
             stdout='{"role": "source", "configured": true, "peer": "127.0.0.1:8787",'
-                   ' "key_present": true, "surfaces": ["sidecar"], "browsers": 1,'
-                   ' "allow": [], "deny": []}',
+                   ' "surfaces": ["sidecar"], "browser_count": 1,'
+                   ' "fail_count": 0, "warn_count": 0, "checks": []}',
             stderr="",
         )
 
@@ -89,15 +91,17 @@ def test_agentpantry_doctor_parses_status(monkeypatch):
 
 
 def test_agentpantry_never_fails_workspace(monkeypatch):
-    # Advisory/operator-scoped: missing key is at most a WARN, never FAIL.
+    # Advisory/operator-scoped: agentpantry FAIL checks become Brigade WARNs.
     t = managed.resolve("agentpantry")
 
     def fake_run(args, **kw):
+        assert args == ["agentpantry", "doctor", "--json"]
         return managed.proc.Result(
-            code=0,
+            code=1,
             stdout='{"role": "sink", "configured": true, "peer": "0.0.0.0:8787",'
-                   ' "key_present": false, "surfaces": ["sidecar"], "browsers": 0,'
-                   ' "allow": [], "deny": []}',
+                   ' "surfaces": ["sidecar"], "browser_count": 0,'
+                   ' "fail_count": 1, "warn_count": 1,'
+                   ' "checks": [{"name": "key", "status": "FAIL", "detail": "PSK not found"}]}',
             stderr="",
         )
 
@@ -112,8 +116,12 @@ def test_agentpantry_doctor_handles_garbage_output(monkeypatch):
     # A misbehaving binary (non-2 exit, non-JSON stdout) must degrade to WARN,
     # never throw - the doctor loop runs adapters unguarded.
     t = managed.resolve("agentpantry")
+    calls = []
 
     def fake_run(args, **kw):
+        calls.append(args)
+        if args == ["agentpantry", "status", "--json"]:
+            return managed.proc.Result(code=1, stdout="boom", stderr="kaboom")
         return managed.proc.Result(code=1, stdout="boom", stderr="kaboom")
 
     monkeypatch.setattr(managed.proc, "run", fake_run)
@@ -121,3 +129,27 @@ def test_agentpantry_doctor_handles_garbage_output(monkeypatch):
     results = t.doctor(ctx)
     assert any(status == "WARN" and "unexpected output" in detail for status, _, detail in results)
     assert all(status != "FAIL" for status, _, _ in results)
+    assert calls == [["agentpantry", "doctor", "--json"], ["agentpantry", "status", "--json"]]
+
+
+def test_agentpantry_doctor_falls_back_to_status_for_old_binary(monkeypatch):
+    t = managed.resolve("agentpantry")
+    calls = []
+
+    def fake_run(args, **kw):
+        calls.append(args)
+        if args == ["agentpantry", "doctor", "--json"]:
+            return managed.proc.Result(code=2, stdout="", stderr="flag provided but not defined: -json")
+        return managed.proc.Result(
+            code=0,
+            stdout='{"role": "sink", "configured": true, "peer": "127.0.0.1:8787",'
+                   ' "key_present": true, "surfaces": ["sidecar"], "browsers": 0,'
+                   ' "allow": [], "deny": []}',
+            stderr="",
+        )
+
+    monkeypatch.setattr(managed.proc, "run", fake_run)
+    ctx = DoctorContext(target=Path("/tmp/ws"), selection=None, harnesses=[])
+    results = t.doctor(ctx)
+    assert any(status == "OK" and "role=sink" in detail for status, _, detail in results)
+    assert calls == [["agentpantry", "doctor", "--json"], ["agentpantry", "status", "--json"]]

--- a/tests/test_pantry_cmd.py
+++ b/tests/test_pantry_cmd.py
@@ -1,0 +1,78 @@
+import json
+
+from brigade import pantry_cmd
+
+
+def test_pantry_status_reports_uninstalled(monkeypatch, tmp_path):
+    monkeypatch.setattr(pantry_cmd.proc, "which", lambda cmd: None)
+
+    payload = pantry_cmd.status_payload(tmp_path)
+
+    assert payload["installed"] is False
+    assert "brigade add pantry" in payload["summary"]
+
+
+def test_pantry_status_combines_status_and_doctor(monkeypatch, tmp_path):
+    monkeypatch.setattr(pantry_cmd.proc, "which", lambda cmd: "/x/agentpantry")
+
+    def fake_run(args, **kw):
+        if args == ["agentpantry", "status", "--json"]:
+            return pantry_cmd.proc.Result(
+                0,
+                json.dumps(
+                    {
+                        "role": "sink",
+                        "peer": "127.0.0.1:8787",
+                        "surfaces": ["sidecar"],
+                        "last_sync": "never",
+                        "last_cookies": 0,
+                        "last_secrets": 0,
+                    }
+                ),
+                "",
+            )
+        if args == ["agentpantry", "doctor", "--json"]:
+            return pantry_cmd.proc.Result(0, json.dumps({"configured": True, "fail_count": 0, "warn_count": 1, "checks": []}), "")
+        raise AssertionError(args)
+
+    monkeypatch.setattr(pantry_cmd.proc, "run", fake_run)
+
+    payload = pantry_cmd.status_payload(tmp_path)
+
+    assert payload["installed"] is True
+    assert "role=sink" in payload["summary"]
+    assert "0 fail/1 warn" in payload["summary"]
+
+
+def test_setup_plan_is_review_only(tmp_path):
+    payload = pantry_cmd.setup_plan_payload(
+        target=tmp_path,
+        role="sink",
+        peer="127.0.0.1:8787",
+        config_path="~/.config/agentpantry/config.toml",
+        key_path="~/.config/agentpantry/psk.key",
+    )
+
+    rendered = pantry_cmd._render_plan_md(payload)
+
+    assert ["agentpantry", "keygen", "--out", "~/.config/agentpantry/psk.key"] in payload["commands"]
+    assert "Brigade does not generate or copy PSKs." in payload["boundaries"]
+    assert "agentpantry sink --config ~/.config/agentpantry/config.toml" in rendered
+
+
+def test_setup_plan_write_creates_json_and_markdown(tmp_path):
+    rc = pantry_cmd.setup_plan(
+        target=tmp_path,
+        role="source",
+        peer="sink.example:8787",
+        write=True,
+        json_output=True,
+    )
+
+    assert rc == 0
+    plans = list((tmp_path / ".brigade" / "pantry" / "plans").glob("*/plan.json"))
+    assert len(plans) == 1
+    payload = json.loads(plans[0].read_text())
+    assert payload["role"] == "source"
+    assert "receipt_path" in payload
+    assert (plans[0].parent / "PLAN.md").exists()


### PR DESCRIPTION
## Summary
- parse agentpantry doctor JSON for advisory pantry health
- add brigade pantry status and setup/service planning commands
- document the pantry command surface and update command inventory

## Test Plan
- python3 -m pytest tests/test_pantry_cmd.py tests/test_managed.py tests/test_registry.py -q
- python3 -m brigade roadmap commands --check