### PR TITLE
feat(evidence): wire miseledger family into managed-tool registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- New `evidence` station (alias `ledger`) wiring the MiseLedger family of managed tools: `miseledger` (local-first evidence ledger, doctored via `status --json`), `stationtrail` (agent-session log exporter, doctored via `doctor --json`), and `sourceharvest` (source-system record exporter, presence-checked via `version`). All three install from `github.com/escoffier-labs/...` and are advisory: they inspect host-global state and never FAIL a workspace doctor run.
+
 ### Changed
+- Corrected stale `github.com/solomonneas/...` install URLs and doc links for `content-guard`, `agent-notify`, and `solos-cookbook` to their actual `escoffier-labs` org, so `brigade add` installs from the right repos.
 - Internal refactor, no behavior change: shared helpers extracted into `brigade.localio` (JSON/JSONL/timestamps/hashes/slugs), `brigade.actionqueue` (action-queue lifecycle for center/repos/release stations), and `brigade.reportstore` (report-bundle lifecycle for center, repos, release candidates, and fleet release trains); and the 11.8k-line `work_cmd` module is now a package (`constants`, `helpers`, `ledger`, `config`, `services`, `session`) behind an explicit re-export facade guarded by a frozen surface test. Station variants with genuinely different semantics (phases actions/reports, release-train privacy conventions) intentionally stay local.
 
 ## [0.9.3] - 2026-06-09

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Brigade
 
-Brigade is the local-first operator CLI for agent memory, handoffs, and reviewable work receipts. It grew out of [Solomon's Cookbook](https://github.com/solomonneas/solos-cookbook), and patches are welcome. Before you start, please skim this file so we both spend our time on the right things.
+Brigade is the local-first operator CLI for agent memory, handoffs, and reviewable work receipts. It grew out of [Solomon's Cookbook](https://github.com/escoffier-labs/solos-cookbook), and patches are welcome. Before you start, please skim this file so we both spend our time on the right things.
 
 ## What kinds of changes land easily
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -96,11 +96,11 @@ brigade reconfigure --target . --harnesses claude --prune
 
 The starter handoff template lives at `<inbox>/TEMPLATE.md`. Copy it to a new dated file (e.g. `2026-05-16-1430-fixed-X.md`), fill it in, and the ingester promotes safe card handoffs into `memory/cards/`, appends targeted updates to the right file, and kicks ambiguous material to the review inbox.
 
-See the [Solo Cookbook](https://github.com/solomonneas/solos-cookbook) for the longer-form guidance on what makes a good handoff and when to use which routing.
+See the [Solo Cookbook](https://github.com/escoffier-labs/solos-cookbook) for the longer-form guidance on what makes a good handoff and when to use which routing.
 
 ## Next steps
 
-- Read [the cookbook](https://github.com/solomonneas/solos-cookbook) for the deep version of every concept here.
+- Read [the cookbook](https://github.com/escoffier-labs/solos-cookbook) for the deep version of every concept here.
 - Customize `USER.md` and `TOOLS.md` with your real preferences and runbooks (kept private; do not commit personal details).
 - Wire the ingester on a cron or a manual end-of-day workflow.
 - Add a memory-care staleness scan when your card set starts to matter. See `memory/cards/memory-care-staleness.md`.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ So I hand-rolled the fixes, one incident at a time: a slim `MEMORY.md` index poi
 
 Two incidents shaped the design more than anything I planned. First, a nightly "dreaming" job that auto-promoted session fragments quietly bloated `MEMORY.md` to 41KB, way past the 12KB bootstrap budget, so every session started with truncated memory and nobody noticed for weeks. Auto-promotion died that day. Everything goes through review now. Second, I found 195 handoff notes sitting unread across 35 repos because the ingester had a hardcoded three-repo allowlist and nothing warned about the coverage gap. Silence is the failure mode. Every part of Brigade that lints, warns, or writes a receipt exists because something once failed quietly.
 
-That system now runs 482 memory cards and survives daily multi-agent work. But explaining it to anyone meant: clone six repos, write these crons, keep your index slim, watch for staleness, and whatever you do, turn auto-promotion off. Brigade is that setup packaged as one installable CLI. The full production stack is documented in the [solos-cookbook](https://github.com/solomonneas/solos-cookbook) if you want to see where it came from.
+That system now runs 482 memory cards and survives daily multi-agent work. But explaining it to anyone meant: clone six repos, write these crons, keep your index slim, watch for staleness, and whatever you do, turn auto-promotion off. Brigade is that setup packaged as one installable CLI. The full production stack is documented in the [solos-cookbook](https://github.com/escoffier-labs/solos-cookbook) if you want to see where it came from.
 
 ## The loop
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,7 +26,7 @@ You should get an acknowledgment within 72 hours. If you do not, please follow u
 ## Out of scope
 
 - Bugs in `content-guard` itself - please report those upstream at
-  <https://github.com/solomonneas/content-guard>.
+  <https://github.com/escoffier-labs/content-guard>.
 - Bugs in OpenClaw, Hermes, Claude Code, or Codex - report those to their respective projects.
 - Issues that require an attacker to already have write access to the user's machine, harness config, or PyPI account.
 - Memory cards or handoffs that a user wrote and committed themselves. solo-mise provides scaffolding and guardrails, not perfect content review.

--- a/docs/announcement-post.md
+++ b/docs/announcement-post.md
@@ -24,7 +24,7 @@ Install: `pipx install brigade-cli` - then `brigade operator quickstart --target
 
 Repo: https://github.com/escoffier-labs/brigade
 Site: https://brigade.tools
-The full production stack it came from: https://github.com/solomonneas/solos-cookbook
+The full production stack it came from: https://github.com/escoffier-labs/solos-cookbook
 
 MIT, Python stdlib only, no runtime dependencies. Early-stage; I fix reported issues fast.
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -46,9 +46,9 @@ flowchart TB
     class WORK,SCAN,RELEASE,CODEX,CLAUDE,OPEN,MORE,HERMES lane;
 ```
 
-> Brigade was extracted from the [**solos-cookbook**](https://github.com/solomonneas/solos-cookbook), a documented 24/7 multi-agent stack running in production. If you want the full picture of how Brigade fits into a real setup, start there, and a star helps other people find it.
+> Brigade was extracted from the [**solos-cookbook**](https://github.com/escoffier-labs/solos-cookbook), a documented 24/7 multi-agent stack running in production. If you want the full picture of how Brigade fits into a real setup, start there, and a star helps other people find it.
 >
-> [![Star the cookbook](https://img.shields.io/github/stars/solomonneas/solos-cookbook?style=social&label=Star%20solos-cookbook)](https://github.com/solomonneas/solos-cookbook)
+> [![Star the cookbook](https://img.shields.io/github/stars/escoffier-labs/solos-cookbook?style=social&label=Star%20solos-cookbook)](https://github.com/escoffier-labs/solos-cookbook)
 
 ## Why This Exists
 
@@ -361,10 +361,16 @@ Memory and handoff tools:
 
 Safety and operations tools:
 
-- [Content Guard](https://github.com/solomonneas/content-guard): policy-driven content scanning and publish checks.
+- [Content Guard](https://github.com/escoffier-labs/content-guard): policy-driven content scanning and publish checks.
 - [Agent Pantry](https://github.com/escoffier-labs/agentpantry): encrypted browser session, cookie, and secret sync for agent machines.
-- [agent-notify](https://github.com/solomonneas/agent-notify): optional notification hooks for long-running agent work.
+- [agent-notify](https://github.com/escoffier-labs/agent-notify): optional notification hooks for long-running agent work.
 - [tokenjuice](https://github.com/solomonneas/tokenjuice): output compaction for terminal-heavy agent workflows.
+
+Evidence ledger tools:
+
+- [MiseLedger](https://github.com/escoffier-labs/miseledger): local-first evidence ledger that imports `miseledger.adapter.v1` JSONL into SQLite, searches with FTS5, and emits Brigade-ready evidence bundles.
+- [StationTrail](https://github.com/escoffier-labs/stationtrail): agent-session log exporter that normalizes Codex, Claude, OpenClaw, OpenCode, and Hermes sessions into adapter JSONL for MiseLedger.
+- [SourceHarvest](https://github.com/escoffier-labs/sourceharvest): source-system record exporter that normalizes notes, files, git history, and generic exports into adapter JSONL for MiseLedger.
 
 Brigade also has native local workflows for [repo fleet operations](repo-fleet.md), [portable tool catalogs](tool-catalog.md), [security scans](security.md), and [handoff promotion](handoff-promotion.md). The highlights are below.
 

--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -1105,8 +1105,8 @@ Each subsystem has a companion doc under [`docs/`]() with the full local contrac
 
 ## Related
 
-- [Cookbook](https://github.com/solomonneas/solos-cookbook): the long-form companion guide and reference docs
-- [content-guard](https://github.com/solomonneas/content-guard): the publish-gate scanner used by the pre-push hook
+- [Cookbook](https://github.com/escoffier-labs/solos-cookbook): the long-form companion guide and reference docs
+- [content-guard](https://github.com/escoffier-labs/content-guard): the publish-gate scanner used by the pre-push hook
 - [OpenClaw](https://github.com/openclaw/openclaw): the reference memory owner
 
 ## License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,9 @@ research = ["playwright>=1.40"]
 [project.urls]
 Homepage = "https://brigade.tools"
 Repository = "https://github.com/escoffier-labs/brigade"
-Cookbook = "https://github.com/solomonneas/solos-cookbook"
+Cookbook = "https://github.com/escoffier-labs/solos-cookbook"
 OpenClaw = "https://github.com/solomonneas/openclaw"
-ContentGuard = "https://github.com/solomonneas/content-guard"
+ContentGuard = "https://github.com/escoffier-labs/content-guard"
 AgentPantry = "https://github.com/escoffier-labs/agentpantry"
 Issues = "https://github.com/escoffier-labs/brigade/issues"
 

--- a/src/brigade/doctor.py
+++ b/src/brigade/doctor.py
@@ -87,6 +87,13 @@ def notifications_station_checks(ctx: DoctorContext) -> List[CheckResult]:
     return []
 
 
+def evidence_station_checks(ctx: DoctorContext) -> List[CheckResult]:
+    # The miseledger family managed tools (miseledger + the stationtrail and
+    # sourceharvest exporters) carry this station's signal; the station itself
+    # owns no per-workspace files and inspects only host-global state.
+    return []
+
+
 def security_station_checks(ctx: DoctorContext) -> List[CheckResult]:
     from . import dogfood_cmd, security_cmd
 

--- a/src/brigade/managed.py
+++ b/src/brigade/managed.py
@@ -171,6 +171,54 @@ def _agent_notify_wire(ctx: DoctorContext) -> List[CheckResult]:
     ]
 
 
+# The miseledger family (miseledger + its stationtrail/sourceharvest exporters)
+# operates on the operator's host-global evidence archive and local session logs,
+# not a per-target workspace. Like the memory and pantry satellites, their findings
+# are advisory: they never FAIL a workspace doctor run.
+def _miseledger_doctor(ctx: DoctorContext) -> List[CheckResult]:
+    name = "miseledger (evidence archive)"
+    # `status --json` opens (and migrates) the local archive and reports counts.
+    r = proc.run(["miseledger", "status", "--json"])
+    data = r.json()
+    if data is None:
+        return [(WARN, name, f"installed but unwired or errored (exit {r.code})")]
+    if not isinstance(data, dict):
+        return [(WARN, name, f"unexpected status output (exit {r.code})")]
+    items = data.get("items", 0)
+    sources = data.get("sources", 0)
+    schema = data.get("schema_version", "?")
+    fts = data.get("fts") or "?"
+    status = WARN if fts != "ok" else OK
+    return [(status, name, f"schema={schema}, items={items}, sources={sources}, fts={fts}")]
+
+
+def _stationtrail_doctor(ctx: DoctorContext) -> List[CheckResult]:
+    name = "stationtrail (session exporter)"
+    # `doctor --json` discovers local harness session roots; ok=false means a
+    # source could not be read, which is advisory (operator local state).
+    r = proc.run(["stationtrail", "doctor", "--json"])
+    data = r.json()
+    if data is None:
+        return [(WARN, name, f"installed but doctor output unreadable (exit {r.code})")]
+    if not isinstance(data, dict):
+        return [(WARN, name, f"unexpected doctor output (exit {r.code})")]
+    sources = data.get("sources") if isinstance(data.get("sources"), list) else []
+    ready = [s for s in sources if isinstance(s, dict) and s.get("status") == "ready"]
+    warnings = data.get("warnings") if isinstance(data.get("warnings"), list) else []
+    status = WARN if (data.get("ok") is False or warnings) else OK
+    return [(status, name, f"sources={len(sources)}, ready={len(ready)}, warnings={len(warnings)}")]
+
+
+def _sourceharvest_doctor(ctx: DoctorContext) -> List[CheckResult]:
+    name = "sourceharvest (source exporter)"
+    # sourceharvest is a stateless adapter emitter with no archive to inspect;
+    # presence + a runnable `version` is the most we can advisively assert.
+    r = proc.run(["sourceharvest", "version"])
+    if r.code != 0:
+        return [(WARN, name, f"installed but not runnable (exit {r.code})")]
+    return [(OK, name, f"installed; {r.stdout.strip() or 'version ok'}")]
+
+
 def _tokenjuice_wire(ctx: DoctorContext) -> List[CheckResult]:
     # Wiring installs a host hook; which host depends on the workspace's harnesses.
     hosts = [h for h in ctx.harnesses if h in ("claude", "codex", "cursor")]
@@ -202,7 +250,7 @@ _TOOLS: Tuple[ManagedTool, ...] = (
     ManagedTool(
         name="content-guard", station="guard", command="content-guard",
         summary="policy-driven content scanning",
-        install_args=["pipx", "install", "git+https://github.com/solomonneas/content-guard"],
+        install_args=["pipx", "install", "git+https://github.com/escoffier-labs/content-guard"],
         wire=_content_guard_wire, doctor=_content_guard_doctor,
     ),
     ManagedTool(
@@ -220,8 +268,26 @@ _TOOLS: Tuple[ManagedTool, ...] = (
     ManagedTool(
         name="agent-notify", station="notifications", command="agent-notify",
         summary="private operator notifications for agent events",
-        install_args=["go", "install", "github.com/solomonneas/agent-notify/cmd/agent-notify@latest"],
+        install_args=["go", "install", "github.com/escoffier-labs/agent-notify/cmd/agent-notify@latest"],
         wire=_agent_notify_wire, doctor=_agent_notify_doctor,
+    ),
+    ManagedTool(
+        name="miseledger", station="evidence", command="miseledger",
+        summary="local-first evidence ledger: imports adapter JSONL, FTS search, evidence bundles",
+        install_args=["go", "install", "github.com/escoffier-labs/miseledger/cmd/miseledger@latest"],
+        wire=_noop_wire, doctor=_miseledger_doctor,
+    ),
+    ManagedTool(
+        name="stationtrail", station="evidence", command="stationtrail",
+        summary="agent-session log exporter to miseledger.adapter.v1 JSONL",
+        install_args=["go", "install", "github.com/escoffier-labs/stationtrail/cmd/stationtrail@latest"],
+        wire=_noop_wire, doctor=_stationtrail_doctor,
+    ),
+    ManagedTool(
+        name="sourceharvest", station="evidence", command="sourceharvest",
+        summary="source-system record exporter to miseledger.adapter.v1 JSONL",
+        install_args=["go", "install", "github.com/escoffier-labs/sourceharvest/cmd/sourceharvest@latest"],
+        wire=_noop_wire, doctor=_sourceharvest_doctor,
     ),
 )
 

--- a/src/brigade/registry.py
+++ b/src/brigade/registry.py
@@ -54,7 +54,15 @@ NOTIFICATIONS = Station(
     tools=("agent-notify",),
 )
 
-_BUILTIN: Tuple[Station, ...] = (CORE, MEMORY, GUARD, TOKENS, SECURITY, PANTRY, NOTIFICATIONS)
+EVIDENCE = Station(
+    name="evidence",
+    summary="local-first evidence ledger and source exporters",
+    aliases=("ledger",),
+    doctor=_doctor.evidence_station_checks,
+    tools=("miseledger", "stationtrail", "sourceharvest"),
+)
+
+_BUILTIN: Tuple[Station, ...] = (CORE, MEMORY, GUARD, TOKENS, SECURITY, PANTRY, NOTIFICATIONS, EVIDENCE)
 
 
 def all_stations() -> Tuple[Station, ...]:

--- a/src/brigade/scrub.py
+++ b/src/brigade/scrub.py
@@ -59,7 +59,7 @@ def hook_status(target: Path, policy: str = "public-repo") -> dict[str, Any]:
     suggestions: list[str] = []
     if not available():
         checks.append({"status": "warn", "name": "content_guard_missing", "detail": f"content-guard not found at {scanner_dir()}"})
-        suggestions.append("clone https://github.com/solomonneas/content-guard or set CONTENT_GUARD_DIR")
+        suggestions.append("clone https://github.com/escoffier-labs/content-guard or set CONTENT_GUARD_DIR")
     if not policy_exists:
         checks.append({"status": "warn", "name": "content_guard_policy_missing", "detail": f"policy not found: {resolved_policy}"})
         suggestions.append(f"brigade scrub --target . --policy {policy} --dry-run")
@@ -187,7 +187,7 @@ def run_scan(scan_target: Path, *, repo_target: Path | None = None, policy: str 
             "exit_code": 2,
             "detail": f"content-guard not found at {scanner}",
             "stdout": "",
-            "stderr": "clone https://github.com/solomonneas/content-guard or set CONTENT_GUARD_DIR",
+            "stderr": "clone https://github.com/escoffier-labs/content-guard or set CONTENT_GUARD_DIR",
             "policy": policy,
             "policy_path": None,
             "target": str(scan_target),
@@ -259,7 +259,7 @@ def run(
             file=sys.stderr,
         )
         print(
-            "brigade scrub: clone https://github.com/solomonneas/content-guard "
+            "brigade scrub: clone https://github.com/escoffier-labs/content-guard "
             "or set CONTENT_GUARD_DIR",
             file=sys.stderr,
         )

--- a/src/brigade/templates/memory/cards/content-safety.md
+++ b/src/brigade/templates/memory/cards/content-safety.md
@@ -44,7 +44,7 @@ git config core.hooksPath hooks
 If content-guard is not installed:
 
 ```bash
-git clone https://github.com/solomonneas/content-guard ~/repos/content-guard
+git clone https://github.com/escoffier-labs/content-guard ~/repos/content-guard
 ```
 
 The hook reads `CONTENT_GUARD_DIR` (defaults to `$HOME/repos/content-guard`) and `CONTENT_GUARD_POLICY` (defaults to `$SCANNER_DIR/policies/public-repo.json`).

--- a/src/brigade/templates/openclaw/README.md
+++ b/src/brigade/templates/openclaw/README.md
@@ -37,6 +37,6 @@ The doctor reports which fragments your live config has picked up and which chec
 ## Gotchas
 
 - Aliases referencing `<provider/...>` placeholders must be replaced with real ids before merging.
-- The ACP fragment assumes you have already installed `acpx` (see [solos-cookbook/ai-stack/acp-claude-code.md](https://github.com/solomonneas/solos-cookbook) for the install path).
+- The ACP fragment assumes you have already installed `acpx` (see [solos-cookbook/ai-stack/acp-claude-code.md](https://github.com/escoffier-labs/solos-cookbook) for the install path).
 - `openclaw doctor` (the OpenClaw tool, not `brigade doctor`) has historically rewritten `openai-codex/*` prefixes on certain versions. If you use OAuth-only auth, audit `agents.defaults.model.primary` after any OpenClaw upgrade.
 - Stagger ingest and sweep cron minutes around OpenClaw update windows. Avoid running memory ingest at the same time as updater jobs.

--- a/tests/test_managed.py
+++ b/tests/test_managed.py
@@ -14,7 +14,7 @@ def test_all_tools_declare_required_fields():
 
 def test_tools_attach_to_known_stations():
     stations = {t.station for t in managed.all_tools()}
-    assert stations <= {"memory", "guard", "tokens", "pantry", "notifications"}
+    assert stations <= {"memory", "guard", "tokens", "pantry", "notifications", "evidence"}
 
 
 def test_for_station_filters():
@@ -153,3 +153,153 @@ def test_agentpantry_doctor_falls_back_to_status_for_old_binary(monkeypatch):
     results = t.doctor(ctx)
     assert any(status == "OK" and "role=sink" in detail for status, _, detail in results)
     assert calls == [["agentpantry", "doctor", "--json"], ["agentpantry", "status", "--json"]]
+
+
+def test_evidence_tools_attach_to_evidence_station():
+    for name in ("miseledger", "stationtrail", "sourceharvest"):
+        t = managed.resolve(name)
+        assert t is not None and t.station == "evidence", name
+    names = {t.name for t in managed.for_station("evidence")}
+    assert names == {"miseledger", "stationtrail", "sourceharvest"}
+
+
+def test_evidence_install_args_use_escoffier_labs():
+    for name in ("miseledger", "stationtrail", "sourceharvest"):
+        t = managed.resolve(name)
+        joined = " ".join(t.install_args)
+        assert f"github.com/escoffier-labs/{name}/cmd/{name}@latest" in joined, name
+
+
+def test_miseledger_doctor_parses_status(monkeypatch):
+    t = managed.resolve("miseledger")
+
+    def fake_run(args, **kw):
+        assert args == ["miseledger", "status", "--json"]
+        return managed.proc.Result(
+            code=0,
+            stdout='{"schema_version": 7, "items": 42, "sources": 3,'
+                   ' "artifacts": 5, "fts": "ok", "source_counts": {}}',
+            stderr="",
+        )
+
+    monkeypatch.setattr(managed.proc, "run", fake_run)
+    ctx = DoctorContext(target=Path("/tmp/ws"), selection=None, harnesses=[])
+    results = t.doctor(ctx)
+    assert any(status == "OK" and "items=42" in detail for status, _, detail in results)
+
+
+def test_miseledger_doctor_warns_on_unavailable_fts(monkeypatch):
+    t = managed.resolve("miseledger")
+
+    def fake_run(args, **kw):
+        return managed.proc.Result(
+            code=0,
+            stdout='{"schema_version": 7, "items": 0, "sources": 0, "fts": "unavailable"}',
+            stderr="",
+        )
+
+    monkeypatch.setattr(managed.proc, "run", fake_run)
+    ctx = DoctorContext(target=Path("/tmp/ws"), selection=None, harnesses=[])
+    results = t.doctor(ctx)
+    assert any(status == "WARN" for status, _, _ in results)
+    assert all(status != "FAIL" for status, _, _ in results)
+
+
+def test_miseledger_doctor_handles_garbage_output(monkeypatch):
+    t = managed.resolve("miseledger")
+
+    def fake_run(args, **kw):
+        return managed.proc.Result(code=1, stdout="boom", stderr="kaboom")
+
+    monkeypatch.setattr(managed.proc, "run", fake_run)
+    ctx = DoctorContext(target=Path("/tmp/ws"), selection=None, harnesses=[])
+    results = t.doctor(ctx)
+    assert any(status == "WARN" and "unwired or errored" in detail for status, _, detail in results)
+    assert all(status != "FAIL" for status, _, _ in results)
+
+
+def test_stationtrail_doctor_parses_report(monkeypatch):
+    t = managed.resolve("stationtrail")
+
+    def fake_run(args, **kw):
+        assert args == ["stationtrail", "doctor", "--json"]
+        return managed.proc.Result(
+            code=0,
+            stdout='{"ok": true, "warnings": [],'
+                   ' "sources": [{"kind": "codex", "status": "ready"},'
+                   ' {"kind": "claude", "status": "missing"}]}',
+            stderr="",
+        )
+
+    monkeypatch.setattr(managed.proc, "run", fake_run)
+    ctx = DoctorContext(target=Path("/tmp/ws"), selection=None, harnesses=[])
+    results = t.doctor(ctx)
+    assert any(status == "OK" and "sources=2" in detail and "ready=1" in detail for status, _, detail in results)
+
+
+def test_stationtrail_doctor_warns_but_never_fails(monkeypatch):
+    # ok=false (a source could not be read) is advisory, not a workspace failure.
+    t = managed.resolve("stationtrail")
+
+    def fake_run(args, **kw):
+        return managed.proc.Result(
+            code=0,
+            stdout='{"ok": false, "warnings": ["codex status is error"],'
+                   ' "sources": [{"kind": "codex", "status": "error"}]}',
+            stderr="",
+        )
+
+    monkeypatch.setattr(managed.proc, "run", fake_run)
+    ctx = DoctorContext(target=Path("/tmp/ws"), selection=None, harnesses=[])
+    results = t.doctor(ctx)
+    assert any(status == "WARN" for status, _, _ in results)
+    assert all(status != "FAIL" for status, _, _ in results)
+
+
+def test_stationtrail_doctor_handles_garbage_output(monkeypatch):
+    t = managed.resolve("stationtrail")
+
+    def fake_run(args, **kw):
+        return managed.proc.Result(code=2, stdout="not json", stderr="flag provided but not defined")
+
+    monkeypatch.setattr(managed.proc, "run", fake_run)
+    ctx = DoctorContext(target=Path("/tmp/ws"), selection=None, harnesses=[])
+    results = t.doctor(ctx)
+    assert any(status == "WARN" and "unreadable" in detail for status, _, detail in results)
+    assert all(status != "FAIL" for status, _, _ in results)
+
+
+def test_sourceharvest_doctor_present(monkeypatch):
+    t = managed.resolve("sourceharvest")
+
+    def fake_run(args, **kw):
+        assert args == ["sourceharvest", "version"]
+        return managed.proc.Result(code=0, stdout="sourceharvest 0.1.0", stderr="")
+
+    monkeypatch.setattr(managed.proc, "run", fake_run)
+    ctx = DoctorContext(target=Path("/tmp/ws"), selection=None, harnesses=[])
+    results = t.doctor(ctx)
+    assert any(status == "OK" and "sourceharvest 0.1.0" in detail for status, _, detail in results)
+
+
+def test_sourceharvest_doctor_warns_when_not_runnable(monkeypatch):
+    t = managed.resolve("sourceharvest")
+
+    def fake_run(args, **kw):
+        return managed.proc.Result(code=127, stdout="", stderr="boom")
+
+    monkeypatch.setattr(managed.proc, "run", fake_run)
+    ctx = DoctorContext(target=Path("/tmp/ws"), selection=None, harnesses=[])
+    results = t.doctor(ctx)
+    assert any(status == "WARN" and "not runnable" in detail for status, _, detail in results)
+    assert all(status != "FAIL" for status, _, _ in results)
+
+
+def test_content_guard_install_args_use_escoffier_labs():
+    t = managed.resolve("content-guard")
+    assert "github.com/escoffier-labs/content-guard" in " ".join(t.install_args)
+
+
+def test_agent_notify_install_args_use_escoffier_labs():
+    t = managed.resolve("agent-notify")
+    assert "github.com/escoffier-labs/agent-notify/cmd/agent-notify@latest" in " ".join(t.install_args)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -38,3 +38,15 @@ def test_pantry_station_declares_agentpantry():
     assert pantry is not None
     assert set(pantry.tools) == {"agentpantry"}
     assert callable(pantry.doctor)
+
+
+def test_evidence_station_declares_miseledger_family():
+    evidence = registry.resolve("evidence")
+    assert evidence is not None
+    assert set(evidence.tools) == {"miseledger", "stationtrail", "sourceharvest"}
+    assert callable(evidence.doctor)
+
+
+def test_resolve_evidence_by_name_and_alias():
+    assert registry.resolve("evidence").name == "evidence"
+    assert registry.resolve("ledger").name == "evidence"


### PR DESCRIPTION
## What

Adds an `evidence` station (alias `ledger`) to the managed-tool registry and wires the MiseLedger family, plus fixes stale org install paths for repos transferred to `escoffier-labs` today.

### New station + tools
`evidence` carries three advisory, host-global tools that inspect operator state and **never FAIL a workspace doctor** (mirrors the `pantry`/`notifications` pattern):

- **miseledger** - local-first evidence ledger. Doctored via `miseledger status --json` (reports schema/items/sources/fts; WARN when FTS is unavailable).
- **stationtrail** - agent-session log exporter. Doctored via `stationtrail doctor --json` (reports source roots + ready count; `ok=false`/warnings surface as WARN, not FAIL).
- **sourceharvest** - stateless source-system exporter. Presence-checked via `sourceharvest version`.

All install from `github.com/escoffier-labs/<tool>/cmd/<tool>@latest` (verified against each repo's `go.mod` module path and `cmd/` layout).

### Stale URL fixes
Updated `solomonneas` -> `escoffier-labs` (repos transferred today) across `src/` and docs:
- `content-guard` install URL in `managed.py` + doc/template links
- `agent-notify` go install path in `managed.py` + doc links
- `solos-cookbook` doc links

`tokenjuice` and `openclaw` deliberately left as-is (still point elsewhere). Historical records in `docs/superpowers/` and prior `CHANGELOG` entries left untouched.

## Tests
- Extended `tests/test_managed.py` and `tests/test_registry.py` with 13 new cases: station attachment, escoffier-labs install-arg assertions, and doctor parse / advisory-never-FAIL / garbage-output paths for each new tool.
- Full suite: 1024 -> green. `brigade roadmap commands --check`, `security template-audit`, and the content-guard publish gate all clean.