### PR TITLE
Import structured .learnings/ logs into the work inbox

### DIFF
--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -25,7 +25,7 @@ brigade roadmap commands --write
 - `brigade hermes-fragments`: 1 command path(s)
 - `brigade ingest`: 1 command path(s)
 - `brigade init`: 1 command path(s)
-- `brigade learn`: 12 command path(s)
+- `brigade learn`: 13 command path(s)
 - `brigade memory`: 7 command path(s)
 - `brigade notifications`: 4 command path(s)
 - `brigade openclaw-fragments`: 1 command path(s)
@@ -151,6 +151,7 @@ brigade roadmap commands --write
 - `brigade learn closeouts`
 - `brigade learn doctor`
 - `brigade learn import-issues`
+- `brigade learn import-learnings`
 - `brigade learn plan`
 - `brigade learn propose-skill`
 - `brigade learn replay compare`

--- a/docs/import-schema.md
+++ b/docs/import-schema.md
@@ -95,6 +95,7 @@ Roadmap and repo-fleet producers use the same import contract:
 - `source: repo-fleet` records local repository readiness gaps from `brigade repos import-issues`. Metadata includes `repo_id`, `issue_type`, `safe_summary`, `source_item_key`, and `source_fingerprint`.
 - `source: project-consolidation` records local project decision or readiness gaps from `brigade projects import-issues`. Metadata includes a safe project alias, `issue_type`, `safe_summary`, `source_item_key`, and `source_fingerprint`.
 - `source: learning-loop` records bounded local learning candidates from `brigade learn import-issues`. Metadata includes candidate id, source subsystem, safe summary, `source_item_key`, and `source_fingerprint`.
+- `source: learnings-import` records entries parsed from structured `.learnings/` markdown logs by `brigade learn import-learnings`. `ERR` entries import as `incident`, `LRN` entries as `finding`, and `FEAT` entries as `feature` tasks. Metadata includes `entry_id`, `entry_prefix`, `source_file`, `area`, redacted `safe_summary` and `safe_detail`, `source_item_key`, and `source_fingerprint`.
 
 Repo-fleet imports must use safe labels only. Do not copy full local paths, guidance file contents, private config values, raw logs, scanner output, owner names, exact private repo names, or raw evidence into import text or metadata.
 

--- a/docs/project-learning.md
+++ b/docs/project-learning.md
@@ -60,6 +60,8 @@ Commands:
 brigade learn plan
 brigade learn doctor
 brigade learn import-issues
+brigade learn import-learnings
+brigade learn import-learnings --file .learnings/ERRORS.md --dry-run
 brigade learn skill-candidates --source security-scan
 brigade learn propose-skill <candidate-id> --dry-run
 brigade learn propose-skill <candidate-id>
@@ -71,6 +73,8 @@ brigade learn replay list
 brigade learn replay show latest
 brigade learn replay compare latest
 ```
+
+`brigade learn import-learnings` reads structured `.learnings/` markdown logs that some operator workflows already keep on disk and proposes one local work-import per logged entry. Each entry is a level-two heading carrying a typed id such as `ERR-20260311-001`, `LRN-20260311-001`, or `FEAT-20260311-001`, with optional `**Priority**`, `**Status**`, and `**Area**` fields and free-form prose. `ERR` entries become `incident` imports, `LRN` entries become `finding` imports, and `FEAT` entries become `feature` task imports. By default the importer scans `.learnings/ERRORS.md`, `.learnings/LEARNINGS.md`, and `.learnings/FEATURE_REQUESTS.md`; pass `--file` to override. Entry text, fields, and prose are redacted and prompt-injection-guarded before they become imports, and the importer never edits the log files or canonical memory. Imported entries flow through `learn plan`, `learn doctor`, and `learn skill-candidates`, so repeated entries that share a logged area surface as one reviewed promote-candidate. The capture-and-promote loop is a well-known community pattern; see pskoett/self-improving-agent for one origin.
 
 Every candidate should end in one reviewed path:
 

--- a/src/brigade/cli.py
+++ b/src/brigade/cli.py
@@ -2147,6 +2147,11 @@ def _build_parser() -> argparse.ArgumentParser:
     p_learn_import.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update.")
     p_learn_import.add_argument("--dry-run", action="store_true", help="Report without writing imports.")
     p_learn_import.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_learn_import_learnings = learn_sub.add_parser("import-learnings", help="Import structured .learnings/ markdown log entries into the work inbox.")
+    p_learn_import_learnings.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update.")
+    p_learn_import_learnings.add_argument("--file", action="append", default=[], help="Override the .learnings file to read. May be repeated.")
+    p_learn_import_learnings.add_argument("--dry-run", action="store_true", help="Report without writing imports.")
+    p_learn_import_learnings.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
     p_learn_skill_candidates = learn_sub.add_parser("skill-candidates", help="Find repeatable learning patterns that could become reviewed skills.")
     p_learn_skill_candidates.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
     p_learn_skill_candidates.add_argument("--min-count", type=int, default=2, help="Minimum repeated evidence count required.")
@@ -3876,6 +3881,8 @@ def main(argv=None) -> int:
             return learn_cmd.doctor(target=args.target, json_output=args.json)
         if args.learn_command == "import-issues":
             return learn_cmd.import_issues(target=args.target, dry_run=args.dry_run, json_output=args.json)
+        if args.learn_command == "import-learnings":
+            return learn_cmd.import_learnings(target=args.target, files=args.file or None, dry_run=args.dry_run, json_output=args.json)
         if args.learn_command == "skill-candidates":
             return learn_cmd.skill_candidates(target=args.target, min_count=args.min_count, source=args.source, json_output=args.json)
         if args.learn_command == "propose-skill":

--- a/src/brigade/learn_cmd.py
+++ b/src/brigade/learn_cmd.py
@@ -20,12 +20,37 @@ LEARNING_IMPORT_SOURCES = {
     "backup-health",
     "code-review",
     "handoff-ingest",
+    "learnings-import",
     "memory-care",
     "repo-fleet-release",
     "scanner-health",
     "security-scan",
     "tool-catalog",
 }
+
+# Importer for the structured `.learnings/` markdown log format that some
+# operator workflows already keep on disk. Each entry is a level-two heading
+# carrying a typed id (ERR/LRN/FEAT), followed by labelled fields and prose
+# sections. The importer reads those entries and proposes one local work-import
+# per entry so historical logs are not stranded. It never edits the log files
+# and never writes canonical memory.
+LEARNINGS_IMPORT_SOURCE = "learnings-import"
+LEARNINGS_DEFAULT_FILES = (
+    ".learnings/ERRORS.md",
+    ".learnings/LEARNINGS.md",
+    ".learnings/FEATURE_REQUESTS.md",
+)
+# Maps the typed id prefix to the proposed work-import kind. ERR entries are
+# failures (incident), LRN entries are durable findings, FEAT entries are
+# actionable feature work.
+LEARNINGS_ENTRY_KINDS = {
+    "ERR": "incident",
+    "LRN": "finding",
+    "FEAT": "task",
+}
+LEARNINGS_PROMOTED_STATUSES = {"promoted", "resolved"}
+_LEARNINGS_HEADING_RE = re.compile(r"^##\s+\[?(?P<id>(?P<prefix>ERR|LRN|FEAT)-\d{8}-\d+)\]?\s*[:\-]?\s*(?P<title>.*?)\s*$")
+_LEARNINGS_FIELD_RE = re.compile(r"^\*\*(?P<key>[A-Za-z][A-Za-z _-]*)\*\*\s*:\s*(?P<value>.*?)\s*$")
 
 
 def _learning_root(target: Path) -> Path:
@@ -182,6 +207,8 @@ def _raw_candidates(target: Path) -> list[dict[str, Any]]:
                 "issue_type",
                 "template",
                 "category",
+                "area",
+                "entry_prefix",
                 "severity",
                 "surface",
                 "confidence",
@@ -336,8 +363,182 @@ def import_issues(*, target: Path, dry_run: bool = False, json_output: bool = Fa
     return 0
 
 
+def _parse_learnings_entries(text: str, *, source_file: str) -> list[dict[str, Any]]:
+    """Parse structured `.learnings/` markdown entries into safe dictionaries.
+
+    Each entry is a level-two heading carrying a typed id such as
+    ``ERR-20260311-001``, optional ``**Label**: value`` fields, and free-form
+    prose sections. Fields and prose are redacted and prompt-injection-guarded
+    before they leave this function.
+    """
+    entries: list[dict[str, Any]] = []
+    current: dict[str, Any] | None = None
+    body_lines: list[str] = []
+
+    def _flush() -> None:
+        if current is None:
+            return
+        body = "\n".join(body_lines).strip()
+        current["safe_detail"] = _safe_learning_text(body, limit=600) if body else ""
+        entries.append(current)
+
+    for raw_line in text.splitlines():
+        heading = _LEARNINGS_HEADING_RE.match(raw_line)
+        if heading:
+            _flush()
+            body_lines = []
+            current = {
+                "entry_id": heading.group("id"),
+                "prefix": heading.group("prefix"),
+                "title": _safe_learning_text(heading.group("title") or "", limit=160),
+                "fields": {},
+                "source_file": source_file,
+            }
+            continue
+        if current is None:
+            continue
+        field = _LEARNINGS_FIELD_RE.match(raw_line)
+        if field:
+            key = field.group("key").strip().lower().replace(" ", "_")
+            current["fields"][key] = _safe_learning_text(field.group("value"), limit=120)
+            continue
+        body_lines.append(raw_line)
+    _flush()
+    return entries
+
+
+def _learnings_record(entry: dict[str, Any]) -> dict[str, Any]:
+    prefix = str(entry.get("prefix") or "")
+    kind = LEARNINGS_ENTRY_KINDS.get(prefix, "finding")
+    fields = entry.get("fields") if isinstance(entry.get("fields"), dict) else {}
+    entry_id = str(entry.get("entry_id") or "")
+    title = str(entry.get("title") or "").strip()
+    summary = title or _short(str(entry.get("safe_detail") or "logged learning entry"), 120)
+    area = fields.get("area")
+    status = str(fields.get("status") or "").strip().lower()
+    metadata: dict[str, Any] = {
+        "entry_id": entry_id,
+        "entry_prefix": prefix,
+        "source_file": entry.get("source_file"),
+        "safe_summary": summary,
+        "source_item_key": f"{LEARNINGS_IMPORT_SOURCE}:{entry_id}",
+    }
+    if isinstance(entry.get("safe_detail"), str) and entry["safe_detail"]:
+        metadata["safe_detail"] = entry["safe_detail"]
+    for key in ("priority", "status", "area", "logged"):
+        value = fields.get(key)
+        if isinstance(value, str) and value.strip():
+            metadata[key] = value.strip()
+    if status in LEARNINGS_PROMOTED_STATUSES:
+        metadata["log_status"] = status
+    record: dict[str, Any] = {
+        "text": f"Review .learnings entry {entry_id}: {summary}",
+        "kind": kind,
+        "source": LEARNINGS_IMPORT_SOURCE,
+        "metadata": metadata,
+    }
+    if kind == "task":
+        record["type"] = "feature"
+        record["template"] = "vertical-slice"
+        record["acceptance"] = [
+            "The logged entry is routed to a task, handoff, suppression, accepted risk, archive, or dismissal.",
+            "No canonical memory, source, policy, or log file is edited automatically.",
+        ]
+        priority = (fields.get("priority") or "").strip().lower()
+        if priority in {"low", "high"}:
+            record["priority"] = priority
+        elif priority == "critical":
+            record["priority"] = "urgent"
+        elif priority == "medium":
+            record["priority"] = "normal"
+    fingerprint_basis = {
+        "entry_id": entry_id,
+        "title": title,
+        "kind": kind,
+        "priority": fields.get("priority"),
+        "status": fields.get("status"),
+        "area": area,
+        "detail": metadata.get("safe_detail"),
+    }
+    metadata["source_fingerprint"] = work_cmd._stable_hash(fingerprint_basis)
+    return record
+
+
+def _resolve_learnings_files(target: Path, files: list[str] | None) -> list[Path]:
+    names = files if files else list(LEARNINGS_DEFAULT_FILES)
+    resolved: list[Path] = []
+    for name in names:
+        candidate = (target / name).expanduser().resolve()
+        if candidate.is_file():
+            resolved.append(candidate)
+    return resolved
+
+
+def import_learnings(
+    *,
+    target: Path,
+    files: list[str] | None = None,
+    dry_run: bool = False,
+    json_output: bool = False,
+) -> int:
+    target = target.expanduser().resolve()
+    if not target.is_dir():
+        print(f"error: --target is not a directory: {target}", file=sys.stderr)
+        return 2
+    paths = _resolve_learnings_files(target, files)
+    records: list[dict[str, Any]] = []
+    parsed_entries = 0
+    scanned_files: list[str] = []
+    for path in paths:
+        try:
+            text = path.read_text()
+        except OSError as exc:
+            print(f"error: cannot read learnings file: {exc}", file=sys.stderr)
+            return 2
+        try:
+            rel = str(path.relative_to(target))
+        except ValueError:
+            rel = path.name
+        scanned_files.append(rel)
+        for entry in _parse_learnings_entries(text, source_file=rel):
+            parsed_entries += 1
+            records.append(_learnings_record(entry))
+    imported, skipped, dismissed = work_cmd._append_import_records(target, records, dry_run=dry_run)
+    output = {
+        "target": str(target),
+        "imports_path": str(work_cmd._imports_path(target)),
+        "scanned_files": scanned_files,
+        "parsed_entries": parsed_entries,
+        "dry_run": dry_run,
+        "created": len(imported),
+        "skipped": len(skipped),
+        "dismissed": len(dismissed),
+        "imports": imported,
+    }
+    if json_output:
+        print(json.dumps(output, indent=2, sort_keys=True))
+        return 0
+    print(f"learnings_import: {target}")
+    print(f"scanned_files: {len(scanned_files)}")
+    print(f"parsed_entries: {parsed_entries}")
+    print(f"created: {len(imported)}")
+    print(f"skipped: {len(skipped)}")
+    print(f"dismissed: {len(dismissed)}")
+    for item in imported:
+        print(f"- {item.get('id')} {_short(str(item.get('text', '')))}")
+    return 0
+
+
 def _skill_pattern_key(item: dict[str, Any]) -> str:
     metadata = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
+    # Imported .learnings entries group by their typed prefix and logged area so
+    # repeated failures or learnings in the same area cluster into one
+    # promote-candidate.
+    if str(item.get("subsystem") or "") == "learnings-import":
+        prefix = metadata.get("entry_prefix")
+        area = metadata.get("area")
+        if isinstance(prefix, str) and prefix.strip() and isinstance(area, str) and area.strip():
+            return f"learnings:{_slug(prefix)}:{_slug(area)}"
     for key in ("rule_id", "issue_type", "template", "subsystem"):
         value = metadata.get(key) if key != "subsystem" else item.get("subsystem")
         if isinstance(value, str) and value.strip():

--- a/tests/test_phase36_cmd.py
+++ b/tests/test_phase36_cmd.py
@@ -812,3 +812,156 @@ def test_center_views_and_cli_dispatch(tmp_path, capsys):
     assert cli.main(["projects", "audit", "--target", str(tmp_path), "--json"]) == 1
     assert cli.main(["learn", "plan", "--target", str(tmp_path), "--json"]) == 0
     assert cli.main(["center", "reviews", "--target", str(tmp_path), "--json"]) == 0
+
+
+_LEARNINGS_ERRORS = """# Errors Log
+
+## [ERR-20260220-001] Port conflict on dev server startup
+
+**Logged**: 2026-02-20 16:45
+**Priority**: medium
+**Status**: resolved
+**Area**: infra
+
+### Summary
+Dev server failed to bind to port because a previous instance was still running.
+
+### Action
+Check the port before starting and kill zombie processes.
+
+## [ERR-20260221-001] SSH host key rotation broke connections
+
+**Priority**: high
+**Status**: resolved
+**Area**: infra
+
+### Action
+Remove the stale known_hosts entry and reconnect.
+
+## [ERR-20260222-001] Build host ran out of disk
+
+**Priority**: high
+**Status**: pending
+**Area**: infra
+
+### Action
+Prune the build cache on a schedule.
+"""
+
+_LEARNINGS_FEATURES = """# Feature Requests
+
+## FEAT-20260228-001: Auto-promote recurring error patterns
+
+**Priority**: high
+**Status**: pending
+**Area**: config
+
+### Summary
+Suggest promotion when the same error repeats.
+"""
+
+
+def _write_learnings(target: Path) -> None:
+    learnings = target / ".learnings"
+    learnings.mkdir(parents=True, exist_ok=True)
+    (learnings / "ERRORS.md").write_text(_LEARNINGS_ERRORS)
+    (learnings / "FEATURE_REQUESTS.md").write_text(_LEARNINGS_FEATURES)
+
+
+def test_import_learnings_parses_structured_entries_into_work_imports(tmp_path, capsys):
+    _write_learnings(tmp_path)
+
+    assert learn_cmd.import_learnings(target=tmp_path, dry_run=True, json_output=True) == 0
+    dry = json.loads(capsys.readouterr().out)
+    assert dry["dry_run"] is True
+    assert dry["parsed_entries"] == 4
+    assert dry["created"] == 4
+    imports_path = tmp_path / ".brigade" / "work" / "imports" / "inbox.jsonl"
+    assert not imports_path.exists()
+
+    assert learn_cmd.import_learnings(target=tmp_path, json_output=True) == 0
+    created = json.loads(capsys.readouterr().out)
+    assert created["created"] == 4
+    assert set(created["scanned_files"]) == {".learnings/ERRORS.md", ".learnings/FEATURE_REQUESTS.md"}
+
+    by_entry = {item["metadata"]["entry_id"]: item for item in created["imports"]}
+    err = by_entry["ERR-20260220-001"]
+    assert err["kind"] == "incident"
+    assert err["source"] == "learnings-import"
+    assert err["metadata"]["area"] == "infra"
+    assert err["metadata"]["safe_summary"] == "Port conflict on dev server startup"
+    feat = by_entry["FEAT-20260228-001"]
+    assert feat["kind"] == "task"
+    assert feat["type"] == "feature"
+    assert feat["priority"] == "high"
+    assert feat["metadata"]["safe_summary"] == "Auto-promote recurring error patterns"
+    assert feat["acceptance"]
+
+    # Re-running is idempotent: unchanged entries skip.
+    assert learn_cmd.import_learnings(target=tmp_path, json_output=True) == 0
+    second = json.loads(capsys.readouterr().out)
+    assert second["created"] == 0
+    assert second["skipped"] == 4
+
+
+def test_import_learnings_feeds_plan_and_recurrence_detection(tmp_path, capsys):
+    _write_learnings(tmp_path)
+    assert cli.main(["learn", "import-learnings", "--target", str(tmp_path), "--json"]) == 0
+    capsys.readouterr()
+
+    assert learn_cmd.plan(target=tmp_path, json_output=True) == 0
+    plan = json.loads(capsys.readouterr().out)
+    assert plan["candidate_count"] == 4
+    assert all(
+        candidate["subsystem"] == "learnings-import"
+        for candidate in plan["candidates"]
+    )
+
+    assert learn_cmd.skill_candidates(target=tmp_path, min_count=3, json_output=True) == 0
+    skills = json.loads(capsys.readouterr().out)
+    assert skills["candidate_count"] == 1
+    candidate = skills["candidates"][0]
+    assert candidate["occurrence_count"] == 3
+    assert candidate["pattern_key"] == "learnings:err:infra"
+
+
+def test_import_learnings_supports_file_override_and_missing_files(tmp_path, capsys):
+    _write_learnings(tmp_path)
+    assert (
+        learn_cmd.import_learnings(
+            target=tmp_path,
+            files=[".learnings/FEATURE_REQUESTS.md"],
+            json_output=True,
+        )
+        == 0
+    )
+    only_features = json.loads(capsys.readouterr().out)
+    assert only_features["created"] == 1
+    assert only_features["scanned_files"] == [".learnings/FEATURE_REQUESTS.md"]
+
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    assert learn_cmd.import_learnings(target=empty, json_output=True) == 0
+    none = json.loads(capsys.readouterr().out)
+    assert none["created"] == 0
+    assert none["scanned_files"] == []
+
+
+def test_import_learnings_redacts_secrets_and_urls(tmp_path, capsys):
+    learnings = tmp_path / ".learnings"
+    learnings.mkdir(parents=True)
+    (learnings / "LEARNINGS.md").write_text(
+        "# Learnings Log\n\n"
+        "## [LRN-20260301-001] Token leaked in config\n\n"
+        "**Priority**: high\n"
+        "**Status**: pending\n"
+        "**Area**: config\n\n"
+        "### Details\n"
+        "Set API_TOKEN=sk-secret123 and visit https://internal.example.com/admin to rotate.\n"
+    )
+    assert learn_cmd.import_learnings(target=tmp_path, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    detail = payload["imports"][0]["metadata"]["safe_detail"]
+    assert "sk-secret123" not in detail
+    assert "internal.example.com" not in detail
+    assert "<redacted>" in detail


### PR DESCRIPTION
## What

Adds `brigade learn import-learnings`, a producer that reads the structured `.learnings/` markdown log format some operator workflows already keep on disk and proposes one local work-import per logged entry. This folds a previously standalone capture-and-promote helper into Brigade's existing learning loop rather than maintaining a parallel tool.

Each entry is a level-two heading carrying a typed id (`ERR-YYYYMMDD-NNN`, `LRN-...`, `FEAT-...`), optional `**Priority**`, `**Status**`, `**Area**` fields, and free-form prose:

- `ERR` entries import as `incident`
- `LRN` entries import as `finding`
- `FEAT` entries import as `feature` tasks (with acceptance criteria)

By default it scans `.learnings/ERRORS.md`, `.learnings/LEARNINGS.md`, and `.learnings/FEATURE_REQUESTS.md`; `--file` overrides the file list. `--dry-run` reports without writing.

## Why

Historical `.learnings/` logs were stranded: Brigade used those filenames only as handoff output targets, never as an input format. This makes the existing on-disk logs reviewable work, then lets the existing learning loop do the rest.

## How it fits the existing loop

The new `learnings-import` source is registered as a learning source, so imported entries flow through `brigade learn plan`, `brigade learn doctor`, and `brigade learn skill-candidates`. Entries that share a logged area cluster into a single promote-candidate that carries the three promotion signals (recurrence, standing preference, cost of repeating). Promotion stays proposed through `propose-skill` or the Memory Handoff flow and is never auto-applied to canonical memory.

## Safety

- Entry text, fields, and prose are redacted and prompt-injection-guarded with the same helpers the rest of `learn_cmd` uses.
- The importer never edits the `.learnings/` files and never writes canonical memory, source, policy, or tool config.
- Idempotent: re-running skips unchanged entries via `source_item_key` and `source_fingerprint`.

## Tests

Four new tests in `tests/test_phase36_cmd.py` cover parsing, plan/recurrence integration, `--file` override and missing-file handling, and secret/URL redaction. Full suite is green (1028 passed). `brigade roadmap commands --check` regenerated `docs/command-inventory.md`; content-guard scan clean.

## Docs

`docs/import-schema.md` documents the new `learnings-import` source. `docs/project-learning.md` documents the importer. The capture-and-promote loop is a well-known community pattern; the docs note pskoett/self-improving-agent as one origin.