### PR TITLE
Add code-search managed station

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -333,6 +333,7 @@ flowchart TB
         PANTRY["Agent Pantry"]
         NOTIFY["agent-notify"]
         TOKEN["tokenjuice"]
+        SEARCH["code-search"]
     end
 
     subgraph NATIVE [" native Brigade stations "]
@@ -349,7 +350,7 @@ flowchart TB
     classDef core fill:#2563eb,stroke:#1d4ed8,color:#fff;
     classDef group fill:#f8fafc,stroke:#94a3b8,color:#334155;
     class BRIGADE core;
-    class OPENCLAW,HERMES,MDOCTOR,BDOCTOR,GUARD,PANTRY,NOTIFY,TOKEN,REPOS,TOOLS,SECURITY,HANDOFFS group;
+    class OPENCLAW,HERMES,MDOCTOR,BDOCTOR,GUARD,PANTRY,NOTIFY,TOKEN,SEARCH,REPOS,TOOLS,SECURITY,HANDOFFS group;
 ```
 
 Memory and handoff tools:
@@ -371,6 +372,11 @@ Evidence ledger tools:
 - [MiseLedger](https://github.com/escoffier-labs/miseledger): local-first evidence ledger that imports `miseledger.adapter.v1` JSONL into SQLite, searches with FTS5, and emits Brigade-ready evidence bundles.
 - [StationTrail](https://github.com/escoffier-labs/stationtrail): agent-session log exporter that normalizes Codex, Claude, OpenClaw, OpenCode, and Hermes sessions into adapter JSONL for MiseLedger.
 - [SourceHarvest](https://github.com/escoffier-labs/sourceharvest): source-system record exporter that normalizes notes, files, git history, and generic exports into adapter JSONL for MiseLedger.
+
+Search and context tools:
+
+- [code-search-api](https://github.com/escoffier-labs/code-search-api): local semantic code-search service backed by SQLite and Ollama embeddings.
+- [code-search-mcp](https://github.com/escoffier-labs/code-search-mcp): read-only MCP bridge for a running code-search-api service. The GitHub repo lives under Escoffier Labs; the npm package remains `@solomonneas/code-search-mcp`.
 
 Brigade also has native local workflows for [repo fleet operations](repo-fleet.md), [portable tool catalogs](tool-catalog.md), [security scans](security.md), and [handoff promotion](handoff-promotion.md). The highlights are below.
 

--- a/src/brigade/doctor.py
+++ b/src/brigade/doctor.py
@@ -75,6 +75,12 @@ def tokens_station_checks(ctx: DoctorContext) -> List[CheckResult]:
     return []
 
 
+def search_station_checks(ctx: DoctorContext) -> List[CheckResult]:
+    # The managed code-search tools carry this station's signal. The station
+    # itself owns no per-workspace files and does not start local services.
+    return []
+
+
 def pantry_station_checks(ctx: DoctorContext) -> List[CheckResult]:
     # The agentpantry managed tool carries this station's signal; the station
     # itself lays down no per-workspace files.

--- a/src/brigade/managed.py
+++ b/src/brigade/managed.py
@@ -6,6 +6,10 @@ never as a hard failure.
 """
 from __future__ import annotations
 
+import json
+import os
+import urllib.error
+import urllib.request
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, List, Optional, Tuple
@@ -89,6 +93,40 @@ def _tokenjuice_doctor(ctx: DoctorContext) -> List[CheckResult]:
     status = data.get("status", "unknown")
     mapping = {"ok": OK, "warn": WARN, "disabled": MANUAL, "broken": FAIL}
     return [(mapping.get(status, WARN), "tokenjuice", f"hook status: {status}")]
+
+
+def _code_search_url() -> str:
+    return os.environ.get("CODE_SEARCH_API_URL", "http://localhost:5204").rstrip("/")
+
+
+def _code_search_api_doctor(ctx: DoctorContext) -> List[CheckResult]:
+    name = "code-search-api (local search service)"
+    url = f"{_code_search_url()}/api/health"
+    request = urllib.request.Request(url)
+    api_key = os.environ.get("CODE_SEARCH_API_KEY")
+    if api_key:
+        request.add_header("X-API-Key", api_key)
+    try:
+        with urllib.request.urlopen(request, timeout=2.0) as response:
+            payload = response.read().decode("utf-8", errors="replace")
+    except (OSError, urllib.error.URLError) as exc:
+        return [(WARN, name, f"installed; service health unavailable at {url} ({exc})")]
+    try:
+        data = json.loads(payload)
+    except json.JSONDecodeError:
+        return [(WARN, name, "installed; service returned non-JSON health")]
+    if not isinstance(data, dict):
+        return [(WARN, name, "installed; service returned unexpected health payload")]
+    status = OK if data.get("status") == "ok" else WARN
+    chunks = data.get("chunks", 0)
+    embedded = data.get("embedded", 0)
+    summarized = data.get("summarized", 0)
+    version = data.get("version") or "?"
+    return [(status, name, f"version={version}, chunks={chunks}, embedded={embedded}, summarized={summarized}")]
+
+
+def _code_search_mcp_doctor(ctx: DoctorContext) -> List[CheckResult]:
+    return [(OK, "code-search-mcp (MCP bridge)", "installed; configure MCP clients with CODE_SEARCH_API_URL and optional CODE_SEARCH_API_KEY")]
 
 
 # agentpantry keeps the agent's machine authenticated by syncing browser sessions
@@ -258,6 +296,18 @@ _TOOLS: Tuple[ManagedTool, ...] = (
         summary="output compaction via host hooks",
         install_args=["npm", "install", "-g", "tokenjuice"],
         wire=_tokenjuice_wire, doctor=_tokenjuice_doctor,
+    ),
+    ManagedTool(
+        name="code-search-api", station="search", command="code-search-api",
+        summary="local semantic code search service with SQLite and Ollama embeddings",
+        install_args=["pipx", "install", "git+https://github.com/escoffier-labs/code-search-api"],
+        wire=_noop_wire, doctor=_code_search_api_doctor,
+    ),
+    ManagedTool(
+        name="code-search-mcp", station="search", command="code-search-mcp",
+        summary="read-only MCP bridge for a running code-search-api service",
+        install_args=["npm", "install", "-g", "@solomonneas/code-search-mcp"],
+        wire=_noop_wire, doctor=_code_search_mcp_doctor,
     ),
     ManagedTool(
         name="agentpantry", station="pantry", command="agentpantry",

--- a/src/brigade/registry.py
+++ b/src/brigade/registry.py
@@ -33,6 +33,13 @@ TOKENS = Station(
     doctor=_doctor.tokens_station_checks,
     tools=("tokenjuice",),
 )
+SEARCH = Station(
+    name="search",
+    summary="local semantic code search",
+    aliases=("code-search",),
+    doctor=_doctor.search_station_checks,
+    tools=("code-search-api", "code-search-mcp"),
+)
 SECURITY = Station(
     name="security",
     summary="agent workspace security scanning",
@@ -62,7 +69,7 @@ EVIDENCE = Station(
     tools=("miseledger", "stationtrail", "sourceharvest"),
 )
 
-_BUILTIN: Tuple[Station, ...] = (CORE, MEMORY, GUARD, TOKENS, SECURITY, PANTRY, NOTIFICATIONS, EVIDENCE)
+_BUILTIN: Tuple[Station, ...] = (CORE, MEMORY, GUARD, TOKENS, SEARCH, SECURITY, PANTRY, NOTIFICATIONS, EVIDENCE)
 
 
 def all_stations() -> Tuple[Station, ...]:

--- a/tests/test_managed.py
+++ b/tests/test_managed.py
@@ -14,7 +14,7 @@ def test_all_tools_declare_required_fields():
 
 def test_tools_attach_to_known_stations():
     stations = {t.station for t in managed.all_tools()}
-    assert stations <= {"memory", "guard", "tokens", "pantry", "notifications", "evidence"}
+    assert stations <= {"memory", "guard", "tokens", "search", "pantry", "notifications", "evidence"}
 
 
 def test_for_station_filters():
@@ -168,6 +168,69 @@ def test_evidence_install_args_use_escoffier_labs():
         t = managed.resolve(name)
         joined = " ".join(t.install_args)
         assert f"github.com/escoffier-labs/{name}/cmd/{name}@latest" in joined, name
+
+
+def test_search_tools_attach_to_search_station():
+    for name in ("code-search-api", "code-search-mcp"):
+        t = managed.resolve(name)
+        assert t is not None and t.station == "search", name
+    names = {t.name for t in managed.for_station("search")}
+    assert names == {"code-search-api", "code-search-mcp"}
+
+
+def test_search_install_args_keep_npm_scope_distinction():
+    api = managed.resolve("code-search-api")
+    mcp = managed.resolve("code-search-mcp")
+    assert "github.com/escoffier-labs/code-search-api" in " ".join(api.install_args)
+    # GitHub moved to escoffier-labs, but npm remains under Solomon's existing scope.
+    assert "@solomonneas/code-search-mcp" in " ".join(mcp.install_args)
+
+
+def test_code_search_api_doctor_reads_http_health(monkeypatch):
+    t = managed.resolve("code-search-api")
+    monkeypatch.setenv("CODE_SEARCH_API_URL", "http://search.local")
+    seen = {}
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def read(self):
+            return b'{"status": "ok", "version": "2.0.1", "chunks": 12, "embedded": 11, "summarized": 7}'
+
+    def fake_urlopen(request, timeout):
+        seen["url"] = request.full_url
+        seen["timeout"] = timeout
+        return FakeResponse()
+
+    monkeypatch.setattr(managed.urllib.request, "urlopen", fake_urlopen)
+    ctx = DoctorContext(target=Path("/tmp/ws"), selection=None, harnesses=[])
+    results = t.doctor(ctx)
+    assert seen == {"url": "http://search.local/api/health", "timeout": 2.0}
+    assert any(status == "OK" and "chunks=12" in detail for status, _, detail in results)
+
+
+def test_code_search_api_doctor_warns_when_service_unavailable(monkeypatch):
+    t = managed.resolve("code-search-api")
+
+    def fake_urlopen(request, timeout):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(managed.urllib.request, "urlopen", fake_urlopen)
+    ctx = DoctorContext(target=Path("/tmp/ws"), selection=None, harnesses=[])
+    results = t.doctor(ctx)
+    assert any(status == "WARN" and "service health unavailable" in detail for status, _, detail in results)
+    assert all(status != "FAIL" for status, _, _ in results)
+
+
+def test_code_search_mcp_doctor_is_presence_only():
+    t = managed.resolve("code-search-mcp")
+    ctx = DoctorContext(target=Path("/tmp/ws"), selection=None, harnesses=[])
+    results = t.doctor(ctx)
+    assert any(status == "OK" and "MCP clients" in detail for status, _, detail in results)
 
 
 def test_miseledger_doctor_parses_status(monkeypatch):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -26,10 +26,12 @@ def test_stations_declare_attached_tools():
     memory = registry.resolve("memory")
     guard = registry.resolve("guard")
     tokens = registry.resolve("tokens")
+    search = registry.resolve("search")
     security = registry.resolve("security")
     assert set(memory.tools) == {"memory-doctor", "bootstrap-doctor"}
     assert set(guard.tools) == {"content-guard"}
     assert tokens is not None and set(tokens.tools) == {"tokenjuice"}
+    assert search is not None and set(search.tools) == {"code-search-api", "code-search-mcp"}
     assert security is not None and set(security.tools) == set()
 
 
@@ -50,3 +52,8 @@ def test_evidence_station_declares_miseledger_family():
 def test_resolve_evidence_by_name_and_alias():
     assert registry.resolve("evidence").name == "evidence"
     assert registry.resolve("ledger").name == "evidence"
+
+
+def test_resolve_search_by_name_and_alias():
+    assert registry.resolve("search").name == "search"
+    assert registry.resolve("code-search").name == "search"


### PR DESCRIPTION
## What

Adds a `search` station to Brigade and registers the transferred code-search pair as managed tools:

- `code-search-api`, installed from `escoffier-labs/code-search-api`
- `code-search-mcp`, installed from the existing npm package `@solomonneas/code-search-mcp`

The API doctor checks `/api/health` using `CODE_SEARCH_API_URL` and optional `CODE_SEARCH_API_KEY`. The MCP bridge remains a presence/configuration check because it is a stdio server and should not be started from doctor.

## Why

The Escoffier suite audit identified code-search-api + code-search-mcp as org-level agent tooling that should move together and be visible from Brigade instead of living only as external repos.

## Tests

- `python3 -m pytest tests/test_managed.py tests/test_registry.py tests/test_add.py -q` - 39 passed
- `python3 -m pytest -q` - 1034 passed
- `brigade scrub --target . --policy public-repo` - clean for blocking findings; existing loopback warnings only
- `brigade doctor --target .` - 0 failed, new search tools show as manual when not installed