### PR TITLE
Doctor first-contact fixes + doctor/status --json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `brigade doctor --json` and `brigade status --json` emit machine-readable output (target, harnesses, owner, depth, per-check status/name/detail, summary counts, and a `ready` flag), so the two most diagnostic surfaces can feed scripts and a future fleet aggregation instead of being text-only.
+
+### Fixed
+- `brigade doctor` memory-care freshness no longer reports a same-day scan as "in the future". The scanner stamps `scan_date` in UTC, but doctor compared it against the host's local date, so an evening run in a behind-UTC timezone warned falsely (issue #83). Doctor now compares in UTC.
+- `brigade init --depth workspace` now creates `.brigade/memory-care/decay`, the directory doctor actually checks, instead of the legacy `memory/cards/decay`. A fresh workspace no longer draws a "staleness scanner not wired" warning on first contact (issue #79).
+- `localio.write_json` now writes receipts atomically (temp file plus `os.replace`), so a reader or a crashed writer never observes a half-written JSON receipt; on failure the original file is left intact and the temp file is removed.
+
 ## [0.11.0] - 2026-06-13
 
 ### Added

--- a/docs/audit/2026-06-16-improvements-and-features-board.md
+++ b/docs/audit/2026-06-16-improvements-and-features-board.md
@@ -1,0 +1,114 @@
+# Brigade: improvements + features board (2026-06-16)
+
+A grounded sweep of the repo across 12 lenses (the `special` feature lenses plus
+line-check / bug-hunt / reduce improvement lenses). Every item cites a file:line
+signal and was verified that the signal exists, the capability is not already
+built, and it does not violate a declared non-goal. 63 candidates found, 59
+survived verification.
+
+Status legend: **[shipped]** landed on branch `fix/doctor-first-contact-and-json`;
+**[issue #N]** filed; everything else is an open proposal.
+
+## The read
+
+The codebase wants two things: a credibility pass on its diagnostics surface, and
+parity-closing on its station verbs. Issue #83's UTC-vs-local clock bug surfaced
+independently in four lenses (the single most-corroborated finding), and first
+contact leaks scary WARNs for dirs that `init` itself fails to create (#79). Both
+erode trust in `doctor`, the surface that sells the tool. The second through-line
+is asymmetry: `install` has rollback but `tools apply` does not, `skills` has lint
+but no `--fix`, `security` has every `--json` except suppress, `projects` is the
+one station missing `doctor`, and `ingest` carries inverted write-defaults between
+its top-level and fleet forms. Underneath both, two infra gaps quietly threaten the
+"grep-able receipt" promise: `write_json` was non-atomic and several git subprocess
+calls still lack the v0.11.0 stdin/timeout fix.
+
+## Top picks
+
+| # | Item | Type | Leverage | Effort | Status |
+|---|------|------|----------|--------|--------|
+| 1 | doctor memory-care UTC-vs-local future-date warn | fix | high | S | **shipped** (#83) |
+| 2 | `.brigade/memory-care/decay` created by workspace init | fix | high | S | **shipped** (#79) |
+| 3 | `write_json` atomic (tmp + os.replace) | fix | high | S | **shipped** |
+| 4 | `doctor --json` / `status --json` | feature | high | S | **shipped** |
+| 5 | `security diff --base --against` (by fingerprint) | feature | high | S | proposal |
+| 6 | Parallelize fleet `_repo_summary` (ThreadPoolExecutor) | perf | high | S | proposal |
+| 7 | `brigade operator checkup` (all first-run doctors at once) | feature | high | M | proposal |
+
+## Improvements backlog
+
+### Bugs / fixes
+- **[shipped] doctor memory-care UTC vs local today (#83)** - `memory_cmd.py:88` `_today()`=UTC; `doctor.py:507` used local `date.today()`; warns at `:478-480` when age<0. Fixed to `datetime.now(timezone.utc).date()` + regression test.
+- **[shipped] workspace init decay dir (#79)** - `templates/depth/workspace.json:29` created legacy `memory/cards/decay`; doctor checks `.brigade/memory-care/decay` (`memory_cmd.py:21`). Template now creates the canonical path.
+- **[shipped] `write_json` non-atomic** - `localio.py:43-46` did a direct `write_text`; `read_json_dict` swallows `JSONDecodeError`. Now tmp + `os.replace` with cleanup on failure.
+- **v0.11.0 stdin/timeout fix missed several git subprocess sites** - present at `proc.py:45`, missing at `localio.py:89` (`check_git_ignored`), `scrub.py:136/151/250`, `work_cmd/helpers.py:27`. Add `stdin=DEVNULL` + `timeout` to the egress-gate and heavy-caller sites first. S, high.
+- **pre-push hook labels any nonzero content-guard exit as "BLOCKED" (#82)** - `templates/hooks/pre-push:30-36` does not discriminate exit codes; content-guard separates 1=findings from 2=infra error. Branch on `rc`. S, med.
+- **TOML 3.10 fallback: top-level quoted keys mis-parsed** - `toml_compat.py:47` assigns the raw key without `_parse_key` (inline tables call it at `:150`). Route line 47 through `_parse_key`. S, high. Sibling bare-date/time issue is real but theoretical since brigade always quotes dates.
+
+### Refactors
+- **Extract `tools_cmd` projection renderer** - 13 contiguous pure functions `tools_cmd.py:1951-2241` in a 6112-line file; `work_cmd/__init__.py:1-24` documents the facade pattern. M, med.
+- **Split `tools_cmd` runtime supervision** (pid/port/process `:992-1593`) into a submodule. L, med.
+- **Share `actionqueue.find_action`** instead of `phases_cmd` reimplementing matching at `:3936/:5310` (keep local stamping; fields diverge). S, high.
+- **`add_target_arg` helper** - `--target` literal duplicated 161x; `cli/_common.py` is the designated home but has no helper; 5 commands drop the help string. S, high.
+
+### Tests
+- UTC-vs-local clock in memory-care freshness (**shipped** with #83).
+- Scrub egress gate: no test where content-guard returns nonzero (`scrub.py:253`). S.
+- Run-lock `PermissionError` (foreign-user PID) path untested (`runguard.py:98-99`). S.
+- Threaded dispatch worker-exception path is `# pragma: no cover` (`aboyeur.py:472`). S, med.
+
+### Perf (maintainer runs ~482 cards / ~35 repos)
+- **Parallelize fleet `_repo_summary`** (`repos_cmd.py:844`) - serial today, ~3 git/IO sweeps per repo. S, high.
+- doctor re-walks the cards tree 3x per run (`doctor.py:352,386,285`). S, high.
+- memory-care `scan` calls `path.stat()` 4x per card (`memory_cmd.py:448,543,551,552`). S, high.
+- `_index_links` re-stats per card (`memory_cmd.py:436,571`). S, high.
+- mtime/hash sidecar index so `scan` skips unchanged cards (`_scan_payload:431-524`); invalidate on config change + date rollover. M, med.
+
+### UX / docs
+- **[shipped] `doctor`/`status --json`.**
+- `ingest` inverted write-defaults: top-level writes by default (`ingest.py:13`), `repos ingest` is dry-run by default (`repos.py:54`). Document both + add a parser-walk guard test. S, high.
+- Parser-walk test enforcing same-named verbs agree on `--apply`/`--dry-run` and read-commands expose `--json` (`test_cli_help.py:8-20` already has the walker). M, high.
+- Document `brigade budgets` (`cli/budgets.py:14`), the `untrusted` station (`cli/untrusted.py:11`), and cover both in the technical-guide tour. S each.
+- Soften README "all harnesses get projected tools/skills" claim - `overview.md:147-159` shows several get only `rules`/`instructions`. S, high.
+- Add a "backing out" / undo subsection (`reconfigure --prune` removes harness files but not root `MEMORY.md`/`AGENTS.md`). S.
+- Mark done-vs-pending state in `work-cmd-split-plan.md` (says "not started" but `work_cmd/` is a 14-module package). S.
+
+## Specials board (leverage-sorted)
+
+- **[high] `security diff`** - new/fixed/persisting findings between two scans, keyed on the existing stable `_fingerprint` (`security_cmd.py:2282`), mirroring `center` report-diff. `brigade security diff --base <dir> --against <dir> [--json]`, nonzero exit on new findings. S.
+- **[high] `brigade operator checkup`** - one command runs every first-run doctor; `lifecycle.py:581,590` already `_capture_json_call`s `tools`+`skills` doctors in sequence. M. Prereq for the #78 fleet sweep.
+- **[high] Surface read-only enforcement strength per harness in `brigade run`** - `agents.py` enforces `--read-only` natively only for codex et al, prompt-only for goose/grok/amp/crush, and not at all for claude + opencode. Print `WARNING: read-only is best-effort for <harness>` + receipt. S.
+- **[high] Expose memory cards over the existing MCP stdio server** - `skills_cmd.py:1319` `serve_mcp` already implements a zero-dep JSON-RPC stdio server for `skill://`; add a read-only `card://` scheme backed by `_iter_cards`. M.
+- **[high] Generate shell completions** for the 594-subcommand surface - pure argparse tree, walkable, zero-dep. `brigade completions bash|zsh|fish`. M-L.
+- **[med] Deterministic keyword search over `memory/cards`** - reuse `_iter_cards`+`_parse_frontmatter`; stdlib precursor to the roadmapped (Later) semantic retrieval. `memory search <term> [--json]`. M.
+- **[med] Route failed runbook steps into work-import** - 30 other sites use `ledger._append_import_records`; runbook closeout (`runbook_cmd.py:370`) does not. M.
+- **[med] `skills uninstall`** to mirror `skills install` - literal inverse, reuses `_install_targets`/`_install_dir` + history receipt. S.
+- **[med] `archive` for `tools call` / `tools checkpoint` queues** - `calls.jsonl` never self-prunes; copy `daily approvals archive` semantics. S.
+- **[med] `projects doctor`** - the one station missing a doctor wrapper; `projects_cmd.health()` already exists. S.
+- **[med] `scrub` receipt + `--json`** - the egress gate is the most safety-critical boundary and the only station with no trail; store summary-only to avoid re-leaking gated PII. S.
+- **[med] AGENTS.md quality lint station (#84)** - `doctor.py:206-258` checks existence + byte budget only. Owner must pin the required-section vocabulary first (brigade's own template uses neither "Definition of Done" nor a handoff-footer heading). M.
+- **[med] `doctor` fleet sweep (#78)** - loop the existing fleet iterator over the operator-doctor payload; build after `operator checkup` + `doctor --json` (shipped). M.
+- **[med] init/doctor detect third-party clones -> recommend `.git/info/exclude` (#81)** - reuse `build_gitignore_block`, recommend-only; needs an owner-identity heuristic. M, med.
+- **[med] Wire `friction scan` staleness into `daily status`** - friction is absent from the daily loop; report latest.json staleness + candidate count, no auto-run. M.
+- **[low] Snapshot on `tools apply`** for rollback (mirror skills install) - `tools_cmd.py:5499` writes with no snapshot. M.
+- **[low] `--json` on `security suppress/unsuppress`** (`cli/security.py:79-89`). S.
+- **[low] `skills lint --fix`** (metadata-only, mirror handoff migrate). M, med.
+- **[low] `runs export`** (portable run summary from `runs_cmd.py:194` show data). S.
+- **[low] `friction list/show`** read past scans (`friction_cmd.py:370-384` writes but no reader). S.
+- **[low] contradictory-card content detection** - today only fires on duplicate ids (`memory_cmd.py:584-600`). M, med.
+- **[low] doctor: separate machine-global from per-repo findings (#80)** - presentation grouping on existing tuples. S.
+
+## Considered and cut
+- skills/tools parity - different concepts by design; the capability exists via user-extensible `adapters.json`.
+- `brigade daily loop` command - `operator guide` already prints the ordered sequence; ~90% duplicative.
+- Stamp a handoff/card format version - misreads the format (section-header markdown), brushes the "never edits canonical memory" non-goal; migrate path is deliberately version-free.
+- Migrate `phases_cmd` report-resolve to reportstore - reverses a documented carve-out (`reportstore.py:12-20`).
+
+## Suggested sequence
+First-contact fixes (#83, #79, atomic receipts) and `doctor/status --json` shipped on
+`fix/doctor-first-contact-and-json`. Next, `security diff` (self-contained, immediate
+value) and the fleet `_repo_summary` parallelization (cheap, high impact). Then
+`operator checkup`, which the `doctor --json` flag now unblocks, followed by the #78
+fleet sweep on top of it. Push the parser-walk consistency test to the end of a batch
+(or xfail it) since it will go red on the ingest/doctor write-default divergences until
+those land.

--- a/src/brigade/cli/doctor.py
+++ b/src/brigade/cli/doctor.py
@@ -15,10 +15,11 @@ def register(sub: argparse._SubParsersAction) -> None:
         choices=["generic", "openclaw", "hermes"],
         default="generic",
     )
+    p_doctor.add_argument("--json", action="store_true", help="Emit machine-readable JSON instead of text.")
     p_doctor.set_defaults(func=dispatch)
 
 
 def dispatch(args) -> int:
     from .. import doctor as doctor_mod
 
-    return doctor_mod.run(target=args.target, harness=args.harness)
+    return doctor_mod.run(target=args.target, harness=args.harness, json_output=args.json)

--- a/src/brigade/cli/status.py
+++ b/src/brigade/cli/status.py
@@ -10,10 +10,11 @@ def register(sub: argparse._SubParsersAction) -> None:
     # status
     p_status = sub.add_parser("status", help="Show which stations are present and healthy.")
     p_status.add_argument("--target", "-t", type=Path, default=Path("."))
+    p_status.add_argument("--json", action="store_true", help="Emit machine-readable JSON instead of text.")
     p_status.set_defaults(func=dispatch)
 
 
 def dispatch(args) -> int:
     from .. import status as status_mod
 
-    return status_mod.run(target=args.target)
+    return status_mod.run(target=args.target, json_output=args.json)

--- a/src/brigade/doctor.py
+++ b/src/brigade/doctor.py
@@ -6,7 +6,7 @@ import json
 import os
 import re
 import shutil
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import List, Tuple
 
@@ -166,17 +166,24 @@ def security_station_checks(ctx: DoctorContext) -> List[CheckResult]:
     return results
 
 
-def run(target: Path, harness: str = "generic") -> int:
-    from .registry import all_stations
-    from . import managed
-
+def run(target: Path, harness: str = "generic", *, json_output: bool = False) -> int:
     ctx = build_context(target, harness)
+    checks = _gather_checks(ctx)
+    if json_output:
+        return _report_json(ctx, checks)
+
     print(f"brigade doctor: target {ctx.target}")
     if ctx.selection is not None:
         sel = ctx.selection
         print(f"  harnesses: {', '.join(sel.harnesses) or '(none)'} (owner={sel.owner}, depth={sel.depth})")
     else:
         print(f"  harnesses: (legacy target, no config; assuming {', '.join(ctx.harnesses)})")
+    return _report(checks)
+
+
+def _gather_checks(ctx: DoctorContext) -> List[CheckResult]:
+    from .registry import all_stations
+    from . import managed
 
     checks: List[CheckResult] = []
     missing_tools: List[Tuple[str, str]] = []
@@ -200,7 +207,7 @@ def run(target: Path, harness: str = "generic") -> int:
                 f"{len(missing_tools)} managed tools not installed ({', '.join(stations)}); optional, install with `brigade add <station>`",
             )
         )
-    return _report(checks)
+    return checks
 
 
 def _check_workspace_files(target: Path) -> List[CheckResult]:
@@ -504,7 +511,10 @@ def _parse_memory_care_scan_date(value: object) -> date | None:
 
 
 def _memory_care_today() -> date:
-    return date.today()
+    # The scanner stamps scan_date in UTC (memory_cmd._today), so the freshness
+    # comparison must also be in UTC. Comparing against a local date made an
+    # evening run in a behind-UTC timezone read a same-day scan as the future.
+    return datetime.now(timezone.utc).date()
 
 
 def _check_publish_gate(target: Path) -> List[CheckResult]:
@@ -691,3 +701,27 @@ def _report(checks: List[CheckResult]) -> int:
     summary = f"summary: {len(checks)} checks, {failed} failed, {manual} manual"
     print(summary)
     return 1 if failed else 0
+
+
+def _report_json(ctx: DoctorContext, checks: List[CheckResult]) -> int:
+    counts = {OK: 0, WARN: 0, FAIL: 0, MANUAL: 0, INFO: 0}
+    for status, _, _ in checks:
+        counts[status] = counts.get(status, 0) + 1
+    sel = ctx.selection
+    payload = {
+        "target": str(ctx.target),
+        "harnesses": list(ctx.harnesses),
+        "owner": getattr(sel, "owner", None),
+        "depth": getattr(sel, "depth", None),
+        "checks": [{"status": status, "name": name, "detail": detail} for status, name, detail in checks],
+        "summary": {
+            "total": len(checks),
+            "ok": counts[OK],
+            "warn": counts[WARN],
+            "manual": counts[MANUAL],
+            "failed": counts[FAIL],
+        },
+        "ready": counts[FAIL] == 0,
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 1 if counts[FAIL] else 0

--- a/src/brigade/localio.py
+++ b/src/brigade/localio.py
@@ -9,8 +9,10 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
 import subprocess
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -41,9 +43,26 @@ def read_json_dict(path: Path) -> dict[str, Any] | None:
 
 
 def write_json(path: Path, payload: dict[str, Any]) -> None:
-    """Write payload as indented, key-sorted JSON, creating parent directories."""
+    """Write payload as indented, key-sorted JSON, atomically, creating parents.
+
+    The write goes to a temp file in the same directory and is swapped in with
+    os.replace, so a reader (or a crashed writer) never observes a half-written
+    receipt: it sees either the old file or the complete new one. On failure the
+    temp file is removed and the existing file is left untouched.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    data = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp")
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, path)
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
 
 
 def read_jsonl_dicts(path: Path) -> list[dict[str, Any]]:

--- a/src/brigade/status.py
+++ b/src/brigade/status.py
@@ -2,21 +2,42 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from . import doctor as _doctor
 from .registry import all_stations
 
 
-def run(target: Path) -> int:
+def run(target: Path, *, json_output: bool = False) -> int:
     ctx = _doctor.build_context(target)
-    print(f"brigade status: {ctx.target}")
-    width = max((len(s.name) for s in all_stations()), default=8)
+    rows = []
     for station in all_stations():
         checks = station.doctor(ctx) if station.doctor else []
         ok = sum(1 for s, _, _ in checks if s == _doctor.OK)
         warn = sum(1 for s, _, _ in checks if s == _doctor.WARN)
         fail = sum(1 for s, _, _ in checks if s == _doctor.FAIL)
         health = "issues" if fail else ("ok" if ok else "empty")
-        print(f"  {station.name.ljust(width)}  [{health}]  {ok} ok, {warn} warn, {fail} fail  - {station.summary}")
+        rows.append(
+            {
+                "station": station.name,
+                "health": health,
+                "ok": ok,
+                "warn": warn,
+                "fail": fail,
+                "summary": station.summary,
+            }
+        )
+
+    if json_output:
+        print(json.dumps({"target": str(ctx.target), "stations": rows}, indent=2, sort_keys=True))
+        return 0
+
+    print(f"brigade status: {ctx.target}")
+    width = max((len(s.name) for s in all_stations()), default=8)
+    for row in rows:
+        print(
+            f"  {row['station'].ljust(width)}  [{row['health']}]  "
+            f"{row['ok']} ok, {row['warn']} warn, {row['fail']} fail  - {row['summary']}"
+        )
     return 0

--- a/src/brigade/templates/depth/workspace.json
+++ b/src/brigade/templates/depth/workspace.json
@@ -26,7 +26,7 @@
     {"src": "scripts/backup-restic.sh", "dst": "scripts/backup-restic.sh", "mode": "0755"}
   ],
   "dirs": [
-    "memory/cards/decay",
+    ".brigade/memory-care/decay",
     "memory/handoff-inbox"
   ]
 }

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime, timezone
 from pathlib import Path
 import json
 
@@ -22,6 +22,59 @@ def test_doctor_passes_against_workspace_profile(tmp_target: Path, capsys):
     out = capsys.readouterr().out
     assert "[ok]" in out
     assert "[fail]" not in out
+
+
+def test_doctor_memory_care_freshness_compares_in_utc(monkeypatch):
+    # Regression for issue #83: the scanner stamps scan_date in UTC, but doctor
+    # compared it against the host's LOCAL date. Run in the evening in a timezone
+    # behind UTC, a same-day scan then read as "in the future". Pin the wall clock
+    # to an instant that is already the 14th in UTC; doctor must read the same UTC
+    # date (not the host's local date), so a 14th-stamped scan reads as today.
+    fixed_utc = datetime(2026, 5, 14, 1, 0, tzinfo=timezone.utc)
+
+    class _FixedClock(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed_utc if tz is not None else fixed_utc.replace(tzinfo=None)
+
+    monkeypatch.setattr(doctor_mod, "datetime", _FixedClock)
+    assert doctor_mod._memory_care_today() == date(2026, 5, 14)
+
+    status, name, detail = doctor_mod._check_memory_care_scan_freshness(Path("decay/scan-latest.json"), "2026-05-14")
+    assert name == "memory-care: scan freshness"
+    assert "in the future" not in detail
+    assert status == doctor_mod.OK
+
+
+def test_doctor_workspace_profile_wires_memory_care_decay_dir(tmp_target: Path, capsys):
+    # Regression for issue #79: a fresh workspace init must create the decay dir
+    # doctor actually looks for (.brigade/memory-care/decay), so first contact does
+    # not warn "staleness scanner not wired" about a dir init was meant to create.
+    install_selection(
+        tmp_target,
+        Selection(depth="workspace", harnesses=["claude"], owner="claude", includes=[]),
+    )
+    assert (tmp_target / ".brigade" / "memory-care" / "decay").is_dir()
+    doctor_mod.run(target=tmp_target, harness="generic")
+    out = capsys.readouterr().out
+    assert "staleness scanner not wired" not in out
+
+
+def test_doctor_json_output_is_structured(tmp_target: Path, capsys):
+    install_selection(
+        tmp_target,
+        Selection(depth="workspace", harnesses=["claude"], owner="claude", includes=[]),
+    )
+    capsys.readouterr()  # drain install output so only the doctor JSON remains
+    rc = doctor_mod.run(target=tmp_target, harness="generic", json_output=True)
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["target"].endswith("ws")
+    assert payload["harnesses"] == ["claude"]
+    assert payload["owner"] == "claude"
+    assert payload["depth"] == "workspace"
+    assert payload["checks"] and {"status", "name", "detail"} <= set(payload["checks"][0])
+    assert payload["summary"]["total"] == len(payload["checks"])
+    assert payload["ready"] is (rc == 0)
 
 
 def test_doctor_reports_failures_on_empty_dir(tmp_target: Path, capsys):

--- a/tests/test_localio.py
+++ b/tests/test_localio.py
@@ -1,0 +1,38 @@
+"""Tests for brigade.localio shared helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from brigade import localio
+
+
+def test_write_json_round_trips_and_is_sorted(tmp_path: Path):
+    path = tmp_path / "nested" / "receipt.json"
+    localio.write_json(path, {"b": 2, "a": 1})
+    assert json.loads(path.read_text()) == {"a": 1, "b": 2}
+    # key-sorted with a trailing newline keeps receipts diff-stable
+    assert path.read_text() == '{\n  "a": 1,\n  "b": 2\n}\n'
+
+
+def test_write_json_is_atomic_and_leaves_original_intact_on_failure(tmp_path: Path, monkeypatch):
+    path = tmp_path / "receipt.json"
+    localio.write_json(path, {"ok": True})
+    original = path.read_text()
+
+    # Force the atomic swap to fail after the temp file is written. The existing
+    # receipt must survive intact (no torn or truncated write) and the temp file
+    # must be cleaned up rather than left as a turd in the directory.
+    def _boom(src, dst):
+        raise OSError("simulated disk full")
+
+    monkeypatch.setattr(localio.os, "replace", _boom)
+    with pytest.raises(OSError):
+        localio.write_json(path, {"ok": False, "padding": "x" * 4096})
+
+    assert path.read_text() == original
+    leftovers = sorted(p.name for p in tmp_path.iterdir() if p.name != "receipt.json")
+    assert leftovers == []

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 from brigade import status as status_mod
@@ -26,3 +27,19 @@ def test_status_runs_on_empty_dir(tmp_target: Path, capsys):
     # status never fails; it reports health, it does not gate
     assert rc == 0
     assert "core" in out
+
+
+def test_status_json_output_is_structured(tmp_target: Path, capsys):
+    install_selection(
+        tmp_target,
+        Selection(depth="workspace", harnesses=["claude"], owner="claude", includes=[]),
+    )
+    capsys.readouterr()  # drain install output so only the status JSON remains
+    rc = status_mod.run(target=tmp_target, json_output=True)
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["target"].endswith("ws")
+    names = {row["station"] for row in payload["stations"]}
+    assert {"core", "memory", "guard", "security"} <= names
+    first = payload["stations"][0]
+    assert {"station", "health", "ok", "warn", "fail", "summary"} <= set(first)


### PR DESCRIPTION
## Summary

Four high-leverage items from a grounded audit of the diagnostics surface: three
first-contact `brigade doctor` bugs and a `--json` flag for the two most diagnostic
commands. The text output paths are unchanged.

## Changes

- **feat:** `brigade doctor --json` and `brigade status --json` emit structured output
  (target, harnesses, owner, depth, per-check status/name/detail, summary counts, and a
  `ready` flag). Unblocks a future fleet aggregation (#78).
- **fix (#83):** memory-care freshness compared a UTC-stamped `scan_date` against the
  host's local date, so an evening run in a behind-UTC timezone reported a same-day scan
  as "in the future". Doctor now compares in UTC, matching the scanner's stamp.
- **fix (#79):** `init --depth workspace` created the legacy `memory/cards/decay` instead
  of the `.brigade/memory-care/decay` dir doctor actually checks, so a fresh workspace
  warned "staleness scanner not wired" on first contact. The template now creates the
  canonical path.
- **fix:** `localio.write_json` writes receipts atomically (temp file + `os.replace`); a
  reader or a crashed writer can no longer observe a half-written receipt, and a failed
  write leaves the original intact.

## Tests

Regression test per fix (`tests/test_localio.py` is new) and a structured-output test per
command. `./scripts/verify` passes: 1140 passed (was 1134).

## Notes

This lands the top picks from `docs/audit/2026-06-16-improvements-and-features-board.md`.
The remaining proposals from that sweep are filed as #85-#90.

Closes #83
Closes #79
