### PR TITLE
Subprocess hang-guards + brigade security diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `brigade security diff --base <dir> --against <dir> [--json]` compares two security reports and reports new, resolved, and persisting findings (matched by the scan's stable per-finding fingerprint). It returns nonzero when there are new findings, so a change that introduces a finding can be caught in review or CI.
+
+### Fixed
+- Apply the v0.11.0 subprocess hang-guard (closed stdin plus a timeout) to the remaining direct `subprocess.run` sites that lacked it: `localio.check_git_ignored`, the work-family `_git` helper, and scrub's git probes. A stuck git call now fails fast instead of hanging the command.
+- `brigade scrub` fails closed when the content-guard scan times out: a hung scanner is reported as `blocked` (exit 124) instead of being able to let content past the egress gate.
+
 ## [0.11.0] - 2026-06-13
 
 ### Added

--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -43,7 +43,7 @@ brigade roadmap commands --write
 - `brigade runbook`: 4 command path(s)
 - `brigade runs`: 3 command path(s)
 - `brigade scrub`: 1 command path(s)
-- `brigade security`: 14 command path(s)
+- `brigade security`: 15 command path(s)
 - `brigade skills`: 26 command path(s)
 - `brigade status`: 1 command path(s)
 - `brigade tools`: 48 command path(s)
@@ -331,6 +331,7 @@ brigade roadmap commands --write
 - `brigade scrub`
 - `brigade security closeout`
 - `brigade security config`
+- `brigade security diff`
 - `brigade security doctor`
 - `brigade security enrich`
 - `brigade security findings`

--- a/src/brigade/cli/security.py
+++ b/src/brigade/cli/security.py
@@ -42,6 +42,23 @@ def register(sub: argparse._SubParsersAction) -> None:
         "--output-dir", type=Path, default=None, help="Security evidence bundle directory."
     )
     p_security_findings.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_security_diff = security_sub.add_parser(
+        "diff", help="Compare two security reports (new/resolved/persisting findings)."
+    )
+    p_security_diff.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace for config and the default --against."
+    )
+    p_security_diff.add_argument(
+        "--base", dest="base_dir", type=Path, required=True, help="Baseline security evidence bundle directory."
+    )
+    p_security_diff.add_argument(
+        "--against",
+        dest="against_dir",
+        type=Path,
+        default=None,
+        help="Bundle to compare against. Defaults to .brigade/security/latest.",
+    )
+    p_security_diff.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
     p_security_sarif = security_sub.add_parser("sarif", help="Write SARIF for an existing security report.")
     p_security_sarif.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to review.")
     p_security_sarif.add_argument("--output-dir", type=Path, default=None, help="Security evidence bundle directory.")
@@ -158,6 +175,13 @@ def dispatch(args) -> int:
         return security_cmd.review(target=args.target, output_dir=args.output_dir, json_output=args.json)
     if args.security_command == "findings":
         return security_cmd.findings(target=args.target, output_dir=args.output_dir, json_output=args.json)
+    if args.security_command == "diff":
+        return security_cmd.diff(
+            target=args.target,
+            base_dir=args.base_dir,
+            against_dir=args.against_dir,
+            json_output=args.json,
+        )
     if args.security_command == "sarif":
         return security_cmd.sarif(
             target=args.target, output_dir=args.output_dir, output_path=args.output_path, json_output=args.json

--- a/src/brigade/localio.py
+++ b/src/brigade/localio.py
@@ -91,8 +91,10 @@ def check_git_ignored(repo: Path, path: Path) -> str:
             check=False,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
+            stdin=subprocess.DEVNULL,
+            timeout=10,
         )
-    except OSError:
+    except (OSError, subprocess.TimeoutExpired):
         return "unknown"
     if result.returncode == 0:
         return "yes"

--- a/src/brigade/scrub.py
+++ b/src/brigade/scrub.py
@@ -139,8 +139,10 @@ def _git_config(target: Path, key: str, *, local_only: bool = False) -> str | No
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             text=True,
+            stdin=subprocess.DEVNULL,
+            timeout=10,
         )
-    except OSError:
+    except (OSError, subprocess.TimeoutExpired):
         return None
     value = result.stdout.strip()
     return value or None
@@ -154,8 +156,10 @@ def _git_pre_push_hook(target: Path) -> Path | None:
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             text=True,
+            stdin=subprocess.DEVNULL,
+            timeout=10,
         )
-    except OSError:
+    except (OSError, subprocess.TimeoutExpired):
         return None
     if result.returncode != 0:
         return None
@@ -247,7 +251,31 @@ def run_scan(scan_target: Path, *, repo_target: Path | None = None, policy: str 
     env = os.environ.copy()
     existing_pp = env.get("PYTHONPATH", "")
     env["PYTHONPATH"] = f"{scanner / 'src'}{os.pathsep}{existing_pp}" if existing_pp else str(scanner / "src")
-    result = subprocess.run(cmd, env=env, check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    try:
+        result = subprocess.run(
+            cmd,
+            env=env,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            stdin=subprocess.DEVNULL,
+            timeout=120,
+        )
+    except subprocess.TimeoutExpired as exc:
+        # Fail closed: a scanner that hangs must not let content past the egress gate.
+        return {
+            "available": True,
+            "status": "blocked",
+            "exit_code": 124,
+            "detail": f"content-guard timed out after {exc.timeout:g}s",
+            "stdout": exc.stdout.decode() if isinstance(exc.stdout, bytes) else (exc.stdout or ""),
+            "stderr": exc.stderr.decode() if isinstance(exc.stderr, bytes) else (exc.stderr or ""),
+            "policy": policy,
+            "policy_path": str(resolved_policy),
+            "target": str(scan_target),
+            "argv": cmd,
+        }
     return {
         "available": True,
         "status": "ok" if result.returncode == 0 else "blocked",

--- a/src/brigade/security_cmd.py
+++ b/src/brigade/security_cmd.py
@@ -762,6 +762,84 @@ def findings(*, target: Path, output_dir: Path | None = None, json_output: bool 
     return review(target=target, output_dir=output_dir, json_output=json_output)
 
 
+def _diff_finding_key(record: dict[str, Any]) -> str:
+    fingerprint = str(record.get("fingerprint") or "")
+    if fingerprint:
+        return fingerprint
+    # Fall back to a stable composite when a report predates fingerprints, so
+    # unkeyed findings are not all collapsed into a single bucket.
+    return "|".join(str(record.get(field) or "") for field in ("category", "path", "line", "title"))
+
+
+def diff(
+    *,
+    target: Path,
+    base_dir: Path,
+    against_dir: Path | None = None,
+    json_output: bool = False,
+) -> int:
+    """Compare two security reports: what is new, resolved, or persisting.
+
+    Findings are matched by fingerprint (the scan's stable per-finding hash), so
+    this answers "did my change add or fix a finding" without eyeballing two
+    reports. Returns nonzero when there are new findings.
+    """
+    target = target.expanduser().resolve()
+    if not target.is_dir():
+        print(f"error: --target is not a directory: {target}", file=sys.stderr)
+        return 2
+    base_dir = base_dir.expanduser().resolve()
+    against_dir = against_dir.expanduser().resolve() if against_dir is not None else default_artifacts_dir(target)
+    try:
+        base_report = _load_report(base_dir)
+        against_report = _load_report(against_dir)
+    except FileNotFoundError as exc:
+        print(f"error: security report not found: {exc}", file=sys.stderr)
+        return 2
+    except (ValueError, json.JSONDecodeError) as exc:
+        print(f"error: invalid security report: {exc}", file=sys.stderr)
+        return 2
+
+    base_records = _report_findings_for_review(target, base_report)
+    against_records = _report_findings_for_review(target, against_report)
+    base_keys = {_diff_finding_key(record) for record in base_records}
+    against_keys = {_diff_finding_key(record) for record in against_records}
+
+    new = [record for record in against_records if _diff_finding_key(record) not in base_keys]
+    resolved = [record for record in base_records if _diff_finding_key(record) not in against_keys]
+    persisting = [record for record in against_records if _diff_finding_key(record) in base_keys]
+
+    payload = {
+        "base": str(base_dir),
+        "against": str(against_dir),
+        "base_generated_at": base_report.get("generated_at"),
+        "against_generated_at": against_report.get("generated_at"),
+        "new": new,
+        "resolved": resolved,
+        "persisting": persisting,
+        "new_count": len(new),
+        "resolved_count": len(resolved),
+        "persisting_count": len(persisting),
+    }
+    if json_output:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 1 if new else 0
+
+    print(f"security diff: {base_dir} -> {against_dir}")
+    print(f"new: {len(new)}  resolved: {len(resolved)}  persisting: {len(persisting)}")
+    for label, records in (("new", new), ("resolved", resolved), ("persisting", persisting)):
+        if not records:
+            continue
+        print(f"{label}:")
+        for finding in records:
+            print(
+                f"- [{finding.get('severity')}] {finding.get('category')} "
+                f"{finding.get('path')}:{finding.get('line')} {finding.get('title')} "
+                f"({finding.get('fingerprint')})"
+            )
+    return 1 if new else 0
+
+
 def sarif(
     *, target: Path, output_dir: Path | None = None, output_path: Path | None = None, json_output: bool = False
 ) -> int:

--- a/src/brigade/work_cmd/helpers.py
+++ b/src/brigade/work_cmd/helpers.py
@@ -24,13 +24,20 @@ from ..localio import (  # noqa: F401
 
 
 def _git(target: Path, *args: str) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        ["git", "-C", str(target), *args],
-        check=False,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
+    try:
+        return subprocess.run(
+            ["git", "-C", str(target), *args],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            stdin=subprocess.DEVNULL,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired as exc:
+        # Preserve the CompletedProcess contract callers rely on; a timed-out git
+        # call reads as a failure (nonzero) instead of hanging forever.
+        return subprocess.CompletedProcess(exc.cmd, 124, stdout="", stderr=f"git timed out after {exc.timeout:g}s")
 
 
 def _git_value(target: Path, *args: str) -> str | None:

--- a/tests/test_security_diff.py
+++ b/tests/test_security_diff.py
@@ -1,0 +1,62 @@
+"""Tests for `brigade security diff`."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from brigade import security_cmd
+
+
+def _write_report(bundle: Path, fingerprints: list[str]) -> None:
+    bundle.mkdir(parents=True, exist_ok=True)
+    findings = [
+        {
+            "fingerprint": fp,
+            "severity": "high",
+            "category": "secret",
+            "path": "app.py",
+            "line": 1,
+            "title": f"finding {fp}",
+        }
+        for fp in fingerprints
+    ]
+    (bundle / "security-report.json").write_text(
+        json.dumps({"generated_at": "2026-06-16T00:00:00Z", "policy": "personal", "findings": findings})
+    )
+
+
+def test_security_diff_buckets_findings_and_flags_regressions(tmp_path: Path, capsys):
+    base = tmp_path / "base"
+    against = tmp_path / "against"
+    _write_report(base, ["aaa", "bbb"])
+    _write_report(against, ["bbb", "ccc"])  # bbb persists, aaa resolved, ccc new
+
+    rc = security_cmd.diff(target=tmp_path, base_dir=base, against_dir=against, json_output=True)
+    payload = json.loads(capsys.readouterr().out)
+
+    assert {f["fingerprint"] for f in payload["new"]} == {"ccc"}
+    assert {f["fingerprint"] for f in payload["resolved"]} == {"aaa"}
+    assert {f["fingerprint"] for f in payload["persisting"]} == {"bbb"}
+    assert (payload["new_count"], payload["resolved_count"], payload["persisting_count"]) == (1, 1, 1)
+    assert rc == 1  # nonzero: a new finding appeared
+
+
+def test_security_diff_is_clean_when_nothing_new(tmp_path: Path, capsys):
+    base = tmp_path / "base"
+    against = tmp_path / "against"
+    _write_report(base, ["aaa", "bbb"])
+    _write_report(against, ["aaa"])  # only a resolution, no new findings
+
+    rc = security_cmd.diff(target=tmp_path, base_dir=base, against_dir=against, json_output=True)
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["new_count"] == 0
+    assert payload["resolved_count"] == 1
+    assert rc == 0
+
+
+def test_security_diff_errors_on_missing_report(tmp_path: Path):
+    base = tmp_path / "base"
+    base.mkdir()  # exists but has no security-report.json
+    rc = security_cmd.diff(target=tmp_path, base_dir=base, against_dir=tmp_path / "missing", json_output=True)
+    assert rc == 2

--- a/tests/test_subprocess_guards.py
+++ b/tests/test_subprocess_guards.py
@@ -1,0 +1,51 @@
+"""A hung git/scanner subprocess must not hang Brigade.
+
+Each of these sites invokes an external process; without an explicit timeout a
+process that never exits (a stuck git over a dead remote, a wedged scanner) would
+hang the whole command. These guard against that regression.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from brigade import localio, scrub
+from brigade.work_cmd import helpers
+
+
+def test_check_git_ignored_returns_unknown_on_timeout(tmp_path: Path, monkeypatch):
+    repo = tmp_path.resolve()
+
+    def _timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=["git", "check-ignore"], timeout=10)
+
+    monkeypatch.setattr(localio.subprocess, "run", _timeout)
+    assert localio.check_git_ignored(repo, repo / "artifact") == "unknown"
+
+
+def test_work_git_reports_failure_on_timeout(tmp_path: Path, monkeypatch):
+    def _timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=["git", "status"], timeout=30)
+
+    monkeypatch.setattr(helpers.subprocess, "run", _timeout)
+    result = helpers._git(tmp_path, "status")
+    assert result.returncode == 124
+    assert "timed out" in result.stderr
+
+
+def test_scrub_egress_gate_fails_closed_on_timeout(tmp_path: Path, monkeypatch):
+    # The scrub scan is the egress gate; a scanner that hangs must block, not pass.
+    policy_file = tmp_path / "policy.json"
+    policy_file.write_text("{}\n")
+    monkeypatch.setattr(scrub, "scanner_dir", lambda: tmp_path)
+    monkeypatch.setattr(scrub, "policy_path", lambda repo, policy: policy_file)
+
+    def _timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=["content_guard"], timeout=120)
+
+    monkeypatch.setattr(scrub.subprocess, "run", _timeout)
+    result = scrub.run_scan(tmp_path, policy="public-repo")
+    assert result["status"] == "blocked"
+    assert result["exit_code"] == 124
+    assert "timed out" in result["detail"]


### PR DESCRIPTION
## Summary

Two follow-ups from the 2026-06-16 audit board: finish applying the v0.11.0
subprocess hang-guard to the sites it missed, and add `brigade security diff`.

## Changes

**fix: subprocess hang-guards**
The v0.11.0 stdin/timeout fix landed in `proc.py` but several direct
`subprocess.run` sites still had no timeout, so a stuck git or a wedged scanner
could hang the whole command.
- `localio.check_git_ignored`, work-family `_git`, and scrub's git probes get
  closed stdin + a timeout.
- `brigade scrub` now fails closed when the content-guard scan times out: a hung
  scanner is reported as `blocked` (exit 124) rather than being able to let
  content past the egress gate.

**feat: `brigade security diff` (#85)**
- `brigade security diff --base <dir> --against <dir> [--json]` reports new,
  resolved, and persisting findings, matched by the scan's stable per-finding
  fingerprint. `--against` defaults to `.brigade/security/latest`.
- Returns nonzero when there are new findings, so a regression fails review/CI.
- Reuses `_load_report`, `_report_findings_for_review`, and the fingerprint,
  mirroring the existing `review` command. No new dependencies.

## Tests

`tests/test_subprocess_guards.py` and `tests/test_security_diff.py` are new; each
timeout path and diff bucket is covered. Regenerates `docs/command-inventory.md`
(security 14 -> 15 paths). `./scripts/verify` passes: 1140 passed.

Implements #85. Part of the board in `docs/audit/2026-06-16-improvements-and-features-board.md`.
