### PR TITLE
perf: parallelize repo fleet summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `brigade doctor --json` and `brigade status --json` emit machine-readable output (target, harnesses, owner, depth, per-check status/name/detail, summary counts, and a `ready` flag), so the two most diagnostic surfaces can feed scripts and a future fleet aggregation instead of being text-only.
 - `brigade security diff --base <dir> --against <dir> [--json]` compares two security reports and reports new, resolved, and persisting findings (matched by the scan's stable per-finding fingerprint). It returns nonzero when there are new findings, so a change that introduces a finding can be caught in review or CI.
 
+### Changed
+- The repo fleet scan now summarizes repos on a small thread pool instead of serially. Each summary is independent and IO-bound (git calls plus file stats), so a multi-repo fleet scans noticeably faster while output stays in config order; a single-repo fleet is unchanged.
+
 ### Fixed
 - `brigade doctor` memory-care freshness no longer reports a same-day scan as "in the future". The scanner stamps `scan_date` in UTC, but doctor compared it against the host's local date, so an evening run in a behind-UTC timezone warned falsely (issue #83). Doctor now compares in UTC.
 - `brigade init --depth workspace` now creates `.brigade/memory-care/decay`, the directory doctor actually checks, instead of the legacy `memory/cards/decay`. A fresh workspace no longer draws a "staleness scanner not wired" warning on first contact (issue #79).

--- a/src/brigade/repos_cmd.py
+++ b/src/brigade/repos_cmd.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import shutil
 import fnmatch
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -753,6 +754,20 @@ def _repo_summary(entry: RepoEntry) -> dict[str, Any]:
     }
 
 
+def _repo_summaries(entries: list[RepoEntry]) -> list[dict[str, Any]]:
+    """Summarize every enabled repo, in config order.
+
+    Each summary is independent and IO-bound (git calls plus file stats), so a
+    multi-repo fleet runs them on a small thread pool; executor.map preserves the
+    config order the rest of the scan depends on. A single repo stays serial.
+    """
+    enabled = [entry for entry in entries if entry.enabled]
+    if len(enabled) <= 1:
+        return [_repo_summary(entry) for entry in enabled]
+    with ThreadPoolExecutor(max_workers=min(8, len(enabled))) as executor:
+        return list(executor.map(_repo_summary, enabled))
+
+
 def _repo_checks(summary: dict[str, Any]) -> list[dict[str, Any]]:
     repo_id = str(summary.get("id") or "unknown")
     checks: list[dict[str, Any]] = []
@@ -841,7 +856,7 @@ def _repo_checks(summary: dict[str, Any]) -> list[dict[str, Any]]:
 def scan_payload(target: Path) -> dict[str, Any]:
     target = target.expanduser().resolve()
     entries, errors, config_loaded = _load_config(target)
-    repos = [_repo_summary(entry) for entry in entries if entry.enabled]
+    repos = _repo_summaries(entries)
     checks: list[dict[str, Any]] = []
     if errors:
         checks.extend({"status": WARN, "name": "repo_fleet_config", "detail": error} for error in errors)

--- a/tests/test_repos_cmd.py
+++ b/tests/test_repos_cmd.py
@@ -290,6 +290,17 @@ def test_repo_summary_counts_opencode_inbox(tmp_path):
     assert ".opencode/memory-handoffs" in summary["handoff_inboxes"]
 
 
+def test_repo_summaries_preserve_config_order_and_skip_disabled(tmp_path, monkeypatch):
+    # The fleet sweep runs summaries on a thread pool; output must stay in config
+    # order and exclude disabled repos regardless of which thread finishes first.
+    entries = [
+        repos_cmd.RepoEntry(repo_id=f"r{i}", label=f"R{i}", path=tmp_path, enabled=(i % 4 != 0)) for i in range(1, 9)
+    ]
+    monkeypatch.setattr(repos_cmd, "_repo_summary", lambda entry: {"id": entry.repo_id})
+    result = repos_cmd._repo_summaries(entries)
+    assert [row["id"] for row in result] == [entry.repo_id for entry in entries if entry.enabled]
+
+
 def test_repo_summary_counts_antigravity_inbox(tmp_path):
     from brigade import repos_cmd
 


### PR DESCRIPTION
## Summary

The repo fleet scan summarized each enabled repo serially. Every summary runs
several git calls plus file stats, so on a multi-repo fleet the IO latency added
up in series.

## Change

`scan_payload` now maps `_repo_summary` over the enabled entries on a small
bounded `ThreadPoolExecutor` (max 8 workers). `executor.map` preserves config
order, which the rest of the scan depends on, and a single-repo fleet stays
serial. Each summary is independent and only reads the filesystem, so there is no
shared state.

## Tests

Adds a test asserting summaries stay in config order and skip disabled repos.
`./scripts/verify` passes: 1147 passed.

From the board in `docs/audit/2026-06-16-improvements-and-features-board.md`.
