### PR TITLE
feat: brigade operator checkup (run all first-run doctors)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `brigade doctor --json` and `brigade status --json` emit machine-readable output (target, harnesses, owner, depth, per-check status/name/detail, summary counts, and a `ready` flag), so the two most diagnostic surfaces can feed scripts and a future fleet aggregation instead of being text-only.
 - `brigade security diff --base <dir> --against <dir> [--json]` compares two security reports and reports new, resolved, and persisting findings (matched by the scan's stable per-finding fingerprint). It returns nonzero when there are new findings, so a change that introduces a finding can be caught in review or CI.
+- `brigade operator checkup [--json]` runs every read-only first-run doctor (`doctor`, `operator doctor`, `handoff doctor`, `tools doctor`, `skills doctor`, `security doctor`) in one pass and rolls them up to a single `ready` / `blocking_surfaces` verdict with the next command to run, so a new operator no longer has to copy-paste each doctor from the first-10-minutes guide.
 
 ### Changed
 - The repo fleet scan now summarizes repos on a small thread pool instead of serially. Each summary is independent and IO-bound (git calls plus file stats), so a multi-repo fleet scans noticeably faster while output stays in config order; a single-repo fleet is unchanged.

--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -30,7 +30,7 @@ brigade roadmap commands --write
 - `brigade memory`: 8 command path(s)
 - `brigade notifications`: 4 command path(s)
 - `brigade openclaw-fragments`: 1 command path(s)
-- `brigade operator`: 22 command path(s)
+- `brigade operator`: 23 command path(s)
 - `brigade pantry`: 3 command path(s)
 - `brigade projects`: 9 command path(s)
 - `brigade reconfigure`: 1 command path(s)
@@ -180,6 +180,7 @@ brigade roadmap commands --write
 - `brigade operator adopt import-issues`
 - `brigade operator adopt plan`
 - `brigade operator bootstrap-portable`
+- `brigade operator checkup`
 - `brigade operator doctor`
 - `brigade operator guide`
 - `brigade operator init`

--- a/src/brigade/cli/operator.py
+++ b/src/brigade/cli/operator.py
@@ -213,6 +213,19 @@ def register(sub: argparse._SubParsersAction) -> None:
         help="Operator profile to inspect.",
     )
     p_operator_doctor.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_operator_checkup = operator_sub.add_parser(
+        "checkup", help="Run every read-only first-run doctor at once and roll up the verdict."
+    )
+    p_operator_checkup.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    p_operator_checkup.add_argument(
+        "--profile",
+        choices=["local-operator", "internal-dogfood"],
+        default="internal-dogfood",
+        help="Operator profile to inspect.",
+    )
+    p_operator_checkup.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
     p_operator_verify_harness = operator_sub.add_parser(
         "verify-harness", help="Verify repo-local wiring for one harness."
     )
@@ -373,6 +386,8 @@ def dispatch(args) -> int:
         return operator_cmd.status(target=args.target, profile=args.profile, json_output=args.json)
     if args.operator_command == "doctor":
         return operator_cmd.doctor(target=args.target, profile=args.profile, json_output=args.json)
+    if args.operator_command == "checkup":
+        return operator_cmd.checkup(target=args.target, profile=args.profile, json_output=args.json)
     if args.operator_command == "verify-harness":
         return operator_cmd.verify_harness(target=args.target, harness=args.harness, json_output=args.json)
     if args.operator_command == "sync-tools":

--- a/src/brigade/operator_cmd/__init__.py
+++ b/src/brigade/operator_cmd/__init__.py
@@ -27,6 +27,8 @@ from .health import (
 )
 from .lifecycle import (
     bootstrap_portable,
+    checkup,
+    checkup_payload,
     init,
     quickstart,
     sync_tools,
@@ -61,6 +63,8 @@ __all__ = [
     "adoption_plan",
     "adoption_plan_payload",
     "bootstrap_portable",
+    "checkup",
+    "checkup_payload",
     "doctor",
     "doctor_payload",
     "guide",

--- a/src/brigade/operator_cmd/lifecycle.py
+++ b/src/brigade/operator_cmd/lifecycle.py
@@ -7,11 +7,11 @@ from io import StringIO
 from pathlib import Path
 from typing import Any
 
-from .. import center_cmd, security_cmd, skills_cmd, tools_cmd
+from .. import center_cmd, doctor as core_doctor, handoff_cmd, security_cmd, skills_cmd, tools_cmd
 from ..install import install_selection
 from ..selection import KNOWN_HARNESSES, WRITER_INBOXES, Selection, resolve_owner
 from .guide import _steps, _validate_profile, plan_payload
-from .health import verify_harness
+from .health import doctor as operator_doctor, verify_harness
 
 
 def init(
@@ -626,3 +626,80 @@ def bootstrap_portable(
         for command in payload["next_commands"]:
             print(f"- {command}")
     return 0 if ok else 1
+
+
+def _surface_issue_count(payload: dict[str, Any]) -> int | None:
+    for key in ("blocking_issue_count", "issue_count"):
+        value = payload.get(key)
+        if isinstance(value, int):
+            return value
+    summary = payload.get("summary")
+    if isinstance(summary, dict) and isinstance(summary.get("failed"), int):
+        return summary["failed"]
+    return None
+
+
+def checkup_payload(target: Path, *, profile: str = "internal-dogfood") -> dict[str, Any]:
+    """Run every read-only first-run doctor once and roll the verdicts up.
+
+    The first-10-minutes path has an operator run several separate doctors by
+    hand. checkup runs them in one pass, captures each one's JSON, and reports a
+    single ready/blocking verdict. Each surface's exit code is the source of
+    truth for readiness; the issue count is informational. Nothing here writes
+    files (security scan and verify-harness are deliberately excluded).
+    """
+    target = target.expanduser().resolve()
+    spec = [
+        ("doctor", "brigade doctor --target .", core_doctor.run, {"target": target}),
+        ("operator", "brigade operator doctor --target .", operator_doctor, {"target": target, "profile": profile}),
+        ("handoff", "brigade handoff doctor --target .", handoff_cmd.doctor, {"target": target}),
+        ("tools", "brigade tools doctor --target .", tools_cmd.doctor, {"target": target}),
+        ("skills", "brigade skills doctor --target .", skills_cmd.doctor, {"target": target}),
+        ("security", "brigade security doctor --target .", security_cmd.doctor, {"target": target}),
+    ]
+    surfaces: list[dict[str, Any]] = []
+    blocking = 0
+    for name, command, func, kwargs in spec:
+        rc, payload = _capture_json_call(func, **kwargs)
+        surface_ready = rc == 0
+        if not surface_ready:
+            blocking += 1
+        surfaces.append(
+            {
+                "name": name,
+                "command": command,
+                "ready": surface_ready,
+                "exit_code": rc,
+                "issue_count": _surface_issue_count(payload),
+            }
+        )
+    ready = blocking == 0
+    next_command = next((surface["command"] for surface in surfaces if not surface["ready"]), None)
+    return {
+        "target": str(target),
+        "profile": profile,
+        "ready": ready,
+        "blocking_surface_count": blocking,
+        "surfaces": surfaces,
+        "next_command": next_command,
+    }
+
+
+def checkup(*, target: Path, profile: str = "internal-dogfood", json_output: bool = False) -> int:
+    payload = checkup_payload(target, profile=profile)
+    if json_output:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0 if payload["ready"] else 1
+
+    print(f"operator checkup: {payload['target']}")
+    print(f"profile: {payload['profile']}")
+    for surface in payload["surfaces"]:
+        mark = "ok" if surface["ready"] else "fail"
+        count = surface["issue_count"]
+        suffix = f" ({count} issue{'s' if count != 1 else ''})" if isinstance(count, int) and count else ""
+        print(f"  [{mark}] {surface['name']}{suffix}")
+    print(f"ready: {'yes' if payload['ready'] else 'no'}")
+    print(f"blocking_surfaces: {payload['blocking_surface_count']}")
+    if payload["next_command"]:
+        print(f"next: {payload['next_command']}")
+    return 0 if payload["ready"] else 1

--- a/tests/test_operator_checkup.py
+++ b/tests/test_operator_checkup.py
@@ -1,0 +1,72 @@
+"""Tests for `brigade operator checkup`."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from brigade import cli
+from brigade.operator_cmd import lifecycle
+
+
+def _stub(rc: int, payload: dict):
+    def _doctor(**kwargs):
+        print(json.dumps(payload))
+        return rc
+
+    return _doctor
+
+
+def _patch_all_doctors(monkeypatch, *, skills_rc: int = 0):
+    monkeypatch.setattr(lifecycle.core_doctor, "run", _stub(0, {"ready": True, "summary": {"failed": 0}}))
+    monkeypatch.setattr(lifecycle, "operator_doctor", _stub(0, {"ready": True, "blocking_issue_count": 0}))
+    monkeypatch.setattr(lifecycle.handoff_cmd, "doctor", _stub(0, {"issue_count": 0}))
+    monkeypatch.setattr(lifecycle.tools_cmd, "doctor", _stub(0, {"issue_count": 0}))
+    monkeypatch.setattr(lifecycle.skills_cmd, "doctor", _stub(skills_rc, {"issue_count": 3 if skills_rc else 0}))
+    monkeypatch.setattr(lifecycle.security_cmd, "doctor", _stub(0, {"issue_count": 0}))
+
+
+def test_operator_checkup_rolls_up_each_first_run_doctor(monkeypatch, capsys):
+    _patch_all_doctors(monkeypatch, skills_rc=1)  # one failing surface
+    rc = lifecycle.checkup(target=Path("."), json_output=True)
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 1
+    assert payload["ready"] is False
+    assert payload["blocking_surface_count"] == 1
+    assert [s["name"] for s in payload["surfaces"]] == [
+        "doctor",
+        "operator",
+        "handoff",
+        "tools",
+        "skills",
+        "security",
+    ]
+    skills = next(s for s in payload["surfaces"] if s["name"] == "skills")
+    assert skills["ready"] is False
+    assert skills["issue_count"] == 3
+    assert payload["next_command"] == "brigade skills doctor --target ."
+
+
+def test_operator_checkup_is_ready_when_all_surfaces_pass(monkeypatch, capsys):
+    _patch_all_doctors(monkeypatch, skills_rc=0)
+    rc = lifecycle.checkup(target=Path("."), json_output=True)
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["ready"] is True
+    assert payload["blocking_surface_count"] == 0
+    assert payload["next_command"] is None
+
+
+def test_operator_checkup_cli_dispatch(monkeypatch, tmp_path):
+    seen = {}
+
+    def fake_checkup(**kwargs):
+        seen.update(kwargs)
+        return 0
+
+    from brigade import operator_cmd
+
+    monkeypatch.setattr(operator_cmd, "checkup", fake_checkup)
+    assert cli.main(["operator", "checkup", "--target", str(tmp_path), "--json"]) == 0
+    assert seen == {"target": tmp_path, "profile": "internal-dogfood", "json_output": True}


### PR DESCRIPTION
## Summary

The first-10-minutes path makes a new operator run several separate doctors by
hand. `brigade operator checkup` runs them all in one pass and gives a single
verdict.

## Change

- `brigade operator checkup [--json]` runs every read-only first-run doctor
  (`doctor`, `operator doctor`, `handoff doctor`, `tools doctor`, `skills doctor`,
  `security doctor`) via the existing `_capture_json_call` pattern, captures each
  one's JSON, and rolls them up to `ready` / `blocking_surfaces` plus the next
  command to run. Exits nonzero when any surface is not ready.
- Each surface's exit code is the readiness signal; the issue count is
  informational. `security scan` and `verify-harness` are excluded because they
  write files / need a specific harness.
- `brigade doctor --json` (shipped earlier this batch) is what makes the core
  workspace surface aggregatable here.

## Tests

`tests/test_operator_checkup.py` covers the rollup, the all-ready case, and CLI
dispatch. Regenerates `docs/command-inventory.md` (operator 22 -> 23).
`./scripts/verify` passes: 1150 passed. Live smoke on a fresh workspace returns a
sensible per-surface verdict.

Implements #86. From the board in `docs/audit/2026-06-16-improvements-and-features-board.md`.
