### PR TITLE
fix: init gitignore plumbing (--no-gitignore no-op, worktree --git-exclude)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `brigade init --git-exclude` writes Brigade's ignore block to the local-only `.git/info/exclude` instead of the tracked `.gitignore`, for third-party clones you do not want to commit Brigade ignores into (issue #81). Automatic detection of a third-party clone is intentionally deferred: there is no reliable repo-owner signal, and a guess would false-positive on your own published repos.
 
 ### Fixed
+- `brigade init --no-gitignore` is now honored. The flag was parsed but never forwarded to the installer, so a `.gitignore` was written anyway; `install_selection` now takes `update_gitignore` and skips the write when asked.
+- `brigade init --git-exclude` now resolves a linked-worktree `.git` file (`gitdir: <path>`) to write the exclude under the worktree's own git dir, instead of silently falling back to a tracked `.gitignore`.
 - The seeded `pre-push` content-guard hook no longer reports a scanner error as a content leak. It now discriminates content-guard's exit codes: exit 1 (findings) blocks with the leak message, any other nonzero exit is reported as "scanner failed to run" rather than mislabeled as violations (issue #82).
 - `brigade doctor` memory-care freshness no longer reports a same-day scan as "in the future". The scanner stamps `scan_date` in UTC, but doctor compared it against the host's local date, so an evening run in a behind-UTC timezone warned falsely (issue #83). Doctor now compares in UTC.
 - `brigade init --depth workspace` now creates `.brigade/memory-care/decay`, the directory doctor actually checks, instead of the legacy `memory/cards/decay`. A fresh workspace no longer draws a "staleness scanner not wired" warning on first contact (issue #79).

--- a/src/brigade/cli/init.py
+++ b/src/brigade/cli/init.py
@@ -88,6 +88,7 @@ def dispatch(args) -> int:
             dry_run=getattr(args, "dry_run", False),
             allow_home=getattr(args, "allow_home", False),
             use_git_exclude=getattr(args, "git_exclude", False),
+            update_gitignore=getattr(args, "update_gitignore", True),
         )
 
     # No selection flags: interactive prompt.
@@ -107,4 +108,5 @@ def dispatch(args) -> int:
         dry_run=getattr(args, "dry_run", False),
         allow_home=getattr(args, "allow_home", False),
         use_git_exclude=getattr(args, "git_exclude", False),
+        update_gitignore=getattr(args, "update_gitignore", True),
     )

--- a/src/brigade/install.py
+++ b/src/brigade/install.py
@@ -133,6 +133,29 @@ def build_gitignore_block(selection: Selection) -> str:
     return "\n".join(lines)
 
 
+def _git_info_dir(target: Path) -> Path | None:
+    """Resolve the git `info/` dir that holds `exclude`, or None when there is no git dir.
+
+    Handles both a normal `.git` directory and a linked-worktree `.git` file
+    ("gitdir: <path>"), whose exclude lives under the worktree's own git dir.
+    """
+    git_path = target / ".git"
+    if git_path.is_dir():
+        return git_path / "info"
+    if git_path.is_file():
+        try:
+            content = git_path.read_text().strip()
+        except OSError:
+            return None
+        if content.startswith("gitdir:"):
+            gitdir = Path(content.split(":", 1)[1].strip())
+            if not gitdir.is_absolute():
+                gitdir = (target / gitdir).resolve()
+            if gitdir.is_dir():
+                return gitdir / "info"
+    return None
+
+
 def apply_gitignore(target: Path, selection: Selection, *, use_git_exclude: bool = False) -> str:
     """Insert or replace the managed ignore block. Returns a 'created/updated (<file>)' label.
 
@@ -142,10 +165,11 @@ def apply_gitignore(target: Path, selection: Selection, *, use_git_exclude: bool
     when there is no `.git` directory to hold it.
     """
     block = build_gitignore_block(selection)
-    if use_git_exclude and (target / ".git").is_dir():
-        gi = target / ".git" / "info" / "exclude"
+    exclude_dir = _git_info_dir(target) if use_git_exclude else None
+    if exclude_dir is not None:
+        gi = exclude_dir / "exclude"
         gi.parent.mkdir(parents=True, exist_ok=True)
-        location = ".git/info/exclude"
+        location = "git info/exclude"
     else:
         gi = target / ".gitignore"
         location = ".gitignore"
@@ -247,6 +271,7 @@ def install_selection(
     dry_run: bool = False,
     allow_home: bool = False,
     use_git_exclude: bool = False,
+    update_gitignore: bool = True,
 ) -> int:
     """Install a Selection into `target`. Returns process exit code."""
     selection.validate()
@@ -325,8 +350,11 @@ def install_selection(
     # Persist config.json.
     write_config(target, Config(version=1, selection=selection))
 
-    result = apply_gitignore(target, selection, use_git_exclude=use_git_exclude)
-    print(f"brigade: gitignore {result}")
+    if update_gitignore:
+        result = apply_gitignore(target, selection, use_git_exclude=use_git_exclude)
+        print(f"brigade: gitignore {result}")
+    else:
+        print("brigade: gitignore skipped (--no-gitignore)")
 
     # Post-install output.
     print(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -17,6 +17,49 @@ def _workspace_sel() -> Selection:
     return Selection(depth="workspace", harnesses=["claude"], owner="claude", includes=[])
 
 
+def test_init_no_gitignore_skips_gitignore(tmp_target: Path):
+    tmp_target.mkdir(parents=True, exist_ok=True)
+    assert install_selection(tmp_target, _workspace_sel(), update_gitignore=False) == 0
+    gitignore = tmp_target / ".gitignore"
+    assert not gitignore.exists() or "brigade gitignore block" not in gitignore.read_text()
+
+
+def test_init_cli_no_gitignore_flag_reaches_install(monkeypatch, tmp_path: Path):
+    # Regression: the --no-gitignore flag was parsed but never forwarded.
+    seen: dict = {}
+
+    def fake_install(**kwargs):
+        seen.update(kwargs)
+        return 0
+
+    monkeypatch.setattr("brigade.install.install_selection", fake_install)
+    from brigade import cli
+
+    assert (
+        cli.main(["init", "--target", str(tmp_path), "--depth", "repo", "--harnesses", "claude", "--no-gitignore"]) == 0
+    )
+    assert seen["update_gitignore"] is False
+
+
+def test_git_info_dir_resolves_dir_file_and_absent(tmp_path: Path):
+    from brigade.install import _git_info_dir
+
+    repo = tmp_path / "repo"
+    (repo / ".git" / "info").mkdir(parents=True)
+    assert _git_info_dir(repo) == repo / ".git" / "info"
+
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    real_gitdir = tmp_path / "realgit"
+    (real_gitdir / "info").mkdir(parents=True)
+    (worktree / ".git").write_text(f"gitdir: {real_gitdir}\n")
+    assert _git_info_dir(worktree) == real_gitdir / "info"
+
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    assert _git_info_dir(plain) is None
+
+
 def test_init_git_exclude_writes_to_git_info_exclude(tmp_target: Path):
     # issue #81: in a third-party clone, write ignores to .git/info/exclude
     # (local-only) instead of the tracked .gitignore.


### PR DESCRIPTION
## Summary

Two gitignore-plumbing fixes found while reviewing the board-cleanup work.

- **`brigade init --no-gitignore` was a no-op.** The flag set `dest=update_gitignore`
  but `install_selection` never accepted or honored it, so `.gitignore` was written
  regardless. `install_selection` now takes `update_gitignore` and skips the write
  (printing `gitignore skipped`) when asked; both init dispatch paths forward it.
- **`--git-exclude` now handles linked worktrees.** A worktree's `.git` is a file
  (`gitdir: <path>`), not a directory, so the previous `.git.is_dir()` check fell
  back to a tracked `.gitignore`. A new `_git_info_dir` helper resolves the real git
  dir (directory or worktree file) and writes the exclude there.

## Tests

`tests/test_init.py` adds: `--no-gitignore` skips the write, the CLI flag actually
reaches the installer, and `_git_info_dir` resolves dir / worktree-file / absent.
`./scripts/verify` passes: 1185 passed.
