### PR TITLE
refactor: share one MCP stdio harness (skills + memory)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `brigade friction show [--severity] [--json]` reads back the latest friction scan, which previously could only be written (issue #90).
 
 ### Changed
+- Internal: the skills and memory MCP stdio servers now share one harness (`mcp_server.serve_stdio`) instead of carrying near-identical JSON-RPC loops. No command surface or protocol change; a new read-only MCP surface is now a few callbacks.
 - The repo fleet scan now summarizes repos on a small thread pool instead of serially. Each summary is independent and IO-bound (git calls plus file stats), so a multi-repo fleet scans noticeably faster while output stays in config order; a single-repo fleet is unchanged.
 - `brigade doctor` now groups host-global findings (OpenClaw config, the content-guard clone, uninstalled managed tools) under a "machine-level (not specific to this repo)" header in text output and tags each check with a `scope` of `repo` or `machine` in `--json`, so a single-repo run no longer reads as if the repo is responsible for machine-wide state (issue #80).
 - `brigade security suppress` and `brigade security unsuppress` gain `--json`, so an agent or CI step can parse the suppression result (issue #90).

--- a/src/brigade/mcp_server.py
+++ b/src/brigade/mcp_server.py
@@ -1,0 +1,96 @@
+"""Shared zero-dependency MCP stdio server harness.
+
+Several stations expose their local data over a read-only MCP stdio server
+(skills, memory cards). The JSON-RPC envelope and the request loop are identical;
+only the resources and tools differ. Each station supplies four callbacks and
+this module owns the protocol, so a new read-only MCP surface is a few lines.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any, Callable
+
+ResourceLister = Callable[[], list[dict[str, Any]]]
+ResourceReader = Callable[[str], "tuple[str | None, str | None]"]
+ToolLister = Callable[[], list[dict[str, Any]]]
+ToolCaller = Callable[[str, dict[str, Any]], "tuple[object, bool]"]
+
+
+def response(
+    request_id: object, *, result: object | None = None, error: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {"jsonrpc": "2.0", "id": request_id}
+    if error is not None:
+        payload["error"] = error
+    else:
+        payload["result"] = result if result is not None else {}
+    return payload
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    print(json.dumps(payload, sort_keys=True), flush=True)
+
+
+def serve_stdio(
+    *,
+    server_name: str,
+    list_resources: ResourceLister,
+    read_resource: ResourceReader,
+    list_tools: ToolLister,
+    call_tool: ToolCaller,
+) -> int:
+    """Run a read-only MCP server over stdin/stdout until EOF.
+
+    read_resource returns (text, mime_type) or (None, None) when the uri is not
+    served. call_tool returns (payload, is_error); a non-string payload is
+    rendered as indented JSON.
+    """
+    for line in sys.stdin:
+        if not line.strip():
+            continue
+        try:
+            request = json.loads(line)
+        except json.JSONDecodeError:
+            _emit(response(None, error={"code": -32700, "message": "parse error"}))
+            continue
+        if not isinstance(request, dict):
+            _emit(response(None, error={"code": -32600, "message": "invalid request"}))
+            continue
+        request_id = request.get("id")
+        method = str(request.get("method") or "")
+        params = request.get("params") if isinstance(request.get("params"), dict) else {}
+        if request_id is None and method.startswith("notifications/"):
+            continue
+        if method == "initialize":
+            _emit(
+                response(
+                    request_id,
+                    result={
+                        "protocolVersion": "2024-11-05",
+                        "capabilities": {"resources": {}, "tools": {}},
+                        "serverInfo": {"name": server_name, "version": "0"},
+                    },
+                )
+            )
+        elif method == "resources/list":
+            _emit(response(request_id, result={"resources": list_resources()}))
+        elif method == "resources/read":
+            uri = str(params.get("uri") or "")
+            text, mime_type = read_resource(uri)
+            if text is None:
+                _emit(response(request_id, error={"code": -32004, "message": f"resource not found: {uri}"}))
+            else:
+                _emit(response(request_id, result={"contents": [{"uri": uri, "mimeType": mime_type, "text": text}]}))
+        elif method == "tools/list":
+            _emit(response(request_id, result={"tools": list_tools()}))
+        elif method == "tools/call":
+            name = str(params.get("name") or "")
+            arguments = params.get("arguments") if isinstance(params.get("arguments"), dict) else {}
+            payload, failed = call_tool(name, arguments)
+            text = payload if isinstance(payload, str) else json.dumps(payload, indent=2, sort_keys=True)
+            _emit(response(request_id, result={"content": [{"type": "text", "text": text}], "isError": failed}))
+        else:
+            _emit(response(request_id, error={"code": -32601, "message": f"method not found: {method}"}))
+    return 0

--- a/src/brigade/memory_cmd.py
+++ b/src/brigade/memory_cmd.py
@@ -12,7 +12,7 @@ from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from . import toml_compat as tomllib, work_cmd
+from . import mcp_server, toml_compat as tomllib, work_cmd
 from .install import apply_gitignore
 from .selection import Selection
 from .localio import utc_now_iso_z as _utc_iso
@@ -1378,91 +1378,15 @@ def _mcp_card_tool_call(
     return (f"unknown tool: {name}", True)
 
 
-def _mcp_response(
-    request_id: object, *, result: object | None = None, error: dict[str, Any] | None = None
-) -> dict[str, Any]:
-    response: dict[str, Any] = {"jsonrpc": "2.0", "id": request_id}
-    if error is not None:
-        response["error"] = error
-    else:
-        response["result"] = result if result is not None else {}
-    return response
-
-
 def _run_card_mcp_stdio(target: Path) -> int:
     config = load_config(target) or MemoryCareConfig()
-    for line in sys.stdin:
-        if not line.strip():
-            continue
-        try:
-            request = json.loads(line)
-        except json.JSONDecodeError:
-            print(json.dumps(_mcp_response(None, error={"code": -32700, "message": "parse error"})), flush=True)
-            continue
-        if not isinstance(request, dict):
-            print(json.dumps(_mcp_response(None, error={"code": -32600, "message": "invalid request"})), flush=True)
-            continue
-        request_id = request.get("id")
-        method = str(request.get("method") or "")
-        params = request.get("params") if isinstance(request.get("params"), dict) else {}
-        if request_id is None and method.startswith("notifications/"):
-            continue
-        if method == "initialize":
-            result = {
-                "protocolVersion": "2024-11-05",
-                "capabilities": {"resources": {}, "tools": {}},
-                "serverInfo": {"name": "brigade-memory-readonly", "version": "0"},
-            }
-            print(json.dumps(_mcp_response(request_id, result=result), sort_keys=True), flush=True)
-        elif method == "resources/list":
-            print(
-                json.dumps(
-                    _mcp_response(request_id, result={"resources": _mcp_card_resources(target, config)}), sort_keys=True
-                ),
-                flush=True,
-            )
-        elif method == "resources/read":
-            uri = str(params.get("uri") or "")
-            text, mime_type = _mcp_read_card(target, config, uri)
-            if text is None:
-                print(
-                    json.dumps(
-                        _mcp_response(request_id, error={"code": -32004, "message": f"resource not found: {uri}"}),
-                        sort_keys=True,
-                    ),
-                    flush=True,
-                )
-            else:
-                print(
-                    json.dumps(
-                        _mcp_response(
-                            request_id, result={"contents": [{"uri": uri, "mimeType": mime_type, "text": text}]}
-                        ),
-                        sort_keys=True,
-                    ),
-                    flush=True,
-                )
-        elif method == "tools/list":
-            print(
-                json.dumps(_mcp_response(request_id, result={"tools": _mcp_card_tool_specs()}), sort_keys=True),
-                flush=True,
-            )
-        elif method == "tools/call":
-            name = str(params.get("name") or "")
-            arguments = params.get("arguments") if isinstance(params.get("arguments"), dict) else {}
-            payload, failed = _mcp_card_tool_call(target, config, name, arguments)
-            text = payload if isinstance(payload, str) else json.dumps(payload, indent=2, sort_keys=True)
-            result = {"content": [{"type": "text", "text": text}], "isError": failed}
-            print(json.dumps(_mcp_response(request_id, result=result), sort_keys=True), flush=True)
-        else:
-            print(
-                json.dumps(
-                    _mcp_response(request_id, error={"code": -32601, "message": f"method not found: {method}"}),
-                    sort_keys=True,
-                ),
-                flush=True,
-            )
-    return 0
+    return mcp_server.serve_stdio(
+        server_name="brigade-memory-readonly",
+        list_resources=lambda: _mcp_card_resources(target, config),
+        read_resource=lambda uri: _mcp_read_card(target, config, uri),
+        list_tools=_mcp_card_tool_specs,
+        call_tool=lambda name, arguments: _mcp_card_tool_call(target, config, name, arguments),
+    )
 
 
 def serve_mcp(*, target: Path, stdio: bool = False, json_output: bool = False) -> int:

--- a/src/brigade/skills_cmd.py
+++ b/src/brigade/skills_cmd.py
@@ -16,6 +16,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from . import mcp_server
 from .untrusted import scan_untrusted
 from .localio import slugify, utc_now_iso as _now, write_json as _write_json
 
@@ -1278,89 +1279,14 @@ def _mcp_tool_call(target: Path, name: str, arguments: dict[str, Any]) -> tuple[
     return {"error": f"unknown read-only skill tool: {name}"}, True
 
 
-def _mcp_response(
-    request_id: object, *, result: object | None = None, error: dict[str, Any] | None = None
-) -> dict[str, Any]:
-    response: dict[str, Any] = {"jsonrpc": "2.0", "id": request_id}
-    if error is not None:
-        response["error"] = error
-    else:
-        response["result"] = result if result is not None else {}
-    return response
-
-
 def _run_mcp_stdio(target: Path) -> int:
-    for line in sys.stdin:
-        if not line.strip():
-            continue
-        try:
-            request = json.loads(line)
-        except json.JSONDecodeError:
-            print(json.dumps(_mcp_response(None, error={"code": -32700, "message": "parse error"})), flush=True)
-            continue
-        if not isinstance(request, dict):
-            print(json.dumps(_mcp_response(None, error={"code": -32600, "message": "invalid request"})), flush=True)
-            continue
-        request_id = request.get("id")
-        method = str(request.get("method") or "")
-        params = request.get("params") if isinstance(request.get("params"), dict) else {}
-        if request_id is None and method.startswith("notifications/"):
-            continue
-        if method == "initialize":
-            result = {
-                "protocolVersion": "2024-11-05",
-                "capabilities": {"resources": {}, "tools": {}},
-                "serverInfo": {"name": "brigade-skills-readonly", "version": "0"},
-            }
-            print(json.dumps(_mcp_response(request_id, result=result), sort_keys=True), flush=True)
-        elif method == "resources/list":
-            print(
-                json.dumps(
-                    _mcp_response(request_id, result={"resources": _mcp_resource_items(target)}), sort_keys=True
-                ),
-                flush=True,
-            )
-        elif method == "resources/read":
-            uri = str(params.get("uri") or "")
-            text, mime_type = _mcp_read_resource(target, uri)
-            if text is None:
-                print(
-                    json.dumps(
-                        _mcp_response(request_id, error={"code": -32004, "message": f"resource not found: {uri}"}),
-                        sort_keys=True,
-                    ),
-                    flush=True,
-                )
-            else:
-                print(
-                    json.dumps(
-                        _mcp_response(
-                            request_id, result={"contents": [{"uri": uri, "mimeType": mime_type, "text": text}]}
-                        ),
-                        sort_keys=True,
-                    ),
-                    flush=True,
-                )
-        elif method == "tools/list":
-            print(
-                json.dumps(_mcp_response(request_id, result={"tools": _mcp_tool_specs()}), sort_keys=True), flush=True
-            )
-        elif method == "tools/call":
-            name = str(params.get("name") or "")
-            arguments = params.get("arguments") if isinstance(params.get("arguments"), dict) else {}
-            payload, failed = _mcp_tool_call(target, name, arguments)
-            text = payload if isinstance(payload, str) else json.dumps(payload, indent=2, sort_keys=True)
-            result = {"content": [{"type": "text", "text": text}], "isError": failed}
-            print(json.dumps(_mcp_response(request_id, result=result), sort_keys=True), flush=True)
-        else:
-            print(
-                json.dumps(
-                    _mcp_response(request_id, error={"code": -32601, "message": f"method not found: {method}"}),
-                    sort_keys=True,
-                ),
-                flush=True,
-            )
-    return 0
+    return mcp_server.serve_stdio(
+        server_name="brigade-skills-readonly",
+        list_resources=lambda: _mcp_resource_items(target),
+        read_resource=lambda uri: _mcp_read_resource(target, uri),
+        list_tools=_mcp_tool_specs,
+        call_tool=lambda name, arguments: _mcp_tool_call(target, name, arguments),
+    )
 
 
 def serve_mcp(*, target: Path, json_output: bool = False, stdio: bool = False) -> int:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,60 @@
+"""Tests for the shared MCP stdio harness."""
+
+from __future__ import annotations
+
+import io
+import json
+
+from brigade import mcp_server
+
+
+def test_response_envelope():
+    ok = mcp_server.response(1, result={"x": 1})
+    assert ok == {"jsonrpc": "2.0", "id": 1, "result": {"x": 1}}
+    err = mcp_server.response(2, error={"code": -1, "message": "boom"})
+    assert err["error"]["code"] == -1 and "result" not in err
+
+
+def test_serve_stdio_dispatches_all_methods(monkeypatch, capsys):
+    requests = (
+        "\n".join(
+            [
+                json.dumps({"jsonrpc": "2.0", "id": 1, "method": "initialize"}),
+                json.dumps({"jsonrpc": "2.0", "id": 2, "method": "resources/list"}),
+                json.dumps({"jsonrpc": "2.0", "id": 3, "method": "resources/read", "params": {"uri": "x://a"}}),
+                json.dumps({"jsonrpc": "2.0", "id": 4, "method": "resources/read", "params": {"uri": "x://missing"}}),
+                json.dumps({"jsonrpc": "2.0", "id": 5, "method": "tools/list"}),
+                json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 6,
+                        "method": "tools/call",
+                        "params": {"name": "echo", "arguments": {"v": "hi"}},
+                    }
+                ),
+                json.dumps({"jsonrpc": "2.0", "id": 7, "method": "bogus"}),
+                json.dumps({"jsonrpc": "2.0", "method": "notifications/ping"}),  # no id -> ignored
+                "not json",
+            ]
+        )
+        + "\n"
+    )
+    monkeypatch.setattr("sys.stdin", io.StringIO(requests))
+    rc = mcp_server.serve_stdio(
+        server_name="test-server",
+        list_resources=lambda: [{"uri": "x://a", "name": "A"}],
+        read_resource=lambda uri: ("hello", "text/plain") if uri == "x://a" else (None, None),
+        list_tools=lambda: [{"name": "echo"}],
+        call_tool=lambda name, arguments: (arguments, False),
+    )
+    responses = [json.loads(line) for line in capsys.readouterr().out.strip().splitlines()]
+    by_id = {r["id"]: r for r in responses if r.get("id") is not None}
+    assert rc == 0
+    assert by_id[1]["result"]["serverInfo"]["name"] == "test-server"
+    assert by_id[2]["result"]["resources"][0]["uri"] == "x://a"
+    assert by_id[3]["result"]["contents"][0]["text"] == "hello"
+    assert by_id[4]["error"]["code"] == -32004
+    assert by_id[5]["result"]["tools"][0]["name"] == "echo"
+    assert "hi" in by_id[6]["result"]["content"][0]["text"]
+    assert by_id[7]["error"]["code"] == -32601
+    assert any(r.get("error", {}).get("code") == -32700 for r in responses)  # the non-JSON line


### PR DESCRIPTION
## Summary

The skills and memory MCP stdio servers carried near-identical JSON-RPC loops
(envelope, initialize/resources/tools dispatch, error codes). This extracts a
single zero-dependency harness, `mcp_server.serve_stdio(...)`, that owns the
protocol; each station passes four callbacks (list_resources, read_resource,
list_tools, call_tool).

- `skills_cmd._run_mcp_stdio` and `memory_cmd._run_card_mcp_stdio` are now thin
  delegations; their resource/tool functions are unchanged.
- No command surface or protocol change. `serverInfo.name` values are preserved
  (`brigade-skills-readonly`, `brigade-memory-readonly`), so existing MCP tests
  pass unchanged. A future read-only MCP surface is now a few lines.

## Tests

New `tests/test_mcp_server.py` exercises the harness directly (every method + error
paths); the existing skills and memory MCP tests still pass against the delegations.
`./scripts/verify` passes: 1187 passed.
