### PR TITLE
release: v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-06-16
+
 ### Added
 - `brigade doctor --json` and `brigade status --json` emit machine-readable output (target, harnesses, owner, depth, per-check status/name/detail, summary counts, and a `ready` flag), so the two most diagnostic surfaces can feed scripts and a future fleet aggregation instead of being text-only.
 - `brigade security diff --base <dir> --against <dir> [--json]` compares two security reports and reports new, resolved, and persisting findings (matched by the scan's stable per-finding fingerprint). It returns nonzero when there are new findings, so a change that introduces a finding can be caught in review or CI.

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Each writer gets its own local inbox; one canonical owner ingests. Brigade keeps
 | Hermes | `hermes` | `.hermes/memory-handoffs/` |
 | OpenClaw | `openclaw` | usually the memory owner, not a writer |
 
-All of them get handoff templates, ingest source coverage, and projected tools/skills. Per-harness details are in the [technical guide](docs/technical-guide.md).
+All of them get handoff templates and ingest source coverage. Most also get projected tools and skills in their native format (some as `rules` or `instructions`, a few not yet); the per-harness matrix is in the [technical guide](docs/technical-guide.md).
 
 ## Beyond memory
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "brigade-cli"
-version = "0.11.0"
+version = "0.12.0"
 description = "AI agent memory, handoffs, and local guardrails for Codex, Claude Code, OpenCode, Hermes, and OpenClaw."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/brigade/__init__.py
+++ b/src/brigade/__init__.py
@@ -1,3 +1,3 @@
 """Brigade: local operator-system CLI for agent workspaces."""
 
-__version__ = "0.11.0"
+__version__ = "0.12.0"

--- a/src/brigade/templates/hermes/memory-handoff.harness.json
+++ b/src/brigade/templates/hermes/memory-handoff.harness.json
@@ -5,7 +5,7 @@
     "Describes the handoff inbox + routing targets that Hermes should treat",
     "as the canonical memory contract."
   ],
-  "_brigade_version": "0.11.0",
+  "_brigade_version": "0.12.0",
   "_brigade_status": "experimental",
   "memory_handoff": {
     "inbox_dir": ".hermes/memory-handoffs",

--- a/src/brigade/templates/hermes/model-lanes.harness.json
+++ b/src/brigade/templates/hermes/model-lanes.harness.json
@@ -5,7 +5,7 @@
     "Suggested model lane names. Same shape as the OpenClaw alias map so",
     "knowledge cards and runbooks can talk about lanes without naming providers."
   ],
-  "_brigade_version": "0.11.0",
+  "_brigade_version": "0.12.0",
   "_brigade_status": "experimental",
   "model_lanes": {
     "main": "<provider/main-model-id>",

--- a/src/brigade/templates/hermes/workspace.harness.json
+++ b/src/brigade/templates/hermes/workspace.harness.json
@@ -8,7 +8,7 @@
     "",
     "Replace <hermes-config-path> with your Hermes config location."
   ],
-  "_brigade_version": "0.11.0",
+  "_brigade_version": "0.12.0",
   "_brigade_status": "experimental",
   "workspace": {
     "root": "<workspace-root>",

--- a/src/brigade/templates/memory/chat-memory-sweep.example.json
+++ b/src/brigade/templates/memory/chat-memory-sweep.example.json
@@ -1,5 +1,5 @@
 {
-  "_brigade_version": "0.11.0",
+  "_brigade_version": "0.12.0",
   "_description": "Example output contract for a nightly chat/session memory sweep. Keep raw chat transcripts in crawler archives; this file contains summaries and local source locators only.",
   "generated_at": "2026-05-26T22:09:00-04:00",
   "window": {

--- a/src/brigade/templates/memory/memory-care.example.json
+++ b/src/brigade/templates/memory/memory-care.example.json
@@ -1,5 +1,5 @@
 {
-  "_brigade_version": "0.11.0",
+  "_brigade_version": "0.12.0",
   "_description": "Example config for a local memory-care scanner. Brigade does not run this scanner for you; it validates the output with `brigade doctor`.",
   "cards_glob": "memory/cards/*.md",
   "decay_dir": ".brigade/memory-care/decay",

--- a/src/brigade/templates/policies/personal.json
+++ b/src/brigade/templates/policies/personal.json
@@ -4,7 +4,7 @@
     "It blocks secrets and attribution trailers, while warning on personal or infrastructure-like context.",
     "Use via: brigade handoff lint --content-guard --guard-policy personal"
   ],
-  "_brigade_version": "0.11.0",
+  "_brigade_version": "0.12.0",
   "categories": {
     "secret": "block",
     "private-network": "warn",

--- a/src/brigade/templates/policies/public-content.json
+++ b/src/brigade/templates/policies/public-content.json
@@ -4,7 +4,7 @@
     "social drafts, and docs that will be published, not just pushed.",
     "Use via: brigade scrub --policy public-content"
   ],
-  "_brigade_version": "0.11.0",
+  "_brigade_version": "0.12.0",
   "categories": {
     "secret": "block",
     "private-network": "block",

--- a/src/brigade/templates/policies/public-repo.json
+++ b/src/brigade/templates/policies/public-repo.json
@@ -4,7 +4,7 @@
     "Used by brigade pre-push hook and `brigade scrub`.",
     "Override by pointing CONTENT_GUARD_POLICY at your own copy of this file."
   ],
-  "_brigade_version": "0.11.0",
+  "_brigade_version": "0.12.0",
   "categories": {
     "secret": "block",
     "private-network": "block",


### PR DESCRIPTION
## v0.12.0

Bumps version to 0.12.0 across `pyproject.toml`, `src/brigade/__init__.py`, and all 8 `_brigade_version` templates, and finalizes the CHANGELOG section.

This release rolls up the full 2026-06-16 audit board: `doctor`/`status --json`, `security diff`, `operator checkup`, `repos doctor --deep`, `completions`, memory `serve-mcp` + `search`, the station-verb parity batch (`projects doctor`, `skills uninstall`, `friction show`, `security`/`scrub --json`, `runbook closeout --import-issues`), `init --git-exclude`, the `run --read-only` enforcement warning, fleet-summary parallelization, and the first-contact doctor fixes (#79, #80, #82, #83, #84) and subprocess hang-guards. Also: the shared MCP harness refactor and the `init --no-gitignore` fix.

Pre-flight (RELEASE.md): `./scripts/verify` green (1187 passed, version sync = 10 locations), `security template-audit` 0 findings, cold-start gate completed.

Tag `v0.12.0` will be pushed after merge to trigger the publish workflow.
