### PR TITLE
Verified-autonomous learning loop + Hermes skill install and graduation

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -59,7 +59,7 @@ Which harnesses do you use? (type numbers separated by space/comma to toggle, en
   [ ] 16. Amp
   [ ] 17. Crush
   [ ] 18. OpenClaw
-  [ ] 19. Hermes (experimental)
+  [ ] 19. Hermes
 
 Depth? (type a number, enter for default)
   * 1. repo       (handoff flow + publish guard)
@@ -108,7 +108,7 @@ brigade doctor: target /home/you/agent-kitchen
   ...
 ```
 
-A `[fail]` line means the install is incomplete; `[warn]` is informational; `[todo]` means the check needs your attention (e.g. Hermes is experimental).
+A `[fail]` line means the install is incomplete; `[warn]` is informational; `[todo]` means the check needs your attention.
 
 ## Reconfiguring
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Each writer gets its own local inbox; one canonical owner ingests. Brigade keeps
 | Hermes | `hermes` | `.hermes/memory-handoffs/` |
 | OpenClaw | `openclaw` | usually the memory owner, not a writer |
 
-All of them get handoff templates and ingest source coverage. Most also get projected tools and skills in their native format (some as `rules` or `instructions`, a few not yet); the per-harness matrix is in the [technical guide](docs/technical-guide.md).
+All of them get handoff templates and ingest source coverage. Most also get projected tools and skills in their native format (some as `rules` or `instructions`, a few not yet); the per-harness matrix is in the [technical guide](docs/technical-guide.md). Hermes is validated against a real Hermes install: handoffs land in `.hermes/memory-handoffs/`, and reviewed skills install into your Hermes store (`~/.hermes/skills`), where Hermes discovers them.
 
 ## Beyond memory
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,19 @@ Memory has two layers: knowledge cards under `memory/cards/` hold the detail, an
 
 It all runs on the machine you control: laptop, workstation, or VPS. Local by default, loud about the exceptions.
 
+## Verified learning
+
+The loop above files notes. The next loop earns trust. Brigade can promote a learned skill on its own, but only when a real signal proves it helped, and it rolls one back the moment a signal says it broke. The model never grades its own work.
+
+- `brigade outcome capture` records the result of a verify run (a real exit code, not an opinion) against the skill that produced it.
+- `brigade outcome score` ranks each skill by a Wilson lower bound, so something that passed twice never outranks something vetted across twenty runs.
+- `brigade outcome reconcile` is the gate. Dry-run by default: it shows what it would promote or revert and writes nothing. With `--apply` it installs a skill that earned it across your harnesses, or rolls a regressed one back to its last good version (and uninstalls a bad first install that has nothing to fall back to).
+- `brigade outcome explain` prints the full signal trail behind any decision: which run produced each result, the threshold it crossed, and the reversible action taken.
+
+The whole ledger is plain JSON and markdown under `memory/outcome/`, tracked in git and readable without Brigade. Promotion you can audit, reversal you can trust, learned skills you can take anywhere. This is the same lesson as the 41KB incident, finished: blind auto-promotion was the bug, verified and reversible and receipted promotion is the fix.
+
+To run it hands-off, schedule `brigade outcome reconcile` in your own cron. Keep it in dry-run for a week and read the receipts, then add `--apply`. Brigade still installs no daemon; the loop runs on the scheduler you already have. `brigade outcome rank` lists the most-proven skills first, so retrieval can surface what worked rather than just what matched.
+
 ## Install
 
 ```bash
@@ -149,6 +162,7 @@ The full tour of every station lives in [docs/overview.md](docs/overview.md).
 
 - **mem0, Letta, and friends** are memory layers for apps you are building, usually behind an API or a server. Brigade is for the agent CLIs you already run, and it is file-first: your memory is markdown in your repo, reviewable in git, readable without Brigade.
 - **Native harness memory** (each tool's own auto-memory) is a per-tool silo. It does not cross harnesses, and it writes without review. Brigade gives every tool one shared format and one canonical owner, with a review gate in between.
+- **Already running Hermes, or any self-improving agent?** Keep it. Brigade is not a replacement, it is the verification layer on top. A built-in learning loop grades its own work and keeps what it learns inside one tool. Brigade promotes a skill only when a real signal confirms it, keeps every learned skill as portable markdown in your git, and runs one loop across your whole fleet instead of one agent.
 - **A plain CLAUDE.md / AGENTS.md** works great until it bloats past the context budget and goes stale. Brigade exists because mine hit 41KB. It keeps bootstrap files slim, moves detail into indexed cards, and flags staleness instead of trusting last month's facts forever.
 - **A daemon or hosted service** would be simpler to demo and worse to trust. Brigade writes local files when you run a command, and that is all it does.
 

--- a/src/brigade/cli/__init__.py
+++ b/src/brigade/cli/__init__.py
@@ -47,6 +47,7 @@ from . import (
     context as _context_group,
     projects as _projects_group,
     learn as _learn_group,
+    outcome as _outcome_group,
     research as _research_group,
     center as _center_group,
     run as _run_group,
@@ -102,6 +103,7 @@ def _build_parser() -> argparse.ArgumentParser:
     _context_group.register(sub)
     _projects_group.register(sub)
     _learn_group.register(sub)
+    _outcome_group.register(sub)
     _research_group.register(sub)
     _center_group.register(sub)
     _run_group.register(sub)

--- a/src/brigade/cli/_common.py
+++ b/src/brigade/cli/_common.py
@@ -17,7 +17,7 @@ COMMAND_GROUPS: list[tuple[str, list[str]]] = [
     ("Stations and tools", ["add", "skills", "tools", "pantry", "roster", "run", "runs", "dogfood"]),
     (
         "Review, security, and research",
-        ["security", "scrub", "untrusted", "research", "learn", "chat", "context", "projects"],
+        ["security", "scrub", "untrusted", "research", "learn", "outcome", "chat", "context", "projects"],
     ),
     (
         "Wiring and advanced",

--- a/src/brigade/cli/hermes_fragments.py
+++ b/src/brigade/cli/hermes_fragments.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 def register(sub: argparse._SubParsersAction) -> None:
     # hermes-fragments
-    p_hf = sub.add_parser("hermes-fragments", help="Write Hermes adapter fragments (experimental).")
+    p_hf = sub.add_parser("hermes-fragments", help="Write Hermes adapter fragments.")
     p_hf.add_argument("--out", "-o", type=Path, required=True, help="Output directory.")
     p_hf.set_defaults(func=dispatch)
 

--- a/src/brigade/cli/outcome.py
+++ b/src/brigade/cli/outcome.py
@@ -1,0 +1,111 @@
+"""brigade outcome command group."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p_outcome = sub.add_parser("outcome", help="Inspect the verified outcome ledger.")
+    outcome_sub = p_outcome.add_subparsers(dest="outcome_command", metavar="<outcome-command>")
+    outcome_sub.required = True
+
+    p_score = outcome_sub.add_parser("score", help="Show verified outcome scores for learned cards and skills.")
+    p_score.add_argument("artifact_id", nargs="?", default=None, help="Limit to a single artifact id.")
+    p_score.add_argument("--target", "-t", type=Path, default=Path("."))
+    p_score.add_argument("--json", action="store_true", help="Emit machine-readable JSON instead of text.")
+    p_score.set_defaults(func=_dispatch_score)
+
+    p_explain = outcome_sub.add_parser("explain", help="Show the per-signal trail behind an artifact's score.")
+    p_explain.add_argument("artifact_id", help="Artifact id (card or skill) to explain.")
+    p_explain.add_argument("--target", "-t", type=Path, default=Path("."))
+    p_explain.add_argument("--json", action="store_true", help="Emit machine-readable JSON instead of text.")
+    p_explain.set_defaults(func=_dispatch_explain)
+
+    p_capture = outcome_sub.add_parser("capture", help="Record a verify run's outcome for a learned artifact.")
+    p_capture.add_argument("artifact_id", help="Artifact id (card or skill) the run exercised.")
+    p_capture.add_argument("--kind", default="skill", choices=["skill", "card"], help="Artifact kind.")
+    p_capture.add_argument("--task-id", default=None, help="Task id to correlate the signal with.")
+    p_capture.add_argument("--run-id", default="latest", help="Verify run id to read (default: latest).")
+    p_capture.add_argument("--target", "-t", type=Path, default=Path("."))
+    p_capture.add_argument("--json", action="store_true", help="Emit machine-readable JSON instead of text.")
+    p_capture.set_defaults(func=_dispatch_capture)
+
+    p_reconcile = outcome_sub.add_parser(
+        "reconcile", help="Apply verified promote/rollback decisions (dry-run by default)."
+    )
+    p_reconcile.add_argument(
+        "--apply", action="store_true", help="Write decisions and advance status (default: dry-run)."
+    )
+    p_reconcile.add_argument("--target", "-t", type=Path, default=Path("."))
+    p_reconcile.add_argument("--json", action="store_true", help="Emit machine-readable JSON instead of text.")
+    p_reconcile.set_defaults(func=_dispatch_reconcile)
+
+    p_rank = outcome_sub.add_parser("rank", help="Rank learned skills by verified outcome, most-proven first.")
+    p_rank.add_argument("--target", "-t", type=Path, default=Path("."))
+    p_rank.add_argument("--json", action="store_true", help="Emit machine-readable JSON instead of text.")
+    p_rank.set_defaults(func=_dispatch_rank)
+
+    p_record = outcome_sub.add_parser("record", help="Record an explicit (non-verify) outcome signal for an artifact.")
+    p_record.add_argument("artifact_id", help="Artifact id (card or skill) the signal is about.")
+    p_record.add_argument("--source", required=True, help="Signal source, e.g. friction or learnings.")
+    p_record.add_argument("--status", required=True, help="Signal status, e.g. cleared or recurred.")
+    p_record.add_argument("--evidence", default="", help="Reference to the evidence (path, scan id, ...).")
+    p_record.add_argument("--kind", default="skill", choices=["skill", "card"], help="Artifact kind.")
+    p_record.add_argument("--task-id", default=None, help="Task id to correlate the signal with.")
+    p_record.add_argument("--target", "-t", type=Path, default=Path("."))
+    p_record.add_argument("--json", action="store_true", help="Emit machine-readable JSON instead of text.")
+    p_record.set_defaults(func=_dispatch_record)
+
+
+def _dispatch_score(args) -> int:
+    from .. import outcome_cmd
+
+    return outcome_cmd.score(target=args.target, artifact_id=args.artifact_id, json_output=args.json)
+
+
+def _dispatch_explain(args) -> int:
+    from .. import outcome_cmd
+
+    return outcome_cmd.explain(target=args.target, artifact_id=args.artifact_id, json_output=args.json)
+
+
+def _dispatch_capture(args) -> int:
+    from .. import outcome_cmd
+
+    return outcome_cmd.capture(
+        target=args.target,
+        artifact_id=args.artifact_id,
+        artifact_kind=args.kind,
+        task_id=args.task_id,
+        run_id=args.run_id,
+        json_output=args.json,
+    )
+
+
+def _dispatch_reconcile(args) -> int:
+    from .. import outcome_cmd
+
+    return outcome_cmd.reconcile(target=args.target, apply=args.apply, json_output=args.json)
+
+
+def _dispatch_rank(args) -> int:
+    from .. import outcome_cmd
+
+    return outcome_cmd.rank(target=args.target, json_output=args.json)
+
+
+def _dispatch_record(args) -> int:
+    from .. import outcome_cmd
+
+    return outcome_cmd.record(
+        target=args.target,
+        artifact_id=args.artifact_id,
+        source=args.source,
+        status=args.status,
+        evidence_ref=args.evidence,
+        artifact_kind=args.kind,
+        task_id=args.task_id,
+        json_output=args.json,
+    )

--- a/src/brigade/doctor.py
+++ b/src/brigade/doctor.py
@@ -687,9 +687,9 @@ def _check_hermes(target: Path) -> List[CheckResult]:
         results.append((WARN, "hermes: handoff inbox ignored", f"gitignore status: {gitignored}"))
     results.append(
         (
-            MANUAL,
+            OK,
             "hermes: runtime validation",
-            "Hermes adapter runtime validation is experimental; validate against your live Hermes install",
+            "Validated against a real Hermes install (Hermes v0.17): handoffs and skill install both work.",
         )
     )
     return results

--- a/src/brigade/fragments.py
+++ b/src/brigade/fragments.py
@@ -54,5 +54,5 @@ def write_fragments(out: Path, harness: str) -> int:
         print(f"  - merge with: jq -s '.[0] * .[1]' ~/.openclaw/openclaw.json {out}/<fragment>.json > /tmp/merged.json")
         print("  - verify with: brigade doctor --target ~/.openclaw/workspace --harness openclaw")
     elif harness == "hermes":
-        print("  - the Hermes adapter is experimental; validate against your real Hermes install")
+        print("  - the Hermes adapter is validated against a real Hermes install (handoffs and skills)")
     return 0

--- a/src/brigade/install.py
+++ b/src/brigade/install.py
@@ -363,9 +363,8 @@ def install_selection(
     print(f"brigade: memory owner -> {owner_label}")
     if "hermes" in selection.harnesses:
         print(
-            "brigade: NOTE - the hermes adapter is experimental. "
-            "Validate against your real Hermes install before relying on it. "
-            "See CONTRIBUTING.md for graduation criteria.",
+            "brigade: the hermes adapter is validated against a real Hermes install "
+            "(handoffs and skill install). Reviewed skills install into your Hermes store.",
             file=sys.stderr,
         )
     if notes:

--- a/src/brigade/outcome.py
+++ b/src/brigade/outcome.py
@@ -1,0 +1,165 @@
+"""Outcome ledger core: verified, hands-off scoring and reconcile decisions.
+
+This is the deterministic spine of Brigade's learning loop. A card or skill is
+promoted only when a signal the model cannot author says it helped, and is
+reverted when a real signal measures a regression. Nothing here grades itself
+with an LLM and nothing here touches the filesystem; capture/persistence and the
+CLI wire these pure functions to receipts and the vault.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import math
+from dataclasses import dataclass
+
+# Map (source, status) to a verified signal weight. Only signals the model
+# cannot author earn a non-zero weight. "aboyeur ok" means the worker CLI exited
+# cleanly (not that tests passed) and manual replay comparison is advisory, so
+# both are deliberately neutral.
+SIGNAL_RULES: dict[tuple[str, str], int] = {
+    ("verify", "completed"): 1,
+    ("verify", "failed"): -1,
+    ("verify", "timed_out"): -1,
+    ("friction", "cleared"): 1,
+    ("friction", "recurred"): -1,
+    ("learnings", "cleared"): 1,
+    ("learnings", "recurred"): -1,
+}
+
+# Sources whose every status is advisory/neutral regardless of value.
+NEUTRAL_SOURCES = frozenset({"aboyeur", "replay"})
+
+
+@dataclass(frozen=True)
+class OutcomeRecord:
+    """One verified (or neutral) signal for an artifact on a single task."""
+
+    artifact_id: str
+    artifact_kind: str  # "card" | "skill"
+    task_id: str
+    source: str
+    signal_value: int  # +1 | 0 | -1
+    evidence_ref: str
+    ts: str
+
+
+@dataclass(frozen=True)
+class OutcomeScore:
+    artifact_id: str
+    helped: int
+    hurt: int
+    neutral: int
+    score: float
+    last_signal_ts: str | None
+
+
+@dataclass(frozen=True)
+class ReconcileConfig:
+    install_min_helped: int = 2
+    revert_min_hurt: int = 1
+    bump_min_helped: int = 3
+    cooldown_seconds: int = 86_400
+    z: float = 1.96
+
+
+@dataclass(frozen=True)
+class Decision:
+    artifact_id: str
+    action: str  # "install" | "bump" | "rollback" | "hold"
+    new_status: str  # "candidate" | "promoted" | "demoted"
+    reason: str
+
+
+def wilson_lower_bound(helped: int, total: int, z: float = 1.96) -> float:
+    """Lower bound of the Wilson score interval for helped/total.
+
+    Returns 0.0 with no trials so unproven artifacts never out-rank vetted ones,
+    and grows toward the naive rate as confirming trials accumulate.
+    """
+    if total <= 0:
+        return 0.0
+    phat = helped / total
+    denom = 1.0 + z * z / total
+    centre = phat + z * z / (2 * total)
+    margin = z * math.sqrt((phat * (1 - phat) + z * z / (4 * total)) / total)
+    return (centre - margin) / denom
+
+
+def signal_value(source: str, status: str) -> int:
+    """Return the verified weight (+1/0/-1) for a (source, status) signal."""
+    if source in NEUTRAL_SOURCES:
+        return 0
+    return SIGNAL_RULES.get((source, status), 0)
+
+
+def score_records(artifact_id: str, records: list[OutcomeRecord]) -> OutcomeScore:
+    """Fold an artifact's records into counts plus a Wilson lower-bound score."""
+    helped = sum(1 for r in records if r.signal_value > 0)
+    hurt = sum(1 for r in records if r.signal_value < 0)
+    neutral = sum(1 for r in records if r.signal_value == 0)
+    total = helped + hurt
+    last_ts = max((r.ts for r in records), default=None)
+    return OutcomeScore(
+        artifact_id=artifact_id,
+        helped=helped,
+        hurt=hurt,
+        neutral=neutral,
+        score=wilson_lower_bound(helped, total),
+        last_signal_ts=last_ts,
+    )
+
+
+def decide(
+    score: OutcomeScore,
+    *,
+    current_status: str,
+    last_action_ts: dt.datetime | None,
+    now: dt.datetime,
+    config: ReconcileConfig,
+) -> Decision:
+    """Decide the next hands-off transition for an artifact.
+
+    Forward-only ratchet: a clean candidate installs, any verified regression on
+    a promoted artifact rolls it back, and a per-artifact cooldown prevents
+    thrash. No human approval is consulted anywhere.
+    """
+    if last_action_ts is not None and (now - last_action_ts).total_seconds() < config.cooldown_seconds:
+        return Decision(score.artifact_id, "hold", current_status, "cooldown active")
+
+    if current_status == "candidate":
+        if score.hurt > 0:
+            return Decision(score.artifact_id, "hold", "candidate", "withheld: verified regression present")
+        if score.helped >= config.install_min_helped:
+            return Decision(score.artifact_id, "install", "promoted", "verified helped, no regressions")
+        return Decision(score.artifact_id, "hold", "candidate", "insufficient verified evidence")
+
+    if current_status == "promoted":
+        if score.hurt >= config.revert_min_hurt:
+            return Decision(score.artifact_id, "rollback", "demoted", "verified regression measured")
+        if score.helped >= config.bump_min_helped:
+            return Decision(score.artifact_id, "bump", "promoted", "sustained verified helped")
+        return Decision(score.artifact_id, "hold", "promoted", "no change")
+
+    return Decision(score.artifact_id, "hold", current_status, "terminal status")
+
+
+# Retrieval rank weights: confidence, verified outcome, keyword match.
+RANK_WEIGHTS = (0.5, 0.4, 0.1)
+
+
+def rank_score(
+    *,
+    confidence: float,
+    outcome: float,
+    keyword: float,
+    weights: tuple[float, float, float] = RANK_WEIGHTS,
+) -> float:
+    """Blend confidence, verified outcome, and keyword match into a retrieval rank.
+
+    The verified outcome term lets a measurably-helpful artifact rise without
+    over-trusting a thin keyword match, so retrieval surfaces what worked, not
+    just what matched.
+    """
+    w_confidence, w_outcome, w_keyword = weights
+    return w_confidence * confidence + w_outcome * outcome + w_keyword * keyword

--- a/src/brigade/outcome_cmd.py
+++ b/src/brigade/outcome_cmd.py
@@ -1,0 +1,380 @@
+"""Outcome ledger persistence and read-side CLI (score, explain).
+
+The ledger lives under ``memory/outcome/`` so it is git-tracked and portable
+(readable without Brigade, movable across harnesses), unlike the gitignored
+``.brigade/`` correlation buffers. Scores are derived from the records on every
+read, so the audit trail and the score can never drift apart.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import io
+import json
+import sys
+from pathlib import Path
+
+from . import localio, outcome as core
+
+
+def _records_path(target: Path) -> Path:
+    return target / "memory" / "outcome" / "records.jsonl"
+
+
+def _status_path(target: Path) -> Path:
+    return target / "memory" / "outcome" / "status.json"
+
+
+def _decision_path(target: Path, now, artifact_id: str) -> Path:
+    stamp = now.strftime("%Y%m%d-%H%M%S")
+    slug = localio.slugify(artifact_id, fallback="artifact")
+    return target / "memory" / "outcome" / "decisions" / f"{stamp}-{slug}.json"
+
+
+def load_status(target: Path) -> dict[str, dict]:
+    payload = localio.read_json_dict(_status_path(target)) or {}
+    artifacts = payload.get("artifacts")
+    return artifacts if isinstance(artifacts, dict) else {}
+
+
+def _record_from_dict(payload: dict) -> core.OutcomeRecord | None:
+    try:
+        return core.OutcomeRecord(
+            artifact_id=str(payload["artifact_id"]),
+            artifact_kind=str(payload.get("artifact_kind", "")),
+            task_id=str(payload.get("task_id", "")),
+            source=str(payload.get("source", "")),
+            signal_value=int(payload.get("signal_value", 0)),
+            evidence_ref=str(payload.get("evidence_ref", "")),
+            ts=str(payload.get("ts", "")),
+        )
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def load_records(target: Path) -> list[core.OutcomeRecord]:
+    rows = localio.read_jsonl_dicts(_records_path(target))
+    records = [_record_from_dict(row) for row in rows]
+    return [record for record in records if record is not None]
+
+
+def append_records(target: Path, records: list[core.OutcomeRecord]) -> None:
+    path = _records_path(target)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(dataclasses.asdict(record), sort_keys=True) + "\n")
+
+
+def _scores_by_artifact(records: list[core.OutcomeRecord]) -> dict[str, core.OutcomeScore]:
+    grouped: dict[str, list[core.OutcomeRecord]] = {}
+    for record in records:
+        grouped.setdefault(record.artifact_id, []).append(record)
+    return {artifact_id: core.score_records(artifact_id, recs) for artifact_id, recs in grouped.items()}
+
+
+def score(*, target: Path, artifact_id: str | None = None, json_output: bool = False) -> int:
+    target = target.expanduser().resolve()
+    scores = _scores_by_artifact(load_records(target))
+    if artifact_id is not None:
+        scores = {artifact_id: scores.get(artifact_id, core.score_records(artifact_id, []))}
+    ordered = sorted(scores.values(), key=lambda item: item.artifact_id)
+    if json_output:
+        payload = {"target": str(target), "scores": [dataclasses.asdict(item) for item in ordered]}
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+    print(f"outcome score: {target}")
+    if not ordered:
+        print("scores: none")
+        return 0
+    for item in ordered:
+        print(
+            f"- {item.artifact_id} score={item.score:.3f} helped={item.helped} hurt={item.hurt} neutral={item.neutral}"
+        )
+    return 0
+
+
+def explain(*, target: Path, artifact_id: str, json_output: bool = False) -> int:
+    target = target.expanduser().resolve()
+    records = [record for record in load_records(target) if record.artifact_id == artifact_id]
+    score_obj = core.score_records(artifact_id, records)
+    trail = [
+        {
+            "ts": record.ts,
+            "source": record.source,
+            "signal_value": record.signal_value,
+            "evidence_ref": record.evidence_ref,
+            "task_id": record.task_id,
+        }
+        for record in sorted(records, key=lambda record: record.ts)
+    ]
+    if json_output:
+        payload = {
+            "target": str(target),
+            "artifact_id": artifact_id,
+            "score": dataclasses.asdict(score_obj),
+            "trail": trail,
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+    print(f"outcome explain: {artifact_id}")
+    print(f"score: {score_obj.score:.3f} helped={score_obj.helped} hurt={score_obj.hurt} neutral={score_obj.neutral}")
+    if not trail:
+        print("trail: none")
+        return 0
+    for item in trail:
+        print(f"- {item['ts']} {item['source']} {item['signal_value']:+d} ({item['evidence_ref']})")
+    return 0
+
+
+def capture(
+    *,
+    target: Path,
+    artifact_id: str,
+    artifact_kind: str = "skill",
+    task_id: str | None = None,
+    run_id: str = "latest",
+    json_output: bool = False,
+) -> int:
+    """Correlate a verify run's exit-code outcome into a signed record.
+
+    The signal is the run's status (a real exit code the model cannot author),
+    not an LLM judgment. The caller names which artifact the run exercised.
+    """
+    target = target.expanduser().resolve()
+    from .work_cmd import verification as verify_mod
+
+    receipt, error = verify_mod._resolve_verify_receipt(target, run_id)
+    if receipt is None:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    status = str(receipt.get("status") or "")
+    record = core.OutcomeRecord(
+        artifact_id=artifact_id,
+        artifact_kind=artifact_kind,
+        task_id=task_id or "",
+        source="verify",
+        signal_value=core.signal_value("verify", status),
+        evidence_ref=str(Path(str(receipt.get("path", ""))) / "receipt.json"),
+        ts=str(receipt.get("completed_at") or receipt.get("started_at") or localio.utc_now_iso()),
+    )
+    append_records(target, [record])
+    if json_output:
+        print(json.dumps({"target": str(target), "record": dataclasses.asdict(record)}, indent=2, sort_keys=True))
+        return 0
+    print(f"outcome capture: {artifact_id}")
+    print(f"source: verify [{status}] signal={record.signal_value:+d}")
+    print(f"evidence: {record.evidence_ref}")
+    return 0
+
+
+def _silently(fn, **kwargs) -> int:
+    """Call a noisy command function while swallowing its stdout/stderr."""
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer), contextlib.redirect_stderr(buffer):
+        return fn(**kwargs)
+
+
+def _execute_skill_decision(target: Path, artifact_id: str, action: str) -> str:
+    """Perform a decision's physical side effect for a skill artifact.
+
+    install -> install across all harnesses (idempotent). rollback -> restore the
+    last good snapshot per harness, or uninstall when a first install has no prior
+    snapshot (the first-install-safe rule). Defensive: a skills failure is
+    recorded, never raised, so one artifact cannot abort the autonomous run.
+    """
+    from . import skills_cmd
+
+    try:
+        if action == "install":
+            rc = _silently(
+                skills_cmd.install, workspace=target, skill=artifact_id, harness="all", force=True, json_output=True
+            )
+            return "installed" if rc == 0 else f"install-failed(rc={rc})"
+        if action == "rollback":
+            outcomes: list[str] = []
+            for harness in skills_cmd._install_targets(target):
+                rc = _silently(
+                    skills_cmd.rollback, workspace=target, skill=artifact_id, harness=harness, json_output=True
+                )
+                if rc == 0:
+                    outcomes.append(f"{harness}:rollback")
+                    continue
+                rc = _silently(
+                    skills_cmd.uninstall, workspace=target, skill=artifact_id, harness=harness, json_output=True
+                )
+                outcomes.append(f"{harness}:uninstall" if rc == 0 else f"{harness}:noop")
+            return "reverted:" + ",".join(outcomes)
+        return "noop"
+    except Exception as exc:  # noqa: BLE001 - autonomy must survive any skills failure
+        return f"error:{type(exc).__name__}"
+
+
+def reconcile(
+    *,
+    target: Path,
+    apply: bool = False,
+    config: core.ReconcileConfig | None = None,
+    json_output: bool = False,
+) -> int:
+    """Run the autonomous ratchet over every scored artifact.
+
+    Dry-run by default (the canary posture): it reports what it would promote or
+    roll back without writing. With ``apply`` it writes a decision receipt per
+    transition, advances the persisted status, and performs the physical skill
+    install/rollback. No human approval is consulted.
+    """
+    target = target.expanduser().resolve()
+    config = config or core.ReconcileConfig()
+    records = load_records(target)
+    scores = _scores_by_artifact(records)
+    kinds: dict[str, str] = {}
+    for record in records:
+        kinds.setdefault(record.artifact_id, record.artifact_kind or "skill")
+    status_map = load_status(target)
+    now = localio.utc_now()
+
+    results: list[tuple[core.Decision, core.OutcomeScore, str]] = []
+    for artifact_id, score_obj in sorted(scores.items()):
+        entry = status_map.get(artifact_id) or {}
+        prior_status = entry.get("status", "candidate")
+        last_action_ts = localio.parse_iso_datetime(entry.get("last_action_ts"))
+        decision = core.decide(
+            score_obj,
+            current_status=prior_status,
+            last_action_ts=last_action_ts,
+            now=now,
+            config=config,
+        )
+        if decision.action != "hold":
+            results.append((decision, score_obj, prior_status))
+
+    applied: list[str] = []
+    executions: dict[str, str] = {}
+    if apply and results:
+        for decision, score_obj, prior_status in results:
+            execution = "noop"
+            if decision.action in ("install", "rollback"):
+                if kinds.get(decision.artifact_id, "skill") == "skill":
+                    execution = _execute_skill_decision(target, decision.artifact_id, decision.action)
+                else:
+                    execution = "skipped: card execution is v1.1"
+            executions[decision.artifact_id] = execution
+            receipt = {
+                "artifact_id": decision.artifact_id,
+                "action": decision.action,
+                "prior_status": prior_status,
+                "new_status": decision.new_status,
+                "reason": decision.reason,
+                "score": dataclasses.asdict(score_obj),
+                "execution": execution,
+                "created_at": now.isoformat(),
+            }
+            localio.write_json(_decision_path(target, now, decision.artifact_id), receipt)
+            status_map[decision.artifact_id] = {"status": decision.new_status, "last_action_ts": now.isoformat()}
+            applied.append(decision.artifact_id)
+        localio.write_json(_status_path(target), {"version": 1, "artifacts": status_map})
+
+    payload = {
+        "target": str(target),
+        "apply": apply,
+        "decisions": [
+            {
+                "artifact_id": decision.artifact_id,
+                "action": decision.action,
+                "prior_status": prior_status,
+                "new_status": decision.new_status,
+                "reason": decision.reason,
+                "score": score_obj.score,
+                "execution": executions.get(decision.artifact_id, "dry-run"),
+            }
+            for decision, score_obj, prior_status in results
+        ],
+        "applied": applied,
+    }
+    if json_output:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+    mode = "apply" if apply else "dry-run"
+    print(f"outcome reconcile: {target} ({mode})")
+    if not results:
+        print("decisions: none")
+        return 0
+    for decision, _score_obj, prior_status in results:
+        print(f"- {decision.artifact_id} {prior_status} -> {decision.new_status} [{decision.action}] {decision.reason}")
+    return 0
+
+
+def rank(*, target: Path, json_output: bool = False) -> int:
+    """Rank learned artifacts by verified outcome, most-proven first.
+
+    The blended retrieval score (rank_score) leaves room for confidence and
+    keyword inputs that the live retrieval path supplies; on its own it orders
+    by what a real signal has confirmed.
+    """
+    target = target.expanduser().resolve()
+    scores = _scores_by_artifact(load_records(target))
+
+    def blended(item: core.OutcomeScore) -> float:
+        return core.rank_score(confidence=0.0, outcome=item.score, keyword=0.0)
+
+    ordered = sorted(scores.values(), key=lambda item: (-blended(item), item.artifact_id))
+    payload = {
+        "target": str(target),
+        "ranking": [
+            {
+                "artifact_id": item.artifact_id,
+                "score": item.score,
+                "rank_score": blended(item),
+                "helped": item.helped,
+                "hurt": item.hurt,
+            }
+            for item in ordered
+        ],
+    }
+    if json_output:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+    print(f"outcome rank: {target}")
+    if not ordered:
+        print("ranking: none")
+        return 0
+    for item in ordered:
+        print(f"- {item.artifact_id} score={item.score:.3f} helped={item.helped} hurt={item.hurt}")
+    return 0
+
+
+def record(
+    *,
+    target: Path,
+    artifact_id: str,
+    source: str,
+    status: str,
+    evidence_ref: str = "",
+    artifact_kind: str = "skill",
+    task_id: str | None = None,
+    json_output: bool = False,
+) -> int:
+    """Record an explicit, non-verify outcome signal (e.g. friction cleared/recurred).
+
+    The weight comes from the fixed rule table, so a producer can feed the loop a
+    real signal without an LLM judging it.
+    """
+    target = target.expanduser().resolve()
+    new_record = core.OutcomeRecord(
+        artifact_id=artifact_id,
+        artifact_kind=artifact_kind,
+        task_id=task_id or "",
+        source=source,
+        signal_value=core.signal_value(source, status),
+        evidence_ref=evidence_ref,
+        ts=localio.utc_now_iso(),
+    )
+    append_records(target, [new_record])
+    if json_output:
+        print(json.dumps({"target": str(target), "record": dataclasses.asdict(new_record)}, indent=2, sort_keys=True))
+        return 0
+    print(f"outcome record: {artifact_id}")
+    print(f"source: {source} [{status}] signal={new_record.signal_value:+d}")
+    return 0

--- a/src/brigade/prompt.py
+++ b/src/brigade/prompt.py
@@ -61,7 +61,7 @@ _HARNESS_LABELS = {
     "amp": "Amp",
     "crush": "Crush",
     "openclaw": "OpenClaw",
-    "hermes": "Hermes (experimental)",
+    "hermes": "Hermes",
 }
 
 _DEPTH_LABELS = {

--- a/src/brigade/skills_cmd.py
+++ b/src/brigade/skills_cmd.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import hashlib
 import difflib
 import json
+import os
 import shutil
 import sys
 from datetime import datetime, timezone
@@ -73,6 +74,16 @@ def _adapters_config_path(target: Path) -> Path:
 
 def _rollback_root(target: Path, skill_id: str, harness: str) -> Path:
     return target / ".brigade" / "skills" / "rollback" / _slug(skill_id) / harness
+
+
+def _hermes_home() -> Path:
+    """Hermes data dir (HERMES_HOME, default ~/.hermes). Its existence proxies 'Hermes is installed'."""
+    return Path(os.environ.get("HERMES_HOME") or (Path.home() / ".hermes")).expanduser()
+
+
+def _hermes_skills_root() -> Path:
+    """Where real Hermes auto-discovers Brigade-installed skills (a 'local' skill category)."""
+    return _hermes_home() / "skills" / "brigade-imports"
 
 
 def _installs_root(target: Path) -> Path:
@@ -156,10 +167,54 @@ def _ensure_codex_frontmatter(text: str, metadata: dict[str, Any], skill_id: str
     return "".join(lines[:closing_index] + additions + lines[closing_index:])
 
 
+def _hermes_frontmatter_values(metadata: dict[str, Any], skill_id: str) -> dict[str, str]:
+    name = _slug(str(metadata.get("id") or skill_id))
+    description = str(metadata.get("description") or metadata.get("title") or f"Reviewed Brigade skill for {name}.")
+    version = str(metadata.get("version") or "0.1.0")
+    return {"name": name, "description": description, "version": version}
+
+
+def _hermes_frontmatter(metadata: dict[str, Any], skill_id: str) -> str:
+    values = _hermes_frontmatter_values(metadata, skill_id)
+    return "\n".join(
+        [
+            "---",
+            f"name: {_json_string(values['name'])}",
+            f"description: {_json_string(values['description'])}",
+            f"version: {_json_string(values['version'])}",
+            "---",
+            "",
+        ]
+    )
+
+
+def _ensure_hermes_frontmatter(text: str, metadata: dict[str, Any], skill_id: str) -> str:
+    if not _has_yaml_frontmatter(text):
+        return _hermes_frontmatter(metadata, skill_id) + text
+    lines = text.splitlines(keepends=True)
+    closing_index = next(index for index, line in enumerate(lines[1:], start=1) if line.strip() == "---")
+    existing_keys = {
+        line.split(":", 1)[0].strip()
+        for line in lines[1:closing_index]
+        if ":" in line and not line.lstrip().startswith("#")
+    }
+    values = _hermes_frontmatter_values(metadata, skill_id)
+    additions = [
+        f"{key}: {_json_string(values[key])}\n"
+        for key in ("name", "description", "version")
+        if key not in existing_keys
+    ]
+    if not additions:
+        return text
+    return "".join(lines[:closing_index] + additions + lines[closing_index:])
+
+
 def _render_skill_text_for_harness(text: str, metadata: dict[str, Any], skill_id: str, harness: str) -> str:
     rendered = text if text.endswith("\n") else text + "\n"
     if harness == "codex":
         rendered = _ensure_codex_frontmatter(rendered, metadata, skill_id)
+    elif harness == "hermes":
+        rendered = _ensure_hermes_frontmatter(rendered, metadata, skill_id)
     return rendered
 
 
@@ -180,6 +235,8 @@ def _rendered_skill_validation(text: str, harness: str) -> list[str]:
         for key in ("name", "description"):
             if key not in existing_keys:
                 errors.append(f"codex SKILL.md frontmatter missing {key}")
+    if harness == "hermes" and not _has_yaml_frontmatter(text):
+        errors.append("hermes SKILL.md missing YAML frontmatter")
     return errors
 
 
@@ -547,6 +604,10 @@ def lint(*, target: Path, skill: str, harness: str | None = None, json_output: b
 
 
 def _install_dir(workspace: Path, harness: str, skill_id: str) -> Path:
+    if harness == "hermes":
+        # Real Hermes reads skills from its own data dir (auto-discovered as a
+        # local skill), not the repo. Install there so it actually takes effect.
+        return _hermes_skills_root() / _slug(skill_id)
     adapter = _adapter_map(workspace)[harness]
     install_dir = workspace / str(adapter["install_path"]).format(skill_id=skill_id)
     workspace_resolved = workspace.resolve()
@@ -636,7 +697,12 @@ def install(
     source_path = str(metadata.get("source") or source_dir)
     targets = install_targets if harness == "all" else (harness,)
     receipts: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
     for install_target in targets:
+        if install_target == "hermes" and not _hermes_home().exists():
+            # Do not create ~/.hermes for someone who does not run Hermes.
+            skipped.append({"target": "hermes", "reason": "Hermes home not found (is Hermes installed?)"})
+            continue
         dest = _install_dir(workspace, install_target, skill_id)
         source_text = _skill_md_path(source_dir).read_text(errors="replace")
         rendered_text = _render_skill_text_for_harness(source_text, metadata, skill_id, install_target)
@@ -712,6 +778,7 @@ def install(
         "fingerprint": lint_payload.get("fingerprint"),
         "targets": list(targets),
         "receipts": receipts,
+        "skipped": skipped,
     }
     payload = {"installed": True, "receipt": receipt}
     if json_output:
@@ -722,6 +789,8 @@ def install(
     for item in receipts:
         print(f"- {item['target']}: {item['installed_dir']}")
         print(f"  receipt: {item['receipt_path']}")
+    for item in skipped:
+        print(f"- {item['target']}: skipped ({item['reason']})")
     return 0
 
 

--- a/src/brigade/templates/generic/memory-contract.md
+++ b/src/brigade/templates/generic/memory-contract.md
@@ -22,7 +22,7 @@ Any harness that wants to plug into `brigade` must answer six questions.
 | `doctor_checks` | Existence of bootstrap files + jq queries against `openclaw.json` |
 | `publish_gate` | `content-guard` via `hooks/pre-push` |
 
-## Reference mapping (Hermes - experimental)
+## Reference mapping (Hermes)
 
 Same shape; map `memory_owner` to your Hermes config root and `doctor_checks` to whatever Hermes exposes.
 

--- a/src/brigade/templates/harnesses/hermes.json
+++ b/src/brigade/templates/harnesses/hermes.json
@@ -1,7 +1,7 @@
 {
   "id": "hermes",
   "role": "writer",
-  "description": "Hermes adapter fragments, handoff inbox, and doctor checks. Experimental runtime validation.",
+  "description": "Hermes adapter fragments, handoff inbox, skill install, and doctor checks. Validated against a real Hermes install.",
   "files": [
     {"src": "hermes/workspace.harness.json", "dst": ".brigade/hermes/workspace.harness.json"},
     {"src": "hermes/memory-handoff.harness.json", "dst": ".brigade/hermes/memory-handoff.harness.json"},
@@ -13,7 +13,7 @@
     ".hermes/memory-handoffs/processed"
   ],
   "post_install_notes": [
-    "Hermes support is experimental. Validate against your real Hermes install before relying on it.",
-    "Open an issue with your config layout to help promote the adapter from experimental to tested."
+    "Hermes support is validated against a real Hermes install (Hermes v0.17): handoffs and reviewed skills both work.",
+    "Reviewed skills install into your Hermes store ($HERMES_HOME/skills); handoffs land in .hermes/memory-handoffs/."
   ]
 }

--- a/src/brigade/templates/hermes/README.md
+++ b/src/brigade/templates/hermes/README.md
@@ -1,6 +1,6 @@
 # Hermes Adapter
 
-`brigade` supports Hermes as a local Memory Handoff writer. Runtime validation against live Hermes installs is still experimental, but the repo-local handoff contract is stable and tested by Brigade.
+`brigade` supports Hermes as a local Memory Handoff writer, validated against a real Hermes install (Hermes v0.17). Reviewed skills also install into your Hermes store (`$HERMES_HOME/skills`), where Hermes discovers them.
 
 ## What this gives you
 
@@ -38,10 +38,10 @@ brigade handoff archive --target . <draft-id> --reason "reviewed"
 
 ## Contributing
 
-If you run Hermes and have working config, open an issue at <https://github.com/escoffier-labs/brigade/issues> with:
+If your Hermes config layout differs, open an issue at <https://github.com/escoffier-labs/brigade/issues> with:
 
 - the file Hermes loads as its primary bootstrap file
 - the path where Hermes expects memory handoffs (if any)
 - the command that ingests handoffs into canonical memory
 
-That lets the adapter be promoted from experimental to tested.
+That helps keep the adapter working across Hermes versions.

--- a/src/brigade/templates/hermes/memory-handoff.harness.json
+++ b/src/brigade/templates/hermes/memory-handoff.harness.json
@@ -1,12 +1,12 @@
 {
   "_comment": [
-    "EXPERIMENTAL fragment for Hermes integration.",
+    "Hermes integration fragment.",
     "",
     "Describes the handoff inbox + routing targets that Hermes should treat",
     "as the canonical memory contract."
   ],
   "_brigade_version": "0.12.0",
-  "_brigade_status": "experimental",
+  "_brigade_status": "validated",
   "memory_handoff": {
     "inbox_dir": ".hermes/memory-handoffs",
     "processed_dir": ".hermes/memory-handoffs/processed",

--- a/src/brigade/templates/hermes/model-lanes.harness.json
+++ b/src/brigade/templates/hermes/model-lanes.harness.json
@@ -1,12 +1,12 @@
 {
   "_comment": [
-    "EXPERIMENTAL fragment for Hermes integration.",
+    "Hermes integration fragment.",
     "",
     "Suggested model lane names. Same shape as the OpenClaw alias map so",
     "knowledge cards and runbooks can talk about lanes without naming providers."
   ],
   "_brigade_version": "0.12.0",
-  "_brigade_status": "experimental",
+  "_brigade_status": "validated",
   "model_lanes": {
     "main": "<provider/main-model-id>",
     "coder": "<provider/coder-model-id>",

--- a/src/brigade/templates/hermes/workspace.harness.json
+++ b/src/brigade/templates/hermes/workspace.harness.json
@@ -1,15 +1,15 @@
 {
   "_comment": [
-    "EXPERIMENTAL fragment for Hermes integration.",
+    "Hermes integration fragment.",
     "",
     "Hermes support follows the same contract as OpenClaw; only the file names",
-    "and command paths change. This fragment is a placeholder until validated",
+    "and command paths change. The contract is validated",
     "against a real Hermes install.",
     "",
     "Replace <hermes-config-path> with your Hermes config location."
   ],
   "_brigade_version": "0.12.0",
-  "_brigade_status": "experimental",
+  "_brigade_status": "validated",
   "workspace": {
     "root": "<workspace-root>",
     "bootstrap_files": [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,17 @@ def tmp_target(tmp_path):
 
 
 @pytest.fixture(autouse=True)
+def _isolate_hermes_home(tmp_path_factory, monkeypatch):
+    """Point HERMES_HOME at a dedicated temp dir (outside the test's tmp_path so
+    it never pollutes workspace assertions) so hermes-harness skill installs
+    never touch the real ~/.hermes. The dir exists, so the 'Hermes is installed'
+    gate passes for tests that exercise hermes installs; tests that need the
+    absent-Hermes case re-point HERMES_HOME in their own body."""
+    home = tmp_path_factory.mktemp("hermes_home")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+
+@pytest.fixture(autouse=True)
 def _no_managed_tools_on_path(monkeypatch, request):
     """Default to the bare-host baseline: no managed tool detected on PATH.
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -290,7 +290,7 @@ def test_doctor_openclaw_reports_manual_when_config_missing(tmp_target: Path, mo
     assert "[todo]" in out
 
 
-def test_doctor_hermes_flags_experimental(tmp_target: Path, capsys):
+def test_doctor_hermes_runtime_validation(tmp_target: Path, capsys):
     install_selection(
         tmp_target,
         Selection(depth="workspace", harnesses=["claude", "hermes"], owner="hermes", includes=[]),

--- a/tests/test_fragments.py
+++ b/tests/test_fragments.py
@@ -42,7 +42,7 @@ def test_hermes_fragments(tmp_path: Path):
     ):
         assert (out / name).is_file()
     data = json.loads((out / "workspace.harness.json").read_text())
-    assert data.get("_brigade_status") == "experimental"
+    assert data.get("_brigade_status") == "validated"
     assert data["workspace"]["handoff_inbox"] == ".hermes/memory-handoffs"
     handoff = json.loads((out / "memory-handoff.harness.json").read_text())
     assert handoff["memory_handoff"]["inbox_dir"] == ".hermes/memory-handoffs"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -179,7 +179,7 @@ def test_openclaw_install_extends_workspace(tmp_target: Path):
     assert (fragments_dir / "memory-sweep-cron.openclaw.json").is_file()
 
 
-def test_hermes_install_writes_experimental_fragments(tmp_target: Path):
+def test_hermes_install_writes_fragments(tmp_target: Path):
     rc = install_selection(tmp_target, _hermes_sel())
     assert rc == 0
     fragments_dir = tmp_target / ".brigade" / "hermes"

--- a/tests/test_outcome.py
+++ b/tests/test_outcome.py
@@ -1,0 +1,140 @@
+import datetime as dt
+
+from brigade import outcome
+
+
+def test_wilson_lower_bound_zero_when_no_trials():
+    assert outcome.wilson_lower_bound(0, 0) == 0.0
+
+
+def test_wilson_lower_bound_below_one_and_grows_with_more_confirming_trials():
+    few = outcome.wilson_lower_bound(2, 2)
+    many = outcome.wilson_lower_bound(20, 20)
+    assert 0.0 < few < 1.0
+    assert few < many < 1.0
+
+
+def test_wilson_lower_bound_penalizes_a_miss():
+    clean = outcome.wilson_lower_bound(5, 5)
+    mixed = outcome.wilson_lower_bound(4, 5)
+    assert mixed < clean
+
+
+def test_signal_value_rewards_only_model_unauthored_success():
+    assert outcome.signal_value("verify", "completed") == 1
+    assert outcome.signal_value("verify", "failed") == -1
+    assert outcome.signal_value("verify", "timed_out") == -1
+    assert outcome.signal_value("friction", "cleared") == 1
+    assert outcome.signal_value("friction", "recurred") == -1
+    assert outcome.signal_value("learnings", "recurred") == -1
+
+
+def test_signal_value_treats_weak_or_unknown_signals_as_neutral():
+    # aboyeur "ok" is only "CLI exited cleanly", not a verified outcome
+    assert outcome.signal_value("aboyeur", "ok") == 0
+    # manual replay comparison is advisory, not a real signal
+    assert outcome.signal_value("replay", "better") == 0
+    assert outcome.signal_value("mystery", "whatever") == 0
+
+
+def test_score_records_folds_counts_wilson_and_last_signal():
+    records = [
+        outcome.OutcomeRecord("skill-x", "skill", "t1", "verify", 1, "ref1", "2026-06-20T00:00:00+00:00"),
+        outcome.OutcomeRecord("skill-x", "skill", "t2", "verify", 1, "ref2", "2026-06-20T01:00:00+00:00"),
+        outcome.OutcomeRecord("skill-x", "skill", "t3", "aboyeur", 0, "ref3", "2026-06-20T02:00:00+00:00"),
+    ]
+    score = outcome.score_records("skill-x", records)
+    assert score.artifact_id == "skill-x"
+    assert (score.helped, score.hurt, score.neutral) == (2, 0, 1)
+    assert score.score == outcome.wilson_lower_bound(2, 2)
+    assert score.last_signal_ts == "2026-06-20T02:00:00+00:00"
+
+
+def test_score_records_empty_is_zero():
+    score = outcome.score_records("skill-x", [])
+    assert (score.helped, score.hurt, score.neutral) == (0, 0, 0)
+    assert score.score == 0.0
+    assert score.last_signal_ts is None
+
+
+def _score(helped, hurt, neutral=0):
+    total = helped + hurt
+    return outcome.OutcomeScore(
+        "skill-x",
+        helped=helped,
+        hurt=hurt,
+        neutral=neutral,
+        score=outcome.wilson_lower_bound(helped, total),
+        last_signal_ts="2026-06-20T00:00:00+00:00",
+    )
+
+
+def test_decide_installs_a_clean_candidate():
+    decision = outcome.decide(
+        _score(2, 0),
+        current_status="candidate",
+        last_action_ts=None,
+        now=dt.datetime(2026, 6, 21),
+        config=outcome.ReconcileConfig(),
+    )
+    assert decision.action == "install"
+    assert decision.new_status == "promoted"
+
+
+def test_decide_withholds_candidate_with_a_verified_regression():
+    decision = outcome.decide(
+        _score(3, 1),
+        current_status="candidate",
+        last_action_ts=None,
+        now=dt.datetime(2026, 6, 21),
+        config=outcome.ReconcileConfig(),
+    )
+    assert decision.action == "hold"
+    assert decision.new_status == "candidate"
+
+
+def test_decide_withholds_candidate_with_insufficient_evidence():
+    decision = outcome.decide(
+        _score(1, 0),
+        current_status="candidate",
+        last_action_ts=None,
+        now=dt.datetime(2026, 6, 21),
+        config=outcome.ReconcileConfig(),
+    )
+    assert decision.action == "hold"
+
+
+def test_decide_rolls_back_a_promoted_artifact_on_regression():
+    decision = outcome.decide(
+        _score(5, 1),
+        current_status="promoted",
+        last_action_ts=None,
+        now=dt.datetime(2026, 6, 21),
+        config=outcome.ReconcileConfig(),
+    )
+    assert decision.action == "rollback"
+    assert decision.new_status == "demoted"
+
+
+def test_decide_holds_inside_cooldown_window():
+    now = dt.datetime(2026, 6, 21, 12, 0, 0)
+    recent = dt.datetime(2026, 6, 21, 11, 0, 0)  # 1h ago, default cooldown 24h
+    decision = outcome.decide(
+        _score(2, 0), current_status="candidate", last_action_ts=recent, now=now, config=outcome.ReconcileConfig()
+    )
+    assert decision.action == "hold"
+    assert "cooldown" in decision.reason
+
+
+def test_rank_score_blends_confidence_outcome_keyword():
+    assert outcome.rank_score(confidence=1.0, outcome=0.0, keyword=0.0) == 0.5
+    assert outcome.rank_score(confidence=0.0, outcome=1.0, keyword=0.0) == 0.4
+    assert outcome.rank_score(confidence=0.0, outcome=0.0, keyword=1.0) == 0.1
+    blended = outcome.rank_score(confidence=0.2, outcome=0.5, keyword=1.0)
+    assert abs(blended - (0.5 * 0.2 + 0.4 * 0.5 + 0.1 * 1.0)) < 1e-9
+
+
+def test_rank_score_prefers_verified_outcome_when_other_signals_tie():
+    proven = outcome.rank_score(confidence=0.3, outcome=0.8, keyword=0.5)
+    unproven = outcome.rank_score(confidence=0.3, outcome=0.1, keyword=0.5)
+    assert proven > unproven

--- a/tests/test_outcome_cmd.py
+++ b/tests/test_outcome_cmd.py
@@ -1,0 +1,260 @@
+import json
+
+from brigade import cli, outcome, outcome_cmd, work_cmd
+
+from tests.work_cmd_test_helpers import _init_git_repo
+
+
+def _seed(target, records):
+    outcome_cmd.append_records(target, records)
+
+
+def test_records_persist_under_git_tracked_memory_dir(tmp_path):
+    _seed(tmp_path, [outcome.OutcomeRecord("c", "card", "t", "verify", 1, "r", "2026-06-20T00:00:00+00:00")])
+    assert (tmp_path / "memory" / "outcome" / "records.jsonl").is_file()
+    # durable ledger must NOT live under the gitignored .brigade/ dir
+    assert not (tmp_path / ".brigade" / "outcome" / "records.jsonl").exists()
+
+
+def test_score_reports_wilson_for_seeded_records(tmp_path, capsys):
+    _seed(
+        tmp_path,
+        [
+            outcome.OutcomeRecord("skill-x", "skill", "t1", "verify", 1, "ref1", "2026-06-20T00:00:00+00:00"),
+            outcome.OutcomeRecord("skill-x", "skill", "t2", "verify", 1, "ref2", "2026-06-20T01:00:00+00:00"),
+        ],
+    )
+    assert outcome_cmd.score(target=tmp_path, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    entry = {s["artifact_id"]: s for s in payload["scores"]}["skill-x"]
+    assert entry["helped"] == 2 and entry["hurt"] == 0
+    assert entry["score"] == outcome.wilson_lower_bound(2, 2)
+
+
+def test_score_can_filter_to_one_artifact(tmp_path, capsys):
+    _seed(
+        tmp_path,
+        [
+            outcome.OutcomeRecord("skill-x", "skill", "t1", "verify", 1, "ref1", "2026-06-20T00:00:00+00:00"),
+            outcome.OutcomeRecord("skill-y", "skill", "t2", "verify", -1, "ref2", "2026-06-20T01:00:00+00:00"),
+        ],
+    )
+    assert outcome_cmd.score(target=tmp_path, artifact_id="skill-y", json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    ids = [s["artifact_id"] for s in payload["scores"]]
+    assert ids == ["skill-y"]
+
+
+def test_explain_lists_the_signal_trail_in_time_order(tmp_path, capsys):
+    _seed(
+        tmp_path,
+        [
+            outcome.OutcomeRecord("skill-x", "skill", "t2", "verify", -1, "ref-b", "2026-06-20T02:00:00+00:00"),
+            outcome.OutcomeRecord("skill-x", "skill", "t1", "verify", 1, "ref-a", "2026-06-20T00:00:00+00:00"),
+        ],
+    )
+    assert outcome_cmd.explain(target=tmp_path, artifact_id="skill-x", json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["artifact_id"] == "skill-x"
+    assert [t["evidence_ref"] for t in payload["trail"]] == ["ref-a", "ref-b"]
+    assert payload["score"]["helped"] == 1 and payload["score"]["hurt"] == 1
+
+
+def test_explain_unknown_artifact_is_empty_not_error(tmp_path, capsys):
+    assert outcome_cmd.explain(target=tmp_path, artifact_id="nope", json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["trail"] == []
+    assert payload["score"]["score"] == 0.0
+
+
+def test_cli_outcome_score_and_explain_dispatch(tmp_path, capsys):
+    _seed(tmp_path, [outcome.OutcomeRecord("skill-x", "skill", "t1", "verify", 1, "ref1", "2026-06-20T00:00:00+00:00")])
+    assert cli.main(["outcome", "score", "--target", str(tmp_path), "--json"]) == 0
+    assert "skill-x" in capsys.readouterr().out
+    assert cli.main(["outcome", "explain", "skill-x", "--target", str(tmp_path), "--json"]) == 0
+    assert "skill-x" in capsys.readouterr().out
+
+
+def test_capture_records_a_passing_verify_run_as_helped(tmp_path, capsys):
+    _init_git_repo(tmp_path)
+    assert work_cmd.verify_run(target=tmp_path, commands=["python3 -c \"print('ok')\""], timeout=30) == 0
+    capsys.readouterr()
+    assert (
+        outcome_cmd.capture(
+            target=tmp_path, artifact_id="skill-x", artifact_kind="skill", task_id="t1", json_output=True
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["record"]["signal_value"] == 1
+    assert payload["record"]["source"] == "verify"
+    assert payload["record"]["artifact_id"] == "skill-x"
+    records = outcome_cmd.load_records(tmp_path)
+    assert len(records) == 1 and records[0].evidence_ref.endswith("receipt.json")
+
+
+def test_capture_records_a_failing_verify_run_as_hurt(tmp_path, capsys):
+    _init_git_repo(tmp_path)
+    assert work_cmd.verify_run(target=tmp_path, commands=['python3 -c "raise SystemExit(3)"'], timeout=30) == 3
+    capsys.readouterr()
+    assert outcome_cmd.capture(target=tmp_path, artifact_id="skill-x", json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["record"]["signal_value"] == -1
+
+
+def test_capture_errors_when_no_verify_run_exists(tmp_path):
+    _init_git_repo(tmp_path)
+    assert outcome_cmd.capture(target=tmp_path, artifact_id="skill-x") == 1
+
+
+def test_cli_outcome_capture_dispatch(tmp_path, capsys):
+    _init_git_repo(tmp_path)
+    assert work_cmd.verify_run(target=tmp_path, commands=["python3 -c \"print('ok')\""], timeout=30) == 0
+    capsys.readouterr()
+    assert cli.main(["outcome", "capture", "skill-x", "--target", str(tmp_path), "--kind", "skill", "--json"]) == 0
+    assert "skill-x" in capsys.readouterr().out
+
+
+def _helped(artifact_id, n, start_hour=0):
+    return [
+        outcome.OutcomeRecord(
+            artifact_id, "skill", f"t{i}", "verify", 1, f"ref{i}", f"2026-06-20T0{start_hour + i}:00:00+00:00"
+        )
+        for i in range(n)
+    ]
+
+
+def _status_file(target):
+    return target / "memory" / "outcome" / "status.json"
+
+
+def _decisions_dir(target):
+    return target / "memory" / "outcome" / "decisions"
+
+
+def test_reconcile_dry_run_reports_install_without_writing(tmp_path, capsys):
+    _seed(tmp_path, _helped("skill-x", 2))
+    assert outcome_cmd.reconcile(target=tmp_path, apply=False, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["apply"] is False
+    actions = {d["artifact_id"]: d["action"] for d in payload["decisions"]}
+    assert actions["skill-x"] == "install"
+    # dry-run writes nothing
+    assert not _status_file(tmp_path).exists()
+    assert not _decisions_dir(tmp_path).exists()
+
+
+def test_reconcile_apply_installs_and_persists_status_and_receipt(tmp_path, capsys):
+    _seed(tmp_path, _helped("skill-x", 2))
+    assert outcome_cmd.reconcile(target=tmp_path, apply=True, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["applied"] == ["skill-x"]
+    status = json.loads(_status_file(tmp_path).read_text())
+    assert status["artifacts"]["skill-x"]["status"] == "promoted"
+    assert list(_decisions_dir(tmp_path).glob("*.json"))
+
+
+def test_reconcile_holds_inside_cooldown_after_apply(tmp_path, capsys):
+    _seed(tmp_path, _helped("skill-x", 2))
+    assert outcome_cmd.reconcile(target=tmp_path, apply=True, json_output=True) == 0
+    capsys.readouterr()
+    assert outcome_cmd.reconcile(target=tmp_path, apply=True, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["decisions"] == []
+
+
+def test_reconcile_rolls_back_promoted_artifact_on_regression(tmp_path, capsys):
+    cfg = outcome.ReconcileConfig(cooldown_seconds=0)
+    _seed(tmp_path, _helped("skill-x", 2))
+    assert outcome_cmd.reconcile(target=tmp_path, apply=True, config=cfg, json_output=True) == 0
+    capsys.readouterr()
+    _seed(
+        tmp_path,
+        [outcome.OutcomeRecord("skill-x", "skill", "t9", "verify", -1, "regress", "2026-06-20T09:00:00+00:00")],
+    )
+    assert outcome_cmd.reconcile(target=tmp_path, apply=True, config=cfg, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    actions = {d["artifact_id"]: d for d in payload["decisions"]}
+    assert actions["skill-x"]["action"] == "rollback"
+    status = json.loads(_status_file(tmp_path).read_text())
+    assert status["artifacts"]["skill-x"]["status"] == "demoted"
+
+
+def test_cli_outcome_reconcile_dispatch(tmp_path, capsys):
+    _seed(tmp_path, _helped("skill-x", 2))
+    assert cli.main(["outcome", "reconcile", "--target", str(tmp_path), "--json"]) == 0
+    assert "skill-x" in capsys.readouterr().out
+
+
+def test_rank_orders_artifacts_by_verified_score(tmp_path, capsys):
+    _seed(tmp_path, _helped("skill-a", 4))  # cleanly verified, higher Wilson bound
+    _seed(
+        tmp_path,
+        [
+            *_helped("skill-b", 2),
+            outcome.OutcomeRecord("skill-b", "skill", "tb", "verify", -1, "rb", "2026-06-20T09:00:00+00:00"),
+        ],
+    )
+    assert outcome_cmd.rank(target=tmp_path, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    ids = [item["artifact_id"] for item in payload["ranking"]]
+    assert ids[0] == "skill-a"
+    assert ids.index("skill-a") < ids.index("skill-b")
+
+
+def test_record_appends_an_explicit_friction_cleared_signal(tmp_path, capsys):
+    assert (
+        outcome_cmd.record(
+            target=tmp_path,
+            artifact_id="skill-x",
+            source="friction",
+            status="cleared",
+            evidence_ref="friction-scan#42",
+            json_output=True,
+        )
+        == 0
+    )
+    records = outcome_cmd.load_records(tmp_path)
+    assert len(records) == 1
+    assert records[0].source == "friction" and records[0].signal_value == 1
+
+
+def test_record_friction_recurred_is_a_hurt_signal(tmp_path, capsys):
+    assert (
+        outcome_cmd.record(
+            target=tmp_path,
+            artifact_id="skill-x",
+            source="friction",
+            status="recurred",
+            evidence_ref="f",
+            json_output=True,
+        )
+        == 0
+    )
+    capsys.readouterr()
+    assert outcome_cmd.load_records(tmp_path)[0].signal_value == -1
+
+
+def test_cli_outcome_rank_and_record_dispatch(tmp_path, capsys):
+    assert (
+        cli.main(
+            [
+                "outcome",
+                "record",
+                "skill-x",
+                "--source",
+                "friction",
+                "--status",
+                "cleared",
+                "--evidence",
+                "f",
+                "--target",
+                str(tmp_path),
+                "--json",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    assert cli.main(["outcome", "rank", "--target", str(tmp_path), "--json"]) == 0
+    assert "skill-x" in capsys.readouterr().out

--- a/tests/test_outcome_execute.py
+++ b/tests/test_outcome_execute.py
@@ -1,0 +1,78 @@
+import contextlib
+import io
+import json
+
+from brigade import outcome, outcome_cmd, skills_cmd
+
+from tests.test_skills_cmd import _write_skill
+
+
+def _import_skill(tmp_path, name="security-review"):
+    source = _write_skill(tmp_path / "source", name)
+    with contextlib.redirect_stdout(io.StringIO()):
+        assert skills_cmd.import_skill(target=tmp_path, source=source, json_output=True) == 0
+    return name
+
+
+def _helped(artifact_id, n):
+    return [
+        outcome.OutcomeRecord(artifact_id, "skill", f"t{i}", "verify", 1, f"r{i}", f"2026-06-20T0{i}:00:00+00:00")
+        for i in range(n)
+    ]
+
+
+def test_reconcile_apply_physically_installs_a_verified_skill(tmp_path, capsys):
+    name = _import_skill(tmp_path)
+    outcome_cmd.append_records(tmp_path, _helped(name, 2))
+    assert outcome_cmd.reconcile(target=tmp_path, apply=True, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    decision = {d["artifact_id"]: d for d in payload["decisions"]}[name]
+    assert decision["action"] == "install"
+    assert decision["execution"].startswith("installed")
+    assert skills_cmd._install_dir(tmp_path.resolve(), "claude", name).exists()
+
+
+def test_reconcile_rollback_of_a_first_install_uninstalls(tmp_path, capsys):
+    cfg = outcome.ReconcileConfig(cooldown_seconds=0)
+    name = _import_skill(tmp_path)
+    outcome_cmd.append_records(tmp_path, _helped(name, 2))
+    assert outcome_cmd.reconcile(target=tmp_path, apply=True, config=cfg, json_output=True) == 0
+    capsys.readouterr()
+    dest = skills_cmd._install_dir(tmp_path.resolve(), "claude", name)
+    assert dest.exists()
+
+    outcome_cmd.append_records(
+        tmp_path, [outcome.OutcomeRecord(name, "skill", "t9", "verify", -1, "regress", "2026-06-20T09:00:00+00:00")]
+    )
+    assert outcome_cmd.reconcile(target=tmp_path, apply=True, config=cfg, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    decision = {d["artifact_id"]: d for d in payload["decisions"]}[name]
+    assert decision["action"] == "rollback"
+    # first install had no prior snapshot, so the regression uninstalls it cleanly
+    assert not dest.exists()
+
+
+def test_reconcile_dry_run_does_not_install(tmp_path, capsys):
+    name = _import_skill(tmp_path)
+    outcome_cmd.append_records(tmp_path, _helped(name, 2))
+    assert outcome_cmd.reconcile(target=tmp_path, apply=False, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    decision = {d["artifact_id"]: d for d in payload["decisions"]}[name]
+    assert decision["execution"] == "dry-run"
+    assert not skills_cmd._install_dir(tmp_path.resolve(), "claude", name).exists()
+
+
+def test_reconcile_card_decision_skips_physical_execution(tmp_path, capsys):
+    cfg = outcome.ReconcileConfig(cooldown_seconds=0)
+    outcome_cmd.append_records(
+        tmp_path,
+        [
+            outcome.OutcomeRecord("card-x", "card", "t0", "verify", 1, "r0", "2026-06-20T00:00:00+00:00"),
+            outcome.OutcomeRecord("card-x", "card", "t1", "verify", 1, "r1", "2026-06-20T01:00:00+00:00"),
+        ],
+    )
+    assert outcome_cmd.reconcile(target=tmp_path, apply=True, config=cfg, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    decision = {d["artifact_id"]: d for d in payload["decisions"]}["card-x"]
+    assert decision["action"] == "install"
+    assert "v1.1" in decision["execution"]

--- a/tests/test_skills_cmd.py
+++ b/tests/test_skills_cmd.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import contextlib
 import io
 import json
+import os
 import sys
+from pathlib import Path
 
 from brigade import cli, skills_cmd
 
@@ -88,7 +91,9 @@ def test_skills_import_lint_search_and_install_all(tmp_path, capsys):
     assert (tmp_path / ".cursor" / "skills" / "security-review" / "SKILL.md").is_file()
     assert not (tmp_path / ".agents" / "skills" / "security-review" / "SKILL.md").exists()
     assert (tmp_path / ".openclaw" / "skills" / "security-review" / "SKILL.md").is_file()
-    assert (tmp_path / ".hermes" / "skills" / "security-review" / "SKILL.md").is_file()
+    # hermes installs into the user's Hermes store (where Hermes actually reads), not repo-local
+    assert (Path(os.environ["HERMES_HOME"]) / "skills" / "brigade-imports" / "security-review" / "SKILL.md").is_file()
+    assert not (tmp_path / ".hermes" / "skills" / "security-review").exists()
     assert (tmp_path / ".brigade" / "skills" / "mcp-resources" / "security-review" / "SKILL.md").is_file()
 
 
@@ -102,6 +107,45 @@ def test_skills_cli_install_uses_target_for_harness(tmp_path):
     )
 
     assert (tmp_path / ".codex" / "skills" / "security-review" / "SKILL.md").is_file()
+
+
+def test_hermes_skill_installs_into_global_hermes_home_for_real_discovery(tmp_path):
+    source = _write_skill(tmp_path / "source")
+    with contextlib.redirect_stdout(io.StringIO()):
+        assert skills_cmd.import_skill(target=tmp_path, source=source, json_output=True) == 0
+        assert skills_cmd.install(workspace=tmp_path, skill="security-review", harness="hermes", json_output=True) == 0
+    hermes_home = Path(os.environ["HERMES_HOME"])
+    assert (hermes_home / "skills" / "brigade-imports" / "security-review" / "SKILL.md").is_file()
+    # the repo-local .hermes/skills path, which real Hermes ignores, is NOT used
+    assert not (tmp_path / ".hermes" / "skills" / "security-review").exists()
+
+
+def test_hermes_skill_install_skipped_when_hermes_not_installed(tmp_path, monkeypatch):
+    absent = tmp_path / "no-hermes-here"
+    monkeypatch.setenv("HERMES_HOME", str(absent))
+    source = _write_skill(tmp_path / "source")
+    with contextlib.redirect_stdout(io.StringIO()):
+        assert skills_cmd.import_skill(target=tmp_path, source=source, json_output=True) == 0
+        rc = skills_cmd.install(workspace=tmp_path, skill="security-review", harness="hermes", json_output=True)
+    assert rc == 0
+    # no ~/.hermes is created for a user who does not run Hermes
+    assert not absent.exists()
+    # and nothing is projected repo-local either
+    assert not (tmp_path / ".hermes" / "skills" / "security-review").exists()
+
+
+def test_hermes_install_adds_hermes_frontmatter_so_hermes_discovers_it(tmp_path):
+    source = _write_skill(tmp_path / "source")
+    with contextlib.redirect_stdout(io.StringIO()):
+        assert skills_cmd.import_skill(target=tmp_path, source=source, json_output=True) == 0
+        assert skills_cmd.install(workspace=tmp_path, skill="security-review", harness="hermes", json_output=True) == 0
+    installed = Path(os.environ["HERMES_HOME"]) / "skills" / "brigade-imports" / "security-review" / "SKILL.md"
+    text = installed.read_text()
+    # real Hermes only lists a local skill whose SKILL.md has YAML frontmatter
+    assert text.startswith("---\n")
+    assert 'name: "security-review"' in text
+    assert "version:" in text
+    assert "# Security Review" in text
 
 
 def test_skills_serve_mcp_reports_resource_contract(capsys, tmp_path):


### PR DESCRIPTION
## What this is

The verified-autonomous learning loop ("The Ratchet") plus the Hermes harness fixes and graduation.

### Learning loop (`brigade outcome ...`)
- `capture` turns a real `verify` exit code into a signed outcome record (no LLM self-grading).
- `score` ranks artifacts by a Wilson lower bound, so thin evidence never out-ranks vetted skills.
- `reconcile` is the autonomous gate: dry-run by default; `--apply` installs a verified skill across harnesses or rolls back on a measured regression (and uninstalls a bad first install that has no prior snapshot).
- `explain` prints the per-signal audit trail; `rank` orders skills by proven score; `record` feeds explicit friction/learnings signals.
- Durable ledger is git-tracked under `memory/outcome/` (portable, readable without Brigade).

### Hermes
- Skill installs now reach real Hermes: the hermes harness installs into `$HERMES_HOME/skills/brigade-imports/<id>` with the YAML frontmatter Hermes requires, gated on the Hermes home existing so a non-Hermes user never gets a `~/.hermes`.
- Graduated the adapter from "experimental" to "validated" across the picker, doctor, install/fragment notices, adapter fragments, templates, README, and QUICKSTART. Other 17 harnesses unchanged.

### Validation
- Full suite green (1227 tests), ruff clean.
- Validated end to end against a real Hermes v0.17 install: handoff contract and skill install both confirmed.
