### PR TITLE
docs: regenerate command inventory for the outcome commands

### DIFF
--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -32,6 +32,7 @@ brigade roadmap commands --write
 - `brigade notifications`: 4 command path(s)
 - `brigade openclaw-fragments`: 1 command path(s)
 - `brigade operator`: 23 command path(s)
+- `brigade outcome`: 6 command path(s)
 - `brigade pantry`: 3 command path(s)
 - `brigade projects`: 10 command path(s)
 - `brigade reconfigure`: 1 command path(s)
@@ -204,6 +205,12 @@ brigade roadmap commands --write
 - `brigade operator surfaces reviews`
 - `brigade operator sync-tools`
 - `brigade operator verify-harness`
+- `brigade outcome capture`
+- `brigade outcome explain`
+- `brigade outcome rank`
+- `brigade outcome reconcile`
+- `brigade outcome record`
+- `brigade outcome score`
 - `brigade pantry service plan`
 - `brigade pantry setup plan`
 - `brigade pantry status`


### PR DESCRIPTION
Follow-up to #100: the inventory check (repo-metadata) needs docs/command-inventory.md regenerated for the new `brigade outcome` command group. Generated with `brigade roadmap commands --write`.