### PR TITLE
feat(context): GraphTrail code-graph section in context packs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ memory/handoff-inbox/
 .mcp/
 scripts/*.md
 # <<< brigade gitignore block <<<
+
+# GraphTrail code-graph index
+.graphtrail/

--- a/src/brigade/context_cmd.py
+++ b/src/brigade/context_cmd.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import sys
 from datetime import datetime, timezone
@@ -10,7 +11,7 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
-from . import work_cmd
+from . import proc, work_cmd
 from .localio import (
     read_json_dict as _read_json,
     stable_hash as _stable_hash,
@@ -98,6 +99,69 @@ def _latest_json(root: Path, filename: str) -> dict[str, Any] | None:
     return _read_json(candidates[0]) if candidates else None
 
 
+def _graphtrail_bin() -> str | None:
+    """Resolve the graphtrail binary: $GRAPHTRAIL_BIN, then PATH, then ~/.cargo/bin (so it
+    works even when the spawning environment's PATH omits the cargo bin dir)."""
+    override = os.environ.get("GRAPHTRAIL_BIN")
+    if override and Path(override).is_file():
+        return override
+    found = proc.which("graphtrail")
+    if found:
+        return found
+    fallback = Path.home() / ".cargo" / "bin" / "graphtrail"
+    return str(fallback) if fallback.is_file() else None
+
+
+def _code_graph_summary(target: Path, selected_task: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Structural code context for the task from GraphTrail, or None when unavailable.
+
+    Reads the repo's ``.graphtrail/graphtrail.db`` (built by ``graphtrail sync``) via the
+    read-only ``graphtrail context`` command. Returns None and never raises when GraphTrail
+    is not installed, the db is absent, or there is no task to query, so pack building is
+    never blocked by this optional integration.
+    """
+    if not isinstance(selected_task, dict):
+        return None
+    query = selected_task.get("text") or selected_task.get("id")
+    if not isinstance(query, str) or not query.strip():
+        return None
+    db_path = target / ".graphtrail" / "graphtrail.db"
+    binary = _graphtrail_bin()
+    if not db_path.is_file() or binary is None:
+        return None
+
+    result = proc.run(
+        [binary, "--db", str(db_path), "context", query, "--json", "--limit", "8"],
+        timeout=10.0,
+        cwd=target,
+    )
+    if result.code != 0:
+        return None
+    data = result.json()
+    if not isinstance(data, dict):
+        return None
+
+    entry_points = data.get("entry_points") if isinstance(data.get("entry_points"), list) else []
+    related_files = data.get("related_files") if isinstance(data.get("related_files"), list) else []
+    return {
+        "schema_version": data.get("schema_version"),
+        "query": query,
+        "entry_points": [
+            {
+                "qualified_name": ep.get("qualified_name"),
+                "kind": ep.get("kind"),
+                "file_path": ep.get("file_path"),
+                "start_line": ep.get("start_line"),
+            }
+            for ep in entry_points
+            if isinstance(ep, dict)
+        ][:8],
+        "related_files": related_files[:20],
+        "caller_count": len(data.get("callers")) if isinstance(data.get("callers"), list) else 0,
+        "callee_count": len(data.get("callees")) if isinstance(data.get("callees"), list) else 0,
+    }
+
+
 def _context_payload(
     target: Path,
     *,
@@ -131,6 +195,7 @@ def _context_payload(
         checks.append({"status": WARN, "name": "context_task", "detail": "no matching task"})
     latest_closeout = _latest_json(target / ".brigade" / "work" / "closeouts", "closeout.json")
     latest_security = _latest_json(target / ".brigade" / "security", "security-report.json")
+    code_graph = _code_graph_summary(target, selected_task)
     return {
         "target": str(target),
         "kind": kind,
@@ -149,6 +214,7 @@ def _context_payload(
             "finding_count": latest_security.get("finding_count") if isinstance(latest_security, dict) else None,
             "summary": latest_security.get("summary") if isinstance(latest_security, dict) else None,
         },
+        "code_graph": code_graph,
         "recent_review_findings": [
             work_cmd._import_summary(item)
             for item in work_cmd._read_imports(target)
@@ -209,6 +275,7 @@ def build(
         f"- kind: {kind}",
         f"- task: {payload['task'].get('id') or 'none'}",
         f"- issues: {len(payload['issues'])}",
+        f"- code graph: {len((payload.get('code_graph') or {}).get('entry_points') or [])} entry points",
         "",
         "## Excluded Private Evidence",
         *[f"- {item}" for item in payload["excluded_private_evidence"]],

--- a/tests/test_context_cmd.py
+++ b/tests/test_context_cmd.py
@@ -1,0 +1,85 @@
+"""Tests for the GraphTrail code-graph section of context packs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from brigade import context_cmd, proc
+
+
+def _make_db(target: Path) -> Path:
+    db = target / ".graphtrail" / "graphtrail.db"
+    db.parent.mkdir(parents=True, exist_ok=True)
+    db.write_text("")  # presence is enough; proc.run is mocked in these tests
+    return db
+
+
+def test_code_graph_summary_none_without_db(tmp_target):
+    tmp_target.mkdir(parents=True)
+    assert context_cmd._code_graph_summary(tmp_target, {"id": "t1", "text": "do x"}) is None
+
+
+def test_code_graph_summary_none_without_task(tmp_target, monkeypatch):
+    tmp_target.mkdir(parents=True)
+    _make_db(tmp_target)
+    monkeypatch.setattr(context_cmd.proc, "which", lambda c: "/x/" + c)
+    assert context_cmd._code_graph_summary(tmp_target, None) is None
+
+
+def test_code_graph_summary_parses_and_trims(tmp_target, monkeypatch):
+    tmp_target.mkdir(parents=True)
+    _make_db(tmp_target)
+    monkeypatch.setattr(context_cmd.proc, "which", lambda c: "/x/" + c)
+
+    pack = {
+        "schema_version": 1,
+        "task": "handoff lint",
+        "entry_points": [
+            {
+                "qualified_name": "lint",
+                "kind": "function",
+                "file_path": "a.py",
+                "start_line": 5,
+                "signature": "drop me",
+            }
+        ],
+        "callers": [{"x": 1}, {"x": 2}],
+        "callees": [],
+        "related_files": ["a.py", "b.py"],
+    }
+
+    def fake_run(args, **kw):
+        assert Path(args[0]).name == "graphtrail"
+        assert "context" in args and "--json" in args
+        return proc.Result(code=0, stdout=json.dumps(pack), stderr="")
+
+    monkeypatch.setattr(context_cmd.proc, "run", fake_run)
+
+    out = context_cmd._code_graph_summary(tmp_target, {"id": "t1", "text": "handoff lint"})
+    assert out is not None
+    assert out["schema_version"] == 1
+    assert out["query"] == "handoff lint"
+    assert out["entry_points"][0]["qualified_name"] == "lint"
+    assert "signature" not in out["entry_points"][0]  # trimmed to the four fields
+    assert out["caller_count"] == 2
+    assert out["callee_count"] == 0
+    assert out["related_files"] == ["a.py", "b.py"]
+
+
+def test_code_graph_summary_none_on_nonzero_exit(tmp_target, monkeypatch):
+    tmp_target.mkdir(parents=True)
+    _make_db(tmp_target)
+    monkeypatch.setattr(context_cmd.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(
+        context_cmd.proc, "run", lambda args, **kw: proc.Result(code=1, stdout="", stderr="boom")
+    )
+    assert context_cmd._code_graph_summary(tmp_target, {"text": "x"}) is None
+
+
+def test_context_payload_always_has_code_graph_key(tmp_target):
+    # No db and no task -> code_graph is None, but the key is always present and the pack builds.
+    tmp_target.mkdir(parents=True)
+    payload = context_cmd._context_payload(tmp_target, kind="repo")
+    assert "code_graph" in payload
+    assert payload["code_graph"] is None


### PR DESCRIPTION
Adds a `code_graph` section to Brigade context packs, sourced from GraphTrail's read-only `graphtrail context` for the selected task.

## What
- New `_code_graph_summary(target, selected_task)` in `context_cmd.py`: runs `graphtrail --db <repo>/.graphtrail/graphtrail.db context <task> --json --limit 8` and embeds a trimmed result (entry points, related files, caller/callee counts).
- Resolves the graphtrail binary via `$GRAPHTRAIL_BIN` → PATH → `~/.cargo/bin`.
- Skips gracefully (returns None, never raises) when the binary, the repo's `.graphtrail` db, or a task is absent. Pack building is never blocked.
- `build` markdown summary gains a one-line code-graph count.

## Why
Gives operator/agent context packs the structural "what connects to what" layer (entry points + blast radius) alongside the existing semantic/security/work evidence.

## Tests
- `tests/test_context_cmd.py`: db-absent skip, task-absent skip, parse+trim, non-zero-exit skip, and code_graph key always present.
- Full suite: 1284 passed. Verified live against brigade's own synced graph.