### PR TITLE
style: ruff format test_context_cmd.py

### DIFF
--- a/tests/test_context_cmd.py
+++ b/tests/test_context_cmd.py
@@ -71,9 +71,7 @@ def test_code_graph_summary_none_on_nonzero_exit(tmp_target, monkeypatch):
     tmp_target.mkdir(parents=True)
     _make_db(tmp_target)
     monkeypatch.setattr(context_cmd.proc, "which", lambda c: "/x/" + c)
-    monkeypatch.setattr(
-        context_cmd.proc, "run", lambda args, **kw: proc.Result(code=1, stdout="", stderr="boom")
-    )
+    monkeypatch.setattr(context_cmd.proc, "run", lambda args, **kw: proc.Result(code=1, stdout="", stderr="boom"))
     assert context_cmd._code_graph_summary(tmp_target, {"text": "x"}) is None
 
 


### PR DESCRIPTION
PR #103 (GraphTrail context section) merged with one unformatted test file, leaving `main` red on the lint job's `ruff format --check` gate. Tests, smoke, and all install-from-source variants were green throughout; only formatting tripped.

This runs `ruff format` on `tests/test_context_cmd.py` (collapses one over-split `monkeypatch.setattr` call onto a single line). Formatting-only, no logic change. `ruff format --check .` now reports all 248 files formatted.