### PR TITLE
fix(outcome): dedup signals so a re-captured run can't auto-promote

### DIFF
--- a/src/brigade/outcome.py
+++ b/src/brigade/outcome.py
@@ -94,10 +94,24 @@ def signal_value(source: str, status: str) -> int:
 
 
 def score_records(artifact_id: str, records: list[OutcomeRecord]) -> OutcomeScore:
-    """Fold an artifact's records into counts plus a Wilson lower-bound score."""
-    helped = sum(1 for r in records if r.signal_value > 0)
-    hurt = sum(1 for r in records if r.signal_value < 0)
-    neutral = sum(1 for r in records if r.signal_value == 0)
+    """Fold an artifact's records into counts plus a Wilson lower-bound score.
+
+    Counts DISTINCT verified evidence, not raw rows. A re-captured or retried run
+    yields a byte-identical record (same source, evidence_ref, task_id), and the
+    same physical receipt must contribute at most one signal, or a single trial
+    could cross install_min_helped and auto-install with no independent evidence.
+    """
+    seen: set[tuple[str, str, str]] = set()
+    deduped: list[OutcomeRecord] = []
+    for r in records:
+        key = (r.source, r.evidence_ref, r.task_id)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(r)
+    helped = sum(1 for r in deduped if r.signal_value > 0)
+    hurt = sum(1 for r in deduped if r.signal_value < 0)
+    neutral = sum(1 for r in deduped if r.signal_value == 0)
     total = helped + hurt
     last_ts = max((r.ts for r in records), default=None)
     return OutcomeScore(

--- a/tests/test_outcome.py
+++ b/tests/test_outcome.py
@@ -50,6 +50,30 @@ def test_score_records_folds_counts_wilson_and_last_signal():
     assert score.last_signal_ts == "2026-06-20T02:00:00+00:00"
 
 
+def test_score_records_dedups_identical_signals():
+    # A re-captured/retried verify run produces a byte-identical record; the same
+    # physical receipt must not be counted twice (P1: double-count auto-installs).
+    duplicate = outcome.OutcomeRecord("skill-x", "skill", "t1", "verify", 1, "ref1", "2026-06-20T00:00:00+00:00")
+    score = outcome.score_records("skill-x", [duplicate, duplicate])
+    assert score.helped == 1
+
+
+def test_score_records_dedup_does_not_promote_a_single_genuine_positive():
+    # Two identical positives are one signal, which is below install_min_helped=2,
+    # so a clean candidate must NOT be promoted off a single genuine trial.
+    duplicate = outcome.OutcomeRecord("skill-x", "skill", "t1", "verify", 1, "ref1", "2026-06-20T00:00:00+00:00")
+    score = outcome.score_records("skill-x", [duplicate, duplicate])
+    decision = outcome.decide(
+        score,
+        current_status="candidate",
+        last_action_ts=None,
+        now=dt.datetime(2026, 6, 21),
+        config=outcome.ReconcileConfig(),
+    )
+    assert decision.action == "hold"
+    assert decision.new_status == "candidate"
+
+
 def test_score_records_empty_is_zero():
     score = outcome.score_records("skill-x", [])
     assert (score.helped, score.hurt, score.neutral) == (0, 0, 0)


### PR DESCRIPTION
## What
A re-captured or retried verify run produces a byte-identical `OutcomeRecord`. `score_records` counted raw rows, so two identical positives yielded `helped=2`, crossing `install_min_helped` and auto-installing a skill across all harnesses with no independent evidence, defeating the "verified, independent trials" guarantee.

## Fix
Count DISTINCT verified evidence keyed on `(source, evidence_ref, task_id)` when scoring, so the same physical receipt contributes at most one signal. The append-only ledger trail is preserved in full; only the score collapses duplicates, keeping the audit/explain trail honest.

## Tests
+2 in `tests/test_outcome.py`: two identical records yield `helped=1`, and a single genuine positive does not promote. Fail on main, pass here. Suite green, ruff clean.
