### PR TITLE
feat(operator): add MCP on-ramp to quickstart golden path

### DIFF
--- a/src/brigade/operator_cmd/lifecycle.py
+++ b/src/brigade/operator_cmd/lifecycle.py
@@ -450,6 +450,8 @@ def quickstart(
         {"id": "portable-bootstrap", "status": portable_status, "return_code": portable_rc, "payload": portable_payload}
     )
 
+    steps.append(_quickstart_mcp_onramp(target, dry_run=dry_run, force=force))
+
     if dry_run:
         for harness in selected_harnesses:
             if harness in WRITER_INBOXES:
@@ -509,6 +511,41 @@ def quickstart(
     return 0 if ok else 1
 
 
+def _quickstart_mcp_onramp(target: Path, *, dry_run: bool, force: bool) -> dict[str, Any]:
+    """Scaffold the canonical MCP catalog and preview the projection plan.
+
+    The README leads with MCP/tool sync, so quickstart must put that feature on
+    the golden path. This writes only `.brigade/mcp.json` (local owned state) and
+    runs `mcp plan` as a dry-run summary. It never writes harness MCP configs,
+    matching the dry-run-by-default, no-auto-write contract for shared config.
+    """
+    from .. import mcp_cmd
+
+    if dry_run:
+        return {
+            "id": "mcp-init",
+            "status": "planned",
+            "return_code": 0,
+            "next_command": "brigade mcp init --target .",
+        }
+    init_rc, init_payload = _capture_json_call(mcp_cmd.init, target=target, force=force)
+    # init returns 3 when the catalog already exists; that is a benign skip here.
+    if init_rc == 3:
+        step: dict[str, Any] = {"id": "mcp-init", "status": "skipped", "return_code": 0, "payload": init_payload}
+    else:
+        step = {
+            "id": "mcp-init",
+            "status": "ok" if init_rc == 0 else "error",
+            "return_code": init_rc,
+            "payload": init_payload,
+        }
+    if init_rc in {0, 3}:
+        _, plan_payload = _capture_json_call(mcp_cmd.plan, target=target)
+        if isinstance(plan_payload, dict):
+            step["plan"] = {"counts": plan_payload.get("counts"), "server_count": len(plan_payload.get("items") or [])}
+    return step
+
+
 def _quickstart_next_commands(harnesses: list[str], *, dry_run: bool) -> list[str]:
     if dry_run:
         return ["rerun without --dry-run after reviewing planned writes"]
@@ -516,6 +553,8 @@ def _quickstart_next_commands(harnesses: list[str], *, dry_run: bool) -> list[st
         "brigade operator doctor --target . --profile local-operator",
         "brigade tools list --target .",
         "brigade skills doctor --target .",
+        "brigade mcp init --target .",
+        "brigade mcp sync --write --target .",
         "brigade security scan --target . --output-dir .brigade/security/latest",
     ]
     commands.extend(

--- a/tests/test_operator_cmd.py
+++ b/tests/test_operator_cmd.py
@@ -1235,6 +1235,34 @@ def test_operator_quickstart_prepares_new_user_workspace(tmp_path, capsys):
     assert handoff_doctor["warnings"] == []
 
 
+def test_operator_quickstart_scaffolds_mcp_onramp(tmp_path, capsys):
+    assert cli.main(["operator", "quickstart", "--target", str(tmp_path), "--harnesses", "codex", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "ok"
+    # The README leads with MCP/tool sync, so quickstart must scaffold the
+    # canonical catalog and surface the MCP commands on the golden path.
+    assert (tmp_path / ".brigade" / "mcp.json").is_file()
+    mcp_step = next((step for step in payload["steps"] if step["id"] == "mcp-init"), None)
+    assert mcp_step is not None
+    assert mcp_step["status"] == "ok"
+    assert any("brigade mcp init" in command for command in payload["next_commands"])
+    assert any("brigade mcp sync --write" in command for command in payload["next_commands"])
+
+
+def test_operator_quickstart_mcp_onramp_does_not_write_tool_configs(tmp_path, capsys):
+    assert cli.main(["operator", "quickstart", "--target", str(tmp_path), "--harnesses", "codex", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "ok"
+    # The on-ramp is dry-run by default: it scaffolds the canonical catalog but
+    # must never write a harness MCP config automatically.
+    assert (tmp_path / ".brigade" / "mcp.json").is_file()
+    assert not (tmp_path / ".mcp.json").exists()
+    # codex's real MCP target is .codex/config.toml; the on-ramp must not write
+    # mcp_servers into it (sync is never invoked, only init + a read-only plan).
+    codex_cfg = tmp_path / ".codex" / "config.toml"
+    assert not codex_cfg.exists() or "mcp_servers" not in codex_cfg.read_text()
+
+
 def test_operator_quickstart_dry_run_does_not_write(tmp_path, capsys):
     assert (
         cli.main(


### PR DESCRIPTION
## What
`brigade operator quickstart` wired inboxes, operator init, and tools/skills bootstrap, but never touched MCP, so a new engineer following the documented golden path never saw the MCP/tool-sync feature the README now leads with.

## Fix
Thread an MCP on-ramp into `quickstart()`: scaffold the canonical `.brigade/mcp.json` via `mcp_cmd.init`, run a read-only `mcp plan` preview, and surface `brigade mcp init` / `sync --write` in the printed next-steps. Gated to never auto-write harness MCP configs (sync is never invoked), and respects `--dry-run`.

## Tests
+2 in `tests/test_operator_cmd.py`: quickstart scaffolds the catalog and surfaces the on-ramp, and writes no harness MCP config. Suite green, ruff clean.
