### PR TITLE
feat(operator): quickstart arms the dogfood/work loop by default

### DIFF
--- a/src/brigade/operator_cmd/lifecycle.py
+++ b/src/brigade/operator_cmd/lifecycle.py
@@ -478,6 +478,7 @@ def quickstart(
         )
 
     steps.append(_quickstart_mcp_onramp(target, dry_run=dry_run, force=force))
+    steps.append(_quickstart_dogfood(target, dry_run=dry_run, force=force))
 
     if dry_run:
         for harness in selected_harnesses:
@@ -575,6 +576,36 @@ def _quickstart_mcp_onramp(target: Path, *, dry_run: bool, force: bool) -> dict[
         if isinstance(plan_payload, dict):
             step["plan"] = {"counts": plan_payload.get("counts"), "server_count": len(plan_payload.get("items") or [])}
     return step
+
+
+def _quickstart_dogfood(target: Path, *, dry_run: bool, force: bool) -> dict[str, Any]:
+    """Arm the work/dogfood loop so a new repo captures runs from day one.
+
+    Without a dogfood config the `work` station is wired but dormant: `work
+    status` reports `dogfood: not ready` and no runs are ever captured, which is
+    the single most common reason a freshly set-up repo never feeds its outcome
+    ledger. This writes only `.brigade/dogfood.toml` (local owned state) and
+    starts no runs, matching the no-auto-run contract of the other steps.
+    """
+    from .. import dogfood_cmd
+
+    if dry_run:
+        return {
+            "id": "dogfood-init",
+            "status": "planned",
+            "return_code": 0,
+            "next_command": "brigade dogfood init --target .",
+        }
+    if dogfood_cmd.config_path(target).exists() and not force:
+        # A dogfood config already exists; keep it rather than clobber local edits.
+        return {"id": "dogfood-init", "status": "skipped", "return_code": 0}
+    init_rc, init_output = _capture_text_call(dogfood_cmd.init, target=target, force=force)
+    return {
+        "id": "dogfood-init",
+        "status": "ok" if init_rc == 0 else "error",
+        "return_code": init_rc,
+        "output": init_output,
+    }
 
 
 def _quickstart_next_commands(harnesses: list[str], *, dry_run: bool) -> list[str]:

--- a/tests/test_operator_cmd.py
+++ b/tests/test_operator_cmd.py
@@ -1272,6 +1272,32 @@ def test_operator_quickstart_scaffolds_mcp_onramp(tmp_path, capsys):
     assert any("brigade mcp sync --write" in command for command in payload["next_commands"])
 
 
+def test_operator_quickstart_arms_dogfood_loop(tmp_path, capsys):
+    assert cli.main(["operator", "quickstart", "--target", str(tmp_path), "--harnesses", "codex", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "ok"
+    # Without a dogfood config the work station is wired but dormant, so a fresh
+    # repo never captures runs or feeds its outcome ledger. Quickstart must arm it.
+    assert (tmp_path / ".brigade" / "dogfood.toml").is_file()
+    dogfood_step = next((step for step in payload["steps"] if step["id"] == "dogfood-init"), None)
+    assert dogfood_step is not None
+    assert dogfood_step["status"] == "ok"
+
+
+def test_operator_quickstart_dry_run_plans_dogfood_without_writing(tmp_path, capsys):
+    assert (
+        cli.main(
+            ["operator", "quickstart", "--target", str(tmp_path), "--harnesses", "codex", "--dry-run", "--json"]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    dogfood_step = next((step for step in payload["steps"] if step["id"] == "dogfood-init"), None)
+    assert dogfood_step is not None
+    assert dogfood_step["status"] == "planned"
+    assert not (tmp_path / ".brigade" / "dogfood.toml").exists()
+
+
 def test_operator_quickstart_mcp_onramp_does_not_write_tool_configs(tmp_path, capsys):
     assert cli.main(["operator", "quickstart", "--target", str(tmp_path), "--harnesses", "codex", "--json"]) == 0
     payload = json.loads(capsys.readouterr().out)

--- a/tests/test_operator_cmd.py
+++ b/tests/test_operator_cmd.py
@@ -1286,9 +1286,7 @@ def test_operator_quickstart_arms_dogfood_loop(tmp_path, capsys):
 
 def test_operator_quickstart_dry_run_plans_dogfood_without_writing(tmp_path, capsys):
     assert (
-        cli.main(
-            ["operator", "quickstart", "--target", str(tmp_path), "--harnesses", "codex", "--dry-run", "--json"]
-        )
+        cli.main(["operator", "quickstart", "--target", str(tmp_path), "--harnesses", "codex", "--dry-run", "--json"])
         == 0
     )
     payload = json.loads(capsys.readouterr().out)


### PR DESCRIPTION
Addresses the root cause in #112.

## Problem
An audit of 62 Brigade-wired fleet repos found the `work` and `outcome` loops dormant everywhere except repos set up by hand. Root cause: `operator quickstart` wires the `work` station but never writes a dogfood config, so `work status` reports `dogfood: not ready`, no runs are captured, and the outcome ledger stays empty. Every new repo is born dormant.

## Fix
`quickstart` now runs a `dogfood-init` step, mirroring the existing `mcp-init` on-ramp:
- writes only `.brigade/dogfood.toml` (local owned state), starts no runs
- dry-run aware (reports `planned` + the next command)
- skips a pre-existing dogfood config instead of clobbering it

After this, a fresh `quickstart` yields `work status -> dogfood: ready`, so the work loop can capture runs and feed `outcome` from day one.

## Verification
- New tests: `test_operator_quickstart_arms_dogfood_loop` (writes the config, step ok) and `test_operator_quickstart_dry_run_plans_dogfood_without_writing` (planned, no write).
- `pytest tests/test_operator_cmd.py tests/test_dogfood_cmd.py` = 78 passed; ruff clean. Verified via `brigade work verify run` (receipt in-repo).

## Scope note
This fixes the forward path (new setups). It intentionally does not enrich the base station manifest or wire notifications/pantry - those are separate follow-ups tracked in #112. Notifications specifically is blocked on a fleet webhook secret, not code.