### PR TITLE
docs: migrate README badges to shieldcn

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/github/actions/workflow/status/escoffier-labs/brigade/ci.yml?branch=main&style=for-the-badge&label=ci" alt="CI status">
-  <img src="https://img.shields.io/pypi/v/brigade-cli?style=for-the-badge&label=pypi" alt="PyPI version">
-  <img src="https://img.shields.io/badge/python-3.10%2B-blue?style=for-the-badge&logo=python&logoColor=white" alt="Python 3.10+">
-  <img src="https://img.shields.io/badge/license-MIT-green?style=for-the-badge" alt="MIT license">
+  <img src="https://shieldcn.dev/github/ci/escoffier-labs/brigade.svg?workflow=ci.yml&branch=main&label=ci&size=xs" alt="CI status">
+  <img src="https://shieldcn.dev/pypi/v/brigade-cli.svg?label=pypi&size=xs" alt="PyPI version">
+  <img src="https://shieldcn.dev/badge/python-3.10+-blue.svg?logo=python&logoColor=white&size=xs" alt="Python 3.10+">
+  <img src="https://shieldcn.dev/badge/license-MIT-green.svg?size=xs" alt="MIT license">
 </p>
 
 Your agents run loops. Brigade keeps the receipts.


### PR DESCRIPTION
## What and why

Swaps the four README status badges from shields.io to [shieldcn](https://shieldcn.dev) equivalents, which render as shadcn/ui Button components. CI, PyPI version, Python version, and license badges are preserved 1:1 in meaning, using the compact `size=xs` preset. The original coloring is kept where it was meaningful — blue Python, green MIT, and status-colored CI — and the `for-the-badge` split style is dropped for the cleaner single-piece look.

## Type of change

- [x] Docs

## Checklist

- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths
- [x] No new runtime dependencies
- [x] Conventional commit messages, no AI co-authorship trailers

<sub>Not applicable: no code/tests/CHANGELOG changes — this is a README-only badge swap.</sub>

---

Before / after (both point at the same underlying data):

| | Badge |
|---|---|
| CI | `https://shieldcn.dev/github/ci/escoffier-labs/brigade.svg?workflow=ci.yml&branch=main&label=ci&size=xs` |
| PyPI | `https://shieldcn.dev/pypi/v/brigade-cli.svg?label=pypi&size=xs` |
| Python | `https://shieldcn.dev/badge/python-3.10+-blue.svg?logo=python&logoColor=white&size=xs` |
| License | `https://shieldcn.dev/badge/license-MIT-green.svg?size=xs` |

Happy to revert if you'd prefer to stay on shields.io — no hard feelings.
