### PR TITLE
release: v0.17.0 - per-adapter model pinning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-07-01
+
+### Added
+- Per-adapter model pinning: `agents.<name>.model` now pins a model on `grok`, `opencode`, `pi`, `kimi`, `cursor`, and `antigravity`, in addition to `claude` and `codex`. A registry places each adapter's model flag where that CLI expects it, so `model = "grok-composer-2.5-fast"` on a `grok` agent runs Grok Composer under a Brigade run. `brigade roster doctor` validates every pin and fails before dispatch when an adapter can't pin a model or when an `ollama:` ref carries a stray `model =`. Ollama cloud models run through the existing `ollama:<model>` ref, e.g. `ollama:qwen3-coder-next:cloud`.
+
+### Fixed
+- The `grok`, `amp`, and `crush` writer adapters invoked a `--prompt` flag that none of those CLIs accept, so every run through them failed at argument parsing. They now use each CLI's real one-shot form: `grok -p`, `amp -x`, and `crush run`.
+- `brigade roster doctor` no longer crashes on endpoint-mode agents (`endpoint` + `model`, no `cli`); it reports the endpoint and skips the CLI model-pin check.
+
 ## [0.16.0] - 2026-06-30
 
 ### Added

--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -278,8 +278,12 @@ unless the run also passes `--sandbox`.
 
 `agents.<name>.model` pins the model a CLI agent runs, instead of relying on that CLI's
 global default. Brigade passes it through the adapter (`claude --model <id>`,
-`codex exec -m <id>`); pinning is supported for the `claude` and `codex` adapters, and
-`ollama:<model>` refs already name their model. The pinned model is recorded in each
+`codex exec -m <id>`, `grok -m <id>`, and so on); pinning is supported for the `claude`,
+`codex`, `grok`, `opencode`, `pi`, `kimi`, `cursor`, and `antigravity` adapters. Each
+adapter's model flag is placed where that CLI expects it. `ollama:<model>` refs already
+name their model, including cloud models such as `ollama:qwen3-coder-next:cloud`. An
+unsupported adapter with a `model =` pin fails `brigade roster doctor` before any run
+dispatches, so a bad pin never reaches a worker. The pinned model is recorded in each
 run's `roster.json` artifact.
 
 The classic split is a strong planner orchestrating a cheaper executor: the architect

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "brigade-cli"
-version = "0.16.0"
+version = "0.17.0"
 description = "One local source for the MCP servers, tools, and memory your AI coding agents share (Codex, Claude Code, OpenCode, Hermes, OpenClaw), merged into each tool's native config with a review gate and a receipt for every change."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/brigade/__init__.py
+++ b/src/brigade/__init__.py
@@ -1,3 +1,3 @@
 """Brigade: local operator-system CLI for agent workspaces."""
 
-__version__ = "0.16.0"
+__version__ = "0.17.0"

--- a/src/brigade/agents.py
+++ b/src/brigade/agents.py
@@ -99,17 +99,17 @@ def _openhands_argv(prompt: str, read_only: bool, sandbox: str | None) -> List[s
 
 def _grok_argv(prompt: str, read_only: bool, sandbox: str | None) -> List[str]:
     task = _read_only_prompt(prompt) if read_only or sandbox == "read-only" else prompt
-    return ["grok", "--prompt", task]
+    return ["grok", "-p", task]
 
 
 def _amp_argv(prompt: str, read_only: bool, sandbox: str | None) -> List[str]:
     task = _read_only_prompt(prompt) if read_only or sandbox == "read-only" else prompt
-    return ["amp", "--prompt", task]
+    return ["amp", "-x", task]
 
 
 def _crush_argv(prompt: str, read_only: bool, sandbox: str | None) -> List[str]:
     task = _read_only_prompt(prompt) if read_only or sandbox == "read-only" else prompt
-    return ["crush", "--prompt", task]
+    return ["crush", "run", task]
 
 
 _ADAPTERS: dict[str, Callable[[str, bool, str | None], List[str]]] = {
@@ -190,14 +190,49 @@ def command_for(cli_ref: str) -> str:
     return cli_ref
 
 
+def _pin_after_cmd(argv: List[str], flag: str, model: str) -> List[str]:
+    """Insert `flag model` right after the command (argv[0])."""
+    return [argv[0], flag, model, *argv[1:]]
+
+
+def _pin_after_subcmd(argv: List[str], flag: str, model: str) -> List[str]:
+    """Insert `flag model` after a subcommand (argv[1], e.g. `run`)."""
+    return [argv[0], argv[1], flag, model, *argv[2:]]
+
+
+def _pin_before_prompt(argv: List[str], flag: str, model: str) -> List[str]:
+    """Insert `flag model` before the final positional (the prompt)."""
+    return [*argv[:-1], flag, model, argv[-1]]
+
+
+# Adapters that accept a per-invocation model flag, with the flag and where it is
+# placed in that adapter's argv. Each entry is verified against the CLI's --help.
+# claude/codex outputs stay byte-identical to their pre-registry form.
+_MODEL_PIN: dict[str, tuple[str, Callable[[List[str], str, str], List[str]]]] = {
+    "claude": ("--model", _pin_after_cmd),  # claude --model X -p <prompt>
+    "codex": ("-m", _pin_before_prompt),  # codex exec [--sandbox M] -m X <prompt>
+    "grok": ("-m", _pin_after_cmd),  # grok -m X -p <prompt>
+    "opencode": ("-m", _pin_after_subcmd),  # opencode run -m X <prompt>   (X = provider/model)
+    "pi": ("--model", _pin_after_cmd),  # pi --model X [--tools ...] -p <prompt>
+    "kimi": ("-m", _pin_after_cmd),  # kimi -m X [--plan] --print -p <prompt> --final-message-only
+    "cursor": ("--model", _pin_after_cmd),  # cursor-agent --model X -p --output-format text <prompt>
+    "antigravity": ("--model", _pin_after_cmd),  # agy --model X [--sandbox] --print <prompt>
+}
+
+
+def supports_model_pinning(cli_ref: str) -> bool:
+    """True if cli_ref accepts a per-agent `model=` pin. Ollama refs name their
+    own model and return False here."""
+    return cli_ref in _MODEL_PIN
+
+
 def _with_model(cli_ref: str, argv: List[str], model: str) -> List[str]:
-    if cli_ref == "claude":
-        # claude --model <id> -p <prompt>
-        return [argv[0], "--model", model, *argv[1:]]
-    if cli_ref == "codex":
-        # codex exec [--sandbox <mode>] -m <id> <prompt>
-        return [*argv[:-1], "-m", model, argv[-1]]
-    raise ValueError(f"{cli_ref!r} does not support model pinning (supported: claude, codex)")
+    entry = _MODEL_PIN.get(cli_ref)
+    if entry is None:
+        supported = ", ".join(sorted(_MODEL_PIN))
+        raise ValueError(f"{cli_ref!r} does not support model pinning (supported: {supported})")
+    flag, placer = entry
+    return placer(argv, flag, model)
 
 
 def build_argv(

--- a/src/brigade/roster_cmd.py
+++ b/src/brigade/roster_cmd.py
@@ -35,7 +35,8 @@ max_workers = {max_workers}
 timeout_seconds = 600
 allow_models = ["codex", "ollama:*"]
 
-# Cross-model example: pin a model per agent with `model = ...` (claude and codex only).
+# Cross-model example: pin a model per agent with `model = ...`
+# (supported: claude, codex, grok, opencode, pi, kimi, cursor).
 # Fable 5 plans and synthesizes, GPT 5.5 executes, the handoff records the run.
 # Use a model id your CLI account supports (ChatGPT-account codex takes "gpt-5.5").
 #
@@ -50,6 +51,11 @@ allow_models = ["codex", "ollama:*"]
 # cli = "codex"
 # model = "gpt-5.5"
 # role = "Make precise code changes and report what changed."
+#
+# [agents.composer]
+# cli = "grok"
+# model = "grok-composer-2.5-fast"
+# role = "Draft fast first-pass changes for the architect to review."
 """
 
 
@@ -99,8 +105,18 @@ def doctor(target: Path, *, roster_path: Path | None = None) -> int:
         checks.append((doctor_mod.WARN, "roster: allow_models", "not set; explicit model allow-list recommended"))
 
     for name, agent in loaded.agents.items():
-        binary = agents.command_for(agent.cli)
         timeout = roster_mod.timeout_for(agent, loaded)
+        if agent.cli is None:
+            # Endpoint-mode agent: model is the HTTP model, not a CLI model pin.
+            checks.append(
+                (
+                    doctor_mod.OK,
+                    f"agent: {name}",
+                    f"endpoint {agent.endpoint} model={agent.model}; timeout={timeout:g}s",
+                )
+            )
+            continue
+        binary = agents.command_for(agent.cli)
         if agents.detect(agent.cli):
             checks.append((doctor_mod.OK, f"agent: {name}", f"{agent.cli} via {binary}; timeout={timeout:g}s"))
         else:
@@ -108,5 +124,20 @@ def doctor(target: Path, *, roster_path: Path | None = None) -> int:
             if agent.cli == "claude":
                 detail += "; Claude is optional, edit the roster if you are not using it"
             checks.append((doctor_mod.WARN, f"agent: {name}", detail))
+        if agent.model is not None:
+            if agent.cli.startswith("ollama:"):
+                checks.append(
+                    (doctor_mod.FAIL, f"agent: {name} model", "ollama names its model in the cli ref; drop model=")
+                )
+            elif agents.supports_model_pinning(agent.cli):
+                checks.append((doctor_mod.OK, f"agent: {name} model", f"{agent.model} via {agent.cli}"))
+            else:
+                checks.append(
+                    (
+                        doctor_mod.FAIL,
+                        f"agent: {name} model",
+                        f"{agent.cli} does not support model pinning; drop model= or switch cli",
+                    )
+                )
 
     return doctor_mod._report(checks)

--- a/src/brigade/templates/hermes/memory-handoff.harness.json
+++ b/src/brigade/templates/hermes/memory-handoff.harness.json
@@ -5,7 +5,7 @@
     "Describes the handoff inbox + routing targets that Hermes should treat",
     "as the canonical memory contract."
   ],
-  "_brigade_version": "0.16.0",
+  "_brigade_version": "0.17.0",
   "_brigade_status": "validated",
   "memory_handoff": {
     "inbox_dir": ".hermes/memory-handoffs",

--- a/src/brigade/templates/hermes/model-lanes.harness.json
+++ b/src/brigade/templates/hermes/model-lanes.harness.json
@@ -5,7 +5,7 @@
     "Suggested model lane names. Same shape as the OpenClaw alias map so",
     "knowledge cards and runbooks can talk about lanes without naming providers."
   ],
-  "_brigade_version": "0.16.0",
+  "_brigade_version": "0.17.0",
   "_brigade_status": "validated",
   "model_lanes": {
     "main": "<provider/main-model-id>",

--- a/src/brigade/templates/hermes/workspace.harness.json
+++ b/src/brigade/templates/hermes/workspace.harness.json
@@ -8,7 +8,7 @@
     "",
     "Replace <hermes-config-path> with your Hermes config location."
   ],
-  "_brigade_version": "0.16.0",
+  "_brigade_version": "0.17.0",
   "_brigade_status": "validated",
   "workspace": {
     "root": "<workspace-root>",

--- a/src/brigade/templates/memory/chat-memory-sweep.example.json
+++ b/src/brigade/templates/memory/chat-memory-sweep.example.json
@@ -1,5 +1,5 @@
 {
-  "_brigade_version": "0.16.0",
+  "_brigade_version": "0.17.0",
   "_description": "Example output contract for a nightly chat/session memory sweep. Keep raw chat transcripts in crawler archives; this file contains summaries and local source locators only.",
   "generated_at": "2026-05-26T22:09:00-04:00",
   "window": {

--- a/src/brigade/templates/memory/memory-care.example.json
+++ b/src/brigade/templates/memory/memory-care.example.json
@@ -1,5 +1,5 @@
 {
-  "_brigade_version": "0.16.0",
+  "_brigade_version": "0.17.0",
   "_description": "Example config for a local memory-care scanner. Brigade does not run this scanner for you; it validates the output with `brigade doctor`.",
   "cards_glob": "memory/cards/*.md",
   "decay_dir": ".brigade/memory-care/decay",

--- a/src/brigade/templates/policies/personal.json
+++ b/src/brigade/templates/policies/personal.json
@@ -4,7 +4,7 @@
     "It blocks secrets and attribution trailers, while warning on personal or infrastructure-like context.",
     "Use via: brigade handoff lint --content-guard --guard-policy personal"
   ],
-  "_brigade_version": "0.16.0",
+  "_brigade_version": "0.17.0",
   "categories": {
     "secret": "block",
     "private-network": "warn",

--- a/src/brigade/templates/policies/public-content.json
+++ b/src/brigade/templates/policies/public-content.json
@@ -4,7 +4,7 @@
     "social drafts, and docs that will be published, not just pushed.",
     "Use via: brigade scrub --policy public-content"
   ],
-  "_brigade_version": "0.16.0",
+  "_brigade_version": "0.17.0",
   "categories": {
     "secret": "block",
     "private-network": "block",

--- a/src/brigade/templates/policies/public-repo.json
+++ b/src/brigade/templates/policies/public-repo.json
@@ -4,7 +4,7 @@
     "Used by brigade pre-push hook and `brigade scrub`.",
     "Override by pointing CONTENT_GUARD_POLICY at your own copy of this file."
   ],
-  "_brigade_version": "0.16.0",
+  "_brigade_version": "0.17.0",
   "categories": {
     "secret": "block",
     "private-network": "block",

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -18,9 +18,9 @@ def test_build_argv_for_known_clis():
     assert agents.build_argv("kimi", "hi") == ["kimi", "--print", "-p", "hi", "--final-message-only"]
     assert agents.build_argv("adal", "hi") == ["adal", "-q", "hi"]
     assert agents.build_argv("openhands", "hi") == ["openhands", "--headless", "-t", "hi"]
-    assert agents.build_argv("grok", "hi") == ["grok", "--prompt", "hi"]
-    assert agents.build_argv("amp", "hi") == ["amp", "--prompt", "hi"]
-    assert agents.build_argv("crush", "hi") == ["crush", "--prompt", "hi"]
+    assert agents.build_argv("grok", "hi") == ["grok", "-p", "hi"]
+    assert agents.build_argv("amp", "hi") == ["amp", "-x", "hi"]
+    assert agents.build_argv("crush", "hi") == ["crush", "run", "hi"]
     assert agents.build_argv("ollama:llama3.3", "hi") == ["ollama", "run", "llama3.3", "hi"]
 
 
@@ -141,7 +141,7 @@ def test_build_argv_without_model_is_unchanged():
 
 def test_build_argv_model_on_unsupported_cli_raises():
     with pytest.raises(ValueError, match="model"):
-        agents.build_argv("opencode", "hi", model="anything")
+        agents.build_argv("goose", "hi", model="anything")
 
 
 def test_build_argv_model_on_ollama_ref_raises():

--- a/tests/test_agents_model_pin.py
+++ b/tests/test_agents_model_pin.py
@@ -1,0 +1,168 @@
+"""Per-adapter model pinning: exact argv assertions, no CLI execution.
+
+Every expected argv here is checked against the real CLI's --help flag; the
+adapters covered are the ones with a confirmed model flag on an installed CLI.
+"""
+
+import pytest
+
+from brigade import agents
+
+
+def test_pins_model_for_grok():
+    assert agents.build_argv("grok", "P", model="grok-composer-2.5-fast") == [
+        "grok",
+        "-m",
+        "grok-composer-2.5-fast",
+        "-p",
+        "P",
+    ]
+    read_only = agents.build_argv("grok", "P", read_only=True, model="grok-composer-2.5-fast")
+    assert read_only[:4] == ["grok", "-m", "grok-composer-2.5-fast", "-p"]
+    assert read_only[-1].startswith("Read-only planning run.")
+
+
+def test_pins_model_for_opencode():
+    assert agents.build_argv("opencode", "P", model="openrouter/x-ai/grok") == [
+        "opencode",
+        "run",
+        "-m",
+        "openrouter/x-ai/grok",
+        "P",
+    ]
+    # opencode has no read-only variant, so the model pin is the only change.
+    assert agents.build_argv("opencode", "P", read_only=True, model="openrouter/x-ai/grok") == [
+        "opencode",
+        "run",
+        "-m",
+        "openrouter/x-ai/grok",
+        "P",
+    ]
+
+
+def test_pins_model_for_pi():
+    assert agents.build_argv("pi", "P", model="openai/gpt-4o") == [
+        "pi",
+        "--model",
+        "openai/gpt-4o",
+        "-p",
+        "P",
+    ]
+    assert agents.build_argv("pi", "P", read_only=True, model="openai/gpt-4o") == [
+        "pi",
+        "--model",
+        "openai/gpt-4o",
+        "--tools",
+        "read,grep,find,ls",
+        "-p",
+        "P",
+    ]
+
+
+def test_pins_model_for_kimi():
+    assert agents.build_argv("kimi", "P", model="kimi-k2.5") == [
+        "kimi",
+        "-m",
+        "kimi-k2.5",
+        "--print",
+        "-p",
+        "P",
+        "--final-message-only",
+    ]
+    assert agents.build_argv("kimi", "P", read_only=True, model="kimi-k2.5") == [
+        "kimi",
+        "-m",
+        "kimi-k2.5",
+        "--plan",
+        "--print",
+        "-p",
+        "P",
+        "--final-message-only",
+    ]
+
+
+def test_pins_model_for_cursor():
+    assert agents.build_argv("cursor", "P", model="gpt-5") == [
+        "cursor-agent",
+        "--model",
+        "gpt-5",
+        "-p",
+        "--output-format",
+        "text",
+        "P",
+    ]
+    read_only = agents.build_argv("cursor", "P", read_only=True, model="gpt-5")
+    assert read_only[:3] == ["cursor-agent", "--model", "gpt-5"]
+    assert read_only[-1] == "P"
+
+
+def test_pins_model_for_antigravity():
+    assert agents.build_argv("antigravity", "P", model="gpt-5") == [
+        "agy",
+        "--model",
+        "gpt-5",
+        "--print",
+        "P",
+    ]
+    assert agents.build_argv("antigravity", "P", read_only=True, model="gpt-5") == [
+        "agy",
+        "--model",
+        "gpt-5",
+        "--sandbox",
+        "--print",
+        "P",
+    ]
+
+
+def test_ollama_cloud_ref_keeps_full_model_name():
+    # A cloud model id carries its own colon; only the `ollama:` prefix is stripped.
+    assert agents.build_argv("ollama:qwen3-coder-next:cloud", "P") == [
+        "ollama",
+        "run",
+        "qwen3-coder-next:cloud",
+        "P",
+    ]
+
+
+def test_claude_and_codex_argv_unchanged_by_registry():
+    assert agents.build_argv("claude", "P", model="claude-fable-5") == [
+        "claude",
+        "--model",
+        "claude-fable-5",
+        "-p",
+        "P",
+    ]
+    assert agents.build_argv("codex", "P", model="gpt-5.5-codex") == [
+        "codex",
+        "exec",
+        "-m",
+        "gpt-5.5-codex",
+        "P",
+    ]
+    assert agents.build_argv("codex", "P", read_only=True, model="gpt-5.5-codex") == [
+        "codex",
+        "exec",
+        "--sandbox",
+        "read-only",
+        "-m",
+        "gpt-5.5-codex",
+        "P",
+    ]
+
+
+def test_unsupported_adapter_still_raises():
+    for cli in ("goose", "amp", "crush", "aider", "qwen", "copilot"):
+        with pytest.raises(ValueError, match="does not support model pinning"):
+            agents.build_argv(cli, "P", model="whatever")
+
+
+def test_ollama_ref_rejects_separate_model():
+    with pytest.raises(ValueError, match="model"):
+        agents.build_argv("ollama:llama3.3", "P", model="mistral")
+
+
+def test_supports_model_pinning_predicate():
+    for cli in ("claude", "codex", "grok", "opencode", "pi", "kimi", "cursor", "antigravity"):
+        assert agents.supports_model_pinning(cli)
+    for cli in ("goose", "amp", "crush", "aider", "qwen", "copilot", "ollama:llama3.3"):
+        assert not agents.supports_model_pinning(cli)

--- a/tests/test_roster_cmd.py
+++ b/tests/test_roster_cmd.py
@@ -96,3 +96,61 @@ def test_roster_cli_init_and_doctor(monkeypatch, tmp_target, capsys):
     assert cli.main(["roster", "doctor", "--target", str(tmp_target)]) == 0
     out = capsys.readouterr().out
     assert "ollama:mistral" in out
+
+
+def _write_roster(tmp_target, body: str) -> None:
+    path = tmp_target / ".brigade" / "roster.toml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+
+
+def test_roster_doctor_ok_for_supported_model_pin(monkeypatch, tmp_target, capsys):
+    _write_roster(
+        tmp_target,
+        'orchestrator = "chef"\n[agents.chef]\ncli = "grok"\nmodel = "grok-composer-2.5-fast"\nrole = "plan"\n',
+    )
+    monkeypatch.setattr(agents.proc, "which", lambda cmd: "/x/" + cmd)
+    rc = roster_cmd.doctor(tmp_target)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "grok-composer-2.5-fast via grok" in out
+
+
+def test_roster_doctor_fails_pin_on_unsupported_cli(monkeypatch, tmp_target, capsys):
+    _write_roster(
+        tmp_target,
+        'orchestrator = "chef"\n[agents.chef]\ncli = "goose"\nmodel = "whatever"\nrole = "plan"\n',
+    )
+    monkeypatch.setattr(agents.proc, "which", lambda cmd: "/x/" + cmd)
+    rc = roster_cmd.doctor(tmp_target)
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "[fail]" in out
+    assert "does not support model pinning" in out
+
+
+def test_roster_doctor_fails_pin_on_ollama_ref(monkeypatch, tmp_target, capsys):
+    _write_roster(
+        tmp_target,
+        'orchestrator = "chef"\n[agents.chef]\ncli = "ollama:llama3.3"\nmodel = "mistral"\nrole = "plan"\n',
+    )
+    monkeypatch.setattr(agents.proc, "which", lambda cmd: "/x/" + cmd)
+    rc = roster_cmd.doctor(tmp_target)
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "ollama names its model in the cli ref" in out
+
+
+def test_roster_doctor_endpoint_agent_skips_pin_check(tmp_target, capsys):
+    _write_roster(
+        tmp_target,
+        'orchestrator = "chef"\n'
+        "[agents.chef]\n"
+        'endpoint = "https://example.test/v1/chat"\n'
+        'model = "some-hosted-model"\n'
+        'role = "plan"\n',
+    )
+    rc = roster_cmd.doctor(tmp_target)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "endpoint https://example.test/v1/chat" in out


### PR DESCRIPTION
## v0.17.0

### Added
- **Per-adapter model pinning.** `agents.<name>.model` now pins a model on `grok`, `opencode`, `pi`, `kimi`, `cursor`, and `antigravity`, in addition to `claude` and `codex`. A registry places each adapter's model flag where that CLI expects it, so `model = "grok-composer-2.5-fast"` on a `grok` agent runs Grok Composer under a Brigade run. `brigade roster doctor` validates every pin and fails before dispatch when an adapter can't pin a model or an `ollama:` ref carries a stray `model =`. Ollama cloud models run through the existing `ollama:<model>` ref, e.g. `ollama:qwen3-coder-next:cloud`.

### Fixed
- The `grok`, `amp`, and `crush` writer adapters invoked a `--prompt` flag that none of those CLIs accept, so every run through them failed at argument parsing. They now use each CLI's real one-shot form: `grok -p`, `amp -x`, and `crush run`.
- `brigade roster doctor` no longer crashes on endpoint-mode agents (`endpoint` + `model`, no `cli`).

Every pinnable adapter's argv was verified against the real CLI's `--help`; grok-composer was proven end to end with a live `brigade run`. Full suite: 1329 passed.