### PR TITLE
docs(roster): list antigravity in the model-pin template comment

### DIFF
--- a/src/brigade/roster_cmd.py
+++ b/src/brigade/roster_cmd.py
@@ -36,7 +36,7 @@ timeout_seconds = 600
 allow_models = ["codex", "ollama:*"]
 
 # Cross-model example: pin a model per agent with `model = ...`
-# (supported: claude, codex, grok, opencode, pi, kimi, cursor).
+# (supported: claude, codex, grok, opencode, pi, kimi, cursor, antigravity).
 # Fable 5 plans and synthesizes, GPT 5.5 executes, the handoff records the run.
 # Use a model id your CLI account supports (ChatGPT-account codex takes "gpt-5.5").
 #


### PR DESCRIPTION
The v0.17.0 registry supports model pinning on `antigravity` (`agy --model`), but the roster template's cross-model example comment listed only 7 of the 8 pinnable adapters. This adds `antigravity` so the comment matches the code and CHANGELOG. Comment-only change.