### PR TITLE
ci: skip CI on docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,17 @@ name: ci
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - 'LICENSE'
+      - '.gitignore'
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - 'LICENSE'
+      - '.gitignore'
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds `paths-ignore` (docs/**, root *.md, LICENSE, .gitignore) to the push and pull_request triggers so documentation and asset-only commits don't spin up the full CI matrix (lint + 3-version tests + content-guard + repo-metadata + 8-combo install-from-source + quickstart-smoke). Saves Actions minutes and stops the CI badge flipping to pending on docs commits. Code/test/workflow/template changes still run CI normally.