### PR TITLE
feat(release): brigade release version-sync

### DIFF
--- a/src/brigade/cli/release.py
+++ b/src/brigade/cli/release.py
@@ -44,6 +44,16 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_release_schema = release_sub.add_parser("schema", help="Show local release evidence schema manifest.")
     p_release_schema.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
     p_release_schema.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_release_version_sync = release_sub.add_parser(
+        "version-sync", help="Check or fix in-tree version stamps against the source of truth."
+    )
+    p_release_version_sync.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    vs_mode = p_release_version_sync.add_mutually_exclusive_group()
+    vs_mode.add_argument("--check", action="store_true", help="Verify stamps match the source (default).")
+    vs_mode.add_argument("--write", action="store_true", help="Rewrite stamps to the source version.")
+    p_release_version_sync.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
     p_release_ci = release_sub.add_parser("ci", help="Inspect local CI platform deprecation evidence.")
     release_ci_sub = p_release_ci.add_subparsers(dest="release_ci_command", metavar="<release-ci-command>")
     release_ci_sub.required = True
@@ -216,6 +226,10 @@ def dispatch(args) -> int:
         return release_cmd.show(target=args.target, run_id=args.run_id, json_output=args.json)
     if args.release_command == "schema":
         return release_cmd.schema(target=args.target, json_output=args.json)
+    if args.release_command == "version-sync":
+        from .. import release_version_sync
+
+        return release_version_sync.version_sync(target=args.target, write=args.write, json_output=args.json)
     if args.release_command == "ci":
         if args.release_ci_command == "doctor":
             return release_cmd.ci_doctor(target=args.target, summary_path=args.summary_path, json_output=args.json)

--- a/src/brigade/release_version_sync.py
+++ b/src/brigade/release_version_sync.py
@@ -36,6 +36,13 @@ class Manifest:
     locations: tuple[Location, ...]
 
 
+@dataclass(frozen=True)
+class LocationResult:
+    path: str
+    status: str  # "ok" | "mismatch" | "missing"
+    found: tuple[str, ...]
+
+
 def _as_str(value: object, field: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise ValueError(f"{field} must be a non-empty string")
@@ -101,3 +108,72 @@ def load_manifest(target: Path) -> Manifest:
         raise ValueError("at least one [[location]] is required")
     locations = tuple(_parse_location(item, i) for i, item in enumerate(raw))
     return Manifest(source=Source(file, key, regex), locations=locations)
+
+
+def resolve_source(manifest: Manifest, target: Path) -> str:
+    src_path = target / manifest.source.file
+    if not src_path.is_file():
+        raise ValueError(f"source file not found: {manifest.source.file}")
+    text = src_path.read_text()
+    if manifest.source.regex is not None:
+        match = re.search(manifest.source.regex, text)
+        if not match:
+            raise ValueError(f"source regex found no version in {manifest.source.file}")
+        return match.group(1)
+    data = toml_compat.loads(text) if src_path.suffix == ".toml" else json.loads(text)
+    value: object = data
+    for part in manifest.source.key.split("."):
+        if not isinstance(value, dict) or part not in value:
+            raise ValueError(f"source key `{manifest.source.key}` not found in {manifest.source.file}")
+        value = value[part]
+    if not isinstance(value, str):
+        raise ValueError(f"source key `{manifest.source.key}` is not a string")
+    return value
+
+
+def _resolve_files(location: Location, target: Path) -> list[Path]:
+    if location.path is not None:
+        return [target / location.path]
+    return sorted(target.glob(location.glob))
+
+
+def scan(manifest: Manifest, target: Path, expected: str) -> list[LocationResult]:
+    results: list[LocationResult] = []
+    for location in manifest.locations:
+        for file in _resolve_files(location, target):
+            rel = file.relative_to(target).as_posix()
+            if not file.is_file():
+                if location.path is not None:
+                    results.append(LocationResult(rel, "missing", ()))
+                continue
+            text = file.read_text()
+            if location.guard is not None and location.guard not in text:
+                continue
+            found = tuple(re.findall(location.pattern, text))
+            if not found:
+                if location.required:
+                    results.append(LocationResult(rel, "missing", ()))
+                continue
+            bad = any(v != expected for v in found)
+            results.append(LocationResult(rel, "mismatch" if bad else "ok", found))
+    return results
+
+
+def _rewrite(text: str, pattern: str, expected: str) -> str:
+    return re.sub(pattern, lambda m: m.group(0).replace(m.group(1), expected), text)
+
+
+def apply(manifest: Manifest, target: Path, expected: str) -> list[str]:
+    changed: list[str] = []
+    for location in manifest.locations:
+        for file in _resolve_files(location, target):
+            if not file.is_file():
+                continue
+            text = file.read_text()
+            if location.guard is not None and location.guard not in text:
+                continue
+            new_text = _rewrite(text, location.pattern, expected)
+            if new_text != text:
+                file.write_text(new_text)
+                changed.append(file.relative_to(target).as_posix())
+    return changed

--- a/src/brigade/release_version_sync.py
+++ b/src/brigade/release_version_sync.py
@@ -165,9 +165,12 @@ def _rewrite(text: str, pattern: str, expected: str) -> str:
 
 def apply(manifest: Manifest, target: Path, expected: str) -> list[str]:
     changed: list[str] = []
+    source_path = (target / manifest.source.file).resolve()
     for location in manifest.locations:
         for file in _resolve_files(location, target):
             if not file.is_file():
+                continue
+            if file.resolve() == source_path:
                 continue
             text = file.read_text()
             if location.guard is not None and location.guard not in text:

--- a/src/brigade/release_version_sync.py
+++ b/src/brigade/release_version_sync.py
@@ -1,0 +1,103 @@
+"""brigade release version-sync: reconcile in-tree version stamps against one source."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from . import toml_compat
+
+MANIFEST_REL = Path(".brigade") / "version-sync.toml"
+
+
+@dataclass(frozen=True)
+class Source:
+    file: str
+    key: str | None
+    regex: str | None
+
+
+@dataclass(frozen=True)
+class Location:
+    path: str | None
+    glob: str | None
+    pattern: str
+    guard: str | None
+    required: bool
+
+
+@dataclass(frozen=True)
+class Manifest:
+    source: Source
+    locations: tuple[Location, ...]
+
+
+def _as_str(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field} must be a non-empty string")
+    return value.strip()
+
+
+def _require_one_group(pattern: str, field: str) -> None:
+    try:
+        compiled = re.compile(pattern)
+    except re.error as exc:
+        raise ValueError(f"{field} is not a valid regex: {exc}") from exc
+    if compiled.groups != 1:
+        raise ValueError(f"{field} must have exactly one capture group, found {compiled.groups}")
+
+
+def _parse_location(item: object, index: int) -> Location:
+    where = f"location[{index}]"
+    if not isinstance(item, dict):
+        raise ValueError(f"{where} must be a table")
+    path = item.get("path")
+    glob = item.get("glob")
+    if (path is None) == (glob is None):
+        raise ValueError(f"{where} must set exactly one of `path` or `glob`")
+    pattern = _as_str(item.get("pattern"), f"{where}.pattern")
+    _require_one_group(pattern, f"{where}.pattern")
+    guard = item.get("guard")
+    if guard is not None:
+        guard = _as_str(guard, f"{where}.guard")
+    if path is not None and guard is not None:
+        raise ValueError(f"{where}.guard is only valid with `glob`")
+    required = item.get("required", True)
+    if not isinstance(required, bool):
+        raise ValueError(f"{where}.required must be a boolean")
+    return Location(
+        path=_as_str(path, f"{where}.path") if path is not None else None,
+        glob=_as_str(glob, f"{where}.glob") if glob is not None else None,
+        pattern=pattern,
+        guard=guard,
+        required=required,
+    )
+
+
+def load_manifest(target: Path) -> Manifest:
+    manifest_path = target / MANIFEST_REL
+    if not manifest_path.is_file():
+        raise FileNotFoundError(manifest_path)
+    data = toml_compat.loads(manifest_path.read_text())
+    src = data.get("source")
+    if not isinstance(src, dict):
+        raise ValueError("[source] table is required")
+    file = _as_str(src.get("file"), "source.file")
+    key = src.get("key")
+    regex = src.get("regex")
+    if (key is None) == (regex is None):
+        raise ValueError("source must set exactly one of `key` or `regex`")
+    if key is not None:
+        key = _as_str(key, "source.key")
+    if regex is not None:
+        regex = _as_str(regex, "source.regex")
+        _require_one_group(regex, "source.regex")
+    raw = data.get("location")
+    if not isinstance(raw, list) or not raw:
+        raise ValueError("at least one [[location]] is required")
+    locations = tuple(_parse_location(item, i) for i, item in enumerate(raw))
+    return Manifest(source=Source(file, key, regex), locations=locations)

--- a/src/brigade/release_version_sync.py
+++ b/src/brigade/release_version_sync.py
@@ -177,3 +177,51 @@ def apply(manifest: Manifest, target: Path, expected: str) -> list[str]:
                 file.write_text(new_text)
                 changed.append(file.relative_to(target).as_posix())
     return changed
+
+
+def version_sync(*, target: Path, write: bool = False, json_output: bool = False) -> int:
+    try:
+        manifest = load_manifest(target)
+        expected = resolve_source(manifest, target)
+    except FileNotFoundError as exc:
+        print(f"error: no version-sync manifest: {exc}", file=sys.stderr)
+        return 2
+    except ValueError as exc:
+        print(f"error: invalid version-sync manifest: {exc}", file=sys.stderr)
+        return 2
+
+    if write:
+        changed = apply(manifest, target, expected)
+        if json_output:
+            print(json.dumps({"version": expected, "changed": changed}, indent=2, sort_keys=True))
+        elif changed:
+            print(f"version={expected} rewrote {len(changed)} file(s):")
+            for rel in changed:
+                print(f"  {rel}")
+        else:
+            print(f"version={expected} already in sync")
+        return 0
+
+    results = scan(manifest, target, expected)
+    problems = [r for r in results if r.status != "ok"]
+    if json_output:
+        payload = {
+            "version": expected,
+            "source": manifest.source.file,
+            "checked": len(results),
+            "results": [{"path": r.path, "status": r.status, "found": list(r.found)} for r in results],
+            "ok": not problems,
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 1 if problems else 0
+
+    print(f"version={expected} source={manifest.source.file} checked={len(results)} locations")
+    github = bool(os.environ.get("GITHUB_ACTIONS"))
+    for result in problems:
+        if result.status == "mismatch":
+            declared = ", ".join(sorted(set(result.found)))
+            msg = f"{result.path} declares {declared}, {manifest.source.file} says {expected}"
+        else:
+            msg = f"{result.path}: version token not found (pattern drifted or asset not re-rendered)"
+        print(f"{'::error::' if github else 'FAIL '}{msg}", file=sys.stderr)
+    return 1 if problems else 0

--- a/tests/test_release_version_sync.py
+++ b/tests/test_release_version_sync.py
@@ -172,3 +172,43 @@ def test_recording_svg_roundtrip(tmp_path):
     assert any(r.path == "docs/quickstart.svg" and r.status == "mismatch" for r in vs.scan(m, tmp_path, "0.17.0"))
     assert "docs/quickstart.svg" in vs.apply(m, tmp_path, "0.17.0")
     assert all(r.status == "ok" for r in vs.scan(m, tmp_path, "0.17.0"))
+
+
+def test_version_sync_check_ok(tmp_path, capsys):
+    _repo(tmp_path)
+    assert vs.version_sync(target=tmp_path, write=False) == 0
+    assert "checked=" in capsys.readouterr().out
+
+
+def test_version_sync_check_drift(tmp_path, capsys):
+    _repo(tmp_path, cast_version="0.13.0")
+    assert vs.version_sync(target=tmp_path, write=False) == 1
+    err = capsys.readouterr().err
+    assert "quickstart.cast declares 0.13.0" in err
+
+
+def test_version_sync_github_annotation(tmp_path, capsys, monkeypatch):
+    _repo(tmp_path, cast_version="0.13.0")
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    vs.version_sync(target=tmp_path, write=False)
+    assert "::error::" in capsys.readouterr().err
+
+
+def test_version_sync_write(tmp_path, capsys):
+    _repo(tmp_path, cast_version="0.13.0")
+    assert vs.version_sync(target=tmp_path, write=True) == 0
+    assert vs.version_sync(target=tmp_path, write=False) == 0
+
+
+def test_version_sync_missing_manifest(tmp_path, capsys):
+    assert vs.version_sync(target=tmp_path, write=False) == 2
+    assert "no version-sync manifest" in capsys.readouterr().err
+
+
+def test_version_sync_json(tmp_path, capsys):
+    _repo(tmp_path, cast_version="0.13.0")
+    assert vs.version_sync(target=tmp_path, write=False, json_output=True) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["version"] == "0.17.0"
+    assert payload["ok"] is False
+    assert any(r["status"] == "mismatch" for r in payload["results"])

--- a/tests/test_release_version_sync.py
+++ b/tests/test_release_version_sync.py
@@ -165,6 +165,17 @@ def test_apply_fixes_only_drifted(tmp_path):
     assert all(r.status == "ok" for r in vs.scan(m, tmp_path, "0.17.0"))
 
 
+def test_apply_never_rewrites_source_file(tmp_path):
+    (tmp_path / "VERSION").write_text("v = 0.13.0\n")
+    _manifest(
+        tmp_path,
+        "[source]\nfile='VERSION'\nregex='v = (\\S+)'\n[[location]]\npath='VERSION'\npattern='v = (\\S+)'\n",
+    )
+    m = vs.load_manifest(tmp_path)
+    assert vs.apply(m, tmp_path, "0.17.0") == []
+    assert (tmp_path / "VERSION").read_text() == "v = 0.13.0\n"
+
+
 def test_recording_svg_roundtrip(tmp_path):
     # The .svg glyph-adjacent pattern must round-trip through scan + apply.
     _repo(tmp_path, svg_version="0.9.9")

--- a/tests/test_release_version_sync.py
+++ b/tests/test_release_version_sync.py
@@ -1,0 +1,71 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from brigade import cli, release_version_sync as vs
+
+
+def _manifest(target: Path, body: str) -> None:
+    (target / ".brigade").mkdir(parents=True, exist_ok=True)
+    (target / ".brigade" / "version-sync.toml").write_text(body)
+
+
+BASIC_MANIFEST = """
+[source]
+file = "pyproject.toml"
+key = "project.version"
+
+[[location]]
+path = "src/pkg/__init__.py"
+pattern = '__version__ = "([^"]+)"'
+"""
+
+
+def test_load_manifest_ok(tmp_path):
+    _manifest(tmp_path, BASIC_MANIFEST)
+    manifest = vs.load_manifest(tmp_path)
+    assert manifest.source.file == "pyproject.toml"
+    assert manifest.source.key == "project.version"
+    assert manifest.source.regex is None
+    assert len(manifest.locations) == 1
+    assert manifest.locations[0].path == "src/pkg/__init__.py"
+    assert manifest.locations[0].required is True
+
+
+def test_load_manifest_missing_file(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        vs.load_manifest(tmp_path)
+
+
+@pytest.mark.parametrize(
+    "body, needle",
+    [
+        (
+            "[source]\nfile='p'\nkey='a'\nregex='(x)'\n[[location]]\npath='f'\npattern='(x)'\n",
+            "exactly one of `key` or `regex`",
+        ),
+        ("[source]\nfile='p'\nkey='a'\n", "at least one [[location]]"),
+        (
+            "[source]\nfile='p'\nkey='a'\n[[location]]\npath='f'\nglob='g'\npattern='(x)'\n",
+            "exactly one of `path` or `glob`",
+        ),
+        (
+            "[source]\nfile='p'\nkey='a'\n[[location]]\npath='f'\npattern='(x)(y)'\n",
+            "exactly one capture group",
+        ),
+        (
+            "[source]\nfile='p'\nkey='a'\n[[location]]\npath='f'\npattern='(x'\n",
+            "not a valid regex",
+        ),
+        (
+            "[source]\nfile='p'\nkey='a'\n[[location]]\npath='f'\npattern='(x)'\nguard='z'\n",
+            "guard is only valid with `glob`",
+        ),
+    ],
+)
+def test_load_manifest_invalid(tmp_path, body, needle):
+    _manifest(tmp_path, body)
+    with pytest.raises(ValueError) as exc:
+        vs.load_manifest(tmp_path)
+    assert needle in str(exc.value)

--- a/tests/test_release_version_sync.py
+++ b/tests/test_release_version_sync.py
@@ -69,3 +69,106 @@ def test_load_manifest_invalid(tmp_path, body, needle):
     with pytest.raises(ValueError) as exc:
         vs.load_manifest(tmp_path)
     assert needle in str(exc.value)
+
+
+FULL_MANIFEST = """
+[source]
+file = "pyproject.toml"
+key = "project.version"
+
+[[location]]
+path = "src/pkg/__init__.py"
+pattern = '__version__ = "([^"]+)"'
+
+[[location]]
+glob = "src/pkg/templates/**/*.json"
+guard = '"_v"'
+pattern = '"_v"\\s*:\\s*"([^"]+)"'
+
+[[location]]
+path = "docs/quickstart.cast"
+pattern = 'pkg (\\d+\\.\\d+\\.\\d+)'
+
+[[location]]
+path = "docs/quickstart.svg"
+pattern = '>pkg</text><text[^>]*>(\\d+\\.\\d+\\.\\d+)</text>'
+"""
+
+
+def _repo(tmp_path, version="0.17.0", cast_version="0.17.0", svg_version="0.17.0"):
+    (tmp_path / "pyproject.toml").write_text(f'[project]\nname = "pkg"\nversion = "{version}"\n')
+    (tmp_path / "src" / "pkg").mkdir(parents=True)
+    (tmp_path / "src" / "pkg" / "__init__.py").write_text(f'__version__ = "{version}"\n')
+    tpl = tmp_path / "src" / "pkg" / "templates" / "a"
+    tpl.mkdir(parents=True)
+    (tpl / "with.json").write_text(f'{{"_v": "{version}"}}\n')
+    (tpl / "without.json").write_text('{"other": "x"}\n')
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "quickstart.cast").write_text(f'[2.0, "o", "pkg {cast_version}\\r\\n"]\n')
+    (tmp_path / "docs" / "quickstart.svg").write_text(f'<text>pkg</text><text class="g">{svg_version}</text>')
+    _manifest(tmp_path, FULL_MANIFEST)
+    return tmp_path
+
+
+def test_resolve_source_key(tmp_path):
+    _repo(tmp_path)
+    m = vs.load_manifest(tmp_path)
+    assert vs.resolve_source(m, tmp_path) == "0.17.0"
+
+
+def test_resolve_source_regex(tmp_path):
+    (tmp_path / "VERSION").write_text("v = 1.2.3\n")
+    _manifest(
+        tmp_path,
+        "[source]\nfile='VERSION'\nregex='v = (\\S+)'\n[[location]]\npath='VERSION'\npattern='v = (\\S+)'\n",
+    )
+    m = vs.load_manifest(tmp_path)
+    assert vs.resolve_source(m, tmp_path) == "1.2.3"
+
+
+def test_scan_all_ok(tmp_path):
+    _repo(tmp_path)
+    m = vs.load_manifest(tmp_path)
+    results = vs.scan(m, tmp_path, "0.17.0")
+    assert all(r.status == "ok" for r in results)
+    # without.json (no guard) is skipped, not reported
+    assert not any("without.json" in r.path for r in results)
+
+
+def test_scan_detects_drift(tmp_path):
+    _repo(tmp_path, cast_version="0.13.0")
+    m = vs.load_manifest(tmp_path)
+    results = vs.scan(m, tmp_path, "0.17.0")
+    bad = [r for r in results if r.status == "mismatch"]
+    assert [r.path for r in bad] == ["docs/quickstart.cast"]
+    assert bad[0].found == ("0.13.0",)
+
+
+def test_scan_missing_required_token(tmp_path):
+    _repo(tmp_path)
+    (tmp_path / "docs" / "quickstart.cast").write_text('[2.0, "o", "no version here\\r\\n"]\n')
+    m = vs.load_manifest(tmp_path)
+    results = vs.scan(m, tmp_path, "0.17.0")
+    assert any(r.path == "docs/quickstart.cast" and r.status == "missing" for r in results)
+
+
+def test_apply_fixes_only_drifted(tmp_path):
+    _repo(tmp_path, cast_version="0.13.0")
+    init_before = (tmp_path / "src" / "pkg" / "__init__.py").read_text()
+    m = vs.load_manifest(tmp_path)
+    changed = vs.apply(m, tmp_path, "0.17.0")
+    assert changed == ["docs/quickstart.cast"]
+    # untouched file is byte-identical
+    assert (tmp_path / "src" / "pkg" / "__init__.py").read_text() == init_before
+    # drifted file now matches and surrounding bytes preserved
+    assert (tmp_path / "docs" / "quickstart.cast").read_text() == '[2.0, "o", "pkg 0.17.0\\r\\n"]\n'
+    assert all(r.status == "ok" for r in vs.scan(m, tmp_path, "0.17.0"))
+
+
+def test_recording_svg_roundtrip(tmp_path):
+    # The .svg glyph-adjacent pattern must round-trip through scan + apply.
+    _repo(tmp_path, svg_version="0.9.9")
+    m = vs.load_manifest(tmp_path)
+    assert any(r.path == "docs/quickstart.svg" and r.status == "mismatch" for r in vs.scan(m, tmp_path, "0.17.0"))
+    assert "docs/quickstart.svg" in vs.apply(m, tmp_path, "0.17.0")
+    assert all(r.status == "ok" for r in vs.scan(m, tmp_path, "0.17.0"))

--- a/tests/test_release_version_sync.py
+++ b/tests/test_release_version_sync.py
@@ -212,3 +212,21 @@ def test_version_sync_json(tmp_path, capsys):
     assert payload["version"] == "0.17.0"
     assert payload["ok"] is False
     assert any(r["status"] == "mismatch" for r in payload["results"])
+
+
+def test_cli_check(tmp_path):
+    _repo(tmp_path)
+    assert cli.main(["release", "version-sync", "--target", str(tmp_path)]) == 0
+
+
+def test_cli_write_then_check(tmp_path):
+    _repo(tmp_path, cast_version="0.13.0")
+    assert cli.main(["release", "version-sync", "--target", str(tmp_path), "--write"]) == 0
+    assert cli.main(["release", "version-sync", "--target", str(tmp_path)]) == 0
+
+
+def test_cli_check_write_mutually_exclusive(tmp_path):
+    _repo(tmp_path)
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["release", "version-sync", "--target", str(tmp_path), "--check", "--write"])
+    assert exc.value.code == 2


### PR DESCRIPTION
## What

Adds `brigade release version-sync`, a first-class command that reconciles every in-tree location a repo stamps its version into against one declared source of truth, driven by a committed `.brigade/version-sync.toml`.

- `--check` (default): hard gate. Exit 0 if every stamp matches, 1 on drift or a missing required token, 2 on config error (missing/invalid manifest, unresolvable source). Emits `::error::` annotations under `GITHUB_ACTIONS`.
- `--write`: rewrites every drifted stamp to the source version (only the captured token, formatting preserved) so a version bump is one command. Never touches the source file.
- `--json`: machine-readable result.

### Why

The version stamps in several files, including rendered demo assets (a `brigade X.Y.Z` frame baked into `quickstart.cast`/`.svg`), and a bump silently strands any location the check doesn't cover. This generalizes the repo-specific gate into a manifest-driven command any fleet repo adopts by declaring its locations, rather than copying a script.

### Manifest shape

```toml
[source]
file = "pyproject.toml"
key = "project.version"        # dotted key path, or: regex = '...'  (one capture group)

[[location]]
path = "src/brigade/__init__.py"
pattern = '__version__ = "([^"]+)"'

[[location]]
glob = "src/brigade/templates/**/*.json"
guard = '"_brigade_version"'   # only globbed files containing this are checked
pattern = '"_brigade_version"\\s*:\\s*"([^"]+)"'
```

Each location is a `(path|glob, pattern-with-one-capture-group)` pair. Stdlib + `toml_compat` only, no new deps.

### Scope

Command + manifest schema only. Migrating Brigade's own `scripts/version_sync.py` onto this command, and auto-wiring it via `operator quickstart`, are decomposed into separate follow-ups. This is the in-tree/hard-fail sibling of the planned remote/advisory `release drift`.

## Verification

- New module `src/brigade/release_version_sync.py` (230 lines) + `tests/test_release_version_sync.py` (25 tests), wired into the `release` subparser.
- `ruff format --check` + `ruff check` clean; full suite `1353 passed` (the one failure, `test_tools_runtime_doctor_safety_warnings`, is pre-existing and environmental, unrelated to this change).
- Driven end-to-end: check catches a drifted `.cast` (exit 1), `--write` fixes it, re-check clean (exit 0), `--json` shape verified.