### PR TITLE
docs(release): regenerate command inventory for version-sync

### DIFF
--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -38,7 +38,7 @@ brigade roadmap commands --write
 - `brigade profiles`: 2 command path(s)
 - `brigade projects`: 10 command path(s)
 - `brigade reconfigure`: 1 command path(s)
-- `brigade release`: 22 command path(s)
+- `brigade release`: 23 command path(s)
 - `brigade repos`: 70 command path(s)
 - `brigade research`: 11 command path(s)
 - `brigade roadmap`: 4 command path(s)
@@ -260,6 +260,7 @@ brigade roadmap commands --write
 - `brigade release smoke plan`
 - `brigade release smoke record`
 - `brigade release smoke show`
+- `brigade release version-sync`
 - `brigade repos actions archive`
 - `brigade repos actions build`
 - `brigade repos actions context`


### PR DESCRIPTION
The `repo-metadata` CI job (`brigade roadmap commands --check`) went red on main after #122 added `brigade release version-sync` without regenerating `docs/command-inventory.md`. Regenerated via `brigade roadmap commands --write`; adds the one missing entry.