### PR TITLE
Audit followups: phases behind extras, renderer consolidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `brigade work phases` (the phase-execution ledger) moved behind the extras wall with the other operator-suite surface; it stubs out with enable guidance when extras are disabled.
+- The shared `render.emit` renderer now backs the mechanical output sites in `tools_cmd`, `daily_cmd`, `center_cmd`, and `phases_cmd` (110 sites converted, byte-identical output); sites with interleaved logic or stderr remain on direct prints.
+
 ### Breaking
 - The CLI surface is now split into core and extras. 18 operator-suite command groups (`release`, `center`, `repos`, `research`, `roadmap`, `friction`, `chat`, `context`, `projects`, `learn`, `runbook`, `dogfood`, `pantry`, `notifications`, `budgets`, `untrusted`, `openclaw-fragments`, `hermes-fragments`) register only when extras are enabled. Enable once with `brigade extras on`, per invocation with `BRIGADE_EXTRAS=1`, and check with `brigade extras status`. A disabled extras command exits 2 with that guidance instead of a parse error. The 24 core groups (init, mcp, tools, skills, handoff, ingest, memory, work, outcome, operator, run, roster, runs, daily, security, scrub, doctor, status, add, stations, profiles, reconfigure, completions, extras) are unchanged.
 - Repo-depth installs default to a minimal footprint: `AGENTS.md` and `SAFETY_RULES.md` plus gitignored `.brigade/` state and the selected harness inboxes and skills. The full kit (`rules/`, the inactive `hooks/pre-push`, `INSTALL_FOR_AGENTS.md`, and the four default tool packs projected into `tools/` and `scripts/`) moved behind `--full` on `brigade init` and `operator quickstart`, or the `repo-extras` include. Workspace-depth installs are unchanged and always get the full kitchen.

--- a/src/brigade/center_cmd.py
+++ b/src/brigade/center_cmd.py
@@ -40,6 +40,7 @@ from .localio import (
     utc_now as _now,
     write_json as _write_json,
 )
+from .render import emit
 
 SCHEMA_VERSION = 1
 SCHEMA_MANIFEST_VERSION = 1
@@ -1393,46 +1394,50 @@ def status_payload(target: Path) -> dict[str, Any]:
 def status(*, target: Path, json_output: bool = False) -> int:
     payload = status_payload(target)
     if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-        return 0
-    print(f"center status: {payload['target']}")
-    print(f"pending_tasks: {payload['pending_task_count']}")
-    print(f"pending_imports: {payload['pending_import_count']}")
-    print(f"reviews: {payload['review_queue_count']}")
-    print(f"actions: {payload['action_queue']['open_count']}")
-    print(f"context_packs: {payload['context']['pack_count']}")
+        return emit(payload, json_output, [], 0)
+    text_lines = [
+        f"center status: {payload['target']}",
+        f"pending_tasks: {payload['pending_task_count']}",
+        f"pending_imports: {payload['pending_import_count']}",
+        f"reviews: {payload['review_queue_count']}",
+        f"actions: {payload['action_queue']['open_count']}",
+        f"context_packs: {payload['context']['pack_count']}",
+    ]
     pantry = payload.get("pantry") if isinstance(payload.get("pantry"), dict) else {}
     if pantry:
-        print(f"pantry: {pantry.get('summary')}")
+        text_lines.append(f"pantry: {pantry.get('summary')}")
     notifications = payload.get("notifications") if isinstance(payload.get("notifications"), dict) else {}
     if notifications:
-        print(f"notifications: {notifications.get('status')} configured={notifications.get('configured')}")
+        text_lines.append(f"notifications: {notifications.get('status')} configured={notifications.get('configured')}")
     phase_ledger = payload.get("phase_ledger") if isinstance(payload.get("phase_ledger"), dict) else {}
     if phase_ledger:
-        print(f"phase_records: {phase_ledger.get('record_count', 0)}")
-        print(f"phase_issues: {phase_ledger.get('issue_count', 0)}")
-        print(f"phase_actions: {phase_ledger.get('open_action_count', 0)}")
+        text_lines.append(f"phase_records: {phase_ledger.get('record_count', 0)}")
+        text_lines.append(f"phase_issues: {phase_ledger.get('issue_count', 0)}")
+        text_lines.append(f"phase_actions: {phase_ledger.get('open_action_count', 0)}")
         latest_phase_session = (
             phase_ledger.get("latest_session") if isinstance(phase_ledger.get("latest_session"), dict) else None
         )
         if latest_phase_session:
-            print(f"phase_session: {latest_phase_session.get('session_id')} [{latest_phase_session.get('status')}]")
-    return 0
+            text_lines.append(
+                f"phase_session: {latest_phase_session.get('session_id')} [{latest_phase_session.get('status')}]"
+            )
+    return emit(payload, json_output, text_lines, 0)
 
 
 def schema(*, target: Path, json_output: bool = False) -> int:
     payload = _center_schema_manifest(target)
     if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-        return 0
-    print(f"center schema manifest: {payload['target']}")
-    print(f"schemas: {payload['schema_count']}")
-    print("read_only: true")
+        return emit(payload, json_output, [], 0)
+    text_lines = [
+        f"center schema manifest: {payload['target']}",
+        f"schemas: {payload['schema_count']}",
+        "read_only: true",
+    ]
     for schema_item in payload["schemas"]:
-        print(f"- {schema_item['id']}: {schema_item['command']}")
+        text_lines.append(f"- {schema_item['id']}: {schema_item['command']}")
     for check in payload["checks"]:
-        print(f"[{check['status']}] {check['name']}: {check['detail']}")
-    return 0
+        text_lines.append(f"[{check['status']}] {check['name']}: {check['detail']}")
+    return emit(payload, json_output, text_lines, 0)
 
 
 def activity(*, target: Path, json_output: bool = False, limit: int = 50) -> int:
@@ -1446,12 +1451,11 @@ def activity(*, target: Path, json_output: bool = False, limit: int = 50) -> int
         "activity_count": len(items),
     }
     if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-        return 0
-    print(f"center activity: {target}")
+        return emit(payload, json_output, [], 0)
+    text_lines = [f"center activity: {target}"]
     for item in items:
-        print(f"- {item['subsystem']} {item['id']} [{item['status']}] {item['safe_summary']}")
-    return 0
+        text_lines.append(f"- {item['subsystem']} {item['id']} [{item['status']}] {item['safe_summary']}")
+    return emit(payload, json_output, text_lines, 0)
 
 
 def reviews(*, target: Path, json_output: bool = False, limit: int = 50) -> int:
@@ -1465,13 +1469,12 @@ def reviews(*, target: Path, json_output: bool = False, limit: int = 50) -> int:
         "review_count": len(items),
     }
     if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-        return 0
-    print(f"center reviews: {target}")
+        return emit(payload, json_output, [], 0)
+    text_lines = [f"center reviews: {target}"]
     for item in items:
-        print(f"- {item['subsystem']} {item['id']} [{item['status']}] {item['safe_summary']}")
-        print(f"  next: {item['suggested_next_command']}")
-    return 0
+        text_lines.append(f"- {item['subsystem']} {item['id']} [{item['status']}] {item['safe_summary']}")
+        text_lines.append(f"  next: {item['suggested_next_command']}")
+    return emit(payload, json_output, text_lines, 0)
 
 
 def templates(*, target: Path, json_output: bool = False) -> int:
@@ -1501,12 +1504,11 @@ def templates(*, target: Path, json_output: bool = False) -> int:
         "template_count": len(items),
     }
     if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-        return 0
-    print(f"center templates: {target}")
+        return emit(payload, json_output, [], 0)
+    text_lines = [f"center templates: {target}"]
     for item in items:
-        print(f"- {item['subsystem']}:{item['id']} {item['safe_summary']}")
-    return 0
+        text_lines.append(f"- {item['subsystem']}:{item['id']} {item['safe_summary']}")
+    return emit(payload, json_output, text_lines, 0)
 
 
 def _readiness_root(target: Path) -> Path:
@@ -1780,18 +1782,20 @@ def readiness_health(target: Path) -> dict[str, Any]:
 
 def readiness_plan(*, target: Path, json_output: bool = False) -> int:
     payload = _readiness_payload(target)
+    rc = 0 if payload["ready"] else 1
     if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-        return 0 if payload["ready"] else 1
-    print(f"center readiness plan: {payload['target']}")
-    print(f"status: {payload['status']}")
-    print(f"blockers: {payload['blocker_count']}")
-    print(f"warnings: {payload['warning_count']}")
+        return emit(payload, json_output, [], rc)
+    text_lines = [
+        f"center readiness plan: {payload['target']}",
+        f"status: {payload['status']}",
+        f"blockers: {payload['blocker_count']}",
+        f"warnings: {payload['warning_count']}",
+    ]
     for finding in payload["findings"][:20]:
         waived = " waived" if finding.get("waived") else ""
-        print(f"- {finding['finding_id']} {finding['severity']}{waived}: {finding['safe_summary']}")
-        print(f"  next: {finding['suggested_next_command']}")
-    return 0 if payload["ready"] else 1
+        text_lines.append(f"- {finding['finding_id']} {finding['severity']}{waived}: {finding['safe_summary']}")
+        text_lines.append(f"  next: {finding['suggested_next_command']}")
+    return emit(payload, json_output, text_lines, rc)
 
 
 def readiness_closeout(
@@ -1888,12 +1892,11 @@ def readiness_list(*, target: Path, limit: int = 20, json_output: bool = False) 
         "readiness_count": len(receipts),
     }
     if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-        return 0
-    print(f"center readiness list: {target}")
+        return emit(payload, json_output, [], 0)
+    text_lines = [f"center readiness list: {target}"]
     for receipt in receipts:
-        print(f"- {receipt.get('readiness_id')} [{receipt.get('status')}] {receipt.get('review_status')}")
-    return 0
+        text_lines.append(f"- {receipt.get('readiness_id')} [{receipt.get('status')}] {receipt.get('review_status')}")
+    return emit(payload, json_output, text_lines, 0)
 
 
 def _resolve_readiness(target: Path, readiness_id: str) -> tuple[dict[str, Any] | None, str | None]:
@@ -3151,16 +3154,17 @@ def actions_doctor(*, target: Path, json_output: bool = False) -> int:
         "health": actions_health(target),
     }
     if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-        return 0
-    print(f"center actions doctor: {target}")
+        return emit(payload, json_output, [], 0)
     health = payload["health"]
-    print(f"actions: {health['action_count']}")
-    print(f"open: {health['open_count']}")
-    print(f"policy_issues: {health['policy_issue_count']}")
+    text_lines = [
+        f"center actions doctor: {target}",
+        f"actions: {health['action_count']}",
+        f"open: {health['open_count']}",
+        f"policy_issues: {health['policy_issue_count']}",
+    ]
     for issue in health["policy_issues"]:
-        print(f"[{issue['status']}] {issue['name']}: {issue['detail']}")
-    return 0
+        text_lines.append(f"[{issue['status']}] {issue['name']}: {issue['detail']}")
+    return emit(payload, json_output, text_lines, 0)
 
 
 def _action_policy_import_record(issue: dict[str, Any], actions_by_id: dict[str, dict[str, Any]]) -> dict[str, Any]:

--- a/src/brigade/cli/extras.py
+++ b/src/brigade/cli/extras.py
@@ -43,30 +43,33 @@ def dispatch(args) -> int:
     return 2
 
 
-def register_stub(sub: argparse._SubParsersAction, name: str) -> None:
+def register_stub(sub: argparse._SubParsersAction, name: str, *, invocation: str | None = None) -> None:
     """Register a disabled extras command so it fails with guidance, not a parse error.
 
     The stub swallows every argument (including -h/--help, which argparse
     would otherwise answer with an empty help page or reject) so the user
-    always sees the enable guidance instead.
+    always sees the enable guidance instead. `invocation` is the full command
+    path for the guidance text when the stub sits below the top level
+    (e.g. "work phases").
     """
+    shown = invocation or name
     p = sub.add_parser(name, help="(extras, disabled) enable with `brigade extras on`", add_help=False)
 
-    def _swallow_all(args=None, namespace=None, *, _name=name):
+    def _swallow_all(args=None, namespace=None, *, _shown=shown):
         ns = namespace or argparse.Namespace()
         ns.stub_args = list(args or [])
-        ns.func = lambda parsed, _n=_name: _stub_dispatch(_n)
+        ns.func = lambda parsed, _s=_shown: _stub_dispatch(_s)
         return ns, []
 
     p.parse_known_args = _swallow_all  # type: ignore[method-assign]
-    p.set_defaults(func=lambda args, _name=name: _stub_dispatch(_name))
+    p.set_defaults(func=lambda args, _shown=shown: _stub_dispatch(_shown))
 
 
-def _stub_dispatch(name: str) -> int:
+def _stub_dispatch(invocation: str) -> int:
     print(
-        f"error: '{name}' is part of the brigade extras surface, which is disabled.\n"
+        f"error: '{invocation}' is part of the brigade extras surface, which is disabled.\n"
         f"Enable it once with: brigade extras on\n"
-        f"Or per invocation:   BRIGADE_EXTRAS=1 brigade {name} ...",
+        f"Or per invocation:   BRIGADE_EXTRAS=1 brigade {invocation} ...",
         file=sys.stderr,
     )
     return 2

--- a/src/brigade/cli/work.py
+++ b/src/brigade/cli/work.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
+from .. import extras as _extras_mod
 from ..dogfood_cmd import DEFAULT_TIMEOUT_SECONDS
 from ..work_cmd import TASK_PRIORITIES, TASK_TYPES
+from . import extras as _extras_cli
 
 
 def register(sub: argparse._SubParsersAction) -> None:
@@ -335,690 +337,12 @@ def register(sub: argparse._SubParsersAction) -> None:
         "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
     )
     p_work_review_closeout.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases = work_sub.add_parser("phases", help="Plan and inspect auditable phase execution records.")
-    phases_sub = p_work_phases.add_subparsers(dest="phases_command", metavar="<phases-command>")
-    phases_sub.required = True
-    p_work_phases_init = phases_sub.add_parser("init", help="Initialize the local phase execution ledger.")
-    p_work_phases_init.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update.")
-    p_work_phases_init.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_plan = phases_sub.add_parser("plan", help="Plan one phase or a range of phases.")
-    p_work_phases_plan.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update.")
-    p_work_phases_plan.add_argument(
-        "--phase-id", "--phase", dest="phase_id", default=None, help="Phase id to create, such as phase-165."
-    )
-    p_work_phases_plan.add_argument(
-        "--range", dest="phase_range", default=None, help="Phase range to create, such as 165-170."
-    )
-    p_work_phases_plan.add_argument("--title", default=None, help="Phase title.")
-    p_work_phases_plan.add_argument("--goal", dest="source_goal", default=None, help="Source goal text or label.")
-    p_work_phases_plan.add_argument("--grouped", action="store_true", help="Declare an explicit grouped phase range.")
-    p_work_phases_plan.add_argument("--force", action="store_true", help="Overwrite existing phase records.")
-    p_work_phases_plan.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_list = phases_sub.add_parser("list", help="List local phase records.")
-    p_work_phases_list.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
-    )
-    p_work_phases_list.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_schema = phases_sub.add_parser("schema", help="Show phase ledger JSON contracts.")
-    p_work_phases_schema.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
-    )
-    p_work_phases_schema.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_status = phases_sub.add_parser("status", help="Summarize phase ledger range status.")
-    p_work_phases_status.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
-    )
-    p_work_phases_status.add_argument("--range", dest="phase_range", default=None, help="Phase range, such as 165-170.")
-    p_work_phases_status.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_next = phases_sub.add_parser("next", help="Show the next open phase.")
-    p_work_phases_next.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
-    )
-    p_work_phases_next.add_argument("--range", dest="phase_range", default=None, help="Phase range, such as 165-170.")
-    p_work_phases_next.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_show = phases_sub.add_parser("show", help="Show one local phase record.")
-    p_work_phases_show.add_argument("phase_id", help="Phase id or unique prefix.")
-    p_work_phases_show.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
-    )
-    p_work_phases_show.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_start = phases_sub.add_parser("start", help="Mark one phase in progress.")
-    p_work_phases_start.add_argument("phase_id", help="Phase id or unique prefix.")
-    p_work_phases_start.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
-    )
-    p_work_phases_start.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_complete = phases_sub.add_parser("complete", help="Attach completion evidence to one phase.")
-    p_work_phases_complete.add_argument("phase_id", help="Phase id or unique prefix.")
-    p_work_phases_complete.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
-    )
-    p_work_phases_complete.add_argument(
-        "--status",
-        choices=["implemented", "verified", "committed", "pushed"],
-        default="implemented",
-        help="Completion status.",
-    )
-    p_work_phases_complete.add_argument("--summary", default=None, help="Implementation summary.")
-    p_work_phases_complete.add_argument(
-        "--file", dest="files_changed", action="append", default=[], help="Changed file. May be repeated."
-    )
-    p_work_phases_complete.add_argument(
-        "--test", dest="tests_run", action="append", default=[], help="Verification command. May be repeated."
-    )
-    p_work_phases_complete.add_argument("--test-result", default=None, help="Test result summary.")
-    p_work_phases_complete.add_argument("--commit", dest="commit_hash", default=None, help="Commit hash.")
-    p_work_phases_complete.add_argument("--push-ref", default=None, help="Push ref.")
-    p_work_phases_complete.add_argument(
-        "--deferred-item", action="append", default=[], help="Deferred item. May be repeated."
-    )
-    p_work_phases_complete.add_argument(
-        "--next", dest="next_phase_recommendation", default=None, help="Next phase recommendation."
-    )
-    p_work_phases_complete.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_defer = phases_sub.add_parser("defer", help="Defer one phase with a reason.")
-    p_work_phases_defer.add_argument("phase_id", help="Phase id or unique prefix.")
-    p_work_phases_defer.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
-    )
-    p_work_phases_defer.add_argument("--reason", required=True, help="Deferral reason.")
-    p_work_phases_defer.add_argument(
-        "--next", dest="next_phase_recommendation", default=None, help="Next phase recommendation."
-    )
-    p_work_phases_defer.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_closeout = phases_sub.add_parser("closeout", help="Review or close out phase records.")
-    p_work_phases_closeout.add_argument("selector", help="Phase id, range such as 201-205, or latest.")
-    p_work_phases_closeout.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
-    )
-    p_work_phases_closeout.add_argument(
-        "--status", choices=["reviewed", "deferred", "blocked", "archived"], default="reviewed", help="Closeout state."
-    )
-    p_work_phases_closeout.add_argument("--reason", default=None, help="Closeout reason.")
-    p_work_phases_closeout.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_compare = phases_sub.add_parser("compare", help="Compare phase evidence against current local state.")
-    p_work_phases_compare.add_argument("selector", help="Phase id, range such as 201-205, or latest.")
-    p_work_phases_compare.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
-    )
-    p_work_phases_compare.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_reconcile = phases_sub.add_parser(
-        "reconcile", help="Reconcile phase commit and push evidence against local git state."
-    )
-    p_work_phases_reconcile.add_argument("selector", help="Phase id, range such as 211-225, or latest.")
-    p_work_phases_reconcile.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
-    )
-    p_work_phases_reconcile.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_privacy = phases_sub.add_parser(
-        "privacy", help="Scan phase evidence for protected private/reference values."
-    )
-    p_work_phases_privacy.add_argument("selector", help="Phase id, range such as 211-225, or latest.")
-    p_work_phases_privacy.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
-    )
-    p_work_phases_privacy.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_handoff = phases_sub.add_parser("handoff", help="Draft a Memory Handoff from phase evidence.")
-    p_work_phases_handoff.add_argument("selector", help="Phase id, range such as 211-225, or latest.")
-    p_work_phases_handoff.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
-    )
-    p_work_phases_handoff.add_argument("--lint", action="store_true", help="Run handoff lint before returning.")
-    p_work_phases_handoff.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_doctor = phases_sub.add_parser("doctor", help="Check phase execution ledger health.")
-    p_work_phases_doctor.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
-    )
-    p_work_phases_doctor.add_argument(
-        "--range", dest="phase_range", default=None, help="Required phase range, such as 165-170."
-    )
-    p_work_phases_doctor.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_import = phases_sub.add_parser(
-        "import-issues", help="Import phase ledger issues into the work inbox."
-    )
-    p_work_phases_import.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
-    )
-    p_work_phases_import.add_argument("--range", dest="phase_range", default=None, help="Phase range, such as 165-170.")
-    p_work_phases_import.add_argument("--dry-run", action="store_true", help="Report imports without writing them.")
-    p_work_phases_import.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_evidence = phases_sub.add_parser("evidence", help="Attach local evidence metadata to phase records.")
-    phases_evidence_sub = p_work_phases_evidence.add_subparsers(
-        dest="phases_evidence_command", metavar="<phases-evidence-command>"
-    )
-    phases_evidence_sub.required = True
-    p_work_phases_evidence_add = phases_evidence_sub.add_parser("add", help="Attach local evidence to one phase.")
-    p_work_phases_evidence_add.add_argument("phase_id", help="Phase id or unique prefix.")
-    p_work_phases_evidence_add.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
-    )
-    p_work_phases_evidence_add.add_argument(
-        "--file", dest="files_changed", action="append", default=[], help="Changed file path. May be repeated."
-    )
-    p_work_phases_evidence_add.add_argument(
-        "--test", dest="tests_run", action="append", default=[], help="Verification command. May be repeated."
-    )
-    p_work_phases_evidence_add.add_argument("--test-result", default=None, help="Verification result summary.")
-    p_work_phases_evidence_add.add_argument(
-        "--report-id", action="append", default=[], help="Related phase report id. May be repeated."
-    )
-    p_work_phases_evidence_add.add_argument(
-        "--handoff", dest="handoff_paths", action="append", default=[], help="Memory Handoff path. May be repeated."
-    )
-    p_work_phases_evidence_add.add_argument(
-        "--note", dest="notes", action="append", default=[], help="Evidence note. May be repeated."
-    )
-    p_work_phases_evidence_add.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_verify = phases_sub.add_parser("verify", help="Plan and record phase verification metadata.")
-    phases_verify_sub = p_work_phases_verify.add_subparsers(
-        dest="phases_verify_command", metavar="<phases-verify-command>"
-    )
-    phases_verify_sub.required = True
-    p_work_phases_verify_plan = phases_verify_sub.add_parser("plan", help="Plan verification for a phase selector.")
-    p_work_phases_verify_plan.add_argument("selector", help="Phase id, range such as 211-225, or latest.")
-    p_work_phases_verify_plan.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
-    )
-    p_work_phases_verify_plan.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_verify_record = phases_verify_sub.add_parser("record", help="Record one phase verification result.")
-    p_work_phases_verify_record.add_argument("phase_id", help="Phase id or unique prefix.")
-    p_work_phases_verify_record.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
-    )
-    p_work_phases_verify_record.add_argument(
-        "--command", dest="verification_command", required=True, help="Verification command label."
-    )
-    p_work_phases_verify_record.add_argument(
-        "--status", choices=["passed", "failed", "skipped", "deferred"], required=True, help="Verification result."
-    )
-    p_work_phases_verify_record.add_argument("--summary", default=None, help="Verification result summary.")
-    p_work_phases_verify_record.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_actions = phases_sub.add_parser("actions", help="Plan and manage local phase ledger action records.")
-    phases_actions_sub = p_work_phases_actions.add_subparsers(
-        dest="phases_actions_command", metavar="<phases-actions-command>"
-    )
-    phases_actions_sub.required = True
-    p_work_phases_actions_plan = phases_actions_sub.add_parser(
-        "plan", help="Preview phase ledger actions from current issues."
-    )
-    p_work_phases_actions_plan.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
-    )
-    p_work_phases_actions_plan.add_argument(
-        "--range", dest="phase_range", default=None, help="Phase range, such as 201-205."
-    )
-    p_work_phases_actions_plan.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_actions_build = phases_actions_sub.add_parser(
-        "build", help="Build local phase ledger action records."
-    )
-    p_work_phases_actions_build.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
-    )
-    p_work_phases_actions_build.add_argument(
-        "--range", dest="phase_range", default=None, help="Phase range, such as 201-205."
-    )
-    p_work_phases_actions_build.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_actions_list = phases_actions_sub.add_parser("list", help="List local phase ledger actions.")
-    p_work_phases_actions_list.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
-    )
-    p_work_phases_actions_list.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_actions_show = phases_actions_sub.add_parser("show", help="Show one phase ledger action.")
-    p_work_phases_actions_show.add_argument("action_id", help="Action id or unique prefix.")
-    p_work_phases_actions_show.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
-    )
-    p_work_phases_actions_show.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_actions_start = phases_actions_sub.add_parser("start", help="Mark one phase ledger action active.")
-    p_work_phases_actions_start.add_argument("action_id", help="Action id or unique prefix.")
-    p_work_phases_actions_start.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
-    )
-    p_work_phases_actions_start.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_actions_done = phases_actions_sub.add_parser("done", help="Mark one phase ledger action done.")
-    p_work_phases_actions_done.add_argument("action_id", help="Action id or unique prefix.")
-    p_work_phases_actions_done.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
-    )
-    p_work_phases_actions_done.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_actions_defer = phases_actions_sub.add_parser("defer", help="Defer one phase ledger action.")
-    p_work_phases_actions_defer.add_argument("action_id", help="Action id or unique prefix.")
-    p_work_phases_actions_defer.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
-    )
-    p_work_phases_actions_defer.add_argument("--reason", required=True, help="Deferral reason.")
-    p_work_phases_actions_defer.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_actions_archive = phases_actions_sub.add_parser("archive", help="Archive phase ledger actions.")
-    p_work_phases_actions_archive.add_argument("action_id", nargs="?", default=None, help="Action id or unique prefix.")
-    p_work_phases_actions_archive.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
-    )
-    p_work_phases_actions_archive.add_argument(
-        "--completed", action="store_true", help="Archive done and deferred actions."
-    )
-    p_work_phases_actions_archive.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_actions_import = phases_actions_sub.add_parser(
-        "import-issues", help="Import open phase actions into the work inbox."
-    )
-    p_work_phases_actions_import.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
-    )
-    p_work_phases_actions_import.add_argument(
-        "--dry-run", action="store_true", help="Report imports without writing them."
-    )
-    p_work_phases_actions_import.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_goal = phases_sub.add_parser("goal", help="Draft reviewed phase goal prompts.")
-    phases_goal_sub = p_work_phases_goal.add_subparsers(dest="phases_goal_command", metavar="<phases-goal-command>")
-    phases_goal_sub.required = True
-    p_work_phases_goal_scaffold = phases_goal_sub.add_parser(
-        "scaffold", help="Draft a local goal prompt from phase ledger state."
-    )
-    p_work_phases_goal_scaffold.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
-    )
-    p_work_phases_goal_scaffold.add_argument(
-        "--range", dest="phase_range", required=True, help="Phase range, such as 211-225."
-    )
-    p_work_phases_goal_scaffold.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_report = phases_sub.add_parser("report", help="Build and inspect phase ledger reports.")
-    phases_report_sub = p_work_phases_report.add_subparsers(
-        dest="phases_report_command", metavar="<phases-report-command>"
-    )
-    phases_report_sub.required = True
-    p_work_phases_report_build = phases_report_sub.add_parser("build", help="Build a local phase ledger report.")
-    p_work_phases_report_build.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
-    )
-    p_work_phases_report_build.add_argument(
-        "--range", dest="phase_range", default=None, help="Phase range, such as 165-170."
-    )
-    p_work_phases_report_build.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_report_list = phases_report_sub.add_parser("list", help="List phase ledger reports.")
-    p_work_phases_report_list.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
-    )
-    p_work_phases_report_list.add_argument("--limit", type=int, default=20, help="Maximum reports to list.")
-    p_work_phases_report_list.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_report_show = phases_report_sub.add_parser("show", help="Show one phase ledger report.")
-    p_work_phases_report_show.add_argument("report_id", help="Report id, unique prefix, or latest.")
-    p_work_phases_report_show.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
-    )
-    p_work_phases_report_show.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_report_closeout = phases_report_sub.add_parser("closeout", help="Close out one phase ledger report.")
-    p_work_phases_report_closeout.add_argument("report_id", help="Report id, unique prefix, or latest.")
-    p_work_phases_report_closeout.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
-    )
-    p_work_phases_report_closeout.add_argument(
-        "--status",
-        choices=["reviewed", "deferred", "superseded", "archived"],
-        default="reviewed",
-        help="Report closeout state.",
-    )
-    p_work_phases_report_closeout.add_argument("--reason", default=None, help="Closeout reason.")
-    p_work_phases_report_closeout.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_report_compare = phases_report_sub.add_parser(
-        "compare", help="Compare one phase ledger report against current state."
-    )
-    p_work_phases_report_compare.add_argument("report_id", help="Report id, unique prefix, or latest.")
-    p_work_phases_report_compare.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
-    )
-    p_work_phases_report_compare.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_session = phases_sub.add_parser("session", help="Start and review phase execution sessions.")
-    phases_session_sub = p_work_phases_session.add_subparsers(
-        dest="phases_session_command", metavar="<phases-session-command>"
-    )
-    phases_session_sub.required = True
-    p_work_phases_session_start = phases_session_sub.add_parser("start", help="Start a local phase execution session.")
-    p_work_phases_session_start.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
-    )
-    p_work_phases_session_start.add_argument(
-        "--range", dest="phase_range", required=True, help="Phase range, such as 211-225."
-    )
-    p_work_phases_session_start.add_argument("--goal", dest="source_goal", default=None, help="Source goal text.")
-    p_work_phases_session_start.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_session_list = phases_session_sub.add_parser("list", help="List phase execution sessions.")
-    p_work_phases_session_list.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
-    )
-    p_work_phases_session_list.add_argument("--limit", type=int, default=20, help="Maximum sessions to list.")
-    p_work_phases_session_list.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_session_show = phases_session_sub.add_parser("show", help="Show one phase execution session.")
-    p_work_phases_session_show.add_argument("session_id", help="Session id, unique prefix, or latest.")
-    p_work_phases_session_show.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
-    )
-    p_work_phases_session_show.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_session_checkpoint = phases_session_sub.add_parser(
-        "checkpoint", help="Record a local phase session checkpoint."
-    )
-    p_work_phases_session_checkpoint.add_argument(
-        "session_id", nargs="?", default="latest", help="Session id, unique prefix, or latest."
-    )
-    p_work_phases_session_checkpoint.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
-    )
-    p_work_phases_session_checkpoint.add_argument("--phase-id", default=None, help="Phase id for the checkpoint.")
-    p_work_phases_session_checkpoint.add_argument(
-        "--status", choices=["noted", "blocked", "recovered"], default="noted", help="Checkpoint state."
-    )
-    p_work_phases_session_checkpoint.add_argument("--summary", default=None, help="Safe checkpoint summary.")
-    p_work_phases_session_checkpoint.add_argument(
-        "--note", dest="notes", action="append", default=[], help="Safe local note. May be repeated."
-    )
-    p_work_phases_session_checkpoint.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_session_checkpoints = phases_session_sub.add_parser(
-        "checkpoints", help="List and inspect phase session checkpoints."
-    )
-    phases_session_checkpoints_sub = p_work_phases_session_checkpoints.add_subparsers(
-        dest="phases_session_checkpoints_command", metavar="<phases-session-checkpoints-command>"
-    )
-    phases_session_checkpoints_sub.required = True
-    p_work_phases_session_checkpoints_list = phases_session_checkpoints_sub.add_parser(
-        "list", help="List phase session checkpoints."
-    )
-    p_work_phases_session_checkpoints_list.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
-    )
-    p_work_phases_session_checkpoints_list.add_argument(
-        "--session", dest="session_id", default=None, help="Limit to one session id, prefix, or latest."
-    )
-    p_work_phases_session_checkpoints_list.add_argument(
-        "--limit", type=int, default=20, help="Maximum checkpoints to list."
-    )
-    p_work_phases_session_checkpoints_list.add_argument(
-        "--json", action="store_true", help="Print machine-readable JSON."
-    )
-    p_work_phases_session_checkpoints_show = phases_session_checkpoints_sub.add_parser(
-        "show", help="Show one phase session checkpoint."
-    )
-    p_work_phases_session_checkpoints_show.add_argument(
-        "checkpoint_id", help="Checkpoint id, unique prefix, or latest."
-    )
-    p_work_phases_session_checkpoints_show.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
-    )
-    p_work_phases_session_checkpoints_show.add_argument(
-        "--json", action="store_true", help="Print machine-readable JSON."
-    )
-    p_work_phases_session_checkpoints_compare = phases_session_checkpoints_sub.add_parser(
-        "compare", help="Compare one checkpoint against current session state."
-    )
-    p_work_phases_session_checkpoints_compare.add_argument(
-        "checkpoint_id", help="Checkpoint id, unique prefix, or latest."
-    )
-    p_work_phases_session_checkpoints_compare.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
-    )
-    p_work_phases_session_checkpoints_compare.add_argument(
-        "--json", action="store_true", help="Print machine-readable JSON."
-    )
-    p_work_phases_session_checkpoints_import = phases_session_checkpoints_sub.add_parser(
-        "import-issues", help="Import checkpoint blockers into the work inbox."
-    )
-    p_work_phases_session_checkpoints_import.add_argument(
-        "checkpoint_id", nargs="?", default="latest", help="Checkpoint id, unique prefix, or latest."
-    )
-    p_work_phases_session_checkpoints_import.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
-    )
-    p_work_phases_session_checkpoints_import.add_argument(
-        "--dry-run", action="store_true", help="Preview imports without writing them."
-    )
-    p_work_phases_session_checkpoints_import.add_argument(
-        "--json", action="store_true", help="Print machine-readable JSON."
-    )
-    p_work_phases_session_checkpoints_archive = phases_session_checkpoints_sub.add_parser(
-        "archive", help="Archive one phase session checkpoint."
-    )
-    p_work_phases_session_checkpoints_archive.add_argument(
-        "checkpoint_id", help="Checkpoint id, unique prefix, or latest."
-    )
-    p_work_phases_session_checkpoints_archive.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
-    )
-    p_work_phases_session_checkpoints_archive.add_argument(
-        "--json", action="store_true", help="Print machine-readable JSON."
-    )
-    p_work_phases_session_recovery_note = phases_session_sub.add_parser(
-        "recovery-note", help="Record a local phase session recovery note."
-    )
-    p_work_phases_session_recovery_note.add_argument(
-        "session_id", nargs="?", default="latest", help="Session id, unique prefix, or latest."
-    )
-    p_work_phases_session_recovery_note.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
-    )
-    p_work_phases_session_recovery_note.add_argument("--phase-id", default=None, help="Phase id for the recovery note.")
-    p_work_phases_session_recovery_note.add_argument("--summary", default=None, help="Safe recovery note summary.")
-    p_work_phases_session_recovery_note.add_argument(
-        "--note", dest="notes", action="append", default=[], help="Safe local note. May be repeated."
-    )
-    p_work_phases_session_recovery_note.add_argument(
-        "--evidence", action="append", default=[], help="Local evidence label or reference. May be repeated."
-    )
-    p_work_phases_session_recovery_note.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_session_recovery_notes = phases_session_sub.add_parser(
-        "recovery-notes", help="List and inspect phase session recovery notes."
-    )
-    phases_session_recovery_notes_sub = p_work_phases_session_recovery_notes.add_subparsers(
-        dest="phases_session_recovery_notes_command", metavar="<phases-session-recovery-notes-command>"
-    )
-    phases_session_recovery_notes_sub.required = True
-    p_work_phases_session_recovery_notes_list = phases_session_recovery_notes_sub.add_parser(
-        "list", help="List phase session recovery notes."
-    )
-    p_work_phases_session_recovery_notes_list.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
-    )
-    p_work_phases_session_recovery_notes_list.add_argument(
-        "--session", dest="session_id", default=None, help="Limit to one session id, prefix, or latest."
-    )
-    p_work_phases_session_recovery_notes_list.add_argument(
-        "--limit", type=int, default=20, help="Maximum recovery notes to list."
-    )
-    p_work_phases_session_recovery_notes_list.add_argument(
-        "--json", action="store_true", help="Print machine-readable JSON."
-    )
-    p_work_phases_session_recovery_notes_show = phases_session_recovery_notes_sub.add_parser(
-        "show", help="Show one phase session recovery note."
-    )
-    p_work_phases_session_recovery_notes_show.add_argument(
-        "note_id", help="Recovery note id, unique prefix, or latest."
-    )
-    p_work_phases_session_recovery_notes_show.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
-    )
-    p_work_phases_session_recovery_notes_show.add_argument(
-        "--json", action="store_true", help="Print machine-readable JSON."
-    )
-    p_work_phases_session_recovery_notes_closeout = phases_session_recovery_notes_sub.add_parser(
-        "closeout", help="Close out one phase session recovery note."
-    )
-    p_work_phases_session_recovery_notes_closeout.add_argument(
-        "note_id", help="Recovery note id, unique prefix, or latest."
-    )
-    p_work_phases_session_recovery_notes_closeout.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
-    )
-    p_work_phases_session_recovery_notes_closeout.add_argument(
-        "--status",
-        choices=["reviewed", "deferred", "blocked", "archived"],
-        default="reviewed",
-        help="Recovery note closeout state.",
-    )
-    p_work_phases_session_recovery_notes_closeout.add_argument("--reason", default=None, help="Closeout reason.")
-    p_work_phases_session_recovery_notes_closeout.add_argument(
-        "--json", action="store_true", help="Print machine-readable JSON."
-    )
-    p_work_phases_session_risk = phases_session_sub.add_parser("risk", help="Summarize phase session risk.")
-    p_work_phases_session_risk.add_argument(
-        "session_id", nargs="?", default="latest", help="Session id, unique prefix, or latest."
-    )
-    p_work_phases_session_risk.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
-    )
-    p_work_phases_session_risk.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_session_verification = phases_session_sub.add_parser(
-        "verification", help="Summarize phase session verification."
-    )
-    p_work_phases_session_verification.add_argument(
-        "session_id", nargs="?", default="latest", help="Session id, unique prefix, or latest."
-    )
-    p_work_phases_session_verification.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
-    )
-    p_work_phases_session_verification.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_session_privacy = phases_session_sub.add_parser(
-        "privacy", help="Summarize phase session privacy checks."
-    )
-    p_work_phases_session_privacy.add_argument(
-        "session_id", nargs="?", default="latest", help="Session id, unique prefix, or latest."
-    )
-    p_work_phases_session_privacy.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
-    )
-    p_work_phases_session_privacy.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_session_handoffs = phases_session_sub.add_parser(
-        "handoffs", help="Summarize phase session handoff coverage."
-    )
-    p_work_phases_session_handoffs.add_argument(
-        "session_id", nargs="?", default="latest", help="Session id, unique prefix, or latest."
-    )
-    p_work_phases_session_handoffs.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
-    )
-    p_work_phases_session_handoffs.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_session_next = phases_session_sub.add_parser(
-        "next", help="Show the next required phase session step."
-    )
-    p_work_phases_session_next.add_argument(
-        "session_id", nargs="?", default="latest", help="Session id, unique prefix, or latest."
-    )
-    p_work_phases_session_next.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
-    )
-    p_work_phases_session_next.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_session_protocol = phases_session_sub.add_parser(
-        "protocol", help="Show wrapper-safe phase session resume protocol."
-    )
-    p_work_phases_session_protocol.add_argument(
-        "session_id", nargs="?", default="latest", help="Session id, unique prefix, or latest."
-    )
-    p_work_phases_session_protocol.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
-    )
-    p_work_phases_session_protocol.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_session_audit = phases_session_sub.add_parser("audit", help="Self-audit AFK phase session evidence.")
-    p_work_phases_session_audit.add_argument(
-        "session_id", nargs="?", default="latest", help="Session id, unique prefix, or latest."
-    )
-    p_work_phases_session_audit.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
-    )
-    p_work_phases_session_audit.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_session_resume = phases_session_sub.add_parser(
-        "resume", help="Record a safe phase session resume recommendation."
-    )
-    p_work_phases_session_resume.add_argument(
-        "session_id", nargs="?", default="latest", help="Session id, unique prefix, or latest."
-    )
-    p_work_phases_session_resume.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
-    )
-    p_work_phases_session_resume.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_session_closeout = phases_session_sub.add_parser(
-        "closeout", help="Close out one phase execution session."
-    )
-    p_work_phases_session_closeout.add_argument("session_id", help="Session id, unique prefix, or latest.")
-    p_work_phases_session_closeout.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
-    )
-    p_work_phases_session_closeout.add_argument(
-        "--status",
-        choices=["reviewed", "deferred", "blocked", "archived"],
-        default="reviewed",
-        help="Session closeout state.",
-    )
-    p_work_phases_session_closeout.add_argument("--reason", default=None, help="Closeout reason.")
-    p_work_phases_session_closeout.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_session_activity = phases_session_sub.add_parser(
-        "activity", help="Show chronological phase session activity."
-    )
-    p_work_phases_session_activity.add_argument(
-        "session_id", nargs="?", default="latest", help="Session id, unique prefix, or latest."
-    )
-    p_work_phases_session_activity.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
-    )
-    p_work_phases_session_activity.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_session_progress = phases_session_sub.add_parser(
-        "progress", help="Show phase session progress summary."
-    )
-    p_work_phases_session_progress.add_argument(
-        "session_id", nargs="?", default="latest", help="Session id, unique prefix, or latest."
-    )
-    p_work_phases_session_progress.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
-    )
-    p_work_phases_session_progress.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_session_import = phases_session_sub.add_parser(
-        "import-issues", help="Import unresolved phase session blockers into the work inbox."
-    )
-    p_work_phases_session_import.add_argument(
-        "session_id", nargs="?", default="latest", help="Session id, unique prefix, or latest."
-    )
-    p_work_phases_session_import.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
-    )
-    p_work_phases_session_import.add_argument(
-        "--dry-run", action="store_true", help="Preview imports without writing them."
-    )
-    p_work_phases_session_import.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_session_gate = phases_session_sub.add_parser(
-        "gate", help="Check whether a phase session is safe to claim complete."
-    )
-    p_work_phases_session_gate.add_argument(
-        "session_id", nargs="?", default="latest", help="Session id, unique prefix, or latest."
-    )
-    p_work_phases_session_gate.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
-    )
-    p_work_phases_session_gate.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_session_report = phases_session_sub.add_parser(
-        "report", help="Build and inspect phase session reports."
-    )
-    phases_session_report_sub = p_work_phases_session_report.add_subparsers(
-        dest="phases_session_report_command", metavar="<phases-session-report-command>"
-    )
-    phases_session_report_sub.required = True
-    p_work_phases_session_report_build = phases_session_report_sub.add_parser(
-        "build", help="Build a local phase session report."
-    )
-    p_work_phases_session_report_build.add_argument(
-        "session_id", nargs="?", default="latest", help="Session id, unique prefix, or latest."
-    )
-    p_work_phases_session_report_build.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
-    )
-    p_work_phases_session_report_build.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_session_report_list = phases_session_report_sub.add_parser("list", help="List phase session reports.")
-    p_work_phases_session_report_list.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
-    )
-    p_work_phases_session_report_list.add_argument("--limit", type=int, default=20, help="Maximum reports to list.")
-    p_work_phases_session_report_list.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
-    p_work_phases_session_report_show = phases_session_report_sub.add_parser(
-        "show", help="Show one phase session report."
-    )
-    p_work_phases_session_report_show.add_argument("report_id", help="Report id, unique prefix, or latest.")
-    p_work_phases_session_report_show.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
-    )
-    p_work_phases_session_report_show.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    if _extras_mod.enabled():
+        _register_phases(work_sub)
+    else:
+        # The phase-execution ledger is operator-suite surface; it gates
+        # like a top-level extras command.
+        _extras_cli.register_stub(work_sub, "phases", invocation="work phases")
     p_work_next = work_sub.add_parser("next", help="Show the next daily work task and suggested command.")
     p_work_next.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
     p_work_next.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
@@ -2053,3 +1377,690 @@ def dispatch(args) -> int:
         )
     args._brigade_parser.error(f"unknown work command: {args.work_command}")
     return 2
+
+
+def _register_phases(work_sub: argparse._SubParsersAction) -> None:
+    p_work_phases = work_sub.add_parser("phases", help="Plan and inspect auditable phase execution records.")
+    phases_sub = p_work_phases.add_subparsers(dest="phases_command", metavar="<phases-command>")
+    phases_sub.required = True
+    p_work_phases_init = phases_sub.add_parser("init", help="Initialize the local phase execution ledger.")
+    p_work_phases_init.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update.")
+    p_work_phases_init.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_plan = phases_sub.add_parser("plan", help="Plan one phase or a range of phases.")
+    p_work_phases_plan.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update.")
+    p_work_phases_plan.add_argument(
+        "--phase-id", "--phase", dest="phase_id", default=None, help="Phase id to create, such as phase-165."
+    )
+    p_work_phases_plan.add_argument(
+        "--range", dest="phase_range", default=None, help="Phase range to create, such as 165-170."
+    )
+    p_work_phases_plan.add_argument("--title", default=None, help="Phase title.")
+    p_work_phases_plan.add_argument("--goal", dest="source_goal", default=None, help="Source goal text or label.")
+    p_work_phases_plan.add_argument("--grouped", action="store_true", help="Declare an explicit grouped phase range.")
+    p_work_phases_plan.add_argument("--force", action="store_true", help="Overwrite existing phase records.")
+    p_work_phases_plan.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_list = phases_sub.add_parser("list", help="List local phase records.")
+    p_work_phases_list.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    p_work_phases_list.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_schema = phases_sub.add_parser("schema", help="Show phase ledger JSON contracts.")
+    p_work_phases_schema.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    p_work_phases_schema.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_status = phases_sub.add_parser("status", help="Summarize phase ledger range status.")
+    p_work_phases_status.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    p_work_phases_status.add_argument("--range", dest="phase_range", default=None, help="Phase range, such as 165-170.")
+    p_work_phases_status.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_next = phases_sub.add_parser("next", help="Show the next open phase.")
+    p_work_phases_next.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    p_work_phases_next.add_argument("--range", dest="phase_range", default=None, help="Phase range, such as 165-170.")
+    p_work_phases_next.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_show = phases_sub.add_parser("show", help="Show one local phase record.")
+    p_work_phases_show.add_argument("phase_id", help="Phase id or unique prefix.")
+    p_work_phases_show.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    p_work_phases_show.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_start = phases_sub.add_parser("start", help="Mark one phase in progress.")
+    p_work_phases_start.add_argument("phase_id", help="Phase id or unique prefix.")
+    p_work_phases_start.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
+    )
+    p_work_phases_start.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_complete = phases_sub.add_parser("complete", help="Attach completion evidence to one phase.")
+    p_work_phases_complete.add_argument("phase_id", help="Phase id or unique prefix.")
+    p_work_phases_complete.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
+    )
+    p_work_phases_complete.add_argument(
+        "--status",
+        choices=["implemented", "verified", "committed", "pushed"],
+        default="implemented",
+        help="Completion status.",
+    )
+    p_work_phases_complete.add_argument("--summary", default=None, help="Implementation summary.")
+    p_work_phases_complete.add_argument(
+        "--file", dest="files_changed", action="append", default=[], help="Changed file. May be repeated."
+    )
+    p_work_phases_complete.add_argument(
+        "--test", dest="tests_run", action="append", default=[], help="Verification command. May be repeated."
+    )
+    p_work_phases_complete.add_argument("--test-result", default=None, help="Test result summary.")
+    p_work_phases_complete.add_argument("--commit", dest="commit_hash", default=None, help="Commit hash.")
+    p_work_phases_complete.add_argument("--push-ref", default=None, help="Push ref.")
+    p_work_phases_complete.add_argument(
+        "--deferred-item", action="append", default=[], help="Deferred item. May be repeated."
+    )
+    p_work_phases_complete.add_argument(
+        "--next", dest="next_phase_recommendation", default=None, help="Next phase recommendation."
+    )
+    p_work_phases_complete.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_defer = phases_sub.add_parser("defer", help="Defer one phase with a reason.")
+    p_work_phases_defer.add_argument("phase_id", help="Phase id or unique prefix.")
+    p_work_phases_defer.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
+    )
+    p_work_phases_defer.add_argument("--reason", required=True, help="Deferral reason.")
+    p_work_phases_defer.add_argument(
+        "--next", dest="next_phase_recommendation", default=None, help="Next phase recommendation."
+    )
+    p_work_phases_defer.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_closeout = phases_sub.add_parser("closeout", help="Review or close out phase records.")
+    p_work_phases_closeout.add_argument("selector", help="Phase id, range such as 201-205, or latest.")
+    p_work_phases_closeout.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
+    )
+    p_work_phases_closeout.add_argument(
+        "--status", choices=["reviewed", "deferred", "blocked", "archived"], default="reviewed", help="Closeout state."
+    )
+    p_work_phases_closeout.add_argument("--reason", default=None, help="Closeout reason.")
+    p_work_phases_closeout.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_compare = phases_sub.add_parser("compare", help="Compare phase evidence against current local state.")
+    p_work_phases_compare.add_argument("selector", help="Phase id, range such as 201-205, or latest.")
+    p_work_phases_compare.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    p_work_phases_compare.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_reconcile = phases_sub.add_parser(
+        "reconcile", help="Reconcile phase commit and push evidence against local git state."
+    )
+    p_work_phases_reconcile.add_argument("selector", help="Phase id, range such as 211-225, or latest.")
+    p_work_phases_reconcile.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    p_work_phases_reconcile.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_privacy = phases_sub.add_parser(
+        "privacy", help="Scan phase evidence for protected private/reference values."
+    )
+    p_work_phases_privacy.add_argument("selector", help="Phase id, range such as 211-225, or latest.")
+    p_work_phases_privacy.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
+    )
+    p_work_phases_privacy.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_handoff = phases_sub.add_parser("handoff", help="Draft a Memory Handoff from phase evidence.")
+    p_work_phases_handoff.add_argument("selector", help="Phase id, range such as 211-225, or latest.")
+    p_work_phases_handoff.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
+    )
+    p_work_phases_handoff.add_argument("--lint", action="store_true", help="Run handoff lint before returning.")
+    p_work_phases_handoff.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_doctor = phases_sub.add_parser("doctor", help="Check phase execution ledger health.")
+    p_work_phases_doctor.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    p_work_phases_doctor.add_argument(
+        "--range", dest="phase_range", default=None, help="Required phase range, such as 165-170."
+    )
+    p_work_phases_doctor.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_import = phases_sub.add_parser(
+        "import-issues", help="Import phase ledger issues into the work inbox."
+    )
+    p_work_phases_import.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
+    )
+    p_work_phases_import.add_argument("--range", dest="phase_range", default=None, help="Phase range, such as 165-170.")
+    p_work_phases_import.add_argument("--dry-run", action="store_true", help="Report imports without writing them.")
+    p_work_phases_import.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_evidence = phases_sub.add_parser("evidence", help="Attach local evidence metadata to phase records.")
+    phases_evidence_sub = p_work_phases_evidence.add_subparsers(
+        dest="phases_evidence_command", metavar="<phases-evidence-command>"
+    )
+    phases_evidence_sub.required = True
+    p_work_phases_evidence_add = phases_evidence_sub.add_parser("add", help="Attach local evidence to one phase.")
+    p_work_phases_evidence_add.add_argument("phase_id", help="Phase id or unique prefix.")
+    p_work_phases_evidence_add.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
+    )
+    p_work_phases_evidence_add.add_argument(
+        "--file", dest="files_changed", action="append", default=[], help="Changed file path. May be repeated."
+    )
+    p_work_phases_evidence_add.add_argument(
+        "--test", dest="tests_run", action="append", default=[], help="Verification command. May be repeated."
+    )
+    p_work_phases_evidence_add.add_argument("--test-result", default=None, help="Verification result summary.")
+    p_work_phases_evidence_add.add_argument(
+        "--report-id", action="append", default=[], help="Related phase report id. May be repeated."
+    )
+    p_work_phases_evidence_add.add_argument(
+        "--handoff", dest="handoff_paths", action="append", default=[], help="Memory Handoff path. May be repeated."
+    )
+    p_work_phases_evidence_add.add_argument(
+        "--note", dest="notes", action="append", default=[], help="Evidence note. May be repeated."
+    )
+    p_work_phases_evidence_add.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_verify = phases_sub.add_parser("verify", help="Plan and record phase verification metadata.")
+    phases_verify_sub = p_work_phases_verify.add_subparsers(
+        dest="phases_verify_command", metavar="<phases-verify-command>"
+    )
+    phases_verify_sub.required = True
+    p_work_phases_verify_plan = phases_verify_sub.add_parser("plan", help="Plan verification for a phase selector.")
+    p_work_phases_verify_plan.add_argument("selector", help="Phase id, range such as 211-225, or latest.")
+    p_work_phases_verify_plan.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    p_work_phases_verify_plan.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_verify_record = phases_verify_sub.add_parser("record", help="Record one phase verification result.")
+    p_work_phases_verify_record.add_argument("phase_id", help="Phase id or unique prefix.")
+    p_work_phases_verify_record.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
+    )
+    p_work_phases_verify_record.add_argument(
+        "--command", dest="verification_command", required=True, help="Verification command label."
+    )
+    p_work_phases_verify_record.add_argument(
+        "--status", choices=["passed", "failed", "skipped", "deferred"], required=True, help="Verification result."
+    )
+    p_work_phases_verify_record.add_argument("--summary", default=None, help="Verification result summary.")
+    p_work_phases_verify_record.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_actions = phases_sub.add_parser("actions", help="Plan and manage local phase ledger action records.")
+    phases_actions_sub = p_work_phases_actions.add_subparsers(
+        dest="phases_actions_command", metavar="<phases-actions-command>"
+    )
+    phases_actions_sub.required = True
+    p_work_phases_actions_plan = phases_actions_sub.add_parser(
+        "plan", help="Preview phase ledger actions from current issues."
+    )
+    p_work_phases_actions_plan.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    p_work_phases_actions_plan.add_argument(
+        "--range", dest="phase_range", default=None, help="Phase range, such as 201-205."
+    )
+    p_work_phases_actions_plan.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_actions_build = phases_actions_sub.add_parser(
+        "build", help="Build local phase ledger action records."
+    )
+    p_work_phases_actions_build.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
+    )
+    p_work_phases_actions_build.add_argument(
+        "--range", dest="phase_range", default=None, help="Phase range, such as 201-205."
+    )
+    p_work_phases_actions_build.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_actions_list = phases_actions_sub.add_parser("list", help="List local phase ledger actions.")
+    p_work_phases_actions_list.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    p_work_phases_actions_list.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_actions_show = phases_actions_sub.add_parser("show", help="Show one phase ledger action.")
+    p_work_phases_actions_show.add_argument("action_id", help="Action id or unique prefix.")
+    p_work_phases_actions_show.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    p_work_phases_actions_show.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_actions_start = phases_actions_sub.add_parser("start", help="Mark one phase ledger action active.")
+    p_work_phases_actions_start.add_argument("action_id", help="Action id or unique prefix.")
+    p_work_phases_actions_start.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
+    )
+    p_work_phases_actions_start.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_actions_done = phases_actions_sub.add_parser("done", help="Mark one phase ledger action done.")
+    p_work_phases_actions_done.add_argument("action_id", help="Action id or unique prefix.")
+    p_work_phases_actions_done.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
+    )
+    p_work_phases_actions_done.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_actions_defer = phases_actions_sub.add_parser("defer", help="Defer one phase ledger action.")
+    p_work_phases_actions_defer.add_argument("action_id", help="Action id or unique prefix.")
+    p_work_phases_actions_defer.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
+    )
+    p_work_phases_actions_defer.add_argument("--reason", required=True, help="Deferral reason.")
+    p_work_phases_actions_defer.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_actions_archive = phases_actions_sub.add_parser("archive", help="Archive phase ledger actions.")
+    p_work_phases_actions_archive.add_argument("action_id", nargs="?", default=None, help="Action id or unique prefix.")
+    p_work_phases_actions_archive.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
+    )
+    p_work_phases_actions_archive.add_argument(
+        "--completed", action="store_true", help="Archive done and deferred actions."
+    )
+    p_work_phases_actions_archive.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_actions_import = phases_actions_sub.add_parser(
+        "import-issues", help="Import open phase actions into the work inbox."
+    )
+    p_work_phases_actions_import.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
+    )
+    p_work_phases_actions_import.add_argument(
+        "--dry-run", action="store_true", help="Report imports without writing them."
+    )
+    p_work_phases_actions_import.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_goal = phases_sub.add_parser("goal", help="Draft reviewed phase goal prompts.")
+    phases_goal_sub = p_work_phases_goal.add_subparsers(dest="phases_goal_command", metavar="<phases-goal-command>")
+    phases_goal_sub.required = True
+    p_work_phases_goal_scaffold = phases_goal_sub.add_parser(
+        "scaffold", help="Draft a local goal prompt from phase ledger state."
+    )
+    p_work_phases_goal_scaffold.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
+    )
+    p_work_phases_goal_scaffold.add_argument(
+        "--range", dest="phase_range", required=True, help="Phase range, such as 211-225."
+    )
+    p_work_phases_goal_scaffold.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_report = phases_sub.add_parser("report", help="Build and inspect phase ledger reports.")
+    phases_report_sub = p_work_phases_report.add_subparsers(
+        dest="phases_report_command", metavar="<phases-report-command>"
+    )
+    phases_report_sub.required = True
+    p_work_phases_report_build = phases_report_sub.add_parser("build", help="Build a local phase ledger report.")
+    p_work_phases_report_build.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
+    )
+    p_work_phases_report_build.add_argument(
+        "--range", dest="phase_range", default=None, help="Phase range, such as 165-170."
+    )
+    p_work_phases_report_build.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_report_list = phases_report_sub.add_parser("list", help="List phase ledger reports.")
+    p_work_phases_report_list.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    p_work_phases_report_list.add_argument("--limit", type=int, default=20, help="Maximum reports to list.")
+    p_work_phases_report_list.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_report_show = phases_report_sub.add_parser("show", help="Show one phase ledger report.")
+    p_work_phases_report_show.add_argument("report_id", help="Report id, unique prefix, or latest.")
+    p_work_phases_report_show.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    p_work_phases_report_show.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_report_closeout = phases_report_sub.add_parser("closeout", help="Close out one phase ledger report.")
+    p_work_phases_report_closeout.add_argument("report_id", help="Report id, unique prefix, or latest.")
+    p_work_phases_report_closeout.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
+    )
+    p_work_phases_report_closeout.add_argument(
+        "--status",
+        choices=["reviewed", "deferred", "superseded", "archived"],
+        default="reviewed",
+        help="Report closeout state.",
+    )
+    p_work_phases_report_closeout.add_argument("--reason", default=None, help="Closeout reason.")
+    p_work_phases_report_closeout.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_report_compare = phases_report_sub.add_parser(
+        "compare", help="Compare one phase ledger report against current state."
+    )
+    p_work_phases_report_compare.add_argument("report_id", help="Report id, unique prefix, or latest.")
+    p_work_phases_report_compare.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    p_work_phases_report_compare.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_session = phases_sub.add_parser("session", help="Start and review phase execution sessions.")
+    phases_session_sub = p_work_phases_session.add_subparsers(
+        dest="phases_session_command", metavar="<phases-session-command>"
+    )
+    phases_session_sub.required = True
+    p_work_phases_session_start = phases_session_sub.add_parser("start", help="Start a local phase execution session.")
+    p_work_phases_session_start.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
+    )
+    p_work_phases_session_start.add_argument(
+        "--range", dest="phase_range", required=True, help="Phase range, such as 211-225."
+    )
+    p_work_phases_session_start.add_argument("--goal", dest="source_goal", default=None, help="Source goal text.")
+    p_work_phases_session_start.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_session_list = phases_session_sub.add_parser("list", help="List phase execution sessions.")
+    p_work_phases_session_list.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    p_work_phases_session_list.add_argument("--limit", type=int, default=20, help="Maximum sessions to list.")
+    p_work_phases_session_list.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_session_show = phases_session_sub.add_parser("show", help="Show one phase execution session.")
+    p_work_phases_session_show.add_argument("session_id", help="Session id, unique prefix, or latest.")
+    p_work_phases_session_show.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    p_work_phases_session_show.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_session_checkpoint = phases_session_sub.add_parser(
+        "checkpoint", help="Record a local phase session checkpoint."
+    )
+    p_work_phases_session_checkpoint.add_argument(
+        "session_id", nargs="?", default="latest", help="Session id, unique prefix, or latest."
+    )
+    p_work_phases_session_checkpoint.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
+    )
+    p_work_phases_session_checkpoint.add_argument("--phase-id", default=None, help="Phase id for the checkpoint.")
+    p_work_phases_session_checkpoint.add_argument(
+        "--status", choices=["noted", "blocked", "recovered"], default="noted", help="Checkpoint state."
+    )
+    p_work_phases_session_checkpoint.add_argument("--summary", default=None, help="Safe checkpoint summary.")
+    p_work_phases_session_checkpoint.add_argument(
+        "--note", dest="notes", action="append", default=[], help="Safe local note. May be repeated."
+    )
+    p_work_phases_session_checkpoint.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_session_checkpoints = phases_session_sub.add_parser(
+        "checkpoints", help="List and inspect phase session checkpoints."
+    )
+    phases_session_checkpoints_sub = p_work_phases_session_checkpoints.add_subparsers(
+        dest="phases_session_checkpoints_command", metavar="<phases-session-checkpoints-command>"
+    )
+    phases_session_checkpoints_sub.required = True
+    p_work_phases_session_checkpoints_list = phases_session_checkpoints_sub.add_parser(
+        "list", help="List phase session checkpoints."
+    )
+    p_work_phases_session_checkpoints_list.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    p_work_phases_session_checkpoints_list.add_argument(
+        "--session", dest="session_id", default=None, help="Limit to one session id, prefix, or latest."
+    )
+    p_work_phases_session_checkpoints_list.add_argument(
+        "--limit", type=int, default=20, help="Maximum checkpoints to list."
+    )
+    p_work_phases_session_checkpoints_list.add_argument(
+        "--json", action="store_true", help="Print machine-readable JSON."
+    )
+    p_work_phases_session_checkpoints_show = phases_session_checkpoints_sub.add_parser(
+        "show", help="Show one phase session checkpoint."
+    )
+    p_work_phases_session_checkpoints_show.add_argument(
+        "checkpoint_id", help="Checkpoint id, unique prefix, or latest."
+    )
+    p_work_phases_session_checkpoints_show.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    p_work_phases_session_checkpoints_show.add_argument(
+        "--json", action="store_true", help="Print machine-readable JSON."
+    )
+    p_work_phases_session_checkpoints_compare = phases_session_checkpoints_sub.add_parser(
+        "compare", help="Compare one checkpoint against current session state."
+    )
+    p_work_phases_session_checkpoints_compare.add_argument(
+        "checkpoint_id", help="Checkpoint id, unique prefix, or latest."
+    )
+    p_work_phases_session_checkpoints_compare.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    p_work_phases_session_checkpoints_compare.add_argument(
+        "--json", action="store_true", help="Print machine-readable JSON."
+    )
+    p_work_phases_session_checkpoints_import = phases_session_checkpoints_sub.add_parser(
+        "import-issues", help="Import checkpoint blockers into the work inbox."
+    )
+    p_work_phases_session_checkpoints_import.add_argument(
+        "checkpoint_id", nargs="?", default="latest", help="Checkpoint id, unique prefix, or latest."
+    )
+    p_work_phases_session_checkpoints_import.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
+    )
+    p_work_phases_session_checkpoints_import.add_argument(
+        "--dry-run", action="store_true", help="Preview imports without writing them."
+    )
+    p_work_phases_session_checkpoints_import.add_argument(
+        "--json", action="store_true", help="Print machine-readable JSON."
+    )
+    p_work_phases_session_checkpoints_archive = phases_session_checkpoints_sub.add_parser(
+        "archive", help="Archive one phase session checkpoint."
+    )
+    p_work_phases_session_checkpoints_archive.add_argument(
+        "checkpoint_id", help="Checkpoint id, unique prefix, or latest."
+    )
+    p_work_phases_session_checkpoints_archive.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
+    )
+    p_work_phases_session_checkpoints_archive.add_argument(
+        "--json", action="store_true", help="Print machine-readable JSON."
+    )
+    p_work_phases_session_recovery_note = phases_session_sub.add_parser(
+        "recovery-note", help="Record a local phase session recovery note."
+    )
+    p_work_phases_session_recovery_note.add_argument(
+        "session_id", nargs="?", default="latest", help="Session id, unique prefix, or latest."
+    )
+    p_work_phases_session_recovery_note.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
+    )
+    p_work_phases_session_recovery_note.add_argument("--phase-id", default=None, help="Phase id for the recovery note.")
+    p_work_phases_session_recovery_note.add_argument("--summary", default=None, help="Safe recovery note summary.")
+    p_work_phases_session_recovery_note.add_argument(
+        "--note", dest="notes", action="append", default=[], help="Safe local note. May be repeated."
+    )
+    p_work_phases_session_recovery_note.add_argument(
+        "--evidence", action="append", default=[], help="Local evidence label or reference. May be repeated."
+    )
+    p_work_phases_session_recovery_note.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_session_recovery_notes = phases_session_sub.add_parser(
+        "recovery-notes", help="List and inspect phase session recovery notes."
+    )
+    phases_session_recovery_notes_sub = p_work_phases_session_recovery_notes.add_subparsers(
+        dest="phases_session_recovery_notes_command", metavar="<phases-session-recovery-notes-command>"
+    )
+    phases_session_recovery_notes_sub.required = True
+    p_work_phases_session_recovery_notes_list = phases_session_recovery_notes_sub.add_parser(
+        "list", help="List phase session recovery notes."
+    )
+    p_work_phases_session_recovery_notes_list.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    p_work_phases_session_recovery_notes_list.add_argument(
+        "--session", dest="session_id", default=None, help="Limit to one session id, prefix, or latest."
+    )
+    p_work_phases_session_recovery_notes_list.add_argument(
+        "--limit", type=int, default=20, help="Maximum recovery notes to list."
+    )
+    p_work_phases_session_recovery_notes_list.add_argument(
+        "--json", action="store_true", help="Print machine-readable JSON."
+    )
+    p_work_phases_session_recovery_notes_show = phases_session_recovery_notes_sub.add_parser(
+        "show", help="Show one phase session recovery note."
+    )
+    p_work_phases_session_recovery_notes_show.add_argument(
+        "note_id", help="Recovery note id, unique prefix, or latest."
+    )
+    p_work_phases_session_recovery_notes_show.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    p_work_phases_session_recovery_notes_show.add_argument(
+        "--json", action="store_true", help="Print machine-readable JSON."
+    )
+    p_work_phases_session_recovery_notes_closeout = phases_session_recovery_notes_sub.add_parser(
+        "closeout", help="Close out one phase session recovery note."
+    )
+    p_work_phases_session_recovery_notes_closeout.add_argument(
+        "note_id", help="Recovery note id, unique prefix, or latest."
+    )
+    p_work_phases_session_recovery_notes_closeout.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
+    )
+    p_work_phases_session_recovery_notes_closeout.add_argument(
+        "--status",
+        choices=["reviewed", "deferred", "blocked", "archived"],
+        default="reviewed",
+        help="Recovery note closeout state.",
+    )
+    p_work_phases_session_recovery_notes_closeout.add_argument("--reason", default=None, help="Closeout reason.")
+    p_work_phases_session_recovery_notes_closeout.add_argument(
+        "--json", action="store_true", help="Print machine-readable JSON."
+    )
+    p_work_phases_session_risk = phases_session_sub.add_parser("risk", help="Summarize phase session risk.")
+    p_work_phases_session_risk.add_argument(
+        "session_id", nargs="?", default="latest", help="Session id, unique prefix, or latest."
+    )
+    p_work_phases_session_risk.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    p_work_phases_session_risk.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_session_verification = phases_session_sub.add_parser(
+        "verification", help="Summarize phase session verification."
+    )
+    p_work_phases_session_verification.add_argument(
+        "session_id", nargs="?", default="latest", help="Session id, unique prefix, or latest."
+    )
+    p_work_phases_session_verification.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    p_work_phases_session_verification.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_session_privacy = phases_session_sub.add_parser(
+        "privacy", help="Summarize phase session privacy checks."
+    )
+    p_work_phases_session_privacy.add_argument(
+        "session_id", nargs="?", default="latest", help="Session id, unique prefix, or latest."
+    )
+    p_work_phases_session_privacy.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    p_work_phases_session_privacy.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_session_handoffs = phases_session_sub.add_parser(
+        "handoffs", help="Summarize phase session handoff coverage."
+    )
+    p_work_phases_session_handoffs.add_argument(
+        "session_id", nargs="?", default="latest", help="Session id, unique prefix, or latest."
+    )
+    p_work_phases_session_handoffs.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    p_work_phases_session_handoffs.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_session_next = phases_session_sub.add_parser(
+        "next", help="Show the next required phase session step."
+    )
+    p_work_phases_session_next.add_argument(
+        "session_id", nargs="?", default="latest", help="Session id, unique prefix, or latest."
+    )
+    p_work_phases_session_next.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    p_work_phases_session_next.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_session_protocol = phases_session_sub.add_parser(
+        "protocol", help="Show wrapper-safe phase session resume protocol."
+    )
+    p_work_phases_session_protocol.add_argument(
+        "session_id", nargs="?", default="latest", help="Session id, unique prefix, or latest."
+    )
+    p_work_phases_session_protocol.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    p_work_phases_session_protocol.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_session_audit = phases_session_sub.add_parser("audit", help="Self-audit AFK phase session evidence.")
+    p_work_phases_session_audit.add_argument(
+        "session_id", nargs="?", default="latest", help="Session id, unique prefix, or latest."
+    )
+    p_work_phases_session_audit.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    p_work_phases_session_audit.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_session_resume = phases_session_sub.add_parser(
+        "resume", help="Record a safe phase session resume recommendation."
+    )
+    p_work_phases_session_resume.add_argument(
+        "session_id", nargs="?", default="latest", help="Session id, unique prefix, or latest."
+    )
+    p_work_phases_session_resume.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
+    )
+    p_work_phases_session_resume.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_session_closeout = phases_session_sub.add_parser(
+        "closeout", help="Close out one phase execution session."
+    )
+    p_work_phases_session_closeout.add_argument("session_id", help="Session id, unique prefix, or latest.")
+    p_work_phases_session_closeout.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
+    )
+    p_work_phases_session_closeout.add_argument(
+        "--status",
+        choices=["reviewed", "deferred", "blocked", "archived"],
+        default="reviewed",
+        help="Session closeout state.",
+    )
+    p_work_phases_session_closeout.add_argument("--reason", default=None, help="Closeout reason.")
+    p_work_phases_session_closeout.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_session_activity = phases_session_sub.add_parser(
+        "activity", help="Show chronological phase session activity."
+    )
+    p_work_phases_session_activity.add_argument(
+        "session_id", nargs="?", default="latest", help="Session id, unique prefix, or latest."
+    )
+    p_work_phases_session_activity.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    p_work_phases_session_activity.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_session_progress = phases_session_sub.add_parser(
+        "progress", help="Show phase session progress summary."
+    )
+    p_work_phases_session_progress.add_argument(
+        "session_id", nargs="?", default="latest", help="Session id, unique prefix, or latest."
+    )
+    p_work_phases_session_progress.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    p_work_phases_session_progress.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_session_import = phases_session_sub.add_parser(
+        "import-issues", help="Import unresolved phase session blockers into the work inbox."
+    )
+    p_work_phases_session_import.add_argument(
+        "session_id", nargs="?", default="latest", help="Session id, unique prefix, or latest."
+    )
+    p_work_phases_session_import.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
+    )
+    p_work_phases_session_import.add_argument(
+        "--dry-run", action="store_true", help="Preview imports without writing them."
+    )
+    p_work_phases_session_import.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_session_gate = phases_session_sub.add_parser(
+        "gate", help="Check whether a phase session is safe to claim complete."
+    )
+    p_work_phases_session_gate.add_argument(
+        "session_id", nargs="?", default="latest", help="Session id, unique prefix, or latest."
+    )
+    p_work_phases_session_gate.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    p_work_phases_session_gate.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_session_report = phases_session_sub.add_parser(
+        "report", help="Build and inspect phase session reports."
+    )
+    phases_session_report_sub = p_work_phases_session_report.add_subparsers(
+        dest="phases_session_report_command", metavar="<phases-session-report-command>"
+    )
+    phases_session_report_sub.required = True
+    p_work_phases_session_report_build = phases_session_report_sub.add_parser(
+        "build", help="Build a local phase session report."
+    )
+    p_work_phases_session_report_build.add_argument(
+        "session_id", nargs="?", default="latest", help="Session id, unique prefix, or latest."
+    )
+    p_work_phases_session_report_build.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
+    )
+    p_work_phases_session_report_build.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_session_report_list = phases_session_report_sub.add_parser("list", help="List phase session reports.")
+    p_work_phases_session_report_list.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    p_work_phases_session_report_list.add_argument("--limit", type=int, default=20, help="Maximum reports to list.")
+    p_work_phases_session_report_list.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_work_phases_session_report_show = phases_session_report_sub.add_parser(
+        "show", help="Show one phase session report."
+    )
+    p_work_phases_session_report_show.add_argument("report_id", help="Report id, unique prefix, or latest.")
+    p_work_phases_session_report_show.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect."
+    )
+    p_work_phases_session_report_show.add_argument("--json", action="store_true", help="Print machine-readable JSON.")

--- a/src/brigade/daily_cmd.py
+++ b/src/brigade/daily_cmd.py
@@ -32,6 +32,7 @@ from . import (
     work_cmd,
 )
 from .localio import read_json_dict as _read_json, utc_now as _now, write_json as _write_json
+from .render import emit
 
 SCHEMA_VERSION = 1
 RUN_STATUSES = {"reviewed", "deferred", "blocked", "archived"}
@@ -1725,33 +1726,32 @@ def status_payload(target: Path) -> dict[str, Any]:
 
 def status(*, target: Path, json_output: bool = False) -> int:
     payload = status_payload(target)
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-        return 0
-    print(f"daily status: {payload['target']}")
-    print(f"pending_tasks: {payload['pending_task_count']}")
-    print(f"pending_imports: {payload['pending_import_count']}")
-    print(f"center_reviews: {payload['center_review_count']}")
-    print(f"open_actions: {payload['open_daily_action_count']}")
+    lines: list[str] = [
+        f"daily status: {payload['target']}",
+        f"pending_tasks: {payload['pending_task_count']}",
+        f"pending_imports: {payload['pending_import_count']}",
+        f"center_reviews: {payload['center_review_count']}",
+        f"open_actions: {payload['open_daily_action_count']}",
+    ]
     notifications = payload.get("notifications") if isinstance(payload.get("notifications"), dict) else {}
     if notifications:
-        print(f"notifications: {notifications.get('status')} configured={notifications.get('configured')}")
+        lines.append(f"notifications: {notifications.get('status')} configured={notifications.get('configured')}")
     if payload.get("status_section_issue_count"):
-        print(f"status_section_issues: {payload['status_section_issue_count']}")
+        lines.append(f"status_section_issues: {payload['status_section_issue_count']}")
         top = payload.get("top_status_section_issue")
         if isinstance(top, dict):
-            print(f"top_status_section_issue: {top.get('name')} {top.get('detail')}")
+            lines.append(f"top_status_section_issue: {top.get('name')} {top.get('detail')}")
     phase_ledger = payload.get("phase_ledger") if isinstance(payload.get("phase_ledger"), dict) else {}
     if phase_ledger:
-        print(f"phase_records: {phase_ledger.get('record_count', 0)}")
-        print(f"phase_issues: {phase_ledger.get('issue_count', 0)}")
+        lines.append(f"phase_records: {phase_ledger.get('record_count', 0)}")
+        lines.append(f"phase_issues: {phase_ledger.get('issue_count', 0)}")
     phase_session = payload.get("phase_session") if isinstance(payload.get("phase_session"), dict) else None
     if phase_session:
-        print(f"phase_session: {phase_session.get('session_id')} [{phase_session.get('status')}]")
+        lines.append(f"phase_session: {phase_session.get('session_id')} [{phase_session.get('status')}]")
     blocker = payload.get("top_readiness_blocker")
-    print(f"top_readiness_blocker: {blocker.get('safe_summary') if isinstance(blocker, dict) else 'none'}")
-    print(f"next: {payload['next_recommended_command']}")
-    return 0
+    lines.append(f"top_readiness_blocker: {blocker.get('safe_summary') if isinstance(blocker, dict) else 'none'}")
+    lines.append(f"next: {payload['next_recommended_command']}")
+    return emit(payload, json_output, lines, 0)
 
 
 def plan_payload(target: Path, *, record: bool = False) -> dict[str, Any]:
@@ -1815,22 +1815,21 @@ def plan_payload(target: Path, *, record: bool = False) -> dict[str, Any]:
 
 def plan(*, target: Path, record: bool = False, json_output: bool = False) -> int:
     payload = plan_payload(target, record=record)
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-        return 0
-    print(f"daily plan: {payload['target']}")
-    print(f"candidates: {payload['candidate_count']}")
+    lines: list[str] = [
+        f"daily plan: {payload['target']}",
+        f"candidates: {payload['candidate_count']}",
+    ]
     selected = payload.get("selected_action")
     if isinstance(selected, dict):
-        print(f"selected: {selected['action_id']}")
-        print(f"summary: {selected['safe_summary']}")
-        print(f"approval_required: {selected['approval_required']}")
-        print(f"next: {selected['suggested_next_command']}")
+        lines.append(f"selected: {selected['action_id']}")
+        lines.append(f"summary: {selected['safe_summary']}")
+        lines.append(f"approval_required: {selected['approval_required']}")
+        lines.append(f"next: {selected['suggested_next_command']}")
     else:
-        print("selected: none")
+        lines.append("selected: none")
     if record:
-        print(f"recorded: {payload.get('path')}")
-    return 0
+        lines.append(f"recorded: {payload.get('path')}")
+    return emit(payload, json_output, lines, 0)
 
 
 def _review_payload(target: Path, selected: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -1893,24 +1892,21 @@ def _review_payload(target: Path, selected: dict[str, Any] | None = None) -> dic
 
 def review(*, target: Path, json_output: bool = False) -> int:
     payload = _review_payload(target)
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-        return 0
-    print(f"daily review: {payload['target']}")
+    lines: list[str] = [f"daily review: {payload['target']}"]
     if payload.get("selected_action"):
-        print(f"selected: {payload['selected_action']['action_id']}")
-        print(f"summary: {payload['safe_summary']}")
-        print(f"risk: {payload['risk_level']}")
-        print(f"adapter: {payload['selected_adapter']}")
-        print(f"approval: {payload['approval_boundary']}")
+        lines.append(f"selected: {payload['selected_action']['action_id']}")
+        lines.append(f"summary: {payload['safe_summary']}")
+        lines.append(f"risk: {payload['risk_level']}")
+        lines.append(f"adapter: {payload['selected_adapter']}")
+        lines.append(f"approval: {payload['approval_boundary']}")
         if payload.get("config_blockers"):
-            print(f"config_blockers: {len(payload['config_blockers'])}")
+            lines.append(f"config_blockers: {len(payload['config_blockers'])}")
         if payload.get("evidence_blockers"):
-            print(f"evidence_blockers: {len(payload['evidence_blockers'])}")
-        print(f"next: {payload['likely_next_command']}")
+            lines.append(f"evidence_blockers: {len(payload['evidence_blockers'])}")
+        lines.append(f"next: {payload['likely_next_command']}")
     else:
-        print("selected: none")
-    return 0
+        lines.append("selected: none")
+    return emit(payload, json_output, lines, 0)
 
 
 def _latest_run(target: Path) -> dict[str, Any] | None:
@@ -2073,14 +2069,12 @@ def _blocked_run(
             "approval_id": receipt.get("approval_id"),
         },
     )
-    if json_output:
-        print(json.dumps(receipt, indent=2, sort_keys=True))
-    else:
-        print(f"daily run: {receipt['run_id']}")
-        print("status: blocked")
-        for blocker in blockers:
-            print(f"blocker: {blocker}")
-    return 1
+    lines: list[str] = [
+        f"daily run: {receipt['run_id']}",
+        "status: blocked",
+    ]
+    lines.extend(f"blocker: {blocker}" for blocker in blockers)
+    return emit(receipt, json_output, lines, 1)
 
 
 def run(
@@ -2338,14 +2332,13 @@ def run(
             "approval_id": receipt.get("approval_id"),
         },
     )
-    if json_output:
-        print(json.dumps(receipt, indent=2, sort_keys=True))
-    else:
-        print(f"daily run: {run_id}")
-        print(f"status: {receipt['status']}")
-        print(f"selected: {receipt['selected_action_id']}")
-        print(f"next: {receipt['next_recommended_command']}")
-    return rc
+    lines: list[str] = [
+        f"daily run: {run_id}",
+        f"status: {receipt['status']}",
+        f"selected: {receipt['selected_action_id']}",
+        f"next: {receipt['next_recommended_command']}",
+    ]
+    return emit(receipt, json_output, lines, rc)
 
 
 def approvals_payload(target: Path, *, limit: int = 50) -> dict[str, Any]:
@@ -2363,13 +2356,12 @@ def approvals_payload(target: Path, *, limit: int = 50) -> dict[str, Any]:
 
 def approvals_list(*, target: Path, limit: int = 50, json_output: bool = False) -> int:
     payload = approvals_payload(target, limit=limit)
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"daily approvals: {payload['target']}")
-        for approval in payload["approvals"]:
-            print(f"- {approval.get('approval_id')} [{approval.get('status')}] {approval.get('safe_summary')}")
-    return 0
+    lines: list[str] = [f"daily approvals: {payload['target']}"]
+    lines.extend(
+        f"- {approval.get('approval_id')} [{approval.get('status')}] {approval.get('safe_summary')}"
+        for approval in payload["approvals"]
+    )
+    return emit(payload, json_output, lines, 0)
 
 
 def approvals_show(*, target: Path, approval_id: str, json_output: bool = False) -> int:
@@ -2476,14 +2468,12 @@ def approvals_compare_payload(target: Path, approval_id: str) -> dict[str, Any]:
 
 def approvals_compare(*, target: Path, approval_id: str, json_output: bool = False) -> int:
     payload = approvals_compare_payload(target, approval_id)
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"daily approval compare: {approval_id}")
-        print(f"issues: {payload['issue_count']}")
-        for issue in payload["issues"]:
-            print(f"[{issue.get('status')}] {issue.get('name')}: {issue.get('detail')}")
-    return 0 if payload["ok"] else 1
+    lines: list[str] = [
+        f"daily approval compare: {approval_id}",
+        f"issues: {payload['issue_count']}",
+    ]
+    lines.extend(f"[{issue.get('status')}] {issue.get('name')}: {issue.get('detail')}" for issue in payload["issues"])
+    return emit(payload, json_output, lines, 0 if payload["ok"] else 1)
 
 
 def approvals_archive(*, target: Path, consumed: bool = False, json_output: bool = False) -> int:
@@ -2517,12 +2507,11 @@ def approvals_archive(*, target: Path, consumed: bool = False, json_output: bool
         "archived_count": len(archived),
         "parse_errors": errors,
     }
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"daily approval archive: {target}")
-        print(f"archived: {len(archived)}")
-    return 0
+    lines: list[str] = [
+        f"daily approval archive: {target}",
+        f"archived: {len(archived)}",
+    ]
+    return emit(payload, json_output, lines, 0)
 
 
 def init(*, target: Path, force: bool = False, json_output: bool = False) -> int:
@@ -2545,23 +2534,18 @@ def init(*, target: Path, force: bool = False, json_output: bool = False) -> int
             "written": True,
             "config": DEFAULT_CONFIG,
         }
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"daily config: {path}")
-        print(f"written: {payload['written']}")
-    return 0
+    lines: list[str] = [
+        f"daily config: {path}",
+        f"written: {payload['written']}",
+    ]
+    return emit(payload, json_output, lines, 0)
 
 
 def schema(*, target: Path, json_output: bool = False) -> int:
     payload = {"schema_version": SCHEMA_VERSION, "target": str(target.expanduser().resolve()), **_schemas()}
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"daily schema: {payload['target']}")
-        for item in payload["schemas"]:
-            print(f"- {item['name']}")
-    return 0
+    lines: list[str] = [f"daily schema: {payload['target']}"]
+    lines.extend(f"- {item['name']}" for item in payload["schemas"])
+    return emit(payload, json_output, lines, 0)
 
 
 def history_payload(target: Path, *, limit: int = 20) -> dict[str, Any]:
@@ -2582,15 +2566,13 @@ def history_payload(target: Path, *, limit: int = 20) -> dict[str, Any]:
 
 def history(*, target: Path, limit: int = 20, json_output: bool = False) -> int:
     payload = history_payload(target, limit=limit)
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"daily history: {payload['target']}")
-        print(f"runs: {payload['run_count']}")
-        for item in payload["runs"]:
-            print(f"- {item.get('run_id')} [{item.get('status')}] {item.get('started_at')}")
-        print(f"plans: {payload['plan_count']}")
-    return 0
+    lines: list[str] = [
+        f"daily history: {payload['target']}",
+        f"runs: {payload['run_count']}",
+    ]
+    lines.extend(f"- {item.get('run_id')} [{item.get('status')}] {item.get('started_at')}" for item in payload["runs"])
+    lines.append(f"plans: {payload['plan_count']}")
+    return emit(payload, json_output, lines, 0)
 
 
 def show(*, target: Path, run_id: str = "latest", json_output: bool = False) -> int:
@@ -2762,13 +2744,11 @@ def doctor(*, target: Path, json_output: bool = False) -> int:
     payload["checks"] = payload["health"]["checks"]
     payload["issue_count"] = payload["health"]["issue_count"]
     payload["top_issue"] = payload["health"]["top_issue"]
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"daily doctor: {target}")
-        for check in payload["checks"]:
-            print(f"[{check.get('status')}] {check.get('name')}: {check.get('detail')}")
-    return 1 if any(check.get("status") == "fail" for check in payload["checks"]) else 0
+    lines: list[str] = [f"daily doctor: {target}"]
+    lines.extend(f"[{check.get('status')}] {check.get('name')}: {check.get('detail')}" for check in payload["checks"])
+    return emit(
+        payload, json_output, lines, 1 if any(check.get("status") == "fail" for check in payload["checks"]) else 0
+    )
 
 
 def protocol_payload(target: Path) -> dict[str, Any]:
@@ -2815,13 +2795,9 @@ def protocol_payload(target: Path) -> dict[str, Any]:
 
 def protocol(*, target: Path, json_output: bool = False) -> int:
     payload = protocol_payload(target)
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"daily protocol: {payload['target']}")
-        for step in payload["steps"]:
-            print(f"- {step['step']}: {step['command']}")
-    return 0
+    lines: list[str] = [f"daily protocol: {payload['target']}"]
+    lines.extend(f"- {step['step']}: {step['command']}" for step in payload["steps"])
+    return emit(payload, json_output, lines, 0)
 
 
 def _repair_suggestions(target: Path) -> list[dict[str, Any]]:
@@ -2865,13 +2841,11 @@ def repair_payload(target: Path, *, write: bool = True) -> dict[str, Any]:
 
 def repair(*, target: Path, json_output: bool = False) -> int:
     payload = repair_payload(target, write=True)
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"daily repair: {payload['repair_id']}")
-        for suggestion in payload["suggestions"]:
-            print(f"- {suggestion.get('name')}: {suggestion.get('suggested_command')}")
-    return 0
+    lines: list[str] = [f"daily repair: {payload['repair_id']}"]
+    lines.extend(
+        f"- {suggestion.get('name')}: {suggestion.get('suggested_command')}" for suggestion in payload["suggestions"]
+    )
+    return emit(payload, json_output, lines, 0)
 
 
 def unblock_payload(target: Path, *, dry_run: bool = False) -> dict[str, Any]:
@@ -2934,14 +2908,13 @@ def unblock_payload(target: Path, *, dry_run: bool = False) -> dict[str, Any]:
 
 def unblock(*, target: Path, dry_run: bool = False, json_output: bool = False) -> int:
     payload = unblock_payload(target, dry_run=dry_run)
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"daily unblock: {payload['unblock_id']}")
-        print(f"created_imports: {len(payload['created_imports'])}")
-        if payload.get("approval_request"):
-            print(f"approval: {payload['approval_request'].get('approval_id')}")
-    return 1 if payload.get("blockers") else 0
+    lines: list[str] = [
+        f"daily unblock: {payload['unblock_id']}",
+        f"created_imports: {len(payload['created_imports'])}",
+    ]
+    if payload.get("approval_request"):
+        lines.append(f"approval: {payload['approval_request'].get('approval_id')}")
+    return emit(payload, json_output, lines, 1 if payload.get("blockers") else 0)
 
 
 def resume(*, target: Path, json_output: bool = False) -> int:
@@ -3065,25 +3038,22 @@ def telemetry_payload(target: Path) -> dict[str, Any]:
 
 def telemetry(*, target: Path, json_output: bool = False) -> int:
     payload = telemetry_payload(target)
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"daily telemetry: {payload['target']}")
-        print(f"runs: {payload['metrics']['run_count']}")
-        print(f"approvals: {payload['metrics']['approval_frequency']}")
-        print(f"issues: {payload['issue_count']}")
-    return 0
+    lines: list[str] = [
+        f"daily telemetry: {payload['target']}",
+        f"runs: {payload['metrics']['run_count']}",
+        f"approvals: {payload['metrics']['approval_frequency']}",
+        f"issues: {payload['issue_count']}",
+    ]
+    return emit(payload, json_output, lines, 0)
 
 
 def telemetry_doctor(*, target: Path, json_output: bool = False) -> int:
     payload = telemetry_payload(target)
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"daily telemetry doctor: {payload['target']}")
-        for check in payload["checks"]:
-            print(f"[{check.get('status')}] {check.get('name')}: {check.get('detail')}")
-    return 1 if any(check.get("status") == "fail" for check in payload["checks"]) else 0
+    lines: list[str] = [f"daily telemetry doctor: {payload['target']}"]
+    lines.extend(f"[{check.get('status')}] {check.get('name')}: {check.get('detail')}" for check in payload["checks"])
+    return emit(
+        payload, json_output, lines, 1 if any(check.get("status") == "fail" for check in payload["checks"]) else 0
+    )
 
 
 def hardening_plan_payload(target: Path) -> dict[str, Any]:
@@ -3120,14 +3090,12 @@ def hardening_plan_payload(target: Path) -> dict[str, Any]:
 
 def hardening_plan(*, target: Path, json_output: bool = False) -> int:
     payload = hardening_plan_payload(target)
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"daily hardening plan: {payload['target']}")
-        print(f"phases: {payload['phase_count']}")
-        for stream in payload["workstreams"]:
-            print(f"- {stream['phase_start']}-{stream['phase_end']} {stream['id']}")
-    return 0
+    lines: list[str] = [
+        f"daily hardening plan: {payload['target']}",
+        f"phases: {payload['phase_count']}",
+    ]
+    lines.extend(f"- {stream['phase_start']}-{stream['phase_end']} {stream['id']}" for stream in payload["workstreams"])
+    return emit(payload, json_output, lines, 0)
 
 
 def _hardening_finding(
@@ -3716,14 +3684,15 @@ def hardening_audit_payload(target: Path) -> dict[str, Any]:
 
 def hardening_audit(*, target: Path, json_output: bool = False) -> int:
     payload = hardening_audit_payload(target)
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"daily hardening audit: {payload['target']}")
-        print(f"findings: {payload['finding_count']}")
-        for finding in payload["findings"][:10]:
-            print(f"- [{finding['severity']}] {finding['finding_id']}: {finding['safe_summary']}")
-    return 0
+    lines: list[str] = [
+        f"daily hardening audit: {payload['target']}",
+        f"findings: {payload['finding_count']}",
+    ]
+    lines.extend(
+        f"- [{finding['severity']}] {finding['finding_id']}: {finding['safe_summary']}"
+        for finding in payload["findings"][:10]
+    )
+    return emit(payload, json_output, lines, 0)
 
 
 def hardening_import_issues(*, target: Path, dry_run: bool = False, json_output: bool = False) -> int:
@@ -3771,14 +3740,13 @@ def hardening_import_issues(*, target: Path, dry_run: bool = False, json_output:
         "skipped_count": len(skipped),
         "dismissed_count": len(skipped_dismissed),
     }
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"daily hardening import-issues: {target}")
-        print(f"created: {len(created)}")
-        print(f"skipped: {len(skipped)}")
-        print(f"dismissed: {len(skipped_dismissed)}")
-    return 0
+    lines: list[str] = [
+        f"daily hardening import-issues: {target}",
+        f"created: {len(created)}",
+        f"skipped: {len(skipped)}",
+        f"dismissed: {len(skipped_dismissed)}",
+    ]
+    return emit(payload, json_output, lines, 0)
 
 
 def hardening_closeout(

--- a/src/brigade/phases_cmd.py
+++ b/src/brigade/phases_cmd.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 from .localio import read_json_dict as _read_json, utc_now as _now, write_json as _write_json
+from .render import emit
 
 SCHEMA_VERSION = 1
 PHASE_STATUSES = {"pending", "in-progress", "implemented", "verified", "committed", "pushed", "deferred", "blocked"}
@@ -399,14 +400,12 @@ def schema(*, target: Path, json_output: bool = False) -> int:
         "completion_rule": "A phase is complete only with evidence or an explicit deferral.",
         "no_silent_compression": True,
     }
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase ledger schema: {target}")
-        print("no_silent_compression: true")
-        for item in payload["schemas"]:
-            print(f"- {item['name']}")
-    return 0
+    lines = []
+    lines.append(f"phase ledger schema: {target}")
+    lines.append("no_silent_compression: true")
+    for item in payload["schemas"]:
+        lines.append(f"- {item['name']}")
+    return emit(payload, json_output, lines, 0)
 
 
 def init(*, target: Path, json_output: bool = False) -> int:
@@ -432,12 +431,10 @@ def init(*, target: Path, json_output: bool = False) -> int:
         "path": str(_root(target)),
         "written": written,
     }
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase ledger: {_root(target)}")
-        print(f"written: {str(written).lower()}")
-    return 0
+    lines = []
+    lines.append(f"phase ledger: {_root(target)}")
+    lines.append(f"written: {str(written).lower()}")
+    return emit(payload, json_output, lines, 0)
 
 
 def plan(
@@ -521,14 +518,12 @@ def plan(
         "skipped_count": len(skipped),
         "suggested_next_command": "brigade work phases list",
     }
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"planned: {len(created)}")
-        print(f"skipped: {len(skipped)}")
-        for item in created:
-            print(f"- {item['phase_id']} [{item['status']}] {item['title']}")
-    return 0
+    lines = []
+    lines.append(f"planned: {len(created)}")
+    lines.append(f"skipped: {len(skipped)}")
+    for item in created:
+        lines.append(f"- {item['phase_id']} [{item['status']}] {item['title']}")
+    return emit(payload, json_output, lines, 0)
 
 
 def list_phases(*, target: Path, json_output: bool = False) -> int:
@@ -541,13 +536,11 @@ def list_phases(*, target: Path, json_output: bool = False) -> int:
         "records": records,
         "record_count": len(records),
     }
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase ledger: {target}")
-        for record in records:
-            print(f"- {record.get('phase_id')} [{record.get('status')}] {record.get('title')}")
-    return 0
+    lines = []
+    lines.append(f"phase ledger: {target}")
+    for record in records:
+        lines.append(f"- {record.get('phase_id')} [{record.get('status')}] {record.get('title')}")
+    return emit(payload, json_output, lines, 0)
 
 
 def status_payload(target: Path, *, phase_range: str | None = None) -> dict[str, Any]:
@@ -628,11 +621,9 @@ def next_phase(*, target: Path, phase_range: str | None = None, json_output: boo
     payload = status_payload(target, phase_range=phase_range)
     next_record = payload.get("next_phase")
     if not isinstance(next_record, dict):
-        if json_output:
-            print(json.dumps({**payload, "found": False}, indent=2, sort_keys=True))
-        else:
-            print("next phase: none")
-        return 1
+        lines = []
+        lines.append("next phase: none")
+        return emit({**payload, "found": False}, json_output, lines, 1)
     out = {
         "schema_version": SCHEMA_VERSION,
         "schema": _schema("phase-ledger-next"),
@@ -641,13 +632,11 @@ def next_phase(*, target: Path, phase_range: str | None = None, json_output: boo
         "phase": next_record,
         "suggested_next_command": payload["suggested_next_command"],
     }
-    if json_output:
-        print(json.dumps(out, indent=2, sort_keys=True))
-    else:
-        print(f"next phase: {next_record.get('phase_id')}")
-        print(f"status: {next_record.get('status')}")
-        print(f"next: {out['suggested_next_command']}")
-    return 0
+    lines = []
+    lines.append(f"next phase: {next_record.get('phase_id')}")
+    lines.append(f"status: {next_record.get('status')}")
+    lines.append(f"next: {out['suggested_next_command']}")
+    return emit(out, json_output, lines, 0)
 
 
 def show(*, target: Path, phase_id: str, json_output: bool = False) -> int:
@@ -657,15 +646,13 @@ def show(*, target: Path, phase_id: str, json_output: bool = False) -> int:
         print(f"error: phase record not found: {phase_id}", file=sys.stderr)
         return 1
     record["path"] = str(path)
-    if json_output:
-        print(json.dumps(record, indent=2, sort_keys=True))
-    else:
-        print(f"phase: {record.get('phase_id')}")
-        print(f"status: {record.get('status')}")
-        print(f"title: {record.get('title')}")
-        print(f"summary: {record.get('implementation_summary') or 'none'}")
-        print(f"next: {record.get('next_phase_recommendation') or 'none'}")
-    return 0
+    lines = []
+    lines.append(f"phase: {record.get('phase_id')}")
+    lines.append(f"status: {record.get('status')}")
+    lines.append(f"title: {record.get('title')}")
+    lines.append(f"summary: {record.get('implementation_summary') or 'none'}")
+    lines.append(f"next: {record.get('next_phase_recommendation') or 'none'}")
+    return emit(record, json_output, lines, 0)
 
 
 def start(*, target: Path, phase_id: str, json_output: bool = False) -> int:
@@ -679,12 +666,10 @@ def start(*, target: Path, phase_id: str, json_output: bool = False) -> int:
     record["updated_at"] = _now().isoformat()
     record["path"] = str(path)
     _write_json(path, record)
-    if json_output:
-        print(json.dumps(record, indent=2, sort_keys=True))
-    else:
-        print(f"phase: {record.get('phase_id')}")
-        print("status: in-progress")
-    return 0
+    lines = []
+    lines.append(f"phase: {record.get('phase_id')}")
+    lines.append("status: in-progress")
+    return emit(record, json_output, lines, 0)
 
 
 def complete(
@@ -731,13 +716,11 @@ def complete(
         record["next_phase_recommendation"] = next_phase_recommendation
     record["path"] = str(path)
     _write_json(path, record)
-    if json_output:
-        print(json.dumps(record, indent=2, sort_keys=True))
-    else:
-        print(f"phase: {record.get('phase_id')}")
-        print(f"status: {status}")
-        print(f"tests: {len(record.get('tests_run') or [])}")
-    return 0
+    lines = []
+    lines.append(f"phase: {record.get('phase_id')}")
+    lines.append(f"status: {status}")
+    lines.append(f"tests: {len(record.get('tests_run') or [])}")
+    return emit(record, json_output, lines, 0)
 
 
 def defer(
@@ -759,13 +742,11 @@ def defer(
         record["next_phase_recommendation"] = next_phase_recommendation
     record["path"] = str(path)
     _write_json(path, record)
-    if json_output:
-        print(json.dumps(record, indent=2, sort_keys=True))
-    else:
-        print(f"phase: {record.get('phase_id')}")
-        print("status: deferred")
-        print(f"reason: {reason}")
-    return 0
+    lines = []
+    lines.append(f"phase: {record.get('phase_id')}")
+    lines.append("status: deferred")
+    lines.append(f"reason: {reason}")
+    return emit(record, json_output, lines, 0)
 
 
 def _parse_time(value: object) -> datetime | None:
@@ -1238,14 +1219,12 @@ def session_start(*, target: Path, phase_range: str, source_goal: str | None = N
     path = _sessions_root(target) / f"{payload['session_id']}.json"
     payload["path"] = str(path)
     _write_json(path, payload)
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase session: {payload['session_id']}")
-        print(f"range: {payload['phase_range']}")
-        print(f"current: {payload.get('current_phase_id') or 'none'}")
-        print(f"next: {payload['next_recommended_command']}")
-    return 0
+    lines = []
+    lines.append(f"phase session: {payload['session_id']}")
+    lines.append(f"range: {payload['phase_range']}")
+    lines.append(f"current: {payload.get('current_phase_id') or 'none'}")
+    lines.append(f"next: {payload['next_recommended_command']}")
+    return emit(payload, json_output, lines, 0)
 
 
 def session_list(*, target: Path, limit: int = 20, json_output: bool = False) -> int:
@@ -1258,13 +1237,11 @@ def session_list(*, target: Path, limit: int = 20, json_output: bool = False) ->
         "sessions": sessions,
         "session_count": len(sessions),
     }
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase sessions: {len(sessions)}")
-        for session in sessions:
-            print(f"- {session.get('session_id')} [{session.get('status')}] range={session.get('phase_range')}")
-    return 0
+    lines = []
+    lines.append(f"phase sessions: {len(sessions)}")
+    for session in sessions:
+        lines.append(f"- {session.get('session_id')} [{session.get('status')}] range={session.get('phase_range')}")
+    return emit(payload, json_output, lines, 0)
 
 
 def session_show(*, target: Path, session_id: str, json_output: bool = False) -> int:
@@ -1273,15 +1250,13 @@ def session_show(*, target: Path, session_id: str, json_output: bool = False) ->
     if session is None:
         print(f"error: {error}", file=sys.stderr)
         return 1
-    if json_output:
-        print(json.dumps(session, indent=2, sort_keys=True))
-    else:
-        print(f"phase session: {session.get('session_id')}")
-        print(f"status: {session.get('status')}")
-        print(f"range: {session.get('phase_range')}")
-        print(f"current: {session.get('current_phase_id') or 'none'}")
-        print(f"next: {session.get('next_recommended_command') or 'none'}")
-    return 0
+    lines = []
+    lines.append(f"phase session: {session.get('session_id')}")
+    lines.append(f"status: {session.get('status')}")
+    lines.append(f"range: {session.get('phase_range')}")
+    lines.append(f"current: {session.get('current_phase_id') or 'none'}")
+    lines.append(f"next: {session.get('next_recommended_command') or 'none'}")
+    return emit(session, json_output, lines, 0)
 
 
 def session_checkpoint(
@@ -1346,15 +1321,13 @@ def session_checkpoint(
     session["updated_at"] = created_at
     session["path"] = str(path)
     _write_json(path, session)
-    if json_output:
-        print(json.dumps(record, indent=2, sort_keys=True))
-    else:
-        print(f"phase session checkpoint: {checkpoint_id}")
-        print(f"session: {session.get('session_id')}")
-        print(f"phase: {selected_phase_id or 'none'}")
-        print(f"status: {status}")
-        print(f"next: {record['suggested_next_command']}")
-    return 0
+    lines = []
+    lines.append(f"phase session checkpoint: {checkpoint_id}")
+    lines.append(f"session: {session.get('session_id')}")
+    lines.append(f"phase: {selected_phase_id or 'none'}")
+    lines.append(f"status: {status}")
+    lines.append(f"next: {record['suggested_next_command']}")
+    return emit(record, json_output, lines, 0)
 
 
 def session_checkpoint_list(
@@ -1383,15 +1356,13 @@ def session_checkpoint_list(
         if summaries
         else "brigade work phases session checkpoint latest",
     }
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase session checkpoints: {len(summaries)}")
-        for checkpoint in summaries:
-            print(
-                f"- {checkpoint.get('checkpoint_id')} [{checkpoint.get('status')}] phase={checkpoint.get('phase_id') or 'none'}"
-            )
-    return 0
+    lines = []
+    lines.append(f"phase session checkpoints: {len(summaries)}")
+    for checkpoint in summaries:
+        lines.append(
+            f"- {checkpoint.get('checkpoint_id')} [{checkpoint.get('status')}] phase={checkpoint.get('phase_id') or 'none'}"
+        )
+    return emit(payload, json_output, lines, 0)
 
 
 def session_checkpoint_show(*, target: Path, checkpoint_id: str, json_output: bool = False) -> int:
@@ -1400,16 +1371,14 @@ def session_checkpoint_show(*, target: Path, checkpoint_id: str, json_output: bo
     if checkpoint is None:
         print(f"error: {error}", file=sys.stderr)
         return 1
-    if json_output:
-        print(json.dumps(checkpoint, indent=2, sort_keys=True))
-    else:
-        print(f"phase session checkpoint: {checkpoint.get('checkpoint_id')}")
-        print(f"session: {checkpoint.get('session_id')}")
-        print(f"phase: {checkpoint.get('phase_id') or 'none'}")
-        print(f"status: {checkpoint.get('status')}")
-        print(f"summary: {checkpoint.get('summary')}")
-        print(f"next: {checkpoint.get('suggested_next_command') or 'none'}")
-    return 0
+    lines = []
+    lines.append(f"phase session checkpoint: {checkpoint.get('checkpoint_id')}")
+    lines.append(f"session: {checkpoint.get('session_id')}")
+    lines.append(f"phase: {checkpoint.get('phase_id') or 'none'}")
+    lines.append(f"status: {checkpoint.get('status')}")
+    lines.append(f"summary: {checkpoint.get('summary')}")
+    lines.append(f"next: {checkpoint.get('suggested_next_command') or 'none'}")
+    return emit(checkpoint, json_output, lines, 0)
 
 
 def _session_checkpoint_compare_payload(target: Path, checkpoint: dict[str, Any]) -> dict[str, Any]:
@@ -1519,15 +1488,13 @@ def session_checkpoint_compare(*, target: Path, checkpoint_id: str, json_output:
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase session checkpoint compare: {payload['checkpoint_id']}")
-        print(f"issues: {payload['issue_count']}")
-        if payload.get("top_issue"):
-            print(f"top: {payload['top_issue']['name']}")
-        print(f"next: {payload['suggested_next_command']}")
-    return 0
+    lines = []
+    lines.append(f"phase session checkpoint compare: {payload['checkpoint_id']}")
+    lines.append(f"issues: {payload['issue_count']}")
+    if payload.get("top_issue"):
+        lines.append(f"top: {payload['top_issue']['name']}")
+    lines.append(f"next: {payload['suggested_next_command']}")
+    return emit(payload, json_output, lines, 0)
 
 
 def _checkpoint_issue_import_records(
@@ -1638,14 +1605,12 @@ def session_checkpoint_import_issues(
         if records
         else "brigade work phases session checkpoints show latest",
     }
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase session checkpoint imports: {payload['checkpoint_id']}")
-        print(f"created: {payload['created_count']}")
-        print(f"skipped: {payload['skipped_count']}")
-        print(f"dismissed: {payload['dismissed_count']}")
-    return 0
+    lines = []
+    lines.append(f"phase session checkpoint imports: {payload['checkpoint_id']}")
+    lines.append(f"created: {payload['created_count']}")
+    lines.append(f"skipped: {payload['skipped_count']}")
+    lines.append(f"dismissed: {payload['dismissed_count']}")
+    return emit(payload, json_output, lines, 0)
 
 
 def session_recovery_note(
@@ -1712,14 +1677,12 @@ def session_recovery_note(
     session["updated_at"] = created_at
     session["path"] = str(path)
     _write_json(path, session)
-    if json_output:
-        print(json.dumps(record, indent=2, sort_keys=True))
-    else:
-        print(f"phase session recovery note: {note_id}")
-        print(f"session: {session.get('session_id')}")
-        print(f"phase: {selected_phase_id or 'none'}")
-        print(f"summary: {record['summary']}")
-    return 0
+    lines = []
+    lines.append(f"phase session recovery note: {note_id}")
+    lines.append(f"session: {session.get('session_id')}")
+    lines.append(f"phase: {selected_phase_id or 'none'}")
+    lines.append(f"summary: {record['summary']}")
+    return emit(record, json_output, lines, 0)
 
 
 def session_recovery_note_list(
@@ -1748,13 +1711,11 @@ def session_recovery_note_list(
         if summaries
         else "brigade work phases session recovery-note latest",
     }
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase session recovery notes: {len(summaries)}")
-        for note in summaries:
-            print(f"- {note.get('note_id')} [{note.get('status')}] phase={note.get('phase_id') or 'none'}")
-    return 0
+    lines = []
+    lines.append(f"phase session recovery notes: {len(summaries)}")
+    for note in summaries:
+        lines.append(f"- {note.get('note_id')} [{note.get('status')}] phase={note.get('phase_id') or 'none'}")
+    return emit(payload, json_output, lines, 0)
 
 
 def session_recovery_note_show(*, target: Path, note_id: str, json_output: bool = False) -> int:
@@ -1763,15 +1724,13 @@ def session_recovery_note_show(*, target: Path, note_id: str, json_output: bool 
     if note is None:
         print(f"error: {error}", file=sys.stderr)
         return 1
-    if json_output:
-        print(json.dumps(note, indent=2, sort_keys=True))
-    else:
-        print(f"phase session recovery note: {note.get('note_id')}")
-        print(f"session: {note.get('session_id')}")
-        print(f"phase: {note.get('phase_id') or 'none'}")
-        print(f"status: {note.get('status')}")
-        print(f"summary: {note.get('summary')}")
-    return 0
+    lines = []
+    lines.append(f"phase session recovery note: {note.get('note_id')}")
+    lines.append(f"session: {note.get('session_id')}")
+    lines.append(f"phase: {note.get('phase_id') or 'none'}")
+    lines.append(f"status: {note.get('status')}")
+    lines.append(f"summary: {note.get('summary')}")
+    return emit(note, json_output, lines, 0)
 
 
 def session_recovery_note_closeout(
@@ -1820,13 +1779,11 @@ def session_recovery_note_closeout(
         "closeout": closeout,
         "suggested_next_command": "brigade work phases session recovery-notes list",
     }
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase session recovery note closeout: {note.get('note_id')}")
-        print(f"status: {status}")
-        print(f"reason: {closeout['reason']}")
-    return 0
+    lines = []
+    lines.append(f"phase session recovery note closeout: {note.get('note_id')}")
+    lines.append(f"status: {status}")
+    lines.append(f"reason: {closeout['reason']}")
+    return emit(payload, json_output, lines, 0)
 
 
 def _session_risk_payload(target: Path, session: dict[str, Any]) -> dict[str, Any]:
@@ -1935,16 +1892,14 @@ def session_risk(*, target: Path, session_id: str, json_output: bool = False) ->
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase session risk: {payload['session_id']}")
-        print(f"risk: {payload['risk_level']}")
-        print(f"issues: {payload['risk_count']}")
-        if payload.get("top_risk"):
-            print(f"top: {payload['top_risk']['name']}")
-        print(f"next: {payload['suggested_next_command']}")
-    return 0
+    lines = []
+    lines.append(f"phase session risk: {payload['session_id']}")
+    lines.append(f"risk: {payload['risk_level']}")
+    lines.append(f"issues: {payload['risk_count']}")
+    if payload.get("top_risk"):
+        lines.append(f"top: {payload['top_risk']['name']}")
+    lines.append(f"next: {payload['suggested_next_command']}")
+    return emit(payload, json_output, lines, 0)
 
 
 def _session_verification_payload(target: Path, session: dict[str, Any]) -> dict[str, Any]:
@@ -1998,15 +1953,13 @@ def session_verification(*, target: Path, session_id: str, json_output: bool = F
         print(f"error: {error}", file=sys.stderr)
         return 1
     payload = _session_verification_payload(target, session)
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase session verification: {payload['session_id']}")
-        print(f"records: {payload['record_count']}")
-        print(f"issues: {payload['issue_count']}")
-        print(f"passed: {payload['status_counts'].get('passed', 0)}")
-        print(f"next: {payload['suggested_next_command']}")
-    return 0
+    lines = []
+    lines.append(f"phase session verification: {payload['session_id']}")
+    lines.append(f"records: {payload['record_count']}")
+    lines.append(f"issues: {payload['issue_count']}")
+    lines.append(f"passed: {payload['status_counts'].get('passed', 0)}")
+    lines.append(f"next: {payload['suggested_next_command']}")
+    return emit(payload, json_output, lines, 0)
 
 
 def _latest_privacy_check(record: dict[str, Any]) -> dict[str, Any] | None:
@@ -2076,15 +2029,13 @@ def session_privacy(*, target: Path, session_id: str, json_output: bool = False)
         print(f"error: {error}", file=sys.stderr)
         return 1
     payload = _session_privacy_payload(target, session)
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase session privacy: {payload['session_id']}")
-        print(f"records: {payload['record_count']}")
-        print(f"issues: {payload['issue_count']}")
-        print(f"clean: {payload['status_counts'].get('clean', 0)}")
-        print(f"next: {payload['suggested_next_command']}")
-    return 0
+    lines = []
+    lines.append(f"phase session privacy: {payload['session_id']}")
+    lines.append(f"records: {payload['record_count']}")
+    lines.append(f"issues: {payload['issue_count']}")
+    lines.append(f"clean: {payload['status_counts'].get('clean', 0)}")
+    lines.append(f"next: {payload['suggested_next_command']}")
+    return emit(payload, json_output, lines, 0)
 
 
 def _latest_phase_handoff(record: dict[str, Any]) -> dict[str, Any] | None:
@@ -2166,15 +2117,13 @@ def session_handoffs(*, target: Path, session_id: str, json_output: bool = False
         print(f"error: {error}", file=sys.stderr)
         return 1
     payload = _session_handoffs_payload(target, session)
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase session handoffs: {payload['session_id']}")
-        print(f"records: {payload['record_count']}")
-        print(f"issues: {payload['issue_count']}")
-        print(f"linted: {payload['status_counts'].get('linted', 0)}")
-        print(f"next: {payload['suggested_next_command']}")
-    return 0
+    lines = []
+    lines.append(f"phase session handoffs: {payload['session_id']}")
+    lines.append(f"records: {payload['record_count']}")
+    lines.append(f"issues: {payload['issue_count']}")
+    lines.append(f"linted: {payload['status_counts'].get('linted', 0)}")
+    lines.append(f"next: {payload['suggested_next_command']}")
+    return emit(payload, json_output, lines, 0)
 
 
 def _checkpoint_state_for_session_next(
@@ -2285,13 +2234,11 @@ def session_closeout(
     session["next_recommended_command"] = "brigade work phases session list"
     session["path"] = str(path)
     _write_json(path, session)
-    if json_output:
-        print(json.dumps(session, indent=2, sort_keys=True))
-    else:
-        print(f"phase session closeout: {session.get('session_id')}")
-        print(f"status: {status}")
-        print(f"unresolved: {doctor_data['issue_count']}")
-    return 0
+    lines = []
+    lines.append(f"phase session closeout: {session.get('session_id')}")
+    lines.append(f"status: {status}")
+    lines.append(f"unresolved: {doctor_data['issue_count']}")
+    return emit(session, json_output, lines, 0)
 
 
 def _session_next_payload(target: Path, session: dict[str, Any]) -> dict[str, Any]:
@@ -2590,15 +2537,13 @@ def session_protocol(*, target: Path, session_id: str, json_output: bool = False
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase session protocol: {payload['session_id']}")
-        print(f"safe_resume: {str(payload['safe_resume']).lower()}")
-        print(f"blockers: {payload['resume_blocker_count']}")
-        for step in payload["wrapper_steps"]:
-            print(f"- {step['step']}: {step['command']}")
-    return 0
+    lines = []
+    lines.append(f"phase session protocol: {payload['session_id']}")
+    lines.append(f"safe_resume: {str(payload['safe_resume']).lower()}")
+    lines.append(f"blockers: {payload['resume_blocker_count']}")
+    for step in payload["wrapper_steps"]:
+        lines.append(f"- {step['step']}: {step['command']}")
+    return emit(payload, json_output, lines, 0)
 
 
 def _session_audit_payload(target: Path, session: dict[str, Any]) -> dict[str, Any]:
@@ -2712,15 +2657,13 @@ def session_audit(*, target: Path, session_id: str, json_output: bool = False) -
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase session audit: {payload['session_id']}")
-        print(f"ready_for_resume: {str(payload['ready_for_resume']).lower()}")
-        print(f"ready_for_completion_claim: {str(payload['ready_for_completion_claim']).lower()}")
-        print(f"issues: {payload['issue_count']}")
-        print(f"next: {payload['suggested_next_command']}")
-    return 0
+    lines = []
+    lines.append(f"phase session audit: {payload['session_id']}")
+    lines.append(f"ready_for_resume: {str(payload['ready_for_resume']).lower()}")
+    lines.append(f"ready_for_completion_claim: {str(payload['ready_for_completion_claim']).lower()}")
+    lines.append(f"issues: {payload['issue_count']}")
+    lines.append(f"next: {payload['suggested_next_command']}")
+    return emit(payload, json_output, lines, 0)
 
 
 def session_resume(*, target: Path, session_id: str, json_output: bool = False) -> int:
@@ -2961,13 +2904,11 @@ def session_report_build(*, target: Path, session_id: str, json_output: bool = F
     payload["bundle_files"] = ["SESSION_REPORT.md", "SESSION_EVIDENCE.json"]
     _write_json(report_dir / "SESSION_EVIDENCE.json", payload)
     _write_session_report_markdown(report_dir / "SESSION_REPORT.md", payload)
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase session report: {payload['report_id']}")
-        print(f"session: {payload['session'].get('session_id')}")
-        print(f"issues: {payload['doctor']['issue_count']}")
-    return 0
+    lines = []
+    lines.append(f"phase session report: {payload['report_id']}")
+    lines.append(f"session: {payload['session'].get('session_id')}")
+    lines.append(f"issues: {payload['doctor']['issue_count']}")
+    return emit(payload, json_output, lines, 0)
 
 
 def session_report_list(*, target: Path, limit: int = 20, json_output: bool = False) -> int:
@@ -2994,13 +2935,13 @@ def session_report_list(*, target: Path, limit: int = 20, json_output: bool = Fa
         "reports": reports,
         "report_count": len(reports),
     }
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase session reports: {len(reports)}")
-        for report in reports:
-            print(f"- {report.get('report_id')} session={report.get('session_id')} issues={report.get('issue_count')}")
-    return 0
+    lines = []
+    lines.append(f"phase session reports: {len(reports)}")
+    for report in reports:
+        lines.append(
+            f"- {report.get('report_id')} session={report.get('session_id')} issues={report.get('issue_count')}"
+        )
+    return emit(payload, json_output, lines, 0)
 
 
 def session_report_show(*, target: Path, report_id: str, json_output: bool = False) -> int:
@@ -3009,17 +2950,15 @@ def session_report_show(*, target: Path, report_id: str, json_output: bool = Fal
     if report is None:
         print(f"error: {error}", file=sys.stderr)
         return 1
-    if json_output:
-        print(json.dumps(report, indent=2, sort_keys=True))
-    else:
-        print(f"phase session report: {report.get('report_id')}")
-        print(
-            f"session: {(report.get('session') or {}).get('session_id') if isinstance(report.get('session'), dict) else 'none'}"
-        )
-        print(
-            f"issues: {(report.get('doctor') or {}).get('issue_count') if isinstance(report.get('doctor'), dict) else 0}"
-        )
-    return 0
+    lines = []
+    lines.append(f"phase session report: {report.get('report_id')}")
+    lines.append(
+        f"session: {(report.get('session') or {}).get('session_id') if isinstance(report.get('session'), dict) else 'none'}"
+    )
+    lines.append(
+        f"issues: {(report.get('doctor') or {}).get('issue_count') if isinstance(report.get('doctor'), dict) else 0}"
+    )
+    return emit(report, json_output, lines, 0)
 
 
 def _activity_event(
@@ -3333,16 +3272,14 @@ def session_activity(*, target: Path, session_id: str, json_output: bool = False
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase session activity: {payload['session_id']}")
-        print(f"events: {payload['event_count']}")
-        for event in payload["events"][-20:]:
-            print(
-                f"- {event.get('timestamp')} {event.get('event_type')} {event.get('phase_id') or event.get('local_id')}: {event.get('safe_summary')}"
-            )
-    return 0
+    lines = []
+    lines.append(f"phase session activity: {payload['session_id']}")
+    lines.append(f"events: {payload['event_count']}")
+    for event in payload["events"][-20:]:
+        lines.append(
+            f"- {event.get('timestamp')} {event.get('event_type')} {event.get('phase_id') or event.get('local_id')}: {event.get('safe_summary')}"
+        )
+    return emit(payload, json_output, lines, 0)
 
 
 def _session_progress_payload(target: Path, session: dict[str, Any]) -> dict[str, Any]:
@@ -3406,15 +3343,13 @@ def session_progress(*, target: Path, session_id: str, json_output: bool = False
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase session progress: {payload['session_id']}")
-        print(f"complete: {payload['percent_complete']}%")
-        print(f"current: {payload['current_phase_id'] or 'none'}")
-        print(f"blockers: {payload['blocker_count']}")
-        print(f"next: {payload['suggested_next_command']}")
-    return 0
+    lines = []
+    lines.append(f"phase session progress: {payload['session_id']}")
+    lines.append(f"complete: {payload['percent_complete']}%")
+    lines.append(f"current: {payload['current_phase_id'] or 'none'}")
+    lines.append(f"blockers: {payload['blocker_count']}")
+    lines.append(f"next: {payload['suggested_next_command']}")
+    return emit(payload, json_output, lines, 0)
 
 
 def _session_blocker_fingerprint(*, session_id: object, phase_id: object, issue_type: object, detail: object) -> str:
@@ -3561,13 +3496,11 @@ def session_import_issues(*, target: Path, session_id: str, dry_run: bool = Fals
         "candidate_count": len(candidates),
         "suggested_next_command": "brigade work inbox",
     }
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase session imports: {session.get('session_id')}")
-        print(f"created: {len(created)}")
-        print(f"skipped: {len(skipped)}")
-    return 0
+    lines = []
+    lines.append(f"phase session imports: {session.get('session_id')}")
+    lines.append(f"created: {len(created)}")
+    lines.append(f"skipped: {len(skipped)}")
+    return emit(payload, json_output, lines, 0)
 
 
 def session_checkpoint_archive(*, target: Path, checkpoint_id: str, json_output: bool = False) -> int:
@@ -3604,12 +3537,10 @@ def session_checkpoint_archive(*, target: Path, checkpoint_id: str, json_output:
         "archive_path": str(_session_checkpoints_archive_path(target)),
         "suggested_next_command": "brigade work phases session checkpoints list",
     }
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase session checkpoint archived: {checkpoint.get('checkpoint_id')}")
-        print(f"archive: {_session_checkpoints_archive_path(target)}")
-    return 0
+    lines = []
+    lines.append(f"phase session checkpoint archived: {checkpoint.get('checkpoint_id')}")
+    lines.append(f"archive: {_session_checkpoints_archive_path(target)}")
+    return emit(payload, json_output, lines, 0)
 
 
 def _record_has_clean_privacy(record: dict[str, Any]) -> bool:
@@ -3814,16 +3745,14 @@ def session_gate(*, target: Path, session_id: str, json_output: bool = False) ->
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase session gate: {payload['session_id']}")
-        print(f"safe: {str(payload['safe_to_claim_complete']).lower()}")
-        print(f"blockers: {payload['blocker_count']}")
-        print(f"next: {payload['suggested_next_command']}")
-        for check in payload["checks"]:
-            print(f"[{check['status']}] {check['name']}: {check['detail']}")
-    return 0
+    lines = []
+    lines.append(f"phase session gate: {payload['session_id']}")
+    lines.append(f"safe: {str(payload['safe_to_claim_complete']).lower()}")
+    lines.append(f"blockers: {payload['blocker_count']}")
+    lines.append(f"next: {payload['suggested_next_command']}")
+    for check in payload["checks"]:
+        lines.append(f"[{check['status']}] {check['name']}: {check['detail']}")
+    return emit(payload, json_output, lines, 0)
 
 
 def _goal_scaffold_markdown(payload: dict[str, Any]) -> str:
@@ -3923,14 +3852,12 @@ def goal_scaffold(*, target: Path, phase_range: str, json_output: bool = False) 
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(_goal_scaffold_markdown(payload))
     payload["path"] = str(path)
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase goal scaffold: {goal_id}")
-        print(f"range: {rendered_range}")
-        print(f"path: {path}")
-        print(f"blockers: {payload['blocker_count']}")
-    return 0
+    lines = []
+    lines.append(f"phase goal scaffold: {goal_id}")
+    lines.append(f"range: {rendered_range}")
+    lines.append(f"path: {path}")
+    lines.append(f"blockers: {payload['blocker_count']}")
+    return emit(payload, json_output, lines, 0)
 
 
 def _find_action(target: Path, action_id: str) -> tuple[Path, dict[str, Any] | None]:
@@ -4390,13 +4317,13 @@ def doctor_payload(target: Path, *, phase_range: str | None = None) -> dict[str,
 
 def doctor(*, target: Path, phase_range: str | None = None, json_output: bool = False) -> int:
     payload = doctor_payload(target, phase_range=phase_range)
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase ledger doctor: {payload['target']}")
-        for check in payload["checks"]:
-            print(f"[{check['status']}] {check['name']}: {check['detail']}")
-    return 1 if any(check.get("status") == "fail" for check in payload["checks"]) else 0
+    lines = []
+    lines.append(f"phase ledger doctor: {payload['target']}")
+    for check in payload["checks"]:
+        lines.append(f"[{check['status']}] {check['name']}: {check['detail']}")
+    return emit(
+        payload, json_output, lines, 1 if any(check.get("status") == "fail" for check in payload["checks"]) else 0
+    )
 
 
 def health(target: Path) -> dict[str, Any]:
@@ -4537,14 +4464,12 @@ def closeout(
     path = _closeouts_root(target) / f"{closeout_id}.json"
     payload["path"] = str(path)
     _write_json(path, payload)
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase closeout: {closeout_id}")
-        print(f"status: {status}")
-        print(f"phases: {', '.join(phase_ids)}")
-        print(f"unresolved: {len(selected_issues)}")
-    return 0
+    lines = []
+    lines.append(f"phase closeout: {closeout_id}")
+    lines.append(f"status: {status}")
+    lines.append(f"phases: {', '.join(phase_ids)}")
+    lines.append(f"unresolved: {len(selected_issues)}")
+    return emit(payload, json_output, lines, 0)
 
 
 def evidence_add(
@@ -4585,12 +4510,10 @@ def evidence_add(
     record["updated_at"] = _now().isoformat()
     record["path"] = str(path)
     _write_json(path, record)
-    if json_output:
-        print(json.dumps(record, indent=2, sort_keys=True))
-    else:
-        print(f"phase evidence: {record.get('phase_id')}")
-        print(f"attachments: {len(attachments)}")
-    return 0
+    lines = []
+    lines.append(f"phase evidence: {record.get('phase_id')}")
+    lines.append(f"attachments: {len(attachments)}")
+    return emit(record, json_output, lines, 0)
 
 
 def _verification_entries(record: dict[str, Any]) -> list[dict[str, Any]]:
@@ -4657,14 +4580,12 @@ def verify_plan(*, target: Path, selector: str, json_output: bool = False) -> in
             if records
             else "brigade work phases status",
         }
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase verification plan: {selector}")
-        print(f"records: {payload['record_count']}")
-        for record in payload["records"]:
-            print(f"- {record.get('phase_id')} verification={len(record.get('verification') or [])}")
-    return 0
+    lines = []
+    lines.append(f"phase verification plan: {selector}")
+    lines.append(f"records: {payload['record_count']}")
+    for record in payload["records"]:
+        lines.append(f"- {record.get('phase_id')} verification={len(record.get('verification') or [])}")
+    return emit(payload, json_output, lines, 0)
 
 
 def verify_record(
@@ -4703,12 +4624,10 @@ def verify_record(
         "verification": entries,
         "suggested_next_command": f"brigade work phases verify plan {record.get('phase_id')}",
     }
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase verification: {record.get('phase_id')}")
-        print(f"status: {status}")
-    return 0
+    lines = []
+    lines.append(f"phase verification: {record.get('phase_id')}")
+    lines.append(f"status: {status}")
+    return emit(payload, json_output, lines, 0)
 
 
 def reconcile(*, target: Path, selector: str, json_output: bool = False) -> int:
@@ -4797,14 +4716,12 @@ def reconcile(*, target: Path, selector: str, json_output: bool = False) -> int:
         "top_issue": issues[0] if issues else None,
         "suggested_next_command": issues[0]["suggested_next_command"] if issues else "brigade work phases status",
     }
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase reconcile: {selector}")
-        print(f"records: {len(records)}")
-        for check in checks:
-            print(f"[{check['status']}] {check['name']}: {check['detail']}")
-    return 0
+    lines = []
+    lines.append(f"phase reconcile: {selector}")
+    lines.append(f"records: {len(records)}")
+    for check in checks:
+        lines.append(f"[{check['status']}] {check['name']}: {check['detail']}")
+    return emit(payload, json_output, lines, 0)
 
 
 def _privacy_findings_for_text(text: str, *, source: str) -> list[dict[str, Any]]:
@@ -4914,15 +4831,13 @@ def privacy(*, target: Path, selector: str, json_output: bool = False) -> int:
         "status": "blocked" if findings else "clean",
         "suggested_next_command": "brigade work phases privacy " + selector,
     }
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase privacy: {selector}")
-        print(f"status: {payload['status']}")
-        print(f"findings: {len(findings)}")
-        for finding in findings:
-            print(f"[{finding['status']}] {finding['name']}: {finding['source']}")
-    return 1 if findings else 0
+    lines = []
+    lines.append(f"phase privacy: {selector}")
+    lines.append(f"status: {payload['status']}")
+    lines.append(f"findings: {len(findings)}")
+    for finding in findings:
+        lines.append(f"[{finding['status']}] {finding['name']}: {finding['source']}")
+    return emit(payload, json_output, lines, 1 if findings else 0)
 
 
 def _handoff_root(target: Path) -> Path:
@@ -5050,13 +4965,11 @@ def handoff(*, target: Path, selector: str, lint: bool = False, json_output: boo
         "lint": lint_payload,
         "suggested_next_command": f"brigade handoff lint --target . {path}",
     }
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase handoff: {handoff_id}")
-        print(f"path: {path}")
-        print(f"lint: {lint_payload['status']}")
-    return 1 if lint_payload["status"] == "failed" else 0
+    lines = []
+    lines.append(f"phase handoff: {handoff_id}")
+    lines.append(f"path: {path}")
+    lines.append(f"lint: {lint_payload['status']}")
+    return emit(payload, json_output, lines, 1 if lint_payload["status"] == "failed" else 0)
 
 
 def compare(*, target: Path, selector: str, json_output: bool = False) -> int:
@@ -5180,14 +5093,12 @@ def compare(*, target: Path, selector: str, json_output: bool = False) -> int:
         "top_issue": issues[0] if issues else None,
         "suggested_next_command": issues[0]["suggested_next_command"] if issues else "brigade work phases doctor",
     }
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase compare: {selector}")
-        print(f"records: {len(records)}")
-        for check in checks:
-            print(f"[{check['status']}] {check['name']}: {check['detail']}")
-    return 0
+    lines = []
+    lines.append(f"phase compare: {selector}")
+    lines.append(f"records: {len(records)}")
+    for check in checks:
+        lines.append(f"[{check['status']}] {check['name']}: {check['detail']}")
+    return emit(payload, json_output, lines, 0)
 
 
 def actions_plan(*, target: Path, phase_range: str | None = None, json_output: bool = False) -> int:
@@ -5210,13 +5121,11 @@ def actions_plan(*, target: Path, phase_range: str | None = None, json_output: b
         "action_count": len(planned),
         "suggested_next_command": "brigade work phases actions build",
     }
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase actions planned: {len(planned)}")
-        for action in planned:
-            print(f"- {action.get('action_id')} [{action.get('status')}] {action.get('issue_type')}")
-    return 0
+    lines = []
+    lines.append(f"phase actions planned: {len(planned)}")
+    for action in planned:
+        lines.append(f"- {action.get('action_id')} [{action.get('status')}] {action.get('issue_type')}")
+    return emit(payload, json_output, lines, 0)
 
 
 def actions_build(*, target: Path, phase_range: str | None = None, json_output: bool = False) -> int:
@@ -5252,12 +5161,10 @@ def actions_build(*, target: Path, phase_range: str | None = None, json_output: 
         "skipped_count": len(skipped),
         "suggested_next_command": "brigade work phases actions list",
     }
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase actions created: {len(created)}")
-        print(f"phase actions skipped: {len(skipped)}")
-    return 0
+    lines = []
+    lines.append(f"phase actions created: {len(created)}")
+    lines.append(f"phase actions skipped: {len(skipped)}")
+    return emit(payload, json_output, lines, 0)
 
 
 def actions_list(*, target: Path, json_output: bool = False) -> int:
@@ -5270,13 +5177,11 @@ def actions_list(*, target: Path, json_output: bool = False) -> int:
         "actions": actions,
         "action_count": len(actions),
     }
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase actions: {len(actions)}")
-        for action in actions:
-            print(f"- {action.get('action_id')} [{action.get('status')}] {action.get('issue_type')}")
-    return 0
+    lines = []
+    lines.append(f"phase actions: {len(actions)}")
+    for action in actions:
+        lines.append(f"- {action.get('action_id')} [{action.get('status')}] {action.get('issue_type')}")
+    return emit(payload, json_output, lines, 0)
 
 
 def actions_show(*, target: Path, action_id: str, json_output: bool = False) -> int:
@@ -5286,14 +5191,12 @@ def actions_show(*, target: Path, action_id: str, json_output: bool = False) -> 
         print(f"error: phase action not found: {action_id}", file=sys.stderr)
         return 1
     action["path"] = str(path)
-    if json_output:
-        print(json.dumps(action, indent=2, sort_keys=True))
-    else:
-        print(f"phase action: {action.get('action_id')}")
-        print(f"status: {action.get('status')}")
-        print(f"issue: {action.get('issue_type')}")
-        print(f"next: {action.get('suggested_next_command')}")
-    return 0
+    lines = []
+    lines.append(f"phase action: {action.get('action_id')}")
+    lines.append(f"status: {action.get('status')}")
+    lines.append(f"issue: {action.get('issue_type')}")
+    lines.append(f"next: {action.get('suggested_next_command')}")
+    return emit(action, json_output, lines, 0)
 
 
 def _set_action_status(
@@ -5324,12 +5227,10 @@ def _actions_update_status(
     result, action = _set_action_status(target.expanduser().resolve(), action_id, status, reason)
     if result != 0 or action is None:
         return result
-    if json_output:
-        print(json.dumps(action, indent=2, sort_keys=True))
-    else:
-        print(f"phase action: {action.get('action_id')}")
-        print(f"status: {status}")
-    return 0
+    lines = []
+    lines.append(f"phase action: {action.get('action_id')}")
+    lines.append(f"status: {status}")
+    return emit(action, json_output, lines, 0)
 
 
 def actions_start(*, target: Path, action_id: str, json_output: bool = False) -> int:
@@ -5377,11 +5278,9 @@ def actions_archive(
         "archived": archived,
         "archived_count": len(archived),
     }
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase actions archived: {len(archived)}")
-    return 0
+    lines = []
+    lines.append(f"phase actions archived: {len(archived)}")
+    return emit(payload, json_output, lines, 0)
 
 
 def actions_import_issues(*, target: Path, dry_run: bool = False, json_output: bool = False) -> int:
@@ -5442,14 +5341,12 @@ def actions_import_issues(*, target: Path, dry_run: bool = False, json_output: b
         "dismissed_count": len(dismissed),
         "invalid_count": 0,
     }
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase action imports: {target}")
-        print(f"created: {payload['created_count']}")
-        print(f"skipped: {payload['skipped_count']}")
-        print(f"dismissed: {payload['dismissed_count']}")
-    return 0
+    lines = []
+    lines.append(f"phase action imports: {target}")
+    lines.append(f"created: {payload['created_count']}")
+    lines.append(f"skipped: {payload['skipped_count']}")
+    lines.append(f"dismissed: {payload['dismissed_count']}")
+    return emit(payload, json_output, lines, 0)
 
 
 def _report_payload(target: Path, *, phase_range: str | None = None) -> dict[str, Any]:
@@ -5519,13 +5416,11 @@ def report_build(*, target: Path, phase_range: str | None = None, json_output: b
     payload["bundle_files"] = ["PHASE_REPORT.md", "PHASE_EVIDENCE.json"]
     _write_json(report_dir / "PHASE_EVIDENCE.json", payload)
     _write_report_markdown(report_dir / "PHASE_REPORT.md", payload)
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase report: {payload['report_id']}")
-        print(f"path: {report_dir}")
-        print(f"issues: {payload['doctor']['issue_count']}")
-    return 0
+    lines = []
+    lines.append(f"phase report: {payload['report_id']}")
+    lines.append(f"path: {report_dir}")
+    lines.append(f"issues: {payload['doctor']['issue_count']}")
+    return emit(payload, json_output, lines, 0)
 
 
 def report_list(*, target: Path, limit: int = 20, json_output: bool = False) -> int:
@@ -5555,15 +5450,13 @@ def report_list(*, target: Path, limit: int = 20, json_output: bool = False) -> 
         "reports": reports,
         "report_count": len(reports),
     }
-    if json_output:
-        print(json.dumps(out, indent=2, sort_keys=True))
-    else:
-        print(f"phase reports: {target}")
-        for item in reports:
-            print(
-                f"- {item.get('report_id')} issues={item.get('issue_count')} range={item.get('phase_range') or 'all'}"
-            )
-    return 0
+    lines = []
+    lines.append(f"phase reports: {target}")
+    for item in reports:
+        lines.append(
+            f"- {item.get('report_id')} issues={item.get('issue_count')} range={item.get('phase_range') or 'all'}"
+        )
+    return emit(out, json_output, lines, 0)
 
 
 def report_show(*, target: Path, report_id: str, json_output: bool = False) -> int:
@@ -5622,13 +5515,11 @@ def report_closeout(
         "suggested_next_command": "brigade work phases report list",
     }
     _write_json(report_path / "CLOSEOUT.json", closeout)
-    if json_output:
-        print(json.dumps(closeout, indent=2, sort_keys=True))
-    else:
-        print(f"phase report closeout: {report.get('report_id')}")
-        print(f"status: {status}")
-        print(f"reason: {closeout['reason']}")
-    return 0
+    lines = []
+    lines.append(f"phase report closeout: {report.get('report_id')}")
+    lines.append(f"status: {status}")
+    lines.append(f"reason: {closeout['reason']}")
+    return emit(closeout, json_output, lines, 0)
 
 
 def report_compare(*, target: Path, report_id: str, json_output: bool = False) -> int:
@@ -5660,14 +5551,12 @@ def report_compare(*, target: Path, report_id: str, json_output: bool = False) -
         if issues
         else "brigade work phases report show latest",
     }
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase report compare: {report.get('report_id')}")
-        print(f"issues: {len(issues)}")
-        for check in summary["checks"]:
-            print(f"[{check['status']}] {check['name']}: {check['detail']}")
-    return 0 if not issues else 1
+    lines = []
+    lines.append(f"phase report compare: {report.get('report_id')}")
+    lines.append(f"issues: {len(issues)}")
+    for check in summary["checks"]:
+        lines.append(f"[{check['status']}] {check['name']}: {check['detail']}")
+    return emit(payload, json_output, lines, 0 if not issues else 1)
 
 
 def import_issues(
@@ -5724,11 +5613,9 @@ def import_issues(
         "dismissed_count": len(dismissed),
         "invalid_count": 0,
     }
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"phase ledger imports: {target}")
-        print(f"created: {payload['created_count']}")
-        print(f"skipped: {payload['skipped_count']}")
-        print(f"dismissed: {payload['dismissed_count']}")
-    return 0
+    lines = []
+    lines.append(f"phase ledger imports: {target}")
+    lines.append(f"created: {payload['created_count']}")
+    lines.append(f"skipped: {payload['skipped_count']}")
+    lines.append(f"dismissed: {payload['dismissed_count']}")
+    return emit(payload, json_output, lines, 0)

--- a/src/brigade/tools_cmd.py
+++ b/src/brigade/tools_cmd.py
@@ -20,8 +20,9 @@ from typing import Any
 from . import toml_compat as tomllib
 from .config import load_config as load_brigade_config
 from .install import apply_gitignore
-from .selection import Selection
 from .localio import stable_hash as _stable_hash, utc_now as _now, write_json as _write_json
+from .render import emit
+from .selection import Selection
 
 OK = "ok"
 WARN = "warn"
@@ -4540,27 +4541,26 @@ def defaults(
         "gitignore": gitignore_result,
         "next_command": "brigade tools apply --target . --all",
     }
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-        return 0 if payload["valid"] else 1
-    print(f"tools defaults: {target}")
-    print(f"config_path: {path}")
-    print(f"dry_run: {dry_run}")
-    print(f"created: {'yes' if created else 'no'}")
-    print(f"added: {len(added)}")
-    print(f"updated: {len(updated)}")
-    print(f"skipped: {len(skipped)}")
-    print(f"conflicts: {len(conflicts)}")
-    print(f"sources_created: {payload['source_created_count']}")
-    print(f"gitignore: {gitignore_result}")
+    text_lines = [
+        f"tools defaults: {target}",
+        f"config_path: {path}",
+        f"dry_run: {dry_run}",
+        f"created: {'yes' if created else 'no'}",
+        f"added: {len(added)}",
+        f"updated: {len(updated)}",
+        f"skipped: {len(skipped)}",
+        f"conflicts: {len(conflicts)}",
+        f"sources_created: {payload['source_created_count']}",
+        f"gitignore: {gitignore_result}",
+    ]
     for tool_id in added:
-        print(f"- added: {tool_id}")
+        text_lines.append(f"- added: {tool_id}")
     for tool_id in updated:
-        print(f"- updated: {tool_id}")
+        text_lines.append(f"- updated: {tool_id}")
     for conflict in conflicts:
-        print(f"- conflict: {conflict['tool_id']} {conflict['detail']}")
-    print(f"next_command: {payload['next_command']}")
-    return 0 if payload["valid"] else 1
+        text_lines.append(f"- conflict: {conflict['tool_id']} {conflict['detail']}")
+    text_lines.append(f"next_command: {payload['next_command']}")
+    return emit(payload, json_output, text_lines, 0 if payload["valid"] else 1)
 
 
 def runtime_init(*, target: Path, force: bool = False) -> int:
@@ -4712,21 +4712,17 @@ def runtime_doctor(*, target: Path, json_output: bool = False) -> int:
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
     payload = _runtime_payload(target)
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-        return 0 if payload["valid"] else 1
-    print(f"tools runtime doctor: {target}")
-    print(f"config_path: {payload['config_path']}")
+    text_lines = [f"tools runtime doctor: {target}", f"config_path: {payload['config_path']}"]
     if payload["errors"]:
         for error in payload["errors"]:
-            print(f"[warn] runtime_config: {error}")
+            text_lines.append(f"[warn] runtime_config: {error}")
     if payload["issues"]:
         for issue in payload["issues"]:
-            print(f"[{issue.get('status', WARN)}] {issue.get('name')}: {issue.get('detail')}")
+            text_lines.append(f"[{issue.get('status', WARN)}] {issue.get('name')}: {issue.get('detail')}")
     else:
-        print("[ok] tool_runtimes: no issues")
-    print(f"runtime_issues: {payload['issue_count']}")
-    return 0 if payload["valid"] else 1
+        text_lines.append("[ok] tool_runtimes: no issues")
+    text_lines.append(f"runtime_issues: {payload['issue_count']}")
+    return emit(payload, json_output, text_lines, 0 if payload["valid"] else 1)
 
 
 def policy_init(*, target: Path, force: bool = False) -> int:
@@ -4787,20 +4783,16 @@ def policy_doctor(*, target: Path, json_output: bool = False) -> int:
     payload = _policy_health(target, tools)
     payload["target"] = str(target)
     payload["tool_errors"] = tool_errors
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-        return 0 if payload["enabled"] and payload["valid"] else 1
-    print(f"tools policy doctor: {target}")
-    print(f"policy_path: {payload['policy_path']}")
+    text_lines = [f"tools policy doctor: {target}", f"policy_path: {payload['policy_path']}"]
     for error in payload.get("errors", []):
-        print(f"[warn] tool_policy: {error}")
+        text_lines.append(f"[warn] tool_policy: {error}")
     if payload["issues"]:
         for issue in payload["issues"]:
-            print(f"[{issue.get('status', WARN)}] {issue.get('name')}: {issue.get('detail')}")
+            text_lines.append(f"[{issue.get('status', WARN)}] {issue.get('name')}: {issue.get('detail')}")
     else:
-        print("[ok] tool_policy: no issues")
-    print(f"policy_issues: {payload['issue_count']}")
-    return 0 if payload["enabled"] and payload["valid"] else 1
+        text_lines.append("[ok] tool_policy: no issues")
+    text_lines.append(f"policy_issues: {payload['issue_count']}")
+    return emit(payload, json_output, text_lines, 0 if payload["enabled"] and payload["valid"] else 1)
 
 
 def list_tools(*, target: Path, json_output: bool = False) -> int:
@@ -5004,22 +4996,21 @@ def call_queue(
         args_json=args_json,
         include_blocked=include_blocked,
     )
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-        return rc
-    print(f"tools call queue: {tool_id}")
-    print(f"calls_path: {payload['calls_path']}")
-    print(f"created: {payload['created']}")
-    print(f"skipped: {payload['skipped']}")
-    print(f"blocked: {payload['blocked']}")
+    text_lines = [
+        f"tools call queue: {tool_id}",
+        f"calls_path: {payload['calls_path']}",
+        f"created: {payload['created']}",
+        f"skipped: {payload['skipped']}",
+        f"blocked: {payload['blocked']}",
+    ]
     if payload.get("reason"):
-        print(f"reason: {payload['reason']}")
+        text_lines.append(f"reason: {payload['reason']}")
     call = payload.get("call") if isinstance(payload.get("call"), dict) else {}
     if call:
-        print(f"call: {call.get('id')}")
-        print(f"status: {call.get('status')}")
-        print(f"blockers: {len(call.get('blockers', [])) if isinstance(call.get('blockers'), list) else 0}")
-    return rc
+        text_lines.append(f"call: {call.get('id')}")
+        text_lines.append(f"status: {call.get('status')}")
+        text_lines.append(f"blockers: {len(call.get('blockers', [])) if isinstance(call.get('blockers'), list) else 0}")
+    return emit(payload, json_output, text_lines, rc)
 
 
 def call_list(*, target: Path, json_output: bool = False) -> int:
@@ -5033,19 +5024,14 @@ def call_list(*, target: Path, json_output: bool = False) -> int:
         status = str(call.get("status") or "unknown")
         counts[status] = counts.get(status, 0) + 1
     payload = {"target": str(target), "calls_path": str(calls_path(target)), "calls": calls, "counts": counts}
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-        return 0
-    print(f"tools call list: {target}")
-    print(f"calls_path: {calls_path(target)}")
-    print(f"calls: {len(calls)}")
+    text_lines = [f"tools call list: {target}", f"calls_path: {calls_path(target)}", f"calls: {len(calls)}"]
     for status, count in sorted(counts.items()):
-        print(f"{status}: {count}")
+        text_lines.append(f"{status}: {count}")
     for call in calls:
-        print(
+        text_lines.append(
             f"- {call.get('id')} [{call.get('status')}] {call.get('tool_id')} blockers={len(call.get('blockers', []))}"
         )
-    return 0
+    return emit(payload, json_output, text_lines, 0)
 
 
 def call_show(*, target: Path, call_id: str, json_output: bool = False) -> int:
@@ -5163,19 +5149,16 @@ def run_list(*, target: Path, json_output: bool = False) -> int:
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
     payload = _run_history_payload(target)
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-        return 0
-    print(f"tools run list: {target}")
-    print(f"runs_path: {payload['runs_path']}")
-    print(f"runs: {payload['run_count']}")
+    text_lines = [f"tools run list: {target}", f"runs_path: {payload['runs_path']}", f"runs: {payload['run_count']}"]
     for status, count in sorted(payload["counts"].items()):
-        print(f"{status}: {count}")
+        text_lines.append(f"{status}: {count}")
     for error in payload["errors"]:
-        print(f"[warn] run_receipt_invalid: {error.get('receipt_path')} {error.get('error')}")
+        text_lines.append(f"[warn] run_receipt_invalid: {error.get('receipt_path')} {error.get('error')}")
     for run in payload["runs"]:
-        print(f"- {run.get('id')} [{run.get('status')}] {run.get('tool_id')} exit_code={run.get('exit_code')}")
-    return 0
+        text_lines.append(
+            f"- {run.get('id')} [{run.get('status')}] {run.get('tool_id')} exit_code={run.get('exit_code')}"
+        )
+    return emit(payload, json_output, text_lines, 0)
 
 
 def run_show(*, target: Path, run_id: str, json_output: bool = False) -> int:
@@ -5267,21 +5250,20 @@ def checkpoint_list(*, target: Path, json_output: bool = False) -> int:
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
     payload = _checkpoint_payload(target)
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-        return 0
-    print(f"tools checkpoint list: {target}")
-    print(f"checkpoints_path: {payload['checkpoints_path']}")
-    print(f"checkpoints: {payload['checkpoint_count']}")
+    text_lines = [
+        f"tools checkpoint list: {target}",
+        f"checkpoints_path: {payload['checkpoints_path']}",
+        f"checkpoints: {payload['checkpoint_count']}",
+    ]
     for status, count in sorted(payload["counts"].items()):
-        print(f"{status}: {count}")
+        text_lines.append(f"{status}: {count}")
     for error in payload["errors"]:
-        print(f"[warn] checkpoint_invalid: {error.get('checkpoint_path')} {error.get('error')}")
+        text_lines.append(f"[warn] checkpoint_invalid: {error.get('checkpoint_path')} {error.get('error')}")
     for checkpoint in payload["checkpoints"]:
-        print(
+        text_lines.append(
             f"- {checkpoint.get('id')} [{checkpoint.get('status')}] {checkpoint.get('tool_id')} {checkpoint.get('requested_action')}"
         )
-    return 0
+    return emit(payload, json_output, text_lines, 0)
 
 
 def checkpoint_show(*, target: Path, checkpoint_id: str, json_output: bool = False) -> int:
@@ -5669,14 +5651,13 @@ def pack_build(*, target: Path, json_output: bool = False) -> int:
         f"- import: brigade tools pack import {pack_dir}\n"
     )
     payload["path"] = str(pack_dir)
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-        return 0
-    print(f"tool_pack: {pack_id}")
-    print(f"path: {pack_dir}")
-    print(f"tools: {payload['tool_count']}")
-    print(f"issues: {payload['issue_count']}")
-    return 0
+    text_lines = [
+        f"tool_pack: {pack_id}",
+        f"path: {pack_dir}",
+        f"tools: {payload['tool_count']}",
+        f"issues: {payload['issue_count']}",
+    ]
+    return emit(payload, json_output, text_lines, 0)
 
 
 def _tool_packs(target: Path) -> list[dict[str, Any]]:
@@ -5766,13 +5747,10 @@ def pack_list(*, target: Path, json_output: bool = False, limit: int = 20) -> in
     target = target.expanduser().resolve()
     packs = _tool_packs(target)[:limit]
     payload = {"target": str(target), "packs": packs, "pack_count": len(packs)}
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-        return 0
-    print(f"tool packs: {target}")
+    text_lines = [f"tool packs: {target}"]
     for pack in packs:
-        print(f"- {pack.get('pack_id')} tools={pack.get('tool_count')} issues={pack.get('issue_count')}")
-    return 0
+        text_lines.append(f"- {pack.get('pack_id')} tools={pack.get('tool_count')} issues={pack.get('issue_count')}")
+    return emit(payload, json_output, text_lines, 0)
 
 
 def _find_tool_pack(target: Path, pack_id: str) -> tuple[dict[str, Any] | None, str | None]:
@@ -5821,12 +5799,7 @@ def pack_archive(*, target: Path, pack_id: str, json_output: bool = False) -> in
         "status": "archived",
         "archive_path": str(destination),
     }
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-        return 0
-    print(f"archived: {pack.get('pack_id')}")
-    print(f"path: {destination}")
-    return 0
+    return emit(payload, json_output, [f"archived: {pack.get('pack_id')}", f"path: {destination}"], 0)
 
 
 def pack_import(*, target: Path, pack: Path, force: bool = False, json_output: bool = False) -> int:
@@ -5895,12 +5868,8 @@ def pack_import(*, target: Path, pack: Path, force: bool = False, json_output: b
             "skipped_existing": skipped_existing,
             "conflicts": conflicts,
         }
-        if json_output:
-            print(json.dumps(payload, indent=2, sort_keys=True))
-            return 1
-        for conflict in conflicts:
-            print(f"conflict: {conflict.get('tool_id')} {conflict.get('reason')}")
-        return 1
+        text_lines = [f"conflict: {conflict.get('tool_id')} {conflict.get('reason')}" for conflict in conflicts]
+        return emit(payload, json_output, text_lines, 1)
     merged_by_id = {str(entry.get("id")): dict(entry) for entry in current_entries if entry.get("id")}
     imported: list[dict[str, Any]] = []
     for entry in entries:
@@ -5946,27 +5915,25 @@ def pack_import(*, target: Path, pack: Path, force: bool = False, json_output: b
         "gitignore": result,
         "next_command": "brigade tools plan --target .",
     }
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-        return 0
-    print(f"tool_pack_import: {manifest.get('pack_id') or pack.name}")
-    print(f"imported: {len(imported)}")
-    print("next_command: brigade tools plan --target .")
-    return 0
+    text_lines = [
+        f"tool_pack_import: {manifest.get('pack_id') or pack.name}",
+        f"imported: {len(imported)}",
+        "next_command: brigade tools plan --target .",
+    ]
+    return emit(payload, json_output, text_lines, 0)
 
 
 def sync_plan(*, target: Path, tool_id: str | None = None, json_output: bool = False) -> int:
     target = target.expanduser().resolve()
     payload = _projection_plan_payload(target, tool_id=tool_id)
     payload.update({"mode": "sync-plan", "dry_run_default": True, "delete_supported": False, "add_only": True})
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-        return 0 if payload["valid"] else 1
-    print(f"tools sync plan: {target}")
-    print(f"projections: {len(payload['projections'])}")
-    print("dry_run_default: true")
-    print("delete_supported: false")
-    return 0 if payload["valid"] else 1
+    text_lines = [
+        f"tools sync plan: {target}",
+        f"projections: {len(payload['projections'])}",
+        "dry_run_default: true",
+        "delete_supported: false",
+    ]
+    return emit(payload, json_output, text_lines, 0 if payload["valid"] else 1)
 
 
 def sync_apply(
@@ -6002,23 +5969,19 @@ def doctor(*, target: Path, json_output: bool = False) -> int:
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
     payload = _catalog_payload(target)
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-        return 0 if payload["valid"] else 1
-    print(f"tools doctor: {target}")
-    print(f"config_path: {payload['config_path']}")
+    text_lines = [f"tools doctor: {target}", f"config_path: {payload['config_path']}"]
     if payload["errors"]:
         for error in payload["errors"]:
-            print(f"[warn] tool_config: {error}")
+            text_lines.append(f"[warn] tool_config: {error}")
     else:
-        print(f"[ok] tool_config: {payload['config_path']}")
+        text_lines.append(f"[ok] tool_config: {payload['config_path']}")
     if payload["issues"]:
         for issue in payload["issues"]:
-            print(f"[{issue.get('status', WARN)}] {issue.get('name')}: {issue.get('detail')}")
+            text_lines.append(f"[{issue.get('status', WARN)}] {issue.get('name')}: {issue.get('detail')}")
     else:
-        print("[ok] tool_catalog: no issues")
-    print(f"tool_issues: {payload['issue_count']}")
-    return 0 if payload["valid"] else 1
+        text_lines.append("[ok] tool_catalog: no issues")
+    text_lines.append(f"tool_issues: {payload['issue_count']}")
+    return emit(payload, json_output, text_lines, 0 if payload["valid"] else 1)
 
 
 def import_issues(*, target: Path, json_output: bool = False) -> int:
@@ -6039,18 +6002,17 @@ def import_issues(*, target: Path, json_output: bool = False) -> int:
         "dismissed": len(skipped_dismissed),
         "imports": imported,
     }
-    if json_output:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-        return 0
-    print(f"tool issue imports: {target}")
-    print(f"imports_path: {payload['imports_path']}")
-    print(f"issues: {len(records)}")
-    print(f"created: {len(imported)}")
-    print(f"skipped: {len(skipped)}")
-    print(f"dismissed: {len(skipped_dismissed)}")
+    text_lines = [
+        f"tool issue imports: {target}",
+        f"imports_path: {payload['imports_path']}",
+        f"issues: {len(records)}",
+        f"created: {len(imported)}",
+        f"skipped: {len(skipped)}",
+        f"dismissed: {len(skipped_dismissed)}",
+    ]
     for item in imported:
-        print(f"- {item.get('id')} [{item.get('kind')}] {_short(str(item.get('text', '')))}")
-    return 0
+        text_lines.append(f"- {item.get('id')} [{item.get('kind')}] {_short(str(item.get('text', '')))}")
+    return emit(payload, json_output, text_lines, 0)
 
 
 def parity_status(*, target: Path, json_output: bool = False) -> int:

--- a/tests/test_extras_gate.py
+++ b/tests/test_extras_gate.py
@@ -71,6 +71,23 @@ def test_disabled_extras_help_shows_guidance_not_empty_parser(extras_off, capsys
     assert "brigade extras on" in err
 
 
+def test_work_phases_gated_behind_extras(extras_off, capsys):
+    # The phase-execution ledger is operator-suite surface inside the core
+    # work group; it stubs out like a top-level extras command.
+    rc = cli.main(["work", "phases", "list"])
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert "brigade extras on" in err
+
+
+def test_work_phases_available_when_extras_enabled(extras_off, monkeypatch, capsys):
+    monkeypatch.setenv("BRIGADE_EXTRAS", "1")
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["work", "phases", "--help"])
+    assert exc.value.code == 0
+    assert "plan" in capsys.readouterr().out
+
+
 def test_extras_cli_group_toggles(extras_off, capsys):
     assert cli.main(["extras", "status"]) == 0
     assert "disabled" in capsys.readouterr().out


### PR DESCRIPTION
Follow-up to #126, closing out the two items that audit branch deliberately left open.

## Changed

- **`brigade work phases` joins the extras wall.** The phase-execution ledger is operator-suite surface living inside the core `work` group; it now registers only when extras are enabled and stubs out with the same enable guidance as the top-level gated groups (including `--help`). `register_stub` learned an `invocation` label so nested stubs print the full command path.
- **Renderer consolidation.** The mechanical `if json_output: print(json.dumps(...)) else: print(...)` sites in `tools_cmd` (15), `daily_cmd` (20), `center_cmd` (16), and `phases_cmd` (59) now go through `render.emit`, byte-identical output verified per file against the domain test selections. Sites with interleaved logic or stderr output stay on direct prints on purpose.

## Verify

```
python -m pytest -q                                   # 1379 passed
python -m mypy                                        # 145 files, no issues
BRIGADE_EXTRAS=0 brigade work phases list             # guidance + exit 2
BRIGADE_EXTRAS=1 brigade work phases --help           # normal help
```