### PR TITLE
brigade run artifacts carry brigade-computed ground truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `brigade run` artifacts now carry brigade-computed ground truth (issue #125): `worker-results.json` and `synthesis.json` include a `ground_truth` block with `git diff --stat`, the changed and untracked file lists, a `changes.patch` reference, and verify exit codes parsed from the actual `.brigade/work/verify-runs` receipts. The synthesis prompt gets a compact brigade-computed facts section, so the chef synthesizes against facts instead of worker narration.
+
 ### Changed
 - `brigade work phases` (the phase-execution ledger) moved behind the extras wall with the other operator-suite surface; it stubs out with enable guidance when extras are disabled.
 - The shared `render.emit` renderer now backs the mechanical output sites in `tools_cmd`, `daily_cmd`, `center_cmd`, and `phases_cmd` (110 sites converted, byte-identical output); sites with interleaved logic or stderr remain on direct prints.

--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -10,9 +10,11 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from json import JSONDecoder
 from pathlib import Path
+from typing import Any
 from uuid import uuid4
 
 from . import agents
+from . import proc, runguard
 from .roster import Agent, Roster, is_cli_allowed, timeout_for, workers
 
 
@@ -483,7 +485,12 @@ def dispatch(
     return all_results
 
 
-def build_synth_prompt(task: str, results: list[WorkerResult], read_only: bool = False) -> str:
+def build_synth_prompt(
+    task: str,
+    results: list[WorkerResult],
+    read_only: bool = False,
+    ground_truth: dict[str, object] | None = None,
+) -> str:
     if results:
         rendered = "\n\n".join(
             "\n".join(
@@ -502,9 +509,12 @@ def build_synth_prompt(task: str, results: list[WorkerResult], read_only: bool =
         rendered = "(No workers were assigned.)"
 
     policy = f"\n\n{_read_only_rules()}" if read_only else ""
+    facts = _ground_truth_facts(ground_truth)
+    facts_block = f"\n\n{facts}" if facts else ""
     return (
         "You are the Brigade orchestrator. Synthesize the final answer for the user.\n"
-        "Account for worker failures if any are present. Do not include implementation chatter.\n\n"
+        "Account for worker failures if any are present. Do not include implementation chatter."
+        f"{facts_block}\n\n"
         f"Original task:\n{task}\n\n"
         f"Worker results:\n{rendered}\n"
         f"{policy}"
@@ -564,6 +574,193 @@ def _agent_result_payload(result: agents.AgentResult) -> dict[str, object]:
         "detail": result.detail,
         "text": result.text,
     }
+
+
+def _parse_iso_datetime(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    raw = value.strip()
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _git_stdout(cwd: Path, *args: str) -> tuple[str, str | None]:
+    result = proc.run(["git", *args], cwd=cwd)
+    if result.code == 0:
+        return result.stdout, None
+    detail = result.stderr.strip() or result.stdout.strip() or f"git {' '.join(args)} failed"
+    return "", detail
+
+
+def _receipt_command_payload(command: object) -> dict[str, object] | None:
+    if not isinstance(command, dict):
+        return None
+    raw_command = command.get("command")
+    if not isinstance(raw_command, str):
+        return None
+    payload: dict[str, object] = {"command": raw_command}
+    status = command.get("status")
+    if isinstance(status, str):
+        payload["status"] = status
+    exit_code = command.get("exit_code")
+    if isinstance(exit_code, int) and not isinstance(exit_code, bool):
+        payload["exit_code"] = exit_code
+    elif exit_code is None:
+        payload["exit_code"] = None
+    return payload
+
+
+def _verify_receipt_payload(data: dict[str, Any]) -> dict[str, object]:
+    payload: dict[str, object] = {}
+    for key in ("run_id", "status", "started_at", "completed_at"):
+        value = data.get(key)
+        if isinstance(value, str):
+            payload[key] = value
+    commands = data.get("commands")
+    if isinstance(commands, list):
+        payload["commands"] = [
+            command_payload for item in commands if (command_payload := _receipt_command_payload(item)) is not None
+        ]
+    else:
+        payload["commands"] = []
+    return payload
+
+
+def _verify_receipts_since(cwd: Path, started_at: datetime) -> list[dict[str, object]]:
+    root = cwd / ".brigade" / "work" / "verify-runs"
+    if not root.is_dir():
+        return []
+    receipts: list[dict[str, object]] = []
+    for receipt_path in sorted(root.glob("*/receipt.json")):
+        try:
+            data = json.loads(receipt_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        receipt_started_at = _parse_iso_datetime(data.get("started_at"))
+        if receipt_started_at is None or receipt_started_at < started_at:
+            continue
+        receipts.append(_verify_receipt_payload(data))
+    receipts.sort(key=lambda item: str(item.get("started_at") or item.get("run_id") or ""), reverse=True)
+    return receipts
+
+
+def build_ground_truth(cwd: Path | None, started_at: datetime) -> dict[str, object]:
+    verify_receipts = _verify_receipts_since(cwd, started_at) if cwd is not None else []
+    payload: dict[str, object] = {
+        "available": False,
+        "cwd": str(cwd) if cwd is not None else None,
+        "diffstat": "",
+        "changed_files": [],
+        "untracked_files": [],
+        "patch_ref": None,
+        "verify_receipts": verify_receipts,
+        "latest_verify": verify_receipts[0] if verify_receipts else None,
+    }
+    if cwd is None:
+        payload["reason"] = "cwd not set"
+        return payload
+
+    inside, error = _git_stdout(cwd, "rev-parse", "--is-inside-work-tree")
+    if error is not None or inside.strip() != "true":
+        payload["reason"] = error or "not a git worktree"
+        return payload
+
+    diffstat, error = _git_stdout(cwd, "diff", "--stat", "HEAD")
+    if error is not None:
+        payload["reason"] = error
+        return payload
+    changed_names, error = _git_stdout(cwd, "diff", "--name-only", "HEAD")
+    if error is not None:
+        payload["reason"] = error
+        return payload
+    try:
+        untracked_files = runguard._untracked_files(cwd)
+    except runguard.RunGuardError as exc:
+        payload["reason"] = str(exc)
+        return payload
+
+    payload.update(
+        {
+            "available": True,
+            "diffstat": diffstat.strip(),
+            "changed_files": [line for line in changed_names.splitlines() if line.strip()],
+            "untracked_files": untracked_files,
+        }
+    )
+    return payload
+
+
+def _ground_truth_str_list(ground_truth: dict[str, object], key: str) -> list[str]:
+    value = ground_truth.get(key)
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _ground_truth_facts(ground_truth: dict[str, object] | None) -> str:
+    if ground_truth is None:
+        return ""
+    lines = ["Brigade-computed facts:"]
+    if ground_truth.get("available") is not True:
+        reason = ground_truth.get("reason")
+        detail = f" ({_one_line(str(reason))})" if reason else ""
+        lines.append(f"- ground_truth: unavailable{detail}")
+    else:
+        changed_files = _ground_truth_str_list(ground_truth, "changed_files")
+        untracked_files = _ground_truth_str_list(ground_truth, "untracked_files")
+        diffstat = _one_line(str(ground_truth.get("diffstat") or "none"))
+        if len(diffstat) > 240:
+            diffstat = diffstat[:237] + "..."
+        lines.append(
+            f"- changed_files: {len(changed_files)}" + (f" ({', '.join(changed_files[:6])})" if changed_files else "")
+        )
+        lines.append(
+            f"- untracked_files: {len(untracked_files)}"
+            + (f" ({', '.join(untracked_files[:6])})" if untracked_files else "")
+        )
+        lines.append(f"- diffstat: {diffstat}")
+    patch_ref = ground_truth.get("patch_ref")
+    if isinstance(patch_ref, str) and patch_ref:
+        lines.append(f"- patch_ref: {patch_ref}")
+    verify_receipts = ground_truth.get("verify_receipts")
+    if isinstance(verify_receipts, list) and verify_receipts:
+        latest = verify_receipts[0] if isinstance(verify_receipts[0], dict) else {}
+        latest_status = latest.get("status") if isinstance(latest.get("status"), str) else "unknown"
+        latest_run = latest.get("run_id") if isinstance(latest.get("run_id"), str) else "unknown"
+        lines.append(f"- verify_receipts: {len(verify_receipts)} latest={latest_run} status={latest_status}")
+    else:
+        lines.append("- verify_receipts: 0")
+    return "\n".join(lines)
+
+
+def _with_patch_ref(ground_truth: object, patch_ref: str) -> object:
+    if not isinstance(ground_truth, dict):
+        return ground_truth
+    updated = dict(ground_truth)
+    updated["patch_ref"] = patch_ref
+    return updated
+
+
+def set_artifact_patch_ref(output_dir: Path, patch_ref: str = "changes.patch") -> None:
+    for filename in ("worker-results.json", "synthesis.json"):
+        path = output_dir / filename
+        try:
+            payload = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(payload, dict) or "ground_truth" not in payload:
+            continue
+        payload["ground_truth"] = _with_patch_ref(payload.get("ground_truth"), patch_ref)
+        _write_json(path, payload)
 
 
 def _roster_payload(roster: Roster) -> dict[str, object]:
@@ -724,8 +921,12 @@ def run(
         sandbox_read_only=sandbox_read_only,
         sandbox=sandbox,
     )
+    ground_truth = build_ground_truth(cwd, started_at)
     if output_dir is not None:
-        _write_json(output_dir / "worker-results.json", {"results": _worker_payload(worker_results)})
+        _write_json(
+            output_dir / "worker-results.json",
+            {"results": _worker_payload(worker_results), "ground_truth": ground_truth},
+        )
     if verbose:
         _print_worker_status(worker_results)
         print("synthesis:")
@@ -733,7 +934,7 @@ def run(
 
     final = _run_orchestrator(
         roster,
-        build_synth_prompt(task, worker_results, read_only=read_only),
+        build_synth_prompt(task, worker_results, read_only=read_only, ground_truth=ground_truth),
         cwd=cwd,
         read_only=read_only,
         sandbox_read_only=sandbox_read_only,
@@ -745,6 +946,7 @@ def run(
             {
                 "orchestrator": roster.orchestrator,
                 "result": _agent_result_payload(final),
+                "ground_truth": ground_truth,
             },
         )
     if not final.ok:

--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -649,7 +649,14 @@ def _verify_receipts_since(cwd: Path, started_at: datetime) -> list[dict[str, ob
         if receipt_started_at is None or receipt_started_at < started_at:
             continue
         receipts.append(_verify_receipt_payload(data))
-    receipts.sort(key=lambda item: str(item.get("started_at") or item.get("run_id") or ""), reverse=True)
+
+    def _sort_key(item: dict[str, object]) -> tuple[datetime, str]:
+        # Sort by parsed UTC time: lexical started_at ordering misorders
+        # receipts with mixed timezone offsets.
+        parsed = _parse_iso_datetime(item.get("started_at"))
+        return (parsed or datetime.min.replace(tzinfo=timezone.utc), str(item.get("run_id") or ""))
+
+    receipts.sort(key=_sort_key, reverse=True)
     return receipts
 
 

--- a/src/brigade/cli/run.py
+++ b/src/brigade/cli/run.py
@@ -190,6 +190,8 @@ def dispatch(args) -> int:
                 # must not let cleanup destroy it.
                 keep_worktree = True
                 summary = runguard.collect_changes_patch(effective_cwd, output_dir / "changes.patch")
+                if summary.path.is_file():
+                    aboyeur_mod.set_artifact_patch_ref(output_dir, "changes.patch")
                 if summary.changed and not runguard.verify_changes_patch(effective_cwd, summary.path):
                     # A corrupt patch must never be the run's silent primary
                     # deliverable; keep the worktree as the recoverable copy.

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -1,8 +1,10 @@
 import json
+import subprocess
 
 from brigade import aboyeur
 from brigade import agents
 from brigade.roster import Agent, Roster
+from tests.work_cmd_test_helpers import _init_git_repo
 
 
 def _roster():
@@ -49,6 +51,25 @@ def _restricted_roster():
         },
         max_workers=1,
         allow_models=("codex",),
+    )
+
+
+def _commit_all(repo):
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, stdout=subprocess.DEVNULL)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Test User",
+            "-c",
+            "user.email=test@example.invalid",
+            "commit",
+            "-m",
+            "test fixture",
+        ],
+        cwd=repo,
+        check=True,
+        stdout=subprocess.DEVNULL,
     )
 
 
@@ -443,11 +464,15 @@ def test_run_writes_artifacts(monkeypatch, tmp_path):
                 ok=True,
             )
         if cli_ref == "ollama:llama3.3":
+            (cwd / "tracked.txt").write_text("changed by worker\n")
             return agents.AgentResult(text="worker output", ok=True)
         return agents.AgentResult(text="final answer", ok=True)
 
     run_cwd = tmp_path / "work"
     run_cwd.mkdir()
+    _init_git_repo(run_cwd)
+    (run_cwd / "tracked.txt").write_text("initial\n")
+    _commit_all(run_cwd)
     output_dir = tmp_path / "run"
     monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
 
@@ -478,7 +503,112 @@ def test_run_writes_artifacts(monkeypatch, tmp_path):
     assert synthesis["orchestrator"] == "chef"
     assert synthesis["result"]["ok"] is True
     assert synthesis["result"]["text"] == "final answer"
+    assert synthesis["ground_truth"]["changed_files"] == ["tracked.txt"]
+    worker_results = json.loads((output_dir / "worker-results.json").read_text())
+    ground_truth = worker_results["ground_truth"]
+    assert ground_truth["available"] is True
+    assert "tracked.txt" in ground_truth["changed_files"]
+    assert ground_truth["diffstat"]
+    assert "Brigade-computed facts:" in calls[-1][1]
+    assert "tracked.txt" in calls[-1][1]
     assert {call[2] for call in calls} == {run_cwd}
+
+
+def test_run_worker_results_include_latest_verification_receipt_commands(monkeypatch, tmp_path):
+    def fake_run_agent(cli_ref, prompt, timeout=600.0, cwd=None, read_only=False):
+        if "assignments" in prompt:
+            return agents.AgentResult(
+                text=json.dumps({"assignments": [{"worker": "coder", "task": "implement it"}]}),
+                ok=True,
+            )
+        if cli_ref == "ollama:llama3.3":
+            return agents.AgentResult(text="worker output", ok=True)
+        return agents.AgentResult(text="final answer", ok=True)
+
+    run_cwd = tmp_path / "work"
+    run_cwd.mkdir()
+    _init_git_repo(run_cwd)
+    (run_cwd / "tracked.txt").write_text("initial\n")
+    _commit_all(run_cwd)
+    stale_receipt_dir = run_cwd / ".brigade" / "work" / "verify-runs" / "20000101-000000-work-verify-old"
+    stale_receipt_dir.mkdir(parents=True)
+    (stale_receipt_dir / "receipt.json").write_text(
+        json.dumps(
+            {
+                "run_id": "20000101-000000-work-verify-old",
+                "status": "completed",
+                "started_at": "2000-01-01T00:00:00+00:00",
+                "commands": [{"command": "python -m pytest stale.py", "status": "completed", "exit_code": 0}],
+            }
+        )
+        + "\n"
+    )
+    receipt_dir = run_cwd / ".brigade" / "work" / "verify-runs" / "99990101-000000-work-verify-abc123"
+    receipt_dir.mkdir(parents=True)
+    (receipt_dir / "receipt.json").write_text(
+        json.dumps(
+            {
+                "run_id": "99990101-000000-work-verify-abc123",
+                "status": "failed",
+                "started_at": "9999-01-01T00:00:00+00:00",
+                "commands": [
+                    {
+                        "command": "python -m pytest tests/test_aboyeur.py -q",
+                        "status": "completed",
+                        "exit_code": 0,
+                    },
+                    {
+                        "command": "python -m ruff check src",
+                        "status": "failed",
+                        "exit_code": 2,
+                    },
+                ],
+            }
+        )
+        + "\n"
+    )
+    output_dir = tmp_path / "run"
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+
+    assert aboyeur.run("build feature", _roster(), cwd=run_cwd, output_dir=output_dir) == 0
+
+    ground_truth = json.loads((output_dir / "worker-results.json").read_text())["ground_truth"]
+    assert [receipt["run_id"] for receipt in ground_truth["verify_receipts"]] == ["99990101-000000-work-verify-abc123"]
+    assert ground_truth["latest_verify"]["status"] == "failed"
+    assert ground_truth["latest_verify"]["commands"] == [
+        {
+            "command": "python -m pytest tests/test_aboyeur.py -q",
+            "status": "completed",
+            "exit_code": 0,
+        },
+        {
+            "command": "python -m ruff check src",
+            "status": "failed",
+            "exit_code": 2,
+        },
+    ]
+
+
+def test_run_worker_results_ground_truth_unavailable_outside_git(monkeypatch, tmp_path):
+    def fake_run_agent(cli_ref, prompt, timeout=600.0, cwd=None, read_only=False):
+        if "assignments" in prompt:
+            return agents.AgentResult(
+                text=json.dumps({"assignments": [{"worker": "coder", "task": "implement it"}]}),
+                ok=True,
+            )
+        if cli_ref == "ollama:llama3.3":
+            return agents.AgentResult(text="worker output", ok=True)
+        return agents.AgentResult(text="final answer", ok=True)
+
+    run_cwd = tmp_path / "work"
+    run_cwd.mkdir()
+    output_dir = tmp_path / "run"
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+
+    assert aboyeur.run("build feature", _roster(), cwd=run_cwd, output_dir=output_dir) == 0
+
+    ground_truth = json.loads((output_dir / "worker-results.json").read_text())["ground_truth"]
+    assert ground_truth["available"] is False
 
 
 def test_dry_run_writes_plan_artifact(monkeypatch, tmp_path):

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -793,3 +793,25 @@ def test_disallowed_worker_is_recorded_not_run(monkeypatch):
     assert aboyeur.run("build feature", _restricted_roster()) == 0
     assert [call[0] for call in calls] == ["codex", "codex"]
     assert "not allowed by limits.allow_models" in calls[-1][1]
+
+
+def test_verify_receipts_sorted_chronologically_across_timezone_offsets(tmp_path):
+    # Lexical started_at ordering breaks with mixed offsets: 05:00+09:00 on
+    # Jan 2 is 20:00 UTC on Jan 1, chronologically BEFORE 23:00+00:00 on
+    # Jan 1, but lexically after it. latest_verify must follow real time.
+    from datetime import datetime, timezone
+
+    root = tmp_path / ".brigade" / "work" / "verify-runs"
+    for run_id, started_at in (
+        ("later-utc", "2030-01-01T23:00:00+00:00"),
+        ("earlier-but-lexically-larger", "2030-01-02T05:00:00+09:00"),
+    ):
+        d = root / run_id
+        d.mkdir(parents=True)
+        (d / "receipt.json").write_text(
+            json.dumps({"run_id": run_id, "status": "completed", "started_at": started_at, "commands": []}) + "\n"
+        )
+
+    receipts = aboyeur._verify_receipts_since(tmp_path, datetime(2020, 1, 1, tzinfo=timezone.utc))
+
+    assert [r["run_id"] for r in receipts] == ["later-utc", "earlier-but-lexically-larger"]

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -611,6 +611,13 @@ def test_run_cli_worktree_passes_detached_cwd_and_writes_changes_patch(tmp_path,
         assert proc.run(["git", "symbolic-ref", "-q", "HEAD"], cwd=cwd).code == 1
         (cwd / "tracked.txt").write_text("changed in worktree\n")
         (cwd / "created.txt").write_text("created\n")
+        output_dir.mkdir(parents=True)
+        (output_dir / "worker-results.json").write_text(
+            json.dumps({"results": [], "ground_truth": {"available": True, "patch_ref": None}}) + "\n"
+        )
+        (output_dir / "synthesis.json").write_text(
+            json.dumps({"orchestrator": "chef", "result": {"ok": True}, "ground_truth": {"patch_ref": None}}) + "\n"
+        )
         return 0
 
     monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
@@ -629,6 +636,8 @@ def test_run_cli_worktree_passes_detached_cwd_and_writes_changes_patch(tmp_path,
     assert "created.txt" in patch
     assert "+changed in worktree" in patch
     assert "+created" in patch
+    assert json.loads((output_dir / "worker-results.json").read_text())["ground_truth"]["patch_ref"] == "changes.patch"
+    assert json.loads((output_dir / "synthesis.json").read_text())["ground_truth"]["patch_ref"] == "changes.patch"
 
 
 def test_run_cli_worktree_keeps_checkout_when_patch_invalid(tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
Closes #125.

## Problem

Worker narration can drift from the actual diff: a real two-stage run produced a correct patch while both the coder's report and the reviewer's confirmation described a change that was never made. The reviewer verified the coder's prose, not the work.

## Fix

`worker-results.json` and `synthesis.json` now carry a `ground_truth` block computed by brigade itself, never by a model:

- `diffstat` and `changed_files` from `git diff` against the run cwd
- `untracked_files` via the existing runguard helper
- `patch_ref` back-filled once `changes.patch` is written and validated
- `verify_receipts`: run_id, status, and per-command exit codes parsed from `.brigade/work/verify-runs/*/receipt.json` receipts started at or after the run, sorted by parsed UTC time (raw-string ordering misorders mixed timezone offsets)

The synthesis prompt gains a compact `Brigade-computed facts` section (bounded: truncated diffstat, first few filenames) so the chef synthesizes against facts. Outside a git worktree the block reports `available: false` with a reason.

## Verify

```
python -m pytest -q          # 1386 passed
python -m mypy               # 145 files, no issues
```

Live check: a real `brigade run --worktree` appending one line to a file produced `ground_truth.diffstat: "a.txt | 1 +"`, `changed_files: ["a.txt"]`, `patch_ref: changes.patch`, and the block is present in `synthesis.json`.

An adversarial review pass confirmed no path lets model output populate `ground_truth`, `set_artifact_patch_ref` tolerates missing or invalid artifact files, and the new tests exercise a real temp git repo rather than mocking git.