### PR TITLE
brigade run attaches a GraphTrail code-graph brief to worker prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `brigade run` artifacts now carry brigade-computed ground truth (issue #125): `worker-results.json` and `synthesis.json` include a `ground_truth` block with `git diff --stat`, the changed and untracked file lists, a `changes.patch` reference, and verify exit codes parsed from the actual `.brigade/work/verify-runs` receipts. The synthesis prompt gets a compact brigade-computed facts section, so the chef synthesizes against facts instead of worker narration.
+- `brigade run` now attaches a fail-open GraphTrail code-graph brief when `.graphtrail/graphtrail.db` exists. The read-only markdown context is prepended to orchestration and worker prompts, can be disabled with `--no-code-graph`, and records `code_graph_brief` metadata in `run.json`.
 
 ### Changed
 - `brigade work phases` (the phase-execution ledger) moved behind the extras wall with the other operator-suite surface; it stubs out with enable guidance when extras are disabled.

--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -17,6 +17,9 @@ from . import agents
 from . import proc, runguard
 from .roster import Agent, Roster, is_cli_allowed, timeout_for, workers
 
+CODE_GRAPH_HEADING = "## Code graph context (GraphTrail, read-only)"
+CODE_GRAPH_LIMIT = 4000
+
 
 @dataclass(frozen=True)
 class Assignment:
@@ -34,11 +37,70 @@ class WorkerResult:
     detail: str = ""
 
 
+@dataclass(frozen=True)
+class CodeGraphBrief:
+    attached: bool
+    text: str = ""
+    bytes: int = 0
+
+
+def _prepend_code_graph(prompt: str, code_graph: CodeGraphBrief | None) -> str:
+    if code_graph is None or not code_graph.attached or not code_graph.text:
+        return prompt
+    if CODE_GRAPH_HEADING in prompt:
+        return prompt
+    return f"{code_graph.text}\n{prompt}"
+
+
+def _truncate_on_line_boundary(text: str, limit: int = CODE_GRAPH_LIMIT) -> str:
+    if len(text) <= limit:
+        return text
+    note = f"\n\n[GraphTrail context truncated to {limit} chars.]\n"
+    room = max(0, limit - len(note))
+    clipped = text[:room]
+    boundary = clipped.rfind("\n")
+    if boundary > 0:
+        clipped = clipped[:boundary]
+    else:
+        clipped = clipped.rstrip()
+    return clipped.rstrip() + note
+
+
+def _graphtrail_bin() -> str | None:
+    from . import context_cmd
+
+    return context_cmd._graphtrail_bin()
+
+
+def code_graph_brief(cwd: Path | None, task: str) -> CodeGraphBrief:
+    if cwd is None:
+        return CodeGraphBrief(attached=False)
+    db_path = cwd / ".graphtrail" / "graphtrail.db"
+    if not db_path.is_file():
+        return CodeGraphBrief(attached=False)
+    binary = _graphtrail_bin()
+    if binary is None:
+        return CodeGraphBrief(attached=False)
+    result = proc.run(
+        [binary, "--db", str(db_path), "context", task, "--markdown", "--limit", "8"],
+        timeout=10.0,
+        cwd=cwd,
+    )
+    if result.code != 0:
+        return CodeGraphBrief(attached=False)
+    body = result.stdout.strip()
+    if not body:
+        return CodeGraphBrief(attached=False)
+    text = _truncate_on_line_boundary(f"{CODE_GRAPH_HEADING}\n\n{body}\n")
+    return CodeGraphBrief(attached=True, text=text, bytes=len(text.encode()))
+
+
 def build_plan_prompt(
     task: str,
     roster: Roster,
     corrective_note: str | None = None,
     read_only: bool = False,
+    code_graph: CodeGraphBrief | None = None,
 ) -> str:
     worker_lines = "\n".join(f"- {agent.name}: cli={agent.cli}; role={agent.role}" for agent in workers(roster))
     if not worker_lines:
@@ -46,7 +108,7 @@ def build_plan_prompt(
 
     note = f"\nCorrection needed: {corrective_note}\n" if corrective_note else ""
     policy = f"\n\n{_read_only_rules()}\n" if read_only else ""
-    return (
+    prompt = (
         "You are the Brigade aboyeur. Split the user's task across the available workers.\n"
         "Return exactly one JSON object, with no prose outside JSON:\n"
         '{"assignments":[{"stage":1,"worker":"<worker-name>","task":"<specific sub-task>"}]}\n'
@@ -61,6 +123,7 @@ def build_plan_prompt(
         "- Use zero assignments only if no worker is useful."
         f"{policy}"
     )
+    return _prepend_code_graph(prompt, code_graph)
 
 
 def _extract_json(text: str) -> object:
@@ -332,10 +395,11 @@ def plan(
     sandbox_read_only: bool | None = None,
     sandbox: str | None = None,
     attempts: list[dict[str, object]] | None = None,
+    code_graph: CodeGraphBrief | None = None,
 ) -> list[Assignment]:
     first = _run_orchestrator(
         roster,
-        build_plan_prompt(task, roster, read_only=read_only),
+        build_plan_prompt(task, roster, read_only=read_only, code_graph=code_graph),
         cwd=cwd,
         read_only=read_only,
         sandbox_read_only=sandbox_read_only,
@@ -352,7 +416,7 @@ def plan(
         _record_plan_attempt(attempts, stage="initial", result=first, parse_error=str(exc))
         second = _run_orchestrator(
             roster,
-            build_plan_prompt(task, roster, corrective_note=str(exc), read_only=read_only),
+            build_plan_prompt(task, roster, corrective_note=str(exc), read_only=read_only, code_graph=code_graph),
             cwd=cwd,
             read_only=read_only,
             sandbox_read_only=sandbox_read_only,
@@ -397,12 +461,13 @@ def _worker_prompt(
     *,
     prior_results: list[WorkerResult] | None = None,
     read_only: bool = False,
+    code_graph: CodeGraphBrief | None = None,
 ) -> str:
     prior_context = ""
     if prior_results:
         prior_context = f"\n\nEarlier-stage context:\n{_render_prior_results(prior_results)}"
     policy = f"\n\n{_read_only_rules()}" if read_only else ""
-    return (
+    prompt = (
         f"You are Brigade worker {agent.name}.\n"
         f"Role:\n{agent.role}\n\n"
         f"Sub-task:\n{assignment.task}\n\n"
@@ -410,6 +475,7 @@ def _worker_prompt(
         f"{prior_context}"
         f"{policy}"
     )
+    return _prepend_code_graph(prompt, code_graph)
 
 
 def dispatch(
@@ -419,6 +485,7 @@ def dispatch(
     read_only: bool = False,
     sandbox_read_only: bool | None = None,
     sandbox: str | None = None,
+    code_graph: CodeGraphBrief | None = None,
 ) -> list[WorkerResult]:
     def run_one(assignment: Assignment, prior_results: list[WorkerResult]) -> WorkerResult:
         agent = roster.agents[assignment.worker]
@@ -441,7 +508,7 @@ def dispatch(
             kwargs["model"] = agent.model
         result = agents.run_agent(
             agent.cli,
-            _worker_prompt(agent, assignment, prior_results=prior_results, read_only=read_only),
+            _worker_prompt(agent, assignment, prior_results=prior_results, read_only=read_only, code_graph=code_graph),
             **kwargs,
         )
         return WorkerResult(
@@ -490,6 +557,7 @@ def build_synth_prompt(
     results: list[WorkerResult],
     read_only: bool = False,
     ground_truth: dict[str, object] | None = None,
+    code_graph: CodeGraphBrief | None = None,
 ) -> str:
     if results:
         rendered = "\n\n".join(
@@ -511,7 +579,7 @@ def build_synth_prompt(
     policy = f"\n\n{_read_only_rules()}" if read_only else ""
     facts = _ground_truth_facts(ground_truth)
     facts_block = f"\n\n{facts}" if facts else ""
-    return (
+    prompt = (
         "You are the Brigade orchestrator. Synthesize the final answer for the user.\n"
         "Account for worker failures if any are present. Do not include implementation chatter."
         f"{facts_block}\n\n"
@@ -519,6 +587,7 @@ def build_synth_prompt(
         f"Worker results:\n{rendered}\n"
         f"{policy}"
     )
+    return _prepend_code_graph(prompt, code_graph)
 
 
 def _print_plan(assignments: list[Assignment]) -> None:
@@ -802,6 +871,7 @@ def _run_payload(
     output_dir: Path | None = None,
     handoff_path: Path | None = None,
     error: str | None = None,
+    code_graph: CodeGraphBrief | None = None,
 ) -> dict[str, object]:
     payload: dict[str, object] = {
         "task": task,
@@ -811,6 +881,10 @@ def _run_payload(
         "read_only": read_only,
         "status": status,
         "started_at": _utc_iso(started_at),
+        "code_graph_brief": {
+            "attached": bool(code_graph.attached) if code_graph is not None else False,
+            "bytes": code_graph.bytes if code_graph is not None else 0,
+        },
     }
     if finished_at is not None:
         payload["finished_at"] = _utc_iso(finished_at)
@@ -837,11 +911,15 @@ def run(
     read_only: bool = False,
     sandbox_read_only: bool | None = None,
     sandbox: str | None = None,
+    code_graph_enabled: bool = True,
+    code_graph: CodeGraphBrief | None = None,
 ) -> int:
     started_at = datetime.now(timezone.utc)
     cwd = cwd.expanduser().resolve() if cwd is not None else None
     output_dir = output_dir.expanduser() if output_dir is not None else None
     handoff_inbox = handoff_inbox.expanduser() if handoff_inbox is not None else None
+    if code_graph is None:
+        code_graph = code_graph_brief(cwd, task) if code_graph_enabled else CodeGraphBrief(attached=False)
     if output_dir is not None:
         output_dir.mkdir(parents=True, exist_ok=True)
         _write_json(output_dir / "roster.json", _roster_payload(roster))
@@ -856,6 +934,7 @@ def run(
                 status="started",
                 started_at=started_at,
                 output_dir=output_dir,
+                code_graph=code_graph,
             ),
         )
 
@@ -869,6 +948,7 @@ def run(
             sandbox_read_only=sandbox_read_only,
             sandbox=sandbox,
             attempts=plan_attempts,
+            code_graph=code_graph,
         )
     except RuntimeError as exc:
         if output_dir is not None:
@@ -887,6 +967,7 @@ def run(
                     finished_at=finished_at,
                     output_dir=output_dir,
                     error=str(exc),
+                    code_graph=code_graph,
                 ),
             )
         print(f"error: {exc}", file=sys.stderr)
@@ -912,6 +993,7 @@ def run(
                     started_at=started_at,
                     finished_at=finished_at,
                     output_dir=output_dir,
+                    code_graph=code_graph,
                 ),
             )
         print(json.dumps(payload, indent=2))
@@ -927,6 +1009,7 @@ def run(
         read_only=read_only,
         sandbox_read_only=sandbox_read_only,
         sandbox=sandbox,
+        code_graph=code_graph,
     )
     ground_truth = build_ground_truth(cwd, started_at)
     if output_dir is not None:
@@ -941,7 +1024,7 @@ def run(
 
     final = _run_orchestrator(
         roster,
-        build_synth_prompt(task, worker_results, read_only=read_only, ground_truth=ground_truth),
+        build_synth_prompt(task, worker_results, read_only=read_only, ground_truth=ground_truth, code_graph=code_graph),
         cwd=cwd,
         read_only=read_only,
         sandbox_read_only=sandbox_read_only,
@@ -972,6 +1055,7 @@ def run(
                     finished_at=finished_at,
                     output_dir=output_dir,
                     error=final.detail,
+                    code_graph=code_graph,
                 ),
             )
         print(f"error: orchestrator failed during synthesis: {final.detail}", file=sys.stderr)
@@ -991,6 +1075,7 @@ def run(
                 started_at=started_at,
                 finished_at=finished_at,
                 output_dir=output_dir,
+                code_graph=code_graph,
             ),
         )
     if handoff_inbox is not None:
@@ -1022,6 +1107,7 @@ def run(
                         finished_at=finished_at,
                         output_dir=output_dir,
                         error=detail,
+                        code_graph=code_graph,
                     ),
                 )
             print(f"error: {detail}", file=sys.stderr)
@@ -1043,6 +1129,7 @@ def run(
                     finished_at=finished_at,
                     output_dir=output_dir,
                     handoff_path=handoff,
+                    code_graph=code_graph,
                 ),
             )
     print(final.text)

--- a/src/brigade/cli/run.py
+++ b/src/brigade/cli/run.py
@@ -36,6 +36,11 @@ def register(sub: argparse._SubParsersAction) -> None:
         help="Tell agents to inspect and recommend only, without modifying files or external state.",
     )
     p_run.add_argument(
+        "--no-code-graph",
+        action="store_true",
+        help="Do not attach GraphTrail code graph context to brigade run prompts.",
+    )
+    p_run.add_argument(
         "--sandbox",
         choices=["read-only", "workspace-write", "danger-full-access"],
         default=None,
@@ -172,18 +177,19 @@ def dispatch(args) -> int:
                 worktree_cwd = _worktree_checkout_path(runguard.git_root(run_cwd), output_dir)
                 effective_cwd = runguard.create_detached_worktree(run_cwd, worktree_cwd)
                 print(f"worktree: {effective_cwd}", file=sys.stderr)
-            rc = aboyeur_mod.run(
-                args.task,
-                loaded_roster,
-                dry_run=args.dry_run,
-                show_plan=args.show_plan,
-                verbose=args.verbose,
-                cwd=effective_cwd,
-                output_dir=output_dir,
-                handoff_inbox=handoff_inbox,
-                read_only=args.read_only,
-                sandbox=effective_sandbox,
-            )
+            run_kwargs = {
+                "dry_run": args.dry_run,
+                "show_plan": args.show_plan,
+                "verbose": args.verbose,
+                "cwd": effective_cwd,
+                "output_dir": output_dir,
+                "handoff_inbox": handoff_inbox,
+                "read_only": args.read_only,
+                "sandbox": effective_sandbox,
+            }
+            if args.no_code_graph:
+                run_kwargs["code_graph_enabled"] = False
+            rc = aboyeur_mod.run(args.task, loaded_roster, **run_kwargs)
             if args.worktree and output_dir is not None:
                 # Until the patch is proven good, the worktree is the only
                 # recoverable copy of the agents' edits; a collection failure

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -3,6 +3,7 @@ import subprocess
 
 from brigade import aboyeur
 from brigade import agents
+from brigade import proc
 from brigade.roster import Agent, Roster
 from tests.work_cmd_test_helpers import _init_git_repo
 
@@ -191,6 +192,228 @@ def test_worker_prompt_without_prior_context_keeps_original_contract():
     assert "Sub-task:\nimplement it" in prompt
     assert "Return a concise, complete result for the orchestrator to synthesize." in prompt
     assert "Earlier-stage context" not in prompt
+
+
+def test_code_graph_brief_attaches_markdown_pack(tmp_path, monkeypatch):
+    db = tmp_path / ".graphtrail" / "graphtrail.db"
+    db.parent.mkdir()
+    db.write_text("")
+    calls = []
+
+    monkeypatch.setattr(aboyeur, "_graphtrail_bin", lambda: "/bin/graphtrail")
+
+    def fake_run(args, **kw):
+        calls.append((args, kw))
+        return proc.Result(code=0, stdout="graph output\n", stderr="")
+
+    monkeypatch.setattr(aboyeur.proc, "run", fake_run)
+
+    brief = aboyeur.code_graph_brief(tmp_path, "fix dispatch")
+
+    assert brief.attached is True
+    assert brief.bytes == len(brief.text.encode())
+    assert brief.text.startswith("## Code graph context (GraphTrail, read-only)\n")
+    assert "graph output" in brief.text
+    assert calls == [
+        (
+            [
+                "/bin/graphtrail",
+                "--db",
+                str(db),
+                "context",
+                "fix dispatch",
+                "--markdown",
+                "--limit",
+                "8",
+            ],
+            {"timeout": 10.0, "cwd": tmp_path},
+        )
+    ]
+
+
+def test_code_graph_brief_missing_db_is_not_attached(tmp_path, monkeypatch):
+    monkeypatch.setattr(aboyeur, "_graphtrail_bin", lambda: "/bin/graphtrail")
+    monkeypatch.setattr(aboyeur.proc, "run", lambda *args, **kw: (_ for _ in ()).throw(AssertionError("no run")))
+
+    brief = aboyeur.code_graph_brief(tmp_path, "fix dispatch")
+
+    assert brief.attached is False
+    assert brief.bytes == 0
+    assert brief.text == ""
+
+
+def test_code_graph_brief_nonzero_exit_is_not_attached(tmp_path, monkeypatch):
+    db = tmp_path / ".graphtrail" / "graphtrail.db"
+    db.parent.mkdir()
+    db.write_text("")
+    monkeypatch.setattr(aboyeur, "_graphtrail_bin", lambda: "/bin/graphtrail")
+    monkeypatch.setattr(aboyeur.proc, "run", lambda args, **kw: proc.Result(code=2, stdout="partial", stderr="boom"))
+
+    brief = aboyeur.code_graph_brief(tmp_path, "fix dispatch")
+
+    assert brief.attached is False
+    assert brief.bytes == 0
+    assert brief.text == ""
+
+
+def test_code_graph_brief_timeout_is_not_attached(tmp_path, monkeypatch):
+    db = tmp_path / ".graphtrail" / "graphtrail.db"
+    db.parent.mkdir()
+    db.write_text("")
+    monkeypatch.setattr(aboyeur, "_graphtrail_bin", lambda: "/bin/graphtrail")
+    monkeypatch.setattr(aboyeur.proc, "run", lambda args, **kw: proc.Result(code=124, stdout="", stderr="timeout"))
+
+    brief = aboyeur.code_graph_brief(tmp_path, "fix dispatch")
+
+    assert brief.attached is False
+    assert brief.bytes == 0
+    assert brief.text == ""
+
+
+def test_code_graph_brief_missing_binary_is_not_attached(tmp_path, monkeypatch):
+    db = tmp_path / ".graphtrail" / "graphtrail.db"
+    db.parent.mkdir()
+    db.write_text("")
+    monkeypatch.setattr(aboyeur, "_graphtrail_bin", lambda: None)
+    monkeypatch.setattr(aboyeur.proc, "run", lambda *args, **kw: (_ for _ in ()).throw(AssertionError("no run")))
+
+    brief = aboyeur.code_graph_brief(tmp_path, "fix dispatch")
+
+    assert brief.attached is False
+    assert brief.bytes == 0
+    assert brief.text == ""
+
+
+def test_code_graph_brief_empty_or_whitespace_output_is_not_attached(tmp_path, monkeypatch):
+    db = tmp_path / ".graphtrail" / "graphtrail.db"
+    db.parent.mkdir()
+    db.write_text("")
+    monkeypatch.setattr(aboyeur, "_graphtrail_bin", lambda: "/bin/graphtrail")
+
+    for stdout in ("", "   \n\t\n"):
+        monkeypatch.setattr(
+            aboyeur.proc, "run", lambda args, _out=stdout, **kw: proc.Result(code=0, stdout=_out, stderr="")
+        )
+
+        brief = aboyeur.code_graph_brief(tmp_path, "fix dispatch")
+
+        assert brief.attached is False
+        assert brief.bytes == 0
+        assert brief.text == ""
+
+
+def test_code_graph_brief_truncates_on_line_boundary(tmp_path, monkeypatch):
+    db = tmp_path / ".graphtrail" / "graphtrail.db"
+    db.parent.mkdir()
+    db.write_text("")
+    monkeypatch.setattr(aboyeur, "_graphtrail_bin", lambda: "/bin/graphtrail")
+    monkeypatch.setattr(
+        aboyeur.proc, "run", lambda args, **kw: proc.Result(code=0, stdout=("x" * 5000) + "\nlast\n", stderr="")
+    )
+
+    brief = aboyeur.code_graph_brief(tmp_path, "fix dispatch")
+
+    assert brief.attached is True
+    assert len(brief.text) <= 4000
+    assert brief.text.endswith("\n\n[GraphTrail context truncated to 4000 chars.]\n")
+    assert "last" not in brief.text
+
+
+def test_code_graph_context_is_prepended_once_to_plan_worker_and_synthesis(monkeypatch):
+    calls = []
+    brief = aboyeur.CodeGraphBrief(
+        attached=True, text="## Code graph context (GraphTrail, read-only)\n\ngraph\n", bytes=64
+    )
+
+    def fake_run_agent(cli_ref, prompt, timeout=600.0, cwd=None, read_only=False):
+        calls.append((cli_ref, prompt))
+        assert prompt.count("## Code graph context (GraphTrail, read-only)") == 1
+        if len(calls) == 1:
+            assert prompt.index("## Code graph context") < prompt.index("User task:\nbuild feature")
+            return agents.AgentResult(
+                text=json.dumps({"assignments": [{"worker": "coder", "task": "implement it"}]}),
+                ok=True,
+            )
+        if cli_ref == "ollama:llama3.3":
+            assert prompt.index("## Code graph context") < prompt.index("Sub-task:\nimplement it")
+            return agents.AgentResult(text="worker output", ok=True)
+        assert prompt.index("## Code graph context") < prompt.index("Original task:\nbuild feature")
+        return agents.AgentResult(text="final answer", ok=True)
+
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+
+    assert aboyeur.run("build feature", _roster(), code_graph=brief) == 0
+    assert len(calls) == 3
+
+
+def test_run_json_records_code_graph_brief_fields(monkeypatch, tmp_path):
+    db = tmp_path / "work" / ".graphtrail" / "graphtrail.db"
+    db.parent.mkdir(parents=True)
+    db.write_text("")
+    calls = []
+
+    monkeypatch.setattr(aboyeur, "_graphtrail_bin", lambda: "/bin/graphtrail")
+    monkeypatch.setattr(aboyeur.proc, "run", lambda args, **kw: proc.Result(code=0, stdout="graph\n", stderr=""))
+
+    def fake_run_agent(cli_ref, prompt, timeout=600.0, cwd=None, read_only=False):
+        calls.append(prompt)
+        if len(calls) == 1:
+            return agents.AgentResult(
+                text=json.dumps({"assignments": [{"worker": "coder", "task": "implement it"}]}),
+                ok=True,
+            )
+        if cli_ref == "ollama:llama3.3":
+            return agents.AgentResult(text="worker output", ok=True)
+        return agents.AgentResult(text="final answer", ok=True)
+
+    output_dir = tmp_path / "run"
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+
+    assert aboyeur.run("build feature", _roster(), cwd=tmp_path / "work", output_dir=output_dir) == 0
+
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["code_graph_brief"]["attached"] is True
+    assert run_meta["code_graph_brief"]["bytes"] > 0
+
+
+def test_run_json_records_disabled_code_graph(monkeypatch, tmp_path):
+    db = tmp_path / "work" / ".graphtrail" / "graphtrail.db"
+    db.parent.mkdir(parents=True)
+    db.write_text("")
+    monkeypatch.setattr(aboyeur, "_graphtrail_bin", lambda: "/bin/graphtrail")
+    monkeypatch.setattr(
+        aboyeur.proc, "run", lambda *args, **kw: (_ for _ in ()).throw(AssertionError("no graphtrail run"))
+    )
+
+    def fake_run_agent(cli_ref, prompt, timeout=600.0, cwd=None, read_only=False):
+        assert "## Code graph context" not in prompt
+        if "assignments" in prompt:
+            return agents.AgentResult(
+                text=json.dumps({"assignments": [{"worker": "coder", "task": "implement it"}]}),
+                ok=True,
+            )
+        if cli_ref == "ollama:llama3.3":
+            return agents.AgentResult(text="worker output", ok=True)
+        return agents.AgentResult(text="final answer", ok=True)
+
+    output_dir = tmp_path / "run"
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+
+    assert (
+        aboyeur.run(
+            "build feature",
+            _roster(),
+            cwd=tmp_path / "work",
+            dry_run=True,
+            output_dir=output_dir,
+            code_graph_enabled=False,
+        )
+        == 0
+    )
+    assert json.loads((output_dir / "run.json").read_text())["code_graph_brief"] == {
+        "attached": False,
+        "bytes": 0,
+    }
 
 
 def test_assignment_payload_serializes_stage():

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -102,6 +102,47 @@ role = "code"
     }
 
 
+def test_run_cli_passes_no_code_graph_to_aboyeur(tmp_path, monkeypatch):
+    config_dir = tmp_path / ".brigade"
+    config_dir.mkdir()
+    (config_dir / "roster.toml").write_text(
+        """
+orchestrator = "chef"
+
+[agents.chef]
+cli = "codex"
+role = "plan"
+
+[agents.coder]
+cli = "codex"
+role = "code"
+"""
+    )
+    seen = {}
+
+    def fake_run(
+        task,
+        loaded_roster,
+        dry_run=False,
+        show_plan=False,
+        verbose=False,
+        cwd=None,
+        output_dir=None,
+        handoff_inbox=None,
+        read_only=False,
+        sandbox=None,
+        code_graph_enabled=True,
+    ):
+        seen["code_graph_enabled"] = code_graph_enabled
+        return 0
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(aboyeur, "run", fake_run)
+
+    assert cli.main(["run", "x", "--no-artifacts", "--no-code-graph"]) == 0
+    assert seen["code_graph_enabled"] is False
+
+
 def test_run_cli_default_sandbox_is_none(tmp_path, monkeypatch):
     config_dir = tmp_path / ".brigade"
     config_dir.mkdir()


### PR DESCRIPTION
Closes the loop on the GraphTrail integration: `brigade context` packs already carry a `code_graph` section, but `brigade run` workers still re-explored every repo from scratch. Now the aboyeur hands them the structure up front.

## What it does

When the run cwd has `.graphtrail/graphtrail.db` and a `graphtrail` binary resolves (`$GRAPHTRAIL_BIN`, PATH, `~/.cargo/bin` - same resolution as `context_cmd`), `brigade run` executes `graphtrail context "<task>" --markdown --limit 8` (10s timeout) and prepends the pack under `## Code graph context (GraphTrail, read-only)` to the orchestrator planning prompt and every worker brief.

- **Strictly fail-open**: missing binary, missing db, nonzero exit, timeout, and empty/whitespace output all proceed exactly as today. No new dependencies.
- Packs truncate at 4000 characters on a line boundary with a note.
- `--no-code-graph` disables; `run.json` records `code_graph_brief: {attached, bytes}`.

## Observed effect

On a real dry-run against an indexed Rust repo, the planner's stage-1 assignment named the exact file and private functions involved (`src/query/graph.rs`, `cap_direction_edges`, `dedupe_edges`) with zero repo exploration - all from the 2,679-byte attached brief.

## Verification

- Full suite green: 1394 passed (`pytest -q`, Brigade verify receipt)
- `ruff check` and `ruff format --check` clean
- Unit coverage: attach happy path, missing db, missing binary, nonzero exit, timeout, empty/whitespace output, line-boundary truncation, `--no-code-graph`, and run.json metadata