### PR TITLE
Render the ground-truth block in runs show

### DIFF
--- a/src/brigade/runs_cmd.py
+++ b/src/brigade/runs_cmd.py
@@ -82,6 +82,37 @@ def _print_workers(worker_results: dict[str, Any] | None) -> None:
         print(f"  [{marker}] {result.get('worker', 'unknown')}{detail}")
 
 
+def _print_ground_truth(worker_results: dict[str, Any] | None) -> None:
+    ground_truth = worker_results.get("ground_truth") if worker_results else None
+    if not isinstance(ground_truth, dict):
+        return
+    if ground_truth.get("available") is not True:
+        reason = ground_truth.get("reason")
+        suffix = f" ({reason})" if isinstance(reason, str) and reason else ""
+        print(f"ground truth: unavailable{suffix}")
+        return
+    print("ground truth:")
+    changed = [item for item in ground_truth.get("changed_files") or [] if isinstance(item, str)]
+    untracked = [item for item in ground_truth.get("untracked_files") or [] if isinstance(item, str)]
+    print(f"  changed_files: {len(changed)}" + (f" ({', '.join(changed[:8])})" if changed else ""))
+    if untracked:
+        print(f"  untracked_files: {len(untracked)} ({', '.join(untracked[:8])})")
+    diffstat = ground_truth.get("diffstat")
+    if isinstance(diffstat, str) and diffstat.strip():
+        for line in diffstat.strip().splitlines():
+            print(f"  {line.strip()}")
+    patch_ref = ground_truth.get("patch_ref")
+    if isinstance(patch_ref, str) and patch_ref:
+        print(f"  patch_ref: {patch_ref}")
+    for receipt in ground_truth.get("verify_receipts") or []:
+        if not isinstance(receipt, dict):
+            continue
+        print(f"  verify: {receipt.get('run_id', 'unknown')} {receipt.get('status', 'unknown')}")
+        for command in receipt.get("commands") or []:
+            if isinstance(command, dict):
+                print(f"    - {command.get('command', '?')} exit={command.get('exit_code')}")
+
+
 def _print_synthesis(synthesis: dict[str, Any] | None) -> None:
     if not synthesis:
         return
@@ -230,6 +261,7 @@ def show(run_dir: Path) -> int:
     _print_roster(roster)
     _print_plan(plan)
     _print_workers(worker_results)
+    _print_ground_truth(worker_results)
     _print_synthesis(synthesis)
     _print_final(_read_text(run_dir / "final.txt"))
     return 0

--- a/tests/test_runs_cmd.py
+++ b/tests/test_runs_cmd.py
@@ -226,3 +226,54 @@ def test_runs_latest_cli_with_explicit_runs_dir(tmp_path, capsys):
 
     assert cli.main(["runs", "latest", "--cwd", str(tmp_path), "--runs-dir", str(runs_root)]) == 0
     assert f"run: {run_dir}" in capsys.readouterr().out
+
+
+def test_runs_show_prints_ground_truth(tmp_path, capsys):
+    run_dir = tmp_path / "run"
+    _write_run_artifacts(run_dir)
+    payload = json.loads((run_dir / "worker-results.json").read_text())
+    payload["ground_truth"] = {
+        "available": True,
+        "diffstat": " a.txt | 1 +\n 1 file changed, 1 insertion(+)",
+        "changed_files": ["a.txt"],
+        "untracked_files": ["notes.md"],
+        "patch_ref": "changes.patch",
+        "verify_receipts": [
+            {
+                "run_id": "20260703-000000-work-verify-abc",
+                "status": "completed",
+                "commands": [{"command": "pytest -q", "status": "completed", "exit_code": 0}],
+            }
+        ],
+    }
+    _write_json(run_dir / "worker-results.json", payload)
+
+    assert runs_cmd.show(run_dir) == 0
+    out = capsys.readouterr().out
+    assert "ground truth:" in out
+    assert "changed_files: 1 (a.txt)" in out
+    assert "untracked_files: 1 (notes.md)" in out
+    assert "1 file changed, 1 insertion(+)" in out
+    assert "patch_ref: changes.patch" in out
+    assert "verify: 20260703-000000-work-verify-abc completed" in out
+    assert "pytest -q" in out and "exit=0" in out
+
+
+def test_runs_show_prints_unavailable_ground_truth_reason(tmp_path, capsys):
+    run_dir = tmp_path / "run"
+    _write_run_artifacts(run_dir)
+    payload = json.loads((run_dir / "worker-results.json").read_text())
+    payload["ground_truth"] = {"available": False, "reason": "not a git worktree"}
+    _write_json(run_dir / "worker-results.json", payload)
+
+    assert runs_cmd.show(run_dir) == 0
+    out = capsys.readouterr().out
+    assert "ground truth: unavailable (not a git worktree)" in out
+
+
+def test_runs_show_without_ground_truth_stays_quiet(tmp_path, capsys):
+    run_dir = tmp_path / "run"
+    _write_run_artifacts(run_dir)
+
+    assert runs_cmd.show(run_dir) == 0
+    assert "ground truth" not in capsys.readouterr().out


### PR DESCRIPTION
Follow-up to #128: the ground_truth data landed in worker-results.json but `brigade runs show` and `brigade run --inspect` never displayed it, so reading the brigade-computed facts still meant opening the JSON by hand.

`show` now prints changed/untracked file counts and names, the diffstat, the patch reference, and per-receipt verify commands with exit codes. An unavailable block prints its reason; runs recorded before #128 print nothing new.

Verify: `python -m pytest tests/test_runs_cmd.py -q` (16 tests, 3 new).