### PR TITLE
roster init --review-model: structural review independence

### DIFF
--- a/src/brigade/cli/roster.py
+++ b/src/brigade/cli/roster.py
@@ -20,6 +20,12 @@ def register(sub: argparse._SubParsersAction) -> None:
         help="Default local researcher model for the starter roster.",
     )
     p_roster_init.add_argument("--max-workers", type=int, default=4)
+    p_roster_init.add_argument(
+        "--review-model",
+        default=None,
+        help="Add a reviewer seat pinned to this model (e.g. gpt-5.3-codex-spark) so review "
+        "independence is structural: the reviewer runs a different model than the coder.",
+    )
     p_roster_doctor = roster_sub.add_parser("doctor", help="Validate roster syntax and installed CLIs.")
     p_roster_doctor.add_argument("--target", "-t", type=Path, default=Path("."))
     p_roster_doctor.add_argument(
@@ -40,6 +46,7 @@ def dispatch(args) -> int:
             force=args.force,
             ollama_model=args.ollama_model,
             max_workers=args.max_workers,
+            review_model=args.review_model,
         )
     if args.roster_command == "doctor":
         return roster_cmd.doctor(target=args.target, roster_path=args.roster)

--- a/src/brigade/roster_cmd.py
+++ b/src/brigade/roster_cmd.py
@@ -12,7 +12,9 @@ from . import roster as roster_mod
 DEFAULT_ROSTER_REL = ".brigade/roster.toml"
 
 
-def default_roster_text(*, ollama_model: str = "llama3.3", max_workers: int = 4) -> str:
+def default_roster_text(
+    *, ollama_model: str = "llama3.3", max_workers: int = 4, review_model: str | None = None
+) -> str:
     return f"""# Brigade aboyeur roster.
 # Edit agent roles and CLI refs to match the tools installed on this machine.
 
@@ -29,7 +31,7 @@ role = "Make precise code changes and report what changed."
 [agents.local_researcher]
 cli = "ollama:{ollama_model}"
 role = "Research locally and summarize useful findings."
-
+{_reviewer_seat(review_model)}
 [limits]
 max_workers = {max_workers}
 timeout_seconds = 600
@@ -59,12 +61,35 @@ allow_models = ["codex", "ollama:*"]
 """
 
 
-def init(target: Path, *, force: bool = False, ollama_model: str = "llama3.3", max_workers: int = 4) -> int:
+def _reviewer_seat(review_model: str | None) -> str:
+    if not review_model:
+        return ""
+    # A reviewer on a different model than the coder makes review
+    # independence structural instead of stylistic (issue #125).
+    return f"""
+[agents.reviewer]
+cli = "codex"
+model = "{review_model}"
+role = "Inspect code and reports, verify claims against the actual diff, and flag problems."
+"""
+
+
+def init(
+    target: Path,
+    *,
+    force: bool = False,
+    ollama_model: str = "llama3.3",
+    max_workers: int = 4,
+    review_model: str | None = None,
+) -> int:
     if max_workers < 1:
         print("error: --max-workers must be a positive integer", file=sys.stderr)
         return 2
     if not ollama_model.strip():
         print("error: --ollama-model must be non-empty", file=sys.stderr)
+        return 2
+    if review_model is not None and not review_model.strip():
+        print("error: --review-model must be non-empty when provided", file=sys.stderr)
         return 2
 
     target = target.expanduser()
@@ -74,7 +99,13 @@ def init(target: Path, *, force: bool = False, ollama_model: str = "llama3.3", m
         return 2
 
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(default_roster_text(ollama_model=ollama_model.strip(), max_workers=max_workers))
+    path.write_text(
+        default_roster_text(
+            ollama_model=ollama_model.strip(),
+            max_workers=max_workers,
+            review_model=review_model.strip() if review_model else None,
+        )
+    )
     print(f"wrote {path}")
     return 0
 

--- a/tests/test_roster_cmd.py
+++ b/tests/test_roster_cmd.py
@@ -1,5 +1,6 @@
 from brigade import agents
 from brigade import cli
+from brigade import roster
 from brigade import roster_cmd
 
 
@@ -154,3 +155,27 @@ def test_roster_doctor_endpoint_agent_skips_pin_check(tmp_target, capsys):
     out = capsys.readouterr().out
     assert rc == 0
     assert "endpoint https://example.test/v1/chat" in out
+
+
+def test_roster_init_review_model_adds_pinned_reviewer_seat(tmp_path):
+    # Structural review independence (issue #125): the reviewer seat runs a
+    # different model than the coder it checks.
+    rc = roster_cmd.init(tmp_path, review_model="gpt-5.3-codex-spark")
+    assert rc == 0
+    text = (tmp_path / ".brigade" / "roster.toml").read_text()
+    assert "[agents.reviewer]" in text
+    assert 'model = "gpt-5.3-codex-spark"' in text
+    # the generated roster stays loadable
+    loaded = roster.load_roster(tmp_path / ".brigade" / "roster.toml")
+    assert loaded.agents["reviewer"].model == "gpt-5.3-codex-spark"
+    assert loaded.agents["reviewer"].cli == "codex"
+
+
+def test_roster_init_without_review_model_has_no_reviewer_seat(tmp_path):
+    assert roster_cmd.init(tmp_path) == 0
+    assert "[agents.reviewer]" not in (tmp_path / ".brigade" / "roster.toml").read_text()
+
+
+def test_roster_init_rejects_blank_review_model(tmp_path, capsys):
+    assert roster_cmd.init(tmp_path, review_model="  ") == 2
+    assert "review-model" in capsys.readouterr().err


### PR DESCRIPTION
Issue #125's optional ask: a reviewer running the same model as the coder agrees too easily with the coder's story. `brigade roster init --review-model gpt-5.3-codex-spark` now writes a reviewer seat pinned to that model, so the review seat is structurally independent. `roster doctor` validates the pin.

Verify: `python -m pytest tests/test_roster_cmd.py -q` (16 tests, 3 new); live `roster init --review-model ... && roster doctor` shows the pinned seat ok.