### PR TITLE
Release docs coherence: minimal footprint, extras wall, migration notes, demo tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Migration
+Upgrading from 0.17.x, two breaking changes need one-time action:
+
+- **Extras surface.** If any script, cron, or habit runs `release`, `center`, `repos`, `research`, `roadmap`, `friction`, `chat`, `context`, `projects`, `learn`, `runbook`, `dogfood`, `pantry`, `notifications`, `budgets`, `untrusted`, either fragments group, or `work phases`, run `brigade extras on` once per machine before upgrading (or export `BRIGADE_EXTRAS=1` in that environment). Disabled commands exit 2 with this guidance rather than failing silently.
+- **Minimal repo installs.** `brigade init` and `operator quickstart` at repo depth now write only `AGENTS.md` and `SAFETY_RULES.md` plus gitignored state. If your setup expects `rules/`, `hooks/pre-push`, `INSTALL_FOR_AGENTS.md`, or the default tool packs, pass `--full` (or add the `repo-extras` include). Existing repos are untouched by the upgrade itself; re-running quickstart on an existing repo only adds missing files and never overwrites.
+
 ### Docs
 - README opening reframed: the one-liner now leads with the per-tool config and memory sprawl instead of abstract nouns, "What it does" defines a receipt as the file it is, and a sample verify-receipt ticket shows one. The receipts wording elsewhere in the opening was trimmed so the word appears where it is the feature, not as a refrain.
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -23,7 +23,7 @@ python3 -m pipx ensurepath
 
 ## First install
 
-The canonical first-run command is `brigade operator quickstart`. It installs the template files, wires the operator config, and runs the health checks in one shot:
+The canonical first-run command is `brigade operator quickstart`. It installs the template files, wires the operator config, scaffolds the MCP catalog and dogfood/work-loop config, and runs the health checks in one shot:
 
 ```bash
 # Code repo with Codex as the writer
@@ -35,7 +35,7 @@ brigade operator quickstart --target ~/agent-workspace --depth workspace --harne
 
 Pass `--dry-run` first to preview the planned steps without writing anything.
 
-Two commands share this surface: `brigade init` installs the template files only, and `brigade operator quickstart` wraps it (init, then operator config, then doctor). Use `init` when you want the interactive harness picker or just the files:
+Two commands share this surface: `brigade init` installs the template files only, and `brigade operator quickstart` wraps it with operator config, the MCP and dogfood on-ramps, writer verification, and health checks. Use `init` when you want the interactive harness picker or just the files:
 
 ```bash
 $ brigade init --target ~/agent-kitchen
@@ -150,4 +150,4 @@ Capture against an id you actually have: a skill you followed, a memory card (`-
 - Wire the ingester on a cron or a manual end-of-day workflow.
 - Add a memory-care staleness scan when your card set starts to matter. See [docs/memory-care.md](docs/memory-care.md).
 - If you use TokenJuice, wire Claude Code and Codex hooks deliberately and tell agents what the wrapper means. See the tokens station in [docs/technical-guide.md](docs/technical-guide.md#managed-stations).
-- Run `brigade work bootstrap` inside active repos when you want the dogfood-backed daily work loop, scanner inbox, and local evidence receipts.
+- Run `brigade work bootstrap` inside active repos that did not use quickstart when you want the dogfood-backed daily work loop, scanner inbox, and local evidence receipts.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ brigade operator quickstart --target ./my-repo --harnesses codex      # wire one
 brigade operator doctor --target ./my-repo --profile local-operator   # verify
 ```
 
-That installs the CLI, wires memory, handoffs, and local guardrails into one repo for a single harness, and prints a readiness check. The default footprint is deliberately small: two tracked files (`AGENTS.md`, `SAFETY_RULES.md`) plus gitignored local state. Pass `--full` for the whole kit (workflow rules, the inactive pre-push hook, the agent install doc, and the default tool packs); workspace-depth installs always get the full kitchen. Nothing leaves your machine and no daemon is started. Add `--dry-run` to preview the file-by-file plan before anything is written. More harnesses, workspace setups, and the homegrown-adoption path are under [Install](#install).
+That installs the CLI, wires memory, handoffs, a local MCP catalog, the dogfood/work-loop config, and local guardrails into one repo for a single harness, and prints a readiness check. The default footprint is deliberately small: `AGENTS.md`, `SAFETY_RULES.md`, the selected handoff template, and local `.brigade/` state. Pass `--full` for the whole kit (workflow rules, the inactive pre-push hook, the agent install doc, and the default tool packs); workspace-depth installs always get the full kitchen. Nothing leaves your machine and no daemon is started. Add `--dry-run` to preview the file-by-file plan before anything is written. More harnesses, workspace setups, and the homegrown-adoption path are under [Install](#install).
 
 The run ends with a readiness verdict (the recording above shows the full report):
 

--- a/docs/first-10-minutes.md
+++ b/docs/first-10-minutes.md
@@ -71,6 +71,8 @@ A `status: warn` (with exit code 1) means setup completed but a step has a host-
 
 Quickstart scopes handoff source coverage to the writer harnesses you selected. A `--harnesses codex` setup watches `.codex/memory-handoffs/` and leaves Claude, OpenCode, Hermes, and OpenClaw paths quiet until you add them.
 
+Quickstart also scaffolds `.brigade/mcp.json` and `.brigade/dogfood.toml` so MCP sync and the work loop have local config from the first run.
+
 ## 5. Check Health
 
 ```bash

--- a/docs/new-user-quickstart.md
+++ b/docs/new-user-quickstart.md
@@ -1,6 +1,6 @@
 # New User Quickstart
 
-Brigade is local-first. Local-first means local data on the operator-controlled machine first, before any external service; that machine can be a laptop, workstation, or VPS. The first run should create local config, handoff inboxes, and portable tool or skill projections without starting services or touching remotes.
+Brigade is local-first. Local-first means local data on the operator-controlled machine first, before any external service; that machine can be a laptop, workstation, or VPS. The first run should create local config and handoff inboxes without starting services or touching remotes; workspace, `--full`, and pack-based installs can also project portable tools or skills.
 
 The target can be a code repo, an OpenClaw or Hermes memory workspace, a VPS operator directory, or another local workspace you control. Repo installs are common, but they are not the only supported shape.
 
@@ -86,7 +86,8 @@ Quickstart runs these local-only steps:
 - installs Brigade repo or workspace templates
 - writes host-local `.brigade/` operator config
 - scopes handoff source coverage to the selected writer harnesses and writes a local bootstrap handoff-ingest latest-run log
-- imports built-in portable tools and skills
+- scaffolds the local MCP catalog and dogfood/work-loop config
+- imports built-in portable tools and skills for workspace installs, `--full`, or explicit pack installs
 - projects harness-specific files such as Codex skills or Claude command docs
 - verifies selected handoff writer inboxes
 - prints next commands

--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -144,6 +144,8 @@ Phase action planning can turn blocked or stale phase-session checkpoint issues 
 Session checkpoint archive moves old recovery points into local JSONL metadata so they stop driving latest-checkpoint health.
 Session report bundles include a recovery section with checkpoint and recovery-note summaries.
 
+Gated operator-suite examples below assume `brigade extras on` has been run once. For one-off invocations, prefix the command with `BRIGADE_EXTRAS=1`.
+
 `brigade work phases evidence add` appends local files, tests, report ids, handoff paths, and notes to a phase record without running commands.
 `brigade work phases verify plan/record` keeps expected verification and recorded outcomes visible without executing tests.
 `brigade work phases reconcile` checks recorded commit and push evidence against local git state without changing git.
@@ -324,7 +326,7 @@ brigade run "make the change" --allow-dirty
 brigade run "make the change" --worktree
 ```
 
-The examples above all drive the same `brigade run` command to show its main flags. Brigade's full surface (work loop, scanners, handoffs, tools, release gates, repo fleet, and more) is documented section by section below. For the complete, auto-generated list of every command, see [`docs/command-inventory.md`](command-inventory.md), and regenerate it with `brigade roadmap commands --write`.
+The examples above all drive the same `brigade run` command to show its main flags. Brigade's full surface (work loop, scanners, handoffs, tools, release gates, repo fleet, and more) is documented section by section below. For the complete, auto-generated list of every command, see [`docs/command-inventory.md`](command-inventory.md), and regenerate it with `BRIGADE_EXTRAS=1 brigade roadmap commands --write`.
 
 Common `brigade run` flags:
 
@@ -516,7 +518,7 @@ brigade operator status --profile internal-dogfood --target .
 brigade daily status --target .
 ```
 
-`brigade operator quickstart` is the first-user path. It runs the repo template install, writes local operator config, imports built-in portable tools and skills, projects harness files, verifies handoff writer inboxes for selected harnesses, and prints the next commands. It is local-only: no daemons, hooks, publishing, pushing, tagging, or remote mutation. JSON output includes a compact `issue_report` object that users can review, redact, and paste into the GitHub quickstart issue form.
+`brigade operator quickstart` is the first-user path. It runs the repo template install, writes local operator config, scaffolds the MCP catalog and dogfood/work-loop config, projects harness files, verifies handoff writer inboxes for selected harnesses, and prints the next commands. Workspace, `--full`, and pack-based quickstarts also import built-in portable tools and skills. It is local-only: no daemons, hooks, publishing, pushing, tagging, or remote mutation. JSON output includes a compact `issue_report` object that users can review, redact, and paste into the GitHub quickstart issue form.
 
 Task ledger commands:
 
@@ -963,8 +965,9 @@ Brigade installs material into a target directory on two independent axes. The t
 
 | Depth | Installs |
 |---|---|
-| `repo` *(default)* | `AGENTS.md`, `SAFETY_RULES.md`, `INSTALL_FOR_AGENTS.md`, `hooks/pre-push`, `.brigade/policies/public-repo.json`, `.brigade/policies/personal.json` |
-| `workspace` | repo + `MEMORY.md`, `TOOLS.md`, `USER.md`, `SOUL.md`, `IDENTITY.md`, `HEARTBEAT.md`, `memory/cards/`, starter cards |
+| `repo` *(default)* | minimal repo baseline: `AGENTS.md`, `SAFETY_RULES.md`, `.brigade/handoff-sources.example.json`, and policy examples under `.brigade/policies/` |
+| `repo` + `--full` | repo baseline + `INSTALL_FOR_AGENTS.md`, `rules/`, and inactive `hooks/pre-push` |
+| `workspace` | repo baseline + full kit, `MEMORY.md`, `TOOLS.md`, `USER.md`, `SOUL.md`, `IDENTITY.md`, `HEARTBEAT.md`, `memory/cards/`, starter cards, and default tool/skill projections |
 
 **Harnesses, which tools you actually use:**
 

--- a/scripts/record-quickstart-demo.sh
+++ b/scripts/record-quickstart-demo.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Regenerate the README quickstart recording (docs/assets/quickstart.cast + .svg)
+# from a real run of the CURRENT build. Run this as part of a release cut,
+# AFTER the version bump, so the recorded `brigade --version` matches the
+# release; scripts/version_sync.py --check fails otherwise.
+#
+# Requires: svg-term on PATH (npm i -g svg-term-cli), python3, a brigade
+# entry point (defaults to .venv/bin/brigade).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BRIGADE="${BRIGADE_BIN:-$ROOT/.venv/bin/brigade}"
+CAST="$ROOT/docs/assets/quickstart.cast"
+SVG="$ROOT/docs/assets/quickstart.svg"
+WIDTH=84
+HEIGHT=28
+
+command -v svg-term >/dev/null || { echo "error: svg-term not on PATH" >&2; exit 2; }
+[ -x "$BRIGADE" ] || { echo "error: brigade not found at $BRIGADE (set BRIGADE_BIN)" >&2; exit 2; }
+
+demo="$(mktemp -d)"
+trap 'rm -rf "$demo"' EXIT
+git init -q -b main "$demo/my-repo"
+
+version_out="$("$BRIGADE" --version)"
+quickstart_out="$(cd "$demo/my-repo" && HOME="$demo/home" "$BRIGADE" operator quickstart --target . --harnesses codex 2>&1)"
+doctor_out="$(cd "$demo/my-repo" && HOME="$demo/home" "$BRIGADE" operator doctor --target . --profile local-operator 2>&1)"
+
+python3 - "$CAST" <<PYEOF
+import json, sys
+
+cast_path = sys.argv[1]
+version_out = """$version_out"""
+quickstart_out = """$quickstart_out"""
+doctor_out = """$doctor_out"""
+
+frames = []
+clock = 0.6
+
+def type_command(text):
+    global clock
+    frames.append([round(clock, 2), "o", "[1;32m\$[0m "])
+    for ch in text:
+        clock += 0.03
+        frames.append([round(clock, 2), "o", ch])
+    clock += 0.4
+    frames.append([round(clock, 2), "o", "\r\n"])
+
+def emit_output(text):
+    global clock
+    for line in text.splitlines():
+        clock += 0.06
+        frames.append([round(clock, 2), "o", line + "\r\n"])
+    clock += 0.8
+
+type_command("brigade --version")
+emit_output(version_out)
+type_command("brigade operator quickstart --target my-repo --harnesses codex")
+emit_output(quickstart_out)
+type_command("brigade operator doctor --target my-repo --profile local-operator")
+emit_output(doctor_out)
+clock += 2.4
+frames.append([round(clock, 2), "o", ""])
+
+header = {
+    "version": 2,
+    "width": $WIDTH,
+    "height": $HEIGHT,
+    "timestamp": 0,
+    "env": {"TERM": "xterm-256color", "SHELL": "/bin/bash"},
+}
+with open(cast_path, "w") as fh:
+    fh.write(json.dumps(header) + "\n")
+    for frame in frames:
+        fh.write(json.dumps(frame) + "\n")
+print(f"wrote {cast_path} ({len(frames)} frames)")
+PYEOF
+
+svg-term --in "$CAST" --out "$SVG" --window --width "$WIDTH" --height "$HEIGHT"
+echo "wrote $SVG"
+python3 "$ROOT/scripts/version_sync.py" --check


### PR DESCRIPTION
Pre-release docs alignment so the breaking changes ship with docs that match.

- **Drift fixes** in QUICKSTART.md, README.md, docs/first-10-minutes.md, docs/new-user-quickstart.md, and docs/technical-guide.md: the default quickstart no longer claims to import tool packs, the minimal footprint and `--full` are described where the old full kit was promised, gated operator-suite examples get the `brigade extras on` prerequisite, and the inventory regen command carries `BRIGADE_EXTRAS=1`. Five other flagged docs checked out as already correct.
- **Migration section** under `[Unreleased]` in the changelog: the two one-time actions for 0.17.x upgraders.
- **scripts/record-quickstart-demo.sh**: reproducible regeneration of the README quickstart recording (real run -> .cast -> svg-term -> version-sync check). Run during release cut after the version bump; the current assets stay correct for 0.17.0 until then, which is why this PR does not regenerate them.

Verify: `python -m pytest tests/test_install.py tests/test_operator_cmd.py -q`; `bash scripts/record-quickstart-demo.sh` produces valid assets and a green version-sync (then `git checkout docs/assets/` to discard until release).