### PR TITLE
Document roster init --review-model

### DIFF
--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -244,6 +244,8 @@ brigade roster init
 brigade roster doctor
 ```
 
+Pass `--review-model <id>` to add a reviewer seat pinned to a different model than the coder (for example `brigade roster init --review-model gpt-5.3-codex-spark`). A same-model reviewer tends to agree with the coder's narration; pinning the review seat to another model makes that independence structural, and `roster doctor` validates the pin like any other seat.
+
 That writes `.brigade/roster.toml` with a Codex orchestrator, a Codex coder, and an optional Ollama local researcher:
 
 ```toml


### PR DESCRIPTION
One paragraph in the technical guide for the reviewer-seat flag shipped in #133.