### PR TITLE
feat: codex app-server transport for brigade run

### DIFF
--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -49,7 +49,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade roster`: 2 command path(s)
 - `brigade run`: 1 command path(s)
 - `brigade runbook` (extras): 4 command path(s)
-- `brigade runs`: 3 command path(s)
+- `brigade runs`: 4 command path(s)
 - `brigade scrub`: 1 command path(s)
 - `brigade security`: 15 command path(s)
 - `brigade skills`: 27 command path(s)
@@ -363,6 +363,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade runbook run` (extras)
 - `brigade runs latest`
 - `brigade runs list`
+- `brigade runs resume`
 - `brigade runs show`
 - `brigade scrub`
 - `brigade security closeout`

--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -523,7 +523,9 @@ def dispatch(
                 ok=False,
                 detail=f"{agent.cli} is not allowed by limits.allow_models",
             )
-        prompt = _worker_prompt(agent, assignment, prior_results=prior_results, read_only=read_only, code_graph=code_graph)
+        prompt = _worker_prompt(
+            agent, assignment, prior_results=prior_results, read_only=read_only, code_graph=code_graph
+        )
         if agent.cli == "codex" and appserver is not None:
             on_event = _worker_event_writer(events_dir, assignment.worker, verbose=verbose)
             result = agents.run_codex_appserver(

--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -14,6 +14,7 @@ from typing import Any
 from uuid import uuid4
 
 from . import agents
+from . import codex_appserver
 from . import proc, runguard
 from .roster import Agent, Roster, is_cli_allowed, timeout_for, workers
 
@@ -35,6 +36,8 @@ class WorkerResult:
     text: str
     ok: bool
     detail: str = ""
+    thread_id: str | None = None
+    status: str = ""
 
 
 @dataclass(frozen=True)
@@ -478,6 +481,26 @@ def _worker_prompt(
     return _prepend_code_graph(prompt, code_graph)
 
 
+def _worker_event_writer(events_dir: Path | None, worker: str, *, verbose: bool = False):
+    """Append lifecycle notifications to events/<worker>.jsonl; optionally narrate."""
+    if events_dir is None and not verbose:
+        return None
+    path = None
+    if events_dir is not None:
+        events_dir.mkdir(parents=True, exist_ok=True)
+        path = events_dir / f"{_slug(worker)}.jsonl"
+
+    def on_event(msg: dict) -> None:
+        if path is not None:
+            with path.open("a") as fh:
+                fh.write(json.dumps(msg) + "\n")
+        if verbose and msg.get("method") == "item/completed":
+            item = (msg.get("params") or {}).get("item") or {}
+            print(f"worker {worker}: {item.get('type', 'item')} completed", file=sys.stderr)
+
+    return on_event
+
+
 def dispatch(
     assignments: list[Assignment],
     roster: Roster,
@@ -486,6 +509,9 @@ def dispatch(
     sandbox_read_only: bool | None = None,
     sandbox: str | None = None,
     code_graph: CodeGraphBrief | None = None,
+    appserver=None,
+    events_dir: Path | None = None,
+    verbose: bool = False,
 ) -> list[WorkerResult]:
     def run_one(assignment: Assignment, prior_results: list[WorkerResult]) -> WorkerResult:
         agent = roster.agents[assignment.worker]
@@ -497,26 +523,38 @@ def dispatch(
                 ok=False,
                 detail=f"{agent.cli} is not allowed by limits.allow_models",
             )
-        kwargs: dict[str, object] = {
-            "timeout": timeout_for(agent, roster),
-            "cwd": cwd,
-            "read_only": read_only if sandbox_read_only is None else sandbox_read_only,
-        }
-        if sandbox is not None:
-            kwargs["sandbox"] = sandbox
-        if agent.model is not None:
-            kwargs["model"] = agent.model
-        result = agents.run_agent(
-            agent.cli,
-            _worker_prompt(agent, assignment, prior_results=prior_results, read_only=read_only, code_graph=code_graph),
-            **kwargs,
-        )
+        prompt = _worker_prompt(agent, assignment, prior_results=prior_results, read_only=read_only, code_graph=code_graph)
+        if agent.cli == "codex" and appserver is not None:
+            on_event = _worker_event_writer(events_dir, assignment.worker, verbose=verbose)
+            result = agents.run_codex_appserver(
+                appserver,
+                prompt,
+                timeout=timeout_for(agent, roster),
+                cwd=cwd,
+                read_only=read_only if sandbox_read_only is None else sandbox_read_only,
+                sandbox=sandbox,
+                model=agent.model,
+                on_event=on_event,
+            )
+        else:
+            kwargs: dict[str, object] = {
+                "timeout": timeout_for(agent, roster),
+                "cwd": cwd,
+                "read_only": read_only if sandbox_read_only is None else sandbox_read_only,
+            }
+            if sandbox is not None:
+                kwargs["sandbox"] = sandbox
+            if agent.model is not None:
+                kwargs["model"] = agent.model
+            result = agents.run_agent(agent.cli, prompt, **kwargs)
         return WorkerResult(
             worker=assignment.worker,
             task=assignment.task,
             text=result.text,
             ok=result.ok,
             detail=result.detail,
+            thread_id=result.thread_id,
+            status=result.status,
         )
 
     if not assignments:
@@ -625,16 +663,20 @@ def _assignment_payload(assignments: list[Assignment]) -> list[dict[str, object]
 
 
 def _worker_payload(results: list[WorkerResult]) -> list[dict[str, object]]:
-    return [
-        {
+    payload: list[dict[str, object]] = []
+    for result in results:
+        entry: dict[str, object] = {
             "worker": result.worker,
             "task": result.task,
             "ok": result.ok,
             "detail": result.detail,
             "text": result.text,
         }
-        for result in results
-    ]
+        if result.thread_id is not None:
+            entry["thread_id"] = result.thread_id
+            entry["status"] = result.status
+        payload.append(entry)
+    return payload
 
 
 def _agent_result_payload(result: agents.AgentResult) -> dict[str, object]:
@@ -872,6 +914,7 @@ def _run_payload(
     handoff_path: Path | None = None,
     error: str | None = None,
     code_graph: CodeGraphBrief | None = None,
+    codex_transport: str | None = None,
 ) -> dict[str, object]:
     payload: dict[str, object] = {
         "task": task,
@@ -895,6 +938,8 @@ def _run_payload(
         payload["handoff"] = str(handoff_path)
     if error is not None:
         payload["error"] = error
+    if codex_transport is not None:
+        payload["codex_transport"] = codex_transport
     return payload
 
 
@@ -913,8 +958,10 @@ def run(
     sandbox: str | None = None,
     code_graph_enabled: bool = True,
     code_graph: CodeGraphBrief | None = None,
+    codex_transport: str | None = None,
 ) -> int:
     started_at = datetime.now(timezone.utc)
+    transport_for_payload = codex_transport or roster.codex_transport
     cwd = cwd.expanduser().resolve() if cwd is not None else None
     output_dir = output_dir.expanduser() if output_dir is not None else None
     handoff_inbox = handoff_inbox.expanduser() if handoff_inbox is not None else None
@@ -935,6 +982,7 @@ def run(
                 started_at=started_at,
                 output_dir=output_dir,
                 code_graph=code_graph,
+                codex_transport=transport_for_payload,
             ),
         )
 
@@ -968,6 +1016,7 @@ def run(
                     output_dir=output_dir,
                     error=str(exc),
                     code_graph=code_graph,
+                    codex_transport=transport_for_payload,
                 ),
             )
         print(f"error: {exc}", file=sys.stderr)
@@ -994,6 +1043,7 @@ def run(
                     finished_at=finished_at,
                     output_dir=output_dir,
                     code_graph=code_graph,
+                    codex_transport=transport_for_payload,
                 ),
             )
         print(json.dumps(payload, indent=2))
@@ -1002,15 +1052,39 @@ def run(
     if show_plan or verbose:
         _print_plan(assignments)
 
-    worker_results = dispatch(
-        assignments,
-        roster,
-        cwd=cwd,
-        read_only=read_only,
-        sandbox_read_only=sandbox_read_only,
-        sandbox=sandbox,
-        code_graph=code_graph,
+    effective_transport = codex_transport or roster.codex_transport
+    has_codex_workers = any(
+        (roster.agents.get(a.worker) is not None and roster.agents[a.worker].cli == "codex") for a in assignments
     )
+    appserver = None
+    if effective_transport == "app-server" and has_codex_workers:
+        try:
+            appserver = codex_appserver.AppServer(cwd=cwd)
+            appserver.start()
+        except codex_appserver.AppServerError as exc:
+            print(f"warning: codex app-server unavailable ({exc}); falling back to exec", file=sys.stderr)
+            appserver = None
+            effective_transport = "exec"
+    elif effective_transport == "app-server":
+        effective_transport = "exec"
+    transport_for_payload = effective_transport
+
+    try:
+        worker_results = dispatch(
+            assignments,
+            roster,
+            cwd=cwd,
+            read_only=read_only,
+            sandbox_read_only=sandbox_read_only,
+            sandbox=sandbox,
+            code_graph=code_graph,
+            appserver=appserver,
+            events_dir=(output_dir / "events") if (output_dir is not None and appserver is not None) else None,
+            verbose=verbose,
+        )
+    finally:
+        if appserver is not None:
+            appserver.close()
     ground_truth = build_ground_truth(cwd, started_at)
     if output_dir is not None:
         _write_json(
@@ -1056,6 +1130,7 @@ def run(
                     output_dir=output_dir,
                     error=final.detail,
                     code_graph=code_graph,
+                    codex_transport=transport_for_payload,
                 ),
             )
         print(f"error: orchestrator failed during synthesis: {final.detail}", file=sys.stderr)
@@ -1076,6 +1151,7 @@ def run(
                 finished_at=finished_at,
                 output_dir=output_dir,
                 code_graph=code_graph,
+                codex_transport=transport_for_payload,
             ),
         )
     if handoff_inbox is not None:
@@ -1108,6 +1184,7 @@ def run(
                         output_dir=output_dir,
                         error=detail,
                         code_graph=code_graph,
+                        codex_transport=transport_for_payload,
                     ),
                 )
             print(f"error: {detail}", file=sys.stderr)
@@ -1130,6 +1207,7 @@ def run(
                     output_dir=output_dir,
                     handoff_path=handoff,
                     code_graph=code_graph,
+                    codex_transport=transport_for_payload,
                 ),
             )
     print(final.text)

--- a/src/brigade/agents.py
+++ b/src/brigade/agents.py
@@ -172,6 +172,9 @@ class AgentResult:
     text: str
     ok: bool
     detail: str = ""
+    # app-server transport extras; None/"" on the exec path.
+    thread_id: str | None = None
+    status: str = ""
 
 
 def is_known(cli_ref: str) -> bool:
@@ -291,3 +294,40 @@ def run_agent(
     if not text:
         return AgentResult(text="", ok=False, detail="empty output")
     return AgentResult(text=text, ok=True)
+
+
+def run_codex_appserver(
+    server,
+    prompt: str,
+    *,
+    timeout: float,
+    cwd: Path | None,
+    read_only: bool = False,
+    sandbox: str | None = None,
+    model: str | None = None,
+    on_event=None,
+) -> AgentResult:
+    """Run one codex worker as a thread + turn on a shared app-server.
+
+    Mirrors run_agent's contract: empty output is a failure, detail is capped.
+    """
+    from . import codex_appserver
+
+    effective_sandbox = sandbox if sandbox is not None else ("read-only" if read_only else None)
+    try:
+        thread = server.start_thread(cwd=cwd, model=model, sandbox=effective_sandbox)
+        turn = thread.run_turn(prompt, timeout=timeout, on_event=on_event)
+    except codex_appserver.AppServerError as exc:
+        return AgentResult(text="", ok=False, detail=str(exc)[:200], status="failed")
+    text = turn.text.strip()
+    if not turn.ok:
+        return AgentResult(
+            text=text,
+            ok=False,
+            detail=(turn.detail or f"turn {turn.status}")[:200],
+            thread_id=turn.thread_id,
+            status=turn.status,
+        )
+    if not text:
+        return AgentResult(text="", ok=False, detail="empty output", thread_id=turn.thread_id, status=turn.status)
+    return AgentResult(text=text, ok=True, thread_id=turn.thread_id, status=turn.status)

--- a/src/brigade/cli/run.py
+++ b/src/brigade/cli/run.py
@@ -50,6 +50,12 @@ def register(sub: argparse._SubParsersAction) -> None:
         ),
     )
     p_run.add_argument(
+        "--codex-transport",
+        choices=["exec", "app-server"],
+        default=None,
+        help="Transport for codex workers. Defaults to the roster's codex_transport (exec).",
+    )
+    p_run.add_argument(
         "--inspect",
         action="store_true",
         help="Print a readable artifact summary after the run completes.",
@@ -187,6 +193,8 @@ def dispatch(args) -> int:
                 "read_only": args.read_only,
                 "sandbox": effective_sandbox,
             }
+            if args.codex_transport is not None:
+                run_kwargs["codex_transport"] = args.codex_transport
             if args.no_code_graph:
                 run_kwargs["code_graph_enabled"] = False
             rc = aboyeur_mod.run(args.task, loaded_roster, **run_kwargs)

--- a/src/brigade/cli/runs.py
+++ b/src/brigade/cli/runs.py
@@ -40,6 +40,10 @@ def register(sub: argparse._SubParsersAction) -> None:
     )
     p_runs_show = runs_sub.add_parser("show", help="Show a readable summary of one run directory.")
     p_runs_show.add_argument("run_dir", type=Path, help="Path to a Brigade run artifact directory.")
+    p_runs_resume = runs_sub.add_parser(
+        "resume", help="Re-attach interrupted app-server workers from a run and re-synthesize."
+    )
+    p_runs_resume.add_argument("run_dir", type=Path, help="Path to a Brigade run artifact directory.")
     p_runs.set_defaults(func=dispatch)
 
 
@@ -52,5 +56,9 @@ def dispatch(args) -> int:
         return runs_cmd.show_latest(cwd=args.cwd, runs_dir=args.runs_dir)
     if args.runs_command == "show":
         return runs_cmd.show(args.run_dir)
+    if args.runs_command == "resume":
+        from .. import run_resume
+
+        return run_resume.resume(args.run_dir)
     args._brigade_parser.error(f"unknown runs command: {args.runs_command}")
     return 2

--- a/src/brigade/codex_appserver.py
+++ b/src/brigade/codex_appserver.py
@@ -125,9 +125,7 @@ class AppServer:
             raise AppServerError(f"{method} failed: {error.get('message', error)}")
         return response.get("result") or {}
 
-    def start_thread(
-        self, *, cwd: Path | None, model: str | None = None, sandbox: str | None = None
-    ) -> "CodexThread":
+    def start_thread(self, *, cwd: Path | None, model: str | None = None, sandbox: str | None = None) -> "CodexThread":
         result = self.request("thread/start", self._thread_params(cwd, model, sandbox))
         return self._attach(result["thread"]["id"])
 
@@ -158,9 +156,7 @@ class AppServer:
             for orphan_id, msg in list(self._orphans):
                 if orphan_id == thread_id:
                     q.put(msg)
-            self._orphans = deque(
-                ((tid, m) for tid, m in self._orphans if tid != thread_id), maxlen=_ORPHAN_LIMIT
-            )
+            self._orphans = deque(((tid, m) for tid, m in self._orphans if tid != thread_id), maxlen=_ORPHAN_LIMIT)
         if dead:
             q.put(_DEAD)
         return CodexThread(self, thread_id, q)
@@ -295,9 +291,7 @@ class CodexThread:
             )
         except AppServerError:
             pass
-        completed = self._consume(
-            time.monotonic() + _INTERRUPT_GRACE, turn_id, deltas, completed_texts, on_event
-        )
+        completed = self._consume(time.monotonic() + _INTERRUPT_GRACE, turn_id, deltas, completed_texts, on_event)
         salvaged = self._salvage(deltas, completed_texts)
         detail = f"timeout after {timeout}s; interrupted"
         if completed is _DEAD:

--- a/src/brigade/codex_appserver.py
+++ b/src/brigade/codex_appserver.py
@@ -1,0 +1,391 @@
+"""JSON-RPC stdio client for `codex app-server`.
+
+Every protocol-shape assumption for the experimental app-server API lives in
+this module and nowhere else. Wire format: newline-delimited JSON-RPC 2.0
+(verified against codex-cli 0.142.5). Approval requests from the server are
+always auto-declined: brigade runs are headless and rely on approvalPolicy
+"never" plus an explicit sandbox.
+"""
+
+from __future__ import annotations
+
+import json
+import queue
+import subprocess
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+_CLIENT_NAME = "brigade"
+_CLIENT_VERSION = "0.0.0"
+_REQUEST_TIMEOUT = 30.0
+_INTERRUPT_GRACE = 5.0
+_ORPHAN_LIMIT = 1000
+_DEAD = object()  # queue sentinel: server process is gone
+
+# Chatty per-token notifications: consumed for salvage, never forwarded to on_event.
+_DELTA_METHODS = frozenset(
+    {
+        "item/agentMessage/delta",
+        "item/plan/delta",
+        "item/reasoning/textDelta",
+        "item/reasoning/summaryTextDelta",
+        "item/commandExecution/outputDelta",
+        "item/fileChange/outputDelta",
+        "command/exec/outputDelta",
+        "process/outputDelta",
+    }
+)
+
+
+class AppServerError(RuntimeError):
+    """Spawn, handshake, transport, or server-reported request failure."""
+
+
+@dataclass(frozen=True)
+class TurnResult:
+    text: str
+    ok: bool
+    status: str  # complete | interrupted | failed
+    thread_id: str
+    detail: str = ""
+
+
+class AppServer:
+    """One `codex app-server` child; thread-safe for concurrent CodexThread turns."""
+
+    def __init__(self, argv: list[str] | None = None, cwd: Path | None = None) -> None:
+        self._argv = argv or ["codex", "app-server"]
+        self._cwd = cwd
+        self._proc: subprocess.Popen | None = None
+        self._write_lock = threading.Lock()
+        self._state_lock = threading.Lock()
+        self._next_id = 0
+        self._pending: dict[int, dict] = {}  # id -> {"event": Event, "response": msg}
+        self._queues: dict[str, queue.Queue] = {}
+        self._orphans: deque[tuple[str, dict]] = deque(maxlen=_ORPHAN_LIMIT)
+        self._dead = False
+
+    def __enter__(self) -> "AppServer":
+        self.start()
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.close()
+
+    def start(self) -> None:
+        try:
+            self._proc = subprocess.Popen(
+                self._argv,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+                cwd=self._cwd,
+            )
+        except OSError as exc:
+            raise AppServerError(f"failed to spawn {self._argv[0]}: {exc}") from exc
+        threading.Thread(target=self._read_loop, daemon=True).start()
+        self.request(
+            "initialize",
+            {"clientInfo": {"name": _CLIENT_NAME, "version": _CLIENT_VERSION}},
+        )
+        self._send({"jsonrpc": "2.0", "method": "initialized"})
+
+    def close(self) -> None:
+        proc = self._proc
+        if proc is None:
+            return
+        proc.terminate()
+        try:
+            proc.wait(timeout=5.0)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5.0)
+
+    def request(self, method: str, params: dict, timeout: float = _REQUEST_TIMEOUT) -> dict:
+        with self._state_lock:
+            if self._dead:
+                raise AppServerError("app-server exited")
+            self._next_id += 1
+            req_id = self._next_id
+            entry: dict = {"event": threading.Event(), "response": None}
+            self._pending[req_id] = entry
+        self._send({"jsonrpc": "2.0", "id": req_id, "method": method, "params": params})
+        if not entry["event"].wait(timeout):
+            with self._state_lock:
+                self._pending.pop(req_id, None)
+            raise AppServerError(f"{method} timed out after {timeout}s")
+        response = entry["response"]
+        if response is None or "error" in response:
+            error = (response or {}).get("error") or {"message": "app-server exited"}
+            raise AppServerError(f"{method} failed: {error.get('message', error)}")
+        return response.get("result") or {}
+
+    def start_thread(
+        self, *, cwd: Path | None, model: str | None = None, sandbox: str | None = None
+    ) -> "CodexThread":
+        result = self.request("thread/start", self._thread_params(cwd, model, sandbox))
+        return self._attach(result["thread"]["id"])
+
+    def resume_thread(
+        self, thread_id: str, *, cwd: Path | None, model: str | None = None, sandbox: str | None = None
+    ) -> "CodexThread":
+        params = self._thread_params(cwd, model, sandbox)
+        params["threadId"] = thread_id
+        result = self.request("thread/resume", params)
+        return self._attach(result["thread"]["id"])
+
+    def _thread_params(self, cwd: Path | None, model: str | None, sandbox: str | None) -> dict:
+        # Omitted keys fall through to the user's codex config, matching exec behavior.
+        params: dict = {"approvalPolicy": "never", "ephemeral": False}
+        if cwd is not None:
+            params["cwd"] = str(cwd)
+        if model is not None:
+            params["model"] = model
+        if sandbox is not None:
+            params["sandbox"] = sandbox
+        return params
+
+    def _attach(self, thread_id: str) -> "CodexThread":
+        q: queue.Queue = queue.Queue()
+        with self._state_lock:
+            self._queues[thread_id] = q
+            dead = self._dead
+            for orphan_id, msg in list(self._orphans):
+                if orphan_id == thread_id:
+                    q.put(msg)
+            self._orphans = deque(
+                ((tid, m) for tid, m in self._orphans if tid != thread_id), maxlen=_ORPHAN_LIMIT
+            )
+        if dead:
+            q.put(_DEAD)
+        return CodexThread(self, thread_id, q)
+
+    def _send(self, obj: dict) -> None:
+        proc = self._proc
+        if proc is None or proc.stdin is None:
+            raise AppServerError("app-server not started")
+        line = json.dumps(obj) + "\n"
+        with self._write_lock:
+            try:
+                proc.stdin.write(line)
+                proc.stdin.flush()
+            except (BrokenPipeError, OSError) as exc:
+                raise AppServerError("app-server exited") from exc
+
+    def _read_loop(self) -> None:
+        assert self._proc is not None and self._proc.stdout is not None
+        for line in self._proc.stdout:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                msg = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(msg, dict):
+                continue
+            if msg.get("id") is not None and "method" in msg:
+                self._handle_server_request(msg)
+            elif msg.get("id") is not None:
+                self._handle_response(msg)
+            elif "method" in msg:
+                self._route_notification(msg)
+        with self._state_lock:
+            self._dead = True
+            pending = list(self._pending.values())
+            self._pending.clear()
+            queues = list(self._queues.values())
+        for entry in pending:
+            entry["event"].set()
+        for q in queues:
+            q.put(_DEAD)
+
+    def _handle_response(self, msg: dict) -> None:
+        with self._state_lock:
+            entry = self._pending.pop(msg["id"], None)
+        if entry is not None:
+            entry["response"] = msg
+            entry["event"].set()
+
+    def _handle_server_request(self, msg: dict) -> None:
+        # Headless policy: decline every approval; refuse anything else.
+        method = str(msg.get("method", ""))
+        if "pproval" in method:
+            reply: dict = {"jsonrpc": "2.0", "id": msg["id"], "result": {"decision": "decline"}}
+        else:
+            reply = {
+                "jsonrpc": "2.0",
+                "id": msg["id"],
+                "error": {"code": -32000, "message": "brigade runs headless; request declined"},
+            }
+        try:
+            self._send(reply)
+        except AppServerError:
+            return
+        params = msg.get("params") or {}
+        thread_id = params.get("threadId")
+        if isinstance(thread_id, str):
+            self._route_to_thread(
+                thread_id,
+                {"method": f"{method}#auto-declined", "params": params},
+            )
+
+    def _route_notification(self, msg: dict) -> None:
+        params = msg.get("params") or {}
+        thread_id = params.get("threadId")
+        if not isinstance(thread_id, str):
+            thread = params.get("thread")
+            thread_id = thread.get("id") if isinstance(thread, dict) else None
+        if isinstance(thread_id, str):
+            self._route_to_thread(thread_id, msg)
+
+    def _route_to_thread(self, thread_id: str, msg: dict) -> None:
+        with self._state_lock:
+            q = self._queues.get(thread_id)
+            if q is None:
+                self._orphans.append((thread_id, msg))
+                return
+        q.put(msg)
+
+
+class CodexThread:
+    def __init__(self, server: AppServer, thread_id: str, q: queue.Queue) -> None:
+        self._server = server
+        self.thread_id = thread_id
+        self._queue = q
+
+    def steer(self, text: str, turn_id: str) -> None:
+        self._server.request(
+            "turn/steer",
+            {"threadId": self.thread_id, "expectedTurnId": turn_id, "input": [{"type": "text", "text": text}]},
+        )
+
+    def run_turn(
+        self,
+        prompt: str,
+        *,
+        timeout: float,
+        on_event: Callable[[dict], None] | None = None,
+    ) -> TurnResult:
+        try:
+            result = self._server.request(
+                "turn/start",
+                {"threadId": self.thread_id, "input": [{"type": "text", "text": prompt}]},
+            )
+        except AppServerError as exc:
+            return TurnResult(text="", ok=False, status="failed", thread_id=self.thread_id, detail=str(exc)[:200])
+        turn_id = result["turn"]["id"]
+        deltas: dict[str, list[str]] = {}
+        completed_texts: list[str] = []
+        deadline = time.monotonic() + timeout
+
+        completed = self._consume(deadline, turn_id, deltas, completed_texts, on_event)
+        if completed is not None:
+            return self._finish(completed, deltas, completed_texts)
+
+        # Timed out: interrupt, then drain briefly for the interrupted turn/completed.
+        try:
+            self._server.request(
+                "turn/interrupt", {"threadId": self.thread_id, "turnId": turn_id}, timeout=_INTERRUPT_GRACE
+            )
+        except AppServerError:
+            pass
+        completed = self._consume(
+            time.monotonic() + _INTERRUPT_GRACE, turn_id, deltas, completed_texts, on_event
+        )
+        salvaged = self._salvage(deltas, completed_texts)
+        detail = f"timeout after {timeout}s; interrupted"
+        if completed is _DEAD:
+            detail = "app-server exited"
+        elif completed is not None:
+            turn = completed["params"]["turn"]
+            if turn.get("status") == "failed":
+                detail = ((turn.get("error") or {}).get("message") or detail)[:200]
+        return TurnResult(text=salvaged, ok=False, status="interrupted", thread_id=self.thread_id, detail=detail)
+
+    def _consume(
+        self,
+        deadline: float,
+        turn_id: str,
+        deltas: dict[str, list[str]],
+        completed_texts: list[str],
+        on_event: Callable[[dict], None] | None,
+    ):
+        """Pump notifications until turn/completed, server death, or deadline.
+
+        Returns the turn/completed message, the _DEAD sentinel, or None on deadline.
+        """
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return None
+            try:
+                msg = self._queue.get(timeout=remaining)
+            except queue.Empty:
+                return None
+            if msg is _DEAD:
+                return _DEAD
+            method = msg.get("method", "")
+            params = msg.get("params") or {}
+            if method in _DELTA_METHODS:
+                item_id = params.get("itemId")
+                delta = params.get("delta")
+                if method == "item/agentMessage/delta" and isinstance(item_id, str) and isinstance(delta, str):
+                    deltas.setdefault(item_id, []).append(delta)
+                continue
+            if on_event is not None:
+                try:
+                    on_event(msg)
+                except Exception:  # noqa: BLE001 - observer must never kill the turn
+                    pass
+            if method == "item/completed":
+                item = params.get("item") or {}
+                if item.get("type") == "agentMessage" and isinstance(item.get("text"), str):
+                    completed_texts.append(item["text"])
+            elif method == "turn/completed" and (params.get("turn") or {}).get("id") == turn_id:
+                return msg
+
+    def _finish(self, completed, deltas: dict, completed_texts: list[str]) -> TurnResult:
+        if completed is _DEAD:
+            return TurnResult(
+                text=self._salvage(deltas, completed_texts),
+                ok=False,
+                status="failed",
+                thread_id=self.thread_id,
+                detail="app-server exited",
+            )
+        turn = completed["params"]["turn"]
+        status = turn.get("status")
+        agent_texts = [
+            item.get("text", "")
+            for item in turn.get("items", [])
+            if isinstance(item, dict) and item.get("type") == "agentMessage"
+        ]
+        text = (agent_texts[-1] if agent_texts else "") or self._salvage(deltas, completed_texts)
+        if status == "completed":
+            return TurnResult(
+                text=text,
+                ok=bool(text),
+                status="complete",
+                thread_id=self.thread_id,
+                detail="" if text else "empty output",
+            )
+        if status == "interrupted":
+            return TurnResult(
+                text=text, ok=False, status="interrupted", thread_id=self.thread_id, detail="turn interrupted"
+            )
+        detail = ((turn.get("error") or {}).get("message") or f"turn status: {status}")[:200]
+        return TurnResult(text=text, ok=False, status="failed", thread_id=self.thread_id, detail=detail)
+
+    def _salvage(self, deltas: dict[str, list[str]], completed_texts: list[str]) -> str:
+        if completed_texts:
+            return completed_texts[-1]
+        if deltas:
+            last_item = list(deltas)[-1]
+            return "".join(deltas[last_item])
+        return ""

--- a/src/brigade/roster.py
+++ b/src/brigade/roster.py
@@ -10,6 +10,7 @@ from . import agents as agent_adapters
 from . import toml_compat
 
 SANDBOX_CHOICES = ("read-only", "workspace-write", "danger-full-access")
+CODEX_TRANSPORT_CHOICES = ("exec", "app-server")
 
 
 @dataclass(frozen=True)
@@ -31,6 +32,7 @@ class Roster:
     allow_models: tuple[str, ...] = ()
     timeout_seconds: float = 600.0
     sandbox: str | None = None
+    codex_transport: str = "exec"
 
     def find_role(self, role: str) -> Agent | None:
         return next((a for a in self.agents.values() if a.role == role), None)
@@ -96,6 +98,11 @@ def load_roster(path: Path) -> Roster:
     timeout_seconds = _as_positive_number(limits.get("timeout_seconds", 600.0), "limits.timeout_seconds")
     sandbox = _as_sandbox(limits.get("sandbox"))
 
+    codex_transport = data.get("codex_transport", "exec")
+    if codex_transport not in CODEX_TRANSPORT_CHOICES:
+        choices = ", ".join(CODEX_TRANSPORT_CHOICES)
+        raise ValueError(f"codex_transport must be one of: {choices}")
+
     raw_allow_models = limits.get("allow_models", [])
     if raw_allow_models is None:
         raw_allow_models = []
@@ -157,6 +164,7 @@ def load_roster(path: Path) -> Roster:
         allow_models=allow_models,
         timeout_seconds=timeout_seconds,
         sandbox=sandbox,
+        codex_transport=codex_transport,
     )
 
 

--- a/src/brigade/run_resume.py
+++ b/src/brigade/run_resume.py
@@ -1,0 +1,177 @@
+"""Re-attach interrupted app-server workers from a past run and re-synthesize.
+
+Salvage path, not a throughput path: workers resume sequentially. Only codex
+workers that ran over the app-server transport carry a thread_id and can be
+resumed; everything else is reported as non-resumable.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from . import aboyeur, agents, codex_appserver
+from .roster import Agent, Roster
+
+_RESUMABLE_STATUSES = ("interrupted", "failed")
+
+
+def _load_json(run_dir: Path, name: str) -> dict | None:
+    path = run_dir / name
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _roster_from_snapshot(snapshot: dict) -> Roster:
+    agents_map = {}
+    for name, raw in (snapshot.get("agents") or {}).items():
+        agents_map[name] = Agent(
+            name=name,
+            cli=raw.get("cli"),
+            role=raw.get("role") or "",
+            timeout_seconds=raw.get("timeout_seconds"),
+            model=raw.get("model"),
+        )
+    return Roster(
+        orchestrator=snapshot["orchestrator"],
+        agents=agents_map,
+        max_workers=snapshot.get("max_workers", 4),
+        allow_models=tuple(snapshot.get("allow_models") or ()),
+        timeout_seconds=snapshot.get("timeout_seconds", 600.0),
+        sandbox=snapshot.get("sandbox"),
+    )
+
+
+def _continuation_prompt(task: str) -> str:
+    return (
+        "You were interrupted before finishing. Original sub-task:\n"
+        f"{task}\n\n"
+        "Finish the sub-task and return a concise, complete final result."
+    )
+
+
+def resume(run_dir: Path) -> int:
+    run_dir = run_dir.expanduser().resolve()
+    run_meta = _load_json(run_dir, "run.json")
+    roster_snapshot = _load_json(run_dir, "roster.json")
+    worker_data = _load_json(run_dir, "worker-results.json")
+    if run_meta is None or roster_snapshot is None or worker_data is None:
+        print(
+            f"error: missing run artifacts in {run_dir} (need run.json, roster.json, worker-results.json)",
+            file=sys.stderr,
+        )
+        return 2
+
+    roster = _roster_from_snapshot(roster_snapshot)
+    results = list(worker_data.get("results") or [])
+    resumable = [
+        r
+        for r in results
+        if isinstance(r.get("thread_id"), str) and not r.get("ok") and r.get("status") in _RESUMABLE_STATUSES
+    ]
+    stuck = [r for r in results if not r.get("ok") and r not in resumable]
+    for r in stuck:
+        print(
+            f"non-resumable: {r.get('worker')} ({r.get('detail') or 'failed'}) - no app-server thread recorded",
+            file=sys.stderr,
+        )
+    if not resumable:
+        print("error: no resumable workers in this run", file=sys.stderr)
+        return 2
+
+    cwd = Path(run_meta["cwd"]) if run_meta.get("cwd") else None
+    read_only = bool(run_meta.get("read_only"))
+    sandbox = roster_snapshot.get("sandbox")
+
+    server = codex_appserver.AppServer(cwd=cwd)
+    try:
+        server.start()
+    except codex_appserver.AppServerError as exc:
+        print(f"error: codex app-server unavailable: {exc}", file=sys.stderr)
+        return 2
+    try:
+        for entry in resumable:
+            worker = entry.get("worker", "")
+            agent = roster.agents.get(worker)
+            timeout = agent.timeout_seconds if agent and agent.timeout_seconds is not None else roster.timeout_seconds
+            print(f"resuming: {worker} (thread {entry['thread_id']})", file=sys.stderr)
+            try:
+                thread = server.resume_thread(
+                    entry["thread_id"],
+                    cwd=cwd,
+                    model=agent.model if agent else None,
+                    sandbox=sandbox if sandbox is not None else ("read-only" if read_only else None),
+                )
+                turn = thread.run_turn(_continuation_prompt(entry.get("task", "")), timeout=timeout)
+            except codex_appserver.AppServerError as exc:
+                entry["detail"] = str(exc)[:200]
+                entry["status"] = "failed"
+                continue
+            entry["text"] = turn.text.strip()
+            entry["ok"] = turn.ok and bool(turn.text.strip())
+            entry["detail"] = "" if entry["ok"] else (turn.detail or f"turn {turn.status}")[:200]
+            entry["status"] = turn.status
+    finally:
+        server.close()
+
+    worker_results = [
+        aboyeur.WorkerResult(
+            worker=r.get("worker", ""),
+            task=r.get("task", ""),
+            text=r.get("text", ""),
+            ok=bool(r.get("ok")),
+            detail=r.get("detail", ""),
+            thread_id=r.get("thread_id"),
+            status=r.get("status", ""),
+        )
+        for r in results
+    ]
+    ground_truth = worker_data.get("ground_truth") or {}
+    (run_dir / "worker-results.json").write_text(
+        json.dumps({"results": aboyeur._worker_payload(worker_results), "ground_truth": ground_truth}, indent=2)
+        + "\n"
+    )
+
+    task = run_meta.get("task", "")
+    synth_prompt = aboyeur.build_synth_prompt(task, worker_results, read_only=read_only, ground_truth=ground_truth)
+    orchestrator = roster.agents[roster.orchestrator]
+    final = agents.run_agent(
+        orchestrator.cli,
+        synth_prompt,
+        timeout=orchestrator.timeout_seconds or roster.timeout_seconds,
+        cwd=cwd,
+        read_only=read_only,
+        **({"model": orchestrator.model} if orchestrator.model is not None else {}),
+    )
+    (run_dir / "synthesis.json").write_text(
+        json.dumps(
+            {
+                "orchestrator": roster.orchestrator,
+                "result": {"ok": final.ok, "detail": final.detail, "text": final.text},
+                "ground_truth": ground_truth,
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+    now = datetime.now(timezone.utc).isoformat()
+    run_meta.setdefault("resumed_at", []).append(now)
+    if not final.ok:
+        run_meta["status"] = "failed"
+        run_meta["error"] = final.detail
+        (run_dir / "run.json").write_text(json.dumps(run_meta, indent=2) + "\n")
+        print(f"error: orchestrator failed during synthesis: {final.detail}", file=sys.stderr)
+        return 2
+    (run_dir / "final.txt").write_text(final.text + "\n")
+    run_meta["status"] = "ok"
+    run_meta.pop("error", None)
+    (run_dir / "run.json").write_text(json.dumps(run_meta, indent=2) + "\n")
+    print(final.text)
+    return 0

--- a/src/brigade/run_resume.py
+++ b/src/brigade/run_resume.py
@@ -135,8 +135,7 @@ def resume(run_dir: Path) -> int:
     ]
     ground_truth = worker_data.get("ground_truth") or {}
     (run_dir / "worker-results.json").write_text(
-        json.dumps({"results": aboyeur._worker_payload(worker_results), "ground_truth": ground_truth}, indent=2)
-        + "\n"
+        json.dumps({"results": aboyeur._worker_payload(worker_results), "ground_truth": ground_truth}, indent=2) + "\n"
     )
 
     task = run_meta.get("task", "")

--- a/src/brigade/run_resume.py
+++ b/src/brigade/run_resume.py
@@ -141,6 +141,12 @@ def resume(run_dir: Path) -> int:
     task = run_meta.get("task", "")
     synth_prompt = aboyeur.build_synth_prompt(task, worker_results, read_only=read_only, ground_truth=ground_truth)
     orchestrator = roster.agents[roster.orchestrator]
+    if orchestrator.cli is None:
+        print(
+            f"error: orchestrator {roster.orchestrator!r} has no CLI in roster.json; cannot re-synthesize",
+            file=sys.stderr,
+        )
+        return 2
     final = agents.run_agent(
         orchestrator.cli,
         synth_prompt,

--- a/tests/fake_appserver.py
+++ b/tests/fake_appserver.py
@@ -100,7 +100,9 @@ def main() -> int:
                     "result": {"turn": {"id": turn_id, "items": [], "status": "inProgress"}},
                 }
             )
-            _notify("turn/started", {"threadId": thread_id, "turn": {"id": turn_id, "items": [], "status": "inProgress"}})
+            _notify(
+                "turn/started", {"threadId": thread_id, "turn": {"id": turn_id, "items": [], "status": "inProgress"}}
+            )
             if "HANG" in prompt:
                 _notify(
                     "item/agentMessage/delta",

--- a/tests/fake_appserver.py
+++ b/tests/fake_appserver.py
@@ -1,0 +1,146 @@
+"""Scripted stand-in for `codex app-server` used by test_codex_appserver.py.
+
+Speaks newline-delimited JSON-RPC on stdio. Turn behavior is selected by the
+prompt text of turn/start: HANG, APPROVAL, DIE, NOISE, or normal completion.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+_next_thread = 0
+
+
+def _send(obj: dict) -> None:
+    sys.stdout.write(json.dumps(obj) + "\n")
+    sys.stdout.flush()
+
+
+def _notify(method: str, params: dict) -> None:
+    _send({"jsonrpc": "2.0", "method": method, "params": params})
+
+
+def _thread_payload(thread_id: str) -> dict:
+    return {
+        "id": thread_id,
+        "cliVersion": "0.0.0-fake",
+        "createdAt": 0,
+        "updatedAt": 0,
+        "cwd": "/tmp",
+        "ephemeral": False,
+        "modelProvider": "fake",
+        "preview": "",
+        "sessionId": "fake-session",
+        "source": "fake",
+        "status": {"type": "idle"},
+        "turns": [],
+    }
+
+
+def _agent_item(item_id: str, text: str) -> dict:
+    return {"id": item_id, "type": "agentMessage", "text": text}
+
+
+def _complete_turn(thread_id: str, turn_id: str, status: str, text: str | None) -> None:
+    items = [_agent_item(f"{turn_id}-msg", text)] if text is not None else []
+    for item in items:
+        _notify(
+            "item/completed",
+            {"threadId": thread_id, "turnId": turn_id, "completedAtMs": 0, "item": item},
+        )
+    _notify(
+        "turn/completed",
+        {"threadId": thread_id, "turn": {"id": turn_id, "items": items, "status": status}},
+    )
+
+
+def main() -> int:
+    global _next_thread
+    pending_hang: dict[str, str] = {}  # turnId -> threadId
+    pending_approval: dict[int, tuple[str, str]] = {}  # request id -> (threadId, turnId)
+    server_req_id = 1000
+
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        msg = json.loads(line)
+        method = msg.get("method")
+        msg_id = msg.get("id")
+
+        if msg_id is not None and method is None:
+            # Response to a server->client request (approval decision).
+            entry = pending_approval.pop(msg_id, None)
+            if entry is not None:
+                thread_id, turn_id = entry
+                decision = (msg.get("result") or {}).get("decision")
+                _complete_turn(thread_id, turn_id, "completed", f"approval:{decision}")
+            continue
+
+        if method == "initialize":
+            _send({"jsonrpc": "2.0", "id": msg_id, "result": {"userAgent": "fake/0.0.0"}})
+        elif method == "initialized":
+            pass
+        elif method in ("thread/start", "thread/resume"):
+            thread_id = msg["params"].get("threadId")
+            if thread_id is None:
+                _next_thread += 1
+                thread_id = f"t-{_next_thread}"
+            _send({"jsonrpc": "2.0", "id": msg_id, "result": {"thread": _thread_payload(thread_id)}})
+        elif method == "turn/start":
+            params = msg["params"]
+            thread_id = params["threadId"]
+            prompt = params["input"][0]["text"]
+            turn_id = f"turn-{thread_id}"
+            _send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": msg_id,
+                    "result": {"turn": {"id": turn_id, "items": [], "status": "inProgress"}},
+                }
+            )
+            _notify("turn/started", {"threadId": thread_id, "turn": {"id": turn_id, "items": [], "status": "inProgress"}})
+            if "HANG" in prompt:
+                _notify(
+                    "item/agentMessage/delta",
+                    {"threadId": thread_id, "turnId": turn_id, "itemId": f"{turn_id}-msg", "delta": "partial "},
+                )
+                _notify(
+                    "item/agentMessage/delta",
+                    {"threadId": thread_id, "turnId": turn_id, "itemId": f"{turn_id}-msg", "delta": "answer"},
+                )
+                pending_hang[turn_id] = thread_id
+            elif "APPROVAL" in prompt:
+                server_req_id += 1
+                pending_approval[server_req_id] = (thread_id, turn_id)
+                _send(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": server_req_id,
+                        "method": "item/commandExecution/requestApproval",
+                        "params": {"threadId": thread_id, "turnId": turn_id, "itemId": "cmd-1"},
+                    }
+                )
+            elif "DIE" in prompt:
+                return 1
+            else:
+                if "NOISE" in prompt:
+                    _notify("totally/unknown", {"threadId": thread_id, "mystery": True})
+                _notify(
+                    "item/started",
+                    {"threadId": thread_id, "turnId": turn_id, "item": {"id": "cmd-0", "type": "commandExecution"}},
+                )
+                _complete_turn(thread_id, turn_id, "completed", f"result for: {prompt}")
+        elif method == "turn/interrupt":
+            turn_id = msg["params"]["turnId"]
+            thread_id = pending_hang.pop(turn_id, msg["params"]["threadId"])
+            _send({"jsonrpc": "2.0", "id": msg_id, "result": {}})
+            _complete_turn(thread_id, turn_id, "interrupted", None)
+        else:
+            _send({"jsonrpc": "2.0", "id": msg_id, "result": {}})
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -1038,3 +1038,104 @@ def test_verify_receipts_sorted_chronologically_across_timezone_offsets(tmp_path
     receipts = aboyeur._verify_receipts_since(tmp_path, datetime(2020, 1, 1, tzinfo=timezone.utc))
 
     assert [r["run_id"] for r in receipts] == ["later-utc", "earlier-but-lexically-larger"]
+
+
+def _appserver_roster():
+    return Roster(
+        orchestrator="chef",
+        agents={
+            "chef": Agent("chef", "claude", "plan and synthesize"),
+            "cook": Agent("cook", "codex", "write code"),
+            "scout": Agent("scout", "claude", "search"),
+        },
+        codex_transport="app-server",
+    )
+
+
+class _StubAppServerThread:
+    def __init__(self, thread_id):
+        self.thread_id = thread_id
+
+    def run_turn(self, prompt, *, timeout, on_event=None):
+        from brigade import codex_appserver
+
+        if on_event is not None:
+            on_event({"method": "item/completed", "params": {"threadId": self.thread_id}})
+        return codex_appserver.TurnResult(
+            text=f"appserver says: {prompt[:20]}", ok=True, status="complete", thread_id=self.thread_id
+        )
+
+
+class _StubAppServer:
+    def __init__(self):
+        self.started = []
+
+    def start_thread(self, *, cwd, model=None, sandbox=None):
+        self.started.append({"cwd": cwd, "model": model, "sandbox": sandbox})
+        return _StubAppServerThread(f"t-{len(self.started)}")
+
+
+def test_dispatch_routes_codex_through_appserver(monkeypatch, tmp_path):
+    roster = _appserver_roster()
+    server = _StubAppServer()
+
+    def fake_run_agent(cli_ref, prompt, **kwargs):
+        assert cli_ref != "codex", "codex must not take the exec path when a server is provided"
+        return agents.AgentResult(text="exec says hi", ok=True)
+
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+    assignments = [
+        aboyeur.Assignment(worker="cook", task="write code"),
+        aboyeur.Assignment(worker="scout", task="find things"),
+    ]
+    results = aboyeur.dispatch(assignments, roster, appserver=server, events_dir=tmp_path)
+    by_worker = {r.worker: r for r in results}
+    assert by_worker["cook"].thread_id == "t-1"
+    assert by_worker["cook"].status == "complete"
+    assert by_worker["scout"].thread_id is None
+    events_file = tmp_path / "cook.jsonl"
+    assert events_file.is_file()
+    assert '"item/completed"' in events_file.read_text()
+
+
+def test_worker_payload_includes_thread_fields_only_for_appserver():
+    results = [
+        aboyeur.WorkerResult(worker="cook", task="t", text="x", ok=True, thread_id="t-1", status="complete"),
+        aboyeur.WorkerResult(worker="scout", task="t", text="y", ok=True),
+    ]
+    payload = aboyeur._worker_payload(results)
+    assert payload[0]["thread_id"] == "t-1" and payload[0]["status"] == "complete"
+    assert "thread_id" not in payload[1] and "status" not in payload[1]
+
+
+def test_run_falls_back_to_exec_when_appserver_unavailable(monkeypatch, tmp_path, capsys):
+    roster = _appserver_roster()
+    monkeypatch.setattr(aboyeur, "_graphtrail_bin", lambda: None)
+
+    class _BoomServer:
+        def __init__(self, *a, **k):
+            pass
+
+        def start(self):
+            from brigade import codex_appserver
+
+            raise codex_appserver.AppServerError("no binary")
+
+    monkeypatch.setattr(aboyeur.codex_appserver, "AppServer", _BoomServer)
+    calls = []
+
+    def fake_run_agent(cli_ref, prompt, **kwargs):
+        calls.append(cli_ref)
+        if len(calls) == 1:
+            return agents.AgentResult(
+                text=json.dumps({"assignments": [{"worker": "cook", "task": "do"}]}), ok=True
+            )
+        return agents.AgentResult(text="done", ok=True)
+
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+    out = tmp_path / "run"
+    rc = aboyeur.run("task", roster, cwd=tmp_path, output_dir=out)
+    assert rc == 0
+    assert "falling back to exec" in capsys.readouterr().err
+    run_json = json.loads((out / "run.json").read_text())
+    assert run_json["codex_transport"] == "exec"

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -1127,9 +1127,7 @@ def test_run_falls_back_to_exec_when_appserver_unavailable(monkeypatch, tmp_path
     def fake_run_agent(cli_ref, prompt, **kwargs):
         calls.append(cli_ref)
         if len(calls) == 1:
-            return agents.AgentResult(
-                text=json.dumps({"assignments": [{"worker": "cook", "task": "do"}]}), ok=True
-            )
+            return agents.AgentResult(text=json.dumps({"assignments": [{"worker": "cook", "task": "do"}]}), ok=True)
         return agents.AgentResult(text="done", ok=True)
 
     monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -227,3 +227,68 @@ def test_run_agent_nonzero_is_not_ok(monkeypatch):
     res = agents.run_agent("claude", "x")
     assert res.ok is False
     assert "boom" in res.detail
+
+
+class _StubThread:
+    def __init__(self, result):
+        self._result = result
+        self.prompts = []
+
+    def run_turn(self, prompt, *, timeout, on_event=None):
+        self.prompts.append((prompt, timeout))
+        return self._result
+
+
+class _StubServer:
+    def __init__(self, result, fail=False):
+        self.thread = _StubThread(result)
+        self.calls = []
+        self.fail = fail
+
+    def start_thread(self, *, cwd, model=None, sandbox=None):
+        if self.fail:
+            from brigade import codex_appserver
+
+            raise codex_appserver.AppServerError("boom")
+        self.calls.append({"cwd": cwd, "model": model, "sandbox": sandbox})
+        return self.thread
+
+
+def test_run_codex_appserver_maps_turn_result():
+    from brigade import codex_appserver
+
+    turn = codex_appserver.TurnResult(text=" hi ", ok=True, status="complete", thread_id="t-1")
+    server = _StubServer(turn)
+    res = agents.run_codex_appserver(server, "do it", timeout=5.0, cwd=None, model="gpt-5.1", sandbox="workspace-write")
+    assert res.ok and res.text == "hi"
+    assert res.thread_id == "t-1" and res.status == "complete"
+    assert server.calls == [{"cwd": None, "model": "gpt-5.1", "sandbox": "workspace-write"}]
+
+
+def test_run_codex_appserver_read_only_maps_to_sandbox():
+    from brigade import codex_appserver
+
+    turn = codex_appserver.TurnResult(text="x", ok=True, status="complete", thread_id="t-1")
+    server = _StubServer(turn)
+    agents.run_codex_appserver(server, "p", timeout=5.0, cwd=None, read_only=True)
+    assert server.calls[0]["sandbox"] == "read-only"
+
+
+def test_run_codex_appserver_empty_text_not_ok():
+    from brigade import codex_appserver
+
+    turn = codex_appserver.TurnResult(text="", ok=True, status="complete", thread_id="t-1")
+    server = _StubServer(turn)
+    res = agents.run_codex_appserver(server, "p", timeout=5.0, cwd=None)
+    assert not res.ok and res.detail == "empty output"
+
+
+def test_run_codex_appserver_server_error_is_failed():
+    server = _StubServer(None, fail=True)
+    res = agents.run_codex_appserver(server, "p", timeout=5.0, cwd=None)
+    assert not res.ok and res.status == "failed" and "boom" in res.detail
+
+
+def test_agent_result_defaults_keep_exec_contract():
+    res = agents.AgentResult(text="t", ok=True)
+    assert res.thread_id is None and res.status == ""

--- a/tests/test_codex_appserver.py
+++ b/tests/test_codex_appserver.py
@@ -1,0 +1,80 @@
+"""Tests for the codex app-server JSON-RPC client against the fake server."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from brigade import codex_appserver
+
+FAKE = [sys.executable, str(Path(__file__).parent / "fake_appserver.py")]
+
+
+def _server():
+    return codex_appserver.AppServer(argv=FAKE)
+
+
+def test_happy_turn_returns_complete():
+    with _server() as server:
+        thread = server.start_thread(cwd=Path("/tmp"))
+        result = thread.run_turn("say hi", timeout=10.0)
+    assert result.ok
+    assert result.status == "complete"
+    assert result.text == "result for: say hi"
+    assert result.thread_id == "t-1"
+
+
+def test_events_are_streamed_without_deltas():
+    events: list[dict] = []
+    with _server() as server:
+        thread = server.start_thread(cwd=Path("/tmp"))
+        thread.run_turn("NOISE say hi", timeout=10.0, on_event=events.append)
+    methods = [e["method"] for e in events]
+    assert "turn/started" in methods
+    assert "item/started" in methods
+    assert "item/completed" in methods
+    assert "turn/completed" in methods
+    assert "totally/unknown" in methods  # unknown methods logged, not fatal
+    assert not any("delta" in m for m in methods)
+
+
+def test_timeout_interrupts_and_salvages_partial_text():
+    with _server() as server:
+        thread = server.start_thread(cwd=Path("/tmp"))
+        result = thread.run_turn("HANG forever", timeout=0.5)
+    assert not result.ok
+    assert result.status == "interrupted"
+    assert result.text == "partial answer"
+    assert "timeout" in result.detail
+
+
+def test_approval_requests_are_auto_declined():
+    with _server() as server:
+        thread = server.start_thread(cwd=Path("/tmp"))
+        result = thread.run_turn("APPROVAL needed", timeout=10.0)
+    assert result.ok
+    assert result.text == "approval:decline"
+
+
+def test_server_death_mid_turn_fails_not_hangs():
+    with _server() as server:
+        thread = server.start_thread(cwd=Path("/tmp"))
+        result = thread.run_turn("DIE now", timeout=10.0)
+    assert not result.ok
+    assert result.status == "failed"
+    assert "app-server exited" in result.detail
+
+
+def test_resume_thread_reuses_id():
+    with _server() as server:
+        thread = server.resume_thread("t-99", cwd=Path("/tmp"))
+        result = thread.run_turn("continue", timeout=10.0)
+    assert result.ok
+    assert result.thread_id == "t-99"
+
+
+def test_spawn_failure_raises():
+    with pytest.raises(codex_appserver.AppServerError):
+        codex_appserver.AppServer(argv=["/nonexistent-binary-xyz"]).start()

--- a/tests/test_codex_appserver_integration.py
+++ b/tests/test_codex_appserver_integration.py
@@ -1,0 +1,25 @@
+"""Opt-in canary against the real `codex app-server` binary.
+
+Run with: BRIGADE_CODEX_INTEGRATION=1 python -m pytest tests/test_codex_appserver_integration.py
+Detects protocol drift in the experimental app-server API without spending tokens.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+
+import pytest
+
+from brigade import codex_appserver
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("codex") is None or os.environ.get("BRIGADE_CODEX_INTEGRATION") != "1",
+    reason="needs codex binary and BRIGADE_CODEX_INTEGRATION=1",
+)
+
+
+def test_real_handshake_and_thread_start(tmp_path):
+    with codex_appserver.AppServer() as server:
+        thread = server.start_thread(cwd=tmp_path, sandbox="read-only")
+        assert thread.thread_id

--- a/tests/test_roster.py
+++ b/tests/test_roster.py
@@ -183,3 +183,22 @@ def test_cli_agent_still_requires_cli_or_endpoint(tmp_path):
     text = 'orchestrator = "chef"\n[agents.chef]\nrole = "plan"\n'
     with pytest.raises(ValueError):
         roster_mod.load_roster(_write(tmp_path, text))
+
+
+def test_codex_transport_defaults_to_exec(tmp_path):
+    p = tmp_path / "roster.toml"
+    p.write_text('orchestrator = "chef"\n\n[agents.chef]\ncli = "codex"\nrole = "plan"\n')
+    assert roster_mod.load_roster(p).codex_transport == "exec"
+
+
+def test_codex_transport_accepts_app_server(tmp_path):
+    p = tmp_path / "roster.toml"
+    p.write_text('orchestrator = "chef"\ncodex_transport = "app-server"\n\n[agents.chef]\ncli = "codex"\nrole = "plan"\n')
+    assert roster_mod.load_roster(p).codex_transport == "app-server"
+
+
+def test_codex_transport_rejects_unknown(tmp_path):
+    p = tmp_path / "roster.toml"
+    p.write_text('orchestrator = "chef"\ncodex_transport = "daemon"\n\n[agents.chef]\ncli = "codex"\nrole = "plan"\n')
+    with pytest.raises(ValueError, match="codex_transport"):
+        roster_mod.load_roster(p)

--- a/tests/test_roster.py
+++ b/tests/test_roster.py
@@ -193,7 +193,9 @@ def test_codex_transport_defaults_to_exec(tmp_path):
 
 def test_codex_transport_accepts_app_server(tmp_path):
     p = tmp_path / "roster.toml"
-    p.write_text('orchestrator = "chef"\ncodex_transport = "app-server"\n\n[agents.chef]\ncli = "codex"\nrole = "plan"\n')
+    p.write_text(
+        'orchestrator = "chef"\ncodex_transport = "app-server"\n\n[agents.chef]\ncli = "codex"\nrole = "plan"\n'
+    )
     assert roster_mod.load_roster(p).codex_transport == "app-server"
 
 

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -787,3 +787,45 @@ def test_run_cli_normal_runs_write_no_changes_patch(tmp_path, monkeypatch):
 
     assert cli.main(["run", "x", "--cwd", str(repo), "--output-dir", str(output_dir)]) == 0
     assert not (output_dir / "changes.patch").exists()
+
+
+def test_run_cli_passes_codex_transport_to_aboyeur(tmp_path, monkeypatch):
+    roster_path = tmp_path / "roster.toml"
+    roster_path.write_text('orchestrator = "chef"\n\n[agents.chef]\ncli = "codex"\nrole = "plan"\n')
+    seen = {}
+
+    def fake_run(task, loaded_roster, **kwargs):
+        seen.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(aboyeur, "run", fake_run)
+    rc = cli.main(
+        [
+            "run",
+            "t",
+            "--roster",
+            str(roster_path),
+            "--cwd",
+            str(tmp_path),
+            "--codex-transport",
+            "app-server",
+            "--no-artifacts",
+        ]
+    )
+    assert rc == 0
+    assert seen["codex_transport"] == "app-server"
+
+
+def test_run_cli_codex_transport_default_is_none(tmp_path, monkeypatch):
+    roster_path = tmp_path / "roster.toml"
+    roster_path.write_text('orchestrator = "chef"\n\n[agents.chef]\ncli = "codex"\nrole = "plan"\n')
+    seen = {}
+
+    def fake_run(task, loaded_roster, **kwargs):
+        seen.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(aboyeur, "run", fake_run)
+    rc = cli.main(["run", "t", "--roster", str(roster_path), "--cwd", str(tmp_path), "--no-artifacts"])
+    assert rc == 0
+    assert "codex_transport" not in seen

--- a/tests/test_run_resume.py
+++ b/tests/test_run_resume.py
@@ -129,3 +129,30 @@ def test_runs_resume_cli_dispatches(tmp_path, monkeypatch):
     rc = cli.main(["runs", "resume", str(tmp_path)])
     assert rc == 0
     assert seen["run_dir"] == tmp_path
+
+
+def test_resume_orchestrator_without_cli_errors(tmp_path, monkeypatch, capsys):
+    run_dir = _write_run_dir(
+        tmp_path,
+        results=[
+            {
+                "worker": "cook",
+                "task": "write code",
+                "ok": False,
+                "detail": "timeout",
+                "text": "",
+                "thread_id": "t-1",
+                "status": "interrupted",
+            },
+        ],
+    )
+    roster = json.loads((run_dir / "roster.json").read_text())
+    roster["agents"]["chef"]["cli"] = None
+    (run_dir / "roster.json").write_text(json.dumps(roster))
+    monkeypatch.setattr(run_resume.codex_appserver, "AppServer", _StubServer)
+    rc = run_resume.resume(run_dir)
+    assert rc == 2
+    assert "no CLI" in capsys.readouterr().err
+    # Resumed worker progress is still persisted even though synthesis was skipped.
+    results = json.loads((run_dir / "worker-results.json").read_text())["results"]
+    assert results[0]["text"] == "finished now"

--- a/tests/test_run_resume.py
+++ b/tests/test_run_resume.py
@@ -1,0 +1,131 @@
+"""Tests for brigade runs resume."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from brigade import agents, codex_appserver, run_resume
+
+
+def _write_run_dir(tmp_path: Path, *, results: list[dict]) -> Path:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / "run.json").write_text(
+        json.dumps(
+            {
+                "task": "big task",
+                "cwd": str(tmp_path),
+                "orchestrator": "chef",
+                "read_only": False,
+                "status": "failed",
+                "started_at": "2026-07-03T00:00:00+00:00",
+            }
+        )
+    )
+    (run_dir / "roster.json").write_text(
+        json.dumps(
+            {
+                "orchestrator": "chef",
+                "max_workers": 4,
+                "timeout_seconds": 600.0,
+                "allow_models": [],
+                "sandbox": None,
+                "agents": {
+                    "chef": {"cli": "claude", "model": None, "role": "plan", "timeout_seconds": None},
+                    "cook": {"cli": "codex", "model": None, "role": "code", "timeout_seconds": None},
+                },
+            }
+        )
+    )
+    (run_dir / "plan.json").write_text(
+        json.dumps({"assignments": [{"stage": 1, "worker": "cook", "task": "write code"}]})
+    )
+    (run_dir / "worker-results.json").write_text(json.dumps({"results": results, "ground_truth": {}}))
+    return run_dir
+
+
+class _StubThread:
+    def __init__(self, thread_id):
+        self.thread_id = thread_id
+
+    def run_turn(self, prompt, *, timeout, on_event=None):
+        assert "big task" not in prompt  # continuation carries the sub-task, not the run task
+        assert "write code" in prompt
+        return codex_appserver.TurnResult(text="finished now", ok=True, status="complete", thread_id=self.thread_id)
+
+
+class _StubServer:
+    def __init__(self, *a, **k):
+        self.resumed = []
+
+    def start(self):
+        pass
+
+    def close(self):
+        pass
+
+    def resume_thread(self, thread_id, *, cwd, model=None, sandbox=None):
+        self.resumed.append(thread_id)
+        return _StubThread(thread_id)
+
+
+def test_resume_reattaches_and_resynthesizes(tmp_path, monkeypatch, capsys):
+    run_dir = _write_run_dir(
+        tmp_path,
+        results=[
+            {
+                "worker": "cook",
+                "task": "write code",
+                "ok": False,
+                "detail": "timeout",
+                "text": "part",
+                "thread_id": "t-1",
+                "status": "interrupted",
+            },
+        ],
+    )
+    monkeypatch.setattr(run_resume.codex_appserver, "AppServer", _StubServer)
+    monkeypatch.setattr(
+        run_resume.agents,
+        "run_agent",
+        lambda *a, **k: agents.AgentResult(text="final synthesis", ok=True),
+    )
+    rc = run_resume.resume(run_dir)
+    assert rc == 0
+    results = json.loads((run_dir / "worker-results.json").read_text())["results"]
+    assert results[0]["ok"] is True and results[0]["text"] == "finished now"
+    assert results[0]["status"] == "complete"
+    assert (run_dir / "final.txt").read_text().strip() == "final synthesis"
+    run_json = json.loads((run_dir / "run.json").read_text())
+    assert run_json["status"] == "ok"
+    assert run_json["resumed_at"]
+
+
+def test_resume_with_nothing_resumable_reports_and_exits_2(tmp_path, capsys):
+    run_dir = _write_run_dir(
+        tmp_path,
+        results=[{"worker": "cook", "task": "write code", "ok": False, "detail": "exec timeout", "text": ""}],
+    )
+    rc = run_resume.resume(run_dir)
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "no resumable workers" in err
+    assert "cook" in err  # names the non-resumable failure
+
+
+def test_resume_missing_artifacts_errors(tmp_path, capsys):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    assert run_resume.resume(empty) == 2
+    assert "missing" in capsys.readouterr().err
+
+
+def test_runs_resume_cli_dispatches(tmp_path, monkeypatch):
+    from brigade import cli
+
+    seen = {}
+    monkeypatch.setattr(run_resume, "resume", lambda run_dir: seen.update(run_dir=run_dir) or 0)
+    rc = cli.main(["runs", "resume", str(tmp_path)])
+    assert rc == 0
+    assert seen["run_dir"] == tmp_path


### PR DESCRIPTION
## Summary

Opt-in app-server transport for codex workers in `brigade run`. Instead of one blocking `codex exec` subprocess per worker, the run spawns a single `codex app-server` child (newline-delimited JSON-RPC over stdio) and each codex worker becomes a thread plus one turn on that shared connection.

What this buys:

- **Progress**: lifecycle notifications stream to `events/<worker>.jsonl` in the run artifacts, and `--verbose` narrates item completions live.
- **Interrupt-and-salvage**: a worker timeout now sends `turn/interrupt` and keeps partial output instead of killing the process and losing everything.
- **Resume**: worker results record the codex `thread_id`. New `brigade runs resume <run-dir>` re-attaches interrupted workers via `thread/resume`, finishes them, and re-synthesizes. Threads persist on disk under `CODEX_HOME`, so resume works even after the original process died.

Exec stays the default transport and the automatic fallback when the app-server handshake fails. Opt in with roster `codex_transport = "app-server"` or `brigade run --codex-transport app-server`.

## Design notes

- All protocol assumptions live in one new module, `src/brigade/codex_appserver.py` (stdlib only, no SDKs, consistent with the no-provider-keys rule). The app-server API is experimental upstream; drift degrades to exec instead of breaking.
- Headless policy: threads start with `approvalPolicy: "never"`; any approval request that still arrives is auto-declined and logged.
- Per-token delta notifications are consumed in memory for salvage but never persisted, so event logs stay small.
- Spec and plan are in `docs/specs/` and `docs/plans/` per the planning-artifacts convention (untracked drafts).

## Testing

- 24 new tests: JSON-RPC client against a scripted fake app-server (happy path, timeout-interrupt-salvage, approval auto-decline, server death, resume), roster parsing, dispatch routing, exec fallback, CLI flag, resume flow.
- Full suite: 1430 passed, 1 skipped (opt-in canary).
- Opt-in integration canary against the real binary (`BRIGADE_CODEX_INTEGRATION=1`), token-free: handshake + thread/start only. Passed against codex-cli 0.142.5.
- Live dogfood: a real run over the transport produced streamed events, a recorded thread_id, and a correct final answer. A forced 5s timeout produced an interrupted worker that `brigade runs resume` re-attached and completed.

## Known behavior

- `runs resume` reuses the run's own roster timeouts from the `roster.json` snapshot; a worker interrupted by a genuinely too-short timeout will time out again on resume.
- The orchestrator plan and synthesis calls still use the exec path (workers only), per the spec's blast-radius call.