### PR TITLE
feat(outcome): add rebuild-status drift oracle and fork/diff

### DIFF
--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -37,7 +37,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade notifications` (extras): 4 command path(s)
 - `brigade openclaw-fragments` (extras): 1 command path(s)
 - `brigade operator`: 24 command path(s)
-- `brigade outcome`: 6 command path(s)
+- `brigade outcome`: 9 command path(s)
 - `brigade pantry` (extras): 3 command path(s)
 - `brigade profiles`: 2 command path(s)
 - `brigade projects` (extras): 10 command path(s)
@@ -224,8 +224,11 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade operator sync-tools`
 - `brigade operator verify-harness`
 - `brigade outcome capture`
+- `brigade outcome diff`
 - `brigade outcome explain`
+- `brigade outcome fork`
 - `brigade outcome rank`
+- `brigade outcome rebuild-status`
 - `brigade outcome reconcile`
 - `brigade outcome record`
 - `brigade outcome score`

--- a/docs/design/activegraph-inspiration.md
+++ b/docs/design/activegraph-inspiration.md
@@ -1,0 +1,74 @@
+# ActiveGraph inspiration: drift oracle + fork/diff
+
+Part of a fleet-wide effort inspired by Yohei Nakajima's
+[ActiveGraph](https://github.com/yoheinakajima/activegraph). Master notes:
+`~/notes/activegraph-credits.md`. ActiveGraph is a reference architecture only;
+no code from it is vendored or depended on here.
+
+## What we borrowed
+
+- **State is a projection of an append-only log.** ActiveGraph's module-level
+  `apply_event` (`activegraph/core/graph.py`) is the only mutator, and current
+  state is recoverable by replaying the event log. Brigade's outcome ledger
+  already has the logs (`records.jsonl` for signals, `decisions/*.json` for
+  transitions) but treated `status.json` as an independently-written blob.
+- **Fork/diff.** ActiveGraph forks a run by replaying its log under a new run id
+  and diffs two runs structurally (`compute_diff`, `runtime/diff.py`).
+
+## What landed in brigade
+
+Three additive `outcome` subcommands, no change to the existing write path:
+
+- `outcome rebuild-status [--check]` — the **drift oracle**. Folds the decision
+  receipts (`core.fold_status`) into the status map they should produce and
+  diffs it against the persisted `status.json`. `--check` exits non-zero on any
+  drift. Read-only; it never rewrites `status.json`.
+- `outcome fork --out <file> [--install-min-helped N ...]` — replays the signal
+  log through the scorer and ratchet from a clean baseline under a hypothetical
+  config (`core.project_statuses`) and writes the resulting per-artifact
+  projection. Never touches live state.
+- `outcome diff <a> <b>` — structural comparison of two fork projections: which
+  artifacts land on a different status/action under different rules.
+
+The payoff: `status.json` is now provably a projection of the transition log
+(drift from a hand-edit or a partial write is detectable), and you can answer
+"how would raising `install_min_helped` change what promotes?" by forking twice
+and diffing, without disturbing the live ledger.
+
+## What we did differently, and why
+
+- **Co-canonical logs, not one.** ActiveGraph has a single event log. Brigade's
+  `status.json` is a projection of the **decisions** log, while the signal counts
+  come from the **records** log. Signals alone cannot reproduce `status.json`
+  because the ratchet is stateful (cooldown via `last_action_ts`, forward-only
+  transitions in `decide()`); the decision receipts are the transition log that
+  carries that state. So the honest framing here is two co-canonical logs, and
+  the drift oracle folds the transition log specifically.
+- **Fork is a config-sensitivity replay, not a divergent run.** ActiveGraph forks
+  to let a run continue along a new branch. Brigade's ratchet is a pure function
+  of (scores, config), so the useful fork is "replay the same log under different
+  rules" rather than "continue from a cut point." That is what makes fork/diff a
+  what-if tool for the promotion thresholds.
+- **Canonical flip deferred.** We deliberately did not demote `status.json` to a
+  regenerated cache. The drift oracle makes that flip *safe to consider later*
+  (run `--check` in CI for a while first); doing it now would change a
+  correctness-critical write path for no immediate gain.
+
+## Deferred (next brigade slice)
+
+The **evidence provenance graph** — unifying the five scattered evidence surfaces
+(ledger `evidence_ref`, card `evidence/sources/refs` frontmatter, handoff
+`## Evidence` + `scanner_provenance`, verify-run receipts) under one node identity
+keyed on receipt path — is the sprawliest piece and touches surfaces owned by
+in-flight work. It is scoped as a follow-up read-only projection rather than
+rushed here.
+
+## Feedback worth sending Yohei
+
+Brigade is a case where a single event log is not enough: the promotion state is
+a stateful ratchet, so reproducing it needs a dedicated **transition** log
+(decision receipts) distinct from the **signal** log. ActiveGraph's single-log
+model would need a second canonical stream to represent this cleanly, or the
+transitions would have to be reconstructable by re-running the ratchet
+deterministically over the signals plus a clock — which is exactly the coupling
+the separate decision receipts avoid.

--- a/src/brigade/cli/outcome.py
+++ b/src/brigade/cli/outcome.py
@@ -47,6 +47,35 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_rank.add_argument("--json", action="store_true", help="Emit machine-readable JSON instead of text.")
     p_rank.set_defaults(func=_dispatch_rank)
 
+    p_rebuild = outcome_sub.add_parser(
+        "rebuild-status", help="Rebuild status.json from decision receipts and report any drift."
+    )
+    p_rebuild.add_argument(
+        "--check", action="store_true", help="Exit non-zero if the persisted status.json has drifted."
+    )
+    p_rebuild.add_argument("--target", "-t", type=Path, default=Path("."))
+    p_rebuild.add_argument("--json", action="store_true", help="Emit machine-readable JSON instead of text.")
+    p_rebuild.set_defaults(func=_dispatch_rebuild_status)
+
+    p_fork = outcome_sub.add_parser(
+        "fork", help="Project what the ratchet would decide under a hypothetical config (read-only)."
+    )
+    p_fork.add_argument("--out", type=Path, required=True, help="Path to write the fork projection JSON.")
+    p_fork.add_argument("--install-min-helped", type=int, default=None, help="Override install_min_helped.")
+    p_fork.add_argument("--revert-min-hurt", type=int, default=None, help="Override revert_min_hurt.")
+    p_fork.add_argument("--bump-min-helped", type=int, default=None, help="Override bump_min_helped.")
+    p_fork.add_argument("--z", type=float, default=None, help="Override the Wilson z score.")
+    p_fork.add_argument("--target", "-t", type=Path, default=Path("."))
+    p_fork.add_argument("--json", action="store_true", help="Emit machine-readable JSON instead of text.")
+    p_fork.set_defaults(func=_dispatch_fork)
+
+    p_diff = outcome_sub.add_parser("diff", help="Compare two outcome fork projections.")
+    p_diff.add_argument("fork_a", type=Path, help="First fork projection JSON.")
+    p_diff.add_argument("fork_b", type=Path, help="Second fork projection JSON.")
+    p_diff.add_argument("--target", "-t", type=Path, default=Path("."))
+    p_diff.add_argument("--json", action="store_true", help="Emit machine-readable JSON instead of text.")
+    p_diff.set_defaults(func=_dispatch_diff)
+
     p_record = outcome_sub.add_parser("record", help="Record an explicit (non-verify) outcome signal for an artifact.")
     p_record.add_argument("artifact_id", help="Artifact id (card or skill) the signal is about.")
     p_record.add_argument("--source", required=True, help="Signal source, e.g. friction or learnings.")
@@ -94,6 +123,34 @@ def _dispatch_rank(args) -> int:
     from .. import outcome_cmd
 
     return outcome_cmd.rank(target=args.target, json_output=args.json)
+
+
+def _dispatch_rebuild_status(args) -> int:
+    from .. import outcome_cmd
+
+    return outcome_cmd.rebuild_status(target=args.target, check=args.check, json_output=args.json)
+
+
+def _dispatch_fork(args) -> int:
+    from .. import outcome, outcome_cmd
+
+    defaults = outcome.ReconcileConfig()
+    config = outcome.ReconcileConfig(
+        install_min_helped=args.install_min_helped
+        if args.install_min_helped is not None
+        else defaults.install_min_helped,
+        revert_min_hurt=args.revert_min_hurt if args.revert_min_hurt is not None else defaults.revert_min_hurt,
+        bump_min_helped=args.bump_min_helped if args.bump_min_helped is not None else defaults.bump_min_helped,
+        cooldown_seconds=defaults.cooldown_seconds,
+        z=args.z if args.z is not None else defaults.z,
+    )
+    return outcome_cmd.fork(target=args.target, out=args.out, config=config, json_output=args.json)
+
+
+def _dispatch_diff(args) -> int:
+    from .. import outcome_cmd
+
+    return outcome_cmd.diff(target=args.target, fork_a=args.fork_a, fork_b=args.fork_b, json_output=args.json)
 
 
 def _dispatch_record(args) -> int:

--- a/src/brigade/outcome.py
+++ b/src/brigade/outcome.py
@@ -165,6 +165,63 @@ def decide(
     return Decision(score.artifact_id, "hold", current_status, "terminal status")
 
 
+@dataclass(frozen=True)
+class StatusTransition:
+    """One persisted status transition, read back from a decision receipt.
+
+    The decision receipts under ``memory/outcome/decisions/`` are the transition
+    log; ``status.json`` is the cache they fold into. Keeping this pure lets the
+    rebuild check prove the cache is reproducible from the log.
+    """
+
+    artifact_id: str
+    new_status: str
+    created_at: str  # ISO 8601
+
+
+def fold_status(transitions: list[StatusTransition]) -> dict[str, dict]:
+    """Fold decision transitions into the status map they produce.
+
+    Later transitions win per artifact, ordered by ``created_at``. This is the
+    projection ``status.json`` caches: reconcile writes a decision receipt and a
+    status entry together on every transition, so replaying the receipts must
+    reproduce the persisted status exactly. Inspired by ActiveGraph's
+    ``apply_event`` projection (state is a fold of the append-only log).
+    """
+    ordered = sorted(transitions, key=lambda t: (t.created_at, t.artifact_id))
+    status: dict[str, dict] = {}
+    for t in ordered:
+        status[t.artifact_id] = {"status": t.new_status, "last_action_ts": t.created_at}
+    return status
+
+
+def project_statuses(
+    scores: dict[str, OutcomeScore],
+    *,
+    config: ReconcileConfig,
+    now: dt.datetime,
+) -> dict[str, Decision]:
+    """Project each artifact's ratchet decision from a clean candidate baseline.
+
+    A pure "what-if" over the signal log: given the scores derived from
+    ``records.jsonl`` and a hypothetical config, what would the ratchet decide
+    for each artifact starting fresh? Because the baseline has no prior action,
+    the cooldown never fires and each artifact gets one decision from its score.
+    This is the fork primitive: replay the log under different rules without
+    touching live state, so two configs can be diffed.
+    """
+    return {
+        artifact_id: decide(
+            score_obj,
+            current_status="candidate",
+            last_action_ts=None,
+            now=now,
+            config=config,
+        )
+        for artifact_id, score_obj in scores.items()
+    }
+
+
 # Retrieval rank weights: confidence, verified outcome, keyword match.
 RANK_WEIGHTS = (0.5, 0.4, 0.1)
 

--- a/src/brigade/outcome_cmd.py
+++ b/src/brigade/outcome_cmd.py
@@ -93,6 +93,175 @@ def append_records(target: Path, records: list[core.OutcomeRecord]) -> None:
             handle.write(json.dumps(dataclasses.asdict(record), sort_keys=True) + "\n")
 
 
+def _decisions_dir(target: Path) -> Path:
+    return target / "memory" / "outcome" / "decisions"
+
+
+def load_transitions(target: Path) -> list[core.StatusTransition]:
+    """Read the decision receipts into the transition log that status.json folds.
+
+    Each receipt written by ``reconcile --apply`` carries the artifact id, the
+    status it moved to, and when. Malformed or partial receipts are skipped so
+    one bad file cannot break the drift check.
+    """
+    decisions = _decisions_dir(target)
+    if not decisions.is_dir():
+        return []
+    transitions: list[core.StatusTransition] = []
+    for path in sorted(decisions.glob("*.json")):
+        payload = localio.read_json_dict(path) or {}
+        artifact_id = payload.get("artifact_id")
+        new_status = payload.get("new_status")
+        created_at = payload.get("created_at")
+        if artifact_id and new_status and created_at:
+            transitions.append(core.StatusTransition(str(artifact_id), str(new_status), str(created_at)))
+    return transitions
+
+
+def _status_drift(rebuilt: dict[str, dict], persisted: dict[str, dict]) -> list[dict]:
+    """Return per-artifact differences between the rebuilt and persisted status."""
+    drift: list[dict] = []
+    for artifact_id in sorted(set(rebuilt) | set(persisted)):
+        want = rebuilt.get(artifact_id)
+        have = persisted.get(artifact_id)
+        if want == have:
+            continue
+        if want is None:
+            drift.append({"artifact_id": artifact_id, "issue": "only-in-status", "persisted": have})
+        elif have is None:
+            drift.append({"artifact_id": artifact_id, "issue": "missing-from-status", "rebuilt": want})
+        else:
+            drift.append({"artifact_id": artifact_id, "issue": "mismatch", "rebuilt": want, "persisted": have})
+    return drift
+
+
+def rebuild_status(*, target: Path, check: bool = False, json_output: bool = False) -> int:
+    """Rebuild status.json from the decision receipts and compare to the persisted file.
+
+    Read-only drift oracle: proves ``status.json`` is reproducible from the
+    append-only transition log before anything is allowed to trust it. With
+    ``--check`` it exits non-zero on any drift (a hand-edit, a partial write, a
+    corrupted status file). It never rewrites status.json; the canonical flip
+    (demoting status.json to a regenerated cache) is a deliberate later step.
+    """
+    target = target.expanduser().resolve()
+    rebuilt = core.fold_status(load_transitions(target))
+    persisted = load_status(target)
+    drift = _status_drift(rebuilt, persisted)
+    if json_output:
+        payload = {
+            "target": str(target),
+            "reproducible": not drift,
+            "rebuilt_count": len(rebuilt),
+            "persisted_count": len(persisted),
+            "drift": drift,
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 1 if (check and drift) else 0
+    print(f"outcome rebuild-status: {target}")
+    print(f"rebuilt={len(rebuilt)} persisted={len(persisted)} reproducible={not drift}")
+    if not drift:
+        print("drift: none")
+        return 0
+    for item in drift:
+        print(f"- {item['artifact_id']} [{item['issue']}]")
+    return 1 if check else 0
+
+
+def fork(
+    *,
+    target: Path,
+    out: Path,
+    config: core.ReconcileConfig | None = None,
+    json_output: bool = False,
+) -> int:
+    """Project what the ratchet would decide over the current signal log under a config.
+
+    A read-only fork: it replays ``records.jsonl`` through the scorer and the
+    ratchet from a clean baseline under the given config, writing the resulting
+    per-artifact projection to ``out``. It never reads or writes the live
+    status.json, so two forks under different configs can be compared with
+    ``outcome diff`` to see how a rule change would move promotions.
+    """
+    target = target.expanduser().resolve()
+    config = config or core.ReconcileConfig()
+    scores = _scores_by_artifact(load_records(target))
+    decisions = core.project_statuses(scores, config=config, now=localio.utc_now())
+    artifacts = {
+        artifact_id: {
+            "action": decision.action,
+            "new_status": decision.new_status,
+            "reason": decision.reason,
+            "score": scores[artifact_id].score,
+            "helped": scores[artifact_id].helped,
+            "hurt": scores[artifact_id].hurt,
+        }
+        for artifact_id, decision in sorted(decisions.items())
+    }
+    projection = {
+        "version": 1,
+        "target": str(target),
+        "config": dataclasses.asdict(config),
+        "artifacts": artifacts,
+    }
+    out = out.expanduser()
+    localio.write_json(out, projection)
+    if json_output:
+        print(json.dumps({"out": str(out), "projection": projection}, indent=2, sort_keys=True))
+        return 0
+    promoted = sum(1 for a in artifacts.values() if a["new_status"] == "promoted")
+    print(f"outcome fork: {out}")
+    print(f"artifacts={len(artifacts)} would-promote={promoted} (config: {dataclasses.asdict(config)})")
+    return 0
+
+
+def _load_projection(path: Path) -> dict[str, dict]:
+    payload = localio.read_json_dict(path) or {}
+    artifacts = payload.get("artifacts")
+    return artifacts if isinstance(artifacts, dict) else {}
+
+
+def diff(*, target: Path, fork_a: Path, fork_b: Path, json_output: bool = False) -> int:
+    """Compare two fork projections: which artifacts land on a different status.
+
+    Structural, read-only comparison of two ``outcome fork`` outputs, mirroring
+    ActiveGraph's ``compute_diff`` (a set-diff over resulting state). Reports
+    artifacts whose projected status differs and artifacts present in only one
+    fork.
+    """
+    _ = target
+    a = _load_projection(fork_a.expanduser())
+    b = _load_projection(fork_b.expanduser())
+    changed: list[dict] = []
+    for artifact_id in sorted(set(a) | set(b)):
+        ea = a.get(artifact_id)
+        eb = b.get(artifact_id)
+        if ea is None:
+            changed.append({"artifact_id": artifact_id, "issue": "only-in-b", "b": eb})
+        elif eb is None:
+            changed.append({"artifact_id": artifact_id, "issue": "only-in-a", "a": ea})
+        elif ea.get("new_status") != eb.get("new_status") or ea.get("action") != eb.get("action"):
+            changed.append(
+                {
+                    "artifact_id": artifact_id,
+                    "issue": "differs",
+                    "a": {"action": ea.get("action"), "new_status": ea.get("new_status")},
+                    "b": {"action": eb.get("action"), "new_status": eb.get("new_status")},
+                }
+            )
+    if json_output:
+        payload = {"fork_a": str(fork_a), "fork_b": str(fork_b), "identical": not changed, "changed": changed}
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+    print(f"outcome diff: {fork_a} <-> {fork_b}")
+    if not changed:
+        print("changed: none")
+        return 0
+    for item in changed:
+        print(f"- {item['artifact_id']} [{item['issue']}]")
+    return 0
+
+
 def _scores_by_artifact(records: list[core.OutcomeRecord]) -> dict[str, core.OutcomeScore]:
     grouped: dict[str, list[core.OutcomeRecord]] = {}
     for record in records:

--- a/tests/test_outcome_activegraph.py
+++ b/tests/test_outcome_activegraph.py
@@ -1,0 +1,90 @@
+"""ActiveGraph-inspired outcome extensions: drift oracle + fork/diff.
+
+The drift oracle proves status.json is a reproducible projection of the decision
+receipts; fork/diff replays the signal log under different configs without
+touching live state. See docs/design/activegraph-inspiration.md.
+"""
+
+import json
+
+from brigade import outcome, outcome_cmd
+
+
+def _seed(target, records):
+    outcome_cmd.append_records(target, records)
+
+
+def _helped(artifact_id, kind, n):
+    return [
+        outcome.OutcomeRecord(
+            artifact_id, kind, f"t{i}", "verify", 1, f"ref-{artifact_id}-{i}", f"2026-06-20T0{i}:00:00+00:00"
+        )
+        for i in range(n)
+    ]
+
+
+def test_rebuild_status_reproduces_persisted(tmp_path, capsys):
+    # A card with two clean verified signals promotes on reconcile --apply, which
+    # writes both a decision receipt and a status entry.
+    _seed(tmp_path, _helped("card-x", "card", 2))
+    assert outcome_cmd.reconcile(target=tmp_path, apply=True, json_output=True) == 0
+    capsys.readouterr()
+    assert outcome_cmd.load_status(tmp_path)["card-x"]["status"] == "promoted"
+
+    # Folding the decision receipts must reproduce the persisted status exactly.
+    assert outcome_cmd.rebuild_status(target=tmp_path, check=True, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["reproducible"] is True
+    assert payload["drift"] == []
+
+
+def test_rebuild_status_detects_drift(tmp_path, capsys):
+    _seed(tmp_path, _helped("card-x", "card", 2))
+    assert outcome_cmd.reconcile(target=tmp_path, apply=True, json_output=True) == 0
+    capsys.readouterr()
+
+    # Hand-edit status.json so it no longer matches the transition log.
+    status_path = tmp_path / "memory" / "outcome" / "status.json"
+    data = json.loads(status_path.read_text())
+    data["artifacts"]["card-x"]["status"] = "demoted"
+    status_path.write_text(json.dumps(data))
+
+    assert outcome_cmd.rebuild_status(target=tmp_path, check=True, json_output=True) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["reproducible"] is False
+    assert any(d["artifact_id"] == "card-x" and d["issue"] == "mismatch" for d in payload["drift"])
+
+
+def test_fork_and_diff_reflect_config_sensitivity(tmp_path, capsys):
+    # skill-x has enough signal to install under any threshold; skill-y only
+    # installs once the threshold drops to 1.
+    _seed(tmp_path, _helped("skill-x", "skill", 2) + _helped("skill-y", "skill", 1))
+
+    fork_a = tmp_path / "A.json"
+    fork_b = tmp_path / "B.json"
+    assert outcome_cmd.fork(target=tmp_path, out=fork_a, config=outcome.ReconcileConfig(), json_output=True) == 0
+    capsys.readouterr()
+    assert (
+        outcome_cmd.fork(
+            target=tmp_path, out=fork_b, config=outcome.ReconcileConfig(install_min_helped=1), json_output=True
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    assert outcome_cmd.diff(target=tmp_path, fork_a=fork_a, fork_b=fork_b, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["identical"] is False
+    changed = {c["artifact_id"]: c for c in payload["changed"]}
+    assert "skill-y" in changed  # hold@candidate under A, install@promoted under B
+    assert "skill-x" not in changed  # installs under both
+
+    # A fork is read-only: the live ledger has no status.json written by fork.
+    assert not (tmp_path / "memory" / "outcome" / "status.json").exists()
+
+    # Identical configs diff clean.
+    fork_c = tmp_path / "C.json"
+    assert outcome_cmd.fork(target=tmp_path, out=fork_c, config=outcome.ReconcileConfig(), json_output=True) == 0
+    capsys.readouterr()
+    assert outcome_cmd.diff(target=tmp_path, fork_a=fork_a, fork_b=fork_c, json_output=True) == 0
+    assert json.loads(capsys.readouterr().out)["identical"] is True


### PR DESCRIPTION
## What

Adds three additive `outcome` subcommands; the existing write path is unchanged.

- `outcome rebuild-status [--check]` folds the decision receipts into the status map they should produce and diffs it against the persisted `status.json`. `--check` exits non-zero on drift (a hand-edit, partial write, or corruption). Read-only; never rewrites status.json. Good CI gate before ever treating status.json as a regenerated cache.
- `outcome fork --out <file> [--install-min-helped N ...]` replays the signal log through the scorer and ratchet from a clean baseline under a hypothetical `ReconcileConfig`.
- `outcome diff <a> <b>` structurally compares two fork projections (which artifacts land on a different status under different rules).

## Verification

40 outcome tests pass (`tests/test_outcome_activegraph.py` covers reproduce/drift/fork-diff plus the existing outcome suite).

## Design

`docs/design/activegraph-inspiration.md`. Note: status.json is a projection of the **decisions** log; signal counts come from **records**. The two are co-canonical because the ratchet is stateful (cooldown, forward-only).