### PR TITLE
docs: correct runbook approval claim in technical guide

### DIFF
--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -742,7 +742,7 @@ Explicit runbook commands:
 - `brigade runbook run --resume <run-id> --approved` retries from the first failed step of a previous run.
 - `brigade runbook closeout latest --status reviewed --reason "..."` records operator review for the runbook run.
 
-Runbooks are the first explicit execution lane for multi-step local workflows. Execution requires `--approved` or `approved: true` in the runbook, blocks destructive default-deny command patterns, and can restrict steps with `allowed_commands`. Status, doctor, brief, and center views still do not execute runbooks automatically.
+Runbooks are the first explicit execution lane for multi-step local workflows. Execution requires the operator to pass `--approved`. An `approved: true` value in the runbook is recorded as file metadata only and does not authorize execution. Runbooks block destructive default-deny command patterns and can restrict steps with `allowed_commands`. Status, doctor, brief, and center views still do not execute runbooks automatically.
 
 Backup health commands:
 


### PR DESCRIPTION
Fixes #150.

One sentence in the runbooks section of docs/technical-guide.md claimed execution requires `--approved` or `approved: true` in the runbook file. The implementation intentionally ignores the file-embedded flag (see the comment in `src/brigade/runbook_cmd.py` above the approval check): runbook files are agent-written, so honoring a file flag would let any file author authorize shell execution without an operator seeing the commands.

The sentence now states that only the operator's `--approved` authorizes execution and that a file-embedded `approved: true` is recorded as metadata only, with the one-line rationale. `rg -n 'approved: true' docs/` confirms this was the only doc location making the claim.