### PR TITLE
fix: use shared import identity keys in friction imports

### DIFF
--- a/src/brigade/friction_cmd.py
+++ b/src/brigade/friction_cmd.py
@@ -476,6 +476,21 @@ def _write_markdown(path: Path, payload: dict[str, Any]) -> None:
     path.write_text(_render_markdown(payload))
 
 
+def _candidate_fingerprint(item: dict[str, Any]) -> str:
+    # Fingerprint only the meaning-bearing fields. Evidence position (path/line/
+    # snippet placement) drifts as scanned logs grow, and a drifted position must
+    # not re-import an otherwise unchanged friction.
+    stable = {
+        "id": item.get("id"),
+        "title": item.get("title"),
+        "text": item.get("text"),
+        "friction_type": item.get("friction_type"),
+        "severity": item.get("severity"),
+        "workflow": item.get("workflow"),
+    }
+    return hashlib.sha256(json.dumps(stable, sort_keys=True, default=str).encode("utf-8")).hexdigest()[:16]
+
+
 def _import_candidates(target: Path, candidates: list[dict[str, Any]], *, dry_run: bool) -> tuple[int, int, int]:
     records: list[dict[str, Any]] = []
     for item in candidates:
@@ -487,10 +502,8 @@ def _import_candidates(target: Path, candidates: list[dict[str, Any]], *, dry_ru
                 "source": "friction-scan",
                 "text": str(item.get("text") or item.get("title") or "").strip(),
                 "metadata": {
-                    "source_key": item.get("id"),
-                    "fingerprint": hashlib.sha256(
-                        json.dumps(item, sort_keys=True, default=str).encode("utf-8")
-                    ).hexdigest()[:16],
+                    "source_item_key": item.get("id"),
+                    "source_fingerprint": _candidate_fingerprint(item),
                     "friction_id": item.get("id"),
                     "friction_type": item.get("friction_type"),
                     "severity": item.get("severity"),
@@ -596,8 +609,8 @@ def add(
         "source": "friction-manual",
         "text": rendered,
         "metadata": {
-            "source_key": friction_id,
-            "fingerprint": hashlib.sha256(rendered.encode("utf-8")).hexdigest()[:16],
+            "source_item_key": friction_id,
+            "source_fingerprint": hashlib.sha256(rendered.encode("utf-8")).hexdigest()[:16],
             "friction_id": friction_id,
             "friction_type": friction_type,
             "severity": severity,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,11 @@
+import sys
+from pathlib import Path
+
 import pytest
+
+SRC = Path(__file__).resolve().parents[1] / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
 
 
 @pytest.fixture

--- a/tests/test_friction_cmd.py
+++ b/tests/test_friction_cmd.py
@@ -42,7 +42,115 @@ def test_friction_scan_writes_artifacts_and_imports_candidates(tmp_path, monkeyp
     imported = json.loads(imports[0])
     assert imported["source"] == "friction-scan"
     assert imported["kind"] == "finding"
-    assert imported["metadata"]["friction_type"] == "auth"
+    metadata = imported["metadata"]
+    assert metadata["friction_type"] == "auth"
+    assert metadata["source_item_key"] == metadata["friction_id"]
+    assert metadata["source_fingerprint"]
+    assert "source_key" not in metadata
+    assert "fingerprint" not in metadata
+
+
+def test_friction_scan_import_dedupes_by_source_identity(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(
+        friction_cmd,
+        "_now",
+        lambda: datetime(2026, 6, 11, 12, 0, 0, tzinfo=timezone.utc),
+    )
+    notes = tmp_path / "notes"
+    notes.mkdir()
+    (notes / "issue.md").write_text("Deploy was blocked because the token expired.\n")
+
+    code = cli.main(
+        [
+            "friction",
+            "scan",
+            "--target",
+            str(tmp_path),
+            "--days",
+            "30",
+            "--import-candidates",
+        ]
+    )
+
+    assert code == 0
+    capsys.readouterr()
+    imports_path = tmp_path / ".brigade" / "work" / "imports" / "inbox.jsonl"
+    imports = [json.loads(line) for line in imports_path.read_text().splitlines()]
+    assert len(imports) == 1
+    imports[0]["text"] = "Operator edited the summary text after import."
+    imports_path.write_text(json.dumps(imports[0], sort_keys=True) + "\n")
+
+    code = cli.main(
+        [
+            "friction",
+            "scan",
+            "--target",
+            str(tmp_path),
+            "--days",
+            "30",
+            "--import-candidates",
+        ]
+    )
+
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "imports_added: 0" in out
+    assert "imports_skipped: 1" in out
+    imports = [json.loads(line) for line in imports_path.read_text().splitlines()]
+    assert len(imports) == 1
+
+
+def test_friction_scan_import_skips_when_evidence_line_drifts(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(
+        friction_cmd,
+        "_now",
+        lambda: datetime(2026, 6, 11, 12, 0, 0, tzinfo=timezone.utc),
+    )
+    notes = tmp_path / "notes"
+    notes.mkdir()
+    issue = notes / "issue.md"
+    issue.write_text("Deploy was blocked because the token expired.\n")
+
+    code = cli.main(
+        [
+            "friction",
+            "scan",
+            "--target",
+            str(tmp_path),
+            "--days",
+            "30",
+            "--import-candidates",
+        ]
+    )
+
+    assert code == 0
+    capsys.readouterr()
+    imports_path = tmp_path / ".brigade" / "work" / "imports" / "inbox.jsonl"
+    assert len(imports_path.read_text().splitlines()) == 1
+
+    issue.write_text(
+        "Weekly maintenance summary.\n"
+        "Nothing unusual in the morning window.\n"
+        "Deploy was blocked because the token expired.\n"
+    )
+
+    code = cli.main(
+        [
+            "friction",
+            "scan",
+            "--target",
+            str(tmp_path),
+            "--days",
+            "30",
+            "--import-candidates",
+        ]
+    )
+
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "imports_added: 0" in out
+    assert "imports_skipped: 1" in out
+    assert len(imports_path.read_text().splitlines()) == 1
 
 
 def test_friction_scan_json_dry_run_does_not_write(tmp_path, monkeypatch, capsys):
@@ -114,4 +222,9 @@ def test_friction_add_creates_manual_import(tmp_path, monkeypatch, capsys):
     assert len(imports) == 1
     imported = json.loads(imports[0])
     assert imported["source"] == "friction-manual"
-    assert imported["metadata"]["workflow"] == "screenshots"
+    metadata = imported["metadata"]
+    assert metadata["workflow"] == "screenshots"
+    assert metadata["source_item_key"] == metadata["friction_id"]
+    assert metadata["source_fingerprint"]
+    assert "source_key" not in metadata
+    assert "fingerprint" not in metadata


### PR DESCRIPTION
Fixes #151.

Friction scan (`_import_candidates`) and manual `friction add` wrote metadata keys `source_key` and `fingerprint`. The ledger's `_import_source_key` resolver does not recognize either, so friction imports had no source identity and dedupe fell back to `(source, kind, normalized text)`.

Two changes:

1. Both sites now emit `source_item_key` and `source_fingerprint`, the keys the ledger resolves.
2. The scan fingerprint now hashes only meaning-bearing fields (`id`, `title`, `text`, `friction_type`, `severity`, `workflow`) instead of the full candidate. The full-candidate hash included `evidence.line`, so the same friction whose line number drifted in a growing log produced a new fingerprint and re-imported as a duplicate despite the stable identity key. The new regression test `test_friction_scan_import_skips_when_evidence_line_drifts` fails against the full-candidate hash and passes with the narrowed one.

Also pins `sys.path` to the local `src` tree in `tests/conftest.py` so the suite tests the checkout it lives in rather than whichever brigade an editable install resolves to.

Verification (receipts under the working tree's `.brigade/work/verify-runs/`):

- `python3 -m pytest tests/test_friction_cmd.py -q`: 6 passed
- `python3 -m pytest -q`: 1458 passed, 1 skipped
- `pipx run ruff check` on the changed files: clean