### PR TITLE
feat(run): add detached dispatch, live watch, and steer/interrupt verbs

### DIFF
--- a/docs/chat-surfaces.md
+++ b/docs/chat-surfaces.md
@@ -70,3 +70,10 @@ Export findings should contain:
 Raw exports and sweep outputs stay under `.brigade/` and should remain gitignored. Brigade rejects raw private chat fields by default, including `raw_text`, `raw_messages`, `messages`, `message_text`, `quotes`, and `transcript`.
 
 Use safe summaries, labels, message ranges, local evidence paths, and confidence values. Brigade does not run Discord, Slack, Telegram, or ClickClack APIs, perform OAuth, send webhooks, edit memory, promote imports, or run a daemon.
+
+## Live Run Controls
+
+`brigade runs watch`, `brigade runs steer`, and `brigade runs interrupt` operate on local run artifacts and, for active Codex app-server runs, the `control_socket` recorded in `run.json`.
+They are not chat export APIs. `runs watch` tails `.brigade/runs/<run>/events/*.jsonl` and other artifacts; `runs steer` and `runs interrupt` send newline-delimited JSON to the local Unix socket for an active worker turn.
+
+The socket exists only while the run process is alive and is removed during cleanup. Completed runs remain inspectable through artifacts, but cannot be steered or interrupted.

--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -49,7 +49,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade roster`: 2 command path(s)
 - `brigade run`: 1 command path(s)
 - `brigade runbook` (extras): 4 command path(s)
-- `brigade runs`: 4 command path(s)
+- `brigade runs`: 7 command path(s)
 - `brigade scrub`: 1 command path(s)
 - `brigade security`: 15 command path(s)
 - `brigade skills`: 27 command path(s)
@@ -365,10 +365,13 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade runbook plan` (extras)
 - `brigade runbook resume` (extras)
 - `brigade runbook run` (extras)
+- `brigade runs interrupt`
 - `brigade runs latest`
 - `brigade runs list`
 - `brigade runs resume`
 - `brigade runs show`
+- `brigade runs steer`
+- `brigade runs watch`
 - `brigade scrub`
 - `brigade security closeout`
 - `brigade security config`

--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -326,6 +326,7 @@ brigade run "review this repo" --read-only
 brigade run "review this repo" --read-only --inspect
 brigade run "make the change" --allow-dirty
 brigade run "make the change" --worktree
+brigade run "make the change" --detach
 ```
 
 The examples above all drive the same `brigade run` command to show its main flags. Brigade's full surface (work loop, scanners, handoffs, tools, release gates, repo fleet, and more) is documented section by section below. For the complete, auto-generated list of every command, see [`docs/command-inventory.md`](command-inventory.md), and regenerate it with `BRIGADE_EXTRAS=1 brigade roadmap commands --write`.
@@ -333,6 +334,7 @@ The examples above all drive the same `brigade run` command to show its main fla
 Common `brigade run` flags:
 
 - `--dry-run` prints planned assignments as JSON and stops before worker dispatch.
+- `--detach` starts the run in a child process, writes child output to `detached.log`, and returns after `run.json` appears.
 - `--allow-dirty` bypasses the default dirty-git-worktree guard.
 - `--worktree` runs agents in a detached git worktree and captures `changes.patch`.
 - `--show-plan` prints assignments before a normal run.
@@ -346,6 +348,27 @@ Common `brigade run` flags:
 For `codex` agents, `--read-only` also passes `codex exec --sandbox read-only`.
 Combine `--sandbox` with `--read-only` to keep prompt-level read-only rules while overriding native sandbox behavior.
 Other adapters receive the prompt policy only.
+
+Detached runs require artifacts, so `--detach` cannot be combined with `--no-artifacts`.
+It also refuses `--dry-run` and `--inspect`, because the parent process exits before it can print a plan or inspect final artifacts.
+Use `brigade runs watch <run>` to follow a detached run from its artifacts:
+
+```bash
+brigade runs watch latest --cwd /path/to/repo
+brigade runs watch <run-id> --cwd /path/to/repo --json
+```
+
+When a run uses the Codex app-server transport, `run.json` records a temporary `control_socket` while workers are active.
+Use it to send live control to active worker turns:
+
+```bash
+brigade runs steer latest coder "narrow this to the failing test"
+brigade runs interrupt latest coder
+brigade runs interrupt latest
+```
+
+`runs steer` requires a worker name and text. `runs interrupt` accepts an optional worker; without one, it interrupts every active worker turn.
+Both commands are local Unix socket requests. They refuse exec-transport runs, completed runs whose socket has been cleaned up, and app-server runs that have no active matching turn.
 
 The `cli` values are adapters for installed command-line tools:
 `codex`, `claude`, `opencode`, `antigravity`, `pi`, `cursor`, and `ollama:<model>`. Brigade shells out to those tools and keeps no provider keys. The Antigravity adapter uses the installed `agy --print` non-interactive CLI path, the Pi adapter uses `pi -p`, and the Cursor adapter uses `cursor-agent -p --output-format text`.

--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -17,6 +17,7 @@ from uuid import uuid4
 from . import agents
 from . import codex_appserver
 from . import proc, runguard
+from . import run_control
 from .roster import Agent, Roster, is_cli_allowed, timeout_for, workers
 
 CODE_GRAPH_HEADING = "## Code graph context (GraphTrail, read-only)"
@@ -753,6 +754,57 @@ def _worker_event_writer(events_dir: Path | None, worker: str, *, verbose: bool 
     return on_event
 
 
+def _run_codex_appserver_worker(
+    appserver,
+    agent: Agent,
+    worker: str,
+    prompt: str,
+    *,
+    timeout: float,
+    cwd: Path | None,
+    read_only: bool,
+    sandbox: str | None,
+    registry: run_control.LiveTurnRegistry | None,
+    on_event=None,
+) -> agents.AgentResult:
+    effective_sandbox = sandbox if sandbox is not None else ("read-only" if read_only else None)
+    active_turn_id: str | None = None
+    try:
+        thread = appserver.start_thread(cwd=cwd, model=agent.model, sandbox=effective_sandbox)
+
+        def on_turn_start(turn_id: str) -> None:
+            nonlocal active_turn_id
+            active_turn_id = turn_id
+            if registry is not None:
+                registry.register(worker, thread, turn_id)
+
+        try:
+            turn = thread.run_turn(prompt, timeout=timeout, on_event=on_event, on_turn_start=on_turn_start)
+        except TypeError as exc:
+            if "on_turn_start" not in str(exc):
+                raise
+            turn = thread.run_turn(prompt, timeout=timeout, on_event=on_event)
+    except codex_appserver.AppServerError as exc:
+        return agents.AgentResult(text="", ok=False, detail=str(exc)[:200], status="failed")
+    finally:
+        if registry is not None and active_turn_id is not None:
+            registry.unregister(worker, active_turn_id)
+    text = turn.text.strip()
+    if not turn.ok:
+        return agents.AgentResult(
+            text=text,
+            ok=False,
+            detail=(turn.detail or f"turn {turn.status}")[:200],
+            thread_id=turn.thread_id,
+            status=turn.status,
+        )
+    if not text:
+        return agents.AgentResult(
+            text="", ok=False, detail="empty output", thread_id=turn.thread_id, status=turn.status
+        )
+    return agents.AgentResult(text=text, ok=True, thread_id=turn.thread_id, status=turn.status)
+
+
 def dispatch(
     assignments: list[Assignment],
     roster: Roster,
@@ -763,6 +815,7 @@ def dispatch(
     code_graph: CodeGraphBrief | None = None,
     drift_impact: DriftImpactBrief | None = None,
     appserver=None,
+    control_registry: run_control.LiveTurnRegistry | None = None,
     events_dir: Path | None = None,
     verbose: bool = False,
 ) -> list[WorkerResult]:
@@ -786,14 +839,16 @@ def dispatch(
         )
         if agent.cli == "codex" and appserver is not None:
             on_event = _worker_event_writer(events_dir, assignment.worker, verbose=verbose)
-            result = agents.run_codex_appserver(
+            result = _run_codex_appserver_worker(
                 appserver,
+                agent,
+                assignment.worker,
                 prompt,
                 timeout=timeout_for(agent, roster),
                 cwd=cwd,
                 read_only=read_only if sandbox_read_only is None else sandbox_read_only,
                 sandbox=sandbox,
-                model=agent.model,
+                registry=control_registry,
                 on_event=on_event,
             )
         else:
@@ -1178,6 +1233,7 @@ def _run_payload(
     drift_impact: DriftImpactBrief | None = None,
     brief_set: BriefSet | None = None,
     codex_transport: str | None = None,
+    control_socket: Path | None = None,
 ) -> dict[str, object]:
     payload: dict[str, object] = {
         "task": task,
@@ -1212,6 +1268,8 @@ def _run_payload(
         payload["error"] = error
     if codex_transport is not None:
         payload["codex_transport"] = codex_transport
+    if control_socket is not None:
+        payload["control_socket"] = str(control_socket)
     return payload
 
 
@@ -1266,6 +1324,7 @@ def run(
             ),
         )
 
+    control_socket = None
     plan_attempts: list[dict[str, object]] | None = [] if output_dir is not None else None
     try:
         assignments = plan(
@@ -1300,6 +1359,7 @@ def run(
                     drift_impact=drift_impact,
                     brief_set=brief_set,
                     codex_transport=transport_for_payload,
+                    control_socket=control_socket,
                 ),
             )
         print(f"error: {exc}", file=sys.stderr)
@@ -1342,6 +1402,8 @@ def run(
         (roster.agents.get(a.worker) is not None and roster.agents[a.worker].cli == "codex") for a in assignments
     )
     appserver = None
+    control_registry = None
+    control_server = None
     if effective_transport == "app-server" and has_codex_workers:
         try:
             appserver = codex_appserver.AppServer(cwd=cwd)
@@ -1350,9 +1412,39 @@ def run(
             print(f"warning: codex app-server unavailable ({exc}); falling back to exec", file=sys.stderr)
             appserver = None
             effective_transport = "exec"
+        if appserver is not None and output_dir is not None:
+            control_registry = run_control.LiveTurnRegistry()
+            control_socket = output_dir / "control.sock"
+            control_server = run_control.ControlServer(control_socket, control_registry)
+            try:
+                control_server.start()
+            except run_control.ControlError as exc:
+                print(f"warning: run control unavailable ({exc})", file=sys.stderr)
+                control_registry = None
+                control_server = None
+                control_socket = None
     elif effective_transport == "app-server":
         effective_transport = "exec"
     transport_for_payload = effective_transport
+    if output_dir is not None and control_socket is not None:
+        _write_json(
+            output_dir / "run.json",
+            _run_payload(
+                task=task,
+                cwd=cwd,
+                roster=roster,
+                dry_run=dry_run,
+                read_only=read_only,
+                status="dispatching",
+                started_at=started_at,
+                output_dir=output_dir,
+                code_graph=code_graph,
+                drift_impact=drift_impact,
+                brief_set=brief_set,
+                codex_transport=transport_for_payload,
+                control_socket=control_socket,
+            ),
+        )
 
     try:
         worker_results = dispatch(
@@ -1365,10 +1457,13 @@ def run(
             code_graph=code_graph,
             drift_impact=drift_impact,
             appserver=appserver,
+            control_registry=control_registry,
             events_dir=(output_dir / "events") if (output_dir is not None and appserver is not None) else None,
             verbose=verbose,
         )
     finally:
+        if control_server is not None:
+            control_server.close()
         if appserver is not None:
             appserver.close()
     ground_truth = build_ground_truth(cwd, started_at)
@@ -1449,6 +1544,7 @@ def run(
                 drift_impact=drift_impact,
                 brief_set=brief_set,
                 codex_transport=transport_for_payload,
+                control_socket=control_socket,
             ),
         )
     if handoff_inbox is not None:
@@ -1484,6 +1580,7 @@ def run(
                         drift_impact=drift_impact,
                         brief_set=brief_set,
                         codex_transport=transport_for_payload,
+                        control_socket=control_socket,
                     ),
                 )
             print(f"error: {detail}", file=sys.stderr)
@@ -1509,6 +1606,7 @@ def run(
                     drift_impact=drift_impact,
                     brief_set=brief_set,
                     codex_transport=transport_for_payload,
+                    control_socket=control_socket,
                 ),
             )
     print(final.text)

--- a/src/brigade/cli/run.py
+++ b/src/brigade/cli/run.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 import argparse
 import sys
+import time
 from pathlib import Path
+from subprocess import DEVNULL, STDOUT, Popen
+
+
+_DETACH_START_TIMEOUT_SECONDS = 30.0
+_DETACH_POLL_INTERVAL_SECONDS = 0.05
 
 
 def register(sub: argparse._SubParsersAction) -> None:
@@ -18,6 +24,11 @@ def register(sub: argparse._SubParsersAction) -> None:
         help="Path to roster.toml. Defaults to .brigade/roster.toml under the current directory.",
     )
     p_run.add_argument("--dry-run", action="store_true", help="Print the plan without dispatching workers.")
+    p_run.add_argument(
+        "--detach",
+        action="store_true",
+        help="Start the run in a detached child process and return after run metadata is written.",
+    )
     p_run.add_argument(
         "--allow-dirty",
         action="store_true",
@@ -95,6 +106,15 @@ def dispatch(args) -> int:
     run_cwd = args.cwd.expanduser().resolve()
     if not run_cwd.is_dir():
         print(f"error: --cwd is not a directory: {run_cwd}", file=sys.stderr)
+        return 2
+    if args.detach and args.dry_run:
+        print("error: --detach cannot be used with --dry-run", file=sys.stderr)
+        return 2
+    if args.detach and args.no_artifacts:
+        print("error: --detach cannot be used with --no-artifacts", file=sys.stderr)
+        return 2
+    if args.detach and args.inspect:
+        print("error: --detach cannot be used with --inspect", file=sys.stderr)
         return 2
     if args.handoff and args.dry_run:
         print("error: --handoff cannot be used with --dry-run", file=sys.stderr)
@@ -174,6 +194,10 @@ def dispatch(args) -> int:
         print(f"error: {exc}", file=sys.stderr)
         return 2
 
+    if args.detach:
+        assert output_dir is not None
+        return _dispatch_detached(args, run_cwd=run_cwd, roster_path=roster_path, output_dir=output_dir)
+
     worktree_cwd = None
     effective_cwd = run_cwd
     keep_worktree = False
@@ -239,6 +263,95 @@ def dispatch(args) -> int:
 
             runs_cmd.show(output_dir)
     return rc
+
+
+def _dispatch_detached(args, *, run_cwd: Path, roster_path: Path, output_dir: Path) -> int:
+    output_dir = output_dir.expanduser().resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    log_path = output_dir / "detached.log"
+    argv = _detached_child_argv(args, run_cwd=run_cwd, roster_path=roster_path, output_dir=output_dir)
+    try:
+        with log_path.open("a", encoding="utf-8") as log:
+            proc = Popen(
+                argv,
+                cwd=run_cwd,
+                stdin=DEVNULL,
+                stdout=log,
+                stderr=STDOUT,
+                start_new_session=True,
+            )
+    except OSError as exc:
+        print(f"error: failed to start detached run: {exc}", file=sys.stderr)
+        print(f"log: {log_path}", file=sys.stderr)
+        return 2
+
+    exit_code = _poll_detached_start(proc, output_dir)
+    if exit_code is not None:
+        print(f"error: detached child exited before run metadata was written: exit {exit_code}", file=sys.stderr)
+        print(f"artifacts: {output_dir}", file=sys.stderr)
+        print(f"log: {log_path}", file=sys.stderr)
+        return 2
+
+    if not (output_dir / "run.json").is_file():
+        print(
+            "warning: detached child has not written run metadata yet; check the log for startup progress.",
+            file=sys.stderr,
+        )
+    print(f"run: {output_dir.name}")
+    print(f"detached: pid {proc.pid}", file=sys.stderr)
+    print(f"artifacts: {output_dir}", file=sys.stderr)
+    print(f"log: {log_path}", file=sys.stderr)
+    return 0
+
+
+def _detached_child_argv(args, *, run_cwd: Path, roster_path: Path, output_dir: Path) -> list[str]:
+    argv = [
+        sys.executable,
+        "-m",
+        "brigade",
+        "run",
+        args.task,
+        "--roster",
+        str(roster_path.expanduser().resolve()),
+        "--cwd",
+        str(run_cwd),
+        "--output-dir",
+        str(output_dir),
+    ]
+    if args.allow_dirty:
+        argv.append("--allow-dirty")
+    if args.worktree:
+        argv.append("--worktree")
+    if args.show_plan:
+        argv.append("--show-plan")
+    if args.verbose:
+        argv.append("--verbose")
+    if args.read_only:
+        argv.append("--read-only")
+    if args.no_code_graph:
+        argv.append("--no-code-graph")
+    if args.sandbox is not None:
+        argv.extend(["--sandbox", args.sandbox])
+    if args.codex_transport is not None:
+        argv.extend(["--codex-transport", args.codex_transport])
+    if args.handoff:
+        argv.append("--handoff")
+    if args.handoff_inbox is not None:
+        argv.extend(["--handoff-inbox", str(args.handoff_inbox.expanduser().resolve())])
+    return argv
+
+
+def _poll_detached_start(proc: Popen, output_dir: Path) -> int | None:
+    run_json = output_dir / "run.json"
+    deadline = time.monotonic() + _DETACH_START_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        if run_json.is_file():
+            return None
+        exit_code = proc.poll()
+        if exit_code is not None:
+            return exit_code
+        time.sleep(_DETACH_POLL_INTERVAL_SECONDS)
+    return None
 
 
 def _worktree_checkout_path(repo_root: Path, output_dir: Path) -> Path:

--- a/src/brigade/cli/runs.py
+++ b/src/brigade/cli/runs.py
@@ -40,6 +40,58 @@ def register(sub: argparse._SubParsersAction) -> None:
     )
     p_runs_show = runs_sub.add_parser("show", help="Show a readable summary of one run directory.")
     p_runs_show.add_argument("run_dir", type=Path, help="Path to a Brigade run artifact directory.")
+    p_runs_watch = runs_sub.add_parser("watch", help="Watch a Brigade run artifact directory until it finishes.")
+    p_runs_watch.add_argument("run", help="Run directory path, run id under --runs-dir, or 'latest'.")
+    p_runs_watch.add_argument(
+        "--cwd",
+        type=Path,
+        default=Path("."),
+        help="Workspace whose default .brigade/runs directory should be used for run ids.",
+    )
+    p_runs_watch.add_argument(
+        "--runs-dir",
+        type=Path,
+        default=None,
+        help="Explicit runs directory for run ids. Defaults to .brigade/runs under --cwd.",
+    )
+    p_runs_watch.add_argument("--json", action="store_true", help="Emit newline-delimited JSON records.")
+    p_runs_watch.add_argument(
+        "--interval",
+        type=float,
+        default=1.0,
+        help="Polling interval in seconds.",
+    )
+    p_runs_steer = runs_sub.add_parser("steer", help="Send steering text to an active app-server worker turn.")
+    p_runs_steer.add_argument("run", help="Run directory path, run id under --runs-dir, or 'latest'.")
+    p_runs_steer.add_argument("worker", help="Worker name to steer.")
+    p_runs_steer.add_argument("text", nargs="+", help="Text to append to the active worker turn.")
+    p_runs_steer.add_argument(
+        "--cwd",
+        type=Path,
+        default=Path("."),
+        help="Workspace whose default .brigade/runs directory should be used for run ids.",
+    )
+    p_runs_steer.add_argument(
+        "--runs-dir",
+        type=Path,
+        default=None,
+        help="Explicit runs directory for run ids. Defaults to .brigade/runs under --cwd.",
+    )
+    p_runs_interrupt = runs_sub.add_parser("interrupt", help="Interrupt active app-server worker turns.")
+    p_runs_interrupt.add_argument("run", help="Run directory path, run id under --runs-dir, or 'latest'.")
+    p_runs_interrupt.add_argument("worker", nargs="?", default=None, help="Optional worker name to interrupt.")
+    p_runs_interrupt.add_argument(
+        "--cwd",
+        type=Path,
+        default=Path("."),
+        help="Workspace whose default .brigade/runs directory should be used for run ids.",
+    )
+    p_runs_interrupt.add_argument(
+        "--runs-dir",
+        type=Path,
+        default=None,
+        help="Explicit runs directory for run ids. Defaults to .brigade/runs under --cwd.",
+    )
     p_runs_resume = runs_sub.add_parser(
         "resume", help="Re-attach interrupted app-server workers from a run and re-synthesize."
     )
@@ -56,9 +108,48 @@ def dispatch(args) -> int:
         return runs_cmd.show_latest(cwd=args.cwd, runs_dir=args.runs_dir)
     if args.runs_command == "show":
         return runs_cmd.show(args.run_dir)
+    if args.runs_command == "watch":
+        return runs_cmd.watch(
+            args.run,
+            cwd=args.cwd,
+            runs_dir=args.runs_dir,
+            json_output=args.json,
+            interval=args.interval,
+        )
+    if args.runs_command == "steer":
+        return _control_request(
+            args.run,
+            cwd=args.cwd,
+            runs_dir=args.runs_dir,
+            payload={"op": "steer", "worker": args.worker, "text": " ".join(args.text)},
+        )
+    if args.runs_command == "interrupt":
+        payload = {"op": "interrupt"}
+        if args.worker is not None:
+            payload["worker"] = args.worker
+        return _control_request(args.run, cwd=args.cwd, runs_dir=args.runs_dir, payload=payload)
     if args.runs_command == "resume":
         from .. import run_resume
 
         return run_resume.resume(args.run_dir)
     args._brigade_parser.error(f"unknown runs command: {args.runs_command}")
     return 2
+
+
+def _control_request(run: str, *, cwd: Path, runs_dir: Path | None, payload: dict[str, object]) -> int:
+    import sys
+
+    from .. import run_control, runs_cmd
+
+    run_dir, error = runs_cmd._resolve_run_dir(run, cwd=cwd, runs_dir=runs_dir)
+    if error is not None:
+        print(error, file=sys.stderr)
+        return 2
+    assert run_dir is not None
+    try:
+        socket_path = run_control.control_socket_from_run(run_dir)
+        response = run_control.send_request(socket_path, payload)
+    except run_control.ControlError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    return run_control.print_control_response(response, op=str(payload["op"]))

--- a/src/brigade/codex_appserver.py
+++ b/src/brigade/codex_appserver.py
@@ -261,12 +261,20 @@ class CodexThread:
             {"threadId": self.thread_id, "expectedTurnId": turn_id, "input": [{"type": "text", "text": text}]},
         )
 
+    def interrupt(self, turn_id: str) -> None:
+        self._server.request(
+            "turn/interrupt",
+            {"threadId": self.thread_id, "turnId": turn_id},
+            timeout=_INTERRUPT_GRACE,
+        )
+
     def run_turn(
         self,
         prompt: str,
         *,
         timeout: float,
         on_event: Callable[[dict], None] | None = None,
+        on_turn_start: Callable[[str], None] | None = None,
     ) -> TurnResult:
         try:
             result = self._server.request(
@@ -276,6 +284,11 @@ class CodexThread:
         except AppServerError as exc:
             return TurnResult(text="", ok=False, status="failed", thread_id=self.thread_id, detail=str(exc)[:200])
         turn_id = result["turn"]["id"]
+        if on_turn_start is not None:
+            try:
+                on_turn_start(turn_id)
+            except Exception:  # noqa: BLE001 - observer must never kill the turn
+                pass
         deltas: dict[str, list[str]] = {}
         completed_texts: list[str] = []
         deadline = time.monotonic() + timeout
@@ -286,9 +299,7 @@ class CodexThread:
 
         # Timed out: interrupt, then drain briefly for the interrupted turn/completed.
         try:
-            self._server.request(
-                "turn/interrupt", {"threadId": self.thread_id, "turnId": turn_id}, timeout=_INTERRUPT_GRACE
-            )
+            self.interrupt(turn_id)
         except AppServerError:
             pass
         completed = self._consume(time.monotonic() + _INTERRUPT_GRACE, turn_id, deltas, completed_texts, on_event)

--- a/src/brigade/run_control.py
+++ b/src/brigade/run_control.py
@@ -1,0 +1,239 @@
+"""Live control socket for app-server Brigade runs."""
+
+from __future__ import annotations
+
+import json
+import socket
+import sys
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+_CLIENT_TIMEOUT_SECONDS = 5.0
+
+
+class ControlError(RuntimeError):
+    """Control socket setup, request, or operation failure."""
+
+
+@dataclass(frozen=True)
+class ActiveTurn:
+    worker: str
+    thread: Any
+    thread_id: str
+    turn_id: str
+
+
+class LiveTurnRegistry:
+    """Thread-safe registry of worker names to their current app-server turn."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._active: dict[str, ActiveTurn] = {}
+
+    def register(self, worker: str, thread: Any, turn_id: str) -> None:
+        thread_id = getattr(thread, "thread_id", "")
+        with self._lock:
+            self._active[worker] = ActiveTurn(worker=worker, thread=thread, thread_id=thread_id, turn_id=turn_id)
+
+    def unregister(self, worker: str, turn_id: str) -> None:
+        with self._lock:
+            active = self._active.get(worker)
+            if active is not None and active.turn_id == turn_id:
+                self._active.pop(worker, None)
+
+    def steer(self, worker: str, text: str) -> dict[str, object]:
+        if not text.strip():
+            raise ControlError("steer text must not be empty")
+        active = self._require_worker(worker)
+        active.thread.steer(text, active.turn_id)
+        return {
+            "ok": True,
+            "worker": active.worker,
+            "thread_id": active.thread_id,
+            "turn_id": active.turn_id,
+        }
+
+    def interrupt(self, worker: str | None = None) -> dict[str, object]:
+        turns = self._turns(worker)
+        if not turns:
+            target = f" for worker {worker!r}" if worker else ""
+            raise ControlError(f"no active turn{target}")
+        interrupted: list[str] = []
+        for active in turns:
+            active.thread.interrupt(active.turn_id)
+            interrupted.append(active.worker)
+        return {"ok": True, "interrupted": len(interrupted), "workers": interrupted}
+
+    def _require_worker(self, worker: str) -> ActiveTurn:
+        with self._lock:
+            active = self._active.get(worker)
+        if active is None:
+            raise ControlError(f"no active turn for worker {worker!r}")
+        return active
+
+    def _turns(self, worker: str | None) -> list[ActiveTurn]:
+        with self._lock:
+            if worker:
+                active = self._active.get(worker)
+                return [active] if active is not None else []
+            return list(self._active.values())
+
+
+class ControlServer:
+    """Newline-delimited JSON control server over a Unix domain socket."""
+
+    def __init__(self, path: Path, registry: LiveTurnRegistry) -> None:
+        self.path = path.expanduser()
+        self.registry = registry
+        self._sock: socket.socket | None = None
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._client_threads: list[threading.Thread] = []
+
+    def start(self) -> None:
+        if self._thread is not None:
+            return
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            self.path.unlink()
+        except FileNotFoundError:
+            pass
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            sock.bind(str(self.path))
+            sock.listen()
+            sock.settimeout(0.1)
+        except OSError as exc:
+            sock.close()
+            raise ControlError(f"failed to start control socket: {exc}") from exc
+        self._sock = sock
+        self._thread = threading.Thread(target=self._serve, name="brigade-run-control", daemon=True)
+        self._thread.start()
+
+    def close(self) -> None:
+        self._stop.set()
+        sock = self._sock
+        self._sock = None
+        if sock is not None:
+            sock.close()
+        thread = self._thread
+        if thread is not None:
+            thread.join(timeout=1.0)
+        for client in list(self._client_threads):
+            client.join(timeout=0.2)
+        try:
+            self.path.unlink()
+        except FileNotFoundError:
+            pass
+
+    def _serve(self) -> None:
+        while not self._stop.is_set():
+            sock = self._sock
+            if sock is None:
+                return
+            try:
+                conn, _ = sock.accept()
+            except TimeoutError:
+                continue
+            except OSError:
+                return
+            thread = threading.Thread(target=self._handle_client, args=(conn,), daemon=True)
+            self._client_threads.append(thread)
+            thread.start()
+
+    def _handle_client(self, conn: socket.socket) -> None:
+        with conn:
+            try:
+                fh = conn.makefile("rwb")
+            except OSError:
+                return
+            with fh:
+                for raw in fh:
+                    try:
+                        request = json.loads(raw.decode())
+                        if not isinstance(request, dict):
+                            raise ControlError("request must be a JSON object")
+                        response = self._dispatch(request)
+                    except json.JSONDecodeError as exc:
+                        response = {"ok": False, "error": f"invalid JSON: {exc.msg}"}
+                    except ControlError as exc:
+                        response = {"ok": False, "error": str(exc)}
+                    except Exception as exc:  # noqa: BLE001 - control server boundary
+                        response = {"ok": False, "error": str(exc)}
+                    fh.write(json.dumps(response, sort_keys=True).encode() + b"\n")
+                    fh.flush()
+
+    def _dispatch(self, request: dict[str, object]) -> dict[str, object]:
+        op = request.get("op")
+        if op == "steer":
+            worker = request.get("worker")
+            text = request.get("text")
+            if not isinstance(worker, str) or not worker:
+                raise ControlError("steer requires worker")
+            if not isinstance(text, str):
+                raise ControlError("steer requires text")
+            return self.registry.steer(worker, text)
+        if op == "interrupt":
+            worker = request.get("worker")
+            if worker is not None and (not isinstance(worker, str) or not worker):
+                raise ControlError("interrupt worker must be a non-empty string")
+            return self.registry.interrupt(worker)
+        raise ControlError(f"unknown control op: {op}")
+
+
+def send_request(path: Path, payload: dict[str, object], *, timeout: float = _CLIENT_TIMEOUT_SECONDS) -> dict[str, Any]:
+    path = path.expanduser()
+    if not path.exists():
+        raise ControlError(f"control socket is not active: {path}")
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.settimeout(timeout)
+    try:
+        sock.connect(str(path))
+        with sock, sock.makefile("rwb") as fh:
+            fh.write(json.dumps(payload, sort_keys=True).encode() + b"\n")
+            fh.flush()
+            raw = fh.readline()
+    except OSError as exc:
+        raise ControlError(f"control socket request failed: {exc}") from exc
+    if not raw:
+        raise ControlError("control socket closed without a response")
+    try:
+        response = json.loads(raw.decode())
+    except json.JSONDecodeError as exc:
+        raise ControlError(f"control socket returned invalid JSON: {exc}") from exc
+    if not isinstance(response, dict):
+        raise ControlError("control socket returned a non-object response")
+    return response
+
+
+def control_socket_from_run(run_dir: Path) -> Path:
+    run_json = run_dir / "run.json"
+    try:
+        meta = json.loads(run_json.read_text())
+    except FileNotFoundError as exc:
+        raise ControlError(f"run.json not found in {run_dir}") from exc
+    except json.JSONDecodeError as exc:
+        raise ControlError(f"run.json is not valid JSON: {exc}") from exc
+    if not isinstance(meta, dict):
+        raise ControlError("run.json must contain a JSON object")
+    socket_value = meta.get("control_socket")
+    if isinstance(socket_value, str) and socket_value:
+        return Path(socket_value)
+    if meta.get("codex_transport") != "app-server":
+        raise ControlError("run was not started with app-server transport")
+    raise ControlError("run does not record a control socket")
+
+
+def print_control_response(response: dict[str, object], *, op: str) -> int:
+    if response.get("ok") is not True:
+        print(f"error: {response.get('error') or 'control request failed'}", file=sys.stderr)
+        return 1
+    if op == "steer":
+        print(f"steer: {response.get('worker')} turn={response.get('turn_id')}")
+    elif op == "interrupt":
+        workers = response.get("workers")
+        worker_text = ", ".join(str(worker) for worker in workers) if isinstance(workers, list) else ""
+        print(f"interrupt: {response.get('interrupted', 0)}" + (f" ({worker_text})" if worker_text else ""))
+    return 0

--- a/src/brigade/runs_cmd.py
+++ b/src/brigade/runs_cmd.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 import json
 import sys
+import time
 from pathlib import Path
 from typing import Any
+
+_NONTERMINAL_STATUSES = frozenset({"started", "planning", "dispatching", "synthesizing", "running"})
+_SUCCESS_STATUSES = frozenset({"ok", "dry-run"})
 
 
 def _read_json(path: Path) -> dict[str, Any] | None:
@@ -24,6 +28,41 @@ def _read_text(path: Path) -> str | None:
     if not path.exists():
         return None
     return path.read_text().strip()
+
+
+def _runs_root(cwd: Path, runs_dir: Path | None) -> tuple[Path | None, str | None]:
+    cwd = cwd.expanduser().resolve()
+    if not cwd.is_dir():
+        return None, f"error: --cwd is not a directory: {cwd}"
+    root = runs_dir.expanduser() if runs_dir is not None else cwd / ".brigade" / "runs"
+    if not root.is_dir():
+        return None, f"error: runs directory not found: {root}"
+    return root, None
+
+
+def _resolve_run_dir(run: str | Path, *, cwd: Path, runs_dir: Path | None = None) -> tuple[Path | None, str | None]:
+    raw = Path(run).expanduser()
+    if raw.is_absolute() or len(raw.parts) > 1 or raw.exists():
+        run_dir = raw.resolve()
+        if not run_dir.is_dir():
+            return None, f"error: run directory not found: {run_dir}"
+        return run_dir, None
+
+    root, error = _runs_root(cwd, runs_dir)
+    if error is not None:
+        return None, error
+    assert root is not None
+    if str(run) == "latest":
+        runs, skipped = _collect_runs(root)
+        if skipped:
+            print(f"skipped {skipped} invalid run director{'y' if skipped == 1 else 'ies'}", file=sys.stderr)
+        if not runs:
+            return None, f"error: no runs found in {root}"
+        return runs[0][0].resolve(), None
+    run_dir = (root / raw).resolve()
+    if not run_dir.is_dir():
+        return None, f"error: run directory not found: {run_dir}"
+    return run_dir, None
 
 
 def _line(label: str, value: object | None) -> None:
@@ -137,6 +176,209 @@ def _print_final(final_text: str | None) -> None:
         print(f"  {line}")
 
 
+def _duration_text(value: object) -> str:
+    if not isinstance(value, (int, float)):
+        return "unknown duration"
+    return f"{value:g}s"
+
+
+def _artifact_signature(payload: object) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _is_terminal(meta: dict[str, Any]) -> bool:
+    status = meta.get("status")
+    if meta.get("finished_at"):
+        return True
+    return isinstance(status, str) and status not in _NONTERMINAL_STATUSES
+
+
+def _watch_return_code(status: object) -> int:
+    if status in _SUCCESS_STATUSES:
+        return 0
+    return 1
+
+
+def _emit_json(payload: dict[str, object]) -> None:
+    print(json.dumps(payload, sort_keys=True))
+
+
+def _emit_run(meta: dict[str, Any], *, json_output: bool) -> None:
+    if json_output:
+        payload = {
+            "type": "run",
+            "status": meta.get("status"),
+            "task": meta.get("task"),
+            "started_at": meta.get("started_at"),
+            "finished_at": meta.get("finished_at"),
+            "duration_seconds": meta.get("duration_seconds"),
+        }
+        _emit_json({key: value for key, value in payload.items() if value is not None})
+        return
+    _line("status", meta.get("status"))
+    _line("task", meta.get("task"))
+
+
+def _emit_plan(plan_payload: dict[str, Any], *, json_output: bool) -> None:
+    assignments = plan_payload.get("assignments")
+    if not isinstance(assignments, list):
+        return
+    if json_output:
+        _emit_json({"type": "plan", "assignments": assignments})
+        return
+    print("plan:")
+    if not assignments:
+        print("  (no worker assignments)")
+        return
+    for assignment in assignments:
+        if not isinstance(assignment, dict):
+            continue
+        stage = assignment.get("stage", 1)
+        print(f"  stage {stage} -> {assignment.get('worker', 'unknown')}: {assignment.get('task', '')}")
+
+
+def _event_item_type(event: dict[str, Any]) -> str:
+    params = event.get("params")
+    if not isinstance(params, dict):
+        return ""
+    item = params.get("item")
+    if isinstance(item, dict) and isinstance(item.get("type"), str):
+        return item["type"]
+    turn = params.get("turn")
+    if isinstance(turn, dict):
+        return "turn"
+    return ""
+
+
+def _emit_event(worker: str, event: dict[str, Any], *, json_output: bool) -> None:
+    if json_output:
+        _emit_json({"type": "event", "worker": worker, "event": event})
+        return
+    method = event.get("method", "unknown")
+    item_type = _event_item_type(event)
+    suffix = f" {item_type}" if item_type else ""
+    print(f"event: {worker} {method}{suffix}")
+
+
+def _emit_workers(worker_results: dict[str, Any], *, json_output: bool) -> None:
+    if json_output:
+        _emit_json({"type": "workers", "results": worker_results.get("results") or []})
+        return
+    _print_workers(worker_results)
+
+
+def _emit_synthesis(synthesis: dict[str, Any], *, json_output: bool) -> None:
+    if json_output:
+        _emit_json(
+            {
+                "type": "synthesis",
+                "orchestrator": synthesis.get("orchestrator"),
+                "result": synthesis.get("result"),
+            }
+        )
+        return
+    _print_synthesis(synthesis)
+
+
+def _emit_final(final_text: str, *, json_output: bool) -> None:
+    if json_output:
+        _emit_json({"type": "final", "text": final_text})
+        return
+    _print_final(final_text)
+
+
+def _emit_summary(run_dir: Path, meta: dict[str, Any], *, json_output: bool) -> None:
+    status = str(meta.get("status") or "unknown")
+    duration = meta.get("duration_seconds")
+    if json_output:
+        payload: dict[str, object] = {"type": "summary", "run": str(run_dir), "status": status}
+        if isinstance(duration, (int, float)):
+            payload["duration_seconds"] = duration
+        _emit_json(payload)
+        return
+    print(f"summary: {status} in {_duration_text(duration)}")
+
+
+def _tail_events(run_dir: Path, offsets: dict[Path, int], *, json_output: bool) -> None:
+    events_dir = run_dir / "events"
+    if not events_dir.is_dir():
+        return
+    for path in sorted(events_dir.glob("*.jsonl")):
+        try:
+            size = path.stat().st_size
+        except OSError:
+            continue
+        offset = offsets.get(path, 0)
+        if size < offset:
+            offset = 0
+        try:
+            with path.open() as fh:
+                fh.seek(offset)
+                for line in fh:
+                    stripped = line.strip()
+                    if not stripped:
+                        continue
+                    try:
+                        event = json.loads(stripped)
+                    except json.JSONDecodeError:
+                        continue
+                    if isinstance(event, dict):
+                        _emit_event(path.stem, event, json_output=json_output)
+                offsets[path] = fh.tell()
+        except OSError:
+            continue
+
+
+def _poll_watch_artifacts(
+    run_dir: Path,
+    signatures: dict[str, str],
+    event_offsets: dict[Path, int],
+    *,
+    json_output: bool,
+) -> tuple[dict[str, Any] | None, int | None]:
+    try:
+        run_meta = _read_json(run_dir / "run.json")
+        if run_meta is None:
+            print(f"error: run.json not found in {run_dir}", file=sys.stderr)
+            return None, 2
+        run_sig = _artifact_signature(run_meta)
+        if signatures.get("run") != run_sig:
+            _emit_run(run_meta, json_output=json_output)
+            signatures["run"] = run_sig
+
+        plan = _read_json(run_dir / "plan.json")
+        if plan is not None:
+            plan_sig = _artifact_signature(plan)
+            if signatures.get("plan") != plan_sig:
+                _emit_plan(plan, json_output=json_output)
+                signatures["plan"] = plan_sig
+
+        _tail_events(run_dir, event_offsets, json_output=json_output)
+
+        worker_results = _read_json(run_dir / "worker-results.json")
+        if worker_results is not None:
+            workers_sig = _artifact_signature(worker_results)
+            if signatures.get("workers") != workers_sig:
+                _emit_workers(worker_results, json_output=json_output)
+                signatures["workers"] = workers_sig
+
+        synthesis = _read_json(run_dir / "synthesis.json")
+        if synthesis is not None:
+            synthesis_sig = _artifact_signature(synthesis)
+            if signatures.get("synthesis") != synthesis_sig:
+                _emit_synthesis(synthesis, json_output=json_output)
+                signatures["synthesis"] = synthesis_sig
+
+        final_text = _read_text(run_dir / "final.txt")
+        if final_text is not None and signatures.get("final") != final_text:
+            _emit_final(final_text, json_output=json_output)
+            signatures["final"] = final_text
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return None, 2
+    return run_meta, None
+
+
 def _short(text: object, limit: int = 72) -> str:
     rendered = " ".join(str(text or "").split())
     if len(rendered) <= limit:
@@ -220,6 +462,48 @@ def show_latest(*, cwd: Path, runs_dir: Path | None = None) -> int:
         print(f"error: no runs found in {root}", file=sys.stderr)
         return 1
     return show(runs[0][0])
+
+
+def watch(
+    run: str | Path,
+    *,
+    cwd: Path,
+    runs_dir: Path | None = None,
+    json_output: bool = False,
+    interval: float = 1.0,
+) -> int:
+    if interval < 0:
+        print("error: --interval must be non-negative", file=sys.stderr)
+        return 2
+    run_dir, error = _resolve_run_dir(run, cwd=cwd, runs_dir=runs_dir)
+    if error is not None:
+        print(error, file=sys.stderr)
+        return 2
+    assert run_dir is not None
+    if json_output:
+        _emit_json({"type": "watch", "run": str(run_dir)})
+    else:
+        print(f"watching: {run_dir}")
+
+    signatures: dict[str, str] = {}
+    event_offsets: dict[Path, int] = {}
+    summary_emitted = False
+    while True:
+        run_meta, rc = _poll_watch_artifacts(
+            run_dir,
+            signatures,
+            event_offsets,
+            json_output=json_output,
+        )
+        if rc is not None:
+            return rc
+        assert run_meta is not None
+        if _is_terminal(run_meta):
+            if not summary_emitted:
+                _emit_summary(run_dir, run_meta, json_output=json_output)
+                summary_emitted = True
+            return _watch_return_code(run_meta.get("status"))
+        time.sleep(interval)
 
 
 def show(run_dir: Path) -> int:

--- a/tests/fake_appserver.py
+++ b/tests/fake_appserver.py
@@ -139,6 +139,13 @@ def main() -> int:
             thread_id = pending_hang.pop(turn_id, msg["params"]["threadId"])
             _send({"jsonrpc": "2.0", "id": msg_id, "result": {}})
             _complete_turn(thread_id, turn_id, "interrupted", None)
+        elif method == "turn/steer":
+            params = msg["params"]
+            turn_id = params["expectedTurnId"]
+            text = params["input"][0]["text"]
+            thread_id = pending_hang.pop(turn_id, params["threadId"])
+            _send({"jsonrpc": "2.0", "id": msg_id, "result": {}})
+            _complete_turn(thread_id, turn_id, "completed", f"steered: {text}")
         else:
             _send({"jsonrpc": "2.0", "id": msg_id, "result": {}})
     return 0

--- a/tests/test_run_control.py
+++ b/tests/test_run_control.py
@@ -1,0 +1,220 @@
+"""Tests for live run steering and interruption."""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+import time
+from pathlib import Path
+
+from brigade import aboyeur, agents, cli, codex_appserver, run_control
+from brigade.roster import Agent, Roster
+
+FAKE = [sys.executable, str(Path(__file__).parent / "fake_appserver.py")]
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n")
+
+
+def _wait_for(predicate, *, timeout: float = 5.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        value = predicate()
+        if value:
+            return value
+        time.sleep(0.02)
+    raise AssertionError("timed out waiting for condition")
+
+
+class _FakeTurn:
+    thread_id = "thread-1"
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, str]] = []
+
+    def steer(self, text: str, turn_id: str) -> None:
+        self.calls.append(("steer", turn_id, text))
+
+    def interrupt(self, turn_id: str) -> None:
+        self.calls.append(("interrupt", turn_id, ""))
+
+
+def test_control_socket_round_trip_with_fake_registry(tmp_path):
+    registry = run_control.LiveTurnRegistry()
+    turn = _FakeTurn()
+    registry.register("coder", turn, "turn-1")
+    server = run_control.ControlServer(tmp_path / "control.sock", registry)
+    server.start()
+    try:
+        steer = run_control.send_request(
+            tmp_path / "control.sock",
+            {"op": "steer", "worker": "coder", "text": "please focus on tests"},
+        )
+        interrupt = run_control.send_request(
+            tmp_path / "control.sock",
+            {"op": "interrupt", "worker": "coder"},
+        )
+    finally:
+        server.close()
+
+    assert steer == {"ok": True, "worker": "coder", "thread_id": "thread-1", "turn_id": "turn-1"}
+    assert interrupt == {"ok": True, "interrupted": 1, "workers": ["coder"]}
+    assert turn.calls == [
+        ("steer", "turn-1", "please focus on tests"),
+        ("interrupt", "turn-1", ""),
+    ]
+    assert not (tmp_path / "control.sock").exists()
+
+
+def test_run_turn_reports_turn_start_callback():
+    turns: list[str] = []
+    with codex_appserver.AppServer(argv=FAKE) as server:
+        thread = server.start_thread(cwd=Path("/tmp"))
+        result = thread.run_turn("say hi", timeout=10.0, on_turn_start=turns.append)
+
+    assert result.ok
+    assert turns == ["turn-t-1"]
+
+
+def test_runs_steer_refuses_non_app_server_run(tmp_path, capsys):
+    run_dir = tmp_path / "run"
+    _write_json(run_dir / "run.json", {"status": "started", "codex_transport": "exec"})
+
+    rc = cli.main(["runs", "steer", str(run_dir), "coder", "keep going"])
+
+    assert rc == 2
+    assert "was not started with app-server transport" in capsys.readouterr().err
+
+
+def test_runs_interrupt_refuses_missing_socket(tmp_path, capsys):
+    run_dir = tmp_path / "run"
+    _write_json(
+        run_dir / "run.json",
+        {
+            "status": "started",
+            "codex_transport": "app-server",
+            "control_socket": str(run_dir / "control.sock"),
+        },
+    )
+
+    rc = cli.main(["runs", "interrupt", str(run_dir)])
+
+    assert rc == 2
+    assert "control socket is not active" in capsys.readouterr().err
+
+
+def test_run_records_control_socket_and_cli_steers_live_worker(tmp_path, monkeypatch, capsys):
+    roster = Roster(
+        orchestrator="chef",
+        agents={
+            "chef": Agent("chef", "claude", "plan and synthesize"),
+            "cook": Agent("cook", "codex", "write code"),
+        },
+        timeout_seconds=10.0,
+        codex_transport="app-server",
+    )
+    run_dir = tmp_path / "run"
+    real_app_server = codex_appserver.AppServer
+    monkeypatch.setattr(
+        aboyeur.codex_appserver,
+        "AppServer",
+        lambda cwd=None: real_app_server(argv=FAKE, cwd=cwd),
+    )
+
+    def fake_run_agent(cli_ref, prompt, **kwargs):
+        if "Return exactly one JSON object" in prompt:
+            return agents.AgentResult(
+                text=json.dumps({"assignments": [{"worker": "cook", "task": "HANG until steered"}]}),
+                ok=True,
+            )
+        assert "steered: please finish" in prompt
+        return agents.AgentResult(text="final synthesis", ok=True)
+
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+    result: dict[str, int] = {}
+
+    thread = threading.Thread(
+        target=lambda: result.update(rc=aboyeur.run("do it", roster, cwd=tmp_path, output_dir=run_dir)),
+        daemon=True,
+    )
+    thread.start()
+
+    control_socket = _wait_for(
+        lambda: (
+            Path(json.loads((run_dir / "run.json").read_text()).get("control_socket", ""))
+            if (run_dir / "run.json").is_file() and json.loads((run_dir / "run.json").read_text()).get("control_socket")
+            else None
+        )
+    )
+    _wait_for(lambda: control_socket.exists())
+
+    assert cli.main(["runs", "steer", str(run_dir), "cook", "please finish"]) == 0
+    thread.join(timeout=5.0)
+
+    assert result == {"rc": 0}
+    assert "steer: cook" in capsys.readouterr().out
+    run_meta = json.loads((run_dir / "run.json").read_text())
+    assert run_meta["control_socket"] == str(control_socket)
+    assert not control_socket.exists()
+    worker_results = json.loads((run_dir / "worker-results.json").read_text())["results"]
+    assert worker_results[0]["text"] == "steered: please finish"
+
+
+def test_cli_interrupt_leaves_live_worker_resumable(tmp_path, monkeypatch, capsys):
+    roster = Roster(
+        orchestrator="chef",
+        agents={
+            "chef": Agent("chef", "claude", "plan and synthesize"),
+            "cook": Agent("cook", "codex", "write code"),
+        },
+        timeout_seconds=10.0,
+        codex_transport="app-server",
+    )
+    run_dir = tmp_path / "run"
+    real_app_server = codex_appserver.AppServer
+    monkeypatch.setattr(
+        aboyeur.codex_appserver,
+        "AppServer",
+        lambda cwd=None: real_app_server(argv=FAKE, cwd=cwd),
+    )
+
+    def fake_run_agent(cli_ref, prompt, **kwargs):
+        if "Return exactly one JSON object" in prompt:
+            return agents.AgentResult(
+                text=json.dumps({"assignments": [{"worker": "cook", "task": "HANG until interrupted"}]}),
+                ok=True,
+            )
+        return agents.AgentResult(text="final synthesis", ok=True)
+
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+    result: dict[str, int] = {}
+
+    thread = threading.Thread(
+        target=lambda: result.update(rc=aboyeur.run("do it", roster, cwd=tmp_path, output_dir=run_dir)),
+        daemon=True,
+    )
+    thread.start()
+
+    control_socket = _wait_for(
+        lambda: (
+            Path(json.loads((run_dir / "run.json").read_text()).get("control_socket", ""))
+            if (run_dir / "run.json").is_file() and json.loads((run_dir / "run.json").read_text()).get("control_socket")
+            else None
+        )
+    )
+    _wait_for(lambda: control_socket.exists())
+
+    assert cli.main(["runs", "interrupt", str(run_dir), "cook"]) == 0
+    thread.join(timeout=5.0)
+
+    assert "rc" in result
+    assert "interrupt: 1 (cook)" in capsys.readouterr().out
+    assert not control_socket.exists()
+    worker_results = json.loads((run_dir / "worker-results.json").read_text())["results"]
+    entry = worker_results[0]
+    assert entry["status"] == "interrupted"
+    assert entry["ok"] is False
+    assert isinstance(entry["thread_id"], str) and entry["thread_id"]

--- a/tests/test_run_detach.py
+++ b/tests/test_run_detach.py
@@ -1,0 +1,95 @@
+import json
+from pathlib import Path
+
+from brigade import cli
+from brigade.cli import run as run_cli
+
+
+def _write_roster(target: Path) -> None:
+    config_dir = target / ".brigade"
+    config_dir.mkdir()
+    (config_dir / "roster.toml").write_text(
+        """
+orchestrator = "chef"
+
+[agents.chef]
+cli = "codex"
+role = "plan"
+
+[agents.coder]
+cli = "codex"
+role = "code"
+"""
+    )
+
+
+def test_run_detach_rejects_fixed_incompatibilities(tmp_path, capsys):
+    _write_roster(tmp_path)
+
+    for flag in ("--dry-run", "--no-artifacts", "--inspect"):
+        rc = cli.main(["run", "x", "--cwd", str(tmp_path), "--detach", flag])
+        assert rc == 2
+        assert f"--detach cannot be used with {flag}" in capsys.readouterr().err
+
+
+def test_run_detach_spawns_child_with_output_dir_and_log(tmp_path, monkeypatch, capsys):
+    _write_roster(tmp_path)
+    calls = []
+
+    class FakeProcess:
+        pid = 4321
+
+        def __init__(self, argv, **kwargs):
+            calls.append((argv, kwargs))
+            output_dir = Path(argv[argv.index("--output-dir") + 1])
+            assert output_dir.is_dir()
+            assert "--detach" not in argv
+            assert argv.count("--output-dir") == 1
+            assert kwargs["cwd"] == tmp_path
+            kwargs["stdout"].write("child started\n")
+            kwargs["stdout"].flush()
+            (output_dir / "run.json").write_text(json.dumps({"status": "started"}) + "\n")
+
+        def poll(self):
+            return None
+
+    monkeypatch.setattr(run_cli, "Popen", FakeProcess)
+
+    rc = cli.main(["run", "do work", "--cwd", str(tmp_path), "--detach"])
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert len(calls) == 1
+    run_dirs = list((tmp_path / ".brigade" / "runs").iterdir())
+    assert len(run_dirs) == 1
+    run_dir = run_dirs[0]
+    assert (run_dir / "detached.log").read_text() == "child started\n"
+    assert f"run: {run_dir.name}" in captured.out
+    assert "detached: pid 4321" in captured.err
+    assert f"artifacts: {run_dir}" in captured.err
+    assert f"log: {run_dir / 'detached.log'}" in captured.err
+
+
+def test_run_detach_reports_early_child_exit(tmp_path, monkeypatch, capsys):
+    _write_roster(tmp_path)
+
+    class FakeProcess:
+        pid = 4321
+
+        def __init__(self, argv, **kwargs):
+            kwargs["stdout"].write("boom\n")
+            kwargs["stdout"].flush()
+
+        def poll(self):
+            return 7
+
+    monkeypatch.setattr(run_cli, "Popen", FakeProcess)
+
+    rc = cli.main(["run", "do work", "--cwd", str(tmp_path), "--detach"])
+
+    captured = capsys.readouterr()
+    run_dir = next((tmp_path / ".brigade" / "runs").iterdir())
+    assert rc == 2
+    assert "detached child exited before run metadata was written: exit 7" in captured.err
+    assert f"log: {run_dir / 'detached.log'}" in captured.err
+    assert (run_dir / "detached.log").read_text() == "boom\n"

--- a/tests/test_runs_watch.py
+++ b/tests/test_runs_watch.py
@@ -1,0 +1,155 @@
+import json
+
+from brigade import cli
+from brigade import runs_cmd
+
+
+def _write_json(path, payload):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n")
+
+
+def _write_run(run_dir, *, status="started", transport="app-server", finished=False):
+    payload = {
+        "task": "watch the run",
+        "cwd": "/tmp/example",
+        "orchestrator": "chef",
+        "dry_run": False,
+        "read_only": False,
+        "status": status,
+        "started_at": "2026-07-08T10:00:00Z",
+        "artifacts": str(run_dir),
+        "codex_transport": transport,
+    }
+    if finished:
+        payload["finished_at"] = "2026-07-08T10:00:03Z"
+        payload["duration_seconds"] = 3.0
+    _write_json(run_dir / "run.json", payload)
+
+
+def _finish_run(run_dir, *, status="ok"):
+    _write_run(run_dir, status=status, finished=True)
+    _write_json(
+        run_dir / "worker-results.json",
+        {"results": [{"worker": "coder", "task": "implement", "ok": True, "detail": "", "text": "done"}]},
+    )
+    _write_json(
+        run_dir / "synthesis.json",
+        {"orchestrator": "chef", "result": {"ok": True, "detail": "", "text": "final answer"}},
+    )
+    (run_dir / "final.txt").write_text("final answer\n")
+
+
+def _append_event(run_dir, worker, method, item_type="commandExecution"):
+    events = run_dir / "events"
+    events.mkdir(exist_ok=True)
+    with (events / f"{worker}.jsonl").open("a") as fh:
+        fh.write(
+            json.dumps(
+                {
+                    "method": method,
+                    "params": {
+                        "threadId": "thread-1",
+                        "item": {"id": "item-1", "type": item_type},
+                    },
+                }
+            )
+            + "\n"
+        )
+
+
+def test_watch_terminal_run_prints_final_summary(tmp_path, capsys):
+    run_dir = tmp_path / "run"
+    _finish_run(run_dir)
+
+    assert runs_cmd.watch(run_dir, cwd=tmp_path, interval=0.0) == 0
+
+    out = capsys.readouterr().out
+    assert f"watching: {run_dir}" in out
+    assert "status: ok" in out
+    assert "workers:" in out
+    assert "  [ok] coder" in out
+    assert "final:" in out
+    assert "  final answer" in out
+    assert "summary: ok in 3s" in out
+
+
+def test_watch_tails_events_and_stops_after_mid_run_completion(tmp_path, capsys, monkeypatch):
+    run_dir = tmp_path / "run"
+    _write_run(run_dir)
+    _write_json(run_dir / "plan.json", {"assignments": [{"stage": 1, "worker": "coder", "task": "implement"}]})
+    _append_event(run_dir, "coder", "item/started")
+    slept = {"count": 0}
+
+    def fake_sleep(_seconds):
+        slept["count"] += 1
+        _append_event(run_dir, "coder", "item/completed")
+        _finish_run(run_dir)
+
+    monkeypatch.setattr(runs_cmd.time, "sleep", fake_sleep)
+
+    assert runs_cmd.watch(run_dir, cwd=tmp_path, interval=0.01) == 0
+
+    out = capsys.readouterr().out
+    assert slept["count"] == 1
+    assert "plan:" in out
+    assert "  stage 1 -> coder: implement" in out
+    assert "event: coder item/started commandExecution" in out
+    assert "event: coder item/completed commandExecution" in out
+    assert "summary: ok in 3s" in out
+
+
+def test_watch_json_outputs_ndjson_incrementally(tmp_path, capsys, monkeypatch):
+    run_dir = tmp_path / "run"
+    _write_run(run_dir)
+    _append_event(run_dir, "coder", "item/started")
+
+    def fake_sleep(_seconds):
+        _append_event(run_dir, "coder", "turn/completed", "turn")
+        _finish_run(run_dir)
+
+    monkeypatch.setattr(runs_cmd.time, "sleep", fake_sleep)
+
+    assert runs_cmd.watch(run_dir, cwd=tmp_path, interval=0.01, json_output=True) == 0
+
+    records = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert [record["type"] for record in records] == [
+        "watch",
+        "run",
+        "event",
+        "run",
+        "event",
+        "workers",
+        "synthesis",
+        "final",
+        "summary",
+    ]
+    assert records[2]["worker"] == "coder"
+    assert records[2]["event"]["method"] == "item/started"
+    assert records[-1]["status"] == "ok"
+
+
+def test_watch_exec_transport_without_events_dir_still_finishes(tmp_path, capsys, monkeypatch):
+    run_dir = tmp_path / "run"
+    _write_run(run_dir, transport="exec")
+
+    def fake_sleep(_seconds):
+        _finish_run(run_dir)
+
+    monkeypatch.setattr(runs_cmd.time, "sleep", fake_sleep)
+
+    assert runs_cmd.watch(run_dir, cwd=tmp_path, interval=0.01) == 0
+
+    captured = capsys.readouterr()
+    assert "summary: ok in 3s" in captured.out
+    assert "events directory not found" not in captured.err
+
+
+def test_watch_cli_resolves_run_name_with_runs_dir(tmp_path, capsys):
+    runs_root = tmp_path / "runs"
+    run_dir = runs_root / "run-1"
+    _finish_run(run_dir)
+
+    assert cli.main(["runs", "watch", "run-1", "--cwd", str(tmp_path), "--runs-dir", str(runs_root)]) == 0
+
+    assert f"watching: {run_dir.resolve()}" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Implements #146: the app-server transport already supported mid-turn control, but `brigade run` was blocking-only and `brigade runs` stopped at `list/latest/show/resume`. This adds the four missing surfaces:

- `brigade run --detach` re-execs the run as a `start_new_session` child, so the child owns `.brigade/run.lock` and the existing pid-staleness and second-dispatch refusal semantics are untouched. The parent polls for `run.json`, prints `run: <run-id>` on stdout, and exits 0; child output appends to `<run-dir>/detached.log`.
- `brigade runs watch <run|latest>` is artifact-only: incremental byte-offset tailing of `events/*.jsonl` plus `run.json` terminal-status polling, with `--json` NDJSON output. Exits 0 on completed and failed runs without hanging; exec-transport runs degrade to `run.json` polling.
- `brigade runs steer <run> <worker> <text>` and `brigade runs interrupt <run> [worker]` reach the live app-server child through a newline-JSON unix control socket at `<run-dir>/control.sock`, recorded as `control_socket` in `run.json` at dispatch. A `LiveTurnRegistry` tracks active turn ids via a new `on_turn_start` callback on `CodexThread.run_turn` (`TurnResult` unchanged); interrupted turns flow through the existing interrupted handling so `runs resume` can finish the run.
- Exec-transport runs and finished runs get clear refusals instead of pretending.

## Notes

- `--detach --verbose` is allowed and forwards verbose output into `detached.log` (useful there), while `--dry-run`, `--no-artifacts`, and `--inspect` are rejected.
- Known small race: two `--detach` parents can both validate before either child grabs the lock; the losing child fails lock acquisition and its parent exits 2 with the log tail.
- Docs updated: `command-inventory.md`, `chat-surfaces.md`, `technical-guide.md`.

## Testing

- `./scripts/verify`: ruff check, ruff format, version sync, pytest all green (1470 passed, 1 skipped; 1457 at base).
- New tests: detach flag incompatibilities and parent/child paths with a stubbed Popen; watch terminal/mid-run/NDJSON/exec-transport cases against synthetic run dirs; control-socket round trip; end-to-end live steer AND live interrupt through `aboyeur.run` with the fake app-server, asserting the interrupted worker is recorded resumable.
- Smoke on real artifacts: `runs watch` on a completed run prints the summary and exits 0; `runs interrupt` on an exec-transport run refuses with exit 2.

Closes #146