### PR TITLE
feat(workflow): workflow sequence scanner and runbook proposal

### DIFF
--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -26,6 +26,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade dogfood` (extras): 1 command path(s)
 - `brigade extras`: 3 command path(s)
 - `brigade friction` (extras): 3 command path(s)
+- `brigade workflow` (extras): 3 command path(s)
 - `brigade handoff`: 17 command path(s)
 - `brigade handoff-template`: 1 command path(s)
 - `brigade hermes-fragments` (extras): 1 command path(s)
@@ -143,6 +144,9 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade friction add` (extras)
 - `brigade friction scan` (extras)
 - `brigade friction show` (extras)
+- `brigade workflow propose-runbook` (extras)
+- `brigade workflow scan` (extras)
+- `brigade workflow show` (extras)
 - `brigade handoff archive`
 - `brigade handoff closeout`
 - `brigade handoff doctor`

--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -26,7 +26,6 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade dogfood` (extras): 1 command path(s)
 - `brigade extras`: 3 command path(s)
 - `brigade friction` (extras): 3 command path(s)
-- `brigade workflow` (extras): 3 command path(s)
 - `brigade handoff`: 17 command path(s)
 - `brigade handoff-template`: 1 command path(s)
 - `brigade hermes-fragments` (extras): 1 command path(s)
@@ -59,6 +58,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade tools`: 48 command path(s)
 - `brigade untrusted` (extras): 2 command path(s)
 - `brigade work`: 139 command path(s)
+- `brigade workflow` (extras): 3 command path(s)
 
 ## Commands
 
@@ -144,9 +144,6 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade friction add` (extras)
 - `brigade friction scan` (extras)
 - `brigade friction show` (extras)
-- `brigade workflow propose-runbook` (extras)
-- `brigade workflow scan` (extras)
-- `brigade workflow show` (extras)
 - `brigade handoff archive`
 - `brigade handoff closeout`
 - `brigade handoff doctor`
@@ -610,3 +607,6 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade work verify run`
 - `brigade work verify runs`
 - `brigade work verify show`
+- `brigade workflow propose-runbook` (extras)
+- `brigade workflow scan` (extras)
+- `brigade workflow show` (extras)

--- a/docs/import-schema.md
+++ b/docs/import-schema.md
@@ -13,6 +13,8 @@ brigade work import memory-care
 brigade work import memory-refresh
 brigade work import chat-sweep
 brigade chat sweep import-issues discord-export
+brigade workflow scan --import-candidates
+brigade workflow propose-runbook <candidate-id>
 brigade work inbox
 brigade work inbox doctor
 brigade work inbox archive
@@ -25,7 +27,7 @@ brigade work import promote --run <import-id>
 brigade work import promote --all --source memory-care --kind task
 ```
 
-`validate` checks a JSONL file without writing. `ingest` appends valid records into `.brigade/work/imports/inbox.jsonl`, skipping duplicate pending records with the same source, kind, and normalized text. Scanner producers can also provide stable source item keys and fingerprints so repeated ingestion skips equivalent pending or promoted imports, while dismissed imports stay dismissed unless the source item changes materially. `inbox` groups pending imports for daily review. `inbox doctor` reports queue hygiene issues, and `inbox archive` moves old closed imports to `.brigade/work/imports/archive.jsonl` without touching pending imports. `import provenance` audits producer imports for stable source identity, source fingerprints, safe summaries, evidence references, and scanner run provenance. `plan` previews the task or handoff a reviewed import would create. `promote --run` promotes one task import and immediately runs it through the normal work-session loop. `plan-handoff` and `promote-handoff` preview and write reviewed Memory Handoff drafts for durable non-task imports. `memory-care` reads `memory/cards/decay/refresh-queue.json` and converts queued cards into task imports. `memory-refresh` accepts the same queue plus `candidates` or `refresh_candidates` and writes TDD-ready refresh task imports. `chat-sweep` reads `.brigade/chat-memory-sweeps/latest.json` and converts sweep `issues`; actionable issues become task imports. `brigade chat sweep import-issues <surface-id>` produces that same chat-sweep import shape from configured local chat export fixtures.
+`validate` checks a JSONL file without writing. `ingest` appends valid records into `.brigade/work/imports/inbox.jsonl`, skipping duplicate pending records with the same source, kind, and normalized text. Scanner producers can also provide stable source item keys and fingerprints so repeated ingestion skips equivalent pending or promoted imports, while dismissed imports stay dismissed unless the source item changes materially. `inbox` groups pending imports for daily review. `inbox doctor` reports queue hygiene issues, and `inbox archive` moves old closed imports to `.brigade/work/imports/archive.jsonl` without touching pending imports. `import provenance` audits producer imports for stable source identity, source fingerprints, safe summaries, evidence references, and scanner run provenance. `plan` previews the task or handoff a reviewed import would create. `promote --run` promotes one task import and immediately runs it through the normal work-session loop. `plan-handoff` and `promote-handoff` preview and write reviewed Memory Handoff drafts for durable non-task imports. `memory-care` reads `memory/cards/decay/refresh-queue.json` and converts queued cards into task imports. `memory-refresh` accepts the same queue plus `candidates` or `refresh_candidates` and writes TDD-ready refresh task imports. `chat-sweep` reads `.brigade/chat-memory-sweeps/latest.json` and converts sweep `issues`. Actionable issues become task imports. `brigade chat sweep import-issues <surface-id>` produces that same chat-sweep import shape from configured local chat export fixtures. `workflow scan --import-candidates` mines repeated command sequences from local verify receipts and daily run receipts, then writes reviewed workflow imports. `workflow propose-runbook` writes a workshop `runbook.json` from a chosen sequence candidate using its concrete `example_commands` only. It does not execute the runbook.
 
 ## Record Shape
 
@@ -96,6 +98,44 @@ Roadmap and repo-fleet producers use the same import contract:
 - `source: project-consolidation` records local project decision or readiness gaps from `brigade projects import-issues`. Metadata includes a safe project alias, `issue_type`, `safe_summary`, `source_item_key`, and `source_fingerprint`.
 - `source: learning-loop` records bounded local learning candidates from `brigade learn import-issues`. Metadata includes candidate id, source subsystem, safe summary, `source_item_key`, and `source_fingerprint`.
 - `source: learnings-import` records entries parsed from structured `.learnings/` markdown logs by `brigade learn import-learnings`. `ERR` entries import as `incident`, `LRN` entries as `finding`, and `FEAT` entries as `feature` tasks. Metadata includes `entry_id`, `entry_prefix`, `source_file`, `area`, redacted `safe_summary` and `safe_detail`, `source_item_key`, and `source_fingerprint`.
+- `source: workflow-scan` records repeated command sequences from `brigade workflow scan --import-candidates`. Verify receipts contribute one observation per receipt from the full ordered `commands[].command` list, falling back to `shlex.join(argv)` when `command` is missing. Daily runs contribute one observation per run from the full ordered `commands_invoked` list. The scanner does not create per-command candidates and does not key candidates on failure status. Metadata includes `workflow_id`, `pattern_key`, `suggested_runbook_id`, `sources`, `review_risk`, `source_item_key`, and `source_fingerprint`. `source_item_key` is exactly the candidate id. `source_fingerprint` is the first 16 hex characters of the SHA-256 digest over canonical JSON containing only `id`, `sequence`, and `suggested_runbook_id`.
+
+## Workflow Sequence Scanner Producer
+
+Run:
+
+```bash
+brigade workflow scan --days 30 --min-count 2 --min-steps 1 --import-candidates
+brigade workflow show
+brigade workflow propose-runbook <candidate-id>
+```
+
+`workflow scan` writes `.brigade/workflow/latest.json` and `.brigade/workflow/latest.md` unless `--dry-run` is passed. `--json` prints the same scan payload. `--min-count` defaults to 2 and must be at least 1, so singleton sequences are excluded unless the operator opts in with `--min-count 1`. `--max-files` bounds receipt file reads per source.
+
+Each candidate object has this exact schema:
+
+```json
+{
+  "id": "workflow-<pattern_key>",
+  "pattern_key": "<sha256 first 12 hex over joined normalized sequence templates>",
+  "sequence": ["python3 -m pytest -q", "python3 -m ruff check ."],
+  "example_commands": ["python3 -m pytest -q", "python3 -m ruff check ."],
+  "occurrence_count": 2,
+  "session_count": 2,
+  "sources": ["verify"],
+  "ends_in_verify_pass": true,
+  "first_seen": "2026-06-11T12:00:00+00:00",
+  "last_seen": "2026-06-11T13:00:00+00:00",
+  "suggested_runbook_id": "workflow-<pattern_key>",
+  "evidence": [],
+  "review_risk": "normal",
+  "suggested_next_command": "brigade workflow propose-runbook workflow-<pattern_key>"
+}
+```
+
+`pattern_key` is computed from the normalized sequence templates joined with newline characters. Normalization replaces volatile tokens with fixed placeholders before hashing: run-id shapes become `<run-id>`, UUIDs and bare hex tokens of 12 or more characters become `<hex>`, ISO timestamps and dates become `<date>`, and absolute paths under `/tmp` or the user home become `<path>`. Repo-relative paths are kept as-is. The same workflow observed across runs that differ only by those tokens therefore produces the same `pattern_key`. The candidate `id` and `suggested_runbook_id` are both `workflow-<pattern_key>`. `sequence` holds the templates; `example_commands` holds the concrete commands from the most recent observation. `review_risk` is `high` when any example command matches the advisory destructive deny-list used by runbook policy, otherwise `normal`.
+
+`workflow propose-runbook` resolves an exact candidate id or a unique prefix against `.brigade/workflow/latest.json`. It writes or prints a runbook whose id is `suggested_runbook_id`, whose description names the scan candidate and provenance, whose `approved` field is false, whose `pins` list is empty, whose `allowed_commands` are sorted command names from `example_commands`, and whose steps use concrete runnable commands from `example_commands` with `timeout_seconds` set to 600. The generated payload is validated against `brigade runbook plan` policy before anything is written; when validation fails, the command reports the policy failures, writes nothing, and exits 1.
 
 Repo-fleet imports must use safe labels only. Do not copy full local paths, guidance file contents, private config values, raw logs, scanner output, owner names, exact private repo names, or raw evidence into import text or metadata.
 

--- a/src/brigade/cli/__init__.py
+++ b/src/brigade/cli/__init__.py
@@ -46,6 +46,7 @@ from . import (
     memory as _memory_group,
     work as _work_group,
     friction as _friction_group,
+    workflow as _workflow_group,
     chat as _chat_group,
     context as _context_group,
     projects as _projects_group,
@@ -78,6 +79,7 @@ _EXTRAS_MODULES = {
     "context": _context_group,
     "dogfood": _dogfood_group,
     "friction": _friction_group,
+    "workflow": _workflow_group,
     "hermes-fragments": _hermes_fragments_group,
     "learn": _learn_group,
     "notifications": _notifications_group,
@@ -136,6 +138,7 @@ def _build_parser() -> argparse.ArgumentParser:
     _memory_group.register(sub)
     _work_group.register(sub)
     _register_extras(sub, "friction", extras_enabled)
+    _register_extras(sub, "workflow", extras_enabled)
 
     _register_extras(sub, "chat", extras_enabled)
 

--- a/src/brigade/cli/_common.py
+++ b/src/brigade/cli/_common.py
@@ -16,7 +16,10 @@ COMMAND_GROUPS: list[tuple[str, list[str]]] = [
         "Core memory loop",
         ["init", "handoff", "handoff-template", "ingest", "memory", "doctor", "status", "profiles"],
     ),
-    ("Daily operator loop", ["operator", "daily", "work", "friction", "center", "runbook", "budgets", "notifications"]),
+    (
+        "Daily operator loop",
+        ["operator", "daily", "work", "friction", "workflow", "center", "runbook", "budgets", "notifications"],
+    ),
     ("Stations and tools", ["add", "stations", "skills", "tools", "mcp", "pantry", "roster", "run", "runs", "dogfood"]),
     (
         "Review, security, and research",

--- a/src/brigade/cli/runs.py
+++ b/src/brigade/cli/runs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+from collections.abc import Mapping
 from pathlib import Path
 
 
@@ -136,7 +137,7 @@ def dispatch(args) -> int:
     return 2
 
 
-def _control_request(run: str, *, cwd: Path, runs_dir: Path | None, payload: dict[str, object]) -> int:
+def _control_request(run: str, *, cwd: Path, runs_dir: Path | None, payload: Mapping[str, object]) -> int:
     import sys
 
     from .. import run_control, runs_cmd
@@ -148,7 +149,7 @@ def _control_request(run: str, *, cwd: Path, runs_dir: Path | None, payload: dic
     assert run_dir is not None
     try:
         socket_path = run_control.control_socket_from_run(run_dir)
-        response = run_control.send_request(socket_path, payload)
+        response = run_control.send_request(socket_path, dict(payload))
     except run_control.ControlError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2

--- a/src/brigade/cli/workflow.py
+++ b/src/brigade/cli/workflow.py
@@ -1,0 +1,94 @@
+"""brigade workflow command group."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p_workflow = sub.add_parser("workflow", help="Mine local receipts for repeatable workflow candidates.")
+    workflow_sub = p_workflow.add_subparsers(dest="workflow_command", metavar="<workflow-command>")
+    workflow_sub.required = True
+
+    p_workflow_scan = workflow_sub.add_parser("scan", help="Scan verify and daily receipts for workflow candidates.")
+    p_workflow_scan.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
+    p_workflow_scan.add_argument(
+        "--days",
+        type=int,
+        default=30,
+        help="Only scan receipts from the last N days.",
+    )
+    p_workflow_scan.add_argument(
+        "--min-count",
+        type=int,
+        default=2,
+        help="Minimum observations needed to emit a candidate.",
+    )
+    p_workflow_scan.add_argument(
+        "--min-steps",
+        type=int,
+        default=1,
+        help="Minimum command count in a sequence.",
+    )
+    p_workflow_scan.add_argument(
+        "--max-files",
+        type=int,
+        default=None,
+        help="Maximum receipt files to read from each source.",
+    )
+    p_workflow_scan.add_argument(
+        "--import-candidates",
+        action="store_true",
+        help="Append candidates to the Brigade work import inbox for review.",
+    )
+    p_workflow_scan.add_argument("--dry-run", action="store_true", help="Report without writing artifacts or imports.")
+    p_workflow_scan.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_workflow_scan.set_defaults(func=dispatch)
+
+    p_workflow_show = workflow_sub.add_parser("show", help="Show the latest workflow scan results.")
+    p_workflow_show.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
+    p_workflow_show.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_workflow_show.set_defaults(func=dispatch)
+
+    p_workflow_propose_runbook = workflow_sub.add_parser(
+        "propose-runbook", help="Write a reviewed runbook draft from a workflow candidate."
+    )
+    p_workflow_propose_runbook.add_argument("candidate_id", help="Workflow candidate id or unique prefix.")
+    p_workflow_propose_runbook.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
+    )
+    p_workflow_propose_runbook.add_argument(
+        "--dry-run", action="store_true", help="Preview generated runbook without writing."
+    )
+    p_workflow_propose_runbook.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_workflow_propose_runbook.set_defaults(func=dispatch)
+
+
+def dispatch(args) -> int:
+    from .. import workflow_cmd
+
+    if args.workflow_command == "scan":
+        return workflow_cmd.scan(
+            target=args.target,
+            days=args.days,
+            min_count=args.min_count,
+            min_steps=args.min_steps,
+            max_files=args.max_files,
+            import_candidates=args.import_candidates,
+            dry_run=args.dry_run,
+            json_output=args.json,
+        )
+    if args.workflow_command == "show":
+        return workflow_cmd.show(target=args.target, json_output=args.json)
+    if args.workflow_command == "propose-runbook":
+        return workflow_cmd.propose_runbook(
+            target=args.target,
+            candidate_id=args.candidate_id,
+            dry_run=args.dry_run,
+            json_output=args.json,
+        )
+    parser = getattr(args, "_brigade_parser", None)
+    if parser is not None:
+        parser.error(f"unknown workflow command: {args.workflow_command}")
+    return 2

--- a/src/brigade/extras.py
+++ b/src/brigade/extras.py
@@ -38,6 +38,7 @@ EXTRAS_COMMANDS: tuple[str, ...] = (
     "roadmap",
     "runbook",
     "untrusted",
+    "workflow",
 )
 
 

--- a/src/brigade/workflow_cmd.py
+++ b/src/brigade/workflow_cmd.py
@@ -81,6 +81,10 @@ _TEMPLATE_PATTERNS = (
 )
 
 
+def _as_list(value: object) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
 def _concrete_command(command: object) -> str:
     return " ".join(str(command or "").split())
 
@@ -229,7 +233,7 @@ def _verify_observations(
         if len(concrete) < min_steps:
             continue
         status = str(receipt.get("status") or "")
-        rows = receipt.get("commands") if isinstance(receipt.get("commands"), list) else []
+        rows = _as_list(receipt.get("commands"))
         all_exit_zero = all(int(row.get("exit_code") or 0) == 0 for row in rows if isinstance(row, dict))
         observations.append(
             {
@@ -283,7 +287,7 @@ def _candidate_from_group(pattern_key: str, observations: list[dict[str, Any]]) 
     first = observations[0]
     latest = observations[-1]
     candidate_id = f"workflow-{pattern_key}"
-    sequence = list(first.get("sequence") if isinstance(first.get("sequence"), list) else [])
+    sequence = list(_as_list(first.get("sequence")))
     sources = sorted({str(item.get("source")) for item in observations}, key=_source_sort_key)
     evidence = [
         {
@@ -292,7 +296,7 @@ def _candidate_from_group(pattern_key: str, observations: list[dict[str, Any]]) 
             "run_id": item.get("run_id"),
             "started_at": item.get("started_at"),
             "status": item.get("status"),
-            "command_count": len(item.get("sequence") if isinstance(item.get("sequence"), list) else []),
+            "command_count": len(_as_list(item.get("sequence"))),
         }
         for item in observations[-MAX_EVIDENCE:]
     ]
@@ -338,7 +342,7 @@ def _review_risk(commands: list[str]) -> str:
 def _group_candidates(observations: list[dict[str, Any]], *, min_count: int) -> list[dict[str, Any]]:
     grouped: dict[str, list[dict[str, Any]]] = {}
     for item in observations:
-        sequence = item.get("sequence") if isinstance(item.get("sequence"), list) else []
+        sequence = _as_list(item.get("sequence"))
         grouped.setdefault(_sequence_pattern_key([str(command) for command in sequence]), []).append(item)
     candidates = [_candidate_from_group(key, items) for key, items in grouped.items()]
     candidates = [item for item in candidates if int(item.get("occurrence_count") or 0) >= min_count]
@@ -380,7 +384,7 @@ def scan_payload(
     candidates = _group_candidates(observations, min_count=min_count)
     source_counts: dict[str, int] = {}
     for item in candidates:
-        for source in item.get("sources") if isinstance(item.get("sources"), list) else []:
+        for source in _as_list(item.get("sources")):
             source_counts[str(source)] = source_counts.get(str(source), 0) + 1
     payload = {
         "version": 1,
@@ -433,7 +437,7 @@ def _render_markdown(payload: dict[str, Any]) -> str:
         lines.append("")
     lines.append("## Candidate Workflows")
     lines.append("")
-    candidates = payload.get("candidates") if isinstance(payload.get("candidates"), list) else []
+    candidates = _as_list(payload.get("candidates"))
     if not candidates:
         lines.append("No workflow candidates found.")
     for item in candidates:
@@ -452,7 +456,7 @@ def _render_markdown(payload: dict[str, Any]) -> str:
                 "",
             ]
         )
-        sequence = item.get("sequence") if isinstance(item.get("sequence"), list) else []
+        sequence = _as_list(item.get("sequence"))
         for command in sequence:
             lines.append(f"  - `{command}`")
         lines.append("")
@@ -468,7 +472,7 @@ def _import_candidates(target: Path, candidates: list[dict[str, Any]], *, dry_ru
     records: list[dict[str, Any]] = []
     for item in candidates:
         candidate_id = str(item.get("id") or "workflow-candidate")
-        sequence = item.get("sequence") if isinstance(item.get("sequence"), list) else []
+        sequence = _as_list(item.get("sequence"))
         preview = " && ".join(str(command) for command in sequence[:3])
         records.append(
             {
@@ -524,7 +528,7 @@ def scan(
     skipped = 0
     skipped_dismissed = 0
     if import_candidates:
-        candidates = payload.get("candidates") if isinstance(payload.get("candidates"), list) else []
+        candidates = _as_list(payload.get("candidates"))
         imported, skipped, skipped_dismissed = _import_candidates(target, candidates, dry_run=dry_run)
     payload["output"] = {
         "json": str(json_path),
@@ -637,7 +641,7 @@ def _runbook_payload(candidate: dict[str, Any]) -> tuple[dict[str, Any] | None, 
         if not name:
             return None, f"workflow candidate has an unparsable example command: {candidate_id}"
         allowed_commands.add(name)
-    sources = candidate.get("sources") if isinstance(candidate.get("sources"), list) else []
+    sources = _as_list(candidate.get("sources"))
     provenance = ", ".join(str(source) for source in sources) or "unknown"
     payload: dict[str, Any] = {
         "id": runbook_id,

--- a/src/brigade/workflow_cmd.py
+++ b/src/brigade/workflow_cmd.py
@@ -1,0 +1,735 @@
+"""Workflow sequence scanner over local Brigade receipts."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+import hashlib
+import json
+import re
+import shlex
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from . import work_cmd
+
+MAX_EVIDENCE = 10
+DEFAULT_DAYS = 30
+DEFAULT_MIN_COUNT = 2
+DEFAULT_MIN_STEPS = 1
+
+
+def _workflow_root(target: Path) -> Path:
+    return target / ".brigade" / "workflow"
+
+
+def _default_json_path(target: Path) -> Path:
+    return _workflow_root(target) / "latest.json"
+
+
+def _default_markdown_path(target: Path) -> Path:
+    return _workflow_root(target) / "latest.md"
+
+
+def _workshop_root(target: Path) -> Path:
+    return _workflow_root(target) / "workshop"
+
+
+def _short(value: object, limit: int = 180) -> str:
+    rendered = " ".join(str(value or "").split())
+    if len(rendered) <= limit:
+        return rendered
+    return rendered[: limit - 3].rstrip() + "..."
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    payload = work_cmd._read_json(path)
+    return payload if isinstance(payload, dict) else None
+
+
+def _read_json_counting(path: Path) -> tuple[dict[str, Any] | None, bool]:
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None, True
+    return (payload, False) if isinstance(payload, dict) else (None, True)
+
+
+def _relative(target: Path, path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(target))
+    except ValueError:
+        return str(path)
+
+
+# Volatile tokens are replaced with fixed placeholders so the same workflow
+# observed across runs hashes to the same pattern_key. Order matters: run-id
+# shapes must win over the bare-hex rule, and path collapsing runs last so it
+# swallows any placeholders already substituted inside a path.
+_TEMPLATE_PATTERNS = (
+    (re.compile(r"\b\d{8}-\d{6}-work-verify-[0-9a-f]{6}\b"), "<run-id>"),
+    (re.compile(r"\b\d{8}-\d{6}-[0-9a-f]{6,}\b"), "<run-id>"),
+    (re.compile(r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b"), "<hex>"),
+    (
+        re.compile(r"\b\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?\b"),
+        "<date>",
+    ),
+    (re.compile(r"\b\d{4}-\d{2}-\d{2}\b"), "<date>"),
+    (re.compile(r"\b[0-9a-f]{12,}\b"), "<hex>"),
+    (re.compile(r"(?:/tmp|" + re.escape(str(Path.home())) + r")/\S+"), "<path>"),
+)
+
+
+def _concrete_command(command: object) -> str:
+    return " ".join(str(command or "").split())
+
+
+def _normalize_command(command: object) -> str:
+    text = _concrete_command(command)
+    for pattern, placeholder in _TEMPLATE_PATTERNS:
+        text = pattern.sub(placeholder, text)
+    return text
+
+
+def _path_token(value: object) -> str:
+    token = re.sub(r"[^A-Za-z0-9_.-]+", "-", str(value or "").strip()).strip("._-")
+    return token or "workflow-candidate"
+
+
+def _command_name(command: str) -> str:
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        return ""
+    return Path(parts[0]).name if parts else ""
+
+
+def _sha256_hex(text: str, length: int) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:length]
+
+
+def _candidate_import_fingerprint(item: dict[str, Any]) -> str:
+    stable = {
+        "id": item.get("id"),
+        "sequence": item.get("sequence"),
+        "suggested_runbook_id": item.get("suggested_runbook_id"),
+    }
+    return _sha256_hex(json.dumps(stable, sort_keys=True, separators=(",", ":")), 16)
+
+
+def _parse_started_at(value: object):
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        return work_cmd._parse_iso_datetime(value)
+    except ValueError:
+        return None
+
+
+def _within_days(receipt: dict[str, Any], *, days: int) -> bool:
+    started = _parse_started_at(receipt.get("started_at"))
+    if started is None:
+        return True
+    cutoff = work_cmd._now() - timedelta(days=days)
+    return started >= cutoff
+
+
+def _iter_verify_receipts(
+    target: Path, *, max_files: int | None = None
+) -> tuple[list[tuple[Path, dict[str, Any]]], int]:
+    root = work_cmd._verify_runs_root(target)
+    if not root.is_dir():
+        return [], 0
+    receipts: list[tuple[Path, dict[str, Any]]] = []
+    skipped = 0
+    children = sorted((child for child in root.iterdir() if child.is_dir()), key=lambda path: path.name, reverse=True)
+    if max_files is not None:
+        children = children[:max_files]
+    for child in children:
+        if not child.is_dir():
+            continue
+        path = child / "receipt.json"
+        if not path.is_file():
+            continue
+        payload, bad_json = _read_json_counting(path)
+        if bad_json:
+            skipped += 1
+        if payload is None:
+            continue
+        payload.setdefault("path", str(child))
+        receipts.append((path, payload))
+    receipts.sort(key=lambda item: str(item[1].get("started_at") or item[1].get("run_id") or ""), reverse=True)
+    return receipts, skipped
+
+
+def _iter_daily_runs(target: Path, *, max_files: int | None = None) -> tuple[list[tuple[Path, dict[str, Any]]], int]:
+    root = target / ".brigade" / "daily" / "runs"
+    if not root.is_dir():
+        return [], 0
+    receipts: list[tuple[Path, dict[str, Any]]] = []
+    skipped = 0
+    children = sorted((child for child in root.iterdir() if child.is_dir()), key=lambda path: path.name, reverse=True)
+    if max_files is not None:
+        children = children[:max_files]
+    for child in children:
+        if not child.is_dir():
+            continue
+        path = child / "run.json"
+        if not path.is_file():
+            continue
+        payload, bad_json = _read_json_counting(path)
+        if bad_json:
+            skipped += 1
+        if payload is None:
+            continue
+        payload.setdefault("path", str(child))
+        receipts.append((path, payload))
+    receipts.sort(key=lambda item: str(item[1].get("started_at") or item[1].get("run_id") or ""), reverse=True)
+    return receipts, skipped
+
+
+def _command_from_row(row: object) -> str:
+    if isinstance(row, dict):
+        command = row.get("command")
+        if isinstance(command, str) and command.strip():
+            return _concrete_command(command)
+        argv = row.get("argv")
+        if isinstance(argv, list) and all(isinstance(item, str) for item in argv):
+            return _concrete_command(shlex.join(argv))
+        return ""
+    return _concrete_command(row)
+
+
+def _commands_from_rows(rows: object) -> list[str]:
+    if not isinstance(rows, list):
+        return []
+    commands: list[str] = []
+    for row in rows:
+        command = _command_from_row(row)
+        if command:
+            commands.append(command)
+    return commands
+
+
+def _sequence_pattern_key(sequence: list[str]) -> str:
+    return _sha256_hex("\n".join(sequence), 12)
+
+
+def _verify_observations(
+    target: Path, *, days: int, min_steps: int, max_files: int | None
+) -> tuple[list[dict[str, Any]], int, int]:
+    observations: list[dict[str, Any]] = []
+    receipts, skipped = _iter_verify_receipts(target, max_files=max_files)
+    for path, receipt in receipts:
+        if not _within_days(receipt, days=days):
+            continue
+        run_id = str(receipt.get("run_id") or path.parent.name)
+        concrete = _commands_from_rows(receipt.get("commands"))
+        if len(concrete) < min_steps:
+            continue
+        status = str(receipt.get("status") or "")
+        rows = receipt.get("commands") if isinstance(receipt.get("commands"), list) else []
+        all_exit_zero = all(
+            int(row.get("exit_code") or 0) == 0 for row in rows if isinstance(row, dict)
+        )
+        observations.append(
+            {
+                "source": "verify",
+                "run_id": run_id,
+                "started_at": receipt.get("started_at"),
+                "path": _relative(target, path),
+                "sequence": [_normalize_command(command) for command in concrete],
+                "example_commands": concrete,
+                "ends_in_verify_pass": status == "completed" and all_exit_zero,
+                "status": status,
+            }
+        )
+    return observations, len(receipts), skipped
+
+
+def _daily_observations(
+    target: Path, *, days: int, min_steps: int, max_files: int | None
+) -> tuple[list[dict[str, Any]], int, int]:
+    observations: list[dict[str, Any]] = []
+    receipts, skipped = _iter_daily_runs(target, max_files=max_files)
+    for path, receipt in receipts:
+        if not _within_days(receipt, days=days):
+            continue
+        concrete = _commands_from_rows(receipt.get("commands_invoked"))
+        if len(concrete) < min_steps:
+            continue
+        status = str(receipt.get("status") or "")
+        observations.append(
+            {
+                "source": "daily",
+                "run_id": str(receipt.get("run_id") or path.parent.name),
+                "started_at": receipt.get("started_at"),
+                "path": _relative(target, path),
+                "sequence": [_normalize_command(command) for command in concrete],
+                "example_commands": concrete,
+                "ends_in_verify_pass": False,
+                "status": status,
+            }
+        )
+    return observations, len(receipts), skipped
+
+
+def _source_sort_key(source: str) -> tuple[int, str]:
+    order = {"verify": 0, "daily": 1}
+    return order.get(source, 99), source
+
+
+def _candidate_from_group(pattern_key: str, observations: list[dict[str, Any]]) -> dict[str, Any]:
+    observations.sort(key=lambda item: str(item.get("started_at") or ""))
+    first = observations[0]
+    latest = observations[-1]
+    candidate_id = f"workflow-{pattern_key}"
+    sequence = list(first.get("sequence") if isinstance(first.get("sequence"), list) else [])
+    sources = sorted({str(item.get("source")) for item in observations}, key=_source_sort_key)
+    evidence = [
+        {
+            "source": item.get("source"),
+            "path": item.get("path"),
+            "run_id": item.get("run_id"),
+            "started_at": item.get("started_at"),
+            "status": item.get("status"),
+            "command_count": len(item.get("sequence") if isinstance(item.get("sequence"), list) else []),
+        }
+        for item in observations[-MAX_EVIDENCE:]
+    ]
+    example_commands = _example_commands_from_observations(observations)
+    ends_in_verify_pass = any(bool(item.get("ends_in_verify_pass")) for item in observations)
+    return {
+        "id": candidate_id,
+        "pattern_key": pattern_key,
+        "sequence": sequence,
+        "example_commands": example_commands,
+        "occurrence_count": len(observations),
+        "session_count": len({f"{item.get('source')}:{item.get('run_id')}" for item in observations}),
+        "sources": sources,
+        "ends_in_verify_pass": ends_in_verify_pass,
+        "first_seen": first.get("started_at"),
+        "last_seen": latest.get("started_at"),
+        "suggested_runbook_id": candidate_id,
+        "evidence": evidence,
+        "review_risk": _review_risk(example_commands),
+        "suggested_next_command": f"brigade workflow propose-runbook {candidate_id}",
+    }
+
+
+def _example_commands_from_observations(observations: list[dict[str, Any]]) -> list[str]:
+    # Concrete commands from the most recent observation, never templates:
+    # propose-runbook turns these into runnable steps.
+    for item in reversed(observations):
+        values = item.get("example_commands")
+        if isinstance(values, list) and values:
+            return [str(value) for value in values]
+    return []
+
+
+def _review_risk(commands: list[str]) -> str:
+    from . import runbook_cmd
+
+    for command in commands:
+        if any(pattern.search(command) for pattern in runbook_cmd.DANGEROUS_PATTERNS):
+            return "high"
+    return "normal"
+
+
+def _group_candidates(observations: list[dict[str, Any]], *, min_count: int) -> list[dict[str, Any]]:
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for item in observations:
+        sequence = item.get("sequence") if isinstance(item.get("sequence"), list) else []
+        grouped.setdefault(_sequence_pattern_key([str(command) for command in sequence]), []).append(item)
+    candidates = [_candidate_from_group(key, items) for key, items in grouped.items()]
+    candidates = [item for item in candidates if int(item.get("occurrence_count") or 0) >= min_count]
+    candidates.sort(key=lambda item: (-int(item.get("occurrence_count") or 0), str(item.get("id") or "")))
+    return candidates
+
+
+def scan_payload(
+    *,
+    target: Path,
+    days: int = DEFAULT_DAYS,
+    min_count: int = DEFAULT_MIN_COUNT,
+    min_steps: int = DEFAULT_MIN_STEPS,
+    max_files: int | None = None,
+) -> tuple[dict[str, Any] | None, int]:
+    target = target.expanduser().resolve()
+    if not target.is_dir():
+        print(f"error: --target is not a directory: {target}", file=sys.stderr)
+        return None, 2
+    if days < 1:
+        print("error: --days must be a positive integer", file=sys.stderr)
+        return None, 2
+    if min_count < 1:
+        print("error: --min-count must be at least 1", file=sys.stderr)
+        return None, 2
+    if min_steps < 1:
+        print("error: --min-steps must be at least 1", file=sys.stderr)
+        return None, 2
+    if max_files is not None and max_files < 1:
+        print("error: --max-files must be a positive integer", file=sys.stderr)
+        return None, 2
+    verify_observations, verify_count, skipped_verify = _verify_observations(
+        target, days=days, min_steps=min_steps, max_files=max_files
+    )
+    daily_observations, daily_count, skipped_daily = _daily_observations(
+        target, days=days, min_steps=min_steps, max_files=max_files
+    )
+    observations = [*verify_observations, *daily_observations]
+    candidates = _group_candidates(observations, min_count=min_count)
+    source_counts: dict[str, int] = {}
+    for item in candidates:
+        for source in item.get("sources") if isinstance(item.get("sources"), list) else []:
+            source_counts[str(source)] = source_counts.get(str(source), 0) + 1
+    payload = {
+        "version": 1,
+        "generated_at": work_cmd._now().isoformat(),
+        "target": str(target),
+        "days": days,
+        "min_count": min_count,
+        "min_steps": min_steps,
+        "max_files": max_files,
+        "receipt_counts": {
+            "verify": verify_count,
+            "daily": daily_count,
+        },
+        "skipped_bad_json_count": skipped_verify + skipped_daily,
+        "observation_count": len(observations),
+        "candidate_count": len(candidates),
+        "counts": {
+            "by_source": dict(sorted(source_counts.items())),
+        },
+        "candidates": candidates,
+    }
+    return payload, 0
+
+
+def _write_payload(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n")
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Brigade Workflow Scan",
+        "",
+        f"- Generated: {payload.get('generated_at')}",
+        f"- Target: `{payload.get('target')}`",
+        f"- Candidates: {payload.get('candidate_count')}",
+        f"- Observations: {payload.get('observation_count')}",
+        "",
+        "## Counts",
+        "",
+    ]
+    counts = payload.get("counts") if isinstance(payload.get("counts"), dict) else {}
+    for label, key in (("Source", "by_source"),):
+        lines.append(f"### {label}")
+        values = counts.get(key) if isinstance(counts, dict) else {}
+        if isinstance(values, dict) and values:
+            lines.extend(f"- {name}: {count}" for name, count in values.items())
+        else:
+            lines.append("- none")
+        lines.append("")
+    lines.append("## Candidate Workflows")
+    lines.append("")
+    candidates = payload.get("candidates") if isinstance(payload.get("candidates"), list) else []
+    if not candidates:
+        lines.append("No workflow candidates found.")
+    for item in candidates:
+        if not isinstance(item, dict):
+            continue
+        lines.extend(
+            [
+                f"### {item.get('id')}",
+                "",
+                f"- Pattern: {item.get('pattern_key')}",
+                f"- Sources: {', '.join(str(source) for source in item.get('sources', []))}",
+                f"- Occurrences: {item.get('occurrence_count')}",
+                f"- Sessions: {item.get('session_count')}",
+                f"- Ends in verify pass: {item.get('ends_in_verify_pass')}",
+                f"- Suggested runbook: {item.get('suggested_runbook_id')}",
+                "",
+            ]
+        )
+        sequence = item.get("sequence") if isinstance(item.get("sequence"), list) else []
+        for command in sequence:
+            lines.append(f"  - `{command}`")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _write_markdown(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_render_markdown(payload))
+
+
+def _import_candidates(target: Path, candidates: list[dict[str, Any]], *, dry_run: bool) -> tuple[int, int, int]:
+    records: list[dict[str, Any]] = []
+    for item in candidates:
+        candidate_id = str(item.get("id") or "workflow-candidate")
+        sequence = item.get("sequence") if isinstance(item.get("sequence"), list) else []
+        preview = " && ".join(str(command) for command in sequence[:3])
+        records.append(
+            {
+                "kind": "task",
+                "source": "workflow-scan",
+                "text": f"Review workflow sequence candidate {candidate_id}: {_short(preview or candidate_id)}",
+                "type": "workflow",
+                "priority": "normal",
+                "template": "red-green-refactor",
+                "acceptance": [
+                    "Review the grouped local receipts and decide whether the sequence should become a runbook.",
+                    "Use `brigade workflow propose-runbook` only after reviewing the concrete example commands.",
+                    "No runbook is generated automatically.",
+                ],
+                "metadata": {
+                    "source_item_key": candidate_id,
+                    "source_fingerprint": _candidate_import_fingerprint(item),
+                    "workflow_id": candidate_id,
+                    "pattern_key": item.get("pattern_key"),
+                    "suggested_runbook_id": item.get("suggested_runbook_id"),
+                    "sources": item.get("sources"),
+                    "review_risk": item.get("review_risk"),
+                },
+            }
+        )
+    imported, skipped, skipped_dismissed = work_cmd._append_import_records(target, records, dry_run=dry_run)
+    return len(imported), len(skipped), len(skipped_dismissed)
+
+
+def scan(
+    *,
+    target: Path,
+    days: int = DEFAULT_DAYS,
+    min_count: int = DEFAULT_MIN_COUNT,
+    min_steps: int = DEFAULT_MIN_STEPS,
+    max_files: int | None = None,
+    import_candidates: bool = False,
+    dry_run: bool = False,
+    json_output: bool = False,
+) -> int:
+    payload, code = scan_payload(
+        target=target, days=days, min_count=min_count, min_steps=min_steps, max_files=max_files
+    )
+    if payload is None:
+        return code
+    target = target.expanduser().resolve()
+    json_path = _default_json_path(target)
+    markdown_path = _default_markdown_path(target)
+    if not dry_run:
+        _write_payload(json_path, payload)
+        _write_markdown(markdown_path, payload)
+    imported = 0
+    skipped = 0
+    skipped_dismissed = 0
+    if import_candidates:
+        candidates = payload.get("candidates") if isinstance(payload.get("candidates"), list) else []
+        imported, skipped, skipped_dismissed = _import_candidates(target, candidates, dry_run=dry_run)
+    payload["output"] = {
+        "json": str(json_path),
+        "markdown": str(markdown_path),
+        "imports_added": imported,
+        "imports_skipped": skipped,
+        "imports_skipped_dismissed": skipped_dismissed,
+        "dry_run": dry_run,
+    }
+    if json_output:
+        print(json.dumps(payload, indent=2))
+        return 0
+    print("workflow scan:")
+    print(f"  target: {payload['target']}")
+    print(f"  candidates: {payload['candidate_count']}")
+    print(f"  observations: {payload['observation_count']}")
+    print(f"  skipped_bad_json: {payload['skipped_bad_json_count']}")
+    print(f"  json: {json_path if not dry_run else '(dry-run) ' + str(json_path)}")
+    print(f"  markdown: {markdown_path if not dry_run else '(dry-run) ' + str(markdown_path)}")
+    if import_candidates:
+        print(f"  imports_added: {imported}")
+        print(f"  imports_skipped: {skipped}")
+        print(f"  imports_skipped_dismissed: {skipped_dismissed}")
+    counts = payload.get("counts", {})
+    by_source = counts.get("by_source") if isinstance(counts, dict) else {}
+    if by_source:
+        print("  by_source:")
+        for name, count in sorted(by_source.items()):
+            print(f"    {name}: {count}")
+    return 0
+
+
+def show(*, target: Path, json_output: bool = False) -> int:
+    target = target.expanduser().resolve()
+    path = _default_json_path(target)
+    data = _read_json(path)
+    if data is None:
+        print(f"error: no workflow scan found at {path}; run `brigade workflow scan` first", file=sys.stderr)
+        return 2
+    candidates_value = data.get("candidates")
+    candidates = candidates_value if isinstance(candidates_value, list) else []
+    payload = {
+        "source": str(path),
+        "generated_at": data.get("generated_at"),
+        "candidate_count": len(candidates),
+        "candidates": candidates,
+    }
+    if json_output:
+        print(json.dumps(payload, indent=2))
+        return 0
+    print(f"workflow show: {path}")
+    print(f"candidates: {len(candidates)}")
+    for item in candidates:
+        if isinstance(item, dict):
+            print(
+                f"- [{item.get('review_risk', '?')}] {item.get('id', '?')} "
+                f"x{item.get('occurrence_count', 0)}: {item.get('suggested_next_command', '')}"
+            )
+    return 0
+
+
+def _latest_candidates(target: Path) -> tuple[list[dict[str, Any]] | None, str | None]:
+    path = _default_json_path(target)
+    data = _read_json(path)
+    if data is None:
+        return None, f"no workflow scan found at {path}; run `brigade workflow scan` first"
+    candidates_value = data.get("candidates")
+    if not isinstance(candidates_value, list):
+        return None, f"workflow scan has invalid candidates at {path}"
+    return [item for item in candidates_value if isinstance(item, dict)], None
+
+
+def _resolve_workflow_candidate(target: Path, candidate_id: str) -> tuple[dict[str, Any] | None, str | None]:
+    candidates, error = _latest_candidates(target)
+    if candidates is None:
+        return None, error
+    needle = candidate_id.strip()
+    matches = [
+        item
+        for item in candidates
+        if needle and (str(item.get("id") or "") == needle or str(item.get("id") or "").startswith(needle))
+    ]
+    if not matches:
+        return None, f"workflow candidate not found: {candidate_id}"
+    if len(matches) > 1:
+        return None, f"workflow candidate id is ambiguous: {candidate_id}"
+    return matches[0], None
+
+
+def _runbook_commands(candidate: dict[str, Any]) -> list[str]:
+    values = candidate.get("example_commands")
+    commands: list[str] = []
+    if isinstance(values, list):
+        for value in values:
+            command = " ".join(str(value or "").split())
+            if command and command not in commands:
+                commands.append(command)
+    return commands
+
+
+def _runbook_payload(candidate: dict[str, Any]) -> tuple[dict[str, Any] | None, str | None]:
+    commands = _runbook_commands(candidate)
+    candidate_id = str(candidate.get("id") or "workflow-candidate")
+    runbook_id = str(candidate.get("suggested_runbook_id") or candidate_id).strip() or candidate_id
+    if not commands:
+        return None, f"workflow candidate has no example_commands: {candidate_id}"
+    allowed_commands: set[str] = set()
+    for command in commands:
+        name = _command_name(command)
+        if not name:
+            return None, f"workflow candidate has an unparsable example command: {candidate_id}"
+        allowed_commands.add(name)
+    sources = candidate.get("sources") if isinstance(candidate.get("sources"), list) else []
+    provenance = ", ".join(str(source) for source in sources) or "unknown"
+    payload: dict[str, Any] = {
+        "id": runbook_id,
+        "description": f"Runbook proposed from workflow scan candidate {candidate_id}, sources: {provenance}.",
+        "approved": False,
+        "allowed_commands": sorted(allowed_commands),
+        "pins": [],
+        "steps": [
+            {"id": f"step-{index}", "run": command, "timeout_seconds": 600}
+            for index, command in enumerate(commands, start=1)
+        ],
+    }
+    return payload, None
+
+
+def _planned_runbook_path(target: Path, candidate: dict[str, Any]) -> Path:
+    return (
+        _workshop_root(target)
+        / _path_token(candidate.get("suggested_runbook_id") or candidate.get("id"))
+        / "runbook.json"
+    )
+
+
+def _plan_generated_runbook(
+    target: Path, runbook_payload: dict[str, Any]
+) -> tuple[dict[str, Any] | None, str | None]:
+    # Always validate the freshly generated payload via a temp file, never a
+    # stale runbook.json already on disk at the destination path.
+    from . import runbook_cmd
+
+    with tempfile.TemporaryDirectory(prefix="brigade-workflow-runbook-") as raw_tmp:
+        temp_path = Path(raw_tmp) / "runbook.json"
+        temp_path.write_text(json.dumps(runbook_payload, indent=2) + "\n")
+        return runbook_cmd._plan_payload(target, temp_path)
+
+
+def propose_runbook(*, target: Path, candidate_id: str, dry_run: bool = False, json_output: bool = False) -> int:
+    target = target.expanduser().resolve()
+    if not target.is_dir():
+        print(f"error: --target is not a directory: {target}", file=sys.stderr)
+        return 2
+    candidate, error = _resolve_workflow_candidate(target, candidate_id)
+    if candidate is None:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+    runbook_payload, runbook_error = _runbook_payload(candidate)
+    if runbook_payload is None:
+        print(f"error: {runbook_error}", file=sys.stderr)
+        return 2
+    runbook_path = _planned_runbook_path(target, candidate)
+    plan_payload, plan_error = _plan_generated_runbook(target, runbook_payload)
+    if plan_payload is None:
+        print(f"error: {plan_error}", file=sys.stderr)
+        return 2
+    plan_payload["runbook_path"] = str(runbook_path)
+    if not plan_payload.get("policy_valid"):
+        failures = [
+            f"{item.get('step')}: {'; '.join(item.get('failures') or [])}"
+            for item in plan_payload.get("policy_failures") or []
+        ]
+        detail = "; ".join(failures) or "runbook plan policy validation failed"
+        print(f"error: generated runbook fails runbook plan policy validation: {detail}", file=sys.stderr)
+        return 1
+    if not dry_run:
+        _write_payload(runbook_path, runbook_payload)
+    payload = {
+        "target": str(target),
+        "candidate": candidate,
+        "dry_run": dry_run,
+        "runbook_path": str(runbook_path),
+        "runbook": runbook_payload,
+        "plan": plan_payload,
+        "manual_only": True,
+        "auto_execute": False,
+        "would_write": [] if not dry_run else [str(runbook_path)],
+        "next_commands": [
+            f"brigade runbook plan {runbook_path} --target {target}",
+            f"brigade runbook run {runbook_path} --target {target} --approved --dry-run",
+        ],
+    }
+    if json_output:
+        print(json.dumps(payload, indent=2))
+        return 0
+    label = "workflow propose-runbook dry-run" if dry_run else "workflow propose-runbook"
+    print(f"{label}: {candidate.get('id')}")
+    print(f"runbook: {runbook_path}")
+    print(f"policy_valid: {plan_payload['policy_valid']}")
+    if dry_run:
+        print("status: no files written")
+    else:
+        print("status: pending review")
+    print(f"next: brigade runbook plan {runbook_path} --target {target}")
+    return 0

--- a/src/brigade/workflow_cmd.py
+++ b/src/brigade/workflow_cmd.py
@@ -230,9 +230,7 @@ def _verify_observations(
             continue
         status = str(receipt.get("status") or "")
         rows = receipt.get("commands") if isinstance(receipt.get("commands"), list) else []
-        all_exit_zero = all(
-            int(row.get("exit_code") or 0) == 0 for row in rows if isinstance(row, dict)
-        )
+        all_exit_zero = all(int(row.get("exit_code") or 0) == 0 for row in rows if isinstance(row, dict))
         observations.append(
             {
                 "source": "verify",
@@ -663,9 +661,7 @@ def _planned_runbook_path(target: Path, candidate: dict[str, Any]) -> Path:
     )
 
 
-def _plan_generated_runbook(
-    target: Path, runbook_payload: dict[str, Any]
-) -> tuple[dict[str, Any] | None, str | None]:
+def _plan_generated_runbook(target: Path, runbook_payload: dict[str, Any]) -> tuple[dict[str, Any] | None, str | None]:
     # Always validate the freshly generated payload via a temp file, never a
     # stale runbook.json already on disk at the destination path.
     from . import runbook_cmd

--- a/tests/test_workflow_cmd.py
+++ b/tests/test_workflow_cmd.py
@@ -1,0 +1,459 @@
+import hashlib
+import json
+
+from brigade import cli
+
+
+def _write_json(path, payload):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def _write_bad_json(path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not json\n")
+
+
+def _write_verify_receipt(target, run_id, *, started_at, commands, status="completed"):
+    command_rows = []
+    for index, command in enumerate(commands, start=1):
+        if isinstance(command, dict):
+            row = dict(command)
+            rendered = row.get("command")
+        else:
+            rendered = command
+            row = {"command": command}
+        row.setdefault("status", "completed")
+        row.setdefault("exit_code", 0)
+        row.setdefault("started_at", started_at)
+        row.setdefault("completed_at", started_at)
+        row.setdefault("stdout_log_path", str(target / f"command-{index}-out.log"))
+        row.setdefault("stderr_log_path", str(target / f"command-{index}-err.log"))
+        if rendered is None and isinstance(row.get("argv"), list):
+            row["command"] = None
+        command_rows.append(row)
+    _write_json(
+        target / ".brigade" / "work" / "verify-runs" / run_id / "receipt.json",
+        {
+            "run_id": run_id,
+            "target": str(target),
+            "status": status,
+            "started_at": started_at,
+            "completed_at": started_at,
+            "path": str(target / ".brigade" / "work" / "verify-runs" / run_id),
+            "commands": command_rows,
+        },
+    )
+
+
+def _write_daily_run(target, run_id, *, started_at, commands_invoked, status="completed"):
+    _write_json(
+        target / ".brigade" / "daily" / "runs" / run_id / "run.json",
+        {
+            "run_id": run_id,
+            "target": str(target),
+            "status": status,
+            "started_at": started_at,
+            "completed_at": started_at,
+            "commands_invoked": commands_invoked,
+            "path": str(target / ".brigade" / "daily" / "runs" / run_id),
+        },
+    )
+
+
+def _write_workflow_latest(target, candidates):
+    _write_json(
+        target / ".brigade" / "workflow" / "latest.json",
+        {
+            "version": 1,
+            "generated_at": "2026-06-11T12:00:00+00:00",
+            "target": str(target),
+            "candidate_count": len(candidates),
+            "candidates": candidates,
+        },
+    )
+
+
+def _pattern_key(sequence):
+    return hashlib.sha256("\n".join(sequence).encode("utf-8")).hexdigest()[:12]
+
+
+def test_workflow_scan_normalizes_two_verify_receipts_into_one_sequence(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("BRIGADE_EXTRAS", "1")
+    commands_one = ["python -m pytest tests/test_alpha.py -q", "ruff check src tests"]
+    commands_two = [
+        {"command": "python   -m   pytest   tests/test_alpha.py   -q", "argv": ["ignored"]},
+        {"command": None, "argv": ["ruff", "check", "src", "tests"]},
+    ]
+    _write_verify_receipt(tmp_path, "verify-one", started_at="2026-06-11T12:00:00+00:00", commands=commands_one)
+    _write_verify_receipt(tmp_path, "verify-two", started_at="2026-06-11T13:00:00+00:00", commands=commands_two)
+
+    assert cli.main(["workflow", "scan", "--target", str(tmp_path), "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["candidate_count"] == 1
+    assert payload["observation_count"] == 2
+    assert payload["skipped_bad_json_count"] == 0
+    candidate = payload["candidates"][0]
+    expected_sequence = ["python -m pytest tests/test_alpha.py -q", "ruff check src tests"]
+    expected_key = _pattern_key(expected_sequence)
+    assert list(candidate) == [
+        "id",
+        "pattern_key",
+        "sequence",
+        "example_commands",
+        "occurrence_count",
+        "session_count",
+        "sources",
+        "ends_in_verify_pass",
+        "first_seen",
+        "last_seen",
+        "suggested_runbook_id",
+        "evidence",
+        "review_risk",
+        "suggested_next_command",
+    ]
+    assert candidate["pattern_key"] == expected_key
+    assert candidate["id"] == f"workflow-{expected_key}"
+    assert candidate["suggested_runbook_id"] == f"workflow-{expected_key}"
+    assert candidate["sequence"] == expected_sequence
+    assert candidate["example_commands"] == expected_sequence
+    assert candidate["occurrence_count"] == 2
+    assert candidate["session_count"] == 2
+    assert candidate["sources"] == ["verify"]
+    assert candidate["ends_in_verify_pass"] is True
+    assert [item["run_id"] for item in candidate["evidence"]] == ["verify-one", "verify-two"]
+
+
+def test_workflow_scan_default_min_count_excludes_singletons_and_min_count_one_includes(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("BRIGADE_EXTRAS", "1")
+    _write_verify_receipt(
+        tmp_path,
+        "verify-one",
+        started_at="2026-06-11T12:00:00+00:00",
+        commands=["python -m pytest tests/test_alpha.py -q"],
+    )
+
+    assert cli.main(["workflow", "scan", "--target", str(tmp_path), "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["candidate_count"] == 0
+    assert payload["observation_count"] == 1
+
+    assert cli.main(["workflow", "scan", "--target", str(tmp_path), "--min-count", "1", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["candidate_count"] == 1
+    assert payload["candidates"][0]["occurrence_count"] == 1
+
+
+def test_workflow_scan_mines_one_daily_observation_from_full_commands_invoked(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("BRIGADE_EXTRAS", "1")
+    commands = [
+        {"command": "brigade context build", "exit_code": 0},
+        {"command": "brigade center report build", "exit_code": 1},
+    ]
+    _write_daily_run(tmp_path, "daily-one", started_at="2026-06-11T12:00:00+00:00", commands_invoked=commands)
+    _write_daily_run(tmp_path, "daily-two", started_at="2026-06-11T13:00:00+00:00", commands_invoked=commands)
+
+    assert cli.main(["workflow", "scan", "--target", str(tmp_path), "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["observation_count"] == 2
+    assert payload["candidate_count"] == 1
+    candidate = payload["candidates"][0]
+    assert candidate["sources"] == ["daily"]
+    assert candidate["sequence"] == ["brigade context build", "brigade center report build"]
+    assert candidate["ends_in_verify_pass"] is False
+    assert candidate["evidence"][0]["command_count"] == 2
+
+
+def test_workflow_import_dedupe_stays_stable_after_count_drift(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("BRIGADE_EXTRAS", "1")
+    command = "python -m pytest tests/test_alpha.py -q"
+    _write_verify_receipt(tmp_path, "verify-one", started_at="2026-06-11T12:00:00+00:00", commands=[command])
+
+    assert cli.main(["workflow", "scan", "--target", str(tmp_path), "--min-count", "1", "--import-candidates"]) == 0
+    capsys.readouterr()
+    imports_path = tmp_path / ".brigade" / "work" / "imports" / "inbox.jsonl"
+    first = json.loads(imports_path.read_text().splitlines()[0])
+    first_metadata = first["metadata"]
+    first_fingerprint = first_metadata["source_fingerprint"]
+
+    _write_verify_receipt(tmp_path, "verify-two", started_at="2026-06-12T12:00:00+00:00", commands=[command])
+    assert cli.main(["workflow", "scan", "--target", str(tmp_path), "--import-candidates"]) == 0
+    out = capsys.readouterr().out
+
+    assert "imports_added: 0" in out
+    assert "imports_skipped: 1" in out
+    imports = [json.loads(line) for line in imports_path.read_text().splitlines()]
+    assert len(imports) == 1
+    latest = json.loads((tmp_path / ".brigade" / "workflow" / "latest.json").read_text())
+    candidate = latest["candidates"][0]
+    assert first_metadata["source_item_key"] == candidate["id"]
+    assert first_metadata["source_fingerprint"] == first_fingerprint
+    assert (
+        first_metadata["source_fingerprint"]
+        == hashlib.sha256(
+            json.dumps(
+                {
+                    "id": candidate["id"],
+                    "sequence": candidate["sequence"],
+                    "suggested_runbook_id": candidate["suggested_runbook_id"],
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).hexdigest()[:16]
+    )
+    assert candidate["occurrence_count"] == 2
+
+
+def test_workflow_scan_dry_run_writes_nothing_with_parseable_json(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("BRIGADE_EXTRAS", "1")
+    _write_verify_receipt(
+        tmp_path,
+        "verify-one",
+        started_at="2026-06-11T12:00:00+00:00",
+        commands=["python -m pytest tests/test_alpha.py -q"],
+    )
+
+    assert cli.main(["workflow", "scan", "--target", str(tmp_path), "--min-count", "1", "--dry-run", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["candidate_count"] == 1
+    assert payload["output"]["dry_run"] is True
+    assert not (tmp_path / ".brigade" / "workflow" / "latest.json").exists()
+    assert not (tmp_path / ".brigade" / "workflow" / "latest.md").exists()
+    assert not (tmp_path / ".brigade" / "work" / "imports" / "inbox.jsonl").exists()
+
+
+def test_workflow_scan_reports_skipped_bad_json_count(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("BRIGADE_EXTRAS", "1")
+    _write_bad_json(tmp_path / ".brigade" / "work" / "verify-runs" / "bad" / "receipt.json")
+    _write_verify_receipt(
+        tmp_path,
+        "verify-one",
+        started_at="2026-06-11T12:00:00+00:00",
+        commands=["python -m pytest tests/test_alpha.py -q"],
+    )
+
+    assert cli.main(["workflow", "scan", "--target", str(tmp_path), "--min-count", "1", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["receipt_counts"] == {"daily": 0, "verify": 1}
+    assert payload["skipped_bad_json_count"] == 1
+
+
+def test_workflow_show_reads_latest_scan(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("BRIGADE_EXTRAS", "1")
+    _write_verify_receipt(
+        tmp_path,
+        "verify-one",
+        started_at="2026-06-11T12:00:00+00:00",
+        commands=["python -m pytest tests/test_alpha.py -q"],
+    )
+    assert cli.main(["workflow", "scan", "--target", str(tmp_path), "--min-count", "1", "--json"]) == 0
+    capsys.readouterr()
+
+    assert cli.main(["workflow", "show", "--target", str(tmp_path), "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["candidate_count"] == 1
+    assert payload["candidates"][0]["sources"] == ["verify"]
+
+
+def test_workflow_propose_runbook_writes_policy_valid_runbook_from_candidate(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("BRIGADE_EXTRAS", "1")
+    _write_workflow_latest(
+        tmp_path,
+        [
+            {
+                "id": "workflow-alpha123",
+                "pattern_key": "alpha123",
+                "sequence": ["rm -rf /tmp/nope"],
+                "example_commands": ["python -m pytest tests/test_alpha.py -q", "ruff check src tests"],
+                "occurrence_count": 2,
+                "session_count": 2,
+                "sources": ["verify"],
+                "ends_in_verify_pass": True,
+                "first_seen": "2026-06-11T12:00:00+00:00",
+                "last_seen": "2026-06-11T13:00:00+00:00",
+                "suggested_runbook_id": "workflow-alpha123",
+                "evidence": [],
+                "review_risk": "low",
+                "suggested_next_command": "brigade workflow propose-runbook workflow-alpha123",
+            }
+        ],
+    )
+
+    assert cli.main(["workflow", "propose-runbook", "workflow-alpha123", "--target", str(tmp_path), "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    runbook_path = payload["runbook_path"]
+    runbook = json.loads(
+        (tmp_path / ".brigade" / "workflow" / "workshop" / "workflow-alpha123" / "runbook.json").read_text()
+    )
+
+    assert payload["candidate"]["id"] == "workflow-alpha123"
+    assert payload["plan"]["policy_valid"] is True
+    assert runbook == {
+        "id": "workflow-alpha123",
+        "description": "Runbook proposed from workflow scan candidate workflow-alpha123, sources: verify.",
+        "approved": False,
+        "allowed_commands": ["python", "ruff"],
+        "pins": [],
+        "steps": [
+            {
+                "id": "step-1",
+                "run": "python -m pytest tests/test_alpha.py -q",
+                "timeout_seconds": 600,
+            },
+            {"id": "step-2", "run": "ruff check src tests", "timeout_seconds": 600},
+        ],
+    }
+
+    assert cli.main(["runbook", "plan", runbook_path, "--target", str(tmp_path), "--json"]) == 0
+    plan = json.loads(capsys.readouterr().out)
+    assert plan["policy_valid"] is True
+    assert [step["run"] for step in plan["steps"]] == [
+        "python -m pytest tests/test_alpha.py -q",
+        "ruff check src tests",
+    ]
+
+
+def test_workflow_propose_runbook_dry_run_does_not_write(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("BRIGADE_EXTRAS", "1")
+    _write_workflow_latest(
+        tmp_path,
+        [
+            {
+                "id": "workflow-beta123",
+                "suggested_runbook_id": "workflow-beta-runbook",
+                "sources": ["daily"],
+                "example_commands": ["python -m pytest tests/test_docs.py -q"],
+            }
+        ],
+    )
+
+    assert (
+        cli.main(["workflow", "propose-runbook", "workflow-beta", "--target", str(tmp_path), "--dry-run", "--json"])
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["dry_run"] is True
+    assert payload["candidate"]["id"] == "workflow-beta123"
+    assert payload["runbook"]["id"] == "workflow-beta-runbook"
+    assert payload["plan"]["policy_valid"] is True
+    assert not (tmp_path / ".brigade" / "workflow" / "workshop" / "workflow-beta-runbook" / "runbook.json").exists()
+
+
+def test_workflow_propose_runbook_unknown_prefix_exits_2(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("BRIGADE_EXTRAS", "1")
+    _write_workflow_latest(
+        tmp_path,
+        [{"id": "workflow-alpha123", "suggested_runbook_id": "workflow-alpha123", "example_commands": ["python -V"]}],
+    )
+
+    assert cli.main(["workflow", "propose-runbook", "workflow-missing", "--target", str(tmp_path)]) == 2
+
+    assert "workflow candidate not found: workflow-missing" in capsys.readouterr().err
+
+
+def test_workflow_propose_runbook_ambiguous_prefix_exits_2(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("BRIGADE_EXTRAS", "1")
+    _write_workflow_latest(
+        tmp_path,
+        [
+            {"id": "workflow-dupe111", "suggested_runbook_id": "workflow-dupe111", "example_commands": ["python -V"]},
+            {
+                "id": "workflow-dupe222",
+                "suggested_runbook_id": "workflow-dupe222",
+                "example_commands": ["python -m pytest -q"],
+            },
+        ],
+    )
+
+    assert cli.main(["workflow", "propose-runbook", "workflow-dupe", "--target", str(tmp_path)]) == 2
+
+    assert "workflow candidate id is ambiguous: workflow-dupe" in capsys.readouterr().err
+
+
+def test_workflow_scan_templates_volatile_tokens_into_stable_pattern(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("BRIGADE_EXTRAS", "1")
+    commands_one = [
+        "brigade work verify show 20260611-120000-work-verify-a1b2c3",
+        "cat /tmp/claude-scratch/run-20260611-120000-abcdef123456/out.log",
+        "git log --since 2026-06-11 --format=%H deadbeefcafe1234",
+    ]
+    commands_two = [
+        "brigade work verify show 20260612-090100-work-verify-9f8e7d",
+        "cat /tmp/other-scratch/run-20260612-090100-fedcba654321/out.log",
+        "git log --since 2026-06-12 --format=%H 1234cafedeadbeef",
+    ]
+    _write_verify_receipt(tmp_path, "verify-one", started_at="2026-06-11T12:00:00+00:00", commands=commands_one)
+    _write_verify_receipt(tmp_path, "verify-two", started_at="2026-06-12T09:01:00+00:00", commands=commands_two)
+
+    assert cli.main(["workflow", "scan", "--target", str(tmp_path), "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    expected_sequence = [
+        "brigade work verify show <run-id>",
+        "cat <path>",
+        "git log --since <date> --format=%H <hex>",
+    ]
+    assert payload["candidate_count"] == 1
+    candidate = payload["candidates"][0]
+    assert candidate["sequence"] == expected_sequence
+    assert candidate["pattern_key"] == _pattern_key(expected_sequence)
+    assert candidate["id"] == f"workflow-{_pattern_key(expected_sequence)}"
+    assert candidate["occurrence_count"] == 2
+    assert candidate["example_commands"] == commands_two
+
+
+def test_workflow_scan_review_risk_follows_runbook_denylist(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("BRIGADE_EXTRAS", "1")
+    risky = ["git reset --hard origin/main", "python -m pytest -q"]
+    safe = ["python -m pytest -q", "ruff check src tests"]
+    _write_verify_receipt(tmp_path, "risky-one", started_at="2026-06-11T12:00:00+00:00", commands=risky)
+    _write_verify_receipt(tmp_path, "risky-two", started_at="2026-06-11T13:00:00+00:00", commands=risky)
+    _write_verify_receipt(tmp_path, "safe-one", started_at="2026-06-11T14:00:00+00:00", commands=safe)
+    _write_verify_receipt(tmp_path, "safe-two", started_at="2026-06-11T15:00:00+00:00", commands=safe)
+
+    assert cli.main(["workflow", "scan", "--target", str(tmp_path), "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    risk_by_sequence = {tuple(item["sequence"]): item["review_risk"] for item in payload["candidates"]}
+    assert risk_by_sequence[tuple(risky)] == "high"
+    assert risk_by_sequence[tuple(safe)] == "normal"
+
+
+def test_workflow_propose_runbook_rejects_policy_invalid_candidate(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("BRIGADE_EXTRAS", "1")
+    _write_workflow_latest(
+        tmp_path,
+        [
+            {
+                "id": "workflow-danger01",
+                "pattern_key": "danger01",
+                "sequence": ["rm -rf <path>"],
+                "example_commands": ["rm -rf build"],
+                "occurrence_count": 2,
+                "session_count": 2,
+                "sources": ["verify"],
+                "ends_in_verify_pass": True,
+                "first_seen": "2026-06-11T12:00:00+00:00",
+                "last_seen": "2026-06-11T13:00:00+00:00",
+                "suggested_runbook_id": "workflow-danger01",
+                "evidence": [],
+                "review_risk": "high",
+                "suggested_next_command": "brigade workflow propose-runbook workflow-danger01",
+            }
+        ],
+    )
+
+    rc = cli.main(["workflow", "propose-runbook", "workflow-danger01", "--target", str(tmp_path)])
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert "policy" in captured.err
+    runbook_path = tmp_path / ".brigade" / "workflow" / "workshop" / "workflow-danger01" / "runbook.json"
+    assert not runbook_path.exists()


### PR DESCRIPTION
Closes #148.

## What this adds

- `brigade workflow scan` (extras): mines recurring command sequences from two structured sources: verify receipts (`.brigade/work/verify-runs/*/receipt.json`, one observation per receipt from the full ordered `commands[].command` list, `shlex.join(argv)` fallback) and daily run receipts (`.brigade/daily/runs/*/run.json`, one observation per run from `commands_invoked`). Flags: `--days` (default 30), `--min-count` (default 2, minimum 1), `--min-steps`, `--max-files`, `--import-candidates`, `--dry-run`, `--json`.
- Normalization templates volatile tokens before hashing so the same workflow groups across runs: run-id shapes become `<run-id>`, UUIDs and 12+ char hex become `<hex>`, ISO timestamps and dates become `<date>`, absolute paths under `/tmp` or the user home become `<path>`. `pattern_key` is sha256 (first 12 hex) over the joined templates; candidate id and `suggested_runbook_id` are `workflow-<pattern_key>`.
- `sequence` holds templates; `example_commands` holds the concrete commands from the most recent observation, so proposed runbooks contain runnable steps, never placeholders.
- `--import-candidates` appends work-ledger records with `source_item_key` = candidate id and `source_fingerprint` = sha256[:16] over `{id, sequence, suggested_runbook_id}` only. Occurrence counts, timestamps, and evidence are deliberately excluded so a rescan with a higher count does not re-import (same class of bug fixed for friction in #153; a regression test covers it).
- `brigade workflow propose-runbook <id>`: generates a workshop `runbook.json` (`approved: false`, `pins: []`, sorted `allowed_commands`, steps from `example_commands` at `timeout_seconds: 600`, provenance description). The payload is validated against `runbook plan` policy before anything is written; on policy failure it reports the failures, writes nothing, and exits 1.
- `review_risk` is `high` when any example command matches the runbook advisory destructive deny-list, else `normal`.
- Registered as an extras group mirroring `friction`; added to `COMMAND_GROUPS` and `EXTRAS_COMMANDS`. Docs updated in `docs/import-schema.md` and `docs/command-inventory.md`.

## Verification

- `python3 -m pytest -q`: 1472 passed, 1 skipped (baseline 1458 plus 14 new workflow tests), via `brigade work verify run`, receipt `20260708-043750-work-verify-3a835f`.
- `pipx run ruff check .`: clean, receipt `20260708-044050-work-verify-ac0d5d`.
- Tests cover: cross-receipt normalization grouping (commands differing only by run-id/date/path/hex tokens produce one candidate with stable `pattern_key`), min-count filtering, daily `commands_invoked` mining, import fingerprint stability under count drift, dry-run purity, skipped-bad-JSON counting, policy-valid runbook generation verified end-to-end through `runbook plan`, and rejection of policy-invalid candidates (exit 1, nothing written).