### PR TITLE
feat(receipts): tamper-evident digests and hash-chained outcome ledger

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,6 +34,12 @@ You should get an acknowledgment within 72 hours. If you do not, please follow u
 - Pins cover `argv[0]` only. For `bash script.sh`, `python script.py`, or a similar interpreter step, the pin covers the interpreter binary, not the script, package imports, shell profile, environment, or network content the interpreter may load.
 - If a pin has `version_cmd`, Brigade runs the resolved pinned binary with those arguments (for example `--version`) during `runbook pin` to refresh the stored `version`, and during `runbook run` pin verification to record runtime `version_output` in the receipt, so the version always describes the same file the hash covers. `runbook plan` and `runbook run --dry-run` never execute `version_cmd`. Review `version_cmd` arguments the same way you review step commands.
 
+## Receipt digests are not signatures
+
+Work verification receipts, runbook receipts, and outcome ledger records use SHA-256 digests to make ordinary local drift visible. `brigade receipts verify` recomputes receipt payload digests, stdout and stderr log digests, and the outcome ledger `prev_digest` chain.
+
+This is tamper-evident bookkeeping, not signing. It can detect hand-edited receipt fields, changed or missing logs, edited outcome records, and deleted middle ledger records. It does not defend against an attacker who can rewrite both the receipt and its digests, or an attacker who can rewrite and re-chain the ledger tail after changing a record. Optional signing with key ids is future work, and would be a separate security boundary.
+
 ## Out of scope
 
 - Bugs in `content-guard` itself - please report those upstream at

--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -37,10 +37,11 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade notifications` (extras): 4 command path(s)
 - `brigade openclaw-fragments` (extras): 1 command path(s)
 - `brigade operator`: 24 command path(s)
-- `brigade outcome`: 9 command path(s)
+- `brigade outcome`: 10 command path(s)
 - `brigade pantry` (extras): 4 command path(s)
 - `brigade profiles`: 2 command path(s)
 - `brigade projects` (extras): 10 command path(s)
+- `brigade receipts`: 1 command path(s)
 - `brigade reconfigure`: 1 command path(s)
 - `brigade release` (extras): 23 command path(s)
 - `brigade repos` (extras): 71 command path(s)
@@ -226,6 +227,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade operator verify-harness`
 - `brigade outcome capture`
 - `brigade outcome diff`
+- `brigade outcome doctor`
 - `brigade outcome explain`
 - `brigade outcome fork`
 - `brigade outcome rank`
@@ -249,6 +251,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade projects readiness plan` (extras)
 - `brigade projects readiness record` (extras)
 - `brigade projects readiness show` (extras)
+- `brigade receipts verify`
 - `brigade reconfigure`
 - `brigade release candidate archive` (extras)
 - `brigade release candidate audit` (extras)

--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -864,8 +864,13 @@ Work verification and closeout commands:
 - `brigade work verify plan` previews the local verification commands and current evidence snapshot without running anything.
 - `brigade work verify run` executes explicit local verification commands without a shell and writes receipts under `.brigade/work/verify-runs/`.
 - `brigade work verify runs` and `brigade work verify show <run-id>` inspect local verification receipts, command exit codes, summaries, and log paths.
+- `brigade receipts verify` recomputes SHA-256 receipt digests, stdout and stderr log digests, and the `memory/outcome/records.jsonl` digest chain. It reports `OK`, `MISMATCH`, `MISSING`, or `LEGACY` for each checked artifact and exits non-zero only for mismatch or missing evidence.
 - `brigade work closeout <session-id-or-latest>` writes a local closeout receipt under `.brigade/work/closeouts/` that collects task acceptance, latest verification, scanner sweep status, code review closeout state, handoff draft status, and session evidence.
 - `brigade work acceptance` reports pending task acceptance coverage, completion metadata gaps, completion-time acceptance evidence, code-review finding outcomes, and latest work closeout state. Release readiness and release candidate evidence include the same rollup.
+
+Verification receipts and runbook receipts include tamper-evident SHA-256 digests over the canonical receipt payload and referenced stdout and stderr logs. Outcome records include `prev_digest` and `digest` fields so the ledger tail points back through prior records. These are digests, not signatures. Optional signing and key ids may be added later, but current receipts do not prove authorship or bind an external identity.
+
+This digest layer detects common local drift, such as hand-edited receipt fields, missing logs, changed logs, edited outcome records, and deleted middle ledger records. It does not defend against an attacker who can rewrite both receipt contents and their stored digests, or an attacker who can rewrite and re-chain the outcome ledger tail from the changed point onward.
 
 Verification and closeout are local gates. Brigade does not mutate CI, GitHub, reviewers, scanner promotions, handoff ingestion, daemons, or schedulers. Verification commands run only when explicitly requested.
 

--- a/src/brigade/cli/__init__.py
+++ b/src/brigade/cli/__init__.py
@@ -28,6 +28,7 @@ from . import (
     doctor as _doctor_group,
     status as _status_group,
     profiles as _profiles_group,
+    receipts as _receipts_group,
     daily as _daily_group,
     add as _add_group,
     stations as _stations_group,
@@ -118,6 +119,7 @@ def _build_parser() -> argparse.ArgumentParser:
     _doctor_group.register(sub)
     _status_group.register(sub)
     _profiles_group.register(sub)
+    _receipts_group.register(sub)
     _daily_group.register(sub)
     _add_group.register(sub)
     _stations_group.register(sub)

--- a/src/brigade/cli/_common.py
+++ b/src/brigade/cli/_common.py
@@ -14,7 +14,7 @@ import argparse
 COMMAND_GROUPS: list[tuple[str, list[str]]] = [
     (
         "Core memory loop",
-        ["init", "handoff", "handoff-template", "ingest", "memory", "doctor", "status", "profiles"],
+        ["init", "handoff", "handoff-template", "ingest", "memory", "doctor", "status", "profiles", "receipts"],
     ),
     (
         "Daily operator loop",

--- a/src/brigade/cli/outcome.py
+++ b/src/brigade/cli/outcome.py
@@ -47,6 +47,11 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_rank.add_argument("--json", action="store_true", help="Emit machine-readable JSON instead of text.")
     p_rank.set_defaults(func=_dispatch_rank)
 
+    p_doctor = outcome_sub.add_parser("doctor", help="Summarize outcome and receipt digest health.")
+    p_doctor.add_argument("--target", "-t", type=Path, default=Path("."))
+    p_doctor.add_argument("--json", action="store_true", help="Emit machine-readable JSON instead of text.")
+    p_doctor.set_defaults(func=_dispatch_doctor)
+
     p_rebuild = outcome_sub.add_parser(
         "rebuild-status", help="Rebuild status.json from decision receipts and report any drift."
     )
@@ -123,6 +128,12 @@ def _dispatch_rank(args) -> int:
     from .. import outcome_cmd
 
     return outcome_cmd.rank(target=args.target, json_output=args.json)
+
+
+def _dispatch_doctor(args) -> int:
+    from .. import outcome_cmd
+
+    return outcome_cmd.doctor(target=args.target, json_output=args.json)
 
 
 def _dispatch_rebuild_status(args) -> int:

--- a/src/brigade/cli/receipts.py
+++ b/src/brigade/cli/receipts.py
@@ -1,0 +1,26 @@
+"""brigade receipts command group."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p_receipts = sub.add_parser("receipts", help="Verify local Brigade receipt digests.")
+    receipts_sub = p_receipts.add_subparsers(dest="receipts_command", metavar="<receipts-command>")
+    receipts_sub.required = True
+
+    p_verify = receipts_sub.add_parser("verify", help="Verify receipt and outcome digest chains.")
+    p_verify.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
+    p_verify.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_verify.set_defaults(func=dispatch)
+
+
+def dispatch(args) -> int:
+    from .. import receipts_cmd
+
+    if args.receipts_command == "verify":
+        return receipts_cmd.verify(target=args.target, json_output=args.json)
+    args._brigade_parser.error(f"unknown receipts command: {args.receipts_command}")
+    return 2

--- a/src/brigade/doctor.py
+++ b/src/brigade/doctor.py
@@ -236,7 +236,24 @@ def _gather_checks(ctx: DoctorContext) -> List[CheckResult]:
                 f"{len(missing_tools)} managed tools not installed ({', '.join(stations)}); optional, install with `brigade add <station>`",
             )
         )
+    checks.append(_check_receipts(ctx.target))
     return checks
+
+
+def _check_receipts(target: Path) -> CheckResult:
+    from . import receipts_cmd
+
+    try:
+        payload = receipts_cmd.verify_payload(target)
+    except Exception as exc:  # noqa: BLE001 - doctor must stay advisory
+        return (WARN, "receipts: verify", f"unable to inspect receipts: {type(exc).__name__}: {exc}")
+    summary = payload["summary"]
+    status = WARN if summary["mismatch"] or summary["missing"] else OK
+    detail = (
+        f"checked={summary['total']} ok={summary['ok']} mismatch={summary['mismatch']} "
+        f"missing={summary['missing']} legacy={summary['legacy']}"
+    )
+    return (status, "receipts: verify", detail)
 
 
 def _check_workspace_files(target: Path) -> List[CheckResult]:

--- a/src/brigade/localio.py
+++ b/src/brigade/localio.py
@@ -86,6 +86,30 @@ def read_jsonl_dicts(path: Path) -> list[dict[str, Any]]:
     return records
 
 
+def canonical_json_digest(payload: Any, *, exclude_keys: set[str] | None = None) -> str:
+    """Return a full sha256 digest of payload's canonical sorted-key JSON.
+
+    exclude_keys applies to the TOP LEVEL only: it exists so an artifact can
+    carry its own digest field without self-reference. Nested keys with the
+    same name are content and must stay inside the hash, or edits to them
+    would be undetectable.
+    """
+    normalized = payload
+    if exclude_keys and isinstance(payload, dict):
+        normalized = {key: item for key, item in payload.items() if key not in exclude_keys}
+    rendered = json.dumps(normalized, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(rendered.encode("utf-8")).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    """Return the sha256 digest for path's bytes, streamed in bounded chunks."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
 def stable_hash(value: object) -> str:
     """Return a 16-char sha256 fingerprint of value's canonical JSON rendering."""
     rendered = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)

--- a/src/brigade/outcome_cmd.py
+++ b/src/brigade/outcome_cmd.py
@@ -85,12 +85,25 @@ def load_records(target: Path) -> list[core.OutcomeRecord]:
     return [record for record in records if record is not None]
 
 
+def _last_record_digest(path: Path) -> str | None:
+    for row in reversed(localio.read_jsonl_dicts(path)):
+        digest = row.get("digest")
+        if isinstance(digest, str) and digest:
+            return digest
+    return None
+
+
 def append_records(target: Path, records: list[core.OutcomeRecord]) -> None:
     path = _records_path(target)
     path.parent.mkdir(parents=True, exist_ok=True)
+    prev_digest = _last_record_digest(path)
     with path.open("a", encoding="utf-8") as handle:
         for record in records:
-            handle.write(json.dumps(dataclasses.asdict(record), sort_keys=True) + "\n")
+            row = dataclasses.asdict(record)
+            row["prev_digest"] = prev_digest
+            row["digest"] = localio.canonical_json_digest(row, exclude_keys={"digest"})
+            handle.write(json.dumps(row, sort_keys=True) + "\n")
+            prev_digest = row["digest"]
 
 
 def _decisions_dir(target: Path) -> Path:
@@ -332,10 +345,11 @@ def capture(
     run_id: str = "latest",
     json_output: bool = False,
 ) -> int:
-    """Correlate a verify run's exit-code outcome into a signed record.
+    """Correlate a verify run's exit-code outcome into the digest-chained ledger.
 
     The signal is the run's status (a real exit code the model cannot author),
-    not an LLM judgment. The caller names which artifact the run exercised.
+    not an LLM judgment. The caller names which artifact the run exercised, and
+    appended records carry a tamper-evident prev_digest/digest chain.
     """
     target = target.expanduser().resolve()
     from .work_cmd import verification as verify_mod
@@ -573,6 +587,12 @@ def rank(*, target: Path, json_output: bool = False) -> int:
     for item in ordered:
         print(f"- {item.artifact_id} score={item.score:.3f} helped={item.helped} hurt={item.hurt}")
     return 0
+
+
+def doctor(*, target: Path, json_output: bool = False) -> int:
+    from . import receipts_cmd
+
+    return receipts_cmd.doctor(target=target, json_output=json_output)
 
 
 def record(

--- a/src/brigade/receipts_cmd.py
+++ b/src/brigade/receipts_cmd.py
@@ -1,0 +1,484 @@
+"""Receipt digest verification for work, runbook, and outcome artifacts."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from . import localio
+
+OK = "OK"
+MISMATCH = "MISMATCH"
+MISSING = "MISSING"
+LEGACY = "LEGACY"
+
+
+def _rel(path: Path, target: Path) -> str:
+    try:
+        return str(path.relative_to(target))
+    except ValueError:
+        return str(path)
+
+
+def _item(
+    *,
+    artifact_type: str,
+    artifact_id: str,
+    status: str,
+    check: str,
+    detail: str,
+    path: Path,
+    target: Path,
+    expected: str | None = None,
+    actual: str | None = None,
+) -> dict[str, Any]:
+    item: dict[str, Any] = {
+        "artifact_type": artifact_type,
+        "artifact_id": artifact_id,
+        "status": status,
+        "check": check,
+        "detail": detail,
+        "path": _rel(path, target),
+    }
+    if expected is not None:
+        item["expected"] = expected
+    if actual is not None:
+        item["actual"] = actual
+    return item
+
+
+def _read_receipt(
+    path: Path, *, artifact_type: str, target: Path
+) -> tuple[dict[str, Any] | None, list[dict[str, Any]]]:
+    try:
+        payload = json.loads(path.read_text())
+    except OSError as exc:
+        return None, [
+            _item(
+                artifact_type=artifact_type,
+                artifact_id=_rel(path, target),
+                status=MISSING,
+                check="receipt",
+                detail=f"receipt unreadable: {exc}",
+                path=path,
+                target=target,
+            )
+        ]
+    except json.JSONDecodeError as exc:
+        return None, [
+            _item(
+                artifact_type=artifact_type,
+                artifact_id=_rel(path, target),
+                status=MISMATCH,
+                check="receipt",
+                detail=f"receipt is not valid JSON: {exc}",
+                path=path,
+                target=target,
+            )
+        ]
+    if not isinstance(payload, dict):
+        return None, [
+            _item(
+                artifact_type=artifact_type,
+                artifact_id=_rel(path, target),
+                status=MISMATCH,
+                check="receipt",
+                detail="receipt JSON is not an object",
+                path=path,
+                target=target,
+            )
+        ]
+    return payload, []
+
+
+def _verify_receipt(path: Path, *, artifact_type: str, log_type: str, target: Path) -> list[dict[str, Any]]:
+    payload, problems = _read_receipt(path, artifact_type=artifact_type, target=target)
+    if payload is None:
+        return problems
+    artifact_id = _rel(path, target)
+    digests = payload.get("digests")
+    if not isinstance(digests, dict):
+        return [
+            _item(
+                artifact_type=artifact_type,
+                artifact_id=artifact_id,
+                status=LEGACY,
+                check="digests",
+                detail="receipt has no digests block",
+                path=path,
+                target=target,
+            )
+        ]
+    items: list[dict[str, Any]] = []
+    if digests.get("algorithm") != "sha256":
+        items.append(
+            _item(
+                artifact_type=artifact_type,
+                artifact_id=artifact_id,
+                status=MISSING,
+                check="algorithm",
+                detail="digests.algorithm is missing or not sha256",
+                path=path,
+                target=target,
+                expected="sha256",
+                actual=str(digests.get("algorithm")),
+            )
+        )
+    expected_receipt = digests.get("receipt_sha256")
+    actual_receipt = localio.canonical_json_digest(payload, exclude_keys={"digests"})
+    if not isinstance(expected_receipt, str) or not expected_receipt:
+        items.append(
+            _item(
+                artifact_type=artifact_type,
+                artifact_id=artifact_id,
+                status=MISSING,
+                check="receipt_sha256",
+                detail="digests.receipt_sha256 is missing",
+                path=path,
+                target=target,
+            )
+        )
+    elif expected_receipt != actual_receipt:
+        items.append(
+            _item(
+                artifact_type=artifact_type,
+                artifact_id=artifact_id,
+                status=MISMATCH,
+                check="receipt_sha256",
+                detail="receipt digest does not match canonical receipt payload",
+                path=path,
+                target=target,
+                expected=expected_receipt,
+                actual=actual_receipt,
+            )
+        )
+    else:
+        items.append(
+            _item(
+                artifact_type=artifact_type,
+                artifact_id=artifact_id,
+                status=OK,
+                check="receipt_sha256",
+                detail="receipt digest matches",
+                path=path,
+                target=target,
+                expected=expected_receipt,
+                actual=actual_receipt,
+            )
+        )
+
+    logs = digests.get("logs")
+    if not isinstance(logs, dict):
+        items.append(
+            _item(
+                artifact_type=artifact_type,
+                artifact_id=artifact_id,
+                status=MISSING,
+                check="logs",
+                detail="digests.logs is missing or not an object",
+                path=path,
+                target=target,
+            )
+        )
+        return items
+    for name, expected_digest in sorted(logs.items()):
+        log_rel = Path(str(name))
+        log_path = path.parent / log_rel
+        log_id = f"{artifact_id}:{name}"
+        if log_rel.is_absolute() or ".." in log_rel.parts:
+            items.append(
+                _item(
+                    artifact_type=log_type,
+                    artifact_id=log_id,
+                    status=MISSING,
+                    check="log_path",
+                    detail="referenced log path is outside the receipt directory",
+                    path=path.parent,
+                    target=target,
+                )
+            )
+            continue
+        if not isinstance(expected_digest, str) or not expected_digest:
+            items.append(
+                _item(
+                    artifact_type=log_type,
+                    artifact_id=log_id,
+                    status=MISSING,
+                    check="log_sha256",
+                    detail="log digest is missing",
+                    path=log_path,
+                    target=target,
+                )
+            )
+            continue
+        if not log_path.is_file():
+            items.append(
+                _item(
+                    artifact_type=log_type,
+                    artifact_id=log_id,
+                    status=MISSING,
+                    check="log_sha256",
+                    detail="referenced log file is missing",
+                    path=log_path,
+                    target=target,
+                    expected=expected_digest,
+                )
+            )
+            continue
+        actual_digest = localio.file_sha256(log_path)
+        if actual_digest != expected_digest:
+            items.append(
+                _item(
+                    artifact_type=log_type,
+                    artifact_id=log_id,
+                    status=MISMATCH,
+                    check="log_sha256",
+                    detail="log digest does not match file bytes",
+                    path=log_path,
+                    target=target,
+                    expected=expected_digest,
+                    actual=actual_digest,
+                )
+            )
+        else:
+            items.append(
+                _item(
+                    artifact_type=log_type,
+                    artifact_id=log_id,
+                    status=OK,
+                    check="log_sha256",
+                    detail="log digest matches",
+                    path=log_path,
+                    target=target,
+                    expected=expected_digest,
+                    actual=actual_digest,
+                )
+            )
+    return items
+
+
+def _verify_receipt_tree(target: Path) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    for path in sorted((target / ".brigade" / "work" / "verify-runs").glob("*/receipt.json")):
+        items.extend(
+            _verify_receipt(path, artifact_type="work-verify-receipt", log_type="work-verify-log", target=target)
+        )
+    for path in sorted((target / ".brigade" / "runbooks" / "runs").glob("*/receipt.json")):
+        items.extend(_verify_receipt(path, artifact_type="runbook-receipt", log_type="runbook-log", target=target))
+    return items
+
+
+def _ledger_item(
+    *,
+    path: Path,
+    target: Path,
+    line_no: int,
+    status: str,
+    check: str,
+    detail: str,
+    expected: str | None = None,
+    actual: str | None = None,
+) -> dict[str, Any]:
+    return _item(
+        artifact_type="outcome-ledger-record",
+        artifact_id=f"{_rel(path, target)}:{line_no}",
+        status=status,
+        check=check,
+        detail=detail,
+        path=path,
+        target=target,
+        expected=expected,
+        actual=actual,
+    )
+
+
+def _verify_outcome_ledger(target: Path) -> list[dict[str, Any]]:
+    path = target / "memory" / "outcome" / "records.jsonl"
+    if not path.exists():
+        return []
+    try:
+        lines = path.read_text().splitlines()
+    except OSError as exc:
+        return [
+            _ledger_item(
+                path=path,
+                target=target,
+                line_no=0,
+                status=MISSING,
+                check="records.jsonl",
+                detail=f"outcome ledger unreadable: {exc}",
+            )
+        ]
+    items: list[dict[str, Any]] = []
+    previous_digest: str | None = None
+    for line_no, line in enumerate(lines, start=1):
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError as exc:
+            items.append(
+                _ledger_item(
+                    path=path,
+                    target=target,
+                    line_no=line_no,
+                    status=MISMATCH,
+                    check="json",
+                    detail=f"ledger line is not valid JSON: {exc}",
+                )
+            )
+            continue
+        if not isinstance(row, dict):
+            items.append(
+                _ledger_item(
+                    path=path,
+                    target=target,
+                    line_no=line_no,
+                    status=MISMATCH,
+                    check="json",
+                    detail="ledger line is not an object",
+                )
+            )
+            continue
+        recorded_digest = row.get("digest")
+        if not isinstance(recorded_digest, str) or not recorded_digest:
+            items.append(
+                _ledger_item(
+                    path=path,
+                    target=target,
+                    line_no=line_no,
+                    status=LEGACY,
+                    check="digest",
+                    detail="ledger record has no digest",
+                )
+            )
+            continue
+        if "prev_digest" not in row:
+            items.append(
+                _ledger_item(
+                    path=path,
+                    target=target,
+                    line_no=line_no,
+                    status=MISSING,
+                    check="prev_digest",
+                    detail="ledger record has no prev_digest",
+                )
+            )
+            previous_digest = recorded_digest
+            continue
+        actual_prev = row.get("prev_digest")
+        if actual_prev != previous_digest:
+            items.append(
+                _ledger_item(
+                    path=path,
+                    target=target,
+                    line_no=line_no,
+                    status=MISMATCH,
+                    check="prev_digest",
+                    detail="ledger chain link does not point to the previous digest",
+                    expected=previous_digest,
+                    actual=str(actual_prev),
+                )
+            )
+            previous_digest = recorded_digest
+            continue
+        recomputed = localio.canonical_json_digest(row, exclude_keys={"digest"})
+        if recomputed != recorded_digest:
+            items.append(
+                _ledger_item(
+                    path=path,
+                    target=target,
+                    line_no=line_no,
+                    status=MISMATCH,
+                    check="digest",
+                    detail="ledger record digest does not match canonical record payload",
+                    expected=recorded_digest,
+                    actual=recomputed,
+                )
+            )
+        else:
+            items.append(
+                _ledger_item(
+                    path=path,
+                    target=target,
+                    line_no=line_no,
+                    status=OK,
+                    check="digest",
+                    detail="ledger record digest matches",
+                    expected=recorded_digest,
+                    actual=recomputed,
+                )
+            )
+        previous_digest = recorded_digest
+    return items
+
+
+def _summary(items: list[dict[str, Any]]) -> dict[str, int]:
+    counts = {OK: 0, MISMATCH: 0, MISSING: 0, LEGACY: 0}
+    for item in items:
+        status = str(item.get("status") or "")
+        if status in counts:
+            counts[status] += 1
+    return {
+        "total": len(items),
+        "ok": counts[OK],
+        "mismatch": counts[MISMATCH],
+        "missing": counts[MISSING],
+        "legacy": counts[LEGACY],
+    }
+
+
+def verify_payload(target: Path) -> dict[str, Any]:
+    target = target.expanduser().resolve()
+    artifacts = _verify_receipt_tree(target)
+    artifacts.extend(_verify_outcome_ledger(target))
+    return {"target": str(target), "summary": _summary(artifacts), "artifacts": artifacts}
+
+
+def summary_detail(target: Path) -> str:
+    summary = verify_payload(target)["summary"]
+    return (
+        f"checked={summary['total']} ok={summary['ok']} mismatch={summary['mismatch']} "
+        f"missing={summary['missing']} legacy={summary['legacy']}"
+    )
+
+
+def verify(*, target: Path, json_output: bool = False) -> int:
+    payload = verify_payload(target)
+    summary = payload["summary"]
+    failed = int(summary["mismatch"]) + int(summary["missing"])
+    if json_output:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 1 if failed else 0
+    print(f"receipts verify: {payload['target']}")
+    print(
+        f"summary: checked={summary['total']} ok={summary['ok']} mismatch={summary['mismatch']} "
+        f"missing={summary['missing']} legacy={summary['legacy']}"
+    )
+    for item in payload["artifacts"]:
+        if item["status"] in {MISMATCH, MISSING, LEGACY}:
+            print(f"- {item['status']} {item['artifact_id']} [{item['check']}] {item['detail']}")
+    return 1 if failed else 0
+
+
+def doctor(*, target: Path, json_output: bool = False) -> int:
+    target = target.expanduser().resolve()
+    payload = verify_payload(target)
+    if json_output:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+    print(f"outcome doctor: {target}")
+    print(f"receipts: {summary_detail(target)}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    from .cli import main as cli_main
+
+    return cli_main(argv)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/src/brigade/runbook_cmd.py
+++ b/src/brigade/runbook_cmd.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import hashlib
 import os
 import re
 import shlex
@@ -12,7 +11,13 @@ import subprocess
 import sys
 from pathlib import Path
 from typing import Any
-from .localio import stable_hash as _stable_hash, utc_now_iso as _now, write_json as _write_json
+from .localio import (
+    canonical_json_digest as _canonical_json_digest,
+    file_sha256 as _file_sha256,
+    stable_hash as _stable_hash,
+    utc_now_iso as _now,
+    write_json as _write_json,
+)
 
 # ADVISORY ONLY. This deny-list catches a few obviously destructive shapes, but
 # it is trivially bypassable by destructive filesystem commands or remote-shell wrappers and
@@ -121,11 +126,7 @@ def _pin_for_step(payload: dict[str, Any], step: dict[str, Any]) -> dict[str, An
 
 
 def _sha256_file(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
+    return _file_sha256(path)
 
 
 def _run_version_cmd(resolved_path: str, version_cmd: str) -> dict[str, Any]:
@@ -545,6 +546,25 @@ def _execute_plan(
     }
     if pin_checks:
         receipt["pin_checks"] = pin_checks
+    log_digests: dict[str, str] = {}
+    for step in receipt["steps"]:
+        if not isinstance(step, dict):
+            continue
+        for key in ("stdout_log_path", "stderr_log_path"):
+            value = step.get(key)
+            if not isinstance(value, str) or not value:
+                continue
+            path = Path(value)
+            try:
+                log_name = str(path.relative_to(run_dir))
+            except ValueError:
+                log_name = path.name
+            log_digests[log_name] = _file_sha256(path)
+    receipt["digests"] = {
+        "algorithm": "sha256",
+        "logs": dict(sorted(log_digests.items())),
+        "receipt_sha256": _canonical_json_digest(receipt, exclude_keys={"digests"}),
+    }
     _write_json(run_dir / "receipt.json", receipt)
     if json_output:
         print(json.dumps(receipt, indent=2, sort_keys=True))

--- a/src/brigade/work_cmd/verification.py
+++ b/src/brigade/work_cmd/verification.py
@@ -11,6 +11,7 @@ import sys
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
+from .. import localio
 from . import constants, helpers, ledger as ledger_mod
 from . import reviews as reviews_mod
 from . import scanners as scanners_mod
@@ -337,6 +338,25 @@ def _run_verify_commands(target: Path, commands: list[str], timeout: int) -> tup
         receipt["status"] = "failed"
     else:
         receipt["status"] = "rejected"
+    log_digests: dict[str, str] = {}
+    for command in receipt["commands"]:
+        if not isinstance(command, dict):
+            continue
+        for key in ("stdout_log_path", "stderr_log_path"):
+            value = command.get(key)
+            if not isinstance(value, str) or not value:
+                continue
+            path = Path(value)
+            try:
+                log_name = str(path.relative_to(run_dir))
+            except ValueError:
+                log_name = path.name
+            log_digests[log_name] = localio.file_sha256(path)
+    receipt["digests"] = {
+        "algorithm": "sha256",
+        "logs": dict(sorted(log_digests.items())),
+        "receipt_sha256": localio.canonical_json_digest(receipt, exclude_keys={"digests"}),
+    }
     helpers._write_json(run_dir / "receipt.json", receipt)
     _write_verify_markdown(run_dir, receipt)
     _prune_verify_runs(target)

--- a/tests/test_localio.py
+++ b/tests/test_localio.py
@@ -36,3 +36,35 @@ def test_write_json_is_atomic_and_leaves_original_intact_on_failure(tmp_path: Pa
     assert path.read_text() == original
     leftovers = sorted(p.name for p in tmp_path.iterdir() if p.name != "receipt.json")
     assert leftovers == []
+
+
+def test_canonical_json_digest_excludes_top_level_keys_and_hashes_files(tmp_path: Path):
+    payload = {
+        "b": 2,
+        "a": {"keep": True, "digest": "kept-as-content"},
+        "items": [{"digest": "kept-as-content"}, {"value": "kept"}],
+        "digests": {"receipt_sha256": "ignore"},
+    }
+    expected = localio.canonical_json_digest(
+        {
+            "a": {"keep": True, "digest": "kept-as-content"},
+            "b": 2,
+            "items": [{"digest": "kept-as-content"}, {"value": "kept"}],
+        }
+    )
+
+    assert localio.canonical_json_digest(payload, exclude_keys={"digest", "digests"}) == expected
+
+    blob = tmp_path / "blob.txt"
+    blob.write_text("hello\n")
+    assert localio.file_sha256(blob) == "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03"
+
+
+def test_canonical_json_digest_excludes_top_level_keys_only():
+    base = {"a": 1, "nested": {"digests": "evidence-digest-1"}, "digests": {"receipt_sha256": "x"}}
+    edited = {"a": 1, "nested": {"digests": "evidence-digest-TAMPERED"}, "digests": {"receipt_sha256": "y"}}
+
+    base_digest = localio.canonical_json_digest(base, exclude_keys={"digests"})
+    edited_digest = localio.canonical_json_digest(edited, exclude_keys={"digests"})
+
+    assert base_digest != edited_digest

--- a/tests/test_outcome_cmd.py
+++ b/tests/test_outcome_cmd.py
@@ -1,6 +1,6 @@
 import json
 
-from brigade import cli, outcome, outcome_cmd, work_cmd
+from brigade import cli, localio, outcome, outcome_cmd, work_cmd
 
 from tests.work_cmd_test_helpers import _init_git_repo
 
@@ -14,6 +14,51 @@ def test_records_persist_under_git_tracked_memory_dir(tmp_path):
     assert (tmp_path / "memory" / "outcome" / "records.jsonl").is_file()
     # durable ledger must NOT live under the gitignored .brigade/ dir
     assert not (tmp_path / ".brigade" / "outcome" / "records.jsonl").exists()
+
+
+def test_appended_records_carry_tamper_evident_digest_chain(tmp_path):
+    first = outcome.OutcomeRecord("skill-x", "skill", "t1", "verify", 1, "ref1", "2026-06-20T00:00:00+00:00")
+    second = outcome.OutcomeRecord("skill-x", "skill", "t2", "verify", -1, "ref2", "2026-06-20T01:00:00+00:00")
+
+    outcome_cmd.append_records(tmp_path, [first])
+    outcome_cmd.append_records(tmp_path, [second])
+
+    rows = [
+        json.loads(line)
+        for line in (tmp_path / "memory" / "outcome" / "records.jsonl").read_text().splitlines()
+        if line.strip()
+    ]
+    assert rows[0]["prev_digest"] is None
+    assert rows[0]["digest"] == localio.canonical_json_digest(rows[0], exclude_keys={"digest"})
+    assert rows[1]["prev_digest"] == rows[0]["digest"]
+    assert rows[1]["digest"] == localio.canonical_json_digest(rows[1], exclude_keys={"digest"})
+
+
+def test_legacy_digestless_records_still_load_and_do_not_break_new_chain(tmp_path):
+    path = tmp_path / "memory" / "outcome" / "records.jsonl"
+    path.parent.mkdir(parents=True)
+    legacy = {
+        "artifact_id": "skill-x",
+        "artifact_kind": "skill",
+        "task_id": "t0",
+        "source": "verify",
+        "signal_value": 1,
+        "evidence_ref": "legacy",
+        "ts": "2026-06-20T00:00:00+00:00",
+    }
+    path.write_text(json.dumps(legacy, sort_keys=True) + "\n")
+
+    outcome_cmd.append_records(
+        tmp_path,
+        [outcome.OutcomeRecord("skill-x", "skill", "t1", "verify", 1, "ref1", "2026-06-20T01:00:00+00:00")],
+    )
+
+    loaded = outcome_cmd.load_records(tmp_path)
+    rows = [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+    assert [record.evidence_ref for record in loaded] == ["legacy", "ref1"]
+    assert "digest" not in rows[0]
+    assert rows[1]["prev_digest"] is None
+    assert rows[1]["digest"] == localio.canonical_json_digest(rows[1], exclude_keys={"digest"})
 
 
 def test_score_reports_wilson_for_seeded_records(tmp_path, capsys):

--- a/tests/test_receipts_cmd.py
+++ b/tests/test_receipts_cmd.py
@@ -1,0 +1,243 @@
+import json
+
+from brigade import cli, localio, outcome, outcome_cmd, receipts_cmd, runbook_cmd, work_cmd
+
+from tests.work_cmd_test_helpers import _init_git_repo
+
+
+def _write_digestless_work_receipt(target):
+    run_dir = target / ".brigade" / "work" / "verify-runs" / "legacy"
+    run_dir.mkdir(parents=True)
+    receipt = {
+        "run_id": "legacy",
+        "target": str(target),
+        "status": "completed",
+        "commands": [],
+    }
+    localio.write_json(run_dir / "receipt.json", receipt)
+
+
+def _write_runbook(path):
+    path.write_text(
+        json.dumps(
+            {
+                "id": "smoke",
+                "description": "tiny runbook",
+                "allowed_commands": ["printf"],
+                "steps": [{"id": "hello", "run": "printf hello"}],
+            }
+        )
+    )
+    return path
+
+
+def _append_outcome(target, evidence_ref):
+    outcome_cmd.append_records(
+        target,
+        [
+            outcome.OutcomeRecord(
+                "taste",
+                "skill",
+                evidence_ref,
+                "verify",
+                1,
+                evidence_ref,
+                f"2026-07-08T00:00:0{evidence_ref[-1]}+00:00",
+            )
+        ],
+    )
+
+
+def test_receipts_verify_fresh_target_passes(tmp_path, capsys):
+    _init_git_repo(tmp_path)
+    assert (
+        work_cmd.verify_run(
+            target=tmp_path,
+            commands=["python3 -c \"print('ok')\""],
+            timeout=30,
+            json_output=True,
+        )
+        == 0
+    )
+    capsys.readouterr()
+    assert (
+        runbook_cmd.run(
+            target=tmp_path,
+            runbook=_write_runbook(tmp_path / "runbook.json"),
+            approved=True,
+            json_output=True,
+        )
+        == 0
+    )
+    capsys.readouterr()
+    _append_outcome(tmp_path, "ref1")
+
+    assert cli.main(["receipts", "verify", "--target", str(tmp_path), "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["summary"]["mismatch"] == 0
+    assert payload["summary"]["missing"] == 0
+    assert payload["summary"]["ok"] >= 2
+    assert {item["status"] for item in payload["artifacts"]} == {"OK"}
+    assert "runbook-receipt" in {item["artifact_type"] for item in payload["artifacts"]}
+
+
+def test_receipts_verify_reports_mismatch_when_receipt_field_is_edited(tmp_path, capsys):
+    _init_git_repo(tmp_path)
+    assert (
+        work_cmd.verify_run(
+            target=tmp_path,
+            commands=["python3 -c \"print('ok')\""],
+            timeout=30,
+            json_output=True,
+        )
+        == 0
+    )
+    receipt = json.loads(capsys.readouterr().out)
+    path = tmp_path / ".brigade" / "work" / "verify-runs" / receipt["run_id"] / "receipt.json"
+    tampered = json.loads(path.read_text())
+    tampered["status"] = "failed"
+    localio.write_json(path, tampered)
+
+    assert receipts_cmd.verify(target=tmp_path, json_output=True) == 1
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["summary"]["mismatch"] == 1
+    problem = [item for item in payload["artifacts"] if item["status"] == "MISMATCH"][0]
+    assert problem["artifact_type"] == "work-verify-receipt"
+    assert problem["check"] == "receipt_sha256"
+
+
+def test_receipts_verify_reports_missing_when_referenced_log_is_deleted(tmp_path, capsys):
+    _init_git_repo(tmp_path)
+    assert (
+        work_cmd.verify_run(
+            target=tmp_path,
+            commands=["python3 -c \"print('ok')\""],
+            timeout=30,
+            json_output=True,
+        )
+        == 0
+    )
+    receipt = json.loads(capsys.readouterr().out)
+    run_dir = tmp_path / ".brigade" / "work" / "verify-runs" / receipt["run_id"]
+    (run_dir / "command-1-stdout.log").unlink()
+
+    assert receipts_cmd.verify(target=tmp_path, json_output=True) == 1
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["summary"]["missing"] == 1
+    problem = [item for item in payload["artifacts"] if item["status"] == "MISSING"][0]
+    assert problem["artifact_type"] == "work-verify-log"
+    assert problem["artifact_id"].endswith("command-1-stdout.log")
+
+
+def test_receipts_verify_reports_mismatch_when_middle_ledger_record_is_edited(tmp_path, capsys):
+    _append_outcome(tmp_path, "ref1")
+    _append_outcome(tmp_path, "ref2")
+    _append_outcome(tmp_path, "ref3")
+    path = tmp_path / "memory" / "outcome" / "records.jsonl"
+    rows = [json.loads(line) for line in path.read_text().splitlines()]
+    rows[1]["signal_value"] = -1
+    path.write_text("\n".join(json.dumps(row, sort_keys=True) for row in rows) + "\n")
+
+    assert receipts_cmd.verify(target=tmp_path, json_output=True) == 1
+    payload = json.loads(capsys.readouterr().out)
+
+    problem = [item for item in payload["artifacts"] if item["status"] == "MISMATCH"][0]
+    assert problem["artifact_type"] == "outcome-ledger-record"
+    assert problem["artifact_id"].endswith("records.jsonl:2")
+    assert problem["check"] == "digest"
+
+
+def test_receipts_verify_reports_mismatch_when_middle_ledger_record_is_deleted(tmp_path, capsys):
+    _append_outcome(tmp_path, "ref1")
+    _append_outcome(tmp_path, "ref2")
+    _append_outcome(tmp_path, "ref3")
+    path = tmp_path / "memory" / "outcome" / "records.jsonl"
+    rows = path.read_text().splitlines()
+    path.write_text(rows[0] + "\n" + rows[2] + "\n")
+
+    assert receipts_cmd.verify(target=tmp_path, json_output=True) == 1
+    payload = json.loads(capsys.readouterr().out)
+
+    problem = [item for item in payload["artifacts"] if item["status"] == "MISMATCH"][0]
+    assert problem["artifact_type"] == "outcome-ledger-record"
+    assert problem["artifact_id"].endswith("records.jsonl:2")
+    assert problem["check"] == "prev_digest"
+
+
+def test_receipts_verify_reports_legacy_and_exits_zero(tmp_path, capsys):
+    _write_digestless_work_receipt(tmp_path)
+    legacy = {
+        "artifact_id": "taste",
+        "artifact_kind": "skill",
+        "task_id": "legacy",
+        "source": "verify",
+        "signal_value": 1,
+        "evidence_ref": "legacy",
+        "ts": "2026-07-08T00:00:00+00:00",
+    }
+    path = tmp_path / "memory" / "outcome" / "records.jsonl"
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps(legacy, sort_keys=True) + "\n")
+
+    assert receipts_cmd.verify(target=tmp_path, json_output=False) == 0
+    out = capsys.readouterr().out
+
+    assert "legacy=2" in out
+    assert "LEGACY" in out
+
+
+def test_doctor_and_outcome_doctor_include_receipt_summary(tmp_path, capsys):
+    _init_git_repo(tmp_path)
+    assert (
+        work_cmd.verify_run(
+            target=tmp_path,
+            commands=["python3 -c \"print('ok')\""],
+            timeout=30,
+            json_output=True,
+        )
+        == 0
+    )
+    receipt = json.loads(capsys.readouterr().out)
+    path = tmp_path / ".brigade" / "work" / "verify-runs" / receipt["run_id"] / "receipt.json"
+    tampered = json.loads(path.read_text())
+    tampered["status"] = "failed"
+    localio.write_json(path, tampered)
+
+    assert cli.main(["doctor", "--target", str(tmp_path)]) == 1
+    doctor_out = capsys.readouterr().out
+    assert "receipts: verify" in doctor_out
+    assert "mismatch=1" in doctor_out
+
+    assert cli.main(["outcome", "doctor", "--target", str(tmp_path)]) == 0
+    outcome_out = capsys.readouterr().out
+    assert "outcome doctor:" in outcome_out
+    assert "mismatch=1" in outcome_out
+
+
+def test_receipts_verify_reports_mismatch_when_referenced_log_is_edited(tmp_path, capsys):
+    _init_git_repo(tmp_path)
+    assert (
+        work_cmd.verify_run(
+            target=tmp_path,
+            commands=["python3 -c \"print('ok')\""],
+            timeout=30,
+            json_output=True,
+        )
+        == 0
+    )
+    receipt = json.loads(capsys.readouterr().out)
+    run_dir = tmp_path / ".brigade" / "work" / "verify-runs" / receipt["run_id"]
+    log_path = run_dir / "command-1-stdout.log"
+    log_path.write_text(log_path.read_text() + "tampered evidence\n")
+
+    assert receipts_cmd.verify(target=tmp_path, json_output=True) == 1
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["summary"]["mismatch"] == 1
+    problem = [item for item in payload["artifacts"] if item["status"] == "MISMATCH"][0]
+    assert problem["artifact_type"] == "work-verify-log"
+    assert problem["artifact_id"].endswith("command-1-stdout.log")
+    assert problem["check"] == "log_sha256"

--- a/tests/test_runbook_cmd.py
+++ b/tests/test_runbook_cmd.py
@@ -6,7 +6,7 @@ import os
 import shutil
 from pathlib import Path
 
-from brigade import cli, runbook_cmd
+from brigade import cli, localio, runbook_cmd
 
 
 def _sha256(path):
@@ -377,8 +377,30 @@ def test_runbook_unpinned_receipt_keys_unchanged_and_no_pin_checks(tmp_path, cap
         "start_index",
         "steps",
         "receipt_path",
+        "digests",
     }
     assert "pin_checks" not in receipt
+
+
+def test_runbook_receipt_digests_recompute_from_payload_and_step_logs(tmp_path, capsys):
+    runbook = _write_runbook(tmp_path / "runbook.json")
+
+    assert runbook_cmd.run(target=tmp_path, runbook=runbook, approved=True, json_output=True) == 0
+    receipt = json.loads(capsys.readouterr().out)
+    digests = receipt["digests"]
+    run_dir = Path(receipt["receipt_path"]).parent
+
+    assert digests["algorithm"] == "sha256"
+    assert digests["receipt_sha256"] == localio.canonical_json_digest(receipt, exclude_keys={"digests"})
+    assert digests["logs"] == {
+        "01-hello.stderr.log": localio.file_sha256(run_dir / "01-hello.stderr.log"),
+        "01-hello.stdout.log": localio.file_sha256(run_dir / "01-hello.stdout.log"),
+        "02-again.stderr.log": localio.file_sha256(run_dir / "02-again.stderr.log"),
+        "02-again.stdout.log": localio.file_sha256(run_dir / "02-again.stdout.log"),
+    }
+
+    stored = json.loads((run_dir / "receipt.json").read_text())
+    assert stored["digests"] == digests
 
 
 def test_runbook_bash_script_step_plan_pins_only_argv0_interpreter(tmp_path, capsys):

--- a/tests/test_work_cmd_verification.py
+++ b/tests/test_work_cmd_verification.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from brigade import cli
+from brigade import localio
 from brigade import work_cmd
 
 from tests.work_cmd_test_helpers import (
@@ -200,6 +201,33 @@ def test_work_verify_plan_run_list_show(tmp_path, capsys):
     out = capsys.readouterr().out
     assert f"work verify run: {receipt['run_id']}" in out
     assert "python3 -c" in out
+
+
+def test_work_verify_receipt_digests_recompute_from_payload_and_logs(tmp_path, capsys):
+    _init_git_repo(tmp_path)
+
+    assert (
+        work_cmd.verify_run(
+            target=tmp_path,
+            commands=["python3 -c \"print('ok')\""],
+            timeout=30,
+            json_output=True,
+        )
+        == 0
+    )
+    receipt = json.loads(capsys.readouterr().out)
+    digests = receipt["digests"]
+    run_dir = Path(receipt["path"])
+
+    assert digests["algorithm"] == "sha256"
+    assert digests["receipt_sha256"] == localio.canonical_json_digest(receipt, exclude_keys={"digests"})
+    assert digests["logs"] == {
+        "command-1-stderr.log": localio.file_sha256(run_dir / "command-1-stderr.log"),
+        "command-1-stdout.log": localio.file_sha256(run_dir / "command-1-stdout.log"),
+    }
+
+    stored = json.loads((run_dir / "receipt.json").read_text())
+    assert stored["digests"] == digests
 
 
 def test_work_closeout_writes_ready_receipt(tmp_path, capsys):


### PR DESCRIPTION
Closes #147.

## What this adds

- **Receipt digests.** Verify receipts (`.brigade/work/verify-runs/*/receipt.json`) and runbook receipts (`.brigade/runbooks/runs/*/receipt.json`) gain a `digests` block added last: `receipt_sha256` over the canonical sorted-key payload excluding the block itself, plus a sha256 per referenced stdout/stderr log so the receipt is bound to its evidence files. Key exclusion applies at the top level only; a nested key named `digest`/`digests` is content and stays inside the hash, so edits to it are detectable.
- **Hash-chained outcome ledger.** Each record appended to `memory/outcome/records.jsonl` carries `prev_digest` and `digest`, with `prev_digest` included in the hashed content, so an edited or deleted middle record breaks the chain at a named link. Legacy records without digests remain readable everywhere.
- **`brigade receipts verify [--target .] [--json]`** walks all three artifact families, recomputes digests, and reports `OK | MISMATCH | MISSING | legacy` per artifact. Exit is nonzero on any MISMATCH or MISSING; legacy alone exits 0, so pre-existing artifacts are never failures. One-line summaries are wired into `brigade doctor` (non-fatal) and `outcome doctor`.
- **Honest docs.** The `outcome capture` docstring claimed a "signed record" that never existed; it and the receipt sections of `SECURITY.md` / `docs/technical-guide.md` now describe tamper-evident digests, state plainly what this does not defend against (an attacker who rewrites both a receipt and its digests block, or re-chains the ledger tail), and name the optional signing tier (`signature`, `key_id` schema room) as future work. `docs/command-inventory.md` regenerated for the new core command group.

## Verification

- `python3 -m pytest -q`: 1510 passed, 1 skipped (1496 baseline plus 14 new tests), via `brigade work verify run`, receipt `20260708-063548-work-verify-dd7389`.
- `pipx run ruff check .` and `pipx run ruff format --check .`: clean, same receipt.
- `python -m mypy`: no issues in 181 source files.
- Live tamper drill on a scratch target: fresh `receipts verify` exits 0 (`checked=3 ok=3`); hand-editing the receipt's status field flips MISMATCH with exit 1 naming the artifact and check.
- Tests cover: digest presence and recomputation for verify and runbook receipts, ledger chain linking across appends, fresh-target verify, edited receipt → MISMATCH, edited log → MISMATCH, deleted log → MISSING, edited middle ledger record → MISMATCH at the broken link, legacy artifacts → `legacy` with exit 0, doctor summaries, and top-level-only digest key exclusion (a nested `digest` key must affect the hash).