### PR TITLE
feat(receipts): attach code-graph deltas to verify and run receipts

### DIFF
--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -959,6 +959,20 @@ brigade security scan --target . --import-findings
 
 When `.graphtrail/graphtrail.db` is present, `brigade run` can attach bounded GraphTrail context. If pending upstream drift state is available, it can also attach a drift impact brief. `run.json` records the shared brief budget, attached brief names, byte counts, and truncation flags.
 
+### Code-graph delta receipts
+
+Work verification and non-read-only aboyeur runs can also record a GraphTrail delta receipt. The flow is: run `graphtrail sync`, take a sqlite backup snapshot of `.graphtrail/graphtrail.db`, run the work, run `graphtrail sync` again, diff the live graph against the snapshot, write `graph-delta.json`, and store a compact `code_graph_delta` summary in the receipt or run artifacts.
+
+Delta capture is fail-open. Missing GraphTrail, sync failures, malformed diff JSON, and snapshot problems are recorded as status data instead of failing the run. `--no-code-graph`, read-only runs, and dry runs record skip statuses and do not run GraphTrail sync.
+
+Snapshots use sqlite backup instead of copying the db file directly. That keeps the baseline safe when the database is in WAL mode or GraphTrail is writing adjacent sqlite state. After the diff, Brigade deletes the temporary snapshot and records SHA-256 attestations for the before snapshot, after database, diff stdout, sidecar, and receipt log digests when those files exist.
+
+GraphTrail raw diff counts are preserved under `raw_counts`. Brigade also computes a line-insensitive edge churn value by stripping line and range fields from added and removed edges before pairing them, so pure line-number movement is less noisy than raw edge add/remove totals.
+
+`brigade receipts verify` includes `graph-delta.json` in the existing log digest map when a verification receipt wrote the sidecar. Editing or deleting that sidecar after the run is treated like editing stdout or stderr logs.
+
+Known blind spots remain GraphTrail blind spots: unsupported languages, parse failures, dynamic dispatch, generated code, import-time side effects, reflection, and runtime wiring can be missed or approximated. A clean delta means the captured static graph did not report meaningful churn, not that the behavior is unchanged.
+
 Use `--handoff` to bridge a completed run back into the memory system.
 
 Handoff behavior:

--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -16,6 +16,7 @@ from uuid import uuid4
 
 from . import agents
 from . import codex_appserver
+from . import graphtrail_delta
 from . import proc, runguard
 from . import run_control
 from .roster import Agent, Roster, is_cli_allowed, timeout_for, workers
@@ -1003,6 +1004,43 @@ def _agent_result_payload(result: agents.AgentResult) -> dict[str, object]:
     }
 
 
+def _code_graph_delta_skip(status: str) -> dict[str, object]:
+    reasons = {
+        "disabled": "disabled",
+        "skipped_read_only": "read-only run",
+        "skipped_dry_run": "dry run",
+        "unavailable": "cwd not set",
+    }
+    reason = reasons.get(status, status.replace("_", " "))
+    return {
+        "status": status,
+        "ok": False,
+        "summary": f"code graph delta skipped: {reason}",
+        "raw_counts": {},
+        "edge_churn": 0,
+        "changed_symbols": [],
+        "changed_symbol_count": 0,
+    }
+
+
+def _initial_code_graph_delta(
+    *,
+    code_graph_enabled: bool,
+    dry_run: bool,
+    read_only: bool,
+    cwd: Path | None,
+) -> dict[str, object] | None:
+    if not code_graph_enabled:
+        return _code_graph_delta_skip("disabled")
+    if read_only:
+        return _code_graph_delta_skip("skipped_read_only")
+    if dry_run:
+        return _code_graph_delta_skip("skipped_dry_run")
+    if cwd is None:
+        return _code_graph_delta_skip("unavailable")
+    return None
+
+
 def _parse_iso_datetime(value: object) -> datetime | None:
     if not isinstance(value, str) or not value.strip():
         return None
@@ -1173,6 +1211,12 @@ def _ground_truth_facts(ground_truth: dict[str, object] | None) -> str:
         lines.append(f"- verify_receipts: {len(verify_receipts)} latest={latest_run} status={latest_status}")
     else:
         lines.append("- verify_receipts: 0")
+    code_graph_delta = ground_truth.get("code_graph_delta")
+    if isinstance(code_graph_delta, dict):
+        summary = _one_line(str(code_graph_delta.get("summary") or code_graph_delta.get("status") or "unknown"))
+        if len(summary) > 240:
+            summary = summary[:237] + "..."
+        lines.append(f"- code_graph_delta: {summary}")
     return "\n".join(lines)
 
 
@@ -1234,6 +1278,7 @@ def _run_payload(
     brief_set: BriefSet | None = None,
     codex_transport: str | None = None,
     control_socket: Path | None = None,
+    code_graph_delta: dict[str, object] | None = None,
 ) -> dict[str, object]:
     payload: dict[str, object] = {
         "task": task,
@@ -1257,6 +1302,8 @@ def _run_payload(
             "attached": list(brief_set.attached) if brief_set is not None else [],
         },
     }
+    if code_graph_delta is not None:
+        payload["code_graph_delta"] = code_graph_delta
     if finished_at is not None:
         payload["finished_at"] = _utc_iso(finished_at)
         payload["duration_seconds"] = max(0.0, round((finished_at - started_at).total_seconds(), 3))
@@ -1303,8 +1350,18 @@ def run(
     brief_set = arbitrate_briefs(task, code_graph=code_graph, drift_impact=drift_impact)
     code_graph = brief_set.code_graph
     drift_impact = brief_set.drift_impact
+    code_graph_delta = _initial_code_graph_delta(
+        code_graph_enabled=code_graph_enabled,
+        dry_run=dry_run,
+        read_only=read_only,
+        cwd=cwd,
+    )
+    code_graph_delta_before: dict[str, object] | None = None
     if output_dir is not None:
         output_dir.mkdir(parents=True, exist_ok=True)
+        if code_graph_delta is None and cwd is not None:
+            code_graph_delta_before = graphtrail_delta.capture_before(cwd, output_dir)
+            code_graph_delta = code_graph_delta_before
         _write_json(output_dir / "roster.json", _roster_payload(roster))
         _write_json(
             output_dir / "run.json",
@@ -1321,6 +1378,7 @@ def run(
                 drift_impact=drift_impact,
                 brief_set=brief_set,
                 codex_transport=transport_for_payload,
+                code_graph_delta=code_graph_delta,
             ),
         )
 
@@ -1360,6 +1418,7 @@ def run(
                     brief_set=brief_set,
                     codex_transport=transport_for_payload,
                     control_socket=control_socket,
+                    code_graph_delta=code_graph_delta,
                 ),
             )
         print(f"error: {exc}", file=sys.stderr)
@@ -1389,6 +1448,7 @@ def run(
                     drift_impact=drift_impact,
                     brief_set=brief_set,
                     codex_transport=transport_for_payload,
+                    code_graph_delta=code_graph_delta,
                 ),
             )
         print(json.dumps(payload, indent=2))
@@ -1443,6 +1503,7 @@ def run(
                 brief_set=brief_set,
                 codex_transport=transport_for_payload,
                 control_socket=control_socket,
+                code_graph_delta=code_graph_delta,
             ),
         )
 
@@ -1466,7 +1527,11 @@ def run(
             control_server.close()
         if appserver is not None:
             appserver.close()
+    if output_dir is not None and code_graph_delta_before is not None and cwd is not None:
+        code_graph_delta = graphtrail_delta.capture_after_and_diff(cwd, output_dir, code_graph_delta_before)
     ground_truth = build_ground_truth(cwd, started_at)
+    if code_graph_delta is not None:
+        ground_truth["code_graph_delta"] = code_graph_delta
     if output_dir is not None:
         _write_json(
             output_dir / "worker-results.json",
@@ -1521,6 +1586,7 @@ def run(
                     drift_impact=drift_impact,
                     brief_set=brief_set,
                     codex_transport=transport_for_payload,
+                    code_graph_delta=code_graph_delta,
                 ),
             )
         print(f"error: orchestrator failed during synthesis: {final.detail}", file=sys.stderr)
@@ -1545,6 +1611,7 @@ def run(
                 brief_set=brief_set,
                 codex_transport=transport_for_payload,
                 control_socket=control_socket,
+                code_graph_delta=code_graph_delta,
             ),
         )
     if handoff_inbox is not None:
@@ -1581,6 +1648,7 @@ def run(
                         brief_set=brief_set,
                         codex_transport=transport_for_payload,
                         control_socket=control_socket,
+                        code_graph_delta=code_graph_delta,
                     ),
                 )
             print(f"error: {detail}", file=sys.stderr)
@@ -1607,6 +1675,7 @@ def run(
                     brief_set=brief_set,
                     codex_transport=transport_for_payload,
                     control_socket=control_socket,
+                    code_graph_delta=code_graph_delta,
                 ),
             )
     print(final.text)

--- a/src/brigade/graphtrail_delta.py
+++ b/src/brigade/graphtrail_delta.py
@@ -1,0 +1,458 @@
+"""Fail-open GraphTrail delta snapshots for verification receipts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import sqlite3
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+SNAPSHOT_NAME = "graphtrail-before.db"
+SNAPSHOT_AFTER_NAME = "graphtrail-after.db"
+SIDECAR_NAME = "graph-delta.json"
+CHANGED_SYMBOL_LIMIT = 20
+LINE_KEYS = {
+    "line",
+    "line_number",
+    "lineno",
+    "start_line",
+    "end_line",
+    "start",
+    "end",
+    "span",
+    "range",
+}
+
+
+def capture_before(target: Path, run_dir: Path, *, timeout: float = 10.0) -> dict[str, Any]:
+    """Sync GraphTrail and snapshot its sqlite DB; return status data, never raise."""
+    try:
+        target = target.expanduser().resolve()
+        run_dir = run_dir.expanduser().resolve()
+        binary = _graphtrail_bin()
+        if binary is None:
+            return _status("unavailable", "code graph delta unavailable: graphtrail binary not found")
+        db_path = target / ".graphtrail" / "graphtrail.db"
+        sync = _run_graphtrail(binary, db_path, "sync", timeout=timeout)
+        if sync["returncode"] != 0:
+            return _status(
+                "sync_failed",
+                f"code graph delta unavailable: graphtrail sync failed ({sync['returncode']})",
+                binary=binary,
+                db_path=str(db_path),
+                sync=sync,
+            )
+        if not db_path.is_file():
+            return _status(
+                "no_database",
+                "code graph delta unavailable: graphtrail sync did not create a database",
+                binary=binary,
+                db_path=str(db_path),
+                sync=sync,
+            )
+        snapshot_path = run_dir / SNAPSHOT_NAME
+        _backup_sqlite(db_path, snapshot_path)
+        return {
+            "ok": True,
+            "status": "captured",
+            "summary": "code graph baseline captured",
+            "binary": binary,
+            "db_path": str(db_path),
+            "before_snapshot_path": str(snapshot_path),
+            "before_snapshot_sha256": _file_sha256(snapshot_path),
+            "sync": sync,
+        }
+    except BaseException as exc:
+        return _status("capture_failed", f"code graph delta unavailable: {type(exc).__name__}: {exc}")
+
+
+def capture_after_and_diff(
+    target: Path,
+    run_dir: Path,
+    before: dict[str, Any] | None,
+    *,
+    timeout: float = 10.0,
+) -> dict[str, Any]:
+    """Sync after verification, diff against the snapshot, write sidecar when available."""
+    try:
+        target = target.expanduser().resolve()
+        run_dir = run_dir.expanduser().resolve()
+        before = before if isinstance(before, dict) else {}
+        if before.get("status") == "unavailable":
+            return _compact(_status("unavailable", str(before.get("summary") or "code graph delta unavailable")))
+        if before.get("ok") is not True:
+            payload = _failure_payload(target, before, str(before.get("status") or "capture_failed"))
+            return _write_and_compact(run_dir, payload)
+
+        binary = str(before.get("binary") or "")
+        db_path = Path(str(before.get("db_path") or target / ".graphtrail" / "graphtrail.db"))
+        snapshot_path = Path(str(before.get("before_snapshot_path") or run_dir / SNAPSHOT_NAME))
+        sync = _run_graphtrail(binary, db_path, "sync", timeout=timeout)
+        if sync["returncode"] != 0:
+            payload = _failure_payload(
+                target,
+                before,
+                "sync_failed",
+                summary=f"code graph delta unavailable: graphtrail sync failed ({sync['returncode']})",
+                after_sync=sync,
+            )
+            return _write_and_compact(run_dir, payload, snapshot_path=snapshot_path)
+
+        after_snapshot_path = run_dir / SNAPSHOT_AFTER_NAME
+        _backup_sqlite(db_path, after_snapshot_path)
+        after_snapshot_sha256 = _file_sha256(after_snapshot_path)
+        diff = _run_graphtrail(
+            binary,
+            db_path,
+            "diff",
+            "--before",
+            str(snapshot_path),
+            "--after",
+            str(after_snapshot_path),
+            timeout=timeout,
+            json_output=True,
+        )
+        if diff["returncode"] != 0:
+            payload = _failure_payload(
+                target,
+                before,
+                "diff_failed",
+                summary=f"code graph delta unavailable: graphtrail diff failed ({diff['returncode']})",
+                after_sync=sync,
+                diff=diff,
+            )
+            return _write_and_compact(
+                run_dir, payload, snapshot_path=snapshot_path, after_snapshot_path=after_snapshot_path
+            )
+        try:
+            diff_payload = json.loads(diff["stdout"])
+        except json.JSONDecodeError as exc:
+            payload = _failure_payload(
+                target,
+                before,
+                "diff_malformed",
+                summary=f"code graph delta unavailable: graphtrail diff returned malformed JSON: {exc.msg}",
+                after_sync=sync,
+                diff=diff,
+            )
+            return _write_and_compact(
+                run_dir, payload, snapshot_path=snapshot_path, after_snapshot_path=after_snapshot_path
+            )
+        if not isinstance(diff_payload, dict):
+            payload = _failure_payload(
+                target,
+                before,
+                "diff_malformed",
+                summary="code graph delta unavailable: graphtrail diff JSON is not an object",
+                after_sync=sync,
+                diff=diff,
+            )
+            return _write_and_compact(
+                run_dir, payload, snapshot_path=snapshot_path, after_snapshot_path=after_snapshot_path
+            )
+
+        changed_symbols = _changed_symbols(diff_payload)
+        # graphtrail names its counts block "summary" (locked by the diff golden fixture).
+        counts_value = diff_payload.get("summary")
+        raw_counts: dict[str, Any] = counts_value if isinstance(counts_value, dict) else {}
+        edge_churn = _edge_churn(diff_payload)
+        payload = {
+            "ok": True,
+            "status": "ok",
+            "target": str(target),
+            "summary": _summary("ok", raw_counts, edge_churn, len(changed_symbols)),
+            "raw_counts": raw_counts,
+            "changed_symbols": changed_symbols,
+            "changed_symbol_count": len(changed_symbols),
+            "changed_symbols_truncated": _symbol_count(diff_payload) > CHANGED_SYMBOL_LIMIT,
+            "edge_churn": edge_churn,
+            "line_insensitive_edge_churn": edge_churn,
+            "before_snapshot_path": str(snapshot_path),
+            "db_path": str(db_path),
+            "commands": {"before_sync": before.get("sync"), "after_sync": sync, "diff": diff},
+            "attestations": {
+                "before_snapshot_sha256": before.get("before_snapshot_sha256"),
+                "after_snapshot_sha256": after_snapshot_sha256,
+                "diff_stdout_sha256": _sha256_text(diff["stdout"]),
+            },
+        }
+        return _write_and_compact(
+            run_dir, payload, snapshot_path=snapshot_path, after_snapshot_path=after_snapshot_path
+        )
+    except BaseException as exc:
+        payload = _status("capture_failed", f"code graph delta unavailable: {type(exc).__name__}: {exc}")
+        try:
+            return _write_and_compact(run_dir, payload)
+        except BaseException:
+            return _compact(payload)
+
+
+def _compact_summary(delta: dict[str, Any] | None) -> str:
+    """Return a one-line summary for markdown; never raise."""
+    try:
+        if not isinstance(delta, dict):
+            return "code graph delta unavailable"
+        return str(delta.get("summary") or _summary(str(delta.get("status") or "unknown"), {}, 0, 0))
+    except BaseException:
+        return "code graph delta unavailable"
+
+
+def _graphtrail_bin() -> str | None:
+    override = os.environ.get("GRAPHTRAIL_BIN")
+    if override and Path(override).is_file():
+        return override
+    found = shutil.which("graphtrail")
+    if found:
+        return found
+    fallback = Path.home() / ".cargo" / "bin" / "graphtrail"
+    return str(fallback) if fallback.is_file() else None
+
+
+def _run_graphtrail(
+    binary: str, db_path: Path, command: str, *extra: str, timeout: float, json_output: bool = False
+) -> dict[str, Any]:
+    # `graphtrail sync` rejects --json; only diff-style subcommands accept it.
+    argv = [binary, "--db", str(db_path), command, *extra]
+    if json_output:
+        argv.append("--json")
+    try:
+        completed = subprocess.run(
+            argv,
+            cwd=db_path.parent.parent if db_path.parent.name == ".graphtrail" else None,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            stdin=subprocess.DEVNULL,
+            text=True,
+            timeout=timeout,
+        )
+        return {
+            "argv": argv,
+            "returncode": completed.returncode,
+            "stdout": completed.stdout or "",
+            "stderr": completed.stderr or "",
+            "timed_out": False,
+        }
+    except FileNotFoundError:
+        return {"argv": argv, "returncode": 127, "stdout": "", "stderr": "command not found", "timed_out": False}
+    except subprocess.TimeoutExpired as exc:
+        return {
+            "argv": argv,
+            "returncode": 124,
+            "stdout": exc.stdout if isinstance(exc.stdout, str) else "",
+            "stderr": exc.stderr if isinstance(exc.stderr, str) else f"timeout after {timeout:g}s",
+            "timed_out": True,
+        }
+
+
+def _backup_sqlite(source: Path, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.unlink(missing_ok=True)
+    source_uri = f"file:{source}?mode=ro"
+    with sqlite3.connect(source_uri, uri=True) as source_conn:
+        with sqlite3.connect(destination) as dest_conn:
+            source_conn.backup(dest_conn)
+
+
+def _failure_payload(
+    target: Path,
+    before: dict[str, Any],
+    status: str,
+    *,
+    summary: str | None = None,
+    after_sync: dict[str, Any] | None = None,
+    diff: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "ok": False,
+        "status": status,
+        "target": str(target),
+        "summary": summary or str(before.get("summary") or f"code graph delta unavailable: {status}"),
+        "before_snapshot_path": before.get("before_snapshot_path"),
+        "db_path": before.get("db_path"),
+        "raw_counts": {},
+        "changed_symbols": [],
+        "changed_symbol_count": 0,
+        "edge_churn": 0,
+        "commands": {"before_sync": before.get("sync"), "after_sync": after_sync, "diff": diff},
+        "attestations": {
+            "before_snapshot_sha256": before.get("before_snapshot_sha256"),
+            "after_snapshot_sha256": None,
+            "diff_stdout_sha256": _sha256_text(diff.get("stdout", "")) if isinstance(diff, dict) else None,
+        },
+    }
+
+
+def _write_and_compact(
+    run_dir: Path,
+    payload: dict[str, Any],
+    *,
+    snapshot_path: Path | None = None,
+    after_snapshot_path: Path | None = None,
+) -> dict[str, Any]:
+    deleted = _delete_snapshot(snapshot_path or _payload_snapshot_path(payload))
+    deleted = _delete_snapshot(after_snapshot_path) and deleted if after_snapshot_path else deleted
+    payload["snapshot_deleted"] = deleted
+    sidecar = run_dir / SIDECAR_NAME
+    _write_json(sidecar, payload)
+    compact = _compact(payload)
+    compact["sidecar_path"] = str(sidecar)
+    compact["sidecar_sha256"] = _file_sha256(sidecar)
+    return compact
+
+
+def _compact(payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "status": payload.get("status", "unknown"),
+        "ok": bool(payload.get("ok")),
+        "summary": _compact_summary(payload),
+        "raw_counts": payload.get("raw_counts") if isinstance(payload.get("raw_counts"), dict) else {},
+        "edge_churn": int(payload.get("edge_churn") or 0),
+        "changed_symbols": payload.get("changed_symbols") if isinstance(payload.get("changed_symbols"), list) else [],
+        "changed_symbol_count": int(payload.get("changed_symbol_count") or 0),
+    }
+
+
+def _status(status: str, summary: str, **extra: Any) -> dict[str, Any]:
+    payload = {"ok": False, "status": status, "summary": summary}
+    payload.update(extra)
+    return payload
+
+
+def _summary(status: str, counts: dict[str, Any], edge_churn: int, changed_symbol_count: int) -> str:
+    if status != "ok":
+        return f"code graph delta unavailable: {status}"
+    parts = [
+        "code graph delta: ok",
+        f"changed_symbols={changed_symbol_count}",
+        f"edge_churn={edge_churn}",
+    ]
+    for key in ("added_nodes", "removed_nodes", "changed_nodes", "added_edges", "removed_edges"):
+        value = counts.get(key)
+        if isinstance(value, int):
+            parts.append(f"{key}={value}")
+    return " ".join(parts)
+
+
+def _changed_symbols(payload: dict[str, Any]) -> list[str]:
+    symbols: list[str] = []
+    for value in _symbol_values(payload):
+        if value not in symbols:
+            symbols.append(value)
+        if len(symbols) >= CHANGED_SYMBOL_LIMIT:
+            break
+    return symbols
+
+
+def _symbol_count(payload: dict[str, Any]) -> int:
+    seen: set[str] = set()
+    for value in _symbol_values(payload):
+        seen.add(value)
+    return len(seen)
+
+
+def _symbol_values(payload: dict[str, Any]) -> list[str]:
+    # graphtrail diff emits changed/added/removed node lists of DiffNode objects
+    # keyed by qualified_name (locked by the diff golden fixture).
+    result: list[str] = []
+    for key in ("changed_nodes", "added_nodes", "removed_nodes"):
+        values = payload.get(key)
+        if not isinstance(values, list):
+            continue
+        for item in values:
+            if isinstance(item, str):
+                result.append(item)
+            elif isinstance(item, dict):
+                name = item.get("qualified_name") or item.get("name") or item.get("symbol")
+                if isinstance(name, str):
+                    result.append(name)
+    return result
+
+
+def _edge_churn(payload: dict[str, Any]) -> int:
+    added_value = payload.get("added_edges")
+    removed_value = payload.get("removed_edges")
+    if not isinstance(added_value, list) and not isinstance(removed_value, list):
+        return _count_from_payload(payload, "added_edges") + _count_from_payload(payload, "removed_edges")
+    added = _edge_fingerprints(added_value)
+    removed = _edge_fingerprints(removed_value)
+    for fingerprint in list(added):
+        pairs = min(added.get(fingerprint, 0), removed.get(fingerprint, 0))
+        if pairs:
+            added[fingerprint] -= pairs
+            removed[fingerprint] -= pairs
+    return sum(max(0, count) for count in added.values()) + sum(max(0, count) for count in removed.values())
+
+
+def _edge_fingerprints(value: Any) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    if not isinstance(value, list):
+        return counts
+    for item in value:
+        fingerprint = json.dumps(_strip_line_keys(item), sort_keys=True, separators=(",", ":"), default=str)
+        counts[fingerprint] = counts.get(fingerprint, 0) + 1
+    return counts
+
+
+def _strip_line_keys(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _strip_line_keys(item) for key, item in value.items() if key not in LINE_KEYS}
+    if isinstance(value, list):
+        return [_strip_line_keys(item) for item in value]
+    return value
+
+
+def _count_from_payload(payload: dict[str, Any], key: str) -> int:
+    counts = payload.get("summary")
+    if isinstance(counts, dict) and isinstance(counts.get(key), int):
+        return int(counts[key])
+    value = payload.get(key)
+    return int(value) if isinstance(value, int) else 0
+
+
+def _payload_snapshot_path(payload: dict[str, Any]) -> Path | None:
+    value = payload.get("before_snapshot_path")
+    return Path(value) if isinstance(value, str) and value else None
+
+
+def _delete_snapshot(path: Path | None) -> bool:
+    if path is None:
+        return False
+    try:
+        path.unlink(missing_ok=True)
+        return not path.exists()
+    except OSError:
+        return False
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp")
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, path)
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()

--- a/src/brigade/work_cmd/verification.py
+++ b/src/brigade/work_cmd/verification.py
@@ -11,7 +11,7 @@ import sys
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
-from .. import localio
+from .. import graphtrail_delta, localio
 from . import constants, helpers, ledger as ledger_mod
 from . import reviews as reviews_mod
 from . import scanners as scanners_mod
@@ -219,6 +219,9 @@ def _write_verify_markdown(run_dir: Path, receipt: dict[str, Any]) -> None:
         lines.append(f"- Session: `{session.get('id')}` status={session.get('status')}")
     if latest_verify:
         lines.append(f"- Previous verification: `{latest_verify.get('run_id')}` status={latest_verify.get('status')}")
+    delta = receipt.get("code_graph_delta")
+    if isinstance(delta, dict):
+        lines.append(f"- Code graph delta: {delta.get('summary') or 'code graph delta unavailable'}")
     (run_dir / "summary.md").write_text("\n".join(lines) + "\n")
 
 
@@ -227,6 +230,7 @@ def _run_verify_commands(target: Path, commands: list[str], timeout: int) -> tup
     run_id = f"{started.strftime('%Y%m%d-%H%M%S')}-work-verify-{uuid4().hex[:6]}"
     run_dir = helpers._verify_runs_root(target) / run_id
     run_dir.mkdir(parents=True, exist_ok=False)
+    graph_delta_before = graphtrail_delta.capture_before(target, run_dir)
     receipt: dict[str, Any] = {
         "run_id": run_id,
         "target": str(target),
@@ -325,6 +329,7 @@ def _run_verify_commands(target: Path, commands: list[str], timeout: int) -> tup
             )
             rc = 124
         receipt["commands"].append(command_result)
+    receipt["code_graph_delta"] = graphtrail_delta.capture_after_and_diff(target, run_dir, graph_delta_before)
     completed_at = helpers._now()
     receipt["completed_at"] = completed_at.isoformat()
     receipt["duration_seconds"] = (completed_at - started).total_seconds()
@@ -352,6 +357,17 @@ def _run_verify_commands(target: Path, commands: list[str], timeout: int) -> tup
             except ValueError:
                 log_name = path.name
             log_digests[log_name] = localio.file_sha256(path)
+    delta = receipt.get("code_graph_delta")
+    if isinstance(delta, dict):
+        sidecar_value = delta.get("sidecar_path")
+        if isinstance(sidecar_value, str) and sidecar_value:
+            sidecar_path = Path(sidecar_value)
+            if sidecar_path.is_file():
+                try:
+                    log_name = str(sidecar_path.relative_to(run_dir))
+                except ValueError:
+                    log_name = sidecar_path.name
+                log_digests[log_name] = localio.file_sha256(sidecar_path)
     receipt["digests"] = {
         "algorithm": "sha256",
         "logs": dict(sorted(log_digests.items())),

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -540,6 +540,7 @@ def test_run_json_records_disabled_code_graph(monkeypatch, tmp_path):
         "attached": False,
         "bytes": 0,
     }
+    assert json.loads((output_dir / "run.json").read_text())["code_graph_delta"]["status"] == "disabled"
 
 
 def test_assignment_payload_serializes_stage():
@@ -563,6 +564,40 @@ def test_run_dry_run_stops_after_plan(monkeypatch, capsys):
     assert rc == 0
     assert "implement it" in out
     assert len(calls) == 1
+
+
+def test_run_dry_run_records_code_graph_delta_skip_without_graphtrail(monkeypatch, tmp_path):
+    def fake_run_agent(cli_ref, prompt, timeout=600.0, cwd=None, read_only=False):
+        return agents.AgentResult(
+            text=json.dumps({"assignments": [{"worker": "coder", "task": "implement it"}]}),
+            ok=True,
+        )
+
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+    monkeypatch.setattr(
+        aboyeur.graphtrail_delta,
+        "capture_before",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("no graphtrail sync")),
+    )
+    monkeypatch.setattr(
+        aboyeur.graphtrail_delta,
+        "capture_after_and_diff",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("no graphtrail sync")),
+    )
+
+    output_dir = tmp_path / "run"
+    assert aboyeur.run("build feature", _roster(), dry_run=True, output_dir=output_dir) == 0
+
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["code_graph_delta"] == {
+        "status": "skipped_dry_run",
+        "ok": False,
+        "summary": "code graph delta skipped: dry run",
+        "raw_counts": {},
+        "edge_churn": 0,
+        "changed_symbols": [],
+        "changed_symbol_count": 0,
+    }
 
 
 def test_run_dispatches_and_synthesizes(monkeypatch, capsys):
@@ -701,6 +736,39 @@ def test_read_only_mode_is_in_all_prompts_and_artifacts(monkeypatch, tmp_path):
     assert all("Do not modify files" in prompt for _, prompt, _ in calls)
     assert all(read_only for _, _, read_only in calls)
     assert json.loads((output_dir / "run.json").read_text())["read_only"] is True
+    assert json.loads((output_dir / "run.json").read_text())["code_graph_delta"]["status"] == "skipped_read_only"
+
+
+def test_read_only_mode_skips_code_graph_delta_without_graphtrail(monkeypatch, tmp_path):
+    def fake_run_agent(cli_ref, prompt, timeout=600.0, cwd=None, read_only=False):
+        if "assignments" in prompt:
+            return agents.AgentResult(
+                text=json.dumps({"assignments": [{"worker": "coder", "task": "inspect it"}]}),
+                ok=True,
+            )
+        if cli_ref == "ollama:llama3.3":
+            return agents.AgentResult(text="worker output", ok=True)
+        return agents.AgentResult(text="final answer", ok=True)
+
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+    monkeypatch.setattr(
+        aboyeur.graphtrail_delta,
+        "capture_before",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("no graphtrail sync")),
+    )
+    monkeypatch.setattr(
+        aboyeur.graphtrail_delta,
+        "capture_after_and_diff",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("no graphtrail sync")),
+    )
+
+    output_dir = tmp_path / "run"
+    assert aboyeur.run("inspect feature", _roster(), output_dir=output_dir, read_only=True) == 0
+
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["code_graph_delta"]["status"] == "skipped_read_only"
+    ground_truth = json.loads((output_dir / "worker-results.json").read_text())["ground_truth"]
+    assert ground_truth["code_graph_delta"]["status"] == "skipped_read_only"
 
 
 def test_prompt_read_only_can_disable_native_sandbox(monkeypatch):
@@ -861,6 +929,63 @@ def test_run_writes_artifacts(monkeypatch, tmp_path):
     assert "Brigade-computed facts:" in calls[-1][1]
     assert "tracked.txt" in calls[-1][1]
     assert {call[2] for call in calls} == {run_cwd}
+
+
+def test_run_writes_code_graph_delta_to_artifacts_and_synthesis(monkeypatch, tmp_path):
+    calls = []
+    before_payload = {"ok": True, "status": "captured", "summary": "before captured"}
+    after_payload = {
+        "status": "ok",
+        "ok": True,
+        "summary": "code graph delta: ok changed_symbols=1 edge_churn=2 edges_added=3",
+        "raw_counts": {"edges_added": 3},
+        "edge_churn": 2,
+        "changed_symbols": ["brigade.aboyeur.run"],
+        "changed_symbol_count": 1,
+    }
+
+    def fake_run_agent(cli_ref, prompt, timeout=600.0, cwd=None, read_only=False):
+        calls.append((cli_ref, prompt))
+        if len(calls) == 1:
+            return agents.AgentResult(
+                text=json.dumps({"assignments": [{"worker": "coder", "task": "implement it"}]}),
+                ok=True,
+            )
+        if cli_ref == "ollama:llama3.3":
+            return agents.AgentResult(text="worker output", ok=True)
+        return agents.AgentResult(text="final answer", ok=True)
+
+    delta_calls = []
+
+    def fake_capture_before(target, run_dir):
+        delta_calls.append(("before", target, run_dir))
+        return before_payload
+
+    def fake_capture_after(target, run_dir, before):
+        delta_calls.append(("after", target, run_dir, before))
+        return after_payload
+
+    run_cwd = tmp_path / "work"
+    run_cwd.mkdir()
+    _init_git_repo(run_cwd)
+    (run_cwd / "tracked.txt").write_text("initial\n")
+    _commit_all(run_cwd)
+    output_dir = tmp_path / "run"
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+    monkeypatch.setattr(aboyeur.graphtrail_delta, "capture_before", fake_capture_before)
+    monkeypatch.setattr(aboyeur.graphtrail_delta, "capture_after_and_diff", fake_capture_after)
+
+    assert aboyeur.run("build feature", _roster(), cwd=run_cwd, output_dir=output_dir) == 0
+
+    assert delta_calls == [
+        ("before", run_cwd, output_dir),
+        ("after", run_cwd, output_dir, before_payload),
+    ]
+    ground_truth = json.loads((output_dir / "worker-results.json").read_text())["ground_truth"]
+    assert ground_truth["code_graph_delta"] == after_payload
+    assert json.loads((output_dir / "synthesis.json").read_text())["ground_truth"]["code_graph_delta"] == after_payload
+    assert json.loads((output_dir / "run.json").read_text())["code_graph_delta"] == after_payload
+    assert "code_graph_delta: code graph delta: ok changed_symbols=1 edge_churn=2 edges_added=3" in calls[-1][1]
 
 
 def test_run_worker_results_include_latest_verification_receipt_commands(monkeypatch, tmp_path):

--- a/tests/test_receipts_cmd.py
+++ b/tests/test_receipts_cmd.py
@@ -241,3 +241,48 @@ def test_receipts_verify_reports_mismatch_when_referenced_log_is_edited(tmp_path
     assert problem["artifact_type"] == "work-verify-log"
     assert problem["artifact_id"].endswith("command-1-stdout.log")
     assert problem["check"] == "log_sha256"
+
+
+def test_receipts_verify_reports_mismatch_when_graph_delta_sidecar_is_edited(tmp_path, capsys):
+    _init_git_repo(tmp_path)
+    run_dir = tmp_path / ".brigade" / "work" / "verify-runs" / "with-graph-delta"
+    run_dir.mkdir(parents=True)
+    (run_dir / "command-1-stdout.log").write_text("ok\n")
+    (run_dir / "command-1-stderr.log").write_text("")
+    sidecar = run_dir / "graph-delta.json"
+    sidecar.write_text(json.dumps({"status": "ok", "summary": "edge_churn=0"}, sort_keys=True) + "\n")
+    receipt = {
+        "run_id": "with-graph-delta",
+        "target": str(tmp_path),
+        "status": "completed",
+        "commands": [
+            {
+                "command": "python3 -c \"print('ok')\"",
+                "status": "completed",
+                "exit_code": 0,
+                "stdout_log_path": str(run_dir / "command-1-stdout.log"),
+                "stderr_log_path": str(run_dir / "command-1-stderr.log"),
+            }
+        ],
+        "code_graph_delta": {"status": "ok", "summary": "edge_churn=0"},
+    }
+    receipt["digests"] = {
+        "algorithm": "sha256",
+        "logs": {
+            "command-1-stderr.log": localio.file_sha256(run_dir / "command-1-stderr.log"),
+            "command-1-stdout.log": localio.file_sha256(run_dir / "command-1-stdout.log"),
+            "graph-delta.json": localio.file_sha256(sidecar),
+        },
+        "receipt_sha256": localio.canonical_json_digest(receipt, exclude_keys={"digests"}),
+    }
+    localio.write_json(run_dir / "receipt.json", receipt)
+    sidecar.write_text(json.dumps({"status": "ok", "summary": "tampered"}, sort_keys=True) + "\n")
+
+    assert receipts_cmd.verify(target=tmp_path, json_output=True) == 1
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["summary"]["mismatch"] == 1
+    problem = [item for item in payload["artifacts"] if item["status"] == "MISMATCH"][0]
+    assert problem["artifact_type"] == "work-verify-log"
+    assert problem["artifact_id"].endswith("graph-delta.json")
+    assert problem["check"] == "log_sha256"

--- a/tests/test_work_cmd_verification.py
+++ b/tests/test_work_cmd_verification.py
@@ -1,4 +1,6 @@
 import json
+import os
+import sys
 from pathlib import Path
 
 from brigade import cli
@@ -203,13 +205,16 @@ def test_work_verify_plan_run_list_show(tmp_path, capsys):
     assert "python3 -c" in out
 
 
-def test_work_verify_receipt_digests_recompute_from_payload_and_logs(tmp_path, capsys):
+def test_work_verify_receipt_digests_recompute_from_payload_and_logs(tmp_path, capsys, monkeypatch):
     _init_git_repo(tmp_path)
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(tmp_path / "missing-graphtrail"))
+    monkeypatch.setenv("PATH", str(tmp_path))
+    monkeypatch.setenv("HOME", str(tmp_path))
 
     assert (
         work_cmd.verify_run(
             target=tmp_path,
-            commands=["python3 -c \"print('ok')\""],
+            commands=[f"{sys.executable} -c \"print('ok')\""],
             timeout=30,
             json_output=True,
         )
@@ -228,6 +233,181 @@ def test_work_verify_receipt_digests_recompute_from_payload_and_logs(tmp_path, c
 
     stored = json.loads((run_dir / "receipt.json").read_text())
     assert stored["digests"] == digests
+
+
+def _write_fake_graphtrail(tmp_path, *, mode: str = "ok") -> Path:
+    script = tmp_path / "fake-graphtrail.py"
+    script.write_text(
+        """
+import hashlib
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+args = sys.argv[1:]
+db = Path(args[args.index("--db") + 1]) if "--db" in args else Path(".graphtrail/graphtrail.db")
+command = args[args.index(str(db)) + 1] if str(db) in args and args.index(str(db)) + 1 < len(args) else ""
+mode = os.environ.get("FAKE_GRAPHTRAIL_MODE", "ok")
+
+# Mirror the real clap CLI strictly: `sync` rejects --json, `diff` requires
+# --before/--after/--json. JSON shape follows graphtrail's diff golden fixture.
+if command == "sync":
+    if "--json" in args:
+        print("error: unexpected argument '--json' found", file=sys.stderr)
+        raise SystemExit(2)
+    if mode == "sync-fail":
+        print("sync failed", file=sys.stderr)
+        raise SystemExit(5)
+    db.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db) as con:
+        con.execute("create table if not exists symbols (name text)")
+        con.execute("insert into symbols values ('after')")
+    print("indexed files=1 symbols=1 calls=0 imports=0 deleted=0 db=" + str(db))
+    raise SystemExit(0)
+
+if command == "diff":
+    if "--before" not in args or "--after" not in args or "--json" not in args:
+        print("error: required arguments missing (--before/--after/--json)", file=sys.stderr)
+        raise SystemExit(2)
+    before = Path(args[args.index("--before") + 1])
+    after = Path(args[args.index("--after") + 1])
+    if not before.is_file() or not after.is_file():
+        print("error: no such database", file=sys.stderr)
+        raise SystemExit(1)
+    if mode == "malformed-diff":
+        print("{not-json")
+        raise SystemExit(0)
+
+    def node(name, line=1):
+        return {
+            "kind": "function",
+            "qualified_name": name,
+            "file_path": "pkg/mod.py",
+            "start_line": line,
+            "signature": "def " + name + "()",
+        }
+
+    def edge(source, target, line):
+        return {
+            "source_file": "pkg/a.py",
+            "source": source,
+            "line": line,
+            "target_file": "pkg/b.py",
+            "target": target,
+        }
+
+    payload = {
+        "schema_version": 3,
+        "summary": {
+            "added_nodes": 2,
+            "removed_nodes": 1,
+            "changed_nodes": 25,
+            "added_edges": 2,
+            "removed_edges": 1,
+        },
+        "added_nodes": [node("pkg.new_a"), node("pkg.new_b")],
+        "removed_nodes": [node("pkg.gone")],
+        "changed_nodes": [node(f"pkg.symbol_{i}", line=i + 1) for i in range(25)],
+        "added_edges": [edge("pkg.a", "pkg.b", 20), edge("pkg.c", "pkg.d", 30)],
+        "removed_edges": [edge("pkg.a", "pkg.b", 10)],
+    }
+    print(json.dumps(payload))
+    raise SystemExit(0)
+
+print("unexpected command: " + repr(args), file=sys.stderr)
+raise SystemExit(9)
+"""
+    )
+    script.chmod(0o755)
+    wrapper = tmp_path / "graphtrail"
+    wrapper.write_text(
+        f'#!/bin/sh\nFAKE_GRAPHTRAIL_MODE={mode} exec {os.environ.get("PYTHON", "python3")} {script} "$@"\n'
+    )
+    wrapper.chmod(0o755)
+    return wrapper
+
+
+def test_work_verify_graphtrail_delta_missing_binary_fails_open(tmp_path, capsys, monkeypatch):
+    _init_git_repo(tmp_path)
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(tmp_path / "missing-graphtrail"))
+    monkeypatch.setenv("PATH", str(tmp_path))
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    assert (
+        work_cmd.verify_run(target=tmp_path, commands=[f"{sys.executable} -c \"print('ok')\""], json_output=True) == 0
+    )
+    receipt = json.loads(capsys.readouterr().out)
+
+    delta = receipt["code_graph_delta"]
+    assert delta["status"] == "unavailable"
+    assert "graphtrail binary not found" in delta["summary"]
+    assert not (Path(receipt["path"]) / "graph-delta.json").exists()
+
+
+def test_work_verify_graphtrail_delta_sidecar_digest_cleanup_and_summary(tmp_path, capsys, monkeypatch):
+    _init_git_repo(tmp_path)
+    graphtrail = _write_fake_graphtrail(tmp_path)
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(graphtrail))
+
+    assert work_cmd.verify_run(target=tmp_path, commands=["python3 -c \"print('ok')\""], json_output=True) == 0
+    receipt = json.loads(capsys.readouterr().out)
+    run_dir = Path(receipt["path"])
+    sidecar_path = run_dir / "graph-delta.json"
+    sidecar = json.loads(sidecar_path.read_text())
+
+    assert receipt["code_graph_delta"]["status"] == "ok"
+    assert receipt["code_graph_delta"]["edge_churn"] == 1
+    assert receipt["code_graph_delta"]["changed_symbol_count"] == 20
+    assert "edge_churn=1" in receipt["code_graph_delta"]["summary"]
+    assert sidecar["raw_counts"] == {
+        "added_nodes": 2,
+        "removed_nodes": 1,
+        "changed_nodes": 25,
+        "added_edges": 2,
+        "removed_edges": 1,
+    }
+    assert len(sidecar["changed_symbols"]) == 20
+    assert sidecar["changed_symbols_truncated"] is True
+    assert sidecar["edge_churn"] == 1
+    assert sidecar["snapshot_deleted"] is True
+    assert not Path(sidecar["before_snapshot_path"]).exists()
+    assert not (run_dir / "graphtrail-after.db").exists()
+    assert sidecar["attestations"]["before_snapshot_sha256"]
+    after_sha = sidecar["attestations"]["after_snapshot_sha256"]
+    assert isinstance(after_sha, str) and len(after_sha) == 64
+    assert receipt["digests"]["logs"]["graph-delta.json"] == localio.file_sha256(sidecar_path)
+    assert json.loads((run_dir / "receipt.json").read_text())["digests"] == receipt["digests"]
+    assert "- Code graph delta: " + receipt["code_graph_delta"]["summary"] in (run_dir / "summary.md").read_text()
+
+
+def test_work_verify_graphtrail_delta_sync_failure_fails_open(tmp_path, capsys, monkeypatch):
+    _init_git_repo(tmp_path)
+    graphtrail = _write_fake_graphtrail(tmp_path, mode="sync-fail")
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(graphtrail))
+
+    assert work_cmd.verify_run(target=tmp_path, commands=["python3 -c \"print('ok')\""], json_output=True) == 0
+    receipt = json.loads(capsys.readouterr().out)
+    sidecar = json.loads((Path(receipt["path"]) / "graph-delta.json").read_text())
+
+    assert receipt["code_graph_delta"]["status"] == "sync_failed"
+    assert sidecar["status"] == "sync_failed"
+    assert sidecar["ok"] is False
+
+
+def test_work_verify_graphtrail_delta_malformed_diff_fails_open(tmp_path, capsys, monkeypatch):
+    _init_git_repo(tmp_path)
+    graphtrail = _write_fake_graphtrail(tmp_path, mode="malformed-diff")
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(graphtrail))
+
+    assert work_cmd.verify_run(target=tmp_path, commands=["python3 -c \"print('ok')\""], json_output=True) == 0
+    receipt = json.loads(capsys.readouterr().out)
+    sidecar = json.loads((Path(receipt["path"]) / "graph-delta.json").read_text())
+
+    assert receipt["code_graph_delta"]["status"] == "diff_malformed"
+    assert sidecar["status"] == "diff_malformed"
+    assert sidecar["ok"] is False
 
 
 def test_work_closeout_writes_ready_receipt(tmp_path, capsys):


### PR DESCRIPTION
Implements the graph-delta receipt slice from the graphtrail integration review (graphtrail run 20260708-052926): a receipt now records what structurally changed in the target's code graph, not just the exit code.

## What

- New `src/brigade/graphtrail_delta.py`: fail-open helper that snapshots the target's `.graphtrail/graphtrail.db` (WAL-safe `sqlite3` `backup()`, never a raw copy), re-syncs and snapshots after, runs `graphtrail diff --before <a> --after <b> --json`, writes the full delta to a `graph-delta.json` sidecar, and returns a compact summary.
- Verify receipts (`work_cmd/verification.py`): `receipt["code_graph_delta"]` summary + the sidecar registered in the #157 `digests.logs` map, so `brigade receipts verify` covers the delta automatically. One-line summary in `summary.md`.
- Brigade runs (`aboyeur.py`): pre-run snapshot after the artifact dir is created, post-dispatch diff before ground truth; the delta lands in `ground_truth`, synthesis facts, and `run.json`. Read-only, dry-run, and `--no-code-graph` runs skip capture (`skipped_read_only` / `skipped_dry_run` / `disabled`).
- Snapshots (~11MB each) are deleted after the diff; their sha256s remain in `attestations` so the diff inputs stay content-addressed without disk retention.
- Summary carries raw edge counts plus a line-insensitive edge churn (graphtrail edge identity includes the call line, so line shifts churn raw counts by design).

## Real-binary fixes on top of the initial generation

The first cut passed its tests but was written against an invented CLI and JSON shape; the strict fixes are part of this PR:
- `sync --json` is a clap error - `--json` now only goes to `diff`.
- `diff --from-db` does not exist - replaced with a real after-snapshot and `--before/--after`.
- The counts block is named `summary` (per graphtrail's golden fixture), not `counts`; symbols come from `changed/added/removed_nodes[].qualified_name`; edges from `added_edges`/`removed_edges`.
- The fake test binary now mirrors the real clap CLI strictly and emits the golden-fixture shape.

## Verification

- `python3 -m pytest -q` green (1513+ passed; brigade receipt `20260708-073304-work-verify-737cb3`), `ruff check`, `ruff format --check`, `mypy` (182 files) all clean.
- Dogfooded end to end with the real binary: a verify command that creates a new Python file mid-run produced `code_graph_delta: added_nodes=1, changed_symbols=[probe_fn]`, the sidecar digest verified via `brigade receipts verify` (0 mismatches), and no snapshot DBs were left behind.