### PR TITLE
feat(receipts): export receipts as miseledger adapter JSONL

### DIFF
--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -41,7 +41,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade pantry` (extras): 4 command path(s)
 - `brigade profiles`: 2 command path(s)
 - `brigade projects` (extras): 10 command path(s)
-- `brigade receipts`: 1 command path(s)
+- `brigade receipts`: 2 command path(s)
 - `brigade reconfigure`: 1 command path(s)
 - `brigade release` (extras): 23 command path(s)
 - `brigade repos` (extras): 71 command path(s)
@@ -251,6 +251,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade projects readiness plan` (extras)
 - `brigade projects readiness record` (extras)
 - `brigade projects readiness show` (extras)
+- `brigade receipts export miseledger`
 - `brigade receipts verify`
 - `brigade reconfigure`
 - `brigade release candidate archive` (extras)

--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -865,12 +865,24 @@ Work verification and closeout commands:
 - `brigade work verify run` executes explicit local verification commands without a shell and writes receipts under `.brigade/work/verify-runs/`.
 - `brigade work verify runs` and `brigade work verify show <run-id>` inspect local verification receipts, command exit codes, summaries, and log paths.
 - `brigade receipts verify` recomputes SHA-256 receipt digests, stdout and stderr log digests, and the `memory/outcome/records.jsonl` digest chain. It reports `OK`, `MISMATCH`, `MISSING`, or `LEGACY` for each checked artifact and exits non-zero only for mismatch or missing evidence.
+- `brigade receipts export miseledger` exports local work verification receipts and Brigade run receipts as `miseledger.adapter.v1` JSONL for offline import into MiseLedger. Stdout is the default output; pass `--out <path>` to write a file and `--limit <n>` to export only the newest receipts.
 - `brigade work closeout <session-id-or-latest>` writes a local closeout receipt under `.brigade/work/closeouts/` that collects task acceptance, latest verification, scanner sweep status, code review closeout state, handoff draft status, and session evidence.
 - `brigade work acceptance` reports pending task acceptance coverage, completion metadata gaps, completion-time acceptance evidence, code-review finding outcomes, and latest work closeout state. Release readiness and release candidate evidence include the same rollup.
 
 Verification receipts and runbook receipts include tamper-evident SHA-256 digests over the canonical receipt payload and referenced stdout and stderr logs. Outcome records include `prev_digest` and `digest` fields so the ledger tail points back through prior records. These are digests, not signatures. Optional signing and key ids may be added later, but current receipts do not prove authorship or bind an external identity.
 
 This digest layer detects common local drift, such as hand-edited receipt fields, missing logs, changed logs, edited outcome records, and deleted middle ledger records. It does not defend against an attacker who can rewrite both receipt contents and their stored digests, or an attacker who can rewrite and re-chain the outcome ledger tail from the changed point onward.
+
+The MiseLedger export is a bridge format, not a live sync. It gives another local tool enough stable identity, digest, artifact, actor, and raw receipt data to index Brigade evidence without reading the Brigade tree directly. A typical flow is:
+
+```bash
+brigade receipts export miseledger --target . --out /tmp/brigade-receipts.jsonl
+miseledger import adapter /tmp/brigade-receipts.jsonl --source brigade --json
+```
+
+The export is deterministic and idempotent for unchanged receipts: records are sorted newest first, external ids derive from receipt ids, hashes derive from stored receipt digests or deterministic fallbacks, and JSONL rendering uses stable key order. Re-importing the same file should update or skip the same MiseLedger adapter items rather than create duplicates.
+
+Export is fail-open per receipt. Malformed or unreadable receipt files produce one stderr warning each and are skipped, so one bad historical receipt does not block newer evidence. The command exits non-zero only when there are no receipt candidates under the target, the target or output path is invalid, or the output cannot be written.
 
 Verification and closeout are local gates. Brigade does not mutate CI, GitHub, reviewers, scanner promotions, handoff ingestion, daemons, or schedulers. Verification commands run only when explicitly requested.
 

--- a/src/brigade/cli/receipts.py
+++ b/src/brigade/cli/receipts.py
@@ -16,11 +16,22 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_verify.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
     p_verify.set_defaults(func=dispatch)
 
+    p_export = receipts_sub.add_parser("export", help="Export receipts for external ingest.")
+    export_sub = p_export.add_subparsers(dest="receipts_export_command", metavar="<export-target>")
+    export_sub.required = True
+    p_miseledger = export_sub.add_parser("miseledger", help="Export receipts as miseledger.adapter.v1 JSONL.")
+    p_miseledger.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
+    p_miseledger.add_argument("--out", default="-", help="Output path, or '-' for stdout.")
+    p_miseledger.add_argument("--limit", type=int, default=0, help="Maximum records to export; 0 means all.")
+    p_miseledger.set_defaults(func=dispatch)
+
 
 def dispatch(args) -> int:
     from .. import receipts_cmd
 
     if args.receipts_command == "verify":
         return receipts_cmd.verify(target=args.target, json_output=args.json)
+    if args.receipts_command == "export" and args.receipts_export_command == "miseledger":
+        return receipts_cmd.export_miseledger(target=args.target, out=args.out, limit=args.limit)
     args._brigade_parser.error(f"unknown receipts command: {args.receipts_command}")
     return 2

--- a/src/brigade/receipts_cmd.py
+++ b/src/brigade/receipts_cmd.py
@@ -7,12 +7,16 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from . import __version__
 from . import localio
 
 OK = "OK"
 MISMATCH = "MISMATCH"
 MISSING = "MISSING"
 LEGACY = "LEGACY"
+MISELEDGER_SCHEMA = "miseledger.adapter.v1"
+MISELEDGER_SOURCE = {"kind": "brigade", "name": "Brigade", "version": __version__}
+MISELEDGER_ACTOR = {"external_id": "brigade:system", "type": "system", "name": "Brigade"}
 
 
 def _rel(path: Path, target: Path) -> str:
@@ -471,6 +475,364 @@ def doctor(*, target: Path, json_output: bool = False) -> int:
         return 0
     print(f"outcome doctor: {target}")
     print(f"receipts: {summary_detail(target)}")
+    return 0
+
+
+def _one_line(value: object, limit: int = 500) -> str:
+    text = " ".join(str(value or "").split())
+    if len(text) <= limit:
+        return text
+    return text[: limit - 3].rstrip() + "..."
+
+
+def _hash_value(value: str) -> str:
+    return value if value.startswith("sha256:") else f"sha256:{value}"
+
+
+def _receipt_hash(payload: dict[str, Any], path: Path) -> tuple[str, str]:
+    digests = payload.get("digests")
+    if isinstance(digests, dict):
+        receipt_digest = digests.get("receipt_sha256")
+        if isinstance(receipt_digest, str) and receipt_digest:
+            return _hash_value(receipt_digest), "receipt_digest"
+    try:
+        return _hash_value(localio.file_sha256(path)), "file_sha256"
+    except OSError:
+        return _hash_value(localio.canonical_json_digest(payload)), "canonical_json_digest"
+
+
+def _read_export_receipt(path: Path, target: Path) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(path.read_text())
+    except OSError as exc:
+        print(f"warning: skipped unreadable receipt {_rel(path, target)}: {exc}", file=sys.stderr)
+        return None
+    except json.JSONDecodeError as exc:
+        print(f"warning: skipped malformed receipt {_rel(path, target)}: {exc}", file=sys.stderr)
+        return None
+    if not isinstance(payload, dict):
+        print(f"warning: skipped malformed receipt {_rel(path, target)}: JSON is not an object", file=sys.stderr)
+        return None
+    return payload
+
+
+def _timestamp_for_sort(payload: dict[str, Any], path: Path) -> str:
+    for key in ("started_at", "completed_at", "finished_at", "created_at"):
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return path.parent.name
+
+
+def _collect_export_receipts(target: Path) -> tuple[list[dict[str, Any]], int]:
+    specs = [
+        ("work_verify", target / ".brigade" / "work" / "verify-runs", "*/receipt.json"),
+        ("run", target / ".brigade" / "runs", "*/run.json"),
+    ]
+    receipts: list[dict[str, Any]] = []
+    candidate_count = 0
+    for receipt_type, root, pattern in specs:
+        if not root.is_dir():
+            continue
+        for path in sorted(root.glob(pattern)):
+            candidate_count += 1
+            payload = _read_export_receipt(path, target)
+            if payload is None:
+                continue
+            receipts.append(
+                {
+                    "receipt_type": receipt_type,
+                    "path": path,
+                    "payload": payload,
+                    "sort_key": (_timestamp_for_sort(payload, path), str(path)),
+                }
+            )
+    receipts.sort(key=lambda item: item["sort_key"], reverse=True)
+    return receipts, candidate_count
+
+
+def _metadata_with_delta(metadata: dict[str, Any], payload: dict[str, Any]) -> dict[str, Any]:
+    delta = payload.get("code_graph_delta")
+    if isinstance(delta, dict):
+        summary = _one_line(delta.get("summary") or delta.get("status") or "code graph delta present")
+        metadata["code_graph_delta_summary"] = summary
+        metadata["code_graph_delta"] = delta
+    return metadata
+
+
+def _append_delta_text(text: str, payload: dict[str, Any]) -> str:
+    delta = payload.get("code_graph_delta")
+    if not isinstance(delta, dict):
+        return text
+    summary = _one_line(delta.get("summary") or delta.get("status") or "code graph delta present", 200)
+    return f"{text} Code graph delta: {summary}."
+
+
+def _mime_for(path: Path) -> str:
+    if path.suffix == ".json":
+        return "application/json"
+    if path.suffix == ".log":
+        return "text/plain"
+    return "application/octet-stream"
+
+
+def _safe_digest_log_path(run_dir: Path, name: object) -> Path | None:
+    if not isinstance(name, str) or not name:
+        return None
+    rel = Path(name)
+    if rel.is_absolute() or ".." in rel.parts:
+        return None
+    return run_dir / rel
+
+
+def _artifact_path(path: Path, target: Path) -> str:
+    return _rel(path, target)
+
+
+def _receipt_artifact(item_external_id: str, path: Path, target: Path, digest: str) -> dict[str, Any]:
+    return {
+        "external_id": f"{item_external_id}:receipt",
+        "kind": "receipt",
+        "path": _artifact_path(path, target),
+        "mime_type": _mime_for(path),
+        "hash": digest,
+    }
+
+
+def _verify_log_artifacts(
+    item_external_id: str, payload: dict[str, Any], path: Path, target: Path
+) -> list[dict[str, Any]]:
+    run_dir = path.parent
+    artifacts: list[dict[str, Any]] = []
+    digests = payload.get("digests")
+    logs = digests.get("logs") if isinstance(digests, dict) else None
+    if isinstance(logs, dict):
+        for name, digest in sorted(logs.items()):
+            log_path = _safe_digest_log_path(run_dir, name)
+            if log_path is None or not isinstance(digest, str) or not digest:
+                continue
+            artifacts.append(
+                {
+                    "external_id": f"{item_external_id}:artifact:{name}",
+                    "kind": "code_graph_delta" if Path(str(name)).name == "graph-delta.json" else "log",
+                    "path": _artifact_path(log_path, target),
+                    "mime_type": _mime_for(log_path),
+                    "hash": _hash_value(digest),
+                }
+            )
+        return artifacts
+
+    seen: set[str] = set()
+    commands = payload.get("commands")
+    if not isinstance(commands, list):
+        return artifacts
+    for command in commands:
+        if not isinstance(command, dict):
+            continue
+        for key in ("stdout_log_path", "stderr_log_path"):
+            raw_path = command.get(key)
+            if not isinstance(raw_path, str) or not raw_path:
+                continue
+            log_path = Path(raw_path)
+            if not log_path.is_absolute():
+                log_path = run_dir / log_path
+            if not log_path.is_file():
+                continue
+            rel_path = _artifact_path(log_path, target)
+            if rel_path in seen:
+                continue
+            seen.add(rel_path)
+            try:
+                digest = _hash_value(localio.file_sha256(log_path))
+            except OSError:
+                continue
+            artifacts.append(
+                {
+                    "external_id": f"{item_external_id}:artifact:{Path(rel_path).name}",
+                    "kind": "log",
+                    "path": rel_path,
+                    "mime_type": _mime_for(log_path),
+                    "hash": digest,
+                }
+            )
+    return artifacts
+
+
+def _short_commands(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    commands = payload.get("commands")
+    if not isinstance(commands, list):
+        return []
+    out: list[dict[str, Any]] = []
+    for command in commands:
+        if not isinstance(command, dict):
+            continue
+        item: dict[str, Any] = {}
+        for key in ("command", "status", "exit_code"):
+            if key in command:
+                item[key] = command[key]
+        if item:
+            out.append(item)
+    return out
+
+
+def _verify_miseledger_item(payload: dict[str, Any], path: Path, target: Path, ordinal: int) -> dict[str, Any]:
+    run_id = str(payload.get("run_id") or path.parent.name)
+    item_external_id = f"brigade:work-verify:{run_id}"
+    receipt_hash, digest_source = _receipt_hash(payload, path)
+    commands = _short_commands(payload)
+    metadata: dict[str, Any] = {
+        "receipt_type": "work_verify",
+        "run_id": run_id,
+        "status": payload.get("status"),
+        "target": payload.get("target"),
+        "path": _rel(path, target),
+        "digest": receipt_hash,
+        "digest_source": digest_source,
+        "command_count": len(commands),
+        "commands": commands,
+    }
+    metadata = _metadata_with_delta(metadata, payload)
+    text = f"Brigade work verify run {run_id} status={payload.get('status') or 'unknown'} commands={len(commands)}."
+    command_text = _one_line(
+        " ; ".join(str(command.get("command") or "") for command in commands if isinstance(command, dict)),
+        limit=240,
+    )
+    if command_text:
+        text = f"{text} Commands: {command_text}."
+    text = _append_delta_text(text, payload)
+    artifacts = [_receipt_artifact(item_external_id, path, target, receipt_hash)]
+    artifacts.extend(_verify_log_artifacts(item_external_id, payload, path, target))
+    return {
+        "schema": MISELEDGER_SCHEMA,
+        "source": MISELEDGER_SOURCE,
+        "collection": {
+            "external_id": "brigade:work:verify-runs",
+            "kind": "brigade_work_verify_runs",
+            "name": "Brigade work verify runs",
+        },
+        "item": {
+            "external_id": item_external_id,
+            "kind": "brigade_work_verify_receipt",
+            "created_at": str(payload.get("started_at") or ""),
+            "updated_at": str(payload.get("completed_at") or ""),
+            "text": text,
+            "tags": ["brigade", "receipt", "work-verify"],
+            "metadata": metadata,
+        },
+        "actor": MISELEDGER_ACTOR,
+        "artifacts": artifacts,
+        "links": [],
+        "relations": [],
+        "raw": {
+            "format": "json",
+            "hash": receipt_hash,
+            "path": _rel(path, target),
+            "ordinal": ordinal,
+        },
+    }
+
+
+def _run_miseledger_item(payload: dict[str, Any], path: Path, target: Path, ordinal: int) -> dict[str, Any]:
+    run_id = path.parent.name
+    item_external_id = f"brigade:run:{run_id}"
+    receipt_hash, digest_source = _receipt_hash(payload, path)
+    task = _one_line(payload.get("task"), 300)
+    metadata: dict[str, Any] = {
+        "receipt_type": "run",
+        "run_id": run_id,
+        "status": payload.get("status"),
+        "cwd": payload.get("cwd"),
+        "path": _rel(path, target),
+        "digest": receipt_hash,
+        "digest_source": digest_source,
+        "task": payload.get("task"),
+        "orchestrator": payload.get("orchestrator"),
+        "dry_run": payload.get("dry_run"),
+        "read_only": payload.get("read_only"),
+    }
+    metadata = _metadata_with_delta(metadata, payload)
+    text = f"Brigade run {run_id} status={payload.get('status') or 'unknown'}."
+    if task:
+        text += f" Task: {task}."
+    text = _append_delta_text(text, payload)
+    artifacts = [_receipt_artifact(item_external_id, path, target, receipt_hash)]
+    output_dir = payload.get("artifacts")
+    if isinstance(output_dir, str) and output_dir:
+        artifacts.append(
+            {
+                "external_id": f"{item_external_id}:artifacts",
+                "kind": "directory",
+                "path": _artifact_path(Path(output_dir), target),
+                "mime_type": "inode/directory",
+            }
+        )
+    return {
+        "schema": MISELEDGER_SCHEMA,
+        "source": MISELEDGER_SOURCE,
+        "collection": {
+            "external_id": "brigade:runs",
+            "kind": "brigade_runs",
+            "name": "Brigade runs",
+        },
+        "item": {
+            "external_id": item_external_id,
+            "kind": "brigade_run_receipt",
+            "created_at": str(payload.get("started_at") or ""),
+            "updated_at": str(payload.get("finished_at") or ""),
+            "text": text,
+            "tags": ["brigade", "receipt", "run"],
+            "metadata": metadata,
+        },
+        "actor": MISELEDGER_ACTOR,
+        "artifacts": artifacts,
+        "links": [],
+        "relations": [],
+        "raw": {
+            "format": "json",
+            "hash": receipt_hash,
+            "path": _rel(path, target),
+            "ordinal": ordinal,
+        },
+    }
+
+
+def _miseledger_item(receipt: dict[str, Any], target: Path, ordinal: int) -> dict[str, Any]:
+    payload = receipt["payload"]
+    path = receipt["path"]
+    if receipt["receipt_type"] == "work_verify":
+        return _verify_miseledger_item(payload, path, target, ordinal)
+    return _run_miseledger_item(payload, path, target, ordinal)
+
+
+def _render_miseledger_jsonl(records: list[dict[str, Any]]) -> str:
+    return "".join(json.dumps(record, sort_keys=True, separators=(",", ":"), default=str) + "\n" for record in records)
+
+
+def export_miseledger(*, target: Path, out: str | Path = "-", limit: int = 0) -> int:
+    if limit < 0:
+        print("error: --limit must be zero or a positive integer", file=sys.stderr)
+        return 2
+    target = target.expanduser().resolve()
+    if not target.is_dir():
+        print(f"error: --target is not a directory: {target}", file=sys.stderr)
+        return 2
+    receipts, candidate_count = _collect_export_receipts(target)
+    if candidate_count == 0:
+        print(f"error: no receipts found under {target}", file=sys.stderr)
+        return 1
+    selected = receipts[:limit] if limit else receipts
+    records = [_miseledger_item(receipt, target, ordinal) for ordinal, receipt in enumerate(selected, start=1)]
+    rendered = _render_miseledger_jsonl(records)
+    if str(out) == "-":
+        sys.stdout.write(rendered)
+        return 0
+    output_path = Path(out).expanduser()
+    try:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(rendered)
+    except OSError as exc:
+        print(f"error: could not write output {output_path}: {exc}", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/tests/test_receipts_cmd.py
+++ b/tests/test_receipts_cmd.py
@@ -48,6 +48,204 @@ def _append_outcome(target, evidence_ref):
     )
 
 
+def _receipt_digest(payload):
+    return localio.canonical_json_digest(payload, exclude_keys={"digests"})
+
+
+def _write_verify_export_receipt(
+    target,
+    run_id,
+    *,
+    started_at,
+    digest=True,
+    code_graph_delta=None,
+):
+    run_dir = target / ".brigade" / "work" / "verify-runs" / run_id
+    run_dir.mkdir(parents=True)
+    stdout = run_dir / "command-1-stdout.log"
+    stderr = run_dir / "command-1-stderr.log"
+    stdout.write_text("ok\n")
+    stderr.write_text("")
+    receipt = {
+        "run_id": run_id,
+        "target": str(target),
+        "status": "completed",
+        "started_at": started_at,
+        "completed_at": started_at.replace("00Z", "05Z"),
+        "commands": [
+            {
+                "command": "python3 -c \"print('ok')\"",
+                "status": "completed",
+                "exit_code": 0,
+                "stdout_log_path": str(stdout),
+                "stderr_log_path": str(stderr),
+            }
+        ],
+    }
+    if code_graph_delta is not None:
+        sidecar = run_dir / "graph-delta.json"
+        sidecar.write_text(json.dumps(code_graph_delta, sort_keys=True) + "\n")
+        receipt["code_graph_delta"] = code_graph_delta
+    if digest:
+        logs = {
+            "command-1-stderr.log": localio.file_sha256(stderr),
+            "command-1-stdout.log": localio.file_sha256(stdout),
+        }
+        if code_graph_delta is not None:
+            logs["graph-delta.json"] = localio.file_sha256(run_dir / "graph-delta.json")
+        receipt["digests"] = {
+            "algorithm": "sha256",
+            "logs": dict(sorted(logs.items())),
+            "receipt_sha256": _receipt_digest(receipt),
+        }
+    localio.write_json(run_dir / "receipt.json", receipt)
+    return run_dir / "receipt.json"
+
+
+def _write_run_export_receipt(target, run_id, *, started_at, digest=False, code_graph_delta=None):
+    run_dir = target / ".brigade" / "runs" / run_id
+    run_dir.mkdir(parents=True)
+    payload = {
+        "task": "export receipts",
+        "cwd": str(target),
+        "orchestrator": "planner",
+        "dry_run": False,
+        "read_only": False,
+        "status": "ok",
+        "started_at": started_at,
+        "finished_at": started_at.replace("00Z", "07Z"),
+        "artifacts": str(run_dir),
+    }
+    if code_graph_delta is not None:
+        payload["code_graph_delta"] = code_graph_delta
+    if digest:
+        payload["digests"] = {
+            "algorithm": "sha256",
+            "receipt_sha256": _receipt_digest(payload),
+        }
+    localio.write_json(run_dir / "run.json", payload)
+    return run_dir / "run.json"
+
+
+def _jsonl(text):
+    return [json.loads(line) for line in text.splitlines() if line.strip()]
+
+
+def test_receipts_export_miseledger_emits_required_verify_fields_and_artifacts(tmp_path, capsys):
+    receipt_path = _write_verify_export_receipt(
+        tmp_path,
+        "20260708-120000-work-verify-abc123",
+        started_at="2026-07-08T12:00:00Z",
+        digest=True,
+        code_graph_delta={"status": "ok", "summary": "edge_churn=2", "changed_symbol_count": 2},
+    )
+
+    assert cli.main(["receipts", "export", "miseledger", "--target", str(tmp_path)]) == 0
+    rows = _jsonl(capsys.readouterr().out)
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["schema"] == "miseledger.adapter.v1"
+    assert row["source"]["kind"] == "brigade"
+    assert row["collection"]["external_id"] == "brigade:work:verify-runs"
+    assert row["collection"]["kind"] == "brigade_work_verify_runs"
+    assert row["item"]["external_id"] == "brigade:work-verify:20260708-120000-work-verify-abc123"
+    assert row["item"]["kind"] == "brigade_work_verify_receipt"
+    assert row["actor"] == {"external_id": "brigade:system", "type": "system", "name": "Brigade"}
+    assert "edge_churn=2" in row["item"]["text"]
+    assert row["item"]["metadata"]["code_graph_delta_summary"] == "edge_churn=2"
+    assert row["item"]["metadata"]["code_graph_delta"]["changed_symbol_count"] == 2
+    assert row["raw"]["path"] == ".brigade/work/verify-runs/20260708-120000-work-verify-abc123/receipt.json"
+    assert row["raw"]["hash"] == "sha256:" + json.loads(receipt_path.read_text())["digests"]["receipt_sha256"]
+    assert row["raw"]["ordinal"] == 1
+    assert all(
+        set(artifact) <= {"external_id", "kind", "path", "url", "mime_type", "text", "hash", "metadata"}
+        for artifact in row["artifacts"]
+    )
+    artifact_paths = {artifact["path"] for artifact in row["artifacts"]}
+    assert ".brigade/work/verify-runs/20260708-120000-work-verify-abc123/receipt.json" in artifact_paths
+    assert ".brigade/work/verify-runs/20260708-120000-work-verify-abc123/command-1-stdout.log" in artifact_paths
+    assert ".brigade/work/verify-runs/20260708-120000-work-verify-abc123/graph-delta.json" in artifact_paths
+    assert row["artifacts"][0]["hash"].startswith("sha256:")
+    assert row["links"] == []
+    assert row["relations"] == []
+
+
+def test_receipts_export_miseledger_exports_run_and_digestless_verify_receipts(tmp_path, capsys):
+    verify_path = _write_verify_export_receipt(
+        tmp_path,
+        "20260708-110000-work-verify-def456",
+        started_at="2026-07-08T11:00:00Z",
+        digest=False,
+    )
+    run_path = _write_run_export_receipt(
+        tmp_path,
+        "20260708-130000-aabbccdd",
+        started_at="2026-07-08T13:00:00Z",
+        digest=True,
+        code_graph_delta={"status": "ok", "summary": "changed_symbols=1"},
+    )
+
+    assert receipts_cmd.export_miseledger(target=tmp_path) == 0
+    rows = _jsonl(capsys.readouterr().out)
+
+    assert [row["item"]["kind"] for row in rows] == [
+        "brigade_run_receipt",
+        "brigade_work_verify_receipt",
+    ]
+    assert rows[0]["collection"]["external_id"] == "brigade:runs"
+    assert rows[0]["item"]["external_id"] == "brigade:run:20260708-130000-aabbccdd"
+    assert rows[0]["raw"]["hash"] == "sha256:" + json.loads(run_path.read_text())["digests"]["receipt_sha256"]
+    assert rows[0]["item"]["metadata"]["code_graph_delta_summary"] == "changed_symbols=1"
+    assert rows[1]["raw"]["hash"] == "sha256:" + localio.file_sha256(verify_path)
+    assert rows[1]["item"]["metadata"]["digest_source"] == "file_sha256"
+
+
+def test_receipts_export_miseledger_is_byte_identical_and_limit_uses_newest_first(tmp_path, capsys):
+    _write_verify_export_receipt(
+        tmp_path,
+        "20260708-090000-work-verify-old",
+        started_at="2026-07-08T09:00:00Z",
+    )
+    _write_run_export_receipt(tmp_path, "20260708-140000-new", started_at="2026-07-08T14:00:00Z")
+
+    assert cli.main(["receipts", "export", "miseledger", "--target", str(tmp_path), "--limit", "1"]) == 0
+    first = capsys.readouterr().out
+    assert cli.main(["receipts", "export", "miseledger", "--target", str(tmp_path), "--limit", "1"]) == 0
+    second = capsys.readouterr().out
+
+    assert first == second
+    rows = _jsonl(first)
+    assert [row["item"]["external_id"] for row in rows] == ["brigade:run:20260708-140000-new"]
+
+
+def test_receipts_export_miseledger_skips_malformed_receipts_with_warning(tmp_path, capsys):
+    _write_verify_export_receipt(
+        tmp_path,
+        "20260708-150000-work-verify-good",
+        started_at="2026-07-08T15:00:00Z",
+    )
+    bad_dir = tmp_path / ".brigade" / "work" / "verify-runs" / "20260708-160000-work-verify-bad"
+    bad_dir.mkdir(parents=True)
+    (bad_dir / "receipt.json").write_text("{not json\n")
+
+    assert receipts_cmd.export_miseledger(target=tmp_path) == 0
+    captured = capsys.readouterr()
+    rows = _jsonl(captured.out)
+
+    assert len(rows) == 1
+    assert "warning: skipped malformed receipt" in captured.err
+    assert "20260708-160000-work-verify-bad" in captured.err
+
+
+def test_receipts_export_miseledger_empty_target_exits_one(tmp_path, capsys):
+    assert cli.main(["receipts", "export", "miseledger", "--target", str(tmp_path)]) == 1
+    captured = capsys.readouterr()
+
+    assert captured.out == ""
+    assert "no receipts found" in captured.err
+
+
 def test_receipts_verify_fresh_target_passes(tmp_path, capsys):
     _init_git_repo(tmp_path)
     assert (


### PR DESCRIPTION
Final slice of the graphtrail integration plan (review run 20260708-052926): brigade receipts flow into miseledger as searchable, content-addressed evidence with zero miseledger-side code changes.

## What

- `brigade receipts export miseledger [--target .] [--out PATH|-] [--limit N]` under the #157 receipts group: walks `.brigade/work/verify-runs/*/receipt.json` and `.brigade/runs/*/run.json` newest-first and emits one `miseledger.adapter.v1` JSONL line per receipt, per `miseledger/docs/ADAPTER_CONTRACT.md`.
- `raw.hash` reuses the #157 `digests.receipt_sha256` when present (computed canonically otherwise), so miseledger's identity boundary (`source_kind + collection + item + content_hash`) dedupes re-imports natively.
- `item.text` is genuinely searchable: status, command strings, run task, and the #158 `code_graph_delta` summary; the compact delta dict rides in `item.metadata`. Artifacts point at `receipt.json`, `graph-delta.json`, and the digest-covered logs.
- Deterministic: exporting twice is byte-identical (no export-time stamps). Fail-open per receipt: malformed receipts warn to stderr and are skipped.

## Verification

- Full `pytest` green on host (brigade receipt `20260708-082653-work-verify-efaed0`); ruff check, ruff format, mypy clean.
- Real end-to-end smoke against an isolated XDG miseledger archive: exported 10 live receipts, `miseledger import adapter --source brigade` inserted 10/10 with no warnings; `miseledger evidence \"pytest\" --source brigade` finds the receipt by its command text with the graph-delta summary in the snippet; re-import of the same file: `inserted: 0, already_known: true`.