### PR TITLE
fix(run): write run receipts atomically to close run.json read race

### DIFF
--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -17,6 +17,7 @@ from uuid import uuid4
 from . import agents
 from . import codex_appserver
 from . import graphtrail_delta
+from . import localio
 from . import proc, runguard
 from . import run_control
 from .roster import Agent, Roster, is_cli_allowed, timeout_for, workers
@@ -417,8 +418,10 @@ def make_run_dir(base: Path, now: datetime | None = None) -> Path:
 
 
 def _write_json(path: Path, payload: object) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, indent=2) + "\n")
+    # run.json is polled by `brigade runs watch/steer/interrupt` while the run
+    # rewrites it, so the write must be atomic or a concurrent reader can
+    # observe a truncated file.
+    localio.write_text_atomic(path, json.dumps(payload, indent=2) + "\n")
 
 
 def _utc_iso(value: datetime) -> str:

--- a/src/brigade/localio.py
+++ b/src/brigade/localio.py
@@ -42,16 +42,15 @@ def read_json_dict(path: Path) -> dict[str, Any] | None:
     return payload if isinstance(payload, dict) else None
 
 
-def write_json(path: Path, payload: dict[str, Any]) -> None:
-    """Write payload as indented, key-sorted JSON, atomically, creating parents.
+def write_text_atomic(path: Path, data: str) -> None:
+    """Write data to path atomically, creating parents.
 
     The write goes to a temp file in the same directory and is swapped in with
     os.replace, so a reader (or a crashed writer) never observes a half-written
-    receipt: it sees either the old file or the complete new one. On failure the
+    file: it sees either the old file or the complete new one. On failure the
     temp file is removed and the existing file is left untouched.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
-    data = json.dumps(payload, indent=2, sort_keys=True) + "\n"
     fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp")
     tmp_path = Path(tmp_name)
     try:
@@ -63,6 +62,11 @@ def write_json(path: Path, payload: dict[str, Any]) -> None:
     except BaseException:
         tmp_path.unlink(missing_ok=True)
         raise
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write payload as indented, key-sorted JSON, atomically, creating parents."""
+    write_text_atomic(path, json.dumps(payload, indent=2, sort_keys=True) + "\n")
 
 
 def read_jsonl_dicts(path: Path) -> list[dict[str, Any]]:

--- a/src/brigade/run_resume.py
+++ b/src/brigade/run_resume.py
@@ -134,8 +134,9 @@ def resume(run_dir: Path) -> int:
         for r in results
     ]
     ground_truth = worker_data.get("ground_truth") or {}
-    (run_dir / "worker-results.json").write_text(
-        json.dumps({"results": aboyeur._worker_payload(worker_results), "ground_truth": ground_truth}, indent=2) + "\n"
+    aboyeur._write_json(
+        run_dir / "worker-results.json",
+        {"results": aboyeur._worker_payload(worker_results), "ground_truth": ground_truth},
     )
 
     task = run_meta.get("task", "")
@@ -155,28 +156,25 @@ def resume(run_dir: Path) -> int:
         read_only=read_only,
         **({"model": orchestrator.model} if orchestrator.model is not None else {}),
     )
-    (run_dir / "synthesis.json").write_text(
-        json.dumps(
-            {
-                "orchestrator": roster.orchestrator,
-                "result": {"ok": final.ok, "detail": final.detail, "text": final.text},
-                "ground_truth": ground_truth,
-            },
-            indent=2,
-        )
-        + "\n"
+    aboyeur._write_json(
+        run_dir / "synthesis.json",
+        {
+            "orchestrator": roster.orchestrator,
+            "result": {"ok": final.ok, "detail": final.detail, "text": final.text},
+            "ground_truth": ground_truth,
+        },
     )
     now = datetime.now(timezone.utc).isoformat()
     run_meta.setdefault("resumed_at", []).append(now)
     if not final.ok:
         run_meta["status"] = "failed"
         run_meta["error"] = final.detail
-        (run_dir / "run.json").write_text(json.dumps(run_meta, indent=2) + "\n")
+        aboyeur._write_json(run_dir / "run.json", run_meta)
         print(f"error: orchestrator failed during synthesis: {final.detail}", file=sys.stderr)
         return 2
     (run_dir / "final.txt").write_text(final.text + "\n")
     run_meta["status"] = "ok"
     run_meta.pop("error", None)
-    (run_dir / "run.json").write_text(json.dumps(run_meta, indent=2) + "\n")
+    aboyeur._write_json(run_dir / "run.json", run_meta)
     print(final.text)
     return 0

--- a/tests/test_run_control.py
+++ b/tests/test_run_control.py
@@ -29,6 +29,19 @@ def _wait_for(predicate, *, timeout: float = 5.0):
     raise AssertionError("timed out waiting for condition")
 
 
+def _control_socket_from_run_json(run_dir: Path) -> Path | None:
+    # Polled while aboyeur.run rewrites run.json on another thread, so tolerate
+    # a file that is missing or not yet parseable and let _wait_for retry.
+    try:
+        meta = json.loads((run_dir / "run.json").read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(meta, dict):
+        return None
+    socket_value = meta.get("control_socket")
+    return Path(socket_value) if socket_value else None
+
+
 class _FakeTurn:
     thread_id = "thread-1"
 
@@ -142,13 +155,7 @@ def test_run_records_control_socket_and_cli_steers_live_worker(tmp_path, monkeyp
     )
     thread.start()
 
-    control_socket = _wait_for(
-        lambda: (
-            Path(json.loads((run_dir / "run.json").read_text()).get("control_socket", ""))
-            if (run_dir / "run.json").is_file() and json.loads((run_dir / "run.json").read_text()).get("control_socket")
-            else None
-        )
-    )
+    control_socket = _wait_for(lambda: _control_socket_from_run_json(run_dir))
     _wait_for(lambda: control_socket.exists())
 
     assert cli.main(["runs", "steer", str(run_dir), "cook", "please finish"]) == 0
@@ -198,13 +205,7 @@ def test_cli_interrupt_leaves_live_worker_resumable(tmp_path, monkeypatch, capsy
     )
     thread.start()
 
-    control_socket = _wait_for(
-        lambda: (
-            Path(json.loads((run_dir / "run.json").read_text()).get("control_socket", ""))
-            if (run_dir / "run.json").is_file() and json.loads((run_dir / "run.json").read_text()).get("control_socket")
-            else None
-        )
-    )
+    control_socket = _wait_for(lambda: _control_socket_from_run_json(run_dir))
     _wait_for(lambda: control_socket.exists())
 
     assert cli.main(["runs", "interrupt", str(run_dir), "cook"]) == 0


### PR DESCRIPTION
## Problem

`tests/test_run_control.py::test_cli_interrupt_leaves_live_worker_resumable` (added in #154) fails intermittently in CI with `json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)` - it hit both the 3.10 and 3.12 matrix jobs of run 28925842236 on #158 while passing locally.

## Root cause

A classic read/write race with two halves:

- **Writer:** `aboyeur._write_json` used a plain `Path.write_text`, which truncates the file before writing the new payload. `run.json` is rewritten several times during a run (started, running with `control_socket`, finished), so any concurrent reader can catch it empty or partial.
- **Reader:** the live-worker tests polled `run.json` with an unguarded `json.loads` while `aboyeur.run` rewrote it on another thread. One mid-write read raised straight through `_wait_for`. The `runs watch/steer/interrupt` CLI reads the same file and had the same exposure in real usage.

Reproduced the mechanism with a tight writer/reader loop against the old writer: **95,580 decode errors out of 147,476 reads in 5 seconds**. Zero errors across 609k reads after the fix.

## Fix

- Extract the existing tempfile + `os.replace` pattern from `localio.write_json` into a new `localio.write_text_atomic`, and route both `localio.write_json` and `aboyeur._write_json` through it. Run receipts keep their current unsorted `indent=2` serialization; the swap-in is now atomic, so a reader sees either the old file or the complete new one.
- Make the test poller (`_control_socket_from_run_json`, shared by the steer and interrupt tests) tolerate a missing or not-yet-parseable `run.json` and let `_wait_for` retry, as defense in depth.

## Verification

- `python3 -m pytest -q` green (brigade receipt `20260708-154601-work-verify-3adabe`), `ruff check`, `ruff format --check`, `mypy` (182 files) all clean.
- Writer/reader race harness: 95,580 decode errors before, 0 after.
- `tests/test_run_control.py` run 30x under full CPU contention (one busy-loop per core): 0 failures.

## Follow-up: resume path (2nd commit)

`brigade runs resume` (`run_resume.py`) rewrote the same three run receipts (`run.json`, `worker-results.json`, `synthesis.json`) with plain `write_text` - the identical truncate-before-write race, on the same files the `runs watch/steer/interrupt` CLI polls out of process. Routed those through the now-atomic `aboyeur._write_json`. Serialization unchanged (`indent=2`, unsorted). A repo-wide grep confirms no other module writes these receipts non-atomically.
