### PR TITLE
feat(receipts): git provenance links and automated miseledger export

### DIFF
--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -865,7 +865,7 @@ Work verification and closeout commands:
 - `brigade work verify run` executes explicit local verification commands without a shell and writes receipts under `.brigade/work/verify-runs/`.
 - `brigade work verify runs` and `brigade work verify show <run-id>` inspect local verification receipts, command exit codes, summaries, and log paths.
 - `brigade receipts verify` recomputes SHA-256 receipt digests, stdout and stderr log digests, and the `memory/outcome/records.jsonl` digest chain. It reports `OK`, `MISMATCH`, `MISSING`, or `LEGACY` for each checked artifact and exits non-zero only for mismatch or missing evidence.
-- `brigade receipts export miseledger` exports local work verification receipts and Brigade run receipts as `miseledger.adapter.v1` JSONL for offline import into MiseLedger. Stdout is the default output; pass `--out <path>` to write a file and `--limit <n>` to export only the newest receipts.
+- `brigade receipts export miseledger` exports local work verification receipts and Brigade run receipts as `miseledger.adapter.v1` JSONL for offline import into MiseLedger. Stdout is the default output; pass `--out <path>` to write a file, `--limit <n>` to export only the newest receipts, `--new-only` to skip hashes already recorded in the local export cursor, and `--import` to invoke `miseledger import adapter <file> --source brigade --json` after the JSONL file is written.
 - `brigade work closeout <session-id-or-latest>` writes a local closeout receipt under `.brigade/work/closeouts/` that collects task acceptance, latest verification, scanner sweep status, code review closeout state, handoff draft status, and session evidence.
 - `brigade work acceptance` reports pending task acceptance coverage, completion metadata gaps, completion-time acceptance evidence, code-review finding outcomes, and latest work closeout state. Release readiness and release candidate evidence include the same rollup.
 
@@ -879,6 +879,14 @@ The MiseLedger export is a bridge format, not a live sync. It gives another loca
 brigade receipts export miseledger --target . --out /tmp/brigade-receipts.jsonl
 miseledger import adapter /tmp/brigade-receipts.jsonl --source brigade --json
 ```
+
+For scheduled local indexing, use the built-in pipeline:
+
+```bash
+brigade receipts export miseledger --target . --new-only --import
+```
+
+`--new-only` stores exported `raw.hash` values in `.brigade/work/miseledger-export-cursor.json`, so later runs only write receipt items that have not already been exported. The cursor is an optimization, not the identity boundary. MiseLedger uses content-hash identity for adapter items, so double-importing the same receipt file remains harmless if the cursor is deleted, copied late, or skipped.
 
 The export is deterministic and idempotent for unchanged receipts: records are sorted newest first, external ids derive from receipt ids, hashes derive from stored receipt digests or deterministic fallbacks, and JSONL rendering uses stable key order. Re-importing the same file should update or skip the same MiseLedger adapter items rather than create duplicates.
 

--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -1064,6 +1064,20 @@ def _git_stdout(cwd: Path, *args: str) -> tuple[str, str | None]:
     return "", detail
 
 
+def _receipt_git_snapshot(cwd: Path | None) -> dict[str, object] | None:
+    if cwd is None:
+        return None
+    try:
+        head, head_error = _git_stdout(cwd, "rev-parse", "HEAD")
+        branch, branch_error = _git_stdout(cwd, "rev-parse", "--abbrev-ref", "HEAD")
+        status, status_error = _git_stdout(cwd, "status", "--porcelain")
+    except Exception:
+        return None
+    if head_error or branch_error or status_error:
+        return None
+    return {"head": head.strip(), "branch": branch.strip(), "dirty_files": len(status.splitlines())}
+
+
 def _receipt_command_payload(command: object) -> dict[str, object] | None:
     if not isinstance(command, dict):
         return None
@@ -1302,6 +1316,9 @@ def _run_payload(
             "attached": list(brief_set.attached) if brief_set is not None else [],
         },
     }
+    git = _receipt_git_snapshot(cwd)
+    if git is not None:
+        payload["git"] = git
     if code_graph_delta is not None:
         payload["code_graph_delta"] = code_graph_delta
     if finished_at is not None:

--- a/src/brigade/cli/receipts.py
+++ b/src/brigade/cli/receipts.py
@@ -23,6 +23,10 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_miseledger.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
     p_miseledger.add_argument("--out", default="-", help="Output path, or '-' for stdout.")
     p_miseledger.add_argument("--limit", type=int, default=0, help="Maximum records to export; 0 means all.")
+    p_miseledger.add_argument("--new-only", action="store_true", help="Export only receipt items not in the cursor.")
+    p_miseledger.add_argument(
+        "--import", dest="import_miseledger", action="store_true", help="Import the JSONL with miseledger."
+    )
     p_miseledger.set_defaults(func=dispatch)
 
 
@@ -32,6 +36,12 @@ def dispatch(args) -> int:
     if args.receipts_command == "verify":
         return receipts_cmd.verify(target=args.target, json_output=args.json)
     if args.receipts_command == "export" and args.receipts_export_command == "miseledger":
-        return receipts_cmd.export_miseledger(target=args.target, out=args.out, limit=args.limit)
+        return receipts_cmd.export_miseledger(
+            target=args.target,
+            out=args.out,
+            limit=args.limit,
+            new_only=args.new_only,
+            import_miseledger=args.import_miseledger,
+        )
     args._brigade_parser.error(f"unknown receipts command: {args.receipts_command}")
     return 2

--- a/src/brigade/receipts_cmd.py
+++ b/src/brigade/receipts_cmd.py
@@ -3,9 +3,14 @@
 from __future__ import annotations
 
 import json
+import re
+import shutil
+import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 from . import __version__
 from . import localio
@@ -17,6 +22,7 @@ LEGACY = "LEGACY"
 MISELEDGER_SCHEMA = "miseledger.adapter.v1"
 MISELEDGER_SOURCE = {"kind": "brigade", "name": "Brigade", "version": __version__}
 MISELEDGER_ACTOR = {"external_id": "brigade:system", "type": "system", "name": "Brigade"}
+MISELEDGER_CURSOR_REL = Path(".brigade") / "work" / "miseledger-export-cursor.json"
 
 
 def _rel(path: Path, target: Path) -> str:
@@ -501,6 +507,84 @@ def _receipt_hash(payload: dict[str, Any], path: Path) -> tuple[str, str]:
         return _hash_value(localio.canonical_json_digest(payload)), "canonical_json_digest"
 
 
+def _git_value(target: Path, *args: str) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(target), *args],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            stdin=subprocess.DEVNULL,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    value = result.stdout.strip()
+    return value or None
+
+
+def _github_host(host: str | None) -> bool:
+    return bool(host and (host == "github.com" or host.endswith(".github.com")))
+
+
+def _strip_git_suffix(repo: str) -> str:
+    return repo[:-4] if repo.endswith(".git") else repo
+
+
+def _github_remote_parts(remote: str) -> tuple[str, str, str] | None:
+    parsed = urlparse(remote)
+    if parsed.scheme == "https" and _github_host(parsed.hostname):
+        parts = [part for part in parsed.path.split("/") if part]
+        if len(parts) == 2:
+            return parsed.hostname or "", parts[0], _strip_git_suffix(parts[1])
+        return None
+    match = re.match(r"^git@([^:]+):([^/]+)/(.+)$", remote)
+    if match and _github_host(match.group(1)):
+        return match.group(1), match.group(2), _strip_git_suffix(match.group(3))
+    return None
+
+
+def _receipt_git(payload: dict[str, Any]) -> dict[str, Any] | None:
+    git = payload.get("git")
+    if not isinstance(git, dict):
+        return None
+    head = git.get("head")
+    if not isinstance(head, str) or not head:
+        return None
+    copied = {key: git[key] for key in ("head", "branch", "dirty_files") if key in git}
+    return copied if copied else None
+
+
+def _git_commit_links(item_external_id: str, payload: dict[str, Any], target: Path) -> list[dict[str, Any]]:
+    git = _receipt_git(payload)
+    if git is None:
+        return []
+    remote = _git_value(target, "remote", "get-url", "origin")
+    if remote is None:
+        return []
+    parts = _github_remote_parts(remote)
+    if parts is None:
+        return []
+    host, org, repo = parts
+    return [
+        {
+            "external_id": f"{item_external_id}:git-commit",
+            "kind": "url",
+            "url": f"https://{host}/{org}/{repo}/commit/{git['head']}",
+        }
+    ]
+
+
+def _metadata_with_git(metadata: dict[str, Any], payload: dict[str, Any]) -> dict[str, Any]:
+    git = _receipt_git(payload)
+    if git is not None:
+        metadata["git"] = git
+    return metadata
+
+
 def _read_export_receipt(path: Path, target: Path) -> dict[str, Any] | None:
     try:
         payload = json.loads(path.read_text())
@@ -692,6 +776,7 @@ def _verify_miseledger_item(payload: dict[str, Any], path: Path, target: Path, o
         "commands": commands,
     }
     metadata = _metadata_with_delta(metadata, payload)
+    metadata = _metadata_with_git(metadata, payload)
     text = f"Brigade work verify run {run_id} status={payload.get('status') or 'unknown'} commands={len(commands)}."
     command_text = _one_line(
         " ; ".join(str(command.get("command") or "") for command in commands if isinstance(command, dict)),
@@ -721,7 +806,7 @@ def _verify_miseledger_item(payload: dict[str, Any], path: Path, target: Path, o
         },
         "actor": MISELEDGER_ACTOR,
         "artifacts": artifacts,
-        "links": [],
+        "links": _git_commit_links(item_external_id, payload, target),
         "relations": [],
         "raw": {
             "format": "json",
@@ -751,6 +836,7 @@ def _run_miseledger_item(payload: dict[str, Any], path: Path, target: Path, ordi
         "read_only": payload.get("read_only"),
     }
     metadata = _metadata_with_delta(metadata, payload)
+    metadata = _metadata_with_git(metadata, payload)
     text = f"Brigade run {run_id} status={payload.get('status') or 'unknown'}."
     if task:
         text += f" Task: {task}."
@@ -785,7 +871,7 @@ def _run_miseledger_item(payload: dict[str, Any], path: Path, target: Path, ordi
         },
         "actor": MISELEDGER_ACTOR,
         "artifacts": artifacts,
-        "links": [],
+        "links": _git_commit_links(item_external_id, payload, target),
         "relations": [],
         "raw": {
             "format": "json",
@@ -808,7 +894,131 @@ def _render_miseledger_jsonl(records: list[dict[str, Any]]) -> str:
     return "".join(json.dumps(record, sort_keys=True, separators=(",", ":"), default=str) + "\n" for record in records)
 
 
-def export_miseledger(*, target: Path, out: str | Path = "-", limit: int = 0) -> int:
+def _miseledger_jsonl_lines(records: list[dict[str, Any]]) -> list[tuple[str, str]]:
+    lines: list[tuple[str, str]] = []
+    for record in records:
+        raw = record.get("raw")
+        raw_hash = raw.get("hash") if isinstance(raw, dict) else None
+        if not isinstance(raw_hash, str) or not raw_hash:
+            continue
+        line = json.dumps(record, sort_keys=True, separators=(",", ":"), default=str) + "\n"
+        lines.append((line, raw_hash))
+    return lines
+
+
+def _miseledger_cursor_path(target: Path) -> Path:
+    return target / MISELEDGER_CURSOR_REL
+
+
+def _read_miseledger_cursor_hashes(target: Path) -> set[str]:
+    payload = localio.read_json_dict(_miseledger_cursor_path(target)) or {}
+    hashes = payload.get("raw_hashes")
+    if not isinstance(hashes, list):
+        return set()
+    return {value for value in hashes if isinstance(value, str) and value}
+
+
+def _write_miseledger_cursor_hashes(target: Path, hashes: set[str]) -> None:
+    localio.write_json(
+        _miseledger_cursor_path(target),
+        {
+            "schema": "brigade.miseledger_export_cursor.v1",
+            "source": "brigade",
+            "raw_hashes": sorted(hashes),
+        },
+    )
+
+
+def _write_miseledger_lines_to_stdout(lines: list[tuple[str, str]]) -> tuple[int, list[str]]:
+    written_hashes: list[str] = []
+    try:
+        for line, raw_hash in lines:
+            written = sys.stdout.write(line)
+            if written != len(line):
+                raise OSError("short write to stdout")
+            written_hashes.append(raw_hash)
+    except OSError as exc:
+        print(f"error: could not write output stdout: {exc}", file=sys.stderr)
+        return 1, written_hashes
+    return 0, written_hashes
+
+
+def _write_miseledger_lines_to_path(output_path: Path, lines: list[tuple[str, str]]) -> tuple[int, list[str]]:
+    written_hashes: list[str] = []
+    try:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with output_path.open("w", encoding="utf-8") as handle:
+            for line, raw_hash in lines:
+                written = handle.write(line)
+                if written != len(line):
+                    raise OSError("short write")
+                written_hashes.append(raw_hash)
+    except OSError as exc:
+        print(f"error: could not write output {output_path}: {exc}", file=sys.stderr)
+        return 1, written_hashes
+    return 0, written_hashes
+
+
+def _temporary_miseledger_export_path(target: Path) -> Path:
+    work_dir = target / ".brigade" / "work"
+    work_dir.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        "w",
+        encoding="utf-8",
+        dir=work_dir,
+        prefix="miseledger-export-",
+        suffix=".jsonl",
+        delete=False,
+    ) as handle:
+        return Path(handle.name)
+
+
+def _miseledger_import_summary(payload: object) -> tuple[object, object]:
+    if not isinstance(payload, dict):
+        return "unknown", "unknown"
+    inserted = payload.get("inserted_items", payload.get("inserted", "unknown"))
+    known = payload.get("already_known", payload.get("known_items", "unknown"))
+    return inserted, known
+
+
+def _import_miseledger_file(path: Path) -> None:
+    binary = shutil.which("miseledger")
+    if binary is None:
+        print(f"warning: miseledger binary not found on PATH; export kept at {path}", file=sys.stderr)
+        return
+    try:
+        result = subprocess.run(
+            [binary, "import", "adapter", str(path), "--source", "brigade", "--json"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            stdin=subprocess.DEVNULL,
+            text=True,
+            timeout=120,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        print(f"warning: miseledger import failed; export kept at {path}: {exc}", file=sys.stderr)
+        return
+    if result.returncode != 0:
+        detail = _one_line(result.stderr or result.stdout or f"exit {result.returncode}", 500)
+        print(f"warning: miseledger import failed; export kept at {path}: {detail}", file=sys.stderr)
+        return
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError:
+        payload = {}
+    inserted, known = _miseledger_import_summary(payload)
+    print(f"miseledger import: inserted_items={inserted} already_known={known}")
+
+
+def export_miseledger(
+    *,
+    target: Path,
+    out: str | Path = "-",
+    limit: int = 0,
+    new_only: bool = False,
+    import_miseledger: bool = False,
+) -> int:
     if limit < 0:
         print("error: --limit must be zero or a positive integer", file=sys.stderr)
         return 2
@@ -822,17 +1032,31 @@ def export_miseledger(*, target: Path, out: str | Path = "-", limit: int = 0) ->
         return 1
     selected = receipts[:limit] if limit else receipts
     records = [_miseledger_item(receipt, target, ordinal) for ordinal, receipt in enumerate(selected, start=1)]
-    rendered = _render_miseledger_jsonl(records)
-    if str(out) == "-":
-        sys.stdout.write(rendered)
-        return 0
-    output_path = Path(out).expanduser()
-    try:
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        output_path.write_text(rendered)
-    except OSError as exc:
-        print(f"error: could not write output {output_path}: {exc}", file=sys.stderr)
-        return 1
+    cursor_hashes: set[str] = set()
+    if new_only:
+        cursor_hashes = _read_miseledger_cursor_hashes(target)
+        records = [
+            record
+            for record in records
+            if isinstance(record.get("raw"), dict) and record["raw"].get("hash") not in cursor_hashes
+        ]
+    lines = _miseledger_jsonl_lines(records)
+    output_path: Path | None = None
+    if str(out) == "-" and not import_miseledger:
+        exit_code, written_hashes = _write_miseledger_lines_to_stdout(lines)
+    else:
+        output_path = _temporary_miseledger_export_path(target) if str(out) == "-" else Path(out).expanduser()
+        exit_code, written_hashes = _write_miseledger_lines_to_path(output_path, lines)
+    if new_only and written_hashes:
+        try:
+            _write_miseledger_cursor_hashes(target, cursor_hashes | set(written_hashes))
+        except OSError as exc:
+            print(f"error: could not write cursor {_miseledger_cursor_path(target)}: {exc}", file=sys.stderr)
+            return 1
+    if exit_code != 0:
+        return exit_code
+    if import_miseledger and output_path is not None:
+        _import_miseledger_file(output_path)
     return 0
 
 

--- a/src/brigade/work_cmd/verification.py
+++ b/src/brigade/work_cmd/verification.py
@@ -29,6 +29,18 @@ def _default_verify_commands(target: Path) -> list[str]:
     return []
 
 
+def _receipt_git_snapshot(target: Path) -> dict[str, Any] | None:
+    try:
+        head = helpers._git_value(target, "rev-parse", "HEAD")
+        branch = helpers._git_value(target, "rev-parse", "--abbrev-ref", "HEAD")
+        status = helpers._git(target, "status", "--porcelain")
+    except OSError:
+        return None
+    if head is None or branch is None or status.returncode != 0:
+        return None
+    return {"head": head, "branch": branch, "dirty_files": len(status.stdout.splitlines())}
+
+
 def _verify_parse_command(command: str) -> tuple[list[str] | None, dict[str, str], str | None]:
     try:
         parts = shlex.split(command)
@@ -343,6 +355,9 @@ def _run_verify_commands(target: Path, commands: list[str], timeout: int) -> tup
         receipt["status"] = "failed"
     else:
         receipt["status"] = "rejected"
+    git = _receipt_git_snapshot(target)
+    if git is not None:
+        receipt["git"] = git
     log_digests: dict[str, str] = {}
     for command in receipt["commands"]:
         if not isinstance(command, dict):

--- a/tests/test_receipts_cmd.py
+++ b/tests/test_receipts_cmd.py
@@ -1,8 +1,24 @@
 import json
+import subprocess
+import sys
+from pathlib import Path
 
 from brigade import cli, localio, outcome, outcome_cmd, receipts_cmd, runbook_cmd, work_cmd
 
 from tests.work_cmd_test_helpers import _init_git_repo
+
+
+def _init_git_repo_with_head(path):
+    _init_git_repo(path)
+    (path / ".gitignore").write_text(".brigade/\n")
+    subprocess.run(["git", "add", ".gitignore"], cwd=path, check=True, stdout=subprocess.DEVNULL)
+    subprocess.run(
+        ["git", "-c", "user.name=Test User", "-c", "user.email=test@example.invalid", "commit", "-m", "init"],
+        cwd=path,
+        check=True,
+        stdout=subprocess.DEVNULL,
+    )
+    return subprocess.check_output(["git", "-C", str(path), "rev-parse", "HEAD"], text=True).strip()
 
 
 def _write_digestless_work_receipt(target):
@@ -59,6 +75,7 @@ def _write_verify_export_receipt(
     started_at,
     digest=True,
     code_graph_delta=None,
+    git=None,
 ):
     run_dir = target / ".brigade" / "work" / "verify-runs" / run_id
     run_dir.mkdir(parents=True)
@@ -86,6 +103,8 @@ def _write_verify_export_receipt(
         sidecar = run_dir / "graph-delta.json"
         sidecar.write_text(json.dumps(code_graph_delta, sort_keys=True) + "\n")
         receipt["code_graph_delta"] = code_graph_delta
+    if git is not None:
+        receipt["git"] = git
     if digest:
         logs = {
             "command-1-stderr.log": localio.file_sha256(stderr),
@@ -217,6 +236,212 @@ def test_receipts_export_miseledger_is_byte_identical_and_limit_uses_newest_firs
     assert first == second
     rows = _jsonl(first)
     assert [row["item"]["external_id"] for row in rows] == ["brigade:run:20260708-140000-new"]
+
+
+def test_receipts_export_miseledger_new_only_exports_once_and_records_cursor(tmp_path, capsys):
+    _write_verify_export_receipt(
+        tmp_path,
+        "20260708-090000-work-verify-old",
+        started_at="2026-07-08T09:00:00Z",
+    )
+    _write_run_export_receipt(tmp_path, "20260708-140000-new", started_at="2026-07-08T14:00:00Z")
+
+    assert cli.main(["receipts", "export", "miseledger", "--target", str(tmp_path), "--new-only"]) == 0
+    first_rows = _jsonl(capsys.readouterr().out)
+    assert len(first_rows) == 2
+
+    cursor_path = tmp_path / ".brigade" / "work" / "miseledger-export-cursor.json"
+    cursor = json.loads(cursor_path.read_text())
+    assert cursor["raw_hashes"] == sorted(row["raw"]["hash"] for row in first_rows)
+
+    assert cli.main(["receipts", "export", "miseledger", "--target", str(tmp_path), "--new-only"]) == 0
+    second = capsys.readouterr()
+    assert second.out == ""
+    assert second.err == ""
+    assert json.loads(cursor_path.read_text()) == cursor
+
+
+def test_receipts_export_miseledger_without_new_only_ignores_cursor(tmp_path, capsys):
+    _write_verify_export_receipt(
+        tmp_path,
+        "20260708-090000-work-verify-old",
+        started_at="2026-07-08T09:00:00Z",
+    )
+    cursor_path = tmp_path / ".brigade" / "work" / "miseledger-export-cursor.json"
+    cursor_path.parent.mkdir(parents=True, exist_ok=True)
+    cursor_path.write_text("{not json\n")
+
+    assert receipts_cmd.export_miseledger(target=tmp_path) == 0
+    rows = _jsonl(capsys.readouterr().out)
+
+    assert len(rows) == 1
+    assert cursor_path.read_text() == "{not json\n"
+
+
+def test_receipts_export_miseledger_new_only_cursor_records_only_written_lines(tmp_path, monkeypatch, capsys):
+    _write_verify_export_receipt(
+        tmp_path,
+        "20260708-120000-work-verify-first",
+        started_at="2026-07-08T12:00:00Z",
+    )
+    _write_run_export_receipt(tmp_path, "20260708-130000-second", started_at="2026-07-08T13:00:00Z")
+    out_path = tmp_path / "export.jsonl"
+    writes = []
+
+    class PartialWrite:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def write(self, line):
+            writes.append(line)
+            if len(writes) == 2:
+                raise OSError("disk full")
+            return len(line)
+
+    original_open = Path.open
+
+    def partial_open(self, *args, **kwargs):
+        mode = args[0] if args else kwargs.get("mode", "r")
+        if self == out_path and "w" in mode:
+            return PartialWrite()
+        return original_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", partial_open)
+
+    assert receipts_cmd.export_miseledger(target=tmp_path, out=out_path, new_only=True) == 1
+    captured = capsys.readouterr()
+
+    assert "could not write output" in captured.err
+    assert len(writes) == 2
+    first_hash = json.loads(writes[0])["raw"]["hash"]
+    cursor = json.loads((tmp_path / ".brigade" / "work" / "miseledger-export-cursor.json").read_text())
+    assert cursor["raw_hashes"] == [first_hash]
+
+
+def test_receipts_export_miseledger_import_runs_fake_binary_and_prints_summary(tmp_path, monkeypatch, capsys):
+    _write_verify_export_receipt(
+        tmp_path,
+        "20260708-120000-work-verify-import",
+        started_at="2026-07-08T12:00:00Z",
+    )
+    fake = tmp_path / "miseledger"
+    fake.write_text(
+        f"""#!{sys.executable}
+import json
+import pathlib
+import sys
+
+assert sys.argv[1:3] == ["import", "adapter"]
+export_path = pathlib.Path(sys.argv[3])
+assert sys.argv[4:] == ["--source", "brigade", "--json"]
+(export_path.parent / "import-argv.json").write_text(json.dumps({{"argv": sys.argv[1:], "input": export_path.read_text()}}))
+print(json.dumps({{"inserted_items": 1, "already_known": 0}}))
+"""
+    )
+    fake.chmod(0o755)
+    monkeypatch.setenv("PATH", str(tmp_path))
+
+    assert cli.main(["receipts", "export", "miseledger", "--target", str(tmp_path), "--import"]) == 0
+    captured = capsys.readouterr()
+
+    assert captured.out == "miseledger import: inserted_items=1 already_known=0\n"
+    assert captured.err == ""
+    marker = json.loads((tmp_path / ".brigade" / "work" / "import-argv.json").read_text())
+    assert marker["argv"][0:2] == ["import", "adapter"]
+    assert marker["argv"][3:] == ["--source", "brigade", "--json"]
+    assert len(_jsonl(marker["input"])) == 1
+
+
+def test_receipts_export_miseledger_import_missing_binary_warns_and_exits_zero(tmp_path, monkeypatch, capsys):
+    _write_verify_export_receipt(
+        tmp_path,
+        "20260708-120000-work-verify-missing-import",
+        started_at="2026-07-08T12:00:00Z",
+    )
+    out_path = tmp_path / "export.jsonl"
+    empty_path = tmp_path / "empty-path"
+    empty_path.mkdir()
+    monkeypatch.setenv("PATH", str(empty_path))
+
+    assert receipts_cmd.export_miseledger(target=tmp_path, out=out_path, import_miseledger=True) == 0
+    captured = capsys.readouterr()
+
+    assert captured.out == ""
+    assert "warning: miseledger binary not found on PATH; export kept at" in captured.err
+    assert len(_jsonl(out_path.read_text())) == 1
+
+
+def test_receipts_export_miseledger_copies_git_metadata_and_github_commit_link(tmp_path, capsys):
+    head = _init_git_repo_with_head(tmp_path)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "https://github.com/example-org/example-repo.git"],
+        cwd=tmp_path,
+        check=True,
+    )
+    git = {"head": head, "branch": "main", "dirty_files": 2}
+    _write_verify_export_receipt(
+        tmp_path,
+        "20260708-120000-work-verify-git",
+        started_at="2026-07-08T12:00:00Z",
+        git=git,
+    )
+
+    assert receipts_cmd.export_miseledger(target=tmp_path) == 0
+    rows = _jsonl(capsys.readouterr().out)
+
+    assert rows[0]["item"]["metadata"]["git"] == git
+    assert rows[0]["links"] == [
+        {
+            "external_id": "brigade:work-verify:20260708-120000-work-verify-git:git-commit",
+            "kind": "url",
+            "url": f"https://github.com/example-org/example-repo/commit/{head}",
+        }
+    ]
+
+
+def test_receipts_export_miseledger_supports_ssh_github_commit_link(tmp_path, capsys):
+    head = _init_git_repo_with_head(tmp_path)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "git@github.com:example-org/example-repo.git"],
+        cwd=tmp_path,
+        check=True,
+    )
+    _write_verify_export_receipt(
+        tmp_path,
+        "20260708-120000-work-verify-ssh-git",
+        started_at="2026-07-08T12:00:00Z",
+        git={"head": head, "branch": "main", "dirty_files": 0},
+    )
+
+    assert receipts_cmd.export_miseledger(target=tmp_path) == 0
+    rows = _jsonl(capsys.readouterr().out)
+
+    assert rows[0]["links"][0]["url"] == f"https://github.com/example-org/example-repo/commit/{head}"
+
+
+def test_receipts_export_miseledger_keeps_git_metadata_without_non_github_link(tmp_path, capsys):
+    head = _init_git_repo_with_head(tmp_path)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "https://example.invalid/example-org/example-repo.git"],
+        cwd=tmp_path,
+        check=True,
+    )
+    git = {"head": head, "branch": "main", "dirty_files": 0}
+    _write_verify_export_receipt(
+        tmp_path,
+        "20260708-120000-work-verify-no-link",
+        started_at="2026-07-08T12:00:00Z",
+        git=git,
+    )
+
+    assert receipts_cmd.export_miseledger(target=tmp_path) == 0
+    rows = _jsonl(capsys.readouterr().out)
+
+    assert rows[0]["item"]["metadata"]["git"] == git
+    assert rows[0]["links"] == []
 
 
 def test_receipts_export_miseledger_skips_malformed_receipts_with_warning(tmp_path, capsys):

--- a/tests/test_work_cmd_verification.py
+++ b/tests/test_work_cmd_verification.py
@@ -1,5 +1,6 @@
 import json
 import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -11,6 +12,18 @@ from tests.work_cmd_test_helpers import (
     _write_json,
     _init_git_repo,
 )
+
+
+def _init_git_repo_with_head(path):
+    _init_git_repo(path)
+    (path / ".gitignore").write_text(".brigade/\n")
+    subprocess.run(["git", "add", ".gitignore"], cwd=path, check=True, stdout=subprocess.DEVNULL)
+    subprocess.run(
+        ["git", "-c", "user.name=Test User", "-c", "user.email=test@example.invalid", "commit", "-m", "init"],
+        cwd=path,
+        check=True,
+        stdout=subprocess.DEVNULL,
+    )
 
 
 def test_verify_run_marks_parser_rejected_command_as_rejected_not_failed(tmp_path, capsys):
@@ -233,6 +246,53 @@ def test_work_verify_receipt_digests_recompute_from_payload_and_logs(tmp_path, c
 
     stored = json.loads((run_dir / "receipt.json").read_text())
     assert stored["digests"] == digests
+
+
+def test_work_verify_receipt_captures_git_state_before_digest(tmp_path, capsys, monkeypatch):
+    _init_git_repo_with_head(tmp_path)
+    (tmp_path / "dirty.txt").write_text("dirty\n")
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(tmp_path / "missing-graphtrail"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    assert (
+        work_cmd.verify_run(
+            target=tmp_path,
+            commands=[f"{sys.executable} -c \"print('ok')\""],
+            timeout=30,
+            json_output=True,
+        )
+        == 0
+    )
+    receipt = json.loads(capsys.readouterr().out)
+    dirty_files = subprocess.check_output(["git", "-C", str(tmp_path), "status", "--porcelain"], text=True)
+
+    assert receipt["git"] == {
+        "head": subprocess.check_output(["git", "-C", str(tmp_path), "rev-parse", "HEAD"], text=True).strip(),
+        "branch": subprocess.check_output(
+            ["git", "-C", str(tmp_path), "rev-parse", "--abbrev-ref", "HEAD"], text=True
+        ).strip(),
+        "dirty_files": len(dirty_files.splitlines()),
+    }
+    assert receipt["digests"]["receipt_sha256"] == localio.canonical_json_digest(receipt, exclude_keys={"digests"})
+
+
+def test_work_verify_receipt_omits_git_state_outside_git_repo(tmp_path, capsys, monkeypatch):
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(tmp_path / "missing-graphtrail"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    assert (
+        work_cmd.verify_run(
+            target=tmp_path,
+            commands=[f"{sys.executable} -c \"print('ok')\""],
+            timeout=30,
+            json_output=True,
+        )
+        == 0
+    )
+    receipt = json.loads(capsys.readouterr().out)
+
+    assert "git" not in receipt
+    assert receipt["digests"]["receipt_sha256"] == localio.canonical_json_digest(receipt, exclude_keys={"digests"})
 
 
 def _write_fake_graphtrail(tmp_path, *, mode: str = "ok") -> Path:


### PR DESCRIPTION
Rounds out the receipts-to-evidence pipeline: receipts now say which commit they attest, and the export runs as a one-command pipeline instead of a manual two-step.

- Verify receipts and run payloads capture `git: {head, branch, dirty_files}` fail-open, added before digest computation so provenance is covered by the receipt hash. Non-git targets and legacy receipts are unaffected (determinism test unchanged).
- Export emits the commit URL (`https://github.com/<org>/<repo>/commit/<head>`) as a `kind: url` link when `remote.origin.url` parses (both `git@` and `https` forms), and puts the git block in `item.metadata.git`.
- `--new-only`: cursor at `.brigade/work/miseledger-export-cursor.json` records exported `raw.hash` values; reruns export only new receipts. The cursor is an optimization, miseledger's content-hash identity remains the correctness mechanism.
- `--import`: pipes the export straight through `miseledger import adapter --source brigade --json`, fail-open if the binary is absent, printing the insert summary.

Verification: full pytest green on host (brigade receipt `20260708-163150-work-verify-f2a00d`), ruff check/format and mypy clean. Dogfood against an isolated archive: first `--new-only --import` run inserted 91 receipts, second run exported and inserted 0; a fresh receipt exported with its commit link (`.../brigade/commit/1465708...`) and git metadata.