### PR TITLE
feat(outcome): carry code-graph deltas on records and surface graph counters

### DIFF
--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -985,6 +985,10 @@ Work verification and non-read-only aboyeur runs can also record a GraphTrail de
 
 Delta capture is fail-open. Missing GraphTrail, sync failures, malformed diff JSON, and snapshot problems are recorded as status data instead of failing the run. `--no-code-graph`, read-only runs, and dry runs record skip statuses and do not run GraphTrail sync.
 
+When `brigade outcome capture` records a verification receipt with `code_graph_delta`, the outcome ledger keeps the compact fields `status`, `summary`, `changed_symbol_count`, `edge_churn`, and `raw_counts`. `brigade outcome rank` and dry-run `brigade outcome reconcile` surface per-artifact counts for scored records whose graph delta is changing or no-op. These counters are display-only today: promotion, rollback, cooldown, and ranking decisions still use the existing verified outcome rules.
+
+For those counters, a delta is changing only when `status` is `ok` and `changed_symbol_count` or `edge_churn` is greater than zero. A delta is no-op only when `status` is `ok` and both counts are zero. Zero graph delta does not mean nothing happened: docs-only changes, test-only changes, and pre-v3 body-edit blind spots can still read as no-op.
+
 Snapshots use sqlite backup instead of copying the db file directly. That keeps the baseline safe when the database is in WAL mode or GraphTrail is writing adjacent sqlite state. After the diff, Brigade deletes the temporary snapshot and records SHA-256 attestations for the before snapshot, after database, diff stdout, sidecar, and receipt log digests when those files exist.
 
 GraphTrail raw diff counts are preserved under `raw_counts`. Brigade also computes a line-insensitive edge churn value by stripping line and range fields from added and removed edges before pairing them, so pure line-number movement is less noisy than raw edge add/remove totals.

--- a/src/brigade/outcome.py
+++ b/src/brigade/outcome.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import datetime as dt
 import math
 from dataclasses import dataclass
+from typing import Any
 
 # Map (source, status) to a verified signal weight. Only signals the model
 # cannot author earn a non-zero weight. "aboyeur ok" means the worker CLI exited
@@ -42,6 +43,7 @@ class OutcomeRecord:
     signal_value: int  # +1 | 0 | -1
     evidence_ref: str
     ts: str
+    code_graph_delta: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True)
@@ -93,8 +95,8 @@ def signal_value(source: str, status: str) -> int:
     return SIGNAL_RULES.get((source, status), 0)
 
 
-def score_records(artifact_id: str, records: list[OutcomeRecord]) -> OutcomeScore:
-    """Fold an artifact's records into counts plus a Wilson lower-bound score.
+def scored_records(records: list[OutcomeRecord]) -> list[OutcomeRecord]:
+    """Return the de-duplicated records that contribute to scoring.
 
     Counts DISTINCT verified evidence, not raw rows. A re-captured or retried run
     yields a byte-identical record (same source, evidence_ref, task_id), and the
@@ -116,6 +118,12 @@ def score_records(artifact_id: str, records: list[OutcomeRecord]) -> OutcomeScor
             continue
         seen.add(key)
         deduped.append(r)
+    return deduped
+
+
+def score_records(artifact_id: str, records: list[OutcomeRecord]) -> OutcomeScore:
+    """Fold an artifact's records into counts plus a Wilson lower-bound score."""
+    deduped = scored_records(records)
     helped = sum(1 for r in deduped if r.signal_value > 0)
     hurt = sum(1 for r in deduped if r.signal_value < 0)
     neutral = sum(1 for r in deduped if r.signal_value == 0)

--- a/src/brigade/outcome_cmd.py
+++ b/src/brigade/outcome_cmd.py
@@ -65,6 +65,7 @@ def _artifact_known(target: Path, artifact_id: str, kind: str) -> bool:
 
 
 def _record_from_dict(payload: dict) -> core.OutcomeRecord | None:
+    code_graph_delta = payload.get("code_graph_delta")
     try:
         return core.OutcomeRecord(
             artifact_id=str(payload["artifact_id"]),
@@ -74,6 +75,7 @@ def _record_from_dict(payload: dict) -> core.OutcomeRecord | None:
             signal_value=int(payload.get("signal_value", 0)),
             evidence_ref=str(payload.get("evidence_ref", "")),
             ts=str(payload.get("ts", "")),
+            code_graph_delta=code_graph_delta if isinstance(code_graph_delta, dict) else None,
         )
     except (KeyError, TypeError, ValueError):
         return None
@@ -93,17 +95,36 @@ def _last_record_digest(path: Path) -> str | None:
     return None
 
 
+def _record_payload(record: core.OutcomeRecord) -> dict:
+    row = dataclasses.asdict(record)
+    if row.get("code_graph_delta") is None:
+        row.pop("code_graph_delta", None)
+    return row
+
+
 def append_records(target: Path, records: list[core.OutcomeRecord]) -> None:
     path = _records_path(target)
     path.parent.mkdir(parents=True, exist_ok=True)
     prev_digest = _last_record_digest(path)
     with path.open("a", encoding="utf-8") as handle:
         for record in records:
-            row = dataclasses.asdict(record)
+            row = _record_payload(record)
             row["prev_digest"] = prev_digest
             row["digest"] = localio.canonical_json_digest(row, exclude_keys={"digest"})
             handle.write(json.dumps(row, sort_keys=True) + "\n")
             prev_digest = row["digest"]
+
+
+def _compact_code_graph_delta(receipt: dict) -> dict | None:
+    delta = receipt.get("code_graph_delta")
+    if not isinstance(delta, dict):
+        return None
+    compact = {
+        key: delta[key]
+        for key in ("status", "summary", "changed_symbol_count", "edge_churn", "raw_counts")
+        if key in delta
+    }
+    return compact or None
 
 
 def _decisions_dir(target: Path) -> Path:
@@ -276,10 +297,56 @@ def diff(*, target: Path, fork_a: Path, fork_b: Path, json_output: bool = False)
 
 
 def _scores_by_artifact(records: list[core.OutcomeRecord]) -> dict[str, core.OutcomeScore]:
+    grouped = _records_by_artifact(records)
+    return {artifact_id: core.score_records(artifact_id, recs) for artifact_id, recs in grouped.items()}
+
+
+def _records_by_artifact(records: list[core.OutcomeRecord]) -> dict[str, list[core.OutcomeRecord]]:
     grouped: dict[str, list[core.OutcomeRecord]] = {}
     for record in records:
         grouped.setdefault(record.artifact_id, []).append(record)
-    return {artifact_id: core.score_records(artifact_id, recs) for artifact_id, recs in grouped.items()}
+    return grouped
+
+
+def _graph_count_value(value) -> int | None:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def _graph_delta_counts(records: list[core.OutcomeRecord]) -> dict[str, int] | None:
+    deltas = [
+        record.code_graph_delta for record in core.scored_records(records) if isinstance(record.code_graph_delta, dict)
+    ]
+    if not deltas:
+        return None
+    counts = {"graph_changing": 0, "graph_no_op": 0}
+    for delta in deltas:
+        if delta.get("status") != "ok":
+            continue
+        changed_symbols = _graph_count_value(delta.get("changed_symbol_count"))
+        edge_churn = _graph_count_value(delta.get("edge_churn"))
+        if (changed_symbols is not None and changed_symbols > 0) or (edge_churn is not None and edge_churn > 0):
+            counts["graph_changing"] += 1
+        elif changed_symbols == 0 and edge_churn == 0:
+            counts["graph_no_op"] += 1
+    return counts
+
+
+def _graph_delta_counts_by_artifact(records: list[core.OutcomeRecord]) -> dict[str, dict[str, int]]:
+    return {
+        artifact_id: counts
+        for artifact_id, recs in _records_by_artifact(records).items()
+        if (counts := _graph_delta_counts(recs)) is not None
+    }
+
+
+def _graph_delta_human_suffix(counts: dict[str, int] | None) -> str:
+    if counts is None:
+        return ""
+    return f" graph: {counts['graph_changing']} changing / {counts['graph_no_op']} no-op"
 
 
 def score(*, target: Path, artifact_id: str | None = None, json_output: bool = False) -> int:
@@ -376,10 +443,11 @@ def capture(
         signal_value=core.signal_value("verify", status),
         evidence_ref=str(Path(str(receipt.get("path", ""))) / "receipt.json"),
         ts=str(receipt.get("completed_at") or receipt.get("started_at") or localio.utc_now_iso()),
+        code_graph_delta=_compact_code_graph_delta(receipt),
     )
     append_records(target, [record])
     if json_output:
-        print(json.dumps({"target": str(target), "record": dataclasses.asdict(record)}, indent=2, sort_keys=True))
+        print(json.dumps({"target": str(target), "record": _record_payload(record)}, indent=2, sort_keys=True))
         return 0
     print(f"outcome capture: {artifact_id}")
     print(f"source: verify [{status}] signal={record.signal_value:+d}")
@@ -452,6 +520,7 @@ def reconcile(
     config = config or core.ReconcileConfig()
     records = load_records(target)
     scores = _scores_by_artifact(records)
+    graph_counts = _graph_delta_counts_by_artifact(records)
     kinds: dict[str, str] = {}
     for record in records:
         kinds.setdefault(record.artifact_id, record.artifact_kind or "skill")
@@ -515,22 +584,26 @@ def reconcile(
                 applied.append(decision.artifact_id)
         localio.write_json(_status_path(target), {"version": 1, "artifacts": status_map})
 
+    decisions_payload = []
+    for decision, score_obj, prior_status in results:
+        item = {
+            "artifact_id": decision.artifact_id,
+            "action": decision.action,
+            "prior_status": prior_status,
+            "new_status": effective_status.get(decision.artifact_id, decision.new_status),
+            "decided_status": decision.new_status,
+            "reason": decision.reason,
+            "score": score_obj.score,
+            "execution": executions.get(decision.artifact_id, "dry-run"),
+        }
+        counts = graph_counts.get(decision.artifact_id)
+        if counts is not None:
+            item.update(counts)
+        decisions_payload.append(item)
     payload = {
         "target": str(target),
         "apply": apply,
-        "decisions": [
-            {
-                "artifact_id": decision.artifact_id,
-                "action": decision.action,
-                "prior_status": prior_status,
-                "new_status": effective_status.get(decision.artifact_id, decision.new_status),
-                "decided_status": decision.new_status,
-                "reason": decision.reason,
-                "score": score_obj.score,
-                "execution": executions.get(decision.artifact_id, "dry-run"),
-            }
-            for decision, score_obj, prior_status in results
-        ],
+        "decisions": decisions_payload,
         "applied": applied,
     }
     if json_output:
@@ -546,7 +619,11 @@ def reconcile(
         # On --apply, surface the physical execution so the output is never
         # byte-identical to a dry-run that did nothing.
         tail = f" -> {executions[decision.artifact_id]}" if apply and decision.artifact_id in executions else ""
-        print(f"- {decision.artifact_id} {prior_status} -> {shown_status} [{decision.action}] {decision.reason}{tail}")
+        graph_tail = _graph_delta_human_suffix(graph_counts.get(decision.artifact_id))
+        print(
+            f"- {decision.artifact_id} {prior_status} -> {shown_status} "
+            f"[{decision.action}] {decision.reason}{graph_tail}{tail}"
+        )
     return 0
 
 
@@ -558,24 +635,30 @@ def rank(*, target: Path, json_output: bool = False) -> int:
     by what a real signal has confirmed.
     """
     target = target.expanduser().resolve()
-    scores = _scores_by_artifact(load_records(target))
+    records = load_records(target)
+    scores = _scores_by_artifact(records)
+    graph_counts = _graph_delta_counts_by_artifact(records)
 
     def blended(item: core.OutcomeScore) -> float:
         return core.rank_score(confidence=0.0, outcome=item.score, keyword=0.0)
 
     ordered = sorted(scores.values(), key=lambda item: (-blended(item), item.artifact_id))
+    ranking_payload = []
+    for item in ordered:
+        entry = {
+            "artifact_id": item.artifact_id,
+            "score": item.score,
+            "rank_score": blended(item),
+            "helped": item.helped,
+            "hurt": item.hurt,
+        }
+        counts = graph_counts.get(item.artifact_id)
+        if counts is not None:
+            entry.update(counts)
+        ranking_payload.append(entry)
     payload = {
         "target": str(target),
-        "ranking": [
-            {
-                "artifact_id": item.artifact_id,
-                "score": item.score,
-                "rank_score": blended(item),
-                "helped": item.helped,
-                "hurt": item.hurt,
-            }
-            for item in ordered
-        ],
+        "ranking": ranking_payload,
     }
     if json_output:
         print(json.dumps(payload, indent=2, sort_keys=True))
@@ -585,7 +668,8 @@ def rank(*, target: Path, json_output: bool = False) -> int:
         print("ranking: none")
         return 0
     for item in ordered:
-        print(f"- {item.artifact_id} score={item.score:.3f} helped={item.helped} hurt={item.hurt}")
+        graph_tail = _graph_delta_human_suffix(graph_counts.get(item.artifact_id))
+        print(f"- {item.artifact_id} score={item.score:.3f} helped={item.helped} hurt={item.hurt}{graph_tail}")
     return 0
 
 
@@ -623,7 +707,7 @@ def record(
     )
     append_records(target, [new_record])
     if json_output:
-        print(json.dumps({"target": str(target), "record": dataclasses.asdict(new_record)}, indent=2, sort_keys=True))
+        print(json.dumps({"target": str(target), "record": _record_payload(new_record)}, indent=2, sort_keys=True))
         return 0
     print(f"outcome record: {artifact_id}")
     print(f"source: {source} [{status}] signal={new_record.signal_value:+d}")

--- a/tests/test_outcome_cmd.py
+++ b/tests/test_outcome_cmd.py
@@ -1,12 +1,41 @@
 import json
 
-from brigade import cli, localio, outcome, outcome_cmd, work_cmd
+from brigade import cli, localio, outcome, outcome_cmd, receipts_cmd, work_cmd
 
 from tests.work_cmd_test_helpers import _init_git_repo
 
 
 def _seed(target, records):
     outcome_cmd.append_records(target, records)
+
+
+def _write_verify_receipt(
+    target,
+    run_id="verify-run",
+    *,
+    status="completed",
+    code_graph_delta=None,
+    started_at="2026-06-20T00:00:00+00:00",
+):
+    run_dir = target / ".brigade" / "work" / "verify-runs" / run_id
+    run_dir.mkdir(parents=True)
+    receipt = {
+        "run_id": run_id,
+        "target": str(target),
+        "status": status,
+        "started_at": started_at,
+        "completed_at": started_at,
+        "commands": [],
+    }
+    if code_graph_delta is not None:
+        receipt["code_graph_delta"] = code_graph_delta
+    receipt["digests"] = {
+        "algorithm": "sha256",
+        "logs": {},
+        "receipt_sha256": localio.canonical_json_digest(receipt, exclude_keys={"digests"}),
+    }
+    localio.write_json(run_dir / "receipt.json", receipt)
+    return run_dir / "receipt.json"
 
 
 def test_records_persist_under_git_tracked_memory_dir(tmp_path):
@@ -138,6 +167,65 @@ def test_capture_records_a_passing_verify_run_as_helped(tmp_path, capsys):
     assert len(records) == 1 and records[0].evidence_ref.endswith("receipt.json")
 
 
+def test_capture_copies_compact_code_graph_delta_from_verify_receipt(tmp_path, capsys):
+    delta = {
+        "status": "ok",
+        "summary": "changed_symbols=3 edge_churn=2",
+        "changed_symbol_count": 3,
+        "edge_churn": 2,
+        "raw_counts": {"edges_added": 5, "edges_removed": 3},
+        "sidecar_path": "/tmp/not-copied.json",
+        "internal_debug": {"ignored": True},
+    }
+    _write_verify_receipt(tmp_path, run_id="with-delta", code_graph_delta=delta)
+
+    assert (
+        outcome_cmd.capture(
+            target=tmp_path,
+            artifact_id="skill-x",
+            artifact_kind="skill",
+            task_id="t-delta",
+            run_id="with-delta",
+            json_output=True,
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    compact = {
+        "status": "ok",
+        "summary": "changed_symbols=3 edge_churn=2",
+        "changed_symbol_count": 3,
+        "edge_churn": 2,
+        "raw_counts": {"edges_added": 5, "edges_removed": 3},
+    }
+    assert payload["record"]["code_graph_delta"] == compact
+
+    row = json.loads((tmp_path / "memory" / "outcome" / "records.jsonl").read_text())
+    assert row["code_graph_delta"] == compact
+    assert "sidecar_path" not in row["code_graph_delta"]
+    assert row["digest"] == localio.canonical_json_digest(row, exclude_keys={"digest"})
+
+
+def test_capture_omits_code_graph_delta_when_verify_receipt_omits_it(tmp_path, capsys):
+    _write_verify_receipt(tmp_path, run_id="legacy-without-delta")
+
+    assert (
+        outcome_cmd.capture(
+            target=tmp_path,
+            artifact_id="skill-x",
+            artifact_kind="skill",
+            run_id="legacy-without-delta",
+            json_output=True,
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    row = json.loads((tmp_path / "memory" / "outcome" / "records.jsonl").read_text())
+
+    assert "code_graph_delta" not in payload["record"]
+    assert "code_graph_delta" not in row
+
+
 def test_capture_records_a_failing_verify_run_as_hurt(tmp_path, capsys):
     _init_git_repo(tmp_path)
     assert work_cmd.verify_run(target=tmp_path, commands=['python3 -c "raise SystemExit(3)"'], timeout=30) == 3
@@ -236,6 +324,36 @@ def test_reconcile_holds_inside_cooldown_after_apply(tmp_path, capsys, monkeypat
     assert payload["decisions"] == []
 
 
+def test_rebuild_status_check_accepts_mixed_legacy_and_delta_ledger(tmp_path, capsys):
+    _seed(
+        tmp_path,
+        [
+            outcome.OutcomeRecord("card-x", "card", "t1", "verify", 1, "ref1", "2026-06-20T00:00:00+00:00"),
+            outcome.OutcomeRecord(
+                "card-x",
+                "card",
+                "t2",
+                "verify",
+                1,
+                "ref2",
+                "2026-06-20T01:00:00+00:00",
+                code_graph_delta={
+                    "status": "ok",
+                    "summary": "changed_symbols=1",
+                    "changed_symbol_count": 1,
+                },
+            ),
+        ],
+    )
+    assert outcome_cmd.reconcile(target=tmp_path, apply=True, json_output=True) == 0
+    capsys.readouterr()
+
+    assert outcome_cmd.rebuild_status(target=tmp_path, check=True, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["reproducible"] is True
+    assert payload["drift"] == []
+
+
 def test_reconcile_rolls_back_promoted_artifact_on_regression(tmp_path, capsys, monkeypatch):
     _stub_execute(monkeypatch)
     cfg = outcome.ReconcileConfig(cooldown_seconds=0)
@@ -276,6 +394,135 @@ def test_rank_orders_artifacts_by_verified_score(tmp_path, capsys):
     assert ids.index("skill-a") < ids.index("skill-b")
 
 
+def test_rank_human_surfaces_graph_delta_counters_for_delta_subjects(tmp_path, capsys):
+    _seed(
+        tmp_path,
+        [
+            outcome.OutcomeRecord(
+                "skill-x",
+                "skill",
+                "t1",
+                "verify",
+                1,
+                "ref1",
+                "2026-06-20T00:00:00+00:00",
+                code_graph_delta={"status": "ok", "changed_symbol_count": 2, "edge_churn": 0},
+            ),
+            outcome.OutcomeRecord(
+                "skill-x",
+                "skill",
+                "t2",
+                "verify",
+                1,
+                "ref2",
+                "2026-06-20T01:00:00+00:00",
+                code_graph_delta={"status": "ok", "changed_symbol_count": 0, "edge_churn": 0},
+            ),
+            outcome.OutcomeRecord(
+                "skill-x",
+                "skill",
+                "t3",
+                "verify",
+                1,
+                "ref3",
+                "2026-06-20T02:00:00+00:00",
+                code_graph_delta={"status": "skipped", "changed_symbol_count": 0, "edge_churn": 0},
+            ),
+        ],
+    )
+
+    assert outcome_cmd.rank(target=tmp_path, json_output=False) == 0
+
+    assert "graph: 1 changing / 1 no-op" in capsys.readouterr().out
+
+
+def test_rank_json_includes_graph_delta_counters_for_mixed_records(tmp_path, capsys):
+    _seed(
+        tmp_path,
+        [
+            outcome.OutcomeRecord(
+                "skill-x",
+                "skill",
+                "t1",
+                "verify",
+                1,
+                "ref1",
+                "2026-06-20T00:00:00+00:00",
+                code_graph_delta={"status": "ok", "changed_symbol_count": 0, "edge_churn": 1},
+            ),
+            outcome.OutcomeRecord(
+                "skill-x",
+                "skill",
+                "t2",
+                "verify",
+                1,
+                "ref2",
+                "2026-06-20T01:00:00+00:00",
+                code_graph_delta={"status": "ok", "changed_symbol_count": 0, "edge_churn": 0},
+            ),
+            outcome.OutcomeRecord("skill-y", "skill", "t3", "verify", 1, "ref3", "2026-06-20T02:00:00+00:00"),
+        ],
+    )
+
+    assert outcome_cmd.rank(target=tmp_path, json_output=True) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    ranking = {item["artifact_id"]: item for item in payload["ranking"]}
+    assert ranking["skill-x"]["graph_changing"] == 1
+    assert ranking["skill-x"]["graph_no_op"] == 1
+    assert "graph_changing" not in ranking["skill-y"]
+    assert "graph_no_op" not in ranking["skill-y"]
+
+
+def test_reconcile_dry_run_json_surfaces_graph_delta_counters(tmp_path, capsys):
+    _seed(
+        tmp_path,
+        [
+            outcome.OutcomeRecord(
+                "skill-x",
+                "skill",
+                "t1",
+                "verify",
+                1,
+                "ref1",
+                "2026-06-20T00:00:00+00:00",
+                code_graph_delta={"status": "ok", "changed_symbol_count": 1, "edge_churn": 0},
+            ),
+            outcome.OutcomeRecord(
+                "skill-x",
+                "skill",
+                "t2",
+                "verify",
+                1,
+                "ref2",
+                "2026-06-20T01:00:00+00:00",
+                code_graph_delta={"status": "ok", "changed_symbol_count": 0, "edge_churn": 0},
+            ),
+        ],
+    )
+
+    assert outcome_cmd.reconcile(target=tmp_path, apply=False, json_output=True) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    decision = {item["artifact_id"]: item for item in payload["decisions"]}["skill-x"]
+    assert decision["action"] == "install"
+    assert decision["graph_changing"] == 1
+    assert decision["graph_no_op"] == 1
+    assert not _status_file(tmp_path).exists()
+    assert not _decisions_dir(tmp_path).exists()
+
+
+def test_rank_human_output_unchanged_without_delta_records(tmp_path, capsys):
+    _seed(tmp_path, [outcome.OutcomeRecord("skill-x", "skill", "t1", "verify", 1, "ref1", "2026-06-20T00:00:00+00:00")])
+
+    assert outcome_cmd.rank(target=tmp_path, json_output=False) == 0
+
+    expected = (
+        f"outcome rank: {tmp_path.resolve()}\n- skill-x score={outcome.wilson_lower_bound(1, 1):.3f} helped=1 hurt=0\n"
+    )
+    assert capsys.readouterr().out == expected
+
+
 def test_record_appends_an_explicit_friction_cleared_signal(tmp_path, capsys):
     assert (
         outcome_cmd.record(
@@ -307,6 +554,28 @@ def test_record_friction_recurred_is_a_hurt_signal(tmp_path, capsys):
     )
     capsys.readouterr()
     assert outcome_cmd.load_records(tmp_path)[0].signal_value == -1
+
+
+def test_receipts_verify_accepts_code_graph_delta_outcome_chain(tmp_path, capsys):
+    _write_verify_receipt(
+        tmp_path,
+        run_id="with-delta",
+        code_graph_delta={
+            "status": "ok",
+            "summary": "edge_churn=1",
+            "edge_churn": 1,
+        },
+    )
+    assert outcome_cmd.capture(target=tmp_path, artifact_id="skill-x", run_id="with-delta", json_output=True) == 0
+    capsys.readouterr()
+
+    assert receipts_cmd.verify(target=tmp_path, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["summary"]["mismatch"] == 0
+    assert payload["summary"]["missing"] == 0
+    ledger_items = [item for item in payload["artifacts"] if item["artifact_type"] == "outcome-ledger-record"]
+    assert ledger_items
+    assert all(item["status"] == "OK" for item in ledger_items)
 
 
 def test_cli_outcome_rank_and_record_dispatch(tmp_path, capsys):


### PR DESCRIPTION
The outcome ledger grades skills by exit codes; now each record can also say whether the run structurally changed the code graph.

- Capture copies the verify receipt's compact `code_graph_delta` ({status, summary, changed_symbol_count, edge_churn, raw_counts}) onto the outcome record, positioned inside the hashed content so the #157 `prev_digest`/`digest` chain covers it. Legacy receipts produce records without the field; mixed ledgers pass `rebuild-status --check` and `receipts verify` (reviewer ran it: ok=40, mismatch=0).
- `outcome rank` and `outcome reconcile` surface `graph: N changing / M no-op` per subject (and the counters in `--json`) when any scored record carries the field. Subjects without deltas print byte-for-byte as today.
- Deliberately surfacing-only: promotion decision rules are untouched. Docs carry the honest caveat that a zero delta does not mean nothing happened (docs-only changes, test-only changes).

Verification: full `pytest` green on host (brigade receipt `20260708-165558-work-verify-dfb652`), ruff check/format and mypy clean, rank dogfooded against the graphtrail ledger (156+ records, legacy output unchanged).