### PR TITLE
fix(receipts): skip miseledger import subprocess on zero-item export

### DIFF
--- a/src/brigade/receipts_cmd.py
+++ b/src/brigade/receipts_cmd.py
@@ -1186,6 +1186,15 @@ def export_miseledger(
             if isinstance(record.get("raw"), dict) and record["raw"].get("hash") not in cursor_hashes
         ]
     lines = _miseledger_jsonl_lines(records)
+    if import_miseledger and not lines:
+        # An import invocation costs minutes against a large archive regardless
+        # of input size, so a zero-item export never launches the subprocess.
+        if str(out) != "-":
+            exit_code, _ = _write_miseledger_lines_to_path(Path(out).expanduser(), lines)
+            if exit_code != 0:
+                return exit_code
+        print("nothing new; import skipped")
+        return 0
     output_path: Path | None = None
     if str(out) == "-" and not import_miseledger:
         exit_code, written_hashes = _write_miseledger_lines_to_stdout(lines)

--- a/tests/test_receipts_cmd.py
+++ b/tests/test_receipts_cmd.py
@@ -406,6 +406,37 @@ def test_receipts_export_miseledger_import_missing_binary_warns_and_exits_zero(t
     assert len(_jsonl(out_path.read_text())) == 1
 
 
+def test_receipts_export_miseledger_import_skips_binary_on_zero_item_export(tmp_path, monkeypatch, capsys):
+    _write_verify_export_receipt(
+        tmp_path,
+        "20260708-120000-work-verify-nothing-new",
+        started_at="2026-07-08T12:00:00Z",
+    )
+    fake = tmp_path / "miseledger"
+    fake.write_text(
+        f"""#!{sys.executable}
+import pathlib
+import sys
+
+pathlib.Path(sys.argv[3]).parent.joinpath("import-argv.json").write_text("invoked")
+"""
+    )
+    fake.chmod(0o755)
+    monkeypatch.setenv("PATH", str(tmp_path))
+
+    assert cli.main(["receipts", "export", "miseledger", "--target", str(tmp_path), "--new-only"]) == 0
+    assert len(_jsonl(capsys.readouterr().out)) == 1
+
+    assert cli.main(["receipts", "export", "miseledger", "--target", str(tmp_path), "--new-only", "--import"]) == 0
+    captured = capsys.readouterr()
+
+    assert captured.out == "nothing new; import skipped\n"
+    assert captured.err == ""
+    work_dir = tmp_path / ".brigade" / "work"
+    assert not (work_dir / "import-argv.json").exists()
+    assert list(work_dir.glob("miseledger-export-*.jsonl")) == []
+
+
 def test_receipts_export_miseledger_copies_git_metadata_and_github_commit_link(tmp_path, capsys):
     head = _init_git_repo_with_head(tmp_path)
     subprocess.run(


### PR DESCRIPTION
## Problem

`brigade receipts export miseledger --new-only --import` (from #159/#162) always invoked the `miseledger import adapter` subprocess, even when the cursor filtered every receipt and the export had zero lines. Against a large miseledger archive an import invocation costs about 2 minutes regardless of input size, so scheduled no-op passes burned that for nothing. Each stdout-mode no-op run also left an empty `miseledger-export-*.jsonl` temp file under `.brigade/work/`.

## Fix

When `--import` is set and the export produced zero lines, print `nothing new; import skipped` and exit 0 without launching the subprocess. With the default stdout output, no temp export file is created either. An explicit `--out` path still gets written (empty), preserving the existing file contract.

## Tests

New `test_receipts_export_miseledger_import_skips_binary_on_zero_item_export` alongside the existing `--import` tests: seeds the cursor with a first `--new-only` export, then runs `--new-only --import` with a fake `miseledger` binary on PATH that drops a marker file when invoked. Asserts exit 0, the skip message, no marker (binary never ran), and no leftover temp export files.

## Verification

- `./scripts/verify` (ruff check, ruff format --check, version sync, full pytest): pass
- `.venv/bin/mypy`: pass

Both runs recorded as Brigade verify receipts (`20260708-181327-work-verify-9a44cc`, `20260708-181647-work-verify-5d4907`).