### PR TITLE
feat(guard): vendor content-guard as the brigade guard command group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Vendored content-guard under `brigade.guard`, added `python -m brigade.guard` and `brigade guard ...`, and packaged the guard policies so scrub works without a separate checkout.
+
+### Changed
+- `brigade scrub` now defaults to the embedded `brigade.guard` scanner and policy set. Setting `CONTENT_GUARD_DIR` still preserves the old external checkout behavior, including `python -m content_guard` with that checkout's `src` on `PYTHONPATH`.
+
 ## [0.19.0] - 2026-07-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ profile: local-operator
 ready: yes
 blocking_issues: 0
 next: brigade daily plan --target .
-content_guard: missing hook=not-enabled policy=public-repo
+content_guard: installed hook=not-enabled policy=public-repo
 ```
 
-content-guard is an optional sidecar in its own repo; doctor reports it missing until you install it (`brigade add guard`) and stays ready regardless.
+Brigade ships its content guard scanner in the CLI, so `brigade scrub` works on a fresh install. Set `CONTENT_GUARD_DIR` only when you want to run an external content-guard checkout instead.
 
 ## One MCP catalog, synced into every tool
 
@@ -193,7 +193,7 @@ The whole ledger is plain JSON and markdown under `memory/outcome/`, tracked in 
 
 ## Sidecars
 
-Brigade is the hub. Each station wires an optional standalone tool, installed with `brigade add <station>` and health-checked by `brigade status` and `brigade doctor`. Every tool is its own repo, independently installable, with no library coupling back into Brigade.
+Brigade is the hub. Most stations wire an optional standalone tool, installed with `brigade add <station>` and health-checked by `brigade status` and `brigade doctor`. Each external tool is its own repo, independently installable, with no library coupling back into Brigade.
 
 Use `brigade profiles list` to see built-in station bundles and `brigade stations list` to see which stations are selected by the default repo profile before installing any sidecar tools. `brigade stations list --json` also shows each managed tool's machine surfaces: doctor JSON, markdown briefs, summary JSON, and verify commands where the tool supports them.
 
@@ -209,7 +209,7 @@ brigade add ../agentpantry --install # run the manifest install command
 | `brigade add` | Tool | What it does |
 |---|---|---|
 | `skills` | built-in Scout skills; optional Skillet roster | wires `brigade-work` and `ultra-work-scout` on init; use `skills add escoffier-labs/skillet` after installing the sidecar CLI for the full roster |
-| `guard` | content-guard | scans handoffs and content for secrets and PII before anything leaves the machine |
+| `guard` | embedded content guard, with an optional external checkout override | scans handoffs and content for secrets and PII before anything leaves the machine |
 | `tokens` | token-glace | tracks token spend across your harnesses and compacts noisy output |
 | `memory` | memory-doctor, bootstrap-doctor | validates memory cards and bootstrap files for staleness and contradictions |
 | `pantry` | agentpantry | syncs browser sessions and auth across an agent's machine |
@@ -251,7 +251,7 @@ The same review-and-receipt pattern covers the rest of an operator's day, and yo
 - **Cross-model runs**: `brigade run "<task>"` plans, dispatches, and synthesizes one bounded task across the agent CLIs in your roster, so an expensive model can think while cheaper ones do the grunt work. It can attach GraphTrail and upstream-drift context under a shared brief budget, then records which briefs attached in `run.json`. `--worktree` runs everything in a detached git checkout that comes back as a reviewable `changes.patch`.
 - **Daily loop**: `brigade work brief` shows pending work, imports, and warnings; `brigade daily status` keeps it bounded and cheap.
 - **Friction logs**: `brigade friction scan` mines recent notes, handoffs, and session artifacts for reviewable workflow friction.
-- **Security and scrub**: `brigade security scan` is a local read-only scanner for agent workspaces; `brigade scrub` gates content before it leaves the machine.
+- **Security and scrub**: `brigade security scan` is a local read-only scanner for agent workspaces. `brigade scrub` gates content before it leaves the machine, and `brigade guard` exposes the embedded content guard CLI.
 - **Research**: `brigade research run` turns a question into a cited local report and a reviewable memory handoff.
 - **Fleet and release**: health evidence across your local repos and release-readiness receipts, with no publish step.
 

--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -26,6 +26,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade dogfood` (extras): 1 command path(s)
 - `brigade extras`: 3 command path(s)
 - `brigade friction` (extras): 3 command path(s)
+- `brigade guard`: 1 command path(s)
 - `brigade handoff`: 17 command path(s)
 - `brigade handoff-template`: 1 command path(s)
 - `brigade hermes-fragments` (extras): 1 command path(s)
@@ -145,6 +146,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade friction add` (extras)
 - `brigade friction scan` (extras)
 - `brigade friction show` (extras)
+- `brigade guard`
 - `brigade handoff archive`
 - `brigade handoff closeout`
 - `brigade handoff doctor`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ solo-mise = "brigade.cli:main_deprecated"
 where = ["src"]
 
 [tool.setuptools.package-data]
-brigade = ["py.typed", "templates/**/*"]
+brigade = ["py.typed", "templates/**/*", "guard/policies/*.json", "guard/examples/**/*.json"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/brigade/cli/__init__.py
+++ b/src/brigade/cli/__init__.py
@@ -58,6 +58,7 @@ from . import (
     run as _run_group,
     roster as _roster_group,
     runs as _runs_group,
+    guard as _guard_group,
     scrub as _scrub_group,
     security as _security_group,
     tools as _tools_group,
@@ -154,6 +155,7 @@ def _build_parser() -> argparse.ArgumentParser:
     _roster_group.register(sub)
 
     _runs_group.register(sub)
+    _guard_group.register(sub)
     _scrub_group.register(sub)
     _security_group.register(sub)
     _tools_group.register(sub)

--- a/src/brigade/cli/_common.py
+++ b/src/brigade/cli/_common.py
@@ -23,7 +23,7 @@ COMMAND_GROUPS: list[tuple[str, list[str]]] = [
     ("Stations and tools", ["add", "stations", "skills", "tools", "mcp", "pantry", "roster", "run", "runs", "dogfood"]),
     (
         "Review, security, and research",
-        ["security", "scrub", "untrusted", "research", "learn", "outcome", "chat", "context", "projects"],
+        ["security", "guard", "scrub", "untrusted", "research", "learn", "outcome", "chat", "context", "projects"],
     ),
     (
         "Wiring and advanced",

--- a/src/brigade/cli/guard.py
+++ b/src/brigade/cli/guard.py
@@ -1,0 +1,74 @@
+"""brigade guard command group."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+
+# Subcommands with their own entry modules. Everything else falls through to
+# the embedded guard CLI (scan, redact, diff, audit, baseline, allow).
+_ROUTED: dict[str, tuple[str, str]] = {
+    "git": ("git_scan", "Scan tracked files or push history in a git repo."),
+    "commits": ("git_commits", "Scan the content introduced by a commit range."),
+    "publish-check": ("publish_check", "Pre-publication scan for a repo about to go public."),
+    "pr": ("pr_draft", "Scan a PR draft body before filing."),
+    "pr-prepare": ("pr_prepare", "Prepare and scan a PR draft."),
+    "n8n-advisory": ("n8n_advisory", "Advisory scan for n8n workflow content."),
+    "n8n-validate": ("n8n_validate", "Run the guard against the bundled n8n fixtures."),
+}
+
+_EMBEDDED: dict[str, str] = {
+    "scan": "Scan a file or stdin against a policy.",
+    "redact": "Redact findings from a file or stdin.",
+    "diff": "Show what redaction would change.",
+    "audit": "Aggregate scan results across a directory.",
+    "baseline": "Manage the accepted-findings baseline.",
+    "allow": "Manage policy allow_values.",
+}
+
+
+def _help_text() -> str:
+    lines = [
+        "usage: brigade guard <command> [args...]",
+        "",
+        "Policy-driven content scanning and redaction (embedded content guard).",
+        "",
+        "commands:",
+    ]
+    width = max(len(name) for name in (*_EMBEDDED, *_ROUTED)) + 2
+    for name, desc in _EMBEDDED.items():
+        lines.append(f"  {name.ljust(width)}{desc}")
+    for name, (_mod, desc) in _ROUTED.items():
+        lines.append(f"  {name.ljust(width)}{desc}")
+    lines.append("")
+    lines.append("Run brigade guard <command> --help for command-specific options.")
+    return "\n".join(lines)
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p_guard = sub.add_parser("guard", help="Run the embedded content guard.", add_help=False)
+    p_guard.add_argument("-h", "--help", action="store_true", dest="guard_help")
+    p_guard.add_argument("guard_args", nargs=argparse.REMAINDER)
+    p_guard.set_defaults(func=dispatch)
+
+
+def dispatch(args) -> int:
+    rest = list(args.guard_args)
+    if not rest:
+        print(_help_text())
+        return 0
+    head = rest[0]
+    if head in ("-h", "--help"):
+        print(_help_text())
+        return 0
+    if head in _ROUTED:
+        mod = importlib.import_module(f"brigade.guard.{_ROUTED[head][0]}")
+        sub_args = rest[1:]
+        if args.guard_help:
+            sub_args = ["--help", *sub_args]
+        return int(mod.main(sub_args))
+    from ..guard.cli import main as embedded_main
+
+    if args.guard_help:
+        rest = ["--help", *rest]
+    return int(embedded_main(rest))

--- a/src/brigade/guard/__init__.py
+++ b/src/brigade/guard/__init__.py
@@ -1,0 +1,6 @@
+"""Policy-driven content scanning and redaction."""
+
+from .engine import GuardResult, scan_text, redact_text
+from .policy import Policy, load_policy
+
+__all__ = ["GuardResult", "Policy", "load_policy", "scan_text", "redact_text"]

--- a/src/brigade/guard/__main__.py
+++ b/src/brigade/guard/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/brigade/guard/allowlist.py
+++ b/src/brigade/guard/allowlist.py
@@ -1,0 +1,111 @@
+"""Manage the allow_values list in a private policy file.
+
+This is the CLI counterpart to the pre-push hook's remedy text: when a
+known-public literal trips a scan (including history scans that inline allow
+comments cannot reach), the sanctioned fix is adding the exact matched string
+to allow_values in the private policy. `content-guard allow add` makes that a
+one-command operation instead of hand-editing JSON.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+DEFAULT_PRIVATE_POLICY = Path.home() / ".config" / "content-guard" / "internal.json"
+NOTES_KEY = "_allow_values_notes"
+
+
+def resolve_policy_path(arg: str | None) -> Path:
+    if arg:
+        return Path(arg)
+    env = os.environ.get("CONTENT_GUARD_PRIVATE_POLICY")
+    if env:
+        return Path(env)
+    return DEFAULT_PRIVATE_POLICY
+
+
+def add_values(policy_path: Path, values: list[str], note: str | None = None) -> tuple[list[str], list[str]]:
+    """Append literal values to allow_values, skipping duplicates.
+
+    Returns (added, skipped). Raises FileNotFoundError or ValueError on a
+    missing or malformed policy file; never creates a policy file from
+    scratch, since the private policy carries more than the allowlist.
+    """
+    raw = json.loads(policy_path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError(f"{policy_path}: policy root must be a JSON object")
+
+    existing = raw.get("allow_values")
+    if existing is None:
+        existing = []
+        raw["allow_values"] = existing
+    if not isinstance(existing, list):
+        raise ValueError(f"{policy_path}: allow_values must be a list")
+
+    added: list[str] = []
+    skipped: list[str] = []
+    for value in values:
+        if value in existing or value in added:
+            skipped.append(value)
+        else:
+            existing.append(value)
+            added.append(value)
+
+    if note and added:
+        notes = raw.get(NOTES_KEY)
+        if not isinstance(notes, dict):
+            notes = {}
+            raw[NOTES_KEY] = notes
+        for value in added:
+            notes[value] = note
+
+    if added or (note and not skipped):
+        policy_path.write_text(json.dumps(raw, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    return added, skipped
+
+
+def list_values(policy_path: Path) -> list[str]:
+    raw = json.loads(policy_path.read_text(encoding="utf-8"))
+    values = raw.get("allow_values", [])
+    if not isinstance(values, list):
+        raise ValueError(f"{policy_path}: allow_values must be a list")
+    return [str(v) for v in values]
+
+
+def run_add(policy_arg: str | None, values: list[str], note: str | None) -> int:
+    policy_path = resolve_policy_path(policy_arg)
+    try:
+        added, skipped = add_values(policy_path, values, note)
+    except FileNotFoundError:
+        print(f"allow add: policy file not found: {policy_path}", file=sys.stderr)
+        return 2
+    except (ValueError, json.JSONDecodeError) as exc:
+        print(f"allow add: {exc}", file=sys.stderr)
+        return 2
+
+    for value in added:
+        print(f"added: {value}")
+    for value in skipped:
+        print(f"already allowed: {value}")
+    print(f"policy: {policy_path} ({len(list_values(policy_path))} allow_values)")
+    return 0
+
+
+def run_list(policy_arg: str | None) -> int:
+    policy_path = resolve_policy_path(policy_arg)
+    try:
+        values = list_values(policy_path)
+    except FileNotFoundError:
+        print(f"allow list: policy file not found: {policy_path}", file=sys.stderr)
+        return 2
+    except (ValueError, json.JSONDecodeError) as exc:
+        print(f"allow list: {exc}", file=sys.stderr)
+        return 2
+
+    for value in values:
+        print(value)
+    return 0

--- a/src/brigade/guard/audit.py
+++ b/src/brigade/guard/audit.py
@@ -1,0 +1,218 @@
+"""Repo-level auditor: aggregate scan results across a directory tree.
+
+The `audit` command is reporting-oriented. It runs the same engine as
+`scan`, but instead of per-file output it produces a consolidated summary
+(counts by action / category / rule, top-offender files).
+
+Two enumeration modes:
+- `tracked` (default): use git's `ls-files` from inside the target directory.
+  Only files Git already knows about. This matches what the pre-push hook
+  scans and is the right default for "what could leak out of this repo".
+- `tree`: walk the filesystem with `Path.rglob("*")`, skipping the standard
+  excluded dirs (node_modules, .git, dist, etc.) and binary files. This is
+  the "what's lurking on disk" mode useful for local lint reviews.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+from .engine import scan_text
+from .git_scan import _read_text, _tracked_paths
+from .policy import Policy
+from .types import GuardResult, ScanOptions
+
+DEFAULT_EXCLUDE_DIR_NAMES = frozenset(
+    {
+        "node_modules",
+        ".git",
+        "dist",
+        "build",
+        "coverage",
+        ".next",
+        ".cache",
+        ".venv",
+        "__pycache__",
+        ".pytest_cache",
+        "out",
+        ".turbo",
+        ".parcel-cache",
+        "vendor",
+        ".claude",
+    }
+)
+
+
+@dataclass
+class FileAudit:
+    path: str
+    findings: int
+    blocked: bool
+
+
+@dataclass
+class AuditReport:
+    target: str
+    scope: str
+    files_scanned: int = 0
+    files_with_findings: int = 0
+    total_findings: int = 0
+    blocked: bool = False
+    by_action: dict[str, int] = field(default_factory=dict)
+    by_category: dict[str, int] = field(default_factory=dict)
+    by_rule: dict[str, int] = field(default_factory=dict)
+    file_audits: list[FileAudit] = field(default_factory=list)
+
+    def top_rules(self, limit: int = 10) -> list[tuple[str, int]]:
+        return sorted(self.by_rule.items(), key=lambda kv: (-kv[1], kv[0]))[:limit]
+
+    def top_offenders(self, limit: int = 5) -> list[FileAudit]:
+        with_findings = [f for f in self.file_audits if f.findings > 0]
+        return sorted(with_findings, key=lambda f: (-f.findings, f.path))[:limit]
+
+    def to_payload(self, *, top_rules: int = 10, top_offenders: int = 5) -> dict:
+        return {
+            "summary": {
+                "target": self.target,
+                "scope": self.scope,
+                "files_scanned": self.files_scanned,
+                "files_with_findings": self.files_with_findings,
+                "total_findings": self.total_findings,
+                "blocked": self.blocked,
+            },
+            "by_action": dict(sorted(self.by_action.items())),
+            "by_category": dict(sorted(self.by_category.items())),
+            "by_rule": [{"rule_id": rule_id, "count": count} for rule_id, count in self.top_rules(limit=top_rules)],
+            "top_offenders": [
+                {"path": entry.path, "findings": entry.findings, "blocked": entry.blocked}
+                for entry in self.top_offenders(limit=top_offenders)
+            ],
+        }
+
+
+def run_audit(
+    target: Path,
+    *,
+    policy: Policy,
+    scope: str = "tracked",
+    options: ScanOptions | None = None,
+    exclude_dirs: Iterable[str] = DEFAULT_EXCLUDE_DIR_NAMES,
+) -> AuditReport:
+    """Walk `target` per `scope`, scan each text file, and aggregate."""
+
+    if scope not in {"tracked", "tree"}:
+        raise ValueError(f"unknown scope: {scope!r} (expected 'tracked' or 'tree')")
+
+    target = Path(target)
+    if not target.exists():
+        raise FileNotFoundError(f"audit target does not exist: {target}")
+    if not target.is_dir():
+        raise NotADirectoryError(f"audit target must be a directory: {target}")
+
+    options = options or ScanOptions()
+    report = AuditReport(target=str(target), scope=scope)
+    paths = _enumerate(target, scope=scope, exclude_dirs=frozenset(exclude_dirs))
+
+    for path in paths:
+        text = _read_text(path)
+        if text is None:
+            continue
+
+        result = scan_text(text, policy=policy, options=options)
+        report.files_scanned += 1
+        _record(report, path, result, target=target)
+
+    return report
+
+
+def _enumerate(target: Path, *, scope: str, exclude_dirs: frozenset[str]) -> list[Path]:
+    if scope == "tracked":
+        rel_paths = _tracked_paths(all_tracked=True, cwd=target)
+        return [target / rel for rel in rel_paths]
+
+    # scope == "tree"
+    paths: list[Path] = []
+    for entry in sorted(target.rglob("*")):
+        if not entry.is_file():
+            continue
+        try:
+            rel_parts = entry.relative_to(target).parts
+        except ValueError:
+            rel_parts = entry.parts
+        if any(part in exclude_dirs for part in rel_parts):
+            continue
+        paths.append(entry)
+    return paths
+
+
+def _record(report: AuditReport, path: Path, result: GuardResult, *, target: Path) -> None:
+    findings = result.findings
+    try:
+        rel = path.relative_to(target)
+        path_str = str(rel)
+    except ValueError:
+        path_str = str(path)
+
+    report.file_audits.append(FileAudit(path=path_str, findings=len(findings), blocked=result.blocked))
+
+    if not findings:
+        return
+
+    report.files_with_findings += 1
+    report.total_findings += len(findings)
+    if result.blocked:
+        report.blocked = True
+
+    for finding in findings:
+        report.by_action[finding.action] = report.by_action.get(finding.action, 0) + 1
+        report.by_category[finding.category] = report.by_category.get(finding.category, 0) + 1
+        report.by_rule[finding.rule_id] = report.by_rule.get(finding.rule_id, 0) + 1
+
+
+def render_text(report: AuditReport) -> str:
+    """Render `report` as a human-readable multi-section summary."""
+
+    lines: list[str] = []
+    lines.append(f"content-guard audit: {report.target}")
+    lines.append("")
+    lines.append("Summary")
+    lines.append(f"  scope:               {report.scope}")
+    lines.append(f"  files scanned:       {report.files_scanned}")
+    lines.append(f"  files with findings: {report.files_with_findings}")
+    lines.append(f"  total findings:      {report.total_findings}")
+    lines.append(f"  blocked:             {str(report.blocked).lower()}")
+
+    if report.by_action:
+        lines.append("")
+        lines.append("By action")
+        for action, count in sorted(report.by_action.items()):
+            lines.append(f"  {action:<8} {count}")
+
+    if report.by_category:
+        lines.append("")
+        lines.append("By category")
+        for category, count in sorted(report.by_category.items()):
+            lines.append(f"  {category:<16} {count}")
+
+    top_rules = report.top_rules(limit=10)
+    if top_rules:
+        lines.append("")
+        lines.append("By rule (top 10)")
+        for rule_id, count in top_rules:
+            lines.append(f"  {rule_id:<32} {count}")
+
+    top_offenders = report.top_offenders(limit=5)
+    if top_offenders:
+        lines.append("")
+        lines.append("Top offenders (top 5)")
+        for entry in top_offenders:
+            marker = " [BLOCKED]" if entry.blocked else ""
+            lines.append(f"  {entry.findings:>4}  {entry.path}{marker}")
+
+    if report.total_findings == 0:
+        lines.append("")
+        lines.append("Clean. No findings.")
+
+    return "\n".join(lines)

--- a/src/brigade/guard/baseline.py
+++ b/src/brigade/guard/baseline.py
@@ -1,0 +1,237 @@
+"""Baseline mode for content-guard.
+
+Baseline mode solves the "first install on a dirty repo" UX problem. The user
+runs ``content-guard baseline init <dir>`` to capture all current findings as
+accepted. Subsequent ``content-guard scan --baseline <path>`` invocations
+filter those known findings out, so the hook only fires on NEW violations.
+
+The baseline file is JSON (not YAML) because the core package is intentionally
+dependency-free; see AGENTS.md. The schema is versioned so future format
+changes can be detected and rejected explicitly.
+
+The fingerprint is a sha256 hash of ``rule_id + "::" + match`` truncated to
+16 hex chars. That gives a stable identifier across runs while ignoring
+position (line/column) so refactors that move text around still match. Path
+is matched separately so the same offending string in a different file is
+treated as a new finding.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .engine import scan_text
+from .policy import Policy
+from .types import Finding
+
+
+BASELINE_SCHEMA_VERSION = 1
+DEFAULT_BASELINE_FILENAME = ".content-guard-baseline.json"
+
+# Mirrors cli.DEFAULT_EXCLUDE_DIR_NAMES. Duplicated here to avoid a circular
+# import (cli imports from this module).
+_DEFAULT_EXCLUDE_DIR_NAMES = frozenset(
+    {
+        "node_modules",
+        ".git",
+        "dist",
+        "build",
+        "coverage",
+        ".next",
+        ".cache",
+        ".venv",
+        "__pycache__",
+        ".pytest_cache",
+        "out",
+        ".turbo",
+        ".parcel-cache",
+        "vendor",
+        ".claude",
+    }
+)
+
+
+@dataclass(frozen=True)
+class BaselineEntry:
+    """One accepted finding in the baseline file."""
+
+    path: str
+    rule_id: str
+    match: str
+    line: int
+    fingerprint: str
+
+
+@dataclass
+class Baseline:
+    """Collection of accepted findings plus metadata."""
+
+    entries: list[BaselineEntry] = field(default_factory=list)
+    created_at: str = ""
+    version: int = BASELINE_SCHEMA_VERSION
+
+    def _index(self) -> dict[tuple[str, str, str], BaselineEntry]:
+        """Index entries by (path, rule_id, fingerprint) for fast lookup."""
+        return {(e.path, e.rule_id, e.fingerprint): e for e in self.entries}
+
+    def contains(self, path: str, rule_id: str, fingerprint: str) -> bool:
+        return (path, rule_id, fingerprint) in self._index()
+
+
+def fingerprint_for(rule_id: str, match: str) -> str:
+    """Stable 16-char hex fingerprint for (rule_id, match) pair.
+
+    Same input always produces same output. Path is intentionally NOT part of
+    the fingerprint so the caller can decide whether to match cross-file or
+    same-file (we choose same-file at the filter step).
+    """
+    digest = hashlib.sha256(f"{rule_id}::{match}".encode("utf-8")).hexdigest()
+    return digest[:16]
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _entry_from_finding(finding: Finding, path: str) -> BaselineEntry:
+    return BaselineEntry(
+        path=path,
+        rule_id=finding.rule_id,
+        match=finding.match,
+        line=finding.line,
+        fingerprint=fingerprint_for(finding.rule_id, finding.match),
+    )
+
+
+def init_baseline(
+    target_dir: Path,
+    policy: Policy | None = None,
+    scope: str = "tree",
+) -> Baseline:
+    """Scan ``target_dir`` and capture all current findings as a baseline.
+
+    ``scope`` is accepted for future compatibility with the planned
+    ``--scope tracked|tree|staged|diff`` flag. Only ``tree`` is implemented
+    here; the scope arg is stored implicitly via the entries we capture.
+    """
+    if scope != "tree":
+        raise ValueError(f"baseline scope {scope!r} not yet supported (only 'tree')")
+
+    active_policy = policy or Policy()
+    entries: list[BaselineEntry] = []
+
+    target_dir = Path(target_dir)
+    if target_dir.is_file():
+        files = [target_dir]
+    else:
+        files = sorted(target_dir.rglob("*.md"))
+
+    for file_path in files:
+        if _DEFAULT_EXCLUDE_DIR_NAMES.intersection(file_path.parts):
+            continue
+        try:
+            text = file_path.read_text()
+        except (OSError, UnicodeDecodeError):
+            continue
+
+        result = scan_text(text, policy=active_policy)
+        rel_path = _relative_path(file_path, target_dir)
+        for finding in result.findings:
+            # Skip findings that are already allowed by inline directives — those
+            # don't need a baseline entry, and capturing them adds noise.
+            if finding.action == "allow":
+                continue
+            entries.append(_entry_from_finding(finding, rel_path))
+
+    return Baseline(entries=entries, created_at=_now_iso())
+
+
+def _relative_path(file_path: Path, target_dir: Path) -> str:
+    """Return a path relative to target_dir if possible, otherwise as-is."""
+    try:
+        if target_dir.is_file():
+            return file_path.name
+        return str(file_path.relative_to(target_dir))
+    except ValueError:
+        return str(file_path)
+
+
+def save_baseline(baseline: Baseline, path: Path) -> None:
+    """Write the baseline to ``path`` as JSON."""
+    payload = {
+        "version": baseline.version or BASELINE_SCHEMA_VERSION,
+        "created_at": baseline.created_at or _now_iso(),
+        "entries": [asdict(e) for e in baseline.entries],
+    }
+    Path(path).write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def load_baseline(path: Path) -> Baseline:
+    """Read and validate a baseline JSON file at ``path``."""
+    raw_text = Path(path).read_text()
+    try:
+        raw = json.loads(raw_text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"baseline file is not valid JSON: {exc}") from exc
+
+    if not isinstance(raw, dict):
+        raise ValueError("baseline root must be a JSON object")
+
+    version = raw.get("version")
+    if not isinstance(version, int):
+        raise ValueError("baseline 'version' must be an integer")
+    if version != BASELINE_SCHEMA_VERSION:
+        raise ValueError(f"unsupported baseline version {version!r}; expected {BASELINE_SCHEMA_VERSION}")
+
+    created_at = raw.get("created_at", "")
+    if not isinstance(created_at, str):
+        raise ValueError("baseline 'created_at' must be a string")
+
+    raw_entries = raw.get("entries")
+    if not isinstance(raw_entries, list):
+        raise ValueError("baseline 'entries' must be a list")
+
+    entries: list[BaselineEntry] = []
+    for i, item in enumerate(raw_entries):
+        if not isinstance(item, dict):
+            raise ValueError(f"baseline entries[{i}] must be an object")
+        try:
+            entry = BaselineEntry(
+                path=str(item["path"]),
+                rule_id=str(item["rule_id"]),
+                match=str(item["match"]),
+                line=int(item["line"]),
+                fingerprint=str(item["fingerprint"]),
+            )
+        except KeyError as exc:
+            raise ValueError(f"baseline entries[{i}] missing required field {exc.args[0]!r}") from exc
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"baseline entries[{i}] has invalid value: {exc}") from exc
+        entries.append(entry)
+
+    return Baseline(entries=entries, created_at=created_at, version=version)
+
+
+def filter_findings(
+    findings: list[Finding],
+    baseline: Baseline,
+    file_path: str,
+) -> list[Finding]:
+    """Return findings NOT present in the baseline for ``file_path``.
+
+    Matches by (path, rule_id, fingerprint). A finding with the same rule_id
+    but different match content (different fingerprint) is treated as NEW
+    even if it lives in a baselined file.
+    """
+    index = baseline._index()
+    kept: list[Finding] = []
+    for finding in findings:
+        key = (file_path, finding.rule_id, fingerprint_for(finding.rule_id, finding.match))
+        if key in index:
+            continue
+        kept.append(finding)
+    return kept

--- a/src/brigade/guard/cli.py
+++ b/src/brigade/guard/cli.py
@@ -1,0 +1,359 @@
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import sys
+from pathlib import Path
+
+from . import allowlist
+from .audit import render_text as render_audit_text, run_audit
+from .baseline import (
+    DEFAULT_BASELINE_FILENAME,
+    Baseline,
+    filter_findings,
+    init_baseline,
+    load_baseline,
+    save_baseline,
+)
+from .engine import scan_text
+from .git_scan import _default_repo_policy
+from .policy import load_policy
+from .report import to_json, to_payload, to_text
+from .types import GuardResult, ScanOptions
+
+
+DEFAULT_EXCLUDE_DIR_NAMES = frozenset(
+    {
+        "node_modules",
+        ".git",
+        "dist",
+        "build",
+        "coverage",
+        ".next",
+        ".cache",
+        ".venv",
+        "__pycache__",
+        ".pytest_cache",
+        "out",
+        ".turbo",
+        ".parcel-cache",
+        "vendor",
+        ".claude",
+    }
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "scan":
+        return _scan(args)
+    if args.command == "redact":
+        return _redact(args)
+    if args.command == "diff":
+        return _diff(args)
+    if args.command == "audit":
+        return _audit(args)
+    if args.command == "baseline":
+        return _baseline(args)
+    if args.command == "allow":
+        if args.allow_action == "add":
+            return allowlist.run_add(args.policy, args.values, args.note)
+        return allowlist.run_list(args.policy)
+
+    parser.error(f"unknown command: {args.command}")
+    return 2
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="brigade guard",
+        description="Policy-driven content scanning and redaction.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    for name in ("scan", "redact", "diff"):
+        cmd = sub.add_parser(name)
+        cmd.add_argument("target", nargs="?", help="file to read, or stdin when omitted")
+        cmd.add_argument("--policy", help="JSON policy file")
+        cmd.add_argument("--opf", action="store_true", help="run optional OPF backend")
+        cmd.add_argument("--opf-bin", help="path to opf binary")
+        cmd.add_argument("--opf-device", help="OPF device, default comes from policy or cpu")
+        cmd.add_argument("--scan-frontmatter", action="store_true", help="scan YAML frontmatter")
+        cmd.add_argument("--skip-code-blocks", action="store_true", help="ignore fenced code blocks")
+        cmd.add_argument("--no-allow-comments", action="store_true", help="ignore content-guard allow comments")
+
+    sub.choices["scan"].add_argument("--json", action="store_true", help="emit JSON report")
+    sub.choices["scan"].add_argument(
+        "--baseline",
+        help="path to a baseline file; findings already in the baseline are suppressed",
+    )
+    sub.choices["redact"].add_argument("--in-place", action="store_true", help="rewrite the target file")
+
+    audit_cmd = sub.add_parser("audit", help="aggregate scan results across a directory")
+    audit_cmd.add_argument("target", help="directory to audit")
+    audit_cmd.add_argument("--policy", help="JSON policy file (default: built-in public-repo policy)")
+    audit_cmd.add_argument(
+        "--scope",
+        choices=("tracked", "tree"),
+        default="tracked",
+        help="enumerate via 'git ls-files' (tracked, default) or filesystem walk (tree)",
+    )
+    audit_cmd.add_argument("--json", action="store_true", help="emit JSON report")
+    audit_cmd.add_argument(
+        "--strict",
+        action="store_true",
+        help="exit non-zero if any blocking findings (default exits 0)",
+    )
+    audit_cmd.add_argument("--scan-frontmatter", action="store_true", help="scan YAML frontmatter")
+    audit_cmd.add_argument("--skip-code-blocks", action="store_true", help="ignore fenced code blocks")
+    audit_cmd.add_argument(
+        "--no-allow-comments",
+        action="store_true",
+        help="ignore content-guard allow comments",
+    )
+    audit_cmd.add_argument("--opf", action="store_true", help="run optional OPF backend")
+    audit_cmd.add_argument("--opf-bin", help="path to opf binary")
+    audit_cmd.add_argument("--opf-device", help="OPF device, default comes from policy or cpu")
+
+    baseline_cmd = sub.add_parser(
+        "baseline",
+        help="manage a baseline of pre-existing findings (gitleaks-style)",
+    )
+    baseline_sub = baseline_cmd.add_subparsers(dest="baseline_action", required=True)
+
+    baseline_init = baseline_sub.add_parser(
+        "init",
+        help="scan a directory and record current findings as an accepted baseline",
+    )
+    baseline_init.add_argument("target", help="directory to scan")
+    baseline_init.add_argument("--policy", help="JSON policy file")
+    baseline_init.add_argument(
+        "--output",
+        help=(f"output path for the baseline file (default: <target>/{DEFAULT_BASELINE_FILENAME})"),
+    )
+
+    allow_cmd = sub.add_parser(
+        "allow",
+        help="manage allow_values in the private policy (known-public literals)",
+    )
+    allow_sub = allow_cmd.add_subparsers(dest="allow_action", required=True)
+
+    allow_add = allow_sub.add_parser(
+        "add",
+        help="append exact literal strings to allow_values, skipping duplicates",
+    )
+    allow_add.add_argument("values", nargs="+", help="exact matched string(s) to allow")
+    allow_add.add_argument(
+        "--policy",
+        help=("policy file to edit (default: $CONTENT_GUARD_PRIVATE_POLICY or ~/.config/content-guard/internal.json)"),
+    )
+    allow_add.add_argument("--note", help="provenance note recorded next to the values")
+
+    allow_list = allow_sub.add_parser("list", help="print current allow_values")
+    allow_list.add_argument("--policy", help="policy file to read (same default as add)")
+
+    return parser
+
+
+def _options(args: argparse.Namespace) -> ScanOptions:
+    return ScanOptions(
+        scan_frontmatter=args.scan_frontmatter,
+        scan_code_blocks=not args.skip_code_blocks,
+        honor_allow_comments=not args.no_allow_comments,
+        include_opf=args.opf,
+        opf_device=args.opf_device,
+        opf_bin=args.opf_bin,
+    )
+
+
+def _read_target(target: str | None) -> tuple[str, str | None]:
+    if not target or target == "-":
+        return sys.stdin.read(), None
+    path = Path(target)
+    return path.read_text(), str(path)
+
+
+def _scan(args: argparse.Namespace) -> int:
+    policy = load_policy(args.policy)
+    options = _options(args)
+    target_path = Path(args.target) if args.target and args.target != "-" else None
+
+    baseline = load_baseline(Path(args.baseline)) if getattr(args, "baseline", None) else None
+
+    if target_path and target_path.is_dir():
+        results = _scan_directory(target_path, policy, options)
+        if baseline is not None:
+            results = [(p, _apply_baseline(r, baseline, _baseline_rel_path(p, target_path))) for p, r in results]
+        blocked = any(result.blocked for _, result in results)
+        if args.json:
+            print(
+                json.dumps(
+                    {
+                        "ok": not blocked,
+                        "blocked": blocked,
+                        "files_scanned": len(results),
+                        "files": [
+                            {"path": str(path), **to_payload(result)} for path, result in results if result.findings
+                        ],
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+        elif not any(result.findings for _, result in results):
+            print(f"Clean. {len(results)} file(s) checked.")
+        else:
+            for path, result in results:
+                if result.findings:
+                    print(to_text(result, path=str(path)))
+        return 1 if blocked else 0
+
+    text, path = _read_target(args.target)
+    result = scan_text(text, policy=policy, options=options)
+    if baseline is not None:
+        # Single-file scan: match against the file's basename, since baseline
+        # entries are stored relative to their init target directory.
+        rel = Path(path).name if path else ""
+        result = _apply_baseline(result, baseline, rel)
+    if args.json:
+        print(to_json(result))
+    else:
+        print(to_text(result, path=path or "<stdin>"))
+    return 1 if result.blocked else 0
+
+
+def _baseline_rel_path(file_path: Path, target_dir: Path) -> str:
+    try:
+        return str(file_path.relative_to(target_dir))
+    except ValueError:
+        return str(file_path)
+
+
+def _apply_baseline(result: GuardResult, baseline: Baseline, rel_path: str) -> GuardResult:
+    """Return a new GuardResult with baseline-known findings filtered out."""
+    kept = filter_findings(result.findings, baseline, rel_path)
+    return GuardResult(text=result.text, redacted_text=result.redacted_text, findings=kept)
+
+
+def _redact(args: argparse.Namespace) -> int:
+    policy = load_policy(args.policy)
+    options = _options(args)
+    target_path = Path(args.target) if args.target and args.target != "-" else None
+
+    if target_path and target_path.is_dir():
+        if not args.in_place:
+            print("directory redact requires --in-place", file=sys.stderr)
+            return 2
+        results = _scan_directory(target_path, policy, options)
+        for path, result in results:
+            if result.changed:
+                path.write_text(result.redacted_text)
+        return 1 if any(result.blocked for _, result in results) else 0
+
+    text, path = _read_target(args.target)
+    result = scan_text(text, policy=policy, options=options)
+
+    if args.in_place:
+        if not path:
+            print("--in-place requires a file target", file=sys.stderr)
+            return 2
+        Path(path).write_text(result.redacted_text)
+    else:
+        sys.stdout.write(result.redacted_text)
+    return 1 if result.blocked else 0
+
+
+def _diff(args: argparse.Namespace) -> int:
+    policy = load_policy(args.policy)
+    options = _options(args)
+    target_path = Path(args.target) if args.target and args.target != "-" else None
+
+    if target_path and target_path.is_dir():
+        results = _scan_directory(target_path, policy, options)
+        for path, result in results:
+            if not result.changed:
+                continue
+            _write_diff(result.text, result.redacted_text, str(path))
+        return 1 if any(result.blocked for _, result in results) else 0
+
+    text, path = _read_target(args.target)
+    result = scan_text(text, policy=policy, options=options)
+    source_name = path or "<stdin>"
+    _write_diff(text, result.redacted_text, source_name)
+    return 1 if result.blocked else 0
+
+
+def _scan_directory(
+    path: Path,
+    policy,
+    options: ScanOptions,
+    exclude_dirs: frozenset[str] = DEFAULT_EXCLUDE_DIR_NAMES,
+):
+    results = []
+    for file_path in sorted(path.rglob("*.md")):
+        if exclude_dirs.intersection(file_path.parts):
+            continue
+        text = file_path.read_text()
+        results.append((file_path, scan_text(text, policy=policy, options=options)))
+    return results
+
+
+def _audit(args: argparse.Namespace) -> int:
+    target = Path(args.target)
+    if not target.exists():
+        print(f"audit target does not exist: {target}", file=sys.stderr)
+        return 2
+    if not target.is_dir():
+        print(f"audit target must be a directory: {target}", file=sys.stderr)
+        return 2
+
+    policy = load_policy(args.policy) if args.policy else _default_repo_policy()
+    options = _options(args)
+
+    report = run_audit(target, policy=policy, scope=args.scope, options=options)
+
+    if args.json:
+        print(json.dumps(report.to_payload(), indent=2, sort_keys=True))
+    else:
+        print(render_audit_text(report))
+
+    if args.strict and report.blocked:
+        return 1
+    return 0
+
+
+def _baseline(args: argparse.Namespace) -> int:
+    if args.baseline_action != "init":
+        print(f"unknown baseline action: {args.baseline_action}", file=sys.stderr)
+        return 2
+
+    target = Path(args.target)
+    if not target.exists():
+        print(f"baseline target does not exist: {target}", file=sys.stderr)
+        return 2
+    if not target.is_dir():
+        print(f"baseline target must be a directory: {target}", file=sys.stderr)
+        return 2
+
+    policy = load_policy(args.policy) if args.policy else None
+    baseline = init_baseline(target, policy=policy, scope="tree")
+
+    out_path = Path(args.output) if args.output else target / DEFAULT_BASELINE_FILENAME
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    save_baseline(baseline, out_path)
+
+    print(f"Baseline written: {out_path} ({len(baseline.entries)} entry(ies) captured)")
+    return 0
+
+
+def _write_diff(text: str, redacted_text: str, source_name: str) -> None:
+    diff = difflib.unified_diff(
+        text.splitlines(keepends=True),
+        redacted_text.splitlines(keepends=True),
+        fromfile=source_name,
+        tofile=f"{source_name} (redacted)",
+    )
+    sys.stdout.writelines(diff)

--- a/src/brigade/guard/detectors/__init__.py
+++ b/src/brigade/guard/detectors/__init__.py
@@ -1,0 +1,1 @@
+"""Detector backends."""

--- a/src/brigade/guard/detectors/opf.py
+++ b/src/brigade/guard/detectors/opf.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class OpfResult:
+    available: bool
+    changed: bool
+    redacted_text: str
+    error: str = ""
+
+
+def default_opf_bin() -> str:
+    return os.environ.get("CONTENT_GUARD_OPF_BIN") or str(Path.home() / ".opf-venv" / "bin" / "opf")
+
+
+def run_opf(text: str, *, opf_bin: str | None = None, device: str = "cpu", timeout: int = 120) -> OpfResult:
+    opf = opf_bin or default_opf_bin()
+    if not os.path.exists(opf) or not os.access(opf, os.X_OK):
+        return OpfResult(False, False, text, f"opf binary not found: {opf}")
+
+    with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False) as handle:
+        handle.write(text)
+        path = handle.name
+
+    try:
+        proc = subprocess.run(
+            [opf, "--device", device, "-f", path],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return OpfResult(True, False, text, str(exc))
+    finally:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+    if proc.returncode != 0:
+        error = (proc.stderr or proc.stdout or "opf failed").strip()
+        return OpfResult(True, False, text, error)
+
+    redacted = proc.stdout
+    return OpfResult(True, redacted != text, redacted, "")

--- a/src/brigade/guard/engine.py
+++ b/src/brigade/guard/engine.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+import bisect
+import re
+
+from .detectors.opf import run_opf
+from .policy import Policy
+from .types import Finding, GuardResult, Rule, ScanOptions, TextEdit
+
+ALLOW_RE = re.compile(r"content-guard:\s*allow\s+([A-Za-z0-9_.:-]+|all)(?:\s+(file))?")
+
+
+def scan_text(text: str, policy: Policy | None = None, options: ScanOptions | None = None) -> GuardResult:
+    active_policy = policy or Policy()
+    active_options = options or ScanOptions()
+
+    line_starts = _line_starts(text)
+    skipped_ranges = _skipped_ranges(text, active_options)
+    if active_options.honor_allow_comments:
+        allow_by_line, file_allows = _allow_comments_by_line(text)
+    else:
+        allow_by_line, file_allows = {}, set()
+
+    allow_values = set(active_policy.allow_values)
+
+    findings: list[Finding] = []
+    occupied: list[tuple[int, int]] = []
+
+    for rule in active_policy.all_rules():
+        regex = re.compile(rule.pattern, rule.flags)
+        for match in regex.finditer(text):
+            start, end = match.span()
+            if start == end:
+                continue
+            if _inside_ranges(start, end, skipped_ranges):
+                continue
+            if _overlaps(start, end, occupied):
+                continue
+
+            line = _line_for_offset(line_starts, start)
+            allowed_by = _allowed_by(rule.id, line, allow_by_line, file_allows)
+            # A known-public literal exact-matches the whole finding text. This
+            # reaches history scans of old diffs where no inline marker exists.
+            if allowed_by is None and match.group(0) in allow_values:
+                allowed_by = "allow-value"
+            # A known-public literal may also be LONGER than the matched span
+            # (e.g. one public path that a broad home-path rule matches only a
+            # prefix of). It clears the finding only when this match span lies
+            # inside an occurrence of the literal on its line, so the same
+            # prefix elsewhere (even on the same line) stays blocked.
+            if allowed_by is None:
+                line_start = line_starts[line - 1]
+                line_end = line_starts[line] if line < len(line_starts) else len(text)
+                line_text = text[line_start:line_end]
+                allowed_by = _allowed_by_superstring_value(
+                    allow_values, match.group(0), line_text, line_start, start, end
+                )
+            action = "allow" if allowed_by else active_policy.action_for(rule)
+            findings.append(
+                Finding(
+                    rule_id=rule.id,
+                    category=rule.category,
+                    action=action,
+                    match=match.group(0),
+                    replacement=rule.replacement,
+                    line=line,
+                    column=start - line_starts[line - 1] + 1,
+                    start=start,
+                    end=end,
+                    source="regex",
+                    message=rule.description,
+                    allowed_by=allowed_by,
+                )
+            )
+            occupied.append((start, end))
+
+    redacted = _apply_edits(text, _edits_for(findings))
+
+    include_opf = active_options.include_opf or active_policy.opf_backend.enabled
+    opf_device = active_options.opf_device or active_policy.opf_backend.device
+    opf_bin = active_options.opf_bin or active_policy.opf_backend.bin
+
+    if include_opf:
+        opf_rule = Rule(
+            id="opf-pii",
+            category="pii",
+            pattern="",
+            replacement="<PRIVATE_DATA>",
+            description="OPF changed the text, indicating model-detected PII.",
+        )
+        opf_result = run_opf(
+            text,
+            opf_bin=opf_bin,
+            device=opf_device,
+        )
+        if opf_result.changed:
+            action = active_policy.action_for(opf_rule)
+            findings.append(
+                Finding(
+                    rule_id=opf_rule.id,
+                    category=opf_rule.category,
+                    action=action,
+                    match="<OPF_DETECTED_PII>",
+                    replacement="<PRIVATE_DATA>",
+                    line=1,
+                    column=1,
+                    start=0,
+                    end=0,
+                    source="opf",
+                    message="OPF redacted one or more spans.",
+                )
+            )
+            if action in {"redact", "block"}:
+                redacted = run_opf(
+                    redacted,
+                    opf_bin=opf_bin,
+                    device=opf_device,
+                ).redacted_text
+        elif opf_result.available and opf_result.error:
+            findings.append(
+                Finding(
+                    rule_id="opf-error",
+                    category="tooling",
+                    action="warn",
+                    match="opf",
+                    replacement="",
+                    line=1,
+                    column=1,
+                    start=0,
+                    end=0,
+                    source="opf",
+                    message=opf_result.error,
+                )
+            )
+        elif not opf_result.available:
+            findings.append(
+                Finding(
+                    rule_id="opf-unavailable",
+                    category="tooling",
+                    action="warn",
+                    match="opf",
+                    replacement="",
+                    line=1,
+                    column=1,
+                    start=0,
+                    end=0,
+                    source="opf",
+                    message=opf_result.error,
+                )
+            )
+
+    findings.sort(key=lambda item: (item.line, item.column, item.rule_id))
+    return GuardResult(text=text, redacted_text=redacted, findings=findings)
+
+
+def redact_text(text: str, policy: Policy | None = None, options: ScanOptions | None = None) -> str:
+    return scan_text(text, policy=policy, options=options).redacted_text
+
+
+def _allowed_by_superstring_value(
+    allow_values: set[str],
+    matched: str,
+    line_text: str,
+    line_start: int,
+    start: int,
+    end: int,
+) -> str | None:
+    """Clear a match covered by a longer known-public allow value.
+
+    The match span must sit inside an occurrence of the allow value on its own
+    line; an identical match outside the literal (even on the same line) is
+    not cleared.
+    """
+    for value in allow_values:
+        if matched not in value:
+            continue
+        idx = line_text.find(value)
+        while idx != -1:
+            value_start = line_start + idx
+            if value_start <= start and end <= value_start + len(value):
+                return "allow-value"
+            idx = line_text.find(value, idx + 1)
+    return None
+
+
+def _line_starts(text: str) -> list[int]:
+    starts = [0]
+    for match in re.finditer("\n", text):
+        starts.append(match.end())
+    return starts
+
+
+def _line_for_offset(starts: list[int], offset: int) -> int:
+    return bisect.bisect_right(starts, offset)
+
+
+def _allow_comments_by_line(text: str) -> tuple[dict[int, set[str]], set[str]]:
+    """Parse allow comments. Returns (line-scoped tokens, file-scoped tokens).
+
+    Line-scoped: `<!-- content-guard: allow <rule-id> -->` applies to the
+    comment's line and the line after (preserves existing semantics).
+
+    File-scoped: `<!-- content-guard: allow <rule-id> file -->` applies to the
+    entire file regardless of where the comment lives.
+    """
+    allowed: dict[int, set[str]] = {}
+    file_allows: set[str] = set()
+    for line_no, line in enumerate(text.splitlines(), 1):
+        match = ALLOW_RE.search(line)
+        if not match:
+            continue
+        token = match.group(1)
+        file_scope = match.group(2) == "file"
+        if file_scope:
+            file_allows.add(token)
+        else:
+            allowed.setdefault(line_no, set()).add(token)
+            allowed.setdefault(line_no + 1, set()).add(token)
+    return allowed, file_allows
+
+
+def _allowed_by(
+    rule_id: str,
+    line: int,
+    allow_by_line: dict[int, set[str]],
+    file_allows: set[str],
+) -> str | None:
+    if "all" in file_allows:
+        return "all"
+    if rule_id in file_allows:
+        return rule_id
+    tokens = allow_by_line.get(line, set())
+    if "all" in tokens:
+        return "all"
+    if rule_id in tokens:
+        return rule_id
+    return None
+
+
+def _skipped_ranges(text: str, options: ScanOptions) -> list[tuple[int, int]]:
+    ranges: list[tuple[int, int]] = []
+    lines = text.splitlines(keepends=True)
+
+    if not options.scan_frontmatter and lines and lines[0].strip() == "---":
+        end = len(lines[0])
+        for line in lines[1:]:
+            end += len(line)
+            if line.strip() == "---":
+                ranges.append((0, end))
+                break
+
+    if not options.scan_code_blocks:
+        in_fence = False
+        fence_start = 0
+        current = 0
+        for line in lines:
+            stripped = line.lstrip()
+            if stripped.startswith("```") or stripped.startswith("~~~"):
+                if not in_fence:
+                    in_fence = True
+                    fence_start = current
+                else:
+                    ranges.append((fence_start, current + len(line)))
+                    in_fence = False
+            current += len(line)
+        if in_fence:
+            ranges.append((fence_start, len(text)))
+
+    current = 0
+    for line in lines:
+        if "content-guard:" in line:
+            ranges.append((current, current + len(line)))
+        current += len(line)
+
+    return ranges
+
+
+def _inside_ranges(start: int, end: int, ranges: list[tuple[int, int]]) -> bool:
+    return any(start < range_end and end > range_start for range_start, range_end in ranges)
+
+
+def _overlaps(start: int, end: int, occupied: list[tuple[int, int]]) -> bool:
+    return any(start < prev_end and end > prev_start for prev_start, prev_end in occupied)
+
+
+def _edits_for(findings: list[Finding]) -> list[TextEdit]:
+    return [
+        TextEdit(finding.start, finding.end, finding.replacement)
+        for finding in findings
+        if finding.redacts and finding.start < finding.end
+    ]
+
+
+def _apply_edits(text: str, edits: list[TextEdit]) -> str:
+    result = text
+    for edit in sorted(edits, key=lambda item: item.start, reverse=True):
+        result = result[: edit.start] + edit.replacement + result[edit.end :]
+    return result

--- a/src/brigade/guard/examples/n8n-validation/blocked-local-service.json
+++ b/src/brigade/guard/examples/n8n-validation/blocked-local-service.json
@@ -1,0 +1,17 @@
+{
+  "description": "Synthetic local service reference should be blocked and redacted.",
+  "request": {
+    "_content_guard_allow": "content-guard: allow localhost-port",
+    "text": "Draft says the preview is running at localhost:5204 before launch.",
+    "name": "blocked-local-service",
+    "source": "n8n:synthetic:blog",
+    "policy": "public-content"
+  },
+  "expected": {
+    "blocked": true,
+    "changed": true,
+    "finding_rule_ids": [
+      "localhost-port"
+    ]
+  }
+}

--- a/src/brigade/guard/examples/n8n-validation/blocked-secret-token.json
+++ b/src/brigade/guard/examples/n8n-validation/blocked-secret-token.json
@@ -1,0 +1,17 @@
+{
+  "description": "Synthetic token assignment should be blocked and redacted.",
+  "request": {
+    "_content_guard_allow": "content-guard: allow api-key-assignment",
+    "text": "Draft accidentally includes token=abc123abc123abc123abc123abc123 in setup notes.",
+    "name": "blocked-secret-token",
+    "source": "n8n:synthetic:blog",
+    "policy": "public-content"
+  },
+  "expected": {
+    "blocked": true,
+    "changed": true,
+    "finding_rule_ids": [
+      "api-key-assignment"
+    ]
+  }
+}

--- a/src/brigade/guard/examples/n8n-validation/clean-blog-post.json
+++ b/src/brigade/guard/examples/n8n-validation/clean-blog-post.json
@@ -1,0 +1,14 @@
+{
+  "description": "Clean blog draft should pass advisory checks.",
+  "request": {
+    "text": "Release notes: the publish workflow now records advisory review status before public posting.",
+    "name": "clean-blog-post",
+    "source": "n8n:synthetic:blog",
+    "policy": "public-content"
+  },
+  "expected": {
+    "blocked": false,
+    "changed": false,
+    "finding_rule_ids": []
+  }
+}

--- a/src/brigade/guard/examples/n8n-validation/clean-social-post.json
+++ b/src/brigade/guard/examples/n8n-validation/clean-social-post.json
@@ -1,0 +1,14 @@
+{
+  "description": "Clean social draft should pass advisory checks.",
+  "request": {
+    "text": "Content Guard is running as an advisory publish check before public posts.",
+    "name": "clean-social-post",
+    "source": "n8n:synthetic:social",
+    "policy": "public-content"
+  },
+  "expected": {
+    "blocked": false,
+    "changed": false,
+    "finding_rule_ids": []
+  }
+}

--- a/src/brigade/guard/examples/n8n-validation/warn-review-email.json
+++ b/src/brigade/guard/examples/n8n-validation/warn-review-email.json
@@ -1,0 +1,17 @@
+{
+  "description": "Synthetic reviewer email should warn without blocking under the public-content policy.",
+  "request": {
+    "_content_guard_allow": "content-guard: allow email",
+    "text": "Draft asks readers to send questions to reviewer@example.test.",
+    "name": "warn-review-email",
+    "source": "n8n:synthetic:social",
+    "policy": "public-content"
+  },
+  "expected": {
+    "blocked": false,
+    "changed": false,
+    "finding_rule_ids": [
+      "example-email-reserved"
+    ]
+  }
+}

--- a/src/brigade/guard/git_commits.py
+++ b/src/brigade/guard/git_commits.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+
+from .engine import scan_text
+from .policy import Policy, load_policy
+from .report import to_text
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="content-guard-commits",
+        description="Scan Git commit messages before publishing or pushing.",
+    )
+    parser.add_argument("--policy", help="JSON policy file")
+    parser.add_argument("--range", dest="rev_range", help="revision range to scan, for example origin/main..HEAD")
+    parser.add_argument("--all", action="store_true", help="scan all reachable commits")
+    parser.add_argument("--json", action="store_true", help="emit JSON report")
+    args = parser.parse_args(argv)
+
+    policy = load_policy(args.policy) if args.policy else _default_commit_policy()
+    revs = _commit_revs(args)
+
+    results = []
+    blocked = False
+    for rev in revs:
+        message = _git(["log", "-1", "--format=%B", rev])
+        result = scan_text(message, policy=policy)
+        if result.findings:
+            blocked = blocked or result.blocked
+            results.append((rev, _subject(result.redacted_text), result))
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "ok": not blocked,
+                    "blocked": blocked,
+                    "commits_scanned": len(revs),
+                    "commits_with_findings": len(results),
+                    "commits": [
+                        {
+                            "commit": rev,
+                            "subject": subject,
+                            "blocked": result.blocked,
+                            "changed": result.changed,
+                            "counts_by_action": result.counts_by_action(),
+                            "counts_by_category": result.counts_by_category(),
+                            "findings": [
+                                {
+                                    "rule_id": finding.rule_id,
+                                    "category": finding.category,
+                                    "action": finding.action,
+                                    "line": finding.line,
+                                    "column": finding.column,
+                                    "source": finding.source,
+                                    "message": finding.message,
+                                }
+                                for finding in result.findings
+                            ],
+                        }
+                        for rev, subject, result in results
+                    ],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    elif not results:
+        print(f"Clean. {len(revs)} commit message(s) checked.")
+    else:
+        for rev, subject, result in results:
+            label = f"commit {rev[:12]} {subject}".strip()
+            print(to_text(result, path=label))
+
+    return 1 if blocked else 0
+
+
+def _default_commit_policy() -> Policy:
+    return Policy(
+        name="public-commit-default",
+        defaults={
+            "infrastructure": "block",
+            "secret": "block",
+            "pii": "block",
+            "personal": "block",
+            "business": "block",
+            "attribution": "block",
+            "tooling": "warn",
+        },
+        rules={"opf-pii": "warn"},
+    )
+
+
+def _commit_revs(args: argparse.Namespace) -> list[str]:
+    if args.all:
+        cmd = ["rev-list", "--reverse", "--all"]
+    else:
+        if not args.rev_range and not _has_head():
+            return []
+        rev_range = args.rev_range or _default_range()
+        cmd = ["rev-list", "--reverse", rev_range]
+
+    output = _git(cmd)
+    return [line for line in output.splitlines() if line.strip()]
+
+
+def _default_range() -> str:
+    proc = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    upstream = proc.stdout.strip()
+    if proc.returncode == 0 and upstream:
+        return f"{upstream}..HEAD"
+    return "HEAD"
+
+
+def _has_head() -> bool:
+    proc = subprocess.run(["git", "rev-parse", "--verify", "HEAD"], capture_output=True, text=True, check=False)
+    return proc.returncode == 0
+
+
+def _git(args: list[str]) -> str:
+    proc = subprocess.run(["git", *args], capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        print((proc.stderr or proc.stdout or "git command failed").strip(), file=sys.stderr)
+        raise SystemExit(2)
+    return proc.stdout
+
+
+def _subject(message: str) -> str:
+    for line in message.splitlines():
+        if line.strip():
+            return line.strip()
+    return "(empty subject)"
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/brigade/guard/git_scan.py
+++ b/src/brigade/guard/git_scan.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from .engine import scan_text
+from .policy import Policy, load_policy
+from .report import to_text
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="content-guard-git",
+        description="Scan public Git repository content before commit or push.",
+    )
+    parser.add_argument("--policy", help="JSON policy file")
+    parser.add_argument(
+        "--allow-values-from",
+        dest="allow_values_from",
+        action="append",
+        metavar="PATH",
+        help=(
+            "merge the allow_values list from another JSON policy file into the "
+            "active policy. Use to apply a private allowlist (e.g. a known-public "
+            "email or example port) to a scan without putting those literals in a "
+            "shipped public policy. Repeatable."
+        ),
+    )
+    parser.add_argument("--all-tracked", action="store_true", help="scan all tracked files")
+    parser.add_argument("--staged", action="store_true", help="scan staged files, default mode")
+    parser.add_argument("--include-git-config", action="store_true", help="also scan .git/config when present")
+    parser.add_argument(
+        "--history",
+        action="store_true",
+        help="scan content INTRODUCED across commit history (added lines), not just the current tip",
+    )
+    parser.add_argument("--range", dest="rev_range", help="revision range for --history, e.g. origin/main..HEAD")
+    parser.add_argument("--all", action="store_true", help="with --history, scan all reachable commits")
+    parser.add_argument("--json", action="store_true", help="emit JSON report")
+    args = parser.parse_args(argv)
+
+    policy = load_policy(args.policy) if args.policy else _default_repo_policy()
+    _merge_allow_values_from(policy, args.allow_values_from or [])
+
+    if args.history:
+        return _scan_history(policy, args)
+
+    paths = _tracked_paths(all_tracked=args.all_tracked)
+    if args.include_git_config and Path(".git/config").is_file():
+        paths.append(Path(".git/config"))
+
+    results = []
+    blocked = False
+    for path in paths:
+        text = _read_text(path)
+        if text is None:
+            continue
+        result = scan_text(text, policy=policy)
+        if result.findings:
+            blocked = blocked or result.blocked
+            results.append((path, result))
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "ok": not blocked,
+                    "blocked": blocked,
+                    "files_with_findings": len(results),
+                    "files": [
+                        {
+                            "path": str(path),
+                            "blocked": result.blocked,
+                            "changed": result.changed,
+                            "counts_by_action": result.counts_by_action(),
+                            "counts_by_category": result.counts_by_category(),
+                        }
+                        for path, result in results
+                    ],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    elif not results:
+        print(f"Clean. {len(paths)} Git file(s) checked.")
+    else:
+        for path, result in results:
+            print(to_text(result, path=str(path)))
+
+    return 1 if blocked else 0
+
+
+def _scan_history(policy: Policy, args: argparse.Namespace) -> int:
+    """Scan the content INTRODUCED by each commit (added lines).
+
+    Closes the forward-scrub gap: a later commit can clean the tip while the
+    leak survives in the commit that originally introduced it. We scan added
+    lines per commit, so a leak is caught at its point of introduction even if
+    a subsequent commit removed it from the working tree.
+    """
+    revs = _history_revs(args)
+    results = []
+    blocked = False
+    for rev in revs:
+        text = _added_lines(rev)
+        if not text:
+            continue
+        result = scan_text(text, policy=policy)
+        if result.findings:
+            blocked = blocked or result.blocked
+            results.append((rev, result))
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "ok": not blocked,
+                    "blocked": blocked,
+                    "commits_scanned": len(revs),
+                    "commits_with_findings": len(results),
+                    "commits": [
+                        {
+                            "commit": rev,
+                            "blocked": result.blocked,
+                            "counts_by_action": result.counts_by_action(),
+                            "counts_by_category": result.counts_by_category(),
+                        }
+                        for rev, result in results
+                    ],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    elif not results:
+        print(f"Clean. introduced content of {len(revs)} commit(s) checked.")
+    else:
+        for rev, result in results:
+            print(to_text(result, path=f"commit {rev[:12]} (introduced content)"))
+
+    return 1 if blocked else 0
+
+
+def _history_revs(args: argparse.Namespace) -> list[str]:
+    if args.all:
+        cmd = ["git", "rev-list", "--all"]
+    elif args.rev_range:
+        cmd = ["git", "rev-list", args.rev_range]
+    else:
+        cmd = ["git", "rev-list", "HEAD"]
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        print((proc.stderr or "git rev-list failed").strip(), file=sys.stderr)
+        raise SystemExit(2)
+    return [line for line in proc.stdout.splitlines() if line.strip()]
+
+
+def _added_lines(rev: str) -> str:
+    proc = subprocess.run(
+        ["git", "show", "--no-color", "--first-parent", "--format=", "--unified=0", rev],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return ""
+    out = []
+    for line in proc.stdout.splitlines():
+        if line.startswith("+") and not line.startswith("+++"):
+            out.append(line[1:])
+    return "\n".join(out)
+
+
+def _merge_allow_values_from(policy: Policy, paths: list[str]) -> None:
+    """Extend ``policy.allow_values`` with allow_values from extra policy files.
+
+    Lets a private allowlist file (kept out of any shipped public policy) apply
+    its known-public literals to a scan that uses a different main policy.
+    Missing files are skipped quietly so an optional private file is never a
+    hard error; malformed files surface through ``load_policy``.
+    """
+    for raw_path in paths:
+        path = Path(raw_path)
+        if not path.is_file():
+            # Fail-safe: a missing allowlist file never weakens a scan (nothing
+            # extra is allowed). Warn so an explicit CLI typo is not silent; the
+            # pre-push hook only passes its private file when it exists.
+            print(f"content-guard: allow-values file not found, skipping: {path}", file=sys.stderr)
+            continue
+        extra = load_policy(path)
+        for value in extra.allow_values:
+            if value not in policy.allow_values:
+                policy.allow_values.append(value)
+
+
+def _default_repo_policy() -> Policy:
+    return Policy(
+        name="public-repo-default",
+        defaults={
+            "infrastructure": "block",
+            "secret": "block",
+            "pii": "block",
+            "personal": "block",
+            "business": "block",
+            "attribution": "block",
+            "tooling": "warn",
+        },
+        rules={
+            "loopback-ipv4": "warn",
+            "localhost-port": "warn",
+            "localhost-bare": "warn",
+            "port-reference": "warn",
+            "opf-pii": "warn",
+        },
+    )
+
+
+def _tracked_paths(*, all_tracked: bool, cwd: Path | None = None) -> list[Path]:
+    if all_tracked:
+        cmd = ["git", "ls-files"]
+    else:
+        cmd = ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR"]
+
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False, cwd=cwd)
+    if proc.returncode != 0:
+        print((proc.stderr or proc.stdout or "git command failed").strip(), file=sys.stderr)
+        raise SystemExit(2)
+
+    return [Path(line) for line in proc.stdout.splitlines() if line.strip()]
+
+
+def _read_text(path: Path) -> str | None:
+    try:
+        raw = path.read_bytes()
+    except OSError:
+        return None
+    if b"\0" in raw:
+        return None
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return None
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/brigade/guard/n8n_advisory.py
+++ b/src/brigade/guard/n8n_advisory.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from importlib.resources.abc import Traversable
+
+if sys.version_info >= (3, 11):
+    from importlib.resources.abc import Traversable
+else:  # pragma: no cover - 3.10 fallback
+    from importlib.abc import Traversable
 from os import PathLike
 from pathlib import Path
 from typing import Any

--- a/src/brigade/guard/n8n_advisory.py
+++ b/src/brigade/guard/n8n_advisory.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from importlib.resources.abc import Traversable
+from os import PathLike
+from pathlib import Path
+from typing import Any
+
+from .engine import scan_text
+from .policy import default_policy, load_policy
+from .report import to_payload
+from .types import ScanOptions
+
+POLICY_ALIASES = {
+    "openclaw-message": "openclaw-message.json",
+    "pr-draft": "pr-draft.json",
+    "public-content": "public-content.json",
+    "public-repo": "public-repo.json",
+}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="content-guard-n8n-advisory",
+        description="Scan one n8n text payload from stdin and return JSON for advisory workflow branching.",
+    )
+    parser.add_argument("--policy", help="policy alias or JSON path, default: public-content")
+    parser.add_argument("--strict", action="store_true", help="return nonzero when blocked findings exist")
+    parser.add_argument("--opf", action="store_true", help="run optional OPF backend")
+    parser.add_argument("--opf-bin", help="path to opf binary")
+    parser.add_argument("--opf-device", help="OPF device, default comes from policy or cpu")
+    args = parser.parse_args(argv)
+
+    try:
+        request = json.loads(sys.stdin.read() or "{}")
+        payload = run_advisory_check(request, args)
+    except ValueError as exc:
+        print(json.dumps({"ok": False, "blocked": True, "error": str(exc)}, indent=2, sort_keys=True))
+        return 2
+
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 1 if args.strict and payload["blocked"] else 0
+
+
+def run_advisory_check(request: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
+    if not isinstance(request, dict):
+        raise ValueError("stdin JSON must be an object")
+
+    text = request.get("text")
+    if not isinstance(text, str):
+        raise ValueError("stdin JSON must include string field 'text'")
+
+    policy_value = request.get("policy") or args.policy or "public-content"
+    if not isinstance(policy_value, str):
+        raise ValueError("'policy' must be a string alias or JSON path")
+
+    source = request.get("source")
+    name = request.get("name")
+    policy_path = _policy_path(policy_value)
+    result = scan_text(
+        text,
+        policy=load_policy(policy_path),
+        options=ScanOptions(
+            include_opf=args.opf,
+            opf_bin=args.opf_bin,
+            opf_device=args.opf_device,
+        ),
+    )
+
+    return {
+        **to_payload(result),
+        "advisory": bool(result.blocked),
+        "policy": str(policy_path),
+        "source": source if isinstance(source, str) else "<stdin>",
+        "name": name if isinstance(name, str) else "n8n-content",
+        "sanitized_text": result.redacted_text,
+    }
+
+
+def _policy_path(value: str) -> Path | PathLike[str] | Traversable:
+    path = Path(value)
+    if path.is_file():
+        return path
+
+    alias = POLICY_ALIASES.get(value)
+    if alias:
+        return default_policy(alias)
+
+    raise ValueError(f"unknown policy alias or file: {value}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/brigade/guard/n8n_validate.py
+++ b/src/brigade/guard/n8n_validate.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from .n8n_advisory import run_advisory_check
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="content-guard-n8n-validate",
+        description="Run synthetic n8n advisory fixtures and verify expected Content Guard results.",
+    )
+    parser.add_argument(
+        "fixtures_dir",
+        nargs="?",
+        default=str(_default_fixtures_dir()),
+        help="directory of JSON fixtures, default: examples/n8n-validation",
+    )
+    parser.add_argument("--policy", help="default policy alias or JSON path when a fixture omits policy")
+    parser.add_argument("--json", action="store_true", help="emit machine-readable validation results")
+    parser.add_argument("--opf", action="store_true", help="run optional OPF backend")
+    parser.add_argument("--opf-bin", help="path to opf binary")
+    parser.add_argument("--opf-device", help="OPF device, default comes from policy or cpu")
+    args = parser.parse_args(argv)
+
+    payload = run_validation(args)
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(_format_text(payload))
+
+    return 0 if payload["ok"] else 1
+
+
+def run_validation(args: argparse.Namespace) -> dict[str, Any]:
+    fixtures_dir = Path(args.fixtures_dir)
+    fixtures = sorted(fixtures_dir.glob("*.json"))
+    if not fixtures_dir.is_dir():
+        return {
+            "ok": False,
+            "fixtures_dir": str(fixtures_dir),
+            "error": "fixtures directory does not exist",
+            "fixtures": [],
+        }
+    if not fixtures:
+        return {
+            "ok": False,
+            "fixtures_dir": str(fixtures_dir),
+            "error": "no JSON fixtures found",
+            "fixtures": [],
+        }
+
+    results = [_run_fixture(path, args) for path in fixtures]
+    return {
+        "ok": all(item["ok"] for item in results),
+        "fixtures_dir": str(fixtures_dir),
+        "fixtures": results,
+    }
+
+
+def _run_fixture(path: Path, args: argparse.Namespace) -> dict[str, Any]:
+    try:
+        fixture = json.loads(path.read_text())
+        if not isinstance(fixture, dict):
+            raise ValueError("fixture must be a JSON object")
+
+        request = fixture.get("request")
+        if not isinstance(request, dict):
+            raise ValueError("fixture must include object field 'request'")
+
+        expected = fixture.get("expected")
+        if not isinstance(expected, dict):
+            raise ValueError("fixture must include object field 'expected'")
+
+        request = _public_request(request)
+        result = run_advisory_check(
+            request,
+            argparse.Namespace(policy=args.policy, opf=args.opf, opf_bin=args.opf_bin, opf_device=args.opf_device),
+        )
+        failures = _expectation_failures(result, expected)
+        return {
+            "ok": not failures,
+            "path": str(path),
+            "name": result["name"],
+            "blocked": result["blocked"],
+            "changed": result["changed"],
+            "finding_rule_ids": _rule_ids(result),
+            "failures": failures,
+        }
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        return {
+            "ok": False,
+            "path": str(path),
+            "failures": [str(exc)],
+        }
+
+
+def _public_request(request: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in request.items() if not key.startswith("_")}
+
+
+def _expectation_failures(result: dict[str, Any], expected: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+    for key in ("blocked", "changed"):
+        if key in expected and result[key] != expected[key]:
+            failures.append(f"expected {key}={expected[key]!r}, got {result[key]!r}")
+
+    expected_rule_ids = expected.get("finding_rule_ids")
+    if expected_rule_ids is not None:
+        actual_rule_ids = _rule_ids(result)
+        if actual_rule_ids != expected_rule_ids:
+            failures.append(f"expected finding_rule_ids={expected_rule_ids!r}, got {actual_rule_ids!r}")
+
+    return failures
+
+
+def _rule_ids(result: dict[str, Any]) -> list[str]:
+    return [finding["rule_id"] for finding in result.get("findings", [])]
+
+
+def _format_text(payload: dict[str, Any]) -> str:
+    lines = [f"Content Guard n8n validation: {'pass' if payload['ok'] else 'fail'}"]
+    if payload.get("error"):
+        lines.append(payload["error"])
+
+    for fixture in payload["fixtures"]:
+        status = "PASS" if fixture["ok"] else "FAIL"
+        lines.append(f"{status} {fixture['path']}")
+        if "blocked" in fixture:
+            lines.append(
+                "  "
+                f"name={fixture['name']} "
+                f"blocked={str(fixture['blocked']).lower()} "
+                f"changed={str(fixture['changed']).lower()} "
+                f"rules={','.join(fixture['finding_rule_ids']) or '-'}"
+            )
+        for failure in fixture["failures"]:
+            lines.append(f"  {failure}")
+
+    return "\n".join(lines)
+
+
+def _default_fixtures_dir() -> Path:
+    return Path(__file__).resolve().parent / "examples" / "n8n-validation"
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/brigade/guard/policies/openclaw-message.json
+++ b/src/brigade/guard/policies/openclaw-message.json
@@ -1,0 +1,32 @@
+{
+  "name": "openclaw-message",
+  "backends": {
+    "opf": {
+      "enabled": false,
+      "action": "warn",
+      "device": "cpu"
+    }
+  },
+  "defaults": {
+    "infrastructure": "redact",
+    "secret": "redact",
+    "pii": "warn",
+    "personal": "warn",
+    "business": "warn",
+    "attribution": "redact",
+    "tooling": "warn"
+  },
+  "rules": {
+    "opf-pii": "warn"
+  },
+  "custom_rules": [
+    {
+      "id": "local-hostname-example",
+      "category": "infrastructure",
+      "pattern": "\\binternal-host\\b",
+      "replacement": "[redacted-host]",
+      "description": "Example local workstation hostname.",
+      "flags": ["ignorecase"]
+    }
+  ]
+}

--- a/src/brigade/guard/policies/pr-draft.json
+++ b/src/brigade/guard/policies/pr-draft.json
@@ -1,0 +1,23 @@
+{
+  "name": "pr-draft",
+  "backends": {
+    "opf": {
+      "enabled": false,
+      "action": "warn",
+      "device": "cpu"
+    }
+  },
+  "defaults": {
+    "infrastructure": "block",
+    "secret": "block",
+    "pii": "block",
+    "personal": "block",
+    "business": "block",
+    "attribution": "block",
+    "tooling": "warn"
+  },
+  "rules": {
+    "opf-pii": "warn"
+  },
+  "custom_rules": []
+}

--- a/src/brigade/guard/policies/public-content.json
+++ b/src/brigade/guard/policies/public-content.json
@@ -1,0 +1,25 @@
+{
+  "name": "public-content",
+  "backends": {
+    "opf": {
+      "enabled": false,
+      "action": "warn",
+      "device": "cpu"
+    }
+  },
+  "defaults": {
+    "infrastructure": "block",
+    "secret": "block",
+    "pii": "warn",
+    "personal": "block",
+    "business": "warn",
+    "attribution": "block",
+    "tooling": "warn"
+  },
+  "rules": {
+    "email": "warn",
+    "us-phone": "warn",
+    "opf-pii": "warn"
+  },
+  "custom_rules": []
+}

--- a/src/brigade/guard/policies/public-repo.json
+++ b/src/brigade/guard/policies/public-repo.json
@@ -1,0 +1,36 @@
+{
+  "_comment": [
+    "Public repo policy. Hard publish gate for actual leakage (RFC 1918 IPs, secrets,",
+    "PII, attribution trailers), but treats baseline technical-doc patterns as warnings:",
+    "loopback-ipv4 (127.x.x.x), localhost-port, localhost-bare, port-reference. README,",
+    "CONTRIBUTING, and docs frequently have to discuss localhost and named ports without",
+    "it being a leak. The stricter public-content policy keeps those at block since",
+    "blog/social copy is a more sensitive public surface than a technical docs repo.",
+    "See policies/public-repo.md for the long-form rationale."
+  ],
+  "name": "public-repo",
+  "backends": {
+    "opf": {
+      "enabled": false,
+      "action": "warn",
+      "device": "cpu"
+    }
+  },
+  "defaults": {
+    "infrastructure": "block",
+    "secret": "block",
+    "pii": "block",
+    "personal": "block",
+    "business": "block",
+    "attribution": "block",
+    "tooling": "warn"
+  },
+  "rules": {
+    "loopback-ipv4": "warn",
+    "localhost-port": "warn",
+    "localhost-bare": "warn",
+    "port-reference": "warn",
+    "opf-pii": "warn"
+  },
+  "custom_rules": []
+}

--- a/src/brigade/guard/policy.py
+++ b/src/brigade/guard/policy.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from importlib import resources
+from importlib.resources.abc import Traversable
+from os import PathLike
+from pathlib import Path
+from typing import Any
+
+from .rules import DEFAULT_RULES
+from .types import Action, Rule
+
+VALID_ACTIONS: set[str] = {"allow", "warn", "redact", "block"}
+
+
+# Per-rule action defaults that override category-level defaults. Each entry
+# represents "this rule should default to X unless the user's policy.rules map
+# explicitly overrides it."
+#
+# Why these exist:
+#   - example-* rules are illustrative-only patterns (NANPA 555 phones, RFC 2606
+#     example.{com,org,net} emails). They live in the PII category but are
+#     almost never real PII. Defaulting them to WARN avoids blocking valid
+#     documentation under a "pii: block" policy.
+#   - known-host is a synthetic rule generated from policy.known_hosts. It
+#     represents user-declared real internal IPs/hostnames. It must BLOCK
+#     even under permissive "infrastructure: warn" policies.
+_RULE_DEFAULTS: dict[str, Action] = {
+    "example-phone-555": "warn",
+    "example-email-reserved": "warn",
+    "known-host": "block",
+}
+
+
+@dataclass
+class OpfBackendConfig:
+    enabled: bool = False
+    device: str = "cpu"
+    bin: str | None = None
+
+
+@dataclass
+class Policy:
+    name: str = "default"
+    defaults: dict[str, Action] = field(
+        default_factory=lambda: {
+            "infrastructure": "block",
+            "secret": "block",
+            "pii": "warn",
+            "personal": "block",
+            "business": "warn",
+            "attribution": "block",
+        }
+    )
+    rules: dict[str, Action] = field(default_factory=dict)
+    custom_rules: list[Rule] = field(default_factory=list)
+    known_hosts: list[str] = field(default_factory=list)
+    # Literal strings that are known-public and safe. A finding whose matched
+    # text equals one of these exactly is forced to action "allow" regardless
+    # of rule or category. Unlike inline `content-guard: allow` comments, this
+    # applies everywhere including history scans of old commit diffs, where no
+    # inline marker can exist. Keep personal or environment-specific values in
+    # a private policy file, never in a shipped public default policy.
+    allow_values: list[str] = field(default_factory=list)
+    opf_backend: OpfBackendConfig = field(default_factory=OpfBackendConfig)
+
+    def action_for(self, rule: Rule) -> Action:
+        # Per-rule defaults that DEFEAT category-level defaults unless the
+        # user explicitly overrides the rule in policy.rules. This is the
+        # mechanism for the example-* rules to remain WARN even when a policy
+        # blocks the entire PII category, and for known-host to BLOCK even
+        # when a policy warns the entire infrastructure category.
+        if rule.id not in self.rules and rule.id in _RULE_DEFAULTS:
+            return _RULE_DEFAULTS[rule.id]
+        return self.rules.get(rule.id) or self.defaults.get(rule.category, "warn")
+
+    def all_rules(self) -> list[Rule]:
+        # Synthetic known-host rule runs FIRST so it claims spans before more
+        # general patterns (private-ipv4, etc.). Always BLOCK regardless of
+        # category default, since these are explicit user-defined real hosts.
+        known_rule: list[Rule] = []
+        if self.known_hosts:
+            pattern = r"\b(?:" + "|".join(re.escape(h) for h in self.known_hosts) + r")\b"
+            known_rule.append(
+                Rule(
+                    id="known-host",
+                    category="infrastructure",
+                    pattern=pattern,
+                    replacement="[redacted-known-host]",
+                    description="Known internal host or IP (policy-defined).",
+                )
+            )
+        return [*known_rule, *DEFAULT_RULES, *self.custom_rules]
+
+
+def _as_action(value: Any, where: str) -> Action:
+    if not isinstance(value, str) or value not in VALID_ACTIONS:
+        raise ValueError(f"{where} must be one of: {', '.join(sorted(VALID_ACTIONS))}")
+    return value  # type: ignore[return-value]
+
+
+def default_policy(name: str) -> Path | Traversable:
+    repo_path = Path(__file__).resolve().parents[2] / "policies" / name
+    if repo_path.is_file():
+        return repo_path
+
+    packaged_path = resources.files("brigade.guard").joinpath("policies", name)
+    if packaged_path.is_file():
+        return packaged_path
+
+    return repo_path
+
+
+def load_policy(path: str | PathLike[str] | Traversable | None) -> Policy:
+    if path is None:
+        return Policy()
+
+    if isinstance(path, (str, PathLike)):
+        policy_path = Path(path)
+        raw_text = policy_path.read_text()
+        fallback_name = policy_path.stem
+    else:
+        raw_text = path.read_text()
+        fallback_name = Path(path.name).stem
+
+    raw = json.loads(raw_text)
+    if not isinstance(raw, dict):
+        raise ValueError("policy root must be an object")
+
+    defaults = Policy().defaults
+    for category, action in raw.get("defaults", {}).items():
+        defaults[str(category)] = _as_action(action, f"defaults.{category}")
+
+    rules: dict[str, Action] = {}
+    for rule_id, action in raw.get("rules", {}).items():
+        rules[str(rule_id)] = _as_action(action, f"rules.{rule_id}")
+
+    custom_rules = [_parse_custom_rule(item, i) for i, item in enumerate(raw.get("custom_rules", []))]
+    known_hosts = _parse_known_hosts(raw.get("known_hosts"))
+    allow_values = _parse_allow_values(raw.get("allow_values"))
+    opf_backend = _parse_opf_backend(
+        raw.get("backends", {}).get("opf") if isinstance(raw.get("backends"), dict) else None
+    )
+    if opf_backend.action:
+        rules["opf-pii"] = opf_backend.action
+
+    return Policy(
+        name=str(raw.get("name") or fallback_name),
+        defaults=defaults,
+        rules=rules,
+        custom_rules=custom_rules,
+        known_hosts=known_hosts,
+        allow_values=allow_values,
+        opf_backend=OpfBackendConfig(
+            enabled=opf_backend.enabled,
+            device=opf_backend.device,
+            bin=opf_backend.bin,
+        ),
+    )
+
+
+def _parse_known_hosts(raw: Any) -> list[str]:
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        raise ValueError("known_hosts must be a list of host strings")
+    hosts: list[str] = []
+    for i, entry in enumerate(raw):
+        if not isinstance(entry, str) or not entry.strip():
+            raise ValueError(f"known_hosts[{i}] must be a non-empty string")
+        hosts.append(entry.strip())
+    return hosts
+
+
+def _parse_allow_values(raw: Any) -> list[str]:
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        raise ValueError("allow_values must be a list of literal strings")
+    values: list[str] = []
+    for i, entry in enumerate(raw):
+        if not isinstance(entry, str) or not entry.strip():
+            raise ValueError(f"allow_values[{i}] must be a non-empty string")
+        values.append(entry)
+    return values
+
+
+def _parse_custom_rule(item: Any, index: int) -> Rule:
+    if not isinstance(item, dict):
+        raise ValueError(f"custom_rules[{index}] must be an object")
+
+    try:
+        rule_id = str(item["id"])
+        category = str(item["category"])
+        pattern = str(item["pattern"])
+    except KeyError as exc:
+        raise ValueError(f"custom_rules[{index}] missing required field {exc.args[0]!r}") from exc
+
+    replacement = str(item.get("replacement", f"[redacted-{category}]"))
+    description = str(item.get("description", ""))
+    flags = 0
+    for flag in item.get("flags", []):
+        if flag == "ignorecase":
+            flags |= re.IGNORECASE
+        elif flag == "multiline":
+            flags |= re.MULTILINE
+        elif flag == "dotall":
+            flags |= re.DOTALL
+        else:
+            raise ValueError(f"custom_rules[{index}].flags has unsupported flag {flag!r}")
+
+    re.compile(pattern, flags)
+    return Rule(
+        id=rule_id,
+        category=category,
+        pattern=pattern,
+        replacement=replacement,
+        description=description,
+        flags=flags,
+    )
+
+
+@dataclass
+class _ParsedOpfBackend:
+    enabled: bool = False
+    device: str = "cpu"
+    bin: str | None = None
+    action: Action | None = None
+
+
+def _parse_opf_backend(raw: Any) -> _ParsedOpfBackend:
+    if raw is None:
+        return _ParsedOpfBackend()
+    if not isinstance(raw, dict):
+        raise ValueError("backends.opf must be an object")
+
+    enabled = bool(raw.get("enabled", False))
+    device = str(raw.get("device", "cpu"))
+    opf_bin = raw.get("bin")
+    action = raw.get("action")
+
+    return _ParsedOpfBackend(
+        enabled=enabled,
+        device=device,
+        bin=str(opf_bin) if opf_bin else None,
+        action=_as_action(action, "backends.opf.action") if action is not None else None,
+    )

--- a/src/brigade/guard/policy.py
+++ b/src/brigade/guard/policy.py
@@ -4,7 +4,12 @@ import json
 import re
 from dataclasses import dataclass, field
 from importlib import resources
-from importlib.resources.abc import Traversable
+import sys
+
+if sys.version_info >= (3, 11):
+    from importlib.resources.abc import Traversable
+else:  # pragma: no cover - 3.10 fallback
+    from importlib.abc import Traversable
 from os import PathLike
 from pathlib import Path
 from typing import Any

--- a/src/brigade/guard/pr_draft.py
+++ b/src/brigade/guard/pr_draft.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import argparse
+import json
+from importlib.resources.abc import Traversable
+from os import PathLike
+from pathlib import Path
+
+from .engine import scan_text
+from .policy import default_policy, load_policy
+from .report import to_payload, to_text
+from .types import ScanOptions
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="content-guard-pr",
+        description="Advisory PR draft guard that writes sanitized copy and report files.",
+    )
+    parser.add_argument("target", help="PR body markdown file")
+    parser.add_argument("--policy", help="policy file, default: policies/pr-draft.json near project root")
+    parser.add_argument("--output", help="sanitized output path, default: <target>.public.md")
+    parser.add_argument("--report", help="JSON report path, default: <target>.content-guard.json")
+    parser.add_argument("--strict", action="store_true", help="return nonzero when blocked findings exist")
+    parser.add_argument("--opf", action="store_true", help="run optional OPF backend")
+    parser.add_argument("--opf-bin", help="path to opf binary")
+    parser.add_argument("--opf-device", help="OPF device, default comes from policy or cpu")
+    args = parser.parse_args(argv)
+
+    target = Path(args.target)
+    text = target.read_text()
+    policy_path = Path(args.policy) if args.policy else _default_policy_path()
+    output_path = Path(args.output) if args.output else _default_output_path(target)
+    report_path = Path(args.report) if args.report else _default_report_path(target)
+
+    result = scan_text(
+        text,
+        policy=load_policy(policy_path),
+        options=ScanOptions(
+            include_opf=args.opf,
+            opf_bin=args.opf_bin,
+            opf_device=args.opf_device,
+        ),
+    )
+
+    output_path.write_text(result.redacted_text)
+    report_path.write_text(
+        json.dumps({**to_payload(result), "source": str(target), "output": str(output_path)}, indent=2, sort_keys=True)
+    )
+
+    print(to_text(result, path=str(target)))
+    print(f"sanitized={output_path}")
+    print(f"report={report_path}")
+    if result.blocked and not args.strict:
+        print("advisory=true")
+
+    return 1 if result.blocked and args.strict else 0
+
+
+def _default_policy_path() -> Path | PathLike[str] | Traversable:
+    return default_policy("pr-draft.json")
+
+
+def _default_output_path(target: Path) -> Path:
+    if target.suffix:
+        return target.with_name(f"{target.stem}.public{target.suffix}")
+    return target.with_name(f"{target.name}.public.md")
+
+
+def _default_report_path(target: Path) -> Path:
+    return target.with_name(f"{target.stem}.content-guard.json")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/brigade/guard/pr_draft.py
+++ b/src/brigade/guard/pr_draft.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 import argparse
 import json
-from importlib.resources.abc import Traversable
+import sys
+
+if sys.version_info >= (3, 11):
+    from importlib.resources.abc import Traversable
+else:  # pragma: no cover - 3.10 fallback
+    from importlib.abc import Traversable
 from os import PathLike
 from pathlib import Path
 

--- a/src/brigade/guard/pr_prepare.py
+++ b/src/brigade/guard/pr_prepare.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from importlib.resources.abc import Traversable
+from os import PathLike
+from pathlib import Path
+
+from .engine import scan_text
+from .policy import default_policy, load_policy
+from .report import to_payload, to_text
+from .types import GuardResult, ScanOptions
+
+
+def prepare_pr_body(
+    text: str,
+    *,
+    source: Path | None,
+    policy_path: Path | PathLike[str] | Traversable,
+    out_dir: Path,
+    name: str,
+    strict: bool = False,
+    include_opf: bool = False,
+    opf_bin: str | None = None,
+    opf_device: str | None = None,
+) -> tuple[dict, GuardResult]:
+    safe_name = _safe_name(name)
+    draft_path = out_dir / f"{safe_name}.draft.md"
+    public_path = out_dir / f"{safe_name}.public.md"
+    report_path = out_dir / f"{safe_name}.content-guard.json"
+
+    result = scan_text(
+        text,
+        policy=load_policy(policy_path),
+        options=ScanOptions(
+            include_opf=include_opf,
+            opf_bin=opf_bin,
+            opf_device=opf_device,
+        ),
+    )
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    draft_path.write_text(text)
+    public_path.write_text(result.redacted_text)
+
+    payload = {
+        **to_payload(result),
+        "source": str(source) if source else "<stdin>",
+        "draft": str(draft_path),
+        "sanitized": str(public_path),
+        "report": str(report_path),
+        "publish_body_file": str(public_path),
+        "advisory": bool(result.blocked and not strict),
+        "strict": bool(strict),
+    }
+    report_path.write_text(json.dumps(payload, indent=2, sort_keys=True))
+    return payload, result
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="content-guard-pr-prepare",
+        description="Prepare a guarded PR body bundle for later publishing.",
+    )
+    parser.add_argument("target", nargs="?", help="PR body markdown file, or stdin when omitted")
+    parser.add_argument("--policy", help="policy file, default: policies/pr-draft.json near project root")
+    parser.add_argument("--out-dir", help="output directory, default: .content-guard/pr-drafts")
+    parser.add_argument("--name", help="output basename, default: target stem or pr-body")
+    parser.add_argument("--strict", action="store_true", help="return nonzero when blocked findings exist")
+    parser.add_argument("--json", action="store_true", help="emit machine-readable publish handoff")
+    parser.add_argument("--opf", action="store_true", help="run optional OPF backend")
+    parser.add_argument("--opf-bin", help="path to opf binary")
+    parser.add_argument("--opf-device", help="OPF device, default comes from policy or cpu")
+    args = parser.parse_args(argv)
+
+    text, source = _read_target(args.target)
+    policy_path = Path(args.policy) if args.policy else _default_policy_path()
+    out_dir = Path(args.out_dir) if args.out_dir else Path(".content-guard") / "pr-drafts"
+    payload, result = prepare_pr_body(
+        text,
+        source=source,
+        policy_path=policy_path,
+        out_dir=out_dir,
+        name=args.name or _default_name(source),
+        strict=args.strict,
+        include_opf=args.opf,
+        opf_bin=args.opf_bin,
+        opf_device=args.opf_device,
+    )
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(to_text(result, path=str(source) if source else "<stdin>"))
+        print(f"draft={payload['draft']}")
+        print(f"sanitized={payload['sanitized']}")
+        print(f"report={payload['report']}")
+        print(f"publish_body_file={payload['publish_body_file']}")
+        print(f"gh_body_arg=--body-file {payload['publish_body_file']}")
+        if payload["blocked"] and not args.strict:
+            print("advisory=true")
+
+    return 1 if payload["blocked"] and args.strict else 0
+
+
+def _read_target(target: str | None) -> tuple[str, Path | None]:
+    if not target or target == "-":
+        return sys.stdin.read(), None
+    path = Path(target)
+    return path.read_text(), path
+
+
+def _default_policy_path() -> Path | PathLike[str] | Traversable:
+    return default_policy("pr-draft.json")
+
+
+def _default_name(source: Path | None) -> str:
+    if source is None:
+        return "pr-body"
+    return source.stem or "pr-body"
+
+
+def _safe_name(value: str) -> str:
+    name = re.sub(r"[^A-Za-z0-9_.-]+", "-", value.strip()).strip(".-")
+    return name or "pr-body"
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/brigade/guard/pr_prepare.py
+++ b/src/brigade/guard/pr_prepare.py
@@ -4,7 +4,11 @@ import argparse
 import json
 import re
 import sys
-from importlib.resources.abc import Traversable
+
+if sys.version_info >= (3, 11):
+    from importlib.resources.abc import Traversable
+else:  # pragma: no cover - 3.10 fallback
+    from importlib.abc import Traversable
 from os import PathLike
 from pathlib import Path
 

--- a/src/brigade/guard/publish_check.py
+++ b/src/brigade/guard/publish_check.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from importlib.resources.abc import Traversable
+
+if sys.version_info >= (3, 11):
+    from importlib.resources.abc import Traversable
+else:  # pragma: no cover - 3.10 fallback
+    from importlib.abc import Traversable
 from os import PathLike
 from pathlib import Path
 from typing import Any

--- a/src/brigade/guard/publish_check.py
+++ b/src/brigade/guard/publish_check.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from importlib.resources.abc import Traversable
+from os import PathLike
+from pathlib import Path
+from typing import Any
+
+from .git_commits import _commit_revs, _git, _subject
+from .git_scan import _read_text, _tracked_paths
+from .engine import scan_text
+from .policy import default_policy, load_policy
+from .pr_prepare import prepare_pr_body
+from .report import to_text
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="content-guard-publish-check",
+        description="Run the local publish guards for PR bodies, staged files, and commit messages.",
+    )
+    parser.add_argument("--pr-body", help="PR body markdown file to prepare for publishing")
+    parser.add_argument("--pr-policy", help="PR policy file, default: policies/pr-draft.json near project root")
+    parser.add_argument("--repo-policy", help="repo policy file, default: policies/public-repo.json near project root")
+    parser.add_argument("--out-dir", help="PR body output directory, default: .content-guard/pr-drafts")
+    parser.add_argument("--name", help="PR body output basename, default: PR body stem")
+    parser.add_argument("--commit-range", dest="rev_range", help="commit revision range to scan")
+    parser.add_argument("--all-commits", action="store_true", help="scan all reachable commit messages")
+    parser.add_argument("--all-tracked", action="store_true", help="also scan all tracked files")
+    parser.add_argument(
+        "--include-git-config", action="store_true", help="include .git/config in file scans when present"
+    )
+    parser.add_argument(
+        "--advisory-only", action="store_true", help="always exit zero while reporting would-fail checks"
+    )
+    parser.add_argument("--json", action="store_true", help="emit machine-readable combined report")
+    parser.add_argument("--opf", action="store_true", help="run optional OPF backend for PR body preparation")
+    parser.add_argument("--opf-bin", help="path to opf binary for PR body preparation")
+    parser.add_argument("--opf-device", help="OPF device for PR body preparation")
+    args = parser.parse_args(argv)
+
+    payload, text_lines = run_publish_check(args)
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print("\n".join(text_lines))
+
+    return 0 if args.advisory_only or payload["ok"] else 1
+
+
+def run_publish_check(args: argparse.Namespace) -> tuple[dict[str, Any], list[str]]:
+    pr_policy_path = Path(args.pr_policy) if args.pr_policy else _default_policy_path("pr-draft.json")
+    repo_policy_path = Path(args.repo_policy) if args.repo_policy else _default_policy_path("public-repo.json")
+    repo_policy = load_policy(repo_policy_path)
+
+    checks: dict[str, Any] = {}
+    lines = ["Content Guard publish check"]
+    publish_body_file: str | None = None
+
+    if args.pr_body:
+        pr_payload, pr_text = _prepare_pr_check(args, pr_policy_path)
+        checks["pr_body"] = pr_payload
+        publish_body_file = pr_payload["publish_body_file"]
+        lines.append("")
+        lines.append("PR body: advisory" if pr_payload["blocked"] else "PR body: clean")
+        lines.append(to_text(pr_text, path=str(args.pr_body)))
+        lines.append(f"publish_body_file={publish_body_file}")
+    else:
+        checks["pr_body"] = {"enabled": False}
+        lines.append("")
+        lines.append("PR body: skipped")
+
+    staged_payload, staged_lines = _scan_file_check(
+        policy=repo_policy,
+        all_tracked=False,
+        include_git_config=args.include_git_config,
+    )
+    checks["staged_files"] = staged_payload
+    lines.append("")
+    lines.append(_summary_line("Staged files", staged_payload))
+    lines.extend(staged_lines)
+
+    commit_payload, commit_lines = _scan_commit_check(
+        policy=repo_policy,
+        rev_range=args.rev_range,
+        all_commits=args.all_commits,
+    )
+    checks["commit_messages"] = commit_payload
+    lines.append("")
+    lines.append(_summary_line("Commit messages", commit_payload))
+    lines.extend(commit_lines)
+
+    if args.all_tracked:
+        all_payload, all_lines = _scan_file_check(
+            policy=repo_policy,
+            all_tracked=True,
+            include_git_config=args.include_git_config,
+        )
+        checks["all_tracked_files"] = all_payload
+        lines.append("")
+        lines.append(_summary_line("All tracked files", all_payload))
+        lines.extend(all_lines)
+    else:
+        checks["all_tracked_files"] = {"enabled": False}
+        lines.append("")
+        lines.append("All tracked files: skipped")
+
+    would_fail = bool(
+        checks["staged_files"].get("blocked")
+        or checks["commit_messages"].get("blocked")
+        or checks["all_tracked_files"].get("blocked")
+    )
+    blocked = bool(would_fail or checks["pr_body"].get("blocked"))
+    ok = not would_fail or bool(args.advisory_only)
+
+    payload: dict[str, Any] = {
+        "ok": ok,
+        "blocked": blocked,
+        "would_fail": would_fail,
+        "advisory_only": bool(args.advisory_only),
+        "checks": checks,
+    }
+    if publish_body_file:
+        payload["publish_body_file"] = publish_body_file
+
+    lines.append("")
+    if args.advisory_only and would_fail:
+        lines.append("Result: advisory-only, publish blockers found")
+    elif ok:
+        lines.append("Result: pass")
+    else:
+        lines.append("Result: fail")
+
+    return payload, lines
+
+
+def _prepare_pr_check(
+    args: argparse.Namespace, policy_path: Path | PathLike[str] | Traversable
+) -> tuple[dict[str, Any], Any]:
+    source = Path(args.pr_body)
+    out_dir = Path(args.out_dir) if args.out_dir else Path(".content-guard") / "pr-drafts"
+    payload, result = prepare_pr_body(
+        source.read_text(),
+        source=source,
+        policy_path=policy_path,
+        out_dir=out_dir,
+        name=args.name or source.stem,
+        strict=False,
+        include_opf=args.opf,
+        opf_bin=args.opf_bin,
+        opf_device=args.opf_device,
+    )
+    payload["enabled"] = True
+    return payload, result
+
+
+def _scan_file_check(*, policy: Any, all_tracked: bool, include_git_config: bool) -> tuple[dict[str, Any], list[str]]:
+    paths = _tracked_paths(all_tracked=all_tracked)
+    if include_git_config and Path(".git/config").is_file():
+        paths.append(Path(".git/config"))
+
+    files = []
+    blocked = False
+    lines: list[str] = []
+    for path in paths:
+        text = _read_text(path)
+        if text is None:
+            continue
+        result = scan_text(text, policy=policy)
+        if not result.findings:
+            continue
+        blocked = blocked or result.blocked
+        files.append(
+            {
+                "path": str(path),
+                "blocked": result.blocked,
+                "changed": result.changed,
+                "counts_by_action": result.counts_by_action(),
+                "counts_by_category": result.counts_by_category(),
+            }
+        )
+        lines.append(to_text(result, path=str(path)))
+
+    return (
+        {
+            "enabled": True,
+            "mode": "all-tracked" if all_tracked else "staged",
+            "ok": not blocked,
+            "blocked": blocked,
+            "files_scanned": len(paths),
+            "files_with_findings": len(files),
+            "files": files,
+        },
+        lines or [f"Clean. {len(paths)} Git file(s) checked."],
+    )
+
+
+def _scan_commit_check(*, policy: Any, rev_range: str | None, all_commits: bool) -> tuple[dict[str, Any], list[str]]:
+    revs = _commit_revs(argparse.Namespace(rev_range=rev_range, all=all_commits))
+
+    commits = []
+    blocked = False
+    lines: list[str] = []
+    for rev in revs:
+        message = _git(["log", "-1", "--format=%B", rev])
+        result = scan_text(message, policy=policy)
+        if not result.findings:
+            continue
+        blocked = blocked or result.blocked
+        subject = _subject(result.redacted_text)
+        commits.append(
+            {
+                "commit": rev,
+                "subject": subject,
+                "blocked": result.blocked,
+                "changed": result.changed,
+                "counts_by_action": result.counts_by_action(),
+                "counts_by_category": result.counts_by_category(),
+                "findings": [
+                    {
+                        "rule_id": finding.rule_id,
+                        "category": finding.category,
+                        "action": finding.action,
+                        "line": finding.line,
+                        "column": finding.column,
+                        "source": finding.source,
+                        "message": finding.message,
+                    }
+                    for finding in result.findings
+                ],
+            }
+        )
+        label = f"commit {rev[:12]} {subject}".strip()
+        lines.append(to_text(result, path=label))
+
+    return (
+        {
+            "enabled": True,
+            "ok": not blocked,
+            "blocked": blocked,
+            "commits_scanned": len(revs),
+            "commits_with_findings": len(commits),
+            "commits": commits,
+        },
+        lines or [f"Clean. {len(revs)} commit message(s) checked."],
+    )
+
+
+def _summary_line(label: str, payload: dict[str, Any]) -> str:
+    if payload.get("blocked"):
+        return f"{label}: blocked"
+    return f"{label}: clean"
+
+
+def _default_policy_path(name: str) -> Path | PathLike[str] | Traversable:
+    return default_policy(name)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/brigade/guard/report.py
+++ b/src/brigade/guard/report.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+
+from .types import GuardResult
+
+
+def to_payload(result: GuardResult) -> dict:
+    return {
+        "ok": not result.blocked,
+        "blocked": result.blocked,
+        "changed": result.changed,
+        "counts_by_action": result.counts_by_action(),
+        "counts_by_category": result.counts_by_category(),
+        "findings": [asdict(finding) for finding in result.findings],
+    }
+
+
+def to_json(result: GuardResult) -> str:
+    return json.dumps(to_payload(result), indent=2, sort_keys=True)
+
+
+def to_text(result: GuardResult, *, path: str = "<stdin>") -> str:
+    if not result.findings:
+        return f"Clean. {path}: no findings."
+
+    lines = [
+        f"{path}: {len(result.findings)} finding(s), blocked={str(result.blocked).lower()}, changed={str(result.changed).lower()}"
+    ]
+    for finding in result.findings:
+        allow_note = f" allowed_by={finding.allowed_by}" if finding.allowed_by else ""
+        lines.append(
+            f"  L{finding.line}:{finding.column} {finding.action.upper()} "
+            f"{finding.category}/{finding.rule_id} source={finding.source}{allow_note}: {finding.match!r}"
+        )
+        if finding.message:
+            lines.append(f"    {finding.message}")
+    return "\n".join(lines)

--- a/src/brigade/guard/rules.py
+++ b/src/brigade/guard/rules.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import re
+
+from .types import Rule
+
+DEFAULT_RULES: tuple[Rule, ...] = (
+    # Example-pattern rules placed BEFORE general patterns so they claim
+    # their spans first (engine uses first-match-wins via _overlaps).
+    # These cover reserved-for-documentation ranges that should warn, not block:
+    #   - NANPA reserved 555-area phone numbers (only the 555-01XX range is
+    #     truly reserved, but 555-XXXX in general is widely used in fiction
+    #     and examples and almost never a real subscriber line)
+    #   - RFC 2606 reserved example.{com,org,net} email domains
+    Rule(
+        id="example-phone-555",
+        category="pii",
+        pattern=(
+            r"(?:"
+            r"(?<!\w)\+1[\s.-]?\(?555\)?[\s.-]?\d{3}[\s.-]?\d{4}(?!\w)"
+            r"|(?<!\w)\(555\)\s*\d{3}[\s.-]?\d{4}(?!\w)"
+            r"|(?<!\w)555[\s.-]\d{3}[\s.-]\d{4}(?!\w)"
+            r")"
+        ),
+        replacement="<EXAMPLE_PHONE>",
+        description="NANPA-reserved 555-area phone number (illustrative/example).",
+        flags=re.IGNORECASE,
+    ),
+    Rule(
+        id="example-email-reserved",
+        category="pii",
+        # Reserved-for-non-real-use email TLDs:
+        #   *.example.{com,org,net}       — RFC 2606
+        #   *.test                        — RFC 2606
+        #   *.invalid                     — RFC 2606
+        #   *.localhost                   — RFC 2606
+        #   *.local                       — mDNS / RFC 6762 (link-local, not real internet domains)
+        # Also matches *@<host>.example for completeness.
+        pattern=(
+            r"\b[A-Z0-9._%+-]+@(?:"
+            r"(?:[A-Z0-9-]+\.)*example\.(?:com|org|net)"
+            r"|(?:[A-Z0-9-]+\.)*(?:test|invalid|localhost|local)"
+            r")\b"
+        ),
+        replacement="<EXAMPLE_EMAIL>",
+        description="Reserved-for-documentation email (RFC 2606 / mDNS .local — illustrative).",
+        flags=re.IGNORECASE,
+    ),
+    Rule(
+        id="ssh-private-target",
+        category="infrastructure",
+        pattern=r"\b[\w.-]+@(?:10\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3})(?::\S+)?",
+        replacement="[redacted-target]",
+        description="SSH or SCP target on a private IP address.",
+    ),
+    Rule(
+        id="private-ipv4",
+        category="infrastructure",
+        pattern=r"\b(?:10\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})\b",
+        replacement="[redacted-ip]",
+        description="RFC 1918 private IPv4 address.",
+    ),
+    Rule(
+        id="loopback-ipv4",
+        category="infrastructure",
+        pattern=r"\b127\.\d{1,3}\.\d{1,3}\.\d{1,3}\b",
+        replacement="[redacted-ip]",
+        description="Loopback IPv4 address.",
+    ),
+    Rule(
+        id="localhost-port",
+        category="infrastructure",
+        pattern=r"\blocalhost:\d+\b",
+        replacement="[redacted-service]",
+        description="Local service endpoint.",
+        flags=re.IGNORECASE,
+    ),
+    Rule(
+        id="localhost-bare",
+        category="infrastructure",
+        pattern=r"(?<![\w.-])local" r"host(?![\w.-])",
+        replacement="[redacted-service]",
+        description="Bare local host reference.",
+        flags=re.IGNORECASE,
+    ),
+    Rule(
+        id="port-reference",
+        category="infrastructure",
+        pattern=r"\bport\s+\d{4,5}\b",
+        replacement="port [redacted]",
+        description="Likely internal service port reference.",
+        flags=re.IGNORECASE,
+    ),
+    Rule(
+        id="coauthored-by-trailer",
+        category="attribution",
+        pattern=r"^Co-authored-by:\s*.+(?:\r?\n)?",
+        replacement="",
+        description="Git co-author trailer.",
+        flags=re.IGNORECASE | re.MULTILINE,
+    ),
+    Rule(
+        id="email",
+        category="pii",
+        # (?!:\S) keeps SSH/scp remotes like git@github.com:owner/repo.git from
+        # matching while emails followed by ": " in prose still do.
+        pattern=r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b(?!:\S)",
+        replacement="<PRIVATE_EMAIL>",
+        description="Email address.",
+        flags=re.IGNORECASE,
+    ),
+    Rule(
+        id="us-phone",
+        category="pii",
+        pattern=(
+            r"(?:"
+            r"(?<!\w)\+1[\s.-]?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}(?!\w)"
+            r"|(?<!\w)\(\d{3}\)\s*\d{3}[\s.-]?\d{4}(?!\w)"
+            r"|(?<!\w)\d{3}[\s.-]\d{3}[\s.-]\d{4}(?!\w)"
+            r"|\b(?:phone|tel|call)[\s:]+\+?1?[\s.-]?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}(?!\w)"
+            r")"
+        ),
+        replacement="<PRIVATE_PHONE>",
+        description="US-style phone number with phone-shape separators or a phone/tel/call cue word.",
+        flags=re.IGNORECASE,
+    ),
+    Rule(
+        id="jwt-token",
+        category="secret",
+        # All standard JWTs base64url-encode a JSON header, so they start with
+        # eyJ. A dedicated rule keeps recall when api-key-assignment skips
+        # dotted identifier chains (JWT segments would otherwise look like a
+        # three-segment chain).
+        pattern=r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b",
+        replacement="[redacted-jwt]",
+        description="JSON Web Token.",
+    ),
+    Rule(
+        id="bearer-token",
+        category="secret",
+        pattern=r"\bBearer\s+[A-Za-z0-9_~+/=-](?:[A-Za-z0-9._~+/=-]{18,}[A-Za-z0-9_~+/=-])\b",
+        replacement="Bearer [redacted-secret]",
+        description="Bearer token.",
+        flags=re.IGNORECASE,
+    ),
+    Rule(
+        id="api-key-assignment",
+        category="secret",
+        # Negative lookahead skips assignments whose RHS is a safe getter:
+        #   apiKey = process.env.X      (Node env lookup)
+        #   apiKey = os.environ["X"]    (Python env lookup)
+        #   apiKey = os.getenv("X")     (Python env lookup)
+        #   apiKey = "${...}"           (shell interpolation)
+        #   apiKey = config.x or cfg.x  (config object access)
+        # These are code reading from a secret, not the secret itself.
+        # Unquoted values must contain a digit and must not be a dotted
+        # identifier chain (apiKeys.anthropicApiKey) or a bare camelCase
+        # identifier (daemonConfigPrimaryToken): those are code passing a
+        # variable, not a hardcoded secret. Quoted 20+ char literals always
+        # match.
+        pattern=(
+            r"\b(?:api[_-]?key|token|secret)\s*[:=]\s*"
+            r"(?!(?:process\.env|os\.environ|os\.getenv|config\.|cfg\.|settings\.|env\.|\$\{|\$\(|null\b|None\b|undefined\b|''|\"\"))"
+            r"(?:"
+            r"['\"][A-Za-z0-9._~+/=-]{20,}['\"]"
+            r"|"
+            r"(?!(?:[A-Za-z_$][A-Za-z0-9_$]*\.)+[A-Za-z_$][A-Za-z0-9_$]*(?![A-Za-z0-9._~+/=-]))"
+            r"(?=[A-Za-z._~+/=-]*[0-9])"
+            r"[A-Za-z0-9_~+/=-](?:[A-Za-z0-9._~+/=-]{18,}[A-Za-z0-9_~+/=-])"
+            r")"
+        ),
+        replacement="[redacted-secret]",
+        description="Likely API key, token, or secret assignment.",
+        flags=re.IGNORECASE,
+    ),
+    Rule(
+        id="private-key-block",
+        category="secret",
+        pattern=r"-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----",
+        replacement="[redacted-private-key]",
+        description="PEM private key block.",
+    ),
+)

--- a/src/brigade/guard/types.py
+++ b/src/brigade/guard/types.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+Action = Literal["allow", "warn", "redact", "block"]
+
+
+@dataclass(frozen=True)
+class Rule:
+    id: str
+    category: str
+    pattern: str
+    replacement: str
+    description: str = ""
+    flags: int = 0
+
+
+@dataclass(frozen=True)
+class Finding:
+    rule_id: str
+    category: str
+    action: Action
+    match: str
+    replacement: str
+    line: int
+    column: int
+    start: int
+    end: int
+    source: str = "regex"
+    message: str = ""
+    allowed_by: str | None = None
+
+    @property
+    def blocks(self) -> bool:
+        return self.action == "block"
+
+    @property
+    def redacts(self) -> bool:
+        return self.action in {"redact", "block"}
+
+
+@dataclass
+class ScanOptions:
+    scan_frontmatter: bool = False
+    scan_code_blocks: bool = True
+    honor_allow_comments: bool = True
+    include_opf: bool = False
+    opf_device: str | None = None
+    opf_bin: str | None = None
+
+
+@dataclass
+class TextEdit:
+    start: int
+    end: int
+    replacement: str
+
+
+@dataclass
+class GuardResult:
+    text: str
+    redacted_text: str
+    findings: list[Finding] = field(default_factory=list)
+
+    @property
+    def blocked(self) -> bool:
+        return any(f.blocks for f in self.findings)
+
+    @property
+    def changed(self) -> bool:
+        return self.text != self.redacted_text
+
+    def counts_by_action(self) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for finding in self.findings:
+            counts[finding.action] = counts.get(finding.action, 0) + 1
+        return counts
+
+    def counts_by_category(self) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for finding in self.findings:
+            counts[finding.category] = counts.get(finding.category, 0) + 1
+        return counts

--- a/src/brigade/operator_cmd/health.py
+++ b/src/brigade/operator_cmd/health.py
@@ -71,9 +71,11 @@ def status_payload(target: Path, *, profile: str = "internal-dogfood") -> dict[s
                 "detail": str((readiness.get("blockers") or [{}])[0].get("safe_summary") or "readiness blocker"),
             }
         )
+    # "Configured" means the operator wired a hook for this repo. Scanner
+    # availability no longer signals intent: the guard ships embedded, so
+    # available is true on every install.
     content_guard_configured = bool(
-        content_guard_health.get("available")
-        or content_guard_health.get("hooks_path")
+        content_guard_health.get("hooks_path")
         or content_guard_health.get("configured_pre_push_hook_exists")
         or content_guard_health.get("git_pre_push_hook_exists")
     )

--- a/src/brigade/scrub.py
+++ b/src/brigade/scrub.py
@@ -14,7 +14,23 @@ from .templates import template_root
 
 
 def scanner_dir() -> Path:
-    return Path(os.environ.get("CONTENT_GUARD_DIR", str(Path.home() / "repos" / "content-guard")))
+    configured = os.environ.get("CONTENT_GUARD_DIR")
+    if configured:
+        return Path(configured).expanduser()
+    return Path(__file__).resolve().parent / "guard"
+
+
+def scanner_module() -> str:
+    return "content_guard" if os.environ.get("CONTENT_GUARD_DIR") else "brigade.guard"
+
+
+def _scanner_env() -> dict[str, str]:
+    env = os.environ.copy()
+    if scanner_module() == "content_guard":
+        existing_pp = env.get("PYTHONPATH", "")
+        external_src = scanner_dir() / "src"
+        env["PYTHONPATH"] = f"{external_src}{os.pathsep}{existing_pp}" if existing_pp else str(external_src)
+    return env
 
 
 def available() -> bool:
@@ -59,11 +75,19 @@ def hook_status(target: Path, policy: str = "public-repo") -> dict[str, Any]:
     policy_exists = Path(resolved_policy).is_file()
     checks: list[dict[str, str]] = []
     suggestions: list[str] = []
+    external_configured = bool(os.environ.get("CONTENT_GUARD_DIR"))
     if not available():
-        checks.append(
-            {"status": "warn", "name": "content_guard_missing", "detail": f"content-guard not found at {scanner_dir()}"}
+        detail = (
+            f"CONTENT_GUARD_DIR points at missing content-guard checkout: {scanner_dir()}"
+            if external_configured
+            else f"embedded content guard not found at {scanner_dir()}"
         )
-        suggestions.append("clone https://github.com/escoffier-labs/content-guard or set CONTENT_GUARD_DIR")
+        checks.append({"status": "warn", "name": "content_guard_missing", "detail": detail})
+        suggestions.append(
+            "unset CONTENT_GUARD_DIR to use Brigade's embedded guard"
+            if external_configured
+            else "reinstall brigade-cli so the embedded guard package is present"
+        )
     if not policy_exists:
         checks.append(
             {"status": "warn", "name": "content_guard_policy_missing", "detail": f"policy not found: {resolved_policy}"}
@@ -96,12 +120,13 @@ def hook_status(target: Path, policy: str = "public-repo") -> dict[str, Any]:
             {
                 "status": "ok",
                 "name": "content_guard_ready",
-                "detail": "content-guard policy and pre-push hook are available",
+                "detail": f"{scanner_module()} policy and pre-push hook are available",
             }
         )
     return {
         "available": available(),
         "scanner_dir": str(scanner_dir()),
+        "scanner_module": scanner_module(),
         "policy": policy,
         "policy_path": resolved_policy,
         "policy_exists": policy_exists,
@@ -203,13 +228,23 @@ def run_scan(scan_target: Path, *, repo_target: Path | None = None, policy: str 
     repo_target = repo_target.expanduser().resolve() if repo_target is not None else scan_target
     scanner = scanner_dir()
     if not scanner.is_dir():
+        external_configured = bool(os.environ.get("CONTENT_GUARD_DIR"))
+        detail = (
+            f"CONTENT_GUARD_DIR points at missing content-guard checkout: {scanner}"
+            if external_configured
+            else f"embedded content guard not found at {scanner}"
+        )
         return {
             "available": False,
             "status": "missing",
             "exit_code": 2,
-            "detail": f"content-guard not found at {scanner}",
+            "detail": detail,
             "stdout": "",
-            "stderr": "clone https://github.com/escoffier-labs/content-guard or set CONTENT_GUARD_DIR",
+            "stderr": (
+                "unset CONTENT_GUARD_DIR to use Brigade's embedded guard"
+                if external_configured
+                else "reinstall brigade-cli so the embedded guard package is present"
+            ),
             "policy": policy,
             "policy_path": None,
             "target": str(scan_target),
@@ -243,19 +278,16 @@ def run_scan(scan_target: Path, *, repo_target: Path | None = None, policy: str 
     cmd = [
         sys.executable,
         "-m",
-        "content_guard",
+        scanner_module(),
         "scan",
         str(scan_target),
         "--policy",
         str(resolved_policy),
     ]
-    env = os.environ.copy()
-    existing_pp = env.get("PYTHONPATH", "")
-    env["PYTHONPATH"] = f"{scanner / 'src'}{os.pathsep}{existing_pp}" if existing_pp else str(scanner / "src")
     try:
         result = subprocess.run(
             cmd,
-            env=env,
+            env=_scanner_env(),
             check=False,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -302,12 +334,18 @@ def run(
     scanner_dir = globals()["scanner_dir"]()
 
     if not scanner_dir.is_dir():
+        external_configured = bool(os.environ.get("CONTENT_GUARD_DIR"))
+        scanner_label = "content-guard checkout" if external_configured else "embedded content guard"
         print(
-            f"brigade scrub: content-guard not found at {scanner_dir}",
+            f"brigade scrub: {scanner_label} not found at {scanner_dir}",
             file=sys.stderr,
         )
         print(
-            "brigade scrub: clone https://github.com/escoffier-labs/content-guard or set CONTENT_GUARD_DIR",
+            (
+                "brigade scrub: unset CONTENT_GUARD_DIR to use Brigade's embedded guard"
+                if external_configured
+                else "brigade scrub: reinstall brigade-cli so the embedded guard package is present"
+            ),
             file=sys.stderr,
         )
         return 2
@@ -321,7 +359,7 @@ def run(
         print(f"brigade scrub: policy not found: {policy_path}", file=sys.stderr)
         return 3
 
-    cmd = [sys.executable, "-m", "content_guard", "scan", str(target), "--policy", str(policy_path)]
+    cmd = [sys.executable, "-m", scanner_module(), "scan", str(target), "--policy", str(policy_path)]
     if dry_run:
         if json_output:
             print(
@@ -332,7 +370,8 @@ def run(
             return 0
         print("brigade scrub: would run:")
         print(" ", " ".join(cmd))
-        print(f"  PYTHONPATH={scanner_dir / 'src'}")
+        if scanner_module() == "content_guard":
+            print(f"  PYTHONPATH={scanner_dir / 'src'}")
         return 0
 
     result = run_scan(target, policy=policy)
@@ -373,7 +412,8 @@ def _resolve_policy(target: Path, scanner_dir: Path, policy: str) -> Path:
          treat it as a literal file path and use it as-is.
       2. Otherwise, treat it as a basename and search the safe lookup chain:
          `<target>/.brigade/policies/<policy>.json`,
-         Brigade's packaged policies, then `<scanner_dir>/policies/<policy>.json`.
+         Brigade's embedded guard policies, Brigade's template policies, then
+         `<scanner_dir>/policies/<policy>.json`.
     """
     looks_like_path = "/" in policy or "\\" in policy or policy.endswith(".json")
     if looks_like_path:
@@ -386,6 +426,7 @@ def _resolve_policy(target: Path, scanner_dir: Path, policy: str) -> Path:
 
     candidates = [
         target / ".brigade" / "policies" / f"{safe}.json",
+        Path(__file__).resolve().parent / "guard" / "policies" / f"{safe}.json",
         template_root() / "policies" / f"{safe}.json",
         scanner_dir / "policies" / f"{safe}.json",
     ]

--- a/tests/guard/__init__.py
+++ b/tests/guard/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for brigade.guard."""

--- a/tests/guard/fixtures/real_world/allowed_localhost_example.md
+++ b/tests/guard/fixtures/real_world/allowed_localhost_example.md
@@ -1,0 +1,9 @@
+# Local Service Documentation Example
+
+Use this command to run the scanner against a local sample file:
+
+<!-- content-guard: allow localhost-bare -->
+Open `http://localhost` in your browser after starting the development server.
+
+This fixture shows an intentional local service placeholder with an explicit
+allow comment on the line immediately before the example.

--- a/tests/guard/fixtures/real_world/clean_content.md
+++ b/tests/guard/fixtures/real_world/clean_content.md
@@ -1,0 +1,10 @@
+# Release Note Draft
+
+The new guard command now scans staged markdown and text files before publishing.
+It reports findings with line numbers, rule identifiers, and suggested redactions.
+
+Verification:
+
+- Unit tests passed locally.
+- Documentation examples were reviewed for public sharing.
+- No local paths, hostnames, credentials, or personal contact details are included.

--- a/tests/guard/fixtures/real_world/infrastructure_leak.md
+++ b/tests/guard/fixtures/real_world/infrastructure_leak.md
@@ -1,0 +1,12 @@
+# Deployment Note
+
+The preview service was tested against the redacted internal address below.
+
+```text
+https://ci-preview.redacted-internal.example.test:8443/status
+content-guard: allow private-ipv4
+10.24.16.42
+```
+
+Expected handling: infrastructure details should be reported before this note is
+copied into a public issue, pull request, changelog, or release artifact.

--- a/tests/guard/fixtures/real_world/pr_draft_leak.md
+++ b/tests/guard/fixtures/real_world/pr_draft_leak.md
@@ -1,0 +1,16 @@
+# Pull Request Draft
+
+Summary:
+
+- Adds a staged-file scan before public pushes.
+- Dogfooded against a local checkout at `/home/example-user/work/private-repo`.
+
+Notes to remove before publishing:
+
+- Follow-up task lives in REDACTED-TRACKER-123.
+- Private branch name was `example-user/private-dogfood-run`.
+<!-- content-guard: allow localhost-port -->
+- Local reproduction used `http://localhost:5204/debug/report`.
+
+Expected handling: draft-only local context should be blocked or redacted before
+the text is used as a hosted pull request body.

--- a/tests/guard/fixtures/real_world/secret_leak.md
+++ b/tests/guard/fixtures/real_world/secret_leak.md
@@ -1,0 +1,13 @@
+# Redacted Secret Example
+
+The copied terminal output below uses fake values that match common credential
+shapes. Do not replace these with real credentials.
+
+```text
+CONTENT_GUARD_API_KEY=abcdefghijklmnopqrstuvwxyz123456
+content-guard: allow bearer-token
+authorization: Bearer exampletoken1234567890exampletoken1234567890
+```
+
+Expected handling: secret-shaped strings should be blocked even when surrounding
+content looks like ordinary setup notes.

--- a/tests/guard/test_allow_cli.py
+++ b/tests/guard/test_allow_cli.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from brigade.guard.cli import main
+from brigade.guard.policy import load_policy
+
+
+def _write_policy(path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "name": "private-test",
+                "defaults": {"infrastructure": "warn"},
+                "allow_values": ["already-public.example"],
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+
+
+class AllowAddTests(unittest.TestCase):
+    def test_add_appends_value_and_policy_still_loads(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            policy_path = Path(tmp) / "internal.json"
+            _write_policy(policy_path)
+
+            rc = main(["allow", "add", "git@github.com", "--policy", str(policy_path)])
+
+            self.assertEqual(rc, 0)
+            data = json.loads(policy_path.read_text())
+            self.assertIn("git@github.com", data["allow_values"])
+            self.assertIn("already-public.example", data["allow_values"])
+            policy = load_policy(policy_path)
+            self.assertIn("git@github.com", policy.allow_values)
+
+    def test_add_is_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            policy_path = Path(tmp) / "internal.json"
+            _write_policy(policy_path)
+
+            main(["allow", "add", "dup-value-123", "--policy", str(policy_path)])
+            rc = main(["allow", "add", "dup-value-123", "--policy", str(policy_path)])
+
+            self.assertEqual(rc, 0)
+            data = json.loads(policy_path.read_text())
+            self.assertEqual(data["allow_values"].count("dup-value-123"), 1)
+
+    def test_add_with_note_records_provenance(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            policy_path = Path(tmp) / "internal.json"
+            _write_policy(policy_path)
+
+            rc = main(
+                [
+                    "allow",
+                    "add",
+                    "public-fixture-string",
+                    "--policy",
+                    str(policy_path),
+                    "--note",
+                    "upstream test fixture, already public",
+                ]
+            )
+
+            self.assertEqual(rc, 0)
+            data = json.loads(policy_path.read_text())
+            self.assertEqual(
+                data["_allow_values_notes"]["public-fixture-string"],
+                "upstream test fixture, already public",
+            )
+            load_policy(policy_path)
+
+    def test_add_creates_allow_values_key_when_absent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            policy_path = Path(tmp) / "internal.json"
+            policy_path.write_text(json.dumps({"name": "bare"}) + "\n")
+
+            rc = main(["allow", "add", "brand-new-value", "--policy", str(policy_path)])
+
+            self.assertEqual(rc, 0)
+            data = json.loads(policy_path.read_text())
+            self.assertEqual(data["allow_values"], ["brand-new-value"])
+
+    def test_add_missing_policy_file_fails_cleanly(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "nope.json"
+
+            rc = main(["allow", "add", "x-value", "--policy", str(missing)])
+
+            self.assertNotEqual(rc, 0)
+            self.assertFalse(missing.exists())
+
+    def test_list_prints_values(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            policy_path = Path(tmp) / "internal.json"
+            _write_policy(policy_path)
+
+            rc = main(["allow", "list", "--policy", str(policy_path)])
+
+            self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/guard/test_allow_values.py
+++ b/tests/guard/test_allow_values.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+# This file uses illustrative example emails (a@b.com, x@y.com, someone@else.com)
+# as test data. They are not real PII, so exempt the whole file from the email
+# rule for content-guard's own pre-push self-scan. This does not affect the
+# scan_text() calls inside the tests, which scan Python string literals.
+# content-guard: allow email file
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from brigade.guard.engine import scan_text
+from brigade.guard.policy import Policy, load_policy
+
+
+class AllowValuesEngineTests(unittest.TestCase):
+    def test_exact_value_is_allowed_not_blocked(self) -> None:
+        policy = Policy(defaults={"pii": "block"}, allow_values=["srneas@gmail.com"])
+        result = scan_text("Reach me at srneas@gmail.com please", policy=policy)
+
+        emails = [f for f in result.findings if f.rule_id == "email"]
+        self.assertEqual(len(emails), 1)
+        self.assertEqual(emails[0].action, "allow")
+        self.assertEqual(emails[0].allowed_by, "allow-value")
+        self.assertFalse(result.blocked)
+
+    def test_non_listed_value_still_blocks(self) -> None:
+        policy = Policy(defaults={"pii": "block"}, allow_values=["srneas@gmail.com"])
+        result = scan_text("Reach me at someone@else.com please", policy=policy)
+
+        emails = [f for f in result.findings if f.rule_id == "email"]
+        self.assertEqual(len(emails), 1)
+        self.assertNotEqual(emails[0].action, "allow")
+        self.assertTrue(result.blocked)
+
+    def test_substring_value_does_not_exempt_larger_match(self) -> None:
+        # Listing a substring must NOT exempt a larger matched span: the
+        # allowlist is exact-match on the whole finding text.
+        policy = Policy(defaults={"pii": "block"}, allow_values=["gmail.com"])
+        result = scan_text("Reach me at srneas@gmail.com please", policy=policy)
+
+        emails = [f for f in result.findings if f.rule_id == "email"]
+        self.assertEqual(len(emails), 1)
+        self.assertNotEqual(emails[0].action, "allow")
+        self.assertTrue(result.blocked)
+
+    def test_superstring_value_on_its_line_allows_contained_match(self) -> None:
+        # A known-public literal can be LONGER than the matched span: listing
+        # the full public path allows the home-path prefix match on that line
+        # only, without allowing the bare prefix everywhere.
+        policy = Policy(
+            defaults={"pii": "block"},
+            allow_values=["Reach me at srneas@gmail.com for docs"],
+        )
+        result = scan_text("intro\nReach me at srneas@gmail.com for docs\noutro", policy=policy)
+
+        emails = [f for f in result.findings if f.rule_id == "email"]
+        self.assertEqual(len(emails), 1)
+        self.assertEqual(emails[0].action, "allow")
+        self.assertEqual(emails[0].allowed_by, "allow-value")
+        self.assertFalse(result.blocked)
+
+    def test_superstring_value_not_on_line_still_blocks(self) -> None:
+        # The superstring allow is line-scoped: the same matched text on a
+        # different line (outside the listed literal) stays blocked.
+        policy = Policy(
+            defaults={"pii": "block"},
+            allow_values=["Reach me at srneas@gmail.com for docs"],
+        )
+        result = scan_text("mail srneas@gmail.com now", policy=policy)
+
+        emails = [f for f in result.findings if f.rule_id == "email"]
+        self.assertEqual(len(emails), 1)
+        self.assertNotEqual(emails[0].action, "allow")
+        self.assertTrue(result.blocked)
+
+    def test_superstring_value_covers_only_its_own_span(self) -> None:
+        # Two identical matches on one line: only the one inside the listed
+        # literal is cleared; the uncovered occurrence still blocks.
+        policy = Policy(
+            defaults={"pii": "block"},
+            allow_values=["docs contact srneas@gmail.com listed"],
+        )
+        result = scan_text(
+            "docs contact srneas@gmail.com listed, private srneas@gmail.com here",
+            policy=policy,
+        )
+
+        emails = [f for f in result.findings if f.rule_id == "email"]
+        self.assertEqual(len(emails), 2)
+        self.assertEqual(emails[0].allowed_by, "allow-value")
+        self.assertIsNone(emails[1].allowed_by)
+        self.assertTrue(result.blocked)
+
+    def test_allow_value_overrides_block_across_rules(self) -> None:
+        policy = Policy(
+            defaults={"infrastructure": "block"},
+            rules={"localhost-port": "block"},
+            allow_values=["localhost:11434"],
+        )
+        result = scan_text("ollama at localhost:11434/api", policy=policy)
+
+        ports = [f for f in result.findings if f.rule_id == "localhost-port"]
+        self.assertEqual(len(ports), 1)
+        self.assertEqual(ports[0].action, "allow")
+        self.assertFalse(result.blocked)
+
+
+class AllowValuesPolicyTests(unittest.TestCase):
+    def _write(self, tmp: str, payload: dict) -> Path:
+        path = Path(tmp) / "policy.json"
+        path.write_text(json.dumps(payload))
+        return path
+
+    def test_load_policy_parses_allow_values(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = self._write(tmp, {"name": "x", "allow_values": ["a@b.com", "localhost:11434"]})
+            policy = load_policy(path)
+            self.assertEqual(policy.allow_values, ["a@b.com", "localhost:11434"])
+
+    def test_allow_values_absent_defaults_empty(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = self._write(tmp, {"name": "x"})
+            self.assertEqual(load_policy(path).allow_values, [])
+
+    def test_allow_values_must_be_list(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = self._write(tmp, {"allow_values": "a@b.com"})
+            with self.assertRaises(ValueError):
+                load_policy(path)
+
+    def test_allow_values_entries_must_be_nonempty_strings(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = self._write(tmp, {"allow_values": ["ok", ""]})
+            with self.assertRaises(ValueError):
+                load_policy(path)
+
+
+class AllowValuesFromMergeTests(unittest.TestCase):
+    def test_merge_extends_policy_allow_values(self) -> None:
+        from brigade.guard.git_scan import _merge_allow_values_from
+
+        with TemporaryDirectory() as tmp:
+            extra = Path(tmp) / "internal.json"
+            extra.write_text(json.dumps({"allow_values": ["x@y.com"]}))
+            policy = Policy(allow_values=["a@b.com"])
+            _merge_allow_values_from(policy, [str(extra)])
+            self.assertIn("a@b.com", policy.allow_values)
+            self.assertIn("x@y.com", policy.allow_values)
+
+    def test_merge_is_noop_for_missing_file(self) -> None:
+        from brigade.guard.git_scan import _merge_allow_values_from
+
+        policy = Policy(allow_values=["a@b.com"])
+        _merge_allow_values_from(policy, ["/nonexistent/internal.json"])
+        self.assertEqual(policy.allow_values, ["a@b.com"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/guard/test_audit.py
+++ b/tests/guard/test_audit.py
@@ -1,0 +1,197 @@
+# content-guard: allow private-ipv4 file
+# content-guard: allow loopback-ipv4 file
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class AuditCliTests(unittest.TestCase):
+    """End-to-end CLI tests for `content-guard audit`."""
+
+    def test_audit_tracked_scope_counts_findings_in_tracked_files_only(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            self._init_repo(repo)
+            (repo / "tracked.md").write_text("Service runs on 192.168.99.10.\n")
+            subprocess.run(["git", "add", "tracked.md"], cwd=repo, check=True)
+            subprocess.run(
+                ["git", "commit", "-m", "add tracked"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            (repo / "untracked.md").write_text("Other service on 192.168.99.20.\n")
+
+            proc = self._audit(repo, str(repo), "--scope", "tracked", "--json")
+
+        self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+        payload = json.loads(proc.stdout)
+        # Two files exist on disk; only one is tracked.
+        self.assertEqual(payload["summary"]["files_scanned"], 2)
+        # README.md is tracked too (from _init_repo) but has no findings.
+        self.assertEqual(payload["summary"]["files_with_findings"], 1)
+        self.assertEqual(payload["summary"]["total_findings"], 1)
+        offenders = {entry["path"] for entry in payload["top_offenders"]}
+        self.assertEqual(offenders, {"tracked.md"})
+
+    def test_audit_tree_scope_counts_all_files(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            self._init_repo(repo)
+            (repo / "tracked.md").write_text("Service runs on 192.168.99.10.\n")
+            subprocess.run(["git", "add", "tracked.md"], cwd=repo, check=True)
+            subprocess.run(
+                ["git", "commit", "-m", "add tracked"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            (repo / "untracked.md").write_text("Other service on 192.168.99.20.\n")
+
+            proc = self._audit(repo, str(repo), "--scope", "tree", "--json")
+
+        self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+        payload = json.loads(proc.stdout)
+        # README.md, tracked.md, untracked.md
+        self.assertEqual(payload["summary"]["files_scanned"], 3)
+        self.assertEqual(payload["summary"]["files_with_findings"], 2)
+        self.assertEqual(payload["summary"]["total_findings"], 2)
+        offenders = {entry["path"] for entry in payload["top_offenders"]}
+        self.assertEqual(offenders, {"tracked.md", "untracked.md"})
+
+    def test_audit_json_output_has_expected_shape(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            self._init_repo(repo)
+            (repo / "leak.md").write_text("Host: 192.168.99.10 and 172.16.0.5.\n")
+            subprocess.run(["git", "add", "leak.md"], cwd=repo, check=True)
+            subprocess.run(
+                ["git", "commit", "-m", "add leak"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            proc = self._audit(repo, str(repo), "--scope", "tracked", "--json")
+
+        self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+        payload = json.loads(proc.stdout)
+        self.assertIn("summary", payload)
+        self.assertIn("by_category", payload)
+        self.assertIn("by_rule", payload)
+        self.assertIn("top_offenders", payload)
+        # Summary shape
+        for key in ("target", "scope", "files_scanned", "files_with_findings", "total_findings", "blocked"):
+            self.assertIn(key, payload["summary"])
+        # by_rule is a list of {rule_id, count}
+        self.assertTrue(payload["by_rule"], "expected at least one rule in by_rule")
+        for entry in payload["by_rule"]:
+            self.assertIn("rule_id", entry)
+            self.assertIn("count", entry)
+        # top_offenders entries have path/findings/blocked
+        self.assertTrue(payload["top_offenders"], "expected at least one offender")
+        for entry in payload["top_offenders"]:
+            self.assertIn("path", entry)
+            self.assertIn("findings", entry)
+            self.assertIn("blocked", entry)
+
+    def test_audit_text_output_includes_section_headers(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            self._init_repo(repo)
+            (repo / "leak.md").write_text("Host: 192.168.99.10.\n")
+            subprocess.run(["git", "add", "leak.md"], cwd=repo, check=True)
+            subprocess.run(
+                ["git", "commit", "-m", "add leak"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            proc = self._audit(repo, str(repo), "--scope", "tracked")
+
+        self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+        self.assertIn("Summary", proc.stdout)
+        self.assertIn("By category", proc.stdout)
+        self.assertIn("Top offenders", proc.stdout)
+
+    def test_audit_strict_flag_exits_1_on_blocking_findings(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            self._init_repo(repo)
+            (repo / "leak.md").write_text("Host: 192.168.99.10.\n")
+            subprocess.run(["git", "add", "leak.md"], cwd=repo, check=True)
+            subprocess.run(
+                ["git", "commit", "-m", "add leak"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            proc = self._audit(repo, str(repo), "--scope", "tracked", "--strict", "--json")
+
+        self.assertEqual(proc.returncode, 1, msg=proc.stdout + proc.stderr)
+        payload = json.loads(proc.stdout)
+        self.assertTrue(payload["summary"]["blocked"])
+
+    def test_audit_exits_zero_without_strict(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            self._init_repo(repo)
+            (repo / "leak.md").write_text("Host: 192.168.99.10.\n")
+            subprocess.run(["git", "add", "leak.md"], cwd=repo, check=True)
+            subprocess.run(
+                ["git", "commit", "-m", "add leak"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            proc = self._audit(repo, str(repo), "--scope", "tracked", "--json")
+
+        self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+        payload = json.loads(proc.stdout)
+        # Even though there are blocking findings, audit is non-blocking by default.
+        self.assertTrue(payload["summary"]["blocked"])
+
+    def _init_repo(self, repo: Path) -> None:
+        subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
+        subprocess.run(["git", "config", "user.name", "Example User"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.email", "user@example"], cwd=repo, check=True)
+        (repo / "README.md").write_text("example\n")
+        subprocess.run(["git", "add", "README.md"], cwd=repo, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "feat: example"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    def _audit(self, cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, "-m", "brigade.guard", "audit", *args],
+            cwd=cwd,
+            env={"PYTHONPATH": str(ROOT / "src")},
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/guard/test_baseline.py
+++ b/tests/guard/test_baseline.py
@@ -1,0 +1,427 @@
+# content-guard: allow private-ipv4 file
+# content-guard: allow loopback-ipv4 file
+# content-guard: allow api-key-assignment file
+# content-guard: allow bearer-token file
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from brigade.guard.baseline import (
+    BASELINE_SCHEMA_VERSION,
+    Baseline,
+    BaselineEntry,
+    filter_findings,
+    fingerprint_for,
+    init_baseline,
+    load_baseline,
+    save_baseline,
+)
+from brigade.guard.engine import scan_text
+from brigade.guard.policy import Policy
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class BaselineModuleTests(unittest.TestCase):
+    def test_init_baseline_captures_current_findings(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            # content-guard: allow all
+            (root / "leak.md").write_text("Service is localhost:5204 and 192.168.99.91.\n")
+            (root / "clean.md").write_text("Nothing to see here.\n")
+
+            baseline = init_baseline(root, policy=Policy())
+
+        rule_ids = {e.rule_id for e in baseline.entries}
+        self.assertIn("localhost-port", rule_ids)
+        self.assertIn("private-ipv4", rule_ids)
+        # Only the leak file has entries.
+        paths = {e.path for e in baseline.entries}
+        self.assertEqual(paths, {"leak.md"})
+
+    def test_init_baseline_skips_allow_comment_findings(self) -> None:
+        # Findings already neutralized by inline allow directives don't need
+        # baseline entries; capturing them just adds noise.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "doc.md").write_text("<!-- content-guard: allow localhost-port -->\nlocalhost:5204\n")
+
+            baseline = init_baseline(root, policy=Policy())
+
+        self.assertEqual(baseline.entries, [])
+
+    def test_init_baseline_skips_excluded_dirs(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            # content-guard: allow localhost-port
+            leak_text = "localhost:5204\n"
+            (root / "real.md").write_text(leak_text)
+            for excluded in ("node_modules", ".git", "dist", ".venv"):
+                sub = root / excluded
+                sub.mkdir()
+                (sub / "leak.md").write_text(leak_text)
+
+            baseline = init_baseline(root, policy=Policy())
+
+        paths = {e.path for e in baseline.entries}
+        self.assertEqual(paths, {"real.md"})
+
+    def test_baseline_save_and_load_round_trip(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            # content-guard: allow all
+            (root / "leak.md").write_text("Service is localhost:5204.\n")
+            baseline = init_baseline(root, policy=Policy())
+
+            out_path = root / "baseline.json"
+            save_baseline(baseline, out_path)
+            loaded = load_baseline(out_path)
+
+        self.assertEqual(loaded.version, BASELINE_SCHEMA_VERSION)
+        self.assertEqual(loaded.created_at, baseline.created_at)
+        self.assertEqual(len(loaded.entries), len(baseline.entries))
+        for original, restored in zip(baseline.entries, loaded.entries, strict=True):
+            self.assertEqual(original, restored)
+
+    def test_baseline_file_has_expected_top_level_schema(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            baseline = Baseline(
+                entries=[
+                    BaselineEntry(
+                        path="docs/foo.md",
+                        rule_id="localhost-port",
+                        match="localhost:5204",
+                        line=3,
+                        fingerprint=fingerprint_for("localhost-port", "localhost:5204"),
+                    )
+                ],
+                created_at="2026-05-22T00:00:00+00:00",
+            )
+            out_path = root / "baseline.json"
+            save_baseline(baseline, out_path)
+            payload = json.loads(out_path.read_text())
+
+        self.assertEqual(payload["version"], 1)
+        self.assertEqual(payload["created_at"], "2026-05-22T00:00:00+00:00")
+        self.assertEqual(len(payload["entries"]), 1)
+        self.assertEqual(payload["entries"][0]["rule_id"], "localhost-port")
+
+    def test_filter_findings_removes_baselined_findings_only(self) -> None:
+        # content-guard: allow all
+        text = "localhost:5204 and 192.168.99.91\n"
+        result = scan_text(text, policy=Policy())
+
+        baseline = Baseline(
+            entries=[
+                BaselineEntry(
+                    path="leak.md",
+                    rule_id="localhost-port",
+                    match="localhost:5204",
+                    line=1,
+                    fingerprint=fingerprint_for("localhost-port", "localhost:5204"),
+                )
+            ],
+            created_at="2026-05-22T00:00:00+00:00",
+        )
+
+        kept = filter_findings(result.findings, baseline, "leak.md")
+        rule_ids = {f.rule_id for f in kept}
+        # localhost-port is baselined and should be filtered out.
+        self.assertNotIn("localhost-port", rule_ids)
+        # private-ipv4 is NOT in the baseline and must remain.
+        self.assertIn("private-ipv4", rule_ids)
+
+    def test_filter_findings_keeps_new_findings_with_different_content(self) -> None:
+        # Baseline accepts ONE specific localhost port. A different port string
+        # produces a different fingerprint and must be flagged as new.
+        # content-guard: allow all
+        text = "old localhost:5204 and new localhost:9999\n"
+        result = scan_text(text, policy=Policy())
+        # Both findings should be from rule localhost-port.
+        all_matches = {f.match for f in result.findings if f.rule_id == "localhost-port"}
+        self.assertEqual(all_matches, {"localhost:5204", "localhost:9999"})
+
+        baseline = Baseline(
+            entries=[
+                BaselineEntry(
+                    path="leak.md",
+                    rule_id="localhost-port",
+                    match="localhost:5204",
+                    line=1,
+                    fingerprint=fingerprint_for("localhost-port", "localhost:5204"),
+                )
+            ],
+            created_at="2026-05-22T00:00:00+00:00",
+        )
+
+        kept = filter_findings(result.findings, baseline, "leak.md")
+        kept_matches = {f.match for f in kept if f.rule_id == "localhost-port"}
+        self.assertEqual(kept_matches, {"localhost:9999"})
+
+    def test_filter_findings_same_match_different_file_is_new(self) -> None:
+        # Same string in a different file should NOT be considered baselined.
+        # content-guard: allow all
+        text = "localhost:5204\n"
+        result = scan_text(text, policy=Policy())
+
+        baseline = Baseline(
+            entries=[
+                BaselineEntry(
+                    path="docs/old.md",
+                    rule_id="localhost-port",
+                    match="localhost:5204",
+                    line=1,
+                    fingerprint=fingerprint_for("localhost-port", "localhost:5204"),
+                )
+            ],
+            created_at="2026-05-22T00:00:00+00:00",
+        )
+
+        kept = filter_findings(result.findings, baseline, "docs/new.md")
+        rule_ids = {f.rule_id for f in kept}
+        self.assertIn("localhost-port", rule_ids)
+
+    def test_fingerprint_is_stable_and_unique(self) -> None:
+        fp1 = fingerprint_for("localhost-port", "localhost:5204")
+        fp2 = fingerprint_for("localhost-port", "localhost:5204")
+        fp3 = fingerprint_for("localhost-port", "localhost:5205")
+        fp4 = fingerprint_for("private-ipv4", "localhost:5204")
+
+        self.assertEqual(fp1, fp2)
+        self.assertNotEqual(fp1, fp3)
+        self.assertNotEqual(fp1, fp4)
+        self.assertEqual(len(fp1), 16)
+
+    def test_baseline_load_rejects_invalid_schema(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "bad.json"
+
+            # Not JSON at all.
+            path.write_text("not json {")
+            with self.assertRaises(ValueError):
+                load_baseline(path)
+
+            # Root is not an object.
+            path.write_text("[]")
+            with self.assertRaises(ValueError):
+                load_baseline(path)
+
+            # Missing 'entries'.
+            path.write_text(json.dumps({"version": 1, "created_at": "x"}))
+            with self.assertRaises(ValueError):
+                load_baseline(path)
+
+            # Entries not a list.
+            path.write_text(json.dumps({"version": 1, "created_at": "x", "entries": {}}))
+            with self.assertRaises(ValueError):
+                load_baseline(path)
+
+            # Entry missing required field.
+            path.write_text(
+                json.dumps(
+                    {
+                        "version": 1,
+                        "created_at": "x",
+                        "entries": [{"path": "a", "rule_id": "b", "match": "c"}],
+                    }
+                )
+            )
+            with self.assertRaises(ValueError):
+                load_baseline(path)
+
+    def test_baseline_load_rejects_unsupported_version(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "bad.json"
+            path.write_text(json.dumps({"version": 999, "created_at": "x", "entries": []}))
+            with self.assertRaises(ValueError) as ctx:
+                load_baseline(path)
+            self.assertIn("version", str(ctx.exception))
+
+            # Non-integer version.
+            path.write_text(json.dumps({"version": "1", "created_at": "x", "entries": []}))
+            with self.assertRaises(ValueError):
+                load_baseline(path)
+
+
+class BaselineCliTests(unittest.TestCase):
+    """End-to-end CLI tests for `content-guard baseline` and `scan --baseline`.
+
+    Kept here (not in test_cli.py) to avoid collisions with a concurrent
+    subagent editing test_cli.py for the audit subcommand.
+    """
+
+    def test_baseline_init_writes_json_file(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            # content-guard: allow all
+            (root / "leak.md").write_text("Service is localhost:5204.\n")
+
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "brigade.guard",
+                    "baseline",
+                    "init",
+                    str(root),
+                ],
+                cwd=ROOT,
+                env={"PYTHONPATH": str(ROOT / "src")},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+            baseline_path = root / ".content-guard-baseline.json"
+            self.assertTrue(baseline_path.exists())
+            payload = json.loads(baseline_path.read_text())
+            self.assertEqual(payload["version"], 1)
+            self.assertGreater(len(payload["entries"]), 0)
+            rule_ids = {e["rule_id"] for e in payload["entries"]}
+            self.assertIn("localhost-port", rule_ids)
+
+    def test_baseline_init_respects_output_flag(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            # content-guard: allow all
+            (root / "leak.md").write_text("Service is localhost:5204.\n")
+            custom_out = root / "custom" / "baseline.json"
+
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "brigade.guard",
+                    "baseline",
+                    "init",
+                    str(root),
+                    "--output",
+                    str(custom_out),
+                ],
+                cwd=ROOT,
+                env={"PYTHONPATH": str(ROOT / "src")},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+            self.assertTrue(custom_out.exists())
+            self.assertFalse((root / ".content-guard-baseline.json").exists())
+
+    def test_scan_with_baseline_suppresses_known_findings(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            target = root / "leak.md"
+            # content-guard: allow all
+            target.write_text("Service is localhost:5204.\n")
+
+            # Create baseline first.
+            init_proc = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "brigade.guard",
+                    "baseline",
+                    "init",
+                    str(root),
+                ],
+                cwd=ROOT,
+                env={"PYTHONPATH": str(ROOT / "src")},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(init_proc.returncode, 0, msg=init_proc.stderr)
+            baseline_path = root / ".content-guard-baseline.json"
+            self.assertTrue(baseline_path.exists())
+
+            # Now scan the same file with the baseline - should be clean.
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "brigade.guard",
+                    "scan",
+                    str(target),
+                    "--baseline",
+                    str(baseline_path),
+                    "--json",
+                ],
+                cwd=ROOT,
+                env={"PYTHONPATH": str(ROOT / "src")},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+            payload = json.loads(proc.stdout)
+            self.assertFalse(payload["blocked"])
+            self.assertEqual(payload["findings"], [])
+
+    def test_scan_with_baseline_still_flags_new_findings(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            target = root / "leak.md"
+            # content-guard: allow all
+            target.write_text("Service is localhost:5204.\n")
+
+            # Capture baseline.
+            subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "brigade.guard",
+                    "baseline",
+                    "init",
+                    str(root),
+                ],
+                cwd=ROOT,
+                env={"PYTHONPATH": str(ROOT / "src")},
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            baseline_path = root / ".content-guard-baseline.json"
+
+            # Add a NEW violation that is not in the baseline.
+            # content-guard: allow all
+            target.write_text("Service is localhost:5204 and new leak localhost:9999.\n")
+
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "brigade.guard",
+                    "scan",
+                    str(target),
+                    "--baseline",
+                    str(baseline_path),
+                    "--json",
+                ],
+                cwd=ROOT,
+                env={"PYTHONPATH": str(ROOT / "src")},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(proc.returncode, 1, msg=proc.stdout + proc.stderr)
+            payload = json.loads(proc.stdout)
+            self.assertTrue(payload["blocked"])
+            matches = [f["match"] for f in payload["findings"]]
+            self.assertIn("localhost:9999", matches)
+            self.assertNotIn("localhost:5204", matches)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/guard/test_cli.py
+++ b/tests/guard/test_cli.py
@@ -1,0 +1,630 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class CliTests(unittest.TestCase):
+    def test_scan_directory_reports_findings(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "clean.md").write_text("This is clean.\n")
+            # content-guard: allow localhost-port
+            (root / "leak.md").write_text("Service is localhost:5204.\n")
+
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "brigade.guard",
+                    "scan",
+                    str(root),
+                    "--policy",
+                    str(ROOT / "src" / "brigade" / "guard" / "policies" / "public-content.json"),
+                    "--json",
+                ],
+                cwd=ROOT,
+                env={"PYTHONPATH": str(ROOT / "src")},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        self.assertEqual(proc.returncode, 1)
+        payload = json.loads(proc.stdout)
+        self.assertTrue(payload["blocked"])
+        self.assertEqual(payload["files_scanned"], 2)
+        self.assertEqual(len(payload["files"]), 1)
+        self.assertEqual(payload["files"][0]["findings"][0]["rule_id"], "localhost-port")
+
+    def test_scan_directory_skips_generated_dirs(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            # content-guard: allow localhost-port
+            leak_text = "Service is localhost:5204.\n"
+            (root / "README.md").write_text(leak_text)
+
+            for excluded in (
+                "node_modules/foo",
+                ".git",
+                "dist",
+                "build",
+                "coverage",
+                ".next",
+                ".venv",
+                "__pycache__",
+                "vendor/sub",
+                ".claude",
+            ):
+                excluded_dir = root / excluded
+                excluded_dir.mkdir(parents=True)
+                (excluded_dir / "README.md").write_text(leak_text)
+
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "brigade.guard",
+                    "scan",
+                    str(root),
+                    "--policy",
+                    str(ROOT / "src" / "brigade" / "guard" / "policies" / "public-content.json"),
+                    "--json",
+                ],
+                cwd=ROOT,
+                env={"PYTHONPATH": str(ROOT / "src")},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        self.assertEqual(proc.returncode, 1, msg=proc.stdout + proc.stderr)
+        payload = json.loads(proc.stdout)
+        self.assertEqual(payload["files_scanned"], 1)
+        self.assertEqual(len(payload["files"]), 1)
+        self.assertTrue(payload["files"][0]["path"].endswith("README.md"))
+        for entry in payload["files"]:
+            for excluded in (
+                "node_modules",
+                ".git",
+                "dist",
+                "build",
+                "coverage",
+                ".next",
+                ".venv",
+                "__pycache__",
+                "vendor",
+                ".claude",
+            ):
+                self.assertNotIn(f"/{excluded}/", entry["path"])
+
+    def test_pr_draft_helper_is_advisory_by_default(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            target = root / "pr-body.md"
+            # content-guard: allow all
+            target.write_text("PR body with localhost:5204 and alice@solomonneas.dev\n")
+
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "brigade.guard.pr_draft",
+                    str(target),
+                    "--policy",
+                    str(ROOT / "src" / "brigade" / "guard" / "policies" / "pr-draft.json"),
+                ],
+                cwd=ROOT,
+                env={"PYTHONPATH": str(ROOT / "src")},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            public_path = root / "pr-body.public.md"
+            report_path = root / "pr-body.content-guard.json"
+
+            self.assertEqual(proc.returncode, 0)
+            self.assertIn("advisory=true", proc.stdout)
+            self.assertTrue(public_path.exists())
+            self.assertTrue(report_path.exists())
+            self.assertIn("[redacted-service]", public_path.read_text())
+            self.assertIn("<PRIVATE_EMAIL>", public_path.read_text())
+            self.assertTrue(json.loads(report_path.read_text())["blocked"])
+
+    def test_pr_draft_helper_strict_blocks(self) -> None:
+        with TemporaryDirectory() as tmp:
+            target = Path(tmp) / "pr-body.md"
+            # content-guard: allow localhost-port
+            target.write_text("PR body with localhost:5204\n")
+
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "brigade.guard.pr_draft",
+                    str(target),
+                    "--policy",
+                    str(ROOT / "src" / "brigade" / "guard" / "policies" / "pr-draft.json"),
+                    "--strict",
+                ],
+                cwd=ROOT,
+                env={"PYTHONPATH": str(ROOT / "src")},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        self.assertEqual(proc.returncode, 1)
+
+    def test_pr_prepare_writes_publish_handoff_from_stdin(self) -> None:
+        with TemporaryDirectory() as tmp:
+            out_dir = Path(tmp) / "guarded"
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "brigade.guard.pr_prepare",
+                    "--out-dir",
+                    str(out_dir),
+                    "--name",
+                    "watchtower fix",
+                    "--policy",
+                    str(ROOT / "src" / "brigade" / "guard" / "policies" / "pr-draft.json"),
+                    "--json",
+                ],
+                cwd=ROOT,
+                env={"PYTHONPATH": str(ROOT / "src")},
+                # content-guard: allow all
+                input="PR body with localhost:5204 and alice@solomonneas.dev.\n",
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(proc.returncode, 0)
+            payload = json.loads(proc.stdout)
+            publish_path = Path(payload["publish_body_file"])
+            self.assertEqual(payload["source"], "<stdin>")
+            self.assertTrue(payload["blocked"])
+            self.assertTrue(payload["advisory"])
+            self.assertEqual(publish_path, out_dir / "watchtower-fix.public.md")
+            self.assertEqual(Path(payload["draft"]), out_dir / "watchtower-fix.draft.md")
+            self.assertEqual(Path(payload["report"]), out_dir / "watchtower-fix.content-guard.json")
+            self.assertIn("[redacted-service]", publish_path.read_text())
+            self.assertIn("<PRIVATE_EMAIL>", publish_path.read_text())
+            self.assertEqual(json.loads(Path(payload["report"]).read_text())["publish_body_file"], str(publish_path))
+
+    def test_pr_prepare_strict_blocks(self) -> None:
+        with TemporaryDirectory() as tmp:
+            target = Path(tmp) / "pr-body.md"
+            # content-guard: allow localhost-port
+            target.write_text("PR body with localhost:5204\n")
+
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "brigade.guard.pr_prepare",
+                    str(target),
+                    "--out-dir",
+                    str(Path(tmp) / "guarded"),
+                    "--policy",
+                    str(ROOT / "src" / "brigade" / "guard" / "policies" / "pr-draft.json"),
+                    "--strict",
+                ],
+                cwd=ROOT,
+                env={"PYTHONPATH": str(ROOT / "src")},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        self.assertEqual(proc.returncode, 1)
+
+    def test_git_commit_scan_blocks_coauthor_trailer(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
+            subprocess.run(["git", "config", "user.name", "Example User"], cwd=repo, check=True)
+            subprocess.run(["git", "config", "user.email", "user@example"], cwd=repo, check=True)
+            (repo / "README.md").write_text("example\n")
+            subprocess.run(["git", "add", "README.md"], cwd=repo, check=True)
+            subprocess.run(
+                [
+                    "git",
+                    "commit",
+                    "-m",
+                    "feat: example",
+                    "-m",
+                    "Co-authored-by: Other User <other@example>",
+                ],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "brigade.guard.git_commits",
+                    "--range",
+                    "HEAD",
+                    "--policy",
+                    str(ROOT / "src" / "brigade" / "guard" / "policies" / "public-repo.json"),
+                    "--json",
+                ],
+                cwd=repo,
+                env={"PYTHONPATH": str(ROOT / "src")},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        self.assertEqual(proc.returncode, 1)
+        payload = json.loads(proc.stdout)
+        self.assertTrue(payload["blocked"])
+        self.assertEqual(payload["commits_with_findings"], 1)
+        self.assertEqual(payload["commits"][0]["findings"][0]["rule_id"], "coauthored-by-trailer")
+
+    def test_git_commit_scan_allows_clean_commit_message(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
+            subprocess.run(["git", "config", "user.name", "Example User"], cwd=repo, check=True)
+            subprocess.run(["git", "config", "user.email", "user@example"], cwd=repo, check=True)
+            (repo / "README.md").write_text("example\n")
+            subprocess.run(["git", "add", "README.md"], cwd=repo, check=True)
+            subprocess.run(
+                ["git", "commit", "-m", "feat: example"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "brigade.guard.git_commits",
+                    "--range",
+                    "HEAD",
+                    "--policy",
+                    str(ROOT / "src" / "brigade" / "guard" / "policies" / "public-repo.json"),
+                    "--json",
+                ],
+                cwd=repo,
+                env={"PYTHONPATH": str(ROOT / "src")},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        self.assertEqual(proc.returncode, 0)
+        payload = json.loads(proc.stdout)
+        self.assertFalse(payload["blocked"])
+        self.assertEqual(payload["commits_with_findings"], 0)
+
+    def test_git_commit_scan_redacts_report_subject(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
+            subprocess.run(["git", "config", "user.name", "Example User"], cwd=repo, check=True)
+            subprocess.run(["git", "config", "user.email", "user@example"], cwd=repo, check=True)
+            (repo / "README.md").write_text("example\n")
+            subprocess.run(["git", "add", "README.md"], cwd=repo, check=True)
+            subprocess.run(
+                # content-guard: allow email
+                ["git", "commit", "-m", "fix: contact person@solomonneas.dev"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "brigade.guard.git_commits",
+                    "--range",
+                    "HEAD",
+                    "--policy",
+                    str(ROOT / "src" / "brigade" / "guard" / "policies" / "public-repo.json"),
+                    "--json",
+                ],
+                cwd=repo,
+                env={"PYTHONPATH": str(ROOT / "src")},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        self.assertEqual(proc.returncode, 1)
+        payload = json.loads(proc.stdout)
+        self.assertEqual(payload["commits"][0]["subject"], "fix: contact <PRIVATE_EMAIL>")
+
+    def test_git_commit_scan_handles_empty_repository(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
+
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "brigade.guard.git_commits",
+                    "--policy",
+                    str(ROOT / "src" / "brigade" / "guard" / "policies" / "public-repo.json"),
+                    "--json",
+                ],
+                cwd=repo,
+                env={"PYTHONPATH": str(ROOT / "src")},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        self.assertEqual(proc.returncode, 0)
+        payload = json.loads(proc.stdout)
+        self.assertEqual(payload["commits_scanned"], 0)
+        self.assertEqual(payload["commits_with_findings"], 0)
+
+    def test_publish_check_prepares_pr_body_advisory_by_default(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            self._init_repo(repo)
+            pr_body = repo / "pr-body.md"
+            # content-guard: allow all
+            pr_body.write_text("PR body mentions localhost:5204 and person@solomonneas.dev.\n")
+
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "brigade.guard.publish_check",
+                    "--pr-body",
+                    str(pr_body),
+                    "--json",
+                ],
+                cwd=repo,
+                env={"PYTHONPATH": str(ROOT / "src")},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(proc.returncode, 0)
+            payload = json.loads(proc.stdout)
+            publish_body_file = repo / payload["publish_body_file"]
+            self.assertTrue(payload["blocked"])
+            self.assertFalse(payload["would_fail"])
+            self.assertTrue(payload["ok"])
+            self.assertTrue(payload["checks"]["pr_body"]["advisory"])
+            self.assertEqual(publish_body_file.name, "pr-body.public.md")
+            self.assertIn("[redacted-service]", publish_body_file.read_text())
+            self.assertIn("<PRIVATE_EMAIL>", publish_body_file.read_text())
+
+    def test_publish_check_blocks_staged_file_findings(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            self._init_repo(repo)
+            leak = repo / "leak.md"
+            # content-guard: allow api-key-assignment
+            leak.write_text("Temporary token=abc123abc123abc123abc123abc123.\n")
+            subprocess.run(["git", "add", "leak.md"], cwd=repo, check=True)
+
+            proc = subprocess.run(
+                [sys.executable, "-m", "brigade.guard.publish_check", "--json"],
+                cwd=repo,
+                env={"PYTHONPATH": str(ROOT / "src")},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        self.assertEqual(proc.returncode, 1)
+        payload = json.loads(proc.stdout)
+        self.assertFalse(payload["ok"])
+        self.assertTrue(payload["blocked"])
+        self.assertTrue(payload["would_fail"])
+        self.assertTrue(payload["checks"]["staged_files"]["blocked"])
+        self.assertEqual(payload["checks"]["staged_files"]["files"][0]["path"], "leak.md")
+
+    def test_publish_check_advisory_only_reports_would_fail_but_exits_zero(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            self._init_repo(repo)
+            leak = repo / "leak.md"
+            # content-guard: allow api-key-assignment
+            leak.write_text("Temporary token=abc123abc123abc123abc123abc123.\n")
+            subprocess.run(["git", "add", "leak.md"], cwd=repo, check=True)
+
+            proc = subprocess.run(
+                [sys.executable, "-m", "brigade.guard.publish_check", "--json", "--advisory-only"],
+                cwd=repo,
+                env={"PYTHONPATH": str(ROOT / "src")},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        self.assertEqual(proc.returncode, 0)
+        payload = json.loads(proc.stdout)
+        self.assertTrue(payload["ok"])
+        self.assertTrue(payload["blocked"])
+        self.assertTrue(payload["would_fail"])
+        self.assertTrue(payload["advisory_only"])
+
+    def test_publish_check_blocks_commit_message_findings(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
+            subprocess.run(["git", "config", "user.name", "Example User"], cwd=repo, check=True)
+            subprocess.run(["git", "config", "user.email", "user@example"], cwd=repo, check=True)
+            (repo / "README.md").write_text("example\n")
+            subprocess.run(["git", "add", "README.md"], cwd=repo, check=True)
+            subprocess.run(
+                [
+                    "git",
+                    "commit",
+                    "-m",
+                    "feat: example",
+                    "-m",
+                    "Co-authored-by: Other User <other@example>",
+                ],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            proc = subprocess.run(
+                [sys.executable, "-m", "brigade.guard.publish_check", "--json"],
+                cwd=repo,
+                env={"PYTHONPATH": str(ROOT / "src")},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        self.assertEqual(proc.returncode, 1)
+        payload = json.loads(proc.stdout)
+        self.assertTrue(payload["would_fail"])
+        self.assertTrue(payload["checks"]["commit_messages"]["blocked"])
+        self.assertEqual(
+            payload["checks"]["commit_messages"]["commits"][0]["findings"][0]["rule_id"],
+            "coauthored-by-trailer",
+        )
+
+    def test_n8n_advisory_scans_text_payload(self) -> None:
+        proc = subprocess.run(
+            [sys.executable, "-m", "brigade.guard.n8n_advisory"],
+            cwd=ROOT,
+            env={"PYTHONPATH": str(ROOT / "src")},
+            input=json.dumps(
+                {
+                    "text": "Public post draft for release notes",
+                    "name": "social-draft",
+                    "policy": "public-content",
+                    "source": "n8n:unit-test",
+                }
+            ),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(proc.returncode, 0)
+        payload = json.loads(proc.stdout)
+        self.assertTrue(payload["ok"])
+        self.assertFalse(payload["blocked"])
+        self.assertEqual(payload["name"], "social-draft")
+        self.assertEqual(payload["source"], "n8n:unit-test")
+        self.assertIn("sanitized_text", payload)
+
+    def test_n8n_advisory_strict_blocks_findings(self) -> None:
+        proc = subprocess.run(
+            [sys.executable, "-m", "brigade.guard.n8n_advisory", "--strict"],
+            cwd=ROOT,
+            env={"PYTHONPATH": str(ROOT / "src")},
+            # content-guard: allow localhost-port
+            input=json.dumps({"text": "Draft references localhost:5204", "policy": "public-content"}),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(proc.returncode, 1)
+        payload = json.loads(proc.stdout)
+        self.assertFalse(payload["ok"])
+        self.assertTrue(payload["blocked"])
+        self.assertTrue(payload["advisory"])
+        self.assertIn("[redacted-service]", payload["sanitized_text"])
+
+    def test_n8n_advisory_rejects_missing_text(self) -> None:
+        proc = subprocess.run(
+            [sys.executable, "-m", "brigade.guard.n8n_advisory"],
+            cwd=ROOT,
+            env={"PYTHONPATH": str(ROOT / "src")},
+            input=json.dumps({"policy": "public-content"}),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(proc.returncode, 2)
+        payload = json.loads(proc.stdout)
+        self.assertFalse(payload["ok"])
+        self.assertIn("text", payload["error"])
+
+    def test_n8n_validation_pack_passes(self) -> None:
+        proc = subprocess.run(
+            [sys.executable, "-m", "brigade.guard.n8n_validate", "--json"],
+            cwd=ROOT,
+            env={"PYTHONPATH": str(ROOT / "src")},
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(proc.returncode, 0)
+        payload = json.loads(proc.stdout)
+        self.assertTrue(payload["ok"])
+        self.assertGreaterEqual(len(payload["fixtures"]), 5)
+
+    def test_n8n_validation_pack_reports_expectation_failure(self) -> None:
+        with TemporaryDirectory() as tmp:
+            fixture_dir = Path(tmp)
+            (fixture_dir / "mismatch.json").write_text(
+                json.dumps(
+                    {
+                        "request": {
+                            "text": "Clean publish draft",
+                            "name": "mismatch",
+                            "policy": "public-content",
+                        },
+                        "expected": {
+                            "blocked": True,
+                            "changed": True,
+                            "finding_rule_ids": ["localhost-port"],
+                        },
+                    }
+                )
+            )
+
+            proc = subprocess.run(
+                [sys.executable, "-m", "brigade.guard.n8n_validate", str(fixture_dir), "--json"],
+                cwd=ROOT,
+                env={"PYTHONPATH": str(ROOT / "src")},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        self.assertEqual(proc.returncode, 1)
+        payload = json.loads(proc.stdout)
+        self.assertFalse(payload["ok"])
+        self.assertIn("expected blocked", payload["fixtures"][0]["failures"][0])
+
+    def _init_repo(self, repo: Path) -> None:
+        subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
+        subprocess.run(["git", "config", "user.name", "Example User"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.email", "user@example"], cwd=repo, check=True)
+        (repo / "README.md").write_text("example\n")
+        subprocess.run(["git", "add", "README.md"], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-m", "feat: example"], cwd=repo, check=True, capture_output=True, text=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/guard/test_engine.py
+++ b/tests/guard/test_engine.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+from importlib import resources
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from brigade.guard.engine import scan_text
+from brigade.guard.policy import Policy, load_policy
+from brigade.guard.types import Rule, ScanOptions
+
+
+class EngineTests(unittest.TestCase):
+    def test_blocks_infrastructure_but_warns_pii_by_default(self) -> None:
+        # content-guard: allow all
+        result = scan_text("Reach me at alice@solomonneas.dev via localhost:5204")
+
+        actions = {(f.rule_id, f.action) for f in result.findings}
+        self.assertIn(("localhost-port", "block"), actions)
+        self.assertIn(("email", "warn"), actions)
+        self.assertTrue(result.blocked)
+
+    def test_redacts_policy_redact_actions(self) -> None:
+        policy = Policy(defaults={"infrastructure": "redact", "secret": "redact", "pii": "warn"})
+        # content-guard: allow private-ipv4
+        result = scan_text("Service is 192.168.1.25", policy=policy)
+
+        self.assertFalse(result.blocked)
+        self.assertEqual(result.redacted_text, "Service is [redacted-ip]")
+
+    def test_allow_comment_applies_to_next_line(self) -> None:
+        text = "<!-- content-guard: allow localhost-bare -->\nUse localhost as an example."
+        result = scan_text(text)
+
+        self.assertEqual(len(result.findings), 1)
+        self.assertEqual(result.findings[0].action, "allow")
+        self.assertFalse(result.blocked)
+
+    def test_frontmatter_is_skipped_by_default(self) -> None:
+        # content-guard: allow localhost-port
+        text = "---\nsource: localhost:5204\n---\nBody is clean.\n"
+        result = scan_text(text)
+
+        self.assertEqual(result.findings, [])
+
+    def test_can_skip_code_blocks(self) -> None:
+        # content-guard: allow localhost-port
+        text = "```\ncurl http://localhost:5204\n```\n"
+        result = scan_text(text, options=ScanOptions(scan_code_blocks=False))
+
+        self.assertEqual(result.findings, [])
+
+    def test_custom_rule(self) -> None:
+        policy = Policy(
+            custom_rules=[
+                Rule(
+                    id="project-codename",
+                    category="business",
+                    pattern=r"\bProject Nightshade\b",
+                    replacement="[redacted-project]",
+                )
+            ]
+        )
+        result = scan_text("Project Nightshade launches later.", policy=policy)
+
+        self.assertEqual(result.findings[0].rule_id, "project-codename")
+        self.assertEqual(result.findings[0].action, "warn")
+
+    def test_pr_draft_policy_blocks_pii(self) -> None:
+        policy_path = Path(__file__).resolve().parents[2] / "src" / "brigade" / "guard" / "policies" / "pr-draft.json"
+        # content-guard: allow all
+        result = scan_text("PR note with alice@solomonneas.dev and localhost:5204", policy=load_policy(policy_path))
+
+        actions = {(f.rule_id, f.action) for f in result.findings}
+        self.assertIn(("email", "block"), actions)
+        self.assertIn(("localhost-port", "block"), actions)
+        self.assertTrue(result.blocked)
+
+    def test_public_repo_policy_blocks_pii_and_secrets(self) -> None:
+        policy_path = (
+            Path(__file__).resolve().parents[2] / "src" / "brigade" / "guard" / "policies" / "public-repo.json"
+        )
+        # content-guard: allow all
+        result = scan_text(
+            "token = abcdefghijklmnopqrstuvwxyz123456 and alice@solomonneas.dev", policy=load_policy(policy_path)
+        )
+
+        actions = {(f.rule_id, f.action) for f in result.findings}
+        self.assertIn(("api-key-assignment", "block"), actions)
+        self.assertIn(("email", "block"), actions)
+        self.assertTrue(result.blocked)
+
+    def test_packaged_policy_resource_loads(self) -> None:
+        policy_path = resources.files("brigade.guard").joinpath("policies", "public-content.json")
+        policy = load_policy(policy_path)
+
+        self.assertEqual(policy.name, "public-content")
+
+    def test_secret_assignment_preserves_sentence_punctuation(self) -> None:
+        # content-guard: allow api-key-assignment
+        result = scan_text("Temporary token=abc123abc123abc123abc123abc123.")
+
+        # content-guard: allow api-key-assignment
+        self.assertEqual(result.findings[0].match, "token=abc123abc123abc123abc123abc123")
+        self.assertEqual(result.redacted_text, "Temporary [redacted-secret].")
+
+    def test_coauthor_trailer_blocks_and_removes_line(self) -> None:
+        # content-guard: allow email
+        # content-guard: allow example-email-reserved
+        result = scan_text("feat: change\n\nCo-authored-by: Example User <user@solomonneas.dev>\n")
+
+        self.assertEqual(result.findings[0].rule_id, "coauthored-by-trailer")
+        self.assertTrue(result.blocked)
+        self.assertEqual(result.redacted_text, "feat: change\n\n")
+
+    def test_policy_can_enable_opf_backend(self) -> None:
+        with TemporaryDirectory() as tmp:
+            opf_bin = Path(tmp) / "opf"
+            policy_path = Path(tmp) / "policy.json"
+            opf_bin.write_text(
+                "#!/usr/bin/env python3\n"
+                "import pathlib, sys\n"
+                "text = pathlib.Path(sys.argv[-1]).read_text()\n"
+                "print(text.replace('Alice Example', '<PRIVATE_PERSON>'), end='')\n"
+            )
+            opf_bin.chmod(0o755)
+            policy_path.write_text(
+                '{"backends":{"opf":{"enabled":true,"action":"redact","bin":"' + str(opf_bin) + '"}}}'
+            )
+
+            result = scan_text("Alice Example wrote the draft.", policy=load_policy(policy_path))
+
+        self.assertIn(("opf-pii", "redact"), {(f.rule_id, f.action) for f in result.findings})
+        self.assertEqual(result.redacted_text, "<PRIVATE_PERSON> wrote the draft.")
+
+
+class ApiKeyAssignmentFalsePositiveTests(unittest.TestCase):
+    """The api-key-assignment rule should not match code that reads a secret
+    from a safe source (env vars, config objects). Those are not leaks; the
+    actual secret is in the env, not in this file."""
+
+    def test_process_env_assignment_not_flagged(self) -> None:
+        # content-guard: allow all
+        result = scan_text("const apiKey = process.env.IMMICH_API_KEY;")
+
+        self.assertNotIn("api-key-assignment", {f.rule_id for f in result.findings})
+
+    def test_os_environ_assignment_not_flagged(self) -> None:
+        # content-guard: allow all
+        result = scan_text('API_KEY = os.environ["IMMICH_API_KEY"]')
+
+        self.assertNotIn("api-key-assignment", {f.rule_id for f in result.findings})
+
+    def test_os_getenv_assignment_not_flagged(self) -> None:
+        # content-guard: allow all
+        result = scan_text('token = os.getenv("GH_TOKEN")')
+
+        self.assertNotIn("api-key-assignment", {f.rule_id for f in result.findings})
+
+    def test_config_object_assignment_not_flagged(self) -> None:
+        # content-guard: allow all
+        result = scan_text("apiKey = config.apiKey || settings.fallback")
+
+        self.assertNotIn("api-key-assignment", {f.rule_id for f in result.findings})
+
+    def test_real_literal_token_still_flagged(self) -> None:
+        # content-guard: allow all
+        result = scan_text('token = "abcdef1234567890abcdef1234567890"')
+
+        self.assertIn("api-key-assignment", {f.rule_id for f in result.findings})
+
+    def test_real_unquoted_token_still_flagged(self) -> None:
+        # content-guard: allow all
+        result = scan_text("token = abcdef1234567890abcdef1234567890")
+
+        self.assertIn("api-key-assignment", {f.rule_id for f in result.findings})
+
+
+class FileScopedAllowTests(unittest.TestCase):
+    def test_allow_file_scope_exempts_entire_file(self) -> None:
+        text = (
+            "<!-- content-guard: allow private-ipv4 file -->\n"
+            "\n"
+            "Use 192.168.1.10 as the gateway.\n"
+            "Also 192.168.1.20 for the backup.\n"
+            "And one more: 192.168.1.30.\n"
+        )
+        result = scan_text(text)
+
+        for finding in result.findings:
+            if finding.rule_id == "private-ipv4":
+                self.assertEqual(finding.action, "allow")
+        self.assertFalse(result.blocked)
+
+    def test_allow_all_file_scope_exempts_all_rules_in_file(self) -> None:
+        text = "<!-- content-guard: allow all file -->\n\nEmail: alice@example.com\nService: 192.168.1.10:8080\n"
+        result = scan_text(text)
+
+        self.assertFalse(result.blocked)
+        for finding in result.findings:
+            self.assertEqual(finding.action, "allow")
+
+    def test_allow_file_scope_does_not_affect_other_rules(self) -> None:
+        text = (
+            "<!-- content-guard: allow private-ipv4 file -->\n"
+            "\n"
+            "Use 192.168.1.10 here.\n"
+            "But token=abcdef1234567890abcdef1234567890 is a real secret.\n"
+        )
+        result = scan_text(text)
+
+        rule_actions = {(f.rule_id, f.action) for f in result.findings}
+        self.assertIn(("private-ipv4", "allow"), rule_actions)
+        # api-key-assignment still blocks
+        self.assertTrue(any(f.action == "block" for f in result.findings))
+
+
+class ExamplePatternDowngradeTests(unittest.TestCase):
+    def test_example_phone_555_warns_not_blocks(self) -> None:
+        # content-guard: allow all
+        result = scan_text("Reach the test line at +1 (555) 123-4567 anytime.")
+
+        actions = {(f.rule_id, f.action) for f in result.findings}
+        self.assertIn(("example-phone-555", "warn"), actions)
+        # The general us-phone rule should NOT also fire (first match wins)
+        self.assertNotIn("us-phone", {f.rule_id for f in result.findings})
+
+    def test_example_phone_555_dashed(self) -> None:
+        # content-guard: allow all
+        result = scan_text("Call 555-123-4567 for the demo.")
+
+        rule_ids = {f.rule_id for f in result.findings}
+        self.assertIn("example-phone-555", rule_ids)
+
+    def test_real_area_code_phone_still_matches_us_phone(self) -> None:
+        # content-guard: allow all
+        result = scan_text("Call 415-555-9999 for service.")
+
+        rule_ids = {f.rule_id for f in result.findings}
+        # 415 area code is real, so us-phone fires, NOT example-phone-555
+        # (the 555 is just the prefix here, not the area code)
+        self.assertIn("us-phone", rule_ids)
+
+    def test_example_email_reserved_warns_not_blocks(self) -> None:
+        # content-guard: allow all
+        result = scan_text("Contact alice@example.com for details.")
+
+        actions = {(f.rule_id, f.action) for f in result.findings}
+        self.assertIn(("example-email-reserved", "warn"), actions)
+        self.assertNotIn("email", {f.rule_id for f in result.findings})
+
+    def test_example_email_covers_example_org_and_net(self) -> None:
+        # content-guard: allow all
+        text = "Try bob@example.org or carol@example.net for testing."
+        result = scan_text(text)
+
+        rule_ids = {f.rule_id for f in result.findings}
+        self.assertEqual(rule_ids, {"example-email-reserved"})
+
+    def test_example_email_covers_test_tld(self) -> None:
+        # RFC 2606 reserves .test for non-real use.
+        # content-guard: allow all
+        result = scan_text("admin@admin.test is the default fixture user.")
+
+        rule_ids = {f.rule_id for f in result.findings}
+        self.assertEqual(rule_ids, {"example-email-reserved"})
+
+    def test_example_email_covers_local_tld(self) -> None:
+        # mDNS / RFC 6762 reserves .local for link-local hosts (not real domains).
+        # content-guard: allow all
+        text = "Default MISP login: admin@misp.local and admin@thehive.local"
+        result = scan_text(text)
+
+        rule_ids = {f.rule_id for f in result.findings}
+        self.assertEqual(rule_ids, {"example-email-reserved"})
+
+    def test_example_email_covers_invalid_tld(self) -> None:
+        # RFC 2606 reserves .invalid.
+        # content-guard: allow all
+        result = scan_text("Use noreply@nowhere.invalid for unverified entries.")
+
+        rule_ids = {f.rule_id for f in result.findings}
+        self.assertEqual(rule_ids, {"example-email-reserved"})
+
+    def test_real_email_still_blocks(self) -> None:
+        policy = Policy(defaults={"pii": "block"})
+        # content-guard: allow all
+        result = scan_text("Contact alice@solomonneas.dev directly.", policy=policy)
+
+        rule_ids = {f.rule_id for f in result.findings}
+        self.assertIn("email", rule_ids)
+        self.assertNotIn("example-email-reserved", rule_ids)
+
+    def test_example_rules_stay_warn_under_pii_block_policy(self) -> None:
+        # Even when the policy aggressively blocks the PII category, the
+        # example-* rules should still WARN (not BLOCK). This is the whole
+        # point of the rule-default-override mechanism.
+        policy = Policy(defaults={"pii": "block"})
+        # content-guard: allow all
+        result = scan_text("Test mail: bob@example.com. Test phone: 555-867-5309.", policy=policy)
+
+        actions = {(f.rule_id, f.action) for f in result.findings}
+        self.assertIn(("example-email-reserved", "warn"), actions)
+        self.assertIn(("example-phone-555", "warn"), actions)
+        self.assertFalse(result.blocked)
+
+    def test_example_rule_action_can_still_be_overridden_in_policy_rules(self) -> None:
+        # Users who want example-* rules to actually block can still opt in.
+        policy = Policy(rules={"example-email-reserved": "block"})
+        # content-guard: allow all
+        result = scan_text("alice@example.com", policy=policy)
+
+        actions = {(f.rule_id, f.action) for f in result.findings}
+        self.assertIn(("example-email-reserved", "block"), actions)
+        self.assertTrue(result.blocked)
+
+
+class KnownHostsTests(unittest.TestCase):
+    def test_known_host_ip_blocks_in_warn_policy(self) -> None:
+        # Policy WARNS on private-ipv4 (lenient) but a known-hosts entry should
+        # still upgrade matches to BLOCK.
+        with TemporaryDirectory() as tmp:
+            policy_path = Path(tmp) / "policy.json"
+            policy_path.write_text(
+                '{"rules": {"private-ipv4": "warn"},"known_hosts": ["192.168.99.56", "192.168.99.91"]}'
+            )
+            # content-guard: allow all
+            result = scan_text("Real host is 192.168.99.56 here.", policy=load_policy(policy_path))
+
+        actions = {(f.rule_id, f.action) for f in result.findings}
+        self.assertIn(("known-host", "block"), actions)
+        # The private-ipv4 rule should NOT also fire (known-host claimed it first)
+        self.assertNotIn("private-ipv4", {f.rule_id for f in result.findings})
+
+    def test_non_known_host_ip_falls_back_to_normal_rule(self) -> None:
+        with TemporaryDirectory() as tmp:
+            policy_path = Path(tmp) / "policy.json"
+            policy_path.write_text('{"rules": {"private-ipv4": "warn"},"known_hosts": ["192.168.99.56"]}')
+            # content-guard: allow all
+            result = scan_text("Some other IP is 10.0.0.5 in the docs.", policy=load_policy(policy_path))
+
+        actions = {(f.rule_id, f.action) for f in result.findings}
+        self.assertIn(("private-ipv4", "warn"), actions)
+        self.assertNotIn("known-host", {f.rule_id for f in result.findings})
+
+    def test_known_hosts_hostname_match(self) -> None:
+        with TemporaryDirectory() as tmp:
+            policy_path = Path(tmp) / "policy.json"
+            policy_path.write_text('{"known_hosts": ["host-a.local", "host-c.local"]}')
+            # content-guard: allow all
+            result = scan_text("SSH into host-a.local to debug.", policy=load_policy(policy_path))
+
+        rule_ids = {f.rule_id for f in result.findings}
+        self.assertIn("known-host", rule_ids)
+
+    def test_known_hosts_does_not_match_partial_ip(self) -> None:
+        # 192.168.99.56 should not match if the text has 192.168.99.560 or similar
+        with TemporaryDirectory() as tmp:
+            policy_path = Path(tmp) / "policy.json"
+            policy_path.write_text('{"known_hosts": ["192.168.99.56"]}')
+            # content-guard: allow all
+            result = scan_text("Version is 1.92.168.4.561 actually.", policy=load_policy(policy_path))
+
+        self.assertNotIn("known-host", {f.rule_id for f in result.findings})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/guard/test_rules.py
+++ b/tests/guard/test_rules.py
@@ -1,0 +1,246 @@
+# content-guard: allow jwt-token file
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from brigade.guard.engine import scan_text
+from brigade.guard.policy import Policy, load_policy
+
+
+class LoopbackSplitTests(unittest.TestCase):
+    def test_loopback_address_matches_loopback_rule_only(self) -> None:
+        # content-guard: allow all
+        result = scan_text("Service is 127.0.0.1 today.")
+        rule_ids = {f.rule_id for f in result.findings}
+
+        self.assertIn("loopback-ipv4", rule_ids)
+        self.assertNotIn("private-ipv4", rule_ids)
+
+    def test_rfc1918_address_matches_private_rule_only(self) -> None:
+        # content-guard: allow all
+        result = scan_text("Service is 192.168.1.10 today.")
+        rule_ids = {f.rule_id for f in result.findings}
+
+        self.assertIn("private-ipv4", rule_ids)
+        self.assertNotIn("loopback-ipv4", rule_ids)
+
+    def test_loopback_uses_redacted_ip_replacement(self) -> None:
+        policy = Policy(defaults={"infrastructure": "redact"})
+        # content-guard: allow all
+        result = scan_text("Bind to 127.0.0.1 here.", policy=policy)
+
+        self.assertEqual(result.redacted_text, "Bind to [redacted-ip] here.")
+
+
+class UsPhoneTighteningTests(unittest.TestCase):
+    def test_bare_ten_digit_number_is_not_a_phone(self) -> None:
+        # content-guard: allow all
+        result = scan_text("Timestamp 1710672000 was logged.")
+        rule_ids = {f.rule_id for f in result.findings}
+
+        self.assertNotIn("us-phone", rule_ids)
+
+    def test_parentheses_area_code_matches(self) -> None:
+        # content-guard: allow all
+        result = scan_text("Call (415) 555-1234 today.")
+        rule_ids = {f.rule_id for f in result.findings}
+
+        self.assertIn("us-phone", rule_ids)
+
+    def test_dashed_phone_matches(self) -> None:
+        # content-guard: allow all
+        result = scan_text("Reach 415-555-1234 anytime.")
+        rule_ids = {f.rule_id for f in result.findings}
+
+        self.assertIn("us-phone", rule_ids)
+
+    def test_plus_one_country_code_matches(self) -> None:
+        # content-guard: allow all
+        result = scan_text("Dial +1 415 555 1234 from abroad.")
+        rule_ids = {f.rule_id for f in result.findings}
+
+        self.assertIn("us-phone", rule_ids)
+
+    def test_bare_ten_digit_timestamp_is_not_a_phone(self) -> None:
+        # content-guard: allow all
+        result = scan_text("Recorded at 1710672000 in the log.")
+        rule_ids = {f.rule_id for f in result.findings}
+
+        self.assertNotIn("us-phone", rule_ids)
+
+    def test_phone_cue_word_promotes_bare_digits(self) -> None:
+        # content-guard: allow all
+        result = scan_text("phone: 4155551234 (primary)")
+        rule_ids = {f.rule_id for f in result.findings}
+
+        self.assertIn("us-phone", rule_ids)
+
+    def test_cue_word_substring_does_not_promote_digits(self) -> None:
+        # content-guard: allow all
+        result = scan_text("recall: 4155551234 was the order id.")
+        rule_ids = {f.rule_id for f in result.findings}
+
+        self.assertNotIn("us-phone", rule_ids)
+
+    def test_phone_shape_inside_alphanumeric_token_does_not_match(self) -> None:
+        # content-guard: allow all
+        result = scan_text("transaction id x415-555-1234 logged.")
+        rule_ids = {f.rule_id for f in result.findings}
+
+        self.assertNotIn("us-phone", rule_ids)
+
+
+class PackagedPolicyParityTests(unittest.TestCase):
+    def test_packaged_public_repo_warns_docs_friendly_rules(self) -> None:
+        from importlib import resources
+
+        from brigade.guard.policy import load_policy
+
+        policy_path = resources.files("brigade.guard").joinpath("policies", "public-repo.json")
+        policy = load_policy(policy_path)
+        # content-guard: allow all
+        result = scan_text("Bind to 127.0.0.1 and use localhost:11434 with port 18789.", policy=policy)
+
+        actions = {(f.rule_id, f.action) for f in result.findings}
+        self.assertIn(("loopback-ipv4", "warn"), actions)
+        self.assertIn(("localhost-port", "warn"), actions)
+        self.assertIn(("port-reference", "warn"), actions)
+        self.assertFalse(result.blocked)
+
+    def test_git_scan_default_policy_warns_docs_friendly_rules(self) -> None:
+        from brigade.guard.git_scan import _default_repo_policy
+
+        policy = _default_repo_policy()
+        # content-guard: allow all
+        result = scan_text("Bind to 127.0.0.1 and use localhost:11434 with port 18789.", policy=policy)
+
+        actions = {(f.rule_id, f.action) for f in result.findings}
+        self.assertIn(("loopback-ipv4", "warn"), actions)
+        self.assertIn(("localhost-port", "warn"), actions)
+        self.assertIn(("port-reference", "warn"), actions)
+        self.assertFalse(result.blocked)
+
+
+class PublicRepoPolicyTests(unittest.TestCase):
+    def test_docs_friendly_findings_warn_only_rfc1918_blocks(self) -> None:
+        policy_path = (
+            Path(__file__).resolve().parents[2] / "src" / "brigade" / "guard" / "policies" / "public-repo.json"
+        )
+        text = (
+            "Bind to 127.0.0.1 for local dev.\n"
+            "Use localhost:11434 for the model.\n"
+            "Open port 18789 on the host.\n"  # content-guard: allow private-ipv4
+            "But 192.168.1.10 is the actual office subnet.\n"
+        )
+        # content-guard: allow all
+        result = scan_text(text, policy=load_policy(policy_path))
+
+        actions = {(f.rule_id, f.action) for f in result.findings}
+
+        self.assertIn(("loopback-ipv4", "warn"), actions)
+        self.assertIn(("localhost-port", "warn"), actions)
+        self.assertIn(("port-reference", "warn"), actions)
+        self.assertIn(("private-ipv4", "block"), actions)
+
+        warn_count = sum(1 for f in result.findings if f.action == "warn")
+        block_count = sum(1 for f in result.findings if f.action == "block")
+        self.assertEqual(warn_count, 3)
+        self.assertEqual(block_count, 1)
+
+    def test_localhost_bare_warns_in_public_repo_policy(self) -> None:
+        policy_path = (
+            Path(__file__).resolve().parents[2] / "src" / "brigade" / "guard" / "policies" / "public-repo.json"
+        )
+        # content-guard: allow all
+        result = scan_text("Visit localhost in your browser.", policy=load_policy(policy_path))
+
+        actions = {(f.rule_id, f.action) for f in result.findings}
+        self.assertIn(("localhost-bare", "warn"), actions)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class EmailSshRemoteTests(unittest.TestCase):
+    def test_ssh_remote_url_is_not_an_email(self) -> None:
+        # content-guard: allow all
+        result = scan_text("Push to git@github.com:owner/repo.git when ready.")
+        rule_ids = {f.rule_id for f in result.findings}
+
+        self.assertNotIn("email", rule_ids)
+
+    def test_scp_style_path_is_not_an_email(self) -> None:
+        # content-guard: allow all
+        result = scan_text("Copy with scp backup@host.example.com:/srv/data .")
+        rule_ids = {f.rule_id for f in result.findings}
+
+        self.assertNotIn("email", rule_ids)
+
+    def test_email_followed_by_colon_and_space_still_matches(self) -> None:
+        # content-guard: allow all
+        result = scan_text("Contact alice@gmail.com: she has the keys.")
+        rule_ids = {f.rule_id for f in result.findings}
+
+        self.assertIn("email", rule_ids)
+
+
+class ApiKeyAssignmentRhsTests(unittest.TestCase):
+    def test_dotted_identifier_chain_is_not_a_secret(self) -> None:
+        # content-guard: allow all
+        result = scan_text("const apiKey = apiKeys.anthropicApiKey;")
+        self.assertNotIn("api-key-assignment", {f.rule_id for f in result.findings})
+
+    def test_camelcase_identifier_is_not_a_secret(self) -> None:
+        # content-guard: allow all
+        result = scan_text("token: daemonConfigPrimaryToken,")
+        self.assertNotIn("api-key-assignment", {f.rule_id for f in result.findings})
+
+    def test_member_env_access_is_not_a_secret(self) -> None:
+        # content-guard: allow all
+        result = scan_text("apiKey: ctx.env.FIRECRAWL_API_KEY,")
+        self.assertNotIn("api-key-assignment", {f.rule_id for f in result.findings})
+
+    def test_unquoted_literal_with_digits_still_matches(self) -> None:
+        # content-guard: allow all
+        result = scan_text("Temporary token=abc123abc123abc123abc123abc123.")
+        self.assertIn("api-key-assignment", {f.rule_id for f in result.findings})
+
+    def test_quoted_literal_still_matches(self) -> None:
+        # content-guard: allow all
+        result = scan_text('api_key = "sk-fixture0123456789abcdefgh"')
+        self.assertIn("api-key-assignment", {f.rule_id for f in result.findings})
+
+    def test_quoted_hex_still_matches(self) -> None:
+        # content-guard: allow all
+        result = scan_text('secret: "0123456789abcdef0123456789abcdef"')
+        self.assertIn("api-key-assignment", {f.rule_id for f in result.findings})
+
+
+class ApiKeyAssignmentDigitChainTests(unittest.TestCase):
+    def test_versioned_property_chain_is_not_a_secret(self) -> None:
+        # content-guard: allow all
+        result = scan_text("const apiKey = apiKeys.v2.anthropicApiKey;")
+        self.assertNotIn("api-key-assignment", {f.rule_id for f in result.findings})
+
+    def test_env_member_with_digit_is_not_a_secret(self) -> None:
+        # content-guard: allow all
+        result = scan_text("token: ctx.env.S3_SECRET_ACCESS_KEY,")
+        self.assertNotIn("api-key-assignment", {f.rule_id for f in result.findings})
+
+
+class JwtTokenRuleTests(unittest.TestCase):
+    def test_bare_jwt_assignment_is_caught(self) -> None:
+        # content-guard: allow all
+        result = scan_text(
+            "token = eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N1XgL0n3I9PlFUP0THsR8U"
+        )
+        self.assertIn("jwt-token", {f.rule_id for f in result.findings})
+
+    def test_jwt_outside_assignment_is_caught(self) -> None:
+        # content-guard: allow all
+        result = scan_text(
+            "Use eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N1XgL0n3I9PlFUP0THsR8U here."
+        )
+        self.assertIn("jwt-token", {f.rule_id for f in result.findings})

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -53,3 +53,66 @@ def test_subcommand_help_still_lists_subcommands(capsys):
     out = capsys.readouterr().out
     assert "brief" in out
     assert "tasks" in out
+
+
+def test_guard_command_delegates_to_embedded_guard(monkeypatch):
+    calls = []
+
+    def fake_main(argv=None):
+        calls.append(argv)
+        return 17
+
+    monkeypatch.setattr("brigade.guard.cli.main", fake_main)
+
+    assert cli.main(["guard", "scan", "-"]) == 17
+    assert calls == [["scan", "-"]]
+
+
+def test_guard_help_prints_group_help_without_delegating(monkeypatch, capsys):
+    calls = []
+
+    def fake_main(argv=None):
+        calls.append(argv)
+        return 0
+
+    monkeypatch.setattr("brigade.guard.cli.main", fake_main)
+
+    assert cli.main(["guard", "--help"]) == 0
+    assert calls == []
+    out = capsys.readouterr().out
+    for name in ("scan", "audit", "git", "commits", "publish-check", "pr", "n8n-validate"):
+        assert name in out
+
+
+def test_guard_no_args_prints_group_help(capsys):
+    assert cli.main(["guard"]) == 0
+    out = capsys.readouterr().out
+    assert "usage: brigade guard" in out
+    assert "git" in out
+    assert "scan" in out
+
+
+def test_guard_routes_git_to_git_scan(monkeypatch):
+    calls = []
+
+    def fake_main(argv=None):
+        calls.append(argv)
+        return 5
+
+    monkeypatch.setattr("brigade.guard.git_scan.main", fake_main)
+
+    assert cli.main(["guard", "git", "--all-tracked", "--policy", "p.json"]) == 5
+    assert calls == [["--all-tracked", "--policy", "p.json"]]
+
+
+def test_guard_routes_publish_check(monkeypatch):
+    calls = []
+
+    def fake_main(argv=None):
+        calls.append(argv)
+        return 0
+
+    monkeypatch.setattr("brigade.guard.publish_check.main", fake_main)
+
+    assert cli.main(["guard", "publish-check", "--target", "."]) == 0
+    assert calls == [["--target", "."]]

--- a/tests/test_operator_cmd.py
+++ b/tests/test_operator_cmd.py
@@ -1542,10 +1542,13 @@ def test_local_operator_doctor_does_not_block_on_inactive_content_guard_hook(tmp
     capsys.readouterr()
 
     def fake_hook_status(target, policy="public-repo"):
+        # A hook file is wired into the repo but not enabled. The embedded
+        # guard makes "available" true on every install, so only explicit
+        # hook signals count as configured.
         return {
             "available": True,
             "hooks_path": None,
-            "configured_pre_push_hook_exists": False,
+            "configured_pre_push_hook_exists": True,
             "git_pre_push_hook_exists": False,
             "pre_push_hook_enabled": False,
             "pre_push_hook_mode": "not-enabled",

--- a/tests/test_scrub.py
+++ b/tests/test_scrub.py
@@ -46,6 +46,51 @@ def test_resolve_named_policy_falls_back_to_packaged_policy(tmp_path: Path):
     assert "templates/policies" in p.as_posix()
 
 
+def test_default_scanner_uses_embedded_guard(monkeypatch):
+    monkeypatch.delenv("CONTENT_GUARD_DIR", raising=False)
+    assert scrub_mod.scanner_module() == "brigade.guard"
+    assert scrub_mod.scanner_dir().is_dir()
+    assert scrub_mod.scanner_dir().name == "guard"
+
+
+def test_run_scan_invokes_embedded_guard_by_default(tmp_path: Path, monkeypatch):
+    target = tmp_path / "repo"
+    target.mkdir()
+    policy_file = tmp_path / "policy.json"
+    policy_file.write_text("{}\n")
+    monkeypatch.delenv("CONTENT_GUARD_DIR", raising=False)
+    monkeypatch.setattr(scrub_mod, "policy_path", lambda repo, policy: policy_file)
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append((argv, kwargs))
+
+        class Result:
+            returncode = 0
+            stdout = "Clean. 1 file(s) checked.\n"
+            stderr = ""
+
+        return Result()
+
+    monkeypatch.setattr(scrub_mod.subprocess, "run", fake_run)
+
+    result = scrub_mod.run_scan(target, policy="public-repo")
+
+    assert result["exit_code"] == 0
+    argv, kwargs = calls[0]
+    assert argv[:3] == [scrub_mod.sys.executable, "-m", "brigade.guard"]
+    assert "PYTHONPATH" not in kwargs["env"] or "content-guard" not in kwargs["env"]["PYTHONPATH"]
+
+
+def test_content_guard_dir_keeps_external_scanner_behavior(tmp_path: Path, monkeypatch):
+    scanner = tmp_path / "content-guard"
+    (scanner / "src").mkdir(parents=True)
+    monkeypatch.setenv("CONTENT_GUARD_DIR", str(scanner))
+
+    assert scrub_mod.scanner_dir() == scanner
+    assert scrub_mod.scanner_module() == "content_guard"
+
+
 def test_hook_status_detects_configured_global_pre_push(tmp_path: Path, monkeypatch):
     target = tmp_path / "repo"
     target.mkdir()


### PR DESCRIPTION
## What

Vendors the content-guard scanner into Brigade as `brigade.guard` and exposes it as a `brigade guard` command group. `brigade scrub` now works on a fresh pip install with no external checkout.

- `src/brigade/guard/`: the content_guard package vendored from escoffier-labs/content-guard v0.3.0 (commit 4b0c9c0), policies and n8n fixtures shipped as package data.
- `brigade guard <command>`: scan, redact, diff, audit, baseline, and allow pass through to the embedded CLI. git, commits, publish-check, pr, pr-prepare, n8n-advisory, and n8n-validate route to their entry modules. Bare `brigade guard` and `--help` print group help.
- `brigade scrub` defaults to the embedded scanner. Setting `CONTENT_GUARD_DIR` keeps the previous external checkout behavior, including the PYTHONPATH subprocess invocation, so existing pre-push hooks keep working unchanged.
- Health checks: the scanner now always counts as available when embedded. `content_guard_missing` only fires when `CONTENT_GUARD_DIR` points at a missing checkout.
- Full content-guard test suite ported under `tests/guard/` (123 tests, name parity verified against the originals file by file).

## Verification

`./scripts/verify` via `brigade work verify run`: ruff check, ruff format check, version sync, and pytest all green. 1679 passed, 1 skipped. Receipt at `.brigade/work/verify-runs/20260708-183743-work-verify-a3b8f3/`.

Smoke: `brigade guard` prints group help and exits 0, `brigade guard git --help` reaches the git_scan parser, embedded scan blocks an RFC 1918 address with the public-repo policy, and `brigade scrub --dry-run --json` exits 0 with `CONTENT_GUARD_DIR` unset.

## Out of scope

The fleet hook sweep (43 repos plus the global hook) and content-guard repo deprecation land after this ships in a release, since hooks call the installed brigade.