### PR TITLE
feat(run): mechanical context evals comparing brief files to graph delta

### DIFF
--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -1002,6 +1002,17 @@ GraphTrail raw diff counts are preserved under `raw_counts`. Brigade also comput
 
 Known blind spots remain GraphTrail blind spots: unsupported languages, parse failures, dynamic dispatch, generated code, import-time side effects, reflection, and runtime wiring can be missed or approximated. A clean delta means the captured static graph did not report meaningful churn, not that the behavior is unchanged.
 
+### Context eval metric
+
+When a non-read-only aboyeur run has both a pre-run code graph brief and a successful GraphTrail delta sidecar with changed file paths, Brigade records `context_eval` in the run artifacts and synthesis ground truth.
+The metric is set arithmetic over repo-relative file paths: it compares the files named by the pre-run context pack with the files the run structurally touched according to the GraphTrail delta.
+For example, `brief hit rate 0.50 (2/4 files, 2 missed)` means two of four structurally touched files were named in the brief, and two touched files were not.
+
+This is not a quality score.
+It does not say whether the context was useful, sufficient, or correct, only whether the pre-run context pack named the structurally changed files.
+Brief parsing is heuristic, and GraphTrail deltas only see structural code changes.
+Docs-only runs and runs without structural graph changes produce no context eval.
+
 Use `--handoff` to bridge a completed run back into the memory system.
 
 Handoff behavior:

--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -16,6 +16,7 @@ from uuid import uuid4
 
 from . import agents
 from . import codex_appserver
+from . import context_eval
 from . import graphtrail_delta
 from . import localio
 from . import proc, runguard
@@ -1234,7 +1235,37 @@ def _ground_truth_facts(ground_truth: dict[str, object] | None) -> str:
         if len(summary) > 240:
             summary = summary[:237] + "..."
         lines.append(f"- code_graph_delta: {summary}")
+    context_eval_payload = ground_truth.get("context_eval")
+    if isinstance(context_eval_payload, dict):
+        summary = _context_eval_fact(context_eval_payload)
+        if summary:
+            lines.append(f"- context eval: {summary}")
     return "\n".join(lines)
+
+
+def _context_eval_fact(payload: dict[str, object]) -> str:
+    try:
+        counts = payload.get("counts")
+        if not isinstance(counts, dict):
+            return ""
+        rate = payload.get("brief_hit_rate")
+        hits = counts.get("hits")
+        delta_files = counts.get("delta_files")
+        missed = counts.get("missed")
+        if (
+            isinstance(rate, bool)
+            or not isinstance(rate, (int, float))
+            or isinstance(hits, bool)
+            or not isinstance(hits, int)
+            or isinstance(delta_files, bool)
+            or not isinstance(delta_files, int)
+            or isinstance(missed, bool)
+            or not isinstance(missed, int)
+        ):
+            return ""
+        return f"brief hit rate {rate:.2f} ({hits}/{delta_files} files, {missed} missed)"
+    except BaseException:
+        return ""
 
 
 def _with_patch_ref(ground_truth: object, patch_ref: str) -> object:
@@ -1243,6 +1274,27 @@ def _with_patch_ref(ground_truth: object, patch_ref: str) -> object:
     updated = dict(ground_truth)
     updated["patch_ref"] = patch_ref
     return updated
+
+
+def _context_eval_for_run(
+    code_graph: CodeGraphBrief | None,
+    code_graph_delta: dict[str, object] | None,
+) -> dict[str, object] | None:
+    try:
+        if code_graph is None or not code_graph.attached or not code_graph.text:
+            return None
+        if not isinstance(code_graph_delta, dict) or code_graph_delta.get("ok") is not True:
+            return None
+        sidecar_path = code_graph_delta.get("sidecar_path")
+        if not isinstance(sidecar_path, str) or not sidecar_path:
+            return None
+        delta_files = context_eval.extract_delta_files(sidecar_path)
+        if not delta_files:
+            return None
+        brief_files = context_eval.extract_brief_files(code_graph.text)
+        return context_eval.evaluate(brief_files, delta_files)
+    except BaseException:
+        return None
 
 
 def set_artifact_patch_ref(output_dir: Path, patch_ref: str = "changes.patch") -> None:
@@ -1296,6 +1348,7 @@ def _run_payload(
     codex_transport: str | None = None,
     control_socket: Path | None = None,
     code_graph_delta: dict[str, object] | None = None,
+    context_eval_payload: dict[str, object] | None = None,
 ) -> dict[str, object]:
     payload: dict[str, object] = {
         "task": task,
@@ -1324,6 +1377,8 @@ def _run_payload(
         payload["git"] = git
     if code_graph_delta is not None:
         payload["code_graph_delta"] = code_graph_delta
+    if context_eval_payload is not None:
+        payload["context_eval"] = context_eval_payload
     if finished_at is not None:
         payload["finished_at"] = _utc_iso(finished_at)
         payload["duration_seconds"] = max(0.0, round((finished_at - started_at).total_seconds(), 3))
@@ -1549,9 +1604,12 @@ def run(
             appserver.close()
     if output_dir is not None and code_graph_delta_before is not None and cwd is not None:
         code_graph_delta = graphtrail_delta.capture_after_and_diff(cwd, output_dir, code_graph_delta_before)
+    context_eval_payload = _context_eval_for_run(code_graph, code_graph_delta)
     ground_truth = build_ground_truth(cwd, started_at)
     if code_graph_delta is not None:
         ground_truth["code_graph_delta"] = code_graph_delta
+    if context_eval_payload is not None:
+        ground_truth["context_eval"] = context_eval_payload
     if output_dir is not None:
         _write_json(
             output_dir / "worker-results.json",
@@ -1607,6 +1665,7 @@ def run(
                     brief_set=brief_set,
                     codex_transport=transport_for_payload,
                     code_graph_delta=code_graph_delta,
+                    context_eval_payload=context_eval_payload,
                 ),
             )
         print(f"error: orchestrator failed during synthesis: {final.detail}", file=sys.stderr)
@@ -1632,6 +1691,7 @@ def run(
                 codex_transport=transport_for_payload,
                 control_socket=control_socket,
                 code_graph_delta=code_graph_delta,
+                context_eval_payload=context_eval_payload,
             ),
         )
     if handoff_inbox is not None:
@@ -1669,6 +1729,7 @@ def run(
                         codex_transport=transport_for_payload,
                         control_socket=control_socket,
                         code_graph_delta=code_graph_delta,
+                        context_eval_payload=context_eval_payload,
                     ),
                 )
             print(f"error: {detail}", file=sys.stderr)
@@ -1696,6 +1757,7 @@ def run(
                     codex_transport=transport_for_payload,
                     control_socket=control_socket,
                     code_graph_delta=code_graph_delta,
+                    context_eval_payload=context_eval_payload,
                 ),
             )
     print(final.text)

--- a/src/brigade/context_eval.py
+++ b/src/brigade/context_eval.py
@@ -1,0 +1,133 @@
+"""Fail-open context coverage helpers for code graph briefs and deltas."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+_PATH_TOKEN_RE = re.compile(
+    r"(?<![A-Za-z0-9_./-])([A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*\.[A-Za-z0-9]+(?::\d+(?::\d+)?)?)"
+)
+_BACKTICK_RE = re.compile(r"`([^`\n]+)`")
+_CODE_EXTENSIONS = {
+    ".bash",
+    ".c",
+    ".cc",
+    ".cpp",
+    ".cs",
+    ".fish",
+    ".go",
+    ".h",
+    ".hpp",
+    ".java",
+    ".js",
+    ".json",
+    ".jsx",
+    ".kt",
+    ".kts",
+    ".php",
+    ".py",
+    ".pyi",
+    ".rb",
+    ".rs",
+    ".scala",
+    ".sh",
+    ".sql",
+    ".swift",
+    ".toml",
+    ".ts",
+    ".tsx",
+    ".yaml",
+    ".yml",
+    ".zsh",
+}
+
+
+def extract_brief_files(brief_text: str) -> list[str]:
+    """Extract conservative repo-relative code paths from GraphTrail markdown."""
+    try:
+        if not isinstance(brief_text, str) or not brief_text:
+            return []
+        files: set[str] = set()
+        for match in _BACKTICK_RE.finditer(brief_text):
+            candidate = _clean_path(match.group(1))
+            if candidate is not None:
+                files.add(candidate)
+        for match in _PATH_TOKEN_RE.finditer(brief_text):
+            candidate = _clean_path(match.group(1))
+            if candidate is not None:
+                files.add(candidate)
+        return sorted(files)
+    except BaseException:
+        return []
+
+
+def extract_delta_files(delta_sidecar_path_or_dict: str | Path | dict[str, Any]) -> list[str]:
+    """Extract changed file paths from a GraphTrail delta sidecar or payload."""
+    try:
+        if isinstance(delta_sidecar_path_or_dict, dict):
+            payload = delta_sidecar_path_or_dict
+        else:
+            path = Path(delta_sidecar_path_or_dict)
+            payload = json.loads(path.read_text())
+        if not isinstance(payload, dict):
+            return []
+
+        files: set[str] = set()
+        for key in ("added_nodes", "removed_nodes", "changed_nodes"):
+            nodes = payload.get(key)
+            if not isinstance(nodes, list):
+                continue
+            for node in nodes:
+                if not isinstance(node, dict):
+                    continue
+                candidate = _clean_path(node.get("file_path"))
+                if candidate is not None:
+                    files.add(candidate)
+        return sorted(files)
+    except BaseException:
+        return []
+
+
+def evaluate(brief_files: list[str], delta_files: list[str]) -> dict[str, object]:
+    """Compare brief coverage against delta files."""
+    brief = {_cleaned for item in brief_files if (_cleaned := _clean_path(item)) is not None}
+    delta = {_cleaned for item in delta_files if (_cleaned := _clean_path(item)) is not None}
+    hits = sorted(brief & delta)
+    missed = sorted(delta - brief)
+    return {
+        "counts": {
+            "brief_files": len(brief),
+            "delta_files": len(delta),
+            "hits": len(hits),
+            "missed": len(missed),
+        },
+        "hits": hits,
+        "missed": missed,
+        "brief_hit_rate": round(len(hits) / len(delta), 3) if delta else None,
+    }
+
+
+def _clean_path(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    raw = value.strip().strip("`'\"()[]{}<>,.;")
+    if not raw or "://" in raw or raw.startswith(("/", "~")):
+        return None
+    raw = re.sub(r":\d+(?::\d+)?$", "", raw)
+    if "\\" in raw:
+        return None
+    if any(char.isspace() for char in raw):
+        return None
+    path = Path(raw)
+    if path.is_absolute():
+        return None
+    parts = path.parts
+    if not parts or any(part in ("", ".", "..") for part in parts):
+        return None
+    suffix = Path(parts[-1]).suffix.lower()
+    if suffix not in _CODE_EXTENSIONS:
+        return None
+    return "/".join(parts)

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -3,6 +3,7 @@ import subprocess
 
 from brigade import aboyeur
 from brigade import agents
+from brigade import context_eval
 from brigade import proc
 from brigade.roster import Agent, Roster
 from tests.work_cmd_test_helpers import _init_git_repo
@@ -300,6 +301,70 @@ def test_code_graph_brief_empty_or_whitespace_output_is_not_attached(tmp_path, m
         assert brief.attached is False
         assert brief.bytes == 0
         assert brief.text == ""
+
+
+def test_context_eval_extracts_real_graphtrail_brief_paths():
+    brief = """## Code graph context (GraphTrail, read-only)
+
+### Entry points
+
+- `brigade.aboyeur.run` function at `src/brigade/aboyeur.py:1211`
+- file_path: `src/brigade/context_eval.py`
+
+### Related files
+
+- `tests/test_aboyeur.py`
+- `/tmp/not-repo.py`
+- `https://example.invalid/not-code.py`
+"""
+
+    assert context_eval.extract_brief_files(brief) == [
+        "src/brigade/aboyeur.py",
+        "src/brigade/context_eval.py",
+        "tests/test_aboyeur.py",
+    ]
+
+
+def test_context_eval_reports_sorted_hits_misses_and_rate():
+    assert context_eval.evaluate(
+        ["src/brigade/aboyeur.py", "tests/test_aboyeur.py"],
+        ["tests/test_aboyeur.py", "src/brigade/context_eval.py"],
+    ) == {
+        "counts": {
+            "brief_files": 2,
+            "delta_files": 2,
+            "hits": 1,
+            "missed": 1,
+        },
+        "hits": ["tests/test_aboyeur.py"],
+        "missed": ["src/brigade/context_eval.py"],
+        "brief_hit_rate": 0.5,
+    }
+
+
+def test_ground_truth_facts_surface_context_eval_metric_once():
+    facts = aboyeur._ground_truth_facts(
+        {
+            "available": True,
+            "changed_files": [],
+            "untracked_files": [],
+            "diffstat": "",
+            "verify_receipts": [],
+            "context_eval": {
+                "counts": {
+                    "brief_files": 3,
+                    "delta_files": 4,
+                    "hits": 2,
+                    "missed": 2,
+                },
+                "hits": ["src/brigade/aboyeur.py", "tests/test_aboyeur.py"],
+                "missed": ["docs/technical-guide.md", "src/brigade/context_eval.py"],
+                "brief_hit_rate": 0.5,
+            },
+        }
+    )
+
+    assert facts.splitlines().count("- context eval: brief hit rate 0.50 (2/4 files, 2 missed)") == 1
 
 
 def test_code_graph_brief_truncates_on_line_boundary(tmp_path, monkeypatch):
@@ -986,6 +1051,187 @@ def test_run_writes_code_graph_delta_to_artifacts_and_synthesis(monkeypatch, tmp
     assert json.loads((output_dir / "synthesis.json").read_text())["ground_truth"]["code_graph_delta"] == after_payload
     assert json.loads((output_dir / "run.json").read_text())["code_graph_delta"] == after_payload
     assert "code_graph_delta: code graph delta: ok changed_symbols=1 edge_churn=2 edges_added=3" in calls[-1][1]
+
+
+def test_run_writes_context_eval_when_brief_and_delta_sidecar_overlap(monkeypatch, tmp_path):
+    calls = []
+    before_payload = {"ok": True, "status": "captured", "summary": "before captured"}
+    brief = aboyeur.CodeGraphBrief(
+        attached=True,
+        text=(
+            "## Code graph context (GraphTrail, read-only)\n\n"
+            "- `tests/test_aboyeur.py:10`\n"
+            "- `src/brigade/aboyeur.py:20`\n"
+        ),
+        bytes=100,
+    )
+
+    def fake_run_agent(cli_ref, prompt, timeout=600.0, cwd=None, read_only=False):
+        calls.append((cli_ref, prompt))
+        if len(calls) == 1:
+            return agents.AgentResult(
+                text=json.dumps({"assignments": [{"worker": "coder", "task": "implement it"}]}),
+                ok=True,
+            )
+        if cli_ref == "ollama:llama3.3":
+            return agents.AgentResult(text="worker output", ok=True)
+        return agents.AgentResult(text="final answer", ok=True)
+
+    def fake_capture_after(target, run_dir, before):
+        sidecar = run_dir / "graph-delta.json"
+        sidecar.write_text(
+            json.dumps(
+                {
+                    "ok": True,
+                    "changed_nodes": [{"file_path": "tests/test_aboyeur.py"}],
+                    "added_nodes": [{"file_path": "src/brigade/context_eval.py"}],
+                    "removed_nodes": [],
+                }
+            )
+            + "\n"
+        )
+        return {
+            "status": "ok",
+            "ok": True,
+            "summary": "code graph delta: ok",
+            "raw_counts": {"changed_nodes": 1, "added_nodes": 1},
+            "edge_churn": 0,
+            "changed_symbols": [],
+            "changed_symbol_count": 0,
+            "sidecar_path": str(sidecar),
+        }
+
+    output_dir = tmp_path / "run"
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+    monkeypatch.setattr(aboyeur.graphtrail_delta, "capture_before", lambda target, run_dir: before_payload)
+    monkeypatch.setattr(aboyeur.graphtrail_delta, "capture_after_and_diff", fake_capture_after)
+
+    assert aboyeur.run("build feature", _roster(), cwd=tmp_path, output_dir=output_dir, code_graph=brief) == 0
+
+    expected = {
+        "counts": {
+            "brief_files": 2,
+            "delta_files": 2,
+            "hits": 1,
+            "missed": 1,
+        },
+        "hits": ["tests/test_aboyeur.py"],
+        "missed": ["src/brigade/context_eval.py"],
+        "brief_hit_rate": 0.5,
+    }
+    ground_truth = json.loads((output_dir / "worker-results.json").read_text())["ground_truth"]
+    assert ground_truth["context_eval"] == expected
+    assert json.loads((output_dir / "synthesis.json").read_text())["ground_truth"]["context_eval"] == expected
+    assert json.loads((output_dir / "run.json").read_text())["context_eval"] == expected
+    assert "- context eval: brief hit rate 0.50 (1/2 files, 1 missed)" in calls[-1][1]
+
+
+def test_run_omits_context_eval_without_brief(monkeypatch, tmp_path):
+    before_payload = {"ok": True, "status": "captured", "summary": "before captured"}
+
+    def fake_run_agent(cli_ref, prompt, timeout=600.0, cwd=None, read_only=False):
+        if "assignments" in prompt:
+            return agents.AgentResult(
+                text=json.dumps({"assignments": [{"worker": "coder", "task": "implement it"}]}),
+                ok=True,
+            )
+        if cli_ref == "ollama:llama3.3":
+            return agents.AgentResult(text="worker output", ok=True)
+        return agents.AgentResult(text="final answer", ok=True)
+
+    def fake_capture_after(target, run_dir, before):
+        sidecar = run_dir / "graph-delta.json"
+        sidecar.write_text(json.dumps({"ok": True, "changed_nodes": [{"file_path": "tests/test_aboyeur.py"}]}) + "\n")
+        return {"status": "ok", "ok": True, "summary": "code graph delta: ok", "sidecar_path": str(sidecar)}
+
+    output_dir = tmp_path / "run"
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+    monkeypatch.setattr(aboyeur.graphtrail_delta, "capture_before", lambda target, run_dir: before_payload)
+    monkeypatch.setattr(aboyeur.graphtrail_delta, "capture_after_and_diff", fake_capture_after)
+
+    assert (
+        aboyeur.run(
+            "build feature",
+            _roster(),
+            cwd=tmp_path,
+            output_dir=output_dir,
+            code_graph=aboyeur.CodeGraphBrief(attached=False),
+        )
+        == 0
+    )
+
+    ground_truth = json.loads((output_dir / "worker-results.json").read_text())["ground_truth"]
+    assert "context_eval" not in ground_truth
+    assert "context_eval" not in json.loads((output_dir / "run.json").read_text())
+
+
+def test_run_omits_context_eval_when_delta_failed(monkeypatch, tmp_path):
+    before_payload = {"ok": True, "status": "captured", "summary": "before captured"}
+    brief = aboyeur.CodeGraphBrief(
+        attached=True,
+        text="## Code graph context (GraphTrail, read-only)\n\n- `tests/test_aboyeur.py:10`\n",
+        bytes=80,
+    )
+
+    def fake_run_agent(cli_ref, prompt, timeout=600.0, cwd=None, read_only=False):
+        if "assignments" in prompt:
+            return agents.AgentResult(
+                text=json.dumps({"assignments": [{"worker": "coder", "task": "implement it"}]}),
+                ok=True,
+            )
+        if cli_ref == "ollama:llama3.3":
+            return agents.AgentResult(text="worker output", ok=True)
+        return agents.AgentResult(text="final answer", ok=True)
+
+    output_dir = tmp_path / "run"
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+    monkeypatch.setattr(aboyeur.graphtrail_delta, "capture_before", lambda target, run_dir: before_payload)
+    monkeypatch.setattr(
+        aboyeur.graphtrail_delta,
+        "capture_after_and_diff",
+        lambda target, run_dir, before: {"status": "sync_failed", "ok": False, "summary": "failed"},
+    )
+
+    assert aboyeur.run("build feature", _roster(), cwd=tmp_path, output_dir=output_dir, code_graph=brief) == 0
+
+    ground_truth = json.loads((output_dir / "worker-results.json").read_text())["ground_truth"]
+    assert "context_eval" not in ground_truth
+    assert "context_eval" not in json.loads((output_dir / "run.json").read_text())
+
+
+def test_run_omits_context_eval_when_delta_has_no_files(monkeypatch, tmp_path):
+    before_payload = {"ok": True, "status": "captured", "summary": "before captured"}
+    brief = aboyeur.CodeGraphBrief(
+        attached=True,
+        text="## Code graph context (GraphTrail, read-only)\n\n- `tests/test_aboyeur.py:10`\n",
+        bytes=80,
+    )
+
+    def fake_run_agent(cli_ref, prompt, timeout=600.0, cwd=None, read_only=False):
+        if "assignments" in prompt:
+            return agents.AgentResult(
+                text=json.dumps({"assignments": [{"worker": "coder", "task": "implement it"}]}),
+                ok=True,
+            )
+        if cli_ref == "ollama:llama3.3":
+            return agents.AgentResult(text="worker output", ok=True)
+        return agents.AgentResult(text="final answer", ok=True)
+
+    def fake_capture_after(target, run_dir, before):
+        sidecar = run_dir / "graph-delta.json"
+        sidecar.write_text(json.dumps({"ok": True, "changed_nodes": []}) + "\n")
+        return {"status": "ok", "ok": True, "summary": "code graph delta: ok", "sidecar_path": str(sidecar)}
+
+    output_dir = tmp_path / "run"
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+    monkeypatch.setattr(aboyeur.graphtrail_delta, "capture_before", lambda target, run_dir: before_payload)
+    monkeypatch.setattr(aboyeur.graphtrail_delta, "capture_after_and_diff", fake_capture_after)
+
+    assert aboyeur.run("build feature", _roster(), cwd=tmp_path, output_dir=output_dir, code_graph=brief) == 0
+
+    ground_truth = json.loads((output_dir / "worker-results.json").read_text())["ground_truth"]
+    assert "context_eval" not in ground_truth
+    assert "context_eval" not in json.loads((output_dir / "run.json").read_text())
 
 
 def test_run_worker_results_include_latest_verification_receipt_commands(monkeypatch, tmp_path):


### PR DESCRIPTION
Every run receipt already holds both halves of a context-quality question: the pre-run `code_graph` brief (what the workers were handed) and the post-run `code_graph_delta` (what structurally changed). This compares them.

- New `src/brigade/context_eval.py`: pure, fail-open extraction of file paths from the brief text and the `graph-delta.json` sidecar, then set arithmetic: `hits`, `missed` (touched but never named in the brief), and `brief_hit_rate` = hits over delta files.
- Wired after delta capture in `aboyeur.py`; payload-only change, the run.json write mechanics are untouched (PR #161's territory). Surfaces one line in synthesis facts: `context eval: brief hit rate 0.50 (2/4 files, 2 missed)`.
- Deliberately absent when there is no brief, no clean delta, or zero delta files. Docs state what it is (did the context pack name the touched files) and what it is not (a quality score; low hit rate on exploratory work is expected, docs-only runs get no eval).

Verification: full `pytest` green on host (brigade receipt `20260708-201016-work-verify-49229d`), ruff check/format and mypy clean, rebased onto current main.