### PR TITLE
feat: add optional you.com search provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ The same review-and-receipt pattern covers the rest of an operator's day, and yo
 - **Daily loop**: `brigade work brief` shows pending work, imports, and warnings; `brigade daily status` keeps it bounded and cheap.
 - **Friction logs**: `brigade friction scan` mines recent notes, handoffs, and session artifacts for reviewable workflow friction.
 - **Security and scrub**: `brigade security scan` is a local read-only scanner for agent workspaces. `brigade scrub` gates content before it leaves the machine, and `brigade guard` exposes the embedded content guard CLI.
-- **Research**: `brigade research run` turns a question into a cited local report and a reviewable memory handoff.
+- **Research**: `brigade research run` turns a question into a cited local report and a reviewable memory handoff. Set `research_search_provider = "youcom"` in `.brigade/research.toml` to swap the web-search backend to You.com, or keep the default browser provider.
 - **Fleet and release**: health evidence across your local repos and release-readiness receipts, with no publish step.
 
 The full tour of every station lives in [docs/overview.md](docs/overview.md).

--- a/src/brigade/research/sources/web.py
+++ b/src/brigade/research/sources/web.py
@@ -1,6 +1,7 @@
 # src/brigade/research/sources/web.py
 from __future__ import annotations
 from typing import Any, Callable, Dict, List, Optional
+from urllib import request
 from urllib.parse import quote_plus
 
 
@@ -83,10 +84,56 @@ class SearxngProvider:
         return PlaywrightProvider().fetch(url)
 
 
+class YouComProvider:
+    trust = "web"
+
+    def __init__(self, api_key: Optional[str] = None, base_url: str = "https://api.you.com") -> None:
+        self.api_key = api_key or ""
+        self.base_url = base_url.rstrip("/")
+
+    def search(self, query: str, limit: int) -> List[Dict[str, str]]:
+        import json
+
+        params = {
+            "query": query,
+            "count": str(max(1, min(limit, 100))),
+            "livecrawl": "web",
+        }
+        u = f"{self.base_url}/v1/agents/search?" + "&".join(
+            f"{k}={quote_plus(v)}" for k, v in params.items()
+        )
+        headers = {"Accept": "application/json"}
+        if self.api_key:
+            headers["X-API-Key"] = self.api_key
+        req = request.Request(u, headers=headers)
+        with request.urlopen(req, timeout=15) as r:
+            data = json.loads(r.read().decode())
+        results = data.get("results", {}) if isinstance(data, dict) else {}
+        hits = []
+        for bucket in ("web", "news"):
+            for item in results.get(bucket, []) if isinstance(results, dict) else []:
+                if not isinstance(item, dict):
+                    continue
+                hits.append(
+                    {
+                        "url": str(item.get("url", "")),
+                        "title": str(item.get("title", "")),
+                    }
+                )
+                if len(hits) >= limit:
+                    return hits
+        return hits
+
+    def fetch(self, url: str) -> Dict[str, Any]:
+        return PlaywrightProvider().fetch(url)
+
+
 def build_provider(name: Optional[str], settings: Dict[str, Any]):
     name = (name or settings.get("research_search_provider") or "playwright").strip()
     if name in ("playwright", "browser", ""):
         return PlaywrightProvider()
     if name == "searxng":
         return SearxngProvider(settings["searxng_url"])
+    if name in ("youcom", "you.com", "ydc"):
+        return YouComProvider(api_key=settings.get("youcom_api_key") or settings.get("ydc_api_key"))
     raise ValueError(f"unknown search provider: {name}")

--- a/tests/test_research_web.py
+++ b/tests/test_research_web.py
@@ -42,3 +42,31 @@ def test_provider_factory_default_is_playwright():
     prov = web.build_provider(None, {})
     assert isinstance(prov, web.PlaywrightProvider)
     assert prov.trust == "browser"
+
+
+def test_youcom_provider_parses_web_and_news_results(monkeypatch):
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return (
+                b'{"results":{"web":[{"url":"https://ex.com/w","title":"Web Hit"}],'
+                b'"news":[{"url":"https://ex.com/n","title":"News Hit"}]}}'
+            )
+
+    monkeypatch.setattr(web.request, "urlopen", lambda req, timeout=15: FakeResponse())
+    prov = web.YouComProvider(api_key="k")
+    hits = prov.search("query", 2)
+    assert hits == [
+        {"url": "https://ex.com/w", "title": "Web Hit"},
+        {"url": "https://ex.com/n", "title": "News Hit"},
+    ]
+
+
+def test_provider_factory_supports_youcom_aliases():
+    prov = web.build_provider("youcom", {"ydc_api_key": "k"})
+    assert isinstance(prov, web.YouComProvider)


### PR DESCRIPTION
Why this is useful

Brigade already supports pluggable research search backends. You.com fits the existing provider pattern and gives the research flow another optional web source without changing defaults.

What changed

- Added a `youcom` provider in `src/brigade/research/sources/web.py`
- It calls You.com's Search API with plain HTTP, using `YDC_API_KEY` only when provided
- It merges web and news results into the existing `{url, title}` shape
- Added tests for the provider and factory aliases
- Documented the new provider in the README

Setup

```toml
[search]
research_search_provider = "youcom"
```

Optional env var:

- `YDC_API_KEY`

Usage example

Run Brigade research as usual after selecting the provider in `.brigade/research.toml`.

Validation

- `uv run pytest tests/test_research_web.py -q`
- `uv run ruff check src/brigade/research/sources/web.py tests/test_research_web.py`
- `uv run mypy src/brigade/research/sources/web.py tests/test_research_web.py`

Fallback behavior

The default provider stays `playwright`. The new provider is opt-in and only affects runs that explicitly select it.

Tracking issue

https://github.com/youdotcom-oss/integration-tracking/issues/87
