### PR TITLE
feat(outcome): capture outcomes from run receipts, where deltas actually live

### DIFF
--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -990,7 +990,20 @@ Work verification and non-read-only aboyeur runs can also record a GraphTrail de
 
 Delta capture is fail-open. Missing GraphTrail, sync failures, malformed diff JSON, and snapshot problems are recorded as status data instead of failing the run. `--no-code-graph`, read-only runs, and dry runs record skip statuses and do not run GraphTrail sync.
 
-When `brigade outcome capture` records a verification receipt with `code_graph_delta`, the outcome ledger keeps the compact fields `status`, `summary`, `changed_symbol_count`, `edge_churn`, and `raw_counts`. `brigade outcome rank` and dry-run `brigade outcome reconcile` surface per-artifact counts for scored records whose graph delta is changing or no-op. These counters are display-only today: promotion, rollback, cooldown, and ranking decisions still use the existing verified outcome rules.
+`brigade outcome capture` can copy code delta summaries from two receipt sources:
+
+```bash
+brigade outcome capture <artifact-id> --run-id <verify-run-id|latest>
+brigade outcome capture <artifact-id> --run-receipt <run-id|latest>
+```
+
+`--run-id` reads work verification receipts under `.brigade/work/verify-runs/`. `--run-receipt` reads aboyeur run receipts under `.brigade/runs/<run-id>/run.json`. The flags are mutually exclusive. Both sources store the same compact `code_graph_delta` fields in the outcome ledger: `status`, `summary`, `changed_symbol_count`, `edge_churn`, and `raw_counts`.
+
+Run-receipt signal mapping is fixed and local: `status: ok` records `+1`, `status: error` and `status: failed` record `-1`, and `dry_run: true` or `read_only: true` records neutral `0`. The evidence reference points at the `run.json` file that supplied the signal and delta. Verification receipts keep their existing mapping: completed is positive, failed or timed out is negative, and rejected or unknown statuses are neutral through the same outcome rule table.
+
+Run receipts usually carry the useful code delta because a non-read-only `brigade run` brackets the worker command itself: GraphTrail syncs before the worker edits, syncs again after the edits, and writes the delta into the run artifacts. Verification runs usually execute after the work, often as tests, linters, docs checks, or receipt checks. Those commands may not edit the source graph at all, so their deltas are commonly absent or no-op even when the preceding worker run made structural code changes.
+
+`brigade outcome rank` and dry-run `brigade outcome reconcile` surface per-artifact counts for scored records whose graph delta is changing or no-op. Verify-sourced and run-receipt-sourced deltas are counted identically once they are in the outcome ledger. These counters are display-only today: promotion, rollback, cooldown, and ranking decisions still use the existing verified outcome rules.
 
 For those counters, a delta is changing only when `status` is `ok` and `changed_symbol_count` or `edge_churn` is greater than zero. A delta is no-op only when `status` is `ok` and both counts are zero. Zero graph delta does not mean nothing happened: docs-only changes, test-only changes, and pre-v3 body-edit blind spots can still read as no-op.
 

--- a/src/brigade/cli/outcome.py
+++ b/src/brigade/cli/outcome.py
@@ -23,11 +23,14 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_explain.add_argument("--json", action="store_true", help="Emit machine-readable JSON instead of text.")
     p_explain.set_defaults(func=_dispatch_explain)
 
-    p_capture = outcome_sub.add_parser("capture", help="Record a verify run's outcome for a learned artifact.")
+    p_capture = outcome_sub.add_parser("capture", help="Record a receipt outcome for a learned artifact.")
     p_capture.add_argument("artifact_id", help="Artifact id (card or skill) the run exercised.")
     p_capture.add_argument("--kind", default="skill", choices=["skill", "card"], help="Artifact kind.")
     p_capture.add_argument("--task-id", default=None, help="Task id to correlate the signal with.")
-    p_capture.add_argument("--run-id", default="latest", help="Verify run id to read (default: latest).")
+    p_capture.add_argument("--run-id", default=None, help="Verify run id to read (default: latest).")
+    p_capture.add_argument(
+        "--run-receipt", default=None, help="Brigade run id to read from .brigade/runs/<id>/run.json."
+    )
     p_capture.add_argument("--target", "-t", type=Path, default=Path("."))
     p_capture.add_argument("--json", action="store_true", help="Emit machine-readable JSON instead of text.")
     p_capture.set_defaults(func=_dispatch_capture)
@@ -114,6 +117,7 @@ def _dispatch_capture(args) -> int:
         artifact_kind=args.kind,
         task_id=args.task_id,
         run_id=args.run_id,
+        run_receipt=args.run_receipt,
         json_output=args.json,
     )
 

--- a/src/brigade/outcome.py
+++ b/src/brigade/outcome.py
@@ -22,6 +22,9 @@ SIGNAL_RULES: dict[tuple[str, str], int] = {
     ("verify", "completed"): 1,
     ("verify", "failed"): -1,
     ("verify", "timed_out"): -1,
+    ("run", "ok"): 1,
+    ("run", "error"): -1,
+    ("run", "failed"): -1,
     ("friction", "cleared"): 1,
     ("friction", "recurred"): -1,
     ("learnings", "cleared"): 1,
@@ -44,6 +47,7 @@ class OutcomeRecord:
     evidence_ref: str
     ts: str
     code_graph_delta: dict[str, Any] | None = None
+    context_eval: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True)

--- a/src/brigade/outcome_cmd.py
+++ b/src/brigade/outcome_cmd.py
@@ -14,6 +14,7 @@ import io
 import json
 import sys
 from pathlib import Path
+from typing import Any
 
 from . import localio, outcome as core
 
@@ -66,6 +67,7 @@ def _artifact_known(target: Path, artifact_id: str, kind: str) -> bool:
 
 def _record_from_dict(payload: dict) -> core.OutcomeRecord | None:
     code_graph_delta = payload.get("code_graph_delta")
+    context_eval = payload.get("context_eval")
     try:
         return core.OutcomeRecord(
             artifact_id=str(payload["artifact_id"]),
@@ -76,6 +78,7 @@ def _record_from_dict(payload: dict) -> core.OutcomeRecord | None:
             evidence_ref=str(payload.get("evidence_ref", "")),
             ts=str(payload.get("ts", "")),
             code_graph_delta=code_graph_delta if isinstance(code_graph_delta, dict) else None,
+            context_eval=context_eval if isinstance(context_eval, dict) else None,
         )
     except (KeyError, TypeError, ValueError):
         return None
@@ -99,6 +102,8 @@ def _record_payload(record: core.OutcomeRecord) -> dict:
     row = dataclasses.asdict(record)
     if row.get("code_graph_delta") is None:
         row.pop("code_graph_delta", None)
+    if row.get("context_eval") is None:
+        row.pop("context_eval", None)
     return row
 
 
@@ -125,6 +130,72 @@ def _compact_code_graph_delta(receipt: dict) -> dict | None:
         if key in delta
     }
     return compact or None
+
+
+def _compact_context_eval(receipt: dict) -> dict | None:
+    context_eval = receipt.get("context_eval")
+    if not isinstance(context_eval, dict):
+        return None
+    return dict(context_eval)
+
+
+def _run_receipts_root(target: Path) -> Path:
+    return target / ".brigade" / "runs"
+
+
+def _read_run_receipt(run_dir: Path) -> tuple[dict[str, Any] | None, Path]:
+    run_json = run_dir / "run.json"
+    if not run_json.is_file():
+        return None, run_json
+    try:
+        payload = json.loads(run_json.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None, run_json
+    if not isinstance(payload, dict):
+        return None, run_json
+    return payload, run_json
+
+
+def _resolve_run_receipt(target: Path, run_id: str) -> tuple[dict[str, Any] | None, Path | None, str | None]:
+    root = _run_receipts_root(target)
+    if not root.is_dir():
+        return None, None, f"run receipt directory not found: {root}"
+    raw = Path(run_id).expanduser()
+    if raw.is_absolute() or len(raw.parts) > 1 or raw.exists():
+        run_dir = raw.resolve()
+        if not run_dir.is_dir():
+            return None, None, f"run receipt directory not found: {run_dir}"
+        payload, run_json = _read_run_receipt(run_dir)
+        if payload is None:
+            return None, None, f"run receipt not found or invalid: {run_json}"
+        return payload, run_json, None
+    runs: list[tuple[Path, dict[str, Any], Path]] = []
+    for child in root.iterdir():
+        if not child.is_dir():
+            continue
+        payload, run_json = _read_run_receipt(child)
+        if payload is not None:
+            runs.append((child, payload, run_json))
+    runs.sort(key=lambda item: str(item[1].get("started_at") or item[0].name), reverse=True)
+    if run_id == "latest":
+        if not runs:
+            return None, None, f"run receipt not found: {run_id}"
+        _, payload, run_json = runs[0]
+        return payload, run_json, None
+    matches = [(payload, run_json) for child, payload, run_json in runs if child.name.startswith(run_id)]
+    if not matches:
+        return None, None, f"run receipt not found: {run_id}"
+    if len(matches) > 1:
+        return None, None, f"run receipt id is ambiguous: {run_id}"
+    return matches[0][0], matches[0][1], None
+
+
+def _run_receipt_signal_status(receipt: dict) -> str:
+    if receipt.get("dry_run") is True:
+        return "dry-run"
+    if receipt.get("read_only") is True:
+        return "read-only"
+    return str(receipt.get("status") or "")
 
 
 def _decisions_dir(target: Path) -> Path:
@@ -409,21 +480,19 @@ def capture(
     artifact_id: str,
     artifact_kind: str = "skill",
     task_id: str | None = None,
-    run_id: str = "latest",
+    run_id: str | None = None,
+    run_receipt: str | None = None,
     json_output: bool = False,
 ) -> int:
-    """Correlate a verify run's exit-code outcome into the digest-chained ledger.
+    """Correlate a verified receipt outcome into the digest-chained ledger.
 
-    The signal is the run's status (a real exit code the model cannot author),
+    The signal is the receipt status (a real run result the model cannot author),
     not an LLM judgment. The caller names which artifact the run exercised, and
     appended records carry a tamper-evident prev_digest/digest chain.
     """
     target = target.expanduser().resolve()
-    from .work_cmd import verification as verify_mod
-
-    receipt, error = verify_mod._resolve_verify_receipt(target, run_id)
-    if receipt is None:
-        print(f"error: {error}", file=sys.stderr)
+    if run_id is not None and run_receipt is not None:
+        print("error: pass either --run-id or --run-receipt, not both", file=sys.stderr)
         return 1
     if not _artifact_known(target, artifact_id, artifact_kind):
         known = _known_skill_names(target) if artifact_kind == "skill" else _known_card_names(target)
@@ -434,23 +503,51 @@ def capture(
             f"trustworthy. known {artifact_kind}s: {hint}",
             file=sys.stderr,
         )
-    status = str(receipt.get("status") or "")
+    source = "verify"
+    effective_status = ""
+    evidence_ref = ""
+    ts = localio.utc_now_iso()
+    code_graph_delta: dict[str, Any] | None = None
+    context_eval: dict[str, Any] | None = None
+    if run_receipt is not None:
+        receipt, run_json, error = _resolve_run_receipt(target, run_receipt)
+        if receipt is None or run_json is None:
+            print(f"error: {error}", file=sys.stderr)
+            return 1
+        source = "run"
+        effective_status = _run_receipt_signal_status(receipt)
+        evidence_ref = str(run_json)
+        ts = str(receipt.get("completed_at") or receipt.get("started_at") or localio.utc_now_iso())
+        code_graph_delta = _compact_code_graph_delta(receipt)
+        context_eval = _compact_context_eval(receipt)
+    else:
+        from .work_cmd import verification as verify_mod
+
+        receipt, error = verify_mod._resolve_verify_receipt(target, run_id or "latest")
+        if receipt is None:
+            print(f"error: {error}", file=sys.stderr)
+            return 1
+        effective_status = str(receipt.get("status") or "")
+        evidence_ref = str(Path(str(receipt.get("path", ""))) / "receipt.json")
+        ts = str(receipt.get("completed_at") or receipt.get("started_at") or localio.utc_now_iso())
+        code_graph_delta = _compact_code_graph_delta(receipt)
     record = core.OutcomeRecord(
         artifact_id=artifact_id,
         artifact_kind=artifact_kind,
         task_id=task_id or "",
-        source="verify",
-        signal_value=core.signal_value("verify", status),
-        evidence_ref=str(Path(str(receipt.get("path", ""))) / "receipt.json"),
-        ts=str(receipt.get("completed_at") or receipt.get("started_at") or localio.utc_now_iso()),
-        code_graph_delta=_compact_code_graph_delta(receipt),
+        source=source,
+        signal_value=core.signal_value(source, effective_status),
+        evidence_ref=evidence_ref,
+        ts=ts,
+        code_graph_delta=code_graph_delta,
+        context_eval=context_eval,
     )
     append_records(target, [record])
     if json_output:
         print(json.dumps({"target": str(target), "record": _record_payload(record)}, indent=2, sort_keys=True))
         return 0
     print(f"outcome capture: {artifact_id}")
-    print(f"source: verify [{status}] signal={record.signal_value:+d}")
+    print(f"source: {source} [{effective_status}] signal={record.signal_value:+d}")
     print(f"evidence: {record.evidence_ref}")
     return 0
 

--- a/tests/test_outcome_cmd.py
+++ b/tests/test_outcome_cmd.py
@@ -38,6 +38,37 @@ def _write_verify_receipt(
     return run_dir / "receipt.json"
 
 
+def _write_run_receipt(
+    target,
+    run_id="brigade-run",
+    *,
+    status="ok",
+    dry_run=False,
+    read_only=False,
+    code_graph_delta=None,
+    context_eval=None,
+    started_at="2026-06-20T00:00:00+00:00",
+):
+    run_dir = target / ".brigade" / "runs" / run_id
+    run_dir.mkdir(parents=True)
+    receipt = {
+        "task": "fixture task",
+        "cwd": str(target),
+        "status": status,
+        "dry_run": dry_run,
+        "read_only": read_only,
+        "started_at": started_at,
+        "completed_at": started_at,
+        "artifacts": str(run_dir),
+    }
+    if code_graph_delta is not None:
+        receipt["code_graph_delta"] = code_graph_delta
+    if context_eval is not None:
+        receipt["context_eval"] = context_eval
+    localio.write_json(run_dir / "run.json", receipt)
+    return run_dir / "run.json"
+
+
 def test_records_persist_under_git_tracked_memory_dir(tmp_path):
     _seed(tmp_path, [outcome.OutcomeRecord("c", "card", "t", "verify", 1, "r", "2026-06-20T00:00:00+00:00")])
     assert (tmp_path / "memory" / "outcome" / "records.jsonl").is_file()
@@ -85,6 +116,10 @@ def test_legacy_digestless_records_still_load_and_do_not_break_new_chain(tmp_pat
     loaded = outcome_cmd.load_records(tmp_path)
     rows = [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
     assert [record.evidence_ref for record in loaded] == ["legacy", "ref1"]
+    assert loaded[0].code_graph_delta is None
+    assert loaded[1].code_graph_delta is None
+    assert loaded[0].context_eval is None
+    assert loaded[1].context_eval is None
     assert "digest" not in rows[0]
     assert rows[1]["prev_digest"] is None
     assert rows[1]["digest"] == localio.canonical_json_digest(rows[1], exclude_keys={"digest"})
@@ -204,6 +239,158 @@ def test_capture_copies_compact_code_graph_delta_from_verify_receipt(tmp_path, c
     assert row["code_graph_delta"] == compact
     assert "sidecar_path" not in row["code_graph_delta"]
     assert row["digest"] == localio.canonical_json_digest(row, exclude_keys={"digest"})
+
+
+def test_capture_run_receipt_copies_delta_and_context_eval_into_digest_chain(tmp_path, capsys):
+    delta = {
+        "status": "ok",
+        "summary": "changed_symbols=2 edge_churn=1",
+        "changed_symbol_count": 2,
+        "edge_churn": 1,
+        "raw_counts": {"edges_added": 2, "edges_removed": 1},
+        "sidecar_path": "/tmp/not-copied.json",
+    }
+    context_eval = {
+        "counts": {"brief_files": 2, "delta_files": 2, "hits": 1, "missed": 1},
+        "hits": ["src/brigade/outcome_cmd.py"],
+        "missed": ["tests/test_outcome_cmd.py"],
+        "brief_hit_rate": 0.5,
+    }
+    run_json = _write_run_receipt(
+        tmp_path,
+        run_id="run-with-delta",
+        code_graph_delta=delta,
+        context_eval=context_eval,
+    )
+
+    assert (
+        outcome_cmd.capture(
+            target=tmp_path,
+            artifact_id="skill-x",
+            artifact_kind="skill",
+            task_id="t-run",
+            run_receipt="run-with-delta",
+            json_output=True,
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    compact = {
+        "status": "ok",
+        "summary": "changed_symbols=2 edge_churn=1",
+        "changed_symbol_count": 2,
+        "edge_churn": 1,
+        "raw_counts": {"edges_added": 2, "edges_removed": 1},
+    }
+    assert payload["record"]["source"] == "run"
+    assert payload["record"]["signal_value"] == 1
+    assert payload["record"]["evidence_ref"] == str(run_json)
+    assert payload["record"]["code_graph_delta"] == compact
+    assert payload["record"]["context_eval"] == context_eval
+
+    row = json.loads((tmp_path / "memory" / "outcome" / "records.jsonl").read_text())
+    assert row["code_graph_delta"] == compact
+    assert row["context_eval"] == context_eval
+    assert "sidecar_path" not in row["code_graph_delta"]
+    assert row["digest"] == localio.canonical_json_digest(row, exclude_keys={"digest"})
+    records = outcome_cmd.load_records(tmp_path)
+    assert records[0].context_eval == context_eval
+
+
+def test_capture_run_receipt_maps_ok_error_and_dry_run_signals(tmp_path, capsys):
+    _write_run_receipt(tmp_path, run_id="ok-run", status="ok")
+    _write_run_receipt(tmp_path, run_id="error-run", status="error")
+    _write_run_receipt(tmp_path, run_id="failed-run", status="failed")
+    _write_run_receipt(tmp_path, run_id="dry-run", status="dry-run", dry_run=True)
+    _write_run_receipt(tmp_path, run_id="read-only-run", status="ok", read_only=True)
+
+    expected = {
+        "ok-run": 1,
+        "error-run": -1,
+        "failed-run": -1,
+        "dry-run": 0,
+        "read-only-run": 0,
+    }
+    for run_id, signal in expected.items():
+        assert (
+            outcome_cmd.capture(
+                target=tmp_path,
+                artifact_id="skill-x",
+                run_receipt=run_id,
+                json_output=True,
+            )
+            == 0
+        )
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["record"]["signal_value"] == signal
+
+
+def test_capture_run_receipt_latest_uses_newest_run_json(tmp_path, capsys):
+    _write_run_receipt(tmp_path, run_id="older", status="error", started_at="2026-06-20T00:00:00+00:00")
+    latest = _write_run_receipt(tmp_path, run_id="newer", status="ok", started_at="2026-06-20T01:00:00+00:00")
+
+    assert outcome_cmd.capture(target=tmp_path, artifact_id="skill-x", run_receipt="latest", json_output=True) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["record"]["signal_value"] == 1
+    assert payload["record"]["evidence_ref"] == str(latest)
+
+
+def test_capture_errors_when_run_id_and_run_receipt_are_both_passed(tmp_path, capsys):
+    _write_verify_receipt(tmp_path, run_id="verify-run")
+    _write_run_receipt(tmp_path, run_id="brigade-run")
+
+    assert (
+        outcome_cmd.capture(
+            target=tmp_path,
+            artifact_id="skill-x",
+            run_id="verify-run",
+            run_receipt="brigade-run",
+        )
+        == 1
+    )
+    assert "pass either --run-id or --run-receipt, not both" in capsys.readouterr().err
+
+
+def test_cli_outcome_capture_accepts_run_receipt_and_rejects_both_flags(tmp_path, capsys):
+    _write_verify_receipt(tmp_path, run_id="verify-run")
+    _write_run_receipt(tmp_path, run_id="brigade-run")
+
+    assert (
+        cli.main(
+            [
+                "outcome",
+                "capture",
+                "skill-x",
+                "--target",
+                str(tmp_path),
+                "--run-receipt",
+                "brigade-run",
+                "--json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["record"]["source"] == "run"
+
+    assert (
+        cli.main(
+            [
+                "outcome",
+                "capture",
+                "skill-x",
+                "--target",
+                str(tmp_path),
+                "--run-id",
+                "verify-run",
+                "--run-receipt",
+                "brigade-run",
+            ]
+        )
+        == 1
+    )
+    assert "pass either --run-id or --run-receipt, not both" in capsys.readouterr().err
 
 
 def test_capture_omits_code_graph_delta_when_verify_receipt_omits_it(tmp_path, capsys):
@@ -472,6 +659,65 @@ def test_rank_json_includes_graph_delta_counters_for_mixed_records(tmp_path, cap
     assert ranking["skill-x"]["graph_no_op"] == 1
     assert "graph_changing" not in ranking["skill-y"]
     assert "graph_no_op" not in ranking["skill-y"]
+
+
+def test_rank_and_reconcile_count_verify_and_run_receipt_graph_deltas_identically(tmp_path, capsys):
+    _write_verify_receipt(
+        tmp_path,
+        run_id="verify-changing",
+        code_graph_delta={"status": "ok", "changed_symbol_count": 1, "edge_churn": 0},
+    )
+    _write_run_receipt(
+        tmp_path,
+        run_id="run-no-op",
+        code_graph_delta={"status": "ok", "changed_symbol_count": 0, "edge_churn": 0},
+        started_at="2026-06-20T01:00:00+00:00",
+    )
+
+    assert (
+        outcome_cmd.capture(
+            target=tmp_path,
+            artifact_id="skill-x",
+            artifact_kind="skill",
+            task_id="t-verify",
+            run_id="verify-changing",
+            json_output=True,
+        )
+        == 0
+    )
+    capsys.readouterr()
+    assert (
+        outcome_cmd.capture(
+            target=tmp_path,
+            artifact_id="skill-x",
+            artifact_kind="skill",
+            task_id="t-run",
+            run_receipt="run-no-op",
+            json_output=True,
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    assert outcome_cmd.rank(target=tmp_path, json_output=True) == 0
+    ranking = {item["artifact_id"]: item for item in json.loads(capsys.readouterr().out)["ranking"]}
+    assert ranking["skill-x"]["helped"] == 2
+    assert ranking["skill-x"]["graph_changing"] == 1
+    assert ranking["skill-x"]["graph_no_op"] == 1
+
+    assert outcome_cmd.reconcile(target=tmp_path, apply=False, json_output=True) == 0
+    decision = {item["artifact_id"]: item for item in json.loads(capsys.readouterr().out)["decisions"]}["skill-x"]
+    assert decision["action"] == "install"
+    assert decision["graph_changing"] == 1
+    assert decision["graph_no_op"] == 1
+
+    assert outcome_cmd.rank(target=tmp_path, json_output=False) == 0
+    expected = (
+        f"outcome rank: {tmp_path.resolve()}\n"
+        f"- skill-x score={outcome.wilson_lower_bound(2, 2):.3f} helped=2 hurt=0 "
+        "graph: 1 changing / 1 no-op\n"
+    )
+    assert capsys.readouterr().out == expected
 
 
 def test_reconcile_dry_run_json_surfaces_graph_delta_counters(tmp_path, capsys):


### PR DESCRIPTION
Follow-on to #163: the `graph: N changing / M no-op` counters read permanently dark because outcome capture only resolved verify receipts, and verify runs execute tests rather than change code. Run receipts are where workers edit code.

- `outcome capture <id> --run-receipt <run-id|latest>`: resolves `.brigade/runs/<id>/run.json`, maps status to signal consistent with verify semantics (`ok` +1, `error/failed` -1, dry-run/read-only neutral), stores `evidence_ref`, and copies `code_graph_delta` plus `context_eval` into the hashed record content. `--run-id` and `--run-receipt` together error clearly; neither = today's behavior.
- Regression test proves rank/reconcile counters treat verify-sourced and run-receipt-sourced deltas identically; ledger chain stayed green (`ok=74 mismatch=0`).

Verification: full pytest green on host (brigade receipt `20260708-210129-work-verify-bc25ee`), ruff check/format and mypy clean. Dogfood: capturing from the codex run that built this feature recorded `signal=+1` with `changed_symbols=19 edge_churn=23 added_nodes=12` - the ledger's first graph-changing outcome.