### PR TITLE
fix(agents): pass approval flags to headless grok so write tasks execute

### DIFF
--- a/src/brigade/agents.py
+++ b/src/brigade/agents.py
@@ -98,8 +98,11 @@ def _openhands_argv(prompt: str, read_only: bool, sandbox: str | None) -> List[s
 
 
 def _grok_argv(prompt: str, read_only: bool, sandbox: str | None) -> List[str]:
-    task = _read_only_prompt(prompt) if read_only or sandbox == "read-only" else prompt
-    return ["grok", "-p", task]
+    # Headless `grok -p` stops silently (exit 0) at the first tool-approval
+    # gate, so a write task without an approval flag no-ops after its preamble.
+    if read_only or sandbox == "read-only":
+        return ["grok", "-p", prompt, "--permission-mode", "plan"]
+    return ["grok", "-p", prompt, "--always-approve"]
 
 
 def _amp_argv(prompt: str, read_only: bool, sandbox: str | None) -> List[str]:
@@ -152,7 +155,7 @@ READ_ONLY_ENFORCEMENT: dict[str, str] = {
     "copilot": "soft",
     "adal": "soft",
     "openhands": "soft",
-    "grok": "soft",
+    "grok": "hard",
     "amp": "soft",
     "crush": "soft",
     "claude": "none",

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -18,7 +18,7 @@ def test_build_argv_for_known_clis():
     assert agents.build_argv("kimi", "hi") == ["kimi", "--print", "-p", "hi", "--final-message-only"]
     assert agents.build_argv("adal", "hi") == ["adal", "-q", "hi"]
     assert agents.build_argv("openhands", "hi") == ["openhands", "--headless", "-t", "hi"]
-    assert agents.build_argv("grok", "hi") == ["grok", "-p", "hi"]
+    assert agents.build_argv("grok", "hi") == ["grok", "-p", "hi", "--always-approve"]
     assert agents.build_argv("amp", "hi") == ["amp", "-x", "hi"]
     assert agents.build_argv("crush", "hi") == ["crush", "run", "hi"]
     assert agents.build_argv("ollama:llama3.3", "hi") == ["ollama", "run", "llama3.3", "hi"]
@@ -66,7 +66,13 @@ def test_build_argv_for_read_only_codex():
     assert agents.build_argv("copilot", "hi", read_only=True)[-1].startswith("Read-only planning run.")
     assert agents.build_argv("adal", "hi", read_only=True)[-1].startswith("Read-only planning run.")
     assert agents.build_argv("openhands", "hi", read_only=True)[-1].startswith("Read-only planning run.")
-    assert agents.build_argv("grok", "hi", read_only=True)[-1].startswith("Read-only planning run.")
+    assert agents.build_argv("grok", "hi", read_only=True) == [
+        "grok",
+        "-p",
+        "hi",
+        "--permission-mode",
+        "plan",
+    ]
     assert agents.build_argv("amp", "hi", read_only=True)[-1].startswith("Read-only planning run.")
     assert agents.build_argv("crush", "hi", read_only=True)[-1].startswith("Read-only planning run.")
     assert agents.build_argv("ollama:llama3.3", "hi", read_only=True) == [

--- a/tests/test_agents_model_pin.py
+++ b/tests/test_agents_model_pin.py
@@ -16,10 +16,18 @@ def test_pins_model_for_grok():
         "grok-composer-2.5-fast",
         "-p",
         "P",
+        "--always-approve",
     ]
     read_only = agents.build_argv("grok", "P", read_only=True, model="grok-composer-2.5-fast")
-    assert read_only[:4] == ["grok", "-m", "grok-composer-2.5-fast", "-p"]
-    assert read_only[-1].startswith("Read-only planning run.")
+    assert read_only == [
+        "grok",
+        "-m",
+        "grok-composer-2.5-fast",
+        "-p",
+        "P",
+        "--permission-mode",
+        "plan",
+    ]
 
 
 def test_pins_model_for_opencode():

--- a/tests/test_read_only_enforcement.py
+++ b/tests/test_read_only_enforcement.py
@@ -10,6 +10,7 @@ from brigade.roster import Agent, Roster
 def test_read_only_enforcement_classification():
     assert agents.read_only_enforcement("codex") == "hard"
     assert agents.read_only_enforcement("aider") == "hard"
+    assert agents.read_only_enforcement("grok") == "hard"
     assert agents.read_only_enforcement("goose") == "soft"
     assert agents.read_only_enforcement("crush") == "soft"
     assert agents.read_only_enforcement("claude") == "none"


### PR DESCRIPTION
## Problem

Headless `grok -p` stops silently (exit 0) at the first tool-approval gate. Brigade's grok adapter passed no approval flag, so every grok worker on a write task reported `ok` while changing zero files - the run log showed only the model's preamble text ("Implementing the game and tests now.") and the repo diffstat was empty.

## Fix

- Write runs: append `--always-approve` (grok's equivalent of qwen's `--approval-mode yolo`).
- Read-only runs: use native `--permission-mode plan` instead of the soft prompt prefix.
- Reclassify grok in `READ_ONLY_ENFORCEMENT` as `hard`, since plan mode is a native guarantee rather than a prompt suggestion.

## Verification

- `python3 -m pytest tests/test_agents.py tests/test_agents_model_pin.py tests/test_read_only_enforcement.py -q` green via brigade verify receipt `20260709-050448-work-verify-0157e5` (full suite run before that: 1 failure = the stale model-pin assertion, updated here).
- Live repro: an all-grok roster (grok-4.5 chef + builder, grok-composer-2.5-fast speedrun) on a scratch repo. Before the fix: workers "ok", no files written. After: minesweeper.py + test_minesweeper.py landed, 11 pytest tests pass independently.