### PR TITLE
feat: productize GraphTrail-Brigade-MiseLedger evidence loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Productized GraphTrail ↔ Brigade ↔ MiseLedger dogfood path: `brigade operator checkup` reports optional loop health (`graph` / `ledger` / last and mean `brief_hit_rate` from run receipts) without blocking readiness; `brigade add graphtrail` installs the code-graph tool under the search station; QUICKSTART documents install → checkup → export → rank.
+- Outcome rank/reconcile surfaces mean `context_eval.brief_hit_rate` per skill as a quality signal (secondary sort among equal Wilson scores; install/rollback thresholds still use verified exit codes only).
+- `brigade-work` skill teaches the full loop: verify with capture → outcome from run → MiseLedger export → evidence brief next time.
+- `brigade add` accepts a managed tool name (e.g. `graphtrail`) as well as a station name, so optional loop sidecars install without pulling every tool on the station.
+
 ## [0.21.0] - 2026-07-08
 
 ### Added

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -143,6 +143,27 @@ brigade work verify run --target . --command "pytest -q" --capture <skill-or-car
 
 Capture against an id you actually have: a skill you followed, a memory card (`--kind card`), or `brigade-work` itself when nothing else applies. `brigade work brief` surfaces the loop's own health so an empty ledger never goes unnoticed.
 
+## Optional: close the GraphTrail ↔ Brigade ↔ MiseLedger loop
+
+0.21.0 already ships receipt deltas, MiseLedger export, evidence briefs, and context evals. Productizing them is a short dogfood path:
+
+```bash
+# optional stations (fail-open everywhere if absent)
+brigade add graphtrail          # or: cargo install graphtrail
+graphtrail sync                 # builds .graphtrail/graphtrail.db in the repo
+brigade add evidence            # miseledger
+
+# one operator glance: doctors + graph ok / ledger ok / last brief hit rate
+brigade operator checkup --target .
+
+# after real work flows through verify/run + capture:
+brigade receipts export miseledger --target . --new-only --import
+brigade outcome rank --target .    # surfaces brief_hit as a skill quality signal
+# next brigade run attaches a capped MiseLedger evidence brief automatically
+```
+
+That is the differentiated loop: receipts that feed the next run's context, with a measured hit rate (`context_eval.brief_hit_rate`) on whether the pre-run brief named the files the run actually touched.
+
 ## Next steps
 
 - Read [the cookbook](https://github.com/escoffier-labs/solos-cookbook) for the deep version of every concept here.

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ brigade add ../agentpantry --install # run the manifest install command
 | `tokens` | token-glace | tracks token spend across your harnesses and compacts noisy output |
 | `memory` | memory-doctor, bootstrap-doctor | validates memory cards and bootstrap files for staleness and contradictions |
 | `pantry` | agentpantry | syncs browser sessions and auth across an agent's machine |
-| `search` | code-search | local semantic code search over your repos |
+| `search` | code-search, graphtrail | local semantic search plus a code-graph CLI for callers, impact, and structural diffs |
 | `evidence` | miseledger | a local-first evidence ledger with receipts and source exporters |
 
 ## Harness support

--- a/docs/audit/2026-06-16-improvements-and-features-board.md
+++ b/docs/audit/2026-06-16-improvements-and-features-board.md
@@ -31,9 +31,9 @@ calls still lack the v0.11.0 stdin/timeout fix.
 | 2 | `.brigade/memory-care/decay` created by workspace init | fix | high | S | **shipped** (#79) |
 | 3 | `write_json` atomic (tmp + os.replace) | fix | high | S | **shipped** |
 | 4 | `doctor --json` / `status --json` | feature | high | S | **shipped** |
-| 5 | `security diff --base --against` (by fingerprint) | feature | high | S | proposal |
-| 6 | Parallelize fleet `_repo_summary` (ThreadPoolExecutor) | perf | high | S | proposal |
-| 7 | `brigade operator checkup` (all first-run doctors at once) | feature | high | M | proposal |
+| 5 | `security diff --base --against` (by fingerprint) | feature | high | S | **shipped** (0.12.0) |
+| 6 | Parallelize fleet `_repo_summary` (ThreadPoolExecutor) | perf | high | S | **shipped** (0.12.0) |
+| 7 | `brigade operator checkup` (all first-run doctors at once) | feature | high | M | **shipped** (0.12.0; loop health in Unreleased) |
 
 ## Improvements backlog
 
@@ -75,11 +75,11 @@ calls still lack the v0.11.0 stdin/timeout fix.
 
 ## Specials board (leverage-sorted)
 
-- **[high] `security diff`** - new/fixed/persisting findings between two scans, keyed on the existing stable `_fingerprint` (`security_cmd.py:2282`), mirroring `center` report-diff. `brigade security diff --base <dir> --against <dir> [--json]`, nonzero exit on new findings. S.
-- **[high] `brigade operator checkup`** - one command runs every first-run doctor; `lifecycle.py:581,590` already `_capture_json_call`s `tools`+`skills` doctors in sequence. M. Prereq for the #78 fleet sweep.
-- **[high] Surface read-only enforcement strength per harness in `brigade run`** - `agents.py` enforces `--read-only` natively only for codex et al, prompt-only for goose/grok/amp/crush, and not at all for claude + opencode. Print `WARNING: read-only is best-effort for <harness>` + receipt. S.
-- **[high] Expose memory cards over the existing MCP stdio server** - `skills_cmd.py:1319` `serve_mcp` already implements a zero-dep JSON-RPC stdio server for `skill://`; add a read-only `card://` scheme backed by `_iter_cards`. M.
-- **[high] Generate shell completions** for the 594-subcommand surface - pure argparse tree, walkable, zero-dep. `brigade completions bash|zsh|fish`. M-L.
+- **[shipped] `security diff`** - 0.12.0: fingerprint-keyed new/resolved/persisting findings between two scans.
+- **[shipped] `brigade operator checkup`** - 0.12.0: every first-run doctor in one pass; Unreleased adds optional GraphTrail/MiseLedger loop health (graph/ledger/brief hit rate).
+- **[shipped] Surface read-only enforcement strength per harness in `brigade run`** - 0.12.0 (issue #87).
+- **[shipped] Expose memory cards over the existing MCP stdio server** - 0.12.0 `memory serve-mcp` with `card://` (issue #88).
+- **[shipped] Generate shell completions** - 0.12.0 `brigade completions bash|zsh|fish` (issue #89).
 - **[med] Deterministic keyword search over `memory/cards`** - reuse `_iter_cards`+`_parse_frontmatter`; stdlib precursor to the roadmapped (Later) semantic retrieval. `memory search <term> [--json]`. M.
 - **[med] Route failed runbook steps into work-import** - 30 other sites use `ledger._append_import_records`; runbook closeout (`runbook_cmd.py:370`) does not. M.
 - **[med] `skills uninstall`** to mirror `skills install` - literal inverse, reuses `_install_targets`/`_install_dir` + history receipt. S.
@@ -87,7 +87,7 @@ calls still lack the v0.11.0 stdin/timeout fix.
 - **[med] `projects doctor`** - the one station missing a doctor wrapper; `projects_cmd.health()` already exists. S.
 - **[med] `scrub` receipt + `--json`** - the egress gate is the most safety-critical boundary and the only station with no trail; store summary-only to avoid re-leaking gated PII. S.
 - **[med] AGENTS.md quality lint station (#84)** - `doctor.py:206-258` checks existence + byte budget only. Owner must pin the required-section vocabulary first (brigade's own template uses neither "Definition of Done" nor a handoff-footer heading). M.
-- **[med] `doctor` fleet sweep (#78)** - loop the existing fleet iterator over the operator-doctor payload; build after `operator checkup` + `doctor --json` (shipped). M.
+- **[shipped] `doctor` fleet sweep (#78)** - 0.12.0 `brigade repos doctor --deep` runs operator checkup per fleet repo.
 - **[med] init/doctor detect third-party clones -> recommend `.git/info/exclude` (#81)** - reuse `build_gitignore_block`, recommend-only; needs an owner-identity heuristic. M, med.
 - **[med] Wire `friction scan` staleness into `daily status`** - friction is absent from the daily loop; report latest.json staleness + candidate count, no auto-run. M.
 - **[low] Snapshot on `tools apply`** for rollback (mirror skills install) - `tools_cmd.py:5499` writes with no snapshot. M.

--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -1013,7 +1013,7 @@ Run-receipt signal mapping is fixed and local: `status: ok` records `+1`, `statu
 
 Run receipts usually carry the useful code delta because a non-read-only `brigade run` brackets the worker command itself: GraphTrail syncs before the worker edits, syncs again after the edits, and writes the delta into the run artifacts. Verification runs usually execute after the work, often as tests, linters, docs checks, or receipt checks. Those commands may not edit the source graph at all, so their deltas are commonly absent or no-op even when the preceding worker run made structural code changes.
 
-`brigade outcome rank` and dry-run `brigade outcome reconcile` surface per-artifact counts for scored records whose graph delta is changing or no-op. Verify-sourced and run-receipt-sourced deltas are counted identically once they are in the outcome ledger. These counters are display-only today: promotion, rollback, cooldown, and ranking decisions still use the existing verified outcome rules.
+`brigade outcome rank` and dry-run `brigade outcome reconcile` surface per-artifact counts for scored records whose graph delta is changing or no-op. Verify-sourced and run-receipt-sourced deltas are counted identically once they are in the outcome ledger. Graph counters remain display-only for install/rollback thresholds: promotion, rollback, and cooldown still use verified exit-code signals only.
 
 For those counters, a delta is changing only when `status` is `ok` and `changed_symbol_count` or `edge_churn` is greater than zero. A delta is no-op only when `status` is `ok` and both counts are zero. Zero graph delta does not mean nothing happened: docs-only changes, test-only changes, and pre-v3 body-edit blind spots can still read as no-op.
 
@@ -1031,10 +1031,11 @@ When a non-read-only aboyeur run has both a pre-run code graph brief and a succe
 The metric is set arithmetic over repo-relative file paths: it compares the files named by the pre-run context pack with the files the run structurally touched according to the GraphTrail delta.
 For example, `brief hit rate 0.50 (2/4 files, 2 missed)` means two of four structurally touched files were named in the brief, and two touched files were not.
 
-This is not a quality score.
-It does not say whether the context was useful, sufficient, or correct, only whether the pre-run context pack named the structurally changed files.
-Brief parsing is heuristic, and GraphTrail deltas only see structural code changes.
-Docs-only runs and runs without structural graph changes produce no context eval.
+`outcome capture --run-receipt` copies `context_eval` onto the hash-chained outcome record. `outcome rank` and dry-run `outcome reconcile` then surface the mean `brief_hit_rate` per skill (`brief_hit: 0.750 (n=2)` in text; `brief_hit_rate` / `brief_hit_samples` in JSON). Among artifacts with equal Wilson scores, a higher mean brief hit rate ranks first. Install and rollback thresholds still ignore brief hit rate: a skill that fails verify still demotes, and a skill that only has strong context coverage without verified exits does not auto-install.
+
+This is a coverage quality signal for skill and runbook ranking, not a claim that the context was useful, sufficient, or correct. Brief parsing is heuristic, and GraphTrail deltas only see structural code changes. Docs-only runs and runs without structural graph changes produce no context eval.
+
+`brigade operator checkup` reports optional loop station health alongside the first-run doctors: graph ok (graphtrail + db), ledger ok (miseledger on PATH), and last/mean brief hit rate from recent run receipts. Missing optional stations warn; they never block the checkup ready verdict.
 
 Use `--handoff` to bridge a completed run back into the memory system.
 

--- a/src/brigade/add.py
+++ b/src/brigade/add.py
@@ -24,12 +24,15 @@ def run(target: Path, station: str, *, install_manifest: bool = False) -> int:
         return 2
 
     if single_tool is not None:
-        tools = (single_tool,)
+        tools: tuple[managed.ManagedTool, ...] = (single_tool,)
         print(f"tool {single_tool.name!r} (station {single_tool.station!r})")
-    else:
+    elif st is not None:
         tools = managed.for_station(st.name)
+    else:  # pragma: no cover - guarded above
+        print(f"error: unknown station or tool {station!r}", file=sys.stderr)
+        return 2
     if not tools:
-        if st.name == "skills":
+        if st is not None and st.name == "skills":
             print("station 'skills' ships built-in Brigade skills:")
             for skill_id in DEFAULT_WIRED_SKILLS:
                 print(f"  [built-in] {skill_id}")
@@ -40,7 +43,8 @@ def run(target: Path, station: str, *, install_manifest: bool = False) -> int:
             print()
             print("Run `brigade init --harnesses codex` to wire the built-in skills into Codex.")
             return 0
-        print(f"station {st.name!r} has no managed tools to add.")
+        station_name = st.name if st is not None else station
+        print(f"station {station_name!r} has no managed tools to add.")
         return 0
 
     ctx = _doctor.build_context(target)

--- a/src/brigade/add.py
+++ b/src/brigade/add.py
@@ -18,11 +18,16 @@ def run(target: Path, station: str, *, install_manifest: bool = False) -> int:
         return _run_manifest_add(station, install_manifest=install_manifest)
 
     st = resolve_station(station)
-    if st is None:
-        print(f"error: unknown station {station!r}", file=sys.stderr)
+    single_tool = managed.resolve(station) if st is None else None
+    if st is None and single_tool is None:
+        print(f"error: unknown station or tool {station!r}", file=sys.stderr)
         return 2
 
-    tools = managed.for_station(st.name)
+    if single_tool is not None:
+        tools = (single_tool,)
+        print(f"tool {single_tool.name!r} (station {single_tool.station!r})")
+    else:
+        tools = managed.for_station(st.name)
     if not tools:
         if st.name == "skills":
             print("station 'skills' ships built-in Brigade skills:")

--- a/src/brigade/managed.py
+++ b/src/brigade/managed.py
@@ -247,6 +247,20 @@ def _agent_notify_wire(ctx: DoctorContext) -> List[CheckResult]:
     ]
 
 
+def _graphtrail_doctor(ctx: DoctorContext) -> List[CheckResult]:
+    """Health-check GraphTrail for the target workspace (optional station)."""
+    name = "graphtrail (code graph)"
+    if not proc.which("graphtrail"):
+        return [(MANUAL, name, "not installed; cargo install graphtrail")]
+    db = ctx.target / ".graphtrail" / "graphtrail.db"
+    if not db.is_file():
+        return [(WARN, name, "installed; run `graphtrail sync` to build .graphtrail/graphtrail.db")]
+    r = proc.run(["graphtrail", "doctor", "--json"], timeout=30.0)
+    if r.code != 0:
+        return [(WARN, name, f"doctor exit {r.code}; graph may need re-sync")]
+    return [(OK, name, f"db present at {db}")]
+
+
 # miseledger (which absorbed the stationtrail/sourceharvest exporters in v0.3.0)
 # operates on the operator's host-global evidence archive and local session logs,
 # not a per-target workspace. Like the memory and pantry satellites, its findings
@@ -423,6 +437,22 @@ _TOOLS: Tuple[ManagedTool, ...] = (
             _surface("doctor-json", ("miseledger", "status", "--json"), timeout_seconds=120.0),
             _surface("brief-markdown", ("miseledger", "export", "--markdown"), timeout_seconds=10.0, max_chars=4000),
             _surface("verify-exit", ("miseledger", "doctor"), timeout_seconds=120.0),
+        ),
+    ),
+    # GraphTrail closes the other half of the receipts-to-context loop: code-graph
+    # briefs and deltas on verify/run receipts. Install is cargo-based; doctor is
+    # fail-open (MANUAL when absent) like every other optional sidecar.
+    ManagedTool(
+        name="graphtrail",
+        station="search",
+        command="graphtrail",
+        summary="local code-graph CLI: callers, callees, impact, context briefs, and structural diffs",
+        install_args=["cargo", "install", "graphtrail"],
+        wire=_noop_wire,
+        doctor=_graphtrail_doctor,
+        surfaces=(
+            _surface("verify-exit", ("graphtrail", "--version"), timeout_seconds=10.0),
+            _surface("doctor-json", ("graphtrail", "doctor", "--json"), timeout_seconds=30.0),
         ),
     ),
 )

--- a/src/brigade/operator_cmd/lifecycle.py
+++ b/src/brigade/operator_cmd/lifecycle.py
@@ -834,6 +834,96 @@ def _surface_issue_count(payload: dict[str, Any]) -> int | None:
     return None
 
 
+def _loop_stations_payload(target: Path) -> dict[str, Any]:
+    """Report GraphTrail / MiseLedger / context-eval loop health (informational).
+
+    Optional stations do not block checkup readiness. The point is one glance:
+    graph ok, ledger ok, last evidence brief hit rate.
+    """
+    from .. import context_cmd, evidence_brief
+
+    graph_bin = context_cmd._graphtrail_bin()
+    graph_db = target / ".graphtrail" / "graphtrail.db"
+    if graph_bin and graph_db.is_file():
+        graph = {
+            "ok": True,
+            "status": "ok",
+            "detail": "graphtrail on PATH and .graphtrail/graphtrail.db present",
+        }
+    elif graph_bin:
+        graph = {
+            "ok": False,
+            "status": "missing-db",
+            "detail": "graphtrail on PATH; run `graphtrail sync` to build .graphtrail/graphtrail.db",
+        }
+    else:
+        graph = {
+            "ok": False,
+            "status": "missing-bin",
+            "detail": "graphtrail not on PATH (optional: cargo install graphtrail)",
+        }
+
+    ledger_bin = evidence_brief._miseledger_bin()
+    if ledger_bin:
+        ledger = {
+            "ok": True,
+            "status": "ok",
+            "detail": "miseledger on PATH",
+        }
+    else:
+        ledger = {
+            "ok": False,
+            "status": "missing-bin",
+            "detail": "miseledger not on PATH (optional: brigade add evidence)",
+        }
+
+    rates: list[float] = []
+    runs_root = target / ".brigade" / "runs"
+    if runs_root.is_dir():
+        run_rows: list[tuple[str, float]] = []
+        for child in runs_root.iterdir():
+            if not child.is_dir():
+                continue
+            run_json = child / "run.json"
+            if not run_json.is_file():
+                continue
+            try:
+                payload = json.loads(run_json.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+                continue
+            if not isinstance(payload, dict):
+                continue
+            context_eval = payload.get("context_eval")
+            if not isinstance(context_eval, dict):
+                continue
+            rate = context_eval.get("brief_hit_rate")
+            if isinstance(rate, bool) or not isinstance(rate, (int, float)):
+                continue
+            stamp = str(payload.get("started_at") or child.name)
+            run_rows.append((stamp, float(rate)))
+        run_rows.sort(key=lambda item: item[0], reverse=True)
+        rates = [rate for _, rate in run_rows]
+
+    last_rate = rates[0] if rates else None
+    mean_rate = round(sum(rates) / len(rates), 3) if rates else None
+    return {
+        "graph": graph,
+        "ledger": ledger,
+        "context_eval": {
+            "last_brief_hit_rate": last_rate,
+            "mean_brief_hit_rate": mean_rate,
+            "sample_count": len(rates),
+            "detail": (
+                f"last={last_rate:.3f} mean={mean_rate:.3f} (n={len(rates)})"
+                if rates and last_rate is not None and mean_rate is not None
+                else "no context_eval on recent run receipts"
+            ),
+            "ok": bool(rates),
+            "status": "ok" if rates else "none",
+        },
+    }
+
+
 def checkup_payload(target: Path, *, profile: str = "internal-dogfood") -> dict[str, Any]:
     """Run every read-only first-run doctor once and roll the verdicts up.
 
@@ -842,6 +932,9 @@ def checkup_payload(target: Path, *, profile: str = "internal-dogfood") -> dict[
     single ready/blocking verdict. Each surface's exit code is the source of
     truth for readiness; the issue count is informational. Nothing here writes
     files (security scan and verify-harness are deliberately excluded).
+
+    Also reports optional GraphTrail/MiseLedger loop health (graph / ledger /
+    last evidence brief hit rate). Those stations never block readiness.
     """
     target = target.expanduser().resolve()
     spec = [
@@ -877,6 +970,7 @@ def checkup_payload(target: Path, *, profile: str = "internal-dogfood") -> dict[
         "blocking_surface_count": blocking,
         "surfaces": surfaces,
         "next_command": next_command,
+        "loop": _loop_stations_payload(target),
     }
 
 
@@ -893,6 +987,17 @@ def checkup(*, target: Path, profile: str = "internal-dogfood", json_output: boo
         count = surface["issue_count"]
         suffix = f" ({count} issue{'s' if count != 1 else ''})" if isinstance(count, int) and count else ""
         print(f"  [{mark}] {surface['name']}{suffix}")
+    loop = payload.get("loop") if isinstance(payload.get("loop"), dict) else {}
+    if loop:
+        print("loop:")
+        for key in ("graph", "ledger", "context_eval"):
+            row = loop.get(key)
+            if not isinstance(row, dict):
+                continue
+            mark = "ok" if row.get("ok") else "warn"
+            detail = row.get("detail") or row.get("status") or ""
+            label = "brief_hit_rate" if key == "context_eval" else key
+            print(f"  [{mark}] {label}: {detail}")
     print(f"ready: {'yes' if payload['ready'] else 'no'}")
     print(f"blocking_surfaces: {payload['blocking_surface_count']}")
     if payload["next_command"]:

--- a/src/brigade/outcome_cmd.py
+++ b/src/brigade/outcome_cmd.py
@@ -420,6 +420,48 @@ def _graph_delta_human_suffix(counts: dict[str, int] | None) -> str:
     return f" graph: {counts['graph_changing']} changing / {counts['graph_no_op']} no-op"
 
 
+def _brief_hit_rate_value(value) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def _brief_hit_stats(records: list[core.OutcomeRecord]) -> dict[str, float | int] | None:
+    """Aggregate context_eval.brief_hit_rate across scored records with a rate."""
+    rates: list[float] = []
+    for record in core.scored_records(records):
+        context_eval = record.context_eval
+        if not isinstance(context_eval, dict):
+            continue
+        rate = _brief_hit_rate_value(context_eval.get("brief_hit_rate"))
+        if rate is None:
+            continue
+        rates.append(rate)
+    if not rates:
+        return None
+    mean = round(sum(rates) / len(rates), 3)
+    return {
+        "brief_hit_rate": mean,
+        "brief_hit_samples": len(rates),
+        "brief_hit_min": round(min(rates), 3),
+        "brief_hit_max": round(max(rates), 3),
+    }
+
+
+def _brief_hit_stats_by_artifact(records: list[core.OutcomeRecord]) -> dict[str, dict[str, float | int]]:
+    return {
+        artifact_id: stats
+        for artifact_id, recs in _records_by_artifact(records).items()
+        if (stats := _brief_hit_stats(recs)) is not None
+    }
+
+
+def _brief_hit_human_suffix(stats: dict[str, float | int] | None) -> str:
+    if stats is None:
+        return ""
+    return f" brief_hit: {stats['brief_hit_rate']:.3f} (n={stats['brief_hit_samples']})"
+
+
 def score(*, target: Path, artifact_id: str | None = None, json_output: bool = False) -> int:
     target = target.expanduser().resolve()
     scores = _scores_by_artifact(load_records(target))
@@ -618,6 +660,7 @@ def reconcile(
     records = load_records(target)
     scores = _scores_by_artifact(records)
     graph_counts = _graph_delta_counts_by_artifact(records)
+    brief_stats = _brief_hit_stats_by_artifact(records)
     kinds: dict[str, str] = {}
     for record in records:
         kinds.setdefault(record.artifact_id, record.artifact_kind or "skill")
@@ -696,6 +739,9 @@ def reconcile(
         counts = graph_counts.get(decision.artifact_id)
         if counts is not None:
             item.update(counts)
+        stats = brief_stats.get(decision.artifact_id)
+        if stats is not None:
+            item.update(stats)
         decisions_payload.append(item)
     payload = {
         "target": str(target),
@@ -717,9 +763,10 @@ def reconcile(
         # byte-identical to a dry-run that did nothing.
         tail = f" -> {executions[decision.artifact_id]}" if apply and decision.artifact_id in executions else ""
         graph_tail = _graph_delta_human_suffix(graph_counts.get(decision.artifact_id))
+        brief_tail = _brief_hit_human_suffix(brief_stats.get(decision.artifact_id))
         print(
             f"- {decision.artifact_id} {prior_status} -> {shown_status} "
-            f"[{decision.action}] {decision.reason}{graph_tail}{tail}"
+            f"[{decision.action}] {decision.reason}{graph_tail}{brief_tail}{tail}"
         )
     return 0
 
@@ -729,17 +776,27 @@ def rank(*, target: Path, json_output: bool = False) -> int:
 
     The blended retrieval score (rank_score) leaves room for confidence and
     keyword inputs that the live retrieval path supplies; on its own it orders
-    by what a real signal has confirmed.
+    by what a real signal has confirmed. When context_eval samples exist,
+    mean brief_hit_rate is a secondary quality key so skills whose pre-run
+    context named the files they actually touched rise among equal scores.
+    Install/rollback thresholds still use verified exit-code signals only.
     """
     target = target.expanduser().resolve()
     records = load_records(target)
     scores = _scores_by_artifact(records)
     graph_counts = _graph_delta_counts_by_artifact(records)
+    brief_stats = _brief_hit_stats_by_artifact(records)
 
     def blended(item: core.OutcomeScore) -> float:
         return core.rank_score(confidence=0.0, outcome=item.score, keyword=0.0)
 
-    ordered = sorted(scores.values(), key=lambda item: (-blended(item), item.artifact_id))
+    def sort_key(item: core.OutcomeScore) -> tuple:
+        stats = brief_stats.get(item.artifact_id)
+        # Missing brief samples sort after measured ones at the same Wilson score.
+        hit = float(stats["brief_hit_rate"]) if stats is not None else -1.0
+        return (-blended(item), -hit, item.artifact_id)
+
+    ordered = sorted(scores.values(), key=sort_key)
     ranking_payload = []
     for item in ordered:
         entry = {
@@ -752,6 +809,9 @@ def rank(*, target: Path, json_output: bool = False) -> int:
         counts = graph_counts.get(item.artifact_id)
         if counts is not None:
             entry.update(counts)
+        stats = brief_stats.get(item.artifact_id)
+        if stats is not None:
+            entry.update(stats)
         ranking_payload.append(entry)
     payload = {
         "target": str(target),
@@ -766,7 +826,10 @@ def rank(*, target: Path, json_output: bool = False) -> int:
         return 0
     for item in ordered:
         graph_tail = _graph_delta_human_suffix(graph_counts.get(item.artifact_id))
-        print(f"- {item.artifact_id} score={item.score:.3f} helped={item.helped} hurt={item.hurt}{graph_tail}")
+        brief_tail = _brief_hit_human_suffix(brief_stats.get(item.artifact_id))
+        print(
+            f"- {item.artifact_id} score={item.score:.3f} helped={item.helped} hurt={item.hurt}{graph_tail}{brief_tail}"
+        )
     return 0
 
 

--- a/src/brigade/templates/skills/brigade-work/SKILL.md
+++ b/src/brigade/templates/skills/brigade-work/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: brigade-work
-description: Use at the start of any work session and whenever you verify a change in a Brigade-wired repo or workspace - routes your work through Brigade so verification, outcomes, and handoffs are actually captured instead of leaving Brigade installed-but-dormant. Triggers on starting a task, running tests/checks, or finishing a session.
+description: Use at the start of any work session and whenever you verify a change in a Brigade-wired repo or workspace - routes work through Brigade so verification, outcomes, evidence export, and handoffs are captured (verify with capture → outcome from run → evidence brief next time) instead of leaving Brigade installed-but-dormant. Triggers on starting a task, running tests/checks, or finishing a session.
 ---
 
 # brigade-work
 
-Brigade only earns its keep if real work flows through it. Installed and never used, it is dead weight: the daily brief is empty, the outcome ledger never fills, and `outcome rank` says "ranking: none". This skill is the loop that feeds it. Check what is pending, run your verification *through* Brigade so it produces a signed receipt, record the outcome against the skill or card that did the work, and hand off what you learned.
+Brigade only earns its keep if real work flows through it. Installed and never used, it is dead weight: the daily brief is empty, the outcome ledger never fills, and `outcome rank` says "ranking: none". This skill is the loop that feeds it. Check what is pending, run your verification *through* Brigade so it produces a signed receipt, record the outcome against the skill or card that did the work, export receipts so the next run gets an evidence brief, and hand off what you learned.
 
-**Core principle:** the model never grades its own work. A real exit code captured as a Brigade verify receipt is the only signal that counts. Route verification through Brigade, capture the outcome, and the loop is honest.
+**Core principle:** the model never grades its own work. A real exit code captured as a Brigade verify or run receipt is the only signal that counts. Route verification through Brigade, capture the outcome, feed receipts forward via MiseLedger when installed, and the loop is honest and measured (`context_eval.brief_hit_rate`).
 
 ## When this applies
 
@@ -48,10 +48,25 @@ This is the +1 (passed) or -1 (failed) the learning ratchet scores. Capture on f
 
 Do not invent a skill name you are not running just to have something to capture against.
 
-### 4. Finish: handoff, and let the ratchet run
+### 4. Export receipts so the next run can reuse them (optional stations)
+When GraphTrail and MiseLedger are installed, close the receipts-to-context loop so the next run sees measured evidence, not only a handoff:
+```bash
+brigade receipts export miseledger --target . --new-only --import   # fail-open if miseledger is absent
+# next brigade run attaches a capped evidence brief from MiseLedger automatically
+# or fetch on demand:
+brigade work import context --from-miseledger "auth receipts" --target .
+```
+GraphTrail is what makes the brief measurable: verify/run receipts carry `code_graph_delta`, and non-read-only runs record `context_eval.brief_hit_rate` (did the pre-run context name the files the run actually touched?). `brigade outcome rank` surfaces mean brief hit rate per skill as a quality signal (secondary sort; install/rollback still use exit-code signals only).
+
+One-glance loop health:
+```bash
+brigade operator checkup --target .   # doctors + graph ok / ledger ok / last brief hit rate
+```
+
+### 5. Finish: handoff, and let the ratchet run
 At session end, write a Memory Handoff for any durable knowledge (use your handoff inbox's `TEMPLATE.md`; `brigade handoff-template` prints it). The ratchet then closes itself, on a schedule or by hand:
 ```bash
-brigade outcome rank --target .            # most-proven skills first
+brigade outcome rank --target .            # most-proven skills first (and brief_hit when present)
 brigade outcome reconcile --target .       # dry-run; --apply promotes a proven skill / rolls back a regressed one across harnesses
 ```
 `reconcile --apply` installs a proven skill only if it lives in the registry. To make a candidate skill promotable, accept it first (`brigade skills inbox accept <id>`); the ledger id must match the registry slug. A reconcile that cannot install reports `install-skipped: not in registry` and leaves the skill a candidate (it never silently marks it promoted).
@@ -60,11 +75,14 @@ brigade outcome reconcile --target .       # dry-run; --apply promotes a proven 
 - When a result should count, verification runs through `brigade work verify run`, never raw.
 - Capture an outcome after every verify, naming the skill or card that did the work.
 - One verify, one capture. Never batch or invent outcomes - the receipt is the evidence.
-- End-of-session handoffs stay mandatory; this skill adds the verify-and-capture half of the loop.
+- Prefer run-receipt capture (`outcome capture --run-receipt latest`) when the worker run is what changed code; verify receipts often have no-op graph deltas.
+- Export receipts into MiseLedger when the evidence station is installed so the next run's context is measured, not guessed.
+- End-of-session handoffs stay mandatory; this skill adds the verify-and-capture-and-feed-forward half of the loop.
 
 ## Common mistakes
 - Running tests raw, so the ledger stays empty and `outcome rank` shows "ranking: none" - the exact symptom of an unfed loop.
 - Capturing against a skill you did not actually use, which poisons the ranking.
 - Skipping capture on failures - the -1 signals are the whole point of the ratchet.
 - Treating Brigade as install-and-forget. It is dormant until work flows through it; this skill is how the work flows.
+- Stopping at capture without export: receipts pile up locally and the next `brigade run` has no MiseLedger evidence brief to attach.
 - Putting shell operators in the verify command. `brigade work verify run` splits `--command` with `shlex` and runs it with `shell=False` in the `--target` directory, so `cd x && pytest`, pipes, and `&&` do NOT work. Set the working directory with `--target <dir>` and pass a single command, e.g. `--target ./pkg --command "pytest -q"`.

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -27,7 +27,24 @@ def test_add_installs_and_wires_station_tools(monkeypatch, tmp_target, capsys):
 def test_add_unknown_station_errors(tmp_target, capsys):
     rc = add_mod.run(target=tmp_target, station="nope")
     assert rc == 2
-    assert "unknown station" in capsys.readouterr().err.lower()
+    err = capsys.readouterr().err.lower()
+    assert "unknown station" in err or "unknown station or tool" in err
+
+
+def test_add_accepts_managed_tool_name(monkeypatch, tmp_target, capsys):
+    calls = []
+    monkeypatch.setattr(managed.proc, "which", lambda c: None)
+
+    def fake_run(args, **kw):
+        calls.append(args)
+        return managed.proc.Result(0, "", "")
+
+    monkeypatch.setattr(managed.proc, "run", fake_run)
+    rc = add_mod.run(target=tmp_target, station="graphtrail")
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "graphtrail" in out
+    assert any("cargo" in a for a in calls)
 
 
 def test_add_skips_install_when_already_present(monkeypatch, tmp_target):

--- a/tests/test_managed.py
+++ b/tests/test_managed.py
@@ -202,11 +202,21 @@ def test_evidence_install_args_use_escoffier_labs():
 
 
 def test_search_tools_attach_to_search_station():
-    for name in ("code-search-api", "code-search-mcp"):
+    for name in ("code-search-api", "code-search-mcp", "graphtrail"):
         t = managed.resolve(name)
         assert t is not None and t.station == "search", name
     names = {t.name for t in managed.for_station("search")}
-    assert names == {"code-search-api", "code-search-mcp"}
+    assert names == {"code-search-api", "code-search-mcp", "graphtrail"}
+
+
+def test_graphtrail_doctor_reports_missing_db(monkeypatch, tmp_path):
+    t = managed.resolve("graphtrail")
+    assert t is not None
+    monkeypatch.setattr(managed.proc, "which", lambda c: "/usr/bin/graphtrail" if c == "graphtrail" else None)
+    ctx = DoctorContext(target=tmp_path, selection=None, harnesses=[])
+    results = t.doctor(ctx)
+    assert results[0][0] == "WARN"
+    assert "graphtrail sync" in results[0][2]
 
 
 def test_search_install_args_keep_npm_scope_distinction():

--- a/tests/test_operator_checkup.py
+++ b/tests/test_operator_checkup.py
@@ -46,6 +46,8 @@ def test_operator_checkup_rolls_up_each_first_run_doctor(monkeypatch, capsys):
     assert skills["ready"] is False
     assert skills["issue_count"] == 3
     assert payload["next_command"] == "brigade skills doctor --target ."
+    assert "loop" in payload
+    assert set(payload["loop"]) == {"graph", "ledger", "context_eval"}
 
 
 def test_operator_checkup_is_ready_when_all_surfaces_pass(monkeypatch, capsys):
@@ -56,6 +58,46 @@ def test_operator_checkup_is_ready_when_all_surfaces_pass(monkeypatch, capsys):
     assert payload["ready"] is True
     assert payload["blocking_surface_count"] == 0
     assert payload["next_command"] is None
+
+
+def test_operator_checkup_loop_reports_graph_ledger_and_brief_hit_rate(monkeypatch, tmp_path, capsys):
+    _patch_all_doctors(monkeypatch, skills_rc=0)
+    monkeypatch.setattr("brigade.context_cmd._graphtrail_bin", lambda: "/usr/bin/graphtrail")
+    monkeypatch.setattr("brigade.evidence_brief._miseledger_bin", lambda: "/usr/bin/miseledger")
+    db = tmp_path / ".graphtrail" / "graphtrail.db"
+    db.parent.mkdir(parents=True)
+    db.write_text("ok")
+    run_dir = tmp_path / ".brigade" / "runs" / "2026-07-09T00-00-00Z"
+    run_dir.mkdir(parents=True)
+    (run_dir / "run.json").write_text(
+        json.dumps(
+            {
+                "started_at": "2026-07-09T00:00:00Z",
+                "context_eval": {
+                    "brief_hit_rate": 0.75,
+                    "hits": ["a.py"],
+                    "missed": ["b.py"],
+                },
+            }
+        )
+    )
+
+    rc = lifecycle.checkup(target=tmp_path, json_output=False)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "loop:" in out
+    assert "[ok] graph:" in out
+    assert "[ok] ledger:" in out
+    assert "[ok] brief_hit_rate:" in out
+    assert "last=0.750" in out
+
+    rc = lifecycle.checkup(target=tmp_path, json_output=True)
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["loop"]["graph"]["ok"] is True
+    assert payload["loop"]["ledger"]["ok"] is True
+    assert payload["loop"]["context_eval"]["last_brief_hit_rate"] == 0.75
+    assert payload["loop"]["context_eval"]["sample_count"] == 1
 
 
 def test_operator_checkup_cli_dispatch(monkeypatch, tmp_path):

--- a/tests/test_outcome_cmd.py
+++ b/tests/test_outcome_cmd.py
@@ -769,6 +769,102 @@ def test_rank_human_output_unchanged_without_delta_records(tmp_path, capsys):
     assert capsys.readouterr().out == expected
 
 
+def test_rank_surfaces_brief_hit_rate_and_uses_it_as_secondary_key(tmp_path, capsys):
+    # Equal Wilson scores: skill-high mean hit rate should rank above skill-low.
+    _seed(
+        tmp_path,
+        [
+            outcome.OutcomeRecord(
+                "skill-high",
+                "skill",
+                "t1",
+                "verify",
+                1,
+                "ref-h1",
+                "2026-06-20T00:00:00+00:00",
+                context_eval={"brief_hit_rate": 1.0, "hits": ["a.py"], "missed": []},
+            ),
+            outcome.OutcomeRecord(
+                "skill-high",
+                "skill",
+                "t2",
+                "verify",
+                1,
+                "ref-h2",
+                "2026-06-20T01:00:00+00:00",
+                context_eval={"brief_hit_rate": 0.5, "hits": ["a.py"], "missed": ["b.py"]},
+            ),
+            outcome.OutcomeRecord(
+                "skill-low",
+                "skill",
+                "t3",
+                "verify",
+                1,
+                "ref-l1",
+                "2026-06-20T02:00:00+00:00",
+                context_eval={"brief_hit_rate": 0.0, "hits": [], "missed": ["c.py"]},
+            ),
+            outcome.OutcomeRecord(
+                "skill-low",
+                "skill",
+                "t4",
+                "verify",
+                1,
+                "ref-l2",
+                "2026-06-20T03:00:00+00:00",
+                context_eval={"brief_hit_rate": 0.25, "hits": ["c.py"], "missed": ["d.py", "e.py", "f.py"]},
+            ),
+        ],
+    )
+
+    assert outcome_cmd.rank(target=tmp_path, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    ranking = {item["artifact_id"]: item for item in payload["ranking"]}
+    ids = [item["artifact_id"] for item in payload["ranking"]]
+    assert ids.index("skill-high") < ids.index("skill-low")
+    assert ranking["skill-high"]["brief_hit_rate"] == 0.75
+    assert ranking["skill-high"]["brief_hit_samples"] == 2
+    assert ranking["skill-low"]["brief_hit_rate"] == 0.125
+
+    assert outcome_cmd.rank(target=tmp_path, json_output=False) == 0
+    out = capsys.readouterr().out
+    assert "brief_hit: 0.750 (n=2)" in out
+    assert "brief_hit: 0.125 (n=2)" in out
+
+
+def test_reconcile_json_includes_brief_hit_rate_stats(tmp_path, capsys):
+    _seed(
+        tmp_path,
+        [
+            outcome.OutcomeRecord(
+                "skill-x",
+                "skill",
+                "t1",
+                "verify",
+                1,
+                "ref1",
+                "2026-06-20T00:00:00+00:00",
+                context_eval={"brief_hit_rate": 1.0},
+            ),
+            outcome.OutcomeRecord(
+                "skill-x",
+                "skill",
+                "t2",
+                "verify",
+                1,
+                "ref2",
+                "2026-06-20T01:00:00+00:00",
+                context_eval={"brief_hit_rate": 0.5},
+            ),
+        ],
+    )
+    assert outcome_cmd.reconcile(target=tmp_path, apply=False, json_output=True) == 0
+    decision = {item["artifact_id"]: item for item in json.loads(capsys.readouterr().out)["decisions"]}["skill-x"]
+    assert decision["action"] == "install"
+    assert decision["brief_hit_rate"] == 0.75
+    assert decision["brief_hit_samples"] == 2
+
+
 def test_record_appends_an_explicit_friction_cleared_signal(tmp_path, capsys):
     assert (
         outcome_cmd.record(


### PR DESCRIPTION
## Summary

- Productize the GraphTrail ↔ Brigade ↔ MiseLedger loop after 0.21.0 plumbing: dogfood path in QUICKSTART, `operator checkup` loop health (graph / ledger / brief hit rate), managed `graphtrail` tool plus `brigade add <tool-name>`, and mean `context_eval.brief_hit_rate` as a rank quality signal.
- Teach the full loop in `brigade-work` (verify → capture → export → next-run evidence brief). Install/rollback thresholds stay on verified exit codes; brief hit rate is secondary sort and display only for promotion gates.
- Mark June board control-plane items as already shipped in 0.12.0 (checkup, fleet doctor deep, security diff, completions, card:// MCP).

## Test plan

- [x] `./scripts/verify` (1714 passed, 1 skipped)
- [x] Targeted: `pytest tests/test_operator_checkup.py tests/test_outcome_cmd.py tests/test_managed.py tests/test_add.py`
- [ ] Manual: `brigade operator checkup --target .` shows loop section
- [ ] Manual: `brigade add graphtrail` resolves the tool name and runs cargo install args when missing