### PR TITLE
feat(research): add PageForge web provider with cached fetches

### DIFF
--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -476,6 +476,26 @@ The web tier needs the optional browser dependency, installed once:
 pip install 'brigade[research]' && playwright install chromium
 ```
 
+PageForge can serve as the web provider when you want searches and fetched pages banked in its local SQLite cache instead of reading each page through headless Chromium:
+
+```toml
+[search]
+research_search_provider = "pageforge"
+pageforge_command = ["node", "/path/to/pageforge/bin/pageforge.js"]
+pageforge_db_path = "/path/to/pageforge.sqlite"
+pageforge_timeout = 120
+```
+
+Then run:
+
+```bash
+brigade research run "latest on X" --web --provider pageforge
+```
+
+`pageforge_command` is the argv prefix Brigade calls before `search_web`, `ingest_url`, and `get`.
+`pageforge_db_path` is optional. When set, Brigade passes it to PageForge as `--db`.
+If PageForge extracts only very short markdown from a fetched page, Brigade tries the Playwright reader once and keeps the PageForge result if that fallback is unavailable or still thin.
+
 Local-only runs need no extra dependency. Without the extra, `--web` records a blocker telling you to install it rather than crashing.
 
 ### Daily Work Loop

--- a/src/brigade/research/sources/web.py
+++ b/src/brigade/research/sources/web.py
@@ -1,5 +1,7 @@
 # src/brigade/research/sources/web.py
 from __future__ import annotations
+import json
+import subprocess
 from typing import Any, Callable, Dict, List, Optional
 from urllib.parse import quote_plus
 
@@ -83,10 +85,116 @@ class SearxngProvider:
         return PlaywrightProvider().fetch(url)
 
 
+class PageforgeProvider:
+    trust = "web"
+
+    def __init__(self, command: list[str], db_path: Optional[str] = None, timeout: int = 120) -> None:
+        if not command or not isinstance(command, list) or not all(isinstance(part, str) for part in command):
+            raise ValueError("missing search.pageforge_command; configure a non-empty list of argv strings")
+        self.command = list(command)
+        self.db_path = db_path
+        self.timeout = timeout
+
+    def _run(self, args: list[str]) -> subprocess.CompletedProcess[str]:
+        argv = self.command + args
+        if self.db_path:
+            argv += ["--db", self.db_path]
+        return subprocess.run(
+            argv,
+            text=True,
+            capture_output=True,
+            timeout=self.timeout,
+            check=False,
+            shell=False,
+        )
+
+    @staticmethod
+    def _error(proc: subprocess.CompletedProcess[str], fallback: str) -> str:
+        message = "\n".join(part for part in (proc.stderr.strip(), proc.stdout.strip()) if part)
+        return message or fallback
+
+    def search(self, query: str, limit: int) -> List[Dict[str, str]]:
+        if limit < 1:
+            return []
+        try:
+            proc = self._run(["search_web", query, "--limit", str(limit), "--format", "json", "--compact"])
+            if proc.returncode != 0:
+                return []
+            data = json.loads(proc.stdout)
+            results = data.get("results", []) if isinstance(data, dict) and data.get("ok", True) is not False else []
+            if not isinstance(results, list):
+                return []
+            return [
+                {"url": str(item["url"]), "title": str(item.get("title") or "")}
+                for item in results[:limit]
+                if isinstance(item, dict) and item.get("url")
+            ]
+        except (OSError, subprocess.TimeoutExpired, json.JSONDecodeError, KeyError, TypeError, ValueError):
+            return []
+
+    def fetch(self, url: str) -> Dict[str, Any]:
+        try:
+            proc = self._run(["ingest_url", url, "--compact"])
+            if proc.returncode != 0:
+                return {
+                    "success": False,
+                    "content": "",
+                    "title": "",
+                    "error": self._error(proc, "pageforge ingest failed"),
+                }
+            data = json.loads(proc.stdout)
+            if not isinstance(data, dict) or data.get("ok", True) is False:
+                return {"success": False, "content": "", "title": "", "error": "pageforge ingest failed"}
+            page = data.get("page", {})
+            if not isinstance(page, dict):
+                page = {}
+            page_id = data.get("pageId") or page.get("pageId")
+            if page_id is None:
+                return {
+                    "success": False,
+                    "content": "",
+                    "title": "",
+                    "error": "pageforge ingest response missing pageId",
+                }
+            title = str(page.get("title") or "")
+
+            proc = self._run(["get", str(page_id), "--format", "markdown"])
+            if proc.returncode != 0:
+                return {
+                    "success": False,
+                    "content": "",
+                    "title": "",
+                    "error": self._error(proc, "pageforge get failed"),
+                }
+            result: Dict[str, Any] = {"success": True, "content": proc.stdout, "title": title}
+        except (OSError, subprocess.TimeoutExpired, json.JSONDecodeError, TypeError, ValueError) as exc:
+            return {"success": False, "content": "", "title": "", "error": str(exc)}
+
+        if len(str(result["content"])) >= 200:
+            return result
+        try:
+            fallback = PlaywrightProvider().fetch(url)
+        except Exception:
+            return result
+        if fallback.get("success") and len(str(fallback.get("content") or "")) >= 200:
+            return fallback
+        return result
+
+
 def build_provider(name: Optional[str], settings: Dict[str, Any]):
     name = (name or settings.get("research_search_provider") or "playwright").strip()
     if name in ("playwright", "browser", ""):
         return PlaywrightProvider()
     if name == "searxng":
         return SearxngProvider(settings["searxng_url"])
+    if name == "pageforge":
+        if "pageforge_command" not in settings:
+            raise ValueError("missing search.pageforge_command; configure the PageForge argv prefix")
+        timeout = settings.get("pageforge_timeout", 120)
+        timeout_int = int(timeout) if isinstance(timeout, int) and timeout > 0 else 120
+        return PageforgeProvider(
+            settings["pageforge_command"],
+            db_path=settings.get("pageforge_db_path"),
+            timeout=timeout_int,
+        )
     raise ValueError(f"unknown search provider: {name}")

--- a/src/brigade/research_cmd.py
+++ b/src/brigade/research_cmd.py
@@ -620,6 +620,33 @@ def sources_payload(*, target: Path) -> Dict[str, Any]:
                 "trust": "web",
             }
         )
+    if web_provider == "pageforge" or settings.get("pageforge_command"):
+        command = clisrc._command_parts(settings.get("pageforge_command"))
+        executable = command[0] if command else ""
+        executable_path = Path(executable).expanduser()
+        if "/" in executable and not executable_path.is_absolute():
+            executable_path = target / executable_path
+        exists = bool(executable) and (
+            executable_path.exists() if "/" in executable else shutil.which(executable) is not None
+        )
+        if not command:
+            status = "fail"
+            detail = "missing search.pageforge_command"
+        elif exists:
+            status = "ok"
+            detail = "configured PageForge web search with local cache"
+        else:
+            status = "fail"
+            detail = "configured PageForge executable not found"
+        routes.append(
+            {
+                "id": "pageforge",
+                "type": "web",
+                "status": status,
+                "detail": detail,
+                "trust": "web",
+            }
+        )
 
     # _safe_source_adapters drops typeless entries, so pair against the same filter.
     typed_adapters = [entry for entry in adapters if str(entry.get("type") or "").strip()]

--- a/tests/test_research_cmd.py
+++ b/tests/test_research_cmd.py
@@ -162,6 +162,23 @@ def test_sources_payload_reports_configured_cli_source(tmp_path: Path):
     assert route["accepts_query"] is True
 
 
+def test_sources_payload_reports_pageforge_status(tmp_path: Path):
+    (tmp_path / ".brigade").mkdir()
+    (tmp_path / ".brigade" / "research.toml").write_text(
+        "[search]\n"
+        'research_search_provider = "pageforge"\n'
+        f'pageforge_command = ["{sys.executable}", "-c", "print(\'ok\')"]\n'
+        'pageforge_db_path = "/tmp/pageforge.db"\n'
+    )
+
+    payload = research_cmd.sources_payload(target=tmp_path)
+    route = next(route for route in payload["routes"] if route["id"] == "pageforge")
+    assert route["status"] == "ok"
+    assert route["type"] == "web"
+    assert route["trust"] == "web"
+    assert "local cache" in route["detail"]
+
+
 def test_antigravity_source_adapter_is_cli_lane(tmp_path: Path):
     (tmp_path / ".brigade").mkdir()
     (tmp_path / ".brigade" / "research.toml").write_text(

--- a/tests/test_research_web.py
+++ b/tests/test_research_web.py
@@ -1,4 +1,7 @@
 # tests/test_research_web.py
+import json
+import subprocess
+
 import pytest
 from brigade.research.sources import web
 
@@ -42,3 +45,150 @@ def test_provider_factory_default_is_playwright():
     prov = web.build_provider(None, {})
     assert isinstance(prov, web.PlaywrightProvider)
     assert prov.trust == "browser"
+
+
+def test_pageforge_requires_non_empty_string_command():
+    with pytest.raises(ValueError) as exc:
+        web.PageforgeProvider([])
+    assert "pageforge_command" in str(exc.value)
+
+    with pytest.raises(ValueError):
+        web.PageforgeProvider(["node", 123])
+
+
+def test_pageforge_search_returns_titles_and_urls(monkeypatch):
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        payload = {
+            "ok": True,
+            "results": [
+                {"url": "https://example.com/a", "title": "A"},
+                {"url": "https://example.com/b", "title": "B"},
+                {"url": "https://example.com/c", "title": "C"},
+            ],
+        }
+        return subprocess.CompletedProcess(argv, 0, stdout=json.dumps(payload), stderr="")
+
+    monkeypatch.setattr(web.subprocess, "run", fake_run)
+    prov = web.PageforgeProvider(["pageforge"], db_path="/tmp/pageforge.db")
+
+    assert prov.search("test query", 2) == [
+        {"url": "https://example.com/a", "title": "A"},
+        {"url": "https://example.com/b", "title": "B"},
+    ]
+    assert calls[0][0] == [
+        "pageforge",
+        "search_web",
+        "test query",
+        "--limit",
+        "2",
+        "--format",
+        "json",
+        "--compact",
+        "--db",
+        "/tmp/pageforge.db",
+    ]
+    assert calls[0][1]["shell"] is False
+
+
+def test_pageforge_search_errors_return_empty(monkeypatch):
+    def fake_run(argv, **kwargs):
+        return subprocess.CompletedProcess(argv, 1, stdout="", stderr="search failed")
+
+    monkeypatch.setattr(web.subprocess, "run", fake_run)
+    prov = web.PageforgeProvider(["pageforge"])
+
+    assert prov.search("test query", 2) == []
+
+
+def test_pageforge_fetch_ingests_then_reads_markdown(monkeypatch):
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append(argv)
+        if argv[1] == "ingest_url":
+            payload = {"ok": True, "pageId": "page-1", "page": {"title": "Example title"}}
+            return subprocess.CompletedProcess(argv, 0, stdout=json.dumps(payload), stderr="")
+        return subprocess.CompletedProcess(argv, 0, stdout="Long markdown content " * 20, stderr="")
+
+    monkeypatch.setattr(web.subprocess, "run", fake_run)
+    prov = web.PageforgeProvider(["pageforge"])
+
+    result = prov.fetch("https://example.com")
+
+    assert result["success"] is True
+    assert result["title"] == "Example title"
+    assert result["content"].startswith("Long markdown content")
+    assert calls == [
+        ["pageforge", "ingest_url", "https://example.com", "--compact"],
+        ["pageforge", "get", "page-1", "--format", "markdown"],
+    ]
+
+
+def test_pageforge_fetch_failure_returns_error(monkeypatch):
+    def fake_run(argv, **kwargs):
+        return subprocess.CompletedProcess(argv, 1, stdout="", stderr="ingest failed")
+
+    monkeypatch.setattr(web.subprocess, "run", fake_run)
+    prov = web.PageforgeProvider(["pageforge"])
+
+    result = prov.fetch("https://example.com")
+
+    assert result["success"] is False
+    assert result["content"] == ""
+    assert "ingest failed" in result["error"]
+
+
+def test_pageforge_fetch_uses_playwright_for_thin_content(monkeypatch):
+    def fake_run(argv, **kwargs):
+        if argv[1] == "ingest_url":
+            payload = {"ok": True, "pageId": 7, "page": {"title": "Short"}}
+            return subprocess.CompletedProcess(argv, 0, stdout=json.dumps(payload), stderr="")
+        return subprocess.CompletedProcess(argv, 0, stdout="short", stderr="")
+
+    class FakePlaywright:
+        def fetch(self, url):
+            return {"success": True, "content": "Fallback content " * 20, "title": "Fallback"}
+
+    monkeypatch.setattr(web.subprocess, "run", fake_run)
+    monkeypatch.setattr(web, "PlaywrightProvider", FakePlaywright)
+    prov = web.PageforgeProvider(["pageforge"])
+
+    result = prov.fetch("https://example.com")
+
+    assert result["success"] is True
+    assert result["title"] == "Fallback"
+    assert result["content"].startswith("Fallback content")
+
+
+def test_pageforge_fetch_keeps_thin_pageforge_success_when_fallback_fails(monkeypatch):
+    def fake_run(argv, **kwargs):
+        if argv[1] == "ingest_url":
+            payload = {"ok": True, "pageId": 7, "page": {"title": "Short"}}
+            return subprocess.CompletedProcess(argv, 0, stdout=json.dumps(payload), stderr="")
+        return subprocess.CompletedProcess(argv, 0, stdout="short", stderr="")
+
+    class FakePlaywright:
+        def fetch(self, url):
+            raise web.PlaywrightUnavailable("missing")
+
+    monkeypatch.setattr(web.subprocess, "run", fake_run)
+    monkeypatch.setattr(web, "PlaywrightProvider", FakePlaywright)
+    prov = web.PageforgeProvider(["pageforge"])
+
+    result = prov.fetch("https://example.com")
+
+    assert result == {"success": True, "content": "short", "title": "Short"}
+
+
+def test_provider_factory_builds_pageforge():
+    prov = web.build_provider(
+        "pageforge",
+        {"pageforge_command": ["node", "/opt/pageforge/bin/pageforge.js"], "pageforge_db_path": "/tmp/pf.db"},
+    )
+
+    assert isinstance(prov, web.PageforgeProvider)
+    assert prov.command == ["node", "/opt/pageforge/bin/pageforge.js"]
+    assert prov.db_path == "/tmp/pf.db"


### PR DESCRIPTION
## What

Adds a `pageforge` web-tier provider to the deep research lane. Search and page fetches route through the external PageForge CLI instead of headless Chromium.

## Why

The current web tier launches Chromium for every fetched page and throws the content away after the run. Routing fetches through PageForge gives research runs clean boilerplate-stripped markdown and banks every page in a local SQLite cache, so later runs on similar topics read from disk instead of the web.

## How

- `PageforgeProvider` in `sources/web.py`: `search` shells to `pageforge search_web --format json`, `fetch` chains `ingest_url` then `get --format markdown`. All subprocess failures degrade to empty results or a structured error instead of crashing the loop.
- Thin extractions (under 200 chars) fall back to the Playwright reader once when available; fallback failures keep the PageForge result.
- `build_provider` wires `research_search_provider = "pageforge"` with `pageforge_command`, optional `pageforge_db_path`, and `pageforge_timeout`.
- `research sources list/doctor` gains a pageforge row that validates the configured executable exists.
- Docs: config snippet and behavior notes in the technical guide.

## Verification

- `brigade work verify run --target . --command ".venv/bin/python -m pytest -q"`: 1729 passed, 1 skipped (receipt 20260709-061156-work-verify-040921)
- Live end to end against a local PageForge install and SearXNG: 3 search hits, fetch returned 165k chars of stored markdown
- The live smoke caught and fixed one integration bug the mocks missed: PageForge's CLI defaults search output to markdown, so the provider passes `--format json` explicitly