### PR TITLE
feat(model): scorecard aggregating per-model outcomes from run artifacts

### DIFF
--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -377,6 +377,61 @@ When `--roster` is omitted, `brigade run` first reads `--cwd/.brigade/roster.tom
 if that file is missing, it falls back to `Path.home()/.brigade/roster.toml`.
 Passing `--roster` keeps using exactly that file.
 
+### Model scorecard
+
+`brigade model scorecard` aggregates run artifacts from `.brigade/runs` into a per-model summary. It is read-only: it never writes or networks. Rows group by `(cli, model)`; a missing or empty `model` is shown as the CLI alone (for example `codex`), otherwise as `cli/model` (for example `claude/claude-fable-5`). The scorecard reads the same run artifacts that `brigade runs show` inspects.
+
+Metrics per row:
+
+- `runs` - distinct run directories that seat the model.
+- `seats` - `worker_seats + orchestrator_seats` (printed as `workers+orchestrators`, for example `6+2`).
+- `w_ok` - worker results with `ok: true`.
+- `ok_rate` - `worker_ok / worker_seats` (0 if no worker seats); shown as a percentage.
+- `noop` - suspected no-op run count for that model (see below).
+- `mean_dur` - mean of `duration_seconds` across the model's runs.
+- `first_seen` / `last_seen` - min/max `started_at` among contributing runs.
+
+Rows sort by `ok_rate` descending, then `seats` descending, then label ascending. A footer shows `scanned: N  skipped: M` (`skipped` counts malformed or missing artifact dirs, not runs filtered by `--since`).
+
+Flags:
+
+- `--target` / `-t` - workspace whose `.brigade/runs` directory is scanned (default `.`).
+- `--runs-dir` - explicit runs directory; repeatable. With the CLI (which always has a target), each `--runs-dir` is an extra root and the target's `.brigade/runs` is still scanned. A library call with only `runs_dirs` and no `target` scans just those directories.
+- `--since YYYY-MM-DD` - only include runs with `started_at` on or after that UTC date at 00:00:00Z. Invalid date exits 2 with `error: --since must use YYYY-MM-DD` on stderr.
+- `--json` - emit machine-readable JSON (`indent=2`, `sort_keys`) instead of the text table. Shape includes `models[]`, `scanned`, `skipped`, and `skipped_dirs[{path,reason}]`. Each model object includes `cli`, `model`, `label`, `runs`, `seats`, `worker_seats`, `orchestrator_seats`, `worker_ok`, `ok_rate`, `suspected_no_op`, `mean_duration_seconds`, `total_duration_seconds`, `first_seen`, and `last_seen`.
+- `--verbose` / `-v` - after the table and footer, list skipped run directories and skip reasons.
+
+A run contributes to a model's `noop` count only when all of the following hold:
+
+1. At least one worker result for that model has `ok: true`.
+2. `worker-results.json` ground_truth is available (`available` is true).
+3. After ignoring housekeeping paths, there are no real changed files: either `changed_files` is null or absent, or every entry is under `.brigade/` (paths starting with `.brigade/` or exactly `.brigade`).
+
+The count is per run per model (at most once per run), not per worker seat. Failed workers with empty changes do not count. Ok workers with ground_truth unavailable do not count. Ok workers with real non-`.brigade/` changed files do not count.
+
+```bash
+brigade model scorecard
+brigade model scorecard --target /path/to/repo
+brigade model scorecard --target /path/to/repo --since 2026-05-01
+brigade model scorecard --runs-dir /path/to/archive/runs --runs-dir /path/to/other/runs
+brigade model scorecard --target /path/to/repo --json
+brigade model scorecard --target /path/to/repo --verbose
+```
+
+Sample output:
+
+```
+model                  runs  seats  w_ok  ok_rate  noop  mean_dur  first_seen            last_seen
+---------------------  ----  -----  ----  -------  ----  --------  --------------------  --------------------
+claude/claude-fable-5  4     6+2    5      83.3%   1     12.0s     2026-05-01T12:00:00Z  2026-06-15T09:30:00Z
+codex/gpt-5.5          3     3+0    2      66.7%   0     30.0s     2026-05-10T08:00:00Z  2026-06-10T18:00:00Z
+codex                  5     0+5    0       0.0%   0     6.0s      2026-04-20T00:00:00Z  2026-06-01T00:00:00Z
+
+scanned: 12  skipped: 1
+```
+
+If no model seats are found, the table is replaced with `no model seats found` and the scanned/skipped footer is still printed.
+
 ### Dogfood
 
 `brigade dogfood` is the shortcut for using Brigade on itself or another trusted repo.

--- a/src/brigade/cli/__init__.py
+++ b/src/brigade/cli/__init__.py
@@ -53,6 +53,7 @@ from . import (
     projects as _projects_group,
     learn as _learn_group,
     outcome as _outcome_group,
+    model as _model_group,
     research as _research_group,
     center as _center_group,
     run as _run_group,
@@ -149,6 +150,7 @@ def _build_parser() -> argparse.ArgumentParser:
     _register_extras(sub, "projects", extras_enabled)
     _register_extras(sub, "learn", extras_enabled)
     _outcome_group.register(sub)
+    _model_group.register(sub)
     _register_extras(sub, "research", extras_enabled)
     _register_extras(sub, "center", extras_enabled)
     _run_group.register(sub)

--- a/src/brigade/cli/_common.py
+++ b/src/brigade/cli/_common.py
@@ -20,7 +20,10 @@ COMMAND_GROUPS: list[tuple[str, list[str]]] = [
         "Daily operator loop",
         ["operator", "daily", "work", "friction", "workflow", "center", "runbook", "budgets", "notifications"],
     ),
-    ("Stations and tools", ["add", "stations", "skills", "tools", "mcp", "pantry", "roster", "run", "runs", "dogfood"]),
+    (
+        "Stations and tools",
+        ["add", "stations", "skills", "tools", "mcp", "pantry", "roster", "run", "runs", "model", "dogfood"],
+    ),
     (
         "Review, security, and research",
         ["security", "guard", "scrub", "untrusted", "research", "learn", "outcome", "chat", "context", "projects"],

--- a/src/brigade/cli/model.py
+++ b/src/brigade/cli/model.py
@@ -1,0 +1,57 @@
+"""brigade model command group."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p_model = sub.add_parser("model", help="Inspect model performance across Brigade runs.")
+    model_sub = p_model.add_subparsers(dest="model_command", metavar="<model-command>")
+    model_sub.required = True
+
+    p_scorecard = model_sub.add_parser(
+        "scorecard",
+        help="Aggregate run artifacts into a per-(cli, model) scorecard (read-only).",
+    )
+    p_scorecard.add_argument(
+        "--target",
+        "-t",
+        type=Path,
+        default=Path("."),
+        help="Workspace whose .brigade/runs directory should be scanned (default: .).",
+    )
+    p_scorecard.add_argument(
+        "--runs-dir",
+        type=Path,
+        action="append",
+        default=None,
+        dest="runs_dirs",
+        help="Explicit runs directory (repeatable). When set, replaces the default under --target.",
+    )
+    p_scorecard.add_argument(
+        "--since",
+        default=None,
+        help="Only include runs with started_at on or after this UTC date (YYYY-MM-DD).",
+    )
+    p_scorecard.add_argument("--json", action="store_true", help="Emit machine-readable JSON instead of text.")
+    p_scorecard.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="List skipped run directories and skip reasons.",
+    )
+    p_scorecard.set_defaults(func=_dispatch_scorecard)
+
+
+def _dispatch_scorecard(args) -> int:
+    from .. import model_scorecard
+
+    return model_scorecard.scorecard(
+        target=args.target,
+        runs_dirs=args.runs_dirs,
+        since=args.since,
+        json_output=args.json,
+        verbose=args.verbose,
+    )

--- a/src/brigade/model_scorecard.py
+++ b/src/brigade/model_scorecard.py
@@ -1,0 +1,517 @@
+"""Read-only model scorecard over Brigade run artifacts.
+
+Aggregates roster + worker-results under ``.brigade/runs/*`` (or explicit
+``--runs-dir`` roots) by ``(cli, model)``. Missing/null model is shown as the
+CLI alone. Never writes, never networks.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, time, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+
+@dataclass(frozen=True)
+class SkippedDir:
+    path: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class ModelRow:
+    cli: str
+    model: str | None
+    runs: int
+    worker_seats: int
+    orchestrator_seats: int
+    worker_ok: int
+    suspected_no_op: int
+    total_duration_seconds: float
+    first_seen: str | None
+    last_seen: str | None
+
+    @property
+    def label(self) -> str:
+        if self.model:
+            return f"{self.cli}/{self.model}"
+        return self.cli
+
+    @property
+    def seats(self) -> int:
+        return self.worker_seats + self.orchestrator_seats
+
+    @property
+    def ok_rate(self) -> float:
+        if self.worker_seats <= 0:
+            return 0.0
+        return self.worker_ok / self.worker_seats
+
+    @property
+    def mean_duration_seconds(self) -> float:
+        if self.runs <= 0:
+            return 0.0
+        return self.total_duration_seconds / self.runs
+
+
+@dataclass(frozen=True)
+class Scorecard:
+    models: list[ModelRow]
+    scanned: int
+    skipped: int
+    skipped_dirs: list[SkippedDir] = field(default_factory=list)
+
+
+@dataclass
+class _Acc:
+    cli: str
+    model: str | None
+    run_ids: set[str] = field(default_factory=set)
+    worker_seats: int = 0
+    orchestrator_seats: int = 0
+    worker_ok: int = 0
+    suspected_no_op_runs: set[str] = field(default_factory=set)
+    total_duration_seconds: float = 0.0
+    first_seen: str | None = None
+    last_seen: str | None = None
+
+    def note_seen(self, started_at: str | None, run_id: str, duration: float | None) -> None:
+        if run_id not in self.run_ids:
+            self.run_ids.add(run_id)
+            if isinstance(duration, (int, float)):
+                self.total_duration_seconds += float(duration)
+        if not started_at:
+            return
+        if self.first_seen is None or started_at < self.first_seen:
+            self.first_seen = started_at
+        if self.last_seen is None or started_at > self.last_seen:
+            self.last_seen = started_at
+
+    def to_row(self) -> ModelRow:
+        return ModelRow(
+            cli=self.cli,
+            model=self.model,
+            runs=len(self.run_ids),
+            worker_seats=self.worker_seats,
+            orchestrator_seats=self.orchestrator_seats,
+            worker_ok=self.worker_ok,
+            suspected_no_op=len(self.suspected_no_op_runs),
+            total_duration_seconds=self.total_duration_seconds,
+            first_seen=self.first_seen,
+            last_seen=self.last_seen,
+        )
+
+
+def _model_key(cli: str, model: Any) -> tuple[str, str | None]:
+    if model is None or model == "":
+        return cli, None
+    return cli, str(model)
+
+
+def _parse_since(value: str | None) -> datetime | None:
+    if value is None:
+        return None
+    try:
+        parsed_date = datetime.strptime(value, "%Y-%m-%d").date()
+    except ValueError as exc:
+        raise ValueError("--since must use YYYY-MM-DD") from exc
+    return datetime.combine(parsed_date, time.min, tzinfo=timezone.utc)
+
+
+def _parse_started_at(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _read_json_object(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    if not path.is_file():
+        return None, f"missing {path.name}"
+    try:
+        raw = path.read_text()
+    except OSError as exc:
+        return None, f"unreadable {path.name}: {exc}"
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return None, f"invalid {path.name}: {exc}"
+    if not isinstance(payload, dict):
+        return None, f"{path.name} must be a JSON object"
+    return payload, None
+
+
+def _default_runs_dirs(target: Path) -> list[Path]:
+    return [target.expanduser().resolve() / ".brigade" / "runs"]
+
+
+def _resolve_runs_dirs(
+    *,
+    target: Path | None,
+    runs_dirs: Iterable[Path] | None,
+) -> list[Path]:
+    # --runs-dir roots are EXTRA artifact roots: when a target is given its
+    # default runs dir is always scanned too, so combining the flags never
+    # silently drops the target's runs. Bare runs_dirs scan only themselves.
+    roots: list[Path] = []
+    if target is not None or not runs_dirs:
+        roots.extend(_default_runs_dirs(target if target is not None else Path(".")))
+    for p in runs_dirs or []:
+        resolved = Path(p).expanduser().resolve()
+        if resolved not in roots:
+            roots.append(resolved)
+    return roots
+
+
+def _agent_cli_model(agent: dict[str, Any]) -> tuple[str, str | None] | None:
+    cli = agent.get("cli")
+    if not isinstance(cli, str) or not cli:
+        return None
+    model = agent.get("model")
+    if model is not None and not isinstance(model, str):
+        model = str(model) if model != "" else None
+    if model == "":
+        model = None
+    return _model_key(cli, model)
+
+
+def _ground_truth_empty_changes(gt: Any) -> bool:
+    if not isinstance(gt, dict):
+        return False
+    if gt.get("available") is not True:
+        return False
+    changed = gt.get("changed_files")
+    if changed is None:
+        return True
+    if not isinstance(changed, list):
+        return False
+    # .brigade/ entries are run housekeeping (roster edits, artifacts), not
+    # task output; a run whose only changes live there still did no work.
+    real = [
+        f
+        for f in changed
+        if isinstance(f, str) and not f.startswith(".brigade/") and f != ".brigade"
+    ]
+    return len(real) == 0
+
+
+def build_scorecard(
+    *,
+    target: Path | None = None,
+    runs_dirs: Iterable[Path] | None = None,
+    since: str | None = None,
+) -> Scorecard:
+    """Scan run dirs and aggregate per (cli, model). Never raises on bad dirs."""
+    since_dt = _parse_since(since)
+    roots = _resolve_runs_dirs(target=target, runs_dirs=runs_dirs)
+
+    acc: dict[tuple[str, str | None], _Acc] = {}
+    scanned = 0
+    skipped_dirs: list[SkippedDir] = []
+
+    for root in roots:
+        if not root.is_dir():
+            skipped_dirs.append(SkippedDir(path=str(root), reason="runs directory not found"))
+            continue
+        try:
+            children = sorted(root.iterdir(), key=lambda p: p.name)
+        except OSError as exc:
+            skipped_dirs.append(SkippedDir(path=str(root), reason=f"unreadable: {exc}"))
+            continue
+        for child in children:
+            if not child.is_dir():
+                continue
+            # Snapshot acc size pattern: scan may mutate then decide to skip on
+            # corrupt worker-results. Use a per-run temp acc merge instead.
+            local: dict[tuple[str, str | None], _Acc] = {}
+            ok, reason = _scan_run_dir(child, since=since_dt, into=local)
+            if reason is not None:
+                skipped_dirs.append(SkippedDir(path=str(child), reason=reason))
+                continue
+            if not ok:
+                # Filtered by --since (or empty participation): not skipped.
+                continue
+            scanned += 1
+            _merge_acc(acc, local)
+
+    rows = [bucket.to_row() for bucket in acc.values()]
+    rows.sort(key=lambda r: (-r.ok_rate, -r.seats, r.label))
+    return Scorecard(
+        models=rows,
+        scanned=scanned,
+        skipped=len(skipped_dirs),
+        skipped_dirs=skipped_dirs,
+    )
+
+
+def _scan_run_dir(
+    run_dir: Path,
+    *,
+    since: datetime | None,
+    into: dict[tuple[str, str | None], _Acc],
+) -> tuple[bool, str | None]:
+    """Parse one run dir into ``into``. Mutates only on full success.
+
+    Returns (scanned, skip_reason). skip_reason set => malformed/partial.
+    scanned False and skip_reason None => filtered out (e.g. --since).
+    """
+    run_meta, err = _read_json_object(run_dir / "run.json")
+    if err is not None:
+        return False, err
+    assert run_meta is not None
+
+    roster, err = _read_json_object(run_dir / "roster.json")
+    if err is not None:
+        return False, err
+    assert roster is not None
+
+    agents_raw = roster.get("agents")
+    if not isinstance(agents_raw, dict):
+        return False, "roster.json agents missing or not an object"
+
+    started_at_raw = run_meta.get("started_at")
+    started_at = str(started_at_raw) if isinstance(started_at_raw, str) else None
+    if since is not None:
+        started_dt = _parse_started_at(started_at)
+        if started_dt is None or started_dt < since:
+            return False, None
+
+    duration = run_meta.get("duration_seconds")
+    duration_f = float(duration) if isinstance(duration, (int, float)) else None
+
+    orchestrator_name = roster.get("orchestrator")
+    if not isinstance(orchestrator_name, str):
+        orch_meta = run_meta.get("orchestrator")
+        orchestrator_name = orch_meta if isinstance(orch_meta, str) else None
+
+    run_id = str(run_dir.resolve())
+    agent_keys: dict[str, tuple[str, str | None]] = {}
+
+    wr_path = run_dir / "worker-results.json"
+    worker_payload: dict[str, Any] | None = None
+    if wr_path.is_file():
+        worker_payload, wr_err = _read_json_object(wr_path)
+        if wr_err is not None:
+            return False, wr_err
+
+    # All inputs valid — mutate into.
+    for name, agent in agents_raw.items():
+        if not isinstance(name, str) or not isinstance(agent, dict):
+            continue
+        key = _agent_cli_model(agent)
+        if key is None:
+            continue
+        agent_keys[name] = key
+        bucket = into.get(key)
+        if bucket is None:
+            bucket = _Acc(cli=key[0], model=key[1])
+            into[key] = bucket
+        bucket.note_seen(started_at, run_id, duration_f)
+        if orchestrator_name is not None and name == orchestrator_name:
+            bucket.orchestrator_seats += 1
+
+    results: list[Any] = []
+    ground_truth: Any = None
+    if worker_payload is not None:
+        raw_results = worker_payload.get("results")
+        if isinstance(raw_results, list):
+            results = raw_results
+        ground_truth = worker_payload.get("ground_truth")
+
+    empty_changes = _ground_truth_empty_changes(ground_truth)
+    noop_models: set[tuple[str, str | None]] = set()
+
+    for item in results:
+        if not isinstance(item, dict):
+            continue
+        worker_name = item.get("worker")
+        if not isinstance(worker_name, str):
+            continue
+        key = agent_keys.get(worker_name)
+        if key is None:
+            continue
+        bucket = into.get(key)
+        if bucket is None:
+            bucket = _Acc(cli=key[0], model=key[1])
+            into[key] = bucket
+            bucket.note_seen(started_at, run_id, duration_f)
+        bucket.worker_seats += 1
+        if item.get("ok") is True:
+            bucket.worker_ok += 1
+            if empty_changes:
+                noop_models.add(key)
+
+    for key in noop_models:
+        into[key].suspected_no_op_runs.add(run_id)
+
+    return True, None
+
+
+def _merge_acc(
+    dest: dict[tuple[str, str | None], _Acc],
+    src: dict[tuple[str, str | None], _Acc],
+) -> None:
+    for key, src_bucket in src.items():
+        dst = dest.get(key)
+        if dst is None:
+            dest[key] = _Acc(
+                cli=src_bucket.cli,
+                model=src_bucket.model,
+                run_ids=set(src_bucket.run_ids),
+                worker_seats=src_bucket.worker_seats,
+                orchestrator_seats=src_bucket.orchestrator_seats,
+                worker_ok=src_bucket.worker_ok,
+                suspected_no_op_runs=set(src_bucket.suspected_no_op_runs),
+                total_duration_seconds=src_bucket.total_duration_seconds,
+                first_seen=src_bucket.first_seen,
+                last_seen=src_bucket.last_seen,
+            )
+            continue
+        for run_id in src_bucket.run_ids:
+            # duration already embedded in src_bucket totals for its run_ids;
+            # when merging, add duration contribution only for new run ids.
+            if run_id not in dst.run_ids:
+                dst.run_ids.add(run_id)
+        dst.worker_seats += src_bucket.worker_seats
+        dst.orchestrator_seats += src_bucket.orchestrator_seats
+        dst.worker_ok += src_bucket.worker_ok
+        dst.suspected_no_op_runs |= src_bucket.suspected_no_op_runs
+        dst.total_duration_seconds += src_bucket.total_duration_seconds
+        if src_bucket.first_seen is not None and (dst.first_seen is None or src_bucket.first_seen < dst.first_seen):
+            dst.first_seen = src_bucket.first_seen
+        if src_bucket.last_seen is not None and (dst.last_seen is None or src_bucket.last_seen > dst.last_seen):
+            dst.last_seen = src_bucket.last_seen
+
+
+def scorecard_to_dict(card: Scorecard) -> dict[str, Any]:
+    """Stable JSON-serializable shape (sort_keys-friendly)."""
+    return {
+        "models": [
+            {
+                "cli": row.cli,
+                "first_seen": row.first_seen,
+                "label": row.label,
+                "last_seen": row.last_seen,
+                "mean_duration_seconds": row.mean_duration_seconds,
+                "model": row.model,
+                "ok_rate": row.ok_rate,
+                "orchestrator_seats": row.orchestrator_seats,
+                "runs": row.runs,
+                "seats": row.seats,
+                "suspected_no_op": row.suspected_no_op,
+                "total_duration_seconds": row.total_duration_seconds,
+                "worker_ok": row.worker_ok,
+                "worker_seats": row.worker_seats,
+            }
+            for row in card.models
+        ],
+        "scanned": card.scanned,
+        "skipped": card.skipped,
+        "skipped_dirs": [{"path": s.path, "reason": s.reason} for s in card.skipped_dirs],
+    }
+
+
+def _format_rate(rate: float) -> str:
+    return f"{rate * 100:5.1f}%"
+
+
+def _format_duration(seconds: float) -> str:
+    if seconds >= 100:
+        return f"{seconds:.0f}s"
+    return f"{seconds:.1f}s"
+
+
+def format_scorecard_text(card: Scorecard, *, verbose: bool = False) -> str:
+    lines: list[str] = []
+    headers = (
+        "model",
+        "runs",
+        "seats",
+        "w_ok",
+        "ok_rate",
+        "noop",
+        "mean_dur",
+        "first_seen",
+        "last_seen",
+    )
+    rows_text: list[tuple[str, ...]] = []
+    for row in card.models:
+        rows_text.append(
+            (
+                row.label,
+                str(row.runs),
+                f"{row.worker_seats}+{row.orchestrator_seats}",
+                str(row.worker_ok),
+                _format_rate(row.ok_rate),
+                str(row.suspected_no_op),
+                _format_duration(row.mean_duration_seconds),
+                row.first_seen or "-",
+                row.last_seen or "-",
+            )
+        )
+
+    if not rows_text:
+        lines.append("no model seats found")
+    else:
+        widths = [len(h) for h in headers]
+        for cells in rows_text:
+            for i, cell in enumerate(cells):
+                widths[i] = max(widths[i], len(cell))
+        lines.append("  ".join(h.ljust(widths[i]) for i, h in enumerate(headers)))
+        lines.append("  ".join("-" * widths[i] for i in range(len(headers))))
+        for cells in rows_text:
+            lines.append("  ".join(cells[i].ljust(widths[i]) for i in range(len(headers))))
+
+    lines.append("")
+    lines.append(f"scanned: {card.scanned}  skipped: {card.skipped}")
+    if verbose and card.skipped_dirs:
+        lines.append("skipped dirs:")
+        for item in card.skipped_dirs:
+            lines.append(f"  - {item.path}: {item.reason}")
+    return "\n".join(lines) + "\n"
+
+
+def scorecard(
+    *,
+    target: Path = Path("."),
+    runs_dirs: list[Path] | None = None,
+    since: str | None = None,
+    json_output: bool = False,
+    verbose: bool = False,
+) -> int:
+    """CLI entry: print scorecard text or JSON. Read-only."""
+    try:
+        card = build_scorecard(target=target, runs_dirs=runs_dirs, since=since)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    if json_output:
+        payload = scorecard_to_dict(card)
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+
+    sys.stdout.write(format_scorecard_text(card, verbose=verbose))
+    return 0
+
+
+__all__ = [
+    "ModelRow",
+    "Scorecard",
+    "SkippedDir",
+    "build_scorecard",
+    "format_scorecard_text",
+    "scorecard",
+    "scorecard_to_dict",
+]

--- a/tests/test_model_scorecard.py
+++ b/tests/test_model_scorecard.py
@@ -1,0 +1,582 @@
+"""TDD tests for `brigade model scorecard` (read-only run-artifact aggregation)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from brigade import cli
+from brigade import model_scorecard
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n")
+
+
+def _write_run(
+    run_dir: Path,
+    *,
+    task: str = "build feature",
+    status: str = "ok",
+    started_at: str = "2026-05-26T14:00:00Z",
+    duration_seconds: float = 2.0,
+    orchestrator: str = "chef",
+    agents: dict | None = None,
+    results: list | None = None,
+    ground_truth: dict | None = None,
+    include_worker_results: bool = True,
+) -> Path:
+    """Write a realistic run artifact tree under run_dir."""
+    run_dir.mkdir(parents=True, exist_ok=True)
+    if agents is None:
+        agents = {
+            "chef": {"cli": "codex", "model": None, "role": "plan and synthesize"},
+            "coder": {"cli": "claude", "model": "claude-fable-5", "role": "write code"},
+        }
+    _write_json(
+        run_dir / "run.json",
+        {
+            "task": task,
+            "status": status,
+            "started_at": started_at,
+            "duration_seconds": duration_seconds,
+            "orchestrator": orchestrator,
+        },
+    )
+    _write_json(
+        run_dir / "roster.json",
+        {
+            "orchestrator": orchestrator,
+            "max_workers": 2,
+            "timeout_seconds": 600.0,
+            "allow_models": [],
+            "agents": agents,
+        },
+    )
+    if include_worker_results:
+        payload: dict = {
+            "results": results
+            if results is not None
+            else [
+                {
+                    "worker": "coder",
+                    "task": "implement it",
+                    "ok": True,
+                    "detail": "",
+                    "text": "done",
+                }
+            ],
+        }
+        if ground_truth is not None:
+            payload["ground_truth"] = ground_truth
+        else:
+            payload["ground_truth"] = {
+                "available": True,
+                "cwd": "/repo",
+                "diffstat": " tracked.txt | 1 +\n 1 file changed, 1 insertion(+)",
+                "changed_files": ["tracked.txt"],
+                "untracked_files": [],
+                "patch_ref": "changes.patch",
+            }
+        _write_json(run_dir / "worker-results.json", payload)
+    return run_dir
+
+
+def _runs_root(target: Path) -> Path:
+    root = target / ".brigade" / "runs"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+# ---------------------------------------------------------------------------
+# Core aggregation
+# ---------------------------------------------------------------------------
+
+
+def test_aggregates_by_cli_and_model_with_missing_model_as_cli_alone(tmp_path):
+    runs = _runs_root(tmp_path)
+    _write_run(
+        runs / "run-a",
+        agents={
+            "chef": {"cli": "codex", "model": None, "role": "plan"},
+            "coder": {"cli": "claude", "model": "claude-fable-5", "role": "code"},
+            "helper": {"cli": "ollama:llama3.3", "role": "code"},  # model omitted
+        },
+        results=[
+            {"worker": "coder", "task": "a", "ok": True, "detail": "", "text": "x"},
+            {"worker": "helper", "task": "b", "ok": False, "detail": "fail", "text": ""},
+        ],
+    )
+
+    card = model_scorecard.build_scorecard(target=tmp_path)
+    by_label = {row.label: row for row in card.models}
+
+    assert "codex" in by_label  # missing model → cli alone
+    assert "claude/claude-fable-5" in by_label
+    assert "ollama:llama3.3" in by_label
+    assert by_label["codex"].model is None
+    assert by_label["claude/claude-fable-5"].model == "claude-fable-5"
+    assert by_label["claude/claude-fable-5"].cli == "claude"
+
+
+def test_runs_participated_worker_and_orchestrator_seats(tmp_path):
+    runs = _runs_root(tmp_path)
+    agents = {
+        "chef": {"cli": "codex", "model": "gpt-5", "role": "plan"},
+        "coder": {"cli": "claude", "model": "claude-fable-5", "role": "code"},
+    }
+    _write_run(runs / "run-1", started_at="2026-05-26T14:00:00Z", duration_seconds=10.0, agents=agents)
+    _write_run(runs / "run-2", started_at="2026-05-27T14:00:00Z", duration_seconds=20.0, agents=agents)
+    # Second run reuses same models; chef is orchestrator, coder is worker once each.
+
+    card = model_scorecard.build_scorecard(target=tmp_path)
+    by_label = {row.label: row for row in card.models}
+
+    chef = by_label["codex/gpt-5"]
+    assert chef.runs == 2
+    assert chef.orchestrator_seats == 2
+    assert chef.worker_seats == 0
+
+    coder = by_label["claude/claude-fable-5"]
+    assert coder.runs == 2
+    assert coder.orchestrator_seats == 0
+    assert coder.worker_seats == 2
+    assert coder.seats == 2
+
+
+def test_worker_ok_count_and_ok_rate(tmp_path):
+    runs = _runs_root(tmp_path)
+    agents = {
+        "chef": {"cli": "codex", "model": None, "role": "plan"},
+        "coder": {"cli": "claude", "model": "m1", "role": "code"},
+    }
+    _write_run(
+        runs / "ok-run",
+        agents=agents,
+        results=[{"worker": "coder", "task": "a", "ok": True, "detail": "", "text": "ok"}],
+    )
+    _write_run(
+        runs / "fail-run",
+        started_at="2026-05-27T14:00:00Z",
+        agents=agents,
+        results=[{"worker": "coder", "task": "b", "ok": False, "detail": "err", "text": ""}],
+    )
+
+    card = model_scorecard.build_scorecard(target=tmp_path)
+    coder = next(r for r in card.models if r.label == "claude/m1")
+    assert coder.worker_seats == 2
+    assert coder.worker_ok == 1
+    assert coder.ok_rate == pytest.approx(0.5)
+
+
+def test_suspected_no_op_flag_per_run_count_per_model(tmp_path):
+    """suspected no-op = worker ok AND ground_truth.available AND empty changed_files."""
+    runs = _runs_root(tmp_path)
+    agents = {
+        "chef": {"cli": "codex", "model": None, "role": "plan"},
+        "coder": {"cli": "claude", "model": "m1", "role": "code"},
+        "helper": {"cli": "claude", "model": "m1", "role": "code"},
+    }
+    # No-op run: two ok workers same model, empty changed_files → count once per model per run
+    _write_run(
+        runs / "noop",
+        agents=agents,
+        results=[
+            {"worker": "coder", "task": "a", "ok": True, "detail": "", "text": "x"},
+            {"worker": "helper", "task": "b", "ok": True, "detail": "", "text": "y"},
+        ],
+        ground_truth={
+            "available": True,
+            "cwd": "/repo",
+            "diffstat": "",
+            "changed_files": [],
+            "untracked_files": [],
+            "patch_ref": None,
+        },
+    )
+    # Real work: ok worker but files changed → not a no-op
+    _write_run(
+        runs / "real",
+        started_at="2026-05-27T14:00:00Z",
+        agents=agents,
+        results=[{"worker": "coder", "task": "c", "ok": True, "detail": "", "text": "z"}],
+        ground_truth={
+            "available": True,
+            "cwd": "/repo",
+            "diffstat": "f | 1 +",
+            "changed_files": ["f"],
+            "untracked_files": [],
+        },
+    )
+    # Ok but GT unavailable → not a no-op
+    _write_run(
+        runs / "no-gt",
+        started_at="2026-05-28T14:00:00Z",
+        agents=agents,
+        results=[{"worker": "coder", "task": "d", "ok": True, "detail": "", "text": "z"}],
+        ground_truth={
+            "available": False,
+            "cwd": "/tmp",
+            "diffstat": "",
+            "changed_files": [],
+            "reason": "not a git worktree",
+        },
+    )
+    # Failed worker with empty changes → not a no-op (needs worker ok)
+    _write_run(
+        runs / "fail",
+        started_at="2026-05-29T14:00:00Z",
+        agents=agents,
+        results=[{"worker": "coder", "task": "e", "ok": False, "detail": "x", "text": ""}],
+        ground_truth={
+            "available": True,
+            "cwd": "/repo",
+            "diffstat": "",
+            "changed_files": [],
+        },
+    )
+
+    card = model_scorecard.build_scorecard(target=tmp_path)
+    coder = next(r for r in card.models if r.label == "claude/m1")
+    assert coder.suspected_no_op == 1
+
+
+def test_duration_total_and_mean_for_participated_runs(tmp_path):
+    runs = _runs_root(tmp_path)
+    agents = {
+        "chef": {"cli": "codex", "model": None, "role": "plan"},
+        "coder": {"cli": "claude", "model": "m1", "role": "code"},
+    }
+    _write_run(runs / "r1", duration_seconds=10.0, agents=agents)
+    _write_run(
+        runs / "r2",
+        started_at="2026-05-27T14:00:00Z",
+        duration_seconds=30.0,
+        agents=agents,
+    )
+
+    card = model_scorecard.build_scorecard(target=tmp_path)
+    coder = next(r for r in card.models if r.label == "claude/m1")
+    assert coder.total_duration_seconds == pytest.approx(40.0)
+    assert coder.mean_duration_seconds == pytest.approx(20.0)
+    assert coder.runs == 2
+
+
+def test_first_and_last_seen_timestamps(tmp_path):
+    runs = _runs_root(tmp_path)
+    agents = {
+        "chef": {"cli": "codex", "model": None, "role": "plan"},
+        "coder": {"cli": "claude", "model": "m1", "role": "code"},
+    }
+    _write_run(runs / "early", started_at="2026-05-20T10:00:00Z", agents=agents)
+    _write_run(runs / "mid", started_at="2026-05-25T12:00:00Z", agents=agents)
+    _write_run(runs / "late", started_at="2026-05-30T18:00:00Z", agents=agents)
+
+    card = model_scorecard.build_scorecard(target=tmp_path)
+    coder = next(r for r in card.models if r.label == "claude/m1")
+    assert coder.first_seen == "2026-05-20T10:00:00Z"
+    assert coder.last_seen == "2026-05-30T18:00:00Z"
+
+
+def test_malformed_and_partial_dirs_skipped_never_crash(tmp_path):
+    runs = _runs_root(tmp_path)
+    _write_run(runs / "good", started_at="2026-05-26T14:00:00Z")
+
+    # empty dir
+    (runs / "empty").mkdir()
+    # missing roster
+    bad_run = runs / "no-roster"
+    bad_run.mkdir()
+    _write_json(bad_run / "run.json", {"task": "x", "status": "ok", "started_at": "2026-05-26T14:00:00Z"})
+    # invalid run.json
+    bad_json = runs / "bad-json"
+    bad_json.mkdir()
+    (bad_json / "run.json").write_text("not json\n")
+    (bad_json / "roster.json").write_text("{}\n")
+    # file instead of dir (ignored, not a run dir)
+    (runs / "not-a-dir.txt").write_text("x\n")
+    # partial: run.json not an object
+    partial = runs / "partial"
+    partial.mkdir()
+    _write_json(partial / "run.json", ["not", "an", "object"])
+    _write_json(partial / "roster.json", {"orchestrator": "chef", "agents": {}})
+
+    card = model_scorecard.build_scorecard(target=tmp_path)
+    assert card.scanned == 1
+    assert card.skipped >= 3
+    assert len(card.models) >= 1
+    assert all(isinstance(s.path, str) and s.reason for s in card.skipped_dirs)
+
+
+def test_since_filter_yyyy_mm_dd(tmp_path):
+    runs = _runs_root(tmp_path)
+    agents = {
+        "chef": {"cli": "codex", "model": None, "role": "plan"},
+        "coder": {"cli": "claude", "model": "m1", "role": "code"},
+    }
+    _write_run(runs / "old", started_at="2026-05-01T12:00:00Z", agents=agents)
+    _write_run(runs / "on-day", started_at="2026-05-15T00:00:00Z", agents=agents)
+    _write_run(runs / "new", started_at="2026-05-20T12:00:00Z", agents=agents)
+
+    card = model_scorecard.build_scorecard(target=tmp_path, since="2026-05-15")
+    coder = next(r for r in card.models if r.label == "claude/m1")
+    assert coder.runs == 2
+    assert coder.first_seen == "2026-05-15T00:00:00Z"
+
+
+def test_multi_runs_dir(tmp_path):
+    a = tmp_path / "a" / "runs"
+    b = tmp_path / "b" / "runs"
+    a.mkdir(parents=True)
+    b.mkdir(parents=True)
+    agents_a = {
+        "chef": {"cli": "codex", "model": None, "role": "plan"},
+        "coder": {"cli": "claude", "model": "m-a", "role": "code"},
+    }
+    agents_b = {
+        "chef": {"cli": "codex", "model": None, "role": "plan"},
+        "coder": {"cli": "claude", "model": "m-b", "role": "code"},
+    }
+    _write_run(a / "r1", agents=agents_a)
+    _write_run(b / "r2", agents=agents_b, started_at="2026-05-27T14:00:00Z")
+
+    card = model_scorecard.build_scorecard(runs_dirs=[a, b])
+    labels = {row.label for row in card.models}
+    assert "claude/m-a" in labels
+    assert "claude/m-b" in labels
+    assert card.scanned == 2
+
+
+def test_json_stable_shape(tmp_path):
+    runs = _runs_root(tmp_path)
+    _write_run(runs / "r1")
+
+    card = model_scorecard.build_scorecard(target=tmp_path)
+    payload = model_scorecard.scorecard_to_dict(card)
+
+    assert set(payload.keys()) == {"models", "scanned", "skipped", "skipped_dirs"}
+    assert isinstance(payload["models"], list)
+    assert payload["scanned"] == 1
+    assert payload["skipped"] == 0
+    row = payload["models"][0]
+    expected_keys = {
+        "cli",
+        "model",
+        "label",
+        "runs",
+        "worker_seats",
+        "orchestrator_seats",
+        "seats",
+        "worker_ok",
+        "ok_rate",
+        "suspected_no_op",
+        "total_duration_seconds",
+        "mean_duration_seconds",
+        "first_seen",
+        "last_seen",
+    }
+    assert set(row.keys()) == expected_keys
+    # sort_keys stability: dumps with sort_keys matches key order when re-parsed fields present
+    dumped = json.dumps(payload, sort_keys=True)
+    assert json.loads(dumped) == payload
+
+
+def test_models_sorted_ok_rate_desc_then_seats_desc(tmp_path):
+    runs = _runs_root(tmp_path)
+    # model A: 100% ok, 1 seat
+    _write_run(
+        runs / "a1",
+        agents={
+            "chef": {"cli": "codex", "model": None, "role": "plan"},
+            "coder": {"cli": "claude", "model": "high-rate", "role": "code"},
+        },
+        results=[{"worker": "coder", "task": "t", "ok": True, "detail": "", "text": "x"}],
+    )
+    # model B: 50% ok, 2 seats (lower rate, more seats)
+    agents_b = {
+        "chef": {"cli": "codex", "model": None, "role": "plan"},
+        "w1": {"cli": "claude", "model": "mid-rate", "role": "code"},
+        "w2": {"cli": "claude", "model": "mid-rate", "role": "code"},
+    }
+    _write_run(
+        runs / "b1",
+        started_at="2026-05-27T14:00:00Z",
+        agents=agents_b,
+        results=[
+            {"worker": "w1", "task": "t", "ok": True, "detail": "", "text": "x"},
+            {"worker": "w2", "task": "t", "ok": False, "detail": "e", "text": ""},
+        ],
+    )
+    # model C: 100% ok, 2 seats — should rank above A (same rate, more seats)
+    agents_c = {
+        "chef": {"cli": "codex", "model": None, "role": "plan"},
+        "w1": {"cli": "claude", "model": "high-seats", "role": "code"},
+        "w2": {"cli": "claude", "model": "high-seats", "role": "code"},
+    }
+    _write_run(
+        runs / "c1",
+        started_at="2026-05-28T14:00:00Z",
+        agents=agents_c,
+        results=[
+            {"worker": "w1", "task": "t", "ok": True, "detail": "", "text": "x"},
+            {"worker": "w2", "task": "t", "ok": True, "detail": "", "text": "y"},
+        ],
+    )
+
+    card = model_scorecard.build_scorecard(target=tmp_path)
+    claude_rows = [r for r in card.models if r.cli == "claude"]
+    labels = [r.label for r in claude_rows]
+    assert labels == ["claude/high-seats", "claude/high-rate", "claude/mid-rate"]
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def test_cli_scorecard_text_table_and_footer(tmp_path, capsys):
+    runs = _runs_root(tmp_path)
+    _write_run(runs / "r1")
+    (runs / "empty").mkdir()
+
+    assert cli.main(["model", "scorecard", "--target", str(tmp_path)]) == 0
+    out = capsys.readouterr().out
+    assert "claude/claude-fable-5" in out or "claude" in out
+    assert "codex" in out
+    assert "scanned" in out.lower()
+    assert "skipped" in out.lower()
+
+
+def test_cli_scorecard_json(tmp_path, capsys):
+    runs = _runs_root(tmp_path)
+    _write_run(runs / "r1")
+
+    assert cli.main(["model", "scorecard", "--target", str(tmp_path), "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert "models" in payload
+    assert payload["scanned"] == 1
+
+
+def test_cli_scorecard_since(tmp_path, capsys):
+    runs = _runs_root(tmp_path)
+    agents = {
+        "chef": {"cli": "codex", "model": None, "role": "plan"},
+        "coder": {"cli": "claude", "model": "m1", "role": "code"},
+    }
+    _write_run(runs / "old", started_at="2026-04-01T00:00:00Z", agents=agents)
+    _write_run(runs / "new", started_at="2026-06-01T00:00:00Z", agents=agents)
+
+    assert cli.main(["model", "scorecard", "--target", str(tmp_path), "--since", "2026-05-01", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    claude = next(m for m in payload["models"] if m["label"] == "claude/m1")
+    assert claude["runs"] == 1
+
+
+def test_cli_scorecard_multi_runs_dir(tmp_path, capsys):
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    _write_run(
+        a / "r1",
+        agents={
+            "chef": {"cli": "codex", "model": None, "role": "plan"},
+            "coder": {"cli": "claude", "model": "from-a", "role": "code"},
+        },
+    )
+    _write_run(
+        b / "r2",
+        started_at="2026-05-27T14:00:00Z",
+        agents={
+            "chef": {"cli": "codex", "model": None, "role": "plan"},
+            "coder": {"cli": "claude", "model": "from-b", "role": "code"},
+        },
+    )
+
+    assert (
+        cli.main(
+            [
+                "model",
+                "scorecard",
+                "--runs-dir",
+                str(a),
+                "--runs-dir",
+                str(b),
+                "--json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    labels = {m["label"] for m in payload["models"]}
+    assert "claude/from-a" in labels
+    assert "claude/from-b" in labels
+
+
+def test_cli_verbose_lists_skipped_dirs_and_reasons(tmp_path, capsys):
+    runs = _runs_root(tmp_path)
+    _write_run(runs / "good")
+    (runs / "empty").mkdir()
+    bad = runs / "bad-json"
+    bad.mkdir()
+    (bad / "run.json").write_text("not json\n")
+
+    assert cli.main(["model", "scorecard", "--target", str(tmp_path), "--verbose"]) == 0
+    out = capsys.readouterr().out
+    assert "empty" in out
+    assert "bad-json" in out
+    # reason text present
+    assert "missing" in out.lower() or "invalid" in out.lower() or "run.json" in out.lower()
+
+
+def test_cli_is_read_only_no_writes(tmp_path):
+    runs = _runs_root(tmp_path)
+    _write_run(runs / "r1")
+    before = {p.relative_to(tmp_path): p.stat().st_mtime_ns for p in tmp_path.rglob("*") if p.is_file()}
+
+    assert cli.main(["model", "scorecard", "--target", str(tmp_path), "--json"]) == 0
+
+    after_files = {p.relative_to(tmp_path) for p in tmp_path.rglob("*") if p.is_file()}
+    assert after_files == set(before)
+    for rel, mtime in before.items():
+        assert (tmp_path / rel).stat().st_mtime_ns == mtime
+
+
+def test_invalid_since_exits_nonzero(tmp_path, capsys):
+    _runs_root(tmp_path)
+    code = cli.main(["model", "scorecard", "--target", str(tmp_path), "--since", "not-a-date"])
+    assert code != 0
+    err = capsys.readouterr().err
+    assert "since" in err.lower() or "YYYY-MM-DD" in err
+
+
+def test_runs_dir_is_additive_with_target(tmp_path):
+    # --runs-dir roots are extra; the target's default runs dir still scans.
+    target = tmp_path / "proj"
+    extra = tmp_path / "elsewhere" / "runs"
+    _write_run(target / ".brigade" / "runs" / "r-target")
+    _write_run(extra / "r-extra", started_at="2026-05-27T14:00:00Z")
+
+    card = model_scorecard.build_scorecard(target=target, runs_dirs=[extra])
+    assert card.scanned == 2
+
+
+def test_noop_ignores_brigade_housekeeping_changes(tmp_path):
+    # A run whose only ground-truth changes live under .brigade/ (roster
+    # edits, artifacts) did no task work: still a suspected no-op.
+    runs = _runs_root(tmp_path)
+    _write_run(
+        runs / "r1",
+        results=[{"worker": "coder", "task": "t", "ok": True, "detail": "", "text": "done"}],
+        ground_truth={
+            "available": True,
+            "cwd": str(tmp_path),
+            "diffstat": ".brigade/roster.toml | 2 +-",
+            "changed_files": [".brigade/roster.toml"],
+        },
+    )
+
+    card = model_scorecard.build_scorecard(target=tmp_path)
+    by_label = {row.label: row for row in card.models}
+    assert by_label["claude/claude-fable-5"].suspected_no_op == 1


### PR DESCRIPTION
## Why

Model choice across the fleet (gpt, opus, fable, grok, ...) has been judged by vibes. Every `brigade run` already records who sat in each seat (roster.json), whether each worker succeeded (worker-results.json), whether the run actually changed anything (ground_truth), and how long it took (run.json). This turns those artifacts into a per-model scoreboard, retroactively.

## Command

```
brigade model scorecard [--target DIR] [--runs-dir DIR ...] [--json] [--since YYYY-MM-DD]
```

Per (cli, model): runs participated, worker+orchestrator seats, worker ok rate, suspected no-op runs (worker reported ok but ground truth shows no changes outside `.brigade/` - the #173 signal), mean run duration, first/last seen. `--runs-dir` roots are additive to the target's default so one call sweeps multiple repos. Malformed dirs are counted and reported, never silently dropped. Read-only, no network.

## First real output (54 runs across 5 roots on this machine)

```
model                           runs  seats  w_ok  ok_rate  noop  mean_dur
codex/gpt-5.5                   45    85+45  85    100.0%   4     799s
codex/gpt-5.3-codex-spark       11    31+0   31    100.0%   4     1059s
grok/grok-4.5                   5     4+5    4     100.0%   1     290s
grok/grok-composer-2.5-fast     5     8+0    8     100.0%   2     290s
codex                           4     3+4    3     100.0%   0     53.6s
ollama:deepseek-v4-flash:cloud  2     1+0    0       0.0%   0     42.9s
```

The flagged grok no-op is the real pre-#172 silent-failure run, correctly detected.

## Caveat

For `--worktree` runs, brigade's ground truth watches the original cwd while changes land in the worktree patch, so such runs can flag as no-ops despite real output (one composer flag above is this). That is an artifact-recording question for #173 rather than a scorecard bug; the scorecard reports what the run recorded.

## Verification

- `python3 -m pytest tests/test_model_scorecard.py -q`: 20 passed
- `python3 -m pytest tests/ -q`: 1734 passed, 1 skipped (pre-existing codex appserver skip)