### PR TITLE
fix(mcp): empty-args fingerprints, url-only import, Grok adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- MCP adapters for Grok CLI: project `.grok/config.toml` (`grok`) and user `~/.grok/config.toml` (`grok-user`, requires `--user-scope`). Same Codex-like `[mcp_servers.<name>]` TOML shape. (#183)
+
+### Fixed
+- MCP Codex/Grok empty-`args` fingerprint conflicts: `to_provider` no longer emits `args: []`, matching TOML render which omits empty arrays, so force-sync stays idempotent. (#181)
+- MCP import of url-only servers no longer lands as invalid `stdio`+`url`; coerce to `http`/`sse`, including OpenClaw sources with a bogus `transport: stdio` or a command that is actually a URL. (#182)
+
+### Added
 - Productized GraphTrail ↔ Brigade ↔ MiseLedger dogfood path: `brigade operator checkup` reports optional loop health (`graph` / `ledger` / last and mean `brief_hit_rate` from run receipts) without blocking readiness; `brigade add graphtrail` installs the code-graph tool under the search station; QUICKSTART documents install → checkup → export → rank.
 - Outcome rank/reconcile surfaces mean `context_eval.brief_hit_rate` per skill as a quality signal (secondary sort among equal Wilson scores; install/rollback thresholds still use verified exit codes only).
 - `brigade-work` skill teaches the full loop: verify with capture → outcome from run → MiseLedger export → evidence brief next time.

--- a/docs/mcp-sync.md
+++ b/docs/mcp-sync.md
@@ -54,9 +54,14 @@ tool expands at launch.
 | Claude Code | `.mcp.json` | JSON `mcpServers`; remote `{type,url}` |
 | Cursor | `.cursor/mcp.json` | JSON `mcpServers` (same as Claude) |
 | Codex CLI | `.codex/config.toml` | TOML `[mcp_servers.<name>]`, merged surgically (other tables/comments preserved) |
+| Grok CLI | `.grok/config.toml` | TOML `[mcp_servers.<name>]` (Codex-like; project scope) |
 | VS Code | `.vscode/mcp.json` | JSON `servers`; secrets become top-level `inputs[]` + `${input:VAR}` |
 | OpenCode | `opencode.json` | JSON `mcp`; `{type:"local",command:[cmd,...args],environment}` |
 | Antigravity | `~/.gemini/config/mcp_config.json` | JSON `mcpServers`; remote uses `serverUrl`. **User-scoped** (`--user-scope`) |
+| Claude user | `~/.claude.json` | JSON `mcpServers`. **User-scoped** (`--user-scope`) |
+| Codex user | `~/.codex/config.toml` | TOML `[mcp_servers.<name>]`. **User-scoped** (`--user-scope`) |
+| Grok user | `~/.grok/config.toml` | TOML `[mcp_servers.<name>]`. **User-scoped** (`--user-scope`) |
+| OpenClaw | `~/.openclaw/openclaw.json` | JSON `mcp.servers`. **User-scoped** (`--user-scope`) |
 
 By default a repo's sync targets the tools in its Brigade selection (`.brigade/config.json`)
 that have an adapter. VS Code is not a Brigade harness: it is included only when the repo

--- a/src/brigade/mcp_adapters.py
+++ b/src/brigade/mcp_adapters.py
@@ -464,8 +464,25 @@ def _codex_write_file(text: str | None, owned: dict[str, dict[str, Any]], remove
 # --------------------------------------------------------------------------- #
 
 
+def _remote_transport(raw: dict[str, Any], *, type_key: str = "type") -> str:
+    """Pick http/sse for a remote server; never keep stdio when only a URL is present."""
+    for key in (type_key, "transport", "type"):
+        value = raw.get(key)
+        if value in ("http", "sse"):
+            return str(value)
+    return "http"
+
+
+def _looks_like_url(value: object) -> bool:
+    return isinstance(value, str) and value.startswith(("http://", "https://"))
+
+
 def _mcpservers_to_provider(server: CanonicalServer, env_style: str, *, remote_url_key: str = "url") -> dict[str, Any]:
-    """The common JSON ``mcpServers`` per-server shape (Claude, Cursor, Antigravity)."""
+    """The common JSON ``mcpServers`` per-server shape (Claude, Cursor, Antigravity).
+
+    Empty ``args`` are omitted so write/read round-trips stay fingerprint-stable
+    for formats (Codex/Grok TOML) that drop empty arrays on render.
+    """
     if server.is_remote:
         out: dict[str, Any] = {remote_url_key: server.url}
         if remote_url_key == "url":
@@ -473,7 +490,9 @@ def _mcpservers_to_provider(server: CanonicalServer, env_style: str, *, remote_u
         if server.headers:
             out["headers"] = _emit_env(server.headers, env_style)
         return out
-    out = {"command": server.command, "args": list(server.args)}
+    out: dict[str, Any] = {"command": server.command}
+    if server.args:
+        out["args"] = list(server.args)
     if server.env:
         out["env"] = _emit_env(server.env, env_style)
     if server.timeout is not None:
@@ -485,9 +504,18 @@ def _mcpservers_from_provider(
     name: str, raw: dict[str, Any], *, remote_url_key: str = "url", keep_secrets: bool = False
 ) -> tuple[CanonicalServer, list[str]]:
     url = raw.get(remote_url_key) or raw.get("url") or raw.get("serverUrl")
+    command = raw.get("command")
+    # Url-only (or command that is actually a URL) is always remote.
+    if not url and _looks_like_url(command) and not raw.get("args"):
+        url = command
+        command = None
+    if url and not command:
+        headers, demoted = _parse_env(raw.get("headers"), keep_secrets=keep_secrets)
+        transport = _remote_transport(raw)
+        return CanonicalServer(name=name, transport=transport, url=str(url), headers=headers), demoted
     if url:
         headers, demoted = _parse_env(raw.get("headers"), keep_secrets=keep_secrets)
-        transport = raw.get("type") if raw.get("type") in ("http", "sse") else "http"
+        transport = _remote_transport(raw)
         return CanonicalServer(name=name, transport=transport, url=str(url), headers=headers), demoted
     env, demoted = _parse_env(raw.get("env"), keep_secrets=keep_secrets)
     timeout = raw.get("timeout")
@@ -495,7 +523,7 @@ def _mcpservers_from_provider(
         CanonicalServer(
             name=name,
             transport="stdio",
-            command=str(raw["command"]) if raw.get("command") else None,
+            command=str(command) if command else None,
             args=tuple(str(a) for a in (raw.get("args") or [])),
             env=env,
             timeout=int(timeout) if isinstance(timeout, (int, float)) else None,
@@ -510,7 +538,9 @@ def _vscode_to_provider(server: CanonicalServer) -> dict[str, Any]:
         if server.headers:
             out["headers"] = _emit_env(server.headers, "vscode-inputs")
         return out
-    out = {"type": "stdio", "command": server.command, "args": list(server.args)}
+    out: dict[str, Any] = {"type": "stdio", "command": server.command}
+    if server.args:
+        out["args"] = list(server.args)
     if server.env:
         out["env"] = _emit_env(server.env, "vscode-inputs")
     return out
@@ -571,7 +601,9 @@ def _openclaw_to_provider(server: CanonicalServer) -> dict[str, Any]:
         if server.headers:
             remote["headers"] = _emit_env(server.headers, "expand")
         return remote
-    out: dict[str, Any] = {"command": server.command, "args": list(server.args)}
+    out: dict[str, Any] = {"command": server.command}
+    if server.args:
+        out["args"] = list(server.args)
     if server.env:
         out["env"] = _emit_env(server.env, "expand")
     return out
@@ -580,12 +612,17 @@ def _openclaw_to_provider(server: CanonicalServer) -> dict[str, Any]:
 def _openclaw_from_provider(
     name: str, raw: dict[str, Any], *, keep_secrets: bool = False
 ) -> tuple[CanonicalServer, list[str]]:
-    if raw.get("url"):
+    url = raw.get("url")
+    command = raw.get("command")
+    if not url and _looks_like_url(command) and not raw.get("args"):
+        url = command
+        command = None
+    if url:
         headers, demoted = _parse_env(raw.get("headers"), keep_secrets=keep_secrets)
+        # Never keep transport=stdio for a URL-bearing entry (import fidelity).
+        transport = _remote_transport(raw, type_key="transport")
         return (
-            CanonicalServer(
-                name=name, transport=str(raw.get("transport") or "http"), url=str(raw["url"]), headers=headers
-            ),
+            CanonicalServer(name=name, transport=transport, url=str(url), headers=headers),
             demoted,
         )
     env, demoted = _parse_env(raw.get("env"), keep_secrets=keep_secrets)
@@ -593,7 +630,7 @@ def _openclaw_from_provider(
         CanonicalServer(
             name=name,
             transport="stdio",
-            command=str(raw["command"]) if raw.get("command") else None,
+            command=str(command) if command else None,
             args=tuple(str(a) for a in (raw.get("args") or [])),
             env=env,
         ),
@@ -700,6 +737,34 @@ ADAPTERS: dict[str, McpAdapter] = {
         from_provider=_openclaw_from_provider,
         read_file=lambda t: _json_read_file(t, "mcp.servers"),
         write_file=lambda t, o, r: _json_write_file(t, o, r, "mcp.servers"),
+    ),
+    # Grok CLI: Codex-like [mcp_servers.<name>] TOML. Project scope lives under
+    # .grok/config.toml; user scope under ~/.grok/config.toml (grok mcp add default).
+    "grok": McpAdapter(
+        harness="grok",
+        path=".grok/config.toml",
+        fmt="toml",
+        top_key="mcp_servers",
+        user_scope=False,
+        supports_remote=True,
+        env_style="passthrough",
+        to_provider=lambda s: _mcpservers_to_provider(s, "passthrough"),
+        from_provider=lambda n, r, keep_secrets=False: _mcpservers_from_provider(n, r, keep_secrets=keep_secrets),
+        read_file=_codex_read_file,
+        write_file=_codex_write_file,
+    ),
+    "grok-user": McpAdapter(
+        harness="grok-user",
+        path="~/.grok/config.toml",
+        fmt="toml",
+        top_key="mcp_servers",
+        user_scope=True,
+        supports_remote=True,
+        env_style="passthrough",
+        to_provider=lambda s: _mcpservers_to_provider(s, "passthrough"),
+        from_provider=lambda n, r, keep_secrets=False: _mcpservers_from_provider(n, r, keep_secrets=keep_secrets),
+        read_file=_codex_read_file,
+        write_file=_codex_write_file,
     ),
 }
 

--- a/tests/test_mcp_adapters.py
+++ b/tests/test_mcp_adapters.py
@@ -228,6 +228,70 @@ def test_openclaw_remote_headers_roundtrip():
     assert back.headers == {"Authorization": {"ref": "TOKEN"}}
 
 
+def test_codex_empty_args_roundtrip_is_idempotent():
+    """#181: empty args must not fingerprint-conflict after codex TOML write/read.
+
+    to_provider used to emit args=[] while _codex_render_table omits empty arrays,
+    so live fingerprint never matched projected_fingerprint.
+    """
+    adapter = A.ADAPTERS["codex"]
+    server = CanonicalServer(name="dossier", transport="stdio", command="/usr/bin/dossier-mcp")
+    projected = adapter.to_provider(server)
+    assert "args" not in projected
+    text = adapter.write_file(None, {"dossier": projected}, set())
+    round_tripped = adapter.read_file(text)["dossier"]
+    assert round_tripped == projected
+    # user-scope alias shares the same transforms
+    user = A.ADAPTERS["codex-user"]
+    assert user.to_provider(server) == projected
+
+
+def test_openclaw_url_only_never_stdio():
+    """#182: url-only import must coerce to http/sse, never stdio+url."""
+    adapter = A.ADAPTERS["openclaw"]
+    # Broken source shapes seen in the wild
+    for raw in (
+        {"url": "http://127.0.0.1:8000/mcp", "transport": "stdio"},
+        {"url": "http://127.0.0.1:8000/mcp"},
+        {"command": "https://mcp.example.com/v1"},
+    ):
+        back, _ = adapter.from_provider("x", raw)
+        assert back.is_remote, raw
+        assert back.transport in ("http", "sse"), raw
+        assert back.url
+        assert back.command is None
+        projected = adapter.to_provider(back)
+        assert "url" in projected
+        assert projected.get("transport") in ("http", "sse")
+
+
+def test_mcpservers_url_only_coerces_http():
+    """#182: common mcpServers from_provider coerces url-only + bogus type."""
+    adapter = A.ADAPTERS["claude"]
+    back, _ = adapter.from_provider("x", {"url": "http://127.0.0.1:8000/mcp", "type": "stdio"})
+    assert back.transport == "http"
+    assert back.url == "http://127.0.0.1:8000/mcp"
+
+
+def test_grok_adapters_share_codex_toml_shape():
+    """#183: Grok project + user adapters reuse Codex-like mcp_servers TOML."""
+    for name, path, user_scope in (
+        ("grok", ".grok/config.toml", False),
+        ("grok-user", "~/.grok/config.toml", True),
+    ):
+        adapter = A.ADAPTERS[name]
+        assert adapter.path == path
+        assert adapter.user_scope is user_scope
+        assert adapter.fmt == "toml"
+        assert adapter.top_key == "mcp_servers"
+    server = CanonicalServer(name="graphtrail", transport="stdio", command="/usr/bin/graphtrail-mcp")
+    for name in ("grok", "grok-user", "codex"):
+        projected = A.ADAPTERS[name].to_provider(server)
+        text = A.ADAPTERS[name].write_file(None, {"graphtrail": projected}, set())
+        assert "[mcp_servers.graphtrail]" in text
+        assert A.ADAPTERS[name].read_file(text)["graphtrail"] == projected
+
+
 def test_server_dict_roundtrip():
     s = _stdio()
     raw = A.server_to_dict(s)

--- a/tests/test_mcp_user_scope.py
+++ b/tests/test_mcp_user_scope.py
@@ -19,11 +19,11 @@ def _stdio():
 
 
 def test_user_scope_adapters_registered():
-    for name in ("codex-user", "claude-user", "openclaw"):
+    for name in ("codex-user", "claude-user", "openclaw", "grok-user"):
         a = A.ADAPTERS[name]
         assert a.user_scope is True
         assert a.path.startswith("~")
-    assert {"codex-user", "claude-user", "openclaw"} <= set(A.MCP_TARGETS)
+    assert {"codex-user", "claude-user", "openclaw", "grok-user"} <= set(A.MCP_TARGETS)
 
 
 def test_codex_user_is_toml_codex_shape():


### PR DESCRIPTION
## Summary

Fixes two MCP sync fidelity bugs and adds Grok CLI adapters.

- **#181**: empty `args` no longer fingerprint-conflicts on Codex/Grok TOML after force-sync (`to_provider` omits `args: []` to match render).
- **#182**: url-only import coerces to `http`/`sse` (never invalid `stdio`+`url`), including OpenClaw bogus `transport: stdio` and command-that-is-a-URL.
- **#183**: `grok` → `.grok/config.toml`, `grok-user` → `~/.grok/config.toml` (`--user-scope`), Codex-like `[mcp_servers.<name>]` TOML.

## Test plan

- [x] `pytest` MCP adapter/cmd/user-scope/integration
- [x] `./scripts/verify` via `brigade work verify run --capture brigade-work`
- [x] Live: claude-user / codex-user / openclaw / grok-user all plan as 24 `skip` after re-sync

Closes #181
Closes #182
Closes #183