### PR TITLE
fix(mcp): omit empty args from projected stdio servers for codex round-trip

### DIFF
--- a/src/brigade/mcp_adapters.py
+++ b/src/brigade/mcp_adapters.py
@@ -473,7 +473,9 @@ def _mcpservers_to_provider(server: CanonicalServer, env_style: str, *, remote_u
         if server.headers:
             out["headers"] = _emit_env(server.headers, env_style)
         return out
-    out = {"command": server.command, "args": list(server.args)}
+    out: dict[str, Any] = {"command": server.command}
+    if server.args:
+        out["args"] = list(server.args)
     if server.env:
         out["env"] = _emit_env(server.env, env_style)
     if server.timeout is not None:

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -49,6 +49,41 @@ def test_user_scope_required_for_antigravity_import(tmp_path):
     assert mcp_cmd.import_servers(target=repo, harness="antigravity", json_output=True) == 2
 
 
+def test_codex_user_stdio_no_args_never_stays_conflicted(tmp_path, monkeypatch, capsys):
+    """Issue #181: a no-args stdio server must not be "conflicted" forever.
+
+    ``_codex_render_table`` omits an empty ``args = []`` from the rendered TOML, so
+    reading the file back never carries an "args" key. If the fingerprint recorded at
+    sync time was computed against a provider dict that DID include ``"args": []``,
+    every later plan sees a live/projected fingerprint mismatch and reports the server
+    "conflicted" forever, even though nothing was ever edited outside Brigade.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    mcp_cmd.init(target=repo, json_output=True)
+    mcp_cmd.add(target=repo, name="noargs", command="some-mcp-server", json_output=True)
+
+    capsys.readouterr()
+    rc = mcp_cmd.sync(target=repo, harness="codex-user", user_scope=True, write=True, force=True, json_output=True)
+    assert rc == 0
+    sync_payload = json.loads(capsys.readouterr().out)
+    assert sync_payload["counts"]["conflict"] == 0
+
+    # Plan again, twice, exactly as `brigade mcp plan --harness codex-user --user-scope`
+    # would after a real sync --write --force. A forever-conflicted server never clears.
+    for _ in range(2):
+        capsys.readouterr()
+        rc = mcp_cmd.plan(target=repo, harness="codex-user", user_scope=True, json_output=True)
+        payload = json.loads(capsys.readouterr().out)
+        statuses = {item["server"]: item["status"] for item in payload["items"]}
+        assert statuses.get("noargs") in ("current", "skip"), payload["items"]
+        assert payload["counts"]["conflict"] == 0
+        assert rc == 0
+
+
 # --- operator sync-mcp (three-phase, dry-run default) --- #
 
 


### PR DESCRIPTION
## Why

Closes #181. After `brigade mcp sync --write --force` to codex/codex-user, stdio servers with no args (dossier, excalidraw, node_repl) stayed `conflicted` on every subsequent `plan`, forever.

## Root cause and fix

`_mcpservers_to_provider` always emitted `"args": []` while `_codex_render_table` omits empty args from the rendered TOML; the re-read had no args key, so the live fingerprint never matched the stored projection. The projection now emits `args` only when non-empty, matching the render side. `env` and `headers` were already conditional, so no equivalent asymmetry exists there.

## Verification

- New round-trip test reproduces the forever-conflicted state through the real sync/plan paths in a tmp HOME (failed before, passes after).
- Full suite independently rerun: 1715 passed, 1 skipped (pre-existing codex gate).
- Live repro: command-only server, `sync --harness codex-user --user-scope --write --force`, then `plan` reports `current -> skip`.

## Note

Touches the same function as #186 (url-only import fix); whichever merges second will need a trivial rebase.

## Provenance note

Built by an all-claude/claude-sonnet-5 brigade roster (tmux relay lane) as part of the model scorecard series (#180).