### PR TITLE
feat(skills): ship skill.json and CHANGELOG.md with bundled templates

### DIFF
--- a/src/brigade/templates/skills/brigade-work/CHANGELOG.md
+++ b/src/brigade/templates/skills/brigade-work/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial bundled brigade-work skill: routes verification, outcomes, evidence export, and handoffs through Brigade.

--- a/src/brigade/templates/skills/brigade-work/skill.json
+++ b/src/brigade/templates/skills/brigade-work/skill.json
@@ -1,0 +1,7 @@
+{
+  "id": "brigade-work",
+  "title": "brigade-work",
+  "version": "0.1.0",
+  "description": "Route work through Brigade so verification, outcomes, evidence export, and handoffs are captured instead of leaving Brigade installed-but-dormant.",
+  "tests": ["brigade skills lint brigade-work"]
+}

--- a/src/brigade/templates/skills/note/CHANGELOG.md
+++ b/src/brigade/templates/skills/note/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial bundled note skill: writes an Obsidian-formatted markdown note and syncs it to the configured inbox.

--- a/src/brigade/templates/skills/note/skill.json
+++ b/src/brigade/templates/skills/note/skill.json
@@ -1,0 +1,7 @@
+{
+  "id": "note",
+  "title": "note",
+  "version": "1.0.0",
+  "description": "Create an Obsidian-formatted markdown note documenting the current session topic and sync it to the configured Obsidian inbox.",
+  "tests": ["brigade skills lint note"]
+}

--- a/src/brigade/templates/skills/ultra-work-scout/CHANGELOG.md
+++ b/src/brigade/templates/skills/ultra-work-scout/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial bundled ultra-work-scout skill: splits a large task into bounded parallel scouting jobs before implementation.

--- a/src/brigade/templates/skills/ultra-work-scout/skill.json
+++ b/src/brigade/templates/skills/ultra-work-scout/skill.json
@@ -1,0 +1,7 @@
+{
+  "id": "ultra-work-scout",
+  "title": "ultra-work-scout",
+  "version": "0.1.0",
+  "description": "Turn a large request into a small number of parallel, bounded scouting jobs before changing code, then bring the results back into one implementation path.",
+  "tests": ["brigade skills lint ultra-work-scout"]
+}

--- a/tests/test_skill_templates_metadata.py
+++ b/tests/test_skill_templates_metadata.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from brigade import skills_cmd
+from brigade.templates import template_root
+
+BUNDLED_TEMPLATES = ("brigade-work", "note", "ultra-work-scout")
+
+
+def _doctor_issue_names(skill_id, target, capsys):
+    assert skills_cmd.doctor(target=target, json_output=True) == 0
+    doctor = json.loads(capsys.readouterr().out)
+    return {issue["name"] for issue in doctor["issues"] if issue.get("skill_id") == skill_id}
+
+
+@pytest.mark.parametrize("skill_id", BUNDLED_TEMPLATES)
+def test_bundled_template_imports_without_tests_or_changelog_warnings(skill_id, tmp_path, capsys):
+    source = template_root() / "skills" / skill_id
+    assert (source / "SKILL.md").is_file()
+
+    assert skills_cmd.import_skill(target=tmp_path, source=source, json_output=True) == 0
+    capsys.readouterr()
+
+    names = _doctor_issue_names(skill_id, tmp_path, capsys)
+    # tests + changelog advisories must be resolved by shipped metadata...
+    assert "skill_tests_missing" not in names
+    assert "skill_changelog_missing" not in names
+    # ...but templates must NOT pre-approve their own trust: the unreviewed
+    # advisory is correct and must survive import.
+    assert "skill_unreviewed_trust" in names
+
+
+@pytest.mark.parametrize("skill_id", BUNDLED_TEMPLATES)
+def test_bundled_template_ships_tests_and_changelog_inside_dir(skill_id):
+    source = template_root() / "skills" / skill_id
+    # CHANGELOG.md must live inside the skill dir so it travels with the
+    # copytree registry import; a changelog_path pointing outside would dangle.
+    assert (source / "CHANGELOG.md").is_file()
+
+    metadata = json.loads((source / "skill.json").read_text())
+    tests = metadata.get("tests")
+    assert isinstance(tests, list) and tests, "template must declare at least one honest test"
+    # trust is a per-workspace review decision; templates stay unreviewed.
+    assert "trust_level" not in metadata


### PR DESCRIPTION
## Why

Closes #170. The first thing `brigade skills doctor` told a new user about Brigade's own bundled skills was that they fail Brigade's quality bar (`skill_tests_missing`, `skill_changelog_missing`).

## Change

Each bundled template (`brigade-work`, `note`, `ultra-work-scout`) now ships:

- `skill.json` with an honest minimal test (`brigade skills lint <id>`), read by `_registry_import_payload` on import
- a per-skill `CHANGELOG.md` inside the skill dir so it travels with the registry copy (no dangling `changelog_path`)
- deliberately NO `trust_level`: templates must not pre-approve themselves, so `skill_unreviewed_trust` still fires (asserted per template in the tests)

## Verification

- `tests/test_skill_templates_metadata.py`: 6 tests importing each template into a tmp registry and asserting the two warnings are gone while the trust warning remains (TDD; failed before the files existed).
- Full suite independently rerun: 1720 passed, 1 skipped (pre-existing codex gate).

## Provenance note

Built by an all-claude/claude-opus-4-8 brigade roster (tmux relay lane) as part of the model scorecard series (#180). First attempt failed before inference started (relay cold-boot timeout under 4-way parallel load; shim startup window now 120s) - the failed run stays in the artifacts as lane-reliability data.