### PR TITLE
fix: attach GraphTrail context to Brigade work evidence

### DIFF
--- a/docs/phase-graphtrail-integration-hardening.md
+++ b/docs/phase-graphtrail-integration-hardening.md
@@ -12,11 +12,11 @@ Architecture: verification receipts reference the previous receipt by stable met
 
 ### Task 1: Compact previous verification evidence
 
-- [ ] Add a failing test that creates a prior receipt containing nested `evidence`, runs a second verification, and asserts the new receipt contains only prior `run_id`, status, path, and digest, with no nested `evidence` key.
-- [ ] Run the focused test; expect failure because the full previous receipt is embedded.
-- [ ] Replace full-payload embedding with a compact reference derived from the prior receipt and its digest.
-- [ ] Run the focused test and receipt-signing tests; expect pass.
-- [ ] Commit `fix(work): reference prior verification receipts compactly`.
+- [x] Add a failing test that creates a prior receipt containing nested `evidence`, runs a second verification, and asserts the new receipt contains only prior `run_id`, status, path, and digest, with no nested `evidence` key.
+- [x] Run the focused test; expect failure because the full previous receipt is embedded.
+- [x] Replace full-payload embedding with a compact reference derived from the prior receipt and its digest.
+- [x] Run the focused test and receipt-signing tests; expect pass.
+- [x] Commit `fix(work): reference prior verification receipts compactly`.
 
 ### Task 2: Attach GraphTrail context before work
 

--- a/docs/phase-graphtrail-integration-hardening.md
+++ b/docs/phase-graphtrail-integration-hardening.md
@@ -28,5 +28,10 @@ Architecture: verification receipts reference the previous receipt by stable met
 
 ### Task 3: Final verification
 
-- [ ] Run through Brigade with `PY` pointing at the existing development venv: `./scripts/verify`.
-- [ ] Generate two temporary verification receipts and assert the second stays below 100 KB and parses with `jq`.
+- [x] Run through Brigade with `PY` pointing at the existing development venv: `./scripts/verify`.
+- [x] Generate two temporary verification receipts and assert the second stays below 100 KB and parses with `jq`.
+
+Verification evidence:
+
+- Branch-backed Brigade run `20260709-201930-work-verify-342ea9`: Ruff checks passed, 374 files were already formatted, version 0.21.1 matched 12 locations, and pytest reported 1,813 passed and 1 skipped.
+- Temporary branch-backed receipts were 3,257 bytes and 3,582 bytes. The second parsed with `jq`, contained only `digest`, `path`, `run_id`, and `status` in its prior-receipt reference, matched the first receipt digest, and remained below 100 KB.

--- a/docs/phase-graphtrail-integration-hardening.md
+++ b/docs/phase-graphtrail-integration-hardening.md
@@ -1,0 +1,32 @@
+# GraphTrail Integration Hardening
+
+Goal: stop recursive Brigade receipt growth and ensure GraphTrail pre-edit context is attached when an indexed target and task are available.
+
+Architecture: verification receipts reference the previous receipt by stable metadata only, never by embedding its full payload. Work briefs reuse the existing GraphTrail context renderer and record a compact attachment result without turning missing GraphTrail into a hard failure.
+
+## File map
+
+- `src/brigade/work_cmd/verification.py`, `tests/test_work_cmd_verification.py`: previous-receipt evidence compaction.
+- `src/brigade/work_cmd/brief.py`, `src/brigade/context_cmd.py`, relevant tests: pre-edit GraphTrail brief attachment.
+- `docs/` and changelog/release notes where the integration contract is documented.
+
+### Task 1: Compact previous verification evidence
+
+- [ ] Add a failing test that creates a prior receipt containing nested `evidence`, runs a second verification, and asserts the new receipt contains only prior `run_id`, status, path, and digest, with no nested `evidence` key.
+- [ ] Run the focused test; expect failure because the full previous receipt is embedded.
+- [ ] Replace full-payload embedding with a compact reference derived from the prior receipt and its digest.
+- [ ] Run the focused test and receipt-signing tests; expect pass.
+- [ ] Commit `fix(work): reference prior verification receipts compactly`.
+
+### Task 2: Attach GraphTrail context before work
+
+- [ ] Add a failing test for a target with `.graphtrail/graphtrail.db`, a fake GraphTrail binary, and a selected task. Assert `work brief --json` contains an attached code-graph brief and a nonzero context record.
+- [ ] Run the focused test; expect failure because current work briefs report no attached context.
+- [ ] Reuse the existing context helper from the work-brief path, keep missing binary/db/task fail-open, and record attachment metadata in the brief payload.
+- [ ] Run focused work/context tests; expect pass.
+- [ ] Commit `feat(work): attach graphtrail context to pre-edit briefs`.
+
+### Task 3: Final verification
+
+- [ ] Run through Brigade with `PY` pointing at the existing development venv: `./scripts/verify`.
+- [ ] Generate two temporary verification receipts and assert the second stays below 100 KB and parses with `jq`.

--- a/docs/phase-graphtrail-integration-hardening.md
+++ b/docs/phase-graphtrail-integration-hardening.md
@@ -7,7 +7,7 @@ Architecture: verification receipts reference the previous receipt by stable met
 ## File map
 
 - `src/brigade/work_cmd/verification.py`, `tests/test_work_cmd_verification.py`: previous-receipt evidence compaction.
-- `src/brigade/work_cmd/brief.py`, `src/brigade/context_cmd.py`, relevant tests: pre-edit GraphTrail brief attachment.
+- `src/brigade/work_cmd/session.py`, `src/brigade/context_cmd.py`, relevant tests: pre-edit GraphTrail brief attachment.
 - `docs/` and changelog/release notes where the integration contract is documented.
 
 ### Task 1: Compact previous verification evidence
@@ -20,11 +20,11 @@ Architecture: verification receipts reference the previous receipt by stable met
 
 ### Task 2: Attach GraphTrail context before work
 
-- [ ] Add a failing test for a target with `.graphtrail/graphtrail.db`, a fake GraphTrail binary, and a selected task. Assert `work brief --json` contains an attached code-graph brief and a nonzero context record.
-- [ ] Run the focused test; expect failure because current work briefs report no attached context.
-- [ ] Reuse the existing context helper from the work-brief path, keep missing binary/db/task fail-open, and record attachment metadata in the brief payload.
-- [ ] Run focused work/context tests; expect pass.
-- [ ] Commit `feat(work): attach graphtrail context to pre-edit briefs`.
+- [x] Add a failing test for a target with `.graphtrail/graphtrail.db`, a fake GraphTrail binary, and a selected task. Assert `work brief --json` contains an attached code-graph brief and a nonzero context record.
+- [x] Run the focused test; expect failure because current work briefs report no attached context.
+- [x] Reuse the existing context helper from the work-brief path, keep missing binary/db/task fail-open, and record attachment metadata in the brief payload.
+- [x] Run focused work/context tests; expect pass.
+- [x] Commit `feat(work): attach graphtrail context to pre-edit briefs`.
 
 ### Task 3: Final verification
 

--- a/src/brigade/work_cmd/session.py
+++ b/src/brigade/work_cmd/session.py
@@ -554,6 +554,7 @@ def _compact_repo_fleet_health(payload: dict[str, Any]) -> dict[str, Any]:
 
 def _brief_payload(target: Path, *, limit: int = 3) -> dict[str, Any]:
     from .. import (
+        aboyeur,
         center_cmd,
         chat_cmd,
         context_cmd,
@@ -579,6 +580,12 @@ def _brief_payload(target: Path, *, limit: int = 3) -> dict[str, Any]:
     latest_session = helpers._session_info(sessions[0][0], sessions[0][1]) if sessions else None
     recent_sessions = [helpers._session_info(path, payload) for path, payload in sessions[:limit]]
     resolved = _resolve_next_task(target)
+    task_text = str(resolved.get("task") or "").strip()
+    code_graph = (
+        aboyeur.code_graph_brief(target, task_text)
+        if task_text and resolved.get("source") != "default_review"
+        else None
+    )
     ledger_task = resolved.get("ledger_task") if isinstance(resolved.get("ledger_task"), dict) else None
     git = helpers._git_snapshot(target)
     suggested = _suggested_command(active, resolved["task"], resolved["source"])
@@ -712,6 +719,11 @@ def _brief_payload(target: Path, *, limit: int = 3) -> dict[str, Any]:
         },
         "pantry": pantry_health,
         "notifications": notification_health,
+        "code_graph_context": code_graph.text if code_graph is not None and code_graph.attached else None,
+        "code_graph_brief": {
+            "attached": bool(code_graph.attached) if code_graph is not None else False,
+            "bytes": code_graph.bytes if code_graph is not None else 0,
+        },
         "context_packs": {
             "pack_count": context_health["pack_count"],
             "issue_count": context_health["issue_count"],

--- a/src/brigade/work_cmd/session.py
+++ b/src/brigade/work_cmd/session.py
@@ -552,7 +552,7 @@ def _compact_repo_fleet_health(payload: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _brief_payload(target: Path, *, limit: int = 3) -> dict[str, Any]:
+def _brief_payload(target: Path, *, limit: int = 3, include_code_graph: bool = False) -> dict[str, Any]:
     from .. import (
         aboyeur,
         center_cmd,
@@ -583,7 +583,7 @@ def _brief_payload(target: Path, *, limit: int = 3) -> dict[str, Any]:
     task_text = str(resolved.get("task") or "").strip()
     code_graph = (
         aboyeur.code_graph_brief(target, task_text)
-        if task_text and resolved.get("source") != "default_review"
+        if include_code_graph and task_text and resolved.get("source") != "default_review"
         else None
     )
     ledger_task = resolved.get("ledger_task") if isinstance(resolved.get("ledger_task"), dict) else None
@@ -1177,7 +1177,7 @@ def brief(*, target: Path, limit: int = 3, json_output: bool = False) -> int:
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
 
-    payload = _brief_payload(target, limit=limit)
+    payload = _brief_payload(target, limit=limit, include_code_graph=json_output)
     if json_output:
         print(json.dumps(payload, indent=2, sort_keys=True))
         return 0

--- a/src/brigade/work_cmd/verification.py
+++ b/src/brigade/work_cmd/verification.py
@@ -124,6 +124,18 @@ def _latest_verify_receipt(target: Path) -> dict[str, Any] | None:
     return receipts[0] if receipts else None
 
 
+def _verify_receipt_reference(receipt: dict[str, Any] | None) -> dict[str, Any] | None:
+    if receipt is None:
+        return None
+    digests = receipt.get("digests") if isinstance(receipt.get("digests"), dict) else {}
+    return {
+        "run_id": receipt.get("run_id"),
+        "status": receipt.get("status"),
+        "path": receipt.get("path"),
+        "digest": digests.get("receipt_sha256"),
+    }
+
+
 def _verify_read_receipt(path: Path) -> dict[str, Any] | None:
     receipt = path / "receipt.json" if path.is_dir() else path
     if not receipt.is_file():
@@ -173,7 +185,7 @@ def _verification_evidence_payload(target: Path, session: tuple[Path, dict[str, 
     latest_session = session or (sessions[0] if sessions else None)
     session_info = helpers._session_info(latest_session[0], latest_session[1]) if latest_session else None
     task = _verification_task_from_session(latest_session[1]) if latest_session else None
-    latest_verify = _latest_verify_receipt(target)
+    latest_verify = _verify_receipt_reference(_latest_verify_receipt(target))
     sweep_health = scanners_mod._scanner_sweep_health(target)
     review_health = reviews_mod._review_health(target)
     handoff_drafts = handoff_cmd.draft_queue_payload(target)

--- a/tests/test_work_cmd_session.py
+++ b/tests/test_work_cmd_session.py
@@ -2,6 +2,7 @@ import json
 import subprocess
 from datetime import datetime, timezone
 
+from brigade import aboyeur
 from brigade import cli
 from brigade import center_cmd
 from brigade import dogfood_cmd
@@ -694,15 +695,37 @@ def test_work_brief_json_attaches_graphtrail_context_for_selected_task(tmp_path,
     }
 
 
+def test_plain_work_brief_skips_graphtrail_while_json_attaches(tmp_path, monkeypatch, capsys):
+    _init_git_repo(tmp_path)
+    assert work_cmd.task_add(target=tmp_path, text="Attach GraphTrail only to JSON brief") == 0
+    capsys.readouterr()
+    calls = []
+    text = "## Code graph context (GraphTrail, read-only)\n\nselected task context\n"
+
+    def fake_code_graph_brief(target, task):
+        calls.append((target, task))
+        return aboyeur.CodeGraphBrief(attached=True, text=text, bytes=len(text.encode()))
+
+    monkeypatch.setattr(aboyeur, "code_graph_brief", fake_code_graph_brief)
+
+    assert cli.main(["work", "brief", "--target", str(tmp_path)]) == 0
+    capsys.readouterr()
+    assert calls == []
+
+    assert cli.main(["work", "brief", "--target", str(tmp_path), "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert calls == [(tmp_path.resolve(), "Attach GraphTrail only to JSON brief")]
+    assert payload["code_graph_context"] == text
+    assert payload["code_graph_brief"] == {"attached": True, "bytes": len(text.encode())}
+
+
 def test_work_brief_json_skips_graphtrail_without_selected_task(tmp_path, monkeypatch, capsys):
     _init_git_repo(tmp_path)
-    db = tmp_path / ".graphtrail" / "graphtrail.db"
-    db.parent.mkdir()
-    db.write_text("")
-    graphtrail = tmp_path / "fake-graphtrail"
-    graphtrail.write_text("#!/bin/sh\nprintf '%s\\n' 'unexpected default-review context'\n")
-    graphtrail.chmod(0o755)
-    monkeypatch.setenv("GRAPHTRAIL_BIN", str(graphtrail))
+
+    def fail_if_called(target, task):
+        raise AssertionError(f"unexpected GraphTrail call for {target}: {task}")
+
+    monkeypatch.setattr(aboyeur, "code_graph_brief", fail_if_called)
 
     assert cli.main(["work", "brief", "--target", str(tmp_path), "--json"]) == 0
     payload = json.loads(capsys.readouterr().out)

--- a/tests/test_work_cmd_session.py
+++ b/tests/test_work_cmd_session.py
@@ -671,6 +671,46 @@ def test_work_brief_json_reports_recent_sessions(tmp_path, monkeypatch, capsys):
     assert payload["suggested_command"] == 'brigade work end --note "..." --handoff'
 
 
+def test_work_brief_json_attaches_graphtrail_context_for_selected_task(tmp_path, monkeypatch, capsys):
+    _init_git_repo(tmp_path)
+    db = tmp_path / ".graphtrail" / "graphtrail.db"
+    db.parent.mkdir()
+    db.write_text("")
+    graphtrail = tmp_path / "fake-graphtrail"
+    graphtrail.write_text("#!/bin/sh\nprintf '%s\\n' '### Entry points' '- brigade.work_cmd.session._brief_payload'\n")
+    graphtrail.chmod(0o755)
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(graphtrail))
+    assert work_cmd.task_add(target=tmp_path, text="Attach GraphTrail to work brief") == 0
+    capsys.readouterr()
+
+    assert cli.main(["work", "brief", "--target", str(tmp_path), "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    context = payload["code_graph_context"]
+
+    assert "brigade.work_cmd.session._brief_payload" in context
+    assert payload["code_graph_brief"] == {
+        "attached": True,
+        "bytes": len(context.encode()),
+    }
+
+
+def test_work_brief_json_skips_graphtrail_without_selected_task(tmp_path, monkeypatch, capsys):
+    _init_git_repo(tmp_path)
+    db = tmp_path / ".graphtrail" / "graphtrail.db"
+    db.parent.mkdir()
+    db.write_text("")
+    graphtrail = tmp_path / "fake-graphtrail"
+    graphtrail.write_text("#!/bin/sh\nprintf '%s\\n' 'unexpected default-review context'\n")
+    graphtrail.chmod(0o755)
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(graphtrail))
+
+    assert cli.main(["work", "brief", "--target", str(tmp_path), "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["code_graph_context"] is None
+    assert payload["code_graph_brief"] == {"attached": False, "bytes": 0}
+
+
 def test_work_brief_json_compacts_heavy_report_and_fleet_health(tmp_path, monkeypatch, capsys):
     _init_git_repo(tmp_path)
     dogfood_cmd.init(target=tmp_path)

--- a/tests/test_work_cmd_verification.py
+++ b/tests/test_work_cmd_verification.py
@@ -344,6 +344,49 @@ def test_work_verify_receipt_digests_recompute_from_payload_and_logs(tmp_path, c
     assert stored["digests"] == digests
 
 
+def test_work_verify_receipt_compacts_prior_nested_evidence(tmp_path, capsys, monkeypatch):
+    prior_dir = tmp_path / ".brigade" / "work" / "verify-runs" / "20260708-120000-work-verify-prior"
+    prior_digest = "a" * 64
+    prior_dir.mkdir(parents=True)
+    _write_json(
+        prior_dir / "receipt.json",
+        {
+            "run_id": prior_dir.name,
+            "status": "completed",
+            "path": str(prior_dir),
+            "started_at": "2026-07-08T12:00:00+00:00",
+            "digests": {"receipt_sha256": prior_digest},
+            "evidence": {
+                "latest_verify": {
+                    "run_id": "20260707-120000-work-verify-older",
+                    "evidence": {"latest_verify": {"run_id": "nested"}},
+                }
+            },
+        },
+    )
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(tmp_path / "missing-graphtrail"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    assert (
+        work_cmd.verify_run(
+            target=tmp_path,
+            commands=[f"{sys.executable} -c \"print('ok')\""],
+            timeout=30,
+            json_output=True,
+        )
+        == 0
+    )
+    receipt = json.loads(capsys.readouterr().out)
+
+    assert receipt["evidence"]["latest_verify"] == {
+        "run_id": prior_dir.name,
+        "status": "completed",
+        "path": str(prior_dir),
+        "digest": prior_digest,
+    }
+    assert "evidence" not in receipt["evidence"]["latest_verify"]
+
+
 def test_work_verify_receipt_captures_git_state_before_digest(tmp_path, capsys, monkeypatch):
     _init_git_repo_with_head(tmp_path)
     (tmp_path / "dirty.txt").write_text("dirty\n")


### PR DESCRIPTION
## Summary

- Replace recursive prior-receipt embedding with a four-field reference containing run ID, status, path, and digest.
- Attach bounded GraphTrail context to JSON work briefs when Brigade selects a ledger or dogfood task.
- Keep plain-text briefs and default-review fallbacks free of GraphTrail subprocess work.

## Verification

- `./scripts/verify`
- 1,814 tests passed, with one expected Codex integration skip
- Final branch-generated receipt was 5,447 bytes and contained a compact prior-run reference

## Review notes

- Work brief assembly reuses the existing 4,000-character GraphTrail renderer.
- The change does not create context-pack records or alter task selection.