### PR TITLE
fix: pass writable flags to Antigravity and Kimi

### DIFF
--- a/src/brigade/agents.py
+++ b/src/brigade/agents.py
@@ -15,11 +15,11 @@ from . import proc
 _OLLAMA_PREFIX = "ollama:"
 
 
-def _claude_argv(prompt: str, read_only: bool, sandbox: str | None) -> List[str]:
+def _claude_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | None) -> List[str]:
     return ["claude", "-p", prompt]
 
 
-def _codex_argv(prompt: str, read_only: bool, sandbox: str | None) -> List[str]:
+def _codex_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | None) -> List[str]:
     if sandbox:
         return ["codex", "exec", "--sandbox", sandbox, prompt]
     if read_only:
@@ -27,23 +27,27 @@ def _codex_argv(prompt: str, read_only: bool, sandbox: str | None) -> List[str]:
     return ["codex", "exec", prompt]
 
 
-def _opencode_argv(prompt: str, read_only: bool, sandbox: str | None) -> List[str]:
+def _opencode_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | None) -> List[str]:
     return ["opencode", "run", prompt]
 
 
-def _antigravity_argv(prompt: str, read_only: bool, sandbox: str | None) -> List[str]:
+def _antigravity_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | None) -> List[str]:
     if read_only or sandbox == "read-only":
         return ["agy", "--sandbox", "--print", prompt]
-    return ["agy", "--print", prompt]
+    argv = ["agy"]
+    if cwd is not None:
+        argv.extend(["--add-dir", str(cwd)])
+    argv.extend(["--dangerously-skip-permissions", "--print", prompt])
+    return argv
 
 
-def _pi_argv(prompt: str, read_only: bool, sandbox: str | None) -> List[str]:
+def _pi_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | None) -> List[str]:
     if read_only or sandbox == "read-only":
         return ["pi", "--tools", "read,grep,find,ls", "-p", prompt]
     return ["pi", "-p", prompt]
 
 
-def _cursor_argv(prompt: str, read_only: bool, sandbox: str | None) -> List[str]:
+def _cursor_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | None) -> List[str]:
     if read_only or sandbox == "read-only":
         return ["cursor-agent", "-p", "--mode", "plan", "--output-format", "text", prompt]
     return ["cursor-agent", "-p", "--output-format", "text", prompt]
@@ -53,51 +57,53 @@ def _read_only_prompt(prompt: str) -> str:
     return f"Read-only planning run. Inspect and answer, but do not modify files or run mutating commands.\n\n{prompt}"
 
 
-def _aider_argv(prompt: str, read_only: bool, sandbox: str | None) -> List[str]:
+def _aider_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | None) -> List[str]:
     if read_only or sandbox == "read-only":
         return ["aider", "--no-auto-commits", "--dry-run", "--message", prompt]
     return ["aider", "--yes", "--no-auto-commits", "--message", prompt]
 
 
-def _goose_argv(prompt: str, read_only: bool, sandbox: str | None) -> List[str]:
+def _goose_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | None) -> List[str]:
     task = _read_only_prompt(prompt) if read_only or sandbox == "read-only" else prompt
     return ["goose", "run", "--no-session", "-t", task]
 
 
-def _continue_argv(prompt: str, read_only: bool, sandbox: str | None) -> List[str]:
+def _continue_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | None) -> List[str]:
     if read_only or sandbox == "read-only":
         return ["cn", "-p", prompt, "--readonly"]
     return ["cn", "-p", prompt]
 
 
-def _copilot_argv(prompt: str, read_only: bool, sandbox: str | None) -> List[str]:
+def _copilot_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | None) -> List[str]:
     task = _read_only_prompt(prompt) if read_only or sandbox == "read-only" else prompt
     return ["copilot", "-p", task]
 
 
-def _qwen_argv(prompt: str, read_only: bool, sandbox: str | None) -> List[str]:
+def _qwen_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | None) -> List[str]:
     mode = "plan" if read_only or sandbox == "read-only" else "yolo"
     return ["qwen", "-p", prompt, "--approval-mode", mode]
 
 
-def _kimi_argv(prompt: str, read_only: bool, sandbox: str | None) -> List[str]:
+def _kimi_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | None) -> List[str]:
     argv = ["kimi", "--print", "-p", prompt, "--final-message-only"]
     if read_only or sandbox == "read-only":
         argv.insert(1, "--plan")
+    else:
+        argv.insert(1, "--yolo")
     return argv
 
 
-def _adal_argv(prompt: str, read_only: bool, sandbox: str | None) -> List[str]:
+def _adal_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | None) -> List[str]:
     task = _read_only_prompt(prompt) if read_only or sandbox == "read-only" else prompt
     return ["adal", "-q", task]
 
 
-def _openhands_argv(prompt: str, read_only: bool, sandbox: str | None) -> List[str]:
+def _openhands_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | None) -> List[str]:
     task = _read_only_prompt(prompt) if read_only or sandbox == "read-only" else prompt
     return ["openhands", "--headless", "-t", task]
 
 
-def _grok_argv(prompt: str, read_only: bool, sandbox: str | None) -> List[str]:
+def _grok_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | None) -> List[str]:
     # Headless `grok -p` stops silently (exit 0) at the first tool-approval
     # gate, so a write task without an approval flag no-ops after its preamble.
     if read_only or sandbox == "read-only":
@@ -105,17 +111,17 @@ def _grok_argv(prompt: str, read_only: bool, sandbox: str | None) -> List[str]:
     return ["grok", "-p", prompt, "--always-approve"]
 
 
-def _amp_argv(prompt: str, read_only: bool, sandbox: str | None) -> List[str]:
+def _amp_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | None) -> List[str]:
     task = _read_only_prompt(prompt) if read_only or sandbox == "read-only" else prompt
     return ["amp", "-x", task]
 
 
-def _crush_argv(prompt: str, read_only: bool, sandbox: str | None) -> List[str]:
+def _crush_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | None) -> List[str]:
     task = _read_only_prompt(prompt) if read_only or sandbox == "read-only" else prompt
     return ["crush", "run", task]
 
 
-_ADAPTERS: dict[str, Callable[[str, bool, str | None], List[str]]] = {
+_ADAPTERS: dict[str, Callable[[str, bool, str | None, Path | None], List[str]]] = {
     "claude": _claude_argv,
     "codex": _codex_argv,
     "opencode": _opencode_argv,
@@ -247,6 +253,7 @@ def build_argv(
     read_only: bool = False,
     sandbox: str | None = None,
     model: str | None = None,
+    cwd: Path | None = None,
 ) -> List[str]:
     if cli_ref.startswith(_OLLAMA_PREFIX):
         ollama_model = cli_ref[len(_OLLAMA_PREFIX) :]
@@ -263,7 +270,7 @@ def build_argv(
             "(known: claude, codex, opencode, antigravity, pi, cursor, aider, goose, continue, "
             "copilot, qwen, kimi, adal, openhands, grok, amp, crush, ollama:<model>)"
         )
-    argv = builder(prompt, read_only, sandbox)
+    argv = builder(prompt, read_only, sandbox, cwd)
     if model is not None:
         argv = _with_model(cli_ref, argv, model)
     return argv
@@ -286,7 +293,7 @@ def run_agent(
         return AgentResult(text="", ok=False, detail=f"{command_for(cli_ref)} not installed")
 
     result = proc.run(
-        build_argv(cli_ref, prompt, read_only=read_only, sandbox=sandbox, model=model),
+        build_argv(cli_ref, prompt, read_only=read_only, sandbox=sandbox, model=model, cwd=cwd),
         timeout=timeout,
         cwd=cwd,
     )

--- a/src/brigade/agents.py
+++ b/src/brigade/agents.py
@@ -34,9 +34,8 @@ def _opencode_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path 
 def _antigravity_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | None) -> List[str]:
     if read_only or sandbox == "read-only":
         return ["agy", "--sandbox", "--print", prompt]
-    argv = ["agy"]
-    if cwd is not None:
-        argv.extend(["--add-dir", str(cwd)])
+    effective_cwd = cwd if cwd is not None else Path.cwd().resolve()
+    argv = ["agy", "--add-dir", str(effective_cwd)]
     argv.extend(["--dangerously-skip-permissions", "--print", prompt])
     return argv
 

--- a/tests/test_agent_write_probes.py
+++ b/tests/test_agent_write_probes.py
@@ -1,0 +1,57 @@
+"""Opt-in real adapter write probes.
+
+These tests intentionally run third-party CLIs against a temporary directory.
+They are skipped by default because they depend on local authentication and may
+consume model quota.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from brigade import agents
+
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("BRIGADE_AGENT_WRITE_PROBES") != "1",
+    reason="set BRIGADE_AGENT_WRITE_PROBES=1 to run real adapter write probes",
+)
+
+
+def _run_probe(cli_ref: str, prompt: str, tmp_path: Path) -> None:
+    if not agents.detect(cli_ref):
+        pytest.skip(f"{agents.command_for(cli_ref)} is not installed")
+    result = subprocess.run(
+        agents.build_argv(cli_ref, prompt, cwd=tmp_path),
+        cwd=tmp_path,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=120,
+    )
+    assert result.returncode == 0, result.stderr[-1000:]
+
+
+def test_antigravity_writable_probe_creates_file_in_temp_dir(tmp_path: Path):
+    target = tmp_path / "antigravity-write-probe.txt"
+    _run_probe(
+        "antigravity",
+        f"Create a file named {target.name} containing exactly: antigravity write probe",
+        tmp_path,
+    )
+    assert target.read_text().strip() == "antigravity write probe"
+
+
+def test_kimi_writable_probe_creates_file_in_temp_dir(tmp_path: Path):
+    target = tmp_path / "kimi-write-probe.txt"
+    _run_probe(
+        "kimi",
+        f"Create a file named {target.name} containing exactly: kimi write probe",
+        tmp_path,
+    )
+    assert target.read_text().strip() == "kimi write probe"

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -7,7 +7,12 @@ def test_build_argv_for_known_clis():
     assert agents.build_argv("claude", "hi") == ["claude", "-p", "hi"]
     assert agents.build_argv("codex", "hi") == ["codex", "exec", "hi"]
     assert agents.build_argv("opencode", "hi") == ["opencode", "run", "hi"]
-    assert agents.build_argv("antigravity", "hi") == ["agy", "--print", "hi"]
+    assert agents.build_argv("antigravity", "hi") == [
+        "agy",
+        "--dangerously-skip-permissions",
+        "--print",
+        "hi",
+    ]
     assert agents.build_argv("pi", "hi") == ["pi", "-p", "hi"]
     assert agents.build_argv("cursor", "hi") == ["cursor-agent", "-p", "--output-format", "text", "hi"]
     assert agents.build_argv("aider", "hi") == ["aider", "--yes", "--no-auto-commits", "--message", "hi"]
@@ -15,7 +20,14 @@ def test_build_argv_for_known_clis():
     assert agents.build_argv("continue", "hi") == ["cn", "-p", "hi"]
     assert agents.build_argv("copilot", "hi") == ["copilot", "-p", "hi"]
     assert agents.build_argv("qwen", "hi") == ["qwen", "-p", "hi", "--approval-mode", "yolo"]
-    assert agents.build_argv("kimi", "hi") == ["kimi", "--print", "-p", "hi", "--final-message-only"]
+    assert agents.build_argv("kimi", "hi") == [
+        "kimi",
+        "--yolo",
+        "--print",
+        "-p",
+        "hi",
+        "--final-message-only",
+    ]
     assert agents.build_argv("adal", "hi") == ["adal", "-q", "hi"]
     assert agents.build_argv("openhands", "hi") == ["openhands", "--headless", "-t", "hi"]
     assert agents.build_argv("grok", "hi") == ["grok", "-p", "hi", "--always-approve"]
@@ -81,6 +93,51 @@ def test_build_argv_for_read_only_codex():
         "llama3.3",
         "hi",
     ]
+
+
+def test_build_argv_antigravity_writable_uses_cwd_write_approval(tmp_path):
+    assert agents.build_argv("antigravity", "hi", cwd=tmp_path) == [
+        "agy",
+        "--add-dir",
+        str(tmp_path),
+        "--dangerously-skip-permissions",
+        "--print",
+        "hi",
+    ]
+
+
+def test_build_argv_antigravity_read_only_keeps_sandbox_without_write_flags(tmp_path):
+    assert agents.build_argv("antigravity", "hi", read_only=True, cwd=tmp_path) == [
+        "agy",
+        "--sandbox",
+        "--print",
+        "hi",
+    ]
+    argv = agents.build_argv("antigravity", "hi", sandbox="read-only", cwd=tmp_path)
+    assert argv == ["agy", "--sandbox", "--print", "hi"]
+    assert "--add-dir" not in argv
+    assert "--dangerously-skip-permissions" not in argv
+
+
+def test_build_argv_kimi_writable_uses_yolo_and_read_only_keeps_plan():
+    assert agents.build_argv("kimi", "hi") == [
+        "kimi",
+        "--yolo",
+        "--print",
+        "-p",
+        "hi",
+        "--final-message-only",
+    ]
+    read_only = agents.build_argv("kimi", "hi", read_only=True)
+    assert read_only == [
+        "kimi",
+        "--plan",
+        "--print",
+        "-p",
+        "hi",
+        "--final-message-only",
+    ]
+    assert "--yolo" not in read_only
 
 
 def test_build_argv_can_set_codex_sandbox():
@@ -225,6 +282,29 @@ def test_run_agent_forwards_model_to_argv(monkeypatch):
     res = agents.run_agent("claude", "hi", model="claude-fable-5")
     assert res.ok is True
     assert captured["argv"] == ["claude", "--model", "claude-fable-5", "-p", "hi"]
+
+
+def test_run_agent_threads_cwd_into_argv_builder(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_run(argv, **kw):
+        captured["argv"] = argv
+        captured["cwd"] = kw["cwd"]
+        return agents.proc.Result(0, "answer", "")
+
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(agents.proc, "run", fake_run)
+    res = agents.run_agent("antigravity", "hi", cwd=tmp_path)
+    assert res.ok is True
+    assert captured["cwd"] == tmp_path
+    assert captured["argv"] == [
+        "agy",
+        "--add-dir",
+        str(tmp_path),
+        "--dangerously-skip-permissions",
+        "--print",
+        "hi",
+    ]
 
 
 def test_run_agent_nonzero_is_not_ok(monkeypatch):

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from brigade import agents
@@ -9,6 +11,8 @@ def test_build_argv_for_known_clis():
     assert agents.build_argv("opencode", "hi") == ["opencode", "run", "hi"]
     assert agents.build_argv("antigravity", "hi") == [
         "agy",
+        "--add-dir",
+        str(Path.cwd().resolve()),
         "--dangerously-skip-permissions",
         "--print",
         "hi",
@@ -100,6 +104,58 @@ def test_build_argv_antigravity_writable_uses_cwd_write_approval(tmp_path):
         "agy",
         "--add-dir",
         str(tmp_path),
+        "--dangerously-skip-permissions",
+        "--print",
+        "hi",
+    ]
+
+
+def test_build_argv_antigravity_writable_preserves_explicit_cwd():
+    cwd = Path("workspace")
+
+    assert agents.build_argv("antigravity", "hi", cwd=cwd) == [
+        "agy",
+        "--add-dir",
+        "workspace",
+        "--dangerously-skip-permissions",
+        "--print",
+        "hi",
+    ]
+
+
+def test_build_argv_antigravity_writable_uses_current_cwd_when_cwd_omitted(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    assert agents.build_argv("antigravity", "hi") == [
+        "agy",
+        "--add-dir",
+        str(tmp_path.resolve()),
+        "--dangerously-skip-permissions",
+        "--print",
+        "hi",
+    ]
+
+
+def test_research_antigravity_cli_uses_current_cwd_when_cwd_omitted(tmp_path, monkeypatch):
+    from brigade.research import llm
+
+    captured = {}
+
+    def fake_run(argv, **kw):
+        captured["argv"] = argv
+        captured["cwd"] = kw["cwd"]
+        return agents.proc.Result(0, "answer", "")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(agents.proc, "run", fake_run)
+
+    assert llm._run_cli("antigravity", "hi", 10) == "answer"
+    assert captured["cwd"] is None
+    assert captured["argv"] == [
+        "agy",
+        "--add-dir",
+        str(tmp_path.resolve()),
         "--dangerously-skip-permissions",
         "--print",
         "hi",
@@ -301,6 +357,31 @@ def test_run_agent_threads_cwd_into_argv_builder(monkeypatch, tmp_path):
         "agy",
         "--add-dir",
         str(tmp_path),
+        "--dangerously-skip-permissions",
+        "--print",
+        "hi",
+    ]
+
+
+def test_run_agent_antigravity_with_no_cwd_allows_current_cwd(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_run(argv, **kw):
+        captured["argv"] = argv
+        captured["cwd"] = kw["cwd"]
+        return agents.proc.Result(0, "answer", "")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(agents.proc, "run", fake_run)
+    res = agents.run_agent("antigravity", "hi")
+
+    assert res.ok is True
+    assert captured["cwd"] is None
+    assert captured["argv"] == [
+        "agy",
+        "--add-dir",
+        str(tmp_path.resolve()),
         "--dangerously-skip-permissions",
         "--print",
         "hi",

--- a/tests/test_agents_model_pin.py
+++ b/tests/test_agents_model_pin.py
@@ -4,6 +4,8 @@ Every expected argv here is checked against the real CLI's --help flag; the
 adapters covered are the ones with a confirmed model flag on an installed CLI.
 """
 
+from pathlib import Path
+
 import pytest
 
 from brigade import agents
@@ -110,6 +112,8 @@ def test_pins_model_for_antigravity():
         "agy",
         "--model",
         "gpt-5",
+        "--add-dir",
+        str(Path.cwd().resolve()),
         "--dangerously-skip-permissions",
         "--print",
         "P",

--- a/tests/test_agents_model_pin.py
+++ b/tests/test_agents_model_pin.py
@@ -72,6 +72,7 @@ def test_pins_model_for_kimi():
         "kimi",
         "-m",
         "kimi-k2.5",
+        "--yolo",
         "--print",
         "-p",
         "P",
@@ -109,6 +110,7 @@ def test_pins_model_for_antigravity():
         "agy",
         "--model",
         "gpt-5",
+        "--dangerously-skip-permissions",
         "--print",
         "P",
     ]


### PR DESCRIPTION
## Summary

- give writable Antigravity runs an explicit working directory and write approval
- give writable Kimi runs `--yolo`
- preserve sandbox and plan behavior for read-only runs

## Verification

- exact argv and model-pinning tests passed
- default and explicit working-directory paths passed
- `./scripts/verify`: 1,911 passed, 3 skipped