### PR TITLE
ci: align local verify with CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,17 +3,7 @@ name: ci
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
-      - 'LICENSE'
-      - '.gitignore'
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
-      - 'LICENSE'
-      - '.gitignore'
 
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,8 +16,15 @@ developing Brigade itself; the contributor policy lives in `CONTRIBUTING.md`.
 ```
 
 It runs the same gates CI blocks on: ruff lint, ruff format check, the
-version-sync check, and the full pytest suite. Report the actual result, paste
-any failure verbatim, and never claim success you did not observe.
+version-sync check, mypy, and the full pytest suite with the coverage floor.
+Report the actual result, paste any failure verbatim, and never claim success
+you did not observe.
+
+CI-only jobs still cover work that is slower, platform-oriented, or depends on
+extra checkout/install context: `content-guard`, `repo-metadata`,
+`install-from-source`, and `quickstart-smoke`. The local `./scripts/verify`
+gate is the fast completion gate; do not treat it as a replacement for those
+CI-only release and public-repo checks.
 
 Setup, if `.venv/` is missing:
 

--- a/scripts/verify
+++ b/scripts/verify
@@ -1,14 +1,15 @@
 #!/bin/bash
 # Single verification entrypoint. CI and AGENTS.md both defer to this file,
 # so the gate lives in exactly one place. Mirrors .github/workflows/ci.yml:
-# ruff lint, ruff format, version sync, pytest.
+# ruff lint, ruff format, mypy, version sync, pytest with coverage.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
 PY=${PY:-.venv/bin}
 "$PY/ruff" check .
 "$PY/ruff" format --check .
+"$PY/mypy"
 # Version sync covers __init__.py, template JSONs, and the recorded demo assets.
 # Run `python scripts/version_sync.py --write` to fix drift in one shot.
 "$PY/python" scripts/version_sync.py --check
-"$PY/pytest" -q
+"$PY/pytest" -q --cov=brigade --cov-report=term --cov-fail-under=78

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_ci_workflow_does_not_skip_docs_only_content_guard():
+    text = (ROOT / ".github/workflows/ci.yml").read_text()
+
+    assert "paths-ignore:" not in text
+    assert "content-guard:" in text
+    assert "python -m content_guard scan" in text
+
+
+def test_agents_doc_names_ci_only_jobs_outside_local_verify():
+    text = (ROOT / "AGENTS.md").read_text()
+
+    assert "CI-only" in text
+    for job in ("content-guard", "repo-metadata", "install-from-source", "quickstart-smoke"):
+        assert job in text

--- a/tests/test_verify_script.py
+++ b/tests/test_verify_script.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_verify_script_runs_mypy_and_coverage_floor():
+    text = (ROOT / "scripts/verify").read_text()
+
+    assert '"$PY/mypy"' in text
+    assert '"$PY/pytest" -q --cov=brigade --cov-report=term --cov-fail-under=78' in text
+
+
+def test_verify_script_documents_same_fast_gate_as_ci():
+    text = (ROOT / "scripts/verify").read_text()
+
+    assert "ruff lint, ruff format, mypy, version sync, pytest with coverage" in text


### PR DESCRIPTION
## Summary

- add mypy and the 78 percent coverage floor to `./scripts/verify`
- ensure documentation-only changes still run content guard
- document the slower checks that remain CI-only

## Verification

- focused workflow and verification-script tests passed
- updated `./scripts/verify` passed