### PR TITLE
fix: pass trust flags to headless cursor-agent runs

### DIFF
--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -371,7 +371,7 @@ brigade runs interrupt latest
 Both commands are local Unix socket requests. They refuse exec-transport runs, completed runs whose socket has been cleaned up, and app-server runs that have no active matching turn.
 
 The `cli` values are adapters for installed command-line tools:
-`codex`, `claude`, `opencode`, `antigravity`, `pi`, `cursor`, and `ollama:<model>`. Brigade shells out to those tools and keeps no provider keys. The Antigravity adapter uses the installed `agy --print` non-interactive CLI path, the Pi adapter uses `pi -p`, and the Cursor adapter uses `cursor-agent -p --output-format text`.
+`codex`, `claude`, `opencode`, `antigravity`, `pi`, `cursor`, and `ollama:<model>`. Brigade shells out to those tools and keeps no provider keys. The Antigravity adapter uses the installed `agy --print` non-interactive CLI path, the Pi adapter uses `pi -p`, and the Cursor adapter uses `cursor-agent -p --output-format text -f` (`--trust` plus `--mode plan` on read-only runs; without a trust flag, headless cursor-agent refuses untrusted workspaces and exits 0).
 Run `brigade roster doctor` to validate roster syntax and check which CLIs are on `PATH`.
 When `--roster` is omitted, `brigade run` first reads `--cwd/.brigade/roster.toml`;
 if that file is missing, it falls back to `Path.home()/.brigade/roster.toml`.

--- a/src/brigade/agents.py
+++ b/src/brigade/agents.py
@@ -47,9 +47,13 @@ def _pi_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | None
 
 
 def _cursor_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | None) -> List[str]:
+    # Headless `cursor-agent -p` refuses to run in a workspace it has not
+    # trusted yet, and the refusal exits 0, so an untrusted directory no-ops
+    # while looking like success. `--trust` clears the gate for plan runs;
+    # write runs also need `-f` so command approvals do not stall the worker.
     if read_only or sandbox == "read-only":
-        return ["cursor-agent", "-p", "--mode", "plan", "--output-format", "text", prompt]
-    return ["cursor-agent", "-p", "--output-format", "text", prompt]
+        return ["cursor-agent", "-p", "--mode", "plan", "--output-format", "text", "--trust", prompt]
+    return ["cursor-agent", "-p", "--output-format", "text", "-f", prompt]
 
 
 def _read_only_prompt(prompt: str) -> str:
@@ -226,7 +230,7 @@ _MODEL_PIN: dict[str, tuple[str, Callable[[List[str], str, str], List[str]]]] = 
     "opencode": ("-m", _pin_after_subcmd),  # opencode run -m X <prompt>   (X = provider/model)
     "pi": ("--model", _pin_after_cmd),  # pi --model X [--tools ...] -p <prompt>
     "kimi": ("-m", _pin_after_cmd),  # kimi -m X [--plan] --print -p <prompt> --final-message-only
-    "cursor": ("--model", _pin_after_cmd),  # cursor-agent --model X -p --output-format text <prompt>
+    "cursor": ("--model", _pin_after_cmd),  # cursor-agent --model X -p --output-format text -f <prompt>
     "antigravity": ("--model", _pin_after_cmd),  # agy --model X [--sandbox] --print <prompt>
 }
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -183,6 +183,19 @@ def test_build_argv_antigravity_read_only_keeps_sandbox_without_write_flags(tmp_
     assert "--dangerously-skip-permissions" not in argv
 
 
+def test_build_argv_cursor_sandbox_read_only_uses_plan_mode():
+    assert agents.build_argv("cursor", "hi", sandbox="read-only") == [
+        "cursor-agent",
+        "-p",
+        "--mode",
+        "plan",
+        "--output-format",
+        "text",
+        "--trust",
+        "hi",
+    ]
+
+
 def test_build_argv_kimi_writable_uses_yolo_and_read_only_keeps_plan():
     assert agents.build_argv("kimi", "hi") == [
         "kimi",

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -18,7 +18,14 @@ def test_build_argv_for_known_clis():
         "hi",
     ]
     assert agents.build_argv("pi", "hi") == ["pi", "-p", "hi"]
-    assert agents.build_argv("cursor", "hi") == ["cursor-agent", "-p", "--output-format", "text", "hi"]
+    assert agents.build_argv("cursor", "hi") == [
+        "cursor-agent",
+        "-p",
+        "--output-format",
+        "text",
+        "-f",
+        "hi",
+    ]
     assert agents.build_argv("aider", "hi") == ["aider", "--yes", "--no-auto-commits", "--message", "hi"]
     assert agents.build_argv("goose", "hi") == ["goose", "run", "--no-session", "-t", "hi"]
     assert agents.build_argv("continue", "hi") == ["cn", "-p", "hi"]
@@ -59,6 +66,7 @@ def test_build_argv_for_read_only_codex():
         "plan",
         "--output-format",
         "text",
+        "--trust",
         "hi",
     ]
     assert agents.build_argv("aider", "hi", read_only=True) == [

--- a/tests/test_agents_model_pin.py
+++ b/tests/test_agents_model_pin.py
@@ -100,6 +100,7 @@ def test_pins_model_for_cursor():
         "-p",
         "--output-format",
         "text",
+        "-f",
         "P",
     ]
     read_only = agents.build_argv("cursor", "P", read_only=True, model="gpt-5")

--- a/tests/test_agents_model_pin.py
+++ b/tests/test_agents_model_pin.py
@@ -104,8 +104,18 @@ def test_pins_model_for_cursor():
         "P",
     ]
     read_only = agents.build_argv("cursor", "P", read_only=True, model="gpt-5")
-    assert read_only[:3] == ["cursor-agent", "--model", "gpt-5"]
-    assert read_only[-1] == "P"
+    assert read_only == [
+        "cursor-agent",
+        "--model",
+        "gpt-5",
+        "-p",
+        "--mode",
+        "plan",
+        "--output-format",
+        "text",
+        "--trust",
+        "P",
+    ]
 
 
 def test_pins_model_for_antigravity():


### PR DESCRIPTION
## Problem

Headless `cursor-agent -p` refuses to run in a workspace it has not trusted yet, and the refusal **exits 0**, so a cursor seat in an untrusted directory no-ops while Brigade records success. Same failure class as the grok `--always-approve` fix (#172).

```
To proceed, you can either:
    - Run 'agent' interactively to decide
    - Pass --trust, --yolo, or -f if you trust this directory
```

## Fix

- Read-only / plan runs: add `--trust` (workspace trust only, keeps plan-mode hard read-only).
- Write runs: add `-f` (force-allow commands; also clears the trust gate, per the refusal message above and verified empirically in a fresh untrusted directory).
- Docs line in the technical guide updated; adapter tests assert the full argv on the default, read-only, sandbox=read-only, and model-pinned paths.

## Verification

- `pytest tests -q` green (Brigade verify receipts `20260711-221710`, `20260711-222343`).
- Live smoke: `cursor-agent --model composer-2.5 -p --output-format text -f` in a never-trusted directory returns model output instead of the refusal; `--mode plan --trust` likewise.