### PR TITLE
docs: add receipt-backed model rating scales for roster seats

### DIFF
--- a/docs/model-ratings.md
+++ b/docs/model-ratings.md
@@ -1,0 +1,87 @@
+# Rating model seats for brigade run
+
+A roster assigns each seat a CLI and a model. This page describes a way to rate
+candidate models per task type with evidence Brigade can stand behind: scripted
+graders, verify receipts, and no model grading its own work. Use it to decide
+which model belongs in which seat instead of assigning by reputation.
+
+## The scale
+
+Each seat gets 0 to 100 per task type, graded by script. Speed is recorded as a
+separate axis, never folded into the score. Read the bands as:
+
+| Band | Meaning |
+|---|---|
+| 90-100 | trust the seat with this task type unsupervised |
+| 70-89 | usable with review |
+| 40-69 | needs a stronger seat or a tighter prompt |
+| below 40 | do not assign this task type |
+
+Treat gaps under 10 points as noise until you have re-runs.
+
+## Task battery
+
+Four task types cover the work brigade seats actually get. Every score traces
+to an exit code or a scripted grader:
+
+- **bug-hunt**: a module with N planted bugs and an answer key. Score is recall.
+  Grade with regexes first (precision), then let a *different* model judge only
+  the regex misses against the answer-key concepts (recall). Self-grading
+  poisons the number. Route each worker's output to a judge from another family.
+- **fix-tests**: a failing test suite the worker must make pass, in an isolated
+  git copy, with a hash check that zeroes the score if the tests file was
+  touched. The pytest exit code is the grade.
+- **strict-json**: messy prose in, exact schema out, with a red-herring figure
+  that must be recomputed. Field-level scoring.
+- **constrained writing**: a short factual doc with hard limits (word cap,
+  required examples). Deduct for every violation a linter or a grep can catch.
+
+Run each task through `brigade work verify run --target . --command "<grader>"`
+so the grading run itself leaves a receipt in `.brigade/work/verify-runs/`.
+
+## Example: pilot run, 2026-07-11
+
+Seven seats, one thinking tier per family, single run per cell:
+
+| seat | bug-hunt | fix-tests | strict-json | writing | mean | total s |
+|---|---:|---:|---:|---:|---:|---:|
+| composer-2.5 | 100 | 100 | 100 | 100 | **100** | 71 |
+| fable-5 | 100 | 100 | 100 | 100 | **100** | 119 |
+| grok-4.5 | 100 | 100 | 100 | 100 | **100** | 83 |
+| gpt-5.6-sol-medium | 100 | 100 | 100 | 100 | **100** | 219 |
+| gpt-5.5 | 90 | 100 | 100 | 100 | **98** | 206 |
+| gpt-5.6-luna-medium | 90 | 100 | 100 | 100 | **98** | 100 |
+| gpt-5.6-terra-medium | 80 | 100 | 100 | 100 | **95** | 86 |
+
+What this run actually showed:
+
+- Three of four tasks hit the ceiling for every seat. When that happens the
+  table ranks speed and the hardest task's tail, not overall ability. Harden
+  the battery before drawing seat-assignment conclusions from it.
+- Within the GPT-5.6 family at the same thinking tier, terra was fastest and
+  missed the two subtlest bugs, sol found everything but took three times
+  luna's wall clock, luna sat between. That is the shape thinking-level fans
+  should quantify next: score per second, per variant, per tier.
+- The one bug most seats missed was the quiet state bug (an item that is never
+  dropped when its quantity goes negative), not the loud crash bugs. Weight
+  planted bugs accordingly.
+
+## Pitfalls that will skew your table
+
+- **Regex-only answer keys under-credit.** One seat in the pilot initially
+  scored 50 on bug-hunt from phrasing variance alone. The cross-model judge
+  pass corrected it to 90. Keep regexes for precision and judge the misses.
+- **Cursor composer models return empty text in plan mode** (issue #206), so
+  benchmark them in write mode with do-not-modify instructions, or their
+  read-only cells score a false 0.
+- **Adapter gaps are not model gaps.** The plain `claude -p` adapter cannot
+  edit files headless. Give the model the same permissions the other seats get
+  when you benchmark, then note the adapter limit in your roster instead.
+- **Deep working directories break app-server steering.** Unix socket paths cap
+  near 108 characters. Brigade warns and the run completes without live control.
+
+## Keeping it honest
+
+One run per cell is a screening pass, not a verdict. Re-run before promoting or
+demoting a seat, keep the receipts, and record roster changes the ratings caused
+next to the run id that justified them.

--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -373,6 +373,7 @@ Both commands are local Unix socket requests. They refuse exec-transport runs, c
 The `cli` values are adapters for installed command-line tools:
 `codex`, `claude`, `opencode`, `antigravity`, `pi`, `cursor`, and `ollama:<model>`. Brigade shells out to those tools and keeps no provider keys. The Antigravity adapter uses the installed `agy --print` non-interactive CLI path, the Pi adapter uses `pi -p`, and the Cursor adapter uses `cursor-agent -p --output-format text`.
 Run `brigade roster doctor` to validate roster syntax and check which CLIs are on `PATH`.
+To decide which model belongs in which seat with receipt-backed evidence instead of reputation, see [model ratings](model-ratings.md).
 When `--roster` is omitted, `brigade run` first reads `--cwd/.brigade/roster.toml`;
 if that file is missing, it falls back to `Path.home()/.brigade/roster.toml`.
 Passing `--roster` keeps using exactly that file.


### PR DESCRIPTION
## What

New page `docs/model-ratings.md`: a method for rating candidate models per task type before assigning them roster seats, plus a cross-link from the roster section of the technical guide.

The scale is 0-100 per task type from scripted graders, with speed kept as a separate axis. The battery (bug-hunt, fix-tests, strict-json, constrained writing) is designed so every score traces to an exit code or a grader script, grading runs leave `brigade work verify` receipts, and no model ever grades its own output (regex answer keys for precision, a cross-family judge for the misses).

Includes a worked example from a 7-seat pilot run (2026-07-11) and the pitfalls that skewed it before correction: regex-only under-crediting, composer plan-mode empty output (#206), adapter gaps vs model gaps, and the AF_UNIX path cap on app-server steering.

Vale-clean.