### PR TITLE
fix: accept displayed category/id form in guard allow comments

### DIFF
--- a/src/brigade/guard/engine.py
+++ b/src/brigade/guard/engine.py
@@ -7,7 +7,9 @@ from .detectors.opf import run_opf
 from .policy import Policy
 from .types import Finding, GuardResult, Rule, ScanOptions, TextEdit
 
-ALLOW_RE = re.compile(r"content-guard:\s*allow\s+([A-Za-z0-9_.:-]+|all)(?:\s+(file))?")
+# The token class includes `/` because findings are displayed as
+# `category/rule-id` and users copy that form into allow comments.
+ALLOW_RE = re.compile(r"content-guard:\s*allow\s+([A-Za-z0-9_./:-]+|all)(?:\s+(file))?")
 
 
 def scan_text(text: str, policy: Policy | None = None, options: ScanOptions | None = None) -> GuardResult:
@@ -38,7 +40,7 @@ def scan_text(text: str, policy: Policy | None = None, options: ScanOptions | No
                 continue
 
             line = _line_for_offset(line_starts, start)
-            allowed_by = _allowed_by(rule.id, line, allow_by_line, file_allows)
+            allowed_by = _allowed_by(rule.id, rule.category, line, allow_by_line, file_allows)
             # A known-public literal exact-matches the whole finding text. This
             # reaches history scans of old diffs where no inline marker exists.
             if allowed_by is None and match.group(0) in allow_values:
@@ -221,19 +223,26 @@ def _allow_comments_by_line(text: str) -> tuple[dict[int, set[str]], set[str]]:
 
 def _allowed_by(
     rule_id: str,
+    category: str,
     line: int,
     allow_by_line: dict[int, set[str]],
     file_allows: set[str],
 ) -> str | None:
+    # Findings are displayed as `category/rule-id` (e.g. `secret/bearer-token`),
+    # so accept that form alongside the bare rule id - a copied display id must
+    # not produce a silently dead allow comment.
+    accepted = (rule_id, f"{category}/{rule_id}")
     if "all" in file_allows:
         return "all"
-    if rule_id in file_allows:
-        return rule_id
+    for token in accepted:
+        if token in file_allows:
+            return token
     tokens = allow_by_line.get(line, set())
     if "all" in tokens:
         return "all"
-    if rule_id in tokens:
-        return rule_id
+    for token in accepted:
+        if token in tokens:
+            return token
     return None
 
 

--- a/tests/guard/test_engine.py
+++ b/tests/guard/test_engine.py
@@ -373,10 +373,7 @@ class AllowCommentDisplayFormTests(unittest.TestCase):
     comment must work, not silently fail (the pre-2026-07 behavior)."""
 
     def test_line_scoped_allow_accepts_displayed_category_id_form(self) -> None:
-        text = (
-            "// content-guard: allow secret/bearer-token\n"
-            "const header = 'Bearer super-secret-token-value-123456';\n"
-        )
+        text = "// content-guard: allow secret/bearer-token\nconst header = 'Bearer super-secret-token-value-123456';\n"
         result = scan_text(text)
         bearer = [f for f in result.findings if f.rule_id == "bearer-token"]
         self.assertEqual(len(bearer), 1)
@@ -397,10 +394,7 @@ class AllowCommentDisplayFormTests(unittest.TestCase):
         self.assertFalse(result.blocked)
 
     def test_bare_rule_id_still_works(self) -> None:
-        text = (
-            "// content-guard: allow bearer-token file\n"
-            "const header = 'Bearer super-secret-token-value-123456';\n"
-        )
+        text = "// content-guard: allow bearer-token file\nconst header = 'Bearer super-secret-token-value-123456';\n"
         result = scan_text(text)
         bearer = [f for f in result.findings if f.rule_id == "bearer-token"]
         self.assertEqual(len(bearer), 1)
@@ -408,8 +402,7 @@ class AllowCommentDisplayFormTests(unittest.TestCase):
 
     def test_wrong_category_prefix_does_not_allow(self) -> None:
         text = (
-            "// content-guard: allow pii/bearer-token file\n"
-            "const header = 'Bearer super-secret-token-value-123456';\n"
+            "// content-guard: allow pii/bearer-token file\nconst header = 'Bearer super-secret-token-value-123456';\n"
         )
         result = scan_text(text)
         bearer = [f for f in result.findings if f.rule_id == "bearer-token"]

--- a/tests/guard/test_engine.py
+++ b/tests/guard/test_engine.py
@@ -366,3 +366,52 @@ class KnownHostsTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class AllowCommentDisplayFormTests(unittest.TestCase):
+    """Findings print as `category/rule-id`; copying that id into an allow
+    comment must work, not silently fail (the pre-2026-07 behavior)."""
+
+    def test_line_scoped_allow_accepts_displayed_category_id_form(self) -> None:
+        text = (
+            "// content-guard: allow secret/bearer-token\n"
+            "const header = 'Bearer super-secret-token-value-123456';\n"
+        )
+        result = scan_text(text)
+        bearer = [f for f in result.findings if f.rule_id == "bearer-token"]
+        self.assertEqual(len(bearer), 1)
+        self.assertEqual(bearer[0].action, "allow")
+        self.assertFalse(result.blocked)
+
+    def test_file_scoped_allow_accepts_displayed_category_id_form(self) -> None:
+        text = (
+            "// content-guard: allow secret/bearer-token file\n"
+            "line two\n"
+            "line three\n"
+            "const header = 'Bearer super-secret-token-value-123456';\n"
+        )
+        result = scan_text(text)
+        bearer = [f for f in result.findings if f.rule_id == "bearer-token"]
+        self.assertEqual(len(bearer), 1)
+        self.assertEqual(bearer[0].action, "allow")
+        self.assertFalse(result.blocked)
+
+    def test_bare_rule_id_still_works(self) -> None:
+        text = (
+            "// content-guard: allow bearer-token file\n"
+            "const header = 'Bearer super-secret-token-value-123456';\n"
+        )
+        result = scan_text(text)
+        bearer = [f for f in result.findings if f.rule_id == "bearer-token"]
+        self.assertEqual(len(bearer), 1)
+        self.assertEqual(bearer[0].action, "allow")
+
+    def test_wrong_category_prefix_does_not_allow(self) -> None:
+        text = (
+            "// content-guard: allow pii/bearer-token file\n"
+            "const header = 'Bearer super-secret-token-value-123456';\n"
+        )
+        result = scan_text(text)
+        bearer = [f for f in result.findings if f.rule_id == "bearer-token"]
+        self.assertEqual(len(bearer), 1)
+        self.assertNotEqual(bearer[0].action, "allow")


### PR DESCRIPTION
Guard findings print as `category/rule-id` (`secret/bearer-token`), and the pre-push hint tells users to add `content-guard: allow <rule-id>`. But `ALLOW_RE`'s token class excluded `/` and `_allowed_by` compared against the bare rule id only, so an allow comment written from the displayed id parsed as its category prefix and never matched anything. The tag failed silently: no warning, no effect, push still blocked.

Found while pushing a repo whose test fixtures are fabricated secrets (a redaction library proving tokens never reach output). `skillet/SECURITY.md` carries one of these dead tags in the wild (`allow pii/email` next to a contact address).

## Changes

- `ALLOW_RE` token class accepts `/`
- `_allowed_by` accepts both the bare rule id and the displayed `category/rule-id` form, line-scoped and file-scoped
- 4 regression tests: displayed form line-scoped, displayed form file-scoped, bare id unchanged, and a wrong-category prefix (`pii/bearer-token`) that must NOT allow

## Notes

A wrong category prefix stays blocked rather than falling back to the id match, so a mislabeled tag cannot widen scope.
