### PR TITLE
fix(friction): stop keyword false positives on machine-written JSON

### DIFF
--- a/src/brigade/friction_cmd.py
+++ b/src/brigade/friction_cmd.py
@@ -95,6 +95,10 @@ PATTERNS: tuple[tuple[str, str, str, str], ...] = (
 )
 SECRET_RE = re.compile(r"(?i)\b(api[_-]?key|token|secret|password|authorization|bearer)\b\s*[:=]\s*['\"]?[^'\"\s]+")
 IGNORED_ATTACHMENT_TYPES = {"hook_success", "hook_additional_context", "skill_listing"}
+# A JSON field whose value is a bare number is configuration or a counter
+# ('"timeout": 900', '"failed": 0'), never friction evidence in itself. Real
+# friction always carries textual evidence (an error string, a status word).
+JSON_NUMERIC_FIELD_RE = re.compile(r'^"[^"\n]+"\s*:\s*-?\d+(?:\.\d+)?\s*,?$')
 
 
 @dataclass(frozen=True)
@@ -247,6 +251,8 @@ def _scan_file(path: Path, *, max_line_length: int = 5000) -> list[Match]:
             if not line:
                 continue
             line = line[:max_line_length]
+            if JSON_NUMERIC_FIELD_RE.match(line):
+                continue
             lowered = line.lower()
             for friction_type, severity, title, pattern in PATTERNS:
                 if re.search(pattern, lowered):
@@ -261,6 +267,66 @@ def _scan_file(path: Path, *, max_line_length: int = 5000) -> list[Match]:
                         )
                     )
                     break
+    return matches
+
+
+def _is_verify_receipt(path: Path) -> bool:
+    return path.name == "receipt.json" and "verify-runs" in path.parts
+
+
+def _scan_receipt(path: Path) -> list[Match]:
+    """Parse a verify-run receipt structurally instead of keyword-matching it.
+
+    Receipts are machine-written JSON where words like "failed" and "timeout"
+    appear as field names and configured budgets; keyword scanning them yields
+    false positives on passing runs. Only real failure evidence counts: a
+    non-zero command exit code, a command that did not complete, or a run
+    whose top-level status is not completed.
+    """
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8", errors="ignore"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+    matches: list[Match] = []
+    commands = payload.get("commands")
+    for command in commands if isinstance(commands, list) else []:
+        if not isinstance(command, dict):
+            continue
+        exit_code = command.get("exit_code")
+        status = str(command.get("status") or "")
+        failed = (isinstance(exit_code, int) and exit_code != 0) or status not in ("", "completed")
+        if not failed:
+            continue
+        rendered = str(command.get("command") or "verification command")
+        stderr_summary = " ".join(str(command.get("stderr_summary") or "").split())
+        detail = f"verify command failed: {rendered} (exit={exit_code}, status={status or 'unknown'})"
+        if stderr_summary:
+            detail += f" stderr: {stderr_summary}"
+        timed_out = "timeout" in status or "timed out" in stderr_summary.lower()
+        matches.append(
+            Match(
+                path=path,
+                line_number=1,
+                line=detail,
+                friction_type="network_timeout" if timed_out else "tool_failure",
+                severity="medium" if timed_out else "high",
+                title="network or timeout friction" if timed_out else "tool or command failure",
+            )
+        )
+    run_status = str(payload.get("status") or "completed")
+    if not matches and run_status != "completed":
+        matches.append(
+            Match(
+                path=path,
+                line_number=1,
+                line=f"verify run did not complete: status={run_status}",
+                friction_type="blocked",
+                severity="high",
+                title="blocked workflow",
+            )
+        )
     return matches
 
 
@@ -340,7 +406,8 @@ def scan_payload(
     severity_counts: dict[str, int] = {}
     workflow_counts: dict[str, int] = {}
     for path in files:
-        for match in _scan_file(path):
+        matches = _scan_receipt(path) if _is_verify_receipt(path) else _scan_file(path)
+        for match in matches:
             candidate = _make_candidate(target, match)
             if candidate["id"] in seen_ids:
                 continue

--- a/tests/test_friction_cmd.py
+++ b/tests/test_friction_cmd.py
@@ -228,3 +228,96 @@ def test_friction_add_creates_manual_import(tmp_path, monkeypatch, capsys):
     assert metadata["source_fingerprint"]
     assert "source_key" not in metadata
     assert "fingerprint" not in metadata
+
+
+def test_friction_scan_ignores_passing_verify_receipt(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(
+        friction_cmd,
+        "_now",
+        lambda: datetime(2026, 6, 11, 12, 0, 0, tzinfo=timezone.utc),
+    )
+    run_dir = tmp_path / ".brigade" / "work" / "verify-runs" / "20260610-run"
+    run_dir.mkdir(parents=True)
+    (run_dir / "receipt.json").write_text(
+        json.dumps(
+            {
+                "status": "completed",
+                "commands": [{"command": "./scripts/verify", "exit_code": 0, "status": "completed"}],
+                "evidence": {"handoff_drafts": {"counts": {"failed": 0}}},
+                "timeouts": {"timeout": 900},
+            },
+            indent=2,
+        )
+    )
+
+    code = cli.main(["friction", "scan", "--target", str(tmp_path), "--json"])
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["candidate_count"] == 0
+
+
+def test_friction_scan_reports_failing_verify_receipt(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(
+        friction_cmd,
+        "_now",
+        lambda: datetime(2026, 6, 11, 12, 0, 0, tzinfo=timezone.utc),
+    )
+    run_dir = tmp_path / ".brigade" / "work" / "verify-runs" / "20260610-run"
+    run_dir.mkdir(parents=True)
+    (run_dir / "receipt.json").write_text(
+        json.dumps(
+            {
+                "status": "completed",
+                "commands": [
+                    {
+                        "command": "pytest -q",
+                        "exit_code": 1,
+                        "status": "completed",
+                        "stderr_summary": "2 failed, 310 passed",
+                    },
+                    {
+                        "command": "slow-check",
+                        "exit_code": None,
+                        "status": "timeout",
+                        "stderr_summary": "",
+                    },
+                ],
+            },
+            indent=2,
+        )
+    )
+
+    code = cli.main(["friction", "scan", "--target", str(tmp_path), "--json"])
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["candidate_count"] == 2
+    by_type = {c["friction_type"]: c for c in payload["candidates"]}
+    failure = by_type["tool_failure"]
+    assert failure["severity"] == "high"
+    assert "pytest -q" in failure["evidence"]["snippet"]
+    assert "2 failed" in failure["evidence"]["snippet"]
+    timeout = by_type["network_timeout"]
+    assert timeout["severity"] == "medium"
+    assert "slow-check" in timeout["evidence"]["snippet"]
+
+
+def test_friction_scan_ignores_numeric_json_fields(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(
+        friction_cmd,
+        "_now",
+        lambda: datetime(2026, 6, 11, 12, 0, 0, tzinfo=timezone.utc),
+    )
+    learnings = tmp_path / ".learnings"
+    learnings.mkdir()
+    (learnings / "stats.json").write_text(
+        '{\n  "failed": 0,\n  "timeout": 900,\n  "note": "everything blocked because auth expired"\n}\n'
+    )
+
+    code = cli.main(["friction", "scan", "--target", str(tmp_path), "--json"])
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["candidate_count"] == 1
+    assert payload["candidates"][0]["friction_type"] == "blocked"


### PR DESCRIPTION
## What and why

`brigade friction scan` keyword-matches every line of every text file in its source roots, including machine-written JSON. In a repo with one passing verify run, the entire friction log consisted of two false positives from that run's receipt: `"failed": 0` matched the blocked-workflow pattern (high severity) and the static budget `"timeout": 900` matched network_timeout, while `status: completed` and `exit_code: 0` sat a few lines away. A scanner whose only output is noise trains operators to ignore it.

Two changes:

- **Structural receipt parsing.** `receipt.json` files under `verify-runs/` are no longer keyword-scanned. A candidate is emitted only for real failure evidence: a command with a non-zero exit code, a command that did not complete (timeout statuses map to `network_timeout` at medium severity), or a run whose top-level status is not completed. The candidate text carries the failing command, exit code, status, and stderr summary, so it is actionable on sight.
- **Numeric-field guard.** A JSON line of the form `"key": <number>` is configuration or a counter, never friction evidence in itself; the keyword scan now skips such lines everywhere. Real friction always carries textual evidence.

Validated against the repo that surfaced the bug: the two false positives disappear, and a deliberately failed verify run now produces `verify command failed: false (exit=1, status=failed)` as a high-severity `tool_failure` candidate.

## Testing

- `./scripts/verify` passes (ruff, format check, version-sync, mypy, full pytest suite with coverage floor), receipt `20260712-070113-work-verify-e519ae`
- New tests: passing receipt yields zero candidates; failing receipt yields `tool_failure` and `network_timeout` candidates with command context; numeric JSON fields are skipped while textual evidence in the same file still matches