### PR TITLE
feat: brigade run --worker for direct single-seat dispatch

### DIFF
--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -339,6 +339,7 @@ Common `brigade run` flags:
 - `--worktree` runs agents in a detached git worktree and captures `changes.patch`.
 - `--show-plan` prints assignments before a normal run.
 - `--verbose` prints the plan, worker statuses, and synthesis status.
+- `--worker <seat>` sends the full task directly to one non-orchestrator roster seat, skipping planning and synthesis.
 - `--cwd` sets the working directory for agent CLI calls.
 - `--handoff` writes a Memory Handoff for a successful non-dry run.
 - `--inspect` prints the same artifact summary as `brigade runs show`.
@@ -348,6 +349,11 @@ Common `brigade run` flags:
 For `codex` agents, `--read-only` also passes `codex exec --sandbox read-only`.
 Combine `--sandbox` with `--read-only` to keep prompt-level read-only rules while overriding native sandbox behavior.
 Other adapters receive the prompt policy only.
+
+Direct worker runs still write normal run artifacts. The synthetic `plan.json`
+contains one assignment with the full task text, `worker-results.json` records
+the selected worker output, `final.txt` is that worker's text, and
+`synthesis.json` is marked with `mode: direct-worker`.
 
 Detached runs require artifacts, so `--detach` cannot be combined with `--no-artifacts`.
 It also refuses `--dry-run` and `--inspect`, because the parent process exits before it can print a plan or inspect final artifacts.

--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -851,6 +851,7 @@ def _worker_prompt(
     *,
     prior_results: list[WorkerResult] | None = None,
     read_only: bool = False,
+    direct: bool = False,
     code_graph: CodeGraphBrief | None = None,
     drift_impact: DriftImpactBrief | None = None,
     evidence: EvidenceBrief | None = None,
@@ -859,11 +860,16 @@ def _worker_prompt(
     if prior_results:
         prior_context = f"\n\nEarlier-stage context:\n{_render_prior_results(prior_results)}"
     policy = f"\n\n{_read_only_rules()}" if read_only else ""
+    return_instruction = (
+        "Return a concise, complete final user-visible result."
+        if direct
+        else "Return a concise, complete result for the orchestrator to synthesize."
+    )
     prompt = (
         f"You are Brigade worker {agent.name}.\n"
         f"Role:\n{agent.role}\n\n"
         f"Sub-task:\n{assignment.task}\n\n"
-        "Return a concise, complete result for the orchestrator to synthesize."
+        f"{return_instruction}"
         f"{prior_context}"
         f"{policy}"
     )
@@ -948,6 +954,7 @@ def dispatch(
     read_only: bool = False,
     sandbox_read_only: bool | None = None,
     sandbox: str | None = None,
+    direct: bool = False,
     code_graph: CodeGraphBrief | None = None,
     drift_impact: DriftImpactBrief | None = None,
     evidence: EvidenceBrief | None = None,
@@ -971,6 +978,7 @@ def dispatch(
             assignment,
             prior_results=prior_results,
             read_only=read_only,
+            direct=direct,
             code_graph=code_graph,
             drift_impact=drift_impact,
             evidence=evidence,
@@ -1554,6 +1562,7 @@ def _run_payload(
     context_eval_payload: dict[str, object] | None = None,
     suspected_noop: bool = False,
     route: RouteBrief | None = None,
+    worker: str | None = None,
 ) -> dict[str, object]:
     payload: dict[str, object] = {
         "task": task,
@@ -1584,6 +1593,8 @@ def _run_payload(
     }
     if route is not None:
         payload["route"] = route.payload()
+    if worker is not None:
+        payload["worker"] = worker
     git = _receipt_git_snapshot(cwd)
     if git is not None:
         payload["git"] = git
@@ -1605,6 +1616,19 @@ def _run_payload(
     if control_socket is not None:
         payload["control_socket"] = str(control_socket)
     return payload
+
+
+def _direct_worker_error(worker: str, roster: Roster) -> str | None:
+    agent = roster.agents.get(worker)
+    if agent is None:
+        return f"unknown worker: {worker}"
+    if worker == roster.orchestrator:
+        return f"--worker cannot target orchestrator seat: {worker}"
+    if agent.cli is None:
+        return f"worker has no CLI adapter: {worker}"
+    if not is_cli_allowed(agent.cli, roster):
+        return f"{agent.cli} is not allowed by limits.allow_models"
+    return None
 
 
 def run(
@@ -1629,12 +1653,19 @@ def run(
     route_enabled: bool = True,
     route_approvals: tuple[str, ...] = (),
     route_template: str | None = None,
+    worker: str | None = None,
 ) -> int:
     started_at = datetime.now(timezone.utc)
     transport_for_payload = codex_transport or roster.codex_transport
     cwd = cwd.expanduser().resolve() if cwd is not None else None
     output_dir = output_dir.expanduser() if output_dir is not None else None
     handoff_inbox = handoff_inbox.expanduser() if handoff_inbox is not None else None
+    direct_worker = worker is not None
+    if worker is not None:
+        worker_error = _direct_worker_error(worker, roster)
+        if worker_error is not None:
+            print(f"error: {worker_error}", file=sys.stderr)
+            return 2
     if code_graph is None:
         code_graph = code_graph_brief(cwd, task) if code_graph_enabled else CodeGraphBrief(attached=False)
     if drift_impact is None:
@@ -1690,57 +1721,65 @@ def run(
                 codex_transport=transport_for_payload,
                 route=route,
                 code_graph_delta=code_graph_delta,
+                worker=worker,
             ),
         )
 
     control_socket = None
     plan_attempts: list[dict[str, object]] | None = [] if output_dir is not None else None
-    try:
-        assignments = plan(
-            task,
-            roster,
-            cwd=cwd,
-            read_only=read_only,
-            sandbox_read_only=sandbox_read_only,
-            sandbox=sandbox,
-            attempts=plan_attempts,
-            code_graph=code_graph,
-            drift_impact=drift_impact,
-            evidence=evidence,
-            route=route,
-        )
-    except RuntimeError as exc:
-        if output_dir is not None:
-            finished_at = datetime.now(timezone.utc)
-            _write_json(output_dir / "plan-attempts.json", {"attempts": plan_attempts or []})
-            _write_json(
-                output_dir / "run.json",
-                _run_payload(
-                    task=task,
-                    cwd=cwd,
-                    roster=roster,
-                    dry_run=dry_run,
-                    read_only=read_only,
-                    status="failed",
-                    started_at=started_at,
-                    finished_at=finished_at,
-                    output_dir=output_dir,
-                    error=str(exc),
-                    code_graph=code_graph,
-                    drift_impact=drift_impact,
-                    evidence=evidence,
-                    brief_set=brief_set,
-                    codex_transport=transport_for_payload,
-                    route=route,
-                    control_socket=control_socket,
-                    code_graph_delta=code_graph_delta,
-                ),
+    if worker is not None:
+        assignments = [Assignment(worker=worker, task=task, stage=1)]
+    else:
+        try:
+            assignments = plan(
+                task,
+                roster,
+                cwd=cwd,
+                read_only=read_only,
+                sandbox_read_only=sandbox_read_only,
+                sandbox=sandbox,
+                attempts=plan_attempts,
+                code_graph=code_graph,
+                drift_impact=drift_impact,
+                evidence=evidence,
+                route=route,
             )
-        print(f"error: {exc}", file=sys.stderr)
-        return 2
+        except RuntimeError as exc:
+            if output_dir is not None:
+                finished_at = datetime.now(timezone.utc)
+                _write_json(output_dir / "plan-attempts.json", {"attempts": plan_attempts or []})
+                _write_json(
+                    output_dir / "run.json",
+                    _run_payload(
+                        task=task,
+                        cwd=cwd,
+                        roster=roster,
+                        dry_run=dry_run,
+                        read_only=read_only,
+                        status="failed",
+                        started_at=started_at,
+                        finished_at=finished_at,
+                        output_dir=output_dir,
+                        error=str(exc),
+                        code_graph=code_graph,
+                        drift_impact=drift_impact,
+                        evidence=evidence,
+                        brief_set=brief_set,
+                        codex_transport=transport_for_payload,
+                        route=route,
+                        control_socket=control_socket,
+                        code_graph_delta=code_graph_delta,
+                        worker=worker,
+                    ),
+                )
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
 
     if output_dir is not None:
-        _write_json(output_dir / "plan-attempts.json", {"attempts": plan_attempts or []})
+        attempts_payload: dict[str, object] = {"attempts": plan_attempts or []}
+        if direct_worker:
+            attempts_payload["mode"] = "direct-worker"
+        _write_json(output_dir / "plan-attempts.json", attempts_payload)
         _write_json(output_dir / "plan.json", {"assignments": _assignment_payload(assignments)})
 
     if dry_run:
@@ -1766,6 +1805,7 @@ def run(
                     codex_transport=transport_for_payload,
                     route=route,
                     code_graph_delta=code_graph_delta,
+                    worker=worker,
                 ),
             )
         print(json.dumps(payload, indent=2))
@@ -1823,6 +1863,7 @@ def run(
                 route=route,
                 control_socket=control_socket,
                 code_graph_delta=code_graph_delta,
+                worker=worker,
             ),
         )
 
@@ -1834,6 +1875,7 @@ def run(
             read_only=read_only,
             sandbox_read_only=sandbox_read_only,
             sandbox=sandbox,
+            direct=direct_worker,
             code_graph=code_graph,
             drift_impact=drift_impact,
             evidence=evidence,
@@ -1872,37 +1914,68 @@ def run(
         )
     if verbose:
         _print_worker_status(worker_results)
-        print("synthesis:")
-        print(f"  -> {roster.orchestrator}")
+        if not direct_worker:
+            print("synthesis:")
+            print(f"  -> {roster.orchestrator}")
 
-    final = _run_orchestrator(
-        roster,
-        build_synth_prompt(
-            task,
-            worker_results,
+    if direct_worker:
+        direct_result = (
+            worker_results[0]
+            if worker_results
+            else WorkerResult(
+                worker=worker or "",
+                task=task,
+                text="",
+                ok=False,
+                detail="direct worker produced no result",
+            )
+        )
+        final = agents.AgentResult(
+            text=direct_result.text,
+            ok=direct_result.ok,
+            detail=direct_result.detail,
+            thread_id=direct_result.thread_id,
+            status=direct_result.status,
+        )
+    else:
+        final = _run_orchestrator(
+            roster,
+            build_synth_prompt(
+                task,
+                worker_results,
+                read_only=read_only,
+                ground_truth=ground_truth,
+                code_graph=code_graph,
+                drift_impact=drift_impact,
+                evidence=evidence,
+            ),
+            cwd=cwd,
             read_only=read_only,
-            ground_truth=ground_truth,
-            code_graph=code_graph,
-            drift_impact=drift_impact,
-            evidence=evidence,
-        ),
-        cwd=cwd,
-        read_only=read_only,
-        sandbox_read_only=sandbox_read_only,
-        sandbox=sandbox,
-    )
+            sandbox_read_only=sandbox_read_only,
+            sandbox=sandbox,
+        )
     if output_dir is not None:
-        _write_json(
-            output_dir / "synthesis.json",
+        synthesis_payload = (
             {
+                "mode": "direct-worker",
+                "worker": worker,
+                "orchestrator": None,
+                "result": _agent_result_payload(final),
+                "ground_truth": ground_truth,
+            }
+            if direct_worker
+            else {
                 "orchestrator": roster.orchestrator,
                 "result": _agent_result_payload(final),
                 "ground_truth": ground_truth,
-            },
+            }
         )
+        _write_json(output_dir / "synthesis.json", synthesis_payload)
     if not final.ok:
         if output_dir is not None:
             finished_at = datetime.now(timezone.utc)
+            if direct_worker:
+                (output_dir / "final.txt").write_text(final.text + "\n")
             _write_json(
                 output_dir / "run.json",
                 _run_payload(
@@ -1925,9 +1998,15 @@ def run(
                     code_graph_delta=code_graph_delta,
                     context_eval_payload=context_eval_payload,
                     suspected_noop=suspected_noop,
+                    worker=worker,
                 ),
             )
-        print(f"error: orchestrator failed during synthesis: {final.detail}", file=sys.stderr)
+        if direct_worker:
+            print(f"error: worker failed: {final.detail}", file=sys.stderr)
+            if final.text:
+                print(final.text)
+        else:
+            print(f"error: orchestrator failed during synthesis: {final.detail}", file=sys.stderr)
         return 2
     if output_dir is not None:
         finished_at = datetime.now(timezone.utc)
@@ -1954,6 +2033,7 @@ def run(
                 code_graph_delta=code_graph_delta,
                 context_eval_payload=context_eval_payload,
                 suspected_noop=suspected_noop,
+                worker=worker,
             ),
         )
     if handoff_inbox is not None:
@@ -1995,6 +2075,7 @@ def run(
                         code_graph_delta=code_graph_delta,
                         context_eval_payload=context_eval_payload,
                         suspected_noop=suspected_noop,
+                        worker=worker,
                     ),
                 )
             print(f"error: {detail}", file=sys.stderr)
@@ -2026,6 +2107,7 @@ def run(
                     code_graph_delta=code_graph_delta,
                     context_eval_payload=context_eval_payload,
                     suspected_noop=suspected_noop,
+                    worker=worker,
                 ),
             )
     print(final.text)

--- a/src/brigade/cli/run.py
+++ b/src/brigade/cli/run.py
@@ -25,6 +25,11 @@ def register(sub: argparse._SubParsersAction) -> None:
     )
     p_run.add_argument("--dry-run", action="store_true", help="Print the plan without dispatching workers.")
     p_run.add_argument(
+        "--worker",
+        default=None,
+        help="Dispatch the full task directly to one worker seat, skipping planning and synthesis.",
+    )
+    p_run.add_argument(
         "--detach",
         action="store_true",
         help="Start the run in a detached child process and return after run metadata is written.",
@@ -179,6 +184,11 @@ def dispatch(args) -> int:
     except ValueError as exc:
         print(f"error: invalid roster: {exc}", file=sys.stderr)
         return 2
+    if args.worker is not None:
+        worker_error = _direct_worker_error(args.worker, loaded_roster, roster_mod)
+        if worker_error is not None:
+            print(f"error: {worker_error}", file=sys.stderr)
+            return 2
     output_dir = None
     if not args.no_artifacts:
         output_dir = args.output_dir or aboyeur_mod.make_run_dir(run_cwd / ".brigade" / "runs")
@@ -237,6 +247,8 @@ def dispatch(args) -> int:
                 "read_only": args.read_only,
                 "sandbox": effective_sandbox,
             }
+            if args.worker is not None:
+                run_kwargs["worker"] = args.worker
             if args.codex_transport is not None:
                 run_kwargs["codex_transport"] = args.codex_transport
             if args.no_code_graph:
@@ -357,6 +369,8 @@ def _detached_child_argv(args, *, run_cwd: Path, roster_path: Path, output_dir: 
         argv.append("--verbose")
     if args.read_only:
         argv.append("--read-only")
+    if args.worker is not None:
+        argv.extend(["--worker", args.worker])
     if args.no_code_graph:
         argv.append("--no-code-graph")
     if args.no_evidence:
@@ -370,6 +384,19 @@ def _detached_child_argv(args, *, run_cwd: Path, roster_path: Path, output_dir: 
     if args.handoff_inbox is not None:
         argv.extend(["--handoff-inbox", str(args.handoff_inbox.expanduser().resolve())])
     return argv
+
+
+def _direct_worker_error(worker: str, loaded_roster, roster_mod) -> str | None:
+    agent = loaded_roster.agents.get(worker)
+    if agent is None:
+        return f"unknown worker: {worker}"
+    if worker == loaded_roster.orchestrator:
+        return f"--worker cannot target orchestrator seat: {worker}"
+    if agent.cli is None:
+        return f"worker has no CLI adapter: {worker}"
+    if not roster_mod.is_cli_allowed(agent.cli, loaded_roster):
+        return f"{agent.cli} is not allowed by limits.allow_models"
+    return None
 
 
 def _poll_detached_start(proc: Popen, output_dir: Path) -> int | None:

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -920,6 +920,102 @@ def test_run_dispatches_and_synthesizes(monkeypatch, capsys):
     assert [call[0] for call in calls] == ["codex", "ollama:llama3.3", "codex"]
 
 
+def test_run_direct_worker_skips_plan_and_synthesis(monkeypatch, capsys, tmp_path):
+    calls = []
+
+    def fake_run_agent(cli_ref, prompt, timeout=600.0, cwd=None, read_only=False):
+        calls.append((cli_ref, prompt))
+        return agents.AgentResult(text="worker final output", ok=True)
+
+    output_dir = tmp_path / "run"
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+
+    rc = aboyeur.run(
+        "do exactly this",
+        _roster(),
+        worker="coder",
+        output_dir=output_dir,
+        route_enabled=False,
+    )
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert out.strip() == "worker final output"
+    assert len(calls) == 1
+    assert calls[0][0] == "ollama:llama3.3"
+    assert "Sub-task:\ndo exactly this" in calls[0][1]
+    assert "Return a concise, complete result for the orchestrator to synthesize." not in calls[0][1]
+    assert "final user-visible result" in calls[0][1].lower()
+    plan = json.loads((output_dir / "plan.json").read_text())
+    assert plan["assignments"] == [{"stage": 1, "worker": "coder", "task": "do exactly this"}]
+    synthesis = json.loads((output_dir / "synthesis.json").read_text())
+    assert synthesis["mode"] == "direct-worker"
+    assert synthesis["orchestrator"] is None
+    assert synthesis["result"]["text"] == "worker final output"
+    assert (output_dir / "final.txt").read_text().strip() == "worker final output"
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "ok"
+
+
+
+def test_run_direct_worker_failure_reports_and_records(monkeypatch, capsys, tmp_path):
+    def fake_run_agent(cli_ref, prompt, timeout=600.0, cwd=None, read_only=False):
+        return agents.AgentResult(text="partial output", ok=False, detail="boom")
+
+    output_dir = tmp_path / "run"
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+
+    rc = aboyeur.run(
+        "do exactly this",
+        _roster(),
+        worker="coder",
+        output_dir=output_dir,
+        route_enabled=False,
+    )
+
+    assert rc != 0
+    assert (output_dir / "final.txt").read_text().strip() == "partial output"
+    run_payload = json.loads((output_dir / "run.json").read_text())
+    assert run_payload["worker"] == "coder"
+    synthesis = json.loads((output_dir / "synthesis.json").read_text())
+    assert synthesis["mode"] == "direct-worker"
+    assert synthesis["result"]["ok"] is False
+
+def test_run_direct_worker_dry_run_skips_agents_and_writes_synthetic_plan(monkeypatch, tmp_path, capsys):
+    calls = []
+
+    def fake_run_agent(cli_ref, prompt, timeout=600.0, cwd=None, read_only=False):
+        calls.append((cli_ref, prompt))
+        raise AssertionError("run_agent should not be called in direct dry-run")
+
+    output_dir = tmp_path / "run"
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+
+    rc = aboyeur.run(
+        "fix the bug",
+        _roster(),
+        worker="coder",
+        dry_run=True,
+        output_dir=output_dir,
+        route_enabled=False,
+    )
+
+    assert rc == 0
+    assert calls == []
+    out = capsys.readouterr().out
+    assert "coder" in out
+    assert "fix the bug" in out
+    plan = json.loads((output_dir / "plan.json").read_text())
+    assert plan["assignments"] == [{"stage": 1, "worker": "coder", "task": "fix the bug"}]
+    attempts = json.loads((output_dir / "plan-attempts.json").read_text())
+    assert attempts["attempts"] == []
+    assert attempts["mode"] == "direct-worker"
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "dry-run"
+    assert not (output_dir / "worker-results.json").exists()
+    assert not (output_dir / "synthesis.json").exists()
+
+
 def test_run_dispatches_stages_in_order_with_earlier_context(monkeypatch):
     calls = []
 

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -1023,3 +1023,81 @@ def test_run_cli_codex_transport_default_is_none(tmp_path, monkeypatch):
     rc = cli.main(["run", "t", "--roster", str(roster_path), "--cwd", str(tmp_path), "--no-artifacts"])
     assert rc == 0
     assert "codex_transport" not in seen
+
+
+def _worker_roster_toml() -> str:
+    return """
+orchestrator = "chef"
+
+[agents.chef]
+cli = "codex"
+role = "plan"
+
+[agents.coder]
+cli = "codex"
+role = "code"
+"""
+
+
+def test_run_cli_forwards_worker_to_aboyeur(tmp_path, monkeypatch):
+    roster_path = tmp_path / "roster.toml"
+    roster_path.write_text(_worker_roster_toml())
+    seen = {}
+
+    def fake_run(task, loaded_roster, **kwargs):
+        seen["task"] = task
+        seen["worker"] = kwargs.get("worker")
+        return 0
+
+    monkeypatch.setattr(aboyeur, "run", fake_run)
+    rc = cli.main(
+        [
+            "run",
+            "do something",
+            "--roster",
+            str(roster_path),
+            "--cwd",
+            str(tmp_path),
+            "--worker",
+            "coder",
+            "--no-artifacts",
+        ]
+    )
+    assert rc == 0
+    assert seen == {"task": "do something", "worker": "coder"}
+
+
+def test_run_cli_rejects_unknown_worker(tmp_path, monkeypatch, capsys):
+    config_dir = tmp_path / ".brigade"
+    config_dir.mkdir()
+    (config_dir / "roster.toml").write_text(_worker_roster_toml())
+
+    def fail_run(*args, **kwargs):
+        raise AssertionError("aboyeur.run should not be called")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(aboyeur, "run", fail_run)
+
+    rc = cli.main(["run", "x", "--worker", "missing", "--no-artifacts"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "missing" in err
+    assert "worker" in err.lower()
+
+
+def test_run_cli_rejects_orchestrator_as_worker(tmp_path, monkeypatch, capsys):
+    config_dir = tmp_path / ".brigade"
+    config_dir.mkdir()
+    (config_dir / "roster.toml").write_text(_worker_roster_toml())
+
+    def fail_run(*args, **kwargs):
+        raise AssertionError("aboyeur.run should not be called")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(aboyeur, "run", fail_run)
+
+    rc = cli.main(["run", "x", "--worker", "chef", "--no-artifacts"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "chef" in err
+    assert "orchestrator" in err.lower()

--- a/tests/test_run_detach.py
+++ b/tests/test_run_detach.py
@@ -1,3 +1,4 @@
+import argparse
 import json
 from pathlib import Path
 
@@ -93,3 +94,33 @@ def test_run_detach_reports_early_child_exit(tmp_path, monkeypatch, capsys):
     assert "detached child exited before run metadata was written: exit 7" in captured.err
     assert f"log: {run_dir / 'detached.log'}" in captured.err
     assert (run_dir / "detached.log").read_text() == "boom\n"
+
+
+def test_run_detach_child_argv_preserves_worker(tmp_path):
+    args = argparse.Namespace(
+        task="do work",
+        allow_dirty=False,
+        worktree=False,
+        show_plan=False,
+        verbose=False,
+        read_only=False,
+        no_code_graph=False,
+        no_evidence=False,
+        sandbox=None,
+        codex_transport=None,
+        handoff=False,
+        handoff_inbox=None,
+        worker="coder",
+    )
+    roster_path = tmp_path / "roster.toml"
+    output_dir = tmp_path / "run"
+
+    argv = run_cli._detached_child_argv(
+        args,
+        run_cwd=tmp_path,
+        roster_path=roster_path,
+        output_dir=output_dir,
+    )
+
+    assert "--worker" in argv
+    assert argv[argv.index("--worker") + 1] == "coder"


### PR DESCRIPTION
## What

`brigade run --worker <seat> "<task>"` dispatches one roster seat directly: no chef plan, no synthesis round. The worker's text is the run output, and the run costs exactly one model call. Closes #211.

External orchestrators treating brigade as their worker fabric were paying two codex calls per mechanical dispatch and depending on the chef obeying "dispatch ONLY seat X" prompts.

## Behavior

- Validation before dispatch: unknown seat (lists available), orchestrator seat refused, missing CLI adapter, roster `allow_models`.
- `--dry-run --worker` writes the synthetic single-assignment plan without dispatching.
- Artifacts unchanged in shape: `plan.json` carries the synthetic assignment, `plan-attempts.json` and `synthesis.json` record `mode: direct-worker`, `run.json` records the worker, `final.txt` is written on success and failure.
- Detached runs preserve the flag.
- Worker prompt asks for a user-visible final result instead of orchestrator-synthesis framing.

## Verification

- Full suite green via brigade verify (receipt `20260712-071607`), including new tests: skip-plan/skip-synthesis, dry-run, failure path (exit code, final.txt, run.json worker), CLI flag forwarding, unknown/orchestrator seat rejection, detach argv preservation.
- Live smoke from branch source: `brigade run --worker grok "Which model are you?"` returned the worker's one-sentence answer directly with a single model call.

Implementation dispatched through `brigade run --worktree` itself; reviewed, formatted, and hardened afterward (added the failure-path test the run's reviewer seat flagged).