### PR TITLE
fix: route calibration from a task corpus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Route calibration from a task corpus: a docs rewrite (`rewrite the QUICKSTART`) no longer takes the full code route (a bare `rewrite`/`redesign` no longer beats a docs hint), UI words `panel`/`dashboard`/`sidebar`/`widget`/`view`/`tooltip` now pull the UI review lenses, and a migration earns tests the way an auth change does.
+
+### Fixed
 - Route derivation no longer misroutes conventional-commit code work as docs: `fix(install): ... referencing docs` and `feat(skills): ship ... CHANGELOG.md` route as code, while prose like `fix typo in README` and `fix(docs): ...` stay docs. A code fix losing its review lenses to a stray "docs" keyword was the one misroute direction that cost coverage.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Route calibration from a task corpus: a docs rewrite (`rewrite the QUICKSTART`) no longer takes the full code route (a bare `rewrite`/`redesign` no longer beats a docs hint), UI words `panel`/`dashboard`/`sidebar`/`widget`/`view`/`tooltip` now pull the UI review lenses, and a migration earns tests the way an auth change does.
-
-### Fixed
 - Route derivation no longer misroutes conventional-commit code work as docs: `fix(install): ... referencing docs` and `feat(skills): ship ... CHANGELOG.md` route as code, while prose like `fix typo in README` and `fix(docs): ...` stay docs. A code fix losing its review lenses to a stray "docs" keyword was the one misroute direction that cost coverage.
 
 ### Added

--- a/docs/proposals/route-recomposition.md
+++ b/docs/proposals/route-recomposition.md
@@ -1,0 +1,74 @@
+# Proposal: route recomposition after the implementer runs
+
+Status: draft, awaiting green-light. Not implemented.
+
+## The gap
+
+The route brief composes once, at plan time, from the task text and whatever
+paths are already dirty. That is the wrong moment for the richest signal. Ask
+`brigade run` to "clean up the config loader," the loader turns out to parse
+auth tokens, and no `security-review` ever joins the route: the word "auth" was
+never in the task, and the tree was clean when the route was derived, so
+`derive_signals` had nothing to catch. The plan covered every stage the route
+named. The route just named the wrong stages.
+
+alp-river does not have this gap. Its loop recomposes every turn: a stage emits
+a signal, the router runs again, and the route grows. Brigade took the router
+and the catalog but kept its own single-shot plan-then-dispatch shape, so the
+route is frozen before any code exists.
+
+## What recomposition would add
+
+After the implementer runs and a real `diff` exists, re-derive signals from the
+diff itself (changed paths, added imports, touched symbols from the GraphTrail
+delta already in the receipt), union them with the plan-time signals, and
+recompose. New surfaces pull their review lenses retroactively: a diff that
+added a call to `verify_token` pulls `security-review` even though the task said
+"clean up the loader."
+
+The router already supports this. `compute_route` takes `already_run` and drops
+stages that have run, so a recompose after implement naturally yields only the
+newly-required stages (the reviews the fresh diff earned). The missing piece is
+the orchestrator loop calling it a second time.
+
+## Sketch
+
+1. Plan-time route as today (task text + dirty paths).
+2. Implementer runs, produces `diff` and the GraphTrail `code_graph_delta`.
+3. Re-derive: `derive_signals(task, changed_paths=diff_paths)` unioned with the
+   plan-time signals, plus a diff-content pass (imports/symbols the delta names
+   that map to a surface, e.g. an added `auth`-segment path -> `auth-surface`).
+4. `compute_route(catalog, live', available', already_run=ran)` -> the delta
+   route: the review stages the real change earned but the task text missed.
+5. Dispatch that delta as a second review wave. Record both routes in
+   `run.json` (`route` and `route_recomposed`) so the receipt shows what the
+   frozen route missed and the recompose caught.
+
+## Cost and risks
+
+- **Loop change, not a pure-function change.** Everything so far has been
+  testable code under a frozen orchestrator loop. This touches the loop: a
+  second derive+compose+dispatch after implement. That is why it is a proposal,
+  not a PR.
+- **Cost.** A second review wave on every run that surfaces new signals. Bound
+  it: only recompose when the diff introduces a surface the plan-time route did
+  not already cover, and cap the delta at the review stages (never re-plan, never
+  re-implement).
+- **The `already_run` contract must hold under recompose.** The property fuzzer
+  covers `already_run`, but a live recompose needs its own e2e: implement a
+  change that touches auth without saying so, confirm `security-review` joins the
+  second wave and lands a receipt.
+
+## Why it is worth it
+
+The single-shot route is honest about what the task text asked for. It is blind
+to what the change turned out to be. Brigade's whole pitch is that the receipt
+tells the truth about a run. A route that cannot see the diff it produced is the
+one place the receipt still trusts the plan over the evidence. Recomposition
+closes that.
+
+## Decision needed
+
+Green-light to build, or park with the gap documented. If built, it is its own
+arc: loop change, a live e2e, and a blog beat about teaching the router to read
+its own diff.

--- a/src/brigade/route_catalog.py
+++ b/src/brigade/route_catalog.py
@@ -189,7 +189,8 @@ _SIGNAL_PATTERNS: list[tuple[str, str]] = [
     ),
     (
         "ui-touched",
-        r"\b(ui|frontend|front-end|component|css|styling|layout|button|modal|form|page|screen|responsive)s?\b",
+        r"\b(ui|frontend|front-end|component|css|styling|layout|button|modal|dialog|form|page|screen|responsive"
+        r"|panel|dashboard|widget|sidebar|navbar|nav menu|tooltip|view)s?\b",
     ),
     (
         "perf-surface",
@@ -218,7 +219,10 @@ _SYSTEM_HINT = re.compile(
 _REPO_HINT = re.compile(
     r"\b(in (the|this|our) (repo|codebase|project)|repo file|template|source (code|file)|\.py|\.ts|\.go|\.rs)\b"
 )
-_DOCS_HINT = re.compile(r"\b(readme|changelog|docs?( page| site)?|documentation|typo)\b")
+_DOCS_HINT = re.compile(
+    r"\b(readme|changelog|docs?( page| site)?|documentation|typo|quickstart|quick start"
+    r"|guide|tutorial|contributing)\b"
+)
 # A conventional-commit code prefix means the task is code work even when it
 # mentions docs in passing: `fix(install): ... referencing docs` is a code fix,
 # not a docs edit. Prose "fix typo in README" has no colon and stays docs. A
@@ -348,13 +352,14 @@ def derive_signals(task: str, template: str | None = None, changed_paths=(), ove
         signals = _apply_overrides(signals, overrides)
 
     if signals and signals[0] == "code":
-        # Auth-surface work always earns tests: security-critical logic is the
-        # last place to skip them.
+        # Auth-surface and migration work always earn tests: security-critical
+        # logic and a data backfill are the last places to skip them.
         tested = (
             template in _TESTED_TEMPLATES
             or "significant-build" in signals
             or "bug" in signals
             or "auth-surface" in signals
+            or "migration" in signals
         )
         if tested and "needs-tests" not in signals:
             signals.append("needs-tests")
@@ -362,9 +367,13 @@ def derive_signals(task: str, template: str | None = None, changed_paths=(), ove
     return signals
 
 
-# Signals that mark a task as code work even when a docs hint is present.
-# `bug` and `ship-requested` are excluded: "fix typo in README" stays docs.
-_CODE_SHAPED = {"auth-surface", "ui-touched", "perf-surface", "migration", "significant-build"}
+# Signals that mark a task as code work even when a docs hint is present:
+# concrete code surfaces. `bug` and `ship-requested` are excluded ("fix typo in
+# README" stays docs), and so is `significant-build` - "rewrite" and "redesign"
+# describe a docs rewrite as readily as a code one, so a docs hint should win.
+# "rewrite the QUICKSTART" is docs; "rewrite the auth module" stays code on its
+# auth-surface hit.
+_CODE_SHAPED = {"auth-surface", "ui-touched", "perf-surface", "migration"}
 
 
 def _code_shaped_hit(text: str) -> bool:

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -498,3 +498,37 @@ def test_validate_overrides_allows_non_path_signals() -> None:
     from brigade.route_catalog import validate_overrides
 
     validate_overrides(["+auth-surface", "~ship-requested", "perf-surface"])  # no raise
+
+
+# --- calibration pass (2026-07-12): real misroutes found by routing task corpus ---
+
+
+def test_calibration_docs_rewrite_not_code() -> None:
+    # "rewrite the QUICKSTART" routed code because "rewrite" fired significant-build
+    # and QUICKSTART was not a docs hint. A docs hint now beats a bare rewrite.
+    assert derive_signals("rewrite the QUICKSTART to lead with the operator flow")[0] == "docs"
+    assert derive_signals("update the contributing guide")[0] == "docs"
+
+
+def test_calibration_significant_build_alone_does_not_force_code_over_docs() -> None:
+    # significant-build is a depth signal, not a "this is code" surface.
+    assert derive_signals("redesign the tutorial")[0] == "docs"
+    # but a concrete code surface still wins over a docs word:
+    assert derive_signals("rewrite the auth module described in the README")[0] == "code"
+    # and a plain rewrite with no docs hint stays code:
+    assert derive_signals("rewrite the export module end to end")[0] == "code"
+
+
+def test_calibration_ui_surface_covers_common_words() -> None:
+    for task in (
+        "polish the run-status panel in the web dashboard",
+        "fix the sidebar widget alignment",
+        "add a tooltip to the settings view",
+    ):
+        assert "ui-touched" in derive_signals(task), task
+
+
+def test_calibration_migration_pulls_tests() -> None:
+    signals = derive_signals("add a nullable owner_id column to the receipts table and backfill it")
+    assert "migration" in signals
+    assert "needs-tests" in signals


### PR DESCRIPTION
Follow-up to #227. Routing 12 real-shaped tasks (one per route/surface class) through `derive_signals` surfaced three misroutes on merged main. This fixes them and lands the recomposition proposal as a draft doc.

## The three misroutes

1. **Docs rewrite took the code route.** `rewrite the QUICKSTART to lead with the operator flow` routed `code / M` with plan + tests + review, because "rewrite" fires `significant-build` and QUICKSTART wasn't a docs hint. `significant-build` is a *depth* signal, not a "this is code" surface, so it no longer beats a docs hint. `rewrite the auth module` still routes code on its `auth-surface` hit; `rewrite the export module end to end` (no docs hint) stays code.
2. **UI task skipped ux-review.** `polish the run-status panel in the web dashboard` fired no `ui-touched`, because panel/dashboard/view weren't UI keywords. The UI surface now covers `panel/dashboard/sidebar/widget/view/tooltip/dialog`.
3. **Migration earned a review but no tests.** A backfill is exactly where you want a test, so `migration` now pulls `needs-tests` the way `auth-surface` does.

The docs hint also learns `quickstart/guide/tutorial/contributing`. Not chasing every keyword (that's the 40-regex trap); the `--route-signal` hatch from #227 handles the genuinely ambiguous ones like "redesign the README layout."

## Also in here

`docs/proposals/route-recomposition.md` (draft, not implemented): the route composes once at plan time and is blind to the diff it produces, so a task that turns out to touch auth without saying so never pulls `security-review`. alp-river recomposes every turn; brigade kept its single-shot loop. The proposal sketches re-deriving from the real diff after the implementer runs, using the `already_run` support the router already has. It's a loop change, not a pure-function change, so it's a proposal awaiting a green-light, not a PR.

## Verification

- 57 router tests incl. the calibration regressions; full gate green, receipted (`20260712-202412`).