### PR TITLE
feat(stations): add reviewed sidecar authority

### DIFF
--- a/docs/phase-explicit-station-status.md
+++ b/docs/phase-explicit-station-status.md
@@ -22,7 +22,7 @@ Key tech: Python mappings, lazy imports to avoid cycles, pytest monkeypatch fixt
 - Modify: `src/brigade/status.py`
 - Modify: `tests/test_status.py`
 
-- [ ] Add failing mapping tests:
+- [x] Add failing mapping tests:
 
 ```python
 import pytest
@@ -63,13 +63,13 @@ def test_health_from_doctor_checks(checks, expected):
     assert status_mod._health_from_checks(checks) == expected
 ```
 
-- [ ] Run the two tests and watch them fail because the helpers do not exist:
+- [x] Run the two tests and watch them fail because the helpers do not exist:
 
 ```bash
 /home/clawdbot/repos/brigade/.venv/bin/pytest tests/test_status.py -q
 ```
 
-- [ ] Add the canonical state tuple and pure mapping helpers to `status.py`:
+- [x] Add the canonical state tuple and pure mapping helpers to `status.py`:
 
 ```python
 STATUS_STATES = (
@@ -110,7 +110,7 @@ def _health_from_checks(checks: list[_doctor.CheckResult]) -> str:
     return "unchecked"
 ```
 
-- [ ] Add a lazy optional-station dispatcher:
+- [x] Add a lazy optional-station dispatcher:
 
 ```python
 def _optional_station_payload(station: str, target: Path) -> dict[str, object] | None:
@@ -132,13 +132,13 @@ def _optional_station_payload(station: str, target: Path) -> dict[str, object] |
     return None
 ```
 
-- [ ] Add a failing dispatcher test that patches `_optional_station_payload`, limits `all_stations()` to `registry.SEARCH`, returns `{"installed": True, "health": "ok", "summary": "graph ok"}`, and asserts JSON health is `ok` with summary `graph ok`.
+- [x] Add a failing dispatcher test that patches `_optional_station_payload`, limits `all_stations()` to `registry.SEARCH`, returns `{"installed": True, "health": "ok", "summary": "graph ok"}`, and asserts JSON health is `ok` with summary `graph ok`.
 
-- [ ] Rewrite the `status.run()` row loop. Optional payloads supply health and summary. Other stations retain doctor counts and use `_health_from_checks`. Set optional-row counts to `ok=1` only for `ok`, `warn=1` only for `degraded`, and `fail=1` only for `failed`.
+- [x] Rewrite the `status.run()` row loop. Optional payloads supply health and summary. Other stations retain doctor counts and use `_health_from_checks`. Set optional-row counts to `ok=1` only for `ok`, `warn=1` only for `degraded`, and `fail=1` only for `failed`.
 
-- [ ] Add a warning regression using one fake station doctor with one `WARN` result. Assert the row health is `degraded`, not `ok` or `empty`.
+- [x] Add a warning regression using one fake station doctor with one `WARN` result. Assert the row health is `degraded`, not `ok` or `empty`.
 
-- [ ] Run `tests/test_status.py` to green through Brigade.
+- [x] Run `tests/test_status.py` to green through Brigade.
 
 ## Task 2: Keep summary probes read-only and bounded
 
@@ -149,9 +149,9 @@ def _optional_station_payload(station: str, target: Path) -> dict[str, object] |
 - Modify: `tests/test_evidence_cmd.py`
 - Modify: `tests/test_tokens_cmd.py`
 
-- [ ] Add a failing MiseLedger test that patches `evidence_brief._miseledger_bin` and `_run_json`, calls `status_payload(tmp_path, include_doctor=False, timeout=5.0)`, and asserts the only command is `["miseledger", "status", "--json"]` with timeout `5.0`.
+- [x] Add a failing MiseLedger test that patches `evidence_brief._miseledger_bin` and `_run_json`, calls `status_payload(tmp_path, include_doctor=False, timeout=5.0)`, and asserts the only command is `["miseledger", "status", "--json"]` with timeout `5.0`.
 
-- [ ] Change the signature to:
+- [x] Change the signature to:
 
 ```python
 def status_payload(
@@ -164,15 +164,15 @@ def status_payload(
 
 Use `timeout` for status and doctor calls. When `include_doctor` is false, do not call doctor. Derive `ok` from exit 0 with a JSON object, `unwired` from exit 2, `timeout` from exit 124, and `incomplete` for any other result. Preserve the existing detailed behavior when `include_doctor` is true.
 
-- [ ] Add a failing Token Glace test that captures the usage-tracker argv and expects:
+- [x] Add a failing Token Glace test that captures the usage-tracker argv and expects:
 
 ```python
 [tracker, "export", "--since", "30d", "--summary-json", "--no-write"]
 ```
 
-- [ ] Replace the current usage-tracker summary argv with that exact command.
+- [x] Replace the current usage-tracker summary argv with that exact command.
 
-- [ ] Run the focused status suites through Brigade:
+- [x] Run the focused status suites through Brigade:
 
 ```bash
 /home/clawdbot/repos/brigade/.venv/bin/brigade work verify run --target . --command "/home/clawdbot/repos/brigade/.venv/bin/pytest tests/test_status.py tests/test_evidence_cmd.py tests/test_tokens_cmd.py tests/test_search_cmd.py tests/test_pantry_cmd.py -q" --capture brigade-work
@@ -180,13 +180,13 @@ Use `timeout` for status and doctor calls. When `include_doctor` is false, do no
 
 Expected: all selected tests pass.
 
-- [ ] Run the full gate through Brigade:
+- [x] Run the full gate through Brigade:
 
 ```bash
 /home/clawdbot/repos/brigade/.venv/bin/brigade work verify run --target . --command "env PY=/home/clawdbot/repos/brigade/.venv/bin ./scripts/verify" --capture brigade-work
 ```
 
-- [ ] Commit:
+- [x] Commit:
 
 ```bash
 git add src/brigade/status.py src/brigade/evidence_cmd.py src/brigade/tokens_cmd.py tests/test_status.py tests/test_evidence_cmd.py tests/test_tokens_cmd.py docs/phase-explicit-station-status.md

--- a/docs/phase-explicit-station-status.md
+++ b/docs/phase-explicit-station-status.md
@@ -66,7 +66,7 @@ def test_health_from_doctor_checks(checks, expected):
 - [x] Run the two tests and watch them fail because the helpers do not exist:
 
 ```bash
-/home/clawdbot/repos/brigade/.venv/bin/pytest tests/test_status.py -q
+.venv/bin/pytest tests/test_status.py -q
 ```
 
 - [x] Add the canonical state tuple and pure mapping helpers to `status.py`:
@@ -175,7 +175,7 @@ Use `timeout` for status and doctor calls. When `include_doctor` is false, do no
 - [x] Run the focused status suites through Brigade:
 
 ```bash
-/home/clawdbot/repos/brigade/.venv/bin/brigade work verify run --target . --command "/home/clawdbot/repos/brigade/.venv/bin/pytest tests/test_status.py tests/test_evidence_cmd.py tests/test_tokens_cmd.py tests/test_search_cmd.py tests/test_pantry_cmd.py -q" --capture brigade-work
+.venv/bin/brigade work verify run --target . --command ".venv/bin/pytest tests/test_status.py tests/test_evidence_cmd.py tests/test_tokens_cmd.py tests/test_search_cmd.py tests/test_pantry_cmd.py -q" --capture brigade-work
 ```
 
 Expected: all selected tests pass.
@@ -183,7 +183,7 @@ Expected: all selected tests pass.
 - [x] Run the full gate through Brigade:
 
 ```bash
-/home/clawdbot/repos/brigade/.venv/bin/brigade work verify run --target . --command "env PY=/home/clawdbot/repos/brigade/.venv/bin ./scripts/verify" --capture brigade-work
+.venv/bin/brigade work verify run --target . --command "env PY=.venv/bin ./scripts/verify" --capture brigade-work
 ```
 
 - [x] Commit:

--- a/docs/phase-explicit-station-status.md
+++ b/docs/phase-explicit-station-status.md
@@ -1,0 +1,194 @@
+# Explicit Station Status Plan
+
+Goal: replace top-level `empty` and `issues` states with the approved six-state vocabulary while keeping summary probes read-only and bounded.
+
+Architecture: `status.py` projects existing station payloads into one public vocabulary. Built-in stations still use their existing doctor checks. Optional sidecar stations use their existing status payloads, except MiseLedger summary mode skips doctor and uses only bounded `status --json`. The detailed station commands keep their current payload vocabulary for compatibility.
+
+Key tech: Python mappings, lazy imports to avoid cycles, pytest monkeypatch fixtures, and existing process-boundary helpers. Execute tasks in order and keep the checkboxes current.
+
+## File Map
+
+- `src/brigade/status.py`: canonical state mapping, optional-station dispatcher, and row construction.
+- `src/brigade/evidence_cmd.py`: bounded status-only mode for top-level summaries.
+- `src/brigade/tokens_cmd.py`: align the usage-tracker summary command with its declared read-only surface.
+- `tests/test_status.py`: state precedence and payload-dispatch regressions.
+- `tests/test_evidence_cmd.py`: prove summary mode never invokes MiseLedger doctor.
+- `tests/test_tokens_cmd.py`: prove the summary command includes `--no-write` and `--since 30d`.
+
+## Task 1: Canonical top-level health
+
+**Files:**
+
+- Modify: `src/brigade/status.py`
+- Modify: `tests/test_status.py`
+
+- [ ] Add failing mapping tests:
+
+```python
+import pytest
+
+from brigade import doctor
+from brigade import registry
+
+
+@pytest.mark.parametrize(
+    ("raw", "installed", "expected"),
+    [
+        ("ok", True, "ok"),
+        ("warn", True, "degraded"),
+        ("fail", True, "failed"),
+        ("timeout", True, "degraded"),
+        ("incomplete", True, "degraded"),
+        ("unwired", True, "not-configured"),
+        ("missing", False, "not-installed"),
+        ("manual", False, "not-installed"),
+        ("unknown", True, "unchecked"),
+    ],
+)
+def test_normalize_payload_health(raw, installed, expected):
+    assert status_mod._normalize_payload_health(raw, installed=installed) == expected
+
+
+@pytest.mark.parametrize(
+    ("checks", "expected"),
+    [
+        ([], "unchecked"),
+        ([(doctor.INFO, "x", "x")], "not-configured"),
+        ([(doctor.OK, "x", "x")], "ok"),
+        ([(doctor.OK, "x", "x"), (doctor.WARN, "y", "y")], "degraded"),
+        ([(doctor.FAIL, "x", "x"), (doctor.WARN, "y", "y")], "failed"),
+    ],
+)
+def test_health_from_doctor_checks(checks, expected):
+    assert status_mod._health_from_checks(checks) == expected
+```
+
+- [ ] Run the two tests and watch them fail because the helpers do not exist:
+
+```bash
+/home/clawdbot/repos/brigade/.venv/bin/pytest tests/test_status.py -q
+```
+
+- [ ] Add the canonical state tuple and pure mapping helpers to `status.py`:
+
+```python
+STATUS_STATES = (
+    "not-installed",
+    "not-configured",
+    "unchecked",
+    "ok",
+    "degraded",
+    "failed",
+)
+
+
+def _normalize_payload_health(raw: object, *, installed: bool | None) -> str:
+    value = str(raw or "").lower()
+    if installed is False and value in {"", "manual", "missing"}:
+        return "not-installed"
+    return {
+        "ok": "ok",
+        "warn": "degraded",
+        "fail": "failed",
+        "timeout": "degraded",
+        "incomplete": "degraded",
+        "unwired": "not-configured",
+        "missing": "not-installed",
+    }.get(value, "unchecked")
+
+
+def _health_from_checks(checks: list[_doctor.CheckResult]) -> str:
+    levels = {status for status, _name, _detail in checks}
+    if _doctor.FAIL in levels:
+        return "failed"
+    if _doctor.WARN in levels:
+        return "degraded"
+    if _doctor.OK in levels:
+        return "ok"
+    if _doctor.MANUAL in levels or _doctor.INFO in levels:
+        return "not-configured"
+    return "unchecked"
+```
+
+- [ ] Add a lazy optional-station dispatcher:
+
+```python
+def _optional_station_payload(station: str, target: Path) -> dict[str, object] | None:
+    if station == "tokens":
+        from . import tokens_cmd
+        return tokens_cmd.status_payload(target)
+    if station == "search":
+        from . import search_cmd
+        return search_cmd.status_payload(target)
+    if station == "pantry":
+        from . import pantry_cmd
+        return pantry_cmd.status_payload(target)
+    if station == "notifications":
+        from . import notifications_cmd
+        return notifications_cmd._status_payload()
+    if station == "evidence":
+        from . import evidence_cmd
+        return evidence_cmd.status_payload(target, include_doctor=False, timeout=5.0)
+    return None
+```
+
+- [ ] Add a failing dispatcher test that patches `_optional_station_payload`, limits `all_stations()` to `registry.SEARCH`, returns `{"installed": True, "health": "ok", "summary": "graph ok"}`, and asserts JSON health is `ok` with summary `graph ok`.
+
+- [ ] Rewrite the `status.run()` row loop. Optional payloads supply health and summary. Other stations retain doctor counts and use `_health_from_checks`. Set optional-row counts to `ok=1` only for `ok`, `warn=1` only for `degraded`, and `fail=1` only for `failed`.
+
+- [ ] Add a warning regression using one fake station doctor with one `WARN` result. Assert the row health is `degraded`, not `ok` or `empty`.
+
+- [ ] Run `tests/test_status.py` to green through Brigade.
+
+## Task 2: Keep summary probes read-only and bounded
+
+**Files:**
+
+- Modify: `src/brigade/evidence_cmd.py`
+- Modify: `src/brigade/tokens_cmd.py`
+- Modify: `tests/test_evidence_cmd.py`
+- Modify: `tests/test_tokens_cmd.py`
+
+- [ ] Add a failing MiseLedger test that patches `evidence_brief._miseledger_bin` and `_run_json`, calls `status_payload(tmp_path, include_doctor=False, timeout=5.0)`, and asserts the only command is `["miseledger", "status", "--json"]` with timeout `5.0`.
+
+- [ ] Change the signature to:
+
+```python
+def status_payload(
+    target: Path,
+    *,
+    include_doctor: bool = True,
+    timeout: float = 120.0,
+) -> dict[str, Any]:
+```
+
+Use `timeout` for status and doctor calls. When `include_doctor` is false, do not call doctor. Derive `ok` from exit 0 with a JSON object, `unwired` from exit 2, `timeout` from exit 124, and `incomplete` for any other result. Preserve the existing detailed behavior when `include_doctor` is true.
+
+- [ ] Add a failing Token Glace test that captures the usage-tracker argv and expects:
+
+```python
+[tracker, "export", "--since", "30d", "--summary-json", "--no-write"]
+```
+
+- [ ] Replace the current usage-tracker summary argv with that exact command.
+
+- [ ] Run the focused status suites through Brigade:
+
+```bash
+/home/clawdbot/repos/brigade/.venv/bin/brigade work verify run --target . --command "/home/clawdbot/repos/brigade/.venv/bin/pytest tests/test_status.py tests/test_evidence_cmd.py tests/test_tokens_cmd.py tests/test_search_cmd.py tests/test_pantry_cmd.py -q" --capture brigade-work
+```
+
+Expected: all selected tests pass.
+
+- [ ] Run the full gate through Brigade:
+
+```bash
+/home/clawdbot/repos/brigade/.venv/bin/brigade work verify run --target . --command "env PY=/home/clawdbot/repos/brigade/.venv/bin ./scripts/verify" --capture brigade-work
+```
+
+- [ ] Commit:
+
+```bash
+git add src/brigade/status.py src/brigade/evidence_cmd.py src/brigade/tokens_cmd.py tests/test_status.py tests/test_evidence_cmd.py tests/test_tokens_cmd.py docs/phase-explicit-station-status.md
+git commit -m "fix(status): report explicit station health"
+```

--- a/docs/phase-managed-station-snapshot.md
+++ b/docs/phase-managed-station-snapshot.md
@@ -18,17 +18,17 @@ Key tech: Python standard library, canonical JSON, SHA-256, immutable dataclass 
 
 ## Task 1: Define the missing runtime contract
 
-- [ ] Add failing tests that expect:
+- [x] Add failing tests that expect:
   - `managed_snapshot.load_snapshot()` returns schema `brigade.managed_snapshot.v1`.
   - names are GraphTrail, MiseLedger, Agent Pantry, Token Glace, Skillet, and Content Guard.
   - Content Guard is `embedded` with owner `brigade-cli`.
   - Skillet stays a `skill-roster` and is not added to `managed.all_tools()`.
   - the 4 active executable tools match `managed.resolve()` for station, command, install, and every surface field.
-- [ ] Run `tests/test_managed_snapshot.py` and watch it fail because the module and bundle do not exist.
+- [x] Run `tests/test_managed_snapshot.py` and watch it fail because the module and bundle do not exist.
 
 ## Task 2: Build and load canonical snapshots
 
-- [ ] Add `src/brigade/managed_snapshot.py` with these public functions:
+- [x] Add `src/brigade/managed_snapshot.py` with these public functions:
 
 ```python
 SCHEMA = "brigade.managed_snapshot.v1"
@@ -133,22 +133,22 @@ def executable_contracts(payload: Mapping[str, Any] | None = None) -> dict[str, 
 
 ## Task 3: Generate the reviewed bundle
 
-- [ ] Add `scripts/managed_snapshot.py` with:
+- [x] Add `scripts/managed_snapshot.py` with:
   - `--write` with one or more manifest path arguments to build and atomically write the bundle.
   - `--check` to load the current bundle and require byte-for-byte canonical rendering.
   - no default network or sibling-repo discovery.
-- [ ] Generate from the 6 explicit worktree or repository paths:
+- [x] Generate from the 6 explicit worktree or repository paths:
   - GraphTrail
   - MiseLedger
   - Agent Pantry
   - Token Glace
   - Skillet
   - Content Guard
-- [ ] Assert the output contains the exact commits recorded in the station-manifest plan.
+- [x] Assert the output contains the exact commits recorded in the station-manifest plan.
 
 ## Task 4: Consume the snapshot at runtime
 
-- [ ] In `managed.py`, add a pure conversion from one snapshot surface:
+- [x] In `managed.py`, add a pure conversion from one snapshot surface:
 
 ```python
 def _surface_from_snapshot(raw: dict[str, object]) -> MachineSurface:
@@ -163,13 +163,13 @@ def _surface_from_snapshot(raw: dict[str, object]) -> MachineSurface:
     )
 ```
 
-- [ ] Add `_apply_snapshot(tool, contract)` using `dataclasses.replace`. Replace only station, command, summary, install args, and surfaces. Preserve `wire` and `doctor`.
-- [ ] After the existing `_TOOLS` literal, load `managed_snapshot.executable_contracts()` and replace matching tools. A missing bundled snapshot is a package error and must not fail open.
-- [ ] Prove the snapshot controls runtime data by changing one temporary snapshot field in a unit test and asserting the converted tool uses it while retaining the original callables.
+- [x] Add `_apply_snapshot(tool, contract)` using `dataclasses.replace`. Replace only station, command, summary, install args, and surfaces. Preserve `wire` and `doctor`.
+- [x] After the existing `_TOOLS` literal, load `managed_snapshot.executable_contracts()` and replace matching tools. A missing bundled snapshot is a package error and must not fail open.
+- [x] Prove the snapshot controls runtime data by changing one temporary snapshot field in a unit test and asserting the converted tool uses it while retaining the original callables.
 
 ## Task 5: Gate drift
 
-- [ ] Add `managed_snapshot.py --check` to `scripts/verify` immediately after version sync.
-- [ ] Run the focused tests through Brigade.
-- [ ] Run the full Brigade gate through Brigade.
-- [ ] Commit `feat(stations): load reviewed managed snapshot`.
+- [x] Add `managed_snapshot.py --check` to `scripts/verify` immediately after version sync.
+- [x] Run the focused tests through Brigade.
+- [x] Run the full Brigade gate through Brigade.
+- [x] Commit `feat(stations): load reviewed managed snapshot`.

--- a/docs/phase-managed-station-snapshot.md
+++ b/docs/phase-managed-station-snapshot.md
@@ -2,7 +2,7 @@
 
 Goal: make the reviewed sidecar manifests the declarative runtime source for first-class managed tools while keeping Brigade offline and dependency-free.
 
-Architecture: a bundled `brigade.managed_snapshot.v1` JSON file stores the 6 reviewed manifest records with source revision and digest. A standard-library loader validates the bundle. `managed.py` keeps Python wire and doctor callables but replaces declarative fields for matching executable tools from the snapshot. A release script regenerates the bundle from explicit local manifest paths and checks the committed file without network access.
+Architecture: a bundled `brigade.managed_snapshot.v1` JSON file stores the 6 reviewed manifest records with provenance and digest. Active sidecar manifests name their source revision. Content Guard is a Brigade-owned lifecycle assertion that separately records the archived repository revision it describes. A standard-library loader validates the bundle. `managed.py` keeps Python wire and doctor callables but replaces declarative fields for matching executable tools from the snapshot. A release script regenerates the bundle from explicit local manifest paths and checks the committed file without network access.
 
 Key tech: Python standard library, canonical JSON, SHA-256, immutable dataclass replacement, and packaged template data.
 
@@ -21,7 +21,8 @@ Key tech: Python standard library, canonical JSON, SHA-256, immutable dataclass 
 - [x] Add failing tests that expect:
   - `managed_snapshot.load_snapshot()` returns schema `brigade.managed_snapshot.v1`.
   - names are GraphTrail, MiseLedger, Agent Pantry, Token Glace, Skillet, and Content Guard.
-  - Content Guard is `embedded` with owner `brigade-cli`.
+  - Content Guard is `embedded` with owner `brigade-cli` and lifecycle-assertion
+    provenance that references archived remote main `d93468ba05485635e252c0fd4129063c750e2cce`.
   - Skillet stays a `skill-roster` and is not added to `managed.all_tools()`.
   - the 4 active executable tools match `managed.resolve()` for station, command, install, and every surface field.
 - [x] Run `tests/test_managed_snapshot.py` and watch it fail because the module and bundle do not exist.
@@ -143,7 +144,7 @@ def executable_contracts(payload: Mapping[str, Any] | None = None) -> dict[str, 
   - Agent Pantry
   - Token Glace
   - Skillet
-  - Content Guard
+  - Content Guard (lifecycle assertion, not a source-manifest revision)
 - [x] Assert the output contains the exact commits recorded in the station-manifest plan.
 
 ## Task 4: Consume the snapshot at runtime

--- a/docs/phase-managed-station-snapshot.md
+++ b/docs/phase-managed-station-snapshot.md
@@ -1,0 +1,175 @@
+# Managed Station Snapshot Plan
+
+Goal: make the reviewed sidecar manifests the declarative runtime source for first-class managed tools while keeping Brigade offline and dependency-free.
+
+Architecture: a bundled `brigade.managed_snapshot.v1` JSON file stores the 6 reviewed manifest records with source revision and digest. A standard-library loader validates the bundle. `managed.py` keeps Python wire and doctor callables but replaces declarative fields for matching executable tools from the snapshot. A release script regenerates the bundle from explicit local manifest paths and checks the committed file without network access.
+
+Key tech: Python standard library, canonical JSON, SHA-256, immutable dataclass replacement, and packaged template data.
+
+## File Map
+
+- `src/brigade/managed_snapshot.py`: build, load, validate, render, and inspect snapshots.
+- `src/brigade/templates/stations/managed-snapshot.json`: generated offline bundle.
+- `src/brigade/managed.py`: apply bundled declarative contracts while retaining runtime callables.
+- `scripts/managed_snapshot.py`: release-time write and CI check entrypoint.
+- `scripts/verify`: reject malformed or non-canonical snapshots.
+- `tests/test_managed_snapshot.py`: generator, validation, lifecycle, and runtime parity coverage.
+- `tests/test_managed.py`: existing managed-tool behavior remains the compatibility gate.
+
+## Task 1: Define the missing runtime contract
+
+- [ ] Add failing tests that expect:
+  - `managed_snapshot.load_snapshot()` returns schema `brigade.managed_snapshot.v1`.
+  - names are GraphTrail, MiseLedger, Agent Pantry, Token Glace, Skillet, and Content Guard.
+  - Content Guard is `embedded` with owner `brigade-cli`.
+  - Skillet stays a `skill-roster` and is not added to `managed.all_tools()`.
+  - the 4 active executable tools match `managed.resolve()` for station, command, install, and every surface field.
+- [ ] Run `tests/test_managed_snapshot.py` and watch it fail because the module and bundle do not exist.
+
+## Task 2: Build and load canonical snapshots
+
+- [ ] Add `src/brigade/managed_snapshot.py` with these public functions:
+
+```python
+SCHEMA = "brigade.managed_snapshot.v1"
+
+
+def _manifest_digest(manifest: Mapping[str, Any]) -> str:
+    encoded = json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _git_revision(root: Path) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(root), "rev-parse", "HEAD"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def snapshot_path() -> Path:
+    return templates.template_root() / "stations" / "managed-snapshot.json"
+
+
+def build_snapshot(paths: Sequence[Path]) -> dict[str, Any]:
+    records = []
+    names = set()
+    for path in paths:
+        manifest = json.loads(path.read_text())
+        if not isinstance(manifest, dict) or manifest.get("schema") != "brigade.station.v1":
+            raise ValueError(f"invalid station manifest: {path}")
+        name = manifest.get("name")
+        if not isinstance(name, str) or not name or name in names:
+            raise ValueError(f"duplicate or invalid station name: {name!r}")
+        names.add(name)
+        records.append(
+            {
+                "manifest": manifest,
+                "source": {
+                    "repository": path.parent.name,
+                    "revision": _git_revision(path.parent),
+                    "manifest_sha256": _manifest_digest(manifest),
+                },
+            }
+        )
+    records.sort(key=lambda record: record["manifest"]["name"])
+    return {"schema": SCHEMA, "records": records}
+
+
+def render_snapshot(payload: Mapping[str, Any]) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def load_snapshot(path: Path | None = None) -> dict[str, Any]:
+    payload = json.loads((path or snapshot_path()).read_text())
+    if not isinstance(payload, dict) or payload.get("schema") != SCHEMA:
+        raise ValueError(f"managed snapshot schema must be {SCHEMA}")
+    records = payload.get("records")
+    if not isinstance(records, list):
+        raise ValueError("managed snapshot records must be a list")
+    names = set()
+    for record in records:
+        if not isinstance(record, dict):
+            raise ValueError("managed snapshot record must be an object")
+        manifest = record.get("manifest")
+        source = record.get("source")
+        if not isinstance(manifest, dict) or manifest.get("schema") != "brigade.station.v1":
+            raise ValueError("managed snapshot contains an invalid manifest")
+        if not isinstance(source, dict) or source.get("manifest_sha256") != _manifest_digest(manifest):
+            raise ValueError("managed snapshot manifest digest mismatch")
+        name = manifest.get("name")
+        if not isinstance(name, str) or name in names:
+            raise ValueError(f"managed snapshot duplicate or invalid name: {name!r}")
+        names.add(name)
+    return payload
+
+
+def executable_contracts(payload: Mapping[str, Any] | None = None) -> dict[str, dict[str, Any]]:
+    snapshot = payload or load_snapshot()
+    contracts = {}
+    for record in snapshot["records"]:
+        manifest = record["manifest"]
+        if manifest.get("lifecycle", "active") != "active":
+            continue
+        for tool in manifest.get("tools", []):
+            if tool.get("kind", "executable") == "executable":
+                contracts[tool["name"]] = {"station": manifest["station"], **tool}
+    return contracts
+```
+
+`build_snapshot` must:
+
+1. Require exactly one valid `brigade.station.v1` JSON object per name.
+2. Sort records by manifest name.
+3. Store each original manifest under `manifest`.
+4. Store `repository`, Git `revision` when available, and the manifest SHA-256 under `source`.
+5. Reject duplicate names.
+
+`load_snapshot` must validate the top-level schema, record list, source digest, manifest schema, and duplicate names. It returns data only after every record passes.
+
+`executable_contracts` flattens active executable tools by tool name. It ignores `skill-roster` and non-active records.
+
+## Task 3: Generate the reviewed bundle
+
+- [ ] Add `scripts/managed_snapshot.py` with:
+  - `--write` with one or more manifest path arguments to build and atomically write the bundle.
+  - `--check` to load the current bundle and require byte-for-byte canonical rendering.
+  - no default network or sibling-repo discovery.
+- [ ] Generate from the 6 explicit worktree or repository paths:
+  - GraphTrail
+  - MiseLedger
+  - Agent Pantry
+  - Token Glace
+  - Skillet
+  - Content Guard
+- [ ] Assert the output contains the exact commits recorded in the station-manifest plan.
+
+## Task 4: Consume the snapshot at runtime
+
+- [ ] In `managed.py`, add a pure conversion from one snapshot surface:
+
+```python
+def _surface_from_snapshot(raw: dict[str, object]) -> MachineSurface:
+    return MachineSurface(
+        kind=str(raw["kind"]),
+        command=tuple(str(part) for part in raw.get("command", [])),
+        read_only=bool(raw.get("read_only", True)),
+        timeout_seconds=float(raw["timeout_seconds"]) if raw.get("timeout_seconds") is not None else None,
+        max_chars=int(raw["max_chars"]) if raw.get("max_chars") is not None else None,
+        probe=tuple(str(part) for part in raw.get("probe", [])),
+        probe_contains=tuple(str(part) for part in raw.get("probe_contains", [])),
+    )
+```
+
+- [ ] Add `_apply_snapshot(tool, contract)` using `dataclasses.replace`. Replace only station, command, summary, install args, and surfaces. Preserve `wire` and `doctor`.
+- [ ] After the existing `_TOOLS` literal, load `managed_snapshot.executable_contracts()` and replace matching tools. A missing bundled snapshot is a package error and must not fail open.
+- [ ] Prove the snapshot controls runtime data by changing one temporary snapshot field in a unit test and asserting the converted tool uses it while retaining the original callables.
+
+## Task 5: Gate drift
+
+- [ ] Add `managed_snapshot.py --check` to `scripts/verify` immediately after version sync.
+- [ ] Run the focused tests through Brigade.
+- [ ] Run the full Brigade gate through Brigade.
+- [ ] Commit `feat(stations): load reviewed managed snapshot`.

--- a/docs/phase-roster-resolution-parity.md
+++ b/docs/phase-roster-resolution-parity.md
@@ -51,7 +51,7 @@ def test_roster_doctor_falls_back_to_home_roster(monkeypatch, tmp_target, tmp_pa
 - [x] Run the new regression and watch it fail:
 
 ```bash
-/home/clawdbot/repos/brigade/.venv/bin/pytest tests/test_roster_cmd.py::test_roster_doctor_falls_back_to_home_roster -q
+.venv/bin/pytest tests/test_roster_cmd.py::test_roster_doctor_falls_back_to_home_roster -q
 ```
 
 Expected: FAIL because `roster_cmd.doctor()` checks only `tmp_target/.brigade/roster.toml`.
@@ -150,7 +150,7 @@ Retain the existing invalid-roster branch and all agent diagnostics.
 - [x] Run the focused suite through Brigade:
 
 ```bash
-/home/clawdbot/repos/brigade/.venv/bin/brigade work verify run --target . --command "/home/clawdbot/repos/brigade/.venv/bin/pytest tests/test_roster.py tests/test_roster_cmd.py tests/test_run_cli.py -q" --capture brigade-work
+.venv/bin/brigade work verify run --target . --command ".venv/bin/pytest tests/test_roster.py tests/test_roster_cmd.py tests/test_run_cli.py -q" --capture brigade-work
 ```
 
 Expected: all selected tests pass.
@@ -158,7 +158,7 @@ Expected: all selected tests pass.
 - [x] Run the full gate through Brigade:
 
 ```bash
-/home/clawdbot/repos/brigade/.venv/bin/brigade work verify run --target . --command "env PY=/home/clawdbot/repos/brigade/.venv/bin ./scripts/verify" --capture brigade-work
+.venv/bin/brigade work verify run --target . --command "env PY=.venv/bin ./scripts/verify" --capture brigade-work
 ```
 
 Expected: exit 0 with the coverage floor met.

--- a/docs/phase-roster-resolution-parity.md
+++ b/docs/phase-roster-resolution-parity.md
@@ -1,0 +1,171 @@
+# Roster Resolution Parity Plan
+
+Goal: make \`brigade run\` and \`brigade roster doctor\` resolve explicit, workspace, and user roster paths through one tested helper.
+
+Architecture: \`src/brigade/roster.py\` owns path selection and missing-path diagnostics. The run CLI and roster doctor call that helper before loading the TOML. Explicit \`--roster\` paths never fall back, workspace rosters win over user rosters, and a missing implicit roster names both checked paths.
+
+Key tech: Python \`pathlib\`, pytest, existing Brigade doctor reporting. Execute the task in order, keep the checkbox state current, run the failing test before production edits, and commit only after the focused and full gates pass.
+
+## File Map
+
+- \`src/brigade/roster.py\`: resolve one roster path and raise a stable missing-path error.
+- \`src/brigade/cli/run.py\`: replace the inline fallback block with the shared resolver.
+- \`src/brigade/roster_cmd.py\`: use the same resolver before loading and reporting the selected path.
+- \`tests/test_roster.py\`: unit coverage for precedence, explicit-path behavior, and missing diagnostics.
+- \`tests/test_roster_cmd.py\`: doctor regression for user fallback and an isolated missing-roster test.
+- \`tests/test_run_cli.py\`: existing CLI regressions remain the compatibility gate.
+
+## Task 1: Centralize roster path selection
+
+**Files:**
+
+- Modify: \`src/brigade/roster.py\`
+- Modify: \`src/brigade/cli/run.py\`
+- Modify: \`src/brigade/roster_cmd.py\`
+- Modify: \`tests/test_roster.py\`
+- Modify: \`tests/test_roster_cmd.py\`
+- Test: \`tests/test_run_cli.py\`
+
+- [ ] Add the failing doctor regression to \`tests/test_roster_cmd.py\`:
+
+\`\`\`python
+def test_roster_doctor_falls_back_to_home_roster(monkeypatch, tmp_target, tmp_path, capsys):
+    home = tmp_path / "home"
+    path = home / ".brigade" / "roster.toml"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        'orchestrator = "chef"\n'
+        '[agents.chef]\n'
+        'endpoint = "https://example.test/v1/chat"\n'
+        'model = "some-hosted-model"\n'
+        'role = "plan"\n'
+    )
+    monkeypatch.setattr(Path, "home", lambda: home)
+
+    assert roster_cmd.doctor(tmp_target) == 0
+    assert str(path) in capsys.readouterr().out
+\`\`\`
+
+- [ ] Isolate \`test_roster_doctor_missing_file_fails\` from the real user roster by adding \`monkeypatch\` and \`tmp_path\`, setting \`Path.home()\` to \`tmp_path / "empty-home"\`, and retaining its existing failure assertions.
+
+- [ ] Run the new regression and watch it fail:
+
+\`\`\`bash
+/home/clawdbot/repos/brigade/.venv/bin/pytest tests/test_roster_cmd.py::test_roster_doctor_falls_back_to_home_roster -q
+\`\`\`
+
+Expected: FAIL because \`roster_cmd.doctor()\` checks only \`tmp_target/.brigade/roster.toml\`.
+
+- [ ] Add resolver unit tests to \`tests/test_roster.py\`:
+
+\`\`\`python
+def test_resolve_roster_path_prefers_workspace(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    workspace = tmp_path / "workspace"
+    local = workspace / ".brigade" / "roster.toml"
+    user = home / ".brigade" / "roster.toml"
+    local.parent.mkdir(parents=True)
+    user.parent.mkdir(parents=True)
+    local.write_text(VALID)
+    user.write_text(VALID)
+    monkeypatch.setattr(Path, "home", lambda: home)
+    assert roster_mod.resolve_roster_path(workspace) == local
+
+
+def test_resolve_roster_path_uses_user_fallback(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    user = home / ".brigade" / "roster.toml"
+    user.parent.mkdir(parents=True)
+    user.write_text(VALID)
+    monkeypatch.setattr(Path, "home", lambda: home)
+    assert roster_mod.resolve_roster_path(tmp_path / "workspace") == user
+
+
+def test_resolve_roster_path_explicit_never_falls_back(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    user = home / ".brigade" / "roster.toml"
+    user.parent.mkdir(parents=True)
+    user.write_text(VALID)
+    missing = tmp_path / "missing.toml"
+    monkeypatch.setattr(Path, "home", lambda: home)
+    with pytest.raises(FileNotFoundError, match=str(missing)):
+        roster_mod.resolve_roster_path(tmp_path / "workspace", missing)
+
+
+def test_resolve_roster_path_missing_names_both_candidates(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    workspace = tmp_path / "workspace"
+    monkeypatch.setattr(Path, "home", lambda: home)
+    with pytest.raises(FileNotFoundError) as exc:
+        roster_mod.resolve_roster_path(workspace)
+    message = str(exc.value)
+    assert str(workspace / ".brigade" / "roster.toml") in message
+    assert str(home / ".brigade" / "roster.toml") in message
+\`\`\`
+
+- [ ] Add the minimal resolver to \`src/brigade/roster.py\` above \`load_roster()\`:
+
+\`\`\`python
+def resolve_roster_path(target: Path, explicit: Path | None = None) -> Path:
+    if explicit is not None:
+        path = explicit.expanduser()
+        if path.exists():
+            return path
+        raise FileNotFoundError(f"roster not found: {path}")
+
+    workspace_path = target.expanduser() / ".brigade" / "roster.toml"
+    user_path = Path.home() / ".brigade" / "roster.toml"
+    if workspace_path.exists():
+        return workspace_path
+    if user_path.exists():
+        return user_path
+    raise FileNotFoundError(f"roster not found: checked {workspace_path} and {user_path}")
+\`\`\`
+
+- [ ] Replace the inline roster-selection block in \`src/brigade/cli/run.py\` with:
+
+\`\`\`python
+try:
+    roster_path = roster_mod.resolve_roster_path(run_cwd, args.roster)
+except FileNotFoundError as exc:
+    print(f"error: {exc}. Create .brigade/roster.toml or pass --roster.", file=sys.stderr)
+    return 2
+\`\`\`
+
+Keep the existing \`load_roster()\` error handling directly after this block.
+
+- [ ] In \`src/brigade/roster_cmd.py::doctor\`, resolve the path before \`load_roster()\`:
+
+\`\`\`python
+try:
+    path = roster_mod.resolve_roster_path(target, roster_path)
+    loaded = roster_mod.load_roster(path)
+except FileNotFoundError as exc:
+    checks.append((doctor_mod.FAIL, "roster: file", f"{exc}; run \`brigade roster init\`"))
+    return doctor_mod._report(checks)
+\`\`\`
+
+Retain the existing invalid-roster branch and all agent diagnostics.
+
+- [ ] Run the focused suite through Brigade:
+
+\`\`\`bash
+/home/clawdbot/repos/brigade/.venv/bin/brigade work verify run --target . --command "/home/clawdbot/repos/brigade/.venv/bin/pytest tests/test_roster.py tests/test_roster_cmd.py tests/test_run_cli.py -q" --capture brigade-work
+\`\`\`
+
+Expected: all selected tests pass.
+
+- [ ] Run the full gate through Brigade:
+
+\`\`\`bash
+/home/clawdbot/repos/brigade/.venv/bin/brigade work verify run --target . --command "env PY=/home/clawdbot/repos/brigade/.venv/bin ./scripts/verify" --capture brigade-work
+\`\`\`
+
+Expected: exit 0 with the coverage floor met.
+
+- [ ] Commit:
+
+\`\`\`bash
+git add src/brigade/roster.py src/brigade/cli/run.py src/brigade/roster_cmd.py tests/test_roster.py tests/test_roster_cmd.py docs/phase-roster-resolution-parity.md
+git commit -m "fix(roster): align user fallback resolution"
+\`\`\`

--- a/docs/phase-roster-resolution-parity.md
+++ b/docs/phase-roster-resolution-parity.md
@@ -1,34 +1,34 @@
 # Roster Resolution Parity Plan
 
-Goal: make \`brigade run\` and \`brigade roster doctor\` resolve explicit, workspace, and user roster paths through one tested helper.
+Goal: make `brigade run` and `brigade roster doctor` resolve explicit, workspace, and user roster paths through one tested helper.
 
-Architecture: \`src/brigade/roster.py\` owns path selection and missing-path diagnostics. The run CLI and roster doctor call that helper before loading the TOML. Explicit \`--roster\` paths never fall back, workspace rosters win over user rosters, and a missing implicit roster names both checked paths.
+Architecture: `src/brigade/roster.py` owns path selection and missing-path diagnostics. The run CLI and roster doctor call that helper before loading the TOML. Explicit `--roster` paths never fall back, workspace rosters win over user rosters, and a missing implicit roster names both checked paths.
 
-Key tech: Python \`pathlib\`, pytest, existing Brigade doctor reporting. Execute the task in order, keep the checkbox state current, run the failing test before production edits, and commit only after the focused and full gates pass.
+Key tech: Python `pathlib`, pytest, existing Brigade doctor reporting. Execute the task in order, keep the checkbox state current, run the failing test before production edits, and commit only after the focused and full gates pass.
 
 ## File Map
 
-- \`src/brigade/roster.py\`: resolve one roster path and raise a stable missing-path error.
-- \`src/brigade/cli/run.py\`: replace the inline fallback block with the shared resolver.
-- \`src/brigade/roster_cmd.py\`: use the same resolver before loading and reporting the selected path.
-- \`tests/test_roster.py\`: unit coverage for precedence, explicit-path behavior, and missing diagnostics.
-- \`tests/test_roster_cmd.py\`: doctor regression for user fallback and an isolated missing-roster test.
-- \`tests/test_run_cli.py\`: existing CLI regressions remain the compatibility gate.
+- `src/brigade/roster.py`: resolve one roster path and raise a stable missing-path error.
+- `src/brigade/cli/run.py`: replace the inline fallback block with the shared resolver.
+- `src/brigade/roster_cmd.py`: use the same resolver before loading and reporting the selected path.
+- `tests/test_roster.py`: unit coverage for precedence, explicit-path behavior, and missing diagnostics.
+- `tests/test_roster_cmd.py`: doctor regression for user fallback and an isolated missing-roster test.
+- `tests/test_run_cli.py`: existing CLI regressions remain the compatibility gate.
 
 ## Task 1: Centralize roster path selection
 
 **Files:**
 
-- Modify: \`src/brigade/roster.py\`
-- Modify: \`src/brigade/cli/run.py\`
-- Modify: \`src/brigade/roster_cmd.py\`
-- Modify: \`tests/test_roster.py\`
-- Modify: \`tests/test_roster_cmd.py\`
-- Test: \`tests/test_run_cli.py\`
+- Modify: `src/brigade/roster.py`
+- Modify: `src/brigade/cli/run.py`
+- Modify: `src/brigade/roster_cmd.py`
+- Modify: `tests/test_roster.py`
+- Modify: `tests/test_roster_cmd.py`
+- Test: `tests/test_run_cli.py`
 
-- [ ] Add the failing doctor regression to \`tests/test_roster_cmd.py\`:
+- [x] Add the failing doctor regression to `tests/test_roster_cmd.py`:
 
-\`\`\`python
+```python
 def test_roster_doctor_falls_back_to_home_roster(monkeypatch, tmp_target, tmp_path, capsys):
     home = tmp_path / "home"
     path = home / ".brigade" / "roster.toml"
@@ -44,21 +44,21 @@ def test_roster_doctor_falls_back_to_home_roster(monkeypatch, tmp_target, tmp_pa
 
     assert roster_cmd.doctor(tmp_target) == 0
     assert str(path) in capsys.readouterr().out
-\`\`\`
+```
 
-- [ ] Isolate \`test_roster_doctor_missing_file_fails\` from the real user roster by adding \`monkeypatch\` and \`tmp_path\`, setting \`Path.home()\` to \`tmp_path / "empty-home"\`, and retaining its existing failure assertions.
+- [x] Isolate `test_roster_doctor_missing_file_fails` from the real user roster by adding `monkeypatch` and `tmp_path`, setting `Path.home()` to `tmp_path / "empty-home"`, and retaining its existing failure assertions.
 
-- [ ] Run the new regression and watch it fail:
+- [x] Run the new regression and watch it fail:
 
-\`\`\`bash
+```bash
 /home/clawdbot/repos/brigade/.venv/bin/pytest tests/test_roster_cmd.py::test_roster_doctor_falls_back_to_home_roster -q
-\`\`\`
+```
 
-Expected: FAIL because \`roster_cmd.doctor()\` checks only \`tmp_target/.brigade/roster.toml\`.
+Expected: FAIL because `roster_cmd.doctor()` checks only `tmp_target/.brigade/roster.toml`.
 
-- [ ] Add resolver unit tests to \`tests/test_roster.py\`:
+- [x] Add resolver unit tests to `tests/test_roster.py`:
 
-\`\`\`python
+```python
 def test_resolve_roster_path_prefers_workspace(monkeypatch, tmp_path):
     home = tmp_path / "home"
     workspace = tmp_path / "workspace"
@@ -101,11 +101,11 @@ def test_resolve_roster_path_missing_names_both_candidates(monkeypatch, tmp_path
     message = str(exc.value)
     assert str(workspace / ".brigade" / "roster.toml") in message
     assert str(home / ".brigade" / "roster.toml") in message
-\`\`\`
+```
 
-- [ ] Add the minimal resolver to \`src/brigade/roster.py\` above \`load_roster()\`:
+- [x] Add the minimal resolver to `src/brigade/roster.py` above `load_roster()`:
 
-\`\`\`python
+```python
 def resolve_roster_path(target: Path, explicit: Path | None = None) -> Path:
     if explicit is not None:
         path = explicit.expanduser()
@@ -120,52 +120,52 @@ def resolve_roster_path(target: Path, explicit: Path | None = None) -> Path:
     if user_path.exists():
         return user_path
     raise FileNotFoundError(f"roster not found: checked {workspace_path} and {user_path}")
-\`\`\`
+```
 
-- [ ] Replace the inline roster-selection block in \`src/brigade/cli/run.py\` with:
+- [x] Replace the inline roster-selection block in `src/brigade/cli/run.py` with:
 
-\`\`\`python
+```python
 try:
     roster_path = roster_mod.resolve_roster_path(run_cwd, args.roster)
 except FileNotFoundError as exc:
     print(f"error: {exc}. Create .brigade/roster.toml or pass --roster.", file=sys.stderr)
     return 2
-\`\`\`
+```
 
-Keep the existing \`load_roster()\` error handling directly after this block.
+Keep the existing `load_roster()` error handling directly after this block.
 
-- [ ] In \`src/brigade/roster_cmd.py::doctor\`, resolve the path before \`load_roster()\`:
+- [x] In `src/brigade/roster_cmd.py::doctor`, resolve the path before `load_roster()`:
 
-\`\`\`python
+```python
 try:
     path = roster_mod.resolve_roster_path(target, roster_path)
     loaded = roster_mod.load_roster(path)
 except FileNotFoundError as exc:
-    checks.append((doctor_mod.FAIL, "roster: file", f"{exc}; run \`brigade roster init\`"))
+    checks.append((doctor_mod.FAIL, "roster: file", f"{exc}; run `brigade roster init`"))
     return doctor_mod._report(checks)
-\`\`\`
+```
 
 Retain the existing invalid-roster branch and all agent diagnostics.
 
-- [ ] Run the focused suite through Brigade:
+- [x] Run the focused suite through Brigade:
 
-\`\`\`bash
+```bash
 /home/clawdbot/repos/brigade/.venv/bin/brigade work verify run --target . --command "/home/clawdbot/repos/brigade/.venv/bin/pytest tests/test_roster.py tests/test_roster_cmd.py tests/test_run_cli.py -q" --capture brigade-work
-\`\`\`
+```
 
 Expected: all selected tests pass.
 
-- [ ] Run the full gate through Brigade:
+- [x] Run the full gate through Brigade:
 
-\`\`\`bash
+```bash
 /home/clawdbot/repos/brigade/.venv/bin/brigade work verify run --target . --command "env PY=/home/clawdbot/repos/brigade/.venv/bin ./scripts/verify" --capture brigade-work
-\`\`\`
+```
 
 Expected: exit 0 with the coverage floor met.
 
-- [ ] Commit:
+- [x] Commit:
 
-\`\`\`bash
+```bash
 git add src/brigade/roster.py src/brigade/cli/run.py src/brigade/roster_cmd.py tests/test_roster.py tests/test_roster_cmd.py docs/phase-roster-resolution-parity.md
 git commit -m "fix(roster): align user fallback resolution"
-\`\`\`
+```

--- a/docs/phase-sidecar-station-manifests.md
+++ b/docs/phase-sidecar-station-manifests.md
@@ -280,9 +280,9 @@ The linter validates static JSON only. It must not invoke `brigade stations veri
 
 | Repository | Commit | Contract receipt | Repository gate receipt |
 | --- | --- | --- | --- |
-| GraphTrail | `e51ed5d` | `20260712-210024-work-verify-6afabd` | `20260712-210040-work-verify-589fea`, `20260712-210058-work-verify-a35c15`, `20260712-210109-work-verify-696bb4`, `20260712-210118-work-verify-45e304` |
+| GraphTrail | merged `54e2972` | `20260712-210024-work-verify-6afabd` | `20260712-210040-work-verify-589fea`, `20260712-210058-work-verify-a35c15`, `20260712-210109-work-verify-696bb4`, `20260712-210118-work-verify-45e304` |
 | MiseLedger | unchanged | `20260712-205916-work-verify-b208bd` | unchanged |
-| Agent Pantry | `d9470b1` | `20260712-210024-work-verify-efbc13` | `20260712-210039-work-verify-361c94` |
-| Token Glace | `44db23d` | `20260712-210024-work-verify-ae323b` | `20260712-210040-work-verify-1ecf42` |
-| Skillet | `74520a2` | `20260712-210024-work-verify-d1f2db` | `20260712-210040-work-verify-0e53d6` |
-| Content Guard | `87e095e` | `20260712-210024-work-verify-9b81e9` | `20260712-210039-work-verify-888db3` |
+| Agent Pantry | merged `9d904c3` | `20260712-210024-work-verify-efbc13` | `20260712-210039-work-verify-361c94` |
+| Token Glace | merged `efb7c85` | `20260712-210024-work-verify-ae323b` | `20260712-210040-work-verify-1ecf42` |
+| Skillet | merged `1f871dd` | `20260712-210024-work-verify-d1f2db` | `20260712-210040-work-verify-0e53d6` |
+| Content Guard | archived remote main `d93468b`; lifecycle assertion owned by Brigade | `20260712-210024-work-verify-9b81e9` | `20260712-210039-work-verify-888db3` |

--- a/docs/phase-sidecar-station-manifests.md
+++ b/docs/phase-sidecar-station-manifests.md
@@ -1,0 +1,277 @@
+# Sidecar Station Manifest Plan
+
+Goal: give every first-class Brigade sidecar a self-describing station contract and make each active executable contract match Brigade's managed catalog.
+
+Architecture: each sidecar repository owns its root `station.json`. Brigade remains the offline runtime catalog during this slice. Cross-repo verification uses `brigade stations verify <repo> --check-managed`. Content Guard publishes a lifecycle-only `embedded` record because its maintained implementation now ships inside Brigade.
+
+Key tech: JSON, existing `brigade.station.v1` parsing, repository-local lint gates, and Brigade parity verification. No runtime dependency or executable behavior changes.
+
+## Repository Map
+
+- GraphTrail: replace the drifting root manifest with the exact managed install and surfaces.
+- MiseLedger: no file change. Verify its existing manifest as the known-good contract.
+- Agent Pantry: add an active executable manifest matching Brigade.
+- Token Glace: add an active executable manifest matching Brigade.
+- Skillet: add an active `skill-roster` manifest and validate its static fields in the existing linter.
+- Content Guard: add an `embedded` lifecycle record owned by `brigade-cli`.
+- Brigade: record execution evidence in this plan. Snapshot generation remains the next control-plane slice.
+
+## Task 1: Capture the failing contract state
+
+- [ ] Run GraphTrail parity through Brigade and expect exit 1 with drift in `install` and `surfaces`.
+- [ ] Run Agent Pantry, Token Glace, Skillet, and Content Guard verification through Brigade and expect exit 2 because `station.json` is absent.
+- [ ] Run MiseLedger verification with `--check-managed` and expect exit 0.
+
+Use the installed Brigade development CLI:
+
+```bash
+/home/clawdbot/repos/brigade/.venv/bin/brigade stations verify . --check-managed
+```
+
+## Task 2: Repair GraphTrail
+
+**Files:**
+
+- Modify: `/home/clawdbot/.cache/codex/worktrees/upstream-integration/graphtrail/station.json`
+
+- [ ] Replace the manifest with:
+
+```json
+{
+  "schema": "brigade.station.v1",
+  "name": "graphtrail",
+  "station": "search",
+  "summary": "local code-graph CLI: callers, callees, impact, context briefs, and structural diffs",
+  "lifecycle": "active",
+  "tools": [
+    {
+      "name": "graphtrail",
+      "kind": "executable",
+      "command": "graphtrail",
+      "summary": "local code-graph CLI: callers, callees, impact, context briefs, and structural diffs",
+      "install": ["cargo", "install", "graphtrail"],
+      "surfaces": [
+        {
+          "kind": "brief-markdown",
+          "command": ["graphtrail", "context", "<task>", "--markdown"],
+          "read_only": true,
+          "timeout_seconds": 10,
+          "max_chars": 4000,
+          "probe": ["graphtrail", "context", "--help"],
+          "probe_contains": ["--markdown"]
+        },
+        {
+          "kind": "verify-exit",
+          "command": ["graphtrail", "--version"],
+          "read_only": true,
+          "timeout_seconds": 10
+        },
+        {
+          "kind": "doctor-json",
+          "command": ["graphtrail", "doctor", "--json"],
+          "read_only": true,
+          "timeout_seconds": 30,
+          "probe": ["graphtrail", "doctor", "--help"],
+          "probe_contains": ["--json"]
+        }
+      ]
+    }
+  ]
+}
+```
+
+- [ ] Run `brigade stations verify . --check-managed` through Brigade and expect exit 0.
+- [ ] Run the GraphTrail completion gate and commit `fix: align Brigade station contract`.
+
+## Task 3: Add Agent Pantry
+
+**Files:**
+
+- Create: `/home/clawdbot/.cache/codex/worktrees/upstream-integration/agentpantry/station.json`
+
+- [ ] Add:
+
+```json
+{
+  "schema": "brigade.station.v1",
+  "name": "agentpantry",
+  "station": "pantry",
+  "summary": "browser session auth sync through a process-boundary Go binary",
+  "lifecycle": "active",
+  "tools": [
+    {
+      "name": "agentpantry",
+      "kind": "executable",
+      "command": "agentpantry",
+      "summary": "browser session auth sync from source to sink",
+      "install": ["go", "install", "github.com/escoffier-labs/agentpantry/cmd/agentpantry@latest"],
+      "surfaces": [
+        {
+          "kind": "doctor-json",
+          "command": ["agentpantry", "doctor", "--json", "--no-net"],
+          "read_only": false,
+          "timeout_seconds": 10,
+          "probe": ["agentpantry", "doctor", "--help"],
+          "probe_contains": ["-json", "-no-net"]
+        },
+        {
+          "kind": "summary-json",
+          "command": ["agentpantry", "inventory", "--json"],
+          "read_only": true,
+          "timeout_seconds": 10,
+          "max_chars": 4000,
+          "probe": ["agentpantry", "inventory", "--help"],
+          "probe_contains": ["-json"]
+        },
+        {
+          "kind": "verify-exit",
+          "command": ["agentpantry", "version", "--json"],
+          "read_only": true,
+          "timeout_seconds": 10
+        }
+      ]
+    }
+  ]
+}
+```
+
+- [ ] Run parity through Brigade and expect exit 0.
+- [ ] Run `./scripts/verify` through Brigade and commit `feat: add Brigade station contract`.
+
+## Task 4: Add Token Glace
+
+**Files:**
+
+- Create: `/home/clawdbot/.cache/codex/worktrees/upstream-integration/token-glace/station.json`
+
+- [ ] Add:
+
+```json
+{
+  "schema": "brigade.station.v1",
+  "name": "token-glace",
+  "station": "tokens",
+  "summary": "output compaction and token-use summaries",
+  "lifecycle": "active",
+  "tools": [
+    {
+      "name": "token-glace",
+      "kind": "executable",
+      "command": "token-glace",
+      "summary": "output compaction through host hooks",
+      "install": [
+        "npm",
+        "install",
+        "-g",
+        "https://github.com/escoffier-labs/token-glace/releases/download/v0.8.3/token-glace-v0.8.3.tar.gz"
+      ],
+      "surfaces": [
+        {
+          "kind": "doctor-json",
+          "command": ["token-glace", "doctor", "hooks", "--format", "json"],
+          "read_only": true,
+          "timeout_seconds": 30
+        },
+        {
+          "kind": "summary-json",
+          "command": ["token-glace", "stats", "--format", "json", "--timezone", "utc"],
+          "read_only": true,
+          "timeout_seconds": 30,
+          "max_chars": 4000,
+          "probe": ["token-glace", "--help"],
+          "probe_contains": ["--format", "--timezone"]
+        },
+        {
+          "kind": "verify-exit",
+          "command": ["token-glace", "verify"],
+          "read_only": true,
+          "timeout_seconds": 60
+        }
+      ]
+    }
+  ]
+}
+```
+
+- [ ] Run parity through Brigade and expect exit 0.
+- [ ] Run `pnpm verify` through Brigade and commit `feat: add Brigade station contract`.
+
+## Task 5: Add Skillet
+
+**Files:**
+
+- Create: `/home/clawdbot/.cache/codex/worktrees/upstream-integration/skillet/station.json`
+- Modify: `/home/clawdbot/.cache/codex/worktrees/upstream-integration/skillet/tests/lint-skills.sh`
+
+- [ ] Add a failing static linter check that requires:
+  - schema `brigade.station.v1`
+  - name `skillet`
+  - station `skills`
+  - lifecycle `active`
+  - one tool with kind `skill-roster`
+  - install `npx skills add escoffier-labs/skillet`
+  - one `verify-exit` probe targeting `tests/lint-skills.sh`
+
+- [ ] Run `./tests/lint-skills.sh` through Brigade and watch it fail because the manifest is absent.
+
+- [ ] Add this manifest:
+
+```json
+{
+  "schema": "brigade.station.v1",
+  "name": "skillet",
+  "station": "skills",
+  "summary": "reviewed portable agent skill roster",
+  "lifecycle": "active",
+  "tools": [
+    {
+      "name": "skillet",
+      "kind": "skill-roster",
+      "summary": "portable skill packages for supported coding harnesses",
+      "install": ["npx", "skills", "add", "escoffier-labs/skillet"],
+      "surfaces": [
+        {
+          "kind": "verify-exit",
+          "probe": ["bash", "tests/lint-skills.sh"],
+          "probe_contains": ["[ok] catalog (36 skills)"],
+          "timeout_seconds": 60
+        }
+      ]
+    }
+  ]
+}
+```
+
+The linter validates static JSON only. It must not invoke `brigade stations verify`, because that verifier executes the linter as the skill-roster probe.
+
+- [ ] Run the linter and Brigade parity to green.
+- [ ] Commit `feat: add Brigade station contract`.
+
+## Task 6: Mark Content Guard embedded
+
+**Files:**
+
+- Create: `/home/clawdbot/.cache/codex/worktrees/upstream-integration/content-guard/station.json`
+
+- [ ] Add:
+
+```json
+{
+  "schema": "brigade.station.v1",
+  "name": "content-guard",
+  "station": "guard",
+  "summary": "historical standalone package now maintained inside brigade-cli",
+  "lifecycle": "embedded",
+  "owner": "brigade-cli",
+  "tools": []
+}
+```
+
+- [ ] Run Brigade verification and expect `embedded-skip` with exit 0.
+- [ ] Run `./scripts/verify` through Brigade and commit `docs: record embedded Brigade lifecycle`.
+
+## Task 7: Cross-repo closeout
+
+- [ ] Re-run `brigade stations verify . --check-managed` for GraphTrail, MiseLedger, Agent Pantry, Token Glace, and Skillet. All 5 active contracts must exit 0.
+- [ ] Re-run Content Guard verification. It must exit 0 with `embedded-skip`.
+- [ ] Record exact repository commits and verification receipts in the ecosystem closeout.

--- a/docs/phase-sidecar-station-manifests.md
+++ b/docs/phase-sidecar-station-manifests.md
@@ -18,9 +18,9 @@ Key tech: JSON, existing `brigade.station.v1` parsing, repository-local lint gat
 
 ## Task 1: Capture the failing contract state
 
-- [ ] Run GraphTrail parity through Brigade and expect exit 1 with drift in `install` and `surfaces`.
-- [ ] Run Agent Pantry, Token Glace, Skillet, and Content Guard verification through Brigade and expect exit 2 because `station.json` is absent.
-- [ ] Run MiseLedger verification with `--check-managed` and expect exit 0.
+- [x] Run GraphTrail parity through Brigade and expect exit 1 with drift in `install` and `surfaces`.
+- [x] Run Agent Pantry, Token Glace, Skillet, and Content Guard verification through Brigade and expect exit 2 because `station.json` is absent.
+- [x] Run MiseLedger verification with `--check-managed` and expect exit 0.
 
 Use the installed Brigade development CLI:
 
@@ -34,7 +34,7 @@ Use the installed Brigade development CLI:
 
 - Modify: `/home/clawdbot/.cache/codex/worktrees/upstream-integration/graphtrail/station.json`
 
-- [ ] Replace the manifest with:
+- [x] Replace the manifest with:
 
 ```json
 {
@@ -80,8 +80,8 @@ Use the installed Brigade development CLI:
 }
 ```
 
-- [ ] Run `brigade stations verify . --check-managed` through Brigade and expect exit 0.
-- [ ] Run the GraphTrail completion gate and commit `fix: align Brigade station contract`.
+- [x] Run `brigade stations verify . --check-managed` through Brigade and expect exit 0.
+- [x] Run the GraphTrail completion gate and commit `fix: align Brigade station contract`.
 
 ## Task 3: Add Agent Pantry
 
@@ -89,7 +89,7 @@ Use the installed Brigade development CLI:
 
 - Create: `/home/clawdbot/.cache/codex/worktrees/upstream-integration/agentpantry/station.json`
 
-- [ ] Add:
+- [x] Add:
 
 ```json
 {
@@ -135,8 +135,8 @@ Use the installed Brigade development CLI:
 }
 ```
 
-- [ ] Run parity through Brigade and expect exit 0.
-- [ ] Run `./scripts/verify` through Brigade and commit `feat: add Brigade station contract`.
+- [x] Run parity through Brigade and expect exit 0.
+- [x] Run `./scripts/verify` through Brigade and commit `feat: add Brigade station contract`.
 
 ## Task 4: Add Token Glace
 
@@ -144,7 +144,7 @@ Use the installed Brigade development CLI:
 
 - Create: `/home/clawdbot/.cache/codex/worktrees/upstream-integration/token-glace/station.json`
 
-- [ ] Add:
+- [x] Add:
 
 ```json
 {
@@ -193,8 +193,8 @@ Use the installed Brigade development CLI:
 }
 ```
 
-- [ ] Run parity through Brigade and expect exit 0.
-- [ ] Run `pnpm verify` through Brigade and commit `feat: add Brigade station contract`.
+- [x] Run parity through Brigade and expect exit 0.
+- [x] Run `pnpm verify` through Brigade and commit `feat: add Brigade station contract`.
 
 ## Task 5: Add Skillet
 
@@ -203,7 +203,7 @@ Use the installed Brigade development CLI:
 - Create: `/home/clawdbot/.cache/codex/worktrees/upstream-integration/skillet/station.json`
 - Modify: `/home/clawdbot/.cache/codex/worktrees/upstream-integration/skillet/tests/lint-skills.sh`
 
-- [ ] Add a failing static linter check that requires:
+- [x] Add a failing static linter check that requires:
   - schema `brigade.station.v1`
   - name `skillet`
   - station `skills`
@@ -212,9 +212,9 @@ Use the installed Brigade development CLI:
   - install `npx skills add escoffier-labs/skillet`
   - one `verify-exit` probe targeting `tests/lint-skills.sh`
 
-- [ ] Run `./tests/lint-skills.sh` through Brigade and watch it fail because the manifest is absent.
+- [x] Run `./tests/lint-skills.sh` through Brigade and watch it fail because the manifest is absent.
 
-- [ ] Add this manifest:
+- [x] Add this manifest:
 
 ```json
 {
@@ -244,8 +244,8 @@ Use the installed Brigade development CLI:
 
 The linter validates static JSON only. It must not invoke `brigade stations verify`, because that verifier executes the linter as the skill-roster probe.
 
-- [ ] Run the linter and Brigade parity to green.
-- [ ] Commit `feat: add Brigade station contract`.
+- [x] Run the linter and Brigade parity to green.
+- [x] Commit `feat: add Brigade station contract`.
 
 ## Task 6: Mark Content Guard embedded
 
@@ -253,7 +253,7 @@ The linter validates static JSON only. It must not invoke `brigade stations veri
 
 - Create: `/home/clawdbot/.cache/codex/worktrees/upstream-integration/content-guard/station.json`
 
-- [ ] Add:
+- [x] Add:
 
 ```json
 {
@@ -267,11 +267,22 @@ The linter validates static JSON only. It must not invoke `brigade stations veri
 }
 ```
 
-- [ ] Run Brigade verification and expect `embedded-skip` with exit 0.
-- [ ] Run `./scripts/verify` through Brigade and commit `docs: record embedded Brigade lifecycle`.
+- [x] Run Brigade verification and expect `embedded-skip` with exit 0.
+- [x] Run `./scripts/verify` through Brigade and commit `docs: record embedded Brigade lifecycle`.
 
 ## Task 7: Cross-repo closeout
 
-- [ ] Re-run `brigade stations verify . --check-managed` for GraphTrail, MiseLedger, Agent Pantry, Token Glace, and Skillet. All 5 active contracts must exit 0.
-- [ ] Re-run Content Guard verification. It must exit 0 with `embedded-skip`.
-- [ ] Record exact repository commits and verification receipts in the ecosystem closeout.
+- [x] Re-run `brigade stations verify . --check-managed` for GraphTrail, MiseLedger, Agent Pantry, Token Glace, and Skillet. All 5 active contracts must exit 0.
+- [x] Re-run Content Guard verification. It must exit 0 with `embedded-skip`.
+- [x] Record exact repository commits and verification receipts in the ecosystem closeout.
+
+## Execution Evidence
+
+| Repository | Commit | Contract receipt | Repository gate receipt |
+| --- | --- | --- | --- |
+| GraphTrail | `e51ed5d` | `20260712-210024-work-verify-6afabd` | `20260712-210040-work-verify-589fea`, `20260712-210058-work-verify-a35c15`, `20260712-210109-work-verify-696bb4`, `20260712-210118-work-verify-45e304` |
+| MiseLedger | unchanged | `20260712-205916-work-verify-b208bd` | unchanged |
+| Agent Pantry | `d9470b1` | `20260712-210024-work-verify-efbc13` | `20260712-210039-work-verify-361c94` |
+| Token Glace | `44db23d` | `20260712-210024-work-verify-ae323b` | `20260712-210040-work-verify-1ecf42` |
+| Skillet | `74520a2` | `20260712-210024-work-verify-d1f2db` | `20260712-210040-work-verify-0e53d6` |
+| Content Guard | `87e095e` | `20260712-210024-work-verify-9b81e9` | `20260712-210039-work-verify-888db3` |

--- a/docs/phase-sidecar-station-manifests.md
+++ b/docs/phase-sidecar-station-manifests.md
@@ -25,14 +25,14 @@ Key tech: JSON, existing `brigade.station.v1` parsing, repository-local lint gat
 Use the installed Brigade development CLI:
 
 ```bash
-/home/clawdbot/repos/brigade/.venv/bin/brigade stations verify . --check-managed
+.venv/bin/brigade stations verify . --check-managed
 ```
 
 ## Task 2: Repair GraphTrail
 
 **Files:**
 
-- Modify: `/home/clawdbot/.cache/codex/worktrees/upstream-integration/graphtrail/station.json`
+- Modify: `../graphtrail/station.json`
 
 - [x] Replace the manifest with:
 
@@ -87,7 +87,7 @@ Use the installed Brigade development CLI:
 
 **Files:**
 
-- Create: `/home/clawdbot/.cache/codex/worktrees/upstream-integration/agentpantry/station.json`
+- Create: `../agentpantry/station.json`
 
 - [x] Add:
 
@@ -142,7 +142,7 @@ Use the installed Brigade development CLI:
 
 **Files:**
 
-- Create: `/home/clawdbot/.cache/codex/worktrees/upstream-integration/token-glace/station.json`
+- Create: `../token-glace/station.json`
 
 - [x] Add:
 
@@ -200,8 +200,8 @@ Use the installed Brigade development CLI:
 
 **Files:**
 
-- Create: `/home/clawdbot/.cache/codex/worktrees/upstream-integration/skillet/station.json`
-- Modify: `/home/clawdbot/.cache/codex/worktrees/upstream-integration/skillet/tests/lint-skills.sh`
+- Create: `../skillet/station.json`
+- Modify: `../skillet/tests/lint-skills.sh`
 
 - [x] Add a failing static linter check that requires:
   - schema `brigade.station.v1`
@@ -251,7 +251,7 @@ The linter validates static JSON only. It must not invoke `brigade stations veri
 
 **Files:**
 
-- Create: `/home/clawdbot/.cache/codex/worktrees/upstream-integration/content-guard/station.json`
+- Create: `../content-guard/station.json`
 
 - [x] Add:
 

--- a/docs/phase-upstream-pattern-integration.md
+++ b/docs/phase-upstream-pattern-integration.md
@@ -1,0 +1,385 @@
+# Brigade Upstream Pattern Integration
+
+Status: approved for implementation  
+Date: 2026-07-12  
+Scope: Brigade, GraphTrail, Skillet, first-class station manifests, and the optional Cursor ACP transport
+
+## Decision
+
+Implement the audit as owner-specific changes instead of creating another sidecar.
+
+- Brigade owns run identity, normalized events, evaluation cells, graders, acceptance, friction, receipt projection, and transport selection.
+- GraphTrail owns personalized, token-budgeted repository context.
+- Skillet owns distributable skill packages and its station manifest.
+- MiseLedger keeps accepting `miseledger.adapter.v1`. Brigade projects richer receipts into that existing contract. The first implementation does not require MiseLedger production code.
+- `acpx` remains a user-installed external executable. Brigade gets an opt-in Cursor transport adapter around one-shot `acpx exec`.
+
+There is no new ACP project in this phase. Extraction becomes eligible only when 2 independent consumers need the same adapter and persistent session lifecycle, cancellation, or queue recovery has entered scope.
+
+## Goals
+
+1. Make Brigade's top-level status agree with the sidecars it reports.
+2. Separate process completion, adapter failure, deterministic verification, grader results, and human acceptance.
+3. Make model comparisons reproducible across cases, seats, and repeated trials.
+4. Feed friction analysis from typed receipts before regex-scanned prose.
+5. Close the Skillet install, registry, promotion, and rollback loop while matching Agent Skills format facts.
+6. Improve GraphTrail context recall under Brigade's 4,000-character budget.
+7. Add a bounded ACP path for Composer and Grok Cursor seats without placing Node or an ACP SDK in Brigade.
+
+## Constraints
+
+- Brigade keeps zero runtime dependencies and Python 3.10 support.
+- Existing run artifacts and rosters remain readable.
+- Direct CLI transports remain the default and fallback.
+- Runtime status stays offline and read-only.
+- Shared receipts omit prompts, model output, command catalogs, tool arguments, and retrieved source by default.
+- Raw provider and ACP streams stay local, private, and opt-in.
+- No model result counts as verified work without deterministic command evidence.
+- No new top-level harness, depth, or include is introduced.
+
+## Options Considered
+
+### A. One new orchestration sidecar
+
+This would place evaluation, receipt conversion, skill metadata, context ranking, and ACP in a new repository. It creates duplicate ownership for contracts that already have clear homes. Brigade would still need most of the integration code.
+
+### B. Changes in the owning repositories
+
+Brigade gains the shared run contract and optional transport. GraphTrail gains ranking. Skillet gains packaging metadata and a station manifest. MiseLedger receives the new evidence through its existing adapter format.
+
+This is the selected approach.
+
+### C. External wrappers only
+
+Brigade could call Inspect, Promptfoo, Aider, skills-ref, and acpx as subprocesses. Inspect and Promptfoo bring large runtimes, Aider brings a broad parsing and graph stack, and skills-ref conflicts with Brigade's dependency and Python boundaries. Wrapper-only integration also leaves Brigade's current run evidence and scorecard defects in place.
+
+## Ownership and Data Flow
+
+```mermaid
+flowchart LR
+    R["Brigade run"] --> E["Versioned run events"]
+    A["Direct adapters"] --> R
+    X["acpx Cursor adapter"] --> R
+    G["GraphTrail ranked context"] --> R
+    E --> C["Evaluation cells and graders"]
+    E --> F["Structured friction"]
+    E --> M["MiseLedger adapter projection"]
+    E --> O["Optional OTel and OpenInference projection"]
+    S["Skillet packages"] --> K["Brigade skill registry"]
+    K --> R
+```
+
+## Contract 1: Versioned Run Evidence
+
+Keep current filenames for compatibility and add schema discriminators. Legacy readers continue accepting missing schema fields.
+
+Initial schema names:
+
+- `brigade.run.v1`
+- `brigade.run_event.v1`
+- `brigade.eval_manifest.v1`
+- `brigade.eval_cell.v1`
+- `brigade.eval_summary.v1`
+- `brigade.grader_result.v1`
+
+The normalized run and event records carry:
+
+- Run, attempt, trace, span, parent, and link identifiers.
+- Operation kind and stable operation name.
+- Start time, end time, and seat duration.
+- Status, exit code, error class, and stop reason.
+- Seat, adapter, transport, requested model, effective model, and reasoning level.
+- Token counts only when the adapter reports them.
+- Artifact path, SHA-256 digest, media type, byte size, and privacy class.
+- Deterministic verification state.
+- Research-task acceptance state.
+- Adapter-native fields inside a namespaced extension object.
+
+Provider events are normalized into `brigade.run_event.v1`. Raw Codex app-server or ACP messages go to a separate private log only when raw logging is enabled.
+
+OpenTelemetry-compatible trace and span identifiers are used in Brigade records. OTel GenAI and OpenInference field names are export projections, not Brigade's storage authority. Each export records the mapping version and audited upstream revision.
+
+## Contract 2: Cases, Seats, Trials, and Resume
+
+Add a model-trial surface under the existing `brigade model` command with plan, run, resume, show, and summary operations.
+
+An evaluation manifest defines:
+
+- A stable schema and experiment name.
+- Cases with explicit IDs and prompt text or a relative prompt file.
+- A roster or selected seat IDs.
+- Default trial count and per-case overrides.
+- Grader definitions.
+- Operational limits such as timeout and concurrency.
+
+Experiment conditions are separated from operational settings. A cell ID is the SHA-256 digest of normalized case content, normalized seat execution spec, trial index, grader contract, and schema version. Array position and wall-clock time do not enter the identity.
+
+A resume operation:
+
+1. Recomputes the expected cell set.
+2. Skips terminal cells whose identity and receipt digest still match.
+3. Reruns missing or interrupted cells.
+4. Reports stale cells when case, seat, transport, reasoning, or grader identity changed.
+5. Appends retries and keeps the earlier attempts.
+
+The summary counts scored, unscored, execution error, adapter error, grader error, rejected, and accepted cells separately. Trial statistics include raw values, count, mean, median, minimum, maximum, and standard deviation using the Python standard library.
+
+## Contract 3: Mechanical Graders and Acceptance
+
+The first grader set is dependency-free:
+
+- Exit status.
+- Exact output.
+- Regular-expression output.
+- JSON field comparison.
+- File existence.
+- Diff constraints.
+- A Brigade verification receipt reference.
+
+Every grader result records its identity and version, cell linkage, status, exit code, score bounds, component checks, duration, and digested output references. `score: 0` remains distinct from an execution that was never graded.
+
+Human or cross-model judgment is stored as acceptance evidence. It reports its own model, prompt digest, errors, and decision. It never replaces deterministic verification.
+
+## Contract 4: Structured Friction
+
+Friction v2 consumes sources in this order:
+
+1. Brigade run, evaluation, grader, and verification receipts.
+2. `miseledger.adapter.v1` records supplied through an explicit local path.
+3. Existing regex scanning as a fallback.
+
+The importer normalizes source, event type, adapter, error class, operation, timestamp, recurrence key, and evidence reference. Root-cause identity excludes source path and line position.
+
+Before truncation, each source family gets a quota. Candidates are then ranked by recurrence, recency, severity, and whether a deterministic failure supports the claim. Scan output reports structured hits, regex hits, duplicates, rejected noise, skipped files, and quota use.
+
+Acceptance fixtures include a large generated `.brigade/work` history plus smaller Codex and Claude logs. The generated history cannot consume every candidate slot.
+
+## Contract 5: Agent Skills and Skillet
+
+Brigade implements the observable Agent Skills format rules with standard-library parsing:
+
+- `name` is required, matches the directory, and follows the 1 to 64 character lowercase identifier rules.
+- `description` is required and limited to 1,024 characters.
+- `license` and `compatibility` are accepted.
+- `metadata` retains string-to-string values.
+- `allowed-tools` is parsed as a declared requirement and never grants permission.
+- `SKILL.md` casing is exact.
+
+Two modes are required:
+
+- Strict authoring mode rejects malformed known fields.
+- Lenient import mode retains unknown fields and emits field-specific diagnostics.
+
+Brigade keeps richer fields in its registry: source repository and revision, content digest, version, trust, required tools, required MCP servers, tests, install receipt, promotion history, and rollback history.
+
+Skillet changes:
+
+- Add an active `brigade.station.v1` root manifest with `tool.kind = "skill-roster"`.
+- Make its linter require version and trust metadata.
+- Declare the repository license in skill frontmatter.
+- Validate the Agent Skills name and description rules locally.
+- Add one reviewed import path into Brigade's registry, including source revision and content digest.
+- Prove that an imported Skillet skill can be installed, scored, promoted, and rolled back.
+
+External install counts do not affect skill quality.
+
+## Contract 6: Personalized GraphTrail Context
+
+GraphTrail adds opt-in `context --personalized --max-chars 4000`, with equivalent MCP arguments. Existing output stays unchanged when personalization is off.
+
+The first ranker uses existing resolved call edges and no new crate:
+
+1. Seed files named in the task and files containing FTS entry points.
+2. Weight FTS seeds by reciprocal result position.
+3. Run bounded file-level personalized PageRank with stable path tie-breaking.
+4. Reorder entry points, call edges, and related files by file rank.
+5. Render complete lines up to the character budget.
+6. Compact long task headings so the heading cannot consume the whole budget.
+
+The fixed acceptance corpus uses these 6 Brigade runs and their 28 changed files:
+
+- `20260708-154455-c6f30720`
+- `20260708-173209-7d72e243`
+- `20260708-185910-45b8c1ab`
+- `20260708-193719-351f1e95`
+- `20260709-050926-2399675f`
+- `20260709-062906-8e8b3cee`
+
+The current macro hit rate is 0.654 with 16 of 28 changed files present. The new ranker must exceed 0.654, exceed 16 of 28 total hits, avoid a per-case regression, and improve at least 2 cases. A synthetic fixture proves that a task-seeded file outranks an unrelated high-degree hub.
+
+Brigade opts into personalized context only after this corpus passes.
+
+## Contract 7: Cursor over ACP
+
+Add a per-seat roster field:
+
+```toml
+[[agents]]
+name = "cursor-composer"
+cli = "cursor"
+model = "composer-2.5"
+transport = "acpx"
+transport_version = "0.12.0"
+```
+
+The first adapter supports Cursor one-shot execution only. Brigade invokes a user-installed `acpx` binary with:
+
+- An exact version check.
+- `--cwd` set to the scoped checkout or worktree.
+- `--format json --json-strict`.
+- `--no-terminal`.
+- `--approve-reads` for read-only work.
+- `--approve-all` only for an already-authorized writable worktree.
+- An explicit timeout and requested model.
+- `cursor exec` with no persistent session name.
+
+The adapter stores protocol version, acpx version, ACP session ID, request ID, stop reason, requested model, acknowledged effective model, exit code, duration, and projected safe events. The final text is extracted from the protocol stream. Missing final text is an adapter or task-contract failure, never a successful worker result.
+
+The direct Cursor adapter remains available. If `acpx` is absent, has the wrong version, emits invalid NDJSON, cannot negotiate protocol 1, or requests unsupported capabilities, Brigade fails that seat with a specific diagnostic and does not switch transports silently.
+
+Persistent ACP sessions, terminal capability, automatic package installation, protocol 2, and an embedded ACP SDK remain out of scope.
+
+## Control-Plane Work
+
+The upstream-pattern work depends on honest status and roster behavior. Complete these fixes before publishing model comparisons:
+
+- Replace the `empty` status with `not-installed`, `not-configured`, `unchecked`, `ok`, `degraded`, or `failed`.
+- Derive top-level station health from fast read-only payloads already exposed by the tool.
+- Make any warning produce `degraded` unless a failure takes precedence.
+- Resolve the same local and user roster fallback in `run` and `roster doctor`.
+- Generate Brigade's bundled managed-tool snapshot from reviewed station manifests during release work.
+- Keep the bundled snapshot at runtime so status and install stay offline.
+- Add or repair manifests for GraphTrail, MiseLedger, Skillet, Agent Pantry, and Token Glace.
+- Record Content Guard as embedded and name Brigade as its maintained owner.
+
+Existing issue prerequisites are included:
+
+- #213: roster fallback parity.
+- #222: warnings only for selected direct-worker seats.
+- #223: correct writable sandbox classification for hard read-only adapters.
+- #224: explicit, compatible Codex reasoning for pinned models.
+- #225: score only dispatched workers and use seat duration.
+- #226: preserve exit code plus full stdout and stderr logs.
+- #231: classify empty Cursor output as failure and cover the Grok path.
+
+## Implementation Sequence
+
+### Phase 0: Baselines and isolated worktrees
+
+- Create one worktree and branch per modified repository.
+- Record clean or pre-existing dirty state before edits.
+- Run each repository's completion gate before code changes.
+- Use only temporary workspaces for Brigade and MiseLedger integration checks.
+
+### Phase 1: Status and station authority
+
+- Land explicit status states and roster fallback parity in Brigade.
+- Add or repair sidecar manifests.
+- Add managed-snapshot generation and drift tests.
+- Verify each active manifest with `--check-managed`.
+
+### Phase 2: Common adapter evidence
+
+- Extend the common agent result with exit code, duration, transport, requested and effective model, reasoning, stop reason, and log references.
+- Fix #222 through #226 and #231 at the shared adapter seam.
+- Version current run artifacts and add legacy normalization tests.
+
+### Phase 3: Evaluation and grading
+
+- Add deterministic manifest expansion and cell IDs.
+- Execute one cell through the existing direct-worker path.
+- Add resume and stale-cell reporting.
+- Add the mechanical grader envelope and summary statistics.
+- Update the documented model-rating battery to use the machine contract.
+
+### Phase 4: Receipts and friction
+
+- Add safe MiseLedger, OTel GenAI, and OpenInference projections.
+- Prove the MiseLedger projection through a temporary archive.
+- Make friction v2 prefer typed receipts and enforce source quotas.
+
+### Phase 5: Skillet and Agent Skills
+
+- Add the Skillet station manifest and local format validation.
+- Add strict and lenient Brigade validation modes.
+- Add reviewed registry import, install receipt, promotion, and rollback coverage.
+
+### Phase 6: GraphTrail ranking
+
+- Add the opt-in personalized ranker and budgeted renderer.
+- Run the 6-case corpus and synthetic high-degree-hub fixture.
+- Enable Brigade's opt-in only after the thresholds pass.
+
+### Phase 7: ACP pilot
+
+- Add the isolated `acpx` adapter and roster fields.
+- Test parser, permissions, version mismatch, timeout, invalid output, empty output, and effective-model acknowledgment with fixtures.
+- Run the same fixed Composer and Grok rating cases through direct Cursor and acpx when credentials and the local binary are available.
+- Keep ACP opt-in until its accepted-cell rate and diagnostic coverage meet or beat direct Cursor on the battery.
+
+### Phase 8: Cross-repo closeout
+
+- Run every repository completion gate.
+- Run Brigade verification through `brigade work verify run` and capture outcomes.
+- Run an independent review on each write set.
+- Update the ecosystem audit with measured before and after results.
+- Write Memory Handoffs for Brigade, GraphTrail, Skillet, and any station repo changed.
+
+## Verification Gates
+
+Brigade:
+
+```bash
+./scripts/verify
+```
+
+GraphTrail:
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features
+cargo build --release
+```
+
+Skillet:
+
+```bash
+bash tests/lint-skills.sh
+```
+
+Other station repositories use their repo-local `AGENTS.md` completion gate. Cross-repo tests use temporary directories and do not inspect a live MiseLedger archive, home directory, or operator workspace.
+
+## License and Reuse Boundary
+
+| Upstream | License | Treatment |
+| --- | --- | --- |
+| OpenTelemetry GenAI | Apache-2.0 | Public field-shape compatibility and export ideas. No vendored schema or runtime. |
+| OpenInference | Apache-2.0 | Role and privacy vocabulary for an optional export projection. No instrumentation dependency. |
+| Inspect AI | MIT | Independently implement run identity, resume, resolved config, and trial statistics. |
+| Promptfoo | MIT | Independently implement cases by seats by trials and grader status separation. |
+| Agent Skills | Apache-2.0 code, CC-BY-4.0 docs with an ambiguous spec-file boundary | Implement observable format facts. Do not copy specification prose. |
+| skills-ref | Apache-2.0 | No dependency and no vendored code. |
+| Aider repository map | Apache-2.0 core with mixed query provenance | Independently implement a GraphTrail ranker. Do not copy queries, constants, or source. |
+| ACP protocol and official SDKs | Apache-2.0 | Treat protocol 1 as an external interface. Do not add an SDK. |
+| acpx | MIT | Execute an exact, user-installed version as an optional process transport. Do not vendor or auto-install it. |
+
+Any later copied source must retain its license and notices and mark modifications. This plan expects independent implementation, published interface names where interoperability requires them, and a recorded upstream revision for every export mapping.
+
+## Completion Criteria
+
+The program is complete when:
+
+- Top-level status matches sidecar-specific health on the acceptance fixtures.
+- Every first-class sidecar has a verified manifest or an explicit embedded lifecycle record.
+- Run artifacts are versioned and old fixtures still load.
+- Adapter success cannot hide an empty result, missing exit code, or missing logs.
+- A repeated evaluation resumes without rerunning matching terminal cells.
+- Scorecard and evaluation summaries include only dispatched cells and seat durations.
+- Friction fixtures preserve agent-log candidates after generated Brigade history reaches its cap.
+- A Skillet skill completes registry import, install, outcome, promotion, and rollback tests.
+- GraphTrail clears the stated 6-case recall thresholds under 4,000 characters.
+- Cursor over acpx passes parser and failure fixtures plus the available live battery.
+- Brigade, GraphTrail, Skillet, and each changed station repository pass their completion gates.
+
+The ACP result at closeout is one of 2 explicit states: `optional-brigade-adapter` or `extraction-candidate`. `extraction-candidate` requires the 2-consumer and session-lifecycle gate stated in the decision. The expected result for this phase is `optional-brigade-adapter`.

--- a/scripts/managed_snapshot.py
+++ b/scripts/managed_snapshot.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Generate or validate Brigade's bundled managed-station snapshot."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from brigade import localio, managed_snapshot  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--write", action="store_true", help="write a snapshot from explicit manifest paths")
+    mode.add_argument("--check", action="store_true", help="validate the committed snapshot")
+    parser.add_argument("manifests", nargs="*", type=Path)
+    args = parser.parse_args()
+
+    path = managed_snapshot.snapshot_path()
+    if args.write:
+        if not args.manifests:
+            parser.error("--write requires at least one manifest path")
+        payload = managed_snapshot.build_snapshot(args.manifests)
+        localio.write_text_atomic(path, managed_snapshot.render_snapshot(payload))
+        print(f"managed snapshot: wrote {path} ({len(payload['records'])} manifests)")
+        return 0
+    if args.manifests:
+        parser.error("manifest paths are accepted only with --write")
+
+    try:
+        payload = managed_snapshot.load_snapshot(path)
+    except ValueError as exc:
+        print(f"managed snapshot: {exc}", file=sys.stderr)
+        return 1
+    expected = managed_snapshot.render_snapshot(payload)
+    actual = path.read_text()
+    if actual != expected:
+        print(f"managed snapshot: non-canonical JSON at {path}", file=sys.stderr)
+        return 1
+    print(f"managed snapshot: ok ({len(payload['records'])} manifests)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify
+++ b/scripts/verify
@@ -12,4 +12,5 @@ PY=${PY:-.venv/bin}
 # Version sync covers __init__.py, template JSONs, and the recorded demo assets.
 # Run `python scripts/version_sync.py --write` to fix drift in one shot.
 "$PY/python" scripts/version_sync.py --check
+"$PY/python" scripts/managed_snapshot.py --check
 "$PY/pytest" -q --cov=brigade --cov-report=term --cov-fail-under=78

--- a/src/brigade/cli/run.py
+++ b/src/brigade/cli/run.py
@@ -173,22 +173,11 @@ def dispatch(args) -> int:
     if args.worktree and not runguard.is_git_worktree(run_cwd):
         print(f"error: --worktree requires a git worktree: {run_cwd}", file=sys.stderr)
         return 2
-    cwd_roster_path = run_cwd / ".brigade" / "roster.toml"
-    if args.roster is not None:
-        roster_path = args.roster.expanduser()
-    elif cwd_roster_path.exists():
-        roster_path = cwd_roster_path
-    else:
-        home_roster_path = Path.home() / ".brigade" / "roster.toml"
-        if home_roster_path.exists():
-            roster_path = home_roster_path
-        else:
-            print(
-                f"error: roster not found: checked {cwd_roster_path} and {home_roster_path}. "
-                "Create .brigade/roster.toml or pass --roster.",
-                file=sys.stderr,
-            )
-            return 2
+    try:
+        roster_path = roster_mod.resolve_roster_path(run_cwd, args.roster)
+    except FileNotFoundError as exc:
+        print(f"error: {exc}. Create .brigade/roster.toml or pass --roster.", file=sys.stderr)
+        return 2
     try:
         loaded_roster = roster_mod.load_roster(roster_path)
     except FileNotFoundError:

--- a/src/brigade/evidence_cmd.py
+++ b/src/brigade/evidence_cmd.py
@@ -44,7 +44,12 @@ def _cursor_path(target: Path) -> Path:
     return target / ".brigade" / "work" / "miseledger-export-cursor.json"
 
 
-def status_payload(target: Path) -> dict[str, Any]:
+def status_payload(
+    target: Path,
+    *,
+    include_doctor: bool = True,
+    timeout: float = 120.0,
+) -> dict[str, Any]:
     target = target.expanduser().resolve()
     binary = evidence_brief._miseledger_bin()
     installed = binary is not None
@@ -84,11 +89,44 @@ def status_payload(target: Path) -> dict[str, Any]:
     if not installed or binary is None:
         return payload
 
-    status_result = _run_json([binary, "status", "--json"], timeout=120.0)
-    doctor_result = _run_json([binary, "doctor", "--json"], timeout=120.0)
+    status_result = _run_json([binary, "status", "--json"], timeout=timeout)
+    payload["status"] = status_result
+    status_json = status_result.get("stdout_json")
+    status_data: dict[str, Any] = status_json if isinstance(status_json, dict) else {}
+
+    if not include_doctor:
+        exit_code = status_result.get("exit_code")
+        if exit_code == 124:
+            payload["health"] = "timeout"
+            payload["summary"] = "miseledger status timed out"
+        elif exit_code == 2:
+            payload["health"] = "unwired"
+            payload["summary"] = "miseledger installed but archive not initialized"
+        elif exit_code == 0 and status_data:
+            payload["health"] = "ok"
+            item_count = next(
+                (
+                    status_data[key]
+                    for key in ("items", "item_count", "total_items", "count")
+                    if isinstance(status_data.get(key), int)
+                ),
+                None,
+            )
+            payload["summary"] = "miseledger status ok" + (f", items={item_count}" if item_count is not None else "")
+        else:
+            payload["health"] = "incomplete"
+            payload["summary"] = f"miseledger status unreadable (exit {exit_code})"
+        payload["next_commands"] = [
+            "miseledger status",
+            "brigade evidence doctor",
+            "brigade receipts export miseledger --target . --new-only --import",
+        ]
+        return payload
+
+    doctor_result = _run_json([binary, "doctor", "--json"], timeout=timeout)
     # doctor may not support --json on older builds; fall back to plain doctor exit
     if doctor_result.get("stdout_json") is None and doctor_result.get("exit_code") not in (0, 1):
-        plain = proc.run([binary, "doctor"], timeout=120.0)
+        plain = proc.run([binary, "doctor"], timeout=timeout)
         doctor_result = {
             "command": [binary, "doctor"],
             "exit_code": plain.code,
@@ -96,12 +134,9 @@ def status_payload(target: Path) -> dict[str, Any]:
             "stdout_unparsed": (plain.stdout or "")[:500],
             "stderr": (plain.stderr or "")[:500],
         }
-    payload["status"] = status_result
     payload["doctor"] = doctor_result
 
-    status_json = status_result.get("stdout_json")
     doctor_json = doctor_result.get("stdout_json")
-    status_data: dict[str, Any] = status_json if isinstance(status_json, dict) else {}
     doctor_data: dict[str, Any] = doctor_json if isinstance(doctor_json, dict) else {}
 
     if status_result.get("exit_code") == 124 or doctor_result.get("exit_code") == 124:

--- a/src/brigade/managed.py
+++ b/src/brigade/managed.py
@@ -11,10 +11,10 @@ import json
 import os
 import urllib.error
 import urllib.request
-from dataclasses import dataclass
-from typing import Callable, List, Optional, Tuple
+from dataclasses import dataclass, replace
+from typing import Any, Callable, List, Optional, Tuple
 
-from . import proc
+from . import managed_snapshot, proc
 from .doctor import OK, WARN, FAIL, MANUAL
 from .station import CheckResult, DoctorContext
 
@@ -70,6 +70,33 @@ def _surface(
         max_chars=max_chars,
         probe=probe,
         probe_contains=probe_contains,
+    )
+
+
+def _surface_from_snapshot(raw: dict[str, Any]) -> MachineSurface:
+    return MachineSurface(
+        kind=str(raw["kind"]),
+        command=tuple(str(part) for part in raw.get("command", [])),
+        read_only=bool(raw.get("read_only", True)),
+        timeout_seconds=float(raw["timeout_seconds"]) if raw.get("timeout_seconds") is not None else None,
+        max_chars=int(raw["max_chars"]) if raw.get("max_chars") is not None else None,
+        probe=tuple(str(part) for part in raw.get("probe", [])),
+        probe_contains=tuple(str(part) for part in raw.get("probe_contains", [])),
+    )
+
+
+def _apply_snapshot(tool: ManagedTool, contract: dict[str, Any]) -> ManagedTool:
+    install = contract.get("install")
+    surfaces = contract.get("surfaces")
+    if not isinstance(install, list) or not isinstance(surfaces, list):
+        raise ValueError(f"managed snapshot contract is incomplete: {tool.name}")
+    return replace(
+        tool,
+        station=str(contract["station"]),
+        command=str(contract["command"]),
+        summary=str(contract.get("summary") or ""),
+        install_args=[str(part) for part in install],
+        surfaces=tuple(_surface_from_snapshot(surface) for surface in surfaces if isinstance(surface, dict)),
     )
 
 
@@ -537,6 +564,12 @@ _TOOLS: Tuple[ManagedTool, ...] = (
             _surface("verify-exit", ("plating", "scan", "--help"), timeout_seconds=10.0),
         ),
     ),
+)
+
+_SNAPSHOT_CONTRACTS = managed_snapshot.executable_contracts()
+_TOOLS = tuple(
+    _apply_snapshot(tool, _SNAPSHOT_CONTRACTS[tool.name]) if tool.name in _SNAPSHOT_CONTRACTS else tool
+    for tool in _TOOLS
 )
 
 

--- a/src/brigade/managed_snapshot.py
+++ b/src/brigade/managed_snapshot.py
@@ -94,6 +94,13 @@ def load_snapshot(path: Path | None = None) -> dict[str, Any]:
             raise ValueError("managed snapshot contains an invalid manifest")
         if not isinstance(source, dict) or source.get("manifest_sha256") != _manifest_digest(manifest):
             raise ValueError("managed snapshot manifest digest mismatch")
+        if source.get("kind") == "lifecycle-assertion":
+            if (
+                source.get("asserted_by") != "brigade-cli"
+                or not isinstance(source.get("observed_repository"), str)
+                or not isinstance(source.get("observed_revision"), str)
+            ):
+                raise ValueError("managed snapshot lifecycle assertion provenance is invalid")
         name = manifest.get("name")
         if not isinstance(name, str) or not name or name in names:
             raise ValueError(f"managed snapshot duplicate or invalid name: {name!r}")

--- a/src/brigade/managed_snapshot.py
+++ b/src/brigade/managed_snapshot.py
@@ -1,0 +1,127 @@
+"""Bundled declarative station contracts for Brigade's managed sidecars."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from . import station_manifest, templates
+
+SCHEMA = "brigade.managed_snapshot.v1"
+STATION_SCHEMA = "brigade.station.v1"
+
+
+def _manifest_digest(manifest: Mapping[str, Any]) -> str:
+    encoded = json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _git_revision(root: Path) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(root), "rev-parse", "HEAD"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def snapshot_path() -> Path:
+    return templates.template_root() / "stations" / "managed-snapshot.json"
+
+
+def build_snapshot(paths: Sequence[Path]) -> dict[str, Any]:
+    if not paths:
+        raise ValueError("at least one station manifest path is required")
+    records: list[dict[str, Any]] = []
+    names: set[str] = set()
+    for source_path in paths:
+        path = source_path.expanduser().resolve()
+        try:
+            station_manifest.load(str(path))
+        except ValueError as exc:
+            raise ValueError(f"invalid station manifest: {path}: {exc}") from exc
+        try:
+            manifest = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ValueError(f"invalid station manifest: {path}") from exc
+        if not isinstance(manifest, dict) or manifest.get("schema") != STATION_SCHEMA:
+            raise ValueError(f"invalid station manifest: {path}")
+        name = manifest.get("name")
+        if not isinstance(name, str) or not name or name in names:
+            raise ValueError(f"duplicate or invalid station name: {name!r}")
+        names.add(name)
+        records.append(
+            {
+                "manifest": manifest,
+                "source": {
+                    "repository": path.parent.name,
+                    "revision": _git_revision(path.parent),
+                    "manifest_sha256": _manifest_digest(manifest),
+                },
+            }
+        )
+    records.sort(key=lambda record: record["manifest"]["name"])
+    return {"schema": SCHEMA, "records": records}
+
+
+def render_snapshot(payload: Mapping[str, Any]) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def load_snapshot(path: Path | None = None) -> dict[str, Any]:
+    source_path = path or snapshot_path()
+    try:
+        payload = json.loads(source_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"managed snapshot could not be loaded: {source_path}") from exc
+    if not isinstance(payload, dict) or payload.get("schema") != SCHEMA:
+        raise ValueError(f"managed snapshot schema must be {SCHEMA}")
+    records = payload.get("records")
+    if not isinstance(records, list):
+        raise ValueError("managed snapshot records must be a list")
+    names: set[str] = set()
+    for record in records:
+        if not isinstance(record, dict):
+            raise ValueError("managed snapshot record must be an object")
+        manifest = record.get("manifest")
+        source = record.get("source")
+        if not isinstance(manifest, dict) or manifest.get("schema") != STATION_SCHEMA:
+            raise ValueError("managed snapshot contains an invalid manifest")
+        if not isinstance(source, dict) or source.get("manifest_sha256") != _manifest_digest(manifest):
+            raise ValueError("managed snapshot manifest digest mismatch")
+        name = manifest.get("name")
+        if not isinstance(name, str) or not name or name in names:
+            raise ValueError(f"managed snapshot duplicate or invalid name: {name!r}")
+        names.add(name)
+    return payload
+
+
+def executable_contracts(payload: Mapping[str, Any] | None = None) -> dict[str, dict[str, Any]]:
+    snapshot = payload if payload is not None else load_snapshot()
+    records = snapshot.get("records")
+    if not isinstance(records, list):
+        raise ValueError("managed snapshot records must be a list")
+    contracts: dict[str, dict[str, Any]] = {}
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        manifest = record.get("manifest")
+        if not isinstance(manifest, dict) or manifest.get("lifecycle", "active") != "active":
+            continue
+        station = manifest.get("station")
+        tools = manifest.get("tools")
+        if not isinstance(station, str) or not isinstance(tools, list):
+            continue
+        for tool in tools:
+            if not isinstance(tool, dict) or tool.get("kind", "executable") != "executable":
+                continue
+            name = tool.get("name")
+            if not isinstance(name, str) or not name:
+                raise ValueError("managed snapshot executable tool needs a name")
+            contracts[name] = {"station": station, **tool}
+    return contracts

--- a/src/brigade/roster.py
+++ b/src/brigade/roster.py
@@ -73,6 +73,22 @@ def _allowed(cli_ref: str, patterns: tuple[str, ...]) -> bool:
     return any(fnmatch.fnmatchcase(cli_ref, pattern) for pattern in patterns)
 
 
+def resolve_roster_path(target: Path, explicit: Path | None = None) -> Path:
+    if explicit is not None:
+        path = explicit.expanduser()
+        if path.exists():
+            return path
+        raise FileNotFoundError(f"roster not found: {path}")
+
+    workspace_path = target.expanduser() / ".brigade" / "roster.toml"
+    user_path = Path.home() / ".brigade" / "roster.toml"
+    if workspace_path.exists():
+        return workspace_path
+    if user_path.exists():
+        return user_path
+    raise FileNotFoundError(f"roster not found: checked {workspace_path} and {user_path}")
+
+
 def load_roster(path: Path) -> Roster:
     if not path.exists():
         raise FileNotFoundError(f"roster not found: {path}")

--- a/src/brigade/roster_cmd.py
+++ b/src/brigade/roster_cmd.py
@@ -115,13 +115,13 @@ def init(
 
 def doctor(target: Path, *, roster_path: Path | None = None) -> int:
     target = target.expanduser()
-    path = roster_path.expanduser() if roster_path is not None else target / DEFAULT_ROSTER_REL
 
     checks: list[doctor_mod.CheckResult] = []
     try:
+        path = roster_mod.resolve_roster_path(target, roster_path)
         loaded = roster_mod.load_roster(path)
-    except FileNotFoundError:
-        checks.append((doctor_mod.FAIL, "roster: file", f"missing at {path}; run `brigade roster init`"))
+    except FileNotFoundError as exc:
+        checks.append((doctor_mod.FAIL, "roster: file", f"{exc}; run `brigade roster init`"))
         return doctor_mod._report(checks)
     except ValueError as exc:
         checks.append((doctor_mod.FAIL, "roster: file", f"invalid {path}: {exc}"))

--- a/src/brigade/status.py
+++ b/src/brigade/status.py
@@ -19,15 +19,92 @@ class StatusRow(TypedDict):
     summary: str
 
 
+STATUS_STATES = (
+    "not-installed",
+    "not-configured",
+    "unchecked",
+    "ok",
+    "degraded",
+    "failed",
+)
+
+
+def _normalize_payload_health(raw: object, *, installed: bool | None) -> str:
+    value = str(raw or "").lower()
+    if installed is False and value in {"", "manual", "missing"}:
+        return "not-installed"
+    if value == "missing":
+        return "unchecked"
+    return {
+        "ok": "ok",
+        "warn": "degraded",
+        "fail": "failed",
+        "timeout": "degraded",
+        "incomplete": "degraded",
+        "unwired": "not-configured",
+    }.get(value, "unchecked")
+
+
+def _health_from_checks(checks: list[_doctor.CheckResult]) -> str:
+    levels = {status for status, _name, _detail in checks}
+    if _doctor.FAIL in levels:
+        return "failed"
+    if _doctor.WARN in levels:
+        return "degraded"
+    if _doctor.OK in levels:
+        return "ok"
+    if _doctor.MANUAL in levels or _doctor.INFO in levels:
+        return "not-configured"
+    return "unchecked"
+
+
+def _optional_station_payload(station: str, target: Path) -> dict[str, object] | None:
+    if station == "tokens":
+        from . import tokens_cmd
+
+        return tokens_cmd.status_payload(target)
+    if station == "search":
+        from . import search_cmd
+
+        return search_cmd.status_payload(target)
+    if station == "pantry":
+        from . import pantry_cmd
+
+        return pantry_cmd.status_payload(target)
+    if station == "notifications":
+        from . import notifications_cmd
+
+        return notifications_cmd._status_payload()
+    if station == "evidence":
+        from . import evidence_cmd
+
+        return evidence_cmd.status_payload(target, include_doctor=False, timeout=5.0)
+    return None
+
+
 def run(target: Path, *, json_output: bool = False) -> int:
     ctx = _doctor.build_context(target)
     rows: list[StatusRow] = []
     for station in all_stations():
-        checks = station.doctor(ctx) if station.doctor else []
-        ok = sum(1 for s, _, _ in checks if s == _doctor.OK)
-        warn = sum(1 for s, _, _ in checks if s == _doctor.WARN)
-        fail = sum(1 for s, _, _ in checks if s == _doctor.FAIL)
-        health = "issues" if fail else ("ok" if ok else "empty")
+        payload = _optional_station_payload(station.name, ctx.target)
+        if payload is not None:
+            installed_raw = payload.get("installed")
+            installed = installed_raw if isinstance(installed_raw, bool) else None
+            health = _normalize_payload_health(
+                payload.get("health") or payload.get("status"),
+                installed=installed,
+            )
+            ok = int(health == "ok")
+            warn = int(health == "degraded")
+            fail = int(health == "failed")
+            summary = str(payload.get("summary") or station.summary)
+        else:
+            checks = station.doctor(ctx) if station.doctor else []
+            ok = sum(1 for s, _, _ in checks if s == _doctor.OK)
+            warn = sum(1 for s, _, _ in checks if s == _doctor.WARN)
+            fail = sum(1 for s, _, _ in checks if s == _doctor.FAIL)
+            health = _health_from_checks(checks)
+            summary = station.summary
         rows.append(
             {
                 "station": station.name,
@@ -35,7 +112,7 @@ def run(target: Path, *, json_output: bool = False) -> int:
                 "ok": ok,
                 "warn": warn,
                 "fail": fail,
-                "summary": station.summary,
+                "summary": summary,
             }
         )
 

--- a/src/brigade/templates/stations/managed-snapshot.json
+++ b/src/brigade/templates/stations/managed-snapshot.json
@@ -167,7 +167,7 @@
       "source": {
         "manifest_sha256": "0e8d9f7a962d5f20857713e39698b567cce7a9e9043db732cf6ab266f3f47176",
         "repository": "graphtrail",
-        "revision": "e51ed5d22fd0f1f11803c356fdb5b932892a094b"
+        "revision": "8a5e15c8e73cb077aa2222b884273d4b8db5fa80"
       }
     },
     {
@@ -288,7 +288,7 @@
       "source": {
         "manifest_sha256": "f09f9a43eb4e1baea1afd9e23b813e0b9966e5fe25517670390a89904f26a6e7",
         "repository": "skillet",
-        "revision": "74520a2b8e40c1959de1044d39e2555b33c6c4cd"
+        "revision": "10b68a9eb70a48fa28242f78e0a43ae06155c18b"
       }
     },
     {

--- a/src/brigade/templates/stations/managed-snapshot.json
+++ b/src/brigade/templates/stations/managed-snapshot.json
@@ -1,0 +1,369 @@
+{
+  "records": [
+    {
+      "manifest": {
+        "lifecycle": "active",
+        "name": "agentpantry",
+        "schema": "brigade.station.v1",
+        "station": "pantry",
+        "summary": "browser session auth sync through a process-boundary Go binary",
+        "tools": [
+          {
+            "command": "agentpantry",
+            "install": [
+              "go",
+              "install",
+              "github.com/escoffier-labs/agentpantry/cmd/agentpantry@latest"
+            ],
+            "kind": "executable",
+            "name": "agentpantry",
+            "summary": "browser session auth sync from source to sink",
+            "surfaces": [
+              {
+                "command": [
+                  "agentpantry",
+                  "doctor",
+                  "--json",
+                  "--no-net"
+                ],
+                "kind": "doctor-json",
+                "probe": [
+                  "agentpantry",
+                  "doctor",
+                  "--help"
+                ],
+                "probe_contains": [
+                  "-json",
+                  "-no-net"
+                ],
+                "read_only": false,
+                "timeout_seconds": 10
+              },
+              {
+                "command": [
+                  "agentpantry",
+                  "inventory",
+                  "--json"
+                ],
+                "kind": "summary-json",
+                "max_chars": 4000,
+                "probe": [
+                  "agentpantry",
+                  "inventory",
+                  "--help"
+                ],
+                "probe_contains": [
+                  "-json"
+                ],
+                "read_only": true,
+                "timeout_seconds": 10
+              },
+              {
+                "command": [
+                  "agentpantry",
+                  "version",
+                  "--json"
+                ],
+                "kind": "verify-exit",
+                "read_only": true,
+                "timeout_seconds": 10
+              }
+            ]
+          }
+        ]
+      },
+      "source": {
+        "manifest_sha256": "5bf46de283063affbd1e3fbabf131fa283b6f8ecc8194f5b873e1861e4932c6a",
+        "repository": "agentpantry",
+        "revision": "d9470b1e29125eaad214b71e96969ceebd0925a6"
+      }
+    },
+    {
+      "manifest": {
+        "lifecycle": "embedded",
+        "name": "content-guard",
+        "owner": "brigade-cli",
+        "schema": "brigade.station.v1",
+        "station": "guard",
+        "summary": "historical standalone package now maintained inside brigade-cli",
+        "tools": []
+      },
+      "source": {
+        "manifest_sha256": "5d488d470c5fb7ac62cae8c3fe774673d5fad1d1d107bc09a7f9d628fde5b6fe",
+        "repository": "content-guard",
+        "revision": "87e095e07fef1f925903f1cce28b5152c58a22b8"
+      }
+    },
+    {
+      "manifest": {
+        "lifecycle": "active",
+        "name": "graphtrail",
+        "schema": "brigade.station.v1",
+        "station": "search",
+        "summary": "local code-graph CLI: callers, callees, impact, context briefs, and structural diffs",
+        "tools": [
+          {
+            "command": "graphtrail",
+            "install": [
+              "cargo",
+              "install",
+              "graphtrail"
+            ],
+            "kind": "executable",
+            "name": "graphtrail",
+            "summary": "local code-graph CLI: callers, callees, impact, context briefs, and structural diffs",
+            "surfaces": [
+              {
+                "command": [
+                  "graphtrail",
+                  "context",
+                  "<task>",
+                  "--markdown"
+                ],
+                "kind": "brief-markdown",
+                "max_chars": 4000,
+                "probe": [
+                  "graphtrail",
+                  "context",
+                  "--help"
+                ],
+                "probe_contains": [
+                  "--markdown"
+                ],
+                "read_only": true,
+                "timeout_seconds": 10
+              },
+              {
+                "command": [
+                  "graphtrail",
+                  "--version"
+                ],
+                "kind": "verify-exit",
+                "read_only": true,
+                "timeout_seconds": 10
+              },
+              {
+                "command": [
+                  "graphtrail",
+                  "doctor",
+                  "--json"
+                ],
+                "kind": "doctor-json",
+                "probe": [
+                  "graphtrail",
+                  "doctor",
+                  "--help"
+                ],
+                "probe_contains": [
+                  "--json"
+                ],
+                "read_only": true,
+                "timeout_seconds": 30
+              }
+            ]
+          }
+        ]
+      },
+      "source": {
+        "manifest_sha256": "0e8d9f7a962d5f20857713e39698b567cce7a9e9043db732cf6ab266f3f47176",
+        "repository": "graphtrail",
+        "revision": "e51ed5d22fd0f1f11803c356fdb5b932892a094b"
+      }
+    },
+    {
+      "manifest": {
+        "lifecycle": "active",
+        "name": "miseledger",
+        "schema": "brigade.station.v1",
+        "station": "evidence",
+        "summary": "local evidence archive, bounded retrieval, and untrusted context bundles",
+        "tools": [
+          {
+            "command": "miseledger",
+            "install": [
+              "go",
+              "install",
+              "github.com/escoffier-labs/miseledger/cmd/miseledger@latest"
+            ],
+            "kind": "executable",
+            "name": "miseledger",
+            "summary": "local-first SQLite archive for agent sessions and imported evidence",
+            "surfaces": [
+              {
+                "command": [
+                  "miseledger",
+                  "doctor",
+                  "--json"
+                ],
+                "kind": "doctor-json",
+                "probe": [
+                  "miseledger",
+                  "doctor",
+                  "--help"
+                ],
+                "probe_contains": [
+                  "--json",
+                  "--mcp",
+                  "--archive"
+                ],
+                "read_only": false,
+                "timeout_seconds": 120
+              },
+              {
+                "command": [
+                  "miseledger",
+                  "evidence",
+                  "<task>",
+                  "--markdown",
+                  "--limit",
+                  "5"
+                ],
+                "kind": "brief-markdown",
+                "max_chars": 4000,
+                "probe": [
+                  "miseledger",
+                  "evidence",
+                  "--help"
+                ],
+                "probe_contains": [
+                  "--markdown",
+                  "--limit"
+                ],
+                "read_only": false,
+                "timeout_seconds": 10
+              },
+              {
+                "command": [
+                  "miseledger",
+                  "version"
+                ],
+                "kind": "verify-exit",
+                "read_only": true,
+                "timeout_seconds": 10
+              }
+            ]
+          }
+        ]
+      },
+      "source": {
+        "manifest_sha256": "fe41dcad9536bbd23832501f20b1cbd1afd60af79e6a9672a36fdd6235cebfe1",
+        "repository": "miseledger",
+        "revision": "87c563dcb6bd1950ac0c28542de47c1556b9f7ea"
+      }
+    },
+    {
+      "manifest": {
+        "lifecycle": "active",
+        "name": "skillet",
+        "schema": "brigade.station.v1",
+        "station": "skills",
+        "summary": "reviewed portable agent skill roster",
+        "tools": [
+          {
+            "install": [
+              "npx",
+              "skills",
+              "add",
+              "escoffier-labs/skillet"
+            ],
+            "kind": "skill-roster",
+            "name": "skillet",
+            "summary": "portable skill packages for supported coding harnesses",
+            "surfaces": [
+              {
+                "kind": "verify-exit",
+                "probe": [
+                  "bash",
+                  "tests/lint-skills.sh"
+                ],
+                "probe_contains": [
+                  "[ok] catalog (36 skills)"
+                ],
+                "timeout_seconds": 60
+              }
+            ]
+          }
+        ]
+      },
+      "source": {
+        "manifest_sha256": "f09f9a43eb4e1baea1afd9e23b813e0b9966e5fe25517670390a89904f26a6e7",
+        "repository": "skillet",
+        "revision": "74520a2b8e40c1959de1044d39e2555b33c6c4cd"
+      }
+    },
+    {
+      "manifest": {
+        "lifecycle": "active",
+        "name": "token-glace",
+        "schema": "brigade.station.v1",
+        "station": "tokens",
+        "summary": "output compaction and token-use summaries",
+        "tools": [
+          {
+            "command": "token-glace",
+            "install": [
+              "npm",
+              "install",
+              "-g",
+              "https://github.com/escoffier-labs/token-glace/releases/download/v0.8.3/token-glace-v0.8.3.tar.gz"
+            ],
+            "kind": "executable",
+            "name": "token-glace",
+            "summary": "output compaction through host hooks",
+            "surfaces": [
+              {
+                "command": [
+                  "token-glace",
+                  "doctor",
+                  "hooks",
+                  "--format",
+                  "json"
+                ],
+                "kind": "doctor-json",
+                "read_only": true,
+                "timeout_seconds": 30
+              },
+              {
+                "command": [
+                  "token-glace",
+                  "stats",
+                  "--format",
+                  "json",
+                  "--timezone",
+                  "utc"
+                ],
+                "kind": "summary-json",
+                "max_chars": 4000,
+                "probe": [
+                  "token-glace",
+                  "--help"
+                ],
+                "probe_contains": [
+                  "--format",
+                  "--timezone"
+                ],
+                "read_only": true,
+                "timeout_seconds": 30
+              },
+              {
+                "command": [
+                  "token-glace",
+                  "verify"
+                ],
+                "kind": "verify-exit",
+                "read_only": true,
+                "timeout_seconds": 60
+              }
+            ]
+          }
+        ]
+      },
+      "source": {
+        "manifest_sha256": "2f3d7f05a159a664c5a020e285c3c05ca91cbda93c981af5f1b8a1df0fd2c45e",
+        "repository": "token-glace",
+        "revision": "44db23dcd0605780de1b2fbb30d99dbecf6ce6c4"
+      }
+    }
+  ],
+  "schema": "brigade.managed_snapshot.v1"
+}

--- a/src/brigade/templates/stations/managed-snapshot.json
+++ b/src/brigade/templates/stations/managed-snapshot.json
@@ -75,7 +75,7 @@
       "source": {
         "manifest_sha256": "5bf46de283063affbd1e3fbabf131fa283b6f8ecc8194f5b873e1861e4932c6a",
         "repository": "agentpantry",
-        "revision": "d9470b1e29125eaad214b71e96969ceebd0925a6"
+        "revision": "9d904c3777f116c3a62d5ab2e7e20849d02c114a"
       }
     },
     {
@@ -89,9 +89,11 @@
         "tools": []
       },
       "source": {
+        "asserted_by": "brigade-cli",
+        "kind": "lifecycle-assertion",
         "manifest_sha256": "5d488d470c5fb7ac62cae8c3fe774673d5fad1d1d107bc09a7f9d628fde5b6fe",
-        "repository": "content-guard",
-        "revision": "87e095e07fef1f925903f1cce28b5152c58a22b8"
+        "observed_repository": "content-guard",
+        "observed_revision": "d93468ba05485635e252c0fd4129063c750e2cce"
       }
     },
     {
@@ -167,7 +169,7 @@
       "source": {
         "manifest_sha256": "0e8d9f7a962d5f20857713e39698b567cce7a9e9043db732cf6ab266f3f47176",
         "repository": "graphtrail",
-        "revision": "8a5e15c8e73cb077aa2222b884273d4b8db5fa80"
+        "revision": "54e29726e186bfef6226635146e65b9793531fa8"
       }
     },
     {
@@ -277,7 +279,7 @@
                   "tests/lint-skills.sh"
                 ],
                 "probe_contains": [
-                  "[ok] catalog (36 skills)"
+                  "[ok] catalog (35 skills)"
                 ],
                 "timeout_seconds": 60
               }
@@ -286,9 +288,9 @@
         ]
       },
       "source": {
-        "manifest_sha256": "f09f9a43eb4e1baea1afd9e23b813e0b9966e5fe25517670390a89904f26a6e7",
+        "manifest_sha256": "77e898d106fdc20cedb4e5efa3d95550f1962287a27ffc77b4e61de54f04c31f",
         "repository": "skillet",
-        "revision": "10b68a9eb70a48fa28242f78e0a43ae06155c18b"
+        "revision": "1f871dd44be70b0e912f832d448436a4a0fcc7b3"
       }
     },
     {
@@ -361,7 +363,7 @@
       "source": {
         "manifest_sha256": "2f3d7f05a159a664c5a020e285c3c05ca91cbda93c981af5f1b8a1df0fd2c45e",
         "repository": "token-glace",
-        "revision": "44db23dcd0605780de1b2fbb30d99dbecf6ce6c4"
+        "revision": "efb7c8544014d1bdd0df436c741d9d0ef20a090e"
       }
     }
   ],

--- a/src/brigade/tokens_cmd.py
+++ b/src/brigade/tokens_cmd.py
@@ -86,7 +86,10 @@ def status_payload(target: Path) -> dict[str, Any]:
     tracker_summary = "usage-tracker not installed"
     if tracker:
         # Prefer compact summary surface when present; fall back to --help probe.
-        summary = health.run_json([tracker, "export", "--summary-json"], timeout=30.0)
+        summary = health.run_json(
+            [tracker, "export", "--since", "30d", "--summary-json", "--no-write"],
+            timeout=30.0,
+        )
         tools["usage-tracker"]["summary_probe"] = summary
         if summary.get("exit_code") == 0 and isinstance(summary.get("stdout_json"), dict):
             data = summary["stdout_json"]

--- a/tests/test_evidence_cmd.py
+++ b/tests/test_evidence_cmd.py
@@ -39,6 +39,29 @@ def test_evidence_status_ok_with_status_json(monkeypatch, tmp_path):
     assert any("receipts export miseledger" in cmd for cmd in payload["next_commands"])
 
 
+def test_evidence_summary_status_skips_doctor(monkeypatch, tmp_path):
+    monkeypatch.setattr(evidence_cmd.evidence_brief, "_miseledger_bin", lambda: "/x/miseledger")
+    calls = []
+
+    def fake_run_json(args, *, timeout):
+        calls.append((args, timeout))
+        return {
+            "command": args,
+            "exit_code": 0,
+            "stdout_json": {"items": 12},
+            "stdout_unparsed": None,
+            "stderr": "",
+        }
+
+    monkeypatch.setattr(evidence_cmd, "_run_json", fake_run_json)
+
+    payload = evidence_cmd.status_payload(tmp_path, include_doctor=False, timeout=5.0)
+
+    assert payload["health"] == "ok"
+    assert calls == [(["/x/miseledger", "status", "--json"], 5.0)]
+    assert payload["doctor"] is None
+
+
 def test_evidence_doctor_exits_nonzero_on_fail(monkeypatch, tmp_path):
     monkeypatch.setattr(evidence_cmd.evidence_brief, "_miseledger_bin", lambda: "/x/miseledger")
 

--- a/tests/test_managed_snapshot.py
+++ b/tests/test_managed_snapshot.py
@@ -1,0 +1,154 @@
+import json
+
+import pytest
+
+from brigade import managed
+from brigade import managed_snapshot
+
+
+EXPECTED_NAMES = {
+    "agentpantry",
+    "content-guard",
+    "graphtrail",
+    "miseledger",
+    "skillet",
+    "token-glace",
+}
+
+
+def test_bundled_snapshot_covers_first_class_sidecars():
+    payload = managed_snapshot.load_snapshot()
+    records = payload["records"]
+    assert payload["schema"] == managed_snapshot.SCHEMA
+    assert {record["manifest"]["name"] for record in records} == EXPECTED_NAMES
+
+    by_name = {record["manifest"]["name"]: record["manifest"] for record in records}
+    assert by_name["content-guard"]["lifecycle"] == "embedded"
+    assert by_name["content-guard"]["owner"] == "brigade-cli"
+    assert by_name["skillet"]["tools"][0]["kind"] == "skill-roster"
+    assert managed.resolve("skillet") is None
+
+
+def test_bundled_executable_contracts_drive_managed_catalog():
+    contracts = managed_snapshot.executable_contracts()
+    assert set(contracts) == {"agentpantry", "graphtrail", "miseledger", "token-glace"}
+
+    for name, contract in contracts.items():
+        tool = managed.resolve(name)
+        assert tool is not None
+        assert tool.station == contract["station"]
+        assert tool.command == contract["command"]
+        assert tool.summary == contract["summary"]
+        assert tool.install_args == contract["install"]
+        actual_surfaces = [
+            {
+                "kind": surface.kind,
+                "command": list(surface.command),
+                "read_only": surface.read_only,
+                "timeout_seconds": surface.timeout_seconds,
+                "max_chars": surface.max_chars,
+                "probe": list(surface.probe),
+                "probe_contains": list(surface.probe_contains),
+            }
+            for surface in tool.surfaces
+        ]
+        expected_surfaces = [
+            {
+                "kind": surface["kind"],
+                "command": surface.get("command", []),
+                "read_only": surface.get("read_only", True),
+                "timeout_seconds": float(surface["timeout_seconds"])
+                if surface.get("timeout_seconds") is not None
+                else None,
+                "max_chars": surface.get("max_chars"),
+                "probe": surface.get("probe", []),
+                "probe_contains": surface.get("probe_contains", []),
+            }
+            for surface in contract["surfaces"]
+        ]
+        assert actual_surfaces == expected_surfaces
+
+
+def test_build_snapshot_sorts_and_digests_manifests(monkeypatch, tmp_path):
+    monkeypatch.setattr(managed_snapshot, "_git_revision", lambda root: "abc123")
+    paths = []
+    for name in ("zeta", "alpha"):
+        root = tmp_path / name
+        root.mkdir()
+        path = root / "station.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "schema": "brigade.station.v1",
+                    "name": name,
+                    "station": "search",
+                    "summary": name,
+                    "lifecycle": "embedded",
+                    "owner": "brigade-cli",
+                    "tools": [],
+                }
+            )
+        )
+        paths.append(path)
+
+    payload = managed_snapshot.build_snapshot(paths)
+    assert [record["manifest"]["name"] for record in payload["records"]] == ["alpha", "zeta"]
+    assert {record["source"]["revision"] for record in payload["records"]} == {"abc123"}
+    managed_snapshot.load_snapshot(_write_snapshot(tmp_path, payload))
+
+
+def test_load_snapshot_rejects_digest_drift(tmp_path):
+    payload = {
+        "schema": managed_snapshot.SCHEMA,
+        "records": [
+            {
+                "manifest": {
+                    "schema": "brigade.station.v1",
+                    "name": "x",
+                    "station": "search",
+                    "summary": "x",
+                    "tools": [],
+                },
+                "source": {
+                    "repository": "x",
+                    "revision": "abc",
+                    "manifest_sha256": "wrong",
+                },
+            }
+        ],
+    }
+    with pytest.raises(ValueError, match="digest"):
+        managed_snapshot.load_snapshot(_write_snapshot(tmp_path, payload))
+
+
+def test_build_snapshot_rejects_incomplete_station_manifest(tmp_path):
+    path = tmp_path / "station.json"
+    path.write_text(json.dumps({"schema": "brigade.station.v1", "name": "missing-fields"}))
+
+    with pytest.raises(ValueError, match="station"):
+        managed_snapshot.build_snapshot([path])
+
+
+def test_apply_snapshot_preserves_runtime_callables():
+    original = managed.resolve("graphtrail")
+    assert original is not None
+    contract = {
+        "station": "search",
+        "command": "graphtrail-next",
+        "summary": "snapshot summary",
+        "install": ["cargo", "install", "graphtrail-next"],
+        "surfaces": [],
+    }
+
+    updated = managed._apply_snapshot(original, contract)
+
+    assert updated.command == "graphtrail-next"
+    assert updated.summary == "snapshot summary"
+    assert updated.wire is original.wire
+    assert updated.doctor is original.doctor
+
+
+def _write_snapshot(tmp_path, payload):
+    path = tmp_path / "managed-snapshot.json"
+    path.write_text(managed_snapshot.render_snapshot(payload))
+    return path

--- a/tests/test_managed_snapshot.py
+++ b/tests/test_managed_snapshot.py
@@ -23,8 +23,19 @@ def test_bundled_snapshot_covers_first_class_sidecars():
     assert {record["manifest"]["name"] for record in records} == EXPECTED_NAMES
 
     by_name = {record["manifest"]["name"]: record["manifest"] for record in records}
+    records_by_name = {record["manifest"]["name"]: record for record in records}
     assert by_name["content-guard"]["lifecycle"] == "embedded"
     assert by_name["content-guard"]["owner"] == "brigade-cli"
+    content_guard_source = records_by_name["content-guard"]["source"]
+    assert content_guard_source["kind"] == "lifecycle-assertion"
+    assert content_guard_source["asserted_by"] == "brigade-cli"
+    assert content_guard_source["observed_repository"] == "content-guard"
+    assert content_guard_source["observed_revision"] == "d93468ba05485635e252c0fd4129063c750e2cce"
+    assert "revision" not in content_guard_source
+    assert records_by_name["agentpantry"]["source"]["revision"] == ("9d904c3777f116c3a62d5ab2e7e20849d02c114a")
+    assert records_by_name["token-glace"]["source"]["revision"] == ("efb7c8544014d1bdd0df436c741d9d0ef20a090e")
+    assert records_by_name["skillet"]["source"]["revision"] == "1f871dd44be70b0e912f832d448436a4a0fcc7b3"
+    assert records_by_name["graphtrail"]["source"]["revision"] == ("54e29726e186bfef6226635146e65b9793531fa8")
     assert by_name["skillet"]["tools"][0]["kind"] == "skill-roster"
     assert managed.resolve("skillet") is None
 

--- a/tests/test_roster.py
+++ b/tests/test_roster.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from brigade import cli
@@ -51,6 +53,50 @@ def test_load_roster_fallback_parser(monkeypatch, tmp_path):
     r = roster_mod.load_roster(_write(tmp_path, VALID))
     assert r.orchestrator == "chef"
     assert r.allow_models == ("codex", "ollama:*")
+
+
+def test_resolve_roster_path_prefers_workspace(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    workspace = tmp_path / "workspace"
+    local = workspace / ".brigade" / "roster.toml"
+    user = home / ".brigade" / "roster.toml"
+    local.parent.mkdir(parents=True)
+    user.parent.mkdir(parents=True)
+    local.write_text(VALID)
+    user.write_text(VALID)
+    monkeypatch.setattr(Path, "home", lambda: home)
+    assert roster_mod.resolve_roster_path(workspace) == local
+
+
+def test_resolve_roster_path_uses_user_fallback(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    user = home / ".brigade" / "roster.toml"
+    user.parent.mkdir(parents=True)
+    user.write_text(VALID)
+    monkeypatch.setattr(Path, "home", lambda: home)
+    assert roster_mod.resolve_roster_path(tmp_path / "workspace") == user
+
+
+def test_resolve_roster_path_explicit_never_falls_back(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    user = home / ".brigade" / "roster.toml"
+    user.parent.mkdir(parents=True)
+    user.write_text(VALID)
+    missing = tmp_path / "missing.toml"
+    monkeypatch.setattr(Path, "home", lambda: home)
+    with pytest.raises(FileNotFoundError, match=str(missing)):
+        roster_mod.resolve_roster_path(tmp_path / "workspace", missing)
+
+
+def test_resolve_roster_path_missing_names_both_candidates(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    workspace = tmp_path / "workspace"
+    monkeypatch.setattr(Path, "home", lambda: home)
+    with pytest.raises(FileNotFoundError) as exc:
+        roster_mod.resolve_roster_path(workspace)
+    message = str(exc.value)
+    assert str(workspace / ".brigade" / "roster.toml") in message
+    assert str(home / ".brigade" / "roster.toml") in message
 
 
 def test_workers_excludes_orchestrator(tmp_path):

--- a/tests/test_roster_cmd.py
+++ b/tests/test_roster_cmd.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from brigade import agents
 from brigade import cli
 from brigade import roster
@@ -39,12 +41,30 @@ def test_roster_init_force_overwrites_with_options(tmp_target):
     assert "max_workers = 2" in text
 
 
-def test_roster_doctor_missing_file_fails(tmp_target, capsys):
+def test_roster_doctor_missing_file_fails(monkeypatch, tmp_target, tmp_path, capsys):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "empty-home")
     rc = roster_cmd.doctor(tmp_target)
     out = capsys.readouterr().out
     assert rc == 1
     assert "[fail]" in out
     assert "brigade roster init" in out
+
+
+def test_roster_doctor_falls_back_to_home_roster(monkeypatch, tmp_target, tmp_path, capsys):
+    home = tmp_path / "home"
+    path = home / ".brigade" / "roster.toml"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        'orchestrator = "chef"\n'
+        "[agents.chef]\n"
+        'endpoint = "https://example.test/v1/chat"\n'
+        'model = "some-hosted-model"\n'
+        'role = "plan"\n'
+    )
+    monkeypatch.setattr(Path, "home", lambda: home)
+
+    assert roster_cmd.doctor(tmp_target) == 0
+    assert str(path) in capsys.readouterr().out
 
 
 def test_roster_doctor_validates_agents(monkeypatch, tmp_target, capsys):

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,9 +1,76 @@
 import json
 from pathlib import Path
 
+import pytest
+
+from brigade import doctor
+from brigade import registry
 from brigade import status as status_mod
 from brigade.install import install_selection
 from brigade.selection import Selection
+from brigade.station import Station
+
+
+@pytest.mark.parametrize(
+    ("raw", "installed", "expected"),
+    [
+        ("ok", True, "ok"),
+        ("warn", True, "degraded"),
+        ("fail", True, "failed"),
+        ("timeout", True, "degraded"),
+        ("incomplete", True, "degraded"),
+        ("unwired", True, "not-configured"),
+        ("missing", False, "not-installed"),
+        ("missing", True, "unchecked"),
+        ("manual", False, "not-installed"),
+        ("unknown", True, "unchecked"),
+    ],
+)
+def test_normalize_payload_health(raw, installed, expected):
+    assert status_mod._normalize_payload_health(raw, installed=installed) == expected
+
+
+@pytest.mark.parametrize(
+    ("checks", "expected"),
+    [
+        ([], "unchecked"),
+        ([(doctor.INFO, "x", "x")], "not-configured"),
+        ([(doctor.OK, "x", "x")], "ok"),
+        ([(doctor.OK, "x", "x"), (doctor.WARN, "y", "y")], "degraded"),
+        ([(doctor.FAIL, "x", "x"), (doctor.WARN, "y", "y")], "failed"),
+    ],
+)
+def test_health_from_doctor_checks(checks, expected):
+    assert status_mod._health_from_checks(checks) == expected
+
+
+def test_status_uses_optional_station_payload(monkeypatch, tmp_target, capsys):
+    monkeypatch.setattr(status_mod, "all_stations", lambda: (registry.SEARCH,))
+    monkeypatch.setattr(
+        status_mod,
+        "_optional_station_payload",
+        lambda station, target: {"installed": True, "health": "ok", "summary": "graph ok"},
+    )
+
+    assert status_mod.run(tmp_target, json_output=True) == 0
+    row = json.loads(capsys.readouterr().out)["stations"][0]
+    assert row["health"] == "ok"
+    assert row["summary"] == "graph ok"
+
+
+def test_status_warning_is_degraded(monkeypatch, tmp_target, capsys):
+    station = Station(
+        name="warning-test",
+        summary="warning fixture",
+        doctor=lambda ctx: [(doctor.WARN, "warning", "degraded")],
+    )
+    monkeypatch.setattr(status_mod, "all_stations", lambda: (station,))
+    monkeypatch.setattr(status_mod, "_optional_station_payload", lambda station, target: None)
+
+    assert status_mod.run(tmp_target, json_output=True) == 0
+    row = json.loads(capsys.readouterr().out)["stations"][0]
+    assert row["health"] == "degraded"
+    assert row["warn"] == 1
 
 
 def test_status_lists_stations_for_installed_workspace(tmp_target: Path, capsys):

--- a/tests/test_tokens_cmd.py
+++ b/tests/test_tokens_cmd.py
@@ -38,6 +38,21 @@ def test_tokens_status_ok_with_token_glace(monkeypatch, tmp_path):
     assert "hook status: ok" in payload["summary"]
 
 
+def test_usage_tracker_status_uses_read_only_summary_surface(monkeypatch, tmp_path):
+    tracker = "/x/usage-tracker"
+    monkeypatch.setattr(tokens_cmd.proc, "which", lambda cmd: tracker if cmd == "usage-tracker" else None)
+    calls = []
+
+    def fake_run(args, **kw):
+        calls.append(args)
+        return tokens_cmd.proc.Result(0, json.dumps({"total_cost_usd": 1.25}), "")
+
+    monkeypatch.setattr(tokens_cmd.proc, "run", fake_run)
+
+    assert tokens_cmd.status_payload(tmp_path)["health"] == "ok"
+    assert calls == [[tracker, "export", "--since", "30d", "--summary-json", "--no-write"]]
+
+
 def test_tokens_doctor_exits_nonzero_on_broken(monkeypatch, tmp_path):
     def which(cmd):
         return f"/x/{cmd}" if cmd == "token-glace" else None


### PR DESCRIPTION
## What changed

- Align workspace and user roster resolution.
- Report explicit station health states.
- Load an offline managed-station snapshot with reviewed source provenance.
- Represent the archived Content Guard package as a Brigade-owned lifecycle assertion.

## Why

Station status and managed sidecar contracts need one authoritative, offline-readable source without attributing unpublished manifests to archived repositories.

## Verification

- Full `./scripts/verify`: 2,179 passed, 3 skipped, coverage 81.21%.
- Published sidecar revisions were checked against Agent Pantry, Token Glace, Skillet, and GraphTrail.

Closes #213.
