### PR TITLE
feat(run): preserve reproducible adapter evidence

### DIFF
--- a/docs/phase-roster-reproducibility.md
+++ b/docs/phase-roster-reproducibility.md
@@ -1,0 +1,18 @@
+# Roster Reproducibility
+
+## Goal
+
+Record and apply per-seat reasoning settings, report read-only enforcement for
+the seats that will actually run, and attribute scorecard observations only to
+participating seats using their measured durations.
+
+## Work
+
+- [x] Add a validated optional `reasoning` field to CLI roster seats.
+- [x] Apply reasoning to Codex exec and app-server, OpenCode, Pi, and Grok.
+- [x] Preserve reasoning in roster snapshots and resume paths.
+- [x] Limit direct-worker read-only advisories to the selected worker.
+- [x] Base advisory classification on the effective transport and sandbox.
+- [x] Record per-seat execution duration in run artifacts.
+- [x] Count only actual worker and orchestrator participation in scorecards.
+- [x] Run focused tests and `./scripts/verify` through Brigade.

--- a/docs/phase-run-adapter-evidence.md
+++ b/docs/phase-run-adapter-evidence.md
@@ -1,0 +1,32 @@
+# Run Adapter Evidence
+
+## Goal
+
+Make every `brigade run` CLI adapter preserve enough process evidence to
+diagnose failures without rerunning the model, and classify silent Cursor and
+Grok exits separately from ordinary empty output.
+
+## Contract
+
+- Preserve the exact captured stdout, stderr, exit code, and timeout state from
+  `proc.run` in the agent and worker result boundaries.
+- Preserve partial stdout and stderr from timed-out subprocesses.
+- Keep the existing normalized `text`, `ok`, and short `detail` fields for
+  compatibility.
+- Write complete worker streams under the run artifact directory and reference
+  them from `worker-results.json` and `synthesis.json`.
+- Classify exit-zero empty output from Cursor or Grok as a silent adapter exit
+  with an actionable message. Other adapters keep the generic empty-output
+  classification.
+- Do not put prompts, credentials, environment variables, or command arguments
+  into the new log metadata.
+
+## Verification
+
+- [x] Add failing unit tests for subprocess timeout output preservation.
+- [x] Add failing adapter tests for process evidence and silent Cursor/Grok
+  classification.
+- [x] Add failing orchestration tests for log files and JSON references.
+- [x] Implement the smallest shared result and artifact changes.
+- [x] Run focused tests through Brigade.
+- [x] Run `./scripts/verify` through Brigade.

--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 import sys
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
@@ -56,6 +57,7 @@ class WorkerResult:
     timed_out: bool = False
     stdout_log: str | None = None
     stderr_log: str | None = None
+    duration_seconds: float | None = None
 
 
 @dataclass(frozen=True)
@@ -698,6 +700,8 @@ def _run_orchestrator(
         kwargs["sandbox"] = sandbox
     if orchestrator.model is not None:
         kwargs["model"] = orchestrator.model
+    if orchestrator.reasoning is not None:
+        kwargs["reasoning"] = orchestrator.reasoning
     return agents.run_agent(orchestrator.cli, prompt, **kwargs)
 
 
@@ -939,11 +943,17 @@ def _run_codex_appserver_worker(
                 registry.register(worker, thread, turn_id)
 
         try:
-            turn = thread.run_turn(prompt, timeout=timeout, on_event=on_event, on_turn_start=on_turn_start)
+            turn_kwargs = {"timeout": timeout, "on_event": on_event, "on_turn_start": on_turn_start}
+            if agent.reasoning is not None:
+                turn_kwargs["effort"] = agent.reasoning
+            turn = thread.run_turn(prompt, **turn_kwargs)
         except TypeError as exc:
             if "on_turn_start" not in str(exc):
                 raise
-            turn = thread.run_turn(prompt, timeout=timeout, on_event=on_event)
+            fallback_kwargs = {"timeout": timeout, "on_event": on_event}
+            if agent.reasoning is not None:
+                fallback_kwargs["effort"] = agent.reasoning
+            turn = thread.run_turn(prompt, **fallback_kwargs)
     except codex_appserver.AppServerError as exc:
         return agents.AgentResult(text="", ok=False, detail=str(exc)[:200], status="failed")
     finally:
@@ -1001,6 +1011,7 @@ def dispatch(
             drift_impact=drift_impact,
             evidence=evidence,
         )
+        started = time.monotonic()
         if agent.cli == "codex" and appserver is not None:
             on_event = _worker_event_writer(events_dir, assignment.worker, verbose=verbose)
             result = _run_codex_appserver_worker(
@@ -1025,6 +1036,8 @@ def dispatch(
                 kwargs["sandbox"] = sandbox
             if agent.model is not None:
                 kwargs["model"] = agent.model
+            if agent.reasoning is not None:
+                kwargs["reasoning"] = agent.reasoning
             result = agents.run_agent(agent.cli, prompt, **kwargs)
         return WorkerResult(
             worker=assignment.worker,
@@ -1038,6 +1051,7 @@ def dispatch(
             stderr=result.stderr,
             exit_code=result.exit_code,
             timed_out=result.timed_out,
+            duration_seconds=max(0.0, round(time.monotonic() - started, 3)),
         )
 
     if not assignments:
@@ -1175,6 +1189,8 @@ def _worker_payload(results: list[WorkerResult]) -> list[dict[str, object]]:
             entry["stdout_log"] = result.stdout_log
         if result.stderr_log is not None:
             entry["stderr_log"] = result.stderr_log
+        if result.duration_seconds is not None:
+            entry["duration_seconds"] = result.duration_seconds
         payload.append(entry)
     return payload
 
@@ -1259,6 +1275,8 @@ def _agent_result_payload(result: agents.AgentResult) -> dict[str, object]:
         payload["stdout_log"] = result.stdout_log
     if result.stderr_log is not None:
         payload["stderr_log"] = result.stderr_log
+    if result.duration_seconds is not None:
+        payload["duration_seconds"] = result.duration_seconds
     return payload
 
 
@@ -1598,6 +1616,7 @@ def _roster_payload(roster: Roster) -> dict[str, object]:
             name: {
                 "cli": agent.cli,
                 "model": agent.model,
+                "reasoning": agent.reasoning,
                 "role": agent.role,
                 "timeout_seconds": agent.timeout_seconds,
             }
@@ -2012,8 +2031,10 @@ def run(
             timed_out=direct_result.timed_out,
             stdout_log=direct_result.stdout_log,
             stderr_log=direct_result.stderr_log,
+            duration_seconds=direct_result.duration_seconds,
         )
     else:
+        synthesis_started = time.monotonic()
         final = _run_orchestrator(
             roster,
             build_synth_prompt(
@@ -2030,6 +2051,7 @@ def run(
             sandbox_read_only=sandbox_read_only,
             sandbox=sandbox,
         )
+        final = replace(final, duration_seconds=max(0.0, round(time.monotonic() - synthesis_started, 3)))
     if output_dir is not None:
         if not direct_worker:
             final = _write_agent_logs(output_dir, "synthesis", final)

--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -50,6 +50,12 @@ class WorkerResult:
     detail: str = ""
     thread_id: str | None = None
     status: str = ""
+    stdout: str | None = None
+    stderr: str | None = None
+    exit_code: int | None = None
+    timed_out: bool = False
+    stdout_log: str | None = None
+    stderr_log: str | None = None
 
 
 @dataclass(frozen=True)
@@ -1028,6 +1034,10 @@ def dispatch(
             detail=result.detail,
             thread_id=result.thread_id,
             status=result.status,
+            stdout=result.stdout,
+            stderr=result.stderr,
+            exit_code=result.exit_code,
+            timed_out=result.timed_out,
         )
 
     if not assignments:
@@ -1158,8 +1168,45 @@ def _worker_payload(results: list[WorkerResult]) -> list[dict[str, object]]:
         if result.thread_id is not None:
             entry["thread_id"] = result.thread_id
             entry["status"] = result.status
+        if result.exit_code is not None:
+            entry["exit_code"] = result.exit_code
+            entry["timed_out"] = result.timed_out
+        if result.stdout_log is not None:
+            entry["stdout_log"] = result.stdout_log
+        if result.stderr_log is not None:
+            entry["stderr_log"] = result.stderr_log
         payload.append(entry)
     return payload
+
+
+def _write_worker_logs(output_dir: Path, results: list[WorkerResult]) -> list[WorkerResult]:
+    logs_dir = output_dir / "logs"
+    recorded: list[WorkerResult] = []
+    for index, result in enumerate(results, start=1):
+        if result.stdout is None and result.stderr is None:
+            recorded.append(result)
+            continue
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        worker = re.sub(r"[^A-Za-z0-9_.-]+", "-", result.worker).strip("-") or "worker"
+        prefix = f"worker-{index:03d}-{worker}"
+        stdout_ref = f"logs/{prefix}.stdout.log"
+        stderr_ref = f"logs/{prefix}.stderr.log"
+        localio.write_text_atomic(output_dir / stdout_ref, result.stdout or "")
+        localio.write_text_atomic(output_dir / stderr_ref, result.stderr or "")
+        recorded.append(replace(result, stdout_log=stdout_ref, stderr_log=stderr_ref))
+    return recorded
+
+
+def _write_agent_logs(output_dir: Path, label: str, result: agents.AgentResult) -> agents.AgentResult:
+    if result.stdout is None and result.stderr is None:
+        return result
+    logs_dir = output_dir / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    stdout_ref = f"logs/{label}.stdout.log"
+    stderr_ref = f"logs/{label}.stderr.log"
+    localio.write_text_atomic(output_dir / stdout_ref, result.stdout or "")
+    localio.write_text_atomic(output_dir / stderr_ref, result.stderr or "")
+    return replace(result, stdout_log=stdout_ref, stderr_log=stderr_ref)
 
 
 def _is_brigade_path(value: str) -> bool:
@@ -1200,11 +1247,19 @@ def _mark_noop_worker_results(worker_results: list[WorkerResult], suspected_noop
 
 
 def _agent_result_payload(result: agents.AgentResult) -> dict[str, object]:
-    return {
+    payload: dict[str, object] = {
         "ok": result.ok,
         "detail": result.detail,
         "text": result.text,
     }
+    if result.exit_code is not None:
+        payload["exit_code"] = result.exit_code
+        payload["timed_out"] = result.timed_out
+    if result.stdout_log is not None:
+        payload["stdout_log"] = result.stdout_log
+    if result.stderr_log is not None:
+        payload["stderr_log"] = result.stderr_log
+    return payload
 
 
 def _code_graph_delta_skip(status: str) -> dict[str, object]:
@@ -1922,6 +1977,7 @@ def run(
     ground_truth["suspected_noop"] = suspected_noop
     worker_results = _mark_noop_worker_results(worker_results, suspected_noop)
     if output_dir is not None:
+        worker_results = _write_worker_logs(output_dir, worker_results)
         _write_json(
             output_dir / "worker-results.json",
             {"results": _worker_payload(worker_results), "ground_truth": ground_truth},
@@ -1950,6 +2006,12 @@ def run(
             detail=direct_result.detail,
             thread_id=direct_result.thread_id,
             status=direct_result.status,
+            stdout=direct_result.stdout,
+            stderr=direct_result.stderr,
+            exit_code=direct_result.exit_code,
+            timed_out=direct_result.timed_out,
+            stdout_log=direct_result.stdout_log,
+            stderr_log=direct_result.stderr_log,
         )
     else:
         final = _run_orchestrator(
@@ -1969,6 +2031,8 @@ def run(
             sandbox=sandbox,
         )
     if output_dir is not None:
+        if not direct_worker:
+            final = _write_agent_logs(output_dir, "synthesis", final)
         synthesis_payload = (
             {
                 "mode": "direct-worker",

--- a/src/brigade/agents.py
+++ b/src/brigade/agents.py
@@ -198,6 +198,7 @@ class AgentResult:
     timed_out: bool = False
     stdout_log: str | None = None
     stderr_log: str | None = None
+    duration_seconds: float | None = None
 
 
 def is_known(cli_ref: str) -> bool:
@@ -249,11 +250,30 @@ _MODEL_PIN: dict[str, tuple[str, Callable[[List[str], str, str], List[str]]]] = 
     "antigravity": ("--model", _pin_after_cmd),  # agy --model X [--sandbox] --print <prompt>
 }
 
+_REASONING_ADAPTERS = frozenset({"codex", "opencode", "pi", "grok"})
+
 
 def supports_model_pinning(cli_ref: str) -> bool:
     """True if cli_ref accepts a per-agent `model=` pin. Ollama refs name their
     own model and return False here."""
     return cli_ref in _MODEL_PIN
+
+
+def supports_reasoning(cli_ref: str) -> bool:
+    return cli_ref in _REASONING_ADAPTERS
+
+
+def _with_reasoning(cli_ref: str, argv: List[str], reasoning: str) -> List[str]:
+    if cli_ref == "codex":
+        return [*argv[:-1], "-c", f'model_reasoning_effort="{reasoning}"', argv[-1]]
+    if cli_ref == "opencode":
+        return [*argv[:-1], "--variant", reasoning, argv[-1]]
+    if cli_ref == "pi":
+        return [argv[0], "--thinking", reasoning, *argv[1:]]
+    if cli_ref == "grok":
+        return [argv[0], "--reasoning-effort", reasoning, *argv[1:]]
+    supported = ", ".join(sorted(_REASONING_ADAPTERS))
+    raise ValueError(f"{cli_ref!r} does not support reasoning pins (supported: {supported})")
 
 
 def _with_model(cli_ref: str, argv: List[str], model: str) -> List[str]:
@@ -271,6 +291,7 @@ def build_argv(
     read_only: bool = False,
     sandbox: str | None = None,
     model: str | None = None,
+    reasoning: str | None = None,
     cwd: Path | None = None,
 ) -> List[str]:
     if cli_ref.startswith(_OLLAMA_PREFIX):
@@ -279,6 +300,8 @@ def build_argv(
             raise ValueError(f"ollama reference needs a model: {cli_ref!r}")
         if model is not None:
             raise ValueError(f"{cli_ref!r} already names a model; drop the separate model setting")
+        if reasoning is not None:
+            raise ValueError(f"{cli_ref!r} does not support reasoning pins")
         return ["ollama", "run", ollama_model, prompt]
 
     if cli_ref.startswith(_CODEX_CLOUD_PREFIX):
@@ -294,6 +317,8 @@ def build_argv(
     argv = builder(prompt, read_only, sandbox, cwd)
     if model is not None:
         argv = _with_model(cli_ref, argv, model)
+    if reasoning is not None:
+        argv = _with_reasoning(cli_ref, argv, reasoning)
     return argv
 
 
@@ -309,6 +334,7 @@ def run_agent(
     read_only: bool = False,
     sandbox: str | None = None,
     model: str | None = None,
+    reasoning: str | None = None,
 ) -> AgentResult:
     if not detect(cli_ref):
         return AgentResult(text="", ok=False, detail=f"{command_for(cli_ref)} not installed")
@@ -332,7 +358,15 @@ def run_agent(
         return codex_cloud.run_cloud_task(prompt, env_id=env_id, timeout=timeout, cwd=cwd)
 
     result = proc.run(
-        build_argv(cli_ref, prompt, read_only=read_only, sandbox=sandbox, model=model, cwd=cwd),
+        build_argv(
+            cli_ref,
+            prompt,
+            read_only=read_only,
+            sandbox=sandbox,
+            model=model,
+            reasoning=reasoning,
+            cwd=cwd,
+        ),
         timeout=timeout,
         cwd=cwd,
     )
@@ -378,6 +412,7 @@ def run_codex_appserver(
     read_only: bool = False,
     sandbox: str | None = None,
     model: str | None = None,
+    reasoning: str | None = None,
     on_event=None,
 ) -> AgentResult:
     """Run one codex worker as a thread + turn on a shared app-server.
@@ -389,7 +424,10 @@ def run_codex_appserver(
     effective_sandbox = sandbox if sandbox is not None else ("read-only" if read_only else None)
     try:
         thread = server.start_thread(cwd=cwd, model=model, sandbox=effective_sandbox)
-        turn = thread.run_turn(prompt, timeout=timeout, on_event=on_event)
+        turn_kwargs = {"timeout": timeout, "on_event": on_event}
+        if reasoning is not None:
+            turn_kwargs["effort"] = reasoning
+        turn = thread.run_turn(prompt, **turn_kwargs)
     except codex_appserver.AppServerError as exc:
         return AgentResult(text="", ok=False, detail=str(exc)[:200], status="failed")
     text = turn.text.strip()

--- a/src/brigade/agents.py
+++ b/src/brigade/agents.py
@@ -192,6 +192,12 @@ class AgentResult:
     # app-server transport extras; None/"" on the exec path.
     thread_id: str | None = None
     status: str = ""
+    stdout: str | None = None
+    stderr: str | None = None
+    exit_code: int | None = None
+    timed_out: bool = False
+    stdout_log: str | None = None
+    stderr_log: str | None = None
 
 
 def is_known(cli_ref: str) -> bool:
@@ -333,10 +339,34 @@ def run_agent(
     text = result.stdout.strip()
     if result.code != 0:
         detail = result.stderr.strip() or f"exit {result.code}"
-        return AgentResult(text=text, ok=False, detail=detail[:200])
+        return AgentResult(
+            text=text,
+            ok=False,
+            detail=detail[:200],
+            stdout=result.stdout,
+            stderr=result.stderr,
+            exit_code=result.code,
+            timed_out=result.code == 124,
+        )
     if not text:
-        return AgentResult(text="", ok=False, detail="empty output")
-    return AgentResult(text=text, ok=True)
+        detail = "empty output"
+        if cli_ref in {"cursor", "grok"}:
+            detail = f"{cli_ref} exited 0 without output; check trust, permissions, and model availability"
+        return AgentResult(
+            text="",
+            ok=False,
+            detail=detail,
+            stdout=result.stdout,
+            stderr=result.stderr,
+            exit_code=result.code,
+        )
+    return AgentResult(
+        text=text,
+        ok=True,
+        stdout=result.stdout,
+        stderr=result.stderr,
+        exit_code=result.code,
+    )
 
 
 def run_codex_appserver(

--- a/src/brigade/cli/run.py
+++ b/src/brigade/cli/run.py
@@ -202,7 +202,7 @@ def dispatch(args) -> int:
         handoff_inbox = args.handoff_inbox or (run_cwd / ".claude" / "memory-handoffs")
     effective_sandbox = args.sandbox if args.sandbox is not None else loaded_roster.sandbox
     if args.read_only:
-        advisory = _read_only_advisory(loaded_roster, effective_sandbox)
+        advisory = _read_only_advisory(loaded_roster, effective_sandbox, worker=args.worker)
         if advisory:
             print("warning: --read-only is best-effort for some agents in this run:", file=sys.stderr)
             for line in advisory:
@@ -438,7 +438,7 @@ def _print_suspected_noop_warning(output_dir: Path) -> None:
         )
 
 
-def _read_only_advisory(roster, effective_sandbox) -> list[str]:
+def _read_only_advisory(roster, effective_sandbox, worker: str | None = None) -> list[str]:
     """Lines describing which worker agents do not hard-enforce read-only.
 
     A writable --sandbox override downgrades even natively-sandboxed CLIs to
@@ -449,9 +449,13 @@ def _read_only_advisory(roster, effective_sandbox) -> list[str]:
 
     sandbox_overrides_native = effective_sandbox in ("workspace-write", "danger-full-access")
     lines: list[str] = []
-    # The orchestrator runs too (it plans), so include it alongside the workers.
-    orchestrator = roster.agents.get(roster.orchestrator)
-    agents_to_check = [orchestrator, *roster_mod.workers(roster)] if orchestrator else roster_mod.workers(roster)
+    if worker is not None:
+        selected = roster.agents.get(worker)
+        agents_to_check = [selected] if selected is not None else []
+    else:
+        # The orchestrator runs too (it plans), so include it alongside the workers.
+        orchestrator = roster.agents.get(roster.orchestrator)
+        agents_to_check = [orchestrator, *roster_mod.workers(roster)] if orchestrator else roster_mod.workers(roster)
     for agent in agents_to_check:
         cli = agent.cli or ""
         enforcement = agents_mod.read_only_enforcement(cli)

--- a/src/brigade/codex_appserver.py
+++ b/src/brigade/codex_appserver.py
@@ -275,11 +275,15 @@ class CodexThread:
         timeout: float,
         on_event: Callable[[dict], None] | None = None,
         on_turn_start: Callable[[str], None] | None = None,
+        effort: str | None = None,
     ) -> TurnResult:
+        params: dict = {"threadId": self.thread_id, "input": [{"type": "text", "text": prompt}]}
+        if effort is not None:
+            params["effort"] = effort
         try:
             result = self._server.request(
                 "turn/start",
-                {"threadId": self.thread_id, "input": [{"type": "text", "text": prompt}]},
+                params,
             )
         except AppServerError as exc:
             return TurnResult(text="", ok=False, status="failed", thread_id=self.thread_id, detail=str(exc)[:200])

--- a/src/brigade/model_scorecard.py
+++ b/src/brigade/model_scorecard.py
@@ -52,9 +52,9 @@ class ModelRow:
 
     @property
     def mean_duration_seconds(self) -> float:
-        if self.runs <= 0:
+        if self.seats <= 0:
             return 0.0
-        return self.total_duration_seconds / self.runs
+        return self.total_duration_seconds / self.seats
 
 
 @dataclass(frozen=True)
@@ -79,10 +79,9 @@ class _Acc:
     last_seen: str | None = None
 
     def note_seen(self, started_at: str | None, run_id: str, duration: float | None) -> None:
-        if run_id not in self.run_ids:
-            self.run_ids.add(run_id)
-            if isinstance(duration, (int, float)):
-                self.total_duration_seconds += float(duration)
+        self.run_ids.add(run_id)
+        if isinstance(duration, (int, float)):
+            self.total_duration_seconds += float(duration)
         if not started_at:
             return
         if self.first_seen is None or started_at < self.first_seen:
@@ -283,9 +282,6 @@ def _scan_run_dir(
         if started_dt is None or started_dt < since:
             return False, None
 
-    duration = run_meta.get("duration_seconds")
-    duration_f = float(duration) if isinstance(duration, (int, float)) else None
-
     orchestrator_name = roster.get("orchestrator")
     if not isinstance(orchestrator_name, str):
         orch_meta = run_meta.get("orchestrator")
@@ -301,7 +297,14 @@ def _scan_run_dir(
         if wr_err is not None:
             return False, wr_err
 
-    # All inputs valid — mutate into.
+    synthesis_payload: dict[str, Any] | None = None
+    synthesis_path = run_dir / "synthesis.json"
+    if synthesis_path.is_file():
+        synthesis_payload, synthesis_err = _read_json_object(synthesis_path)
+        if synthesis_err is not None:
+            return False, synthesis_err
+
+    # All inputs valid - map roster identities without counting unused seats.
     for name, agent in agents_raw.items():
         if not isinstance(name, str) or not isinstance(agent, dict):
             continue
@@ -309,13 +312,6 @@ def _scan_run_dir(
         if key is None:
             continue
         agent_keys[name] = key
-        bucket = into.get(key)
-        if bucket is None:
-            bucket = _Acc(cli=key[0], model=key[1])
-            into[key] = bucket
-        bucket.note_seen(started_at, run_id, duration_f)
-        if orchestrator_name is not None and name == orchestrator_name:
-            bucket.orchestrator_seats += 1
 
     results: list[Any] = []
     ground_truth: Any = None
@@ -341,7 +337,9 @@ def _scan_run_dir(
         if bucket is None:
             bucket = _Acc(cli=key[0], model=key[1])
             into[key] = bucket
-            bucket.note_seen(started_at, run_id, duration_f)
+        item_duration = item.get("duration_seconds")
+        duration_f = float(item_duration) if isinstance(item_duration, (int, float)) else None
+        bucket.note_seen(started_at, run_id, duration_f)
         bucket.worker_seats += 1
         if item.get("ok") is True:
             bucket.worker_ok += 1
@@ -350,6 +348,19 @@ def _scan_run_dir(
 
     for key in noop_models:
         into[key].suspected_no_op_runs.add(run_id)
+
+    if synthesis_payload is not None and synthesis_payload.get("mode") != "direct-worker":
+        orchestrator_key = agent_keys.get(orchestrator_name) if orchestrator_name is not None else None
+        synthesis_result = synthesis_payload.get("result")
+        if orchestrator_key is not None and isinstance(synthesis_result, dict):
+            bucket = into.get(orchestrator_key)
+            if bucket is None:
+                bucket = _Acc(cli=orchestrator_key[0], model=orchestrator_key[1])
+                into[orchestrator_key] = bucket
+            duration = synthesis_result.get("duration_seconds")
+            duration_f = float(duration) if isinstance(duration, (int, float)) else None
+            bucket.note_seen(started_at, run_id, duration_f)
+            bucket.orchestrator_seats += 1
 
     return True, None
 

--- a/src/brigade/proc.py
+++ b/src/brigade/proc.py
@@ -23,6 +23,14 @@ class Result:
             return None
 
 
+def _timeout_text(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode(errors="replace")
+    return value
+
+
 def which(cmd: str) -> Optional[str]:
     return shutil.which(cmd)
 
@@ -47,5 +55,10 @@ def run(
         return Result(code=cp.returncode, stdout=cp.stdout, stderr=cp.stderr)
     except FileNotFoundError:
         return Result(code=127, stdout="", stderr=f"command not found: {args[0]}")
-    except subprocess.TimeoutExpired:
-        return Result(code=124, stdout="", stderr=f"timeout after {timeout}s")
+    except subprocess.TimeoutExpired as exc:
+        stdout = _timeout_text(exc.stdout)
+        stderr = _timeout_text(exc.stderr)
+        timeout_detail = f"timeout after {timeout}s"
+        if stderr and not stderr.endswith("\n"):
+            stderr += "\n"
+        return Result(code=124, stdout=stdout, stderr=stderr + timeout_detail)

--- a/src/brigade/roster.py
+++ b/src/brigade/roster.py
@@ -22,6 +22,7 @@ class Agent:
     endpoint: str | None = None
     model: str | None = None
     headers: dict | None = None
+    reasoning: str | None = None
 
 
 @dataclass(frozen=True)
@@ -143,6 +144,8 @@ def load_roster(path: Path) -> Roster:
         model_raw = raw_agent.get("model")
         endpoint = _as_str(endpoint_raw, f"agents.{agent_name}.endpoint") if endpoint_raw is not None else None
         model = _as_str(model_raw, f"agents.{agent_name}.model") if model_raw is not None else None
+        reasoning_raw = raw_agent.get("reasoning")
+        reasoning = _as_str(reasoning_raw, f"agents.{agent_name}.reasoning") if reasoning_raw is not None else None
 
         headers_raw = raw_agent.get("headers")
         if headers_raw is not None and not isinstance(headers_raw, dict):
@@ -153,6 +156,8 @@ def load_roster(path: Path) -> Roster:
         has_endpoint = endpoint is not None and model is not None
         if cli_raw is None and has_endpoint:
             cli = None
+            if reasoning is not None:
+                raise ValueError(f"agents.{agent_name}.reasoning requires a CLI adapter")
         else:
             cli = _as_str(cli_raw, f"agents.{agent_name}.cli")
             if not agent_adapters.is_known(cli):
@@ -168,6 +173,7 @@ def load_roster(path: Path) -> Roster:
             endpoint=endpoint,
             model=model,
             headers=headers,
+            reasoning=reasoning,
         )
 
     if orchestrator not in parsed_agents:

--- a/src/brigade/roster_cmd.py
+++ b/src/brigade/roster_cmd.py
@@ -39,6 +39,7 @@ allow_models = ["codex", "ollama:*"]
 
 # Cross-model example: pin a model per agent with `model = ...`
 # (supported: claude, codex, grok, opencode, pi, kimi, cursor, antigravity).
+# Pin reasoning with `reasoning = "high"` for codex, grok, opencode, or pi.
 # A `codex-cloud:<env-id>` seat submits the task to Codex Cloud, polls it to a
 # terminal state, and returns the summary plus unified diff (never auto-applied;
 # land it with `codex cloud apply <task-id>`). Allow it with "codex-cloud:*".
@@ -55,6 +56,7 @@ allow_models = ["codex", "ollama:*"]
 # [agents.builder]
 # cli = "codex"
 # model = "gpt-5.5"
+# reasoning = "xhigh"
 # role = "Make precise code changes and report what changed."
 #
 # [agents.composer]
@@ -171,6 +173,17 @@ def doctor(target: Path, *, roster_path: Path | None = None) -> int:
                         doctor_mod.FAIL,
                         f"agent: {name} model",
                         f"{agent.cli} does not support model pinning; drop model= or switch cli",
+                    )
+                )
+        if agent.reasoning is not None:
+            if agents.supports_reasoning(agent.cli):
+                checks.append((doctor_mod.OK, f"agent: {name} reasoning", f"{agent.reasoning} via {agent.cli}"))
+            else:
+                checks.append(
+                    (
+                        doctor_mod.FAIL,
+                        f"agent: {name} reasoning",
+                        f"{agent.cli} does not support reasoning pins; drop reasoning= or switch cli",
                     )
                 )
 

--- a/src/brigade/run_resume.py
+++ b/src/brigade/run_resume.py
@@ -38,6 +38,7 @@ def _roster_from_snapshot(snapshot: dict) -> Roster:
             role=raw.get("role") or "",
             timeout_seconds=raw.get("timeout_seconds"),
             model=raw.get("model"),
+            reasoning=raw.get("reasoning"),
         )
     return Roster(
         orchestrator=snapshot["orchestrator"],
@@ -109,7 +110,14 @@ def resume(run_dir: Path) -> int:
                     model=agent.model if agent else None,
                     sandbox=sandbox if sandbox is not None else ("read-only" if read_only else None),
                 )
-                turn = thread.run_turn(_continuation_prompt(entry.get("task", "")), timeout=timeout)
+                if agent and agent.reasoning is not None:
+                    turn = thread.run_turn(
+                        _continuation_prompt(entry.get("task", "")),
+                        timeout=timeout,
+                        effort=agent.reasoning,
+                    )
+                else:
+                    turn = thread.run_turn(_continuation_prompt(entry.get("task", "")), timeout=timeout)
             except codex_appserver.AppServerError as exc:
                 entry["detail"] = str(exc)[:200]
                 entry["status"] = "failed"
@@ -155,6 +163,7 @@ def resume(run_dir: Path) -> int:
         cwd=cwd,
         read_only=read_only,
         **({"model": orchestrator.model} if orchestrator.model is not None else {}),
+        **({"reasoning": orchestrator.reasoning} if orchestrator.reasoning is not None else {}),
     )
     aboyeur._write_json(
         run_dir / "synthesis.json",

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -1135,6 +1135,14 @@ def test_roster_payload_includes_model():
     assert payload["agents"]["builder"]["model"] == "gpt-5.5-codex"
 
 
+def test_roster_payload_includes_reasoning():
+    roster = Roster(
+        orchestrator="chef",
+        agents={"chef": Agent("chef", "codex", "plan", reasoning="xhigh")},
+    )
+    assert aboyeur._roster_payload(roster)["agents"]["chef"]["reasoning"] == "xhigh"
+
+
 def test_roster_payload_includes_sandbox():
     roster = Roster(
         orchestrator="chef",
@@ -1878,11 +1886,10 @@ def test_synthesis_failure_writes_artifact(monkeypatch, tmp_path, capsys):
     assert run_meta["duration_seconds"] >= 0
     synthesis = json.loads((output_dir / "synthesis.json").read_text())
     assert synthesis["orchestrator"] == "chef"
-    assert synthesis["result"] == {
-        "ok": False,
-        "detail": "synthesis failed",
-        "text": "partial synthesis",
-    }
+    assert synthesis["result"]["ok"] is False
+    assert synthesis["result"]["detail"] == "synthesis failed"
+    assert synthesis["result"]["text"] == "partial synthesis"
+    assert synthesis["result"]["duration_seconds"] >= 0
     assert not (output_dir / "final.txt").exists()
 
 

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -981,6 +981,41 @@ def test_run_direct_worker_failure_reports_and_records(monkeypatch, capsys, tmp_
     assert synthesis["result"]["ok"] is False
 
 
+def test_run_direct_worker_writes_complete_process_logs(monkeypatch, tmp_path):
+    def fake_run_agent(cli_ref, prompt, **kwargs):
+        return agents.AgentResult(
+            text="answer",
+            ok=True,
+            stdout="answer\n",
+            stderr="adapter diagnostic\n",
+            exit_code=0,
+            timed_out=False,
+        )
+
+    output_dir = tmp_path / "run"
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+
+    rc = aboyeur.run(
+        "do exactly this",
+        _roster(),
+        worker="coder",
+        output_dir=output_dir,
+        route_enabled=False,
+    )
+
+    assert rc == 0
+    worker_payload = json.loads((output_dir / "worker-results.json").read_text())["results"][0]
+    assert worker_payload["exit_code"] == 0
+    assert worker_payload["timed_out"] is False
+    assert worker_payload["stdout_log"] == "logs/worker-001-coder.stdout.log"
+    assert worker_payload["stderr_log"] == "logs/worker-001-coder.stderr.log"
+    assert (output_dir / worker_payload["stdout_log"]).read_text() == "answer\n"
+    assert (output_dir / worker_payload["stderr_log"]).read_text() == "adapter diagnostic\n"
+    synthesis = json.loads((output_dir / "synthesis.json").read_text())["result"]
+    assert synthesis["stdout_log"] == worker_payload["stdout_log"]
+    assert synthesis["stderr_log"] == worker_payload["stderr_log"]
+
+
 def test_run_direct_worker_dry_run_skips_agents_and_writes_synthetic_plan(monkeypatch, tmp_path, capsys):
     calls = []
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -345,6 +345,10 @@ def test_run_agent_captures_output(monkeypatch):
     res = agents.run_agent("codex", "do it")
     assert res.ok is True
     assert res.text == "answer"
+    assert res.stdout == "  answer  "
+    assert res.stderr == ""
+    assert res.exit_code == 0
+    assert res.timed_out is False
 
 
 def test_run_agent_forwards_model_to_argv(monkeypatch):
@@ -415,6 +419,20 @@ def test_run_agent_nonzero_is_not_ok(monkeypatch):
     res = agents.run_agent("claude", "x")
     assert res.ok is False
     assert "boom" in res.detail
+    assert res.exit_code == 1
+    assert res.stderr == "boom"
+
+
+@pytest.mark.parametrize("cli_ref", ["cursor", "grok"])
+def test_run_agent_classifies_silent_adapter_exit(monkeypatch, cli_ref):
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(agents.proc, "run", lambda argv, **kw: agents.proc.Result(0, "", ""))
+
+    result = agents.run_agent(cli_ref, "do it")
+
+    assert result.ok is False
+    assert result.detail == f"{cli_ref} exited 0 without output; check trust, permissions, and model availability"
+    assert result.exit_code == 0
 
 
 class _StubThread:

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -365,6 +365,24 @@ def test_run_agent_forwards_model_to_argv(monkeypatch):
     assert captured["argv"] == ["claude", "--model", "claude-fable-5", "-p", "hi"]
 
 
+@pytest.mark.parametrize(
+    ("cli_ref", "expected"),
+    [
+        ("codex", ["codex", "exec", "-c", 'model_reasoning_effort="xhigh"', "hi"]),
+        ("opencode", ["opencode", "run", "--variant", "xhigh", "hi"]),
+        ("pi", ["pi", "--thinking", "xhigh", "-p", "hi"]),
+        ("grok", ["grok", "--reasoning-effort", "xhigh", "-p", "hi", "--always-approve"]),
+    ],
+)
+def test_build_argv_applies_reasoning(cli_ref, expected):
+    assert agents.build_argv(cli_ref, "hi", reasoning="xhigh") == expected
+
+
+def test_build_argv_rejects_reasoning_for_unsupported_adapter():
+    with pytest.raises(ValueError, match="does not support reasoning"):
+        agents.build_argv("claude", "hi", reasoning="high")
+
+
 def test_run_agent_threads_cwd_into_argv_builder(monkeypatch, tmp_path):
     captured = {}
 
@@ -439,9 +457,11 @@ class _StubThread:
     def __init__(self, result):
         self._result = result
         self.prompts = []
+        self.efforts = []
 
-    def run_turn(self, prompt, *, timeout, on_event=None):
+    def run_turn(self, prompt, *, timeout, on_event=None, effort=None):
         self.prompts.append((prompt, timeout))
+        self.efforts.append(effort)
         return self._result
 
 
@@ -478,6 +498,15 @@ def test_run_codex_appserver_read_only_maps_to_sandbox():
     server = _StubServer(turn)
     agents.run_codex_appserver(server, "p", timeout=5.0, cwd=None, read_only=True)
     assert server.calls[0]["sandbox"] == "read-only"
+
+
+def test_run_codex_appserver_passes_reasoning_to_turn():
+    from brigade import codex_appserver
+
+    turn = codex_appserver.TurnResult(text="x", ok=True, status="complete", thread_id="t-1")
+    server = _StubServer(turn)
+    agents.run_codex_appserver(server, "p", timeout=5.0, cwd=None, reasoning="xhigh")
+    assert server.thread.efforts == ["xhigh"]
 
 
 def test_run_codex_appserver_empty_text_not_ok():

--- a/tests/test_model_scorecard.py
+++ b/tests/test_model_scorecard.py
@@ -28,6 +28,8 @@ def _write_run(
     results: list | None = None,
     ground_truth: dict | None = None,
     include_worker_results: bool = True,
+    include_synthesis: bool = True,
+    direct_worker: bool = False,
 ) -> Path:
     """Write a realistic run artifact tree under run_dir."""
     run_dir.mkdir(parents=True, exist_ok=True)
@@ -57,8 +59,8 @@ def _write_run(
         },
     )
     if include_worker_results:
-        payload: dict = {
-            "results": results
+        result_items = (
+            results
             if results is not None
             else [
                 {
@@ -68,7 +70,13 @@ def _write_run(
                     "detail": "",
                     "text": "done",
                 }
-            ],
+            ]
+        )
+        result_items = [
+            dict(item, duration_seconds=item.get("duration_seconds", duration_seconds)) for item in result_items
+        ]
+        payload: dict = {
+            "results": result_items,
         }
         if ground_truth is not None:
             payload["ground_truth"] = ground_truth
@@ -82,6 +90,14 @@ def _write_run(
                 "patch_ref": "changes.patch",
             }
         _write_json(run_dir / "worker-results.json", payload)
+    if include_synthesis:
+        synthesis: dict = {
+            "orchestrator": orchestrator,
+            "result": {"ok": True, "detail": "", "text": "done", "duration_seconds": duration_seconds},
+        }
+        if direct_worker:
+            synthesis["mode"] = "direct-worker"
+        _write_json(run_dir / "synthesis.json", synthesis)
     return run_dir
 
 
@@ -263,6 +279,37 @@ def test_duration_total_and_mean_for_participated_runs(tmp_path):
     assert coder.total_duration_seconds == pytest.approx(40.0)
     assert coder.mean_duration_seconds == pytest.approx(20.0)
     assert coder.runs == 2
+
+
+def test_ignores_roster_seats_that_did_not_participate(tmp_path):
+    runs = _runs_root(tmp_path)
+    _write_run(
+        runs / "r1",
+        agents={
+            "chef": {"cli": "codex", "model": "gpt-5", "role": "plan"},
+            "used": {"cli": "pi", "model": "openai/gpt-5.6", "role": "code"},
+            "idle": {"cli": "grok", "model": "grok-4.5", "role": "review"},
+        },
+        results=[{"worker": "used", "task": "code", "ok": True, "text": "done", "duration_seconds": 4.5}],
+    )
+
+    labels = {row.label for row in model_scorecard.build_scorecard(target=tmp_path).models}
+    assert labels == {"codex/gpt-5", "pi/openai/gpt-5.6"}
+
+
+def test_direct_worker_does_not_attribute_orchestrator_seat(tmp_path):
+    runs = _runs_root(tmp_path)
+    _write_run(
+        runs / "r1",
+        agents={
+            "chef": {"cli": "codex", "model": "gpt-5", "role": "plan"},
+            "coder": {"cli": "pi", "model": "openai/gpt-5.6", "role": "code"},
+        },
+        direct_worker=True,
+    )
+
+    labels = {row.label for row in model_scorecard.build_scorecard(target=tmp_path).models}
+    assert labels == {"pi/openai/gpt-5.6"}
 
 
 def test_first_and_last_seen_timestamps(tmp_path):

--- a/tests/test_model_scorecard.py
+++ b/tests/test_model_scorecard.py
@@ -457,7 +457,7 @@ def test_models_sorted_ok_rate_desc_then_seats_desc(tmp_path):
             {"worker": "w2", "task": "t", "ok": False, "detail": "e", "text": ""},
         ],
     )
-    # model C: 100% ok, 2 seats — should rank above A (same rate, more seats)
+    # model C: 100% ok, 2 seats - should rank above A (same rate, more seats)
     agents_c = {
         "chef": {"cli": "codex", "model": None, "role": "plan"},
         "w1": {"cli": "claude", "model": "high-seats", "role": "code"},

--- a/tests/test_proc.py
+++ b/tests/test_proc.py
@@ -1,3 +1,5 @@
+import subprocess
+
 from brigade import proc
 
 
@@ -20,3 +22,21 @@ def test_run_json_returns_none_on_nonjson():
 def test_which_detects_present_and_absent():
     assert proc.which("python3") is not None
     assert proc.which("definitely-not-a-real-binary-xyz") is None
+
+
+def test_run_preserves_partial_output_on_timeout(monkeypatch):
+    def timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(
+            cmd=["worker"],
+            timeout=3.0,
+            output=b"partial stdout\n",
+            stderr=b"partial stderr\n",
+        )
+
+    monkeypatch.setattr(proc.subprocess, "run", timeout)
+
+    result = proc.run(["worker"], timeout=3.0)
+
+    assert result.code == 124
+    assert result.stdout == "partial stdout\n"
+    assert result.stderr == "partial stderr\ntimeout after 3.0s"

--- a/tests/test_read_only_enforcement.py
+++ b/tests/test_read_only_enforcement.py
@@ -46,3 +46,12 @@ def test_writable_sandbox_override_downgrades_hard_agents():
     # the native sandbox is overridden, so even codex is now best-effort
     assert "safe (codex)" in joined
     assert "soft (goose)" in joined
+
+
+def test_direct_worker_advisory_only_checks_selected_seat():
+    lines = run_cli._read_only_advisory(_roster(), None, worker="safe")
+    assert lines == []
+
+    lines = run_cli._read_only_advisory(_roster(), None, worker="open")
+    assert len(lines) == 1
+    assert "open (opencode)" in lines[0]

--- a/tests/test_roster.py
+++ b/tests/test_roster.py
@@ -225,6 +225,15 @@ def test_cli_agent_accepts_model_pin(tmp_path):
     assert loaded.agents["builder"].model == "gpt-5.5-codex"
 
 
+def test_cli_agent_accepts_reasoning_pin(tmp_path):
+    text = (
+        'orchestrator = "chef"\n'
+        '[agents.chef]\ncli = "opencode"\nmodel = "openai/gpt-5.6"\nreasoning = "max"\nrole = "plan"\n'
+    )
+    loaded = roster_mod.load_roster(_write(tmp_path, text))
+    assert loaded.agents["chef"].reasoning == "max"
+
+
 def test_cli_agent_still_requires_cli_or_endpoint(tmp_path):
     text = 'orchestrator = "chef"\n[agents.chef]\nrole = "plan"\n'
     with pytest.raises(ValueError):


### PR DESCRIPTION
## What changed

- Preserve worker stdout, stderr, exit status, timeout state, duration, transport, model, reasoning, and session evidence.
- Treat successful processes with empty output as adapter failures.
- Pin supported reasoning settings in roster seats.
- Score only workers and synthesis seats that actually ran.

## Why

Run receipts and model scorecards must describe the processes that executed, not inferred roster participation or unrecorded local settings.

## Verification

- Full `./scripts/verify`: 2,179 passed, 3 skipped, coverage 81.21%.

Closes #222, #224, #225, and #226.
