### PR TITLE
feat(model): add transport-aware trial cells

### DIFF
--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -36,7 +36,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade learn` (extras): 13 command path(s)
 - `brigade mcp`: 7 command path(s)
 - `brigade memory`: 14 command path(s)
-- `brigade model`: 1 command path(s)
+- `brigade model`: 6 command path(s)
 - `brigade notifications` (extras): 4 command path(s)
 - `brigade openclaw-fragments` (extras): 1 command path(s)
 - `brigade operator`: 24 command path(s)
@@ -212,6 +212,11 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade memory serve-mcp`
 - `brigade memory status`
 - `brigade model scorecard`
+- `brigade model trial plan`
+- `brigade model trial resume`
+- `brigade model trial run`
+- `brigade model trial show`
+- `brigade model trial summary`
 - `brigade notifications event plan` (extras)
 - `brigade notifications event record` (extras)
 - `brigade notifications setup plan` (extras)

--- a/docs/phase-acpx-cursor-adapter.md
+++ b/docs/phase-acpx-cursor-adapter.md
@@ -1,0 +1,35 @@
+# acpx Cursor Adapter
+
+## Goal
+
+Add an opt-in, one-shot Cursor ACP transport without adding a runtime
+dependency or adopting acpx session ownership.
+
+## Boundary
+
+- Require user-installed acpx 0.12.0 and Cursor CLI with `cursor-agent acp`.
+- Invoke acpx with its raw agent command escape hatch.
+- Use strict JSON, no terminal capability, explicit timeout, cwd, model, and
+  permission mode.
+- Allow writable ACP only in a Brigade-created worktree.
+- Parse ACP protocol 1 NDJSON into the common agent result.
+- Keep direct Cursor as the default and never fall back silently.
+- Do not add persistent sessions, cancellation, queue recovery, Node, an ACP
+  SDK, or a separate repository.
+
+## Verification
+
+- [x] Test exact version and command construction.
+- [x] Test strict NDJSON, protocol metadata, final text, and model acknowledgment.
+- [x] Test invalid output, empty final output, timeout, and permission failures.
+- [x] Test roster validation and dispatch selection.
+- [x] Run focused tests and `./scripts/verify` through Brigade.
+- [x] Attempt a live local smoke test and record the environmental blocker or result.
+
+## Live result
+
+The installed Cursor CLI `2026.07.09-a3815c0` completed an ACP initialize
+handshake at protocol version 1 and advertised load-session, MCP, prompt, and
+session capabilities. No model prompt was sent. A full acpx smoke run could not
+start because `acpx` is not installed on this machine. Brigade does not install
+it automatically.

--- a/docs/phase-model-trials.md
+++ b/docs/phase-model-trials.md
@@ -10,11 +10,15 @@ separate.
 
 - JSON manifests using `brigade.eval_manifest.v1`.
 - Stable cell IDs from normalized case, seat, trial, grader, and schema data.
+- An optional `execution.mode` set to `read-only` (the default) or
+  `writable-worktree`. Writable cells each run in a fresh Brigade-created
+  detached worktree that is removed after grading.
 - `brigade model trial plan|run|resume|show|summary`.
 - Existing direct-worker execution path for every cell.
 - Exit-status, exact-output, regex-output, JSON-field, file-existence,
   diff-constraint, and verification-receipt graders.
 - Append-only attempts with stale-cell reporting.
+- Current-plan-only summaries with separate counts for stale stored cells.
 - Raw values plus count, mean, median, min, max, and population standard
   deviation.
 

--- a/docs/phase-model-trials.md
+++ b/docs/phase-model-trials.md
@@ -1,0 +1,27 @@
+# Model Trials
+
+## Goal
+
+Add a dependency-free, resumable model experiment surface that runs named
+cases against roster seats and keeps execution, grading, and acceptance states
+separate.
+
+## Scope
+
+- JSON manifests using `brigade.eval_manifest.v1`.
+- Stable cell IDs from normalized case, seat, trial, grader, and schema data.
+- `brigade model trial plan|run|resume|show|summary`.
+- Existing direct-worker execution path for every cell.
+- Exit-status, exact-output, regex-output, JSON-field, file-existence,
+  diff-constraint, and verification-receipt graders.
+- Append-only attempts with stale-cell reporting.
+- Raw values plus count, mean, median, min, max, and population standard
+  deviation.
+
+## Verification
+
+- [x] Prove stable identity and changed-condition invalidation.
+- [x] Prove mechanical grader zero scores are distinct from grader errors.
+- [x] Prove run and resume behavior with a mocked direct-worker boundary.
+- [x] Prove summary state counts and statistics.
+- [x] Run focused tests and `./scripts/verify` through Brigade.

--- a/docs/phase-upstream-pattern-integration.md
+++ b/docs/phase-upstream-pattern-integration.md
@@ -110,9 +110,10 @@ An evaluation manifest defines:
 - A roster or selected seat IDs.
 - Default trial count and per-case overrides.
 - Grader definitions.
+- Execution mode: `read-only` or `writable-worktree`.
 - Operational limits such as timeout and concurrency.
 
-Experiment conditions are separated from operational settings. A cell ID is the SHA-256 digest of normalized case content, normalized seat execution spec, trial index, grader contract, and schema version. Array position and wall-clock time do not enter the identity.
+Experiment conditions are separated from operational settings. A cell ID is the SHA-256 digest of normalized case content, normalized seat execution spec, execution mode, trial index, grader contract, and schema version. The seat execution spec includes the adapter transport, reviewed transport version, and Codex exec or app-server transport. Array position and wall-clock time do not enter the identity.
 
 A resume operation:
 
@@ -122,7 +123,7 @@ A resume operation:
 4. Reports stale cells when case, seat, transport, reasoning, or grader identity changed.
 5. Appends retries and keeps the earlier attempts.
 
-The summary counts scored, unscored, execution error, adapter error, grader error, rejected, and accepted cells separately. Trial statistics include raw values, count, mean, median, minimum, maximum, and standard deviation using the Python standard library.
+The summary counts scored, unscored, execution error, adapter error, grader error, rejected, and accepted cells separately for the current plan. Stored cells outside the current plan are reported under separate stale counts and never affect current statistics. Trial statistics include raw values, count, mean, median, minimum, maximum, and standard deviation using the Python standard library.
 
 ## Contract 3: Mechanical Graders and Acceptance
 

--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -58,6 +58,16 @@ class WorkerResult:
     stdout_log: str | None = None
     stderr_log: str | None = None
     duration_seconds: float | None = None
+    transport: str = "cli"
+    requested_model: str | None = None
+    effective_model: str | None = None
+    reasoning: str | None = None
+    stop_reason: str | None = None
+    protocol_version: int | None = None
+    session_id: str | None = None
+    request_id: str | None = None
+    acpx_version: str | None = None
+    safe_events: tuple[dict[str, object], ...] = ()
 
 
 @dataclass(frozen=True)
@@ -955,7 +965,15 @@ def _run_codex_appserver_worker(
                 fallback_kwargs["effort"] = agent.reasoning
             turn = thread.run_turn(prompt, **fallback_kwargs)
     except codex_appserver.AppServerError as exc:
-        return agents.AgentResult(text="", ok=False, detail=str(exc)[:200], status="failed")
+        return agents.AgentResult(
+            text="",
+            ok=False,
+            detail=str(exc)[:200],
+            status="failed",
+            transport="codex-app-server",
+            requested_model=agent.model,
+            reasoning=agent.reasoning,
+        )
     finally:
         if registry is not None and active_turn_id is not None:
             registry.unregister(worker, active_turn_id)
@@ -967,12 +985,30 @@ def _run_codex_appserver_worker(
             detail=(turn.detail or f"turn {turn.status}")[:200],
             thread_id=turn.thread_id,
             status=turn.status,
+            transport="codex-app-server",
+            requested_model=agent.model,
+            reasoning=agent.reasoning,
         )
     if not text:
         return agents.AgentResult(
-            text="", ok=False, detail="empty output", thread_id=turn.thread_id, status=turn.status
+            text="",
+            ok=False,
+            detail="empty output",
+            thread_id=turn.thread_id,
+            status=turn.status,
+            transport="codex-app-server",
+            requested_model=agent.model,
+            reasoning=agent.reasoning,
         )
-    return agents.AgentResult(text=text, ok=True, thread_id=turn.thread_id, status=turn.status)
+    return agents.AgentResult(
+        text=text,
+        ok=True,
+        thread_id=turn.thread_id,
+        status=turn.status,
+        transport="codex-app-server",
+        requested_model=agent.model,
+        reasoning=agent.reasoning,
+    )
 
 
 def dispatch(
@@ -990,6 +1026,7 @@ def dispatch(
     control_registry: run_control.LiveTurnRegistry | None = None,
     events_dir: Path | None = None,
     verbose: bool = False,
+    authorized_writable_worktree: bool = False,
 ) -> list[WorkerResult]:
     def run_one(assignment: Assignment, prior_results: list[WorkerResult]) -> WorkerResult:
         agent = roster.agents[assignment.worker]
@@ -1012,7 +1049,19 @@ def dispatch(
             evidence=evidence,
         )
         started = time.monotonic()
-        if agent.cli == "codex" and appserver is not None:
+        if agent.transport == "acpx":
+            from . import acpx_adapter
+
+            result = acpx_adapter.run_cursor(
+                prompt,
+                cwd=cwd or Path.cwd(),
+                timeout=timeout_for(agent, roster),
+                model=agent.model or "",
+                version=agent.transport_version or "",
+                read_only=read_only if sandbox_read_only is None else sandbox_read_only,
+                writable_worktree=authorized_writable_worktree,
+            )
+        elif agent.cli == "codex" and appserver is not None:
             on_event = _worker_event_writer(events_dir, assignment.worker, verbose=verbose)
             result = _run_codex_appserver_worker(
                 appserver,
@@ -1052,6 +1101,16 @@ def dispatch(
             exit_code=result.exit_code,
             timed_out=result.timed_out,
             duration_seconds=max(0.0, round(time.monotonic() - started, 3)),
+            transport=result.transport,
+            requested_model=result.requested_model,
+            effective_model=result.effective_model,
+            reasoning=result.reasoning,
+            stop_reason=result.stop_reason,
+            protocol_version=result.protocol_version,
+            session_id=result.session_id,
+            request_id=result.request_id,
+            acpx_version=result.acpx_version,
+            safe_events=result.safe_events,
         )
 
     if not assignments:
@@ -1191,6 +1250,21 @@ def _worker_payload(results: list[WorkerResult]) -> list[dict[str, object]]:
             entry["stderr_log"] = result.stderr_log
         if result.duration_seconds is not None:
             entry["duration_seconds"] = result.duration_seconds
+        entry["transport"] = result.transport
+        for key, value in (
+            ("requested_model", result.requested_model),
+            ("effective_model", result.effective_model),
+            ("reasoning", result.reasoning),
+            ("stop_reason", result.stop_reason),
+            ("protocol_version", result.protocol_version),
+            ("session_id", result.session_id),
+            ("request_id", result.request_id),
+            ("acpx_version", result.acpx_version),
+        ):
+            if value is not None:
+                entry[key] = value
+        if result.safe_events:
+            entry["events"] = list(result.safe_events)
         payload.append(entry)
     return payload
 
@@ -1277,6 +1351,21 @@ def _agent_result_payload(result: agents.AgentResult) -> dict[str, object]:
         payload["stderr_log"] = result.stderr_log
     if result.duration_seconds is not None:
         payload["duration_seconds"] = result.duration_seconds
+    payload["transport"] = result.transport
+    for key, value in (
+        ("requested_model", result.requested_model),
+        ("effective_model", result.effective_model),
+        ("reasoning", result.reasoning),
+        ("stop_reason", result.stop_reason),
+        ("protocol_version", result.protocol_version),
+        ("session_id", result.session_id),
+        ("request_id", result.request_id),
+        ("acpx_version", result.acpx_version),
+    ):
+        if value is not None:
+            payload[key] = value
+    if result.safe_events:
+        payload["events"] = list(result.safe_events)
     return payload
 
 
@@ -1607,6 +1696,7 @@ def set_artifact_patch_ref(output_dir: Path, patch_ref: str = "changes.patch") -
 
 def _roster_payload(roster: Roster) -> dict[str, object]:
     return {
+        "schema": "brigade.roster_snapshot.v1",
         "orchestrator": roster.orchestrator,
         "max_workers": roster.max_workers,
         "timeout_seconds": roster.timeout_seconds,
@@ -1617,6 +1707,8 @@ def _roster_payload(roster: Roster) -> dict[str, object]:
                 "cli": agent.cli,
                 "model": agent.model,
                 "reasoning": agent.reasoning,
+                "transport": agent.transport,
+                "transport_version": agent.transport_version,
                 "role": agent.role,
                 "timeout_seconds": agent.timeout_seconds,
             }
@@ -1651,6 +1743,7 @@ def _run_payload(
     worker: str | None = None,
 ) -> dict[str, object]:
     payload: dict[str, object] = {
+        "schema": "brigade.run.v1",
         "task": task,
         "cwd": str(cwd) if cwd is not None else None,
         "orchestrator": roster.orchestrator,
@@ -1741,6 +1834,7 @@ def run(
     route_template: str | None = None,
     route_overrides: tuple[str, ...] = (),
     worker: str | None = None,
+    authorized_writable_worktree: bool = False,
 ) -> int:
     started_at = datetime.now(timezone.utc)
     transport_for_payload = codex_transport or roster.codex_transport
@@ -1868,7 +1962,10 @@ def run(
         if direct_worker:
             attempts_payload["mode"] = "direct-worker"
         _write_json(output_dir / "plan-attempts.json", attempts_payload)
-        _write_json(output_dir / "plan.json", {"assignments": _assignment_payload(assignments)})
+        _write_json(
+            output_dir / "plan.json",
+            {"schema": "brigade.run_plan.v1", "assignments": _assignment_payload(assignments)},
+        )
 
     if dry_run:
         payload = {"assignments": _assignment_payload(assignments)}
@@ -1971,6 +2068,7 @@ def run(
             control_registry=control_registry,
             events_dir=(output_dir / "events") if (output_dir is not None and appserver is not None) else None,
             verbose=verbose,
+            authorized_writable_worktree=authorized_writable_worktree,
         )
     finally:
         if control_server is not None:
@@ -1999,7 +2097,11 @@ def run(
         worker_results = _write_worker_logs(output_dir, worker_results)
         _write_json(
             output_dir / "worker-results.json",
-            {"results": _worker_payload(worker_results), "ground_truth": ground_truth},
+            {
+                "schema": "brigade.worker_results.v1",
+                "results": _worker_payload(worker_results),
+                "ground_truth": ground_truth,
+            },
         )
     if verbose:
         _print_worker_status(worker_results)
@@ -2032,6 +2134,16 @@ def run(
             stdout_log=direct_result.stdout_log,
             stderr_log=direct_result.stderr_log,
             duration_seconds=direct_result.duration_seconds,
+            transport=direct_result.transport,
+            requested_model=direct_result.requested_model,
+            effective_model=direct_result.effective_model,
+            reasoning=direct_result.reasoning,
+            stop_reason=direct_result.stop_reason,
+            protocol_version=direct_result.protocol_version,
+            session_id=direct_result.session_id,
+            request_id=direct_result.request_id,
+            acpx_version=direct_result.acpx_version,
+            safe_events=direct_result.safe_events,
         )
     else:
         synthesis_started = time.monotonic()
@@ -2057,6 +2169,7 @@ def run(
             final = _write_agent_logs(output_dir, "synthesis", final)
         synthesis_payload = (
             {
+                "schema": "brigade.synthesis.v1",
                 "mode": "direct-worker",
                 "worker": worker,
                 "orchestrator": None,
@@ -2065,6 +2178,7 @@ def run(
             }
             if direct_worker
             else {
+                "schema": "brigade.synthesis.v1",
                 "orchestrator": roster.orchestrator,
                 "result": _agent_result_payload(final),
                 "ground_truth": ground_truth,

--- a/src/brigade/acpx_adapter.py
+++ b/src/brigade/acpx_adapter.py
@@ -1,0 +1,248 @@
+"""One-shot Cursor ACP transport through a user-installed acpx executable."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from . import proc
+from .agents import AgentResult
+
+SUPPORTED_VERSION = "0.12.0"
+
+
+def _timeout_arg(value: float) -> str:
+    return str(int(value)) if value.is_integer() else str(value)
+
+
+def build_argv(
+    *,
+    prompt: str,
+    cwd: Path,
+    timeout: float,
+    model: str,
+    read_only: bool,
+    writable_worktree: bool,
+) -> list[str]:
+    if not read_only and not writable_worktree:
+        raise ValueError("writable acpx Cursor runs require a Brigade-created writable worktree")
+    permission = "--approve-reads" if read_only else "--approve-all"
+    argv = [
+        "acpx",
+        "--cwd",
+        str(cwd.expanduser().resolve()),
+        "--format",
+        "json",
+        "--json-strict",
+        "--no-terminal",
+        "--timeout",
+        _timeout_arg(float(timeout)),
+        "--model",
+        model,
+        permission,
+    ]
+    if read_only:
+        argv.extend(["--non-interactive-permissions", "fail"])
+    argv.extend(["--agent", "cursor-agent acp", "exec", prompt])
+    return argv
+
+
+def installed_version() -> tuple[str | None, str]:
+    result = proc.run(["acpx", "--version"], timeout=10.0)
+    if result.code != 0:
+        return None, result.stderr.strip() or result.stdout.strip() or f"exit {result.code}"
+    match = re.search(r"\b(\d+\.\d+\.\d+)\b", result.stdout)
+    if match is None:
+        return None, "acpx --version did not report a semantic version"
+    return match.group(1), ""
+
+
+def _objects(stdout: str) -> tuple[list[dict[str, Any]] | None, str]:
+    messages: list[dict[str, Any]] = []
+    for line_number, line in enumerate(stdout.splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError as exc:
+            return None, f"invalid ACP NDJSON at line {line_number}: {exc.msg}"
+        if not isinstance(message, dict) or message.get("jsonrpc") != "2.0":
+            return None, f"invalid ACP NDJSON at line {line_number}: expected JSON-RPC 2.0 object"
+        messages.append(message)
+    if not messages:
+        return None, "empty ACP NDJSON stream"
+    return messages, ""
+
+
+def _update(message: dict[str, Any]) -> dict[str, Any] | None:
+    if message.get("method") != "session/update":
+        return None
+    params = message.get("params")
+    if not isinstance(params, dict):
+        return None
+    nested = params.get("update")
+    return nested if isinstance(nested, dict) else params
+
+
+def _model_from(value: object) -> str | None:
+    if not isinstance(value, dict):
+        return None
+    for key in ("effectiveModel", "modelId", "currentModelId", "model"):
+        model = value.get(key)
+        if isinstance(model, str) and model:
+            return model
+    for nested in value.values():
+        found = _model_from(nested)
+        if found is not None:
+            return found
+    return None
+
+
+def parse_stream(stdout: str) -> tuple[dict[str, Any] | None, str]:
+    messages, error = _objects(stdout)
+    if messages is None:
+        return None, error
+    text_parts: list[str] = []
+    protocol_version: int | None = None
+    session_id: str | None = None
+    request_id: str | None = None
+    stop_reason: str | None = None
+    effective_model: str | None = None
+    safe_events: list[dict[str, Any]] = []
+    for message in messages:
+        result = message.get("result")
+        if isinstance(result, dict):
+            version = result.get("protocolVersion")
+            if isinstance(version, int):
+                protocol_version = version
+            stop = result.get("stopReason")
+            if isinstance(stop, str):
+                stop_reason = stop
+                if isinstance(message.get("id"), (str, int)):
+                    request_id = str(message["id"])
+        params = message.get("params")
+        if isinstance(params, dict):
+            candidate_session = params.get("sessionId")
+            if isinstance(candidate_session, str):
+                session_id = candidate_session
+            if message.get("method") == "session/prompt" and isinstance(message.get("id"), (str, int)):
+                request_id = str(message["id"])
+        update = _update(message)
+        if update is None:
+            continue
+        kind = update.get("sessionUpdate")
+        safe_event: dict[str, Any] = {"type": str(kind or "session_update")}
+        status = update.get("status")
+        if isinstance(status, str):
+            safe_event["status"] = status
+        safe_events.append(safe_event)
+        effective_model = _model_from(update) or effective_model
+        if kind == "agent_message_chunk":
+            content = update.get("content")
+            if isinstance(content, dict) and content.get("type") == "text" and isinstance(content.get("text"), str):
+                text_parts.append(content["text"])
+    if protocol_version not in (None, 1):
+        return None, f"unsupported ACP protocol version: {protocol_version}"
+    text = "".join(text_parts).strip()
+    if not text:
+        return None, "ACP stream contained no final assistant text"
+    return {
+        "text": text,
+        "protocol_version": protocol_version or 1,
+        "session_id": session_id,
+        "request_id": request_id,
+        "stop_reason": stop_reason,
+        "effective_model": effective_model,
+        "events": safe_events,
+    }, ""
+
+
+def run_cursor(
+    prompt: str,
+    *,
+    cwd: Path,
+    timeout: float,
+    model: str,
+    version: str,
+    read_only: bool,
+    writable_worktree: bool = False,
+) -> AgentResult:
+    if version != SUPPORTED_VERSION:
+        return AgentResult(
+            text="",
+            ok=False,
+            detail=f"unsupported acpx adapter version {version}; reviewed version is {SUPPORTED_VERSION}",
+            transport="acpx",
+        )
+    if proc.which("acpx") is None:
+        return AgentResult(text="", ok=False, detail="acpx not installed", transport="acpx")
+    if proc.which("cursor-agent") is None:
+        return AgentResult(text="", ok=False, detail="cursor-agent not installed", transport="acpx")
+    installed, version_error = installed_version()
+    if installed != version:
+        found = installed or version_error
+        return AgentResult(
+            text="",
+            ok=False,
+            detail=f"seat requires acpx {version}; found {found}",
+            transport="acpx",
+            acpx_version=installed,
+        )
+    try:
+        argv = build_argv(
+            prompt=prompt,
+            cwd=cwd,
+            timeout=timeout,
+            model=model,
+            read_only=read_only,
+            writable_worktree=writable_worktree,
+        )
+    except ValueError as exc:
+        return AgentResult(text="", ok=False, detail=str(exc), transport="acpx", acpx_version=installed)
+    result = proc.run(argv, timeout=timeout + 5.0, cwd=cwd)
+    parsed, parse_error = parse_stream(result.stdout)
+    if result.code != 0:
+        detail = result.stderr.strip() or parse_error or f"acpx exit {result.code}"
+        return AgentResult(
+            text=parsed["text"] if parsed is not None else "",
+            ok=False,
+            detail=detail[:200],
+            stdout=result.stdout,
+            stderr=result.stderr,
+            exit_code=result.code,
+            timed_out=result.code in {3, 124},
+            transport="acpx",
+            requested_model=model,
+            effective_model=parsed.get("effective_model") if parsed is not None else None,
+            acpx_version=installed,
+        )
+    if parsed is None:
+        return AgentResult(
+            text="",
+            ok=False,
+            detail=parse_error[:200],
+            stdout=result.stdout,
+            stderr=result.stderr,
+            exit_code=result.code,
+            transport="acpx",
+            requested_model=model,
+            acpx_version=installed,
+        )
+    return AgentResult(
+        text=parsed["text"],
+        ok=True,
+        stdout=result.stdout,
+        stderr=result.stderr,
+        exit_code=result.code,
+        transport="acpx",
+        requested_model=model,
+        effective_model=parsed["effective_model"],
+        stop_reason=parsed["stop_reason"],
+        protocol_version=parsed["protocol_version"],
+        session_id=parsed["session_id"],
+        request_id=parsed["request_id"],
+        acpx_version=installed,
+        safe_events=tuple(parsed["events"]),
+    )

--- a/src/brigade/agents.py
+++ b/src/brigade/agents.py
@@ -199,6 +199,16 @@ class AgentResult:
     stdout_log: str | None = None
     stderr_log: str | None = None
     duration_seconds: float | None = None
+    transport: str = "cli"
+    requested_model: str | None = None
+    effective_model: str | None = None
+    reasoning: str | None = None
+    stop_reason: str | None = None
+    protocol_version: int | None = None
+    session_id: str | None = None
+    request_id: str | None = None
+    acpx_version: str | None = None
+    safe_events: tuple[dict[str, object], ...] = ()
 
 
 def is_known(cli_ref: str) -> bool:
@@ -381,6 +391,8 @@ def run_agent(
             stderr=result.stderr,
             exit_code=result.code,
             timed_out=result.code == 124,
+            requested_model=model,
+            reasoning=reasoning,
         )
     if not text:
         detail = "empty output"
@@ -393,6 +405,8 @@ def run_agent(
             stdout=result.stdout,
             stderr=result.stderr,
             exit_code=result.code,
+            requested_model=model,
+            reasoning=reasoning,
         )
     return AgentResult(
         text=text,
@@ -400,6 +414,8 @@ def run_agent(
         stdout=result.stdout,
         stderr=result.stderr,
         exit_code=result.code,
+        requested_model=model,
+        reasoning=reasoning,
     )
 
 
@@ -429,7 +445,15 @@ def run_codex_appserver(
             turn_kwargs["effort"] = reasoning
         turn = thread.run_turn(prompt, **turn_kwargs)
     except codex_appserver.AppServerError as exc:
-        return AgentResult(text="", ok=False, detail=str(exc)[:200], status="failed")
+        return AgentResult(
+            text="",
+            ok=False,
+            detail=str(exc)[:200],
+            status="failed",
+            transport="codex-app-server",
+            requested_model=model,
+            reasoning=reasoning,
+        )
     text = turn.text.strip()
     if not turn.ok:
         return AgentResult(
@@ -438,7 +462,27 @@ def run_codex_appserver(
             detail=(turn.detail or f"turn {turn.status}")[:200],
             thread_id=turn.thread_id,
             status=turn.status,
+            transport="codex-app-server",
+            requested_model=model,
+            reasoning=reasoning,
         )
     if not text:
-        return AgentResult(text="", ok=False, detail="empty output", thread_id=turn.thread_id, status=turn.status)
-    return AgentResult(text=text, ok=True, thread_id=turn.thread_id, status=turn.status)
+        return AgentResult(
+            text="",
+            ok=False,
+            detail="empty output",
+            thread_id=turn.thread_id,
+            status=turn.status,
+            transport="codex-app-server",
+            requested_model=model,
+            reasoning=reasoning,
+        )
+    return AgentResult(
+        text=text,
+        ok=True,
+        thread_id=turn.thread_id,
+        status=turn.status,
+        transport="codex-app-server",
+        requested_model=model,
+        reasoning=reasoning,
+    )

--- a/src/brigade/cli/model.py
+++ b/src/brigade/cli/model.py
@@ -44,6 +44,24 @@ def register(sub: argparse._SubParsersAction) -> None:
     )
     p_scorecard.set_defaults(func=_dispatch_scorecard)
 
+    p_trial = model_sub.add_parser("trial", help="Plan and run resumable model evaluation cells.")
+    trial_sub = p_trial.add_subparsers(dest="trial_command", metavar="<trial-command>")
+    trial_sub.required = True
+    for command in ("plan", "run", "resume"):
+        parser = trial_sub.add_parser(command, help=f"{command.title()} a model trial manifest.")
+        parser.add_argument("manifest", type=Path, help="brigade.eval_manifest.v1 JSON file.")
+        parser.add_argument("--target", "-t", type=Path, default=Path("."), help="Workspace used by trial runs.")
+        parser.add_argument(
+            "--roster", type=Path, default=None, help="Roster path. Uses normal workspace/user fallback."
+        )
+        parser.add_argument("--output-dir", type=Path, default=None, help="Trial artifact directory.")
+        parser.set_defaults(func=_dispatch_trial)
+    for command in ("show", "summary"):
+        parser = trial_sub.add_parser(command, help=f"{command.title()} trial artifacts.")
+        parser.add_argument("output_dir", type=Path, help="Trial artifact directory.")
+        parser.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+        parser.set_defaults(func=_dispatch_trial)
+
 
 def _dispatch_scorecard(args) -> int:
     from .. import model_scorecard
@@ -54,4 +72,44 @@ def _dispatch_scorecard(args) -> int:
         since=args.since,
         json_output=args.json,
         verbose=args.verbose,
+    )
+
+
+def _dispatch_trial(args) -> int:
+    import json
+    import sys
+
+    from .. import model_trials
+    from .. import roster as roster_mod
+
+    if args.trial_command in {"show", "summary"}:
+        if args.trial_command == "show":
+            return model_trials.show(args.output_dir, json_output=args.json)
+        payload = model_trials.summarize(args.output_dir)
+        if args.json:
+            print(json.dumps(payload, indent=2, sort_keys=True))
+        else:
+            for state, count in payload["counts"].items():
+                print(f"{state}: {count}")
+        return 0
+
+    target = args.target.expanduser().resolve()
+    try:
+        roster_path = roster_mod.resolve_roster_path(target, args.roster)
+        roster = roster_mod.load_roster(roster_path)
+        manifest = model_trials.load_manifest(args.manifest)
+        output_dir = args.output_dir or target / ".brigade" / "evals" / manifest["name"]
+        plan, cells = model_trials.build_plan(args.manifest, roster, output_dir)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    if args.trial_command == "plan":
+        print(json.dumps(plan, indent=2, sort_keys=True))
+        return 0
+    return model_trials.execute(
+        args.manifest,
+        roster,
+        workspace=target,
+        output_dir=output_dir,
+        resume=args.trial_command == "resume",
     )

--- a/src/brigade/cli/run.py
+++ b/src/brigade/cli/run.py
@@ -252,6 +252,8 @@ def dispatch(args) -> int:
                 "read_only": args.read_only,
                 "sandbox": effective_sandbox,
             }
+            if args.worktree and any(agent.transport == "acpx" for agent in loaded_roster.agents.values()):
+                run_kwargs["authorized_writable_worktree"] = True
             if args.worker is not None:
                 run_kwargs["worker"] = args.worker
             if args.codex_transport is not None:

--- a/src/brigade/model_trials.py
+++ b/src/brigade/model_trials.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from . import aboyeur, localio
+from . import aboyeur, localio, runguard
 from .roster import Roster
 
 MANIFEST_SCHEMA = "brigade.eval_manifest.v1"
@@ -31,6 +31,7 @@ class CellSpec:
     seat: str
     trial: int
     graders: tuple[dict[str, Any], ...]
+    execution_mode: str
 
     def payload(self) -> dict[str, Any]:
         return {
@@ -41,6 +42,7 @@ class CellSpec:
             "seat": self.seat,
             "trial": self.trial,
             "graders": list(self.graders),
+            "execution_mode": self.execution_mode,
         }
 
 
@@ -93,6 +95,12 @@ def expand_cells(manifest: dict[str, Any], roster: Roster, *, base_dir: Path = P
     default_trials = manifest.get("trials", 1)
     if not isinstance(default_trials, int) or isinstance(default_trials, bool) or default_trials < 1:
         raise ValueError("manifest trials must be a positive integer")
+    execution = manifest.get("execution", {"mode": "read-only"})
+    if not isinstance(execution, dict):
+        raise ValueError("manifest execution must be an object")
+    execution_mode = execution.get("mode", "read-only")
+    if execution_mode not in {"read-only", "writable-worktree"}:
+        raise ValueError("manifest execution.mode must be read-only or writable-worktree")
     cells: list[CellSpec] = []
     seen_cases: set[str] = set()
     for raw_case in manifest["cases"]:
@@ -123,6 +131,8 @@ def expand_cells(manifest: dict[str, Any], roster: Roster, *, base_dir: Path = P
                 "model": agent.model,
                 "reasoning": agent.reasoning,
                 "transport": getattr(agent, "transport", None),
+                "transport_version": getattr(agent, "transport_version", None),
+                "codex_transport": roster.codex_transport if agent.cli == "codex" else None,
             }
             for trial in range(1, trials + 1):
                 coordinate = f"{case_id}:{seat}:{trial}"
@@ -132,6 +142,7 @@ def expand_cells(manifest: dict[str, Any], roster: Roster, *, base_dir: Path = P
                     "seat": seat_spec,
                     "trial": trial,
                     "graders": graders,
+                    "execution_mode": execution_mode,
                 }
                 cells.append(
                     CellSpec(
@@ -142,6 +153,7 @@ def expand_cells(manifest: dict[str, Any], roster: Roster, *, base_dir: Path = P
                         seat=seat,
                         trial=trial,
                         graders=tuple(dict(item) for item in graders),
+                        execution_mode=execution_mode,
                     )
                 )
     return cells
@@ -154,10 +166,12 @@ def _grader_result(kind: str, index: int, started: float, *, status: str, score:
         "grader_type": kind,
         "version": 1,
         "status": status,
+        "exit_code": 0 if status == "scored" else None,
         "score": score,
         "score_min": 0.0,
         "score_max": 1.0,
         "detail": detail,
+        "component_checks": ([{"name": kind, "passed": score == 1.0, "detail": detail}] if status == "scored" else []),
         "duration_seconds": max(0.0, round(time.monotonic() - started, 6)),
     }
 
@@ -266,14 +280,44 @@ def grade_output(
     return results
 
 
-def _state(exit_code: int, graders: list[dict[str, Any]]) -> str:
+def _worker_result(run_dir: Path) -> dict[str, Any] | None:
+    payload = _load_json(run_dir / "worker-results.json")
+    if payload is None:
+        return None
+    results = payload.get("results")
+    if not isinstance(results, list) or not results or not isinstance(results[0], dict):
+        return None
+    return results[0]
+
+
+def _state(exit_code: int, graders: list[dict[str, Any]], worker_result: dict[str, Any] | None = None) -> str:
     if exit_code != 0:
+        if worker_result is not None and worker_result.get("ok") is False:
+            adapter_exit = worker_result.get("exit_code")
+            if adapter_exit is None or adapter_exit == 0:
+                return "adapter_error"
         return "execution_error"
     if not graders:
         return "unscored"
     if any(item["status"] == "grader_error" for item in graders):
         return "grader_error"
     return "accepted" if all(item["score"] == item["score_max"] for item in graders) else "rejected"
+
+
+def _trial_worktree_path(
+    workspace: Path,
+    output_dir: Path,
+    cell: CellSpec,
+    attempt: int,
+) -> Path:
+    experiment = hashlib.sha256(str(output_dir).encode()).hexdigest()[:12]
+    return (
+        Path.home()
+        / ".cache"
+        / "brigade"
+        / "worktrees"
+        / f"eval-{workspace.name}-{experiment}-{cell.cell_id[:12]}-{attempt:03d}"
+    )
 
 
 def _attempt_number(cell_dir: Path) -> int:
@@ -334,6 +378,10 @@ def execute(
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
+    writable = any(cell.execution_mode == "writable-worktree" for cell in cells)
+    if writable and not runguard.is_git_worktree(workspace):
+        print("error: writable-worktree trials require a git worktree target", file=sys.stderr)
+        return 2
     localio.write_json(output_dir / "plan.json", plan)
     failures = 0
     for cell in cells:
@@ -343,31 +391,46 @@ def execute(
             continue
         attempt = _attempt_number(cell_dir)
         run_dir = cell_dir / "attempts" / f"attempt-{attempt:03d}" / "run"
-        rc = aboyeur.run(
-            cell.prompt,
-            roster,
-            worker=cell.seat,
-            cwd=workspace,
-            output_dir=run_dir,
-            route_enabled=False,
-            read_only=True,
-        )
+        cell_workspace = workspace
+        worktree_path: Path | None = None
+        if cell.execution_mode == "writable-worktree":
+            worktree_path = _trial_worktree_path(workspace, output_dir, cell, attempt)
+            try:
+                cell_workspace = runguard.create_detached_worktree(workspace, worktree_path)
+            except runguard.RunGuardError as exc:
+                print(f"error: {exc}", file=sys.stderr)
+                return 2
         try:
-            text = (run_dir / "final.txt").read_text()
-        except OSError:
-            text = ""
-        graders = grade_output(
-            graders=cell.graders,
-            text=text,
-            exit_code=rc,
-            workspace=workspace,
-            run_dir=run_dir,
-        )
+            rc = aboyeur.run(
+                cell.prompt,
+                roster,
+                worker=cell.seat,
+                cwd=cell_workspace,
+                output_dir=run_dir,
+                route_enabled=False,
+                read_only=cell.execution_mode == "read-only",
+                authorized_writable_worktree=cell.execution_mode == "writable-worktree",
+            )
+            try:
+                text = (run_dir / "final.txt").read_text()
+            except OSError:
+                text = ""
+            graders = grade_output(
+                graders=cell.graders,
+                text=text,
+                exit_code=rc,
+                workspace=cell_workspace,
+                run_dir=run_dir,
+            )
+        finally:
+            if worktree_path is not None:
+                runguard.remove_worktree(workspace, worktree_path)
         output_digest = hashlib.sha256(text.encode()).hexdigest()
         for grader in graders:
             grader["cell_id"] = cell.cell_id
             grader["output_digest"] = f"sha256:{output_digest}"
-        state = _state(rc, graders)
+            grader["output_refs"] = [{"path": "run/final.txt", "sha256": grader["output_digest"]}]
+        state = _state(rc, graders, _worker_result(run_dir))
         run_meta = _load_json(run_dir / "run.json") or {}
         payload = {
             "schema": CELL_SCHEMA,
@@ -405,15 +468,26 @@ def _stats(values: list[float]) -> dict[str, Any]:
 
 def summarize(output_dir: Path) -> dict[str, Any]:
     counts: dict[str, int] = {}
+    stale_counts: dict[str, int] = {}
     scores: list[float] = []
     durations: list[float] = []
     cells_dir = output_dir / "cells"
     paths = sorted(cells_dir.glob("*/cell.json")) if cells_dir.is_dir() else []
+    plan = _load_json(output_dir / "plan.json")
+    current_ids = {
+        item["cell_id"]
+        for item in (plan or {}).get("cells", [])
+        if isinstance(item, dict) and isinstance(item.get("cell_id"), str)
+    }
     for path in paths:
         cell = _load_json(path)
         if cell is None:
             continue
         state = str(cell.get("state", "unknown"))
+        cell_id = cell.get("cell_id")
+        if current_ids and cell_id not in current_ids:
+            stale_counts[state] = stale_counts.get(state, 0) + 1
+            continue
         counts[state] = counts.get(state, 0) + 1
         if isinstance(cell.get("duration_seconds"), (int, float)):
             durations.append(float(cell["duration_seconds"]))
@@ -423,6 +497,7 @@ def summarize(output_dir: Path) -> dict[str, Any]:
     return {
         "schema": SUMMARY_SCHEMA,
         "counts": dict(sorted(counts.items())),
+        "stale_counts": dict(sorted(stale_counts.items())),
         "scores": _stats(scores),
         "durations": _stats(durations),
     }

--- a/src/brigade/model_trials.py
+++ b/src/brigade/model_trials.py
@@ -1,0 +1,444 @@
+"""Deterministic, resumable model trials over Brigade direct-worker runs."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import statistics
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from . import aboyeur, localio
+from .roster import Roster
+
+MANIFEST_SCHEMA = "brigade.eval_manifest.v1"
+CELL_SCHEMA = "brigade.eval_cell.v1"
+SUMMARY_SCHEMA = "brigade.eval_summary.v1"
+GRADER_SCHEMA = "brigade.grader_result.v1"
+TERMINAL_STATES = frozenset({"accepted", "rejected", "unscored", "execution_error", "adapter_error", "grader_error"})
+
+
+@dataclass(frozen=True)
+class CellSpec:
+    cell_id: str
+    coordinate: str
+    case_id: str
+    prompt: str
+    seat: str
+    trial: int
+    graders: tuple[dict[str, Any], ...]
+
+    def payload(self) -> dict[str, Any]:
+        return {
+            "cell_id": self.cell_id,
+            "coordinate": self.coordinate,
+            "case_id": self.case_id,
+            "prompt": self.prompt,
+            "seat": self.seat,
+            "trial": self.trial,
+            "graders": list(self.graders),
+        }
+
+
+def _canonical_digest(value: object) -> str:
+    raw = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    path = path.expanduser().resolve()
+    try:
+        data = json.loads(path.read_text())
+    except OSError as exc:
+        raise ValueError(f"manifest unreadable: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"manifest is not valid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError("manifest must be a JSON object")
+    if data.get("schema") != MANIFEST_SCHEMA:
+        raise ValueError(f"manifest schema must be {MANIFEST_SCHEMA}")
+    if not isinstance(data.get("name"), str) or not data["name"].strip():
+        raise ValueError("manifest name must be a non-empty string")
+    if not isinstance(data.get("cases"), list) or not data["cases"]:
+        raise ValueError("manifest cases must be a non-empty list")
+    if not isinstance(data.get("seats"), list) or not data["seats"]:
+        raise ValueError("manifest seats must be a non-empty list")
+    return data
+
+
+def _case_prompt(case: dict[str, Any], base_dir: Path) -> str:
+    prompt = case.get("prompt")
+    prompt_file = case.get("prompt_file")
+    if isinstance(prompt, str) and prompt:
+        return prompt
+    if isinstance(prompt_file, str) and prompt_file:
+        candidate = (base_dir / prompt_file).resolve()
+        if base_dir.resolve() not in candidate.parents and candidate != base_dir.resolve():
+            raise ValueError(f"case {case.get('id')!r} prompt_file escapes the manifest directory")
+        try:
+            return candidate.read_text()
+        except OSError as exc:
+            raise ValueError(f"case {case.get('id')!r} prompt_file unreadable: {exc}") from exc
+    raise ValueError(f"case {case.get('id')!r} needs prompt or prompt_file")
+
+
+def expand_cells(manifest: dict[str, Any], roster: Roster, *, base_dir: Path = Path(".")) -> list[CellSpec]:
+    defaults = manifest.get("graders", [])
+    if not isinstance(defaults, list) or not all(isinstance(item, dict) for item in defaults):
+        raise ValueError("manifest graders must be a list of objects")
+    default_trials = manifest.get("trials", 1)
+    if not isinstance(default_trials, int) or isinstance(default_trials, bool) or default_trials < 1:
+        raise ValueError("manifest trials must be a positive integer")
+    cells: list[CellSpec] = []
+    seen_cases: set[str] = set()
+    for raw_case in manifest["cases"]:
+        if not isinstance(raw_case, dict):
+            raise ValueError("each case must be an object")
+        case_id = raw_case.get("id")
+        if not isinstance(case_id, str) or not case_id.strip():
+            raise ValueError("each case needs a non-empty id")
+        if case_id in seen_cases:
+            raise ValueError(f"duplicate case id: {case_id}")
+        seen_cases.add(case_id)
+        prompt = _case_prompt(raw_case, base_dir)
+        trials = raw_case.get("trials", default_trials)
+        if not isinstance(trials, int) or isinstance(trials, bool) or trials < 1:
+            raise ValueError(f"case {case_id!r} trials must be a positive integer")
+        graders = raw_case.get("graders", defaults)
+        if not isinstance(graders, list) or not all(isinstance(item, dict) for item in graders):
+            raise ValueError(f"case {case_id!r} graders must be a list of objects")
+        for seat in manifest["seats"]:
+            if not isinstance(seat, str) or seat not in roster.agents:
+                raise ValueError(f"unknown roster seat: {seat!r}")
+            agent = roster.agents[seat]
+            if seat == roster.orchestrator or agent.cli is None:
+                raise ValueError(f"trial seat must be a CLI worker, not orchestrator or endpoint: {seat}")
+            seat_spec = {
+                "seat": seat,
+                "cli": agent.cli,
+                "model": agent.model,
+                "reasoning": agent.reasoning,
+                "transport": getattr(agent, "transport", None),
+            }
+            for trial in range(1, trials + 1):
+                coordinate = f"{case_id}:{seat}:{trial}"
+                identity = {
+                    "schema": CELL_SCHEMA,
+                    "case": {"id": case_id, "prompt": prompt},
+                    "seat": seat_spec,
+                    "trial": trial,
+                    "graders": graders,
+                }
+                cells.append(
+                    CellSpec(
+                        cell_id=_canonical_digest(identity),
+                        coordinate=coordinate,
+                        case_id=case_id,
+                        prompt=prompt,
+                        seat=seat,
+                        trial=trial,
+                        graders=tuple(dict(item) for item in graders),
+                    )
+                )
+    return cells
+
+
+def _grader_result(kind: str, index: int, started: float, *, status: str, score: float | None, detail: str) -> dict:
+    return {
+        "schema": GRADER_SCHEMA,
+        "grader_id": f"{kind}:{index}",
+        "grader_type": kind,
+        "version": 1,
+        "status": status,
+        "score": score,
+        "score_min": 0.0,
+        "score_max": 1.0,
+        "detail": detail,
+        "duration_seconds": max(0.0, round(time.monotonic() - started, 6)),
+    }
+
+
+def _json_field(value: Any, path: str) -> Any:
+    current = value
+    for part in path.split("."):
+        if not isinstance(current, dict) or part not in current:
+            raise KeyError(path)
+        current = current[part]
+    return current
+
+
+def _changed_files(run_dir: Path) -> list[str]:
+    try:
+        data = json.loads((run_dir / "worker-results.json").read_text())
+    except (OSError, json.JSONDecodeError):
+        return []
+    ground_truth = data.get("ground_truth") if isinstance(data, dict) else None
+    if not isinstance(ground_truth, dict):
+        return []
+    values = [ground_truth.get("changed_files"), ground_truth.get("untracked_files")]
+    return sorted({item for group in values if isinstance(group, list) for item in group if isinstance(item, str)})
+
+
+def grade_output(
+    *,
+    graders: list[dict[str, Any]] | tuple[dict[str, Any], ...],
+    text: str,
+    exit_code: int,
+    workspace: Path,
+    run_dir: Path,
+) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    for index, grader in enumerate(graders, start=1):
+        started = time.monotonic()
+        kind = grader.get("type")
+        if not isinstance(kind, str):
+            results.append(
+                _grader_result(
+                    "unknown", index, started, status="grader_error", score=None, detail="missing grader type"
+                )
+            )
+            continue
+        try:
+            passed = False
+            detail = ""
+            if kind == "exit_status":
+                expected = grader.get("expected", 0)
+                if not isinstance(expected, int):
+                    raise ValueError("expected must be an integer")
+                passed = exit_code == expected
+                detail = f"exit {exit_code}, expected {expected}"
+            elif kind == "exact_output":
+                expected = grader.get("expected")
+                if not isinstance(expected, str):
+                    raise ValueError("expected must be a string")
+                passed = text.rstrip("\n") == expected.rstrip("\n")
+                detail = "output matched" if passed else "output did not match"
+            elif kind == "regex_output":
+                pattern = grader.get("pattern")
+                if not isinstance(pattern, str):
+                    raise ValueError("pattern must be a string")
+                passed = re.search(pattern, text, re.MULTILINE) is not None
+                detail = "pattern matched" if passed else "pattern did not match"
+            elif kind == "json_field":
+                path = grader.get("path")
+                if not isinstance(path, str):
+                    raise ValueError("path must be a string")
+                actual = _json_field(json.loads(text), path)
+                expected = grader.get("expected")
+                passed = actual == expected
+                detail = f"{path} matched" if passed else f"{path} did not match"
+            elif kind == "file_exists":
+                rel = grader.get("path")
+                if not isinstance(rel, str) or Path(rel).is_absolute() or ".." in Path(rel).parts:
+                    raise ValueError("path must be workspace-relative")
+                passed = (workspace / rel).exists()
+                detail = f"{rel} exists" if passed else f"{rel} missing"
+            elif kind == "diff_constraints":
+                changed = _changed_files(run_dir)
+                forbidden = grader.get("forbidden", [])
+                allowed = grader.get("allowed", [])
+                if not isinstance(forbidden, list) or not isinstance(allowed, list):
+                    raise ValueError("allowed and forbidden must be lists")
+                forbidden_hits = [path for path in changed if any(re.fullmatch(str(p), path) for p in forbidden)]
+                outside = [path for path in changed if allowed and not any(re.fullmatch(str(p), path) for p in allowed)]
+                passed = not forbidden_hits and not outside
+                detail = f"changed={changed}; forbidden={forbidden_hits}; outside_allowed={outside}"
+            elif kind == "verify_receipt":
+                rel = grader.get("path")
+                if not isinstance(rel, str) or Path(rel).is_absolute() or ".." in Path(rel).parts:
+                    raise ValueError("path must be workspace-relative")
+                receipt = json.loads((workspace / rel).read_text())
+                passed = isinstance(receipt, dict) and receipt.get("status") == "completed"
+                detail = "verification completed" if passed else "verification not completed"
+            else:
+                raise ValueError(f"unknown grader type: {kind}")
+            results.append(
+                _grader_result(kind, index, started, status="scored", score=1.0 if passed else 0.0, detail=detail)
+            )
+        except (OSError, ValueError, KeyError, json.JSONDecodeError, re.error) as exc:
+            results.append(
+                _grader_result(kind, index, started, status="grader_error", score=None, detail=str(exc)[:200])
+            )
+    return results
+
+
+def _state(exit_code: int, graders: list[dict[str, Any]]) -> str:
+    if exit_code != 0:
+        return "execution_error"
+    if not graders:
+        return "unscored"
+    if any(item["status"] == "grader_error" for item in graders):
+        return "grader_error"
+    return "accepted" if all(item["score"] == item["score_max"] for item in graders) else "rejected"
+
+
+def _attempt_number(cell_dir: Path) -> int:
+    attempts = cell_dir / "attempts"
+    existing = [p for p in attempts.iterdir() if p.is_dir()] if attempts.is_dir() else []
+    return len(existing) + 1
+
+
+def _load_json(path: Path) -> dict[str, Any] | None:
+    try:
+        value = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def build_plan(manifest_path: Path, roster: Roster, output_dir: Path) -> tuple[dict[str, Any], list[CellSpec]]:
+    manifest = load_manifest(manifest_path)
+    cells = expand_cells(manifest, roster, base_dir=manifest_path.expanduser().resolve().parent)
+    prior = _load_json(output_dir / "plan.json") or {}
+    prior_by_coordinate = {
+        item.get("coordinate"): item.get("cell_id")
+        for item in prior.get("cells", [])
+        if isinstance(item, dict) and isinstance(item.get("coordinate"), str)
+    }
+    stale = [
+        {
+            "coordinate": cell.coordinate,
+            "previous_cell_id": prior_by_coordinate[cell.coordinate],
+            "cell_id": cell.cell_id,
+        }
+        for cell in cells
+        if cell.coordinate in prior_by_coordinate and prior_by_coordinate[cell.coordinate] != cell.cell_id
+    ]
+    payload = {
+        "schema": MANIFEST_SCHEMA,
+        "name": manifest["name"],
+        "manifest_digest": _canonical_digest(manifest),
+        "cells": [cell.payload() for cell in cells],
+        "stale_cells": stale,
+    }
+    return payload, cells
+
+
+def execute(
+    manifest_path: Path,
+    roster: Roster,
+    *,
+    workspace: Path,
+    output_dir: Path,
+    resume: bool,
+) -> int:
+    workspace = workspace.expanduser().resolve()
+    output_dir = output_dir.expanduser().resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        plan, cells = build_plan(manifest_path, roster, output_dir)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    localio.write_json(output_dir / "plan.json", plan)
+    failures = 0
+    for cell in cells:
+        cell_dir = output_dir / "cells" / cell.cell_id
+        current = _load_json(cell_dir / "cell.json")
+        if resume and current is not None and current.get("state") in TERMINAL_STATES:
+            continue
+        attempt = _attempt_number(cell_dir)
+        run_dir = cell_dir / "attempts" / f"attempt-{attempt:03d}" / "run"
+        rc = aboyeur.run(
+            cell.prompt,
+            roster,
+            worker=cell.seat,
+            cwd=workspace,
+            output_dir=run_dir,
+            route_enabled=False,
+        )
+        try:
+            text = (run_dir / "final.txt").read_text()
+        except OSError:
+            text = ""
+        graders = grade_output(
+            graders=cell.graders,
+            text=text,
+            exit_code=rc,
+            workspace=workspace,
+            run_dir=run_dir,
+        )
+        output_digest = hashlib.sha256(text.encode()).hexdigest()
+        for grader in graders:
+            grader["cell_id"] = cell.cell_id
+            grader["output_digest"] = f"sha256:{output_digest}"
+        state = _state(rc, graders)
+        run_meta = _load_json(run_dir / "run.json") or {}
+        payload = {
+            "schema": CELL_SCHEMA,
+            **cell.payload(),
+            "state": state,
+            "attempt": attempt,
+            "exit_code": rc,
+            "duration_seconds": run_meta.get("duration_seconds"),
+            "run_dir": str(run_dir),
+            "graders": graders,
+            "acceptance": {"state": "accepted" if state == "accepted" else "not-accepted"},
+        }
+        cell_dir.mkdir(parents=True, exist_ok=True)
+        localio.write_json(cell_dir / "cell.json", payload)
+        localio.write_json(run_dir.parent / "cell.json", payload)
+        if state not in {"accepted", "unscored"}:
+            failures += 1
+    localio.write_json(output_dir / "summary.json", summarize(output_dir))
+    return 1 if failures else 0
+
+
+def _stats(values: list[float]) -> dict[str, Any]:
+    if not values:
+        return {"values": [], "count": 0, "mean": None, "median": None, "min": None, "max": None, "stdev": None}
+    return {
+        "values": values,
+        "count": len(values),
+        "mean": statistics.mean(values),
+        "median": statistics.median(values),
+        "min": min(values),
+        "max": max(values),
+        "stdev": statistics.pstdev(values),
+    }
+
+
+def summarize(output_dir: Path) -> dict[str, Any]:
+    counts: dict[str, int] = {}
+    scores: list[float] = []
+    durations: list[float] = []
+    cells_dir = output_dir / "cells"
+    paths = sorted(cells_dir.glob("*/cell.json")) if cells_dir.is_dir() else []
+    for path in paths:
+        cell = _load_json(path)
+        if cell is None:
+            continue
+        state = str(cell.get("state", "unknown"))
+        counts[state] = counts.get(state, 0) + 1
+        if isinstance(cell.get("duration_seconds"), (int, float)):
+            durations.append(float(cell["duration_seconds"]))
+        for grader in cell.get("graders", []):
+            if isinstance(grader, dict) and isinstance(grader.get("score"), (int, float)):
+                scores.append(float(grader["score"]))
+    return {
+        "schema": SUMMARY_SCHEMA,
+        "counts": dict(sorted(counts.items())),
+        "scores": _stats(scores),
+        "durations": _stats(durations),
+    }
+
+
+def show(output_dir: Path, *, json_output: bool = False) -> int:
+    plan = _load_json(output_dir / "plan.json")
+    if plan is None:
+        print(f"error: no trial plan at {output_dir}", file=sys.stderr)
+        return 2
+    summary = summarize(output_dir)
+    if json_output:
+        print(json.dumps({"plan": plan, "summary": summary}, indent=2, sort_keys=True))
+    else:
+        print(f"trial: {plan.get('name')}")
+        print(f"cells: {len(plan.get('cells', []))}")
+        print(f"stale: {len(plan.get('stale_cells', []))}")
+        for state, count in summary["counts"].items():
+            print(f"{state}: {count}")
+    return 0

--- a/src/brigade/model_trials.py
+++ b/src/brigade/model_trials.py
@@ -350,6 +350,7 @@ def execute(
             cwd=workspace,
             output_dir=run_dir,
             route_enabled=False,
+            read_only=True,
         )
         try:
             text = (run_dir / "final.txt").read_text()

--- a/src/brigade/roster.py
+++ b/src/brigade/roster.py
@@ -11,6 +11,8 @@ from . import toml_compat
 
 SANDBOX_CHOICES = ("read-only", "workspace-write", "danger-full-access")
 CODEX_TRANSPORT_CHOICES = ("exec", "app-server")
+AGENT_TRANSPORT_CHOICES = ("direct", "acpx")
+ACPX_TRANSPORT_VERSION = "0.12.0"
 
 
 @dataclass(frozen=True)
@@ -23,6 +25,8 @@ class Agent:
     model: str | None = None
     headers: dict | None = None
     reasoning: str | None = None
+    transport: str = "direct"
+    transport_version: str | None = None
 
 
 @dataclass(frozen=True)
@@ -146,6 +150,16 @@ def load_roster(path: Path) -> Roster:
         model = _as_str(model_raw, f"agents.{agent_name}.model") if model_raw is not None else None
         reasoning_raw = raw_agent.get("reasoning")
         reasoning = _as_str(reasoning_raw, f"agents.{agent_name}.reasoning") if reasoning_raw is not None else None
+        transport_raw = raw_agent.get("transport", "direct")
+        if not isinstance(transport_raw, str) or transport_raw not in AGENT_TRANSPORT_CHOICES:
+            choices = ", ".join(AGENT_TRANSPORT_CHOICES)
+            raise ValueError(f"agents.{agent_name}.transport must be one of: {choices}")
+        transport_version_raw = raw_agent.get("transport_version")
+        transport_version = (
+            _as_str(transport_version_raw, f"agents.{agent_name}.transport_version")
+            if transport_version_raw is not None
+            else None
+        )
 
         headers_raw = raw_agent.get("headers")
         if headers_raw is not None and not isinstance(headers_raw, dict):
@@ -165,6 +179,23 @@ def load_roster(path: Path) -> Roster:
             if not _allowed(cli, allow_models):
                 raise ValueError(f"agents.{agent_name}.cli is not allowed by limits.allow_models: {cli!r}")
 
+        if transport_raw == "acpx":
+            if cli != "cursor":
+                raise ValueError(f'agents.{agent_name}.transport acpx currently supports cli = "cursor" only')
+            if model is None:
+                raise ValueError(f"agents.{agent_name}.transport acpx requires model")
+            if transport_version is None:
+                raise ValueError(f"agents.{agent_name}.transport acpx requires transport_version")
+            if transport_version != ACPX_TRANSPORT_VERSION:
+                raise ValueError(
+                    f"agents.{agent_name}.transport acpx reviewed version is {ACPX_TRANSPORT_VERSION}; "
+                    f"got {transport_version}"
+                )
+            if agent_name == orchestrator:
+                raise ValueError("acpx Cursor seats are workers only")
+        elif transport_version is not None:
+            raise ValueError(f'agents.{agent_name}.transport_version requires transport = "acpx"')
+
         parsed_agents[agent_name] = Agent(
             name=agent_name,
             cli=cli,
@@ -174,6 +205,8 @@ def load_roster(path: Path) -> Roster:
             model=model,
             headers=headers,
             reasoning=reasoning,
+            transport=transport_raw,
+            transport_version=transport_version,
         )
 
     if orchestrator not in parsed_agents:

--- a/src/brigade/roster_cmd.py
+++ b/src/brigade/roster_cmd.py
@@ -40,6 +40,8 @@ allow_models = ["codex", "ollama:*"]
 # Cross-model example: pin a model per agent with `model = ...`
 # (supported: claude, codex, grok, opencode, pi, kimi, cursor, antigravity).
 # Pin reasoning with `reasoning = "high"` for codex, grok, opencode, or pi.
+# Cursor workers may opt into reviewed ACP transport with
+# `transport = "acpx"` and `transport_version = "0.12.0"`.
 # A `codex-cloud:<env-id>` seat submits the task to Codex Cloud, polls it to a
 # terminal state, and returns the summary plus unified diff (never auto-applied;
 # land it with `codex cloud apply <task-id>`). Allow it with "codex-cloud:*".
@@ -186,5 +188,22 @@ def doctor(target: Path, *, roster_path: Path | None = None) -> int:
                         f"{agent.cli} does not support reasoning pins; drop reasoning= or switch cli",
                     )
                 )
+        if agent.transport == "acpx":
+            from . import acpx_adapter
+
+            if agents.proc.which("acpx") is None:
+                checks.append((doctor_mod.WARN, f"agent: {name} acpx", "acpx is not installed"))
+            else:
+                installed, detail = acpx_adapter.installed_version()
+                if installed == agent.transport_version:
+                    checks.append((doctor_mod.OK, f"agent: {name} acpx", f"version {installed}"))
+                else:
+                    checks.append(
+                        (
+                            doctor_mod.FAIL,
+                            f"agent: {name} acpx",
+                            f"requires {agent.transport_version}; found {installed or detail}",
+                        )
+                    )
 
     return doctor_mod._report(checks)

--- a/src/brigade/run_resume.py
+++ b/src/brigade/run_resume.py
@@ -39,6 +39,8 @@ def _roster_from_snapshot(snapshot: dict) -> Roster:
             timeout_seconds=raw.get("timeout_seconds"),
             model=raw.get("model"),
             reasoning=raw.get("reasoning"),
+            transport=raw.get("transport", "direct"),
+            transport_version=raw.get("transport_version"),
         )
     return Roster(
         orchestrator=snapshot["orchestrator"],
@@ -144,7 +146,11 @@ def resume(run_dir: Path) -> int:
     ground_truth = worker_data.get("ground_truth") or {}
     aboyeur._write_json(
         run_dir / "worker-results.json",
-        {"results": aboyeur._worker_payload(worker_results), "ground_truth": ground_truth},
+        {
+            "schema": "brigade.worker_results.v1",
+            "results": aboyeur._worker_payload(worker_results),
+            "ground_truth": ground_truth,
+        },
     )
 
     task = run_meta.get("task", "")
@@ -168,6 +174,7 @@ def resume(run_dir: Path) -> int:
     aboyeur._write_json(
         run_dir / "synthesis.json",
         {
+            "schema": "brigade.synthesis.v1",
             "orchestrator": roster.orchestrator,
             "result": {"ok": final.ok, "detail": final.detail, "text": final.text},
             "ground_truth": ground_truth,

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -1129,6 +1129,48 @@ def test_run_passes_agent_models(monkeypatch):
     ]
 
 
+def test_dispatch_uses_acpx_transport(monkeypatch, tmp_path):
+    from brigade import acpx_adapter
+
+    seen = {}
+
+    def fake_cursor(prompt, **kwargs):
+        seen.update(prompt=prompt, **kwargs)
+        return agents.AgentResult(
+            text="through ACP",
+            ok=True,
+            transport="acpx",
+            requested_model="composer-2.5",
+            effective_model="composer-2.5",
+            protocol_version=1,
+        )
+
+    monkeypatch.setattr(acpx_adapter, "run_cursor", fake_cursor)
+    roster = Roster(
+        orchestrator="chef",
+        agents={
+            "chef": Agent("chef", "codex", "plan"),
+            "composer": Agent(
+                "composer",
+                "cursor",
+                "build",
+                model="composer-2.5",
+                transport="acpx",
+                transport_version="0.12.0",
+            ),
+        },
+    )
+    result = aboyeur.dispatch(
+        [aboyeur.Assignment(worker="composer", task="inspect")],
+        roster,
+        cwd=tmp_path,
+        read_only=True,
+    )[0]
+    assert result.ok is True and result.transport == "acpx"
+    assert seen["version"] == "0.12.0"
+    assert seen["read_only"] is True
+
+
 def test_roster_payload_includes_model():
     payload = aboyeur._roster_payload(_model_roster())
     assert payload["agents"]["architect"]["model"] == "claude-fable-5"

--- a/tests/test_acpx_adapter.py
+++ b/tests/test_acpx_adapter.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import json
+
+from brigade import acpx_adapter
+from brigade import proc
+
+
+def _stream(*messages: dict) -> str:
+    return "\n".join(json.dumps(message) for message in messages) + "\n"
+
+
+def _success_stream() -> str:
+    return _stream(
+        {"jsonrpc": "2.0", "id": "init-1", "result": {"protocolVersion": 1}},
+        {
+            "jsonrpc": "2.0",
+            "id": "req-1",
+            "method": "session/prompt",
+            "params": {"sessionId": "session-1", "prompt": "hidden"},
+        },
+        {
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "session-1",
+                "update": {"sessionUpdate": "config_option_update", "modelId": "composer-2.5"},
+            },
+        },
+        {
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "session-1",
+                "update": {"sessionUpdate": "agent_message_chunk", "content": {"type": "text", "text": "hello"}},
+            },
+        },
+        {"jsonrpc": "2.0", "id": "req-1", "result": {"stopReason": "end_turn"}},
+    )
+
+
+def test_build_argv_is_bounded_and_permission_specific(tmp_path):
+    read = acpx_adapter.build_argv(
+        prompt="inspect",
+        cwd=tmp_path,
+        timeout=120.0,
+        model="composer-2.5",
+        read_only=True,
+        writable_worktree=False,
+    )
+    assert read == [
+        "acpx",
+        "--cwd",
+        str(tmp_path.resolve()),
+        "--format",
+        "json",
+        "--json-strict",
+        "--no-terminal",
+        "--timeout",
+        "120",
+        "--model",
+        "composer-2.5",
+        "--approve-reads",
+        "--non-interactive-permissions",
+        "fail",
+        "--agent",
+        "cursor-agent acp",
+        "exec",
+        "inspect",
+    ]
+    write = acpx_adapter.build_argv(
+        prompt="edit",
+        cwd=tmp_path,
+        timeout=12.5,
+        model="composer-2.5",
+        read_only=False,
+        writable_worktree=True,
+    )
+    assert "--approve-all" in write
+
+
+def test_build_argv_refuses_writable_non_worktree(tmp_path):
+    try:
+        acpx_adapter.build_argv(
+            prompt="edit",
+            cwd=tmp_path,
+            timeout=10,
+            model="composer-2.5",
+            read_only=False,
+            writable_worktree=False,
+        )
+    except ValueError as exc:
+        assert "writable worktree" in str(exc)
+    else:
+        raise AssertionError("expected writable ACP refusal")
+
+
+def test_run_parses_protocol_and_final_text(monkeypatch, tmp_path):
+    monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append(argv)
+        if argv == ["acpx", "--version"]:
+            return proc.Result(0, "acpx 0.12.0\n", "")
+        return proc.Result(0, _success_stream(), "")
+
+    monkeypatch.setattr(acpx_adapter.proc, "run", fake_run)
+    result = acpx_adapter.run_cursor(
+        "inspect", cwd=tmp_path, timeout=120, model="composer-2.5", version="0.12.0", read_only=True
+    )
+    assert result.ok is True
+    assert result.text == "hello"
+    assert result.transport == "acpx"
+    assert result.protocol_version == 1
+    assert result.session_id == "session-1"
+    assert result.request_id == "req-1"
+    assert result.stop_reason == "end_turn"
+    assert result.effective_model == "composer-2.5"
+
+
+def test_run_rejects_version_mismatch(monkeypatch, tmp_path):
+    monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
+    monkeypatch.setattr(acpx_adapter.proc, "run", lambda argv, **kwargs: proc.Result(0, "acpx 0.13.0\n", ""))
+    result = acpx_adapter.run_cursor(
+        "inspect", cwd=tmp_path, timeout=120, model="composer-2.5", version="0.12.0", read_only=True
+    )
+    assert result.ok is False
+    assert "requires acpx 0.12.0" in result.detail
+
+
+def test_run_rejects_invalid_or_empty_protocol_output(monkeypatch, tmp_path):
+    monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
+    outputs = iter(
+        [
+            proc.Result(0, "acpx 0.12.0\n", ""),
+            proc.Result(0, "not-json\n", ""),
+            proc.Result(0, "acpx 0.12.0\n", ""),
+            proc.Result(0, _stream({"jsonrpc": "2.0", "id": "x", "result": {"stopReason": "end_turn"}}), ""),
+        ]
+    )
+    monkeypatch.setattr(acpx_adapter.proc, "run", lambda argv, **kwargs: next(outputs))
+    invalid = acpx_adapter.run_cursor(
+        "inspect", cwd=tmp_path, timeout=120, model="composer-2.5", version="0.12.0", read_only=True
+    )
+    empty = acpx_adapter.run_cursor(
+        "inspect", cwd=tmp_path, timeout=120, model="composer-2.5", version="0.12.0", read_only=True
+    )
+    assert invalid.ok is False and "invalid ACP NDJSON" in invalid.detail
+    assert empty.ok is False and "no final assistant text" in empty.detail
+
+
+def test_run_preserves_timeout_and_permission_exit(monkeypatch, tmp_path):
+    monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
+    outputs = iter(
+        [
+            proc.Result(0, "acpx 0.12.0\n", ""),
+            proc.Result(3, "", "acpx timed out"),
+            proc.Result(0, "acpx 0.12.0\n", ""),
+            proc.Result(5, "", "permission denied"),
+        ]
+    )
+    monkeypatch.setattr(acpx_adapter.proc, "run", lambda argv, **kwargs: next(outputs))
+    timeout = acpx_adapter.run_cursor(
+        "inspect", cwd=tmp_path, timeout=120, model="composer-2.5", version="0.12.0", read_only=True
+    )
+    denied = acpx_adapter.run_cursor(
+        "inspect", cwd=tmp_path, timeout=120, model="composer-2.5", version="0.12.0", read_only=True
+    )
+    assert timeout.exit_code == 3 and timeout.timed_out is True
+    assert denied.exit_code == 5 and denied.detail == "permission denied"

--- a/tests/test_model_trials.py
+++ b/tests/test_model_trials.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+
+from brigade import cli
+from brigade import model_trials
+from brigade.roster import Agent, Roster
+
+
+def _manifest() -> dict:
+    return {
+        "schema": "brigade.eval_manifest.v1",
+        "name": "adapter-check",
+        "trials": 2,
+        "seats": ["cursor"],
+        "cases": [{"id": "hello", "prompt": "Say hello"}],
+        "graders": [{"type": "exact_output", "expected": "hello"}],
+    }
+
+
+def _roster() -> Roster:
+    return Roster(
+        orchestrator="chef",
+        agents={
+            "chef": Agent("chef", "codex", "plan"),
+            "cursor": Agent("cursor", "cursor", "answer", model="composer-2.5"),
+        },
+    )
+
+
+def test_expand_cells_is_stable_and_conditions_change_identity():
+    first = model_trials.expand_cells(_manifest(), _roster())
+    second = model_trials.expand_cells(_manifest(), _roster())
+    assert [cell.cell_id for cell in first] == [cell.cell_id for cell in second]
+    assert len(first) == 2
+
+    changed = _manifest()
+    changed["cases"][0]["prompt"] = "Say hello clearly"
+    assert model_trials.expand_cells(changed, _roster())[0].cell_id != first[0].cell_id
+
+
+def test_graders_distinguish_zero_score_from_error(tmp_path):
+    results = model_trials.grade_output(
+        graders=[
+            {"type": "exact_output", "expected": "wanted"},
+            {"type": "regex_output", "pattern": "["},
+        ],
+        text="actual",
+        exit_code=0,
+        workspace=tmp_path,
+        run_dir=tmp_path,
+    )
+    assert results[0]["status"] == "scored"
+    assert results[0]["score"] == 0.0
+    assert results[1]["status"] == "grader_error"
+    assert results[1]["score"] is None
+
+
+def test_run_then_resume_skips_matching_terminal_cells(tmp_path, monkeypatch):
+    manifest_path = tmp_path / "eval.json"
+    manifest_path.write_text(json.dumps(_manifest()))
+    calls: list[str] = []
+
+    def fake_run(task, roster, **kwargs):
+        calls.append(kwargs["worker"])
+        out = kwargs["output_dir"]
+        out.mkdir(parents=True, exist_ok=True)
+        (out / "final.txt").write_text("hello\n")
+        (out / "run.json").write_text(json.dumps({"status": "ok", "duration_seconds": 1.25}))
+        return 0
+
+    monkeypatch.setattr(model_trials.aboyeur, "run", fake_run)
+    root = tmp_path / "results"
+
+    assert model_trials.execute(manifest_path, _roster(), workspace=tmp_path, output_dir=root, resume=False) == 0
+    assert calls == ["cursor", "cursor"]
+    assert model_trials.execute(manifest_path, _roster(), workspace=tmp_path, output_dir=root, resume=True) == 0
+    assert calls == ["cursor", "cursor"]
+
+    summary = model_trials.summarize(root)
+    assert summary["counts"] == {"accepted": 2}
+    assert summary["scores"]["count"] == 2
+    assert summary["scores"]["mean"] == 1.0
+
+
+def test_resume_reports_stale_cells_when_conditions_change(tmp_path, monkeypatch):
+    manifest_path = tmp_path / "eval.json"
+    manifest_path.write_text(json.dumps(_manifest()))
+
+    def fake_run(task, roster, **kwargs):
+        out = kwargs["output_dir"]
+        out.mkdir(parents=True, exist_ok=True)
+        (out / "final.txt").write_text("hello\n")
+        (out / "run.json").write_text(json.dumps({"status": "ok", "duration_seconds": 0.5}))
+        return 0
+
+    monkeypatch.setattr(model_trials.aboyeur, "run", fake_run)
+    root = tmp_path / "results"
+    assert model_trials.execute(manifest_path, _roster(), workspace=tmp_path, output_dir=root, resume=False) == 0
+
+    changed = _manifest()
+    changed["graders"] = [{"type": "exact_output", "expected": "goodbye"}]
+    manifest_path.write_text(json.dumps(changed))
+    assert model_trials.execute(manifest_path, _roster(), workspace=tmp_path, output_dir=root, resume=True) == 1
+    plan = json.loads((root / "plan.json").read_text())
+    assert len(plan["stale_cells"]) == 2
+
+
+def test_cli_trial_plan_uses_explicit_roster(tmp_path, capsys):
+    manifest_path = tmp_path / "eval.json"
+    manifest_path.write_text(json.dumps(_manifest()))
+    roster_path = tmp_path / "roster.toml"
+    roster_path.write_text(
+        'orchestrator = "chef"\n'
+        '[agents.chef]\ncli = "codex"\nrole = "plan"\n'
+        '[agents.cursor]\ncli = "cursor"\nmodel = "composer-2.5"\nrole = "answer"\n'
+    )
+
+    rc = cli.main(
+        [
+            "model",
+            "trial",
+            "plan",
+            str(manifest_path),
+            "--target",
+            str(tmp_path),
+            "--roster",
+            str(roster_path),
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert len(payload["cells"]) == 2

--- a/tests/test_model_trials.py
+++ b/tests/test_model_trials.py
@@ -38,6 +38,60 @@ def test_expand_cells_is_stable_and_conditions_change_identity():
     changed["cases"][0]["prompt"] = "Say hello clearly"
     assert model_trials.expand_cells(changed, _roster())[0].cell_id != first[0].cell_id
 
+    acpx_roster = _roster()
+    acpx_roster = Roster(
+        orchestrator=acpx_roster.orchestrator,
+        agents={
+            **acpx_roster.agents,
+            "cursor": Agent(
+                "cursor",
+                "cursor",
+                "answer",
+                model="composer-2.5",
+                transport="acpx",
+                transport_version="0.12.0",
+            ),
+        },
+    )
+    newer_acpx = Roster(
+        orchestrator=acpx_roster.orchestrator,
+        agents={
+            **acpx_roster.agents,
+            "cursor": Agent(
+                "cursor",
+                "cursor",
+                "answer",
+                model="composer-2.5",
+                transport="acpx",
+                transport_version="0.13.0",
+            ),
+        },
+    )
+    assert (
+        model_trials.expand_cells(_manifest(), acpx_roster)[0].cell_id
+        != model_trials.expand_cells(_manifest(), newer_acpx)[0].cell_id
+    )
+
+
+def test_codex_transport_and_execution_mode_change_cell_identity():
+    manifest = _manifest()
+    manifest["seats"] = ["worker"]
+    manifest["execution"] = {"mode": "read-only"}
+    exec_roster = Roster(
+        orchestrator="chef",
+        agents={"chef": Agent("chef", "codex", "plan"), "worker": Agent("worker", "codex", "work")},
+        codex_transport="exec",
+    )
+    appserver_roster = Roster(
+        orchestrator="chef",
+        agents=exec_roster.agents,
+        codex_transport="app-server",
+    )
+    first = model_trials.expand_cells(manifest, exec_roster)[0]
+    assert model_trials.expand_cells(manifest, appserver_roster)[0].cell_id != first.cell_id
+    manifest["execution"] = {"mode": "writable-worktree"}
+    assert model_trials.expand_cells(manifest, exec_roster)[0].cell_id != first.cell_id
+
 
 def test_graders_distinguish_zero_score_from_error(tmp_path):
     results = model_trials.grade_output(
@@ -54,6 +108,11 @@ def test_graders_distinguish_zero_score_from_error(tmp_path):
     assert results[0]["score"] == 0.0
     assert results[1]["status"] == "grader_error"
     assert results[1]["score"] is None
+    assert results[0]["exit_code"] == 0
+    assert results[0]["component_checks"] == [
+        {"name": "exact_output", "passed": False, "detail": "output did not match"}
+    ]
+    assert results[1]["exit_code"] is None
 
 
 def test_run_then_resume_skips_matching_terminal_cells(tmp_path, monkeypatch):
@@ -104,6 +163,106 @@ def test_resume_reports_stale_cells_when_conditions_change(tmp_path, monkeypatch
     assert model_trials.execute(manifest_path, _roster(), workspace=tmp_path, output_dir=root, resume=True) == 1
     plan = json.loads((root / "plan.json").read_text())
     assert len(plan["stale_cells"]) == 2
+    summary = model_trials.summarize(root)
+    assert summary["counts"] == {"rejected": 2}
+    assert summary["stale_counts"] == {"accepted": 2}
+
+
+def test_grader_envelope_links_digested_output(tmp_path, monkeypatch):
+    manifest_path = tmp_path / "eval.json"
+    manifest_path.write_text(json.dumps(_manifest()))
+
+    def fake_run(task, roster, **kwargs):
+        out = kwargs["output_dir"]
+        out.mkdir(parents=True, exist_ok=True)
+        (out / "final.txt").write_text("hello\n")
+        (out / "run.json").write_text(json.dumps({"status": "ok", "duration_seconds": 0.5}))
+        (out / "worker-results.json").write_text(
+            json.dumps({"results": [{"worker": "cursor", "ok": True, "exit_code": 0, "transport": "cli"}]})
+        )
+        return 0
+
+    monkeypatch.setattr(model_trials.aboyeur, "run", fake_run)
+    root = tmp_path / "results"
+    assert model_trials.execute(manifest_path, _roster(), workspace=tmp_path, output_dir=root, resume=False) == 0
+    cell = json.loads(next((root / "cells").glob("*/cell.json")).read_text())
+    grader = cell["graders"][0]
+    assert grader["cell_id"] == cell["cell_id"]
+    assert grader["output_refs"] == [{"path": "run/final.txt", "sha256": grader["output_digest"]}]
+
+
+def test_adapter_failure_is_distinct_from_execution_failure(tmp_path, monkeypatch):
+    manifest_path = tmp_path / "eval.json"
+    manifest_path.write_text(json.dumps(_manifest()))
+
+    def fake_run(task, roster, **kwargs):
+        out = kwargs["output_dir"]
+        out.mkdir(parents=True, exist_ok=True)
+        (out / "run.json").write_text(json.dumps({"status": "failed"}))
+        (out / "worker-results.json").write_text(
+            json.dumps(
+                {
+                    "results": [
+                        {"worker": "cursor", "ok": False, "detail": "cursor-agent not installed", "transport": "cli"}
+                    ]
+                }
+            )
+        )
+        return 2
+
+    monkeypatch.setattr(model_trials.aboyeur, "run", fake_run)
+    root = tmp_path / "results"
+    assert model_trials.execute(manifest_path, _roster(), workspace=tmp_path, output_dir=root, resume=False) == 1
+    cell = json.loads(next((root / "cells").glob("*/cell.json")).read_text())
+    assert cell["state"] == "adapter_error"
+
+
+def test_writable_trials_use_fresh_isolated_worktrees(tmp_path, monkeypatch):
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    manifest = _manifest()
+    manifest["execution"] = {"mode": "writable-worktree"}
+    manifest_path = workspace / "eval.json"
+    manifest_path.write_text(json.dumps(manifest))
+    created: list[object] = []
+    removed: list[object] = []
+    run_cwds: list[object] = []
+
+    def fake_create(repo, path):
+        created.append((repo, path))
+        path.mkdir(parents=True)
+        return path
+
+    def fake_remove(repo, path):
+        removed.append((repo, path))
+
+    def fake_run(task, roster, **kwargs):
+        run_cwds.append(kwargs["cwd"])
+        assert kwargs["read_only"] is False
+        assert kwargs["authorized_writable_worktree"] is True
+        out = kwargs["output_dir"]
+        out.mkdir(parents=True, exist_ok=True)
+        (out / "final.txt").write_text("hello\n")
+        (out / "run.json").write_text(json.dumps({"status": "ok"}))
+        (out / "worker-results.json").write_text(
+            json.dumps({"results": [{"worker": "cursor", "ok": True, "exit_code": 0, "transport": "cli"}]})
+        )
+        return 0
+
+    monkeypatch.setattr(model_trials.runguard, "is_git_worktree", lambda path: True)
+    monkeypatch.setattr(
+        model_trials,
+        "_trial_worktree_path",
+        lambda workspace, output_dir, cell, attempt: tmp_path / "checkouts" / f"{cell.cell_id}-{attempt}",
+    )
+    monkeypatch.setattr(model_trials.runguard, "create_detached_worktree", fake_create)
+    monkeypatch.setattr(model_trials.runguard, "remove_worktree", fake_remove)
+    monkeypatch.setattr(model_trials.aboyeur, "run", fake_run)
+    root = tmp_path / "results"
+    assert model_trials.execute(manifest_path, _roster(), workspace=workspace, output_dir=root, resume=False) == 0
+    assert len(created) == 2
+    assert len(removed) == 2
+    assert len(set(run_cwds)) == 2
 
 
 def test_cli_trial_plan_uses_explicit_roster(tmp_path, capsys):

--- a/tests/test_roster.py
+++ b/tests/test_roster.py
@@ -234,6 +234,33 @@ def test_cli_agent_accepts_reasoning_pin(tmp_path):
     assert loaded.agents["chef"].reasoning == "max"
 
 
+def test_cursor_worker_accepts_pinned_acpx_transport(tmp_path):
+    text = (
+        'orchestrator = "chef"\n'
+        '[agents.chef]\ncli = "codex"\nrole = "plan"\n'
+        '[agents.composer]\ncli = "cursor"\nmodel = "composer-2.5"\n'
+        'transport = "acpx"\ntransport_version = "0.12.0"\nrole = "build"\n'
+    )
+    loaded = roster_mod.load_roster(_write(tmp_path, text))
+    assert loaded.agents["composer"].transport == "acpx"
+    assert loaded.agents["composer"].transport_version == "0.12.0"
+
+
+def test_acpx_transport_rejects_wrong_cli_or_unreviewed_version(tmp_path):
+    wrong_cli = (
+        'orchestrator = "chef"\n'
+        '[agents.chef]\ncli = "codex"\nrole = "plan"\n'
+        '[agents.worker]\ncli = "grok"\nmodel = "grok-4.5"\n'
+        'transport = "acpx"\ntransport_version = "0.12.0"\nrole = "build"\n'
+    )
+    with pytest.raises(ValueError, match="cursor"):
+        roster_mod.load_roster(_write(tmp_path, wrong_cli))
+
+    wrong_version = wrong_cli.replace('cli = "grok"', 'cli = "cursor"').replace("0.12.0", "0.13.0")
+    with pytest.raises(ValueError, match="reviewed version"):
+        roster_mod.load_roster(_write(tmp_path, wrong_version))
+
+
 def test_cli_agent_still_requires_cli_or_endpoint(tmp_path):
     text = 'orchestrator = "chef"\n[agents.chef]\nrole = "plan"\n'
     with pytest.raises(ValueError):


### PR DESCRIPTION
## What changed

- Add resumable case, seat, and trial cells with stable identities and mechanical graders.
- Separate current-plan, stale, adapter, execution, grader, accepted, and rejected states.
- Run writable trials in fresh Brigade-created worktrees.
- Add an explicit, pinned Cursor ACP transport through an external `acpx` executable.

## Why

Model comparisons need reproducible conditions and isolated writable runs. ACP support belongs behind an opt-in adapter with no silent fallback.

## Verification

- Full `./scripts/verify`: 2,179 passed, 3 skipped, coverage 81.21%.
- Cursor completed an ACP protocol-version-1 initialization handshake.

Related: #223, #231.
