### PR TITLE
feat(evidence): add safe typed projections

### DIFF
--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -44,7 +44,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade pantry` (extras): 5 command path(s)
 - `brigade profiles`: 2 command path(s)
 - `brigade projects` (extras): 10 command path(s)
-- `brigade receipts`: 3 command path(s)
+- `brigade receipts`: 5 command path(s)
 - `brigade reconfigure`: 1 command path(s)
 - `brigade release` (extras): 23 command path(s)
 - `brigade repos` (extras): 71 command path(s)
@@ -274,6 +274,8 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade projects readiness record` (extras)
 - `brigade projects readiness show` (extras)
 - `brigade receipts export miseledger`
+- `brigade receipts export openinference`
+- `brigade receipts export otel-genai`
 - `brigade receipts keygen`
 - `brigade receipts verify`
 - `brigade reconfigure`

--- a/docs/phase-skills-friction-projections.md
+++ b/docs/phase-skills-friction-projections.md
@@ -1,0 +1,25 @@
+# Skills, Friction, and Receipt Projections
+
+## Completed
+
+- Added strict Agent Skills authoring validation for exact `SKILL.md` casing,
+  name, description, license, compatibility, string metadata, and declared
+  `allowed-tools` requirements.
+- Added lenient import diagnostics while retaining legacy skill packages and
+  unknown fields.
+- Kept `allowed-tools` informational. It never grants execution permission.
+- Made friction v2 consume verification, run, evaluation, and explicit
+  MiseLedger receipts before regex evidence.
+- Added per-source-family candidate quotas and recurrence identities that omit
+  source paths and line positions.
+- Added privacy-safe OTel GenAI and OpenInference JSONL projections. Prompts,
+  model output, tool arguments, command catalogs, and retrieved content are
+  omitted.
+- Reused the existing MiseLedger adapter, install receipts, history,
+  fingerprint scoring, promotion signals, and rollback implementation.
+
+## Verification
+
+- Focused skills, friction, receipt, and projection tests passed.
+- Full `./scripts/verify` passed through Brigade in run
+  `20260712-220804-work-verify-12fab0`.

--- a/src/brigade/agent_skill_format.py
+++ b/src/brigade/agent_skill_format.py
@@ -54,7 +54,7 @@ def validate(skill_dir: Path, *, mode: str) -> Validation:
             return Validation({}, (), (framing_error or "invalid frontmatter",))
         return Validation({}, (framing_error or "invalid frontmatter",), ())
     fields: dict[str, object] = {}
-    unknown: list[str] = []
+    unknown: dict[str, str] = {}
     metadata: dict[str, str] = {}
     current_map: str | None = None
     errors: list[str] = []
@@ -79,7 +79,7 @@ def validate(skill_dir: Path, *, mode: str) -> Validation:
         key, raw = line.split(":", 1)
         key = key.strip()
         if key not in KNOWN_FIELDS:
-            unknown.append(key)
+            unknown[key] = _scalar(raw)
             continue
         if key == "metadata":
             current_map = key
@@ -120,6 +120,5 @@ def validate(skill_dir: Path, *, mode: str) -> Validation:
         fields["allowed-tools"] = tuple(item for item in re.split(r"[\s,]+", allowed) if item)
     elif allowed is not None:
         errors.append("frontmatter allowed-tools must be a string declaration")
-    for key in unknown:
-        fields[key] = "retained"
+    fields.update(unknown)
     return Validation(fields, tuple(dict.fromkeys(errors)), tuple(diagnostics))

--- a/src/brigade/agent_skill_format.py
+++ b/src/brigade/agent_skill_format.py
@@ -1,0 +1,125 @@
+"""Dependency-free validation for the observable Agent Skills frontmatter contract."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+KNOWN_FIELDS = frozenset({"name", "description", "license", "compatibility", "metadata", "allowed-tools"})
+NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+
+@dataclass(frozen=True)
+class Validation:
+    fields: dict[str, object]
+    errors: tuple[str, ...]
+    diagnostics: tuple[str, ...]
+
+
+def _scalar(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] == '"':
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return value
+        return parsed if isinstance(parsed, str) else value
+    if len(value) >= 2 and value[0] == value[-1] == "'":
+        return value[1:-1].replace("''", "'")
+    return value
+
+
+def _frontmatter(text: str) -> tuple[list[str] | None, str | None]:
+    lines = text.splitlines()
+    if not lines or lines[0] != "---":
+        return None, "SKILL.md must start with exact YAML frontmatter delimiter ---"
+    try:
+        end = lines.index("---", 1)
+    except ValueError:
+        return None, "SKILL.md frontmatter is not closed with exact delimiter ---"
+    return lines[1:end], None
+
+
+def validate(skill_dir: Path, *, mode: str) -> Validation:
+    if mode not in {"strict", "lenient"}:
+        raise ValueError("skill validation mode must be strict or lenient")
+    path = skill_dir / "SKILL.md"
+    if not path.is_file():
+        return Validation({}, (f"SKILL.md not found: {path}",), ())
+    lines, framing_error = _frontmatter(path.read_text(errors="replace"))
+    if lines is None:
+        if mode == "lenient":
+            return Validation({}, (), (framing_error or "invalid frontmatter",))
+        return Validation({}, (framing_error or "invalid frontmatter",), ())
+    fields: dict[str, object] = {}
+    unknown: list[str] = []
+    metadata: dict[str, str] = {}
+    current_map: str | None = None
+    errors: list[str] = []
+    for number, line in enumerate(lines, start=2):
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        if line[:1].isspace():
+            if current_map != "metadata" or ":" not in line:
+                errors.append(f"frontmatter line {number} has unsupported nesting")
+                continue
+            key, raw = line.strip().split(":", 1)
+            value = _scalar(raw)
+            if not key or not value:
+                errors.append(f"metadata line {number} must contain string key and value")
+            else:
+                metadata[key] = value
+            continue
+        current_map = None
+        if ":" not in line:
+            errors.append(f"frontmatter line {number} must be key: value")
+            continue
+        key, raw = line.split(":", 1)
+        key = key.strip()
+        if key not in KNOWN_FIELDS:
+            unknown.append(key)
+            continue
+        if key == "metadata":
+            current_map = key
+            if raw.strip() not in {"", "{}"}:
+                errors.append("metadata must be a string-to-string mapping")
+            continue
+        value = _scalar(raw)
+        fields[key] = value
+    if metadata:
+        fields["metadata"] = metadata
+    diagnostics = [f"unknown frontmatter field retained: {key}" for key in unknown]
+    if mode == "strict":
+        errors.extend(f"unknown frontmatter field: {key}" for key in unknown)
+    name = fields.get("name")
+    if not isinstance(name, str) or not name:
+        message = "frontmatter name is required"
+        (errors if mode == "strict" else diagnostics).append(message)
+    else:
+        if len(name) > 64 or NAME_RE.fullmatch(name) is None:
+            message = "frontmatter name must be a 1-64 character lowercase identifier"
+            (errors if mode == "strict" else diagnostics).append(message)
+        if name != skill_dir.name:
+            message = f"frontmatter name {name!r} must match directory {skill_dir.name!r}"
+            (errors if mode == "strict" else diagnostics).append(message)
+    description = fields.get("description")
+    if not isinstance(description, str) or not description:
+        message = "frontmatter description is required"
+        (errors if mode == "strict" else diagnostics).append(message)
+    elif len(description) > 1024:
+        message = "frontmatter description exceeds 1024 characters"
+        (errors if mode == "strict" else diagnostics).append(message)
+    for key in ("license", "compatibility"):
+        field_value = fields.get(key)
+        if field_value is not None and (not isinstance(field_value, str) or not field_value):
+            errors.append(f"frontmatter {key} must be a non-empty string")
+    allowed = fields.get("allowed-tools")
+    if isinstance(allowed, str):
+        fields["allowed-tools"] = tuple(item for item in re.split(r"[\s,]+", allowed) if item)
+    elif allowed is not None:
+        errors.append("frontmatter allowed-tools must be a string declaration")
+    for key in unknown:
+        fields[key] = "retained"
+    return Validation(fields, tuple(dict.fromkeys(errors)), tuple(diagnostics))

--- a/src/brigade/cli/friction.py
+++ b/src/brigade/cli/friction.py
@@ -18,6 +18,14 @@ def register(sub: argparse._SubParsersAction) -> None:
         action="store_true",
         help="Also scan local Codex and Claude Code session/log directories.",
     )
+    p_friction_scan.add_argument(
+        "--miseledger",
+        type=Path,
+        action="append",
+        default=None,
+        dest="miseledger_paths",
+        help="Explicit miseledger.adapter.v1 JSONL source. Repeatable.",
+    )
     p_friction_scan.add_argument("--max-files", type=int, default=5000, help="Maximum source files to scan.")
     p_friction_scan.add_argument("--max-candidates", type=int, default=200, help="Maximum candidates to record.")
     p_friction_scan.add_argument(
@@ -75,6 +83,7 @@ def dispatch(args) -> int:
             import_candidates=args.import_candidates,
             dry_run=args.dry_run,
             json_output=args.json,
+            miseledger_paths=args.miseledger_paths,
         )
     if args.friction_command == "show":
         return friction_cmd.show(target=args.target, severity=args.severity, json_output=args.json)

--- a/src/brigade/cli/receipts.py
+++ b/src/brigade/cli/receipts.py
@@ -33,6 +33,11 @@ def register(sub: argparse._SubParsersAction) -> None:
         "--import", dest="import_miseledger", action="store_true", help="Import the JSONL with miseledger."
     )
     p_miseledger.set_defaults(func=dispatch)
+    for projection in ("otel-genai", "openinference"):
+        parser = export_sub.add_parser(projection, help=f"Export privacy-safe {projection} span JSONL.")
+        parser.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
+        parser.add_argument("--out", default="-", help="Output path, or '-' for stdout.")
+        parser.set_defaults(func=dispatch)
 
 
 def dispatch(args) -> int:
@@ -49,6 +54,14 @@ def dispatch(args) -> int:
             limit=args.limit,
             new_only=args.new_only,
             import_miseledger=args.import_miseledger,
+        )
+    if args.receipts_command == "export" and args.receipts_export_command in {"otel-genai", "openinference"}:
+        from .. import telemetry_export
+
+        return telemetry_export.export(
+            target=args.target,
+            projection=args.receipts_export_command,
+            out=args.out,
         )
     args._brigade_parser.error(f"unknown receipts command: {args.receipts_command}")
     return 2

--- a/src/brigade/cli/skills.py
+++ b/src/brigade/cli/skills.py
@@ -25,6 +25,9 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_skills_lint.add_argument("skill", help="Skill id, path, or directory.")
     p_skills_lint.add_argument("--target", "-t", type=Path, default=Path("."), help="Workspace registry to inspect.")
     p_skills_lint.add_argument("--harness", default=None, help="Optional harness adapter to validate rendered output.")
+    p_skills_lint.add_argument(
+        "--mode", choices=["strict", "lenient"], default="strict", help="Agent Skills validation mode."
+    )
     p_skills_lint.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
     p_skills_doctor = skills_sub.add_parser("doctor", help="Check reviewed skill registry health.")
     p_skills_doctor.add_argument("--target", "-t", type=Path, default=Path("."), help="Workspace registry to inspect.")
@@ -186,7 +189,9 @@ def dispatch(args) -> int:
             json_output=args.json,
         )
     if args.skills_command == "lint":
-        return skills_cmd.lint(target=args.target, skill=args.skill, harness=args.harness, json_output=args.json)
+        return skills_cmd.lint(
+            target=args.target, skill=args.skill, harness=args.harness, mode=args.mode, json_output=args.json
+        )
     if args.skills_command == "doctor":
         return skills_cmd.doctor(target=args.target, json_output=args.json)
     if args.skills_command == "import-issues":

--- a/src/brigade/friction_cmd.py
+++ b/src/brigade/friction_cmd.py
@@ -133,7 +133,8 @@ def _parse_since(days: int) -> datetime:
 
 
 def _candidate_id(source: str, friction_type: str, text: str) -> str:
-    digest = hashlib.sha256(f"{source}\0{friction_type}\0{text}".encode("utf-8")).hexdigest()[:12]
+    del source
+    digest = hashlib.sha256(f"{friction_type}\0{text}".encode("utf-8")).hexdigest()[:12]
     return f"friction-{digest}"
 
 
@@ -159,10 +160,12 @@ def _iter_files(roots: list[Path], *, since: datetime, max_files: int) -> tuple[
     files: list[Path] = []
     skipped = 0
     cutoff = since.timestamp()
+    per_root = max(1, max_files // max(1, len(roots)))
     for root in roots:
+        root_count = 0
         candidates = [root] if root.is_file() else root.rglob("*")
         for path in candidates:
-            if len(files) >= max_files:
+            if len(files) >= max_files or root_count >= per_root:
                 skipped += 1
                 continue
             if not path.is_file() or path.suffix.lower() not in TEXT_SUFFIXES:
@@ -176,6 +179,7 @@ def _iter_files(roots: list[Path], *, since: datetime, max_files: int) -> tuple[
                 skipped += 1
                 continue
             files.append(path)
+            root_count += 1
     return files, skipped
 
 
@@ -371,7 +375,195 @@ def _make_candidate(target: Path, match: Match) -> dict[str, Any]:
             "snippet": snippet,
         },
         "suggested_fix": "Review the evidence, decide whether this is actionable, then promote to a task, note, memory card, rule, or tool fix.",
+        "detection": "regex",
     }
+
+
+def _structured_candidate(
+    *,
+    target: Path,
+    path: Path,
+    family: str,
+    event_type: str,
+    friction_type: str,
+    severity: str,
+    operation: str,
+    detail: str,
+    adapter: str | None = None,
+    error_class: str | None = None,
+) -> dict[str, Any]:
+    try:
+        source = str(path.resolve().relative_to(target))
+    except ValueError:
+        source = str(path)
+    recurrence_key = "|".join(
+        str(value or "") for value in (event_type, friction_type, adapter, error_class, operation)
+    )
+    snippet = _short(detail)
+    return {
+        "id": _candidate_id("", friction_type, recurrence_key),
+        "title": f"structured {friction_type.replace('_', ' ')}",
+        "text": f"{operation}: {snippet}",
+        "status": "candidate",
+        "kind": "finding",
+        "source": "friction-scan",
+        "source_family": family,
+        "detection": "structured",
+        "event_type": event_type,
+        "friction_type": friction_type,
+        "severity": severity,
+        "workflow": _workflow_from_path(target, path),
+        "adapter": adapter,
+        "error_class": error_class,
+        "operation": operation,
+        "recurrence_key": recurrence_key,
+        "evidence": {"path": source, "line": 1, "snippet": snippet},
+        "suggested_fix": "Inspect the typed receipt and fix the recurring operation or adapter failure.",
+    }
+
+
+def _read_object(path: Path) -> dict[str, Any] | None:
+    try:
+        value = json.loads(path.read_text(errors="replace"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _structured_families(target: Path, miseledger_paths: list[Path] | None) -> dict[str, list[dict[str, Any]]]:
+    families: dict[str, list[dict[str, Any]]] = {
+        "verification": [],
+        "run": [],
+        "evaluation": [],
+        "miseledger": [],
+    }
+    verify_root = target / ".brigade" / "work" / "verify-runs"
+    for path in sorted(verify_root.glob("*/receipt.json")) if verify_root.is_dir() else []:
+        for match in _scan_receipt(path):
+            families["verification"].append(
+                _structured_candidate(
+                    target=target,
+                    path=path,
+                    family="verification",
+                    event_type="verification_failure",
+                    friction_type=match.friction_type,
+                    severity=match.severity,
+                    operation="work.verify",
+                    detail=match.line,
+                    error_class=match.friction_type,
+                )
+            )
+    runs_root = target / ".brigade" / "runs"
+    for path in sorted(runs_root.glob("*/worker-results.json")) if runs_root.is_dir() else []:
+        payload = _read_object(path)
+        for result in payload.get("results", []) if payload is not None else []:
+            if not isinstance(result, dict) or result.get("ok") is True:
+                continue
+            detail = str(result.get("detail") or "worker failed")
+            families["run"].append(
+                _structured_candidate(
+                    target=target,
+                    path=path,
+                    family="run",
+                    event_type="adapter_failure",
+                    friction_type="tool_failure",
+                    severity="high",
+                    operation=f"run.worker.{result.get('worker') or 'unknown'}",
+                    detail=detail,
+                    adapter=str(result.get("transport") or "direct"),
+                    error_class="timeout" if result.get("timed_out") else "adapter_error",
+                )
+            )
+    eval_root = target / ".brigade" / "evals"
+    for path in sorted(eval_root.glob("*/cells/*/cell.json")) if eval_root.is_dir() else []:
+        payload = _read_object(path)
+        if payload is None:
+            continue
+        state = payload.get("state")
+        if state not in {"execution_error", "adapter_error", "grader_error", "rejected"}:
+            continue
+        families["evaluation"].append(
+            _structured_candidate(
+                target=target,
+                path=path,
+                family="evaluation",
+                event_type="evaluation_failure",
+                friction_type=str(state),
+                severity="high" if state != "rejected" else "medium",
+                operation=f"model.trial.{payload.get('case_id') or 'unknown'}",
+                detail=f"cell {payload.get('cell_id')} ended in {state}",
+                adapter=str(payload.get("seat") or "unknown"),
+                error_class=str(state),
+            )
+        )
+    for path in miseledger_paths or []:
+        resolved = path.expanduser().resolve()
+        try:
+            lines = resolved.read_text(errors="replace").splitlines()
+        except OSError:
+            continue
+        for line in lines:
+            try:
+                item = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(item, dict):
+                continue
+            status = str(item.get("status") or item.get("state") or "")
+            if status in {"", "ok", "completed", "accepted", "success"}:
+                continue
+            families["miseledger"].append(
+                _structured_candidate(
+                    target=target,
+                    path=resolved,
+                    family="miseledger",
+                    event_type="miseledger_failure",
+                    friction_type="tool_failure",
+                    severity="high",
+                    operation=str(item.get("operation") or item.get("type") or "miseledger.item"),
+                    detail=str(item.get("detail") or item.get("error") or status),
+                    error_class=status,
+                )
+            )
+    return families
+
+
+def _quota_select(families: dict[str, list[dict[str, Any]]], limit: int) -> tuple[list[dict[str, Any]], dict[str, int]]:
+    names = [name for name, items in families.items() if items]
+    selected: list[dict[str, Any]] = []
+    use: dict[str, int] = {name: 0 for name in families}
+    if not names:
+        return selected, use
+    quota = max(1, limit // len(names))
+    remaining: list[tuple[str, dict[str, Any]]] = []
+    for name in names:
+        items = families[name]
+        for item in items[:quota]:
+            selected.append(item)
+            use[name] += 1
+        remaining.extend((name, item) for item in items[quota:])
+    for name, item in remaining:
+        if len(selected) >= limit:
+            break
+        selected.append(item)
+        use[name] += 1
+    return selected[:limit], use
+
+
+def _dedupe_families(families: dict[str, list[dict[str, Any]]]) -> int:
+    seen: set[str] = set()
+    duplicates = 0
+    for name, items in families.items():
+        unique: list[dict[str, Any]] = []
+        for item in items:
+            item_id = str(item.get("id") or "")
+            if item_id in seen:
+                duplicates += 1
+                continue
+            seen.add(item_id)
+            unique.append(item)
+        families[name] = unique
+    return duplicates
 
 
 def scan_payload(
@@ -381,6 +573,7 @@ def scan_payload(
     include_agent_logs: bool = False,
     max_files: int = 5000,
     max_candidates: int = 200,
+    miseledger_paths: list[Path] | None = None,
 ) -> tuple[dict[str, Any] | None, int]:
     target = target.expanduser().resolve()
     if not target.is_dir():
@@ -400,29 +593,39 @@ def scan_payload(
 
     roots = _iter_source_roots(target, include_agent_logs=include_agent_logs)
     files, skipped_files = _iter_files(roots, since=since, max_files=max_files)
-    candidates: list[dict[str, Any]] = []
+    families = _structured_families(target, miseledger_paths)
+    regex_candidates: list[dict[str, Any]] = []
     seen_ids: set[str] = set()
     type_counts: dict[str, int] = {}
     severity_counts: dict[str, int] = {}
     workflow_counts: dict[str, int] = {}
     for path in files:
+        if _is_verify_receipt(path) or path.name in {"run.json", "worker-results.json", "cell.json"}:
+            continue
         matches = _scan_receipt(path) if _is_verify_receipt(path) else _scan_file(path)
         for match in matches:
             candidate = _make_candidate(target, match)
             if candidate["id"] in seen_ids:
                 continue
             seen_ids.add(str(candidate["id"]))
-            candidates.append(candidate)
+            candidate["source_family"] = "regex"
+            regex_candidates.append(candidate)
             type_counts[str(candidate["friction_type"])] = type_counts.get(str(candidate["friction_type"]), 0) + 1
             severity_counts[str(candidate["severity"])] = severity_counts.get(str(candidate["severity"]), 0) + 1
             workflow_counts[str(candidate["workflow"])] = workflow_counts.get(str(candidate["workflow"]), 0) + 1
-            if len(candidates) >= max_candidates:
-                break
-        if len(candidates) >= max_candidates:
-            break
+    families["regex"] = regex_candidates
+    duplicate_count = _dedupe_families(families)
+    candidates, quota_use = _quota_select(families, max_candidates)
+    type_counts = {}
+    severity_counts = {}
+    workflow_counts = {}
+    for candidate in candidates:
+        type_counts[str(candidate["friction_type"])] = type_counts.get(str(candidate["friction_type"]), 0) + 1
+        severity_counts[str(candidate["severity"])] = severity_counts.get(str(candidate["severity"]), 0) + 1
+        workflow_counts[str(candidate["workflow"])] = workflow_counts.get(str(candidate["workflow"]), 0) + 1
 
     payload = {
-        "version": 1,
+        "version": 2,
         "generated_at": _now().isoformat(),
         "target": str(target),
         "days": days,
@@ -432,7 +635,12 @@ def scan_payload(
         "files_scanned": len(files),
         "files_skipped": skipped_files,
         "candidate_count": len(candidates),
-        "truncated": len(candidates) >= max_candidates,
+        "truncated": sum(len(items) for items in families.values()) > len(candidates),
+        "structured_hits": sum(1 for item in candidates if item.get("detection") == "structured"),
+        "regex_hits": sum(1 for item in candidates if item.get("detection") == "regex"),
+        "duplicates": duplicate_count,
+        "rejected_noise": 0,
+        "quota_use": quota_use,
         "counts": {
             "by_type": dict(sorted(type_counts.items())),
             "by_severity": dict(sorted(severity_counts.items())),
@@ -596,6 +804,7 @@ def scan(
     import_candidates: bool = False,
     dry_run: bool = False,
     json_output: bool = False,
+    miseledger_paths: list[Path] | None = None,
 ) -> int:
     payload, code = scan_payload(
         target=target,
@@ -603,6 +812,7 @@ def scan(
         include_agent_logs=include_agent_logs,
         max_files=max_files,
         max_candidates=max_candidates,
+        miseledger_paths=miseledger_paths,
     )
     if payload is None:
         return code

--- a/src/brigade/skills_cmd.py
+++ b/src/brigade/skills_cmd.py
@@ -424,7 +424,7 @@ def _registry_import_payload(
     )
     metadata["fingerprint"] = _fingerprint(dest)
     _write_json(_metadata_path(dest), metadata)
-    lint_payload = _lint_payload(target, resolved_id)
+    lint_payload = _lint_payload(target, resolved_id, mode="lenient")
     return (
         {"target": str(target), "skill_id": resolved_id, "skill_dir": str(dest), "lint": lint_payload},
         None,
@@ -443,7 +443,11 @@ def _load_skill(target: Path, skill_or_path: str) -> tuple[Path, dict[str, Any]]
     return skill_dir, metadata
 
 
-def _lint_payload(target: Path, skill_or_path: str, harness: str | None = None) -> dict[str, Any]:
+def _lint_payload(
+    target: Path, skill_or_path: str, harness: str | None = None, *, mode: str = "lenient"
+) -> dict[str, Any]:
+    from . import agent_skill_format
+
     skill_dir, metadata = _load_skill(target, skill_or_path)
     skill_md = _skill_md_path(skill_dir)
     errors: list[str] = []
@@ -467,6 +471,9 @@ def _lint_payload(target: Path, skill_or_path: str, harness: str | None = None) 
     for key in ("required_tools", "required_mcp_servers", "supported_harnesses", "tests"):
         if key in metadata and not isinstance(metadata[key], list):
             errors.append(f"metadata {key} must be a list")
+    format_result = agent_skill_format.validate(skill_dir, mode=mode)
+    errors.extend(format_result.errors)
+    warnings.extend(format_result.diagnostics)
     if harness is not None:
         adapters = _adapter_map(target)
         adapter = adapters.get(harness)
@@ -499,6 +506,12 @@ def _lint_payload(target: Path, skill_or_path: str, harness: str | None = None) 
             "markers": injection.markers,
         },
         "metadata": metadata,
+        "agent_skills": {
+            "mode": mode,
+            "fields": format_result.fields,
+            "diagnostics": list(format_result.diagnostics),
+            "allowed_tools_are_permissions": False,
+        },
         "fingerprint": _fingerprint(skill_dir) if skill_dir.is_dir() else None,
     }
     payload["changelog"] = (
@@ -586,9 +599,11 @@ def import_skill(
     return rc
 
 
-def lint(*, target: Path, skill: str, harness: str | None = None, json_output: bool = False) -> int:
+def lint(
+    *, target: Path, skill: str, harness: str | None = None, mode: str = "lenient", json_output: bool = False
+) -> int:
     target = target.expanduser().resolve()
-    payload = _lint_payload(target, skill, harness=harness)
+    payload = _lint_payload(target, skill, harness=harness, mode=mode)
     if json_output:
         print(json.dumps(payload, indent=2, sort_keys=True))
         return 0 if payload["valid"] else 1

--- a/src/brigade/telemetry_export.py
+++ b/src/brigade/telemetry_export.py
@@ -1,0 +1,145 @@
+"""Privacy-safe projections of Brigade run receipts into telemetry conventions."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from . import localio
+
+OTEL_MAPPING = {
+    "name": "otel-genai",
+    "mapping_version": 1,
+    "upstream_revision": "opentelemetry-semconv-1.43.0",
+}
+OPENINFERENCE_MAPPING = {
+    "name": "openinference",
+    "mapping_version": 1,
+    "upstream_revision": "audited-2026-07-12",
+}
+
+
+def _object(path: Path) -> dict[str, Any] | None:
+    try:
+        value = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _ids(run_id: str, seat: str, ordinal: int) -> tuple[str, str]:
+    trace = hashlib.sha256(f"brigade:{run_id}".encode()).hexdigest()[:32]
+    span = hashlib.sha256(f"brigade:{run_id}:{seat}:{ordinal}".encode()).hexdigest()[:16]
+    return trace, span
+
+
+def _provider(cli: str) -> str | None:
+    if cli in {"codex", "opencode", "pi"}:
+        return "openai"
+    if cli == "claude":
+        return "anthropic"
+    if cli == "grok":
+        return "x_ai"
+    return None
+
+
+def _base(run_id: str, run: dict[str, Any], seat: str, result: dict[str, Any], ordinal: int) -> dict[str, Any]:
+    trace_id, span_id = _ids(run_id, seat, ordinal)
+    return {
+        "trace_id": trace_id,
+        "span_id": span_id,
+        "name": "brigade.run.worker",
+        "start_time": run.get("started_at"),
+        "end_time": run.get("finished_at"),
+        "duration_seconds": result.get("duration_seconds"),
+        "status": "OK" if result.get("ok") is True else "ERROR",
+        "error_type": None if result.get("ok") is True else str(result.get("detail") or "worker_error")[:120],
+        "seat": seat,
+        "adapter": result.get("transport") or "cli",
+        "requested_model": result.get("requested_model"),
+        "effective_model": result.get("effective_model"),
+        "reasoning": result.get("reasoning"),
+        "stop_reason": result.get("stop_reason"),
+        "exit_code": result.get("exit_code"),
+    }
+
+
+def _otel(base: dict[str, Any], cli: str) -> dict[str, Any]:
+    attributes: dict[str, Any] = {
+        "gen_ai.operation.name": "invoke_agent",
+        "brigade.seat.name": base["seat"],
+        "brigade.adapter.name": base["adapter"],
+    }
+    provider = _provider(cli)
+    if provider is not None:
+        attributes["gen_ai.provider.name"] = provider
+    if base["requested_model"] is not None:
+        attributes["gen_ai.request.model"] = base["requested_model"]
+    if base["effective_model"] is not None:
+        attributes["gen_ai.response.model"] = base["effective_model"]
+    if base["stop_reason"] is not None:
+        attributes["gen_ai.response.finish_reasons"] = [base["stop_reason"]]
+    if base["error_type"] is not None:
+        attributes["error.type"] = base["error_type"]
+    return {"schema": "brigade.otel_genai_projection.v1", "mapping": OTEL_MAPPING, **base, "attributes": attributes}
+
+
+def _openinference(base: dict[str, Any]) -> dict[str, Any]:
+    attributes: dict[str, Any] = {
+        "openinference.span.kind": "AGENT",
+        "brigade.seat.name": base["seat"],
+        "brigade.adapter.name": base["adapter"],
+    }
+    model = base["effective_model"] or base["requested_model"]
+    if model is not None:
+        attributes["llm.model_name"] = model
+    return {
+        "schema": "brigade.openinference_projection.v1",
+        "mapping": OPENINFERENCE_MAPPING,
+        **base,
+        "attributes": attributes,
+    }
+
+
+def records(target: Path, projection: str) -> list[dict[str, Any]]:
+    target = target.expanduser().resolve()
+    rows: list[dict[str, Any]] = []
+    root = target / ".brigade" / "runs"
+    for run_dir in sorted(root.iterdir()) if root.is_dir() else []:
+        if not run_dir.is_dir():
+            continue
+        run = _object(run_dir / "run.json")
+        roster = _object(run_dir / "roster.json")
+        workers = _object(run_dir / "worker-results.json")
+        if run is None or roster is None or workers is None:
+            continue
+        agents = roster.get("agents")
+        if not isinstance(agents, dict):
+            continue
+        for ordinal, result in enumerate(workers.get("results", []), start=1):
+            if not isinstance(result, dict) or not isinstance(result.get("worker"), str):
+                continue
+            seat = result["worker"]
+            agent = agents.get(seat)
+            if not isinstance(agent, dict):
+                continue
+            cli = str(agent.get("cli") or "unknown")
+            base = _base(run_dir.name, run, seat, result, ordinal)
+            rows.append(_otel(base, cli) if projection == "otel-genai" else _openinference(base))
+    return rows
+
+
+def export(*, target: Path, projection: str, out: str = "-") -> int:
+    rows = records(target, projection)
+    if not rows:
+        print("error: no Brigade worker receipts found", file=sys.stderr)
+        return 1
+    rendered = "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows)
+    if out == "-":
+        sys.stdout.write(rendered)
+    else:
+        localio.write_text_atomic(Path(out).expanduser(), rendered)
+    return 0

--- a/src/brigade/telemetry_export.py
+++ b/src/brigade/telemetry_export.py
@@ -37,13 +37,24 @@ def _ids(run_id: str, seat: str, ordinal: int) -> tuple[str, str]:
 
 
 def _provider(cli: str) -> str | None:
-    if cli in {"codex", "opencode", "pi"}:
+    if cli == "codex":
         return "openai"
     if cli == "claude":
         return "anthropic"
     if cli == "grok":
         return "x_ai"
     return None
+
+
+def _error_type(result: dict[str, Any]) -> str | None:
+    if result.get("ok") is True:
+        return None
+    if result.get("timed_out") is True:
+        return "timeout"
+    exit_code = result.get("exit_code")
+    if isinstance(exit_code, int) and not isinstance(exit_code, bool):
+        return "process_error"
+    return "worker_error"
 
 
 def _base(run_id: str, run: dict[str, Any], seat: str, result: dict[str, Any], ordinal: int) -> dict[str, Any]:
@@ -56,7 +67,7 @@ def _base(run_id: str, run: dict[str, Any], seat: str, result: dict[str, Any], o
         "end_time": run.get("finished_at"),
         "duration_seconds": result.get("duration_seconds"),
         "status": "OK" if result.get("ok") is True else "ERROR",
-        "error_type": None if result.get("ok") is True else str(result.get("detail") or "worker_error")[:120],
+        "error_type": _error_type(result),
         "seat": seat,
         "adapter": result.get("transport") or "cli",
         "requested_model": result.get("requested_model"),

--- a/tests/test_agent_skill_format.py
+++ b/tests/test_agent_skill_format.py
@@ -38,6 +38,7 @@ def test_strict_rejects_unknown_and_lenient_retains_diagnostic(tmp_path):
     assert "unknown frontmatter field: future-field" in strict.errors
     assert lenient.errors == ()
     assert lenient.diagnostics == ("unknown frontmatter field retained: future-field",)
+    assert lenient.fields["future-field"] == "value"
 
 
 def test_name_description_and_exact_casing_are_enforced(tmp_path):

--- a/tests/test_agent_skill_format.py
+++ b/tests/test_agent_skill_format.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from brigade import agent_skill_format
+
+
+def _skill(tmp_path, name: str, frontmatter: str):
+    directory = tmp_path / name
+    directory.mkdir()
+    (directory / "SKILL.md").write_text(f"---\n{frontmatter}---\n\n# Body\n")
+    return directory
+
+
+def test_strict_accepts_agent_skills_fields_and_treats_tools_as_requirements(tmp_path):
+    directory = _skill(
+        tmp_path,
+        "code-review",
+        "name: code-review\n"
+        "description: Review a change.\n"
+        "license: MIT\n"
+        "compatibility: Requires git.\n"
+        "allowed-tools: read, grep\n"
+        "metadata:\n  owner: team\n",
+    )
+    result = agent_skill_format.validate(directory, mode="strict")
+    assert result.errors == ()
+    assert result.fields["allowed-tools"] == ("read", "grep")
+    assert result.fields["metadata"] == {"owner": "team"}
+
+
+def test_strict_rejects_unknown_and_lenient_retains_diagnostic(tmp_path):
+    directory = _skill(
+        tmp_path,
+        "code-review",
+        "name: code-review\ndescription: Review a change.\nfuture-field: value\n",
+    )
+    strict = agent_skill_format.validate(directory, mode="strict")
+    lenient = agent_skill_format.validate(directory, mode="lenient")
+    assert "unknown frontmatter field: future-field" in strict.errors
+    assert lenient.errors == ()
+    assert lenient.diagnostics == ("unknown frontmatter field retained: future-field",)
+
+
+def test_name_description_and_exact_casing_are_enforced(tmp_path):
+    directory = _skill(tmp_path, "Bad_Name", "name: Bad_Name\ndescription: x\n")
+    result = agent_skill_format.validate(directory, mode="strict")
+    assert any("lowercase identifier" in error for error in result.errors)
+
+    wrong = tmp_path / "lowercase"
+    wrong.mkdir()
+    (wrong / "skill.md").write_text("---\nname: lowercase\ndescription: x\n---\n")
+    result = agent_skill_format.validate(wrong, mode="strict")
+    assert any("SKILL.md not found" in error for error in result.errors)

--- a/tests/test_friction_cmd.py
+++ b/tests/test_friction_cmd.py
@@ -168,6 +168,7 @@ def test_friction_scan_json_dry_run_does_not_write(tmp_path, monkeypatch, capsys
     assert code == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["candidate_count"] == 1
+    assert payload["candidates"][0]["friction_type"] == "blocked"
     assert payload["output"]["dry_run"] is True
     assert not (tmp_path / ".brigade" / "friction" / "latest.json").exists()
 
@@ -320,4 +321,72 @@ def test_friction_scan_ignores_numeric_json_fields(tmp_path, monkeypatch, capsys
     assert code == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["candidate_count"] == 1
-    assert payload["candidates"][0]["friction_type"] == "blocked"
+
+
+def test_friction_v2_preserves_each_typed_source_family_before_truncation(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(
+        friction_cmd,
+        "_now",
+        lambda: datetime(2026, 6, 11, 12, 0, 0, tzinfo=timezone.utc),
+    )
+    verify = tmp_path / ".brigade" / "work" / "verify-runs" / "v1"
+    verify.mkdir(parents=True)
+    (verify / "receipt.json").write_text(
+        json.dumps({"status": "failed", "commands": [{"command": "check", "exit_code": 1, "status": "failed"}]})
+    )
+    run = tmp_path / ".brigade" / "runs" / "r1"
+    run.mkdir(parents=True)
+    (run / "worker-results.json").write_text(
+        json.dumps({"results": [{"worker": "composer", "ok": False, "detail": "empty output"}]})
+    )
+    cell = tmp_path / ".brigade" / "evals" / "e1" / "cells" / "c1"
+    cell.mkdir(parents=True)
+    (cell / "cell.json").write_text(
+        json.dumps({"cell_id": "c1", "case_id": "case", "seat": "composer", "state": "rejected"})
+    )
+    ledger = tmp_path / "ledger.jsonl"
+    ledger.write_text(json.dumps({"status": "failed", "operation": "archive", "error": "locked"}) + "\n")
+    notes = tmp_path / "notes"
+    notes.mkdir()
+    (notes / "issue.md").write_text("Manual workflow was blocked because docs were missing.\n")
+
+    rc = cli.main(
+        [
+            "friction",
+            "scan",
+            "--target",
+            str(tmp_path),
+            "--miseledger",
+            str(ledger),
+            "--max-candidates",
+            "5",
+            "--json",
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert {item["source_family"] for item in payload["candidates"]} == {
+        "verification",
+        "run",
+        "evaluation",
+        "miseledger",
+        "regex",
+    }
+    assert payload["structured_hits"] == 4
+    assert payload["regex_hits"] == 1
+    assert all(value == 1 for value in payload["quota_use"].values())
+
+
+def test_structured_recurrence_dedupes_across_receipt_paths(tmp_path, capsys):
+    for run_id in ("r1", "r2"):
+        run = tmp_path / ".brigade" / "runs" / run_id
+        run.mkdir(parents=True)
+        (run / "worker-results.json").write_text(
+            json.dumps({"results": [{"worker": "composer", "ok": False, "detail": "same failure"}]})
+        )
+
+    assert cli.main(["friction", "scan", "--target", str(tmp_path), "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["candidate_count"] == 1
+    assert payload["duplicates"] == 1

--- a/tests/test_telemetry_export.py
+++ b/tests/test_telemetry_export.py
@@ -52,3 +52,35 @@ def test_openinference_projection_is_content_free(tmp_path, capsys):
     assert row["attributes"]["openinference.span.kind"] == "AGENT"
     assert row["attributes"]["llm.model_name"] == "grok-4.5"
     assert "input.value" not in raw and "output.value" not in raw
+
+
+def test_failed_projection_uses_normalized_error_without_detail(tmp_path, capsys):
+    _run(tmp_path)
+    path = tmp_path / ".brigade" / "runs" / "run-1" / "worker-results.json"
+    payload = json.loads(path.read_text())
+    payload["results"][0].update(
+        {
+            "ok": False,
+            "detail": "Bearer secret-token at /home/example/private",
+            "exit_code": 1,
+        }
+    )
+    path.write_text(json.dumps(payload))
+
+    assert cli.main(["receipts", "export", "otel-genai", "--target", str(tmp_path)]) == 0
+    raw = capsys.readouterr().out
+    row = json.loads(raw)
+    assert row["error_type"] == "process_error"
+    assert row["attributes"]["error.type"] == "process_error"
+    assert "secret-token" not in raw
+    assert "/home/example" not in raw
+
+
+def test_multiprovider_cli_does_not_guess_provider(tmp_path, capsys):
+    _run(tmp_path)
+    roster_path = tmp_path / ".brigade" / "runs" / "run-1" / "roster.json"
+    roster_path.write_text(json.dumps({"agents": {"worker": {"cli": "opencode", "model": "anthropic/claude"}}}))
+
+    assert cli.main(["receipts", "export", "otel-genai", "--target", str(tmp_path)]) == 0
+    row = json.loads(capsys.readouterr().out)
+    assert "gen_ai.provider.name" not in row["attributes"]

--- a/tests/test_telemetry_export.py
+++ b/tests/test_telemetry_export.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+
+from brigade import cli
+
+
+def _run(tmp_path):
+    run = tmp_path / ".brigade" / "runs" / "run-1"
+    run.mkdir(parents=True)
+    (run / "run.json").write_text(
+        json.dumps({"started_at": "2026-01-01T00:00:00Z", "finished_at": "2026-01-01T00:00:02Z", "task": "SECRET"})
+    )
+    (run / "roster.json").write_text(json.dumps({"agents": {"worker": {"cli": "grok", "model": "grok-4.5"}}}))
+    (run / "worker-results.json").write_text(
+        json.dumps(
+            {
+                "results": [
+                    {
+                        "worker": "worker",
+                        "ok": True,
+                        "text": "PRIVATE OUTPUT",
+                        "duration_seconds": 2.0,
+                        "transport": "acpx",
+                        "requested_model": "grok-4.5",
+                        "effective_model": "grok-4.5",
+                        "stop_reason": "end_turn",
+                        "exit_code": 0,
+                    }
+                ]
+            }
+        )
+    )
+
+
+def test_otel_projection_uses_genai_names_and_omits_content(tmp_path, capsys):
+    _run(tmp_path)
+    assert cli.main(["receipts", "export", "otel-genai", "--target", str(tmp_path)]) == 0
+    raw = capsys.readouterr().out
+    row = json.loads(raw)
+    assert row["attributes"]["gen_ai.operation.name"] == "invoke_agent"
+    assert row["attributes"]["gen_ai.provider.name"] == "x_ai"
+    assert row["attributes"]["gen_ai.request.model"] == "grok-4.5"
+    assert "SECRET" not in raw and "PRIVATE OUTPUT" not in raw
+
+
+def test_openinference_projection_is_content_free(tmp_path, capsys):
+    _run(tmp_path)
+    assert cli.main(["receipts", "export", "openinference", "--target", str(tmp_path)]) == 0
+    raw = capsys.readouterr().out
+    row = json.loads(raw)
+    assert row["attributes"]["openinference.span.kind"] == "AGENT"
+    assert row["attributes"]["llm.model_name"] == "grok-4.5"
+    assert "input.value" not in raw and "output.value" not in raw


### PR DESCRIPTION
## What changed

- Add typed friction ingestion with source quotas and noise accounting.
- Validate Agent Skills packages in strict and lenient modes while retaining unknown values.
- Export content-free OpenTelemetry GenAI and OpenInference receipt projections.
- Normalize telemetry errors and omit provider attribution when the receipt does not prove it.

## Why

Friction, skill, and telemetry data should be machine-readable without exporting prompts, responses, tool arguments, retrieved content, or raw failure details.

## Verification

- Full `./scripts/verify`: 2,179 passed, 3 skipped, coverage 81.21%.
