### PR TITLE
feat(run): add bounded lock waiting

### DIFF
--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -327,6 +327,7 @@ brigade run "review this repo" --read-only --inspect
 brigade run "make the change" --allow-dirty
 brigade run "make the change" --worktree
 brigade run "make the change" --detach
+brigade run "serialize behind an active run" --wait=120
 ```
 
 The examples above all drive the same `brigade run` command to show its main flags. Brigade's full surface (work loop, scanners, handoffs, tools, release gates, repo fleet, and more) is documented section by section below. For the complete, auto-generated list of every command, see [`docs/command-inventory.md`](command-inventory.md), and regenerate it with `BRIGADE_EXTRAS=1 brigade roadmap commands --write`.
@@ -335,6 +336,7 @@ Common `brigade run` flags:
 
 - `--dry-run` prints planned assignments as JSON and stops before worker dispatch.
 - `--detach` starts the run in a child process, writes child output to `detached.log`, and returns after `run.json` appears.
+- `--wait[=SECONDS]` waits for the target's active run lock instead of failing immediately. A bare `--wait` waits up to 600 seconds. Without this flag, lock conflicts remain fail-fast.
 - `--allow-dirty` bypasses the default dirty-git-worktree guard.
 - `--worktree` runs agents in a detached git worktree and captures `changes.patch`.
 - `--show-plan` prints assignments before a normal run.

--- a/src/brigade/cli/run.py
+++ b/src/brigade/cli/run.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import math
 import sys
 import time
 from pathlib import Path
@@ -11,6 +12,17 @@ from subprocess import DEVNULL, STDOUT, Popen
 
 _DETACH_START_TIMEOUT_SECONDS = 30.0
 _DETACH_POLL_INTERVAL_SECONDS = 0.05
+_DEFAULT_RUN_LOCK_WAIT_SECONDS = 600.0
+
+
+def _non_negative_seconds(value: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a number of seconds") from exc
+    if not math.isfinite(parsed) or parsed < 0:
+        raise argparse.ArgumentTypeError("must be a finite non-negative number of seconds")
+    return parsed
 
 
 def register(sub: argparse._SubParsersAction) -> None:
@@ -33,6 +45,18 @@ def register(sub: argparse._SubParsersAction) -> None:
         "--detach",
         action="store_true",
         help="Start the run in a detached child process and return after run metadata is written.",
+    )
+    p_run.add_argument(
+        "--wait",
+        nargs="?",
+        const=_DEFAULT_RUN_LOCK_WAIT_SECONDS,
+        default=0.0,
+        type=_non_negative_seconds,
+        metavar="SECONDS",
+        help=(
+            "Wait up to SECONDS for an active run lock instead of failing immediately "
+            f"(default with no value: {_DEFAULT_RUN_LOCK_WAIT_SECONDS:g}s)."
+        ),
     )
     p_run.add_argument(
         "--allow-dirty",
@@ -237,7 +261,7 @@ def dispatch(args) -> int:
     effective_cwd = run_cwd
     keep_worktree = False
     try:
-        with runguard.run_lock(run_cwd):
+        with runguard.run_lock(run_cwd, wait_seconds=args.wait):
             if args.worktree:
                 worktree_cwd = _worktree_checkout_path(runguard.git_root(run_cwd), output_dir)
                 effective_cwd = runguard.create_detached_worktree(run_cwd, worktree_cwd)
@@ -380,6 +404,8 @@ def _detached_child_argv(args, *, run_cwd: Path, roster_path: Path, output_dir: 
         argv.append("--read-only")
     if args.worker is not None:
         argv.extend(["--worker", args.worker])
+    if args.wait > 0:
+        argv.extend(["--wait", f"{args.wait:g}"])
     if args.no_code_graph:
         argv.append("--no-code-graph")
     if args.no_evidence:

--- a/src/brigade/runguard.py
+++ b/src/brigade/runguard.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import os
 import shutil
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -117,10 +118,25 @@ def _acquire_lock(path: Path) -> None:
 
 
 @contextlib.contextmanager
-def run_lock(cwd: Path):
+def run_lock(cwd: Path, *, wait_seconds: float = 0.0, poll_interval: float = 0.1):
+    if wait_seconds < 0:
+        raise ValueError("run lock wait_seconds must be non-negative")
+    if poll_interval <= 0:
+        raise ValueError("run lock poll_interval must be positive")
     path = lock_path(cwd)
     path.parent.mkdir(parents=True, exist_ok=True)
-    _acquire_lock(path)
+    deadline = time.monotonic() + wait_seconds
+    while True:
+        try:
+            _acquire_lock(path)
+            break
+        except RunLockError as exc:
+            if wait_seconds == 0:
+                raise
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise RunLockError(f"timed out after {wait_seconds:g}s waiting for run lock: {path}") from exc
+            time.sleep(min(poll_interval, remaining))
     try:
         yield path
     finally:

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -1,4 +1,5 @@
 import json
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -760,6 +761,26 @@ def test_run_cli_lock_conflict_errors(tmp_path, monkeypatch, capsys):
 
     assert rc == 2
     assert "another brigade run appears active" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(("wait_arg", "expected"), [("--wait=0.25", 0.25), ("--wait", 600.0)])
+def test_run_cli_passes_bounded_wait_to_run_lock(tmp_path, monkeypatch, wait_arg, expected):
+    repo = _git_repo_with_roster(tmp_path)
+    seen = {}
+
+    @contextmanager
+    def fake_lock(cwd, *, wait_seconds=0.0):
+        seen["cwd"] = cwd
+        seen["wait_seconds"] = wait_seconds
+        yield
+
+    monkeypatch.setattr(runguard, "run_lock", fake_lock)
+    monkeypatch.setattr(aboyeur, "run", lambda *args, **kwargs: 0)
+
+    rc = cli.main(["run", "x", "--cwd", str(repo), wait_arg, "--no-artifacts"])
+
+    assert rc == 0
+    assert seen == {"cwd": repo, "wait_seconds": expected}
 
 
 def test_run_cli_worktree_passes_detached_cwd_and_writes_changes_patch(tmp_path, monkeypatch):

--- a/tests/test_run_detach.py
+++ b/tests/test_run_detach.py
@@ -111,6 +111,7 @@ def test_run_detach_child_argv_preserves_worker(tmp_path):
         handoff=False,
         handoff_inbox=None,
         worker="coder",
+        wait=2.5,
     )
     roster_path = tmp_path / "roster.toml"
     output_dir = tmp_path / "run"
@@ -124,3 +125,4 @@ def test_run_detach_child_argv_preserves_worker(tmp_path):
 
     assert "--worker" in argv
     assert argv[argv.index("--worker") + 1] == "coder"
+    assert argv[argv.index("--wait") + 1] == "2.5"

--- a/tests/test_runguard.py
+++ b/tests/test_runguard.py
@@ -67,6 +67,45 @@ def test_run_lock_rejects_lock_held_by_live_process(tmp_path):
             pass
 
 
+def test_run_lock_waits_until_live_lock_clears(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    lock_path = runguard.lock_path(repo)
+    lock_path.mkdir(parents=True)
+    (lock_path / "pid").write_text(f"{os.getpid()}\n")
+    sleeps = []
+
+    def release_lock(delay):
+        sleeps.append(delay)
+        (lock_path / "pid").unlink()
+        lock_path.rmdir()
+
+    monkeypatch.setattr(runguard.time, "sleep", release_lock)
+
+    with runguard.run_lock(repo, wait_seconds=1.0, poll_interval=0.05):
+        assert (lock_path / "pid").read_text().strip() == str(os.getpid())
+
+    assert sleeps == [0.05]
+    assert not lock_path.exists()
+
+
+def test_run_lock_wait_timeout_is_bounded(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    lock_path = runguard.lock_path(repo)
+    lock_path.mkdir(parents=True)
+    (lock_path / "pid").write_text(f"{os.getpid()}\n")
+    monotonic = iter((10.0, 10.0, 10.25))
+    sleeps = []
+    monkeypatch.setattr(runguard.time, "monotonic", lambda: next(monotonic))
+    monkeypatch.setattr(runguard.time, "sleep", sleeps.append)
+
+    with pytest.raises(runguard.RunLockError, match=r"timed out after 0.2s waiting for run lock"):
+        with runguard.run_lock(repo, wait_seconds=0.2, poll_interval=0.05):
+            pass
+
+    assert sleeps == [0.05]
+    assert lock_path.is_dir()
+
+
 def test_run_lock_replaces_lock_with_dead_pid(tmp_path):
     repo = _repo(tmp_path)
     lock_path = runguard.lock_path(repo)


### PR DESCRIPTION
Closes #212.

## Summary

- keep the existing fail-fast lock behavior by default
- add bounded `--wait` and `--wait=SECONDS` handling
- forward the wait duration to detached runs
- preserve stale-lock recovery without removing an active owner's lock

## Verification

`./scripts/verify` through Brigade: 2,201 passed, 3 skipped, 81.24% coverage.

Receipt: `.brigade/work/verify-runs/20260713-010443-work-verify-6b1e30/receipt.json`

Waiting serializes contenders but does not promise FIFO ordering.
