### PR TITLE
fix(run): align adapter execution modes

### DIFF
--- a/docs/model-ratings.md
+++ b/docs/model-ratings.md
@@ -71,9 +71,11 @@ What this run actually showed:
 - **Regex-only answer keys under-credit.** One seat in the pilot initially
   scored 50 on bug-hunt from phrasing variance alone. The cross-model judge
   pass corrected it to 90. Keep regexes for precision and judge the misses.
-- **Cursor composer models return empty text in plan mode** (issue #206), so
-  benchmark them in write mode with do-not-modify instructions, or their
-  read-only cells score a false 0.
+- **Direct Cursor plan mode cannot return Composer findings as assistant text**
+  (issue #206). Use a roster seat with `transport = "acpx"` and the reviewed
+  `transport_version` for read-only Composer cells. Direct Grok 4.5 Cursor
+  cells have also returned exit 0 with empty assistant text (issue #231), so
+  keep those failures in the adapter bucket instead of scoring them as model 0s.
 - **Adapter gaps are not model gaps.** The plain `claude -p` adapter cannot
   edit files headless. Give the model the same permissions the other seats get
   when you benchmark, then note the adapter limit in your roster instead.

--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -347,8 +347,7 @@ Common `brigade run` flags:
 - `--sandbox {read-only,workspace-write,danger-full-access}` overrides the native Codex sandbox mode from the roster.
 
 For `codex` agents, `--read-only` also passes `codex exec --sandbox read-only`.
-Combine `--sandbox` with `--read-only` to keep prompt-level read-only rules while overriding native sandbox behavior.
-Other adapters receive the prompt policy only.
+Combine `--sandbox` with `--read-only` to keep prompt-level read-only rules while overriding native Codex sandbox behavior. This override does not weaken adapters whose read-only flag takes precedence, including Cursor plan mode, Antigravity's sandbox, Kimi's plan mode, Aider's dry run, and Codex Cloud's remote isolation. Brigade's warning follows the command each adapter will execute.
 
 Direct worker runs still write normal run artifacts. The synthetic `plan.json`
 contains one assignment with the full task text, `worker-results.json` records
@@ -378,7 +377,22 @@ Both commands are local Unix socket requests. They refuse exec-transport runs, c
 
 The `cli` values are adapters for installed command-line tools:
 `codex`, `claude`, `opencode`, `antigravity`, `pi`, `cursor`, and `ollama:<model>`. Brigade shells out to those tools and keeps no provider keys.
-A `codex-cloud:<env-id>` seat is different: it submits the task to Codex Cloud with `codex cloud exec`, polls `codex cloud status` until the task reaches a terminal state (bounded by the seat timeout), and returns the final status plus the unified diff as the worker text. The diff is never applied to the local tree. Land it deliberately with `codex cloud apply <task-id>`; the task id is recorded on the worker result. Environment ids come from your Codex Cloud workspace (browse with `codex cloud`). Allow the seat with a `"codex-cloud:*"` entry in `limits.allow_models`. Model pins are rejected because the cloud environment decides the model. The Antigravity adapter uses the installed `agy --print` non-interactive CLI path, the Pi adapter uses `pi -p`, and the Cursor adapter uses `cursor-agent -p --output-format text -f` (`--trust` plus `--mode plan` on read-only runs; without a trust flag, headless cursor-agent refuses untrusted workspaces and exits 0).
+A `codex-cloud:<env-id>` seat is different: it submits the task to Codex Cloud with `codex cloud exec`, polls `codex cloud status` until the task reaches a terminal state (bounded by the seat timeout), and returns the final status plus the unified diff as the worker text. The diff is never applied to the local tree. Land it deliberately with `codex cloud apply <task-id>`; the task id is recorded on the worker result. Environment ids come from your Codex Cloud workspace (browse with `codex cloud`). Allow the seat with a `"codex-cloud:*"` entry in `limits.allow_models`. Model pins are rejected because the cloud environment decides the model.
+
+The local adapters use explicit non-interactive execution modes. Writable Antigravity runs pass `--add-dir <cwd> --dangerously-skip-permissions`; read-only runs pass `--sandbox` without either write flag. Writable Kimi runs pass `--yolo`; read-only runs pass `--plan`. Cursor write runs use `cursor-agent -p --output-format text -f`. Direct read-only Cursor runs use `--trust --mode plan`, which keeps the workspace read-only but has model-specific output limits: Composer 2.5 findings go to Cursor's plan artifact instead of assistant stdout, so Brigade rejects that combination before spawning the process. Grok 4.5 has also returned exit 0 with empty assistant text in this mode. Brigade preserves the process stdout, stderr, and exit code, then reports the ACP alternative.
+
+Use the reviewed ACP transport when a Cursor model needs read-only findings on stdout:
+
+```toml
+[agents.cursor_reviewer]
+cli = "cursor"
+model = "composer-2.5-fast"
+transport = "acpx"
+transport_version = "0.12.0"
+role = "Inspect the change and report concrete defects."
+```
+
+This path requires user-installed `acpx 0.12.0` and `cursor-agent acp`. Read-only calls use `--approve-reads`, reject interactive permission requests, disable terminal capability, and parse strict ACP protocol 1 NDJSON. Brigade never falls back from ACP to direct Cursor. Writable ACP calls require `brigade run --worktree`, so approval applies only inside a Brigade-created detached worktree.
 Run `brigade roster doctor` to validate roster syntax and check which CLIs are on `PATH`.
 To decide which model belongs in which seat with receipt-backed evidence instead of reputation, see [model ratings](model-ratings.md).
 When `--roster` is omitted, `brigade run` first reads `--cwd/.brigade/roster.toml`;

--- a/src/brigade/agents.py
+++ b/src/brigade/agents.py
@@ -173,15 +173,37 @@ READ_ONLY_ENFORCEMENT: dict[str, str] = {
 }
 
 
-def read_only_enforcement(cli_ref: str) -> str:
+def read_only_enforcement(cli_ref: str, *, sandbox: str | None = None, transport: str = "direct") -> str:
     """Return how strongly cli_ref enforces read-only: 'hard', 'soft', or 'none'."""
+    if transport == "acpx":
+        return "hard"
     if cli_ref.startswith(_OLLAMA_PREFIX):
         return "none"
     if cli_ref.startswith(_CODEX_CLOUD_PREFIX):
         # Cloud tasks run in an isolated remote environment; the local tree is
         # never modified (diffs are only applied via `codex cloud apply`).
         return "hard"
+    if cli_ref == "codex" and sandbox in {"workspace-write", "danger-full-access"}:
+        # Codex gives an explicit sandbox precedence over read_only. Other hard
+        # adapters select their native read-only mode before consulting sandbox.
+        return "soft"
     return READ_ONLY_ENFORCEMENT.get(cli_ref, "none")
+
+
+def direct_cursor_read_only_limitation(model: str | None) -> str | None:
+    """Describe a model-specific direct Cursor plan-mode output limitation."""
+    normalized = (model or "").strip().lower()
+    if normalized.startswith("composer-"):
+        return (
+            "direct Cursor plan mode does not return Composer findings as assistant text; "
+            'use transport = "acpx" with the reviewed transport_version'
+        )
+    if normalized.startswith("grok-"):
+        return (
+            "direct Cursor plan mode returned no assistant text for this Grok model; "
+            'retry with transport = "acpx" and the reviewed transport_version'
+        )
+    return None
 
 
 @dataclass(frozen=True)
@@ -367,6 +389,17 @@ def run_agent(
 
         return codex_cloud.run_cloud_task(prompt, env_id=env_id, timeout=timeout, cwd=cwd)
 
+    cursor_limitation = None
+    if cli_ref == "cursor" and (read_only or sandbox == "read-only"):
+        cursor_limitation = direct_cursor_read_only_limitation(model)
+        if cursor_limitation is not None and (model or "").strip().lower().startswith("composer-"):
+            return AgentResult(
+                text="",
+                ok=False,
+                detail=cursor_limitation,
+                requested_model=model,
+            )
+
     result = proc.run(
         build_argv(
             cli_ref,
@@ -396,7 +429,9 @@ def run_agent(
         )
     if not text:
         detail = "empty output"
-        if cli_ref in {"cursor", "grok"}:
+        if cursor_limitation is not None:
+            detail = cursor_limitation
+        elif cli_ref in {"cursor", "grok"}:
             detail = f"{cli_ref} exited 0 without output; check trust, permissions, and model availability"
         return AgentResult(
             text="",

--- a/src/brigade/cli/run.py
+++ b/src/brigade/cli/run.py
@@ -203,6 +203,7 @@ def dispatch(args) -> int:
     effective_sandbox = args.sandbox if args.sandbox is not None else loaded_roster.sandbox
     if args.read_only:
         advisory = _read_only_advisory(loaded_roster, effective_sandbox, worker=args.worker)
+        output_warnings = _read_only_output_warnings(loaded_roster, worker=args.worker)
         if advisory:
             print("warning: --read-only is best-effort for some agents in this run:", file=sys.stderr)
             for line in advisory:
@@ -211,13 +212,22 @@ def dispatch(args) -> int:
                 "  brigade cannot guarantee these agents leave the tree untouched; review the run output.",
                 file=sys.stderr,
             )
-            if output_dir is not None:
-                from .. import localio
+        if output_warnings:
+            print("warning: direct Cursor read-only output is model-limited:", file=sys.stderr)
+            for line in output_warnings:
+                print(f"  - {line}", file=sys.stderr)
+        if output_dir is not None and (advisory or output_warnings):
+            from .. import localio
 
-                localio.write_json(
-                    output_dir / "read-only-enforcement.json",
-                    {"read_only": True, "sandbox": effective_sandbox, "best_effort_agents": advisory},
-                )
+            localio.write_json(
+                output_dir / "read-only-enforcement.json",
+                {
+                    "read_only": True,
+                    "sandbox": effective_sandbox,
+                    "best_effort_agents": advisory,
+                    "output_warnings": output_warnings,
+                },
+            )
     # The dirty guard protects write runs from mixing agent edits with uncommitted
     # work. Dry, read-only, and worktree runs never edit the tree, so reviewing
     # uncommitted changes stays possible without --allow-dirty.
@@ -443,13 +453,12 @@ def _print_suspected_noop_warning(output_dir: Path) -> None:
 def _read_only_advisory(roster, effective_sandbox, worker: str | None = None) -> list[str]:
     """Lines describing which worker agents do not hard-enforce read-only.
 
-    A writable --sandbox override downgrades even natively-sandboxed CLIs to
-    prompt-only, so the advisory reflects the sandbox actually in effect.
+    Enforcement follows each adapter's actual read-only versus sandbox
+    precedence rather than treating every hard adapter like Codex.
     """
     from .. import agents as agents_mod
     from .. import roster as roster_mod
 
-    sandbox_overrides_native = effective_sandbox in ("workspace-write", "danger-full-access")
     lines: list[str] = []
     if worker is not None:
         selected = roster.agents.get(worker)
@@ -460,11 +469,34 @@ def _read_only_advisory(roster, effective_sandbox, worker: str | None = None) ->
         agents_to_check = [orchestrator, *roster_mod.workers(roster)] if orchestrator else roster_mod.workers(roster)
     for agent in agents_to_check:
         cli = agent.cli or ""
-        enforcement = agents_mod.read_only_enforcement(cli)
-        if sandbox_overrides_native and enforcement == "hard":
-            enforcement = "soft"
+        enforcement = agents_mod.read_only_enforcement(
+            cli,
+            sandbox=effective_sandbox,
+            transport=agent.transport,
+        )
         if enforcement == "hard":
             continue
         how = "prompt-only (the model may ignore it)" if enforcement == "soft" else "not applied for this CLI"
         lines.append(f"{agent.name} ({cli or 'unknown'}): read-only is {how}")
+    return lines
+
+
+def _read_only_output_warnings(roster, worker: str | None = None) -> list[str]:
+    """Warnings for direct adapters whose read-only mode can lose assistant text."""
+    from .. import agents as agents_mod
+    from .. import roster as roster_mod
+
+    if worker is not None:
+        selected = roster.agents.get(worker)
+        agents_to_check = [selected] if selected is not None else []
+    else:
+        orchestrator = roster.agents.get(roster.orchestrator)
+        agents_to_check = [orchestrator, *roster_mod.workers(roster)] if orchestrator else roster_mod.workers(roster)
+    lines: list[str] = []
+    for agent in agents_to_check:
+        if agent.cli != "cursor" or agent.transport != "direct":
+            continue
+        limitation = agents_mod.direct_cursor_read_only_limitation(agent.model)
+        if limitation is not None:
+            lines.append(f"{agent.name} (cursor/{agent.model}): {limitation}")
     return lines

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -453,6 +453,36 @@ def test_run_agent_classifies_silent_adapter_exit(monkeypatch, cli_ref):
     assert result.exit_code == 0
 
 
+def test_run_agent_rejects_direct_read_only_cursor_composer_before_spawn(monkeypatch):
+    calls = []
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(agents.proc, "run", lambda argv, **kw: calls.append(argv))
+
+    result = agents.run_agent("cursor", "inspect", read_only=True, model="composer-2.5-fast")
+
+    assert result.ok is False
+    assert result.exit_code is None
+    assert result.requested_model == "composer-2.5-fast"
+    assert "direct Cursor plan mode does not return Composer findings" in result.detail
+    assert 'transport = "acpx"' in result.detail
+    assert calls == []
+
+
+def test_run_agent_classifies_grok_cursor_empty_output_with_process_evidence(monkeypatch):
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(agents.proc, "run", lambda argv, **kw: agents.proc.Result(0, "\n", "provider note"))
+
+    result = agents.run_agent("cursor", "inspect", read_only=True, model="grok-4.5-xhigh")
+
+    assert result.ok is False
+    assert result.exit_code == 0
+    assert result.stdout == "\n"
+    assert result.stderr == "provider note"
+    assert result.requested_model == "grok-4.5-xhigh"
+    assert "direct Cursor plan mode returned no assistant text" in result.detail
+    assert 'transport = "acpx"' in result.detail
+
+
 class _StubThread:
     def __init__(self, result):
         self._result = result

--- a/tests/test_read_only_enforcement.py
+++ b/tests/test_read_only_enforcement.py
@@ -25,6 +25,8 @@ def _roster() -> Roster:
         agents={
             "lead": Agent(name="lead", cli="claude", role="orchestrator"),
             "safe": Agent(name="safe", cli="codex", role="builder"),  # hard
+            "cursor": Agent(name="cursor", cli="cursor", role="builder"),  # hard, read_only wins
+            "cloud": Agent(name="cloud", cli="codex-cloud:example", role="builder"),  # remote isolation
             "soft": Agent(name="soft", cli="goose", role="builder"),  # soft
             "open": Agent(name="open", cli="opencode", role="builder"),  # none
         },
@@ -40,11 +42,14 @@ def test_advisory_lists_non_hard_agents_including_orchestrator():
     assert "lead (claude)" in joined  # the orchestrator runs too and claude does not enforce read-only
 
 
-def test_writable_sandbox_override_downgrades_hard_agents():
+def test_writable_sandbox_override_only_downgrades_codex_exec():
     lines = run_cli._read_only_advisory(_roster(), "workspace-write")
     joined = "\n".join(lines)
-    # the native sandbox is overridden, so even codex is now best-effort
+    # Codex applies the explicit writable sandbox before its read-only fallback.
     assert "safe (codex)" in joined
+    # These adapters still enforce isolation because read_only wins over sandbox.
+    assert "cursor (cursor)" not in joined
+    assert "cloud (codex-cloud:example)" not in joined
     assert "soft (goose)" in joined
 
 
@@ -55,3 +60,27 @@ def test_direct_worker_advisory_only_checks_selected_seat():
     lines = run_cli._read_only_advisory(_roster(), None, worker="open")
     assert len(lines) == 1
     assert "open (opencode)" in lines[0]
+
+
+def test_direct_cursor_output_warning_names_grok_fallback_but_skips_acpx():
+    roster = Roster(
+        orchestrator="lead",
+        agents={
+            "lead": Agent(name="lead", cli="codex", role="orchestrator"),
+            "grok": Agent(name="grok", cli="cursor", model="grok-4.5-xhigh", role="reviewer"),
+            "grok_acp": Agent(
+                name="grok_acp",
+                cli="cursor",
+                model="grok-4.5-xhigh",
+                role="reviewer",
+                transport="acpx",
+                transport_version="0.12.0",
+            ),
+        },
+    )
+
+    direct = run_cli._read_only_output_warnings(roster, worker="grok")
+    assert len(direct) == 1
+    assert "grok (cursor/grok-4.5-xhigh)" in direct[0]
+    assert 'transport = "acpx"' in direct[0]
+    assert run_cli._read_only_output_warnings(roster, worker="grok_acp") == []


### PR DESCRIPTION
Closes #206.
Closes #223.
Closes #231.

## Summary

- report read-only enforcement using each adapter's actual sandbox precedence
- reject direct read-only Composer seats before process spawn and point to the reviewed ACP configuration
- warn before direct read-only Grok dispatch and preserve exit status, model, stdout, and stderr for empty-output failures
- document direct Cursor and ACP behavior for Composer and Grok
- retain regression coverage for the Antigravity and Kimi writable commands that already fixed #192

## Verification

`./scripts/verify` through Brigade: 2,200 passed, 3 skipped, 81.24% coverage.

Receipt: `.brigade/work/verify-runs/20260713-010813-work-verify-12c99f/receipt.json`

Authenticated direct Grok, ACP 0.12.0, Antigravity, and Kimi probes remain opt-in runtime checks.
