### PR TITLE
feat(outcome): route as a cohort axis (Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Route as a third outcome-ledger cohort axis (Phase 1: record and surface, no scoring change). `brigade outcome capture` stamps a coarse route manifest (`followed`, `path`, `size`, sorted `signals`, `coverage`) and a `route_fingerprint` on each record, resolved from the owning `brigade run`'s route. A bare verify-capture with no owning run is the honest unrouted cohort. `brigade outcome explain` splits records into routed-vs-unrouted cohorts with a help-rate, so the ledger can finally answer whether runs that followed a composed route verify greener. Ratchet unchanged; see `docs/design/route-outcome-cohort.md`.
+
+### Added
 - Recency-weighted outcome ranking (context-aware outcomes follow-up): `outcome rank --recency` (default half-life 45 days, `--recency-half-life DAYS` to override) weights the score it sorts by over recency-weighted counts, so a signal's weight halves every half-life and credit earned under a drifted-away environment fades without rewriting the append-only log. It applies to the pooled score by default and the capability-shrunk score with `--by-capability`; the two flags compose. Off by default, so rank output stays byte-identical. The Wilson bound and shrinkage prior now accept fractional counts; the promotion ratchet never uses recency. See [docs/design/context-blind-spot.md](docs/design/context-blind-spot.md).
 
 ## [0.22.0] - 2026-07-13

--- a/docs/design/route-outcome-cohort.md
+++ b/docs/design/route-outcome-cohort.md
@@ -1,0 +1,117 @@
+# Route as an outcome cohort axis
+
+Status: Phase 1 implemented. Sibling to `context-blind-spot.md`: a third
+cohort axis on the outcome ledger. Phase 2 and Phase 3 remain proposed.
+
+## The problem
+
+The deterministic route brief (brigade #210, #227, #232) composes the stages a
+`brigade run` must cover, records the route in `run.json`, and ships in 0.22.0.
+It is exercised in live runs. What it is not is measured. The outcome ledger
+scores skills and cards by verified exit codes, but nothing in the ledger knows
+whether a run followed a composed route, so `outcome rank` cannot answer the one
+question the feature exists to earn: do routed runs verify greener than unrouted
+ones.
+
+Today the route and the outcome live in two files that never meet:
+
+- the route is in `.brigade/runs/<id>/run.json` under `route`,
+- the outcome is captured from a verify receipt in
+  `.brigade/work/verify-runs/<id>/receipt.json`.
+
+The receipt already carries a `run_id`, and `outcome_cmd._resolve_run_receipt`
+already reads `run.json`. The linkage exists in the plumbing. It is just not
+threaded onto the outcome record, so the ledger is route-blind the same way it
+was context-blind before #228.
+
+## The mechanism
+
+Route is a third cohort axis alongside the two already designed. Content
+fingerprint sees what an artifact is made of. Capability fingerprint sees the
+harness it ran under. Route fingerprint sees the shape of the plan the run
+followed. All three are separate axes, never folded into each other, each with
+its own graceful-degrade cohort.
+
+**What gets stamped.** A `route` manifest and a low-cardinality
+`route_fingerprint` on each new `OutcomeRecord`, resolved at capture time from
+the run the outcome belongs to:
+
+- `path` (code / docs / system), `size` (XS..XXL), and the sorted `signals`
+  list, hashed into `route_fingerprint`. Coarse on purpose, the same lesson
+  context learned: the full ordered stage list is higher cardinality and
+  fragments cohorts to n=1, so the fingerprint keys on path + size + sorted
+  signals, not the stage sequence.
+- `followed`: whether the run carried a route at all. A bare
+  `brigade work verify run` with no owning `brigade run`, or a `--no-route` run,
+  records `followed: false` and no fingerprint. This is the grandfathered
+  cohort, exactly like a record with no capability manifest.
+- `coverage`: whether the plan covered every required stage, read from the
+  `plan-attempts.json` the route already writes (`coverage_missing`,
+  `unknown_covers`). A run that shipped with an uncovered stage is a different
+  cohort from one that covered cleanly.
+
+**Where it comes from.** Capture already resolves the run. Extend that path:
+verify receipt -> `run_id` -> `run.json` -> `route` payload -> manifest. Capture
+what Brigade computes, never what the model asserts, the same integrity posture
+as exit codes. No route in the run, no manifest, `followed: false`.
+
+## Phased plan
+
+### Phase 1: record and surface, no scoring change (DONE)
+
+Stamp the `route` manifest and `route_fingerprint` onto new outcome records
+(`route_manifest`/`route_fingerprint` in `outcome_cmd.py`). Surface a
+routed-vs-unrouted breakdown in `outcome explain` (`_route_breakdown`). The default score,
+rank order, and promotion ratchet are unchanged. This is the data foundation:
+cohort-aware comparison means nothing until records carry the fingerprint, the
+same sequencing content fingerprints (#218 record, #219 score) and context
+fingerprints (#228 record, later score) followed. Records without a route
+manifest are grandfathered.
+
+### Phase 2: the comparison the feature exists for
+
+`outcome rank --by-route` (and a line in `outcome explain`) split each artifact's
+score by route cohort: routed vs unrouted, and by route shape where a cohort has
+enough samples. Reuse `split_by_fingerprint` and the Wilson lower bound already
+in `outcome.py`, so a thin route cohort shrinks toward the pooled rate and never
+out-ranks a vetted one on a single lucky run. The output is the receipt this
+feature is missing: a number for whether following the route helped.
+
+### Phase 3 (deferred): route-arm paired attribution
+
+The honest version of the question is counterfactual: would this run have
+verified green without the route. Borrow the paired-attribution idea from
+`context-blind-spot.md` Phase 3, on a deterministically-sampled fraction: run the
+same task once routed and once with `--no-route`, record
+`delta = +1 if the routed arm passes and the unrouted arm fails`. Two exit codes,
+no judge. Expensive (doubles the run on sampled tasks, needs a disposable
+workspace), gated to safe tasks, deferred until Phase 2 shows the correlation is
+worth chasing.
+
+## What this does not do
+
+- **It does not change scoring in Phase 1.** A route cohort that looks worse
+  must never demote a skill on the record-only milestone. Same rule as context.
+- **It does not fingerprint the stage sequence.** Path + size + sorted signals
+  only. The ordered stage list is a Phase 2 display detail, never a cohort key.
+- **It does not credit the route for the skill's own work.** The route axis
+  answers "did routed runs verify greener," not "did the route write the code."
+  It stratifies attribution, it does not claim it.
+- **It does not require every run to be routed.** Unrouted and `--no-route` runs
+  are a valid cohort, not missing data.
+
+## Why it is worth building
+
+Brigade's whole pitch is that the receipt tells the truth about a run. The route
+is currently the one shipped feature with no receipt of its own: it is used, it
+is exercised, and its value is asserted rather than measured. This closes that.
+Phase 1 is a small, precedented change (one manifest on a record, one line in
+`explain`), it reuses the cohort machinery already built twice, and it turns the
+next hundred `brigade run` invocations into the evidence for whether the router
+earned its keep.
+
+## Decision needed
+
+Green-light Phase 1 as its own PR (record + surface, no scoring change),
+matching the #218 shape. Phase 2 follows once records carry the fingerprint.
+Phase 3 stays deferred behind Phase 2's result.

--- a/src/brigade/outcome.py
+++ b/src/brigade/outcome.py
@@ -50,6 +50,14 @@ class OutcomeRecord:
     vector. Both are ``None`` on records captured before context tracking existed.
     Phase 1 records them but does not score on them; see
     docs/design/context-blind-spot.md.
+
+    ``route`` is a coarse manifest of the deterministic route the owning
+    ``brigade run`` followed (``followed``, ``path``, ``size``, sorted
+    ``signals``, ``coverage``), and ``route_fingerprint`` is the sha256 of its
+    low-cardinality vector (path + size + signals, never the stage sequence).
+    Both are ``None`` on a bare verify-capture with no owning run, and on records
+    captured before route tracking existed. The third cohort axis, recorded but
+    not scored in Phase 1; see docs/design/route-outcome-cohort.md.
     """
 
     artifact_id: str
@@ -64,6 +72,8 @@ class OutcomeRecord:
     content_fingerprint: str | None = None
     context: dict[str, Any] | None = None
     capability_fingerprint: str | None = None
+    route: dict[str, Any] | None = None
+    route_fingerprint: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/brigade/outcome_cmd.py
+++ b/src/brigade/outcome_cmd.py
@@ -323,6 +323,71 @@ def capability_fingerprint(manifest: dict[str, Any]) -> str:
     return localio.canonical_json_digest(vector)
 
 
+def _route_coverage(run_json_path: Path | None) -> str | None:
+    """ "clean" / "gap" / None, read best-effort from the run's plan-attempts.json
+    sibling. A gap is a final attempt with uncovered stages or hallucinated
+    covers; None when the file is absent or unreadable (never a hard failure)."""
+    if run_json_path is None:
+        return None
+    attempts_path = run_json_path.parent / "plan-attempts.json"
+    if not attempts_path.is_file():
+        return None
+    try:
+        payload = json.loads(attempts_path.read_text())
+        attempts = payload.get("attempts") if isinstance(payload, dict) else None
+        if not isinstance(attempts, list) or not attempts:
+            return None
+        final = attempts[-1]
+    except (OSError, json.JSONDecodeError, AttributeError, IndexError):
+        return None
+    if not isinstance(final, dict):
+        return None
+    if final.get("coverage_missing") or final.get("unknown_covers"):
+        return "gap"
+    return "clean"
+
+
+def route_manifest(run_payload: dict[str, Any] | None, run_json_path: Path | None = None) -> dict[str, Any]:
+    """Coarse manifest of the route the owning brigade run followed. A run with
+    no attached route, or a bare verify-capture with no owning run, is the honest
+    unrouted cohort: ``{"followed": False}``. Signals are sorted so the manifest
+    (and its fingerprint) do not depend on derivation order."""
+    from . import router
+
+    route = run_payload.get("route") if isinstance(run_payload, dict) else None
+    if not isinstance(route, dict) or not route.get("attached"):
+        return {"followed": False}
+    raw = route.get("signals")
+    signals = [str(s) for s in raw] if isinstance(raw, list) else []
+    # The path is the code/docs/system signal by identity, not by position, so a
+    # reordered signals list yields the same manifest and fingerprint.
+    path = next((s for s in signals if s in router.PATHS), "unknown")
+    manifest: dict[str, Any] = {
+        "followed": True,
+        "path": path,
+        "size": route.get("size", "unknown"),
+        "signals": sorted(signals),
+    }
+    coverage = _route_coverage(run_json_path)
+    if coverage is not None:
+        manifest["coverage"] = coverage
+    return manifest
+
+
+def route_fingerprint(manifest: dict[str, Any]) -> str | None:
+    """sha256 of the low-cardinality route vector (path + size + sorted signals),
+    or None for an unrouted record. Coverage is in the manifest but not the
+    fingerprint: it would fragment cohorts the way exact context does."""
+    if not manifest.get("followed"):
+        return None
+    vector = {
+        "path": manifest.get("path", "unknown"),
+        "size": manifest.get("size", "unknown"),
+        "signals": manifest.get("signals", []),
+    }
+    return localio.canonical_json_digest(vector)
+
+
 def _fingerprint_cohorts_by_artifact(
     target: Path, records: list[core.OutcomeRecord]
 ) -> dict[str, core.FingerprintCohorts]:
@@ -343,6 +408,8 @@ def _record_from_dict(payload: dict) -> core.OutcomeRecord | None:
     content_fingerprint = payload.get("content_fingerprint")
     context = payload.get("context")
     capability_fingerprint_value = payload.get("capability_fingerprint")
+    route = payload.get("route")
+    route_fingerprint_value = payload.get("route_fingerprint")
     try:
         return core.OutcomeRecord(
             artifact_id=str(payload["artifact_id"]),
@@ -360,6 +427,10 @@ def _record_from_dict(payload: dict) -> core.OutcomeRecord | None:
             context=context if isinstance(context, dict) else None,
             capability_fingerprint=capability_fingerprint_value
             if isinstance(capability_fingerprint_value, str) and capability_fingerprint_value
+            else None,
+            route=route if isinstance(route, dict) else None,
+            route_fingerprint=route_fingerprint_value
+            if isinstance(route_fingerprint_value, str) and route_fingerprint_value
             else None,
         )
     except (KeyError, TypeError, ValueError):
@@ -392,6 +463,10 @@ def _record_payload(record: core.OutcomeRecord) -> dict:
         row.pop("context", None)
     if row.get("capability_fingerprint") is None:
         row.pop("capability_fingerprint", None)
+    if row.get("route") is None:
+        row.pop("route", None)
+    if row.get("route_fingerprint") is None:
+        row.pop("route_fingerprint", None)
     return row
 
 
@@ -791,6 +866,39 @@ def _fingerprint_decision_suffix(cohorts: core.FingerprintCohorts) -> str:
     )
 
 
+def _route_breakdown(records: list[core.OutcomeRecord]) -> list[dict] | None:
+    """Split an artifact's scored records into routed vs unrouted cohorts (Phase 1,
+    display-only). This is the receipt the route feature was missing: whether runs
+    that followed a composed route verify greener than bare verify captures.
+
+    Returns None when no record carries a route manifest, so a pre-route ledger's
+    output is unchanged. Routed records group by route_fingerprint (path/size);
+    unrouted records (a bare verify with no owning run) share one cohort. Not
+    scored: Phase 1 records and surfaces, the ratchet ignores it.
+    """
+    scored = core.scored_records(records)
+    if not any(isinstance(r.route, dict) for r in scored):
+        return None
+    groups: dict[str, dict] = {}
+    for record in scored:
+        route = record.route if isinstance(record.route, dict) else {}
+        if route.get("followed") and record.route_fingerprint:
+            key = record.route_fingerprint
+            label = f"routed {route.get('path', '?')}/{route.get('size', '?')}"
+        else:
+            key = "unrouted"
+            label = "unrouted"
+        entry = groups.setdefault(key, {"key": key, "label": label, "helped": 0, "hurt": 0, "neutral": 0})
+        if record.signal_value > 0:
+            entry["helped"] += 1
+        elif record.signal_value < 0:
+            entry["hurt"] += 1
+        else:
+            entry["neutral"] += 1
+    # unrouted last, then routed cohorts by fingerprint for a stable read
+    return sorted(groups.values(), key=lambda e: (e["key"] == "unrouted", e["key"]))
+
+
 def _capability_breakdown(records: list[core.OutcomeRecord]) -> list[dict] | None:
     """Group an artifact's scored records by capability cohort (Phase 1, display-only).
 
@@ -868,6 +976,7 @@ def explain(*, target: Path, artifact_id: str, json_output: bool = False) -> int
         for record in sorted(records, key=lambda record: record.ts)
     ]
     capability_breakdown = _capability_breakdown(records)
+    route_breakdown = _route_breakdown(records)
     current_capability = capability_fingerprint(context_manifest())
     cap_cohorts = core.split_by_capability(
         artifact_id, core.current_content_records(records, cohorts.current_fingerprint), current_capability
@@ -891,6 +1000,8 @@ def explain(*, target: Path, artifact_id: str, json_output: bool = False) -> int
         }
         if capability_breakdown is not None:
             payload["capability_breakdown"] = capability_breakdown
+        if route_breakdown is not None:
+            payload["route_breakdown"] = route_breakdown
         print(json.dumps(payload, indent=2, sort_keys=True))
         return 0
     print(f"outcome explain: {artifact_id}")
@@ -924,6 +1035,15 @@ def explain(*, target: Path, artifact_id: str, json_output: bool = False) -> int
             print(
                 f"- {entry['capability_fingerprint'][:12]} {entry['label']} "
                 f"helped={entry['helped']} hurt={entry['hurt']} neutral={entry['neutral']}"
+            )
+    if route_breakdown is not None:
+        print("route cohorts (did following the route verify greener? retrieval only, not scored):")
+        for entry in route_breakdown:
+            total = entry["helped"] + entry["hurt"]
+            rate = f"{entry['helped'] / total:.3f}" if total else "n/a"
+            print(
+                f"- {entry['label']} helped={entry['helped']} hurt={entry['hurt']} "
+                f"neutral={entry['neutral']} (help-rate {rate})"
             )
     if not trail:
         print("trail: none")
@@ -970,6 +1090,8 @@ def capture(
     code_graph_delta: dict[str, Any] | None = None
     context_eval: dict[str, Any] | None = None
     run_agent: dict[str, Any] | None = None
+    route_run_payload: dict[str, Any] | None = None
+    route_run_json: Path | None = None
     if run_receipt is not None:
         receipt, run_json, error = _resolve_run_receipt(target, run_receipt)
         if receipt is None or run_json is None:
@@ -983,6 +1105,8 @@ def capture(
         context_eval = _compact_context_eval(receipt)
         agent = receipt.get("agent")
         run_agent = agent if isinstance(agent, dict) else None
+        route_run_payload = receipt
+        route_run_json = run_json
     else:
         from .work_cmd import verification as verify_mod
 
@@ -995,6 +1119,7 @@ def capture(
         ts = str(receipt.get("completed_at") or receipt.get("started_at") or localio.utc_now_iso())
         code_graph_delta = _compact_code_graph_delta(receipt)
     manifest = context_manifest(run_agent)
+    route = route_manifest(route_run_payload, route_run_json)
     record = core.OutcomeRecord(
         artifact_id=artifact_id,
         artifact_kind=artifact_kind,
@@ -1008,6 +1133,8 @@ def capture(
         content_fingerprint=artifact_fingerprint(target, artifact_id, artifact_kind),
         context=manifest,
         capability_fingerprint=capability_fingerprint(manifest),
+        route=route,
+        route_fingerprint=route_fingerprint(route),
     )
     append_records(target, [record])
     if json_output:
@@ -1020,6 +1147,10 @@ def capture(
         print(f"fingerprint: {record.content_fingerprint[:12]}")
     if record.capability_fingerprint:
         print(f"capability: {record.capability_fingerprint[:12]} ({manifest['harness']}/{manifest['model_family']})")
+    if record.route_fingerprint:
+        print(f"route: {record.route_fingerprint[:12]} ({route['path']}/{route['size']}, followed)")
+    else:
+        print("route: unrouted (no owning brigade run)")
     return 0
 
 

--- a/tests/test_outcome_cmd.py
+++ b/tests/test_outcome_cmd.py
@@ -49,6 +49,8 @@ def _write_run_receipt(
     code_graph_delta=None,
     context_eval=None,
     started_at="2026-06-20T00:00:00+00:00",
+    route=None,
+    plan_attempts=None,
 ):
     run_dir = target / ".brigade" / "runs" / run_id
     run_dir.mkdir(parents=True)
@@ -66,6 +68,10 @@ def _write_run_receipt(
         receipt["code_graph_delta"] = code_graph_delta
     if context_eval is not None:
         receipt["context_eval"] = context_eval
+    if route is not None:
+        receipt["route"] = route
+    if plan_attempts is not None:
+        localio.write_json(run_dir / "plan-attempts.json", {"attempts": plan_attempts})
     localio.write_json(run_dir / "run.json", receipt)
     return run_dir / "run.json"
 
@@ -1926,3 +1932,105 @@ def test_cli_rank_recency_flag_dispatch(tmp_path, capsys):
     assert cli.main(["outcome", "rank", "--recency-half-life", "10", "--target", str(tmp_path), "--json"]) == 0
     entry = json.loads(capsys.readouterr().out)["ranking"][0]
     assert entry["recency_half_life_days"] == 10.0
+
+
+# --- Phase 1: route as a cohort axis (record + surface, no scoring change) ---
+
+
+ROUTE_M = {"attached": True, "signals": ["code", "auth-surface", "needs-tests"], "size": "M"}
+
+
+def test_route_manifest_and_fingerprint_are_order_stable():
+    a = outcome_cmd.route_manifest({"route": {"attached": True, "signals": ["code", "auth-surface"], "size": "S"}})
+    b = outcome_cmd.route_manifest({"route": {"attached": True, "signals": ["auth-surface", "code"], "size": "S"}})
+    assert a["path"] == "code"
+    assert a["signals"] == ["auth-surface", "code"]
+    assert outcome_cmd.route_fingerprint(a) == outcome_cmd.route_fingerprint(b)
+
+
+def test_route_manifest_unrouted_when_no_route():
+    for payload in ({"status": "completed"}, {"route": {"attached": False}}, None):
+        m = outcome_cmd.route_manifest(payload)
+        assert m == {"followed": False}
+        assert outcome_cmd.route_fingerprint(m) is None
+
+
+def test_route_coverage_reads_plan_attempts(tmp_path):
+    _init_git_repo(tmp_path)
+    clean = _write_run_receipt(
+        tmp_path, run_id="clean", route=ROUTE_M, plan_attempts=[{"stage": "initial", "parsed": True}]
+    )
+    gap = _write_run_receipt(
+        tmp_path,
+        run_id="gap",
+        route=ROUTE_M,
+        plan_attempts=[{"stage": "initial", "coverage_missing": ["verify"]}],
+    )
+    assert outcome_cmd._route_coverage(clean) == "clean"
+    assert outcome_cmd._route_coverage(gap) == "gap"
+    # no plan-attempts.json -> None, never a hard failure
+    bare = _write_run_receipt(tmp_path, run_id="bare", route=ROUTE_M)
+    assert outcome_cmd._route_coverage(bare) is None
+
+
+def test_capture_run_receipt_stamps_route_and_survives_roundtrip(tmp_path, capsys):
+    _init_git_repo(tmp_path)
+    _write_run_receipt(tmp_path, run_id="routed", route=ROUTE_M, plan_attempts=[{"stage": "initial", "parsed": True}])
+    assert outcome_cmd.capture(target=tmp_path, artifact_id="brigade-work", run_receipt="routed") == 0
+    out = capsys.readouterr().out
+    assert "route:" in out and "code/M, followed" in out
+    records = outcome_cmd.load_records(tmp_path)
+    assert len(records) == 1
+    rec = records[0]
+    assert rec.route["followed"] is True
+    assert rec.route["path"] == "code"
+    assert rec.route["size"] == "M"
+    assert rec.route["coverage"] == "clean"
+    assert rec.route_fingerprint  # set for a routed record
+
+
+def test_capture_verify_run_is_unrouted(tmp_path, capsys):
+    _init_git_repo(tmp_path)
+    _write_verify_receipt(tmp_path, run_id="v1", status="completed")
+    assert outcome_cmd.capture(target=tmp_path, artifact_id="brigade-work", run_id="v1") == 0
+    assert "route: unrouted" in capsys.readouterr().out
+    rec = outcome_cmd.load_records(tmp_path)[0]
+    assert rec.route == {"followed": False}
+    assert rec.route_fingerprint is None
+
+
+def test_explain_splits_routed_vs_unrouted(tmp_path, capsys):
+    _init_git_repo(tmp_path)
+    # one routed helped, one unrouted hurt
+    _write_run_receipt(tmp_path, run_id="r1", status="ok", route=ROUTE_M, plan_attempts=[{"parsed": True}])
+    outcome_cmd.capture(target=tmp_path, artifact_id="brigade-work", run_receipt="r1")
+    _write_verify_receipt(tmp_path, run_id="v1", status="failed")
+    outcome_cmd.capture(target=tmp_path, artifact_id="brigade-work", run_id="v1")
+    capsys.readouterr()
+    assert outcome_cmd.explain(target=tmp_path, artifact_id="brigade-work", json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    cohorts = {c["label"]: c for c in payload["route_breakdown"]}
+    assert cohorts["routed code/M"]["helped"] == 1
+    assert cohorts["unrouted"]["hurt"] == 1
+
+
+def test_route_breakdown_absent_on_pre_route_ledger(tmp_path, capsys):
+    _init_git_repo(tmp_path)
+    # a record with no route field (legacy) yields no route_breakdown key
+    _seed(
+        tmp_path,
+        [
+            outcome.OutcomeRecord(
+                artifact_id="brigade-work",
+                artifact_kind="skill",
+                task_id="t",
+                source="verify",
+                signal_value=1,
+                evidence_ref="e",
+                ts="2026-06-20T00:00:00+00:00",
+            )
+        ],
+    )
+    assert outcome_cmd.explain(target=tmp_path, artifact_id="brigade-work", json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert "route_breakdown" not in payload


### PR DESCRIPTION
Implements Phase 1 of `docs/design/route-outcome-cohort.md` (supersedes the spec-only #247, which this includes). Answers "keep track of the route feature's performance now that 0.22.0 is live."

## The gap

The deterministic route ships in 0.22.0 and runs live (real `ecosystem-audit` runs carry `route:L` payloads), but the outcome ledger didn't know whether a run followed a route, so `outcome rank` couldn't show whether routed runs verify greener. The feature was used and asserted, not measured.

## What Phase 1 adds

Route is the third cohort axis after `content_fingerprint` (#218/#219) and `capability_fingerprint` (#228), following the same record-then-score phasing:

- **`route_manifest()`** builds a coarse manifest from the owning `brigade run`'s route: `followed`, `path` (resolved by identity against `router.PATHS`, not position, so a reordered signals list is stable), `size`, sorted `signals`, and `coverage` read best-effort from `plan-attempts.json`.
- **`route_fingerprint()`** hashes path + size + signals only. Never the stage sequence, which would fragment cohorts to n=1 the way exact context does.
- **`capture`** stamps both: the `--run-receipt` path reads `run.json`'s route, the bare `--run-id` verify path is the honest unrouted cohort (`{followed: false}`).
- **`explain`** splits routed-vs-unrouted with a help-rate, display-only.
- Round-trips through the digest chain; legacy records (no route field) are grandfathered, so a pre-route ledger's output is unchanged.

No scoring change. The ratchet ignores the route axis in Phase 1. Phase 2 (`rank --by-route` via the existing Wilson machinery) and Phase 3 (paired attribution) remain proposed.

## Verification

- 7 new tests (manifest order-stability, unrouted cohort, coverage from plan-attempts, capture round-trip, explain split, legacy-ledger absence) + 100 outcome tests green; digest chain and receipts-verify intact.
- Live end-to-end through the real CLI: captured a real L-size `ecosystem-audit` run as `route: dbfeed29735a (code/L, followed)`, showed it in the `explain` breakdown.
- My own smoke test caught a positional-path bug (fingerprint wasn't order-stable) before commit; fixed.
- Full gate (`./scripts/verify`) green, receipted.