### PR TITLE
fix(handoff): accept fenced card content

### DIFF
--- a/src/brigade/handoff_cmd/issue_ops.py
+++ b/src/brigade/handoff_cmd/issue_ops.py
@@ -16,6 +16,7 @@ from typing import Any
 from .. import scrub
 from ..budgets import HANDOFF_BACKLOG_STALE_SECONDS
 from ..config import load_config as load_brigade_config
+from ..handoff_content import normalize_suggested_card_content
 from ..localio import write_json as _write_json
 from ..selection import WRITER_INBOXES as _WRITER_INBOX_MAP
 
@@ -314,7 +315,7 @@ def _lint_card_action(
     elif not CARD_TARGET_PATTERN.fullmatch(target_card.splitlines()[0].strip()):
         errors.append("Target card must be a filename like project-context.md with no path separators")
 
-    suggested_card = _section_value(sections, "Suggested card content")
+    suggested_card = normalize_suggested_card_content(_section_value(sections, "Suggested card content"))
     if not suggested_card:
         errors.append("card handoffs require Suggested card content")
     elif not suggested_card.startswith("---"):

--- a/src/brigade/handoff_cmd/issue_ops.py
+++ b/src/brigade/handoff_cmd/issue_ops.py
@@ -315,8 +315,10 @@ def _lint_card_action(
     elif not CARD_TARGET_PATTERN.fullmatch(target_card.splitlines()[0].strip()):
         errors.append("Target card must be a filename like project-context.md with no path separators")
 
-    suggested_card = normalize_suggested_card_content(_section_value(sections, "Suggested card content"))
-    if not suggested_card:
+    suggested_card, fence_error = normalize_suggested_card_content(sections.get("Suggested card content", ""))
+    if fence_error:
+        errors.append(fence_error)
+    elif not suggested_card:
         errors.append("card handoffs require Suggested card content")
     elif not suggested_card.startswith("---"):
         errors.append("Suggested card content must start with YAML frontmatter")

--- a/src/brigade/handoff_content.py
+++ b/src/brigade/handoff_content.py
@@ -2,19 +2,62 @@
 
 from __future__ import annotations
 
-import re
 
-_OUTER_MARKDOWN_FENCE = re.compile(r"```[A-Za-z0-9_-]*")
+def _without_leading_html_comments_before_fence(lines: list[str]) -> list[str]:
+    """Drop HTML comment blocks that wrap, rather than belong to, a fence."""
+    start = 0
+    while start < len(lines):
+        while start < len(lines) and not lines[start].strip():
+            start += 1
+        if start >= len(lines) or not lines[start].strip().startswith("<!--"):
+            break
+        end = start
+        while end < len(lines) and not lines[end].strip().endswith("-->"):
+            end += 1
+        if end >= len(lines):
+            return lines
+        start = end + 1
+
+    while start < len(lines) and not lines[start].strip():
+        start += 1
+    if start < len(lines) and lines[start].strip().startswith("```"):
+        return lines[start:]
+    return lines
 
 
-def normalize_suggested_card_content(value: str) -> str:
-    """Remove one complete outer Markdown fence from suggested card content."""
-    lines = value.splitlines()
-    if len(lines) < 2:
-        return value
+def _without_trailing_html_comments(lines: list[str]) -> list[str]:
+    """Drop HTML comment blocks that follow an outer content fence."""
+    end = len(lines)
+    while end:
+        while end and not lines[end - 1].strip():
+            end -= 1
+        if not end or not lines[end - 1].strip().endswith("-->"):
+            break
+        start = end - 1
+        while start >= 0 and not lines[start].strip().startswith("<!--"):
+            start -= 1
+        if start < 0:
+            break
+        end = start
+    return lines[:end]
+
+
+def normalize_suggested_card_content(value: str) -> tuple[str, str | None]:
+    """Remove a supported outer Markdown fence and report malformed fences."""
+    lines = _without_leading_html_comments_before_fence(value.splitlines())
+    if not lines:
+        return value, None
 
     opening = lines[0].strip()
-    closing = lines[-1].strip()
-    if _OUTER_MARKDOWN_FENCE.fullmatch(opening) and closing == "```":
-        return "\n".join(lines[1:-1]).strip()
-    return value
+    if not opening.startswith("```"):
+        return value, None
+
+    language = opening[3:].strip()
+    if language and language.lower() != "markdown":
+        return value, f"Suggested card content uses an unsupported Markdown fence language: {language}"
+
+    fenced_lines = _without_trailing_html_comments(lines[1:])
+    if not fenced_lines or fenced_lines[-1].strip() != "```":
+        return value, "Suggested card content Markdown fence is missing a closing fence"
+
+    return "\n".join(fenced_lines[:-1]).strip(), None

--- a/src/brigade/handoff_content.py
+++ b/src/brigade/handoff_content.py
@@ -1,0 +1,20 @@
+"""Shared normalization for Memory Handoff content sections."""
+
+from __future__ import annotations
+
+import re
+
+_OUTER_MARKDOWN_FENCE = re.compile(r"```[A-Za-z0-9_-]*")
+
+
+def normalize_suggested_card_content(value: str) -> str:
+    """Remove one complete outer Markdown fence from suggested card content."""
+    lines = value.splitlines()
+    if len(lines) < 2:
+        return value
+
+    opening = lines[0].strip()
+    closing = lines[-1].strip()
+    if _OUTER_MARKDOWN_FENCE.fullmatch(opening) and closing == "```":
+        return "\n".join(lines[1:-1]).strip()
+    return value

--- a/src/brigade/ingest.py
+++ b/src/brigade/ingest.py
@@ -183,7 +183,7 @@ def parse(path: Path) -> Dict[str, str]:
     if last_name is not None:
         sections[last_name.lower()] = body[last_pos:].strip()
     if "suggested card content" in sections:
-        sections["suggested card content"] = normalize_suggested_card_content(sections["suggested card content"])
+        sections["suggested card content"], _ = normalize_suggested_card_content(sections["suggested card content"])
     return sections
 
 
@@ -227,8 +227,11 @@ def decide(
     if action in ("create-card", "update-card") and promote_cards:
         card = sections.get("target card", "").strip()
         content = sections.get("suggested card content", "")
+        content, fence_error = normalize_suggested_card_content(content)
         if not SAFE_CARD_NAME_RE.match(card):
             return Outcome("inboxed", reason=f"target card name unsafe: {card!r}")
+        if fence_error:
+            return Outcome("inboxed", reason=fence_error)
         if not content.lstrip().startswith("---"):
             return Outcome("inboxed", reason="card content missing YAML frontmatter")
         sig = scan_untrusted(content)

--- a/src/brigade/ingest.py
+++ b/src/brigade/ingest.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Dict, List
 
 from . import budgets
+from .handoff_content import normalize_suggested_card_content
 from .selection import WRITER_INBOXES
 from .untrusted import scan_untrusted
 
@@ -181,6 +182,8 @@ def parse(path: Path) -> Dict[str, str]:
         last_pos = m.end()
     if last_name is not None:
         sections[last_name.lower()] = body[last_pos:].strip()
+    if "suggested card content" in sections:
+        sections["suggested card content"] = normalize_suggested_card_content(sections["suggested card content"])
     return sections
 
 

--- a/tests/test_handoff_cmd.py
+++ b/tests/test_handoff_cmd.py
@@ -126,6 +126,71 @@ def test_handoff_lint_accepts_fenced_card_content(tmp_path, capsys):
     assert "Suggested card content must start with YAML frontmatter" not in out
 
 
+def test_handoff_lint_accepts_comment_before_fenced_card_content(tmp_path, capsys):
+    path = tmp_path / "note.md"
+    path.write_text(
+        CARD_HANDOFF.replace(
+            "## Suggested card content\n---\n",
+            "## Suggested card content\n<!-- Card envelope. -->\n```markdown\n---\n",
+        )
+        + "\n```\n"
+    )
+
+    assert handoff_cmd.lint(target=tmp_path, paths=[path]) == 0
+
+    out = capsys.readouterr().out
+    assert "[ok]" in out
+
+
+def test_handoff_lint_rejects_comment_inside_fence_before_frontmatter(tmp_path, capsys):
+    path = tmp_path / "note.md"
+    path.write_text(
+        CARD_HANDOFF.replace(
+            "## Suggested card content\n---\n",
+            "## Suggested card content\n```markdown\n<!-- Card content starts here. -->\n---\n",
+        )
+        + "\n```\n"
+    )
+
+    assert handoff_cmd.lint(target=tmp_path, paths=[path]) == 1
+
+    out = capsys.readouterr().out
+    assert "Suggested card content must start with YAML frontmatter" in out
+
+
+def test_handoff_lint_rejects_fenced_card_content_without_closing_fence(tmp_path, capsys):
+    path = tmp_path / "note.md"
+    path.write_text(
+        CARD_HANDOFF.replace(
+            "## Suggested card content\n---\n",
+            "## Suggested card content\n```markdown\n---\n",
+        )
+    )
+
+    assert handoff_cmd.lint(target=tmp_path, paths=[path]) == 1
+
+    out = capsys.readouterr().out
+    assert "Markdown fence is missing a closing fence" in out
+    assert "Suggested card content must start with YAML frontmatter" not in out
+
+
+def test_handoff_lint_rejects_unsupported_card_content_fence_language(tmp_path, capsys):
+    path = tmp_path / "note.md"
+    path.write_text(
+        CARD_HANDOFF.replace(
+            "## Suggested card content\n---\n",
+            "## Suggested card content\n```yaml\n---\n",
+        )
+        + "\n```\n"
+    )
+
+    assert handoff_cmd.lint(target=tmp_path, paths=[path]) == 1
+
+    out = capsys.readouterr().out
+    assert "unsupported Markdown fence language" in out
+    assert "Suggested card content must start with YAML frontmatter" not in out
+
+
 def test_handoff_lint_allows_level_three_card_headings_without_warning(tmp_path, capsys):
     path = tmp_path / "note.md"
     path.write_text(CARD_HANDOFF + "\n### Details\n\nMore durable context.\n")

--- a/tests/test_handoff_cmd.py
+++ b/tests/test_handoff_cmd.py
@@ -108,6 +108,24 @@ def test_handoff_lint_accepts_card_handoff_without_document_sections(tmp_path, c
     assert "(create-card)" in out
 
 
+def test_handoff_lint_accepts_fenced_card_content(tmp_path, capsys):
+    path = tmp_path / "note.md"
+    path.write_text(
+        CARD_HANDOFF.replace(
+            "## Suggested card content\n---\n",
+            "## Suggested card content\n```markdown\n---\n",
+        )
+        + "\n```\n"
+    )
+
+    assert handoff_cmd.lint(target=tmp_path, paths=[path]) == 0
+
+    out = capsys.readouterr().out
+    assert "[ok]" in out
+    assert "(create-card)" in out
+    assert "Suggested card content must start with YAML frontmatter" not in out
+
+
 def test_handoff_lint_allows_level_three_card_headings_without_warning(tmp_path, capsys):
     path = tmp_path / "note.md"
     path.write_text(CARD_HANDOFF + "\n### Details\n\nMore durable context.\n")

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -66,6 +66,48 @@ def test_create_card_handoff_promotes_to_memory_cards(tmp_target: Path):
     assert processed.is_file()
 
 
+def test_fenced_create_card_handoff_promotes_without_fences(tmp_target: Path):
+    inbox = _seed(tmp_target)
+    _write_handoff(
+        inbox,
+        "2026-05-13-1000-promote-fenced.md",
+        """\
+        # Memory Handoff
+
+        ## Type
+        decision
+
+        ## Title
+        Promote fenced card
+
+        ## Recommended memory action
+        create-card
+
+        ## Target card
+        promote-fenced.md
+
+        ## Suggested card content
+        ```markdown
+        ---
+        topic: promote-fenced
+        category: test
+        tags: [test]
+        ---
+
+        # Promote fenced card
+
+        Body line.
+        ```
+        """,
+    )
+
+    assert ingest_mod.run(target=tmp_target, dry_run=False, promote_cards=True, route_documents=True) == 0
+
+    card = tmp_target / "memory" / "cards" / "promote-fenced.md"
+    assert card.read_text().startswith("---\ntopic: promote-fenced\n")
+    assert "```" not in card.read_text()
+
+
 def test_default_run_does_not_mutate_without_flags(tmp_target: Path):
     """Conservative default: no flags = everything routes to inbox."""
     inbox = _seed(tmp_target)

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -6,7 +6,7 @@ import textwrap
 from pathlib import Path
 
 
-from brigade import ingest as ingest_mod
+from brigade import handoff_cmd, ingest as ingest_mod
 from brigade.install import install_selection
 from brigade.selection import Selection
 
@@ -105,7 +105,153 @@ def test_fenced_create_card_handoff_promotes_without_fences(tmp_target: Path):
 
     card = tmp_target / "memory" / "cards" / "promote-fenced.md"
     assert card.read_text().startswith("---\ntopic: promote-fenced\n")
+    assert "# Promote fenced card" in card.read_text()
+    assert "Body line." in card.read_text()
     assert "```" not in card.read_text()
+
+
+def test_fenced_create_card_handoff_ignores_trailing_template_comment(tmp_target: Path):
+    inbox = _seed(tmp_target)
+    handoff = _write_handoff(
+        inbox,
+        "2026-05-13-1001-promote-fenced-comment.md",
+        """\
+        # Memory Handoff
+
+        ## Type
+        decision
+
+        ## Title
+        Promote fenced card with envelope comment
+
+        ## Summary
+        Preserve comments inside the card while ignoring template comments outside it.
+
+        ## Recommended memory action
+        create-card
+
+        ## Target card
+        promote-fenced-comment.md
+
+        ## Suggested card content
+        ```markdown
+        ---
+        topic: promote-fenced-comment
+        category: test
+        tags: [test]
+        ---
+
+        # Promote fenced card
+
+        <!-- Keep this card comment. -->
+        Body line.
+        ```
+
+        <!-- Template branch marker outside the card. -->
+        """,
+    )
+
+    assert handoff_cmd.lint_file(handoff).valid
+    assert ingest_mod.run(target=tmp_target, dry_run=False, promote_cards=True, route_documents=True) == 0
+
+    card = tmp_target / "memory" / "cards" / "promote-fenced-comment.md"
+    content = card.read_text()
+    assert "<!-- Keep this card comment. -->" in content
+    assert "Template branch marker" not in content
+    assert "```" not in content
+
+
+def test_fenced_create_card_handoff_ignores_leading_envelope_comment(tmp_target: Path):
+    inbox = _seed(tmp_target)
+    handoff = _write_handoff(
+        inbox,
+        "2026-05-13-1002-promote-fenced-leading-comment.md",
+        """\
+        # Memory Handoff
+
+        ## Type
+        decision
+
+        ## Title
+        Promote fenced card after an envelope comment
+
+        ## Summary
+        Ignore an envelope comment before the outer fence.
+
+        ## Recommended memory action
+        create-card
+
+        ## Target card
+        promote-fenced-leading-comment.md
+
+        ## Suggested card content
+        <!-- Card envelope. -->
+        ```markdown
+        ---
+        topic: promote-fenced-leading-comment
+        category: test
+        tags: [test]
+        ---
+
+        # Promote fenced card
+
+        Body line.
+        ```
+        """,
+    )
+
+    assert handoff_cmd.lint_file(handoff).valid
+    assert ingest_mod.run(target=tmp_target, dry_run=False, promote_cards=True, route_documents=True) == 0
+
+    card = tmp_target / "memory" / "cards" / "promote-fenced-leading-comment.md"
+    content = card.read_text()
+    assert content.startswith("---\ntopic: promote-fenced-leading-comment\n")
+    assert "Card envelope" not in content
+
+
+def test_fenced_create_card_handoff_rejects_comment_before_frontmatter(tmp_target: Path):
+    inbox = _seed(tmp_target)
+    handoff = _write_handoff(
+        inbox,
+        "2026-05-13-1003-inbox-fenced-content-comment.md",
+        """\
+        # Memory Handoff
+
+        ## Type
+        decision
+
+        ## Title
+        Reject fenced content without leading frontmatter
+
+        ## Summary
+        Keep lint and ingestion aligned on the first card content line.
+
+        ## Recommended memory action
+        create-card
+
+        ## Target card
+        inbox-fenced-content-comment.md
+
+        ## Suggested card content
+        ```markdown
+        <!-- This comment belongs to the card. -->
+        ---
+        topic: inbox-fenced-content-comment
+        ---
+
+        # Inbox fenced card
+        ```
+        """,
+    )
+
+    lint_result = handoff_cmd.lint_file(handoff)
+    assert not lint_result.valid
+    assert "Suggested card content must start with YAML frontmatter" in lint_result.errors
+
+    assert ingest_mod.run(target=tmp_target, dry_run=False, promote_cards=True, route_documents=True) == 0
+    assert not (tmp_target / "memory" / "cards" / "inbox-fenced-content-comment.md").exists()
+    inboxed = list((tmp_target / "memory" / "handoff-inbox").glob(f"*-{handoff.name}"))
+    assert len(inboxed) == 1
 
 
 def test_default_run_does_not_mutate_without_flags(tmp_target: Path):
@@ -544,6 +690,20 @@ def test_decide_promotes_clean_card(tmp_path):
     body = "---\nname: x\n---\nA perfectly ordinary durable fact about the system."
     outcome = ingest_mod.decide(_card_sections(body), target=tmp_path, promote_cards=True, route_documents=True)
     assert outcome.kind == "promoted"
+
+
+def test_decide_inboxes_card_with_incomplete_markdown_fence(tmp_path):
+    body = "```markdown\n---\nname: x\n---\nBody line."
+    outcome = ingest_mod.decide(_card_sections(body), target=tmp_path, promote_cards=True, route_documents=True)
+    assert outcome.kind == "inboxed"
+    assert outcome.reason == "Suggested card content Markdown fence is missing a closing fence"
+
+
+def test_decide_inboxes_card_with_unsupported_fence_language(tmp_path):
+    body = "```yaml\n---\nname: x\n---\nBody line.\n```"
+    outcome = ingest_mod.decide(_card_sections(body), target=tmp_path, promote_cards=True, route_documents=True)
+    assert outcome.kind == "inboxed"
+    assert outcome.reason == "Suggested card content uses an unsupported Markdown fence language: yaml"
 
 
 def _doc_sections(content_body):


### PR DESCRIPTION
## Summary

- Accept complete outer Markdown fences around Suggested card content.
- Normalize fenced content consistently in lint and ingestion.
- Reject missing closing fences and unsupported fence languages with specific errors.
- Ignore HTML envelope comments outside the fence while preserving comments inside card content.

## Root cause

Generated handoff templates wrap card YAML in a `markdown` code fence, while lint and ingestion expected the section to begin directly with `---`. Their separate preprocessing also let lint approve inputs that ingestion would inbox.

## Verification

- `./scripts/verify`
- 2,239 passed, 3 skipped
- 81.26% coverage
- Final Codex review completed with no remaining findings
- CodeRabbit findings reproduced and addressed

Closes #260

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Markdown-fenced card content is now recognized and cleaned up automatically during handoff processing.
  * Surrounding template and envelope comments are handled appropriately.

* **Bug Fixes**
  * Invalid or incomplete Markdown fences now produce clear validation errors.
  * Invalid card content is routed to the inbox instead of creating an incomplete card.
  * Card handoff linting now correctly accepts valid fenced Markdown content.

* **Tests**
  * Added coverage for valid fences, comments, missing closing fences, unsupported languages, and missing frontmatter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->