### PR TITLE
fix(roster): never auto-pull ollama models; small starter default

### DIFF
--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -256,7 +256,7 @@ cli = "codex"
 role = "Plan the work, choose useful workers, and synthesize the final answer."
 
 [agents.local_researcher]
-cli = "ollama:llama3.3"
+cli = "ollama:llama3.2:3b"
 role = "Research locally and summarize useful findings."
 timeout_seconds = 300
 
@@ -272,6 +272,11 @@ sandbox = "workspace-write"
 ```
 
 Edit the roles, CLI refs, and timeouts to match the tools on your machine.
+Brigade never auto-pulls Ollama models: dispatch to an `ollama:<model>` seat
+fails with a clear message unless the model is already pulled locally, because
+a bare `ollama run` silently downloads the model first (tens of gigabytes for
+a large one). Pull the model yourself (`ollama pull llama3.2:3b`) or name one
+`ollama list` already shows; `brigade roster doctor` warns about missing ones.
 `limits.timeout_seconds` is the default per-agent timeout.
 `agents.<name>.timeout_seconds` overrides it for one agent.
 `limits.sandbox` is optional. When set to `read-only`, `workspace-write`, or

--- a/src/brigade/agents.py
+++ b/src/brigade/agents.py
@@ -358,6 +358,27 @@ def detect(cli_ref: str) -> bool:
     return proc.which(command_for(cli_ref)) is not None
 
 
+def ollama_model_present(model: str) -> tuple[bool, str]:
+    """Check whether an ollama model is already pulled locally.
+
+    `ollama run` on a missing model silently auto-pulls it (tens of GB for
+    large models), so callers must refuse to dispatch instead of letting the
+    pull start. Returns (present, detail); detail explains a False result.
+    """
+    listing = proc.run(["ollama", "list"], timeout=15.0)
+    if listing.code != 0:
+        reason = listing.stderr.strip() or f"exit {listing.code}"
+        return False, f"could not list local ollama models ({reason[:120]}); is the ollama server running?"
+    names = {line.split()[0] for line in listing.stdout.splitlines()[1:] if line.strip()}
+    wanted = {model} if ":" in model else {model, f"{model}:latest"}
+    if names & wanted:
+        return True, ""
+    return False, (
+        f"ollama model {model!r} is not pulled locally; brigade never auto-pulls. "
+        f"Run `ollama pull {model}` yourself or point the seat at an installed model"
+    )
+
+
 def run_agent(
     cli_ref: str,
     prompt: str,
@@ -388,6 +409,13 @@ def run_agent(
         from . import codex_cloud
 
         return codex_cloud.run_cloud_task(prompt, env_id=env_id, timeout=timeout, cwd=cwd)
+
+    if cli_ref.startswith(_OLLAMA_PREFIX):
+        ollama_model = cli_ref[len(_OLLAMA_PREFIX) :]
+        if ollama_model:
+            present, missing_detail = ollama_model_present(ollama_model)
+            if not present:
+                return AgentResult(text="", ok=False, detail=missing_detail)
 
     cursor_limitation = None
     if cli_ref == "cursor" and (read_only or sandbox == "read-only"):

--- a/src/brigade/cli/roster.py
+++ b/src/brigade/cli/roster.py
@@ -16,8 +16,9 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_roster_init.add_argument("--force", action="store_true", help="Overwrite an existing roster.")
     p_roster_init.add_argument(
         "--ollama-model",
-        default="llama3.3",
-        help="Default local researcher model for the starter roster.",
+        default=None,
+        help="Local researcher model for the starter roster (default: a small model; "
+        "brigade never auto-pulls, so pick one you have already pulled).",
     )
     p_roster_init.add_argument("--max-workers", type=int, default=4)
     p_roster_init.add_argument(
@@ -44,7 +45,7 @@ def dispatch(args) -> int:
         return roster_cmd.init(
             target=args.target,
             force=args.force,
-            ollama_model=args.ollama_model,
+            ollama_model=args.ollama_model if args.ollama_model is not None else roster_cmd.DEFAULT_OLLAMA_MODEL,
             max_workers=args.max_workers,
             review_model=args.review_model,
         )

--- a/src/brigade/roster_cmd.py
+++ b/src/brigade/roster_cmd.py
@@ -11,9 +11,13 @@ from . import roster as roster_mod
 
 DEFAULT_ROSTER_REL = ".brigade/roster.toml"
 
+# Small on purpose: a starter roster must never name a model whose absence
+# triggers a multi-GB `ollama pull` (a 43GB default once filled a root disk).
+DEFAULT_OLLAMA_MODEL = "llama3.2:3b"
+
 
 def default_roster_text(
-    *, ollama_model: str = "llama3.3", max_workers: int = 4, review_model: str | None = None
+    *, ollama_model: str = DEFAULT_OLLAMA_MODEL, max_workers: int = 4, review_model: str | None = None
 ) -> str:
     return f"""# Brigade aboyeur roster.
 # Edit agent roles and CLI refs to match the tools installed on this machine.
@@ -28,6 +32,8 @@ role = "Plan the work, choose useful workers, and synthesize the final answer."
 cli = "codex"
 role = "Make precise code changes and report what changed."
 
+# Brigade never auto-pulls ollama models: dispatch fails unless the model is
+# already local. Run `ollama pull {ollama_model}` once before using this seat.
 [agents.local_researcher]
 cli = "ollama:{ollama_model}"
 role = "Research locally and summarize useful findings."
@@ -85,7 +91,7 @@ def init(
     target: Path,
     *,
     force: bool = False,
-    ollama_model: str = "llama3.3",
+    ollama_model: str = DEFAULT_OLLAMA_MODEL,
     max_workers: int = 4,
     review_model: str | None = None,
 ) -> int:
@@ -157,6 +163,13 @@ def doctor(target: Path, *, roster_path: Path | None = None) -> int:
         binary = agents.command_for(agent.cli)
         if agents.detect(agent.cli):
             checks.append((doctor_mod.OK, f"agent: {name}", f"{agent.cli} via {binary}; timeout={timeout:g}s"))
+            if agent.cli.startswith("ollama:"):
+                ollama_model = agent.cli[len("ollama:") :]
+                present, missing_detail = agents.ollama_model_present(ollama_model)
+                if present:
+                    checks.append((doctor_mod.OK, f"agent: {name} ollama model", f"{ollama_model} pulled locally"))
+                else:
+                    checks.append((doctor_mod.WARN, f"agent: {name} ollama model", missing_detail))
         else:
             detail = f"{agent.cli} needs `{binary}` on PATH; timeout={timeout:g}s"
             if agent.cli == "claude":

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -339,6 +339,62 @@ def test_run_agent_reports_missing(monkeypatch):
     assert "not installed" in res.detail
 
 
+_OLLAMA_LIST_HEADER = "NAME                ID              SIZE      MODIFIED\n"
+
+
+def _fake_ollama_env(monkeypatch, list_result, run_result=None):
+    """Route proc.run so `ollama list` returns list_result and record any other argv."""
+    calls = []
+
+    def fake_run(argv, **kw):
+        calls.append(argv)
+        if argv[:2] == ["ollama", "list"]:
+            return list_result
+        return run_result if run_result is not None else agents.proc.Result(0, "answer", "")
+
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(agents.proc, "run", fake_run)
+    return calls
+
+
+def test_run_agent_ollama_refuses_model_not_pulled(monkeypatch):
+    # `ollama run` on a missing model silently auto-pulls it (43GB for
+    # llama3.3, once enough to fill a root disk); dispatch must refuse instead.
+    listing = agents.proc.Result(0, _OLLAMA_LIST_HEADER + "other:latest  abc  2.0 GB  2 days ago\n", "")
+    calls = _fake_ollama_env(monkeypatch, listing)
+    res = agents.run_agent("ollama:llama3.3", "hi")
+    assert res.ok is False
+    assert "not pulled locally" in res.detail
+    assert "never auto-pulls" in res.detail
+    assert calls == [["ollama", "list"]]
+
+
+def test_run_agent_ollama_runs_when_model_pulled(monkeypatch):
+    listing = agents.proc.Result(0, _OLLAMA_LIST_HEADER + "llama3.3:latest  abc  43 GB  2 days ago\n", "")
+    calls = _fake_ollama_env(monkeypatch, listing)
+    res = agents.run_agent("ollama:llama3.3", "hi")
+    assert res.ok is True
+    assert res.text == "answer"
+    assert calls[-1] == ["ollama", "run", "llama3.3", "hi"]
+
+
+def test_run_agent_ollama_matches_exact_tag(monkeypatch):
+    listing = agents.proc.Result(0, _OLLAMA_LIST_HEADER + "llama3.2:3b  abc  2.0 GB  2 days ago\n", "")
+    calls = _fake_ollama_env(monkeypatch, listing)
+    res = agents.run_agent("ollama:llama3.2:3b", "hi")
+    assert res.ok is True
+    assert calls[-1] == ["ollama", "run", "llama3.2:3b", "hi"]
+
+
+def test_run_agent_ollama_fails_seat_when_list_fails(monkeypatch):
+    listing = agents.proc.Result(1, "", "could not connect to ollama server")
+    calls = _fake_ollama_env(monkeypatch, listing)
+    res = agents.run_agent("ollama:llama3.2:3b", "hi")
+    assert res.ok is False
+    assert "could not list local ollama models" in res.detail
+    assert calls == [["ollama", "list"]]
+
+
 def test_run_agent_captures_output(monkeypatch):
     monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
     monkeypatch.setattr(agents.proc, "run", lambda argv, **kw: agents.proc.Result(0, "  answer  ", ""))

--- a/tests/test_roster_cmd.py
+++ b/tests/test_roster_cmd.py
@@ -15,9 +15,18 @@ def test_roster_init_writes_default_roster(tmp_target, capsys):
     text = path.read_text()
     assert 'orchestrator = "chef"' in text
     assert 'cli = "codex"' in text
-    assert 'cli = "ollama:llama3.3"' in text
+    assert 'cli = "ollama:llama3.2:3b"' in text
     assert "timeout_seconds = 600" in text
     assert str(path) in out
+
+
+def test_default_roster_ollama_model_is_small_and_documented():
+    # The starter roster must never name a model whose absence triggers a
+    # multi-GB auto-pull (a 43GB llama3.3 default once filled a root disk).
+    assert roster_cmd.DEFAULT_OLLAMA_MODEL == "llama3.2:3b"
+    text = roster_cmd.default_roster_text()
+    assert "llama3.3" not in text
+    assert "never auto-pulls" in text
 
 
 def test_roster_template_documents_model_pinning(tmp_target):
@@ -114,9 +123,39 @@ def test_roster_doctor_invalid_roster_fails(tmp_target, capsys):
 def test_roster_cli_init_and_doctor(monkeypatch, tmp_target, capsys):
     assert cli.main(["roster", "init", "--target", str(tmp_target), "--ollama-model", "mistral"]) == 0
     monkeypatch.setattr(agents.proc, "which", lambda cmd: "/x/" + cmd)
+    monkeypatch.setattr(agents, "ollama_model_present", lambda model: (True, ""))
     assert cli.main(["roster", "doctor", "--target", str(tmp_target)]) == 0
     out = capsys.readouterr().out
     assert "ollama:mistral" in out
+
+
+def test_roster_cli_init_default_uses_small_ollama_model(tmp_target):
+    assert cli.main(["roster", "init", "--target", str(tmp_target)]) == 0
+    text = (tmp_target / ".brigade" / "roster.toml").read_text()
+    assert f'cli = "ollama:{roster_cmd.DEFAULT_OLLAMA_MODEL}"' in text
+
+
+def test_roster_doctor_warns_when_ollama_model_not_pulled(monkeypatch, tmp_target, capsys):
+    roster_cmd.init(tmp_target)
+    monkeypatch.setattr(agents.proc, "which", lambda cmd: "/x/" + cmd)
+    monkeypatch.setattr(
+        agents, "ollama_model_present", lambda model: (False, f"ollama model {model!r} is not pulled locally")
+    )
+    rc = roster_cmd.doctor(tmp_target)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "[warn]" in out
+    assert "not pulled locally" in out
+
+
+def test_roster_doctor_ok_when_ollama_model_pulled(monkeypatch, tmp_target, capsys):
+    roster_cmd.init(tmp_target)
+    monkeypatch.setattr(agents.proc, "which", lambda cmd: "/x/" + cmd)
+    monkeypatch.setattr(agents, "ollama_model_present", lambda model: (True, ""))
+    rc = roster_cmd.doctor(tmp_target)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "pulled locally" in out
 
 
 def _write_roster(tmp_target, body: str) -> None:
@@ -156,6 +195,7 @@ def test_roster_doctor_fails_pin_on_ollama_ref(monkeypatch, tmp_target, capsys):
         'orchestrator = "chef"\n[agents.chef]\ncli = "ollama:llama3.3"\nmodel = "mistral"\nrole = "plan"\n',
     )
     monkeypatch.setattr(agents.proc, "which", lambda cmd: "/x/" + cmd)
+    monkeypatch.setattr(agents, "ollama_model_present", lambda model: (True, ""))
     rc = roster_cmd.doctor(tmp_target)
     out = capsys.readouterr().out
     assert rc == 1


### PR DESCRIPTION
## Problem

On 2026-07-15 a `brigade run` in a worktree dispatched to the starter roster's default `local_researcher` seat (`ollama:llama3.3`). The model was not pulled, so `ollama run` silently auto-pulled all 43GB of it onto a 98G root filesystem, filling it to 0 bytes and crashing an unrelated gateway service with ENOSPC.

Two compounding defaults caused this: the starter roster names a huge model, and dispatch happily lets `ollama run` download anything that is missing.

## Fix

- **Dispatch preflight:** `run_agent` now checks `ollama list` before routing to any `ollama:<model>` seat. If the model is not already local (exact tag match, or `<name>:latest` for untagged refs), the seat fails with a clear message instead of triggering a pull. If `ollama list` itself fails, the seat fails with that reason. Brigade never auto-pulls.
- **Safe starter default:** `roster init` drops `llama3.3` for `llama3.2:3b` (`DEFAULT_OLLAMA_MODEL`, single source of truth used by both the command and the CLI flag), and the generated roster documents the no-auto-pull contract next to the seat.
- **Doctor:** `roster doctor` warns when an ollama seat names a model that is not pulled locally.
- Docs updated (`docs/technical-guide.md`); tests cover the refusal path, the happy path, tag matching, `ollama list` failure, the new default, and the doctor warn.

## Verification

`./scripts/verify` via `brigade work verify run --capture brigade-work`: exit 0 (ruff, format check, mypy, version sync, pytest with coverage floor).