### PR TITLE
fix(run): clean up failed control socket startup

### DIFF
--- a/src/brigade/run_control.py
+++ b/src/brigade/run_control.py
@@ -101,16 +101,29 @@ class ControlServer:
         except FileNotFoundError:
             pass
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        bound = False
         try:
             sock.bind(str(self.path))
+            bound = True
             sock.listen()
             sock.settimeout(0.1)
-        except OSError as exc:
-            sock.close()
+            thread = threading.Thread(target=self._serve, name="brigade-run-control", daemon=True)
+            self._sock = sock
+            self._thread = thread
+            thread.start()
+        except (OSError, RuntimeError) as exc:
+            self._sock = None
+            self._thread = None
+            try:
+                sock.close()
+            except OSError:
+                pass
+            if bound:
+                try:
+                    self.path.unlink()
+                except OSError:
+                    pass
             raise ControlError(f"failed to start control socket: {exc}") from exc
-        self._sock = sock
-        self._thread = threading.Thread(target=self._serve, name="brigade-run-control", daemon=True)
-        self._thread.start()
 
     def close(self) -> None:
         self._stop.set()

--- a/tests/test_run_control.py
+++ b/tests/test_run_control.py
@@ -8,6 +8,8 @@ import threading
 import time
 from pathlib import Path
 
+import pytest
+
 from brigade import aboyeur, agents, cli, codex_appserver, run_control
 from brigade.roster import Agent, Roster
 
@@ -80,6 +82,54 @@ def test_control_socket_round_trip_with_fake_registry(tmp_path):
         ("interrupt", "turn-1", ""),
     ]
     assert not (tmp_path / "control.sock").exists()
+
+
+def test_control_server_start_cleans_up_after_thread_start_failure(tmp_path, monkeypatch):
+    path = tmp_path / "control.sock"
+    server = run_control.ControlServer(path, run_control.LiveTurnRegistry())
+    startup_error = RuntimeError("forced thread start failure")
+
+    def fail_start(_thread):
+        raise startup_error
+
+    monkeypatch.setattr(run_control.threading.Thread, "start", fail_start)
+
+    with pytest.raises(run_control.ControlError, match="forced thread start failure") as exc_info:
+        server.start()
+
+    assert exc_info.value.__cause__ is startup_error
+    assert not path.exists()
+    assert server._sock is None
+    assert server._thread is None
+
+
+def test_control_server_start_does_not_unlink_socket_owned_by_bind_race(tmp_path, monkeypatch):
+    path = tmp_path / "control.sock"
+    server = run_control.ControlServer(path, run_control.LiveTurnRegistry())
+    real_socket = run_control.socket.socket
+    competing_socket = real_socket(run_control.socket.AF_UNIX, run_control.socket.SOCK_STREAM)
+    bind_error = OSError("address already in use")
+
+    class BindRaceSocket:
+        def bind(self, socket_path):
+            competing_socket.bind(socket_path)
+            competing_socket.listen()
+            raise bind_error
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_control.socket, "socket", lambda *_args: BindRaceSocket())
+
+    try:
+        with pytest.raises(run_control.ControlError, match="address already in use") as exc_info:
+            server.start()
+
+        assert exc_info.value.__cause__ is bind_error
+        assert path.exists()
+    finally:
+        competing_socket.close()
+        path.unlink(missing_ok=True)
 
 
 def test_run_turn_reports_turn_start_callback():


### PR DESCRIPTION
## Summary

`ControlServer.start()` closed its socket after a partial startup failure but could leave the bound Unix socket path behind. Thread startup also happened outside the setup error handler.

- Keep socket setup and control-thread startup in one guarded block.
- Reset server state and remove the socket path after failures that occur after this server binds it.
- Preserve the original startup exception as the `ControlError` cause without unlinking a competing process's socket.

## Verification

- Control-server module through Brigade: 8 passed.
- `./scripts/verify` through Brigade, run `20260715-235758-work-verify-b8e6e0`: 2,230 passed, 3 skipped, 81.25% coverage.
- `codex review --uncommitted`: no actionable findings.

Closes #268