### PR TITLE
fix(run): identify invalid roster paths

### DIFF
--- a/src/brigade/cli/run.py
+++ b/src/brigade/cli/run.py
@@ -211,7 +211,7 @@ def dispatch(args) -> int:
         )
         return 2
     except ValueError as exc:
-        print(f"error: invalid roster: {exc}", file=sys.stderr)
+        print(f"error: invalid roster at {roster_path}: {exc}", file=sys.stderr)
         return 2
     if args.worker is not None:
         worker_error = _direct_worker_error(args.worker, loaded_roster, roster_mod)

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -423,6 +423,34 @@ role = "code"
     assert seen["orchestrator"] == "chef"
 
 
+def test_run_cli_identifies_fallback_roster_in_validation_error(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "home"
+    roster_path = home / ".brigade" / "roster.toml"
+    roster_path.parent.mkdir(parents=True)
+    roster_path.write_text(
+        """
+orchestrator = "chef"
+
+[agents.chef]
+cli = "claude"
+role = "plan"
+
+[limits]
+allow_models = ["codex"]
+"""
+    )
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(Path, "home", lambda: home)
+
+    rc = cli.main(["run", "x", "--dry-run", "--no-artifacts"])
+
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert f"invalid roster at {roster_path}" in err
+    assert "agents.chef.cli is not allowed by limits.allow_models" in err
+
+
 def test_run_cli_explicit_roster_does_not_fall_back_to_home(tmp_path, monkeypatch, capsys):
     home = tmp_path / "home"
     config_dir = home / ".brigade"


### PR DESCRIPTION
## Summary

`brigade run` reported roster validation failures without naming the file it loaded. This was ambiguous when the command resolved the user-level fallback instead of a repository roster.

- Include the resolved roster path in validation errors.
- Preserve the original validation detail.
- Cover an invalid user-level fallback roster with a regression test.

## Verification

- Run CLI tests through Brigade: 36 passed.
- Full `./scripts/verify` through Brigade, run `20260716-003234-work-verify-fcff5f`: 2,229 passed, 3 skipped, 81.26% coverage.
- `codex review --uncommitted`: no findings.

Closes #243
