### PR TITLE
fix(mcp): sync Cursor user scope globally

### DIFF
--- a/docs/mcp-sync.md
+++ b/docs/mcp-sync.md
@@ -59,6 +59,7 @@ tool expands at launch.
 | OpenCode | `opencode.json` | JSON `mcp`; `{type:"local",command:[cmd,...args],environment}` |
 | Antigravity | `~/.gemini/config/mcp_config.json` | JSON `mcpServers`; remote uses `serverUrl`. **User-scoped** (`--user-scope`) |
 | Claude user | `~/.claude.json` | JSON `mcpServers`. **User-scoped** (`--user-scope`) |
+| Cursor user | `~/.cursor/mcp.json` | JSON `mcpServers`. **User-scoped** (`--harness cursor --user-scope`) |
 | Codex user | `~/.codex/config.toml` | TOML `[mcp_servers.<name>]`. **User-scoped** (`--user-scope`) |
 | Grok user | `~/.grok/config.toml` | TOML `[mcp_servers.<name>]`. **User-scoped** (`--user-scope`) |
 | OpenClaw | `~/.openclaw/openclaw.json` | JSON `mcp.servers`. **User-scoped** (`--user-scope`) |
@@ -81,11 +82,17 @@ brigade mcp list                       # show the catalog
 brigade mcp plan                       # preview what a sync would do (read-only)
 brigade mcp sync                       # dry-run across every configured tool
 brigade mcp sync --write               # actually merge into each tool's config
-brigade mcp sync --write --user-scope  # also write Antigravity's user-global config
+brigade mcp sync --write --user-scope  # also write configured user-global targets
+brigade mcp sync --harness cursor --user-scope --write  # write ~/.cursor/mcp.json
 brigade mcp doctor                     # validate the catalog, report unsupported tools
 brigade mcp import --harness cursor --merge   # read an existing config into the catalog
 brigade operator sync-mcp --write      # validate -> sync -> summary, one receipt
 ```
+
+Cursor stays project-scoped unless both `--harness cursor` and `--user-scope`
+are present. A user-scoped Cursor projection drops a GraphTrail `--db` argument
+when that database resolves inside the source repository, so the global client
+does not pin every workspace to one repository.
 
 ## Merge and ownership
 

--- a/src/brigade/mcp_adapters.py
+++ b/src/brigade/mcp_adapters.py
@@ -267,6 +267,7 @@ def _json_write_file(
     top_key: str,
     *,
     collect_inputs: bool = False,
+    reject_invalid_existing: bool = False,
 ) -> str:
     doc: dict[str, Any] = {}
     if text:
@@ -274,19 +275,27 @@ def _json_write_file(
             loaded = json.loads(text)
             if isinstance(loaded, dict):
                 doc = loaded
-        except json.JSONDecodeError:
+            elif reject_invalid_existing:
+                raise ValueError("existing JSON configuration must be an object; refusing to overwrite")
+        except json.JSONDecodeError as exc:
+            if reject_invalid_existing:
+                raise ValueError("existing JSON configuration is invalid; refusing to overwrite") from exc
             doc = {}
     # Navigate/create the (possibly nested) server map, preserving every sibling key.
     parts = top_key.split(".")
     node = doc
     for part in parts[:-1]:
         child = node.get(part)
+        if reject_invalid_existing and part in node and not isinstance(child, dict):
+            raise ValueError(f"existing {top_key} section must be an object; refusing to overwrite")
         if not isinstance(child, dict):
             child = {}
             node[part] = child
         node = child
     leaf = parts[-1]
     section = node.get(leaf)
+    if reject_invalid_existing and leaf in node and not isinstance(section, dict):
+        raise ValueError(f"existing {top_key} section must be an object; refusing to overwrite")
     if not isinstance(section, dict):
         section = {}
     for name in remove:
@@ -903,7 +912,12 @@ def _openclaw_from_provider(
 
 
 def _make_json_mcpservers(
-    harness: str, path: str, *, user_scope: bool = False, remote_url_key: str = "url"
+    harness: str,
+    path: str,
+    *,
+    user_scope: bool = False,
+    remote_url_key: str = "url",
+    reject_invalid_existing: bool = False,
 ) -> McpAdapter:
     env_style = "expand"
     return McpAdapter(
@@ -919,7 +933,13 @@ def _make_json_mcpservers(
             n, r, remote_url_key=remote_url_key, keep_secrets=keep_secrets
         ),
         read_file=lambda t: _json_read_file(t, "mcpServers"),
-        write_file=lambda t, o, r: _json_write_file(t, o, r, "mcpServers"),
+        write_file=lambda t, o, r: _json_write_file(
+            t,
+            o,
+            r,
+            "mcpServers",
+            reject_invalid_existing=reject_invalid_existing,
+        ),
     )
 
 
@@ -984,6 +1004,12 @@ ADAPTERS: dict[str, McpAdapter] = {
     # User-global scopes: these write the per-user config the tool reads everywhere,
     # not a per-repo file. Gated behind --user-scope. Used to sync a machine's daily tools.
     "claude-user": _make_json_mcpservers("claude-user", "~/.claude.json", user_scope=True),
+    "cursor-user": _make_json_mcpservers(
+        "cursor-user",
+        "~/.cursor/mcp.json",
+        user_scope=True,
+        reject_invalid_existing=True,
+    ),
     "codex-user": McpAdapter(
         harness="codex-user",
         path="~/.codex/config.toml",

--- a/src/brigade/mcp_adapters.py
+++ b/src/brigade/mcp_adapters.py
@@ -270,7 +270,7 @@ def _json_write_file(
     reject_invalid_existing: bool = False,
 ) -> str:
     doc: dict[str, Any] = {}
-    if text:
+    if text is not None:
         try:
             loaded = json.loads(text)
             if isinstance(loaded, dict):

--- a/src/brigade/mcp_cmd.py
+++ b/src/brigade/mcp_cmd.py
@@ -100,10 +100,17 @@ def _configured_harnesses(target: Path) -> set[str] | None:
     return set(cfg.selection.harnesses)
 
 
+def _scoped_harness(harness: str, *, user_scope: bool) -> str:
+    if harness == "cursor" and user_scope:
+        return "cursor-user"
+    return harness
+
+
 def active_targets(target: Path, *, harness: str | None, user_scope: bool) -> tuple[list[str], list[str]]:
     """Resolve which adapters this run touches. Returns (harnesses, notes)."""
     notes: list[str] = []
     if harness is not None:
+        harness = _scoped_harness(harness, user_scope=user_scope)
         if harness not in ADAPTERS:
             return [], [f"unknown MCP target {harness!r} (known: {', '.join(MCP_TARGETS)})"]
         adapter = ADAPTERS[harness]
@@ -116,6 +123,10 @@ def active_targets(target: Path, *, harness: str | None, user_scope: bool) -> tu
     for name in MCP_TARGETS:
         adapter = ADAPTERS[name]
         if adapter.user_scope and not user_scope:
+            continue
+        if name == "cursor-user":
+            # Cursor's global config is selected only by the explicit
+            # --harness cursor --user-scope combination.
             continue
         if name == "vscode":
             # vscode is not a Brigade harness. Only include it when the repo
@@ -136,7 +147,59 @@ def active_targets(target: Path, *, harness: str | None, user_scope: bool) -> tu
 
 
 def _server_targets_harness(server: CanonicalServer, harness: str) -> bool:
-    return server.targets is None or harness in server.targets
+    if server.targets is None:
+        return True
+    if harness == "cursor-user":
+        return "cursor" in server.targets or "cursor-user" in server.targets
+    return harness in server.targets
+
+
+def _repo_local_path(target: Path, value: str) -> bool:
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        return False
+    resolved = path.resolve()
+    try:
+        resolved.relative_to(target.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+def _without_repo_graphtrail_db_pin(target: Path, args: tuple[str, ...]) -> tuple[str, ...]:
+    cleaned: list[str] = []
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg == "--db" and index + 1 < len(args) and _repo_local_path(target, args[index + 1]):
+            index += 2
+            continue
+        if arg.startswith("--db=") and _repo_local_path(target, arg.split("=", 1)[1]):
+            index += 1
+            continue
+        cleaned.append(arg)
+        index += 1
+    return tuple(cleaned)
+
+
+def _project_server(target: Path, harness: str, server: CanonicalServer) -> dict[str, Any]:
+    adapter = ADAPTERS[harness]
+    projected = adapter.to_provider(server)
+    command_name = Path(server.command or "").name.lower()
+    if (
+        harness != "cursor-user"
+        or server.is_remote
+        or (server.name.lower() != "graphtrail" and "graphtrail" not in command_name)
+    ):
+        return projected
+    args = _without_repo_graphtrail_db_pin(target, server.args)
+    if args == server.args:
+        return projected
+    if args:
+        projected["args"] = list(args)
+    else:
+        projected.pop("args", None)
+    return projected
 
 
 def _plan_for_harness(
@@ -166,7 +229,7 @@ def _plan_for_harness(
     for name, server in sorted(desired.items()):
         if name_filter is not None and name != name_filter:
             continue
-        provider_dict = adapter.to_provider(server)
+        provider_dict = _project_server(target, harness, server)
         desired_fp = localio.stable_hash(provider_dict)
         canon_fp = localio.stable_hash(mcp_adapters.server_to_dict(server))
         record = owned.get(name)
@@ -457,16 +520,22 @@ def plan(
             _plan_for_harness(target, h, servers, state, force=False, prune=True, adopt=False, name_filter=name)
         )
     counts = _counts(items)
+    source_catalog = str(canonical_path(target))
+    destination_files = [str(mcp_adapters.resolve_path(ADAPTERS[h], target)) for h in harnesses]
     payload = {
         "target": str(target),
+        "source_catalog": source_catalog,
+        "destination_files": destination_files,
         "harnesses": harnesses,
         "notes": notes,
         "items": _public_items(items),
         "counts": counts,
     }
-    lines = [f"{i['harness']:<12} {i['server']:<20} {i['status']:<14} -> {i['action']}" for i in items] or [
-        "(nothing to plan)"
-    ]
+    lines = [f"source: {source_catalog}"]
+    lines.extend(f"destination: {path}" for path in destination_files)
+    lines.extend(f"{i['harness']:<12} {i['server']:<20} {i['status']:<14} -> {i['action']}" for i in items)
+    if not items:
+        lines.append("(nothing to plan)")
     lines.extend(notes)
     rc = 1 if counts["conflict"] else 0
     return _emit(payload, json_output, lines, rc)
@@ -509,7 +578,7 @@ def sync(
             server_name = item["server"]
             action, status = item["action"], item["status"]
             if action in ("create", "update"):
-                to_write[server_name] = adapter.to_provider(servers[server_name])
+                to_write[server_name] = _project_server(target, h, servers[server_name])
                 owner_map[server_name] = {
                     "canonical_fingerprint": item["_canon_fp"],
                     "projected_fingerprint": item["_proj_fp"],
@@ -522,14 +591,18 @@ def sync(
             elif status == "current":
                 # Owned + matching (or reconciled after state loss): re-assert ownership and
                 # keep it present in the file. Identical content, so not a "change".
-                to_write[server_name] = adapter.to_provider(servers[server_name])
+                to_write[server_name] = _project_server(target, h, servers[server_name])
                 owner_map[server_name] = {
                     "canonical_fingerprint": item["_canon_fp"],
                     "projected_fingerprint": item["_proj_fp"],
                 }
         if write and (changed or any(i.get("_reconciled") for i in items)):
             existing = path.read_text() if path.is_file() else None
-            new_text = adapter.write_file(existing, to_write, to_remove)
+            try:
+                new_text = adapter.write_file(existing, to_write, to_remove)
+            except ValueError as exc:
+                message = f"{path}: {exc}"
+                return _emit({"errors": [message]}, json_output, [f"error: {message}"], 2)
             path.parent.mkdir(parents=True, exist_ok=True)
             path.write_text(new_text)
             files_written.append(str(path))
@@ -537,8 +610,12 @@ def sync(
     if write:
         _save_state(target, state)
     counts = _counts(all_items)
+    source_catalog = str(canonical_path(target))
+    destination_files = [str(mcp_adapters.resolve_path(ADAPTERS[h], target)) for h in harnesses]
     payload = {
         "target": str(target),
+        "source_catalog": source_catalog,
+        "destination_files": destination_files,
         "harnesses": harnesses,
         "wrote": write,
         "files_written": files_written,
@@ -547,7 +624,8 @@ def sync(
         "counts": counts,
     }
     verb = "wrote" if write else "would"
-    lines = [f"brigade mcp sync ({'write' if write else 'dry-run'}): {target}"]
+    lines = [f"brigade mcp sync ({'write' if write else 'dry-run'}): {target}", f"source: {source_catalog}"]
+    lines += [f"destination: {path}" for path in destination_files]
     lines += [f"{i['harness']:<12} {i['server']:<20} {i['status']:<14} -> {i['action']}" for i in all_items]
     lines += [f"{verb}: {f}" for f in files_written]
     lines += notes
@@ -592,6 +670,7 @@ def import_servers(
     json_output: bool = False,
 ) -> int:
     target = target.expanduser().resolve()
+    harness = _scoped_harness(harness, user_scope=user_scope)
     adapter = ADAPTERS.get(harness)
     if adapter is None:
         return _emit(

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -216,6 +216,10 @@ def test_cursor_user_scope_preserves_remote_graphtrail_shape(tmp_path, monkeypat
     ("invalid", "error"),
     [
         (
+            "",
+            "existing JSON configuration is invalid; refusing to overwrite",
+        ),
+        (
             '{"mcpServers": {"private": {"command": "private-mcp"}},}',
             "existing JSON configuration is invalid; refusing to overwrite",
         ),

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -42,6 +42,235 @@ def test_user_scope_antigravity_writes_home(tmp_path, monkeypatch):
     assert "github" in json.loads(cfg.read_text())["mcpServers"]
 
 
+def test_cursor_user_scope_uses_home_config_and_reports_paths(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _seed(repo)
+
+    capsys.readouterr()
+    assert mcp_cmd.plan(target=repo, harness="cursor", user_scope=True, json_output=True) == 0
+    plan = json.loads(capsys.readouterr().out)
+    destination = home / ".cursor" / "mcp.json"
+    assert plan["source_catalog"] == str(repo / ".brigade" / "mcp.json")
+    assert plan["destination_files"] == [str(destination)]
+    assert {item["file"] for item in plan["items"]} == {"~/.cursor/mcp.json"}
+
+    assert (
+        mcp_cmd.sync(
+            target=repo,
+            harness="cursor",
+            user_scope=True,
+            write=True,
+            json_output=True,
+        )
+        == 0
+    )
+    assert "github" in json.loads(destination.read_text())["mcpServers"]
+    assert not (repo / ".cursor" / "mcp.json").exists()
+
+
+def test_broad_user_scope_does_not_select_cursor_global_config(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _seed(repo)
+
+    capsys.readouterr()
+    assert mcp_cmd.plan(target=repo, user_scope=True, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert "cursor-user" not in payload["harnesses"]
+    assert str(home / ".cursor" / "mcp.json") not in payload["destination_files"]
+
+
+def test_cursor_user_scope_accepts_global_target_alias(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    mcp_cmd.init(target=repo, json_output=True)
+    mcp_cmd.add(
+        target=repo,
+        name="global-only",
+        command="global-mcp",
+        targets=["cursor-user"],
+        json_output=True,
+    )
+
+    capsys.readouterr()
+    assert mcp_cmd.plan(target=repo, harness="cursor", user_scope=True, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert [(item["server"], item["action"]) for item in payload["items"]] == [("global-only", "create")]
+
+
+def test_cursor_user_scope_normalizes_repo_graphtrail_pin_and_preserves_config(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "home"
+    cursor_config = home / ".cursor" / "mcp.json"
+    cursor_config.parent.mkdir(parents=True)
+    cursor_config.write_text(
+        json.dumps(
+            {
+                "theme": "keep",
+                "mcpServers": {
+                    "private": {
+                        "command": "private-mcp",
+                        "env": {"API_TOKEN": "keep-this-secret"},
+                    }
+                },
+            }
+        )
+    )
+    monkeypatch.setenv("HOME", str(home))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    mcp_cmd.init(target=repo, json_output=True)
+    repo_db = repo / ".graphtrail" / "graphtrail.db"
+    mcp_cmd.add(
+        target=repo,
+        name="graphtrail",
+        command="graphtrail",
+        args=["mcp", "--db", str(repo_db), "--verbose"],
+        timeout=60,
+        targets=["cursor"],
+        json_output=True,
+    )
+
+    before = cursor_config.read_text()
+    capsys.readouterr()
+    assert mcp_cmd.sync(target=repo, harness="cursor", user_scope=True, json_output=True) == 0
+    first_dry_run = json.loads(capsys.readouterr().out)
+    assert first_dry_run["counts"]["create"] == 1
+    assert cursor_config.read_text() == before
+
+    assert (
+        mcp_cmd.sync(
+            target=repo,
+            harness="cursor",
+            user_scope=True,
+            write=True,
+            json_output=True,
+        )
+        == 0
+    )
+    written = json.loads(cursor_config.read_text())
+    assert written["theme"] == "keep"
+    assert written["mcpServers"]["private"]["env"]["API_TOKEN"] == "keep-this-secret"
+    assert written["mcpServers"]["graphtrail"]["args"] == ["mcp", "--verbose"]
+
+    capsys.readouterr()
+    assert mcp_cmd.sync(target=repo, harness="cursor", user_scope=True, json_output=True) == 0
+    second_dry_run = json.loads(capsys.readouterr().out)
+    assert second_dry_run["counts"] == {"create": 0, "update": 0, "skip": 1, "conflict": 0, "remove": 0}
+    assert second_dry_run["items"][0]["status"] == "current"
+
+
+def test_cursor_user_scope_preserves_relative_graphtrail_pin(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    mcp_cmd.init(target=repo, json_output=True)
+    mcp_cmd.add(
+        target=repo,
+        name="graphtrail",
+        command="graphtrail",
+        args=["mcp", "--db", ".graphtrail/custom.db"],
+        targets=["cursor"],
+        json_output=True,
+    )
+
+    assert mcp_cmd.sync(target=repo, harness="cursor", user_scope=True, write=True, json_output=True) == 0
+    written = json.loads((home / ".cursor" / "mcp.json").read_text())
+    assert written["mcpServers"]["graphtrail"]["args"] == ["mcp", "--db", ".graphtrail/custom.db"]
+
+
+def test_cursor_user_scope_preserves_remote_graphtrail_shape(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    mcp_cmd.init(target=repo, json_output=True)
+    mcp_cmd.add(
+        target=repo,
+        name="graphtrail",
+        transport="http",
+        url="https://example.test/mcp",
+        args=["--db", str(repo / ".graphtrail/graphtrail.db"), "--verbose"],
+        targets=["cursor"],
+        json_output=True,
+    )
+
+    assert mcp_cmd.sync(target=repo, harness="cursor", user_scope=True, write=True, json_output=True) == 0
+    projected = json.loads((home / ".cursor" / "mcp.json").read_text())["mcpServers"]["graphtrail"]
+    assert projected == {"url": "https://example.test/mcp", "type": "http"}
+
+
+@pytest.mark.parametrize(
+    ("invalid", "error"),
+    [
+        (
+            '{"mcpServers": {"private": {"command": "private-mcp"}},}',
+            "existing JSON configuration is invalid; refusing to overwrite",
+        ),
+        (
+            '[{"mcpServers": {}}]',
+            "existing JSON configuration must be an object; refusing to overwrite",
+        ),
+        (
+            '{"mcpServers": [{"command": "private-mcp"}]}',
+            "existing mcpServers section must be an object; refusing to overwrite",
+        ),
+    ],
+)
+def test_cursor_user_scope_rejects_invalid_existing_config(tmp_path, monkeypatch, capsys, invalid, error):
+    home = tmp_path / "home"
+    cursor_config = home / ".cursor" / "mcp.json"
+    cursor_config.parent.mkdir(parents=True)
+    cursor_config.write_text(invalid)
+    monkeypatch.setenv("HOME", str(home))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _seed(repo)
+
+    capsys.readouterr()
+    assert mcp_cmd.sync(target=repo, harness="cursor", user_scope=True, write=True, json_output=True) == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["errors"] == [f"{cursor_config}: {error}"]
+    assert cursor_config.read_text() == invalid
+
+
+def test_cursor_user_scope_import_reads_home_config(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "home"
+    cursor_config = home / ".cursor" / "mcp.json"
+    cursor_config.parent.mkdir(parents=True)
+    cursor_config.write_text(json.dumps({"mcpServers": {"global": {"command": "global-mcp"}}}))
+    monkeypatch.setenv("HOME", str(home))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    mcp_cmd.init(target=repo, json_output=True)
+
+    capsys.readouterr()
+    assert (
+        mcp_cmd.import_servers(
+            target=repo,
+            harness="cursor",
+            user_scope=True,
+            json_output=True,
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["harness"] == "cursor-user"
+    assert payload["discovered"] == ["global"]
+
+
 def test_user_scope_grok_writes_home(tmp_path, monkeypatch, capsys):
     home = tmp_path / "home"
     home.mkdir()

--- a/tests/test_mcp_user_scope.py
+++ b/tests/test_mcp_user_scope.py
@@ -19,16 +19,23 @@ def _stdio():
 
 
 def test_user_scope_adapters_registered():
-    for name in ("codex-user", "claude-user", "openclaw", "grok-user", "hermes"):
+    for name in ("codex-user", "claude-user", "cursor-user", "openclaw", "grok-user", "hermes"):
         a = A.ADAPTERS[name]
         assert a.user_scope is True
         assert a.path.startswith("~")
-    assert {"codex-user", "claude-user", "openclaw", "grok-user", "hermes"} <= set(A.MCP_TARGETS)
+    assert {"codex-user", "claude-user", "cursor-user", "openclaw", "grok-user", "hermes"} <= set(A.MCP_TARGETS)
 
 
 def test_codex_user_is_toml_codex_shape():
     a = A.ADAPTERS["codex-user"]
     assert a.fmt == "toml" and a.path == "~/.codex/config.toml"
+
+
+def test_cursor_user_is_global_json_shape():
+    a = A.ADAPTERS["cursor-user"]
+    assert a.fmt == "json"
+    assert a.path == "~/.cursor/mcp.json"
+    assert a.top_key == "mcpServers"
 
 
 def test_grok_user_is_toml_grok_shape():


### PR DESCRIPTION
## Summary

`brigade mcp sync --harness cursor --user-scope` still targeted the repository's `.cursor/mcp.json`, so a normal Brigade repository could not project its catalog into Cursor's global config.

- Route explicit Cursor user-scope plans, syncs, and imports to `~/.cursor/mcp.json`.
- Show the source catalog and resolved destinations in plan and sync output.
- Remove a GraphTrail `--db` argument only when it is an absolute path inside the source repository.
- Preserve portable relative GraphTrail paths, foreign Cursor servers, sibling settings, and existing secret values.
- Refuse to overwrite empty, malformed, or incompatible global Cursor JSON.
- Keep broad `--user-scope` syncs from changing Cursor's global file unless Cursor is selected explicitly.
- Cover dry-run, write, repeat dry-run, target aliases, remote projections, and user-scope import behavior.

## Verification

- MCP suite through Brigade, run `20260716-024805-work-verify-c6877c`: 100 passed.
- Full `./scripts/verify` through Brigade, run `20260716-024814-work-verify-0d64de`: 2,240 passed, 3 skipped, 81.27% coverage.
- CodeRabbit's empty-file finding was fixed and covered by a regression test.
- `codex review --uncommitted`: all findings addressed; follow-up review found no actionable defects.

Closes #251

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added user-scoped Cursor MCP configuration support using `~/.cursor/mcp.json`.
  * Planning, syncing, and importing now report the source catalog and destination files.
  * Cursor user-scope syncing preserves unrelated configuration and existing servers while handling GraphTrail settings appropriately.

* **Bug Fixes**
  * Invalid or incorrectly structured existing Cursor configuration files are now rejected safely instead of being overwritten.
  * Improved scope selection prevents broad user-scope operations from targeting unintended Cursor configurations.

* **Tests**
  * Added comprehensive coverage for Cursor user-scope planning, syncing, importing, preservation, and validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->