### PR TITLE
fix(run): reject Grok progress-only output

### DIFF
--- a/src/brigade/agents.py
+++ b/src/brigade/agents.py
@@ -505,11 +505,7 @@ def run_agent(
     )
     structured_grok = cli_ref == "grok" and (read_only or sandbox == "read-only")
     if structured_grok:
-        try:
-            plan_index = argv.index("--permission-mode")
-        except ValueError:
-            plan_index = -1
-        if plan_index < 0 or argv[plan_index : plan_index + 2] != ["--permission-mode", "plan"]:
+        if argv[-2:] != ["--permission-mode", "plan"]:
             return AgentResult(
                 text="",
                 ok=False,
@@ -517,7 +513,7 @@ def run_agent(
                 requested_model=model,
                 reasoning=reasoning,
             )
-        argv[plan_index : plan_index + 2] = ["--sandbox", "read-only", "--always-approve"]
+        argv[-2:] = ["--sandbox", "read-only", "--always-approve"]
         argv.extend(["--json-schema", _GROK_RESULT_SCHEMA])
     result = proc.run(
         argv,

--- a/src/brigade/agents.py
+++ b/src/brigade/agents.py
@@ -6,6 +6,7 @@ does not store provider keys or import provider SDKs.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, List
@@ -14,6 +15,18 @@ from . import proc
 
 _OLLAMA_PREFIX = "ollama:"
 _CODEX_CLOUD_PREFIX = "codex-cloud:"
+_GROK_RESULT_SCHEMA = json.dumps(
+    {
+        "type": "object",
+        "properties": {
+            "kind": {"type": "string", "enum": ["answer"]},
+            "answer": {"type": "string", "minLength": 1},
+        },
+        "required": ["kind", "answer"],
+        "additionalProperties": False,
+    },
+    separators=(",", ":"),
+)
 
 
 def _claude_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | None) -> List[str]:
@@ -108,8 +121,8 @@ def _openhands_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path
 
 
 def _grok_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | None) -> List[str]:
-    # Headless `grok -p` stops silently (exit 0) at the first tool-approval
-    # gate, so a write task without an approval flag no-ops after its preamble.
+    # run_agent replaces plan mode with the native read-only filesystem sandbox
+    # before dispatch. Keep this base shape stable for argv construction callers.
     if read_only or sandbox == "read-only":
         return ["grok", "-p", prompt, "--permission-mode", "plan"]
     return ["grok", "-p", prompt, "--always-approve"]
@@ -204,6 +217,59 @@ def direct_cursor_read_only_limitation(model: str | None) -> str | None:
             'retry with transport = "acpx" and the reviewed transport_version'
         )
     return None
+
+
+def _parse_grok_final_output(stdout: str) -> tuple[str, str]:
+    """Extract a schema-constrained final answer from Grok's JSON envelope."""
+    base_error = "grok exited 0 without a structured final response"
+    raw = stdout.strip()
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return raw, base_error
+    if not isinstance(payload, dict):
+        return raw, base_error
+
+    diagnostic_parts: list[str] = []
+    stop_reason = payload.get("stopReason")
+    if isinstance(stop_reason, str) and stop_reason:
+        diagnostic_parts.append(f"stopReason={stop_reason}")
+    structured_output_error = payload.get("structuredOutputError")
+    structured_error_present = "structuredOutputError" in payload and structured_output_error is not None
+    if structured_error_present:
+        if isinstance(structured_output_error, str) and structured_output_error:
+            diagnostic_parts.append(structured_output_error)
+        else:
+            diagnostic_parts.append("structuredOutputError was present")
+
+    display_text = payload.get("text")
+    fallback = display_text.strip() if isinstance(display_text, str) else raw
+    if isinstance(display_text, str):
+        try:
+            nested = json.loads(display_text)
+        except json.JSONDecodeError:
+            nested = None
+        if isinstance(nested, dict) and isinstance(nested.get("answer"), str):
+            fallback = nested["answer"].strip()
+
+    structured = payload.get("structuredOutput")
+    answer = structured.get("answer") if isinstance(structured, dict) else None
+    exact_shape = (
+        isinstance(structured, dict)
+        and set(structured) == {"kind", "answer"}
+        and structured.get("kind") == "answer"
+        and isinstance(answer, str)
+        and bool(answer.strip())
+    )
+    if not exact_shape and not structured_error_present:
+        diagnostic_parts.append("structured output did not match expected schema")
+    successful_stop = stop_reason == "EndTurn"
+    no_structured_error = not structured_error_present
+    if not successful_stop or not no_structured_error or not exact_shape:
+        detail = f"{base_error} ({'; '.join(diagnostic_parts)})" if diagnostic_parts else base_error
+        return fallback, detail[:200]
+    assert isinstance(answer, str)
+    return answer.strip(), ""
 
 
 @dataclass(frozen=True)
@@ -428,20 +494,40 @@ def run_agent(
                 requested_model=model,
             )
 
+    argv = build_argv(
+        cli_ref,
+        prompt,
+        read_only=read_only,
+        sandbox=sandbox,
+        model=model,
+        reasoning=reasoning,
+        cwd=cwd,
+    )
+    structured_grok = cli_ref == "grok" and (read_only or sandbox == "read-only")
+    if structured_grok:
+        try:
+            plan_index = argv.index("--permission-mode")
+        except ValueError:
+            plan_index = -1
+        if plan_index < 0 or argv[plan_index : plan_index + 2] != ["--permission-mode", "plan"]:
+            return AgentResult(
+                text="",
+                ok=False,
+                detail="internal error: grok read-only argv missing --permission-mode plan",
+                requested_model=model,
+                reasoning=reasoning,
+            )
+        argv[plan_index : plan_index + 2] = ["--sandbox", "read-only", "--always-approve"]
+        argv.extend(["--json-schema", _GROK_RESULT_SCHEMA])
     result = proc.run(
-        build_argv(
-            cli_ref,
-            prompt,
-            read_only=read_only,
-            sandbox=sandbox,
-            model=model,
-            reasoning=reasoning,
-            cwd=cwd,
-        ),
+        argv,
         timeout=timeout,
         cwd=cwd,
     )
     text = result.stdout.strip()
+    structured_error = ""
+    if structured_grok:
+        text, structured_error = _parse_grok_final_output(result.stdout)
     if result.code != 0:
         detail = result.stderr.strip() or f"exit {result.code}"
         return AgentResult(
@@ -452,6 +538,17 @@ def run_agent(
             stderr=result.stderr,
             exit_code=result.code,
             timed_out=result.code == 124,
+            requested_model=model,
+            reasoning=reasoning,
+        )
+    if structured_error:
+        return AgentResult(
+            text=text,
+            ok=False,
+            detail=structured_error,
+            stdout=result.stdout,
+            stderr=result.stderr,
+            exit_code=result.code,
             requested_model=model,
             reasoning=reasoning,
         )

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -47,6 +47,23 @@ def _model_roster():
     )
 
 
+def _grok_roster():
+    return Roster(
+        orchestrator="chef",
+        agents={
+            "chef": Agent("chef", "codex", "plan and synthesize"),
+            "grok_cli": Agent(
+                "grok_cli",
+                "grok",
+                "review focused code changes",
+                model="grok-4.5",
+                reasoning="high",
+            ),
+        },
+        max_workers=1,
+    )
+
+
 def _restricted_roster():
     return Roster(
         orchestrator="chef",
@@ -979,6 +996,74 @@ def test_run_direct_worker_failure_reports_and_records(monkeypatch, capsys, tmp_
     synthesis = json.loads((output_dir / "synthesis.json").read_text())
     assert synthesis["mode"] == "direct-worker"
     assert synthesis["result"]["ok"] is False
+
+
+def test_run_direct_grok_progress_only_output_fails_with_honest_artifacts(monkeypatch, tmp_path):
+    output = (
+        "Reviewing the README.md and tools/brigade.md diffs against Brigade 0.22.0. "
+        "Gathering the git diffs and current file content first."
+    )
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+    monkeypatch.setattr(agents.proc, "run", lambda argv, **kwargs: agents.proc.Result(0, output + "\n", ""))
+    output_dir = tmp_path / "run"
+
+    rc = aboyeur.run(
+        "Review the current documentation diff and report only actionable findings.",
+        _grok_roster(),
+        cwd=tmp_path,
+        worker="grok_cli",
+        output_dir=output_dir,
+        read_only=True,
+        route_enabled=False,
+    )
+
+    assert rc == 2
+    run_payload = json.loads((output_dir / "run.json").read_text())
+    assert run_payload["status"] == "failed"
+    assert run_payload["error"] == "grok exited 0 without a structured final response"
+    assert run_payload["suspected_noop"] is False
+    worker = json.loads((output_dir / "worker-results.json").read_text())["results"][0]
+    assert worker["ok"] is False
+    assert worker["detail"] == "grok exited 0 without a structured final response"
+    assert worker["exit_code"] == 0
+    assert (output_dir / worker["stdout_log"]).read_text() == output + "\n"
+    assert (output_dir / "final.txt").read_text().strip() == output
+
+
+def test_run_direct_grok_structured_final_succeeds_with_honest_artifacts(monkeypatch, tmp_path):
+    answer = "No actionable findings."
+    structured = {"kind": "answer", "answer": answer}
+    stdout = json.dumps(
+        {
+            "text": json.dumps(structured),
+            "stopReason": "EndTurn",
+            "sessionId": "019f0000-0000-7000-8000-000000000001",
+            "requestId": "00000000-0000-4000-8000-000000000001",
+            "structuredOutput": structured,
+        }
+    )
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+    monkeypatch.setattr(agents.proc, "run", lambda argv, **kwargs: agents.proc.Result(0, stdout + "\n", ""))
+    output_dir = tmp_path / "run"
+
+    rc = aboyeur.run(
+        "Review the current documentation diff and report only actionable findings.",
+        _grok_roster(),
+        cwd=tmp_path,
+        worker="grok_cli",
+        output_dir=output_dir,
+        read_only=True,
+        route_enabled=False,
+    )
+
+    assert rc == 0
+    assert json.loads((output_dir / "run.json").read_text())["status"] == "ok"
+    worker = json.loads((output_dir / "worker-results.json").read_text())["results"][0]
+    assert worker["ok"] is True
+    assert worker["text"] == answer
+    assert worker["exit_code"] == 0
+    assert (output_dir / worker["stdout_log"]).read_text() == stdout + "\n"
+    assert (output_dir / "final.txt").read_text().strip() == answer
 
 
 def test_run_direct_worker_writes_complete_process_logs(monkeypatch, tmp_path):

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import pytest
@@ -507,6 +508,164 @@ def test_run_agent_classifies_silent_adapter_exit(monkeypatch, cli_ref):
     assert result.ok is False
     assert result.detail == f"{cli_ref} exited 0 without output; check trust, permissions, and model availability"
     assert result.exit_code == 0
+
+
+def _grok_json_output(answer: str, *, structured: bool = True, stop_reason: str = "EndTurn") -> str:
+    result = {"kind": "answer", "answer": answer}
+    return json.dumps(
+        {
+            "text": json.dumps(result),
+            "stopReason": stop_reason,
+            "sessionId": "019f0000-0000-7000-8000-000000000001",
+            "requestId": "00000000-0000-4000-8000-000000000001",
+            "structuredOutput": result if structured else None,
+            "structuredOutputError": None if structured else "model did not produce structured output",
+        }
+    )
+
+
+def test_run_agent_rejects_grok_progress_without_structured_final_output(monkeypatch):
+    output = (
+        "Reviewing the README.md and tools/brigade.md diffs against Brigade 0.22.0. "
+        "Gathering the git diffs and current file content first."
+    )
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+    monkeypatch.setattr(agents.proc, "run", lambda argv, **kwargs: agents.proc.Result(0, output + "\n", ""))
+
+    result = agents.run_agent("grok", "review it", read_only=True, model="grok-4.5")
+
+    assert result.ok is False
+    assert result.detail == "grok exited 0 without a structured final response"
+    assert result.text == output
+    assert result.stdout == output + "\n"
+    assert result.exit_code == 0
+
+
+def test_run_agent_rejects_grok_json_without_structured_final_output(monkeypatch):
+    output = "Reviewing the diff and gathering the relevant files first."
+    stdout = _grok_json_output(output, structured=False, stop_reason="Cancelled")
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+    monkeypatch.setattr(agents.proc, "run", lambda argv, **kwargs: agents.proc.Result(0, stdout + "\n", ""))
+
+    result = agents.run_agent("grok", "review it", read_only=True, model="grok-4.5")
+
+    assert result.ok is False
+    assert result.detail == (
+        "grok exited 0 without a structured final response "
+        "(stopReason=Cancelled; model did not produce structured output)"
+    )
+    assert result.text == output
+    assert result.stdout == stdout + "\n"
+
+
+@pytest.mark.parametrize("case", ["cancelled", "extra-property", "structured-error"])
+def test_run_agent_rejects_invalid_grok_structured_final_output(monkeypatch, case):
+    payload = json.loads(_grok_json_output("No actionable findings."))
+    if case == "cancelled":
+        payload["stopReason"] = "Cancelled"
+    elif case == "extra-property":
+        payload["structuredOutput"]["extra"] = True
+    else:
+        payload["structuredOutputError"] = "model reported an invalid structured result"
+    stdout = json.dumps(payload)
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+    monkeypatch.setattr(agents.proc, "run", lambda argv, **kwargs: agents.proc.Result(0, stdout + "\n", ""))
+
+    result = agents.run_agent("grok", "review it", read_only=True, model="grok-4.5")
+
+    assert result.ok is False
+    assert "grok exited 0 without a structured final response" in result.detail
+    assert result.text == "No actionable findings."
+    assert result.stdout == stdout + "\n"
+
+
+@pytest.mark.parametrize("error_value", ["", False, 0, {}])
+def test_run_agent_rejects_falsey_present_grok_structured_error(monkeypatch, error_value):
+    payload = json.loads(_grok_json_output("No actionable findings."))
+    payload["structuredOutputError"] = error_value
+    stdout = json.dumps(payload)
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+    monkeypatch.setattr(agents.proc, "run", lambda argv, **kwargs: agents.proc.Result(0, stdout + "\n", ""))
+
+    result = agents.run_agent("grok", "review it", read_only=True, model="grok-4.5")
+
+    assert result.ok is False
+    assert "structuredOutputError was present" in result.detail
+    assert result.text == "No actionable findings."
+    assert result.stdout == stdout + "\n"
+    assert result.exit_code == 0
+
+
+def test_run_agent_accepts_structured_grok_finding_with_progress_opening(monkeypatch):
+    output = "Reviewing the diff: missing bounds check in foo."
+    stdout = _grok_json_output(output)
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+    monkeypatch.setattr(agents.proc, "run", lambda argv, **kwargs: agents.proc.Result(0, stdout + "\n", ""))
+
+    result = agents.run_agent("grok", "review it", read_only=True, model="grok-4.5")
+
+    assert result.ok is True
+    assert result.text == output
+    assert result.stdout == stdout + "\n"
+
+
+def test_run_agent_accepts_concise_grok_no_findings(monkeypatch):
+    output = _grok_json_output("No actionable findings.")
+    seen = {}
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+
+    def fake_run(argv, **kwargs):
+        seen["argv"] = argv
+        return agents.proc.Result(0, output + "\n", "")
+
+    monkeypatch.setattr(agents.proc, "run", fake_run)
+
+    result = agents.run_agent("grok", "review it", read_only=True, model="grok-4.5")
+
+    assert result.ok is True
+    assert result.text == "No actionable findings."
+    assert result.exit_code == 0
+    assert seen["argv"][-2:] == [
+        "--json-schema",
+        (
+            '{"type":"object","properties":{"kind":{"type":"string","enum":["answer"]},'
+            '"answer":{"type":"string","minLength":1}},"required":["kind","answer"],'
+            '"additionalProperties":false}'
+        ),
+    ]
+    assert "--permission-mode" not in seen["argv"]
+    assert seen["argv"][seen["argv"].index("--sandbox") :] == [
+        "--sandbox",
+        "read-only",
+        "--always-approve",
+        "--json-schema",
+        seen["argv"][-1],
+    ]
+
+
+def test_run_agent_keeps_writable_grok_plain_output(monkeypatch):
+    output = "Implemented the requested change."
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+    monkeypatch.setattr(agents.proc, "run", lambda argv, **kwargs: agents.proc.Result(0, output + "\n", ""))
+
+    result = agents.run_agent("grok", "implement it", read_only=False, model="grok-4.5")
+
+    assert result.ok is True
+    assert result.text == output
+
+
+def test_run_agent_reports_invalid_internal_grok_read_only_argv(monkeypatch):
+    calls = []
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+    monkeypatch.setattr(agents, "build_argv", lambda *args, **kwargs: ["grok", "-p", "review it"])
+    monkeypatch.setattr(agents.proc, "run", lambda argv, **kwargs: calls.append(argv))
+
+    result = agents.run_agent("grok", "review it", read_only=True, model="grok-4.5")
+
+    assert result.ok is False
+    assert result.detail == "internal error: grok read-only argv missing --permission-mode plan"
+    assert result.requested_model == "grok-4.5"
+    assert calls == []
 
 
 def test_run_agent_rejects_direct_read_only_cursor_composer_before_spawn(monkeypatch):

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -643,6 +643,30 @@ def test_run_agent_accepts_concise_grok_no_findings(monkeypatch):
     ]
 
 
+def test_run_agent_keeps_permission_mode_prompt_separate_from_grok_flags(monkeypatch):
+    output = _grok_json_output("No actionable findings.")
+    seen = {}
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+
+    def fake_run(argv, **kwargs):
+        seen["argv"] = argv
+        return agents.proc.Result(0, output + "\n", "")
+
+    monkeypatch.setattr(agents.proc, "run", fake_run)
+
+    result = agents.run_agent("grok", "--permission-mode", read_only=True, model="grok-4.5")
+
+    assert result.ok is True
+    assert result.text == "No actionable findings."
+    assert seen["argv"][seen["argv"].index("-p") + 1] == "--permission-mode"
+    assert seen["argv"].count("--permission-mode") == 1
+    assert seen["argv"][seen["argv"].index("--sandbox") : seen["argv"].index("--json-schema")] == [
+        "--sandbox",
+        "read-only",
+        "--always-approve",
+    ]
+
+
 def test_run_agent_keeps_writable_grok_plain_output(monkeypatch):
     output = "Implemented the requested change."
     monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)


### PR DESCRIPTION
## Summary

- run standalone Grok read-only workers with `--sandbox read-only --always-approve` so read tools can finish without granting filesystem writes
- request a JSON Schema-constrained final response and accept only an exact `EndTurn` answer with no structured-output error
- preserve raw stdout and exit code when Grok exits 0 with an empty, cancelled, malformed, or preamble-only response
- cover adapter and direct-worker artifact behavior, including concise `No actionable findings.` responses and unchanged writable runs

## Root cause

The direct Grok adapter mapped Brigade read-only runs to Grok plan mode. Reproductions showed plan mode ending after a read turn with exit 0 and either progress narration or no output. The same tasks completed when Grok used its native read-only filesystem sandbox with normal tool approval.

The adapter now separates execution safety from result integrity: the filesystem sandbox blocks writes, while the structured final-response contract prevents progress text from becoming review evidence.

## Verification

- `brigade work verify run --target . --command './scripts/verify' --capture brigade-work`
- receipt `20260716-161932-work-verify-4b6018`: 2307 passed, 3 skipped, 81.40% coverage
- live Grok 4.5 high control: `status=ok` in 24.044 seconds with a substantive structured final response and zero changed files
- Pi Terra High exact-head review: no actionable findings, ready to merge
- Cursor-Grok 4.5 ACP and Composer 2.5 ACP exact-marker controls both completed with `status=ok`

Closes #264


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured final-response handling for Grok in read-only mode.
  * Valid final answers are extracted cleanly, while incomplete or invalid responses are reported as failures.
  * Read-only Grok runs now use sandboxed execution and preserve accurate output artifacts.

* **Bug Fixes**
  * Prevented successful process exits from being reported as successful runs when no structured final response is produced.
  * Preserved raw output while separating the final extracted answer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->