### PR TITLE
fix(work): configure GraphTrail delta timeout

### DIFF
--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -1429,6 +1429,8 @@ def _context_eval_for_run(
             return None
         if not isinstance(code_graph_delta, dict) or code_graph_delta.get("ok") is not True:
             return None
+        if code_graph_delta.get("stale_graph_used") is True:
+            return None
         sidecar_path = code_graph_delta.get("sidecar_path")
         if not isinstance(sidecar_path, str) or not sidecar_path:
             return None

--- a/src/brigade/cli/work/dispatching.py
+++ b/src/brigade/cli/work/dispatching.py
@@ -109,6 +109,7 @@ def dispatch(args) -> int:
                 target=args.target,
                 commands=commands,
                 timeout=args.timeout,
+                graphtrail_timeout=args.graphtrail_timeout,
                 json_output=args.json,
                 capture=args.capture,
                 capture_kind=args.capture_kind,

--- a/src/brigade/cli/work/registration.py
+++ b/src/brigade/cli/work/registration.py
@@ -145,6 +145,12 @@ def register(sub: argparse._SubParsersAction) -> None:
     )
     p_work_verify_run.add_argument("--timeout", type=int, default=900, help="Timeout per command in seconds.")
     p_work_verify_run.add_argument(
+        "--graphtrail-timeout",
+        type=float,
+        default=None,
+        help="Timeout in seconds for each GraphTrail sync/diff during code graph delta capture.",
+    )
+    p_work_verify_run.add_argument(
         "--capture",
         default=None,
         metavar="ARTIFACT_ID",

--- a/src/brigade/config.py
+++ b/src/brigade/config.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import json
+import math
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from .selection import Selection
 
@@ -14,12 +15,32 @@ WORKSPACE_DIRNAME = ".brigade"
 LEGACY_WORKSPACE_DIRNAMES = (".solo-mise",)
 CONFIG_REL_PATH = f"{WORKSPACE_DIRNAME}/config.json"
 SUPPORTED_VERSIONS = (1,)
+DEFAULT_GRAPHTRAIL_DELTA_TIMEOUT_SECONDS = 10.0
 
 
 @dataclass
 class Config:
     version: int
     selection: Selection
+    graphtrail_delta_timeout_seconds: float = DEFAULT_GRAPHTRAIL_DELTA_TIMEOUT_SECONDS
+
+
+def _validate_graphtrail_delta_timeout(value: Any) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError("graphtrail_delta_timeout_seconds must be a positive number")
+    timeout = float(value)
+    if not math.isfinite(timeout) or timeout <= 0:
+        raise ValueError("graphtrail_delta_timeout_seconds must be a positive number")
+    return timeout
+
+
+def resolve_graphtrail_delta_timeout(target: Path, cli_override: float | None = None) -> float:
+    if cli_override is not None:
+        return _validate_graphtrail_delta_timeout(cli_override)
+    cfg = load_config(target)
+    if cfg is not None:
+        return cfg.graphtrail_delta_timeout_seconds
+    return DEFAULT_GRAPHTRAIL_DELTA_TIMEOUT_SECONDS
 
 
 def config_path(target: Path) -> Path:
@@ -28,6 +49,7 @@ def config_path(target: Path) -> Path:
 
 def write_config(target: Path, cfg: Config) -> None:
     cfg.selection.validate()
+    graphtrail_timeout = _validate_graphtrail_delta_timeout(cfg.graphtrail_delta_timeout_seconds)
     path = config_path(target)
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = {
@@ -37,6 +59,8 @@ def write_config(target: Path, cfg: Config) -> None:
         "owner": cfg.selection.owner,
         "includes": list(cfg.selection.includes),
     }
+    if graphtrail_timeout != DEFAULT_GRAPHTRAIL_DELTA_TIMEOUT_SECONDS:
+        payload["graphtrail_delta_timeout_seconds"] = graphtrail_timeout
     path.write_text(json.dumps(payload, indent=2) + "\n")
 
 
@@ -61,4 +85,6 @@ def load_config(target: Path) -> Optional[Config]:
         includes=list(data.get("includes", [])),
     )
     sel.validate()
-    return Config(version=version, selection=sel)
+    timeout_raw = data.get("graphtrail_delta_timeout_seconds", DEFAULT_GRAPHTRAIL_DELTA_TIMEOUT_SECONDS)
+    timeout = _validate_graphtrail_delta_timeout(timeout_raw)
+    return Config(version=version, selection=sel, graphtrail_delta_timeout_seconds=timeout)

--- a/src/brigade/config.py
+++ b/src/brigade/config.py
@@ -36,7 +36,10 @@ def validate_graphtrail_delta_timeout(value: Any) -> float:
 
 def resolve_graphtrail_delta_timeout(target: Path, cli_override: float | None = None) -> float:
     if cli_override is not None:
-        return validate_graphtrail_delta_timeout(cli_override)
+        try:
+            return validate_graphtrail_delta_timeout(cli_override)
+        except ValueError:
+            raise ValueError("--graphtrail-timeout must be a positive number") from None
     cfg = load_config(target)
     if cfg is not None:
         return cfg.graphtrail_delta_timeout_seconds

--- a/src/brigade/config.py
+++ b/src/brigade/config.py
@@ -25,7 +25,7 @@ class Config:
     graphtrail_delta_timeout_seconds: float = DEFAULT_GRAPHTRAIL_DELTA_TIMEOUT_SECONDS
 
 
-def _validate_graphtrail_delta_timeout(value: Any) -> float:
+def validate_graphtrail_delta_timeout(value: Any) -> float:
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise ValueError("graphtrail_delta_timeout_seconds must be a positive number")
     timeout = float(value)
@@ -36,7 +36,7 @@ def _validate_graphtrail_delta_timeout(value: Any) -> float:
 
 def resolve_graphtrail_delta_timeout(target: Path, cli_override: float | None = None) -> float:
     if cli_override is not None:
-        return _validate_graphtrail_delta_timeout(cli_override)
+        return validate_graphtrail_delta_timeout(cli_override)
     cfg = load_config(target)
     if cfg is not None:
         return cfg.graphtrail_delta_timeout_seconds
@@ -49,7 +49,7 @@ def config_path(target: Path) -> Path:
 
 def write_config(target: Path, cfg: Config) -> None:
     cfg.selection.validate()
-    graphtrail_timeout = _validate_graphtrail_delta_timeout(cfg.graphtrail_delta_timeout_seconds)
+    graphtrail_timeout = validate_graphtrail_delta_timeout(cfg.graphtrail_delta_timeout_seconds)
     path = config_path(target)
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = {
@@ -86,5 +86,5 @@ def load_config(target: Path) -> Optional[Config]:
     )
     sel.validate()
     timeout_raw = data.get("graphtrail_delta_timeout_seconds", DEFAULT_GRAPHTRAIL_DELTA_TIMEOUT_SECONDS)
-    timeout = _validate_graphtrail_delta_timeout(timeout_raw)
+    timeout = validate_graphtrail_delta_timeout(timeout_raw)
     return Config(version=version, selection=sel, graphtrail_delta_timeout_seconds=timeout)

--- a/src/brigade/graphtrail_delta.py
+++ b/src/brigade/graphtrail_delta.py
@@ -9,6 +9,7 @@ import shutil
 import sqlite3
 import subprocess
 import tempfile
+import time
 from pathlib import Path
 from typing import Any
 
@@ -38,7 +39,32 @@ def capture_before(target: Path, run_dir: Path, *, timeout: float = 10.0) -> dic
         if binary is None:
             return _status("unavailable", "code graph delta unavailable: graphtrail binary not found")
         db_path = target / ".graphtrail" / "graphtrail.db"
-        sync = _run_graphtrail(binary, db_path, "sync", timeout=timeout)
+        sync_stage = "incremental-sync" if db_path.is_file() else "initial-index"
+        sync = _run_graphtrail(binary, db_path, "sync", timeout=timeout, stage=sync_stage)
+        if sync.get("timed_out"):
+            if db_path.is_file():
+                snapshot_path = run_dir / SNAPSHOT_NAME
+                _backup_sqlite(db_path, snapshot_path)
+                return {
+                    "ok": True,
+                    "status": "captured",
+                    "summary": "code graph baseline captured from stale database",
+                    "binary": binary,
+                    "db_path": str(db_path),
+                    "before_snapshot_path": str(snapshot_path),
+                    "before_snapshot_sha256": _file_sha256(snapshot_path),
+                    "stale_graph_used": True,
+                    "graphtrail_timeout_seconds": timeout,
+                    "sync": sync,
+                }
+            return _status(
+                "sync_timed_out",
+                f"code graph delta unavailable: graphtrail {sync_stage} sync timed out after {timeout:g}s",
+                binary=binary,
+                db_path=str(db_path),
+                sync=sync,
+                graphtrail_timeout_seconds=timeout,
+            )
         if sync["returncode"] != 0:
             return _status(
                 "sync_failed",
@@ -46,6 +72,7 @@ def capture_before(target: Path, run_dir: Path, *, timeout: float = 10.0) -> dic
                 binary=binary,
                 db_path=str(db_path),
                 sync=sync,
+                graphtrail_timeout_seconds=timeout,
             )
         if not db_path.is_file():
             return _status(
@@ -65,6 +92,7 @@ def capture_before(target: Path, run_dir: Path, *, timeout: float = 10.0) -> dic
             "db_path": str(db_path),
             "before_snapshot_path": str(snapshot_path),
             "before_snapshot_sha256": _file_sha256(snapshot_path),
+            "graphtrail_timeout_seconds": timeout,
             "sync": sync,
         }
     except BaseException as exc:
@@ -86,13 +114,28 @@ def capture_after_and_diff(
         if before.get("status") == "unavailable":
             return _compact(_status("unavailable", str(before.get("summary") or "code graph delta unavailable")))
         if before.get("ok") is not True:
-            payload = _failure_payload(target, before, str(before.get("status") or "capture_failed"))
+            payload = _failure_payload(
+                target,
+                before,
+                str(before.get("status") or "capture_failed"),
+                graphtrail_timeout_seconds=float(before.get("graphtrail_timeout_seconds") or timeout),
+            )
             return _write_and_compact(run_dir, payload)
 
         binary = str(before.get("binary") or "")
         db_path = Path(str(before.get("db_path") or target / ".graphtrail" / "graphtrail.db"))
         snapshot_path = Path(str(before.get("before_snapshot_path") or run_dir / SNAPSHOT_NAME))
-        sync = _run_graphtrail(binary, db_path, "sync", timeout=timeout)
+        sync = _run_graphtrail(binary, db_path, "sync", timeout=timeout, stage="incremental-sync")
+        if sync.get("timed_out"):
+            payload = _failure_payload(
+                target,
+                before,
+                "sync_timed_out",
+                summary=f"code graph delta unavailable: graphtrail incremental-sync timed out after {timeout:g}s",
+                after_sync=sync,
+                graphtrail_timeout_seconds=timeout,
+            )
+            return _write_and_compact(run_dir, payload, snapshot_path=snapshot_path)
         if sync["returncode"] != 0:
             payload = _failure_payload(
                 target,
@@ -100,6 +143,7 @@ def capture_after_and_diff(
                 "sync_failed",
                 summary=f"code graph delta unavailable: graphtrail sync failed ({sync['returncode']})",
                 after_sync=sync,
+                graphtrail_timeout_seconds=timeout,
             )
             return _write_and_compact(run_dir, payload, snapshot_path=snapshot_path)
 
@@ -116,7 +160,21 @@ def capture_after_and_diff(
             str(after_snapshot_path),
             timeout=timeout,
             json_output=True,
+            stage="diff",
         )
+        if diff.get("timed_out"):
+            payload = _failure_payload(
+                target,
+                before,
+                "diff_timed_out",
+                summary=f"code graph delta unavailable: graphtrail diff timed out after {timeout:g}s",
+                after_sync=sync,
+                diff=diff,
+                graphtrail_timeout_seconds=timeout,
+            )
+            return _write_and_compact(
+                run_dir, payload, snapshot_path=snapshot_path, after_snapshot_path=after_snapshot_path
+            )
         if diff["returncode"] != 0:
             payload = _failure_payload(
                 target,
@@ -165,6 +223,7 @@ def capture_after_and_diff(
             "ok": True,
             "status": "ok",
             "target": str(target),
+            "graphtrail_timeout_seconds": timeout,
             "summary": _summary("ok", raw_counts, edge_churn, len(changed_symbols)),
             "raw_counts": raw_counts,
             "changed_symbols": changed_symbols,
@@ -181,6 +240,8 @@ def capture_after_and_diff(
                 "diff_stdout_sha256": _sha256_text(diff["stdout"]),
             },
         }
+        if before.get("stale_graph_used") is True:
+            payload["stale_graph_used"] = True
         return _write_and_compact(
             run_dir, payload, snapshot_path=snapshot_path, after_snapshot_path=after_snapshot_path
         )
@@ -214,12 +275,19 @@ def _graphtrail_bin() -> str | None:
 
 
 def _run_graphtrail(
-    binary: str, db_path: Path, command: str, *extra: str, timeout: float, json_output: bool = False
+    binary: str,
+    db_path: Path,
+    command: str,
+    *extra: str,
+    timeout: float,
+    json_output: bool = False,
+    stage: str | None = None,
 ) -> dict[str, Any]:
     # `graphtrail sync` rejects --json; only diff-style subcommands accept it.
     argv = [binary, "--db", str(db_path), command, *extra]
     if json_output:
         argv.append("--json")
+    started = time.monotonic()
     try:
         completed = subprocess.run(
             argv,
@@ -231,23 +299,66 @@ def _run_graphtrail(
             text=True,
             timeout=timeout,
         )
-        return {
-            "argv": argv,
-            "returncode": completed.returncode,
-            "stdout": completed.stdout or "",
-            "stderr": completed.stderr or "",
-            "timed_out": False,
-        }
+        return _command_result(
+            argv=argv,
+            returncode=completed.returncode,
+            stdout=completed.stdout or "",
+            stderr=completed.stderr or "",
+            timed_out=False,
+            duration_seconds=time.monotonic() - started,
+            timeout=timeout,
+            stage=stage,
+        )
     except FileNotFoundError:
-        return {"argv": argv, "returncode": 127, "stdout": "", "stderr": "command not found", "timed_out": False}
+        return _command_result(
+            argv=argv,
+            returncode=127,
+            stdout="",
+            stderr="command not found",
+            timed_out=False,
+            duration_seconds=time.monotonic() - started,
+            timeout=timeout,
+            stage=stage,
+        )
     except subprocess.TimeoutExpired as exc:
-        return {
-            "argv": argv,
-            "returncode": 124,
-            "stdout": exc.stdout if isinstance(exc.stdout, str) else "",
-            "stderr": exc.stderr if isinstance(exc.stderr, str) else f"timeout after {timeout:g}s",
-            "timed_out": True,
-        }
+        stderr = exc.stderr if isinstance(exc.stderr, str) else ""
+        if not stderr:
+            stderr = f"timeout after {timeout:g}s"
+        return _command_result(
+            argv=argv,
+            returncode=124,
+            stdout=exc.stdout if isinstance(exc.stdout, str) else "",
+            stderr=stderr,
+            timed_out=True,
+            duration_seconds=time.monotonic() - started,
+            timeout=timeout,
+            stage=stage,
+        )
+
+
+def _command_result(
+    *,
+    argv: list[str],
+    returncode: int,
+    stdout: str,
+    stderr: str,
+    timed_out: bool,
+    duration_seconds: float,
+    timeout: float,
+    stage: str | None,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "argv": argv,
+        "returncode": returncode,
+        "stdout": stdout,
+        "stderr": stderr,
+        "timed_out": timed_out,
+        "duration_seconds": duration_seconds,
+        "graphtrail_timeout_seconds": timeout,
+    }
+    if stage:
+        result["stage"] = stage
+    return result
 
 
 def _backup_sqlite(source: Path, destination: Path) -> None:
@@ -267,8 +378,13 @@ def _failure_payload(
     summary: str | None = None,
     after_sync: dict[str, Any] | None = None,
     diff: dict[str, Any] | None = None,
+    graphtrail_timeout_seconds: float | None = None,
 ) -> dict[str, Any]:
-    return {
+    timeout_value = graphtrail_timeout_seconds
+    if timeout_value is None:
+        raw_timeout = before.get("graphtrail_timeout_seconds")
+        timeout_value = float(raw_timeout) if isinstance(raw_timeout, (int, float)) else None
+    payload: dict[str, Any] = {
         "ok": False,
         "status": status,
         "target": str(target),
@@ -286,6 +402,11 @@ def _failure_payload(
             "diff_stdout_sha256": _sha256_text(diff.get("stdout", "")) if isinstance(diff, dict) else None,
         },
     }
+    if timeout_value is not None:
+        payload["graphtrail_timeout_seconds"] = timeout_value
+    if before.get("stale_graph_used") is True:
+        payload["stale_graph_used"] = True
+    return payload
 
 
 def _write_and_compact(
@@ -307,7 +428,7 @@ def _write_and_compact(
 
 
 def _compact(payload: dict[str, Any]) -> dict[str, Any]:
-    return {
+    compact: dict[str, Any] = {
         "status": payload.get("status", "unknown"),
         "ok": bool(payload.get("ok")),
         "summary": _compact_summary(payload),
@@ -316,6 +437,15 @@ def _compact(payload: dict[str, Any]) -> dict[str, Any]:
         "changed_symbols": payload.get("changed_symbols") if isinstance(payload.get("changed_symbols"), list) else [],
         "changed_symbol_count": int(payload.get("changed_symbol_count") or 0),
     }
+    timeout = payload.get("graphtrail_timeout_seconds")
+    if isinstance(timeout, (int, float)) and not isinstance(timeout, bool):
+        compact["graphtrail_timeout_seconds"] = float(timeout)
+    if payload.get("stale_graph_used") is True:
+        compact["stale_graph_used"] = True
+    commands = payload.get("commands")
+    if isinstance(commands, dict):
+        compact["commands"] = commands
+    return compact
 
 
 def _status(status: str, summary: str, **extra: Any) -> dict[str, Any]:

--- a/src/brigade/graphtrail_delta.py
+++ b/src/brigade/graphtrail_delta.py
@@ -39,10 +39,11 @@ def capture_before(target: Path, run_dir: Path, *, timeout: float = 10.0) -> dic
         if binary is None:
             return _status("unavailable", "code graph delta unavailable: graphtrail binary not found")
         db_path = target / ".graphtrail" / "graphtrail.db"
-        sync_stage = "incremental-sync" if db_path.is_file() else "initial-index"
+        db_existed_before_sync = db_path.is_file()
+        sync_stage = "incremental-sync" if db_existed_before_sync else "initial-index"
         sync = _run_graphtrail(binary, db_path, "sync", timeout=timeout, stage=sync_stage)
         if sync.get("timed_out"):
-            if db_path.is_file():
+            if db_existed_before_sync:
                 snapshot_path = run_dir / SNAPSHOT_NAME
                 _backup_sqlite(db_path, snapshot_path)
                 return {
@@ -81,6 +82,7 @@ def capture_before(target: Path, run_dir: Path, *, timeout: float = 10.0) -> dic
                 binary=binary,
                 db_path=str(db_path),
                 sync=sync,
+                graphtrail_timeout_seconds=timeout,
             )
         snapshot_path = run_dir / SNAPSHOT_NAME
         _backup_sqlite(db_path, snapshot_path)

--- a/src/brigade/outcome_cmd.py
+++ b/src/brigade/outcome_cmd.py
@@ -762,6 +762,8 @@ def _graph_delta_counts(records: list[core.OutcomeRecord]) -> dict[str, int] | N
         return None
     counts = {"graph_changing": 0, "graph_no_op": 0}
     for delta in deltas:
+        if delta.get("stale_graph_used") is True:
+            continue
         if delta.get("status") != "ok":
             continue
         changed_symbols = _graph_count_value(delta.get("changed_symbol_count"))

--- a/src/brigade/outcome_cmd.py
+++ b/src/brigade/outcome_cmd.py
@@ -489,7 +489,14 @@ def _compact_code_graph_delta(receipt: dict) -> dict | None:
         return None
     compact = {
         key: delta[key]
-        for key in ("status", "summary", "changed_symbol_count", "edge_churn", "raw_counts")
+        for key in (
+            "status",
+            "summary",
+            "changed_symbol_count",
+            "edge_churn",
+            "raw_counts",
+            "stale_graph_used",
+        )
         if key in delta
     }
     return compact or None

--- a/src/brigade/work_cmd/verification.py
+++ b/src/brigade/work_cmd/verification.py
@@ -11,7 +11,7 @@ import sys
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
-from .. import graphtrail_delta, localio, receipt_signing
+from .. import config, graphtrail_delta, localio, receipt_signing
 from . import constants, helpers, ledger as ledger_mod
 from . import reviews as reviews_mod
 from . import scanners as scanners_mod
@@ -292,12 +292,19 @@ def _write_verify_markdown(run_dir: Path, receipt: dict[str, Any]) -> None:
     (run_dir / "summary.md").write_text("\n".join(lines) + "\n")
 
 
-def _run_verify_commands(target: Path, commands: list[str | list[str]], timeout: int) -> tuple[dict[str, Any], int]:
+def _run_verify_commands(
+    target: Path,
+    commands: list[str | list[str]],
+    timeout: int,
+    *,
+    graphtrail_timeout: float | None = None,
+) -> tuple[dict[str, Any], int]:
     started = helpers._now()
     run_id = f"{started.strftime('%Y%m%d-%H%M%S')}-work-verify-{uuid4().hex[:6]}"
     run_dir = helpers._verify_runs_root(target) / run_id
     run_dir.mkdir(parents=True, exist_ok=False)
-    graph_delta_before = graphtrail_delta.capture_before(target, run_dir)
+    effective_graphtrail_timeout = config.resolve_graphtrail_delta_timeout(target, graphtrail_timeout)
+    graph_delta_before = graphtrail_delta.capture_before(target, run_dir, timeout=effective_graphtrail_timeout)
     receipt: dict[str, Any] = {
         "run_id": run_id,
         "target": str(target),
@@ -422,7 +429,9 @@ def _run_verify_commands(target: Path, commands: list[str | list[str]], timeout:
             if rc == 0:
                 rc = 127
         receipt["commands"].append(command_result)
-    receipt["code_graph_delta"] = graphtrail_delta.capture_after_and_diff(target, run_dir, graph_delta_before)
+    receipt["code_graph_delta"] = graphtrail_delta.capture_after_and_diff(
+        target, run_dir, graph_delta_before, timeout=effective_graphtrail_timeout
+    )
     completed_at = helpers._now()
     receipt["completed_at"] = completed_at.isoformat()
     receipt["duration_seconds"] = (completed_at - started).total_seconds()
@@ -657,6 +666,7 @@ def verify_run(
     target: Path,
     commands: list[str | list[str]] | None = None,
     timeout: int = 900,
+    graphtrail_timeout: float | None = None,
     json_output: bool = False,
     capture: str | None = None,
     capture_kind: str = "skill",
@@ -668,11 +678,17 @@ def verify_run(
     if timeout < 1:
         print("error: --timeout must be a positive integer", file=sys.stderr)
         return 2
+    if graphtrail_timeout is not None:
+        try:
+            graphtrail_timeout = config._validate_graphtrail_delta_timeout(graphtrail_timeout)
+        except ValueError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
     planned = commands if commands is not None else _default_verify_commands(target)
     if not planned:
         print("error: no verification commands found; pass --command", file=sys.stderr)
         return 2
-    receipt, rc = _run_verify_commands(target, planned, timeout)
+    receipt, rc = _run_verify_commands(target, planned, timeout, graphtrail_timeout=graphtrail_timeout)
     if json_output:
         if capture:
             # Record the outcome in the same command (closes the loop without a

--- a/src/brigade/work_cmd/verification.py
+++ b/src/brigade/work_cmd/verification.py
@@ -297,14 +297,13 @@ def _run_verify_commands(
     commands: list[str | list[str]],
     timeout: int,
     *,
-    graphtrail_timeout: float | None = None,
+    graphtrail_timeout: float,
 ) -> tuple[dict[str, Any], int]:
     started = helpers._now()
     run_id = f"{started.strftime('%Y%m%d-%H%M%S')}-work-verify-{uuid4().hex[:6]}"
     run_dir = helpers._verify_runs_root(target) / run_id
     run_dir.mkdir(parents=True, exist_ok=False)
-    effective_graphtrail_timeout = config.resolve_graphtrail_delta_timeout(target, graphtrail_timeout)
-    graph_delta_before = graphtrail_delta.capture_before(target, run_dir, timeout=effective_graphtrail_timeout)
+    graph_delta_before = graphtrail_delta.capture_before(target, run_dir, timeout=graphtrail_timeout)
     receipt: dict[str, Any] = {
         "run_id": run_id,
         "target": str(target),
@@ -430,7 +429,7 @@ def _run_verify_commands(
                 rc = 127
         receipt["commands"].append(command_result)
     receipt["code_graph_delta"] = graphtrail_delta.capture_after_and_diff(
-        target, run_dir, graph_delta_before, timeout=effective_graphtrail_timeout
+        target, run_dir, graph_delta_before, timeout=graphtrail_timeout
     )
     completed_at = helpers._now()
     receipt["completed_at"] = completed_at.isoformat()
@@ -678,17 +677,16 @@ def verify_run(
     if timeout < 1:
         print("error: --timeout must be a positive integer", file=sys.stderr)
         return 2
-    if graphtrail_timeout is not None:
-        try:
-            graphtrail_timeout = config._validate_graphtrail_delta_timeout(graphtrail_timeout)
-        except ValueError as exc:
-            print(f"error: {exc}", file=sys.stderr)
-            return 2
+    try:
+        effective_graphtrail_timeout = config.resolve_graphtrail_delta_timeout(target, graphtrail_timeout)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
     planned = commands if commands is not None else _default_verify_commands(target)
     if not planned:
         print("error: no verification commands found; pass --command", file=sys.stderr)
         return 2
-    receipt, rc = _run_verify_commands(target, planned, timeout, graphtrail_timeout=graphtrail_timeout)
+    receipt, rc = _run_verify_commands(target, planned, timeout, graphtrail_timeout=effective_graphtrail_timeout)
     if json_output:
         if capture:
             # Record the outcome in the same command (closes the loop without a

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -345,6 +345,26 @@ def test_context_eval_reports_sorted_hits_misses_and_rate():
     }
 
 
+def test_context_eval_for_run_returns_none_when_stale_graph_used(tmp_path):
+    brief = aboyeur.CodeGraphBrief(
+        attached=True,
+        text="## Code graph context (GraphTrail, read-only)\n\n- `tests/test_aboyeur.py:10`\n",
+        bytes=80,
+    )
+    sidecar = tmp_path / "graph-delta.json"
+    sidecar.write_text(json.dumps({"ok": True, "changed_nodes": [{"file_path": "tests/test_aboyeur.py"}]}) + "\n")
+    delta = {
+        "ok": True,
+        "status": "ok",
+        "stale_graph_used": True,
+        "sidecar_path": str(sidecar),
+        "changed_symbol_count": 1,
+        "edge_churn": 0,
+    }
+
+    assert aboyeur._context_eval_for_run(brief, delta) is None
+
+
 def test_ground_truth_facts_surface_context_eval_metric_once():
     facts = aboyeur._ground_truth_facts(
         {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -36,6 +36,21 @@ def test_write_then_load_round_trip(tmp_path):
     assert loaded.selection.includes == ["publisher"]
 
 
+def test_write_then_load_round_trip_preserves_graphtrail_delta_timeout_seconds(tmp_path):
+    sel = Selection(
+        depth="workspace",
+        harnesses=["claude", "codex", "openclaw"],
+        owner="openclaw",
+        includes=["publisher"],
+    )
+    cfg = Config(version=1, selection=sel, graphtrail_delta_timeout_seconds=25)
+    write_config(tmp_path, cfg)
+
+    loaded = load_config(tmp_path)
+    assert loaded is not None
+    assert loaded.graphtrail_delta_timeout_seconds == 25.0
+
+
 def test_write_creates_parent_dir(tmp_path):
     sel = Selection(depth="repo", harnesses=["claude"], owner="claude", includes=[])
     write_config(tmp_path, Config(version=1, selection=sel))
@@ -81,3 +96,53 @@ def test_load_config_reads_legacy_solo_mise_dir(tmp_path):
     cfg = load_config(tmp_path)
     assert cfg is not None
     assert cfg.selection.harnesses == ["claude"]
+
+
+def test_load_config_defaults_graphtrail_delta_timeout_seconds(tmp_path):
+    sel = Selection(depth="repo", harnesses=["claude"], owner="claude", includes=[])
+    write_config(tmp_path, Config(version=1, selection=sel))
+    loaded = load_config(tmp_path)
+    assert loaded is not None
+    assert loaded.graphtrail_delta_timeout_seconds == 10.0
+
+
+def test_load_config_reads_graphtrail_delta_timeout_seconds(tmp_path):
+    path = tmp_path / ".brigade" / "config.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "depth": "repo",
+                "harnesses": ["claude"],
+                "owner": "claude",
+                "includes": [],
+                "graphtrail_delta_timeout_seconds": 25,
+            }
+        )
+        + "\n"
+    )
+    loaded = load_config(tmp_path)
+    assert loaded is not None
+    assert loaded.graphtrail_delta_timeout_seconds == 25.0
+
+
+@pytest.mark.parametrize("value", [0, -1, "slow"])
+def test_load_config_rejects_invalid_graphtrail_delta_timeout_seconds(tmp_path, value):
+    path = tmp_path / ".brigade" / "config.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "depth": "repo",
+                "harnesses": ["claude"],
+                "owner": "claude",
+                "includes": [],
+                "graphtrail_delta_timeout_seconds": value,
+            }
+        )
+        + "\n"
+    )
+    with pytest.raises(ValueError, match="graphtrail_delta_timeout_seconds must be a positive number"):
+        load_config(tmp_path)

--- a/tests/test_outcome_cmd.py
+++ b/tests/test_outcome_cmd.py
@@ -668,6 +668,45 @@ def test_rank_json_includes_graph_delta_counters_for_mixed_records(tmp_path, cap
     assert "graph_no_op" not in ranking["skill-y"]
 
 
+def test_graph_delta_counts_excludes_stale_graph_used_deltas():
+    records = [
+        outcome.OutcomeRecord(
+            "skill-x",
+            "skill",
+            "t1",
+            "verify",
+            1,
+            "ref1",
+            "2026-06-20T00:00:00+00:00",
+            code_graph_delta={
+                "status": "ok",
+                "ok": True,
+                "changed_symbol_count": 2,
+                "edge_churn": 0,
+                "stale_graph_used": True,
+            },
+        ),
+        outcome.OutcomeRecord(
+            "skill-x",
+            "skill",
+            "t2",
+            "verify",
+            1,
+            "ref2",
+            "2026-06-20T01:00:00+00:00",
+            code_graph_delta={
+                "status": "ok",
+                "ok": True,
+                "changed_symbol_count": 0,
+                "edge_churn": 0,
+                "stale_graph_used": True,
+            },
+        ),
+    ]
+
+    assert outcome_cmd._graph_delta_counts(records) == {"graph_changing": 0, "graph_no_op": 0}
+
+
 def test_rank_and_reconcile_count_verify_and_run_receipt_graph_deltas_identically(tmp_path, capsys):
     _write_verify_receipt(
         tmp_path,

--- a/tests/test_outcome_cmd.py
+++ b/tests/test_outcome_cmd.py
@@ -248,6 +248,51 @@ def test_capture_copies_compact_code_graph_delta_from_verify_receipt(tmp_path, c
     assert row["digest"] == localio.canonical_json_digest(row, exclude_keys={"digest"})
 
 
+def test_capture_persists_stale_graph_used_and_loaded_counts_exclude_it(tmp_path, capsys):
+    delta = {
+        "status": "ok",
+        "summary": "changed_symbols=2 edge_churn=0 stale_graph",
+        "changed_symbol_count": 2,
+        "edge_churn": 0,
+        "raw_counts": {"edges_added": 2, "edges_removed": 0},
+        "stale_graph_used": True,
+        "sidecar_path": "/tmp/not-copied.json",
+    }
+    _write_verify_receipt(tmp_path, run_id="stale-delta", code_graph_delta=delta)
+
+    assert (
+        outcome_cmd.capture(
+            target=tmp_path,
+            artifact_id="skill-x",
+            artifact_kind="skill",
+            task_id="t-stale",
+            run_id="stale-delta",
+            json_output=True,
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    compact = {
+        "status": "ok",
+        "summary": "changed_symbols=2 edge_churn=0 stale_graph",
+        "changed_symbol_count": 2,
+        "edge_churn": 0,
+        "raw_counts": {"edges_added": 2, "edges_removed": 0},
+        "stale_graph_used": True,
+    }
+    assert payload["record"]["code_graph_delta"] == compact
+
+    row = json.loads((tmp_path / "memory" / "outcome" / "records.jsonl").read_text())
+    assert row["code_graph_delta"] == compact
+    assert "sidecar_path" not in row["code_graph_delta"]
+
+    records = outcome_cmd.load_records(tmp_path)
+    assert len(records) == 1
+    assert records[0].code_graph_delta is not None
+    assert records[0].code_graph_delta.get("stale_graph_used") is True
+    assert outcome_cmd._graph_delta_counts(records) == {"graph_changing": 0, "graph_no_op": 0}
+
+
 def test_capture_run_receipt_copies_delta_and_context_eval_into_digest_chain(tmp_path, capsys):
     delta = {
         "status": "ok",

--- a/tests/test_work_cmd_verification.py
+++ b/tests/test_work_cmd_verification.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sqlite3
 import subprocess
 import sys
 from pathlib import Path
@@ -7,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from brigade import cli
+from brigade import graphtrail_delta
 from brigade import localio
 from brigade import work_cmd
 
@@ -522,7 +524,38 @@ def test_work_verify_receipt_omits_git_state_outside_git_repo(tmp_path, capsys, 
     assert receipt["digests"]["receipt_sha256"] == localio.canonical_json_digest(receipt, exclude_keys={"digests"})
 
 
-def _write_fake_graphtrail(tmp_path, *, mode: str = "ok") -> Path:
+def _write_brigade_config(tmp_path, *, graphtrail_delta_timeout_seconds: float | None = None) -> None:
+    payload = {
+        "version": 1,
+        "depth": "repo",
+        "harnesses": ["codex"],
+        "owner": "this-repo",
+        "includes": [],
+    }
+    if graphtrail_delta_timeout_seconds is not None:
+        payload["graphtrail_delta_timeout_seconds"] = graphtrail_delta_timeout_seconds
+    brigade = tmp_path / ".brigade"
+    brigade.mkdir(parents=True, exist_ok=True)
+    (brigade / "config.json").write_text(json.dumps(payload, indent=2) + "\n")
+
+
+def _seed_graphtrail_db(tmp_path: Path) -> Path:
+    db_dir = tmp_path / ".graphtrail"
+    db_dir.mkdir(parents=True, exist_ok=True)
+    db_path = db_dir / "graphtrail.db"
+    with sqlite3.connect(db_path) as con:
+        con.execute("create table if not exists symbols (name text)")
+        con.execute("insert into symbols values ('stale-baseline')")
+    return db_path
+
+
+def _write_fake_graphtrail(
+    tmp_path,
+    *,
+    mode: str = "ok",
+    sync_delay_seconds: float = 0.0,
+    diff_delay_seconds: float = 0.0,
+) -> Path:
     script = tmp_path / "fake-graphtrail.py"
     script.write_text(
         """
@@ -531,12 +564,15 @@ import json
 import os
 import sqlite3
 import sys
+import time
 from pathlib import Path
 
 args = sys.argv[1:]
 db = Path(args[args.index("--db") + 1]) if "--db" in args else Path(".graphtrail/graphtrail.db")
 command = args[args.index(str(db)) + 1] if str(db) in args and args.index(str(db)) + 1 < len(args) else ""
 mode = os.environ.get("FAKE_GRAPHTRAIL_MODE", "ok")
+sync_delay_seconds = float(os.environ.get("FAKE_GRAPHTRAIL_SYNC_SECONDS", "0"))
+diff_delay_seconds = float(os.environ.get("FAKE_GRAPHTRAIL_DIFF_SECONDS", "0"))
 
 # Mirror the real clap CLI strictly: `sync` rejects --json, `diff` requires
 # --before/--after/--json. JSON shape follows graphtrail's diff golden fixture.
@@ -544,6 +580,8 @@ if command == "sync":
     if "--json" in args:
         print("error: unexpected argument '--json' found", file=sys.stderr)
         raise SystemExit(2)
+    if sync_delay_seconds > 0:
+        time.sleep(sync_delay_seconds)
     if mode == "sync-fail":
         print("sync failed", file=sys.stderr)
         raise SystemExit(5)
@@ -563,6 +601,8 @@ if command == "diff":
     if not before.is_file() or not after.is_file():
         print("error: no such database", file=sys.stderr)
         raise SystemExit(1)
+    if diff_delay_seconds > 0:
+        time.sleep(diff_delay_seconds)
     if mode == "malformed-diff":
         print("{not-json")
         raise SystemExit(0)
@@ -610,7 +650,12 @@ raise SystemExit(9)
     script.chmod(0o755)
     wrapper = tmp_path / "graphtrail"
     wrapper.write_text(
-        f'#!/bin/sh\nFAKE_GRAPHTRAIL_MODE={mode} exec {os.environ.get("PYTHON", "python3")} {script} "$@"\n'
+        "#!/bin/sh\n"
+        f"FAKE_GRAPHTRAIL_MODE={mode}\n"
+        f"FAKE_GRAPHTRAIL_SYNC_SECONDS={sync_delay_seconds}\n"
+        f"FAKE_GRAPHTRAIL_DIFF_SECONDS={diff_delay_seconds}\n"
+        f"export FAKE_GRAPHTRAIL_MODE FAKE_GRAPHTRAIL_SYNC_SECONDS FAKE_GRAPHTRAIL_DIFF_SECONDS\n"
+        f'exec {os.environ.get("PYTHON", "python3")} {script} "$@"\n'
     )
     wrapper.chmod(0o755)
     return wrapper
@@ -695,6 +740,229 @@ def test_work_verify_graphtrail_delta_malformed_diff_fails_open(tmp_path, capsys
     assert receipt["code_graph_delta"]["status"] == "diff_malformed"
     assert sidecar["status"] == "diff_malformed"
     assert sidecar["ok"] is False
+
+
+def test_work_verify_graphtrail_delta_config_timeout_reaches_pre_and_post_sync(tmp_path, capsys, monkeypatch):
+    _init_git_repo(tmp_path)
+    _write_brigade_config(tmp_path, graphtrail_delta_timeout_seconds=25)
+    graphtrail = _write_fake_graphtrail(tmp_path)
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(graphtrail))
+    recorded: list[tuple[str, float | None]] = []
+    real_capture_before = graphtrail_delta.capture_before
+    real_capture_after = graphtrail_delta.capture_after_and_diff
+
+    def spy_before(target, run_dir, **kwargs):
+        recorded.append(("before", kwargs.get("timeout")))
+        return real_capture_before(target, run_dir, **kwargs)
+
+    def spy_after(target, run_dir, before, **kwargs):
+        recorded.append(("after", kwargs.get("timeout")))
+        return real_capture_after(target, run_dir, before, **kwargs)
+
+    monkeypatch.setattr(graphtrail_delta, "capture_before", spy_before)
+    monkeypatch.setattr(graphtrail_delta, "capture_after_and_diff", spy_after)
+
+    assert work_cmd.verify_run(target=tmp_path, commands=["python3 -c \"print('ok')\""], json_output=True) == 0
+    capsys.readouterr()
+
+    assert recorded == [("before", 25.0), ("after", 25.0)]
+
+
+def test_work_verify_graphtrail_delta_cli_override_precedes_config(tmp_path, capsys, monkeypatch):
+    _init_git_repo(tmp_path)
+    _write_brigade_config(tmp_path, graphtrail_delta_timeout_seconds=25)
+    graphtrail = _write_fake_graphtrail(tmp_path)
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(graphtrail))
+    recorded: list[tuple[str, float | None]] = []
+    real_capture_before = graphtrail_delta.capture_before
+    real_capture_after = graphtrail_delta.capture_after_and_diff
+
+    def spy_before(target, run_dir, **kwargs):
+        recorded.append(("before", kwargs.get("timeout")))
+        return real_capture_before(target, run_dir, **kwargs)
+
+    def spy_after(target, run_dir, before, **kwargs):
+        recorded.append(("after", kwargs.get("timeout")))
+        return real_capture_after(target, run_dir, before, **kwargs)
+
+    monkeypatch.setattr(graphtrail_delta, "capture_before", spy_before)
+    monkeypatch.setattr(graphtrail_delta, "capture_after_and_diff", spy_after)
+
+    assert (
+        work_cmd.verify_run(
+            target=tmp_path,
+            commands=["python3 -c \"print('ok')\""],
+            graphtrail_timeout=45,
+            json_output=True,
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    assert recorded == [("before", 45.0), ("after", 45.0)]
+
+
+def test_work_verify_graphtrail_delta_slow_sync_succeeds_with_configured_timeout(tmp_path, capsys, monkeypatch):
+    _init_git_repo(tmp_path)
+    _write_brigade_config(tmp_path, graphtrail_delta_timeout_seconds=1.0)
+    graphtrail = _write_fake_graphtrail(tmp_path, sync_delay_seconds=0.2)
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(graphtrail))
+
+    assert work_cmd.verify_run(target=tmp_path, commands=["python3 -c \"print('ok')\""], json_output=True) == 0
+    receipt = json.loads(capsys.readouterr().out)
+    sidecar = json.loads((Path(receipt["path"]) / "graph-delta.json").read_text())
+
+    assert receipt["code_graph_delta"]["status"] == "ok"
+    assert sidecar["graphtrail_timeout_seconds"] == 1.0
+    assert sidecar["commands"]["before_sync"]["timed_out"] is False
+    assert sidecar["commands"]["after_sync"]["timed_out"] is False
+
+
+def test_work_verify_graphtrail_delta_timeout_evidence_and_verify_exit_unchanged(tmp_path, capsys, monkeypatch):
+    _init_git_repo(tmp_path)
+    graphtrail = _write_fake_graphtrail(tmp_path, sync_delay_seconds=0.2)
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(graphtrail))
+
+    assert (
+        work_cmd.verify_run(
+            target=tmp_path,
+            commands=["python3 -c \"print('ok')\""],
+            graphtrail_timeout=0.05,
+            json_output=True,
+        )
+        == 0
+    )
+    receipt = json.loads(capsys.readouterr().out)
+    sidecar = json.loads((Path(receipt["path"]) / "graph-delta.json").read_text())
+    before_sync = sidecar["commands"]["before_sync"]
+    compact_delta = receipt["code_graph_delta"]
+
+    assert receipt["commands"][0]["status"] == "completed"
+    assert receipt["commands"][0]["exit_code"] == 0
+    assert compact_delta["status"] == "sync_timed_out"
+    assert sidecar["status"] == "sync_timed_out"
+    assert sidecar["graphtrail_timeout_seconds"] == 0.05
+    assert compact_delta["graphtrail_timeout_seconds"] == 0.05
+    assert before_sync["timed_out"] is True
+    assert before_sync["returncode"] == 124
+    assert before_sync["duration_seconds"] >= 0.05
+    assert before_sync["stderr"]
+    compact_before_sync = compact_delta["commands"]["before_sync"]
+    assert compact_before_sync["timed_out"] is True
+    assert compact_before_sync["duration_seconds"] >= 0.05
+    assert compact_before_sync["stderr"]
+
+
+def test_work_verify_graphtrail_delta_preexisting_db_timeout_uses_stale_baseline(tmp_path, capsys, monkeypatch):
+    _init_git_repo(tmp_path)
+    _seed_graphtrail_db(tmp_path)
+    graphtrail = _write_fake_graphtrail(tmp_path, sync_delay_seconds=0.2)
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(graphtrail))
+
+    assert (
+        work_cmd.verify_run(
+            target=tmp_path,
+            commands=["python3 -c \"print('ok')\""],
+            graphtrail_timeout=0.05,
+            json_output=True,
+        )
+        == 0
+    )
+    receipt = json.loads(capsys.readouterr().out)
+    sidecar = json.loads((Path(receipt["path"]) / "graph-delta.json").read_text())
+    before_sync = sidecar["commands"]["before_sync"]
+
+    assert receipt["commands"][0]["status"] == "completed"
+    assert receipt["commands"][0]["exit_code"] == 0
+    assert receipt["code_graph_delta"]["stale_graph_used"] is True
+    assert sidecar["stale_graph_used"] is True
+    assert before_sync["stage"] == "incremental-sync"
+    assert before_sync["timed_out"] is True
+
+
+def test_work_verify_graphtrail_delta_diff_timeout_is_distinct_from_sync_timeout(tmp_path, capsys, monkeypatch):
+    _init_git_repo(tmp_path)
+    graphtrail = _write_fake_graphtrail(tmp_path, diff_delay_seconds=0.2)
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(graphtrail))
+
+    assert (
+        work_cmd.verify_run(
+            target=tmp_path,
+            commands=["python3 -c \"print('ok')\""],
+            graphtrail_timeout=0.05,
+            json_output=True,
+        )
+        == 0
+    )
+    receipt = json.loads(capsys.readouterr().out)
+    sidecar = json.loads((Path(receipt["path"]) / "graph-delta.json").read_text())
+    diff_command = sidecar["commands"]["diff"]
+
+    assert receipt["commands"][0]["status"] == "completed"
+    assert receipt["commands"][0]["exit_code"] == 0
+    assert receipt["code_graph_delta"]["status"] == "diff_timed_out"
+    assert sidecar["status"] == "diff_timed_out"
+    assert diff_command["stage"] == "diff"
+    assert diff_command["timed_out"] is True
+    assert diff_command["returncode"] == 124
+    assert diff_command["duration_seconds"] >= 0.05
+    assert diff_command["stderr"]
+
+
+def test_work_verify_graphtrail_delta_timeout_differs_from_sync_command_failure(tmp_path, capsys, monkeypatch):
+    _init_git_repo(tmp_path)
+    graphtrail = _write_fake_graphtrail(tmp_path, mode="sync-fail")
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(graphtrail))
+
+    assert work_cmd.verify_run(target=tmp_path, commands=["python3 -c \"print('ok')\""], json_output=True) == 0
+    receipt = json.loads(capsys.readouterr().out)
+    sidecar = json.loads((Path(receipt["path"]) / "graph-delta.json").read_text())
+    before_sync = sidecar["commands"]["before_sync"]
+
+    assert receipt["code_graph_delta"]["status"] == "sync_failed"
+    assert sidecar["status"] == "sync_failed"
+    assert before_sync["timed_out"] is False
+    assert before_sync["returncode"] == 5
+    assert "sync failed" in before_sync["stderr"]
+
+
+def test_work_verify_run_cli_passes_graphtrail_timeout_override(tmp_path, monkeypatch):
+    seen: list[dict[str, object]] = []
+
+    def fake_verify_run(**kwargs):
+        seen.append(kwargs)
+        return 0
+
+    monkeypatch.setattr(work_cmd, "verify_run", fake_verify_run)
+
+    assert (
+        cli.main(
+            [
+                "work",
+                "verify",
+                "run",
+                "--target",
+                str(tmp_path),
+                "--command",
+                "python3 -m pytest -q",
+                "--graphtrail-timeout",
+                "45",
+                "--json",
+            ]
+        )
+        == 0
+    )
+    assert seen == [
+        {
+            "target": tmp_path,
+            "commands": ["python3 -m pytest -q"],
+            "timeout": 900,
+            "graphtrail_timeout": 45,
+            "json_output": True,
+            "capture": None,
+            "capture_kind": "skill",
+        }
+    ]
 
 
 def test_work_closeout_writes_ready_receipt(tmp_path, capsys):
@@ -811,6 +1079,7 @@ def test_work_verify_and_closeout_cli(tmp_path, monkeypatch):
                 "target": tmp_path,
                 "commands": ["python3 -m pytest -q"],
                 "timeout": 12,
+                "graphtrail_timeout": None,
                 "json_output": True,
                 "capture": None,
                 "capture_kind": "skill",

--- a/tests/test_work_cmd_verification.py
+++ b/tests/test_work_cmd_verification.py
@@ -980,7 +980,7 @@ def test_work_verify_graphtrail_delta_rejects_invalid_per_invocation_timeout_ove
 
     assert rc == 2
     assert "error:" in err
-    assert "graphtrail_delta_timeout_seconds must be a positive number" in err
+    assert "--graphtrail-timeout must be a positive number" in err
     assert "Traceback" not in err
     assert _count_verify_run_dirs(tmp_path) == 0
 

--- a/tests/test_work_cmd_verification.py
+++ b/tests/test_work_cmd_verification.py
@@ -549,12 +549,23 @@ def _seed_graphtrail_db(tmp_path: Path) -> Path:
     return db_path
 
 
+def _count_verify_run_dirs(target: Path) -> int:
+    from brigade.work_cmd import helpers
+
+    root = helpers._verify_runs_root(target)
+    if not root.is_dir():
+        return 0
+    return sum(1 for entry in root.iterdir() if entry.is_dir())
+
+
 def _write_fake_graphtrail(
     tmp_path,
     *,
     mode: str = "ok",
     sync_delay_seconds: float = 0.0,
     diff_delay_seconds: float = 0.0,
+    create_db_before_delay: bool = False,
+    sync_delay_from_call: int = 1,
 ) -> Path:
     script = tmp_path / "fake-graphtrail.py"
     script.write_text(
@@ -573,6 +584,8 @@ command = args[args.index(str(db)) + 1] if str(db) in args and args.index(str(db
 mode = os.environ.get("FAKE_GRAPHTRAIL_MODE", "ok")
 sync_delay_seconds = float(os.environ.get("FAKE_GRAPHTRAIL_SYNC_SECONDS", "0"))
 diff_delay_seconds = float(os.environ.get("FAKE_GRAPHTRAIL_DIFF_SECONDS", "0"))
+create_db_before_delay = os.environ.get("FAKE_GRAPHTRAIL_CREATE_DB_BEFORE_DELAY", "") == "1"
+sync_delay_from_call = int(os.environ.get("FAKE_GRAPHTRAIL_SYNC_DELAY_FROM_CALL", "1"))
 
 # Mirror the real clap CLI strictly: `sync` rejects --json, `diff` requires
 # --before/--after/--json. JSON shape follows graphtrail's diff golden fixture.
@@ -580,7 +593,16 @@ if command == "sync":
     if "--json" in args:
         print("error: unexpected argument '--json' found", file=sys.stderr)
         raise SystemExit(2)
-    if sync_delay_seconds > 0:
+    counter_path = db.parent / ".fake-graphtrail-sync-count"
+    sync_call = int(counter_path.read_text()) if counter_path.is_file() else 0
+    sync_call += 1
+    counter_path.parent.mkdir(parents=True, exist_ok=True)
+    counter_path.write_text(str(sync_call))
+    if create_db_before_delay:
+        db.parent.mkdir(parents=True, exist_ok=True)
+        with sqlite3.connect(db) as con:
+            con.execute("create table if not exists symbols (name text)")
+    if sync_delay_seconds > 0 and sync_call >= sync_delay_from_call:
         time.sleep(sync_delay_seconds)
     if mode == "sync-fail":
         print("sync failed", file=sys.stderr)
@@ -654,7 +676,10 @@ raise SystemExit(9)
         f"FAKE_GRAPHTRAIL_MODE={mode}\n"
         f"FAKE_GRAPHTRAIL_SYNC_SECONDS={sync_delay_seconds}\n"
         f"FAKE_GRAPHTRAIL_DIFF_SECONDS={diff_delay_seconds}\n"
-        f"export FAKE_GRAPHTRAIL_MODE FAKE_GRAPHTRAIL_SYNC_SECONDS FAKE_GRAPHTRAIL_DIFF_SECONDS\n"
+        f"FAKE_GRAPHTRAIL_CREATE_DB_BEFORE_DELAY={'1' if create_db_before_delay else '0'}\n"
+        f"FAKE_GRAPHTRAIL_SYNC_DELAY_FROM_CALL={sync_delay_from_call}\n"
+        "export FAKE_GRAPHTRAIL_MODE FAKE_GRAPHTRAIL_SYNC_SECONDS FAKE_GRAPHTRAIL_DIFF_SECONDS "
+        "FAKE_GRAPHTRAIL_CREATE_DB_BEFORE_DELAY FAKE_GRAPHTRAIL_SYNC_DELAY_FROM_CALL\n"
         f'exec {os.environ.get("PYTHON", "python3")} {script} "$@"\n'
     )
     wrapper.chmod(0o755)
@@ -851,6 +876,113 @@ def test_work_verify_graphtrail_delta_timeout_evidence_and_verify_exit_unchanged
     assert compact_before_sync["timed_out"] is True
     assert compact_before_sync["duration_seconds"] >= 0.05
     assert compact_before_sync["stderr"]
+    assert before_sync["stage"] == "initial-index"
+
+
+def test_work_verify_graphtrail_delta_cold_initial_early_db_timeout_stays_sync_timed_out(tmp_path, capsys, monkeypatch):
+    _init_git_repo(tmp_path)
+    graphtrail = _write_fake_graphtrail(
+        tmp_path,
+        sync_delay_seconds=0.2,
+        create_db_before_delay=True,
+    )
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(graphtrail))
+
+    assert (
+        work_cmd.verify_run(
+            target=tmp_path,
+            commands=["python3 -c \"print('ok')\""],
+            graphtrail_timeout=0.05,
+            json_output=True,
+        )
+        == 0
+    )
+    receipt = json.loads(capsys.readouterr().out)
+    sidecar = json.loads((Path(receipt["path"]) / "graph-delta.json").read_text())
+    before_sync = sidecar["commands"]["before_sync"]
+    compact_delta = receipt["code_graph_delta"]
+
+    assert receipt["commands"][0]["exit_code"] == 0
+    assert compact_delta["status"] == "sync_timed_out"
+    assert sidecar["status"] == "sync_timed_out"
+    assert "stale_graph_used" not in compact_delta
+    assert "stale_graph_used" not in sidecar
+    assert before_sync["stage"] == "initial-index"
+    assert before_sync["timed_out"] is True
+    assert sidecar["commands"]["after_sync"] is None
+
+
+def test_work_verify_graphtrail_delta_invalid_config_timeout_returns_2_without_orphan_run(tmp_path, capsys):
+    _init_git_repo(tmp_path)
+    _write_brigade_config(tmp_path, graphtrail_delta_timeout_seconds=0)
+    assert _count_verify_run_dirs(tmp_path) == 0
+
+    rc = work_cmd.verify_run(
+        target=tmp_path,
+        commands=["python3 -c \"print('ok')\""],
+        json_output=True,
+    )
+    err = capsys.readouterr().err
+
+    assert rc == 2
+    assert "error:" in err
+    assert "graphtrail_delta_timeout_seconds must be a positive number" in err
+    assert "Traceback" not in err
+    assert _count_verify_run_dirs(tmp_path) == 0
+
+
+def test_work_verify_graphtrail_delta_post_sync_timeout_after_successful_pre_sync(tmp_path, capsys, monkeypatch):
+    _init_git_repo(tmp_path)
+    graphtrail = _write_fake_graphtrail(
+        tmp_path,
+        sync_delay_seconds=0.2,
+        sync_delay_from_call=2,
+    )
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(graphtrail))
+
+    assert (
+        work_cmd.verify_run(
+            target=tmp_path,
+            commands=["python3 -c \"print('ok')\""],
+            graphtrail_timeout=0.05,
+            json_output=True,
+        )
+        == 0
+    )
+    receipt = json.loads(capsys.readouterr().out)
+    sidecar = json.loads((Path(receipt["path"]) / "graph-delta.json").read_text())
+    before_sync = sidecar["commands"]["before_sync"]
+    after_sync = sidecar["commands"]["after_sync"]
+
+    assert receipt["commands"][0]["status"] == "completed"
+    assert receipt["commands"][0]["exit_code"] == 0
+    assert receipt["code_graph_delta"]["status"] == "sync_timed_out"
+    assert sidecar["status"] == "sync_timed_out"
+    assert before_sync["timed_out"] is False
+    assert after_sync["stage"] == "incremental-sync"
+    assert after_sync["timed_out"] is True
+
+
+@pytest.mark.parametrize(
+    "bad_timeout",
+    [0, -1, True, float("nan"), float("inf")],
+    ids=["zero", "negative", "boolean", "nan", "infinity"],
+)
+def test_work_verify_graphtrail_delta_rejects_invalid_per_invocation_timeout_override(tmp_path, capsys, bad_timeout):
+    _init_git_repo(tmp_path)
+
+    rc = work_cmd.verify_run(
+        target=tmp_path,
+        commands=["python3 -c \"print('ok')\""],
+        graphtrail_timeout=bad_timeout,
+    )
+    err = capsys.readouterr().err
+
+    assert rc == 2
+    assert "error:" in err
+    assert "graphtrail_delta_timeout_seconds must be a positive number" in err
+    assert "Traceback" not in err
+    assert _count_verify_run_dirs(tmp_path) == 0
 
 
 def test_work_verify_graphtrail_delta_preexisting_db_timeout_uses_stale_baseline(tmp_path, capsys, monkeypatch):


### PR DESCRIPTION
## Summary

- Add `graphtrail_delta_timeout_seconds` to repository configuration and `--graphtrail-timeout` to individual work verification runs.
- Apply the effective timeout to GraphTrail pre-sync, post-sync, and diff commands without changing verification command timeouts or exit codes.
- Record timeout stage, duration, stderr, stale graph use, and failure classification in GraphTrail delta evidence.
- Reject invalid timeout values before creating a verification run directory.
- Keep stale-baseline deltas out of live context evaluation and outcome graph counters, including after outcome capture persists and reloads the compact receipt data.

## Verification

- `./scripts/verify`: 2,317 passed, 3 skipped, 81.40% coverage.
- Exact-head Brigade receipt: `20260716-235347-work-verify-6771ba`.
- Capture-path regression receipt: `20260716-235339-work-verify-3d9668`.
- Independent exact-head review: `CLEAN` at `cc7f1e65cdbd773e36330181ec6cb137c7977a71`.

## Review focus

- Timeout precedence and invalid-value handling.
- Pre-sync stale-baseline fallback versus cold-start timeout failure.
- Persistence and exclusion of `stale_graph_used` across verify receipts, outcome capture, rank, reconcile, and context evaluation.

Closes #253
