### PR TITLE
fix(work): bound fleet status memory to current artifacts

### DIFF
--- a/scripts/benchmark_issue266_work_status_memory.py
+++ b/scripts/benchmark_issue266_work_status_memory.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Benchmark work-brief and daily-status memory for issue 266."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_TESTS_DIR = _REPO_ROOT / "tests"
+if str(_TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TESTS_DIR))
+
+from issue266_fixture import (  # noqa: E402
+    FLEET_REPO_COUNT,
+    OPERATOR_REPORT_HISTORY_COUNT,
+    build_daily_status_workspace,
+)
+
+DEFAULT_BUDGETS = {
+    "work_brief": {
+        "exit_code": 0,
+        "peak_rss_mib_max": 200.0,
+        "stdout_bytes_max": 2_000_000,
+        "wall_seconds_max": 8.0,
+    },
+    "daily_status": {
+        "exit_code": 0,
+        "peak_rss_mib_max": 180.0,
+        "stdout_bytes_max": 1_500_000,
+        "wall_seconds_max": 6.0,
+    },
+}
+
+
+def _python_argv() -> list[str]:
+    return [sys.executable, "-m", "brigade"]
+
+
+def _proc_peak_rss_kib(pid: int) -> int:
+    status_path = Path(f"/proc/{pid}/status")
+    if not status_path.is_file():
+        return 0
+    peak_kib = 0
+    for line in status_path.read_text().splitlines():
+        if line.startswith(("VmRSS:", "VmHWM:")):
+            peak_kib = max(peak_kib, int(line.split()[1]))
+    return peak_kib
+
+
+def _run_command(argv: list[str], *, cwd: Path) -> dict[str, object]:
+    started = time.perf_counter()
+    proc = subprocess.Popen(
+        argv,
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    peak_rss_kib = 0
+    while proc.poll() is None:
+        peak_rss_kib = max(peak_rss_kib, _proc_peak_rss_kib(proc.pid))
+        time.sleep(0.005)
+    peak_rss_kib = max(peak_rss_kib, _proc_peak_rss_kib(proc.pid))
+    stdout, stderr = proc.communicate()
+    wall_seconds = round(time.perf_counter() - started, 3)
+    return {
+        "argv": argv,
+        "exit_code": proc.returncode,
+        "stdout_bytes": len(stdout),
+        "stderr_bytes": len(stderr),
+        "wall_seconds": wall_seconds,
+        "peak_rss_kib": peak_rss_kib,
+        "peak_rss_mib": round(peak_rss_kib / 1024, 2),
+    }
+
+
+def _budget_result(name: str, observed: dict[str, object], budget: dict[str, object]) -> dict[str, object]:
+    checks = {
+        "exit_code": observed["exit_code"] == budget["exit_code"],
+        "peak_rss_mib": float(observed["peak_rss_mib"]) <= float(budget["peak_rss_mib_max"]),
+        "stdout_bytes": int(observed["stdout_bytes"]) <= int(budget["stdout_bytes_max"]),
+        "wall_seconds": float(observed["wall_seconds"]) <= float(budget["wall_seconds_max"]),
+    }
+    return {
+        "name": name,
+        "budget": budget,
+        "observed": {
+            "exit_code": observed["exit_code"],
+            "peak_rss_mib": observed["peak_rss_mib"],
+            "stdout_bytes": observed["stdout_bytes"],
+            "wall_seconds": observed["wall_seconds"],
+        },
+        "checks": checks,
+        "passed": all(checks.values()),
+    }
+
+
+def _build_workspace(
+    workspace: Path | None,
+    *,
+    repo_count: int,
+    report_count: int,
+    sweep_history_count: int,
+    artifact_padding_bytes: int,
+) -> Path:
+    if workspace is None:
+        workspace = Path(tempfile.mkdtemp(prefix="brigade-issue266-"))
+    build_daily_status_workspace(
+        workspace,
+        repo_count=repo_count,
+        report_count=report_count,
+        sweep_history_count=sweep_history_count,
+        artifact_padding_bytes=artifact_padding_bytes,
+    )
+    return workspace
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workspace", type=Path, default=None, help="Existing or new workspace path.")
+    parser.add_argument(
+        "--results-out",
+        type=Path,
+        default=None,
+        help="Write JSON results to this durable path.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional alias for --results-out.",
+    )
+    parser.add_argument("--phase", default="local", help="Phase label stored in the output JSON.")
+    parser.add_argument("--repo-count", type=int, default=FLEET_REPO_COUNT)
+    parser.add_argument("--report-count", type=int, default=OPERATOR_REPORT_HISTORY_COUNT)
+    parser.add_argument("--sweep-history-count", type=int, default=1)
+    parser.add_argument("--artifact-padding-bytes", type=int, default=0)
+    parser.add_argument(
+        "--work-brief-peak-rss-mib-max",
+        type=float,
+        default=DEFAULT_BUDGETS["work_brief"]["peak_rss_mib_max"],
+    )
+    parser.add_argument(
+        "--daily-status-peak-rss-mib-max",
+        type=float,
+        default=DEFAULT_BUDGETS["daily_status"]["peak_rss_mib_max"],
+    )
+    args = parser.parse_args()
+
+    workspace = _build_workspace(
+        args.workspace,
+        repo_count=args.repo_count,
+        report_count=args.report_count,
+        sweep_history_count=args.sweep_history_count,
+        artifact_padding_bytes=args.artifact_padding_bytes,
+    )
+
+    brigade = _python_argv()
+    commands = {
+        "work_brief": _run_command(
+            [*brigade, "work", "brief", "--target", str(workspace), "--json"],
+            cwd=_REPO_ROOT,
+        ),
+        "daily_status": _run_command(
+            [*brigade, "daily", "status", "--target", str(workspace), "--json"],
+            cwd=_REPO_ROOT,
+        ),
+    }
+
+    budgets = {
+        "work_brief": {
+            **DEFAULT_BUDGETS["work_brief"],
+            "peak_rss_mib_max": args.work_brief_peak_rss_mib_max,
+        },
+        "daily_status": {
+            **DEFAULT_BUDGETS["daily_status"],
+            "peak_rss_mib_max": args.daily_status_peak_rss_mib_max,
+        },
+    }
+    budget_results = [
+        _budget_result(name, commands[name], budgets[name])
+        for name in ("work_brief", "daily_status")
+    ]
+    payload = {
+        "issue": 266,
+        "phase": args.phase,
+        "passed": all(item["passed"] for item in budget_results),
+        "default_budgets": DEFAULT_BUDGETS,
+        "fixture": {
+            "fixture_kind": "issue-266-synthetic-fleet",
+            "workspace": str(workspace),
+            "fleet_repo_count": args.repo_count,
+            "operator_report_history_count": args.report_count,
+            "sweep_history_count": args.sweep_history_count,
+            "artifact_padding_bytes": args.artifact_padding_bytes,
+        },
+        "commands": commands,
+        "budget_results": budget_results,
+    }
+
+    encoded = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    results_path = args.results_out if args.results_out is not None else args.output
+    if results_path is not None:
+        results_path.parent.mkdir(parents=True, exist_ok=True)
+        results_path.write_text(encoded)
+    print(encoded, end="")
+    return 0 if payload["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark_issue266_work_status_memory.py
+++ b/scripts/benchmark_issue266_work_status_memory.py
@@ -18,6 +18,7 @@ if str(_TESTS_DIR) not in sys.path:
 
 from issue266_fixture import (  # noqa: E402
     FLEET_REPO_COUNT,
+    FLEET_SWEEP_HISTORY_COUNT,
     OPERATOR_REPORT_HISTORY_COUNT,
     build_daily_status_workspace,
 )
@@ -42,47 +43,71 @@ def _python_argv() -> list[str]:
     return [sys.executable, "-m", "brigade"]
 
 
-def _proc_peak_rss_kib(pid: int) -> int:
+def _proc_peak_rss_kib(pid: int) -> int | None:
     status_path = Path(f"/proc/{pid}/status")
-    if not status_path.is_file():
-        return 0
-    peak_kib = 0
-    for line in status_path.read_text().splitlines():
+    try:
+        lines = status_path.read_text().splitlines()
+    except OSError:
+        return None
+    peak_kib: int | None = None
+    for line in lines:
         if line.startswith(("VmRSS:", "VmHWM:")):
-            peak_kib = max(peak_kib, int(line.split()[1]))
+            value = int(line.split()[1])
+            peak_kib = value if peak_kib is None else max(peak_kib, value)
     return peak_kib
 
 
-def _run_command(argv: list[str], *, cwd: Path) -> dict[str, object]:
+def _run_command(argv: list[str], *, cwd: Path, wall_seconds_max: float) -> dict[str, object]:
     started = time.perf_counter()
-    proc = subprocess.Popen(
-        argv,
-        cwd=cwd,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    peak_rss_kib = 0
-    while proc.poll() is None:
-        peak_rss_kib = max(peak_rss_kib, _proc_peak_rss_kib(proc.pid))
-        time.sleep(0.005)
-    peak_rss_kib = max(peak_rss_kib, _proc_peak_rss_kib(proc.pid))
-    stdout, stderr = proc.communicate()
+    deadline = started + wall_seconds_max
+    peak_rss_kib: int | None = None
+    timed_out = False
+    with tempfile.TemporaryFile() as stdout_file, tempfile.TemporaryFile() as stderr_file:
+        proc = subprocess.Popen(
+            argv,
+            cwd=cwd,
+            stdout=stdout_file,
+            stderr=stderr_file,
+        )
+        while proc.poll() is None:
+            sample = _proc_peak_rss_kib(proc.pid)
+            if sample is not None:
+                peak_rss_kib = sample if peak_rss_kib is None else max(peak_rss_kib, sample)
+            if time.perf_counter() >= deadline:
+                timed_out = True
+                proc.terminate()
+                try:
+                    proc.wait(timeout=1.0)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait()
+                break
+            time.sleep(0.005)
+        if proc.returncode is None:
+            proc.wait()
+        stdout_file.seek(0, 2)
+        stderr_file.seek(0, 2)
+        stdout_bytes = stdout_file.tell()
+        stderr_bytes = stderr_file.tell()
     wall_seconds = round(time.perf_counter() - started, 3)
     return {
         "argv": argv,
         "exit_code": proc.returncode,
-        "stdout_bytes": len(stdout),
-        "stderr_bytes": len(stderr),
+        "stdout_bytes": stdout_bytes,
+        "stderr_bytes": stderr_bytes,
         "wall_seconds": wall_seconds,
         "peak_rss_kib": peak_rss_kib,
-        "peak_rss_mib": round(peak_rss_kib / 1024, 2),
+        "peak_rss_mib": None if peak_rss_kib is None else round(peak_rss_kib / 1024, 2),
+        "rss_sampling_supported": peak_rss_kib is not None,
+        "timed_out": timed_out,
     }
 
 
 def _budget_result(name: str, observed: dict[str, object], budget: dict[str, object]) -> dict[str, object]:
+    peak_rss_mib = observed["peak_rss_mib"]
     checks = {
         "exit_code": observed["exit_code"] == budget["exit_code"],
-        "peak_rss_mib": float(observed["peak_rss_mib"]) <= float(budget["peak_rss_mib_max"]),
+        "peak_rss_mib": peak_rss_mib is not None and float(peak_rss_mib) <= float(budget["peak_rss_mib_max"]),
         "stdout_bytes": int(observed["stdout_bytes"]) <= int(budget["stdout_bytes_max"]),
         "wall_seconds": float(observed["wall_seconds"]) <= float(budget["wall_seconds_max"]),
     }
@@ -92,7 +117,9 @@ def _budget_result(name: str, observed: dict[str, object], budget: dict[str, obj
         "observed": {
             "exit_code": observed["exit_code"],
             "peak_rss_mib": observed["peak_rss_mib"],
+            "rss_sampling_supported": observed["rss_sampling_supported"],
             "stdout_bytes": observed["stdout_bytes"],
+            "timed_out": observed["timed_out"],
             "wall_seconds": observed["wall_seconds"],
         },
         "checks": checks,
@@ -122,7 +149,7 @@ def _build_workspace(
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--workspace", type=Path, default=None, help="Existing or new workspace path.")
+    parser.add_argument("--workspace", type=Path, default=None, help="Absent or empty workspace path.")
     parser.add_argument(
         "--results-out",
         type=Path,
@@ -138,7 +165,7 @@ def main() -> int:
     parser.add_argument("--phase", default="local", help="Phase label stored in the output JSON.")
     parser.add_argument("--repo-count", type=int, default=FLEET_REPO_COUNT)
     parser.add_argument("--report-count", type=int, default=OPERATOR_REPORT_HISTORY_COUNT)
-    parser.add_argument("--sweep-history-count", type=int, default=1)
+    parser.add_argument("--sweep-history-count", type=int, default=FLEET_SWEEP_HISTORY_COUNT)
     parser.add_argument("--artifact-padding-bytes", type=int, default=0)
     parser.add_argument(
         "--work-brief-peak-rss-mib-max",
@@ -165,10 +192,12 @@ def main() -> int:
         "work_brief": _run_command(
             [*brigade, "work", "brief", "--target", str(workspace), "--json"],
             cwd=_REPO_ROOT,
+            wall_seconds_max=float(DEFAULT_BUDGETS["work_brief"]["wall_seconds_max"]),
         ),
         "daily_status": _run_command(
             [*brigade, "daily", "status", "--target", str(workspace), "--json"],
             cwd=_REPO_ROOT,
+            wall_seconds_max=float(DEFAULT_BUDGETS["daily_status"]["wall_seconds_max"]),
         ),
     }
 

--- a/src/brigade/center_cmd/reports.py
+++ b/src/brigade/center_cmd/reports.py
@@ -77,8 +77,26 @@ def _reports(target: Path, *, include_archived: bool = False) -> list[dict[str, 
     )
 
 
+def _latest_reports(
+    target: Path,
+    *,
+    limit: int = 1,
+    include_archived: bool = False,
+) -> list[dict[str, Any]]:
+    roots = [_reports_root(target)]
+    if include_archived:
+        roots.append(_reports_archive_root(target))
+    return reportstore.latest_bundles(
+        roots,
+        _read_report,
+        id_field="report_id",
+        limit=limit,
+        skip_child=lambda name: name.endswith("archive"),
+    )
+
+
 def latest_report(target: Path) -> dict[str, Any] | None:
-    reports = _reports(target)
+    reports = _latest_reports(target, limit=1)
     return reports[0] if reports else None
 
 
@@ -409,10 +427,14 @@ def _write_report_bundle(report_dir: Path, payload: dict[str, Any]) -> None:
     )
 
 
-def report_health(target: Path) -> dict[str, Any]:
+def report_health(
+    target: Path,
+    *,
+    reports: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
     target = target.expanduser().resolve()
-    latest = latest_report(target)
-    reports = _reports(target)
+    loaded_reports = reports if reports is not None else _latest_reports(target, limit=2)
+    latest = loaded_reports[0] if loaded_reports else None
     checks: list[dict[str, Any]] = []
     if latest is None:
         checks.append(
@@ -483,9 +505,9 @@ def report_health(target: Path) -> dict[str, Any]:
             }
         )
     latest_diff = latest_report_diff(target)
-    if len(reports) >= 2:
-        compare_report = reports[0]
-        base_report = reports[1]
+    if len(loaded_reports) >= 2:
+        compare_report = loaded_reports[0]
+        base_report = loaded_reports[1]
         if latest_diff is None:
             checks.append(
                 {

--- a/src/brigade/daily_cmd/candidates.py
+++ b/src/brigade/daily_cmd/candidates.py
@@ -464,8 +464,12 @@ def _notification_candidates(target: Path) -> list[dict[str, Any]]:
     ]
 
 
-def _report_candidate(target: Path) -> list[dict[str, Any]]:
-    health = center_cmd.report_health(target)
+def _report_candidate(
+    target: Path,
+    *,
+    operator_report_health: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    health = operator_report_health if operator_report_health is not None else center_cmd.report_health(target)
     top = health.get("top_issue") if isinstance(health.get("top_issue"), dict) else None
     if not top:
         return []
@@ -684,7 +688,12 @@ def _phase_session_candidates(target: Path) -> list[dict[str, Any]]:
     return candidates
 
 
-def _all_candidates(target: Path, diagnostics: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
+def _all_candidates(
+    target: Path,
+    diagnostics: list[dict[str, Any]] | None = None,
+    *,
+    operator_report_health: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
     config, _ = _load_config(target)
     candidates: list[dict[str, Any]] = []
     sections = [
@@ -701,7 +710,14 @@ def _all_candidates(target: Path, diagnostics: list[dict[str, Any]] | None = Non
         ("operator-report", _report_candidate),
     ]
     for label, builder in sections:
-        result, check = _bounded_status_call(label, lambda builder=builder: builder(target), [])
+        if label == "operator-report":
+            result, check = _bounded_status_call(
+                label,
+                lambda builder=builder: builder(target, operator_report_health=operator_report_health),
+                [],
+            )
+        else:
+            result, check = _bounded_status_call(label, lambda builder=builder: builder(target), [])
         if diagnostics is not None:
             diagnostics.append(check)
         if isinstance(result, list):

--- a/src/brigade/daily_cmd/status_plan.py
+++ b/src/brigade/daily_cmd/status_plan.py
@@ -206,17 +206,28 @@ def status_payload(target: Path) -> dict[str, Any]:
     )
     status_section_checks.append(check)
     config, config_checks = _load_config(target)
-    candidates = _all_candidates(target, diagnostics=status_section_checks)
+    operator_report_health, check = _bounded_status_call(
+        "operator-report-health",
+        lambda: center_cmd.report_health(target),
+        {"latest": None, "checks": [], "issue_count": 0, "top_issue": None},
+    )
+    status_section_checks.append(check)
+    candidates = _all_candidates(
+        target,
+        diagnostics=status_section_checks,
+        operator_report_health=operator_report_health,
+    )
     selected = _selected(candidates)
     handoffs = center.get("handoff_drafts") if isinstance(center.get("handoff_drafts"), dict) else {}
     memory = center.get("memory_care") if isinstance(center.get("memory_care"), dict) else {}
     security = center.get("security") if isinstance(center.get("security"), dict) else {}
     notifications = center.get("notifications") if isinstance(center.get("notifications"), dict) else {}
     tools = center.get("tool_catalog") if isinstance(center.get("tool_catalog"), dict) else {}
-    latest_report, check = _bounded_status_call(
-        "latest-operator-report", lambda: center_cmd.latest_report(target), None
+    latest_report = (
+        operator_report_health.get("latest")
+        if isinstance(operator_report_health, dict) and isinstance(operator_report_health.get("latest"), dict)
+        else None
     )
-    status_section_checks.append(check)
     daily_health_fallback = {
         "schema_version": SCHEMA_VERSION,
         "config_path": str(_config_path(target)),

--- a/src/brigade/reportstore.py
+++ b/src/brigade/reportstore.py
@@ -22,6 +22,7 @@ write_json because the train CLOSEOUT.json intentionally carries no
 
 from __future__ import annotations
 
+import re
 import shutil
 from pathlib import Path
 from typing import Any, Callable, Iterable
@@ -29,6 +30,7 @@ from typing import Any, Callable, Iterable
 from .localio import read_json_dict, write_json
 
 CLOSEOUT_STATUSES = frozenset({"reviewed", "deferred", "superseded", "archived"})
+_TIMESTAMP_PREFIXED_DIR = re.compile(r"^\d{8}-\d{6}")
 
 
 def bundle_json_path(path: Path, evidence_name: str) -> Path:
@@ -45,6 +47,26 @@ def read_bundle(path: Path, evidence_name: str) -> dict[str, Any] | None:
     return payload
 
 
+def _bundle_dirs(
+    roots: Iterable[Path],
+    *,
+    skip_child: Callable[[str], bool] | None = None,
+) -> list[Path]:
+    children: list[Path] = []
+    for root in roots:
+        if not root.is_dir():
+            continue
+        for child in root.iterdir():
+            if child.is_dir() and (skip_child is None or not skip_child(child.name)):
+                children.append(child)
+    children.sort(key=lambda path: path.name, reverse=True)
+    return children
+
+
+def _dir_names_are_timestamp_prefixed(children: list[Path]) -> bool:
+    return bool(children) and all(_TIMESTAMP_PREFIXED_DIR.match(child.name) for child in children)
+
+
 def list_bundles(
     roots: Iterable[Path],
     read: Callable[[Path], dict[str, Any] | None],
@@ -54,16 +76,53 @@ def list_bundles(
 ) -> list[dict[str, Any]]:
     """Read the bundle dirs under roots via read, newest first by created_at then id_field."""
     bundles: list[dict[str, Any]] = []
-    for root in roots:
-        if not root.is_dir():
-            continue
-        for child in root.iterdir():
-            if not child.is_dir() or (skip_child is not None and skip_child(child.name)):
-                continue
+    for child in _bundle_dirs(roots, skip_child=skip_child):
+        payload = read(child)
+        if payload is not None:
+            bundles.append(payload)
+    bundles.sort(key=lambda item: str(item.get("created_at") or item.get(id_field) or ""), reverse=True)
+    return bundles
+
+
+def latest_bundles(
+    roots: Iterable[Path],
+    read: Callable[[Path], dict[str, Any] | None],
+    *,
+    id_field: str,
+    limit: int = 1,
+    skip_child: Callable[[str], bool] | None = None,
+) -> list[dict[str, Any]]:
+    """Read up to limit newest bundles without decoding the full history when possible.
+
+    Production bundle dirs are timestamp-prefixed and sortable by name; in that case
+    only the newest ``limit`` dirs are decoded. Legacy or arbitrary dir names fall
+    back to created_at ordering, which may require decoding every bundle.
+    """
+    if limit < 1:
+        return []
+
+    def sort_key(item: dict[str, Any]) -> str:
+        return str(item.get("created_at") or item.get(id_field) or "")
+
+    children = _bundle_dirs(roots, skip_child=skip_child)
+    bundles: list[dict[str, Any]] = []
+    if _dir_names_are_timestamp_prefixed(children):
+        for child in children:
             payload = read(child)
             if payload is not None:
                 bundles.append(payload)
-    bundles.sort(key=lambda item: str(item.get("created_at") or item.get(id_field) or ""), reverse=True)
+            if len(bundles) >= limit:
+                break
+    else:
+        for child in children:
+            payload = read(child)
+            if payload is None:
+                continue
+            bundles.append(payload)
+            if len(bundles) > limit:
+                bundles.sort(key=sort_key, reverse=True)
+                del bundles[limit:]
+    bundles.sort(key=sort_key, reverse=True)
     return bundles
 
 

--- a/src/brigade/reportstore.py
+++ b/src/brigade/reportstore.py
@@ -30,7 +30,7 @@ from typing import Any, Callable, Iterable
 from .localio import read_json_dict, write_json
 
 CLOSEOUT_STATUSES = frozenset({"reviewed", "deferred", "superseded", "archived"})
-_TIMESTAMP_PREFIXED_DIR = re.compile(r"^\d{8}-\d{6}")
+_TIMESTAMP_PREFIXED_DIR = re.compile(r"^\d{8}-\d{6}(?:-|$)")
 
 
 def bundle_json_path(path: Path, evidence_name: str) -> Path:

--- a/src/brigade/repos_cmd/fleet.py
+++ b/src/brigade/repos_cmd/fleet.py
@@ -797,9 +797,19 @@ def _repo_checks(summary: dict[str, Any]) -> list[dict[str, Any]]:
     return checks
 
 
-def scan_payload(target: Path) -> dict[str, Any]:
+def scan_payload(
+    target: Path,
+    *,
+    entries: list[constants.RepoEntry] | None = None,
+    errors: list[str] | None = None,
+    config_loaded: bool | None = None,
+) -> dict[str, Any]:
     target = target.expanduser().resolve()
-    entries, errors, config_loaded = _load_config(target)
+    if entries is None:
+        entries, errors, config_loaded = _load_config(target)
+    else:
+        errors = list(errors or [])
+        config_loaded = bool(config_loaded)
     repos = _repo_summaries(entries)
     checks: list[dict[str, Any]] = []
     if errors:

--- a/src/brigade/repos_cmd/fleet_health.py
+++ b/src/brigade/repos_cmd/fleet_health.py
@@ -482,11 +482,25 @@ def actions_archive_completed(*, target: Path, json_output: bool = False) -> int
 
 
 def health(target: Path) -> dict[str, Any]:
-    payload = fleet.scan_payload(target)
+    target = target.expanduser().resolve()
+    entries, errors, config_loaded = fleet._load_config(target)
+    payload = fleet.scan_payload(
+        target,
+        entries=entries,
+        errors=errors,
+        config_loaded=config_loaded,
+    )
+    health_snapshot = sweeps._health_sweep_snapshot(target, entries)
     report = report_health(target)
     actions = actions_health(target)
-    sweep = sweeps.sweep_health(target)
-    health_registry = sweeps._health_command_registry_payload(target)
+    sweep = sweeps.sweep_health(target, health_snapshot=health_snapshot)
+    health_registry = sweeps._health_command_registry_payload(
+        target,
+        entries=entries,
+        errors=errors,
+        config_loaded=config_loaded,
+        health_snapshot=health_snapshot,
+    )
     release_train_data = release_train_health(target)
     issue_count = (
         payload["issue_count"]

--- a/src/brigade/repos_cmd/sweeps.py
+++ b/src/brigade/repos_cmd/sweeps.py
@@ -8,6 +8,7 @@ import re
 import shutil
 import subprocess
 import sys
+from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import redirect_stdout
 from dataclasses import dataclass, field
@@ -118,6 +119,10 @@ def _list_sweep_dirs_newest_first(target: Path) -> list[Path]:
     return dirs
 
 
+def _has_timestamp_sweep_name(path: Path) -> bool:
+    return re.match(r"^\d{8}-\d{6}(?:-|$)", path.name) is not None
+
+
 def _sweeps(target: Path) -> list[dict[str, Any]]:
     sweeps: list[dict[str, Any]] = []
     for child in _list_sweep_dirs_newest_first(target):
@@ -147,6 +152,7 @@ def _required_health_receipt_keys(entries: list[constants.RepoEntry]) -> set[tup
 def _index_sweep_health_receipts(
     sweep: dict[str, Any],
     receipt_index: dict[tuple[str, str], dict[str, Any]],
+    required: set[tuple[str, str]],
 ) -> None:
     sweep_id = sweep.get("sweep_id")
     sweep_status = sweep.get("status")
@@ -164,7 +170,7 @@ def _index_sweep_health_receipts(
             if not label:
                 continue
             key = (repo_id, label)
-            if key in receipt_index:
+            if key not in required or key in receipt_index:
                 continue
             receipt_index[key] = {
                 "sweep_id": sweep_id,
@@ -186,13 +192,18 @@ def _health_sweep_snapshot(target: Path, entries: list[constants.RepoEntry]) -> 
     required = _required_health_receipt_keys(entries)
     latest: dict[str, Any] | None = None
     receipt_index: dict[tuple[str, str], dict[str, Any]] = {}
-    for sweep_dir in _list_sweep_dirs_newest_first(target):
-        sweep = _read_sweep(sweep_dir)
+    sweep_dirs = _list_sweep_dirs_newest_first(target)
+    ordered_sweeps: Iterable[dict[str, Any] | None]
+    if all(_has_timestamp_sweep_name(path) for path in sweep_dirs):
+        ordered_sweeps = (_read_sweep(path) for path in sweep_dirs)
+    else:
+        ordered_sweeps = _sweeps(target)
+    for sweep in ordered_sweeps:
         if sweep is None:
             continue
         if latest is None:
             latest = sweep
-        _index_sweep_health_receipts(sweep, receipt_index)
+        _index_sweep_health_receipts(sweep, receipt_index, required)
         if not required or required.issubset(receipt_index):
             break
     return HealthSweepSnapshot(latest=latest, receipt_index=receipt_index)

--- a/src/brigade/repos_cmd/sweeps.py
+++ b/src/brigade/repos_cmd/sweeps.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import redirect_stdout
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from io import StringIO
 from pathlib import Path
@@ -109,17 +109,93 @@ def _list_or_empty(value: object) -> list[Any]:
     return value if isinstance(value, list) else []
 
 
-def _sweeps(target: Path) -> list[dict[str, Any]]:
+def _list_sweep_dirs_newest_first(target: Path) -> list[Path]:
     root = _sweeps_root(target)
+    if not root.is_dir():
+        return []
+    dirs = [child for child in root.iterdir() if child.is_dir()]
+    dirs.sort(key=lambda path: path.name, reverse=True)
+    return dirs
+
+
+def _sweeps(target: Path) -> list[dict[str, Any]]:
     sweeps: list[dict[str, Any]] = []
-    if root.is_dir():
-        for child in root.iterdir():
-            if child.is_dir():
-                payload = _read_sweep(child)
-                if payload is not None:
-                    sweeps.append(payload)
+    for child in _list_sweep_dirs_newest_first(target):
+        payload = _read_sweep(child)
+        if payload is not None:
+            sweeps.append(payload)
     sweeps.sort(key=lambda item: str(item.get("started_at") or item.get("sweep_id") or ""), reverse=True)
     return sweeps
+
+
+@dataclass
+class HealthSweepSnapshot:
+    latest: dict[str, Any] | None = None
+    receipt_index: dict[tuple[str, str], dict[str, Any]] = field(default_factory=dict)
+
+
+def _required_health_receipt_keys(entries: list[constants.RepoEntry]) -> set[tuple[str, str]]:
+    keys: set[tuple[str, str]] = set()
+    for entry in entries:
+        if not entry.enabled:
+            continue
+        for command in entry.health_commands:
+            keys.add((entry.repo_id, command.label))
+    return keys
+
+
+def _index_sweep_health_receipts(
+    sweep: dict[str, Any],
+    receipt_index: dict[tuple[str, str], dict[str, Any]],
+) -> None:
+    sweep_id = sweep.get("sweep_id")
+    sweep_status = sweep.get("status")
+    sweep_path_label = sweep.get("path_label") or sweep_id
+    for repo in _list_or_empty(sweep.get("repos")):
+        if not isinstance(repo, dict):
+            continue
+        repo_id = str(repo.get("repo_id") or "")
+        if not repo_id:
+            continue
+        for command in _list_or_empty(repo.get("commands")):
+            if not isinstance(command, dict):
+                continue
+            label = str(command.get("label") or "")
+            if not label:
+                continue
+            key = (repo_id, label)
+            if key in receipt_index:
+                continue
+            receipt_index[key] = {
+                "sweep_id": sweep_id,
+                "sweep_status": sweep_status,
+                "sweep_path_label": sweep_path_label,
+                "repo_id": repo_id,
+                "label": label,
+                "status": command.get("status"),
+                "exit_code": command.get("exit_code"),
+                "timed_out": command.get("timed_out"),
+                "started_at": command.get("started_at"),
+                "completed_at": command.get("completed_at"),
+                "stdout_log_label": command.get("stdout_log_label"),
+                "stderr_log_label": command.get("stderr_log_label"),
+            }
+
+
+def _health_sweep_snapshot(target: Path, entries: list[constants.RepoEntry]) -> HealthSweepSnapshot:
+    required = _required_health_receipt_keys(entries)
+    latest: dict[str, Any] | None = None
+    receipt_index: dict[tuple[str, str], dict[str, Any]] = {}
+    for sweep_dir in _list_sweep_dirs_newest_first(target):
+        sweep = _read_sweep(sweep_dir)
+        if sweep is None:
+            continue
+        if latest is None:
+            latest = sweep
+        _index_sweep_health_receipts(sweep, receipt_index)
+        if not required or required.issubset(receipt_index):
+            break
+    return HealthSweepSnapshot(latest=latest, receipt_index=receipt_index)
 
 
 def latest_sweep(target: Path) -> dict[str, Any] | None:
@@ -155,35 +231,21 @@ def _commands_for_entry(entry: constants.RepoEntry) -> list[constants.SweepComma
     return [*_sweep_commands(), *entry.health_commands]
 
 
-def _latest_command_receipt(target: Path, repo_id: str, label: str) -> dict[str, Any] | None:
-    for sweep in _sweeps(target):
-        repos = _list_or_empty(sweep.get("repos"))
-        for repo in repos:
-            if not isinstance(repo, dict) or repo.get("repo_id") != repo_id:
-                continue
-            commands = _list_or_empty(repo.get("commands"))
-            for command in commands:
-                if isinstance(command, dict) and command.get("label") == label:
-                    return {
-                        "sweep_id": sweep.get("sweep_id"),
-                        "sweep_status": sweep.get("status"),
-                        "sweep_path_label": sweep.get("path_label") or sweep.get("sweep_id"),
-                        "repo_id": repo_id,
-                        "label": label,
-                        "status": command.get("status"),
-                        "exit_code": command.get("exit_code"),
-                        "timed_out": command.get("timed_out"),
-                        "started_at": command.get("started_at"),
-                        "completed_at": command.get("completed_at"),
-                        "stdout_log_label": command.get("stdout_log_label"),
-                        "stderr_log_label": command.get("stderr_log_label"),
-                    }
-    return None
-
-
-def _health_command_registry_payload(target: Path) -> dict[str, Any]:
+def _health_command_registry_payload(
+    target: Path,
+    *,
+    entries: list[constants.RepoEntry] | None = None,
+    errors: list[str] | None = None,
+    config_loaded: bool | None = None,
+    health_snapshot: HealthSweepSnapshot | None = None,
+) -> dict[str, Any]:
     target = target.expanduser().resolve()
-    entries, errors, config_loaded = fleet._load_config(target)
+    if entries is None:
+        entries, errors, config_loaded = fleet._load_config(target)
+    else:
+        errors = list(errors or [])
+        config_loaded = bool(config_loaded)
+    snapshot = health_snapshot or _health_sweep_snapshot(target, entries)
     checks: list[dict[str, Any]] = []
     repos: list[dict[str, Any]] = []
     if errors:
@@ -199,6 +261,7 @@ def _health_command_registry_payload(target: Path) -> dict[str, Any]:
         checks.append(
             {"status": constants.OK, "name": "repo_health_command_config", "detail": constants.CONFIG_REL_PATH}
         )
+    receipt_index = snapshot.receipt_index
     for entry in entries:
         if not entry.enabled:
             continue
@@ -209,7 +272,7 @@ def _health_command_registry_payload(target: Path) -> dict[str, Any]:
             if command.label in seen_labels:
                 duplicate_labels.add(command.label)
             seen_labels.add(command.label)
-            receipt = _latest_command_receipt(target, entry.repo_id, command.label)
+            receipt = receipt_index.get((entry.repo_id, command.label))
             stale = False
             age_hours: float | None = None
             if receipt is None:
@@ -691,9 +754,13 @@ def sweep_closeout(
     return emit(payload, json_output, text_lines, 0)
 
 
-def sweep_health(target: Path) -> dict[str, Any]:
+def sweep_health(
+    target: Path,
+    *,
+    health_snapshot: HealthSweepSnapshot | None = None,
+) -> dict[str, Any]:
     target = target.expanduser().resolve()
-    latest = latest_sweep(target)
+    latest = health_snapshot.latest if health_snapshot is not None else latest_sweep(target)
     checks: list[dict[str, Any]] = []
     if latest is None:
         checks.append(

--- a/tests/issue266_fixture.py
+++ b/tests/issue266_fixture.py
@@ -35,7 +35,7 @@ def init_workspace_git(target: Path) -> None:
 
 
 def seed_fleet_repo_dirs(target: Path, ids: list[str] | None = None) -> list[str]:
-    ids = ids or repo_ids()
+    ids = repo_ids() if ids is None else ids
     for repo_id in ids:
         repo_dir = target / "fixtures" / "repos" / repo_id
         repo_dir.mkdir(parents=True, exist_ok=True)
@@ -167,6 +167,8 @@ def build_fleet_workspace(
     sweep_history_count: int = 1,
     artifact_padding_bytes: int = DEFAULT_ARTIFACT_PADDING_BYTES,
 ) -> Path:
+    if target.exists() and (not target.is_dir() or any(target.iterdir())):
+        raise ValueError(f"benchmark workspace target must be absent or empty: {target}")
     target.mkdir(parents=True, exist_ok=True)
     init_workspace_git(target)
     ids = seed_fleet_repo_dirs(target, repo_ids(repo_count))

--- a/tests/issue266_fixture.py
+++ b/tests/issue266_fixture.py
@@ -1,0 +1,198 @@
+"""Synthetic fixtures for issue 266 work-status memory regression tests."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+FLEET_REPO_COUNT = 53
+FLEET_SWEEP_HISTORY_COUNT = 30
+OPERATOR_REPORT_HISTORY_COUNT = 30
+SHARED_SWEEP_ID = "20260716-120000-repo-fleet-sweep-fake01"
+HEALTH_COMMAND_LABEL = "fake-health-check"
+DEFAULT_ARTIFACT_PADDING_BYTES = 0
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def repo_ids(count: int = FLEET_REPO_COUNT) -> list[str]:
+    return [f"fake-repo-{index:03d}" for index in range(1, count + 1)]
+
+
+def init_workspace_git(target: Path) -> None:
+    subprocess.run(["git", "init"], cwd=target, check=True, stdout=subprocess.DEVNULL)
+    subprocess.run(["git", "config", "user.email", "dev@example.invalid"], cwd=target, check=True)
+    subprocess.run(["git", "config", "user.name", "Fixture Dev"], cwd=target, check=True)
+    (target / "README.md").write_text("Synthetic issue-266 benchmark workspace.\n")
+    (target / "CHANGELOG.md").write_text("## [Unreleased]\n\n- Fixture only.\n")
+    (target / "ROADMAP.md").write_text("# Roadmap\n\n- Synthetic fleet.\n")
+    subprocess.run(["git", "add", "."], cwd=target, check=True)
+    subprocess.run(["git", "commit", "-m", "fixture"], cwd=target, check=True, stdout=subprocess.DEVNULL)
+
+
+def seed_fleet_repo_dirs(target: Path, ids: list[str] | None = None) -> list[str]:
+    ids = ids or repo_ids()
+    for repo_id in ids:
+        repo_dir = target / "fixtures" / "repos" / repo_id
+        repo_dir.mkdir(parents=True, exist_ok=True)
+        (repo_dir / "README.md").write_text(f"Synthetic repo {repo_id}\n")
+    return ids
+
+
+def seed_repos_toml(target: Path, ids: list[str]) -> None:
+    lines: list[str] = []
+    for repo_id in ids:
+        rel = (target / "fixtures" / "repos" / repo_id).relative_to(target)
+        lines.extend(
+            [
+                "[[repo]]",
+                f'id = "{repo_id}"',
+                f'label = "Synthetic {repo_id}"',
+                f'path = "{rel.as_posix()}"',
+                "enabled = true",
+                "expect_brigade = false",
+                "",
+                "[[repo.health_command]]",
+                f'label = "{HEALTH_COMMAND_LABEL}"',
+                'argv = ["python3", "-c", "print(0)"]',
+                "timeout = 30",
+                "",
+            ]
+        )
+    config = target / ".brigade" / "repos.toml"
+    config.parent.mkdir(parents=True, exist_ok=True)
+    config.write_text("\n".join(lines))
+
+
+def _artifact_padding(padding_bytes: int) -> dict[str, str]:
+    if padding_bytes <= 0:
+        return {}
+    return {"_fixture_padding": "x" * padding_bytes}
+
+
+def _sweep_payload(ids: list[str], sweep_id: str, *, padding_bytes: int = 0) -> dict:
+    payload = {
+        "sweep_id": sweep_id,
+        "status": "completed",
+        "started_at": "2026-07-16T12:00:00+00:00",
+        "completed_at": "2026-07-16T12:00:10+00:00",
+        "repos": [
+            {
+                "repo_id": repo_id,
+                "repo_label": f"Synthetic {repo_id}",
+                "status": "completed",
+                "commands": [
+                    {
+                        "label": HEALTH_COMMAND_LABEL,
+                        "status": "completed",
+                        "exit_code": 0,
+                        "timed_out": False,
+                        "started_at": "2026-07-16T12:00:01+00:00",
+                        "completed_at": "2026-07-16T12:00:05+00:00",
+                    }
+                ],
+            }
+            for repo_id in ids
+        ],
+    }
+    payload.update(_artifact_padding(padding_bytes))
+    return payload
+
+
+def seed_shared_fleet_sweep(
+    target: Path,
+    ids: list[str],
+    *,
+    sweep_id: str = SHARED_SWEEP_ID,
+    padding_bytes: int = 0,
+) -> None:
+    sweep_dir = target / ".brigade" / "repos" / "sweeps" / sweep_id
+    write_json(sweep_dir / "sweep.json", _sweep_payload(ids, sweep_id, padding_bytes=padding_bytes))
+
+
+def seed_fleet_sweep_history(
+    target: Path,
+    ids: list[str],
+    *,
+    count: int = 1,
+    padding_bytes: int = 0,
+) -> None:
+    for index in range(count):
+        minute = index % 60
+        hour = 12 + index // 60
+        sweep_id = f"20260716-{hour:02d}{minute:02d}00-repo-fleet-sweep-{index:03d}"
+        seed_shared_fleet_sweep(target, ids, sweep_id=sweep_id, padding_bytes=padding_bytes)
+
+
+def _operator_report_payload(report_id: str, created_at: str, *, padding_bytes: int = 0) -> dict:
+    payload = {
+        "report_id": report_id,
+        "status": "ready",
+        "created_at": created_at,
+        "generated_at": created_at,
+        "closeout": {"status": "reviewed", "reviewed_at": created_at},
+        "git": {"head": "0000000000000000000000000000000000000001"},
+        "activity": [],
+        "receipt_references": [],
+    }
+    payload.update(_artifact_padding(padding_bytes))
+    return payload
+
+
+def seed_operator_report_history(
+    target: Path,
+    count: int = OPERATOR_REPORT_HISTORY_COUNT,
+    *,
+    padding_bytes: int = 0,
+) -> None:
+    for index in range(count):
+        minute = index % 60
+        hour = 12 + index // 60
+        report_id = f"20260716-{hour:02d}{minute:02d}00-operator-report-{index:03d}"
+        created_at = f"2026-07-16T{hour:02d}:{minute:02d}:00+00:00"
+        write_json(
+            target / ".brigade" / "center" / "reports" / report_id / "CENTER_EVIDENCE.json",
+            _operator_report_payload(report_id, created_at, padding_bytes=padding_bytes),
+        )
+
+
+def build_fleet_workspace(
+    target: Path,
+    *,
+    repo_count: int = FLEET_REPO_COUNT,
+    sweep_history_count: int = 1,
+    artifact_padding_bytes: int = DEFAULT_ARTIFACT_PADDING_BYTES,
+) -> Path:
+    target.mkdir(parents=True, exist_ok=True)
+    init_workspace_git(target)
+    ids = seed_fleet_repo_dirs(target, repo_ids(repo_count))
+    seed_repos_toml(target, ids)
+    seed_fleet_sweep_history(
+        target,
+        ids,
+        count=sweep_history_count,
+        padding_bytes=artifact_padding_bytes,
+    )
+    return target
+
+
+def build_daily_status_workspace(
+    target: Path,
+    *,
+    repo_count: int = FLEET_REPO_COUNT,
+    report_count: int = OPERATOR_REPORT_HISTORY_COUNT,
+    sweep_history_count: int = 1,
+    artifact_padding_bytes: int = DEFAULT_ARTIFACT_PADDING_BYTES,
+) -> Path:
+    build_fleet_workspace(
+        target,
+        repo_count=repo_count,
+        sweep_history_count=sweep_history_count,
+        artifact_padding_bytes=artifact_padding_bytes,
+    )
+    seed_operator_report_history(target, report_count, padding_bytes=artifact_padding_bytes)
+    return target

--- a/tests/issue266_fixture.py
+++ b/tests/issue266_fixture.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import json
 import subprocess
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 FLEET_REPO_COUNT = 53
 FLEET_SWEEP_HISTORY_COUNT = 30
 OPERATOR_REPORT_HISTORY_COUNT = 30
-SHARED_SWEEP_ID = "20260716-120000-repo-fleet-sweep-fake01"
 HEALTH_COMMAND_LABEL = "fake-health-check"
 DEFAULT_ARTIFACT_PADDING_BYTES = 0
 
@@ -74,12 +74,18 @@ def _artifact_padding(padding_bytes: int) -> dict[str, str]:
     return {"_fixture_padding": "x" * padding_bytes}
 
 
-def _sweep_payload(ids: list[str], sweep_id: str, *, padding_bytes: int = 0) -> dict:
+def _sweep_payload(
+    ids: list[str],
+    sweep_id: str,
+    *,
+    started_at: datetime,
+    padding_bytes: int = 0,
+) -> dict:
     payload = {
         "sweep_id": sweep_id,
         "status": "completed",
-        "started_at": "2026-07-16T12:00:00+00:00",
-        "completed_at": "2026-07-16T12:00:10+00:00",
+        "started_at": started_at.isoformat(),
+        "completed_at": (started_at + timedelta(seconds=10)).isoformat(),
         "repos": [
             {
                 "repo_id": repo_id,
@@ -91,8 +97,8 @@ def _sweep_payload(ids: list[str], sweep_id: str, *, padding_bytes: int = 0) -> 
                         "status": "completed",
                         "exit_code": 0,
                         "timed_out": False,
-                        "started_at": "2026-07-16T12:00:01+00:00",
-                        "completed_at": "2026-07-16T12:00:05+00:00",
+                        "started_at": (started_at + timedelta(seconds=1)).isoformat(),
+                        "completed_at": (started_at + timedelta(seconds=5)).isoformat(),
                     }
                 ],
             }
@@ -107,11 +113,17 @@ def seed_shared_fleet_sweep(
     target: Path,
     ids: list[str],
     *,
-    sweep_id: str = SHARED_SWEEP_ID,
+    sweep_id: str | None = None,
+    started_at: datetime | None = None,
     padding_bytes: int = 0,
 ) -> None:
+    started_at = (started_at or datetime.now(timezone.utc)).replace(microsecond=0)
+    sweep_id = sweep_id or f"{started_at.strftime('%Y%m%d-%H%M%S')}-repo-fleet-sweep-fake01"
     sweep_dir = target / ".brigade" / "repos" / "sweeps" / sweep_id
-    write_json(sweep_dir / "sweep.json", _sweep_payload(ids, sweep_id, padding_bytes=padding_bytes))
+    write_json(
+        sweep_dir / "sweep.json",
+        _sweep_payload(ids, sweep_id, started_at=started_at, padding_bytes=padding_bytes),
+    )
 
 
 def seed_fleet_sweep_history(
@@ -119,13 +131,20 @@ def seed_fleet_sweep_history(
     ids: list[str],
     *,
     count: int = 1,
+    base_time: datetime | None = None,
     padding_bytes: int = 0,
 ) -> None:
+    base_time = (base_time or datetime.now(timezone.utc)).replace(microsecond=0)
     for index in range(count):
-        minute = index % 60
-        hour = 12 + index // 60
-        sweep_id = f"20260716-{hour:02d}{minute:02d}00-repo-fleet-sweep-{index:03d}"
-        seed_shared_fleet_sweep(target, ids, sweep_id=sweep_id, padding_bytes=padding_bytes)
+        started_at = base_time - timedelta(minutes=count - index - 1)
+        sweep_id = f"{started_at.strftime('%Y%m%d-%H%M%S')}-repo-fleet-sweep-{index:03d}"
+        seed_shared_fleet_sweep(
+            target,
+            ids,
+            sweep_id=sweep_id,
+            started_at=started_at,
+            padding_bytes=padding_bytes,
+        )
 
 
 def _operator_report_payload(report_id: str, created_at: str, *, padding_bytes: int = 0) -> dict:
@@ -147,13 +166,14 @@ def seed_operator_report_history(
     target: Path,
     count: int = OPERATOR_REPORT_HISTORY_COUNT,
     *,
+    base_time: datetime | None = None,
     padding_bytes: int = 0,
 ) -> None:
+    base_time = (base_time or datetime.now(timezone.utc)).replace(microsecond=0)
     for index in range(count):
-        minute = index % 60
-        hour = 12 + index // 60
-        report_id = f"20260716-{hour:02d}{minute:02d}00-operator-report-{index:03d}"
-        created_at = f"2026-07-16T{hour:02d}:{minute:02d}:00+00:00"
+        created = base_time - timedelta(minutes=count - index - 1)
+        report_id = f"{created.strftime('%Y%m%d-%H%M%S')}-operator-report-{index:03d}"
+        created_at = created.isoformat()
         write_json(
             target / ".brigade" / "center" / "reports" / report_id / "CENTER_EVIDENCE.json",
             _operator_report_payload(report_id, created_at, padding_bytes=padding_bytes),
@@ -166,6 +186,7 @@ def build_fleet_workspace(
     repo_count: int = FLEET_REPO_COUNT,
     sweep_history_count: int = 1,
     artifact_padding_bytes: int = DEFAULT_ARTIFACT_PADDING_BYTES,
+    base_time: datetime | None = None,
 ) -> Path:
     if target.exists() and (not target.is_dir() or any(target.iterdir())):
         raise ValueError(f"benchmark workspace target must be absent or empty: {target}")
@@ -177,6 +198,7 @@ def build_fleet_workspace(
         target,
         ids,
         count=sweep_history_count,
+        base_time=base_time,
         padding_bytes=artifact_padding_bytes,
     )
     return target
@@ -190,11 +212,18 @@ def build_daily_status_workspace(
     sweep_history_count: int = 1,
     artifact_padding_bytes: int = DEFAULT_ARTIFACT_PADDING_BYTES,
 ) -> Path:
+    base_time = datetime.now(timezone.utc).replace(microsecond=0)
     build_fleet_workspace(
         target,
         repo_count=repo_count,
         sweep_history_count=sweep_history_count,
         artifact_padding_bytes=artifact_padding_bytes,
+        base_time=base_time,
     )
-    seed_operator_report_history(target, report_count, padding_bytes=artifact_padding_bytes)
+    seed_operator_report_history(
+        target,
+        report_count,
+        base_time=base_time,
+        padding_bytes=artifact_padding_bytes,
+    )
     return target

--- a/tests/test_issue266_benchmark.py
+++ b/tests/test_issue266_benchmark.py
@@ -1,0 +1,91 @@
+"""Regression tests for the issue 266 benchmark harness."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from scripts import benchmark_issue266_work_status_memory as benchmark
+from tests.issue266_fixture import FLEET_SWEEP_HISTORY_COUNT
+
+
+def _observed_result(**overrides: object) -> dict[str, object]:
+    result: dict[str, object] = {
+        "argv": [sys.executable, "-c", "pass"],
+        "exit_code": 0,
+        "stdout_bytes": 0,
+        "stderr_bytes": 0,
+        "wall_seconds": 0.01,
+        "peak_rss_kib": 1024,
+        "peak_rss_mib": 1.0,
+        "rss_sampling_supported": True,
+        "timed_out": False,
+    }
+    result.update(overrides)
+    return result
+
+
+def test_proc_peak_rss_marks_unavailable_sampling(monkeypatch):
+    def missing_status(_self: Path) -> str:
+        raise FileNotFoundError
+
+    monkeypatch.setattr(Path, "read_text", missing_status)
+
+    assert benchmark._proc_peak_rss_kib(999_999) is None
+
+
+def test_run_command_does_not_pass_memory_budget_without_rss_sampling(tmp_path, monkeypatch):
+    monkeypatch.setattr(benchmark, "_proc_peak_rss_kib", lambda _pid: None)
+
+    observed = benchmark._run_command(
+        [sys.executable, "-c", "pass"],
+        cwd=tmp_path,
+        wall_seconds_max=1.0,
+    )
+    result = benchmark._budget_result("work_brief", observed, benchmark.DEFAULT_BUDGETS["work_brief"])
+
+    assert observed["rss_sampling_supported"] is False
+    assert observed["peak_rss_mib"] is None
+    assert result["checks"]["peak_rss_mib"] is False
+    assert result["passed"] is False
+
+
+def test_run_command_drains_large_output_without_pipe_deadlock(tmp_path):
+    observed = benchmark._run_command(
+        [
+            sys.executable,
+            "-c",
+            "import os; os.write(1, b'x' * 200_000); os.write(2, b'y' * 200_000)",
+        ],
+        cwd=tmp_path,
+        wall_seconds_max=2.0,
+    )
+
+    assert observed["exit_code"] == 0
+    assert observed["timed_out"] is False
+    assert observed["stdout_bytes"] == 200_000
+    assert observed["stderr_bytes"] == 200_000
+
+
+def test_run_command_enforces_wall_time_deadline(tmp_path):
+    observed = benchmark._run_command(
+        [sys.executable, "-c", "import time; time.sleep(10)"],
+        cwd=tmp_path,
+        wall_seconds_max=0.05,
+    )
+
+    assert observed["timed_out"] is True
+    assert observed["exit_code"] != 0
+    assert observed["wall_seconds"] < 1.0
+
+
+def test_benchmark_defaults_to_representative_sweep_history(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(benchmark, "_build_workspace", lambda *_args, **_kwargs: tmp_path)
+    monkeypatch.setattr(benchmark, "_run_command", lambda *_args, **_kwargs: _observed_result())
+    monkeypatch.setattr(sys, "argv", ["benchmark_issue266_work_status_memory.py"])
+
+    assert benchmark.main() == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["fixture"]["sweep_history_count"] == FLEET_SWEEP_HISTORY_COUNT

--- a/tests/test_issue266_work_status_memory.py
+++ b/tests/test_issue266_work_status_memory.py
@@ -155,8 +155,7 @@ def test_health_sweep_snapshot_retains_only_required_receipts(tmp_path):
     sweep = repos_sweeps._read_sweep(sweep_dir)
     assert sweep is not None
     sweep["repos"][0]["commands"].extend(
-        {"label": f"removed-health-{index}", "status": "completed", "exit_code": 0}
-        for index in range(20)
+        {"label": f"removed-health-{index}", "status": "completed", "exit_code": 0} for index in range(20)
     )
     write_json(sweep_dir / "sweep.json", sweep)
     entries, issues, _config = repos_fleet._load_config(target)

--- a/tests/test_issue266_work_status_memory.py
+++ b/tests/test_issue266_work_status_memory.py
@@ -1,0 +1,127 @@
+"""RED regression tests for issue 266 work-status memory churn."""
+
+from __future__ import annotations
+
+from brigade import center_cmd
+from brigade import daily_cmd
+from brigade import repos_cmd
+from brigade.repos_cmd import fleet as repos_fleet
+from brigade.repos_cmd import sweeps as repos_sweeps
+from tests.issue266_fixture import (
+    FLEET_REPO_COUNT,
+    FLEET_SWEEP_HISTORY_COUNT,
+    OPERATOR_REPORT_HISTORY_COUNT,
+    build_daily_status_workspace,
+    build_fleet_workspace,
+)
+
+
+def _counting_wrapper(original, counter: dict[str, int], key: str):
+    def wrapped(*args, **kwargs):
+        counter[key] += 1
+        return original(*args, **kwargs)
+
+    return wrapped
+
+
+def test_repos_health_does_not_decode_full_sweep_history(tmp_path, monkeypatch):
+    target = build_fleet_workspace(
+        tmp_path / "fleet-history-ws",
+        sweep_history_count=FLEET_SWEEP_HISTORY_COUNT,
+    )
+    counter = {"sweep_json_decodes": 0}
+    monkeypatch.setattr(
+        repos_sweeps,
+        "_read_sweep",
+        _counting_wrapper(repos_sweeps._read_sweep, counter, "sweep_json_decodes"),
+    )
+
+    repos_cmd.health(target)
+
+    assert counter["sweep_json_decodes"] == 1, (
+        "repos health should decode only the newest sweep needed for health-command "
+        "receipts, not every timestamp-prefixed sweep on disk; "
+        f"got {counter['sweep_json_decodes']} decodes across "
+        f"{FLEET_SWEEP_HISTORY_COUNT} historical sweeps covering {FLEET_REPO_COUNT} repos "
+        "(expected root cause: fleet_health.health calls sweeps._sweeps, which reads and "
+        "decodes every sweep.json under .brigade/repos/sweeps)"
+    )
+
+
+def test_repos_health_loads_fleet_config_once(tmp_path, monkeypatch):
+    target = build_fleet_workspace(tmp_path / "fleet-config-ws")
+    counter = {"fleet_config_loads": 0}
+    monkeypatch.setattr(
+        repos_fleet,
+        "_load_config",
+        _counting_wrapper(repos_fleet._load_config, counter, "fleet_config_loads"),
+    )
+
+    repos_cmd.health(target)
+
+    assert counter["fleet_config_loads"] == 1, (
+        "repos health should load repos.toml once per invocation; "
+        f"got {counter['fleet_config_loads']} fleet._load_config calls "
+        "(expected root cause: fleet.scan_payload and "
+        "_health_command_registry_payload each call fleet._load_config)"
+    )
+
+
+def test_repos_health_decodes_shared_fleet_sweep_once(tmp_path, monkeypatch):
+    target = build_fleet_workspace(tmp_path / "fleet-ws")
+    counter = {"sweep_json_decodes": 0}
+    monkeypatch.setattr(
+        repos_sweeps,
+        "_read_sweep",
+        _counting_wrapper(repos_sweeps._read_sweep, counter, "sweep_json_decodes"),
+    )
+
+    repos_cmd.health(target)
+
+    assert counter["sweep_json_decodes"] == 1, (
+        "repos health should decode the shared fleet sweep artifact once; "
+        f"got {counter['sweep_json_decodes']} decodes for {FLEET_REPO_COUNT} configured repos "
+        "(expected root cause: _health_command_registry_payload calls _latest_command_receipt per "
+        "repo-command and each call reloads all sweep JSON via _sweeps)"
+    )
+
+
+def test_operator_report_health_does_not_decode_full_report_history(tmp_path, monkeypatch):
+    target = build_daily_status_workspace(tmp_path / "report-ws")
+    counter = {"operator_report_decodes": 0}
+    monkeypatch.setattr(
+        center_cmd,
+        "_read_report",
+        _counting_wrapper(center_cmd._read_report, counter, "operator_report_decodes"),
+    )
+
+    center_cmd.report_health(target)
+
+    assert counter["operator_report_decodes"] <= 2, (
+        "operator report health should decode at most latest and compare metadata; "
+        f"got {counter['operator_report_decodes']} decodes across "
+        f"{OPERATOR_REPORT_HISTORY_COUNT} historical reports "
+        "(expected root cause: report_health calls latest_report and then _reports, "
+        "each decoding the full operator report history)"
+    )
+
+
+def test_daily_status_does_not_decode_full_operator_report_history(tmp_path, monkeypatch):
+    target = build_daily_status_workspace(tmp_path / "daily-ws")
+    counter = {"operator_report_decodes": 0}
+    monkeypatch.setattr(
+        center_cmd,
+        "_read_report",
+        _counting_wrapper(center_cmd._read_report, counter, "operator_report_decodes"),
+    )
+
+    daily_cmd.status_payload(target)
+
+    assert counter["operator_report_decodes"] <= 2, (
+        "daily status should not repeatedly decode full operator report history when only "
+        "latest/two-latest metadata is needed; "
+        f"got {counter['operator_report_decodes']} decodes across "
+        f"{OPERATOR_REPORT_HISTORY_COUNT} historical reports "
+        "(expected root cause: status_payload calls latest_report and candidate gathering "
+        "re-enters report_health)"
+    )

--- a/tests/test_issue266_work_status_memory.py
+++ b/tests/test_issue266_work_status_memory.py
@@ -13,6 +13,7 @@ from tests.issue266_fixture import (
     OPERATOR_REPORT_HISTORY_COUNT,
     build_daily_status_workspace,
     build_fleet_workspace,
+    write_json,
 )
 
 
@@ -84,6 +85,36 @@ def test_repos_health_decodes_shared_fleet_sweep_once(tmp_path, monkeypatch):
         "(expected root cause: _health_command_registry_payload calls _latest_command_receipt per "
         "repo-command and each call reloads all sweep JSON via _sweeps)"
     )
+
+
+def test_repos_health_falls_back_for_receipt_missing_from_newest_sweep(tmp_path, monkeypatch):
+    target = build_fleet_workspace(
+        tmp_path / "fleet-fallback-ws",
+        repo_count=2,
+        sweep_history_count=3,
+    )
+    newest_dir, fallback_dir, unused_dir = repos_sweeps._list_sweep_dirs_newest_first(target)
+    newest = repos_sweeps._read_sweep(newest_dir)
+    assert newest is not None
+    newest["repos"][1]["commands"] = []
+    write_json(newest_dir / "sweep.json", newest)
+    counter = {"sweep_json_decodes": 0}
+    monkeypatch.setattr(
+        repos_sweeps,
+        "_read_sweep",
+        _counting_wrapper(repos_sweeps._read_sweep, counter, "sweep_json_decodes"),
+    )
+
+    payload = repos_cmd.health(target)
+
+    assert counter["sweep_json_decodes"] == 2
+    assert payload["sweep"]["latest"]["sweep_id"] == newest_dir.name
+    health_by_repo = {
+        repo["repo_id"]: repo["health_commands"][0]["latest_receipt"] for repo in payload["health_commands"]["repos"]
+    }
+    assert health_by_repo["fake-repo-001"]["sweep_id"] == newest_dir.name
+    assert health_by_repo["fake-repo-002"]["sweep_id"] == fallback_dir.name
+    assert all(receipt["sweep_id"] != unused_dir.name for receipt in health_by_repo.values())
 
 
 def test_operator_report_health_does_not_decode_full_report_history(tmp_path, monkeypatch):

--- a/tests/test_issue266_work_status_memory.py
+++ b/tests/test_issue266_work_status_memory.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+from datetime import datetime, timedelta, timezone
+
 from brigade import center_cmd
 from brigade import daily_cmd
 from brigade import repos_cmd
@@ -187,6 +190,31 @@ def test_build_fleet_workspace_rejects_nonempty_target(tmp_path):
         raise AssertionError("expected a non-empty benchmark target to be rejected")
 
     assert marker.read_text() == "do not overwrite\n"
+
+
+def test_daily_fixture_uses_one_current_base_time_for_evidence(tmp_path):
+    before = datetime.now(timezone.utc) - timedelta(seconds=1)
+    target = build_daily_status_workspace(
+        tmp_path / "current-evidence-ws",
+        repo_count=1,
+        report_count=2,
+        sweep_history_count=2,
+    )
+    after = datetime.now(timezone.utc) + timedelta(seconds=1)
+
+    newest_sweep_dir = repos_sweeps._list_sweep_dirs_newest_first(target)[0]
+    newest_sweep = repos_sweeps._read_sweep(newest_sweep_dir)
+    assert newest_sweep is not None
+    newest_report_dir = max((target / ".brigade" / "center" / "reports").iterdir())
+    newest_report = json.loads((newest_report_dir / "CENTER_EVIDENCE.json").read_text())
+
+    base_time = datetime.fromisoformat(newest_sweep["started_at"])
+    command = newest_sweep["repos"][0]["commands"][0]
+    assert before <= base_time <= after
+    assert datetime.fromisoformat(newest_report["created_at"]) == base_time
+    assert datetime.fromisoformat(command["started_at"]) == base_time + timedelta(seconds=1)
+    assert datetime.fromisoformat(command["completed_at"]) == base_time + timedelta(seconds=5)
+    assert datetime.fromisoformat(newest_sweep["completed_at"]) == base_time + timedelta(seconds=10)
 
 
 def test_operator_report_health_does_not_decode_full_report_history(tmp_path, monkeypatch):

--- a/tests/test_issue266_work_status_memory.py
+++ b/tests/test_issue266_work_status_memory.py
@@ -10,9 +10,11 @@ from brigade.repos_cmd import sweeps as repos_sweeps
 from tests.issue266_fixture import (
     FLEET_REPO_COUNT,
     FLEET_SWEEP_HISTORY_COUNT,
+    HEALTH_COMMAND_LABEL,
     OPERATOR_REPORT_HISTORY_COUNT,
     build_daily_status_workspace,
     build_fleet_workspace,
+    seed_fleet_repo_dirs,
     write_json,
 )
 
@@ -115,6 +117,77 @@ def test_repos_health_falls_back_for_receipt_missing_from_newest_sweep(tmp_path,
     assert health_by_repo["fake-repo-001"]["sweep_id"] == newest_dir.name
     assert health_by_repo["fake-repo-002"]["sweep_id"] == fallback_dir.name
     assert all(receipt["sweep_id"] != unused_dir.name for receipt in health_by_repo.values())
+
+
+def test_repos_health_orders_legacy_sweep_dirs_by_payload_timestamp(tmp_path):
+    target = build_fleet_workspace(
+        tmp_path / "fleet-legacy-order-ws",
+        repo_count=1,
+        sweep_history_count=2,
+    )
+    older_dir, newer_dir = repos_sweeps._list_sweep_dirs_newest_first(target)
+    older = repos_sweeps._read_sweep(older_dir)
+    newer = repos_sweeps._read_sweep(newer_dir)
+    assert older is not None
+    assert newer is not None
+    older["started_at"] = "2026-07-16T12:00:00+00:00"
+    newer["started_at"] = "2026-07-16T13:00:00+00:00"
+    older_legacy_dir = older_dir.with_name("zzz-renamed-older")
+    newer_legacy_dir = newer_dir.with_name("aaa-renamed-newer")
+    older_dir.rename(older_legacy_dir)
+    newer_dir.rename(newer_legacy_dir)
+    write_json(older_legacy_dir / "sweep.json", older)
+    write_json(newer_legacy_dir / "sweep.json", newer)
+
+    payload = repos_cmd.health(target)
+
+    assert payload["sweep"]["latest"]["sweep_id"] == newer["sweep_id"]
+    latest_receipt = payload["health_commands"]["repos"][0]["health_commands"][0]["latest_receipt"]
+    assert latest_receipt["sweep_id"] == newer["sweep_id"]
+
+
+def test_health_sweep_snapshot_retains_only_required_receipts(tmp_path):
+    target = build_fleet_workspace(
+        tmp_path / "fleet-required-receipts-ws",
+        repo_count=1,
+    )
+    sweep_dir = repos_sweeps._list_sweep_dirs_newest_first(target)[0]
+    sweep = repos_sweeps._read_sweep(sweep_dir)
+    assert sweep is not None
+    sweep["repos"][0]["commands"].extend(
+        {"label": f"removed-health-{index}", "status": "completed", "exit_code": 0}
+        for index in range(20)
+    )
+    write_json(sweep_dir / "sweep.json", sweep)
+    entries, issues, _config = repos_fleet._load_config(target)
+    assert issues == []
+
+    snapshot = repos_sweeps._health_sweep_snapshot(target, entries)
+
+    assert set(snapshot.receipt_index) == {("fake-repo-001", HEALTH_COMMAND_LABEL)}
+
+
+def test_seed_fleet_repo_dirs_preserves_explicit_empty_ids(tmp_path):
+    target = tmp_path / "empty-fleet"
+
+    assert seed_fleet_repo_dirs(target, []) == []
+    assert not (target / "fixtures" / "repos").exists()
+
+
+def test_build_fleet_workspace_rejects_nonempty_target(tmp_path):
+    target = tmp_path / "occupied"
+    target.mkdir()
+    marker = target / "keep.txt"
+    marker.write_text("do not overwrite\n")
+
+    try:
+        build_fleet_workspace(target)
+    except ValueError as exc:
+        assert "empty" in str(exc)
+    else:
+        raise AssertionError("expected a non-empty benchmark target to be rejected")
+
+    assert marker.read_text() == "do not overwrite\n"
 
 
 def test_operator_report_health_does_not_decode_full_report_history(tmp_path, monkeypatch):

--- a/tests/test_reportstore.py
+++ b/tests/test_reportstore.py
@@ -56,6 +56,45 @@ def test_list_bundles_sorts_newest_first(tmp_path: Path):
     assert [b["report_id"] for b in bundles] == ["new", "old"]
 
 
+def test_latest_bundles_sorts_newest_first_when_dir_names_diverge(tmp_path: Path):
+    _bundle(tmp_path, "old", {"report_id": "old", "created_at": "2026-01-01"})
+    _bundle(tmp_path, "new", {"report_id": "new", "created_at": "2026-06-01"})
+    bundles = reportstore.latest_bundles([tmp_path], _read, id_field="report_id", limit=1)
+    assert [b["report_id"] for b in bundles] == ["new"]
+
+
+def test_latest_bundles_limit_preserves_newest_first_order(tmp_path: Path):
+    _bundle(tmp_path, "old", {"report_id": "old", "created_at": "2026-01-01"})
+    _bundle(tmp_path, "mid", {"report_id": "mid", "created_at": "2026-03-01"})
+    _bundle(tmp_path, "new", {"report_id": "new", "created_at": "2026-06-01"})
+    bundles = reportstore.latest_bundles([tmp_path], _read, id_field="report_id", limit=2)
+    assert [b["report_id"] for b in bundles] == ["new", "mid"]
+
+
+def test_latest_bundles_timestamp_prefixed_decodes_only_limit_payloads(tmp_path: Path):
+    decode_count = 0
+
+    def counting_read(child: Path) -> dict | None:
+        nonlocal decode_count
+        decode_count += 1
+        return _read(child)
+
+    history_count = 30
+    limit = 2
+    for index in range(history_count):
+        minute = index % 60
+        hour = 12 + index // 60
+        report_id = f"20260716-{hour:02d}{minute:02d}00-operator-report-{index:03d}"
+        created_at = f"2026-07-16T{hour:02d}:{minute:02d}:00+00:00"
+        _bundle(tmp_path, report_id, {"report_id": report_id, "created_at": created_at})
+
+    bundles = reportstore.latest_bundles([tmp_path], counting_read, id_field="report_id", limit=limit)
+
+    assert decode_count == limit
+    assert len(bundles) == limit
+    assert bundles[0]["report_id"].endswith(f"-{history_count - 1:03d}")
+
+
 def test_list_bundles_skips_missing_roots_and_skip_child(tmp_path: Path):
     _bundle(tmp_path, "keep", {"report_id": "keep", "created_at": "2026-01-01"})
     _bundle(tmp_path, "drop", {"report_id": "drop", "created_at": "2026-01-02"})

--- a/tests/test_reportstore.py
+++ b/tests/test_reportstore.py
@@ -95,6 +95,23 @@ def test_latest_bundles_timestamp_prefixed_decodes_only_limit_payloads(tmp_path:
     assert bundles[0]["report_id"].endswith(f"-{history_count - 1:03d}")
 
 
+def test_latest_bundles_rejects_long_timestamp_like_prefix_for_fast_path(tmp_path: Path):
+    _bundle(
+        tmp_path,
+        "20260716-1200009-older",
+        {"report_id": "older", "created_at": "2026-01-01T00:00:00+00:00"},
+    )
+    _bundle(
+        tmp_path,
+        "20260716-120000-newer",
+        {"report_id": "newer", "created_at": "2026-06-01T00:00:00+00:00"},
+    )
+
+    bundles = reportstore.latest_bundles([tmp_path], _read, id_field="report_id", limit=1)
+
+    assert [bundle["report_id"] for bundle in bundles] == ["newer"]
+
+
 def test_list_bundles_skips_missing_roots_and_skip_child(tmp_path: Path):
     _bundle(tmp_path, "keep", {"report_id": "keep", "created_at": "2026-01-01"})
     _bundle(tmp_path, "drop", {"report_id": "drop", "created_at": "2026-01-02"})


### PR DESCRIPTION
## Summary

- load fleet configuration and sweep health data once per `repos health` invocation
- retain the newest sweep plus compact health-receipt records, and bound operator status reads to the latest two reports
- add a generated 53-repo benchmark fixture and regression coverage for incomplete newest-sweep fallback

## Results

On the generated 53-repo fixture with 30 sweeps, 30 reports, and 110 MiB artifact padding:

| Command | Before peak RSS | After peak RSS | Before wall time | After wall time |
| --- | ---: | ---: | ---: | ---: |
| `brigade work brief` | 3,668.28 MiB | 482.41 MiB | 241.761s | 1.124s |
| `brigade daily status` | 3,444.37 MiB | 364.43 MiB | 12.596s | 0.433s |

## Verification

- `./scripts/verify`
- `.venv/bin/pytest -q tests/test_issue266_work_status_memory.py tests/test_repos_sweep_health_cmd.py`
- independent exact-head review passed with no actionable findings

Legacy report directories without timestamp prefixes still use `created_at` ordering, which can require scanning their history. Timestamp-prefixed production bundles use the bounded path.

Closes #266

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI benchmark to measure peak memory and wall-time budgets for work brief and daily status.
* **Bug Fixes**
  * Reduced unnecessary decoding and improved data selection so fleet health, operator report health, and daily status use only the most relevant recent receipts/reports, with correct fallback when newest data is incomplete.
  * Improved bundle/report retrieval to more efficiently handle timestamp-prefixed directories.
* **Refactor**
  * Centralized bundle enumeration and reused precomputed sweep/health snapshot data across health-related computations.
* **Tests**
  * Added regression and unit tests covering bounded decoding, bundle ordering, benchmark behavior, and memory sampling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->