### PR TITLE
fix: recover abandoned runs safely

### DIFF
--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -54,7 +54,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade route`: 1 command path(s)
 - `brigade run`: 1 command path(s)
 - `brigade runbook` (extras): 5 command path(s)
-- `brigade runs`: 7 command path(s)
+- `brigade runs`: 8 command path(s)
 - `brigade scrub`: 1 command path(s)
 - `brigade search`: 3 command path(s)
 - `brigade security`: 15 command path(s)
@@ -400,6 +400,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade runs interrupt`
 - `brigade runs latest`
 - `brigade runs list`
+- `brigade runs recover`
 - `brigade runs resume`
 - `brigade runs show`
 - `brigade runs steer`

--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -1763,10 +1763,38 @@ def run(
     has_codex_workers = any(
         (roster.agents.get(a.worker) is not None and roster.agents[a.worker].cli == "codex") for a in assignments
     )
+    if effective_transport == "app-server" and not has_codex_workers:
+        effective_transport = "exec"
+    elif effective_transport == "app-server" and output_dir is not None:
+        control_socket = output_dir / "control.sock"
+    transport_for_payload = effective_transport
+    if output_dir is not None:
+        _write_json(
+            output_dir / "run.json",
+            _run_payload(
+                task=task,
+                cwd=cwd,
+                roster=roster,
+                dry_run=dry_run,
+                read_only=read_only,
+                status="dispatching",
+                started_at=started_at,
+                output_dir=output_dir,
+                code_graph=code_graph,
+                drift_impact=drift_impact,
+                evidence=evidence,
+                brief_set=brief_set,
+                codex_transport=transport_for_payload,
+                route=route,
+                control_socket=control_socket,
+                code_graph_delta=code_graph_delta,
+                worker=worker,
+            ),
+        )
     appserver = None
     control_registry = None
     control_server = None
-    if effective_transport == "app-server" and has_codex_workers:
+    if effective_transport == "app-server":
         try:
             appserver = codex_appserver.AppServer(cwd=cwd)
             appserver.start()
@@ -1774,9 +1802,9 @@ def run(
             print(f"warning: codex app-server unavailable ({exc}); falling back to exec", file=sys.stderr)
             appserver = None
             effective_transport = "exec"
+            control_socket = None
         if appserver is not None and output_dir is not None:
             control_registry = run_control.LiveTurnRegistry()
-            control_socket = output_dir / "control.sock"
             control_server = run_control.ControlServer(control_socket, control_registry)
             try:
                 control_server.start()
@@ -1785,10 +1813,8 @@ def run(
                 control_registry = None
                 control_server = None
                 control_socket = None
-    elif effective_transport == "app-server":
-        effective_transport = "exec"
     transport_for_payload = effective_transport
-    if output_dir is not None and control_socket is not None:
+    if output_dir is not None:
         _write_json(
             output_dir / "run.json",
             _run_payload(

--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -1672,6 +1672,28 @@ def run(
     if worker is not None:
         assignments = [Assignment(worker=worker, task=task, stage=1)]
     else:
+        if output_dir is not None:
+            _write_json(
+                output_dir / "run.json",
+                _run_payload(
+                    task=task,
+                    cwd=cwd,
+                    roster=roster,
+                    dry_run=dry_run,
+                    read_only=read_only,
+                    status="planning",
+                    started_at=started_at,
+                    output_dir=output_dir,
+                    code_graph=code_graph,
+                    drift_impact=drift_impact,
+                    evidence=evidence,
+                    brief_set=brief_set,
+                    codex_transport=transport_for_payload,
+                    route=route,
+                    code_graph_delta=code_graph_delta,
+                    worker=worker,
+                ),
+            )
         try:
             assignments = plan(
                 task,
@@ -1909,6 +1931,29 @@ def run(
         )
         final = _agent_result_from_worker(direct_result)
     else:
+        if output_dir is not None:
+            _write_json(
+                output_dir / "run.json",
+                _run_payload(
+                    task=task,
+                    cwd=cwd,
+                    roster=roster,
+                    dry_run=dry_run,
+                    read_only=read_only,
+                    status="synthesizing",
+                    started_at=started_at,
+                    output_dir=output_dir,
+                    code_graph=code_graph,
+                    drift_impact=drift_impact,
+                    evidence=evidence,
+                    brief_set=brief_set,
+                    codex_transport=transport_for_payload,
+                    route=route,
+                    control_socket=control_socket,
+                    code_graph_delta=code_graph_delta,
+                    worker=worker,
+                ),
+            )
         synthesis_started = time.monotonic()
         final = _run_orchestrator(
             roster,

--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -1481,6 +1481,7 @@ def _run_payload(
     *,
     task: str,
     cwd: Path | None,
+    lock_workspace: Path | None,
     roster: Roster,
     dry_run: bool,
     read_only: bool,
@@ -1530,6 +1531,8 @@ def _run_payload(
             "attached": list(brief_set.attached) if brief_set is not None else [],
         },
     }
+    if lock_workspace is not None:
+        payload["lock_workspace"] = str(lock_workspace)
     if route is not None:
         payload["route"] = route.payload()
     if worker is not None:
@@ -1578,6 +1581,7 @@ def run(
     show_plan: bool = False,
     verbose: bool = False,
     cwd: Path | None = None,
+    lock_workspace: Path | None = None,
     output_dir: Path | None = None,
     handoff_inbox: Path | None = None,
     read_only: bool = False,
@@ -1599,9 +1603,14 @@ def run(
     started_at = datetime.now(timezone.utc)
     transport_for_payload = codex_transport or roster.codex_transport
     cwd = cwd.expanduser().resolve() if cwd is not None else None
+    lock_workspace = lock_workspace.expanduser().resolve() if lock_workspace is not None else cwd
     output_dir = output_dir.expanduser() if output_dir is not None else None
     handoff_inbox = handoff_inbox.expanduser() if handoff_inbox is not None else None
     direct_worker = worker is not None
+
+    def _payload(**kwargs: Any) -> dict[str, object]:
+        return _run_payload(lock_workspace=lock_workspace, **kwargs)
+
     if worker is not None:
         worker_error = _direct_worker_error(worker, roster)
         if worker_error is not None:
@@ -1647,7 +1656,7 @@ def run(
         _write_json(output_dir / "roster.json", _roster_payload(roster))
         _write_json(
             output_dir / "run.json",
-            _run_payload(
+            _payload(
                 task=task,
                 cwd=cwd,
                 roster=roster,
@@ -1675,7 +1684,7 @@ def run(
         if output_dir is not None:
             _write_json(
                 output_dir / "run.json",
-                _run_payload(
+                _payload(
                     task=task,
                     cwd=cwd,
                     roster=roster,
@@ -1714,7 +1723,7 @@ def run(
                 _write_json(output_dir / "plan-attempts.json", {"attempts": plan_attempts or []})
                 _write_json(
                     output_dir / "run.json",
-                    _run_payload(
+                    _payload(
                         task=task,
                         cwd=cwd,
                         roster=roster,
@@ -1755,7 +1764,7 @@ def run(
             finished_at = datetime.now(timezone.utc)
             _write_json(
                 output_dir / "run.json",
-                _run_payload(
+                _payload(
                     task=task,
                     cwd=cwd,
                     roster=roster,
@@ -1793,7 +1802,7 @@ def run(
     if output_dir is not None:
         _write_json(
             output_dir / "run.json",
-            _run_payload(
+            _payload(
                 task=task,
                 cwd=cwd,
                 roster=roster,
@@ -1839,7 +1848,7 @@ def run(
     if output_dir is not None:
         _write_json(
             output_dir / "run.json",
-            _run_payload(
+            _payload(
                 task=task,
                 cwd=cwd,
                 roster=roster,
@@ -1934,7 +1943,7 @@ def run(
         if output_dir is not None:
             _write_json(
                 output_dir / "run.json",
-                _run_payload(
+                _payload(
                     task=task,
                     cwd=cwd,
                     roster=roster,
@@ -2000,7 +2009,7 @@ def run(
                 (output_dir / "final.txt").write_text(final.text + "\n")
             _write_json(
                 output_dir / "run.json",
-                _run_payload(
+                _payload(
                     task=task,
                     cwd=cwd,
                     roster=roster,
@@ -2035,7 +2044,7 @@ def run(
         (output_dir / "final.txt").write_text(final.text + "\n")
         _write_json(
             output_dir / "run.json",
-            _run_payload(
+            _payload(
                 task=task,
                 cwd=cwd,
                 roster=roster,
@@ -2076,7 +2085,7 @@ def run(
                 finished_at = datetime.now(timezone.utc)
                 _write_json(
                     output_dir / "run.json",
-                    _run_payload(
+                    _payload(
                         task=task,
                         cwd=cwd,
                         roster=roster,
@@ -2108,7 +2117,7 @@ def run(
             finished_at = datetime.now(timezone.utc)
             _write_json(
                 output_dir / "run.json",
-                _run_payload(
+                _payload(
                     task=task,
                     cwd=cwd,
                     roster=roster,

--- a/src/brigade/cli/run.py
+++ b/src/brigade/cli/run.py
@@ -288,6 +288,8 @@ def dispatch(args) -> int:
             }
             if args.worktree and any(agent.transport == "acpx" for agent in loaded_roster.agents.values()):
                 run_kwargs["authorized_writable_worktree"] = True
+            if args.worktree:
+                run_kwargs["lock_workspace"] = run_cwd
             if args.worker is not None:
                 run_kwargs["worker"] = args.worker
             if args.codex_transport is not None:

--- a/src/brigade/cli/run.py
+++ b/src/brigade/cli/run.py
@@ -271,7 +271,7 @@ def dispatch(args) -> int:
     effective_cwd = run_cwd
     keep_worktree = False
     try:
-        with runguard.run_lock(run_cwd, wait_seconds=args.wait):
+        with runguard.run_lock(run_cwd, run_dir=output_dir, wait_seconds=args.wait):
             if args.worktree:
                 worktree_cwd = _worktree_checkout_path(runguard.git_root(run_cwd), output_dir)
                 effective_cwd = runguard.create_detached_worktree(run_cwd, worktree_cwd)

--- a/src/brigade/cli/runs.py
+++ b/src/brigade/cli/runs.py
@@ -93,6 +93,23 @@ def register(sub: argparse._SubParsersAction) -> None:
         default=None,
         help="Explicit runs directory for run ids. Defaults to .brigade/runs under --cwd.",
     )
+    p_runs_recover = runs_sub.add_parser(
+        "recover",
+        help="Recover a nonterminal run whose recorded owner process has exited.",
+    )
+    p_runs_recover.add_argument("run", help="Run directory path, run id under --runs-dir, or 'latest'.")
+    p_runs_recover.add_argument(
+        "--cwd",
+        type=Path,
+        default=Path("."),
+        help="Workspace whose default .brigade/runs directory should be used for run ids.",
+    )
+    p_runs_recover.add_argument(
+        "--runs-dir",
+        type=Path,
+        default=None,
+        help="Explicit runs directory for run ids. Defaults to .brigade/runs under --cwd.",
+    )
     p_runs_resume = runs_sub.add_parser(
         "resume", help="Re-attach interrupted app-server workers from a run and re-synthesize."
     )
@@ -129,6 +146,8 @@ def dispatch(args) -> int:
         if args.worker is not None:
             payload["worker"] = args.worker
         return _control_request(args.run, cwd=args.cwd, runs_dir=args.runs_dir, payload=payload)
+    if args.runs_command == "recover":
+        return runs_cmd.recover(args.run, cwd=args.cwd, runs_dir=args.runs_dir)
     if args.runs_command == "resume":
         from .. import run_resume
 

--- a/src/brigade/run_resume.py
+++ b/src/brigade/run_resume.py
@@ -191,6 +191,14 @@ def resume(run_dir: Path) -> int:
     (run_dir / "final.txt").write_text(final.text + "\n")
     run_meta["status"] = "ok"
     run_meta.pop("error", None)
+    recovered_failure = run_meta.pop("failure", None)
+    run_meta.pop("failure_phase", None)
+    if isinstance(recovered_failure, dict):
+        history = run_meta.get("recovery_history")
+        if not isinstance(history, list):
+            history = []
+            run_meta["recovery_history"] = history
+        history.append(recovered_failure)
     aboyeur._write_json(run_dir / "run.json", run_meta)
     print(final.text)
     return 0

--- a/src/brigade/run_resume.py
+++ b/src/brigade/run_resume.py
@@ -64,6 +64,33 @@ def _continuation_prompt(task: str) -> str:
 def resume(run_dir: Path) -> int:
     run_dir = run_dir.expanduser().resolve()
     run_meta = _load_json(run_dir, "run.json")
+    if run_meta is None:
+        print(
+            f"error: missing run artifacts in {run_dir} (need run.json, roster.json, worker-results.json)",
+            file=sys.stderr,
+        )
+        return 2
+    status = run_meta.get("status")
+    if not isinstance(status, str) or status in _NONTERMINAL_RUN_STATUSES:
+        print("error: run is not terminal; recover or wait for the active run before resuming", file=sys.stderr)
+        return 2
+    raw_workspace = run_meta.get("lock_workspace") or run_meta.get("cwd")
+    if not isinstance(raw_workspace, str) or not raw_workspace:
+        print("error: run artifact has no workspace cwd; cannot verify lock ownership", file=sys.stderr)
+        return 2
+    workspace = Path(raw_workspace).expanduser().resolve()
+    try:
+        runguard.recover_stale_run(workspace, run_dir, required=False)
+        with runguard.run_lock(workspace, run_dir=run_dir):
+            return _resume_locked(run_dir)
+    except runguard.RunLockError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+def _resume_locked(run_dir: Path) -> int:
+    run_dir = run_dir.expanduser().resolve()
+    run_meta = _load_json(run_dir, "run.json")
     roster_snapshot = _load_json(run_dir, "roster.json")
     worker_data = _load_json(run_dir, "worker-results.json")
     if run_meta is None or roster_snapshot is None or worker_data is None:
@@ -81,12 +108,6 @@ def resume(run_dir: Path) -> int:
         print("error: run artifact has no workspace cwd; cannot verify lock ownership", file=sys.stderr)
         return 2
     cwd = Path(raw_cwd).expanduser().resolve()
-    try:
-        runguard.recover_stale_run(cwd, run_dir, required=False)
-    except runguard.RunLockError as exc:
-        print(f"error: {exc}", file=sys.stderr)
-        return 2
-
     roster = _roster_from_snapshot(roster_snapshot)
     results = list(worker_data.get("results") or [])
     resumable = [

--- a/src/brigade/run_resume.py
+++ b/src/brigade/run_resume.py
@@ -74,11 +74,10 @@ def resume(run_dir: Path) -> int:
     if not isinstance(status, str) or status in _NONTERMINAL_RUN_STATUSES:
         print("error: run is not terminal; recover or wait for the active run before resuming", file=sys.stderr)
         return 2
-    raw_workspace = run_meta.get("lock_workspace") or run_meta.get("cwd")
-    if not isinstance(raw_workspace, str) or not raw_workspace:
+    workspace = runguard.resolve_run_lock_workspace(run_meta, run_dir)
+    if workspace is None:
         print("error: run artifact has no workspace cwd; cannot verify lock ownership", file=sys.stderr)
         return 2
-    workspace = Path(raw_workspace).expanduser().resolve()
     try:
         runguard.recover_stale_run(workspace, run_dir, required=False)
         with runguard.run_lock(workspace, run_dir=run_dir):

--- a/src/brigade/run_resume.py
+++ b/src/brigade/run_resume.py
@@ -12,10 +12,11 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-from . import aboyeur, agents, codex_appserver
+from . import aboyeur, agents, codex_appserver, runguard
 from .roster import Agent, Roster
 
 _RESUMABLE_STATUSES = ("interrupted", "failed")
+_NONTERMINAL_RUN_STATUSES = frozenset({"started", "planning", "dispatching", "synthesizing", "running"})
 
 
 def _load_json(run_dir: Path, name: str) -> dict | None:
@@ -71,6 +72,20 @@ def resume(run_dir: Path) -> int:
             file=sys.stderr,
         )
         return 2
+    status = run_meta.get("status")
+    if not isinstance(status, str) or status in _NONTERMINAL_RUN_STATUSES:
+        print("error: run is not terminal; recover or wait for the active run before resuming", file=sys.stderr)
+        return 2
+    raw_cwd = run_meta.get("cwd")
+    if not isinstance(raw_cwd, str) or not raw_cwd:
+        print("error: run artifact has no workspace cwd; cannot verify lock ownership", file=sys.stderr)
+        return 2
+    cwd = Path(raw_cwd).expanduser().resolve()
+    try:
+        runguard.recover_stale_run(cwd, run_dir, required=False)
+    except runguard.RunLockError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
 
     roster = _roster_from_snapshot(roster_snapshot)
     results = list(worker_data.get("results") or [])
@@ -89,7 +104,6 @@ def resume(run_dir: Path) -> int:
         print("error: no resumable workers in this run", file=sys.stderr)
         return 2
 
-    cwd = Path(run_meta["cwd"]) if run_meta.get("cwd") else None
     read_only = bool(run_meta.get("read_only"))
     sandbox = roster_snapshot.get("sandbox")
 

--- a/src/brigade/runguard.py
+++ b/src/brigade/runguard.py
@@ -117,13 +117,18 @@ def _pid_is_active(pid: int) -> bool:
 def _lock_is_stale(path: Path) -> bool:
     if path.exists() and not path.is_dir():
         raise RunLockError(f"malformed run lock is not a directory: {path}")
+    recorded_pids: list[int] = []
     try:
-        pid = int((path / "pid").read_text().strip())
+        recorded_pids.append(int((path / "pid").read_text().strip()))
     except (FileNotFoundError, NotADirectoryError, ValueError):
-        return True
+        pass
     except OSError as exc:
         raise RunLockError(f"could not inspect run lock {path}: {exc}") from exc
-    return not _pid_is_active(pid)
+    owner = _read_lock_owner(path)
+    owner_pid = owner.get("pid") if owner is not None else None
+    if isinstance(owner_pid, int):
+        recorded_pids.append(owner_pid)
+    return not any(_pid_is_active(pid) for pid in set(recorded_pids))
 
 
 def _lock_owner_payload(*, owner_token: str, run_dir: Path | None) -> dict[str, object]:
@@ -217,6 +222,10 @@ def _claim_existing_stale(path: Path, stale: Path) -> tuple[Path, dict[str, obje
         return None
     except OSError as exc:
         raise RunLockError(f"could not claim stale run lock {stale}: {exc}") from exc
+    if not _lock_is_stale(claimed):
+        if not stale.exists():
+            claimed.rename(stale)
+        raise RunLockError(f"stale run lock owner process is still active: {stale}")
     return claimed, _owner_with_workspace(_read_lock_owner(claimed), path)
 
 
@@ -247,7 +256,16 @@ def _recover_run_artifact(owner: dict[str, object] | None) -> str:
     except OSError:
         return "write-failed"
     if not isinstance(payload, dict):
-        payload = {"schema": "brigade.run.v1", "artifacts": raw_run_dir}
+        backup = run_json.with_name(f"run.json.corrupt-{uuid4().hex}")
+        try:
+            run_json.rename(backup)
+        except OSError:
+            return "write-failed"
+        payload = {
+            "schema": "brigade.run.v1",
+            "artifacts": raw_run_dir,
+            "recovery_preserved_artifact": str(backup),
+        }
     else:
         status = payload.get("status")
         if isinstance(status, str) and status:

--- a/src/brigade/runguard.py
+++ b/src/brigade/runguard.py
@@ -100,6 +100,26 @@ def lock_path(cwd: Path) -> Path:
     return base / ".brigade" / "run.lock"
 
 
+def resolve_run_lock_workspace(
+    run_meta: dict[str, object],
+    run_dir: Path,
+    *,
+    fallback: Path | None = None,
+) -> Path | None:
+    raw_workspace = run_meta.get("lock_workspace")
+    if isinstance(raw_workspace, str) and raw_workspace:
+        return Path(raw_workspace).expanduser().resolve()
+    run_dir = run_dir.expanduser().resolve()
+    if run_dir.parent.name == "runs" and run_dir.parent.parent.name == ".brigade":
+        return run_dir.parent.parent.parent
+    if fallback is not None:
+        return fallback.expanduser().resolve()
+    raw_cwd = run_meta.get("cwd")
+    if isinstance(raw_cwd, str) and raw_cwd:
+        return Path(raw_cwd).expanduser().resolve()
+    return None
+
+
 def _pid_is_active(pid: int) -> bool:
     try:
         os.kill(pid, 0)
@@ -277,6 +297,7 @@ def _recover_run_artifact(owner: dict[str, object] | None) -> str:
     workspace = owner.get("_lock_workspace")
     if isinstance(workspace, str) and workspace:
         payload.setdefault("cwd", workspace)
+        payload.setdefault("lock_workspace", workspace)
     acquired_at = owner.get("acquired_at")
     if isinstance(acquired_at, str) and acquired_at:
         payload.setdefault("started_at", acquired_at)

--- a/src/brigade/runguard.py
+++ b/src/brigade/runguard.py
@@ -3,13 +3,19 @@
 from __future__ import annotations
 
 import contextlib
+import errno
+import json
 import os
 import shutil
 import time
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
+from uuid import uuid4
 
-from . import proc
+from . import localio, proc
+
+_NONTERMINAL_RUN_STATUSES = frozenset({"started", "planning", "dispatching", "synthesizing", "running"})
 
 
 class RunGuardError(RuntimeError):
@@ -37,6 +43,13 @@ class PatchSummary:
     changed: bool
     tracked_count: int
     untracked_count: int
+
+
+@dataclass(frozen=True)
+class _LockOwnership:
+    owner_token: str
+    device: int
+    inode: int
 
 
 def _git(cwd: Path, *args: str, timeout: float = 30.0) -> proc.Result:
@@ -87,38 +100,346 @@ def lock_path(cwd: Path) -> Path:
     return base / ".brigade" / "run.lock"
 
 
-def _lock_is_stale(path: Path) -> bool:
-    try:
-        pid = int((path / "pid").read_text().strip())
-    except (FileNotFoundError, ValueError):
-        return True
+def _pid_is_active(pid: int) -> bool:
     try:
         os.kill(pid, 0)
     except ProcessLookupError:
-        return True
-    except PermissionError:
         return False
-    return False
+    except PermissionError:
+        return True
+    except OSError as exc:
+        if exc.errno == errno.ESRCH or getattr(exc, "winerror", None) == 87:
+            return False
+        return True
+    return True
 
 
-def _acquire_lock(path: Path) -> None:
-    for _ in range(2):
+def _lock_is_stale(path: Path) -> bool:
+    if path.exists() and not path.is_dir():
+        raise RunLockError(f"malformed run lock is not a directory: {path}")
+    try:
+        pid = int((path / "pid").read_text().strip())
+    except (FileNotFoundError, NotADirectoryError, ValueError):
+        return True
+    except OSError as exc:
+        raise RunLockError(f"could not inspect run lock {path}: {exc}") from exc
+    return not _pid_is_active(pid)
+
+
+def _lock_owner_payload(*, owner_token: str, run_dir: Path | None) -> dict[str, object]:
+    return {
+        "schema": "brigade.run_lock.v1",
+        "owner_token": owner_token,
+        "pid": os.getpid(),
+        "run_dir": str(run_dir.expanduser().resolve()) if run_dir is not None else None,
+        "acquired_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def _read_lock_owner(path: Path) -> dict[str, object] | None:
+    try:
+        payload = json.loads((path / "owner.json").read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _publish_lock(path: Path, *, run_dir: Path | None) -> _LockOwnership:
+    owner_token = uuid4().hex
+    candidate = path.with_name(f".{path.name}.{owner_token}.tmp")
+    candidate.mkdir()
+    try:
+        (candidate / "pid").write_text(f"{os.getpid()}\n")
+        (candidate / "owner.json").write_text(json.dumps(_lock_owner_payload(owner_token=owner_token, run_dir=run_dir)))
         try:
-            path.mkdir()
+            candidate.rename(path)
+        except OSError:
+            if path.exists():
+                raise FileExistsError(path) from None
+            raise
+    finally:
+        if candidate.exists():
+            shutil.rmtree(candidate, ignore_errors=True)
+    published = path.stat()
+    return _LockOwnership(owner_token=owner_token, device=published.st_dev, inode=published.st_ino)
+
+
+def _recovery_claim_path(path: Path) -> Path:
+    return path.with_name(f".{path.name}.recovering-{os.getpid()}-{uuid4().hex}.stale")
+
+
+def _stale_claims(path: Path) -> list[Path]:
+    return sorted(path.parent.glob(f".{path.name}.*.stale"))
+
+
+def _recovery_claim_pid(path: Path, claimed: Path) -> int | None:
+    prefix = f".{path.name}.recovering-"
+    if not claimed.name.startswith(prefix) or not claimed.name.endswith(".stale"):
+        return None
+    raw = claimed.name[len(prefix) : -len(".stale")].split("-", 1)[0]
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
+def _owner_with_workspace(owner: dict[str, object] | None, path: Path) -> dict[str, object] | None:
+    if owner is None:
+        return None
+    enriched = dict(owner)
+    enriched["_lock_workspace"] = str(path.parent.parent.resolve())
+    return enriched
+
+
+def _claim_stale_lock(path: Path) -> tuple[Path, dict[str, object] | None] | None:
+    if not _lock_is_stale(path):
+        return None
+    claimed = _recovery_claim_path(path)
+    try:
+        path.rename(claimed)
+    except FileNotFoundError:
+        return None
+    if not _lock_is_stale(claimed):
+        if not path.exists():
+            claimed.rename(path)
+        return None
+    return claimed, _owner_with_workspace(_read_lock_owner(claimed), path)
+
+
+def _claim_existing_stale(path: Path, stale: Path) -> tuple[Path, dict[str, object] | None] | None:
+    recovery_pid = _recovery_claim_pid(path, stale)
+    if recovery_pid is not None and _pid_is_active(recovery_pid):
+        raise RunLockError(f"stale run lock recovery is still active: {stale}")
+    claimed = _recovery_claim_path(path)
+    try:
+        stale.rename(claimed)
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise RunLockError(f"could not claim stale run lock {stale}: {exc}") from exc
+    return claimed, _owner_with_workspace(_read_lock_owner(claimed), path)
+
+
+def _recover_run_artifact(owner: dict[str, object] | None) -> str:
+    if owner is None:
+        return "unattributable"
+    raw_run_dir = owner.get("run_dir")
+    owner_pid = owner.get("pid")
+    if not isinstance(raw_run_dir, str) or not raw_run_dir or not isinstance(owner_pid, int):
+        return "unattributable"
+    run_json = Path(raw_run_dir).expanduser().resolve() / "run.json"
+    prior_status = "artifact-unavailable"
+    try:
+        payload = json.loads(run_json.read_text())
+    except FileNotFoundError:
+        payload = {"schema": "brigade.run.v1", "artifacts": raw_run_dir}
+    except json.JSONDecodeError:
+        backup = run_json.with_name(f"run.json.corrupt-{uuid4().hex}")
+        try:
+            run_json.rename(backup)
+        except OSError:
+            return "write-failed"
+        payload = {
+            "schema": "brigade.run.v1",
+            "artifacts": raw_run_dir,
+            "recovery_preserved_artifact": str(backup),
+        }
+    except OSError:
+        return "write-failed"
+    if not isinstance(payload, dict):
+        payload = {"schema": "brigade.run.v1", "artifacts": raw_run_dir}
+    else:
+        status = payload.get("status")
+        if isinstance(status, str) and status:
+            prior_status = status
+            if status not in _NONTERMINAL_RUN_STATUSES:
+                return "terminal"
+    recovered_at = datetime.now(timezone.utc).isoformat()
+    detail = f"run owner process {owner_pid} is no longer active"
+    workspace = owner.get("_lock_workspace")
+    if isinstance(workspace, str) and workspace:
+        payload.setdefault("cwd", workspace)
+    acquired_at = owner.get("acquired_at")
+    if isinstance(acquired_at, str) and acquired_at:
+        payload.setdefault("started_at", acquired_at)
+    payload.update(
+        {
+            "status": "failed",
+            "finished_at": recovered_at,
+            "error": detail,
+            "failure_phase": "stale-lock-recovery",
+            "failure": {
+                "phase": "stale-lock-recovery",
+                "kind": "owner-process-exited",
+                "detail": detail,
+                "owner_pid": owner_pid,
+                "prior_status": prior_status,
+                "recovered_at": recovered_at,
+            },
+        }
+    )
+    try:
+        localio.write_json(run_json, payload)
+    except OSError:
+        return "write-failed"
+    return "recovered"
+
+
+def _restore_claimed_lock(path: Path, claimed: Path) -> Path:
+    if path.exists():
+        return claimed
+    try:
+        claimed.rename(path)
+    except OSError:
+        return claimed
+    return path
+
+
+def _owner_matches_run(owner: dict[str, object] | None, run_dir: Path) -> bool:
+    if owner is None:
+        return False
+    recorded = owner.get("run_dir")
+    return isinstance(recorded, str) and Path(recorded).expanduser().resolve() == run_dir
+
+
+def _quarantine_unattributable(path: Path, claimed: Path) -> None:
+    quarantined = path.with_name(f".{path.name}.{uuid4().hex}.orphaned")
+    try:
+        claimed.rename(quarantined)
+    except OSError:
+        pass
+
+
+def _finish_claimed_recovery(path: Path, claimed: Path, owner: dict[str, object] | None) -> str:
+    recovery = _recover_run_artifact(owner)
+    if recovery == "write-failed":
+        retained = _restore_claimed_lock(path, claimed)
+        raise RunLockError(f"could not preserve the stale run failure; lock retained at {retained}")
+    if recovery == "unattributable":
+        _quarantine_unattributable(path, claimed)
+        return recovery
+    shutil.rmtree(claimed, ignore_errors=True)
+    return recovery
+
+
+def _recover_pending_claims(path: Path, *, run_dir: Path | None = None, required: bool = False) -> bool:
+    recovered = False
+    for stale in _stale_claims(path):
+        owner = _read_lock_owner(stale)
+        if run_dir is not None and not _owner_matches_run(owner, run_dir):
+            continue
+        claimed_owner = _claim_existing_stale(path, stale)
+        if claimed_owner is None:
+            continue
+        claimed, owner = claimed_owner
+        _finish_claimed_recovery(path, claimed, owner)
+        recovered = True
+    if required and not recovered:
+        raise RunLockError(f"run lock not found for run: {run_dir}")
+    return recovered
+
+
+def recover_stale_run(cwd: Path, run_dir: Path, *, required: bool = True) -> bool:
+    run_dir = run_dir.expanduser().resolve()
+    path = lock_path(cwd)
+    if path.exists() and not path.is_dir():
+        raise RunLockError(f"malformed run lock is not a directory: {path}")
+    if path.is_dir():
+        owner = _read_lock_owner(path)
+        if owner is None:
+            raise RunLockError(f"run lock has no owner metadata: {path}")
+        if _owner_matches_run(owner, run_dir):
+            stale = _claim_stale_lock(path)
+            if stale is None:
+                if path.exists():
+                    raise RunLockError(f"run owner process is still active: {path}")
+            else:
+                claimed, claimed_owner = stale
+                if claimed_owner is None or claimed_owner.get("owner_token") != owner.get("owner_token"):
+                    retained = _restore_claimed_lock(path, claimed)
+                    raise RunLockError(f"run lock owner changed during recovery; lock retained at {retained}")
+                _finish_claimed_recovery(path, claimed, claimed_owner)
+                return True
+        elif required:
+            raise RunLockError(f"run lock belongs to a different run: {path}")
+    return _recover_pending_claims(path, run_dir=run_dir, required=required)
+
+
+def run_recovery_status(cwd: Path, run_dir: Path) -> str:
+    cwd = cwd.expanduser().resolve()
+    run_dir = run_dir.expanduser().resolve()
+    if not cwd.is_dir():
+        return "unknown"
+    path = lock_path(cwd)
+    if path.exists() and not path.is_dir():
+        return "unknown"
+    candidates = ([path] if path.is_dir() else []) + _stale_claims(path)
+    saw_unreadable = False
+    for candidate in candidates:
+        owner = _read_lock_owner(candidate)
+        if owner is None:
+            saw_unreadable = True
+        elif _owner_matches_run(owner, run_dir):
+            return "required"
+    return "unknown" if saw_unreadable else "cleared"
+
+
+def _acquire_lock(path: Path, *, run_dir: Path | None = None) -> _LockOwnership:
+    for _ in range(8):
+        try:
+            ownership = _publish_lock(path, run_dir=run_dir)
         except FileExistsError:
-            if _lock_is_stale(path):
-                shutil.rmtree(path, ignore_errors=True)
-                continue
-            raise RunLockError(
-                f"another brigade run appears active: {path}. Remove the lock only if no run is active."
-            ) from None
-        (path / "pid").write_text(f"{os.getpid()}\n")
-        return
+            if path.exists() and not path.is_dir():
+                raise RunLockError(f"malformed run lock is not a directory: {path}") from None
+            stale = _claim_stale_lock(path)
+            if stale is None:
+                if not path.exists():
+                    continue
+                raise RunLockError(
+                    f"another brigade run appears active: {path}. Remove the lock only if no run is active."
+                ) from None
+            claimed, owner = stale
+            _finish_claimed_recovery(path, claimed, owner)
+            continue
+        pending = _stale_claims(path)
+        if not pending:
+            return ownership
+        _release_lock(path, ownership)
+        _recover_pending_claims(path)
     raise RunLockError(f"could not acquire run lock: {path}")
 
 
+def _release_lock(path: Path, ownership: _LockOwnership) -> None:
+    try:
+        visible = path.stat()
+    except OSError:
+        return
+    if visible.st_dev != ownership.device or visible.st_ino != ownership.inode:
+        return
+    release_path = path.with_name(f".{path.name}.{ownership.owner_token}.release")
+    try:
+        path.rename(release_path)
+    except FileNotFoundError:
+        return
+    try:
+        released = release_path.stat()
+    except OSError:
+        return
+    if released.st_dev == ownership.device and released.st_ino == ownership.inode:
+        shutil.rmtree(release_path, ignore_errors=True)
+        return
+    if not path.exists():
+        release_path.rename(path)
+
+
 @contextlib.contextmanager
-def run_lock(cwd: Path, *, wait_seconds: float = 0.0, poll_interval: float = 0.1):
+def run_lock(
+    cwd: Path,
+    *,
+    run_dir: Path | None = None,
+    wait_seconds: float = 0.0,
+    poll_interval: float = 0.1,
+):
     if wait_seconds < 0:
         raise ValueError("run lock wait_seconds must be non-negative")
     if poll_interval <= 0:
@@ -126,9 +447,10 @@ def run_lock(cwd: Path, *, wait_seconds: float = 0.0, poll_interval: float = 0.1
     path = lock_path(cwd)
     path.parent.mkdir(parents=True, exist_ok=True)
     deadline = time.monotonic() + wait_seconds
+    ownership: _LockOwnership | None = None
     while True:
         try:
-            _acquire_lock(path)
+            ownership = _acquire_lock(path, run_dir=run_dir)
             break
         except RunLockError as exc:
             if wait_seconds == 0:
@@ -140,7 +462,8 @@ def run_lock(cwd: Path, *, wait_seconds: float = 0.0, poll_interval: float = 0.1
     try:
         yield path
     finally:
-        shutil.rmtree(path, ignore_errors=True)
+        if ownership is not None:
+            _release_lock(path, ownership)
 
 
 def create_detached_worktree(repo: Path, worktree_path: Path) -> Path:

--- a/src/brigade/runs_cmd.py
+++ b/src/brigade/runs_cmd.py
@@ -519,13 +519,21 @@ def _print_recovery_guidance(run_dir: Path) -> None:
         print("resume: unavailable (no resumable app-server worker thread)")
 
 
+def _lock_workspace(run_meta: dict[str, Any]) -> Path | None:
+    for key in ("lock_workspace", "cwd"):
+        raw_workspace = run_meta.get(key)
+        if isinstance(raw_workspace, str) and raw_workspace:
+            return Path(raw_workspace).expanduser().resolve()
+    return None
+
+
 def _lock_recovery_status(run_dir: Path, run_meta: dict[str, Any]) -> str:
-    raw_cwd = run_meta.get("cwd")
-    if not isinstance(raw_cwd, str) or not raw_cwd:
+    workspace = _lock_workspace(run_meta)
+    if workspace is None:
         return "unknown"
     from . import runguard
 
-    return runguard.run_recovery_status(Path(raw_cwd), run_dir)
+    return runguard.run_recovery_status(workspace, run_dir)
 
 
 def _print_terminal_guidance(run_dir: Path, run_meta: dict[str, Any]) -> None:
@@ -582,12 +590,11 @@ def recover(run: str | Path, *, cwd: Path, runs_dir: Path | None = None) -> int:
         return 0
     if _is_terminal(run_meta):
         phase, _, _ = _failure_fields(run_meta)
-        raw_cwd = run_meta.get("cwd")
         if phase == "stale-lock-recovery":
-            if not isinstance(raw_cwd, str) or not raw_cwd:
+            workspace = _lock_workspace(run_meta)
+            if workspace is None:
                 print(f"error: recovered run artifact has no workspace cwd: {run_dir}", file=sys.stderr)
                 return 2
-            workspace = Path(raw_cwd).expanduser().resolve()
             try:
                 runguard.recover_stale_run(workspace, run_dir, required=False)
             except runguard.RunLockError as exc:
@@ -596,11 +603,10 @@ def recover(run: str | Path, *, cwd: Path, runs_dir: Path | None = None) -> int:
         print(f"already terminal: {run_dir} [{run_meta.get('status', 'unknown')}]")
         _print_recovery_guidance(run_dir)
         return 0
-    raw_cwd = run_meta.get("cwd")
-    if not isinstance(raw_cwd, str) or not raw_cwd:
+    workspace = _lock_workspace(run_meta)
+    if workspace is None:
         print(f"error: run artifact has no workspace cwd: {run_dir}", file=sys.stderr)
         return 2
-    workspace = Path(raw_cwd).expanduser().resolve()
     try:
         runguard.recover_stale_run(workspace, run_dir)
     except runguard.RunLockError as exc:

--- a/src/brigade/runs_cmd.py
+++ b/src/brigade/runs_cmd.py
@@ -519,16 +519,14 @@ def _print_recovery_guidance(run_dir: Path) -> None:
         print("resume: unavailable (no resumable app-server worker thread)")
 
 
-def _lock_workspace(run_meta: dict[str, Any]) -> Path | None:
-    for key in ("lock_workspace", "cwd"):
-        raw_workspace = run_meta.get(key)
-        if isinstance(raw_workspace, str) and raw_workspace:
-            return Path(raw_workspace).expanduser().resolve()
-    return None
+def _lock_workspace(run_dir: Path, run_meta: dict[str, Any], *, fallback: Path | None = None) -> Path | None:
+    from . import runguard
+
+    return runguard.resolve_run_lock_workspace(run_meta, run_dir, fallback=fallback)
 
 
 def _lock_recovery_status(run_dir: Path, run_meta: dict[str, Any]) -> str:
-    workspace = _lock_workspace(run_meta)
+    workspace = _lock_workspace(run_dir, run_meta)
     if workspace is None:
         return "unknown"
     from . import runguard
@@ -569,8 +567,10 @@ def recover(run: str | Path, *, cwd: Path, runs_dir: Path | None = None) -> int:
     else:
         read_error = f"run.json not found in {run_dir}" if run_meta is None else None
     if run_meta is None:
+        workspace = _lock_workspace(run_dir, {}, fallback=cwd)
+        assert workspace is not None
         try:
-            runguard.recover_stale_run(cwd.expanduser().resolve(), run_dir)
+            runguard.recover_stale_run(workspace, run_dir)
         except runguard.RunLockError as exc:
             detail = read_error if str(exc).startswith("run lock not found for run:") else str(exc)
             print(f"error: {detail}", file=sys.stderr)
@@ -591,7 +591,7 @@ def recover(run: str | Path, *, cwd: Path, runs_dir: Path | None = None) -> int:
     if _is_terminal(run_meta):
         phase, _, _ = _failure_fields(run_meta)
         if phase == "stale-lock-recovery":
-            workspace = _lock_workspace(run_meta)
+            workspace = _lock_workspace(run_dir, run_meta, fallback=cwd)
             if workspace is None:
                 print(f"error: recovered run artifact has no workspace cwd: {run_dir}", file=sys.stderr)
                 return 2
@@ -603,7 +603,7 @@ def recover(run: str | Path, *, cwd: Path, runs_dir: Path | None = None) -> int:
         print(f"already terminal: {run_dir} [{run_meta.get('status', 'unknown')}]")
         _print_recovery_guidance(run_dir)
         return 0
-    workspace = _lock_workspace(run_meta)
+    workspace = _lock_workspace(run_dir, run_meta, fallback=cwd)
     if workspace is None:
         print(f"error: run artifact has no workspace cwd: {run_dir}", file=sys.stderr)
         return 2

--- a/src/brigade/runs_cmd.py
+++ b/src/brigade/runs_cmd.py
@@ -604,6 +604,15 @@ def recover(run: str | Path, *, cwd: Path, runs_dir: Path | None = None) -> int:
     try:
         runguard.recover_stale_run(workspace, run_dir)
     except runguard.RunLockError as exc:
+        if str(exc).startswith("run lock not found for run:"):
+            try:
+                concurrent_meta = _read_json(run_dir / "run.json")
+            except ValueError:
+                concurrent_meta = None
+            if concurrent_meta is not None and _is_terminal(concurrent_meta):
+                print(f"already terminal: {run_dir} [{concurrent_meta.get('status', 'unknown')}]")
+                _print_recovery_guidance(run_dir)
+                return 0
         print(f"error: {exc}", file=sys.stderr)
         return 2
     print(f"recovered: {run_dir}")

--- a/src/brigade/runs_cmd.py
+++ b/src/brigade/runs_cmd.py
@@ -193,6 +193,23 @@ def _is_terminal(meta: dict[str, Any]) -> bool:
     return isinstance(status, str) and status not in _NONTERMINAL_STATUSES
 
 
+def _failure_fields(meta: dict[str, Any]) -> tuple[object, object, object]:
+    failure = meta.get("failure")
+    failure_payload = failure if isinstance(failure, dict) else {}
+    return (
+        meta.get("failure_phase") or failure_payload.get("phase"),
+        failure_payload.get("kind"),
+        failure_payload.get("detail"),
+    )
+
+
+def _print_failure(meta: dict[str, Any]) -> None:
+    phase, kind, detail = _failure_fields(meta)
+    _line("failure phase", phase)
+    _line("failure kind", kind)
+    _line("failure detail", detail)
+
+
 def _watch_return_code(status: object) -> int:
     if status in _SUCCESS_STATUSES:
         return 0
@@ -205,6 +222,7 @@ def _emit_json(payload: dict[str, object]) -> None:
 
 def _emit_run(meta: dict[str, Any], *, json_output: bool) -> None:
     if json_output:
+        phase, kind, detail = _failure_fields(meta)
         payload = {
             "type": "run",
             "status": meta.get("status"),
@@ -212,11 +230,15 @@ def _emit_run(meta: dict[str, Any], *, json_output: bool) -> None:
             "started_at": meta.get("started_at"),
             "finished_at": meta.get("finished_at"),
             "duration_seconds": meta.get("duration_seconds"),
+            "failure_phase": phase,
+            "failure_kind": kind,
+            "failure_detail": detail,
         }
         _emit_json({key: value for key, value in payload.items() if value is not None})
         return
     _line("status", meta.get("status"))
     _line("task", meta.get("task"))
+    _print_failure(meta)
 
 
 def _emit_plan(plan_payload: dict[str, Any], *, json_output: bool) -> None:
@@ -294,9 +316,17 @@ def _emit_summary(run_dir: Path, meta: dict[str, Any], *, json_output: bool) -> 
         payload: dict[str, object] = {"type": "summary", "run": str(run_dir), "status": status}
         if isinstance(duration, (int, float)):
             payload["duration_seconds"] = duration
+        phase, _, _ = _failure_fields(meta)
+        if phase == "stale-lock-recovery":
+            recovery_status = _lock_recovery_status(run_dir, meta)
+            payload["failure_phase"] = phase
+            payload["inspect_command"] = f"brigade runs show {run_dir}"
+            payload["recover_status"] = recovery_status
+            payload["resume_available"] = _resume_available(run_dir)
         _emit_json(payload)
         return
     print(f"summary: {status} in {_duration_text(duration)}")
+    _print_terminal_guidance(run_dir, meta)
 
 
 def _tail_events(run_dir: Path, offsets: dict[Path, int], *, json_output: bool) -> None:
@@ -464,6 +494,123 @@ def show_latest(*, cwd: Path, runs_dir: Path | None = None) -> int:
     return show(runs[0][0])
 
 
+def _resume_available(run_dir: Path) -> bool:
+    try:
+        worker_results = _read_json(run_dir / "worker-results.json")
+    except ValueError:
+        return False
+    results = worker_results.get("results") if worker_results else None
+    if not isinstance(results, list):
+        return False
+    return any(
+        isinstance(result, dict)
+        and isinstance(result.get("thread_id"), str)
+        and bool(result["thread_id"])
+        and not result.get("ok")
+        and result.get("status") in {"interrupted", "failed"}
+        for result in results
+    )
+
+
+def _print_recovery_guidance(run_dir: Path) -> None:
+    if _resume_available(run_dir):
+        print(f"resume: brigade runs resume {run_dir}")
+    else:
+        print("resume: unavailable (no resumable app-server worker thread)")
+
+
+def _lock_recovery_status(run_dir: Path, run_meta: dict[str, Any]) -> str:
+    raw_cwd = run_meta.get("cwd")
+    if not isinstance(raw_cwd, str) or not raw_cwd:
+        return "unknown"
+    from . import runguard
+
+    return runguard.run_recovery_status(Path(raw_cwd), run_dir)
+
+
+def _print_terminal_guidance(run_dir: Path, run_meta: dict[str, Any]) -> None:
+    phase, _, _ = _failure_fields(run_meta)
+    if phase != "stale-lock-recovery":
+        return
+    print(f"inspect: brigade runs show {run_dir}")
+    recovery_status = _lock_recovery_status(run_dir, run_meta)
+    if recovery_status == "cleared":
+        print("recover: completed (stale lock cleared)")
+    elif recovery_status == "required":
+        print("recover: required (stale lock remains)")
+    else:
+        print("recover: unknown (workspace or lock metadata unavailable)")
+    _print_recovery_guidance(run_dir)
+
+
+def recover(run: str | Path, *, cwd: Path, runs_dir: Path | None = None) -> int:
+    from . import runguard
+
+    run_dir, error = _resolve_run_dir(run, cwd=cwd, runs_dir=runs_dir)
+    if error is not None:
+        print(error, file=sys.stderr)
+        return 2
+    assert run_dir is not None
+    recovered_unreadable_artifact = False
+    read_error: str | None = None
+    try:
+        run_meta = _read_json(run_dir / "run.json")
+    except ValueError as exc:
+        run_meta = None
+        read_error = str(exc)
+    else:
+        read_error = f"run.json not found in {run_dir}" if run_meta is None else None
+    if run_meta is None:
+        try:
+            runguard.recover_stale_run(cwd.expanduser().resolve(), run_dir)
+        except runguard.RunLockError as exc:
+            detail = read_error if str(exc).startswith("run lock not found for run:") else str(exc)
+            print(f"error: {detail}", file=sys.stderr)
+            return 2
+        try:
+            run_meta = _read_json(run_dir / "run.json")
+        except ValueError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        if run_meta is None:
+            print(f"error: run.json not found in {run_dir} after recovery", file=sys.stderr)
+            return 2
+        recovered_unreadable_artifact = True
+    if recovered_unreadable_artifact:
+        print(f"recovered: {run_dir}")
+        _print_recovery_guidance(run_dir)
+        return 0
+    if _is_terminal(run_meta):
+        phase, _, _ = _failure_fields(run_meta)
+        raw_cwd = run_meta.get("cwd")
+        if phase == "stale-lock-recovery":
+            if not isinstance(raw_cwd, str) or not raw_cwd:
+                print(f"error: recovered run artifact has no workspace cwd: {run_dir}", file=sys.stderr)
+                return 2
+            workspace = Path(raw_cwd).expanduser().resolve()
+            try:
+                runguard.recover_stale_run(workspace, run_dir, required=False)
+            except runguard.RunLockError as exc:
+                print(f"error: {exc}", file=sys.stderr)
+                return 2
+        print(f"already terminal: {run_dir} [{run_meta.get('status', 'unknown')}]")
+        _print_recovery_guidance(run_dir)
+        return 0
+    raw_cwd = run_meta.get("cwd")
+    if not isinstance(raw_cwd, str) or not raw_cwd:
+        print(f"error: run artifact has no workspace cwd: {run_dir}", file=sys.stderr)
+        return 2
+    workspace = Path(raw_cwd).expanduser().resolve()
+    try:
+        runguard.recover_stale_run(workspace, run_dir)
+    except runguard.RunLockError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(f"recovered: {run_dir}")
+    _print_recovery_guidance(run_dir)
+    return 0
+
+
 def watch(
     run: str | Path,
     *,
@@ -541,6 +688,7 @@ def show(run_dir: Path) -> int:
     _line("artifacts", run_meta.get("artifacts"))
     _line("handoff", run_meta.get("handoff"))
     _line("error", run_meta.get("error"))
+    _print_failure(run_meta)
     if run_meta.get("suspected_noop") is True:
         print("warning: suspected no-op run; ok workers produced no non-.brigade file changes.")
 
@@ -550,4 +698,7 @@ def show(run_dir: Path) -> int:
     _print_ground_truth(worker_results)
     _print_synthesis(synthesis)
     _print_final(_read_text(run_dir / "final.txt"))
+    _print_terminal_guidance(run_dir, run_meta)
+    if _is_terminal(run_meta):
+        return _watch_return_code(run_meta.get("status"))
     return 0

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from brigade import aboyeur
+from brigade import agents
 from brigade import cli
 from brigade import proc
 from brigade import runguard
@@ -890,6 +891,44 @@ role = "code"
 
     assert rc == 0
     assert seen["status"] == "dispatching"
+
+
+def test_orchestrated_run_records_planning_and_synthesizing_phases(tmp_path, monkeypatch):
+    repo = _git_repo_with_roster(tmp_path)
+    output_dir = tmp_path / "run-artifacts"
+    seen = {}
+
+    def fake_plan(*args, **kwargs):
+        seen["plan"] = json.loads((output_dir / "run.json").read_text())["status"]
+        return [aboyeur.Assignment(worker="coder", task="inspect")]
+
+    def fake_dispatch(*args, **kwargs):
+        return [aboyeur.WorkerResult(worker="coder", task="inspect", text="done", ok=True)]
+
+    def fake_orchestrator(*args, **kwargs):
+        seen["synthesis"] = json.loads((output_dir / "run.json").read_text())["status"]
+        return agents.AgentResult(text="final", ok=True)
+
+    monkeypatch.setattr(aboyeur, "plan", fake_plan)
+    monkeypatch.setattr(aboyeur, "dispatch", fake_dispatch)
+    monkeypatch.setattr(aboyeur, "_run_orchestrator", fake_orchestrator)
+
+    rc = cli.main(
+        [
+            "run",
+            "inspect",
+            "--cwd",
+            str(repo),
+            "--output-dir",
+            str(output_dir),
+            "--no-code-graph",
+            "--no-evidence",
+            "--no-route",
+        ]
+    )
+
+    assert rc == 0
+    assert seen == {"plan": "planning", "synthesis": "synthesizing"}
 
 
 def test_app_server_and_control_start_after_dispatching_is_recorded(tmp_path, monkeypatch):

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -1039,12 +1039,14 @@ def test_run_cli_worktree_passes_detached_cwd_and_writes_changes_patch(tmp_path,
         show_plan=False,
         verbose=False,
         cwd=None,
+        lock_workspace=None,
         output_dir=None,
         handoff_inbox=None,
         read_only=False,
         sandbox=None,
     ):
         seen["cwd"] = cwd
+        seen["lock_workspace"] = lock_workspace
         seen["output_dir"] = output_dir
         assert cwd != repo
         assert (cwd / "tracked.txt").read_text() == "base\n"
@@ -1069,6 +1071,7 @@ def test_run_cli_worktree_passes_detached_cwd_and_writes_changes_patch(tmp_path,
     assert seen["output_dir"] == output_dir
     expected_checkout = tmp_path / "home" / ".cache" / "brigade" / "worktrees" / f"{repo.name}-{output_dir.name}"
     assert seen["cwd"] == expected_checkout
+    assert seen["lock_workspace"] == repo.resolve()
     assert not expected_checkout.exists()
     assert (repo / "tracked.txt").read_text() == "base\n"
     patch = (output_dir / "changes.patch").read_text()

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -797,8 +797,9 @@ def test_run_cli_passes_bounded_wait_to_run_lock(tmp_path, monkeypatch, wait_arg
     seen = {}
 
     @contextmanager
-    def fake_lock(cwd, *, wait_seconds=0.0):
+    def fake_lock(cwd, *, run_dir=None, wait_seconds=0.0):
         seen["cwd"] = cwd
+        seen["run_dir"] = run_dir
         seen["wait_seconds"] = wait_seconds
         yield
 
@@ -808,7 +809,183 @@ def test_run_cli_passes_bounded_wait_to_run_lock(tmp_path, monkeypatch, wait_arg
     rc = cli.main(["run", "x", "--cwd", str(repo), wait_arg, "--no-artifacts"])
 
     assert rc == 0
-    assert seen == {"cwd": repo, "wait_seconds": expected}
+    assert seen == {"cwd": repo, "run_dir": None, "wait_seconds": expected}
+
+
+def test_run_cli_records_output_dir_in_run_lock(tmp_path, monkeypatch):
+    repo = _git_repo_with_roster(tmp_path)
+    output_dir = tmp_path / "run-artifacts"
+    seen = {}
+
+    @contextmanager
+    def fake_lock(cwd, *, run_dir=None, wait_seconds=0.0):
+        seen["cwd"] = cwd
+        seen["run_dir"] = run_dir
+        seen["wait_seconds"] = wait_seconds
+        yield
+
+    monkeypatch.setattr(runguard, "run_lock", fake_lock)
+    monkeypatch.setattr(aboyeur, "run", lambda *args, **kwargs: 0)
+
+    rc = cli.main(["run", "x", "--cwd", str(repo), "--output-dir", str(output_dir)])
+
+    assert rc == 0
+    assert seen == {"cwd": repo, "run_dir": output_dir, "wait_seconds": 0.0}
+
+
+@pytest.mark.parametrize("lane", ["direct", "acpx"])
+def test_direct_worker_run_records_dispatching_before_provider_call(tmp_path, monkeypatch, lane):
+    repo = _git_repo_with_roster(tmp_path)
+    output_dir = tmp_path / "run-artifacts"
+    seen = {}
+    worker = "coder"
+    if lane == "acpx":
+        worker = "composer"
+        (repo / ".brigade" / "roster.toml").write_text(
+            """
+orchestrator = "chef"
+
+[agents.chef]
+cli = "codex"
+role = "plan"
+
+[agents.composer]
+cli = "cursor"
+model = "composer-2.5"
+transport = "acpx"
+transport_version = "0.12.0"
+role = "code"
+"""
+        )
+
+    def fake_dispatch(*args, **kwargs):
+        seen.update(json.loads((output_dir / "run.json").read_text()))
+        return [
+            aboyeur.WorkerResult(
+                worker=worker,
+                task="inspect",
+                text="done",
+                ok=True,
+            )
+        ]
+
+    monkeypatch.setattr(aboyeur, "dispatch", fake_dispatch)
+
+    rc = cli.main(
+        [
+            "run",
+            "inspect",
+            "--cwd",
+            str(repo),
+            "--output-dir",
+            str(output_dir),
+            "--worker",
+            worker,
+            "--allow-dirty",
+            "--no-code-graph",
+            "--no-evidence",
+            "--no-route",
+        ]
+    )
+
+    assert rc == 0
+    assert seen["status"] == "dispatching"
+
+
+def test_app_server_and_control_start_after_dispatching_is_recorded(tmp_path, monkeypatch):
+    repo = _git_repo_with_roster(tmp_path)
+    output_dir = tmp_path / "run-artifacts"
+    seen = {}
+
+    class StubAppServer:
+        def __init__(self, *, cwd):
+            self.cwd = cwd
+
+        def start(self):
+            seen["app_server"] = json.loads((output_dir / "run.json").read_text())["status"]
+
+        def close(self):
+            pass
+
+    class StubControlServer:
+        def __init__(self, socket_path, registry):
+            self.socket_path = socket_path
+            self.registry = registry
+
+        def start(self):
+            seen["control_server"] = json.loads((output_dir / "run.json").read_text())["status"]
+
+        def close(self):
+            pass
+
+    def fake_dispatch(*args, **kwargs):
+        return [aboyeur.WorkerResult(worker="coder", task="inspect", text="done", ok=True)]
+
+    monkeypatch.setattr(aboyeur.codex_appserver, "AppServer", StubAppServer)
+    monkeypatch.setattr(aboyeur.run_control, "ControlServer", StubControlServer)
+    monkeypatch.setattr(aboyeur, "dispatch", fake_dispatch)
+
+    rc = cli.main(
+        [
+            "run",
+            "inspect",
+            "--cwd",
+            str(repo),
+            "--output-dir",
+            str(output_dir),
+            "--worker",
+            "coder",
+            "--codex-transport",
+            "app-server",
+            "--no-code-graph",
+            "--no-evidence",
+            "--no-route",
+        ]
+    )
+
+    assert rc == 0
+    assert seen == {"app_server": "dispatching", "control_server": "dispatching"}
+
+
+def test_app_server_fallback_clears_uncreated_control_socket(tmp_path, monkeypatch):
+    repo = _git_repo_with_roster(tmp_path)
+    output_dir = tmp_path / "run-artifacts"
+
+    class UnavailableAppServer:
+        def __init__(self, *, cwd):
+            self.cwd = cwd
+
+        def start(self):
+            raise aboyeur.codex_appserver.AppServerError("unavailable")
+
+    def fake_dispatch(*args, **kwargs):
+        return [aboyeur.WorkerResult(worker="coder", task="inspect", text="done", ok=True)]
+
+    monkeypatch.setattr(aboyeur.codex_appserver, "AppServer", UnavailableAppServer)
+    monkeypatch.setattr(aboyeur, "dispatch", fake_dispatch)
+
+    rc = cli.main(
+        [
+            "run",
+            "inspect",
+            "--cwd",
+            str(repo),
+            "--output-dir",
+            str(output_dir),
+            "--worker",
+            "coder",
+            "--codex-transport",
+            "app-server",
+            "--no-code-graph",
+            "--no-evidence",
+            "--no-route",
+        ]
+    )
+
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert rc == 0
+    assert run_meta["codex_transport"] == "exec"
+    assert "control_socket" not in run_meta
 
 
 def test_run_cli_worktree_passes_detached_cwd_and_writes_changes_patch(tmp_path, monkeypatch):

--- a/tests/test_run_control.py
+++ b/tests/test_run_control.py
@@ -237,6 +237,15 @@ def test_cli_interrupt_leaves_live_worker_resumable(tmp_path, monkeypatch, capsy
         "AppServer",
         lambda cwd=None: real_app_server(argv=FAKE, cwd=cwd),
     )
+    turn_registered = threading.Event()
+    real_register = run_control.LiveTurnRegistry.register
+
+    def register_and_signal(registry, worker, turn, turn_id):
+        real_register(registry, worker, turn, turn_id)
+        if worker == "cook":
+            turn_registered.set()
+
+    monkeypatch.setattr(run_control.LiveTurnRegistry, "register", register_and_signal)
 
     def fake_run_agent(cli_ref, prompt, **kwargs):
         if "Return exactly one JSON object" in prompt:
@@ -257,6 +266,7 @@ def test_cli_interrupt_leaves_live_worker_resumable(tmp_path, monkeypatch, capsy
 
     control_socket = _wait_for(lambda: _control_socket_from_run_json(run_dir))
     _wait_for(lambda: control_socket.exists())
+    assert turn_registered.wait(timeout=5.0)
 
     assert cli.main(["runs", "interrupt", str(run_dir), "cook"]) == 0
     thread.join(timeout=5.0)

--- a/tests/test_run_detach.py
+++ b/tests/test_run_detach.py
@@ -2,7 +2,7 @@ import argparse
 import json
 from pathlib import Path
 
-from brigade import cli
+from brigade import aboyeur, cli
 from brigade.cli import run as run_cli
 
 
@@ -94,6 +94,37 @@ def test_run_detach_reports_early_child_exit(tmp_path, monkeypatch, capsys):
     assert "detached child exited before run metadata was written: exit 7" in captured.err
     assert f"log: {run_dir / 'detached.log'}" in captured.err
     assert (run_dir / "detached.log").read_text() == "boom\n"
+
+
+def test_run_detach_child_records_artifact_identity_in_lock(tmp_path, monkeypatch):
+    _write_roster(tmp_path)
+    seen = {}
+
+    def fake_run(*args, output_dir=None, **kwargs):
+        owner_path = tmp_path / ".brigade" / "run.lock" / "owner.json"
+        seen.update(json.loads(owner_path.read_text()))
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "run.json").write_text(json.dumps({"status": "ok"}) + "\n")
+        return 0
+
+    class FakeProcess:
+        pid = 4321
+
+        def __init__(self, argv, **kwargs):
+            assert cli.main(argv[3:]) == 0
+
+        def poll(self):
+            return None
+
+    monkeypatch.setattr(aboyeur, "run", fake_run)
+    monkeypatch.setattr(run_cli, "Popen", FakeProcess)
+
+    assert cli.main(["run", "do work", "--cwd", str(tmp_path), "--detach"]) == 0
+
+    run_dir = next((tmp_path / ".brigade" / "runs").iterdir())
+    assert seen["run_dir"] == str(run_dir.resolve())
+    assert isinstance(seen["owner_token"], str) and seen["owner_token"]
+    assert not (tmp_path / ".brigade" / "run.lock").exists()
 
 
 def test_run_detach_child_argv_preserves_worker(tmp_path):

--- a/tests/test_run_resume.py
+++ b/tests/test_run_resume.py
@@ -225,6 +225,47 @@ def test_resume_refuses_foreign_live_owner(tmp_path, monkeypatch, capsys):
     assert lock.is_dir()
 
 
+def test_resume_infers_lock_workspace_for_legacy_worktree_run(tmp_path, monkeypatch, capsys):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    original_run_dir = _write_run_dir(
+        workspace,
+        results=[
+            {
+                "worker": "cook",
+                "task": "write code",
+                "ok": False,
+                "thread_id": "t-1",
+                "status": "interrupted",
+            }
+        ],
+    )
+    run_dir = workspace / ".brigade" / "runs" / "legacy"
+    run_dir.parent.mkdir(parents=True)
+    original_run_dir.rename(run_dir)
+    detached = tmp_path / "detached"
+    detached.mkdir()
+    run_meta = json.loads((run_dir / "run.json").read_text())
+    run_meta["cwd"] = str(detached)
+    (run_dir / "run.json").write_text(json.dumps(run_meta))
+    foreign_run = workspace / ".brigade" / "runs" / "foreign"
+    lock = runguard.lock_path(workspace)
+    lock.mkdir(parents=True)
+    (lock / "pid").write_text(f"{os.getpid()}\n")
+    (lock / "owner.json").write_text(
+        json.dumps({"owner_token": "live", "pid": os.getpid(), "run_dir": str(foreign_run.resolve())})
+    )
+    monkeypatch.setattr(
+        run_resume.codex_appserver,
+        "AppServer",
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError("provider must not start")),
+    )
+
+    assert run_resume.resume(run_dir) == 2
+    assert "another brigade run appears active" in capsys.readouterr().err
+    assert lock.is_dir()
+
+
 def test_runs_resume_cli_dispatches(tmp_path, monkeypatch):
     from brigade import cli
 

--- a/tests/test_run_resume.py
+++ b/tests/test_run_resume.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
-from brigade import agents, codex_appserver, run_resume
+from brigade import agents, codex_appserver, runguard, run_resume
 
 
 def _write_run_dir(tmp_path: Path, *, results: list[dict]) -> Path:
@@ -135,6 +136,62 @@ def test_resume_missing_artifacts_errors(tmp_path, capsys):
     empty.mkdir()
     assert run_resume.resume(empty) == 2
     assert "missing" in capsys.readouterr().err
+
+
+def test_resume_refuses_nonterminal_run(tmp_path, monkeypatch, capsys):
+    run_dir = _write_run_dir(
+        tmp_path,
+        results=[
+            {
+                "worker": "cook",
+                "task": "write code",
+                "ok": False,
+                "thread_id": "t-1",
+                "status": "interrupted",
+            }
+        ],
+    )
+    run_meta = json.loads((run_dir / "run.json").read_text())
+    run_meta["status"] = "dispatching"
+    (run_dir / "run.json").write_text(json.dumps(run_meta))
+    monkeypatch.setattr(
+        run_resume.codex_appserver,
+        "AppServer",
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError("provider must not start")),
+    )
+
+    assert run_resume.resume(run_dir) == 2
+    assert "run is not terminal" in capsys.readouterr().err
+
+
+def test_resume_refuses_matching_live_owner(tmp_path, monkeypatch, capsys):
+    run_dir = _write_run_dir(
+        tmp_path,
+        results=[
+            {
+                "worker": "cook",
+                "task": "write code",
+                "ok": False,
+                "thread_id": "t-1",
+                "status": "interrupted",
+            }
+        ],
+    )
+    lock = runguard.lock_path(tmp_path)
+    lock.mkdir(parents=True)
+    (lock / "pid").write_text(f"{os.getpid()}\n")
+    (lock / "owner.json").write_text(
+        json.dumps({"owner_token": "live", "pid": os.getpid(), "run_dir": str(run_dir.resolve())})
+    )
+    monkeypatch.setattr(
+        run_resume.codex_appserver,
+        "AppServer",
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError("provider must not start")),
+    )
+
+    assert run_resume.resume(run_dir) == 2
+    assert "run owner process is still active" in capsys.readouterr().err
+    assert lock.is_dir()
 
 
 def test_runs_resume_cli_dispatches(tmp_path, monkeypatch):

--- a/tests/test_run_resume.py
+++ b/tests/test_run_resume.py
@@ -194,6 +194,37 @@ def test_resume_refuses_matching_live_owner(tmp_path, monkeypatch, capsys):
     assert lock.is_dir()
 
 
+def test_resume_refuses_foreign_live_owner(tmp_path, monkeypatch, capsys):
+    run_dir = _write_run_dir(
+        tmp_path,
+        results=[
+            {
+                "worker": "cook",
+                "task": "write code",
+                "ok": False,
+                "thread_id": "t-1",
+                "status": "interrupted",
+            }
+        ],
+    )
+    foreign_run = tmp_path / "foreign-run"
+    lock = runguard.lock_path(tmp_path)
+    lock.mkdir(parents=True)
+    (lock / "pid").write_text(f"{os.getpid()}\n")
+    (lock / "owner.json").write_text(
+        json.dumps({"owner_token": "live", "pid": os.getpid(), "run_dir": str(foreign_run.resolve())})
+    )
+    monkeypatch.setattr(
+        run_resume.codex_appserver,
+        "AppServer",
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError("provider must not start")),
+    )
+
+    assert run_resume.resume(run_dir) == 2
+    assert "another brigade run appears active" in capsys.readouterr().err
+    assert lock.is_dir()
+
+
 def test_runs_resume_cli_dispatches(tmp_path, monkeypatch):
     from brigade import cli
 

--- a/tests/test_run_resume.py
+++ b/tests/test_run_resume.py
@@ -85,6 +85,19 @@ def test_resume_reattaches_and_resynthesizes(tmp_path, monkeypatch, capsys):
             },
         ],
     )
+    recovered = json.loads((run_dir / "run.json").read_text())
+    recovered.update(
+        {
+            "error": "run owner process 99999999 is no longer active",
+            "failure_phase": "stale-lock-recovery",
+            "failure": {
+                "phase": "stale-lock-recovery",
+                "kind": "owner-process-exited",
+                "owner_pid": 99999999,
+            },
+        }
+    )
+    (run_dir / "run.json").write_text(json.dumps(recovered))
     monkeypatch.setattr(run_resume.codex_appserver, "AppServer", _StubServer)
     monkeypatch.setattr(
         run_resume.agents,
@@ -100,6 +113,9 @@ def test_resume_reattaches_and_resynthesizes(tmp_path, monkeypatch, capsys):
     run_json = json.loads((run_dir / "run.json").read_text())
     assert run_json["status"] == "ok"
     assert run_json["resumed_at"]
+    assert run_json["recovery_history"] == [recovered["failure"]]
+    assert "failure_phase" not in run_json
+    assert "failure" not in run_json
 
 
 def test_resume_with_nothing_resumable_reports_and_exits_2(tmp_path, capsys):

--- a/tests/test_runguard.py
+++ b/tests/test_runguard.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import json
 import os
+import threading
 
 import pytest
 
@@ -67,6 +69,129 @@ def test_run_lock_rejects_lock_held_by_live_process(tmp_path):
             pass
 
 
+def test_run_lock_reports_regular_file_lock_as_typed_error_and_preserves_it(tmp_path):
+    repo = _repo(tmp_path)
+    lock_path = runguard.lock_path(repo)
+    lock_path.parent.mkdir(parents=True)
+    lock_path.write_text("malformed lock\n")
+
+    with pytest.raises(runguard.RunLockError, match="malformed run lock"):
+        with runguard.run_lock(repo):
+            pass
+
+    assert lock_path.is_file()
+    assert lock_path.read_text() == "malformed lock\n"
+
+
+def test_run_lock_handles_windows_missing_process_error_as_stale(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    lock_path = runguard.lock_path(repo)
+    lock_path.mkdir(parents=True)
+    (lock_path / "pid").write_text("43210\n")
+    missing_process = OSError("invalid process parameter")
+    missing_process.winerror = 87
+    monkeypatch.setattr(runguard.os, "kill", lambda *args: (_ for _ in ()).throw(missing_process))
+
+    with runguard.run_lock(repo):
+        assert (lock_path / "pid").read_text().strip() == str(os.getpid())
+
+    assert not lock_path.exists()
+
+
+def test_run_lock_publishes_complete_owner_metadata(tmp_path):
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    lock_path = runguard.lock_path(repo)
+
+    with runguard.run_lock(repo, run_dir=run_dir):
+        owner = json.loads((lock_path / "owner.json").read_text())
+        assert owner["schema"] == "brigade.run_lock.v1"
+        assert owner["pid"] == os.getpid()
+        assert owner["run_dir"] == str(run_dir.resolve())
+        assert isinstance(owner["owner_token"], str) and owner["owner_token"]
+        assert isinstance(owner["acquired_at"], str) and owner["acquired_at"]
+        assert (lock_path / "pid").read_text().strip() == str(os.getpid())
+
+
+def test_run_lock_release_does_not_delete_replacement_owner(tmp_path):
+    repo = _repo(tmp_path)
+    lock_path = runguard.lock_path(repo)
+
+    with runguard.run_lock(repo):
+        replacement = lock_path.with_name("replacement.lock")
+        replacement.mkdir()
+        (replacement / "pid").write_text(f"{os.getpid()}\n")
+        (replacement / "owner.json").write_text(
+            json.dumps(
+                {
+                    "schema": "brigade.run_lock.v1",
+                    "owner_token": "replacement-owner",
+                    "pid": os.getpid(),
+                    "run_dir": None,
+                    "acquired_at": "2026-07-16T00:00:00+00:00",
+                }
+            )
+        )
+        runguard.shutil.rmtree(lock_path)
+        replacement.rename(lock_path)
+
+    assert lock_path.is_dir()
+    assert json.loads((lock_path / "owner.json").read_text())["owner_token"] == "replacement-owner"
+
+
+def test_run_lock_allows_only_one_concurrent_owner(tmp_path):
+    repo = _repo(tmp_path)
+    start = threading.Barrier(3)
+    loser_finished = threading.Event()
+    results = []
+
+    def contend(name):
+        start.wait()
+        try:
+            with runguard.run_lock(repo):
+                results.append((name, "acquired"))
+                assert loser_finished.wait(timeout=2.0)
+        except runguard.RunLockError:
+            results.append((name, "locked"))
+            loser_finished.set()
+
+    threads = [threading.Thread(target=contend, args=(name,)) for name in ("one", "two")]
+    for thread in threads:
+        thread.start()
+    start.wait()
+    for thread in threads:
+        thread.join(timeout=3.0)
+
+    assert not any(thread.is_alive() for thread in threads)
+    assert sorted(result for _, result in results) == ["acquired", "locked"]
+    assert not runguard.lock_path(repo).exists()
+
+
+def test_run_lock_retries_when_concurrent_stale_claim_removes_visible_lock(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    lock_path = runguard.lock_path(repo)
+    lock_path.mkdir(parents=True)
+    (lock_path / "pid").write_text("99999999\n")
+    original_claim = runguard._claim_stale_lock
+    calls = 0
+
+    def concurrent_claim(path):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            runguard.shutil.rmtree(path)
+            return None
+        return original_claim(path)
+
+    monkeypatch.setattr(runguard, "_claim_stale_lock", concurrent_claim)
+
+    with runguard.run_lock(repo):
+        assert lock_path.is_dir()
+
+    assert calls == 1
+
+
 def test_run_lock_waits_until_live_lock_clears(tmp_path, monkeypatch):
     repo = _repo(tmp_path)
     lock_path = runguard.lock_path(repo)
@@ -114,6 +239,229 @@ def test_run_lock_replaces_lock_with_dead_pid(tmp_path):
 
     with runguard.run_lock(repo):
         assert (lock_path / "pid").read_text().strip() == str(os.getpid())
+
+    assert not lock_path.exists()
+
+
+def test_run_lock_recovers_dead_owner_run_to_typed_terminal_state(tmp_path):
+    repo = _repo(tmp_path)
+    abandoned_run = tmp_path / "abandoned-run"
+    abandoned_run.mkdir()
+    (abandoned_run / "run.json").write_text(
+        json.dumps({"schema": "brigade.run.v1", "status": "dispatching", "task": "inspect"})
+    )
+    lock_path = runguard.lock_path(repo)
+    lock_path.mkdir(parents=True)
+    (lock_path / "pid").write_text("99999999\n")
+    (lock_path / "owner.json").write_text(
+        json.dumps(
+            {
+                "schema": "brigade.run_lock.v1",
+                "owner_token": "dead-owner",
+                "pid": 99999999,
+                "run_dir": str(abandoned_run.resolve()),
+                "acquired_at": "2026-07-16T00:00:00+00:00",
+            }
+        )
+    )
+
+    with runguard.run_lock(repo, run_dir=tmp_path / "new-run"):
+        recovered = json.loads((abandoned_run / "run.json").read_text())
+        assert recovered["status"] == "failed"
+        assert recovered["failure_phase"] == "stale-lock-recovery"
+        assert recovered["failure"] == {
+            "phase": "stale-lock-recovery",
+            "kind": "owner-process-exited",
+            "detail": "run owner process 99999999 is no longer active",
+            "owner_pid": 99999999,
+            "prior_status": "dispatching",
+            "recovered_at": recovered["failure"]["recovered_at"],
+        }
+        assert recovered["finished_at"] == recovered["failure"]["recovered_at"]
+        assert recovered["task"] == "inspect"
+
+
+def test_run_lock_keeps_stale_lock_when_failure_artifact_cannot_be_written(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    abandoned_run = tmp_path / "abandoned-run"
+    abandoned_run.mkdir()
+    (abandoned_run / "run.json").write_text(
+        json.dumps({"schema": "brigade.run.v1", "status": "dispatching", "task": "inspect"})
+    )
+    lock_path = runguard.lock_path(repo)
+    lock_path.mkdir(parents=True)
+    (lock_path / "pid").write_text("99999999\n")
+    (lock_path / "owner.json").write_text(
+        json.dumps(
+            {
+                "schema": "brigade.run_lock.v1",
+                "owner_token": "dead-owner",
+                "pid": 99999999,
+                "run_dir": str(abandoned_run.resolve()),
+                "acquired_at": "2026-07-16T00:00:00+00:00",
+            }
+        )
+    )
+    monkeypatch.setattr(
+        runguard.localio, "write_json", lambda *args, **kwargs: (_ for _ in ()).throw(OSError("disk full"))
+    )
+
+    with pytest.raises(runguard.RunLockError, match="could not preserve the stale run failure"):
+        with runguard.run_lock(repo, run_dir=tmp_path / "new-run"):
+            pass
+
+    assert lock_path.is_dir()
+    assert json.loads((lock_path / "owner.json").read_text())["owner_token"] == "dead-owner"
+    assert json.loads((abandoned_run / "run.json").read_text())["status"] == "dispatching"
+
+
+def test_run_lock_quarantines_unattributable_dead_owner_without_blocking_workspace(tmp_path):
+    repo = _repo(tmp_path)
+    lock_path = runguard.lock_path(repo)
+    lock_path.mkdir(parents=True)
+    (lock_path / "pid").write_text("99999999\n")
+    (lock_path / "owner.json").write_text(
+        json.dumps(
+            {
+                "schema": "brigade.run_lock.v1",
+                "owner_token": "dead-owner",
+                "pid": 99999999,
+                "run_dir": None,
+                "acquired_at": "2026-07-16T00:00:00+00:00",
+            }
+        )
+    )
+
+    with runguard.run_lock(repo, run_dir=tmp_path / "new-run"):
+        assert lock_path.is_dir()
+
+    assert not lock_path.exists()
+
+
+@pytest.mark.parametrize("existing_run_json", [None, "not json"])
+def test_run_lock_records_dead_owner_when_initial_run_json_is_unavailable(tmp_path, existing_run_json):
+    repo = _repo(tmp_path)
+    abandoned_run = tmp_path / "abandoned-run"
+    abandoned_run.mkdir()
+    if existing_run_json is not None:
+        (abandoned_run / "run.json").write_text(existing_run_json)
+    lock_path = runguard.lock_path(repo)
+    lock_path.mkdir(parents=True)
+    (lock_path / "pid").write_text("99999999\n")
+    (lock_path / "owner.json").write_text(
+        json.dumps(
+            {
+                "schema": "brigade.run_lock.v1",
+                "owner_token": "dead-owner",
+                "pid": 99999999,
+                "run_dir": str(abandoned_run.resolve()),
+                "acquired_at": "2026-07-16T00:00:00+00:00",
+            }
+        )
+    )
+
+    with runguard.run_lock(repo, run_dir=tmp_path / "new-run"):
+        recovered = json.loads((abandoned_run / "run.json").read_text())
+        assert recovered["status"] == "failed"
+        assert recovered["failure"]["kind"] == "owner-process-exited"
+        assert recovered["failure"]["prior_status"] == "artifact-unavailable"
+
+
+def test_run_lock_finishes_abandoned_stale_claim_before_new_owner_enters(tmp_path):
+    repo = _repo(tmp_path)
+    abandoned_run = tmp_path / "abandoned-run"
+    abandoned_run.mkdir()
+    (abandoned_run / "run.json").write_text(
+        json.dumps({"schema": "brigade.run.v1", "status": "dispatching", "task": "inspect"})
+    )
+    lock_path = runguard.lock_path(repo)
+    claimed = lock_path.with_name(f".{lock_path.name}.crashed.stale")
+    claimed.mkdir(parents=True)
+    (claimed / "pid").write_text("99999999\n")
+    (claimed / "owner.json").write_text(
+        json.dumps(
+            {
+                "schema": "brigade.run_lock.v1",
+                "owner_token": "dead-owner",
+                "pid": 99999999,
+                "run_dir": str(abandoned_run.resolve()),
+                "acquired_at": "2026-07-16T00:00:00+00:00",
+            }
+        )
+    )
+
+    with runguard.run_lock(repo, run_dir=tmp_path / "new-run"):
+        assert json.loads((abandoned_run / "run.json").read_text())["status"] == "failed"
+        assert not claimed.exists()
+
+
+def test_run_lock_does_not_admit_new_owner_while_stale_recovery_is_in_progress(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    abandoned_run = tmp_path / "abandoned-run"
+    abandoned_run.mkdir()
+    (abandoned_run / "run.json").write_text(
+        json.dumps({"schema": "brigade.run.v1", "status": "dispatching", "task": "inspect"})
+    )
+    lock_path = runguard.lock_path(repo)
+    lock_path.mkdir(parents=True)
+    (lock_path / "pid").write_text("99999999\n")
+    (lock_path / "owner.json").write_text(
+        json.dumps(
+            {
+                "schema": "brigade.run_lock.v1",
+                "owner_token": "dead-owner",
+                "pid": 99999999,
+                "run_dir": str(abandoned_run.resolve()),
+                "acquired_at": "2026-07-16T00:00:00+00:00",
+            }
+        )
+    )
+    recovery_started = threading.Event()
+    finish_recovery = threading.Event()
+    second_entered = threading.Event()
+    original_recover = runguard._recover_run_artifact
+
+    def paused_recover(owner):
+        recovery_started.set()
+        assert finish_recovery.wait(timeout=2.0)
+        return original_recover(owner)
+
+    monkeypatch.setattr(runguard, "_recover_run_artifact", paused_recover)
+
+    def first_owner():
+        with runguard.run_lock(repo, run_dir=tmp_path / "first-new-run"):
+            pass
+
+    def second_owner():
+        try:
+            with runguard.run_lock(repo, run_dir=tmp_path / "second-new-run"):
+                second_entered.set()
+        except runguard.RunLockError:
+            pass
+
+    first = threading.Thread(target=first_owner)
+    first.start()
+    assert recovery_started.wait(timeout=2.0)
+    second = threading.Thread(target=second_owner)
+    second.start()
+    second.join(timeout=2.0)
+
+    assert not second.is_alive()
+    assert not second_entered.is_set()
+    finish_recovery.set()
+    first.join(timeout=2.0)
+    assert not first.is_alive()
+
+
+@pytest.mark.parametrize("owner_json", [None, "not json"])
+def test_run_lock_release_uses_published_directory_identity_when_owner_metadata_is_lost(tmp_path, owner_json):
+    repo = _repo(tmp_path)
+    lock_path = runguard.lock_path(repo)
+
+    with runguard.run_lock(repo):
+        (lock_path / "owner.json").unlink()
+        if owner_json is not None:
+            (lock_path / "owner.json").write_text(owner_json)
 
     assert not lock_path.exists()
 

--- a/tests/test_runguard.py
+++ b/tests/test_runguard.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import threading
+from pathlib import Path
 
 import pytest
 
@@ -243,6 +244,28 @@ def test_run_lock_replaces_lock_with_dead_pid(tmp_path):
     assert not lock_path.exists()
 
 
+@pytest.mark.parametrize("pid_text", [None, "not-a-pid\n"])
+def test_run_lock_preserves_live_owner_when_pid_sidecar_is_missing_or_corrupt(tmp_path, pid_text):
+    repo = _repo(tmp_path)
+    abandoned_run = tmp_path / "active-run"
+    abandoned_run.mkdir()
+    (abandoned_run / "run.json").write_text(json.dumps({"status": "dispatching"}))
+    lock_path = runguard.lock_path(repo)
+    lock_path.mkdir(parents=True)
+    if pid_text is not None:
+        (lock_path / "pid").write_text(pid_text)
+    (lock_path / "owner.json").write_text(
+        json.dumps({"owner_token": "live-owner", "pid": os.getpid(), "run_dir": str(abandoned_run.resolve())})
+    )
+
+    with pytest.raises(runguard.RunLockError, match="another brigade run appears active"):
+        with runguard.run_lock(repo, run_dir=tmp_path / "new-run"):
+            pass
+
+    assert lock_path.is_dir()
+    assert json.loads((abandoned_run / "run.json").read_text())["status"] == "dispatching"
+
+
 def test_run_lock_recovers_dead_owner_run_to_typed_terminal_state(tmp_path):
     repo = _repo(tmp_path)
     abandoned_run = tmp_path / "abandoned-run"
@@ -392,7 +415,45 @@ def test_run_lock_finishes_abandoned_stale_claim_before_new_owner_enters(tmp_pat
 
     with runguard.run_lock(repo, run_dir=tmp_path / "new-run"):
         assert json.loads((abandoned_run / "run.json").read_text())["status"] == "failed"
-        assert not claimed.exists()
+    assert not claimed.exists()
+
+
+def test_recover_stale_run_refuses_pending_claim_with_live_owner(tmp_path):
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "active-run"
+    run_dir.mkdir()
+    (run_dir / "run.json").write_text(json.dumps({"status": "dispatching"}))
+    lock_path = runguard.lock_path(repo)
+    claimed = lock_path.with_name(f".{lock_path.name}.recovering-99999999-dead.stale")
+    claimed.mkdir(parents=True)
+    (claimed / "pid").write_text(f"{os.getpid()}\n")
+    (claimed / "owner.json").write_text(
+        json.dumps({"owner_token": "live-owner", "pid": os.getpid(), "run_dir": str(run_dir.resolve())})
+    )
+
+    with pytest.raises(runguard.RunLockError, match="owner process is still active"):
+        runguard.recover_stale_run(repo, run_dir)
+
+    assert claimed.is_dir()
+    assert json.loads((run_dir / "run.json").read_text())["status"] == "dispatching"
+
+
+def test_recovery_preserves_non_object_run_json(tmp_path):
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "abandoned-run"
+    run_dir.mkdir()
+    (run_dir / "run.json").write_text("[]")
+    lock_path = runguard.lock_path(repo)
+    lock_path.mkdir(parents=True)
+    (lock_path / "pid").write_text("99999999\n")
+    (lock_path / "owner.json").write_text(
+        json.dumps({"owner_token": "dead", "pid": 99999999, "run_dir": str(run_dir.resolve())})
+    )
+
+    assert runguard.recover_stale_run(repo, run_dir) is True
+    recovered = json.loads((run_dir / "run.json").read_text())
+    preserved = Path(recovered["recovery_preserved_artifact"])
+    assert preserved.read_text() == "[]"
 
 
 def test_run_lock_does_not_admit_new_owner_while_stale_recovery_is_in_progress(tmp_path, monkeypatch):

--- a/tests/test_runs_cmd.py
+++ b/tests/test_runs_cmd.py
@@ -1,4 +1,6 @@
 import json
+import os
+from pathlib import Path
 
 from brigade import cli
 from brigade import runs_cmd
@@ -71,6 +73,23 @@ def _write_minimal_run(run_dir, *, task, status, started_at, duration=1.0, read_
     )
 
 
+def _write_lock_owner(workspace, run_dir, *, pid=99999999, owner_token="owner"):
+    lock_path = workspace / ".brigade" / "run.lock"
+    lock_path.mkdir(parents=True)
+    (lock_path / "pid").write_text(f"{pid}\n")
+    _write_json(
+        lock_path / "owner.json",
+        {
+            "schema": "brigade.run_lock.v1",
+            "owner_token": owner_token,
+            "pid": pid,
+            "run_dir": str(run_dir.resolve()),
+            "acquired_at": "2026-07-16T00:00:00+00:00",
+        },
+    )
+    return lock_path
+
+
 def test_runs_show_prints_summary(tmp_path, capsys):
     run_dir = tmp_path / "run"
     _write_run_artifacts(run_dir)
@@ -117,6 +136,324 @@ def test_runs_show_cli(tmp_path, capsys):
 
     assert cli.main(["runs", "show", str(run_dir)]) == 0
     assert "status: ok" in capsys.readouterr().out
+
+
+def test_runs_recover_cli_dispatches_resolved_run(tmp_path, monkeypatch):
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    seen = {}
+    monkeypatch.setattr(
+        runs_cmd,
+        "recover",
+        lambda run, **kwargs: seen.update(run=run, **kwargs) or 0,
+        raising=False,
+    )
+
+    rc = cli.main(["runs", "recover", str(run_dir), "--cwd", str(tmp_path)])
+
+    assert rc == 0
+    assert seen == {"run": str(run_dir), "cwd": tmp_path, "runs_dir": None}
+
+
+def test_runs_recover_marks_dead_owner_run_terminal(tmp_path, capsys):
+    workspace = tmp_path / "workspace"
+    run_dir = workspace / ".brigade" / "runs" / "orphan"
+    _write_minimal_run(
+        run_dir,
+        task="orphaned task",
+        status="dispatching",
+        started_at="2026-07-16T00:00:00Z",
+    )
+    run_meta = json.loads((run_dir / "run.json").read_text())
+    run_meta["cwd"] = str(workspace)
+    _write_json(run_dir / "run.json", run_meta)
+    lock_path = _write_lock_owner(workspace, run_dir)
+
+    rc = runs_cmd.recover(str(run_dir), cwd=workspace)
+
+    assert rc == 0
+    recovered = json.loads((run_dir / "run.json").read_text())
+    assert recovered["status"] == "failed"
+    assert recovered["failure_phase"] == "stale-lock-recovery"
+    assert not lock_path.exists()
+    out = capsys.readouterr().out
+    assert f"recovered: {run_dir}" in out
+    assert "resume: unavailable" in out
+
+
+def test_runs_recover_reconstructs_missing_run_json_from_matching_dead_lock(tmp_path, capsys):
+    workspace = tmp_path / "workspace"
+    run_dir = workspace / ".brigade" / "runs" / "orphan"
+    run_dir.mkdir(parents=True)
+    _write_lock_owner(workspace, run_dir)
+
+    rc = runs_cmd.recover(str(run_dir), cwd=workspace)
+
+    assert rc == 0
+    recovered = json.loads((run_dir / "run.json").read_text())
+    assert recovered["status"] == "failed"
+    assert recovered["failure"]["prior_status"] == "artifact-unavailable"
+    assert f"recovered: {run_dir}" in capsys.readouterr().out
+
+
+def test_runs_recover_preserves_and_reconstructs_corrupt_run_json(tmp_path, capsys):
+    workspace = tmp_path / "workspace"
+    run_dir = workspace / ".brigade" / "runs" / "orphan"
+    run_dir.mkdir(parents=True)
+    (run_dir / "run.json").write_text("not json")
+    _write_lock_owner(workspace, run_dir)
+
+    rc = runs_cmd.recover(str(run_dir), cwd=workspace)
+
+    assert rc == 0
+    recovered = json.loads((run_dir / "run.json").read_text())
+    preserved = Path(recovered["recovery_preserved_artifact"])
+    assert preserved.read_text() == "not json"
+    assert f"recovered: {run_dir}" in capsys.readouterr().out
+
+
+def test_runs_recover_refuses_live_owner_without_changing_artifacts(tmp_path, capsys):
+    workspace = tmp_path / "workspace"
+    run_dir = workspace / ".brigade" / "runs" / "active"
+    _write_minimal_run(
+        run_dir,
+        task="active task",
+        status="dispatching",
+        started_at="2026-07-16T00:00:00Z",
+    )
+    run_meta = json.loads((run_dir / "run.json").read_text())
+    run_meta["cwd"] = str(workspace)
+    _write_json(run_dir / "run.json", run_meta)
+    lock_path = _write_lock_owner(workspace, run_dir, pid=os.getpid())
+
+    rc = runs_cmd.recover(str(run_dir), cwd=workspace)
+
+    assert rc == 2
+    assert json.loads((run_dir / "run.json").read_text())["status"] == "dispatching"
+    assert lock_path.is_dir()
+    assert "run owner process is still active" in capsys.readouterr().err
+
+
+def test_runs_recover_refuses_lock_for_different_run(tmp_path, capsys):
+    workspace = tmp_path / "workspace"
+    requested = workspace / ".brigade" / "runs" / "requested"
+    recorded = workspace / ".brigade" / "runs" / "recorded"
+    _write_minimal_run(
+        requested,
+        task="requested task",
+        status="dispatching",
+        started_at="2026-07-16T00:00:00Z",
+    )
+    run_meta = json.loads((requested / "run.json").read_text())
+    run_meta["cwd"] = str(workspace)
+    _write_json(requested / "run.json", run_meta)
+    lock_path = _write_lock_owner(workspace, recorded)
+
+    rc = runs_cmd.recover(str(requested), cwd=workspace)
+
+    assert rc == 2
+    assert json.loads((requested / "run.json").read_text())["status"] == "dispatching"
+    assert lock_path.is_dir()
+    assert "run lock belongs to a different run" in capsys.readouterr().err
+
+
+def test_runs_recover_is_idempotent_for_terminal_run(tmp_path, capsys):
+    workspace = tmp_path / "workspace"
+    run_dir = workspace / ".brigade" / "runs" / "failed"
+    _write_minimal_run(
+        run_dir,
+        task="failed task",
+        status="failed",
+        started_at="2026-07-16T00:00:00Z",
+    )
+
+    rc = runs_cmd.recover(str(run_dir), cwd=workspace)
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert f"already terminal: {run_dir} [failed]" in out
+    assert "resume: unavailable" in out
+
+
+def test_runs_recover_terminal_run_ignores_foreign_workspace_lock(tmp_path, capsys):
+    workspace = tmp_path / "workspace"
+    run_dir = workspace / ".brigade" / "runs" / "failed"
+    foreign_run = workspace / ".brigade" / "runs" / "other"
+    _write_minimal_run(
+        run_dir,
+        task="failed task",
+        status="failed",
+        started_at="2026-07-16T00:00:00Z",
+    )
+    run_meta = json.loads((run_dir / "run.json").read_text())
+    run_meta.update({"cwd": str(workspace), "failure_phase": "stale-lock-recovery"})
+    _write_json(run_dir / "run.json", run_meta)
+    lock_path = _write_lock_owner(workspace, foreign_run)
+
+    rc = runs_cmd.recover(str(run_dir), cwd=workspace)
+
+    assert rc == 0
+    assert lock_path.is_dir()
+    assert f"already terminal: {run_dir} [failed]" in capsys.readouterr().out
+
+
+def test_runs_recover_clears_matching_dead_lock_after_artifact_was_already_terminal(tmp_path, capsys):
+    workspace = tmp_path / "workspace"
+    run_dir = workspace / ".brigade" / "runs" / "failed"
+    _write_minimal_run(
+        run_dir,
+        task="failed task",
+        status="failed",
+        started_at="2026-07-16T00:00:00Z",
+    )
+    run_meta = json.loads((run_dir / "run.json").read_text())
+    run_meta.update({"cwd": str(workspace), "failure_phase": "stale-lock-recovery"})
+    _write_json(run_dir / "run.json", run_meta)
+    lock_path = _write_lock_owner(workspace, run_dir)
+
+    rc = runs_cmd.recover(str(run_dir), cwd=workspace)
+
+    assert rc == 0
+    assert not lock_path.exists()
+    assert f"already terminal: {run_dir} [failed]" in capsys.readouterr().out
+
+
+def test_runs_recover_reports_app_server_resume_when_available(tmp_path, capsys):
+    workspace = tmp_path / "workspace"
+    run_dir = workspace / ".brigade" / "runs" / "failed"
+    _write_minimal_run(
+        run_dir,
+        task="failed task",
+        status="failed",
+        started_at="2026-07-16T00:00:00Z",
+    )
+    _write_json(
+        run_dir / "worker-results.json",
+        {
+            "results": [
+                {
+                    "worker": "coder",
+                    "ok": False,
+                    "status": "failed",
+                    "thread_id": "thread-123",
+                }
+            ]
+        },
+    )
+
+    rc = runs_cmd.recover(str(run_dir), cwd=workspace)
+
+    assert rc == 0
+    assert f"resume: brigade runs resume {run_dir}" in capsys.readouterr().out
+
+
+def test_runs_show_surfaces_stale_lock_recovery_and_returns_nonzero(tmp_path, capsys):
+    run_dir = tmp_path / "run"
+    _write_minimal_run(
+        run_dir,
+        task="orphaned task",
+        status="failed",
+        started_at="2026-07-16T00:00:00Z",
+    )
+    run_meta = json.loads((run_dir / "run.json").read_text())
+    run_meta.update(
+        {
+            "cwd": str(tmp_path),
+            "finished_at": "2026-07-16T00:01:00Z",
+            "failure_phase": "stale-lock-recovery",
+            "failure": {
+                "phase": "stale-lock-recovery",
+                "kind": "owner-process-exited",
+                "detail": "run owner process 99999999 is no longer active",
+            },
+        }
+    )
+    _write_json(run_dir / "run.json", run_meta)
+
+    rc = runs_cmd.show(run_dir)
+
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "failure phase: stale-lock-recovery" in out
+    assert "failure kind: owner-process-exited" in out
+    assert f"inspect: brigade runs show {run_dir}" in out
+    assert "recover: completed (stale lock cleared)" in out
+    assert "resume: unavailable" in out
+
+
+def test_runs_watch_surfaces_stale_lock_recovery_and_returns_nonzero(tmp_path, capsys):
+    run_dir = tmp_path / "run"
+    _write_minimal_run(
+        run_dir,
+        task="orphaned task",
+        status="failed",
+        started_at="2026-07-16T00:00:00Z",
+    )
+    run_meta = json.loads((run_dir / "run.json").read_text())
+    run_meta.update(
+        {
+            "cwd": str(tmp_path),
+            "finished_at": "2026-07-16T00:01:00Z",
+            "failure_phase": "stale-lock-recovery",
+            "failure": {
+                "phase": "stale-lock-recovery",
+                "kind": "owner-process-exited",
+                "detail": "run owner process 99999999 is no longer active",
+            },
+        }
+    )
+    _write_json(run_dir / "run.json", run_meta)
+
+    rc = runs_cmd.watch(run_dir, cwd=tmp_path, interval=0.0)
+
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "failure phase: stale-lock-recovery" in out
+    assert f"inspect: brigade runs show {run_dir}" in out
+    assert "recover: completed (stale lock cleared)" in out
+    assert "resume: unavailable" in out
+
+
+def test_runs_show_does_not_claim_stale_lock_was_cleared_while_matching_lock_remains(tmp_path, capsys):
+    workspace = tmp_path / "workspace"
+    run_dir = workspace / ".brigade" / "runs" / "orphan"
+    _write_minimal_run(
+        run_dir,
+        task="orphaned task",
+        status="failed",
+        started_at="2026-07-16T00:00:00Z",
+    )
+    run_meta = json.loads((run_dir / "run.json").read_text())
+    run_meta.update({"cwd": str(workspace), "failure_phase": "stale-lock-recovery"})
+    _write_json(run_dir / "run.json", run_meta)
+    _write_lock_owner(workspace, run_dir)
+
+    assert runs_cmd.show(run_dir) == 1
+    out = capsys.readouterr().out
+    assert "recover: required (stale lock remains)" in out
+    assert "recover: completed (stale lock cleared)" not in out
+
+
+def test_runs_watch_does_not_claim_stale_lock_was_cleared_while_matching_claim_remains(tmp_path, capsys):
+    workspace = tmp_path / "workspace"
+    run_dir = workspace / ".brigade" / "runs" / "orphan"
+    _write_minimal_run(
+        run_dir,
+        task="orphaned task",
+        status="failed",
+        started_at="2026-07-16T00:00:00Z",
+    )
+    run_meta = json.loads((run_dir / "run.json").read_text())
+    run_meta.update({"cwd": str(workspace), "failure_phase": "stale-lock-recovery"})
+    _write_json(run_dir / "run.json", run_meta)
+    lock_path = _write_lock_owner(workspace, run_dir)
+    claimed = lock_path.with_name(f".{lock_path.name}.crashed.stale")
+    lock_path.rename(claimed)
+
+    assert runs_cmd.watch(run_dir, cwd=workspace, interval=0.0) == 1
+    out = capsys.readouterr().out
+    assert "recover: required (stale lock remains)" in out
+    assert "recover: completed (stale lock cleared)" not in out
 
 
 def test_runs_list_prints_recent_runs(tmp_path, capsys):

--- a/tests/test_runs_cmd.py
+++ b/tests/test_runs_cmd.py
@@ -275,6 +275,28 @@ def test_runs_recover_is_idempotent_for_terminal_run(tmp_path, capsys):
     assert "resume: unavailable" in out
 
 
+def test_runs_recover_treats_lost_concurrent_claim_as_already_terminal(tmp_path, monkeypatch, capsys):
+    from brigade import runguard
+
+    workspace = tmp_path / "workspace"
+    run_dir = workspace / ".brigade" / "runs" / "orphan"
+    _write_minimal_run(run_dir, task="orphaned task", status="dispatching", started_at="2026-07-16T00:00:00Z")
+    run_meta = json.loads((run_dir / "run.json").read_text())
+    run_meta["cwd"] = str(workspace)
+    _write_json(run_dir / "run.json", run_meta)
+
+    def lose_claim(cwd, requested_run, *, required=True):
+        terminal = json.loads((run_dir / "run.json").read_text())
+        terminal.update({"status": "failed", "failure_phase": "stale-lock-recovery"})
+        _write_json(run_dir / "run.json", terminal)
+        raise runguard.RunLockError(f"run lock not found for run: {requested_run}")
+
+    monkeypatch.setattr(runguard, "recover_stale_run", lose_claim)
+
+    assert runs_cmd.recover(str(run_dir), cwd=workspace) == 0
+    assert f"already terminal: {run_dir} [failed]" in capsys.readouterr().out
+
+
 def test_runs_recover_terminal_run_ignores_foreign_workspace_lock(tmp_path, capsys):
     workspace = tmp_path / "workspace"
     run_dir = workspace / ".brigade" / "runs" / "failed"

--- a/tests/test_runs_cmd.py
+++ b/tests/test_runs_cmd.py
@@ -205,6 +205,30 @@ def test_runs_recover_uses_recorded_lock_workspace_for_worktree_run(tmp_path, ca
     assert f"recovered: {run_dir}" in capsys.readouterr().out
 
 
+def test_runs_recover_infers_lock_workspace_for_legacy_worktree_run(tmp_path, capsys):
+    workspace = tmp_path / "workspace"
+    detached = tmp_path / "detached"
+    detached.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / "legacy"
+    _write_minimal_run(
+        run_dir,
+        task="legacy worktree task",
+        status="dispatching",
+        started_at="2026-07-16T00:00:00Z",
+    )
+    run_meta = json.loads((run_dir / "run.json").read_text())
+    run_meta["cwd"] = str(detached)
+    _write_json(run_dir / "run.json", run_meta)
+    lock_path = _write_lock_owner(workspace, run_dir)
+
+    rc = runs_cmd.recover(str(run_dir), cwd=tmp_path)
+
+    assert rc == 0
+    assert not lock_path.exists()
+    assert json.loads((run_dir / "run.json").read_text())["status"] == "failed"
+    assert f"recovered: {run_dir}" in capsys.readouterr().out
+
+
 def test_runs_recover_reconstructs_missing_run_json_from_matching_dead_lock(tmp_path, capsys):
     workspace = tmp_path / "workspace"
     run_dir = workspace / ".brigade" / "runs" / "orphan"

--- a/tests/test_runs_cmd.py
+++ b/tests/test_runs_cmd.py
@@ -181,6 +181,30 @@ def test_runs_recover_marks_dead_owner_run_terminal(tmp_path, capsys):
     assert "resume: unavailable" in out
 
 
+def test_runs_recover_uses_recorded_lock_workspace_for_worktree_run(tmp_path, capsys):
+    workspace = tmp_path / "workspace"
+    detached = tmp_path / "detached"
+    detached.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / "orphan"
+    _write_minimal_run(
+        run_dir,
+        task="orphaned worktree task",
+        status="dispatching",
+        started_at="2026-07-16T00:00:00Z",
+    )
+    run_meta = json.loads((run_dir / "run.json").read_text())
+    run_meta.update({"cwd": str(detached), "lock_workspace": str(workspace)})
+    _write_json(run_dir / "run.json", run_meta)
+    lock_path = _write_lock_owner(workspace, run_dir)
+
+    rc = runs_cmd.recover(str(run_dir), cwd=detached)
+
+    assert rc == 0
+    assert not lock_path.exists()
+    assert json.loads((run_dir / "run.json").read_text())["status"] == "failed"
+    assert f"recovered: {run_dir}" in capsys.readouterr().out
+
+
 def test_runs_recover_reconstructs_missing_run_json_from_matching_dead_lock(tmp_path, capsys):
     workspace = tmp_path / "workspace"
     run_dir = workspace / ".brigade" / "runs" / "orphan"


### PR DESCRIPTION
Closes #279

## Summary

- Publish run-lock ownership metadata atomically, including the artifact directory, lock workspace, owner PID, and ownership token.
- Convert dead-owner runs to typed `stale-lock-recovery` failures before clearing their locks. Missing metadata is reconstructed, corrupt artifacts are preserved, unattributable owners are quarantined, and locks remain when failure receipts cannot be written.
- Recover abandoned stale claims without racing new owners. Live or mismatched owners are left untouched.
- Add `brigade runs recover <run>` with idempotent recovery, terminal-state guidance, and app-server resume checks.
- Hold the workspace lock through resume so matching and foreign live runs cannot overlap. Older worktree receipts infer the source workspace from `.brigade/runs/<id>`.
- Record `planning`, `dispatching`, and `synthesizing` before provider work starts. Interrupt handling waits until the worker registry is ready.
- Refresh the generated command inventory for the new `runs recover` command.

## Root cause

Run locks did not carry enough ownership data to connect a dead child to its artifact directory. Recovery was not atomic, run phases were written too late, and resume checked a lock without holding it through provider work. Worktree runs also recorded the detached checkout as `cwd`, which hid the source workspace lock during later recovery.

## Verification

- Exact head: `4216b58c96c38df2c0ba871730991603e3302c5e`
- Brigade receipt: `20260717-003309-work-verify-17c9b3`
- `./scripts/verify`
- 2,375 passed, 3 skipped
- 81.42% coverage
- Independent exact-head review: no actionable findings

## Review focus

- Lock ownership and release races
- Crash recovery after the canonical lock moves to a stale claim
- Resume exclusion against matching and foreign live runs
- Recovery of older worktree receipts without `lock_workspace`
- Artifact preservation when recovery writes fail
