### PR TITLE
fix(handoff): preserve Grok source coverage

### DIFF
--- a/docs/examples/hermes-handoff-smoke.md
+++ b/docs/examples/hermes-handoff-smoke.md
@@ -4,7 +4,7 @@ This is a local-only smoke path for a repo where Hermes writes Brigade Memory Ha
 
 ```bash
 brigade init --target . --depth workspace --harnesses hermes
-brigade handoff sources init --target . --force
+brigade handoff sources init --target .
 brigade handoff draft --target . --inbox hermes \
   --title "Hermes smoke handoff" \
   --summary "Hermes can write a local Brigade Memory Handoff." \

--- a/docs/hermes-handoffs.md
+++ b/docs/hermes-handoffs.md
@@ -9,7 +9,7 @@ The inbox uses the same Markdown handoff schema as Claude Code, Codex, and OpenC
 
 ```bash
 brigade init --target . --depth workspace --harnesses hermes
-brigade handoff sources init --target . --force
+brigade handoff sources init --target .
 ```
 
 `init` writes the shared workspace files, the Hermes adapter fragments under `.brigade/hermes/`, the local `.hermes/memory-handoffs/` inbox, and the matching gitignore entries. `handoff sources init` records the local inboxes that the canonical ingestor is expected to scan, including `.hermes/memory-handoffs/`.
@@ -38,7 +38,7 @@ This creates a local ignored file under `.hermes/memory-handoffs/` and lints it 
 ## Smoke Test The Wiring
 
 ```bash
-brigade handoff sources init --target . --force
+brigade handoff sources init --target .
 brigade handoff draft --target . --inbox hermes \
   --title "Hermes smoke handoff" \
   --summary "Hermes can write a local Brigade Memory Handoff." \

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -569,7 +569,7 @@ flowchart LR
 
 ```bash
 brigade init --target . --depth workspace --harnesses hermes
-brigade handoff sources init --target . --force
+brigade handoff sources init --target .
 ```
 
 ```bash

--- a/src/brigade/handoff_cmd/issue_ops.py
+++ b/src/brigade/handoff_cmd/issue_ops.py
@@ -195,36 +195,39 @@ def doctor(*, target: Path, sources: Path | None = None, json_output: bool = Fal
     return 1 if health.failures else 0
 
 
-def _merge_local_source_inboxes(payload: object, desired: list[str]) -> tuple[dict[str, Any] | None, bool, str | None]:
+def _merge_local_source_inboxes(
+    payload: object, desired: list[str]
+) -> tuple[dict[str, Any] | None, bool, str | None, list[str]]:
     if not isinstance(payload, dict):
-        return None, False, "root must be a JSON object"
+        return None, False, "root must be a JSON object", []
     sources = payload.get("sources")
     if not isinstance(sources, list):
-        return None, False, "sources must be a list"
+        return None, False, "sources must be a list", []
 
     for entry in sources:
         if isinstance(entry, str):
             if entry == ".":
-                return payload, False, None
+                return payload, False, None, list(WRITER_INBOXES)
             continue
         if not isinstance(entry, dict):
-            return None, False, "sources entries must be objects or strings"
+            return None, False, "sources entries must be objects or strings", []
         root = entry.get("root", ".")
         if root != ".":
             continue
         inbox_values = entry.get("inboxes")
         if inbox_values is None:
-            return payload, False, None
+            return payload, False, None, list(WRITER_INBOXES)
         if not isinstance(inbox_values, list) or not all(isinstance(item, str) for item in inbox_values):
-            return None, False, "local source inboxes must be a list of strings"
+            return None, False, "local source inboxes must be a list of strings", []
         merged = list(dict.fromkeys([*inbox_values, *desired]))
         if merged == inbox_values:
-            return payload, False, None
+            return payload, False, None, merged
         entry["inboxes"] = merged
-        return payload, True, None
+        return payload, True, None, merged
 
-    sources.append({"root": ".", "inboxes": list(dict.fromkeys(desired))})
-    return payload, True, None
+    merged = list(dict.fromkeys(desired))
+    sources.append({"root": ".", "inboxes": merged})
+    return payload, True, None, merged
 
 
 def sources_init(
@@ -254,11 +257,12 @@ def sources_init(
         except (OSError, json.JSONDecodeError) as exc:
             print(f"error: invalid handoff source config {path}: {exc}", file=sys.stderr)
             return 2
-        payload, written, error = _merge_local_source_inboxes(existing, inbox_values)
+        payload, written, error, effective_inboxes = _merge_local_source_inboxes(existing, inbox_values)
         if error or payload is None:
             print(f"error: invalid handoff source config {path}: {error}", file=sys.stderr)
             return 2
     else:
+        effective_inboxes = inbox_values
         payload = {
             "_description": "Local handoff source coverage. Relative roots resolve from this repo or workspace target.",
             "canonical_owner": "openclaw",
@@ -281,13 +285,13 @@ def sources_init(
         "target": str(target),
         "path": str(path),
         "written": written,
-        "inboxes": inbox_values,
+        "inboxes": effective_inboxes,
     }
     if json_output:
         print(json.dumps(output, indent=2, sort_keys=True))
         return 0
     print(f"handoff_sources: {path}")
-    print(f"inboxes: {', '.join(inbox_values) if inbox_values else '(none)'}")
+    print(f"inboxes: {', '.join(effective_inboxes) if effective_inboxes else '(none)'}")
     print("next_command: brigade handoff doctor")
     return 0
 

--- a/src/brigade/handoff_cmd/issue_ops.py
+++ b/src/brigade/handoff_cmd/issue_ops.py
@@ -195,6 +195,38 @@ def doctor(*, target: Path, sources: Path | None = None, json_output: bool = Fal
     return 1 if health.failures else 0
 
 
+def _merge_local_source_inboxes(payload: object, desired: list[str]) -> tuple[dict[str, Any] | None, bool, str | None]:
+    if not isinstance(payload, dict):
+        return None, False, "root must be a JSON object"
+    sources = payload.get("sources")
+    if not isinstance(sources, list):
+        return None, False, "sources must be a list"
+
+    for entry in sources:
+        if isinstance(entry, str):
+            if entry == ".":
+                return payload, False, None
+            continue
+        if not isinstance(entry, dict):
+            return None, False, "sources entries must be objects or strings"
+        root = entry.get("root", ".")
+        if root != ".":
+            continue
+        inbox_values = entry.get("inboxes")
+        if inbox_values is None:
+            return payload, False, None
+        if not isinstance(inbox_values, list) or not all(isinstance(item, str) for item in inbox_values):
+            return None, False, "local source inboxes must be a list of strings"
+        merged = list(dict.fromkeys([*inbox_values, *desired]))
+        if merged == inbox_values:
+            return payload, False, None
+        entry["inboxes"] = merged
+        return payload, True, None
+
+    sources.append({"root": ".", "inboxes": list(dict.fromkeys(desired))})
+    return payload, True, None
+
+
 def sources_init(
     *, target: Path, force: bool = False, inboxes: list[str] | None = None, json_output: bool = False
 ) -> int:
@@ -203,9 +235,6 @@ def sources_init(
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
     path = default_sources_path(target)
-    if path.exists() and not force:
-        print(f"error: handoff source config already exists: {path}", file=sys.stderr)
-        return 2
     if inboxes is not None:
         inbox_values = list(inboxes)
     else:
@@ -218,27 +247,40 @@ def sources_init(
             selected = [_WRITER_INBOX_MAP[h] for h in config.selection.harnesses if h in _WRITER_INBOX_MAP]
             if selected:
                 inbox_values = selected
-    payload = {
-        "_description": "Local handoff source coverage. Relative roots resolve from this repo or workspace target.",
-        "canonical_owner": "openclaw",
-        "ingestor": {
-            "last_run_log": ".brigade/handoff-ingest/latest.log",
-            "stale_after_minutes": DEFAULT_STALE_AFTER_MINUTES,
-            "warning_patterns": list(DEFAULT_WARNING_PATTERNS),
-        },
-        "sources": [
-            {
-                "root": ".",
-                "inboxes": inbox_values,
-            }
-        ],
-    }
+    written = True
+    if path.exists() and not force:
+        try:
+            existing = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"error: invalid handoff source config {path}: {exc}", file=sys.stderr)
+            return 2
+        payload, written, error = _merge_local_source_inboxes(existing, inbox_values)
+        if error or payload is None:
+            print(f"error: invalid handoff source config {path}: {error}", file=sys.stderr)
+            return 2
+    else:
+        payload = {
+            "_description": "Local handoff source coverage. Relative roots resolve from this repo or workspace target.",
+            "canonical_owner": "openclaw",
+            "ingestor": {
+                "last_run_log": ".brigade/handoff-ingest/latest.log",
+                "stale_after_minutes": DEFAULT_STALE_AFTER_MINUTES,
+                "warning_patterns": list(DEFAULT_WARNING_PATTERNS),
+            },
+            "sources": [
+                {
+                    "root": ".",
+                    "inboxes": inbox_values,
+                }
+            ],
+        }
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    if written:
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
     output = {
         "target": str(target),
         "path": str(path),
-        "written": True,
+        "written": written,
         "inboxes": inbox_values,
     }
     if json_output:

--- a/src/brigade/operator_cmd/guide.py
+++ b/src/brigade/operator_cmd/guide.py
@@ -155,12 +155,16 @@ def plan_payload(
     steps = []
     for step in _steps(target, profile=profile, handoff_inboxes=handoff_inboxes):
         path = step["path"]
+        if path.exists() and step["id"] == "handoff-sources":
+            action = "merge"
+        else:
+            action = "skip" if path.exists() else "write"
         steps.append(
             {
                 "id": step["id"],
                 "path": str(path),
                 "exists": path.exists(),
-                "action": "skip" if path.exists() else "write",
+                "action": action,
             }
         )
     return {

--- a/src/brigade/operator_cmd/health.py
+++ b/src/brigade/operator_cmd/health.py
@@ -456,7 +456,7 @@ def verify_harness_payload(target: Path, *, harness: str) -> dict[str, Any]:
         elif inbox_health is None or not inbox_path.exists():
             next_command = f"brigade handoff draft --inbox {harness} --target . --title <title> --summary <summary> --content <content>"
         elif not (inbox_health and inbox_health.watched):
-            next_command = "brigade handoff sources init --target . --force"
+            next_command = "brigade handoff sources init --target ."
         elif invalid:
             next_command = f"brigade handoff lint {inbox_rel} --target ."
         else:

--- a/src/brigade/operator_cmd/lifecycle.py
+++ b/src/brigade/operator_cmd/lifecycle.py
@@ -50,7 +50,7 @@ def init(
     results: list[dict[str, Any]] = []
     for step in _steps(target, profile=profile, handoff_inboxes=handoff_inboxes, default_tools=default_tools):
         path = step["path"]
-        if path.exists() and not force:
+        if path.exists() and not force and step["id"] != "handoff-sources":
             results.append({"id": step["id"], "path": str(path), "status": "skipped", "reason": "already exists"})
             continue
         kwargs = dict(step["kwargs"])

--- a/src/brigade/operator_cmd/lifecycle.py
+++ b/src/brigade/operator_cmd/lifecycle.py
@@ -55,18 +55,28 @@ def init(
             continue
         kwargs = dict(step["kwargs"])
         kwargs.update({"target": target, "force": force})
+        if step["id"] == "handoff-sources":
+            kwargs["json_output"] = True
         output = StringIO()
         with redirect_stdout(output):
             rc = step["command"](**kwargs)
-        results.append(
-            {
-                "id": step["id"],
-                "path": str(path),
-                "status": "written" if rc == 0 else "error",
-                "return_code": rc,
-                "output": output.getvalue().strip().splitlines(),
-            }
-        )
+        output_text = output.getvalue().strip()
+        result = {
+            "id": step["id"],
+            "path": str(path),
+            "status": "written" if rc == 0 else "error",
+            "return_code": rc,
+            "output": output_text.splitlines(),
+        }
+        if step["id"] == "handoff-sources" and rc == 0:
+            try:
+                source_result = json.loads(output_text)
+            except json.JSONDecodeError:
+                source_result = None
+            if isinstance(source_result, dict) and source_result.get("written") is False:
+                result["status"] = "skipped"
+                result["reason"] = "source coverage already current"
+        results.append(result)
     post_actions = _post_init_actions(target, profile=profile, waive_public_release=waive_public_release)
     payload = {
         "target": str(target),

--- a/src/brigade/repos_cmd/fleet.py
+++ b/src/brigade/repos_cmd/fleet.py
@@ -653,12 +653,37 @@ def _handoff_backlog(repo: Path) -> tuple[int, int | None]:
     return pending, oldest_days
 
 
+def _handoff_source_coverage(repo: Path) -> tuple[list[str], list[str], list[str]]:
+    if not repo.is_dir():
+        return [], [], []
+    try:
+        config = brigade_config.load_config(repo)
+    except (OSError, ValueError):
+        return [], [], []
+    if config is None:
+        return [], [], []
+
+    expected = [WRITER_INBOXES[harness] for harness in config.selection.harnesses if harness in WRITER_INBOXES]
+    missing = [inbox for inbox in expected if not (repo / inbox).is_dir()]
+
+    from .. import handoff_cmd
+
+    try:
+        health = handoff_cmd.inspect(repo)
+    except (OSError, ValueError):
+        return expected, missing, []
+    watched = {inbox.inbox for inbox in health.inboxes if inbox.watched}
+    unwatched = [inbox for inbox in expected if inbox not in missing and inbox not in watched]
+    return expected, missing, unwatched
+
+
 def _repo_summary(entry: constants.RepoEntry) -> dict[str, Any]:
     repo = entry.path
     tracked_dirty, untracked_dirty = _dirty_counts(repo) if repo.is_dir() else (0, 0)
     has_agents = (repo / "AGENTS.md").is_file()
     has_claude = (repo / "CLAUDE.md").is_file() or (repo / ".claude" / "CLAUDE.md").is_file()
     handoff_inboxes = [inbox for inbox in WRITER_INBOXES.values() if (repo / inbox).is_dir()]
+    handoff_expected, handoff_missing, handoff_unwatched = _handoff_source_coverage(repo)
     handoff_pending, handoff_backlog_oldest_days = _handoff_backlog(repo)
     hooks = repo / ".git" / "hooks"
     publish_guard_hooks = (
@@ -681,6 +706,9 @@ def _repo_summary(entry: constants.RepoEntry) -> dict[str, Any]:
         "has_changelog": (repo / "CHANGELOG.md").is_file(),
         "test_hints": _test_hints(repo) if repo.is_dir() else [],
         "handoff_inboxes": handoff_inboxes,
+        "handoff_inboxes_expected": handoff_expected,
+        "handoff_inboxes_missing": handoff_missing,
+        "handoff_inboxes_unwatched": handoff_unwatched,
         "handoff_pending": handoff_pending,
         "handoff_backlog_oldest_days": handoff_backlog_oldest_days,
         "publish_guard_hooks": publish_guard_hooks,
@@ -774,7 +802,26 @@ def _repo_checks(summary: dict[str, Any]) -> list[dict[str, Any]]:
                 "repo_id": repo_id,
             }
         )
-    if not summary.get("handoff_inboxes"):
+    expected_inboxes = summary.get("handoff_inboxes_expected") or []
+    for inbox in summary.get("handoff_inboxes_missing") or []:
+        checks.append(
+            {
+                "status": constants.WARN,
+                "name": "repo_handoff_inbox_missing",
+                "detail": f"{repo_id} selected handoff inbox is missing: {inbox}",
+                "repo_id": repo_id,
+            }
+        )
+    for inbox in summary.get("handoff_inboxes_unwatched") or []:
+        checks.append(
+            {
+                "status": constants.WARN,
+                "name": "repo_handoff_inbox_unwatched",
+                "detail": f"{repo_id} selected handoff inbox is not watched: {inbox}",
+                "repo_id": repo_id,
+            }
+        )
+    if not expected_inboxes and not summary.get("handoff_inboxes"):
         checks.append(
             {
                 "status": constants.WARN,

--- a/src/brigade/templates/handoff/handoff-sources.example.json
+++ b/src/brigade/templates/handoff/handoff-sources.example.json
@@ -33,6 +33,7 @@
         ".kimi/memory-handoffs",
         ".adal/memory-handoffs",
         ".openhands/memory-handoffs",
+        ".grok/memory-handoffs",
         ".hermes/memory-handoffs"
       ]
     }

--- a/src/brigade/templates/hermes/README.md
+++ b/src/brigade/templates/hermes/README.md
@@ -12,7 +12,7 @@
 ## Smoke test
 
 ```bash
-brigade handoff sources init --target . --force
+brigade handoff sources init --target .
 brigade handoff draft --target . --inbox hermes \
   --title "Hermes smoke handoff" \
   --summary "Hermes can write a local Brigade Memory Handoff." \

--- a/tests/test_handoff_cmd.py
+++ b/tests/test_handoff_cmd.py
@@ -1571,6 +1571,7 @@ def test_handoff_sources_init_adds_grok_without_replacing_custom_sources(tmp_pat
     first_payload = json.loads(capsys.readouterr().out)
     first = json.loads(path.read_text())
     assert first_payload["written"] is True
+    assert first_payload["inboxes"] == [".codex/memory-handoffs", ".grok/memory-handoffs"]
     assert first["custom"] == original["custom"]
     assert first["sources"][1] == original["sources"][1]
     assert first["sources"][0]["inboxes"] == [".codex/memory-handoffs", ".grok/memory-handoffs"]

--- a/tests/test_handoff_cmd.py
+++ b/tests/test_handoff_cmd.py
@@ -1525,7 +1525,61 @@ def test_handoff_sources_init_writes_all_writer_inboxes(tmp_path, capsys):
     assert ".antigravity/memory-handoffs" in data["sources"][0]["inboxes"]
     assert ".pi/memory-handoffs" in data["sources"][0]["inboxes"]
     assert ".cursor/memory-handoffs" in data["sources"][0]["inboxes"]
+    assert ".grok/memory-handoffs" in data["sources"][0]["inboxes"]
     assert ".hermes/memory-handoffs" in data["sources"][0]["inboxes"]
+
+
+def test_handoff_sources_init_makes_installed_grok_ready(tmp_path, capsys):
+    from brigade.install import install_selection
+    from brigade.operator_cmd.health import verify_harness_payload
+    from brigade.selection import Selection
+
+    selection = Selection(depth="repo", harnesses=["grok"], owner="this-repo", includes=[])
+    assert install_selection(tmp_path, selection) == 0
+    capsys.readouterr()
+
+    assert handoff_cmd.sources_init(target=tmp_path, json_output=True) == 0
+    sources_payload = json.loads(capsys.readouterr().out)
+    assert sources_payload["inboxes"] == [".grok/memory-handoffs"]
+
+    verify_payload = verify_harness_payload(tmp_path, harness="grok")
+    assert verify_payload["ready"] is True
+    assert verify_payload["issue_count"] == 0
+    assert verify_payload["handoff_inbox"]["watched"] is True
+
+
+def test_handoff_sources_init_adds_grok_without_replacing_custom_sources(tmp_path, capsys):
+    from brigade.config import Config, write_config
+    from brigade.selection import Selection
+
+    write_config(
+        tmp_path,
+        Config(version=1, selection=Selection(depth="repo", harnesses=["grok"], owner="this-repo")),
+    )
+    path = tmp_path / ".brigade" / "handoff-sources.json"
+    original = {
+        "canonical_owner": "openclaw",
+        "custom": {"keep": True},
+        "sources": [
+            {"root": ".", "inboxes": [".codex/memory-handoffs"]},
+            {"root": "../shared", "inboxes": ["team/handoffs"]},
+        ],
+    }
+    path.write_text(json.dumps(original, indent=2) + "\n")
+
+    assert handoff_cmd.sources_init(target=tmp_path, json_output=True) == 0
+    first_payload = json.loads(capsys.readouterr().out)
+    first = json.loads(path.read_text())
+    assert first_payload["written"] is True
+    assert first["custom"] == original["custom"]
+    assert first["sources"][1] == original["sources"][1]
+    assert first["sources"][0]["inboxes"] == [".codex/memory-handoffs", ".grok/memory-handoffs"]
+
+    assert handoff_cmd.sources_init(target=tmp_path, json_output=True) == 0
+    second_payload = json.loads(capsys.readouterr().out)
+    second = json.loads(path.read_text())
+    assert second_payload["written"] is False
+    assert second == first
 
 
 def test_handoff_sources_init_accepts_scoped_inboxes(tmp_path, capsys):
@@ -1787,12 +1841,15 @@ def test_doctor_checks_no_backlog_warn_for_fresh_pending(tmp_path):
 
 def test_handoff_writer_inboxes_include_supported_writer_harnesses():
     from brigade import handoff_cmd
+    from brigade.selection import KNOWN_HARNESSES, WRITER_INBOXES
 
     assert ".opencode/memory-handoffs" in handoff_cmd.WRITER_INBOXES
     assert ".antigravity/memory-handoffs" in handoff_cmd.WRITER_INBOXES
     assert ".pi/memory-handoffs" in handoff_cmd.WRITER_INBOXES
     assert ".cursor/memory-handoffs" in handoff_cmd.WRITER_INBOXES
+    assert ".grok/memory-handoffs" in handoff_cmd.WRITER_INBOXES
     assert ".hermes/memory-handoffs" in handoff_cmd.WRITER_INBOXES
+    assert set(KNOWN_HARNESSES) == {*WRITER_INBOXES, "openclaw"}
 
 
 def test_handoff_sources_example_lists_supported_writer_harnesses():
@@ -1804,6 +1861,7 @@ def test_handoff_sources_example_lists_supported_writer_harnesses():
     assert ".antigravity/memory-handoffs" in data["sources"][0]["inboxes"]
     assert ".pi/memory-handoffs" in data["sources"][0]["inboxes"]
     assert ".cursor/memory-handoffs" in data["sources"][0]["inboxes"]
+    assert ".grok/memory-handoffs" in data["sources"][0]["inboxes"]
     assert ".hermes/memory-handoffs" in data["sources"][0]["inboxes"]
 
 

--- a/tests/test_operator_cmd.py
+++ b/tests/test_operator_cmd.py
@@ -837,6 +837,26 @@ def test_operator_init_dry_run_does_not_write(tmp_path, capsys):
     assert not (tmp_path / ".brigade" / "daily.toml").exists()
 
 
+def test_operator_init_dry_run_previews_existing_handoff_source_merge(tmp_path, capsys):
+    path = tmp_path / ".brigade" / "handoff-sources.json"
+    path.parent.mkdir()
+    path.write_text(json.dumps({"sources": [{"root": ".", "inboxes": [".codex/memory-handoffs"]}]}) + "\n")
+
+    assert (
+        operator_cmd.init(
+            target=tmp_path,
+            handoff_inboxes=[".grok/memory-handoffs"],
+            dry_run=True,
+            json_output=True,
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    sources_step = next(row for row in payload["steps"] if row["id"] == "handoff-sources")
+
+    assert sources_step["action"] == "merge"
+
+
 def test_operator_init_merges_existing_handoff_source_coverage(tmp_path, capsys):
     path = tmp_path / ".brigade" / "handoff-sources.json"
     path.parent.mkdir()
@@ -869,6 +889,20 @@ def test_operator_init_merges_existing_handoff_source_coverage(tmp_path, capsys)
     assert sources["custom"] == {"keep": True}
     assert sources["sources"][0]["inboxes"] == [".codex/memory-handoffs", ".grok/memory-handoffs"]
     assert sources["sources"][1] == {"root": "../shared", "inboxes": ["team/handoffs"]}
+
+    assert (
+        operator_cmd.init(
+            target=tmp_path,
+            handoff_inboxes=[".grok/memory-handoffs"],
+            json_output=True,
+        )
+        == 0
+    )
+    rerun = json.loads(capsys.readouterr().out)
+    rerun_sources = next(row for row in rerun["results"] if row["id"] == "handoff-sources")
+    assert rerun_sources["status"] == "skipped"
+    assert rerun_sources["reason"] == "source coverage already current"
+    assert rerun["written_count"] == 0
 
 
 def test_operator_internal_dogfood_init_and_status(tmp_path, capsys, monkeypatch):

--- a/tests/test_operator_cmd.py
+++ b/tests/test_operator_cmd.py
@@ -837,6 +837,40 @@ def test_operator_init_dry_run_does_not_write(tmp_path, capsys):
     assert not (tmp_path / ".brigade" / "daily.toml").exists()
 
 
+def test_operator_init_merges_existing_handoff_source_coverage(tmp_path, capsys):
+    path = tmp_path / ".brigade" / "handoff-sources.json"
+    path.parent.mkdir()
+    path.write_text(
+        json.dumps(
+            {
+                "custom": {"keep": True},
+                "sources": [
+                    {"root": ".", "inboxes": [".codex/memory-handoffs"]},
+                    {"root": "../shared", "inboxes": ["team/handoffs"]},
+                ],
+            }
+        )
+        + "\n"
+    )
+
+    assert (
+        operator_cmd.init(
+            target=tmp_path,
+            handoff_inboxes=[".grok/memory-handoffs"],
+            json_output=True,
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    sources_step = next(row for row in payload["results"] if row["id"] == "handoff-sources")
+    sources = json.loads(path.read_text())
+
+    assert sources_step["status"] == "written"
+    assert sources["custom"] == {"keep": True}
+    assert sources["sources"][0]["inboxes"] == [".codex/memory-handoffs", ".grok/memory-handoffs"]
+    assert sources["sources"][1] == {"root": "../shared", "inboxes": ["team/handoffs"]}
+
+
 def test_operator_internal_dogfood_init_and_status(tmp_path, capsys, monkeypatch):
     monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
     monkeypatch.setattr(
@@ -1102,6 +1136,17 @@ def test_operator_verify_harness_hermes_after_handoff_init_and_draft(tmp_path, c
         row["name"] == "hermes_adapter_workspace_handoff_inbox" and row["status"] == "ok" for row in payload["checks"]
     )
     assert any(row["name"] == "handoff_lint" and row["status"] == "ok" for row in payload["checks"])
+
+
+def test_operator_verify_harness_recommends_additive_source_init(tmp_path, capsys):
+    assert cli.main(["init", "--target", str(tmp_path), "--depth", "repo", "--harnesses", "grok"]) == 0
+    capsys.readouterr()
+
+    assert operator_cmd.verify_harness(target=tmp_path, harness="grok", json_output=True) == 1
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["handoff_inbox"]["watched"] is False
+    assert payload["next_command"] == "brigade handoff sources init --target ."
 
 
 def test_operator_verify_harness_hermes_fails_broken_adapter_inbox(tmp_path, capsys):

--- a/tests/test_repos_cmd.py
+++ b/tests/test_repos_cmd.py
@@ -501,3 +501,34 @@ def test_repo_summary_counts_cursor_inbox(tmp_path):
     entry = repos_cmd.RepoEntry(repo_id="r1", label="R1", path=tmp_path)
     summary = repos_cmd._repo_summary(entry)
     assert ".cursor/memory-handoffs" in summary["handoff_inboxes"]
+
+
+def test_repo_summary_reports_selected_grok_inbox_missing(tmp_path):
+    _write_brigade_config(tmp_path, harnesses=("grok",), owner="grok")
+    entry = repos_cmd.RepoEntry(repo_id="r1", label="R1", path=tmp_path)
+
+    summary = repos_cmd._repo_summary(entry)
+    checks = repos_cmd.fleet._repo_checks(summary)
+
+    assert summary["handoff_inboxes_expected"] == [".grok/memory-handoffs"]
+    assert summary["handoff_inboxes_missing"] == [".grok/memory-handoffs"]
+    assert summary["handoff_inboxes_unwatched"] == []
+    assert [check["name"] for check in checks].count("repo_handoff_inbox_missing") == 1
+    assert not any(check["name"] == "repo_missing_handoff_inbox" for check in checks)
+
+
+def test_repo_summary_reports_selected_grok_inbox_unwatched(tmp_path):
+    _write_brigade_config(tmp_path, harnesses=("grok",), owner="grok")
+    (tmp_path / ".grok" / "memory-handoffs").mkdir(parents=True)
+    (tmp_path / ".brigade" / "handoff-sources.json").write_text(
+        json.dumps({"sources": [{"root": ".", "inboxes": [".codex/memory-handoffs"]}]}) + "\n"
+    )
+    entry = repos_cmd.RepoEntry(repo_id="r1", label="R1", path=tmp_path)
+
+    summary = repos_cmd._repo_summary(entry)
+    checks = repos_cmd.fleet._repo_checks(summary)
+
+    assert summary["handoff_inboxes_expected"] == [".grok/memory-handoffs"]
+    assert summary["handoff_inboxes_missing"] == []
+    assert summary["handoff_inboxes_unwatched"] == [".grok/memory-handoffs"]
+    assert [check["name"] for check in checks].count("repo_handoff_inbox_unwatched") == 1


### PR DESCRIPTION
## Summary

- Add Grok to the shipped handoff source example and enforce the shared harness registry in tests.
- Merge selected writer inboxes into existing source configs while preserving custom keys and remote sources.
- Report selected missing or unwatched inboxes in fleet scans, and align operator setup, dry-run output, and remediation with the additive behavior.

## Verification

- `./scripts/verify`: 2,489 passed, 3 skipped, 81.52% coverage.
- Exact-head Brigade receipt: `20260717-012949-work-verify-56e7ef`.
- Final independent exact-head review: CLEAN at `427d06cfcaa66edd5a143a5935eb3ae0ed8ecc7c`.

Closes #259
