### PR TITLE
test(claude): cover rewritten verification closeout

### DIFF
--- a/tests/test_claude_hooks_runtime.py
+++ b/tests/test_claude_hooks_runtime.py
@@ -9,6 +9,8 @@ import sys
 from datetime import timedelta
 from pathlib import Path
 
+import pytest
+
 from brigade import cli, localio
 from brigade.claude_hooks import runtime
 from brigade.install import install_selection
@@ -663,9 +665,10 @@ def test_stop_accepts_failed_or_rejected_routed_receipt_and_nudges_handoff(tmp_p
     assert "Memory Handoff" in result["hookSpecificOutput"]["additionalContext"]
 
 
-def test_stop_accepts_session_receipt_after_wrapped_verify_posttooluse(tmp_path: Path, monkeypatch):
+@pytest.mark.parametrize("wrapper", ["tokenjuice", "token-glace"])
+def test_stop_accepts_session_receipt_after_wrapped_verify_posttooluse(tmp_path: Path, monkeypatch, wrapper: str):
     target = _wired_claude(tmp_path)
-    session_id = "wrapped-verify"
+    session_id = f"wrapped-verify-{wrapper}"
     monkeypatch.setattr(runtime, "_run_brief", lambda repo: "brief")
     runtime.handle_payload("SessionStart", _payload(target, "SessionStart", session_id=session_id))
     runtime.handle_payload(
@@ -679,6 +682,17 @@ def test_stop_accepts_session_receipt_after_wrapped_verify_posttooluse(tmp_path:
         ),
     )
     state = runtime.read_session_state(target, session_id)
+    original = 'brigade work verify run --target . --command "true" --capture brigade-work'
+    pretool = _payload(
+        target,
+        "PreToolUse",
+        session_id=session_id,
+        tool_name="Bash",
+        tool_input={"command": original},
+    )
+    assert runtime.handle_payload("PreToolUse", pretool) is None
+    assert runtime.read_session_state(target, session_id)["pending_bash_fingerprint"]
+
     run_dir = target / ".brigade" / "work" / "verify-runs" / "wrapped-run"
     run_dir.mkdir(parents=True)
     (run_dir / "receipt.json").write_text(
@@ -696,10 +710,7 @@ def test_stop_accepts_session_receipt_after_wrapped_verify_posttooluse(tmp_path:
         + "\n"
     )
 
-    wrapped = (
-        "tokenjuice wrap --source claude-code -- /bin/bash -lc "
-        "'brigade work verify run --target . --command true --capture brigade-work'"
-    )
+    wrapped = f"{wrapper} wrap --source claude-code -- /bin/bash -lc {shlex.quote(original)}"
     runtime.handle_payload(
         "PostToolUse",
         _payload(
@@ -710,6 +721,9 @@ def test_stop_accepts_session_receipt_after_wrapped_verify_posttooluse(tmp_path:
             tool_input={"command": wrapped},
         ),
     )
+    posttool_state = runtime.read_session_state(target, session_id)
+    assert posttool_state["last_write_at"] == state["last_write_at"]
+    assert "pending_bash_fingerprint" not in posttool_state
 
     result = runtime.handle_payload("Stop", _payload(target, "Stop", session_id=session_id, stop_hook_active=False))
     assert "decision" not in result

--- a/tests/test_claude_hooks_runtime.py
+++ b/tests/test_claude_hooks_runtime.py
@@ -663,6 +663,59 @@ def test_stop_accepts_failed_or_rejected_routed_receipt_and_nudges_handoff(tmp_p
     assert "Memory Handoff" in result["hookSpecificOutput"]["additionalContext"]
 
 
+def test_stop_accepts_session_receipt_after_wrapped_verify_posttooluse(tmp_path: Path, monkeypatch):
+    target = _wired_claude(tmp_path)
+    session_id = "wrapped-verify"
+    monkeypatch.setattr(runtime, "_run_brief", lambda repo: "brief")
+    runtime.handle_payload("SessionStart", _payload(target, "SessionStart", session_id=session_id))
+    runtime.handle_payload(
+        "PostToolUse",
+        _payload(
+            target,
+            "PostToolUse",
+            session_id=session_id,
+            tool_name="Write",
+            tool_input={"file_path": str(target / "file.py")},
+        ),
+    )
+    state = runtime.read_session_state(target, session_id)
+    run_dir = target / ".brigade" / "work" / "verify-runs" / "wrapped-run"
+    run_dir.mkdir(parents=True)
+    (run_dir / "receipt.json").write_text(
+        json.dumps(
+            {
+                "run_id": "wrapped-run",
+                "status": "completed",
+                "started_at": state["last_write_at"],
+                "harness_session": {
+                    "harness": "claude",
+                    "fingerprint": state["session_fingerprint"],
+                },
+            }
+        )
+        + "\n"
+    )
+
+    wrapped = (
+        "tokenjuice wrap --source claude-code -- /bin/bash -lc "
+        "'brigade work verify run --target . --command true --capture brigade-work'"
+    )
+    runtime.handle_payload(
+        "PostToolUse",
+        _payload(
+            target,
+            "PostToolUse",
+            session_id=session_id,
+            tool_name="Bash",
+            tool_input={"command": wrapped},
+        ),
+    )
+
+    result = runtime.handle_payload("Stop", _payload(target, "Stop", session_id=session_id, stop_hook_active=False))
+    assert "decision" not in result
+    assert "Memory Handoff" in result["hookSpecificOutput"]["additionalContext"]
+
+
 def test_stop_rejects_receipt_created_before_later_write(tmp_path: Path):
     target = _wired_claude(tmp_path)
     now = localio.utc_now()


### PR DESCRIPTION
## Summary

- Reproduce Claude Code's original PreToolUse command followed by tokenjuice or token-glace rewriting at PostToolUse.
- Confirm the session-scoped Brigade receipt allows Stop closeout without parsing the rewritten command.
- Assert the wrapped verification does not advance write state and clears the pending Bash fingerprint.

PR #285 removed the command-text-dependent closeout state that caused issue #263. This test locks in the receipt-based behavior for both wrapper names captured by the issue.

## Verification

- `./scripts/verify`: 2,491 passed, 3 skipped, 81.50% coverage.
- Exact-head Brigade receipt: `20260717-014652-work-verify-aa8904`.
- Independent exact-head review: CLEAN at `22d52002759ed1587f0b92fa99fe81a72613b228`.

Closes #263
