### PR TITLE
fix: reject non-final brigade run output

### DIFF
--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -1752,12 +1752,8 @@ def run(
                 (attempt for attempt in reversed(plan_attempts or []) if attempt.get("ok") is False),
                 None,
             )
-            failure_phase = (
-                failed_attempt.get("failure_phase") if isinstance(failed_attempt, dict) else None
-            )
-            failure_kind = (
-                failed_attempt.get("failure_kind") if isinstance(failed_attempt, dict) else None
-            )
+            failure_phase = failed_attempt.get("failure_phase") if isinstance(failed_attempt, dict) else None
+            failure_kind = failed_attempt.get("failure_kind") if isinstance(failed_attempt, dict) else None
             if output_dir is not None:
                 finished_at = datetime.now(timezone.utc)
                 _write_json(output_dir / "plan-attempts.json", {"attempts": plan_attempts or []})

--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -642,6 +642,10 @@ def _record_plan_attempt(
         "detail": result.detail,
         "text": result.text,
     }
+    if result.failure_phase is not None:
+        payload["failure_phase"] = result.failure_phase
+    if result.failure_kind is not None:
+        payload["failure_kind"] = result.failure_kind
     if parse_error is not None:
         payload["parse_error"] = parse_error
     if coverage_missing:
@@ -1744,6 +1748,16 @@ def run(
                 route=route,
             )
         except RuntimeError as exc:
+            failed_attempt = next(
+                (attempt for attempt in reversed(plan_attempts or []) if attempt.get("ok") is False),
+                None,
+            )
+            failure_phase = (
+                failed_attempt.get("failure_phase") if isinstance(failed_attempt, dict) else None
+            )
+            failure_kind = (
+                failed_attempt.get("failure_kind") if isinstance(failed_attempt, dict) else None
+            )
             if output_dir is not None:
                 finished_at = datetime.now(timezone.utc)
                 _write_json(output_dir / "plan-attempts.json", {"attempts": plan_attempts or []})
@@ -1760,6 +1774,8 @@ def run(
                         finished_at=finished_at,
                         output_dir=output_dir,
                         error=str(exc),
+                        failure_phase=(failure_phase if isinstance(failure_phase, str) else None),
+                        failure_kind=(failure_kind if isinstance(failure_kind, str) else None),
                         code_graph=code_graph,
                         drift_impact=drift_impact,
                         evidence=evidence,

--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -1493,6 +1493,8 @@ def _run_payload(
     output_dir: Path | None = None,
     handoff_path: Path | None = None,
     error: str | None = None,
+    failure_phase: str | None = None,
+    failure_kind: str | None = None,
     code_graph: CodeGraphBrief | None = None,
     drift_impact: DriftImpactBrief | None = None,
     evidence: EvidenceBrief | None = None,
@@ -1555,6 +1557,13 @@ def _run_payload(
         payload["handoff"] = str(handoff_path)
     if error is not None:
         payload["error"] = error
+        if failure_phase is not None or failure_kind is not None:
+            payload["failure_phase"] = failure_phase or "unknown"
+            payload["failure"] = {
+                "phase": failure_phase or "unknown",
+                "kind": failure_kind or "unknown",
+                "detail": error,
+            }
     if codex_transport is not None:
         payload["codex_transport"] = codex_transport
     if control_socket is not None:
@@ -2022,6 +2031,8 @@ def run(
                     finished_at=finished_at,
                     output_dir=output_dir,
                     error=final.detail,
+                    failure_phase=final.failure_phase,
+                    failure_kind=final.failure_kind,
                     code_graph=code_graph,
                     drift_impact=drift_impact,
                     evidence=evidence,

--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -22,6 +22,7 @@ from . import graphtrail_delta
 from . import localio
 from . import proc, runguard
 from . import run_control
+from .result_integrity import validate_final_output
 from .run_receipts import (
     agent_result_from_worker as _agent_result_from_worker,
     agent_result_payload as _agent_result_payload,
@@ -966,6 +967,20 @@ def _run_codex_appserver_worker(
             text="",
             ok=False,
             detail="empty output",
+            thread_id=turn.thread_id,
+            status=turn.status,
+            transport="codex-app-server",
+            requested_model=agent.model,
+            reasoning=agent.reasoning,
+        )
+    output_failure = validate_final_output(text)
+    if output_failure is not None:
+        return agents.AgentResult(
+            text=text,
+            ok=False,
+            detail=output_failure.detail,
+            failure_phase="output-validation",
+            failure_kind=output_failure.kind,
             thread_id=turn.thread_id,
             status=turn.status,
             transport="codex-app-server",

--- a/src/brigade/acpx_adapter.py
+++ b/src/brigade/acpx_adapter.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from . import proc
 from .agents import AgentResult
+from .result_integrity import validate_final_output
 
 SUPPORTED_VERSION = "0.12.0"
 
@@ -229,6 +230,27 @@ def run_cursor(
             transport="acpx",
             requested_model=model,
             acpx_version=installed,
+        )
+    output_failure = validate_final_output(parsed["text"])
+    if output_failure is not None:
+        return AgentResult(
+            text=parsed["text"],
+            ok=False,
+            detail=output_failure.detail,
+            failure_phase="output-validation",
+            failure_kind=output_failure.kind,
+            stdout=result.stdout,
+            stderr=result.stderr,
+            exit_code=result.code,
+            transport="acpx",
+            requested_model=model,
+            effective_model=parsed["effective_model"],
+            stop_reason=parsed["stop_reason"],
+            protocol_version=parsed["protocol_version"],
+            session_id=parsed["session_id"],
+            request_id=parsed["request_id"],
+            acpx_version=installed,
+            safe_events=tuple(parsed["events"]),
         )
     return AgentResult(
         text=parsed["text"],

--- a/src/brigade/acpx_adapter.py
+++ b/src/brigade/acpx_adapter.py
@@ -110,6 +110,7 @@ def parse_stream(stdout: str) -> tuple[dict[str, Any] | None, str]:
     session_id: str | None = None
     request_id: str | None = None
     stop_reason: str | None = None
+    stop_reasons: dict[str, str] = {}
     effective_model: str | None = None
     safe_events: list[dict[str, Any]] = []
     for message in messages:
@@ -119,10 +120,8 @@ def parse_stream(stdout: str) -> tuple[dict[str, Any] | None, str]:
             if isinstance(version, int):
                 protocol_version = version
             stop = result.get("stopReason")
-            if isinstance(stop, str):
-                stop_reason = stop
-                if isinstance(message.get("id"), (str, int)):
-                    request_id = str(message["id"])
+            if isinstance(stop, str) and isinstance(message.get("id"), (str, int)):
+                stop_reasons[str(message["id"])] = stop
         params = message.get("params")
         if isinstance(params, dict):
             candidate_session = params.get("sessionId")
@@ -144,6 +143,10 @@ def parse_stream(stdout: str) -> tuple[dict[str, Any] | None, str]:
             content = update.get("content")
             if isinstance(content, dict) and content.get("type") == "text" and isinstance(content.get("text"), str):
                 text_parts.append(content["text"])
+    if request_id is not None:
+        stop_reason = stop_reasons.get(request_id)
+    elif len(stop_reasons) == 1:
+        request_id, stop_reason = next(iter(stop_reasons.items()))
     if protocol_version not in (None, 1):
         return None, f"unsupported ACP protocol version: {protocol_version}"
     text = "".join(text_parts).strip()

--- a/src/brigade/acpx_adapter.py
+++ b/src/brigade/acpx_adapter.py
@@ -231,6 +231,27 @@ def run_cursor(
             requested_model=model,
             acpx_version=installed,
         )
+    if parsed["stop_reason"] != "end_turn":
+        stop_reason = parsed["stop_reason"] or "missing"
+        return AgentResult(
+            text=parsed["text"],
+            ok=False,
+            detail=f"ACP stream ended without a final completion (stopReason={stop_reason})",
+            failure_phase="output-validation",
+            failure_kind="non-final-stop",
+            stdout=result.stdout,
+            stderr=result.stderr,
+            exit_code=result.code,
+            transport="acpx",
+            requested_model=model,
+            effective_model=parsed["effective_model"],
+            stop_reason=parsed["stop_reason"],
+            protocol_version=parsed["protocol_version"],
+            session_id=parsed["session_id"],
+            request_id=parsed["request_id"],
+            acpx_version=installed,
+            safe_events=tuple(parsed["events"]),
+        )
     output_failure = validate_final_output(parsed["text"])
     if output_failure is not None:
         return AgentResult(

--- a/src/brigade/agents.py
+++ b/src/brigade/agents.py
@@ -545,6 +545,8 @@ def run_agent(
             text=text,
             ok=False,
             detail=structured_error,
+            failure_phase="output-validation",
+            failure_kind="malformed-final-output",
             stdout=result.stdout,
             stderr=result.stderr,
             exit_code=result.code,

--- a/src/brigade/agents.py
+++ b/src/brigade/agents.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Callable, List
 
 from . import proc
+from .result_integrity import validate_final_output
 
 _OLLAMA_PREFIX = "ollama:"
 _CODEX_CLOUD_PREFIX = "codex-cloud:"
@@ -297,6 +298,8 @@ class AgentResult:
     request_id: str | None = None
     acpx_version: str | None = None
     safe_events: tuple[dict[str, object], ...] = ()
+    failure_phase: str | None = None
+    failure_kind: str | None = None
 
 
 def is_known(cli_ref: str) -> bool:
@@ -564,6 +567,20 @@ def run_agent(
             requested_model=model,
             reasoning=reasoning,
         )
+    output_failure = validate_final_output(text)
+    if output_failure is not None:
+        return AgentResult(
+            text=text,
+            ok=False,
+            detail=output_failure.detail,
+            failure_phase="output-validation",
+            failure_kind=output_failure.kind,
+            stdout=result.stdout,
+            stderr=result.stderr,
+            exit_code=result.code,
+            requested_model=model,
+            reasoning=reasoning,
+        )
     return AgentResult(
         text=text,
         ok=True,
@@ -627,6 +644,20 @@ def run_codex_appserver(
             text="",
             ok=False,
             detail="empty output",
+            thread_id=turn.thread_id,
+            status=turn.status,
+            transport="codex-app-server",
+            requested_model=model,
+            reasoning=reasoning,
+        )
+    output_failure = validate_final_output(text)
+    if output_failure is not None:
+        return AgentResult(
+            text=text,
+            ok=False,
+            detail=output_failure.detail,
+            failure_phase="output-validation",
+            failure_kind=output_failure.kind,
             thread_id=turn.thread_id,
             status=turn.status,
             transport="codex-app-server",

--- a/src/brigade/result_integrity.py
+++ b/src/brigade/result_integrity.py
@@ -51,11 +51,18 @@ _OPERATIONAL_ERRORS = (
 )
 _CLAUSE_SPLIT = re.compile(r"(?:\r?\n)+|(?<=[.!?])\s+")
 _FUTURE_INTENT = re.compile(
-    r"\A\s*(?:i\s+(?:will|shall|need to|plan to|am going to)|i['’]ll|let me)\b",
+    r"\A\s*(?:(?:first|next|now)\s*,?\s*)?"
+    r"(?:i\s+(?:will|shall|need to|plan to|am going to)|i['’](?:ll|m going to)|let me)\b",
     re.IGNORECASE,
 )
 _PROGRESS_ACTION = re.compile(
     r"\A\s*(?:reviewing|gathering|inspecting|reading|checking|searching|running|locating|"
+    r"listing|opening|looking|finding|examining|analyzing|exploring|tracing|investigating)\b",
+    re.IGNORECASE,
+)
+_ONGOING_PROGRESS = re.compile(
+    r"\A\s*(?:(?:first|next|now)\s*,?\s*)?i(?:\s+am|['’]m)\s+"
+    r"(?:reviewing|gathering|inspecting|reading|checking|searching|running|locating|"
     r"listing|opening|looking|finding|examining|analyzing|exploring|tracing|investigating)\b",
     re.IGNORECASE,
 )
@@ -97,6 +104,8 @@ def _contains_tool_marker(value: object) -> bool:
 
 def _contains_final_text(value: object) -> bool:
     if isinstance(value, dict):
+        if any(str(key).lower() in _TOOL_KEYS for key in value):
+            return False
         role = value.get("role")
         event_type = value.get("type")
         if isinstance(role, str) and role.lower() in {"function", "tool"}:
@@ -146,7 +155,7 @@ def _progress_only(text: str) -> bool:
         return False
     explicit_progress = False
     for clause in clauses:
-        if _FUTURE_INTENT.match(clause):
+        if _FUTURE_INTENT.match(clause) or _ONGOING_PROGRESS.match(clause):
             explicit_progress = True
             continue
         if _PROGRESS_ACTION.match(clause):
@@ -156,6 +165,7 @@ def _progress_only(text: str) -> bool:
                 tail = clause.split(":", 1)[1].strip()
                 tail_is_progress = bool(
                     _FUTURE_INTENT.match(tail)
+                    or _ONGOING_PROGRESS.match(tail)
                     or _PROGRESS_ACTION.match(tail)
                     or re.match(r"(?:first|next|now)\b", tail, re.IGNORECASE)
                 )

--- a/src/brigade/result_integrity.py
+++ b/src/brigade/result_integrity.py
@@ -91,9 +91,17 @@ def _contains_tool_marker(value: object) -> bool:
         if any(str(key).lower() in _TOOL_KEYS for key in value):
             return True
         event_type = value.get("type")
-        if isinstance(event_type, str) and event_type.lower() in _TOOL_KEYS:
-            return True
+        if isinstance(event_type, str):
+            normalized_type = event_type.lower()
+            if (
+                normalized_type in _TOOL_KEYS
+                or normalized_type in _TOOL_RESULT_TYPES
+                or normalized_type.endswith("_call_output")
+            ):
+                return True
         normalized_keys = {str(key).lower() for key in value}
+        if "call_id" in normalized_keys and "output" in normalized_keys:
+            return True
         if "arguments" in normalized_keys and normalized_keys & {"function", "name"}:
             return True
         return any(_contains_tool_marker(item) for item in value.values())

--- a/src/brigade/result_integrity.py
+++ b/src/brigade/result_integrity.py
@@ -59,7 +59,11 @@ _PROGRESS_ACTION = re.compile(
     r"listing|opening|looking|finding|examining|analyzing|exploring|tracing|investigating)\b",
     re.IGNORECASE,
 )
-_PROGRESS_MARKER = re.compile(r"\b(?:first|next|now|before (?:i|we)|to begin|starting with)\b", re.IGNORECASE)
+_OUTCOME_MARKER = re.compile(
+    r"\b(?:found|identified|shows?|reveals?|completed|fixed|changed|"
+    r"no (?:actionable )?(?:issues|findings|changes))\b",
+    re.IGNORECASE,
+)
 _FINAL_TEXT_KEYS = frozenset({"answer", "content", "final", "final_answer", "output", "response", "text"})
 _TOOL_KEYS = frozenset(
     {
@@ -136,7 +140,18 @@ def _progress_only(text: str) -> bool:
             explicit_progress = True
             continue
         if _PROGRESS_ACTION.match(clause):
-            explicit_progress = explicit_progress or bool(_PROGRESS_MARKER.search(clause))
+            if _OUTCOME_MARKER.search(clause):
+                return False
+            if ":" in clause:
+                tail = clause.split(":", 1)[1].strip()
+                tail_is_progress = bool(
+                    _FUTURE_INTENT.match(tail)
+                    or _PROGRESS_ACTION.match(tail)
+                    or re.match(r"(?:first|next|now)\b", tail, re.IGNORECASE)
+                )
+                if tail and not tail_is_progress:
+                    return False
+            explicit_progress = True
             continue
         return False
     return explicit_progress

--- a/src/brigade/result_integrity.py
+++ b/src/brigade/result_integrity.py
@@ -1,0 +1,181 @@
+"""Conservative validation for provider output presented as a final result."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class OutputFailure:
+    kind: str
+    detail: str
+
+
+_PROVIDER_ERROR = re.compile(
+    r"^\s*error:\s*nonretriableerror:\s*provider error\b",
+    re.IGNORECASE | re.MULTILINE,
+)
+_OPERATIONAL_ERRORS = (
+    (
+        "authentication-error",
+        re.compile(
+            r"^\s*error:.*\b(?:authentication (?:required|failed|failure)|not authenticated|"
+            r"unauthorized|invalid (?:api )?key)\b",
+            re.IGNORECASE | re.MULTILINE,
+        ),
+    ),
+    (
+        "rate-limit-error",
+        re.compile(
+            r"^\s*error:.*\b(?:rate limit(?:ed| exceeded)?|quota exceeded)\b",
+            re.IGNORECASE | re.MULTILINE,
+        ),
+    ),
+    (
+        "provider-setting-error",
+        re.compile(
+            r"^\s*error:.*\b(?:unknown model|invalid model|model [^\n]+ (?:is )?not (?:available|found))\b",
+            re.IGNORECASE | re.MULTILINE,
+        ),
+    ),
+    (
+        "network-error",
+        re.compile(
+            r"^\s*error:.*\b(?:failed to connect|unable to connect|network error|"
+            r"connection (?:refused|failed))\b",
+            re.IGNORECASE | re.MULTILINE,
+        ),
+    ),
+)
+_CLAUSE_SPLIT = re.compile(r"(?:\r?\n)+|(?<=[.!?])\s+")
+_FUTURE_INTENT = re.compile(
+    r"\A\s*(?:i\s+(?:will|shall|need to|plan to|am going to)|i['’]ll|let me)\b",
+    re.IGNORECASE,
+)
+_PROGRESS_ACTION = re.compile(
+    r"\A\s*(?:reviewing|gathering|inspecting|reading|checking|searching|running|locating|"
+    r"listing|opening|looking|finding|examining|analyzing|exploring|tracing|investigating)\b",
+    re.IGNORECASE,
+)
+_PROGRESS_MARKER = re.compile(r"\b(?:first|next|now|before (?:i|we)|to begin|starting with)\b", re.IGNORECASE)
+_FINAL_TEXT_KEYS = frozenset({"answer", "content", "final", "final_answer", "output", "response", "text"})
+_TOOL_KEYS = frozenset(
+    {
+        "function_call",
+        "function_calls",
+        "tool_call",
+        "tool_calls",
+        "tool_use",
+        "tool_uses",
+    }
+)
+
+
+def _contains_tool_marker(value: object) -> bool:
+    if isinstance(value, dict):
+        if any(str(key).lower() in _TOOL_KEYS for key in value):
+            return True
+        event_type = value.get("type")
+        if isinstance(event_type, str) and event_type.lower() in _TOOL_KEYS:
+            return True
+        normalized_keys = {str(key).lower() for key in value}
+        if "arguments" in normalized_keys and normalized_keys & {"function", "name"}:
+            return True
+        return any(_contains_tool_marker(item) for item in value.values())
+    if isinstance(value, list):
+        return any(_contains_tool_marker(item) for item in value)
+    return False
+
+
+def _contains_final_text(value: object) -> bool:
+    if isinstance(value, dict):
+        event_type = value.get("type")
+        if isinstance(event_type, str) and event_type.lower() in _TOOL_KEYS:
+            return False
+        normalized_keys = {str(key).lower() for key in value}
+        if "arguments" in normalized_keys and normalized_keys & {"function", "name"}:
+            return False
+        for key, item in value.items():
+            normalized_key = str(key).lower()
+            if normalized_key in _TOOL_KEYS:
+                continue
+            if normalized_key in _FINAL_TEXT_KEYS and isinstance(item, str) and item.strip():
+                return True
+            if _contains_final_text(item):
+                return True
+    elif isinstance(value, list):
+        return any(_contains_final_text(item) for item in value)
+    return False
+
+
+def _tool_only(text: str) -> bool:
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        payload = None
+    if payload is not None and _contains_tool_marker(payload) and not _contains_final_text(payload):
+        return True
+    return bool(
+        re.fullmatch(
+            r"\s*<(?P<tag>tool_call|function_call)>[\s\S]*</(?P=tag)>\s*",
+            text,
+            re.IGNORECASE,
+        )
+    )
+
+
+def _progress_only(text: str) -> bool:
+    clauses = [clause.strip() for clause in _CLAUSE_SPLIT.split(text) if clause.strip()]
+    if not clauses:
+        return False
+    explicit_progress = False
+    for clause in clauses:
+        if _FUTURE_INTENT.match(clause):
+            explicit_progress = True
+            continue
+        if _PROGRESS_ACTION.match(clause):
+            explicit_progress = explicit_progress or bool(_PROGRESS_MARKER.search(clause))
+            continue
+        return False
+    return explicit_progress
+
+
+def validate_final_output(text: str) -> OutputFailure | None:
+    """Return a typed failure only for deterministic non-final output shapes."""
+    stripped = text.strip()
+    if not stripped:
+        return OutputFailure("empty-output", "provider returned no final result")
+    if "```" not in stripped:
+        provider_error = _PROVIDER_ERROR.search(stripped)
+        if provider_error is not None:
+            prefix = stripped[: provider_error.start()].strip()
+            if not prefix or _progress_only(prefix):
+                diagnostic = stripped[provider_error.start() :].strip()
+                return OutputFailure(
+                    "provider-error",
+                    f"provider returned an error instead of a final result: {diagnostic}"[:200],
+                )
+        for kind, pattern in _OPERATIONAL_ERRORS:
+            operational_error = pattern.search(stripped)
+            if operational_error is None:
+                continue
+            prefix = stripped[: operational_error.start()].strip()
+            if not prefix or _progress_only(prefix):
+                diagnostic = stripped[operational_error.start() :].strip()
+                return OutputFailure(
+                    kind,
+                    f"provider returned an operational error instead of a final result: {diagnostic}"[:200],
+                )
+    if _tool_only(stripped):
+        return OutputFailure(
+            "tool-only-output",
+            "provider returned tool-call data without a final result",
+        )
+    if _progress_only(stripped):
+        return OutputFailure(
+            "non-final-output",
+            "provider returned progress or intent without a final result",
+        )
+    return None

--- a/src/brigade/result_integrity.py
+++ b/src/brigade/result_integrity.py
@@ -110,7 +110,11 @@ def _contains_final_text(value: object) -> bool:
         event_type = value.get("type")
         if isinstance(role, str) and role.lower() in {"function", "tool"}:
             return False
-        if isinstance(event_type, str) and event_type.lower() in _TOOL_RESULT_TYPES:
+        if isinstance(event_type, str):
+            normalized_type = event_type.lower()
+            if normalized_type in _TOOL_RESULT_TYPES or normalized_type.endswith("_call_output"):
+                return False
+        if "call_id" in value and "output" in value:
             return False
         if isinstance(event_type, str) and event_type.lower() in _TOOL_KEYS:
             return False

--- a/src/brigade/result_integrity.py
+++ b/src/brigade/result_integrity.py
@@ -60,7 +60,7 @@ _PROGRESS_ACTION = re.compile(
     re.IGNORECASE,
 )
 _OUTCOME_MARKER = re.compile(
-    r"\b(?:found|identified|shows?|reveals?|completed|fixed|changed|"
+    r"\b(?:found|identified|shows?|reveals?|"
     r"no (?:actionable )?(?:issues|findings|changes))\b",
     re.IGNORECASE,
 )
@@ -123,7 +123,7 @@ def _tool_only(text: str) -> bool:
         return True
     return bool(
         re.fullmatch(
-            r"\s*<(?P<tag>tool_call|function_call)>[\s\S]*</(?P=tag)>\s*",
+            r"\s*<(?P<tag>tool_call|function_call|tool_use)>[\s\S]*</(?P=tag)>\s*",
             text,
             re.IGNORECASE,
         )

--- a/src/brigade/result_integrity.py
+++ b/src/brigade/result_integrity.py
@@ -61,7 +61,8 @@ _PROGRESS_ACTION = re.compile(
 )
 _OUTCOME_MARKER = re.compile(
     r"\b(?:found|identified|shows?|reveals?|"
-    r"no (?:actionable )?(?:issues|findings|changes))\b",
+    r"no (?:actionable )?(?:issues|findings|changes|regressions)|"
+    r"(?:tests?|checks?) passed|(?:do not|don['’]t) see)\b",
     re.IGNORECASE,
 )
 _FINAL_TEXT_KEYS = frozenset({"answer", "content", "final", "final_answer", "output", "response", "text"})
@@ -75,6 +76,7 @@ _TOOL_KEYS = frozenset(
         "tool_uses",
     }
 )
+_TOOL_RESULT_TYPES = frozenset({"function_result", "tool_result", "tool_response"})
 
 
 def _contains_tool_marker(value: object) -> bool:
@@ -95,7 +97,12 @@ def _contains_tool_marker(value: object) -> bool:
 
 def _contains_final_text(value: object) -> bool:
     if isinstance(value, dict):
+        role = value.get("role")
         event_type = value.get("type")
+        if isinstance(role, str) and role.lower() in {"function", "tool"}:
+            return False
+        if isinstance(event_type, str) and event_type.lower() in _TOOL_RESULT_TYPES:
+            return False
         if isinstance(event_type, str) and event_type.lower() in _TOOL_KEYS:
             return False
         normalized_keys = {str(key).lower() for key in value}

--- a/src/brigade/result_integrity.py
+++ b/src/brigade/result_integrity.py
@@ -123,7 +123,10 @@ def _tool_only(text: str) -> bool:
         return True
     return bool(
         re.fullmatch(
-            r"\s*<(?P<tag>tool_call|function_call|tool_use)>[\s\S]*</(?P=tag)>\s*",
+            r"\s*(?:(?:"
+            r"<(?P<tag>tool_call|function_call|tool_use)\b[^>]*>[\s\S]*?</(?P=tag)>|"
+            r"<(?:tool_call|function_call|tool_use)\b[^>]*/>"
+            r")\s*)+",
             text,
             re.IGNORECASE,
         )

--- a/src/brigade/run_receipts.py
+++ b/src/brigade/run_receipts.py
@@ -34,6 +34,10 @@ def worker_payload(results: list[WorkerResult]) -> list[dict[str, object]]:
             "detail": result.detail,
             "text": result.text,
         }
+        if result.failure_phase is not None:
+            entry["failure_phase"] = result.failure_phase
+        if result.failure_kind is not None:
+            entry["failure_kind"] = result.failure_kind
         if result.thread_id is not None:
             entry["thread_id"] = result.thread_id
             entry["status"] = result.status
@@ -71,6 +75,10 @@ def agent_result_payload(result: agents.AgentResult) -> dict[str, object]:
         "detail": result.detail,
         "text": result.text,
     }
+    if result.failure_phase is not None:
+        payload["failure_phase"] = result.failure_phase
+    if result.failure_kind is not None:
+        payload["failure_kind"] = result.failure_kind
     if result.exit_code is not None:
         payload["exit_code"] = result.exit_code
         payload["timed_out"] = result.timed_out
@@ -103,6 +111,8 @@ def agent_result_from_worker(result: WorkerResult) -> agents.AgentResult:
         text=result.text,
         ok=result.ok,
         detail=result.detail,
+        failure_phase=result.failure_phase,
+        failure_kind=result.failure_kind,
         thread_id=result.thread_id,
         status=result.status,
         stdout=result.stdout,

--- a/src/brigade/run_transport.py
+++ b/src/brigade/run_transport.py
@@ -46,6 +46,8 @@ class WorkerResult:
     request_id: str | None = None
     acpx_version: str | None = None
     safe_events: tuple[dict[str, object], ...] = ()
+    failure_phase: str | None = None
+    failure_kind: str | None = None
 
 
 class PromptBuilder(Protocol):
@@ -243,6 +245,8 @@ def dispatch(
             text=result.text,
             ok=result.ok,
             detail=result.detail,
+            failure_phase=result.failure_phase,
+            failure_kind=result.failure_kind,
             thread_id=result.thread_id,
             status=result.status,
             stdout=result.stdout,

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -2215,6 +2215,37 @@ class _StubAppServer:
         return _StubAppServerThread(f"t-{len(self.started)}")
 
 
+class _IntentOnlyAppServer(_StubAppServer):
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+
+    def start(self):
+        return None
+
+    def close(self):
+        return None
+
+    def start_thread(self, *, cwd, model=None, sandbox=None):
+        from brigade import codex_appserver
+
+        self.started.append({"cwd": cwd, "model": model, "sandbox": sandbox})
+
+        class _Thread:
+            thread_id = "t-intent"
+
+            def run_turn(self, prompt, *, timeout, on_event=None, on_turn_start=None):
+                if on_turn_start is not None:
+                    on_turn_start("turn-intent")
+                return codex_appserver.TurnResult(
+                    text="I will inspect the repository first.",
+                    ok=True,
+                    status="complete",
+                    thread_id=self.thread_id,
+                )
+
+        return _Thread()
+
+
 def test_dispatch_routes_codex_through_appserver(monkeypatch, tmp_path):
     roster = _appserver_roster()
     server = _StubAppServer()
@@ -2236,6 +2267,32 @@ def test_dispatch_routes_codex_through_appserver(monkeypatch, tmp_path):
     events_file = tmp_path / "cook.jsonl"
     assert events_file.is_file()
     assert '"item/completed"' in events_file.read_text()
+
+
+def test_run_appserver_worker_rejects_non_final_output_in_receipts(monkeypatch, tmp_path):
+    monkeypatch.setattr(aboyeur.codex_appserver, "AppServer", _IntentOnlyAppServer)
+    output_dir = tmp_path / "run"
+
+    rc = aboyeur.run(
+        "review the repository",
+        _appserver_roster(),
+        worker="cook",
+        cwd=tmp_path,
+        output_dir=output_dir,
+        read_only=True,
+        route_enabled=False,
+    )
+
+    assert rc == 2
+    run_payload = json.loads((output_dir / "run.json").read_text())
+    assert run_payload["status"] == "failed"
+    assert run_payload["failure_phase"] == "output-validation"
+    assert run_payload["failure"]["kind"] == "non-final-output"
+    worker = json.loads((output_dir / "worker-results.json").read_text())["results"][0]
+    assert worker["ok"] is False
+    assert worker["transport"] == "codex-app-server"
+    assert worker["failure_phase"] == "output-validation"
+    assert worker["failure_kind"] == "non-final-output"
 
 
 def test_worker_payload_includes_thread_fields_only_for_appserver():

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -996,7 +996,14 @@ def test_run_direct_worker_skips_plan_and_synthesis(monkeypatch, capsys, tmp_pat
 
 def test_run_direct_worker_failure_reports_and_records(monkeypatch, capsys, tmp_path):
     def fake_run_agent(cli_ref, prompt, timeout=600.0, cwd=None, read_only=False):
-        return agents.AgentResult(text="partial output", ok=False, detail="boom")
+        return agents.AgentResult(
+            text="partial output",
+            ok=False,
+            detail="provider returned progress or intent without a final result",
+            exit_code=0,
+            failure_phase="output-validation",
+            failure_kind="non-final-output",
+        )
 
     output_dir = tmp_path / "run"
     monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
@@ -1013,9 +1020,22 @@ def test_run_direct_worker_failure_reports_and_records(monkeypatch, capsys, tmp_
     assert (output_dir / "final.txt").read_text().strip() == "partial output"
     run_payload = json.loads((output_dir / "run.json").read_text())
     assert run_payload["worker"] == "coder"
+    assert run_payload["status"] == "failed"
+    assert run_payload["failure_phase"] == "output-validation"
+    assert run_payload["failure"] == {
+        "phase": "output-validation",
+        "kind": "non-final-output",
+        "detail": "provider returned progress or intent without a final result",
+    }
     synthesis = json.loads((output_dir / "synthesis.json").read_text())
     assert synthesis["mode"] == "direct-worker"
     assert synthesis["result"]["ok"] is False
+    assert synthesis["result"]["failure_phase"] == "output-validation"
+    assert synthesis["result"]["failure_kind"] == "non-final-output"
+    worker = json.loads((output_dir / "worker-results.json").read_text())["results"][0]
+    assert worker["exit_code"] == 0
+    assert worker["failure_phase"] == "output-validation"
+    assert worker["failure_kind"] == "non-final-output"
 
 
 def test_run_direct_grok_progress_only_output_fails_with_honest_artifacts(monkeypatch, tmp_path):

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -2026,6 +2026,30 @@ def test_invalid_plan_writes_attempt_artifact(monkeypatch, tmp_path, capsys):
     assert not (output_dir / "plan.json").exists()
 
 
+def test_plan_output_validation_failure_preserves_typed_receipts(monkeypatch, tmp_path):
+    def fake_run_agent(cli_ref, prompt, timeout=600.0, cwd=None, read_only=False):
+        return agents.AgentResult(
+            text="I will inspect the repository first.",
+            ok=False,
+            detail="provider returned progress or intent without a final result",
+            failure_phase="output-validation",
+            failure_kind="non-final-output",
+            exit_code=0,
+        )
+
+    output_dir = tmp_path / "run"
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+
+    assert aboyeur.run("build feature", _roster(), output_dir=output_dir) == 2
+    attempt = json.loads((output_dir / "plan-attempts.json").read_text())["attempts"][0]
+    assert attempt["failure_phase"] == "output-validation"
+    assert attempt["failure_kind"] == "non-final-output"
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "failed"
+    assert run_meta["failure_phase"] == "output-validation"
+    assert run_meta["failure"]["kind"] == "non-final-output"
+
+
 def test_synthesis_failure_writes_artifact(monkeypatch, tmp_path, capsys):
     calls = []
 

--- a/tests/test_acpx_adapter.py
+++ b/tests/test_acpx_adapter.py
@@ -119,6 +119,46 @@ def test_run_parses_protocol_and_final_text(monkeypatch, tmp_path):
     assert result.effective_model == "composer-2.5"
 
 
+def test_run_rejects_in_band_provider_error_with_protocol_evidence(monkeypatch, tmp_path):
+    diagnostic = (
+        "I will check the provider first.\n"
+        "Error: NonRetriableError: Provider Error We're having trouble connecting "
+        "to the model provider. This might be temporary - please try again in a moment."
+    )
+    stream = _success_stream().replace('"text": "hello"', f'"text": {json.dumps(diagnostic)}')
+    monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
+    outputs = iter([proc.Result(0, "acpx 0.12.0\n", ""), proc.Result(0, stream, "")])
+    monkeypatch.setattr(acpx_adapter.proc, "run", lambda argv, **kwargs: next(outputs))
+
+    result = acpx_adapter.run_cursor(
+        "inspect", cwd=tmp_path, timeout=120, model="grok-4.5", version="0.12.0", read_only=True
+    )
+
+    assert result.ok is False
+    assert result.text == diagnostic
+    assert result.exit_code == 0
+    assert result.stop_reason == "end_turn"
+    assert result.session_id == "session-1"
+    assert result.request_id == "req-1"
+    assert result.failure_phase == "output-validation"
+    assert result.failure_kind == "provider-error"
+    assert result.detail.startswith("provider returned an error instead of a final result:")
+
+
+def test_run_accepts_short_substantive_final(monkeypatch, tmp_path):
+    stream = _success_stream().replace('"text": "hello"', '"text": "No findings."')
+    monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
+    outputs = iter([proc.Result(0, "acpx 0.12.0\n", ""), proc.Result(0, stream, "")])
+    monkeypatch.setattr(acpx_adapter.proc, "run", lambda argv, **kwargs: next(outputs))
+
+    result = acpx_adapter.run_cursor(
+        "inspect", cwd=tmp_path, timeout=120, model="composer-2.5", version="0.12.0", read_only=True
+    )
+
+    assert result.ok is True
+    assert result.text == "No findings."
+
+
 def test_run_rejects_version_mismatch(monkeypatch, tmp_path):
     monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
     monkeypatch.setattr(acpx_adapter.proc, "run", lambda argv, **kwargs: proc.Result(0, "acpx 0.13.0\n", ""))

--- a/tests/test_acpx_adapter.py
+++ b/tests/test_acpx_adapter.py
@@ -159,6 +159,25 @@ def test_run_accepts_short_substantive_final(monkeypatch, tmp_path):
     assert result.text == "No findings."
 
 
+def test_run_rejects_non_final_stop_reason_with_partial_text(monkeypatch, tmp_path):
+    stream = _success_stream().replace('"stopReason": "end_turn"', '"stopReason": "cancelled"')
+    monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
+    outputs = iter([proc.Result(0, "acpx 0.12.0\n", ""), proc.Result(0, stream, "")])
+    monkeypatch.setattr(acpx_adapter.proc, "run", lambda argv, **kwargs: next(outputs))
+
+    result = acpx_adapter.run_cursor(
+        "inspect", cwd=tmp_path, timeout=120, model="composer-2.5", version="0.12.0", read_only=True
+    )
+
+    assert result.ok is False
+    assert result.text == "hello"
+    assert result.exit_code == 0
+    assert result.stop_reason == "cancelled"
+    assert result.failure_phase == "output-validation"
+    assert result.failure_kind == "non-final-stop"
+    assert result.detail == "ACP stream ended without a final completion (stopReason=cancelled)"
+
+
 def test_run_rejects_version_mismatch(monkeypatch, tmp_path):
     monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
     monkeypatch.setattr(acpx_adapter.proc, "run", lambda argv, **kwargs: proc.Result(0, "acpx 0.13.0\n", ""))

--- a/tests/test_acpx_adapter.py
+++ b/tests/test_acpx_adapter.py
@@ -178,6 +178,40 @@ def test_run_rejects_non_final_stop_reason_with_partial_text(monkeypatch, tmp_pa
     assert result.detail == "ACP stream ended without a final completion (stopReason=cancelled)"
 
 
+def test_run_correlates_stop_reason_to_prompt_request(monkeypatch, tmp_path):
+    stream = _stream(
+        {"jsonrpc": "2.0", "id": "init-1", "result": {"protocolVersion": 1}},
+        {
+            "jsonrpc": "2.0",
+            "id": "req-1",
+            "method": "session/prompt",
+            "params": {"sessionId": "session-1", "prompt": "hidden"},
+        },
+        {
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "session-1",
+                "update": {"sessionUpdate": "agent_message_chunk", "content": {"type": "text", "text": "partial"}},
+            },
+        },
+        {"jsonrpc": "2.0", "id": "req-1", "result": {"stopReason": "cancelled"}},
+        {"jsonrpc": "2.0", "id": "unrelated", "result": {"stopReason": "end_turn"}},
+    )
+    monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
+    outputs = iter([proc.Result(0, "acpx 0.12.0\n", ""), proc.Result(0, stream, "")])
+    monkeypatch.setattr(acpx_adapter.proc, "run", lambda argv, **kwargs: next(outputs))
+
+    result = acpx_adapter.run_cursor(
+        "inspect", cwd=tmp_path, timeout=120, model="composer-2.5", version="0.12.0", read_only=True
+    )
+
+    assert result.ok is False
+    assert result.request_id == "req-1"
+    assert result.stop_reason == "cancelled"
+    assert result.failure_kind == "non-final-stop"
+
+
 def test_run_rejects_version_mismatch(monkeypatch, tmp_path):
     monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
     monkeypatch.setattr(acpx_adapter.proc, "run", lambda argv, **kwargs: proc.Result(0, "acpx 0.13.0\n", ""))

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -482,8 +482,15 @@ def test_run_agent_rejects_tool_call_only_output(monkeypatch, payload):
     assert result.detail == "provider returned tool-call data without a final result"
 
 
-def test_run_agent_rejects_tool_use_markup_without_final_text(monkeypatch):
-    output = '<tool_use>{"name":"read_file","path":"README.md"}</tool_use>'
+@pytest.mark.parametrize(
+    "output",
+    [
+        '<tool_use>{"name":"read_file","path":"README.md"}</tool_use>',
+        '<tool_use name="read_file">{"path":"README.md"}</tool_use>',
+        '<tool_call name="read_file"/><function_call>{"name":"inspect"}</function_call>',
+    ],
+)
+def test_run_agent_rejects_tool_use_markup_without_final_text(monkeypatch, output):
     monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
     monkeypatch.setattr(agents.proc, "run", lambda argv, **kwargs: agents.proc.Result(0, output, ""))
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -430,6 +430,20 @@ def test_run_agent_rejects_intent_only_antigravity_output(monkeypatch):
     assert result.detail == "provider returned progress or intent without a final result"
 
 
+def test_run_agent_rejects_bare_progress_only_output(monkeypatch):
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+    monkeypatch.setattr(
+        agents.proc,
+        "run",
+        lambda argv, **kwargs: agents.proc.Result(0, "Reviewing repository files.\n", ""),
+    )
+
+    result = agents.run_agent("antigravity", "review it")
+
+    assert result.ok is False
+    assert result.failure_kind == "non-final-output"
+
+
 @pytest.mark.parametrize(
     "payload",
     [

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -477,6 +477,9 @@ def test_run_agent_rejects_progress_over_changed_files(monkeypatch):
         {"type": "tool_call", "name": "write_file", "arguments": {"text": "content"}},
         {"name": "read_file", "arguments": {"path": "README.md"}},
         {"name": "write_file", "arguments": {"text": "content"}},
+        {"type": "function_call_output", "call_id": "call-1", "output": "file contents"},
+        {"type": "tool_result", "content": "file contents"},
+        {"call_id": "call-1", "output": "file contents"},
     ],
 )
 def test_run_agent_rejects_tool_call_only_output(monkeypatch, payload):

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -444,6 +444,20 @@ def test_run_agent_rejects_bare_progress_only_output(monkeypatch):
     assert result.failure_kind == "non-final-output"
 
 
+def test_run_agent_rejects_progress_over_changed_files(monkeypatch):
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+    monkeypatch.setattr(
+        agents.proc,
+        "run",
+        lambda argv, **kwargs: agents.proc.Result(0, "Reviewing changed files.\n", ""),
+    )
+
+    result = agents.run_agent("antigravity", "review it")
+
+    assert result.ok is False
+    assert result.failure_kind == "non-final-output"
+
+
 @pytest.mark.parametrize(
     "payload",
     [
@@ -466,6 +480,17 @@ def test_run_agent_rejects_tool_call_only_output(monkeypatch, payload):
     assert result.failure_phase == "output-validation"
     assert result.failure_kind == "tool-only-output"
     assert result.detail == "provider returned tool-call data without a final result"
+
+
+def test_run_agent_rejects_tool_use_markup_without_final_text(monkeypatch):
+    output = '<tool_use>{"name":"read_file","path":"README.md"}</tool_use>'
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+    monkeypatch.setattr(agents.proc, "run", lambda argv, **kwargs: agents.proc.Result(0, output, ""))
+
+    result = agents.run_agent("antigravity", "inspect it")
+
+    assert result.ok is False
+    assert result.failure_kind == "tool-only-output"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -500,6 +500,27 @@ def test_run_agent_rejects_tool_use_markup_without_final_text(monkeypatch, outpu
     assert result.failure_kind == "tool-only-output"
 
 
+def test_run_agent_rejects_tool_call_and_tool_result_transcript(monkeypatch):
+    output = json.dumps(
+        {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "tool_calls": [{"name": "read_file", "arguments": {"path": "README.md"}}],
+                },
+                {"role": "tool", "type": "tool_result", "content": "file contents"},
+            ]
+        }
+    )
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+    monkeypatch.setattr(agents.proc, "run", lambda argv, **kwargs: agents.proc.Result(0, output, ""))
+
+    result = agents.run_agent("antigravity", "inspect it")
+
+    assert result.ok is False
+    assert result.failure_kind == "tool-only-output"
+
+
 @pytest.mark.parametrize(
     ("output", "failure_kind"),
     [
@@ -527,6 +548,8 @@ def test_run_agent_rejects_in_band_operational_diagnostics(monkeypatch, output, 
         "No findings.",
         "OK",
         "I will inspect the repository first. No findings.",
+        "Running the targeted tests passed.",
+        "Checking the implementation, I do not see any regressions.",
         "```text\nError: NonRetriableError: Provider Error\n```\nThis is the requested fixture.",
     ],
 )
@@ -668,6 +691,8 @@ def test_run_agent_rejects_grok_progress_without_structured_final_output(monkeyp
 
     assert result.ok is False
     assert result.detail == "grok exited 0 without a structured final response"
+    assert result.failure_phase == "output-validation"
+    assert result.failure_kind == "malformed-final-output"
     assert result.text == output
     assert result.stdout == output + "\n"
     assert result.exit_code == 0

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -408,6 +408,92 @@ def test_run_agent_captures_output(monkeypatch):
     assert res.timed_out is False
 
 
+def test_run_agent_rejects_intent_only_antigravity_output(monkeypatch):
+    output = "\n".join(
+        [
+            "I will locate the relevant files in the repository.",
+            "I will list the repository contents to understand its structure.",
+            "I will run a search for the provider dispatch path.",
+            "I will inspect the matching source files next.",
+        ]
+    )
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+    monkeypatch.setattr(agents.proc, "run", lambda argv, **kwargs: agents.proc.Result(0, output + "\n", ""))
+
+    result = agents.run_agent("antigravity", "trace it", model="Gemini 3.5 Flash (High)")
+
+    assert result.ok is False
+    assert result.text == output
+    assert result.exit_code == 0
+    assert result.failure_phase == "output-validation"
+    assert result.failure_kind == "non-final-output"
+    assert result.detail == "provider returned progress or intent without a final result"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"tool_calls": [{"name": "read_file", "arguments": {"path": "README.md"}}]},
+        {"tool_calls": [{"name": "write_file", "arguments": {"text": "content"}}]},
+        {"type": "tool_call", "name": "read_file", "arguments": {"path": "README.md"}},
+        {"type": "tool_call", "name": "write_file", "arguments": {"text": "content"}},
+        {"name": "read_file", "arguments": {"path": "README.md"}},
+        {"name": "write_file", "arguments": {"text": "content"}},
+    ],
+)
+def test_run_agent_rejects_tool_call_only_output(monkeypatch, payload):
+    output = json.dumps(payload)
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+    monkeypatch.setattr(agents.proc, "run", lambda argv, **kwargs: agents.proc.Result(0, output, ""))
+
+    result = agents.run_agent("antigravity", "inspect it")
+
+    assert result.ok is False
+    assert result.failure_phase == "output-validation"
+    assert result.failure_kind == "tool-only-output"
+    assert result.detail == "provider returned tool-call data without a final result"
+
+
+@pytest.mark.parametrize(
+    ("output", "failure_kind"),
+    [
+        ("Error: authentication required. Run provider login.", "authentication-error"),
+        ("Error: failed to connect to the model provider.", "network-error"),
+        ("Error: model gemini-example is not available.", "provider-setting-error"),
+        ("Error: rate limit exceeded for this provider.", "rate-limit-error"),
+    ],
+)
+def test_run_agent_rejects_in_band_operational_diagnostics(monkeypatch, output, failure_kind):
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+    monkeypatch.setattr(agents.proc, "run", lambda argv, **kwargs: agents.proc.Result(0, output, ""))
+
+    result = agents.run_agent("antigravity", "answer directly")
+
+    assert result.ok is False
+    assert result.failure_phase == "output-validation"
+    assert result.failure_kind == failure_kind
+    assert result.detail.startswith("provider returned an operational error instead of a final result:")
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        "No findings.",
+        "OK",
+        "I will inspect the repository first. No findings.",
+        "```text\nError: NonRetriableError: Provider Error\n```\nThis is the requested fixture.",
+    ],
+)
+def test_run_agent_accepts_short_or_quoted_substantive_output(monkeypatch, output):
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+    monkeypatch.setattr(agents.proc, "run", lambda argv, **kwargs: agents.proc.Result(0, output, ""))
+
+    result = agents.run_agent("antigravity", "answer directly")
+
+    assert result.ok is True
+    assert result.text == output
+
+
 def test_run_agent_forwards_model_to_argv(monkeypatch):
     captured = {}
 
@@ -785,6 +871,24 @@ def test_run_codex_appserver_empty_text_not_ok():
     server = _StubServer(turn)
     res = agents.run_codex_appserver(server, "p", timeout=5.0, cwd=None)
     assert not res.ok and res.detail == "empty output"
+
+
+def test_run_codex_appserver_rejects_intent_only_final():
+    from brigade import codex_appserver
+
+    turn = codex_appserver.TurnResult(
+        text="I will inspect the repository first. I will report the result next.",
+        ok=True,
+        status="complete",
+        thread_id="t-1",
+    )
+    server = _StubServer(turn)
+
+    result = agents.run_codex_appserver(server, "p", timeout=5.0, cwd=None)
+
+    assert result.ok is False
+    assert result.failure_phase == "output-validation"
+    assert result.failure_kind == "non-final-output"
 
 
 def test_run_codex_appserver_server_error_is_failed():

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -430,12 +430,22 @@ def test_run_agent_rejects_intent_only_antigravity_output(monkeypatch):
     assert result.detail == "provider returned progress or intent without a final result"
 
 
-def test_run_agent_rejects_bare_progress_only_output(monkeypatch):
+@pytest.mark.parametrize(
+    "output",
+    [
+        "Reviewing repository files.",
+        "First, I will inspect the repo.",
+        "Now I will run the tests.",
+        "I'm going to inspect the files first.",
+        "I am inspecting the files first.",
+    ],
+)
+def test_run_agent_rejects_bare_progress_only_output(monkeypatch, output):
     monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
     monkeypatch.setattr(
         agents.proc,
         "run",
-        lambda argv, **kwargs: agents.proc.Result(0, "Reviewing repository files.\n", ""),
+        lambda argv, **kwargs: agents.proc.Result(0, output + "\n", ""),
     )
 
     result = agents.run_agent("antigravity", "review it")
@@ -506,6 +516,7 @@ def test_run_agent_rejects_tool_call_and_tool_result_transcript(monkeypatch):
             "messages": [
                 {
                     "role": "assistant",
+                    "content": "I will inspect the repository first.",
                     "tool_calls": [{"name": "read_file", "arguments": {"path": "README.md"}}],
                 },
                 {"role": "tool", "type": "tool_result", "content": "file contents"},

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -532,6 +532,25 @@ def test_run_agent_rejects_tool_call_and_tool_result_transcript(monkeypatch):
     assert result.failure_kind == "tool-only-output"
 
 
+@pytest.mark.parametrize("result_type", ["function_call_output", "tool_call_output"])
+def test_run_agent_rejects_call_output_without_final_text(monkeypatch, result_type):
+    output = json.dumps(
+        {
+            "items": [
+                {"type": "function_call", "name": "read_file", "arguments": "{}"},
+                {"type": result_type, "call_id": "call-1", "output": "file contents"},
+            ]
+        }
+    )
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+    monkeypatch.setattr(agents.proc, "run", lambda argv, **kwargs: agents.proc.Result(0, output, ""))
+
+    result = agents.run_agent("antigravity", "inspect it")
+
+    assert result.ok is False
+    assert result.failure_kind == "tool-only-output"
+
+
 @pytest.mark.parametrize(
     ("output", "failure_kind"),
     [


### PR DESCRIPTION
## Summary

- reject exit-0 provider diagnostics, progress-only text, tool calls, and tool results before `brigade run` reports success
- require Cursor ACP `end_turn` to match the prompt request, and preserve the protocol evidence when it does not
- carry typed output-validation failures through planning, workers, synthesis, and `run.json`
- keep concise final results such as `OK` and `No findings.` valid without a minimum-length rule

## Root cause

The shared adapter contract treated process exit 0 plus nonempty text as a successful final result. Cursor ACP also accepted text from any assistant chunk and the last observed stop reason, even when the stop belonged to another request.

## Verification

- focused provider and receipt suite: 196 passed in receipt `20260717-014740-work-verify-aa29ef`
- full `./scripts/verify`: 2,521 passed, 3 skipped, 81.57% coverage in receipt `20260717-015322-work-verify-5e420d`
- live Cursor provider-error replay now exits 2 with `status=failed`, `failure_phase=output-validation`, and `failure.kind=provider-error` while retaining exit 0, `end_turn`, request/session IDs, and raw logs

Fixes #293