### PR TITLE
fix: finalize worktree artifact collection honestly

### DIFF
--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -1467,12 +1467,107 @@ def set_artifact_patch_ref(output_dir: Path, patch_ref: str = "changes.patch") -
         path = output_dir / filename
         try:
             payload = json.loads(path.read_text())
-        except (OSError, json.JSONDecodeError):
+        except FileNotFoundError:
             continue
+        except OSError as exc:
+            raise runguard.RunGuardError(
+                f"failed to read {filename} while recording artifact patch reference: {exc}"
+            ) from exc
+        except json.JSONDecodeError as exc:
+            raise runguard.RunGuardError(
+                f"failed to parse {filename} while recording artifact patch reference: {exc}"
+            ) from exc
         if not isinstance(payload, dict) or "ground_truth" not in payload:
-            continue
+            raise runguard.RunGuardError(f"{filename} is missing ground_truth while recording artifact patch reference")
         payload["ground_truth"] = _with_patch_ref(payload.get("ground_truth"), patch_ref)
-        _write_json(path, payload)
+        try:
+            _write_json(path, payload)
+        except OSError as exc:
+            raise runguard.RunGuardError(f"failed to record artifact patch reference in {filename}: {exc}") from exc
+
+
+def record_artifact_collection(
+    output_dir: Path,
+    *,
+    status: str,
+    patch_ref: str | None = None,
+    changed: bool | None = None,
+    tracked_count: int | None = None,
+    untracked_count: int | None = None,
+    worktree: Path | None = None,
+    failure_phase: str | None = None,
+    failure_kind: str | None = None,
+    detail: str | None = None,
+) -> None:
+    run_path = output_dir / "run.json"
+    try:
+        payload = json.loads(run_path.read_text())
+    except OSError as exc:
+        raise runguard.RetainRunLockError(f"failed to read run receipt during artifact collection: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise runguard.RetainRunLockError(f"run receipt is invalid during artifact collection: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise runguard.RetainRunLockError("run receipt must contain an object during artifact collection")
+
+    collection: dict[str, object] = {"status": status}
+    if patch_ref is not None:
+        collection["patch_ref"] = patch_ref
+    if changed is not None:
+        collection["changed"] = changed
+    if tracked_count is not None:
+        collection["tracked_count"] = tracked_count
+    if untracked_count is not None:
+        collection["untracked_count"] = untracked_count
+    if worktree is not None:
+        collection["worktree"] = str(worktree)
+
+    if status == "failed":
+        bounded_detail = _one_line(detail or "artifact collection failed")[:2000]
+        phase = failure_phase or "artifact-collection"
+        artifact_failure = {
+            "phase": phase,
+            "kind": failure_kind or "unknown",
+            "detail": bounded_detail,
+        }
+        collection["failure"] = artifact_failure
+        if payload.get("status") not in {"failed", "handoff-failed", "interrupted"}:
+            payload["status"] = "failed"
+            payload["error"] = bounded_detail
+            payload["failure_phase"] = phase
+            payload["failure"] = artifact_failure
+            finished_at = datetime.now(timezone.utc)
+            payload["finished_at"] = _utc_iso(finished_at)
+            started_at = payload.get("started_at")
+            if isinstance(started_at, str):
+                try:
+                    started = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+                except ValueError:
+                    pass
+                else:
+                    payload["duration_seconds"] = max(
+                        0.0,
+                        round((finished_at - started.astimezone(timezone.utc)).total_seconds(), 3),
+                    )
+    elif status == "ok" and payload.get("status") == "artifact-collection":
+        finished_at = datetime.now(timezone.utc)
+        payload["status"] = "ok"
+        payload["finished_at"] = _utc_iso(finished_at)
+        started_at = payload.get("started_at")
+        if isinstance(started_at, str):
+            try:
+                started = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+            except ValueError:
+                pass
+            else:
+                payload["duration_seconds"] = max(
+                    0.0,
+                    round((finished_at - started.astimezone(timezone.utc)).total_seconds(), 3),
+                )
+    payload["artifact_collection"] = collection
+    try:
+        _write_json(run_path, payload)
+    except OSError as exc:
+        raise runguard.RetainRunLockError(f"failed to update run receipt after artifact collection: {exc}") from exc
 
 
 def _roster_payload(roster: Roster) -> dict[str, object]:
@@ -1629,6 +1724,7 @@ def run(
     route_overrides: tuple[str, ...] = (),
     worker: str | None = None,
     authorized_writable_worktree: bool = False,
+    defer_artifact_collection: bool = False,
 ) -> int:
     started_at = datetime.now(timezone.utc)
     transport_for_payload = codex_transport or roster.codex_transport
@@ -2080,7 +2176,7 @@ def run(
             print(f"error: orchestrator failed during synthesis: {final.detail}", file=sys.stderr)
         return 2
     if output_dir is not None:
-        finished_at = datetime.now(timezone.utc)
+        finished_at = None if defer_artifact_collection else datetime.now(timezone.utc)
         (output_dir / "final.txt").write_text(final.text + "\n")
         _write_json(
             output_dir / "run.json",
@@ -2090,7 +2186,7 @@ def run(
                 roster=roster,
                 dry_run=dry_run,
                 read_only=read_only,
-                status="ok",
+                status="artifact-collection" if defer_artifact_collection else "ok",
                 started_at=started_at,
                 finished_at=finished_at,
                 output_dir=output_dir,
@@ -2154,7 +2250,7 @@ def run(
             return 2
         print(f"handoff: {handoff}", file=sys.stderr)
         if output_dir is not None:
-            finished_at = datetime.now(timezone.utc)
+            finished_at = None if defer_artifact_collection else datetime.now(timezone.utc)
             _write_json(
                 output_dir / "run.json",
                 _payload(
@@ -2163,7 +2259,7 @@ def run(
                     roster=roster,
                     dry_run=dry_run,
                     read_only=read_only,
-                    status="ok",
+                    status="artifact-collection" if defer_artifact_collection else "ok",
                     started_at=started_at,
                     finished_at=finished_at,
                     output_dir=output_dir,

--- a/src/brigade/cli/run.py
+++ b/src/brigade/cli/run.py
@@ -290,6 +290,7 @@ def dispatch(args) -> int:
                 run_kwargs["authorized_writable_worktree"] = True
             if args.worktree:
                 run_kwargs["lock_workspace"] = run_cwd
+                run_kwargs["defer_artifact_collection"] = True
             if args.worker is not None:
                 run_kwargs["worker"] = args.worker
             if args.codex_transport is not None:
@@ -312,27 +313,81 @@ def dispatch(args) -> int:
                 # recoverable copy of the agents' edits; a collection failure
                 # must not let cleanup destroy it.
                 keep_worktree = True
-                summary = runguard.collect_changes_patch(effective_cwd, output_dir / "changes.patch")
-                if summary.path.is_file():
-                    aboyeur_mod.set_artifact_patch_ref(output_dir, "changes.patch")
+                patch_path = output_dir / "changes.patch"
+                try:
+                    summary = runguard.collect_changes_patch(effective_cwd, patch_path)
+                except (runguard.RunGuardError, OSError) as exc:
+                    detail = (
+                        str(exc) if isinstance(exc, runguard.RunGuardError) else f"failed to write changes.patch: {exc}"
+                    )
+                    patch_ref = "changes.patch" if patch_path.is_file() else None
+                    aboyeur_mod.record_artifact_collection(
+                        output_dir,
+                        status="failed",
+                        patch_ref=patch_ref,
+                        worktree=effective_cwd,
+                        failure_phase="artifact-collection",
+                        failure_kind="collection-error",
+                        detail=detail,
+                    )
+                    if isinstance(exc, runguard.RunGuardError):
+                        raise
+                    raise runguard.RunGuardError(detail) from exc
                 if summary.changed and not runguard.verify_changes_patch(effective_cwd, summary.path):
                     # A corrupt patch must never be the run's silent primary
                     # deliverable; keep the worktree as the recoverable copy.
+                    aboyeur_mod.record_artifact_collection(
+                        output_dir,
+                        status="failed",
+                        patch_ref="changes.patch",
+                        changed=True,
+                        tracked_count=summary.tracked_count,
+                        untracked_count=summary.untracked_count,
+                        worktree=effective_cwd,
+                        failure_phase="artifact-validation",
+                        failure_kind="invalid-patch",
+                        detail="changes.patch failed validation",
+                    )
                     print(
                         f"error: changes.patch failed validation ({summary.path}); "
                         f"worktree kept for recovery: {effective_cwd}",
                         file=sys.stderr,
                     )
                     rc = max(rc, 2)
-                elif summary.changed:
-                    keep_worktree = False
-                    print(
-                        f"changes: {summary.path} ({summary.tracked_count + summary.untracked_count} file(s))",
-                        file=sys.stderr,
-                    )
                 else:
+                    if summary.path.is_file():
+                        try:
+                            aboyeur_mod.set_artifact_patch_ref(output_dir, "changes.patch")
+                        except runguard.RunGuardError as exc:
+                            aboyeur_mod.record_artifact_collection(
+                                output_dir,
+                                status="failed",
+                                patch_ref="changes.patch",
+                                changed=summary.changed,
+                                tracked_count=summary.tracked_count,
+                                untracked_count=summary.untracked_count,
+                                worktree=effective_cwd,
+                                failure_phase="artifact-collection",
+                                failure_kind="receipt-update-error",
+                                detail=str(exc),
+                            )
+                            raise
+                    aboyeur_mod.record_artifact_collection(
+                        output_dir,
+                        status="ok",
+                        patch_ref="changes.patch",
+                        changed=summary.changed,
+                        tracked_count=summary.tracked_count,
+                        untracked_count=summary.untracked_count,
+                    )
                     keep_worktree = False
-                    print(f"changes: none ({summary.path})", file=sys.stderr)
+                    if summary.changed:
+                        print(
+                            f"changes: {summary.path} ({summary.tracked_count + summary.untracked_count} file(s))",
+                            file=sys.stderr,
+                        )
+                    else:
+                        print(f"changes: none ({summary.path})", file=sys.stderr)
     except runguard.RunGuardError as exc:
         print(f"error: {exc}", file=sys.stderr)
         if worktree_cwd is not None and keep_worktree:

--- a/src/brigade/run_resume.py
+++ b/src/brigade/run_resume.py
@@ -16,7 +16,9 @@ from . import aboyeur, agents, codex_appserver, runguard
 from .roster import Agent, Roster
 
 _RESUMABLE_STATUSES = ("interrupted", "failed")
-_NONTERMINAL_RUN_STATUSES = frozenset({"started", "planning", "dispatching", "synthesizing", "running"})
+_NONTERMINAL_RUN_STATUSES = frozenset(
+    {"started", "planning", "dispatching", "synthesizing", "artifact-collection", "running"}
+)
 
 
 def _load_json(run_dir: Path, name: str) -> dict | None:

--- a/src/brigade/runguard.py
+++ b/src/brigade/runguard.py
@@ -15,11 +15,17 @@ from uuid import uuid4
 
 from . import localio, proc
 
-_NONTERMINAL_RUN_STATUSES = frozenset({"started", "planning", "dispatching", "synthesizing", "running"})
+_NONTERMINAL_RUN_STATUSES = frozenset(
+    {"started", "planning", "dispatching", "synthesizing", "artifact-collection", "running"}
+)
 
 
 class RunGuardError(RuntimeError):
     """Base error for run guard failures."""
+
+
+class RetainRunLockError(RunGuardError):
+    """A terminal receipt could not be written, so stale recovery still needs the lock."""
 
 
 class DirtyWorktreeError(RunGuardError):
@@ -498,10 +504,14 @@ def run_lock(
             if remaining <= 0:
                 raise RunLockError(f"timed out after {wait_seconds:g}s waiting for run lock: {path}") from exc
             time.sleep(min(poll_interval, remaining))
+    retain_lock = False
     try:
         yield path
+    except RetainRunLockError:
+        retain_lock = True
+        raise
     finally:
-        if ownership is not None:
+        if ownership is not None and not retain_lock:
             _release_lock(path, ownership)
 
 

--- a/src/brigade/runs_cmd.py
+++ b/src/brigade/runs_cmd.py
@@ -8,7 +8,9 @@ import time
 from pathlib import Path
 from typing import Any
 
-_NONTERMINAL_STATUSES = frozenset({"started", "planning", "dispatching", "synthesizing", "running"})
+_NONTERMINAL_STATUSES = frozenset(
+    {"started", "planning", "dispatching", "synthesizing", "artifact-collection", "running"}
+)
 _SUCCESS_STATUSES = frozenset({"ok", "dry-run"})
 
 
@@ -660,6 +662,27 @@ def watch(
         if rc is not None:
             return rc
         assert run_meta is not None
+        if run_meta.get("status") == "artifact-collection":
+            workspace = _lock_workspace(run_dir, run_meta, fallback=cwd)
+            if workspace is not None:
+                from . import runguard
+
+                try:
+                    if runguard.recover_stale_run(workspace, run_dir, required=False):
+                        continue
+                    refreshed = _read_json(run_dir / "run.json")
+                    if refreshed is not None and _is_terminal(refreshed):
+                        continue
+                    print(
+                        "error: artifact-collection run has no matching recoverable lock",
+                        file=sys.stderr,
+                    )
+                    return 2
+                except runguard.RunLockError as exc:
+                    detail = str(exc)
+                    if "owner process is still active" not in detail and "recovery is still active" not in detail:
+                        print(f"error: artifact-collection recovery failed: {detail}", file=sys.stderr)
+                        return 2
         if _is_terminal(run_meta):
             if not summary_emitted:
                 _emit_summary(run_dir, run_meta, json_output=json_output)

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -1106,6 +1106,55 @@ def test_run_direct_grok_structured_final_succeeds_with_honest_artifacts(monkeyp
     assert (output_dir / "final.txt").read_text().strip() == answer
 
 
+def test_run_defers_success_until_worktree_artifact_collection(monkeypatch, tmp_path):
+    answer = "Implementation complete."
+    structured = {"kind": "answer", "answer": answer}
+    stdout = json.dumps(
+        {
+            "text": json.dumps(structured),
+            "stopReason": "EndTurn",
+            "sessionId": "019f0000-0000-7000-8000-000000000001",
+            "requestId": "00000000-0000-4000-8000-000000000001",
+            "structuredOutput": structured,
+        }
+    )
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+    monkeypatch.setattr(agents.proc, "run", lambda argv, **kwargs: agents.proc.Result(0, stdout + "\n", ""))
+    output_dir = tmp_path / "run"
+
+    rc = aboyeur.run(
+        "Implement the requested change.",
+        _grok_roster(),
+        cwd=tmp_path,
+        worker="grok_cli",
+        output_dir=output_dir,
+        read_only=True,
+        route_enabled=False,
+        defer_artifact_collection=True,
+    )
+
+    assert rc == 0
+    run_payload = json.loads((output_dir / "run.json").read_text())
+    assert run_payload["status"] == "artifact-collection"
+    assert "finished_at" not in run_payload
+    assert "duration_seconds" not in run_payload
+    assert (output_dir / "final.txt").read_text().strip() == answer
+
+    aboyeur.record_artifact_collection(
+        output_dir,
+        status="ok",
+        patch_ref="changes.patch",
+        changed=False,
+        tracked_count=0,
+        untracked_count=0,
+    )
+
+    run_payload = json.loads((output_dir / "run.json").read_text())
+    assert run_payload["status"] == "ok"
+    assert "finished_at" in run_payload
+    assert "duration_seconds" in run_payload
+
+
 def test_run_direct_worker_writes_complete_process_logs(monkeypatch, tmp_path):
     def fake_run_agent(cli_ref, prompt, **kwargs):
         return agents.AgentResult(

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -1027,6 +1027,26 @@ def test_app_server_fallback_clears_uncreated_control_socket(tmp_path, monkeypat
     assert "control_socket" not in run_meta
 
 
+def _write_successful_worktree_run(output_dir: Path, cwd: Path, *, final: str = "done") -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "run.json").write_text(
+        json.dumps(
+            {
+                "schema": "brigade.run.v1",
+                "task": "x",
+                "cwd": str(cwd),
+                "status": "ok",
+                "started_at": "2026-07-09T12:00:00Z",
+                "finished_at": "2026-07-09T12:00:01Z",
+                "duration_seconds": 1,
+                "artifacts": str(output_dir),
+            }
+        )
+        + "\n"
+    )
+    (output_dir / "final.txt").write_text(final + "\n")
+
+
 def test_run_cli_worktree_passes_detached_cwd_and_writes_changes_patch(tmp_path, monkeypatch):
     repo = _git_repo_with_roster(tmp_path)
     output_dir = tmp_path / "run"
@@ -1044,16 +1064,18 @@ def test_run_cli_worktree_passes_detached_cwd_and_writes_changes_patch(tmp_path,
         handoff_inbox=None,
         read_only=False,
         sandbox=None,
+        defer_artifact_collection=False,
     ):
         seen["cwd"] = cwd
         seen["lock_workspace"] = lock_workspace
         seen["output_dir"] = output_dir
+        seen["defer_artifact_collection"] = defer_artifact_collection
         assert cwd != repo
         assert (cwd / "tracked.txt").read_text() == "base\n"
         assert proc.run(["git", "symbolic-ref", "-q", "HEAD"], cwd=cwd).code == 1
         (cwd / "tracked.txt").write_text("changed in worktree\n")
         (cwd / "created.txt").write_text("created\n")
-        output_dir.mkdir(parents=True)
+        _write_successful_worktree_run(output_dir, cwd)
         (output_dir / "worker-results.json").write_text(
             json.dumps({"results": [], "ground_truth": {"available": True, "patch_ref": None}}) + "\n"
         )
@@ -1072,6 +1094,7 @@ def test_run_cli_worktree_passes_detached_cwd_and_writes_changes_patch(tmp_path,
     expected_checkout = tmp_path / "home" / ".cache" / "brigade" / "worktrees" / f"{repo.name}-{output_dir.name}"
     assert seen["cwd"] == expected_checkout
     assert seen["lock_workspace"] == repo.resolve()
+    assert seen["defer_artifact_collection"] is True
     assert not expected_checkout.exists()
     assert (repo / "tracked.txt").read_text() == "base\n"
     patch = (output_dir / "changes.patch").read_text()
@@ -1079,6 +1102,15 @@ def test_run_cli_worktree_passes_detached_cwd_and_writes_changes_patch(tmp_path,
     assert "created.txt" in patch
     assert "+changed in worktree" in patch
     assert "+created" in patch
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "ok"
+    assert run_meta["artifact_collection"] == {
+        "status": "ok",
+        "patch_ref": "changes.patch",
+        "changed": True,
+        "tracked_count": 1,
+        "untracked_count": 1,
+    }
     assert json.loads((output_dir / "worker-results.json").read_text())["ground_truth"]["patch_ref"] == "changes.patch"
     assert json.loads((output_dir / "synthesis.json").read_text())["ground_truth"]["patch_ref"] == "changes.patch"
 
@@ -1138,6 +1170,13 @@ def test_run_cli_worktree_warns_on_empty_changes_patch_noop(tmp_path, monkeypatc
     assert rc == 0
     assert (output_dir / "changes.patch").read_text() == ""
     assert json.loads((output_dir / "worker-results.json").read_text())["ground_truth"]["patch_ref"] == "changes.patch"
+    assert json.loads((output_dir / "run.json").read_text())["artifact_collection"] == {
+        "status": "ok",
+        "patch_ref": "changes.patch",
+        "changed": False,
+        "tracked_count": 0,
+        "untracked_count": 0,
+    }
     assert "changes: none" in captured.err
     assert "changes.patch" in captured.err
     assert "warning: suspected no-op run" in captured.err
@@ -1150,6 +1189,20 @@ def test_run_cli_worktree_keeps_checkout_when_patch_invalid(tmp_path, monkeypatc
     def fake_run(task, loaded_roster, **kwargs):
         cwd = kwargs["cwd"]
         (cwd / "tracked.txt").write_text("changed in worktree\n")
+        output = kwargs["output_dir"]
+        _write_successful_worktree_run(output, cwd, final="implementation complete")
+        run_path = output / "run.json"
+        run_meta = json.loads(run_path.read_text())
+        run_meta["status"] = "artifact-collection"
+        run_meta.pop("finished_at")
+        run_meta.pop("duration_seconds")
+        run_path.write_text(json.dumps(run_meta) + "\n")
+        (output / "worker-results.json").write_text(
+            json.dumps({"results": [], "ground_truth": {"patch_ref": None}}) + "\n"
+        )
+        (output / "synthesis.json").write_text(
+            json.dumps({"result": {"ok": True}, "ground_truth": {"patch_ref": None}}) + "\n"
+        )
         return 0
 
     monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
@@ -1164,6 +1217,86 @@ def test_run_cli_worktree_keeps_checkout_when_patch_invalid(tmp_path, monkeypatc
     assert "changes.patch failed validation" in err
     assert str(checkout) in err
     assert checkout.exists()
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "failed"
+    assert run_meta["failure_phase"] == "artifact-validation"
+    assert run_meta["failure"] == {
+        "phase": "artifact-validation",
+        "kind": "invalid-patch",
+        "detail": "changes.patch failed validation",
+    }
+    assert run_meta["artifact_collection"] == {
+        "status": "failed",
+        "patch_ref": "changes.patch",
+        "changed": True,
+        "tracked_count": 1,
+        "untracked_count": 0,
+        "worktree": str(checkout),
+        "failure": {
+            "phase": "artifact-validation",
+            "kind": "invalid-patch",
+            "detail": "changes.patch failed validation",
+        },
+    }
+    assert (output_dir / "final.txt").read_text() == "implementation complete\n"
+    assert json.loads((output_dir / "worker-results.json").read_text())["ground_truth"]["patch_ref"] is None
+    assert json.loads((output_dir / "synthesis.json").read_text())["ground_truth"]["patch_ref"] is None
+    assert runs_cmd.show(output_dir) == 1
+    show_output = capsys.readouterr().out
+    assert "status: failed" in show_output
+    assert "failure phase: artifact-validation" in show_output
+    assert "final:\n  implementation complete" in show_output
+    assert runs_cmd.watch(output_dir, cwd=repo, interval=0) == 1
+    watch_output = capsys.readouterr().out
+    assert "status: failed" in watch_output
+    assert "failure phase: artifact-validation" in watch_output
+
+
+def test_run_cli_worktree_artifact_failure_preserves_model_failure(tmp_path, monkeypatch):
+    repo = _git_repo_with_roster(tmp_path)
+    output_dir = tmp_path / "run"
+
+    def fake_run(task, loaded_roster, **kwargs):
+        cwd = kwargs["cwd"]
+        (cwd / "tracked.txt").write_text("changed in worktree\n")
+        _write_successful_worktree_run(kwargs["output_dir"], cwd, final="provider diagnostic")
+        run_path = kwargs["output_dir"] / "run.json"
+        run_meta = json.loads(run_path.read_text())
+        run_meta.update(
+            {
+                "status": "failed",
+                "error": "provider inference failed",
+                "failure_phase": "inference",
+                "failure": {
+                    "phase": "inference",
+                    "kind": "provider-error",
+                    "detail": "provider inference failed",
+                },
+            }
+        )
+        run_path.write_text(json.dumps(run_meta) + "\n")
+        return 2
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    monkeypatch.setattr(aboyeur, "run", fake_run)
+    monkeypatch.setattr(runguard, "verify_changes_patch", lambda cwd, patch_path: False)
+
+    rc = cli.main(["run", "x", "--cwd", str(repo), "--output-dir", str(output_dir), "--worktree"])
+
+    assert rc == 2
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "failed"
+    assert run_meta["failure_phase"] == "inference"
+    assert run_meta["failure"] == {
+        "phase": "inference",
+        "kind": "provider-error",
+        "detail": "provider inference failed",
+    }
+    assert run_meta["artifact_collection"]["failure"] == {
+        "phase": "artifact-validation",
+        "kind": "invalid-patch",
+        "detail": "changes.patch failed validation",
+    }
 
 
 def test_run_cli_worktree_kept_when_patch_collection_raises(tmp_path, monkeypatch, capsys):
@@ -1173,10 +1306,13 @@ def test_run_cli_worktree_kept_when_patch_collection_raises(tmp_path, monkeypatc
     output_dir = tmp_path / "run"
 
     def fake_run(task, loaded_roster, **kwargs):
-        (kwargs["cwd"] / "tracked.txt").write_text("changed in worktree\n")
+        cwd = kwargs["cwd"]
+        (cwd / "tracked.txt").write_text("changed in worktree\n")
+        _write_successful_worktree_run(kwargs["output_dir"], cwd, final="implementation complete")
         return 0
 
     def raising_collect(cwd, patch_path):
+        patch_path.write_text("partial patch\n")
         raise runguard.RunGuardError("failed to collect tracked diff: boom")
 
     monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
@@ -1191,6 +1327,174 @@ def test_run_cli_worktree_kept_when_patch_collection_raises(tmp_path, monkeypatc
     assert checkout.exists()
     assert (checkout / "tracked.txt").read_text() == "changed in worktree\n"
     assert str(checkout) in err
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "failed"
+    assert run_meta["failure_phase"] == "artifact-collection"
+    assert run_meta["failure"] == {
+        "phase": "artifact-collection",
+        "kind": "collection-error",
+        "detail": "failed to collect tracked diff: boom",
+    }
+    assert run_meta["artifact_collection"] == {
+        "status": "failed",
+        "patch_ref": "changes.patch",
+        "worktree": str(checkout),
+        "failure": {
+            "phase": "artifact-collection",
+            "kind": "collection-error",
+            "detail": "failed to collect tracked diff: boom",
+        },
+    }
+    assert (output_dir / "final.txt").read_text() == "implementation complete\n"
+
+
+def test_run_cli_worktree_records_patch_write_error(tmp_path, monkeypatch, capsys):
+    repo = _git_repo_with_roster(tmp_path)
+    output_dir = tmp_path / "run"
+
+    def fake_run(task, loaded_roster, **kwargs):
+        cwd = kwargs["cwd"]
+        (cwd / "tracked.txt").write_text("changed in worktree\n")
+        _write_successful_worktree_run(kwargs["output_dir"], cwd, final="implementation complete")
+        return 0
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    monkeypatch.setattr(aboyeur, "run", fake_run)
+    monkeypatch.setattr(
+        runguard,
+        "collect_changes_patch",
+        lambda cwd, patch_path: (_ for _ in ()).throw(OSError("disk full")),
+    )
+
+    rc = cli.main(["run", "x", "--cwd", str(repo), "--output-dir", str(output_dir), "--worktree"])
+
+    checkout = tmp_path / "home" / ".cache" / "brigade" / "worktrees" / f"{repo.name}-{output_dir.name}"
+    assert rc == 2
+    assert checkout.exists()
+    assert "failed to write changes.patch: disk full" in capsys.readouterr().err
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "failed"
+    assert run_meta["failure_phase"] == "artifact-collection"
+    assert run_meta["failure"]["kind"] == "collection-error"
+    assert run_meta["failure"]["detail"] == "failed to write changes.patch: disk full"
+    assert run_meta["artifact_collection"] == {
+        "status": "failed",
+        "worktree": str(checkout),
+        "failure": {
+            "phase": "artifact-collection",
+            "kind": "collection-error",
+            "detail": "failed to write changes.patch: disk full",
+        },
+    }
+
+
+def test_run_cli_worktree_keeps_checkout_when_receipt_finalization_fails(tmp_path, monkeypatch, capsys):
+    repo = _git_repo_with_roster(tmp_path)
+    output_dir = tmp_path / "run"
+
+    def fake_run(task, loaded_roster, **kwargs):
+        cwd = kwargs["cwd"]
+        (cwd / "tracked.txt").write_text("changed in worktree\n")
+        output = kwargs["output_dir"]
+        _write_successful_worktree_run(output, cwd, final="implementation complete")
+        run_path = output / "run.json"
+        run_meta = json.loads(run_path.read_text())
+        run_meta["status"] = "artifact-collection"
+        run_meta.pop("finished_at")
+        run_meta.pop("duration_seconds")
+        run_path.write_text(json.dumps(run_meta) + "\n")
+        return 0
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    monkeypatch.setattr(aboyeur, "run", fake_run)
+    monkeypatch.setattr(
+        aboyeur,
+        "_write_json",
+        lambda path, payload: (_ for _ in ()).throw(OSError("receipt disk full")),
+    )
+
+    rc = cli.main(["run", "x", "--cwd", str(repo), "--output-dir", str(output_dir), "--worktree"])
+
+    checkout = tmp_path / "home" / ".cache" / "brigade" / "worktrees" / f"{repo.name}-{output_dir.name}"
+    assert rc == 2
+    assert checkout.exists()
+    assert "failed to update run receipt after artifact collection: receipt disk full" in capsys.readouterr().err
+    assert json.loads((output_dir / "run.json").read_text())["status"] == "artifact-collection"
+    assert runguard.lock_path(repo).is_dir()
+
+    monkeypatch.setattr(runguard, "_pid_is_active", lambda pid: False)
+    assert runs_cmd.watch(output_dir, cwd=repo, interval=0) == 1
+    recovered = json.loads((output_dir / "run.json").read_text())
+    assert recovered["status"] == "failed"
+    assert recovered["failure_phase"] == "stale-lock-recovery"
+    assert recovered["failure"]["prior_status"] == "artifact-collection"
+    assert not runguard.lock_path(repo).exists()
+
+
+def test_run_cli_worktree_records_patch_reference_failure(tmp_path, monkeypatch, capsys):
+    repo = _git_repo_with_roster(tmp_path)
+    output_dir = tmp_path / "run"
+
+    def fake_run(task, loaded_roster, **kwargs):
+        cwd = kwargs["cwd"]
+        output = kwargs["output_dir"]
+        (cwd / "tracked.txt").write_text("changed in worktree\n")
+        _write_successful_worktree_run(output, cwd, final="implementation complete")
+        (output / "worker-results.json").write_text(
+            json.dumps({"results": [], "ground_truth": {"patch_ref": None}}) + "\n"
+        )
+        return 0
+
+    original_write_json = aboyeur._write_json
+
+    def fail_worker_results(path, payload):
+        if path.name == "worker-results.json":
+            raise OSError("worker receipt disk full")
+        return original_write_json(path, payload)
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    monkeypatch.setattr(aboyeur, "run", fake_run)
+    monkeypatch.setattr(aboyeur, "_write_json", fail_worker_results)
+
+    rc = cli.main(["run", "x", "--cwd", str(repo), "--output-dir", str(output_dir), "--worktree"])
+
+    checkout = tmp_path / "home" / ".cache" / "brigade" / "worktrees" / f"{repo.name}-{output_dir.name}"
+    assert rc == 2
+    assert checkout.exists()
+    detail = "failed to record artifact patch reference in worker-results.json: worker receipt disk full"
+    assert detail in capsys.readouterr().err
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "failed"
+    assert run_meta["failure_phase"] == "artifact-collection"
+    assert run_meta["failure"]["kind"] == "receipt-update-error"
+    assert run_meta["failure"]["detail"] == detail
+
+
+def test_run_cli_worktree_rejects_corrupt_worker_receipt_during_patch_reference(tmp_path, monkeypatch, capsys):
+    repo = _git_repo_with_roster(tmp_path)
+    output_dir = tmp_path / "run"
+
+    def fake_run(task, loaded_roster, **kwargs):
+        cwd = kwargs["cwd"]
+        output = kwargs["output_dir"]
+        (cwd / "tracked.txt").write_text("changed in worktree\n")
+        _write_successful_worktree_run(output, cwd, final="implementation complete")
+        (output / "worker-results.json").write_text("{not json\n")
+        return 0
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    monkeypatch.setattr(aboyeur, "run", fake_run)
+
+    rc = cli.main(["run", "x", "--cwd", str(repo), "--output-dir", str(output_dir), "--worktree"])
+
+    checkout = tmp_path / "home" / ".cache" / "brigade" / "worktrees" / f"{repo.name}-{output_dir.name}"
+    assert rc == 2
+    assert checkout.exists()
+    assert "failed to parse worker-results.json while recording artifact patch reference" in capsys.readouterr().err
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "failed"
+    assert run_meta["failure_phase"] == "artifact-collection"
+    assert run_meta["failure"]["kind"] == "receipt-update-error"
 
 
 def test_run_cli_rejects_worktree_with_no_artifacts(tmp_path, capsys):

--- a/tests/test_run_resume.py
+++ b/tests/test_run_resume.py
@@ -151,17 +151,19 @@ def test_resume_refuses_nonterminal_run(tmp_path, monkeypatch, capsys):
             }
         ],
     )
-    run_meta = json.loads((run_dir / "run.json").read_text())
-    run_meta["status"] = "dispatching"
-    (run_dir / "run.json").write_text(json.dumps(run_meta))
     monkeypatch.setattr(
         run_resume.codex_appserver,
         "AppServer",
         lambda **kwargs: (_ for _ in ()).throw(AssertionError("provider must not start")),
     )
 
-    assert run_resume.resume(run_dir) == 2
-    assert "run is not terminal" in capsys.readouterr().err
+    for status in ("dispatching", "artifact-collection"):
+        run_meta = json.loads((run_dir / "run.json").read_text())
+        run_meta["status"] = status
+        (run_dir / "run.json").write_text(json.dumps(run_meta))
+
+        assert run_resume.resume(run_dir) == 2
+        assert "run is not terminal" in capsys.readouterr().err
 
 
 def test_resume_refuses_matching_live_owner(tmp_path, monkeypatch, capsys):

--- a/tests/test_runguard.py
+++ b/tests/test_runguard.py
@@ -115,6 +115,26 @@ def test_run_lock_publishes_complete_owner_metadata(tmp_path):
         assert (lock_path / "pid").read_text().strip() == str(os.getpid())
 
 
+def test_run_lock_is_retained_when_terminal_receipt_cannot_be_written(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / "run.json").write_text(json.dumps({"status": "artifact-collection"}))
+    lock_path = runguard.lock_path(repo)
+
+    with pytest.raises(runguard.RetainRunLockError, match="receipt disk full"):
+        with runguard.run_lock(repo, run_dir=run_dir):
+            raise runguard.RetainRunLockError("receipt disk full")
+
+    assert lock_path.is_dir()
+    monkeypatch.setattr(runguard, "_pid_is_active", lambda pid: False)
+    assert runguard.recover_stale_run(repo, run_dir) is True
+    assert not lock_path.exists()
+    recovered = json.loads((run_dir / "run.json").read_text())
+    assert recovered["status"] == "failed"
+    assert recovered["failure"]["prior_status"] == "artifact-collection"
+
+
 def test_run_lock_release_does_not_delete_replacement_owner(tmp_path):
     repo = _repo(tmp_path)
     lock_path = runguard.lock_path(repo)
@@ -271,7 +291,7 @@ def test_run_lock_recovers_dead_owner_run_to_typed_terminal_state(tmp_path):
     abandoned_run = tmp_path / "abandoned-run"
     abandoned_run.mkdir()
     (abandoned_run / "run.json").write_text(
-        json.dumps({"schema": "brigade.run.v1", "status": "dispatching", "task": "inspect"})
+        json.dumps({"schema": "brigade.run.v1", "status": "artifact-collection", "task": "inspect"})
     )
     lock_path = runguard.lock_path(repo)
     lock_path.mkdir(parents=True)
@@ -297,7 +317,7 @@ def test_run_lock_recovers_dead_owner_run_to_typed_terminal_state(tmp_path):
             "kind": "owner-process-exited",
             "detail": "run owner process 99999999 is no longer active",
             "owner_pid": 99999999,
-            "prior_status": "dispatching",
+            "prior_status": "artifact-collection",
             "recovered_at": recovered["failure"]["recovered_at"],
         }
         assert recovered["finished_at"] == recovered["failure"]["recovered_at"]

--- a/tests/test_runs_cmd.py
+++ b/tests/test_runs_cmd.py
@@ -3,11 +3,78 @@ import os
 from pathlib import Path
 
 from brigade import cli
+from brigade import runguard
 from brigade import runs_cmd
 
 
 def _write_json(path, payload):
     path.write_text(json.dumps(payload, indent=2) + "\n")
+
+
+def test_artifact_collection_status_is_nonterminal():
+    assert runs_cmd._is_terminal({"status": "artifact-collection"}) is False
+
+
+def test_watch_reports_unrecoverable_artifact_collection_lock_error(tmp_path, monkeypatch, capsys):
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    _write_json(
+        run_dir / "run.json",
+        {
+            "status": "artifact-collection",
+            "cwd": str(tmp_path),
+            "lock_workspace": str(tmp_path),
+            "started_at": "2026-07-17T00:00:00Z",
+        },
+    )
+    monkeypatch.setattr(
+        runguard,
+        "recover_stale_run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(runguard.RunLockError("run lock has no owner metadata")),
+    )
+
+    assert runs_cmd.watch(run_dir, cwd=tmp_path, interval=0) == 2
+    assert "artifact-collection recovery failed: run lock has no owner metadata" in capsys.readouterr().err
+
+
+def test_watch_reports_artifact_collection_without_matching_lock(tmp_path, capsys):
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    _write_json(
+        run_dir / "run.json",
+        {
+            "status": "artifact-collection",
+            "cwd": str(tmp_path),
+            "lock_workspace": str(tmp_path),
+            "started_at": "2026-07-17T00:00:00Z",
+        },
+    )
+
+    assert runs_cmd.watch(run_dir, cwd=tmp_path, interval=0) == 2
+    assert "artifact-collection run has no matching recoverable lock" in capsys.readouterr().err
+
+
+def test_watch_handles_artifact_collection_completion_race(tmp_path, monkeypatch):
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    run_path = run_dir / "run.json"
+    payload = {
+        "status": "artifact-collection",
+        "cwd": str(tmp_path),
+        "lock_workspace": str(tmp_path),
+        "started_at": "2026-07-17T00:00:00Z",
+    }
+    _write_json(run_path, payload)
+
+    def finish_without_recovery(*args, **kwargs):
+        payload["status"] = "ok"
+        payload["finished_at"] = "2026-07-17T00:00:01Z"
+        _write_json(run_path, payload)
+        return False
+
+    monkeypatch.setattr(runguard, "recover_stale_run", finish_without_recovery)
+
+    assert runs_cmd.watch(run_dir, cwd=tmp_path, interval=0) == 0
 
 
 def _write_run_artifacts(run_dir):


### PR DESCRIPTION
## Summary

- keep successful worktree runs in a nonterminal `artifact-collection` phase until `changes.patch` is collected and validated
- record typed collection and validation failures while preserving the model result and recovery worktree
- retain the run lock when the terminal receipt cannot be written, then let watch and stale recovery close the abandoned run
- avoid publishing invalid patch references and preserve earlier model or synthesis failures as the primary diagnosis

## Root cause

`aboyeur.run()` wrote terminal `status: ok` before `cli.run.dispatch()` collected or validated the worktree patch. A later collection error or corrupt patch changed the process exit code but could not change the already-successful lifecycle receipt.

## Verification

- focused lifecycle suite: `20260717-030016-work-verify-426a4e`
- full `./scripts/verify`: `20260717-030056-work-verify-e9d56f`
- 2,548 passed, 3 skipped, 81.55% coverage
- exact reviewed head: `dc08daa0c4ebe0f22f1816030098e6a261f391e2`

Fixes #283