### PR TITLE
feat(run): record roster resolution provenance

### DIFF
--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -1570,8 +1570,18 @@ def record_artifact_collection(
         raise runguard.RetainRunLockError(f"failed to update run receipt after artifact collection: {exc}") from exc
 
 
-def _roster_payload(roster: Roster) -> dict[str, object]:
+def _roster_resolution_payload(roster: Roster) -> dict[str, object] | None:
+    if roster.resolution is None:
+        return None
     return {
+        "path": str(roster.resolution.path),
+        "source": roster.resolution.source,
+        "shadowed": [str(path) for path in roster.resolution.shadowed],
+    }
+
+
+def _roster_payload(roster: Roster) -> dict[str, object]:
+    payload: dict[str, object] = {
         "schema": "brigade.roster_snapshot.v1",
         "orchestrator": roster.orchestrator,
         "max_workers": roster.max_workers,
@@ -1591,6 +1601,9 @@ def _roster_payload(roster: Roster) -> dict[str, object]:
             for name, agent in roster.agents.items()
         },
     }
+    if resolution := _roster_resolution_payload(roster):
+        payload["resolution"] = resolution
+    return payload
 
 
 def _run_payload(
@@ -1649,6 +1662,8 @@ def _run_payload(
             "attached": list(brief_set.attached) if brief_set is not None else [],
         },
     }
+    if resolution := _roster_resolution_payload(roster):
+        payload["roster"] = resolution
     if lock_workspace is not None:
         payload["lock_workspace"] = str(lock_workspace)
     if route is not None:

--- a/src/brigade/cli/run.py
+++ b/src/brigade/cli/run.py
@@ -35,6 +35,19 @@ def register(sub: argparse._SubParsersAction) -> None:
         default=None,
         help="Path to roster.toml. Defaults to .brigade/roster.toml under the current directory.",
     )
+    p_run.add_argument(
+        "--resolved-roster-source",
+        choices=("explicit", "workspace", "user"),
+        default=None,
+        help=argparse.SUPPRESS,
+    )
+    p_run.add_argument(
+        "--resolved-roster-shadowed",
+        action="append",
+        default=[],
+        type=Path,
+        help=argparse.SUPPRESS,
+    )
     p_run.add_argument("--dry-run", action="store_true", help="Print the plan without dispatching workers.")
     p_run.add_argument(
         "--worker",
@@ -198,12 +211,19 @@ def dispatch(args) -> int:
         print(f"error: --worktree requires a git worktree: {run_cwd}", file=sys.stderr)
         return 2
     try:
-        roster_path = roster_mod.resolve_roster_path(run_cwd, args.roster)
+        roster_resolution = roster_mod.resolve_roster(run_cwd, args.roster)
     except FileNotFoundError as exc:
         print(f"error: {exc}. Create .brigade/roster.toml or pass --roster.", file=sys.stderr)
         return 2
+    if args.resolved_roster_source is not None:
+        roster_resolution = roster_mod.RosterResolution(
+            path=roster_resolution.path,
+            source=args.resolved_roster_source,
+            shadowed=tuple(path.expanduser().resolve() for path in args.resolved_roster_shadowed),
+        )
+    roster_path = roster_resolution.path
     try:
-        loaded_roster = roster_mod.load_roster(roster_path)
+        loaded_roster = roster_mod.load_roster(roster_path, resolution=roster_resolution)
     except FileNotFoundError:
         print(
             f"error: roster not found: {roster_path}. Create .brigade/roster.toml or pass --roster.",
@@ -213,6 +233,13 @@ def dispatch(args) -> int:
     except ValueError as exc:
         print(f"error: invalid roster at {roster_path}: {exc}", file=sys.stderr)
         return 2
+    print(f"roster: {roster_resolution.path} ({roster_resolution.source})", file=sys.stderr)
+    for shadowed in roster_resolution.shadowed:
+        print(
+            f"warning: workspace roster {roster_resolution.path} shadows user roster {shadowed}; "
+            "pass --roster PATH to choose either file explicitly.",
+            file=sys.stderr,
+        )
     if args.worker is not None:
         worker_error = _direct_worker_error(args.worker, loaded_roster, roster_mod)
         if worker_error is not None:
@@ -265,7 +292,12 @@ def dispatch(args) -> int:
 
     if args.detach:
         assert output_dir is not None
-        return _dispatch_detached(args, run_cwd=run_cwd, roster_path=roster_path, output_dir=output_dir)
+        return _dispatch_detached(
+            args,
+            run_cwd=run_cwd,
+            roster_resolution=roster_resolution,
+            output_dir=output_dir,
+        )
 
     worktree_cwd = None
     effective_cwd = run_cwd
@@ -406,11 +438,16 @@ def dispatch(args) -> int:
     return rc
 
 
-def _dispatch_detached(args, *, run_cwd: Path, roster_path: Path, output_dir: Path) -> int:
+def _dispatch_detached(args, *, run_cwd: Path, roster_resolution, output_dir: Path) -> int:
     output_dir = output_dir.expanduser().resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
     log_path = output_dir / "detached.log"
-    argv = _detached_child_argv(args, run_cwd=run_cwd, roster_path=roster_path, output_dir=output_dir)
+    argv = _detached_child_argv(
+        args,
+        run_cwd=run_cwd,
+        roster_resolution=roster_resolution,
+        output_dir=output_dir,
+    )
     try:
         with log_path.open("a", encoding="utf-8") as log:
             proc = Popen(
@@ -445,7 +482,7 @@ def _dispatch_detached(args, *, run_cwd: Path, roster_path: Path, output_dir: Pa
     return 0
 
 
-def _detached_child_argv(args, *, run_cwd: Path, roster_path: Path, output_dir: Path) -> list[str]:
+def _detached_child_argv(args, *, run_cwd: Path, roster_resolution, output_dir: Path) -> list[str]:
     argv = [
         sys.executable,
         "-m",
@@ -453,12 +490,16 @@ def _detached_child_argv(args, *, run_cwd: Path, roster_path: Path, output_dir: 
         "run",
         args.task,
         "--roster",
-        str(roster_path.expanduser().resolve()),
+        str(roster_resolution.path),
+        "--resolved-roster-source",
+        roster_resolution.source,
         "--cwd",
         str(run_cwd),
         "--output-dir",
         str(output_dir),
     ]
+    for shadowed in roster_resolution.shadowed:
+        argv.extend(["--resolved-roster-shadowed", str(shadowed)])
     if args.allow_dirty:
         argv.append("--allow-dirty")
     if args.worktree:

--- a/src/brigade/roster.py
+++ b/src/brigade/roster.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import fnmatch
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 
 from . import agents as agent_adapters
 from . import toml_compat
@@ -13,6 +14,14 @@ SANDBOX_CHOICES = ("read-only", "workspace-write", "danger-full-access")
 CODEX_TRANSPORT_CHOICES = ("exec", "app-server")
 AGENT_TRANSPORT_CHOICES = ("direct", "acpx")
 ACPX_TRANSPORT_VERSION = "0.12.0"
+RosterSource = Literal["explicit", "workspace", "user"]
+
+
+@dataclass(frozen=True)
+class RosterResolution:
+    path: Path
+    source: RosterSource
+    shadowed: tuple[Path, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -38,6 +47,7 @@ class Roster:
     timeout_seconds: float = 600.0
     sandbox: str | None = None
     codex_transport: str = "exec"
+    resolution: RosterResolution | None = None
 
     def find_role(self, role: str) -> Agent | None:
         return next((a for a in self.agents.values() if a.role == role), None)
@@ -78,23 +88,31 @@ def _allowed(cli_ref: str, patterns: tuple[str, ...]) -> bool:
     return any(fnmatch.fnmatchcase(cli_ref, pattern) for pattern in patterns)
 
 
-def resolve_roster_path(target: Path, explicit: Path | None = None) -> Path:
+def resolve_roster(target: Path, explicit: Path | None = None) -> RosterResolution:
     if explicit is not None:
-        path = explicit.expanduser()
+        path = explicit.expanduser().resolve()
         if path.exists():
-            return path
+            return RosterResolution(path=path, source="explicit")
         raise FileNotFoundError(f"roster not found: {path}")
 
-    workspace_path = target.expanduser() / ".brigade" / "roster.toml"
-    user_path = Path.home() / ".brigade" / "roster.toml"
+    workspace_path = (target.expanduser() / ".brigade" / "roster.toml").resolve()
+    user_path = (Path.home() / ".brigade" / "roster.toml").expanduser().resolve()
     if workspace_path.exists():
-        return workspace_path
+        shadowed = (user_path,) if user_path != workspace_path and user_path.exists() else ()
+        return RosterResolution(path=workspace_path, source="workspace", shadowed=shadowed)
     if user_path.exists():
-        return user_path
+        return RosterResolution(path=user_path, source="user")
     raise FileNotFoundError(f"roster not found: checked {workspace_path} and {user_path}")
 
 
-def load_roster(path: Path) -> Roster:
+def resolve_roster_path(target: Path, explicit: Path | None = None) -> Path:
+    """Return only the selected path for callers that do not need provenance."""
+
+    return resolve_roster(target, explicit).path
+
+
+def load_roster(path: Path, *, resolution: RosterResolution | None = None) -> Roster:
+    path = path.expanduser().resolve()
     if not path.exists():
         raise FileNotFoundError(f"roster not found: {path}")
 
@@ -220,6 +238,7 @@ def load_roster(path: Path) -> Roster:
         timeout_seconds=timeout_seconds,
         sandbox=sandbox,
         codex_transport=codex_transport,
+        resolution=resolution,
     )
 
 

--- a/tests/test_roster.py
+++ b/tests/test_roster.py
@@ -46,6 +46,12 @@ def test_load_valid_roster(tmp_path):
     assert not roster_mod.is_cli_allowed("claude", r)
 
 
+def test_load_roster_without_resolution_does_not_invent_source(tmp_path):
+    loaded = roster_mod.load_roster(_write(tmp_path, VALID))
+
+    assert loaded.resolution is None
+
+
 def test_load_roster_fallback_parser(monkeypatch, tmp_path):
     # Force the pure-Python TOML fallback (the Python 3.10 path, where tomllib
     # is absent) and confirm a real roster still loads through it.
@@ -65,7 +71,62 @@ def test_resolve_roster_path_prefers_workspace(monkeypatch, tmp_path):
     local.write_text(VALID)
     user.write_text(VALID)
     monkeypatch.setattr(Path, "home", lambda: home)
-    assert roster_mod.resolve_roster_path(workspace) == local
+    assert roster_mod.resolve_roster_path(workspace) == local.resolve()
+
+
+def test_resolve_roster_reports_workspace_shadowing_user_roster(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    workspace = tmp_path / "workspace"
+    local = workspace / ".brigade" / "roster.toml"
+    user = home / ".brigade" / "roster.toml"
+    local.parent.mkdir(parents=True)
+    user.parent.mkdir(parents=True)
+    local.write_text(VALID)
+    user.write_text(VALID)
+    monkeypatch.setattr(Path, "home", lambda: home)
+
+    resolution = roster_mod.resolve_roster(workspace)
+
+    assert resolution.path == local.resolve()
+    assert resolution.source == "workspace"
+    assert resolution.shadowed == (user.resolve(),)
+
+
+def test_resolve_roster_does_not_shadow_same_file_through_workspace_symlink(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    workspace = tmp_path / "workspace"
+    user = home / ".brigade" / "roster.toml"
+    user.parent.mkdir(parents=True)
+    user.write_text(VALID)
+    workspace.mkdir()
+    (workspace / ".brigade").symlink_to(user.parent, target_is_directory=True)
+    monkeypatch.setattr(Path, "home", lambda: home)
+
+    resolution = roster_mod.resolve_roster(workspace)
+
+    assert resolution.path == user.resolve()
+    assert resolution.source == "workspace"
+    assert resolution.shadowed == ()
+
+
+def test_resolve_roster_explicit_choice_has_no_implicit_shadow(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    workspace = tmp_path / "workspace"
+    local = workspace / ".brigade" / "roster.toml"
+    user = home / ".brigade" / "roster.toml"
+    explicit = tmp_path / "chosen.toml"
+    local.parent.mkdir(parents=True)
+    user.parent.mkdir(parents=True)
+    local.write_text(VALID)
+    user.write_text(VALID)
+    explicit.write_text(VALID)
+    monkeypatch.setattr(Path, "home", lambda: home)
+
+    resolution = roster_mod.resolve_roster(workspace, explicit)
+
+    assert resolution.path == explicit.resolve()
+    assert resolution.source == "explicit"
+    assert resolution.shadowed == ()
 
 
 def test_resolve_roster_path_uses_user_fallback(monkeypatch, tmp_path):
@@ -74,7 +135,21 @@ def test_resolve_roster_path_uses_user_fallback(monkeypatch, tmp_path):
     user.parent.mkdir(parents=True)
     user.write_text(VALID)
     monkeypatch.setattr(Path, "home", lambda: home)
-    assert roster_mod.resolve_roster_path(tmp_path / "workspace") == user
+    assert roster_mod.resolve_roster_path(tmp_path / "workspace") == user.resolve()
+
+
+def test_resolve_roster_reports_user_fallback_source(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    user = home / ".brigade" / "roster.toml"
+    user.parent.mkdir(parents=True)
+    user.write_text(VALID)
+    monkeypatch.setattr(Path, "home", lambda: home)
+
+    resolution = roster_mod.resolve_roster(tmp_path / "workspace")
+
+    assert resolution.path == user.resolve()
+    assert resolution.source == "user"
+    assert resolution.shadowed == ()
 
 
 def test_resolve_roster_path_explicit_never_falls_back(monkeypatch, tmp_path):

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -424,6 +424,103 @@ role = "code"
     assert seen["orchestrator"] == "chef"
 
 
+def test_run_cli_records_workspace_roster_provenance_and_shadow_warning(tmp_path, monkeypatch, capsys):
+    workspace = tmp_path / "workspace"
+    workspace_roster = workspace / ".brigade" / "roster.toml"
+    home = tmp_path / "home"
+    user_roster = home / ".brigade" / "roster.toml"
+    workspace_roster.parent.mkdir(parents=True)
+    user_roster.parent.mkdir(parents=True)
+    roster_text = (
+        'orchestrator = "chef"\n'
+        '[agents.chef]\ncli = "codex"\nrole = "plan"\n'
+        '[agents.coder]\ncli = "codex"\nrole = "code"\n'
+    )
+    workspace_roster.write_text(roster_text)
+    user_roster.write_text(roster_text)
+    output_dir = tmp_path / "run"
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setattr(
+        aboyeur.agents,
+        "run_agent",
+        lambda *args, **kwargs: agents.AgentResult(
+            text=json.dumps({"assignments": [{"worker": "coder", "task": "inspect"}]}),
+            ok=True,
+        ),
+    )
+
+    rc = cli.main(
+        [
+            "run",
+            "inspect",
+            "--cwd",
+            str(workspace),
+            "--output-dir",
+            str(output_dir),
+            "--dry-run",
+            "--no-code-graph",
+            "--no-evidence",
+            "--no-route",
+        ]
+    )
+
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert f"roster: {workspace_roster.resolve()} (workspace)" in err
+    assert f"workspace roster {workspace_roster.resolve()} shadows user roster {user_roster.resolve()}" in err
+    assert "--roster" in err
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["roster"] == {
+        "path": str(workspace_roster.resolve()),
+        "source": "workspace",
+        "shadowed": [str(user_roster.resolve())],
+    }
+    roster_meta = json.loads((output_dir / "roster.json").read_text())
+    assert roster_meta["resolution"] == {
+        "path": str(workspace_roster.resolve()),
+        "source": "workspace",
+        "shadowed": [str(user_roster.resolve())],
+    }
+
+
+def test_run_cli_explicit_direct_worker_reports_choice_without_shadow_warning(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "home"
+    user_roster = home / ".brigade" / "roster.toml"
+    workspace_roster = tmp_path / ".brigade" / "roster.toml"
+    explicit_roster = tmp_path / "chosen.toml"
+    user_roster.parent.mkdir(parents=True)
+    workspace_roster.parent.mkdir(parents=True)
+    roster_text = (
+        'orchestrator = "chef"\n'
+        '[agents.chef]\ncli = "codex"\nrole = "plan"\n'
+        '[agents.coder]\ncli = "codex"\nrole = "code"\n'
+    )
+    for path in (user_roster, workspace_roster, explicit_roster):
+        path.write_text(roster_text)
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setattr(aboyeur, "run", lambda *args, **kwargs: 0)
+
+    rc = cli.main(
+        [
+            "run",
+            "inspect",
+            "--cwd",
+            str(tmp_path),
+            "--roster",
+            str(explicit_roster),
+            "--worker",
+            "coder",
+            "--no-artifacts",
+            "--read-only",
+        ]
+    )
+
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert f"roster: {explicit_roster.resolve()} (explicit)" in err
+    assert "shadows user roster" not in err
+
+
 def test_run_cli_identifies_fallback_roster_in_validation_error(tmp_path, monkeypatch, capsys):
     home = tmp_path / "home"
     roster_path = home / ".brigade" / "roster.toml"

--- a/tests/test_run_detach.py
+++ b/tests/test_run_detach.py
@@ -3,6 +3,7 @@ import json
 from pathlib import Path
 
 from brigade import aboyeur, cli
+from brigade import roster as roster_mod
 from brigade.cli import run as run_cli
 
 
@@ -98,9 +99,18 @@ def test_run_detach_reports_early_child_exit(tmp_path, monkeypatch, capsys):
 
 def test_run_detach_child_records_artifact_identity_in_lock(tmp_path, monkeypatch):
     _write_roster(tmp_path)
+    home = tmp_path / "home"
+    home.mkdir()
+    _write_roster(home)
+    workspace_roster = tmp_path / ".brigade" / "roster.toml"
+    user_roster = home / ".brigade" / "roster.toml"
     seen = {}
 
     def fake_run(*args, output_dir=None, **kwargs):
+        resolution = args[1].resolution
+        seen["roster_path"] = str(resolution.path)
+        seen["roster_source"] = resolution.source
+        seen["roster_shadowed"] = [str(path) for path in resolution.shadowed]
         owner_path = tmp_path / ".brigade" / "run.lock" / "owner.json"
         seen.update(json.loads(owner_path.read_text()))
         output_dir.mkdir(parents=True, exist_ok=True)
@@ -118,12 +128,16 @@ def test_run_detach_child_records_artifact_identity_in_lock(tmp_path, monkeypatc
 
     monkeypatch.setattr(aboyeur, "run", fake_run)
     monkeypatch.setattr(run_cli, "Popen", FakeProcess)
+    monkeypatch.setattr(Path, "home", lambda: home)
 
     assert cli.main(["run", "do work", "--cwd", str(tmp_path), "--detach"]) == 0
 
     run_dir = next((tmp_path / ".brigade" / "runs").iterdir())
     assert seen["run_dir"] == str(run_dir.resolve())
     assert isinstance(seen["owner_token"], str) and seen["owner_token"]
+    assert seen["roster_path"] == str(workspace_roster.resolve())
+    assert seen["roster_source"] == "workspace"
+    assert seen["roster_shadowed"] == [str(user_roster.resolve())]
     assert not (tmp_path / ".brigade" / "run.lock").exists()
 
 
@@ -144,16 +158,22 @@ def test_run_detach_child_argv_preserves_worker(tmp_path):
         worker="coder",
         wait=2.5,
     )
-    roster_path = tmp_path / "roster.toml"
+    roster_resolution = roster_mod.RosterResolution(
+        path=(tmp_path / "roster.toml").resolve(),
+        source="workspace",
+        shadowed=((tmp_path / "user-roster.toml").resolve(),),
+    )
     output_dir = tmp_path / "run"
 
     argv = run_cli._detached_child_argv(
         args,
         run_cwd=tmp_path,
-        roster_path=roster_path,
+        roster_resolution=roster_resolution,
         output_dir=output_dir,
     )
 
     assert "--worker" in argv
     assert argv[argv.index("--worker") + 1] == "coder"
     assert argv[argv.index("--wait") + 1] == "2.5"
+    assert argv[argv.index("--resolved-roster-source") + 1] == "workspace"
+    assert argv[argv.index("--resolved-roster-shadowed") + 1] == str(roster_resolution.shadowed[0])


### PR DESCRIPTION
## Summary

- Record the canonical roster path, selection source, and shadowed candidates in `run.json` and `roster.json`.
- Print the resolved roster before dispatch and warn when an implicit workspace roster shadows a distinct user roster.
- Preserve the parent's exact roster identity through detached child dispatch, including symlinked roster paths.

## Root cause

`resolve_roster_path()` returned only a `Path`. The CLI used the selected file, then discarded whether it came from `--roster`, the workspace, or the user fallback before dispatch and receipt serialization. Detached children received the resolved path as an explicit flag, which also erased the parent's selection source.

## Verification

- `./scripts/verify`: 2,570 passed, 3 skipped, 81.58% coverage.
- Brigade receipt: `20260717-034820-work-verify-372612`.
- Focused symlink regression: `20260717-034805-work-verify-63be89`.

Fixes #280