### PR TITLE
fix(run): preflight Cursor ACP authentication

### DIFF
--- a/src/brigade/acpx_adapter.py
+++ b/src/brigade/acpx_adapter.py
@@ -18,13 +18,21 @@ CURSOR_AUTH_RECOVERY = "run `cursor-agent login` once, then verify with `cursor-
 _ANSI_ESCAPE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 _EMAIL = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.IGNORECASE)
 _AUTH_IDENTITY = re.compile(r"(?i)(\blogged in as)\s+[^\r\n]+")
-_SENSITIVE_VALUE = re.compile(r"(?i)\b(token|secret|password|api[_ -]?key)\b\s*[:=]\s*[^\s,;]+")
+_SENSITIVE_VALUE = re.compile(r"(?i)\b(token|secret|password|api[_ -]?key)\b(?:\s*[:=]\s*|\s+)[^\s,;]+")
 _BEARER = re.compile(r"(?i)\b(bearer)\s+[^\s,;]+")
-_UNAUTHENTICATED = re.compile(
-    r"\b(?:not logged in|not authenticated|unauthenticated|authentication required)\b",
+_UNAUTHENTICATED_LINE = re.compile(
+    r"^(?:[x✗✘]\s*)?(?:not logged in|not authenticated|unauthenticated|authentication required)[.!]?$",
     re.IGNORECASE,
 )
-_AUTHENTICATED = re.compile(r"\b(?:logged in|authenticated)\b", re.IGNORECASE)
+_AUTHENTICATED_LINE = re.compile(
+    r"^(?:[✓✔]\s*)?(?:logged in as\s+\S+|authenticated)[.!]?$",
+    re.IGNORECASE,
+)
+_PERMISSION_FAILURE = re.compile(
+    r"\b(?:permission denied|permission required|not permitted|auto-denied)\b",
+    re.IGNORECASE,
+)
+_SAFE_STATUS_KEYS = ("hasAccessToken", "hasRefreshToken", "isAuthenticated", "status")
 
 
 @dataclass(frozen=True)
@@ -50,6 +58,18 @@ def _diagnostic_line(stdout: str, stderr: str) -> str:
     return " ".join(text.split())[:500] or "no diagnostic output"
 
 
+def _status_payload(stdout: str) -> tuple[dict[str, Any] | None, str]:
+    try:
+        payload = json.loads(stdout)
+    except (json.JSONDecodeError, ValueError):
+        return None, _safe_diagnostic(stdout)
+    if not isinstance(payload, dict):
+        return None, _safe_diagnostic(stdout)
+    safe_payload = {key: value for key in _SAFE_STATUS_KEYS if isinstance((value := payload.get(key)), (bool, str))}
+    safe_stdout = json.dumps(safe_payload, sort_keys=True, separators=(",", ":"))
+    return payload, _safe_diagnostic(safe_stdout)
+
+
 def cursor_auth_status() -> CursorAuthStatus:
     """Return a bounded, prompt-free diagnosis for the headless Cursor CLI."""
     if proc.which("cursor-agent") is None:
@@ -60,12 +80,16 @@ def cursor_auth_status() -> CursorAuthStatus:
             "",
             127,
         )
-    result = proc.run(["cursor-agent", "status"], timeout=CURSOR_AUTH_TIMEOUT_SECONDS)
-    stdout = _safe_diagnostic(result.stdout)
+    result = proc.run(
+        ["cursor-agent", "status", "--format", "json"],
+        timeout=CURSOR_AUTH_TIMEOUT_SECONDS,
+    )
+    payload, stdout = _status_payload(result.stdout)
     stderr = _safe_diagnostic(result.stderr)
     diagnostic = _diagnostic_line(stdout, stderr)
-    combined = f"{stdout}\n{stderr}"
-    if _UNAUTHENTICATED.search(combined):
+    authenticated = payload.get("isAuthenticated") if payload is not None else None
+    primary_line = next((line.strip() for line in stdout.splitlines() if line.strip()), "")
+    if authenticated is False or (payload is None and _UNAUTHENTICATED_LINE.fullmatch(primary_line)):
         return CursorAuthStatus(
             "unauthenticated",
             f"cursor-agent CLI is not logged in; {CURSOR_AUTH_RECOVERY}",
@@ -81,7 +105,7 @@ def cursor_auth_status() -> CursorAuthStatus:
             stderr,
             result.code,
         )
-    if _AUTHENTICATED.search(combined):
+    if authenticated is True or (payload is None and _AUTHENTICATED_LINE.fullmatch(primary_line)):
         return CursorAuthStatus(
             "authenticated",
             "cursor-agent CLI is authenticated",
@@ -349,12 +373,21 @@ def run_cursor(
         detail = result.stderr.strip() or parse_error or f"acpx exit {result.code}"
         timed_out = result.code in {3, 124}
         provider_startup = parsed is None
+        permission_denied = bool(_PERMISSION_FAILURE.search(detail))
         return AgentResult(
             text=parsed["text"] if parsed is not None else "",
             ok=False,
             detail=detail[:200],
             failure_phase="inference" if timed_out or not provider_startup else "dispatch",
-            failure_kind=("timeout" if timed_out else "provider-startup" if provider_startup else "transport-error"),
+            failure_kind=(
+                "timeout"
+                if timed_out
+                else "permission-denied"
+                if permission_denied
+                else "provider-startup"
+                if provider_startup
+                else "transport-error"
+            ),
             stdout=result.stdout,
             stderr=result.stderr,
             exit_code=result.code,

--- a/src/brigade/acpx_adapter.py
+++ b/src/brigade/acpx_adapter.py
@@ -4,14 +4,98 @@ from __future__ import annotations
 
 import json
 import re
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from . import proc
 from .agents import AgentResult
 from .result_integrity import validate_final_output
 
 SUPPORTED_VERSION = "0.12.0"
+CURSOR_AUTH_TIMEOUT_SECONDS = 10.0
+CURSOR_AUTH_RECOVERY = "run `cursor-agent login` once, then verify with `cursor-agent status`"
+_ANSI_ESCAPE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+_EMAIL = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.IGNORECASE)
+_AUTH_IDENTITY = re.compile(r"(?i)(\blogged in as)\s+[^\r\n]+")
+_SENSITIVE_VALUE = re.compile(r"(?i)\b(token|secret|password|api[_ -]?key)\b\s*[:=]\s*[^\s,;]+")
+_BEARER = re.compile(r"(?i)\b(bearer)\s+[^\s,;]+")
+_UNAUTHENTICATED = re.compile(
+    r"\b(?:not logged in|not authenticated|unauthenticated|authentication required)\b",
+    re.IGNORECASE,
+)
+_AUTHENTICATED = re.compile(r"\b(?:logged in|authenticated)\b", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class CursorAuthStatus:
+    state: Literal["authenticated", "unauthenticated", "unavailable", "unrecognized"]
+    detail: str
+    stdout: str
+    stderr: str
+    exit_code: int
+
+
+def _safe_diagnostic(text: str, *, limit: int = 2000) -> str:
+    safe = _ANSI_ESCAPE.sub("", text).strip()
+    safe = _AUTH_IDENTITY.sub(r"\1 <redacted>", safe)
+    safe = _EMAIL.sub("<redacted>", safe)
+    safe = _SENSITIVE_VALUE.sub(lambda match: f"{match.group(1)}=<redacted>", safe)
+    safe = _BEARER.sub(lambda match: f"{match.group(1)} <redacted>", safe)
+    return safe[:limit]
+
+
+def _diagnostic_line(stdout: str, stderr: str) -> str:
+    text = stderr or stdout
+    return " ".join(text.split())[:500] or "no diagnostic output"
+
+
+def cursor_auth_status() -> CursorAuthStatus:
+    """Return a bounded, prompt-free diagnosis for the headless Cursor CLI."""
+    if proc.which("cursor-agent") is None:
+        return CursorAuthStatus(
+            "unavailable",
+            "cursor-agent is not installed",
+            "",
+            "",
+            127,
+        )
+    result = proc.run(["cursor-agent", "status"], timeout=CURSOR_AUTH_TIMEOUT_SECONDS)
+    stdout = _safe_diagnostic(result.stdout)
+    stderr = _safe_diagnostic(result.stderr)
+    diagnostic = _diagnostic_line(stdout, stderr)
+    combined = f"{stdout}\n{stderr}"
+    if _UNAUTHENTICATED.search(combined):
+        return CursorAuthStatus(
+            "unauthenticated",
+            f"cursor-agent CLI is not logged in; {CURSOR_AUTH_RECOVERY}",
+            stdout,
+            stderr,
+            result.code,
+        )
+    if result.code != 0:
+        return CursorAuthStatus(
+            "unavailable",
+            f"cursor-agent status failed (exit {result.code}): {diagnostic}",
+            stdout,
+            stderr,
+            result.code,
+        )
+    if _AUTHENTICATED.search(combined):
+        return CursorAuthStatus(
+            "authenticated",
+            "cursor-agent CLI is authenticated",
+            stdout,
+            stderr,
+            result.code,
+        )
+    return CursorAuthStatus(
+        "unrecognized",
+        f"cursor-agent status returned an unrecognized response: {diagnostic}",
+        stdout,
+        stderr,
+        result.code,
+    )
 
 
 def _timeout_arg(value: float) -> str:
@@ -178,12 +262,28 @@ def run_cursor(
             text="",
             ok=False,
             detail=f"unsupported acpx adapter version {version}; reviewed version is {SUPPORTED_VERSION}",
+            failure_phase="preflight",
+            failure_kind="version-mismatch",
             transport="acpx",
         )
     if proc.which("acpx") is None:
-        return AgentResult(text="", ok=False, detail="acpx not installed", transport="acpx")
+        return AgentResult(
+            text="",
+            ok=False,
+            detail="acpx not installed",
+            failure_phase="preflight",
+            failure_kind="missing-executable",
+            transport="acpx",
+        )
     if proc.which("cursor-agent") is None:
-        return AgentResult(text="", ok=False, detail="cursor-agent not installed", transport="acpx")
+        return AgentResult(
+            text="",
+            ok=False,
+            detail="cursor-agent not installed",
+            failure_phase="preflight",
+            failure_kind="missing-executable",
+            transport="acpx",
+        )
     installed, version_error = installed_version()
     if installed != version:
         found = installed or version_error
@@ -191,8 +291,37 @@ def run_cursor(
             text="",
             ok=False,
             detail=f"seat requires acpx {version}; found {found}",
+            failure_phase="preflight",
+            failure_kind="version-mismatch",
             transport="acpx",
             acpx_version=installed,
+        )
+    auth = cursor_auth_status()
+    auth_event: dict[str, object] = {
+        "type": "provider_auth",
+        "status": auth.state,
+        "detail": auth.detail,
+    }
+    if auth.state != "authenticated":
+        failure_kind = {
+            "unauthenticated": "provider-auth",
+            "unavailable": "auth-status-unavailable",
+            "unrecognized": "auth-status-unrecognized",
+        }.get(auth.state, "auth-status-unrecognized")
+        return AgentResult(
+            text="",
+            ok=False,
+            detail=auth.detail,
+            failure_phase="preflight",
+            failure_kind=failure_kind,
+            stdout=auth.stdout,
+            stderr=auth.stderr,
+            exit_code=auth.exit_code,
+            timed_out=auth.exit_code == 124,
+            transport="acpx",
+            requested_model=model,
+            acpx_version=installed,
+            safe_events=(auth_event,),
         )
     try:
         argv = build_argv(
@@ -204,35 +333,53 @@ def run_cursor(
             writable_worktree=writable_worktree,
         )
     except ValueError as exc:
-        return AgentResult(text="", ok=False, detail=str(exc), transport="acpx", acpx_version=installed)
+        return AgentResult(
+            text="",
+            ok=False,
+            detail=str(exc),
+            failure_phase="preflight",
+            failure_kind="unsafe-worktree",
+            transport="acpx",
+            acpx_version=installed,
+            safe_events=(auth_event,),
+        )
     result = proc.run(argv, timeout=timeout + 5.0, cwd=cwd)
     parsed, parse_error = parse_stream(result.stdout)
     if result.code != 0:
         detail = result.stderr.strip() or parse_error or f"acpx exit {result.code}"
+        timed_out = result.code in {3, 124}
+        provider_startup = parsed is None
         return AgentResult(
             text=parsed["text"] if parsed is not None else "",
             ok=False,
             detail=detail[:200],
+            failure_phase="inference" if timed_out or not provider_startup else "dispatch",
+            failure_kind=("timeout" if timed_out else "provider-startup" if provider_startup else "transport-error"),
             stdout=result.stdout,
             stderr=result.stderr,
             exit_code=result.code,
-            timed_out=result.code in {3, 124},
+            timed_out=timed_out,
             transport="acpx",
             requested_model=model,
             effective_model=parsed.get("effective_model") if parsed is not None else None,
             acpx_version=installed,
+            safe_events=(auth_event, *(parsed["events"] if parsed is not None else [])),
         )
     if parsed is None:
+        empty_final = parse_error == "ACP stream contained no final assistant text"
         return AgentResult(
             text="",
             ok=False,
             detail=parse_error[:200],
+            failure_phase="output-validation",
+            failure_kind="empty-output" if empty_final else "malformed-transport",
             stdout=result.stdout,
             stderr=result.stderr,
             exit_code=result.code,
             transport="acpx",
             requested_model=model,
             acpx_version=installed,
+            safe_events=(auth_event,),
         )
     if parsed["stop_reason"] != "end_turn":
         stop_reason = parsed["stop_reason"] or "missing"
@@ -253,7 +400,7 @@ def run_cursor(
             session_id=parsed["session_id"],
             request_id=parsed["request_id"],
             acpx_version=installed,
-            safe_events=tuple(parsed["events"]),
+            safe_events=(auth_event, *parsed["events"]),
         )
     output_failure = validate_final_output(parsed["text"])
     if output_failure is not None:
@@ -274,7 +421,7 @@ def run_cursor(
             session_id=parsed["session_id"],
             request_id=parsed["request_id"],
             acpx_version=installed,
-            safe_events=tuple(parsed["events"]),
+            safe_events=(auth_event, *parsed["events"]),
         )
     return AgentResult(
         text=parsed["text"],
@@ -290,5 +437,5 @@ def run_cursor(
         session_id=parsed["session_id"],
         request_id=parsed["request_id"],
         acpx_version=installed,
-        safe_events=tuple(parsed["events"]),
+        safe_events=(auth_event, *parsed["events"]),
     )

--- a/src/brigade/roster_cmd.py
+++ b/src/brigade/roster_cmd.py
@@ -210,6 +210,9 @@ def doctor(target: Path, *, roster_path: Path | None = None) -> int:
                 installed, detail = acpx_adapter.installed_version()
                 if installed == agent.transport_version:
                     checks.append((doctor_mod.OK, f"agent: {name} acpx", f"version {installed}"))
+                    auth = acpx_adapter.cursor_auth_status()
+                    auth_status = doctor_mod.OK if auth.state == "authenticated" else doctor_mod.FAIL
+                    checks.append((auth_status, f"agent: {name} cursor auth", auth.detail))
                 else:
                     checks.append(
                         (

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -1345,6 +1345,71 @@ def test_dispatch_uses_acpx_transport(monkeypatch, tmp_path):
     assert seen["read_only"] is True
 
 
+def test_direct_acpx_auth_failure_reaches_worker_run_receipt_and_human_summary(monkeypatch, capsys, tmp_path):
+    from brigade import acpx_adapter
+
+    diagnosis = (
+        "cursor-agent CLI is not logged in; run `cursor-agent login` once, then verify with `cursor-agent status`"
+    )
+
+    def fake_cursor(prompt, **kwargs):
+        return agents.AgentResult(
+            text="",
+            ok=False,
+            detail=diagnosis,
+            failure_phase="preflight",
+            failure_kind="provider-auth",
+            stdout="Not logged in",
+            stderr="",
+            exit_code=0,
+            transport="acpx",
+            requested_model="composer-2.5",
+            acpx_version="0.12.0",
+        )
+
+    monkeypatch.setattr(acpx_adapter, "run_cursor", fake_cursor)
+    roster = Roster(
+        orchestrator="chef",
+        agents={
+            "chef": Agent("chef", "codex", "plan"),
+            "composer": Agent(
+                "composer",
+                "cursor",
+                "review",
+                model="composer-2.5",
+                transport="acpx",
+                transport_version="0.12.0",
+            ),
+        },
+    )
+    output_dir = tmp_path / "run"
+
+    rc = aboyeur.run(
+        "inspect",
+        roster,
+        worker="composer",
+        cwd=tmp_path,
+        output_dir=output_dir,
+        read_only=True,
+        route_enabled=False,
+    )
+
+    assert rc == 2
+    assert capsys.readouterr().err.strip() == f"error: worker failed: {diagnosis}"
+    worker = json.loads((output_dir / "worker-results.json").read_text())["results"][0]
+    assert worker["detail"] == diagnosis
+    assert worker["failure_phase"] == "preflight"
+    assert worker["failure_kind"] == "provider-auth"
+    assert (output_dir / worker["stdout_log"]).read_text() == "Not logged in"
+    run_payload = json.loads((output_dir / "run.json").read_text())
+    assert run_payload["error"] == diagnosis
+    assert run_payload["failure"] == {
+        "phase": "preflight",
+        "kind": "provider-auth",
+        "detail": diagnosis,
+    }
+
+
 def test_roster_payload_includes_model():
     payload = aboyeur._roster_payload(_model_roster())
     assert payload["agents"]["architect"]["model"] == "claude-fable-5"

--- a/tests/test_acpx_adapter.py
+++ b/tests/test_acpx_adapter.py
@@ -39,6 +39,155 @@ def _success_stream() -> str:
     )
 
 
+def _authenticated_status() -> acpx_adapter.CursorAuthStatus:
+    return acpx_adapter.CursorAuthStatus(
+        "authenticated",
+        "cursor-agent CLI is authenticated",
+        "Logged in as <redacted>",
+        "",
+        0,
+    )
+
+
+def test_cursor_auth_status_is_prompt_free_bounded_and_redacted(monkeypatch):
+    seen = {}
+
+    def fake_run(argv, **kwargs):
+        seen.update(argv=argv, kwargs=kwargs)
+        return proc.Result(0, "✓ Logged in as person@example.test\n", "")
+
+    monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
+    monkeypatch.setattr(acpx_adapter.proc, "run", fake_run)
+
+    status = acpx_adapter.cursor_auth_status()
+
+    assert status.state == "authenticated"
+    assert status.detail == "cursor-agent CLI is authenticated"
+    assert status.stdout == "✓ Logged in as <redacted>"
+    assert "person@example.test" not in repr(status)
+    assert seen == {"argv": ["cursor-agent", "status"], "kwargs": {"timeout": 10.0}}
+
+
+def test_cursor_auth_status_reports_unauthenticated_with_recovery(monkeypatch):
+    monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
+    monkeypatch.setattr(
+        acpx_adapter.proc,
+        "run",
+        lambda argv, **kwargs: proc.Result(1, "Not logged in\n", ""),
+    )
+
+    status = acpx_adapter.cursor_auth_status()
+
+    assert status.state == "unauthenticated"
+    assert status.detail == (
+        "cursor-agent CLI is not logged in; run `cursor-agent login` once, then verify with `cursor-agent status`"
+    )
+    assert status.stdout == "Not logged in"
+    assert status.exit_code == 1
+
+
+def test_cursor_auth_status_distinguishes_failure_and_unrecognized_output(monkeypatch):
+    monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
+    outputs = iter(
+        [
+            proc.Result(124, "", "timeout after 10.0s"),
+            proc.Result(0, "status format changed", ""),
+        ]
+    )
+    monkeypatch.setattr(acpx_adapter.proc, "run", lambda argv, **kwargs: next(outputs))
+
+    failed = acpx_adapter.cursor_auth_status()
+    unknown = acpx_adapter.cursor_auth_status()
+
+    assert failed.state == "unavailable"
+    assert failed.detail == "cursor-agent status failed (exit 124): timeout after 10.0s"
+    assert failed.exit_code == 124
+    assert unknown.state == "unrecognized"
+    assert unknown.detail == "cursor-agent status returned an unrecognized response: status format changed"
+
+
+def test_run_refuses_unauthenticated_cursor_before_acpx(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append(argv)
+        if argv == ["acpx", "--version"]:
+            return proc.Result(0, "acpx 0.12.0\n", "")
+        if argv == ["cursor-agent", "status"]:
+            return proc.Result(0, "Not logged in\n", "")
+        raise AssertionError(f"ACPX must not start when Cursor is unauthenticated: {argv}")
+
+    monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
+    monkeypatch.setattr(acpx_adapter.proc, "run", fake_run)
+
+    result = acpx_adapter.run_cursor(
+        "inspect", cwd=tmp_path, timeout=120, model="composer-2.5", version="0.12.0", read_only=True
+    )
+
+    assert result.ok is False
+    assert result.failure_phase == "preflight"
+    assert result.failure_kind == "provider-auth"
+    assert result.detail == (
+        "cursor-agent CLI is not logged in; run `cursor-agent login` once, then verify with `cursor-agent status`"
+    )
+    assert result.stdout == "Not logged in"
+    assert result.exit_code == 0
+    assert calls == [["acpx", "--version"], ["cursor-agent", "status"]]
+
+
+def test_run_refuses_unavailable_or_unrecognized_cursor_status_before_acpx(monkeypatch, tmp_path):
+    monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
+    outputs = iter(
+        [
+            proc.Result(0, "acpx 0.12.0\n", ""),
+            proc.Result(5, "", "status service unavailable"),
+            proc.Result(0, "acpx 0.12.0\n", ""),
+            proc.Result(0, "new status format", ""),
+        ]
+    )
+    monkeypatch.setattr(acpx_adapter.proc, "run", lambda argv, **kwargs: next(outputs))
+
+    unavailable = acpx_adapter.run_cursor(
+        "inspect", cwd=tmp_path, timeout=120, model="composer-2.5", version="0.12.0", read_only=True
+    )
+    unrecognized = acpx_adapter.run_cursor(
+        "inspect", cwd=tmp_path, timeout=120, model="composer-2.5", version="0.12.0", read_only=True
+    )
+
+    assert unavailable.ok is False
+    assert unavailable.failure_phase == "preflight"
+    assert unavailable.failure_kind == "auth-status-unavailable"
+    assert unavailable.exit_code == 5
+    assert unrecognized.ok is False
+    assert unrecognized.failure_phase == "preflight"
+    assert unrecognized.failure_kind == "auth-status-unrecognized"
+    assert unrecognized.exit_code == 0
+
+
+def test_run_authenticated_cursor_reaches_acpx_and_preserves_short_final(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append(argv)
+        if argv == ["acpx", "--version"]:
+            return proc.Result(0, "acpx 0.12.0\n", "")
+        if argv == ["cursor-agent", "status"]:
+            return proc.Result(0, "Logged in as person@example.test\n", "")
+        return proc.Result(0, _success_stream().replace('"text": "hello"', '"text": "No findings."'), "")
+
+    monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
+    monkeypatch.setattr(acpx_adapter.proc, "run", fake_run)
+
+    result = acpx_adapter.run_cursor(
+        "inspect", cwd=tmp_path, timeout=120, model="composer-2.5", version="0.12.0", read_only=True
+    )
+
+    assert result.ok is True
+    assert result.text == "No findings."
+    assert calls[1] == ["cursor-agent", "status"]
+    assert calls[2][0] == "acpx"
+
+
 def test_build_argv_is_bounded_and_permission_specific(tmp_path):
     read = acpx_adapter.build_argv(
         prompt="inspect",
@@ -97,6 +246,7 @@ def test_build_argv_refuses_writable_non_worktree(tmp_path):
 
 def test_run_parses_protocol_and_final_text(monkeypatch, tmp_path):
     monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
+    monkeypatch.setattr(acpx_adapter, "cursor_auth_status", _authenticated_status)
     calls = []
 
     def fake_run(argv, **kwargs):
@@ -127,6 +277,7 @@ def test_run_rejects_in_band_provider_error_with_protocol_evidence(monkeypatch, 
     )
     stream = _success_stream().replace('"text": "hello"', f'"text": {json.dumps(diagnostic)}')
     monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
+    monkeypatch.setattr(acpx_adapter, "cursor_auth_status", _authenticated_status)
     outputs = iter([proc.Result(0, "acpx 0.12.0\n", ""), proc.Result(0, stream, "")])
     monkeypatch.setattr(acpx_adapter.proc, "run", lambda argv, **kwargs: next(outputs))
 
@@ -148,6 +299,7 @@ def test_run_rejects_in_band_provider_error_with_protocol_evidence(monkeypatch, 
 def test_run_accepts_short_substantive_final(monkeypatch, tmp_path):
     stream = _success_stream().replace('"text": "hello"', '"text": "No findings."')
     monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
+    monkeypatch.setattr(acpx_adapter, "cursor_auth_status", _authenticated_status)
     outputs = iter([proc.Result(0, "acpx 0.12.0\n", ""), proc.Result(0, stream, "")])
     monkeypatch.setattr(acpx_adapter.proc, "run", lambda argv, **kwargs: next(outputs))
 
@@ -162,6 +314,7 @@ def test_run_accepts_short_substantive_final(monkeypatch, tmp_path):
 def test_run_rejects_non_final_stop_reason_with_partial_text(monkeypatch, tmp_path):
     stream = _success_stream().replace('"stopReason": "end_turn"', '"stopReason": "cancelled"')
     monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
+    monkeypatch.setattr(acpx_adapter, "cursor_auth_status", _authenticated_status)
     outputs = iter([proc.Result(0, "acpx 0.12.0\n", ""), proc.Result(0, stream, "")])
     monkeypatch.setattr(acpx_adapter.proc, "run", lambda argv, **kwargs: next(outputs))
 
@@ -199,6 +352,7 @@ def test_run_correlates_stop_reason_to_prompt_request(monkeypatch, tmp_path):
         {"jsonrpc": "2.0", "id": "unrelated", "result": {"stopReason": "end_turn"}},
     )
     monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
+    monkeypatch.setattr(acpx_adapter, "cursor_auth_status", _authenticated_status)
     outputs = iter([proc.Result(0, "acpx 0.12.0\n", ""), proc.Result(0, stream, "")])
     monkeypatch.setattr(acpx_adapter.proc, "run", lambda argv, **kwargs: next(outputs))
 
@@ -220,10 +374,13 @@ def test_run_rejects_version_mismatch(monkeypatch, tmp_path):
     )
     assert result.ok is False
     assert "requires acpx 0.12.0" in result.detail
+    assert result.failure_phase == "preflight"
+    assert result.failure_kind == "version-mismatch"
 
 
 def test_run_rejects_invalid_or_empty_protocol_output(monkeypatch, tmp_path):
     monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
+    monkeypatch.setattr(acpx_adapter, "cursor_auth_status", _authenticated_status)
     outputs = iter(
         [
             proc.Result(0, "acpx 0.12.0\n", ""),
@@ -241,10 +398,15 @@ def test_run_rejects_invalid_or_empty_protocol_output(monkeypatch, tmp_path):
     )
     assert invalid.ok is False and "invalid ACP NDJSON" in invalid.detail
     assert empty.ok is False and "no final assistant text" in empty.detail
+    assert invalid.failure_phase == "output-validation"
+    assert invalid.failure_kind == "malformed-transport"
+    assert empty.failure_phase == "output-validation"
+    assert empty.failure_kind == "empty-output"
 
 
 def test_run_preserves_timeout_and_permission_exit(monkeypatch, tmp_path):
     monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
+    monkeypatch.setattr(acpx_adapter, "cursor_auth_status", _authenticated_status)
     outputs = iter(
         [
             proc.Result(0, "acpx 0.12.0\n", ""),
@@ -262,3 +424,7 @@ def test_run_preserves_timeout_and_permission_exit(monkeypatch, tmp_path):
     )
     assert timeout.exit_code == 3 and timeout.timed_out is True
     assert denied.exit_code == 5 and denied.detail == "permission denied"
+    assert timeout.failure_phase == "inference"
+    assert timeout.failure_kind == "timeout"
+    assert denied.failure_phase == "dispatch"
+    assert denied.failure_kind == "provider-startup"

--- a/tests/test_acpx_adapter.py
+++ b/tests/test_acpx_adapter.py
@@ -54,7 +54,24 @@ def test_cursor_auth_status_is_prompt_free_bounded_and_redacted(monkeypatch):
 
     def fake_run(argv, **kwargs):
         seen.update(argv=argv, kwargs=kwargs)
-        return proc.Result(0, "✓ Logged in as person@example.test\n", "")
+        return proc.Result(
+            0,
+            json.dumps(
+                {
+                    "isAuthenticated": True,
+                    "hasAccessToken": True,
+                    "hasRefreshToken": True,
+                    "status": "authenticated",
+                    "userInfo": {
+                        "email": "person@example.test",
+                        "firstName": "Private",
+                        "lastName": "Person",
+                        "userId": "user-secret-id",
+                    },
+                }
+            ),
+            "",
+        )
 
     monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
     monkeypatch.setattr(acpx_adapter.proc, "run", fake_run)
@@ -63,9 +80,16 @@ def test_cursor_auth_status_is_prompt_free_bounded_and_redacted(monkeypatch):
 
     assert status.state == "authenticated"
     assert status.detail == "cursor-agent CLI is authenticated"
-    assert status.stdout == "✓ Logged in as <redacted>"
+    assert status.stdout == (
+        '{"hasAccessToken":true,"hasRefreshToken":true,"isAuthenticated":true,"status":"authenticated"}'
+    )
     assert "person@example.test" not in repr(status)
-    assert seen == {"argv": ["cursor-agent", "status"], "kwargs": {"timeout": 10.0}}
+    assert "Private" not in repr(status)
+    assert "user-secret-id" not in repr(status)
+    assert seen == {
+        "argv": ["cursor-agent", "status", "--format", "json"],
+        "kwargs": {"timeout": 10.0},
+    }
 
 
 def test_cursor_auth_status_reports_unauthenticated_with_recovery(monkeypatch):
@@ -73,7 +97,17 @@ def test_cursor_auth_status_reports_unauthenticated_with_recovery(monkeypatch):
     monkeypatch.setattr(
         acpx_adapter.proc,
         "run",
-        lambda argv, **kwargs: proc.Result(1, "Not logged in\n", ""),
+        lambda argv, **kwargs: proc.Result(
+            1,
+            json.dumps(
+                {
+                    "isAuthenticated": False,
+                    "status": "unauthenticated",
+                    "userInfo": {"email": "person@example.test"},
+                }
+            ),
+            "",
+        ),
     )
 
     status = acpx_adapter.cursor_auth_status()
@@ -82,8 +116,54 @@ def test_cursor_auth_status_reports_unauthenticated_with_recovery(monkeypatch):
     assert status.detail == (
         "cursor-agent CLI is not logged in; run `cursor-agent login` once, then verify with `cursor-agent status`"
     )
-    assert status.stdout == "Not logged in"
+    assert status.stdout == '{"isAuthenticated":false,"status":"unauthenticated"}'
     assert status.exit_code == 1
+
+
+def test_cursor_auth_status_uses_boolean_json_state_not_incidental_words(monkeypatch):
+    monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
+    outputs = iter(
+        [
+            proc.Result(0, '{"isAuthenticated":false,"status":"authenticated"}', ""),
+            proc.Result(
+                0,
+                '{"isAuthenticated":true,"status":"authenticated"}',
+                "warning: optional telemetry authentication required",
+            ),
+            proc.Result(0, "authenticated: false", ""),
+        ]
+    )
+    monkeypatch.setattr(acpx_adapter.proc, "run", lambda argv, **kwargs: next(outputs))
+
+    false_state = acpx_adapter.cursor_auth_status()
+    true_state = acpx_adapter.cursor_auth_status()
+    prose = acpx_adapter.cursor_auth_status()
+
+    assert false_state.state == "unauthenticated"
+    assert true_state.state == "authenticated"
+    assert prose.state == "unrecognized"
+
+
+def test_cursor_auth_status_redacts_ansi_and_common_credential_shapes(monkeypatch):
+    monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
+    monkeypatch.setattr(
+        acpx_adapter.proc,
+        "run",
+        lambda argv, **kwargs: proc.Result(
+            5,
+            "",
+            "\x1b[31mToken raw-token Bearer raw-bearer password=raw-password\x1b[0m",
+        ),
+    )
+
+    status = acpx_adapter.cursor_auth_status()
+
+    assert status.state == "unavailable"
+    assert "\x1b" not in status.stderr
+    assert "raw-token" not in repr(status)
+    assert "raw-bearer" not in repr(status)
+    assert "raw-password" not in repr(status)
+    assert status.stderr == "Token=<redacted> Bearer <redacted> password=<redacted>"
 
 
 def test_cursor_auth_status_distinguishes_failure_and_unrecognized_output(monkeypatch):
@@ -113,8 +193,8 @@ def test_run_refuses_unauthenticated_cursor_before_acpx(monkeypatch, tmp_path):
         calls.append(argv)
         if argv == ["acpx", "--version"]:
             return proc.Result(0, "acpx 0.12.0\n", "")
-        if argv == ["cursor-agent", "status"]:
-            return proc.Result(0, "Not logged in\n", "")
+        if argv == ["cursor-agent", "status", "--format", "json"]:
+            return proc.Result(0, '{"isAuthenticated":false,"status":"unauthenticated"}\n', "")
         raise AssertionError(f"ACPX must not start when Cursor is unauthenticated: {argv}")
 
     monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
@@ -130,9 +210,12 @@ def test_run_refuses_unauthenticated_cursor_before_acpx(monkeypatch, tmp_path):
     assert result.detail == (
         "cursor-agent CLI is not logged in; run `cursor-agent login` once, then verify with `cursor-agent status`"
     )
-    assert result.stdout == "Not logged in"
+    assert result.stdout == '{"isAuthenticated":false,"status":"unauthenticated"}'
     assert result.exit_code == 0
-    assert calls == [["acpx", "--version"], ["cursor-agent", "status"]]
+    assert calls == [
+        ["acpx", "--version"],
+        ["cursor-agent", "status", "--format", "json"],
+    ]
 
 
 def test_run_refuses_unavailable_or_unrecognized_cursor_status_before_acpx(monkeypatch, tmp_path):
@@ -171,8 +254,8 @@ def test_run_authenticated_cursor_reaches_acpx_and_preserves_short_final(monkeyp
         calls.append(argv)
         if argv == ["acpx", "--version"]:
             return proc.Result(0, "acpx 0.12.0\n", "")
-        if argv == ["cursor-agent", "status"]:
-            return proc.Result(0, "Logged in as person@example.test\n", "")
+        if argv == ["cursor-agent", "status", "--format", "json"]:
+            return proc.Result(0, '{"isAuthenticated":true,"status":"authenticated"}\n', "")
         return proc.Result(0, _success_stream().replace('"text": "hello"', '"text": "No findings."'), "")
 
     monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
@@ -184,7 +267,7 @@ def test_run_authenticated_cursor_reaches_acpx_and_preserves_short_final(monkeyp
 
     assert result.ok is True
     assert result.text == "No findings."
-    assert calls[1] == ["cursor-agent", "status"]
+    assert calls[1] == ["cursor-agent", "status", "--format", "json"]
     assert calls[2][0] == "acpx"
 
 
@@ -404,7 +487,7 @@ def test_run_rejects_invalid_or_empty_protocol_output(monkeypatch, tmp_path):
     assert empty.failure_kind == "empty-output"
 
 
-def test_run_preserves_timeout_and_permission_exit(monkeypatch, tmp_path):
+def test_run_distinguishes_timeout_permission_and_provider_startup(monkeypatch, tmp_path):
     monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
     monkeypatch.setattr(acpx_adapter, "cursor_auth_status", _authenticated_status)
     outputs = iter(
@@ -413,6 +496,8 @@ def test_run_preserves_timeout_and_permission_exit(monkeypatch, tmp_path):
             proc.Result(3, "", "acpx timed out"),
             proc.Result(0, "acpx 0.12.0\n", ""),
             proc.Result(5, "", "permission denied"),
+            proc.Result(0, "acpx 0.12.0\n", ""),
+            proc.Result(7, "", "provider failed before ACP startup"),
         ]
     )
     monkeypatch.setattr(acpx_adapter.proc, "run", lambda argv, **kwargs: next(outputs))
@@ -422,9 +507,15 @@ def test_run_preserves_timeout_and_permission_exit(monkeypatch, tmp_path):
     denied = acpx_adapter.run_cursor(
         "inspect", cwd=tmp_path, timeout=120, model="composer-2.5", version="0.12.0", read_only=True
     )
+    startup = acpx_adapter.run_cursor(
+        "inspect", cwd=tmp_path, timeout=120, model="composer-2.5", version="0.12.0", read_only=True
+    )
     assert timeout.exit_code == 3 and timeout.timed_out is True
     assert denied.exit_code == 5 and denied.detail == "permission denied"
     assert timeout.failure_phase == "inference"
     assert timeout.failure_kind == "timeout"
     assert denied.failure_phase == "dispatch"
-    assert denied.failure_kind == "provider-startup"
+    assert denied.failure_kind == "permission-denied"
+    assert startup.exit_code == 7
+    assert startup.failure_phase == "dispatch"
+    assert startup.failure_kind == "provider-startup"

--- a/tests/test_roster_cmd.py
+++ b/tests/test_roster_cmd.py
@@ -158,6 +158,36 @@ def test_roster_doctor_ok_when_ollama_model_pulled(monkeypatch, tmp_target, caps
     assert "pulled locally" in out
 
 
+def test_roster_doctor_fails_unauthenticated_acpx_cursor_with_recovery(monkeypatch, tmp_target, capsys):
+    from brigade import acpx_adapter
+
+    _write_roster(
+        tmp_target,
+        'orchestrator = "chef"\n'
+        '[agents.chef]\ncli = "codex"\nrole = "plan"\n'
+        '[agents.composer]\ncli = "cursor"\nmodel = "composer-2.5"\n'
+        'transport = "acpx"\ntransport_version = "0.12.0"\nrole = "review"\n',
+    )
+    monkeypatch.setattr(agents.proc, "which", lambda cmd: f"/bin/{cmd}")
+    monkeypatch.setattr(acpx_adapter, "installed_version", lambda: ("0.12.0", ""))
+    diagnosis = (
+        "cursor-agent CLI is not logged in; run `cursor-agent login` once, then verify with `cursor-agent status`"
+    )
+    monkeypatch.setattr(
+        acpx_adapter,
+        "cursor_auth_status",
+        lambda: acpx_adapter.CursorAuthStatus("unauthenticated", diagnosis, "Not logged in", "", 0),
+    )
+
+    rc = roster_cmd.doctor(tmp_target)
+    out = capsys.readouterr().out
+
+    assert rc == 1
+    assert "[fail]" in out
+    assert "agent: composer cursor auth" in out
+    assert diagnosis in out
+
+
 def _write_roster(tmp_target, body: str) -> None:
     path = tmp_target / ".brigade" / "roster.toml"
     path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Closes #284

## What changed

- Run `cursor-agent status --format json` before ACPX starts and require an explicit `isAuthenticated: true` result.
- Drop Cursor account data from diagnostics, redact credential-shaped fallback output, and reuse the same diagnosis in roster doctor and run failures.
- Record typed failures for missing executables, version mismatch, unavailable or unrecognized auth status, provider authentication, permission denial, provider startup, timeout, malformed transport, and empty final output.
- Keep short substantive ACP results accepted.

## Verification

- `./scripts/verify`: 2606 passed, 3 skipped, 81.63% coverage.
- Authenticated roster doctor control: 10 checks passed with no account identifier in output.
- Deterministic tests cover logged-out, logged-in, status failure, unrecognized status, redaction, launch gating, failure taxonomy, worker receipts, `run.json`, and the human error.
- Independent exact-head review found no actionable issues.