### PR TITLE
feat(harness): add safe Cursor user onboarding

### DIFF
--- a/docs/agents-guide.md
+++ b/docs/agents-guide.md
@@ -42,6 +42,27 @@ brigade operator quickstart --target . --harnesses codex,claude,opencode,antigra
 
 If you are unsure which harnesses the user uses, start with the current harness and explain how to add more later.
 
+### Cursor GUI work loop at user scope
+
+Cursor GUI agents need user-level wiring in addition to a repository handoff inbox. Preview the narrow profile before applying it:
+
+```bash
+brigade harness install cursor --scope user --dry-run
+brigade harness install cursor --scope user --write
+brigade harness doctor cursor --scope user
+```
+
+This profile manages a local plugin rule, the global `brigade-work` skill, one `sessionStart` hook, and the `brigade`, `graphtrail`, and `miseledger` entries in `~/.cursor/mcp.json`. It preserves unrelated plugins, hooks, MCP servers, and sibling JSON fields. Existing values with a managed name are reported as conflicts instead of being replaced. Reload Cursor windows after a successful write.
+
+To remove the profile, preview and then apply the ownership-aware uninstall:
+
+```bash
+brigade harness uninstall cursor --scope user --dry-run
+brigade harness uninstall cursor --scope user --write
+```
+
+Uninstall removes entries only when they still match Brigade's ownership record. User-edited managed entries are preserved and reported as conflicts.
+
 ## Adapting Existing Setups
 
 Before changing files, inspect the target directory for existing setup:

--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -30,6 +30,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade guard`: 1 command path(s)
 - `brigade handoff`: 17 command path(s)
 - `brigade handoff-template`: 1 command path(s)
+- `brigade harness`: 3 command path(s)
 - `brigade hermes-fragments` (extras): 1 command path(s)
 - `brigade ingest`: 1 command path(s)
 - `brigade init`: 1 command path(s)
@@ -174,6 +175,9 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade handoff sources init`
 - `brigade handoff sync-issues`
 - `brigade handoff-template`
+- `brigade harness doctor`
+- `brigade harness install`
+- `brigade harness uninstall`
 - `brigade hermes-fragments` (extras)
 - `brigade ingest`
 - `brigade init`

--- a/src/brigade/cli/__init__.py
+++ b/src/brigade/cli/__init__.py
@@ -40,6 +40,7 @@ from . import (
     budgets as _budgets_group,
     untrusted as _untrusted_group,
     skills as _skills_group,
+    harness as _harness_group,
     operator as _operator_group,
     runbook as _runbook_group,
     dogfood as _dogfood_group,
@@ -138,6 +139,7 @@ def _build_parser() -> argparse.ArgumentParser:
     _register_extras(sub, "untrusted", extras_enabled)
 
     _skills_group.register(sub)
+    _harness_group.register(sub)
     _operator_group.register(sub)
     _register_extras(sub, "runbook", extras_enabled)
     _register_extras(sub, "dogfood", extras_enabled)

--- a/src/brigade/cli/_common.py
+++ b/src/brigade/cli/_common.py
@@ -26,6 +26,7 @@ COMMAND_GROUPS: list[tuple[str, list[str]]] = [
             "add",
             "stations",
             "skills",
+            "harness",
             "tools",
             "mcp",
             "evidence",

--- a/src/brigade/cli/harness.py
+++ b/src/brigade/cli/harness.py
@@ -1,0 +1,49 @@
+"""User-scoped harness onboarding commands."""
+
+from __future__ import annotations
+
+import argparse
+
+
+def _write_mode(parser: argparse.ArgumentParser) -> None:
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", action="store_true", help="Preview changes without writing (default).")
+    mode.add_argument("--write", action="store_true", help="Apply the planned changes.")
+
+
+def _common(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("harness", choices=["cursor"], help="Harness to configure.")
+    parser.add_argument("--scope", choices=["user"], required=True, help="Configuration scope.")
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    parser = sub.add_parser("harness", help="Install, inspect, or remove narrow harness onboarding profiles.")
+    commands = parser.add_subparsers(dest="harness_command", metavar="<harness-command>")
+    commands.required = True
+
+    install = commands.add_parser("install", help="Plan or apply a harness onboarding profile.")
+    _common(install)
+    _write_mode(install)
+
+    uninstall = commands.add_parser("uninstall", help="Remove only Brigade-owned harness configuration.")
+    _common(uninstall)
+    _write_mode(uninstall)
+
+    doctor = commands.add_parser("doctor", help="Check a harness onboarding profile.")
+    _common(doctor)
+
+    parser.set_defaults(func=dispatch)
+
+
+def dispatch(args) -> int:
+    from .. import cursor_user_cmd
+
+    if args.harness_command == "install":
+        return cursor_user_cmd.install(write=args.write, json_output=args.json)
+    if args.harness_command == "uninstall":
+        return cursor_user_cmd.uninstall(write=args.write, json_output=args.json)
+    if args.harness_command == "doctor":
+        return cursor_user_cmd.doctor(json_output=args.json)
+    args._brigade_parser.error(f"unknown harness command: {args.harness_command}")
+    return 2

--- a/src/brigade/cursor_user_cmd.py
+++ b/src/brigade/cursor_user_cmd.py
@@ -1,0 +1,602 @@
+"""Safe user-scoped Cursor onboarding for the Brigade work loop."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from . import __version__, localio
+
+STATE_VERSION = 1
+MANAGED_MCP_NAMES = ("brigade", "graphtrail", "miseledger")
+
+
+def _home_dir() -> Path:
+    return Path.home()
+
+
+def _cursor_root() -> Path:
+    return _home_dir().expanduser().resolve() / ".cursor"
+
+
+def _digest_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _digest_value(value: object) -> str:
+    rendered = json.dumps(value, sort_keys=True, separators=(",", ":"))
+    return _digest_text(rendered)
+
+
+def _json_text(payload: object) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def _coowned_json_text(payload: object) -> str:
+    return json.dumps(payload, indent=2, sort_keys=False) + "\n"
+
+
+def _mcp_servers() -> dict[str, dict[str, Any]]:
+    return {
+        "brigade": {
+            "command": "brigade",
+            "args": ["memory", "serve-mcp", "--stdio", "--target", "."],
+            "timeout": 60,
+        },
+        "graphtrail": {"command": "graphtrail-mcp"},
+        "miseledger": {"command": "miseledger", "args": ["mcp"], "timeout": 60},
+    }
+
+
+def _plugin_manifest() -> str:
+    return _json_text(
+        {
+            "name": "brigade-loop",
+            "displayName": "Brigade Work Loop",
+            "version": __version__,
+            "description": "Applies the Brigade, GraphTrail, and MiseLedger evidence loop to Cursor agent workspaces.",
+            "author": {"name": "Escoffier Labs"},
+            "license": "MIT",
+            "keywords": ["brigade", "graphtrail", "miseledger", "verification", "receipts"],
+            "category": "developer-tools",
+            "rules": "./rules/",
+        }
+    )
+
+
+def _rule_text() -> str:
+    return """---
+alwaysApply: true
+---
+
+# Brigade work loop
+
+In a Brigade-wired repository, invoke the global `brigade-work` skill before substantive work. Start with `brigade work brief --target .`. Run checks that should count through `brigade work verify run --target . --command "<test command>" --capture brigade-work`. Capture failures too, export new receipts to MiseLedger when it is installed, and finish durable work with a Memory Handoff.
+"""
+
+
+def _hook_text() -> str:
+    context = (
+        "BRIGADE WORK LOOP: In a Brigade-wired repository, invoke the global brigade-work skill before substantive "
+        "work. Start with brigade work brief --target .. Run checks that should count through brigade work verify "
+        "run with --capture brigade-work. Capture failures, export new receipts to MiseLedger when installed, and "
+        "finish durable work with a Memory Handoff."
+    )
+    return (
+        "#!/bin/sh\ncat >/dev/null\nprintf '%s\\n' "
+        + _shell_single_quote(_json_text({"additional_context": context}).strip())
+        + "\n"
+    )
+
+
+def _shell_single_quote(value: str) -> str:
+    return "'" + value.replace("'", "'\"'\"'") + "'"
+
+
+def _desired_files(root: Path) -> dict[Path, tuple[str, bool, str]]:
+    package = Path(__file__).parent / "templates" / "skills" / "brigade-work"
+    plugin = root / "plugins" / "local" / "brigade-loop"
+    skill = root / "skills" / "brigade-work"
+    desired: dict[Path, tuple[str, bool, str]] = {
+        plugin / ".cursor-plugin" / "plugin.json": (_plugin_manifest(), False, "plugin"),
+        plugin / "rules" / "brigade-loop.mdc": (_rule_text(), False, "rule"),
+        root / "hooks" / "brigade-session-start": (_hook_text(), True, "hook"),
+        root / "brigade" / "mcp.json": (
+            _json_text({"version": 1, "servers": _mcp_servers()}),
+            False,
+            "mcp-catalog",
+        ),
+    }
+    for name in ("SKILL.md", "skill.json", "CHANGELOG.md"):
+        desired[skill / name] = ((package / name).read_text(), False, "skill")
+    return desired
+
+
+def _state_path(root: Path) -> Path:
+    return root / "brigade" / "install-state.json"
+
+
+def _load_state(root: Path) -> dict[str, Any]:
+    path = _state_path(root)
+    empty: dict[str, Any] = {"version": STATE_VERSION, "files": {}, "hooks": {}, "mcp": {}}
+    if not path.exists():
+        return empty
+    payload, error = _read_json_object(path)
+    if payload is None:
+        empty["_read_error"] = error or "ownership state is unreadable"
+        return empty
+    if payload.get("version") != STATE_VERSION:
+        empty["_read_error"] = f"unsupported ownership state version: {payload.get('version')!r}"
+        return empty
+    for key in ("files", "hooks", "mcp"):
+        if not isinstance(payload.get(key), dict):
+            payload[key] = {}
+    return payload
+
+
+def _relative(root: Path, path: Path) -> str:
+    return path.relative_to(root).as_posix()
+
+
+def _file_item(
+    root: Path, path: Path, text: str, executable: bool, surface: str, state: dict[str, Any]
+) -> dict[str, Any]:
+    desired = _digest_text(text)
+    stored = state["files"].get(_relative(root, path))
+    if not path.exists():
+        status, action = "missing", "create"
+    elif not path.is_file():
+        status, action = "conflict", "skip"
+    else:
+        try:
+            live = _digest_text(path.read_text())
+            mode_current = not executable or bool(path.stat().st_mode & 0o111)
+        except (OSError, UnicodeError) as exc:
+            return {
+                "surface": surface,
+                "path": str(path),
+                "status": "conflict",
+                "action": "skip",
+                "detail": str(exc),
+                "desired_fingerprint": desired,
+            }
+        if live == desired and mode_current:
+            status, action = "current", "none"
+        elif live == desired:
+            status, action = "changed", "update"
+        elif stored == live:
+            status, action = "changed", "update"
+        else:
+            status, action = "conflict", "skip"
+    return {
+        "surface": surface,
+        "path": str(path),
+        "status": status,
+        "action": action,
+        "desired_fingerprint": desired,
+    }
+
+
+def _read_json_object(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    if not path.exists():
+        return {}, None
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        return None, str(exc)
+    if not isinstance(payload, dict):
+        return None, "existing JSON configuration must be an object"
+    return payload, None
+
+
+def _hook_entry(root: Path) -> dict[str, str]:
+    return {"command": str(root / "hooks" / "brigade-session-start")}
+
+
+def _plan_hook(root: Path, state: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any] | None, str | None]:
+    path = root / "hooks.json"
+    doc, error = _read_json_object(path)
+    item: dict[str, Any] = {"surface": "hook-config", "path": str(path), "name": "sessionStart"}
+    if doc is None:
+        item.update(status="conflict", action="skip", detail=error or "could not read hooks configuration")
+        return item, None, error
+    hooks = doc.get("hooks")
+    if hooks is None:
+        hooks = {}
+    if not isinstance(hooks, dict):
+        item.update(status="conflict", action="skip", detail="existing hooks field must be an object")
+        return item, None, str(item["detail"])
+    entries = hooks.get("sessionStart")
+    if entries is None:
+        entries = []
+    if not isinstance(entries, list):
+        item.update(status="conflict", action="skip", detail="existing sessionStart hooks must be a list")
+        return item, None, str(item["detail"])
+    desired = _hook_entry(root)
+    desired_fp = _digest_value(desired)
+    if desired in entries:
+        item.update(status="current", action="none", desired_fingerprint=desired_fp)
+    else:
+        prior = state["hooks"].get("sessionStart")
+        prior_index = next((index for index, entry in enumerate(entries) if _digest_value(entry) == prior), None)
+        if prior_index is None:
+            item.update(status="missing", action="create", desired_fingerprint=desired_fp)
+        else:
+            item.update(status="changed", action="update", desired_fingerprint=desired_fp, prior_index=prior_index)
+    return item, doc, None
+
+
+def _plan_mcp(root: Path, state: dict[str, Any]) -> tuple[list[dict[str, Any]], dict[str, Any] | None, str | None]:
+    path = root / "mcp.json"
+    doc, error = _read_json_object(path)
+    if doc is None:
+        return (
+            [{"surface": "mcp-config", "path": str(path), "status": "conflict", "action": "skip", "detail": error}],
+            None,
+            error,
+        )
+    servers = doc.get("mcpServers")
+    if servers is None:
+        servers = {}
+    if not isinstance(servers, dict):
+        detail = "existing mcpServers field must be an object"
+        return (
+            [{"surface": "mcp-config", "path": str(path), "status": "conflict", "action": "skip", "detail": detail}],
+            None,
+            detail,
+        )
+    items: list[dict[str, Any]] = []
+    for name, desired in _mcp_servers().items():
+        desired_fp = _digest_value(desired)
+        live = servers.get(name)
+        if live == desired:
+            status, action = "current", "none"
+        elif name not in servers:
+            status, action = "missing", "create"
+        elif state["mcp"].get(name) == _digest_value(live):
+            status, action = "changed", "update"
+        else:
+            status, action = "conflict", "skip"
+        items.append(
+            {
+                "surface": "mcp-config",
+                "path": str(path),
+                "name": name,
+                "status": status,
+                "action": action,
+                "desired_fingerprint": desired_fp,
+            }
+        )
+    return items, doc, None
+
+
+def _public(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    private = {"desired_fingerprint", "prior_index"}
+    return [{key: value for key, value in item.items() if key not in private} for item in items]
+
+
+def _emit(payload: dict[str, Any], *, json_output: bool, rc: int) -> int:
+    if json_output:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        action = payload.get("operation", "cursor user profile")
+        print(f"cursor user profile: {action}")
+        for item in payload.get("items", []):
+            name = f" [{item['name']}]" if item.get("name") else ""
+            print(f"- {item['status']}: {item['path']}{name}")
+        if payload.get("reload_required"):
+            print("next: reload Cursor windows")
+    return rc
+
+
+def install(*, write: bool = False, json_output: bool = False) -> int:
+    root = _cursor_root()
+    state = _load_state(root)
+    desired_files = _desired_files(root)
+    items = [
+        _file_item(root, path, text, executable, surface, state)
+        for path, (text, executable, surface) in desired_files.items()
+    ]
+    hook_item, hooks_doc, _ = _plan_hook(root, state)
+    mcp_items, mcp_doc, _ = _plan_mcp(root, state)
+    items.extend([hook_item, *mcp_items])
+    state_error = state.get("_read_error")
+    if state_error:
+        items.append(
+            {
+                "surface": "ownership-state",
+                "path": str(_state_path(root)),
+                "status": "conflict",
+                "action": "skip",
+                "detail": str(state_error),
+            }
+        )
+    files_written: list[str] = []
+
+    if write and not state_error:
+        next_state: dict[str, Any] = {
+            "version": STATE_VERSION,
+            "package_version": __version__,
+            "files": {},
+            "hooks": {},
+            "mcp": {},
+        }
+        for item in items:
+            if item["surface"] in {"hook-config", "mcp-config"}:
+                continue
+            path = Path(item["path"])
+            if item["action"] in {"create", "update"}:
+                text, executable, _ = desired_files[path]
+                localio.write_text_atomic(path, text)
+                if executable:
+                    path.chmod(path.stat().st_mode | 0o755)
+                files_written.append(str(path))
+            if item["status"] != "conflict":
+                next_state["files"][_relative(root, path)] = item["desired_fingerprint"]
+            elif _relative(root, path) in state["files"]:
+                next_state["files"][_relative(root, path)] = state["files"][_relative(root, path)]
+
+        if hooks_doc is not None and hook_item["status"] != "conflict":
+            hooks = hooks_doc.setdefault("hooks", {})
+            entries = hooks.setdefault("sessionStart", [])
+            desired_hook = _hook_entry(root)
+            if hook_item["action"] == "create":
+                entries.append(desired_hook)
+            elif hook_item["action"] == "update":
+                entries[hook_item["prior_index"]] = desired_hook
+            if hook_item["action"] != "none":
+                path = root / "hooks.json"
+                localio.write_text_atomic(path, _coowned_json_text(hooks_doc))
+                files_written.append(str(path))
+            next_state["hooks"]["sessionStart"] = hook_item["desired_fingerprint"]
+        elif "sessionStart" in state["hooks"]:
+            next_state["hooks"]["sessionStart"] = state["hooks"]["sessionStart"]
+
+        if mcp_doc is not None:
+            servers = mcp_doc.setdefault("mcpServers", {})
+            changed = False
+            desired_servers = _mcp_servers()
+            for item in mcp_items:
+                if item["status"] == "conflict":
+                    if item.get("name") in state["mcp"]:
+                        next_state["mcp"][item["name"]] = state["mcp"][item["name"]]
+                    continue
+                name = item["name"]
+                if item["action"] in {"create", "update"}:
+                    servers[name] = desired_servers[name]
+                    changed = True
+                next_state["mcp"][name] = item["desired_fingerprint"]
+            if changed:
+                path = root / "mcp.json"
+                localio.write_text_atomic(path, _coowned_json_text(mcp_doc))
+                files_written.append(str(path))
+        else:
+            next_state["mcp"].update(state["mcp"])
+
+        state_path = _state_path(root)
+        if next_state != state:
+            localio.write_json(state_path, next_state)
+            files_written.append(str(state_path))
+
+    conflicts = [item for item in items if item["status"] == "conflict"]
+    payload = {
+        "schema_version": 1,
+        "operation": "install",
+        "harness": "cursor",
+        "scope": "user",
+        "home": str(_home_dir().expanduser().resolve()),
+        "write": write,
+        "ready": not conflicts,
+        "reload_required": bool(write and files_written) or not write,
+        "files_written": files_written,
+        "items": _public(items),
+        "conflicts": _public(conflicts),
+    }
+    return _emit(payload, json_output=json_output, rc=1 if conflicts else 0)
+
+
+def _remove_owned_leaf_dirs(root: Path) -> None:
+    plugin = root / "plugins" / "local" / "brigade-loop"
+    for current in (
+        plugin / ".cursor-plugin",
+        plugin / "rules",
+        plugin,
+        root / "skills" / "brigade-work",
+        root / "brigade",
+    ):
+        if not current.is_dir():
+            continue
+        try:
+            current.rmdir()
+        except OSError:
+            continue
+
+
+def uninstall(*, write: bool = False, json_output: bool = False) -> int:
+    root = _cursor_root()
+    state = _load_state(root)
+    items: list[dict[str, Any]] = []
+    conflicts: list[dict[str, Any]] = []
+    files_removed: list[str] = []
+    state_error = state.get("_read_error")
+    if state_error:
+        state_item = {
+            "surface": "ownership-state",
+            "path": str(_state_path(root)),
+            "status": "conflict",
+            "action": "preserve",
+            "detail": str(state_error),
+        }
+        items.append(state_item)
+        conflicts.append(state_item)
+
+    for rel, fingerprint in sorted(state["files"].items()):
+        path = root / rel
+        item = {"surface": "owned-file", "path": str(path)}
+        if not path.exists():
+            item.update(status="absent", action="none")
+        elif path.is_file():
+            try:
+                live_fingerprint = _digest_text(path.read_text())
+            except (OSError, UnicodeError) as exc:
+                item.update(status="conflict", action="preserve", detail=str(exc))
+                conflicts.append(item)
+            else:
+                if live_fingerprint == fingerprint:
+                    item.update(status="managed", action="remove")
+                    if write:
+                        path.unlink()
+                        files_removed.append(str(path))
+                else:
+                    item.update(status="conflict", action="preserve")
+                    conflicts.append(item)
+        else:
+            item.update(status="conflict", action="preserve")
+            conflicts.append(item)
+        items.append(item)
+
+    hook_path = root / "hooks.json"
+    hook_fp = state["hooks"].get("sessionStart")
+    hook_removed = False
+    if hook_fp:
+        doc, error = _read_json_object(hook_path)
+        hook_item: dict[str, Any] = {"surface": "hook-config", "path": str(hook_path), "name": "sessionStart"}
+        entries = None
+        if doc is not None and isinstance(doc.get("hooks"), dict):
+            entries = doc["hooks"].get("sessionStart", [])
+        index = (
+            next((i for i, entry in enumerate(entries) if _digest_value(entry) == hook_fp), None)
+            if isinstance(entries, list)
+            else None
+        )
+        if index is not None:
+            hook_item.update(status="managed", action="remove")
+            if write:
+                assert doc is not None and isinstance(entries, list)
+                entries.pop(index)
+                if not entries:
+                    doc["hooks"].pop("sessionStart", None)
+                localio.write_text_atomic(hook_path, _coowned_json_text(doc))
+                hook_removed = True
+        elif not hook_path.exists():
+            hook_item.update(status="absent", action="none")
+        else:
+            hook_item.update(status="conflict", action="preserve", detail=error or "managed hook was edited or removed")
+            conflicts.append(hook_item)
+        items.append(hook_item)
+
+    mcp_path = root / "mcp.json"
+    mcp_doc, mcp_error = _read_json_object(mcp_path)
+    mcp_servers = mcp_doc.get("mcpServers") if mcp_doc is not None else None
+    mcp_config_absent = not mcp_path.exists() or (mcp_doc is not None and "mcpServers" not in mcp_doc)
+    mcp_changed = False
+    for name, fingerprint in sorted(state["mcp"].items()):
+        item = {"surface": "mcp-config", "path": str(mcp_path), "name": name}
+        if isinstance(mcp_servers, dict) and name in mcp_servers and _digest_value(mcp_servers[name]) == fingerprint:
+            item.update(status="managed", action="remove")
+            if write:
+                mcp_servers.pop(name)
+                mcp_changed = True
+        elif mcp_config_absent or (isinstance(mcp_servers, dict) and name not in mcp_servers):
+            item.update(status="absent", action="none")
+        else:
+            item.update(status="conflict", action="preserve", detail=mcp_error or "managed server was edited")
+            conflicts.append(item)
+        items.append(item)
+    if write and mcp_changed and mcp_doc is not None:
+        localio.write_text_atomic(mcp_path, _coowned_json_text(mcp_doc))
+
+    if write and not conflicts:
+        state_path = _state_path(root)
+        state_path.unlink(missing_ok=True)
+        _remove_owned_leaf_dirs(root)
+
+    payload = {
+        "schema_version": 1,
+        "operation": "uninstall",
+        "harness": "cursor",
+        "scope": "user",
+        "write": write,
+        "files_removed": files_removed,
+        "items": items,
+        "conflicts": conflicts,
+        "reload_required": bool(write and (files_removed or mcp_changed or hook_removed)),
+    }
+    return _emit(payload, json_output=json_output, rc=1 if conflicts else 0)
+
+
+def _check(check_id: str, ok: bool, detail: str) -> dict[str, str]:
+    return {"id": check_id, "status": "OK" if ok else "FAIL", "detail": detail}
+
+
+def doctor(*, json_output: bool = False) -> int:
+    root = _cursor_root()
+    desired = _desired_files(root)
+    rule = root / "plugins" / "local" / "brigade-loop" / "rules" / "brigade-loop.mdc"
+    manifest = root / "plugins" / "local" / "brigade-loop" / ".cursor-plugin" / "plugin.json"
+    skill_dir = root / "skills" / "brigade-work"
+    hook_script = root / "hooks" / "brigade-session-start"
+    hooks_doc, _ = _read_json_object(root / "hooks.json")
+    hook_entries: object = None
+    if hooks_doc is not None and isinstance(hooks_doc.get("hooks"), dict):
+        hook_entries = hooks_doc["hooks"].get("sessionStart")
+    mcp_doc, _ = _read_json_object(root / "mcp.json")
+    live_servers = mcp_doc.get("mcpServers") if mcp_doc is not None else None
+    checks = [
+        _check(
+            "plugin-current",
+            _file_matches(manifest, desired[manifest][0]),
+            str(manifest),
+        ),
+        _check(
+            "rule-always-applied",
+            _file_matches(rule, desired[rule][0]) and "alwaysApply: true" in _read_text(rule),
+            str(rule),
+        ),
+        _check(
+            "skill-current",
+            all(_file_matches(path, desired[path][0]) for path in desired if path.parent == skill_dir),
+            str(skill_dir),
+        ),
+        _check(
+            "session-hook",
+            _file_matches(hook_script, desired[hook_script][0])
+            and bool(hook_script.stat().st_mode & 0o111)
+            and isinstance(hook_entries, list)
+            and _hook_entry(root) in hook_entries,
+            str(root / "hooks.json"),
+        ),
+    ]
+    expected_servers = _mcp_servers()
+    for name in MANAGED_MCP_NAMES:
+        checks.append(
+            _check(
+                f"mcp-{name}",
+                isinstance(live_servers, dict) and live_servers.get(name) == expected_servers[name],
+                str(root / "mcp.json"),
+            )
+        )
+    ready = all(item["status"] == "OK" for item in checks)
+    payload = {
+        "schema_version": 1,
+        "operation": "doctor",
+        "harness": "cursor",
+        "scope": "user",
+        "ready": ready,
+        "checks": checks,
+        "next": "reload Cursor windows" if ready else "run brigade harness install cursor --scope user --write",
+    }
+    return _emit(payload, json_output=json_output, rc=0 if ready else 1)
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text()
+    except (OSError, UnicodeError):
+        return ""
+
+
+def _file_matches(path: Path, expected: str) -> bool:
+    return path.is_file() and _read_text(path) == expected

--- a/tests/test_cursor_user_cmd.py
+++ b/tests/test_cursor_user_cmd.py
@@ -1,0 +1,342 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from brigade import cli, cursor_user_cmd
+
+
+def _use_home(monkeypatch, home: Path) -> None:
+    monkeypatch.setattr(cursor_user_cmd, "_home_dir", lambda: home)
+
+
+def test_cursor_user_install_dry_run_lists_all_surfaces_without_writing(tmp_path, monkeypatch, capsys):
+    _use_home(monkeypatch, tmp_path)
+
+    assert cli.main(["harness", "install", "cursor", "--scope", "user", "--dry-run", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    paths = {item["path"] for item in payload["items"]}
+    cursor = tmp_path / ".cursor"
+    assert {
+        str(cursor / "plugins" / "local" / "brigade-loop" / ".cursor-plugin" / "plugin.json"),
+        str(cursor / "plugins" / "local" / "brigade-loop" / "rules" / "brigade-loop.mdc"),
+        str(cursor / "skills" / "brigade-work" / "SKILL.md"),
+        str(cursor / "hooks" / "brigade-session-start"),
+        str(cursor / "hooks.json"),
+        str(cursor / "brigade" / "mcp.json"),
+        str(cursor / "mcp.json"),
+    } <= paths
+    assert payload["write"] is False
+    assert payload["reload_required"] is True
+    assert not cursor.exists()
+
+
+def test_cursor_user_install_merges_all_surfaces_and_is_idempotent(tmp_path, monkeypatch, capsys):
+    _use_home(monkeypatch, tmp_path)
+    cursor = tmp_path / ".cursor"
+    (cursor / "plugins" / "local" / "other-plugin").mkdir(parents=True)
+    (cursor / "plugins" / "local" / "other-plugin" / "keep.txt").write_text("keep\n")
+    (cursor / "hooks.json").write_text(
+        json.dumps({"version": 1, "hooks": {"beforeSubmitPrompt": [{"command": "keep-hook"}]}})
+    )
+    (cursor / "mcp.json").write_text(
+        json.dumps({"settings": {"keep": True}, "mcpServers": {"foreign": {"command": "keep-server"}}})
+    )
+
+    command = ["harness", "install", "cursor", "--scope", "user", "--write", "--json"]
+    assert cli.main(command) == 0
+    first = json.loads(capsys.readouterr().out)
+
+    assert first["ready"] is True
+    assert (cursor / "plugins" / "local" / "other-plugin" / "keep.txt").read_text() == "keep\n"
+    assert (cursor / "plugins" / "local" / "brigade-loop" / "rules" / "brigade-loop.mdc").is_file()
+    assert (cursor / "skills" / "brigade-work" / "SKILL.md").is_file()
+    hook = cursor / "hooks" / "brigade-session-start"
+    assert hook.is_file()
+    assert hook.stat().st_mode & 0o111
+
+    hooks = json.loads((cursor / "hooks.json").read_text())
+    assert hooks["hooks"]["beforeSubmitPrompt"] == [{"command": "keep-hook"}]
+    assert hooks["hooks"]["sessionStart"] == [{"command": str(hook)}]
+
+    mcp = json.loads((cursor / "mcp.json").read_text())
+    assert mcp["settings"] == {"keep": True}
+    assert mcp["mcpServers"]["foreign"] == {"command": "keep-server"}
+    assert {"brigade", "graphtrail", "miseledger"} <= set(mcp["mcpServers"])
+    assert (cursor / "brigade" / "mcp.json").is_file()
+    assert not (tmp_path / ".brigade").exists()
+    assert not (cursor / "memory-handoffs").exists()
+
+    assert cli.main(command) == 0
+    second = json.loads(capsys.readouterr().out)
+    assert second["files_written"] == []
+    assert all(item["status"] == "current" for item in second["items"])
+
+
+def test_cursor_user_doctor_checks_rule_skill_hook_and_mcp(tmp_path, monkeypatch, capsys):
+    _use_home(monkeypatch, tmp_path)
+    assert cli.main(["harness", "install", "cursor", "--scope", "user", "--write", "--json"]) == 0
+    capsys.readouterr()
+
+    assert cli.main(["harness", "doctor", "cursor", "--scope", "user", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["ready"] is True
+    checks = {item["id"]: item for item in payload["checks"]}
+    assert checks["rule-always-applied"]["status"] == "OK"
+    assert checks["plugin-current"]["status"] == "OK"
+    assert checks["skill-current"]["status"] == "OK"
+    assert checks["session-hook"]["status"] == "OK"
+    assert checks["mcp-brigade"]["status"] == "OK"
+    assert checks["mcp-graphtrail"]["status"] == "OK"
+    assert checks["mcp-miseledger"]["status"] == "OK"
+
+
+def test_cursor_user_uninstall_removes_only_managed_files_and_blocks(tmp_path, monkeypatch, capsys):
+    _use_home(monkeypatch, tmp_path)
+    cursor = tmp_path / ".cursor"
+    (cursor / "plugins" / "local" / "other-plugin").mkdir(parents=True)
+    (cursor / "plugins" / "local" / "other-plugin" / "keep.txt").write_text("keep\n")
+    (cursor / "hooks.json").parent.mkdir(parents=True, exist_ok=True)
+    (cursor / "hooks.json").write_text(
+        json.dumps({"version": 1, "hooks": {"sessionStart": [{"command": "keep-hook"}]}})
+    )
+    (cursor / "mcp.json").write_text(json.dumps({"mcpServers": {"foreign": {"command": "keep-server"}}}))
+
+    assert cli.main(["harness", "install", "cursor", "--scope", "user", "--write", "--json"]) == 0
+    capsys.readouterr()
+    assert cli.main(["harness", "uninstall", "cursor", "--scope", "user", "--write", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["conflicts"] == []
+    assert (cursor / "plugins" / "local" / "other-plugin" / "keep.txt").read_text() == "keep\n"
+    assert not (cursor / "plugins" / "local" / "brigade-loop").exists()
+    assert not (cursor / "skills" / "brigade-work").exists()
+    assert not (cursor / "hooks" / "brigade-session-start").exists()
+    hooks = json.loads((cursor / "hooks.json").read_text())
+    assert hooks["hooks"]["sessionStart"] == [{"command": "keep-hook"}]
+    mcp = json.loads((cursor / "mcp.json").read_text())
+    assert mcp["mcpServers"] == {"foreign": {"command": "keep-server"}}
+
+
+def test_cursor_user_uninstall_preserves_user_edited_managed_mcp_entry(tmp_path, monkeypatch, capsys):
+    _use_home(monkeypatch, tmp_path)
+    cursor = tmp_path / ".cursor"
+    assert cli.main(["harness", "install", "cursor", "--scope", "user", "--write", "--json"]) == 0
+    capsys.readouterr()
+    mcp_path = cursor / "mcp.json"
+    mcp = json.loads(mcp_path.read_text())
+    mcp["mcpServers"]["graphtrail"] = {"command": "user-custom-graph"}
+    mcp_path.write_text(json.dumps(mcp))
+
+    assert cli.main(["harness", "uninstall", "cursor", "--scope", "user", "--write", "--json"]) == 1
+    payload = json.loads(capsys.readouterr().out)
+
+    assert any(item["path"] == str(mcp_path) and item["name"] == "graphtrail" for item in payload["conflicts"])
+    live = json.loads(mcp_path.read_text())
+    assert live["mcpServers"]["graphtrail"] == {"command": "user-custom-graph"}
+    assert "brigade" not in live["mcpServers"]
+    assert "miseledger" not in live["mcpServers"]
+
+
+def test_cursor_user_install_preserves_managed_name_collisions(tmp_path, monkeypatch, capsys):
+    _use_home(monkeypatch, tmp_path)
+    cursor = tmp_path / ".cursor"
+    cursor.mkdir()
+    foreign = {"command": "foreign-brigade"}
+    (cursor / "mcp.json").write_text(json.dumps({"mcpServers": {"brigade": foreign}}))
+
+    assert cli.main(["harness", "install", "cursor", "--scope", "user", "--write", "--json"]) == 1
+    payload = json.loads(capsys.readouterr().out)
+
+    assert any(item.get("name") == "brigade" and item["status"] == "conflict" for item in payload["items"])
+    live = json.loads((cursor / "mcp.json").read_text())
+    assert live["mcpServers"]["brigade"] == foreign
+    assert "graphtrail" in live["mcpServers"]
+    assert "miseledger" in live["mcpServers"]
+
+
+def test_cursor_user_install_rejects_malformed_coowned_json(tmp_path, monkeypatch, capsys):
+    _use_home(monkeypatch, tmp_path)
+    cursor = tmp_path / ".cursor"
+    cursor.mkdir()
+    hooks_path = cursor / "hooks.json"
+    mcp_path = cursor / "mcp.json"
+    hooks_path.write_text("{bad hooks")
+    mcp_path.write_text("[]")
+
+    assert cli.main(["harness", "install", "cursor", "--scope", "user", "--write", "--json"]) == 1
+    payload = json.loads(capsys.readouterr().out)
+
+    assert len(payload["conflicts"]) == 2
+    assert hooks_path.read_text() == "{bad hooks"
+    assert mcp_path.read_text() == "[]"
+
+
+def test_cursor_user_install_reports_non_utf8_coowned_json_as_conflict(tmp_path, monkeypatch, capsys):
+    _use_home(monkeypatch, tmp_path)
+    hooks_path = tmp_path / ".cursor" / "hooks.json"
+    hooks_path.parent.mkdir(parents=True)
+    hooks_path.write_bytes(b"\xff\xfe")
+
+    assert cli.main(["harness", "install", "cursor", "--scope", "user", "--write", "--json"]) == 1
+    payload = json.loads(capsys.readouterr().out)
+
+    assert any(item["path"] == str(hooks_path) and item["status"] == "conflict" for item in payload["conflicts"])
+    assert hooks_path.read_bytes() == b"\xff\xfe"
+
+
+def test_cursor_user_doctor_fails_when_plugin_manifest_is_missing(tmp_path, monkeypatch, capsys):
+    _use_home(monkeypatch, tmp_path)
+    assert cli.main(["harness", "install", "cursor", "--scope", "user", "--write", "--json"]) == 0
+    capsys.readouterr()
+    manifest = tmp_path / ".cursor" / "plugins" / "local" / "brigade-loop" / ".cursor-plugin" / "plugin.json"
+    manifest.unlink()
+
+    assert cli.main(["harness", "doctor", "cursor", "--scope", "user", "--json"]) == 1
+    payload = json.loads(capsys.readouterr().out)
+    checks = {item["id"]: item for item in payload["checks"]}
+    assert payload["ready"] is False
+    assert checks["plugin-current"]["status"] == "FAIL"
+
+
+def test_cursor_user_install_repairs_session_hook_executable_mode(tmp_path, monkeypatch, capsys):
+    _use_home(monkeypatch, tmp_path)
+    install = ["harness", "install", "cursor", "--scope", "user", "--write", "--json"]
+    assert cli.main(install) == 0
+    capsys.readouterr()
+    hook = tmp_path / ".cursor" / "hooks" / "brigade-session-start"
+    hook.chmod(0o644)
+
+    assert cli.main(["harness", "doctor", "cursor", "--scope", "user", "--json"]) == 1
+    capsys.readouterr()
+    assert cli.main(install) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert str(hook) in payload["files_written"]
+    assert hook.stat().st_mode & 0o111
+    assert cli.main(["harness", "doctor", "cursor", "--scope", "user", "--json"]) == 0
+
+
+def test_cursor_user_dry_run_does_not_create_ownership_state(tmp_path, monkeypatch, capsys):
+    _use_home(monkeypatch, tmp_path)
+
+    assert cli.main(["harness", "install", "cursor", "--scope", "user", "--dry-run", "--json"]) == 0
+    capsys.readouterr()
+    assert not (tmp_path / ".cursor" / "brigade" / "install-state.json").exists()
+
+
+def test_cursor_user_uninstall_does_not_remove_foreign_empty_ancestors(tmp_path, monkeypatch, capsys):
+    _use_home(monkeypatch, tmp_path)
+    assert cli.main(["harness", "install", "cursor", "--scope", "user", "--write", "--json"]) == 0
+    capsys.readouterr()
+
+    assert cli.main(["harness", "uninstall", "cursor", "--scope", "user", "--write", "--json"]) == 0
+    capsys.readouterr()
+    assert (tmp_path / ".cursor" / "plugins" / "local").is_dir()
+    assert (tmp_path / ".cursor" / "skills").is_dir()
+    assert (tmp_path / ".cursor" / "hooks").is_dir()
+
+
+def test_cursor_user_preserves_non_utf8_managed_file_as_conflict(tmp_path, monkeypatch, capsys):
+    _use_home(monkeypatch, tmp_path)
+    assert cli.main(["harness", "install", "cursor", "--scope", "user", "--write", "--json"]) == 0
+    capsys.readouterr()
+    rule = tmp_path / ".cursor" / "plugins" / "local" / "brigade-loop" / "rules" / "brigade-loop.mdc"
+    rule.write_bytes(b"\xff\xfe")
+
+    assert cli.main(["harness", "install", "cursor", "--scope", "user", "--dry-run", "--json"]) == 1
+    install_payload = json.loads(capsys.readouterr().out)
+    assert any(item["path"] == str(rule) and item["status"] == "conflict" for item in install_payload["conflicts"])
+
+    assert cli.main(["harness", "uninstall", "cursor", "--scope", "user", "--write", "--json"]) == 1
+    uninstall_payload = json.loads(capsys.readouterr().out)
+    assert any(item["path"] == str(rule) and item["status"] == "conflict" for item in uninstall_payload["conflicts"])
+    assert rule.read_bytes() == b"\xff\xfe"
+
+
+def test_cursor_user_corrupt_ownership_state_blocks_install_and_uninstall(tmp_path, monkeypatch, capsys):
+    _use_home(monkeypatch, tmp_path)
+    command = ["harness", "install", "cursor", "--scope", "user", "--write", "--json"]
+    assert cli.main(command) == 0
+    capsys.readouterr()
+    cursor = tmp_path / ".cursor"
+    state = cursor / "brigade" / "install-state.json"
+    rule = cursor / "plugins" / "local" / "brigade-loop" / "rules" / "brigade-loop.mdc"
+    state.write_bytes(b"\xff\xfe")
+
+    assert cli.main(command) == 1
+    install_payload = json.loads(capsys.readouterr().out)
+    assert install_payload["files_written"] == []
+    assert any(item["path"] == str(state) and item["status"] == "conflict" for item in install_payload["conflicts"])
+    assert state.read_bytes() == b"\xff\xfe"
+
+    assert cli.main(["harness", "uninstall", "cursor", "--scope", "user", "--write", "--json"]) == 1
+    uninstall_payload = json.loads(capsys.readouterr().out)
+    assert any(item["path"] == str(state) and item["status"] == "conflict" for item in uninstall_payload["conflicts"])
+    assert state.read_bytes() == b"\xff\xfe"
+    assert rule.is_file()
+
+
+def test_cursor_user_unreadable_mcp_config_preserves_ownership_for_later_uninstall(tmp_path, monkeypatch, capsys):
+    _use_home(monkeypatch, tmp_path)
+    install = ["harness", "install", "cursor", "--scope", "user", "--write", "--json"]
+    assert cli.main(install) == 0
+    capsys.readouterr()
+    cursor = tmp_path / ".cursor"
+    mcp_path = cursor / "mcp.json"
+    state_path = cursor / "brigade" / "install-state.json"
+    valid_mcp = mcp_path.read_bytes()
+    mcp_path.write_bytes(b"\xff\xfe")
+
+    assert cli.main(install) == 1
+    capsys.readouterr()
+    state = json.loads(state_path.read_text())
+    assert set(state["mcp"]) == {"brigade", "graphtrail", "miseledger"}
+
+    mcp_path.write_bytes(valid_mcp)
+    assert cli.main(["harness", "uninstall", "cursor", "--scope", "user", "--write", "--json"]) == 0
+    capsys.readouterr()
+    live = json.loads(mcp_path.read_text())
+    assert not {"brigade", "graphtrail", "miseledger"} & set(live["mcpServers"])
+
+
+def test_cursor_user_uninstall_reload_requires_an_actual_change(tmp_path, monkeypatch, capsys):
+    _use_home(monkeypatch, tmp_path)
+    assert cli.main(["harness", "install", "cursor", "--scope", "user", "--write", "--json"]) == 0
+    capsys.readouterr()
+    cursor = tmp_path / ".cursor"
+    state_path = cursor / "brigade" / "install-state.json"
+    state = json.loads(state_path.read_text())
+    state["files"] = {}
+    state["mcp"] = {}
+    state_path.write_text(json.dumps(state))
+    hooks_path = cursor / "hooks.json"
+    hooks = json.loads(hooks_path.read_text())
+    hooks["hooks"].pop("sessionStart")
+    hooks_path.write_text(json.dumps(hooks))
+
+    assert cli.main(["harness", "uninstall", "cursor", "--scope", "user", "--write", "--json"]) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["reload_required"] is False
+
+
+@pytest.mark.parametrize("missing_shape", ["file", "mcpServers-key"])
+def test_cursor_user_uninstall_treats_missing_mcp_config_as_already_removed(
+    tmp_path, monkeypatch, capsys, missing_shape
+):
+    _use_home(monkeypatch, tmp_path)
+    assert cli.main(["harness", "install", "cursor", "--scope", "user", "--write", "--json"]) == 0
+    capsys.readouterr()
+    cursor = tmp_path / ".cursor"
+    mcp_path = cursor / "mcp.json"
+    if missing_shape == "file":
+        mcp_path.unlink()
+    else:
+        mcp_path.write_text(json.dumps({"settings": {"keep": True}}))
+
+    assert cli.main(["harness", "uninstall", "cursor", "--scope", "user", "--write", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    mcp_items = [item for item in payload["items"] if item["surface"] == "mcp-config"]
+    assert all(item["status"] == "absent" for item in mcp_items)
+    assert not (cursor / "brigade" / "install-state.json").exists()


### PR DESCRIPTION
## Summary

- Add a dry-run-first `brigade harness` profile for user-scoped Cursor install, doctor, and uninstall operations.
- Wire the Brigade work-loop plugin, bundled skill, session hook, user MCP catalog, and Brigade, GraphTrail, and MiseLedger MCP entries without creating a workspace tree in the user home.
- Preserve foreign Cursor configuration and user edits through fingerprint-gated ownership, blocking on malformed or unreadable state instead of overwriting it.

## Verification

- `./scripts/verify`: 2,654 passed, 3 skipped, 81.76% coverage.
- Exact-head Brigade receipt: `20260717-072805-work-verify-41125a`.
- Exact-head Opus review: CLEAN at `32d583db4df0574f4a8558ae5218b6bdc644e7fe`, receipt `20260717-073313-work-verify-fd6392`.
- Memory handoff lint and content guard: `20260717-073842-work-verify-397b5e`.

Closes #250