### PR TITLE
feat(run): add bounded Grok recovery

### DIFF
--- a/docs/seat-catalog.md
+++ b/docs/seat-catalog.md
@@ -81,6 +81,28 @@ role = "Cross-model reviewer on the Google lane; verify claims without spending 
 
 Remember: every seat's `cli` value must appear in `limits.allow_models`, in the same edit. Brigade validates at roster load, not at edit time, and a missing entry fails every run against that roster.
 
+### Direct Grok invalid-final recovery
+
+A direct Grok read-only worker can continue its exact session once when the CLI exits 0 without the required structured final. To allow the one terminal fallback after another invalid final, name a reviewed Cursor-Grok ACP seat on the direct seat:
+
+```toml
+[agents.grok-review]
+cli = "grok"
+model = "grok-4.5"
+reasoning = "high"
+role = "Review the requested change and report actionable findings."
+invalid_final_fallback = "cursor-grok"
+
+[agents.cursor-grok]
+cli = "cursor"
+model = "grok-4.5"
+transport = "acpx"
+transport_version = "0.12.0"
+role = "Fallback review through the reviewed ACP transport."
+```
+
+The reference is fail-closed: it must resolve to a non-orchestrator Cursor seat with a `grok-*` model and the reviewed ACPX version. Brigade does not search the roster for a similar model. The policy applies only to a typed malformed-final result from a direct Grok `--worker` read-only run; startup, authentication, network, timeout, permission, and nonzero failures are terminal.
+
 ### Anthropic-compatible API lanes (Kimi, GLM, and friends)
 
 Several open-weight providers expose Anthropic-compatible endpoints, which means the `claude` CLI can drive them and Brigade can seat them directly. Declare the lane's environment on the seat: plain values inline, secrets by reference with a `_REF` suffix naming the environment variable that holds the value (the roster never stores the secret itself):

--- a/docs/superpowers/plans/2026-07-17-bounded-grok-recovery.md
+++ b/docs/superpowers/plans/2026-07-17-bounded-grok-recovery.md
@@ -1,0 +1,158 @@
+# Bounded direct-Grok recovery implementation plan
+
+**Goal:** Land issue #282 with one typed exact-session continuation, one explicit Cursor-Grok ACP fallback, and complete attempt receipts for direct Grok read-only workers.
+
+**Architecture:** `agents.py` owns Grok envelope parsing and exact-session CLI construction. `roster.py` owns the explicit fallback reference and validates its transport. `run_transport.py` owns the bounded state machine because it already has the selected seat and all dispatch settings. `run_receipts.py` serializes and logs every attempt.
+
+**Execution:** Complete each task in order, keep the checkboxes current, run every test through `brigade work verify run`, and commit each green slice.
+
+## File map
+
+- `src/brigade/agents.py`: extract Grok session metadata and build one exact-session continuation.
+- `src/brigade/roster.py`: parse and validate `invalid_final_fallback`.
+- `src/brigade/run_transport.py`: represent attempts and execute the bounded recovery policy.
+- `src/brigade/run_receipts.py`: serialize attempt metadata and persist per-attempt logs.
+- `tests/test_agents.py`: adapter metadata and continuation argv coverage.
+- `tests/test_roster.py`: fallback-reference schema coverage.
+- `tests/test_run_transport_recovery.py`: typed trigger and bounded transport-policy coverage.
+- `tests/test_aboyeur.py`: direct-worker artifact and terminal-result coverage.
+- `docs/seat-catalog.md`: public roster syntax and constraints.
+
+### Task 1: Exact Grok continuation support
+
+**Files:** `tests/test_agents.py`, `src/brigade/agents.py`
+
+- [x] Add failing adapter tests asserting that valid and malformed Grok JSON envelopes populate `session_id`, `request_id`, and `stop_reason`, and that `resume_session_id` produces one argv containing `--resume <id>`, the original model/reasoning/sandbox, and the JSON schema.
+- [x] Run RED:
+  `brigade work verify run --target . --command ".venv/bin/python -m pytest tests/test_agents.py -q" --capture brigade-work`
+  Expect failures because `run_agent` has no continuation argument and drops envelope metadata.
+- [x] Replace the parser tuple with a frozen result object and thread its metadata into every structured-Grok `AgentResult`:
+
+```python
+@dataclass(frozen=True)
+class _GrokFinal:
+    text: str
+    error: str
+    session_id: str | None
+    request_id: str | None
+    stop_reason: str | None
+```
+
+- [x] Add `resume_session_id: str | None = None` to `build_argv` and `run_agent`. Reject it for non-Grok and writable calls. For Grok, insert `--resume`, the exact ID, and the continuation prompt before the generated read-only flags while retaining model, reasoning, sandbox, and schema arguments.
+- [x] Run the same Brigade command to GREEN.
+- [x] Commit: `feat(run): support exact Grok continuation`
+
+### Task 2: Explicit fallback roster contract
+
+**Files:** `tests/test_roster.py`, `src/brigade/roster.py`, `docs/seat-catalog.md`
+
+- [x] Add failing roster tests for one valid reference plus missing seat, non-Grok source, direct Cursor target, non-Grok Cursor model, and wrong ACPX version.
+- [x] Run RED:
+  `brigade work verify run --target . --command ".venv/bin/python -m pytest tests/test_roster.py -q" --capture brigade-work`
+  Expect the new field to be ignored or absent.
+- [x] Add the field and parse it as a non-empty seat name:
+
+```python
+@dataclass(frozen=True)
+class Agent:
+    # existing fields
+    invalid_final_fallback: str | None = None
+```
+
+- [x] After all agents are parsed, validate that a configured source is direct Grok and its target exists, is not the orchestrator, uses `cli = "cursor"`, has a `grok-*` model, and uses reviewed ACPX transport/version. Do not require the field when no recovery is needed.
+- [x] Document the TOML field and its fail-closed constraints in `docs/seat-catalog.md`.
+- [x] Run the same Brigade command to GREEN.
+- [x] Commit: `feat(roster): validate Grok fallback seats`
+
+### Task 3: Attempt receipt model and logs
+
+**Files:** `tests/test_run_transport_recovery.py`, `src/brigade/run_transport.py`, `src/brigade/run_receipts.py`
+
+- [x] Add failing serialization tests for required attempt fields, null exit codes, selected flags, and distinct stdout/stderr log references.
+- [x] Run RED:
+  `brigade work verify run --target . --command ".venv/bin/python -m pytest tests/test_run_transport_recovery.py -q" --capture brigade-work`
+  Expect import or field failures because attempts are not modeled.
+- [x] Add a frozen attempt record and attach it to `WorkerResult`:
+
+```python
+@dataclass(frozen=True)
+class WorkerAttempt:
+    kind: str
+    worker: str
+    task: str
+    transport: str
+    model: str | None
+    reasoning: str | None
+    started_at: str
+    finished_at: str
+    exit_code: int | None
+    terminal_reason: str
+    failure_phase: str | None
+    failure_kind: str | None
+    session_id: str | None
+    selected: bool = False
+    stdout: str | None = None
+    stderr: str | None = None
+    stdout_log: str | None = None
+    stderr_log: str | None = None
+```
+
+- [x] Serialize `attempts` only when present, always emitting the required machine fields. Extend `write_worker_logs` to write `worker-NNN-<seat>-attempt-NNN-<kind>.stdout.log` and `.stderr.log`, then store their relative paths on the attempt.
+- [x] Run the same Brigade command to GREEN.
+- [x] Commit: `feat(run): persist worker attempt receipts`
+
+### Task 4: Bounded recovery state machine
+
+**Files:** `tests/test_run_transport_recovery.py`, `src/brigade/run_transport.py`
+
+- [x] Add failing policy tests for first-attempt success, continuation recovery, fallback recovery, missing fallback, all attempts invalid, missing session ID, nonzero initial failure, continuation timeout, writable dispatch, and orchestrated dispatch.
+- [x] Run RED:
+  `brigade work verify run --target . --command ".venv/bin/python -m pytest tests/test_run_transport_recovery.py -q" --capture brigade-work`
+  Expect only the first dispatch call and no attempt ledger.
+- [x] Define the sole trigger and fixed continuation request:
+
+```python
+_GROK_CONTINUATION_PROMPT = (
+    "Return the final answer now using the required structured answer schema. "
+    "Do not narrate progress or repeat the task."
+)
+
+def _is_direct_grok_invalid_final(agent: Agent, result: agents.AgentResult, *, direct: bool, read_only: bool) -> bool:
+    return (
+        direct
+        and read_only
+        and agent.cli == "grok"
+        and agent.transport == "direct"
+        and result.failure_phase == "output-validation"
+        and result.failure_kind == "malformed-final-output"
+    )
+```
+
+- [x] Refactor the existing transport branches into one inner invocation helper without changing legacy call shapes. Record the initial attempt. On the exact trigger, require `session_id`, run one continuation with identical settings, and only on the same typed continuation failure run the explicitly named ACP target once with the original task. Never call the recovery helper for the fallback result.
+- [x] Mark exactly one successful attempt selected. When no fallback is configured after an invalid continuation, return `failure_kind = "grok-fallback-missing"`; when the first envelope lacks a session ID, return `failure_kind = "grok-session-missing"`.
+- [x] Run the same Brigade command to GREEN.
+- [x] Commit: `feat(run): add bounded Grok recovery`
+
+### Task 5: Direct-worker artifact contract
+
+**Files:** `tests/test_aboyeur.py`, `src/brigade/run_receipts.py`, `src/brigade/run_transport.py`
+
+- [x] Add failing end-to-end direct-worker tests that invoke `aboyeur.run` and inspect `worker-results.json`, `synthesis.json`, `final.txt`, and every attempt log for first success, continuation success, fallback success, missing fallback, and all-invalid failure.
+- [x] Run RED:
+  `brigade work verify run --target . --command ".venv/bin/python -m pytest tests/test_aboyeur.py -q" --capture brigade-work`
+  Expect artifact assertions to fail until the receipt and selected-result mapping are complete.
+- [x] Make only the minimal receipt or result-mapping corrections exposed by those tests. Keep the existing top-level worker fields as the selected or terminal result so old readers remain compatible.
+- [x] Run the same Brigade command to GREEN.
+- [x] Commit: `test(run): cover bounded Grok recovery artifacts`
+
+### Task 6: Full verification and publication
+
+**Files:** all changed files
+
+- [x] Run focused recovery coverage through Brigade:
+  `brigade work verify run --target . --command ".venv/bin/python -m pytest tests/test_agents.py tests/test_roster.py tests/test_run_transport_recovery.py tests/test_aboyeur.py -q" --capture brigade-work`
+- [x] Run the full repository gate through Brigade:
+  `brigade work verify run --target . --command "./scripts/verify" --capture brigade-work`
+- [x] Review the exact diff and verify issue #282 acceptance criteria against code and receipts.
+- [x] Request independent review, verify every claim before changing code, and repeat the focused and full gates after accepted fixes.
+- [ ] Push the branch, open a ready PR that closes #282, monitor checks and review threads, merge only when the head is clean and green, then write and lint the memory handoff.

--- a/docs/superpowers/specs/2026-07-17-bounded-grok-recovery.md
+++ b/docs/superpowers/specs/2026-07-17-bounded-grok-recovery.md
@@ -1,0 +1,35 @@
+# Bounded direct-Grok recovery
+
+## Goal
+
+Recover one narrow direct Grok read-only result-integrity failure without turning Brigade into a general provider router: continue the exact Grok session once, then use one explicitly configured Cursor-Grok ACP seat if the continuation also lacks a valid structured final.
+
+## Scope
+
+The policy applies only to `brigade run --worker <seat> --read-only` when the selected seat uses `cli = "grok"`, `transport = "direct"`, and the adapter returns `failure_phase = "output-validation"` with `failure_kind = "malformed-final-output"`. Startup, authentication, settings, network, timeout, permission, nonzero inference, writable, orchestrated-worker, and other output-validation failures do not trigger recovery.
+
+## Considered approaches
+
+1. Retry inside the Grok adapter. This keeps CLI mechanics together but cannot resolve or validate a roster fallback and cannot produce worker-level attempt artifacts cleanly.
+2. Retry in the top-level run command. This has artifact context but duplicates transport dispatch and model-setting logic outside its current boundary.
+3. Add a bounded recovery policy to `run_transport.dispatch`. This is the selected approach because dispatch already owns the seat, transport, model, reasoning, timeout, cwd, sandbox, and direct-worker mode. The adapter only gains exact-session continuation support and Grok envelope metadata extraction.
+
+## Configuration
+
+A direct Grok seat may declare `invalid_final_fallback = "<seat-name>"`. Roster loading rejects this field on any non-direct-Grok seat and rejects references that do not name an existing worker with `cli = "cursor"`, a `grok-*` model, `transport = "acpx"`, and the reviewed ACPX version. The field remains optional so first-attempt success does not require a fallback; an exhausted continuation without it fails as `grok-fallback-missing`.
+
+## Execution
+
+The first direct attempt keeps the original task, model, reasoning, cwd, sandbox, timeout, and read-only settings. A typed invalid final must include the Grok session identifier. Brigade then invokes `grok --resume <session-id>` once with the same settings and a fixed request to return the final answer through the required schema. A missing session identifier fails as `grok-session-missing`.
+
+If the continuation succeeds, it is selected. If it returns the same typed invalid-final result, Brigade invokes the configured ACP fallback once with the original task. Any other continuation failure stops recovery. The ACP result is terminal whether it succeeds or fails, so the policy cannot recurse.
+
+## Artifacts
+
+`worker-results.json` keeps the selected result in the existing worker fields and adds `attempts` for direct-Grok recovery candidates, including first-attempt success. Each attempt records kind, worker, original task, transport, requested model, reasoning, UTC start and finish, exit code, terminal reason, failure phase and kind, session ID, log references, and `selected`. Raw stdout and stderr from every attempted process are written to distinct worker-attempt logs.
+
+No invalid attempt is selected. Concise schema-valid answers such as `No actionable findings.` remain valid and suppress recovery.
+
+## Verification
+
+Adapter tests cover session metadata extraction and exact `--resume` argv construction. Roster tests cover valid and invalid fallback references. Direct-worker tests cover first-attempt success, continuation recovery, fallback recovery, missing fallback, all attempts invalid, and non-trigger failures. The final gate is `./scripts/verify` through `brigade work verify run`.

--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -1599,6 +1599,7 @@ def _roster_payload(roster: Roster) -> dict[str, object]:
                 "transport_version": agent.transport_version,
                 "role": agent.role,
                 "timeout_seconds": agent.timeout_seconds,
+                "invalid_final_fallback": agent.invalid_final_fallback,
                 # env tables hold names and references only, never secret
                 # values (enforced at roster load), so persisting them for
                 # resume is safe.

--- a/src/brigade/agents.py
+++ b/src/brigade/agents.py
@@ -17,6 +17,16 @@ from .result_integrity import validate_final_output
 
 _OLLAMA_PREFIX = "ollama:"
 _CODEX_CLOUD_PREFIX = "codex-cloud:"
+_NONRECOVERABLE_GROK_OUTPUT_FAILURES = frozenset(
+    {
+        "provider-error",
+        "authentication-error",
+        "rate-limit-error",
+        "provider-setting-error",
+        "network-error",
+        "permission-error",
+    }
+)
 _GROK_RESULT_SCHEMA = json.dumps(
     {
         "type": "object",
@@ -29,6 +39,16 @@ _GROK_RESULT_SCHEMA = json.dumps(
     },
     separators=(",", ":"),
 )
+
+
+@dataclass(frozen=True)
+class _GrokFinal:
+    text: str
+    error: str
+    diagnostic: str = ""
+    session_id: str | None = None
+    request_id: str | None = None
+    stop_reason: str | None = None
 
 
 def _claude_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | None) -> List[str]:
@@ -221,16 +241,16 @@ def direct_cursor_read_only_limitation(model: str | None) -> str | None:
     return None
 
 
-def _parse_grok_final_output(stdout: str) -> tuple[str, str]:
+def _parse_grok_final_output(stdout: str) -> _GrokFinal:
     """Extract a schema-constrained final answer from Grok's JSON envelope."""
     base_error = "grok exited 0 without a structured final response"
     raw = stdout.strip()
     try:
         payload = json.loads(raw)
     except json.JSONDecodeError:
-        return raw, base_error
+        return _GrokFinal(text=raw, error=base_error)
     if not isinstance(payload, dict):
-        return raw, base_error
+        return _GrokFinal(text=raw, error=base_error)
 
     diagnostic_parts: list[str] = []
     stop_reason = payload.get("stopReason")
@@ -269,9 +289,22 @@ def _parse_grok_final_output(stdout: str) -> tuple[str, str]:
     no_structured_error = not structured_error_present
     if not successful_stop or not no_structured_error or not exact_shape:
         detail = f"{base_error} ({'; '.join(diagnostic_parts)})" if diagnostic_parts else base_error
-        return fallback, detail[:200]
+        return _GrokFinal(
+            text=fallback,
+            error=detail[:200],
+            diagnostic=(structured_output_error if isinstance(structured_output_error, str) else ""),
+            session_id=payload.get("sessionId") if isinstance(payload.get("sessionId"), str) else None,
+            request_id=payload.get("requestId") if isinstance(payload.get("requestId"), str) else None,
+            stop_reason=stop_reason if isinstance(stop_reason, str) else None,
+        )
     assert isinstance(answer, str)
-    return answer.strip(), ""
+    return _GrokFinal(
+        text=answer.strip(),
+        error="",
+        session_id=payload.get("sessionId") if isinstance(payload.get("sessionId"), str) else None,
+        request_id=payload.get("requestId") if isinstance(payload.get("requestId"), str) else None,
+        stop_reason=stop_reason if isinstance(stop_reason, str) else None,
+    )
 
 
 @dataclass(frozen=True)
@@ -395,7 +428,16 @@ def build_argv(
     model: str | None = None,
     reasoning: str | None = None,
     cwd: Path | None = None,
+    resume_session_id: str | None = None,
 ) -> List[str]:
+    if resume_session_id is not None:
+        if cli_ref != "grok":
+            raise ValueError("exact-session continuation supports grok only")
+        if not (read_only or sandbox == "read-only"):
+            raise ValueError("grok exact-session continuation requires read-only dispatch")
+        if not resume_session_id.strip():
+            raise ValueError("grok exact-session continuation requires a session id")
+
     if cli_ref.startswith(_OLLAMA_PREFIX):
         ollama_model = cli_ref[len(_OLLAMA_PREFIX) :]
         if not ollama_model:
@@ -417,6 +459,8 @@ def build_argv(
             "codex-cloud:<env-id>)"
         )
     argv = builder(prompt, read_only, sandbox, cwd)
+    if resume_session_id is not None:
+        argv = [argv[0], "--resume", resume_session_id, *argv[1:]]
     if model is not None:
         argv = _with_model(cli_ref, argv, model)
     if reasoning is not None:
@@ -483,9 +527,21 @@ def run_agent(
     model: str | None = None,
     reasoning: str | None = None,
     env: dict[str, str] | None = None,
+    resume_session_id: str | None = None,
 ) -> AgentResult:
     if not detect(cli_ref):
         return AgentResult(text="", ok=False, detail=f"{command_for(cli_ref)} not installed")
+
+    if resume_session_id is not None and (cli_ref != "grok" or not (read_only or sandbox == "read-only")):
+        return AgentResult(
+            text="",
+            ok=False,
+            detail="exact-session continuation requires a read-only grok worker",
+            failure_phase="dispatch",
+            failure_kind="invalid-session-continuation",
+            requested_model=model,
+            reasoning=reasoning,
+        )
 
     if cli_ref.startswith(_CODEX_CLOUD_PREFIX):
         env_id = cli_ref[len(_CODEX_CLOUD_PREFIX) :]
@@ -546,6 +602,7 @@ def run_agent(
         model=model,
         reasoning=reasoning,
         cwd=cwd,
+        resume_session_id=resume_session_id,
     )
     structured_grok = cli_ref == "grok" and (read_only or sandbox == "read-only")
     if structured_grok:
@@ -567,8 +624,18 @@ def run_agent(
     )
     text = result.stdout.strip()
     structured_error = ""
+    structured_diagnostic = ""
+    grok_session_id = None
+    grok_request_id = None
+    grok_stop_reason = None
     if structured_grok:
-        text, structured_error = _parse_grok_final_output(result.stdout)
+        grok_final = _parse_grok_final_output(result.stdout)
+        text = grok_final.text
+        structured_error = grok_final.error
+        structured_diagnostic = grok_final.diagnostic
+        grok_session_id = grok_final.session_id
+        grok_request_id = grok_final.request_id
+        grok_stop_reason = grok_final.stop_reason
     if result.code != 0:
         detail = result.stderr.strip() or f"exit {result.code}"
         return AgentResult(
@@ -581,8 +648,29 @@ def run_agent(
             timed_out=result.code == 124,
             requested_model=model,
             reasoning=reasoning,
+            stop_reason=grok_stop_reason,
+            session_id=grok_session_id,
+            request_id=grok_request_id,
         )
     if structured_error:
+        for diagnostic in (text, structured_diagnostic, result.stderr):
+            output_failure = validate_final_output(diagnostic)
+            if output_failure is not None and output_failure.kind in _NONRECOVERABLE_GROK_OUTPUT_FAILURES:
+                return AgentResult(
+                    text=text,
+                    ok=False,
+                    detail=output_failure.detail,
+                    failure_phase="output-validation",
+                    failure_kind=output_failure.kind,
+                    stdout=result.stdout,
+                    stderr=result.stderr,
+                    exit_code=result.code,
+                    requested_model=model,
+                    reasoning=reasoning,
+                    stop_reason=grok_stop_reason,
+                    session_id=grok_session_id,
+                    request_id=grok_request_id,
+                )
         return AgentResult(
             text=text,
             ok=False,
@@ -594,6 +682,9 @@ def run_agent(
             exit_code=result.code,
             requested_model=model,
             reasoning=reasoning,
+            stop_reason=grok_stop_reason,
+            session_id=grok_session_id,
+            request_id=grok_request_id,
         )
     if not text:
         detail = "empty output"
@@ -610,6 +701,9 @@ def run_agent(
             exit_code=result.code,
             requested_model=model,
             reasoning=reasoning,
+            stop_reason=grok_stop_reason,
+            session_id=grok_session_id,
+            request_id=grok_request_id,
         )
     output_failure = validate_final_output(text)
     if output_failure is not None:
@@ -624,6 +718,9 @@ def run_agent(
             exit_code=result.code,
             requested_model=model,
             reasoning=reasoning,
+            stop_reason=grok_stop_reason,
+            session_id=grok_session_id,
+            request_id=grok_request_id,
         )
     return AgentResult(
         text=text,
@@ -633,6 +730,9 @@ def run_agent(
         exit_code=result.code,
         requested_model=model,
         reasoning=reasoning,
+        stop_reason=grok_stop_reason,
+        session_id=grok_session_id,
+        request_id=grok_request_id,
     )
 
 

--- a/src/brigade/result_integrity.py
+++ b/src/brigade/result_integrity.py
@@ -48,6 +48,13 @@ _OPERATIONAL_ERRORS = (
             re.IGNORECASE | re.MULTILINE,
         ),
     ),
+    (
+        "permission-error",
+        re.compile(
+            r"^\s*error:.*\b(?:permission (?:denied|required)|not permitted|auto-denied)\b",
+            re.IGNORECASE | re.MULTILINE,
+        ),
+    ),
 )
 _CLAUSE_SPLIT = re.compile(r"(?:\r?\n)+|(?<=[.!?])\s+")
 _FUTURE_INTENT = re.compile(

--- a/src/brigade/roster.py
+++ b/src/brigade/roster.py
@@ -38,6 +38,7 @@ class Agent:
     transport: str = "direct"
     transport_version: str | None = None
     env: dict[str, str] | None = None
+    invalid_final_fallback: str | None = None
 
 
 @dataclass(frozen=True)
@@ -241,6 +242,10 @@ def load_roster(path: Path, *, resolution: RosterResolution | None = None) -> Ro
         headers = dict(headers_raw) if headers_raw is not None else None
 
         env = _as_env(raw_agent.get("env"), agent_name)
+        fallback_raw = raw_agent.get("invalid_final_fallback")
+        invalid_final_fallback = (
+            _as_str(fallback_raw, f"agents.{agent_name}.invalid_final_fallback") if fallback_raw is not None else None
+        )
 
         cli_raw = raw_agent.get("cli")
         has_endpoint = endpoint is not None and model is not None
@@ -295,10 +300,32 @@ def load_roster(path: Path, *, resolution: RosterResolution | None = None) -> Ro
             transport=transport_raw,
             transport_version=transport_version,
             env=env,
+            invalid_final_fallback=invalid_final_fallback,
         )
 
     if orchestrator not in parsed_agents:
         raise ValueError(f"orchestrator {orchestrator!r} is not defined in [agents]")
+
+    for agent_name, agent in parsed_agents.items():
+        fallback_name = agent.invalid_final_fallback
+        if fallback_name is None:
+            continue
+        if agent.cli != "grok" or agent.transport != "direct":
+            raise ValueError(f"agents.{agent_name}.invalid_final_fallback requires a direct grok seat")
+        fallback = parsed_agents.get(fallback_name)
+        if fallback is None:
+            raise ValueError(
+                f"agents.{agent_name}.invalid_final_fallback references {fallback_name!r}, which is not defined"
+            )
+        if fallback_name == orchestrator or fallback.cli != "cursor" or fallback.transport != "acpx":
+            raise ValueError(f"agents.{agent_name}.invalid_final_fallback must name a reviewed cursor-grok acpx seat")
+        if fallback.model is None or not fallback.model.lower().startswith("grok-"):
+            raise ValueError(f"agents.{agent_name}.invalid_final_fallback target must use a grok model")
+        if fallback.transport_version != ACPX_TRANSPORT_VERSION:
+            raise ValueError(
+                f"agents.{agent_name}.invalid_final_fallback target requires reviewed acpx version "
+                f"{ACPX_TRANSPORT_VERSION}"
+            )
 
     return Roster(
         orchestrator=orchestrator,

--- a/src/brigade/run_receipts.py
+++ b/src/brigade/run_receipts.py
@@ -7,7 +7,7 @@ from dataclasses import replace
 from pathlib import Path
 
 from . import agents, localio
-from .run_transport import Assignment, WorkerResult
+from .run_transport import Assignment, WorkerAttempt, WorkerResult
 
 
 def assignment_payload(assignments: list[Assignment]) -> list[dict[str, object]]:
@@ -69,7 +69,33 @@ def worker_payload(results: list[WorkerResult]) -> list[dict[str, object]]:
             entry["env_overrides"] = list(result.env_overrides)
         if result.endpoint_host is not None:
             entry["endpoint_host"] = result.endpoint_host
+        if result.attempts:
+            entry["attempts"] = [_attempt_payload(attempt) for attempt in result.attempts]
         payload.append(entry)
+    return payload
+
+
+def _attempt_payload(attempt: WorkerAttempt) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "kind": attempt.kind,
+        "worker": attempt.worker,
+        "task": attempt.task,
+        "transport": attempt.transport,
+        "model": attempt.model,
+        "reasoning": attempt.reasoning,
+        "started_at": attempt.started_at,
+        "finished_at": attempt.finished_at,
+        "exit_code": attempt.exit_code,
+        "terminal_reason": attempt.terminal_reason,
+        "failure_phase": attempt.failure_phase,
+        "failure_kind": attempt.failure_kind,
+        "session_id": attempt.session_id,
+        "selected": attempt.selected,
+    }
+    if attempt.stdout_log is not None:
+        payload["stdout_log"] = attempt.stdout_log
+    if attempt.stderr_log is not None:
+        payload["stderr_log"] = attempt.stderr_log
     return payload
 
 
@@ -143,17 +169,31 @@ def write_worker_logs(output_dir: Path, results: list[WorkerResult]) -> list[Wor
     logs_dir = output_dir / "logs"
     recorded: list[WorkerResult] = []
     for index, result in enumerate(results, start=1):
-        if result.stdout is None and result.stderr is None:
-            recorded.append(result)
-            continue
-        logs_dir.mkdir(parents=True, exist_ok=True)
         worker = re.sub(r"[^A-Za-z0-9_.-]+", "-", result.worker).strip("-") or "worker"
-        prefix = f"worker-{index:03d}-{worker}"
-        stdout_ref = f"logs/{prefix}.stdout.log"
-        stderr_ref = f"logs/{prefix}.stderr.log"
-        localio.write_text_atomic(output_dir / stdout_ref, result.stdout or "")
-        localio.write_text_atomic(output_dir / stderr_ref, result.stderr or "")
-        recorded.append(replace(result, stdout_log=stdout_ref, stderr_log=stderr_ref))
+        recorded_attempts: list[WorkerAttempt] = []
+        for attempt_index, attempt in enumerate(result.attempts, start=1):
+            if attempt.stdout is None and attempt.stderr is None:
+                recorded_attempts.append(attempt)
+                continue
+            logs_dir.mkdir(parents=True, exist_ok=True)
+            kind = re.sub(r"[^A-Za-z0-9_.-]+", "-", attempt.kind).strip("-") or "attempt"
+            prefix = f"worker-{index:03d}-{worker}-attempt-{attempt_index:03d}-{kind}"
+            stdout_ref = f"logs/{prefix}.stdout.log"
+            stderr_ref = f"logs/{prefix}.stderr.log"
+            localio.write_text_atomic(output_dir / stdout_ref, attempt.stdout or "")
+            localio.write_text_atomic(output_dir / stderr_ref, attempt.stderr or "")
+            recorded_attempts.append(replace(attempt, stdout_log=stdout_ref, stderr_log=stderr_ref))
+
+        recorded_result = replace(result, attempts=tuple(recorded_attempts))
+        if result.stdout is not None or result.stderr is not None:
+            logs_dir.mkdir(parents=True, exist_ok=True)
+            prefix = f"worker-{index:03d}-{worker}"
+            stdout_ref = f"logs/{prefix}.stdout.log"
+            stderr_ref = f"logs/{prefix}.stderr.log"
+            localio.write_text_atomic(output_dir / stdout_ref, result.stdout or "")
+            localio.write_text_atomic(output_dir / stderr_ref, result.stderr or "")
+            recorded_result = replace(recorded_result, stdout_log=stdout_ref, stderr_log=stderr_ref)
+        recorded.append(recorded_result)
     return recorded
 
 

--- a/src/brigade/run_resume.py
+++ b/src/brigade/run_resume.py
@@ -45,6 +45,7 @@ def _roster_from_snapshot(snapshot: dict) -> Roster:
             transport=raw.get("transport", "direct"),
             transport_version=raw.get("transport_version"),
             env=dict(raw["env"]) if raw.get("env") else None,
+            invalid_final_fallback=raw.get("invalid_final_fallback"),
         )
     return Roster(
         orchestrator=snapshot["orchestrator"],

--- a/src/brigade/run_transport.py
+++ b/src/brigade/run_transport.py
@@ -5,13 +5,19 @@ from __future__ import annotations
 import os
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Protocol
 from urllib.parse import urlparse
 
 from . import agents, run_control
 from .roster import Agent, Roster, is_cli_allowed, timeout_for
+
+_GROK_CONTINUATION_PROMPT = (
+    "Return the final answer now using the required structured answer schema. "
+    "Do not narrate progress or repeat the task."
+)
 
 
 @dataclass(frozen=True)
@@ -20,6 +26,82 @@ class Assignment:
     task: str
     stage: int = 1
     covers: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class WorkerAttempt:
+    kind: str
+    worker: str
+    task: str
+    transport: str
+    model: str | None
+    reasoning: str | None
+    started_at: str
+    finished_at: str
+    exit_code: int | None
+    terminal_reason: str
+    failure_phase: str | None
+    failure_kind: str | None
+    session_id: str | None
+    selected: bool = False
+    stdout: str | None = None
+    stderr: str | None = None
+    stdout_log: str | None = None
+    stderr_log: str | None = None
+
+
+def _attempt_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _is_direct_grok_invalid_final(
+    agent: Agent,
+    result: agents.AgentResult,
+    *,
+    direct: bool,
+    read_only: bool,
+) -> bool:
+    return (
+        direct
+        and read_only
+        and agent.cli == "grok"
+        and agent.transport == "direct"
+        and result.failure_phase == "output-validation"
+        and result.failure_kind == "malformed-final-output"
+    )
+
+
+def _worker_attempt(
+    *,
+    kind: str,
+    worker: Agent,
+    task: str,
+    result: agents.AgentResult,
+    started_at: str,
+    finished_at: str,
+    selected: bool = False,
+) -> WorkerAttempt:
+    terminal_reason = result.stop_reason or (
+        "completed" if result.ok else result.failure_kind or result.detail or "failed"
+    )
+    return WorkerAttempt(
+        kind=kind,
+        worker=worker.name,
+        task=task,
+        transport=worker.transport,
+        model=result.requested_model or worker.model,
+        reasoning=result.reasoning or worker.reasoning,
+        started_at=started_at,
+        finished_at=finished_at,
+        exit_code=result.exit_code,
+        terminal_reason=terminal_reason,
+        failure_phase=result.failure_phase,
+        failure_kind=result.failure_kind,
+        session_id=result.session_id,
+        selected=selected,
+        stdout=result.stdout,
+        stderr=result.stderr,
+    )
 
 
 def _env_override_names(env: dict[str, str] | None) -> tuple[str, ...]:
@@ -85,6 +167,7 @@ class WorkerResult:
     failure_kind: str | None = None
     env_overrides: tuple[str, ...] = ()
     endpoint_host: str | None = None
+    attempts: tuple[WorkerAttempt, ...] = ()
 
 
 class PromptBuilder(Protocol):
@@ -162,7 +245,6 @@ def dispatch(
                     else f"{agent.cli} is not allowed by limits.allow_models"
                 ),
             )
-        cli_ref = agent.cli
         prompt = build_prompt(
             agent,
             assignment,
@@ -175,156 +257,272 @@ def dispatch(
         )
         started = time.monotonic()
         effective_read_only = read_only if sandbox_read_only is None else sandbox_read_only
-        if agent.transport == "acpx":
-            from . import acpx_adapter
 
-            result = acpx_adapter.run_cursor(
-                prompt,
-                cwd=cwd or Path.cwd(),
-                timeout=timeout_for(agent, roster),
-                model=agent.model or "",
-                version=agent.transport_version or "",
-                read_only=effective_read_only,
-                writable_worktree=authorized_writable_worktree,
-            )
-        elif agent.env is not None:
-            # env seats always dispatch through the direct CLI path, even for
-            # codex under app-server transport: the app-server session cannot
-            # apply per-seat env, and silently dropping it would falsify the
-            # provenance recorded below.
-            env_kwargs: dict[str, Any] = {}
-            if sandbox is not None:
-                env_kwargs["sandbox"] = sandbox
-            if agent.model is not None:
-                env_kwargs["model"] = agent.model
-            if agent.reasoning is not None:
-                env_kwargs["reasoning"] = agent.reasoning
-            result = agents.run_agent(
+        def invoke(
+            selected_agent: Agent,
+            selected_prompt: str,
+            *,
+            resume_session_id: str | None = None,
+        ) -> agents.AgentResult:
+            assert selected_agent.cli is not None
+            cli_ref = selected_agent.cli
+            if selected_agent.transport == "acpx":
+                from . import acpx_adapter
+
+                return acpx_adapter.run_cursor(
+                    selected_prompt,
+                    cwd=cwd or Path.cwd(),
+                    timeout=timeout_for(selected_agent, roster),
+                    model=selected_agent.model or "",
+                    version=selected_agent.transport_version or "",
+                    read_only=effective_read_only,
+                    writable_worktree=authorized_writable_worktree,
+                )
+            if resume_session_id is not None:
+                return agents.run_agent(
+                    cli_ref,
+                    selected_prompt,
+                    timeout=timeout_for(selected_agent, roster),
+                    cwd=cwd,
+                    read_only=effective_read_only,
+                    sandbox=sandbox,
+                    model=selected_agent.model,
+                    reasoning=selected_agent.reasoning,
+                    env=dict(selected_agent.env) if selected_agent.env is not None else None,
+                    resume_session_id=resume_session_id,
+                )
+            if selected_agent.env is not None:
+                # Env seats always dispatch through the direct CLI path. The
+                # app-server session cannot apply per-seat env safely.
+                env_kwargs: dict[str, Any] = {}
+                if sandbox is not None:
+                    env_kwargs["sandbox"] = sandbox
+                if selected_agent.model is not None:
+                    env_kwargs["model"] = selected_agent.model
+                if selected_agent.reasoning is not None:
+                    env_kwargs["reasoning"] = selected_agent.reasoning
+                return agents.run_agent(
+                    cli_ref,
+                    selected_prompt,
+                    timeout=timeout_for(selected_agent, roster),
+                    cwd=cwd,
+                    read_only=effective_read_only,
+                    env=dict(selected_agent.env),
+                    **env_kwargs,
+                )
+            if selected_agent.cli == "codex" and appserver is not None:
+                on_event = event_writer(events_dir, selected_agent.name, verbose=verbose)
+                return run_appserver_worker(
+                    appserver,
+                    selected_agent,
+                    selected_agent.name,
+                    selected_prompt,
+                    timeout=timeout_for(selected_agent, roster),
+                    cwd=cwd,
+                    read_only=effective_read_only,
+                    sandbox=sandbox,
+                    registry=control_registry,
+                    on_event=on_event,
+                )
+
+            timeout = timeout_for(selected_agent, roster)
+            if sandbox is None and selected_agent.model is None and selected_agent.reasoning is None:
+                return agents.run_agent(
+                    cli_ref, selected_prompt, timeout=timeout, cwd=cwd, read_only=effective_read_only
+                )
+            if sandbox is not None and selected_agent.model is None and selected_agent.reasoning is None:
+                return agents.run_agent(
+                    cli_ref,
+                    selected_prompt,
+                    timeout=timeout,
+                    cwd=cwd,
+                    read_only=effective_read_only,
+                    sandbox=sandbox,
+                )
+            if sandbox is None and selected_agent.model is not None and selected_agent.reasoning is None:
+                return agents.run_agent(
+                    cli_ref,
+                    selected_prompt,
+                    timeout=timeout,
+                    cwd=cwd,
+                    read_only=effective_read_only,
+                    model=selected_agent.model,
+                )
+            if sandbox is None and selected_agent.model is None and selected_agent.reasoning is not None:
+                return agents.run_agent(
+                    cli_ref,
+                    selected_prompt,
+                    timeout=timeout,
+                    cwd=cwd,
+                    read_only=effective_read_only,
+                    reasoning=selected_agent.reasoning,
+                )
+            if sandbox is not None and selected_agent.model is not None and selected_agent.reasoning is None:
+                return agents.run_agent(
+                    cli_ref,
+                    selected_prompt,
+                    timeout=timeout,
+                    cwd=cwd,
+                    read_only=effective_read_only,
+                    sandbox=sandbox,
+                    model=selected_agent.model,
+                )
+            if sandbox is not None and selected_agent.model is None and selected_agent.reasoning is not None:
+                return agents.run_agent(
+                    cli_ref,
+                    selected_prompt,
+                    timeout=timeout,
+                    cwd=cwd,
+                    read_only=effective_read_only,
+                    sandbox=sandbox,
+                    reasoning=selected_agent.reasoning,
+                )
+            if sandbox is None and selected_agent.model is not None and selected_agent.reasoning is not None:
+                return agents.run_agent(
+                    cli_ref,
+                    selected_prompt,
+                    timeout=timeout,
+                    cwd=cwd,
+                    read_only=effective_read_only,
+                    model=selected_agent.model,
+                    reasoning=selected_agent.reasoning,
+                )
+            assert sandbox is not None
+            assert selected_agent.model is not None
+            assert selected_agent.reasoning is not None
+            return agents.run_agent(
                 cli_ref,
-                prompt,
-                timeout=timeout_for(agent, roster),
-                cwd=cwd,
-                read_only=effective_read_only,
-                env=dict(agent.env),
-                **env_kwargs,
-            )
-        elif agent.cli == "codex" and appserver is not None:
-            on_event = event_writer(events_dir, assignment.worker, verbose=verbose)
-            result = run_appserver_worker(
-                appserver,
-                agent,
-                assignment.worker,
-                prompt,
-                timeout=timeout_for(agent, roster),
+                selected_prompt,
+                timeout=timeout,
                 cwd=cwd,
                 read_only=effective_read_only,
                 sandbox=sandbox,
-                registry=control_registry,
-                on_event=on_event,
+                model=selected_agent.model,
+                reasoning=selected_agent.reasoning,
             )
-        else:
-            timeout = timeout_for(agent, roster)
-            if sandbox is None and agent.model is None and agent.reasoning is None:
-                result = agents.run_agent(cli_ref, prompt, timeout=timeout, cwd=cwd, read_only=effective_read_only)
-            elif sandbox is not None and agent.model is None and agent.reasoning is None:
-                result = agents.run_agent(
-                    cli_ref,
-                    prompt,
-                    timeout=timeout,
-                    cwd=cwd,
-                    read_only=effective_read_only,
-                    sandbox=sandbox,
-                )
-            elif sandbox is None and agent.model is not None and agent.reasoning is None:
-                result = agents.run_agent(
-                    cli_ref,
-                    prompt,
-                    timeout=timeout,
-                    cwd=cwd,
-                    read_only=effective_read_only,
-                    model=agent.model,
-                )
-            elif sandbox is None and agent.model is None and agent.reasoning is not None:
-                result = agents.run_agent(
-                    cli_ref,
-                    prompt,
-                    timeout=timeout,
-                    cwd=cwd,
-                    read_only=effective_read_only,
-                    reasoning=agent.reasoning,
-                )
-            elif sandbox is not None and agent.model is not None and agent.reasoning is None:
-                result = agents.run_agent(
-                    cli_ref,
-                    prompt,
-                    timeout=timeout,
-                    cwd=cwd,
-                    read_only=effective_read_only,
-                    sandbox=sandbox,
-                    model=agent.model,
-                )
-            elif sandbox is not None and agent.model is None and agent.reasoning is not None:
-                result = agents.run_agent(
-                    cli_ref,
-                    prompt,
-                    timeout=timeout,
-                    cwd=cwd,
-                    read_only=effective_read_only,
-                    sandbox=sandbox,
-                    reasoning=agent.reasoning,
-                )
-            elif sandbox is None and agent.model is not None and agent.reasoning is not None:
-                result = agents.run_agent(
-                    cli_ref,
-                    prompt,
-                    timeout=timeout,
-                    cwd=cwd,
-                    read_only=effective_read_only,
-                    model=agent.model,
-                    reasoning=agent.reasoning,
-                )
-            else:
-                assert sandbox is not None
-                assert agent.model is not None
-                assert agent.reasoning is not None
-                result = agents.run_agent(
-                    cli_ref,
-                    prompt,
-                    timeout=timeout,
-                    cwd=cwd,
-                    read_only=effective_read_only,
-                    sandbox=sandbox,
-                    model=agent.model,
-                    reasoning=agent.reasoning,
-                )
-        return WorkerResult(
-            worker=assignment.worker,
-            task=assignment.task,
-            text=result.text,
-            ok=result.ok,
-            detail=result.detail,
-            failure_phase=result.failure_phase,
-            failure_kind=result.failure_kind,
-            thread_id=result.thread_id,
-            status=result.status,
-            stdout=result.stdout,
-            stderr=result.stderr,
-            exit_code=result.exit_code,
-            timed_out=result.timed_out,
-            duration_seconds=max(0.0, round(time.monotonic() - started, 3)),
-            transport=result.transport,
-            requested_model=result.requested_model,
-            effective_model=result.effective_model,
-            reasoning=result.reasoning,
-            stop_reason=result.stop_reason,
-            protocol_version=result.protocol_version,
-            session_id=result.session_id,
-            request_id=result.request_id,
-            acpx_version=result.acpx_version,
-            safe_events=result.safe_events,
-            env_overrides=_env_override_names(agent.env) if result.failure_kind != "env-ref-missing" else (),
-            endpoint_host=_env_endpoint_host(agent.env) if result.failure_kind != "env-ref-missing" else None,
+
+        def finish(
+            result: agents.AgentResult,
+            terminal_agent: Agent,
+            attempts: list[WorkerAttempt] | None = None,
+        ) -> WorkerResult:
+            return WorkerResult(
+                worker=assignment.worker,
+                task=assignment.task,
+                text=result.text,
+                ok=result.ok,
+                detail=result.detail,
+                failure_phase=result.failure_phase,
+                failure_kind=result.failure_kind,
+                thread_id=result.thread_id,
+                status=result.status,
+                stdout=result.stdout,
+                stderr=result.stderr,
+                exit_code=result.exit_code,
+                timed_out=result.timed_out,
+                duration_seconds=max(0.0, round(time.monotonic() - started, 3)),
+                transport=result.transport,
+                requested_model=result.requested_model,
+                effective_model=result.effective_model,
+                reasoning=result.reasoning,
+                stop_reason=result.stop_reason,
+                protocol_version=result.protocol_version,
+                session_id=result.session_id,
+                request_id=result.request_id,
+                acpx_version=result.acpx_version,
+                safe_events=result.safe_events,
+                env_overrides=(
+                    _env_override_names(terminal_agent.env) if result.failure_kind != "env-ref-missing" else ()
+                ),
+                endpoint_host=(
+                    _env_endpoint_host(terminal_agent.env) if result.failure_kind != "env-ref-missing" else None
+                ),
+                attempts=tuple(attempts or ()),
+            )
+
+        initial_started = _attempt_timestamp()
+        result = invoke(agent, prompt)
+        initial_finished = _attempt_timestamp()
+        recovery_candidate = direct and effective_read_only and agent.cli == "grok" and agent.transport == "direct"
+        if not recovery_candidate:
+            return finish(result, agent)
+
+        attempts = [
+            _worker_attempt(
+                kind="initial",
+                worker=agent,
+                task=assignment.task,
+                result=result,
+                started_at=initial_started,
+                finished_at=initial_finished,
+                selected=result.ok,
+            )
+        ]
+        if result.ok or not _is_direct_grok_invalid_final(agent, result, direct=direct, read_only=effective_read_only):
+            return finish(result, agent, attempts)
+        if not result.session_id:
+            missing_session = replace(
+                result,
+                detail="grok invalid-final result did not include the session id required for exact continuation",
+                failure_kind="grok-session-missing",
+            )
+            return finish(missing_session, agent, attempts)
+
+        continuation_started = _attempt_timestamp()
+        continuation = invoke(agent, _GROK_CONTINUATION_PROMPT, resume_session_id=result.session_id)
+        continuation_finished = _attempt_timestamp()
+        attempts.append(
+            _worker_attempt(
+                kind="continuation",
+                worker=agent,
+                task=assignment.task,
+                result=continuation,
+                started_at=continuation_started,
+                finished_at=continuation_finished,
+                selected=continuation.ok,
+            )
         )
+        if continuation.ok or not _is_direct_grok_invalid_final(
+            agent, continuation, direct=direct, read_only=effective_read_only
+        ):
+            return finish(continuation, agent, attempts)
+
+        fallback_name = agent.invalid_final_fallback
+        if fallback_name is None:
+            missing_fallback = replace(
+                continuation,
+                detail="grok continuation also lacked a structured final; invalid_final_fallback is not configured",
+                failure_phase="dispatch",
+                failure_kind="grok-fallback-missing",
+            )
+            return finish(missing_fallback, agent, attempts)
+
+        fallback_agent = roster.agents[fallback_name]
+        fallback_prompt = build_prompt(
+            fallback_agent,
+            assignment,
+            prior_results=prior_results,
+            read_only=read_only,
+            direct=direct,
+            code_graph=code_graph,
+            drift_impact=drift_impact,
+            evidence=evidence,
+        )
+        fallback_started = _attempt_timestamp()
+        fallback_result = invoke(fallback_agent, fallback_prompt)
+        fallback_finished = _attempt_timestamp()
+        attempts.append(
+            _worker_attempt(
+                kind="fallback",
+                worker=fallback_agent,
+                task=assignment.task,
+                result=fallback_result,
+                started_at=fallback_started,
+                finished_at=fallback_finished,
+                selected=fallback_result.ok,
+            )
+        )
+        return finish(fallback_result, fallback_agent, attempts)
 
     if not assignments:
         return []

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -3,6 +3,8 @@ import os
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from brigade import aboyeur
 from brigade import agents
 from brigade import context_eval
@@ -47,21 +49,62 @@ def _model_roster():
     )
 
 
-def _grok_roster():
+def _grok_roster(*, fallback=False):
+    seats = {
+        "chef": Agent("chef", "codex", "plan and synthesize"),
+        "grok_cli": Agent(
+            "grok_cli",
+            "grok",
+            "review focused code changes",
+            model="grok-4.5",
+            reasoning="high",
+            invalid_final_fallback="cursor_grok" if fallback else None,
+        ),
+    }
+    if fallback:
+        seats["cursor_grok"] = Agent(
+            "cursor_grok",
+            "cursor",
+            "fallback review",
+            model="grok-4.5",
+            transport="acpx",
+            transport_version="0.12.0",
+        )
     return Roster(
         orchestrator="chef",
-        agents={
-            "chef": Agent("chef", "codex", "plan and synthesize"),
-            "grok_cli": Agent(
-                "grok_cli",
-                "grok",
-                "review focused code changes",
-                model="grok-4.5",
-                reasoning="high",
-            ),
-        },
+        agents=seats,
         max_workers=1,
     )
+
+
+def _grok_envelope(answer, *, valid=True, stop_reason="EndTurn"):
+    structured = {"kind": "answer", "answer": answer}
+    return json.dumps(
+        {
+            "text": json.dumps(structured),
+            "stopReason": stop_reason,
+            "sessionId": "019f0000-0000-7000-8000-000000000001",
+            "requestId": "00000000-0000-4000-8000-000000000001",
+            "structuredOutput": structured if valid else None,
+            "structuredOutputError": None if valid else "model did not produce structured output",
+        }
+    )
+
+
+def _stub_grok_process(monkeypatch, *results):
+    real_run = agents.proc.run
+    outputs = iter(results)
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        if argv and argv[0] == "grok":
+            calls.append(argv)
+            return next(outputs)
+        return real_run(argv, **kwargs)
+
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+    monkeypatch.setattr(agents.proc, "run", fake_run)
+    return calls
 
 
 def _restricted_roster():
@@ -1060,12 +1103,20 @@ def test_run_direct_grok_progress_only_output_fails_with_honest_artifacts(monkey
     assert rc == 2
     run_payload = json.loads((output_dir / "run.json").read_text())
     assert run_payload["status"] == "failed"
-    assert run_payload["error"] == "grok exited 0 without a structured final response"
+    assert run_payload["error"] == (
+        "grok invalid-final result did not include the session id required for exact continuation"
+    )
     assert run_payload["suspected_noop"] is False
     worker = json.loads((output_dir / "worker-results.json").read_text())["results"][0]
     assert worker["ok"] is False
-    assert worker["detail"] == "grok exited 0 without a structured final response"
+    assert worker["detail"] == (
+        "grok invalid-final result did not include the session id required for exact continuation"
+    )
+    assert worker["failure_kind"] == "grok-session-missing"
     assert worker["exit_code"] == 0
+    assert len(worker["attempts"]) == 1
+    assert worker["attempts"][0]["failure_kind"] == "malformed-final-output"
+    assert worker["attempts"][0]["selected"] is False
     assert (output_dir / worker["stdout_log"]).read_text() == output + "\n"
     assert (output_dir / "final.txt").read_text().strip() == output
 
@@ -1102,8 +1153,226 @@ def test_run_direct_grok_structured_final_succeeds_with_honest_artifacts(monkeyp
     assert worker["ok"] is True
     assert worker["text"] == answer
     assert worker["exit_code"] == 0
+    assert len(worker["attempts"]) == 1
+    assert worker["attempts"][0]["kind"] == "initial"
+    assert worker["attempts"][0]["selected"] is True
+    assert (output_dir / worker["attempts"][0]["stdout_log"]).read_text() == stdout + "\n"
     assert (output_dir / worker["stdout_log"]).read_text() == stdout + "\n"
     assert (output_dir / "final.txt").read_text().strip() == answer
+
+
+def test_run_direct_grok_continuation_recovery_preserves_both_attempts(monkeypatch, tmp_path):
+    invalid = _grok_envelope("Reviewing files first.", valid=False, stop_reason="Cancelled")
+    recovered = _grok_envelope("Recovered final answer.")
+    _stub_grok_process(
+        monkeypatch,
+        agents.proc.Result(0, invalid + "\n", ""),
+        agents.proc.Result(0, recovered + "\n", ""),
+    )
+    output_dir = tmp_path / "run"
+
+    rc = aboyeur.run(
+        "Review the current diff.",
+        _grok_roster(),
+        cwd=tmp_path,
+        worker="grok_cli",
+        output_dir=output_dir,
+        read_only=True,
+        route_enabled=False,
+    )
+
+    assert rc == 0
+    worker = json.loads((output_dir / "worker-results.json").read_text())["results"][0]
+    assert worker["text"] == "Recovered final answer."
+    assert [attempt["kind"] for attempt in worker["attempts"]] == ["initial", "continuation"]
+    assert [attempt["selected"] for attempt in worker["attempts"]] == [False, True]
+    assert (output_dir / worker["attempts"][0]["stdout_log"]).read_text() == invalid + "\n"
+    assert (output_dir / worker["attempts"][1]["stdout_log"]).read_text() == recovered + "\n"
+    synthesis = json.loads((output_dir / "synthesis.json").read_text())
+    assert synthesis["result"]["text"] == "Recovered final answer."
+    assert (output_dir / "final.txt").read_text().strip() == "Recovered final answer."
+
+
+def test_run_direct_grok_fallback_recovery_selects_explicit_acpx_seat(monkeypatch, tmp_path):
+    invalid = _grok_envelope("Reviewing files first.", valid=False, stop_reason="Cancelled")
+    _stub_grok_process(
+        monkeypatch,
+        agents.proc.Result(0, invalid + "\n", ""),
+        agents.proc.Result(0, invalid + "\n", ""),
+    )
+    monkeypatch.setattr(
+        "brigade.acpx_adapter.run_cursor",
+        lambda *args, **kwargs: agents.AgentResult(
+            text="Fallback final answer.",
+            ok=True,
+            stdout="fallback stdout\n",
+            stderr="",
+            exit_code=0,
+            transport="acpx",
+            requested_model="grok-4.5",
+            effective_model="grok-4.5",
+            stop_reason="end_turn",
+            session_id="cursor-session",
+        ),
+    )
+    output_dir = tmp_path / "run"
+
+    rc = aboyeur.run(
+        "Review the current diff.",
+        _grok_roster(fallback=True),
+        cwd=tmp_path,
+        worker="grok_cli",
+        output_dir=output_dir,
+        read_only=True,
+        route_enabled=False,
+    )
+
+    assert rc == 0
+    worker = json.loads((output_dir / "worker-results.json").read_text())["results"][0]
+    assert worker["transport"] == "acpx"
+    assert worker["text"] == "Fallback final answer."
+    assert [attempt["worker"] for attempt in worker["attempts"]] == ["grok_cli", "grok_cli", "cursor_grok"]
+    assert [attempt["selected"] for attempt in worker["attempts"]] == [False, False, True]
+    assert [(output_dir / attempt["stdout_log"]).read_text() for attempt in worker["attempts"]] == [
+        invalid + "\n",
+        invalid + "\n",
+        "fallback stdout\n",
+    ]
+    synthesis = json.loads((output_dir / "synthesis.json").read_text())
+    assert synthesis["result"]["transport"] == "acpx"
+    assert synthesis["result"]["text"] == "Fallback final answer."
+
+
+def test_run_direct_grok_missing_fallback_is_typed_after_continuation(monkeypatch, tmp_path):
+    invalid = _grok_envelope("Reviewing files first.", valid=False, stop_reason="Cancelled")
+    _stub_grok_process(
+        monkeypatch,
+        agents.proc.Result(0, invalid + "\n", ""),
+        agents.proc.Result(0, invalid + "\n", ""),
+    )
+    output_dir = tmp_path / "run"
+
+    rc = aboyeur.run(
+        "Review the current diff.",
+        _grok_roster(),
+        cwd=tmp_path,
+        worker="grok_cli",
+        output_dir=output_dir,
+        read_only=True,
+        route_enabled=False,
+    )
+
+    assert rc == 2
+    worker = json.loads((output_dir / "worker-results.json").read_text())["results"][0]
+    assert worker["failure_kind"] == "grok-fallback-missing"
+    assert [attempt["selected"] for attempt in worker["attempts"]] == [False, False]
+
+
+def test_run_direct_grok_all_attempts_invalid_preserves_terminal_failure(monkeypatch, tmp_path):
+    invalid = _grok_envelope("Reviewing files first.", valid=False, stop_reason="Cancelled")
+    _stub_grok_process(
+        monkeypatch,
+        agents.proc.Result(0, invalid + "\n", ""),
+        agents.proc.Result(0, invalid + "\n", ""),
+    )
+    monkeypatch.setattr(
+        "brigade.acpx_adapter.run_cursor",
+        lambda *args, **kwargs: agents.AgentResult(
+            text="Still reviewing.",
+            ok=False,
+            detail="ACP stream contained no final assistant text",
+            stdout="fallback invalid\n",
+            stderr="",
+            exit_code=0,
+            transport="acpx",
+            requested_model="grok-4.5",
+            failure_phase="output-validation",
+            failure_kind="empty-output",
+        ),
+    )
+    output_dir = tmp_path / "run"
+
+    rc = aboyeur.run(
+        "Review the current diff.",
+        _grok_roster(fallback=True),
+        cwd=tmp_path,
+        worker="grok_cli",
+        output_dir=output_dir,
+        read_only=True,
+        route_enabled=False,
+    )
+
+    assert rc == 2
+    worker = json.loads((output_dir / "worker-results.json").read_text())["results"][0]
+    assert worker["failure_kind"] == "empty-output"
+    assert len(worker["attempts"]) == 3
+    assert not any(attempt["selected"] for attempt in worker["attempts"])
+
+
+@pytest.mark.parametrize(
+    ("diagnostic", "failure_kind"),
+    [
+        ("Error: authentication required. Run provider login.", "authentication-error"),
+        ("Error: model grok-example is not available.", "provider-setting-error"),
+        ("Error: failed to connect to the model provider.", "network-error"),
+        ("Error: permission denied while reading the workspace.", "permission-error"),
+    ],
+)
+def test_run_direct_grok_operational_envelope_never_enters_recovery(monkeypatch, tmp_path, diagnostic, failure_kind):
+    envelope = _grok_envelope(diagnostic, valid=False, stop_reason="Cancelled")
+    calls = _stub_grok_process(monkeypatch, agents.proc.Result(0, envelope + "\n", ""))
+    output_dir = tmp_path / "run"
+
+    rc = aboyeur.run(
+        "Review the current diff.",
+        _grok_roster(fallback=True),
+        cwd=tmp_path,
+        worker="grok_cli",
+        output_dir=output_dir,
+        read_only=True,
+        route_enabled=False,
+    )
+
+    assert rc == 2
+    assert len(calls) == 1
+    worker = json.loads((output_dir / "worker-results.json").read_text())["results"][0]
+    assert worker["failure_kind"] == failure_kind
+    assert len(worker["attempts"]) == 1
+    assert worker["attempts"][0]["selected"] is False
+
+
+@pytest.mark.parametrize("diagnostic_location", ["structured_error", "stderr"])
+def test_run_direct_grok_operational_diagnostic_outside_answer_never_enters_recovery(
+    monkeypatch, tmp_path, diagnostic_location
+):
+    diagnostic = "Error: authentication required. Run provider login."
+    payload = json.loads(_grok_envelope("Reviewing files first.", valid=False, stop_reason="Cancelled"))
+    stderr = ""
+    if diagnostic_location == "structured_error":
+        payload["structuredOutputError"] = diagnostic
+    else:
+        stderr = diagnostic
+    calls = _stub_grok_process(
+        monkeypatch,
+        agents.proc.Result(0, json.dumps(payload) + "\n", stderr),
+    )
+    output_dir = tmp_path / "run"
+
+    rc = aboyeur.run(
+        "Review the current diff.",
+        _grok_roster(fallback=True),
+        cwd=tmp_path,
+        worker="grok_cli",
+        output_dir=output_dir,
+        read_only=True,
+        route_enabled=False,
+    )
+
+    assert rc == 2
+    assert len(calls) == 1
+    worker = json.loads((output_dir / "worker-results.json").read_text())["results"][0]
+    assert worker["failure_kind"] == "authentication-error"
+    assert len(worker["attempts"]) == 1
 
 
 def test_run_defers_success_until_worktree_artifact_collection(monkeypatch, tmp_path):
@@ -1422,6 +1691,12 @@ def test_roster_payload_includes_reasoning():
         agents={"chef": Agent("chef", "codex", "plan", reasoning="xhigh")},
     )
     assert aboyeur._roster_payload(roster)["agents"]["chef"]["reasoning"] == "xhigh"
+
+
+def test_roster_payload_includes_invalid_final_fallback():
+    payload = aboyeur._roster_payload(_grok_roster(fallback=True))
+
+    assert payload["agents"]["grok_cli"]["invalid_final_fallback"] == "cursor_grok"
 
 
 def test_roster_payload_includes_sandbox():

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -746,6 +746,9 @@ def test_run_agent_rejects_grok_json_without_structured_final_output(monkeypatch
     )
     assert result.text == output
     assert result.stdout == stdout + "\n"
+    assert result.session_id == "019f0000-0000-7000-8000-000000000001"
+    assert result.request_id == "00000000-0000-4000-8000-000000000001"
+    assert result.stop_reason == "Cancelled"
 
 
 @pytest.mark.parametrize("case", ["cancelled", "extra-property", "structured-error"])
@@ -815,6 +818,9 @@ def test_run_agent_accepts_concise_grok_no_findings(monkeypatch):
     assert result.ok is True
     assert result.text == "No actionable findings."
     assert result.exit_code == 0
+    assert result.session_id == "019f0000-0000-7000-8000-000000000001"
+    assert result.request_id == "00000000-0000-4000-8000-000000000001"
+    assert result.stop_reason == "EndTurn"
     assert seen["argv"][-2:] == [
         "--json-schema",
         (
@@ -831,6 +837,41 @@ def test_run_agent_accepts_concise_grok_no_findings(monkeypatch):
         "--json-schema",
         seen["argv"][-1],
     ]
+
+
+def test_run_agent_resumes_exact_grok_session_with_original_settings(monkeypatch, tmp_path):
+    output = _grok_json_output("Recovered final answer.")
+    seen = {}
+    session_id = "019f0000-0000-7000-8000-000000000001"
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+
+    def fake_run(argv, **kwargs):
+        seen["argv"] = argv
+        seen["kwargs"] = kwargs
+        return agents.proc.Result(0, output + "\n", "")
+
+    monkeypatch.setattr(agents.proc, "run", fake_run)
+
+    result = agents.run_agent(
+        "grok",
+        "Return the final answer now.",
+        timeout=47,
+        cwd=tmp_path,
+        read_only=True,
+        sandbox="read-only",
+        model="grok-4.5",
+        reasoning="high",
+        resume_session_id=session_id,
+    )
+
+    assert result.ok is True
+    assert seen["argv"].count("--resume") == 1
+    assert seen["argv"][seen["argv"].index("--resume") + 1] == session_id
+    assert seen["argv"][seen["argv"].index("-p") + 1] == "Return the final answer now."
+    assert seen["argv"][seen["argv"].index("-m") + 1] == "grok-4.5"
+    assert seen["argv"][seen["argv"].index("--reasoning-effort") + 1] == "high"
+    assert seen["kwargs"]["timeout"] == 47
+    assert seen["kwargs"]["cwd"] == tmp_path
 
 
 def test_run_agent_keeps_permission_mode_prompt_separate_from_grok_flags(monkeypatch):

--- a/tests/test_roster.py
+++ b/tests/test_roster.py
@@ -496,3 +496,66 @@ def test_env_empty_table_loads_as_none(tmp_path):
     )
     r = roster_mod.load_roster(_write(tmp_path, bad))
     assert r.agents["k3"].env is None
+
+
+GROK_FALLBACK_ROSTER = """
+orchestrator = "chef"
+
+[agents.chef]
+cli = "codex"
+role = "plan"
+
+[agents.grok-review]
+cli = "grok"
+model = "grok-4.5"
+reasoning = "high"
+role = "review"
+invalid_final_fallback = "cursor-grok"
+
+[agents.cursor-grok]
+cli = "cursor"
+model = "grok-4.5"
+transport = "acpx"
+transport_version = "0.12.0"
+role = "fallback review"
+"""
+
+
+def test_grok_invalid_final_fallback_names_reviewed_acpx_seat(tmp_path):
+    loaded = roster_mod.load_roster(_write(tmp_path, GROK_FALLBACK_ROSTER))
+
+    assert loaded.agents["grok-review"].invalid_final_fallback == "cursor-grok"
+
+
+@pytest.mark.parametrize(
+    ("roster_text", "match"),
+    [
+        (
+            GROK_FALLBACK_ROSTER.replace(
+                'invalid_final_fallback = "cursor-grok"', 'invalid_final_fallback = "missing"'
+            ),
+            "is not defined",
+        ),
+        (
+            GROK_FALLBACK_ROSTER.replace('cli = "grok"\nmodel = "grok-4.5"', 'cli = "codex"\nmodel = "gpt-5.6"'),
+            "direct grok seat",
+        ),
+        (
+            GROK_FALLBACK_ROSTER.replace('transport = "acpx"\ntransport_version = "0.12.0"\n', ""),
+            "reviewed cursor-grok acpx seat",
+        ),
+        (
+            GROK_FALLBACK_ROSTER.replace(
+                'model = "grok-4.5"\ntransport = "acpx"', 'model = "composer-2.5"\ntransport = "acpx"'
+            ),
+            "grok model",
+        ),
+        (
+            GROK_FALLBACK_ROSTER.replace('transport_version = "0.12.0"', 'transport_version = "0.11.0"'),
+            "reviewed version is 0.12.0",
+        ),
+    ],
+)
+def test_grok_invalid_final_fallback_rejects_unreviewed_routes(tmp_path, roster_text, match):
+    with pytest.raises(ValueError, match=match):
+        roster_mod.load_roster(_write(tmp_path, roster_text))

--- a/tests/test_run_resume.py
+++ b/tests/test_run_resume.py
@@ -71,6 +71,30 @@ class _StubServer:
         return _StubThread(thread_id)
 
 
+def test_roster_snapshot_preserves_invalid_final_fallback():
+    snapshot = {
+        "orchestrator": "chef",
+        "agents": {
+            "chef": {"cli": "codex", "role": "plan"},
+            "grok-review": {
+                "cli": "grok",
+                "role": "review",
+                "invalid_final_fallback": "cursor-grok",
+            },
+            "cursor-grok": {
+                "cli": "cursor",
+                "role": "fallback review",
+                "transport": "acpx",
+                "transport_version": "0.12.0",
+            },
+        },
+    }
+
+    roster = run_resume._roster_from_snapshot(snapshot)
+
+    assert roster.agents["grok-review"].invalid_final_fallback == "cursor-grok"
+
+
 def test_resume_reattaches_and_resynthesizes(tmp_path, monkeypatch, capsys):
     run_dir = _write_run_dir(
         tmp_path,

--- a/tests/test_run_transport_recovery.py
+++ b/tests/test_run_transport_recovery.py
@@ -1,0 +1,377 @@
+from dataclasses import replace
+
+from brigade import acpx_adapter, agents, run_transport
+from brigade.roster import Agent, Roster
+from brigade.run_receipts import worker_payload, write_worker_logs
+from brigade.run_transport import Assignment, WorkerAttempt, WorkerResult
+
+
+def _attempt(**overrides):
+    values = {
+        "kind": "initial",
+        "worker": "grok-review",
+        "task": "Review the diff.",
+        "transport": "direct",
+        "model": "grok-4.5",
+        "reasoning": "high",
+        "started_at": "2026-07-17T08:00:00+00:00",
+        "finished_at": "2026-07-17T08:00:01+00:00",
+        "exit_code": None,
+        "terminal_reason": "malformed-final-output",
+        "failure_phase": "output-validation",
+        "failure_kind": "malformed-final-output",
+        "session_id": "019f0000-0000-7000-8000-000000000001",
+        "selected": False,
+    }
+    values.update(overrides)
+    return WorkerAttempt(**values)
+
+
+def test_worker_payload_serializes_required_attempt_fields_with_null_exit_code():
+    result = WorkerResult(
+        worker="grok-review",
+        task="Review the diff.",
+        text="progress",
+        ok=False,
+        attempts=(_attempt(),),
+    )
+
+    attempt = worker_payload([result])[0]["attempts"][0]
+
+    assert attempt == {
+        "kind": "initial",
+        "worker": "grok-review",
+        "task": "Review the diff.",
+        "transport": "direct",
+        "model": "grok-4.5",
+        "reasoning": "high",
+        "started_at": "2026-07-17T08:00:00+00:00",
+        "finished_at": "2026-07-17T08:00:01+00:00",
+        "exit_code": None,
+        "terminal_reason": "malformed-final-output",
+        "failure_phase": "output-validation",
+        "failure_kind": "malformed-final-output",
+        "session_id": "019f0000-0000-7000-8000-000000000001",
+        "selected": False,
+    }
+
+
+def test_write_worker_logs_preserves_distinct_attempt_streams(tmp_path):
+    first = _attempt(stdout="first stdout\n", stderr="first stderr\n")
+    second = _attempt(
+        kind="continuation",
+        started_at="2026-07-17T08:00:02+00:00",
+        finished_at="2026-07-17T08:00:03+00:00",
+        terminal_reason="EndTurn",
+        failure_phase=None,
+        failure_kind=None,
+        exit_code=0,
+        selected=True,
+        stdout="second stdout\n",
+        stderr="",
+    )
+    result = WorkerResult(
+        worker="grok-review",
+        task="Review the diff.",
+        text="answer",
+        ok=True,
+        attempts=(first, second),
+    )
+
+    recorded = write_worker_logs(tmp_path, [result])[0]
+
+    assert recorded.attempts[0].stdout_log == "logs/worker-001-grok-review-attempt-001-initial.stdout.log"
+    assert recorded.attempts[1].stdout_log == "logs/worker-001-grok-review-attempt-002-continuation.stdout.log"
+    assert (tmp_path / recorded.attempts[0].stdout_log).read_text() == "first stdout\n"
+    assert (tmp_path / recorded.attempts[0].stderr_log).read_text() == "first stderr\n"
+    assert (tmp_path / recorded.attempts[1].stdout_log).read_text() == "second stdout\n"
+
+
+def _recovery_roster(*, fallback: bool = True, source_env: dict[str, str] | None = None) -> Roster:
+    grok = Agent(
+        name="grok-review",
+        cli="grok",
+        role="review",
+        timeout_seconds=31,
+        model="grok-4.5",
+        reasoning="high",
+        env=source_env or {},
+        invalid_final_fallback="cursor-grok" if fallback else None,
+    )
+    seats = {
+        "chef": Agent(name="chef", cli="codex", role="plan"),
+        "grok-review": grok,
+    }
+    if fallback:
+        seats["cursor-grok"] = Agent(
+            name="cursor-grok",
+            cli="cursor",
+            role="fallback review",
+            model="grok-4.5",
+            transport="acpx",
+            transport_version="0.12.0",
+        )
+    return Roster(orchestrator="chef", agents=seats, max_workers=1)
+
+
+def _invalid_final(*, session_id="019f0000-0000-7000-8000-000000000001") -> agents.AgentResult:
+    return agents.AgentResult(
+        text="Reviewing files first.",
+        ok=False,
+        detail="grok exited 0 without a structured final response",
+        stdout="invalid stdout\n",
+        stderr="",
+        exit_code=0,
+        requested_model="grok-4.5",
+        reasoning="high",
+        stop_reason="Cancelled",
+        session_id=session_id,
+        failure_phase="output-validation",
+        failure_kind="malformed-final-output",
+    )
+
+
+def _successful_final(text="No actionable findings.") -> agents.AgentResult:
+    return agents.AgentResult(
+        text=text,
+        ok=True,
+        stdout="success stdout\n",
+        stderr="",
+        exit_code=0,
+        requested_model="grok-4.5",
+        reasoning="high",
+        stop_reason="EndTurn",
+        session_id="019f0000-0000-7000-8000-000000000001",
+    )
+
+
+def _dispatch_recovery(
+    monkeypatch,
+    tmp_path,
+    direct_results,
+    *,
+    fallback_result=None,
+    fallback=True,
+    read_only=True,
+    direct=True,
+    source_env=None,
+):
+    direct_calls = []
+    fallback_calls = []
+    results = iter(direct_results)
+
+    def fake_run_agent(cli_ref, prompt, **kwargs):
+        direct_calls.append((cli_ref, prompt, kwargs))
+        return next(results)
+
+    def fake_run_cursor(prompt, **kwargs):
+        fallback_calls.append((prompt, kwargs))
+        assert fallback_result is not None
+        return fallback_result
+
+    monkeypatch.setattr(agents, "run_agent", fake_run_agent)
+    monkeypatch.setattr(acpx_adapter, "run_cursor", fake_run_cursor)
+    result = run_transport.dispatch(
+        [Assignment(worker="grok-review", task="Review the diff.")],
+        _recovery_roster(fallback=fallback, source_env=source_env),
+        build_prompt=lambda agent, assignment, **kwargs: assignment.task,
+        run_appserver_worker=lambda *args, **kwargs: agents.AgentResult(text="", ok=False, detail="unused"),
+        event_writer=lambda events_dir, worker, verbose=False: None,
+        cwd=tmp_path,
+        read_only=read_only,
+        sandbox="read-only" if read_only else None,
+        direct=direct,
+    )[0]
+    return result, direct_calls, fallback_calls
+
+
+def test_direct_grok_first_attempt_success_is_selected(monkeypatch, tmp_path):
+    result, direct_calls, fallback_calls = _dispatch_recovery(monkeypatch, tmp_path, [_successful_final()])
+
+    assert result.ok is True
+    assert result.text == "No actionable findings."
+    assert len(direct_calls) == 1
+    assert fallback_calls == []
+    assert [attempt.kind for attempt in result.attempts] == ["initial"]
+    assert [attempt.selected for attempt in result.attempts] == [True]
+
+
+def test_direct_grok_continuation_reuses_exact_session_and_settings(monkeypatch, tmp_path):
+    result, direct_calls, fallback_calls = _dispatch_recovery(
+        monkeypatch,
+        tmp_path,
+        [_invalid_final(), _successful_final("Recovered final.")],
+    )
+
+    assert result.ok is True
+    assert result.text == "Recovered final."
+    assert fallback_calls == []
+    assert len(direct_calls) == 2
+    _, continuation_prompt, continuation_kwargs = direct_calls[1]
+    assert "Return the final answer now" in continuation_prompt
+    assert continuation_kwargs["resume_session_id"] == "019f0000-0000-7000-8000-000000000001"
+    assert continuation_kwargs["timeout"] == 31
+    assert continuation_kwargs["cwd"] == tmp_path
+    assert continuation_kwargs["read_only"] is True
+    assert continuation_kwargs["sandbox"] == "read-only"
+    assert continuation_kwargs["model"] == "grok-4.5"
+    assert continuation_kwargs["reasoning"] == "high"
+    assert [attempt.kind for attempt in result.attempts] == ["initial", "continuation"]
+    assert [attempt.selected for attempt in result.attempts] == [False, True]
+
+
+def test_direct_grok_fallback_recovers_after_two_invalid_finals(monkeypatch, tmp_path):
+    fallback = replace(_successful_final("Fallback final."), transport="acpx", stop_reason="end_turn")
+    result, direct_calls, fallback_calls = _dispatch_recovery(
+        monkeypatch,
+        tmp_path,
+        [_invalid_final(), _invalid_final()],
+        fallback_result=fallback,
+    )
+
+    assert result.ok is True
+    assert result.text == "Fallback final."
+    assert len(direct_calls) == 2
+    assert len(fallback_calls) == 1
+    assert fallback_calls[0][0] == "Review the diff."
+    assert [attempt.kind for attempt in result.attempts] == ["initial", "continuation", "fallback"]
+    assert [attempt.worker for attempt in result.attempts] == ["grok-review", "grok-review", "cursor-grok"]
+    assert [attempt.selected for attempt in result.attempts] == [False, False, True]
+
+
+def test_direct_grok_fallback_uses_selected_seat_endpoint_provenance(monkeypatch, tmp_path):
+    fallback = replace(_successful_final("Fallback final."), transport="acpx", stop_reason="end_turn")
+    result, _, _ = _dispatch_recovery(
+        monkeypatch,
+        tmp_path,
+        [_invalid_final(), _invalid_final()],
+        fallback_result=fallback,
+        source_env={"OPENAI_BASE_URL": "https://direct.example.com/v1"},
+    )
+
+    assert result.ok is True
+    assert result.env_overrides == ()
+    assert result.endpoint_host is None
+
+
+def test_direct_grok_missing_fallback_fails_after_one_continuation(monkeypatch, tmp_path):
+    result, direct_calls, fallback_calls = _dispatch_recovery(
+        monkeypatch,
+        tmp_path,
+        [_invalid_final(), _invalid_final()],
+        fallback=False,
+    )
+
+    assert result.ok is False
+    assert result.failure_kind == "grok-fallback-missing"
+    assert len(direct_calls) == 2
+    assert fallback_calls == []
+    assert [attempt.selected for attempt in result.attempts] == [False, False]
+
+
+def test_direct_grok_all_attempts_invalid_has_no_selected_result(monkeypatch, tmp_path):
+    result, direct_calls, fallback_calls = _dispatch_recovery(
+        monkeypatch,
+        tmp_path,
+        [_invalid_final(), _invalid_final()],
+        fallback_result=agents.AgentResult(
+            text="Still reviewing.",
+            ok=False,
+            detail="ACP stream contained no final assistant text",
+            stdout="fallback invalid\n",
+            stderr="",
+            exit_code=0,
+            transport="acpx",
+            requested_model="grok-4.5",
+            failure_phase="output-validation",
+            failure_kind="empty-output",
+        ),
+    )
+
+    assert result.ok is False
+    assert result.failure_kind == "empty-output"
+    assert len(direct_calls) == 2
+    assert len(fallback_calls) == 1
+    assert len(result.attempts) == 3
+    assert not any(attempt.selected for attempt in result.attempts)
+
+
+def test_direct_grok_missing_session_id_does_not_guess_or_fallback(monkeypatch, tmp_path):
+    result, direct_calls, fallback_calls = _dispatch_recovery(
+        monkeypatch,
+        tmp_path,
+        [_invalid_final(session_id=None)],
+    )
+
+    assert result.ok is False
+    assert result.failure_kind == "grok-session-missing"
+    assert len(direct_calls) == 1
+    assert fallback_calls == []
+
+
+def test_direct_grok_nonzero_failure_does_not_enter_recovery(monkeypatch, tmp_path):
+    failure = agents.AgentResult(
+        text="",
+        ok=False,
+        detail="network failed",
+        stderr="network failed",
+        exit_code=1,
+        requested_model="grok-4.5",
+        failure_phase="inference",
+        failure_kind="transport-error",
+    )
+    result, direct_calls, fallback_calls = _dispatch_recovery(monkeypatch, tmp_path, [failure])
+
+    assert result.failure_kind == "transport-error"
+    assert len(direct_calls) == 1
+    assert fallback_calls == []
+
+
+def test_direct_grok_continuation_timeout_does_not_enter_fallback(monkeypatch, tmp_path):
+    timeout = agents.AgentResult(
+        text="",
+        ok=False,
+        detail="timed out",
+        exit_code=124,
+        timed_out=True,
+        requested_model="grok-4.5",
+        failure_phase="inference",
+        failure_kind="timeout",
+    )
+    result, direct_calls, fallback_calls = _dispatch_recovery(
+        monkeypatch,
+        tmp_path,
+        [_invalid_final(), timeout],
+    )
+
+    assert result.failure_kind == "timeout"
+    assert len(direct_calls) == 2
+    assert fallback_calls == []
+
+
+def test_writable_grok_dispatch_does_not_enter_recovery(monkeypatch, tmp_path):
+    result, direct_calls, fallback_calls = _dispatch_recovery(
+        monkeypatch,
+        tmp_path,
+        [_invalid_final()],
+        read_only=False,
+    )
+
+    assert result.failure_kind == "malformed-final-output"
+    assert len(direct_calls) == 1
+    assert fallback_calls == []
+    assert result.attempts == ()
+
+
+def test_orchestrated_grok_dispatch_does_not_enter_recovery(monkeypatch, tmp_path):
+    result, direct_calls, fallback_calls = _dispatch_recovery(
+        monkeypatch,
+        tmp_path,
+        [_invalid_final()],
+        direct=False,
+    )
+
+    assert result.failure_kind == "malformed-final-output"
+    assert len(direct_calls) == 1
+    assert fallback_calls == []
+    assert result.attempts == ()


### PR DESCRIPTION
## Summary

- Continue one exact direct Grok read-only session after a typed malformed structured final, preserving the model, reasoning level, cwd, sandbox, and session identifier.
- Dispatch one explicitly configured Cursor-Grok ACP fallback after a second invalid final, with no roster search and no recursive recovery.
- Record every attempt, terminal result, selection, timing, transport, model, exit status, and failure provenance in worker artifacts.
- Keep startup, authentication, provider settings, network, timeout, permission, and nonzero failures outside the recovery policy.

## Evidence

- Baseline: receipt `20260717-080519-work-verify-b7df67`, 2,689 passed and 3 skipped.
- Core RED to GREEN chain: `b01a3a` / `53c924` to `223a7b`, `0d789d` to `021dbb`, `d1e603` to `2a1492`, `66d766` to `a21811`, and `eaf220` to `b4eeba`.
- Review sendbacks: operational failure exclusion `2f5f93` to `3bfbcd`, selected-seat provenance `0e2545` to `fb6f65`, snapshot persistence `cd55d3` to `876449`, and external diagnostic classification `92334c` to `57675e`.
- Final focused recovery gate: receipt `20260717-085528-work-verify-c5573e`.
- Final repository gate: receipt `20260717-085538-work-verify-36bc84`, 2,721 passed, 3 skipped, 81.82% coverage.
- Independent review completed two sendback passes. The final pass reported no Critical, Important, or Minor findings.

Closes #282
