### PR TITLE
feat(roster): validate live model inventory

### DIFF
--- a/docs/seat-catalog.md
+++ b/docs/seat-catalog.md
@@ -139,4 +139,4 @@ A seat that answers a smoke prompt is wired, not proven. The pattern:
 2. Bench it against an incumbent seat on a task with an objectively gradable answer (a planted bug with a known line and fix works well), and keep the receipts.
 3. Capture the outcome against the seat so `brigade outcome rank` learns something: a seat with no outcome history is a guess wearing a roster stanza.
 
-Retire stale IDs on sight. Harness model inventories drift: one roster carried a model ID its harness no longer listed (it worked only through fuzzy mapping), and a hosted model was retired upstream two days before a run tried to use it.
+Retire stale IDs on sight. Harness model inventories drift: one roster carried a model ID its harness no longer listed (it worked only through fuzzy mapping), and a hosted model was retired upstream two days before a run tried to use it. Run `brigade roster doctor` after changing direct Cursor, Grok, or Ollama seats. It reports `exact`, `fuzzy-resolved`, `missing`, or `unavailable`; the last three warn without rejecting the roster. A transient inventory failure is not evidence that a model disappeared.

--- a/docs/superpowers/plans/2026-07-17-live-model-inventory.md
+++ b/docs/superpowers/plans/2026-07-17-live-model-inventory.md
@@ -1,0 +1,44 @@
+# Live roster model inventory implementation plan
+
+### Task 1: Classify live harness inventory
+
+**Files:** `src/brigade/model_inventory.py`, `tests/test_model_inventory.py`
+
+- [x] Add failing tests for exact, narrow fuzzy, missing, and unavailable Cursor inventory results.
+- [x] Add failing tests for Grok's model-list shape and the same exact/fuzzy boundary.
+- [x] Add failing tests for exact, absent, retired cloud, and unavailable Ollama results.
+- [x] Run the focused module through Brigade and confirm RED.
+- [x] Implement the smallest typed inspector with per-run caching and no dependencies.
+- [x] Run the same Brigade command to GREEN.
+- [x] Commit the classifier.
+
+### Task 2: Surface inventory in roster doctor
+
+**Files:** `src/brigade/roster_cmd.py`, `tests/test_roster_cmd.py`
+
+- [x] Add failing doctor tests for exact, fuzzy-resolved, missing, retired, and unavailable seats.
+- [x] Run the focused roster-doctor tests through Brigade and confirm RED.
+- [x] Add one advisory model-inventory check per supported seat while preserving existing pin and ACP checks.
+- [x] Reuse inventory results across repeated seats in the same doctor run.
+- [x] Run the same Brigade command to GREEN.
+- [x] Commit the doctor integration.
+
+### Task 3: Document the operator contract
+
+**Files:** `docs/technical-guide.md`, `docs/seat-catalog.md`
+
+- [x] Document supported harnesses, the four states, the narrow fuzzy boundary, and warning-only behavior.
+- [x] Document the Ollama cloud retirement probe and the unavailable-inventory fallback.
+- [x] Commit the documentation.
+
+### Task 4: Verify, review, and publish
+
+**Files:** all changed files
+
+- [x] Run focused inventory and roster-doctor coverage through Brigade.
+- [x] Run `./scripts/verify` through Brigade.
+- [x] Review the exact diff against every #299 acceptance criterion.
+- [x] Request independent review and verify every sendback claim before changing code.
+- [x] Repeat focused and full gates after accepted fixes.
+- [ ] Push an exact-tree branch, open a ready PR closing #299, monitor CI and review threads, merge only when the head is clean, then run the merged-head gate.
+- [ ] Write and lint the #299 memory handoff.

--- a/docs/superpowers/specs/2026-07-17-live-model-inventory.md
+++ b/docs/superpowers/specs/2026-07-17-live-model-inventory.md
@@ -1,0 +1,9 @@
+# Live roster model inventory
+
+Issue #299 needs an advisory check at the point where operators already inspect a roster. Schema validation proves that a CLI accepts a model flag, but it cannot prove that the named model still exists. `brigade roster doctor` should query only harnesses with cheap read-only inventory commands and report one of four states: `exact`, `fuzzy-resolved`, `missing`, or `unavailable`.
+
+The first supported inventories are direct Cursor, direct Grok, and Ollama. Cursor uses `cursor-agent models`; Grok uses `grok models`. Exact IDs pass. A non-exact ID is `fuzzy-resolved` only when it shares the same normalized model family and version with a live ID after removing Cursor's `cursor-` namespace and recognized effort or `-fast` suffixes. This narrow rule catches aliases such as `grok-4.5-xhigh` without treating a different model version as compatible. Cursor ACP seats are excluded because the ACP server advertises different model IDs than the direct CLI.
+
+Ollama continues to use its existing local list guard. A listed local model is exact. A listed `:cloud` model also gets `ollama show <model>`, which is read-only and exposes retired remote models even when the local list still contains their manifest. A known retired or missing response is `missing`; network, authentication, timeout, command, and output-shape failures are `unavailable`.
+
+All non-exact states are warnings. Inventory failures never make roster loading fail and never turn transient provider state into a blocking doctor result. Brigade does not invoke a model, guess across versions, pull an Ollama model, or add a general provider router. Repeated seats share inventory results within one doctor run.

--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -295,6 +295,21 @@ unsupported adapter with a `model =` pin fails `brigade roster doctor` before an
 dispatches, so a bad pin never reaches a worker. The pinned model is recorded in each
 run's `roster.json` artifact.
 
+`brigade roster doctor` also checks live inventory for direct Cursor and Grok pins and
+for `ollama:<model>` refs. `exact` means the configured ID appears verbatim, or a
+parameterized Cursor ID has an advertised base ID that appears verbatim. Ollama also
+treats an omitted `:latest` tag as the listed `<model>:latest` ID.
+`fuzzy-resolved` means the exact ID is absent but the harness lists the same model family
+and version under a recognized namespace, effort, or fast suffix. `missing` means no such
+live ID exists. `unavailable` means the inventory command failed or its output could not
+be parsed. Every non-exact state is a warning because authentication, network access, and
+provider inventory can fail transiently.
+
+Ollama models must still be present in `ollama list`. For a listed `:cloud` model, doctor
+also runs the read-only `ollama show <model>` probe so a retired remote model is warned
+even when its cached manifest remains in the local list. Doctor never pulls or invokes a
+model while checking inventory.
+
 The classic split is a strong planner orchestrating a cheaper executor: the architect
 plans and synthesizes, the builder does the token-heavy work, and the run handoff is the
 record you judge.
@@ -402,6 +417,7 @@ role = "Inspect the change and report concrete defects."
 This path requires user-installed `acpx 0.12.0` and `cursor-agent acp`. Read-only calls use `--approve-reads`, reject interactive permission requests, disable terminal capability, and parse strict ACP protocol 1 NDJSON. Brigade never falls back from ACP to direct Cursor. Writable ACP calls require `brigade run --worktree`, so approval applies only inside a Brigade-created detached worktree.
 
 ACP model ids follow the ids advertised by `cursor-agent acp`, which can differ from direct Cursor aliases. Authenticated checks with `acpx 0.12.0` passed `composer-2.5` and `grok-4.5`. The direct alias `grok-4.5-xhigh` is rejected by ACP; the ACP server advertises `grok-4.5` with `modelId` `grok-4.5[effort=high,fast=true]`. Acpx has no separate reasoning flag, so Brigade does not translate the direct alias or infer an effort setting. Pin the exact model id for the selected transport.
+Direct Cursor inventory is not applied to ACP seats because the two transports advertise different IDs. ACP version and authentication checks remain separate roster-doctor checks.
 Run `brigade roster doctor` to validate roster syntax and check which CLIs are on `PATH`.
 To decide which model belongs in which seat with receipt-backed evidence instead of reputation, see [model ratings](model-ratings.md).
 When `--roster` is omitted, `brigade run` first reads `--cwd/.brigade/roster.toml`;

--- a/src/brigade/model_inventory.py
+++ b/src/brigade/model_inventory.py
@@ -1,0 +1,243 @@
+"""Advisory live model inventory checks for roster doctor."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Literal
+
+from . import proc
+
+InventoryState = Literal["exact", "fuzzy-resolved", "missing", "unavailable"]
+
+_LIST_COMMANDS = {
+    "cursor": ["cursor-agent", "models"],
+    "grok": ["grok", "models"],
+    "ollama": ["ollama", "list"],
+}
+_EFFORT_SUFFIX = re.compile(r"-(?:none|low|medium|high|xhigh|extra-high|max)$")
+_OLLAMA_OPERATIONAL_ERRORS = (
+    "authentication",
+    "connection",
+    "dial tcp",
+    "i/o timeout",
+    "network",
+    "no such host",
+    "temporary failure",
+    "timed out",
+    "timeout",
+    "tls",
+    "unauthorized",
+)
+
+
+@dataclass(frozen=True)
+class ModelInventoryResult:
+    state: InventoryState
+    requested: str
+    matches: tuple[str, ...]
+    detail: str
+
+
+@dataclass(frozen=True)
+class _HarnessInventory:
+    models: tuple[str, ...] = ()
+    error: str = ""
+
+
+class ModelInventoryInspector:
+    """Inspect supported harness inventories, caching results for one doctor run."""
+
+    def __init__(self) -> None:
+        self._inventories: dict[str, _HarnessInventory] = {}
+        self._results: dict[tuple[str, str], ModelInventoryResult] = {}
+
+    def inspect(self, cli_ref: str, requested: str) -> ModelInventoryResult | None:
+        key = (cli_ref, requested)
+        if key in self._results:
+            return self._results[key]
+        if cli_ref in _LIST_COMMANDS:
+            result = self._inspect_listed(cli_ref, requested)
+        elif cli_ref.startswith("ollama:"):
+            result = self._inspect_ollama(requested)
+        else:
+            return None
+        self._results[key] = result
+        return result
+
+    def _inspect_listed(self, cli_ref: str, requested: str) -> ModelInventoryResult:
+        inventory = self._inventory(cli_ref)
+        harness = "Cursor" if cli_ref == "cursor" else "Grok"
+        if inventory.error:
+            return ModelInventoryResult(
+                "unavailable",
+                requested,
+                (),
+                f"could not inspect live {harness} inventory: {inventory.error}",
+            )
+        advertised = _advertised_model_id(cli_ref, requested)
+        if advertised in inventory.models:
+            return ModelInventoryResult(
+                "exact",
+                requested,
+                (advertised,),
+                f"model {requested!r} exactly matches live {harness} inventory",
+            )
+        family = _model_family(advertised)
+        related = (
+            tuple(sorted(model for model in inventory.models if _model_family(model) == family))
+            if re.search(r"\d", family)
+            else ()
+        )
+        if related:
+            return ModelInventoryResult(
+                "fuzzy-resolved",
+                requested,
+                related,
+                f"model {requested!r} is not exact; related live {harness} IDs: {', '.join(related)}",
+            )
+        return ModelInventoryResult(
+            "missing",
+            requested,
+            (),
+            f"model {requested!r} is absent from live {harness} inventory",
+        )
+
+    def _inventory(self, cli_ref: str) -> _HarnessInventory:
+        cached = self._inventories.get(cli_ref)
+        if cached is not None:
+            return cached
+        result = proc.run(_LIST_COMMANDS[cli_ref], timeout=15.0)
+        if result.code != 0:
+            diagnostic = result.stderr.strip() or result.stdout.strip() or f"exit {result.code}"
+            inventory = _HarnessInventory(error=diagnostic[:160])
+        else:
+            recognized, models = _parse_model_list(cli_ref, f"{result.stdout}\n{result.stderr}")
+            if not recognized:
+                inventory = _HarnessInventory(error="command returned an unrecognized inventory shape")
+            elif not models and cli_ref != "ollama":
+                inventory = _HarnessInventory(error="command returned no model IDs")
+            else:
+                inventory = _HarnessInventory(models=models)
+        self._inventories[cli_ref] = inventory
+        return inventory
+
+    def _inspect_ollama(self, requested: str) -> ModelInventoryResult:
+        inventory = self._inventory("ollama")
+        if inventory.error:
+            return ModelInventoryResult(
+                "unavailable",
+                requested,
+                (),
+                f"could not inspect live Ollama inventory: {inventory.error}",
+            )
+        wanted = {requested} if ":" in requested else {requested, f"{requested}:latest"}
+        matches = tuple(sorted(wanted & set(inventory.models)))
+        if not matches:
+            return ModelInventoryResult(
+                "missing",
+                requested,
+                (),
+                f"ollama model {requested!r} is not listed locally; Brigade never auto-pulls it",
+            )
+        if not requested.endswith(":cloud"):
+            return ModelInventoryResult(
+                "exact",
+                requested,
+                matches,
+                f"model {requested!r} is pulled locally and exactly matches Ollama inventory",
+            )
+
+        result = proc.run(["ollama", "show", requested], timeout=15.0)
+        if result.code == 0:
+            return ModelInventoryResult(
+                "exact",
+                requested,
+                matches,
+                f"cloud model {requested!r} is listed locally and available from Ollama",
+            )
+        diagnostic = result.stderr.strip() or result.stdout.strip() or f"exit {result.code}"
+        state: InventoryState = "missing" if _ollama_model_is_missing(diagnostic) else "unavailable"
+        return ModelInventoryResult(state, requested, (), diagnostic[:200])
+
+
+def _parse_model_list(cli_ref: str, output: str) -> tuple[bool, tuple[str, ...]]:
+    lines = output.splitlines()
+    header_index = _inventory_header_index(cli_ref, lines)
+    if header_index is None:
+        return False, ()
+    models: set[str] = set()
+    for line in lines[header_index + 1 :]:
+        if cli_ref == "cursor":
+            if line.startswith("Tip:"):
+                break
+            match = re.match(r"^([a-z0-9][a-z0-9._:/\[\],=-]*)\s+-\s+.+$", line)
+        elif cli_ref == "grok":
+            match = re.match(r"^\s*\*\s+([^\s(]+)", line)
+        else:
+            if not line.strip():
+                continue
+            model = _parse_ollama_row(line)
+            if model is None:
+                return False, ()
+            models.add(model)
+            continue
+        if match is not None:
+            models.add(match.group(1))
+    return True, tuple(sorted(models))
+
+
+def _inventory_header_index(cli_ref: str, lines: list[str]) -> int | None:
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+        if cli_ref == "cursor" and stripped == "Available models":
+            return index
+        if cli_ref == "grok" and stripped == "Available models:":
+            return index
+        if cli_ref == "ollama" and stripped.startswith("NAME") and " ID " in f" {stripped} ":
+            return index
+    return None
+
+
+def _advertised_model_id(cli_ref: str, requested: str) -> str:
+    if cli_ref == "cursor" and requested.endswith("]") and "[" in requested:
+        return requested.split("[", 1)[0]
+    return requested
+
+
+def _parse_ollama_row(line: str) -> str | None:
+    columns = line.split()
+    if len(columns) < 5:
+        return None
+    model, model_id, size = columns[:3]
+    if re.fullmatch(r"[a-zA-Z0-9][a-zA-Z0-9._/-]*(?::[a-zA-Z0-9][a-zA-Z0-9._-]*)?", model) is None:
+        return None
+    if re.fullmatch(r"[0-9a-fA-F]{12}", model_id) is None:
+        return None
+    if size == "-":
+        return model
+    if re.fullmatch(r"\d+(?:\.\d+)?", size) is None:
+        return None
+    if columns[3].upper() not in {"B", "KB", "MB", "GB", "TB"}:
+        return None
+    return model
+
+
+def _ollama_model_is_missing(diagnostic: str) -> bool:
+    normalized = diagnostic.lower()
+    if any(marker in normalized for marker in _OLLAMA_OPERATIONAL_ERRORS):
+        return False
+    if "retired" in normalized or "does not exist" in normalized:
+        return True
+    if re.search(r"\bmodel\b.*\bnot found\b", normalized):
+        return True
+    return "pull model manifest" in normalized and ("404" in normalized or "not found" in normalized)
+
+
+def _model_family(model: str) -> str:
+    normalized = model.lower()
+    if normalized.startswith("cursor-"):
+        normalized = normalized[len("cursor-") :]
+    if normalized.endswith("-fast"):
+        normalized = normalized[: -len("-fast")]
+    return _EFFORT_SUFFIX.sub("", normalized)

--- a/src/brigade/roster_cmd.py
+++ b/src/brigade/roster_cmd.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from . import agents
 from . import doctor as doctor_mod
+from . import model_inventory
 from . import roster as roster_mod
 
 DEFAULT_ROSTER_REL = ".brigade/roster.toml"
@@ -148,6 +149,7 @@ def doctor(target: Path, *, roster_path: Path | None = None) -> int:
     else:
         checks.append((doctor_mod.WARN, "roster: allow_models", "not set; explicit model allow-list recommended"))
 
+    inventory_inspector = model_inventory.ModelInventoryInspector()
     for name, agent in loaded.agents.items():
         timeout = roster_mod.timeout_for(agent, loaded)
         if agent.cli is None:
@@ -161,15 +163,14 @@ def doctor(target: Path, *, roster_path: Path | None = None) -> int:
             )
             continue
         binary = agents.command_for(agent.cli)
-        if agents.detect(agent.cli):
+        detected = agents.detect(agent.cli)
+        if detected:
             checks.append((doctor_mod.OK, f"agent: {name}", f"{agent.cli} via {binary}; timeout={timeout:g}s"))
             if agent.cli.startswith("ollama:"):
                 ollama_model = agent.cli[len("ollama:") :]
-                present, missing_detail = agents.ollama_model_present(ollama_model)
-                if present:
-                    checks.append((doctor_mod.OK, f"agent: {name} ollama model", f"{ollama_model} pulled locally"))
-                else:
-                    checks.append((doctor_mod.WARN, f"agent: {name} ollama model", missing_detail))
+                inventory = inventory_inspector.inspect(agent.cli, ollama_model)
+                assert inventory is not None
+                checks.append(_model_inventory_check(name, inventory))
         else:
             detail = f"{agent.cli} needs `{binary}` on PATH; timeout={timeout:g}s"
             if agent.cli == "claude":
@@ -182,6 +183,10 @@ def doctor(target: Path, *, roster_path: Path | None = None) -> int:
                 )
             elif agents.supports_model_pinning(agent.cli):
                 checks.append((doctor_mod.OK, f"agent: {name} model", f"{agent.model} via {agent.cli}"))
+                if detected and agent.transport == "direct":
+                    inventory = inventory_inspector.inspect(agent.cli, agent.model)
+                    if inventory is not None:
+                        checks.append(_model_inventory_check(name, inventory))
             else:
                 checks.append(
                     (
@@ -223,3 +228,8 @@ def doctor(target: Path, *, roster_path: Path | None = None) -> int:
                     )
 
     return doctor_mod._report(checks)
+
+
+def _model_inventory_check(agent_name: str, result: model_inventory.ModelInventoryResult) -> doctor_mod.CheckResult:
+    status = doctor_mod.OK if result.state == "exact" else doctor_mod.WARN
+    return (status, f"agent: {agent_name} model inventory", f"{result.state}: {result.detail}")

--- a/tests/test_model_inventory.py
+++ b/tests/test_model_inventory.py
@@ -1,0 +1,303 @@
+from brigade import agents, model_inventory
+
+
+def _cursor_listing(*ids: str) -> str:
+    lines = ["Available models", ""]
+    lines.extend(f"{model_id} - Label for {model_id}" for model_id in ids)
+    return "\n".join(lines) + "\n"
+
+
+def _grok_listing(*ids: str) -> str:
+    lines = ["You are logged in with grok.com.", "", "Available models:"]
+    lines.extend(f"  * {model_id} (default)" for model_id in ids)
+    return "\n".join(lines) + "\n"
+
+
+def _ollama_listing(*ids: str) -> str:
+    lines = ["NAME                       ID              SIZE      MODIFIED"]
+    lines.extend(f"{model_id}  abcdef123456  2.0 GB  2 days ago" for model_id in ids)
+    return "\n".join(lines) + "\n"
+
+
+def test_cursor_inventory_exact_match(monkeypatch):
+    monkeypatch.setattr(
+        model_inventory.proc,
+        "run",
+        lambda argv, **kwargs: agents.proc.Result(0, _cursor_listing("composer-2.5"), ""),
+    )
+
+    result = model_inventory.ModelInventoryInspector().inspect("cursor", "composer-2.5")
+
+    assert result is not None
+    assert result.state == "exact"
+    assert result.matches == ("composer-2.5",)
+
+
+def test_cursor_inventory_narrow_fuzzy_match(monkeypatch):
+    monkeypatch.setattr(
+        model_inventory.proc,
+        "run",
+        lambda argv, **kwargs: agents.proc.Result(
+            0,
+            _cursor_listing("cursor-grok-4.5-low", "cursor-grok-4.5-high", "cursor-grok-4.6-high"),
+            "",
+        ),
+    )
+
+    result = model_inventory.ModelInventoryInspector().inspect("cursor", "grok-4.5-xhigh")
+
+    assert result is not None
+    assert result.state == "fuzzy-resolved"
+    assert result.matches == ("cursor-grok-4.5-high", "cursor-grok-4.5-low")
+
+
+def test_cursor_inventory_different_version_is_missing(monkeypatch):
+    monkeypatch.setattr(
+        model_inventory.proc,
+        "run",
+        lambda argv, **kwargs: agents.proc.Result(0, _cursor_listing("cursor-grok-4.6-high"), ""),
+    )
+
+    result = model_inventory.ModelInventoryInspector().inspect("cursor", "grok-4.5-xhigh")
+
+    assert result is not None
+    assert result.state == "missing"
+    assert result.matches == ()
+
+
+def test_cursor_inventory_requires_versioned_family_for_fuzzy_match(monkeypatch):
+    monkeypatch.setattr(
+        model_inventory.proc,
+        "run",
+        lambda argv, **kwargs: agents.proc.Result(0, _cursor_listing("cursor-auto-low"), ""),
+    )
+
+    result = model_inventory.ModelInventoryInspector().inspect("cursor", "auto-high")
+
+    assert result is not None
+    assert result.state == "missing"
+    assert result.matches == ()
+
+
+def test_cursor_inventory_command_failure_is_unavailable(monkeypatch):
+    monkeypatch.setattr(
+        model_inventory.proc,
+        "run",
+        lambda argv, **kwargs: agents.proc.Result(1, "", "not logged in"),
+    )
+
+    result = model_inventory.ModelInventoryInspector().inspect("cursor", "composer-2.5")
+
+    assert result is not None
+    assert result.state == "unavailable"
+    assert "not logged in" in result.detail
+
+
+def test_cursor_inventory_unrecognized_output_is_unavailable(monkeypatch):
+    monkeypatch.setattr(
+        model_inventory.proc,
+        "run",
+        lambda argv, **kwargs: agents.proc.Result(0, "model output changed\n", ""),
+    )
+
+    result = model_inventory.ModelInventoryInspector().inspect("cursor", "composer-2.5")
+
+    assert result is not None
+    assert result.state == "unavailable"
+    assert "unrecognized inventory shape" in result.detail
+
+
+def test_cursor_inventory_error_shaped_success_is_unavailable(monkeypatch):
+    monkeypatch.setattr(
+        model_inventory.proc,
+        "run",
+        lambda argv, **kwargs: agents.proc.Result(0, "Warning - authentication required\n", ""),
+    )
+
+    result = model_inventory.ModelInventoryInspector().inspect("cursor", "composer-2.5")
+
+    assert result is not None
+    assert result.state == "unavailable"
+
+
+def test_cursor_inventory_accepts_parameterized_exact_model(monkeypatch):
+    base_model = "claude-opus-4-8-thinking-high"
+    monkeypatch.setattr(
+        model_inventory.proc,
+        "run",
+        lambda argv, **kwargs: agents.proc.Result(0, _cursor_listing(base_model), ""),
+    )
+
+    result = model_inventory.ModelInventoryInspector().inspect(
+        "cursor",
+        f"{base_model}[context=1m,effort=high,fast=false]",
+    )
+
+    assert result is not None
+    assert result.state == "exact"
+    assert result.matches == (base_model,)
+
+
+def test_cursor_inventory_is_loaded_once_for_repeated_seats(monkeypatch):
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append(argv)
+        return agents.proc.Result(0, _cursor_listing("composer-2.5", "gpt-5.5-high"), "")
+
+    monkeypatch.setattr(model_inventory.proc, "run", fake_run)
+    inspector = model_inventory.ModelInventoryInspector()
+
+    assert inspector.inspect("cursor", "composer-2.5").state == "exact"
+    assert inspector.inspect("cursor", "gpt-5.5-high").state == "exact"
+    assert calls == [["cursor-agent", "models"]]
+
+
+def test_grok_inventory_parses_exact_and_fuzzy_models(monkeypatch):
+    monkeypatch.setattr(
+        model_inventory.proc,
+        "run",
+        lambda argv, **kwargs: agents.proc.Result(0, _grok_listing("grok-4.5"), ""),
+    )
+    inspector = model_inventory.ModelInventoryInspector()
+
+    assert inspector.inspect("grok", "grok-4.5").state == "exact"
+    fuzzy = inspector.inspect("grok", "grok-4.5-xhigh")
+    assert fuzzy.state == "fuzzy-resolved"
+    assert fuzzy.matches == ("grok-4.5",)
+
+
+def test_ollama_local_model_exact_match(monkeypatch):
+    monkeypatch.setattr(
+        model_inventory.proc,
+        "run",
+        lambda argv, **kwargs: agents.proc.Result(0, _ollama_listing("llama3.2:3b"), ""),
+    )
+
+    result = model_inventory.ModelInventoryInspector().inspect("ollama:llama3.2:3b", "llama3.2:3b")
+
+    assert result is not None
+    assert result.state == "exact"
+    assert "pulled locally" in result.detail
+
+
+def test_ollama_absent_model_is_missing(monkeypatch):
+    monkeypatch.setattr(
+        model_inventory.proc,
+        "run",
+        lambda argv, **kwargs: agents.proc.Result(0, _ollama_listing("other:cloud"), ""),
+    )
+
+    result = model_inventory.ModelInventoryInspector().inspect("ollama:missing:cloud", "missing:cloud")
+
+    assert result is not None
+    assert result.state == "missing"
+
+
+def test_ollama_list_failure_is_unavailable(monkeypatch):
+    monkeypatch.setattr(
+        model_inventory.proc,
+        "run",
+        lambda argv, **kwargs: agents.proc.Result(1, "", "connection refused"),
+    )
+
+    result = model_inventory.ModelInventoryInspector().inspect("ollama:llama3.2:3b", "llama3.2:3b")
+
+    assert result is not None
+    assert result.state == "unavailable"
+
+
+def test_ollama_malformed_successful_list_is_unavailable(monkeypatch):
+    monkeypatch.setattr(
+        model_inventory.proc,
+        "run",
+        lambda argv, **kwargs: agents.proc.Result(0, "output format changed\n", ""),
+    )
+
+    result = model_inventory.ModelInventoryInspector().inspect("ollama:llama3.2:3b", "llama3.2:3b")
+
+    assert result is not None
+    assert result.state == "unavailable"
+
+
+def test_ollama_recognized_header_with_malformed_body_is_unavailable(monkeypatch):
+    monkeypatch.setattr(
+        model_inventory.proc,
+        "run",
+        lambda argv, **kwargs: agents.proc.Result(
+            0,
+            "NAME ID SIZE MODIFIED\nformat changed\n",
+            "",
+        ),
+    )
+
+    result = model_inventory.ModelInventoryInspector().inspect("ollama:llama3.2:3b", "llama3.2:3b")
+
+    assert result is not None
+    assert result.state == "unavailable"
+
+
+def test_ollama_warning_shaped_body_is_unavailable(monkeypatch):
+    monkeypatch.setattr(
+        model_inventory.proc,
+        "run",
+        lambda argv, **kwargs: agents.proc.Result(
+            0,
+            "NAME ID SIZE MODIFIED\nwarning - - not inventory\n",
+            "",
+        ),
+    )
+
+    result = model_inventory.ModelInventoryInspector().inspect("ollama:llama3.2:3b", "llama3.2:3b")
+
+    assert result is not None
+    assert result.state == "unavailable"
+
+
+def test_ollama_retired_cloud_model_is_missing(monkeypatch):
+    def fake_run(argv, **kwargs):
+        if argv == ["ollama", "list"]:
+            return agents.proc.Result(0, _ollama_listing("glm-5:cloud"), "")
+        return agents.proc.Result(1, "", "Error: glm-5 was retired at 2026-07-15")
+
+    monkeypatch.setattr(model_inventory.proc, "run", fake_run)
+
+    result = model_inventory.ModelInventoryInspector().inspect("ollama:glm-5:cloud", "glm-5:cloud")
+
+    assert result is not None
+    assert result.state == "missing"
+    assert "retired" in result.detail
+
+
+def test_ollama_cloud_probe_network_failure_is_unavailable(monkeypatch):
+    def fake_run(argv, **kwargs):
+        if argv == ["ollama", "list"]:
+            return agents.proc.Result(0, _ollama_listing("kimi-k2.7-code:cloud"), "")
+        return agents.proc.Result(1, "", "pull model manifest: Get registry: dial tcp: connection refused")
+
+    monkeypatch.setattr(model_inventory.proc, "run", fake_run)
+
+    result = model_inventory.ModelInventoryInspector().inspect("ollama:kimi-k2.7-code:cloud", "kimi-k2.7-code:cloud")
+
+    assert result is not None
+    assert result.state == "unavailable"
+    assert "dial tcp" in result.detail
+
+
+def test_ollama_inventory_is_loaded_once_for_different_seats(monkeypatch):
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append(argv)
+        return agents.proc.Result(0, _ollama_listing("llama3.2:3b", "qwen3-embedding:8b"), "")
+
+    monkeypatch.setattr(model_inventory.proc, "run", fake_run)
+    inspector = model_inventory.ModelInventoryInspector()
+
+    assert inspector.inspect("ollama:llama3.2:3b", "llama3.2:3b").state == "exact"
+    assert inspector.inspect("ollama:qwen3-embedding:8b", "qwen3-embedding:8b").state == "exact"
+    assert calls == [["ollama", "list"]]
+
+
+def test_unsupported_harness_has_no_live_inventory_check():
+    assert model_inventory.ModelInventoryInspector().inspect("codex", "gpt-5.5") is None

--- a/tests/test_roster_cmd.py
+++ b/tests/test_roster_cmd.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from brigade import agents
 from brigade import cli
+from brigade import model_inventory
 from brigade import roster
 from brigade import roster_cmd
 
@@ -139,19 +140,34 @@ def test_roster_doctor_warns_when_ollama_model_not_pulled(monkeypatch, tmp_targe
     roster_cmd.init(tmp_target)
     monkeypatch.setattr(agents.proc, "which", lambda cmd: "/x/" + cmd)
     monkeypatch.setattr(
-        agents, "ollama_model_present", lambda model: (False, f"ollama model {model!r} is not pulled locally")
+        model_inventory.proc,
+        "run",
+        lambda argv, **kwargs: agents.proc.Result(
+            0,
+            "NAME ID SIZE MODIFIED\nother:latest abcdef123456 2.0 GB 2 days ago\n",
+            "",
+        ),
     )
     rc = roster_cmd.doctor(tmp_target)
     out = capsys.readouterr().out
     assert rc == 0
     assert "[warn]" in out
-    assert "not pulled locally" in out
+    assert "not listed locally" in out
+    assert "never auto-pulls" in out
 
 
 def test_roster_doctor_ok_when_ollama_model_pulled(monkeypatch, tmp_target, capsys):
     roster_cmd.init(tmp_target)
     monkeypatch.setattr(agents.proc, "which", lambda cmd: "/x/" + cmd)
-    monkeypatch.setattr(agents, "ollama_model_present", lambda model: (True, ""))
+    monkeypatch.setattr(
+        model_inventory.proc,
+        "run",
+        lambda argv, **kwargs: agents.proc.Result(
+            0,
+            f"NAME ID SIZE MODIFIED\n{roster_cmd.DEFAULT_OLLAMA_MODEL} abcdef123456 2.0 GB 2 days ago\n",
+            "",
+        ),
+    )
     rc = roster_cmd.doctor(tmp_target)
     out = capsys.readouterr().out
     assert rc == 0
@@ -206,6 +222,166 @@ def test_roster_doctor_ok_for_supported_model_pin(monkeypatch, tmp_target, capsy
     assert "grok-composer-2.5-fast via grok" in out
 
 
+def _write_grok_inventory_roster(tmp_target, model: str) -> None:
+    _write_roster(
+        tmp_target,
+        f'orchestrator = "chef"\n[agents.chef]\ncli = "grok"\nmodel = "{model}"\nrole = "plan"\n',
+    )
+
+
+def test_roster_doctor_reports_exact_live_model_inventory(monkeypatch, tmp_target, capsys):
+    _write_grok_inventory_roster(tmp_target, "grok-4.5")
+    monkeypatch.setattr(agents.proc, "which", lambda cmd: "/x/" + cmd)
+    monkeypatch.setattr(
+        model_inventory.proc,
+        "run",
+        lambda argv, **kwargs: agents.proc.Result(0, "Available models:\n  * grok-4.5 (default)\n", ""),
+    )
+
+    rc = roster_cmd.doctor(tmp_target)
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "agent: chef model inventory" in out
+    assert "exact:" in out
+
+
+def test_roster_doctor_warns_on_fuzzy_resolved_model(monkeypatch, tmp_target, capsys):
+    _write_grok_inventory_roster(tmp_target, "grok-4.5-xhigh")
+    monkeypatch.setattr(agents.proc, "which", lambda cmd: "/x/" + cmd)
+    monkeypatch.setattr(
+        model_inventory.proc,
+        "run",
+        lambda argv, **kwargs: agents.proc.Result(0, "Available models:\n  * grok-4.5 (default)\n", ""),
+    )
+
+    rc = roster_cmd.doctor(tmp_target)
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "[warn] agent: chef model inventory" in out
+    assert "fuzzy-resolved:" in out
+    assert "grok-4.5" in out
+
+
+def test_roster_doctor_warns_on_missing_live_model(monkeypatch, tmp_target, capsys):
+    _write_grok_inventory_roster(tmp_target, "grok-4.6")
+    monkeypatch.setattr(agents.proc, "which", lambda cmd: "/x/" + cmd)
+    monkeypatch.setattr(
+        model_inventory.proc,
+        "run",
+        lambda argv, **kwargs: agents.proc.Result(0, "Available models:\n  * grok-4.5 (default)\n", ""),
+    )
+
+    rc = roster_cmd.doctor(tmp_target)
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "[warn] agent: chef model inventory" in out
+    assert "missing:" in out
+    assert "absent" in out
+
+
+def test_roster_doctor_warns_when_live_inventory_is_unavailable(monkeypatch, tmp_target, capsys):
+    _write_grok_inventory_roster(tmp_target, "grok-4.5")
+    monkeypatch.setattr(agents.proc, "which", lambda cmd: "/x/" + cmd)
+    monkeypatch.setattr(
+        model_inventory.proc,
+        "run",
+        lambda argv, **kwargs: agents.proc.Result(1, "", "inventory network error"),
+    )
+
+    rc = roster_cmd.doctor(tmp_target)
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "[warn] agent: chef model inventory" in out
+    assert "unavailable:" in out
+    assert "inventory network error" in out
+
+
+def test_roster_doctor_warns_on_retired_ollama_cloud_model(monkeypatch, tmp_target, capsys):
+    _write_roster(
+        tmp_target,
+        'orchestrator = "chef"\n[agents.chef]\ncli = "ollama:glm-5:cloud"\nrole = "plan"\n',
+    )
+    monkeypatch.setattr(agents.proc, "which", lambda cmd: "/x/" + cmd)
+
+    def fake_run(argv, **kwargs):
+        if argv == ["ollama", "list"]:
+            return agents.proc.Result(
+                0,
+                "NAME ID SIZE MODIFIED\nglm-5:cloud abcdef123456 - 2 days ago\n",
+                "",
+            )
+        assert argv == ["ollama", "show", "glm-5:cloud"]
+        return agents.proc.Result(1, "", "Error: glm-5 was retired at 2026-07-15")
+
+    monkeypatch.setattr(model_inventory.proc, "run", fake_run)
+
+    rc = roster_cmd.doctor(tmp_target)
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "[warn] agent: chef model inventory" in out
+    assert "missing:" in out
+    assert "retired" in out
+
+
+def test_roster_doctor_reuses_inventory_for_repeated_harness_seats(monkeypatch, tmp_target, capsys):
+    _write_roster(
+        tmp_target,
+        'orchestrator = "chef"\n'
+        '[agents.chef]\ncli = "cursor"\nmodel = "composer-2.5"\nrole = "plan"\n'
+        '[agents.reviewer]\ncli = "cursor"\nmodel = "gpt-5.5-high"\nrole = "review"\n',
+    )
+    monkeypatch.setattr(agents.proc, "which", lambda cmd: "/x/" + cmd)
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append(argv)
+        return agents.proc.Result(
+            0,
+            "Available models\n\ncomposer-2.5 - Composer 2.5\ngpt-5.5-high - GPT-5.5 High\n",
+            "",
+        )
+
+    monkeypatch.setattr(model_inventory.proc, "run", fake_run)
+
+    assert roster_cmd.doctor(tmp_target) == 0
+    assert capsys.readouterr().out.count("model inventory") == 2
+    assert calls == [["cursor-agent", "models"]]
+
+
+def test_roster_doctor_does_not_apply_direct_cursor_inventory_to_acpx_seat(monkeypatch, tmp_target, capsys):
+    from brigade import acpx_adapter
+
+    _write_roster(
+        tmp_target,
+        'orchestrator = "chef"\n'
+        '[agents.chef]\ncli = "codex"\nrole = "plan"\n'
+        '[agents.reviewer]\ncli = "cursor"\nmodel = "grok-4.5"\nrole = "review"\n'
+        'transport = "acpx"\ntransport_version = "0.12.0"\n',
+    )
+    monkeypatch.setattr(agents.proc, "which", lambda cmd: "/x/" + cmd)
+    monkeypatch.setattr(acpx_adapter, "installed_version", lambda: ("0.12.0", ""))
+    monkeypatch.setattr(
+        acpx_adapter,
+        "cursor_auth_status",
+        lambda: acpx_adapter.CursorAuthStatus("authenticated", "authenticated", "", "", 0),
+    )
+    monkeypatch.setattr(
+        model_inventory.proc,
+        "run",
+        lambda argv, **kwargs: (_ for _ in ()).throw(AssertionError(f"unexpected direct inventory: {argv}")),
+    )
+
+    assert roster_cmd.doctor(tmp_target) == 0
+    out = capsys.readouterr().out
+    assert "agent: reviewer model inventory" not in out
+    assert "agent: reviewer acpx" in out
+
+
 def test_roster_doctor_fails_pin_on_unsupported_cli(monkeypatch, tmp_target, capsys):
     _write_roster(
         tmp_target,
@@ -225,7 +401,15 @@ def test_roster_doctor_fails_pin_on_ollama_ref(monkeypatch, tmp_target, capsys):
         'orchestrator = "chef"\n[agents.chef]\ncli = "ollama:llama3.3"\nmodel = "mistral"\nrole = "plan"\n',
     )
     monkeypatch.setattr(agents.proc, "which", lambda cmd: "/x/" + cmd)
-    monkeypatch.setattr(agents, "ollama_model_present", lambda model: (True, ""))
+    monkeypatch.setattr(
+        model_inventory.proc,
+        "run",
+        lambda argv, **kwargs: agents.proc.Result(
+            0,
+            "NAME ID SIZE MODIFIED\nllama3.3 abcdef123456 43 GB 2 days ago\n",
+            "",
+        ),
+    )
     rc = roster_cmd.doctor(tmp_target)
     out = capsys.readouterr().out
     assert rc == 1


### PR DESCRIPTION
Closes #299.

## What changed

- `brigade roster doctor` now queries live model inventories for direct Cursor and Grok seats, plus Ollama refs.
- Results report `exact`, `fuzzy-resolved`, `missing`, or `unavailable`. Every non-exact result is advisory, so an inventory outage does not reject a roster.
- Fuzzy matching is limited to versioned model families and known namespace, effort, and fast suffixes.
- Ollama inventory parsing validates the current 12-hex ID format. Listed cloud models receive a read-only `ollama show` probe so retired models are reported even when their local manifest remains cached.
- Direct Cursor inventory does not apply to ACP seats because ACP advertises different model IDs.

## Verification

- Classifier RED: `7385fd`; GREEN: `9f8be3`
- Doctor integration RED: `be44a8`; GREEN: `d014bb`
- Direct-harness scope RED: `fcff42`; GREEN: `1fb8a0`
- Versioned fuzzy boundary RED: `be0c08`; GREEN: `4c2888`
- Malformed Ollama body RED: `20260717-094935-work-verify-8243ef`; focused GREEN: `20260717-095027-work-verify-614660`
- Ollama ID-shape RED: `20260717-095244-work-verify-be00cb`; focused GREEN: `20260717-095308-work-verify-50d18c`
- Independent review completed after three sendback rounds with no remaining findings at `d40cec0`.
- Canonical Brigade gate at exact local head `5c9703d`: `20260717-100103-work-verify-20c28b`, 2,748 passed, 3 skipped, 81.85% coverage.
