### PR TITLE
fix(run): scrub resolved seat env secrets

### DIFF
--- a/docs/seat-catalog.md
+++ b/docs/seat-catalog.md
@@ -115,7 +115,7 @@ role = "Open-weight worker on a coding-plan quota; relief for orchestrator-tier 
 env = { ANTHROPIC_BASE_URL = "https://api.moonshot.ai/anthropic", ANTHROPIC_AUTH_TOKEN_REF = "KIMI_API_KEY", CLAUDE_CONFIG_DIR = "/home/operator/.claude-lanes" }
 ```
 
-Overrides apply to the spawned CLI process only, `run.json` records the override names and endpoint host (never values), and a missing referenced variable fails the worker before dispatch. Direct CLI seats only: acpx and codex-cloud seats manage their own environment.
+Overrides apply to the spawned CLI process only, `run.json` records the override names and endpoint host (never values), and a missing referenced variable fails the worker before dispatch. If the CLI echoes any resolved override value, Brigade replaces the exact value with its target name in brackets before worker text, detail, stdout, or stderr can be stored. Direct CLI seats only: acpx and codex-cloud seats manage their own environment.
 
 The isolated `CLAUDE_CONFIG_DIR` is load-bearing: with the default config directory, the `claude` CLI prefers its subscription OAuth over env auth, the upstream returns 401, and the CLI retries silently, which presents as an indefinite hang.
 

--- a/docs/superpowers/plans/2026-07-17-env-override-log-scrubbing.md
+++ b/docs/superpowers/plans/2026-07-17-env-override-log-scrubbing.md
@@ -1,0 +1,41 @@
+# Environment override log scrubbing implementation plan
+
+### Task 1: Scrub resolved values at direct-agent output
+
+**Files:** `src/brigade/agents.py`, `tests/test_agents.py`
+
+- [x] Add failing tests for successful stdout, failed stderr and detail, overlapping override values, and unrelated parent environment values.
+- [x] Run the focused agent tests through Brigade and confirm RED.
+- [x] Add exact nonempty replacement after process execution and structured-output parsing, before any `AgentResult` return.
+- [x] Run the same Brigade command to GREEN.
+- [x] Commit the direct-agent scrubber.
+
+### Task 2: Prove persisted worker logs are safe
+
+**Files:** `tests/test_run_transport_env.py`
+
+- [x] Add a failing dispatch and persistence test whose process stdout and stderr echo a resolved reference value.
+- [x] Assert the worker text, detail, stdout, stderr, and stored log files contain `[OVERRIDE_NAME]` and not the value.
+- [x] Run the focused transport test through Brigade to GREEN.
+- [x] Commit the persistence coverage.
+
+### Task 3: Revalidate environment tables on resume
+
+**Files:** `src/brigade/run_resume.py`, `tests/test_run_resume.py`
+
+- [x] Add failing snapshot tests for an inline secret and a colliding target.
+- [x] Run the focused resume tests through Brigade and confirm RED.
+- [x] Reuse roster `_as_env` while rebuilding snapshot agents and report invalid snapshots without dispatch.
+- [x] Run the same Brigade command to GREEN.
+- [x] Commit resume validation.
+
+### Task 4: Document and publish
+
+**Files:** `docs/technical-guide.md`, all changed files
+
+- [x] Document the exact-value scrub boundary and snapshot revalidation.
+- [x] Run all focused coverage and the full pytest suite through Brigade.
+- [x] Review the exact diff against #310 and request independent review.
+- [x] Verify each sendback claim before changing code, then repeat affected gates.
+- [ ] Publish an exact-tree PR closing #310, monitor CI and review threads, and merge only at a clean expected head.
+- [ ] Run the merged-head gate and write a linted memory handoff.

--- a/docs/superpowers/specs/2026-07-17-env-override-log-scrubbing.md
+++ b/docs/superpowers/specs/2026-07-17-env-override-log-scrubbing.md
@@ -1,0 +1,9 @@
+# Environment override log scrubbing
+
+Issue #310 closes two follow-ups from the per-seat environment override work. A direct CLI can echo an injected override value in stdout or stderr, and those streams are later stored under the run directory. Resume also rebuilds agents from `roster.json` without applying the environment-table validation used by the original roster loader.
+
+After a seat environment table resolves successfully, `agents.run_agent` will replace every exact nonempty resolved override value in output-derived strings with the resolved target name in brackets, such as `[ANTHROPIC_AUTH_TOKEN]`. Scrubbing happens after the process returns and after structured Grok JSON is parsed, so replacement cannot corrupt parsing. The returned text, detail, stdout, and stderr are scrubbed before worker, attempt, synthesis, or research code can persist them. Longer values are replaced first, and equal values use a deterministic target name. Brigade does not scan the parent environment, apply heuristic secret detection to output, or change the child environment passed to the CLI.
+
+Snapshot resume will call the roster loader's `_as_env` validator for each stored agent environment table. Invalid variable names, inline secret names or values, malformed references, and target collisions are rejected before a resumed synthesis can dispatch. Existing valid snapshots keep the same environment mapping.
+
+This change adds no dependency, does not rewrite historical logs, and does not turn log scrubbing into a general content-guard pass. Exact-value replacement is bounded to values Brigade resolved for the current seat dispatch.

--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -376,6 +376,14 @@ contains one assignment with the full task text, `worker-results.json` records
 the selected worker output, `final.txt` is that worker's text, and
 `synthesis.json` is marked with `mode: direct-worker`.
 
+Direct CLI seats may declare per-seat environment overrides in their roster entry. Values
+whose keys end in `_REF` are read from the named parent environment variable and injected
+under the key without `_REF`. After execution, Brigade replaces every exact nonempty
+resolved override value in returned text, detail, stdout, and stderr with `[TARGET_NAME]`
+before run logs or receipts are written. This bounded replacement covers only values
+resolved for that seat; it is not a heuristic scan of the parent environment or historical
+logs. Resume revalidates stored environment tables before any synthesis dispatch.
+
 Detached runs require artifacts, so `--detach` cannot be combined with `--no-artifacts`.
 It also refuses `--dry-run` and `--inspect`, because the parent process exits before it can print a plan or inspect final artifacts.
 Use `brigade runs watch <run>` to follow a detached run from its artifacts:

--- a/src/brigade/agents.py
+++ b/src/brigade/agents.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, List
@@ -291,7 +292,7 @@ def _parse_grok_final_output(stdout: str) -> _GrokFinal:
         detail = f"{base_error} ({'; '.join(diagnostic_parts)})" if diagnostic_parts else base_error
         return _GrokFinal(
             text=fallback,
-            error=detail[:200],
+            error=detail,
             diagnostic=(structured_output_error if isinstance(structured_output_error, str) else ""),
             session_id=payload.get("sessionId") if isinstance(payload.get("sessionId"), str) else None,
             request_id=payload.get("requestId") if isinstance(payload.get("requestId"), str) else None,
@@ -517,6 +518,22 @@ def resolve_env_overrides(env: dict[str, str]) -> tuple[dict[str, str] | None, s
     return resolved, ""
 
 
+def _scrub_env_override_values(text: str, overrides: dict[str, str] | None) -> str:
+    """Replace exact resolved override values with stable target-name labels."""
+
+    if not text or not overrides:
+        return text
+    replacements: dict[str, str] = {}
+    for target, value in sorted(overrides.items()):
+        if value:
+            replacements.setdefault(value, f"[{target}]")
+    if not replacements:
+        return text
+    values = sorted(replacements, key=lambda value: (-len(value), value))
+    pattern = re.compile("|".join(re.escape(value) for value in values))
+    return pattern.sub(lambda match: replacements[match.group(0)], text)
+
+
 def run_agent(
     cli_ref: str,
     prompt: str,
@@ -569,6 +586,7 @@ def run_agent(
                 return AgentResult(text="", ok=False, detail=missing_detail)
 
     child_env: dict[str, str] | None = None
+    resolved_overrides: dict[str, str] | None = None
     if env is not None:
         overrides, env_error = resolve_env_overrides(env)
         if overrides is None:
@@ -580,6 +598,7 @@ def run_agent(
                 failure_kind="env-ref-missing",
                 requested_model=model,
             )
+        resolved_overrides = overrides
         child_env = dict(os.environ)
         child_env.update(overrides)
 
@@ -636,14 +655,22 @@ def run_agent(
         grok_session_id = grok_final.session_id
         grok_request_id = grok_final.request_id
         grok_stop_reason = grok_final.stop_reason
+    safe_text = _scrub_env_override_values(text, resolved_overrides)
+    safe_stdout = _scrub_env_override_values(result.stdout, resolved_overrides)
+    safe_stderr = _scrub_env_override_values(result.stderr, resolved_overrides)
+    safe_structured_error = _scrub_env_override_values(structured_error, resolved_overrides)[:200]
+
+    def scrub_detail(detail: str) -> str:
+        return _scrub_env_override_values(detail, resolved_overrides)
+
     if result.code != 0:
-        detail = result.stderr.strip() or f"exit {result.code}"
+        detail = safe_stderr.strip() or f"exit {result.code}"
         return AgentResult(
-            text=text,
+            text=safe_text,
             ok=False,
             detail=detail[:200],
-            stdout=result.stdout,
-            stderr=result.stderr,
+            stdout=safe_stdout,
+            stderr=safe_stderr,
             exit_code=result.code,
             timed_out=result.code == 124,
             requested_model=model,
@@ -654,16 +681,16 @@ def run_agent(
         )
     if structured_error:
         for diagnostic in (text, structured_diagnostic, result.stderr):
-            output_failure = validate_final_output(diagnostic)
+            output_failure = validate_final_output(diagnostic, detail_transform=scrub_detail)
             if output_failure is not None and output_failure.kind in _NONRECOVERABLE_GROK_OUTPUT_FAILURES:
                 return AgentResult(
-                    text=text,
+                    text=safe_text,
                     ok=False,
                     detail=output_failure.detail,
                     failure_phase="output-validation",
                     failure_kind=output_failure.kind,
-                    stdout=result.stdout,
-                    stderr=result.stderr,
+                    stdout=safe_stdout,
+                    stderr=safe_stderr,
                     exit_code=result.code,
                     requested_model=model,
                     reasoning=reasoning,
@@ -672,13 +699,13 @@ def run_agent(
                     request_id=grok_request_id,
                 )
         return AgentResult(
-            text=text,
+            text=safe_text,
             ok=False,
-            detail=structured_error,
+            detail=safe_structured_error,
             failure_phase="output-validation",
             failure_kind="malformed-final-output",
-            stdout=result.stdout,
-            stderr=result.stderr,
+            stdout=safe_stdout,
+            stderr=safe_stderr,
             exit_code=result.code,
             requested_model=model,
             reasoning=reasoning,
@@ -696,8 +723,8 @@ def run_agent(
             text="",
             ok=False,
             detail=detail,
-            stdout=result.stdout,
-            stderr=result.stderr,
+            stdout=safe_stdout,
+            stderr=safe_stderr,
             exit_code=result.code,
             requested_model=model,
             reasoning=reasoning,
@@ -705,16 +732,16 @@ def run_agent(
             session_id=grok_session_id,
             request_id=grok_request_id,
         )
-    output_failure = validate_final_output(text)
+    output_failure = validate_final_output(text, detail_transform=scrub_detail)
     if output_failure is not None:
         return AgentResult(
-            text=text,
+            text=safe_text,
             ok=False,
             detail=output_failure.detail,
             failure_phase="output-validation",
             failure_kind=output_failure.kind,
-            stdout=result.stdout,
-            stderr=result.stderr,
+            stdout=safe_stdout,
+            stderr=safe_stderr,
             exit_code=result.code,
             requested_model=model,
             reasoning=reasoning,
@@ -723,10 +750,10 @@ def run_agent(
             request_id=grok_request_id,
         )
     return AgentResult(
-        text=text,
+        text=safe_text,
         ok=True,
-        stdout=result.stdout,
-        stderr=result.stderr,
+        stdout=safe_stdout,
+        stderr=safe_stderr,
         exit_code=result.code,
         requested_model=model,
         reasoning=reasoning,

--- a/src/brigade/result_integrity.py
+++ b/src/brigade/result_integrity.py
@@ -231,9 +231,7 @@ def validate_final_output(
                 diagnostic = stripped[operational_error.start() :].strip()
                 return OutputFailure(
                     kind,
-                    safe_detail(
-                        f"provider returned an operational error instead of a final result: {diagnostic}"
-                    ),
+                    safe_detail(f"provider returned an operational error instead of a final result: {diagnostic}"),
                 )
     if _tool_only(stripped):
         return OutputFailure(

--- a/src/brigade/result_integrity.py
+++ b/src/brigade/result_integrity.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import dataclass
+from typing import Callable
 
 
 @dataclass(frozen=True)
@@ -196,11 +197,21 @@ def _progress_only(text: str) -> bool:
     return explicit_progress
 
 
-def validate_final_output(text: str) -> OutputFailure | None:
+def validate_final_output(
+    text: str,
+    *,
+    detail_transform: Callable[[str], str] | None = None,
+) -> OutputFailure | None:
     """Return a typed failure only for deterministic non-final output shapes."""
+
+    def safe_detail(detail: str) -> str:
+        if detail_transform is not None:
+            detail = detail_transform(detail)
+        return detail[:200]
+
     stripped = text.strip()
     if not stripped:
-        return OutputFailure("empty-output", "provider returned no final result")
+        return OutputFailure("empty-output", safe_detail("provider returned no final result"))
     if "```" not in stripped:
         provider_error = _PROVIDER_ERROR.search(stripped)
         if provider_error is not None:
@@ -209,7 +220,7 @@ def validate_final_output(text: str) -> OutputFailure | None:
                 diagnostic = stripped[provider_error.start() :].strip()
                 return OutputFailure(
                     "provider-error",
-                    f"provider returned an error instead of a final result: {diagnostic}"[:200],
+                    safe_detail(f"provider returned an error instead of a final result: {diagnostic}"),
                 )
         for kind, pattern in _OPERATIONAL_ERRORS:
             operational_error = pattern.search(stripped)
@@ -220,16 +231,18 @@ def validate_final_output(text: str) -> OutputFailure | None:
                 diagnostic = stripped[operational_error.start() :].strip()
                 return OutputFailure(
                     kind,
-                    f"provider returned an operational error instead of a final result: {diagnostic}"[:200],
+                    safe_detail(
+                        f"provider returned an operational error instead of a final result: {diagnostic}"
+                    ),
                 )
     if _tool_only(stripped):
         return OutputFailure(
             "tool-only-output",
-            "provider returned tool-call data without a final result",
+            safe_detail("provider returned tool-call data without a final result"),
         )
     if _progress_only(stripped):
         return OutputFailure(
             "non-final-output",
-            "provider returned progress or intent without a final result",
+            safe_detail("provider returned progress or intent without a final result"),
         )
     return None

--- a/src/brigade/run_resume.py
+++ b/src/brigade/run_resume.py
@@ -13,7 +13,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from . import aboyeur, agents, codex_appserver, runguard
-from .roster import Agent, Roster
+from .roster import Agent, Roster, _as_env
 
 _RESUMABLE_STATUSES = ("interrupted", "failed")
 _NONTERMINAL_RUN_STATUSES = frozenset(
@@ -44,7 +44,7 @@ def _roster_from_snapshot(snapshot: dict) -> Roster:
             reasoning=raw.get("reasoning"),
             transport=raw.get("transport", "direct"),
             transport_version=raw.get("transport_version"),
-            env=dict(raw["env"]) if raw.get("env") else None,
+            env=_as_env(raw.get("env"), name),
             invalid_final_fallback=raw.get("invalid_final_fallback"),
         )
     return Roster(
@@ -111,7 +111,11 @@ def _resume_locked(run_dir: Path) -> int:
         print("error: run artifact has no workspace cwd; cannot verify lock ownership", file=sys.stderr)
         return 2
     cwd = Path(raw_cwd).expanduser().resolve()
-    roster = _roster_from_snapshot(roster_snapshot)
+    try:
+        roster = _roster_from_snapshot(roster_snapshot)
+    except (KeyError, TypeError, ValueError) as exc:
+        print(f"error: invalid roster snapshot: {exc}", file=sys.stderr)
+        return 2
     results = list(worker_data.get("results") or [])
     resumable = [
         r

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1086,6 +1086,223 @@ def test_run_agent_env_ref_resolves_from_parent(monkeypatch):
     assert "ANTHROPIC_AUTH_TOKEN_REF" not in captured["env"]
 
 
+def test_run_agent_scrubs_resolved_env_values_from_success_output(monkeypatch):
+    token = "lane-token-value-for-test"
+    endpoint = "https://lane.example.test/anthropic"
+
+    def fake_run(argv, **kw):
+        return agents.proc.Result(
+            0,
+            f"answer used {token} at {endpoint}\n",
+            f"debug auth={token}\n",
+        )
+
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(agents.proc, "run", fake_run)
+    monkeypatch.setenv("LANE_KEY", token)
+
+    result = agents.run_agent(
+        "claude",
+        "hi",
+        env={"ANTHROPIC_BASE_URL": endpoint, "ANTHROPIC_AUTH_TOKEN_REF": "LANE_KEY"},
+    )
+
+    assert result.ok
+    assert token not in result.text
+    assert token not in result.stdout
+    assert token not in result.stderr
+    assert endpoint not in result.text
+    assert result.text == "answer used [ANTHROPIC_AUTH_TOKEN] at [ANTHROPIC_BASE_URL]"
+    assert result.stderr == "debug auth=[ANTHROPIC_AUTH_TOKEN]\n"
+
+
+def test_run_agent_scrubs_resolved_env_value_from_failure_detail(monkeypatch):
+    token = "lane-token-value-for-test"
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(
+        agents.proc,
+        "run",
+        lambda argv, **kw: agents.proc.Result(1, f"request used {token}\n", f"401 bearer {token}\n"),
+    )
+    monkeypatch.setenv("LANE_KEY", token)
+
+    result = agents.run_agent("claude", "hi", env={"ANTHROPIC_AUTH_TOKEN_REF": "LANE_KEY"})
+
+    assert not result.ok
+    assert token not in result.text
+    assert token not in result.detail
+    assert token not in result.stdout
+    assert token not in result.stderr
+    assert result.detail == "401 bearer [ANTHROPIC_AUTH_TOKEN]"
+
+
+def test_run_agent_scrubs_longer_overlapping_env_value_first(monkeypatch):
+    endpoint = "https://api.example.test/v1"
+    host = "api.example.test"
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(
+        agents.proc,
+        "run",
+        lambda argv, **kw: agents.proc.Result(0, f"connected to {endpoint}\n", ""),
+    )
+
+    result = agents.run_agent("claude", "hi", env={"ENDPOINT": endpoint, "HOST_FRAGMENT": host})
+
+    assert result.ok
+    assert result.text == "connected to [ENDPOINT]"
+
+
+def test_run_agent_scrubs_equal_env_values_with_stable_target(monkeypatch):
+    shared = "shared-override-value"
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(
+        agents.proc,
+        "run",
+        lambda argv, **kw: agents.proc.Result(0, f"configured {shared}\n", ""),
+    )
+
+    result = agents.run_agent("claude", "hi", env={"Z_MODE": shared, "A_MODE": shared})
+
+    assert result.ok
+    assert result.text == "configured [A_MODE]"
+
+
+def test_run_agent_scrubs_structured_grok_after_parsing(monkeypatch):
+    token = "lane-token-value-for-test"
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(
+        agents.proc,
+        "run",
+        lambda argv, **kw: agents.proc.Result(0, _grok_json_output(f"answer used {token}"), ""),
+    )
+    monkeypatch.setenv("LANE_KEY", token)
+
+    result = agents.run_agent(
+        "grok",
+        "review it",
+        read_only=True,
+        env={"GROK_AUTH_TOKEN_REF": "LANE_KEY"},
+    )
+
+    assert result.ok
+    assert result.text == "answer used [GROK_AUTH_TOKEN]"
+    assert token not in result.stdout
+
+
+def test_run_agent_classifies_output_before_scrubbing_env_values(monkeypatch):
+    diagnostic = "rate limit exceeded"
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(
+        agents.proc,
+        "run",
+        lambda argv, **kw: agents.proc.Result(0, f"Error: {diagnostic} for this provider.\n", ""),
+    )
+    monkeypatch.setenv("LANE_DIAGNOSTIC", diagnostic)
+
+    result = agents.run_agent("claude", "hi", env={"LANE_MODE_REF": "LANE_DIAGNOSTIC"})
+
+    assert not result.ok
+    assert result.failure_kind == "rate-limit-error"
+    assert diagnostic not in result.text
+    assert diagnostic not in result.detail
+    assert diagnostic not in result.stdout
+    assert result.text == "Error: [LANE_MODE] for this provider."
+    assert "Error: [LANE_MODE] for this provider." in result.detail
+
+
+def test_run_agent_classifies_invalid_grok_before_scrubbing_env_values(monkeypatch):
+    diagnostic = "rate limit exceeded"
+    stdout = _grok_json_output(f"Error: {diagnostic} for this provider.", structured=False)
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(
+        agents.proc,
+        "run",
+        lambda argv, **kw: agents.proc.Result(0, stdout + "\n", ""),
+    )
+    monkeypatch.setenv("LANE_DIAGNOSTIC", diagnostic)
+
+    result = agents.run_agent(
+        "grok",
+        "review it",
+        read_only=True,
+        env={"GROK_MODE_REF": "LANE_DIAGNOSTIC"},
+    )
+
+    assert not result.ok
+    assert result.failure_kind == "rate-limit-error"
+    assert diagnostic not in result.text
+    assert diagnostic not in result.detail
+    assert diagnostic not in result.stdout
+    assert result.text == "Error: [GROK_MODE] for this provider."
+    assert "Error: [GROK_MODE] for this provider." in result.detail
+
+
+def test_run_agent_scrubs_long_env_value_before_detail_truncation(monkeypatch):
+    token = "secret-boundary-" + "x" * 240
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(
+        agents.proc,
+        "run",
+        lambda argv, **kw: agents.proc.Result(
+            0,
+            f"Error: rate limit exceeded while using {token}.\n",
+            "",
+        ),
+    )
+    monkeypatch.setenv("LONG_LANE_TOKEN", token)
+
+    result = agents.run_agent("claude", "hi", env={"LANE_TOKEN_REF": "LONG_LANE_TOKEN"})
+
+    assert not result.ok
+    assert result.failure_kind == "rate-limit-error"
+    assert token[:80] not in result.detail
+    assert "[LANE_TOKEN]" in result.detail
+    assert len(result.detail) <= 200
+
+
+def test_run_agent_scrubs_long_grok_error_before_detail_truncation(monkeypatch):
+    token = "secret-boundary-" + "x" * 240
+    payload = json.loads(_grok_json_output("No findings."))
+    payload["structuredOutputError"] = f"schema rejected token {token}"
+    stdout = json.dumps(payload)
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(
+        agents.proc,
+        "run",
+        lambda argv, **kw: agents.proc.Result(0, stdout + "\n", ""),
+    )
+    monkeypatch.setenv("LONG_GROK_TOKEN", token)
+
+    result = agents.run_agent(
+        "grok",
+        "review it",
+        read_only=True,
+        env={"GROK_TOKEN_REF": "LONG_GROK_TOKEN"},
+    )
+
+    assert not result.ok
+    assert result.failure_kind == "malformed-final-output"
+    assert token[:80] not in result.detail
+    assert "[GROK_TOKEN]" in result.detail
+    assert len(result.detail) <= 200
+
+
+def test_run_agent_does_not_scrub_unrelated_parent_environment(monkeypatch):
+    unrelated = "parent-value-not-overridden"
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(
+        agents.proc,
+        "run",
+        lambda argv, **kw: agents.proc.Result(0, f"diagnostic {unrelated}\n", ""),
+    )
+    monkeypatch.setenv("UNRELATED_VALUE", unrelated)
+
+    result = agents.run_agent("claude", "hi", env={"LANE_MODE": "test"})
+
+    assert result.ok
+    assert unrelated in result.text
+
+
 def test_run_agent_env_ref_missing_fails_before_spawn(monkeypatch):
     calls = []
     monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)

--- a/tests/test_run_resume.py
+++ b/tests/test_run_resume.py
@@ -6,6 +6,8 @@ import json
 import os
 from pathlib import Path
 
+import pytest
+
 from brigade import agents, codex_appserver, runguard, run_resume
 
 
@@ -93,6 +95,38 @@ def test_roster_snapshot_preserves_invalid_final_fallback():
     roster = run_resume._roster_from_snapshot(snapshot)
 
     assert roster.agents["grok-review"].invalid_final_fallback == "cursor-grok"
+
+
+def test_roster_snapshot_rejects_inline_secret_env():
+    snapshot = {
+        "orchestrator": "chef",
+        "agents": {
+            "chef": {
+                "cli": "claude",
+                "role": "plan",
+                "env": {"ANTHROPIC_AUTH_TOKEN": "not-for-storage"},
+            }
+        },
+    }
+
+    with pytest.raises(ValueError, match="pass it by reference"):
+        run_resume._roster_from_snapshot(snapshot)
+
+
+def test_roster_snapshot_rejects_colliding_env_targets():
+    snapshot = {
+        "orchestrator": "chef",
+        "agents": {
+            "chef": {
+                "cli": "claude",
+                "role": "plan",
+                "env": {"LANE_MODE": "direct", "LANE_MODE_REF": "PARENT_LANE_MODE"},
+            }
+        },
+    }
+
+    with pytest.raises(ValueError, match="both resolve to LANE_MODE"):
+        run_resume._roster_from_snapshot(snapshot)
 
 
 def test_resume_reattaches_and_resynthesizes(tmp_path, monkeypatch, capsys):
@@ -370,3 +404,31 @@ def test_resume_synthesis_carries_orchestrator_env(tmp_path, monkeypatch):
     monkeypatch.setattr(run_resume.agents, "run_agent", fake_run_agent)
     assert run_resume.resume(run_dir) == 0
     assert captured["env"] == {"ANTHROPIC_BASE_URL": "https://api.example.com/anthropic"}
+
+
+def test_resume_rejects_invalid_snapshot_env_before_dispatch(tmp_path, monkeypatch, capsys):
+    run_dir = _write_run_dir(
+        tmp_path,
+        results=[
+            {
+                "worker": "cook",
+                "task": "write code",
+                "ok": False,
+                "detail": "timeout",
+                "text": "part",
+                "thread_id": "t-1",
+                "status": "interrupted",
+            }
+        ],
+    )
+    roster_snapshot = json.loads((run_dir / "roster.json").read_text())
+    roster_snapshot["agents"]["chef"]["env"] = {"ANTHROPIC_AUTH_TOKEN": "not-for-storage"}
+    (run_dir / "roster.json").write_text(json.dumps(roster_snapshot))
+    monkeypatch.setattr(
+        run_resume.codex_appserver,
+        "AppServer",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("dispatch must not start")),
+    )
+
+    assert run_resume._resume_locked(run_dir) == 2
+    assert "invalid roster snapshot" in capsys.readouterr().err

--- a/tests/test_run_transport_env.py
+++ b/tests/test_run_transport_env.py
@@ -3,6 +3,7 @@
 from brigade import agents
 from brigade import run_transport
 from brigade.roster import Agent, Roster
+from brigade.run_receipts import write_worker_logs
 from brigade.run_transport import Assignment
 
 
@@ -12,10 +13,10 @@ def _roster_with_env(env):
     return Roster(orchestrator="chef", agents={"chef": chef, "k3": k3})
 
 
-def _dispatch(roster, monkeypatch, captured):
+def _dispatch(roster, monkeypatch, captured, *, stdout="worker answer", stderr=""):
     def fake_run(argv, **kw):
         captured["env"] = kw.get("env")
-        return agents.proc.Result(0, "worker answer", "")
+        return agents.proc.Result(0, stdout, stderr)
 
     monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
     monkeypatch.setattr(agents.proc, "run", fake_run)
@@ -60,6 +61,34 @@ def test_worker_result_records_env_provenance_without_values(monkeypatch):
     assert result.endpoint_host == "api.example.com"
     serialized = str(result)
     assert "sk-lane-value" not in serialized
+
+
+def test_worker_logs_scrub_resolved_env_values_before_persistence(monkeypatch, tmp_path):
+    token = "lane-token-value-for-test"
+    monkeypatch.setenv("LANE_KEY", token)
+    captured = {}
+    roster = _roster_with_env({"ANTHROPIC_AUTH_TOKEN_REF": "LANE_KEY"})
+
+    result = _dispatch(
+        roster,
+        monkeypatch,
+        captured,
+        stdout=f"worker answer token={token}\n",
+        stderr=f"adapter diagnostic bearer={token}\n",
+    )[0]
+    recorded = write_worker_logs(tmp_path, [result])[0]
+
+    assert token not in result.text
+    assert token not in result.stdout
+    assert token not in result.stderr
+    assert recorded.stdout_log is not None
+    assert recorded.stderr_log is not None
+    stdout_log = (tmp_path / recorded.stdout_log).read_text()
+    stderr_log = (tmp_path / recorded.stderr_log).read_text()
+    assert token not in stdout_log
+    assert token not in stderr_log
+    assert stdout_log == "worker answer token=[ANTHROPIC_AUTH_TOKEN]\n"
+    assert stderr_log == "adapter diagnostic bearer=[ANTHROPIC_AUTH_TOKEN]\n"
 
 
 def test_worker_env_missing_ref_fails_the_worker(monkeypatch):


### PR DESCRIPTION
## Summary

- Replace exact nonempty resolved seat environment values in worker text, detail, stdout, and stderr before results or log files are persisted.
- Classify raw provider diagnostics before replacement, then replace values before the 200-character detail limit so partial secrets cannot survive truncation.
- Revalidate saved seat environment tables during resume and reject inline values, duplicate targets, and malformed references before dispatch.

## Verification

- Initial RED: `20260717-103024-work-verify-482ba8`, 7 expected failures covering result fields, stored logs, and resume validation.
- Initial focused GREEN: `20260717-103157-work-verify-a05995`, 127 passed.
- Classification sendback RED: `20260717-104234-work-verify-8af4b2`, 2 expected failures.
- Truncation sendback RED: `20260717-104714-work-verify-bb60d4`, 2 expected failures.
- Final focused GREEN: `20260717-104824-work-verify-05c5ca`, 109 passed.
- Post-rebase full gate: `20260717-105526-work-verify-e6a256`, 2,787 passed and 3 skipped.

## Review

Independent review found the classification-order and truncation-order defects. Each claim was reproduced through Brigade before the source fix. The same reviewer checked both fixes and returned no remaining findings.

Closes #310
