### PR TITLE
fix(handoff): suggest migration for freeform notes

### DIFF
--- a/src/brigade/handoff_cmd/linting.py
+++ b/src/brigade/handoff_cmd/linting.py
@@ -79,6 +79,8 @@ def lint(
         print(f"[{status}] {result.path}{action}")
         for error in result.errors:
             print(f"  - {error}")
+        for hint in result.hints:
+            print(f"  hint: {hint}")
         for warning in result.warnings:
             print(f"  warning: {warning}")
         signals = injection_counts.get(str(result.path), 0)
@@ -120,6 +122,7 @@ def lint_file(path: Path) -> HandoffLintResult:
     path = path.expanduser().resolve()
     errors: list[str] = []
     warnings: list[str] = []
+    hints: list[str] = []
     action: str | None = None
     try:
         text = path.read_text(errors="replace")
@@ -136,6 +139,14 @@ def lint_file(path: Path) -> HandoffLintResult:
     for required in ("Type", "Title", "Summary", "Recommended memory action"):
         if required not in sections or not _section_value(sections, required):
             errors.append(f"missing required section: {required}")
+
+    if any(error.startswith("missing required section:") for error in errors):
+        _, migration_gaps = _migrate_extract(text)
+        if not migration_gaps:
+            from ..untrusted import scan_untrusted
+
+            if not scan_untrusted(text).flagged:
+                hints.append("this looks like a freeform note; try `brigade handoff migrate --target .`")
 
     action_value = _section_value(sections, "Recommended memory action")
     if action_value:
@@ -154,6 +165,7 @@ def lint_file(path: Path) -> HandoffLintResult:
         valid=not errors,
         errors=tuple(errors),
         warnings=tuple(warnings),
+        hints=tuple(hints),
     )
 
 

--- a/src/brigade/handoff_cmd/models.py
+++ b/src/brigade/handoff_cmd/models.py
@@ -180,6 +180,7 @@ class HandoffLintResult:
     valid: bool
     errors: tuple[str, ...]
     warnings: tuple[str, ...]
+    hints: tuple[str, ...] = ()
 
     def as_dict(self) -> dict[str, Any]:
         return {
@@ -188,6 +189,7 @@ class HandoffLintResult:
             "valid": self.valid,
             "errors": list(self.errors),
             "warnings": list(self.warnings),
+            "hints": list(self.hints),
         }
 
 

--- a/tests/test_handoff_cmd.py
+++ b/tests/test_handoff_cmd.py
@@ -1967,6 +1967,27 @@ def _homegrown_note(inbox, name="2026-06-01-1200-good-note.md"):
     return inbox / name
 
 
+def test_handoff_lint_suggests_migrate_for_extractable_homegrown_note(tmp_path, capsys):
+    note = _homegrown_note(tmp_path / ".claude" / "memory-handoffs")
+
+    assert handoff_cmd.lint(target=tmp_path, paths=[note]) == 1
+    out = capsys.readouterr().out
+    expected = "this looks like a freeform note; try `brigade handoff migrate --target .`"
+    assert f"hint: {expected}" in out
+
+    assert handoff_cmd.lint(target=tmp_path, paths=[note], json_output=True) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["results"][0]["hints"] == [expected]
+
+
+def test_handoff_lint_does_not_suggest_migrate_for_unextractable_note(tmp_path, capsys):
+    note = tmp_path / "garbage.md"
+    note.write_text("random unstructured note, nothing usable\n")
+
+    assert handoff_cmd.lint(target=tmp_path, paths=[note]) == 1
+    assert "handoff migrate" not in capsys.readouterr().out
+
+
 def test_handoff_migrate_dry_run_plans_homegrown_note(tmp_path, capsys):
     inbox = tmp_path / ".claude" / "memory-handoffs"
     note = _homegrown_note(inbox)
@@ -2034,8 +2055,10 @@ def test_handoff_lint_surfaces_injection_signals(tmp_path, capsys):
     payload = json.loads(capsys.readouterr().out)
     flagged = [r for r in payload["results"] if r.get("injection_signals")]
     assert flagged, "lint should report injection signal counts"
+    assert flagged[0]["hints"] == []
 
     handoff_cmd.lint(target=tmp_path)
     out = capsys.readouterr().out
     assert "injection" in out.lower()
     assert "security scan" in out.lower()
+    assert "handoff migrate" not in out


### PR DESCRIPTION
## Summary

- Add structured lint hints for freeform handoff notes that `brigade handoff migrate` can convert.
- Print the migration command in text output and expose the same guidance in JSON.
- Suppress the hint for unextractable or injection-flagged notes so lint matches migrate behavior.

## Verification

- `./scripts/verify`: passed on the GitHub head, receipt `20260717-110404-work-verify-c41f50`.
- Exact-head review: CLEAN at `3ee55695086625b85221fe48116c5de56af6a0d0`, receipt `20260717-110848-work-verify-d6ca57`.
- Memory handoff lint: passed, receipt `20260717-110102-work-verify-2cc87c`.
- Public-repo content guard: passed, receipt `20260717-110108-work-verify-d99ca1`.

Closes #311
