### PR TITLE
fix(run): isolate lock timeout clock

### DIFF
--- a/src/brigade/runguard.py
+++ b/src/brigade/runguard.py
@@ -7,10 +7,11 @@ import errno
 import json
 import os
 import shutil
-import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from time import monotonic as _monotonic
+from time import sleep as _sleep
 from uuid import uuid4
 
 from . import localio, proc
@@ -18,6 +19,15 @@ from . import localio, proc
 _NONTERMINAL_RUN_STATUSES = frozenset(
     {"started", "planning", "dispatching", "synthesizing", "artifact-collection", "running"}
 )
+
+
+class _RunLockClock:
+    monotonic = staticmethod(_monotonic)
+    sleep = staticmethod(_sleep)
+
+
+# Keep lock-clock patches local instead of replacing the process-wide time module.
+time = _RunLockClock()
 
 
 class RunGuardError(RuntimeError):

--- a/tests/test_runguard.py
+++ b/tests/test_runguard.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import threading
+import time as stdlib_time
 from pathlib import Path
 
 import pytest
@@ -244,6 +245,25 @@ def test_run_lock_wait_timeout_is_bounded(tmp_path, monkeypatch):
     monkeypatch.setattr(runguard.time, "monotonic", lambda: next(monotonic))
     monkeypatch.setattr(runguard.time, "sleep", sleeps.append)
 
+    with pytest.raises(runguard.RunLockError, match=r"timed out after 0.2s waiting for run lock"):
+        with runguard.run_lock(repo, wait_seconds=0.2, poll_interval=0.05):
+            pass
+
+    assert sleeps == [0.05]
+    assert lock_path.is_dir()
+
+
+def test_run_lock_timeout_clock_is_isolated_from_process_clock(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    lock_path = runguard.lock_path(repo)
+    lock_path.mkdir(parents=True)
+    (lock_path / "pid").write_text(f"{os.getpid()}\n")
+    monotonic = iter((10.0, 10.0, 10.25))
+    sleeps = []
+    monkeypatch.setattr(runguard.time, "monotonic", lambda: next(monotonic))
+    monkeypatch.setattr(runguard.time, "sleep", sleeps.append)
+
+    stdlib_time.monotonic()
     with pytest.raises(runguard.RunLockError, match=r"timed out after 0.2s waiting for run lock"):
         with runguard.run_lock(repo, wait_seconds=0.2, poll_interval=0.05):
             pass


### PR DESCRIPTION
## Summary

- Bind the run-lock clock behind a module-local facade instead of exposing Python's shared `time` module as the test seam.
- Keep the existing deadline, bounded sleep, and monkeypatch interface unchanged.
- Add a deterministic regression proving that an unrelated process-clock call cannot consume the run-lock test clock.

## Verification

- RED: `20260717-111934-work-verify-6f4095`, the unrelated clock call consumed the first iterator value and skipped the expected poll.
- Focused GREEN: `20260717-112013-work-verify-5d0e9d`, 39 passed.
- Ruff format: `20260717-112038-work-verify-18cab5`.
- Ruff lint: `20260717-112044-work-verify-b4b788`.
- Mypy: `20260717-112049-work-verify-2e43b9`.
- Post-rebase full gate: `20260717-112708-work-verify-bd9f43`, 2,790 passed and 3 skipped.

## Review

Independent review verified the shared-module root cause, found no production dependency on `runguard.time`, and returned no Critical, Important, or Minor findings.

Closes #309
