### PR TITLE
feat(model-trials): journal running cell state before attempt dispatch

### DIFF
--- a/src/brigade/model_trials.py
+++ b/src/brigade/model_trials.py
@@ -9,6 +9,7 @@ import statistics
 import sys
 import time
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -391,6 +392,18 @@ def execute(
         if resume and current is not None and current.get("state") in TERMINAL_STATES:
             continue
         attempt = _attempt_number(cell_dir)
+        started_at = current.get("started_at") if isinstance(current, dict) and isinstance(current.get("started_at"), str) else datetime.now(timezone.utc).isoformat()
+        cell_dir.mkdir(parents=True, exist_ok=True)
+        localio.write_json(
+            cell_dir / "cell.json",
+            {
+                "schema": CELL_SCHEMA,
+                **cell.payload(),
+                "state": "running",
+                "attempt": attempt,
+                "started_at": started_at,
+            },
+        )
         run_dir = cell_dir / "attempts" / f"attempt-{attempt:03d}" / "run"
         cell_workspace = workspace
         worktree_path: Path | None = None
@@ -438,6 +451,7 @@ def execute(
             **cell.payload(),
             "state": state,
             "attempt": attempt,
+            "started_at": started_at,
             "exit_code": rc,
             "duration_seconds": run_meta.get("duration_seconds"),
             "run_dir": str(run_dir),

--- a/tests/test_model_trials.py
+++ b/tests/test_model_trials.py
@@ -115,6 +115,66 @@ def test_graders_distinguish_zero_score_from_error(tmp_path):
     assert results[1]["exit_code"] is None
 
 
+def test_execute_writes_running_marker_before_aboyeur_run(tmp_path, monkeypatch):
+    manifest = _manifest()
+    manifest["trials"] = 1
+    manifest_path = tmp_path / "eval.json"
+    manifest_path.write_text(json.dumps(manifest))
+    cell = model_trials.expand_cells(manifest, _roster())[0]
+    started_at_seen: list[str] = []
+    root = tmp_path / "results"
+
+    def fake_run(task, roster, **kwargs):
+        cell_path = root / "cells" / cell.cell_id / "cell.json"
+        assert cell_path.is_file()
+        running = json.loads(cell_path.read_text())
+        assert running["schema"] == model_trials.CELL_SCHEMA
+        assert running["state"] == "running"
+        assert running["attempt"] == 1
+        for key, value in cell.payload().items():
+            assert running[key] == value
+        assert isinstance(running.get("started_at"), str)
+        started_at_seen.append(running["started_at"])
+        out = kwargs["output_dir"]
+        out.mkdir(parents=True, exist_ok=True)
+        (out / "final.txt").write_text("hello\n")
+        (out / "run.json").write_text(json.dumps({"status": "ok", "duration_seconds": 0.5}))
+        return 0
+
+    monkeypatch.setattr(model_trials.aboyeur, "run", fake_run)
+    assert model_trials.execute(manifest_path, _roster(), workspace=tmp_path, output_dir=root, resume=False) == 0
+    final = json.loads((root / "cells" / cell.cell_id / "cell.json").read_text())
+    assert final["state"] == "accepted"
+    assert final["started_at"] == started_at_seen[0]
+
+
+def test_resume_does_not_skip_running_cells(tmp_path, monkeypatch):
+    manifest_path = tmp_path / "eval.json"
+    manifest_path.write_text(json.dumps(_manifest()))
+    calls: list[str] = []
+
+    def fake_run(task, roster, **kwargs):
+        calls.append(kwargs["worker"])
+        out = kwargs["output_dir"]
+        out.mkdir(parents=True, exist_ok=True)
+        (out / "final.txt").write_text("hello\n")
+        (out / "run.json").write_text(json.dumps({"status": "ok", "duration_seconds": 0.5}))
+        return 0
+
+    monkeypatch.setattr(model_trials.aboyeur, "run", fake_run)
+    root = tmp_path / "results"
+    assert model_trials.execute(manifest_path, _roster(), workspace=tmp_path, output_dir=root, resume=False) == 0
+    assert calls == ["cursor", "cursor"]
+
+    crashed_path = next((root / "cells").glob("*/cell.json"))
+    crashed = json.loads(crashed_path.read_text())
+    crashed["state"] = "running"
+    crashed_path.write_text(json.dumps(crashed))
+
+    assert model_trials.execute(manifest_path, _roster(), workspace=tmp_path, output_dir=root, resume=True) == 0
+    assert calls == ["cursor", "cursor", "cursor"]
+
+
 def test_run_then_resume_skips_matching_terminal_cells(tmp_path, monkeypatch):
     manifest_path = tmp_path / "eval.json"
     manifest_path.write_text(json.dumps(_manifest()))


### PR DESCRIPTION
## What

`cells/<cell_id>/cell.json` is now written with `state: "running"`, the attempt number, and a UTC `started_at` immediately before a trial attempt dispatches. The terminal write preserves `started_at` and is otherwise unchanged. `running` is not a terminal state, so `trial resume` retries such cells exactly as before.

## Why

A killed trial process previously left an `attempts/` directory with run artifacts but no `cell.json` at all - indistinguishable from a cell that never started, and invisible to anything watching the output tree. Cross-checking cell identity and retry semantics against a mature eval harness's log/resume behavior showed start-of-work journaling was the one durability gap on our side (our content-addressed cell identity is stronger than its nominal task versioning; happy-path resume is equivalent). Live probe: kill -9 mid-attempt now leaves `state: running` with the start timestamp; completed cells show terminal state with `started_at` preserved.

## Verification

`python -m pytest tests/test_model_trials.py -q` (11 passed) and full suite (2796 passed, 3 skipped), receipted via `brigade work verify run`. New tests: `test_execute_writes_running_marker_before_aboyeur_run`, `test_resume_does_not_skip_running_cells`; both fail against the old code.