### PR TITLE
style(model-trials): wrap started_at fallback for formatter

### DIFF
--- a/src/brigade/model_trials.py
+++ b/src/brigade/model_trials.py
@@ -392,7 +392,11 @@ def execute(
         if resume and current is not None and current.get("state") in TERMINAL_STATES:
             continue
         attempt = _attempt_number(cell_dir)
-        started_at = current.get("started_at") if isinstance(current, dict) and isinstance(current.get("started_at"), str) else datetime.now(timezone.utc).isoformat()
+        started_at = (
+            current.get("started_at")
+            if isinstance(current, dict) and isinstance(current.get("started_at"), str)
+            else datetime.now(timezone.utc).isoformat()
+        )
         cell_dir.mkdir(parents=True, exist_ok=True)
         localio.write_json(
             cell_dir / "cell.json",


### PR DESCRIPTION
Ruff-format cleanup for the running-marker change merged in #327, which landed with the lint job red (a long conditional expression). Pure re-wrap, no behavior change; `pytest tests/test_model_trials.py` green. This PR's CI run also re-exercises the `test_run_control` socket test that failed on #327's run - it passes locally at merged main, so this run arbitrates flake vs real.