### PR TITLE
feat(skills): enforce the 500-character compatibility bound

### DIFF
--- a/src/brigade/agent_skill_format.py
+++ b/src/brigade/agent_skill_format.py
@@ -115,6 +115,10 @@ def validate(skill_dir: Path, *, mode: str) -> Validation:
         field_value = fields.get(key)
         if field_value is not None and (not isinstance(field_value, str) or not field_value):
             errors.append(f"frontmatter {key} must be a non-empty string")
+    compatibility = fields.get("compatibility")
+    if isinstance(compatibility, str) and len(compatibility) > 500:
+        message = "frontmatter compatibility exceeds 500 characters"
+        (errors if mode == "strict" else diagnostics).append(message)
     allowed = fields.get("allowed-tools")
     if isinstance(allowed, str):
         fields["allowed-tools"] = tuple(item for item in re.split(r"[\s,]+", allowed) if item)

--- a/tests/test_agent_skill_format.py
+++ b/tests/test_agent_skill_format.py
@@ -51,3 +51,23 @@ def test_name_description_and_exact_casing_are_enforced(tmp_path):
     (wrong / "skill.md").write_text("---\nname: lowercase\ndescription: x\n---\n")
     result = agent_skill_format.validate(wrong, mode="strict")
     assert any("SKILL.md not found" in error for error in result.errors)
+
+
+def test_digit_bearing_names_are_valid(tmp_path):
+    directory = _skill(
+        tmp_path,
+        "pdf2text-v2",
+        "name: pdf2text-v2\ndescription: Convert PDFs.\n",
+    )
+    result = agent_skill_format.validate(directory, mode="strict")
+    assert result.errors == ()
+
+
+def test_compatibility_over_500_characters_is_strict_error_lenient_diagnostic(tmp_path):
+    frontmatter = f"name: code-review\ndescription: Review a change.\ncompatibility: {'x' * 501}\n"
+    directory = _skill(tmp_path, "code-review", frontmatter)
+    strict = agent_skill_format.validate(directory, mode="strict")
+    lenient = agent_skill_format.validate(directory, mode="lenient")
+    assert "frontmatter compatibility exceeds 500 characters" in strict.errors
+    assert lenient.errors == ()
+    assert "frontmatter compatibility exceeds 500 characters" in lenient.diagnostics


### PR DESCRIPTION
## What

The skills specification caps `compatibility` at 500 characters. Validation enforced the name (64) and description (1024) bounds but let `compatibility` through unbounded. Strict authoring mode now errors; lenient import records a diagnostic - the same split the description bound uses. Also adds a digit-bearing name fixture (`pdf2text-v2`) covering the spec's alphanumeric name range explicitly.

## Why

Spec-tracking round against the upstream specification: field inventory and name/description bounds all matched current spec text; the compatibility cap was the one observable without enforcement or a fixture. Per the standing rule, fixtures land with the parser change.

## Verification

`pytest tests/test_agent_skill_format.py` (5 passed; new compatibility test failed RED before the fix), ruff format + check clean, receipted via Brigade. The 6 `test_repos_sweep_health_cmd` failures visible in local full-suite runs are pre-existing environment failures, identical on clean main.