### PR TITLE
fix(run): feed codex plan prompts on stdin so planning cannot block

### DIFF
--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -655,6 +655,32 @@ def _record_plan_attempt(
     attempts.append(payload)
 
 
+def _orchestrator_failure_detail(
+    result: agents.AgentResult,
+    *,
+    seat: str,
+    cli: str | None,
+    transport: str,
+) -> str:
+    if cli != "codex":
+        return result.detail or ""
+    # Prefer stderr: it still carries the raw codex banner after run_agent maps detail.
+    source = result.stderr or result.detail or ""
+    mapped = agents.codex_stdin_hang_detail(source, seat=seat, transport=transport)
+    if mapped is not None:
+        return mapped
+    if "blocked waiting for stdin" in (result.detail or "").lower():
+        return (
+            agents.codex_stdin_hang_detail(
+                "Reading additional input from stdin",
+                seat=seat,
+                transport=transport,
+            )
+            or result.detail
+        )
+    return result.detail or ""
+
+
 def _run_orchestrator(
     roster: Roster,
     prompt: str,
@@ -662,8 +688,10 @@ def _run_orchestrator(
     read_only: bool = False,
     sandbox_read_only: bool | None = None,
     sandbox: str | None = None,
+    codex_transport: str | None = None,
 ) -> agents.AgentResult:
     orchestrator = roster.agents[roster.orchestrator]
+    transport = codex_transport or roster.codex_transport
     if not is_cli_allowed(orchestrator.cli, roster):
         return agents.AgentResult(
             text="",
@@ -691,7 +719,28 @@ def _run_orchestrator(
         kwargs["reasoning"] = orchestrator.reasoning
     if orchestrator.env is not None:
         kwargs["env"] = dict(orchestrator.env)
-    return agents.run_agent(orchestrator.cli, prompt, **kwargs)
+    result = agents.run_agent(orchestrator.cli, prompt, **kwargs)
+    if not result.ok and orchestrator.cli == "codex":
+        detail = _orchestrator_failure_detail(
+            result,
+            seat=roster.orchestrator,
+            cli=orchestrator.cli,
+            transport=transport,
+        )
+        if detail != result.detail:
+            return agents.AgentResult(
+                text=result.text,
+                ok=False,
+                detail=detail,
+                stdout=result.stdout,
+                stderr=result.stderr,
+                exit_code=result.exit_code,
+                timed_out=result.timed_out,
+                requested_model=result.requested_model,
+                reasoning=result.reasoning,
+                transport=result.transport,
+            )
+    return result
 
 
 def _coverage_missing(route: RouteBrief | None, assignments: list[Assignment]) -> list[str]:
@@ -718,7 +767,9 @@ def plan(
     drift_impact: DriftImpactBrief | None = None,
     evidence: EvidenceBrief | None = None,
     route: RouteBrief | None = None,
+    codex_transport: str | None = None,
 ) -> list[Assignment]:
+    transport = codex_transport or roster.codex_transport
     first = _run_orchestrator(
         roster,
         build_plan_prompt(
@@ -734,6 +785,7 @@ def plan(
         read_only=read_only,
         sandbox_read_only=sandbox_read_only,
         sandbox=sandbox,
+        codex_transport=transport,
     )
     if not first.ok:
         _record_plan_attempt(attempts, stage="initial", result=first)
@@ -766,6 +818,7 @@ def plan(
             read_only=read_only,
             sandbox_read_only=sandbox_read_only,
             sandbox=sandbox,
+            codex_transport=transport,
         )
         if not second.ok:
             _record_plan_attempt(attempts, stage="correction", result=second)
@@ -815,6 +868,7 @@ def plan(
         read_only=read_only,
         sandbox_read_only=sandbox_read_only,
         sandbox=sandbox,
+        codex_transport=transport,
     )
     if not revised_result.ok:
         _record_plan_attempt(attempts, stage="coverage-correction", result=revised_result)
@@ -1864,6 +1918,7 @@ def run(
                 drift_impact=drift_impact,
                 evidence=evidence,
                 route=route,
+                codex_transport=transport_for_payload,
             )
         except RuntimeError as exc:
             failed_attempt = next(
@@ -2135,6 +2190,7 @@ def run(
             read_only=read_only,
             sandbox_read_only=sandbox_read_only,
             sandbox=sandbox,
+            codex_transport=transport_for_payload,
         )
         final = replace(final, duration_seconds=max(0.0, round(time.monotonic() - synthesis_started, 3)))
     if output_dir is not None:

--- a/src/brigade/agents.py
+++ b/src/brigade/agents.py
@@ -57,11 +57,15 @@ def _claude_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | 
 
 
 def _codex_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | None) -> List[str]:
+    # Prompt is fed on stdin via `-`. Codex 0.144+ treats a non-TTY open stdin as
+    # optional append input and can hang on "Reading additional input from stdin..."
+    # when the prompt is only a trailing argv token.
+    _ = prompt  # carried by run_agent via proc.run(stdin=...)
     if sandbox:
-        return ["codex", "exec", "--sandbox", sandbox, prompt]
+        return ["codex", "exec", "--sandbox", sandbox, "-"]
     if read_only:
-        return ["codex", "exec", "--sandbox", "read-only", prompt]
-    return ["codex", "exec", prompt]
+        return ["codex", "exec", "--sandbox", "read-only", "-"]
+    return ["codex", "exec", "-"]
 
 
 def _opencode_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | None) -> List[str]:
@@ -534,6 +538,27 @@ def _scrub_env_override_values(text: str, overrides: dict[str, str] | None) -> s
     return pattern.sub(lambda match: replacements[match.group(0)], text)
 
 
+_CODEX_STDIN_HANG_MARKER = "Reading additional input from stdin"
+
+
+def codex_stdin_hang_detail(raw: str, *, seat: str | None = None, transport: str | None = None) -> str | None:
+    """Rewrite the codex stdin-hang banner into a clear, actionable detail."""
+    if _CODEX_STDIN_HANG_MARKER.lower() not in raw.lower():
+        return None
+    where = "codex"
+    if seat is not None:
+        where = f"orchestrator seat {seat!r} (cli=codex"
+        if transport is not None:
+            where += f", transport={transport!r}"
+        where += ")"
+    elif transport is not None:
+        where = f"codex (transport={transport!r})"
+    return (
+        f"{where} blocked waiting for stdin during a non-interactive run; "
+        "feed the prompt via `codex exec -` on stdin (and close stdin after the prompt)"
+    )
+
+
 def run_agent(
     cli_ref: str,
     prompt: str,
@@ -635,12 +660,21 @@ def run_agent(
             )
         argv[-2:] = ["--sandbox", "read-only", "--always-approve"]
         argv.extend(["--json-schema", _GROK_RESULT_SCHEMA])
-    result = proc.run(
-        argv,
-        timeout=timeout,
-        cwd=cwd,
-        env=child_env,
-    )
+    if cli_ref == "codex":
+        result = proc.run(
+            argv,
+            timeout=timeout,
+            cwd=cwd,
+            env=child_env,
+            stdin=prompt.encode(),
+        )
+    else:
+        result = proc.run(
+            argv,
+            timeout=timeout,
+            cwd=cwd,
+            env=child_env,
+        )
     text = result.stdout.strip()
     structured_error = ""
     structured_diagnostic = ""
@@ -664,7 +698,10 @@ def run_agent(
         return _scrub_env_override_values(detail, resolved_overrides)
 
     if result.code != 0:
-        detail = safe_stderr.strip() or f"exit {result.code}"
+        raw_detail = safe_stderr.strip() or f"exit {result.code}"
+        detail = codex_stdin_hang_detail(raw_detail) if cli_ref == "codex" else None
+        if detail is None:
+            detail = raw_detail
         return AgentResult(
             text=safe_text,
             ok=False,

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -3009,3 +3009,74 @@ def test_plan_records_unknown_covers(monkeypatch):
     aboyeur.plan("rename the config loader helper", _roster(), attempts=attempts, route=route)
     assert attempts[-1]["unknown_covers"] == ["ghost-review"]
     assert "coverage_missing" not in attempts[-1]  # real coverage is complete
+
+
+def test_plan_codex_orchestrator_feeds_prompt_on_stdin_for_both_transports(monkeypatch):
+    """Plan must invoke a codex orchestrator with stdin-fed `codex exec -`.
+
+    Both roster transports use this exec-shaped plan path today (app-server is
+    for workers); the prompt must not be a trailing argv token.
+    """
+    plan_json = json.dumps({"assignments": [{"worker": "coder", "task": "implement it"}]})
+    captured = []
+
+    def fake_run(argv, **kw):
+        captured.append({"argv": list(argv), "stdin": kw.get("stdin")})
+        return proc.Result(0, plan_json, "")
+
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/bin/" + c)
+    monkeypatch.setattr(agents.proc, "run", fake_run)
+
+    for transport in ("exec", "app-server"):
+        captured.clear()
+        roster = Roster(
+            orchestrator="chef",
+            agents={
+                "chef": Agent("chef", "codex", "plan and synthesize", model="gpt-5.5"),
+                "coder": Agent("coder", "ollama:llama3.3", "write code"),
+            },
+            max_workers=1,
+            codex_transport=transport,
+        )
+        assignments = aboyeur.plan("build feature", roster)
+        assert len(assignments) == 1
+        assert len(captured) == 1
+        call = captured[0]
+        assert call["argv"][0:2] == ["codex", "exec"]
+        assert call["argv"][-1] == "-"
+        assert "-m" in call["argv"]
+        assert call["argv"][call["argv"].index("-m") + 1] == "gpt-5.5"
+        assert call["stdin"] is not None
+        assert b"build feature" in call["stdin"]
+        assert b"assignments" in call["stdin"]
+
+
+def test_plan_codex_stdin_hang_names_seat_and_transport(monkeypatch):
+    import pytest
+
+    def fake_run(argv, **kw):  # noqa: ARG001
+        return proc.Result(
+            124,
+            "",
+            "Reading additional input from stdin...\nOpenAI Codex v0.144.5\n--------\n"
+            "workdir: /tmp\nmodel: gpt-5.5\nprovider: openai\napproval: never\n",
+        )
+
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/bin/" + c)
+    monkeypatch.setattr(agents.proc, "run", fake_run)
+
+    roster = Roster(
+        orchestrator="chef",
+        agents={
+            "chef": Agent("chef", "codex", "plan and synthesize"),
+            "coder": Agent("coder", "ollama:llama3.3", "write code"),
+        },
+        max_workers=1,
+        codex_transport="app-server",
+    )
+    with pytest.raises(
+        RuntimeError,
+        match=r"orchestrator seat 'chef'.*transport='app-server'.*stdin",
+    ) as exc:
+        aboyeur.plan("build feature", roster, codex_transport="app-server")
+    assert "Reading additional input from stdin" not in str(exc.value)

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -8,7 +8,7 @@ from brigade import agents
 
 def test_build_argv_for_known_clis():
     assert agents.build_argv("claude", "hi") == ["claude", "-p", "hi"]
-    assert agents.build_argv("codex", "hi") == ["codex", "exec", "hi"]
+    assert agents.build_argv("codex", "hi") == ["codex", "exec", "-"]
     assert agents.build_argv("opencode", "hi") == ["opencode", "run", "hi"]
     assert agents.build_argv("antigravity", "hi") == [
         "agy",
@@ -54,7 +54,7 @@ def test_build_argv_for_read_only_codex():
         "exec",
         "--sandbox",
         "read-only",
-        "hi",
+        "-",
     ]
     assert agents.build_argv("claude", "hi", read_only=True) == ["claude", "-p", "hi"]
     assert agents.build_argv("opencode", "hi", read_only=True) == ["opencode", "run", "hi"]
@@ -224,14 +224,14 @@ def test_build_argv_can_set_codex_sandbox():
         "exec",
         "--sandbox",
         "danger-full-access",
-        "hi",
+        "-",
     ]
     assert agents.build_argv("codex", "hi", read_only=True, sandbox="workspace-write") == [
         "codex",
         "exec",
         "--sandbox",
         "workspace-write",
-        "hi",
+        "-",
     ]
 
 
@@ -253,7 +253,7 @@ def test_build_argv_pins_model_for_claude_and_codex():
         "exec",
         "-m",
         "gpt-5.5-codex",
-        "hi",
+        "-",
     ]
     assert agents.build_argv("codex", "hi", read_only=True, model="gpt-5.5-codex") == [
         "codex",
@@ -262,7 +262,7 @@ def test_build_argv_pins_model_for_claude_and_codex():
         "read-only",
         "-m",
         "gpt-5.5-codex",
-        "hi",
+        "-",
     ]
     assert agents.build_argv("codex", "hi", sandbox="workspace-write", model="gpt-5.5-codex") == [
         "codex",
@@ -271,13 +271,13 @@ def test_build_argv_pins_model_for_claude_and_codex():
         "workspace-write",
         "-m",
         "gpt-5.5-codex",
-        "hi",
+        "-",
     ]
 
 
 def test_build_argv_without_model_is_unchanged():
     assert agents.build_argv("claude", "hi", model=None) == ["claude", "-p", "hi"]
-    assert agents.build_argv("codex", "hi", model=None) == ["codex", "exec", "hi"]
+    assert agents.build_argv("codex", "hi", model=None) == ["codex", "exec", "-"]
 
 
 def test_build_argv_model_on_unsupported_cli_raises():
@@ -610,10 +610,57 @@ def test_run_agent_forwards_model_to_argv(monkeypatch):
     assert captured["argv"] == ["claude", "--model", "claude-fable-5", "-p", "hi"]
 
 
+def test_run_agent_codex_feeds_prompt_on_stdin(monkeypatch):
+    """codex exec must take the prompt on stdin (`-`), not as a trailing argv token.
+
+    Codex 0.144+ treats a non-TTY open stdin as optional append input and can
+    hang on 'Reading additional input from stdin...' when the prompt is only
+    passed as an argument.
+    """
+    captured = {}
+
+    def fake_run(argv, **kw):
+        captured["argv"] = argv
+        captured["stdin"] = kw.get("stdin")
+        return agents.proc.Result(0, "answer", "")
+
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(agents.proc, "run", fake_run)
+    res = agents.run_agent("codex", "plan this task", model="gpt-5.5", read_only=True)
+    assert res.ok is True
+    assert captured["argv"] == [
+        "codex",
+        "exec",
+        "--sandbox",
+        "read-only",
+        "-m",
+        "gpt-5.5",
+        "-",
+    ]
+    assert captured["stdin"] == b"plan this task"
+
+
+def test_run_agent_maps_codex_stdin_hang_banner(monkeypatch):
+    def fake_run(argv, **kw):
+        return agents.proc.Result(
+            124,
+            "",
+            "Reading additional input from stdin...\nOpenAI Codex v0.144.5\n--------\n",
+        )
+
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(agents.proc, "run", fake_run)
+    res = agents.run_agent("codex", "hi")
+    assert res.ok is False
+    assert "Reading additional input from stdin" not in res.detail
+    assert "stdin" in res.detail.lower()
+    assert "codex" in res.detail.lower()
+
+
 @pytest.mark.parametrize(
     ("cli_ref", "expected"),
     [
-        ("codex", ["codex", "exec", "-c", 'model_reasoning_effort="xhigh"', "hi"]),
+        ("codex", ["codex", "exec", "-c", 'model_reasoning_effort="xhigh"', "-"]),
         ("opencode", ["opencode", "run", "--variant", "xhigh", "hi"]),
         ("pi", ["pi", "--thinking", "xhigh", "-p", "hi"]),
         ("grok", ["grok", "--reasoning-effort", "xhigh", "-p", "hi", "--always-approve"]),

--- a/tests/test_agents_model_pin.py
+++ b/tests/test_agents_model_pin.py
@@ -162,7 +162,7 @@ def test_claude_and_codex_argv_unchanged_by_registry():
         "exec",
         "-m",
         "gpt-5.5-codex",
-        "P",
+        "-",
     ]
     assert agents.build_argv("codex", "P", read_only=True, model="gpt-5.5-codex") == [
         "codex",
@@ -171,7 +171,7 @@ def test_claude_and_codex_argv_unchanged_by_registry():
         "read-only",
         "-m",
         "gpt-5.5-codex",
-        "P",
+        "-",
     ]
 
 

--- a/tests/test_proc.py
+++ b/tests/test_proc.py
@@ -51,3 +51,30 @@ def test_run_preserves_partial_output_on_timeout(monkeypatch):
     assert result.code == 124
     assert result.stdout == "partial stdout\n"
     assert result.stderr == "partial stderr\ntimeout after 3.0s"
+
+
+def test_run_feeds_stdin_when_provided(monkeypatch):
+    captured = {}
+
+    def fake_run(*args, **kwargs):
+        captured.update(kwargs)
+        return subprocess.CompletedProcess(args=kwargs.get("args") or args, returncode=0, stdout=b"ok\n", stderr=b"")
+
+    monkeypatch.setattr(proc.subprocess, "run", fake_run)
+    result = proc.run(["codex", "exec", "-"], stdin=b"plan prompt")
+    assert result.code == 0
+    assert captured["input"] == b"plan prompt"
+    assert "stdin" not in captured
+
+
+def test_run_uses_devnull_stdin_when_stdin_omitted(monkeypatch):
+    captured = {}
+
+    def fake_run(*args, **kwargs):
+        captured.update(kwargs)
+        return subprocess.CompletedProcess(args=kwargs.get("args") or args, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(proc.subprocess, "run", fake_run)
+    proc.run(["true"])
+    assert captured["stdin"] is subprocess.DEVNULL
+    assert "input" not in captured


### PR DESCRIPTION
Closes #325.

Codex CLI 0.144+ treats a non-TTY open stdin as optional append input. Brigade passed the plan prompt as a trailing argv token to 'codex exec', so orchestrator planning could block on 'Reading additional input from stdin...' before any worker dispatched. Both transports were affected because plan always routes through exec (app-server is workers-only).

Changes:
- 'codex exec -' with the prompt piped on stdin ('proc.run' grew an 'input' parameter; only the codex path uses it).
- If the stdin-hang banner still surfaces, the error is rewritten to name the orchestrator seat and transport instead of dumping the raw codex banner ('codex_stdin_hang_detail' in agents.py, applied in the orchestrator failure path).
- The plan path threads 'codex_transport' through so the error can report it.

Verification: 'pytest tests/test_agents.py tests/test_agents_model_pin.py tests/test_proc.py tests/test_aboyeur.py -q' passes (152 tests) through captured verify. The drafting run also probed the live behavior: 'codex exec' with a prompt arg and open non-TTY stdin reproduces the hang banner, 'codex exec -' with the prompt on stdin does not.

Note: implemented by a brigade run worker seat in a detached worktree, reviewed and applied from changes.patch.