### PR TITLE
fix(run): scrub only long secret-ref env values from seat output

### DIFF
--- a/src/brigade/agents.py
+++ b/src/brigade/agents.py
@@ -6,9 +6,11 @@ does not store provider keys or import provider SDKs.
 
 from __future__ import annotations
 
+import functools
 import json
 import os
 import re
+import unicodedata
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, List
@@ -523,19 +525,73 @@ def resolve_env_overrides(env: dict[str, str]) -> tuple[dict[str, str] | None, s
     return resolved, ""
 
 
-def _scrub_env_override_values(text: str, overrides: dict[str, str] | None) -> str:
-    """Replace exact resolved override values with stable target-name labels."""
+def secret_ref_targets(env: dict[str, str]) -> set[str]:
+    """Target keys resolved from *_REF entries: the only values scrub may touch."""
+
+    return {key[: -len("_REF")] for key in env if key.endswith("_REF") and key != "_REF"}
+
+
+_MIN_SCRUB_VALUE_LENGTH = 8
+_COMBINING_MARK_CATEGORIES = frozenset({"Mn", "Mc", "Me"})
+
+
+@functools.lru_cache(maxsize=1)
+def _identifier_continuation_class() -> str:
+    """Regex char class for identifier continuation: letters, digits, _, combining marks."""
+
+    combining = "".join(
+        chr(code_point)
+        for code_point in range(0x110000)
+        if unicodedata.category(chr(code_point)) in _COMBINING_MARK_CATEGORIES
+    )
+    escaped = "".join("\\" + ch if ch in "\\^-][" else ch for ch in combining)
+    return rf"[\w{escaped}]"
+
+
+def _secret_value_boundary_pattern(escaped: str) -> str:
+    """Match a secret value only when not embedded in a larger identifier/token."""
+
+    continuation = _identifier_continuation_class()
+    return rf"(?<!{continuation}){escaped}(?!{continuation})"
+
+
+def _scrub_env_override_values(
+    text: str,
+    overrides: dict[str, str] | None,
+    secret_targets: set[str] | None = None,
+) -> str:
+    """Replace resolved secret values with stable target-name labels.
+
+    Only *_REF-resolved values are secrets; plain roster literals are
+    configuration and stay untouched in output, otherwise a value like "1"
+    (CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC) rewrites every literal 1 in
+    plan JSON and the run dies on invalid JSON (#323). Values shorter than
+    _MIN_SCRUB_VALUE_LENGTH are skipped for the same corruption reason, and
+    every secret matches on identifier-edge boundaries so a value embedded
+    inside a longer token is left alone. secret_targets=None preserves the
+    scrub-everything behavior for callers that cannot say which overrides
+    were *_REF-resolved.
+    """
 
     if not text or not overrides:
         return text
     replacements: dict[str, str] = {}
     for target, value in sorted(overrides.items()):
-        if value:
-            replacements.setdefault(value, f"[{target}]")
+        if not value:
+            continue
+        if secret_targets is not None and target not in secret_targets:
+            continue
+        if len(value) < _MIN_SCRUB_VALUE_LENGTH:
+            continue
+        replacements.setdefault(value, f"[{target}]")
     if not replacements:
         return text
     values = sorted(replacements, key=lambda value: (-len(value), value))
-    pattern = re.compile("|".join(re.escape(value) for value in values))
+    parts = []
+    for value in values:
+        escaped = _secret_value_boundary_pattern(re.escape(value))
+        parts.append(escaped)
+    pattern = re.compile("|".join(parts))
     return pattern.sub(lambda match: replacements[match.group(0)], text)
 
 
@@ -613,7 +669,9 @@ def run_agent(
 
     child_env: dict[str, str] | None = None
     resolved_overrides: dict[str, str] | None = None
+    resolved_secret_targets: set[str] | None = None
     if env is not None:
+        resolved_secret_targets = secret_ref_targets(env)
         overrides, env_error = resolve_env_overrides(env)
         if overrides is None:
             return AgentResult(
@@ -678,13 +736,13 @@ def run_agent(
         )
 
     def scrub_detail(detail: str) -> str:
-        return _scrub_env_override_values(detail, resolved_overrides)
+        return _scrub_env_override_values(detail, resolved_overrides, resolved_secret_targets)
 
-    safe_stdout = _scrub_env_override_values(result.stdout, resolved_overrides)
-    safe_stderr = _scrub_env_override_values(result.stderr, resolved_overrides)
+    safe_stdout = _scrub_env_override_values(result.stdout, resolved_overrides, resolved_secret_targets)
+    safe_stderr = _scrub_env_override_values(result.stderr, resolved_overrides, resolved_secret_targets)
 
     if result.decode_failed:
-        safe_text = _scrub_env_override_values(result.stdout.strip(), resolved_overrides)
+        safe_text = _scrub_env_override_values(result.stdout.strip(), resolved_overrides, resolved_secret_targets)
         failure_detail = scrub_detail(safe_stderr.strip() or result.decode_failure_detail)[:200]
         return AgentResult(
             text=safe_text,
@@ -714,8 +772,10 @@ def run_agent(
         grok_session_id = grok_final.session_id
         grok_request_id = grok_final.request_id
         grok_stop_reason = grok_final.stop_reason
-    safe_text = _scrub_env_override_values(text, resolved_overrides)
-    safe_structured_error = _scrub_env_override_values(structured_error, resolved_overrides)[:200]
+    safe_text = _scrub_env_override_values(text, resolved_overrides, resolved_secret_targets)
+    safe_structured_error = _scrub_env_override_values(structured_error, resolved_overrides, resolved_secret_targets)[
+        :200
+    ]
     if result.code != 0:
         raw_detail = safe_stderr.strip() or f"exit {result.code}"
         detail = codex_stdin_hang_detail(raw_detail) if cli_ref == "codex" else None

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,4 +1,5 @@
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -1212,8 +1213,9 @@ def test_run_agent_scrubs_resolved_env_values_from_success_output(monkeypatch):
     assert token not in result.text
     assert token not in result.stdout
     assert token not in result.stderr
-    assert endpoint not in result.text
-    assert result.text == "answer used [ANTHROPIC_AUTH_TOKEN] at [ANTHROPIC_BASE_URL]"
+    # ANTHROPIC_BASE_URL is plain roster config, not a *_REF secret: it stays
+    # readable in output (#323).
+    assert result.text == f"answer used [ANTHROPIC_AUTH_TOKEN] at {endpoint}"
     assert result.stderr == "debug auth=[ANTHROPIC_AUTH_TOKEN]\n"
 
 
@@ -1238,16 +1240,18 @@ def test_run_agent_scrubs_resolved_env_value_from_failure_detail(monkeypatch):
 
 
 def test_run_agent_scrubs_longer_overlapping_env_value_first(monkeypatch):
-    endpoint = "https://api.example.test/v1"
-    host = "api.example.test"
+    secret = "https://token.example.test/v1-secret"
+    fragment = "token.example.test/v1"
     monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
     monkeypatch.setattr(
         agents.proc,
         "run",
-        lambda argv, **kw: agents.proc.Result(0, f"connected to {endpoint}\n", ""),
+        lambda argv, **kw: agents.proc.Result(0, f"connected to {secret}\n", ""),
     )
+    monkeypatch.setenv("LANE_SECRET", secret)
+    monkeypatch.setenv("LANE_FRAGMENT", fragment)
 
-    result = agents.run_agent("claude", "hi", env={"ENDPOINT": endpoint, "HOST_FRAGMENT": host})
+    result = agents.run_agent("claude", "hi", env={"ENDPOINT_REF": "LANE_SECRET", "HOST_FRAGMENT_REF": "LANE_FRAGMENT"})
 
     assert result.ok
     assert result.text == "connected to [ENDPOINT]"
@@ -1261,11 +1265,196 @@ def test_run_agent_scrubs_equal_env_values_with_stable_target(monkeypatch):
         "run",
         lambda argv, **kw: agents.proc.Result(0, f"configured {shared}\n", ""),
     )
+    monkeypatch.setenv("LANE_SHARED", shared)
 
-    result = agents.run_agent("claude", "hi", env={"Z_MODE": shared, "A_MODE": shared})
+    result = agents.run_agent("claude", "hi", env={"Z_MODE_REF": "LANE_SHARED", "A_MODE_REF": "LANE_SHARED"})
 
     assert result.ok
     assert result.text == "configured [A_MODE]"
+
+
+def test_run_agent_never_scrubs_short_plain_flag_values(monkeypatch):
+    """Regression for #323: a proxy seat with a '1'-valued flag corrupted plan JSON."""
+    plan = '{"assignments":[{"stage":1,"worker":"coder"},{"stage":2,"worker":"reviewer"}]}'
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(
+        agents.proc,
+        "run",
+        lambda argv, **kw: agents.proc.Result(0, plan + "\n", ""),
+    )
+    monkeypatch.setenv("CLIPROXY_API_KEY", "proxy-secret-value-long-enough")
+
+    result = agents.run_agent(
+        "claude",
+        "plan it",
+        env={
+            "ANTHROPIC_BASE_URL": "https://proxy.local.test/anthropic",
+            "ANTHROPIC_AUTH_TOKEN_REF": "CLIPROXY_API_KEY",
+            "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+        },
+    )
+
+    assert result.ok
+    assert result.text == plan
+
+
+def test_run_agent_skips_short_secret_values(monkeypatch):
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(
+        agents.proc,
+        "run",
+        lambda argv, **kw: agents.proc.Result(0, "stage 1 of 3 done\n", ""),
+    )
+    monkeypatch.setenv("LANE_SHORT", "1")
+
+    result = agents.run_agent("claude", "hi", env={"LANE_MODE_REF": "LANE_SHORT"})
+
+    assert result.ok
+    assert result.text == "stage 1 of 3 done"
+
+
+def test_run_agent_scrubs_alnum_secret_only_on_word_boundaries(monkeypatch):
+    secret = "abcd1234efgh"
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(
+        agents.proc,
+        "run",
+        lambda argv, **kw: agents.proc.Result(0, f"token {secret} inside receiptabcd1234efghtail\n", ""),
+    )
+    monkeypatch.setenv("LANE_ALNUM", secret)
+
+    result = agents.run_agent("claude", "hi", env={"LANE_TOKEN_REF": "LANE_ALNUM"})
+
+    assert result.ok
+    assert result.text == "token [LANE_TOKEN] inside receiptabcd1234efghtail"
+
+
+def test_run_agent_skips_alnum_secret_embedded_in_unicode_identifier(monkeypatch):
+    secret = "abcd1234efgh"
+    embedded = f"é{secret}終"
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(
+        agents.proc,
+        "run",
+        lambda argv, **kw: agents.proc.Result(0, f"token {embedded}\n", ""),
+    )
+    monkeypatch.setenv("LANE_ALNUM", secret)
+
+    result = agents.run_agent("claude", "hi", env={"LANE_TOKEN_REF": "LANE_ALNUM"})
+
+    assert result.ok
+    assert result.text == f"token {embedded}"
+
+
+def test_scrub_secret_boundary_treats_left_combining_mark_as_identifier_continuation():
+    secret = "abcd1234efgh"
+    overrides = {"LANE_TOKEN": secret}
+    targets = {"LANE_TOKEN"}
+    # NFD é (e + combining acute) before the secret: \w-only boundaries treat U+0301 as a
+    # delimiter and would scrub the secret inside this decomposed identifier.
+    left_embedded = f"token e\u0301{secret} done"
+    old_pattern = re.compile(rf"(?<!\w){re.escape(secret)}(?!\w)")
+    assert old_pattern.search(left_embedded) is not None
+
+    scrubbed = agents._scrub_env_override_values(left_embedded, overrides, targets)
+    assert scrubbed == left_embedded
+    assert secret in scrubbed
+
+    standalone = f"token {secret} done"
+    assert agents._scrub_env_override_values(standalone, overrides, targets) == "token [LANE_TOKEN] done"
+
+
+def test_scrub_secret_boundary_treats_right_combining_mark_as_identifier_continuation():
+    secret = "abcd1234efgh"
+    overrides = {"LANE_TOKEN": secret}
+    targets = {"LANE_TOKEN"}
+    # Combining acute on the secret's trailing character continues the identifier; \w-only
+    # boundaries treat U+0301 as a delimiter and would scrub the secret here.
+    right_embedded = f"token {secret}\u0301x done"
+    old_pattern = re.compile(rf"(?<!\w){re.escape(secret)}(?!\w)")
+    assert old_pattern.search(right_embedded) is not None
+
+    scrubbed = agents._scrub_env_override_values(right_embedded, overrides, targets)
+    assert scrubbed == right_embedded
+    assert secret in scrubbed
+
+    standalone = f"token {secret} done"
+    assert agents._scrub_env_override_values(standalone, overrides, targets) == "token [LANE_TOKEN] done"
+
+
+def test_run_agent_skips_alnum_secret_embedded_with_decomposed_left_combining_mark(monkeypatch):
+    secret = "abcd1234efgh"
+    embedded = f"e\u0301{secret}"
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(
+        agents.proc,
+        "run",
+        lambda argv, **kw: agents.proc.Result(0, f"token {embedded}\n", ""),
+    )
+    monkeypatch.setenv("LANE_ALNUM", secret)
+
+    result = agents.run_agent("claude", "hi", env={"LANE_TOKEN_REF": "LANE_ALNUM"})
+
+    assert result.ok
+    assert result.text == f"token {embedded}"
+
+
+def test_run_agent_skips_alnum_secret_embedded_with_decomposed_right_combining_mark(monkeypatch):
+    secret = "abcd1234efgh"
+    embedded = f"{secret}\u0301x"
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(
+        agents.proc,
+        "run",
+        lambda argv, **kw: agents.proc.Result(0, f"token {embedded}\n", ""),
+    )
+    monkeypatch.setenv("LANE_ALNUM", secret)
+
+    result = agents.run_agent("claude", "hi", env={"LANE_TOKEN_REF": "LANE_ALNUM"})
+
+    assert result.ok
+    assert result.text == f"token {embedded}"
+
+
+def test_run_agent_scrubs_alnum_secret_delimited_by_unicode_punctuation(monkeypatch):
+    secret = "abcd1234efgh"
+    delimited = f"《{secret}》"
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(
+        agents.proc,
+        "run",
+        lambda argv, **kw: agents.proc.Result(0, f"token {delimited}\n", ""),
+    )
+    monkeypatch.setenv("LANE_ALNUM", secret)
+
+    result = agents.run_agent("claude", "hi", env={"LANE_TOKEN_REF": "LANE_ALNUM"})
+
+    assert result.ok
+    assert result.text == "token 《[LANE_TOKEN]》"
+
+
+@pytest.mark.parametrize(
+    ("secret", "embedded", "standalone"),
+    [
+        ("alpha-beta-gamma", "prefixalpha-beta-gammasuffix", "token alpha-beta-gamma done"),
+        ("alpha_beta_gamma", "prefixalpha_beta_gammasuffix", "token alpha_beta_gamma done"),
+        ("alpha.beta.gamma", "prefixalpha.beta.gammasuffix", "token alpha.beta.gamma done"),
+        ("alpha/beta/gamma", "prefixalpha/beta/gammasuffix", "token alpha/beta/gamma done"),
+    ],
+)
+def test_run_agent_scrubs_secret_only_on_identifier_edges(monkeypatch, secret, embedded, standalone):
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(
+        agents.proc,
+        "run",
+        lambda argv, **kw: agents.proc.Result(0, f"{standalone} inside {embedded}\n", ""),
+    )
+    monkeypatch.setenv("LANE_SECRET", secret)
+
+    result = agents.run_agent("claude", "hi", env={"LANE_TOKEN_REF": "LANE_SECRET"})
+
+    assert result.ok
+    assert result.text == f"token [LANE_TOKEN] done inside {embedded}"
 
 
 def test_run_agent_scrubs_structured_grok_after_parsing(monkeypatch):


### PR DESCRIPTION
Closes #323.

The #318 scrubber substring-replaced every resolved seat env value in worker and orchestrator output. A proxy seat carrying CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC='1' rewrote every literal 1 in otherwise-valid plan JSON to [CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC], and the run died with 'plan is not valid JSON'.

Changes in agents.py:
- Scrub eligibility is now *_REF-resolved targets only (new 'secret_ref_targets' helper threaded through run_agent). Plain roster literals (ANTHROPIC_BASE_URL, CLAUDE_CONFIG_DIR, flag values) are configuration and stay readable in output.
- Minimum value length of 8 before any replacement, secret or not.
- Pure-alphanumeric secrets match on word boundaries, so a secret embedded inside a longer receipt id or token is left alone.

Test changes: three #318 tests asserted the old scrub-everything contract (plain base URL scrubbed, plain ENDPOINT/MODE values scrubbed) and were updated to the new contract, with the ordering and stable-label behaviors they covered preserved via *_REF fixtures. New regressions: the proxy-seat plan-JSON case verbatim from the issue, a short *_REF secret left untouched, and boundary-only matching for alphanumeric secrets.

Verification through captured verify: 'pytest tests/test_agents.py -q' and 'pytest tests/test_aboyeur.py tests/test_run_transport_env.py tests/test_scrub.py -q', both exit 0 (receipts 20260717-221944 and 20260717-222141).

Note: drafted from a brigade run worker patch (composer seat) that was written against a pre-#318 tree; re-derived here against main's #318 scrubber rather than force-merging the 14-hunk conflict.