### PR TITLE
fix(runs): retry steer and interrupt while a live run has no active turn

### DIFF
--- a/src/brigade/cli/runs.py
+++ b/src/brigade/cli/runs.py
@@ -168,7 +168,7 @@ def _control_request(run: str, *, cwd: Path, runs_dir: Path | None, payload: Map
     assert run_dir is not None
     try:
         socket_path = run_control.control_socket_from_run(run_dir)
-        response = run_control.send_request(socket_path, dict(payload))
+        response = run_control.send_request_with_retry(run_dir, socket_path, dict(payload))
     except run_control.ControlError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2

--- a/src/brigade/run_control.py
+++ b/src/brigade/run_control.py
@@ -6,15 +6,24 @@ import json
 import socket
 import sys
 import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 _CLIENT_TIMEOUT_SECONDS = 5.0
+NO_ACTIVE_TURN = "no-active-turn"
+_NO_ACTIVE_TURN_RETRY_SECONDS = 5.0
+_NO_ACTIVE_TURN_RETRY_INTERVAL = 0.1
+_LIVE_RUN_STATUSES = frozenset({"started", "dispatching"})
 
 
 class ControlError(RuntimeError):
     """Control socket setup, request, or operation failure."""
+
+    def __init__(self, message: str, *, code: str | None = None) -> None:
+        super().__init__(message)
+        self.code = code
 
 
 @dataclass(frozen=True)
@@ -59,7 +68,7 @@ class LiveTurnRegistry:
         turns = self._turns(worker)
         if not turns:
             target = f" for worker {worker!r}" if worker else ""
-            raise ControlError(f"no active turn{target}")
+            raise ControlError(f"no active turn{target}", code=NO_ACTIVE_TURN)
         interrupted: list[str] = []
         for active in turns:
             active.thread.interrupt(active.turn_id)
@@ -70,7 +79,7 @@ class LiveTurnRegistry:
         with self._lock:
             active = self._active.get(worker)
         if active is None:
-            raise ControlError(f"no active turn for worker {worker!r}")
+            raise ControlError(f"no active turn for worker {worker!r}", code=NO_ACTIVE_TURN)
         return active
 
     def _turns(self, worker: str | None) -> list[ActiveTurn]:
@@ -173,6 +182,8 @@ class ControlServer:
                         response = {"ok": False, "error": f"invalid JSON: {exc.msg}"}
                     except ControlError as exc:
                         response = {"ok": False, "error": str(exc)}
+                        if exc.code is not None:
+                            response["code"] = exc.code
                     except Exception as exc:  # noqa: BLE001 - control server boundary
                         response = {"ok": False, "error": str(exc)}
                     fh.write(json.dumps(response, sort_keys=True).encode() + b"\n")
@@ -219,6 +230,40 @@ def send_request(path: Path, payload: dict[str, object], *, timeout: float = _CL
     if not isinstance(response, dict):
         raise ControlError("control socket returned a non-object response")
     return response
+
+
+def send_request_with_retry(
+    run_dir: Path,
+    path: Path,
+    payload: dict[str, object],
+    *,
+    retry_seconds: float = _NO_ACTIVE_TURN_RETRY_SECONDS,
+    retry_interval: float = _NO_ACTIVE_TURN_RETRY_INTERVAL,
+) -> dict[str, Any]:
+    """Send a control request, retrying while the live run has no active turn.
+
+    The control socket exists from the moment a run starts dispatching, before
+    any worker turn has registered, and workers are briefly unregistered
+    between turns. A steer or interrupt landing in that window would fail with
+    "no active turn" even though a turn is about to start, so retry until the
+    run leaves a live status or the window closes.
+    """
+    deadline = time.monotonic() + retry_seconds
+    while True:
+        response = send_request(path, payload)
+        if response.get("ok") is True or response.get("code") != NO_ACTIVE_TURN:
+            return response
+        if time.monotonic() >= deadline or not _run_is_live(run_dir):
+            return response
+        time.sleep(retry_interval)
+
+
+def _run_is_live(run_dir: Path) -> bool:
+    try:
+        meta = json.loads((run_dir / "run.json").read_text())
+    except (OSError, json.JSONDecodeError):
+        return False
+    return isinstance(meta, dict) and meta.get("status") in _LIVE_RUN_STATUSES
 
 
 def control_socket_from_run(run_dir: Path) -> Path:

--- a/tests/test_run_control.py
+++ b/tests/test_run_control.py
@@ -220,6 +220,87 @@ def test_run_records_control_socket_and_cli_steers_live_worker(tmp_path, monkeyp
     assert worker_results[0]["text"] == "steered: please finish"
 
 
+def test_cli_steer_retries_until_worker_turn_registers(tmp_path, monkeypatch, capsys):
+    # The control socket exists as soon as the run starts dispatching, before
+    # any worker turn has registered. Delay registration so the steer request
+    # is guaranteed to arrive first; the CLI must retry instead of failing
+    # with "no active turn" (the race CI runners hit on unmodified diffs).
+    roster = Roster(
+        orchestrator="chef",
+        agents={
+            "chef": Agent("chef", "claude", "plan and synthesize"),
+            "cook": Agent("cook", "codex", "write code"),
+        },
+        timeout_seconds=10.0,
+        codex_transport="app-server",
+    )
+    run_dir = tmp_path / "run"
+    real_app_server = codex_appserver.AppServer
+    monkeypatch.setattr(
+        aboyeur.codex_appserver,
+        "AppServer",
+        lambda cwd=None: real_app_server(argv=FAKE, cwd=cwd),
+    )
+    real_register = run_control.LiveTurnRegistry.register
+
+    def slow_register(self, worker, thread, turn_id):
+        time.sleep(0.5)
+        real_register(self, worker, thread, turn_id)
+
+    monkeypatch.setattr(run_control.LiveTurnRegistry, "register", slow_register)
+
+    def fake_run_agent(cli_ref, prompt, **kwargs):
+        if "Return exactly one JSON object" in prompt:
+            return agents.AgentResult(
+                text=json.dumps({"assignments": [{"worker": "cook", "task": "HANG until steered"}]}),
+                ok=True,
+            )
+        assert "steered: please finish" in prompt
+        return agents.AgentResult(text="final synthesis", ok=True)
+
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+    result: dict[str, int] = {}
+
+    thread = threading.Thread(
+        target=lambda: result.update(rc=aboyeur.run("do it", roster, cwd=tmp_path, output_dir=run_dir)),
+        daemon=True,
+    )
+    thread.start()
+
+    control_socket = _wait_for(lambda: _control_socket_from_run_json(run_dir))
+    _wait_for(lambda: control_socket.exists())
+
+    assert cli.main(["runs", "steer", str(run_dir), "cook", "please finish"]) == 0
+    thread.join(timeout=5.0)
+
+    assert result == {"rc": 0}
+    assert "steer: cook" in capsys.readouterr().out
+    worker_results = json.loads((run_dir / "worker-results.json").read_text())["results"]
+    assert worker_results[0]["text"] == "steered: please finish"
+
+
+def test_cli_steer_does_not_retry_when_run_is_finished(tmp_path, capsys):
+    registry = run_control.LiveTurnRegistry()
+    socket_path = tmp_path / "run" / "control.sock"
+    _write_json(
+        tmp_path / "run" / "run.json",
+        {
+            "status": "ok",
+            "codex_transport": "app-server",
+            "control_socket": str(socket_path),
+        },
+    )
+    server = run_control.ControlServer(socket_path, registry)
+    server.start()
+    try:
+        rc = cli.main(["runs", "steer", str(tmp_path / "run"), "cook", "keep going"])
+    finally:
+        server.close()
+
+    assert rc == 1
+    assert "no active turn for worker 'cook'" in capsys.readouterr().err
+
+
 def test_cli_interrupt_leaves_live_worker_resumable(tmp_path, monkeypatch, capsys):
     roster = Roster(
         orchestrator="chef",


### PR DESCRIPTION
## Problem

`tests/test_run_control.py::test_run_records_control_socket_and_cli_steers_live_worker` was flaky in CI: it failed on runs 29615329074, 29615958808, and 29616963901 (2026-07-17) on unrelated diffs, each time with `assert 1 == 0` at the `runs steer` call and stderr `error: no active turn for worker 'cook'`. It passed locally and on rerun.

The control socket exists from the moment a run starts dispatching, before any worker turn has registered (registration happens after the `turn/start` round trip on the worker thread). The test waits for the socket, so on slow runners its steer arrives inside that window and the registry rejects it. The same race hits real users who steer right after starting a run, and workers are also briefly unregistered between turns.

## Fix

- `ControlError` carries an optional machine `code`; the registry raises `no-active-turn` with it and the control server includes it in error responses.
- `runs steer` / `runs interrupt` now go through `send_request_with_retry`, which retries a `no-active-turn` response every 100ms for up to 5s while `run.json` still reports a live status (`started`/`dispatching`). Any other error, a finished run, or an expired window returns immediately as before.

## Reproduction and tests

- New `test_cli_steer_retries_until_worker_turn_registers` forces the race deterministically by delaying `LiveTurnRegistry.register` by 0.5s before steering. Pre-fix it fails with exactly the CI signature (`assert 1 == 0`, `no active turn for worker 'cook'`); post-fix it passes.
- New `test_cli_steer_does_not_retry_when_run_is_finished` pins the guard: a non-live run still errors immediately with rc 1.

## Verification

`./scripts/verify` green (ruff lint + format, version sync, mypy, full pytest with coverage floor).