### PR TITLE
fix(acp): preserve finals after late permission prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- ACPX late permission prompts after a completed `end_turn` answer no longer discard the usable final result. Brigade now preserves the terminal text, stdout/stderr, exit code, session/request metadata, and records a typed `transport_warning` while marking the worker `ok` with warning instead of failing the run. Post-permission assistant chunks and permission errors without pre-final text no longer qualify as usable-with-warning. Pre-final permission failures remain failed. Stderr fallback infers late `-32072` only when the stream has no structured JSON-RPC error; any structured error takes precedence over stderr markers. (#277)
+
 ### Added
 - `brigade repos adoption` separates configured harness wiring from observed work-loop use across the local repository fleet. It reports `unwired`, `partial`, `advisory-only`, `enforced-idle`, `active`, `bypassed`, and `stale` rows, correlates Claude session writes with brief, verify, outcome, GraphTrail, MiseLedger, and handoff evidence, exposes fleet denominators and stable JSON monitor keys, and provides a read-only `repair` plan. (#257)
 - `brigade operator checkup` accepts repeatable `--surface` selectors, lists stable surface names with `--list-surfaces`, and provides an `evidence-loop` preset for work receipt integrity and outcome capture, GraphTrail health and receipt deltas, and MiseLedger work-receipt import state. Scoped JSON separates `selected_ready` from unevaluated `overall_ready` and reports selected, skipped, and per-surface elapsed data. The default six-doctor checkup is unchanged. (#256)

--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -1629,6 +1629,7 @@ def _run_payload(
     error: str | None = None,
     failure_phase: str | None = None,
     failure_kind: str | None = None,
+    transport_warning: dict[str, object] | None = None,
     code_graph: CodeGraphBrief | None = None,
     drift_impact: DriftImpactBrief | None = None,
     evidence: EvidenceBrief | None = None,
@@ -1700,6 +1701,8 @@ def _run_payload(
                 "kind": failure_kind or "unknown",
                 "detail": error,
             }
+    if transport_warning is not None:
+        payload["transport_warning"] = dict(transport_warning)
     if codex_transport is not None:
         payload["codex_transport"] = codex_transport
     if control_socket is not None:
@@ -2188,6 +2191,7 @@ def run(
                     context_eval_payload=context_eval_payload,
                     suspected_noop=suspected_noop,
                     worker=worker,
+                    transport_warning=final.transport_warning,
                 ),
             )
         if direct_worker:
@@ -2223,6 +2227,7 @@ def run(
                 context_eval_payload=context_eval_payload,
                 suspected_noop=suspected_noop,
                 worker=worker,
+                transport_warning=direct_result.transport_warning if direct_worker else None,
             ),
         )
     if handoff_inbox is not None:

--- a/src/brigade/acpx_adapter.py
+++ b/src/brigade/acpx_adapter.py
@@ -32,6 +32,12 @@ _PERMISSION_FAILURE = re.compile(
     r"\b(?:permission denied|permission required|not permitted|auto-denied)\b",
     re.IGNORECASE,
 )
+_LATE_PERMISSION_CODE = -32072
+_LATE_PERMISSION_DETAIL = "PERMISSION_PROMPT_UNAVAILABLE"
+_LATE_PERMISSION_MARKER = re.compile(
+    r"PERMISSION_PROMPT_UNAVAILABLE|-32072",
+    re.IGNORECASE,
+)
 _SAFE_STATUS_KEYS = ("hasAccessToken", "hasRefreshToken", "isAuthenticated", "status")
 
 
@@ -168,6 +174,48 @@ def installed_version() -> tuple[str | None, str]:
     return match.group(1), ""
 
 
+def _permission_prompt_diagnostic(error: object) -> dict[str, object] | None:
+    if not isinstance(error, dict):
+        return None
+    if error.get("code") != _LATE_PERMISSION_CODE:
+        return None
+    return {
+        "phase": "post-final",
+        "kind": "permission-prompt-unavailable",
+        "code": _LATE_PERMISSION_CODE,
+        "detail": _LATE_PERMISSION_DETAIL,
+    }
+
+
+def _late_permission_from_stderr(stderr: str, *, prompt_completed: bool) -> dict[str, object] | None:
+    if not prompt_completed or not stderr.strip():
+        return None
+    if not _LATE_PERMISSION_MARKER.search(stderr):
+        return None
+    return {
+        "phase": "post-final",
+        "kind": "permission-prompt-unavailable",
+        "code": _LATE_PERMISSION_CODE,
+        "detail": _LATE_PERMISSION_DETAIL,
+    }
+
+
+def _usable_with_late_permission(parsed: dict[str, Any], warning: dict[str, object]) -> bool:
+    return (
+        parsed.get("stop_reason") == "end_turn"
+        and bool(str(parsed.get("text", "")).strip())
+        and warning.get("phase") == "post-final"
+        and warning.get("kind") == "permission-prompt-unavailable"
+    )
+
+
+def _late_permission_detail(warning: dict[str, object]) -> str:
+    code = warning.get("code")
+    code_text = f"code {code}" if isinstance(code, int) else "code -32072"
+    base = str(warning.get("detail") or "PERMISSION_PROMPT_UNAVAILABLE")
+    return f"late permission prompt unavailable ({code_text}); preserved completed final answer: {base}"[:200]
+
+
 def _objects(stdout: str) -> tuple[list[dict[str, Any]] | None, str]:
     messages: list[dict[str, Any]] = []
     for line_number, line in enumerate(stdout.splitlines(), start=1):
@@ -221,6 +269,10 @@ def parse_stream(stdout: str) -> tuple[dict[str, Any] | None, str]:
     stop_reasons: dict[str, str] = {}
     effective_model: str | None = None
     safe_events: list[dict[str, Any]] = []
+    prompt_completed = False
+    late_permission: dict[str, object] | None = None
+    stream_finalized = False
+    has_structured_jsonrpc_error = False
     for message in messages:
         result = message.get("result")
         if isinstance(result, dict):
@@ -230,6 +282,8 @@ def parse_stream(stdout: str) -> tuple[dict[str, Any] | None, str]:
             stop = result.get("stopReason")
             if isinstance(stop, str) and isinstance(message.get("id"), (str, int)):
                 stop_reasons[str(message["id"])] = stop
+                if request_id is not None and str(message["id"]) == request_id and stop == "end_turn":
+                    prompt_completed = True
         params = message.get("params")
         if isinstance(params, dict):
             candidate_session = params.get("sessionId")
@@ -238,19 +292,29 @@ def parse_stream(stdout: str) -> tuple[dict[str, Any] | None, str]:
             if message.get("method") == "session/prompt" and isinstance(message.get("id"), (str, int)):
                 request_id = str(message["id"])
         update = _update(message)
-        if update is None:
-            continue
-        kind = update.get("sessionUpdate")
-        safe_event: dict[str, Any] = {"type": str(kind or "session_update")}
-        status = update.get("status")
-        if isinstance(status, str):
-            safe_event["status"] = status
-        safe_events.append(safe_event)
-        effective_model = _model_from(update) or effective_model
-        if kind == "agent_message_chunk":
-            content = update.get("content")
-            if isinstance(content, dict) and content.get("type") == "text" and isinstance(content.get("text"), str):
-                text_parts.append(content["text"])
+        if update is not None:
+            kind = update.get("sessionUpdate")
+            safe_event: dict[str, Any] = {"type": str(kind or "session_update")}
+            status = update.get("status")
+            if isinstance(status, str):
+                safe_event["status"] = status
+            safe_events.append(safe_event)
+            effective_model = _model_from(update) or effective_model
+            if not stream_finalized and kind == "agent_message_chunk":
+                content = update.get("content")
+                if isinstance(content, dict) and content.get("type") == "text" and isinstance(content.get("text"), str):
+                    text_parts.append(content["text"])
+        rpc_error = message.get("error")
+        if isinstance(rpc_error, dict):
+            has_structured_jsonrpc_error = True
+        permission_error = _permission_prompt_diagnostic(rpc_error)
+        if permission_error is not None:
+            if prompt_completed:
+                if "".join(text_parts).strip():
+                    late_permission = permission_error
+                stream_finalized = True
+            else:
+                return None, str(permission_error["detail"])
     if request_id is not None:
         stop_reason = stop_reasons.get(request_id)
     elif len(stop_reasons) == 1:
@@ -260,7 +324,7 @@ def parse_stream(stdout: str) -> tuple[dict[str, Any] | None, str]:
     text = "".join(text_parts).strip()
     if not text:
         return None, "ACP stream contained no final assistant text"
-    return {
+    parsed: dict[str, Any] = {
         "text": text,
         "protocol_version": protocol_version or 1,
         "session_id": session_id,
@@ -268,7 +332,12 @@ def parse_stream(stdout: str) -> tuple[dict[str, Any] | None, str]:
         "stop_reason": stop_reason,
         "effective_model": effective_model,
         "events": safe_events,
-    }, ""
+        "prompt_completed": prompt_completed,
+        "has_structured_jsonrpc_error": has_structured_jsonrpc_error,
+    }
+    if late_permission is not None:
+        parsed["late_permission"] = late_permission
+    return parsed, ""
 
 
 def run_cursor(
@@ -370,6 +439,57 @@ def run_cursor(
     result = proc.run(argv, timeout=timeout + 5.0, cwd=cwd)
     parsed, parse_error = parse_stream(result.stdout)
     if result.code != 0:
+        late_warning: dict[str, object] | None = None
+        if parsed is not None:
+            candidate = parsed.get("late_permission")
+            late_warning = candidate if isinstance(candidate, dict) else None
+            if late_warning is None and not parsed.get("has_structured_jsonrpc_error"):
+                late_warning = _late_permission_from_stderr(
+                    result.stderr,
+                    prompt_completed=bool(parsed.get("prompt_completed")),
+                )
+        if parsed is not None and late_warning is not None and _usable_with_late_permission(parsed, late_warning):
+            output_failure = validate_final_output(parsed["text"])
+            if output_failure is not None:
+                return AgentResult(
+                    text=parsed["text"],
+                    ok=False,
+                    detail=output_failure.detail,
+                    failure_phase="output-validation",
+                    failure_kind=output_failure.kind,
+                    stdout=result.stdout,
+                    stderr=result.stderr,
+                    exit_code=result.code,
+                    transport="acpx",
+                    requested_model=model,
+                    effective_model=parsed["effective_model"],
+                    stop_reason=parsed["stop_reason"],
+                    protocol_version=parsed["protocol_version"],
+                    session_id=parsed["session_id"],
+                    request_id=parsed["request_id"],
+                    acpx_version=installed,
+                    safe_events=(auth_event, *parsed["events"]),
+                    transport_warning=late_warning,
+                )
+            warning_detail = _late_permission_detail(late_warning)
+            return AgentResult(
+                text=parsed["text"],
+                ok=True,
+                detail=warning_detail,
+                stdout=result.stdout,
+                stderr=result.stderr,
+                exit_code=result.code,
+                transport="acpx",
+                requested_model=model,
+                effective_model=parsed["effective_model"],
+                stop_reason=parsed["stop_reason"],
+                protocol_version=parsed["protocol_version"],
+                session_id=parsed["session_id"],
+                request_id=parsed["request_id"],
+                acpx_version=installed,
+                safe_events=(auth_event, *parsed["events"]),
+                transport_warning=late_warning,
+            )
         detail = result.stderr.strip() or parse_error or f"acpx exit {result.code}"
         timed_out = result.code in {3, 124}
         provider_startup = parsed is None
@@ -395,6 +515,10 @@ def run_cursor(
             transport="acpx",
             requested_model=model,
             effective_model=parsed.get("effective_model") if parsed is not None else None,
+            stop_reason=parsed.get("stop_reason") if parsed is not None else None,
+            protocol_version=parsed.get("protocol_version") if parsed is not None else None,
+            session_id=parsed.get("session_id") if parsed is not None else None,
+            request_id=parsed.get("request_id") if parsed is not None else None,
             acpx_version=installed,
             safe_events=(auth_event, *(parsed["events"] if parsed is not None else [])),
         )

--- a/src/brigade/agents.py
+++ b/src/brigade/agents.py
@@ -335,6 +335,7 @@ class AgentResult:
     safe_events: tuple[dict[str, object], ...] = ()
     failure_phase: str | None = None
     failure_kind: str | None = None
+    transport_warning: dict[str, object] | None = None
 
 
 def is_known(cli_ref: str) -> bool:

--- a/src/brigade/run_receipts.py
+++ b/src/brigade/run_receipts.py
@@ -38,6 +38,8 @@ def worker_payload(results: list[WorkerResult]) -> list[dict[str, object]]:
             entry["failure_phase"] = result.failure_phase
         if result.failure_kind is not None:
             entry["failure_kind"] = result.failure_kind
+        if result.transport_warning is not None:
+            entry["transport_warning"] = dict(result.transport_warning)
         if result.thread_id is not None:
             entry["thread_id"] = result.thread_id
             entry["status"] = result.status
@@ -109,6 +111,8 @@ def agent_result_payload(result: agents.AgentResult) -> dict[str, object]:
         payload["failure_phase"] = result.failure_phase
     if result.failure_kind is not None:
         payload["failure_kind"] = result.failure_kind
+    if result.transport_warning is not None:
+        payload["transport_warning"] = dict(result.transport_warning)
     if result.exit_code is not None:
         payload["exit_code"] = result.exit_code
         payload["timed_out"] = result.timed_out
@@ -143,6 +147,7 @@ def agent_result_from_worker(result: WorkerResult) -> agents.AgentResult:
         detail=result.detail,
         failure_phase=result.failure_phase,
         failure_kind=result.failure_kind,
+        transport_warning=result.transport_warning,
         thread_id=result.thread_id,
         status=result.status,
         stdout=result.stdout,

--- a/src/brigade/run_transport.py
+++ b/src/brigade/run_transport.py
@@ -165,6 +165,7 @@ class WorkerResult:
     safe_events: tuple[dict[str, object], ...] = ()
     failure_phase: str | None = None
     failure_kind: str | None = None
+    transport_warning: dict[str, object] | None = None
     env_overrides: tuple[str, ...] = ()
     endpoint_host: str | None = None
     attempts: tuple[WorkerAttempt, ...] = ()
@@ -414,6 +415,7 @@ def dispatch(
                 detail=result.detail,
                 failure_phase=result.failure_phase,
                 failure_kind=result.failure_kind,
+                transport_warning=result.transport_warning,
                 thread_id=result.thread_id,
                 status=result.status,
                 stdout=result.stdout,

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -1679,6 +1679,156 @@ def test_direct_acpx_auth_failure_reaches_worker_run_receipt_and_human_summary(m
     }
 
 
+def test_direct_acpx_late_permission_preserves_final_in_artifacts(monkeypatch, tmp_path):
+    from brigade import acpx_adapter
+
+    final_text = "Actionable review findings."
+    warning = {
+        "phase": "post-final",
+        "kind": "permission-prompt-unavailable",
+        "code": -32072,
+        "detail": "PERMISSION_PROMPT_UNAVAILABLE",
+    }
+
+    def fake_cursor(prompt, **kwargs):
+        return agents.AgentResult(
+            text=final_text,
+            ok=True,
+            detail="late permission prompt unavailable (code -32072); preserved completed final answer",
+            stdout="acp stdout preserved",
+            stderr="PERMISSION_PROMPT_UNAVAILABLE",
+            exit_code=5,
+            transport="acpx",
+            requested_model="composer-2.5",
+            effective_model="composer-2.5",
+            stop_reason="end_turn",
+            protocol_version=1,
+            session_id="session-1",
+            request_id="req-1",
+            acpx_version="0.12.0",
+            transport_warning=warning,
+        )
+
+    monkeypatch.setattr(acpx_adapter, "run_cursor", fake_cursor)
+    roster = Roster(
+        orchestrator="chef",
+        agents={
+            "chef": Agent("chef", "codex", "plan"),
+            "composer": Agent(
+                "composer",
+                "cursor",
+                "review",
+                model="composer-2.5",
+                transport="acpx",
+                transport_version="0.12.0",
+            ),
+        },
+    )
+    output_dir = tmp_path / "run"
+
+    rc = aboyeur.run(
+        "inspect",
+        roster,
+        worker="composer",
+        cwd=tmp_path,
+        output_dir=output_dir,
+        read_only=True,
+        route_enabled=False,
+    )
+
+    assert rc == 0
+    worker = json.loads((output_dir / "worker-results.json").read_text())["results"][0]
+    assert worker["ok"] is True
+    assert worker["text"] == final_text
+    assert worker["exit_code"] == 5
+    assert worker["stop_reason"] == "end_turn"
+    assert worker["session_id"] == "session-1"
+    assert worker["request_id"] == "req-1"
+    assert worker["transport_warning"] == warning
+    assert (output_dir / worker["stdout_log"]).read_text() == "acp stdout preserved"
+    assert (output_dir / worker["stderr_log"]).read_text() == "PERMISSION_PROMPT_UNAVAILABLE"
+    assert (output_dir / "final.txt").read_text() == f"{final_text}\n"
+    run_payload = json.loads((output_dir / "run.json").read_text())
+    assert run_payload["status"] == "ok"
+    assert run_payload["transport_warning"] == warning
+
+
+def test_direct_acpx_late_permission_output_validation_failure_preserves_warning(monkeypatch, tmp_path):
+    from brigade import acpx_adapter
+
+    final_text = "Reviewing repository files."
+    warning = {
+        "phase": "post-final",
+        "kind": "permission-prompt-unavailable",
+        "code": -32072,
+        "detail": "PERMISSION_PROMPT_UNAVAILABLE",
+    }
+
+    def fake_cursor(prompt, **kwargs):
+        return agents.AgentResult(
+            text=final_text,
+            ok=False,
+            detail="provider returned progress or intent without a final result",
+            stdout="acp stdout preserved",
+            stderr="PERMISSION_PROMPT_UNAVAILABLE",
+            exit_code=5,
+            transport="acpx",
+            requested_model="composer-2.5",
+            effective_model="composer-2.5",
+            stop_reason="end_turn",
+            protocol_version=1,
+            session_id="session-1",
+            request_id="req-1",
+            acpx_version="0.12.0",
+            failure_phase="output-validation",
+            failure_kind="non-final-output",
+            transport_warning=warning,
+        )
+
+    monkeypatch.setattr(acpx_adapter, "run_cursor", fake_cursor)
+    roster = Roster(
+        orchestrator="chef",
+        agents={
+            "chef": Agent("chef", "codex", "plan"),
+            "composer": Agent(
+                "composer",
+                "cursor",
+                "review",
+                model="composer-2.5",
+                transport="acpx",
+                transport_version="0.12.0",
+            ),
+        },
+    )
+    output_dir = tmp_path / "run"
+
+    rc = aboyeur.run(
+        "inspect",
+        roster,
+        worker="composer",
+        cwd=tmp_path,
+        output_dir=output_dir,
+        read_only=True,
+        route_enabled=False,
+    )
+
+    assert rc == 2
+    worker = json.loads((output_dir / "worker-results.json").read_text())["results"][0]
+    assert worker["ok"] is False
+    assert worker["failure_phase"] == "output-validation"
+    assert worker["failure_kind"] == "non-final-output"
+    assert worker["transport_warning"] == warning
+    synthesis = json.loads((output_dir / "synthesis.json").read_text())
+    assert synthesis["mode"] == "direct-worker"
+    assert synthesis["result"]["ok"] is False
+    assert synthesis["result"]["transport_warning"] == warning
+    run_payload = json.loads((output_dir / "run.json").read_text())
+    assert run_payload["status"] == "failed"
+    assert run_payload["failure_phase"] == "output-validation"
+    assert run_payload["transport_warning"] == warning
+    assert (output_dir / "final.txt").read_text().strip() == final_text
+
+
 def test_roster_payload_includes_model():
     payload = aboyeur._roster_payload(_model_roster())
     assert payload["agents"]["architect"]["model"] == "claude-fable-5"

--- a/tests/test_acpx_adapter.py
+++ b/tests/test_acpx_adapter.py
@@ -39,6 +39,78 @@ def _success_stream() -> str:
     )
 
 
+def _late_permission_stream(*, final_text: str = "Complete review findings.") -> str:
+    return _stream(
+        {"jsonrpc": "2.0", "id": "init-1", "result": {"protocolVersion": 1}},
+        {
+            "jsonrpc": "2.0",
+            "id": "req-1",
+            "method": "session/prompt",
+            "params": {"sessionId": "session-1", "prompt": "hidden"},
+        },
+        {
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "session-1",
+                "update": {"sessionUpdate": "agent_message_chunk", "content": {"type": "text", "text": final_text}},
+            },
+        },
+        {"jsonrpc": "2.0", "id": "req-1", "result": {"stopReason": "end_turn"}},
+        {
+            "jsonrpc": "2.0",
+            "id": "perm-1",
+            "error": {"code": -32072, "message": "PERMISSION_PROMPT_UNAVAILABLE"},
+        },
+    )
+
+
+def _malformed_late_permission_chronology_stream() -> str:
+    return _stream(
+        {"jsonrpc": "2.0", "id": "init-1", "result": {"protocolVersion": 1}},
+        {
+            "jsonrpc": "2.0",
+            "id": "req-1",
+            "method": "session/prompt",
+            "params": {"sessionId": "session-1", "prompt": "hidden"},
+        },
+        {"jsonrpc": "2.0", "id": "req-1", "result": {"stopReason": "end_turn"}},
+        {
+            "jsonrpc": "2.0",
+            "id": "perm-1",
+            "error": {"code": -32072, "message": "PERMISSION_PROMPT_UNAVAILABLE"},
+        },
+        {
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "session-1",
+                "update": {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": {"type": "text", "text": "Complete review findings."},
+                },
+            },
+        },
+    )
+
+
+def _prefinal_permission_stream() -> str:
+    return _stream(
+        {"jsonrpc": "2.0", "id": "init-1", "result": {"protocolVersion": 1}},
+        {
+            "jsonrpc": "2.0",
+            "id": "req-1",
+            "method": "session/prompt",
+            "params": {"sessionId": "session-1", "prompt": "hidden"},
+        },
+        {
+            "jsonrpc": "2.0",
+            "id": "perm-1",
+            "error": {"code": -32072, "message": "PERMISSION_PROMPT_UNAVAILABLE"},
+        },
+    )
+
+
 def _authenticated_status() -> acpx_adapter.CursorAuthStatus:
     return acpx_adapter.CursorAuthStatus(
         "authenticated",
@@ -519,3 +591,360 @@ def test_run_distinguishes_timeout_permission_and_provider_startup(monkeypatch, 
     assert startup.exit_code == 7
     assert startup.failure_phase == "dispatch"
     assert startup.failure_kind == "provider-startup"
+
+
+def test_run_preserves_end_turn_final_after_late_permission_prompt(monkeypatch, tmp_path):
+    stream = _late_permission_stream()
+    monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
+    monkeypatch.setattr(acpx_adapter, "cursor_auth_status", _authenticated_status)
+    outputs = iter(
+        [
+            proc.Result(0, "acpx 0.12.0\n", ""),
+            proc.Result(5, stream, "PERMISSION_PROMPT_UNAVAILABLE"),
+        ]
+    )
+    monkeypatch.setattr(acpx_adapter.proc, "run", lambda argv, **kwargs: next(outputs))
+
+    result = acpx_adapter.run_cursor(
+        "inspect", cwd=tmp_path, timeout=120, model="composer-2.5", version="0.12.0", read_only=True
+    )
+
+    assert result.ok is True
+    assert result.text == "Complete review findings."
+    assert result.exit_code == 5
+    assert result.stop_reason == "end_turn"
+    assert result.session_id == "session-1"
+    assert result.request_id == "req-1"
+    assert result.stdout == stream
+    assert result.stderr == "PERMISSION_PROMPT_UNAVAILABLE"
+    assert result.transport_warning == {
+        "phase": "post-final",
+        "kind": "permission-prompt-unavailable",
+        "code": -32072,
+        "detail": "PERMISSION_PROMPT_UNAVAILABLE",
+    }
+    assert "late permission prompt unavailable" in result.detail
+
+
+def test_parse_stream_rejects_post_permission_text_without_prefinal_answer():
+    parsed, error = acpx_adapter.parse_stream(_malformed_late_permission_chronology_stream())
+
+    assert parsed is None
+    assert error == "ACP stream contained no final assistant text"
+
+
+def test_run_rejects_post_permission_text_without_prefinal_answer(monkeypatch, tmp_path):
+    stream = _malformed_late_permission_chronology_stream()
+    monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
+    monkeypatch.setattr(acpx_adapter, "cursor_auth_status", _authenticated_status)
+    outputs = iter(
+        [
+            proc.Result(0, "acpx 0.12.0\n", ""),
+            proc.Result(5, stream, "PERMISSION_PROMPT_UNAVAILABLE"),
+        ]
+    )
+    monkeypatch.setattr(acpx_adapter.proc, "run", lambda argv, **kwargs: next(outputs))
+
+    result = acpx_adapter.run_cursor(
+        "inspect", cwd=tmp_path, timeout=120, model="composer-2.5", version="0.12.0", read_only=True
+    )
+
+    assert result.ok is False
+    assert result.text == ""
+    assert result.exit_code == 5
+    assert result.transport_warning is None
+    assert result.failure_kind == "provider-startup"
+
+
+def test_run_keeps_prefinal_permission_failure_failed(monkeypatch, tmp_path):
+    stream = _prefinal_permission_stream()
+    monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
+    monkeypatch.setattr(acpx_adapter, "cursor_auth_status", _authenticated_status)
+    outputs = iter(
+        [
+            proc.Result(0, "acpx 0.12.0\n", ""),
+            proc.Result(5, stream, "PERMISSION_PROMPT_UNAVAILABLE"),
+        ]
+    )
+    monkeypatch.setattr(acpx_adapter.proc, "run", lambda argv, **kwargs: next(outputs))
+
+    result = acpx_adapter.run_cursor(
+        "inspect", cwd=tmp_path, timeout=120, model="composer-2.5", version="0.12.0", read_only=True
+    )
+
+    assert result.ok is False
+    assert result.text == ""
+    assert result.exit_code == 5
+    assert result.failure_kind == "provider-startup"
+    assert result.transport_warning is None
+
+
+def test_permission_prompt_diagnostic_requires_exact_code():
+    assert acpx_adapter._permission_prompt_diagnostic({"code": -32072, "message": "PERMISSION_PROMPT_UNAVAILABLE"}) == {
+        "phase": "post-final",
+        "kind": "permission-prompt-unavailable",
+        "code": -32072,
+        "detail": "PERMISSION_PROMPT_UNAVAILABLE",
+    }
+    assert (
+        acpx_adapter._permission_prompt_diagnostic({"code": -32000, "message": "PERMISSION_PROMPT_UNAVAILABLE"}) is None
+    )
+    assert (
+        acpx_adapter._permission_prompt_diagnostic({"code": "-32072", "message": "PERMISSION_PROMPT_UNAVAILABLE"})
+        is None
+    )
+
+
+def test_permission_prompt_diagnostic_canonicalizes_structured_message():
+    message = "PERMISSION_PROMPT_UNAVAILABLE token=fake-secret-token /tmp/fake-secret-path"
+    warning = acpx_adapter._permission_prompt_diagnostic({"code": -32072, "message": message})
+
+    assert warning == {
+        "phase": "post-final",
+        "kind": "permission-prompt-unavailable",
+        "code": -32072,
+        "detail": "PERMISSION_PROMPT_UNAVAILABLE",
+    }
+    assert "fake-secret-token" not in repr(warning)
+    assert "/tmp/fake-secret-path" not in repr(warning)
+
+
+def test_run_late_permission_structured_error_sanitizes_receipt_detail(monkeypatch, tmp_path):
+    secret_message = "PERMISSION_PROMPT_UNAVAILABLE token=fake-secret-token /tmp/fake-secret-path"
+    stream = _stream(
+        {"jsonrpc": "2.0", "id": "init-1", "result": {"protocolVersion": 1}},
+        {
+            "jsonrpc": "2.0",
+            "id": "req-1",
+            "method": "session/prompt",
+            "params": {"sessionId": "session-1", "prompt": "hidden"},
+        },
+        {
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "session-1",
+                "update": {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": {"type": "text", "text": "Complete review findings."},
+                },
+            },
+        },
+        {"jsonrpc": "2.0", "id": "req-1", "result": {"stopReason": "end_turn"}},
+        {
+            "jsonrpc": "2.0",
+            "id": "perm-1",
+            "error": {"code": -32072, "message": secret_message},
+        },
+    )
+    monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
+    monkeypatch.setattr(acpx_adapter, "cursor_auth_status", _authenticated_status)
+    outputs = iter(
+        [
+            proc.Result(0, "acpx 0.12.0\n", ""),
+            proc.Result(5, stream, "transport stderr preserved"),
+        ]
+    )
+    monkeypatch.setattr(acpx_adapter.proc, "run", lambda argv, **kwargs: next(outputs))
+
+    result = acpx_adapter.run_cursor(
+        "inspect", cwd=tmp_path, timeout=120, model="composer-2.5", version="0.12.0", read_only=True
+    )
+
+    assert result.ok is True
+    assert result.transport_warning == {
+        "phase": "post-final",
+        "kind": "permission-prompt-unavailable",
+        "code": -32072,
+        "detail": "PERMISSION_PROMPT_UNAVAILABLE",
+    }
+    assert "fake-secret-token" not in repr(result.transport_warning)
+    assert "/tmp/fake-secret-path" not in repr(result.transport_warning)
+    assert "fake-secret-token" not in result.detail
+    assert "/tmp/fake-secret-path" not in result.detail
+    assert result.stdout == stream
+    assert result.stderr == "transport stderr preserved"
+
+
+def test_late_permission_from_stderr_uses_canonical_detail():
+    stderr = "PERMISSION_PROMPT_UNAVAILABLE token=fake-secret-token /tmp/fake-secret-path"
+    warning = acpx_adapter._late_permission_from_stderr(stderr, prompt_completed=True)
+
+    assert warning == {
+        "phase": "post-final",
+        "kind": "permission-prompt-unavailable",
+        "code": -32072,
+        "detail": "PERMISSION_PROMPT_UNAVAILABLE",
+    }
+    assert "fake-secret-token" not in repr(warning)
+    assert "/tmp/fake-secret-path" not in repr(warning)
+
+
+def test_run_late_permission_stderr_fallback_sanitizes_structured_output(monkeypatch, tmp_path):
+    stream = _stream(
+        {"jsonrpc": "2.0", "id": "init-1", "result": {"protocolVersion": 1}},
+        {
+            "jsonrpc": "2.0",
+            "id": "req-1",
+            "method": "session/prompt",
+            "params": {"sessionId": "session-1", "prompt": "hidden"},
+        },
+        {
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "session-1",
+                "update": {"sessionUpdate": "agent_message_chunk", "content": {"type": "text", "text": "Done."}},
+            },
+        },
+        {"jsonrpc": "2.0", "id": "req-1", "result": {"stopReason": "end_turn"}},
+    )
+    stderr = "PERMISSION_PROMPT_UNAVAILABLE token=fake-secret-token /tmp/fake-secret-path"
+    monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
+    monkeypatch.setattr(acpx_adapter, "cursor_auth_status", _authenticated_status)
+    outputs = iter(
+        [
+            proc.Result(0, "acpx 0.12.0\n", ""),
+            proc.Result(5, stream, stderr),
+        ]
+    )
+    monkeypatch.setattr(acpx_adapter.proc, "run", lambda argv, **kwargs: next(outputs))
+
+    result = acpx_adapter.run_cursor(
+        "inspect", cwd=tmp_path, timeout=120, model="composer-2.5", version="0.12.0", read_only=True
+    )
+
+    assert result.ok is True
+    assert result.transport_warning == {
+        "phase": "post-final",
+        "kind": "permission-prompt-unavailable",
+        "code": -32072,
+        "detail": "PERMISSION_PROMPT_UNAVAILABLE",
+    }
+    assert "fake-secret-token" not in repr(result.transport_warning)
+    assert "/tmp/fake-secret-path" not in repr(result.transport_warning)
+    assert "fake-secret-token" not in result.detail
+    assert "/tmp/fake-secret-path" not in result.detail
+
+
+def test_run_preserves_transport_warning_when_late_final_fails_output_validation(monkeypatch, tmp_path):
+    stream = _late_permission_stream(final_text="Reviewing repository files.")
+    monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
+    monkeypatch.setattr(acpx_adapter, "cursor_auth_status", _authenticated_status)
+    outputs = iter(
+        [
+            proc.Result(0, "acpx 0.12.0\n", ""),
+            proc.Result(5, stream, "PERMISSION_PROMPT_UNAVAILABLE"),
+        ]
+    )
+    monkeypatch.setattr(acpx_adapter.proc, "run", lambda argv, **kwargs: next(outputs))
+
+    result = acpx_adapter.run_cursor(
+        "inspect", cwd=tmp_path, timeout=120, model="composer-2.5", version="0.12.0", read_only=True
+    )
+
+    assert result.ok is False
+    assert result.failure_phase == "output-validation"
+    assert result.failure_kind == "non-final-output"
+    assert result.transport_warning == {
+        "phase": "post-final",
+        "kind": "permission-prompt-unavailable",
+        "code": -32072,
+        "detail": "PERMISSION_PROMPT_UNAVAILABLE",
+    }
+
+
+def test_run_rejects_mixed_channel_wrong_code_with_stderr_marker(monkeypatch, tmp_path):
+    stream = _stream(
+        {"jsonrpc": "2.0", "id": "init-1", "result": {"protocolVersion": 1}},
+        {
+            "jsonrpc": "2.0",
+            "id": "req-1",
+            "method": "session/prompt",
+            "params": {"sessionId": "session-1", "prompt": "hidden"},
+        },
+        {
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "session-1",
+                "update": {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": {"type": "text", "text": "Complete review findings."},
+                },
+            },
+        },
+        {"jsonrpc": "2.0", "id": "req-1", "result": {"stopReason": "end_turn"}},
+        {
+            "jsonrpc": "2.0",
+            "id": "perm-1",
+            "error": {"code": -32000, "message": "PERMISSION_PROMPT_UNAVAILABLE"},
+        },
+    )
+    stderr = "PERMISSION_PROMPT_UNAVAILABLE token=fake-secret-token /tmp/fake-secret-path"
+    monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
+    monkeypatch.setattr(acpx_adapter, "cursor_auth_status", _authenticated_status)
+    outputs = iter(
+        [
+            proc.Result(0, "acpx 0.12.0\n", ""),
+            proc.Result(5, stream, stderr),
+        ]
+    )
+    monkeypatch.setattr(acpx_adapter.proc, "run", lambda argv, **kwargs: next(outputs))
+
+    result = acpx_adapter.run_cursor(
+        "inspect", cwd=tmp_path, timeout=120, model="composer-2.5", version="0.12.0", read_only=True
+    )
+
+    assert result.ok is False
+    assert result.text == "Complete review findings."
+    assert result.exit_code == 5
+    assert result.transport_warning is None
+    assert result.failure_kind == "transport-error"
+
+
+def test_run_rejects_wrong_permission_code_even_with_marker_message(monkeypatch, tmp_path):
+    stream = _stream(
+        {"jsonrpc": "2.0", "id": "init-1", "result": {"protocolVersion": 1}},
+        {
+            "jsonrpc": "2.0",
+            "id": "req-1",
+            "method": "session/prompt",
+            "params": {"sessionId": "session-1", "prompt": "hidden"},
+        },
+        {
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "session-1",
+                "update": {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": {"type": "text", "text": "Complete review findings."},
+                },
+            },
+        },
+        {"jsonrpc": "2.0", "id": "req-1", "result": {"stopReason": "end_turn"}},
+        {
+            "jsonrpc": "2.0",
+            "id": "perm-1",
+            "error": {"code": -32000, "message": "PERMISSION_PROMPT_UNAVAILABLE"},
+        },
+    )
+    monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
+    monkeypatch.setattr(acpx_adapter, "cursor_auth_status", _authenticated_status)
+    outputs = iter(
+        [
+            proc.Result(0, "acpx 0.12.0\n", ""),
+            proc.Result(5, stream, "unrelated transport failure"),
+        ]
+    )
+    monkeypatch.setattr(acpx_adapter.proc, "run", lambda argv, **kwargs: next(outputs))
+
+    result = acpx_adapter.run_cursor(
+        "inspect", cwd=tmp_path, timeout=120, model="composer-2.5", version="0.12.0", read_only=True
+    )
+
+    assert result.ok is False
+    assert result.text == "Complete review findings."
+    assert result.transport_warning is None
+    assert result.failure_kind == "transport-error"


### PR DESCRIPTION
Closes #277.

## Root cause

ACPX can emit a non-empty assistant final and `end_turn`, then report `PERMISSION_PROMPT_UNAVAILABLE` with code `-32072` and exit 5. Brigade previously collapsed that chronology into a failed worker and discarded the usable final.

## What changed

- Preserve a final as usable-with-warning only when non-empty assistant text and `end_turn` occur before the exact `-32072` event.
- Keep pre-final errors, other structured error codes, mixed-channel errors, and text arriving after the error failed.
- Record a canonical typed warning without copying raw protocol error text into receipts.
- Preserve stdout, stderr, exit code, session ID, request ID, stop reason, and warning data across worker, synthesis, successful run, and failed validation receipts.
- Keep output validation active even when the terminal result is otherwise usable.

## Verification

- 142 focused ACP and direct-worker tests passed through Brigade.
- Full `./scripts/verify` passed on the committed head with 2,814 tests.
- Receipt integrity checked 111 artifacts with no mismatches or missing files.
- Independent review approved the final ordering and mixed-channel behavior.