### PR TITLE
docs: clarify cross-platform installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,12 @@ jobs:
           esac
 
   quickstart-smoke:
-    runs-on: ubuntu-latest
+    name: quickstart-smoke (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
@@ -160,7 +165,8 @@ jobs:
           python -m pip install --upgrade pip pipx
           pipx install .
           brigade --version
-      - name: Quickstart (minimal default)
+      - name: Quickstart (minimal default, Linux/macOS)
+        if: runner.os != 'Windows'
         run: |
           target="$(mktemp -d)"
           git init -q -b main "$target"
@@ -173,7 +179,23 @@ jobs:
           test ! -e "$target/tools"
           test ! -e "$target/rules"
           test ! -e "$target/INSTALL_FOR_AGENTS.md"
-      - name: Quickstart (--full)
+      - name: Quickstart (minimal default, PowerShell)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $target = Join-Path $env:RUNNER_TEMP "brigade-quickstart-minimal"
+          git init -q -b main $target
+          brigade operator quickstart --target $target --harnesses codex --json
+          brigade operator doctor --target $target --profile local-operator --json
+          if (-not (Test-Path (Join-Path $target ".brigade/config.json"))) { throw "missing Brigade config" }
+          if (-not (Test-Path (Join-Path $target ".codex/memory-handoffs"))) { throw "missing Codex handoff inbox" }
+          if (-not (Test-Path (Join-Path $target ".codex/skills/brigade-work/SKILL.md"))) { throw "missing brigade-work skill" }
+          if (-not (Test-Path (Join-Path $target "AGENTS.md"))) { throw "missing AGENTS.md" }
+          if (Test-Path (Join-Path $target "tools")) { throw "minimal install unexpectedly created tools" }
+          if (Test-Path (Join-Path $target "rules")) { throw "minimal install unexpectedly created rules" }
+          if (Test-Path (Join-Path $target "INSTALL_FOR_AGENTS.md")) { throw "minimal install unexpectedly created full-kit guide" }
+      - name: Quickstart (--full, Linux/macOS)
+        if: runner.os != 'Windows'
         run: |
           target="$(mktemp -d)"
           git init -q -b main "$target"
@@ -183,3 +205,15 @@ jobs:
           test -f "$target/tools/antislop.md"
           test -f "$target/INSTALL_FOR_AGENTS.md"
           test -f "$target/rules/issue-tdd-loop.md"
+      - name: Quickstart (--full, PowerShell)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $target = Join-Path $env:RUNNER_TEMP "brigade-quickstart-full"
+          git init -q -b main $target
+          brigade operator quickstart --target $target --harnesses codex --full --json
+          brigade operator doctor --target $target --profile local-operator --json
+          if (-not (Test-Path (Join-Path $target ".codex/skills/frontend/SKILL.md"))) { throw "missing frontend skill" }
+          if (-not (Test-Path (Join-Path $target "tools/antislop.md"))) { throw "missing antislop tool" }
+          if (-not (Test-Path (Join-Path $target "INSTALL_FOR_AGENTS.md"))) { throw "missing full-kit guide" }
+          if (-not (Test-Path (Join-Path $target "rules/issue-tdd-loop.md"))) { throw "missing issue/TDD rule" }

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -4,6 +4,48 @@ Five minutes from install to a working agent kitchen.
 
 ## 1. Install
 
+Brigade supports Linux, macOS, and Windows with Python 3.10 or newer. Install `pipx` with the package manager for your OS, then install Brigade.
+
+### Linux
+
+Ubuntu 23.04+, Debian 12+, and Fedora use an externally managed system Python. Install `pipx` from the distribution package instead of using `pip install --user`:
+
+```bash
+# Ubuntu or Debian
+sudo apt update
+sudo apt install pipx
+
+# Fedora
+sudo dnf install pipx
+
+pipx ensurepath
+```
+
+On another distribution, use its `pipx` package when available. The [pipx install guide](https://pipx.pypa.io/latest/how-to/install-pipx.html) covers the virtual-environment fallback.
+
+### macOS
+
+```bash
+brew install pipx
+pipx ensurepath
+```
+
+### Windows PowerShell
+
+```powershell
+scoop install pipx
+pipx ensurepath
+```
+
+Without Scoop, use Python's Windows launcher:
+
+```powershell
+py -m pip install --user pipx
+# Run pipx.exe ensurepath from the directory printed by pip if it is not on PATH yet.
+```
+
+Open a new terminal after `pipx ensurepath`, then continue on any OS:
+
 ```bash
 pipx install brigade-cli
 ```
@@ -12,13 +54,6 @@ To track the latest `main` branch instead of the latest package release:
 
 ```bash
 pipx install git+https://github.com/escoffier-labs/brigade
-```
-
-If you do not have `pipx`:
-
-```bash
-python3 -m pip install --user pipx
-python3 -m pipx ensurepath
 ```
 
 ## First install
@@ -34,6 +69,15 @@ brigade operator quickstart --target ~/agent-workspace --depth workspace --harne
 ```
 
 Pass `--dry-run` first to preview the planned steps without writing anything.
+
+PowerShell uses Windows path spelling when you provide a path explicitly:
+
+```powershell
+brigade operator quickstart --target .\my-repo --harnesses codex
+brigade operator doctor --target .\my-repo --profile local-operator
+```
+
+No WSL is required. Worker CLIs must resolve to native executables; when an npm tool resolves only to a `.cmd` or `.bat` shim, Brigade reports the shim and asks for a native launcher. Shell completions currently cover bash, zsh, and fish. `brigade stations verify` is POSIX-only and reports `unsupported-platform` on Windows; quickstart, doctor, the work loop, and native worker runs are supported.
 
 Two commands share this surface: `brigade init` installs the template files only, and `brigade operator quickstart` wraps it with operator config, the MCP and dogfood on-ramps, writer verification, and health checks. Use `init` when you want the interactive harness picker or just the files:
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@
 
 ## Install
 
+Brigade runs on Linux, macOS, and Windows with Python 3.10 or newer. The CLI and quickstart commands are the same on every platform; only the one-time `pipx` setup differs. See the [per-OS install guide](https://brigade.tools/docs/getting-started/install) for apt, Homebrew, Scoop, and PowerShell instructions.
+
 ```bash
 pipx install brigade-cli
 pipx ensurepath          # then open a new shell so `brigade` is on PATH

--- a/docs/agents-guide.md
+++ b/docs/agents-guide.md
@@ -16,6 +16,8 @@ Brigade is local-first workspace wiring. Local-first means local data on the ope
 
 ## Installing Brigade For A User
 
+Brigade supports Linux, macOS, and native Windows PowerShell with Python 3.10 or newer. If `pipx` is missing, use the platform package instructions in [`QUICKSTART.md`](../QUICKSTART.md#1-install). Do not assume WSL is required.
+
 When the user wants Brigade installed in a target repo or operator workspace, work in that target directory and run:
 
 ```bash

--- a/docs/first-10-minutes.md
+++ b/docs/first-10-minutes.md
@@ -11,7 +11,7 @@ brigade --version
 
 Expected: `brigade X.Y.Z` matching the [latest release](https://pypi.org/project/brigade-cli/).
 
-If `pipx` is missing, install it with your OS package manager or Python packaging tool, then rerun the command above. Brigade requires Python 3.10 or newer.
+If `pipx` is missing, follow the [Linux, macOS, or Windows install steps](../QUICKSTART.md#1-install), then rerun the command above. Brigade requires Python 3.10 or newer and does not require WSL on Windows.
 
 ## 2. Pick A Target
 
@@ -21,12 +21,20 @@ For a code repo:
 cd ./my-repo
 ```
 
-For a scratch check:
+For a scratch check on Linux or macOS:
 
 ```bash
 target="$(mktemp -d)"
 git init -q -b main "$target"
 cd "$target"
+```
+
+In PowerShell:
+
+```powershell
+$target = Join-Path $env:TEMP "brigade-scratch"
+git init -q -b main $target
+Set-Location $target
 ```
 
 For an operator workspace such as an OpenClaw or Hermes home, use that workspace directory instead of a code repo.

--- a/docs/new-user-quickstart.md
+++ b/docs/new-user-quickstart.md
@@ -8,10 +8,14 @@ For the shortest path, see [`first-10-minutes.md`](first-10-minutes.md). This pa
 
 ## Install
 
+Brigade supports Linux, macOS, and Windows with Python 3.10 or newer. Follow the [per-OS install steps](../QUICKSTART.md#1-install) if `pipx` is not already available.
+
 ```bash
 pipx install brigade-cli
 brigade --version
 ```
+
+Open a new terminal after `pipx ensurepath`. On Windows, run the same commands in PowerShell and use `.\my-repo` when you want Windows-style relative paths. WSL is optional, not required.
 
 ## Preview A Setup
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: MacOS",
+    "Operating System :: POSIX :: Linux",
 ]
 dependencies = []
 

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -18,3 +18,12 @@ def test_agents_doc_names_ci_only_jobs_outside_local_verify():
     assert "CI-only" in text
     for job in ("content-guard", "repo-metadata", "install-from-source", "quickstart-smoke"):
         assert job in text
+
+
+def test_quickstart_smoke_covers_linux_macos_and_windows_powershell():
+    text = (ROOT / ".github/workflows/ci.yml").read_text()
+
+    assert "os: [ubuntu-latest, macos-latest, windows-latest]" in text
+    assert "shell: pwsh" in text
+    assert "brigade operator quickstart --target $target" in text
+    assert "brigade operator doctor --target $target" in text


### PR DESCRIPTION
## Summary

- state Linux, macOS, and native Windows support in the README and quickstarts
- document PowerShell paths and current Windows boundaries
- run quickstart smoke coverage on Ubuntu, macOS, and Windows
- advertise Windows, macOS, and Linux in package metadata

## Verification

- `python3 -m pytest tests/test_ci_workflow.py tests/test_agents_windows_executable.py tests/test_stations_verify.py -q`
- `git diff --check`
- range-scoped content guard on `origin/main..HEAD`
- native PowerShell quickstart and operator doctor on Gandalf

Refs #350
