### PR TITLE
feat(components): define manifest v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,20 @@ jobs:
         if: matrix.python == '3.12'
         run: python -m pytest -q --cov=brigade --cov-report=term --cov-fail-under=78
 
+  component-manifest-provenance:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Verify component manifest provenance
+        run: python scripts/verify_component_manifest_provenance.py
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
   content-guard:
     runs-on: ubuntu-latest
     steps:

--- a/docs/component-manifest-policy.md
+++ b/docs/component-manifest-policy.md
@@ -1,0 +1,96 @@
+# Component manifest v1 policy
+
+Brigade ships a standalone component manifest contract for Phase 1 native tools. It is separate
+from `brigade.station.v1` and `station_manifest.load`.
+
+## Phase 1 components
+
+| Component id | Executable | Native release status |
+| --- | --- | --- |
+| `graphtrail` | `graphtrail` | pinned to GraphTrail commit `64fcd2f9`, assets unpublished |
+| `graphtrail-mcp` | `graphtrail-mcp` | pinned to GraphTrail commit `64fcd2f9`, assets unpublished |
+| `miseledger` | `miseledger` | pinned to MiseLedger v0.6.0 |
+| `sessionfind` | `sessionfind` | pinned to MiseLedger v0.6.0 |
+
+GraphTrail components record an immutable 40-character lowercase git SHA in `component_revision`.
+Published components also record the GitHub release tag in `source.release_tag`. The engine revision
+and release tag are independent: GraphTrail may pin a commit SHA while release assets use a semantic
+tag such as `v0.1.0`. Issue #354 will update the GraphTrail commit SHA and add its release tag and
+assets.
+
+MiseLedger components record the release tag in both `component_revision` and `source.release_tag`
+(`v0.6.0` today).
+
+## Platform matrix
+
+All Phase 1 components share one fixed support matrix:
+
+- `linux-amd64`
+- `linux-arm64`
+- `darwin-amd64`
+- `darwin-arm64`
+- `windows-amd64`
+
+Unsupported host platforms fail with the resolved key and the supported keys. Requesting an
+unpublished component/platform pair (for example GraphTrail on any platform today) raises an
+`unsupported-component-platform` diagnostic. Brigade never invents a filename and never falls
+back to Cargo builds.
+
+## Asset filenames
+
+Go-style platform keys drive asset names:
+
+- Linux and macOS: `<executable>-<platform-key>` with no suffix (`miseledger-linux-amd64`)
+- Windows: same pattern with a `.exe` suffix (`miseledger-windows-amd64.exe`)
+
+Each asset records `asset_name`, `byte_size`, lowercase 64-hex `sha256`, and an immutable
+`download_url` whose final path segment equals `asset_name` over HTTPS with no query or fragment.
+The JSON Schema constrains URL shape and Go-style asset names; Brigade runtime validation also
+requires the download URL final segment to match `asset_name` exactly.
+
+## Schema and runtime validation
+
+`docs/component-manifest-v1.schema.json` is the structural contract for manifest authorship and
+review. `brigade.component_manifest.load` enforces the same platform matrix, asset naming rules,
+and download URL invariants at runtime, including exact `supported_platforms` order, full-matrix
+published assets, and empty or complete unpublished assets. Unknown component ids remain a soft
+diagnostic; malformed known components are a hard failure.
+
+CI runs `scripts/verify_component_manifest_provenance.py` in a separate job from `./scripts/verify`.
+That script reads the bundled manifest, calls the GitHub Releases tag API with `urllib`, compares
+each published asset's name, `byte_size`, `browser_download_url`, and API `sha256:<hex>` digest,
+cross-checks every manifest `sha256`/name pair against the release `checksums.txt`, and verifies
+that each published component's `source.release_tag` matches the GitHub release tag embedded in
+asset `download_url` values. It never compares `component_revision` to the release tag and never
+downloads native binaries. Local runs work without `GITHUB_TOKEN`; CI passes `github.token` for
+rate-limit headroom.
+
+## User-local path invariants
+
+Components install under the user data root, never under a repo `.brigade` directory:
+
+- Data root defaults: Linux `XDG_DATA_HOME` or `~/.local/share`, macOS
+  `~/Library/Application Support`, Windows `%LOCALAPPDATA%`
+- Cache root defaults: Linux `XDG_CACHE_HOME` or `~/.cache`, macOS `~/Library/Caches`,
+  Windows `%LOCALAPPDATA%`
+
+Layout:
+
+- `<data-root>/brigade/components/` - component metadata directory
+- `<data-root>/brigade/bin/<executable>` - managed executables
+- `<data-root>/brigade/installed.json` - install state (future phases)
+- `<cache-root>/brigade/components/<sha256>/<asset_name>` - verified download cache
+
+Brigade does not relocate `.graphtrail/graphtrail.db` or MiseLedger archive paths.
+
+## Forward compatibility
+
+- Unknown `schema_version` values are a hard failure naming received and supported versions.
+- Unknown component ids listed in a v1 manifest are ignored for known-component operations and
+  emit a deterministic diagnostic. The manifest is not rejected.
+- Malformed known components or assets are a hard failure naming component, platform, and field.
+
+## Phase 1 boundaries
+
+Issue #353 defines schema, pins, path invariants, and validation only. Downloading, unpacking,
+rollback, and managed-catalog rewrites are reserved for later issues.

--- a/docs/component-manifest-v1.schema.json
+++ b/docs/component-manifest-v1.schema.json
@@ -1,0 +1,234 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://brigade.tools/schemas/component-manifest-v1.schema.json",
+  "title": "Brigade component manifest v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "brigade_version",
+    "manifest_revision",
+    "supported_platforms",
+    "components"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "brigade_version": {"type": "string", "minLength": 1},
+    "manifest_revision": {"type": "string", "minLength": 1},
+    "supported_platforms": {
+      "const": [
+        "linux-amd64",
+        "linux-arm64",
+        "darwin-amd64",
+        "darwin-arm64",
+        "windows-amd64"
+      ]
+    },
+    "components": {
+      "type": "object",
+      "required": ["graphtrail", "graphtrail-mcp", "miseledger", "sessionfind"],
+      "properties": {
+        "graphtrail": {
+          "allOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["component_revision", "source", "executable", "assets"],
+              "properties": {
+                "component_revision": {"$ref": "#/$defs/graphtrail_component_revision"},
+                "executable": {"const": "graphtrail"},
+                "source": {},
+                "assets": {}
+              }
+            },
+            {
+              "oneOf": [
+                {
+                  "properties": {
+                    "source": {"$ref": "#/$defs/unpublished_source"},
+                    "assets": {"$ref": "#/$defs/empty_assets"}
+                  },
+                  "required": ["source", "assets"]
+                },
+                {
+                  "properties": {
+                    "source": {"$ref": "#/$defs/published_source"},
+                    "assets": {"$ref": "#/$defs/published_assets"}
+                  },
+                  "required": ["source", "assets"]
+                }
+              ]
+            }
+          ]
+        },
+        "graphtrail-mcp": {
+          "allOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["component_revision", "source", "executable", "assets"],
+              "properties": {
+                "component_revision": {"$ref": "#/$defs/graphtrail_component_revision"},
+                "executable": {"const": "graphtrail-mcp"},
+                "source": {},
+                "assets": {}
+              }
+            },
+            {
+              "oneOf": [
+                {
+                  "properties": {
+                    "source": {"$ref": "#/$defs/unpublished_source"},
+                    "assets": {"$ref": "#/$defs/empty_assets"}
+                  },
+                  "required": ["source", "assets"]
+                },
+                {
+                  "properties": {
+                    "source": {"$ref": "#/$defs/published_source"},
+                    "assets": {"$ref": "#/$defs/published_assets"}
+                  },
+                  "required": ["source", "assets"]
+                }
+              ]
+            }
+          ]
+        },
+        "miseledger": {
+          "allOf": [
+            {"$ref": "#/$defs/known_component"},
+            {
+              "properties": {
+                "executable": {"const": "miseledger"},
+                "assets": {"$ref": "#/$defs/published_assets"},
+                "source": {"$ref": "#/$defs/published_source"}
+              }
+            }
+          ]
+        },
+        "sessionfind": {
+          "allOf": [
+            {"$ref": "#/$defs/known_component"},
+            {
+              "properties": {
+                "executable": {"const": "sessionfind"},
+                "assets": {"$ref": "#/$defs/published_assets"},
+                "source": {"$ref": "#/$defs/published_source"}
+              }
+            }
+          ]
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "$defs": {
+    "known_component": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["component_revision", "source", "executable", "assets"],
+      "properties": {
+        "component_revision": {"type": "string", "minLength": 1},
+        "source": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["repository"],
+          "properties": {
+            "repository": {"type": "string", "pattern": "^[^/]+/[^/]+$"},
+            "release_tag": {"type": "string", "minLength": 1}
+          }
+        },
+        "executable": {"type": "string", "minLength": 1},
+        "assets": {
+          "type": "object",
+          "propertyNames": {
+            "pattern": "^(linux|darwin|windows)-(amd64|arm64)$"
+          },
+          "additionalProperties": {"$ref": "#/$defs/asset"}
+        }
+      }
+    },
+    "graphtrail_component_revision": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "published_source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "release_tag"],
+      "properties": {
+        "repository": {"type": "string", "pattern": "^[^/]+/[^/]+$"},
+        "release_tag": {"type": "string", "minLength": 1}
+      }
+    },
+    "unpublished_source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository"],
+      "properties": {
+        "repository": {"type": "string", "pattern": "^[^/]+/[^/]+$"}
+      }
+    },
+    "empty_assets": {
+      "type": "object",
+      "additionalProperties": false,
+      "maxProperties": 0
+    },
+    "published_assets": {
+      "type": "object",
+      "required": [
+        "linux-amd64",
+        "linux-arm64",
+        "darwin-amd64",
+        "darwin-arm64",
+        "windows-amd64"
+      ],
+      "properties": {
+        "linux-amd64": {"$ref": "#/$defs/unix_asset"},
+        "linux-arm64": {"$ref": "#/$defs/unix_asset"},
+        "darwin-amd64": {"$ref": "#/$defs/unix_asset"},
+        "darwin-arm64": {"$ref": "#/$defs/unix_asset"},
+        "windows-amd64": {"$ref": "#/$defs/windows_asset"}
+      },
+      "additionalProperties": false
+    },
+    "asset": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["asset_name", "byte_size", "sha256", "download_url"],
+      "properties": {
+        "asset_name": {"type": "string", "minLength": 1, "pattern": "^[^/\\\\]+$"},
+        "byte_size": {"type": "integer", "minimum": 1},
+        "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "download_url": {
+          "type": "string",
+          "pattern": "^https://[^?#]+/[^/?#]+$"
+        }
+      }
+    },
+    "unix_asset": {
+      "allOf": [
+        {"$ref": "#/$defs/asset"},
+        {
+          "properties": {
+            "asset_name": {
+              "pattern": "^[a-z0-9-]+-(linux|darwin)-(amd64|arm64)$"
+            }
+          }
+        }
+      ]
+    },
+    "windows_asset": {
+      "allOf": [
+        {"$ref": "#/$defs/asset"},
+        {
+          "properties": {
+            "asset_name": {
+              "pattern": "^[a-z0-9-]+-windows-amd64\\.exe$"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/scripts/verify_component_manifest_provenance.py
+++ b/scripts/verify_component_manifest_provenance.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""Verify bundled component manifest release assets against GitHub provenance."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_MANIFEST = ROOT / "src/brigade/templates/components/manifest-v1.json"
+USER_AGENT = "brigade-component-manifest-provenance/1.0"
+GITHUB_RELEASE_URL = re.compile(
+    r"^https://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/releases/download/(?P<tag>[^/]+)/(?P<filename>[^/?#]+)$"
+)
+GITHUB_RELEASE_TAG_API = "https://api.github.com/repos/{owner}/{repo}/releases/tags/{tag}"
+_SHA256_DIGEST = re.compile(r"^sha256:([0-9a-f]{64})$")
+
+
+FetchFn = Callable[[str], tuple[int, str]]
+
+
+def parse_github_release_url(url: str) -> tuple[str, str, str, str]:
+    match = GITHUB_RELEASE_URL.fullmatch(url)
+    if match is None:
+        raise ValueError(f"download_url is not a direct GitHub release asset URL: {url}")
+    return (
+        match.group("owner"),
+        match.group("repo"),
+        match.group("tag"),
+        match.group("filename"),
+    )
+
+
+def parse_checksums(text: str) -> dict[str, str]:
+    digests: dict[str, str] = {}
+    for line_number, raw_line in enumerate(text.splitlines(), start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split()
+        if len(parts) != 2:
+            raise ValueError(f"checksums.txt line {line_number} is malformed: {raw_line!r}")
+        digest, name = parts
+        if not re.fullmatch(r"[0-9a-f]{64}", digest):
+            raise ValueError(f"checksums.txt line {line_number} has invalid sha256: {digest!r}")
+        if name in digests:
+            raise ValueError(f"checksums.txt lists duplicate asset name {name!r}")
+        digests[name] = digest
+    return digests
+
+
+def default_fetch(url: str) -> tuple[int, str]:
+    request = urllib.request.Request(url, headers=_request_headers())
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            body = response.read().decode("utf-8")
+            return response.status, body
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read().decode("utf-8", errors="replace")
+
+
+def _request_headers() -> dict[str, str]:
+    headers = {"Accept": "application/vnd.github+json", "User-Agent": USER_AGENT}
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def verify_manifest(manifest_path: Path, *, fetch: FetchFn = default_fetch) -> list[str]:
+    try:
+        raw = json.loads(manifest_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        return [f"component manifest could not be loaded: {manifest_path} ({exc})"]
+    if not isinstance(raw, dict):
+        return [f"component manifest must be a JSON object: {manifest_path}"]
+
+    errors: list[str] = []
+    components = raw.get("components")
+    if not isinstance(components, dict):
+        return [f"component manifest field 'components' must be an object: {manifest_path}"]
+
+    for component_id, component_raw in sorted(components.items()):
+        if not isinstance(component_raw, dict):
+            errors.append(f"component {component_id!r} must be an object")
+            continue
+        assets_raw = component_raw.get("assets")
+        if not isinstance(assets_raw, dict) or not assets_raw:
+            continue
+        errors.extend(
+            _verify_component(
+                component_id,
+                component_raw,
+                assets_raw,
+                fetch=fetch,
+            )
+        )
+    return errors
+
+
+def _verify_component(
+    component_id: str,
+    component_raw: dict[str, Any],
+    assets_raw: dict[str, Any],
+    *,
+    fetch: FetchFn,
+) -> list[str]:
+    errors: list[str] = []
+    source = component_raw.get("source")
+    repository = ""
+    if isinstance(source, dict) and isinstance(source.get("repository"), str):
+        repository = source["repository"].strip()
+    release_tag = ""
+    if isinstance(source, dict) and isinstance(source.get("release_tag"), str):
+        release_tag = source["release_tag"].strip()
+
+    parsed_assets: list[dict[str, Any]] = []
+    seen_names: dict[str, str] = {}
+    release_coords: tuple[str, str, str] | None = None
+
+    for platform, asset_raw in sorted(assets_raw.items()):
+        if not isinstance(asset_raw, dict):
+            errors.append(f"component {component_id!r} platform {platform!r} asset must be an object")
+            continue
+        asset_name = asset_raw.get("asset_name")
+        byte_size = asset_raw.get("byte_size")
+        digest = asset_raw.get("sha256")
+        download_url = asset_raw.get("download_url")
+        if not isinstance(asset_name, str) or not asset_name:
+            errors.append(
+                f"component {component_id!r} platform {platform!r} field 'asset_name' must be a non-empty string"
+            )
+            continue
+        if asset_name in seen_names:
+            errors.append(
+                f"component {component_id!r} lists duplicate asset_name {asset_name!r} "
+                f"on platforms {seen_names[asset_name]!r} and {platform!r}"
+            )
+        else:
+            seen_names[asset_name] = platform
+        if not isinstance(byte_size, int) or isinstance(byte_size, bool) or byte_size <= 0:
+            errors.append(
+                f"component {component_id!r} platform {platform!r} field 'byte_size' must be a positive integer"
+            )
+            continue
+        if not isinstance(digest, str) or not re.fullmatch(r"[0-9a-f]{64}", digest):
+            errors.append(
+                f"component {component_id!r} platform {platform!r} field 'sha256' must be 64 lowercase hex characters"
+            )
+            continue
+        if not isinstance(download_url, str) or not download_url:
+            errors.append(
+                f"component {component_id!r} platform {platform!r} field 'download_url' must be a non-empty string"
+            )
+            continue
+        path_name = Path(urlparse(download_url).path).name
+        if path_name != asset_name:
+            errors.append(
+                f"component {component_id!r} platform {platform!r} download_url final segment "
+                f"must equal asset_name {asset_name!r} (found {path_name!r})"
+            )
+        try:
+            owner, repo, tag, filename = parse_github_release_url(download_url)
+        except ValueError as exc:
+            errors.append(f"component {component_id!r} platform {platform!r} {exc}")
+            continue
+        if filename != asset_name:
+            errors.append(
+                f"component {component_id!r} platform {platform!r} download_url filename "
+                f"must equal asset_name {asset_name!r} (found {filename!r})"
+            )
+        coords = (owner, repo, tag)
+        if release_coords is None:
+            release_coords = coords
+        elif release_coords != coords:
+            expected_owner, expected_repo, expected_tag = release_coords
+            errors.append(
+                f"component {component_id!r} platform {platform!r} download_url must use the "
+                f"same repository and tag as other assets "
+                f"({expected_owner}/{expected_repo}@{expected_tag}, found {owner}/{repo}@{tag})"
+            )
+        if repository and repository != f"{owner}/{repo}":
+            errors.append(
+                f"component {component_id!r} source.repository {repository!r} does not match "
+                f"download_url repository {owner}/{repo}"
+            )
+        if not release_tag:
+            errors.append(
+                f"component {component_id!r} source.release_tag must be set when assets are published"
+            )
+        elif release_tag != tag:
+            errors.append(
+                f"component {component_id!r} source.release_tag {release_tag!r} does not match "
+                f"download_url tag {tag!r}"
+            )
+        parsed_assets.append(
+            {
+                "platform": platform,
+                "asset_name": asset_name,
+                "byte_size": byte_size,
+                "sha256": digest,
+                "download_url": download_url,
+            }
+        )
+
+    if errors or release_coords is None or not parsed_assets:
+        return errors
+
+    owner, repo, tag = release_coords
+    release_url = GITHUB_RELEASE_TAG_API.format(owner=owner, repo=repo, tag=tag)
+    status, body = fetch(release_url)
+    if status != 200:
+        errors.append(
+            f"component {component_id!r} GitHub release lookup failed for {owner}/{repo}@{tag}: HTTP {status}"
+        )
+        return errors
+    try:
+        release = json.loads(body)
+    except json.JSONDecodeError:
+        errors.append(
+            f"component {component_id!r} GitHub release lookup returned invalid JSON for {owner}/{repo}@{tag}"
+        )
+        return errors
+
+    release_assets = release.get("assets")
+    if not isinstance(release_assets, list):
+        errors.append(f"component {component_id!r} GitHub release for {owner}/{repo}@{tag} is missing an assets array")
+        return errors
+
+    by_name: dict[str, dict[str, Any]] = {}
+    checksums_url: str | None = None
+    for asset in release_assets:
+        if not isinstance(asset, dict):
+            continue
+        name = asset.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        if name == "checksums.txt":
+            browser_download_url = asset.get("browser_download_url")
+            if isinstance(browser_download_url, str) and browser_download_url:
+                checksums_url = browser_download_url
+            continue
+        by_name[name] = asset
+
+    expected_names = {asset["asset_name"] for asset in parsed_assets}
+    release_names = set(by_name)
+    missing = sorted(expected_names - release_names)
+    if missing:
+        errors.append(
+            f"component {component_id!r} release {owner}/{repo}@{tag} is missing assets: " + ", ".join(missing)
+        )
+
+    for asset in parsed_assets:
+        release_asset = by_name.get(asset["asset_name"])
+        if release_asset is None:
+            continue
+        platform = asset["platform"]
+        name = asset["asset_name"]
+        release_size = release_asset.get("size")
+        if release_size != asset["byte_size"]:
+            errors.append(
+                f"component {component_id!r} platform {platform!r} asset {name!r} byte_size "
+                f"{asset['byte_size']} does not match GitHub release size {release_size!r}"
+            )
+        release_url_value = release_asset.get("browser_download_url")
+        if release_url_value != asset["download_url"]:
+            errors.append(
+                f"component {component_id!r} platform {platform!r} asset {name!r} "
+                "browser_download_url does not match the GitHub release asset URL"
+            )
+        digest_value = release_asset.get("digest")
+        if not isinstance(digest_value, str):
+            errors.append(
+                f"component {component_id!r} platform {platform!r} asset {name!r} is missing a GitHub release digest"
+            )
+        else:
+            digest_match = _SHA256_DIGEST.fullmatch(digest_value)
+            if digest_match is None:
+                errors.append(
+                    f"component {component_id!r} platform {platform!r} asset {name!r} "
+                    f"has malformed GitHub release digest {digest_value!r}"
+                )
+            elif digest_match.group(1) != asset["sha256"]:
+                errors.append(
+                    f"component {component_id!r} platform {platform!r} asset {name!r} sha256 "
+                    f"{asset['sha256']} does not match GitHub release digest {digest_value}"
+                )
+
+    if checksums_url is None:
+        errors.append(f"component {component_id!r} release {owner}/{repo}@{tag} is missing checksums.txt")
+        return errors
+
+    checksum_status, checksum_body = fetch(checksums_url)
+    if checksum_status != 200:
+        errors.append(
+            f"component {component_id!r} checksums.txt fetch failed for {owner}/{repo}@{tag}: HTTP {checksum_status}"
+        )
+        return errors
+    try:
+        checksum_map = parse_checksums(checksum_body)
+    except ValueError as exc:
+        errors.append(f"component {component_id!r} checksums.txt is malformed: {exc}")
+        return errors
+
+    for asset in parsed_assets:
+        name = asset["asset_name"]
+        expected = asset["sha256"]
+        found = checksum_map.get(name)
+        if found is None:
+            errors.append(f"component {component_id!r} asset {name!r} is missing from checksums.txt")
+        elif found != expected:
+            errors.append(
+                f"component {component_id!r} asset {name!r} sha256 {expected} "
+                f"does not match checksums.txt entry {found}"
+            )
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=DEFAULT_MANIFEST,
+        help="path to manifest-v1.json (default: bundled template manifest)",
+    )
+    args = parser.parse_args(argv)
+    errors = verify_manifest(args.manifest.resolve())
+    if errors:
+        for error in errors:
+            print(f"component manifest provenance: {error}", file=sys.stderr)
+        return 1
+    print(f"component manifest provenance: ok ({args.manifest})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/version_sync.py
+++ b/scripts/version_sync.py
@@ -28,9 +28,11 @@ import os
 import pathlib
 import re
 import sys
-import tomllib
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from brigade import toml_compat  # noqa: E402
 
 # --- Per-repo configuration -------------------------------------------------
 # Source of truth for the version.
@@ -55,7 +57,7 @@ RECORDINGS = [
 
 
 def _expected() -> str:
-    data = tomllib.loads((ROOT / VERSION_FILE).read_text())
+    data = toml_compat.loads((ROOT / VERSION_FILE).read_text())
     return data["project"]["version"]
 
 

--- a/scripts/version_sync.py
+++ b/scripts/version_sync.py
@@ -38,6 +38,10 @@ VERSION_FILE = "pyproject.toml"  # read [project].version
 # Simple, single-token locations checked/rewritten by regex. Each pattern must
 # have exactly one capture group: the version token.
 INIT_FILE = ("src/brigade/__init__.py", r'__version__ = "([^"]+)"')
+COMPONENT_MANIFEST = (
+    "src/brigade/templates/components/manifest-v1.json",
+    r'"brigade_version"\s*:\s*"([^"]+)"',
+)
 TEMPLATES_GLOB = "src/brigade/templates/**/*.json"
 TEMPLATE_PATTERN = r'"_brigade_version"\s*:\s*"([^"]+)"'
 # Recorded demo assets with the version baked into the frames. The .cast is the
@@ -57,7 +61,7 @@ def _expected() -> str:
 
 def _locations() -> list[tuple[str, str]]:
     """Return every (path, pattern) location the version is stamped into."""
-    locs: list[tuple[str, str]] = [INIT_FILE]
+    locs: list[tuple[str, str]] = [INIT_FILE, COMPONENT_MANIFEST]
     for path in sorted(ROOT.glob(TEMPLATES_GLOB)):
         if '"_brigade_version"' in path.read_text():
             locs.append((path.relative_to(ROOT).as_posix(), TEMPLATE_PATTERN))

--- a/src/brigade/component_manifest.py
+++ b/src/brigade/component_manifest.py
@@ -1,0 +1,359 @@
+"""Versioned manifest for pinned native Brigade components."""
+
+from __future__ import annotations
+
+import json
+import platform as host_platform
+import re
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.parse import urlparse
+
+from . import templates
+
+SCHEMA_VERSION = 1
+SUPPORTED_PLATFORMS: tuple[str, ...] = (
+    "linux-amd64",
+    "linux-arm64",
+    "darwin-amd64",
+    "darwin-arm64",
+    "windows-amd64",
+)
+KNOWN_COMPONENT_IDS: tuple[str, ...] = (
+    "graphtrail",
+    "graphtrail-mcp",
+    "miseledger",
+    "sessionfind",
+)
+UNPUBLISHED_COMPONENT_IDS: frozenset[str] = frozenset({"graphtrail", "graphtrail-mcp"})
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_GIT_SHA = re.compile(r"^[0-9a-f]{40}$")
+_PLATFORM = re.compile(r"^(linux|darwin|windows)-(amd64|arm64)$")
+
+
+@dataclass(frozen=True)
+class ComponentSource:
+    repository: str
+    release_tag: str | None = None
+
+
+@dataclass(frozen=True)
+class ComponentAsset:
+    asset_name: str
+    byte_size: int
+    sha256: str
+    download_url: str
+
+
+@dataclass(frozen=True)
+class Component:
+    component_revision: str
+    source: ComponentSource
+    executable: str
+    assets: dict[str, ComponentAsset]
+
+
+@dataclass(frozen=True)
+class ComponentManifest:
+    path: Path
+    schema_version: int
+    brigade_version: str
+    manifest_revision: str
+    supported_platforms: tuple[str, ...]
+    components: dict[str, Component]
+    unknown_component_diagnostics: tuple[str, ...]
+
+
+def manifest_path() -> Path:
+    return templates.template_root() / "components" / "manifest-v1.json"
+
+
+def load(path: Path | None = None) -> ComponentManifest:
+    source = path or manifest_path()
+    try:
+        raw = json.loads(source.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"component manifest could not be loaded: {source}") from exc
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"unsupported component manifest schema version {None!r}; this Brigade supports {SCHEMA_VERSION}"
+        )
+    schema_version = raw.get("schema_version")
+    if type(schema_version) is not int or schema_version != SCHEMA_VERSION:
+        raise ValueError(
+            f"unsupported component manifest schema version {schema_version!r}; this Brigade supports {SCHEMA_VERSION}"
+        )
+    _reject_unexpected_keys(
+        raw,
+        allowed=frozenset(
+            {
+                "schema_version",
+                "brigade_version",
+                "manifest_revision",
+                "supported_platforms",
+                "components",
+            }
+        ),
+        owner="manifest",
+    )
+    brigade_version = _required_str(raw, "brigade_version", "manifest")
+    manifest_revision = _required_str(raw, "manifest_revision", "manifest")
+    supported_platforms = _supported_platforms(raw)
+    components_raw = raw.get("components")
+    if not isinstance(components_raw, dict):
+        raise ValueError("component manifest field 'components' must be an object")
+
+    unknown_ids: list[str] = []
+    components: dict[str, Component] = {}
+    for name, value in sorted(components_raw.items()):
+        if not isinstance(name, str) or not name:
+            raise ValueError("component manifest components must be named objects")
+        if name not in KNOWN_COMPONENT_IDS:
+            unknown_ids.append(name)
+            continue
+        if not isinstance(value, dict):
+            raise ValueError(f"component manifest component {name!r} must be an object")
+        components[name] = _parse_known_component(name, value)
+
+    missing = [component_id for component_id in KNOWN_COMPONENT_IDS if component_id not in components]
+    if missing:
+        missing_list = ", ".join(missing)
+        raise ValueError(f"component manifest is missing required components: {missing_list}")
+
+    diagnostics = _unknown_component_diagnostics(unknown_ids)
+    return ComponentManifest(
+        path=source,
+        schema_version=SCHEMA_VERSION,
+        brigade_version=brigade_version,
+        manifest_revision=manifest_revision,
+        supported_platforms=supported_platforms,
+        components=components,
+        unknown_component_diagnostics=diagnostics,
+    )
+
+
+def resolve_asset(manifest: ComponentManifest, component_id: str, platform: str) -> ComponentAsset:
+    component = manifest.components.get(component_id)
+    if component is None:
+        known = ", ".join(KNOWN_COMPONENT_IDS)
+        raise ValueError(f"unknown component {component_id!r}; known components: {known}")
+    if platform not in SUPPORTED_PLATFORMS:
+        supported = ", ".join(SUPPORTED_PLATFORMS)
+        raise ValueError(f"unsupported platform {platform!r}; supported platform keys: {supported}")
+    asset = component.assets.get(platform)
+    if asset is None:
+        raise ValueError(
+            f"unsupported-component-platform: component {component_id!r} has no pinned native "
+            f"asset for {platform!r}; published platforms: "
+            f"{', '.join(sorted(component.assets)) or 'none'}"
+        )
+    return asset
+
+
+def platform_key(*, system: str | None = None, machine: str | None = None) -> str:
+    os_names = {"linux": "linux", "darwin": "darwin", "windows": "windows"}
+    arch_names = {"x86_64": "amd64", "amd64": "amd64", "aarch64": "arm64", "arm64": "arm64"}
+    system_value = (system or host_platform.system()).lower()
+    machine_value = (machine or host_platform.machine()).lower()
+    os_name = os_names.get(system_value)
+    arch = arch_names.get(machine_value)
+    if os_name is None or arch is None:
+        resolved = f"{system_value}-{machine_value}"
+        supported = ", ".join(SUPPORTED_PLATFORMS)
+        raise ValueError(f"unsupported platform {resolved}; supported platform keys: {supported}")
+    key = f"{os_name}-{arch}"
+    if key not in SUPPORTED_PLATFORMS:
+        supported = ", ".join(SUPPORTED_PLATFORMS)
+        raise ValueError(f"unsupported platform {key}; supported platform keys: {supported}")
+    return key
+
+
+def _supported_platforms(raw: dict[str, Any]) -> tuple[str, ...]:
+    value = raw.get("supported_platforms")
+    if not isinstance(value, list) or not value:
+        raise ValueError("component manifest field 'supported_platforms' must be a non-empty array")
+    platforms: list[str] = []
+    for item in value:
+        if not isinstance(item, str) or not _PLATFORM.fullmatch(item):
+            raise ValueError("component manifest field 'supported_platforms' must list Go-style platform keys")
+        platforms.append(item)
+    if tuple(platforms) != SUPPORTED_PLATFORMS:
+        expected = ", ".join(SUPPORTED_PLATFORMS)
+        found = ", ".join(platforms)
+        raise ValueError(f"component manifest field 'supported_platforms' must be exactly: {expected} (found: {found})")
+    return tuple(platforms)
+
+
+def _parse_known_component(name: str, raw: dict[str, Any]) -> Component:
+    _reject_unexpected_keys(
+        raw,
+        allowed=frozenset({"component_revision", "source", "executable", "assets"}),
+        owner=f"component {name!r}",
+    )
+    component_revision = _required_str(raw, "component_revision", name)
+    if name in UNPUBLISHED_COMPONENT_IDS and not _GIT_SHA.fullmatch(component_revision):
+        raise ValueError(f"component {name!r} field 'component_revision' must be a 40-character lowercase git SHA")
+    source_raw = raw.get("source")
+    if not isinstance(source_raw, dict):
+        raise ValueError(f"component {name!r} field 'source' must be an object")
+    _reject_unexpected_keys(
+        source_raw,
+        allowed=frozenset({"repository", "release_tag"}),
+        owner=f"component {name!r} source",
+    )
+    repository = _required_str(source_raw, "repository", name)
+    if repository.count("/") != 1:
+        raise ValueError(f"component {name!r} source.repository must be an owner/name pair")
+    release_tag_raw = source_raw.get("release_tag")
+    release_tag: str | None
+    if release_tag_raw is None:
+        release_tag = None
+    elif not isinstance(release_tag_raw, str) or not release_tag_raw.strip():
+        raise ValueError(f"component {name!r} field 'source.release_tag' must be a non-empty string when present")
+    else:
+        release_tag = release_tag_raw.strip()
+    executable = _required_str(raw, "executable", name)
+    if executable != name:
+        raise ValueError(f"component {name!r} field 'executable' must equal the component id {name!r}")
+    assets_raw = raw.get("assets")
+    if not isinstance(assets_raw, dict):
+        raise ValueError(f"component {name!r} field 'assets' must be an object")
+    assets: dict[str, ComponentAsset] = {}
+    for key, asset_raw in assets_raw.items():
+        if not isinstance(key, str) or not _PLATFORM.fullmatch(key):
+            raise ValueError(f"component {name!r} has invalid platform key {key!r}")
+        if key not in SUPPORTED_PLATFORMS:
+            raise ValueError(f"component {name!r} platform {key!r} is outside the Phase 1 support matrix")
+        if not isinstance(asset_raw, dict):
+            raise ValueError(f"component {name!r} platform {key!r} asset must be an object")
+        assets[key] = _parse_asset(name, executable, key, asset_raw)
+    _validate_asset_coverage(name, assets)
+    _validate_release_tag_coverage(name, assets, release_tag)
+    return Component(
+        component_revision=component_revision,
+        source=ComponentSource(repository=repository, release_tag=release_tag),
+        executable=executable,
+        assets=assets,
+    )
+
+
+def _validate_release_tag_coverage(
+    name: str,
+    assets: dict[str, ComponentAsset],
+    release_tag: str | None,
+) -> None:
+    if assets:
+        if not release_tag:
+            raise ValueError(f"component {name!r} field 'source.release_tag' must be set when assets are published")
+        return
+    if release_tag is not None:
+        raise ValueError(f"component {name!r} field 'source.release_tag' must be omitted when assets are unpublished")
+
+
+def _validate_asset_coverage(name: str, assets: dict[str, ComponentAsset]) -> None:
+    if not assets:
+        if name not in UNPUBLISHED_COMPONENT_IDS:
+            raise ValueError(f"component {name!r} must publish assets for every supported platform")
+        return
+    published = set(assets)
+    expected = set(SUPPORTED_PLATFORMS)
+    if published != expected:
+        missing = ", ".join(sorted(expected - published))
+        extra = ", ".join(sorted(published - expected))
+        details: list[str] = []
+        if missing:
+            details.append(f"missing: {missing}")
+        if extra:
+            details.append(f"unexpected: {extra}")
+        detail_text = "; ".join(details)
+        raise ValueError(
+            f"component {name!r} must publish the full supported platform matrix or no assets ({detail_text})"
+        )
+
+
+def _expected_asset_name(executable: str, platform: str) -> str:
+    base = f"{executable}-{platform}"
+    if platform == "windows-amd64":
+        return f"{base}.exe"
+    return base
+
+
+def _parse_asset(component: str, executable: str, platform: str, raw: dict[str, Any]) -> ComponentAsset:
+    owner = f"component {component!r} platform {platform!r}"
+    _reject_unexpected_keys(
+        raw,
+        allowed=frozenset({"asset_name", "byte_size", "sha256", "download_url"}),
+        owner=owner,
+    )
+    asset_name = _required_str(raw, "asset_name", f"{component}/{platform}")
+    expected_name = _expected_asset_name(executable, platform)
+    if asset_name != expected_name:
+        raise ValueError(f"component {component!r} platform {platform!r} field 'asset_name' must be {expected_name!r}")
+    if not _safe_asset_name(asset_name):
+        raise ValueError(f"component {component!r} platform {platform!r} field 'asset_name' must be a basename")
+    byte_size = raw.get("byte_size")
+    if not isinstance(byte_size, int) or isinstance(byte_size, bool) or byte_size <= 0:
+        raise ValueError(f"component {component!r} platform {platform!r} field 'byte_size' must be a positive integer")
+    digest = raw.get("sha256")
+    if not isinstance(digest, str) or not _SHA256.fullmatch(digest):
+        raise ValueError(
+            f"component {component!r} platform {platform!r} field 'sha256' must be 64 lowercase hex characters"
+        )
+    download_url = _required_str(raw, "download_url", f"{component}/{platform}")
+    _validate_download_url(component, platform, asset_name, download_url)
+    return ComponentAsset(
+        asset_name=asset_name,
+        byte_size=byte_size,
+        sha256=digest,
+        download_url=download_url,
+    )
+
+
+def _validate_download_url(component: str, platform: str, asset_name: str, download_url: str) -> None:
+    parsed = urlparse(download_url)
+    if parsed.scheme != "https" or not parsed.hostname:
+        raise ValueError(
+            f"component {component!r} platform {platform!r} field 'download_url' "
+            "must be an immutable https URL with a hostname"
+        )
+    if parsed.query or parsed.fragment:
+        raise ValueError(
+            f"component {component!r} platform {platform!r} field 'download_url' "
+            "must not include query or fragment components"
+        )
+    path_name = PurePosixPath(parsed.path).name
+    if path_name != asset_name:
+        raise ValueError(
+            f"component {component!r} platform {platform!r} field 'download_url' "
+            "final path segment must equal asset_name"
+        )
+
+
+def _required_str(data: dict[str, Any], key: str, owner: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"component {owner!r} field {key!r} must be a non-empty string")
+    return value.strip()
+
+
+def _reject_unexpected_keys(data: dict[str, Any], *, allowed: frozenset[str], owner: str) -> None:
+    for key in sorted(data):
+        if key not in allowed:
+            raise ValueError(f"{owner} field {key!r} is not supported")
+
+
+def _safe_asset_name(asset_name: str) -> bool:
+    if "/" in asset_name or "\\" in asset_name or asset_name in {".", ".."}:
+        return False
+    return Path(asset_name).name == asset_name
+
+
+def _unknown_component_diagnostics(unknown_ids: list[str]) -> tuple[str, ...]:
+    if not unknown_ids:
+        return ()
+    known = ", ".join(KNOWN_COMPONENT_IDS)
+    return tuple(
+        f"component manifest lists unknown component {component_id!r}; known components: {known}"
+        for component_id in unknown_ids
+    )

--- a/src/brigade/component_paths.py
+++ b/src/brigade/component_paths.py
@@ -1,0 +1,117 @@
+"""User-local install and cache path invariants for native components."""
+
+from __future__ import annotations
+
+import os
+import platform as host_platform
+import re
+from collections.abc import Mapping
+from pathlib import PurePosixPath, PureWindowsPath
+
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+
+def data_root(*, env: Mapping[str, str] | None = None, system: str | None = None) -> str:
+    """Return the OS-specific user data root without admin rights."""
+    environment = env if env is not None else os.environ
+    os_name = _normalize_system(system)
+    if os_name == "windows":
+        localappdata = environment.get("LOCALAPPDATA")
+        if not localappdata:
+            raise ValueError("windows component data root requires LOCALAPPDATA")
+        return _normalize(localappdata, windows=True)
+    home = environment.get("HOME")
+    if not home:
+        raise ValueError("component data root requires HOME")
+    if os_name == "darwin":
+        return _join(home, "Library", "Application Support", windows=False)
+    data_home = environment.get("XDG_DATA_HOME")
+    return _normalize(data_home, windows=False) if data_home else _join(home, ".local", "share", windows=False)
+
+
+def cache_root(*, env: Mapping[str, str] | None = None, system: str | None = None) -> str:
+    """Return the OS-specific user cache root without admin rights."""
+    environment = env if env is not None else os.environ
+    os_name = _normalize_system(system)
+    if os_name == "windows":
+        localappdata = environment.get("LOCALAPPDATA")
+        if not localappdata:
+            raise ValueError("windows component cache root requires LOCALAPPDATA")
+        return _normalize(localappdata, windows=True)
+    home = environment.get("HOME")
+    if not home:
+        raise ValueError("component cache root requires HOME")
+    if os_name == "darwin":
+        return _join(home, "Library", "Caches", windows=False)
+    cache_home = environment.get("XDG_CACHE_HOME")
+    return _normalize(cache_home, windows=False) if cache_home else _join(home, ".cache", windows=False)
+
+
+def components_dir(data_root_path: str) -> str:
+    return _join(data_root_path, "brigade", "components", windows=_is_windows_path(data_root_path))
+
+
+def managed_executable_path(data_root_path: str, executable: str) -> str:
+    windows = _is_windows_path(data_root_path)
+    name = executable
+    if windows and not executable.lower().endswith(".exe"):
+        name = f"{executable}.exe"
+    return _join(
+        data_root_path,
+        "brigade",
+        "bin",
+        name,
+        windows=windows,
+    )
+
+
+def installed_state_path(data_root_path: str) -> str:
+    return _join(data_root_path, "brigade", "installed.json", windows=_is_windows_path(data_root_path))
+
+
+def cached_asset_path(cache_root_path: str, sha256: str, asset_name: str) -> str:
+    if not _SHA256.fullmatch(sha256):
+        raise ValueError("sha256 must be 64 lowercase hex characters")
+    if not _safe_basename(asset_name):
+        raise ValueError("asset_name must be a safe basename")
+    return _join(
+        cache_root_path,
+        "brigade",
+        "components",
+        sha256,
+        asset_name,
+        windows=_is_windows_path(cache_root_path),
+    )
+
+
+def _normalize_system(system: str | None) -> str:
+    raw = (system or host_platform.system()).lower()
+    if raw in {"darwin", "macos", "mac os x"}:
+        return "darwin"
+    if raw in {"windows", "nt"}:
+        return "windows"
+    if raw == "linux":
+        return "linux"
+    raise ValueError(f"unsupported component path platform system {raw!r}; supported systems: darwin, linux, windows")
+
+
+def _is_windows_path(path: str) -> bool:
+    return "\\" in path or (len(path) > 1 and path[1] == ":")
+
+
+def _safe_basename(name: str) -> bool:
+    if "/" in name or "\\" in name or name in {".", ".."}:
+        return False
+    return PurePosixPath(name).name == name and PureWindowsPath(name).name == name
+
+
+def _join(*parts: str, windows: bool) -> str:
+    if windows:
+        return str(PureWindowsPath(*parts))
+    return str(PurePosixPath(*parts))
+
+
+def _normalize(path: str, *, windows: bool) -> str:
+    if windows:
+        return str(PureWindowsPath(path))
+    return str(PurePosixPath(path))

--- a/src/brigade/templates/components/manifest-v1.json
+++ b/src/brigade/templates/components/manifest-v1.json
@@ -1,0 +1,100 @@
+{
+  "schema_version": 1,
+  "brigade_version": "0.23.0",
+  "manifest_revision": "2026-07-18",
+  "supported_platforms": [
+    "linux-amd64",
+    "linux-arm64",
+    "darwin-amd64",
+    "darwin-arm64",
+    "windows-amd64"
+  ],
+  "components": {
+    "graphtrail": {
+      "component_revision": "64fcd2f9ec37f33e286708845a92e6cfa4abf3bb",
+      "source": {"repository": "escoffier-labs/graphtrail"},
+      "executable": "graphtrail",
+      "assets": {}
+    },
+    "graphtrail-mcp": {
+      "component_revision": "64fcd2f9ec37f33e286708845a92e6cfa4abf3bb",
+      "source": {"repository": "escoffier-labs/graphtrail"},
+      "executable": "graphtrail-mcp",
+      "assets": {}
+    },
+    "miseledger": {
+      "component_revision": "v0.6.0",
+      "source": {"repository": "escoffier-labs/miseledger", "release_tag": "v0.6.0"},
+      "executable": "miseledger",
+      "assets": {
+        "darwin-amd64": {
+          "asset_name": "miseledger-darwin-amd64",
+          "byte_size": 16659744,
+          "sha256": "fb952aefd763a624e2c0346e7cc22dde8af812649ece97bd6cb62f16bc9881df",
+          "download_url": "https://github.com/escoffier-labs/miseledger/releases/download/v0.6.0/miseledger-darwin-amd64"
+        },
+        "darwin-arm64": {
+          "asset_name": "miseledger-darwin-arm64",
+          "byte_size": 15784018,
+          "sha256": "ae13b508d84d651e388218275511ca13176a4747c6b93dfc78c7ab6bc9cdca1f",
+          "download_url": "https://github.com/escoffier-labs/miseledger/releases/download/v0.6.0/miseledger-darwin-arm64"
+        },
+        "linux-amd64": {
+          "asset_name": "miseledger-linux-amd64",
+          "byte_size": 16441315,
+          "sha256": "246893c8c39318f774fc7a06338b5a8e87bf84661b1951251b2c0c971e9a7a6c",
+          "download_url": "https://github.com/escoffier-labs/miseledger/releases/download/v0.6.0/miseledger-linux-amd64"
+        },
+        "linux-arm64": {
+          "asset_name": "miseledger-linux-arm64",
+          "byte_size": 15314138,
+          "sha256": "425ea81daaf9fc793862e2d66f49ef948dc1ea186d3db56df49544dca5e26b32",
+          "download_url": "https://github.com/escoffier-labs/miseledger/releases/download/v0.6.0/miseledger-linux-arm64"
+        },
+        "windows-amd64": {
+          "asset_name": "miseledger-windows-amd64.exe",
+          "byte_size": 16616960,
+          "sha256": "033f9a492435068cd7e2bd1882422c1419189f60898071411656595a93640e39",
+          "download_url": "https://github.com/escoffier-labs/miseledger/releases/download/v0.6.0/miseledger-windows-amd64.exe"
+        }
+      }
+    },
+    "sessionfind": {
+      "component_revision": "v0.6.0",
+      "source": {"repository": "escoffier-labs/miseledger", "release_tag": "v0.6.0"},
+      "executable": "sessionfind",
+      "assets": {
+        "darwin-amd64": {
+          "asset_name": "sessionfind-darwin-amd64",
+          "byte_size": 16659776,
+          "sha256": "33359c447f58954463a1a7a02253f7090db52f6e8189c406c7707bc20844689d",
+          "download_url": "https://github.com/escoffier-labs/miseledger/releases/download/v0.6.0/sessionfind-darwin-amd64"
+        },
+        "darwin-arm64": {
+          "asset_name": "sessionfind-darwin-arm64",
+          "byte_size": 15784066,
+          "sha256": "0219288e4bd1df8cf49989ab83753f6b7f564eee072f63af1db8a7460a902771",
+          "download_url": "https://github.com/escoffier-labs/miseledger/releases/download/v0.6.0/sessionfind-darwin-arm64"
+        },
+        "linux-amd64": {
+          "asset_name": "sessionfind-linux-amd64",
+          "byte_size": 16445238,
+          "sha256": "5b42f573d44f4301b0e1cfc2008842849c7704c0f96e390c2f5461f1f8059ac0",
+          "download_url": "https://github.com/escoffier-labs/miseledger/releases/download/v0.6.0/sessionfind-linux-amd64"
+        },
+        "linux-arm64": {
+          "asset_name": "sessionfind-linux-arm64",
+          "byte_size": 15315773,
+          "sha256": "80695c1d92a0a01cffe8248c655bba3fe2579bb931c35ca311e7067eef69ab37",
+          "download_url": "https://github.com/escoffier-labs/miseledger/releases/download/v0.6.0/sessionfind-linux-arm64"
+        },
+        "windows-amd64": {
+          "asset_name": "sessionfind-windows-amd64.exe",
+          "byte_size": 16620032,
+          "sha256": "b8bb05fe9b310012893cd49d11f4acf27171194b9a7ab492fa5d2dc1614b0842",
+          "download_url": "https://github.com/escoffier-labs/miseledger/releases/download/v0.6.0/sessionfind-windows-amd64.exe"
+        }
+      }
+    }
+  }
+}

--- a/tests/test_component_manifest.py
+++ b/tests/test_component_manifest.py
@@ -1,0 +1,638 @@
+"""Tests for brigade component manifest v1."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from brigade import component_manifest
+
+MISELEDGER_BASE = "https://github.com/escoffier-labs/miseledger/releases/download/v0.6.0/"
+GRAPHTRAIL_SHA = "64fcd2f9ec37f33e286708845a92e6cfa4abf3bb"
+
+MISELEDGER_V060_ASSETS = [
+    (
+        "miseledger",
+        "darwin-amd64",
+        "miseledger-darwin-amd64",
+        16659744,
+        "fb952aefd763a624e2c0346e7cc22dde8af812649ece97bd6cb62f16bc9881df",
+    ),
+    (
+        "miseledger",
+        "darwin-arm64",
+        "miseledger-darwin-arm64",
+        15784018,
+        "ae13b508d84d651e388218275511ca13176a4747c6b93dfc78c7ab6bc9cdca1f",
+    ),
+    (
+        "miseledger",
+        "linux-amd64",
+        "miseledger-linux-amd64",
+        16441315,
+        "246893c8c39318f774fc7a06338b5a8e87bf84661b1951251b2c0c971e9a7a6c",
+    ),
+    (
+        "miseledger",
+        "linux-arm64",
+        "miseledger-linux-arm64",
+        15314138,
+        "425ea81daaf9fc793862e2d66f49ef948dc1ea186d3db56df49544dca5e26b32",
+    ),
+    (
+        "miseledger",
+        "windows-amd64",
+        "miseledger-windows-amd64.exe",
+        16616960,
+        "033f9a492435068cd7e2bd1882422c1419189f60898071411656595a93640e39",
+    ),
+    (
+        "sessionfind",
+        "darwin-amd64",
+        "sessionfind-darwin-amd64",
+        16659776,
+        "33359c447f58954463a1a7a02253f7090db52f6e8189c406c7707bc20844689d",
+    ),
+    (
+        "sessionfind",
+        "darwin-arm64",
+        "sessionfind-darwin-arm64",
+        15784066,
+        "0219288e4bd1df8cf49989ab83753f6b7f564eee072f63af1db8a7460a902771",
+    ),
+    (
+        "sessionfind",
+        "linux-amd64",
+        "sessionfind-linux-amd64",
+        16445238,
+        "5b42f573d44f4301b0e1cfc2008842849c7704c0f96e390c2f5461f1f8059ac0",
+    ),
+    (
+        "sessionfind",
+        "linux-arm64",
+        "sessionfind-linux-arm64",
+        15315773,
+        "80695c1d92a0a01cffe8248c655bba3fe2579bb931c35ca311e7067eef69ab37",
+    ),
+    (
+        "sessionfind",
+        "windows-amd64",
+        "sessionfind-windows-amd64.exe",
+        16620032,
+        "b8bb05fe9b310012893cd49d11f4acf27171194b9a7ab492fa5d2dc1614b0842",
+    ),
+]
+
+
+def _minimal_known_component(
+    *,
+    component_revision: str = "v0.6.0",
+    repository: str = "escoffier-labs/miseledger",
+    release_tag: str | None = "v0.6.0",
+    executable: str = "miseledger",
+    assets: dict | None = None,
+) -> dict:
+    source: dict[str, str] = {"repository": repository}
+    asset_map = assets if assets is not None else {}
+    if asset_map:
+        if release_tag is None:
+            raise ValueError("release_tag is required when assets are published")
+        source["release_tag"] = release_tag
+    elif release_tag is not None:
+        raise ValueError("release_tag must be omitted when assets are unpublished")
+    return {
+        "component_revision": component_revision,
+        "source": source,
+        "executable": executable,
+        "assets": asset_map,
+    }
+
+
+def _miseledger_asset(asset_name: str, byte_size: int, sha256: str) -> dict:
+    return {
+        "asset_name": asset_name,
+        "byte_size": byte_size,
+        "sha256": sha256,
+        "download_url": MISELEDGER_BASE + asset_name,
+    }
+
+
+def _full_miseledger_assets(component_id: str) -> dict:
+    assets: dict = {}
+    for comp, platform, asset_name, byte_size, sha256 in MISELEDGER_V060_ASSETS:
+        if comp != component_id:
+            continue
+        assets[platform] = _miseledger_asset(asset_name, byte_size, sha256)
+    return assets
+
+
+def _write_manifest(tmp_path: Path, **overrides) -> Path:
+    payload = {
+        "schema_version": 1,
+        "brigade_version": "test",
+        "manifest_revision": "2026-07-18",
+        "supported_platforms": list(component_manifest.SUPPORTED_PLATFORMS),
+        "components": {
+            "graphtrail": _minimal_known_component(
+                component_revision=GRAPHTRAIL_SHA,
+                repository="escoffier-labs/graphtrail",
+                release_tag=None,
+                executable="graphtrail",
+            ),
+            "graphtrail-mcp": _minimal_known_component(
+                component_revision=GRAPHTRAIL_SHA,
+                repository="escoffier-labs/graphtrail",
+                release_tag=None,
+                executable="graphtrail-mcp",
+            ),
+            "miseledger": _minimal_known_component(assets=_full_miseledger_assets("miseledger")),
+            "sessionfind": _minimal_known_component(
+                executable="sessionfind",
+                assets=_full_miseledger_assets("sessionfind"),
+            ),
+        },
+    }
+    payload.update(overrides)
+    path = tmp_path / "manifest-v1.json"
+    path.write_text(json.dumps(payload))
+    return path
+
+
+def test_bundled_manifest_pins_miseledger_and_leaves_graphtrail_assets_unpublished():
+    manifest = component_manifest.load()
+
+    assert manifest.schema_version == 1
+    assert manifest.brigade_version == "0.23.0"
+    assert manifest.manifest_revision
+    assert manifest.supported_platforms == component_manifest.SUPPORTED_PLATFORMS
+    assert set(manifest.components) == set(component_manifest.KNOWN_COMPONENT_IDS)
+    assert manifest.components["miseledger"].component_revision == "v0.6.0"
+    assert manifest.components["miseledger"].source.release_tag == "v0.6.0"
+    asset = manifest.components["miseledger"].assets["linux-amd64"]
+    assert asset.asset_name == "miseledger-linux-amd64"
+    assert asset.byte_size == 16441315
+    assert asset.sha256 == "246893c8c39318f774fc7a06338b5a8e87bf84661b1951251b2c0c971e9a7a6c"
+    assert asset.download_url.endswith("/miseledger-linux-amd64")
+    assert manifest.components["graphtrail"].assets == {}
+    assert manifest.components["graphtrail"].source.release_tag is None
+    assert manifest.components["graphtrail-mcp"].assets == {}
+    assert manifest.components["graphtrail-mcp"].source.release_tag is None
+    assert manifest.unknown_component_diagnostics == ()
+
+
+@pytest.mark.parametrize(
+    ("component_id", "platform", "asset_name", "byte_size", "sha256"),
+    MISELEDGER_V060_ASSETS,
+    ids=[f"{comp}-{plat}" for comp, plat, *_ in MISELEDGER_V060_ASSETS],
+)
+def test_bundled_manifest_pins_miseledger_v060_assets(component_id, platform, asset_name, byte_size, sha256):
+    manifest = component_manifest.load()
+    asset = manifest.components[component_id].assets[platform]
+    assert asset.asset_name == asset_name
+    assert asset.byte_size == byte_size
+    assert asset.sha256 == sha256
+    assert asset.download_url == MISELEDGER_BASE + asset_name
+    if platform == "windows-amd64":
+        assert asset_name.endswith(".exe")
+    else:
+        assert not asset_name.endswith(".exe")
+
+
+def test_bundled_manifest_pins_graphtrail_to_git_sha():
+    manifest = component_manifest.load()
+    for component_id in ("graphtrail", "graphtrail-mcp"):
+        revision = manifest.components[component_id].component_revision
+        assert revision == GRAPHTRAIL_SHA
+        assert len(revision) == 40
+        assert all(ch in "0123456789abcdef" for ch in revision)
+
+
+def test_schema_contract_requires_exact_platform_order_and_known_components():
+    schema = json.loads((Path(__file__).resolve().parents[1] / "docs/component-manifest-v1.schema.json").read_text())
+    supported = schema["properties"]["supported_platforms"]
+    assert supported["const"] == list(component_manifest.SUPPORTED_PLATFORMS)
+
+    components = schema["properties"]["components"]
+    assert components["required"] == list(component_manifest.KNOWN_COMPONENT_IDS)
+    for component_id in ("miseledger", "sessionfind"):
+        component_schema = components["properties"][component_id]
+        assert component_schema["allOf"][0]["$ref"] == "#/$defs/known_component"
+        assert component_schema["allOf"][1]["properties"]["executable"]["const"] == component_id
+    graphtrail_paired_branches = [
+        {
+            "properties": {
+                "source": {"$ref": "#/$defs/unpublished_source"},
+                "assets": {"$ref": "#/$defs/empty_assets"},
+            },
+            "required": ["source", "assets"],
+        },
+        {
+            "properties": {
+                "source": {"$ref": "#/$defs/published_source"},
+                "assets": {"$ref": "#/$defs/published_assets"},
+            },
+            "required": ["source", "assets"],
+        },
+    ]
+    for component_id in ("graphtrail", "graphtrail-mcp"):
+        component_schema = components["properties"][component_id]
+        base = component_schema["allOf"][0]
+        assert base["type"] == "object"
+        assert base["additionalProperties"] is False
+        assert base["properties"]["executable"]["const"] == component_id
+        assert component_schema["allOf"][1]["oneOf"] == graphtrail_paired_branches
+    assert components["additionalProperties"] is True
+
+    known_component = schema["$defs"]["known_component"]
+    assert known_component["additionalProperties"] is False
+    assert set(known_component["required"]) == {
+        "component_revision",
+        "source",
+        "executable",
+        "assets",
+    }
+
+    graphtrail_revision = schema["$defs"]["graphtrail_component_revision"]
+    assert graphtrail_revision["pattern"] == "^[0-9a-f]{40}$"
+    for component_id in ("graphtrail", "graphtrail-mcp"):
+        revision = components["properties"][component_id]["allOf"][0]["properties"]["component_revision"]
+        assert revision == {"$ref": "#/$defs/graphtrail_component_revision"}
+
+    platform_keys = list(component_manifest.SUPPORTED_PLATFORMS)
+    published_assets = schema["$defs"]["published_assets"]
+    assert published_assets["required"] == platform_keys
+    assert set(published_assets["properties"]) == set(platform_keys)
+    assert published_assets["additionalProperties"] is False
+    for component_id in ("miseledger", "sessionfind"):
+        assets = components["properties"][component_id]["allOf"][1]["properties"]["assets"]
+        assert assets == {"$ref": "#/$defs/published_assets"}
+        source = components["properties"][component_id]["allOf"][1]["properties"]["source"]
+        assert source == {"$ref": "#/$defs/published_source"}
+
+    published_source = schema["$defs"]["published_source"]
+    assert published_source["required"] == ["repository", "release_tag"]
+    assert set(published_source["properties"]) == {"repository", "release_tag"}
+
+    asset = schema["$defs"]["asset"]
+    assert asset["additionalProperties"] is False
+    assert set(asset["properties"]) == {"asset_name", "byte_size", "sha256", "download_url"}
+    assert asset["properties"]["download_url"]["pattern"] == "^https://[^?#]+/[^/?#]+$"
+
+    empty_assets = schema["$defs"]["empty_assets"]
+    assert empty_assets["type"] == "object"
+    assert empty_assets["additionalProperties"] is False
+    assert empty_assets["maxProperties"] == 0
+    assert "unpublished_assets" not in schema["$defs"]
+
+    unpublished_source = schema["$defs"]["unpublished_source"]
+    assert unpublished_source["required"] == ["repository"]
+    assert set(unpublished_source["properties"]) == {"repository"}
+
+    unix_asset = schema["$defs"]["unix_asset"]
+    assert "linux|darwin" in unix_asset["allOf"][1]["properties"]["asset_name"]["pattern"]
+    windows_asset = schema["$defs"]["windows_asset"]
+    assert windows_asset["allOf"][1]["properties"]["asset_name"]["pattern"].endswith("\\.exe$")
+
+
+def test_manifest_rejects_unknown_schema_versions(tmp_path):
+    path = _write_manifest(tmp_path, schema_version=2)
+    with pytest.raises(ValueError, match="unsupported component manifest schema version 2"):
+        component_manifest.load(path)
+
+    path = _write_manifest(tmp_path, schema_version=True)
+    with pytest.raises(ValueError, match="unsupported component manifest schema version"):
+        component_manifest.load(path)
+
+
+def test_manifest_rejects_unsupported_host_platform_matrix(tmp_path):
+    path = _write_manifest(tmp_path, supported_platforms=["linux-amd64"])
+    with pytest.raises(ValueError, match="supported_platforms"):
+        component_manifest.load(path)
+
+
+def test_manifest_rejects_reordered_supported_platforms(tmp_path):
+    reordered = [
+        "linux-arm64",
+        "linux-amd64",
+        "darwin-amd64",
+        "darwin-arm64",
+        "windows-amd64",
+    ]
+    path = _write_manifest(tmp_path, supported_platforms=reordered)
+    with pytest.raises(ValueError, match="supported_platforms"):
+        component_manifest.load(path)
+
+
+def test_manifest_rejects_partial_graphtrail_assets(tmp_path):
+    base = json.loads(_write_manifest(tmp_path).read_text())
+    base["components"]["graphtrail"]["assets"] = {
+        "linux-amd64": _miseledger_asset(
+            "graphtrail-linux-amd64",
+            100,
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )
+    }
+    path = tmp_path / "partial-graphtrail.json"
+    path.write_text(json.dumps(base))
+    with pytest.raises(ValueError, match="must publish the full supported platform matrix"):
+        component_manifest.load(path)
+
+
+def test_manifest_accepts_full_graphtrail_matrix(tmp_path):
+    base = json.loads(_write_manifest(tmp_path).read_text())
+    release_tag = "v0.1.0"
+    assets = {}
+    for platform, asset_name, byte_size, sha256 in [
+        ("linux-amd64", "graphtrail-linux-amd64", 100, "a" * 64),
+        ("linux-arm64", "graphtrail-linux-arm64", 100, "b" * 64),
+        ("darwin-amd64", "graphtrail-darwin-amd64", 100, "c" * 64),
+        ("darwin-arm64", "graphtrail-darwin-arm64", 100, "d" * 64),
+        (
+            "windows-amd64",
+            "graphtrail-windows-amd64.exe",
+            100,
+            "e" * 64,
+        ),
+    ]:
+        assets[platform] = {
+            "asset_name": asset_name,
+            "byte_size": byte_size,
+            "sha256": sha256,
+            "download_url": (
+                f"https://github.com/escoffier-labs/graphtrail/releases/download/{release_tag}/{asset_name}"
+            ),
+        }
+    base["components"]["graphtrail"]["assets"] = assets
+    base["components"]["graphtrail"]["source"]["release_tag"] = release_tag
+    path = tmp_path / "full-graphtrail.json"
+    path.write_text(json.dumps(base))
+    manifest = component_manifest.load(path)
+    assert set(manifest.components["graphtrail"].assets) == set(component_manifest.SUPPORTED_PLATFORMS)
+    assert manifest.components["graphtrail"].source.release_tag == release_tag
+
+
+def test_manifest_rejects_invalid_asset_platform_key(tmp_path):
+    base = json.loads(_write_manifest(tmp_path).read_text())
+    asset = base["components"]["miseledger"]["assets"]["linux-amd64"]
+    base["components"]["miseledger"]["assets"] = {"freebsd-amd64": asset}
+    path = tmp_path / "bad-platform-key.json"
+    path.write_text(json.dumps(base))
+    with pytest.raises(ValueError, match="invalid platform key 'freebsd-amd64'"):
+        component_manifest.load(path)
+
+
+def test_manifest_rejects_out_of_matrix_asset_platform_key(tmp_path):
+    base = json.loads(_write_manifest(tmp_path).read_text())
+    asset = base["components"]["miseledger"]["assets"]["linux-amd64"]
+    base["components"]["miseledger"]["assets"] = {"windows-arm64": asset}
+    path = tmp_path / "out-of-matrix-platform-key.json"
+    path.write_text(json.dumps(base))
+    with pytest.raises(ValueError, match="outside the Phase 1 support matrix"):
+        component_manifest.load(path)
+
+
+def test_manifest_ignores_unknown_components_with_deterministic_diagnostic(tmp_path):
+    path = _write_manifest(tmp_path)
+    base = json.loads(path.read_text())
+    base["components"]["future-tool"] = {
+        "component_revision": "v9",
+        "source": {"repository": "example/future"},
+        "executable": "future-tool",
+        "assets": {},
+    }
+    path.write_text(json.dumps(base))
+
+    manifest = component_manifest.load(path)
+
+    assert "future-tool" not in manifest.components
+    assert manifest.unknown_component_diagnostics == (
+        "component manifest lists unknown component 'future-tool'; known components: "
+        "graphtrail, graphtrail-mcp, miseledger, sessionfind",
+    )
+
+
+@pytest.mark.parametrize("value", ["future-tool", ["future-tool"], None])
+def test_manifest_ignores_unknown_components_regardless_of_value_shape(tmp_path, value):
+    path = _write_manifest(tmp_path)
+    base = json.loads(path.read_text())
+    base["components"]["future-tool"] = value
+    path.write_text(json.dumps(base))
+
+    manifest = component_manifest.load(path)
+
+    assert "future-tool" not in manifest.components
+    assert manifest.unknown_component_diagnostics == (
+        "component manifest lists unknown component 'future-tool'; known components: "
+        "graphtrail, graphtrail-mcp, miseledger, sessionfind",
+    )
+
+
+def test_manifest_rejects_unexpected_top_level_key(tmp_path):
+    path = _write_manifest(tmp_path, extra_field="nope")
+    with pytest.raises(ValueError, match="manifest field 'extra_field' is not supported"):
+        component_manifest.load(path)
+
+
+def test_manifest_rejects_unexpected_known_component_key(tmp_path):
+    base = json.loads(_write_manifest(tmp_path).read_text())
+    base["components"]["miseledger"]["extra_field"] = True
+    path = tmp_path / "bad.json"
+    path.write_text(json.dumps(base))
+    with pytest.raises(ValueError, match="component 'miseledger' field 'extra_field' is not supported"):
+        component_manifest.load(path)
+
+
+def test_manifest_rejects_unexpected_source_key(tmp_path):
+    base = json.loads(_write_manifest(tmp_path).read_text())
+    base["components"]["miseledger"]["source"]["extra_field"] = True
+    path = tmp_path / "bad.json"
+    path.write_text(json.dumps(base))
+    with pytest.raises(ValueError, match="component 'miseledger' source field 'extra_field' is not supported"):
+        component_manifest.load(path)
+
+
+def test_manifest_rejects_unexpected_asset_key(tmp_path):
+    base = json.loads(_write_manifest(tmp_path).read_text())
+    base["components"]["miseledger"]["assets"]["linux-amd64"]["extra_field"] = True
+    path = tmp_path / "bad.json"
+    path.write_text(json.dumps(base))
+    with pytest.raises(
+        ValueError,
+        match="component 'miseledger' platform 'linux-amd64' field 'extra_field' is not supported",
+    ):
+        component_manifest.load(path)
+
+
+def test_manifest_accepts_alternate_valid_graphtrail_git_sha(tmp_path):
+    alternate_sha = "a" * 40
+    base = json.loads(_write_manifest(tmp_path).read_text())
+    base["components"]["graphtrail"]["component_revision"] = alternate_sha
+    path = tmp_path / "alt-sha.json"
+    path.write_text(json.dumps(base))
+    manifest = component_manifest.load(path)
+    assert manifest.components["graphtrail"].component_revision == alternate_sha
+
+
+def test_resolve_unknown_component_lists_known_components(tmp_path):
+    manifest = component_manifest.load(_write_manifest(tmp_path))
+    with pytest.raises(ValueError, match="unknown component 'missing'"):
+        component_manifest.resolve_asset(manifest, "missing", "linux-amd64")
+
+
+def test_resolve_unpublished_graphtrail_raises_unsupported_component_platform(tmp_path):
+    manifest = component_manifest.load(_write_manifest(tmp_path))
+    with pytest.raises(ValueError, match="unsupported-component-platform"):
+        component_manifest.resolve_asset(manifest, "graphtrail", "linux-amd64")
+
+
+def test_resolve_miseledger_returns_pinned_asset(tmp_path):
+    manifest = component_manifest.load(_write_manifest(tmp_path))
+    asset = component_manifest.resolve_asset(manifest, "miseledger", "linux-amd64")
+    assert asset.asset_name == "miseledger-linux-amd64"
+
+
+def test_manifest_rejects_malformed_known_asset_fields(tmp_path):
+    base = json.loads(_write_manifest(tmp_path).read_text())
+    base["components"]["miseledger"]["assets"]["linux-amd64"]["sha256"] = "not-hex"
+    path = tmp_path / "bad.json"
+    path.write_text(json.dumps(base))
+    with pytest.raises(ValueError, match="component 'miseledger' platform 'linux-amd64' field 'sha256'"):
+        component_manifest.load(path)
+
+
+def test_manifest_rejects_asset_names_that_escape_cache(tmp_path):
+    base = json.loads(_write_manifest(tmp_path).read_text())
+    base["components"]["miseledger"]["assets"]["linux-amd64"]["asset_name"] = "../miseledger"
+    path = tmp_path / "bad.json"
+    path.write_text(json.dumps(base))
+    with pytest.raises(ValueError, match="must be 'miseledger-linux-amd64'"):
+        component_manifest.load(path)
+
+
+def test_manifest_rejects_executable_mismatch(tmp_path):
+    base = json.loads(_write_manifest(tmp_path).read_text())
+    base["components"]["miseledger"]["executable"] = "wrong-name"
+    path = tmp_path / "bad.json"
+    path.write_text(json.dumps(base))
+    with pytest.raises(ValueError, match="field 'executable' must equal the component id"):
+        component_manifest.load(path)
+
+
+def test_manifest_rejects_partial_miseledger_assets(tmp_path):
+    base = json.loads(_write_manifest(tmp_path).read_text())
+    del base["components"]["miseledger"]["assets"]["linux-arm64"]
+    path = tmp_path / "bad.json"
+    path.write_text(json.dumps(base))
+    with pytest.raises(ValueError, match="must publish the full supported platform matrix"):
+        component_manifest.load(path)
+
+
+def test_manifest_rejects_empty_sessionfind_assets(tmp_path):
+    base = json.loads(_write_manifest(tmp_path).read_text())
+    base["components"]["sessionfind"]["assets"] = {}
+    path = tmp_path / "bad.json"
+    path.write_text(json.dumps(base))
+    with pytest.raises(ValueError, match="must publish assets for every supported platform"):
+        component_manifest.load(path)
+
+
+def test_manifest_rejects_graphtrail_revision_that_is_not_git_sha(tmp_path):
+    base = json.loads(_write_manifest(tmp_path).read_text())
+    base["components"]["graphtrail"]["component_revision"] = "unreleased"
+    path = tmp_path / "bad.json"
+    path.write_text(json.dumps(base))
+    with pytest.raises(ValueError, match="must be a 40-character lowercase git SHA"):
+        component_manifest.load(path)
+
+
+def test_manifest_rejects_published_component_without_release_tag(tmp_path):
+    base = json.loads(_write_manifest(tmp_path).read_text())
+    del base["components"]["miseledger"]["source"]["release_tag"]
+    path = tmp_path / "bad.json"
+    path.write_text(json.dumps(base))
+    with pytest.raises(ValueError, match="source.release_tag' must be set when assets are published"):
+        component_manifest.load(path)
+
+
+def test_manifest_rejects_unpublished_component_with_release_tag(tmp_path):
+    base = json.loads(_write_manifest(tmp_path).read_text())
+    base["components"]["graphtrail"]["source"]["release_tag"] = "v0.1.0"
+    path = tmp_path / "bad.json"
+    path.write_text(json.dumps(base))
+    with pytest.raises(ValueError, match="source.release_tag' must be omitted when assets are unpublished"):
+        component_manifest.load(path)
+
+
+def test_manifest_accepts_sha_revision_with_semantic_release_tag(tmp_path):
+    base = json.loads(_write_manifest(tmp_path).read_text())
+    base["components"]["graphtrail"]["component_revision"] = GRAPHTRAIL_SHA
+    release_tag = "v0.1.0"
+    assets = {}
+    for platform, asset_name, byte_size, sha256 in [
+        ("linux-amd64", "graphtrail-linux-amd64", 100, "a" * 64),
+        ("linux-arm64", "graphtrail-linux-arm64", 100, "b" * 64),
+        ("darwin-amd64", "graphtrail-darwin-amd64", 100, "c" * 64),
+        ("darwin-arm64", "graphtrail-darwin-arm64", 100, "d" * 64),
+        ("windows-amd64", "graphtrail-windows-amd64.exe", 100, "e" * 64),
+    ]:
+        assets[platform] = {
+            "asset_name": asset_name,
+            "byte_size": byte_size,
+            "sha256": sha256,
+            "download_url": (
+                f"https://github.com/escoffier-labs/graphtrail/releases/download/{release_tag}/{asset_name}"
+            ),
+        }
+    base["components"]["graphtrail"]["assets"] = assets
+    base["components"]["graphtrail"]["source"]["release_tag"] = release_tag
+    path = tmp_path / "sha-with-release-tag.json"
+    path.write_text(json.dumps(base))
+    manifest = component_manifest.load(path)
+    assert manifest.components["graphtrail"].component_revision == GRAPHTRAIL_SHA
+    assert manifest.components["graphtrail"].source.release_tag == release_tag
+
+
+@pytest.mark.parametrize(
+    "download_url",
+    [
+        "http://github.com/escoffier-labs/miseledger/releases/download/v0.6.0/miseledger-linux-amd64",
+        "https:///miseledger-linux-amd64",
+        MISELEDGER_BASE + "miseledger-linux-amd64?cache=1",
+        MISELEDGER_BASE + "miseledger-linux-amd64#frag",
+        MISELEDGER_BASE + "evil-miseledger-linux-amd64",
+    ],
+)
+def test_manifest_rejects_bad_download_urls(tmp_path, download_url):
+    base = json.loads(_write_manifest(tmp_path).read_text())
+    base["components"]["miseledger"]["assets"]["linux-amd64"]["download_url"] = download_url
+    path = tmp_path / "bad.json"
+    path.write_text(json.dumps(base))
+    with pytest.raises(ValueError, match="download_url"):
+        component_manifest.load(path)
+
+
+def test_manifest_rejects_wrong_windows_asset_suffix(tmp_path):
+    base = json.loads(_write_manifest(tmp_path).read_text())
+    base["components"]["miseledger"]["assets"]["windows-amd64"]["asset_name"] = "miseledger-windows-amd64"
+    base["components"]["miseledger"]["assets"]["windows-amd64"]["download_url"] = (
+        MISELEDGER_BASE + "miseledger-windows-amd64"
+    )
+    path = tmp_path / "bad.json"
+    path.write_text(json.dumps(base))
+    with pytest.raises(ValueError, match="must be 'miseledger-windows-amd64.exe'"):
+        component_manifest.load(path)
+
+
+def test_platform_key_uses_go_names_and_rejects_unsupported_values():
+    assert component_manifest.platform_key(system="Linux", machine="x86_64") == "linux-amd64"
+    assert component_manifest.platform_key(system="Darwin", machine="arm64") == "darwin-arm64"
+    assert component_manifest.platform_key(system="Windows", machine="AMD64") == "windows-amd64"
+    with pytest.raises(ValueError, match="unsupported platform"):
+        component_manifest.platform_key(system="linux", machine="plan9")
+
+
+def test_platform_key_hard_failure_lists_supported_keys():
+    with pytest.raises(ValueError, match="supported platform keys: linux-amd64"):
+        component_manifest.platform_key(system="Plan9", machine="mips")

--- a/tests/test_component_manifest_provenance.py
+++ b/tests/test_component_manifest_provenance.py
@@ -1,0 +1,352 @@
+"""Tests for scripts/verify_component_manifest_provenance.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+MISELEDGER_BASE = "https://github.com/escoffier-labs/miseledger/releases/download/v0.6.0/"
+CHECKSUMS_URL = MISELEDGER_BASE + "checksums.txt"
+RELEASE_API = "https://api.github.com/repos/escoffier-labs/miseledger/releases/tags/v0.6.0"
+
+MISELEDGER_ASSETS = {
+    "miseledger-darwin-amd64": {
+        "byte_size": 16659744,
+        "sha256": "fb952aefd763a624e2c0346e7cc22dde8af812649ece97bd6cb62f16bc9881df",
+    },
+    "miseledger-linux-amd64": {
+        "byte_size": 16441315,
+        "sha256": "246893c8c39318f774fc7a06338b5a8e87bf84661b1951251b2c0c971e9a7a6c",
+    },
+    "miseledger-windows-amd64.exe": {
+        "byte_size": 16616960,
+        "sha256": "033f9a492435068cd7e2bd1882422c1419189f60898071411656595a93640e39",
+    },
+    "sessionfind-linux-amd64": {
+        "byte_size": 16445238,
+        "sha256": "5b42f573d44f4301b0e1cfc2008842849c7704c0f96e390c2f5461f1f8059ac0",
+    },
+}
+
+
+def _load_provenance_module():
+    spec = importlib.util.spec_from_file_location(
+        "verify_component_manifest_provenance_test",
+        ROOT / "scripts/verify_component_manifest_provenance.py",
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _asset(name: str, *, byte_size: int, sha256: str) -> dict:
+    return {
+        "asset_name": name,
+        "byte_size": byte_size,
+        "sha256": sha256,
+        "download_url": MISELEDGER_BASE + name,
+    }
+
+
+def _minimal_manifest(*, miseledger_assets: dict | None = None) -> dict:
+    if miseledger_assets is None:
+        assets = {
+            "linux-amd64": _asset(
+                "miseledger-linux-amd64",
+                byte_size=MISELEDGER_ASSETS["miseledger-linux-amd64"]["byte_size"],
+                sha256=MISELEDGER_ASSETS["miseledger-linux-amd64"]["sha256"],
+            ),
+        }
+    else:
+        assets = miseledger_assets
+    return {
+        "schema_version": 1,
+        "brigade_version": "test",
+        "manifest_revision": "2026-07-18",
+        "supported_platforms": [
+            "linux-amd64",
+            "linux-arm64",
+            "darwin-amd64",
+            "darwin-arm64",
+            "windows-amd64",
+        ],
+        "components": {
+            "graphtrail": {
+                "component_revision": "a" * 40,
+                "source": {"repository": "escoffier-labs/graphtrail"},
+                "executable": "graphtrail",
+                "assets": {},
+            },
+            "graphtrail-mcp": {
+                "component_revision": "a" * 40,
+                "source": {"repository": "escoffier-labs/graphtrail"},
+                "executable": "graphtrail-mcp",
+                "assets": {},
+            },
+            "miseledger": {
+                "component_revision": "v0.6.0",
+                "source": {"repository": "escoffier-labs/miseledger", "release_tag": "v0.6.0"},
+                "executable": "miseledger",
+                "assets": assets,
+            },
+            "sessionfind": {
+                "component_revision": "v0.6.0",
+                "source": {"repository": "escoffier-labs/miseledger"},
+                "executable": "sessionfind",
+                "assets": {},
+            },
+        },
+    }
+
+
+def _release_payload(extra_assets: dict[str, dict] | None = None) -> dict:
+    assets = []
+    merged = dict(MISELEDGER_ASSETS)
+    if extra_assets:
+        merged.update(extra_assets)
+    for name, meta in merged.items():
+        assets.append(
+            {
+                "name": name,
+                "size": meta["byte_size"],
+                "browser_download_url": MISELEDGER_BASE + name,
+                "digest": f"sha256:{meta['sha256']}",
+            }
+        )
+    assets.append(
+        {
+            "name": "checksums.txt",
+            "size": 123,
+            "browser_download_url": CHECKSUMS_URL,
+        }
+    )
+    return {"tag_name": "v0.6.0", "assets": assets}
+
+
+def _checksums_text(asset_map: dict[str, dict] | None = None) -> str:
+    merged = dict(MISELEDGER_ASSETS)
+    if asset_map:
+        merged.update(asset_map)
+    return "\n".join(f"{meta['sha256']}  {name}" for name, meta in sorted(merged.items())) + "\n"
+
+
+def _mock_fetcher(
+    *,
+    release: dict | None = None,
+    checksums: str | None = None,
+    release_status: int = 200,
+) -> object:
+    release_payload = release if release is not None else _release_payload()
+    checksums_body = checksums if checksums is not None else _checksums_text()
+
+    def fetch(url: str) -> tuple[int, str]:
+        if url == RELEASE_API:
+            if release_status != 200:
+                return release_status, "not found"
+            return 200, json.dumps(release_payload)
+        if url == CHECKSUMS_URL:
+            return 200, checksums_body
+        raise AssertionError(f"unexpected fetch url: {url}")
+
+    return fetch
+
+
+def test_verify_manifest_provenance_success(tmp_path):
+    module = _load_provenance_module()
+    manifest_path = tmp_path / "manifest-v1.json"
+    manifest_path.write_text(json.dumps(_minimal_manifest()))
+
+    errors = module.verify_manifest(manifest_path, fetch=_mock_fetcher())
+
+    assert errors == []
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "match"),
+    [
+        ("byte_size", 1, "byte_size"),
+        ("sha256", "a" * 64, "sha256"),
+    ],
+)
+def test_verify_manifest_provenance_reports_release_mismatches(tmp_path, field, value, match):
+    module = _load_provenance_module()
+    assets = _minimal_manifest()["components"]["miseledger"]["assets"]
+    assets["linux-amd64"][field] = value
+    manifest_path = tmp_path / "manifest-v1.json"
+    manifest_path.write_text(json.dumps(_minimal_manifest(miseledger_assets=assets)))
+
+    errors = module.verify_manifest(manifest_path, fetch=_mock_fetcher())
+
+    assert any(match in error for error in errors)
+
+
+def test_verify_manifest_provenance_reports_browser_download_url_mismatch(tmp_path):
+    module = _load_provenance_module()
+    release = _release_payload()
+    for asset in release["assets"]:
+        if asset["name"] == "miseledger-linux-amd64":
+            asset["browser_download_url"] = MISELEDGER_BASE + "other-name"
+            break
+    manifest_path = tmp_path / "manifest-v1.json"
+    manifest_path.write_text(json.dumps(_minimal_manifest()))
+
+    errors = module.verify_manifest(manifest_path, fetch=_mock_fetcher(release=release))
+
+    assert any("browser_download_url" in error for error in errors)
+
+
+def test_verify_manifest_provenance_reports_missing_api_digest(tmp_path):
+    module = _load_provenance_module()
+    release = _release_payload()
+    for asset in release["assets"]:
+        if asset["name"] == "miseledger-linux-amd64":
+            asset.pop("digest", None)
+            break
+    manifest_path = tmp_path / "manifest-v1.json"
+    manifest_path.write_text(json.dumps(_minimal_manifest()))
+
+    errors = module.verify_manifest(manifest_path, fetch=_mock_fetcher(release=release))
+
+    assert any("digest" in error for error in errors)
+
+
+def test_verify_manifest_provenance_reports_checksums_mismatch(tmp_path):
+    module = _load_provenance_module()
+    manifest_path = tmp_path / "manifest-v1.json"
+    manifest_path.write_text(json.dumps(_minimal_manifest()))
+    checksums = _checksums_text(
+        {
+            "miseledger-linux-amd64": {
+                "byte_size": 16441315,
+                "sha256": "b" * 64,
+            }
+        }
+    )
+
+    errors = module.verify_manifest(manifest_path, fetch=_mock_fetcher(checksums=checksums))
+
+    assert any("checksums.txt" in error for error in errors)
+
+
+def test_verify_manifest_provenance_reports_wrong_repo_or_tag(tmp_path):
+    module = _load_provenance_module()
+    assets = _minimal_manifest()["components"]["miseledger"]["assets"]
+    assets["linux-amd64"]["download_url"] = (
+        "https://github.com/other/repo/releases/download/v9.9.9/miseledger-linux-amd64"
+    )
+    manifest_path = tmp_path / "manifest-v1.json"
+    manifest_path.write_text(json.dumps(_minimal_manifest(miseledger_assets=assets)))
+
+    errors = module.verify_manifest(manifest_path, fetch=_mock_fetcher())
+
+    assert any("repository" in error or "release_tag" in error for error in errors)
+
+
+def test_verify_manifest_provenance_accepts_sha_revision_with_semantic_release_tag(tmp_path):
+    module = _load_provenance_module()
+    release_tag = "v0.1.0"
+    graphtrail_base = f"https://github.com/escoffier-labs/graphtrail/releases/download/{release_tag}/"
+    graphtrail_api = f"https://api.github.com/repos/escoffier-labs/graphtrail/releases/tags/{release_tag}"
+    asset_name = "graphtrail-linux-amd64"
+    sha256 = "a" * 64
+    manifest = _minimal_manifest(miseledger_assets={})
+    manifest["components"]["graphtrail"] = {
+        "component_revision": "b" * 40,
+        "source": {"repository": "escoffier-labs/graphtrail", "release_tag": release_tag},
+        "executable": "graphtrail",
+        "assets": {
+            "linux-amd64": {
+                "asset_name": asset_name,
+                "byte_size": 100,
+                "sha256": sha256,
+                "download_url": graphtrail_base + asset_name,
+            }
+        },
+    }
+    release = {
+        "tag_name": release_tag,
+        "assets": [
+            {
+                "name": asset_name,
+                "size": 100,
+                "browser_download_url": graphtrail_base + asset_name,
+                "digest": f"sha256:{sha256}",
+            },
+            {
+                "name": "checksums.txt",
+                "size": 10,
+                "browser_download_url": graphtrail_base + "checksums.txt",
+            },
+        ],
+    }
+    checksums = f"{sha256}  {asset_name}\n"
+
+    def fetch(url: str) -> tuple[int, str]:
+        if url == graphtrail_api:
+            return 200, json.dumps(release)
+        if url == graphtrail_base + "checksums.txt":
+            return 200, checksums
+        raise AssertionError(f"unexpected fetch url: {url}")
+
+    manifest_path = tmp_path / "manifest-v1.json"
+    manifest_path.write_text(json.dumps(manifest))
+
+    errors = module.verify_manifest(manifest_path, fetch=fetch)
+
+    assert errors == []
+
+
+def test_verify_manifest_provenance_reports_missing_release_tag(tmp_path):
+    module = _load_provenance_module()
+    manifest = _minimal_manifest()
+    del manifest["components"]["miseledger"]["source"]["release_tag"]
+    manifest_path = tmp_path / "manifest-v1.json"
+    manifest_path.write_text(json.dumps(manifest))
+
+    errors = module.verify_manifest(manifest_path, fetch=_mock_fetcher())
+
+    assert any("source.release_tag must be set" in error for error in errors)
+
+
+def test_verify_manifest_provenance_reports_mismatched_release_tag(tmp_path):
+    module = _load_provenance_module()
+    manifest = _minimal_manifest()
+    manifest["components"]["miseledger"]["source"]["release_tag"] = "v9.9.9"
+    manifest_path = tmp_path / "manifest-v1.json"
+    manifest_path.write_text(json.dumps(manifest))
+
+    errors = module.verify_manifest(manifest_path, fetch=_mock_fetcher())
+
+    assert any("source.release_tag" in error and "download_url tag" in error for error in errors)
+
+
+def test_verify_manifest_provenance_reports_duplicate_asset_names(tmp_path):
+    module = _load_provenance_module()
+    duplicate = _asset(
+        "miseledger-linux-amd64",
+        byte_size=MISELEDGER_ASSETS["miseledger-linux-amd64"]["byte_size"],
+        sha256=MISELEDGER_ASSETS["miseledger-linux-amd64"]["sha256"],
+    )
+    manifest_path = tmp_path / "manifest-v1.json"
+    manifest_path.write_text(
+        json.dumps(
+            _minimal_manifest(
+                miseledger_assets={
+                    "linux-amd64": duplicate,
+                    "linux-arm64": duplicate,
+                }
+            )
+        )
+    )
+
+    errors = module.verify_manifest(manifest_path, fetch=_mock_fetcher())
+
+    assert any("duplicate" in error for error in errors)

--- a/tests/test_component_paths.py
+++ b/tests/test_component_paths.py
@@ -1,0 +1,117 @@
+"""Tests for user-local component install and cache path invariants."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from brigade import component_paths
+
+_VALID_SHA = "a" * 64
+
+
+def test_unsupported_system_raises_actionable_error():
+    env = {"HOME": "/home/alice"}
+    with pytest.raises(
+        ValueError,
+        match="unsupported component path platform system 'freebsd'; supported systems: darwin, linux, windows",
+    ):
+        component_paths.data_root(env=env, system="freebsd")
+    with pytest.raises(
+        ValueError,
+        match="unsupported component path platform system 'freebsd'; supported systems: darwin, linux, windows",
+    ):
+        component_paths.cache_root(env=env, system="freebsd")
+
+
+def test_linux_defaults_use_xdg_paths():
+    env = {"HOME": "/home/alice"}
+    data = component_paths.data_root(env=env, system="linux")
+    cache = component_paths.cache_root(env=env, system="linux")
+    assert data == "/home/alice/.local/share"
+    assert cache == "/home/alice/.cache"
+
+
+def test_linux_honors_xdg_overrides():
+    env = {"HOME": "/home/alice", "XDG_DATA_HOME": "/data", "XDG_CACHE_HOME": "/cache"}
+    assert component_paths.data_root(env=env, system="linux") == "/data"
+    assert component_paths.cache_root(env=env, system="linux") == "/cache"
+
+
+def test_macos_defaults_use_library_paths():
+    env = {"HOME": "/Users/alice"}
+    data = component_paths.data_root(env=env, system="darwin")
+    cache = component_paths.cache_root(env=env, system="darwin")
+    assert data == "/Users/alice/Library/Application Support"
+    assert cache == "/Users/alice/Library/Caches"
+
+
+@patch("brigade.component_paths.host_platform.system", return_value="Darwin")
+def test_default_detection_uses_platform_system_for_macos(_mock_system):
+    env = {"HOME": "/Users/alice"}
+    data = component_paths.data_root(env=env)
+    cache = component_paths.cache_root(env=env)
+    assert data == "/Users/alice/Library/Application Support"
+    assert cache == "/Users/alice/Library/Caches"
+
+
+def test_windows_defaults_use_localappdata():
+    env = {"LOCALAPPDATA": r"C:\Users\alice\AppData\Local"}
+    data = component_paths.data_root(env=env, system="windows")
+    cache = component_paths.cache_root(env=env, system="windows")
+    assert data == r"C:\Users\alice\AppData\Local"
+    assert cache == r"C:\Users\alice\AppData\Local"
+
+
+def test_windows_managed_executable_appends_exe_for_drive_path():
+    root = r"C:\Users\alice\AppData\Local"
+    path = component_paths.managed_executable_path(root, "miseledger")
+    assert path == r"C:\Users\alice\AppData\Local\brigade\bin\miseledger.exe"
+
+
+def test_windows_managed_executable_does_not_double_append_exe():
+    root = r"C:\Users\alice\AppData\Local"
+    path = component_paths.managed_executable_path(root, "miseledger.exe")
+    assert path == r"C:\Users\alice\AppData\Local\brigade\bin\miseledger.exe"
+
+
+def test_windows_managed_executable_appends_exe_for_unc_root():
+    root = r"\\server\share\appdata"
+    path = component_paths.managed_executable_path(root, "sessionfind")
+    assert path == r"\\server\share\appdata\brigade\bin\sessionfind.exe"
+
+
+def test_component_paths_never_use_repo_brigade(tmp_path):
+    repo = tmp_path / "project"
+    repo.mkdir()
+    (repo / ".brigade").mkdir()
+    env = {"HOME": str(tmp_path / "home"), "XDG_DATA_HOME": str(tmp_path / "xdg-data")}
+    data = component_paths.data_root(env=env, system="linux")
+    installed = component_paths.installed_state_path(data)
+    executable = component_paths.managed_executable_path(data, "miseledger")
+    cached = component_paths.cached_asset_path(
+        component_paths.cache_root(env=env, system="linux"),
+        _VALID_SHA,
+        "miseledger-linux-amd64",
+    )
+    assert ".brigade" not in installed
+    assert str(installed).endswith("brigade/installed.json")
+    assert str(executable).endswith("brigade/bin/miseledger")
+    assert str(cached).endswith(f"brigade/components/{_VALID_SHA}/miseledger-linux-amd64")
+
+
+@pytest.mark.parametrize(
+    ("sha256", "asset_name"),
+    [
+        ("A" * 64, "miseledger-linux-amd64"),
+        ("abc", "miseledger-linux-amd64"),
+        (_VALID_SHA, "../miseledger-linux-amd64"),
+        (_VALID_SHA, "..\\miseledger-linux-amd64"),
+        (_VALID_SHA, "nested/miseledger-linux-amd64"),
+        (_VALID_SHA, "nested\\miseledger-linux-amd64"),
+    ],
+)
+def test_cached_asset_path_rejects_unsafe_inputs(sha256, asset_name):
+    with pytest.raises(ValueError):
+        component_paths.cached_asset_path("/tmp/cache", sha256, asset_name)

--- a/tests/test_version_sync_script.py
+++ b/tests/test_version_sync_script.py
@@ -1,0 +1,48 @@
+"""Tests for scripts/version_sync.py component manifest coverage."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_version_sync_module(repo_root: Path):
+    spec = importlib.util.spec_from_file_location("version_sync_test", ROOT / "scripts/version_sync.py")
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    module.ROOT = repo_root
+    module.RECORDINGS = []
+    return module
+
+
+def test_version_sync_checks_component_manifest_brigade_version(tmp_path):
+    repo = tmp_path / "repo"
+    init_dir = repo / "src/brigade"
+    manifest_dir = repo / "src/brigade/templates/components"
+    init_dir.mkdir(parents=True)
+    manifest_dir.mkdir(parents=True)
+    (repo / "pyproject.toml").write_text('[project]\nversion = "1.0.0"\n')
+    (init_dir / "__init__.py").write_text('__version__ = "1.0.0"\n')
+    manifest_rel = "src/brigade/templates/components/manifest-v1.json"
+    manifest_path = repo / manifest_rel
+    manifest_path.write_text('{"brigade_version": "0.9.0"}\n')
+
+    module = _load_version_sync_module(repo)
+    stderr = io.StringIO()
+    original_stderr = sys.stderr
+    sys.stderr = stderr
+    try:
+        exit_code = module.check("1.0.0")
+    finally:
+        sys.stderr = original_stderr
+
+    output = stderr.getvalue()
+    assert exit_code == 1
+    assert manifest_rel in output
+    assert "0.9.0" in output


### PR DESCRIPTION
## Summary

- define component manifest v1 with the fixed five-platform matrix and user-local path rules
- pin GraphTrail's engine revision and all ten MiseLedger v0.6.0 assets with live release provenance checks
- add the parser, schema, version-sync coverage, tests, and a CI-only provenance job

## Verification

- `./scripts/verify`
- `python3 scripts/verify_component_manifest_provenance.py`

Closes #353