### PR TITLE
feat: install pinned native components with brigade setup

### DIFF
--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -59,6 +59,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade scrub`: 1 command path(s)
 - `brigade search`: 3 command path(s)
 - `brigade security`: 15 command path(s)
+- `brigade setup`: 1 command path(s)
 - `brigade skills`: 29 command path(s)
 - `brigade stations`: 3 command path(s)
 - `brigade status`: 1 command path(s)
@@ -432,6 +433,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade security suppress`
 - `brigade security template-audit`
 - `brigade security unsuppress`
+- `brigade setup`
 - `brigade skills adapters init`
 - `brigade skills adapters list`
 - `brigade skills adapters show`

--- a/docs/phase-355-pinned-component-setup.md
+++ b/docs/phase-355-pinned-component-setup.md
@@ -1,0 +1,672 @@
+# Phase 355: Pinned Component Setup
+
+Parent: [#352](https://github.com/escoffier-labs/brigade/issues/352). Issue: [#355](https://github.com/escoffier-labs/brigade/issues/355).
+
+Goal: add `brigade setup` as a top-level command that installs all four manifest-backed native components (GraphTrail, graphtrail-mcp, MiseLedger, sessionfind) into the user-local Brigade managed bin with SHA-256 and byte-size verification, digest-keyed caching, offline cache hits, dry-run reporting, one-step rollback, and post-install smoke that invokes only absolute managed paths.
+
+Architecture: the bundled `templates/components/manifest-v1.json` shipped inside the installed `brigade-cli` release is the sole manifest source. Setup rejects a `brigade_version` mismatch between the running Brigade and the bundled manifest. A new `component_install` module downloads and verifies every asset before mutating managed binaries, materializes executables via temp-sibling `os.replace`, runs smoke only on absolute managed paths, and commits `installed.json` only after smoke passes. `installed.previous.json` stores one prior state and rotates only when manifest revision or component digests change. Rollback swaps current and prior state using verified cache entries. `brigade add` and its Cargo/Go/npm fallbacks remain unchanged. PATH is never mutated automatically.
+
+Out of scope: [#356](https://github.com/escoffier-labs/brigade/issues/356) doctor/version reporting and [#357](https://github.com/escoffier-labs/brigade/issues/357) Windows porting beyond the existing `component_paths` Windows behavior.
+
+Key tech: Python standard library (`urllib.request`, `hashlib`, `os.replace`, `stat`), existing `component_manifest`, `component_paths`, and `localio` helpers.
+
+## Command Alternatives (Scouting)
+
+### Alternative A — Top-level `brigade setup` (recommended)
+
+Add `brigade setup` as a first-class top-level command with flags `--dry-run`, `--offline`, and `--rollback`. A dedicated `component_install` module owns download, verify, cache, materialize, smoke, state, and rollback. `brigade add` stays station-oriented with unchanged Cargo/Go/npm fallbacks.
+
+Tradeoffs: matches the stated “top-level brigade setup” requirement, keeps install semantics separate from station wiring, and limits blast radius to new files plus manifest publication.
+
+### Alternative B — Native-first inside `brigade add`
+
+`brigade add <station>` checks the bundled manifest for matching tools and downloads pinned natives when assets exist; otherwise runs existing `install_args`.
+
+Tradeoffs: reuses a familiar verb but mixes two install models (toolchain source builds vs pinned binaries), makes dry-run/rollback harder because `add` prints wiring guidance and is station-scoped, and couples manifest publication to station names.
+
+### Alternative C — `brigade components` command group
+
+Expose `brigade components install`, `status`, and `rollback` backed by the same engine as Alternative A.
+
+Tradeoffs: clearer future growth surface, but does not satisfy the top-level `brigade setup` requirement without an alias and adds CLI surface area before Phase 1 needs it.
+
+**Recommendation:** Alternative A. Register `setup` in `COMMAND_GROUPS` under “Stations and tools”. The `component_install` module can later back a `components` group if reporting (#356) needs it.
+
+## Sous-Mode Decision Record
+
+| Decision | Basis | Label |
+| --- | --- | --- |
+| Top-level `brigade setup` instead of extending `brigade add` | Issue #355 and parent #352 require top-level setup | stated-constraint |
+| Bundled installed-release manifest is authoritative; reject `brigade_version` mismatch | Prevents applying pins from a different Brigade build than the one running setup | stated-constraint |
+| Publish graphtrail and graphtrail-mcp v0.4.0 assets at commit `64fcd2f9ec37f33e286708845a92e6cfa4abf3bb` with release evidence sizes/digests | Release assets exist; manifest must carry full platform matrix before setup can install GraphTrail tools | evidence |
+| Install all four components by default | Phase 1 acceptance requires a clean machine to complete setup without per-component flags | stated-constraint |
+| Flags limited to `--dry-run`, `--offline`, `--rollback` | Approved interface; no `--component`, no PATH flags | stated-constraint |
+| No automatic PATH mutation | PATH edits are fragile and platform-specific; doctor and docs can reference managed absolute paths | judgment |
+| Keep `brigade add` Cargo/Go/npm fallbacks unchanged | Compatibility window and existing `managed.py` install_args remain the alternate install path | evidence |
+| Cache at `cached_asset_path(cache_root, sha256, asset_name)` | `component_paths.cached_asset_path` already encodes digest/name layout | evidence |
+| Verify byte size and SHA-256 before caching, materializing, or executing | Requirement and existing `localio.file_sha256` pattern | stated-constraint |
+| Online: replace bad cache only after a verified temp download; offline: fail on bad cache | Prevents clobbering a recoverable cache with a partial download while keeping offline strict | stated-constraint |
+| Download and verify all assets before changing any managed bin | Atomic failure domain: no half-upgraded bin directory | stated-constraint |
+| Materialize via temp sibling + `os.replace` with executable bit; restore prior bytes on later failure | Matches `localio.write_text_atomic` swap semantics for binaries | evidence |
+| Post-install smoke uses only absolute managed paths | Acceptance criterion: smoke must not accidentally pass via PATH | stated-constraint |
+| Commit `installed.json` only after smoke passes | State must reflect a verified, runnable install | stated-constraint |
+| `installed.previous.json` holds one prior state; rotate only on manifest/digest change; idempotent repeat does not rotate | Rollback and repeat-install requirements | stated-constraint |
+| Tests inject temp roots; never use live network or real `$HOME` | CI determinism and contributor safety | stated-constraint |
+
+## GraphTrail v0.4.0 Release Evidence
+
+Commit: `64fcd2f9ec37f33e286708845a92e6cfa4abf3bb`. Release tag: `v0.4.0`. Repository: `escoffier-labs/graphtrail`.
+
+Download URL pattern: `https://github.com/escoffier-labs/graphtrail/releases/download/v0.4.0/<asset_name>`.
+
+### graphtrail
+
+| Platform | asset_name | byte_size | sha256 |
+| --- | --- | ---: | --- |
+| darwin-amd64 | graphtrail-darwin-amd64 | 11695172 | eb6768be11d26a9d82c1bcecd503a9fdc7c883bda3bd627dea9ccb04fd31379c |
+| darwin-arm64 | graphtrail-darwin-arm64 | 11426112 | 20534dbbb84f134a5a892520fd5a695d2520c2e040733b5535e991c611c99686 |
+| linux-amd64 | graphtrail-linux-amd64 | 12802256 | e78c73a80a2eadbe297066739044e2c5fcdd187c8219198f453bd004bf9c9a55 |
+| linux-arm64 | graphtrail-linux-arm64 | 12424560 | 7f961a4f018e4b12b9dcf5227a7cdc20fa7cdd9a723d96ec0336e254adf33c07 |
+| windows-amd64 | graphtrail-windows-amd64.exe | 10753536 | 1a9adc002c81661d2b0838e642f1c9db2671a2808c93e6b4499cfc2b33d6ea22 |
+
+### graphtrail-mcp
+
+| Platform | asset_name | byte_size | sha256 |
+| --- | --- | ---: | --- |
+| darwin-amd64 | graphtrail-mcp-darwin-amd64 | 11004028 | d8d605a522d3894c36a2f30e94cdcc99b87c34d05e53b01f4c47018eaebaf93f |
+| darwin-arm64 | graphtrail-mcp-darwin-arm64 | 10766928 | 649abe87a3e40415d1933db493c94f1049d84577a996df7ba9c27c4b3c4cf597 |
+| linux-amd64 | graphtrail-mcp-linux-amd64 | 11981944 | 66606e4e394973766e1e91d3b0b78b26bd9077076cc85e62b9d0faf9780e7154 |
+| linux-arm64 | graphtrail-mcp-linux-arm64 | 11609512 | 0bf17d38d44c5fc4f3132e17078a2db74e92da9bcb27a40c3d8345056523a651 |
+| windows-amd64 | graphtrail-mcp-windows-amd64.exe | 10020864 | ec642c7e736fff1673c3d7e06d10eb02c9782008d8f783ab2b40699e69a35b08 |
+
+MiseLedger and sessionfind remain pinned at v0.6.0 per the current bundled manifest; setup installs them through the same engine.
+
+## Installed State Schema v1
+
+Path: `component_paths.installed_state_path(data_root)` → `<data_root>/brigade/installed.json`.
+
+Prior path: `component_paths.installed_previous_state_path(data_root)` → `<data_root>/brigade/installed.previous.json`.
+
+```json
+{
+  "schema_version": 1,
+  "brigade_version": "0.23.0",
+  "manifest_revision": "2026-07-18",
+  "platform": "linux-amd64",
+  "timestamp": "2026-07-19T06:00:00.000000+00:00",
+  "components": {
+    "graphtrail": {
+      "component_revision": "64fcd2f9ec37f33e286708845a92e6cfa4abf3bb",
+      "asset_name": "graphtrail-linux-amd64",
+      "byte_size": 12802256,
+      "sha256": "e78c73a80a2eadbe297066739044e2c5fcdd187c8219198f453bd004bf9c9a55",
+      "download_url": "https://github.com/escoffier-labs/graphtrail/releases/download/v0.4.0/graphtrail-linux-amd64",
+      "executable": "/tmp/home/.local/share/brigade/bin/graphtrail"
+    }
+  }
+}
+```
+
+`installed.previous.json` uses the same schema. Rotation copies the current file to `installed.previous.json` only when `manifest_revision` or any component `sha256` changes after a successful install. Idempotent repeat installs that verify matching cache and managed bytes leave `installed.previous.json` untouched.
+
+## Setup Orchestration
+
+1. Load bundled manifest via `component_manifest.load()`.
+2. Compare `manifest.brigade_version` to `brigade.__version__`; exit non-zero on mismatch.
+3. Resolve host platform via `component_manifest.platform_key()`.
+4. For each component in `KNOWN_COMPONENT_IDS`, resolve asset with `component_manifest.resolve_asset`.
+5. **Dry-run (`--dry-run`):** print brigade version, manifest revision, platform, and for each component: component revision, asset name, byte size, sha256, download URL, cache path, managed executable path, and planned actions (`verify-cache`, `download`, `materialize`, `smoke`). Write nothing. Exit 0.
+6. **Rollback (`--rollback`):** require `installed.previous.json`. Verify every prior component cache entry (size + sha256). Swap managed executables from verified cache, swap `installed.json` ↔ `installed.previous.json` via atomic writes. Run smoke on restored managed paths. Exit non-zero on verification or smoke failure.
+7. **Install (default):** for each asset, ensure cache file at `cached_asset_path` matches `byte_size` and `sha256`. Online: download to temp sibling, verify, then `os.replace` into cache (replacing a bad cache only after verified temp). Offline (`--offline`): require valid cache; fail if cache missing or corrupt. After all caches verified, snapshot current managed executables (if any) for restore-on-failure. Materialize each component to `managed_executable_path` via temp sibling + `os.replace` + executable bit (`0o755` on Unix). Run smoke suite on absolute managed paths. On any materialize or smoke failure, restore snapshotted executables. On success, rotate `installed.previous.json` when manifest revision or digests changed, then write `installed.json`.
+
+### Post-install smoke (absolute paths only)
+
+| Component | Command | Success |
+| --- | --- | --- |
+| graphtrail | `<managed>/graphtrail --version` | exit 0, non-empty stdout |
+| graphtrail-mcp | `<managed>/graphtrail-mcp` JSON-RPC `initialize` on stdin | valid JSON-RPC response on stdout |
+| miseledger | `<managed>/miseledger version` | exit 0 |
+| sessionfind | `<managed>/sessionfind --help` | exit 2 with usage text in stdout or stderr |
+
+## File Map
+
+| File | Role |
+| --- | --- |
+| `src/brigade/component_paths.py` | Add `installed_previous_state_path`, `managed_bin_dir` |
+| `src/brigade/component_state.py` | Load, validate, render, rotate installed state v1 |
+| `src/brigade/component_install.py` | Download, verify, cache, materialize, smoke, orchestration |
+| `src/brigade/cli/setup.py` | `brigade setup` argparse registration and dispatch |
+| `src/brigade/cli/__init__.py` | Register `_setup_group` after `_add_group` |
+| `src/brigade/cli/_common.py` | Add `setup` to `COMMAND_GROUPS` (“Stations and tools”) |
+| `src/brigade/component_manifest.py` | Remove graphtrail IDs from `UNPUBLISHED_COMPONENT_IDS` after manifest publication |
+| `src/brigade/templates/components/manifest-v1.json` | Publish graphtrail v0.4.0 assets; bump `manifest_revision` |
+| `tests/test_component_install.py` | Engine and orchestration tests (no network) |
+| `tests/test_cli_setup.py` | CLI wiring and flag tests |
+| `tests/test_component_manifest.py` | Extend bundled-manifest assertions for graphtrail v0.4.0 assets |
+| `tests/test_component_paths.py` | Assert `installed_previous_state_path` |
+| `tests/test_cli_help.py` | Unchanged gate; fails if `setup` missing from `COMMAND_GROUPS` |
+
+## Public Module Signatures
+
+```python
+# src/brigade/component_state.py
+SCHEMA_VERSION = 1
+
+@dataclass(frozen=True)
+class InstalledComponentRecord:
+    component_revision: str
+    asset_name: str
+    byte_size: int
+    sha256: str
+    download_url: str
+    executable: str
+
+@dataclass(frozen=True)
+class InstalledState:
+    schema_version: int
+    brigade_version: str
+    manifest_revision: str
+    platform: str
+    timestamp: str
+    components: dict[str, InstalledComponentRecord]
+
+def load_installed_state(path: Path) -> InstalledState | None
+def render_installed_state(state: InstalledState) -> dict[str, object]
+def state_digest_map(state: InstalledState) -> dict[str, str]
+def should_rotate_previous(current: InstalledState | None, next_state: InstalledState) -> bool
+
+# src/brigade/component_install.py
+@dataclass(frozen=True)
+class SetupPlanAction:
+    component_id: str
+    action: str  # verify-cache | download | materialize | smoke
+    cache_path: str
+    managed_path: str
+    asset_name: str
+    byte_size: int
+    sha256: str
+    download_url: str
+    component_revision: str
+
+@dataclass(frozen=True)
+class SetupRoots:
+    data_root: str
+    cache_root: str
+    env: Mapping[str, str]
+
+class ComponentInstallError(RuntimeError)
+
+def resolve_roots(*, env: Mapping[str, str] | None = None, system: str | None = None) -> SetupRoots
+def build_setup_plan(manifest: ComponentManifest, *, platform: str, roots: SetupRoots) -> list[SetupPlanAction]
+def verify_cached_asset(path: Path, *, byte_size: int, sha256: str) -> None
+def fetch_asset_to_cache(asset: ComponentAsset, *, cache_path: Path, offline: bool, opener: Callable[..., object] | None = None) -> Path
+def materialize_executable(*, cache_path: Path, managed_path: Path) -> None
+def run_post_install_smoke(managed_paths: Mapping[str, str], *, runner: Callable[..., subprocess.CompletedProcess] | None = None) -> None
+def setup_native_components(*, dry_run: bool = False, offline: bool = False, rollback: bool = False, env: Mapping[str, str] | None = None, opener: Callable[..., object] | None = None, runner: Callable[..., subprocess.CompletedProcess] | None = None) -> int
+```
+
+## Test Helpers
+
+Add `tests/component_install_helpers.py`:
+
+```python
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+
+from brigade import component_manifest
+
+GRAPHTRAIL_SHA = "64fcd2f9ec37f33e286708845a92e6cfa4abf3bb"
+GRAPHTRAIL_BASE = "https://github.com/escoffier-labs/graphtrail/releases/download/v0.4.0/"
+
+
+def linux_env(root: Path) -> dict[str, str]:
+    home = root / "home"
+    home.mkdir(parents=True, exist_ok=True)
+    return {
+        "HOME": str(home),
+        "XDG_DATA_HOME": str(root / "xdg-data"),
+        "XDG_CACHE_HOME": str(root / "xdg-cache"),
+    }
+
+
+def asset_bytes(*, byte_size: int, sha256: str) -> bytes:
+    body = (sha256 * ((byte_size // 64) + 1)).encode("ascii")[:byte_size]
+    assert hashlib.sha256(body).hexdigest() == sha256
+    return body
+
+
+def write_verified_cache(cache_path: Path, *, byte_size: int, sha256: str) -> None:
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_bytes(asset_bytes(byte_size=byte_size, sha256=sha256))
+    cache_path.chmod(0o755)
+
+
+def smoke_stub_script(name: str) -> str:
+    if name == "graphtrail":
+        return f'#!/usr/bin/env python3\nimport sys\nif sys.argv[1:] == ["--version"]:\n    print("graphtrail test 0.4.0")\n    raise SystemExit(0)\nraise SystemExit(1)\n'
+    if name == "graphtrail-mcp":
+        return (
+            '#!/usr/bin/env python3\nimport json, sys\n'
+            'req = json.load(sys.stdin)\n'
+            'assert req.get("method") == "initialize"\n'
+            'print(json.dumps({"jsonrpc": "2.0", "id": req.get("id"), "result": {"protocolVersion": "2024-11-05", "capabilities": {}, "serverInfo": {"name": "graphtrail-mcp", "version": "0.4.0"}}}))\n'
+        )
+    if name == "miseledger":
+        return '#!/usr/bin/env python3\nimport sys\nif sys.argv[1:] == ["version"]:\n    print("miseledger test 0.6.0")\n    raise SystemExit(0)\nraise SystemExit(1)\n'
+    if name == "sessionfind":
+        return '#!/usr/bin/env python3\nimport sys\nif sys.argv[1:] == ["--help"]:\n    print("usage: sessionfind [options]")\n    raise SystemExit(2)\nraise SystemExit(1)\n'
+    raise ValueError(name)
+
+
+class FakeOpener:
+    def __init__(self, payloads: dict[str, bytes]):
+        self.payloads = payloads
+        self.calls: list[str] = []
+
+    def __call__(self, url: str, *args, **kwargs):
+        self.calls.append(url)
+        from io import BytesIO
+        from urllib.error import HTTPError
+
+        if url not in self.payloads:
+            raise HTTPError(url, 404, "not found", hdrs=None, fp=BytesIO(b""))
+        return BytesIO(self.payloads[url])
+```
+
+Tests use small `byte_size` fixtures (for example 64 or 128 bytes) with precomputed `sha256` values checked into `tests/component_install_helpers.py`.
+
+## Implementation Recipe
+
+Each task follows RED → GREEN through Brigade verify, then a small conventional commit. Verification command template:
+
+```bash
+brigade work verify run --target . \
+  --command ".venv/bin/python -m pytest <test-target> -q" \
+  --capture brigade-work
+```
+
+### Task 0: Publish graphtrail v0.4.0 assets in bundled manifest
+
+**Files:** `src/brigade/templates/components/manifest-v1.json`, `src/brigade/component_manifest.py`, `tests/test_component_manifest.py`.
+
+- [ ] Update manifest: set `manifest_revision` to `2026-07-19`, add full graphtrail and graphtrail-mcp asset matrices from the release evidence table with `source.release_tag` `v0.4.0` and `component_revision` `64fcd2f9ec37f33e286708845a92e6cfa4abf3bb`.
+- [ ] Remove `graphtrail` and `graphtrail-mcp` from `UNPUBLISHED_COMPONENT_IDS`.
+- [ ] Add failing bundled-manifest tests:
+
+```python
+def test_bundled_manifest_pins_graphtrail_v040_assets():
+    manifest = component_manifest.load()
+    asset = manifest.components["graphtrail"].assets["linux-amd64"]
+    assert asset.byte_size == 12802256
+    assert asset.sha256 == "e78c73a80a2eadbe297066739044e2c5fcdd187c8219198f453bd004bf9c9a55"
+    assert manifest.components["graphtrail"].source.release_tag == "v0.4.0"
+
+
+def test_bundled_manifest_pins_graphtrail_mcp_v040_assets():
+    manifest = component_manifest.load()
+    asset = manifest.components["graphtrail-mcp"].assets["linux-amd64"]
+    assert asset.byte_size == 11981944
+    assert asset.sha256 == "66606e4e394973766e1e91d3b0b78b26bd9077076cc85e62b9d0faf9780e7154"
+```
+
+- [ ] RED: `brigade work verify run --target . --command ".venv/bin/python -m pytest tests/test_component_manifest.py::test_bundled_manifest_pins_graphtrail_v040_assets tests/test_component_manifest.py::test_bundled_manifest_pins_graphtrail_mcp_v040_assets -q" --capture brigade-work`
+- [ ] GREEN after manifest + `UNPUBLISHED_COMPONENT_IDS` update.
+- [ ] Commit: `chore(components): publish graphtrail v0.4.0 manifest assets`.
+
+### Task 1: Installed state path and schema
+
+**Files:** `src/brigade/component_paths.py`, `src/brigade/component_state.py`, `tests/test_component_paths.py`, `tests/test_component_state.py`.
+
+- [ ] Add `installed_previous_state_path(data_root_path: str) -> str`.
+- [ ] Add failing path test:
+
+```python
+def test_installed_previous_state_path_uses_brigade_subdir():
+    env = {"HOME": "/home/alice"}
+    data = component_paths.data_root(env=env, system="linux")
+    path = component_paths.installed_previous_state_path(data)
+    assert path.endswith("brigade/installed.previous.json")
+```
+
+- [ ] Add failing state tests:
+
+```python
+def test_render_installed_state_round_trips_required_fields():
+    state = InstalledState(
+        schema_version=1,
+        brigade_version="0.23.0",
+        manifest_revision="2026-07-19",
+        platform="linux-amd64",
+        timestamp="2026-07-19T06:00:00+00:00",
+        components={
+            "miseledger": InstalledComponentRecord(
+                component_revision="v0.6.0",
+                asset_name="miseledger-linux-amd64",
+                byte_size=16441315,
+                sha256="246893c8c39318f774fc7a06338b5a8e87bf84661b1951251b2c0c971e9a7a6c",
+                download_url="https://github.com/escoffier-labs/miseledger/releases/download/v0.6.0/miseledger-linux-amd64",
+                executable="/tmp/xdg-data/brigade/bin/miseledger",
+            )
+        },
+    )
+    payload = render_installed_state(state)
+    assert payload["schema_version"] == 1
+    assert payload["components"]["miseledger"]["executable"].endswith("/brigade/bin/miseledger")
+
+
+def test_should_rotate_previous_when_digest_changes():
+    current = _sample_state(sha256="a" * 64)
+    nxt = _sample_state(sha256="b" * 64)
+    assert should_rotate_previous(current, nxt) is True
+
+
+def test_should_not_rotate_previous_on_identical_digest_map():
+    current = _sample_state(sha256="a" * 64)
+    nxt = _sample_state(sha256="a" * 64, manifest_revision=current.manifest_revision)
+    assert should_rotate_previous(current, nxt) is False
+```
+
+- [ ] RED → implement → GREEN on `tests/test_component_paths.py tests/test_component_state.py`.
+- [ ] Commit: `feat(components): add installed state schema v1`.
+
+### Task 2: Verify cached assets and brigade_version gate
+
+**Files:** `src/brigade/component_install.py`, `tests/test_component_install.py`.
+
+- [ ] Add failing tests:
+
+```python
+def test_verify_cached_asset_rejects_size_mismatch(tmp_path):
+    path = tmp_path / "asset"
+    path.write_bytes(b"short")
+    with pytest.raises(ComponentInstallError, match="byte_size"):
+        verify_cached_asset(path, byte_size=10, sha256="a" * 64)
+
+
+def test_verify_cached_asset_rejects_digest_mismatch(tmp_path):
+    path = tmp_path / "asset"
+    path.write_bytes(b"0123456789")
+    with pytest.raises(ComponentInstallError, match="sha256"):
+        verify_cached_asset(path, byte_size=10, sha256="b" * 64)
+
+
+def test_setup_rejects_brigade_version_mismatch(tmp_path, monkeypatch):
+    env = linux_env(tmp_path)
+    monkeypatch.setattr(component_install, "__version__", "9.9.9", raising=False)
+    monkeypatch.setattr(component_install, "brigade_version", lambda: "9.9.9")
+    rc = setup_native_components(env=env)
+    assert rc == 1
+```
+
+- [ ] Implement `verify_cached_asset` using `path.stat().st_size` and `localio.file_sha256`.
+- [ ] Implement manifest `brigade_version` check at start of `setup_native_components`.
+- [ ] RED → GREEN on focused tests.
+- [ ] Commit: `feat(components): verify cache bytes and brigade version`.
+
+### Task 3: Download-to-cache with online replace and offline strictness
+
+**Files:** `src/brigade/component_install.py`, `tests/test_component_install.py`, `tests/component_install_helpers.py`.
+
+- [ ] Add failing tests:
+
+```python
+def test_fetch_asset_to_cache_writes_verified_bytes(tmp_path):
+    asset = _linux_miseledger_asset()
+    cache_path = tmp_path / "cache" / asset.sha256 / asset.asset_name
+    payload = asset_bytes(byte_size=asset.byte_size, sha256=asset.sha256)
+    opener = FakeOpener({asset.download_url: payload})
+    result = fetch_asset_to_cache(asset, cache_path=cache_path, offline=False, opener=opener)
+    assert result == cache_path
+    verify_cached_asset(cache_path, byte_size=asset.byte_size, sha256=asset.sha256)
+
+
+def test_fetch_asset_offline_fails_when_cache_corrupt(tmp_path):
+    asset = _linux_miseledger_asset()
+    cache_path = tmp_path / "cache" / asset.sha256 / asset.asset_name
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_bytes(b"bad")
+    with pytest.raises(ComponentInstallError, match="offline"):
+        fetch_asset_to_cache(asset, cache_path=cache_path, offline=True)
+
+
+def test_fetch_asset_online_replaces_bad_cache_only_after_verified_download(tmp_path):
+    asset = _linux_miseledger_asset()
+    cache_path = tmp_path / "cache" / asset.sha256 / asset.asset_name
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_bytes(b"stale")
+    good = asset_bytes(byte_size=asset.byte_size, sha256=asset.sha256)
+    opener = FakeOpener({asset.download_url: good})
+    fetch_asset_to_cache(asset, cache_path=cache_path, offline=False, opener=opener)
+    verify_cached_asset(cache_path, byte_size=asset.byte_size, sha256=asset.sha256)
+```
+
+- [ ] Implement temp-sibling download, verify, `os.replace` into cache; offline raises when cache invalid; online never replaces until verified temp passes.
+- [ ] RED → GREEN.
+- [ ] Commit: `feat(components): download assets into digest cache`.
+
+### Task 4: Materialize managed executables with restore-on-failure
+
+**Files:** `src/brigade/component_install.py`, `tests/test_component_install.py`.
+
+- [ ] Add failing tests:
+
+```python
+def test_materialize_executable_sets_mode_and_replaces(tmp_path):
+    cache_path = tmp_path / "cache.bin"
+    managed_path = tmp_path / "bin" / "tool"
+    cache_path.write_bytes(b"#!/bin/sh\n")
+    materialize_executable(cache_path=cache_path, managed_path=managed_path)
+    assert managed_path.read_bytes() == cache_path.read_bytes()
+    assert oct(managed_path.stat().st_mode & 0o777) == oct(0o755)
+
+
+def test_install_restores_prior_executable_when_smoke_fails(tmp_path, monkeypatch):
+    env = linux_env(tmp_path)
+    roots = resolve_roots(env=env, system="linux")
+    prior = Path(roots.data_root) / "brigade" / "bin" / "miseledger"
+    prior.parent.mkdir(parents=True)
+    prior.write_bytes(b"OLD")
+    prior.chmod(0o755)
+    monkeypatch.setattr(component_install, "run_post_install_smoke", _raise_smoke_failure)
+    with pytest.raises(ComponentInstallError):
+        _install_with_stub_assets(env=env, opener=_all_good_opener(env))
+    assert prior.read_bytes() == b"OLD"
+```
+
+- [ ] Implement snapshot/restore around materialize loop.
+- [ ] RED → GREEN.
+- [ ] Commit: `feat(components): materialize managed executables safely`.
+
+### Task 5: Post-install smoke on absolute managed paths
+
+**Files:** `src/brigade/component_install.py`, `tests/test_component_install.py`.
+
+- [ ] Add failing test:
+
+```python
+def test_run_post_install_smoke_invokes_absolute_paths_only(tmp_path):
+    managed = {}
+    for name in ("graphtrail", "graphtrail-mcp", "miseledger", "sessionfind"):
+        path = tmp_path / name
+        path.write_text(smoke_stub_script(name))
+        path.chmod(0o755)
+        managed[name] = str(path)
+    calls: list[list[str]] = []
+
+    def runner(argv, **kwargs):
+        calls.append(list(argv))
+        return subprocess.CompletedProcess(argv, 0, stdout="ok", stderr="")
+
+    run_post_install_smoke(managed, runner=runner)
+    assert all(cmd[0] == managed[cmd[0].split("/")[-1].split(".")[0]] or cmd[0] in managed.values() for cmd in calls)
+```
+
+- [ ] Implement smoke runner: `subprocess.run` with absolute argv[0], JSON-RPC stdin for graphtrail-mcp, accept exit 2 for sessionfind --help.
+- [ ] RED → GREEN.
+- [ ] Commit: `feat(components): add post-install smoke suite`.
+
+### Task 6: Dry-run plan reporting
+
+**Files:** `src/brigade/component_install.py`, `src/brigade/cli/setup.py`, `tests/test_component_install.py`, `tests/test_cli_setup.py`.
+
+- [ ] Add failing tests:
+
+```python
+def test_build_setup_plan_lists_all_four_components():
+    manifest = component_manifest.load()
+    roots = resolve_roots(env=linux_env(Path("/tmp/not-used")), system="linux")
+    plan = build_setup_plan(manifest, platform="linux-amd64", roots=roots)
+    assert {action.component_id for action in plan} == set(component_manifest.KNOWN_COMPONENT_IDS)
+
+
+def test_setup_dry_run_writes_nothing(tmp_path, capsys):
+    env = linux_env(tmp_path)
+    rc = setup_native_components(dry_run=True, env=env)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "graphtrail-linux-amd64" in out
+    assert "download" in out
+    assert not (Path(env["XDG_DATA_HOME"]) / "brigade" / "installed.json").exists()
+
+
+def test_cli_setup_dry_run_flag(tmp_path, monkeypatch, capsys):
+    env = linux_env(tmp_path)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    assert cli.main(["setup", "--dry-run"]) == 0
+```
+
+- [ ] Implement `build_setup_plan` and dry-run printer; wire CLI.
+- [ ] RED → GREEN.
+- [ ] Commit: `feat(cli): add brigade setup dry-run`.
+
+### Task 7: Full install, idempotent repeat, and state commit after smoke
+
+**Files:** `src/brigade/component_install.py`, `tests/test_component_install.py`.
+
+- [ ] Add failing tests:
+
+```python
+def test_setup_install_writes_state_after_smoke(tmp_path):
+    env = linux_env(tmp_path)
+    payloads = _all_manifest_payloads(env, platform="linux-amd64")
+    rc = setup_native_components(env=env, opener=FakeOpener(payloads))
+    assert rc == 0
+    state_path = Path(component_paths.installed_state_path(resolve_roots(env=env).data_root))
+    state = json.loads(state_path.read_text())
+    assert state["schema_version"] == 1
+    assert set(state["components"]) == set(component_manifest.KNOWN_COMPONENT_IDS)
+
+
+def test_repeat_setup_is_idempotent_and_skips_previous_rotation(tmp_path):
+    env = linux_env(tmp_path)
+    payloads = _all_manifest_payloads(env, platform="linux-amd64")
+    opener = FakeOpener(payloads)
+    assert setup_native_components(env=env, opener=opener) == 0
+    roots = resolve_roots(env=env)
+    previous_path = Path(component_paths.installed_previous_state_path(roots.data_root))
+    previous_before = previous_path.read_text() if previous_path.is_file() else None
+    assert setup_native_components(env=env, opener=opener) == 0
+    if previous_before is not None:
+        assert previous_path.read_text() == previous_before
+```
+
+- [ ] Implement full orchestration: download all → materialize all → smoke → rotate/write state.
+- [ ] RED → GREEN.
+- [ ] Commit: `feat(components): install pinned native components`.
+
+### Task 8: Rollback via verified prior state
+
+**Files:** `src/brigade/component_install.py`, `tests/test_component_install.py`, `tests/test_cli_setup.py`.
+
+- [ ] Add failing tests:
+
+```python
+def test_setup_rollback_restores_previous_manifest(tmp_path):
+    env = linux_env(tmp_path)
+    _seed_installed_pair(env, revision_a="2026-07-18", revision_b="2026-07-19")
+    rc = setup_native_components(rollback=True, env=env)
+    assert rc == 0
+    state = json.loads(Path(component_paths.installed_state_path(resolve_roots(env=env).data_root)).read_text())
+    assert state["manifest_revision"] == "2026-07-18"
+
+
+def test_setup_rollback_fails_when_prior_cache_missing(tmp_path):
+    env = linux_env(tmp_path)
+    _seed_installed_pair(env, revision_a="2026-07-18", revision_b="2026-07-19", drop_prior_cache=True)
+    assert setup_native_components(rollback=True, env=env) == 1
+```
+
+- [ ] Implement rollback swap and smoke on restored paths.
+- [ ] RED → GREEN.
+- [ ] Commit: `feat(components): add setup rollback`.
+
+### Task 9: CLI registration and help coverage
+
+**Files:** `src/brigade/cli/setup.py`, `src/brigade/cli/__init__.py`, `src/brigade/cli/_common.py`, `tests/test_cli_setup.py`, `tests/test_cli_help.py`.
+
+- [ ] Register parser:
+
+```python
+def register(sub: argparse._SubParsersAction) -> None:
+    p_setup = sub.add_parser("setup", help="Install pinned native Brigade components.")
+    p_setup.add_argument("--dry-run", action="store_true", help="Report planned actions without writing.")
+    p_setup.add_argument("--offline", action="store_true", help="Use verified cache only; fail if missing.")
+    p_setup.add_argument("--rollback", action="store_true", help="Restore the previous installed manifest.")
+    p_setup.set_defaults(func=dispatch)
+```
+
+- [ ] Add `setup` to `COMMAND_GROUPS` and `_setup_group.register(sub)` after `_add_group.register(sub)`.
+- [ ] RED: `tests/test_cli_help.py::test_command_groups_cover_every_command_exactly_once` fails until registration complete.
+- [ ] GREEN after wiring.
+- [ ] Commit: `feat(cli): register brigade setup command`.
+
+### Task 10: Final verification and review gate
+
+- [ ] Run full local gate:
+
+```bash
+./scripts/verify
+```
+
+- [ ] Run final Brigade verify:
+
+```bash
+brigade work verify run --target . \
+  --command "./scripts/verify" \
+  --capture brigade-work
+```
+
+- [ ] Capture outcome:
+
+```bash
+brigade outcome capture brigade-work --run-id latest --kind skill
+```
+
+- [ ] Content guard: ensure `git push` pre-push hook passes (no leaked hostnames, tokens, or personal paths in new files).
+- [ ] Independent Opus review: dispatch `review` skill on the branch diff before opening the PR.
+- [ ] Open PR with test plan checklist mirroring Tasks 0–9; confirm CI `content-guard`, `repo-metadata`, `install-from-source`, and `quickstart-smoke` jobs pass on the PR branch.
+- [ ] Memory handoff: `.claude/memory-handoffs/<date>-issue-355-pinned-setup.md` recording manifest publication, rollback semantics, and smoke absolute-path requirement.
+
+## Self-Review Checklist
+
+- [x] Three scouting alternatives documented with recommendation.
+- [x] Sous-mode decisions carry evidence, stated-constraint, or judgment labels.
+- [x] GraphTrail v0.4.0 asset table matches release evidence byte-for-byte.
+- [x] Every behavior maps to a file, test name, RED/GREEN verify command, and commit message.
+- [x] `#356` reporting and `#357` porting explicitly excluded.
+- [x] No automatic PATH mutation; Cargo/Go fallbacks unchanged.
+- [x] Tests require temp roots and stubbed network; no live GitHub or real home directory.
+
+## Placeholder Scan
+
+Run before committing this document (must return no matches outside this instruction line):
+
+```bash
+rg -n 'TODO|TBD|FIXME|XXX' docs/phase-355-pinned-component-setup.md && exit 1 || true
+```

--- a/docs/phase-355-pinned-component-setup.md
+++ b/docs/phase-355-pinned-component-setup.md
@@ -214,8 +214,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
-import sys
 from pathlib import Path
 
 import brigade
@@ -223,6 +221,7 @@ from brigade import component_manifest
 
 GRAPHTRAIL_SHA = "64fcd2f9ec37f33e286708845a92e6cfa4abf3bb"
 GRAPHTRAIL_BASE = "https://github.com/escoffier-labs/graphtrail/releases/download/v0.4.0/"
+FIXTURE_REPOSITORY = "example/components"
 
 
 def linux_env(root: Path) -> dict[str, str]:
@@ -235,11 +234,46 @@ def linux_env(root: Path) -> dict[str, str]:
     }
 
 
+def smoke_stub_script(name: str) -> str:
+    if name == "graphtrail":
+        return f'#!/usr/bin/env python3\nimport sys\nif sys.argv[1:] == ["--version"]:\n    print("graphtrail test 0.4.0")\n    raise SystemExit(0)\nraise SystemExit(1)\n'
+    if name == "graphtrail-mcp":
+        return (
+            '#!/usr/bin/env python3\nimport json, sys\n'
+            'req = json.load(sys.stdin)\n'
+            'assert req.get("method") == "initialize"\n'
+            'print(json.dumps({"jsonrpc": "2.0", "id": req.get("id"), "result": {"protocolVersion": "2024-11-05", "capabilities": {}, "serverInfo": {"name": "graphtrail-mcp", "version": "0.4.0"}}}))\n'
+        )
+    if name == "miseledger":
+        return '#!/usr/bin/env python3\nimport sys\nif sys.argv[1:] == ["version"]:\n    print("miseledger test 0.6.0")\n    raise SystemExit(0)\nraise SystemExit(1)\n'
+    if name == "sessionfind":
+        return '#!/usr/bin/env python3\nimport sys\nif sys.argv[1:] == ["--help"]:\n    print("usage: sessionfind [options]")\n    raise SystemExit(2)\nraise SystemExit(1)\n'
+    raise ValueError(name)
+
+
 def fixture_payload(component_id: str, *, platform: str = "linux-amd64") -> tuple[bytes, int, str]:
-    """Return (payload_bytes, byte_size, sha256) for deterministic offline fixtures."""
-    body = f"fixture:{component_id}:{platform}\n".encode("ascii")
+    """Return (payload_bytes, byte_size, sha256) for runnable smoke-stub fixture bytes."""
+    lines = smoke_stub_script(component_id).splitlines(keepends=True)
+    if lines and lines[0].startswith("#!"):
+        lines.insert(1, f"# platform: {platform}\n")
+    else:
+        lines.insert(0, f"# platform: {platform}\n")
+    body = "".join(lines).encode("utf-8")
     digest = hashlib.sha256(body).hexdigest()
     return body, len(body), digest
+
+
+def fixture_asset_name(component_id: str, *, platform: str) -> str:
+    base = f"{component_id}-{platform}"
+    if platform == "windows-amd64":
+        return f"{base}.exe"
+    return base
+
+
+def test_component_revision(component_id: str) -> str:
+    if component_id in ("graphtrail", "graphtrail-mcp"):
+        return GRAPHTRAIL_SHA
+    return "fixture-revision"
 
 
 def write_verified_cache(cache_path: Path, *, payload: bytes) -> None:
@@ -250,37 +284,36 @@ def write_verified_cache(cache_path: Path, *, payload: bytes) -> None:
 
 def test_manifest_asset(component_id: str, *, platform: str = "linux-amd64") -> component_manifest.ComponentAsset:
     _, byte_size, sha256 = fixture_payload(component_id, platform=platform)
-    asset_name = f"{component_id}-{platform}"
-    if platform.startswith("windows"):
-        asset_name += ".exe"
+    asset_name = fixture_asset_name(component_id, platform=platform)
     return component_manifest.ComponentAsset(
         asset_name=asset_name,
         byte_size=byte_size,
         sha256=sha256,
-        download_url=f"https://example.invalid/components/{component_id}/{platform}",
+        download_url=f"https://example.invalid/components/{asset_name}",
     )
 
 
-def write_test_manifest(path: Path, *, platform: str = "linux-amd64", brigade_version: str) -> component_manifest.ComponentManifest:
+def write_test_manifest(path: Path, *, brigade_version: str) -> component_manifest.ComponentManifest:
     """Write a manifest whose digests match fixture_payload bytes for offline engine tests."""
     components: dict[str, object] = {}
     for component_id in component_manifest.KNOWN_COMPONENT_IDS:
-        _, byte_size, sha256 = fixture_payload(component_id, platform=platform)
-        asset = test_manifest_asset(component_id, platform=platform)
-        assert asset.byte_size == byte_size
-        assert asset.sha256 == sha256
+        assets: dict[str, object] = {}
+        for platform in component_manifest.SUPPORTED_PLATFORMS:
+            _, byte_size, sha256 = fixture_payload(component_id, platform=platform)
+            asset = test_manifest_asset(component_id, platform=platform)
+            assert asset.byte_size == byte_size
+            assert asset.sha256 == sha256
+            assets[platform] = {
+                "asset_name": asset.asset_name,
+                "byte_size": byte_size,
+                "sha256": sha256,
+                "download_url": asset.download_url,
+            }
         components[component_id] = {
-            "component_revision": f"fixture-{component_id}",
-            "source": {"repository": f"https://example.invalid/{component_id}", "release_tag": "fixture"},
+            "component_revision": test_component_revision(component_id),
+            "source": {"repository": FIXTURE_REPOSITORY, "release_tag": "fixture"},
             "executable": component_id,
-            "assets": {
-                platform: {
-                    "asset_name": asset.asset_name,
-                    "byte_size": byte_size,
-                    "sha256": sha256,
-                    "download_url": asset.download_url,
-                }
-            },
+            "assets": assets,
         }
     path.write_text(
         json.dumps(
@@ -305,23 +338,6 @@ def all_fixture_payloads(*, platform: str = "linux-amd64") -> dict[str, bytes]:
     return payloads
 
 
-def smoke_stub_script(name: str) -> str:
-    if name == "graphtrail":
-        return f'#!/usr/bin/env python3\nimport sys\nif sys.argv[1:] == ["--version"]:\n    print("graphtrail test 0.4.0")\n    raise SystemExit(0)\nraise SystemExit(1)\n'
-    if name == "graphtrail-mcp":
-        return (
-            '#!/usr/bin/env python3\nimport json, sys\n'
-            'req = json.load(sys.stdin)\n'
-            'assert req.get("method") == "initialize"\n'
-            'print(json.dumps({"jsonrpc": "2.0", "id": req.get("id"), "result": {"protocolVersion": "2024-11-05", "capabilities": {}, "serverInfo": {"name": "graphtrail-mcp", "version": "0.4.0"}}}))\n'
-        )
-    if name == "miseledger":
-        return '#!/usr/bin/env python3\nimport sys\nif sys.argv[1:] == ["version"]:\n    print("miseledger test 0.6.0")\n    raise SystemExit(0)\nraise SystemExit(1)\n'
-    if name == "sessionfind":
-        return '#!/usr/bin/env python3\nimport sys\nif sys.argv[1:] == ["--help"]:\n    print("usage: sessionfind [options]")\n    raise SystemExit(2)\nraise SystemExit(1)\n'
-    raise ValueError(name)
-
-
 class FakeOpener:
     def __init__(self, payloads: dict[str, bytes]):
         self.payloads = payloads
@@ -337,7 +353,7 @@ class FakeOpener:
         return BytesIO(self.payloads[url])
 ```
 
-Engine tests load `write_test_manifest(...)` from a temp path (or monkeypatch `component_manifest.load`) so every asset `byte_size` and `sha256` is derived from `fixture_payload` at test time. Never synthesize bytes to match an arbitrary digest.
+Engine tests load `write_test_manifest(...)` from a temp path (or monkeypatch `component_manifest.load`) so every component publishes the full five-platform matrix, `source.repository` stays an `owner/name` pair, and every asset `byte_size` and `sha256` is derived from executable `fixture_payload` stub bytes at test time. Full-install tests materialize those same bytes so post-install smoke exercises real stub behavior. Never synthesize bytes to match an arbitrary digest.
 
 ## Implementation Recipe
 
@@ -553,24 +569,27 @@ def test_install_restores_prior_executable_when_smoke_fails(tmp_path, monkeypatc
 - [ ] Add failing test:
 
 ```python
+import subprocess
+
+
 def test_run_post_install_smoke_invokes_absolute_paths_only(tmp_path):
     managed = {}
     for name in ("graphtrail", "graphtrail-mcp", "miseledger", "sessionfind"):
         path = tmp_path / name
-        path.write_text(smoke_stub_script(name))
+        path.write_bytes(fixture_payload(name, platform="linux-amd64")[0])
         path.chmod(0o755)
         managed[name] = str(path)
     calls: list[list[str]] = []
 
     def runner(argv, **kwargs):
         calls.append(list(argv))
-        return subprocess.CompletedProcess(argv, 0, stdout="ok", stderr="")
+        return subprocess.run(argv, **kwargs)
 
     run_post_install_smoke(managed, runner=runner)
     assert {cmd[0] for cmd in calls} == set(managed.values())
 ```
 
-- [ ] Implement smoke runner: `subprocess.run` with absolute argv[0], JSON-RPC stdin for graphtrail-mcp, accept exit 2 for sessionfind --help.
+- [ ] Implement smoke runner: `subprocess.run` with absolute argv[0], JSON-RPC stdin for graphtrail-mcp, accept exit 2 for sessionfind --help. Inject `runner` records argv then delegates to real `subprocess.run` so MCP JSON and sessionfind exit 2 are exercised.
 - [ ] RED → GREEN.
 - [ ] Commit: `feat(components): add post-install smoke suite`.
 
@@ -761,7 +780,8 @@ brigade outcome capture brigade-work --run-id latest --kind skill
 - [x] `#356` reporting and `#357` porting explicitly excluded.
 - [x] No automatic PATH mutation; Cargo/Go fallbacks unchanged.
 - [x] Installed state uses `installed_at` consistently in schema, signatures, and tests.
-- [x] Offline engine tests derive digests from `fixture_payload`; no reverse SHA-256 synthesis.
+- [x] Offline engine tests derive digests from executable `fixture_payload` stubs; no reverse SHA-256 synthesis.
+- [x] `write_test_manifest` publishes the full five-platform matrix with `owner/name` `source.repository` values.
 - [x] Task 6 is engine-only dry-run planning; Task 9 owns all CLI wiring and flag dispatch tests.
 - [x] Tests require temp roots and stubbed network; no live GitHub or real home directory.
 

--- a/docs/phase-355-pinned-component-setup.md
+++ b/docs/phase-355-pinned-component-setup.md
@@ -93,7 +93,7 @@ Prior path: `component_paths.installed_previous_state_path(data_root)` → `<dat
   "brigade_version": "0.23.0",
   "manifest_revision": "2026-07-18",
   "platform": "linux-amd64",
-  "timestamp": "2026-07-19T06:00:00.000000+00:00",
+  "installed_at": "2026-07-19T06:00:00.000000+00:00",
   "components": {
     "graphtrail": {
       "component_revision": "64fcd2f9ec37f33e286708845a92e6cfa4abf3bb",
@@ -167,7 +167,7 @@ class InstalledState:
     brigade_version: str
     manifest_revision: str
     platform: str
-    timestamp: str
+    installed_at: str
     components: dict[str, InstalledComponentRecord]
 
 def load_installed_state(path: Path) -> InstalledState | None
@@ -218,6 +218,7 @@ import os
 import sys
 from pathlib import Path
 
+import brigade
 from brigade import component_manifest
 
 GRAPHTRAIL_SHA = "64fcd2f9ec37f33e286708845a92e6cfa4abf3bb"
@@ -234,16 +235,74 @@ def linux_env(root: Path) -> dict[str, str]:
     }
 
 
-def asset_bytes(*, byte_size: int, sha256: str) -> bytes:
-    body = (sha256 * ((byte_size // 64) + 1)).encode("ascii")[:byte_size]
-    assert hashlib.sha256(body).hexdigest() == sha256
-    return body
+def fixture_payload(component_id: str, *, platform: str = "linux-amd64") -> tuple[bytes, int, str]:
+    """Return (payload_bytes, byte_size, sha256) for deterministic offline fixtures."""
+    body = f"fixture:{component_id}:{platform}\n".encode("ascii")
+    digest = hashlib.sha256(body).hexdigest()
+    return body, len(body), digest
 
 
-def write_verified_cache(cache_path: Path, *, byte_size: int, sha256: str) -> None:
+def write_verified_cache(cache_path: Path, *, payload: bytes) -> None:
     cache_path.parent.mkdir(parents=True, exist_ok=True)
-    cache_path.write_bytes(asset_bytes(byte_size=byte_size, sha256=sha256))
+    cache_path.write_bytes(payload)
     cache_path.chmod(0o755)
+
+
+def test_manifest_asset(component_id: str, *, platform: str = "linux-amd64") -> component_manifest.ComponentAsset:
+    _, byte_size, sha256 = fixture_payload(component_id, platform=platform)
+    asset_name = f"{component_id}-{platform}"
+    if platform.startswith("windows"):
+        asset_name += ".exe"
+    return component_manifest.ComponentAsset(
+        asset_name=asset_name,
+        byte_size=byte_size,
+        sha256=sha256,
+        download_url=f"https://example.invalid/components/{component_id}/{platform}",
+    )
+
+
+def write_test_manifest(path: Path, *, platform: str = "linux-amd64", brigade_version: str) -> component_manifest.ComponentManifest:
+    """Write a manifest whose digests match fixture_payload bytes for offline engine tests."""
+    components: dict[str, object] = {}
+    for component_id in component_manifest.KNOWN_COMPONENT_IDS:
+        _, byte_size, sha256 = fixture_payload(component_id, platform=platform)
+        asset = test_manifest_asset(component_id, platform=platform)
+        assert asset.byte_size == byte_size
+        assert asset.sha256 == sha256
+        components[component_id] = {
+            "component_revision": f"fixture-{component_id}",
+            "source": {"repository": f"https://example.invalid/{component_id}", "release_tag": "fixture"},
+            "executable": component_id,
+            "assets": {
+                platform: {
+                    "asset_name": asset.asset_name,
+                    "byte_size": byte_size,
+                    "sha256": sha256,
+                    "download_url": asset.download_url,
+                }
+            },
+        }
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "brigade_version": brigade_version,
+                "manifest_revision": "fixture",
+                "supported_platforms": list(component_manifest.SUPPORTED_PLATFORMS),
+                "components": components,
+            }
+        )
+    )
+    return component_manifest.load(path)
+
+
+def all_fixture_payloads(*, platform: str = "linux-amd64") -> dict[str, bytes]:
+    payloads: dict[str, bytes] = {}
+    for component_id in component_manifest.KNOWN_COMPONENT_IDS:
+        payload, _, _ = fixture_payload(component_id, platform=platform)
+        asset = test_manifest_asset(component_id, platform=platform)
+        payloads[asset.download_url] = payload
+    return payloads
 
 
 def smoke_stub_script(name: str) -> str:
@@ -278,7 +337,7 @@ class FakeOpener:
         return BytesIO(self.payloads[url])
 ```
 
-Tests use small `byte_size` fixtures (for example 64 or 128 bytes) with precomputed `sha256` values checked into `tests/component_install_helpers.py`.
+Engine tests load `write_test_manifest(...)` from a temp path (or monkeypatch `component_manifest.load`) so every asset `byte_size` and `sha256` is derived from `fixture_payload` at test time. Never synthesize bytes to match an arbitrary digest.
 
 ## Implementation Recipe
 
@@ -342,7 +401,7 @@ def test_render_installed_state_round_trips_required_fields():
         brigade_version="0.23.0",
         manifest_revision="2026-07-19",
         platform="linux-amd64",
-        timestamp="2026-07-19T06:00:00+00:00",
+        installed_at="2026-07-19T06:00:00+00:00",
         components={
             "miseledger": InstalledComponentRecord(
                 component_revision="v0.6.0",
@@ -356,6 +415,7 @@ def test_render_installed_state_round_trips_required_fields():
     )
     payload = render_installed_state(state)
     assert payload["schema_version"] == 1
+    assert payload["installed_at"] == "2026-07-19T06:00:00+00:00"
     assert payload["components"]["miseledger"]["executable"].endswith("/brigade/bin/miseledger")
 
 
@@ -397,8 +457,10 @@ def test_verify_cached_asset_rejects_digest_mismatch(tmp_path):
 
 def test_setup_rejects_brigade_version_mismatch(tmp_path, monkeypatch):
     env = linux_env(tmp_path)
-    monkeypatch.setattr(component_install, "__version__", "9.9.9", raising=False)
-    monkeypatch.setattr(component_install, "brigade_version", lambda: "9.9.9")
+    manifest_path = tmp_path / "manifest-v1.json"
+    write_test_manifest(manifest_path, brigade_version="9.9.9")
+    monkeypatch.setattr("brigade.__version__", "0.23.0", raising=False)
+    monkeypatch.setattr(component_manifest, "manifest_path", lambda: manifest_path)
     rc = setup_native_components(env=env)
     assert rc == 1
 ```
@@ -416,17 +478,19 @@ def test_setup_rejects_brigade_version_mismatch(tmp_path, monkeypatch):
 
 ```python
 def test_fetch_asset_to_cache_writes_verified_bytes(tmp_path):
-    asset = _linux_miseledger_asset()
-    cache_path = tmp_path / "cache" / asset.sha256 / asset.asset_name
-    payload = asset_bytes(byte_size=asset.byte_size, sha256=asset.sha256)
+    asset = test_manifest_asset("miseledger", platform="linux-amd64")
+    payload, byte_size, sha256 = fixture_payload("miseledger", platform="linux-amd64")
+    assert asset.byte_size == byte_size
+    assert asset.sha256 == sha256
+    cache_path = tmp_path / "cache" / sha256 / asset.asset_name
     opener = FakeOpener({asset.download_url: payload})
     result = fetch_asset_to_cache(asset, cache_path=cache_path, offline=False, opener=opener)
     assert result == cache_path
-    verify_cached_asset(cache_path, byte_size=asset.byte_size, sha256=asset.sha256)
+    verify_cached_asset(cache_path, byte_size=byte_size, sha256=sha256)
 
 
 def test_fetch_asset_offline_fails_when_cache_corrupt(tmp_path):
-    asset = _linux_miseledger_asset()
+    asset = test_manifest_asset("miseledger", platform="linux-amd64")
     cache_path = tmp_path / "cache" / asset.sha256 / asset.asset_name
     cache_path.parent.mkdir(parents=True)
     cache_path.write_bytes(b"bad")
@@ -435,14 +499,14 @@ def test_fetch_asset_offline_fails_when_cache_corrupt(tmp_path):
 
 
 def test_fetch_asset_online_replaces_bad_cache_only_after_verified_download(tmp_path):
-    asset = _linux_miseledger_asset()
-    cache_path = tmp_path / "cache" / asset.sha256 / asset.asset_name
+    asset = test_manifest_asset("miseledger", platform="linux-amd64")
+    payload, byte_size, sha256 = fixture_payload("miseledger", platform="linux-amd64")
+    cache_path = tmp_path / "cache" / sha256 / asset.asset_name
     cache_path.parent.mkdir(parents=True)
     cache_path.write_bytes(b"stale")
-    good = asset_bytes(byte_size=asset.byte_size, sha256=asset.sha256)
-    opener = FakeOpener({asset.download_url: good})
+    opener = FakeOpener({asset.download_url: payload})
     fetch_asset_to_cache(asset, cache_path=cache_path, offline=False, opener=opener)
-    verify_cached_asset(cache_path, byte_size=asset.byte_size, sha256=asset.sha256)
+    verify_cached_asset(cache_path, byte_size=byte_size, sha256=sha256)
 ```
 
 - [ ] Implement temp-sibling download, verify, `os.replace` into cache; offline raises when cache invalid; online never replaces until verified temp passes.
@@ -503,7 +567,7 @@ def test_run_post_install_smoke_invokes_absolute_paths_only(tmp_path):
         return subprocess.CompletedProcess(argv, 0, stdout="ok", stderr="")
 
     run_post_install_smoke(managed, runner=runner)
-    assert all(cmd[0] == managed[cmd[0].split("/")[-1].split(".")[0]] or cmd[0] in managed.values() for cmd in calls)
+    assert {cmd[0] for cmd in calls} == set(managed.values())
 ```
 
 - [ ] Implement smoke runner: `subprocess.run` with absolute argv[0], JSON-RPC stdin for graphtrail-mcp, accept exit 2 for sessionfind --help.
@@ -512,38 +576,36 @@ def test_run_post_install_smoke_invokes_absolute_paths_only(tmp_path):
 
 ### Task 6: Dry-run plan reporting
 
-**Files:** `src/brigade/component_install.py`, `src/brigade/cli/setup.py`, `tests/test_component_install.py`, `tests/test_cli_setup.py`.
+**Files:** `src/brigade/component_install.py`, `tests/test_component_install.py`.
 
 - [ ] Add failing tests:
 
 ```python
-def test_build_setup_plan_lists_all_four_components():
-    manifest = component_manifest.load()
-    roots = resolve_roots(env=linux_env(Path("/tmp/not-used")), system="linux")
+def test_build_setup_plan_lists_all_four_components(tmp_path, monkeypatch):
+    manifest_path = tmp_path / "manifest-v1.json"
+    manifest = write_test_manifest(manifest_path, brigade_version=brigade.__version__)
+    monkeypatch.setattr(component_manifest, "manifest_path", lambda: manifest_path)
+    roots = resolve_roots(env=linux_env(tmp_path), system="linux")
     plan = build_setup_plan(manifest, platform="linux-amd64", roots=roots)
     assert {action.component_id for action in plan} == set(component_manifest.KNOWN_COMPONENT_IDS)
 
 
-def test_setup_dry_run_writes_nothing(tmp_path, capsys):
+def test_setup_dry_run_writes_nothing(tmp_path, monkeypatch, capsys):
     env = linux_env(tmp_path)
+    manifest_path = tmp_path / "manifest-v1.json"
+    write_test_manifest(manifest_path, brigade_version=brigade.__version__)
+    monkeypatch.setattr(component_manifest, "manifest_path", lambda: manifest_path)
     rc = setup_native_components(dry_run=True, env=env)
     out = capsys.readouterr().out
     assert rc == 0
-    assert "graphtrail-linux-amd64" in out
+    assert "miseledger-linux-amd64" in out
     assert "download" in out
     assert not (Path(env["XDG_DATA_HOME"]) / "brigade" / "installed.json").exists()
-
-
-def test_cli_setup_dry_run_flag(tmp_path, monkeypatch, capsys):
-    env = linux_env(tmp_path)
-    for key, value in env.items():
-        monkeypatch.setenv(key, value)
-    assert cli.main(["setup", "--dry-run"]) == 0
 ```
 
-- [ ] Implement `build_setup_plan` and dry-run printer; wire CLI.
-- [ ] RED → GREEN.
-- [ ] Commit: `feat(cli): add brigade setup dry-run`.
+- [ ] Implement `build_setup_plan` and dry-run reporting in `component_install` only; no CLI files in this task.
+- [ ] RED → GREEN on `tests/test_component_install.py` focused tests.
+- [ ] Commit: `feat(components): add setup dry-run planning`.
 
 ### Task 7: Full install, idempotent repeat, and state commit after smoke
 
@@ -552,9 +614,12 @@ def test_cli_setup_dry_run_flag(tmp_path, monkeypatch, capsys):
 - [ ] Add failing tests:
 
 ```python
-def test_setup_install_writes_state_after_smoke(tmp_path):
+def test_setup_install_writes_state_after_smoke(tmp_path, monkeypatch):
     env = linux_env(tmp_path)
-    payloads = _all_manifest_payloads(env, platform="linux-amd64")
+    manifest_path = tmp_path / "manifest-v1.json"
+    write_test_manifest(manifest_path, brigade_version=brigade.__version__)
+    monkeypatch.setattr(component_manifest, "manifest_path", lambda: manifest_path)
+    payloads = all_fixture_payloads(platform="linux-amd64")
     rc = setup_native_components(env=env, opener=FakeOpener(payloads))
     assert rc == 0
     state_path = Path(component_paths.installed_state_path(resolve_roots(env=env).data_root))
@@ -563,9 +628,12 @@ def test_setup_install_writes_state_after_smoke(tmp_path):
     assert set(state["components"]) == set(component_manifest.KNOWN_COMPONENT_IDS)
 
 
-def test_repeat_setup_is_idempotent_and_skips_previous_rotation(tmp_path):
+def test_repeat_setup_is_idempotent_and_skips_previous_rotation(tmp_path, monkeypatch):
     env = linux_env(tmp_path)
-    payloads = _all_manifest_payloads(env, platform="linux-amd64")
+    manifest_path = tmp_path / "manifest-v1.json"
+    write_test_manifest(manifest_path, brigade_version=brigade.__version__)
+    monkeypatch.setattr(component_manifest, "manifest_path", lambda: manifest_path)
+    payloads = all_fixture_payloads(platform="linux-amd64")
     opener = FakeOpener(payloads)
     assert setup_native_components(env=env, opener=opener) == 0
     roots = resolve_roots(env=env)
@@ -582,7 +650,7 @@ def test_repeat_setup_is_idempotent_and_skips_previous_rotation(tmp_path):
 
 ### Task 8: Rollback via verified prior state
 
-**Files:** `src/brigade/component_install.py`, `tests/test_component_install.py`, `tests/test_cli_setup.py`.
+**Files:** `src/brigade/component_install.py`, `tests/test_component_install.py`.
 
 - [ ] Add failing tests:
 
@@ -610,7 +678,7 @@ def test_setup_rollback_fails_when_prior_cache_missing(tmp_path):
 
 **Files:** `src/brigade/cli/setup.py`, `src/brigade/cli/__init__.py`, `src/brigade/cli/_common.py`, `tests/test_cli_setup.py`, `tests/test_cli_help.py`.
 
-- [ ] Register parser:
+- [ ] Create `src/brigade/cli/setup.py` and register parser:
 
 ```python
 def register(sub: argparse._SubParsersAction) -> None:
@@ -622,6 +690,37 @@ def register(sub: argparse._SubParsersAction) -> None:
 ```
 
 - [ ] Add `setup` to `COMMAND_GROUPS` and `_setup_group.register(sub)` after `_add_group.register(sub)`.
+- [ ] Add failing CLI dispatch tests:
+
+```python
+def test_cli_setup_dry_run_flag(tmp_path, monkeypatch):
+    env = linux_env(tmp_path)
+    manifest_path = tmp_path / "manifest-v1.json"
+    write_test_manifest(manifest_path, brigade_version=brigade.__version__)
+    monkeypatch.setattr(component_manifest, "manifest_path", lambda: manifest_path)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    assert cli.main(["setup", "--dry-run"]) == 0
+
+
+def test_cli_setup_offline_flag(tmp_path, monkeypatch):
+    env = linux_env(tmp_path)
+    manifest_path = tmp_path / "manifest-v1.json"
+    write_test_manifest(manifest_path, brigade_version=brigade.__version__)
+    monkeypatch.setattr(component_manifest, "manifest_path", lambda: manifest_path)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    assert cli.main(["setup", "--offline"]) == 1
+
+
+def test_cli_setup_rollback_flag(tmp_path, monkeypatch):
+    env = linux_env(tmp_path)
+    _seed_installed_pair(env, revision_a="2026-07-18", revision_b="2026-07-19")
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    assert cli.main(["setup", "--rollback"]) == 0
+```
+
 - [ ] RED: `tests/test_cli_help.py::test_command_groups_cover_every_command_exactly_once` fails until registration complete.
 - [ ] GREEN after wiring.
 - [ ] Commit: `feat(cli): register brigade setup command`.
@@ -661,12 +760,15 @@ brigade outcome capture brigade-work --run-id latest --kind skill
 - [x] Every behavior maps to a file, test name, RED/GREEN verify command, and commit message.
 - [x] `#356` reporting and `#357` porting explicitly excluded.
 - [x] No automatic PATH mutation; Cargo/Go fallbacks unchanged.
+- [x] Installed state uses `installed_at` consistently in schema, signatures, and tests.
+- [x] Offline engine tests derive digests from `fixture_payload`; no reverse SHA-256 synthesis.
+- [x] Task 6 is engine-only dry-run planning; Task 9 owns all CLI wiring and flag dispatch tests.
 - [x] Tests require temp roots and stubbed network; no live GitHub or real home directory.
 
 ## Placeholder Scan
 
-Run before committing this document (must return no matches outside this instruction line):
+Run before committing this document (scan body only; exclude this section):
 
 ```bash
-rg -n 'TODO|TBD|FIXME|XXX' docs/phase-355-pinned-component-setup.md && exit 1 || true
+python -c "from pathlib import Path; import re, sys; text=Path('docs/phase-355-pinned-component-setup.md').read_text(); body=text.split('## Placeholder Scan', 1)[0]; sys.exit(1 if re.search(r'TODO|TBD|FIXME|XXX', body) else 0)"
 ```

--- a/src/brigade/cli/__init__.py
+++ b/src/brigade/cli/__init__.py
@@ -31,6 +31,7 @@ from . import (
     receipts as _receipts_group,
     daily as _daily_group,
     add as _add_group,
+    setup as _setup_group,
     stations as _stations_group,
     pantry as _pantry_group,
     evidence as _evidence_group,
@@ -129,6 +130,7 @@ def _build_parser() -> argparse.ArgumentParser:
     _receipts_group.register(sub)
     _daily_group.register(sub)
     _add_group.register(sub)
+    _setup_group.register(sub)
     _stations_group.register(sub)
     _evidence_group.register(sub)
     _search_group.register(sub)

--- a/src/brigade/cli/_common.py
+++ b/src/brigade/cli/_common.py
@@ -24,6 +24,7 @@ COMMAND_GROUPS: list[tuple[str, list[str]]] = [
         "Stations and tools",
         [
             "add",
+            "setup",
             "stations",
             "skills",
             "harness",

--- a/src/brigade/cli/setup.py
+++ b/src/brigade/cli/setup.py
@@ -1,0 +1,23 @@
+"""brigade setup command group."""
+
+from __future__ import annotations
+
+import argparse
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p_setup = sub.add_parser("setup", help="Install pinned native Brigade components.")
+    p_setup.add_argument("--dry-run", action="store_true", help="Report planned actions without writing.")
+    p_setup.add_argument("--offline", action="store_true", help="Use verified cache only; fail if missing.")
+    p_setup.add_argument("--rollback", action="store_true", help="Restore the previous installed manifest.")
+    p_setup.set_defaults(func=dispatch)
+
+
+def dispatch(args) -> int:
+    from ..component_install import setup_native_components
+
+    return setup_native_components(
+        dry_run=args.dry_run,
+        offline=args.offline,
+        rollback=args.rollback,
+    )

--- a/src/brigade/component_install.py
+++ b/src/brigade/component_install.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import json
 import os
 import re
+import stat
 import subprocess
 import sys
 import tempfile
+import urllib.error
 import urllib.request
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
@@ -15,13 +17,14 @@ from pathlib import Path
 from typing import Any
 
 import brigade
-from brigade import component_manifest, component_paths, localio
+from brigade import component_manifest, component_paths, component_state, localio
 
 _SHA256 = re.compile(r"^[0-9a-f]{64}$")
 _READ_CHUNK = 1024 * 1024
 _EXECUTABLE_MODE = 0o755
 _SMOKE_COMPONENT_IDS = component_manifest.KNOWN_COMPONENT_IDS
 _SMOKE_TIMEOUT_SECONDS = 30.0
+_DOWNLOAD_TIMEOUT_SECONDS = 30.0
 _JSONRPC_INIT_REQUEST = json.dumps(
     {
         "jsonrpc": "2.0",
@@ -189,14 +192,35 @@ def _restore_managed_executables(snapshots: Sequence[_ManagedExecutableSnapshot]
     for snapshot in snapshots:
         if snapshot.existed:
             if snapshot.content is None or snapshot.mode is None:
-                raise ComponentInstallError(
-                    f"invalid managed executable snapshot for {snapshot.path}"
-                )
-            snapshot.path.parent.mkdir(parents=True, exist_ok=True)
-            snapshot.path.write_bytes(snapshot.content)
-            snapshot.path.chmod(snapshot.mode)
+                raise ComponentInstallError(f"invalid managed executable snapshot for {snapshot.path}")
+            _restore_file_atomically(
+                snapshot.path,
+                content=snapshot.content,
+                mode=snapshot.mode,
+            )
         elif snapshot.path.exists():
             snapshot.path.unlink()
+
+
+def _restore_file_atomically(path: Path, *, content: bytes, mode: int) -> None:
+    """Restore one snapshotted file through a temp sibling and os.replace."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        tmp_path.chmod(stat.S_IMODE(mode))
+        os.replace(tmp_path, path)
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
 
 
 def materialize_executable(*, cache_path: Path, managed_path: Path) -> None:
@@ -242,14 +266,10 @@ def verify_cached_asset(path: Path, *, byte_size: int, sha256: str) -> None:
         raise ComponentInstallError(f"cached asset missing: {path}")
     actual_size = path.stat().st_size
     if actual_size != byte_size:
-        raise ComponentInstallError(
-            f"byte_size mismatch for {path}: expected {byte_size}, got {actual_size}"
-        )
+        raise ComponentInstallError(f"byte_size mismatch for {path}: expected {byte_size}, got {actual_size}")
     actual_sha256 = localio.file_sha256(path)
     if actual_sha256 != sha256:
-        raise ComponentInstallError(
-            f"sha256 mismatch for {path}: expected {sha256}, got {actual_sha256}"
-        )
+        raise ComponentInstallError(f"sha256 mismatch for {path}: expected {sha256}, got {actual_sha256}")
 
 
 def fetch_asset_to_cache(
@@ -265,21 +285,21 @@ def fetch_asset_to_cache(
         verify_cached_asset(cache_path, byte_size=asset.byte_size, sha256=asset.sha256)
     except ComponentInstallError:
         if offline:
-            raise ComponentInstallError(
-                f"offline: verified cache required at {cache_path}"
-            ) from None
+            raise ComponentInstallError(f"offline: verified cache required at {cache_path}") from None
     else:
         return cache_path
 
-    url_opener = opener if opener is not None else urllib.request.urlopen
+    def open_url(url: str) -> Any:
+        if opener is not None:
+            return opener(url)
+        return urllib.request.urlopen(url, timeout=_DOWNLOAD_TIMEOUT_SECONDS)
+
     cache_path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp_name = tempfile.mkstemp(
-        dir=cache_path.parent, prefix=f".{cache_path.name}.", suffix=".tmp"
-    )
+    fd, tmp_name = tempfile.mkstemp(dir=cache_path.parent, prefix=f".{cache_path.name}.", suffix=".tmp")
     tmp_path = Path(tmp_name)
     try:
         with os.fdopen(fd, "wb") as handle:
-            with url_opener(asset.download_url) as response:
+            with open_url(asset.download_url) as response:
                 while True:
                     chunk = response.read(_READ_CHUNK)
                     if not chunk:
@@ -293,9 +313,7 @@ def fetch_asset_to_cache(
     return cache_path
 
 
-def _default_smoke_runner(
-    argv: Sequence[str], **kwargs: object
-) -> subprocess.CompletedProcess[str]:
+def _default_smoke_runner(argv: Sequence[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
     run_kwargs: dict[str, object] = {
         "capture_output": True,
         "text": True,
@@ -333,8 +351,7 @@ def _validate_smoke_managed_paths(managed_paths: Mapping[str, str]) -> dict[str,
         if extra:
             parts.append(f"unexpected: {', '.join(extra)}")
         raise ComponentInstallError(
-            "post-install smoke requires exactly "
-            f"{len(expected)} managed paths; {'; '.join(parts)}"
+            f"post-install smoke requires exactly {len(expected)} managed paths; {'; '.join(parts)}"
         )
 
     resolved: dict[str, Path] = {}
@@ -343,13 +360,10 @@ def _validate_smoke_managed_paths(managed_paths: Mapping[str, str]) -> dict[str,
         path = Path(raw)
         if not path.is_absolute():
             raise ComponentInstallError(
-                f"post-install smoke for {component_id} requires absolute managed path, "
-                f"got {raw!r}"
+                f"post-install smoke for {component_id} requires absolute managed path, got {raw!r}"
             )
         if not path.is_file():
-            raise ComponentInstallError(
-                f"post-install smoke for {component_id}: managed executable missing: {raw}"
-            )
+            raise ComponentInstallError(f"post-install smoke for {component_id}: managed executable missing: {raw}")
         resolved[component_id] = path
     return resolved
 
@@ -362,20 +376,14 @@ def _smoke_graphtrail(
     try:
         completed = _invoke_smoke_runner(run, argv)
     except subprocess.TimeoutExpired as exc:
-        raise ComponentInstallError(
-            f"graphtrail smoke timed out after {_SMOKE_TIMEOUT_SECONDS}s"
-        ) from exc
+        raise ComponentInstallError(f"graphtrail smoke timed out after {_SMOKE_TIMEOUT_SECONDS}s") from exc
     except OSError as exc:
         raise ComponentInstallError(f"graphtrail smoke failed to run {path}: {exc}") from exc
 
     if completed.returncode != 0:
-        raise ComponentInstallError(
-            f"graphtrail smoke failed: {path} --version exited {completed.returncode}"
-        )
+        raise ComponentInstallError(f"graphtrail smoke failed: {path} --version exited {completed.returncode}")
     if not (completed.stdout or "").strip():
-        raise ComponentInstallError(
-            f"graphtrail smoke failed: {path} --version produced empty stdout"
-        )
+        raise ComponentInstallError(f"graphtrail smoke failed: {path} --version produced empty stdout")
 
 
 def _smoke_graphtrail_mcp(
@@ -386,19 +394,15 @@ def _smoke_graphtrail_mcp(
     try:
         completed = _invoke_smoke_runner(run, argv, input=_JSONRPC_INIT_REQUEST)
     except subprocess.TimeoutExpired as exc:
-        raise ComponentInstallError(
-            f"graphtrail-mcp smoke timed out after {_SMOKE_TIMEOUT_SECONDS}s"
-        ) from exc
+        raise ComponentInstallError(f"graphtrail-mcp smoke timed out after {_SMOKE_TIMEOUT_SECONDS}s") from exc
     except OSError as exc:
-        raise ComponentInstallError(
-            f"graphtrail-mcp smoke failed to run {path}: {exc}"
-        ) from exc
+        raise ComponentInstallError(f"graphtrail-mcp smoke failed to run {path}: {exc}") from exc
 
+    if completed.returncode != 0:
+        raise ComponentInstallError(f"graphtrail-mcp smoke failed: {path} exited {completed.returncode}")
     stdout = (completed.stdout or "").strip()
     if not stdout:
-        raise ComponentInstallError(
-            f"graphtrail-mcp smoke failed: {path} produced empty stdout"
-        )
+        raise ComponentInstallError(f"graphtrail-mcp smoke failed: {path} produced empty stdout")
     try:
         response = json.loads(stdout)
     except json.JSONDecodeError as exc:
@@ -406,17 +410,11 @@ def _smoke_graphtrail_mcp(
             f"graphtrail-mcp smoke failed: {path} returned malformed JSON-RPC response"
         ) from exc
     if response.get("jsonrpc") != "2.0":
-        raise ComponentInstallError(
-            f"graphtrail-mcp smoke failed: {path} returned invalid JSON-RPC version"
-        )
+        raise ComponentInstallError(f"graphtrail-mcp smoke failed: {path} returned invalid JSON-RPC version")
     if response.get("id") != 1:
-        raise ComponentInstallError(
-            f"graphtrail-mcp smoke failed: {path} JSON-RPC response id mismatch"
-        )
+        raise ComponentInstallError(f"graphtrail-mcp smoke failed: {path} JSON-RPC response id mismatch")
     if "result" not in response:
-        raise ComponentInstallError(
-            f"graphtrail-mcp smoke failed: {path} JSON-RPC response missing result"
-        )
+        raise ComponentInstallError(f"graphtrail-mcp smoke failed: {path} JSON-RPC response missing result")
 
 
 def _smoke_miseledger(
@@ -427,16 +425,12 @@ def _smoke_miseledger(
     try:
         completed = _invoke_smoke_runner(run, argv)
     except subprocess.TimeoutExpired as exc:
-        raise ComponentInstallError(
-            f"miseledger smoke timed out after {_SMOKE_TIMEOUT_SECONDS}s"
-        ) from exc
+        raise ComponentInstallError(f"miseledger smoke timed out after {_SMOKE_TIMEOUT_SECONDS}s") from exc
     except OSError as exc:
         raise ComponentInstallError(f"miseledger smoke failed to run {path}: {exc}") from exc
 
     if completed.returncode != 0:
-        raise ComponentInstallError(
-            f"miseledger smoke failed: {path} version exited {completed.returncode}"
-        )
+        raise ComponentInstallError(f"miseledger smoke failed: {path} version exited {completed.returncode}")
 
 
 def _smoke_sessionfind(
@@ -447,9 +441,7 @@ def _smoke_sessionfind(
     try:
         completed = _invoke_smoke_runner(run, argv)
     except subprocess.TimeoutExpired as exc:
-        raise ComponentInstallError(
-            f"sessionfind smoke timed out after {_SMOKE_TIMEOUT_SECONDS}s"
-        ) from exc
+        raise ComponentInstallError(f"sessionfind smoke timed out after {_SMOKE_TIMEOUT_SECONDS}s") from exc
     except OSError as exc:
         raise ComponentInstallError(f"sessionfind smoke failed to run {path}: {exc}") from exc
 
@@ -459,9 +451,7 @@ def _smoke_sessionfind(
         )
     combined = f"{completed.stdout or ''}{completed.stderr or ''}"
     if "usage" not in combined.lower():
-        raise ComponentInstallError(
-            f"sessionfind smoke failed: {path} --help produced no usage text"
-        )
+        raise ComponentInstallError(f"sessionfind smoke failed: {path} --help produced no usage text")
 
 
 def run_post_install_smoke(
@@ -485,25 +475,105 @@ def setup_native_components(
     offline: bool = False,
     rollback: bool = False,
     env: Mapping[str, str] | None = None,
-    opener: object | None = None,
-    runner: object | None = None,
+    opener: Callable[..., Any] | None = None,
+    runner: Callable[..., subprocess.CompletedProcess[str]] | None = None,
 ) -> int:
     """Install pinned native components; return process exit code."""
-    del opener, runner
     try:
         manifest = component_manifest.load()
-    except ValueError as exc:
+        if manifest.brigade_version != brigade.__version__:
+            raise ComponentInstallError(
+                "brigade_version mismatch: "
+                f"manifest requires {manifest.brigade_version!r}, "
+                f"running Brigade {brigade.__version__!r}"
+            )
+        if dry_run:
+            return _setup_dry_run(manifest, env=env)
+        if rollback:
+            raise ComponentInstallError("rollback is not implemented")
+
+        roots = resolve_roots(env=env)
+        platform = component_manifest.platform_key()
+        plan = build_setup_plan(manifest, platform=platform, roots=roots)
+        assets = [entry for entry in plan if entry.action == "verify-cache"]
+        current_state_path = Path(component_paths.installed_state_path(roots.data_root))
+        previous_state_path = Path(component_paths.installed_previous_state_path(roots.data_root))
+        current_state = component_state.load_installed_state(current_state_path)
+        if current_state_path.exists() and current_state is None:
+            raise ComponentInstallError(f"invalid installed state: {current_state_path}")
+
+        for entry in assets:
+            asset = manifest.components[entry.component_id].assets[platform]
+            fetch_asset_to_cache(
+                asset,
+                cache_path=Path(entry.cache_path),
+                offline=offline,
+                opener=opener,
+            )
+
+        managed_paths = {entry.component_id: Path(entry.managed_path) for entry in assets}
+        snapshots = _snapshot_managed_executables(list(managed_paths.values()))
+        state_snapshots = _snapshot_managed_executables([current_state_path, previous_state_path])
+        try:
+            for entry in assets:
+                managed_path = managed_paths[entry.component_id]
+                try:
+                    verify_cached_asset(
+                        managed_path,
+                        byte_size=entry.byte_size,
+                        sha256=entry.sha256,
+                    )
+                except ComponentInstallError:
+                    verify_cached_asset(
+                        Path(entry.cache_path),
+                        byte_size=entry.byte_size,
+                        sha256=entry.sha256,
+                    )
+                    materialize_executable(
+                        cache_path=Path(entry.cache_path),
+                        managed_path=managed_path,
+                    )
+
+            for entry in assets:
+                verify_cached_asset(
+                    managed_paths[entry.component_id],
+                    byte_size=entry.byte_size,
+                    sha256=entry.sha256,
+                )
+
+            run_post_install_smoke(
+                {component_id: str(path) for component_id, path in managed_paths.items()},
+                runner=runner,
+            )
+            next_state = component_state.InstalledState(
+                schema_version=component_state.SCHEMA_VERSION,
+                brigade_version=brigade.__version__,
+                manifest_revision=manifest.manifest_revision,
+                platform=platform,
+                installed_at=localio.utc_now_iso(),
+                components={
+                    entry.component_id: component_state.InstalledComponentRecord(
+                        component_revision=entry.component_revision,
+                        asset_name=entry.asset_name,
+                        byte_size=entry.byte_size,
+                        sha256=entry.sha256,
+                        download_url=entry.download_url,
+                        executable=str(managed_paths[entry.component_id]),
+                    )
+                    for entry in assets
+                },
+            )
+            if current_state is not None and component_state.should_rotate_previous(current_state, next_state):
+                component_state.write_installed_state(previous_state_path, current_state)
+            component_state.write_installed_state(current_state_path, next_state)
+        except (ComponentInstallError, OSError, ValueError, urllib.error.URLError) as exc:
+            try:
+                _restore_managed_executables(snapshots)
+                _restore_managed_executables(state_snapshots)
+            except (ComponentInstallError, OSError) as restore_exc:
+                raise ComponentInstallError(f"{exc}; failed to restore prior managed files: {restore_exc}") from exc
+            raise
+    except (ComponentInstallError, OSError, ValueError, urllib.error.URLError) as exc:
         print(f"component setup: {exc}", file=sys.stderr)
         return 1
-    if manifest.brigade_version != brigade.__version__:
-        print(
-            "component setup: brigade_version mismatch: "
-            f"manifest requires {manifest.brigade_version!r}, "
-            f"running Brigade {brigade.__version__!r}",
-            file=sys.stderr,
-        )
-        return 1
-    if dry_run:
-        return _setup_dry_run(manifest, env=env)
-    del offline, rollback, env
     return 0

--- a/src/brigade/component_install.py
+++ b/src/brigade/component_install.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import json
 import os
 import re
+import subprocess
 import sys
 import tempfile
 import urllib.request
@@ -18,6 +20,20 @@ from brigade import component_manifest, localio
 _SHA256 = re.compile(r"^[0-9a-f]{64}$")
 _READ_CHUNK = 1024 * 1024
 _EXECUTABLE_MODE = 0o755
+_SMOKE_COMPONENT_IDS = component_manifest.KNOWN_COMPONENT_IDS
+_SMOKE_TIMEOUT_SECONDS = 30.0
+_JSONRPC_INIT_REQUEST = json.dumps(
+    {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "brigade-setup", "version": "1"},
+        },
+    }
+)
 
 
 class ComponentInstallError(RuntimeError):
@@ -156,6 +172,192 @@ def fetch_asset_to_cache(
         tmp_path.unlink(missing_ok=True)
         raise
     return cache_path
+
+
+def _default_smoke_runner(
+    argv: Sequence[str], **kwargs: object
+) -> subprocess.CompletedProcess[str]:
+    run_kwargs: dict[str, object] = {
+        "capture_output": True,
+        "text": True,
+        "shell": False,
+        "timeout": _SMOKE_TIMEOUT_SECONDS,
+    }
+    run_kwargs.update(kwargs)
+    return subprocess.run(list(argv), **run_kwargs)  # type: ignore[arg-type, call-overload]
+
+
+def _invoke_smoke_runner(
+    run: Callable[..., subprocess.CompletedProcess[str]],
+    argv: Sequence[str],
+    **kwargs: object,
+) -> subprocess.CompletedProcess[str]:
+    return run(
+        list(argv),
+        capture_output=True,
+        text=True,
+        shell=False,
+        timeout=_SMOKE_TIMEOUT_SECONDS,
+        **kwargs,
+    )
+
+
+def _validate_smoke_managed_paths(managed_paths: Mapping[str, str]) -> dict[str, Path]:
+    keys = set(managed_paths)
+    expected = set(_SMOKE_COMPONENT_IDS)
+    if keys != expected:
+        missing = sorted(expected - keys)
+        extra = sorted(keys - expected)
+        parts: list[str] = []
+        if missing:
+            parts.append(f"missing: {', '.join(missing)}")
+        if extra:
+            parts.append(f"unexpected: {', '.join(extra)}")
+        raise ComponentInstallError(
+            "post-install smoke requires exactly "
+            f"{len(expected)} managed paths; {'; '.join(parts)}"
+        )
+
+    resolved: dict[str, Path] = {}
+    for component_id in _SMOKE_COMPONENT_IDS:
+        raw = managed_paths[component_id]
+        path = Path(raw)
+        if not path.is_absolute():
+            raise ComponentInstallError(
+                f"post-install smoke for {component_id} requires absolute managed path, "
+                f"got {raw!r}"
+            )
+        if not path.is_file():
+            raise ComponentInstallError(
+                f"post-install smoke for {component_id}: managed executable missing: {raw}"
+            )
+        resolved[component_id] = path
+    return resolved
+
+
+def _smoke_graphtrail(
+    path: Path,
+    run: Callable[..., subprocess.CompletedProcess[str]],
+) -> None:
+    argv = [str(path), "--version"]
+    try:
+        completed = _invoke_smoke_runner(run, argv)
+    except subprocess.TimeoutExpired as exc:
+        raise ComponentInstallError(
+            f"graphtrail smoke timed out after {_SMOKE_TIMEOUT_SECONDS}s"
+        ) from exc
+    except OSError as exc:
+        raise ComponentInstallError(f"graphtrail smoke failed to run {path}: {exc}") from exc
+
+    if completed.returncode != 0:
+        raise ComponentInstallError(
+            f"graphtrail smoke failed: {path} --version exited {completed.returncode}"
+        )
+    if not (completed.stdout or "").strip():
+        raise ComponentInstallError(
+            f"graphtrail smoke failed: {path} --version produced empty stdout"
+        )
+
+
+def _smoke_graphtrail_mcp(
+    path: Path,
+    run: Callable[..., subprocess.CompletedProcess[str]],
+) -> None:
+    argv = [str(path)]
+    try:
+        completed = _invoke_smoke_runner(run, argv, input=_JSONRPC_INIT_REQUEST)
+    except subprocess.TimeoutExpired as exc:
+        raise ComponentInstallError(
+            f"graphtrail-mcp smoke timed out after {_SMOKE_TIMEOUT_SECONDS}s"
+        ) from exc
+    except OSError as exc:
+        raise ComponentInstallError(
+            f"graphtrail-mcp smoke failed to run {path}: {exc}"
+        ) from exc
+
+    stdout = (completed.stdout or "").strip()
+    if not stdout:
+        raise ComponentInstallError(
+            f"graphtrail-mcp smoke failed: {path} produced empty stdout"
+        )
+    try:
+        response = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise ComponentInstallError(
+            f"graphtrail-mcp smoke failed: {path} returned malformed JSON-RPC response"
+        ) from exc
+    if response.get("jsonrpc") != "2.0":
+        raise ComponentInstallError(
+            f"graphtrail-mcp smoke failed: {path} returned invalid JSON-RPC version"
+        )
+    if response.get("id") != 1:
+        raise ComponentInstallError(
+            f"graphtrail-mcp smoke failed: {path} JSON-RPC response id mismatch"
+        )
+    if "result" not in response:
+        raise ComponentInstallError(
+            f"graphtrail-mcp smoke failed: {path} JSON-RPC response missing result"
+        )
+
+
+def _smoke_miseledger(
+    path: Path,
+    run: Callable[..., subprocess.CompletedProcess[str]],
+) -> None:
+    argv = [str(path), "version"]
+    try:
+        completed = _invoke_smoke_runner(run, argv)
+    except subprocess.TimeoutExpired as exc:
+        raise ComponentInstallError(
+            f"miseledger smoke timed out after {_SMOKE_TIMEOUT_SECONDS}s"
+        ) from exc
+    except OSError as exc:
+        raise ComponentInstallError(f"miseledger smoke failed to run {path}: {exc}") from exc
+
+    if completed.returncode != 0:
+        raise ComponentInstallError(
+            f"miseledger smoke failed: {path} version exited {completed.returncode}"
+        )
+
+
+def _smoke_sessionfind(
+    path: Path,
+    run: Callable[..., subprocess.CompletedProcess[str]],
+) -> None:
+    argv = [str(path), "--help"]
+    try:
+        completed = _invoke_smoke_runner(run, argv)
+    except subprocess.TimeoutExpired as exc:
+        raise ComponentInstallError(
+            f"sessionfind smoke timed out after {_SMOKE_TIMEOUT_SECONDS}s"
+        ) from exc
+    except OSError as exc:
+        raise ComponentInstallError(f"sessionfind smoke failed to run {path}: {exc}") from exc
+
+    if completed.returncode != 2:
+        raise ComponentInstallError(
+            f"sessionfind smoke failed: {path} --help exited {completed.returncode}, expected 2"
+        )
+    combined = f"{completed.stdout or ''}{completed.stderr or ''}"
+    if "usage" not in combined.lower():
+        raise ComponentInstallError(
+            f"sessionfind smoke failed: {path} --help produced no usage text"
+        )
+
+
+def run_post_install_smoke(
+    managed_paths: Mapping[str, str],
+    *,
+    runner: Callable[..., subprocess.CompletedProcess[str]] | None = None,
+) -> None:
+    """Run post-install smoke checks using only absolute managed executable paths."""
+    paths = _validate_smoke_managed_paths(managed_paths)
+    run = runner if runner is not None else _default_smoke_runner
+
+    _smoke_graphtrail(paths["graphtrail"], run)
+    _smoke_graphtrail_mcp(paths["graphtrail-mcp"], run)
+    _smoke_miseledger(paths["miseledger"], run)
+    _smoke_sessionfind(paths["sessionfind"], run)
 
 
 def setup_native_components(

--- a/src/brigade/component_install.py
+++ b/src/brigade/component_install.py
@@ -7,7 +7,8 @@ import re
 import sys
 import tempfile
 import urllib.request
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -16,10 +17,80 @@ from brigade import component_manifest, localio
 
 _SHA256 = re.compile(r"^[0-9a-f]{64}$")
 _READ_CHUNK = 1024 * 1024
+_EXECUTABLE_MODE = 0o755
 
 
 class ComponentInstallError(RuntimeError):
     """Raised when a component install step fails verification."""
+
+
+@dataclass(frozen=True)
+class _ManagedExecutableSnapshot:
+    path: Path
+    existed: bool
+    content: bytes | None = None
+    mode: int | None = None
+
+
+def _snapshot_managed_executables(paths: Sequence[Path]) -> tuple[_ManagedExecutableSnapshot, ...]:
+    snapshots: list[_ManagedExecutableSnapshot] = []
+    for path in paths:
+        if path.is_file():
+            stat_result = path.stat()
+            snapshots.append(
+                _ManagedExecutableSnapshot(
+                    path=path,
+                    existed=True,
+                    content=path.read_bytes(),
+                    mode=stat_result.st_mode,
+                )
+            )
+        else:
+            snapshots.append(_ManagedExecutableSnapshot(path=path, existed=False))
+    return tuple(snapshots)
+
+
+def _restore_managed_executables(snapshots: Sequence[_ManagedExecutableSnapshot]) -> None:
+    for snapshot in snapshots:
+        if snapshot.existed:
+            if snapshot.content is None or snapshot.mode is None:
+                raise ComponentInstallError(
+                    f"invalid managed executable snapshot for {snapshot.path}"
+                )
+            snapshot.path.parent.mkdir(parents=True, exist_ok=True)
+            snapshot.path.write_bytes(snapshot.content)
+            snapshot.path.chmod(snapshot.mode)
+        elif snapshot.path.exists():
+            snapshot.path.unlink()
+
+
+def materialize_executable(*, cache_path: Path, managed_path: Path) -> None:
+    """Copy a verified cache file into a managed executable path atomically."""
+    if not cache_path.is_file():
+        raise ComponentInstallError(f"cache asset missing: {cache_path}")
+    managed_path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        dir=managed_path.parent,
+        prefix=f".{managed_path.name}.",
+        suffix=".tmp",
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            with cache_path.open("rb") as source:
+                while True:
+                    chunk = source.read(_READ_CHUNK)
+                    if not chunk:
+                        break
+                    handle.write(chunk)
+            handle.flush()
+            os.fsync(handle.fileno())
+        if sys.platform != "win32":
+            tmp_path.chmod(_EXECUTABLE_MODE)
+        os.replace(tmp_path, managed_path)
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
 
 
 def _validate_expected(*, byte_size: int, sha256: str) -> None:

--- a/src/brigade/component_install.py
+++ b/src/brigade/component_install.py
@@ -15,6 +15,7 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 import brigade
 from brigade import component_manifest, component_paths, component_state, localio
@@ -259,6 +260,44 @@ def _validate_expected(*, byte_size: int, sha256: str) -> None:
         raise ComponentInstallError(f"sha256 must be 64 lowercase hex characters, got {sha256!r}")
 
 
+def _require_https_final_url(response: Any) -> None:
+    geturl = getattr(response, "geturl", None)
+    if geturl is None:
+        return
+    final_url = geturl()
+    if urlparse(final_url).scheme.lower() != "https":
+        raise ComponentInstallError(f"download redirect downgraded to non-https URL: {final_url}")
+
+
+def _write_bounded_download(handle: Any, response: Any, *, byte_size: int) -> None:
+    nbytes = 0
+    while True:
+        remaining = byte_size - nbytes
+        if remaining <= 0:
+            if response.read(1):
+                raise ComponentInstallError(f"download exceeded byte_size {byte_size}")
+            break
+        chunk = response.read(min(_READ_CHUNK, remaining + 1))
+        if not chunk:
+            break
+        if len(chunk) > remaining:
+            handle.write(chunk[:remaining])
+            raise ComponentInstallError(f"download exceeded byte_size {byte_size}")
+        handle.write(chunk)
+        nbytes += len(chunk)
+
+
+def _managed_executable_is_ready(path: Path, *, byte_size: int, sha256: str) -> bool:
+    try:
+        verify_cached_asset(path, byte_size=byte_size, sha256=sha256)
+    except ComponentInstallError:
+        return False
+    if sys.platform == "win32":
+        return True
+    mode = path.stat().st_mode
+    return bool(mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))
+
+
 def verify_cached_asset(path: Path, *, byte_size: int, sha256: str) -> None:
     """Verify cached asset byte size and SHA-256 digest."""
     _validate_expected(byte_size=byte_size, sha256=sha256)
@@ -300,11 +339,10 @@ def fetch_asset_to_cache(
     try:
         with os.fdopen(fd, "wb") as handle:
             with open_url(asset.download_url) as response:
-                while True:
-                    chunk = response.read(_READ_CHUNK)
-                    if not chunk:
-                        break
-                    handle.write(chunk)
+                _require_https_final_url(response)
+                _write_bounded_download(handle, response, byte_size=asset.byte_size)
+            handle.flush()
+            os.fsync(handle.fileno())
         verify_cached_asset(tmp_path, byte_size=asset.byte_size, sha256=asset.sha256)
         os.replace(tmp_path, cache_path)
     except BaseException:
@@ -626,13 +664,11 @@ def setup_native_components(
         try:
             for entry in assets:
                 managed_path = managed_paths[entry.component_id]
-                try:
-                    verify_cached_asset(
-                        managed_path,
-                        byte_size=entry.byte_size,
-                        sha256=entry.sha256,
-                    )
-                except ComponentInstallError:
+                if not _managed_executable_is_ready(
+                    managed_path,
+                    byte_size=entry.byte_size,
+                    sha256=entry.sha256,
+                ):
                     verify_cached_asset(
                         Path(entry.cache_path),
                         byte_size=entry.byte_size,

--- a/src/brigade/component_install.py
+++ b/src/brigade/component_install.py
@@ -469,6 +469,113 @@ def run_post_install_smoke(
     _smoke_sessionfind(paths["sessionfind"], run)
 
 
+def _load_rollback_state(
+    path: Path,
+    *,
+    label: str,
+    platform: str,
+) -> component_state.InstalledState:
+    if not path.is_file():
+        raise ComponentInstallError(f"{label} installed state missing: {path}")
+    state = component_state.load_installed_state(path)
+    if state is None:
+        raise ComponentInstallError(f"invalid {label} installed state: {path}")
+    expected_components = set(component_manifest.KNOWN_COMPONENT_IDS)
+    if set(state.components) != expected_components:
+        raise ComponentInstallError(
+            f"{label} installed state requires exactly {len(expected_components)} components: {path}"
+        )
+    if state.platform != platform:
+        raise ComponentInstallError(
+            f"{label} installed state platform {state.platform!r} does not match host {platform!r}"
+        )
+    return state
+
+
+def _rollback_cache_paths(
+    state: component_state.InstalledState,
+    *,
+    cache_root: str,
+) -> dict[str, Path]:
+    cache_paths: dict[str, Path] = {}
+    for component_id in component_manifest.KNOWN_COMPONENT_IDS:
+        record = state.components[component_id]
+        try:
+            cache_path = component_paths.cached_asset_path(
+                cache_root,
+                record.sha256,
+                record.asset_name,
+            )
+        except ValueError as exc:
+            raise ComponentInstallError(f"invalid previous installed cache path for {component_id}: {exc}") from exc
+        cache_paths[component_id] = Path(cache_path)
+    return cache_paths
+
+
+def _setup_rollback(
+    *,
+    env: Mapping[str, str] | None,
+    runner: Callable[..., subprocess.CompletedProcess[str]] | None,
+) -> int:
+    roots = resolve_roots(env=env)
+    platform = component_manifest.platform_key()
+    current_state_path = Path(component_paths.installed_state_path(roots.data_root))
+    previous_state_path = Path(component_paths.installed_previous_state_path(roots.data_root))
+    current_state = _load_rollback_state(
+        current_state_path,
+        label="current",
+        platform=platform,
+    )
+    previous_state = _load_rollback_state(
+        previous_state_path,
+        label="previous",
+        platform=platform,
+    )
+    cache_paths = _rollback_cache_paths(previous_state, cache_root=roots.cache_root)
+
+    for component_id in component_manifest.KNOWN_COMPONENT_IDS:
+        record = previous_state.components[component_id]
+        verify_cached_asset(
+            cache_paths[component_id],
+            byte_size=record.byte_size,
+            sha256=record.sha256,
+        )
+
+    managed_paths = {
+        component_id: Path(component_paths.managed_executable_path(roots.data_root, component_id))
+        for component_id in component_manifest.KNOWN_COMPONENT_IDS
+    }
+    managed_snapshots = _snapshot_managed_executables(list(managed_paths.values()))
+    state_snapshots = _snapshot_managed_executables([current_state_path, previous_state_path])
+    try:
+        for component_id in component_manifest.KNOWN_COMPONENT_IDS:
+            materialize_executable(
+                cache_path=cache_paths[component_id],
+                managed_path=managed_paths[component_id],
+            )
+        for component_id in component_manifest.KNOWN_COMPONENT_IDS:
+            record = previous_state.components[component_id]
+            verify_cached_asset(
+                managed_paths[component_id],
+                byte_size=record.byte_size,
+                sha256=record.sha256,
+            )
+        run_post_install_smoke(
+            {component_id: str(path) for component_id, path in managed_paths.items()},
+            runner=runner,
+        )
+        component_state.write_installed_state(current_state_path, previous_state)
+        component_state.write_installed_state(previous_state_path, current_state)
+    except (ComponentInstallError, OSError, ValueError) as exc:
+        try:
+            _restore_managed_executables(managed_snapshots)
+            _restore_managed_executables(state_snapshots)
+        except (ComponentInstallError, OSError) as restore_exc:
+            raise ComponentInstallError(f"{exc}; failed to restore rollback transaction: {restore_exc}") from exc
+        raise
+    return 0
+
+
 def setup_native_components(
     *,
     dry_run: bool = False,
@@ -480,6 +587,10 @@ def setup_native_components(
 ) -> int:
     """Install pinned native components; return process exit code."""
     try:
+        if dry_run and rollback:
+            raise ComponentInstallError("--dry-run and --rollback cannot be used together")
+        if rollback:
+            return _setup_rollback(env=env, runner=runner)
         manifest = component_manifest.load()
         if manifest.brigade_version != brigade.__version__:
             raise ComponentInstallError(
@@ -489,8 +600,6 @@ def setup_native_components(
             )
         if dry_run:
             return _setup_dry_run(manifest, env=env)
-        if rollback:
-            raise ComponentInstallError("rollback is not implemented")
 
         roots = resolve_roots(env=env)
         platform = component_manifest.platform_key()

--- a/src/brigade/component_install.py
+++ b/src/brigade/component_install.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Any
 
 import brigade
-from brigade import component_manifest, localio
+from brigade import component_manifest, component_paths, localio
 
 _SHA256 = re.compile(r"^[0-9a-f]{64}$")
 _READ_CHUNK = 1024 * 1024
@@ -38,6 +38,125 @@ _JSONRPC_INIT_REQUEST = json.dumps(
 
 class ComponentInstallError(RuntimeError):
     """Raised when a component install step fails verification."""
+
+
+_SETUP_ACTIONS: tuple[str, ...] = ("verify-cache", "download", "materialize", "smoke")
+
+
+@dataclass(frozen=True)
+class SetupPlanAction:
+    component_id: str
+    action: str
+    cache_path: str
+    managed_path: str
+    asset_name: str
+    byte_size: int
+    sha256: str
+    download_url: str
+    component_revision: str
+
+
+@dataclass(frozen=True)
+class SetupRoots:
+    data_root: str
+    cache_root: str
+    env: Mapping[str, str]
+
+
+def resolve_roots(
+    *,
+    env: Mapping[str, str] | None = None,
+    system: str | None = None,
+) -> SetupRoots:
+    """Resolve user-local data and cache roots for component setup."""
+    environment = dict(env if env is not None else os.environ)
+    data_root_path = component_paths.data_root(env=environment, system=system)
+    cache_root_path = component_paths.cache_root(env=environment, system=system)
+    return SetupRoots(
+        data_root=data_root_path,
+        cache_root=cache_root_path,
+        env=environment,
+    )
+
+
+def build_setup_plan(
+    manifest: component_manifest.ComponentManifest,
+    *,
+    platform: str,
+    roots: SetupRoots,
+) -> list[SetupPlanAction]:
+    """Build a deterministic dry-run/install plan for every known component."""
+    plan: list[SetupPlanAction] = []
+    for component_id in component_manifest.KNOWN_COMPONENT_IDS:
+        asset = component_manifest.resolve_asset(manifest, component_id, platform)
+        component = manifest.components[component_id]
+        cache_path = component_paths.cached_asset_path(
+            roots.cache_root,
+            asset.sha256,
+            asset.asset_name,
+        )
+        managed_path = component_paths.managed_executable_path(
+            roots.data_root,
+            component.executable,
+        )
+        for action in _SETUP_ACTIONS:
+            plan.append(
+                SetupPlanAction(
+                    component_id=component_id,
+                    action=action,
+                    cache_path=cache_path,
+                    managed_path=managed_path,
+                    asset_name=asset.asset_name,
+                    byte_size=asset.byte_size,
+                    sha256=asset.sha256,
+                    download_url=asset.download_url,
+                    component_revision=component.component_revision,
+                )
+            )
+    return plan
+
+
+def _print_setup_dry_run(
+    manifest: component_manifest.ComponentManifest,
+    *,
+    platform: str,
+    plan: Sequence[SetupPlanAction],
+) -> None:
+    print("component setup dry-run")
+    print(f"brigade_version: {brigade.__version__}")
+    print(f"manifest_revision: {manifest.manifest_revision}")
+    print(f"platform: {platform}")
+    current_component: str | None = None
+    for entry in plan:
+        if entry.component_id != current_component:
+            current_component = entry.component_id
+            print()
+            print(f"component: {entry.component_id}")
+            print(f"component_revision: {entry.component_revision}")
+            print(f"asset_name: {entry.asset_name}")
+            print(f"byte_size: {entry.byte_size}")
+            print(f"sha256: {entry.sha256}")
+            print(f"download_url: {entry.download_url}")
+            print(f"cache_path: {entry.cache_path}")
+            print(f"managed_path: {entry.managed_path}")
+            print("actions:")
+        print(f"  - {entry.action}")
+
+
+def _setup_dry_run(
+    manifest: component_manifest.ComponentManifest,
+    *,
+    env: Mapping[str, str] | None,
+) -> int:
+    try:
+        roots = resolve_roots(env=env)
+        platform = component_manifest.platform_key()
+        plan = build_setup_plan(manifest, platform=platform, roots=roots)
+    except ValueError as exc:
+        print(f"component setup: {exc}", file=sys.stderr)
+        return 1
+    _print_setup_dry_run(manifest, platform=platform, plan=plan)
+    return 0
 
 
 @dataclass(frozen=True)
@@ -370,8 +489,12 @@ def setup_native_components(
     runner: object | None = None,
 ) -> int:
     """Install pinned native components; return process exit code."""
-    del dry_run, offline, rollback, env, opener, runner
-    manifest = component_manifest.load()
+    del opener, runner
+    try:
+        manifest = component_manifest.load()
+    except ValueError as exc:
+        print(f"component setup: {exc}", file=sys.stderr)
+        return 1
     if manifest.brigade_version != brigade.__version__:
         print(
             "component setup: brigade_version mismatch: "
@@ -380,4 +503,7 @@ def setup_native_components(
             file=sys.stderr,
         )
         return 1
+    if dry_run:
+        return _setup_dry_run(manifest, env=env)
+    del offline, rollback, env
     return 0

--- a/src/brigade/component_install.py
+++ b/src/brigade/component_install.py
@@ -2,20 +2,36 @@
 
 from __future__ import annotations
 
+import os
+import re
 import sys
-from collections.abc import Mapping
+import tempfile
+import urllib.request
+from collections.abc import Callable, Mapping
 from pathlib import Path
+from typing import Any
 
 import brigade
 from brigade import component_manifest, localio
+
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_READ_CHUNK = 1024 * 1024
 
 
 class ComponentInstallError(RuntimeError):
     """Raised when a component install step fails verification."""
 
 
+def _validate_expected(*, byte_size: int, sha256: str) -> None:
+    if not isinstance(byte_size, int) or isinstance(byte_size, bool) or byte_size <= 0:
+        raise ComponentInstallError(f"byte_size must be a positive integer, got {byte_size!r}")
+    if not _SHA256.fullmatch(sha256):
+        raise ComponentInstallError(f"sha256 must be 64 lowercase hex characters, got {sha256!r}")
+
+
 def verify_cached_asset(path: Path, *, byte_size: int, sha256: str) -> None:
     """Verify cached asset byte size and SHA-256 digest."""
+    _validate_expected(byte_size=byte_size, sha256=sha256)
     if not path.is_file():
         raise ComponentInstallError(f"cached asset missing: {path}")
     actual_size = path.stat().st_size
@@ -28,6 +44,47 @@ def verify_cached_asset(path: Path, *, byte_size: int, sha256: str) -> None:
         raise ComponentInstallError(
             f"sha256 mismatch for {path}: expected {sha256}, got {actual_sha256}"
         )
+
+
+def fetch_asset_to_cache(
+    asset: component_manifest.ComponentAsset,
+    *,
+    cache_path: Path,
+    offline: bool,
+    opener: Callable[..., Any] | None = None,
+) -> Path:
+    """Download or reuse a verified cache entry for asset."""
+    _validate_expected(byte_size=asset.byte_size, sha256=asset.sha256)
+    try:
+        verify_cached_asset(cache_path, byte_size=asset.byte_size, sha256=asset.sha256)
+    except ComponentInstallError:
+        if offline:
+            raise ComponentInstallError(
+                f"offline: verified cache required at {cache_path}"
+            ) from None
+    else:
+        return cache_path
+
+    url_opener = opener if opener is not None else urllib.request.urlopen
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        dir=cache_path.parent, prefix=f".{cache_path.name}.", suffix=".tmp"
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            with url_opener(asset.download_url) as response:
+                while True:
+                    chunk = response.read(_READ_CHUNK)
+                    if not chunk:
+                        break
+                    handle.write(chunk)
+        verify_cached_asset(tmp_path, byte_size=asset.byte_size, sha256=asset.sha256)
+        os.replace(tmp_path, cache_path)
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
+    return cache_path
 
 
 def setup_native_components(

--- a/src/brigade/component_install.py
+++ b/src/brigade/component_install.py
@@ -1,0 +1,53 @@
+"""Download, verify, cache, and install pinned native Brigade components."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+import brigade
+from brigade import component_manifest, localio
+
+
+class ComponentInstallError(RuntimeError):
+    """Raised when a component install step fails verification."""
+
+
+def verify_cached_asset(path: Path, *, byte_size: int, sha256: str) -> None:
+    """Verify cached asset byte size and SHA-256 digest."""
+    if not path.is_file():
+        raise ComponentInstallError(f"cached asset missing: {path}")
+    actual_size = path.stat().st_size
+    if actual_size != byte_size:
+        raise ComponentInstallError(
+            f"byte_size mismatch for {path}: expected {byte_size}, got {actual_size}"
+        )
+    actual_sha256 = localio.file_sha256(path)
+    if actual_sha256 != sha256:
+        raise ComponentInstallError(
+            f"sha256 mismatch for {path}: expected {sha256}, got {actual_sha256}"
+        )
+
+
+def setup_native_components(
+    *,
+    dry_run: bool = False,
+    offline: bool = False,
+    rollback: bool = False,
+    env: Mapping[str, str] | None = None,
+    opener: object | None = None,
+    runner: object | None = None,
+) -> int:
+    """Install pinned native components; return process exit code."""
+    del dry_run, offline, rollback, env, opener, runner
+    manifest = component_manifest.load()
+    if manifest.brigade_version != brigade.__version__:
+        print(
+            "component setup: brigade_version mismatch: "
+            f"manifest requires {manifest.brigade_version!r}, "
+            f"running Brigade {brigade.__version__!r}",
+            file=sys.stderr,
+        )
+        return 1
+    return 0

--- a/src/brigade/component_manifest.py
+++ b/src/brigade/component_manifest.py
@@ -26,7 +26,7 @@ KNOWN_COMPONENT_IDS: tuple[str, ...] = (
     "miseledger",
     "sessionfind",
 )
-UNPUBLISHED_COMPONENT_IDS: frozenset[str] = frozenset({"graphtrail", "graphtrail-mcp"})
+UNPUBLISHED_COMPONENT_IDS: frozenset[str] = frozenset()
 _SHA256 = re.compile(r"^[0-9a-f]{64}$")
 _GIT_SHA = re.compile(r"^[0-9a-f]{40}$")
 _PLATFORM = re.compile(r"^(linux|darwin|windows)-(amd64|arm64)$")

--- a/src/brigade/component_paths.py
+++ b/src/brigade/component_paths.py
@@ -69,6 +69,10 @@ def installed_state_path(data_root_path: str) -> str:
     return _join(data_root_path, "brigade", "installed.json", windows=_is_windows_path(data_root_path))
 
 
+def installed_previous_state_path(data_root_path: str) -> str:
+    return _join(data_root_path, "brigade", "installed.previous.json", windows=_is_windows_path(data_root_path))
+
+
 def cached_asset_path(cache_root_path: str, sha256: str, asset_name: str) -> str:
     if not _SHA256.fullmatch(sha256):
         raise ValueError("sha256 must be 64 lowercase hex characters")

--- a/src/brigade/component_state.py
+++ b/src/brigade/component_state.py
@@ -1,0 +1,190 @@
+"""Installed native component state schema v1."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from brigade import localio
+from brigade.component_manifest import KNOWN_COMPONENT_IDS, SUPPORTED_PLATFORMS
+
+SCHEMA_VERSION = 1
+_TOP_LEVEL_KEYS = frozenset(
+    {
+        "schema_version",
+        "brigade_version",
+        "manifest_revision",
+        "platform",
+        "installed_at",
+        "components",
+    }
+)
+_RECORD_KEYS = frozenset(
+    {
+        "component_revision",
+        "asset_name",
+        "byte_size",
+        "sha256",
+        "download_url",
+        "executable",
+    }
+)
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+
+@dataclass(frozen=True)
+class InstalledComponentRecord:
+    component_revision: str
+    asset_name: str
+    byte_size: int
+    sha256: str
+    download_url: str
+    executable: str
+
+
+@dataclass(frozen=True)
+class InstalledState:
+    schema_version: int
+    brigade_version: str
+    manifest_revision: str
+    platform: str
+    installed_at: str
+    components: dict[str, InstalledComponentRecord]
+
+
+def _non_empty_str(value: Any) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return value.strip()
+
+
+def _load_record(value: Any) -> InstalledComponentRecord | None:
+    if not isinstance(value, dict) or set(value.keys()) != _RECORD_KEYS:
+        return None
+    byte_size = value["byte_size"]
+    if not isinstance(byte_size, int) or isinstance(byte_size, bool) or byte_size <= 0:
+        return None
+    component_revision = _non_empty_str(value["component_revision"])
+    asset_name = _non_empty_str(value["asset_name"])
+    download_url = _non_empty_str(value["download_url"])
+    executable = _non_empty_str(value["executable"])
+    sha256 = value["sha256"]
+    if (
+        component_revision is None
+        or asset_name is None
+        or download_url is None
+        or executable is None
+        or not isinstance(sha256, str)
+        or not _SHA256.fullmatch(sha256)
+    ):
+        return None
+    return InstalledComponentRecord(
+        component_revision=component_revision,
+        asset_name=asset_name,
+        byte_size=byte_size,
+        sha256=sha256,
+        download_url=download_url,
+        executable=executable,
+    )
+
+
+def _load_components(value: Any) -> dict[str, InstalledComponentRecord] | None:
+    if not isinstance(value, dict):
+        return None
+    result: dict[str, InstalledComponentRecord] = {}
+    for key, item in value.items():
+        if not isinstance(key, str) or not key.strip() or key not in KNOWN_COMPONENT_IDS:
+            return None
+        record = _load_record(item)
+        if record is None:
+            return None
+        result[key] = record
+    return result
+
+
+def load_installed_state(path: Path) -> InstalledState | None:
+    """Load and validate installed state from path; return None when invalid or missing."""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    if not isinstance(payload, dict) or set(payload.keys()) != _TOP_LEVEL_KEYS:
+        return None
+    schema_version = payload["schema_version"]
+    if not isinstance(schema_version, int) or isinstance(schema_version, bool):
+        return None
+    if schema_version != SCHEMA_VERSION:
+        return None
+    brigade_version = _non_empty_str(payload["brigade_version"])
+    manifest_revision = _non_empty_str(payload["manifest_revision"])
+    platform = _non_empty_str(payload["platform"])
+    installed_at = _non_empty_str(payload["installed_at"])
+    if (
+        brigade_version is None
+        or manifest_revision is None
+        or platform is None
+        or installed_at is None
+        or platform not in SUPPORTED_PLATFORMS
+        or localio.parse_iso_datetime(installed_at) is None
+    ):
+        return None
+    components = _load_components(payload["components"])
+    if components is None:
+        return None
+    return InstalledState(
+        schema_version=SCHEMA_VERSION,
+        brigade_version=brigade_version,
+        manifest_revision=manifest_revision,
+        platform=platform,
+        installed_at=installed_at,
+        components=components,
+    )
+
+
+def render_installed_state(state: InstalledState) -> dict[str, Any]:
+    """Render state to a JSON-serializable dict with sorted component keys."""
+    return {
+        "schema_version": state.schema_version,
+        "brigade_version": state.brigade_version,
+        "manifest_revision": state.manifest_revision,
+        "platform": state.platform,
+        "installed_at": state.installed_at,
+        "components": {
+            key: {
+                "component_revision": record.component_revision,
+                "asset_name": record.asset_name,
+                "byte_size": record.byte_size,
+                "sha256": record.sha256,
+                "download_url": record.download_url,
+                "executable": record.executable,
+            }
+            for key, record in sorted(state.components.items())
+        },
+    }
+
+
+def state_digest_map(state: InstalledState) -> dict[str, str]:
+    """Return a mapping of component id to sha256 digest for change detection."""
+    return {key: record.sha256 for key, record in sorted(state.components.items())}
+
+
+def should_rotate_previous(current: InstalledState | None, next_state: InstalledState) -> bool:
+    """Return True when the previous state should rotate to the current one.
+
+    Rotation happens on first install, manifest revision change, or any
+    component digest change. Idempotent repeat installs with identical
+    manifest revisions and digest maps leave the previous state untouched.
+    """
+    if current is None:
+        return False
+    if current.manifest_revision != next_state.manifest_revision:
+        return True
+    return state_digest_map(current) != state_digest_map(next_state)
+
+
+def write_installed_state(path: Path, state: InstalledState) -> None:
+    """Write installed state atomically as sorted JSON."""
+    localio.write_json(path, render_installed_state(state))

--- a/src/brigade/component_state.py
+++ b/src/brigade/component_state.py
@@ -174,9 +174,9 @@ def state_digest_map(state: InstalledState) -> dict[str, str]:
 def should_rotate_previous(current: InstalledState | None, next_state: InstalledState) -> bool:
     """Return True when the previous state should rotate to the current one.
 
-    Rotation happens on first install, manifest revision change, or any
-    component digest change. Idempotent repeat installs with identical
-    manifest revisions and digest maps leave the previous state untouched.
+    Rotation happens on manifest revision change or any component digest
+    change. Idempotent repeat installs with identical manifest revisions
+    and digest maps leave the previous state untouched.
     """
     if current is None:
         return False

--- a/src/brigade/templates/components/manifest-v1.json
+++ b/src/brigade/templates/components/manifest-v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "brigade_version": "0.23.0",
-  "manifest_revision": "2026-07-18",
+  "manifest_revision": "2026-07-19",
   "supported_platforms": [
     "linux-amd64",
     "linux-arm64",
@@ -12,15 +12,77 @@
   "components": {
     "graphtrail": {
       "component_revision": "64fcd2f9ec37f33e286708845a92e6cfa4abf3bb",
-      "source": {"repository": "escoffier-labs/graphtrail"},
+      "source": {"repository": "escoffier-labs/graphtrail", "release_tag": "v0.4.0"},
       "executable": "graphtrail",
-      "assets": {}
+      "assets": {
+        "darwin-amd64": {
+          "asset_name": "graphtrail-darwin-amd64",
+          "byte_size": 11695172,
+          "sha256": "eb6768be11d26a9d82c1bcecd503a9fdc7c883bda3bd627dea9ccb04fd31379c",
+          "download_url": "https://github.com/escoffier-labs/graphtrail/releases/download/v0.4.0/graphtrail-darwin-amd64"
+        },
+        "darwin-arm64": {
+          "asset_name": "graphtrail-darwin-arm64",
+          "byte_size": 11426112,
+          "sha256": "20534dbbb84f134a5a892520fd5a695d2520c2e040733b5535e991c611c99686",
+          "download_url": "https://github.com/escoffier-labs/graphtrail/releases/download/v0.4.0/graphtrail-darwin-arm64"
+        },
+        "linux-amd64": {
+          "asset_name": "graphtrail-linux-amd64",
+          "byte_size": 12802256,
+          "sha256": "e78c73a80a2eadbe297066739044e2c5fcdd187c8219198f453bd004bf9c9a55",
+          "download_url": "https://github.com/escoffier-labs/graphtrail/releases/download/v0.4.0/graphtrail-linux-amd64"
+        },
+        "linux-arm64": {
+          "asset_name": "graphtrail-linux-arm64",
+          "byte_size": 12424560,
+          "sha256": "7f961a4f018e4b12b9dcf5227a7cdc20fa7cdd9a723d96ec0336e254adf33c07",
+          "download_url": "https://github.com/escoffier-labs/graphtrail/releases/download/v0.4.0/graphtrail-linux-arm64"
+        },
+        "windows-amd64": {
+          "asset_name": "graphtrail-windows-amd64.exe",
+          "byte_size": 10753536,
+          "sha256": "1a9adc002c81661d2b0838e642f1c9db2671a2808c93e6b4499cfc2b33d6ea22",
+          "download_url": "https://github.com/escoffier-labs/graphtrail/releases/download/v0.4.0/graphtrail-windows-amd64.exe"
+        }
+      }
     },
     "graphtrail-mcp": {
       "component_revision": "64fcd2f9ec37f33e286708845a92e6cfa4abf3bb",
-      "source": {"repository": "escoffier-labs/graphtrail"},
+      "source": {"repository": "escoffier-labs/graphtrail", "release_tag": "v0.4.0"},
       "executable": "graphtrail-mcp",
-      "assets": {}
+      "assets": {
+        "darwin-amd64": {
+          "asset_name": "graphtrail-mcp-darwin-amd64",
+          "byte_size": 11004028,
+          "sha256": "d8d605a522d3894c36a2f30e94cdcc99b87c34d05e53b01f4c47018eaebaf93f",
+          "download_url": "https://github.com/escoffier-labs/graphtrail/releases/download/v0.4.0/graphtrail-mcp-darwin-amd64"
+        },
+        "darwin-arm64": {
+          "asset_name": "graphtrail-mcp-darwin-arm64",
+          "byte_size": 10766928,
+          "sha256": "649abe87a3e40415d1933db493c94f1049d84577a996df7ba9c27c4b3c4cf597",
+          "download_url": "https://github.com/escoffier-labs/graphtrail/releases/download/v0.4.0/graphtrail-mcp-darwin-arm64"
+        },
+        "linux-amd64": {
+          "asset_name": "graphtrail-mcp-linux-amd64",
+          "byte_size": 11981944,
+          "sha256": "66606e4e394973766e1e91d3b0b78b26bd9077076cc85e62b9d0faf9780e7154",
+          "download_url": "https://github.com/escoffier-labs/graphtrail/releases/download/v0.4.0/graphtrail-mcp-linux-amd64"
+        },
+        "linux-arm64": {
+          "asset_name": "graphtrail-mcp-linux-arm64",
+          "byte_size": 11609512,
+          "sha256": "0bf17d38d44c5fc4f3132e17078a2db74e92da9bcb27a40c3d8345056523a651",
+          "download_url": "https://github.com/escoffier-labs/graphtrail/releases/download/v0.4.0/graphtrail-mcp-linux-arm64"
+        },
+        "windows-amd64": {
+          "asset_name": "graphtrail-mcp-windows-amd64.exe",
+          "byte_size": 10020864,
+          "sha256": "ec642c7e736fff1673c3d7e06d10eb02c9782008d8f783ab2b40699e69a35b08",
+          "download_url": "https://github.com/escoffier-labs/graphtrail/releases/download/v0.4.0/graphtrail-mcp-windows-amd64.exe"
+        }
+      }
     },
     "miseledger": {
       "component_revision": "v0.6.0",

--- a/tests/component_install_helpers.py
+++ b/tests/component_install_helpers.py
@@ -138,10 +138,61 @@ def all_fixture_payloads(*, platform: str = "linux-amd64") -> dict[str, bytes]:
     return payloads
 
 
+class _RedirectFakeResponse:
+    def __init__(self, payload: bytes, *, final_url: str):
+        from io import BytesIO
+
+        self._stream = BytesIO(payload)
+        self._final_url = final_url
+        self.read_sizes: list[int] = []
+
+    def read(self, size: int = -1) -> bytes:
+        if size < 0:
+            return self._stream.read()
+        self.read_sizes.append(size)
+        return self._stream.read(size)
+
+    def geturl(self) -> str:
+        return self._final_url
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+
+class _TrackingFakeResponse:
+    def __init__(self, payload: bytes):
+        from io import BytesIO
+
+        self._stream = BytesIO(payload)
+        self.read_sizes: list[int] = []
+
+    def read(self, size: int = -1) -> bytes:
+        if size < 0:
+            return self._stream.read()
+        self.read_sizes.append(size)
+        return self._stream.read(size)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+
 class FakeOpener:
-    def __init__(self, payloads: dict[str, bytes]):
+    def __init__(
+        self,
+        payloads: dict[str, bytes],
+        *,
+        final_urls: dict[str, str] | None = None,
+    ):
         self.payloads = payloads
+        self.final_urls = final_urls or {}
         self.calls: list[str] = []
+        self.responses: list[_TrackingFakeResponse | _RedirectFakeResponse] = []
 
     def __call__(self, url: str, *args, **kwargs):
         self.calls.append(url)
@@ -150,4 +201,13 @@ class FakeOpener:
 
         if url not in self.payloads:
             raise HTTPError(url, 404, "not found", hdrs=None, fp=BytesIO(b""))
-        return BytesIO(self.payloads[url])
+        payload = self.payloads[url]
+        final_url = self.final_urls.get(url)
+        if final_url is not None:
+            response: _TrackingFakeResponse | _RedirectFakeResponse = _RedirectFakeResponse(
+                payload, final_url=final_url
+            )
+        else:
+            response = _TrackingFakeResponse(payload)
+        self.responses.append(response)
+        return response

--- a/tests/component_install_helpers.py
+++ b/tests/component_install_helpers.py
@@ -10,6 +10,7 @@ import brigade
 from brigade import component_manifest
 
 GRAPHTRAIL_SHA = "64fcd2f9ec37f33e286708845a92e6cfa4abf3bb"
+GRAPHTRAIL_BASE = "https://github.com/escoffier-labs/graphtrail/releases/download/v0.4.0/"
 FIXTURE_REPOSITORY = "example/components"
 
 
@@ -76,6 +77,12 @@ def test_component_revision(component_id: str) -> str:
     return "fixture-revision"
 
 
+def write_verified_cache(cache_path: Path, *, payload: bytes) -> None:
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_bytes(payload)
+    cache_path.chmod(0o755)
+
+
 def test_manifest_asset(
     component_id: str, *, platform: str = "linux-amd64"
 ) -> component_manifest.ComponentAsset:
@@ -123,3 +130,27 @@ def write_test_manifest(path: Path, *, brigade_version: str) -> component_manife
         )
     )
     return component_manifest.load(path)
+
+
+def all_fixture_payloads(*, platform: str = "linux-amd64") -> dict[str, bytes]:
+    payloads: dict[str, bytes] = {}
+    for component_id in component_manifest.KNOWN_COMPONENT_IDS:
+        payload, _, _ = fixture_payload(component_id, platform=platform)
+        asset = test_manifest_asset(component_id, platform=platform)
+        payloads[asset.download_url] = payload
+    return payloads
+
+
+class FakeOpener:
+    def __init__(self, payloads: dict[str, bytes]):
+        self.payloads = payloads
+        self.calls: list[str] = []
+
+    def __call__(self, url: str, *args, **kwargs):
+        self.calls.append(url)
+        from io import BytesIO
+        from urllib.error import HTTPError
+
+        if url not in self.payloads:
+            raise HTTPError(url, 404, "not found", hdrs=None, fp=BytesIO(b""))
+        return BytesIO(self.payloads[url])

--- a/tests/component_install_helpers.py
+++ b/tests/component_install_helpers.py
@@ -1,0 +1,125 @@
+"""Shared helpers for component install engine tests."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import brigade
+from brigade import component_manifest
+
+GRAPHTRAIL_SHA = "64fcd2f9ec37f33e286708845a92e6cfa4abf3bb"
+FIXTURE_REPOSITORY = "example/components"
+
+
+def linux_env(root: Path) -> dict[str, str]:
+    home = root / "home"
+    home.mkdir(parents=True, exist_ok=True)
+    return {
+        "HOME": str(home),
+        "XDG_DATA_HOME": str(root / "xdg-data"),
+        "XDG_CACHE_HOME": str(root / "xdg-cache"),
+    }
+
+
+def smoke_stub_script(name: str) -> str:
+    if name == "graphtrail":
+        return (
+            '#!/usr/bin/env python3\nimport sys\nif sys.argv[1:] == ["--version"]:\n'
+            '    print("graphtrail test 0.4.0")\n    raise SystemExit(0)\nraise SystemExit(1)\n'
+        )
+    if name == "graphtrail-mcp":
+        return (
+            '#!/usr/bin/env python3\nimport json, sys\n'
+            'req = json.load(sys.stdin)\n'
+            'assert req.get("method") == "initialize"\n'
+            'print(json.dumps({"jsonrpc": "2.0", "id": req.get("id"), "result": '
+            '{"protocolVersion": "2024-11-05", "capabilities": {}, '
+            '"serverInfo": {"name": "graphtrail-mcp", "version": "0.4.0"}}}))\n'
+        )
+    if name == "miseledger":
+        return (
+            '#!/usr/bin/env python3\nimport sys\nif sys.argv[1:] == ["version"]:\n'
+            '    print("miseledger test 0.6.0")\n    raise SystemExit(0)\nraise SystemExit(1)\n'
+        )
+    if name == "sessionfind":
+        return (
+            '#!/usr/bin/env python3\nimport sys\nif sys.argv[1:] == ["--help"]:\n'
+            '    print("usage: sessionfind [options]")\n    raise SystemExit(2)\nraise SystemExit(1)\n'
+        )
+    raise ValueError(name)
+
+
+def fixture_payload(component_id: str, *, platform: str = "linux-amd64") -> tuple[bytes, int, str]:
+    """Return (payload_bytes, byte_size, sha256) for runnable smoke-stub fixture bytes."""
+    lines = smoke_stub_script(component_id).splitlines(keepends=True)
+    if lines and lines[0].startswith("#!"):
+        lines.insert(1, f"# platform: {platform}\n")
+    else:
+        lines.insert(0, f"# platform: {platform}\n")
+    body = "".join(lines).encode("utf-8")
+    digest = hashlib.sha256(body).hexdigest()
+    return body, len(body), digest
+
+
+def fixture_asset_name(component_id: str, *, platform: str) -> str:
+    base = f"{component_id}-{platform}"
+    if platform == "windows-amd64":
+        return f"{base}.exe"
+    return base
+
+
+def test_component_revision(component_id: str) -> str:
+    if component_id in ("graphtrail", "graphtrail-mcp"):
+        return GRAPHTRAIL_SHA
+    return "fixture-revision"
+
+
+def test_manifest_asset(
+    component_id: str, *, platform: str = "linux-amd64"
+) -> component_manifest.ComponentAsset:
+    _, byte_size, sha256 = fixture_payload(component_id, platform=platform)
+    asset_name = fixture_asset_name(component_id, platform=platform)
+    return component_manifest.ComponentAsset(
+        asset_name=asset_name,
+        byte_size=byte_size,
+        sha256=sha256,
+        download_url=f"https://example.invalid/components/{asset_name}",
+    )
+
+
+def write_test_manifest(path: Path, *, brigade_version: str) -> component_manifest.ComponentManifest:
+    """Write a manifest whose digests match fixture_payload bytes for offline engine tests."""
+    components: dict[str, object] = {}
+    for component_id in component_manifest.KNOWN_COMPONENT_IDS:
+        assets: dict[str, object] = {}
+        for platform in component_manifest.SUPPORTED_PLATFORMS:
+            _, byte_size, sha256 = fixture_payload(component_id, platform=platform)
+            asset = test_manifest_asset(component_id, platform=platform)
+            assert asset.byte_size == byte_size
+            assert asset.sha256 == sha256
+            assets[platform] = {
+                "asset_name": asset.asset_name,
+                "byte_size": byte_size,
+                "sha256": sha256,
+                "download_url": asset.download_url,
+            }
+        components[component_id] = {
+            "component_revision": test_component_revision(component_id),
+            "source": {"repository": FIXTURE_REPOSITORY, "release_tag": "fixture"},
+            "executable": component_id,
+            "assets": assets,
+        }
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "brigade_version": brigade_version,
+                "manifest_revision": "fixture",
+                "supported_platforms": list(component_manifest.SUPPORTED_PLATFORMS),
+                "components": components,
+            }
+        )
+    )
+    return component_manifest.load(path)

--- a/tests/component_install_helpers.py
+++ b/tests/component_install_helpers.py
@@ -6,7 +6,6 @@ import hashlib
 import json
 from pathlib import Path
 
-import brigade
 from brigade import component_manifest
 
 GRAPHTRAIL_SHA = "64fcd2f9ec37f33e286708845a92e6cfa4abf3bb"
@@ -32,8 +31,8 @@ def smoke_stub_script(name: str) -> str:
         )
     if name == "graphtrail-mcp":
         return (
-            '#!/usr/bin/env python3\nimport json, sys\n'
-            'req = json.load(sys.stdin)\n'
+            "#!/usr/bin/env python3\nimport json, sys\n"
+            "req = json.load(sys.stdin)\n"
             'assert req.get("method") == "initialize"\n'
             'print(json.dumps({"jsonrpc": "2.0", "id": req.get("id"), "result": '
             '{"protocolVersion": "2024-11-05", "capabilities": {}, '
@@ -83,9 +82,7 @@ def write_verified_cache(cache_path: Path, *, payload: bytes) -> None:
     cache_path.chmod(0o755)
 
 
-def test_manifest_asset(
-    component_id: str, *, platform: str = "linux-amd64"
-) -> component_manifest.ComponentAsset:
+def test_manifest_asset(component_id: str, *, platform: str = "linux-amd64") -> component_manifest.ComponentAsset:
     _, byte_size, sha256 = fixture_payload(component_id, platform=platform)
     asset_name = fixture_asset_name(component_id, platform=platform)
     return component_manifest.ComponentAsset(

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -1,0 +1,140 @@
+"""Tests for brigade setup CLI wiring."""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+import brigade
+from brigade import cli, component_manifest
+from tests.component_install_helpers import linux_env, write_test_manifest
+from tests.test_component_install import _seed_rollback_pair
+
+
+def _subparsers_action(parser):
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            return action
+    raise AssertionError("no subparsers action found")
+
+
+def _apply_env(monkeypatch, env: dict[str, str]) -> None:
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+
+def test_setup_parser_flag_defaults():
+    parser = cli._build_parser()
+    ns = parser.parse_args(["setup"])
+    assert ns.dry_run is False
+    assert ns.offline is False
+    assert ns.rollback is False
+
+
+def test_setup_command_help_lists_flags(capsys):
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["setup", "--help"])
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "usage: brigade setup" in out
+    assert "--dry-run" in out
+    assert "Report planned actions without writing." in out
+    assert "--offline" in out
+    assert "Use verified cache only; fail if missing." in out
+    assert "--rollback" in out
+    assert "Restore the previous installed manifest." in out
+
+
+def test_top_level_help_includes_setup():
+    parser = cli._build_parser()
+    help_text = parser.format_help()
+    assert "setup" in help_text
+    assert "Install pinned native Brigade components." in help_text
+
+
+def test_setup_registered_immediately_after_add():
+    parser = cli._build_parser()
+    sub = _subparsers_action(parser)
+    choices = list(sub.choices)
+    assert choices.index("setup") == choices.index("add") + 1
+
+
+def test_setup_appears_once_in_command_groups():
+    grouped = [name for _, names in cli.COMMAND_GROUPS for name in names]
+    assert grouped.count("setup") == 1
+    stations_group = next(names for title, names in cli.COMMAND_GROUPS if title == "Stations and tools")
+    assert stations_group.index("setup") == stations_group.index("add") + 1
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [
+        (["setup"], {"dry_run": False, "offline": False, "rollback": False}),
+        (["setup", "--dry-run"], {"dry_run": True, "offline": False, "rollback": False}),
+        (["setup", "--offline"], {"dry_run": False, "offline": True, "rollback": False}),
+        (["setup", "--rollback"], {"dry_run": False, "offline": False, "rollback": True}),
+    ],
+)
+def test_cli_setup_forwards_flags_to_engine(monkeypatch, argv, expected):
+    captured: dict[str, bool] = {}
+
+    def fake_setup(*, dry_run=False, offline=False, rollback=False, env=None, opener=None, runner=None):
+        captured.update(dry_run=dry_run, offline=offline, rollback=rollback)
+        return 0
+
+    monkeypatch.setattr("brigade.component_install.setup_native_components", fake_setup)
+    assert cli.main(argv) == 0
+    assert captured == expected
+
+
+def test_cli_setup_dry_run_flag(tmp_path, monkeypatch):
+    env = linux_env(tmp_path)
+    manifest_path = tmp_path / "manifest-v1.json"
+    write_test_manifest(manifest_path, brigade_version=brigade.__version__)
+    monkeypatch.setattr(component_manifest, "manifest_path", lambda: manifest_path)
+    monkeypatch.setattr(component_manifest, "platform_key", lambda **_kwargs: "linux-amd64")
+    _apply_env(monkeypatch, env)
+    assert cli.main(["setup", "--dry-run"]) == 0
+
+
+def test_cli_setup_dry_run_writes_nothing(tmp_path, monkeypatch):
+    from pathlib import Path
+
+    env = linux_env(tmp_path)
+    manifest_path = tmp_path / "manifest-v1.json"
+    write_test_manifest(manifest_path, brigade_version=brigade.__version__)
+    monkeypatch.setattr(component_manifest, "manifest_path", lambda: manifest_path)
+    monkeypatch.setattr(component_manifest, "platform_key", lambda **_kwargs: "linux-amd64")
+    _apply_env(monkeypatch, env)
+    assert cli.main(["setup", "--dry-run"]) == 0
+    assert not (Path(env["XDG_DATA_HOME"]) / "brigade" / "installed.json").exists()
+    assert not Path(env["XDG_DATA_HOME"]).exists()
+
+
+def test_cli_setup_offline_flag(tmp_path, monkeypatch):
+    env = linux_env(tmp_path)
+    manifest_path = tmp_path / "manifest-v1.json"
+    write_test_manifest(manifest_path, brigade_version=brigade.__version__)
+    monkeypatch.setattr(component_manifest, "manifest_path", lambda: manifest_path)
+    monkeypatch.setattr(component_manifest, "platform_key", lambda **_kwargs: "linux-amd64")
+    _apply_env(monkeypatch, env)
+    assert cli.main(["setup", "--offline"]) == 1
+
+
+def test_cli_setup_rollback_flag(tmp_path, monkeypatch):
+    env = linux_env(tmp_path)
+    _seed_rollback_pair(env, revision_a="2026-07-18", revision_b="2026-07-19")
+    _apply_env(monkeypatch, env)
+    assert cli.main(["setup", "--rollback"]) == 0
+
+
+def test_cli_setup_propagates_engine_error(tmp_path, monkeypatch, capsys):
+    env = linux_env(tmp_path)
+    manifest_path = tmp_path / "manifest-v1.json"
+    write_test_manifest(manifest_path, brigade_version="9.9.9")
+    monkeypatch.setattr(component_manifest, "manifest_path", lambda: manifest_path)
+    _apply_env(monkeypatch, env)
+    assert cli.main(["setup"]) == 1
+    err = capsys.readouterr().err
+    assert "brigade_version mismatch" in err

--- a/tests/test_component_install.py
+++ b/tests/test_component_install.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import subprocess
 
 import pytest
 
@@ -15,6 +16,7 @@ from brigade.component_install import (
     _snapshot_managed_executables,
     fetch_asset_to_cache,
     materialize_executable,
+    run_post_install_smoke,
     setup_native_components,
     verify_cached_asset,
 )
@@ -23,10 +25,36 @@ from tests.component_install_helpers import (
     FakeOpener,
     fixture_payload,
     linux_env,
+    smoke_stub_script,
     test_manifest_asset as manifest_asset_fixture,
     write_test_manifest,
     write_verified_cache,
 )
+
+_SMOKE_COMPONENTS = ("graphtrail", "graphtrail-mcp", "miseledger", "sessionfind")
+
+
+def _write_managed_stub(tmp_path, component_id: str, *, script: str | None = None) -> str:
+    payload = script.encode("utf-8") if script is not None else fixture_payload(component_id)[0]
+    path = tmp_path / component_id
+    path.write_bytes(payload)
+    path.chmod(0o755)
+    return str(path)
+
+
+def _write_managed_smoke_stubs(tmp_path) -> dict[str, str]:
+    managed: dict[str, str] = {}
+    for component_id in _SMOKE_COMPONENTS:
+        managed[component_id] = _write_managed_stub(tmp_path, component_id)
+    return managed
+
+
+def _recording_runner(calls: list[tuple[list[str], dict[str, object]]]):
+    def runner(argv, **kwargs):
+        calls.append((list(argv), dict(kwargs)))
+        return subprocess.run(argv, **kwargs)
+
+    return runner
 
 
 def test_verify_cached_asset_rejects_invalid_byte_size(tmp_path):
@@ -259,3 +287,108 @@ def test_restore_managed_executables_removes_newly_created_paths(tmp_path):
 
     assert existing.read_bytes() == b"keep-me"
     assert not new_path.exists()
+
+
+def test_run_post_install_smoke_invokes_absolute_paths_only(tmp_path):
+    managed = _write_managed_smoke_stubs(tmp_path)
+    calls: list[tuple[list[str], dict[str, object]]] = []
+
+    run_post_install_smoke(managed, runner=_recording_runner(calls))
+
+    assert {cmd[0] for cmd, _kwargs in calls} == set(managed.values())
+    assert calls[0][0] == [managed["graphtrail"], "--version"]
+    assert calls[1][0] == [managed["graphtrail-mcp"]]
+    assert "input" in calls[1][1]
+    assert calls[2][0] == [managed["miseledger"], "version"]
+    assert calls[3][0] == [managed["sessionfind"], "--help"]
+
+
+def test_run_post_install_smoke_rejects_relative_paths(tmp_path):
+    managed = _write_managed_smoke_stubs(tmp_path)
+    managed["graphtrail"] = "graphtrail"
+    with pytest.raises(ComponentInstallError, match="graphtrail.*absolute managed path"):
+        run_post_install_smoke(managed)
+
+
+def test_run_post_install_smoke_rejects_wrong_component_set(tmp_path):
+    managed = {"graphtrail": _write_managed_stub(tmp_path, "graphtrail")}
+    with pytest.raises(ComponentInstallError, match="exactly 4 managed paths"):
+        run_post_install_smoke(managed)
+
+
+def test_run_post_install_smoke_rejects_missing_executable(tmp_path):
+    managed = _write_managed_smoke_stubs(tmp_path)
+    missing = tmp_path / "graphtrail"
+    missing.unlink()
+    with pytest.raises(ComponentInstallError, match="graphtrail.*managed executable missing"):
+        run_post_install_smoke(managed)
+
+
+def test_run_post_install_smoke_rejects_graphtrail_nonzero_exit(tmp_path):
+    managed = _write_managed_smoke_stubs(tmp_path)
+    script = smoke_stub_script("graphtrail").replace("raise SystemExit(0)", "raise SystemExit(1)")
+    managed["graphtrail"] = _write_managed_stub(tmp_path, "graphtrail", script=script)
+    with pytest.raises(ComponentInstallError, match="graphtrail smoke failed.*exited 1"):
+        run_post_install_smoke(managed)
+
+
+def test_run_post_install_smoke_rejects_graphtrail_empty_stdout(tmp_path):
+    script = (
+        '#!/usr/bin/env python3\nimport sys\nif sys.argv[1:] == ["--version"]:\n'
+        "    raise SystemExit(0)\nraise SystemExit(1)\n"
+    )
+    managed = _write_managed_smoke_stubs(tmp_path)
+    managed["graphtrail"] = _write_managed_stub(tmp_path, "graphtrail", script=script)
+    with pytest.raises(ComponentInstallError, match="graphtrail smoke failed.*empty stdout"):
+        run_post_install_smoke(managed)
+
+
+def test_run_post_install_smoke_rejects_graphtrail_mcp_malformed_json(tmp_path):
+    script = '#!/usr/bin/env python3\nprint("not-json")\n'
+    managed = _write_managed_smoke_stubs(tmp_path)
+    managed["graphtrail-mcp"] = _write_managed_stub(tmp_path, "graphtrail-mcp", script=script)
+    with pytest.raises(ComponentInstallError, match="graphtrail-mcp smoke failed.*malformed JSON-RPC"):
+        run_post_install_smoke(managed)
+
+
+def test_run_post_install_smoke_rejects_miseledger_nonzero_exit(tmp_path):
+    managed = _write_managed_smoke_stubs(tmp_path)
+    script = smoke_stub_script("miseledger").replace("raise SystemExit(0)", "raise SystemExit(1)")
+    managed["miseledger"] = _write_managed_stub(tmp_path, "miseledger", script=script)
+    with pytest.raises(ComponentInstallError, match="miseledger smoke failed.*exited 1"):
+        run_post_install_smoke(managed)
+
+
+def test_run_post_install_smoke_rejects_sessionfind_wrong_exit(tmp_path):
+    managed = _write_managed_smoke_stubs(tmp_path)
+    script = smoke_stub_script("sessionfind").replace("raise SystemExit(2)", "raise SystemExit(0)")
+    managed["sessionfind"] = _write_managed_stub(tmp_path, "sessionfind", script=script)
+    with pytest.raises(ComponentInstallError, match="sessionfind smoke failed.*expected 2"):
+        run_post_install_smoke(managed)
+
+
+def test_run_post_install_smoke_rejects_sessionfind_missing_usage(tmp_path):
+    script = (
+        '#!/usr/bin/env python3\nimport sys\nif sys.argv[1:] == ["--help"]:\n'
+        '    print("options only")\n    raise SystemExit(2)\nraise SystemExit(1)\n'
+    )
+    managed = _write_managed_smoke_stubs(tmp_path)
+    managed["sessionfind"] = _write_managed_stub(tmp_path, "sessionfind", script=script)
+    with pytest.raises(ComponentInstallError, match="sessionfind smoke failed.*no usage text"):
+        run_post_install_smoke(managed)
+
+
+def test_run_post_install_smoke_rejects_timeout(tmp_path):
+    managed = _write_managed_smoke_stubs(tmp_path)
+    sleep_script = '#!/usr/bin/env python3\nimport time\ntime.sleep(5)\n'
+
+    def slow_runner(argv, **kwargs):
+        kwargs["timeout"] = 0.2
+        if argv[0] == managed["graphtrail"]:
+            kwargs.pop("timeout", None)
+            return subprocess.run(argv, **kwargs)
+        return subprocess.run(argv, **kwargs)
+
+    managed["graphtrail-mcp"] = _write_managed_stub(tmp_path, "graphtrail-mcp", script=sleep_script)
+    with pytest.raises(ComponentInstallError, match="graphtrail-mcp smoke timed out"):
+        run_post_install_smoke(managed, runner=slow_runner)

--- a/tests/test_component_install.py
+++ b/tests/test_component_install.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import os
 
 import pytest
 
@@ -10,7 +11,10 @@ import brigade
 from brigade import component_manifest
 from brigade.component_install import (
     ComponentInstallError,
+    _restore_managed_executables,
+    _snapshot_managed_executables,
     fetch_asset_to_cache,
+    materialize_executable,
     setup_native_components,
     verify_cached_asset,
 )
@@ -152,3 +156,106 @@ def test_setup_rejects_brigade_version_mismatch(tmp_path, monkeypatch):
     monkeypatch.setattr(component_manifest, "manifest_path", lambda: manifest_path)
     rc = setup_native_components(env=env)
     assert rc == 1
+
+
+def test_materialize_executable_sets_mode_and_replaces(tmp_path):
+    cache_path = tmp_path / "cache.bin"
+    managed_path = tmp_path / "bin" / "tool"
+    cache_path.write_bytes(b"#!/bin/sh\n")
+    materialize_executable(cache_path=cache_path, managed_path=managed_path)
+    assert managed_path.read_bytes() == cache_path.read_bytes()
+    assert oct(managed_path.stat().st_mode & 0o777) == oct(0o755)
+
+
+def test_materialize_executable_creates_parent_dirs(tmp_path):
+    cache_path = tmp_path / "cache.bin"
+    managed_path = tmp_path / "deep" / "nested" / "bin" / "tool"
+    payload = b"#!/bin/sh\necho ok\n"
+    cache_path.write_bytes(payload)
+    materialize_executable(cache_path=cache_path, managed_path=managed_path)
+    assert managed_path.read_bytes() == payload
+    assert managed_path.parent.is_dir()
+
+
+def test_materialize_executable_rejects_missing_cache(tmp_path):
+    cache_path = tmp_path / "cache.bin"
+    managed_path = tmp_path / "bin" / "tool"
+    with pytest.raises(ComponentInstallError, match="cache asset missing"):
+        materialize_executable(cache_path=cache_path, managed_path=managed_path)
+
+
+def test_materialize_executable_failure_preserves_prior_bytes(tmp_path, monkeypatch):
+    cache_path = tmp_path / "cache.bin"
+    managed_path = tmp_path / "bin" / "tool"
+    prior = b"OLD"
+    managed_path.parent.mkdir(parents=True)
+    managed_path.write_bytes(prior)
+    managed_path.chmod(0o755)
+    cache_path.write_bytes(b"NEW")
+
+    def fail_replace(src, dst):
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(os, "replace", fail_replace)
+    with pytest.raises(OSError, match="replace failed"):
+        materialize_executable(cache_path=cache_path, managed_path=managed_path)
+    assert managed_path.read_bytes() == prior
+
+
+def test_materialize_executable_cleans_up_temp_on_failure(tmp_path, monkeypatch):
+    cache_path = tmp_path / "cache.bin"
+    managed_path = tmp_path / "bin" / "tool"
+    cache_path.write_bytes(b"NEW")
+
+    def fail_replace(src, dst):
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(os, "replace", fail_replace)
+    with pytest.raises(OSError):
+        materialize_executable(cache_path=cache_path, managed_path=managed_path)
+    leftovers = list(managed_path.parent.glob(f".{managed_path.name}.*"))
+    assert leftovers == []
+
+
+def test_restore_managed_executables_restores_bytes_and_mode(tmp_path):
+    path_a = tmp_path / "bin" / "a"
+    path_b = tmp_path / "bin" / "b"
+    path_a.parent.mkdir(parents=True)
+    path_a.write_bytes(b"original-a")
+    path_a.chmod(0o754)
+    path_b.write_bytes(b"original-b")
+    path_b.chmod(0o700)
+
+    snapshot = _snapshot_managed_executables([path_a, path_b])
+
+    path_a.write_bytes(b"mutated-a")
+    path_a.chmod(0o644)
+    path_b.write_bytes(b"mutated-b")
+    path_b.chmod(0o644)
+
+    _restore_managed_executables(snapshot)
+
+    assert path_a.read_bytes() == b"original-a"
+    assert path_b.read_bytes() == b"original-b"
+    assert oct(path_a.stat().st_mode & 0o777) == oct(0o754)
+    assert oct(path_b.stat().st_mode & 0o777) == oct(0o700)
+
+
+def test_restore_managed_executables_removes_newly_created_paths(tmp_path):
+    existing = tmp_path / "bin" / "existing"
+    existing.parent.mkdir(parents=True)
+    existing.write_bytes(b"keep-me")
+    existing.chmod(0o755)
+
+    new_path = tmp_path / "bin" / "new"
+    snapshot = _snapshot_managed_executables([existing, new_path])
+
+    existing.write_bytes(b"changed")
+    new_path.parent.mkdir(parents=True, exist_ok=True)
+    new_path.write_bytes(b"brand-new")
+    new_path.chmod(0o755)
+
+    _restore_managed_executables(snapshot)
+
+    assert existing.read_bytes() == b"keep-me"
+    assert not new_path.exists()

--- a/tests/test_component_install.py
+++ b/tests/test_component_install.py
@@ -280,6 +280,72 @@ def test_fetch_asset_cleans_up_temp_on_failure(tmp_path):
     assert leftovers == []
 
 
+def test_fetch_asset_oversized_stream_aborts_with_bounded_reads(tmp_path):
+    asset = manifest_asset_fixture("miseledger", platform="linux-amd64")
+    payload, byte_size, _sha256 = fixture_payload("miseledger", platform="linux-amd64")
+    oversized = payload + b"extra-bytes"
+    cache_path = tmp_path / "cache" / asset.sha256 / asset.asset_name
+    stale = b"stale-cache"
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_bytes(stale)
+    opener = FakeOpener({asset.download_url: oversized})
+    with pytest.raises(ComponentInstallError, match="byte_size"):
+        fetch_asset_to_cache(asset, cache_path=cache_path, offline=False, opener=opener)
+    assert cache_path.read_bytes() == stale
+    assert list(cache_path.parent.glob(f".{cache_path.name}.*")) == []
+    assert all(size <= byte_size + 1 for size in opener.responses[0].read_sizes)
+
+
+def test_fetch_asset_rejects_https_to_http_redirect(tmp_path):
+    asset = manifest_asset_fixture("miseledger", platform="linux-amd64")
+    payload, _byte_size, _sha256 = fixture_payload("miseledger", platform="linux-amd64")
+    cache_path = tmp_path / "cache" / asset.sha256 / asset.asset_name
+    opener = FakeOpener(
+        {asset.download_url: payload},
+        final_urls={asset.download_url: asset.download_url.replace("https://", "http://", 1)},
+    )
+    with pytest.raises(ComponentInstallError, match="https"):
+        fetch_asset_to_cache(asset, cache_path=cache_path, offline=False, opener=opener)
+    assert not cache_path.exists()
+
+
+def test_fetch_asset_fsyncs_verified_download_before_replace(tmp_path, monkeypatch):
+    asset = manifest_asset_fixture("miseledger", platform="linux-amd64")
+    payload, byte_size, sha256 = fixture_payload("miseledger", platform="linux-amd64")
+    cache_path = tmp_path / "cache" / sha256 / asset.asset_name
+    opener = FakeOpener({asset.download_url: payload})
+    fsync_calls: list[int] = []
+    original_fsync = os.fsync
+
+    def recording_fsync(fd: int) -> None:
+        fsync_calls.append(fd)
+        original_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", recording_fsync)
+    fetch_asset_to_cache(asset, cache_path=cache_path, offline=False, opener=opener)
+    assert fsync_calls
+    verify_cached_asset(cache_path, byte_size=byte_size, sha256=sha256)
+
+
+def test_repeat_setup_repairs_cleared_execute_bits_without_network(tmp_path, monkeypatch):
+    env, _manifest_path = _install_fixture_manifest(tmp_path, monkeypatch)
+    assert setup_native_components(env=env, opener=FakeOpener(all_fixture_payloads())) == 0
+    paths = _managed_paths(env)
+    mtimes_before = {component_id: path.stat().st_mtime_ns for component_id, path in paths.items()}
+    repair_target = component_manifest.KNOWN_COMPONENT_IDS[0]
+    paths[repair_target].chmod(0o644)
+
+    assert setup_native_components(env=env, opener=FakeOpener({})) == 0
+
+    payload, _byte_size, _sha256 = fixture_payload(repair_target)
+    assert paths[repair_target].read_bytes() == payload
+    assert paths[repair_target].stat().st_mode & 0o111
+    for component_id, path in paths.items():
+        if component_id == repair_target:
+            continue
+        assert path.stat().st_mtime_ns == mtimes_before[component_id]
+
+
 def test_resolve_roots_uses_xdg_paths(tmp_path):
     env = linux_env(tmp_path)
     roots = resolve_roots(env=env, system="linux")

--- a/tests/test_component_install.py
+++ b/tests/test_component_install.py
@@ -1,0 +1,51 @@
+"""Tests for native component install engine."""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+import brigade
+from brigade import component_manifest
+from brigade.component_install import ComponentInstallError, setup_native_components, verify_cached_asset
+
+from tests.component_install_helpers import linux_env, write_test_manifest
+
+
+def test_verify_cached_asset_rejects_size_mismatch(tmp_path):
+    path = tmp_path / "asset"
+    path.write_bytes(b"short")
+    with pytest.raises(ComponentInstallError, match="byte_size"):
+        verify_cached_asset(path, byte_size=10, sha256="a" * 64)
+
+
+def test_verify_cached_asset_rejects_digest_mismatch(tmp_path):
+    path = tmp_path / "asset"
+    path.write_bytes(b"0123456789")
+    with pytest.raises(ComponentInstallError, match="sha256"):
+        verify_cached_asset(path, byte_size=10, sha256="b" * 64)
+
+
+def test_verify_cached_asset_rejects_missing_file(tmp_path):
+    path = tmp_path / "asset"
+    with pytest.raises(ComponentInstallError, match="missing"):
+        verify_cached_asset(path, byte_size=10, sha256="a" * 64)
+
+
+def test_verify_cached_asset_accepts_valid_cache(tmp_path):
+    path = tmp_path / "asset"
+    payload = b"0123456789"
+    path.write_bytes(payload)
+    digest = hashlib.sha256(payload).hexdigest()
+    verify_cached_asset(path, byte_size=len(payload), sha256=digest)
+
+
+def test_setup_rejects_brigade_version_mismatch(tmp_path, monkeypatch):
+    env = linux_env(tmp_path)
+    manifest_path = tmp_path / "manifest-v1.json"
+    write_test_manifest(manifest_path, brigade_version="9.9.9")
+    monkeypatch.setattr("brigade.__version__", "0.23.0", raising=False)
+    monkeypatch.setattr(component_manifest, "manifest_path", lambda: manifest_path)
+    rc = setup_native_components(env=env)
+    assert rc == 1

--- a/tests/test_component_install.py
+++ b/tests/test_component_install.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import subprocess
 from pathlib import Path
@@ -10,8 +11,7 @@ from pathlib import Path
 import pytest
 
 import brigade
-from brigade import component_manifest
-from brigade import component_paths
+from brigade import component_install, component_manifest, component_paths, component_state
 from brigade.component_install import (
     ComponentInstallError,
     _restore_managed_executables,
@@ -27,6 +27,7 @@ from brigade.component_install import (
 
 from tests.component_install_helpers import (
     FakeOpener,
+    all_fixture_payloads,
     fixture_payload,
     linux_env,
     smoke_stub_script,
@@ -59,6 +60,35 @@ def _recording_runner(calls: list[tuple[list[str], dict[str, object]]]):
         return subprocess.run(argv, **kwargs)
 
     return runner
+
+
+def _install_fixture_manifest(tmp_path, monkeypatch):
+    env = linux_env(tmp_path)
+    manifest_path = tmp_path / "manifest-v1.json"
+    write_test_manifest(manifest_path, brigade_version=brigade.__version__)
+    monkeypatch.setattr(component_manifest, "manifest_path", lambda: manifest_path)
+    monkeypatch.setattr(component_manifest, "platform_key", lambda **_kwargs: "linux-amd64")
+    return env, manifest_path
+
+
+def _managed_paths(env: dict[str, str]) -> dict[str, Path]:
+    roots = resolve_roots(env=env, system="linux")
+    return {
+        component_id: Path(component_paths.managed_executable_path(roots.data_root, component_id))
+        for component_id in component_manifest.KNOWN_COMPONENT_IDS
+    }
+
+
+def _write_prior_managed(paths: dict[str, Path]) -> dict[str, bytes]:
+    prior: dict[str, bytes] = {}
+    for index, path in enumerate(paths.values()):
+        if index % 2 == 0:
+            payload = f"prior-{path.name}".encode()
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(payload)
+            path.chmod(0o700)
+            prior[path.name] = payload
+    return prior
 
 
 def test_verify_cached_asset_rejects_invalid_byte_size(tmp_path):
@@ -201,9 +231,7 @@ def test_build_setup_plan_emits_deterministic_actions(tmp_path):
     roots = resolve_roots(env=linux_env(tmp_path), system="linux")
     plan = build_setup_plan(manifest, platform="linux-amd64", roots=roots)
     per_component = ("verify-cache", "download", "materialize", "smoke")
-    assert [action.action for action in plan] == list(per_component) * len(
-        component_manifest.KNOWN_COMPONENT_IDS
-    )
+    assert [action.action for action in plan] == list(per_component) * len(component_manifest.KNOWN_COMPONENT_IDS)
     expected_ids: list[str] = []
     for component_id in component_manifest.KNOWN_COMPONENT_IDS:
         expected_ids.extend([component_id] * len(per_component))
@@ -218,9 +246,7 @@ def test_build_setup_plan_uses_exact_cache_and_managed_paths(tmp_path):
     plan = build_setup_plan(manifest, platform=platform, roots=roots)
     for component_id in component_manifest.KNOWN_COMPONENT_IDS:
         asset = manifest.components[component_id].assets[platform]
-        cache_path = component_paths.cached_asset_path(
-            roots.cache_root, asset.sha256, asset.asset_name
-        )
+        cache_path = component_paths.cached_asset_path(roots.cache_root, asset.sha256, asset.asset_name)
         managed_path = component_paths.managed_executable_path(roots.data_root, component_id)
         component_actions = [action for action in plan if action.component_id == component_id]
         assert len(component_actions) == 4
@@ -230,9 +256,7 @@ def test_build_setup_plan_uses_exact_cache_and_managed_paths(tmp_path):
         assert component_actions[0].byte_size == asset.byte_size
         assert component_actions[0].sha256 == asset.sha256
         assert component_actions[0].download_url == asset.download_url
-        assert component_actions[0].component_revision == manifest.components[
-            component_id
-        ].component_revision
+        assert component_actions[0].component_revision == manifest.components[component_id].component_revision
 
 
 def test_setup_dry_run_writes_nothing(tmp_path, monkeypatch, capsys):
@@ -322,6 +346,178 @@ def test_setup_rejects_brigade_version_mismatch(tmp_path, monkeypatch):
     monkeypatch.setattr(component_manifest, "manifest_path", lambda: manifest_path)
     rc = setup_native_components(env=env)
     assert rc == 1
+
+
+def test_setup_install_writes_all_four_managed_files_and_state_after_smoke(tmp_path, monkeypatch):
+    env, _manifest_path = _install_fixture_manifest(tmp_path, monkeypatch)
+    opener = FakeOpener(all_fixture_payloads())
+
+    assert setup_native_components(env=env, opener=opener) == 0
+
+    roots = resolve_roots(env=env, system="linux")
+    state_path = Path(component_paths.installed_state_path(roots.data_root))
+    state = component_state.load_installed_state(state_path)
+    assert state is not None
+    assert set(state.components) == set(component_manifest.KNOWN_COMPONENT_IDS)
+    assert len(opener.calls) == len(component_manifest.KNOWN_COMPONENT_IDS)
+    for component_id, managed_path in _managed_paths(env).items():
+        payload, byte_size, sha256 = fixture_payload(component_id)
+        assert managed_path.read_bytes() == payload
+        assert state.components[component_id].byte_size == byte_size
+        assert state.components[component_id].sha256 == sha256
+        assert state.components[component_id].executable == str(managed_path)
+
+
+def test_setup_state_is_absent_while_smoke_runs(tmp_path, monkeypatch):
+    env, _manifest_path = _install_fixture_manifest(tmp_path, monkeypatch)
+    roots = resolve_roots(env=env, system="linux")
+    state_path = Path(component_paths.installed_state_path(roots.data_root))
+    original_smoke = component_install.run_post_install_smoke
+
+    def assert_state_absent(managed_paths, **kwargs):
+        assert not state_path.exists()
+        original_smoke(managed_paths, **kwargs)
+
+    monkeypatch.setattr(component_install, "run_post_install_smoke", assert_state_absent)
+
+    assert setup_native_components(env=env, opener=FakeOpener(all_fixture_payloads())) == 0
+    assert state_path.is_file()
+
+
+def test_setup_fetches_every_asset_before_managed_bin_mutation(tmp_path, monkeypatch):
+    env, _manifest_path = _install_fixture_manifest(tmp_path, monkeypatch)
+    opener = FakeOpener(all_fixture_payloads())
+    original_materialize = component_install.materialize_executable
+
+    def assert_all_downloaded(*, cache_path, managed_path):
+        assert len(opener.calls) == len(component_manifest.KNOWN_COMPONENT_IDS)
+        original_materialize(cache_path=cache_path, managed_path=managed_path)
+
+    monkeypatch.setattr(component_install, "materialize_executable", assert_all_downloaded)
+
+    assert setup_native_components(env=env, opener=opener) == 0
+
+
+def test_setup_last_download_failure_preserves_managed_bin(tmp_path, monkeypatch):
+    env, _manifest_path = _install_fixture_manifest(tmp_path, monkeypatch)
+    paths = _managed_paths(env)
+    prior = _write_prior_managed(paths)
+    payloads = all_fixture_payloads()
+    payloads.pop(next(reversed(payloads)))
+
+    assert setup_native_components(env=env, opener=FakeOpener(payloads)) == 1
+
+    for component_id, path in paths.items():
+        if component_id in prior:
+            assert path.read_bytes() == prior[component_id]
+            assert path.stat().st_mode & 0o777 == 0o700
+        else:
+            assert not path.exists()
+
+
+def test_setup_smoke_failure_restores_old_files_and_removes_new_files(tmp_path, monkeypatch):
+    env, _manifest_path = _install_fixture_manifest(tmp_path, monkeypatch)
+    paths = _managed_paths(env)
+    prior = _write_prior_managed(paths)
+
+    def boom_runner(argv, **kwargs):
+        return subprocess.CompletedProcess(argv, 1, stdout="", stderr="boom")
+
+    assert setup_native_components(env=env, opener=FakeOpener(all_fixture_payloads()), runner=boom_runner) == 1
+
+    for component_id, path in paths.items():
+        if component_id in prior:
+            assert path.read_bytes() == prior[component_id]
+            assert path.stat().st_mode & 0o777 == 0o700
+        else:
+            assert not path.exists()
+
+
+def test_setup_materialize_failure_restores_managed_bin(tmp_path, monkeypatch):
+    env, _manifest_path = _install_fixture_manifest(tmp_path, monkeypatch)
+    paths = _managed_paths(env)
+    prior = _write_prior_managed(paths)
+    original_materialize = component_install.materialize_executable
+    materialized = 0
+
+    def fail_mid_batch(*, cache_path, managed_path):
+        nonlocal materialized
+        materialized += 1
+        if materialized == 3:
+            raise OSError("materialize failed")
+        original_materialize(cache_path=cache_path, managed_path=managed_path)
+
+    monkeypatch.setattr(component_install, "materialize_executable", fail_mid_batch)
+
+    assert setup_native_components(env=env, opener=FakeOpener(all_fixture_payloads())) == 1
+
+    for component_id, path in paths.items():
+        if component_id in prior:
+            assert path.read_bytes() == prior[component_id]
+            assert path.stat().st_mode & 0o777 == 0o700
+        else:
+            assert not path.exists()
+
+
+def test_setup_state_write_failure_restores_managed_bin(tmp_path, monkeypatch):
+    env, _manifest_path = _install_fixture_manifest(tmp_path, monkeypatch)
+    paths = _managed_paths(env)
+
+    def fail_state_write(*_args, **_kwargs):
+        raise OSError("state write failed")
+
+    monkeypatch.setattr(component_install.component_state, "write_installed_state", fail_state_write)
+
+    assert setup_native_components(env=env, opener=FakeOpener(all_fixture_payloads())) == 1
+    assert all(not path.exists() for path in paths.values())
+
+
+def test_setup_refuses_an_invalid_existing_current_state(tmp_path, monkeypatch, capsys):
+    env, _manifest_path = _install_fixture_manifest(tmp_path, monkeypatch)
+    roots = resolve_roots(env=env, system="linux")
+    state_path = Path(component_paths.installed_state_path(roots.data_root))
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text("{not valid json")
+    opener = FakeOpener(all_fixture_payloads())
+
+    assert setup_native_components(env=env, opener=opener) == 1
+    assert "invalid installed state" in capsys.readouterr().err
+    assert opener.calls == []
+
+
+def test_repeat_setup_is_idempotent_without_network_or_managed_rewrites(tmp_path, monkeypatch):
+    env, _manifest_path = _install_fixture_manifest(tmp_path, monkeypatch)
+    first_opener = FakeOpener(all_fixture_payloads())
+    assert setup_native_components(env=env, opener=first_opener) == 0
+    paths = _managed_paths(env)
+    mtimes_before = {component_id: path.stat().st_mtime_ns for component_id, path in paths.items()}
+    roots = resolve_roots(env=env, system="linux")
+    previous_path = Path(component_paths.installed_previous_state_path(roots.data_root))
+    previous_before = previous_path.read_bytes() if previous_path.exists() else None
+
+    second_opener = FakeOpener({})
+    assert setup_native_components(env=env, opener=second_opener) == 0
+
+    assert second_opener.calls == []
+    assert {component_id: path.stat().st_mtime_ns for component_id, path in paths.items()} == mtimes_before
+    assert (previous_path.read_bytes() if previous_path.exists() else None) == previous_before
+
+
+def test_setup_rotates_previous_state_when_manifest_revision_changes(tmp_path, monkeypatch):
+    env, manifest_path = _install_fixture_manifest(tmp_path, monkeypatch)
+    assert setup_native_components(env=env, opener=FakeOpener(all_fixture_payloads())) == 0
+    roots = resolve_roots(env=env, system="linux")
+    current_path = Path(component_paths.installed_state_path(roots.data_root))
+    current_before = current_path.read_bytes()
+    payload = json.loads(manifest_path.read_text())
+    payload["manifest_revision"] = "fixture-next"
+    manifest_path.write_text(json.dumps(payload))
+
+    assert setup_native_components(env=env, opener=FakeOpener({})) == 0
+
+    previous_path = Path(component_paths.installed_previous_state_path(roots.data_root))
+    assert previous_path.read_bytes() == current_before
+    assert component_state.load_installed_state(current_path).manifest_revision == "fixture-next"
 
 
 def test_materialize_executable_sets_mode_and_replaces(tmp_path):
@@ -489,6 +685,19 @@ def test_run_post_install_smoke_rejects_graphtrail_mcp_malformed_json(tmp_path):
         run_post_install_smoke(managed)
 
 
+def test_run_post_install_smoke_rejects_graphtrail_mcp_nonzero_exit(tmp_path):
+    managed = _write_managed_smoke_stubs(tmp_path)
+
+    def nonzero_runner(argv, **kwargs):
+        completed = subprocess.run(argv, **kwargs)
+        if argv[0] == managed["graphtrail-mcp"]:
+            return subprocess.CompletedProcess(argv, 1, completed.stdout, completed.stderr)
+        return completed
+
+    with pytest.raises(ComponentInstallError, match="graphtrail-mcp smoke failed.*exited 1"):
+        run_post_install_smoke(managed, runner=nonzero_runner)
+
+
 def test_run_post_install_smoke_rejects_miseledger_nonzero_exit(tmp_path):
     managed = _write_managed_smoke_stubs(tmp_path)
     script = smoke_stub_script("miseledger").replace("raise SystemExit(0)", "raise SystemExit(1)")
@@ -518,7 +727,7 @@ def test_run_post_install_smoke_rejects_sessionfind_missing_usage(tmp_path):
 
 def test_run_post_install_smoke_rejects_timeout(tmp_path):
     managed = _write_managed_smoke_stubs(tmp_path)
-    sleep_script = '#!/usr/bin/env python3\nimport time\ntime.sleep(5)\n'
+    sleep_script = "#!/usr/bin/env python3\nimport time\ntime.sleep(5)\n"
 
     def slow_runner(argv, **kwargs):
         kwargs["timeout"] = 0.2

--- a/tests/test_component_install.py
+++ b/tests/test_component_install.py
@@ -91,6 +91,76 @@ def _write_prior_managed(paths: dict[str, Path]) -> dict[str, bytes]:
     return prior
 
 
+def _rollback_payload(component_id: str, *, version: str) -> bytes:
+    payload = fixture_payload(component_id)[0]
+    return payload.replace(
+        b"# platform: linux-amd64\n",
+        f"# platform: linux-amd64 {version}\n".encode(),
+        1,
+    )
+
+
+def _rollback_state(
+    env: dict[str, str],
+    *,
+    revision: str,
+    version: str,
+    executable: str | None = None,
+) -> component_state.InstalledState:
+    roots = resolve_roots(env=env, system="linux")
+    components: dict[str, component_state.InstalledComponentRecord] = {}
+    for component_id in component_manifest.KNOWN_COMPONENT_IDS:
+        payload = _rollback_payload(component_id, version=version)
+        sha256 = hashlib.sha256(payload).hexdigest()
+        asset_name = f"{component_id}-rollback-{version}"
+        cache_path = Path(component_paths.cached_asset_path(roots.cache_root, sha256, asset_name))
+        write_verified_cache(cache_path, payload=payload)
+        components[component_id] = component_state.InstalledComponentRecord(
+            component_revision=f"fixture-{version}",
+            asset_name=asset_name,
+            byte_size=len(payload),
+            sha256=sha256,
+            download_url=f"https://example.invalid/components/{asset_name}",
+            executable=executable or f"/untrusted/{component_id}",
+        )
+    return component_state.InstalledState(
+        schema_version=component_state.SCHEMA_VERSION,
+        brigade_version=brigade.__version__,
+        manifest_revision=revision,
+        platform="linux-amd64",
+        installed_at="2026-07-19T06:00:00+00:00",
+        components=components,
+    )
+
+
+def _seed_rollback_pair(
+    env: dict[str, str],
+    *,
+    revision_a: str = "fixture-a",
+    revision_b: str = "fixture-b",
+) -> tuple[component_state.InstalledState, component_state.InstalledState]:
+    roots = resolve_roots(env=env, system="linux")
+    previous = _rollback_state(env, revision=revision_a, version="previous")
+    current = _rollback_state(env, revision=revision_b, version="current")
+    component_state.write_installed_state(Path(component_paths.installed_state_path(roots.data_root)), current)
+    component_state.write_installed_state(
+        Path(component_paths.installed_previous_state_path(roots.data_root)), previous
+    )
+    for component_id, path in _managed_paths(env).items():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(_rollback_payload(component_id, version="current"))
+        path.chmod(0o700)
+    return previous, current
+
+
+def _rollback_state_paths(env: dict[str, str]) -> tuple[Path, Path]:
+    roots = resolve_roots(env=env, system="linux")
+    return (
+        Path(component_paths.installed_state_path(roots.data_root)),
+        Path(component_paths.installed_previous_state_path(roots.data_root)),
+    )
+
+
 def test_verify_cached_asset_rejects_invalid_byte_size(tmp_path):
     path = tmp_path / "asset"
     path.write_bytes(b"data")
@@ -346,6 +416,233 @@ def test_setup_rejects_brigade_version_mismatch(tmp_path, monkeypatch):
     monkeypatch.setattr(component_manifest, "manifest_path", lambda: manifest_path)
     rc = setup_native_components(env=env)
     assert rc == 1
+
+
+def test_setup_rejects_dry_run_with_rollback(tmp_path):
+    assert setup_native_components(dry_run=True, rollback=True, env=linux_env(tmp_path)) == 1
+
+
+def test_setup_rollback_restores_previous_binaries_and_swaps_state(tmp_path):
+    env = linux_env(tmp_path)
+    previous, current = _seed_rollback_pair(env)
+    current_path, previous_path = _rollback_state_paths(env)
+    current_before = current_path.read_bytes()
+    previous_before = previous_path.read_bytes()
+    opener = FakeOpener({})
+
+    assert setup_native_components(rollback=True, env=env, opener=opener) == 0
+
+    restored = component_state.load_installed_state(current_path)
+    swapped = component_state.load_installed_state(previous_path)
+    assert restored == previous
+    assert swapped == current
+    assert current_path.read_bytes() != current_before
+    assert previous_path.read_bytes() != previous_before
+    assert opener.calls == []
+    for component_id, path in _managed_paths(env).items():
+        assert path.read_bytes() == _rollback_payload(component_id, version="previous")
+        assert path.stat().st_mode & 0o777 == 0o755
+
+
+def test_setup_rollback_verifies_all_prior_caches_before_mutating_managed_files(tmp_path, monkeypatch):
+    env = linux_env(tmp_path)
+    previous, _current = _seed_rollback_pair(env)
+    current_path, previous_path = _rollback_state_paths(env)
+    state_before = (current_path.read_bytes(), previous_path.read_bytes())
+    paths = _managed_paths(env)
+    managed_before = {component_id: path.read_bytes() for component_id, path in paths.items()}
+    last_component = component_manifest.KNOWN_COMPONENT_IDS[-1]
+    record = previous.components[last_component]
+    roots = resolve_roots(env=env, system="linux")
+    Path(component_paths.cached_asset_path(roots.cache_root, record.sha256, record.asset_name)).unlink()
+
+    def mutation_before_cache_verification(*_args, **_kwargs):
+        pytest.fail("managed files must not mutate before every prior cache verifies")
+
+    monkeypatch.setattr(component_install, "materialize_executable", mutation_before_cache_verification)
+
+    assert setup_native_components(rollback=True, env=env) == 1
+    assert (current_path.read_bytes(), previous_path.read_bytes()) == state_before
+    assert {component_id: path.read_bytes() for component_id, path in paths.items()} == managed_before
+
+
+@pytest.mark.parametrize("failure", ("missing", "corrupt"))
+def test_setup_rollback_bad_prior_cache_preserves_binaries_and_state(tmp_path, failure):
+    env = linux_env(tmp_path)
+    previous, _current = _seed_rollback_pair(env)
+    current_path, previous_path = _rollback_state_paths(env)
+    state_before = (current_path.read_bytes(), previous_path.read_bytes())
+    paths = _managed_paths(env)
+    managed_before = {component_id: path.read_bytes() for component_id, path in paths.items()}
+    component_id = component_manifest.KNOWN_COMPONENT_IDS[0]
+    record = previous.components[component_id]
+    roots = resolve_roots(env=env, system="linux")
+    cache_path = Path(component_paths.cached_asset_path(roots.cache_root, record.sha256, record.asset_name))
+    if failure == "missing":
+        cache_path.unlink()
+    else:
+        cache_path.write_bytes(b"corrupt")
+
+    assert setup_native_components(rollback=True, env=env) == 1
+    assert (current_path.read_bytes(), previous_path.read_bytes()) == state_before
+    assert {component_id: path.read_bytes() for component_id, path in paths.items()} == managed_before
+
+
+@pytest.mark.parametrize("state_name", ("current", "previous"))
+@pytest.mark.parametrize("invalid", (False, True))
+def test_setup_rollback_rejects_missing_or_invalid_state_without_mutation(tmp_path, state_name, invalid):
+    env = linux_env(tmp_path)
+    _seed_rollback_pair(env)
+    current_path, previous_path = _rollback_state_paths(env)
+    target = current_path if state_name == "current" else previous_path
+    if invalid:
+        target.write_text("{invalid json")
+    else:
+        target.unlink()
+    paths = _managed_paths(env)
+    managed_before = {component_id: path.read_bytes() for component_id, path in paths.items()}
+    other_path = previous_path if target == current_path else current_path
+    other_before = other_path.read_bytes()
+
+    assert setup_native_components(rollback=True, env=env) == 1
+    assert not target.exists() if not invalid else target.read_text() == "{invalid json"
+    assert other_path.read_bytes() == other_before
+    assert {component_id: path.read_bytes() for component_id, path in paths.items()} == managed_before
+
+
+def test_setup_rollback_rejects_partial_component_state_without_mutation(tmp_path):
+    env = linux_env(tmp_path)
+    previous, _current = _seed_rollback_pair(env)
+    current_path, previous_path = _rollback_state_paths(env)
+    state_before = current_path.read_bytes()
+    partial = component_state.InstalledState(
+        schema_version=previous.schema_version,
+        brigade_version=previous.brigade_version,
+        manifest_revision=previous.manifest_revision,
+        platform=previous.platform,
+        installed_at=previous.installed_at,
+        components={"graphtrail": previous.components["graphtrail"]},
+    )
+    component_state.write_installed_state(previous_path, partial)
+    previous_before = previous_path.read_bytes()
+    paths = _managed_paths(env)
+    managed_before = {component_id: path.read_bytes() for component_id, path in paths.items()}
+
+    assert setup_native_components(rollback=True, env=env) == 1
+    assert current_path.read_bytes() == state_before
+    assert previous_path.read_bytes() == previous_before
+    assert {component_id: path.read_bytes() for component_id, path in paths.items()} == managed_before
+
+
+def test_setup_rollback_rejects_host_platform_mismatch_without_mutation(tmp_path):
+    env = linux_env(tmp_path)
+    previous, _current = _seed_rollback_pair(env)
+    current_path, previous_path = _rollback_state_paths(env)
+    state_before = current_path.read_bytes()
+    mismatch = component_state.InstalledState(
+        schema_version=previous.schema_version,
+        brigade_version=previous.brigade_version,
+        manifest_revision=previous.manifest_revision,
+        platform="linux-arm64",
+        installed_at=previous.installed_at,
+        components=previous.components,
+    )
+    component_state.write_installed_state(previous_path, mismatch)
+    previous_before = previous_path.read_bytes()
+    paths = _managed_paths(env)
+    managed_before = {component_id: path.read_bytes() for component_id, path in paths.items()}
+
+    assert setup_native_components(rollback=True, env=env) == 1
+    assert current_path.read_bytes() == state_before
+    assert previous_path.read_bytes() == previous_before
+    assert {component_id: path.read_bytes() for component_id, path in paths.items()} == managed_before
+
+
+def test_setup_rollback_ignores_persisted_executable_destinations(tmp_path):
+    env = linux_env(tmp_path)
+    _seed_rollback_pair(env)
+    untrusted = tmp_path / "persisted-executable"
+    current_path, _previous_path = _rollback_state_paths(env)
+    current = component_state.load_installed_state(current_path)
+    assert current is not None
+    altered = component_state.InstalledState(
+        schema_version=current.schema_version,
+        brigade_version=current.brigade_version,
+        manifest_revision=current.manifest_revision,
+        platform=current.platform,
+        installed_at=current.installed_at,
+        components={
+            component_id: component_state.InstalledComponentRecord(
+                component_revision=record.component_revision,
+                asset_name=record.asset_name,
+                byte_size=record.byte_size,
+                sha256=record.sha256,
+                download_url=record.download_url,
+                executable=str(untrusted / component_id),
+            )
+            for component_id, record in current.components.items()
+        },
+    )
+    component_state.write_installed_state(current_path, altered)
+
+    assert setup_native_components(rollback=True, env=env) == 0
+    assert not untrusted.exists()
+    for component_id, path in _managed_paths(env).items():
+        assert path.read_bytes() == _rollback_payload(component_id, version="previous")
+
+
+def test_setup_rollback_smoke_failure_restores_binaries_and_state(tmp_path):
+    env = linux_env(tmp_path)
+    _seed_rollback_pair(env)
+    current_path, previous_path = _rollback_state_paths(env)
+    state_before = (current_path.read_bytes(), previous_path.read_bytes())
+    paths = _managed_paths(env)
+    managed_before = {component_id: path.read_bytes() for component_id, path in paths.items()}
+
+    def failed_smoke(argv, **_kwargs):
+        return subprocess.CompletedProcess(argv, 1, stdout="", stderr="boom")
+
+    assert setup_native_components(rollback=True, env=env, runner=failed_smoke) == 1
+    assert (current_path.read_bytes(), previous_path.read_bytes()) == state_before
+    assert {component_id: path.read_bytes() for component_id, path in paths.items()} == managed_before
+
+
+def test_setup_rollback_state_write_failure_restores_binaries_and_state(tmp_path, monkeypatch):
+    env = linux_env(tmp_path)
+    _seed_rollback_pair(env)
+    current_path, previous_path = _rollback_state_paths(env)
+    state_before = (current_path.read_bytes(), previous_path.read_bytes())
+    paths = _managed_paths(env)
+    managed_before = {component_id: path.read_bytes() for component_id, path in paths.items()}
+    original_write = component_install.component_state.write_installed_state
+    writes = 0
+
+    def fail_second_state_write(path, state):
+        nonlocal writes
+        writes += 1
+        if writes == 2:
+            raise OSError("state write failed")
+        original_write(path, state)
+
+    monkeypatch.setattr(component_install.component_state, "write_installed_state", fail_second_state_write)
+
+    assert setup_native_components(rollback=True, env=env) == 1
+    assert (current_path.read_bytes(), previous_path.read_bytes()) == state_before
+    assert {component_id: path.read_bytes() for component_id, path in paths.items()} == managed_before
+
+
+def test_setup_rollback_twice_toggles_back_to_original_current_state(tmp_path):
+    env = linux_env(tmp_path)
+    _previous, _current = _seed_rollback_pair(env)
+    current_path, previous_path = _rollback_state_paths(env)
+    original = (current_path.read_bytes(), previous_path.read_bytes())
+
+    assert setup_native_components(rollback=True, env=env) == 0
+    assert setup_native_components(rollback=True, env=env) == 0
+
+    assert (current_path.read_bytes(), previous_path.read_bytes()) == original
+    for component_id, path in _managed_paths(env).items():
+        assert path.read_bytes() == _rollback_payload(component_id, version="current")
 
 
 def test_setup_install_writes_all_four_managed_files_and_state_after_smoke(tmp_path, monkeypatch):

--- a/tests/test_component_install.py
+++ b/tests/test_component_install.py
@@ -280,7 +280,9 @@ def test_fetch_asset_cleans_up_temp_on_failure(tmp_path):
     assert leftovers == []
 
 
-def test_fetch_asset_oversized_stream_aborts_with_bounded_reads(tmp_path):
+def test_fetch_asset_oversized_stream_aborts_with_bounded_reads(tmp_path, monkeypatch):
+    small_chunk = 16
+    monkeypatch.setattr(component_install, "_READ_CHUNK", small_chunk)
     asset = manifest_asset_fixture("miseledger", platform="linux-amd64")
     payload, byte_size, _sha256 = fixture_payload("miseledger", platform="linux-amd64")
     oversized = payload + b"extra-bytes"
@@ -291,9 +293,11 @@ def test_fetch_asset_oversized_stream_aborts_with_bounded_reads(tmp_path):
     opener = FakeOpener({asset.download_url: oversized})
     with pytest.raises(ComponentInstallError, match="byte_size"):
         fetch_asset_to_cache(asset, cache_path=cache_path, offline=False, opener=opener)
+    read_sizes = opener.responses[0].read_sizes
+    assert len(read_sizes) > 1
+    assert all(size <= small_chunk + 1 for size in read_sizes)
     assert cache_path.read_bytes() == stale
     assert list(cache_path.parent.glob(f".{cache_path.name}.*")) == []
-    assert all(size <= byte_size + 1 for size in opener.responses[0].read_sizes)
 
 
 def test_fetch_asset_rejects_https_to_http_redirect(tmp_path):
@@ -309,21 +313,44 @@ def test_fetch_asset_rejects_https_to_http_redirect(tmp_path):
     assert not cache_path.exists()
 
 
+def test_fetch_asset_accepts_https_to_https_redirect(tmp_path):
+    asset = manifest_asset_fixture("miseledger", platform="linux-amd64")
+    payload, byte_size, sha256 = fixture_payload("miseledger", platform="linux-amd64")
+    cache_path = tmp_path / "cache" / sha256 / asset.asset_name
+    final_url = asset.download_url.replace("/components/", "/components/redirect/", 1)
+    opener = FakeOpener(
+        {asset.download_url: payload},
+        final_urls={asset.download_url: final_url},
+    )
+    result = fetch_asset_to_cache(asset, cache_path=cache_path, offline=False, opener=opener)
+    assert result == cache_path
+    assert opener.responses[0].geturl() == final_url
+    verify_cached_asset(cache_path, byte_size=byte_size, sha256=sha256)
+
+
 def test_fetch_asset_fsyncs_verified_download_before_replace(tmp_path, monkeypatch):
     asset = manifest_asset_fixture("miseledger", platform="linux-amd64")
     payload, byte_size, sha256 = fixture_payload("miseledger", platform="linux-amd64")
     cache_path = tmp_path / "cache" / sha256 / asset.asset_name
     opener = FakeOpener({asset.download_url: payload})
-    fsync_calls: list[int] = []
+    events: list[str] = []
     original_fsync = os.fsync
+    original_replace = os.replace
 
     def recording_fsync(fd: int) -> None:
-        fsync_calls.append(fd)
+        events.append("fsync")
         original_fsync(fd)
 
+    def recording_replace(src: str | os.PathLike[str], dst: str | os.PathLike[str]) -> None:
+        events.append("replace")
+        original_replace(src, dst)
+
     monkeypatch.setattr(os, "fsync", recording_fsync)
+    monkeypatch.setattr(os, "replace", recording_replace)
     fetch_asset_to_cache(asset, cache_path=cache_path, offline=False, opener=opener)
-    assert fsync_calls
+    assert "fsync" in events
+    assert "replace" in events
+    assert events.index("fsync") < events.index("replace")
     verify_cached_asset(cache_path, byte_size=byte_size, sha256=sha256)
 
 

--- a/tests/test_component_install.py
+++ b/tests/test_component_install.py
@@ -5,17 +5,21 @@ from __future__ import annotations
 import hashlib
 import os
 import subprocess
+from pathlib import Path
 
 import pytest
 
 import brigade
 from brigade import component_manifest
+from brigade import component_paths
 from brigade.component_install import (
     ComponentInstallError,
     _restore_managed_executables,
     _snapshot_managed_executables,
+    build_setup_plan,
     fetch_asset_to_cache,
     materialize_executable,
+    resolve_roots,
     run_post_install_smoke,
     setup_native_components,
     verify_cached_asset,
@@ -174,6 +178,140 @@ def test_fetch_asset_cleans_up_temp_on_failure(tmp_path):
         fetch_asset_to_cache(asset, cache_path=cache_path, offline=False, opener=opener)
     leftovers = list(cache_path.parent.glob(f".{cache_path.name}.*"))
     assert leftovers == []
+
+
+def test_resolve_roots_uses_xdg_paths(tmp_path):
+    env = linux_env(tmp_path)
+    roots = resolve_roots(env=env, system="linux")
+    assert roots.data_root == env["XDG_DATA_HOME"]
+    assert roots.cache_root == env["XDG_CACHE_HOME"]
+
+
+def test_build_setup_plan_lists_all_four_components(tmp_path):
+    manifest_path = tmp_path / "manifest-v1.json"
+    manifest = write_test_manifest(manifest_path, brigade_version=brigade.__version__)
+    roots = resolve_roots(env=linux_env(tmp_path), system="linux")
+    plan = build_setup_plan(manifest, platform="linux-amd64", roots=roots)
+    assert {action.component_id for action in plan} == set(component_manifest.KNOWN_COMPONENT_IDS)
+
+
+def test_build_setup_plan_emits_deterministic_actions(tmp_path):
+    manifest_path = tmp_path / "manifest-v1.json"
+    manifest = write_test_manifest(manifest_path, brigade_version=brigade.__version__)
+    roots = resolve_roots(env=linux_env(tmp_path), system="linux")
+    plan = build_setup_plan(manifest, platform="linux-amd64", roots=roots)
+    per_component = ("verify-cache", "download", "materialize", "smoke")
+    assert [action.action for action in plan] == list(per_component) * len(
+        component_manifest.KNOWN_COMPONENT_IDS
+    )
+    expected_ids: list[str] = []
+    for component_id in component_manifest.KNOWN_COMPONENT_IDS:
+        expected_ids.extend([component_id] * len(per_component))
+    assert [action.component_id for action in plan] == expected_ids
+
+
+def test_build_setup_plan_uses_exact_cache_and_managed_paths(tmp_path):
+    manifest_path = tmp_path / "manifest-v1.json"
+    manifest = write_test_manifest(manifest_path, brigade_version=brigade.__version__)
+    roots = resolve_roots(env=linux_env(tmp_path), system="linux")
+    platform = "linux-amd64"
+    plan = build_setup_plan(manifest, platform=platform, roots=roots)
+    for component_id in component_manifest.KNOWN_COMPONENT_IDS:
+        asset = manifest.components[component_id].assets[platform]
+        cache_path = component_paths.cached_asset_path(
+            roots.cache_root, asset.sha256, asset.asset_name
+        )
+        managed_path = component_paths.managed_executable_path(roots.data_root, component_id)
+        component_actions = [action for action in plan if action.component_id == component_id]
+        assert len(component_actions) == 4
+        assert all(action.cache_path == cache_path for action in component_actions)
+        assert all(action.managed_path == managed_path for action in component_actions)
+        assert component_actions[0].asset_name == asset.asset_name
+        assert component_actions[0].byte_size == asset.byte_size
+        assert component_actions[0].sha256 == asset.sha256
+        assert component_actions[0].download_url == asset.download_url
+        assert component_actions[0].component_revision == manifest.components[
+            component_id
+        ].component_revision
+
+
+def test_setup_dry_run_writes_nothing(tmp_path, monkeypatch, capsys):
+    env = linux_env(tmp_path)
+    manifest_path = tmp_path / "manifest-v1.json"
+    write_test_manifest(manifest_path, brigade_version=brigade.__version__)
+    monkeypatch.setattr(component_manifest, "manifest_path", lambda: manifest_path)
+    monkeypatch.setattr(component_manifest, "platform_key", lambda **_kwargs: "linux-amd64")
+    rc = setup_native_components(dry_run=True, env=env)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "miseledger-linux-amd64" in out
+    assert "download" in out
+    assert not (Path(env["XDG_DATA_HOME"]) / "brigade" / "installed.json").exists()
+
+
+def test_setup_dry_run_prints_required_metadata(tmp_path, monkeypatch, capsys):
+    env = linux_env(tmp_path)
+    manifest_path = tmp_path / "manifest-v1.json"
+    write_test_manifest(manifest_path, brigade_version=brigade.__version__)
+    monkeypatch.setattr(component_manifest, "manifest_path", lambda: manifest_path)
+    monkeypatch.setattr(component_manifest, "platform_key", lambda **_kwargs: "linux-amd64")
+    rc = setup_native_components(dry_run=True, env=env)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert brigade.__version__ in out
+    assert "fixture" in out
+    assert "linux-amd64" in out
+    for component_id in component_manifest.KNOWN_COMPONENT_IDS:
+        assert component_id in out
+    assert "verify-cache" in out
+    assert "materialize" in out
+    assert "smoke" in out
+
+
+def test_setup_dry_run_creates_no_directories(tmp_path, monkeypatch):
+    env = linux_env(tmp_path)
+    manifest_path = tmp_path / "manifest-v1.json"
+    write_test_manifest(manifest_path, brigade_version=brigade.__version__)
+    monkeypatch.setattr(component_manifest, "manifest_path", lambda: manifest_path)
+    monkeypatch.setattr(component_manifest, "platform_key", lambda **_kwargs: "linux-amd64")
+    assert not Path(env["XDG_DATA_HOME"]).exists()
+    assert not Path(env["XDG_CACHE_HOME"]).exists()
+    rc = setup_native_components(dry_run=True, env=env)
+    assert rc == 0
+    assert not Path(env["XDG_DATA_HOME"]).exists()
+    assert not Path(env["XDG_CACHE_HOME"]).exists()
+
+
+def test_setup_dry_run_invokes_no_opener_or_runner(tmp_path, monkeypatch):
+    env = linux_env(tmp_path)
+    manifest_path = tmp_path / "manifest-v1.json"
+    write_test_manifest(manifest_path, brigade_version=brigade.__version__)
+    monkeypatch.setattr(component_manifest, "manifest_path", lambda: manifest_path)
+    monkeypatch.setattr(component_manifest, "platform_key", lambda **_kwargs: "linux-amd64")
+    opener = FakeOpener({})
+
+    def boom_runner(*_args, **_kwargs):
+        pytest.fail("runner should not be called during dry-run")
+
+    rc = setup_native_components(dry_run=True, env=env, opener=opener, runner=boom_runner)
+    assert rc == 0
+    assert opener.calls == []
+
+
+def test_setup_dry_run_rejects_unsupported_platform(tmp_path, monkeypatch, capsys):
+    env = linux_env(tmp_path)
+    manifest_path = tmp_path / "manifest-v1.json"
+    write_test_manifest(manifest_path, brigade_version=brigade.__version__)
+    monkeypatch.setattr(component_manifest, "manifest_path", lambda: manifest_path)
+
+    def bad_platform(**_kwargs):
+        raise ValueError("unsupported platform foo-bar")
+
+    monkeypatch.setattr(component_manifest, "platform_key", bad_platform)
+    rc = setup_native_components(dry_run=True, env=env)
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "unsupported platform" in err
 
 
 def test_setup_rejects_brigade_version_mismatch(tmp_path, monkeypatch):

--- a/tests/test_component_install.py
+++ b/tests/test_component_install.py
@@ -8,9 +8,38 @@ import pytest
 
 import brigade
 from brigade import component_manifest
-from brigade.component_install import ComponentInstallError, setup_native_components, verify_cached_asset
+from brigade.component_install import (
+    ComponentInstallError,
+    fetch_asset_to_cache,
+    setup_native_components,
+    verify_cached_asset,
+)
 
-from tests.component_install_helpers import linux_env, write_test_manifest
+from tests.component_install_helpers import (
+    FakeOpener,
+    fixture_payload,
+    linux_env,
+    test_manifest_asset as manifest_asset_fixture,
+    write_test_manifest,
+    write_verified_cache,
+)
+
+
+def test_verify_cached_asset_rejects_invalid_byte_size(tmp_path):
+    path = tmp_path / "asset"
+    path.write_bytes(b"data")
+    with pytest.raises(ComponentInstallError, match="byte_size"):
+        verify_cached_asset(path, byte_size=0, sha256="a" * 64)
+    with pytest.raises(ComponentInstallError, match="byte_size"):
+        verify_cached_asset(path, byte_size=-1, sha256="a" * 64)
+
+
+def test_verify_cached_asset_rejects_malformed_sha256(tmp_path):
+    path = tmp_path / "asset"
+    with pytest.raises(ComponentInstallError, match="sha256"):
+        verify_cached_asset(path, byte_size=10, sha256="not-a-valid-digest")
+    with pytest.raises(ComponentInstallError, match="sha256"):
+        verify_cached_asset(path, byte_size=10, sha256="G" * 64)
 
 
 def test_verify_cached_asset_rejects_size_mismatch(tmp_path):
@@ -39,6 +68,80 @@ def test_verify_cached_asset_accepts_valid_cache(tmp_path):
     path.write_bytes(payload)
     digest = hashlib.sha256(payload).hexdigest()
     verify_cached_asset(path, byte_size=len(payload), sha256=digest)
+
+
+def test_fetch_asset_to_cache_writes_verified_bytes(tmp_path):
+    asset = manifest_asset_fixture("miseledger", platform="linux-amd64")
+    payload, byte_size, sha256 = fixture_payload("miseledger", platform="linux-amd64")
+    assert asset.byte_size == byte_size
+    assert asset.sha256 == sha256
+    cache_path = tmp_path / "cache" / sha256 / asset.asset_name
+    opener = FakeOpener({asset.download_url: payload})
+    result = fetch_asset_to_cache(asset, cache_path=cache_path, offline=False, opener=opener)
+    assert result == cache_path
+    verify_cached_asset(cache_path, byte_size=byte_size, sha256=sha256)
+
+
+def test_fetch_asset_to_cache_reuses_valid_cache_without_network(tmp_path):
+    asset = manifest_asset_fixture("miseledger", platform="linux-amd64")
+    payload, byte_size, sha256 = fixture_payload("miseledger", platform="linux-amd64")
+    cache_path = tmp_path / "cache" / sha256 / asset.asset_name
+    write_verified_cache(cache_path, payload=payload)
+    opener = FakeOpener({})
+    result = fetch_asset_to_cache(asset, cache_path=cache_path, offline=False, opener=opener)
+    assert result == cache_path
+    assert opener.calls == []
+
+
+def test_fetch_asset_offline_fails_when_cache_missing(tmp_path):
+    asset = manifest_asset_fixture("miseledger", platform="linux-amd64")
+    cache_path = tmp_path / "cache" / asset.sha256 / asset.asset_name
+    with pytest.raises(ComponentInstallError, match="offline"):
+        fetch_asset_to_cache(asset, cache_path=cache_path, offline=True)
+
+
+def test_fetch_asset_offline_fails_when_cache_corrupt(tmp_path):
+    asset = manifest_asset_fixture("miseledger", platform="linux-amd64")
+    cache_path = tmp_path / "cache" / asset.sha256 / asset.asset_name
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_bytes(b"bad")
+    with pytest.raises(ComponentInstallError, match="offline"):
+        fetch_asset_to_cache(asset, cache_path=cache_path, offline=True)
+
+
+def test_fetch_asset_online_replaces_bad_cache_only_after_verified_download(tmp_path):
+    asset = manifest_asset_fixture("miseledger", platform="linux-amd64")
+    payload, byte_size, sha256 = fixture_payload("miseledger", platform="linux-amd64")
+    cache_path = tmp_path / "cache" / sha256 / asset.asset_name
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_bytes(b"stale")
+    opener = FakeOpener({asset.download_url: payload})
+    fetch_asset_to_cache(asset, cache_path=cache_path, offline=False, opener=opener)
+    verify_cached_asset(cache_path, byte_size=byte_size, sha256=sha256)
+
+
+def test_fetch_asset_invalid_download_preserves_stale_cache(tmp_path):
+    asset = manifest_asset_fixture("miseledger", platform="linux-amd64")
+    cache_path = tmp_path / "cache" / asset.sha256 / asset.asset_name
+    stale = b"stale"
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_bytes(stale)
+    bad_payload = b"wrong-bytes"
+    opener = FakeOpener({asset.download_url: bad_payload})
+    with pytest.raises(ComponentInstallError):
+        fetch_asset_to_cache(asset, cache_path=cache_path, offline=False, opener=opener)
+    assert cache_path.read_bytes() == stale
+
+
+def test_fetch_asset_cleans_up_temp_on_failure(tmp_path):
+    asset = manifest_asset_fixture("miseledger", platform="linux-amd64")
+    cache_path = tmp_path / "cache" / asset.sha256 / asset.asset_name
+    bad_payload = b"wrong-bytes"
+    opener = FakeOpener({asset.download_url: bad_payload})
+    with pytest.raises(ComponentInstallError):
+        fetch_asset_to_cache(asset, cache_path=cache_path, offline=False, opener=opener)
+    leftovers = list(cache_path.parent.glob(f".{cache_path.name}.*"))
+    assert leftovers == []
 
 
 def test_setup_rejects_brigade_version_mismatch(tmp_path, monkeypatch):

--- a/tests/test_component_manifest.py
+++ b/tests/test_component_manifest.py
@@ -10,7 +10,81 @@ import pytest
 from brigade import component_manifest
 
 MISELEDGER_BASE = "https://github.com/escoffier-labs/miseledger/releases/download/v0.6.0/"
+GRAPHTRAIL_BASE = "https://github.com/escoffier-labs/graphtrail/releases/download/v0.4.0/"
 GRAPHTRAIL_SHA = "64fcd2f9ec37f33e286708845a92e6cfa4abf3bb"
+
+GRAPHTRAIL_V040_ASSETS = [
+    (
+        "graphtrail",
+        "darwin-amd64",
+        "graphtrail-darwin-amd64",
+        11695172,
+        "eb6768be11d26a9d82c1bcecd503a9fdc7c883bda3bd627dea9ccb04fd31379c",
+    ),
+    (
+        "graphtrail",
+        "darwin-arm64",
+        "graphtrail-darwin-arm64",
+        11426112,
+        "20534dbbb84f134a5a892520fd5a695d2520c2e040733b5535e991c611c99686",
+    ),
+    (
+        "graphtrail",
+        "linux-amd64",
+        "graphtrail-linux-amd64",
+        12802256,
+        "e78c73a80a2eadbe297066739044e2c5fcdd187c8219198f453bd004bf9c9a55",
+    ),
+    (
+        "graphtrail",
+        "linux-arm64",
+        "graphtrail-linux-arm64",
+        12424560,
+        "7f961a4f018e4b12b9dcf5227a7cdc20fa7cdd9a723d96ec0336e254adf33c07",
+    ),
+    (
+        "graphtrail",
+        "windows-amd64",
+        "graphtrail-windows-amd64.exe",
+        10753536,
+        "1a9adc002c81661d2b0838e642f1c9db2671a2808c93e6b4499cfc2b33d6ea22",
+    ),
+    (
+        "graphtrail-mcp",
+        "darwin-amd64",
+        "graphtrail-mcp-darwin-amd64",
+        11004028,
+        "d8d605a522d3894c36a2f30e94cdcc99b87c34d05e53b01f4c47018eaebaf93f",
+    ),
+    (
+        "graphtrail-mcp",
+        "darwin-arm64",
+        "graphtrail-mcp-darwin-arm64",
+        10766928,
+        "649abe87a3e40415d1933db493c94f1049d84577a996df7ba9c27c4b3c4cf597",
+    ),
+    (
+        "graphtrail-mcp",
+        "linux-amd64",
+        "graphtrail-mcp-linux-amd64",
+        11981944,
+        "66606e4e394973766e1e91d3b0b78b26bd9077076cc85e62b9d0faf9780e7154",
+    ),
+    (
+        "graphtrail-mcp",
+        "linux-arm64",
+        "graphtrail-mcp-linux-arm64",
+        11609512,
+        "0bf17d38d44c5fc4f3132e17078a2db74e92da9bcb27a40c3d8345056523a651",
+    ),
+    (
+        "graphtrail-mcp",
+        "windows-amd64",
+        "graphtrail-mcp-windows-amd64.exe",
+        10020864,
+        "ec642c7e736fff1673c3d7e06d10eb02c9782008d8f783ab2b40699e69a35b08",
+    ),
+]
 
 MISELEDGER_V060_ASSETS = [
     (
@@ -128,6 +202,24 @@ def _full_miseledger_assets(component_id: str) -> dict:
     return assets
 
 
+def _graphtrail_asset(asset_name: str, byte_size: int, sha256: str) -> dict:
+    return {
+        "asset_name": asset_name,
+        "byte_size": byte_size,
+        "sha256": sha256,
+        "download_url": GRAPHTRAIL_BASE + asset_name,
+    }
+
+
+def _full_graphtrail_assets(component_id: str) -> dict:
+    assets: dict = {}
+    for comp, platform, asset_name, byte_size, sha256 in GRAPHTRAIL_V040_ASSETS:
+        if comp != component_id:
+            continue
+        assets[platform] = _graphtrail_asset(asset_name, byte_size, sha256)
+    return assets
+
+
 def _write_manifest(tmp_path: Path, **overrides) -> Path:
     payload = {
         "schema_version": 1,
@@ -138,14 +230,16 @@ def _write_manifest(tmp_path: Path, **overrides) -> Path:
             "graphtrail": _minimal_known_component(
                 component_revision=GRAPHTRAIL_SHA,
                 repository="escoffier-labs/graphtrail",
-                release_tag=None,
+                release_tag="v0.4.0",
                 executable="graphtrail",
+                assets=_full_graphtrail_assets("graphtrail"),
             ),
             "graphtrail-mcp": _minimal_known_component(
                 component_revision=GRAPHTRAIL_SHA,
                 repository="escoffier-labs/graphtrail",
-                release_tag=None,
+                release_tag="v0.4.0",
                 executable="graphtrail-mcp",
+                assets=_full_graphtrail_assets("graphtrail-mcp"),
             ),
             "miseledger": _minimal_known_component(assets=_full_miseledger_assets("miseledger")),
             "sessionfind": _minimal_known_component(
@@ -160,12 +254,12 @@ def _write_manifest(tmp_path: Path, **overrides) -> Path:
     return path
 
 
-def test_bundled_manifest_pins_miseledger_and_leaves_graphtrail_assets_unpublished():
+def test_bundled_manifest_pins_miseledger_and_graphtrail_assets():
     manifest = component_manifest.load()
 
     assert manifest.schema_version == 1
     assert manifest.brigade_version == "0.23.0"
-    assert manifest.manifest_revision
+    assert manifest.manifest_revision == "2026-07-19"
     assert manifest.supported_platforms == component_manifest.SUPPORTED_PLATFORMS
     assert set(manifest.components) == set(component_manifest.KNOWN_COMPONENT_IDS)
     assert manifest.components["miseledger"].component_revision == "v0.6.0"
@@ -175,10 +269,10 @@ def test_bundled_manifest_pins_miseledger_and_leaves_graphtrail_assets_unpublish
     assert asset.byte_size == 16441315
     assert asset.sha256 == "246893c8c39318f774fc7a06338b5a8e87bf84661b1951251b2c0c971e9a7a6c"
     assert asset.download_url.endswith("/miseledger-linux-amd64")
-    assert manifest.components["graphtrail"].assets == {}
-    assert manifest.components["graphtrail"].source.release_tag is None
-    assert manifest.components["graphtrail-mcp"].assets == {}
-    assert manifest.components["graphtrail-mcp"].source.release_tag is None
+    assert set(manifest.components["graphtrail"].assets) == set(component_manifest.SUPPORTED_PLATFORMS)
+    assert manifest.components["graphtrail"].source.release_tag == "v0.4.0"
+    assert set(manifest.components["graphtrail-mcp"].assets) == set(component_manifest.SUPPORTED_PLATFORMS)
+    assert manifest.components["graphtrail-mcp"].source.release_tag == "v0.4.0"
     assert manifest.unknown_component_diagnostics == ()
 
 
@@ -198,6 +292,21 @@ def test_bundled_manifest_pins_miseledger_v060_assets(component_id, platform, as
         assert asset_name.endswith(".exe")
     else:
         assert not asset_name.endswith(".exe")
+
+
+def test_bundled_manifest_pins_graphtrail_v040_assets():
+    manifest = component_manifest.load()
+    asset = manifest.components["graphtrail"].assets["linux-amd64"]
+    assert asset.byte_size == 12802256
+    assert asset.sha256 == "e78c73a80a2eadbe297066739044e2c5fcdd187c8219198f453bd004bf9c9a55"
+    assert manifest.components["graphtrail"].source.release_tag == "v0.4.0"
+
+
+def test_bundled_manifest_pins_graphtrail_mcp_v040_assets():
+    manifest = component_manifest.load()
+    asset = manifest.components["graphtrail-mcp"].assets["linux-amd64"]
+    assert asset.byte_size == 11981944
+    assert asset.sha256 == "66606e4e394973766e1e91d3b0b78b26bd9077076cc85e62b9d0faf9780e7154"
 
 
 def test_bundled_manifest_pins_graphtrail_to_git_sha():
@@ -481,10 +590,10 @@ def test_resolve_unknown_component_lists_known_components(tmp_path):
         component_manifest.resolve_asset(manifest, "missing", "linux-amd64")
 
 
-def test_resolve_unpublished_graphtrail_raises_unsupported_component_platform(tmp_path):
+def test_resolve_graphtrail_returns_pinned_asset(tmp_path):
     manifest = component_manifest.load(_write_manifest(tmp_path))
-    with pytest.raises(ValueError, match="unsupported-component-platform"):
-        component_manifest.resolve_asset(manifest, "graphtrail", "linux-amd64")
+    asset = component_manifest.resolve_asset(manifest, "graphtrail", "linux-amd64")
+    assert asset.asset_name == "graphtrail-linux-amd64"
 
 
 def test_resolve_miseledger_returns_pinned_asset(tmp_path):
@@ -538,8 +647,11 @@ def test_manifest_rejects_empty_sessionfind_assets(tmp_path):
         component_manifest.load(path)
 
 
-def test_manifest_rejects_graphtrail_revision_that_is_not_git_sha(tmp_path):
+def test_manifest_rejects_graphtrail_revision_that_is_not_git_sha(tmp_path, monkeypatch):
+    monkeypatch.setattr(component_manifest, "UNPUBLISHED_COMPONENT_IDS", frozenset({"graphtrail"}))
     base = json.loads(_write_manifest(tmp_path).read_text())
+    base["components"]["graphtrail"]["assets"] = {}
+    del base["components"]["graphtrail"]["source"]["release_tag"]
     base["components"]["graphtrail"]["component_revision"] = "unreleased"
     path = tmp_path / "bad.json"
     path.write_text(json.dumps(base))
@@ -556,9 +668,13 @@ def test_manifest_rejects_published_component_without_release_tag(tmp_path):
         component_manifest.load(path)
 
 
-def test_manifest_rejects_unpublished_component_with_release_tag(tmp_path):
+def test_manifest_rejects_unpublished_component_with_release_tag(tmp_path, monkeypatch):
+    monkeypatch.setattr(component_manifest, "UNPUBLISHED_COMPONENT_IDS", frozenset({"graphtrail"}))
     base = json.loads(_write_manifest(tmp_path).read_text())
     base["components"]["graphtrail"]["source"]["release_tag"] = "v0.1.0"
+    base["components"]["graphtrail"]["assets"] = {}
+    base["components"]["graphtrail-mcp"]["assets"] = {}
+    del base["components"]["graphtrail-mcp"]["source"]["release_tag"]
     path = tmp_path / "bad.json"
     path.write_text(json.dumps(base))
     with pytest.raises(ValueError, match="source.release_tag' must be omitted when assets are unpublished"):

--- a/tests/test_component_paths.py
+++ b/tests/test_component_paths.py
@@ -89,6 +89,7 @@ def test_component_paths_never_use_repo_brigade(tmp_path):
     env = {"HOME": str(tmp_path / "home"), "XDG_DATA_HOME": str(tmp_path / "xdg-data")}
     data = component_paths.data_root(env=env, system="linux")
     installed = component_paths.installed_state_path(data)
+    previous = component_paths.installed_previous_state_path(data)
     executable = component_paths.managed_executable_path(data, "miseledger")
     cached = component_paths.cached_asset_path(
         component_paths.cache_root(env=env, system="linux"),
@@ -97,8 +98,16 @@ def test_component_paths_never_use_repo_brigade(tmp_path):
     )
     assert ".brigade" not in installed
     assert str(installed).endswith("brigade/installed.json")
+    assert str(previous).endswith("brigade/installed.previous.json")
     assert str(executable).endswith("brigade/bin/miseledger")
     assert str(cached).endswith(f"brigade/components/{_VALID_SHA}/miseledger-linux-amd64")
+
+
+def test_installed_previous_state_path_uses_brigade_subdir():
+    env = {"HOME": "/home/alice"}
+    data = component_paths.data_root(env=env, system="linux")
+    path = component_paths.installed_previous_state_path(data)
+    assert path.endswith("brigade/installed.previous.json")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_component_state.py
+++ b/tests/test_component_state.py
@@ -1,0 +1,441 @@
+"""Tests for installed component state schema v1."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from brigade.component_state import (
+    InstalledComponentRecord,
+    InstalledState,
+    load_installed_state,
+    render_installed_state,
+    should_rotate_previous,
+    state_digest_map,
+)
+
+
+def _minimal_record(**overrides: object) -> dict[str, object]:
+    record: dict[str, object] = {
+        "component_revision": "v0.6.0",
+        "asset_name": "miseledger-linux-amd64",
+        "byte_size": 16441315,
+        "sha256": "a" * 64,
+        "download_url": "https://example.invalid/miseledger",
+        "executable": "/tmp/xdg-data/brigade/bin/miseledger",
+    }
+    record.update(overrides)
+    return record
+
+
+def _minimal_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_version": 1,
+        "brigade_version": "0.23.0",
+        "manifest_revision": "2026-07-18",
+        "platform": "linux-amd64",
+        "installed_at": "2026-07-19T06:00:00+00:00",
+        "components": {"miseledger": _minimal_record()},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _write_installed_state(path, payload: dict[str, object]) -> None:
+    path.write_text(json.dumps(payload))
+
+
+def _sample_state(
+    *,
+    sha256: str = "a" * 64,
+    manifest_revision: str = "2026-07-18",
+    installed_at: str = "2026-07-19T06:00:00+00:00",
+) -> InstalledState:
+    return InstalledState(
+        schema_version=1,
+        brigade_version="0.23.0",
+        manifest_revision=manifest_revision,
+        platform="linux-amd64",
+        installed_at=installed_at,
+        components={
+            "miseledger": InstalledComponentRecord(
+                component_revision="v0.6.0",
+                asset_name="miseledger-linux-amd64",
+                byte_size=16441315,
+                sha256=sha256,
+                download_url="https://github.com/escoffier-labs/miseledger/releases/download/v0.6.0/miseledger-linux-amd64",
+                executable="/tmp/xdg-data/brigade/bin/miseledger",
+            )
+        },
+    )
+
+
+def test_render_installed_state_round_trips_required_fields():
+    state = InstalledState(
+        schema_version=1,
+        brigade_version="0.23.0",
+        manifest_revision="2026-07-19",
+        platform="linux-amd64",
+        installed_at="2026-07-19T06:00:00+00:00",
+        components={
+            "miseledger": InstalledComponentRecord(
+                component_revision="v0.6.0",
+                asset_name="miseledger-linux-amd64",
+                byte_size=16441315,
+                sha256="246893c8c39318f774fc7a06338b5a8e87bf84661b1951251b2c0c971e9a7a6c",
+                download_url="https://github.com/escoffier-labs/miseledger/releases/download/v0.6.0/miseledger-linux-amd64",
+                executable="/tmp/xdg-data/brigade/bin/miseledger",
+            )
+        },
+    )
+    payload = render_installed_state(state)
+    assert payload["schema_version"] == 1
+    assert payload["brigade_version"] == "0.23.0"
+    assert payload["manifest_revision"] == "2026-07-19"
+    assert payload["platform"] == "linux-amd64"
+    assert payload["installed_at"] == "2026-07-19T06:00:00+00:00"
+    assert payload["components"]["miseledger"]["executable"].endswith("/brigade/bin/miseledger")
+    assert (
+        payload["components"]["miseledger"]["sha256"]
+        == "246893c8c39318f774fc7a06338b5a8e87bf84661b1951251b2c0c971e9a7a6c"
+    )
+
+
+def test_load_installed_state_round_trips(tmp_path):
+    state = InstalledState(
+        schema_version=1,
+        brigade_version="0.23.0",
+        manifest_revision="2026-07-18",
+        platform="linux-amd64",
+        installed_at="2026-07-19T06:00:00+00:00",
+        components={
+            "miseledger": InstalledComponentRecord(
+                component_revision="v0.6.0",
+                asset_name="miseledger-linux-amd64",
+                byte_size=16441315,
+                sha256="a" * 64,
+                download_url="https://example.invalid/miseledger",
+                executable="/tmp/xdg-data/brigade/bin/miseledger",
+            )
+        },
+    )
+    path = tmp_path / "installed.json"
+    path.write_text(
+        """{
+  "schema_version": 1,
+  "brigade_version": "0.23.0",
+  "manifest_revision": "2026-07-18",
+  "platform": "linux-amd64",
+  "installed_at": "2026-07-19T06:00:00+00:00",
+  "components": {
+    "miseledger": {
+      "component_revision": "v0.6.0",
+      "asset_name": "miseledger-linux-amd64",
+      "byte_size": 16441315,
+      "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "download_url": "https://example.invalid/miseledger",
+      "executable": "/tmp/xdg-data/brigade/bin/miseledger"
+    }
+  }
+}"""
+    )
+    loaded = load_installed_state(path)
+    assert loaded is not None
+    assert loaded == state
+
+
+def test_load_installed_state_missing_returns_none(tmp_path):
+    path = tmp_path / "installed.json"
+    assert load_installed_state(path) is None
+
+
+def test_load_installed_state_invalid_json_returns_none(tmp_path):
+    path = tmp_path / "installed.json"
+    path.write_text("not json")
+    assert load_installed_state(path) is None
+
+
+def test_load_installed_state_top_level_type_mismatch_returns_none(tmp_path):
+    path = tmp_path / "installed.json"
+    path.write_text("[]")
+    assert load_installed_state(path) is None
+
+
+def test_load_installed_state_missing_required_field_returns_none(tmp_path):
+    path = tmp_path / "installed.json"
+    path.write_text(
+        """{
+  "schema_version": 1,
+  "brigade_version": "0.23.0",
+  "platform": "linux-amd64",
+  "installed_at": "2026-07-19T06:00:00+00:00",
+  "components": {}
+}"""
+    )
+    assert load_installed_state(path) is None
+
+
+def test_load_installed_state_bad_component_record_returns_none(tmp_path):
+    path = tmp_path / "installed.json"
+    path.write_text(
+        """{
+  "schema_version": 1,
+  "brigade_version": "0.23.0",
+  "manifest_revision": "2026-07-18",
+  "platform": "linux-amd64",
+  "installed_at": "2026-07-19T06:00:00+00:00",
+  "components": {
+    "miseledger": {
+      "component_revision": "v0.6.0",
+      "asset_name": "miseledger-linux-amd64",
+      "byte_size": "not-an-int",
+      "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "download_url": "https://example.invalid/miseledger",
+      "executable": "/tmp/xdg-data/brigade/bin/miseledger"
+    }
+  }
+}"""
+    )
+    assert load_installed_state(path) is None
+
+
+def test_load_installed_state_bad_schema_version_returns_none(tmp_path):
+    path = tmp_path / "installed.json"
+    path.write_text(
+        """{
+  "schema_version": 2,
+  "brigade_version": "0.23.0",
+  "manifest_revision": "2026-07-18",
+  "platform": "linux-amd64",
+  "installed_at": "2026-07-19T06:00:00+00:00",
+  "components": {}
+}"""
+    )
+    assert load_installed_state(path) is None
+
+
+def test_load_installed_state_components_not_dict_returns_none(tmp_path):
+    path = tmp_path / "installed.json"
+    path.write_text(
+        """{
+  "schema_version": 1,
+  "brigade_version": "0.23.0",
+  "manifest_revision": "2026-07-18",
+  "platform": "linux-amd64",
+  "installed_at": "2026-07-19T06:00:00+00:00",
+  "components": []
+}"""
+    )
+    assert load_installed_state(path) is None
+
+
+def test_load_installed_state_empty_components_ok(tmp_path):
+    path = tmp_path / "installed.json"
+    _write_installed_state(path, _minimal_payload(components={}))
+    loaded = load_installed_state(path)
+    assert loaded is not None
+    assert loaded.components == {}
+
+
+def test_load_installed_state_rejects_unexpected_top_level_key(tmp_path):
+    path = tmp_path / "installed.json"
+    payload = _minimal_payload()
+    payload["extra"] = "nope"
+    _write_installed_state(path, payload)
+    assert load_installed_state(path) is None
+
+
+def test_load_installed_state_rejects_unexpected_record_key(tmp_path):
+    path = tmp_path / "installed.json"
+    record = _minimal_record()
+    record["extra"] = "nope"
+    _write_installed_state(path, _minimal_payload(components={"miseledger": record}))
+    assert load_installed_state(path) is None
+
+
+@pytest.mark.parametrize("schema_version", [True, "1", 1.0])
+def test_load_installed_state_rejects_invalid_schema_version_type(tmp_path, schema_version):
+    path = tmp_path / "installed.json"
+    _write_installed_state(path, _minimal_payload(schema_version=schema_version))
+    assert load_installed_state(path) is None
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["brigade_version", "manifest_revision", "installed_at"],
+)
+def test_load_installed_state_rejects_empty_top_level_strings(tmp_path, field):
+    path = tmp_path / "installed.json"
+    _write_installed_state(path, _minimal_payload(**{field: "   "}))
+    assert load_installed_state(path) is None
+
+
+def test_load_installed_state_rejects_invalid_platform(tmp_path):
+    path = tmp_path / "installed.json"
+    _write_installed_state(path, _minimal_payload(platform="freebsd-amd64"))
+    assert load_installed_state(path) is None
+
+
+@pytest.mark.parametrize("installed_at", ["not-a-timestamp", ""])
+def test_load_installed_state_rejects_invalid_installed_at(tmp_path, installed_at):
+    path = tmp_path / "installed.json"
+    _write_installed_state(path, _minimal_payload(installed_at=installed_at))
+    assert load_installed_state(path) is None
+
+
+def test_load_installed_state_accepts_zulu_installed_at(tmp_path):
+    path = tmp_path / "installed.json"
+    _write_installed_state(path, _minimal_payload(installed_at="2026-07-19T06:00:00.000000Z"))
+    loaded = load_installed_state(path)
+    assert loaded is not None
+    assert loaded.installed_at == "2026-07-19T06:00:00.000000Z"
+
+
+def test_load_installed_state_rejects_unknown_component_id(tmp_path):
+    path = tmp_path / "installed.json"
+    _write_installed_state(path, _minimal_payload(components={"unknown-tool": _minimal_record()}))
+    assert load_installed_state(path) is None
+
+
+def test_load_installed_state_rejects_empty_component_id(tmp_path):
+    path = tmp_path / "installed.json"
+    _write_installed_state(path, _minimal_payload(components={"": _minimal_record()}))
+    assert load_installed_state(path) is None
+
+
+@pytest.mark.parametrize("byte_size", [True, 0, -1])
+def test_load_installed_state_rejects_invalid_byte_size(tmp_path, byte_size):
+    path = tmp_path / "installed.json"
+    record = _minimal_record(byte_size=byte_size)
+    _write_installed_state(path, _minimal_payload(components={"miseledger": record}))
+    assert load_installed_state(path) is None
+
+
+@pytest.mark.parametrize(
+    "sha256",
+    ["A" * 64, "abc", "a" * 63, ""],
+)
+def test_load_installed_state_rejects_malformed_sha256(tmp_path, sha256):
+    path = tmp_path / "installed.json"
+    record = _minimal_record(sha256=sha256)
+    _write_installed_state(path, _minimal_payload(components={"miseledger": record}))
+    assert load_installed_state(path) is None
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["component_revision", "asset_name", "download_url", "executable"],
+)
+def test_load_installed_state_rejects_empty_record_strings(tmp_path, field):
+    path = tmp_path / "installed.json"
+    record = _minimal_record(**{field: "   "})
+    _write_installed_state(path, _minimal_payload(components={"miseledger": record}))
+    assert load_installed_state(path) is None
+
+
+def test_load_installed_state_single_component_does_not_require_all_ids(tmp_path):
+    path = tmp_path / "installed.json"
+    _write_installed_state(
+        path, _minimal_payload(components={"sessionfind": _minimal_record(asset_name="sessionfind-linux-amd64")})
+    )
+    loaded = load_installed_state(path)
+    assert loaded is not None
+    assert set(loaded.components) == {"sessionfind"}
+
+
+def test_state_digest_map_hashes_components():
+    state = _sample_state(sha256="b" * 64)
+    digest_map = state_digest_map(state)
+    assert digest_map == {"miseledger": "b" * 64}
+
+
+def test_state_digest_map_ignores_non_digest_fields():
+    state_a = _sample_state(sha256="b" * 64)
+    state_b = InstalledState(
+        schema_version=state_a.schema_version,
+        brigade_version=state_a.brigade_version,
+        manifest_revision=state_a.manifest_revision,
+        platform=state_a.platform,
+        installed_at=state_a.installed_at,
+        components={
+            "miseledger": InstalledComponentRecord(
+                component_revision="different",
+                asset_name=state_a.components["miseledger"].asset_name,
+                byte_size=state_a.components["miseledger"].byte_size + 1,
+                sha256="b" * 64,
+                download_url=state_a.components["miseledger"].download_url,
+                executable=state_a.components["miseledger"].executable,
+            )
+        },
+    )
+    assert state_digest_map(state_a) == state_digest_map(state_b)
+
+
+def test_should_rotate_previous_when_digest_changes():
+    current = _sample_state(sha256="a" * 64)
+    nxt = _sample_state(sha256="b" * 64)
+    assert should_rotate_previous(current, nxt) is True
+
+
+def test_should_rotate_previous_when_manifest_revision_changes():
+    current = _sample_state(manifest_revision="2026-07-18")
+    nxt = _sample_state(manifest_revision="2026-07-19")
+    assert should_rotate_previous(current, nxt) is True
+
+
+def test_should_not_rotate_previous_on_identical_digest_map():
+    current = _sample_state(sha256="a" * 64)
+    nxt = _sample_state(sha256="a" * 64, manifest_revision=current.manifest_revision)
+    assert should_rotate_previous(current, nxt) is False
+
+
+def test_should_not_rotate_previous_when_no_current_state():
+    nxt = _sample_state(sha256="a" * 64)
+    assert should_rotate_previous(None, nxt) is False
+
+
+def test_should_rotate_previous_when_component_set_changes():
+    current = _sample_state(sha256="a" * 64)
+    nxt = _sample_state(sha256="a" * 64)
+    nxt.components["graphtrail"] = InstalledComponentRecord(
+        component_revision="sha",
+        asset_name="graphtrail-linux-amd64",
+        byte_size=1,
+        sha256="c" * 64,
+        download_url="https://example.invalid/graphtrail",
+        executable="/tmp/xdg-data/brigade/bin/graphtrail",
+    )
+    assert should_rotate_previous(current, nxt) is True
+
+
+def test_should_rotate_previous_empty_next_different_from_current():
+    current = _sample_state(sha256="a" * 64)
+    nxt = InstalledState(
+        schema_version=current.schema_version,
+        brigade_version=current.brigade_version,
+        manifest_revision=current.manifest_revision,
+        platform=current.platform,
+        installed_at=current.installed_at,
+        components={},
+    )
+    assert should_rotate_previous(current, nxt) is True
+
+
+def test_installed_state_records_are_frozen():
+    record = InstalledComponentRecord(
+        component_revision="v0.6.0",
+        asset_name="miseledger-linux-amd64",
+        byte_size=1,
+        sha256="a" * 64,
+        download_url="https://example.invalid",
+        executable="/tmp/xdg-data/brigade/bin/miseledger",
+    )
+    with pytest.raises(AttributeError):
+        record.sha256 = "b" * 64
+
+
+def test_installed_state_is_frozen():
+    state = _sample_state()
+    with pytest.raises(AttributeError):
+        state.manifest_revision = "2026-07-20"


### PR DESCRIPTION
Closes #355

## Why

The existing setup path depended on unpinned Cargo and Go installs. A clean machine could not install the Phase 1 evidence tools without language toolchains, and the downloaded bytes were not tied to the installed Brigade release.

## What changed

- add `brigade setup` with `--dry-run`, `--offline`, and `--rollback`
- publish five-platform native asset pins for GraphTrail, GraphTrail MCP, MiseLedger, and sessionfind
- verify byte size and SHA-256 before caching, materializing, or executing an asset
- install through a digest-keyed user-local cache and atomic managed-path swaps
- smoke all four binaries by absolute managed path before writing installed state
- preserve one prior installed state for verified, network-free rollback
- keep the existing `brigade add` fallback installers available

## Verification

- `./scripts/verify`: 3,121 passed, 3 skipped, 82.15% coverage
- CI-equivalent content guard scan: exit 0, zero unresolved findings
- independent review of the full diff and download-hardening follow-up

## Review focus

The main risk surface is the install transaction in `component_install.py`: cache verification, failure restoration, and the two-state rollback swap.