### PR TITLE
fix(components): accept sessionfind help exit zero

### DIFF
--- a/docs/phase-355-pinned-component-setup.md
+++ b/docs/phase-355-pinned-component-setup.md
@@ -126,7 +126,7 @@ Prior path: `component_paths.installed_previous_state_path(data_root)` → `<dat
 | graphtrail | `<managed>/graphtrail --version` | exit 0, non-empty stdout |
 | graphtrail-mcp | `<managed>/graphtrail-mcp` JSON-RPC `initialize` on stdin | valid JSON-RPC response on stdout |
 | miseledger | `<managed>/miseledger version` | exit 0 |
-| sessionfind | `<managed>/sessionfind --help` | exit 2 with usage text in stdout or stderr |
+| sessionfind | `<managed>/sessionfind --help` | exit 0 with usage text in stdout or stderr |
 
 ## File Map
 
@@ -589,7 +589,7 @@ def test_run_post_install_smoke_invokes_absolute_paths_only(tmp_path):
     assert {cmd[0] for cmd in calls} == set(managed.values())
 ```
 
-- [ ] Implement smoke runner: `subprocess.run` with absolute argv[0], JSON-RPC stdin for graphtrail-mcp, accept exit 2 for sessionfind --help. Inject `runner` records argv then delegates to real `subprocess.run` so MCP JSON and sessionfind exit 2 are exercised.
+- [ ] Implement smoke runner: `subprocess.run` with absolute argv[0], JSON-RPC stdin for graphtrail-mcp, accept exit 0 for sessionfind --help. Inject `runner` records argv then delegates to real `subprocess.run` so MCP JSON and sessionfind exit 0 are exercised.
 - [ ] RED → GREEN.
 - [ ] Commit: `feat(components): add post-install smoke suite`.
 

--- a/src/brigade/component_install.py
+++ b/src/brigade/component_install.py
@@ -483,9 +483,9 @@ def _smoke_sessionfind(
     except OSError as exc:
         raise ComponentInstallError(f"sessionfind smoke failed to run {path}: {exc}") from exc
 
-    if completed.returncode != 2:
+    if completed.returncode != 0:
         raise ComponentInstallError(
-            f"sessionfind smoke failed: {path} --help exited {completed.returncode}, expected 2"
+            f"sessionfind smoke failed: {path} --help exited {completed.returncode}, expected 0"
         )
     combined = f"{completed.stdout or ''}{completed.stderr or ''}"
     if "usage" not in combined.lower():

--- a/tests/component_install_helpers.py
+++ b/tests/component_install_helpers.py
@@ -46,7 +46,7 @@ def smoke_stub_script(name: str) -> str:
     if name == "sessionfind":
         return (
             '#!/usr/bin/env python3\nimport sys\nif sys.argv[1:] == ["--help"]:\n'
-            '    print("usage: sessionfind [options]")\n    raise SystemExit(2)\nraise SystemExit(1)\n'
+            '    print("usage: sessionfind [options]")\n    raise SystemExit(0)\nraise SystemExit(1)\n'
         )
     raise ValueError(name)
 

--- a/tests/test_component_install.py
+++ b/tests/test_component_install.py
@@ -1096,18 +1096,23 @@ def test_run_post_install_smoke_rejects_miseledger_nonzero_exit(tmp_path):
         run_post_install_smoke(managed)
 
 
-def test_run_post_install_smoke_rejects_sessionfind_wrong_exit(tmp_path):
+def test_run_post_install_smoke_accepts_sessionfind_help_exit_zero(tmp_path):
     managed = _write_managed_smoke_stubs(tmp_path)
-    script = smoke_stub_script("sessionfind").replace("raise SystemExit(2)", "raise SystemExit(0)")
+    run_post_install_smoke(managed)
+
+
+def test_run_post_install_smoke_rejects_sessionfind_nonzero_exit(tmp_path):
+    managed = _write_managed_smoke_stubs(tmp_path)
+    script = smoke_stub_script("sessionfind").replace("raise SystemExit(0)", "raise SystemExit(2)", 1)
     managed["sessionfind"] = _write_managed_stub(tmp_path, "sessionfind", script=script)
-    with pytest.raises(ComponentInstallError, match="sessionfind smoke failed.*expected 2"):
+    with pytest.raises(ComponentInstallError, match="sessionfind smoke failed.*expected 0"):
         run_post_install_smoke(managed)
 
 
 def test_run_post_install_smoke_rejects_sessionfind_missing_usage(tmp_path):
     script = (
         '#!/usr/bin/env python3\nimport sys\nif sys.argv[1:] == ["--help"]:\n'
-        '    print("options only")\n    raise SystemExit(2)\nraise SystemExit(1)\n'
+        '    print("options only")\n    raise SystemExit(0)\nraise SystemExit(1)\n'
     )
     managed = _write_managed_smoke_stubs(tmp_path)
     managed["sessionfind"] = _write_managed_stub(tmp_path, "sessionfind", script=script)


### PR DESCRIPTION
Refs #355

## What changed

- Align the sessionfind post-install smoke with miseledger v0.6.0, where sessionfind --help exits 0.
- Keep the absolute managed-path invocation and usage-text check.
- Add success, nonzero-exit, and missing-usage regression coverage.
- Correct the reviewed phase spec to match the shipped binary contract.

## Verification

- Brigade full verification receipt: 20260719-123408-work-verify-21e15a
- Result: 3,122 passed, 3 skipped, 82.14% coverage
- Independent read-only review: no remaining findings

Clean-machine setup still needs to be rerun against a published package containing this fix before #355 can be accepted.