### PR TITLE
fix(components): accept sessionfind command help

### DIFF
--- a/docs/phase-355-pinned-component-setup.md
+++ b/docs/phase-355-pinned-component-setup.md
@@ -126,7 +126,7 @@ Prior path: `component_paths.installed_previous_state_path(data_root)` → `<dat
 | graphtrail | `<managed>/graphtrail --version` | exit 0, non-empty stdout |
 | graphtrail-mcp | `<managed>/graphtrail-mcp` JSON-RPC `initialize` on stdin | valid JSON-RPC response on stdout |
 | miseledger | `<managed>/miseledger version` | exit 0 |
-| sessionfind | `<managed>/sessionfind --help` | exit 0 with usage text in stdout or stderr |
+| sessionfind | `<managed>/sessionfind --help` | exit 0; command-syntax lines beginning with `sessionfind ` read from stdout, or legacy text containing `usage` read from stdout or stderr |
 
 ## File Map
 
@@ -247,7 +247,7 @@ def smoke_stub_script(name: str) -> str:
     if name == "miseledger":
         return '#!/usr/bin/env python3\nimport sys\nif sys.argv[1:] == ["version"]:\n    print("miseledger test 0.6.0")\n    raise SystemExit(0)\nraise SystemExit(1)\n'
     if name == "sessionfind":
-        return '#!/usr/bin/env python3\nimport sys\nif sys.argv[1:] == ["--help"]:\n    print("usage: sessionfind [options]")\n    raise SystemExit(2)\nraise SystemExit(1)\n'
+        return '#!/usr/bin/env python3\nimport sys\nif sys.argv[1:] == ["--help"]:\n    print("sessionfind list [--source KIND] ...")\n    print("sessionfind search <query> ...")\n    print("sessionfind <query> ...")\n    raise SystemExit(0)\nraise SystemExit(1)\n'
     raise ValueError(name)
 
 

--- a/src/brigade/component_install.py
+++ b/src/brigade/component_install.py
@@ -471,6 +471,13 @@ def _smoke_miseledger(
         raise ComponentInstallError(f"miseledger smoke failed: {path} version exited {completed.returncode}")
 
 
+def _sessionfind_help_is_valid(stdout: str, stderr: str) -> bool:
+    combined = f"{stdout}{stderr}"
+    if "usage" in combined.lower():
+        return True
+    return any(line.strip().startswith("sessionfind ") for line in stdout.splitlines())
+
+
 def _smoke_sessionfind(
     path: Path,
     run: Callable[..., subprocess.CompletedProcess[str]],
@@ -487,9 +494,10 @@ def _smoke_sessionfind(
         raise ComponentInstallError(
             f"sessionfind smoke failed: {path} --help exited {completed.returncode}, expected 0"
         )
-    combined = f"{completed.stdout or ''}{completed.stderr or ''}"
-    if "usage" not in combined.lower():
-        raise ComponentInstallError(f"sessionfind smoke failed: {path} --help produced no usage text")
+    stdout = completed.stdout or ""
+    stderr = completed.stderr or ""
+    if not _sessionfind_help_is_valid(stdout, stderr):
+        raise ComponentInstallError(f"sessionfind smoke failed: {path} --help produced no help text")
 
 
 def run_post_install_smoke(

--- a/tests/component_install_helpers.py
+++ b/tests/component_install_helpers.py
@@ -46,7 +46,10 @@ def smoke_stub_script(name: str) -> str:
     if name == "sessionfind":
         return (
             '#!/usr/bin/env python3\nimport sys\nif sys.argv[1:] == ["--help"]:\n'
-            '    print("usage: sessionfind [options]")\n    raise SystemExit(0)\nraise SystemExit(1)\n'
+            '    print("sessionfind list [--source KIND] ...")\n'
+            '    print("sessionfind search <query> ...")\n'
+            '    print("sessionfind <query> ...")\n'
+            "    raise SystemExit(0)\nraise SystemExit(1)\n"
         )
     raise ValueError(name)
 

--- a/tests/test_component_install.py
+++ b/tests/test_component_install.py
@@ -1096,8 +1096,23 @@ def test_run_post_install_smoke_rejects_miseledger_nonzero_exit(tmp_path):
         run_post_install_smoke(managed)
 
 
+SESSIONFIND_V060_HELP = (
+    "sessionfind list [--source KIND] ...\nsessionfind search <query> ...\nsessionfind <query> ...\n"
+)
+
+
 def test_run_post_install_smoke_accepts_sessionfind_help_exit_zero(tmp_path):
     managed = _write_managed_smoke_stubs(tmp_path)
+    run_post_install_smoke(managed)
+
+
+def test_run_post_install_smoke_accepts_sessionfind_v060_help_shape(tmp_path):
+    script = (
+        '#!/usr/bin/env python3\nimport sys\nif sys.argv[1:] == ["--help"]:\n'
+        f'    print({SESSIONFIND_V060_HELP!r}, end="")\n    raise SystemExit(0)\nraise SystemExit(1)\n'
+    )
+    managed = _write_managed_smoke_stubs(tmp_path)
+    managed["sessionfind"] = _write_managed_stub(tmp_path, "sessionfind", script=script)
     run_post_install_smoke(managed)
 
 
@@ -1109,14 +1124,14 @@ def test_run_post_install_smoke_rejects_sessionfind_nonzero_exit(tmp_path):
         run_post_install_smoke(managed)
 
 
-def test_run_post_install_smoke_rejects_sessionfind_missing_usage(tmp_path):
+def test_run_post_install_smoke_rejects_sessionfind_missing_help(tmp_path):
     script = (
         '#!/usr/bin/env python3\nimport sys\nif sys.argv[1:] == ["--help"]:\n'
         '    print("options only")\n    raise SystemExit(0)\nraise SystemExit(1)\n'
     )
     managed = _write_managed_smoke_stubs(tmp_path)
     managed["sessionfind"] = _write_managed_stub(tmp_path, "sessionfind", script=script)
-    with pytest.raises(ComponentInstallError, match="sessionfind smoke failed.*no usage text"):
+    with pytest.raises(ComponentInstallError, match="sessionfind smoke failed.*no help text"):
         run_post_install_smoke(managed)
 
 


### PR DESCRIPTION
Refs #355

## Root cause

sessionfind v0.6.0 exits successfully for `--help` and prints command-syntax lines, but it does not include the literal word `usage`. The 0.23.2 smoke check rejected that healthy output and rolled back setup.

## Change

- Accept exit-0 help when stdout contains a line beginning with `sessionfind `.
- Keep legacy `usage` text support and reject empty or unrelated output.
- Update the regression fixtures and Phase 355 smoke contract to match the released binary.

## Verification

- Brigade full verification receipt `20260719-140456-work-verify-a2a625`: 3,123 passed, 3 skipped, 82.15% coverage.
- Independent read-only Opus review: no correctness findings.
- Clean Windows reproduction confirmed exit 0, 271 stdout bytes, no stderr, and no literal `usage`.