### PR TITLE
feat: report managed component state

### DIFF
--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -66,6 +66,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade tokens`: 3 command path(s)
 - `brigade tools`: 48 command path(s)
 - `brigade untrusted` (extras): 2 command path(s)
+- `brigade version`: 1 command path(s)
 - `brigade work`: 144 command path(s)
 - `brigade workflow` (extras): 3 command path(s)
 
@@ -520,6 +521,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade tools sync plan`
 - `brigade untrusted scan` (extras)
 - `brigade untrusted wrap` (extras)
+- `brigade version`
 - `brigade work acceptance`
 - `brigade work backup closeout`
 - `brigade work backup contract`

--- a/src/brigade/cli/__init__.py
+++ b/src/brigade/cli/__init__.py
@@ -26,6 +26,7 @@ from .. import extras as _extras_mod
 from . import (
     init as _init_group,
     doctor as _doctor_group,
+    version as _version_group,
     status as _status_group,
     profiles as _profiles_group,
     receipts as _receipts_group,
@@ -125,6 +126,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     _init_group.register(sub)
     _doctor_group.register(sub)
+    _version_group.register(sub)
     _status_group.register(sub)
     _profiles_group.register(sub)
     _receipts_group.register(sub)

--- a/src/brigade/cli/_common.py
+++ b/src/brigade/cli/_common.py
@@ -14,7 +14,18 @@ import argparse
 COMMAND_GROUPS: list[tuple[str, list[str]]] = [
     (
         "Core memory loop",
-        ["init", "handoff", "handoff-template", "ingest", "memory", "doctor", "status", "profiles", "receipts"],
+        [
+            "init",
+            "handoff",
+            "handoff-template",
+            "ingest",
+            "memory",
+            "doctor",
+            "version",
+            "status",
+            "profiles",
+            "receipts",
+        ],
     ),
     (
         "Daily operator loop",

--- a/src/brigade/cli/version.py
+++ b/src/brigade/cli/version.py
@@ -1,0 +1,24 @@
+"""brigade version command group."""
+
+from __future__ import annotations
+
+import argparse
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p_version = sub.add_parser("version", help="Show Brigade version.")
+    p_version.add_argument(
+        "--components",
+        action="store_true",
+        help="Report managed native component installation state.",
+    )
+    p_version.add_argument("--json", action="store_true", help="Emit machine-readable JSON instead of text.")
+    p_version.set_defaults(func=dispatch)
+
+
+def dispatch(args) -> int:
+    if args.json and not args.components:
+        args._brigade_parser.error("--json requires --components")
+    from .. import version_cmd
+
+    return version_cmd.run(components=args.components, json_output=args.json)

--- a/src/brigade/component_report.py
+++ b/src/brigade/component_report.py
@@ -1,0 +1,532 @@
+"""Read-only inspection of pinned native Brigade components."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+import brigade
+from brigade import component_install, component_manifest, component_paths, component_state, localio
+
+ComponentStatus = Literal["healthy", "missing", "stale", "corrupt", "unsupported"]
+STATE_FILE_STATUS = Literal["missing", "valid", "corrupt"]
+
+# Deterministic precedence: first matching condition wins.
+STATUS_PRECEDENCE: tuple[ComponentStatus, ...] = (
+    "unsupported",
+    "corrupt",
+    "stale",
+    "missing",
+    "healthy",
+)
+
+
+@dataclass(frozen=True)
+class ComponentInspection:
+    component_id: str
+    status: ComponentStatus
+    detail: str
+    expected_component_revision: str | None
+    installed_component_revision: str | None
+    expected_asset_name: str | None
+    expected_byte_size: int | None
+    expected_sha256: str | None
+    installed_asset_name: str | None
+    installed_byte_size: int | None
+    installed_sha256: str | None
+    recorded_executable: str | None
+    managed_executable_path: str
+    actual_byte_size: int | None
+    actual_sha256: str | None
+    path_binary: str | None
+
+
+@dataclass(frozen=True)
+class ComponentReport:
+    brigade_version: str
+    manifest_schema_version: int | None
+    manifest_revision: str | None
+    manifest_brigade_version: str | None
+    manifest_path: str
+    platform: str | None
+    platform_error: str | None
+    state_schema_version: int
+    installed_state_path: str
+    state_file_status: STATE_FILE_STATUS
+    installed_manifest_revision: str | None
+    installed_brigade_version: str | None
+    installed_platform: str | None
+    manifest_unknown_diagnostics: tuple[str, ...]
+    components: tuple[ComponentInspection, ...]
+
+
+_UNAVAILABLE_DATA_ROOT = "<unavailable>"
+
+
+def inspect_components(
+    *,
+    env: Mapping[str, str] | None = None,
+    system: str | None = None,
+    manifest_path: Path | None = None,
+) -> ComponentReport:
+    """Inspect managed native components without mutating user data."""
+    environment = dict(env if env is not None else os.environ)
+    manifest_source = manifest_path or component_manifest.manifest_path()
+    manifest_unknown: tuple[str, ...] = ()
+    manifest_schema_version: int | None = None
+    manifest_revision: str | None = None
+    manifest_brigade_version: str | None = None
+    manifest: component_manifest.ComponentManifest | None = None
+    try:
+        manifest = component_manifest.load(manifest_source)
+    except ValueError as exc:
+        return _environment_blocked_report(
+            manifest_source=manifest_source,
+            platform_error=str(exc),
+            manifest=None,
+        )
+    manifest_schema_version = manifest.schema_version
+    manifest_revision = manifest.manifest_revision
+    manifest_brigade_version = manifest.brigade_version
+    manifest_unknown = manifest.unknown_component_diagnostics
+
+    roots: component_install.SetupRoots | None = None
+    environment_error: str | None = None
+    try:
+        roots = component_install.resolve_roots(env=environment, system=system)
+    except ValueError as exc:
+        environment_error = str(exc)
+
+    platform: str | None = None
+    platform_error: str | None = environment_error
+    if environment_error is None:
+        try:
+            platform = component_manifest.platform_key(system=system)
+        except ValueError as exc:
+            platform_error = str(exc)
+
+    if roots is None:
+        return _environment_blocked_report(
+            manifest_source=manifest_source,
+            platform_error=platform_error or "component environment is unavailable",
+            manifest=manifest,
+            manifest_unknown_diagnostics=manifest_unknown,
+        )
+
+    state_path = Path(component_paths.installed_state_path(roots.data_root))
+    installed_state, state_file_status = _read_installed_state(state_path)
+
+    inspections: list[ComponentInspection] = []
+    for component_id in component_manifest.KNOWN_COMPONENT_IDS:
+        inspections.append(
+            _inspect_component(
+                component_id,
+                manifest=manifest,
+                platform=platform,
+                platform_error=platform_error,
+                roots=roots,
+                installed_state=installed_state,
+                state_file_status=state_file_status,
+                env=environment,
+            )
+        )
+
+    return ComponentReport(
+        brigade_version=brigade.__version__,
+        manifest_schema_version=manifest_schema_version,
+        manifest_revision=manifest_revision,
+        manifest_brigade_version=manifest_brigade_version,
+        manifest_path=str(manifest_source),
+        platform=platform,
+        platform_error=platform_error,
+        state_schema_version=component_state.SCHEMA_VERSION,
+        installed_state_path=str(state_path),
+        state_file_status=state_file_status,
+        installed_manifest_revision=installed_state.manifest_revision if installed_state else None,
+        installed_brigade_version=installed_state.brigade_version if installed_state else None,
+        installed_platform=installed_state.platform if installed_state else None,
+        manifest_unknown_diagnostics=manifest_unknown,
+        components=tuple(inspections),
+    )
+
+
+def _environment_blocked_report(
+    *,
+    manifest_source: Path,
+    platform_error: str,
+    manifest: component_manifest.ComponentManifest | None,
+    manifest_unknown_diagnostics: tuple[str, ...] = (),
+) -> ComponentReport:
+    """Return a read-only unsupported report when roots or manifest cannot be resolved."""
+    state_path = Path(component_paths.installed_state_path(_UNAVAILABLE_DATA_ROOT))
+    components = tuple(
+        ComponentInspection(
+            component_id=component_id,
+            status="unsupported",
+            detail=platform_error,
+            expected_component_revision=(
+                manifest.components[component_id].component_revision if manifest is not None else None
+            ),
+            installed_component_revision=None,
+            expected_asset_name=None,
+            expected_byte_size=None,
+            expected_sha256=None,
+            installed_asset_name=None,
+            installed_byte_size=None,
+            installed_sha256=None,
+            recorded_executable=None,
+            managed_executable_path=component_paths.managed_executable_path(
+                _UNAVAILABLE_DATA_ROOT,
+                component_id,
+            ),
+            actual_byte_size=None,
+            actual_sha256=None,
+            path_binary=None,
+        )
+        for component_id in component_manifest.KNOWN_COMPONENT_IDS
+    )
+    return ComponentReport(
+        brigade_version=brigade.__version__,
+        manifest_schema_version=manifest.schema_version if manifest is not None else None,
+        manifest_revision=manifest.manifest_revision if manifest is not None else None,
+        manifest_brigade_version=manifest.brigade_version if manifest is not None else None,
+        manifest_path=str(manifest_source),
+        platform=None,
+        platform_error=platform_error,
+        state_schema_version=component_state.SCHEMA_VERSION,
+        installed_state_path=str(state_path),
+        state_file_status="missing",
+        installed_manifest_revision=None,
+        installed_brigade_version=None,
+        installed_platform=None,
+        manifest_unknown_diagnostics=manifest_unknown_diagnostics,
+        components=components,
+    )
+
+
+def doctor_checks(
+    *,
+    env: Mapping[str, str] | None = None,
+    system: str | None = None,
+    manifest_path: Path | None = None,
+) -> list[tuple[str, str, str]]:
+    """Return doctor check tuples for managed component inspection."""
+    from .doctor import FAIL, INFO
+
+    report = inspect_components(env=env, system=system, manifest_path=manifest_path)
+    checks: list[tuple[str, str, str]] = []
+    if report.manifest_schema_version is None:
+        checks.append((FAIL, "components: manifest", report.platform_error or "manifest could not be loaded"))
+        return checks
+    for diagnostic in report.manifest_unknown_diagnostics:
+        checks.append((INFO, "components: manifest", diagnostic))
+    if report.platform is None and report.platform_error:
+        checks.append((INFO, "components: platform", report.platform_error))
+    for component in report.components:
+        checks.append(
+            (_doctor_severity(component, report), f"components: {component.component_id}", _doctor_detail(component))
+        )
+    return checks
+
+
+def render_text(report: ComponentReport) -> str:
+    lines = [f"brigade {report.brigade_version}"]
+    if report.manifest_schema_version is not None:
+        lines.append(f"manifest schema {report.manifest_schema_version} (revision {report.manifest_revision})")
+    else:
+        lines.append(f"manifest: {report.platform_error}")
+    if report.platform is not None:
+        lines.append(f"platform: {report.platform}")
+    elif report.platform_error:
+        lines.append(f"platform: unsupported ({report.platform_error})")
+    lines.append("")
+    for component in report.components:
+        lines.append(f"{component.component_id}: {component.status}")
+        if component.expected_component_revision is not None:
+            lines.append(f"  expected revision: {component.expected_component_revision}")
+        if component.installed_component_revision is not None:
+            lines.append(f"  installed revision: {component.installed_component_revision}")
+        if component.expected_asset_name is not None:
+            lines.append(f"  expected asset: {component.expected_asset_name}")
+        if component.expected_byte_size is not None and component.expected_sha256 is not None:
+            lines.append(f"  expected size: {component.expected_byte_size} sha256: {component.expected_sha256}")
+        if component.installed_asset_name is not None:
+            lines.append(f"  installed asset: {component.installed_asset_name}")
+        if component.installed_byte_size is not None and component.installed_sha256 is not None:
+            lines.append(f"  installed size: {component.installed_byte_size} sha256: {component.installed_sha256}")
+        if component.recorded_executable is not None:
+            lines.append(f"  recorded executable: {component.recorded_executable}")
+        lines.append(f"  managed executable: {component.managed_executable_path}")
+        if component.actual_byte_size is not None:
+            lines.append(f"  actual size: {component.actual_byte_size}")
+        if component.actual_sha256 is not None:
+            lines.append(f"  actual sha256: {component.actual_sha256}")
+        if component.path_binary is not None:
+            lines.append(f"  path binary: {component.path_binary}")
+        if component.detail:
+            lines.append(f"  detail: {component.detail}")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def render_json(report: ComponentReport) -> dict[str, Any]:
+    return {
+        "brigade_version": report.brigade_version,
+        "manifest": {
+            "schema_version": report.manifest_schema_version,
+            "revision": report.manifest_revision,
+            "brigade_version": report.manifest_brigade_version,
+            "path": report.manifest_path,
+            "unknown_component_diagnostics": list(report.manifest_unknown_diagnostics),
+        },
+        "platform": report.platform,
+        "platform_error": report.platform_error,
+        "installed_state": {
+            "schema_version": report.state_schema_version,
+            "path": report.installed_state_path,
+            "state_file_status": report.state_file_status,
+            "manifest_revision": report.installed_manifest_revision,
+            "brigade_version": report.installed_brigade_version,
+            "platform": report.installed_platform,
+        },
+        "status_precedence": list(STATUS_PRECEDENCE),
+        "components": [
+            {
+                "component_id": component.component_id,
+                "status": component.status,
+                "detail": component.detail,
+                "expected_component_revision": component.expected_component_revision,
+                "installed_component_revision": component.installed_component_revision,
+                "expected_asset_name": component.expected_asset_name,
+                "expected_byte_size": component.expected_byte_size,
+                "expected_sha256": component.expected_sha256,
+                "installed_asset_name": component.installed_asset_name,
+                "installed_byte_size": component.installed_byte_size,
+                "installed_sha256": component.installed_sha256,
+                "recorded_executable": component.recorded_executable,
+                "managed_executable_path": component.managed_executable_path,
+                "actual_byte_size": component.actual_byte_size,
+                "actual_sha256": component.actual_sha256,
+                "path_binary": component.path_binary,
+            }
+            for component in report.components
+        ],
+    }
+
+
+def _read_installed_state(path: Path) -> tuple[component_state.InstalledState | None, STATE_FILE_STATUS]:
+    if not path.exists():
+        return None, "missing"
+    state = component_state.load_installed_state(path)
+    if state is None:
+        return None, "corrupt"
+    return state, "valid"
+
+
+def _path_binary(executable: str, managed_path: str, env: Mapping[str, str]) -> str | None:
+    try:
+        found = shutil.which(executable, path=env.get("PATH"))
+        if found is None:
+            return None
+        resolved_managed = str(Path(managed_path).resolve())
+        resolved_found = str(Path(found).resolve())
+    except OSError:
+        return None
+    if resolved_found == resolved_managed:
+        return None
+    return resolved_found
+
+
+def _inspect_component(
+    component_id: str,
+    *,
+    manifest: component_manifest.ComponentManifest,
+    platform: str | None,
+    platform_error: str | None,
+    roots: component_install.SetupRoots,
+    installed_state: component_state.InstalledState | None,
+    state_file_status: STATE_FILE_STATUS,
+    env: Mapping[str, str],
+) -> ComponentInspection:
+    component = manifest.components[component_id]
+    managed_path = component_paths.managed_executable_path(roots.data_root, component_id)
+    path_binary = _path_binary(component.executable, managed_path, env)
+    asset: component_manifest.ComponentAsset | None = None
+    asset_error: str | None = None
+    if platform is not None:
+        try:
+            asset = component_manifest.resolve_asset(manifest, component_id, platform)
+        except ValueError as exc:
+            asset_error = str(exc)
+
+    managed_file = Path(managed_path)
+    managed_exists = False
+    actual_byte_size: int | None = None
+    actual_sha256: str | None = None
+    file_inspection_error: str | None = None
+    try:
+        managed_exists = managed_file.is_file()
+        if managed_exists:
+            actual_byte_size = managed_file.stat().st_size
+            actual_sha256 = localio.file_sha256(managed_file)
+    except OSError as exc:
+        file_inspection_error = str(exc)
+        managed_exists = True
+
+    installed_record = installed_state.components.get(component_id) if installed_state is not None else None
+    status, detail = _diagnose_component(
+        platform=platform,
+        platform_error=platform_error,
+        asset=asset,
+        asset_error=asset_error,
+        state_file_status=state_file_status,
+        installed_state=installed_state,
+        installed_record=installed_record,
+        expected_revision=component.component_revision,
+        expected_executable=managed_path,
+        manifest_revision=manifest.manifest_revision,
+        managed_exists=managed_exists,
+        actual_byte_size=actual_byte_size,
+        actual_sha256=actual_sha256,
+        managed_path=managed_path,
+        file_inspection_error=file_inspection_error,
+    )
+    return ComponentInspection(
+        component_id=component_id,
+        status=status,
+        detail=detail,
+        expected_component_revision=component.component_revision,
+        installed_component_revision=installed_record.component_revision if installed_record else None,
+        expected_asset_name=asset.asset_name if asset is not None else None,
+        expected_byte_size=asset.byte_size if asset is not None else None,
+        expected_sha256=asset.sha256 if asset is not None else None,
+        installed_asset_name=installed_record.asset_name if installed_record else None,
+        installed_byte_size=installed_record.byte_size if installed_record else None,
+        installed_sha256=installed_record.sha256 if installed_record else None,
+        recorded_executable=installed_record.executable if installed_record else None,
+        managed_executable_path=managed_path,
+        actual_byte_size=actual_byte_size,
+        actual_sha256=actual_sha256,
+        path_binary=path_binary,
+    )
+
+
+def _diagnose_component(
+    *,
+    platform: str | None,
+    platform_error: str | None,
+    asset: component_manifest.ComponentAsset | None,
+    asset_error: str | None,
+    state_file_status: STATE_FILE_STATUS,
+    installed_state: component_state.InstalledState | None,
+    installed_record: component_state.InstalledComponentRecord | None,
+    expected_revision: str,
+    expected_executable: str,
+    manifest_revision: str,
+    managed_exists: bool,
+    actual_byte_size: int | None,
+    actual_sha256: str | None,
+    managed_path: str,
+    file_inspection_error: str | None = None,
+) -> tuple[ComponentStatus, str]:
+    findings: dict[ComponentStatus, str] = {}
+
+    if file_inspection_error is not None:
+        findings["corrupt"] = f"managed executable is unreadable: {file_inspection_error}"
+
+    if platform is None:
+        findings["unsupported"] = platform_error or "host platform is unsupported"
+    elif asset is None:
+        findings["unsupported"] = asset_error or f"no asset for platform {platform!r}"
+
+    if state_file_status == "corrupt":
+        findings["corrupt"] = "installed.json exists but is invalid"
+
+    if state_file_status == "missing" and managed_exists:
+        findings["corrupt"] = "managed executable exists without installed.json"
+    if state_file_status == "valid" and installed_record is None and managed_exists:
+        findings["corrupt"] = "managed executable exists but component is absent from installed state"
+
+    if managed_exists and asset is not None and file_inspection_error is None:
+        if actual_byte_size != asset.byte_size:
+            findings["corrupt"] = (
+                f"byte_size mismatch for {managed_path}: expected {asset.byte_size}, got {actual_byte_size}"
+            )
+        elif actual_sha256 != asset.sha256:
+            findings["corrupt"] = f"sha256 mismatch for {managed_path}: expected {asset.sha256}, got {actual_sha256}"
+
+    if installed_state is not None and platform is not None and installed_state.platform != platform:
+        findings["unsupported"] = (
+            f"installed state platform {installed_state.platform!r} does not match host {platform!r}"
+        )
+
+    if installed_state is not None and installed_state.manifest_revision != manifest_revision:
+        findings["stale"] = (
+            f"installed manifest revision {installed_state.manifest_revision!r} != expected {manifest_revision!r}"
+        )
+    if installed_record is not None and installed_record.component_revision != expected_revision:
+        findings["stale"] = (
+            f"installed component revision {installed_record.component_revision!r} != expected {expected_revision!r}"
+        )
+    if installed_record is not None and asset is not None:
+        stale_metadata: list[str] = []
+        if installed_record.asset_name != asset.asset_name:
+            stale_metadata.append(
+                f"installed asset name {installed_record.asset_name!r} != expected {asset.asset_name!r}"
+            )
+        if installed_record.byte_size != asset.byte_size:
+            stale_metadata.append(f"installed byte size {installed_record.byte_size} != expected {asset.byte_size}")
+        if installed_record.sha256 != asset.sha256:
+            stale_metadata.append("installed sha256 does not match manifest asset")
+        if installed_record.executable != expected_executable:
+            stale_metadata.append(
+                f"recorded executable {installed_record.executable!r} != expected {expected_executable!r}"
+            )
+        if stale_metadata:
+            findings["stale"] = "; ".join(stale_metadata)
+
+    if state_file_status == "missing" and installed_record is None and not managed_exists:
+        findings["missing"] = "not installed"
+    elif state_file_status == "valid" and installed_record is None and not managed_exists:
+        findings["missing"] = "component not present in installed state"
+    elif not managed_exists and "corrupt" not in findings and "stale" not in findings:
+        findings["missing"] = f"managed executable missing: {managed_path}"
+
+    if not findings:
+        findings["healthy"] = "installed and verified"
+
+    for status in STATUS_PRECEDENCE:
+        if status in findings:
+            return status, findings[status]
+    return "healthy", findings["healthy"]
+
+
+def _doctor_severity(component: ComponentInspection, report: ComponentReport) -> str:
+    from .doctor import FAIL, INFO, MANUAL, OK, WARN
+
+    if component.status == "healthy":
+        return OK
+    if component.status == "missing":
+        return MANUAL
+    if component.status == "stale":
+        return WARN
+    if component.status == "corrupt":
+        return FAIL
+    if component.status == "unsupported":
+        if report.state_file_status == "corrupt":
+            return FAIL
+        if report.installed_platform is not None and report.platform is not None:
+            if report.installed_platform != report.platform:
+                return FAIL
+        return INFO
+    return WARN
+
+
+def _doctor_detail(component: ComponentInspection) -> str:
+    expected = component.expected_component_revision or "unknown"
+    installed = component.installed_component_revision or "none"
+    return f"expected revision {expected}, installed revision {installed}; {component.detail}"

--- a/src/brigade/doctor.py
+++ b/src/brigade/doctor.py
@@ -226,10 +226,12 @@ def run(target: Path, harness: str = "generic", *, json_output: bool = False, fu
 
 
 def _gather_checks(ctx: DoctorContext) -> List[CheckResult]:
+    from . import component_report
     from .registry import all_stations
     from . import managed
 
     checks: List[CheckResult] = []
+    checks.extend(component_report.doctor_checks())
     missing_tools: List[Tuple[str, str]] = []
     for station in all_stations():
         if station.doctor is not None:
@@ -841,7 +843,7 @@ _MARKERS = {
 # Checks about host-global state rather than this specific repo. Grouping them
 # under their own header keeps a single-repo run from reading as if the repo
 # itself is responsible for an unrelated OpenClaw config or content-guard clone.
-_MACHINE_LEVEL_PREFIXES = ("openclaw:",)
+_MACHINE_LEVEL_PREFIXES = ("openclaw:", "components:")
 _MACHINE_LEVEL_NAMES = {"guard: embedded content guard", "managed tools"}
 
 

--- a/src/brigade/version_cmd.py
+++ b/src/brigade/version_cmd.py
@@ -1,0 +1,20 @@
+"""`brigade version` - report Brigade and managed component versions."""
+
+from __future__ import annotations
+
+import json
+
+import brigade
+from brigade import component_report
+
+
+def run(*, components: bool = False, json_output: bool = False) -> int:
+    if not components:
+        print(f"brigade {brigade.__version__}")
+        return 0
+    report = component_report.inspect_components()
+    if json_output:
+        print(json.dumps(component_report.render_json(report), indent=2, sort_keys=True))
+    else:
+        print(component_report.render_text(report), end="")
+    return 0

--- a/tests/test_component_report.py
+++ b/tests/test_component_report.py
@@ -1,0 +1,509 @@
+"""Tests for managed component reporting."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+import brigade
+from brigade import cli, component_manifest, component_paths, component_report, component_state, doctor as doctor_mod
+from brigade.component_install import resolve_roots, setup_native_components
+from brigade.install import install_selection
+from brigade.selection import Selection
+
+from tests.component_install_helpers import (
+    FakeOpener,
+    all_fixture_payloads,
+    fixture_payload,
+    linux_env,
+    test_component_revision as fixture_component_revision,
+    write_test_manifest,
+)
+
+
+def _install_fixture_manifest(tmp_path: Path, monkeypatch) -> dict[str, str]:
+    env = linux_env(tmp_path)
+    manifest_path = tmp_path / "manifest-v1.json"
+    write_test_manifest(manifest_path, brigade_version=brigade.__version__)
+    monkeypatch.setattr(component_manifest, "manifest_path", lambda: manifest_path)
+    monkeypatch.setattr(component_manifest, "platform_key", lambda **_kwargs: "linux-amd64")
+    isolated_bin = tmp_path / "isolated-bin"
+    isolated_bin.mkdir()
+    env["PATH"] = str(isolated_bin)
+    for key in ("HOME", "XDG_DATA_HOME", "XDG_CACHE_HOME", "PATH"):
+        monkeypatch.setenv(key, env[key])
+    localappdata = tmp_path / "localappdata"
+    localappdata.mkdir(parents=True, exist_ok=True)
+    env["LOCALAPPDATA"] = str(localappdata)
+    monkeypatch.setenv("LOCALAPPDATA", env["LOCALAPPDATA"])
+    return env
+
+
+def _managed_paths(env: dict[str, str]) -> dict[str, Path]:
+    roots = resolve_roots(env=env, system="linux")
+    return {
+        component_id: Path(component_paths.managed_executable_path(roots.data_root, component_id))
+        for component_id in component_manifest.KNOWN_COMPONENT_IDS
+    }
+
+
+def _write_healthy_install(env: dict[str, str], manifest_path: Path) -> None:
+    manifest = component_manifest.load(manifest_path)
+    roots = resolve_roots(env=env, system="linux")
+    components: dict[str, component_state.InstalledComponentRecord] = {}
+    for component_id in component_manifest.KNOWN_COMPONENT_IDS:
+        asset = component_manifest.resolve_asset(manifest, component_id, "linux-amd64")
+        payload, _, _ = fixture_payload(component_id)
+        managed_path = Path(component_paths.managed_executable_path(roots.data_root, component_id))
+        managed_path.parent.mkdir(parents=True, exist_ok=True)
+        managed_path.write_bytes(payload)
+        managed_path.chmod(0o755)
+        components[component_id] = component_state.InstalledComponentRecord(
+            component_revision=fixture_component_revision(component_id),
+            asset_name=asset.asset_name,
+            byte_size=asset.byte_size,
+            sha256=asset.sha256,
+            download_url=asset.download_url,
+            executable=str(managed_path),
+        )
+    state = component_state.InstalledState(
+        schema_version=component_state.SCHEMA_VERSION,
+        brigade_version=brigade.__version__,
+        manifest_revision=manifest.manifest_revision,
+        platform="linux-amd64",
+        installed_at="2026-07-19T12:00:00+00:00",
+        components=components,
+    )
+    component_state.write_installed_state(
+        Path(component_paths.installed_state_path(roots.data_root)),
+        state,
+    )
+
+
+def test_status_precedence_is_documented_and_stable():
+    assert component_report.STATUS_PRECEDENCE == (
+        "unsupported",
+        "corrupt",
+        "stale",
+        "missing",
+        "healthy",
+    )
+
+
+def test_plain_version_matches_global_flag(capsys):
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["--version"])
+    assert exc.value.code == 0
+    global_out = capsys.readouterr().out
+    capsys.readouterr()
+    assert cli.main(["version"]) == 0
+    command_out = capsys.readouterr().out
+    assert command_out == global_out == f"brigade {brigade.__version__}\n"
+
+
+def test_version_json_requires_components():
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["version", "--json"])
+    assert exc.value.code == 2
+
+
+def test_version_components_missing_state(tmp_path, monkeypatch, capsys):
+    _install_fixture_manifest(tmp_path, monkeypatch)
+    capsys.readouterr()
+    assert cli.main(["version", "--components"]) == 0
+    out = capsys.readouterr().out
+    assert out.startswith(f"brigade {brigade.__version__}\n")
+    assert "platform: linux-amd64" in out
+    for component_id in component_manifest.KNOWN_COMPONENT_IDS:
+        assert f"{component_id}: missing" in out
+
+
+def test_version_components_json_is_single_document(tmp_path, monkeypatch, capsys):
+    _install_fixture_manifest(tmp_path, monkeypatch)
+    capsys.readouterr()
+    assert cli.main(["version", "--components", "--json"]) == 0
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert payload["brigade_version"] == brigade.__version__
+    assert payload["manifest"]["schema_version"] == 1
+    assert payload["platform"] == "linux-amd64"
+    assert payload["status_precedence"] == list(component_report.STATUS_PRECEDENCE)
+    assert len(payload["components"]) == len(component_manifest.KNOWN_COMPONENT_IDS)
+    assert all(item["status"] == "missing" for item in payload["components"])
+    assert all("expected_asset_name" in item for item in payload["components"])
+    assert all("asset_name" not in item for item in payload["components"])
+
+
+def test_healthy_install_reports_all_components(tmp_path, monkeypatch):
+    env = _install_fixture_manifest(tmp_path, monkeypatch)
+    manifest_path = component_manifest.manifest_path()
+    _write_healthy_install(env, manifest_path)
+    report = component_report.inspect_components(env=env, system="linux")
+    assert report.state_file_status == "valid"
+    assert all(component.status == "healthy" for component in report.components)
+    assert all(component.actual_byte_size is not None for component in report.components)
+    assert all(component.actual_sha256 is not None for component in report.components)
+
+
+def test_setup_native_then_inspect_reports_healthy(tmp_path, monkeypatch):
+    env = linux_env(tmp_path)
+    manifest_path = tmp_path / "manifest-v1.json"
+    write_test_manifest(manifest_path, brigade_version=brigade.__version__)
+    monkeypatch.setattr(component_manifest, "manifest_path", lambda: manifest_path)
+    monkeypatch.setattr(component_manifest, "platform_key", lambda **_kwargs: "linux-amd64")
+    for key in ("HOME", "XDG_DATA_HOME", "XDG_CACHE_HOME"):
+        monkeypatch.setenv(key, env[key])
+    assert setup_native_components(env=env, opener=FakeOpener(all_fixture_payloads())) == 0
+    report = component_report.inspect_components(env=env, system="linux")
+    assert report.state_file_status == "valid"
+    assert all(component.status == "healthy" for component in report.components)
+    assert all(component.expected_asset_name is not None for component in report.components)
+
+
+def test_healthy_install_recorded_executable_matches_setup_native_components(tmp_path, monkeypatch):
+    env = _install_fixture_manifest(tmp_path, monkeypatch)
+    manifest_path = component_manifest.manifest_path()
+    _write_healthy_install(env, manifest_path)
+    roots = resolve_roots(env=env, system="linux")
+    report = component_report.inspect_components(env=env, system="linux")
+    for component_id in component_manifest.KNOWN_COMPONENT_IDS:
+        managed_path = component_paths.managed_executable_path(roots.data_root, component_id)
+        component = next(item for item in report.components if item.component_id == component_id)
+        assert component.recorded_executable == str(managed_path)
+        assert component.status == "healthy"
+
+
+def test_stale_manifest_revision(tmp_path, monkeypatch):
+    env = _install_fixture_manifest(tmp_path, monkeypatch)
+    manifest_path = component_manifest.manifest_path()
+    _write_healthy_install(env, manifest_path)
+    roots = resolve_roots(env=env, system="linux")
+    state_path = Path(component_paths.installed_state_path(roots.data_root))
+    state = component_state.load_installed_state(state_path)
+    assert state is not None
+    stale = component_state.InstalledState(
+        schema_version=state.schema_version,
+        brigade_version=state.brigade_version,
+        manifest_revision="stale-revision",
+        platform=state.platform,
+        installed_at=state.installed_at,
+        components=state.components,
+    )
+    component_state.write_installed_state(state_path, stale)
+    report = component_report.inspect_components(env=env, system="linux")
+    assert all(component.status == "stale" for component in report.components)
+
+
+def test_corrupt_invalid_installed_json(tmp_path, monkeypatch):
+    env = _install_fixture_manifest(tmp_path, monkeypatch)
+    roots = resolve_roots(env=env, system="linux")
+    state_path = Path(component_paths.installed_state_path(roots.data_root))
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text("{not-json", encoding="utf-8")
+    report = component_report.inspect_components(env=env, system="linux")
+    assert report.state_file_status == "corrupt"
+    assert all(component.status == "corrupt" for component in report.components)
+
+
+def test_corrupt_managed_executable_hash(tmp_path, monkeypatch):
+    env = _install_fixture_manifest(tmp_path, monkeypatch)
+    manifest_path = component_manifest.manifest_path()
+    _write_healthy_install(env, manifest_path)
+    paths = _managed_paths(env)
+    paths["graphtrail"].write_bytes(b"wrong-bytes")
+    report = component_report.inspect_components(env=env, system="linux")
+    by_id = {component.component_id: component for component in report.components}
+    assert by_id["graphtrail"].status == "corrupt"
+    assert by_id["miseledger"].status == "healthy"
+
+
+def test_corrupt_managed_executable_read_error(tmp_path, monkeypatch):
+    env = _install_fixture_manifest(tmp_path, monkeypatch)
+    manifest_path = component_manifest.manifest_path()
+    _write_healthy_install(env, manifest_path)
+
+    def raise_os_error(_path):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(component_report.localio, "file_sha256", raise_os_error)
+    report = component_report.inspect_components(env=env, system="linux")
+    assert all(component.status == "corrupt" for component in report.components)
+    assert all("permission denied" in component.detail for component in report.components)
+
+
+def test_unsupported_platform(tmp_path, monkeypatch):
+    env = _install_fixture_manifest(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        component_manifest,
+        "platform_key",
+        lambda **_kwargs: (_ for _ in ()).throw(ValueError("unsupported platform solaris-sparc")),
+    )
+    report = component_report.inspect_components(env=env, system="linux")
+    assert report.platform is None
+    assert all(component.status == "unsupported" for component in report.components)
+
+
+def test_inspect_components_unsupported_system(tmp_path, monkeypatch):
+    env = _install_fixture_manifest(tmp_path, monkeypatch)
+    report = component_report.inspect_components(env=env, system="solaris")
+    assert report.platform is None
+    assert "unsupported component path platform system" in (report.platform_error or "")
+    assert len(report.components) == len(component_manifest.KNOWN_COMPONENT_IDS)
+    assert all(component.status == "unsupported" for component in report.components)
+
+
+def test_inspect_components_missing_data_root(tmp_path, monkeypatch):
+    env = _install_fixture_manifest(tmp_path, monkeypatch)
+    env = {key: value for key, value in env.items() if key != "HOME"}
+    report = component_report.inspect_components(env=env, system="linux")
+    assert report.platform is None
+    assert report.platform_error == "component data root requires HOME"
+    assert report.state_file_status == "missing"
+    assert len(report.components) == len(component_manifest.KNOWN_COMPONENT_IDS)
+    assert all(component.status == "unsupported" for component in report.components)
+
+
+def test_unsupported_asset_for_platform(tmp_path, monkeypatch):
+    env = _install_fixture_manifest(tmp_path, monkeypatch)
+    original_resolve = component_manifest.resolve_asset
+
+    def fake_resolve(manifest, component_id, platform):
+        if component_id == "graphtrail":
+            raise ValueError("unsupported-component-platform: component 'graphtrail' has no pinned native asset")
+        return original_resolve(manifest, component_id, platform)
+
+    monkeypatch.setattr(component_manifest, "resolve_asset", fake_resolve)
+    report = component_report.inspect_components(env=env, system="linux")
+    by_id = {component.component_id: component for component in report.components}
+    assert by_id["graphtrail"].status == "unsupported"
+    assert by_id["miseledger"].status == "missing"
+
+
+def test_path_binary_is_reported_without_satisfying_install(tmp_path, monkeypatch):
+    env = _install_fixture_manifest(tmp_path, monkeypatch)
+    path_bin = tmp_path / "bin"
+    path_bin.mkdir()
+    payload, _, _ = fixture_payload("graphtrail")
+    shim = path_bin / "graphtrail"
+    shim.write_bytes(payload)
+    shim.chmod(0o755)
+    env = dict(env)
+    env["PATH"] = f"{path_bin}{os.pathsep}{env.get('PATH', '')}"
+    report = component_report.inspect_components(env=env, system="linux")
+    graphtrail = next(item for item in report.components if item.component_id == "graphtrail")
+    assert graphtrail.status == "missing"
+    assert graphtrail.path_binary == str(shim.resolve())
+
+
+def test_path_binary_oserror_returns_none(tmp_path, monkeypatch):
+    env = _install_fixture_manifest(tmp_path, monkeypatch)
+
+    def raise_os_error(*_args, **_kwargs):
+        raise OSError("bad path resolution")
+
+    monkeypatch.setattr(component_report.shutil, "which", raise_os_error)
+    report = component_report.inspect_components(env=env, system="linux")
+    assert all(component.path_binary is None for component in report.components)
+
+
+def test_precedence_corrupt_before_stale(tmp_path, monkeypatch):
+    env = _install_fixture_manifest(tmp_path, monkeypatch)
+    manifest_path = component_manifest.manifest_path()
+    _write_healthy_install(env, manifest_path)
+    paths = _managed_paths(env)
+    paths["graphtrail"].write_bytes(b"tampered")
+    roots = resolve_roots(env=env, system="linux")
+    state_path = Path(component_paths.installed_state_path(roots.data_root))
+    state = component_state.load_installed_state(state_path)
+    assert state is not None
+    stale = component_state.InstalledState(
+        schema_version=state.schema_version,
+        brigade_version=state.brigade_version,
+        manifest_revision="stale-revision",
+        platform=state.platform,
+        installed_at=state.installed_at,
+        components=state.components,
+    )
+    component_state.write_installed_state(state_path, stale)
+    report = component_report.inspect_components(env=env, system="linux")
+    graphtrail = next(item for item in report.components if item.component_id == "graphtrail")
+    assert graphtrail.status == "corrupt"
+
+
+def test_stale_asset_name(tmp_path, monkeypatch):
+    env = _install_fixture_manifest(tmp_path, monkeypatch)
+    manifest_path = component_manifest.manifest_path()
+    _write_healthy_install(env, manifest_path)
+    roots = resolve_roots(env=env, system="linux")
+    state_path = Path(component_paths.installed_state_path(roots.data_root))
+    state = component_state.load_installed_state(state_path)
+    assert state is not None
+    graphtrail = state.components["graphtrail"]
+    stale_components = dict(state.components)
+    stale_components["graphtrail"] = component_state.InstalledComponentRecord(
+        component_revision=graphtrail.component_revision,
+        asset_name="graphtrail-linux-amd64-stale",
+        byte_size=graphtrail.byte_size,
+        sha256=graphtrail.sha256,
+        download_url=graphtrail.download_url,
+        executable=graphtrail.executable,
+    )
+    stale = component_state.InstalledState(
+        schema_version=state.schema_version,
+        brigade_version=state.brigade_version,
+        manifest_revision=state.manifest_revision,
+        platform=state.platform,
+        installed_at=state.installed_at,
+        components=stale_components,
+    )
+    component_state.write_installed_state(state_path, stale)
+    report = component_report.inspect_components(env=env, system="linux")
+    graphtrail_report = next(item for item in report.components if item.component_id == "graphtrail")
+    assert graphtrail_report.status == "stale"
+    assert graphtrail_report.installed_asset_name == "graphtrail-linux-amd64-stale"
+    assert "installed asset name" in graphtrail_report.detail
+
+
+def test_stale_recorded_executable(tmp_path, monkeypatch):
+    env = _install_fixture_manifest(tmp_path, monkeypatch)
+    manifest_path = component_manifest.manifest_path()
+    _write_healthy_install(env, manifest_path)
+    roots = resolve_roots(env=env, system="linux")
+    state_path = Path(component_paths.installed_state_path(roots.data_root))
+    state = component_state.load_installed_state(state_path)
+    assert state is not None
+    graphtrail = state.components["graphtrail"]
+    stale_components = dict(state.components)
+    stale_components["graphtrail"] = component_state.InstalledComponentRecord(
+        component_revision=graphtrail.component_revision,
+        asset_name=graphtrail.asset_name,
+        byte_size=graphtrail.byte_size,
+        sha256=graphtrail.sha256,
+        download_url=graphtrail.download_url,
+        executable="graphtrail-stale",
+    )
+    stale = component_state.InstalledState(
+        schema_version=state.schema_version,
+        brigade_version=state.brigade_version,
+        manifest_revision=state.manifest_revision,
+        platform=state.platform,
+        installed_at=state.installed_at,
+        components=stale_components,
+    )
+    component_state.write_installed_state(state_path, stale)
+    report = component_report.inspect_components(env=env, system="linux")
+    graphtrail_report = next(item for item in report.components if item.component_id == "graphtrail")
+    assert graphtrail_report.status == "stale"
+    assert graphtrail_report.recorded_executable == "graphtrail-stale"
+    assert "recorded executable" in graphtrail_report.detail
+
+
+def test_doctor_component_checks_human_and_json(tmp_target: Path, tmp_path, monkeypatch, capsys):
+    install_selection(
+        tmp_target,
+        Selection(depth="workspace", harnesses=["claude"], owner="claude", includes=[]),
+    )
+    env = _install_fixture_manifest(tmp_path, monkeypatch)
+    manifest_path = component_manifest.manifest_path()
+    _write_healthy_install(env, manifest_path)
+    checks = component_report.doctor_checks(env=env, system="linux")
+    assert all(status == doctor_mod.OK for status, _name, _detail in checks)
+    capsys.readouterr()
+    assert doctor_mod.run(target=tmp_target, harness="generic", json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    component_checks = [item for item in payload["checks"] if item["name"].startswith("components:")]
+    assert component_checks
+    assert all(item["status"] == doctor_mod.OK for item in component_checks)
+    assert all(item["scope"] == "machine" for item in component_checks)
+
+
+def test_doctor_missing_is_manual_and_stale_is_warn(tmp_path, monkeypatch):
+    env = _install_fixture_manifest(tmp_path, monkeypatch)
+    checks = component_report.doctor_checks(env=env, system="linux")
+    assert all(status == doctor_mod.MANUAL for status, _name, _detail in checks)
+
+    manifest_path = component_manifest.manifest_path()
+    _write_healthy_install(env, manifest_path)
+    roots = resolve_roots(env=env, system="linux")
+    state_path = Path(component_paths.installed_state_path(roots.data_root))
+    state = component_state.load_installed_state(state_path)
+    assert state is not None
+    stale = component_state.InstalledState(
+        schema_version=state.schema_version,
+        brigade_version=state.brigade_version,
+        manifest_revision="stale-revision",
+        platform=state.platform,
+        installed_at=state.installed_at,
+        components=state.components,
+    )
+    component_state.write_installed_state(state_path, stale)
+    checks = component_report.doctor_checks(env=env, system="linux")
+    assert all(status == doctor_mod.WARN for status, _name, _detail in checks)
+
+
+def test_doctor_corrupt_is_fail(tmp_path, monkeypatch):
+    env = _install_fixture_manifest(tmp_path, monkeypatch)
+    roots = resolve_roots(env=env, system="linux")
+    state_path = Path(component_paths.installed_state_path(roots.data_root))
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text('{"schema_version": "bad"}', encoding="utf-8")
+    checks = component_report.doctor_checks(env=env, system="linux")
+    assert all(status == doctor_mod.FAIL for status, _name, _detail in checks)
+
+
+def test_doctor_unsupported_platform_is_advisory(tmp_path, monkeypatch):
+    env = _install_fixture_manifest(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        component_manifest,
+        "platform_key",
+        lambda **_kwargs: (_ for _ in ()).throw(ValueError("unsupported platform solaris-sparc")),
+    )
+    checks = component_report.doctor_checks(env=env, system="linux")
+    platform_checks = [item for item in checks if item[1] == "components: platform"]
+    component_checks = [
+        item for item in checks if item[1].startswith("components:") and item[1] != "components: platform"
+    ]
+    assert platform_checks and platform_checks[0][0] == doctor_mod.INFO
+    assert all(status == doctor_mod.INFO for status, _name, _detail in component_checks)
+
+
+def test_doctor_missing_data_root_is_advisory(tmp_path, monkeypatch):
+    env = _install_fixture_manifest(tmp_path, monkeypatch)
+    env = {key: value for key, value in env.items() if key != "HOME"}
+    checks = component_report.doctor_checks(env=env, system="linux")
+    component_checks = [item for item in checks if item[1].startswith("components:")]
+    assert component_checks
+    assert all(status == doctor_mod.INFO for status, _name, _detail in component_checks)
+
+
+def test_doctor_invalid_managed_platform_state_fails(tmp_path, monkeypatch):
+    env = _install_fixture_manifest(tmp_path, monkeypatch)
+    manifest_path = component_manifest.manifest_path()
+    _write_healthy_install(env, manifest_path)
+    roots = resolve_roots(env=env, system="linux")
+    state_path = Path(component_paths.installed_state_path(roots.data_root))
+    state = component_state.load_installed_state(state_path)
+    assert state is not None
+    wrong_platform = component_state.InstalledState(
+        schema_version=state.schema_version,
+        brigade_version=state.brigade_version,
+        manifest_revision=state.manifest_revision,
+        platform="darwin-amd64",
+        installed_at=state.installed_at,
+        components=state.components,
+    )
+    component_state.write_installed_state(state_path, wrong_platform)
+    checks = component_report.doctor_checks(env=env, system="linux")
+    assert all(status == doctor_mod.FAIL for status, _name, _detail in checks if _name.startswith("components:"))
+
+
+def test_doctor_detail_includes_expected_and_installed_revisions(tmp_path, monkeypatch):
+    env = _install_fixture_manifest(tmp_path, monkeypatch)
+    checks = component_report.doctor_checks(env=env, system="linux")
+    assert checks
+    _status, _name, detail = checks[0]
+    assert "expected revision" in detail
+    assert "installed revision none" in detail


### PR DESCRIPTION
## Summary

- Add `brigade version` with compatible default output and human or JSON managed-component reports.
- Diagnose healthy, missing, stale, corrupt, and unsupported native component installations from pinned manifest and installed state.
- Add machine-scoped component checks to `brigade doctor` without changing failure behavior for optional missing tools.
- Regenerate the command inventory for the new public command.

## Verification

- `./scripts/verify` via Brigade receipt `20260719-161637-work-verify-a9f99a`: 3,151 passed, 3 skipped, 82.18% coverage.
- `brigade roadmap commands --check` via receipt `20260719-161516-work-verify-2c9e1e`: passed.
- Independent Opus review completed; its command-inventory blocker and two exception/performance recommendations were addressed.

Closes #356