### PR TITLE
feat: add Windows native acceptance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,3 +231,16 @@ jobs:
           if (-not (Test-Path (Join-Path $target "tools/antislop.md"))) { throw "missing antislop tool" }
           if (-not (Test-Path (Join-Path $target "INSTALL_FOR_AGENTS.md"))) { throw "missing full-kit guide" }
           if (-not (Test-Path (Join-Path $target "rules/issue-tdd-loop.md"))) { throw "missing issue/TDD rule" }
+
+  windows-native-acceptance:
+    name: windows-native-acceptance
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Run Windows native acceptance (source install)
+        shell: powershell
+        run: |
+          & "${{ github.workspace }}\scripts\windows-native-acceptance.ps1" -InstallMode source -RepoRoot "${{ github.workspace }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,3 +58,21 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+
+  windows-native-acceptance:
+    name: windows-native-acceptance
+    needs: build-and-publish
+    if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Run Windows native acceptance (published CLI)
+        shell: powershell
+        env:
+          BRIGADE_VERSION: ${{ github.ref_name }}
+        run: |
+          $version = $env:BRIGADE_VERSION.Substring(1)
+          & "${{ github.workspace }}\scripts\windows-native-acceptance.ps1" -InstallMode pypi -BrigadeVersion $version

--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,8 @@ Thumbs.db
 /USER.md
 /hooks/
 /memory/
-/scripts/
+/scripts/*
+!/scripts/windows-native-acceptance.ps1
 /skills/
 
 # Local plan/spec scratch dirs only. Reviewed planning artifacts ARE

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,9 +22,9 @@ you did not observe.
 
 CI-only jobs still cover work that is slower, platform-oriented, or depends on
 extra checkout/install context: `content-guard`, `repo-metadata`,
-`install-from-source`, and `quickstart-smoke`. The local `./scripts/verify`
-gate is the fast completion gate; do not treat it as a replacement for those
-CI-only release and public-repo checks.
+`install-from-source`, `quickstart-smoke`, and `windows-native-acceptance`.
+The local `./scripts/verify` gate is the fast completion gate; do not treat it
+as a replacement for those CI-only release and public-repo checks.
 
 Setup, if `.venv/` is missing:
 

--- a/scripts/windows-native-acceptance.ps1
+++ b/scripts/windows-native-acceptance.ps1
@@ -96,7 +96,7 @@ function Initialize-PipxBootstrap {
         [string]$BootstrapRoot
     )
     $bootstrapVenv = Join-Path $BootstrapRoot "bootstrap-venv"
-    & $SystemPython -m venv $bootstrapVenv
+    $null = & $SystemPython -m venv $bootstrapVenv
     if ($LASTEXITCODE -ne 0) {
         throw "bootstrap venv creation failed"
     }
@@ -104,7 +104,7 @@ function Initialize-PipxBootstrap {
     if (-not (Test-Path $bootstrapPython)) {
         throw "bootstrap python missing at $bootstrapPython"
     }
-    & $bootstrapPython -m pip install --upgrade pip pipx
+    & $bootstrapPython -m pip install --upgrade pip pipx 2>&1 | Out-Host
     if ($LASTEXITCODE -ne 0) {
         throw "bootstrap pip/pipx install failed"
     }

--- a/scripts/windows-native-acceptance.ps1
+++ b/scripts/windows-native-acceptance.ps1
@@ -1,0 +1,541 @@
+#requires -Version 5.1
+<#
+.SYNOPSIS
+    Windows native component acceptance for Brigade issue #357 Phase 1.
+#>
+param(
+    [Parameter(Mandatory = $false)]
+    [ValidateSet("source", "pypi")]
+    [string]$InstallMode = "source",
+
+    [Parameter(Mandatory = $false)]
+    [string]$BrigadeVersion = "",
+
+    [Parameter(Mandatory = $false)]
+    [string]$RepoRoot = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+function Write-Step {
+    param([string]$Message)
+    Write-Host "==> $Message"
+}
+
+function Assert-CommandPresent {
+    param([string]$Name)
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        throw "$Name must resolve on PATH during acceptance"
+    }
+}
+
+function Assert-CommandMissing {
+    param([string]$Name)
+    if (Get-Command $Name -ErrorAction SilentlyContinue) {
+        throw "$Name must not be available on PATH during acceptance"
+    }
+}
+
+function Save-EnvSnapshot {
+    param([string[]]$Names)
+    $snapshot = @{}
+    foreach ($name in $Names) {
+        $item = Get-Item -Path "Env:$name" -ErrorAction SilentlyContinue
+        if ($item) {
+            $snapshot[$name] = $item.Value
+        }
+        else {
+            $snapshot[$name] = $null
+        }
+    }
+    return $snapshot
+}
+
+function Restore-EnvSnapshot {
+    param([hashtable]$Snapshot)
+    foreach ($entry in $Snapshot.GetEnumerator()) {
+        if ($null -eq $entry.Value) {
+            Remove-Item -Path ("Env:{0}" -f $entry.Key) -ErrorAction SilentlyContinue
+        }
+        else {
+            Set-Item -Path ("Env:{0}" -f $entry.Key) -Value $entry.Value
+        }
+    }
+}
+
+function Get-PythonExeDir {
+    param([string]$PythonExe = "python")
+    $python = Get-Command $PythonExe -ErrorAction Stop
+    return (Split-Path -Parent $python.Source)
+}
+
+function Get-PythonScriptsDir {
+    param([string]$PythonExe = "python")
+    $scriptDir = & $PythonExe -c "import sysconfig; print(sysconfig.get_path('scripts'))"
+    if (-not $scriptDir) {
+        throw "unable to resolve Python scripts directory"
+    }
+    return $scriptDir.Trim()
+}
+
+function Get-PipxBinDir {
+    param([string]$BootstrapPython)
+    if ($env:PIPX_BIN_DIR) {
+        return $env:PIPX_BIN_DIR
+    }
+    $binDir = & $BootstrapPython -m pipx environment --value PIPX_BIN_DIR 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $binDir) {
+        return $null
+    }
+    return $binDir.Trim()
+}
+
+function Initialize-PipxBootstrap {
+    param(
+        [string]$SystemPython,
+        [string]$BootstrapRoot
+    )
+    $bootstrapVenv = Join-Path $BootstrapRoot "bootstrap-venv"
+    & $SystemPython -m venv $bootstrapVenv
+    if ($LASTEXITCODE -ne 0) {
+        throw "bootstrap venv creation failed"
+    }
+    $bootstrapPython = Join-Path $bootstrapVenv "Scripts\python.exe"
+    if (-not (Test-Path $bootstrapPython)) {
+        throw "bootstrap python missing at $bootstrapPython"
+    }
+    & $bootstrapPython -m pip install --upgrade pip pipx
+    if ($LASTEXITCODE -ne 0) {
+        throw "bootstrap pip/pipx install failed"
+    }
+    return $bootstrapPython
+}
+
+function Invoke-Pipx {
+    param(
+        [string]$BootstrapPython,
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [string[]]$PipxArgs
+    )
+    & $BootstrapPython -m pipx @PipxArgs
+}
+
+function Remove-BrigadePipxInstall {
+    param([string]$BootstrapPython)
+    Invoke-Pipx -BootstrapPython $BootstrapPython uninstall brigade-cli 2>$null | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        Invoke-Pipx -BootstrapPython $BootstrapPython uninstall brigade 2>$null | Out-Null
+    }
+}
+
+function Get-BoundedStderr {
+    param(
+        [string]$Path,
+        [int]$MaxChars = 2000
+    )
+    if (-not (Test-Path $Path)) {
+        return ""
+    }
+    $text = (Get-Content -LiteralPath $Path -Raw -ErrorAction SilentlyContinue)
+    if (-not $text) {
+        return ""
+    }
+    $text = $text.Trim()
+    if ($text.Length -le $MaxChars) {
+        return $text
+    }
+    return $text.Substring(0, $MaxChars) + "..."
+}
+
+function Invoke-ExternalCommand {
+    param(
+        [scriptblock]$Command,
+        [string]$FailureMessage,
+        [string]$StderrRoot = ""
+    )
+    if (-not $StderrRoot) {
+        $StderrRoot = [System.IO.Path]::GetTempPath()
+    }
+    $stderrFile = Join-Path $StderrRoot ("brigade-accept-stderr-{0}.txt" -f [guid]::NewGuid().ToString("N"))
+    try {
+        $stdout = & $Command 2> $stderrFile
+        $exitCode = $LASTEXITCODE
+        if ($exitCode -ne 0) {
+            $stderr = Get-BoundedStderr -Path $stderrFile
+            if ($stderr) {
+                throw "$FailureMessage (exit $exitCode): $stderr"
+            }
+            throw "$FailureMessage (exit $exitCode)"
+        }
+        return $stdout
+    }
+    finally {
+        Remove-Item -LiteralPath $stderrFile -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Get-BrigadeCliVersion {
+    $raw = Invoke-ExternalCommand -Command { & brigade --version } -FailureMessage "brigade --version failed"
+    $line = ($raw | Select-Object -First 1).ToString().Trim()
+    if ($line -match '^brigade\s+(.+)$') {
+        return $Matches[1].Trim()
+    }
+    throw "unrecognized brigade --version output: $line"
+}
+
+function Assert-BrigadeVersionMatches {
+    param([string]$Expected)
+    $installed = Get-BrigadeCliVersion
+    if ($installed -ne $Expected) {
+        throw "installed brigade version mismatch: expected $Expected, got $installed"
+    }
+}
+
+function Install-BrigadeFromSource {
+    param(
+        [string]$Root,
+        [string]$BootstrapPython
+    )
+    Write-Step "Installing Brigade from source at $Root"
+    Remove-BrigadePipxInstall -BootstrapPython $BootstrapPython
+    Push-Location $Root
+    try {
+        Invoke-Pipx -BootstrapPython $BootstrapPython install .
+        if ($LASTEXITCODE -ne 0) { throw "pipx install from source failed" }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+function Install-BrigadeFromPyPI {
+    param(
+        [string]$Version,
+        [string]$BootstrapPython
+    )
+    if (-not $Version) {
+        throw "BrigadeVersion is required when InstallMode is pypi"
+    }
+    Write-Step "Installing brigade-cli==$Version from PyPI"
+
+    $maxAttempts = 36
+    $installed = $false
+    for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+        $releaseReady = $false
+        try {
+            $response = Invoke-RestMethod -Uri "https://pypi.org/pypi/brigade-cli/json" -Method Get -UseBasicParsing
+            $releaseNames = @($response.releases.PSObject.Properties.Name)
+            if ($releaseNames -contains $Version) {
+                $releaseReady = $true
+            }
+        }
+        catch {
+            # retry until timeout
+        }
+
+        if ($releaseReady) {
+            Remove-BrigadePipxInstall -BootstrapPython $BootstrapPython
+            Invoke-Pipx -BootstrapPython $BootstrapPython install "brigade-cli==$Version"
+            if ($LASTEXITCODE -eq 0) {
+                $installed = $true
+                break
+            }
+            Remove-BrigadePipxInstall -BootstrapPython $BootstrapPython
+        }
+        Start-Sleep -Seconds 10
+    }
+    if (-not $installed) {
+        throw "timed out installing brigade-cli==$Version from PyPI"
+    }
+}
+
+function Set-AcceptancePath {
+    param(
+        [string]$PythonExeDir,
+        [string]$PythonScripts,
+        [string]$PipxBinDir
+    )
+    $paths = New-Object System.Collections.Generic.List[string]
+    $paths.Add($PythonExeDir)
+    $paths.Add($PythonScripts)
+    if ($PipxBinDir) {
+        $paths.Add($PipxBinDir)
+    }
+    $git = Get-Command git -ErrorAction SilentlyContinue
+    if ($git) {
+        $paths.Add((Split-Path -Parent $git.Source))
+    }
+    $systemRoot = $env:SystemRoot
+    if (-not $systemRoot) {
+        $systemRoot = "C:\Windows"
+    }
+    foreach ($segment in @(
+            (Join-Path $systemRoot "System32"),
+            (Join-Path $systemRoot "System32\Wbem"),
+            (Join-Path $systemRoot "System32\WindowsPowerShell\v1.0")
+        )) {
+        if (Test-Path $segment) {
+            $paths.Add($segment)
+        }
+    }
+    $env:PATH = ($paths | Select-Object -Unique) -join ";"
+}
+
+function Assert-AcceptanceToolchainPresent {
+    Assert-CommandPresent "python"
+    Assert-CommandPresent "git"
+    Assert-CommandMissing "go"
+    Assert-CommandMissing "cargo"
+}
+
+function Assert-BrigadeResolvesFromPipxBin {
+    param([string]$PipxBinDir)
+    $command = Get-Command brigade -ErrorAction SilentlyContinue
+    if (-not $command) {
+        throw "brigade must resolve on PATH after pipx install"
+    }
+    $expectedDir = (Resolve-Path -LiteralPath $PipxBinDir).Path
+    $actualDir = (Split-Path -Parent $command.Source)
+    if ($actualDir -ne $expectedDir) {
+        throw "brigade must resolve from isolated PIPX_BIN_DIR ($expectedDir), got $($command.Source)"
+    }
+}
+
+function Get-ComponentReport {
+    param([string]$StderrRoot)
+    $raw = Invoke-ExternalCommand -StderrRoot $StderrRoot -Command {
+        & brigade version --components --json
+    } -FailureMessage "brigade version --components --json failed"
+    return ($raw | Out-String).Trim() | ConvertFrom-Json
+}
+
+function Assert-OperatorDoctorReady {
+    param(
+        [string]$Target,
+        [string]$Profile,
+        [string]$StderrRoot
+    )
+    $raw = Invoke-ExternalCommand -StderrRoot $StderrRoot -Command {
+        & brigade operator doctor --target $Target --profile $Profile --json
+    } -FailureMessage "operator doctor failed"
+    if (-not $raw) {
+        throw "operator doctor produced no JSON output"
+    }
+    $payload = ($raw | Out-String).Trim() | ConvertFrom-Json
+    if (-not $payload.ready) {
+        throw "operator doctor ready=false blocking_issue_count=$($payload.blocking_issue_count)"
+    }
+    if ($payload.blocking_issue_count -ne 0) {
+        throw "operator doctor blocking_issue_count=$($payload.blocking_issue_count)"
+    }
+}
+
+function Assert-AllComponentsHealthy {
+    param($Report)
+    if ($Report.components.Count -ne 4) {
+        throw "expected 4 components, got $($Report.components.Count)"
+    }
+    foreach ($component in $Report.components) {
+        if ($component.status -ne "healthy") {
+            throw "component $($component.component_id) is $($component.status): $($component.detail)"
+        }
+    }
+}
+
+function Get-ManagedExecutablePath {
+    param(
+        $Report,
+        [string]$ComponentId
+    )
+    $item = $Report.components | Where-Object { $_.component_id -eq $ComponentId } | Select-Object -First 1
+    if (-not $item) {
+        throw "missing component $ComponentId in report"
+    }
+    $path = $item.recorded_executable
+    if (-not $path) {
+        $path = $item.managed_executable_path
+    }
+    if (-not $path) {
+        throw "no managed path for $ComponentId"
+    }
+    if (-not (Test-Path $path)) {
+        throw "managed executable missing for ${ComponentId}: $path"
+    }
+    return $path
+}
+
+$acceptRoot = $null
+$envSnapshot = $null
+try {
+    $envSnapshot = Save-EnvSnapshot @(
+        "APPDATA",
+        "HOME",
+        "LOCALAPPDATA",
+        "USERPROFILE",
+        "PATH",
+        "XDG_CONFIG_HOME",
+        "XDG_DATA_HOME",
+        "XDG_CACHE_HOME",
+        "PIPX_HOME",
+        "PIPX_BIN_DIR"
+    )
+
+    if ($env:RUNNER_TEMP) {
+        $acceptRoot = Join-Path $env:RUNNER_TEMP ("brigade-native-acceptance-{0}" -f ([guid]::NewGuid().ToString("N").Substring(0, 8)))
+    }
+    else {
+        $acceptRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("brigade-native-acceptance-{0}" -f ([guid]::NewGuid().ToString("N").Substring(0, 8)))
+    }
+    New-Item -ItemType Directory -Force -Path $acceptRoot | Out-Null
+
+    $profileRoot = Join-Path $acceptRoot "profile"
+    $env:USERPROFILE = $profileRoot
+    $env:HOME = $profileRoot
+    $env:LOCALAPPDATA = Join-Path $acceptRoot "localappdata"
+    $env:APPDATA = Join-Path $profileRoot "AppData\Roaming"
+    $env:PIPX_HOME = Join-Path $env:LOCALAPPDATA "pipx"
+    $env:PIPX_BIN_DIR = Join-Path $env:LOCALAPPDATA "bin"
+    $env:XDG_CONFIG_HOME = Join-Path $acceptRoot "xdg-config"
+    $env:XDG_DATA_HOME = Join-Path $acceptRoot "xdg-data"
+    $env:XDG_CACHE_HOME = Join-Path $acceptRoot "xdg-cache"
+    New-Item -ItemType Directory -Force -Path @(
+        $env:LOCALAPPDATA,
+        $env:USERPROFILE,
+        $env:APPDATA,
+        $env:PIPX_HOME,
+        $env:PIPX_BIN_DIR,
+        $env:XDG_CONFIG_HOME,
+        $env:XDG_DATA_HOME,
+        $env:XDG_CACHE_HOME
+    ) | Out-Null
+
+    $systemPython = (Get-Command python -ErrorAction Stop).Source
+    $pythonExeDir = Get-PythonExeDir -PythonExe $systemPython
+    $pythonScriptsDir = Get-PythonScriptsDir -PythonExe $systemPython
+    $bootstrapPython = Initialize-PipxBootstrap -SystemPython $systemPython -BootstrapRoot $acceptRoot
+    $pipxBinDir = Get-PipxBinDir -BootstrapPython $bootstrapPython
+
+    Set-AcceptancePath -PythonExeDir $pythonExeDir -PythonScripts $pythonScriptsDir -PipxBinDir $pipxBinDir
+    Assert-AcceptanceToolchainPresent
+
+    if ($InstallMode -eq "source") {
+        if (-not $RepoRoot) {
+            $RepoRoot = (Get-Location).Path
+        }
+        Install-BrigadeFromSource -Root $RepoRoot -BootstrapPython $bootstrapPython
+    }
+    else {
+        Install-BrigadeFromPyPI -Version $BrigadeVersion -BootstrapPython $bootstrapPython
+    }
+
+    Assert-BrigadeResolvesFromPipxBin -PipxBinDir $pipxBinDir
+    if ($InstallMode -eq "pypi") {
+        Assert-BrigadeVersionMatches -Expected $BrigadeVersion
+    }
+
+    & brigade --version
+    if ($LASTEXITCODE -ne 0) { throw "brigade --version failed" }
+
+    Write-Step "brigade setup (online)"
+    & brigade setup
+    if ($LASTEXITCODE -ne 0) { throw "brigade setup failed" }
+
+    Write-Step "brigade setup --offline"
+    & brigade setup --offline
+    if ($LASTEXITCODE -ne 0) { throw "brigade setup --offline failed" }
+
+    $report = Get-ComponentReport -StderrRoot $acceptRoot
+    Assert-AllComponentsHealthy $report
+
+    $graphtrailExe = Get-ManagedExecutablePath -Report $report -ComponentId "graphtrail"
+    $miseledgerExe = Get-ManagedExecutablePath -Report $report -ComponentId "miseledger"
+
+    $workRepo = Join-Path $acceptRoot "repo"
+    New-Item -ItemType Directory -Force -Path $workRepo | Out-Null
+    Push-Location $workRepo
+    try {
+        & git init -q -b main
+        if ($LASTEXITCODE -ne 0) { throw "git init failed" }
+
+        $samplePath = Join-Path $workRepo "sample.py"
+        @"
+def greet():
+    return "acceptance"
+
+
+def call_greet():
+    return greet()
+"@ | Set-Content -Path $samplePath -Encoding UTF8
+
+        Write-Step "operator quickstart"
+        & brigade operator quickstart --target $workRepo --harnesses codex --json
+        if ($LASTEXITCODE -ne 0) { throw "operator quickstart failed" }
+
+        Write-Step "operator doctor"
+        Assert-OperatorDoctorReady -Target $workRepo -Profile "local-operator" -StderrRoot $acceptRoot
+
+        $dbPath = Join-Path $workRepo ".graphtrail\graphtrail.db"
+        Write-Step "graphtrail sync"
+        & $graphtrailExe --db $dbPath sync $workRepo
+        if ($LASTEXITCODE -ne 0) { throw "graphtrail sync failed" }
+        if (-not (Test-Path $dbPath)) {
+            throw "graphtrail database missing at $dbPath"
+        }
+
+        Write-Step "graphtrail callers query"
+        $callersOutput = & $graphtrailExe --db $dbPath callers greet 2>&1 | Out-String
+        if ($LASTEXITCODE -ne 0) { throw "graphtrail callers greet failed" }
+        if ($callersOutput -notmatch "call_greet") {
+            throw "graphtrail callers greet missing call_greet edge: $callersOutput"
+        }
+
+        $acceptanceMarker = "brigade-win-acceptance-$([guid]::NewGuid().ToString('N').Substring(0, 8))"
+        $verifyScript = Join-Path $workRepo "verify_smoke.py"
+        ('print("{0}")' -f $acceptanceMarker) | Set-Content -Path $verifyScript -Encoding UTF8
+
+        Write-Step "brigade work verify run"
+        & brigade work verify run --target $workRepo --command "python verify_smoke.py" --capture brigade-work
+        if ($LASTEXITCODE -ne 0) { throw "work verify run failed" }
+
+        $exportPath = Join-Path $acceptRoot "receipts.jsonl"
+        Write-Step "receipts export miseledger"
+        & brigade receipts export miseledger --target $workRepo --out $exportPath --new-only
+        if ($LASTEXITCODE -ne 0) { throw "receipts export failed" }
+        if (-not (Test-Path $exportPath)) {
+            throw "export file missing: $exportPath"
+        }
+
+        Write-Step "miseledger import adapter"
+        $importStdout = Invoke-ExternalCommand -StderrRoot $acceptRoot -Command {
+            & $miseledgerExe import adapter $exportPath --source brigade --json
+        } -FailureMessage "miseledger import failed"
+        $importPayload = ($importStdout | Out-String).Trim() | ConvertFrom-Json
+        $inserted = [int]$importPayload.inserted_items
+        $alreadyKnown = [int]$importPayload.already_known
+        if (($inserted + $alreadyKnown) -lt 1) {
+            throw "miseledger import did not ingest receipts: inserted_items=$inserted already_known=$alreadyKnown"
+        }
+
+        Write-Step "miseledger search"
+        $searchStdout = Invoke-ExternalCommand -StderrRoot $acceptRoot -Command {
+            & $miseledgerExe search $acceptanceMarker --limit 3
+        } -FailureMessage "miseledger search failed"
+        $searchOutput = $searchStdout | Out-String
+        if ($searchOutput -notmatch [regex]::Escape($acceptanceMarker)) {
+            throw "miseledger search missing acceptance marker: $searchOutput"
+        }
+    }
+    finally {
+        Pop-Location
+    }
+
+    Write-Step "Windows native acceptance passed"
+}
+finally {
+    if ($envSnapshot) {
+        Restore-EnvSnapshot -Snapshot $envSnapshot
+    }
+    if ($acceptRoot -and (Test-Path $acceptRoot)) {
+        Remove-Item -LiteralPath $acceptRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/scripts/windows-native-acceptance.ps1
+++ b/scripts/windows-native-acceptance.ps1
@@ -489,12 +489,13 @@ def call_greet():
             throw "graphtrail callers greet missing call_greet edge: $callersOutput"
         }
 
-        $acceptanceMarker = "brigade-win-acceptance-$([guid]::NewGuid().ToString('N').Substring(0, 8))"
-        $verifyScript = Join-Path $workRepo "verify_smoke.py"
-        ('print("{0}")' -f $acceptanceMarker) | Set-Content -Path $verifyScript -Encoding UTF8
+        $acceptanceMarker = "brigadewinacceptance$([guid]::NewGuid().ToString('N').Substring(0, 8))"
+        $verifyScriptName = "verify_$acceptanceMarker.py"
+        $verifyScript = Join-Path $workRepo $verifyScriptName
+        'print("ok")' | Set-Content -Path $verifyScript -Encoding UTF8
 
         Write-Step "brigade work verify run"
-        & brigade work verify run --target $workRepo --command "python verify_smoke.py" --capture brigade-work
+        & brigade work verify run --target $workRepo --command "python $verifyScriptName" --capture brigade-work
         if ($LASTEXITCODE -ne 0) { throw "work verify run failed" }
 
         $exportPath = Join-Path $acceptRoot "receipts.jsonl"

--- a/src/brigade/component_install.py
+++ b/src/brigade/component_install.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 import os
 import re
+import shutil
+import ssl
 import stat
 import subprocess
 import sys
@@ -26,6 +28,11 @@ _EXECUTABLE_MODE = 0o755
 _SMOKE_COMPONENT_IDS = component_manifest.KNOWN_COMPONENT_IDS
 _SMOKE_TIMEOUT_SECONDS = 30.0
 _DOWNLOAD_TIMEOUT_SECONDS = 30.0
+_WINDOWS_HTTPS_PRIME_TIMEOUT_SECONDS = 30.0
+_WINDOWS_HTTPS_PRIME_URL_ENV = "BRIGADE_HTTPS_PRIME_URL"
+_WINDOWS_HTTPS_PRIME_COMMAND = (
+    "Invoke-WebRequest -Uri $env:BRIGADE_HTTPS_PRIME_URL -Method Head -UseBasicParsing | Out-Null"
+)
 _JSONRPC_INIT_REQUEST = json.dumps(
     {
         "jsonrpc": "2.0",
@@ -298,6 +305,65 @@ def _managed_executable_is_ready(path: Path, *, byte_size: int, sha256: str) -> 
     return bool(mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))
 
 
+def _is_certificate_verify_failure(exc: BaseException) -> bool:
+    reason: BaseException | object = exc
+    if isinstance(exc, urllib.error.URLError):
+        reason = exc.reason
+    if isinstance(reason, ssl.CertificateError):
+        return True
+    message = str(exc)
+    if isinstance(reason, BaseException):
+        message = f"{message} {reason}"
+    return "CERTIFICATE_VERIFY_FAILED" in message.upper()
+
+
+def _windows_powershell_exe() -> str:
+    system_root = os.environ.get("SystemRoot", r"C:\Windows")
+    candidate = Path(system_root) / "System32" / "WindowsPowerShell" / "v1.0" / "powershell.exe"
+    if candidate.is_file():
+        return str(candidate)
+    found = shutil.which("powershell.exe") or shutil.which("powershell")
+    return found if found is not None else "powershell.exe"
+
+
+def _prime_windows_https_roots(url: str, *, timeout: float) -> bool:
+    """Run a bounded native Windows HTTPS HEAD request to refresh trusted roots."""
+    environment = os.environ.copy()
+    environment[_WINDOWS_HTTPS_PRIME_URL_ENV] = url
+    try:
+        completed = subprocess.run(
+            [
+                _windows_powershell_exe(),
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                _WINDOWS_HTTPS_PRIME_COMMAND,
+            ],
+            shell=False,
+            capture_output=True,
+            timeout=timeout,
+            env=environment,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return completed.returncode == 0
+
+
+def _default_urlopen(url: str) -> Any:
+    return urllib.request.urlopen(url, timeout=_DOWNLOAD_TIMEOUT_SECONDS)
+
+
+def _urlopen_default_with_windows_cert_retry(url: str) -> Any:
+    try:
+        return _default_urlopen(url)
+    except urllib.error.URLError as exc:
+        if not _is_certificate_verify_failure(exc):
+            raise
+        if not _prime_windows_https_roots(url, timeout=_WINDOWS_HTTPS_PRIME_TIMEOUT_SECONDS):
+            raise
+        return _default_urlopen(url)
+
+
 def verify_cached_asset(path: Path, *, byte_size: int, sha256: str) -> None:
     """Verify cached asset byte size and SHA-256 digest."""
     _validate_expected(byte_size=byte_size, sha256=sha256)
@@ -331,7 +397,9 @@ def fetch_asset_to_cache(
     def open_url(url: str) -> Any:
         if opener is not None:
             return opener(url)
-        return urllib.request.urlopen(url, timeout=_DOWNLOAD_TIMEOUT_SECONDS)
+        if sys.platform == "win32":
+            return _urlopen_default_with_windows_cert_retry(url)
+        return _default_urlopen(url)
 
     cache_path.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_name = tempfile.mkstemp(dir=cache_path.parent, prefix=f".{cache_path.name}.", suffix=".tmp")

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -174,6 +174,66 @@ def test_windows_native_acceptance_json_commands_keep_stderr_separate():
     assert "Invoke-ExternalCommand" in search_section
 
 
+def _extract_powershell_function(text: str, name: str) -> str:
+    start = text.index(f"function {name}")
+    lines = text[start:].splitlines()
+    result = [lines[0]]
+    depth = lines[0].count("{") - lines[0].count("}")
+    for line in lines[1:]:
+        result.append(line)
+        depth += line.count("{") - line.count("}")
+        if depth == 0:
+            break
+    return "\n".join(result)
+
+
+def _powershell_line_consumes_success_stream(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped.startswith("&"):
+        return True
+    if "| Out-Host" in line or "| Out-Null" in line:
+        return True
+    assignment, _, _ = stripped.partition("=")
+    return assignment.endswith("$null") or (assignment.startswith("$") and "&" not in assignment)
+
+
+def test_windows_native_acceptance_bootstrap_return_is_single_python_path():
+    text = (ROOT / "scripts/windows-native-acceptance.ps1").read_text()
+    bootstrap = _extract_powershell_function(text, "Initialize-PipxBootstrap")
+
+    assert bootstrap.count("return ") == 1
+    assert "return $bootstrapPython" in bootstrap
+
+    venv_line = next(line for line in bootstrap.splitlines() if "-m venv" in line)
+    pip_line = next(line for line in bootstrap.splitlines() if "-m pip install" in line)
+    assert _powershell_line_consumes_success_stream(venv_line)
+    assert _powershell_line_consumes_success_stream(pip_line)
+
+
+def test_windows_native_acceptance_assigned_return_functions_do_not_leak_stdout():
+    text = (ROOT / "scripts/windows-native-acceptance.ps1").read_text()
+    assigned_returns = (
+        "Get-PythonExeDir",
+        "Get-PythonScriptsDir",
+        "Get-PipxBinDir",
+        "Initialize-PipxBootstrap",
+        "Get-ManagedExecutablePath",
+    )
+
+    for name in assigned_returns:
+        body = _extract_powershell_function(text, name)
+        assert "return " in body
+        for line in body.splitlines():
+            stripped = line.strip()
+            if not stripped.startswith("&"):
+                continue
+            if "{ &" in line:
+                continue
+            assert _powershell_line_consumes_success_stream(line), (
+                f"{name} leaks success-stream output from: {stripped}"
+            )
+
+
 def test_windows_native_acceptance_brigade_version_regex_matches_cli_output():
     script = (ROOT / "scripts/windows-native-acceptance.ps1").read_text()
     assert r"if ($line -match '^brigade\s+(.+)$')" in script

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+import re
+import subprocess
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -16,7 +18,13 @@ def test_agents_doc_names_ci_only_jobs_outside_local_verify():
     text = (ROOT / "AGENTS.md").read_text()
 
     assert "CI-only" in text
-    for job in ("content-guard", "repo-metadata", "install-from-source", "quickstart-smoke"):
+    for job in (
+        "content-guard",
+        "repo-metadata",
+        "install-from-source",
+        "quickstart-smoke",
+        "windows-native-acceptance",
+    ):
         assert job in text
 
 
@@ -27,3 +35,154 @@ def test_quickstart_smoke_covers_linux_macos_and_windows_powershell():
     assert "shell: pwsh" in text
     assert "brigade operator quickstart --target $target" in text
     assert "brigade operator doctor --target $target" in text
+
+
+def test_ci_windows_native_acceptance_job_uses_script_and_source_install():
+    text = (ROOT / ".github/workflows/ci.yml").read_text()
+
+    job = text.index("  windows-native-acceptance:")
+    quickstart = text.index("  quickstart-smoke:")
+    assert job > quickstart
+    section = text[job:]
+    assert "runs-on: windows-latest" in section
+    assert "shell: powershell" in section
+    assert "windows-native-acceptance.ps1" in section
+    assert "-InstallMode source" in section
+    assert "brigade setup" not in section
+    assert "self-hosted" not in section
+
+
+def test_windows_native_acceptance_script_is_tracked_by_gitignore_negation():
+    gitignore = (ROOT / ".gitignore").read_text()
+    script = ROOT / "scripts/windows-native-acceptance.ps1"
+
+    assert "/scripts/*" in gitignore
+    assert "!/scripts/windows-native-acceptance.ps1" in gitignore
+    assert script.is_file()
+    result = subprocess.run(
+        ["git", "check-ignore", "-q", str(script)],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 1
+
+
+def test_ci_windows_native_acceptance_script_covers_required_flow():
+    text = (ROOT / "scripts/windows-native-acceptance.ps1").read_text()
+
+    assert '$env:LOCALAPPDATA = Join-Path $acceptRoot "localappdata"' in text
+    assert "$env:HOME = $profileRoot" in text
+    assert '$env:APPDATA = Join-Path $profileRoot "AppData\\Roaming"' in text
+    assert '"HOME"' in text
+    assert '"APPDATA"' in text
+    assert "Save-EnvSnapshot" in text
+    assert "Restore-EnvSnapshot" in text
+    assert "Get-PythonExeDir" in text
+    assert "Initialize-PipxBootstrap" in text
+    assert "bootstrap-venv" in text
+    assert "-m venv" in text
+    assert "Invoke-Pipx" in text
+    assert "-m pipx" in text
+    assert "python -m pip install --upgrade pip pipx" not in text
+    assert "& python -m pip install" not in text
+    assert "Get-BrigadeCliVersion" in text
+    assert r"if ($line -match '^brigade\s+(.+)$')" in text
+    assert "Assert-CommandPresent" in text
+    assert 'Assert-CommandPresent "python"' in text
+    assert 'Assert-CommandPresent "git"' in text
+    assert "Assert-CommandMissing" in text
+    assert 'Assert-CommandMissing "go"' in text
+    assert 'Assert-CommandMissing "cargo"' in text
+    assert "Set-AcceptancePath" in text
+    assert "Assert-AcceptanceToolchainPresent" in text
+    assert "Assert-BrigadeResolvesFromPipxBin" in text
+    assert "Remove-BrigadePipxInstall" in text
+    assert "Assert-BrigadeVersionMatches" in text
+    assert "Invoke-ExternalCommand" in text
+    assert "Get-BoundedStderr" in text
+    assert "brigade setup" in text
+    assert "brigade setup --offline" in text
+    assert "brigade version --components --json" in text
+    assert 'if ($component.status -ne "healthy")' in text
+    assert "def call_greet" in text
+    assert "git init" in text
+    assert "brigade operator quickstart" in text
+    assert "Assert-OperatorDoctorReady" in text
+    assert "$payload.ready" in text
+    assert "$payload.blocking_issue_count" in text
+    assert "--db $dbPath sync $workRepo" in text
+    assert "callers greet" in text
+    assert 'if ($callersOutput -notmatch "call_greet")' in text
+    assert "brigade-win-acceptance-" in text
+    assert "brigade work verify run" in text
+    assert "brigade receipts export miseledger" in text
+    assert "import adapter" in text
+    assert "$importPayload.inserted_items" in text
+    assert "$importPayload.already_known" in text
+    assert "$acceptanceMarker" in text
+    assert "recorded_executable" in text
+    assert "$env:XDG_CONFIG_HOME" in text
+    assert "$env:XDG_DATA_HOME" in text
+    assert "$env:XDG_CACHE_HOME" in text
+    assert "finally" in text
+    assert "#requires -Version 5.1" in text
+
+
+def test_windows_native_acceptance_path_and_install_ordering():
+    text = (ROOT / "scripts/windows-native-acceptance.ps1").read_text()
+    main = text[text.index("$acceptRoot = $null") :]
+
+    set_path = main.index("Set-AcceptancePath")
+    toolchain = main.index("Assert-AcceptanceToolchainPresent")
+    source_install = main.index("Install-BrigadeFromSource")
+    pypi_install = main.index("Install-BrigadeFromPyPI")
+    resolve_brigade = main.index("Assert-BrigadeResolvesFromPipxBin")
+    version_match = main.index("Assert-BrigadeVersionMatches")
+
+    assert set_path < toolchain < source_install
+    assert set_path < toolchain < pypi_install
+    assert source_install < resolve_brigade
+    assert pypi_install < resolve_brigade
+    assert resolve_brigade < version_match
+
+    pypi_function = text[text.index("function Install-BrigadeFromPyPI") : text.index("function Set-AcceptancePath")]
+    assert "Assert-BrigadeVersionMatches" not in pypi_function
+
+
+def test_windows_native_acceptance_json_commands_keep_stderr_separate():
+    text = (ROOT / "scripts/windows-native-acceptance.ps1").read_text()
+
+    doctor = text[
+        text.index("function Assert-OperatorDoctorReady") : text.index("function Assert-AllComponentsHealthy")
+    ]
+    assert "2>&1" not in doctor
+    assert "Invoke-ExternalCommand" in doctor
+
+    import_section = text[
+        text.index('Write-Step "miseledger import adapter"') : text.index('Write-Step "miseledger search"')
+    ]
+    assert "2>&1" not in import_section
+    assert "Invoke-ExternalCommand" in import_section
+    assert "ConvertFrom-Json" in import_section
+
+    search_section = text[
+        text.index('Write-Step "miseledger search"') : text.index('Write-Step "Windows native acceptance passed"')
+    ]
+    assert "2>&1" not in search_section
+    assert "Invoke-ExternalCommand" in search_section
+
+
+def test_windows_native_acceptance_brigade_version_regex_matches_cli_output():
+    script = (ROOT / "scripts/windows-native-acceptance.ps1").read_text()
+    assert r"if ($line -match '^brigade\s+(.+)$')" in script
+
+    pattern = r"^brigade\s+(.+)$"
+    for line, expected in (
+        ("brigade 0.23.3", "0.23.3"),
+        ("brigade 1.2.3", "1.2.3"),
+    ):
+        match = re.match(pattern, line.strip())
+        assert match is not None
+        assert match.group(1).strip() == expected

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -115,7 +115,7 @@ def test_ci_windows_native_acceptance_script_covers_required_flow():
     assert "--db $dbPath sync $workRepo" in text
     assert "callers greet" in text
     assert 'if ($callersOutput -notmatch "call_greet")' in text
-    assert "brigade-win-acceptance-" in text
+    assert "brigadewinacceptance" in text
     assert "brigade work verify run" in text
     assert "brigade receipts export miseledger" in text
     assert "import adapter" in text
@@ -232,6 +232,20 @@ def test_windows_native_acceptance_assigned_return_functions_do_not_leak_stdout(
             assert _powershell_line_consumes_success_stream(line), (
                 f"{name} leaks success-stream output from: {stripped}"
             )
+
+
+def test_windows_native_acceptance_miseledger_marker_is_in_verify_command_filename():
+    """MiseLedger indexes work-verify item.text (command text), not command stdout."""
+    text = (ROOT / "scripts/windows-native-acceptance.ps1").read_text()
+    section = text[text.index("$acceptanceMarker =") : text.index('Write-Step "Windows native acceptance passed"')]
+
+    assert "$acceptanceMarker = \"brigadewinacceptance$([guid]::NewGuid().ToString('N').Substring(0, 8))\"" in section
+    assert '$verifyScriptName = "verify_$acceptanceMarker.py"' in section
+    assert "$verifyScript = Join-Path $workRepo $verifyScriptName" in section
+    assert '--command "python $verifyScriptName"' in section
+    assert "& $miseledgerExe search $acceptanceMarker" in section
+    assert "verify_smoke.py" not in section
+    assert 'print("{0}")' not in section
 
 
 def test_windows_native_acceptance_brigade_version_regex_matches_cli_output():

--- a/tests/test_component_install.py
+++ b/tests/test_component_install.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import ssl
 import subprocess
+import urllib.error
 from pathlib import Path
 
 import pytest
@@ -14,8 +16,13 @@ import brigade
 from brigade import component_install, component_manifest, component_paths, component_state
 from brigade.component_install import (
     ComponentInstallError,
+    _WINDOWS_HTTPS_PRIME_COMMAND,
+    _WINDOWS_HTTPS_PRIME_URL_ENV,
+    _is_certificate_verify_failure,
+    _prime_windows_https_roots,
     _restore_managed_executables,
     _snapshot_managed_executables,
+    _urlopen_default_with_windows_cert_retry,
     build_setup_plan,
     fetch_asset_to_cache,
     materialize_executable,
@@ -326,6 +333,118 @@ def test_fetch_asset_accepts_https_to_https_redirect(tmp_path):
     assert result == cache_path
     assert opener.responses[0].geturl() == final_url
     verify_cached_asset(cache_path, byte_size=byte_size, sha256=sha256)
+
+
+def test_is_certificate_verify_failure_detects_ssl_and_message():
+    cert_error = ssl.SSLCertVerificationError("CERTIFICATE_VERIFY_FAILED")
+    assert _is_certificate_verify_failure(urllib.error.URLError(cert_error))
+    assert _is_certificate_verify_failure(urllib.error.URLError("CERTIFICATE_VERIFY_FAILED"))
+    assert not _is_certificate_verify_failure(urllib.error.URLError("connection refused"))
+
+
+def test_urlopen_default_retries_after_windows_cert_prime(monkeypatch):
+    calls: list[str] = []
+    cert_error = urllib.error.URLError(ssl.SSLCertVerificationError("CERTIFICATE_VERIFY_FAILED"))
+
+    def fake_urlopen(url: str):
+        calls.append(url)
+        if len(calls) == 1:
+            raise cert_error
+        return object()
+
+    monkeypatch.setattr(component_install, "_default_urlopen", fake_urlopen)
+    monkeypatch.setattr(component_install, "_prime_windows_https_roots", lambda url, timeout: True)
+    assert _urlopen_default_with_windows_cert_retry("https://example.invalid/asset") is not None
+    assert calls == ["https://example.invalid/asset", "https://example.invalid/asset"]
+
+
+def test_urlopen_default_preserves_cert_failure_when_prime_fails(monkeypatch):
+    cert_error = urllib.error.URLError(ssl.SSLCertVerificationError("CERTIFICATE_VERIFY_FAILED"))
+
+    def fake_urlopen(url: str):
+        raise cert_error
+
+    monkeypatch.setattr(component_install, "_default_urlopen", fake_urlopen)
+    monkeypatch.setattr(component_install, "_prime_windows_https_roots", lambda url, timeout: False)
+    with pytest.raises(urllib.error.URLError):
+        _urlopen_default_with_windows_cert_retry("https://example.invalid/asset")
+
+
+def test_fetch_asset_default_opener_retries_cert_failure_on_windows(tmp_path, monkeypatch):
+    asset = manifest_asset_fixture("miseledger", platform="linux-amd64")
+    payload, byte_size, sha256 = fixture_payload("miseledger", platform="linux-amd64")
+    cache_path = tmp_path / "cache" / sha256 / asset.asset_name
+    calls: list[str] = []
+    cert_error = urllib.error.URLError(ssl.SSLCertVerificationError("CERTIFICATE_VERIFY_FAILED"))
+
+    def fake_urlopen(url: str):
+        calls.append(url)
+        if len(calls) == 1:
+            raise cert_error
+        return FakeOpener({asset.download_url: payload})(url)
+
+    monkeypatch.setattr(component_install.sys, "platform", "win32")
+    monkeypatch.setattr(component_install, "_default_urlopen", fake_urlopen)
+    monkeypatch.setattr(component_install, "_prime_windows_https_roots", lambda url, timeout: True)
+    result = fetch_asset_to_cache(asset, cache_path=cache_path, offline=False)
+    assert result == cache_path
+    assert calls == [asset.download_url, asset.download_url]
+    verify_cached_asset(cache_path, byte_size=byte_size, sha256=sha256)
+
+
+def test_fetch_asset_custom_opener_does_not_retry_cert_failure_on_windows(tmp_path, monkeypatch):
+    asset = manifest_asset_fixture("miseledger", platform="linux-amd64")
+    cache_path = tmp_path / "cache" / asset.sha256 / asset.asset_name
+    cert_error = urllib.error.URLError(ssl.SSLCertVerificationError("CERTIFICATE_VERIFY_FAILED"))
+
+    def boom(url: str):
+        raise cert_error
+
+    monkeypatch.setattr(component_install.sys, "platform", "win32")
+
+    def fail_prime(*_args, **_kwargs):
+        pytest.fail("custom opener must not trigger Windows HTTPS priming")
+
+    monkeypatch.setattr(component_install, "_prime_windows_https_roots", fail_prime)
+    with pytest.raises(urllib.error.URLError):
+        fetch_asset_to_cache(asset, cache_path=cache_path, offline=False, opener=boom)
+
+
+def test_fetch_asset_default_opener_does_not_retry_non_cert_failure_on_windows(tmp_path, monkeypatch):
+    asset = manifest_asset_fixture("miseledger", platform="linux-amd64")
+    cache_path = tmp_path / "cache" / asset.sha256 / asset.asset_name
+    other_error = urllib.error.URLError("connection refused")
+
+    def boom(url: str):
+        raise other_error
+
+    monkeypatch.setattr(component_install.sys, "platform", "win32")
+    monkeypatch.setattr(component_install, "_default_urlopen", boom)
+
+    def fail_prime(*_args, **_kwargs):
+        pytest.fail("non-certificate failures must not trigger Windows HTTPS priming")
+
+    monkeypatch.setattr(component_install, "_prime_windows_https_roots", fail_prime)
+    with pytest.raises(urllib.error.URLError):
+        fetch_asset_to_cache(asset, cache_path=cache_path, offline=False)
+
+
+def test_windows_https_prime_passes_url_via_environment(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def fake_run(argv, **kwargs):
+        captured["argv"] = list(argv)
+        captured["env"] = dict(kwargs["env"])
+        captured["shell"] = kwargs["shell"]
+        return subprocess.CompletedProcess(argv, 0)
+
+    monkeypatch.setattr(component_install.subprocess, "run", fake_run)
+    url = 'https://example.invalid/asset"; Remove-Item -Recurse C:\\'
+    assert _prime_windows_https_roots(url, timeout=1.0)
+    assert captured["shell"] is False
+    assert captured["env"][_WINDOWS_HTTPS_PRIME_URL_ENV] == url
+    assert url not in " ".join(captured["argv"])
+    assert captured["argv"][-1] == _WINDOWS_HTTPS_PRIME_COMMAND
 
 
 def test_fetch_asset_fsyncs_verified_download_before_replace(tmp_path, monkeypatch):

--- a/tests/test_publish_workflow.py
+++ b/tests/test_publish_workflow.py
@@ -28,3 +28,42 @@ def test_ci_checks_managed_snapshot():
     text = (ROOT / ".github" / "workflows" / "ci.yml").read_text()
 
     assert "python scripts/managed_snapshot.py --check" in text
+
+
+def test_publish_windows_native_acceptance_waits_for_pypi_and_uses_script():
+    text = (ROOT / ".github" / "workflows" / "publish.yml").read_text()
+
+    job = text.index("  windows-native-acceptance:")
+    build = text.index("  build-and-publish:")
+    assert build < job
+    section = text[job:]
+    assert "needs: build-and-publish" in section
+    assert "runs-on: windows-latest" in section
+    assert "shell: powershell" in section
+    assert "if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')" in section
+    assert "windows-native-acceptance.ps1" in section
+    assert "-InstallMode pypi" in section
+    assert "-BrigadeVersion" in section
+    script = (ROOT / "scripts/windows-native-acceptance.ps1").read_text()
+    assert "pypi.org/pypi/brigade-cli/json" in script
+    assert "Get-BrigadeCliVersion" in script
+    assert r"if ($line -match '^brigade\s+(.+)$')" in script
+    assert "Assert-BrigadeVersionMatches" in script
+    assert "Assert-BrigadeResolvesFromPipxBin" in script
+    assert "Set-AcceptancePath" in script
+    assert "Assert-AcceptanceToolchainPresent" in script
+    assert "Initialize-PipxBootstrap" in script
+    assert "bootstrap-venv" in script
+    assert "python -m pip install --upgrade pip pipx" not in script
+    assert "Remove-BrigadePipxInstall" in script
+    assert '"HOME"' in script
+    assert '"APPDATA"' in script
+    pypi_function = script[
+        script.index("function Install-BrigadeFromPyPI") : script.index("function Set-AcceptancePath")
+    ]
+    assert "Assert-BrigadeVersionMatches" not in pypi_function
+    main = script[script.index("$acceptRoot = $null") :]
+    assert main.index("Set-AcceptancePath") < main.index("Install-BrigadeFromPyPI")
+    assert main.index("Install-BrigadeFromPyPI") < main.index("Assert-BrigadeResolvesFromPipxBin")
+    assert main.index("Assert-BrigadeResolvesFromPipxBin") < main.index("Assert-BrigadeVersionMatches")
+    assert "self-hosted" not in section


### PR DESCRIPTION
Closes #357
Refs #352

## What changed

- Retry a Windows component download once after a certificate-verification failure and a bounded native HTTPS request triggers normal Windows root acquisition.
- Add a PowerShell 5.1 acceptance script that installs Brigade in disposable paths, removes Go and Cargo from PATH, verifies online and offline component setup, and exercises GraphTrail and MiseLedger with real data.
- Run that script on GitHub-hosted `windows-latest` for source installs and after tagged PyPI publication. No self-hosted runner is registered.
- Add unit and workflow contract coverage for TLS retry limits, command safety, PATH ordering, isolated pipx resolution, and clean JSON streams.

## Verification

- Brigade receipt `20260719-170950-work-verify-9d4cfb`: `./scripts/verify` exited 0.
- 3,165 tests passed, 3 skipped, 82.19% coverage.
- Ruff, formatting, mypy, version sync, and the managed snapshot passed.
- Focused Windows/TLS/workflow suite: 94 passed.
- Opus cross-file review found a publish-only PATH ordering defect. The defect was fixed before this PR, and order-aware tests now cover it.

The new `windows-native-acceptance` check is the merge authority for the PowerShell execution path.
