### PR TITLE
fix(run): terminalize interrupted and stale runs

### DIFF
--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -2,16 +2,21 @@
 
 from __future__ import annotations
 
+import inspect
 import json
 import os
 import re
+import signal
 import sys
+import threading
 import time
+from contextlib import contextmanager
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
+from functools import wraps
 from json import JSONDecoder
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable, Iterator
 from uuid import uuid4
 
 from . import agents
@@ -641,6 +646,8 @@ def _record_plan_attempt(
         "parsed": parsed,
         "detail": result.detail,
         "text": result.text,
+        "timed_out": result.timed_out,
+        "status": result.status,
     }
     if result.failure_phase is not None:
         payload["failure_phase"] = result.failure_phase
@@ -689,6 +696,7 @@ def _run_orchestrator(
     sandbox_read_only: bool | None = None,
     sandbox: str | None = None,
     codex_transport: str | None = None,
+    process_registry: proc.ProcessRegistry | None = None,
 ) -> agents.AgentResult:
     orchestrator = roster.agents[roster.orchestrator]
     transport = codex_transport or roster.codex_transport
@@ -719,7 +727,13 @@ def _run_orchestrator(
         kwargs["reasoning"] = orchestrator.reasoning
     if orchestrator.env is not None:
         kwargs["env"] = dict(orchestrator.env)
-    result = agents.run_agent(orchestrator.cli, prompt, **kwargs)
+    result = _call_with_process_registry(
+        agents.run_agent,
+        orchestrator.cli,
+        prompt,
+        process_registry=process_registry,
+        **kwargs,
+    )
     if not result.ok and orchestrator.cli == "codex":
         detail = _orchestrator_failure_detail(
             result,
@@ -741,6 +755,22 @@ def _run_orchestrator(
                 transport=result.transport,
             )
     return result
+
+
+def _call_with_process_registry(
+    function: Callable[..., Any],
+    *args: Any,
+    process_registry: proc.ProcessRegistry | None,
+    **kwargs: Any,
+) -> Any:
+    parameters = inspect.signature(function).parameters.values()
+    accepts_registry = any(
+        parameter.name == "process_registry" or parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters
+    )
+    if accepts_registry:
+        kwargs["process_registry"] = process_registry
+    return function(*args, **kwargs)
 
 
 def _coverage_missing(route: RouteBrief | None, assignments: list[Assignment]) -> list[str]:
@@ -768,9 +798,11 @@ def plan(
     evidence: EvidenceBrief | None = None,
     route: RouteBrief | None = None,
     codex_transport: str | None = None,
+    process_registry: proc.ProcessRegistry | None = None,
 ) -> list[Assignment]:
     transport = codex_transport or roster.codex_transport
-    first = _run_orchestrator(
+    first = _call_with_process_registry(
+        _run_orchestrator,
         roster,
         build_plan_prompt(
             task,
@@ -786,6 +818,7 @@ def plan(
         sandbox_read_only=sandbox_read_only,
         sandbox=sandbox,
         codex_transport=transport,
+        process_registry=process_registry,
     )
     if not first.ok:
         _record_plan_attempt(attempts, stage="initial", result=first)
@@ -802,7 +835,8 @@ def plan(
         )
     except ValueError as exc:
         _record_plan_attempt(attempts, stage="initial", result=first, parse_error=str(exc))
-        second = _run_orchestrator(
+        second = _call_with_process_registry(
+            _run_orchestrator,
             roster,
             build_plan_prompt(
                 task,
@@ -819,6 +853,7 @@ def plan(
             sandbox_read_only=sandbox_read_only,
             sandbox=sandbox,
             codex_transport=transport,
+            process_registry=process_registry,
         )
         if not second.ok:
             _record_plan_attempt(attempts, stage="correction", result=second)
@@ -848,7 +883,8 @@ def plan(
     # The plan parses but skips required route stages: one corrective retry, then
     # keep whichever plan covers more. Advisory, never fatal - a deterministic
     # constraint must not brick a run the orchestrator can finish.
-    revised_result = _run_orchestrator(
+    revised_result = _call_with_process_registry(
+        _run_orchestrator,
         roster,
         build_plan_prompt(
             task,
@@ -869,6 +905,7 @@ def plan(
         sandbox_read_only=sandbox_read_only,
         sandbox=sandbox,
         codex_transport=transport,
+        process_registry=process_registry,
     )
     if not revised_result.ok:
         _record_plan_attempt(attempts, stage="coverage-correction", result=revised_result)
@@ -1012,12 +1049,16 @@ def _run_codex_appserver_worker(
             registry.unregister(worker, active_turn_id)
     text = turn.text.strip()
     if not turn.ok:
+        timed_out = bool(getattr(turn, "timed_out", False))
+        failure_kind = "timeout" if timed_out else "interrupted" if turn.status == "interrupted" else None
         return agents.AgentResult(
             text=text,
             ok=False,
             detail=(turn.detail or f"turn {turn.status}")[:200],
+            failure_kind=failure_kind,
             thread_id=turn.thread_id,
             status=turn.status,
+            timed_out=timed_out,
             transport="codex-app-server",
             requested_model=agent.model,
             reasoning=agent.reasoning,
@@ -1074,6 +1115,9 @@ def dispatch(
     events_dir: Path | None = None,
     verbose: bool = False,
     authorized_writable_worktree: bool = False,
+    on_stage_start: Callable[[int, tuple[str, ...]], None] | None = None,
+    on_interrupt: Callable[[], None] | None = None,
+    process_registry: proc.ProcessRegistry | None = None,
 ) -> list[WorkerResult]:
     from . import run_transport
 
@@ -1096,6 +1140,9 @@ def dispatch(
         events_dir=events_dir,
         verbose=verbose,
         authorized_writable_worktree=authorized_writable_worktree,
+        on_stage_start=on_stage_start,
+        on_interrupt=on_interrupt,
+        process_registry=process_registry,
     )
 
 
@@ -1483,7 +1530,7 @@ def _context_eval_fact(payload: dict[str, object]) -> str:
         ):
             return ""
         return f"brief hit rate {rate:.2f} ({hits}/{delta_files} files, {missed} missed)"
-    except BaseException:
+    except Exception:
         return ""
 
 
@@ -1514,7 +1561,7 @@ def _context_eval_for_run(
             return None
         brief_files = context_eval.extract_brief_files(code_graph.text)
         return context_eval.evaluate(brief_files, delta_files)
-    except BaseException:
+    except Exception:
         return None
 
 
@@ -1586,44 +1633,181 @@ def record_artifact_collection(
             "detail": bounded_detail,
         }
         collection["failure"] = artifact_failure
-        if payload.get("status") not in {"failed", "handoff-failed", "interrupted"}:
+        primary_status = payload.get("status")
+        primary_terminal = isinstance(primary_status, str) and primary_status not in {
+            "started",
+            "planning",
+            "dispatching",
+            "result-processing",
+            "synthesizing",
+            "handoff",
+            "artifact-collection",
+            "running",
+        }
+        if not primary_terminal:
             payload["status"] = "failed"
             payload["error"] = bounded_detail
             payload["failure_phase"] = phase
             payload["failure"] = artifact_failure
             finished_at = datetime.now(timezone.utc)
+            payload["status_started_at"] = _utc_iso(finished_at)
             payload["finished_at"] = _utc_iso(finished_at)
             started_at = payload.get("started_at")
             if isinstance(started_at, str):
-                try:
-                    started = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
-                except ValueError:
-                    pass
-                else:
+                started = _parse_iso_datetime(started_at)
+                if started is not None:
                     payload["duration_seconds"] = max(
                         0.0,
-                        round((finished_at - started.astimezone(timezone.utc)).total_seconds(), 3),
+                        round((finished_at - started).total_seconds(), 3),
                     )
     elif status == "ok" and payload.get("status") == "artifact-collection":
         finished_at = datetime.now(timezone.utc)
         payload["status"] = "ok"
+        payload["status_started_at"] = _utc_iso(finished_at)
         payload["finished_at"] = _utc_iso(finished_at)
         started_at = payload.get("started_at")
         if isinstance(started_at, str):
-            try:
-                started = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
-            except ValueError:
-                pass
-            else:
+            started = _parse_iso_datetime(started_at)
+            if started is not None:
                 payload["duration_seconds"] = max(
                     0.0,
-                    round((finished_at - started.astimezone(timezone.utc)).total_seconds(), 3),
+                    round((finished_at - started).total_seconds(), 3),
                 )
     payload["artifact_collection"] = collection
     try:
         _write_json(run_path, payload)
     except OSError as exc:
         raise runguard.RetainRunLockError(f"failed to update run receipt after artifact collection: {exc}") from exc
+
+
+def record_run_termination(
+    output_dir: Path,
+    *,
+    status: str,
+    failure_phase: str | None,
+    failure_kind: str,
+    detail: str,
+    seat: str | None = None,
+    active_seats: tuple[str, ...] = (),
+) -> None:
+    """Terminalize a run that escaped its normal result path."""
+
+    run_path = output_dir / "run.json"
+    try:
+        payload = json.loads(run_path.read_text())
+    except OSError as exc:
+        raise runguard.RetainRunLockError(f"failed to read run receipt during termination: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise runguard.RetainRunLockError(f"run receipt is invalid during termination: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise runguard.RetainRunLockError("run receipt must contain an object during termination")
+    if payload.get("finished_at"):
+        return
+
+    stored_status = payload.get("status")
+    phase_owner = payload.get("phase_owner")
+    if stored_status == "result-processing" and isinstance(phase_owner, str) and phase_owner:
+        seat = phase_owner
+        active_seats = ()
+    phase = failure_phase or {
+        "started": "startup",
+        "planning": "planning",
+        "dispatching": "dispatch",
+        "result-processing": "result-processing",
+        "synthesizing": "synthesis",
+        "handoff": "handoff",
+        "artifact-collection": "artifact-collection",
+    }.get(stored_status, "run")
+    bounded_detail = _one_line(detail or failure_kind)[:2000]
+    failure: dict[str, object] = {
+        "phase": phase,
+        "kind": failure_kind,
+        "detail": bounded_detail,
+    }
+    if seat:
+        failure["seat"] = seat
+    elif active_seats:
+        failure["seats"] = list(active_seats)
+    finished_at = datetime.now(timezone.utc)
+    payload.update(
+        {
+            "status": status,
+            "status_started_at": _utc_iso(finished_at),
+            "error": bounded_detail,
+            "failure_phase": phase,
+            "failure": failure,
+            "finished_at": _utc_iso(finished_at),
+        }
+    )
+    started_at = payload.get("started_at")
+    if isinstance(started_at, str):
+        started = _parse_iso_datetime(started_at)
+        if started is not None:
+            payload["duration_seconds"] = max(
+                0.0,
+                round((finished_at - started).total_seconds(), 3),
+            )
+    try:
+        _write_json(run_path, payload)
+    except OSError as exc:
+        raise runguard.RetainRunLockError(f"failed to write terminal run receipt: {exc}") from exc
+
+
+def record_dispatch_stage(output_dir: Path, *, stage: int, seats: tuple[str, ...]) -> None:
+    """Record the currently executing dispatch stage without terminalizing it."""
+
+    run_path = output_dir / "run.json"
+    try:
+        payload = json.loads(run_path.read_text())
+    except OSError as exc:
+        raise runguard.RetainRunLockError(f"failed to read run receipt during stage transition: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise runguard.RetainRunLockError(f"run receipt is invalid during stage transition: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise runguard.RetainRunLockError("run receipt must contain an object during stage transition")
+    if payload.get("finished_at"):
+        return
+    payload.update(
+        {
+            "status": "dispatching",
+            "status_started_at": _utc_iso(datetime.now(timezone.utc)),
+            "active_stage": stage,
+            "active_seats": list(seats),
+        }
+    )
+    try:
+        _write_json(run_path, payload)
+    except OSError as exc:
+        raise runguard.RetainRunLockError(f"failed to write dispatch stage receipt: {exc}") from exc
+
+
+def record_result_processing(output_dir: Path, *, seat: str) -> None:
+    """Record post-dispatch result processing and clear completed worker ownership."""
+
+    run_path = output_dir / "run.json"
+    try:
+        payload = json.loads(run_path.read_text())
+    except OSError as exc:
+        raise runguard.RetainRunLockError(f"failed to read run receipt during result processing: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise runguard.RetainRunLockError(f"run receipt is invalid during result processing: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise runguard.RetainRunLockError("run receipt must contain an object during result processing")
+    if payload.get("finished_at"):
+        return
+    payload.update(
+        {
+            "status": "result-processing",
+            "status_started_at": _utc_iso(datetime.now(timezone.utc)),
+            "phase_owner": seat,
+        }
+    )
+    payload.pop("active_stage", None)
+    payload.pop("active_seats", None)
+    try:
+        _write_json(run_path, payload)
+    except OSError as exc:
+        raise runguard.RetainRunLockError(f"failed to record result-processing phase: {exc}") from exc
 
 
 def _roster_resolution_payload(roster: Roster) -> dict[str, object] | None:
@@ -1683,6 +1867,7 @@ def _run_payload(
     error: str | None = None,
     failure_phase: str | None = None,
     failure_kind: str | None = None,
+    failure_seat: str | None = None,
     transport_warning: dict[str, object] | None = None,
     code_graph: CodeGraphBrief | None = None,
     drift_impact: DriftImpactBrief | None = None,
@@ -1696,6 +1881,7 @@ def _run_payload(
     suspected_noop: bool = False,
     route: RouteBrief | None = None,
     worker: str | None = None,
+    include_git: bool = True,
 ) -> dict[str, object]:
     payload: dict[str, object] = {
         "schema": "brigade.run.v1",
@@ -1706,6 +1892,7 @@ def _run_payload(
         "read_only": read_only,
         "status": status,
         "started_at": _utc_iso(started_at),
+        "status_started_at": _utc_iso(started_at if status == "started" else datetime.now(timezone.utc)),
         "suspected_noop": suspected_noop,
         "code_graph_brief": {
             "attached": bool(code_graph.attached) if code_graph is not None else False,
@@ -1733,9 +1920,10 @@ def _run_payload(
         payload["route"] = route.payload()
     if worker is not None:
         payload["worker"] = worker
-    git = _receipt_git_snapshot(cwd)
-    if git is not None:
-        payload["git"] = git
+    if include_git:
+        git = _receipt_git_snapshot(cwd)
+        if git is not None:
+            payload["git"] = git
     if code_graph_delta is not None:
         payload["code_graph_delta"] = code_graph_delta
     if context_eval_payload is not None:
@@ -1751,11 +1939,14 @@ def _run_payload(
         payload["error"] = error
         if failure_phase is not None or failure_kind is not None:
             payload["failure_phase"] = failure_phase or "unknown"
-            payload["failure"] = {
+            failure_payload: dict[str, object] = {
                 "phase": failure_phase or "unknown",
                 "kind": failure_kind or "unknown",
                 "detail": error,
             }
+            if failure_seat is not None:
+                failure_payload["seat"] = failure_seat
+            payload["failure"] = failure_payload
     if transport_warning is not None:
         payload["transport_warning"] = dict(transport_warning)
     if codex_transport is not None:
@@ -1782,6 +1973,173 @@ def _direct_worker_error(worker: str, roster: Roster) -> str | None:
     return None
 
 
+def record_run_start(
+    output_dir: Path,
+    *,
+    task: str,
+    cwd: Path | None,
+    roster: Roster,
+    read_only: bool,
+    worker: str | None = None,
+    dry_run: bool = False,
+    lock_workspace: Path | None = None,
+    codex_transport: str | None = None,
+    started_at: datetime | None = None,
+) -> None:
+    """Write the minimal typed receipt needed before optional or blocking work."""
+
+    output_dir = output_dir.expanduser().resolve()
+    started_at = started_at or datetime.now(timezone.utc)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _write_json(
+        output_dir / "run.json",
+        _run_payload(
+            task=task,
+            cwd=cwd,
+            lock_workspace=lock_workspace if lock_workspace is not None else cwd,
+            roster=roster,
+            dry_run=dry_run,
+            read_only=read_only,
+            status="started",
+            started_at=started_at,
+            output_dir=output_dir,
+            code_graph=CodeGraphBrief(attached=False),
+            drift_impact=DriftImpactBrief(attached=False),
+            evidence=EvidenceBrief(attached=False),
+            codex_transport=codex_transport or roster.codex_transport,
+            worker=worker,
+            include_git=False,
+        ),
+    )
+    _write_json(output_dir / "roster.json", _roster_payload(roster))
+
+
+@contextmanager
+def terminal_sigterm_handler(
+    output_dir: Path | None,
+    *,
+    seat: str | None,
+    before_record: Callable[[], None] | None = None,
+    should_record: Callable[[], bool] | None = None,
+) -> Iterator[None]:
+    """Terminalize SIGTERM while preserving the conventional 128+signal exit."""
+
+    if output_dir is None or threading.current_thread() is not threading.main_thread():
+        yield
+        return
+
+    output_dir = output_dir.expanduser()
+    previous = signal.getsignal(signal.SIGTERM)
+
+    def handle_sigterm(signum: int, frame: object) -> None:  # noqa: ARG001
+        if should_record is not None and not should_record():
+            raise SystemExit(128 + signum)
+        if before_record is not None:
+            before_record()
+        run_path = output_dir / "run.json"
+        if run_path.is_file():
+            active_seats: tuple[str, ...] = ()
+            active_seat = seat
+            try:
+                payload = json.loads(run_path.read_text())
+            except (OSError, json.JSONDecodeError):
+                payload = None
+            if isinstance(payload, dict):
+                stored_active = payload.get("active_seats")
+                if isinstance(stored_active, list):
+                    active_seats = tuple(value for value in stored_active if isinstance(value, str) and value)
+                    if len(active_seats) == 1:
+                        active_seat = active_seats[0]
+                    elif active_seats:
+                        active_seat = None
+                if not active_seats:
+                    phase_owner = payload.get("phase_owner")
+                    if isinstance(phase_owner, str) and phase_owner:
+                        active_seat = phase_owner
+                    else:
+                        stored_worker = payload.get("worker")
+                        if isinstance(stored_worker, str) and stored_worker:
+                            active_seat = stored_worker
+            record_run_termination(
+                output_dir,
+                status="canceled",
+                failure_phase=None,
+                failure_kind="signal",
+                detail="run terminated by SIGTERM",
+                seat=active_seat,
+                active_seats=active_seats,
+            )
+        raise SystemExit(128 + signum)
+
+    signal.signal(signal.SIGTERM, handle_sigterm)
+    try:
+        yield
+    finally:
+        signal.signal(signal.SIGTERM, previous)
+
+
+def _terminalize_run_lifecycle(function: Callable[..., int]) -> Callable[..., int]:
+    """Ensure every artifact-producing run leaves a terminal receipt on escape."""
+
+    @wraps(function)
+    def wrapped(*args: Any, **kwargs: Any) -> int:
+        raw_output_dir = kwargs.get("output_dir")
+        output_dir = raw_output_dir.expanduser() if isinstance(raw_output_dir, Path) else None
+        raw_roster = args[1] if len(args) > 1 else kwargs.get("roster")
+        raw_worker = kwargs.get("worker")
+        seat = (
+            raw_worker
+            if isinstance(raw_worker, str) and raw_worker
+            else raw_roster.orchestrator
+            if isinstance(raw_roster, Roster)
+            else None
+        )
+
+        def terminate_existing(
+            *, status: str, failure_kind: str, detail: str, failure_phase: str | None = None
+        ) -> None:
+            if output_dir is None or not (output_dir / "run.json").is_file():
+                return
+            record_run_termination(
+                output_dir,
+                status=status,
+                failure_phase=failure_phase,
+                failure_kind=failure_kind,
+                detail=detail,
+                seat=seat,
+            )
+
+        try:
+            with terminal_sigterm_handler(output_dir, seat=seat):
+                return function(*args, **kwargs)
+        except runguard.RetainRunLockError:
+            raise
+        except KeyboardInterrupt:
+            terminate_existing(
+                status="canceled",
+                failure_kind="keyboard-interrupt",
+                detail="run canceled by user",
+            )
+            raise
+        except TimeoutError as exc:
+            terminate_existing(
+                status="timeout",
+                failure_kind="timeout",
+                detail=_one_line(str(exc)) or "run timed out",
+            )
+            raise
+        except Exception as exc:
+            terminate_existing(
+                status="failed",
+                failure_kind="unexpected-error",
+                detail=f"{type(exc).__name__}: {_one_line(str(exc)) or 'unexpected run failure'}",
+            )
+            raise
+
+    return wrapped
+
+
+@_terminalize_run_lifecycle
 def run(
     task: str,
     roster: Roster,
@@ -1811,6 +2169,7 @@ def run(
     defer_artifact_collection: bool = False,
 ) -> int:
     started_at = datetime.now(timezone.utc)
+    process_registry = proc.ProcessRegistry()
     transport_for_payload = codex_transport or roster.codex_transport
     cwd = cwd.expanduser().resolve() if cwd is not None else None
     lock_workspace = lock_workspace.expanduser().resolve() if lock_workspace is not None else cwd
@@ -1826,6 +2185,19 @@ def run(
         if worker_error is not None:
             print(f"error: {worker_error}", file=sys.stderr)
             return 2
+    if output_dir is not None:
+        record_run_start(
+            output_dir,
+            task=task,
+            cwd=cwd,
+            roster=roster,
+            read_only=read_only,
+            worker=worker,
+            dry_run=dry_run,
+            lock_workspace=lock_workspace,
+            codex_transport=transport_for_payload,
+            started_at=started_at,
+        )
     if code_graph is None:
         code_graph = code_graph_brief(cwd, task) if code_graph_enabled else CodeGraphBrief(attached=False)
     if drift_impact is None:
@@ -1915,7 +2287,8 @@ def run(
                 ),
             )
         try:
-            assignments = plan(
+            assignments = _call_with_process_registry(
+                plan,
                 task,
                 roster,
                 cwd=cwd,
@@ -1928,14 +2301,19 @@ def run(
                 evidence=evidence,
                 route=route,
                 codex_transport=transport_for_payload,
+                process_registry=process_registry,
             )
         except RuntimeError as exc:
-            failed_attempt = next(
-                (attempt for attempt in reversed(plan_attempts or []) if attempt.get("ok") is False),
-                None,
-            )
-            failure_phase = failed_attempt.get("failure_phase") if isinstance(failed_attempt, dict) else None
-            failure_kind = failed_attempt.get("failure_kind") if isinstance(failed_attempt, dict) else None
+            final_attempt = plan_attempts[-1] if plan_attempts else None
+            timed_out = isinstance(final_attempt, dict) and final_attempt.get("timed_out") is True
+            if isinstance(final_attempt, dict) and isinstance(final_attempt.get("failure_kind"), str):
+                failure_kind = final_attempt["failure_kind"]
+            elif isinstance(final_attempt, dict) and isinstance(final_attempt.get("parse_error"), str):
+                failure_kind = "invalid-plan"
+            else:
+                failure_kind = "orchestrator-error"
+            if timed_out:
+                failure_kind = "timeout"
             if output_dir is not None:
                 finished_at = datetime.now(timezone.utc)
                 _write_json(output_dir / "plan-attempts.json", {"attempts": plan_attempts or []})
@@ -1947,13 +2325,14 @@ def run(
                         roster=roster,
                         dry_run=dry_run,
                         read_only=read_only,
-                        status="failed",
+                        status="timeout" if timed_out else "failed",
                         started_at=started_at,
                         finished_at=finished_at,
                         output_dir=output_dir,
                         error=str(exc),
-                        failure_phase=(failure_phase if isinstance(failure_phase, str) else None),
-                        failure_kind=(failure_kind if isinstance(failure_kind, str) else None),
+                        failure_phase="planning",
+                        failure_kind=failure_kind,
+                        failure_seat=roster.orchestrator,
                         code_graph=code_graph,
                         drift_impact=drift_impact,
                         evidence=evidence,
@@ -2047,75 +2426,178 @@ def run(
     appserver = None
     control_registry = None
     control_server = None
-    if effective_transport == "app-server":
+
+    def close_appserver() -> None:
+        nonlocal appserver
+        server = appserver
+        appserver = None
+        close = getattr(server, "close", None)
+        if callable(close):
+            close()
+
+    def close_control_server() -> None:
+        nonlocal control_server
+        server = control_server
+        control_server = None
+        close = getattr(server, "close", None)
+        if callable(close):
+            close()
+
+    def close_server_resources() -> None:
         try:
-            appserver = codex_appserver.AppServer(cwd=cwd)
-            appserver.start()
-        except codex_appserver.AppServerError as exc:
-            print(f"warning: codex app-server unavailable ({exc}); falling back to exec", file=sys.stderr)
-            appserver = None
-            effective_transport = "exec"
-            control_socket = None
-        if appserver is not None and output_dir is not None:
-            control_registry = run_control.LiveTurnRegistry()
-            control_server = run_control.ControlServer(control_socket, control_registry)
+            close_control_server()
+        finally:
+            close_appserver()
+
+    try:
+        if effective_transport == "app-server":
             try:
-                control_transport = control_server.start()
-            except run_control.ControlError as exc:
-                print(f"warning: run control unavailable ({exc})", file=sys.stderr)
-                control_registry = None
-                control_server = None
-                control_transport = None
+                appserver = _call_with_process_registry(
+                    codex_appserver.AppServer,
+                    cwd=cwd,
+                    process_registry=process_registry,
+                )
+                appserver.start()
+            except codex_appserver.AppServerError as exc:
+                close_appserver()
+                print(f"warning: codex app-server unavailable ({exc}); falling back to exec", file=sys.stderr)
+                effective_transport = "exec"
                 control_socket = None
-    transport_for_payload = effective_transport
-    if output_dir is not None:
-        _write_json(
-            output_dir / "run.json",
-            _payload(
-                task=task,
+            if appserver is not None and output_dir is not None:
+                control_registry = run_control.LiveTurnRegistry()
+                control_server = run_control.ControlServer(control_socket, control_registry)
+                try:
+                    control_transport = control_server.start()
+                except run_control.ControlError as exc:
+                    close_control_server()
+                    print(f"warning: run control unavailable ({exc})", file=sys.stderr)
+                    control_registry = None
+                    control_transport = None
+                    control_socket = None
+        transport_for_payload = effective_transport
+        if output_dir is not None:
+            _write_json(
+                output_dir / "run.json",
+                _payload(
+                    task=task,
+                    cwd=cwd,
+                    roster=roster,
+                    dry_run=dry_run,
+                    read_only=read_only,
+                    status="dispatching",
+                    started_at=started_at,
+                    output_dir=output_dir,
+                    code_graph=code_graph,
+                    drift_impact=drift_impact,
+                    evidence=evidence,
+                    brief_set=brief_set,
+                    codex_transport=transport_for_payload,
+                    route=route,
+                    control_socket=control_socket,
+                    control_transport=control_transport,
+                    code_graph_delta=code_graph_delta,
+                    worker=worker,
+                ),
+            )
+
+        active_stage = min(assignment.stage for assignment in assignments) if assignments else 1
+        active_seats = tuple(assignment.worker for assignment in assignments if assignment.stage == active_stage)
+    except BaseException:
+        close_server_resources()
+        raise
+
+    def stage_started(stage: int, seats: tuple[str, ...]) -> None:
+        nonlocal active_stage, active_seats
+        active_stage = stage
+        active_seats = seats
+        if output_dir is not None:
+            record_dispatch_stage(output_dir, stage=stage, seats=seats)
+
+    def dispatch_interrupted() -> None:
+        if output_dir is None:
+            return
+        active_seat = active_seats[0] if len(active_seats) == 1 else None
+        record_run_termination(
+            output_dir,
+            status="canceled",
+            failure_phase="dispatch",
+            failure_kind="keyboard-interrupt",
+            detail="run canceled by user",
+            seat=active_seat,
+            active_seats=active_seats,
+        )
+
+    active_seat = active_seats[0] if len(active_seats) == 1 else None
+    try:
+        try:
+            worker_results = _call_with_process_registry(
+                dispatch,
+                assignments,
+                roster,
                 cwd=cwd,
-                roster=roster,
-                dry_run=dry_run,
                 read_only=read_only,
-                status="dispatching",
-                started_at=started_at,
-                output_dir=output_dir,
+                sandbox_read_only=sandbox_read_only,
+                sandbox=sandbox,
+                direct=direct_worker,
                 code_graph=code_graph,
                 drift_impact=drift_impact,
                 evidence=evidence,
-                brief_set=brief_set,
-                codex_transport=transport_for_payload,
-                route=route,
-                control_socket=control_socket,
-                control_transport=control_transport,
-                code_graph_delta=code_graph_delta,
-                worker=worker,
-            ),
-        )
-
-    try:
-        worker_results = dispatch(
-            assignments,
-            roster,
-            cwd=cwd,
-            read_only=read_only,
-            sandbox_read_only=sandbox_read_only,
-            sandbox=sandbox,
-            direct=direct_worker,
-            code_graph=code_graph,
-            drift_impact=drift_impact,
-            evidence=evidence,
-            appserver=appserver,
-            control_registry=control_registry,
-            events_dir=(output_dir / "events") if (output_dir is not None and appserver is not None) else None,
-            verbose=verbose,
-            authorized_writable_worktree=authorized_writable_worktree,
-        )
+                appserver=appserver,
+                control_registry=control_registry,
+                events_dir=(output_dir / "events") if (output_dir is not None and appserver is not None) else None,
+                verbose=verbose,
+                authorized_writable_worktree=authorized_writable_worktree,
+                on_stage_start=stage_started,
+                on_interrupt=dispatch_interrupted,
+                process_registry=process_registry,
+            )
+        except runguard.RetainRunLockError:
+            raise
+        except KeyboardInterrupt:
+            active_seat = active_seats[0] if len(active_seats) == 1 else None
+            if output_dir is not None:
+                record_run_termination(
+                    output_dir,
+                    status="canceled",
+                    failure_phase="dispatch",
+                    failure_kind="keyboard-interrupt",
+                    detail="run canceled by user",
+                    seat=active_seat,
+                    active_seats=active_seats,
+                )
+            raise
+        except TimeoutError as exc:
+            active_seat = active_seats[0] if len(active_seats) == 1 else None
+            detail = _one_line(str(exc)) or "worker dispatch timed out"
+            if output_dir is not None:
+                record_run_termination(
+                    output_dir,
+                    status="timeout",
+                    failure_phase="dispatch",
+                    failure_kind="timeout",
+                    detail=detail,
+                    seat=active_seat,
+                    active_seats=active_seats,
+                )
+            raise
+        except Exception as exc:
+            active_seat = active_seats[0] if len(active_seats) == 1 else None
+            detail = f"{type(exc).__name__}: {_one_line(str(exc)) or 'unexpected dispatch failure'}"
+            if output_dir is not None:
+                record_run_termination(
+                    output_dir,
+                    status="failed",
+                    failure_phase="dispatch",
+                    failure_kind="unexpected-error",
+                    detail=detail,
+                    seat=active_seat,
+                    active_seats=active_seats,
+                )
+            raise
     finally:
-        if control_server is not None:
-            control_server.close()
-        if appserver is not None:
-            appserver.close()
+        close_server_resources()
+    if output_dir is not None:
+        record_result_processing(output_dir, seat=roster.orchestrator)
     if output_dir is not None and code_graph_delta_before is not None and cwd is not None:
         code_graph_delta = graphtrail_delta.capture_after_and_diff(cwd, output_dir, code_graph_delta_before)
     context_eval_payload = _context_eval_for_run(code_graph, code_graph_delta)
@@ -2189,7 +2671,8 @@ def run(
                 ),
             )
         synthesis_started = time.monotonic()
-        final = _run_orchestrator(
+        final = _call_with_process_registry(
+            _run_orchestrator,
             roster,
             build_synth_prompt(
                 task,
@@ -2205,6 +2688,7 @@ def run(
             sandbox_read_only=sandbox_read_only,
             sandbox=sandbox,
             codex_transport=transport_for_payload,
+            process_registry=process_registry,
         )
         final = replace(final, duration_seconds=max(0.0, round(time.monotonic() - synthesis_started, 3)))
     if output_dir is not None:
@@ -2231,6 +2715,7 @@ def run(
     if not final.ok:
         if output_dir is not None:
             finished_at = datetime.now(timezone.utc)
+            interrupted = final.status == "interrupted"
             if direct_worker:
                 (output_dir / "final.txt").write_text(final.text + "\n")
             _write_json(
@@ -2241,13 +2726,21 @@ def run(
                     roster=roster,
                     dry_run=dry_run,
                     read_only=read_only,
-                    status="failed",
+                    status="timeout" if final.timed_out else "canceled" if interrupted else "failed",
                     started_at=started_at,
                     finished_at=finished_at,
                     output_dir=output_dir,
                     error=final.detail,
-                    failure_phase=final.failure_phase,
-                    failure_kind=final.failure_kind,
+                    failure_phase=(
+                        final.failure_phase
+                        or ("inference" if final.timed_out else "dispatch" if direct_worker else "synthesis")
+                    ),
+                    failure_kind=(
+                        "timeout"
+                        if final.timed_out
+                        else final.failure_kind or ("interrupted" if interrupted else "agent-error")
+                    ),
+                    failure_seat=worker if direct_worker else roster.orchestrator,
                     code_graph=code_graph,
                     drift_impact=drift_impact,
                     evidence=evidence,
@@ -2269,7 +2762,9 @@ def run(
             print(f"error: orchestrator failed during synthesis: {final.detail}", file=sys.stderr)
         return 2
     if output_dir is not None:
-        finished_at = None if defer_artifact_collection else datetime.now(timezone.utc)
+        final_status = "artifact-collection" if defer_artifact_collection else "ok"
+        pending_handoff = handoff_inbox is not None
+        finished_at = None if defer_artifact_collection or pending_handoff else datetime.now(timezone.utc)
         (output_dir / "final.txt").write_text(final.text + "\n")
         _write_json(
             output_dir / "run.json",
@@ -2279,7 +2774,7 @@ def run(
                 roster=roster,
                 dry_run=dry_run,
                 read_only=read_only,
-                status="artifact-collection" if defer_artifact_collection else "ok",
+                status="handoff" if pending_handoff else final_status,
                 started_at=started_at,
                 finished_at=finished_at,
                 output_dir=output_dir,
@@ -2322,11 +2817,14 @@ def run(
                         roster=roster,
                         dry_run=dry_run,
                         read_only=read_only,
-                        status="handoff-failed",
+                        status="failed",
                         started_at=started_at,
                         finished_at=finished_at,
                         output_dir=output_dir,
                         error=detail,
+                        failure_phase="handoff",
+                        failure_kind="handoff-write-error",
+                        failure_seat=roster.orchestrator,
                         code_graph=code_graph,
                         drift_impact=drift_impact,
                         evidence=evidence,

--- a/src/brigade/acpx_adapter.py
+++ b/src/brigade/acpx_adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import json
 import re
 from dataclasses import dataclass
@@ -76,7 +77,7 @@ def _status_payload(stdout: str) -> tuple[dict[str, Any] | None, str]:
     return payload, _safe_diagnostic(safe_stdout)
 
 
-def cursor_auth_status() -> CursorAuthStatus:
+def cursor_auth_status(*, process_registry: proc.ProcessRegistry | None = None) -> CursorAuthStatus:
     """Return a bounded, prompt-free diagnosis for the headless Cursor CLI."""
     if proc.which("cursor-agent") is None:
         return CursorAuthStatus(
@@ -86,10 +87,11 @@ def cursor_auth_status() -> CursorAuthStatus:
             "",
             127,
         )
-    result = proc.run(
-        ["cursor-agent", "status", "--format", "json"],
-        timeout=CURSOR_AUTH_TIMEOUT_SECONDS,
-    )
+    argv = ["cursor-agent", "status", "--format", "json"]
+    if process_registry is None:
+        result = proc.run(argv, timeout=CURSOR_AUTH_TIMEOUT_SECONDS)
+    else:
+        result = proc.run(argv, timeout=CURSOR_AUTH_TIMEOUT_SECONDS, process_registry=process_registry)
     payload, stdout = _status_payload(result.stdout)
     stderr = _safe_diagnostic(result.stderr)
     diagnostic = _diagnostic_line(stdout, stderr)
@@ -164,14 +166,28 @@ def build_argv(
     return argv
 
 
-def installed_version() -> tuple[str | None, str]:
-    result = proc.run(["acpx", "--version"], timeout=10.0)
+def installed_version(*, process_registry: proc.ProcessRegistry | None = None) -> tuple[str | None, str]:
+    if process_registry is None:
+        result = proc.run(["acpx", "--version"], timeout=10.0)
+    else:
+        result = proc.run(["acpx", "--version"], timeout=10.0, process_registry=process_registry)
     if result.code != 0:
         return None, result.stderr.strip() or result.stdout.strip() or f"exit {result.code}"
     match = re.search(r"\b(\d+\.\d+\.\d+)\b", result.stdout)
     if match is None:
         return None, "acpx --version did not report a semantic version"
     return match.group(1), ""
+
+
+def _call_with_process_registry(function, *, process_registry: proc.ProcessRegistry | None):
+    parameters = inspect.signature(function).parameters.values()
+    accepts_registry = any(
+        parameter.name == "process_registry" or parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters
+    )
+    if accepts_registry:
+        return function(process_registry=process_registry)
+    return function()
 
 
 def _permission_prompt_diagnostic(error: object) -> dict[str, object] | None:
@@ -349,6 +365,7 @@ def run_cursor(
     version: str,
     read_only: bool,
     writable_worktree: bool = False,
+    process_registry: proc.ProcessRegistry | None = None,
 ) -> AgentResult:
     if version != SUPPORTED_VERSION:
         return AgentResult(
@@ -377,7 +394,10 @@ def run_cursor(
             failure_kind="missing-executable",
             transport="acpx",
         )
-    installed, version_error = installed_version()
+    installed, version_error = _call_with_process_registry(
+        installed_version,
+        process_registry=process_registry,
+    )
     if installed != version:
         found = installed or version_error
         return AgentResult(
@@ -389,7 +409,10 @@ def run_cursor(
             transport="acpx",
             acpx_version=installed,
         )
-    auth = cursor_auth_status()
+    auth = _call_with_process_registry(
+        cursor_auth_status,
+        process_registry=process_registry,
+    )
     auth_event: dict[str, object] = {
         "type": "provider_auth",
         "status": auth.state,
@@ -436,7 +459,12 @@ def run_cursor(
             acpx_version=installed,
             safe_events=(auth_event,),
         )
-    result = proc.run(argv, timeout=timeout + 5.0, cwd=cwd)
+    result = proc.run(
+        argv,
+        timeout=timeout + 5.0,
+        cwd=cwd,
+        process_registry=process_registry,
+    )
     if result.decode_failed:
         detail = (result.stderr.strip() or result.decode_failure_detail)[:200]
         return AgentResult(

--- a/src/brigade/agents.py
+++ b/src/brigade/agents.py
@@ -7,6 +7,7 @@ does not store provider keys or import provider SDKs.
 from __future__ import annotations
 
 import functools
+import inspect
 import json
 import os
 import re
@@ -507,7 +508,20 @@ def detect(cli_ref: str) -> bool:
     return resolve_agent_executable(cli_ref).runnable
 
 
-def ollama_model_present(model: str, executable: proc.ExecutableIdentity | None = None) -> tuple[bool, str]:
+def _accepts_process_registry(function: Callable[..., object]) -> bool:
+    parameters = inspect.signature(function).parameters.values()
+    return any(
+        parameter.name == "process_registry" or parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters
+    )
+
+
+def ollama_model_present(
+    model: str,
+    executable: proc.ExecutableIdentity | None = None,
+    *,
+    process_registry: proc.ProcessRegistry | None = None,
+) -> tuple[bool, str]:
     """Check whether an ollama model is already pulled locally.
 
     `ollama run` on a missing model silently auto-pulls it (tens of GB for
@@ -517,7 +531,10 @@ def ollama_model_present(model: str, executable: proc.ExecutableIdentity | None 
     ollama = executable or proc.resolve_executable("ollama")
     if not ollama.runnable or ollama.path is None:
         return False, "ollama is not installed"
-    listing = proc.run([ollama.path, "list"], timeout=15.0)
+    if process_registry is None:
+        listing = proc.run([ollama.path, "list"], timeout=15.0)
+    else:
+        listing = proc.run([ollama.path, "list"], timeout=15.0, process_registry=process_registry)
     if listing.code != 0:
         reason = listing.stderr.strip() or f"exit {listing.code}"
         return False, f"could not list local ollama models ({reason[:120]}); is the ollama server running?"
@@ -657,6 +674,7 @@ def run_agent(
     reasoning: str | None = None,
     env: dict[str, str] | None = None,
     resume_session_id: str | None = None,
+    process_registry: proc.ProcessRegistry | None = None,
 ) -> AgentResult:
     child_env: dict[str, str] | None = None
     resolved_overrides: dict[str, str] | None = None
@@ -719,12 +737,27 @@ def run_agent(
             )
         from . import codex_cloud
 
+        if process_registry is not None and _accepts_process_registry(codex_cloud.run_cloud_task):
+            return codex_cloud.run_cloud_task(
+                prompt,
+                env_id=env_id,
+                timeout=timeout,
+                cwd=cwd,
+                process_registry=process_registry,
+            )
         return codex_cloud.run_cloud_task(prompt, env_id=env_id, timeout=timeout, cwd=cwd)
 
     if cli_ref.startswith(_OLLAMA_PREFIX):
         ollama_model = cli_ref[len(_OLLAMA_PREFIX) :]
         if ollama_model:
-            present, missing_detail = ollama_model_present(ollama_model, executable)
+            if process_registry is not None and _accepts_process_registry(ollama_model_present):
+                present, missing_detail = ollama_model_present(
+                    ollama_model,
+                    executable,
+                    process_registry=process_registry,
+                )
+            else:
+                present, missing_detail = ollama_model_present(ollama_model, executable)
             if not present:
                 return AgentResult(text="", ok=False, detail=missing_detail)
     cursor_limitation = None
@@ -769,6 +802,7 @@ def run_agent(
             cwd=cwd,
             env=child_env,
             stdin=prompt.encode(),
+            process_registry=process_registry,
         )
     else:
         result = proc.run(
@@ -776,6 +810,7 @@ def run_agent(
             timeout=timeout,
             cwd=cwd,
             env=child_env,
+            process_registry=process_registry,
         )
 
     def scrub_detail(detail: str) -> str:

--- a/src/brigade/cli/run.py
+++ b/src/brigade/cli/run.py
@@ -6,13 +6,78 @@ import argparse
 import math
 import sys
 import time
+from contextlib import ExitStack, contextmanager
 from pathlib import Path
 from subprocess import DEVNULL, STDOUT, Popen
+from typing import Callable, Iterator
 
 
 _DETACH_START_TIMEOUT_SECONDS = 30.0
 _DETACH_POLL_INTERVAL_SECONDS = 0.05
 _DEFAULT_RUN_LOCK_WAIT_SECONDS = 600.0
+
+
+@contextmanager
+def _terminalize_escaped_run(
+    output_dir: Path | None,
+    *,
+    seat: str | None,
+    should_terminalize: Callable[[], bool] | None = None,
+) -> Iterator[None]:
+    from .. import aboyeur as aboyeur_mod
+    from .. import runguard
+
+    try:
+        yield
+    except runguard.RetainRunLockError:
+        raise
+    except KeyboardInterrupt:
+        if (
+            (should_terminalize is None or should_terminalize())
+            and output_dir is not None
+            and (output_dir / "run.json").is_file()
+        ):
+            aboyeur_mod.record_run_termination(
+                output_dir,
+                status="canceled",
+                failure_phase=None,
+                failure_kind="keyboard-interrupt",
+                detail="run canceled by user",
+                seat=seat,
+            )
+        raise
+    except TimeoutError as exc:
+        detail = " ".join(str(exc).split()) or "run timed out"
+        if (
+            (should_terminalize is None or should_terminalize())
+            and output_dir is not None
+            and (output_dir / "run.json").is_file()
+        ):
+            aboyeur_mod.record_run_termination(
+                output_dir,
+                status="timeout",
+                failure_phase=None,
+                failure_kind="timeout",
+                detail=detail,
+                seat=seat,
+            )
+        raise
+    except Exception as exc:
+        detail = f"{type(exc).__name__}: {' '.join(str(exc).split()) or 'unexpected run failure'}"
+        if (
+            (should_terminalize is None or should_terminalize())
+            and output_dir is not None
+            and (output_dir / "run.json").is_file()
+        ):
+            aboyeur_mod.record_run_termination(
+                output_dir,
+                status="failed",
+                failure_phase=None,
+                failure_kind="unexpected-error",
+                detail=detail,
+                seat=seat,
+            )
+        raise
 
 
 def _non_negative_seconds(value: str) -> float:
@@ -245,13 +310,12 @@ def dispatch(args) -> int:
         if worker_error is not None:
             print(f"error: {worker_error}", file=sys.stderr)
             return 2
-    output_dir = None
-    if not args.no_artifacts:
-        output_dir = args.output_dir or aboyeur_mod.make_run_dir(run_cwd / ".brigade" / "runs")
     handoff_inbox = None
     if args.handoff:
         handoff_inbox = args.handoff_inbox or (run_cwd / ".claude" / "memory-handoffs")
     effective_sandbox = args.sandbox if args.sandbox is not None else loaded_roster.sandbox
+    advisory: list[str] = []
+    output_warnings: list[str] = []
     if args.read_only:
         advisory = _read_only_advisory(loaded_roster, effective_sandbox, worker=args.worker)
         output_warnings = _read_only_output_warnings(loaded_roster, worker=args.worker)
@@ -267,18 +331,6 @@ def dispatch(args) -> int:
             print("warning: direct Cursor read-only output is model-limited:", file=sys.stderr)
             for line in output_warnings:
                 print(f"  - {line}", file=sys.stderr)
-        if output_dir is not None and (advisory or output_warnings):
-            from .. import localio
-
-            localio.write_json(
-                output_dir / "read-only-enforcement.json",
-                {
-                    "read_only": True,
-                    "sandbox": effective_sandbox,
-                    "best_effort_agents": advisory,
-                    "output_warnings": output_warnings,
-                },
-            )
     # The dirty guard protects write runs from mixing agent edits with uncommitted
     # work. Dry, read-only, and worktree runs never edit the tree, so reviewing
     # uncommitted changes stays possible without --allow-dirty.
@@ -290,23 +342,57 @@ def dispatch(args) -> int:
         print(f"error: {exc}", file=sys.stderr)
         return 2
 
+    output_dir = None
+    if not args.no_artifacts:
+        output_dir = args.output_dir or aboyeur_mod.make_run_dir(run_cwd / ".brigade" / "runs")
+
     if args.detach:
         assert output_dir is not None
         return _dispatch_detached(
             args,
             run_cwd=run_cwd,
             roster_resolution=roster_resolution,
+            roster=loaded_roster,
             output_dir=output_dir,
         )
 
     worktree_cwd = None
     effective_cwd = run_cwd
     keep_worktree = False
+    lifecycle_seat = args.worker or loaded_roster.orchestrator
     try:
-        with runguard.run_lock(run_cwd, run_dir=output_dir, wait_seconds=args.wait):
+        with ExitStack() as lifecycle:
+            lifecycle.enter_context(_terminalize_escaped_run(output_dir, seat=lifecycle_seat))
+            lifecycle.enter_context(aboyeur_mod.terminal_sigterm_handler(output_dir, seat=lifecycle_seat))
+            if output_dir is not None:
+                aboyeur_mod.record_run_start(
+                    output_dir,
+                    task=args.task,
+                    cwd=run_cwd,
+                    roster=loaded_roster,
+                    read_only=args.read_only,
+                    worker=args.worker,
+                    dry_run=args.dry_run,
+                    lock_workspace=run_cwd,
+                    codex_transport=args.codex_transport or loaded_roster.codex_transport,
+                )
+            if output_dir is not None and (advisory or output_warnings):
+                from .. import localio
+
+                localio.write_json(
+                    output_dir / "read-only-enforcement.json",
+                    {
+                        "read_only": True,
+                        "sandbox": effective_sandbox,
+                        "best_effort_agents": advisory,
+                        "output_warnings": output_warnings,
+                    },
+                )
+            lifecycle.enter_context(runguard.run_lock(run_cwd, run_dir=output_dir, wait_seconds=args.wait))
             if args.worktree:
                 worktree_cwd = _worktree_checkout_path(runguard.git_root(run_cwd), output_dir)
                 effective_cwd = runguard.create_detached_worktree(run_cwd, worktree_cwd)
+                keep_worktree = True
                 print(f"worktree: {effective_cwd}", file=sys.stderr)
             run_kwargs = {
                 "dry_run": args.dry_run,
@@ -339,12 +425,49 @@ def dispatch(args) -> int:
                 run_kwargs["route_template"] = args.route_template
             if args.route_signals:
                 run_kwargs["route_overrides"] = tuple(args.route_signals)
-            rc = aboyeur_mod.run(args.task, loaded_roster, **run_kwargs)
+            try:
+                rc = aboyeur_mod.run(args.task, loaded_roster, **run_kwargs)
+            except runguard.RetainRunLockError:
+                raise
+            except KeyboardInterrupt:
+                if output_dir is not None:
+                    aboyeur_mod.record_run_termination(
+                        output_dir,
+                        status="canceled",
+                        failure_phase=None,
+                        failure_kind="keyboard-interrupt",
+                        detail="run canceled by user",
+                        seat=lifecycle_seat,
+                    )
+                raise
+            except TimeoutError as exc:
+                detail = " ".join(str(exc).split()) or "run timed out"
+                if output_dir is not None:
+                    aboyeur_mod.record_run_termination(
+                        output_dir,
+                        status="timeout",
+                        failure_phase=None,
+                        failure_kind="timeout",
+                        detail=detail,
+                        seat=lifecycle_seat,
+                    )
+                raise
+            except Exception as exc:
+                detail = f"{type(exc).__name__}: {' '.join(str(exc).split()) or 'unexpected run failure'}"
+                if output_dir is not None:
+                    aboyeur_mod.record_run_termination(
+                        output_dir,
+                        status="failed",
+                        failure_phase=None,
+                        failure_kind="unexpected-error",
+                        detail=detail,
+                        seat=lifecycle_seat,
+                    )
+                raise
             if args.worktree and output_dir is not None:
                 # Until the patch is proven good, the worktree is the only
                 # recoverable copy of the agents' edits; a collection failure
                 # must not let cleanup destroy it.
-                keep_worktree = True
                 patch_path = output_dir / "changes.patch"
                 try:
                     summary = runguard.collect_changes_patch(effective_cwd, patch_path)
@@ -420,8 +543,25 @@ def dispatch(args) -> int:
                         )
                     else:
                         print(f"changes: none ({summary.path})", file=sys.stderr)
+    except KeyboardInterrupt:
+        print("error: run canceled by user", file=sys.stderr)
+        if worktree_cwd is not None and keep_worktree:
+            print(f"worktree kept for recovery: {worktree_cwd}", file=sys.stderr)
+        return 130
     except runguard.RunGuardError as exc:
         print(f"error: {exc}", file=sys.stderr)
+        if worktree_cwd is not None and keep_worktree:
+            print(f"worktree kept for recovery: {worktree_cwd}", file=sys.stderr)
+        return 2
+    except TimeoutError as exc:
+        detail = " ".join(str(exc).split()) or "worker dispatch timed out"
+        print(f"error: run timed out: {detail}", file=sys.stderr)
+        if worktree_cwd is not None and keep_worktree:
+            print(f"worktree kept for recovery: {worktree_cwd}", file=sys.stderr)
+        return 2
+    except Exception as exc:
+        detail = " ".join(str(exc).split()) or "unexpected run failure"
+        print(f"error: unexpected run failure: {type(exc).__name__}: {detail}", file=sys.stderr)
         if worktree_cwd is not None and keep_worktree:
             print(f"worktree kept for recovery: {worktree_cwd}", file=sys.stderr)
         return 2
@@ -438,48 +578,145 @@ def dispatch(args) -> int:
     return rc
 
 
-def _dispatch_detached(args, *, run_cwd: Path, roster_resolution, output_dir: Path) -> int:
+def _dispatch_detached(args, *, run_cwd: Path, roster_resolution, roster, output_dir: Path) -> int:
+    from .. import aboyeur as aboyeur_mod
+    from .. import proc as proc_mod
+
     output_dir = output_dir.expanduser().resolve()
-    output_dir.mkdir(parents=True, exist_ok=True)
-    log_path = output_dir / "detached.log"
-    argv = _detached_child_argv(
-        args,
-        run_cwd=run_cwd,
-        roster_resolution=roster_resolution,
-        output_dir=output_dir,
-    )
+    lifecycle_seat = args.worker or roster.orchestrator
+    startup_registry = proc_mod.ProcessRegistry()
+    child = None
+    child_handoff = False
+
+    def cancel_startup_child() -> None:
+        if child is not None and not child_handoff:
+            startup_registry.cancel()
+
     try:
-        with log_path.open("a", encoding="utf-8") as log:
-            proc = Popen(
-                argv,
-                cwd=run_cwd,
-                stdin=DEVNULL,
-                stdout=log,
-                stderr=STDOUT,
-                start_new_session=True,
+        with ExitStack() as lifecycle:
+            lifecycle.enter_context(
+                _terminalize_escaped_run(
+                    output_dir,
+                    seat=lifecycle_seat,
+                    should_terminalize=lambda: not child_handoff,
+                )
             )
-    except OSError as exc:
-        print(f"error: failed to start detached run: {exc}", file=sys.stderr)
-        print(f"log: {log_path}", file=sys.stderr)
-        return 2
+            lifecycle.enter_context(
+                aboyeur_mod.terminal_sigterm_handler(
+                    output_dir,
+                    seat=lifecycle_seat,
+                    before_record=cancel_startup_child,
+                    should_record=lambda: not child_handoff,
+                )
+            )
+            aboyeur_mod.record_run_start(
+                output_dir,
+                task=args.task,
+                cwd=run_cwd,
+                roster=roster,
+                read_only=args.read_only,
+                worker=args.worker,
+            )
+            initial_receipt = (output_dir / "run.json").read_bytes()
+            log_path = output_dir / "detached.log"
+            argv = _detached_child_argv(
+                args,
+                run_cwd=run_cwd,
+                roster_resolution=roster_resolution,
+                output_dir=output_dir,
+            )
+            try:
+                with log_path.open("a", encoding="utf-8") as log:
+                    child = Popen(
+                        argv,
+                        cwd=run_cwd,
+                        stdin=DEVNULL,
+                        stdout=log,
+                        stderr=STDOUT,
+                        start_new_session=True,
+                    )
+                    startup_registry.register(child)
+            except OSError as exc:
+                if child is not None:
+                    startup_registry.terminate(child)
+                detail = f"failed to start detached run: {exc}"
+                aboyeur_mod.record_run_termination(
+                    output_dir,
+                    status="failed",
+                    failure_phase="startup",
+                    failure_kind="spawn-error",
+                    detail=detail,
+                    seat=lifecycle_seat,
+                )
+                print(f"error: {detail}", file=sys.stderr)
+                print(f"log: {log_path}", file=sys.stderr)
+                return 2
+            except BaseException:
+                if child is not None:
+                    startup_registry.terminate(child)
+                raise
 
-    exit_code = _poll_detached_start(proc, output_dir)
-    if exit_code is not None:
-        print(f"error: detached child exited before run metadata was written: exit {exit_code}", file=sys.stderr)
-        print(f"artifacts: {output_dir}", file=sys.stderr)
-        print(f"log: {log_path}", file=sys.stderr)
-        return 2
+            try:
+                exit_code, metadata_taken_over = _poll_detached_start(
+                    child,
+                    output_dir,
+                    initial_receipt=initial_receipt,
+                )
+            except BaseException:
+                cancel_startup_child()
+                raise
+            if metadata_taken_over:
+                child_handoff = True
+                startup_registry.unregister(child)
+            elif exit_code is None:
+                cancel_startup_child()
+                detail = f"detached child did not write run metadata within {_DETACH_START_TIMEOUT_SECONDS:g} seconds"
+                aboyeur_mod.record_run_termination(
+                    output_dir,
+                    status="timeout",
+                    failure_phase="startup",
+                    failure_kind="timeout",
+                    detail=detail,
+                    seat=lifecycle_seat,
+                )
+                print(f"error: {detail}", file=sys.stderr)
+                print(f"artifacts: {output_dir}", file=sys.stderr)
+                print(f"log: {log_path}", file=sys.stderr)
+                return 2
+            else:
+                startup_registry.unregister(child)
+            if exit_code is not None:
+                detail = f"detached child exited before run metadata was written: exit {exit_code}"
+                aboyeur_mod.record_run_termination(
+                    output_dir,
+                    status="failed",
+                    failure_phase="startup",
+                    failure_kind="early-exit",
+                    detail=detail,
+                    seat=lifecycle_seat,
+                )
+                print(f"error: {detail}", file=sys.stderr)
+                print(f"artifacts: {output_dir}", file=sys.stderr)
+                print(f"log: {log_path}", file=sys.stderr)
+                return 2
 
-    if not (output_dir / "run.json").is_file():
-        print(
-            "warning: detached child has not written run metadata yet; check the log for startup progress.",
-            file=sys.stderr,
-        )
-    print(f"run: {output_dir.name}")
-    print(f"detached: pid {proc.pid}", file=sys.stderr)
-    print(f"artifacts: {output_dir}", file=sys.stderr)
-    print(f"log: {log_path}", file=sys.stderr)
-    return 0
+            if not (output_dir / "run.json").is_file():
+                print(
+                    "warning: detached child has not written run metadata yet; check the log for startup progress.",
+                    file=sys.stderr,
+                )
+            print(f"run: {output_dir.name}")
+            print(f"detached: pid {child.pid}", file=sys.stderr)
+            print(f"artifacts: {output_dir}", file=sys.stderr)
+            print(f"log: {log_path}", file=sys.stderr)
+            return 0
+    except KeyboardInterrupt:
+        print("error: run canceled by user", file=sys.stderr)
+        return 130
+    except Exception as exc:
+        detail = " ".join(str(exc).split()) or "unexpected run failure"
+        print(f"error: unexpected run failure: {type(exc).__name__}: {detail}", file=sys.stderr)
+        return 2
 
 
 def _detached_child_argv(args, *, run_cwd: Path, roster_resolution, output_dir: Path) -> list[str]:
@@ -542,17 +779,20 @@ def _direct_worker_error(worker: str, loaded_roster, roster_mod) -> str | None:
     return None
 
 
-def _poll_detached_start(proc: Popen, output_dir: Path) -> int | None:
+def _poll_detached_start(proc: Popen, output_dir: Path, *, initial_receipt: bytes) -> tuple[int | None, bool]:
     run_json = output_dir / "run.json"
     deadline = time.monotonic() + _DETACH_START_TIMEOUT_SECONDS
     while time.monotonic() < deadline:
-        if run_json.is_file():
-            return None
+        try:
+            if run_json.read_bytes() != initial_receipt:
+                return None, True
+        except OSError:
+            pass
         exit_code = proc.poll()
         if exit_code is not None:
-            return exit_code
+            return exit_code, False
         time.sleep(_DETACH_POLL_INTERVAL_SECONDS)
-    return None
+    return None, False
 
 
 def _worktree_checkout_path(repo_root: Path, output_dir: Path) -> Path:

--- a/src/brigade/codex_appserver.py
+++ b/src/brigade/codex_appserver.py
@@ -10,6 +10,7 @@ always auto-declined: brigade runs are headless and rely on approvalPolicy
 from __future__ import annotations
 
 import json
+import os
 import queue
 import subprocess
 import threading
@@ -17,7 +18,9 @@ import time
 from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable
+from typing import Any, Callable, cast
+
+from . import proc as proc_mod
 
 _CLIENT_NAME = "brigade"
 _CLIENT_VERSION = "0.0.0"
@@ -52,14 +55,21 @@ class TurnResult:
     status: str  # complete | interrupted | failed
     thread_id: str
     detail: str = ""
+    timed_out: bool = False
 
 
 class AppServer:
     """One `codex app-server` child; thread-safe for concurrent CodexThread turns."""
 
-    def __init__(self, argv: list[str] | None = None, cwd: Path | None = None) -> None:
+    def __init__(
+        self,
+        argv: list[str] | None = None,
+        cwd: Path | None = None,
+        process_registry: proc_mod.ProcessRegistry | None = None,
+    ) -> None:
         self._argv = argv or ["codex", "app-server"]
         self._cwd = cwd
+        self._process_registry = process_registry or proc_mod.ProcessRegistry()
         self._proc: subprocess.Popen | None = None
         self._write_lock = threading.Lock()
         self._state_lock = threading.Lock()
@@ -77,6 +87,15 @@ class AppServer:
         self.close()
 
     def start(self) -> None:
+        process_group_kwargs: dict[str, Any] = {}
+        if os.name == "posix":
+            process_group_kwargs["start_new_session"] = True
+        elif os.name == "nt":
+            process_group_kwargs["creationflags"] = getattr(
+                subprocess,
+                "CREATE_NEW_PROCESS_GROUP",
+                0x00000200,
+            )
         try:
             self._proc = subprocess.Popen(
                 self._argv,
@@ -85,26 +104,31 @@ class AppServer:
                 stderr=subprocess.DEVNULL,
                 text=True,
                 cwd=self._cwd,
+                **process_group_kwargs,
             )
+            self._process_registry.register(cast("subprocess.Popen[bytes]", self._proc))
         except OSError as exc:
             raise AppServerError(f"failed to spawn {self._argv[0]}: {exc}") from exc
-        threading.Thread(target=self._read_loop, daemon=True).start()
-        self.request(
-            "initialize",
-            {"clientInfo": {"name": _CLIENT_NAME, "version": _CLIENT_VERSION}},
-        )
-        self._send({"jsonrpc": "2.0", "method": "initialized"})
+        try:
+            threading.Thread(target=self._read_loop, daemon=True).start()
+            self.request(
+                "initialize",
+                {"clientInfo": {"name": _CLIENT_NAME, "version": _CLIENT_VERSION}},
+            )
+            self._send({"jsonrpc": "2.0", "method": "initialized"})
+        except BaseException:
+            self.close()
+            raise
 
     def close(self) -> None:
         proc = self._proc
+        self._proc = None
         if proc is None:
             return
-        proc.terminate()
         try:
-            proc.wait(timeout=5.0)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            proc.wait(timeout=5.0)
+            self._process_registry.terminate(cast("subprocess.Popen[bytes]", proc))
+        finally:
+            self._process_registry.unregister(cast("subprocess.Popen[bytes]", proc))
 
     def request(self, method: str, params: dict, timeout: float = _REQUEST_TIMEOUT) -> dict:
         with self._state_lock:
@@ -315,7 +339,14 @@ class CodexThread:
             turn = completed["params"]["turn"]
             if turn.get("status") == "failed":
                 detail = ((turn.get("error") or {}).get("message") or detail)[:200]
-        return TurnResult(text=salvaged, ok=False, status="interrupted", thread_id=self.thread_id, detail=detail)
+        return TurnResult(
+            text=salvaged,
+            ok=False,
+            status="interrupted",
+            thread_id=self.thread_id,
+            detail=detail,
+            timed_out=True,
+        )
 
     def _consume(
         self,

--- a/src/brigade/codex_cloud.py
+++ b/src/brigade/codex_cloud.py
@@ -75,9 +75,21 @@ def run_cloud_task(
     poll_interval: float = POLL_INTERVAL,
     sleep=time.sleep,
     clock=time.monotonic,
+    process_registry: proc.ProcessRegistry | None = None,
 ):
     """Submit, poll, and collect one Codex Cloud task. Mirrors run_agent's contract."""
     from .agents import AgentResult
+
+    def timeout_result(detail: str, *, task_id: str | None = None, text: str = ""):
+        return AgentResult(
+            text=text[:DIFF_CAP],
+            ok=False,
+            detail=detail[:200],
+            failure_kind="timeout",
+            thread_id=task_id,
+            status="timeout",
+            timed_out=True,
+        )
 
     argv = ["codex", "cloud", "exec", "--env", env_id]
     if attempts > 1:
@@ -86,8 +98,16 @@ def run_cloud_task(
         argv += ["--branch", branch]
     argv.append(prompt)
 
+    def run_command(command: list[str], *, command_timeout: float) -> proc.Result:
+        if process_registry is None:
+            return proc.run(command, timeout=command_timeout, cwd=cwd)
+        return proc.run(command, timeout=command_timeout, cwd=cwd, process_registry=process_registry)
+
     deadline = clock() + timeout
-    submit = proc.run(argv, timeout=min(timeout, SUBMIT_TIMEOUT), cwd=cwd)
+    submit = run_command(argv, command_timeout=min(timeout, SUBMIT_TIMEOUT))
+    if submit.code == 124:
+        detail = submit.stderr.strip() or submit.stdout.strip() or "exit 124"
+        return timeout_result(f"cloud submit timed out: {detail}")
     if submit.code != 0:
         detail = submit.stderr.strip() or submit.stdout.strip() or f"exit {submit.code}"
         return AgentResult(text="", ok=False, detail=f"cloud submit failed: {detail}"[:200])
@@ -103,12 +123,18 @@ def run_cloud_task(
     status_text = ""
     status_word = None
     while True:
-        st = proc.run(
+        st = run_command(
             ["codex", "cloud", "status", task_id],
-            timeout=min(POLL_TIMEOUT, remaining()),
-            cwd=cwd,
+            command_timeout=min(POLL_TIMEOUT, remaining()),
         )
         status_text = (st.stdout + "\n" + st.stderr).strip()
+        if st.code == 124:
+            detail = st.stderr.strip() or st.stdout.strip() or "exit 124"
+            return timeout_result(
+                f"cloud status timed out for task {task_id}: {detail}",
+                task_id=task_id,
+                text=status_text,
+            )
         if st.code == 0:
             status_word = _scan_status(status_text)
             if status_word in TERMINAL_FAIL:
@@ -122,23 +148,25 @@ def run_cloud_task(
             if status_word in TERMINAL_OK:
                 break
         if clock() >= deadline:
-            return AgentResult(
-                text=status_text[:DIFF_CAP],
-                ok=False,
-                detail=(
-                    f"cloud task {task_id} still pending after {int(timeout)}s; check `codex cloud status {task_id}`"
-                )[:200],
-                thread_id=task_id,
-                status="pending",
+            return timeout_result(
+                f"cloud task {task_id} timed out after {int(timeout)}s; check `codex cloud status {task_id}`",
+                task_id=task_id,
+                text=status_text,
             )
         sleep(poll_interval)
 
-    diff = proc.run(
+    diff = run_command(
         ["codex", "cloud", "diff", task_id],
-        timeout=min(DIFF_TIMEOUT, remaining(floor=30.0)),
-        cwd=cwd,
+        command_timeout=min(DIFF_TIMEOUT, remaining(floor=30.0)),
     )
     parts = [f"codex cloud task {task_id} [{status_word}]", status_text]
+    if diff.code == 124:
+        detail = diff.stderr.strip() or diff.stdout.strip() or "exit 124"
+        return timeout_result(
+            f"cloud diff timed out for task {task_id}: {detail}",
+            task_id=task_id,
+            text=status_text,
+        )
     if diff.code != 0:
         err = diff.stderr.strip() or f"exit {diff.code}"
         parts.append(f"WARNING: `codex cloud diff {task_id}` failed: {err[:300]}")

--- a/src/brigade/context_eval.py
+++ b/src/brigade/context_eval.py
@@ -60,7 +60,7 @@ def extract_brief_files(brief_text: str) -> list[str]:
             if candidate is not None:
                 files.add(candidate)
         return sorted(files)
-    except BaseException:
+    except Exception:
         return []
 
 
@@ -87,7 +87,7 @@ def extract_delta_files(delta_sidecar_path_or_dict: str | Path | dict[str, Any])
                 if candidate is not None:
                     files.add(candidate)
         return sorted(files)
-    except BaseException:
+    except Exception:
         return []
 
 

--- a/src/brigade/graphtrail_delta.py
+++ b/src/brigade/graphtrail_delta.py
@@ -97,7 +97,7 @@ def capture_before(target: Path, run_dir: Path, *, timeout: float = 10.0) -> dic
             "graphtrail_timeout_seconds": timeout,
             "sync": sync,
         }
-    except BaseException as exc:
+    except Exception as exc:
         return _status("capture_failed", f"code graph delta unavailable: {type(exc).__name__}: {exc}")
 
 
@@ -247,11 +247,11 @@ def capture_after_and_diff(
         return _write_and_compact(
             run_dir, payload, snapshot_path=snapshot_path, after_snapshot_path=after_snapshot_path
         )
-    except BaseException as exc:
+    except Exception as exc:
         payload = _status("capture_failed", f"code graph delta unavailable: {type(exc).__name__}: {exc}")
         try:
             return _write_and_compact(run_dir, payload)
-        except BaseException:
+        except Exception:
             return _compact(payload)
 
 
@@ -261,7 +261,7 @@ def _compact_summary(delta: dict[str, Any] | None) -> str:
         if not isinstance(delta, dict):
             return "code graph delta unavailable"
         return str(delta.get("summary") or _summary(str(delta.get("status") or "unknown"), {}, 0, 0))
-    except BaseException:
+    except Exception:
         return "code graph delta unavailable"
 
 

--- a/src/brigade/proc.py
+++ b/src/brigade/proc.py
@@ -5,12 +5,16 @@ from __future__ import annotations
 import errno
 import json
 import ntpath
+import os
+import signal
 import shutil
 import subprocess
 import sys
+import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, List, Optional
 
 _STREAM_ENCODING = "utf-8"
 _UNSUPPORTED_WINDOWS_SUFFIXES: dict[str, str] = {
@@ -22,6 +26,113 @@ _UNSUPPORTED_WINDOWS_SUFFIXES: dict[str, str] = {
     ".msi": "Windows installer",
 }
 _WINDOWS_BATCH_SUFFIXES = frozenset({".cmd", ".bat"})
+_WINDOWS_NEW_PROCESS_GROUP = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200)
+_TIMED_OUT_DRAIN_SECONDS = 0.5
+
+
+class ProcessRegistry:
+    """Own cancellable subprocess groups for one worker dispatch."""
+
+    def __init__(self, *, terminate_grace: float = 0.5, kill_grace: float = 0.5) -> None:
+        self._terminate_grace = terminate_grace
+        self._kill_grace = kill_grace
+        self._lock = threading.Lock()
+        self._processes: set[subprocess.Popen[bytes]] = set()
+        self._canceled = False
+
+    def register(self, process: subprocess.Popen[bytes]) -> None:
+        with self._lock:
+            if not self._canceled:
+                self._processes.add(process)
+                return
+        _terminate_processes(
+            (process,),
+            terminate_grace=self._terminate_grace,
+            kill_grace=self._kill_grace,
+        )
+
+    def unregister(self, process: subprocess.Popen[bytes]) -> None:
+        with self._lock:
+            self._processes.discard(process)
+
+    def cancel(self) -> None:
+        with self._lock:
+            self._canceled = True
+            processes = tuple(self._processes)
+        _terminate_processes(
+            processes,
+            terminate_grace=self._terminate_grace,
+            kill_grace=self._kill_grace,
+        )
+
+    def terminate(self, process: subprocess.Popen[bytes]) -> None:
+        _terminate_processes(
+            (process,),
+            terminate_grace=self._terminate_grace,
+            kill_grace=self._kill_grace,
+        )
+
+
+def _signal_process_group(process: subprocess.Popen[bytes], sig: int) -> None:
+    try:
+        if os.name == "posix":
+            os.killpg(process.pid, sig)
+        elif sig == signal.SIGTERM:
+            process.terminate()
+        else:
+            process.kill()
+    except OSError:
+        pass
+
+
+def _terminate_windows_process_tree(process: subprocess.Popen[bytes], *, timeout: float) -> None:
+    try:
+        subprocess.run(
+            ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=max(timeout, 0.1),
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    if process.poll() is None:
+        try:
+            process.kill()
+        except OSError:
+            pass
+
+
+def _wait_for_processes(processes: tuple[subprocess.Popen[bytes], ...], timeout: float) -> None:
+    deadline = time.monotonic() + max(timeout, 0.0)
+    while any(process.poll() is None for process in processes):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return
+        time.sleep(min(0.01, remaining))
+
+
+def _terminate_processes(
+    processes: tuple[subprocess.Popen[bytes], ...],
+    *,
+    terminate_grace: float,
+    kill_grace: float,
+) -> None:
+    if not processes:
+        return
+    if os.name == "nt":
+        timeout = terminate_grace + kill_grace
+        for process in processes:
+            _terminate_windows_process_tree(process, timeout=timeout)
+        _wait_for_processes(processes, kill_grace)
+        return
+    for process in processes:
+        _signal_process_group(process, signal.SIGTERM)
+    _wait_for_processes(processes, terminate_grace)
+    for process in processes:
+        _signal_process_group(process, signal.SIGKILL)
+    _wait_for_processes(processes, kill_grace)
 
 
 @dataclass
@@ -215,8 +326,63 @@ def run(
     env: Optional[dict] = None,
     cwd: Optional[Path] = None,
     stdin: bytes | None = None,
+    process_registry: ProcessRegistry | None = None,
 ) -> Result:
     try:
+        if process_registry is not None:
+            process_group_kwargs: dict[str, Any] = {}
+            if os.name == "posix":
+                process_group_kwargs["start_new_session"] = True
+            elif os.name == "nt":
+                process_group_kwargs["creationflags"] = _WINDOWS_NEW_PROCESS_GROUP
+            process = subprocess.Popen(
+                args,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                stdin=subprocess.DEVNULL if stdin is None else subprocess.PIPE,
+                env=env,
+                cwd=cwd,
+                shell=False,
+                **process_group_kwargs,
+            )
+            process_registry.register(process)
+            try:
+                process_stdout, process_stderr = process.communicate(input=stdin, timeout=timeout)
+            except subprocess.TimeoutExpired:
+                process_registry.terminate(process)
+                try:
+                    process_stdout, process_stderr = process.communicate(timeout=_TIMED_OUT_DRAIN_SECONDS)
+                except subprocess.TimeoutExpired as drain_exc:
+                    process_stdout, process_stderr = drain_exc.output, drain_exc.stderr
+                    for stream_name in ("stdout", "stderr"):
+                        stream = getattr(process, stream_name, None)
+                        if stream is not None:
+                            try:
+                                stream.close()
+                            except OSError:
+                                pass
+                result = _result_from_output(code=124, stdout=process_stdout, stderr=process_stderr)
+                timeout_detail = f"timeout after {timeout}s"
+                result_stderr = result.stderr
+                if result_stderr and not result_stderr.endswith("\n"):
+                    result_stderr += "\n"
+                return Result(
+                    code=124,
+                    stdout=result.stdout,
+                    stderr=result_stderr + timeout_detail,
+                    stdout_decode_error=result.stdout_decode_error,
+                    stderr_decode_error=result.stderr_decode_error,
+                )
+            except BaseException:
+                process_registry.terminate(process)
+                raise
+            finally:
+                process_registry.unregister(process)
+            return _result_from_output(
+                code=process.returncode,
+                stdout=process_stdout,
+                stderr=process_stderr,
+            )
         if stdin is None:
             cp = subprocess.run(
                 args,

--- a/src/brigade/run_receipts.py
+++ b/src/brigade/run_receipts.py
@@ -45,6 +45,7 @@ def worker_payload(results: list[WorkerResult]) -> list[dict[str, object]]:
             entry["status"] = result.status
         if result.exit_code is not None:
             entry["exit_code"] = result.exit_code
+        if result.exit_code is not None or result.timed_out:
             entry["timed_out"] = result.timed_out
         if result.stdout_log is not None:
             entry["stdout_log"] = result.stdout_log
@@ -115,6 +116,7 @@ def agent_result_payload(result: agents.AgentResult) -> dict[str, object]:
         payload["transport_warning"] = dict(result.transport_warning)
     if result.exit_code is not None:
         payload["exit_code"] = result.exit_code
+    if result.exit_code is not None or result.timed_out:
         payload["timed_out"] = result.timed_out
     if result.stdout_log is not None:
         payload["stdout_log"] = result.stdout_log

--- a/src/brigade/run_resume.py
+++ b/src/brigade/run_resume.py
@@ -17,7 +17,16 @@ from .roster import Agent, Roster, _as_env
 
 _RESUMABLE_STATUSES = ("interrupted", "failed")
 _NONTERMINAL_RUN_STATUSES = frozenset(
-    {"started", "planning", "dispatching", "synthesizing", "artifact-collection", "running"}
+    {
+        "started",
+        "planning",
+        "dispatching",
+        "result-processing",
+        "synthesizing",
+        "handoff",
+        "artifact-collection",
+        "running",
+    }
 )
 
 

--- a/src/brigade/run_transport.py
+++ b/src/brigade/run_transport.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import os
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -11,7 +12,7 @@ from pathlib import Path
 from typing import Any, Callable, Protocol
 from urllib.parse import urlparse
 
-from . import agents, run_control
+from . import agents, proc, run_control
 from .roster import Agent, Roster, is_cli_allowed, timeout_for
 
 _GROK_CONTINUATION_PROMPT = (
@@ -229,8 +230,41 @@ def dispatch(
     events_dir: Path | None = None,
     verbose: bool = False,
     authorized_writable_worktree: bool = False,
+    on_stage_start: Callable[[int, tuple[str, ...]], None] | None = None,
+    on_interrupt: Callable[[], None] | None = None,
+    process_registry: proc.ProcessRegistry | None = None,
 ) -> list[WorkerResult]:
     """Dispatch staged assignments while keeping transport policy in one module."""
+
+    process_registry = process_registry or proc.ProcessRegistry()
+
+    def run_direct_agent(*args: Any, **kwargs: Any) -> agents.AgentResult:
+        runner = agents.run_agent
+        parameters = inspect.signature(runner).parameters.values()
+        accepts_registry = any(
+            parameter.name == "process_registry" or parameter.kind is inspect.Parameter.VAR_KEYWORD
+            for parameter in parameters
+        )
+        if not accepts_registry:
+            kwargs.pop("process_registry", None)
+        return runner(*args, **kwargs)
+
+    def cancel_active_work(futures: dict[Any, int]) -> None:
+        for future in futures:
+            future.cancel()
+        process_registry.cancel()
+        if control_registry is not None:
+            try:
+                control_registry.interrupt()
+            except Exception:
+                pass
+        if appserver is not None:
+            close = getattr(appserver, "close", None)
+            if callable(close):
+                try:
+                    close()
+                except Exception:
+                    pass
 
     def run_one(assignment: Assignment, prior_results: list[WorkerResult]) -> WorkerResult:
         agent = roster.agents[assignment.worker]
@@ -278,9 +312,10 @@ def dispatch(
                     version=selected_agent.transport_version or "",
                     read_only=effective_read_only,
                     writable_worktree=authorized_writable_worktree,
+                    process_registry=process_registry,
                 )
             if resume_session_id is not None:
-                return agents.run_agent(
+                return run_direct_agent(
                     cli_ref,
                     selected_prompt,
                     timeout=timeout_for(selected_agent, roster),
@@ -291,6 +326,7 @@ def dispatch(
                     reasoning=selected_agent.reasoning,
                     env=dict(selected_agent.env) if selected_agent.env is not None else None,
                     resume_session_id=resume_session_id,
+                    process_registry=process_registry,
                 )
             if selected_agent.env is not None:
                 # Env seats always dispatch through the direct CLI path. The
@@ -302,13 +338,14 @@ def dispatch(
                     env_kwargs["model"] = selected_agent.model
                 if selected_agent.reasoning is not None:
                     env_kwargs["reasoning"] = selected_agent.reasoning
-                return agents.run_agent(
+                return run_direct_agent(
                     cli_ref,
                     selected_prompt,
                     timeout=timeout_for(selected_agent, roster),
                     cwd=cwd,
                     read_only=effective_read_only,
                     env=dict(selected_agent.env),
+                    process_registry=process_registry,
                     **env_kwargs,
                 )
             if selected_agent.cli == "codex" and appserver is not None:
@@ -328,38 +365,46 @@ def dispatch(
 
             timeout = timeout_for(selected_agent, roster)
             if sandbox is None and selected_agent.model is None and selected_agent.reasoning is None:
-                return agents.run_agent(
-                    cli_ref, selected_prompt, timeout=timeout, cwd=cwd, read_only=effective_read_only
+                return run_direct_agent(
+                    cli_ref,
+                    selected_prompt,
+                    timeout=timeout,
+                    cwd=cwd,
+                    read_only=effective_read_only,
+                    process_registry=process_registry,
                 )
             if sandbox is not None and selected_agent.model is None and selected_agent.reasoning is None:
-                return agents.run_agent(
+                return run_direct_agent(
                     cli_ref,
                     selected_prompt,
                     timeout=timeout,
                     cwd=cwd,
                     read_only=effective_read_only,
                     sandbox=sandbox,
+                    process_registry=process_registry,
                 )
             if sandbox is None and selected_agent.model is not None and selected_agent.reasoning is None:
-                return agents.run_agent(
+                return run_direct_agent(
                     cli_ref,
                     selected_prompt,
                     timeout=timeout,
                     cwd=cwd,
                     read_only=effective_read_only,
                     model=selected_agent.model,
+                    process_registry=process_registry,
                 )
             if sandbox is None and selected_agent.model is None and selected_agent.reasoning is not None:
-                return agents.run_agent(
+                return run_direct_agent(
                     cli_ref,
                     selected_prompt,
                     timeout=timeout,
                     cwd=cwd,
                     read_only=effective_read_only,
                     reasoning=selected_agent.reasoning,
+                    process_registry=process_registry,
                 )
             if sandbox is not None and selected_agent.model is not None and selected_agent.reasoning is None:
-                return agents.run_agent(
+                return run_direct_agent(
                     cli_ref,
                     selected_prompt,
                     timeout=timeout,
@@ -367,9 +412,10 @@ def dispatch(
                     read_only=effective_read_only,
                     sandbox=sandbox,
                     model=selected_agent.model,
+                    process_registry=process_registry,
                 )
             if sandbox is not None and selected_agent.model is None and selected_agent.reasoning is not None:
-                return agents.run_agent(
+                return run_direct_agent(
                     cli_ref,
                     selected_prompt,
                     timeout=timeout,
@@ -377,9 +423,10 @@ def dispatch(
                     read_only=effective_read_only,
                     sandbox=sandbox,
                     reasoning=selected_agent.reasoning,
+                    process_registry=process_registry,
                 )
             if sandbox is None and selected_agent.model is not None and selected_agent.reasoning is not None:
-                return agents.run_agent(
+                return run_direct_agent(
                     cli_ref,
                     selected_prompt,
                     timeout=timeout,
@@ -387,11 +434,12 @@ def dispatch(
                     read_only=effective_read_only,
                     model=selected_agent.model,
                     reasoning=selected_agent.reasoning,
+                    process_registry=process_registry,
                 )
             assert sandbox is not None
             assert selected_agent.model is not None
             assert selected_agent.reasoning is not None
-            return agents.run_agent(
+            return run_direct_agent(
                 cli_ref,
                 selected_prompt,
                 timeout=timeout,
@@ -400,6 +448,7 @@ def dispatch(
                 sandbox=sandbox,
                 model=selected_agent.model,
                 reasoning=selected_agent.reasoning,
+                process_registry=process_registry,
             )
 
         def finish(
@@ -532,13 +581,15 @@ def dispatch(
     all_results: list[WorkerResult] = []
     for stage in sorted({assignment.stage for assignment in assignments}):
         stage_assignments = [assignment for assignment in assignments if assignment.stage == stage]
+        if on_stage_start is not None:
+            on_stage_start(stage, tuple(assignment.worker for assignment in stage_assignments))
         stage_results_by_index: dict[int, WorkerResult] = {}
         prior_results = list(all_results)
-        with ThreadPoolExecutor(max_workers=min(roster.max_workers, len(stage_assignments))) as executor:
-            future_to_index = {
-                executor.submit(run_one, assignment, prior_results): index
-                for index, assignment in enumerate(stage_assignments)
-            }
+        executor = ThreadPoolExecutor(max_workers=min(roster.max_workers, len(stage_assignments)))
+        future_to_index = {}
+        try:
+            for index, assignment in enumerate(stage_assignments):
+                future_to_index[executor.submit(run_one, assignment, prior_results)] = index
             for future in as_completed(future_to_index):
                 index = future_to_index[future]
                 try:
@@ -552,5 +603,19 @@ def dispatch(
                         ok=False,
                         detail=str(exc)[:200],
                     )
+        except KeyboardInterrupt:
+            try:
+                if on_interrupt is not None:
+                    on_interrupt()
+            finally:
+                cancel_active_work(future_to_index)
+                executor.shutdown(wait=True, cancel_futures=True)
+            raise
+        except BaseException:
+            cancel_active_work(future_to_index)
+            executor.shutdown(wait=True, cancel_futures=True)
+            raise
+        else:
+            executor.shutdown(wait=True)
         all_results.extend(stage_results_by_index[index] for index in range(len(stage_assignments)))
     return all_results

--- a/src/brigade/runguard.py
+++ b/src/brigade/runguard.py
@@ -17,7 +17,16 @@ from uuid import uuid4
 from . import localio, proc
 
 _NONTERMINAL_RUN_STATUSES = frozenset(
-    {"started", "planning", "dispatching", "synthesizing", "artifact-collection", "running"}
+    {
+        "started",
+        "planning",
+        "dispatching",
+        "result-processing",
+        "synthesizing",
+        "handoff",
+        "artifact-collection",
+        "running",
+    }
 )
 
 
@@ -310,6 +319,25 @@ def _recover_run_artifact(owner: dict[str, object] | None) -> str:
                 return "terminal"
     recovered_at = datetime.now(timezone.utc).isoformat()
     detail = f"run owner process {owner_pid} is no longer active"
+    failure_attribution: dict[str, object] = {}
+    stored_status = payload.get("status")
+    active_seats = payload.get("active_seats")
+    phase_owner = payload.get("phase_owner")
+    if stored_status == "dispatching" and isinstance(active_seats, list):
+        seats = [seat for seat in active_seats if isinstance(seat, str) and seat]
+        if len(seats) == 1:
+            failure_attribution["seat"] = seats[0]
+        elif seats:
+            failure_attribution["seats"] = seats
+    if not failure_attribution and isinstance(phase_owner, str) and phase_owner:
+        failure_attribution["seat"] = phase_owner
+    if not failure_attribution:
+        worker = payload.get("worker")
+        orchestrator = payload.get("orchestrator")
+        if isinstance(worker, str) and worker:
+            failure_attribution["seat"] = worker
+        elif isinstance(orchestrator, str) and orchestrator:
+            failure_attribution["seat"] = orchestrator
     workspace = owner.get("_lock_workspace")
     if isinstance(workspace, str) and workspace:
         payload.setdefault("cwd", workspace)
@@ -320,6 +348,7 @@ def _recover_run_artifact(owner: dict[str, object] | None) -> str:
     payload.update(
         {
             "status": "failed",
+            "status_started_at": recovered_at,
             "finished_at": recovered_at,
             "error": detail,
             "failure_phase": "stale-lock-recovery",
@@ -330,6 +359,7 @@ def _recover_run_artifact(owner: dict[str, object] | None) -> str:
                 "owner_pid": owner_pid,
                 "prior_status": prior_status,
                 "recovered_at": recovered_at,
+                **failure_attribution,
             },
         }
     )

--- a/src/brigade/runs_cmd.py
+++ b/src/brigade/runs_cmd.py
@@ -5,11 +5,21 @@ from __future__ import annotations
 import json
 import sys
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 _NONTERMINAL_STATUSES = frozenset(
-    {"started", "planning", "dispatching", "synthesizing", "artifact-collection", "running"}
+    {
+        "started",
+        "planning",
+        "dispatching",
+        "result-processing",
+        "synthesizing",
+        "handoff",
+        "artifact-collection",
+        "running",
+    }
 )
 _SUCCESS_STATUSES = frozenset({"ok", "dry-run"})
 
@@ -443,6 +453,79 @@ def _collect_runs(root: Path) -> tuple[list[tuple[Path, dict[str, Any]]], int]:
     return runs, skipped
 
 
+def _positive_timeout(value: object) -> float | None:
+    if isinstance(value, (int, float)) and value > 0:
+        return float(value)
+    return None
+
+
+def _run_timeout_seconds(run_dir: Path, meta: dict[str, Any]) -> float | None:
+    try:
+        roster = _read_json(run_dir / "roster.json")
+    except (OSError, ValueError):
+        return None
+    if roster is None:
+        return None
+    default_timeout = _positive_timeout(roster.get("timeout_seconds"))
+    agents = roster.get("agents")
+    if not isinstance(agents, dict):
+        return default_timeout
+
+    status = meta.get("status")
+    seats: list[str] = []
+    if status in {"planning", "result-processing", "synthesizing", "handoff"}:
+        orchestrator = roster.get("orchestrator")
+        if isinstance(orchestrator, str):
+            seats.append(orchestrator)
+    elif isinstance(meta.get("worker"), str):
+        seats.append(meta["worker"])
+    elif status == "dispatching" and isinstance(meta.get("active_seats"), list):
+        seats.extend(seat for seat in meta["active_seats"] if isinstance(seat, str))
+    elif status == "started":
+        orchestrator = roster.get("orchestrator")
+        if isinstance(orchestrator, str):
+            seats.append(orchestrator)
+    else:
+        try:
+            plan = _read_json(run_dir / "plan.json")
+        except (OSError, ValueError):
+            plan = None
+        if plan is not None:
+            assignments = plan.get("assignments")
+            if isinstance(assignments, list):
+                seats.extend(
+                    item["worker"]
+                    for item in assignments
+                    if isinstance(item, dict) and isinstance(item.get("worker"), str)
+                )
+
+    timeouts: list[float] = []
+    for seat in seats:
+        agent = agents.get(seat)
+        seat_timeout = _positive_timeout(agent.get("timeout_seconds")) if isinstance(agent, dict) else None
+        if seat_timeout is not None:
+            timeouts.append(seat_timeout)
+        elif default_timeout is not None:
+            timeouts.append(default_timeout)
+    return max(timeouts) if timeouts else default_timeout
+
+
+def _stale_timeout(run_dir: Path, meta: dict[str, Any]) -> float | None:
+    if _is_terminal(meta):
+        return None
+    timeout = _run_timeout_seconds(run_dir, meta)
+    started_at = meta.get("status_started_at", meta.get("started_at"))
+    if timeout is None or not isinstance(started_at, str):
+        return None
+    try:
+        started = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if started.tzinfo is None:
+        started = started.replace(tzinfo=timezone.utc)
+    return timeout if time.time() - started.timestamp() > timeout else None
+
+
 def list_runs(*, cwd: Path, runs_dir: Path | None = None, limit: int = 10) -> int:
     if limit < 1:
         print("error: --limit must be a positive integer", file=sys.stderr)
@@ -460,13 +543,15 @@ def list_runs(*, cwd: Path, runs_dir: Path | None = None, limit: int = 10) -> in
     runs, skipped = _collect_runs(root)
     for path, meta in runs[:limit]:
         status = meta.get("status", "unknown")
+        stale_timeout = _stale_timeout(path, meta)
+        status_text = f"{status}; stale > {stale_timeout:g}s timeout" if stale_timeout is not None else str(status)
         started = meta.get("started_at", path.name)
         duration = meta.get("duration_seconds")
         duration_text = f" {duration:g}s" if isinstance(duration, (int, float)) else ""
         mode = " read-only" if meta.get("read_only") else ""
         if meta.get("dry_run"):
             mode += " dry-run"
-        print(f"{started} [{status}]{duration_text}{mode} {path}")
+        print(f"{started} [{status_text}]{duration_text}{mode} {path}")
         task = _short(meta.get("task"))
         if task:
             print(f"  {task}")

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -1,6 +1,10 @@
 import json
 import os
+import signal
 import subprocess
+import sys
+import time
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -10,6 +14,7 @@ from brigade import agents
 from brigade import context_eval
 from brigade import evidence_brief
 from brigade import proc
+from brigade import runguard
 from brigade.roster import Agent, Roster
 from tests.work_cmd_test_helpers import _init_git_repo
 
@@ -405,6 +410,24 @@ def test_context_eval_reports_sorted_hits_misses_and_rate():
     }
 
 
+@pytest.mark.parametrize("signal_type", [KeyboardInterrupt, SystemExit])
+def test_context_eval_extractors_propagate_process_signals(monkeypatch, signal_type):
+    class SignalPattern:
+        def finditer(self, text):  # noqa: ARG002
+            raise signal_type()
+
+    class SignalMapping(dict):
+        def get(self, key, default=None):  # noqa: ARG002
+            raise signal_type()
+
+    monkeypatch.setattr(context_eval, "_BACKTICK_RE", SignalPattern())
+    with pytest.raises(signal_type):
+        context_eval.extract_brief_files("src/brigade/context_eval.py")
+
+    with pytest.raises(signal_type):
+        context_eval.extract_delta_files(SignalMapping())
+
+
 def test_context_eval_for_run_returns_none_when_stale_graph_used(tmp_path):
     brief = aboyeur.CodeGraphBrief(
         attached=True,
@@ -423,6 +446,30 @@ def test_context_eval_for_run_returns_none_when_stale_graph_used(tmp_path):
     }
 
     assert aboyeur._context_eval_for_run(brief, delta) is None
+
+
+@pytest.mark.parametrize("signal_type", [KeyboardInterrupt, SystemExit])
+def test_context_eval_for_run_propagates_process_signals(monkeypatch, tmp_path, signal_type):
+    brief = aboyeur.CodeGraphBrief(attached=True, text="- `src/brigade/aboyeur.py:10`", bytes=36)
+    delta = {"ok": True, "sidecar_path": str(tmp_path / "graph-delta.json")}
+
+    def raise_signal(path):
+        raise signal_type()
+
+    monkeypatch.setattr(aboyeur.context_eval, "extract_delta_files", raise_signal)
+
+    with pytest.raises(signal_type):
+        aboyeur._context_eval_for_run(brief, delta)
+
+
+@pytest.mark.parametrize("signal_type", [KeyboardInterrupt, SystemExit])
+def test_context_eval_fact_propagates_process_signals(signal_type):
+    class SignalMapping(dict):
+        def get(self, key, default=None):
+            raise signal_type()
+
+    with pytest.raises(signal_type):
+        aboyeur._context_eval_fact(SignalMapping())
 
 
 def test_ground_truth_facts_surface_context_eval_metric_once():
@@ -1069,6 +1116,7 @@ def test_run_direct_worker_failure_reports_and_records(monkeypatch, capsys, tmp_
         "phase": "output-validation",
         "kind": "non-final-output",
         "detail": "provider returned progress or intent without a final result",
+        "seat": "coder",
     }
     synthesis = json.loads((output_dir / "synthesis.json").read_text())
     assert synthesis["mode"] == "direct-worker"
@@ -1424,6 +1472,188 @@ def test_run_defers_success_until_worktree_artifact_collection(monkeypatch, tmp_
     assert "duration_seconds" in run_payload
 
 
+def test_record_run_termination_is_idempotent_for_finished_receipt(tmp_path):
+    output_dir = tmp_path / "run"
+    output_dir.mkdir()
+    run_path = output_dir / "run.json"
+    run_path.write_text(
+        json.dumps(
+            {
+                "status": "failed",
+                "started_at": "2026-07-19T12:00:00Z",
+                "finished_at": "2026-07-19T12:00:01Z",
+                "failure_phase": "planning",
+                "failure": {
+                    "phase": "planning",
+                    "kind": "invalid-plan",
+                    "detail": "specific planning failure",
+                    "seat": "chef",
+                },
+            }
+        )
+        + "\n"
+    )
+    before = run_path.read_bytes()
+
+    aboyeur.record_run_termination(
+        output_dir,
+        status="failed",
+        failure_phase="run",
+        failure_kind="unexpected-error",
+        detail="fallback failure",
+        seat="chef",
+    )
+
+    assert run_path.read_bytes() == before
+
+
+@pytest.mark.parametrize("primary_status", ["ok", "failed", "timeout", "canceled", "handoff-failed", "interrupted"])
+def test_artifact_collection_failure_preserves_terminal_primary_receipt(tmp_path, primary_status):
+    output_dir = tmp_path / "run"
+    output_dir.mkdir()
+    run_path = output_dir / "run.json"
+    primary = {
+        "status": primary_status,
+        "started_at": "2026-07-19T12:00:00Z",
+        "finished_at": "2026-07-19T12:00:01Z",
+        "error": "primary failure",
+        "failure_phase": "inference",
+        "failure": {
+            "phase": "inference",
+            "kind": "provider-error",
+            "detail": "primary failure",
+            "seat": "coder",
+            "reason": "provider stopped",
+        },
+    }
+    run_path.write_text(json.dumps(primary) + "\n")
+
+    aboyeur.record_artifact_collection(
+        output_dir,
+        status="failed",
+        failure_phase="artifact-validation",
+        failure_kind="invalid-patch",
+        detail="changes.patch failed validation",
+    )
+
+    receipt = json.loads(run_path.read_text())
+    assert {key: receipt[key] for key in primary} == primary
+    assert receipt["artifact_collection"]["failure"] == {
+        "phase": "artifact-validation",
+        "kind": "invalid-patch",
+        "detail": "changes.patch failed validation",
+    }
+
+
+@pytest.mark.parametrize("escape", ["keyboard", "sigterm"])
+def test_post_dispatch_escape_uses_result_processing_phase_owner(monkeypatch, tmp_path, escape):
+    output_dir = tmp_path / "run"
+    monkeypatch.setattr(
+        aboyeur,
+        "plan",
+        lambda *args, **kwargs: [aboyeur.Assignment(worker="coder", task="implement")],
+    )
+    monkeypatch.setattr(
+        aboyeur,
+        "dispatch",
+        lambda *args, **kwargs: [aboyeur.WorkerResult(worker="coder", task="implement", text="done", ok=True)],
+    )
+    monkeypatch.setattr(aboyeur.graphtrail_delta, "capture_before", lambda *args, **kwargs: {})
+
+    def interrupt_after_dispatch(*args, **kwargs):  # noqa: ARG001
+        receipt = json.loads((output_dir / "run.json").read_text())
+        assert receipt["status"] == "result-processing"
+        assert receipt["phase_owner"] == "chef"
+        assert "active_stage" not in receipt
+        assert "active_seats" not in receipt
+        if escape == "sigterm":
+            signal.raise_signal(signal.SIGTERM)
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(aboyeur.graphtrail_delta, "capture_after_and_diff", interrupt_after_dispatch)
+
+    expected_kind = "signal" if escape == "sigterm" else "keyboard-interrupt"
+    expected_exception = SystemExit if escape == "sigterm" else KeyboardInterrupt
+    with pytest.raises(expected_exception):
+        aboyeur.run(
+            "build feature",
+            _roster(),
+            worker="coder",
+            cwd=tmp_path,
+            output_dir=output_dir,
+            route_enabled=False,
+        )
+
+    receipt = json.loads((output_dir / "run.json").read_text())
+    assert receipt["status"] == "canceled"
+    assert receipt["failure"]["phase"] == "result-processing"
+    assert receipt["failure"]["kind"] == expected_kind
+    assert receipt["failure"]["seat"] == "chef"
+
+
+@pytest.mark.skipif(not hasattr(time, "tzset"), reason="requires POSIX timezone control")
+@pytest.mark.parametrize("terminalizer", ["artifact", "termination"])
+def test_legacy_naive_started_at_is_treated_as_utc(tmp_path, terminalizer):
+    output_dir = tmp_path / "run"
+    output_dir.mkdir()
+    started_at = (datetime.now(timezone.utc) - timedelta(seconds=10)).replace(tzinfo=None).isoformat()
+    status = "artifact-collection" if terminalizer == "artifact" else "dispatching"
+    (output_dir / "run.json").write_text(json.dumps({"status": status, "started_at": started_at}) + "\n")
+
+    prior_tz = os.environ.get("TZ")
+    os.environ["TZ"] = "America/New_York"
+    time.tzset()
+    try:
+        if terminalizer == "artifact":
+            aboyeur.record_artifact_collection(output_dir, status="ok")
+        else:
+            aboyeur.record_run_termination(
+                output_dir,
+                status="canceled",
+                failure_phase="dispatch",
+                failure_kind="signal",
+                detail="canceled",
+                seat="coder",
+            )
+    finally:
+        if prior_tz is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = prior_tz
+        time.tzset()
+
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert 5 <= run_meta["duration_seconds"] <= 30
+
+
+def test_record_run_termination_write_error_retains_run_lock(tmp_path, monkeypatch):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    output_dir = workspace / ".brigade" / "runs" / "active"
+    output_dir.mkdir(parents=True)
+    (output_dir / "run.json").write_text(
+        json.dumps({"status": "dispatching", "started_at": "2026-07-19T12:00:00Z"}) + "\n"
+    )
+    monkeypatch.setattr(
+        aboyeur,
+        "_write_json",
+        lambda path, payload: (_ for _ in ()).throw(OSError("receipt disk full")),
+    )
+
+    with pytest.raises(runguard.RetainRunLockError, match="failed to write terminal run receipt: receipt disk full"):
+        with runguard.run_lock(workspace, run_dir=output_dir):
+            aboyeur.record_run_termination(
+                output_dir,
+                status="failed",
+                failure_phase="dispatch",
+                failure_kind="unexpected-error",
+                detail="provider failed",
+                seat="coder",
+            )
+
+    assert runguard.lock_path(workspace).is_dir()
+
+
 def test_run_direct_worker_writes_complete_process_logs(monkeypatch, tmp_path):
     def fake_run_agent(cli_ref, prompt, **kwargs):
         return agents.AgentResult(
@@ -1457,6 +1687,40 @@ def test_run_direct_worker_writes_complete_process_logs(monkeypatch, tmp_path):
     synthesis = json.loads((output_dir / "synthesis.json").read_text())["result"]
     assert synthesis["stdout_log"] == worker_payload["stdout_log"]
     assert synthesis["stderr_log"] == worker_payload["stderr_log"]
+
+
+def test_run_direct_worker_preserves_timeout_as_terminal_status(monkeypatch, tmp_path):
+    def fake_run_agent(cli_ref, prompt, **kwargs):
+        return agents.AgentResult(
+            text="",
+            ok=False,
+            detail="worker timed out",
+            timed_out=True,
+        )
+
+    output_dir = tmp_path / "run"
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+
+    assert (
+        aboyeur.run(
+            "do exactly this",
+            _roster(),
+            worker="coder",
+            output_dir=output_dir,
+            route_enabled=False,
+        )
+        == 2
+    )
+
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "timeout"
+    assert run_meta["finished_at"].endswith("Z")
+    assert run_meta["failure"] == {
+        "phase": "inference",
+        "kind": "timeout",
+        "detail": "worker timed out",
+        "seat": "coder",
+    }
 
 
 def test_run_direct_worker_dry_run_skips_agents_and_writes_synthetic_plan(monkeypatch, tmp_path, capsys):
@@ -1528,6 +1792,182 @@ def test_run_dispatches_stages_in_order_with_earlier_context(monkeypatch):
     assert calls[-1][0] == "codex"
     assert "implementation output" in calls[-1][1]
     assert "review output" in calls[-1][1]
+
+
+def test_run_stage_two_interruption_records_current_stage_seat(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_run_agent(cli_ref, prompt, **kwargs):
+        calls.append(cli_ref)
+        if len(calls) == 1:
+            return agents.AgentResult(
+                text=json.dumps(
+                    {
+                        "assignments": [
+                            {"stage": 1, "worker": "coder", "task": "implement"},
+                            {"stage": 2, "worker": "reviewer", "task": "review"},
+                        ]
+                    }
+                ),
+                ok=True,
+            )
+        if len(calls) == 2:
+            return agents.AgentResult(text="implemented", ok=True)
+        raise KeyboardInterrupt
+
+    output_dir = tmp_path / "run"
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+
+    with pytest.raises(KeyboardInterrupt):
+        aboyeur.run(
+            "build feature",
+            _roster(),
+            output_dir=output_dir,
+            code_graph_enabled=False,
+            route_enabled=False,
+        )
+
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "canceled"
+    assert run_meta["active_stage"] == 2
+    assert run_meta["active_seats"] == ["reviewer"]
+    assert run_meta["status_started_at"].endswith("Z")
+    assert run_meta["failure"] == {
+        "phase": "dispatch",
+        "kind": "keyboard-interrupt",
+        "detail": "run canceled by user",
+        "seat": "reviewer",
+    }
+
+
+def test_run_terminalizes_keyboard_interrupt_during_planning_without_cli(monkeypatch, tmp_path):
+    output_dir = tmp_path / "run"
+
+    def interrupted_plan(*args, **kwargs):  # noqa: ARG001
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(aboyeur, "plan", interrupted_plan)
+
+    with pytest.raises(KeyboardInterrupt):
+        aboyeur.run(
+            "build feature",
+            _roster(),
+            output_dir=output_dir,
+            code_graph_enabled=False,
+            route_enabled=False,
+        )
+
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "canceled"
+    assert run_meta["finished_at"].endswith("Z")
+    assert run_meta["failure"] == {
+        "phase": "planning",
+        "kind": "keyboard-interrupt",
+        "detail": "run canceled by user",
+        "seat": "chef",
+    }
+
+
+def test_run_terminalizes_unexpected_synthesis_error_without_cli(monkeypatch, tmp_path):
+    output_dir = tmp_path / "run"
+    monkeypatch.setattr(
+        aboyeur,
+        "plan",
+        lambda *args, **kwargs: [aboyeur.Assignment(worker="coder", task="implement")],
+    )
+    monkeypatch.setattr(
+        aboyeur,
+        "dispatch",
+        lambda *args, **kwargs: [aboyeur.WorkerResult(worker="coder", task="implement", text="done", ok=True)],
+    )
+
+    def failed_synthesis(*args, **kwargs):  # noqa: ARG001
+        raise RuntimeError("synthesis exploded")
+
+    monkeypatch.setattr(aboyeur, "_run_orchestrator", failed_synthesis)
+
+    with pytest.raises(RuntimeError, match="synthesis exploded"):
+        aboyeur.run(
+            "build feature",
+            _roster(),
+            output_dir=output_dir,
+            code_graph_enabled=False,
+            route_enabled=False,
+        )
+
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "failed"
+    assert run_meta["finished_at"].endswith("Z")
+    assert run_meta["failure"] == {
+        "phase": "synthesis",
+        "kind": "unexpected-error",
+        "detail": "RuntimeError: synthesis exploded",
+        "seat": "chef",
+    }
+
+
+def test_direct_run_terminalizes_sigterm_in_subprocess(tmp_path):
+    output_dir = tmp_path / "run"
+    script = f"""
+import time
+from pathlib import Path
+from brigade import aboyeur
+from brigade.roster import Agent, Roster
+
+roster = Roster(
+    orchestrator="chef",
+    agents={{
+        "chef": Agent("chef", "codex", "plan"),
+        "coder": Agent("coder", "codex", "code"),
+    }},
+)
+
+def blocked_plan(*args, **kwargs):
+    while True:
+        time.sleep(0.05)
+
+aboyeur.plan = blocked_plan
+aboyeur.run(
+    "build feature",
+    roster,
+    output_dir=Path({str(output_dir)!r}),
+    code_graph_enabled=False,
+    route_enabled=False,
+)
+"""
+    child_env = os.environ.copy()
+    child_env["PYTHONPATH"] = str(Path(__file__).parents[1] / "src")
+    proc = subprocess.Popen([sys.executable, "-c", script], env=child_env)
+    try:
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            try:
+                run_meta = json.loads((output_dir / "run.json").read_text())
+            except (OSError, json.JSONDecodeError):
+                time.sleep(0.02)
+                continue
+            if run_meta.get("status") == "planning":
+                break
+            time.sleep(0.02)
+        else:
+            pytest.fail("direct run did not reach planning before SIGTERM")
+
+        proc.send_signal(signal.SIGTERM)
+        assert proc.wait(timeout=5) == 128 + signal.SIGTERM
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5)
+
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "canceled"
+    assert run_meta["finished_at"].endswith("Z")
+    assert run_meta["failure"] == {
+        "phase": "planning",
+        "kind": "signal",
+        "detail": "run terminated by SIGTERM",
+        "seat": "chef",
+    }
 
 
 def test_run_uses_roster_timeouts(monkeypatch):
@@ -1676,6 +2116,7 @@ def test_direct_acpx_auth_failure_reaches_worker_run_receipt_and_human_summary(m
         "phase": "preflight",
         "kind": "provider-auth",
         "detail": diagnosis,
+        "seat": "composer",
     }
 
 
@@ -2557,12 +2998,57 @@ def test_invalid_plan_writes_attempt_artifact(monkeypatch, tmp_path, capsys):
     assert run_meta["started_at"].endswith("Z")
     assert run_meta["finished_at"].endswith("Z")
     assert run_meta["duration_seconds"] >= 0
+    assert run_meta["failure"] == {
+        "phase": "planning",
+        "kind": "invalid-plan",
+        "detail": "orchestrator returned an invalid plan: plan is not valid JSON: Expecting value: line 1 column 1 (char 0)",
+        "seat": "chef",
+    }
     attempts = json.loads((output_dir / "plan-attempts.json").read_text())["attempts"]
     assert [attempt["stage"] for attempt in attempts] == ["initial", "correction"]
     assert [attempt["parsed"] for attempt in attempts] == [False, False]
     assert all(attempt["text"] == "not json" for attempt in attempts)
+    assert all(attempt["timed_out"] is False for attempt in attempts)
+    assert all(attempt["status"] == "" for attempt in attempts)
     assert all("plan is not valid JSON" in attempt["parse_error"] for attempt in attempts)
     assert not (output_dir / "plan.json").exists()
+
+
+def test_plan_timeout_writes_terminal_timeout_receipt(monkeypatch, tmp_path):
+    def fake_run_agent(cli_ref, prompt, **kwargs):
+        return agents.AgentResult(
+            text="",
+            ok=False,
+            detail="planner timed out",
+            timed_out=True,
+            status="timeout",
+        )
+
+    output_dir = tmp_path / "run"
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+
+    assert (
+        aboyeur.run(
+            "build feature",
+            _roster(),
+            output_dir=output_dir,
+            code_graph_enabled=False,
+            route_enabled=False,
+        )
+        == 2
+    )
+
+    attempt = json.loads((output_dir / "plan-attempts.json").read_text())["attempts"][0]
+    assert attempt["timed_out"] is True
+    assert attempt["status"] == "timeout"
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "timeout"
+    assert run_meta["failure"] == {
+        "phase": "planning",
+        "kind": "timeout",
+        "detail": "orchestrator failed during plan: planner timed out",
+        "seat": "chef",
+    }
 
 
 def test_plan_output_validation_failure_preserves_typed_receipts(monkeypatch, tmp_path):
@@ -2585,8 +3071,12 @@ def test_plan_output_validation_failure_preserves_typed_receipts(monkeypatch, tm
     assert attempt["failure_kind"] == "non-final-output"
     run_meta = json.loads((output_dir / "run.json").read_text())
     assert run_meta["status"] == "failed"
-    assert run_meta["failure_phase"] == "output-validation"
-    assert run_meta["failure"]["kind"] == "non-final-output"
+    assert run_meta["failure"] == {
+        "phase": "planning",
+        "kind": "non-final-output",
+        "detail": "orchestrator failed during plan: provider returned progress or intent without a final result",
+        "seat": "chef",
+    }
 
 
 def test_synthesis_failure_writes_artifact(monkeypatch, tmp_path, capsys):
@@ -2639,7 +3129,17 @@ def test_run_writes_handoff(monkeypatch, tmp_path, capsys):
 
     inbox = tmp_path / ".claude" / "memory-handoffs"
     output_dir = tmp_path / "run"
+    original_write_handoff = aboyeur.write_run_handoff
+
+    def observed_write_handoff(*args, **kwargs):
+        run_meta = json.loads((output_dir / "run.json").read_text())
+        assert run_meta["status"] == "handoff"
+        assert "finished_at" not in run_meta
+        assert (output_dir / "final.txt").read_text() == "final answer\n## model heading\n"
+        return original_write_handoff(*args, **kwargs)
+
     monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+    monkeypatch.setattr(aboyeur, "write_run_handoff", observed_write_handoff)
 
     assert (
         aboyeur.run(
@@ -2683,6 +3183,9 @@ def test_handoff_failure_preserves_final_artifacts(monkeypatch, tmp_path, capsys
         return agents.AgentResult(text="final answer", ok=True)
 
     def fail_handoff(*args, **kwargs):
+        run_meta = json.loads((output_dir / "run.json").read_text())
+        assert run_meta["status"] == "handoff"
+        assert "finished_at" not in run_meta
         raise OSError("cannot write handoff")
 
     output_dir = tmp_path / "run"
@@ -2695,12 +3198,181 @@ def test_handoff_failure_preserves_final_artifacts(monkeypatch, tmp_path, capsys
     assert "handoff failed: cannot write handoff" in captured.err
     assert (output_dir / "final.txt").read_text() == "final answer\n"
     run_meta = json.loads((output_dir / "run.json").read_text())
-    assert run_meta["status"] == "handoff-failed"
+    assert run_meta["status"] == "failed"
     assert run_meta["error"] == "handoff failed: cannot write handoff"
+    assert run_meta["failure_phase"] == "handoff"
+    assert run_meta["failure"] == {
+        "phase": "handoff",
+        "kind": "handoff-write-error",
+        "detail": "handoff failed: cannot write handoff",
+        "seat": "chef",
+    }
     assert run_meta["artifacts"] == str(output_dir)
     assert run_meta["started_at"].endswith("Z")
     assert run_meta["finished_at"].endswith("Z")
     assert run_meta["duration_seconds"] >= 0
+
+
+@pytest.mark.parametrize(
+    ("exception", "status", "kind", "detail"),
+    [
+        (KeyboardInterrupt(), "canceled", "keyboard-interrupt", "run canceled by user"),
+        (RuntimeError("handoff exploded"), "failed", "unexpected-error", "RuntimeError: handoff exploded"),
+    ],
+)
+def test_handoff_escape_terminalizes_nonterminal_receipt(monkeypatch, tmp_path, exception, status, kind, detail):
+    calls = []
+
+    def fake_run_agent(cli_ref, prompt, **kwargs):
+        calls.append(cli_ref)
+        if len(calls) == 1:
+            return agents.AgentResult(
+                text=json.dumps({"assignments": [{"worker": "coder", "task": "implement it"}]}),
+                ok=True,
+            )
+        if cli_ref == "ollama:llama3.3":
+            return agents.AgentResult(text="worker output", ok=True)
+        return agents.AgentResult(text="final answer", ok=True)
+
+    def fail_handoff(*args, **kwargs):
+        run_meta = json.loads((output_dir / "run.json").read_text())
+        assert run_meta["status"] == "handoff"
+        assert "finished_at" not in run_meta
+        raise exception
+
+    output_dir = tmp_path / "run"
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+    monkeypatch.setattr(aboyeur, "write_run_handoff", fail_handoff)
+
+    with pytest.raises(type(exception)):
+        aboyeur.run(
+            "build feature",
+            _roster(),
+            output_dir=output_dir,
+            handoff_inbox=tmp_path / "handoffs",
+            route_enabled=False,
+        )
+
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == status
+    assert run_meta["finished_at"].endswith("Z")
+    assert run_meta["failure"] == {
+        "phase": "handoff",
+        "kind": kind,
+        "detail": detail,
+        "seat": "chef",
+    }
+
+
+def test_handoff_sigterm_terminalizes_nonterminal_receipt(tmp_path):
+    output_dir = tmp_path / "run"
+    script = f"""
+import json
+import time
+from pathlib import Path
+from brigade import aboyeur, agents
+from brigade.roster import Agent, Roster
+
+roster = Roster(
+    orchestrator="chef",
+    agents={{
+        "chef": Agent("chef", "codex", "plan"),
+        "coder": Agent("coder", "codex", "code"),
+    }},
+)
+calls = []
+def fake_run_agent(cli_ref, prompt, **kwargs):
+    calls.append(cli_ref)
+    if len(calls) == 1:
+        return agents.AgentResult(
+            text=json.dumps({{"assignments": [{{"worker": "coder", "task": "implement"}}]}}),
+            ok=True,
+        )
+    if cli_ref == "codex" and len(calls) == 2:
+        return agents.AgentResult(text="worker output", ok=True)
+    return agents.AgentResult(text="final answer", ok=True)
+def blocked_handoff(*args, **kwargs):
+    while True:
+        time.sleep(0.05)
+aboyeur.agents.run_agent = fake_run_agent
+aboyeur.write_run_handoff = blocked_handoff
+aboyeur.run(
+    "build feature",
+    roster,
+    output_dir=Path({str(output_dir)!r}),
+    handoff_inbox=Path({str(tmp_path / "handoffs")!r}),
+    code_graph_enabled=False,
+    route_enabled=False,
+)
+"""
+    child_env = os.environ.copy()
+    child_env["PYTHONPATH"] = str(Path(__file__).parents[1] / "src")
+    child = subprocess.Popen([sys.executable, "-c", script], env=child_env)
+    try:
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            try:
+                run_meta = json.loads((output_dir / "run.json").read_text())
+            except (OSError, json.JSONDecodeError):
+                time.sleep(0.02)
+                continue
+            if run_meta.get("status") == "handoff":
+                break
+            time.sleep(0.02)
+        else:
+            pytest.fail("run did not reach handoff before SIGTERM")
+
+        child.send_signal(signal.SIGTERM)
+        assert child.wait(timeout=3) == 128 + signal.SIGTERM
+    finally:
+        if child.poll() is None:
+            child.kill()
+            child.wait(timeout=5)
+
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "canceled"
+    assert run_meta["failure"] == {
+        "phase": "handoff",
+        "kind": "signal",
+        "detail": "run terminated by SIGTERM",
+        "seat": "chef",
+    }
+
+
+def test_run_reuses_one_process_registry_across_all_cli_phases(monkeypatch, tmp_path):
+    seen = []
+
+    def fake_plan(*args, process_registry=None, **kwargs):
+        seen.append(("plan", process_registry))
+        return [aboyeur.Assignment(worker="coder", task="implement")]
+
+    def fake_dispatch(*args, process_registry=None, **kwargs):
+        seen.append(("dispatch", process_registry))
+        return [aboyeur.WorkerResult(worker="coder", task="implement", text="done", ok=True)]
+
+    def fake_orchestrator(*args, process_registry=None, **kwargs):
+        seen.append(("synthesis", process_registry))
+        return agents.AgentResult(text="final answer", ok=True)
+
+    monkeypatch.setattr(aboyeur, "plan", fake_plan)
+    monkeypatch.setattr(aboyeur, "dispatch", fake_dispatch)
+    monkeypatch.setattr(aboyeur, "_run_orchestrator", fake_orchestrator)
+
+    assert (
+        aboyeur.run(
+            "build feature",
+            _roster(),
+            output_dir=tmp_path / "run",
+            code_graph_enabled=False,
+            route_enabled=False,
+        )
+        == 0
+    )
+
+    registries = [registry for _, registry in seen]
+    assert [phase for phase, _ in seen] == ["plan", "dispatch", "synthesis"]
+    assert registries[0] is not None
+    assert registries[0] is registries[1] is registries[2]
 
 
 def test_disallowed_worker_is_recorded_not_run(monkeypatch):
@@ -2832,6 +3504,130 @@ def test_dispatch_routes_codex_through_appserver(monkeypatch, tmp_path):
     assert '"item/completed"' in events_file.read_text()
 
 
+@pytest.mark.parametrize(
+    ("detail", "timed_out", "expected_kind"),
+    [
+        ("timeout after 5.0s; interrupted", True, "timeout"),
+        ("turn interrupted", False, "interrupted"),
+        ("app-server exited", True, "timeout"),
+    ],
+)
+def test_appserver_worker_classifies_interrupted_turns(detail, timed_out, expected_kind):
+    class InterruptedThread:
+        def run_turn(self, prompt, **kwargs):  # noqa: ARG002
+            from brigade import codex_appserver
+
+            return codex_appserver.TurnResult(
+                text="partial output",
+                ok=False,
+                status="interrupted",
+                thread_id="thread-1",
+                detail=detail,
+                timed_out=timed_out,
+            )
+
+    class InterruptedServer:
+        def start_thread(self, **kwargs):  # noqa: ARG002
+            return InterruptedThread()
+
+    result = aboyeur._run_codex_appserver_worker(
+        InterruptedServer(),
+        Agent("cook", "codex", "write code"),
+        "cook",
+        "do work",
+        timeout=5.0,
+        cwd=None,
+        read_only=False,
+        sandbox=None,
+        registry=None,
+    )
+
+    assert result.ok is False
+    assert result.status == "interrupted"
+    assert result.detail == detail
+    assert result.timed_out is timed_out
+    assert result.failure_kind == expected_kind
+
+
+@pytest.mark.parametrize(
+    ("turn_status", "detail", "expected_status", "expected_phase", "expected_kind", "expected_timed_out"),
+    [
+        ("interrupted", "timeout after 5.0s; interrupted", "timeout", "inference", "timeout", True),
+        ("interrupted", "turn interrupted", "canceled", "dispatch", "interrupted", False),
+        ("failed", "provider failed", "failed", "dispatch", "agent-error", False),
+    ],
+)
+def test_direct_appserver_failure_receipt_preserves_terminal_semantics(
+    monkeypatch,
+    tmp_path,
+    turn_status,
+    detail,
+    expected_status,
+    expected_phase,
+    expected_kind,
+    expected_timed_out,
+):
+    class ResultThread:
+        def run_turn(self, prompt, **kwargs):  # noqa: ARG002
+            from brigade import codex_appserver
+
+            return codex_appserver.TurnResult(
+                text="partial output",
+                ok=False,
+                status=turn_status,
+                thread_id="thread-1",
+                detail=detail,
+                timed_out=expected_timed_out,
+            )
+
+    class ResultServer:
+        def __init__(self, **kwargs):  # noqa: ARG002
+            pass
+
+        def start(self):
+            pass
+
+        def close(self):
+            pass
+
+        def start_thread(self, **kwargs):  # noqa: ARG002
+            return ResultThread()
+
+    monkeypatch.setattr(aboyeur.codex_appserver, "AppServer", ResultServer)
+    output_dir = tmp_path / "run"
+
+    assert (
+        aboyeur.run(
+            "task",
+            _appserver_roster(),
+            worker="cook",
+            cwd=tmp_path,
+            output_dir=output_dir,
+            route_enabled=False,
+        )
+        == 2
+    )
+
+    run_payload = json.loads((output_dir / "run.json").read_text())
+    assert run_payload["status"] == expected_status
+    assert run_payload["failure"] == {
+        "phase": expected_phase,
+        "kind": expected_kind,
+        "detail": detail,
+        "seat": "cook",
+    }
+    worker = json.loads((output_dir / "worker-results.json").read_text())["results"][0]
+    if expected_kind == "agent-error":
+        assert worker.get("failure_kind") is None
+    else:
+        assert worker["failure_kind"] == expected_kind
+    if expected_timed_out:
+        assert worker["timed_out"] is True
+    synthesis = json.loads((output_dir / "synthesis.json").read_text())["result"]
+    if expected_timed_out:
+        assert synthesis["timed_out"] is True
+
+
 def test_run_appserver_worker_rejects_non_final_output_in_receipts(monkeypatch, tmp_path):
     monkeypatch.setattr(aboyeur.codex_appserver, "AppServer", _IntentOnlyAppServer)
     output_dir = tmp_path / "run"
@@ -2856,6 +3652,42 @@ def test_run_appserver_worker_rejects_non_final_output_in_receipts(monkeypatch, 
     assert worker["transport"] == "codex-app-server"
     assert worker["failure_phase"] == "output-validation"
     assert worker["failure_kind"] == "non-final-output"
+
+
+def test_run_reuses_dispatch_process_registry_for_appserver(monkeypatch, tmp_path):
+    seen = {}
+
+    class RegistryAwareAppServer:
+        def __init__(self, *, cwd, process_registry):
+            seen["cwd"] = cwd
+            seen["appserver_registry"] = process_registry
+
+        def start(self):
+            pass
+
+        def close(self):
+            pass
+
+    def fake_dispatch(*args, process_registry=None, **kwargs):
+        seen["dispatch_registry"] = process_registry
+        return [aboyeur.WorkerResult(worker="cook", task="task", text="done", ok=True)]
+
+    monkeypatch.setattr(aboyeur.codex_appserver, "AppServer", RegistryAwareAppServer)
+    monkeypatch.setattr(aboyeur, "dispatch", fake_dispatch)
+
+    assert (
+        aboyeur.run(
+            "task",
+            _appserver_roster(),
+            worker="cook",
+            cwd=tmp_path,
+            output_dir=tmp_path / "run",
+            route_enabled=False,
+        )
+        == 0
+    )
+    assert seen["cwd"] == tmp_path
+    assert seen["appserver_registry"] is seen["dispatch_registry"]
 
 
 def test_worker_payload_includes_thread_fields_only_for_appserver():
@@ -2897,6 +3729,142 @@ def test_run_falls_back_to_exec_when_appserver_unavailable(monkeypatch, tmp_path
     assert "falling back to exec" in capsys.readouterr().err
     run_json = json.loads((out / "run.json").read_text())
     assert run_json["codex_transport"] == "exec"
+
+
+def test_appserver_error_fallback_closes_partially_started_candidate(monkeypatch, tmp_path):
+    instances = []
+
+    class FailingAppServer:
+        def __init__(self, *, cwd):
+            self.closed = 0
+            instances.append(self)
+
+        def start(self):
+            raise aboyeur.codex_appserver.AppServerError("initialize failed")
+
+        def close(self):
+            self.closed += 1
+
+    def fake_dispatch(*args, **kwargs):
+        assert kwargs["appserver"] is None
+        return [aboyeur.WorkerResult(worker="cook", task="task", text="done", ok=True)]
+
+    monkeypatch.setattr(aboyeur.codex_appserver, "AppServer", FailingAppServer)
+    monkeypatch.setattr(aboyeur, "dispatch", fake_dispatch)
+
+    assert (
+        aboyeur.run(
+            "task",
+            _appserver_roster(),
+            worker="cook",
+            cwd=tmp_path,
+            output_dir=tmp_path / "run",
+            route_enabled=False,
+        )
+        == 0
+    )
+    assert instances[0].closed == 1
+
+
+def test_control_error_closes_partial_server_and_preserves_warning_fallback(monkeypatch, tmp_path, capsys):
+    instances = {}
+
+    class StubAppServer:
+        def __init__(self, *, cwd):
+            self.closed = 0
+            instances["app"] = self
+
+        def start(self):
+            pass
+
+        def close(self):
+            self.closed += 1
+
+    class FailingControlServer:
+        def __init__(self, path, registry):
+            self.closed = 0
+            instances["control"] = self
+
+        def start(self):
+            raise aboyeur.run_control.ControlError("bind failed")
+
+        def close(self):
+            self.closed += 1
+
+    def fake_dispatch(*args, **kwargs):
+        assert kwargs["appserver"] is instances["app"]
+        assert kwargs["control_registry"] is None
+        return [aboyeur.WorkerResult(worker="cook", task="task", text="done", ok=True)]
+
+    monkeypatch.setattr(aboyeur.codex_appserver, "AppServer", StubAppServer)
+    monkeypatch.setattr(aboyeur.run_control, "ControlServer", FailingControlServer)
+    monkeypatch.setattr(aboyeur, "dispatch", fake_dispatch)
+
+    assert (
+        aboyeur.run(
+            "task",
+            _appserver_roster(),
+            worker="cook",
+            cwd=tmp_path,
+            output_dir=tmp_path / "run",
+            route_enabled=False,
+        )
+        == 0
+    )
+    assert "run control unavailable (bind failed)" in capsys.readouterr().err
+    assert instances["control"].closed == 1
+    assert instances["app"].closed == 1
+
+
+@pytest.mark.parametrize("interrupt_phase", ["appserver", "control"])
+def test_server_setup_keyboard_interrupt_closes_every_acquired_resource(monkeypatch, tmp_path, interrupt_phase):
+    instances = {}
+
+    class InterruptibleAppServer:
+        def __init__(self, *, cwd):
+            self.closed = 0
+            instances["app"] = self
+
+        def start(self):
+            if interrupt_phase == "appserver":
+                raise KeyboardInterrupt
+
+        def close(self):
+            self.closed += 1
+
+    class InterruptibleControlServer:
+        def __init__(self, path, registry):
+            self.closed = 0
+            instances["control"] = self
+
+        def start(self):
+            raise KeyboardInterrupt
+
+        def close(self):
+            self.closed += 1
+
+    monkeypatch.setattr(aboyeur.codex_appserver, "AppServer", InterruptibleAppServer)
+    monkeypatch.setattr(aboyeur.run_control, "ControlServer", InterruptibleControlServer)
+    output_dir = tmp_path / "run"
+
+    with pytest.raises(KeyboardInterrupt):
+        aboyeur.run(
+            "task",
+            _appserver_roster(),
+            worker="cook",
+            cwd=tmp_path,
+            output_dir=output_dir,
+            route_enabled=False,
+        )
+
+    assert instances["app"].closed == 1
+    if interrupt_phase == "control":
+        assert instances["control"].closed == 1
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "canceled"
+    assert run_meta["failure"]["phase"] == "dispatch"
+    assert run_meta["failure"]["kind"] == "keyboard-interrupt"
+    assert run_meta["failure"]["seat"] == "cook"
 
 
 # --- deterministic route brief (router integration) ---

--- a/tests/test_acpx_adapter.py
+++ b/tests/test_acpx_adapter.py
@@ -343,6 +343,35 @@ def test_run_authenticated_cursor_reaches_acpx_and_preserves_short_final(monkeyp
     assert calls[2][0] == "acpx"
 
 
+def test_run_cursor_reuses_registry_for_all_preflight_and_execution_calls(monkeypatch, tmp_path):
+    registry = proc.ProcessRegistry()
+    registries = []
+
+    def fake_run(argv, **kwargs):
+        registries.append(kwargs.get("process_registry"))
+        if argv == ["acpx", "--version"]:
+            return proc.Result(0, "acpx 0.12.0\n", "")
+        if argv == ["cursor-agent", "status", "--format", "json"]:
+            return proc.Result(0, '{"isAuthenticated":true,"status":"authenticated"}\n', "")
+        return proc.Result(0, _success_stream(), "")
+
+    monkeypatch.setattr(acpx_adapter.proc, "which", lambda cmd: f"/bin/{cmd}")
+    monkeypatch.setattr(acpx_adapter.proc, "run", fake_run)
+
+    result = acpx_adapter.run_cursor(
+        "inspect",
+        cwd=tmp_path,
+        timeout=120,
+        model="composer-2.5",
+        version="0.12.0",
+        read_only=True,
+        process_registry=registry,
+    )
+
+    assert result.ok is True
+    assert registries == [registry, registry, registry]
+
+
 def test_build_argv_is_bounded_and_permission_specific(tmp_path):
     read = acpx_adapter.build_argv(
         prompt="inspect",

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -753,6 +753,65 @@ def test_run_agent_threads_cwd_into_argv_builder(monkeypatch, tmp_path):
     ]
 
 
+def test_ollama_model_present_threads_process_registry(monkeypatch):
+    registry = agents.proc.ProcessRegistry()
+    seen = {}
+
+    def fake_run(argv, timeout=30.0, process_registry=None):
+        seen.update(argv=argv, timeout=timeout, process_registry=process_registry)
+        return agents.proc.Result(0, "NAME ID SIZE MODIFIED\nllama3.3:latest id size now\n", "")
+
+    executable = agents.proc.ExecutableIdentity(
+        command="ollama", path="/x/ollama", kind="native", runnable=True, detail="test"
+    )
+    monkeypatch.setattr(agents.proc, "run", fake_run)
+
+    present, detail = agents.ollama_model_present("llama3.3", executable, process_registry=registry)
+
+    assert present
+    assert detail == ""
+    assert seen["process_registry"] is registry
+
+
+def test_ollama_model_present_preserves_legacy_proc_call_shape(monkeypatch):
+    def fake_run(argv, timeout=30.0):
+        return agents.proc.Result(0, "NAME ID SIZE MODIFIED\nllama3.3:latest id size now\n", "")
+
+    executable = agents.proc.ExecutableIdentity(
+        command="ollama", path="/x/ollama", kind="native", runnable=True, detail="test"
+    )
+    monkeypatch.setattr(agents.proc, "run", fake_run)
+
+    assert agents.ollama_model_present("llama3.3", executable) == (True, "")
+
+
+def test_run_agent_threads_process_registry_to_ollama_preflight(monkeypatch):
+    registry = agents.proc.ProcessRegistry()
+    seen = {}
+
+    def fake_present(model, executable=None, process_registry=None):
+        seen["process_registry"] = process_registry
+        return False, "stop before dispatch"
+
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+    monkeypatch.setattr(agents, "ollama_model_present", fake_present)
+
+    result = agents.run_agent("ollama:llama3.3", "fix it", process_registry=registry)
+
+    assert not result.ok
+    assert seen["process_registry"] is registry
+
+
+def test_run_agent_preserves_legacy_ollama_preflight_call_shape(monkeypatch):
+    def fake_present(model, executable=None):
+        return False, "stop before dispatch"
+
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+    monkeypatch.setattr(agents, "ollama_model_present", fake_present)
+
+    assert not agents.run_agent("ollama:llama3.3", "fix it").ok
+
+
 def test_run_agent_antigravity_with_no_cwd_allows_current_cwd(monkeypatch, tmp_path):
     captured = {}
 

--- a/tests/test_codex_appserver.py
+++ b/tests/test_codex_appserver.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import os
+import signal
+import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
 
-from brigade import codex_appserver
+from brigade import codex_appserver, proc
 
 FAKE = [sys.executable, str(Path(__file__).parent / "fake_appserver.py")]
 
@@ -48,6 +52,38 @@ def test_timeout_interrupts_and_salvages_partial_text():
     assert result.status == "interrupted"
     assert result.text == "partial answer"
     assert "timeout" in result.detail
+    assert result.timed_out is True
+
+
+@pytest.mark.parametrize(
+    "grace_result",
+    [
+        codex_appserver._DEAD,
+        {
+            "params": {
+                "turn": {
+                    "id": "turn-1",
+                    "status": "failed",
+                    "error": {"message": "provider stopped during interrupt grace"},
+                }
+            }
+        },
+    ],
+)
+def test_timeout_cause_survives_terminal_event_during_interrupt_grace(monkeypatch, grace_result):
+    class StubServer:
+        def request(self, method, params, timeout=None):  # noqa: ARG002
+            return {"turn": {"id": "turn-1"}}
+
+    thread = codex_appserver.CodexThread(StubServer(), "thread-1", None)
+    results = iter((None, grace_result))
+    monkeypatch.setattr(thread, "_consume", lambda *args, **kwargs: next(results))
+    monkeypatch.setattr(thread, "interrupt", lambda *args, **kwargs: None)
+
+    result = thread.run_turn("work", timeout=0)
+
+    assert result.status == "interrupted"
+    assert result.timed_out is True
 
 
 def test_approval_requests_are_auto_declined():
@@ -78,3 +114,136 @@ def test_resume_thread_reuses_id():
 def test_spawn_failure_raises():
     with pytest.raises(codex_appserver.AppServerError):
         codex_appserver.AppServer(argv=["/nonexistent-binary-xyz"]).start()
+
+
+def test_start_closes_spawned_process_when_initialize_fails(monkeypatch):
+    events = []
+
+    class StubProcess:
+        pid = 4242
+
+    class StubRegistry:
+        def register(self, process):
+            events.append(("register", process.pid))
+
+        def terminate(self, process):
+            events.append(("terminate", process.pid))
+
+        def unregister(self, process):
+            events.append(("unregister", process.pid))
+
+    class StubThread:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            events.append("reader-start")
+
+    server = codex_appserver.AppServer(argv=["codex", "app-server"], process_registry=StubRegistry())
+    monkeypatch.setattr(codex_appserver.subprocess, "Popen", lambda *args, **kwargs: StubProcess())
+    monkeypatch.setattr(codex_appserver.threading, "Thread", StubThread)
+    monkeypatch.setattr(
+        server,
+        "request",
+        lambda *args, **kwargs: (_ for _ in ()).throw(codex_appserver.AppServerError("initialize failed")),
+    )
+
+    with pytest.raises(codex_appserver.AppServerError, match="initialize failed"):
+        server.start()
+
+    assert events == [
+        ("register", 4242),
+        "reader-start",
+        ("terminate", 4242),
+        ("unregister", 4242),
+    ]
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX process-group regression")
+def test_close_terminates_appserver_descendant_process_group(tmp_path):
+    child_pid_path = tmp_path / "child.pid"
+    server_script = tmp_path / "server_with_child.py"
+    server_script.write_text(
+        "\n".join(
+            [
+                "import json, subprocess, sys, time",
+                f"child_pid_path = {str(child_pid_path)!r}",
+                "child = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(60)'])",
+                "open(child_pid_path, 'w').write(str(child.pid))",
+                "for line in sys.stdin:",
+                "    request = json.loads(line)",
+                "    if request.get('method') == 'initialize':",
+                "        print(json.dumps({'jsonrpc': '2.0', 'id': request['id'], 'result': {}}), flush=True)",
+                "    time.sleep(0.01)",
+            ]
+        )
+    )
+    registry = proc.ProcessRegistry(terminate_grace=0.1, kill_grace=0.1)
+    server = codex_appserver.AppServer(
+        argv=[sys.executable, str(server_script)],
+        process_registry=registry,
+    )
+    server.start()
+    assert server._proc is not None
+    process_group = server._proc.pid
+    deadline = time.monotonic() + 5
+    while not child_pid_path.is_file() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert child_pid_path.is_file()
+
+    server.close()
+
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        try:
+            os.killpg(process_group, 0)
+        except ProcessLookupError:
+            break
+        time.sleep(0.01)
+    else:
+        os.killpg(process_group, signal.SIGKILL)
+        pytest.fail("app-server descendant process group survived close")
+
+
+def test_windows_appserver_uses_group_and_registry_tree_termination(monkeypatch):
+    events = []
+    captured = {}
+
+    class StubProcess:
+        pid = 4242
+
+    class StubRegistry:
+        def register(self, process):
+            events.append(("register", process.pid))
+
+        def terminate(self, process):
+            events.append(("terminate", process.pid))
+
+        def unregister(self, process):
+            events.append(("unregister", process.pid))
+
+    class StubThread:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            pass
+
+    def fake_popen(*args, **kwargs):
+        captured.update(kwargs)
+        return StubProcess()
+
+    registry = StubRegistry()
+    server = codex_appserver.AppServer(argv=["codex", "app-server"], process_registry=registry)
+    monkeypatch.setattr(codex_appserver.os, "name", "nt")
+    monkeypatch.setattr(codex_appserver.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(codex_appserver.threading, "Thread", StubThread)
+    monkeypatch.setattr(server, "request", lambda *args, **kwargs: {})
+    monkeypatch.setattr(server, "_send", lambda *args, **kwargs: None)
+
+    server.start()
+    server.close()
+
+    assert captured["creationflags"] == getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200)
+    assert "start_new_session" not in captured
+    assert events == [("register", 4242), ("terminate", 4242), ("unregister", 4242)]

--- a/tests/test_codex_cloud.py
+++ b/tests/test_codex_cloud.py
@@ -52,6 +52,39 @@ def test_run_agent_rejects_model_pin(monkeypatch):
     assert "model" in result.detail
 
 
+def test_run_agent_threads_process_registry_to_codex_cloud(monkeypatch):
+    registry = proc.ProcessRegistry()
+    seen = {}
+
+    def fake_cloud_task(prompt, *, env_id, timeout, cwd=None, process_registry=None):
+        seen.update(
+            prompt=prompt,
+            env_id=env_id,
+            timeout=timeout,
+            cwd=cwd,
+            process_registry=process_registry,
+        )
+        return agents.AgentResult(text="done", ok=True)
+
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+    monkeypatch.setattr(codex_cloud, "run_cloud_task", fake_cloud_task)
+
+    result = agents.run_agent("codex-cloud:env-123", "fix it", process_registry=registry)
+
+    assert result.ok
+    assert seen["process_registry"] is registry
+
+
+def test_run_agent_preserves_legacy_codex_cloud_call_shape(monkeypatch):
+    def fake_cloud_task(prompt, *, env_id, timeout, cwd=None):
+        return agents.AgentResult(text=f"{env_id}: {prompt}", ok=True)
+
+    monkeypatch.setattr(agents.proc, "which", lambda command: "/x/" + command)
+    monkeypatch.setattr(codex_cloud, "run_cloud_task", fake_cloud_task)
+
+    assert agents.run_agent("codex-cloud:env-123", "fix it").ok
+
+
 def test_parse_task_id_variants():
     assert (
         codex_cloud.parse_task_id("Created https://chatgpt.com/codex/tasks/task_e_abc123 for review") == "task_e_abc123"
@@ -108,6 +141,34 @@ def test_run_cloud_task_happy_path(monkeypatch):
     assert "diff --git" in result.text
     assert "NOT applied locally" in result.text
     assert fake.calls[0][:5] == ["codex", "cloud", "exec", "--env", "env-123"]
+
+
+def test_run_cloud_task_threads_registry_through_submit_status_and_diff(monkeypatch):
+    registry = proc.ProcessRegistry()
+    calls = []
+
+    def fake_run(argv, timeout=30.0, env=None, cwd=None, process_registry=None):
+        calls.append((argv[2], process_registry))
+        if argv[2] == "exec":
+            return _result(stdout="task_registered1")
+        if argv[2] == "status":
+            return _result(stdout="status: completed")
+        return _result(stdout="")
+
+    monkeypatch.setattr(codex_cloud.proc, "run", fake_run)
+
+    result = codex_cloud.run_cloud_task(
+        "fix it",
+        env_id="env-123",
+        timeout=600,
+        poll_interval=0,
+        sleep=lambda seconds: None,
+        clock=lambda: 0,
+        process_registry=registry,
+    )
+
+    assert result.ok
+    assert calls == [("exec", registry), ("status", registry), ("diff", registry)]
 
 
 def test_run_cloud_task_failure_status(monkeypatch):
@@ -167,8 +228,45 @@ def test_run_cloud_task_timeout_reports_task_id(monkeypatch):
         clock=lambda: next(ticks),
     )
     assert not result.ok
-    assert result.status == "pending"
+    assert result.status == "timeout"
+    assert result.timed_out is True
+    assert result.failure_kind == "timeout"
     assert "task_slow1" in result.detail
+
+
+@pytest.mark.parametrize("timed_out_stage", ["submit", "status", "diff"])
+def test_run_cloud_task_command_timeout_is_terminal_timeout(monkeypatch, timed_out_stage):
+    timed_out_subcommand = "exec" if timed_out_stage == "submit" else timed_out_stage
+    fake = FakeRuns(
+        {
+            "exec": [_result(code=124, stderr="timeout after 5s")]
+            if timed_out_subcommand == "exec"
+            else [_result(stdout="task_timeout1")],
+            "status": [_result(code=124, stderr="timeout after 5s")]
+            if timed_out_subcommand == "status"
+            else [_result(stdout="status: completed")],
+            "diff": [_result(code=124, stderr="timeout after 5s")]
+            if timed_out_subcommand == "diff"
+            else [_result(stdout="")],
+        }
+    )
+    monkeypatch.setattr(codex_cloud.proc, "run", fake)
+    ticks = iter([0, 0, 601])
+
+    result = codex_cloud.run_cloud_task(
+        "x",
+        env_id="e",
+        timeout=600,
+        poll_interval=0,
+        sleep=lambda seconds: None,
+        clock=lambda: next(ticks, 601),
+    )
+
+    assert result.ok is False
+    assert result.status == "timeout"
+    assert result.timed_out is True
+    assert result.failure_kind == "timeout"
+    assert timed_out_stage in result.detail
 
 
 def test_run_cloud_task_polls_past_incidental_failure_words(monkeypatch):

--- a/tests/test_graphtrail_delta.py
+++ b/tests/test_graphtrail_delta.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+import pytest
+
+from brigade import graphtrail_delta
+
+
+@pytest.mark.parametrize("signal_type", [KeyboardInterrupt, SystemExit])
+def test_capture_before_propagates_process_signals(monkeypatch, tmp_path, signal_type):
+    def raise_signal():
+        raise signal_type()
+
+    monkeypatch.setattr(graphtrail_delta, "_graphtrail_bin", raise_signal)
+
+    with pytest.raises(signal_type):
+        graphtrail_delta.capture_before(tmp_path, tmp_path / "run")
+
+
+@pytest.mark.parametrize("signal_type", [KeyboardInterrupt, SystemExit])
+def test_capture_after_and_diff_propagates_process_signals(monkeypatch, tmp_path, signal_type):
+    def raise_signal(*args, **kwargs):
+        raise signal_type()
+
+    before = {
+        "ok": True,
+        "binary": "graphtrail",
+        "db_path": str(tmp_path / ".graphtrail" / "graphtrail.db"),
+        "before_snapshot_path": str(tmp_path / "run" / graphtrail_delta.SNAPSHOT_NAME),
+    }
+    monkeypatch.setattr(graphtrail_delta, "_run_graphtrail", raise_signal)
+
+    with pytest.raises(signal_type):
+        graphtrail_delta.capture_after_and_diff(tmp_path, tmp_path / "run", before)
+
+
+@pytest.mark.parametrize("signal_type", [KeyboardInterrupt, SystemExit])
+def test_compact_summary_propagates_process_signals(signal_type):
+    class SignalMapping(dict):
+        def get(self, key, default=None):
+            raise signal_type()
+
+    with pytest.raises(signal_type):
+        graphtrail_delta._compact_summary(SignalMapping())
+
+
+def test_capture_before_still_fails_open_for_regular_exceptions(monkeypatch, tmp_path):
+    def fail():
+        raise OSError("graph unavailable")
+
+    monkeypatch.setattr(graphtrail_delta, "_graphtrail_bin", fail)
+
+    result = graphtrail_delta.capture_before(Path(tmp_path), tmp_path / "run")
+
+    assert result["status"] == "capture_failed"
+    assert "OSError: graph unavailable" in result["summary"]

--- a/tests/test_proc.py
+++ b/tests/test_proc.py
@@ -1,11 +1,310 @@
 import errno
 import locale
+import os
+import signal
 import subprocess
 import sys
+import threading
+import time
+from pathlib import Path
 
 import pytest
 
 from brigade import proc
+
+
+def test_process_registry_escalates_every_owned_process_group(monkeypatch):
+    class ExitsOnTerminate:
+        pid = 101
+
+        def __init__(self):
+            self.polls = 0
+
+        def poll(self):
+            self.polls += 1
+            return None if self.polls == 1 else 0
+
+    class IgnoresTerminate:
+        pid = 202
+
+        def poll(self):
+            return None
+
+    exited = ExitsOnTerminate()
+    running = IgnoresTerminate()
+    signals = []
+    monkeypatch.setattr(
+        proc,
+        "_signal_process_group",
+        lambda process, sig: signals.append((process.pid, sig)),
+    )
+
+    proc._terminate_processes(
+        (exited, running),
+        terminate_grace=0,
+        kill_grace=0,
+    )
+
+    assert signals == [
+        (101, signal.SIGTERM),
+        (202, signal.SIGTERM),
+        (101, signal.SIGKILL),
+        (202, signal.SIGKILL),
+    ]
+
+
+def test_registered_windows_process_starts_in_new_process_group(monkeypatch):
+    captured = {}
+
+    class StubProcess:
+        pid = 4242
+        returncode = 0
+
+        def communicate(self, *, input, timeout):
+            return b"ok\n", b""
+
+    def fake_popen(args, **kwargs):
+        captured["args"] = args
+        captured.update(kwargs)
+        return StubProcess()
+
+    monkeypatch.setattr(proc.os, "name", "nt")
+    monkeypatch.setattr(proc.subprocess, "Popen", fake_popen)
+
+    result = proc.run(["worker.exe"], process_registry=proc.ProcessRegistry())
+
+    assert result.code == 0
+    assert captured["creationflags"] == getattr(proc.subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200)
+    assert "start_new_session" not in captured
+
+
+def test_registered_process_terminates_before_unregister_on_base_exception(monkeypatch):
+    events = []
+
+    class StubProcess:
+        pid = 4242
+
+        def communicate(self, *, input, timeout):
+            raise KeyboardInterrupt
+
+    class StubRegistry:
+        def register(self, process):
+            events.append(("register", process.pid))
+
+        def terminate(self, process):
+            events.append(("terminate", process.pid))
+
+        def unregister(self, process):
+            events.append(("unregister", process.pid))
+
+    monkeypatch.setattr(proc.subprocess, "Popen", lambda *args, **kwargs: StubProcess())
+
+    with pytest.raises(KeyboardInterrupt):
+        proc.run(["worker"], process_registry=StubRegistry())
+
+    assert events == [("register", 4242), ("terminate", 4242), ("unregister", 4242)]
+
+
+def test_windows_registry_cancellation_targets_owned_descendant_tree(monkeypatch):
+    class StubProcess:
+        pid = 4242
+
+        def __init__(self):
+            self.running = True
+            self.killed = False
+
+        def poll(self):
+            return None if self.running else 1
+
+        def kill(self):
+            self.killed = True
+
+    process = StubProcess()
+    calls = []
+
+    def fake_run(args, **kwargs):
+        calls.append((args, kwargs))
+        process.running = False
+        return subprocess.CompletedProcess(args, 0)
+
+    monkeypatch.setattr(proc.os, "name", "nt")
+    monkeypatch.setattr(proc.subprocess, "run", fake_run)
+
+    proc._terminate_processes((process,), terminate_grace=0, kill_grace=0)
+
+    assert calls[0][0] == ["taskkill", "/PID", "4242", "/T", "/F"]
+    assert process.killed is False
+
+
+def test_windows_registry_targets_tree_after_group_leader_exits(monkeypatch):
+    class ExitedProcess:
+        pid = 4242
+
+        def poll(self):
+            return 0
+
+        def kill(self):
+            pytest.fail("an exited group leader must not be killed directly")
+
+    calls = []
+    monkeypatch.setattr(proc.os, "name", "nt")
+    monkeypatch.setattr(
+        proc.subprocess,
+        "run",
+        lambda args, **kwargs: calls.append((args, kwargs)) or subprocess.CompletedProcess(args, 0),
+    )
+
+    proc._terminate_processes((ExitedProcess(),), terminate_grace=0, kill_grace=0)
+
+    assert calls[0][0] == ["taskkill", "/PID", "4242", "/T", "/F"]
+
+
+def test_registered_timeout_never_uses_unbounded_output_drain(monkeypatch):
+    communicate_timeouts = []
+
+    class StubProcess:
+        pid = 4242
+        returncode = 0
+
+        def communicate(self, *, input=None, timeout=None):
+            communicate_timeouts.append(timeout)
+            raise subprocess.TimeoutExpired(
+                ["worker"],
+                timeout,
+                output=b"partial output",
+                stderr=b"partial error",
+            )
+
+    class StubRegistry:
+        def register(self, process):
+            pass
+
+        def terminate(self, process):
+            pass
+
+        def unregister(self, process):
+            pass
+
+    monkeypatch.setattr(proc.subprocess, "Popen", lambda *args, **kwargs: StubProcess())
+
+    result = proc.run(["worker"], timeout=0.01, process_registry=StubRegistry())
+
+    assert result.code == 124
+    assert result.stdout == "partial output"
+    assert result.stderr.startswith("partial error")
+    assert len(communicate_timeouts) == 2
+    assert all(timeout is not None for timeout in communicate_timeouts)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="requires POSIX process groups")
+def test_registered_timeout_kills_descendant_after_group_leader_exits(tmp_path):
+    descendant_pid_path = tmp_path / "descendant.pid"
+    descendant_code = (
+        "import os,time; from pathlib import Path; "
+        f"Path({str(descendant_pid_path)!r}).write_text(str(os.getpid())); "
+        "time.sleep(60)"
+    )
+    parent_code = f"import subprocess,sys; subprocess.Popen([sys.executable, '-c', {descendant_code!r}])"
+    result_holder = {}
+
+    def invoke():
+        result_holder["result"] = proc.run(
+            [sys.executable, "-c", parent_code],
+            timeout=0.2,
+            process_registry=proc.ProcessRegistry(terminate_grace=0.05, kill_grace=0.05),
+        )
+
+    runner = threading.Thread(target=invoke, daemon=True)
+    runner.start()
+    deadline = time.monotonic() + 2
+    while not descendant_pid_path.is_file() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert descendant_pid_path.is_file()
+    descendant_pid = int(descendant_pid_path.read_text())
+    runner.join(timeout=1)
+    returned_without_external_cleanup = not runner.is_alive()
+    if runner.is_alive():
+        try:
+            os.kill(descendant_pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        runner.join(timeout=1)
+
+    assert returned_without_external_cleanup
+    assert result_holder["result"].code == 124
+
+    def descendant_is_running() -> bool:
+        try:
+            state = Path(f"/proc/{descendant_pid}/stat").read_text().split()[2]
+        except (FileNotFoundError, IndexError, OSError):
+            return False
+        return state != "Z"
+
+    deadline = time.monotonic() + 1
+    while descendant_is_running() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert not descendant_is_running(), "descendant retained the timed-out process group's output pipes"
+
+
+def test_windows_registry_taskkill_timeout_is_bounded_and_falls_back(monkeypatch):
+    class StubProcess:
+        pid = 4242
+
+        def __init__(self):
+            self.killed = False
+
+        def poll(self):
+            return None
+
+        def kill(self):
+            self.killed = True
+
+    process = StubProcess()
+    calls = []
+
+    def fake_run(args, **kwargs):
+        calls.append((args, kwargs))
+        raise subprocess.TimeoutExpired(args, kwargs["timeout"])
+
+    monkeypatch.setattr(proc.os, "name", "nt")
+    monkeypatch.setattr(proc.subprocess, "run", fake_run)
+
+    proc._terminate_processes((process,), terminate_grace=0, kill_grace=0)
+
+    assert calls == [
+        (
+            ["taskkill", "/PID", "4242", "/T", "/F"],
+            {
+                "stdin": subprocess.DEVNULL,
+                "stdout": subprocess.DEVNULL,
+                "stderr": subprocess.DEVNULL,
+                "check": False,
+                "timeout": 0.1,
+            },
+        )
+    ]
+    assert process.killed is True
+
+
+def test_windows_run_without_registry_keeps_legacy_subprocess_path(monkeypatch):
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        return subprocess.CompletedProcess(args=args[0], returncode=0, stdout=b"ok\n", stderr=b"")
+
+    monkeypatch.setattr(proc.os, "name", "nt")
+    monkeypatch.setattr(proc.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        proc.subprocess,
+        "Popen",
+        lambda *args, **kwargs: pytest.fail("legacy proc.run must not use Popen"),
+    )
+
+    result = proc.run(["worker.exe"])
+
+    assert result.code == 0
+    assert len(calls) == 1
 
 
 def test_run_captures_exit_and_output():

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -1,4 +1,9 @@
 import json
+import os
+import signal
+import subprocess
+import sys
+import time
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -7,6 +12,7 @@ import pytest
 from brigade import aboyeur
 from brigade import agents
 from brigade import cli
+from brigade import localio
 from brigade import proc
 from brigade import runguard
 from brigade import runs_cmd
@@ -720,7 +726,7 @@ role = "code"
     output_dir = tmp_path / "run"
 
     def fake_run(task, loaded_roster, **kwargs):
-        output_dir.mkdir(parents=True)
+        output_dir.mkdir(parents=True, exist_ok=True)
         (output_dir / "run.json").write_text(
             json.dumps(
                 {
@@ -845,6 +851,22 @@ def test_run_cli_dirty_guard_blocks_by_default(tmp_path, monkeypatch, capsys):
     assert "--allow-dirty" in err
 
 
+def test_run_cli_dirty_guard_does_not_allocate_artifact_directory(tmp_path, monkeypatch):
+    repo = _git_repo_with_roster(tmp_path)
+    (repo / "tracked.txt").write_text("dirty\n")
+    allocations = []
+
+    def record_allocation(base):
+        allocations.append(base)
+        return base / "should-not-exist"
+
+    monkeypatch.setattr(aboyeur, "make_run_dir", record_allocation)
+
+    assert cli.main(["run", "x", "--cwd", str(repo)]) == 2
+    assert allocations == []
+    assert not (repo / ".brigade" / "runs").exists()
+
+
 def test_run_cli_allow_dirty_passes_dirty_guard(tmp_path, monkeypatch):
     repo = _git_repo_with_roster(tmp_path)
     (repo / "tracked.txt").write_text("dirty\n")
@@ -929,6 +951,171 @@ def test_run_cli_records_output_dir_in_run_lock(tmp_path, monkeypatch):
 
     assert rc == 0
     assert seen == {"cwd": repo, "run_dir": output_dir, "wait_seconds": 0.0}
+
+
+def test_run_cli_terminalizes_roster_snapshot_write_failure(tmp_path, monkeypatch):
+    repo = _git_repo_with_roster(tmp_path)
+    output_dir = repo / ".brigade" / "runs" / "roster-write"
+    real_write_json = aboyeur._write_json
+
+    def fail_roster_write(path, payload):
+        if path.name == "roster.json":
+            raise OSError("roster snapshot denied")
+        return real_write_json(path, payload)
+
+    monkeypatch.setattr(aboyeur, "_write_json", fail_roster_write)
+
+    assert cli.main(["run", "x", "--cwd", str(repo), "--output-dir", str(output_dir), "--worker", "coder"]) == 2
+
+    receipt = json.loads((output_dir / "run.json").read_text())
+    assert receipt["schema"] == "brigade.run.v1"
+    assert receipt["status"] == "failed"
+    assert receipt["failure"] == {
+        "phase": "startup",
+        "kind": "unexpected-error",
+        "detail": "OSError: roster snapshot denied",
+        "seat": "coder",
+    }
+
+
+def test_run_cli_terminalizes_sigterm_during_roster_snapshot(tmp_path, monkeypatch):
+    repo = _git_repo_with_roster(tmp_path)
+    output_dir = repo / ".brigade" / "runs" / "roster-signal"
+    real_write_json = aboyeur._write_json
+
+    def terminate_during_roster_write(path, payload):
+        if path.name == "roster.json":
+            signal.raise_signal(signal.SIGTERM)
+        return real_write_json(path, payload)
+
+    monkeypatch.setattr(aboyeur, "_write_json", terminate_during_roster_write)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["run", "x", "--cwd", str(repo), "--output-dir", str(output_dir), "--worker", "coder"])
+
+    assert exc_info.value.code == 128 + signal.SIGTERM
+    receipt = json.loads((output_dir / "run.json").read_text())
+    assert receipt["schema"] == "brigade.run.v1"
+    assert receipt["status"] == "canceled"
+    assert receipt["failure"] == {
+        "phase": "startup",
+        "kind": "signal",
+        "detail": "run terminated by SIGTERM",
+        "seat": "coder",
+    }
+
+
+def test_run_cli_terminalizes_keyboard_interrupt_during_lock_entry(tmp_path, monkeypatch):
+    repo = _git_repo_with_roster(tmp_path)
+    output_dir = repo / ".brigade" / "runs" / "lock-entry"
+
+    class InterruptingLock:
+        def __enter__(self):
+            raise KeyboardInterrupt
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+    monkeypatch.setattr(runguard, "run_lock", lambda *args, **kwargs: InterruptingLock())
+
+    assert cli.main(["run", "x", "--cwd", str(repo), "--output-dir", str(output_dir), "--worker", "coder"]) == 130
+
+    receipt = json.loads((output_dir / "run.json").read_text())
+    assert receipt["schema"] == "brigade.run.v1"
+    assert receipt["status"] == "canceled"
+    assert receipt["failure"]["phase"] == "startup"
+    assert receipt["failure"]["seat"] == "coder"
+    assert not (repo / ".brigade" / "run.lock").exists()
+
+
+def test_run_cli_terminalizes_keyboard_interrupt_during_worktree_creation(tmp_path, monkeypatch):
+    repo = _git_repo_with_roster(tmp_path)
+    output_dir = repo / ".brigade" / "runs" / "worktree-entry"
+    checkout = tmp_path / "checkout"
+
+    monkeypatch.setattr(
+        "brigade.cli.run._worktree_checkout_path",
+        lambda repo_root, run_dir: checkout,
+    )
+    monkeypatch.setattr(
+        runguard,
+        "create_detached_worktree",
+        lambda repo_root, worktree_path: (_ for _ in ()).throw(KeyboardInterrupt()),
+    )
+    monkeypatch.setattr(runguard, "remove_worktree", lambda repo_root, worktree_path: None)
+
+    assert (
+        cli.main(
+            [
+                "run",
+                "x",
+                "--cwd",
+                str(repo),
+                "--output-dir",
+                str(output_dir),
+                "--worktree",
+                "--worker",
+                "coder",
+            ]
+        )
+        == 130
+    )
+
+    receipt = json.loads((output_dir / "run.json").read_text())
+    assert receipt["schema"] == "brigade.run.v1"
+    assert receipt["status"] == "canceled"
+    assert receipt["failure"]["phase"] == "startup"
+    assert receipt["failure"]["seat"] == "coder"
+    assert not (repo / ".brigade" / "run.lock").exists()
+
+
+@pytest.mark.parametrize(
+    ("error_type", "expected_rc", "expected_status", "expected_kind"),
+    [
+        (KeyboardInterrupt, 130, "canceled", "keyboard-interrupt"),
+        (OSError, 2, "failed", "unexpected-error"),
+    ],
+)
+def test_run_cli_terminalizes_read_only_warning_write_failures(
+    tmp_path,
+    monkeypatch,
+    error_type,
+    expected_rc,
+    expected_status,
+    expected_kind,
+):
+    repo = _git_repo_with_roster(tmp_path)
+    output_dir = repo / ".brigade" / "runs" / "warning-write"
+    roster_path = repo / ".brigade" / "roster.toml"
+    roster_path.write_text(
+        roster_path.read_text().replace('cli = "codex"\nrole = "code"', 'cli = "claude"\nrole = "code"')
+    )
+
+    def fail_warning_write(path, payload):
+        raise error_type("warning write failed")
+
+    monkeypatch.setattr(localio, "write_json", fail_warning_write)
+
+    rc = cli.main(
+        [
+            "run",
+            "x",
+            "--cwd",
+            str(repo),
+            "--output-dir",
+            str(output_dir),
+            "--read-only",
+        ]
+    )
+
+    assert rc == expected_rc
+    receipt = json.loads((output_dir / "run.json").read_text())
+    assert receipt["schema"] == "brigade.run.v1"
+    assert receipt["status"] == expected_status
+    assert receipt["failure"]["phase"] == "startup"
+    assert receipt["failure"]["kind"] == expected_kind
+    assert not (output_dir / "read-only-enforcement.json").exists()
+    assert not (repo / ".brigade" / "run.lock").exists()
 
 
 @pytest.mark.parametrize("lane", ["direct", "acpx"])
@@ -1083,6 +1270,628 @@ def test_app_server_and_control_start_after_dispatching_is_recorded(tmp_path, mo
     assert seen == {"app_server": "dispatching", "control_server": "dispatching"}
 
 
+def test_sigterm_during_control_setup_closes_appserver_child_before_lock_release(tmp_path):
+    repo = _git_repo_with_roster(tmp_path)
+    output_dir = tmp_path / "run-artifacts"
+    appserver_pid_path = tmp_path / "appserver.pid"
+    stubborn_appserver = (
+        "import json,sys,time; "
+        "request=json.loads(sys.stdin.readline()); "
+        "print(json.dumps({'jsonrpc':'2.0','id':request['id'],'result':{}}),flush=True); "
+        "sys.stdin.readline(); time.sleep(60)"
+    )
+    script = f"""
+import sys
+import time
+from pathlib import Path
+from brigade import aboyeur, cli
+from brigade.codex_appserver import AppServer
+
+class RecordingAppServer(AppServer):
+    def __init__(self, *, cwd):
+        super().__init__(argv=[sys.executable, "-c", {stubborn_appserver!r}], cwd=cwd)
+    def start(self):
+        super().start()
+        Path({str(appserver_pid_path)!r}).write_text(str(self._proc.pid))
+
+class BlockingControlServer:
+    def __init__(self, path, registry):
+        self.closed = False
+    def start(self):
+        while True:
+            time.sleep(0.05)
+    def close(self):
+        self.closed = True
+
+aboyeur.codex_appserver.AppServer = RecordingAppServer
+aboyeur.run_control.ControlServer = BlockingControlServer
+raise SystemExit(cli.main([
+    "run", "blocked setup", "--cwd", {str(repo)!r},
+    "--output-dir", {str(output_dir)!r}, "--worker", "coder",
+    "--codex-transport", "app-server", "--no-code-graph", "--no-evidence", "--no-route",
+]))
+"""
+    child_env = os.environ.copy()
+    child_env["PYTHONPATH"] = str(Path(__file__).parents[1] / "src")
+    child = subprocess.Popen([sys.executable, "-c", script], env=child_env, start_new_session=True)
+    appserver_pid = None
+    try:
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            try:
+                run_meta = json.loads((output_dir / "run.json").read_text())
+                appserver_pid = int(appserver_pid_path.read_text())
+            except (OSError, ValueError, json.JSONDecodeError):
+                time.sleep(0.02)
+                continue
+            if run_meta.get("status") == "dispatching" and (repo / ".brigade" / "run.lock").is_dir():
+                break
+            time.sleep(0.02)
+        else:
+            pytest.fail("run did not block during control setup")
+
+        child.send_signal(signal.SIGTERM)
+        assert child.wait(timeout=3) == 128 + signal.SIGTERM
+        assert not (repo / ".brigade" / "run.lock").exists()
+
+        deadline = time.monotonic() + 1
+        while time.monotonic() < deadline:
+            try:
+                os.kill(appserver_pid, 0)
+            except ProcessLookupError:
+                break
+            time.sleep(0.02)
+        else:
+            pytest.fail("app-server child survived setup cancellation")
+    finally:
+        if child.poll() is None:
+            os.killpg(child.pid, signal.SIGKILL)
+            child.wait(timeout=5)
+        if appserver_pid is not None:
+            try:
+                os.kill(appserver_pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "canceled"
+    assert run_meta["finished_at"].endswith("Z")
+    assert run_meta["failure"] == {
+        "phase": "dispatch",
+        "kind": "signal",
+        "detail": "run terminated by SIGTERM",
+        "seat": "coder",
+    }
+
+
+def test_run_cli_terminalizes_keyboard_interrupt_during_dispatch(tmp_path, monkeypatch, capsys):
+    repo = _git_repo_with_roster(tmp_path)
+    output_dir = tmp_path / "run-artifacts"
+
+    def interrupted_dispatch(*args, **kwargs):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(aboyeur, "dispatch", interrupted_dispatch)
+
+    try:
+        rc = cli.main(
+            [
+                "run",
+                "inspect",
+                "--cwd",
+                str(repo),
+                "--output-dir",
+                str(output_dir),
+                "--worker",
+                "coder",
+                "--no-code-graph",
+                "--no-evidence",
+                "--no-route",
+            ]
+        )
+    except KeyboardInterrupt:
+        pytest.fail("run dispatch leaked KeyboardInterrupt without terminalizing the receipt")
+
+    assert rc == 130
+    assert "run canceled by user" in capsys.readouterr().err
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "canceled"
+    assert run_meta["finished_at"].endswith("Z")
+    assert run_meta["failure"] == {
+        "phase": "dispatch",
+        "kind": "keyboard-interrupt",
+        "detail": "run canceled by user",
+        "seat": "coder",
+    }
+    assert not (repo / ".brigade" / "run.lock").exists()
+
+
+@pytest.mark.parametrize(
+    ("sig", "expected_code", "failure_kind"),
+    [
+        (signal.SIGINT, 128 + signal.SIGINT, "keyboard-interrupt"),
+        (signal.SIGTERM, 128 + signal.SIGTERM, "signal"),
+    ],
+)
+def test_run_cli_cancels_blocked_worker_process_before_releasing_lock(tmp_path, sig, expected_code, failure_kind):
+    repo = _git_repo_with_roster(tmp_path)
+    output_dir = tmp_path / "run-artifacts"
+    worker_pid_path = tmp_path / "worker.pid"
+    worker_code = (
+        "import os,time; from pathlib import Path; "
+        f"Path({str(worker_pid_path)!r}).write_text(str(os.getpid())); "
+        "time.sleep(60)"
+    )
+    script = f"""
+import sys
+from pathlib import Path
+from brigade import agents, cli
+from brigade.proc import ExecutableIdentity
+
+agents.resolve_agent_executable = lambda *args, **kwargs: ExecutableIdentity(
+    command="codex", path=sys.executable, kind="native", runnable=True, detail="test"
+)
+agents.build_argv = lambda *args, **kwargs: [sys.executable, "-c", {worker_code!r}]
+raise SystemExit(cli.main([
+    "run", "blocked", "--cwd", {str(repo)!r},
+    "--output-dir", {str(output_dir)!r}, "--worker", "coder",
+    "--no-code-graph", "--no-evidence", "--no-route",
+]))
+"""
+    child_env = os.environ.copy()
+    child_env["PYTHONPATH"] = str(Path(__file__).parents[1] / "src")
+    child = subprocess.Popen([sys.executable, "-c", script], env=child_env, start_new_session=True)
+    worker_pid = None
+    try:
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            try:
+                run_meta = json.loads((output_dir / "run.json").read_text())
+                worker_pid = int(worker_pid_path.read_text())
+            except (OSError, ValueError, json.JSONDecodeError):
+                time.sleep(0.02)
+                continue
+            if run_meta.get("status") == "dispatching":
+                break
+            time.sleep(0.02)
+        else:
+            pytest.fail("run did not reach a blocked dispatch")
+
+        child.send_signal(sig)
+        assert child.wait(timeout=3) == expected_code
+        assert not (repo / ".brigade" / "run.lock").exists()
+
+        deadline = time.monotonic() + 1
+        while time.monotonic() < deadline:
+            try:
+                os.kill(worker_pid, 0)
+            except ProcessLookupError:
+                break
+            time.sleep(0.02)
+        else:
+            pytest.fail("blocked worker process survived run cancellation")
+    finally:
+        if child.poll() is None:
+            os.killpg(child.pid, signal.SIGKILL)
+            child.wait(timeout=5)
+        if worker_pid is not None:
+            try:
+                os.kill(worker_pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "canceled"
+    assert run_meta["active_seats"] == ["coder"]
+    assert run_meta["failure"]["phase"] == "dispatch"
+    assert run_meta["failure"]["kind"] == failure_kind
+    assert run_meta["failure"]["seat"] == "coder"
+
+
+def test_run_cli_terminalizes_sigint_during_graphtrail_baseline_capture(tmp_path, capsys):
+    repo = _git_repo_with_roster(tmp_path)
+    output_dir = repo / ".brigade" / "runs" / "blocked-graphtrail-baseline"
+    ready_path = tmp_path / "capture-ready"
+    script = f"""
+import time
+from pathlib import Path
+from brigade import aboyeur, cli
+
+aboyeur.code_graph_brief = lambda *args, **kwargs: aboyeur.CodeGraphBrief(attached=False)
+aboyeur.drift_impact_brief = lambda *args, **kwargs: aboyeur.DriftImpactBrief(attached=False)
+aboyeur.evidence_brief_mod.evidence_brief = lambda *args, **kwargs: aboyeur.EvidenceBrief(attached=False)
+def blocked_capture(target, run_dir):
+    Path({str(ready_path)!r}).write_text("ready")
+    time.sleep(60)
+aboyeur.graphtrail_delta.capture_before = blocked_capture
+raise SystemExit(cli.main([
+    "run", "blocked baseline", "--cwd", {str(repo)!r},
+    "--output-dir", {str(output_dir)!r}, "--worker", "coder",
+    "--no-evidence", "--no-route",
+]))
+"""
+    child_env = os.environ.copy()
+    child_env["PYTHONPATH"] = str(Path(__file__).parents[1] / "src")
+    child = subprocess.Popen([sys.executable, "-c", script], env=child_env, start_new_session=True)
+    try:
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            if ready_path.is_file() and (repo / ".brigade" / "run.lock").is_dir():
+                break
+            time.sleep(0.02)
+        else:
+            pytest.fail("run did not block during GraphTrail baseline capture")
+
+        child.send_signal(signal.SIGINT)
+        assert child.wait(timeout=3) == 128 + signal.SIGINT
+    finally:
+        if child.poll() is None:
+            os.killpg(child.pid, signal.SIGKILL)
+            child.wait(timeout=5)
+
+    receipt = json.loads((output_dir / "run.json").read_text())
+    assert receipt["schema"] == "brigade.run.v1"
+    assert receipt["status"] == "canceled"
+    assert receipt["failure"] == {
+        "phase": "startup",
+        "kind": "keyboard-interrupt",
+        "detail": "run canceled by user",
+        "seat": "coder",
+    }
+    assert not (repo / ".brigade" / "run.lock").exists()
+    assert runs_cmd.list_runs(cwd=repo, limit=10) == 0
+    assert "blocked baseline" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    ("phase", "sig", "expected_code", "expected_status", "expected_seat"),
+    [
+        ("planning", signal.SIGINT, 128 + signal.SIGINT, "planning", "chef"),
+        ("synthesis", signal.SIGTERM, 128 + signal.SIGTERM, "synthesizing", "chef"),
+        ("acpx-preflight", signal.SIGINT, 128 + signal.SIGINT, "dispatching", "composer"),
+        ("ollama-preflight", signal.SIGINT, 128 + signal.SIGINT, "dispatching", "coder"),
+        ("codex-cloud-submit", signal.SIGTERM, 128 + signal.SIGTERM, "dispatching", "coder"),
+    ],
+)
+def test_run_cli_cancels_blocked_phase_process_before_releasing_lock(
+    tmp_path, phase, sig, expected_code, expected_status, expected_seat
+):
+    repo = _git_repo_with_roster(tmp_path)
+    output_dir = tmp_path / "run-artifacts"
+    worker_pid_path = tmp_path / "phase-worker.pid"
+    worker_code = (
+        "import os,time; from pathlib import Path; "
+        f"Path({str(worker_pid_path)!r}).write_text(str(os.getpid())); "
+        "time.sleep(60)"
+    )
+    if phase == "acpx-preflight":
+        (repo / ".brigade" / "roster.toml").write_text(
+            """
+orchestrator = "chef"
+
+[agents.chef]
+cli = "codex"
+role = "plan"
+
+[agents.composer]
+cli = "cursor"
+model = "composer-2.5"
+transport = "acpx"
+transport_version = "0.12.0"
+role = "code"
+"""
+        )
+        _git(repo, "add", ".brigade/roster.toml")
+        _git(repo, "commit", "-m", "test acpx roster")
+    elif phase in {"ollama-preflight", "codex-cloud-submit"}:
+        cli_ref = "ollama:llama3.3" if phase == "ollama-preflight" else "codex-cloud:env-123"
+        (repo / ".brigade" / "roster.toml").write_text(
+            f"""
+orchestrator = "chef"
+
+[agents.chef]
+cli = "codex"
+role = "plan"
+
+[agents.coder]
+cli = "{cli_ref}"
+role = "code"
+"""
+        )
+        _git(repo, "add", ".brigade/roster.toml")
+        _git(repo, "commit", "-m", f"test {phase} roster")
+
+    setup = ""
+    worker_args = ""
+    if phase in {"planning", "synthesis"}:
+        setup = f"""
+agents.resolve_agent_executable = lambda *args, **kwargs: ExecutableIdentity(
+    command="codex", path=sys.executable, kind="native", runnable=True, detail="test"
+)
+agents.build_argv = lambda *args, **kwargs: [sys.executable, "-c", {worker_code!r}]
+"""
+    if phase == "synthesis":
+        setup += """
+aboyeur.plan = lambda *args, **kwargs: [aboyeur.Assignment(worker="coder", task="implement")]
+aboyeur.dispatch = lambda *args, **kwargs: [
+    aboyeur.WorkerResult(worker="coder", task="implement", text="done", ok=True)
+]
+"""
+    elif phase == "acpx-preflight":
+        setup = f"""
+acpx_adapter.proc.which = lambda *args, **kwargs: sys.executable
+def blocked_version(*, process_registry=None):
+    proc.run(
+        [sys.executable, "-c", {worker_code!r}],
+        timeout=60,
+        process_registry=process_registry,
+    )
+    return "0.12.0", ""
+acpx_adapter.installed_version = blocked_version
+"""
+        worker_args = ', "--worker", "composer"'
+    elif phase == "ollama-preflight":
+        setup = f"""
+agents.resolve_agent_executable = lambda *args, **kwargs: ExecutableIdentity(
+    command="ollama", path=sys.executable, kind="native", runnable=True, detail="test"
+)
+def blocked_ollama(model, executable=None, process_registry=None):
+    proc.run(
+        [sys.executable, "-c", {worker_code!r}],
+        timeout=60,
+        process_registry=process_registry,
+    )
+    return True, ""
+agents.ollama_model_present = blocked_ollama
+"""
+        worker_args = ', "--worker", "coder"'
+    elif phase == "codex-cloud-submit":
+        setup = f"""
+agents.resolve_agent_executable = lambda *args, **kwargs: ExecutableIdentity(
+    command="codex", path=sys.executable, kind="native", runnable=True, detail="test"
+)
+def blocked_cloud(prompt, *, env_id, timeout, cwd=None, process_registry=None):
+    proc.run(
+        [sys.executable, "-c", {worker_code!r}],
+        timeout=60,
+        process_registry=process_registry,
+    )
+    return agents.AgentResult(text="done", ok=True)
+codex_cloud.run_cloud_task = blocked_cloud
+"""
+        worker_args = ', "--worker", "coder"'
+
+    script = f"""
+import sys
+from brigade import aboyeur, acpx_adapter, agents, cli, codex_cloud, proc
+from brigade.proc import ExecutableIdentity
+{setup}
+raise SystemExit(cli.main([
+    "run", "blocked", "--cwd", {str(repo)!r},
+    "--output-dir", {str(output_dir)!r}{worker_args},
+    "--no-code-graph", "--no-evidence", "--no-route",
+]))
+"""
+    child_env = os.environ.copy()
+    child_env["PYTHONPATH"] = str(Path(__file__).parents[1] / "src")
+    child = subprocess.Popen([sys.executable, "-c", script], env=child_env, start_new_session=True)
+    worker_pid = None
+    try:
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            try:
+                run_meta = json.loads((output_dir / "run.json").read_text())
+                worker_pid = int(worker_pid_path.read_text())
+            except (OSError, ValueError, json.JSONDecodeError):
+                time.sleep(0.02)
+                continue
+            if run_meta.get("status") == expected_status and (repo / ".brigade" / "run.lock").is_dir():
+                break
+            time.sleep(0.02)
+        else:
+            pytest.fail(f"run did not reach blocked {phase}")
+
+        child.send_signal(sig)
+        deadline = time.monotonic() + 3
+        while child.poll() is None and time.monotonic() < deadline:
+            try:
+                os.kill(worker_pid, 0)
+                worker_alive = True
+            except ProcessLookupError:
+                worker_alive = False
+            if not (repo / ".brigade" / "run.lock").exists() and worker_alive:
+                pytest.fail(f"run lock released before blocked {phase} process exited")
+            time.sleep(0.01)
+        assert child.wait(timeout=3) == expected_code
+        assert not (repo / ".brigade" / "run.lock").exists()
+
+        deadline = time.monotonic() + 1
+        while time.monotonic() < deadline:
+            try:
+                os.kill(worker_pid, 0)
+            except ProcessLookupError:
+                break
+            time.sleep(0.02)
+        else:
+            pytest.fail(f"blocked {phase} process survived run cancellation")
+    finally:
+        if child.poll() is None:
+            os.killpg(child.pid, signal.SIGKILL)
+            child.wait(timeout=5)
+        if worker_pid is not None:
+            try:
+                os.kill(worker_pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "canceled"
+    expected_failure_phase = "dispatch" if phase.endswith("preflight") or phase.endswith("submit") else phase
+    assert run_meta["failure"]["phase"] == expected_failure_phase
+    assert run_meta["failure"]["seat"] == expected_seat
+
+
+def test_run_cli_terminalizes_unexpected_dispatch_exception(tmp_path, monkeypatch, capsys):
+    repo = _git_repo_with_roster(tmp_path)
+    output_dir = tmp_path / "run-artifacts"
+
+    def broken_dispatch(*args, **kwargs):
+        raise RuntimeError("provider exploded")
+
+    monkeypatch.setattr(aboyeur, "dispatch", broken_dispatch)
+
+    rc = cli.main(
+        [
+            "run",
+            "inspect",
+            "--cwd",
+            str(repo),
+            "--output-dir",
+            str(output_dir),
+            "--worker",
+            "coder",
+            "--no-code-graph",
+            "--no-evidence",
+            "--no-route",
+        ]
+    )
+
+    assert rc == 2
+    assert "unexpected run failure: RuntimeError: provider exploded" in capsys.readouterr().err
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "failed"
+    assert run_meta["finished_at"].endswith("Z")
+    assert run_meta["failure"] == {
+        "phase": "dispatch",
+        "kind": "unexpected-error",
+        "detail": "RuntimeError: provider exploded",
+        "seat": "coder",
+    }
+    assert not (repo / ".brigade" / "run.lock").exists()
+
+
+def test_run_cli_terminalizes_keyboard_interrupt_during_planning(tmp_path, monkeypatch, capsys):
+    repo = _git_repo_with_roster(tmp_path)
+    output_dir = tmp_path / "run-artifacts"
+
+    def interrupted_plan(*args, **kwargs):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(aboyeur, "plan", interrupted_plan)
+
+    try:
+        rc = cli.main(
+            [
+                "run",
+                "inspect",
+                "--cwd",
+                str(repo),
+                "--output-dir",
+                str(output_dir),
+                "--no-code-graph",
+                "--no-evidence",
+                "--no-route",
+            ]
+        )
+    except KeyboardInterrupt:
+        pytest.fail("run planning leaked KeyboardInterrupt without terminalizing the receipt")
+
+    assert rc == 130
+    assert "run canceled by user" in capsys.readouterr().err
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "canceled"
+    assert run_meta["finished_at"].endswith("Z")
+    assert run_meta["failure"] == {
+        "phase": "planning",
+        "kind": "keyboard-interrupt",
+        "detail": "run canceled by user",
+        "seat": "chef",
+    }
+
+
+def test_run_cli_terminalizes_unexpected_planning_exception(tmp_path, monkeypatch):
+    repo = _git_repo_with_roster(tmp_path)
+    output_dir = tmp_path / "run-artifacts"
+
+    def broken_plan(*args, **kwargs):
+        raise ValueError("planner exploded")
+
+    monkeypatch.setattr(aboyeur, "plan", broken_plan)
+
+    assert (
+        cli.main(
+            [
+                "run",
+                "inspect",
+                "--cwd",
+                str(repo),
+                "--output-dir",
+                str(output_dir),
+                "--no-code-graph",
+                "--no-evidence",
+                "--no-route",
+            ]
+        )
+        == 2
+    )
+
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "failed"
+    assert run_meta["finished_at"].endswith("Z")
+    assert run_meta["failure"] == {
+        "phase": "planning",
+        "kind": "unexpected-error",
+        "detail": "ValueError: planner exploded",
+        "seat": "chef",
+    }
+
+
+def test_run_cli_does_not_reclassify_receipt_write_failure(tmp_path, monkeypatch):
+    repo = _git_repo_with_roster(tmp_path)
+    output_dir = tmp_path / "run-artifacts"
+    termination_calls = []
+
+    def failed_run(*args, **kwargs):  # noqa: ARG001
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "run.json").write_text(
+            json.dumps(
+                {
+                    "status": "planning",
+                    "started_at": "2026-07-19T12:00:00Z",
+                    "status_started_at": "2026-07-19T12:00:00Z",
+                }
+            )
+        )
+        raise runguard.RetainRunLockError("receipt disk full")
+
+    monkeypatch.setattr(aboyeur, "run", failed_run)
+    monkeypatch.setattr(
+        aboyeur,
+        "record_run_termination",
+        lambda *args, **kwargs: termination_calls.append((args, kwargs)),
+    )
+
+    assert (
+        cli.main(
+            [
+                "run",
+                "inspect",
+                "--cwd",
+                str(repo),
+                "--output-dir",
+                str(output_dir),
+                "--no-code-graph",
+                "--no-evidence",
+                "--no-route",
+            ]
+        )
+        == 2
+    )
+
+    assert termination_calls == []
+    assert (repo / ".brigade" / "run.lock").is_dir()
+
+
 def test_app_server_fallback_clears_uncreated_control_socket(tmp_path, monkeypatch):
     repo = _git_repo_with_roster(tmp_path)
     output_dir = tmp_path / "run-artifacts"
@@ -1133,10 +1942,8 @@ def _write_successful_worktree_run(output_dir: Path, cwd: Path, *, final: str = 
                 "schema": "brigade.run.v1",
                 "task": "x",
                 "cwd": str(cwd),
-                "status": "ok",
+                "status": "artifact-collection",
                 "started_at": "2026-07-09T12:00:00Z",
-                "finished_at": "2026-07-09T12:00:01Z",
-                "duration_seconds": 1,
                 "artifacts": str(output_dir),
             }
         )
@@ -1220,7 +2027,7 @@ def test_run_cli_worktree_warns_on_empty_changes_patch_noop(tmp_path, monkeypatc
     def fake_run(task, loaded_roster, **kwargs):
         cwd = kwargs["cwd"]
         output = kwargs["output_dir"]
-        output.mkdir(parents=True)
+        output.mkdir(parents=True, exist_ok=True)
         (output / "run.json").write_text(
             json.dumps(
                 {
@@ -1292,8 +2099,8 @@ def test_run_cli_worktree_keeps_checkout_when_patch_invalid(tmp_path, monkeypatc
         run_path = output / "run.json"
         run_meta = json.loads(run_path.read_text())
         run_meta["status"] = "artifact-collection"
-        run_meta.pop("finished_at")
-        run_meta.pop("duration_seconds")
+        run_meta.pop("finished_at", None)
+        run_meta.pop("duration_seconds", None)
         run_path.write_text(json.dumps(run_meta) + "\n")
         (output / "worker-results.json").write_text(
             json.dumps({"results": [], "ground_truth": {"patch_ref": None}}) + "\n"
@@ -1397,6 +2204,50 @@ def test_run_cli_worktree_artifact_failure_preserves_model_failure(tmp_path, mon
     }
 
 
+def test_run_cli_terminalizes_keyboard_interrupt_during_artifact_collection(tmp_path, monkeypatch, capsys):
+    repo = _git_repo_with_roster(tmp_path)
+    output_dir = tmp_path / "run"
+
+    def fake_run(task, loaded_roster, **kwargs):
+        cwd = kwargs["cwd"]
+        (cwd / "tracked.txt").write_text("changed in worktree\n")
+        output = kwargs["output_dir"]
+        _write_successful_worktree_run(output, cwd, final="implementation complete")
+        run_path = output / "run.json"
+        run_meta = json.loads(run_path.read_text())
+        run_meta["status"] = "artifact-collection"
+        run_meta["status_started_at"] = "2026-07-19T12:00:01Z"
+        run_meta.pop("finished_at", None)
+        run_meta.pop("duration_seconds", None)
+        run_path.write_text(json.dumps(run_meta) + "\n")
+        return 0
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    monkeypatch.setattr(aboyeur, "run", fake_run)
+    monkeypatch.setattr(
+        runguard,
+        "collect_changes_patch",
+        lambda cwd, patch_path: (_ for _ in ()).throw(KeyboardInterrupt),
+    )
+
+    rc = cli.main(["run", "x", "--cwd", str(repo), "--output-dir", str(output_dir), "--worktree"])
+
+    checkout = tmp_path / "home" / ".cache" / "brigade" / "worktrees" / f"{repo.name}-{output_dir.name}"
+    assert rc == 130
+    assert checkout.exists()
+    assert (checkout / "tracked.txt").read_text() == "changed in worktree\n"
+    assert str(checkout) in capsys.readouterr().err
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "canceled"
+    assert run_meta["failure"] == {
+        "phase": "artifact-collection",
+        "kind": "keyboard-interrupt",
+        "detail": "run canceled by user",
+        "seat": "chef",
+    }
+    assert not runguard.lock_path(repo).exists()
+
+
 def test_run_cli_worktree_kept_when_patch_collection_raises(tmp_path, monkeypatch, capsys):
     # If patch collection itself dies after agents edited the worktree, the
     # worktree is the only copy of the work and must survive cleanup.
@@ -1489,8 +2340,10 @@ def test_run_cli_worktree_records_patch_write_error(tmp_path, monkeypatch, capsy
 def test_run_cli_worktree_keeps_checkout_when_receipt_finalization_fails(tmp_path, monkeypatch, capsys):
     repo = _git_repo_with_roster(tmp_path)
     output_dir = tmp_path / "run"
+    fail_writes = False
 
     def fake_run(task, loaded_roster, **kwargs):
+        nonlocal fail_writes
         cwd = kwargs["cwd"]
         (cwd / "tracked.txt").write_text("changed in worktree\n")
         output = kwargs["output_dir"]
@@ -1498,18 +2351,22 @@ def test_run_cli_worktree_keeps_checkout_when_receipt_finalization_fails(tmp_pat
         run_path = output / "run.json"
         run_meta = json.loads(run_path.read_text())
         run_meta["status"] = "artifact-collection"
-        run_meta.pop("finished_at")
-        run_meta.pop("duration_seconds")
+        run_meta.pop("finished_at", None)
+        run_meta.pop("duration_seconds", None)
         run_path.write_text(json.dumps(run_meta) + "\n")
+        fail_writes = True
         return 0
+
+    real_write_json = aboyeur._write_json
+
+    def fail_finalization_write(path, payload):
+        if fail_writes:
+            raise OSError("receipt disk full")
+        real_write_json(path, payload)
 
     monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
     monkeypatch.setattr(aboyeur, "run", fake_run)
-    monkeypatch.setattr(
-        aboyeur,
-        "_write_json",
-        lambda path, payload: (_ for _ in ()).throw(OSError("receipt disk full")),
-    )
+    monkeypatch.setattr(aboyeur, "_write_json", fail_finalization_write)
 
     rc = cli.main(["run", "x", "--cwd", str(repo), "--output-dir", str(output_dir), "--worktree"])
 

--- a/tests/test_run_control.py
+++ b/tests/test_run_control.py
@@ -356,19 +356,19 @@ def test_cli_interrupt_leaves_live_worker_resumable(tmp_path, monkeypatch, capsy
 
     monkeypatch.setattr(run_control.LiveTurnRegistry, "register", register_and_signal)
 
-    def fake_run_agent(cli_ref, prompt, **kwargs):
-        if "Return exactly one JSON object" in prompt:
-            return agents.AgentResult(
-                text=json.dumps({"assignments": [{"worker": "cook", "task": "HANG until interrupted"}]}),
-                ok=True,
-            )
-        return agents.AgentResult(text="final synthesis", ok=True)
-
-    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
     result: dict[str, int] = {}
 
     thread = threading.Thread(
-        target=lambda: result.update(rc=aboyeur.run("do it", roster, cwd=tmp_path, output_dir=run_dir)),
+        target=lambda: result.update(
+            rc=aboyeur.run(
+                "HANG until interrupted",
+                roster,
+                worker="cook",
+                cwd=tmp_path,
+                output_dir=run_dir,
+                route_enabled=False,
+            )
+        ),
         daemon=True,
     )
     thread.start()
@@ -380,14 +380,23 @@ def test_cli_interrupt_leaves_live_worker_resumable(tmp_path, monkeypatch, capsy
     assert cli.main(["runs", "interrupt", str(run_dir), "cook"]) == 0
     thread.join(timeout=5.0)
 
-    assert "rc" in result
+    assert result == {"rc": 2}
     assert "interrupt: 1 (cook)" in capsys.readouterr().out
     assert not _control_transport_active(control_transport)
     worker_results = json.loads((run_dir / "worker-results.json").read_text())["results"]
     entry = worker_results[0]
     assert entry["status"] == "interrupted"
     assert entry["ok"] is False
+    assert entry["failure_kind"] == "interrupted"
     assert isinstance(entry["thread_id"], str) and entry["thread_id"]
+    run_meta = json.loads((run_dir / "run.json").read_text())
+    assert run_meta["status"] == "canceled"
+    assert run_meta["failure"] == {
+        "phase": "dispatch",
+        "kind": "interrupted",
+        "detail": "turn interrupted",
+        "seat": "cook",
+    }
 
 
 def test_plan_control_transport_selects_loopback_when_af_unix_missing(tmp_path, monkeypatch):

--- a/tests/test_run_detach.py
+++ b/tests/test_run_detach.py
@@ -1,10 +1,25 @@
 import argparse
 import json
+import os
+import signal
+import subprocess
+import sys
+import time
 from pathlib import Path
 
-from brigade import aboyeur, cli
+import pytest
+
+from brigade import aboyeur, cli, proc
 from brigade import roster as roster_mod
 from brigade.cli import run as run_cli
+
+
+def _pid_is_running(pid: int) -> bool:
+    try:
+        state = Path(f"/proc/{pid}/stat").read_text().split()[2]
+    except (FileNotFoundError, IndexError, OSError):
+        return False
+    return state != "Z"
 
 
 def _write_roster(target: Path) -> None:
@@ -57,7 +72,7 @@ def test_run_detach_spawns_child_with_output_dir_and_log(tmp_path, monkeypatch, 
 
     monkeypatch.setattr(run_cli, "Popen", FakeProcess)
 
-    rc = cli.main(["run", "do work", "--cwd", str(tmp_path), "--detach"])
+    rc = cli.main(["run", "do work", "--cwd", str(tmp_path), "--detach", "--worker", "coder"])
 
     captured = capsys.readouterr()
     assert rc == 0
@@ -87,7 +102,7 @@ def test_run_detach_reports_early_child_exit(tmp_path, monkeypatch, capsys):
 
     monkeypatch.setattr(run_cli, "Popen", FakeProcess)
 
-    rc = cli.main(["run", "do work", "--cwd", str(tmp_path), "--detach"])
+    rc = cli.main(["run", "do work", "--cwd", str(tmp_path), "--detach", "--worker", "coder"])
 
     captured = capsys.readouterr()
     run_dir = next((tmp_path / ".brigade" / "runs").iterdir())
@@ -95,6 +110,312 @@ def test_run_detach_reports_early_child_exit(tmp_path, monkeypatch, capsys):
     assert "detached child exited before run metadata was written: exit 7" in captured.err
     assert f"log: {run_dir / 'detached.log'}" in captured.err
     assert (run_dir / "detached.log").read_text() == "boom\n"
+    run_meta = json.loads((run_dir / "run.json").read_text())
+    assert run_meta["status"] == "failed"
+    assert run_meta["finished_at"].endswith("Z")
+    assert run_meta["failure"] == {
+        "phase": "startup",
+        "kind": "early-exit",
+        "detail": "detached child exited before run metadata was written: exit 7",
+        "seat": "coder",
+    }
+
+
+def test_run_detach_records_spawn_failure_receipt(tmp_path, monkeypatch, capsys):
+    _write_roster(tmp_path)
+
+    def failed_spawn(*args, **kwargs):  # noqa: ARG001
+        raise OSError("spawn denied")
+
+    monkeypatch.setattr(run_cli, "Popen", failed_spawn)
+
+    assert cli.main(["run", "do work", "--cwd", str(tmp_path), "--detach", "--worker", "coder"]) == 2
+
+    run_dir = next((tmp_path / ".brigade" / "runs").iterdir())
+    run_meta = json.loads((run_dir / "run.json").read_text())
+    assert "failed to start detached run: spawn denied" in capsys.readouterr().err
+    assert run_meta["status"] == "failed"
+    assert run_meta["finished_at"].endswith("Z")
+    assert run_meta["failure"] == {
+        "phase": "startup",
+        "kind": "spawn-error",
+        "detail": "failed to start detached run: spawn denied",
+        "seat": "coder",
+    }
+
+
+def test_run_detach_terminalizes_roster_snapshot_write_failure(tmp_path, monkeypatch):
+    _write_roster(tmp_path)
+    real_write_json = aboyeur._write_json
+
+    def fail_roster_write(path, payload):
+        if path.name == "roster.json":
+            raise OSError("roster snapshot denied")
+        return real_write_json(path, payload)
+
+    monkeypatch.setattr(aboyeur, "_write_json", fail_roster_write)
+
+    assert cli.main(["run", "do work", "--cwd", str(tmp_path), "--detach", "--worker", "coder"]) == 2
+
+    run_dir = next((tmp_path / ".brigade" / "runs").iterdir())
+    receipt = json.loads((run_dir / "run.json").read_text())
+    assert receipt["schema"] == "brigade.run.v1"
+    assert receipt["status"] == "failed"
+    assert receipt["failure"] == {
+        "phase": "startup",
+        "kind": "unexpected-error",
+        "detail": "OSError: roster snapshot denied",
+        "seat": "coder",
+    }
+
+
+def test_run_detach_terminalizes_sigterm_during_roster_snapshot(tmp_path, monkeypatch):
+    _write_roster(tmp_path)
+    real_write_json = aboyeur._write_json
+
+    def terminate_during_roster_write(path, payload):
+        if path.name == "roster.json":
+            signal.raise_signal(signal.SIGTERM)
+        return real_write_json(path, payload)
+
+    monkeypatch.setattr(aboyeur, "_write_json", terminate_during_roster_write)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["run", "do work", "--cwd", str(tmp_path), "--detach", "--worker", "coder"])
+
+    assert exc_info.value.code == 128 + signal.SIGTERM
+    run_dir = next((tmp_path / ".brigade" / "runs").iterdir())
+    receipt = json.loads((run_dir / "run.json").read_text())
+    assert receipt["schema"] == "brigade.run.v1"
+    assert receipt["status"] == "canceled"
+    assert receipt["failure"] == {
+        "phase": "startup",
+        "kind": "signal",
+        "detail": "run terminated by SIGTERM",
+        "seat": "coder",
+    }
+
+
+def test_run_detach_terminalizes_keyboard_interrupt_during_startup_poll(tmp_path, monkeypatch):
+    _write_roster(tmp_path)
+
+    class FakeProcess:
+        pid = 4321
+
+        def poll(self):
+            return 0
+
+    monkeypatch.setattr(run_cli, "Popen", lambda *args, **kwargs: FakeProcess())
+    monkeypatch.setattr(
+        run_cli,
+        "_poll_detached_start",
+        lambda *args, **kwargs: (_ for _ in ()).throw(KeyboardInterrupt()),
+    )
+
+    assert cli.main(["run", "do work", "--cwd", str(tmp_path), "--detach", "--worker", "coder"]) == 130
+
+    run_dir = next((tmp_path / ".brigade" / "runs").iterdir())
+    receipt = json.loads((run_dir / "run.json").read_text())
+    assert receipt["schema"] == "brigade.run.v1"
+    assert receipt["status"] == "canceled"
+    assert receipt["failure"] == {
+        "phase": "startup",
+        "kind": "keyboard-interrupt",
+        "detail": "run canceled by user",
+        "seat": "coder",
+    }
+
+
+def test_run_detach_kills_child_when_interrupted_during_registry_registration(tmp_path, monkeypatch):
+    _write_roster(tmp_path)
+    events = []
+
+    class FakeProcess:
+        pid = 4321
+
+        def poll(self):
+            return None
+
+    class InterruptingRegistry:
+        def register(self, child):
+            events.append(("register", child.pid))
+            raise KeyboardInterrupt
+
+        def terminate(self, child):
+            events.append(("terminate", child.pid))
+
+        def cancel(self):
+            events.append(("cancel", None))
+
+        def unregister(self, child):
+            events.append(("unregister", child.pid))
+
+    monkeypatch.setattr(run_cli, "Popen", lambda *args, **kwargs: FakeProcess())
+    monkeypatch.setattr(proc, "ProcessRegistry", InterruptingRegistry)
+
+    assert cli.main(["run", "do work", "--cwd", str(tmp_path), "--detach", "--worker", "coder"]) == 130
+    assert events[:2] == [("register", 4321), ("terminate", 4321)]
+
+
+@pytest.mark.parametrize("escape", ["keyboard", "sigterm"])
+def test_run_detach_parent_stops_terminalizing_receipt_at_child_takeover(tmp_path, monkeypatch, escape):
+    _write_roster(tmp_path)
+    events = []
+
+    class FakeProcess:
+        pid = 4321
+
+        def poll(self):
+            return None
+
+    class InterruptingRegistry:
+        def register(self, child):
+            events.append(("register", child.pid))
+
+        def terminate(self, child):
+            events.append(("terminate", child.pid))
+
+        def cancel(self):
+            events.append(("cancel", None))
+
+        def unregister(self, child):
+            events.append(("unregister", child.pid))
+            if escape == "sigterm":
+                signal.raise_signal(signal.SIGTERM)
+            raise KeyboardInterrupt
+
+    def take_over(child, output_dir, *, initial_receipt):  # noqa: ARG001
+        (output_dir / "run.json").write_text(json.dumps({"status": "dispatching", "active_seats": ["coder"]}) + "\n")
+        return None, True
+
+    monkeypatch.setattr(run_cli, "Popen", lambda *args, **kwargs: FakeProcess())
+    monkeypatch.setattr(proc, "ProcessRegistry", InterruptingRegistry)
+    monkeypatch.setattr(run_cli, "_poll_detached_start", take_over)
+
+    if escape == "sigterm":
+        with pytest.raises(SystemExit) as exc_info:
+            cli.main(["run", "do work", "--cwd", str(tmp_path), "--detach", "--worker", "coder"])
+        assert exc_info.value.code == 128 + signal.SIGTERM
+    else:
+        assert cli.main(["run", "do work", "--cwd", str(tmp_path), "--detach", "--worker", "coder"]) == 130
+
+    run_dir = next((tmp_path / ".brigade" / "runs").iterdir())
+    receipt = json.loads((run_dir / "run.json").read_text())
+    assert receipt == {"status": "dispatching", "active_seats": ["coder"]}
+    assert events == [("register", 4321), ("unregister", 4321)]
+
+
+@pytest.mark.skipif(os.name != "posix", reason="requires POSIX process groups")
+@pytest.mark.parametrize(
+    ("escape", "expected_code", "expected_status", "expected_kind"),
+    [
+        ("keyboard", 130, "canceled", "keyboard-interrupt"),
+        ("sigterm", 128 + signal.SIGTERM, "canceled", "signal"),
+        ("error", 2, "failed", "unexpected-error"),
+    ],
+)
+def test_run_detach_startup_escape_kills_child_group_before_terminal_receipt(
+    tmp_path, monkeypatch, escape, expected_code, expected_status, expected_kind
+):
+    _write_roster(tmp_path)
+    child_pid_path = tmp_path / "detached-child.pid"
+    descendant_pid_path = tmp_path / "detached-descendant.pid"
+    output_dir = tmp_path / "run"
+    overwrite_code = (
+        "import time; from pathlib import Path; "
+        "time.sleep(0.4); "
+        f'Path({str(output_dir / "run.json")!r}).write_text(\'{{"status": "overwritten"}}\\n\')'
+    )
+    child_code = (
+        "import os,subprocess,sys,time; from pathlib import Path; "
+        f"child=subprocess.Popen([sys.executable, '-c', {overwrite_code!r}]); "
+        f"Path({str(child_pid_path)!r}).write_text(str(os.getpid())); "
+        f"Path({str(descendant_pid_path)!r}).write_text(str(child.pid)); "
+        "time.sleep(60)"
+    )
+    spawned = []
+    real_popen = subprocess.Popen
+
+    def tracked_popen(*args, **kwargs):
+        process = real_popen(*args, **kwargs)
+        spawned.append(process)
+        return process
+
+    def interrupt_poll(*args, **kwargs):  # noqa: ARG001
+        deadline = time.monotonic() + 3
+        while time.monotonic() < deadline:
+            if child_pid_path.is_file() and descendant_pid_path.is_file():
+                break
+            time.sleep(0.01)
+        else:
+            pytest.fail("detached child did not start")
+        if escape == "keyboard":
+            raise KeyboardInterrupt
+        if escape == "sigterm":
+            signal.raise_signal(signal.SIGTERM)
+        raise RuntimeError("startup poll exploded")
+
+    monkeypatch.setattr(run_cli, "Popen", tracked_popen)
+    monkeypatch.setattr(
+        run_cli,
+        "_detached_child_argv",
+        lambda *args, **kwargs: [sys.executable, "-c", child_code],
+    )
+    monkeypatch.setattr(run_cli, "_poll_detached_start", interrupt_poll)
+
+    try:
+        if escape == "sigterm":
+            with pytest.raises(SystemExit) as exc_info:
+                cli.main(["run", "do work", "--cwd", str(tmp_path), "--output-dir", str(output_dir), "--detach"])
+            assert exc_info.value.code == expected_code
+        else:
+            assert (
+                cli.main(["run", "do work", "--cwd", str(tmp_path), "--output-dir", str(output_dir), "--detach"])
+                == expected_code
+            )
+
+        time.sleep(0.6)
+        receipt = json.loads((output_dir / "run.json").read_text())
+        assert receipt["status"] == expected_status
+        assert receipt["failure"]["kind"] == expected_kind
+        assert not _pid_is_running(int(child_pid_path.read_text()))
+        assert not _pid_is_running(int(descendant_pid_path.read_text()))
+    finally:
+        for process in spawned:
+            if process.poll() is None:
+                os.killpg(process.pid, signal.SIGKILL)
+                process.wait(timeout=3)
+
+
+def test_run_detach_terminalizes_startup_timeout_and_kills_child(tmp_path, monkeypatch):
+    _write_roster(tmp_path)
+
+    class FakeProcess:
+        pid = 4321
+
+        def __init__(self, argv, **kwargs):
+            pass
+
+        def poll(self):
+            return None
+
+    monkeypatch.setattr(run_cli, "Popen", FakeProcess)
+    monkeypatch.setattr(run_cli, "_DETACH_START_TIMEOUT_SECONDS", 0.0)
+
+    assert cli.main(["run", "do work", "--cwd", str(tmp_path), "--detach"]) == 2
+
+    run_dir = next((tmp_path / ".brigade" / "runs").iterdir())
+    run_meta = json.loads((run_dir / "run.json").read_text())
+    roster = json.loads((run_dir / "roster.json").read_text())
+    assert run_meta["status"] == "timeout"
+    assert run_meta["failure"] == {
+        "phase": "startup",
+        "kind": "timeout",
+        "detail": "detached child did not write run metadata within 0 seconds",
+        "seat": "chef",
+    }
+    assert run_meta["finished_at"].endswith("Z")
+    assert roster["orchestrator"] == "chef"
 
 
 def test_run_detach_child_records_artifact_identity_in_lock(tmp_path, monkeypatch):

--- a/tests/test_run_resume.py
+++ b/tests/test_run_resume.py
@@ -215,7 +215,7 @@ def test_resume_refuses_nonterminal_run(tmp_path, monkeypatch, capsys):
         lambda **kwargs: (_ for _ in ()).throw(AssertionError("provider must not start")),
     )
 
-    for status in ("dispatching", "artifact-collection"):
+    for status in ("dispatching", "result-processing", "artifact-collection"):
         run_meta = json.loads((run_dir / "run.json").read_text())
         run_meta["status"] = status
         (run_dir / "run.json").write_text(json.dumps(run_meta))

--- a/tests/test_run_transport_env.py
+++ b/tests/test_run_transport_env.py
@@ -1,6 +1,8 @@
 """Per-seat env overrides flowing through worker dispatch (issue #301)."""
 
-from brigade import agents
+import threading
+
+from brigade import acpx_adapter, agents
 from brigade import run_transport
 from brigade.roster import Agent, Roster
 from brigade.run_receipts import write_worker_logs
@@ -16,6 +18,7 @@ def _roster_with_env(env):
 def _dispatch(roster, monkeypatch, captured, *, stdout="worker answer", stderr=""):
     def fake_run(argv, **kw):
         captured["env"] = kw.get("env")
+        captured["process_registry"] = kw.get("process_registry")
         return agents.proc.Result(0, stdout, stderr)
 
     monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
@@ -101,6 +104,135 @@ def test_worker_env_missing_ref_fails_the_worker(monkeypatch):
     assert captured.get("env") is None
 
 
+def test_keyboard_interrupt_notifies_before_blocked_worker_finishes(monkeypatch):
+    worker_started = threading.Event()
+    allow_interrupt = threading.Event()
+    release_worker = threading.Event()
+    worker_finished = threading.Event()
+    interruption_recorded = threading.Event()
+    dispatch_finished = threading.Event()
+    errors = []
+
+    def blocked_run_agent(*args, **kwargs):  # noqa: ARG001
+        worker_started.set()
+        release_worker.wait()
+        worker_finished.set()
+        return agents.AgentResult(text="done", ok=True)
+
+    def interrupted_wait(futures):  # noqa: ARG001
+        allow_interrupt.wait()
+        raise KeyboardInterrupt
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(agents, "run_agent", blocked_run_agent)
+    monkeypatch.setattr(run_transport, "as_completed", interrupted_wait)
+
+    def invoke_dispatch():
+        try:
+            run_transport.dispatch(
+                [Assignment(worker="k3", task="do the thing")],
+                _roster_with_env(None),
+                build_prompt=lambda agent, assignment, **kw: assignment.task,
+                run_appserver_worker=lambda *a, **kw: agents.AgentResult(text="", ok=False, detail="unused"),
+                event_writer=lambda events_dir, worker, verbose=False: None,
+                read_only=True,
+                on_interrupt=interruption_recorded.set,
+            )
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            dispatch_finished.set()
+
+    controller = threading.Thread(target=invoke_dispatch)
+    controller.start()
+    try:
+        assert worker_started.wait(2)
+        allow_interrupt.set()
+        assert interruption_recorded.wait(2)
+        assert not dispatch_finished.wait(0.1)
+        assert not worker_finished.is_set()
+    finally:
+        release_worker.set()
+        controller.join(2)
+
+    assert not controller.is_alive()
+    assert worker_finished.wait(2)
+    assert len(errors) == 1
+    assert isinstance(errors[0], KeyboardInterrupt)
+
+
+def test_keyboard_interrupt_stops_scoped_appserver_turn_before_return(monkeypatch):
+    worker_started = threading.Event()
+    allow_interrupt = threading.Event()
+    release_worker = threading.Event()
+    registry_interrupted = threading.Event()
+    appserver_closed = threading.Event()
+    dispatch_finished = threading.Event()
+    errors = []
+
+    class StubRegistry:
+        def interrupt(self):
+            registry_interrupted.set()
+
+    class StubAppserver:
+        def close(self):
+            appserver_closed.set()
+            release_worker.set()
+
+    def blocked_appserver(*args, **kwargs):  # noqa: ARG001
+        worker_started.set()
+        release_worker.wait()
+        return agents.AgentResult(text="done", ok=True)
+
+    def interrupted_wait(futures):  # noqa: ARG001
+        allow_interrupt.wait()
+        raise KeyboardInterrupt
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(run_transport, "as_completed", interrupted_wait)
+
+    roster = Roster(
+        orchestrator="chef",
+        agents={
+            "chef": Agent(name="chef", cli="codex", role="plan"),
+            "worker": Agent(name="worker", cli="codex", role="worker"),
+        },
+    )
+
+    def invoke_dispatch():
+        try:
+            run_transport.dispatch(
+                [Assignment(worker="worker", task="do the thing")],
+                roster,
+                build_prompt=lambda agent, assignment, **kw: assignment.task,
+                run_appserver_worker=blocked_appserver,
+                event_writer=lambda events_dir, worker, verbose=False: None,
+                appserver=StubAppserver(),
+                control_registry=StubRegistry(),
+                read_only=True,
+            )
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            dispatch_finished.set()
+
+    controller = threading.Thread(target=invoke_dispatch)
+    controller.start()
+    try:
+        assert worker_started.wait(2)
+        allow_interrupt.set()
+        assert registry_interrupted.wait(2)
+        assert appserver_closed.wait(2)
+        assert dispatch_finished.wait(2)
+    finally:
+        release_worker.set()
+        controller.join(2)
+
+    assert not controller.is_alive()
+    assert len(errors) == 1
+    assert isinstance(errors[0], KeyboardInterrupt)
+
+
 def test_worker_without_env_keeps_legacy_call_shape(monkeypatch):
     captured = {}
     roster = _roster_with_env(None)
@@ -109,6 +241,49 @@ def test_worker_without_env_keeps_legacy_call_shape(monkeypatch):
     assert captured["env"] is None
     assert result.env_overrides == ()
     assert result.endpoint_host is None
+
+
+def test_direct_worker_uses_dispatch_scoped_process_registry(monkeypatch):
+    captured = {}
+
+    assert _dispatch(_roster_with_env(None), monkeypatch, captured)[0].ok
+    assert captured["process_registry"] is not None
+
+
+def test_acpx_worker_uses_dispatch_scoped_process_registry(monkeypatch, tmp_path):
+    captured = {}
+    roster = Roster(
+        orchestrator="chef",
+        agents={
+            "chef": Agent(name="chef", cli="codex", role="plan"),
+            "composer": Agent(
+                name="composer",
+                cli="cursor",
+                role="worker",
+                transport="acpx",
+                transport_version="0.12.0",
+                model="composer-2.5",
+            ),
+        },
+    )
+
+    def fake_run_cursor(prompt, **kwargs):
+        captured["process_registry"] = kwargs.get("process_registry")
+        return agents.AgentResult(text="done", ok=True)
+
+    monkeypatch.setattr(acpx_adapter, "run_cursor", fake_run_cursor)
+    result = run_transport.dispatch(
+        [Assignment(worker="composer", task="do the thing")],
+        roster,
+        build_prompt=lambda agent, assignment, **kw: assignment.task,
+        run_appserver_worker=lambda *a, **kw: agents.AgentResult(text="", ok=False, detail="unused"),
+        event_writer=lambda events_dir, worker, verbose=False: None,
+        cwd=tmp_path,
+        read_only=True,
+    )[0]
+
+    assert result.ok
+    assert captured["process_registry"] is not None
 
 
 def test_worker_payload_serializes_env_provenance(monkeypatch):

--- a/tests/test_runguard.py
+++ b/tests/test_runguard.py
@@ -136,6 +136,28 @@ def test_run_lock_is_retained_when_terminal_receipt_cannot_be_written(tmp_path, 
     assert recovered["failure"]["prior_status"] == "artifact-collection"
 
 
+def test_recover_stale_dispatching_run_attributes_active_seat(tmp_path):
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / "run.json").write_text(
+        json.dumps(
+            {
+                "status": "dispatching",
+                "active_seats": ["coder"],
+                "phase_owner": "chef",
+                "worker": "fallback-worker",
+                "orchestrator": "fallback-chef",
+            }
+        )
+    )
+
+    result = runguard._recover_run_artifact({"run_dir": str(run_dir), "pid": 4321})
+
+    assert result == "recovered"
+    recovered = json.loads((run_dir / "run.json").read_text())
+    assert recovered["failure"]["seat"] == "coder"
+
+
 def test_run_lock_release_does_not_delete_replacement_owner(tmp_path):
     repo = _repo(tmp_path)
     lock_path = runguard.lock_path(repo)
@@ -306,12 +328,13 @@ def test_run_lock_preserves_live_owner_when_pid_sidecar_is_missing_or_corrupt(tm
     assert json.loads((abandoned_run / "run.json").read_text())["status"] == "dispatching"
 
 
-def test_run_lock_recovers_dead_owner_run_to_typed_terminal_state(tmp_path):
+@pytest.mark.parametrize("prior_status", ["result-processing", "artifact-collection"])
+def test_run_lock_recovers_dead_owner_run_to_typed_terminal_state(tmp_path, prior_status):
     repo = _repo(tmp_path)
     abandoned_run = tmp_path / "abandoned-run"
     abandoned_run.mkdir()
     (abandoned_run / "run.json").write_text(
-        json.dumps({"schema": "brigade.run.v1", "status": "artifact-collection", "task": "inspect"})
+        json.dumps({"schema": "brigade.run.v1", "status": prior_status, "task": "inspect"})
     )
     lock_path = runguard.lock_path(repo)
     lock_path.mkdir(parents=True)
@@ -337,7 +360,7 @@ def test_run_lock_recovers_dead_owner_run_to_typed_terminal_state(tmp_path):
             "kind": "owner-process-exited",
             "detail": "run owner process 99999999 is no longer active",
             "owner_pid": 99999999,
-            "prior_status": "artifact-collection",
+            "prior_status": prior_status,
             "recovered_at": recovered["failure"]["recovered_at"],
         }
         assert recovered["finished_at"] == recovered["failure"]["recovered_at"]

--- a/tests/test_runs_cmd.py
+++ b/tests/test_runs_cmd.py
@@ -1,5 +1,6 @@
 import json
 import os
+import time as system_time
 from pathlib import Path
 
 from brigade import cli
@@ -13,6 +14,11 @@ def _write_json(path, payload):
 
 def test_artifact_collection_status_is_nonterminal():
     assert runs_cmd._is_terminal({"status": "artifact-collection"}) is False
+    assert runs_cmd._is_terminal({"status": "result-processing"}) is False
+
+
+def test_legacy_handoff_failed_status_remains_terminal():
+    assert runs_cmd._is_terminal({"status": "handoff-failed"}) is True
 
 
 def test_watch_reports_unrecoverable_artifact_collection_lock_error(tmp_path, monkeypatch, capsys):
@@ -617,6 +623,278 @@ def test_runs_list_prints_recent_runs(tmp_path, capsys):
     assert first < second
     assert "[ok] 2.5s read-only" in out
     assert str(runs_root / "newer") in out
+
+
+def test_runs_list_flags_over_timeout_nonterminal_run_without_mutating_it(tmp_path, monkeypatch, capsys):
+    runs_root = tmp_path / ".brigade" / "runs"
+    run_dir = runs_root / "stale"
+    _write_minimal_run(
+        run_dir,
+        task="stalled task",
+        status="dispatching",
+        started_at="2026-05-26T14:00:00Z",
+    )
+    _write_json(
+        run_dir / "roster.json",
+        {
+            "orchestrator": "chef",
+            "timeout_seconds": 180.0,
+            "agents": {
+                "chef": {"timeout_seconds": None},
+                "coder": {"timeout_seconds": 30.0},
+                "reviewer": {"timeout_seconds": 90.0},
+            },
+        },
+    )
+    _write_json(
+        run_dir / "plan.json",
+        {
+            "assignments": [
+                {"stage": 1, "worker": "coder", "task": "inspect"},
+                {"stage": 2, "worker": "reviewer", "task": "review"},
+            ]
+        },
+    )
+    before = (run_dir / "run.json").read_bytes()
+    monkeypatch.setattr(runs_cmd.time, "time", lambda: 1779804091.0)
+
+    assert runs_cmd.list_runs(cwd=tmp_path, limit=10) == 0
+
+    out = capsys.readouterr().out
+    assert "[dispatching; stale > 90s timeout]" in out
+    assert (run_dir / "run.json").read_bytes() == before
+
+
+def test_runs_list_uses_current_synthesis_phase_age(tmp_path, monkeypatch, capsys):
+    runs_root = tmp_path / ".brigade" / "runs"
+    run_dir = runs_root / "synthesizing"
+    _write_minimal_run(
+        run_dir,
+        task="synthesize result",
+        status="synthesizing",
+        started_at="2026-05-26T14:00:00Z",
+    )
+    run_meta = json.loads((run_dir / "run.json").read_text())
+    run_meta["status_started_at"] = "2026-05-26T14:01:10Z"
+    _write_json(run_dir / "run.json", run_meta)
+    _write_json(
+        run_dir / "roster.json",
+        {
+            "orchestrator": "chef",
+            "timeout_seconds": 180.0,
+            "agents": {"chef": {"timeout_seconds": 30.0}},
+        },
+    )
+    monkeypatch.setattr(runs_cmd.time, "time", lambda: 1779804091.0)
+
+    assert runs_cmd.list_runs(cwd=tmp_path, limit=10) == 0
+
+    out = capsys.readouterr().out
+    assert "[synthesizing]" in out
+    assert "stale" not in out
+
+
+def test_handoff_timeout_uses_orchestrator_default_not_planned_workers(tmp_path):
+    run_dir = tmp_path / ".brigade" / "runs" / "handoff"
+    _write_minimal_run(
+        run_dir,
+        task="write handoff",
+        status="handoff",
+        started_at="2026-05-26T14:00:00Z",
+    )
+    _write_json(
+        run_dir / "roster.json",
+        {
+            "orchestrator": "chef",
+            "timeout_seconds": 180.0,
+            "agents": {
+                "chef": {"timeout_seconds": None},
+                "coder": {"timeout_seconds": 30.0},
+                "reviewer": {"timeout_seconds": 90.0},
+            },
+        },
+    )
+    _write_json(
+        run_dir / "plan.json",
+        {
+            "assignments": [
+                {"stage": 1, "worker": "coder", "task": "implement"},
+                {"stage": 2, "worker": "reviewer", "task": "review"},
+            ]
+        },
+    )
+
+    run_meta = json.loads((run_dir / "run.json").read_text())
+    assert runs_cmd._run_timeout_seconds(run_dir, run_meta) == 180.0
+
+
+def test_result_processing_timeout_uses_orchestrator_not_direct_worker(tmp_path):
+    run_dir = tmp_path / ".brigade" / "runs" / "result-processing"
+    _write_minimal_run(
+        run_dir,
+        task="process worker result",
+        status="result-processing",
+        started_at="2026-05-26T14:00:00Z",
+    )
+    run_meta = json.loads((run_dir / "run.json").read_text())
+    run_meta["worker"] = "coder"
+    _write_json(run_dir / "run.json", run_meta)
+    _write_json(
+        run_dir / "roster.json",
+        {
+            "orchestrator": "chef",
+            "timeout_seconds": 180.0,
+            "agents": {
+                "chef": {"timeout_seconds": 90.0},
+                "coder": {"timeout_seconds": 30.0},
+            },
+        },
+    )
+
+    assert runs_cmd._run_timeout_seconds(run_dir, run_meta) == 90.0
+
+
+def test_runs_list_uses_current_later_stage_age(tmp_path, monkeypatch, capsys):
+    runs_root = tmp_path / ".brigade" / "runs"
+    run_dir = runs_root / "stage-two"
+    _write_minimal_run(
+        run_dir,
+        task="review implementation",
+        status="dispatching",
+        started_at="2026-05-26T14:00:00Z",
+    )
+    run_meta = json.loads((run_dir / "run.json").read_text())
+    run_meta.update(
+        {
+            "status_started_at": "2026-05-26T14:01:10Z",
+            "active_stage": 2,
+            "active_seats": ["reviewer"],
+        }
+    )
+    _write_json(run_dir / "run.json", run_meta)
+    _write_json(
+        run_dir / "roster.json",
+        {
+            "orchestrator": "chef",
+            "timeout_seconds": 180.0,
+            "agents": {
+                "chef": {"timeout_seconds": 180.0},
+                "coder": {"timeout_seconds": 30.0},
+                "reviewer": {"timeout_seconds": 90.0},
+            },
+        },
+    )
+    _write_json(
+        run_dir / "plan.json",
+        {
+            "assignments": [
+                {"stage": 1, "worker": "coder", "task": "implement"},
+                {"stage": 2, "worker": "reviewer", "task": "review"},
+            ]
+        },
+    )
+    monkeypatch.setattr(runs_cmd.time, "time", lambda: 1779804091.0)
+
+    assert runs_cmd.list_runs(cwd=tmp_path, limit=10) == 0
+
+    out = capsys.readouterr().out
+    assert "[dispatching]" in out
+    assert "stale" not in out
+
+
+def test_runs_list_detects_stale_active_phase_with_corrupt_optional_plan(tmp_path, monkeypatch, capsys):
+    runs_root = tmp_path / ".brigade" / "runs"
+    run_dir = runs_root / "active-corrupt-plan"
+    _write_minimal_run(
+        run_dir,
+        task="review implementation",
+        status="dispatching",
+        started_at="2026-05-26T14:00:00Z",
+    )
+    run_meta = json.loads((run_dir / "run.json").read_text())
+    run_meta["active_seats"] = ["reviewer"]
+    _write_json(run_dir / "run.json", run_meta)
+    _write_json(
+        run_dir / "roster.json",
+        {
+            "orchestrator": "chef",
+            "timeout_seconds": 180.0,
+            "agents": {
+                "chef": {"timeout_seconds": 180.0},
+                "reviewer": {"timeout_seconds": 90.0},
+            },
+        },
+    )
+    (run_dir / "plan.json").write_text("not json")
+    monkeypatch.setattr(runs_cmd.time, "time", lambda: 1779804091.0)
+
+    assert runs_cmd.list_runs(cwd=tmp_path, limit=10) == 0
+
+    assert "[dispatching; stale > 90s timeout]" in capsys.readouterr().out
+
+
+def test_runs_list_uses_direct_worker_timeout_while_status_is_started(tmp_path, monkeypatch, capsys):
+    runs_root = tmp_path / ".brigade" / "runs"
+    run_dir = runs_root / "direct-worker"
+    _write_minimal_run(
+        run_dir,
+        task="direct task",
+        status="started",
+        started_at="2026-05-26T14:01:00Z",
+    )
+    run_meta = json.loads((run_dir / "run.json").read_text())
+    run_meta["worker"] = "coder"
+    _write_json(run_dir / "run.json", run_meta)
+    _write_json(
+        run_dir / "roster.json",
+        {
+            "orchestrator": "chef",
+            "timeout_seconds": 180.0,
+            "agents": {
+                "chef": {"timeout_seconds": 180.0},
+                "coder": {"timeout_seconds": 30.0},
+            },
+        },
+    )
+    monkeypatch.setattr(runs_cmd.time, "time", lambda: 1779804091.0)
+
+    assert runs_cmd.list_runs(cwd=tmp_path, limit=10) == 0
+
+    assert "[started; stale > 30s timeout]" in capsys.readouterr().out
+
+
+def test_runs_list_treats_naive_legacy_timestamp_as_utc(tmp_path, monkeypatch, capsys):
+    runs_root = tmp_path / ".brigade" / "runs"
+    run_dir = runs_root / "legacy-naive"
+    _write_minimal_run(
+        run_dir,
+        task="legacy task",
+        status="started",
+        started_at="2026-05-26T14:00:00",
+    )
+    _write_json(
+        run_dir / "roster.json",
+        {
+            "orchestrator": "chef",
+            "timeout_seconds": 30.0,
+            "agents": {"chef": {"timeout_seconds": None}},
+        },
+    )
+    previous_tz = os.environ.get("TZ")
+    try:
+        os.environ["TZ"] = "America/New_York"
+        system_time.tzset()
+        monkeypatch.setattr(runs_cmd.time, "time", lambda: 1779804031.0)
+
+        assert runs_cmd.list_runs(cwd=tmp_path, limit=10) == 0
+    finally:
+        if previous_tz is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = previous_tz
+        system_time.tzset()
+
+    assert "[started; stale > 30s timeout]" in capsys.readouterr().out
 
 
 def test_runs_list_respects_limit(tmp_path, capsys):


### PR DESCRIPTION
Closes #376.

## What changed

- Terminalize failures from setup through artifact collection with phase, kind, seat, reason, and finish time.
- Track the active phase, stage, seat, and phase-relative start time, then flag non-terminal runs older than the applicable timeout in `brigade runs list`.
- Own worker process groups across direct, detached, ACPX, app-server, cloud, and Ollama transports, with bounded termination and output draining on POSIX and Windows.
- Distinguish timeouts from operator cancellation, record the terminal receipt before cleanup waits, and preserve the first terminal failure when later cleanup also fails.
- Keep run locks when terminal receipt writes fail, make repeated terminalization idempotent, and recover abandoned locked runs with phase-aware seat attribution.

## Root cause

Run lifecycle state and subprocess ownership were split across setup, dispatch, transports, and cleanup. Exceptions could escape local handlers, exited process-group leaders could leave pipe-holding descendants alive, and interruption races could occur during detached ownership transfer. Stale detection also lacked phase-relative timing and active-seat metadata.

## Verification

- `brigade work verify run --target . --command "./scripts/verify" --capture brigade-work`
- Brigade receipt: `20260720-014713-work-verify-0ca6c8`
- Result: 3,288 passed, 3 skipped, 82.27% coverage
- Independent review: no findings after the integration rebase

## Risk

Terminal receipt updates are idempotent, and legacy run artifacts without phase timestamps fall back to `started_at`. Process cleanup is bounded and covered for parent-exits-first descendants. The stale detector only annotates list output and does not mutate old runs.
