### PR TITLE
fix(run): reject empty tasks

### DIFF
--- a/src/brigade/cli/run.py
+++ b/src/brigade/cli/run.py
@@ -80,6 +80,12 @@ def _terminalize_escaped_run(
         raise
 
 
+def _non_empty_task(value: str) -> str:
+    if not value.strip():
+        raise argparse.ArgumentTypeError("must not be empty or whitespace")
+    return value
+
+
 def _non_negative_seconds(value: str) -> float:
     try:
         parsed = float(value)
@@ -93,7 +99,11 @@ def _non_negative_seconds(value: str) -> float:
 def register(sub: argparse._SubParsersAction) -> None:
     # run
     p_run = sub.add_parser("run", help="Run a bounded cross-model orchestration task.")
-    p_run.add_argument("task", help="Task for the aboyeur to plan, dispatch, and synthesize.")
+    p_run.add_argument(
+        "task",
+        type=_non_empty_task,
+        help="Task for the aboyeur to plan, dispatch, and synthesize.",
+    )
     p_run.add_argument(
         "--roster",
         type=Path,

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -14,6 +14,7 @@ from brigade import agents
 from brigade import cli
 from brigade import localio
 from brigade import proc
+from brigade import roster
 from brigade import runguard
 from brigade import runs_cmd
 
@@ -33,6 +34,46 @@ def test_run_cli_rejects_missing_cwd(tmp_path, capsys):
     rc = cli.main(["run", "do something", "--cwd", str(tmp_path / "missing")])
     assert rc == 2
     assert "--cwd is not a directory" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("task", ["", " \t\n"])
+def test_run_cli_rejects_blank_task_before_run_setup(tmp_path, capsys, monkeypatch, task):
+    config_dir = tmp_path / ".brigade"
+    config_dir.mkdir()
+    (config_dir / "roster.toml").write_text('orchestrator = "chef"\n\n[agents.chef]\ncli = "codex"\nrole = "plan"\n')
+    runs_dir = config_dir / "runs"
+    calls = []
+    resolve_roster = roster.resolve_roster
+
+    def tracked_resolve_roster(*args, **kwargs):
+        calls.append("resolve_roster")
+        return resolve_roster(*args, **kwargs)
+
+    def tracked_make_run_dir(*args, **kwargs):
+        calls.append("make_run_dir")
+        return runs_dir / "unexpected"
+
+    @contextmanager
+    def tracked_run_lock(*args, **kwargs):
+        calls.append("run_lock")
+        yield
+
+    def tracked_run(*args, **kwargs):
+        calls.append("run")
+        return 0
+
+    monkeypatch.setattr(roster, "resolve_roster", tracked_resolve_roster)
+    monkeypatch.setattr(aboyeur, "make_run_dir", tracked_make_run_dir)
+    monkeypatch.setattr(runguard, "run_lock", tracked_run_lock)
+    monkeypatch.setattr(aboyeur, "run", tracked_run)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["run", task, "--cwd", str(tmp_path)])
+
+    assert exc.value.code == 2
+    assert "argument task: must not be empty or whitespace" in capsys.readouterr().err
+    assert calls == []
+    assert not runs_dir.exists()
 
 
 def test_run_cli_loads_roster_and_dispatches(tmp_path, monkeypatch):


### PR DESCRIPTION
Closes #378.

## What changed

- Reject empty and whitespace-only `brigade run` task arguments during argparse validation.
- Return the original string unchanged for valid tasks, including detached forwarding.
- Add regression coverage that proves blank input reaches none of roster resolution, run-directory allocation, locking, or `aboyeur.run()`.

## Root cause

Argparse required the positional task to be present but accepted an explicitly supplied blank string. `dispatch()` then performed setup and created artifacts before any task-content check.

## Verification

- `brigade work verify run --target . --command "./scripts/verify" --capture brigade-work`
- Brigade receipt: `20260720-014725-work-verify-b083f5`
- Result: 3,171 passed, 3 skipped, 82.19% coverage
- Independent review: no findings; conflict-free rebase followed by a full gate

## Risk

The CLI now exits with argparse status 2 for input that never represented a runnable task. Valid task parsing and detached command forwarding are unchanged.
