### PR TITLE
ci: add polyglot engine and release checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,141 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code_graph: ${{ steps.filter.outputs.code_graph }}
+      evidence_ledger: ${{ steps.filter.outputs.evidence_ledger }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code_graph:
+              - 'engines/code-graph/**'
+              - 'src/brigade/templates/components/manifest-v1.json'
+              - '.github/workflows/ci.yml'
+            evidence_ledger:
+              - 'engines/evidence-ledger/**'
+              - 'src/brigade/templates/components/manifest-v1.json'
+              - '.github/workflows/ci.yml'
+
+  code-graph-msrv:
+    name: MSRV (Rust 1.85)
+    needs: changes
+    if: ${{ needs.changes.outputs.code_graph == 'true' }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: engines/code-graph
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@1.85.0
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: engines/code-graph
+      - name: Check locked all-features build
+        run: cargo check --locked --all-features
+
+  code-graph-build-and-test:
+    name: build-and-test
+    needs: changes
+    if: ${{ needs.changes.outputs.code_graph == 'true' }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: engines/code-graph
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: engines/code-graph
+      - name: Format
+        run: cargo fmt --check
+      - name: Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+      - name: Test
+        run: cargo test --all-features
+      - name: Build (default, no-network)
+        run: cargo build --release
+
+  code-graph-feature-configurations:
+    name: Feature configuration (${{ matrix.name }})
+    needs: changes
+    if: ${{ needs.changes.outputs.code_graph == 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: no-default
+            cargo_args: --no-default-features
+          - name: default
+            cargo_args: ""
+          - name: watch-only
+            cargo_args: --no-default-features --features watch
+          - name: codesearch-only
+            cargo_args: --no-default-features --features codesearch
+          - name: miseledger-only
+            cargo_args: --no-default-features --features miseledger
+          - name: all-features
+            cargo_args: --all-features
+    defaults:
+      run:
+        working-directory: engines/code-graph
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: engines/code-graph
+      - name: Check locked feature configuration
+        run: cargo check --locked ${{ matrix.cargo_args }}
+
+  code-graph-windows:
+    name: Windows (stable, default features)
+    needs: changes
+    if: ${{ needs.changes.outputs.code_graph == 'true' }}
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: engines/code-graph
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: engines/code-graph
+      - name: Test locked default features
+        run: cargo test --locked
+
+  evidence-ledger-test:
+    needs: changes
+    if: ${{ needs.changes.outputs.evidence_ledger == 'true' }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: engines/evidence-ledger
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - run: go test ./...
+      - run: go vet ./...
+      - run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
+      - run: govulncheck ./...
+      - run: go build -o bin/miseledger ./cmd/miseledger
+      - run: go build -o bin/sessionfind ./cmd/sessionfind
+      - run: scripts/check_release_workflow.sh
+      - run: scripts/smoke_archive.sh
+      - run: scripts/smoke_mcp.sh
+      - run: scripts/smoke_http.sh
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ permissions:
 jobs:
   changes:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       code_graph: ${{ steps.filter.outputs.code_graph }}
       evidence_ledger: ${{ steps.filter.outputs.evidence_ledger }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,17 +59,33 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
 
-  windows-native-acceptance:
-    name: windows-native-acceptance
+  published-artifact-acceptance:
+    name: published-artifact-acceptance (${{ matrix.os }})
     needs: build-and-publish
     if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            kind: unix
+          - os: macos-13
+            kind: unix
+          - os: windows-latest
+            kind: windows
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+      - name: Run published artifact acceptance (Unix)
+        if: matrix.kind == 'unix'
+        env:
+          BRIGADE_VERSION: ${{ github.ref_name }}
+        run: python scripts/published-artifact-acceptance.py --brigade-version "${BRIGADE_VERSION#v}"
       - name: Run Windows native acceptance (published CLI)
+        if: matrix.kind == 'windows'
         shell: powershell
         env:
           BRIGADE_VERSION: ${{ github.ref_name }}

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ Thumbs.db
 /memory/
 /scripts/*
 !/scripts/windows-native-acceptance.ps1
+!/scripts/published-artifact-acceptance.py
 /skills/
 
 # Local plan/spec scratch dirs only. Reviewed planning artifacts ARE

--- a/scripts/published-artifact-acceptance.py
+++ b/scripts/published-artifact-acceptance.py
@@ -11,16 +11,68 @@ import stat
 import subprocess
 import sys
 import tempfile
+import time
+import urllib.request
 from pathlib import Path
 from typing import Any, Callable, Mapping, Sequence
 
 
 COMPONENT_IDS = ("graphtrail", "graphtrail-mcp", "miseledger", "sessionfind")
+PYPI_PROJECT_URL = "https://pypi.org/pypi/brigade-cli/json"
+PYPI_AVAILABILITY_TIMEOUT_SECONDS = 6 * 60
+PYPI_POLL_INTERVAL_SECONDS = 5
 Runner = Callable[..., subprocess.CompletedProcess[str]]
+JsonFetcher = Callable[[str], Any]
 
 
 class AcceptanceError(RuntimeError):
     """A published-artifact acceptance requirement was not met."""
+
+
+def managed_bin_path(data_home: Path, profile: Path, *, platform: str | None = None) -> Path:
+    if (platform or sys.platform) == "darwin":
+        return profile / "Library" / "Application Support" / "brigade" / "bin"
+    return data_home / "brigade" / "bin"
+
+
+def fetch_pypi_json(url: str) -> Any:
+    with urllib.request.urlopen(url, timeout=15) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def wait_for_pypi_version(
+    version: str,
+    *,
+    fetch_json: JsonFetcher = fetch_pypi_json,
+    sleep: Callable[[float], None] = time.sleep,
+    monotonic: Callable[[], float] = time.monotonic,
+    timeout_seconds: float = PYPI_AVAILABILITY_TIMEOUT_SECONDS,
+    poll_interval_seconds: float = PYPI_POLL_INTERVAL_SECONDS,
+) -> None:
+    deadline = monotonic() + timeout_seconds
+    detail = "PyPI response did not list the version"
+    while True:
+        try:
+            payload = fetch_json(PYPI_PROJECT_URL)
+        except (OSError, ValueError) as exc:
+            detail = f"PyPI was unavailable: {exc}"
+        else:
+            releases = payload.get("releases") if isinstance(payload, dict) else None
+            if isinstance(releases, dict) and version in releases:
+                return
+            if releases is None:
+                detail = "PyPI response did not contain a releases object"
+            elif not isinstance(releases, dict):
+                detail = "PyPI response contained an invalid releases object"
+            else:
+                detail = "PyPI response did not list the version"
+
+        remaining = deadline - monotonic()
+        if remaining <= 0:
+            raise AcceptanceError(
+                f"PyPI version {version} was not available within {timeout_seconds:g} seconds: {detail}"
+            )
+        sleep(min(poll_interval_seconds, remaining))
 
 
 def run_checked(
@@ -155,6 +207,7 @@ def run_acceptance(version: str, *, runner: Runner = subprocess.run) -> None:
         managed_brigade = pipx_bin / "brigade"
         try:
             run_checked([sys.executable, "-m", "pip", "install", "--upgrade", "pip", "pipx"], runner=runner, env=env)
+            wait_for_pypi_version(version)
             run_checked([sys.executable, "-m", "pipx", "install", f"brigade-cli=={version}"], runner=runner, env=env)
             if not managed_brigade.is_file():
                 raise AcceptanceError(f"pipx did not install brigade at {managed_brigade}")
@@ -169,7 +222,7 @@ def run_acceptance(version: str, *, runner: Runner = subprocess.run) -> None:
                 report = json.loads(report_output.stdout)
             except json.JSONDecodeError as exc:
                 raise AcceptanceError("brigade version --components --json returned malformed JSON") from exc
-            managed_paths = validate_component_report(report, data_home / "brigade" / "bin")
+            managed_paths = validate_component_report(report, managed_bin_path(data_home, profile))
             smoke_managed_components(managed_paths, runner=runner, env=env)
         finally:
             assert_no_poison_invocation(marker)

--- a/scripts/published-artifact-acceptance.py
+++ b/scripts/published-artifact-acceptance.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Accept a published Brigade artifact on Unix GitHub-hosted runners."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import stat
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+
+COMPONENT_IDS = ("graphtrail", "graphtrail-mcp", "miseledger", "sessionfind")
+Runner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+class AcceptanceError(RuntimeError):
+    """A published-artifact acceptance requirement was not met."""
+
+
+def run_checked(
+    argv: Sequence[str | Path],
+    *,
+    runner: Runner = subprocess.run,
+    env: Mapping[str, str] | None = None,
+    input_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    command = [str(value) for value in argv]
+    try:
+        completed = runner(command, text=True, input=input_text, capture_output=True, env=env, check=False)
+    except OSError as exc:
+        raise AcceptanceError(f"could not run {' '.join(command)}: {exc}") from exc
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout or "no command output").strip()
+        raise AcceptanceError(f"{' '.join(command)} failed with exit {completed.returncode}: {detail}")
+    return completed
+
+
+def validate_component_report(report: Any, managed_bin: Path) -> dict[str, Path]:
+    if not isinstance(report, dict) or not isinstance(report.get("components"), list):
+        raise AcceptanceError("component report did not contain a components list")
+    components = report["components"]
+    if len(components) != len(COMPONENT_IDS):
+        raise AcceptanceError(f"expected exactly 4 components, got {len(components)}")
+
+    root = managed_bin.resolve()
+    managed_paths: dict[str, Path] = {}
+    for component in components:
+        if not isinstance(component, dict):
+            raise AcceptanceError("component report entry was not an object")
+        component_id = component.get("component_id")
+        if component_id not in COMPONENT_IDS:
+            raise AcceptanceError(f"unexpected component {component_id!r}")
+        if component_id in managed_paths:
+            raise AcceptanceError(f"component report repeated {component_id}")
+        if component.get("status") != "healthy":
+            raise AcceptanceError(
+                f"component {component_id} is {component.get('status')}: {component.get('detail', '')}"
+            )
+        executable = component.get("recorded_executable") or component.get("managed_executable_path")
+        if not isinstance(executable, str) or not executable:
+            raise AcceptanceError(f"component {component_id} has no managed executable path")
+        raw_path = Path(executable)
+        if not raw_path.is_absolute():
+            raise AcceptanceError(f"component {component_id} executable must be absolute: {executable!r}")
+        resolved = raw_path.resolve()
+        try:
+            resolved.relative_to(root)
+        except ValueError as exc:
+            raise AcceptanceError(f"component {component_id} executable is outside managed root: {resolved}") from exc
+        if not resolved.is_file():
+            raise AcceptanceError(f"component {component_id} managed executable missing: {resolved}")
+        managed_paths[component_id] = resolved
+
+    if set(managed_paths) != set(COMPONENT_IDS):
+        missing = ", ".join(sorted(set(COMPONENT_IDS) - set(managed_paths)))
+        raise AcceptanceError(f"component report missing required components: {missing}")
+    return managed_paths
+
+
+def smoke_managed_components(
+    managed_paths: Mapping[str, Path], *, runner: Runner = subprocess.run, env: Mapping[str, str] | None = None
+) -> None:
+    graphtrail = run_checked([managed_paths["graphtrail"], "--version"], runner=runner, env=env)
+    if not graphtrail.stdout.strip():
+        raise AcceptanceError("graphtrail smoke produced no version output")
+
+    mcp = run_checked(
+        [managed_paths["graphtrail-mcp"]],
+        runner=runner,
+        env=env,
+        input_text='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}\n',
+    )
+    try:
+        response = json.loads(mcp.stdout)
+    except json.JSONDecodeError as exc:
+        raise AcceptanceError("graphtrail-mcp smoke returned malformed JSON-RPC") from exc
+    if response.get("jsonrpc") != "2.0" or response.get("id") != 1 or "result" not in response:
+        raise AcceptanceError("graphtrail-mcp smoke returned an invalid JSON-RPC response")
+
+    run_checked([managed_paths["miseledger"], "version"], runner=runner, env=env)
+    sessionfind = run_checked([managed_paths["sessionfind"], "--help"], runner=runner, env=env)
+    if "usage" not in f"{sessionfind.stdout}{sessionfind.stderr}".lower():
+        raise AcceptanceError("sessionfind smoke produced no help text")
+
+
+def assert_no_poison_invocation(marker: Path) -> None:
+    if marker.exists() and marker.read_text().strip():
+        raise AcceptanceError(f"poison component binary was invoked: {marker.read_text().strip()}")
+
+
+def _write_poison_binaries(poison_dir: Path, marker: Path) -> None:
+    poison_dir.mkdir(parents=True)
+    marker_literal = shlex.quote(str(marker))
+    for component_id in COMPONENT_IDS:
+        poison = poison_dir / component_id
+        poison.write_text(f"#!/bin/sh\nprintf '%s\\n' {shlex.quote(component_id)} >> {marker_literal}\nexit 97\n")
+        poison.chmod(poison.stat().st_mode | stat.S_IXUSR)
+
+
+def run_acceptance(version: str, *, runner: Runner = subprocess.run) -> None:
+    if not version or version.startswith("v"):
+        raise AcceptanceError("--brigade-version must be an exact PyPI version without a v prefix")
+
+    runner_temp = os.environ.get("RUNNER_TEMP")
+    with tempfile.TemporaryDirectory(prefix="brigade-published-acceptance-", dir=runner_temp) as temporary:
+        root = Path(temporary)
+        profile = root / "profile"
+        data_home = root / "xdg-data"
+        pipx_home = root / "pipx-home"
+        pipx_bin = root / "pipx-bin"
+        poison_dir = root / "poison-bin"
+        marker = root / "poison-invoked"
+        for directory in (profile, data_home, pipx_home, pipx_bin, root / "xdg-config", root / "xdg-cache"):
+            directory.mkdir(parents=True)
+        _write_poison_binaries(poison_dir, marker)
+
+        env = os.environ.copy()
+        env.update(
+            {
+                "HOME": str(profile),
+                "XDG_CONFIG_HOME": str(root / "xdg-config"),
+                "XDG_DATA_HOME": str(data_home),
+                "XDG_CACHE_HOME": str(root / "xdg-cache"),
+                "PIPX_HOME": str(pipx_home),
+                "PIPX_BIN_DIR": str(pipx_bin),
+                "PATH": os.pathsep.join((str(poison_dir), env.get("PATH", ""))),
+            }
+        )
+        managed_brigade = pipx_bin / "brigade"
+        try:
+            run_checked([sys.executable, "-m", "pip", "install", "--upgrade", "pip", "pipx"], runner=runner, env=env)
+            run_checked([sys.executable, "-m", "pipx", "install", f"brigade-cli=={version}"], runner=runner, env=env)
+            if not managed_brigade.is_file():
+                raise AcceptanceError(f"pipx did not install brigade at {managed_brigade}")
+
+            version_output = run_checked([managed_brigade, "--version"], runner=runner, env=env).stdout.strip()
+            if version_output != f"brigade {version}":
+                raise AcceptanceError(f"installed brigade version mismatch: expected {version}, got {version_output}")
+            run_checked([managed_brigade, "setup"], runner=runner, env=env)
+            run_checked([managed_brigade, "setup", "--offline"], runner=runner, env=env)
+            report_output = run_checked([managed_brigade, "version", "--components", "--json"], runner=runner, env=env)
+            try:
+                report = json.loads(report_output.stdout)
+            except json.JSONDecodeError as exc:
+                raise AcceptanceError("brigade version --components --json returned malformed JSON") from exc
+            managed_paths = validate_component_report(report, data_home / "brigade" / "bin")
+            smoke_managed_components(managed_paths, runner=runner, env=env)
+        finally:
+            assert_no_poison_invocation(marker)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--brigade-version", required=True)
+    args = parser.parse_args(argv)
+    try:
+        run_acceptance(args.brigade_version)
+    except AcceptanceError as exc:
+        print(f"published artifact acceptance failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -34,6 +34,15 @@ def test_ci_workflow_path_filter_has_valid_structure_and_engine_paths():
         assert path in changes
 
 
+def test_ci_workflow_path_filter_can_read_pull_request_files():
+    text = (ROOT / ".github/workflows/ci.yml").read_text()
+    changes = _workflow_job_section(text, "changes")
+
+    assert "permissions:" in changes
+    assert "contents: read" in changes
+    assert "pull-requests: read" in changes
+
+
 def test_ci_workflow_gates_native_engine_jobs_with_valid_expressions():
     text = (ROOT / ".github/workflows/ci.yml").read_text()
     expected_jobs = {

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -6,6 +6,97 @@ import subprocess
 ROOT = Path(__file__).resolve().parents[1]
 
 
+def _workflow_job_section(text: str, job_name: str) -> str:
+    start = text.index(f"  {job_name}:")
+    next_job = re.search(r"^  [a-z0-9][a-z0-9-]*:$", text[start + 1 :], re.MULTILINE)
+    end = start + 1 + next_job.start() if next_job else len(text)
+    return text[start:end]
+
+
+def test_ci_workflow_path_filter_has_valid_structure_and_engine_paths():
+    text = (ROOT / ".github/workflows/ci.yml").read_text()
+    changes = _workflow_job_section(text, "changes")
+
+    assert "jobs:\n  changes:" in text
+    assert "runs-on: ubuntu-latest" in changes
+    assert "uses: dorny/paths-filter@v3" in changes
+    assert "code_graph: ${{ steps.filter.outputs.code_graph }}" in changes
+    assert "evidence_ledger: ${{ steps.filter.outputs.evidence_ledger }}" in changes
+    assert "code-graph:" not in changes
+    assert "evidence-ledger:" not in changes
+
+    for path in (
+        "engines/code-graph/**",
+        "engines/evidence-ledger/**",
+        "src/brigade/templates/components/manifest-v1.json",
+        ".github/workflows/ci.yml",
+    ):
+        assert path in changes
+
+
+def test_ci_workflow_gates_native_engine_jobs_with_valid_expressions():
+    text = (ROOT / ".github/workflows/ci.yml").read_text()
+    expected_jobs = {
+        "code-graph-msrv": "code_graph",
+        "code-graph-build-and-test": "code_graph",
+        "code-graph-feature-configurations": "code_graph",
+        "code-graph-windows": "code_graph",
+        "evidence-ledger-test": "evidence_ledger",
+    }
+
+    job_names = re.findall(r"^  ([a-z0-9][a-z0-9-]*):$", text, re.MULTILINE)
+    assert {name for name in job_names if name.startswith(("code-graph-", "evidence-ledger-"))} == set(expected_jobs)
+
+    for job_name, output_name in expected_jobs.items():
+        section = _workflow_job_section(text, job_name)
+        assert "needs: changes" in section
+        assert f"if: ${{{{ needs.changes.outputs.{output_name} == 'true' }}}}" in section
+        assert "self-hosted" not in section
+
+
+def test_ci_workflow_runs_embedded_engine_commands_from_engine_directories():
+    text = (ROOT / ".github/workflows/ci.yml").read_text()
+
+    for job_name in (
+        "code-graph-msrv",
+        "code-graph-build-and-test",
+        "code-graph-feature-configurations",
+        "code-graph-windows",
+    ):
+        section = _workflow_job_section(text, job_name)
+        assert "working-directory: engines/code-graph" in section
+        assert "uses: Swatinem/rust-cache@v2" in section
+        assert "workspaces: engines/code-graph" in section
+
+    code_graph = _workflow_job_section(text, "code-graph-build-and-test")
+    for command in (
+        "cargo fmt --check",
+        "cargo clippy --all-targets --all-features -- -D warnings",
+        "cargo test --all-features",
+        "cargo build --release",
+    ):
+        assert command in code_graph
+
+    feature_configurations = _workflow_job_section(text, "code-graph-feature-configurations")
+    assert "cargo check --locked ${{ matrix.cargo_args }}" in feature_configurations
+
+    evidence_ledger = _workflow_job_section(text, "evidence-ledger-test")
+    assert "working-directory: engines/evidence-ledger" in evidence_ledger
+    for command in (
+        "go test ./...",
+        "go vet ./...",
+        "go install golang.org/x/vuln/cmd/govulncheck@v1.3.0",
+        "govulncheck ./...",
+        "go build -o bin/miseledger ./cmd/miseledger",
+        "go build -o bin/sessionfind ./cmd/sessionfind",
+        "scripts/check_release_workflow.sh",
+        "scripts/smoke_archive.sh",
+        "scripts/smoke_mcp.sh",
+        "scripts/smoke_http.sh",
+    ):
+        assert command in evidence_ledger
+
+
 def test_ci_workflow_does_not_skip_docs_only_content_guard():
     text = (ROOT / ".github/workflows/ci.yml").read_text()
 

--- a/tests/test_publish_workflow.py
+++ b/tests/test_publish_workflow.py
@@ -30,20 +30,25 @@ def test_ci_checks_managed_snapshot():
     assert "python scripts/managed_snapshot.py --check" in text
 
 
-def test_publish_windows_native_acceptance_waits_for_pypi_and_uses_script():
+def test_published_artifact_acceptance_matrix_waits_for_pypi_and_uses_platform_wrappers():
     text = (ROOT / ".github" / "workflows" / "publish.yml").read_text()
 
-    job = text.index("  windows-native-acceptance:")
+    job = text.index("  published-artifact-acceptance:")
     build = text.index("  build-and-publish:")
     assert build < job
     section = text[job:]
     assert "needs: build-and-publish" in section
-    assert "runs-on: windows-latest" in section
+    assert "runs-on: ${{ matrix.os }}" in section
+    assert "ubuntu-latest" in section
+    assert "macos-13" in section
+    assert "windows-latest" in section
     assert "shell: powershell" in section
     assert "if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')" in section
     assert "windows-native-acceptance.ps1" in section
     assert "-InstallMode pypi" in section
     assert "-BrigadeVersion" in section
+    assert "scripts/published-artifact-acceptance.py" in section
+    assert "self-hosted" not in section
     script = (ROOT / "scripts/windows-native-acceptance.ps1").read_text()
     assert "pypi.org/pypi/brigade-cli/json" in script
     assert "Get-BrigadeCliVersion" in script

--- a/tests/test_published_artifact_acceptance.py
+++ b/tests/test_published_artifact_acceptance.py
@@ -1,0 +1,128 @@
+import importlib.util
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "published-artifact-acceptance.py"
+
+
+@pytest.fixture()
+def acceptance_module():
+    spec = importlib.util.spec_from_file_location("published_artifact_acceptance", SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _component(component_id, executable, *, status="healthy", detail="ok"):
+    return {
+        "component_id": component_id,
+        "status": status,
+        "detail": detail,
+        "recorded_executable": str(executable),
+        "managed_executable_path": str(executable),
+    }
+
+
+def _healthy_report(managed_bin):
+    return {
+        "components": [
+            _component(component_id, managed_bin / component_id)
+            for component_id in ("graphtrail", "graphtrail-mcp", "miseledger", "sessionfind")
+        ]
+    }
+
+
+def _write_managed_binaries(managed_bin):
+    managed_bin.mkdir(parents=True)
+    for component_id in ("graphtrail", "graphtrail-mcp", "miseledger", "sessionfind"):
+        executable = managed_bin / component_id
+        executable.write_text("#!/bin/sh\nexit 0\n")
+        executable.chmod(0o755)
+
+
+def test_component_report_rejects_relative_executable_before_resolving(acceptance_module, tmp_path):
+    report = _healthy_report(tmp_path / "xdg-data" / "brigade" / "bin")
+    report["components"][0]["recorded_executable"] = "graphtrail"
+
+    with pytest.raises(acceptance_module.AcceptanceError, match="absolute"):
+        acceptance_module.validate_component_report(report, tmp_path / "xdg-data" / "brigade" / "bin")
+
+
+def test_component_report_rejects_outside_managed_root(acceptance_module, tmp_path):
+    managed_bin = tmp_path / "xdg-data" / "brigade" / "bin"
+    _write_managed_binaries(managed_bin)
+    outside = tmp_path / "outside"
+    outside.write_text("not managed")
+    report = _healthy_report(managed_bin)
+    report["components"][0]["recorded_executable"] = str(outside)
+
+    with pytest.raises(acceptance_module.AcceptanceError, match="outside"):
+        acceptance_module.validate_component_report(report, managed_bin)
+
+
+def test_component_report_rejects_missing_or_unhealthy_component(acceptance_module, tmp_path):
+    managed_bin = tmp_path / "xdg-data" / "brigade" / "bin"
+    report = _healthy_report(managed_bin)
+
+    with pytest.raises(acceptance_module.AcceptanceError, match="missing"):
+        acceptance_module.validate_component_report(report, managed_bin)
+
+    _write_managed_binaries(managed_bin)
+    report["components"][0]["status"] = "corrupt"
+    report["components"][0]["detail"] = "digest mismatch"
+    with pytest.raises(acceptance_module.AcceptanceError, match="digest mismatch"):
+        acceptance_module.validate_component_report(report, managed_bin)
+
+
+def test_component_report_requires_exactly_four_components(acceptance_module, tmp_path):
+    managed_bin = tmp_path / "xdg-data" / "brigade" / "bin"
+    _write_managed_binaries(managed_bin)
+    report = _healthy_report(managed_bin)
+    report["components"].pop()
+
+    with pytest.raises(acceptance_module.AcceptanceError, match="exactly 4"):
+        acceptance_module.validate_component_report(report, managed_bin)
+
+
+def test_command_failure_preserves_installer_or_asset_error(acceptance_module):
+    def failing_runner(*args, **kwargs):
+        return subprocess.CompletedProcess(args[0], 1, "", "missing asset: digest mismatch")
+
+    with pytest.raises(acceptance_module.AcceptanceError, match="missing asset: digest mismatch"):
+        acceptance_module.run_checked(["pipx", "install", "brigade-cli==1.2.3"], runner=failing_runner)
+
+
+def test_smoke_uses_only_absolute_managed_executables(acceptance_module, tmp_path):
+    managed_bin = tmp_path / "xdg-data" / "brigade" / "bin"
+    _write_managed_binaries(managed_bin)
+    calls = []
+
+    def runner(argv, **kwargs):
+        calls.append(argv)
+        assert Path(argv[0]).is_absolute()
+        if Path(argv[0]).name == "graphtrail-mcp":
+            return subprocess.CompletedProcess(argv, 0, '{"jsonrpc":"2.0","id":1,"result":{}}', "")
+        if Path(argv[0]).name == "sessionfind":
+            return subprocess.CompletedProcess(argv, 0, "usage: sessionfind", "")
+        return subprocess.CompletedProcess(argv, 0, "ok", "")
+
+    acceptance_module.smoke_managed_components(
+        {component_id: managed_bin / component_id for component_id in acceptance_module.COMPONENT_IDS},
+        runner=runner,
+    )
+
+    assert {Path(argv[0]).name for argv in calls} == set(acceptance_module.COMPONENT_IDS)
+
+
+def test_poison_binary_invocation_is_a_failure(acceptance_module, tmp_path):
+    marker = tmp_path / "poison-invoked"
+    marker.write_text("graphtrail\n")
+
+    with pytest.raises(acceptance_module.AcceptanceError, match="poison"):
+        acceptance_module.assert_no_poison_invocation(marker)

--- a/tests/test_published_artifact_acceptance.py
+++ b/tests/test_published_artifact_acceptance.py
@@ -54,6 +54,18 @@ def test_component_report_rejects_relative_executable_before_resolving(acceptanc
         acceptance_module.validate_component_report(report, tmp_path / "xdg-data" / "brigade" / "bin")
 
 
+def test_managed_bin_path_uses_xdg_data_home_on_linux(acceptance_module, tmp_path):
+    assert acceptance_module.managed_bin_path(tmp_path / "xdg-data", tmp_path / "profile", platform="linux") == (
+        tmp_path / "xdg-data" / "brigade" / "bin"
+    )
+
+
+def test_managed_bin_path_uses_application_support_on_macos(acceptance_module, tmp_path):
+    assert acceptance_module.managed_bin_path(tmp_path / "xdg-data", tmp_path / "profile", platform="darwin") == (
+        tmp_path / "profile" / "Library" / "Application Support" / "brigade" / "bin"
+    )
+
+
 def test_component_report_rejects_outside_managed_root(acceptance_module, tmp_path):
     managed_bin = tmp_path / "xdg-data" / "brigade" / "bin"
     _write_managed_binaries(managed_bin)
@@ -61,6 +73,20 @@ def test_component_report_rejects_outside_managed_root(acceptance_module, tmp_pa
     outside.write_text("not managed")
     report = _healthy_report(managed_bin)
     report["components"][0]["recorded_executable"] = str(outside)
+
+    with pytest.raises(acceptance_module.AcceptanceError, match="outside"):
+        acceptance_module.validate_component_report(report, managed_bin)
+
+
+def test_component_report_rejects_symlink_outside_managed_root(acceptance_module, tmp_path):
+    managed_bin = tmp_path / "xdg-data" / "brigade" / "bin"
+    _write_managed_binaries(managed_bin)
+    outside = tmp_path / "outside"
+    outside.write_text("not managed")
+    linked = managed_bin / "graphtrail"
+    linked.unlink()
+    linked.symlink_to(outside)
+    report = _healthy_report(managed_bin)
 
     with pytest.raises(acceptance_module.AcceptanceError, match="outside"):
         acceptance_module.validate_component_report(report, managed_bin)
@@ -96,6 +122,64 @@ def test_command_failure_preserves_installer_or_asset_error(acceptance_module):
 
     with pytest.raises(acceptance_module.AcceptanceError, match="missing asset: digest mismatch"):
         acceptance_module.run_checked(["pipx", "install", "brigade-cli==1.2.3"], runner=failing_runner)
+
+
+def test_wait_for_pypi_version_returns_when_exact_version_is_immediately_available(acceptance_module):
+    calls = []
+
+    def fetch_json(url):
+        calls.append(url)
+        return {"releases": {"1.2.3": [{}]}}
+
+    acceptance_module.wait_for_pypi_version(
+        "1.2.3",
+        fetch_json=fetch_json,
+        sleep=lambda _: pytest.fail("available version should not sleep"),
+    )
+
+    assert calls == [acceptance_module.PYPI_PROJECT_URL]
+
+
+def test_wait_for_pypi_version_retries_until_exact_version_is_available(acceptance_module):
+    clock = [0.0]
+    sleeps = []
+    responses = iter(({"releases": {}}, {"releases": {}}, {"releases": {"1.2.3": [{}]}}))
+
+    def sleep(seconds):
+        sleeps.append(seconds)
+        clock[0] += seconds
+
+    acceptance_module.wait_for_pypi_version(
+        "1.2.3",
+        fetch_json=lambda _: next(responses),
+        sleep=sleep,
+        monotonic=lambda: clock[0],
+        timeout_seconds=10,
+        poll_interval_seconds=2,
+    )
+
+    assert sleeps == [2, 2]
+
+
+def test_wait_for_pypi_version_times_out_after_unavailable_or_malformed_responses(acceptance_module):
+    clock = [0.0]
+    sleeps = []
+
+    def sleep(seconds):
+        sleeps.append(seconds)
+        clock[0] += seconds
+
+    with pytest.raises(acceptance_module.AcceptanceError, match="not available"):
+        acceptance_module.wait_for_pypi_version(
+            "1.2.3",
+            fetch_json=lambda _: {"releases": []},
+            sleep=sleep,
+            monotonic=lambda: clock[0],
+            timeout_seconds=6,
+            poll_interval_seconds=2,
+        )
+
+    assert sleeps == [2, 2, 2]
 
 
 def test_smoke_uses_only_absolute_managed_executables(acceptance_module, tmp_path):


### PR DESCRIPTION
Closes #360.

## Summary

- add path-filtered GraphTrail and MiseLedger jobs to the root CI workflow while leaving existing Python jobs unchanged
- add published-package acceptance on GitHub-hosted Ubuntu, macOS, and Windows runners
- require all four native component executables to be healthy absolute paths inside Brigade's managed bin directory
- fail release acceptance on missing or corrupt assets, relative or escaped paths, symlink escapes, or accidental PATH resolution

## Verification

- `./scripts/verify` through Brigade: `20260720-023000-work-verify-b1e399`
- focused component-install safeguards: `20260720-020138-work-verify-2addf2`
- focused workflow and acceptance tests: 33 passed in the final independent review
- `git diff --check origin/main..HEAD`

## Release note

The published-artifact workflow runs after a tagged PyPI publication. The PR validates its structure and unit-tested failure paths. The first tagged release will exercise the complete hosted package-install matrix.