### PR TITLE
docs: align commit co-author policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ Format: trigger, then the rule, then what to do instead.
 - Bumping the version: update `pyproject.toml`, `src/brigade/__init__.py`, and
   every template `_brigade_version` field together. `./scripts/verify` checks
   the sync.
-- Committing: use conventional commits. In escoffier-labs organizations and original solomonneas repositories, commits for substantial coding work should carry the coding agent's co-author trailer. For Codex work in Brigade, use `Co-authored-by: Codex <codex@openai.com>`. External repositories and upstream third-party PRs remain trailer-free.
+- Committing: use conventional commits. In escoffier-labs organizations and original solomonneas repositories, commits for substantial coding work should carry the coding agent's co-author trailer. External repositories and upstream third-party PRs remain trailer-free.
 
 ## Orientation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ Format: trigger, then the rule, then what to do instead.
 - Bumping the version: update `pyproject.toml`, `src/brigade/__init__.py`, and
   every template `_brigade_version` field together. `./scripts/verify` checks
   the sync.
-- Committing: conventional commits, no co-authorship trailers.
+- Committing: use conventional commits. In escoffier-labs organizations and original solomonneas repositories, commits for substantial coding work should carry the coding agent's co-author trailer. For Codex work in Brigade, use `Co-authored-by: Codex <codex@openai.com>`. External repositories and upstream third-party PRs remain trailer-free.
 
 ## Orientation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Brigade is the local-first operator CLI for agent memory, handoffs, and reviewab
 
 - Personal details, hostnames, IPs, account IDs, or live auth profiles in templates or tests. The whole point of this kit is to keep that stuff out of public repos. The `content-guard` job in CI will fail if it finds any.
 - Cron jobs or hooks that post or call out to the network without explicit opt-in.
-- AI-co-authorship trailers on commits (`Co-Authored-By: <model>`). Conventional commits only.
+- Commits must use conventional commits. In-house commits in escoffier-labs organizations and original solomonneas repositories should include a co-author trailer for a coding agent that did substantial work; external repositories and upstream third-party PRs remain trailer-free.
 
 ## Planning artifacts
 


### PR DESCRIPTION
## Summary

- align the repository commit rules with the maintainer credit policy
- require coding-agent co-author trailers for substantial in-house work
- keep external repositories and upstream third-party pull requests trailer-free

This also removes the conflicting contributor rule that still prohibited all coding-agent trailers. The policy avoids embedding a literal account identity in tracked files, so content-guard continues to scan repository content while commit trailers remain allowed.

## Verification

- `brigade work verify run --target . --command "./scripts/verify" --capture brigade-work`
- full-suite receipt: `20260720-032140-work-verify-474daa`, exit 0
- pinned content-guard `v0.1.1` scan of `AGENTS.md`
- content-guard receipt: `20260720-032136-work-verify-207819`, exit 0