### PR TITLE
feat(cli): complete code and evidence facades

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -194,10 +194,14 @@ Capture against an id you actually have: a skill you followed, a memory card (`-
 ```bash
 # optional stations (fail-open everywhere if absent)
 brigade add graphtrail          # or: cargo install graphtrail
-graphtrail sync                 # builds .graphtrail/graphtrail.db in the repo
+brigade code sync .             # explicitly runs local GraphTrail and builds .graphtrail/graphtrail.db
+brigade code context "auth receipt flow"
+brigade code impact brigade.work.verify.run
 brigade add evidence            # miseledger (process-boundary Go binary)
 
-# evidence station CLI (install / plan / health; does not crawl for you)
+# evidence station CLI: explicit local operations
+brigade evidence crawl sessions
+brigade evidence search "auth receipt flow"
 brigade evidence crawl plan     # review-only miseledger init + crawl commands
 brigade evidence doctor
 brigade evidence export plan    # review-only receipts export path
@@ -236,7 +240,11 @@ brigade pantry expiry-alert --send
 ```bash
 # GraphTrail code-graph + optional local semantic search
 brigade add search              # or: brigade add graphtrail
-brigade search sync plan        # review-only; does not run sync
+brigade code sync .             # preferred GraphTrail facade
+brigade code context "auth receipt flow"
+brigade code impact brigade.work.verify.run
+# `brigade search sync|context|impact` remain compatibility aliases.
+brigade search sync plan        # review-only; does not run GraphTrail
 brigade search doctor
 
 # Token Glace (output compaction; TokenJuice was the old name) + optional usage export

--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -19,12 +19,13 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade budgets` (extras): 2 command path(s)
 - `brigade center` (extras): 29 command path(s)
 - `brigade chat` (extras): 7 command path(s)
+- `brigade code`: 3 command path(s)
 - `brigade completions`: 1 command path(s)
 - `brigade context` (extras): 8 command path(s)
 - `brigade daily`: 26 command path(s)
 - `brigade doctor`: 1 command path(s)
 - `brigade dogfood` (extras): 1 command path(s)
-- `brigade evidence`: 4 command path(s)
+- `brigade evidence`: 6 command path(s)
 - `brigade extras`: 3 command path(s)
 - `brigade friction` (extras): 3 command path(s)
 - `brigade guard`: 1 command path(s)
@@ -57,7 +58,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade runbook` (extras): 5 command path(s)
 - `brigade runs`: 8 command path(s)
 - `brigade scrub`: 1 command path(s)
-- `brigade search`: 3 command path(s)
+- `brigade search`: 6 command path(s)
 - `brigade security`: 15 command path(s)
 - `brigade setup`: 1 command path(s)
 - `brigade skills`: 29 command path(s)
@@ -111,6 +112,9 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade chat sweep import-issues` (extras)
 - `brigade chat sweep ingest` (extras)
 - `brigade chat sweep validate` (extras)
+- `brigade code context`
+- `brigade code impact`
+- `brigade code sync`
 - `brigade completions`
 - `brigade context archive` (extras)
 - `brigade context build` (extras)
@@ -148,9 +152,11 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade daily unblock`
 - `brigade doctor`
 - `brigade dogfood` (extras)
+- `brigade evidence crawl`
 - `brigade evidence crawl plan`
 - `brigade evidence doctor`
 - `brigade evidence export plan`
+- `brigade evidence search`
 - `brigade evidence status`
 - `brigade extras off`
 - `brigade extras on`
@@ -416,8 +422,11 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade runs steer`
 - `brigade runs watch`
 - `brigade scrub`
+- `brigade search context`
 - `brigade search doctor`
+- `brigade search impact`
 - `brigade search status`
+- `brigade search sync`
 - `brigade search sync plan`
 - `brigade security closeout`
 - `brigade security config`

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -343,9 +343,10 @@ Safety and operations tools:
 Evidence ledger tools:
 
 - [MiseLedger](https://github.com/escoffier-labs/miseledger): local-first evidence ledger. One binary crawls sessions, files, git history, and chat sources (`miseledger crawl ...`), stores `miseledger.adapter.v1` JSONL in SQLite with FTS5, and emits Brigade-ready evidence bundles. No separate exporter install.
-- Brigade station CLI (process boundary; does not crawl for you):
+- Brigade station CLI (process boundary):
   - `brigade add evidence` installs miseledger and prints the crawl/export path
   - `brigade evidence status` / `doctor` — advisory health + next commands
+  - `brigade evidence crawl <args...>` / `search <args...>` - transparent MiseLedger execution; engine output and exit code pass through
   - `brigade evidence crawl plan` / `export plan` — review-only plans under `.brigade/evidence/plans/`
   - `brigade receipts export miseledger --new-only --import` — export verify/run receipts into the ledger
 - Historical note only: StationTrail and SourceHarvest were absorbed into MiseLedger crawl in v0.3.0; their archived repos are migration notes, not active products.

--- a/docs/station-contract.md
+++ b/docs/station-contract.md
@@ -18,7 +18,7 @@ Fresh repo installs use the `repo` profile: core, skills, memory, guard, securit
 | `memory` | bootstrap-doctor (optional); memory maintenance is built in | `brigade memory status|lint|compact` plus memory-care for card freshness |
 | `pantry` | agentpantry (Go sidecar) | plans and health-checks sealed browser-session sync; never starts source/sink |
 | `search` | code-search, graphtrail | local semantic search plus a code-graph CLI for callers, impact, and structural diffs |
-| `evidence` | miseledger (Go sidecar) | plans crawl/export and health-checks the local evidence ledger; does not crawl for you |
+| `evidence` | miseledger (Go sidecar) | explicitly runs local MiseLedger for `brigade evidence crawl|search`; crawl/export plans are review-only, and Brigade neither starts daemons nor uploads data |
 
 ## Inspecting a station before install
 

--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -1360,8 +1360,9 @@ First-class station CLIs (always registered; not extras-gated):
 
 | Command group | Plans / health |
 |---|---|
-| `brigade evidence` | `status`, `doctor`, `crawl plan`, `export plan` |
-| `brigade search` | `status`, `doctor`, `sync plan` |
+| `brigade evidence` | `status`, `doctor`, `crawl`, `search`, `crawl plan`, `export plan` |
+| `brigade code` | `sync`, `context`, `impact` |
+| `brigade search` | `status`, `doctor`, `sync`, `context`, `impact`, `sync plan` |
 | `brigade tokens` | `status`, `doctor`, `wire plan` |
 | `brigade stations` | `list`, `discover` |
 
@@ -1377,11 +1378,9 @@ These plan commands do not generate or copy PSKs, start services, or mutate brow
 
 `evidence` (alias `ledger`) is the local evidence-ledger station. MiseLedger remains a process-boundary Go binary; Brigade never imports it.
 `brigade add evidence` installs miseledger and prints the crawl/export path.
-Use `brigade evidence status` and `brigade evidence doctor` for advisory health with explicit `next` commands, `brigade evidence crawl plan` to preview miseledger init/crawl/doctor commands, and `brigade evidence export plan` to preview `brigade receipts export miseledger --new-only --import`.
-These plan commands do not execute crawl or import. Product page: https://brigade.tools/miseledger.
+Use `brigade evidence status` and `brigade evidence doctor` for advisory health with explicit `next` commands. `brigade evidence crawl <args...>` and `brigade evidence search <args...>` relay a safe argv list to MiseLedger, preserving its text or JSON output and exit status. `--code-reference <brigade.code-reference.v1 JSON>` is passed to MiseLedger unchanged, so its exact code-reference lookup runs before lexical fallback. Crawl defaults to 900 seconds and can be changed with the positive finite numeric `BRIGADE_EVIDENCE_CRAWL_TIMEOUT_SECONDS`; search remains at 30 seconds. An invalid crawl timeout reports a diagnostic and exits 2 before starting MiseLedger. `brigade evidence crawl plan` still previews miseledger init/crawl/doctor commands, and `brigade evidence export plan` still previews `brigade receipts export miseledger --new-only --import`. Product page: https://brigade.tools/miseledger.
 
-`search` (alias `code-search`) wires GraphTrail and optional code-search-api. The `code-search-mcp` compatibility key points to the bridge maintained under `code-search-api/mcp`.
-Use `brigade search status` / `doctor` and review-only `brigade search sync plan`. Brigade does not run `graphtrail sync` or start the search API for you.
+`code` runs GraphTrail through a process boundary: `brigade code sync|context|impact <args...>` uses safe argument forwarding and preserves engine text, JSON, and exit status. Sync defaults to 900 seconds and can be changed with the positive finite numeric `BRIGADE_CODE_SYNC_TIMEOUT_SECONDS`; context and impact remain at 30 seconds. An invalid sync timeout reports a diagnostic and exits 2 before starting GraphTrail. `search` retains its `status`, `doctor`, and `sync plan` surfaces; its executable `sync`, `context`, and `impact` forms are compatibility aliases for `code` for at least two minor releases or 90 days, whichever is longer. `search` still wires optional code-search-api, and the `code-search-mcp` compatibility key points to the bridge maintained under `code-search-api/mcp`.
 
 `tokens` wires Token Glace (current name; TokenJuice is the old name) and optional usage-tracker spend export.
 Use `brigade tokens status` / `doctor` and review-only `brigade tokens wire plan`.
@@ -1390,8 +1389,7 @@ Use `brigade tokens status` / `doctor` and review-only `brigade tokens wire plan
 
 `evidence` (alias `ledger`) is the local evidence-ledger station. MiseLedger remains a process-boundary Go binary; Brigade never imports it.
 `brigade add evidence` installs miseledger and prints the crawl/export path.
-Use `brigade evidence status` and `brigade evidence doctor` for advisory health with explicit `next` commands, `brigade evidence crawl plan` to preview miseledger init/crawl/doctor commands, and `brigade evidence export plan` to preview `brigade receipts export miseledger --new-only --import`.
-These plan commands do not execute crawl or import. Product page: https://brigade.tools/miseledger.
+Use `brigade evidence status` and `brigade evidence doctor` for advisory health with explicit `next` commands. `brigade evidence crawl <args...>` and `brigade evidence search <args...>` relay a safe argv list to MiseLedger, preserving its text or JSON output and exit status. `brigade evidence crawl plan` still previews miseledger init/crawl/doctor commands, and `brigade evidence export plan` still previews `brigade receipts export miseledger --new-only --import`. Product page: https://brigade.tools/miseledger.
 
 Security commands:
 

--- a/engines/evidence-ledger/internal/app/app.go
+++ b/engines/evidence-ledger/internal/app/app.go
@@ -1541,20 +1541,20 @@ func cmdSearch(args []string, out, errw io.Writer) int {
 	if err != nil {
 		return fatalf(errw, "search: %s", err)
 	}
-	if len(rest) < 1 {
-		return fatalf(errw, "usage: miseledger search <query>")
-	}
 	limit := 20
 	if values["limit"] != "" {
 		if _, err := fmt.Sscan(values["limit"], &limit); err != nil {
 			return fatalf(errw, "search: invalid --limit")
 		}
 	}
-	query := strings.Join(rest, " ")
 	codeReference, err := parseCodeReference(values["code-reference"])
 	if err != nil {
 		return fatalf(errw, "search: %s", err)
 	}
+	if len(rest) < 1 && codeReference == nil {
+		return fatalf(errw, "usage: miseledger search <query>")
+	}
+	query := strings.Join(rest, " ")
 	db, _, err := openMigrated()
 	if err != nil {
 		return fatalf(errw, "search: %s", err)
@@ -1905,6 +1905,9 @@ func search(db *sql.DB, opts SearchOpts) ([]SearchResult, error) {
 			return nil, err
 		}
 		if len(exact) != 0 {
+			return exact, nil
+		}
+		if opts.Query == "" {
 			return exact, nil
 		}
 	}

--- a/engines/evidence-ledger/internal/app/app_test.go
+++ b/engines/evidence-ledger/internal/app/app_test.go
@@ -2082,6 +2082,67 @@ func TestSearchUsesExactCodeReferenceBeforeLexicalFallbackAndLegacyItemsStillSea
 	}
 }
 
+func TestCLISearchAllowsOnlyValidExactCodeReferenceWithoutLexicalQuery(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+	db, _, err := openMigrated()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	insertSyntheticSearchArchive(t, db, 40)
+
+	reference := CodeReference{
+		Schema:        "brigade.code-reference.v1",
+		Repository:    "escoffier-labs/brigade",
+		Revision:      CodeRevision{Commit: strings.Repeat("a", 40)},
+		FilePath:      "src/brigade/receipts_cmd.py",
+		QualifiedName: "brigade.receipts_cmd._metadata_with_delta",
+		SymbolKind:    "function",
+		SourceSpan:    SourceSpan{StartLine: 787, LineCount: 3},
+		ChangeKind:    "changed",
+	}
+	metadata, err := json.Marshal(map[string]any{"code_references": []CodeReference{reference}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`update items set metadata_json = ? where id = 'item-001'`, string(metadata)); err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.Marshal(reference)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	exactOnly := runJSON(t, "search", "--code-reference", string(encoded), "--json")
+	if results := exactOnly["results"].([]any); len(results) != 1 || results[0].(map[string]any)["id"] != "item-001" {
+		t.Fatalf("exact-only CLI search = %#v", exactOnly)
+	}
+
+	missing := reference
+	missing.ChangeKind = "removed"
+	missingEncoded, err := json.Marshal(missing)
+	if err != nil {
+		t.Fatal(err)
+	}
+	exactOnlyMiss := runJSON(t, "search", "--code-reference", string(missingEncoded), "--json")
+	if results := exactOnlyMiss["results"].([]any); len(results) != 0 {
+		t.Fatalf("exact-only nonmatch fell through to lexical search: %#v", exactOnlyMiss)
+	}
+
+	combinedFallback := runJSON(t, "search", "needle", "--code-reference", string(missingEncoded), "--limit", "5", "--json")
+	if results := combinedFallback["results"].([]any); len(results) != 5 || results[0].(map[string]any)["id"] != "item-030" {
+		t.Fatalf("combined CLI fallback = %#v", combinedFallback)
+	}
+
+	if code, _, stderr := run("search", "--code-reference", "{}", "--json"); code == 0 || !strings.Contains(stderr, "invalid code reference") {
+		t.Fatalf("malformed exact-only reference code=%d stderr=%q", code, stderr)
+	}
+	if code, _, stderr := run("search", "--json"); code == 0 || !strings.Contains(stderr, "usage: miseledger search <query>") {
+		t.Fatalf("missing query and reference code=%d stderr=%q", code, stderr)
+	}
+}
+
 func TestCodeReferenceIntegerVectorsAreAcceptedAndCanonicalized(t *testing.T) {
 	data, err := os.ReadFile(repoPath(t, "../../schemas/code-reference.v1.integer-vectors.json"))
 	if err != nil {

--- a/src/brigade/cli/__init__.py
+++ b/src/brigade/cli/__init__.py
@@ -34,6 +34,7 @@ from . import (
     add as _add_group,
     setup as _setup_group,
     stations as _stations_group,
+    code as _code_group,
     pantry as _pantry_group,
     evidence as _evidence_group,
     search as _search_group,
@@ -105,6 +106,20 @@ _EXTRAS_MODULES = {
 }
 
 
+_PASSTHROUGH_LEAVES = {
+    ("code", "sync"),
+    ("code", "context"),
+    ("code", "impact"),
+    ("evidence", "crawl"),
+    ("evidence", "search"),
+    ("search", "sync"),
+    ("search", "context"),
+    ("search", "impact"),
+}
+
+_PLAN_LEAVES = {("evidence", "crawl"), ("search", "sync")}
+
+
 def _register_extras(sub: argparse._SubParsersAction, name: str, extras_enabled: bool) -> None:
     if extras_enabled:
         _EXTRAS_MODULES[name].register(sub)
@@ -134,6 +149,7 @@ def _build_parser() -> argparse.ArgumentParser:
     _add_group.register(sub)
     _setup_group.register(sub)
     _stations_group.register(sub)
+    _code_group.register(sub)
     _evidence_group.register(sub)
     _search_group.register(sub)
     _tokens_group.register(sub)
@@ -188,9 +204,24 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _peel_passthrough_engine_args(argv: list[str]) -> tuple[list[str], list[str] | None]:
+    """Keep opaque engine flags out of argparse for known passthrough leaves."""
+
+    leaf = tuple(argv[:2])
+    if leaf not in _PASSTHROUGH_LEAVES:
+        return argv, None
+    if leaf in _PLAN_LEAVES and len(argv) > 2 and argv[2] == "plan":
+        return argv, None
+    return argv[:2], argv[2:]
+
+
 def main(argv=None) -> int:
+    raw_argv = list(sys.argv[1:] if argv is None else argv)
+    parse_argv, engine_args = _peel_passthrough_engine_args(raw_argv)
     parser = _build_parser()
-    args = parser.parse_args(argv)
+    args = parser.parse_args(parse_argv)
+    if engine_args is not None:
+        args.engine_args = engine_args
 
     # Command groups dispatch via set_defaults(func=...). The parser is attached
     # so dispatch functions can call parser.error for unreachable

--- a/src/brigade/cli/_common.py
+++ b/src/brigade/cli/_common.py
@@ -42,6 +42,7 @@ COMMAND_GROUPS: list[tuple[str, list[str]]] = [
             "tools",
             "mcp",
             "evidence",
+            "code",
             "search",
             "tokens",
             "pantry",

--- a/src/brigade/cli/code.py
+++ b/src/brigade/cli/code.py
@@ -1,0 +1,21 @@
+"""Executable GraphTrail facade commands."""
+
+from __future__ import annotations
+
+import argparse
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    parser = sub.add_parser("code", help="Run GraphTrail graph commands through Brigade.")
+    commands = parser.add_subparsers(dest="code_command", metavar="<code-command>")
+    commands.required = True
+    for verb in ("sync", "context", "impact"):
+        command = commands.add_parser(verb, help=f"Run `graphtrail {verb}`.")
+        command.add_argument("engine_args", nargs=argparse.REMAINDER, help=argparse.SUPPRESS)
+    parser.set_defaults(func=dispatch)
+
+
+def dispatch(args) -> int:
+    from .. import code_cmd
+
+    return code_cmd.run(args.code_command, args.engine_args)

--- a/src/brigade/cli/evidence.py
+++ b/src/brigade/cli/evidence.py
@@ -25,15 +25,14 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_doctor.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
     p_doctor.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
 
-    p_crawl = evidence_sub.add_parser("crawl", help="Plan miseledger crawl without executing it.")
-    crawl_sub = p_crawl.add_subparsers(dest="evidence_crawl_command", metavar="<crawl-command>")
-    crawl_sub.required = True
-    p_crawl_plan = crawl_sub.add_parser("plan", help="Plan miseledger init/crawl/doctor commands.")
-    p_crawl_plan.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace for plan paths and --write."
-    )
-    p_crawl_plan.add_argument("--write", action="store_true", help="Write plan under .brigade/evidence/plans/.")
-    p_crawl_plan.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_crawl = evidence_sub.add_parser("crawl", help="Run `miseledger crawl`, or use `crawl plan` to preview it.")
+    # Executable crawl arguments are intentionally opaque. `crawl plan` is
+    # parsed in dispatch to preserve the established plan command contract.
+    p_crawl.add_argument("engine_args", nargs=argparse.REMAINDER, help=argparse.SUPPRESS)
+    p_crawl.set_defaults(_brigade_command_contract_leaf=True, _brigade_legacy_plan=True)
+
+    p_search = evidence_sub.add_parser("search", help="Run `miseledger search`.")
+    p_search.add_argument("engine_args", nargs=argparse.REMAINDER, help=argparse.SUPPRESS)
 
     p_export = evidence_sub.add_parser("export", help="Plan receipt export into MiseLedger without executing it.")
     export_sub = p_export.add_subparsers(dest="evidence_export_command", metavar="<export-command>")
@@ -56,10 +55,12 @@ def dispatch(args) -> int:
     if args.evidence_command == "doctor":
         return evidence_cmd.doctor(target=args.target, json_output=args.json)
     if args.evidence_command == "crawl":
-        if args.evidence_crawl_command == "plan":
-            return evidence_cmd.crawl_plan(target=args.target, write=args.write, json_output=args.json)
-        args._brigade_parser.error(f"unknown evidence crawl command: {args.evidence_crawl_command}")
-        return 2
+        if args.engine_args and args.engine_args[0] == "plan":
+            plan_args = _crawl_plan_parser().parse_args(args.engine_args[1:])
+            return evidence_cmd.crawl_plan(target=plan_args.target, write=plan_args.write, json_output=plan_args.json)
+        return evidence_cmd.run_engine("crawl", args.engine_args)
+    if args.evidence_command == "search":
+        return evidence_cmd.run_engine("search", args.engine_args)
     if args.evidence_command == "export":
         if args.evidence_export_command == "plan":
             return evidence_cmd.export_plan(target=args.target, write=args.write, json_output=args.json)
@@ -67,3 +68,13 @@ def dispatch(args) -> int:
         return 2
     args._brigade_parser.error(f"unknown evidence command: {args.evidence_command}")
     return 2
+
+
+def _crawl_plan_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="brigade evidence crawl plan")
+    parser.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace for plan paths and --write."
+    )
+    parser.add_argument("--write", action="store_true", help="Write plan under .brigade/evidence/plans/.")
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    return parser

--- a/src/brigade/cli/search.py
+++ b/src/brigade/cli/search.py
@@ -25,15 +25,15 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_doctor.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
     p_doctor.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
 
-    p_sync = search_sub.add_parser("sync", help="Plan graphtrail/code-search setup without executing it.")
-    sync_sub = p_sync.add_subparsers(dest="search_sync_command", metavar="<sync-command>")
-    sync_sub.required = True
-    p_sync_plan = sync_sub.add_parser("plan", help="Plan graphtrail sync and optional code-search serve.")
-    p_sync_plan.add_argument(
-        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace for plan paths and --write."
-    )
-    p_sync_plan.add_argument("--write", action="store_true", help="Write plan under .brigade/search/plans/.")
-    p_sync_plan.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_sync = search_sub.add_parser("sync", help="Run `graphtrail sync`, or use `sync plan` to preview setup.")
+    # The opaque remainder lets `search sync <path>` remain a direct alias.
+    # `sync plan` is parsed in dispatch to preserve its established spelling.
+    p_sync.add_argument("engine_args", nargs=argparse.REMAINDER, help=argparse.SUPPRESS)
+    p_sync.set_defaults(_brigade_command_contract_leaf=True, _brigade_legacy_plan=True)
+
+    for verb in ("context", "impact"):
+        command = search_sub.add_parser(verb, help=f"Compatibility alias for `brigade code {verb}`.")
+        command.add_argument("engine_args", nargs=argparse.REMAINDER, help=argparse.SUPPRESS)
 
     p_search.set_defaults(func=dispatch)
 
@@ -46,9 +46,27 @@ def dispatch(args) -> int:
     if args.search_command == "doctor":
         return search_cmd.doctor(target=args.target, json_output=args.json)
     if args.search_command == "sync":
-        if args.search_sync_command == "plan":
-            return search_cmd.sync_plan(target=args.target, write=args.write, json_output=args.json)
-        args._brigade_parser.error(f"unknown search sync command: {args.search_sync_command}")
-        return 2
+        if args.engine_args and args.engine_args[0] == "plan":
+            plan_args = _sync_plan_parser().parse_args(args.engine_args[1:])
+            return search_cmd.sync_plan(target=plan_args.target, write=plan_args.write, json_output=plan_args.json)
+        return _run_code_alias("sync", args.engine_args)
+    if args.search_command in ("context", "impact"):
+        return _run_code_alias(args.search_command, args.engine_args)
     args._brigade_parser.error(f"unknown search command: {args.search_command}")
     return 2
+
+
+def _sync_plan_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="brigade search sync plan")
+    parser.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace for plan paths and --write."
+    )
+    parser.add_argument("--write", action="store_true", help="Write plan under .brigade/search/plans/.")
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    return parser
+
+
+def _run_code_alias(verb: str, arguments: list[str]) -> int:
+    from .. import code_cmd
+
+    return code_cmd.run(verb, arguments)

--- a/src/brigade/code_cmd.py
+++ b/src/brigade/code_cmd.py
@@ -1,0 +1,61 @@
+"""Thin GraphTrail command facade.
+
+GraphTrail remains the owner of graph storage, discovery, and command output.
+Brigade only resolves its executable and relays an argv list across the process
+boundary.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import sys
+from collections.abc import Sequence
+
+from . import context_cmd, proc
+
+
+# `brigade search` executable aliases remain supported through at least this
+# compatibility window. Keep these public constants so release tooling and
+# downstream wrappers can inspect the policy without parsing documentation.
+SEARCH_ALIAS_RETENTION_MINOR_RELEASES = 2
+SEARCH_ALIAS_RETENTION_DAYS = 90
+
+_SHORT_OPERATION_TIMEOUT_SECONDS = 30.0
+_SYNC_TIMEOUT_SECONDS = 900.0
+_SYNC_TIMEOUT_ENV = "BRIGADE_CODE_SYNC_TIMEOUT_SECONDS"
+
+
+def _configured_timeout(environment_variable: str, default: float) -> float | None:
+    raw = os.environ.get(environment_variable)
+    if raw is None:
+        return default
+    try:
+        timeout = float(raw)
+    except ValueError:
+        return None
+    return timeout if math.isfinite(timeout) and timeout > 0 else None
+
+
+def run(verb: str, arguments: Sequence[str]) -> int:
+    """Run one GraphTrail command and relay its output and exit status."""
+
+    timeout = _SHORT_OPERATION_TIMEOUT_SECONDS
+    if verb == "sync":
+        configured_timeout = _configured_timeout(_SYNC_TIMEOUT_ENV, _SYNC_TIMEOUT_SECONDS)
+        if configured_timeout is None:
+            print(f"error: {_SYNC_TIMEOUT_ENV} must be a positive finite number of seconds", file=sys.stderr)
+            return 2
+        timeout = configured_timeout
+
+    binary = context_cmd._graphtrail_bin()
+    if binary is None:
+        print("error: graphtrail is not installed; run `brigade add graphtrail`", file=sys.stderr)
+        return 127
+
+    result = proc.run([binary, verb, *arguments], timeout=timeout)
+    if result.stdout:
+        print(result.stdout, end="")
+    if result.stderr:
+        print(result.stderr, end="", file=sys.stderr)
+    return result.code

--- a/src/brigade/completions.py
+++ b/src/brigade/completions.py
@@ -27,6 +27,11 @@ def _command_tree() -> dict[str, list[str]]:
             tree[" ".join(prefix)] = sorted(dict.fromkeys(children))
 
     walk(_build_parser(), ["brigade"])
+    # These legacy plan forms share an executable command's opaque engine
+    # arguments, so argparse cannot model both alternatives as subparsers.
+    # Keep them in the static completion contract explicitly.
+    for path in ("brigade search sync", "brigade evidence crawl"):
+        tree[path] = sorted(set(tree.get(path, []) + ["plan"]))
     return tree
 
 

--- a/src/brigade/evidence_cmd.py
+++ b/src/brigade/evidence_cmd.py
@@ -1,13 +1,17 @@
 """Evidence station commands for MiseLedger integration.
 
-MiseLedger stays a process-boundary Go binary. These commands install/plan/health-check
-only: they do not crawl sessions, write the ledger, or import adapter JSONL unless the
-operator runs the printed miseledger / receipts commands.
+MiseLedger stays a process-boundary Go binary. Explicit user-invoked
+``brigade evidence crawl`` and ``brigade evidence search`` commands relay work to it;
+status, doctor, and crawl/export plans remain local checks or review-only output.
+Brigade does not start daemons or upload data.
 """
 
 from __future__ import annotations
 
 import json
+import math
+import os
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -15,8 +19,51 @@ from . import evidence_brief, proc
 from .localio import utc_now_iso as _now
 
 
+_SHORT_OPERATION_TIMEOUT_SECONDS = 30.0
+_CRAWL_TIMEOUT_SECONDS = 900.0
+_CRAWL_TIMEOUT_ENV = "BRIGADE_EVIDENCE_CRAWL_TIMEOUT_SECONDS"
+
+
+def _configured_timeout(environment_variable: str, default: float) -> float | None:
+    raw = os.environ.get(environment_variable)
+    if raw is None:
+        return default
+    try:
+        timeout = float(raw)
+    except ValueError:
+        return None
+    return timeout if math.isfinite(timeout) and timeout > 0 else None
+
+
 def _json_print(payload: dict[str, Any]) -> None:
     print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def run_engine(verb: str, arguments: list[str]) -> int:
+    """Run MiseLedger without changing its argv, output, or data contract.
+
+    A ``--code-reference`` JSON value is relayed verbatim to MiseLedger, which
+    performs exact code-reference matching before lexical fallback.
+    """
+
+    timeout = _SHORT_OPERATION_TIMEOUT_SECONDS
+    if verb == "crawl":
+        configured_timeout = _configured_timeout(_CRAWL_TIMEOUT_ENV, _CRAWL_TIMEOUT_SECONDS)
+        if configured_timeout is None:
+            print(f"error: {_CRAWL_TIMEOUT_ENV} must be a positive finite number of seconds", file=sys.stderr)
+            return 2
+        timeout = configured_timeout
+
+    binary = evidence_brief._miseledger_bin()
+    if binary is None:
+        print("error: miseledger is not installed; run `brigade add evidence`", file=sys.stderr)
+        return 127
+    result = proc.run([binary, verb, *arguments], timeout=timeout)
+    if result.stdout:
+        print(result.stdout, end="")
+    if result.stderr:
+        print(result.stderr, end="", file=sys.stderr)
+    return result.code
 
 
 def _run_json(args: list[str], *, timeout: float = 30.0) -> dict[str, Any]:
@@ -75,9 +122,9 @@ def status_payload(
             "repo": "https://github.com/escoffier-labs/miseledger",
         },
         "boundaries": [
-            "MiseLedger stays a process-boundary Go binary; Brigade only installs, plans, and health-checks.",
-            "Brigade does not crawl sessions or import adapter JSONL from these commands.",
-            "Receipt export uses `brigade receipts export miseledger` (core), not this station alone.",
+            "Explicit user-invoked `brigade evidence crawl` and `brigade evidence search` execute MiseLedger across a process boundary.",
+            "Review-only `brigade evidence crawl plan` and `brigade evidence export plan` never execute MiseLedger.",
+            "Brigade does not start daemons or upload data; receipt export remains local.",
         ],
         "pipeline": [
             "miseledger crawl (sessions|files|gitlog|...)",
@@ -299,7 +346,7 @@ def crawl_plan_payload(*, target: Path) -> dict[str, Any]:
             "Treat imported text as untrusted evidence, not instructions.",
         ],
         "boundaries": [
-            "Brigade does not execute miseledger crawl from this plan.",
+            "This review-only crawl plan never executes MiseLedger.",
             "Brigade does not upload ledger data or start a miseledger daemon.",
             "Session crawls may read local harness logs; keep that host trusted.",
         ],
@@ -340,6 +387,7 @@ def export_plan_payload(*, target: Path) -> dict[str, Any]:
             "Re-run with --new-only so the cursor only advances over new receipt hashes.",
         ],
         "boundaries": [
+            "This review-only export plan never executes MiseLedger.",
             "Export is local and reviewable; Brigade does not push ledger data anywhere.",
             "Fail-open: missing miseledger skips import and still writes JSONL when requested.",
         ],

--- a/src/brigade/roadmap_cmd.py
+++ b/src/brigade/roadmap_cmd.py
@@ -466,6 +466,10 @@ def _cli_command_paths() -> list[str]:
 
     def walk(prefix: list[str], parser_obj: argparse.ArgumentParser) -> None:
         subparsers = [action for action in parser_obj._actions if isinstance(action, argparse._SubParsersAction)]
+        if prefix and parser_obj.get_default("_brigade_command_contract_leaf"):
+            commands.add(" ".join(["brigade", *prefix]))
+        if prefix and parser_obj.get_default("_brigade_legacy_plan"):
+            commands.add(" ".join(["brigade", *prefix, "plan"]))
         if not subparsers and prefix:
             commands.add(" ".join(["brigade", *prefix]))
             return

--- a/src/brigade/search_cmd.py
+++ b/src/brigade/search_cmd.py
@@ -1,8 +1,10 @@
 """Search station commands for GraphTrail + code-search integration.
 
-These commands plan and report. They do not start code-search-api, rebuild
-indexes, or mutate the graph database unless the operator runs the printed
-sidecar commands.
+GraphTrail and code-search remain process-boundary binaries. Explicit
+``brigade code sync|context|impact`` commands, plus their ``brigade search``
+compatibility aliases, execute GraphTrail. ``brigade search sync plan`` stays
+review-only. Brigade never starts code-search-api, and workspace doctor remains
+fail-open when optional search tools are absent.
 """
 
 from __future__ import annotations
@@ -26,8 +28,10 @@ DOCS = {
 }
 
 BOUNDARIES = [
-    "GraphTrail and code-search stay process-boundary binaries; Brigade only installs, plans, and health-checks.",
-    "Brigade does not start code-search-api or run graphtrail sync from these commands.",
+    "GraphTrail and code-search stay process-boundary binaries.",
+    "Explicit `brigade code sync|context|impact` commands execute GraphTrail across a process boundary; `brigade search sync|context|impact` are compatibility aliases.",
+    "`brigade search sync plan` is review-only and never executes GraphTrail.",
+    "Brigade never starts code-search-api.",
     "Search station tools are optional and fail-open for workspace doctor.",
     "The code-search-mcp compatibility key is maintained by code-search-api/mcp.",
 ]

--- a/tests/test_evidence_cmd.py
+++ b/tests/test_evidence_cmd.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
-from brigade import evidence_cmd
+from brigade import code_cmd, evidence_cmd, search_cmd
 
 
 def test_evidence_status_reports_uninstalled(monkeypatch, tmp_path):
@@ -17,6 +18,61 @@ def test_evidence_status_reports_uninstalled(monkeypatch, tmp_path):
     assert "brigade add evidence" in payload["summary"]
     assert "brigade evidence crawl plan" in payload["next_commands"]
     assert payload["pipeline"][0].startswith("miseledger crawl")
+
+
+def test_evidence_status_distinguishes_explicit_execution_from_review_only_plans(monkeypatch, tmp_path):
+    monkeypatch.setattr(evidence_cmd.evidence_brief, "_miseledger_bin", lambda: None)
+
+    payload = evidence_cmd.status_payload(tmp_path)
+    boundaries = payload["boundaries"]
+
+    assert (
+        "Explicit user-invoked `brigade evidence crawl` and `brigade evidence search` execute MiseLedger across a process boundary."
+        in boundaries
+    )
+    assert (
+        "Review-only `brigade evidence crawl plan` and `brigade evidence export plan` never execute MiseLedger."
+        in boundaries
+    )
+    assert "Brigade does not start daemons or upload data; receipt export remains local." in boundaries
+    assert "Brigade does not crawl sessions or import adapter JSONL from these commands." not in boundaries
+    assert "only: they do not crawl sessions" not in (evidence_cmd.__doc__ or "")
+    repo_root = Path(__file__).parents[1]
+    quickstart = (repo_root / "QUICKSTART.md").read_text()
+    station_contract = (repo_root / "docs" / "station-contract.md").read_text()
+    search_docstring = search_cmd.__doc__ or ""
+    evidence_docstring = evidence_cmd.__doc__ or ""
+
+    assert "brigade evidence crawl sessions" in quickstart
+    assert "brigade evidence search" in quickstart
+    assert "brigade evidence crawl plan     # review-only" in quickstart
+    assert "brigade evidence export plan    # review-only" in quickstart
+    assert "brigade code sync .             # preferred GraphTrail facade" in quickstart
+    assert "brigade search sync|context|impact` remain compatibility aliases" in quickstart
+    assert "explicitly runs local MiseLedger for `brigade evidence crawl|search`" in station_contract
+    assert "crawl/export plans are review-only" in station_contract
+    assert "Explicit user-invoked" in evidence_docstring
+    assert "brigade code sync|context|impact" in search_docstring
+    assert "compatibility aliases" in search_docstring
+    assert "sync plan`` stays\nreview-only" in search_docstring
+    for text in (quickstart, station_contract, search_docstring, evidence_docstring):
+        assert "does not crawl for you" not in text
+
+
+def test_code_run_relays_child_stderr_unchanged(monkeypatch, capsys):
+    monkeypatch.setattr(code_cmd.context_cmd, "_graphtrail_bin", lambda: "/x/graphtrail")
+    monkeypatch.setattr(code_cmd.proc, "run", lambda *_, **__: code_cmd.proc.Result(7, "", "graph warning\\n"))
+
+    assert code_cmd.run("impact", ["brigade.cli.main"]) == 7
+    assert capsys.readouterr().err == "graph warning\\n"
+
+
+def test_evidence_run_engine_relays_child_stderr_unchanged(monkeypatch, capsys):
+    monkeypatch.setattr(evidence_cmd.evidence_brief, "_miseledger_bin", lambda: "/x/miseledger")
+    monkeypatch.setattr(evidence_cmd.proc, "run", lambda *_, **__: evidence_cmd.proc.Result(6, "", "ledger warning\\n"))
+
+    assert evidence_cmd.run_engine("search", ["needle"]) == 6
+    assert capsys.readouterr().err == "ledger warning\\n"
 
 
 def test_evidence_status_ok_with_status_json(monkeypatch, tmp_path):
@@ -91,7 +147,7 @@ def test_crawl_plan_is_review_only(tmp_path):
     rendered = evidence_cmd._render_plan_md(payload)
 
     assert ["miseledger", "crawl", "sessions"] in payload["commands"]
-    assert "Brigade does not execute miseledger crawl" in payload["boundaries"][0]
+    assert "review-only crawl plan never executes MiseLedger" in payload["boundaries"][0]
     assert "miseledger crawl sessions" in rendered
 
 

--- a/tests/test_issue362_code_evidence_facades.py
+++ b/tests/test_issue362_code_evidence_facades.py
@@ -1,0 +1,506 @@
+"""Failing-first tests for issue #362 code/evidence engine facades.
+
+These tests define the executable subprocess contract for `brigade code`,
+`brigade search` compatibility aliases, and `brigade evidence crawl|search`.
+They should fail until the facade implementation lands.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import stat
+
+import pytest
+
+from brigade import (
+    cli,
+    code_references,
+    completions,
+    component_manifest,
+    context_cmd,
+    evidence_brief,
+    evidence_cmd,
+    proc,
+    roadmap_cmd,
+    search_cmd,
+)
+
+REFERENCE = {
+    "schema": "brigade.code-reference.v1",
+    "repository": "escoffier-labs/brigade",
+    "revision": {"commit": "a" * 40},
+    "file_path": "src/brigade/receipts_cmd.py",
+    "qualified_name": "brigade.receipts_cmd._metadata_with_delta",
+    "symbol_kind": "function",
+    "source_span": {"start_line": 787, "line_count": 3},
+    "change_kind": "changed",
+}
+
+ISSUE_362_CODE_COMMANDS = (
+    "brigade code sync",
+    "brigade code context",
+    "brigade code impact",
+)
+
+ISSUE_362_SEARCH_ALIASES = (
+    "brigade search sync",
+    "brigade search context",
+    "brigade search impact",
+)
+
+ISSUE_362_EVIDENCE_COMMANDS = (
+    "brigade evidence crawl",
+    "brigade evidence search",
+)
+
+
+def _patch_graphtrail(monkeypatch, *, run_calls: list | None = None):
+    def fake_run(args, timeout=30.0, **kwargs):
+        if run_calls is not None:
+            run_calls.append({"args": list(args), "timeout": timeout, "kwargs": kwargs})
+        exit_code = 0
+        if args and args[-1].isdigit() and len(args) >= 2 and args[-2] == "--test-exit":
+            exit_code = int(args[-1])
+        stdout = '{"ok": true}\n' if "--json" in args else "graphtrail-stdout\n"
+        return proc.Result(exit_code, stdout, "")
+
+    monkeypatch.setattr(context_cmd, "_graphtrail_bin", lambda: "/fake/graphtrail")
+    monkeypatch.setattr(proc, "run", fake_run)
+
+
+def _patch_miseledger(monkeypatch, *, run_calls: list | None = None):
+    def fake_run(args, timeout=30.0, **kwargs):
+        if run_calls is not None:
+            run_calls.append({"args": list(args), "timeout": timeout, "kwargs": kwargs})
+        exit_code = 0
+        if args and args[-1].isdigit() and len(args) >= 2 and args[-2] == "--test-exit":
+            exit_code = int(args[-1])
+        stdout = '{"matches": []}\n' if "--json" in args else "miseledger-stdout\n"
+        return proc.Result(exit_code, stdout, "")
+
+    monkeypatch.setattr(evidence_brief, "_miseledger_bin", lambda: "/fake/miseledger")
+    monkeypatch.setattr(proc, "run", fake_run)
+
+
+# --- parser / discovery -----------------------------------------------------
+
+
+def test_parser_registers_brigade_code_group():
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["code", "--help"])
+    assert exc.value.code == 0
+
+
+def test_parser_keeps_search_group_and_sync_plan_subcommand():
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["search", "sync", "plan", "--help"])
+    assert exc.value.code == 0
+
+
+def test_command_tree_exposes_code_and_executable_search_aliases():
+    tree = completions._command_tree()
+    assert "code" in tree["brigade"]
+    assert set(tree["brigade code"]) >= {"sync", "context", "impact"}
+    assert set(tree["brigade search"]) >= {"status", "doctor", "sync", "context", "impact"}
+    assert "plan" in tree["brigade search sync"]
+
+
+def test_command_tree_exposes_executable_evidence_crawl_and_search():
+    tree = completions._command_tree()
+    assert set(tree["brigade evidence"]) >= {"status", "doctor", "crawl", "search", "export"}
+    assert "plan" in tree["brigade evidence crawl"]
+    assert "plan" in tree["brigade evidence export"]
+
+
+@pytest.mark.parametrize("shell", ("bash", "zsh", "fish"))
+def test_completion_scripts_advertise_issue_362_commands(shell):
+    renderer = {"bash": completions.bash_script, "zsh": completions.zsh_script, "fish": completions.fish_script}[shell]
+    script = renderer()
+    for fragment in ("code", "context", "impact"):
+        assert fragment in script
+    assert "evidence" in script
+    assert "crawl" in script
+    assert "search" in script
+
+
+def test_roadmap_command_contract_includes_issue_362_paths(tmp_path):
+    payload = roadmap_cmd.command_contract_payload(tmp_path)
+    commands = set(payload["cli_commands"])
+    for command in (*ISSUE_362_CODE_COMMANDS, *ISSUE_362_SEARCH_ALIASES, *ISSUE_362_EVIDENCE_COMMANDS):
+        assert command in commands
+    inventory = payload["expected_inventory"]
+    assert "- `brigade code sync`" in inventory
+    assert "- `brigade evidence search`" in inventory
+
+
+def test_search_alias_compatibility_window_is_documented():
+    code_cmd = importlib.import_module("brigade.code_cmd")
+    minor_releases = getattr(code_cmd, "SEARCH_ALIAS_RETENTION_MINOR_RELEASES", 0)
+    days = getattr(code_cmd, "SEARCH_ALIAS_RETENTION_DAYS", 0)
+    assert minor_releases >= 2
+    assert days >= 90
+
+
+# --- brigade code: GraphTrail forwarding ------------------------------------
+
+
+def test_code_sync_forwards_exact_argv_and_stdout(monkeypatch, tmp_path, capsys):
+    calls: list[dict] = []
+    _patch_graphtrail(monkeypatch, run_calls=calls)
+    space = tmp_path / "my repo"
+    space.mkdir()
+
+    rc = cli.main(["code", "sync", str(space)])
+
+    assert rc == 0
+    assert calls == [{"args": ["/fake/graphtrail", "sync", str(space)], "timeout": 900.0, "kwargs": {}}]
+    assert capsys.readouterr().out == "graphtrail-stdout\n"
+
+
+def test_code_sync_uses_configured_timeout(monkeypatch, tmp_path):
+    calls: list[dict] = []
+    _patch_graphtrail(monkeypatch, run_calls=calls)
+    monkeypatch.setenv("BRIGADE_CODE_SYNC_TIMEOUT_SECONDS", "42.5")
+
+    assert cli.main(["code", "sync", str(tmp_path)]) == 0
+    assert calls[0]["timeout"] == 42.5
+
+
+@pytest.mark.parametrize("value", ("", "zero", "0", "-1", "nan", "inf"))
+def test_code_sync_rejects_invalid_configured_timeout_before_starting_engine(monkeypatch, tmp_path, capsys, value):
+    calls: list[dict] = []
+    _patch_graphtrail(monkeypatch, run_calls=calls)
+    monkeypatch.setenv("BRIGADE_CODE_SYNC_TIMEOUT_SECONDS", value)
+
+    assert cli.main(["code", "sync", str(tmp_path)]) == 2
+    assert calls == []
+    assert "BRIGADE_CODE_SYNC_TIMEOUT_SECONDS" in capsys.readouterr().err
+
+
+def test_code_context_forwards_remaining_args(monkeypatch, capsys):
+    calls: list[dict] = []
+    _patch_graphtrail(monkeypatch, run_calls=calls)
+
+    rc = cli.main(["code", "context", "wire facades", "--json", "--limit", "5"])
+
+    assert rc == 0
+    assert calls[0]["args"] == ["/fake/graphtrail", "context", "wire facades", "--json", "--limit", "5"]
+    assert calls[0]["timeout"] == 30.0
+    assert json.loads(capsys.readouterr().out) == {"ok": True}
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected_engine_argv"),
+    [
+        (["code", "context", "--json", "--limit", "5"], ["context", "--json", "--limit", "5"]),
+        (["search", "context", "--json", "--limit", "5"], ["context", "--json", "--limit", "5"]),
+    ],
+)
+def test_graphtrail_passthrough_leaves_accept_leading_flags(monkeypatch, argv, expected_engine_argv):
+    calls: list[dict] = []
+    _patch_graphtrail(monkeypatch, run_calls=calls)
+
+    rc = cli.main(argv)
+
+    assert rc == 0
+    assert calls[0]["args"] == ["/fake/graphtrail", *expected_engine_argv]
+
+
+def test_code_impact_propagates_child_exit_code(monkeypatch):
+    calls: list[dict] = []
+    _patch_graphtrail(monkeypatch, run_calls=calls)
+
+    rc = cli.main(["code", "impact", "brigade.cli.main", "--test-exit", "3"])
+
+    assert rc == 3
+    assert calls[0]["args"][:3] == ["/fake/graphtrail", "impact", "brigade.cli.main"]
+
+
+def test_code_sync_missing_graphtrail_exits_127_with_diagnostic(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(context_cmd, "_graphtrail_bin", lambda: None)
+
+    rc = cli.main(["code", "sync", str(tmp_path)])
+
+    assert rc == 127
+    err = capsys.readouterr().err
+    assert "graphtrail" in err.lower()
+    assert "add" in err.lower() or "install" in err.lower()
+
+
+def test_code_sync_uses_graphtrail_bin_override(monkeypatch, tmp_path):
+    override = tmp_path / "graphtrail"
+    override.write_text("#!/bin/sh\n")
+    override.chmod(override.stat().st_mode | stat.S_IXUSR)
+    calls: list[list[str]] = []
+
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(override))
+    monkeypatch.setattr(proc, "which", lambda _: pytest.fail("resolver should use GRAPHTRAIL_BIN first"))
+    monkeypatch.setattr(proc, "run", lambda args, **_: calls.append(args) or proc.Result(0, "", ""))
+
+    assert cli.main(["code", "sync", str(tmp_path)]) == 0
+    assert calls == [[str(override), "sync", str(tmp_path)]]
+
+
+def test_code_sync_timeout_returns_124(monkeypatch, tmp_path):
+    _patch_graphtrail(monkeypatch)
+
+    def timeout_run(args, timeout=30.0, **kwargs):
+        return proc.Result(124, "", "timeout after 0.1s\n")
+
+    monkeypatch.setattr(proc, "run", timeout_run)
+
+    rc = cli.main(["code", "sync", str(tmp_path)])
+
+    assert rc == 124
+
+
+# --- brigade search: tested compatibility aliases ---------------------------
+
+
+@pytest.mark.parametrize(
+    ("alias_argv", "expected_engine_argv"),
+    [
+        (["search", "sync", "{path}"], ["sync", "{path}"]),
+        (["search", "context", "task", "--json"], ["context", "task", "--json"]),
+        (["search", "impact", "brigade.cli.main", "--depth", "2"], ["impact", "brigade.cli.main", "--depth", "2"]),
+    ],
+)
+def test_search_executable_verbs_alias_code_facades(monkeypatch, tmp_path, alias_argv, expected_engine_argv):
+    calls: list[dict] = []
+    _patch_graphtrail(monkeypatch, run_calls=calls)
+    path = tmp_path / "space path"
+    path.mkdir()
+    argv = [part.format(path=str(path)) for part in alias_argv]
+
+    rc = cli.main(argv)
+
+    assert rc == 0
+    assert calls[0]["args"] == ["/fake/graphtrail", *[part.format(path=str(path)) for part in expected_engine_argv]]
+
+
+def test_search_sync_plan_stays_plan_only_and_preserves_json_contract(monkeypatch, tmp_path, capsys):
+    calls: list[dict] = []
+    _patch_graphtrail(monkeypatch, run_calls=calls)
+
+    rc = cli.main(["search", "sync", "plan", "--target", str(tmp_path), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert calls == []
+    assert payload["station"] == "search"
+    assert payload["kind"] == "sync"
+    assert ["graphtrail", "sync", str(tmp_path.resolve())] in payload["commands"]
+
+
+# --- brigade evidence: MiseLedger forwarding --------------------------------
+
+
+def test_evidence_crawl_forwards_exact_argv_with_space_path(monkeypatch, tmp_path, capsys):
+    calls: list[dict] = []
+    _patch_miseledger(monkeypatch, run_calls=calls)
+    space = tmp_path / "evidence root"
+    space.mkdir()
+
+    rc = cli.main(["evidence", "crawl", "files", str(space)])
+
+    assert rc == 0
+    assert calls == [{"args": ["/fake/miseledger", "crawl", "files", str(space)], "timeout": 900.0, "kwargs": {}}]
+    assert capsys.readouterr().out == "miseledger-stdout\n"
+
+
+def test_evidence_crawl_uses_configured_timeout(monkeypatch):
+    calls: list[dict] = []
+    _patch_miseledger(monkeypatch, run_calls=calls)
+    monkeypatch.setenv("BRIGADE_EVIDENCE_CRAWL_TIMEOUT_SECONDS", "42.5")
+
+    assert cli.main(["evidence", "crawl", "sessions"]) == 0
+    assert calls[0]["timeout"] == 42.5
+
+
+@pytest.mark.parametrize("value", ("", "zero", "0", "-1", "nan", "inf"))
+def test_evidence_crawl_rejects_invalid_configured_timeout_before_starting_engine(monkeypatch, capsys, value):
+    calls: list[dict] = []
+    _patch_miseledger(monkeypatch, run_calls=calls)
+    monkeypatch.setenv("BRIGADE_EVIDENCE_CRAWL_TIMEOUT_SECONDS", value)
+
+    assert cli.main(["evidence", "crawl", "sessions"]) == 2
+    assert calls == []
+    assert "BRIGADE_EVIDENCE_CRAWL_TIMEOUT_SECONDS" in capsys.readouterr().err
+
+
+def test_evidence_search_forwards_code_reference_before_lexical_fallback(monkeypatch, capsys):
+    calls: list[dict] = []
+    _patch_miseledger(monkeypatch, run_calls=calls)
+    ref = code_references.canonical_json(REFERENCE)
+    code_references.validate(REFERENCE)
+
+    rc = cli.main(["evidence", "search", "needle", "--code-reference", ref, "--json"])
+
+    assert rc == 0
+    assert calls[0]["args"] == ["/fake/miseledger", "search", "needle", "--code-reference", ref, "--json"]
+    assert calls[0]["timeout"] == 30.0
+    assert json.loads(capsys.readouterr().out) == {"matches": []}
+
+
+def test_evidence_search_accepts_a_leading_code_reference(monkeypatch):
+    calls: list[dict] = []
+    _patch_miseledger(monkeypatch, run_calls=calls)
+    ref = code_references.canonical_json(REFERENCE)
+
+    rc = cli.main(["evidence", "search", "--code-reference", ref])
+
+    assert rc == 0
+    assert calls[0]["args"] == ["/fake/miseledger", "search", "--code-reference", ref]
+
+
+def test_evidence_search_propagates_child_exit_code(monkeypatch):
+    calls: list[dict] = []
+    _patch_miseledger(monkeypatch, run_calls=calls)
+
+    rc = cli.main(["evidence", "search", "needle", "--test-exit", "5"])
+
+    assert rc == 5
+    assert calls[0]["args"][:3] == ["/fake/miseledger", "search", "needle"]
+
+
+def test_evidence_crawl_missing_miseledger_exits_127_with_diagnostic(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(evidence_brief, "_miseledger_bin", lambda: None)
+
+    rc = cli.main(["evidence", "crawl", "sessions"])
+
+    assert rc == 127
+    err = capsys.readouterr().err
+    assert "miseledger" in err.lower()
+
+
+def test_evidence_crawl_uses_miseledger_bin_override(monkeypatch, tmp_path):
+    override = tmp_path / "miseledger"
+    override.write_text("#!/bin/sh\n")
+    override.chmod(override.stat().st_mode | stat.S_IXUSR)
+    calls: list[list[str]] = []
+
+    monkeypatch.setenv("MISELEDGER_BIN", str(override))
+    monkeypatch.setattr(proc, "which", lambda _: pytest.fail("facade should use _miseledger_bin"))
+    monkeypatch.setattr(proc, "run", lambda args, **_: calls.append(args) or proc.Result(0, "", ""))
+
+    assert cli.main(["evidence", "crawl", "sessions"]) == 0
+    assert calls == [[str(override), "crawl", "sessions"]]
+
+
+def test_evidence_search_timeout_returns_124(monkeypatch):
+    _patch_miseledger(monkeypatch)
+
+    def timeout_run(args, timeout=30.0, **kwargs):
+        return proc.Result(124, "", "timeout after 0.1s\n")
+
+    monkeypatch.setattr(proc, "run", timeout_run)
+
+    rc = cli.main(["evidence", "search", "needle"])
+
+    assert rc == 124
+
+
+def test_evidence_crawl_timeout_returns_124(monkeypatch):
+    _patch_miseledger(monkeypatch)
+
+    def timeout_run(args, timeout=30.0, **kwargs):
+        return proc.Result(124, "", "timeout after 0.1s\n")
+
+    monkeypatch.setattr(proc, "run", timeout_run)
+
+    assert cli.main(["evidence", "crawl", "sessions"]) == 124
+
+
+def test_evidence_crawl_plan_stays_plan_only_and_preserves_json_contract(monkeypatch, tmp_path, capsys):
+    calls: list[dict] = []
+    _patch_miseledger(monkeypatch, run_calls=calls)
+
+    rc = cli.main(["evidence", "crawl", "plan", "--target", str(tmp_path), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert calls == []
+    assert payload["kind"] == "crawl"
+    assert ["miseledger", "crawl", "sessions"] in payload["commands"]
+
+
+# --- legacy health/plan JSON contracts (must keep passing) ------------------
+
+
+def test_search_status_json_contract_unchanged(monkeypatch, tmp_path):
+    monkeypatch.setattr(search_cmd.proc, "which", lambda cmd: None)
+    payload = search_cmd.status_payload(tmp_path)
+    assert {
+        "target",
+        "station",
+        "summary",
+        "health",
+        "installed",
+        "next_commands",
+        "docs",
+        "boundaries",
+        "tools",
+        "pipeline",
+    } <= set(payload.keys())
+    assert payload["station"] == "search"
+
+
+def test_search_doctor_json_contract_unchanged(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(search_cmd.proc, "which", lambda cmd: None)
+    rc = search_cmd.doctor(target=tmp_path, json_output=True)
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["station"] == "search"
+    assert "tools" in payload
+
+
+def test_evidence_status_json_contract_unchanged(monkeypatch, tmp_path):
+    monkeypatch.setattr(evidence_cmd.evidence_brief, "_miseledger_bin", lambda: None)
+    payload = evidence_cmd.status_payload(tmp_path)
+    assert {
+        "target",
+        "installed",
+        "health",
+        "summary",
+        "status",
+        "doctor",
+        "export_cursor_present",
+        "next_commands",
+        "docs",
+        "boundaries",
+        "pipeline",
+    } <= set(payload.keys())
+
+
+def test_evidence_export_plan_json_contract_unchanged(tmp_path):
+    payload = evidence_cmd.export_plan_payload(target=tmp_path)
+    assert payload["kind"] == "export"
+    assert any("receipts export miseledger" in " ".join(cmd) for cmd in payload["commands"])
+
+
+def test_component_shim_ids_remain_required():
+    assert set(component_manifest.KNOWN_COMPONENT_IDS) >= {
+        "graphtrail",
+        "graphtrail-mcp",
+        "miseledger",
+        "sessionfind",
+    }
+
+
+def test_proc_run_uses_argv_lists_not_shell(monkeypatch, tmp_path):
+    """Facade implementations must call proc.run with argv lists (no shell=True)."""
+    observed: list[dict] = []
+
+    def fake_run(args, timeout=30.0, **kwargs):
+        observed.append({"args": args, "shell": kwargs.get("shell")})
+        return proc.Result(0, "", "")
+
+    monkeypatch.setattr(context_cmd, "_graphtrail_bin", lambda: "/fake/graphtrail")
+    monkeypatch.setattr(proc, "run", fake_run)
+
+    assert cli.main(["code", "sync", str(tmp_path / "space dir")]) == 0
+
+    assert observed
+    assert observed[0]["shell"] is not True
+    assert isinstance(observed[0]["args"], list)

--- a/tests/test_search_cmd.py
+++ b/tests/test_search_cmd.py
@@ -66,7 +66,13 @@ def test_sync_plan_is_review_only(tmp_path):
     rendered = search_cmd.health.render_plan_md("search sync plan", payload)
 
     assert ["graphtrail", "sync", str(tmp_path.resolve())] in payload["commands"]
-    assert "Brigade does not start code-search-api" in payload["boundaries"][1]
+    assert any("brigade code sync" in boundary for boundary in payload["boundaries"])
+    assert any("brigade search sync plan" in boundary for boundary in payload["boundaries"])
+    assert any("Brigade never starts code-search-api" in boundary for boundary in payload["boundaries"])
+    assert not any("only installs, plans, and health-checks" in boundary for boundary in payload["boundaries"])
+    assert not any(
+        "does not start code-search-api or run graphtrail sync" in boundary for boundary in payload["boundaries"]
+    )
     assert "graphtrail sync" in rendered
 
 


### PR DESCRIPTION
Closes #362.

## Summary

- Add executable `brigade code sync|context|impact` GraphTrail facades.
- Keep `brigade search status|doctor|sync plan` intact and add tested `sync|context|impact` compatibility aliases for at least two minor releases or 90 days.
- Add executable `brigade evidence crawl|search` paths while preserving `status`, `doctor`, `crawl plan`, and `export plan`.
- Support exact-only structured code-reference searches in the imported evidence engine before lexical fallback.
- Use Brigade's existing engine resolvers, raw argv/stdout/stderr/exit propagation, 30-second query timeouts, and configurable 900-second sync/crawl timeouts.
- Update command discovery, completions, inventory, quickstart, station boundaries, and technical docs.

## Compatibility and scope

Existing plan and health JSON keys remain in place. The GraphTrail, graphtrail-mcp, MiseLedger, and sessionfind executable shims are unchanged. This adds no dependency, SQLite schema change, migration, backfill, direct engine coupling, daemon, release cutover, repository archival, or product-page change.

## Verification

Captured through Brigade:

- `20260720-075328-work-verify-1c2fe1`: Ruff format check, 502 files formatted.
- `20260720-075336-work-verify-43873b`: focused facade suite, 66 passed.
- `20260720-075349-work-verify-1486c2`: `git diff --check`, exit 0.
- `20260720-075355-work-verify-7d42b7`: `./scripts/verify`, 3401 passed, 3 skipped, 82.38% coverage.
- MiseLedger evidence `75d6c377049cd45ffdb35285`: focused exact-only Go CLI test, exit 0.
- MiseLedger evidence `323020ff1e6af92d88e74c89`: full evidence-ledger Go suite, exit 0.
- Final read-only Brigade review `20260720-080011-b44cf906`: merge-ready, no actionable findings.