### PR TITLE
feat(graphtrail): deprecate direct MiseLedger adapter

### DIFF
--- a/engines/code-graph/CHANGELOG.md
+++ b/engines/code-graph/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+- The direct `miseledger` Cargo feature, `graphtrail context --evidence`, and `graphtrail links` are deprecated but remain functional. Use `brigade code sync .`, `brigade code context "rate limiting" --markdown`, `brigade code impact dispatch --json`, `brigade evidence crawl plan --target .`, `brigade evidence search "dispatch"`, `brigade evidence search "dispatch" --code-reference '{"schema":"brigade.code-reference.v1","repository":"escoffier-labs/brigade","revision":{"commit":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},"file_path":"src/brigade/receipts_cmd.py","qualified_name":"brigade.receipts_cmd._metadata_with_delta","symbol_kind":"function","source_span":{"start_line":788,"line_count":3}}'`, and `brigade evidence doctor --target .` for structured composition. An exact code reference is matched before lexical fallback. Compatibility lasts through at least two minor GraphTrail releases or 90 days after the first GraphTrail release containing this deprecation, whichever is longer. Removal cannot occur before that policy is satisfied. The standalone release pipeline is unchanged.
+
 ## [0.4.0] - 2026-07-17
 
 ### Fixed

--- a/engines/code-graph/README.md
+++ b/engines/code-graph/README.md
@@ -187,6 +187,22 @@ cargo build --features codesearch --bin graphtrail-mcp
 cargo run --features miseledger -- links "dispatch" --json
 ```
 
+### MiseLedger adapter deprecation
+
+The direct `miseledger` Cargo feature, `graphtrail context --evidence`, and `graphtrail links` are deprecated but remain functional. Use Brigade for structured composition instead:
+
+```bash
+brigade code sync .
+brigade code context "rate limiting" --markdown
+brigade code impact dispatch --json
+brigade evidence crawl plan --target .
+brigade evidence search "dispatch"
+brigade evidence search "dispatch" --code-reference '{"schema":"brigade.code-reference.v1","repository":"escoffier-labs/brigade","revision":{"commit":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},"file_path":"src/brigade/receipts_cmd.py","qualified_name":"brigade.receipts_cmd._metadata_with_delta","symbol_kind":"function","source_span":{"start_line":788,"line_count":3}}'
+brigade evidence doctor --target .
+```
+
+An exact code reference is matched before lexical fallback. GraphTrail will keep the direct adapter functional through at least two minor GraphTrail releases or 90 days after the first GraphTrail release containing this deprecation, whichever is longer. Removal cannot occur before that compatibility policy is satisfied. The direct adapter keeps its existing default database resolution and read-only FTS behavior during the compatibility window.
+
 When `codesearch` is enabled, GraphTrail also reads the shared Code Search index
 manifest from `CODE_INDEX_MANIFEST`, `XDG_DATA_HOME/code-index/manifest.json`, or
 `~/.local/share/code-index/manifest.json`. `CODE_SEARCH_URL` still wins when it is

--- a/engines/code-graph/build.rs
+++ b/engines/code-graph/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_MISELEDGER");
+
+    if std::env::var_os("CARGO_FEATURE_MISELEDGER").is_some() {
+        println!(
+            "cargo:warning=GraphTrail's direct MiseLedger adapter is deprecated. Use `brigade code sync`, `brigade code context`, `brigade code impact`, `brigade evidence crawl`, `brigade evidence search`, and `brigade evidence doctor` instead. The adapter remains functional for at least two minor GraphTrail releases or 90 days after the first GraphTrail release containing this deprecation, whichever is longer. It will not be removed before that compatibility policy is satisfied."
+        );
+    }
+}

--- a/engines/code-graph/src/adapters/miseledger.rs
+++ b/engines/code-graph/src/adapters/miseledger.rs
@@ -9,6 +9,13 @@ use anyhow::{Context, Result};
 use rusqlite::{Connection, OpenFlags, params};
 use serde::Serialize;
 
+/// Emitted once by each deprecated CLI command invocation, always on stderr.
+pub const DEPRECATION_WARNING: &str = "warning: GraphTrail's direct MiseLedger adapter is deprecated. Use `brigade code sync`, `brigade code context`, `brigade code impact`, `brigade evidence crawl`, `brigade evidence search`, and `brigade evidence doctor` instead. The adapter remains functional for at least two minor GraphTrail releases or 90 days after the first GraphTrail release containing this deprecation, whichever is longer. It will not be removed before that compatibility policy is satisfied.";
+
+pub fn emit_deprecation_warning() {
+    eprintln!("{DEPRECATION_WARNING}");
+}
+
 #[derive(Debug, Serialize)]
 pub struct EvidenceHit {
     pub item_id: String,

--- a/engines/code-graph/src/cli.rs
+++ b/engines/code-graph/src/cli.rs
@@ -322,6 +322,10 @@ pub fn run(cli: Cli) -> Result<()> {
             #[cfg(feature = "miseledger")]
             evidence,
         } => {
+            #[cfg(feature = "miseledger")]
+            if evidence {
+                crate::adapters::miseledger::emit_deprecation_warning();
+            }
             let db_path = default_query_db_path(cli.db.clone());
             let conn = open_read_only(&db_path)?;
             #[cfg(feature = "codesearch")]
@@ -603,6 +607,7 @@ pub fn run(cli: Cli) -> Result<()> {
         }
         #[cfg(feature = "miseledger")]
         Command::Links { term, limit, json } => {
+            crate::adapters::miseledger::emit_deprecation_warning();
             let db = crate::adapters::miseledger::default_db_path();
             let hits = crate::adapters::miseledger::search_evidence(&db, &term, limit)?;
             if json {

--- a/engines/code-graph/tests/cli_read_only.rs
+++ b/engines/code-graph/tests/cli_read_only.rs
@@ -9,6 +9,9 @@ use std::time::SystemTime;
 use graphtrail::store::{init_schema, open_db, sync_repo};
 use sha2::{Digest, Sha256};
 
+#[cfg(feature = "miseledger")]
+const MISELEDGER_DEPRECATION_WARNING: &str = "warning: GraphTrail's direct MiseLedger adapter is deprecated. Use `brigade code sync`, `brigade code context`, `brigade code impact`, `brigade evidence crawl`, `brigade evidence search`, and `brigade evidence doctor` instead. The adapter remains functional for at least two minor GraphTrail releases or 90 days after the first GraphTrail release containing this deprecation, whichever is longer. It will not be removed before that compatibility policy is satisfied.";
+
 fn graphtrail() -> &'static str {
     env!("CARGO_BIN_EXE_graphtrail")
 }
@@ -47,6 +50,60 @@ def run():
     conn.pragma_update(None, "wal_checkpoint", "TRUNCATE")
         .unwrap();
     drop(conn);
+    db
+}
+
+#[cfg(feature = "miseledger")]
+fn build_miseledger_db(root: &Path) -> PathBuf {
+    let db = root.join("miseledger.db");
+    let conn = rusqlite::Connection::open(&db).unwrap();
+    conn.execute_batch(
+        "CREATE VIRTUAL TABLE item_fts USING fts5(item_id, source_kind, body);\
+         INSERT INTO item_fts (item_id, source_kind, body) VALUES\
+             ('evidence-helper', 'session', 'helper helper');",
+    )
+    .unwrap();
+    conn.pragma_update(None, "wal_checkpoint", "TRUNCATE")
+        .unwrap();
+    db
+}
+
+#[cfg(feature = "miseledger")]
+fn build_evidence_context_miseledger_db(root: &Path) -> PathBuf {
+    let db = root.join("miseledger.db");
+    let conn = rusqlite::Connection::open(&db).unwrap();
+    conn.execute_batch(
+        "CREATE VIRTUAL TABLE item_fts USING fts5(item_id, source_kind, body);\
+         INSERT INTO item_fts (item_id, source_kind, body) VALUES\
+             ('evidence-task', 'session', 'evidence'),\
+             ('evidence-alpha', 'session', 'evidence_alpha'),\
+             ('evidence-beta', 'session', 'evidence_beta');",
+    )
+    .unwrap();
+    conn.pragma_update(None, "wal_checkpoint", "TRUNCATE")
+        .unwrap();
+    db
+}
+
+#[cfg(feature = "miseledger")]
+fn build_evidence_context_db(root: &Path) -> PathBuf {
+    fs::write(
+        root.join("evidence.py"),
+        r#"
+def evidence_alpha():
+    return 1
+
+def evidence_beta():
+    return evidence_alpha()
+"#,
+    )
+    .unwrap();
+    let db = root.join(".graphtrail").join("graphtrail.db");
+    let conn = open_db(&db).unwrap();
+    init_schema(&conn).unwrap();
+    sync_repo(&conn, root).unwrap();
+    conn.pragma_update(None, "wal_checkpoint", "TRUNCATE")
+        .unwrap();
     db
 }
 
@@ -365,6 +422,147 @@ fn doctor_does_not_mutate_db_or_tree() {
         "doctor mutated the repo tree"
     );
     assert_eq!(before_tree, snapshot_tree(graph_dir.parent().unwrap()));
+}
+
+#[cfg(feature = "miseledger")]
+#[test]
+fn deprecated_miseledger_commands_warn_once_without_changing_json_or_databases() {
+    let graph_dir = tempfile::tempdir().unwrap();
+    let evidence_dir = tempfile::tempdir().unwrap();
+    let links_evidence_dir = tempfile::tempdir().unwrap();
+    let graph_db = build_evidence_context_db(graph_dir.path());
+    let evidence_db = build_evidence_context_miseledger_db(evidence_dir.path());
+    let links_evidence_db = build_miseledger_db(links_evidence_dir.path());
+    let before_graph = snapshot_tree(graph_dir.path());
+    let before_evidence = snapshot_tree(evidence_dir.path());
+    let before_links_evidence = snapshot_tree(links_evidence_dir.path());
+
+    let context_without_evidence = Command::new(graphtrail())
+        .current_dir(graph_dir.path())
+        .args([
+            "--db",
+            &graph_db.display().to_string(),
+            "context",
+            "evidence",
+            "--json",
+        ])
+        .env("MISELEDGER_DB", &evidence_db)
+        .output()
+        .unwrap();
+    assert!(
+        context_without_evidence.status.success(),
+        "context without --evidence failed: {context_without_evidence:?}"
+    );
+    assert!(
+        context_without_evidence.stderr.is_empty(),
+        "context without --evidence warned: {:?}",
+        String::from_utf8_lossy(&context_without_evidence.stderr)
+    );
+
+    let context_with_evidence = Command::new(graphtrail())
+        .current_dir(graph_dir.path())
+        .args([
+            "--db",
+            &graph_db.display().to_string(),
+            "context",
+            "evidence",
+            "--json",
+            "--evidence",
+        ])
+        .env("MISELEDGER_DB", &evidence_db)
+        .output()
+        .unwrap();
+    assert!(
+        context_with_evidence.status.success(),
+        "context with --evidence failed: {context_with_evidence:?}"
+    );
+    assert_eq!(
+        String::from_utf8(context_with_evidence.stderr).unwrap(),
+        format!("{MISELEDGER_DEPRECATION_WARNING}\n")
+    );
+    assert_eq!(
+        context_with_evidence.stdout, context_without_evidence.stdout,
+        "--evidence must not change context JSON output"
+    );
+    let context_json: serde_json::Value =
+        serde_json::from_slice(&context_with_evidence.stdout).unwrap();
+    assert_eq!(context_json["task"], "evidence");
+
+    let context_markdown_with_evidence = Command::new(graphtrail())
+        .current_dir(graph_dir.path())
+        .args([
+            "--db",
+            &graph_db.display().to_string(),
+            "context",
+            "evidence",
+            "--markdown",
+            "--evidence",
+        ])
+        .env("MISELEDGER_DB", &evidence_db)
+        .output()
+        .unwrap();
+    assert!(
+        context_markdown_with_evidence.status.success(),
+        "markdown context with --evidence failed: {context_markdown_with_evidence:?}"
+    );
+    assert_eq!(
+        String::from_utf8(context_markdown_with_evidence.stderr).unwrap(),
+        format!("{MISELEDGER_DEPRECATION_WARNING}\n")
+    );
+    let markdown = String::from_utf8(context_markdown_with_evidence.stdout).unwrap();
+    assert_eq!(markdown.matches("### `").count(), 3, "{markdown}");
+    for expected_link in [
+        "### `evidence`",
+        "- [session] `evidence-task` - [evidence]",
+        "### `evidence_alpha`",
+        "- [session] `evidence-alpha` - [evidence-alpha]",
+        "### `evidence_beta`",
+        "- [session] `evidence-beta` - [evidence-beta]",
+    ] {
+        assert!(markdown.contains(expected_link), "{markdown}");
+    }
+
+    let links = Command::new(graphtrail())
+        .args(["links", "helper", "--json"])
+        .env("MISELEDGER_DB", &links_evidence_db)
+        .output()
+        .unwrap();
+    assert!(links.status.success(), "links failed: {links:?}");
+    assert_eq!(
+        String::from_utf8(links.stderr).unwrap(),
+        format!("{MISELEDGER_DEPRECATION_WARNING}\n")
+    );
+    let links_json: serde_json::Value = serde_json::from_slice(&links.stdout).unwrap();
+    assert_eq!(links_json[0]["item_id"], "evidence-helper");
+
+    assert_eq!(before_graph, snapshot_tree(graph_dir.path()));
+    assert_eq!(before_evidence, snapshot_tree(evidence_dir.path()));
+    assert_eq!(
+        before_links_evidence,
+        snapshot_tree(links_evidence_dir.path())
+    );
+}
+
+#[cfg(not(feature = "miseledger"))]
+#[test]
+fn miseledger_commands_are_unavailable_without_the_feature_and_do_not_warn() {
+    let context_help = Command::new(graphtrail())
+        .args(["context", "--help"])
+        .output()
+        .unwrap();
+    assert!(context_help.status.success(), "{context_help:?}");
+    assert!(
+        !String::from_utf8_lossy(&context_help.stdout).contains("--evidence"),
+        "{context_help:?}"
+    );
+    assert!(context_help.stderr.is_empty(), "{context_help:?}");
+
+    let links = Command::new(graphtrail()).arg("links").output().unwrap();
+    assert!(!links.status.success(), "links unexpectedly succeeded");
+    assert!(
+        !String::from_utf8_lossy(&links.stderr).contains("direct MiseLedger adapter is deprecated"),
+        "miseledger-free build warned: {links:?}"
+    );
 }
 
 #[cfg(all(feature = "codesearch", feature = "miseledger"))]

--- a/engines/code-graph/tests/repository_contract.rs
+++ b/engines/code-graph/tests/repository_contract.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, fs, path::Path};
+use std::{collections::HashSet, fs, path::Path, process::Command};
 
 use serde_json::Value;
 
@@ -188,6 +188,128 @@ fn supported_toolchain_and_agent_workflow_are_documented() {
             "AGENTS.md must document the refresh contract: {required}"
         );
     }
+}
+
+#[test]
+fn miseledger_deprecation_contract_is_build_time_and_documented() {
+    let build_script = repository_file("build.rs");
+    for required in [
+        "CARGO_FEATURE_MISELEDGER",
+        "cargo:rerun-if-env-changed=CARGO_FEATURE_MISELEDGER",
+        "cargo:warning=GraphTrail's direct MiseLedger adapter is deprecated.",
+        "brigade code sync",
+        "brigade code context",
+        "brigade code impact",
+        "brigade evidence crawl",
+        "brigade evidence search",
+        "brigade evidence doctor",
+        "two minor GraphTrail releases or 90 days",
+        "will not be removed before that compatibility policy is satisfied",
+    ] {
+        assert!(
+            build_script.contains(required),
+            "build.rs must preserve the MiseLedger deprecation warning contract: {required}"
+        );
+    }
+
+    let adapter = repository_file("src/adapters/miseledger.rs");
+    for required in [
+        "pub const DEPRECATION_WARNING",
+        "pub fn emit_deprecation_warning()",
+        "eprintln!(\"{DEPRECATION_WARNING}\")",
+        "SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX",
+    ] {
+        assert!(
+            adapter.contains(required),
+            "MiseLedger adapter must preserve: {required}"
+        );
+    }
+
+    for path in ["README.md", "CHANGELOG.md"] {
+        let document = repository_file(path);
+        for required in [
+            "`miseledger` Cargo feature",
+            "`graphtrail context --evidence`",
+            "`graphtrail links`",
+            "brigade code sync",
+            "brigade code context",
+            "brigade code impact",
+            "brigade evidence crawl",
+            "brigade evidence search",
+            "brigade evidence doctor",
+            "--code-reference",
+            "brigade.code-reference.v1",
+            "An exact code reference is matched before lexical fallback.",
+            "two minor GraphTrail releases or 90 days",
+            "Removal cannot occur before",
+        ] {
+            assert!(
+                document.contains(required),
+                "{path} must document the MiseLedger deprecation contract: {required}"
+            );
+        }
+    }
+
+    let manifest = repository_file("Cargo.toml");
+    assert!(
+        manifest.contains("miseledger = []"),
+        "the MiseLedger feature must remain available during the compatibility window"
+    );
+}
+
+#[test]
+fn miseledger_deprecation_warning_requires_the_miseledger_feature() {
+    let target_dir = tempfile::tempdir().unwrap();
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+
+    let without_feature = Command::new(&cargo)
+        .current_dir(manifest_dir)
+        .env(
+            "CARGO_TARGET_DIR",
+            target_dir.path().join("without-feature"),
+        )
+        .args(["check", "--locked", "--no-default-features"])
+        .output()
+        .expect("cargo check without the MiseLedger feature must run");
+    assert!(
+        without_feature.status.success(),
+        "cargo check without the MiseLedger feature failed:\n{}",
+        String::from_utf8_lossy(&without_feature.stderr)
+    );
+    assert!(
+        !String::from_utf8_lossy(&without_feature.stderr)
+            .contains("GraphTrail's direct MiseLedger adapter is deprecated."),
+        "cargo check without the MiseLedger feature emitted the deprecation warning:\n{}",
+        String::from_utf8_lossy(&without_feature.stderr)
+    );
+
+    let with_feature = Command::new(&cargo)
+        .current_dir(manifest_dir)
+        .env(
+            "CARGO_TARGET_DIR",
+            target_dir.path().join("with-miseledger"),
+        )
+        .args([
+            "check",
+            "--locked",
+            "--no-default-features",
+            "--features",
+            "miseledger",
+        ])
+        .output()
+        .expect("cargo check with the MiseLedger feature must run");
+    assert!(
+        with_feature.status.success(),
+        "cargo check with the MiseLedger feature failed:\n{}",
+        String::from_utf8_lossy(&with_feature.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&with_feature.stderr)
+            .contains("GraphTrail's direct MiseLedger adapter is deprecated."),
+        "cargo check with the MiseLedger feature did not emit the deprecation warning:\n{}",
+        String::from_utf8_lossy(&with_feature.stderr)
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #363

## Summary

- emit deprecation warnings when the GraphTrail miseledger feature is compiled and when its direct adapter commands run
- keep the adapter functional and read-only through the two-minor-release or 90-day compatibility window
- document Brigade code and evidence commands as the replacement, including exact code-reference lookup before lexical fallback

## Verification

- full repository gate: 3401 passed, 3 skipped, 82.38%% coverage
- GraphTrail default and all-feature test suites
- clippy with warnings denied
- six feature-matrix cargo checks
- independent Brigade review: approved

No database migration, dependency change, feature removal, standalone release-pipeline change, or Phase 4 work is included.
