### PR TITLE
fix(ci): accept SessionFind command-list help

### DIFF
--- a/scripts/published-artifact-acceptance.py
+++ b/scripts/published-artifact-acceptance.py
@@ -157,7 +157,9 @@ def smoke_managed_components(
 
     run_checked([managed_paths["miseledger"], "version"], runner=runner, env=env)
     sessionfind = run_checked([managed_paths["sessionfind"], "--help"], runner=runner, env=env)
-    if "usage" not in f"{sessionfind.stdout}{sessionfind.stderr}".lower():
+    if "usage" not in f"{sessionfind.stdout}{sessionfind.stderr}".lower() and not any(
+        line.strip().startswith("sessionfind ") for line in sessionfind.stdout.splitlines()
+    ):
         raise AcceptanceError("sessionfind smoke produced no help text")
 
 

--- a/tests/test_published_artifact_acceptance.py
+++ b/tests/test_published_artifact_acceptance.py
@@ -204,6 +204,41 @@ def test_smoke_uses_only_absolute_managed_executables(acceptance_module, tmp_pat
     assert {Path(argv[0]).name for argv in calls} == set(acceptance_module.COMPONENT_IDS)
 
 
+def test_smoke_accepts_sessionfind_command_list_help(acceptance_module, tmp_path):
+    managed_bin = tmp_path / "xdg-data" / "brigade" / "bin"
+    _write_managed_binaries(managed_bin)
+
+    def runner(argv, **kwargs):
+        if Path(argv[0]).name == "graphtrail-mcp":
+            return subprocess.CompletedProcess(argv, 0, '{"jsonrpc":"2.0","id":1,"result":{}}', "")
+        if Path(argv[0]).name == "sessionfind":
+            return subprocess.CompletedProcess(argv, 0, "\n  sessionfind query [PATH]...\n", "")
+        return subprocess.CompletedProcess(argv, 0, "ok", "")
+
+    acceptance_module.smoke_managed_components(
+        {component_id: managed_bin / component_id for component_id in acceptance_module.COMPONENT_IDS},
+        runner=runner,
+    )
+
+
+def test_smoke_rejects_sessionfind_unrelated_success_output(acceptance_module, tmp_path):
+    managed_bin = tmp_path / "xdg-data" / "brigade" / "bin"
+    _write_managed_binaries(managed_bin)
+
+    def runner(argv, **kwargs):
+        if Path(argv[0]).name == "graphtrail-mcp":
+            return subprocess.CompletedProcess(argv, 0, '{"jsonrpc":"2.0","id":1,"result":{}}', "")
+        if Path(argv[0]).name == "sessionfind":
+            return subprocess.CompletedProcess(argv, 0, "commands available", "no help text")
+        return subprocess.CompletedProcess(argv, 0, "ok", "")
+
+    with pytest.raises(acceptance_module.AcceptanceError, match="sessionfind smoke produced no help text"):
+        acceptance_module.smoke_managed_components(
+            {component_id: managed_bin / component_id for component_id in acceptance_module.COMPONENT_IDS},
+            runner=runner,
+        )
+
+
 def test_poison_binary_invocation_is_a_failure(acceptance_module, tmp_path):
     marker = tmp_path / "poison-invoked"
     marker.write_text("graphtrail\n")


### PR DESCRIPTION
## Summary

- align the Unix published-artifact SessionFind smoke predicate with the installer contract
- accept SessionFind 0.6.0 command-list help while retaining the existing usage-form check
- add focused acceptance and rejection regression tests

## Root cause

The release acceptance script was added after the installer had been fixed to accept SessionFind command-list help, but copied the older usage-only predicate. That caused the v0.24.0 Ubuntu published-artifact job to reject a healthy managed binary.

## Verification

- focused tests: 15 passed
- full repository gate: 3403 passed, 3 skipped, 82.38%% coverage
- live published artifact: brigade-cli 0.24.0 acceptance completed successfully

No component version, dependency, database, release metadata, product surface, or Phase 4 change is included.
