### PR TITLE
fix(guard): scope agent coauthor trailers

### DIFF
--- a/src/brigade/cli/release.py
+++ b/src/brigade/cli/release.py
@@ -132,6 +132,10 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_release_candidate_plan.add_argument(
         "--base-ref", default="origin/main", help="Base ref for changed files and release notes."
     )
+    p_release_candidate_plan.add_argument(
+        "--guard-policy",
+        help="Bundled guard policy name or path used to sanitize commit messages (default: public-repo).",
+    )
     p_release_candidate_plan.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
     p_release_candidate_build = release_candidate_sub.add_parser(
         "build", help="Build a local release candidate bundle."
@@ -141,6 +145,10 @@ def register(sub: argparse._SubParsersAction) -> None:
     )
     p_release_candidate_build.add_argument(
         "--base-ref", default="origin/main", help="Base ref for changed files and release notes."
+    )
+    p_release_candidate_build.add_argument(
+        "--guard-policy",
+        help="Bundled guard policy name or path used to sanitize commit messages (default: public-repo).",
     )
     p_release_candidate_build.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
     p_release_candidate_list = release_candidate_sub.add_parser("list", help="List local release candidate bundles.")
@@ -263,9 +271,19 @@ def dispatch(args) -> int:
         return 2
     if args.release_command == "candidate":
         if args.release_candidate_command == "plan":
-            return release_cmd.candidate_plan(target=args.target, base_ref=args.base_ref, json_output=args.json)
+            return release_cmd.candidate_plan(
+                target=args.target,
+                base_ref=args.base_ref,
+                guard_policy=args.guard_policy,
+                json_output=args.json,
+            )
         if args.release_candidate_command == "build":
-            return release_cmd.candidate_build(target=args.target, base_ref=args.base_ref, json_output=args.json)
+            return release_cmd.candidate_build(
+                target=args.target,
+                base_ref=args.base_ref,
+                guard_policy=args.guard_policy,
+                json_output=args.json,
+            )
         if args.release_candidate_command == "list":
             return release_cmd.candidate_list(target=args.target, limit=args.limit, json_output=args.json)
         if args.release_candidate_command == "show":

--- a/src/brigade/guard/engine.py
+++ b/src/brigade/guard/engine.py
@@ -34,6 +34,10 @@ def scan_text(text: str, policy: Policy | None = None, options: ScanOptions | No
             start, end = match.span()
             if start == end:
                 continue
+            if rule.id == "email" and active_policy.allows_agent_coauthor_email(
+                match.group(0), _line_at(text, start, end)
+            ):
+                continue
             if _inside_ranges(start, end, skipped_ranges):
                 continue
             if _overlaps(start, end, occupied):
@@ -190,6 +194,12 @@ def _line_starts(text: str) -> list[int]:
     for match in re.finditer("\n", text):
         starts.append(match.end())
     return starts
+
+
+def _line_at(text: str, start: int, end: int) -> str:
+    line_start = text.rfind("\n", 0, start) + 1
+    line_end = text.find("\n", end)
+    return text[line_start:] if line_end == -1 else text[line_start:line_end]
 
 
 def _line_for_offset(starts: list[int], offset: int) -> int:

--- a/src/brigade/guard/policies/in-house-repo.json
+++ b/src/brigade/guard/policies/in-house-repo.json
@@ -1,0 +1,32 @@
+{
+  "_comment": [
+    "Explicit opt-in policy for in-house repository history and release inputs.",
+    "It permits only the approved agent attribution address patterns."
+  ],
+  "name": "in-house-repo",
+  "allow_agent_coauthors": true,
+  "backends": {
+    "opf": {
+      "enabled": false,
+      "action": "warn",
+      "device": "cpu"
+    }
+  },
+  "defaults": {
+    "infrastructure": "block",
+    "secret": "block",
+    "pii": "block",
+    "personal": "block",
+    "business": "block",
+    "attribution": "block",
+    "tooling": "warn"
+  },
+  "rules": {
+    "loopback-ipv4": "warn",
+    "localhost-port": "warn",
+    "localhost-bare": "warn",
+    "port-reference": "warn",
+    "opf-pii": "warn"
+  },
+  "custom_rules": []
+}

--- a/src/brigade/guard/policy.py
+++ b/src/brigade/guard/policy.py
@@ -19,6 +19,15 @@ from .types import Action, Rule
 
 VALID_ACTIONS: set[str] = {"allow", "warn", "redact", "block"}
 
+_AGENT_COAUTHOR_EMAIL = (
+    r"(?:noreply@anthropic\.com|codex@openai\.com|cursoragent@cursor\.com|"
+    r"[0-9]+@users\.noreply\.github\.com)"
+)
+_ALLOWED_AGENT_COAUTHOR_TRAILER = re.compile(
+    rf"^Co-authored-by:\s*[^<\r\n]+<(?P<email>{_AGENT_COAUTHOR_EMAIL})>\s*$", re.IGNORECASE
+)
+_UNAPPROVED_COAUTHOR_TRAILER = rf"^Co-authored-by:\s*(?![^\r\n]*<{_AGENT_COAUTHOR_EMAIL}>\s*\r?$).+(?:\r?\n)?"
+
 
 # Per-rule action defaults that override category-level defaults. Each entry
 # represents "this rule should default to X unless the user's policy.rules map
@@ -69,6 +78,10 @@ class Policy:
     # inline marker can exist. Keep personal or environment-specific values in
     # a private policy file, never in a shipped public default policy.
     allow_values: list[str] = field(default_factory=list)
+    # In-house commit and repository scans may retain only the explicitly
+    # approved agent attribution addresses. Outbound prose policies leave this
+    # disabled, so every co-author trailer is still removed.
+    allow_agent_coauthors: bool = False
     opf_backend: OpfBackendConfig = field(default_factory=OpfBackendConfig)
 
     def action_for(self, rule: Rule) -> Action:
@@ -97,7 +110,30 @@ class Policy:
                     description="Known internal host or IP (policy-defined).",
                 )
             )
-        return [*known_rule, *DEFAULT_RULES, *self.custom_rules]
+        default_rules = list(DEFAULT_RULES)
+        if self.allow_agent_coauthors:
+            default_rules = [
+                Rule(
+                    id=rule.id,
+                    category=rule.category,
+                    pattern=_UNAPPROVED_COAUTHOR_TRAILER,
+                    replacement=rule.replacement,
+                    description=rule.description,
+                    flags=rule.flags,
+                )
+                if rule.id == "coauthored-by-trailer"
+                else rule
+                for rule in default_rules
+            ]
+        coauthor_rules = [rule for rule in default_rules if rule.id == "coauthored-by-trailer"]
+        default_rules = [rule for rule in default_rules if rule.id != "coauthored-by-trailer"]
+        default_rules = [*coauthor_rules, *default_rules]
+        return [*known_rule, *default_rules, *self.custom_rules]
+
+    def allows_agent_coauthor_email(self, email: str, line: str) -> bool:
+        """Allow only the approved bracketed address in an approved trailer."""
+        trailer = _ALLOWED_AGENT_COAUTHOR_TRAILER.fullmatch(line.rstrip("\r\n"))
+        return bool(self.allow_agent_coauthors and trailer and trailer.group("email").casefold() == email.casefold())
 
 
 def _as_action(value: Any, where: str) -> Action:
@@ -145,6 +181,7 @@ def load_policy(path: str | PathLike[str] | Traversable | None) -> Policy:
     custom_rules = [_parse_custom_rule(item, i) for i, item in enumerate(raw.get("custom_rules", []))]
     known_hosts = _parse_known_hosts(raw.get("known_hosts"))
     allow_values = _parse_allow_values(raw.get("allow_values"))
+    allow_agent_coauthors = _parse_allow_agent_coauthors(raw.get("allow_agent_coauthors"))
     opf_backend = _parse_opf_backend(
         raw.get("backends", {}).get("opf") if isinstance(raw.get("backends"), dict) else None
     )
@@ -158,6 +195,7 @@ def load_policy(path: str | PathLike[str] | Traversable | None) -> Policy:
         custom_rules=custom_rules,
         known_hosts=known_hosts,
         allow_values=allow_values,
+        allow_agent_coauthors=allow_agent_coauthors,
         opf_backend=OpfBackendConfig(
             enabled=opf_backend.enabled,
             device=opf_backend.device,
@@ -190,6 +228,14 @@ def _parse_allow_values(raw: Any) -> list[str]:
             raise ValueError(f"allow_values[{i}] must be a non-empty string")
         values.append(entry)
     return values
+
+
+def _parse_allow_agent_coauthors(raw: Any) -> bool:
+    if raw is None:
+        return False
+    if not isinstance(raw, bool):
+        raise ValueError("allow_agent_coauthors must be a boolean")
+    return raw
 
 
 def _parse_custom_rule(item: Any, index: int) -> Rule:

--- a/src/brigade/release_cmd/candidate.py
+++ b/src/brigade/release_cmd/candidate.py
@@ -29,6 +29,8 @@ from .. import (
     tools_cmd,
     work_cmd,
 )
+from ..guard.engine import scan_text
+from ..guard.policy import Policy, default_policy, load_policy
 from ..selection import KNOWN_HARNESSES
 from ..localio import (
     read_json_dict as _read_json,
@@ -52,6 +54,42 @@ def _commit_subjects(target: Path, base_ref: str | None) -> list[str]:
     if result.returncode != 0:
         return []
     return [_release_safe_text(line.strip()) for line in result.stdout.splitlines() if line.strip()]
+
+
+def _commit_messages(target: Path, base_ref: str | None, *, guard_policy: Policy) -> list[str]:
+    args = ["log", "--format=%B%x00"]
+    if base_ref:
+        args.append(f"{base_ref}..HEAD")
+    else:
+        args.extend(["-n", "20"])
+    result = _git(target, *args)
+    if result.returncode != 0:
+        return []
+    messages = []
+    for message in result.stdout.split("\x00"):
+        safe_message = _release_safe_commit_text(message, guard_policy=guard_policy)
+        if safe_message:
+            messages.append(safe_message)
+    return messages
+
+
+def _release_safe_commit_text(message: str, *, guard_policy: Policy) -> str:
+    cleaned = _release_safe_text(message.strip())
+    return scan_text(cleaned, policy=guard_policy).redacted_text.strip()
+
+
+def _load_guard_policy(selection: str | Path | None) -> Policy:
+    if selection is None:
+        return load_policy(default_policy("public-repo.json"))
+
+    path = Path(selection)
+    if path.is_file():
+        return load_policy(path)
+
+    name = str(selection)
+    if not name.endswith(".json"):
+        name = f"{name}.json"
+    return load_policy(default_policy(name))
 
 
 def _changelog_unreleased(path: Path) -> list[str]:
@@ -88,13 +126,14 @@ def _latest_release_or_payload(target: Path, *, base_ref: str | None) -> dict[st
     }
 
 
-def _candidate_payload(target: Path, *, base_ref: str | None) -> dict[str, Any]:
+def _candidate_payload(target: Path, *, base_ref: str | None, guard_policy: str | Path | None = None) -> dict[str, Any]:
     readiness = _latest_release_or_payload(target, base_ref=base_ref)
     evidence = readiness.get("evidence") if isinstance(readiness.get("evidence"), dict) else {}
     git = evidence.get("git") if isinstance(evidence.get("git"), dict) else _git_state(target)
     changed_files = evidence.get("docs", {}).get("changed_files") if isinstance(evidence.get("docs"), dict) else None
     if not isinstance(changed_files, list):
         changed_files = _changed_files(target, base_ref)
+    active_guard_policy = _load_guard_policy(guard_policy)
     return {
         "target": str(target),
         "base_ref": base_ref,
@@ -147,7 +186,9 @@ def _candidate_payload(target: Path, *, base_ref: str | None) -> dict[str, Any]:
         },
         "release_notes_inputs": {
             "changelog_unreleased": _changelog_unreleased(target),
-            "commit_subjects": _commit_subjects(target, base_ref),
+            # Keep the serialized key for release-candidate schema compatibility;
+            # its values now contain full sanitized commit messages.
+            "commit_subjects": _commit_messages(target, base_ref, guard_policy=active_guard_policy),
             "touched_docs": [path for path in changed_files if str(path).startswith("docs/")],
         },
         "command_contract": _command_contract_snapshot(target),
@@ -502,12 +543,18 @@ def schema(*, target: Path, json_output: bool = False) -> int:
     return 0
 
 
-def candidate_plan(*, target: Path, base_ref: str | None = "origin/main", json_output: bool = False) -> int:
+def candidate_plan(
+    *,
+    target: Path,
+    base_ref: str | None = "origin/main",
+    guard_policy: str | Path | None = None,
+    json_output: bool = False,
+) -> int:
     target = target.expanduser().resolve()
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
-    candidate = _candidate_payload(target, base_ref=base_ref)
+    candidate = _candidate_payload(target, base_ref=base_ref, guard_policy=guard_policy)
     candidate.update(
         {
             "candidate_id": "planned",
@@ -532,7 +579,13 @@ def candidate_plan(*, target: Path, base_ref: str | None = "origin/main", json_o
     return 0
 
 
-def candidate_build(*, target: Path, base_ref: str | None = "origin/main", json_output: bool = False) -> int:
+def candidate_build(
+    *,
+    target: Path,
+    base_ref: str | None = "origin/main",
+    guard_policy: str | Path | None = None,
+    json_output: bool = False,
+) -> int:
     target = target.expanduser().resolve()
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
@@ -540,7 +593,7 @@ def candidate_build(*, target: Path, base_ref: str | None = "origin/main", json_
     created = _now()
     candidate_id = f"{created.strftime('%Y%m%d-%H%M%S')}-candidate-{uuid4().hex[:6]}"
     candidate_dir = _release_candidates_root(target) / candidate_id
-    candidate = _candidate_payload(target, base_ref=base_ref)
+    candidate = _candidate_payload(target, base_ref=base_ref, guard_policy=guard_policy)
     candidate.update(
         {
             "candidate_id": candidate_id,

--- a/tests/guard/test_cli.py
+++ b/tests/guard/test_cli.py
@@ -276,6 +276,44 @@ class CliTests(unittest.TestCase):
         self.assertEqual(payload["commits_with_findings"], 1)
         self.assertEqual(payload["commits"][0]["findings"][0]["rule_id"], "coauthored-by-trailer")
 
+    def test_git_commit_scan_blocks_approved_agent_coauthor_trailer_by_default(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
+            subprocess.run(["git", "config", "user.name", "Example User"], cwd=repo, check=True)
+            subprocess.run(["git", "config", "user.email", "user@example"], cwd=repo, check=True)
+            (repo / "README.md").write_text("example\n")
+            subprocess.run(["git", "add", "README.md"], cwd=repo, check=True)
+            subprocess.run(
+                [
+                    "git",
+                    "commit",
+                    "-m",
+                    "feat: example",
+                    "-m",
+                    "Co-authored-by: Codex <codex@openai.com>",
+                ],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            proc = subprocess.run(
+                [sys.executable, "-m", "brigade.guard.git_commits", "--range", "HEAD", "--json"],
+                cwd=repo,
+                env={"PYTHONPATH": str(ROOT / "src")},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        self.assertEqual(proc.returncode, 1)
+        payload = json.loads(proc.stdout)
+        self.assertTrue(payload["blocked"])
+        self.assertEqual(payload["commits_with_findings"], 1)
+        self.assertEqual(payload["commits"][0]["findings"][0]["rule_id"], "coauthored-by-trailer")
+
     def test_git_commit_scan_allows_clean_commit_message(self) -> None:
         with TemporaryDirectory() as tmp:
             repo = Path(tmp)

--- a/tests/guard/test_engine.py
+++ b/tests/guard/test_engine.py
@@ -6,7 +6,9 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from brigade.guard.engine import scan_text
-from brigade.guard.policy import Policy, load_policy
+from brigade.guard.git_commits import _default_commit_policy
+from brigade.guard.git_scan import _default_repo_policy
+from brigade.guard.policy import Policy, default_policy, load_policy
 from brigade.guard.types import Rule, ScanOptions
 
 
@@ -112,6 +114,61 @@ class EngineTests(unittest.TestCase):
         self.assertEqual(result.findings[0].rule_id, "coauthored-by-trailer")
         self.assertTrue(result.blocked)
         self.assertEqual(result.redacted_text, "feat: change\n\n")
+
+    def test_inhouse_policy_allows_only_approved_agent_coauthor_trailers(self) -> None:
+        rejected = "feat: change\n\nCo-authored-by: Example User <person@private.test>\n"
+        inhouse_policy = load_policy(default_policy("in-house-repo.json"))
+
+        rejected_result = scan_text(rejected, policy=inhouse_policy)
+
+        for address in (
+            "noreply@anthropic.com",
+            "codex@openai.com",
+            "cursoragent@cursor.com",
+            "12345@users.noreply.github.com",
+        ):
+            allowed = f"feat: change\n\nCo-authored-by: Agent <{address}>\n"
+            allowed_result = scan_text(allowed, policy=inhouse_policy)
+            self.assertEqual(allowed_result.findings, [])
+            self.assertEqual(allowed_result.redacted_text, allowed)
+
+        outbound_result = scan_text(
+            "feat: change\n\nCo-authored-by: Codex <codex@openai.com>\n",
+            policy=load_policy(default_policy("pr-draft.json")),
+        )
+        self.assertTrue(rejected_result.blocked)
+        self.assertEqual(rejected_result.redacted_text, "feat: change\n\n")
+        self.assertTrue(outbound_result.blocked)
+        self.assertEqual(outbound_result.redacted_text, "feat: change\n\n")
+
+    def test_inhouse_policy_blocks_private_display_email_in_approved_agent_trailer(self) -> None:
+        message = "feat: change\n\nCo-authored-by: secret.person@corp.internal <codex@openai.com>\n"
+        inhouse_policy = load_policy(default_policy("in-house-repo.json"))
+
+        result = scan_text(message, policy=inhouse_policy)
+
+        self.assertEqual(
+            [(finding.rule_id, finding.match) for finding in result.findings],
+            [("email", "secret.person@corp.internal")],
+        )
+        self.assertTrue(result.blocked)
+        self.assertEqual(
+            result.redacted_text,
+            "feat: change\n\nCo-authored-by: <PRIVATE_EMAIL> <codex@openai.com>\n",
+        )
+
+    def test_external_defaults_strip_approved_agent_coauthor_trailers(self) -> None:
+        message = "feat: change\n\nCo-authored-by: Codex <codex@openai.com>\n"
+        policies = (
+            load_policy(default_policy("public-repo.json")),
+            _default_commit_policy(),
+            _default_repo_policy(),
+        )
+
+        for policy in policies:
+            result = scan_text(message, policy=policy)
+            self.assertTrue(result.blocked)
+            self.assertEqual(result.redacted_text, "feat: change\n\n")
 
     def test_policy_can_enable_opf_backend(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_release_cmd.py
+++ b/tests/test_release_cmd.py
@@ -449,8 +449,40 @@ def test_release_cli(tmp_path, monkeypatch):
     assert cli.main(["release", "runs", "--target", str(tmp_path), "--limit", "3", "--json"]) == 0
     assert cli.main(["release", "show", "latest", "--target", str(tmp_path), "--json"]) == 0
     assert cli.main(["release", "schema", "--target", str(tmp_path), "--json"]) == 0
-    assert cli.main(["release", "candidate", "plan", "--target", str(tmp_path), "--base-ref", "main", "--json"]) == 0
-    assert cli.main(["release", "candidate", "build", "--target", str(tmp_path), "--base-ref", "main", "--json"]) == 0
+    assert (
+        cli.main(
+            [
+                "release",
+                "candidate",
+                "plan",
+                "--target",
+                str(tmp_path),
+                "--base-ref",
+                "main",
+                "--guard-policy",
+                "in-house-repo",
+                "--json",
+            ]
+        )
+        == 0
+    )
+    assert (
+        cli.main(
+            [
+                "release",
+                "candidate",
+                "build",
+                "--target",
+                str(tmp_path),
+                "--base-ref",
+                "main",
+                "--guard-policy",
+                "in-house-repo",
+                "--json",
+            ]
+        )
+        == 0
+    )
     assert cli.main(["release", "candidate", "list", "--target", str(tmp_path), "--limit", "4", "--json"]) == 0
     assert cli.main(["release", "candidate", "show", "latest", "--target", str(tmp_path), "--json"]) == 0
     assert cli.main(["release", "candidate", "archive", "latest", "--target", str(tmp_path), "--json"]) == 0
@@ -466,8 +498,14 @@ def test_release_cli(tmp_path, monkeypatch):
         ("runs", {"target": tmp_path, "limit": 3, "json_output": True}),
         ("show", {"target": tmp_path, "run_id": "latest", "json_output": True}),
         ("schema", {"target": tmp_path, "json_output": True}),
-        ("candidate_plan", {"target": tmp_path, "base_ref": "main", "json_output": True}),
-        ("candidate_build", {"target": tmp_path, "base_ref": "main", "json_output": True}),
+        (
+            "candidate_plan",
+            {"target": tmp_path, "base_ref": "main", "guard_policy": "in-house-repo", "json_output": True},
+        ),
+        (
+            "candidate_build",
+            {"target": tmp_path, "base_ref": "main", "guard_policy": "in-house-repo", "json_output": True},
+        ),
         ("candidate_list", {"target": tmp_path, "limit": 4, "json_output": True}),
         ("candidate_show", {"target": tmp_path, "candidate_id": "latest", "json_output": True}),
         ("candidate_archive", {"target": tmp_path, "candidate_id": "latest", "json_output": True}),
@@ -763,11 +801,38 @@ def test_release_candidate_notes_and_publish_plan(tmp_path, monkeypatch, capsys)
     (docs / "release-candidates.md").write_text("docs\n")
     subprocess.run(["git", "add", "CHANGELOG.md", "docs/release-candidates.md"], cwd=tmp_path, check=True)
     subprocess.run(
-        ["git", "commit", "-m", "add release candidate docs"], cwd=tmp_path, check=True, stdout=subprocess.DEVNULL
+        [
+            "git",
+            "commit",
+            "-m",
+            "add release candidate docs",
+            "-m",
+            "Co-authored-by: Codex <codex@openai.com>",
+        ],
+        cwd=tmp_path,
+        check=True,
+        stdout=subprocess.DEVNULL,
     )
 
     assert release_cmd.run(target=tmp_path, base_ref="HEAD~1", json_output=True) == 0
     capsys.readouterr()
+    inhouse_policy_path = (
+        Path(__file__).resolve().parents[1] / "src" / "brigade" / "guard" / "policies" / "in-house-repo.json"
+    )
+    assert (
+        release_cmd.candidate_plan(
+            target=tmp_path,
+            base_ref="HEAD~1",
+            guard_policy=inhouse_policy_path,
+            json_output=True,
+        )
+        == 0
+    )
+    plan_payload = json.loads(capsys.readouterr().out)
+    assert plan_payload["release_notes_inputs"]["commit_subjects"] == [
+        "add release candidate docs\n\nCo-authored-by: Codex <codex@openai.com>"
+    ]
+
     assert release_cmd.candidate_build(target=tmp_path, base_ref="HEAD~1", json_output=True) == 0
     candidate = json.loads(capsys.readouterr().out)
     candidate_dir = Path(candidate["path"])
@@ -776,11 +841,25 @@ def test_release_candidate_notes_and_publish_plan(tmp_path, monkeypatch, capsys)
 
     assert "Add release candidate bundles." in notes
     assert "add release candidate docs" in notes
+    assert "Co-authored-by:" not in notes
     assert "`docs/release-candidates.md`" in notes
     assert "Manual-only remote step" in plan
     assert "git tag <version>" in plan
     assert "git push origin" in plan
     assert "gh release create <version>" in plan
+
+    assert (
+        release_cmd.candidate_build(
+            target=tmp_path,
+            base_ref="HEAD~1",
+            guard_policy="in-house-repo",
+            json_output=True,
+        )
+        == 0
+    )
+    inhouse_candidate = json.loads(capsys.readouterr().out)
+    inhouse_notes = Path(inhouse_candidate["path"], "RELEASE_NOTES_DRAFT.md").read_text()
+    assert "Co-authored-by: Codex <codex@openai.com>" in inhouse_notes
 
 
 def test_release_candidate_health_warnings(tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
## Summary

- add an explicit `in-house-repo` guard policy for approved agent attribution addresses
- keep default, external repository, and outbound prose policies strict
- preserve allowed trailers in release candidates when `--guard-policy in-house-repo` is selected
- keep private emails in trailer display names covered by PII scanning

## Verification

- `brigade work verify run --target . --command "./scripts/verify" --capture brigade-work`
- receipt `20260720-131851-work-verify-93d1f5`
- 3,408 passed, 3 skipped, 82.40% coverage

Closes #386