### PR TITLE
docs(compatibility): add Phase 4A policy

### DIFF
--- a/docs/phase-4a-compatibility-and-archive.md
+++ b/docs/phase-4a-compatibility-and-archive.md
@@ -1,0 +1,179 @@
+# Phase 4A Compatibility Policy and Phase 4B Archive Checklist
+
+> **Status: Phase 4A policy is active. Phase 4B archival execution is not authorized.**
+
+Phase 4A and Phase 4B are this policy's execution split within RFC Phase 4.
+This policy records the planned compatibility window for the unified Brigade
+release. The window has not started because v0.25.0 is not yet a live release.
+It does not authorize, execute, or claim completion of any archival step. Phase
+4B requires the gates and checklist below.
+
+## Scope and references
+
+This policy implements the release and repository-retirement boundaries from
+[RFC #352](https://github.com/escoffier-labs/brigade/issues/352), the Phase 4
+release work in [#364](https://github.com/escoffier-labs/brigade/issues/364),
+and [#365](https://github.com/escoffier-labs/brigade/issues/365). The public
+release record is the [Brigade releases page](https://github.com/escoffier-labs/brigade/releases).
+
+The Phase 2 [import source-of-truth policy
+context](https://github.com/escoffier-labs/brigade/issues/352#issuecomment-5018303485)
+documents the interim import-history, commit-map, and authorship context.
+Those records remain anchored to the standalone mirrors; the comment neither
+sets nor governs a binding boundary. The governing Phase 3 [no-rewrite
+amendment](https://github.com/escoffier-labs/brigade/issues/352#issuecomment-5019220456)
+is the authority that prohibits rewriting or force-pushing their `master`
+branches. The mirrors are
+[escoffier-labs/graphtrail](https://github.com/escoffier-labs/graphtrail) and
+[escoffier-labs/miseledger](https://github.com/escoffier-labs/miseledger).
+
+Agent Pantry is out of scope. agent-notify/#366 is out of scope. Neither
+repository is part of this compatibility policy, source-history migration, or
+future archive checklist.
+
+## Release record and dual gate
+
+| Record | Value |
+| --- | --- |
+| Planned first unified compatibility-bearing minor | v0.25.0 |
+| Planned publication date | 2026-07-20 |
+| Conditional 90-day calendar gate | 2026-10-18, only if v0.25.0 publishes on 2026-07-20 |
+| Second compatibility-bearing minor | v0.26.0 |
+| Earliest removal or archival release | v0.27.0 |
+| T0 | The actual published date shown on the Brigade release page, once v0.25.0 is live |
+| Current status | The compatibility window has not started. Phase 4B archival execution is not authorized |
+
+v0.25.0 is the planned first compatibility-bearing unified minor. v0.26.0 is
+the second. The release page's actual published date is T0. The compatibility
+window begins only when that live release exists. If v0.25.0 publishes on
+2026-07-20, the conditional calendar gate is 2026-10-18. If publication occurs
+on a date other than 2026-07-20, recompute T0 + 90 days before treating any
+calendar date as valid.
+
+Removal or archival may first ship in v0.27.0, and only after the actual
+calendar gate of T0 + 90 days. Both the version gate and the calendar gate must
+be satisfied.
+
+If v0.27.0 ships before the actual calendar gate, wait for the calendar gate.
+If the actual calendar gate arrives before v0.27.0, wait for the version gate.
+A release date alone does not authorize removal, and a version number alone
+does not authorize archival.
+
+## Compatibility contract
+
+The compatibility window covers these executable shims:
+
+- `graphtrail`
+- `graphtrail-mcp`
+- `miseledger`
+- `sessionfind`
+
+It also covers the `brigade search sync`, `brigade search context`, and
+`brigade search impact` executable aliases for `brigade code sync`,
+`brigade code context`, and `brigade code impact`. Standalone manifest-source
+and independent-install compatibility paths retain their separately documented
+[one-release fallback](update-channels.md).
+
+At T0, the governed operation inventory for each v0.25.0 shim is its public
+subcommands, help behavior, and JSON contracts. For every shipped non-meta
+operation, Phase 4B requires either a behavior-equivalent Brigade-owned path
+or an explicit maintainer decision to retain the shim. An operation without a
+disposition blocks removal.
+
+`--help`, `--version`, and `version` are compatibility probes, not migration
+workflows that require replacement commands. They must remain functional for
+the compatibility window. This includes `sessionfind version`; its probe does
+not imply that it needs a user-workflow replacement command.
+
+| Compatibility invocation | Current compatibility-equivalent engine command |
+| --- | --- |
+| `sessionfind list` | `miseledger sessions list` |
+| `sessionfind search <query>` | `miseledger sessions search <query>` |
+| `sessionfind <query>` | `miseledger sessions search <query>` |
+
+The `miseledger sessions list` and `miseledger sessions search` entries are
+current compatibility-equivalent engine commands, not final Brigade-owned
+replacements. Because `miseledger` is in the same shim cohort as `sessionfind`,
+`sessionfind` is not removal-ready until a Brigade-owned session list/search
+facade exists, tests prove equivalent filters and JSON behavior, and its
+deprecation message names that Brigade command. A missing Brigade-owned session
+facade blocks Phase 4B.
+
+`brigade setup` is the distribution replacement command for `graphtrail-mcp`.
+It installs the Brigade-managed `graphtrail-mcp` binary. MCP clients retain the
+`graphtrail-mcp` protocol but must move their configuration to the managed
+absolute path. The `graphtrail-mcp` deprecation message must name `brigade
+setup`, the managed-path configuration change, and the earliest removal
+condition: v0.27.0 after the actual T0 + 90-day calendar gate, with both the
+version gate and the calendar gate satisfied.
+
+For each shipped non-meta operation, Phase 4B requires either a
+behavior-equivalent Brigade-owned path or an explicit maintainer decision to
+retain the shim. Any operation without that disposition blocks removal.
+
+Existing databases, data paths, and schemas are non-destructive invariants.
+No compatibility action may relocate, delete, or migrate an existing database
+or data path destructively.
+
+Each deprecation message must name the replacement command and state the
+earliest removal condition: v0.27.0 after the actual T0 + 90-day calendar gate,
+with both the version gate and the calendar gate satisfied. For code-graph
+invocations, name the applicable `brigade code sync`, `brigade code context`,
+or `brigade code impact` command. For MiseLedger-backed evidence invocations,
+name the applicable `brigade evidence crawl`, `brigade evidence search`, or
+`brigade evidence doctor` command. For sessionfind invocations, use the mappings
+above. There are no silent removals.
+
+## Frozen standalone mirrors
+
+The `master` branches of `escoffier-labs/graphtrail` and
+`escoffier-labs/miseledger` must not be rewritten or force-pushed. Their import
+commit maps anchor the source-history migration.
+
+Migration notices are ordinary commits on top of `master`. Security fixes may
+also be ordinary commits during the compatibility window. No feature work
+returns to either mirror.
+
+## GraphTrail crates.io policy
+
+Publish graphtrail 0.5.0 from the Brigade monorepo as the final compatibility
+minor. It must retain working legacy binaries and features and include migration
+warnings. Patch releases during the compatibility window are limited to security
+and release-integrity fixes.
+
+After both gates are satisfied, leave every published crate version unyanked for
+reproducibility. Mark the crate deprecated and maintenance-frozen, remove current
+`cargo install` guidance, and publish no feature releases.
+
+## Future Phase 4B checklist
+
+All unchecked items below describe future work. They are not authorization to
+perform it while Phase 4A is active.
+
+- [ ] Confirm both the version gate and the calendar gate.
+- [ ] Verify every shim and Brigade search alias, including its replacement command and earliest removal message.
+- [ ] Capture the T0 shim operation inventory and disposition every shipped non-meta operation with a behavior-equivalent Brigade-owned path or an explicit maintainer decision to retain the shim.
+- [ ] Build and verify the Brigade-owned session list/search facade, including equivalent filters and JSON behavior, then name it in the `sessionfind` deprecation message.
+- [ ] Migrate `graphtrail-mcp` MCP client configuration to the Brigade-managed absolute path installed by `brigade setup`, and verify its deprecation message.
+- [ ] Audit and migrate Brigade-generated MCP configs, including `src/brigade/cursor_user_cmd.py`, from PATH-based `graphtrail-mcp` and `miseledger` commands to managed absolute paths.
+- [ ] Audit, transfer, or close remaining issues with links to [#364](https://github.com/escoffier-labs/brigade/issues/364) and [#365](https://github.com/escoffier-labs/brigade/issues/365).
+- [ ] Publish and verify the final `graphtrail` 0.5.0 compatibility release.
+- [ ] Confirm migration notices as ordinary commits on both mirrors.
+- [ ] Verify that neither standalone `master` branch was rewritten or force-pushed.
+- [ ] Update product and documentation links to the Brigade release path.
+- [ ] Capture final release and acceptance evidence.
+- [ ] Obtain maintainer approval for Phase 4B execution.
+- [ ] Archive `escoffier-labs/graphtrail` (prohibited during Phase 4A).
+- [ ] Archive `escoffier-labs/miseledger` (prohibited during Phase 4A).
+
+## Stop and rollback conditions
+
+Stop Phase 4B before archival if either dual gate is unmet, a shim or alias
+lacks its required message, a data-path or schema invariant is at risk, the
+final crate release is not verified, a migration notice is missing, or
+maintainer approval is absent.
+
+If a pre-archive compatibility problem appears, keep the mirrors active and
+repair it with an ordinary commit or a security/release-integrity patch as
+applicable. Do not rewrite standalone `master`, do not force-push, and do not
+archive either repository until every Phase 4B checklist item is complete.

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -1,3 +1,4 @@
+from datetime import date, timedelta
 from pathlib import Path
 
 from brigade import __version__
@@ -58,3 +59,91 @@ def test_repo_memory_handoff_template_matches_agents_guidance():
         "## Recommended memory action",
     ):
         assert heading in text
+
+
+def test_phase_4a_compatibility_and_archive_policy_is_tracked():
+    path = ROOT / "docs" / "phase-4a-compatibility-and-archive.md"
+    planned_date = date(2026, 7, 20)
+    conditional_gate = date(2026, 10, 18)
+
+    assert path.is_file()
+    text = path.read_text()
+    policy_text = " ".join(text.split())
+
+    for expected in (
+        "v0.25.0",
+        "v0.27.0",
+        "both the version gate and the calendar gate",
+        "v0.26.0",
+        "Phase 4A and Phase 4B are this policy's execution split within RFC Phase 4",
+        "The compatibility window has not started",
+        "If publication occurs on a date other than 2026-07-20, recompute T0 + 90 days",
+        "The release page's actual published date is T0",
+        "recompute T0 + 90 days",
+        "A release date alone does not authorize removal, and a version number alone does not authorize archival.",
+        "`graphtrail`",
+        "`graphtrail-mcp`",
+        "`miseledger`",
+        "`sessionfind`",
+        "`brigade search sync`",
+        "`brigade search context`",
+        "`brigade search impact`",
+        "`brigade code sync`",
+        "`brigade code context`",
+        "`brigade code impact`",
+        "[one-release fallback](update-channels.md)",
+        "At T0, the governed operation inventory for each v0.25.0 shim is its public subcommands, help behavior, and JSON contracts.",
+        "For every shipped non-meta operation, Phase 4B requires either a behavior-equivalent Brigade-owned path or an explicit maintainer decision to retain the shim.",
+        "An operation without a disposition blocks removal.",
+        "`--help`, `--version`, and `version` are compatibility probes, not migration workflows that require replacement commands.",
+        "They must remain functional for the compatibility window.",
+        "This includes `sessionfind version`; its probe does not imply that it needs a user-workflow replacement command.",
+        "must not be rewritten or force-pushed",
+        "No feature work returns to either mirror.",
+        "documents the interim import-history, commit-map, and authorship context",
+        "Agent Pantry is out of scope.",
+        "Publish graphtrail 0.5.0 from the Brigade monorepo as the final compatibility minor.",
+        "Patch releases during the compatibility window are limited to security and release-integrity fixes.",
+        "unyanked",
+        "deprecated and maintenance-frozen",
+        "Phase 4B archival execution is not authorized",
+        "escoffier-labs/graphtrail",
+        "escoffier-labs/miseledger",
+        "agent-notify/#366 is out of scope",
+        "https://github.com/escoffier-labs/brigade/issues/352#issuecomment-5018303485",
+        "https://github.com/escoffier-labs/brigade/issues/352#issuecomment-5019220456",
+        "https://github.com/escoffier-labs/brigade/issues/364",
+        "https://github.com/escoffier-labs/brigade/issues/365",
+        "`sessionfind list` | `miseledger sessions list`",
+        "`sessionfind search <query>` | `miseledger sessions search <query>`",
+        "`sessionfind <query>` | `miseledger sessions search <query>`",
+        "| Compatibility invocation | Current compatibility-equivalent engine command |",
+        "current compatibility-equivalent engine commands, not final Brigade-owned replacements.",
+        "Because `miseledger` is in the same shim cohort as `sessionfind`,",
+        "`sessionfind` is not removal-ready until a Brigade-owned session list/search facade exists",
+        "tests prove equivalent filters and JSON behavior",
+        "deprecation message names that Brigade command.",
+        "A missing Brigade-owned session facade blocks Phase 4B.",
+        "`brigade setup` is the distribution replacement command for `graphtrail-mcp`.",
+        "It installs the Brigade-managed `graphtrail-mcp` binary.",
+        "MCP clients retain the `graphtrail-mcp` protocol but must move their configuration to the managed absolute path.",
+        "The `graphtrail-mcp` deprecation message must name `brigade setup`, the managed-path configuration change, and the earliest removal condition",
+        "- [ ] Confirm both the version gate and the calendar gate",
+        "- [ ] Capture the T0 shim operation inventory and disposition every shipped non-meta operation with a behavior-equivalent Brigade-owned path or an explicit maintainer decision to retain the shim.",
+        "- [ ] Build and verify the Brigade-owned session list/search facade, including equivalent filters and JSON behavior, then name it in the `sessionfind` deprecation message.",
+        "- [ ] Migrate `graphtrail-mcp` MCP client configuration to the Brigade-managed absolute path installed by `brigade setup`, and verify its deprecation message.",
+        "- [ ] Audit and migrate Brigade-generated MCP configs, including `src/brigade/cursor_user_cmd.py`, from PATH-based `graphtrail-mcp` and `miseledger` commands to managed absolute paths.",
+        "- [ ] Archive `escoffier-labs/graphtrail` (prohibited during Phase 4A)",
+        "- [ ] Archive `escoffier-labs/miseledger` (prohibited during Phase 4A)",
+    ):
+        assert expected in policy_text
+
+    assert f"| Planned publication date | {planned_date.isoformat()} |" in text
+    assert (
+        "| Conditional 90-day calendar gate | "
+        f"{conditional_gate.isoformat()}, only if v0.25.0 publishes on "
+        f"{planned_date.isoformat()} |"
+    ) in text
+    assert conditional_gate == planned_date + timedelta(days=90)
+    assert "- [x]" not in text.lower()
+    assert text.count("- [ ]") == 15


### PR DESCRIPTION
## Summary

- Record the Phase 4A compatibility policy and its planned v0.25.0 release anchor.
- Define T0 as the actual GitHub release publication date and require both the v0.27.0 version gate and the T0 + 90-day calendar gate.
- Preserve the standalone mirror histories, define the GraphTrail crate policy, and document shim replacement blockers.
- Add a 15-item Phase 4B checklist with every item unchecked and both archive actions explicitly prohibited during Phase 4A.
- Lock the release clock, no-rewrite rule, replacement paths, scope exclusions, and unchecked checklist in a tracked policy test.

## Release status

v0.25.0 is planned but is not yet published. This change does not start the compatibility clock. T0 remains the actual publication date shown on the Brigade release page. If v0.25.0 publishes on a date other than 2026-07-20, the calendar gate must be recomputed as T0 + 90 days.

This PR does not archive a repository, execute a Phase 4B checklist item, or change Agent Pantry or agent-notify/#366.

## Verification

- `./scripts/verify`: 3,488 passed, 3 skipped, 82.41% coverage
- Brigade verification receipt: `20260720-202728-work-verify-d390e6`
- Final independent review: no blocking findings

Refs #352
Refs #365


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added tracking for the Phase 4A compatibility and archive policy.
  * Documented archival rules, shim retention/disposition guidance, command naming/invocation mappings, and planned publication timing.
  * Included a “90-day calendar gate” and updated the policy checklist to reflect remaining work.
* **Tests**
  * Added a release-metadata validation test to ensure the policy document contains the required tracked text and checklist state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->