### PR TITLE
docs: record Phase 4A compatibility window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Native component releases now publish one verified asset set for `brigade setup`, and `brigade update` has explicit `stable` and `beta` update channels. (#364 / #398)
-- The Phase 4A policy documents migration and archive gates for GraphTrail, GraphTrail MCP, MiseLedger, and SessionFind. The compatibility window has not started, and the policy does not authorize archival. (#399)
+- The Phase 4A policy documents migration and archive gates for GraphTrail, GraphTrail MCP, MiseLedger, and SessionFind. The compatibility window is active as of the v0.25.0 publication, and the policy does not authorize archival. (#399)
 
 ### Deprecated
 - GraphTrail's direct `miseledger` Cargo feature, `graphtrail context --evidence`, and `graphtrail links` are deprecated. They remain functional for at least two minor GraphTrail releases or 90 days after the first GraphTrail release containing this deprecation, whichever is longer. Use `brigade code sync`, `brigade code context`, `brigade code impact`, `brigade evidence crawl`, `brigade evidence search`, and `brigade evidence doctor`. (#392)

--- a/docs/phase-4a-compatibility-and-archive.md
+++ b/docs/phase-4a-compatibility-and-archive.md
@@ -3,10 +3,10 @@
 > **Status: Phase 4A policy is active. Phase 4B archival execution is not authorized.**
 
 Phase 4A and Phase 4B are this policy's execution split within RFC Phase 4.
-This policy records the planned compatibility window for the unified Brigade
-release. The window has not started because v0.25.0 is not yet a live release.
-It does not authorize, execute, or claim completion of any archival step. Phase
-4B requires the gates and checklist below.
+This policy records the active compatibility window for the unified Brigade
+release. v0.25.0 is live, so the window began at T0 on
+2026-07-21T00:50:15Z. It does not authorize, execute, or claim completion of
+any archival step. Phase 4B requires the gates and checklist below.
 
 ## Scope and references
 
@@ -35,27 +35,25 @@ future archive checklist.
 
 | Record | Value |
 | --- | --- |
-| Planned first unified compatibility-bearing minor | v0.25.0 |
-| Planned publication date | 2026-07-20 |
-| Conditional 90-day calendar gate | 2026-10-18, only if v0.25.0 publishes on 2026-07-20 |
+| First unified compatibility-bearing minor | v0.25.0 |
+| Published at | 2026-07-21T00:50:15Z |
+| UTC calendar gate | 2026-10-19 |
+| Exact 90-day timestamp | 2026-10-19T00:50:15Z |
 | Second compatibility-bearing minor | v0.26.0 |
-| Earliest removal or archival release | v0.27.0 |
-| T0 | The actual published date shown on the Brigade release page, once v0.25.0 is live |
-| Current status | The compatibility window has not started. Phase 4B archival execution is not authorized |
+| Earliest removal or archival release | v0.27.0, after the calendar gate |
+| T0 | v0.25.0 published at 2026-07-21T00:50:15Z |
+| Current status | The compatibility window is active. Phase 4B archival execution remains unauthorized |
 
-v0.25.0 is the planned first compatibility-bearing unified minor. v0.26.0 is
-the second. The release page's actual published date is T0. The compatibility
-window begins only when that live release exists. If v0.25.0 publishes on
-2026-07-20, the conditional calendar gate is 2026-10-18. If publication occurs
-on a date other than 2026-07-20, recompute T0 + 90 days before treating any
-calendar date as valid.
+v0.25.0 is the first compatibility-bearing unified minor, and v0.26.0 is the
+second. T0 is the live v0.25.0 publication timestamp, 2026-07-21T00:50:15Z.
+The UTC calendar gate date is 2026-10-19. The gate does not open until
+2026-10-19T00:50:15Z.
 
-Removal or archival may first ship in v0.27.0, and only after the actual
-calendar gate of T0 + 90 days. Both the version gate and the calendar gate must
-be satisfied.
+Removal or archival may first ship in v0.27.0 after the calendar gate. Both the
+version gate and the calendar gate must be satisfied.
 
-If v0.27.0 ships before the actual calendar gate, wait for the calendar gate.
-If the actual calendar gate arrives before v0.27.0, wait for the version gate.
+If v0.27.0 ships before the calendar gate, wait for the calendar gate. If the
+calendar gate arrives before v0.27.0, wait for the version gate.
 A release date alone does not authorize removal, and a version number alone
 does not authorize archival.
 

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -69,8 +69,8 @@ def test_repo_memory_handoff_template_matches_agents_guidance():
 
 def test_phase_4a_compatibility_and_archive_policy_is_tracked():
     path = ROOT / "docs" / "phase-4a-compatibility-and-archive.md"
-    planned_date = date(2026, 7, 20)
-    conditional_gate = date(2026, 10, 18)
+    published_date = date(2026, 7, 21)
+    calendar_gate = date(2026, 10, 19)
 
     assert path.is_file()
     text = path.read_text()
@@ -82,10 +82,10 @@ def test_phase_4a_compatibility_and_archive_policy_is_tracked():
         "both the version gate and the calendar gate",
         "v0.26.0",
         "Phase 4A and Phase 4B are this policy's execution split within RFC Phase 4",
-        "The compatibility window has not started",
-        "If publication occurs on a date other than 2026-07-20, recompute T0 + 90 days",
-        "The release page's actual published date is T0",
-        "recompute T0 + 90 days",
+        "v0.25.0 is live, so the window began at T0 on 2026-07-21T00:50:15Z",
+        "Status: Phase 4A policy is active. Phase 4B archival execution is not authorized.",
+        "The UTC calendar gate date is 2026-10-19.",
+        "The gate does not open until 2026-10-19T00:50:15Z.",
         "A release date alone does not authorize removal, and a version number alone does not authorize archival.",
         "`graphtrail`",
         "`graphtrail-mcp`",
@@ -144,12 +144,12 @@ def test_phase_4a_compatibility_and_archive_policy_is_tracked():
     ):
         assert expected in policy_text
 
-    assert f"| Planned publication date | {planned_date.isoformat()} |" in text
+    assert "| Published at | 2026-07-21T00:50:15Z |" in text
+    assert f"| UTC calendar gate | {calendar_gate.isoformat()} |" in text
+    assert "| Exact 90-day timestamp | 2026-10-19T00:50:15Z |" in text
     assert (
-        "| Conditional 90-day calendar gate | "
-        f"{conditional_gate.isoformat()}, only if v0.25.0 publishes on "
-        f"{planned_date.isoformat()} |"
+        "| Current status | The compatibility window is active. Phase 4B archival execution remains unauthorized |"
     ) in text
-    assert conditional_gate == planned_date + timedelta(days=90)
+    assert calendar_gate == published_date + timedelta(days=90)
     assert "- [x]" not in text.lower()
     assert text.count("- [ ]") == 15

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -27,7 +27,7 @@ def test_current_release_has_expected_v025_release_notes():
         "one verified asset set for `brigade setup`",
         "explicit `stable` and `beta` update channels",
         "Phase 4A policy documents migration and archive gates",
-        "The compatibility window has not started",
+        "The compatibility window is active as of the v0.25.0 publication",
         "does not authorize archival",
         "direct `miseledger` Cargo feature",
         "`graphtrail context --evidence`",


### PR DESCRIPTION
## Summary

- Record the v0.25.0 publication timestamp as Phase 4A T0.
- Set the exact 90-day calendar gate and retain v0.27.0 as the earliest two-minor removal or archival release.
- Keep Phase 4B unauthorized and all 15 archival checklist items unchecked.
- Update the release metadata test from the pre-release plan to the live compatibility-window contract.

## Verification

- `./scripts/verify`
- 3,488 tests passed, 3 skipped, with 82.41% coverage.

## Related issues

- #352
- #365 remains open for Phase 4B.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and release-metadata test updates only; no runtime, auth, or archival behavior changes.
> 
> **Overview**
> **Phase 4A is now documented as active** after the unified **v0.25.0** release, with **T0** fixed at **2026-07-21T00:50:15Z** and the **90-day** gate at **2026-10-19T00:50:15Z** (calendar date **2026-10-19**). Planned/pre-release wording in `docs/phase-4a-compatibility-and-archive.md` is replaced with published timestamps, an active-window status, and **v0.27.0** still as the earliest removal/archival release only after both gates.
> 
> The **0.25.0** changelog entry now states the compatibility window is **active** as of that publication and still **does not authorize archival**. `tests/test_release_metadata.py` asserts the new contract (published-at row, exact gate timestamp, active status strings) instead of the old “window has not started” / conditional planned-date expectations; all **15** Phase 4B checklist items remain unchecked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9e131ff8d5371be48e12a9115e1e9f81c99c8dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->