### PR TITLE
fix(components): honor unified release manifests in reports

### DIFF
--- a/src/brigade/component_install.py
+++ b/src/brigade/component_install.py
@@ -778,7 +778,7 @@ def _load_setup_manifest(
             update_cmd.UpdatePaths(Path(roots.data_root), Path(roots.cache_root), Path("unused")), release
         )
         return update_cmd.validate_release_manifest_bytes(release), release
-    except (update_cmd.UpdateError, ExactReleaseManifestError) as exc:
+    except (update_cmd.UpdateError, ExactReleaseManifestError, ValueError) as exc:
         raise ComponentInstallError(f"exact release manifest setup failed: {exc}") from exc
 
 

--- a/src/brigade/component_install.py
+++ b/src/brigade/component_install.py
@@ -52,6 +52,14 @@ class ComponentInstallError(RuntimeError):
     """Raised when a component install step fails verification."""
 
 
+class ExactReleaseManifestError(RuntimeError):
+    """Raised when matching update state cannot provide a verified manifest."""
+
+    def __init__(self, message: str, manifest_path: Path) -> None:
+        super().__init__(message)
+        self.manifest_path = manifest_path
+
+
 _SETUP_ACTIONS: tuple[str, ...] = ("verify-cache", "download", "materialize", "smoke")
 
 
@@ -89,6 +97,51 @@ def resolve_roots(
         cache_root=cache_root_path,
         env=environment,
     )
+
+
+def uses_bundled_compatibility_manifest() -> bool:
+    """Return whether automatic manifest selection starts at the bundled fallback."""
+    bundled_path = templates.template_root() / "components" / "manifest-v1.json"
+    return component_manifest.manifest_path() == bundled_path
+
+
+def load_verified_exact_release_manifest(
+    roots: SetupRoots,
+) -> tuple[component_manifest.ComponentManifest, Path] | None:
+    """Read the current release manifest recorded in update state without mutating it."""
+    from brigade import update_cmd
+
+    state_path = Path(component_paths.update_state_path(roots.data_root))
+    state = update_cmd.load_update_state(state_path)
+    if state is None or state.component_tag != f"v{brigade.__version__}":
+        return None
+
+    cached = Path(component_paths.verified_manifest_path(roots.cache_root, state.component_manifest_sha256))
+    if not cached.is_file():
+        raise ExactReleaseManifestError("cached exact-release manifest is missing", cached)
+    try:
+        cached_bytes = cached.read_bytes()
+    except OSError as exc:
+        raise ExactReleaseManifestError(f"cached exact-release manifest cannot be read: {exc}", cached) from exc
+    if hashlib.sha256(cached_bytes).hexdigest() != state.component_manifest_sha256:
+        raise ExactReleaseManifestError("cached exact-release manifest digest does not match update state", cached)
+
+    release = update_cmd.ResolvedRelease(
+        state.component_release_id,
+        state.component_tag,
+        brigade.__version__,
+        state.component_target_commit,
+        state.component_manifest_url,
+        len(cached_bytes),
+        state.component_manifest_sha256,
+        cached_bytes,
+    )
+    try:
+        return update_cmd.validate_release_manifest_bytes(release), cached
+    except update_cmd.UpdateError as exc:
+        raise ExactReleaseManifestError(str(exc), cached) from exc
+    except ValueError as exc:
+        raise ExactReleaseManifestError(f"cached exact-release manifest is invalid: {exc}", cached) from exc
 
 
 def build_setup_plan(
@@ -707,8 +760,7 @@ def _load_setup_manifest(
     if manifest_source != "auto":
         raise ComponentInstallError("manifest source must be auto or standalone")
 
-    bundled_path = templates.template_root() / "components" / "manifest-v1.json"
-    if component_manifest.manifest_path() != bundled_path:
+    if not uses_bundled_compatibility_manifest():
         return component_manifest.load(), None
 
     from brigade import update_cmd
@@ -716,25 +768,9 @@ def _load_setup_manifest(
     roots = resolve_roots(env=env)
     try:
         if offline:
-            state_path = Path(component_paths.update_state_path(roots.data_root))
-            state = update_cmd.load_update_state(state_path)
-            if state is not None and state.component_tag == f"v{brigade.__version__}":
-                cached = Path(component_paths.verified_manifest_path(roots.cache_root, state.component_manifest_sha256))
-                if cached.is_file():
-                    cached_bytes = cached.read_bytes()
-                    if hashlib.sha256(cached_bytes).hexdigest() != state.component_manifest_sha256:
-                        raise ComponentInstallError("cached exact-release manifest digest does not match update state")
-                    release = update_cmd.ResolvedRelease(
-                        state.component_release_id,
-                        state.component_tag,
-                        brigade.__version__,
-                        state.component_target_commit,
-                        state.component_manifest_url,
-                        len(cached_bytes),
-                        state.component_manifest_sha256,
-                        cached_bytes,
-                    )
-                    return update_cmd.validate_release_manifest_bytes(release), None
+            cached_manifest = load_verified_exact_release_manifest(roots)
+            if cached_manifest is not None:
+                return cached_manifest[0], None
             raise ComponentInstallError("offline setup requires a verified exact-release manifest cache")
 
         release = update_cmd.resolve_release(update_cmd._DefaultHttp(), latest=False, tag=f"v{brigade.__version__}")
@@ -742,7 +778,7 @@ def _load_setup_manifest(
             update_cmd.UpdatePaths(Path(roots.data_root), Path(roots.cache_root), Path("unused")), release
         )
         return update_cmd.validate_release_manifest_bytes(release), release
-    except update_cmd.UpdateError as exc:
+    except (update_cmd.UpdateError, ExactReleaseManifestError) as exc:
         raise ComponentInstallError(f"exact release manifest setup failed: {exc}") from exc
 
 

--- a/src/brigade/component_report.py
+++ b/src/brigade/component_report.py
@@ -280,7 +280,10 @@ def _installed_state_matches_manifest(
         if installed is None:
             return False
         component = manifest.components[component_id]
-        asset = component_manifest.resolve_asset(manifest, component_id, installed_state.platform)
+        try:
+            asset = component_manifest.resolve_asset(manifest, component_id, installed_state.platform)
+        except ValueError:
+            return False
         if (
             installed.component_revision != component.component_revision
             or installed.asset_name != asset.asset_name

--- a/src/brigade/component_report.py
+++ b/src/brigade/component_report.py
@@ -75,31 +75,62 @@ def inspect_components(
 ) -> ComponentReport:
     """Inspect managed native components without mutating user data."""
     environment = dict(env if env is not None else os.environ)
-    manifest_source = manifest_path or component_manifest.manifest_path()
     manifest_unknown: tuple[str, ...] = ()
     manifest_schema_version: int | None = None
     manifest_revision: str | None = None
     manifest_brigade_version: str | None = None
-    manifest: component_manifest.ComponentManifest | None = None
-    try:
-        manifest = component_manifest.load(manifest_path) if manifest_path is not None else component_manifest.load()
-    except ValueError as exc:
-        return _environment_blocked_report(
-            manifest_source=manifest_source,
-            platform_error=str(exc),
-            manifest=None,
-        )
-    manifest_schema_version = manifest.schema_version
-    manifest_revision = manifest.manifest_revision
-    manifest_brigade_version = manifest.brigade_version
-    manifest_unknown = manifest.unknown_component_diagnostics
-
     roots: component_install.SetupRoots | None = None
     environment_error: str | None = None
     try:
         roots = component_install.resolve_roots(env=environment, system=system)
     except ValueError as exc:
         environment_error = str(exc)
+
+    state_path = Path(
+        component_paths.installed_state_path(roots.data_root if roots is not None else _UNAVAILABLE_DATA_ROOT)
+    )
+    installed_state, state_file_status = _read_installed_state(state_path) if roots is not None else (None, "missing")
+
+    manifest_source = manifest_path or component_manifest.manifest_path()
+    manifest: component_manifest.ComponentManifest | None = None
+    try:
+        if manifest_path is not None:
+            manifest = component_manifest.load(manifest_path)
+        elif roots is not None and component_install.uses_bundled_compatibility_manifest():
+            exact_release_manifest = component_install.load_verified_exact_release_manifest(roots)
+            if exact_release_manifest is None:
+                manifest = component_manifest.load()
+            else:
+                manifest, manifest_source = exact_release_manifest
+                if installed_state is not None and not _installed_state_matches_manifest(installed_state, manifest):
+                    manifest = component_manifest.load()
+                    manifest_source = component_manifest.manifest_path()
+        else:
+            manifest = component_manifest.load()
+    except component_install.ExactReleaseManifestError as exc:
+        return _environment_blocked_report(
+            manifest_source=exc.manifest_path,
+            platform_error=str(exc),
+            manifest=None,
+            roots=roots,
+            state_path=state_path,
+            installed_state=installed_state,
+            state_file_status=state_file_status,
+        )
+    except ValueError as exc:
+        return _environment_blocked_report(
+            manifest_source=manifest_source,
+            platform_error=str(exc),
+            manifest=None,
+            roots=roots,
+            state_path=state_path,
+            installed_state=installed_state,
+            state_file_status=state_file_status,
+        )
+    manifest_schema_version = manifest.schema_version
+    manifest_revision = manifest.manifest_revision
+    manifest_brigade_version = manifest.brigade_version
+    manifest_unknown = manifest.unknown_component_diagnostics
 
     platform: str | None = None
     platform_error: str | None = environment_error
@@ -115,10 +146,11 @@ def inspect_components(
             platform_error=platform_error or "component environment is unavailable",
             manifest=manifest,
             manifest_unknown_diagnostics=manifest_unknown,
+            roots=roots,
+            state_path=state_path,
+            installed_state=installed_state,
+            state_file_status=state_file_status,
         )
-
-    state_path = Path(component_paths.installed_state_path(roots.data_root))
-    installed_state, state_file_status = _read_installed_state(state_path)
 
     inspections: list[ComponentInspection] = []
     for component_id in component_manifest.KNOWN_COMPONENT_IDS:
@@ -160,9 +192,14 @@ def _environment_blocked_report(
     platform_error: str,
     manifest: component_manifest.ComponentManifest | None,
     manifest_unknown_diagnostics: tuple[str, ...] = (),
+    roots: component_install.SetupRoots | None = None,
+    state_path: Path | None = None,
+    installed_state: component_state.InstalledState | None = None,
+    state_file_status: STATE_FILE_STATUS = "missing",
 ) -> ComponentReport:
     """Return a read-only unsupported report when roots or manifest cannot be resolved."""
-    state_path = Path(component_paths.installed_state_path(_UNAVAILABLE_DATA_ROOT))
+    report_state_path = state_path or Path(component_paths.installed_state_path(_UNAVAILABLE_DATA_ROOT))
+    data_root = roots.data_root if roots is not None else _UNAVAILABLE_DATA_ROOT
     components = tuple(
         ComponentInspection(
             component_id=component_id,
@@ -171,16 +208,36 @@ def _environment_blocked_report(
             expected_component_revision=(
                 manifest.components[component_id].component_revision if manifest is not None else None
             ),
-            installed_component_revision=None,
+            installed_component_revision=(
+                installed_state.components[component_id].component_revision
+                if installed_state is not None and component_id in installed_state.components
+                else None
+            ),
             expected_asset_name=None,
             expected_byte_size=None,
             expected_sha256=None,
-            installed_asset_name=None,
-            installed_byte_size=None,
-            installed_sha256=None,
-            recorded_executable=None,
+            installed_asset_name=(
+                installed_state.components[component_id].asset_name
+                if installed_state is not None and component_id in installed_state.components
+                else None
+            ),
+            installed_byte_size=(
+                installed_state.components[component_id].byte_size
+                if installed_state is not None and component_id in installed_state.components
+                else None
+            ),
+            installed_sha256=(
+                installed_state.components[component_id].sha256
+                if installed_state is not None and component_id in installed_state.components
+                else None
+            ),
+            recorded_executable=(
+                installed_state.components[component_id].executable
+                if installed_state is not None and component_id in installed_state.components
+                else None
+            ),
             managed_executable_path=component_paths.managed_executable_path(
-                _UNAVAILABLE_DATA_ROOT,
+                data_root,
                 component_id,
             ),
             actual_byte_size=None,
@@ -198,14 +255,41 @@ def _environment_blocked_report(
         platform=None,
         platform_error=platform_error,
         state_schema_version=component_state.SCHEMA_VERSION,
-        installed_state_path=str(state_path),
-        state_file_status="missing",
-        installed_manifest_revision=None,
-        installed_brigade_version=None,
-        installed_platform=None,
+        installed_state_path=str(report_state_path),
+        state_file_status=state_file_status,
+        installed_manifest_revision=installed_state.manifest_revision if installed_state else None,
+        installed_brigade_version=installed_state.brigade_version if installed_state else None,
+        installed_platform=installed_state.platform if installed_state else None,
         manifest_unknown_diagnostics=manifest_unknown_diagnostics,
         components=components,
     )
+
+
+def _installed_state_matches_manifest(
+    installed_state: component_state.InstalledState,
+    manifest: component_manifest.ComponentManifest,
+) -> bool:
+    """Return whether installed components use the manifest's exact recorded coordinates."""
+    if (
+        installed_state.manifest_revision != manifest.manifest_revision
+        or installed_state.brigade_version != manifest.brigade_version
+    ):
+        return False
+    for component_id in component_manifest.KNOWN_COMPONENT_IDS:
+        installed = installed_state.components.get(component_id)
+        if installed is None:
+            return False
+        component = manifest.components[component_id]
+        asset = component_manifest.resolve_asset(manifest, component_id, installed_state.platform)
+        if (
+            installed.component_revision != component.component_revision
+            or installed.asset_name != asset.asset_name
+            or installed.byte_size != asset.byte_size
+            or installed.sha256 != asset.sha256
+            or installed.download_url != asset.download_url
+        ):
+            return False
+    return True
 
 
 def doctor_checks(

--- a/src/brigade/localio.py
+++ b/src/brigade/localio.py
@@ -37,7 +37,7 @@ def read_json_dict(path: Path) -> dict[str, Any] | None:
     """Read a JSON object from path; return None when missing, invalid, or not a dict."""
     try:
         payload = json.loads(path.read_text())
-    except (OSError, json.JSONDecodeError):
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         return None
     return payload if isinstance(payload, dict) else None
 

--- a/tests/test_component_install.py
+++ b/tests/test_component_install.py
@@ -810,6 +810,24 @@ def test_setup_auto_offline_translates_rejected_cached_manifest_update_errors(tm
     assert "Traceback" not in err
 
 
+def test_setup_auto_online_translates_invalid_release_manifest(tmp_path, monkeypatch):
+    env, _release = _prepare_auto_release_setup(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        update_cmd,
+        "validate_release_manifest_bytes",
+        lambda _release: (_ for _ in ()).throw(ValueError("release manifest is invalid")),
+    )
+
+    with pytest.raises(ComponentInstallError, match="exact release manifest setup failed: release manifest is invalid"):
+        component_install._load_setup_manifest(
+            manifest_path=None,
+            manifest_source="auto",
+            offline=False,
+            opener=FakeOpener({}),
+            env=env,
+        )
+
+
 def test_setup_auto_online_translates_manifest_cache_collisions(tmp_path, monkeypatch, capsys):
     env, release = _prepare_auto_release_setup(tmp_path, monkeypatch)
     roots = resolve_roots(env=env, system="linux")

--- a/tests/test_component_report.py
+++ b/tests/test_component_report.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -9,7 +10,16 @@ from pathlib import Path
 import pytest
 
 import brigade
-from brigade import cli, component_manifest, component_paths, component_report, component_state, doctor as doctor_mod
+from brigade import (
+    cli,
+    component_install,
+    component_manifest,
+    component_paths,
+    component_report,
+    component_state,
+    doctor as doctor_mod,
+    update_cmd,
+)
 from brigade.component_install import resolve_roots, setup_native_components
 from brigade.install import install_selection
 from brigade.selection import Selection
@@ -50,11 +60,234 @@ def _managed_paths(env: dict[str, str]) -> dict[str, Path]:
     }
 
 
+def _prepare_unified_release_setup(tmp_path: Path, monkeypatch) -> tuple[dict[str, str], update_cmd.ResolvedRelease]:
+    """Route setup through a cached exact-release manifest fixture."""
+    env = linux_env(tmp_path)
+    bundled = tmp_path / "templates" / "components" / "manifest-v1.json"
+    bundled.parent.mkdir(parents=True)
+    write_test_manifest(bundled, brigade_version=brigade.__version__)
+    manifest_bytes = bundled.read_bytes()
+    release = update_cmd.ResolvedRelease(
+        42,
+        f"v{brigade.__version__}",
+        brigade.__version__,
+        "a" * 40,
+        "https://github.com/escoffier-labs/brigade/releases/download/"
+        f"v{brigade.__version__}/component-manifest-v1.json",
+        len(manifest_bytes),
+        hashlib.sha256(manifest_bytes).hexdigest(),
+        manifest_bytes,
+    )
+    monkeypatch.setattr(component_install.templates, "template_root", lambda: bundled.parents[1])
+    monkeypatch.setattr(component_manifest, "manifest_path", lambda: bundled)
+    monkeypatch.setattr(update_cmd, "resolve_release", lambda *_args, **_kwargs: release)
+    monkeypatch.setattr(
+        update_cmd,
+        "validate_release_manifest_bytes",
+        lambda resolved: component_manifest.load_bytes(resolved.manifest_bytes, source=Path(resolved.manifest_url)),
+    )
+    monkeypatch.setattr(component_manifest, "platform_key", lambda **_kwargs: "linux-amd64")
+    return env, release
+
+
 def test_default_component_report_loads_bundled_compatibility_manifest(tmp_path):
     report = component_report.inspect_components(env=linux_env(tmp_path), system="linux")
 
     assert report.platform_error is None
     assert report.manifest_revision == "2026-07-19"
+
+
+def test_component_report_uses_verified_exact_release_manifest_after_unified_setup(tmp_path, monkeypatch):
+    env, release = _prepare_unified_release_setup(tmp_path, monkeypatch)
+
+    assert setup_native_components(env=env, opener=FakeOpener(all_fixture_payloads())) == 0
+
+    roots = resolve_roots(env=env, system="linux")
+    cached = Path(component_paths.verified_manifest_path(roots.cache_root, release.manifest_sha256))
+    report = component_report.inspect_components(env=env, system="linux")
+
+    assert report.manifest_path == str(cached)
+    assert report.state_file_status == "valid"
+    assert all(component.status == "healthy" for component in report.components)
+
+
+def test_component_report_ignores_stale_release_cache_after_explicit_setup(tmp_path, monkeypatch):
+    env, _release = _prepare_unified_release_setup(tmp_path, monkeypatch)
+    assert setup_native_components(env=env, opener=FakeOpener(all_fixture_payloads())) == 0
+
+    roots = resolve_roots(env=env, system="linux")
+    update_state_path = Path(component_paths.update_state_path(roots.data_root))
+    update_state_before = update_state_path.read_bytes()
+
+    explicit_manifest = tmp_path / "explicit-manifest.json"
+    write_test_manifest(explicit_manifest, brigade_version=brigade.__version__)
+    explicit_data = json.loads(explicit_manifest.read_text())
+    explicit_data["manifest_revision"] = "explicit-revision"
+    explicit_data["components"]["graphtrail"]["component_revision"] = "b" * 40
+    explicit_manifest.write_text(json.dumps(explicit_data))
+    assert (
+        setup_native_components(
+            env=env,
+            manifest_path=explicit_manifest,
+            opener=FakeOpener(all_fixture_payloads()),
+        )
+        == 0
+    )
+
+    report = component_report.inspect_components(env=env, system="linux")
+
+    assert update_state_path.read_bytes() == update_state_before
+    assert report.manifest_path == str(component_manifest.manifest_path())
+    assert report.manifest_revision == "fixture"
+    assert report.installed_manifest_revision == "explicit-revision"
+
+
+def test_component_report_ignores_stale_release_cache_after_explicit_setup_with_only_manifest_revision_changed(
+    tmp_path, monkeypatch
+):
+    env, _release = _prepare_unified_release_setup(tmp_path, monkeypatch)
+    assert setup_native_components(env=env, opener=FakeOpener(all_fixture_payloads())) == 0
+
+    roots = resolve_roots(env=env, system="linux")
+    update_state_path = Path(component_paths.update_state_path(roots.data_root))
+    update_state_before = update_state_path.read_bytes()
+
+    explicit_manifest = tmp_path / "explicit-manifest.json"
+    write_test_manifest(explicit_manifest, brigade_version=brigade.__version__)
+    explicit_data = json.loads(explicit_manifest.read_text())
+    explicit_data["manifest_revision"] = "explicit-revision"
+    explicit_manifest.write_text(json.dumps(explicit_data))
+    assert (
+        setup_native_components(
+            env=env,
+            manifest_path=explicit_manifest,
+            opener=FakeOpener(all_fixture_payloads()),
+        )
+        == 0
+    )
+
+    report = component_report.inspect_components(env=env, system="linux")
+
+    assert update_state_path.read_bytes() == update_state_before
+    assert report.manifest_path == str(component_manifest.manifest_path())
+    assert report.manifest_revision == "fixture"
+    assert report.installed_manifest_revision == "explicit-revision"
+
+
+def test_component_report_without_matching_update_state_uses_standalone_manifest(tmp_path):
+    env = linux_env(tmp_path)
+
+    report = component_report.inspect_components(env=env, system="linux")
+
+    assert report.manifest_path == str(component_manifest.manifest_path())
+    assert report.manifest_revision == "2026-07-19"
+
+
+def test_component_report_reports_tampered_matching_release_manifest_cache(tmp_path, monkeypatch):
+    env, release = _prepare_unified_release_setup(tmp_path, monkeypatch)
+    assert setup_native_components(env=env, opener=FakeOpener(all_fixture_payloads())) == 0
+    roots = resolve_roots(env=env, system="linux")
+    cached = Path(component_paths.verified_manifest_path(roots.cache_root, release.manifest_sha256))
+    cached.write_bytes(cached.read_bytes() + b"\n")
+
+    report = component_report.inspect_components(env=env, system="linux")
+
+    assert report.manifest_path == str(cached)
+    assert report.manifest_schema_version is None
+    assert report.platform_error == "cached exact-release manifest digest does not match update state"
+    assert report.state_file_status == "valid"
+    assert report.installed_manifest_revision == "fixture"
+    assert report.installed_brigade_version == brigade.__version__
+    assert report.installed_platform == "linux-amd64"
+    assert all(component.installed_component_revision is not None for component in report.components)
+    checks = component_report.doctor_checks(env=env, system="linux")
+    assert checks == [
+        (doctor_mod.FAIL, "components: manifest", "cached exact-release manifest digest does not match update state")
+    ]
+
+
+def test_component_report_matching_update_state_missing_cache(tmp_path, monkeypatch):
+    env, release = _prepare_unified_release_setup(tmp_path, monkeypatch)
+    assert setup_native_components(env=env, opener=FakeOpener(all_fixture_payloads())) == 0
+    roots = resolve_roots(env=env, system="linux")
+    cached = Path(component_paths.verified_manifest_path(roots.cache_root, release.manifest_sha256))
+    assert cached.is_file()
+    cached.unlink()
+
+    report = component_report.inspect_components(env=env, system="linux")
+
+    assert report.manifest_path == str(cached)
+    assert report.manifest_schema_version is None
+    assert report.platform_error == "cached exact-release manifest is missing"
+    assert report.state_file_status == "valid"
+    assert report.installed_manifest_revision == "fixture"
+    assert report.installed_brigade_version == brigade.__version__
+    assert report.installed_platform == "linux-amd64"
+    assert all(component.installed_component_revision is not None for component in report.components)
+    checks = component_report.doctor_checks(env=env, system="linux")
+    assert checks == [(doctor_mod.FAIL, "components: manifest", "cached exact-release manifest is missing")]
+
+
+def test_component_report_mismatched_update_tag_falls_back_to_bundled(tmp_path, monkeypatch):
+    env, release = _prepare_unified_release_setup(tmp_path, monkeypatch)
+    assert setup_native_components(env=env, opener=FakeOpener(all_fixture_payloads())) == 0
+
+    roots = resolve_roots(env=env, system="linux")
+    state_path = Path(component_paths.update_state_path(roots.data_root))
+    assert state_path.is_file()
+
+    state = update_cmd.load_update_state(state_path)
+    assert state is not None
+
+    mismatched_state = update_cmd.UpdateState(
+        schema_version=state.schema_version,
+        channel=state.channel,
+        owner=state.owner,
+        cli_coordinate=state.cli_coordinate,
+        component_release_id=state.component_release_id,
+        component_tag="v99.99.99",
+        component_target_commit=state.component_target_commit,
+        component_manifest_url="https://github.com/escoffier-labs/brigade/releases/download/v99.99.99/component-manifest-v1.json",
+        component_manifest_sha256=state.component_manifest_sha256,
+        updated_at=state.updated_at,
+    )
+    update_cmd.write_update_state(state_path, mismatched_state)
+
+    report = component_report.inspect_components(env=env, system="linux")
+
+    assert report.manifest_path == str(component_manifest.manifest_path())
+    assert report.manifest_revision == "fixture"
+
+
+def test_component_report_invalid_utf8_update_state_falls_back_to_bundled(tmp_path, monkeypatch):
+    env, _release = _prepare_unified_release_setup(tmp_path, monkeypatch)
+    assert setup_native_components(env=env, opener=FakeOpener(all_fixture_payloads())) == 0
+
+    roots = resolve_roots(env=env, system="linux")
+    state_path = Path(component_paths.update_state_path(roots.data_root))
+    state_path.write_bytes(b'{"component_tag":"\xff"}')
+
+    report = component_report.inspect_components(env=env, system="linux")
+
+    assert report.manifest_path == str(component_manifest.manifest_path())
+    assert report.manifest_revision == "fixture"
+
+
+def test_component_report_explicit_manifest_path_overrides_matching_state(tmp_path, monkeypatch):
+    env, release = _prepare_unified_release_setup(tmp_path, monkeypatch)
+    assert setup_native_components(env=env, opener=FakeOpener(all_fixture_payloads())) == 0
+
+    explicit_manifest_file = tmp_path / "explicit-manifest.json"
+    write_test_manifest(explicit_manifest_file, brigade_version=brigade.__version__)
+
+    data = json.loads(explicit_manifest_file.read_text())
+    data["manifest_revision"] = "explicit-rev-123"
+    explicit_manifest_file.write_text(json.dumps(data))
+
+    report = component_report.inspect_components(env=env, system="linux", manifest_path=explicit_manifest_file)
+
+    assert report.manifest_path == str(explicit_manifest_file)
+    assert report.manifest_revision == "explicit-rev-123"
 
 
 def _write_healthy_install(env: dict[str, str], manifest_path: Path) -> None:

--- a/tests/test_component_report.py
+++ b/tests/test_component_report.py
@@ -111,6 +111,26 @@ def test_component_report_uses_verified_exact_release_manifest_after_unified_set
     assert all(component.status == "healthy" for component in report.components)
 
 
+def test_component_report_falls_back_when_release_manifest_asset_is_unsupported(tmp_path, monkeypatch):
+    env, _release = _prepare_unified_release_setup(tmp_path, monkeypatch)
+    assert setup_native_components(env=env, opener=FakeOpener(all_fixture_payloads())) == 0
+
+    original_resolve = component_manifest.resolve_asset
+
+    def fake_resolve(manifest, component_id, platform):
+        if manifest.path != component_manifest.manifest_path():
+            raise ValueError("release manifest asset is unsupported")
+        return original_resolve(manifest, component_id, platform)
+
+    monkeypatch.setattr(component_manifest, "resolve_asset", fake_resolve)
+
+    report = component_report.inspect_components(env=env, system="linux")
+
+    assert report.manifest_path == str(component_manifest.manifest_path())
+    assert report.platform_error is None
+    assert all(component.status == "healthy" for component in report.components)
+
+
 def test_component_report_ignores_stale_release_cache_after_explicit_setup(tmp_path, monkeypatch):
     env, _release = _prepare_unified_release_setup(tmp_path, monkeypatch)
     assert setup_native_components(env=env, opener=FakeOpener(all_fixture_payloads())) == 0

--- a/tests/test_localio.py
+++ b/tests/test_localio.py
@@ -10,6 +10,13 @@ import pytest
 from brigade import localio
 
 
+def test_read_json_dict_invalid_utf8_returns_none(tmp_path: Path):
+    path = tmp_path / "invalid-utf8.json"
+    path.write_bytes(b'{"value":"\xff"}')
+
+    assert localio.read_json_dict(path) is None
+
+
 def test_write_json_round_trips_and_is_sorted(tmp_path: Path):
     path = tmp_path / "nested" / "receipt.json"
     localio.write_json(path, {"b": 2, "a": 1})


### PR DESCRIPTION
## Summary

- Share exact-release manifest validation between setup and component reporting.
- Use unified-release expectations only when the installed state matches the Brigade version, manifest revision, component revisions, and asset coordinates.
- Fail closed when the exact-release cache is missing or tampered with while preserving installed-state metadata for diagnosis.
- Keep explicit manifest paths and standalone bundled-manifest fallback behavior.
- Treat invalid non-UTF-8 JSON state as unreadable state instead of crashing.

## Verification

- Full `./scripts/verify` gate passed through Brigade receipt `20260721-042941-work-verify-71c9a8`: 3,498 passed, 3 skipped, 82.41% coverage.
- Focused component, setup, update, and JSON-reader checks passed through receipt `20260721-035423-work-verify-eb6a88`.
- Live v0.25.0 exact-release assertions passed through receipt `20260721-040012-work-verify-ebf7fb`.
- No MiseLedger evidence was returned for these local receipts.

## Independent review

- Usable passes came from Codex, Claude, Kimi K3 through Kimi Code, Gemini, and Ollama.
- The broad run found a stale-update-state contract issue, and a later Codex pass found the non-UTF-8 crash. Both are covered by the final implementation and tests.
- K3 through ClaudeX timed out and is not counted as a completed review.
- A final Claude Opus contract-drift pass reported no blocking findings.
- CodeRabbit and one manual Cursor Bugbot review are requested on this final PR head.

Closes #406

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes manifest selection and verification for setup and doctor/reporting; mistakes could mis-diagnose installs or block offline setup, but behavior is heavily tested and read-only reporting paths fail closed on cache tampering.
> 
> **Overview**
> **Component setup and reporting now share one path for loading a verified exact-release manifest** from update state and the SHA-256–keyed cache (`load_verified_exact_release_manifest`, `uses_bundled_compatibility_manifest`). Setup’s auto/offline bundled flow delegates to that helper; failures surface as `ExactReleaseManifestError` (with the cache path) and are folded into `ComponentInstallError`, including invalid manifest `ValueError`s.
> 
> **`inspect_components` aligns with setup** when the active manifest is the bundled compatibility file: it prefers the cached release manifest only if update state matches the running Brigade version and installed coordinates still match that manifest (`_installed_state_matches_manifest`). Otherwise it falls back to the bundled manifest so stale release cache or explicit installs are not misread. Missing, tampered, or invalid cached manifests **fail closed** with clear errors while **keeping installed-state fields** on blocked reports and doctor output.
> 
> **`read_json_dict`** treats invalid UTF-8 like other unreadable JSON (returns `None`), avoiding crashes on corrupt update state files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0661bcc5deb12e3ab38367ab086cd58079840b71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved offline component setup by validating cached release manifests before use.
  * Reports now provide more accurate installed component details when manifest or environment issues occur.
  * Detects tampered, missing, unreadable, or invalid cached manifests and surfaces clear errors.
  * Handles invalidly encoded state files without crashing.
  * Prevents stale cached data from overriding explicitly selected manifests.

* **Tests**
  * Added coverage for cached manifest validation, fallback behavior, state mismatches, and invalid files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->