### PR TITLE
docs: finish engines-vs-stations reframe below the fold

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ brigade status --target .
 
 GraphTrail and MiseLedger ship from this repository's unified releases. The remaining rows are optional stations with their own repos. For one release, `brigade add evidence`, `brigade add search`, and `brigade add graphtrail` remain compatibility paths for independent installations. They are not required after `brigade setup`.
 
-Station pages: [GraphTrail](https://brigade.tools/graphtrail) · [MiseLedger](https://brigade.tools/miseledger) · [Agent Pantry](https://brigade.tools/agentpantry) · [Content Guard](https://brigade.tools/content-guard) · [Skillet](https://brigade.tools/skillet) · [Token Glace](https://brigade.tools/token-glace). Full station reference (install, profiles, `brigade add`, contract): [docs/station-contract.md](docs/station-contract.md).
+Capability pages: [Code Intelligence](https://brigade.tools/code-intelligence) · [Evidence Memory](https://brigade.tools/evidence-memory). Station pages: [Agent Pantry](https://brigade.tools/agentpantry) · [Content Guard](https://brigade.tools/content-guard) · [Skillet](https://brigade.tools/skillet) · [Token Glace](https://brigade.tools/token-glace). Full station reference (install, profiles, `brigade add`, contract): [docs/station-contract.md](docs/station-contract.md).
 
 ## One MCP catalog, synced into every tool
 
@@ -309,7 +309,7 @@ I run an always-on OpenClaw agent next to daily Codex and Claude Code sessions. 
 - [Security and Content Guard](docs/security.md): scanner policies, handoff guards, import flow.
 - [Handoff promotion](docs/handoff-promotion.md): how notes move toward memory.
 - [Repo fleet](docs/repo-fleet.md) and [Tool catalog](docs/tool-catalog.md).
-- [Station contract](docs/station-contract.md): how `brigade stations verify` checks a sidecar's `station.json` (isolation, manifest rules, exit codes).
+- [Station contract](docs/station-contract.md): how `brigade stations verify` checks a station's `station.json` (isolation, manifest rules, exit codes).
 - [Command inventory](docs/command-inventory.md): every public CLI command.
 - [Maintainers](MAINTAINERS.md), [Governance](GOVERNANCE.md), [Security](SECURITY.md), and [Contributing](CONTRIBUTING.md).
 - [Roadmap](ROADMAP.md) and [roadmap archive](docs/roadmap-archive.md).

--- a/docs/station-contract.md
+++ b/docs/station-contract.md
@@ -1,12 +1,12 @@
 # Stations reference
 
-Brigade is the hub. Most stations wire an optional standalone tool, installed with `brigade add <station>` and health-checked by `brigade status` and `brigade doctor`. Each external tool is its own repo, independently installable, with no library coupling back into Brigade.
+Brigade is the hub. Most stations wire an optional standalone tool, installed with `brigade add <station>` and health-checked by `brigade status` and `brigade doctor`. Each station tool is its own repo, independently installable, with no library coupling back into Brigade. The code-graph and evidence engines are not stations: they live in this repository under `engines/` and are installed by `brigade setup` from the release manifest.
 
 ## Selecting stations
 
-Use `brigade profiles list` to see built-in station bundles and `brigade stations list` to see which stations are selected by the default repo profile before installing any sidecar tools. `brigade stations list --json` also shows each managed tool's machine surfaces: doctor JSON, markdown briefs, summary JSON, and verify commands where the tool supports them.
+Use `brigade profiles list` to see built-in station bundles and `brigade stations list` to see which stations are selected by the default repo profile before installing any station tools. `brigade stations list --json` also shows each managed tool's machine surfaces: doctor JSON, markdown briefs, summary JSON, and verify commands where the tool supports them.
 
-Fresh repo installs use the `repo` profile: core, skills, memory, guard, security, tokens, evidence, and search are selected up front. `brigade init` wires the built-in skills immediately, including `brigade-work` and `ultra-work-scout`, so new Codex users can run the Brigade work loop and broad Scout scoping from the start. External sidecars stay in their own repos and install only when you run `brigade add <station>`.
+Fresh repo installs use the `repo` profile: core, skills, memory, guard, security, tokens, evidence, and search are selected up front. `brigade init` wires the built-in skills immediately, including `brigade-work` and `ultra-work-scout`, so new Codex users can run the Brigade work loop and broad Scout scoping from the start. External stations stay in their own repos and install only when you run `brigade add <station>`.
 
 ## The `brigade add` reference
 
@@ -17,8 +17,8 @@ Fresh repo installs use the `repo` profile: core, skills, memory, guard, securit
 | `tokens` | token-glace | tracks token spend across your harnesses and compacts noisy output |
 | `memory` | bootstrap-doctor (optional); memory maintenance is built in | `brigade memory status|lint|compact` plus memory-care for card freshness |
 | `pantry` | agentpantry (Go sidecar) | plans and health-checks sealed browser-session sync; never starts source/sink |
-| `search` | code-search, graphtrail | local semantic search plus a code-graph CLI for callers, impact, and structural diffs |
-| `evidence` | miseledger (Go sidecar) | explicitly runs local MiseLedger for `brigade evidence crawl|search`; crawl/export plans are review-only, and Brigade neither starts daemons nor uploads data |
+| `search` | code-search; GraphTrail is installed by `brigade setup` | local semantic search plus the code-graph engine for callers, impact, and structural diffs |
+| `evidence` | MiseLedger, the evidence engine installed by `brigade setup` | explicitly runs local MiseLedger for `brigade evidence crawl|search`; crawl/export plans are review-only, and Brigade neither starts daemons nor uploads data |
 
 ## Inspecting a station before install
 


### PR DESCRIPTION
Follow-up to #409, which fixed the tagline, hub paragraph, and table header. This sweeps the remaining framing:

- README station-pages line: capability pages (Code Intelligence, Evidence Memory) listed separately from true station pages; engine product links replaced with the capability URLs
- README docs index: "a sidecar's station.json" -> "a station's station.json"
- docs/station-contract.md: intro now states the engines are not stations (in-repo under engines/, installed by brigade setup); "sidecar tools"/"external sidecars" -> stations; the search and evidence rows stop calling engine binaries sidecars while keeping the brigade add compat-path mechanics intact

Not touched: docs/mcp-sync.md and src/ "sidecar" uses (state-file sense, correct), docs/phase-*.md (historical plan records), docs/wiring-graphtrail-miseledger.md (mechanics only, no framing found).

Merge order: hold until the brigade.tools capability pages ship, since this adds links to /code-intelligence and /evidence-memory. Vale: parity with main on both files (captured receipt in .brigade work log).