### PR TITLE
fix(hooks): reconcile and remove legacy standalone work-loop hooks (#397)

### DIFF
--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -625,7 +625,7 @@ Start-of-day commands:
 - `brigade work brief` shows branch state, active sessions, pending tasks, import counts, latest dogfood run, and the command to continue.
 - `brigade work status` is the quick dashboard for branch state, dogfood readiness, paths, latest run, and extracted next step.
 - `brigade work doctor` checks dogfood config, security config, evidence bundles, Codex CLI, artifact paths, handoff inbox, task acceptance, issue-backed tasks, stale active sessions, ignore coverage, and latest run context.
-- `brigade work hooks install|update|status|uninstall` manages the project-scoped Claude Code work-loop package while preserving foreign settings and hooks. The runtime entrypoint is `brigade work hook-run`; it is called by Claude Code rather than by operators.
+- `brigade work hooks install|update|status|uninstall` manages the project-scoped Claude Code work-loop package while preserving foreign settings and hooks. The runtime entrypoint is `brigade work hook-run`; it is called by Claude Code rather than by operators. The work-loop snapshot fingerprint skips normally-gitignored directories such as model caches, virtualenvs (`.venv`), `__pycache__`, `node_modules`, and generated databases.
 - `brigade work resume` shows the active or latest session, latest dogfood run, extracted next step, and suggested command.
 - `brigade work inbox` groups pending scanner imports by source, kind, priority, age, and acceptance coverage, then suggests plan, promote, dismiss, or run commands.
 - `brigade work backup status` reads local backup health summaries and reports snapshot, check, prune, and restore rehearsal risk without running backup commands.

--- a/src/brigade/claude_hooks/install_cmd.py
+++ b/src/brigade/claude_hooks/install_cmd.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from .. import localio
 from ..config import load_config
-from .package import MANAGED_EVENTS, PACKAGE_ID, PACKAGE_VERSION, is_managed_handler, managed_groups
+from .package import MANAGED_EVENTS, PACKAGE_ID, PACKAGE_VERSION, is_legacy_handler, is_managed_handler, managed_groups
 
 SETTINGS_REL_PATH = Path(".claude/settings.json")
 SIDECAR_REL_PATH = Path(".brigade/claude-hooks.json")
@@ -35,7 +35,12 @@ def _load_settings(path: Path) -> tuple[dict[str, Any] | None, str | None]:
     return payload, None
 
 
-def _without_managed(groups: object, event: str) -> list[object]:
+def _without_managed_or_legacy(groups: object, event: str) -> list[object]:
+    """Drop managed and legacy standalone handlers, preserving genuine foreign hooks.
+
+    Groups that become empty after dropping handlers are removed so install/update
+    reconciliation is idempotent and does not leave stale empty arrays behind.
+    """
     if not isinstance(groups, list):
         return []
     kept: list[object] = []
@@ -47,7 +52,9 @@ def _without_managed(groups: object, event: str) -> list[object]:
         if not isinstance(handlers, list):
             kept.append(group)
             continue
-        foreign = [handler for handler in handlers if not is_managed_handler(handler)]
+        foreign = [
+            handler for handler in handlers if not is_managed_handler(handler) and not is_legacy_handler(handler)
+        ]
         if foreign:
             updated = dict(group)
             updated["hooks"] = foreign
@@ -64,7 +71,7 @@ def _merge_settings(settings: dict[str, Any]) -> dict[str, Any]:
     hooks: dict[str, Any] = dict(existing_hooks)
     specs = managed_groups()
     for event in MANAGED_EVENTS:
-        hooks[event] = _without_managed(hooks.get(event), event) + specs[event]
+        hooks[event] = _without_managed_or_legacy(hooks.get(event), event) + specs[event]
     merged["hooks"] = hooks
     return merged
 
@@ -78,7 +85,7 @@ def _remove_settings(settings: dict[str, Any]) -> dict[str, Any]:
         if event not in MANAGED_EVENTS or not isinstance(groups, list):
             hooks[event] = groups
             continue
-        cleaned = _without_managed(groups, event)
+        cleaned = _without_managed_or_legacy(groups, event)
         if cleaned:
             hooks[event] = cleaned
     if hooks:
@@ -173,6 +180,8 @@ def status_payload(target: Path) -> dict[str, Any]:
     present: list[str] = []
     current_events: list[str] = []
     foreign_count = 0
+    legacy_count = 0
+    legacy_events: list[str] = []
     expected_groups = managed_groups()
     for event, groups in hooks.items():
         managed_signatures: list[str] = []
@@ -184,6 +193,10 @@ def status_payload(target: Path) -> dict[str, Any]:
                 for handler in handlers:
                     if is_managed_handler(handler, event):
                         managed_signatures.append(_managed_signature(group, handler))
+                    elif is_legacy_handler(handler):
+                        legacy_count += 1
+                        if event not in legacy_events:
+                            legacy_events.append(event)
                     else:
                         foreign_count += 1
         if event in MANAGED_EVENTS and managed_signatures:
@@ -201,6 +214,7 @@ def status_payload(target: Path) -> dict[str, Any]:
     ordered_current = [event for event in MANAGED_EVENTS if event in current_events]
     missing = [event for event in MANAGED_EVENTS if event not in ordered_present]
     stale = [event for event in ordered_present if event not in ordered_current]
+    ordered_legacy_events = [event for event in MANAGED_EVENTS if event in legacy_events]
     return {
         "target": str(target),
         "package_id": PACKAGE_ID,
@@ -212,6 +226,8 @@ def status_payload(target: Path) -> dict[str, Any]:
         "missing_events": missing,
         "stale_events": stale,
         "foreign_handler_count": foreign_count,
+        "legacy_handler_count": legacy_count,
+        "legacy_events": ordered_legacy_events,
         "sidecar": sidecar,
         "error": error,
     }
@@ -229,6 +245,7 @@ def hooks_status(*, target: Path, json_output: bool = False) -> int:
         if payload["missing_events"]:
             print(f"missing: {', '.join(payload['missing_events'])}")
         print(f"foreign_handlers: {payload.get('foreign_handler_count', 0)}")
+        print(f"legacy_handlers: {payload.get('legacy_handler_count', 0)}")
         if payload.get("error"):
             print(f"error: {payload['error']}")
     return 2 if payload.get("error") else 0

--- a/src/brigade/claude_hooks/package.py
+++ b/src/brigade/claude_hooks/package.py
@@ -11,6 +11,7 @@ PACKAGE_VERSION = "1.0.0"
 PACKAGE_REF = f"{PACKAGE_ID}@{PACKAGE_VERSION}"
 COMMAND_PREFIX = "brigade work hook-run"
 MANAGED_EVENTS = ("SessionStart", "PreToolUse", "PostToolUse", "PostToolUseFailure", "Stop")
+LEGACY_SCRIPT_NAME = "brigade-work-loop.py"
 
 
 def managed_command(event: str) -> str:
@@ -56,3 +57,44 @@ def is_managed_handler(value: object, event: str | None = None) -> bool:
         and tokens[6].startswith(f"{PACKAGE_ID}@")
         and len(tokens[6]) > len(PACKAGE_ID) + 1
     )
+
+
+def _is_python_interpreter(token: str) -> bool:
+    name = Path(token).name
+    if name in {"python", "python3"}:
+        return True
+    if name.startswith("python3.") and name[8:].isdigit():
+        return True
+    return False
+
+
+def is_legacy_handler(value: object) -> bool:
+    """Identify obsolete standalone Brigade work-loop hook registrations.
+
+    Matches a command-type handler whose command executes the standalone
+    ``brigade-work-loop.py`` script, either directly as the first token or as
+    the first non-flag argument after an explicit Python interpreter. This is
+    anchored to the executable position so unrelated foreign user hooks that
+    merely mention the filename are never touched.
+    """
+    if not isinstance(value, dict):
+        return False
+    if value.get("type") != "command":
+        return False
+    command = value.get("command")
+    if not isinstance(command, str):
+        return False
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return False
+    if not tokens:
+        return False
+    if Path(tokens[0]).name == LEGACY_SCRIPT_NAME:
+        return True
+    if not _is_python_interpreter(tokens[0]):
+        return False
+    for token in tokens[1:]:
+        if not token.startswith("-"):
+            return Path(token).name == LEGACY_SCRIPT_NAME
+    return False

--- a/src/brigade/claude_hooks/package.py
+++ b/src/brigade/claude_hooks/package.py
@@ -34,17 +34,28 @@ def managed_groups() -> dict[str, list[dict[str, Any]]]:
     }
 
 
-def is_managed_handler(value: object, event: str | None = None) -> bool:
+def _command_tokens(value: object) -> list[str] | None:
+    """Shell-split a command-type hook handler's command, or None if it is not one.
+
+    Shared by is_managed_handler and is_legacy_handler so both predicates apply
+    the same tokenization rules.
+    """
     if not isinstance(value, dict):
-        return False
+        return None
     if value.get("type") != "command":
-        return False
+        return None
     command = value.get("command")
     if not isinstance(command, str):
-        return False
+        return None
     try:
-        tokens = shlex.split(command)
+        return shlex.split(command)
     except ValueError:
+        return None
+
+
+def is_managed_handler(value: object, event: str | None = None) -> bool:
+    tokens = _command_tokens(value)
+    if tokens is None:
         return False
     parsed_event = tokens[4] if len(tokens) > 4 else None
     return bool(
@@ -77,17 +88,7 @@ def is_legacy_handler(value: object) -> bool:
     anchored to the executable position so unrelated foreign user hooks that
     merely mention the filename are never touched.
     """
-    if not isinstance(value, dict):
-        return False
-    if value.get("type") != "command":
-        return False
-    command = value.get("command")
-    if not isinstance(command, str):
-        return False
-    try:
-        tokens = shlex.split(command)
-    except ValueError:
-        return False
+    tokens = _command_tokens(value)
     if not tokens:
         return False
     if Path(tokens[0]).name == LEGACY_SCRIPT_NAME:

--- a/src/brigade/claude_hooks/runtime.py
+++ b/src/brigade/claude_hooks/runtime.py
@@ -449,7 +449,7 @@ def _verifier_target_from_command(command: str, cwd: Path, *, depth: int = 0) ->
     return None
 
 
-def _command_candidate_paths(command: str, cwd: Path, *, depth: int = 0) -> list[Path]:
+def _command_candidate_paths(command: str, cwd: Path, *, depth: int = 0, include_cwd: bool = False) -> list[Path]:
     command = _strip_heredoc_bodies(command)
     candidates: list[Path] = []
     tokenized, groups = _command_segment_groups(command)
@@ -459,7 +459,7 @@ def _command_candidate_paths(command: str, cwd: Path, *, depth: int = 0) -> list
         tokens = []
     nested = _nested_shell_script(tokens)
     if nested is not None and depth < 4:
-        candidates.extend(_command_candidate_paths(nested, cwd, depth=depth + 1))
+        candidates.extend(_command_candidate_paths(nested, cwd, depth=depth + 1, include_cwd=include_cwd))
     if tokenized:
         effective = cwd
         for separator, segment in groups:
@@ -474,6 +474,11 @@ def _command_candidate_paths(command: str, cwd: Path, *, depth: int = 0) -> list
     for index, token in enumerate(tokens[:-1]):
         if Path(token).name == "git" and tokens[index + 1] == "-C" and index + 2 < len(tokens):
             candidates.append(_resolve_command_path(tokens[index + 2], cwd))
+    if include_cwd:
+        # Session cwd takes precedence over incidental bare paths so a command
+        # that merely mentions another wired repo (e.g. `rg pattern {other}/file`)
+        # is still attributed to the session repo, not the mentioned path.
+        candidates.append(cwd)
     for token in tokens:
         if token.startswith("-") or token in _SHELL_SEPARATORS:
             continue
@@ -493,6 +498,7 @@ def wired_target_from_payload(payload: dict[str, Any]) -> Path | None:
         cwd = Path(str(payload.get("cwd") or ".")).expanduser().resolve(strict=False)
     except OSError:
         return resolve_wired_target(payload.get("cwd"))
+    has_cwd = bool(payload.get("cwd"))
     tool_name = str(payload.get("tool_name") or "")
     tool_input = _as_tool_input(payload.get("tool_input"))
     if tool_name == "Bash":
@@ -502,7 +508,7 @@ def wired_target_from_payload(payload: dict[str, Any]) -> Path | None:
             wired = resolve_wired_target(str(verifier_target))
             if wired is not None:
                 return wired
-        for candidate in _command_candidate_paths(command, cwd):
+        for candidate in _command_candidate_paths(command, cwd, include_cwd=has_cwd):
             wired = resolve_wired_target(str(candidate))
             if wired is not None:
                 return wired

--- a/src/brigade/doctor.py
+++ b/src/brigade/doctor.py
@@ -70,7 +70,16 @@ def _check_claude_work_loop(target: Path) -> CheckResult | None:
     if payload is None:
         return None
     status = OK if payload["state"] == "enforced" else WARN
-    return (status, "claude work loop", str(payload["detail"]))
+    detail = str(payload["detail"])
+    hooks = payload.get("hooks") or {}
+    legacy_count = hooks.get("legacy_handler_count", 0)
+    if legacy_count:
+        status = WARN
+        detail = (
+            f"{detail}; {legacy_count} legacy hook handler(s) in .claude/settings.json - "
+            f"run `brigade work hooks install --target {target}` to reconcile"
+        )
+    return (status, "claude work loop", detail)
 
 
 def memory_station_checks(ctx: DoctorContext) -> List[CheckResult]:

--- a/tests/test_claude_hooks_doctor.py
+++ b/tests/test_claude_hooks_doctor.py
@@ -220,6 +220,73 @@ def test_doctor_uses_last_write_time_for_receipt_threshold(tmp_path: Path, capsy
     assert "dormant" in check["detail"]
 
 
+def test_status_payload_reports_legacy_handlers(tmp_path: Path):
+    target = _wired(tmp_path)
+    settings = target / ".claude" / "settings.json"
+    payload = json.loads(settings.read_text())
+    payload["hooks"]["SessionStart"] = [
+        {
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "python3 hooks/brigade-work-loop.py --event SessionStart",
+                }
+            ]
+        }
+    ]
+    payload["hooks"]["Stop"] = [
+        {
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "python3 hooks/brigade-work-loop.py --event Stop",
+                }
+            ]
+        }
+    ]
+    settings.write_text(json.dumps(payload, indent=2) + "\n")
+
+    from brigade.claude_hooks.install_cmd import status_payload
+
+    status = status_payload(target)
+
+    assert status["legacy_handler_count"] == 2
+    assert status["legacy_events"] == ["SessionStart", "Stop"]
+
+
+def test_doctor_warns_for_legacy_handlers_with_repair_command(tmp_path: Path, capsys):
+    target = _wired(tmp_path)
+    settings = target / ".claude" / "settings.json"
+    payload = json.loads(settings.read_text())
+    payload["hooks"]["SessionStart"] = [
+        {
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "python3 hooks/brigade-work-loop.py --event SessionStart",
+                }
+            ]
+        }
+    ]
+    settings.write_text(json.dumps(payload, indent=2) + "\n")
+
+    check = _loop_check(target, capsys)
+
+    assert check["status"] == "WARN"
+    assert ".claude/settings.json" in check["detail"]
+    assert f"brigade work hooks install --target {target}" in check["detail"]
+    # The base state detail is preserved, not replaced by the legacy-only message.
+    assert "state=" in check["detail"]
+
+
+def test_doctor_reports_normal_state_when_no_legacy_handler(tmp_path: Path, capsys):
+    target = _wired(tmp_path)
+    check = _loop_check(target, capsys)
+    assert check["status"] == "OK"
+    assert "state=enforced" in check["detail"]
+    assert "legacy" not in check["detail"]
+
+
 def test_doctor_skips_old_state_files_and_caps_recent_candidates(tmp_path: Path, capsys, monkeypatch):
     target = _wired(tmp_path)
     from brigade.claude_hooks import runtime

--- a/tests/test_claude_hooks_runtime.py
+++ b/tests/test_claude_hooks_runtime.py
@@ -619,6 +619,78 @@ def test_repo_worktree_fingerprint_detects_untracked_tail_byte_change(tmp_path: 
     assert baseline != updated
 
 
+def test_repo_worktree_fingerprint_hashes_large_untracked_without_read_bytes(tmp_path: Path, monkeypatch):
+    target = _git_wired_claude(tmp_path)
+    large = target / "model.cache"
+    with large.open("wb") as handle:
+        handle.seek(100 * 1024 * 1024 - 1)
+        handle.write(b"\0")
+    hash_calls: list[str] = []
+    real_run = runtime._run_snapshot_git
+
+    def tracked_run(repo: Path, *git_args: str):
+        if git_args[:1] == ("hash-object",):
+            hash_calls.append(git_args[-1])
+        return real_run(repo, *git_args)
+
+    def forbid_read_bytes(self: Path, *args, **kwargs):
+        raise AssertionError("repo_worktree_fingerprint must not read whole file bytes in-process")
+
+    monkeypatch.setattr(runtime, "_run_snapshot_git", tracked_run)
+    monkeypatch.setattr(Path, "read_bytes", forbid_read_bytes)
+
+    fingerprint = runtime.repo_worktree_fingerprint(target)
+
+    assert fingerprint is not None
+    assert "model.cache" in hash_calls
+
+
+def test_wired_target_from_payload_ignores_incidental_repo_paths(tmp_path: Path):
+    cwd_repo = _configured_git_repo(tmp_path / "cwdrepo")
+    incidental = _configured_git_repo(tmp_path / "incidental")
+    command = f"rg pattern {incidental}/tracked.txt"
+
+    resolved = runtime.wired_target_from_payload(
+        _payload(
+            cwd_repo,
+            "PreToolUse",
+            tool_name="Bash",
+            tool_input={"command": command},
+        )
+    )
+
+    assert resolved == cwd_repo.resolve()
+
+
+def test_wired_target_from_payload_without_cwd_uses_named_repo_not_process_dir(tmp_path: Path):
+    named = _configured_git_repo(tmp_path / "named")
+    # Payload omits cwd; the command explicitly names a wired repo.
+    payload = {
+        "session_id": "no-cwd",
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": f"rg pattern {named}/tracked.txt"},
+    }
+
+    resolved = runtime.wired_target_from_payload(payload)
+
+    assert resolved == named.resolve()
+
+
+def test_wired_target_from_payload_without_cwd_and_no_named_repo_returns_none(tmp_path: Path):
+    # Payload omits cwd and the command mentions no wired repo path.
+    payload = {
+        "session_id": "no-cwd",
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "echo hello"},
+    }
+
+    resolved = runtime.wired_target_from_payload(payload)
+
+    assert resolved is None
+
+
 def test_repo_worktree_fingerprint_returns_none_when_hash_object_fails_for_untracked(tmp_path: Path, monkeypatch):
     target = _git_wired_claude(tmp_path)
     (target / "new.txt").write_text("content")

--- a/tests/test_claude_hooks_settings_merge.py
+++ b/tests/test_claude_hooks_settings_merge.py
@@ -7,7 +7,12 @@ from pathlib import Path
 
 from brigade import cli
 from brigade.claude_hooks.install_cmd import hooks_install, hooks_status, hooks_uninstall, hooks_update, status_payload
-from brigade.claude_hooks.package import PACKAGE_ID, PACKAGE_VERSION, managed_command
+from brigade.claude_hooks.package import (
+    PACKAGE_ID,
+    PACKAGE_VERSION,
+    is_legacy_handler,
+    managed_command,
+)
 from brigade.install import install_selection
 from brigade.selection import Selection
 
@@ -316,3 +321,224 @@ def test_claude_templates_import_agents_md():
     for rel in ("repo/CLAUDE.md", "workspace/CLAUDE.md"):
         text = (root / rel).read_text()
         assert any(line.strip() == "@AGENTS.md" for line in text.splitlines())
+
+
+LEGACY_WORK_LOOP_CMD = "python3 hooks/brigade-work-loop.py --event SessionStart"
+
+
+def _legacy_handler(event: str) -> dict[str, str]:
+    return {
+        "type": "command",
+        "command": LEGACY_WORK_LOOP_CMD.replace("SessionStart", event),
+    }
+
+
+def test_hooks_install_removes_legacy_standalone_handler_and_is_idempotent(tmp_path: Path):
+    target = _wired_claude(tmp_path)
+    settings = target / ".claude" / "settings.json"
+    settings.parent.mkdir(parents=True, exist_ok=True)
+    seeded = {
+        "hooks": {
+            "SessionStart": [{"hooks": [_legacy_handler("SessionStart")]}],
+            "PreToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [
+                        _legacy_handler("PreToolUse"),
+                        {"type": "command", "command": "echo foreign-pretool"},
+                    ],
+                }
+            ],
+        }
+    }
+    settings.write_text(json.dumps(seeded, indent=2) + "\n")
+
+    assert hooks_install(target=target) == 0
+    after_first = json.loads(settings.read_text())
+    pre_cmds = [
+        handler["command"]
+        for group in after_first["hooks"]["PreToolUse"]
+        for handler in group.get("hooks", [])
+        if isinstance(handler, dict)
+    ]
+    assert "echo foreign-pretool" in pre_cmds
+    assert not any("brigade-work-loop.py" in cmd for cmd in pre_cmds)
+    session_cmds = [
+        handler["command"]
+        for group in after_first["hooks"]["SessionStart"]
+        for handler in group.get("hooks", [])
+        if isinstance(handler, dict)
+    ]
+    assert not any("brigade-work-loop.py" in cmd for cmd in session_cmds)
+    assert any(cmd.startswith("brigade work hook-run") for cmd in session_cmds)
+
+    before_second = settings.read_text()
+    assert hooks_install(target=target) == 0
+    assert settings.read_text() == before_second
+
+
+def test_is_legacy_handler_anchors_to_executable_position():
+    # False positives: mentions of the filename in non-executable positions.
+    assert is_legacy_handler({"type": "command", "command": "grep -r brigade-work-loop.py ."}) is False
+    assert is_legacy_handler({"type": "command", "command": "echo hi # brigade-work-loop.py"}) is False
+    assert is_legacy_handler({"type": "command", "command": 'echo "docs/brigade-work-loop.py"'}) is False
+    # Direct executable form.
+    assert (
+        is_legacy_handler(
+            {
+                "type": "command",
+                "command": "python3 /home/u/.claude/hooks/brigade-work-loop.py --event PreToolUse",
+            }
+        )
+        is True
+    )
+    assert (
+        is_legacy_handler(
+            {
+                "type": "command",
+                "command": "/opt/brigade/hooks/brigade-work-loop.py",
+            }
+        )
+        is True
+    )
+    # Interpreter form with flags.
+    assert (
+        is_legacy_handler(
+            {
+                "type": "command",
+                "command": "python3 -u /x/brigade-work-loop.py",
+            }
+        )
+        is True
+    )
+    # Similar but not matching basenames.
+    assert is_legacy_handler({"type": "command", "command": "/x/brigade-work-loop.py.bak"}) is False
+    assert is_legacy_handler({"type": "command", "command": "/x/my-brigade-work-loop.py"}) is False
+    # Interpreter form that runs a module or inline code, not the script.
+    assert is_legacy_handler({"type": "command", "command": "python3 -c 'print(1)'"}) is False
+    assert is_legacy_handler({"type": "command", "command": "python3 -m brigade_work_loop"}) is False
+
+
+def test_hooks_install_removes_legacy_coexisting_with_managed_and_foreign(tmp_path: Path):
+    target = _wired_claude(tmp_path)
+    settings = target / ".claude" / "settings.json"
+    settings.parent.mkdir(parents=True, exist_ok=True)
+    seeded = {
+        "hooks": {
+            "SessionStart": [
+                {
+                    "hooks": [
+                        _legacy_handler("SessionStart"),
+                        {"type": "command", "command": "echo foreign-session"},
+                        {"type": "command", "command": managed_command("SessionStart")},
+                    ]
+                }
+            ]
+        }
+    }
+    settings.write_text(json.dumps(seeded, indent=2) + "\n")
+
+    assert hooks_update(target=target) == 0
+
+    payload = json.loads(settings.read_text())
+    session_cmds = [
+        handler["command"]
+        for group in payload["hooks"]["SessionStart"]
+        for handler in group.get("hooks", [])
+        if isinstance(handler, dict)
+    ]
+    assert "echo foreign-session" in session_cmds
+    assert not any("brigade-work-loop.py" in cmd for cmd in session_cmds)
+    assert managed_command("SessionStart") in session_cmds
+
+
+def test_hooks_install_removes_legacy_from_multiple_managed_events(tmp_path: Path):
+    target = _wired_claude(tmp_path)
+    settings = target / ".claude" / "settings.json"
+    settings.parent.mkdir(parents=True, exist_ok=True)
+    seeded = {
+        "hooks": {
+            "SessionStart": [{"hooks": [_legacy_handler("SessionStart")]}],
+            "Stop": [{"hooks": [_legacy_handler("Stop")]}],
+        }
+    }
+    settings.write_text(json.dumps(seeded, indent=2) + "\n")
+
+    before = status_payload(target)
+    assert before["legacy_handler_count"] == 2
+    assert before["legacy_events"] == ["SessionStart", "Stop"]
+
+    assert hooks_install(target=target) == 0
+
+    payload = json.loads(settings.read_text())
+    for event in ("SessionStart", "Stop"):
+        cmds = [
+            handler["command"]
+            for group in payload["hooks"][event]
+            for handler in group.get("hooks", [])
+            if isinstance(handler, dict)
+        ]
+        assert not any("brigade-work-loop.py" in cmd for cmd in cmds)
+        assert managed_command(event) in cmds
+
+    after = status_payload(target)
+    assert after["legacy_handler_count"] == 0
+    assert after["legacy_events"] == []
+
+
+def test_hooks_uninstall_removes_legacy_and_preserves_foreign(tmp_path: Path):
+    target = _wired_claude(tmp_path)
+    settings = target / ".claude" / "settings.json"
+    settings.parent.mkdir(parents=True, exist_ok=True)
+    seeded = {
+        "hooks": {
+            "SessionStart": [
+                {
+                    "hooks": [
+                        _legacy_handler("SessionStart"),
+                        {"type": "command", "command": "echo foreign-session"},
+                    ]
+                }
+            ]
+        }
+    }
+    settings.write_text(json.dumps(seeded, indent=2) + "\n")
+
+    assert hooks_uninstall(target=target) == 0
+
+    payload = json.loads(settings.read_text())
+    cmds = [
+        handler["command"]
+        for group in payload["hooks"]["SessionStart"]
+        for handler in group.get("hooks", [])
+        if isinstance(handler, dict)
+    ]
+    assert cmds == ["echo foreign-session"]
+
+
+def test_status_payload_counts_legacy_and_foreign_as_disjoint(tmp_path: Path):
+    target = _wired_claude(tmp_path)
+    settings = target / ".claude" / "settings.json"
+    payload = json.loads(settings.read_text())
+    payload["hooks"]["SessionStart"] = [
+        {
+            "hooks": [
+                _legacy_handler("SessionStart"),
+                {"type": "command", "command": "echo foreign-1"},
+            ]
+        }
+    ]
+    payload["hooks"]["Stop"] = [
+        {
+            "hooks": [
+                _legacy_handler("Stop"),
+                {"type": "command", "command": "echo foreign-2"},
+            ]
+        }
+    ]
+    settings.write_text(json.dumps(payload, indent=2) + "\n")
+
+    status = status_payload(target)
+    assert status["legacy_handler_count"] == 2
+    assert status["foreign_handler_count"] == 2
+    assert status["legacy_events"] == ["SessionStart", "Stop"]


### PR DESCRIPTION
## What

Fixes #397. An upgraded install kept the obsolete standalone `brigade-work-loop.py` hook registered because `is_managed_handler` never recognized it, so install/update reconciliation preserved it as a foreign user hook. That stale hook read each untracked file fully into memory (`digest.update(path.read_bytes())`) and OOMed on a ~10 GB untracked cache blob.

## Changes

- **Legacy detection + removal** (`package.py`, `install_cmd.py`): `is_legacy_handler` recognizes standalone `brigade-work-loop.py` registrations, **anchored to executable position** (tokens[0] is the script, or a python interpreter followed by the script as first non-flag arg) so commands that merely *mention* the name (`grep -r brigade-work-loop.py .`, a trailing comment, a quoted path) are never matched and never deleted. Install/update reconciliation drops legacy handlers idempotently while preserving genuine foreign hooks and dropping emptied groups.
- **Status/doctor reporting** (`install_cmd.py`, `doctor.py`): `legacy_handler_count` + `legacy_events` in hook status (disjoint from `foreign_handler_count`); doctor emits a WARN that preserves the base state signal and appends the settings file + exact repair command `brigade work hooks install --target <path>`.
- **Attribution guard** (`runtime.py`): `wired_target_from_payload` prefers the session cwd and explicit `cd`/`--target`/`git -C` targets over incidental bare-path arguments, and only enrolls cwd when the payload actually supplies one, so a Bash command that mentions another wired repo no longer enrolls it.
- **Bounded fingerprinting**: confirmed by inspection — the managed path hashes via `git hash-object` (streamed, bounded) and the directory fallback is stat-only; no in-process whole-file reads. Peak RSS does not scale with file size. A regression test locks this in.
- **Docs** (`technical-guide.md`): names model caches, virtualenvs, and generated databases as snapshot-skipped directories.

## Tests

Regression tests (using `tmp_target`/`tmp_path`, never the real workspace): legacy anchoring incl. false-positive guards, legacy+managed coexistence in one group, multi-event removal, disjoint foreign/legacy counts, uninstall preserving foreign hooks, doctor normal-vs-legacy behavior, no-cwd attribution, and a mocked-large untracked file fingerprinted without reading its bytes.

## Verification

`./scripts/verify` green (ruff, format, mypy, version_sync, managed_snapshot, pytest coverage 82.42% ≥ 78 floor). Captured receipt: `20260721-153145-work-verify-ab0bf2`.

> Note for local reviewers on this machine: `TMPDIR` under a `.cache`-named path makes `tests/guard/` spuriously fail (the content-guard scanner excludes `.cache`); run verify with `TMPDIR=/tmp`. CI uses `/tmp` and is unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Claude hook reconciliation and Bash repo attribution in the work-loop runtime; mistakes could drop wrong hooks or mis-attribute sessions, but behavior is heavily tested and legacy matching is narrowly anchored.
> 
> **Overview**
> **Fixes stale `brigade-work-loop.py` hooks** that survived install/update and could OOM on large untracked files. Hook install/update/uninstall now strips **legacy** standalone script registrations (executable-position matching only) alongside managed handlers, while keeping foreign hooks and dropping empty groups idempotently.
> 
> **Status and doctor** expose `legacy_handler_count` / `legacy_events` (separate from foreign handlers) and **WARN** with `brigade work hooks install --target <path>` when legacy entries remain.
> 
> **Runtime** tightens which repo a Bash tool call is attributed to: session `cwd` is preferred over incidental paths in the command, and `cwd` is only considered when the payload actually provides it—so mentioning another wired repo in `rg` no longer enrolls that repo.
> 
> Docs note that work-loop snapshot fingerprints skip common gitignored dirs (caches, `.venv`, `node_modules`, etc.). Tests cover legacy removal, doctor messaging, attribution edge cases, and large-file fingerprinting without in-process full reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bcb6d27652d1a726ca953de763a949c57e3161a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Claude hook installation, updates, and removal now clean up legacy standalone handlers while preserving unrelated handlers.
  * Hook status reports identify legacy handlers and affected events.
  * `brigade doctor` now warns when legacy handlers are detected and provides a repair command.
  * Improved command target resolution when an explicit working directory is provided.
* **Tests**
  * Added coverage for legacy handler detection, cleanup, status reporting, diagnostics, and command resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->