### PR TITLE
feat(run): preflight Cloudflare AI Gateway seats for required env vars (#394)

### DIFF
--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -725,6 +725,15 @@ def _run_orchestrator(
             ok=False,
             detail="codex-cloud seats are workers only; pick a local CLI for the orchestrator",
         )
+    cloudflare_detail = agents.cloudflare_ai_gateway_preflight_detail(orchestrator.model)
+    if cloudflare_detail is not None:
+        return agents.AgentResult(
+            text="",
+            ok=False,
+            detail=cloudflare_detail,
+            failure_phase="preflight",
+            failure_kind="provider-config",
+        )
     kwargs: dict[str, object] = {
         "timeout": timeout_for(orchestrator, roster),
         "cwd": cwd,
@@ -1951,6 +1960,8 @@ def _run_payload(
         payload["error"] = error
         if failure_phase is not None or failure_kind is not None:
             payload["failure_phase"] = failure_phase or "unknown"
+            if failure_kind is not None:
+                payload["failure_kind"] = failure_kind
             failure_payload: dict[str, object] = {
                 "phase": failure_phase or "unknown",
                 "kind": failure_kind or "unknown",
@@ -2333,6 +2344,12 @@ def run(
             if output_dir is not None:
                 finished_at = datetime.now(timezone.utc)
                 _write_json(output_dir / "plan-attempts.json", {"attempts": plan_attempts or []})
+                failure_phase = "planning"
+                if isinstance(final_attempt, dict):
+                    attempt_phase = final_attempt.get("failure_phase")
+                    attempt_kind = final_attempt.get("failure_kind")
+                    if attempt_phase == "preflight" and attempt_kind == "provider-config":
+                        failure_phase = "preflight"
                 _write_json(
                     output_dir / "run.json",
                     _payload(
@@ -2346,7 +2363,7 @@ def run(
                         finished_at=finished_at,
                         output_dir=output_dir,
                         error=str(exc),
-                        failure_phase="planning",
+                        failure_phase=failure_phase,
                         failure_kind=failure_kind,
                         failure_seat=roster.orchestrator,
                         code_graph=code_graph,

--- a/src/brigade/agents.py
+++ b/src/brigade/agents.py
@@ -12,6 +12,7 @@ import json
 import os
 import re
 import unicodedata
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, List
@@ -21,6 +22,8 @@ from .result_integrity import validate_final_output
 
 _OLLAMA_PREFIX = "ollama:"
 _CODEX_CLOUD_PREFIX = "codex-cloud:"
+_CLOUDFLARE_AI_GATEWAY_PREFIX = "cloudflare-ai-gateway/"
+_CLOUDFLARE_AI_GATEWAY_REQUIRED_ENV = ("CLOUDFLARE_ACCOUNT_ID", "CLOUDFLARE_GATEWAY_ID")
 _NONRECOVERABLE_GROK_OUTPUT_FAILURES = frozenset(
     {
         "provider-error",
@@ -576,6 +579,50 @@ def secret_ref_targets(env: dict[str, str]) -> set[str]:
     """Target keys resolved from *_REF entries: the only values scrub may touch."""
 
     return {key[: -len("_REF")] for key in env if key.endswith("_REF") and key != "_REF"}
+
+
+def is_cloudflare_ai_gateway_route(model: str | None) -> bool:
+    """Return True if the model route is a Cloudflare AI Gateway route.
+
+    The first path segment must be exactly ``cloudflare-ai-gateway``, not a
+    substring such as ``cloudflare-ai-gateway-other``.
+    """
+
+    if not model:
+        return False
+    if not model.startswith(_CLOUDFLARE_AI_GATEWAY_PREFIX):
+        return False
+    return len(model) > len(_CLOUDFLARE_AI_GATEWAY_PREFIX)
+
+
+def missing_cloudflare_ai_gateway_env_vars(
+    env: Mapping[str, str] | None = None,
+) -> list[str]:
+    """Return the required Cloudflare AI Gateway env vars that are missing.
+
+    Reads only variable names and presence; never reads or prints values.
+    Empty strings count as missing.
+    ``env`` defaults to ``os.environ``.
+    """
+
+    if env is None:
+        env = os.environ
+    return [name for name in _CLOUDFLARE_AI_GATEWAY_REQUIRED_ENV if not env.get(name)]
+
+
+def cloudflare_ai_gateway_preflight_detail(model: str | None) -> str | None:
+    """Return a provider-config detail if the Cloudflare route lacks env.
+
+    Empty string values are treated as missing. Returns None when the route is
+    not a Cloudflare AI Gateway route or when all required env vars are present.
+    """
+
+    if not is_cloudflare_ai_gateway_route(model):
+        return None
+    missing = missing_cloudflare_ai_gateway_env_vars()
+    if not missing:
+        return None
+    return f"Cloudflare AI Gateway seat missing required env vars: {', '.join(missing)}; set them before running"
 
 
 _MIN_SCRUB_VALUE_LENGTH = 8

--- a/src/brigade/roster_cmd.py
+++ b/src/brigade/roster_cmd.py
@@ -195,6 +195,22 @@ def doctor(target: Path, *, roster_path: Path | None = None) -> int:
                         f"{agent.cli} does not support model pinning; drop model= or switch cli",
                     )
                 )
+            # Endpoint-mode agents are intentionally exempt: their model is a
+            # remote HTTP model name, not a local CLI route that needs Cloudflare
+            # env vars (the cli=None branch above already continued past this).
+            if agents.is_cloudflare_ai_gateway_route(agent.model):
+                missing = agents.missing_cloudflare_ai_gateway_env_vars()
+                label = f"agent: {name} cloudflare gateway"
+                if missing:
+                    checks.append(
+                        (
+                            doctor_mod.FAIL,
+                            label,
+                            f"requires env vars: {', '.join(missing)}; set them before running",
+                        )
+                    )
+                else:
+                    checks.append((doctor_mod.OK, label, "required env vars are set"))
         if agent.reasoning is not None:
             if agents.supports_reasoning(agent.cli):
                 checks.append((doctor_mod.OK, f"agent: {name} reasoning", f"{agent.reasoning} via {agent.cli}"))

--- a/src/brigade/run_transport.py
+++ b/src/brigade/run_transport.py
@@ -72,6 +72,26 @@ def _is_direct_grok_invalid_final(
     )
 
 
+def _cloudflare_preflight_failure(agent: Agent, assignment: Assignment) -> WorkerResult | None:
+    """Return a preflight failure if the agent's Cloudflare route lacks env.
+
+    Empty string values are treated as missing.
+    """
+
+    detail = agents.cloudflare_ai_gateway_preflight_detail(agent.model)
+    if detail is None:
+        return None
+    return WorkerResult(
+        worker=assignment.worker,
+        task=assignment.task,
+        text="",
+        ok=False,
+        detail=detail,
+        failure_phase="preflight",
+        failure_kind="provider-config",
+    )
+
+
 def _worker_attempt(
     *,
     kind: str,
@@ -280,6 +300,9 @@ def dispatch(
                     else f"{agent.cli} is not allowed by limits.allow_models"
                 ),
             )
+        preflight = _cloudflare_preflight_failure(agent, assignment)
+        if preflight is not None:
+            return preflight
         prompt = build_prompt(
             agent,
             assignment,
@@ -549,6 +572,9 @@ def dispatch(
             return finish(missing_fallback, agent, attempts)
 
         fallback_agent = roster.agents[fallback_name]
+        fallback_preflight = _cloudflare_preflight_failure(fallback_agent, assignment)
+        if fallback_preflight is not None:
+            return fallback_preflight
         fallback_prompt = build_prompt(
             fallback_agent,
             assignment,

--- a/src/brigade/run_transport.py
+++ b/src/brigade/run_transport.py
@@ -572,9 +572,21 @@ def dispatch(
             return finish(missing_fallback, agent, attempts)
 
         fallback_agent = roster.agents[fallback_name]
-        fallback_preflight = _cloudflare_preflight_failure(fallback_agent, assignment)
-        if fallback_preflight is not None:
-            return fallback_preflight
+        fallback_cloudflare_detail = agents.cloudflare_ai_gateway_preflight_detail(fallback_agent.model)
+        if fallback_cloudflare_detail is not None:
+            # Route through finish() so the accumulated grok attempt history and
+            # elapsed duration are preserved in the persisted WorkerResult.
+            return finish(
+                agents.AgentResult(
+                    text="",
+                    ok=False,
+                    detail=fallback_cloudflare_detail,
+                    failure_phase="preflight",
+                    failure_kind="provider-config",
+                ),
+                fallback_agent,
+                attempts,
+            )
         fallback_prompt = build_prompt(
             fallback_agent,
             assignment,

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -3154,6 +3154,63 @@ def test_plan_output_validation_failure_preserves_typed_receipts(monkeypatch, tm
     }
 
 
+def test_orchestrator_cloudflare_preflight_fails_before_plan_and_reaches_run_json(monkeypatch, tmp_path, capsys):
+    _CF_MODEL_ROUTE = "cloudflare-ai-gateway/openai/gpt-5.3-codex"
+    _FAKE_CF_ACCOUNT = "fake-account-id-for-test"
+    _FAKE_CF_GATEWAY = "fake-gateway-id-for-test"
+
+    roster = Roster(
+        orchestrator="chef",
+        agents={
+            "chef": Agent(
+                name="chef",
+                cli="codex",
+                role="plan",
+                model=_CF_MODEL_ROUTE,
+            ),
+            "coder": Agent(name="coder", cli="codex", role="worker"),
+        },
+        max_workers=1,
+    )
+
+    def should_not_run(*args, **kwargs):  # noqa: ARG001
+        raise AssertionError("agents.run_agent must not be called when Cloudflare orchestrator env is missing")
+
+    monkeypatch.setattr(aboyeur.agents, "run_agent", should_not_run)
+    monkeypatch.delenv("CLOUDFLARE_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("CLOUDFLARE_GATEWAY_ID", raising=False)
+
+    output_dir = tmp_path / "run"
+    rc = aboyeur.run(
+        "build feature",
+        roster,
+        output_dir=output_dir,
+        code_graph_enabled=False,
+        route_enabled=False,
+    )
+
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "orchestrator failed during plan" in err
+    assert "Cloudflare AI Gateway" in err
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "failed"
+    assert run_meta["failure_phase"] == "preflight"
+    assert run_meta["failure_kind"] == "provider-config"
+    assert run_meta["failure"] == {
+        "phase": "preflight",
+        "kind": "provider-config",
+        "detail": (
+            "orchestrator failed during plan: "
+            "Cloudflare AI Gateway seat missing required env vars: "
+            "CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_GATEWAY_ID; set them before running"
+        ),
+        "seat": "chef",
+    }
+    assert _FAKE_CF_ACCOUNT not in str(run_meta)
+    assert _FAKE_CF_GATEWAY not in str(run_meta)
+
+
 def test_synthesis_failure_writes_artifact(monkeypatch, tmp_path, capsys):
     calls = []
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1677,3 +1677,55 @@ def test_run_agent_env_ref_empty_value_is_typed_failure(monkeypatch):
     assert not result.ok
     assert result.failure_kind == "env-ref-missing"
     assert "is not set or is empty" in result.detail
+
+
+_CF_MODEL_ROUTE = "cloudflare-ai-gateway/openai/gpt-5.3-codex"
+
+
+@pytest.mark.parametrize(
+    ("route", "expected"),
+    [
+        (_CF_MODEL_ROUTE, True),
+        ("cloudflare-ai-gateway-other/openai/gpt-5.3-codex", False),
+        ("openai-cloudflare-ai-gateway/gpt-5.3-codex", False),
+        ("foo/cloudflare-ai-gateway/openai/gpt-5.3-codex", False),
+        (None, False),
+        ("", False),
+    ],
+)
+def test_is_cloudflare_ai_gateway_route(route, expected):
+    assert agents.is_cloudflare_ai_gateway_route(route) is expected
+
+
+def test_missing_cloudflare_ai_gateway_env_vars_both_missing():
+    assert agents.missing_cloudflare_ai_gateway_env_vars({}) == [
+        "CLOUDFLARE_ACCOUNT_ID",
+        "CLOUDFLARE_GATEWAY_ID",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("env", "expected_missing"),
+    [
+        ({"CLOUDFLARE_ACCOUNT_ID": "fake-account-id-for-test"}, ["CLOUDFLARE_GATEWAY_ID"]),
+        ({"CLOUDFLARE_GATEWAY_ID": "fake-gateway-id-for-test"}, ["CLOUDFLARE_ACCOUNT_ID"]),
+        (
+            {
+                "CLOUDFLARE_ACCOUNT_ID": "fake-account-id-for-test",
+                "CLOUDFLARE_GATEWAY_ID": "fake-gateway-id-for-test",
+            },
+            [],
+        ),
+    ],
+)
+def test_missing_cloudflare_ai_gateway_env_vars_partial(env, expected_missing):
+    assert agents.missing_cloudflare_ai_gateway_env_vars(env) == expected_missing
+
+
+def test_missing_cloudflare_ai_gateway_env_vars_empty_string_counts_as_missing():
+    assert agents.missing_cloudflare_ai_gateway_env_vars(
+        {
+            "CLOUDFLARE_ACCOUNT_ID": "",
+            "CLOUDFLARE_GATEWAY_ID": "fake-gateway-id-for-test",
+        }
+    ) == ["CLOUDFLARE_ACCOUNT_ID"]

--- a/tests/test_roster_cmd.py
+++ b/tests/test_roster_cmd.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from brigade import agents
 from brigade import cli
 from brigade import model_inventory
@@ -414,6 +416,68 @@ def test_roster_doctor_fails_pin_on_ollama_ref(monkeypatch, tmp_target, capsys):
     out = capsys.readouterr().out
     assert rc == 1
     assert "ollama names its model in the cli ref" in out
+
+
+_CF_MODEL_ROUTE = "cloudflare-ai-gateway/openai/gpt-5.3-codex"
+_FAKE_CF_ACCOUNT = "fake-account-id-for-test"
+_FAKE_CF_GATEWAY = "fake-gateway-id-for-test"
+
+
+def _write_cloudflare_gateway_roster(tmp_target) -> None:
+    _write_roster(
+        tmp_target,
+        'orchestrator = "chef"\n'
+        '[agents.chef]\ncli = "codex"\nmodel = "gpt-5.5"\nrole = "plan"\n'
+        f'[agents.cf_worker]\ncli = "codex"\nmodel = "{_CF_MODEL_ROUTE}"\nrole = "worker"\n',
+    )
+
+
+def _clear_cloudflare_gateway_env(monkeypatch) -> None:
+    monkeypatch.delenv("CLOUDFLARE_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("CLOUDFLARE_GATEWAY_ID", raising=False)
+
+
+def test_roster_doctor_ok_for_cloudflare_gateway_when_env_present(monkeypatch, tmp_target, capsys):
+    _write_cloudflare_gateway_roster(tmp_target)
+    _clear_cloudflare_gateway_env(monkeypatch)
+    monkeypatch.setattr(agents.proc, "which", lambda cmd: "/x/" + cmd)
+    monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", _FAKE_CF_ACCOUNT)
+    monkeypatch.setenv("CLOUDFLARE_GATEWAY_ID", _FAKE_CF_GATEWAY)
+
+    rc = roster_cmd.doctor(tmp_target)
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "[ok]   agent: cf_worker cloudflare gateway" in out
+    assert "required env vars are set" in out
+    assert _FAKE_CF_ACCOUNT not in out
+    assert _FAKE_CF_GATEWAY not in out
+
+
+@pytest.mark.parametrize(
+    ("env", "missing_vars"),
+    [
+        ({}, ("CLOUDFLARE_ACCOUNT_ID", "CLOUDFLARE_GATEWAY_ID")),
+        ({"CLOUDFLARE_ACCOUNT_ID": _FAKE_CF_ACCOUNT}, ("CLOUDFLARE_GATEWAY_ID",)),
+        ({"CLOUDFLARE_GATEWAY_ID": _FAKE_CF_GATEWAY}, ("CLOUDFLARE_ACCOUNT_ID",)),
+    ],
+)
+def test_roster_doctor_fails_cloudflare_gateway_when_env_missing(monkeypatch, tmp_target, capsys, env, missing_vars):
+    _write_cloudflare_gateway_roster(tmp_target)
+    _clear_cloudflare_gateway_env(monkeypatch)
+    monkeypatch.setattr(agents.proc, "which", lambda cmd: "/x/" + cmd)
+    for name, value in env.items():
+        monkeypatch.setenv(name, value)
+
+    rc = roster_cmd.doctor(tmp_target)
+    out = capsys.readouterr().out
+
+    assert rc == 1
+    assert "[fail] agent: cf_worker cloudflare gateway" in out
+    for var in missing_vars:
+        assert var in out
+    assert _FAKE_CF_ACCOUNT not in out
+    assert _FAKE_CF_GATEWAY not in out
 
 
 def test_roster_doctor_endpoint_agent_skips_pin_check(tmp_target, capsys):

--- a/tests/test_run_transport_env.py
+++ b/tests/test_run_transport_env.py
@@ -2,6 +2,8 @@
 
 import threading
 
+import pytest
+
 from brigade import acpx_adapter, agents
 from brigade import run_transport
 from brigade.roster import Agent, Roster
@@ -376,6 +378,225 @@ def test_endpoint_host_generalizes_to_any_base_url(monkeypatch):
     )
     result = _dispatch(roster, monkeypatch, captured)[0]
     assert result.endpoint_host == "openai-lane.example.com"
+
+
+_CF_MODEL_ROUTE = "cloudflare-ai-gateway/openai/gpt-5.3-codex"
+_FAKE_CF_ACCOUNT = "fake-account-id-for-test"
+_FAKE_CF_GATEWAY = "fake-gateway-id-for-test"
+
+
+def _assert_cloudflare_values_not_echoed(result):
+    """Secret values from env must never leak into WorkerResult or its payload."""
+    payload = str(result)
+    assert _FAKE_CF_ACCOUNT not in result.detail
+    assert _FAKE_CF_GATEWAY not in result.detail
+    assert _FAKE_CF_ACCOUNT not in payload
+    assert _FAKE_CF_GATEWAY not in payload
+
+
+def _cloudflare_gateway_roster():
+    chef = Agent(name="chef", cli="codex", role="plan")
+    worker = Agent(name="cf_worker", cli="codex", role="worker", model=_CF_MODEL_ROUTE)
+    return Roster(orchestrator="chef", agents={"chef": chef, "cf_worker": worker})
+
+
+def _dispatch_cloudflare_worker(monkeypatch, *, run_impl):
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(agents.proc, "run", run_impl)
+    return run_transport.dispatch(
+        [Assignment(worker="cf_worker", task="do the thing")],
+        _cloudflare_gateway_roster(),
+        build_prompt=lambda agent, assignment, **kw: assignment.task,
+        run_appserver_worker=lambda *a, **kw: agents.AgentResult(text="", ok=False, detail="unused"),
+        event_writer=lambda events_dir, worker, verbose=False: None,
+        read_only=True,
+    )
+
+
+def _clear_cloudflare_gateway_env(monkeypatch) -> None:
+    monkeypatch.delenv("CLOUDFLARE_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("CLOUDFLARE_GATEWAY_ID", raising=False)
+
+
+def test_cloudflare_gateway_preflight_fails_without_required_env(monkeypatch):
+    _clear_cloudflare_gateway_env(monkeypatch)
+
+    def should_not_run(*args, **kwargs):
+        raise AssertionError("proc.run must not be called when Cloudflare gateway env is missing")
+
+    result = _dispatch_cloudflare_worker(monkeypatch, run_impl=should_not_run)[0]
+
+    assert not result.ok
+    assert result.failure_phase == "preflight"
+    assert result.failure_kind == "provider-config"
+    assert "CLOUDFLARE_ACCOUNT_ID" in result.detail
+    assert "CLOUDFLARE_GATEWAY_ID" in result.detail
+
+
+@pytest.mark.parametrize(
+    ("env", "missing_vars"),
+    [
+        ({}, ("CLOUDFLARE_ACCOUNT_ID", "CLOUDFLARE_GATEWAY_ID")),
+        ({"CLOUDFLARE_ACCOUNT_ID": _FAKE_CF_ACCOUNT}, ("CLOUDFLARE_GATEWAY_ID",)),
+        ({"CLOUDFLARE_GATEWAY_ID": _FAKE_CF_GATEWAY}, ("CLOUDFLARE_ACCOUNT_ID",)),
+    ],
+)
+def test_cloudflare_gateway_preflight_names_each_missing_env_var(monkeypatch, env, missing_vars):
+    _clear_cloudflare_gateway_env(monkeypatch)
+    for name, value in env.items():
+        monkeypatch.setenv(name, value)
+
+    def should_not_run(*args, **kwargs):
+        raise AssertionError("proc.run must not be called when Cloudflare gateway env is missing")
+
+    result = _dispatch_cloudflare_worker(monkeypatch, run_impl=should_not_run)[0]
+
+    assert not result.ok
+    assert result.failure_kind == "provider-config"
+    for var in missing_vars:
+        assert var in result.detail
+    _assert_cloudflare_values_not_echoed(result)
+
+
+def test_cloudflare_gateway_preflight_payload_serializes_provider_config_failure(monkeypatch):
+    from brigade.run_receipts import worker_payload
+
+    _clear_cloudflare_gateway_env(monkeypatch)
+
+    def should_not_run(*args, **kwargs):
+        raise AssertionError("proc.run must not be called when Cloudflare gateway env is missing")
+
+    entry = worker_payload(_dispatch_cloudflare_worker(monkeypatch, run_impl=should_not_run))[0]
+
+    assert entry["ok"] is False
+    assert entry["failure_phase"] == "preflight"
+    assert entry["failure_kind"] == "provider-config"
+    assert "CLOUDFLARE_ACCOUNT_ID" in entry["detail"]
+    assert "CLOUDFLARE_GATEWAY_ID" in entry["detail"]
+
+
+def test_cloudflare_gateway_preflight_empty_string_env_counts_as_missing(monkeypatch):
+    _clear_cloudflare_gateway_env(monkeypatch)
+    monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "")
+    monkeypatch.setenv("CLOUDFLARE_GATEWAY_ID", _FAKE_CF_GATEWAY)
+
+    def should_not_run(*args, **kwargs):
+        raise AssertionError("proc.run must not be called when Cloudflare gateway env is missing")
+
+    result = _dispatch_cloudflare_worker(monkeypatch, run_impl=should_not_run)[0]
+
+    assert not result.ok
+    assert result.failure_phase == "preflight"
+    assert result.failure_kind == "provider-config"
+    assert "CLOUDFLARE_ACCOUNT_ID" in result.detail
+    assert "CLOUDFLARE_GATEWAY_ID" not in result.detail
+    _assert_cloudflare_values_not_echoed(result)
+
+
+def test_cloudflare_gateway_preflight_passes_when_env_present(monkeypatch):
+    _clear_cloudflare_gateway_env(monkeypatch)
+    monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", _FAKE_CF_ACCOUNT)
+    monkeypatch.setenv("CLOUDFLARE_GATEWAY_ID", _FAKE_CF_GATEWAY)
+    captured = {"called": False}
+
+    def fake_run(argv, **kw):
+        captured["called"] = True
+        return agents.proc.Result(0, "worker answer", "")
+
+    result = _dispatch_cloudflare_worker(monkeypatch, run_impl=fake_run)[0]
+
+    assert result.ok
+    assert captured["called"] is True
+
+
+def test_non_cloudflare_route_unaffected_when_gateway_env_missing(monkeypatch):
+    _clear_cloudflare_gateway_env(monkeypatch)
+    captured = {}
+
+    def fake_run(argv, **kw):
+        captured["called"] = True
+        return agents.proc.Result(0, "worker answer", "")
+
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(agents.proc, "run", fake_run)
+    roster = Roster(
+        orchestrator="chef",
+        agents={
+            "chef": Agent(name="chef", cli="codex", role="plan"),
+            "coder": Agent(name="coder", cli="codex", role="worker", model="gpt-5.5"),
+        },
+    )
+    result = run_transport.dispatch(
+        [Assignment(worker="coder", task="do the thing")],
+        roster,
+        build_prompt=lambda agent, assignment, **kw: assignment.task,
+        run_appserver_worker=lambda *a, **kw: agents.AgentResult(text="", ok=False, detail="unused"),
+        event_writer=lambda events_dir, worker, verbose=False: None,
+        read_only=True,
+    )[0]
+
+    assert result.ok
+    assert captured["called"] is True
+
+
+def test_cloudflare_gateway_preflight_fallback_agent_fails_without_launch(monkeypatch):
+    _clear_cloudflare_gateway_env(monkeypatch)
+    roster = Roster(
+        orchestrator="chef",
+        agents={
+            "chef": Agent(name="chef", cli="codex", role="plan"),
+            "grok_cli": Agent(
+                name="grok_cli",
+                cli="grok",
+                role="worker",
+                model="grok-4.5",
+                invalid_final_fallback="cf_fallback",
+            ),
+            "cf_fallback": Agent(
+                name="cf_fallback",
+                cli="codex",
+                role="worker",
+                model=_CF_MODEL_ROUTE,
+            ),
+        },
+        max_workers=1,
+    )
+    calls = []
+
+    def fake_run_agent(cli_ref, prompt, **kwargs):
+        calls.append(cli_ref)
+        if cli_ref == "grok":
+            return agents.AgentResult(
+                text="",
+                ok=False,
+                detail="grok produced malformed final output",
+                failure_phase="output-validation",
+                failure_kind="malformed-final-output",
+                session_id="session-1",
+                requested_model="grok-4.5",
+            )
+        raise AssertionError(f"run_agent must not be called for {cli_ref!r} after fallback preflight fails")
+
+    monkeypatch.setattr(agents, "run_agent", fake_run_agent)
+
+    results = run_transport.dispatch(
+        [Assignment(worker="grok_cli", task="do the thing")],
+        roster,
+        build_prompt=lambda agent, assignment, **kw: assignment.task,
+        run_appserver_worker=lambda *a, **kw: agents.AgentResult(text="", ok=False, detail="unused"),
+        event_writer=lambda events_dir, worker, verbose=False: None,
+        read_only=True,
+        direct=True,
+    )
+
+    assert len(results) == 1
+    result = results[0]
+    assert not result.ok
+    assert result.failure_phase == "preflight"
+    assert result.failure_kind == "provider-config"
+    assert "CLOUDFLARE_ACCOUNT_ID" in result.detail
+    assert "CLOUDFLARE_GATEWAY_ID" in result.detail
+    assert "codex" not in calls
 
 
 def test_endpoint_host_records_all_distinct_hosts(monkeypatch):

--- a/tests/test_run_transport_env.py
+++ b/tests/test_run_transport_env.py
@@ -597,6 +597,10 @@ def test_cloudflare_gateway_preflight_fallback_agent_fails_without_launch(monkey
     assert "CLOUDFLARE_ACCOUNT_ID" in result.detail
     assert "CLOUDFLARE_GATEWAY_ID" in result.detail
     assert "codex" not in calls
+    # The fallback preflight must route through finish() so the accumulated grok
+    # attempt history is preserved, not dropped by returning a bare preflight result.
+    assert len(result.attempts) >= 1
+    assert any(attempt.worker == "grok_cli" for attempt in result.attempts)
 
 
 def test_endpoint_host_records_all_distinct_hosts(monkeypatch):


### PR DESCRIPTION
## What

Fixes #394. A worker seat on a `cloudflare-ai-gateway/<provider>/<model>` route could reach dispatch and then die inside the child with `Error: CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_GATEWAY_ID missing`, recorded as a generic adapter failure. The route identifies the Cloudflare AI Gateway path and the required variable names are static, so this is diagnosable at plan/dispatch time.

## Changes

- **Detection helpers** (`agents.py`): `is_cloudflare_ai_gateway_route` (exact first-segment match, so `cloudflare-ai-gateway-other/...` is rejected), `missing_cloudflare_ai_gateway_env_vars` (empty-string counts as missing), and `cloudflare_ai_gateway_preflight_detail`. Names only — the secret **values** are never read, logged, or interpolated.
- **`roster doctor`** (`roster_cmd.py`): a Cloudflare seat missing either `CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_GATEWAY_ID` fails, naming the missing var(s) and smallest remediation without printing values. Endpoint-mode seats are intentionally exempt.
- **Dispatch preflight on every child-launch path** (`run_transport.py`, `aboyeur.py`): direct worker, the grok invalid-final fallback agent, and the orchestrator seat all preflight before launching. Missing env → `failure_phase=preflight`, `failure_kind=provider-config`, no child launched.
- **Classification propagation**: the provider-config kind reaches worker results, the **top-level run.json** failure fields, and the human summary — not a generic adapter error.

## Tests

`test_agents.py` (route classification incl. near-miss, missing-var lists, empty-string), `test_roster_cmd.py` (doctor OK/FAIL + values-not-echoed), `test_run_transport_env.py` (worker + fallback preflight, no child launched, values-not-echoed), `test_aboyeur.py` (orchestrator preflight fails before planning, `run_agent` asserted never called, run.json top-level classification).

## Verification

`./scripts/verify` green (coverage 82.42% ≥ 78 floor). Captured receipt `20260721-162830-work-verify-e170be`.

> Local reviewers on this machine: run verify with `TMPDIR=/tmp` (a `.cache`-path TMPDIR makes `tests/guard/` spuriously fail; the scanner excludes `.cache`). CI is unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive configuration checks on a specific model route; no changes to auth, data handling, or default run paths when env is set.
> 
> **Overview**
> Adds **early validation** for seats whose `model` is a `cloudflare-ai-gateway/...` route so missing `CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_GATEWAY_ID` fails before any child CLI is launched, with **`preflight` / `provider-config`** classification instead of a generic adapter error.
> 
> New helpers in `agents.py` detect the route (exact first path segment), list missing env vars (empty string counts as missing; only names are surfaced), and build the preflight message. **`roster doctor`** fails or passes a per-agent Cloudflare gateway check; endpoint-mode agents stay exempt.
> 
> Preflight runs on the **orchestrator** (`aboyeur`), **every worker dispatch** (`run_transport`), and the **grok invalid-final fallback** agent. Plan failures that originated from orchestrator preflight now write **`failure_phase: preflight`** on `run.json`, and top-level **`failure_kind`** is only set when a kind is known.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04cc3f8629b9e87174deea44db4b9112d2e7ab70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added preflight validation for Cloudflare AI Gateway configuration before agents run.
  * Added clear diagnostics identifying missing required configuration.
  * Added roster health checks showing whether Cloudflare Gateway configuration is ready.

* **Bug Fixes**
  * Runs now stop safely before execution when provider configuration is incomplete.
  * Run receipts accurately record preflight failures without exposing sensitive configuration values.
  * Fallback execution is skipped when its provider configuration fails validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->