### PR TITLE
fix(work): name the remedy when verify rejects a shell interpreter

### DIFF
--- a/src/brigade/work_cmd/verification.py
+++ b/src/brigade/work_cmd/verification.py
@@ -41,6 +41,22 @@ def _receipt_git_snapshot(target: Path) -> dict[str, Any] | None:
     return {"head": head, "branch": branch, "dirty_files": len(status.stdout.splitlines())}
 
 
+def _high_risk_command_message(executable: str) -> str:
+    """Rejection message for a shell/remote executable used as a verify command.
+
+    Mirrors the shell-metacharacter branch by naming the remedy: verify runs the
+    command directly with no shell, so a shell interpreter is never a valid
+    executable. ``--argv-json`` is deliberately not suggested here because that
+    path applies the same high-risk block, so the fix is a resolvable non-shell
+    executable, e.g. a chmod +x script invoked by its path.
+    """
+    return (
+        f"high-risk verification command: {executable} "
+        "(verify runs with no shell; use a resolvable executable, e.g. a "
+        "chmod +x script run by its path like ./scripts/check.sh)"
+    )
+
+
 def _verify_parse_command(command: str, target: Path) -> tuple[list[str] | None, dict[str, str], str | None]:
     try:
         parts = shlex.split(command)
@@ -57,7 +73,7 @@ def _verify_parse_command(command: str, target: Path) -> tuple[list[str] | None,
         return None, env, "command contains only environment assignments"
     executable = Path(argv[0]).name
     if executable in constants.SCANNER_HIGH_RISK_COMMANDS:
-        return None, env, f"high-risk verification command: {executable}"
+        return None, env, _high_risk_command_message(executable)
     if any(constants.SCANNER_SHELL_META_RE.search(part) for part in argv):
         return (
             None,
@@ -89,7 +105,7 @@ def _verify_parse_argv(argv: list[str], target: Path) -> tuple[list[str] | None,
         return None, {}, "empty command"
     executable = Path(argv[0]).name
     if executable in constants.SCANNER_HIGH_RISK_COMMANDS:
-        return None, {}, f"high-risk verification command: {executable}"
+        return None, {}, _high_risk_command_message(executable)
     if "/" in argv[0]:
         executable_path = Path(argv[0]).expanduser()
         if not executable_path.is_absolute():

--- a/tests/test_work_cmd_verification.py
+++ b/tests/test_work_cmd_verification.py
@@ -375,6 +375,32 @@ def test_work_verify_run_command_still_rejects_shell_metacharacters(tmp_path, ca
     assert "--argv-json" in receipt["commands"][0]["stderr_summary"]
 
 
+@pytest.mark.parametrize(
+    ("option", "value"),
+    [
+        ("--command", "bash ./check.sh"),
+        ("--argv-json", json.dumps(["bash", "-c", "true"])),
+    ],
+)
+def test_work_verify_run_rejects_shell_interpreter_with_remedy(tmp_path, capsys, option, value):
+    # A shell interpreter is never a valid verify executable (verify runs argv
+    # directly with shell=False). Both the --command and --argv-json paths reject
+    # it, and the message must name the remedy - mirroring the metacharacter
+    # branch - so a caller is not left at a dead end. It must NOT point at
+    # --argv-json, which applies the same block.
+    _init_git_repo(tmp_path)
+
+    rc = cli.main(["work", "verify", "run", "--target", str(tmp_path), option, value, "--json"])
+    receipt = json.loads(capsys.readouterr().out)
+    summary = receipt["commands"][0]["stderr_summary"]
+    assert rc != 0
+    assert receipt["status"] == "rejected"
+    assert receipt["commands"][0]["status"] == "rejected"
+    assert "high-risk verification command: bash" in summary
+    assert "resolvable executable" in summary
+    assert "--argv-json" not in summary
+
+
 def test_work_verify_run_command_and_argv_json_are_mutually_exclusive(tmp_path, capsys):
     with pytest.raises(SystemExit) as exc:
         cli.main(


### PR DESCRIPTION
Closes #412.

## What

`verify run` rejects shell interpreters (`bash`, `sh`, `zsh`, ...) as verify
executables, which is correct: verify runs argv directly with `shell=False`, so a
shell interpreter is never a valid executable. But the rejection message
dead-ended at `high-risk verification command: bash`, while the sibling
shell-metacharacter branch already names its remedy (`use --argv-json`). A caller
whose check was `bash ./script.sh` had no pointer to the supported pattern.

## Change

- Add a shared `_high_risk_command_message` helper, used by both the `--command`
  (`_verify_parse_command`) and `--argv-json` (`_verify_parse_argv`) rejection
  sites so the two stay in sync.
- The message names the supported shape (a resolvable executable, e.g. a
  `chmod +x` script invoked by its path) and deliberately does **not** point at
  `--argv-json`, which applies the same high-risk block and so is not a shell
  escape hatch.

Message-only: the set of accepted and rejected commands is unchanged.

## Tests

Adds `test_work_verify_run_rejects_shell_interpreter_with_remedy`, parametrized
over `--command` and `--argv-json`, asserting the rejection carries the remedy
text and does not mention `--argv-json`.

`./scripts/verify` green: ruff, ruff-format, mypy, version-sync, managed-snapshot,
and `3502 passed, 3 skipped`, coverage 82.42%.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved and standardized rejection messaging when high-risk shell interpreters are used as verification commands.
  * Ensured consistent, actionable guidance across both supported input formats for specifying the verify executable.

* **Tests**
  * Added CLI coverage to confirm `work verify run` rejects these high-risk commands in both `--command` and `--argv-json` modes, and that the error details include the recommended remedy without referencing the `--argv-json` flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->