### PR TITLE
feat(doctor): detect competing memory-care queue writers (#403)

### DIFF
--- a/docs/memory-care.md
+++ b/docs/memory-care.md
@@ -63,9 +63,11 @@ Safe fix plans are copied into memory-care imports as metadata so the work inbox
 `brigade memory care scan` writes:
 
 ```text
-memory/cards/decay/scan-latest.json
-memory/cards/decay/refresh-queue.json
+.brigade/memory-care/decay/scan-latest.json
+.brigade/memory-care/decay/refresh-queue.json
 ```
+
+Before 0.9.1, scans wrote to `memory/cards/decay/`. Readers still fall back to that location when the default path has no `scan-latest.json` and the legacy path has existing output, so existing workspaces keep their queue continuity.
 
 Queue entries include card identity, issue type, severity, priority, safe summary, evidence references, suggested refresh action, acceptance criteria, source item key, source fingerprint, and safe fix-plan metadata when available. `brigade memory care import-issues` imports those entries as source `memory-care` task imports with dedupe and dismissed-until-changed behavior.
 

--- a/src/brigade/doctor.py
+++ b/src/brigade/doctor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
 import shutil
 from datetime import date, datetime, timezone
 from pathlib import Path
@@ -80,6 +81,7 @@ def memory_station_checks(ctx: DoctorContext) -> List[CheckResult]:
     checks.extend(_check_memory_cards(ctx.target))
     checks.extend(_check_memory_index(ctx.target))
     checks.extend(_check_memory_care(ctx.target))
+    checks.extend(_check_memory_care_producer_collision(ctx.target))
     return checks
 
 
@@ -624,6 +626,104 @@ def _check_memory_care(target: Path) -> List[CheckResult]:
     else:
         results.append((WARN, "memory-care: refresh-queue", f"missing at {queue}"))
 
+    return results
+
+
+def _is_memory_care_scan_command(command: str) -> bool:
+    """Return True when a scanner command is the Brigade memory-care writer."""
+    try:
+        parts = shlex.split(command.strip())
+    except ValueError:
+        return False
+    return len(parts) >= 4 and parts[:4] == ["brigade", "memory", "care", "scan"]
+
+
+def _check_memory_care_producer_collision(target: Path) -> List[CheckResult]:
+    """Warn when two enabled producers can write the same memory-care artifact.
+
+    This is a read-only migration-planning check. It inspects configured
+    producers, resolves their output destinations, and reports collisions. It
+    never disables a cron job, edits a card, or mutates a queue file.
+    """
+    from . import memory_cmd
+    from .work_cmd.config import _scanner_output_path
+
+    target = target.expanduser().resolve()
+    producer_dirs: dict[Path, set[str]] = {}
+
+    def _add(dir_path: Path, label: str) -> None:
+        producer_dirs.setdefault(dir_path, set()).add(label)
+
+    p1_exists = False
+    config_dir: Path | None = None
+
+    # Brigade memory-care scanner configured for this workspace.
+    if memory_cmd.config_path(target).is_file():
+        p1_exists = True
+        try:
+            config = memory_cmd.load_config(target) or memory_cmd.MemoryCareConfig()
+        except ValueError:
+            config = memory_cmd.MemoryCareConfig()
+        config_dir = memory_cmd._output_dir(target, config).expanduser().resolve()
+        _add(config_dir, "brigade memory-care")
+
+    # Enabled Brigade scanners whose command is the memory-care writer.
+    scanners_path = target / ".brigade" / "scanners.toml"
+    if scanners_path.is_file():
+        try:
+            data = memory_cmd.tomllib.loads(scanners_path.read_text())
+        except (memory_cmd.tomllib.TOMLDecodeError, OSError):
+            data = {}
+        if isinstance(data, dict):
+            for scanner in data.get("scanner", []):
+                if not isinstance(scanner, dict):
+                    continue
+                if not scanner.get("enabled", False):
+                    continue
+                command = scanner.get("command")
+                if not isinstance(command, str) or not _is_memory_care_scan_command(command):
+                    continue
+                p1_exists = True
+                output_path = _scanner_output_path(target, scanner)
+                if output_path is None:
+                    continue
+                scanner_dir = output_path.expanduser().resolve().parent
+                if scanner_dir == config_dir:
+                    # Same producer as the configured writer; do not double-count.
+                    continue
+                _add(scanner_dir, f"brigade memory-care scanner {scanner.get('id', 'unknown')}")
+
+    # Legacy OpenClaw cron producer (only when this target is a memory-care workspace).
+    if p1_exists:
+        jobs_path = Path.home() / ".openclaw" / "cron" / "jobs.json"
+        if jobs_path.is_file():
+            try:
+                data = json.loads(jobs_path.read_text())
+            except (OSError, json.JSONDecodeError):
+                data = {}
+            jobs = data.get("jobs", []) if isinstance(data, dict) else []
+            legacy_job = _find_job(jobs, "Card Decay Scanner (Daily)")
+            if legacy_job is not None and legacy_job.get("enabled", False):
+                legacy_dir = (target / "memory/cards/decay").expanduser().resolve()
+                _add(legacy_dir, "legacy Card Decay Scanner (Daily)")
+
+    results: List[CheckResult] = []
+    for dir_path, labels in sorted(producer_dirs.items()):
+        if len(labels) < 2:
+            continue
+        try:
+            rel = dir_path.relative_to(target)
+        except ValueError:
+            rel = dir_path.name
+        labels_str = ", ".join(sorted(labels))
+        detail = (
+            f"writer collision on `{rel}`: enabled producers are {labels_str}. "
+            "Migration order: (1) verify the Brigade output with `brigade memory care status`; "
+            "(2) point consumers at the Brigade output location; "
+            "(3) disable the legacy 'Card Decay Scanner (Daily)' cron job. "
+            "This check is read-only; no queue files, cards, or cron jobs were changed."
+        )
+        results.append((WARN, "memory-care: producer collision", detail))
     return results
 
 

--- a/src/brigade/memory_cmd.py
+++ b/src/brigade/memory_cmd.py
@@ -79,6 +79,19 @@ def _read_output_dir(target: Path, config: MemoryCareConfig) -> Path:
     return output
 
 
+def memory_care_producer_artifacts(target: Path, config: MemoryCareConfig) -> list[tuple[Path, str]]:
+    """Return the absolute artifact paths produced by the Brigade memory-care scanner.
+
+    Uses the write location (`_output_dir`), not the reader fallback, so
+    producer-collision checks compare actual write destinations.
+    """
+    output = _output_dir(target, config)
+    return [
+        (output / "scan-latest.json", "brigade memory-care"),
+        (output / "refresh-queue.json", "brigade memory-care"),
+    ]
+
+
 def _scan_path(target: Path, config: MemoryCareConfig) -> Path:
     return _read_output_dir(target, config) / "scan-latest.json"
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1058,10 +1058,30 @@ conflict_window = "02:55-03:15"
 
 
 def test_doctor_no_collision_with_shipped_scanners_toml(tmp_target: Path, monkeypatch):
-    """The repo's shipped scanners.toml contains only memory-care consumers; no collision."""
+    """A scanners.toml of only memory-care CONSUMERS (like the shipped one) is no collision.
+
+    Mirrors the shipped registry's memory-care entries (queue readers, not the
+    ``brigade memory care scan`` writer) as an inline fixture, so the test stays
+    hermetic and never reads the repo's own gitignored .brigade/scanners.toml.
+    """
     _write_memory_care_config(tmp_target)  # default Brigade output path
-    shipped = Path(__file__).parent.parent.joinpath(".brigade", "scanners.toml").read_text()
-    _write_scanners_toml(tmp_target, shipped)
+    shipped_consumers = (
+        "[[scanner]]\n"
+        "id = 'memory-refresh'\n"
+        "source = 'memory-refresh'\n"
+        "command = 'brigade work import memory-refresh --json'\n"
+        "cadence = 'daily@02:45'\n"
+        "enabled = true\n"
+        "output_path = 'memory/cards/decay/refresh-queue.json'\n\n"
+        "[[scanner]]\n"
+        "id = 'memory-care'\n"
+        "source = 'memory-care'\n"
+        "command = 'brigade memory care import-issues --json'\n"
+        "cadence = 'daily@03:00'\n"
+        "enabled = false\n"
+        "output_path = 'memory/cards/decay/refresh-queue.json'\n"
+    )
+    _write_scanners_toml(tmp_target, shipped_consumers)
     # Point HOME at the temp target so any host-global cron state is isolated.
     openclaw_dir = tmp_target / ".openclaw"
     (openclaw_dir / "cron").mkdir(parents=True)

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -780,3 +780,294 @@ def test_doctor_collapses_missing_managed_tools_to_one_line(tmp_path, capsys, mo
     manual_lines = [line for line in out.splitlines() if "not installed; run `brigade add" in line]
     assert len(manual_lines) <= 1, manual_lines
     assert "managed tools not installed" in out
+
+
+# --- memory-care producer collision (#403) ---
+
+FAKE_CRON_COMMAND = "FAKE-CRON-PAYLOAD-SECRET-TOKEN-abc123"
+
+
+def _write_openclaw_cron(tmp_target: Path, jobs: list[dict], monkeypatch) -> None:
+    openclaw_dir = tmp_target / ".openclaw"
+    cron_dir = openclaw_dir / "cron"
+    cron_dir.mkdir(parents=True)
+    (openclaw_dir / "openclaw.json").write_text(
+        json.dumps(
+            {
+                "plugins": {"entries": {"memory-core": {}}},
+                "agents": {"defaults": {"model": {"primary": "example-provider/example-model"}}},
+            }
+        )
+    )
+    payload_jobs = []
+    for job in jobs:
+        entry = dict(job)
+        entry.setdefault("command", FAKE_CRON_COMMAND)
+        payload_jobs.append(entry)
+    (cron_dir / "jobs.json").write_text(json.dumps({"jobs": payload_jobs}))
+    monkeypatch.setenv("HOME", str(tmp_target))
+    monkeypatch.setattr(Path, "home", lambda: tmp_target)
+
+
+def _write_scanners_toml(tmp_target: Path, body: str) -> None:
+    brigade = tmp_target / ".brigade"
+    brigade.mkdir(parents=True, exist_ok=True)
+    (brigade / "scanners.toml").write_text(body)
+
+
+def _write_memory_care_config(tmp_target: Path, *, output_path: str | None = None) -> None:
+    brigade = tmp_target / ".brigade"
+    brigade.mkdir(parents=True, exist_ok=True)
+    lines: list[str] = []
+    if output_path is not None:
+        lines.append(f"output_path = {json.dumps(output_path)}")
+    (brigade / "memory-care.toml").write_text("\n".join(lines) + ("\n" if lines else ""))
+
+
+def _producer_collision_checks(results: list) -> list:
+    return [result for result in results if result[1] == "memory-care: producer collision"]
+
+
+def _run_producer_collision_check(tmp_target: Path) -> list:
+    return doctor_mod._check_memory_care_producer_collision(tmp_target)
+
+
+def test_doctor_warns_memory_care_writer_collision(tmp_target: Path, monkeypatch):
+    """A Brigade memory-care scan writer and legacy cron sharing one dir -> one warning."""
+    _write_memory_care_config(tmp_target, output_path="memory/cards/decay")
+    _write_scanners_toml(
+        tmp_target,
+        """
+[[scanner]]
+id = "memory-care-scan"
+source = "memory-care"
+command = "brigade memory care scan"
+cadence = "daily@03:00"
+enabled = true
+timeout = 180
+output_path = "memory/cards/decay/refresh-queue.json"
+conflict_window = "02:55-03:15"
+""",
+    )
+    _write_openclaw_cron(
+        tmp_target,
+        [
+            {
+                "name": "Card Decay Scanner (Daily)",
+                "enabled": True,
+                "schedule": {"kind": "cron", "expr": "30 5 * * *", "tz": "Example/Place"},
+            },
+        ],
+        monkeypatch,
+    )
+
+    results = _run_producer_collision_check(tmp_target)
+    collisions = _producer_collision_checks(results)
+
+    assert len(collisions) == 1
+    status, name, detail = collisions[0]
+    assert status == doctor_mod.WARN
+    assert name == "memory-care: producer collision"
+    assert "memory/cards/decay" in detail
+    assert "brigade memory-care" in detail
+    assert "legacy Card Decay Scanner (Daily)" in detail
+
+
+def test_doctor_no_collision_with_memory_care_consumer_scanner(tmp_target: Path, monkeypatch):
+    """A consumer scanner that reads the queue must not be classified as a producer."""
+    _write_scanners_toml(
+        tmp_target,
+        """
+[[scanner]]
+id = "memory-care"
+source = "memory-care"
+command = "brigade memory care import-issues --json"
+cadence = "daily@03:00"
+enabled = true
+timeout = 180
+output_path = "memory/cards/decay/refresh-queue.json"
+conflict_window = "02:55-03:15"
+""",
+    )
+    _write_openclaw_cron(
+        tmp_target,
+        [
+            {
+                "name": "Card Decay Scanner (Daily)",
+                "enabled": True,
+                "schedule": {"kind": "cron", "expr": "30 5 * * *", "tz": "Example/Place"},
+            },
+        ],
+        monkeypatch,
+    )
+
+    results = _run_producer_collision_check(tmp_target)
+    assert _producer_collision_checks(results) == []
+
+
+def test_doctor_no_collision_with_refresh_consumer(tmp_target: Path, monkeypatch):
+    _write_memory_care_config(tmp_target)
+    _write_openclaw_cron(
+        tmp_target,
+        [
+            {
+                "name": "Card Decay Auto-Refresh (Safe)",
+                "enabled": True,
+                "schedule": {"kind": "cron", "expr": "40 5 * * *", "tz": "Example/Place"},
+            },
+        ],
+        monkeypatch,
+    )
+
+    results = _run_producer_collision_check(tmp_target)
+
+    assert _producer_collision_checks(results) == []
+
+
+def test_doctor_no_collision_with_custom_memory_care_output_path(tmp_target: Path, monkeypatch):
+    _write_memory_care_config(tmp_target, output_path=".brigade/memory-care/custom-decay")
+    _write_openclaw_cron(
+        tmp_target,
+        [
+            {
+                "name": "Card Decay Scanner (Daily)",
+                "enabled": True,
+                "schedule": {"kind": "cron", "expr": "30 5 * * *", "tz": "Example/Place"},
+            },
+        ],
+        monkeypatch,
+    )
+
+    results = _run_producer_collision_check(tmp_target)
+
+    assert _producer_collision_checks(results) == []
+
+
+def test_doctor_warns_when_custom_memory_care_output_collides(tmp_target: Path, monkeypatch):
+    _write_memory_care_config(tmp_target, output_path="memory/cards/decay")
+    _write_openclaw_cron(
+        tmp_target,
+        [
+            {
+                "name": "Card Decay Scanner (Daily)",
+                "enabled": True,
+                "schedule": {"kind": "cron", "expr": "30 5 * * *", "tz": "Example/Place"},
+            },
+        ],
+        monkeypatch,
+    )
+
+    results = _run_producer_collision_check(tmp_target)
+    collisions = _producer_collision_checks(results)
+
+    assert len(collisions) == 1
+    _, _, detail = collisions[0]
+    assert "memory/cards/decay" in detail
+    assert "brigade memory-care" in detail
+    assert "legacy Card Decay Scanner (Daily)" in detail
+
+
+def test_doctor_memory_care_collision_redacts_sensitive_cron_details(tmp_target: Path, monkeypatch):
+    _write_memory_care_config(tmp_target, output_path="memory/cards/decay")
+    _write_scanners_toml(
+        tmp_target,
+        """
+[[scanner]]
+id = "memory-care-scan"
+source = "memory-care"
+command = "brigade memory care scan"
+cadence = "daily@03:00"
+enabled = true
+timeout = 180
+output_path = "memory/cards/decay/refresh-queue.json"
+conflict_window = "02:55-03:15"
+""",
+    )
+    _write_openclaw_cron(
+        tmp_target,
+        [
+            {
+                "name": "Card Decay Scanner (Daily)",
+                "enabled": True,
+                "schedule": {"kind": "cron", "expr": "30 5 * * *", "tz": "Example/Place"},
+            },
+        ],
+        monkeypatch,
+    )
+
+    results = _run_producer_collision_check(tmp_target)
+    collisions = _producer_collision_checks(results)
+    assert len(collisions) == 1
+
+    detail = collisions[0][2]
+    assert "memory/cards/decay" in detail
+    assert FAKE_CRON_COMMAND not in detail
+    assert "SECRET-TOKEN" not in detail
+    assert str(tmp_target) not in detail
+    assert "/home/" not in detail
+    assert "30 5 * * *" not in detail
+    assert "Example/Place" not in detail
+    assert "jobs.json" not in detail
+    assert ".openclaw" not in detail
+
+
+def test_doctor_memory_care_collision_suggested_next_step_is_read_only(tmp_target: Path, monkeypatch):
+    _write_memory_care_config(tmp_target, output_path="memory/cards/decay")
+    _write_scanners_toml(
+        tmp_target,
+        """
+[[scanner]]
+id = "memory-care-scan"
+source = "memory-care"
+command = "brigade memory care scan"
+cadence = "daily@03:00"
+enabled = true
+timeout = 180
+output_path = "memory/cards/decay/refresh-queue.json"
+conflict_window = "02:55-03:15"
+""",
+    )
+    _write_openclaw_cron(
+        tmp_target,
+        [
+            {
+                "name": "Card Decay Scanner (Daily)",
+                "enabled": True,
+                "schedule": {"kind": "cron", "expr": "30 5 * * *", "tz": "Example/Place"},
+            },
+        ],
+        monkeypatch,
+    )
+
+    results = _run_producer_collision_check(tmp_target)
+    collisions = _producer_collision_checks(results)
+    assert len(collisions) == 1
+
+    detail = collisions[0][2].lower()
+    assert "brigade memory care status" in detail
+    assert "read-only" in detail
+    for destructive in ("rm ", "unlink(", "write_text", "edit card", "overwrite"):
+        assert destructive not in detail
+    # The diagnostic must not leak the raw cron payload, schedule, or workspace path.
+    assert FAKE_CRON_COMMAND not in detail
+    assert str(tmp_target) not in detail
+    assert "30 5 * * *" not in detail
+    assert "example/place" not in detail
+    assert "jobs.json" not in detail
+    assert ".openclaw" not in detail
+
+
+def test_doctor_no_collision_with_shipped_scanners_toml(tmp_target: Path, monkeypatch):
+    """The repo's shipped scanners.toml contains only memory-care consumers; no collision."""
+    _write_memory_care_config(tmp_target)  # default Brigade output path
+    shipped = Path(__file__).parent.parent.joinpath(".brigade", "scanners.toml").read_text()
+    _write_scanners_toml(tmp_target, shipped)
+    # Point HOME at the temp target so any host-global cron state is isolated.
+    openclaw_dir = tmp_target / ".openclaw"
+    (openclaw_dir / "cron").mkdir(parents=True)
+    (openclaw_dir / "cron" / "jobs.json").write_text(json.dumps({"jobs": []}))
+    monkeypatch.setenv("HOME", str(tmp_target))
+    monkeypatch.setattr(Path, "home", lambda: tmp_target)
+
+    results = _run_producer_collision_check(tmp_target)
+    assert _producer_collision_checks(results) == []

--- a/tests/test_memory_cmd.py
+++ b/tests/test_memory_cmd.py
@@ -586,3 +586,27 @@ def test_memory_care_backfill_falls_back_to_mtime_outside_git(tmp_path, capsys):
     item = payload["candidates"][0]
     assert item["source"] == "file-mtime"
     assert item["last_reviewed"] == "2026-04-02"
+
+
+def test_memory_care_producer_artifacts_use_write_dir_not_read_fallback(tmp_path):
+    legacy = tmp_path / "memory" / "cards" / "decay"
+    legacy.mkdir(parents=True)
+    (legacy / "scan-latest.json").write_text('{"scan_date": "2026-06-01", "counts": {}}')
+
+    config = memory_cmd.MemoryCareConfig()
+    artifacts = memory_cmd.memory_care_producer_artifacts(tmp_path, config)
+
+    assert artifacts == [
+        (tmp_path / ".brigade" / "memory-care" / "decay" / "scan-latest.json", "brigade memory-care"),
+        (tmp_path / ".brigade" / "memory-care" / "decay" / "refresh-queue.json", "brigade memory-care"),
+    ]
+
+
+def test_memory_care_producer_artifacts_honor_custom_output_path(tmp_path):
+    config = memory_cmd.MemoryCareConfig(output_path=".brigade/memory-care/custom-decay")
+    artifacts = memory_cmd.memory_care_producer_artifacts(tmp_path, config)
+
+    assert artifacts == [
+        (tmp_path / ".brigade" / "memory-care" / "custom-decay" / "scan-latest.json", "brigade memory-care"),
+        (tmp_path / ".brigade" / "memory-care" / "custom-decay" / "refresh-queue.json", "brigade memory-care"),
+    ]


### PR DESCRIPTION
## What
Implements #403. Warns when more than one enabled producer can write the same memory-care `scan-latest.json` / `refresh-queue.json`, with a read-only migration plan. Diagnostic only — never disables a cron job, edits a card, or mutates a queue file.

## Design (producers classified by what they write)
- **P1** Brigade memory-care **scan writer** (`brigade memory care scan` → `_output_dir`, default `.brigade/memory-care/decay/`).
- **P2** legacy OpenClaw cron **"Card Decay Scanner (Daily)"** → `memory/cards/decay/`.
- Reader scanners (`import-issues`, `import memory-refresh`) and the **"Card Decay Auto-Refresh (Safe)"** consumer are never counted as writers (the earlier suffix heuristic misclassified them and false-flagged the repo's own shipped `scanners.toml`).

Directory-level collision (`expanduser`+`resolve`, reusing `_scanner_output_path`) → exactly one WARN per shared dir. Host-global legacy cron producer gated on the target being a memory-care workspace.

## Tests
Collision → one warning; consumer scanner → none; shipped `scanners.toml` → none; custom colliding path → one; safe consumer → none; redaction asserts raw cron command/schedule/`jobs.json`/paths never leak.

## Verification
`./scripts/verify` green (receipt `20260721-173606-work-verify-c2a322`). Local reviewers: run with `TMPDIR=/tmp` (a `.cache`-path TMPDIR spuriously fails `tests/guard/`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added diagnostics to detect conflicting memory-care producers writing to the same artifacts.
  * Added support for custom memory-care output locations when checking for conflicts.
  * Collision warnings include migration guidance and confirm that checks are read-only.

* **Bug Fixes**
  * Improved recognition of memory-care scan commands.
  * Sensitive scheduling and command details are excluded from diagnostic warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->