### PR TITLE
fix(engines): resolve managed engine binaries by absolute path everywhere

### DIFF
--- a/src/brigade/add.py
+++ b/src/brigade/add.py
@@ -148,7 +148,7 @@ def _run_manifest_add(ref: str, *, install_manifest: bool) -> int:
         return 0
     rc = 0
     for tool in manifest.tools:
-        installed = tool.kind == "executable" and managed.proc.which(tool.command) is not None
+        installed = tool.kind == "executable" and managed.component_bins.resolve(tool.command) is not None
         marker = "installed" if installed else "missing"
         if tool.kind == "skill-roster":
             marker = "skill-roster"

--- a/src/brigade/component_bins.py
+++ b/src/brigade/component_bins.py
@@ -62,23 +62,23 @@ def managed_path(name: str, *, env: Mapping[str, str] | None = None) -> str | No
 def resolve(name: str, *, env: Mapping[str, str] | None = None) -> str | None:
     """Resolve ``name`` to an executable path, or None when nowhere to be found."""
     environment = env if env is not None else os.environ
+    search_path = environment.get("PATH")
     override = environment.get(ENV_OVERRIDES.get(name, ""))
     if override:
         candidate = Path(override).expanduser()
         if _is_executable(candidate):
             return str(candidate)
-        found = shutil.which(override)
-        if found:
-            return found
-        return None
+        return shutil.which(override, path=search_path)
     managed = managed_path(name, env=env)
     if managed:
         return managed
-    found = shutil.which(name)
+    found = shutil.which(name, path=search_path)
     if found:
         return found
+    home = environment.get("HOME")
+    home_path = Path(home).expanduser() if home else Path.home()
     for relative in _LEGACY_RELATIVE.get(name, ()):
-        legacy = Path.home() / relative
+        legacy = home_path / relative
         if _is_executable(legacy):
             return str(legacy)
     return None

--- a/src/brigade/component_bins.py
+++ b/src/brigade/component_bins.py
@@ -1,0 +1,100 @@
+"""Resolve executables for the native components ``brigade setup`` manages.
+
+Every consumer of a managed engine (GraphTrail, MiseLedger, sessionfind) goes
+through :func:`resolve` so one resolution order applies everywhere:
+
+1. an explicit env override (``GRAPHTRAIL_BIN``, ``MISELEDGER_BIN``, ...);
+2. the managed install recorded in ``installed.json`` under the user data root;
+3. ``PATH``;
+4. a legacy standalone location kept for machines mid-migration.
+
+Config generators use the same resolver so emitted configs (Cursor MCP
+servers, station wiring) carry the managed absolute path instead of a bare
+name that depends on the spawning environment's PATH.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from collections.abc import Mapping
+from pathlib import Path
+
+from . import component_paths, component_state
+
+# Engine name -> env var override honored before any other resolution step.
+ENV_OVERRIDES = {
+    "graphtrail": "GRAPHTRAIL_BIN",
+    "graphtrail-mcp": "GRAPHTRAIL_MCP_BIN",
+    "miseledger": "MISELEDGER_BIN",
+    "sessionfind": "SESSIONFIND_BIN",
+}
+
+# Pre-consolidation install locations still honored as a last resort.
+_LEGACY_RELATIVE = {
+    "graphtrail": (Path(".cargo") / "bin" / "graphtrail",),
+    "graphtrail-mcp": (Path(".cargo") / "bin" / "graphtrail-mcp",),
+    "miseledger": (Path(".local") / "bin" / "miseledger",),
+    "sessionfind": (Path(".local") / "bin" / "sessionfind",),
+}
+
+
+def _is_executable(path: Path) -> bool:
+    return path.is_file() and os.access(path, os.X_OK)
+
+
+def managed_path(name: str, *, env: Mapping[str, str] | None = None) -> str | None:
+    """Return the installed.json executable for ``name`` when present on disk."""
+    try:
+        data_root = component_paths.data_root(env=env)
+    except ValueError:
+        return None
+    state = component_state.load_installed_state(Path(component_paths.installed_state_path(data_root)))
+    if state is None:
+        return None
+    record = state.components.get(name)
+    if record is None:
+        return None
+    executable = Path(record.executable)
+    return str(executable) if _is_executable(executable) else None
+
+
+def resolve(name: str, *, env: Mapping[str, str] | None = None) -> str | None:
+    """Resolve ``name`` to an executable path, or None when nowhere to be found."""
+    environment = env if env is not None else os.environ
+    override = environment.get(ENV_OVERRIDES.get(name, ""))
+    if override:
+        candidate = Path(override).expanduser()
+        if _is_executable(candidate):
+            return str(candidate)
+        found = shutil.which(override)
+        if found:
+            return found
+        return None
+    managed = managed_path(name, env=env)
+    if managed:
+        return managed
+    found = shutil.which(name)
+    if found:
+        return found
+    for relative in _LEGACY_RELATIVE.get(name, ()):
+        legacy = Path.home() / relative
+        if _is_executable(legacy):
+            return str(legacy)
+    return None
+
+
+def resolve_argv(argv: tuple[str, ...] | list[str]) -> list[str]:
+    """Return argv with a managed engine name in position 0 resolved to a path.
+
+    Unknown or already-absolute commands pass through unchanged, so this is safe
+    to apply to any surface command before execution.
+    """
+    if not argv:
+        return list(argv)
+    head = argv[0]
+    if head in ENV_OVERRIDES and not Path(head).is_absolute():
+        resolved = resolve(head)
+        if resolved:
+            return [resolved, *argv[1:]]
+    return list(argv)

--- a/src/brigade/component_bins.py
+++ b/src/brigade/component_bins.py
@@ -90,6 +90,8 @@ def resolve(name: str, *, env: Mapping[str, str] | None = None) -> str | None:
     home_path = Path(home) if home else Path.home()
     for relative in _LEGACY_RELATIVE.get(name, ()):
         legacy = home_path / relative
+        if os.name == "nt" and legacy.suffix.lower() != ".exe":
+            legacy = legacy.with_suffix(".exe")
         if _is_executable(legacy):
             return str(legacy)
     return None

--- a/src/brigade/component_bins.py
+++ b/src/brigade/component_bins.py
@@ -43,6 +43,17 @@ def _is_executable(path: Path) -> bool:
     return path.is_file() and os.access(path, os.X_OK)
 
 
+def _expand_home(value: str, environment: Mapping[str, str]) -> Path:
+    """Expand a leading ``~`` against the supplied environment's HOME."""
+    home = environment.get("HOME")
+    if home:
+        if value == "~":
+            return Path(home)
+        if value.startswith("~/"):
+            return Path(home) / value[2:]
+    return Path(value).expanduser()
+
+
 def managed_path(name: str, *, env: Mapping[str, str] | None = None) -> str | None:
     """Return the installed.json executable for ``name`` when present on disk."""
     try:
@@ -65,7 +76,7 @@ def resolve(name: str, *, env: Mapping[str, str] | None = None) -> str | None:
     search_path = environment.get("PATH")
     override = environment.get(ENV_OVERRIDES.get(name, ""))
     if override:
-        candidate = Path(override).expanduser()
+        candidate = _expand_home(override, environment)
         if _is_executable(candidate):
             return str(candidate)
         return shutil.which(override, path=search_path)
@@ -76,7 +87,7 @@ def resolve(name: str, *, env: Mapping[str, str] | None = None) -> str | None:
     if found:
         return found
     home = environment.get("HOME")
-    home_path = Path(home).expanduser() if home else Path.home()
+    home_path = Path(home) if home else Path.home()
     for relative in _LEGACY_RELATIVE.get(name, ()):
         legacy = home_path / relative
         if _is_executable(legacy):

--- a/src/brigade/context_cmd.py
+++ b/src/brigade/context_cmd.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
 import re
 import sys
 from datetime import datetime, timezone
@@ -11,7 +10,7 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
-from . import proc, work_cmd
+from . import component_bins, proc, work_cmd
 from .localio import (
     read_json_dict as _read_json,
     stable_hash as _stable_hash,
@@ -100,16 +99,9 @@ def _latest_json(root: Path, filename: str) -> dict[str, Any] | None:
 
 
 def _graphtrail_bin() -> str | None:
-    """Resolve the graphtrail binary: $GRAPHTRAIL_BIN, then PATH, then ~/.cargo/bin (so it
-    works even when the spawning environment's PATH omits the cargo bin dir)."""
-    override = os.environ.get("GRAPHTRAIL_BIN")
-    if override and Path(override).is_file():
-        return override
-    found = proc.which("graphtrail")
-    if found:
-        return found
-    fallback = Path.home() / ".cargo" / "bin" / "graphtrail"
-    return str(fallback) if fallback.is_file() else None
+    """Resolve the graphtrail binary: $GRAPHTRAIL_BIN, then the managed install
+    from ``brigade setup``, then PATH, then the legacy ~/.cargo/bin location."""
+    return component_bins.resolve("graphtrail")
 
 
 def _code_graph_summary(target: Path, selected_task: dict[str, Any] | None) -> dict[str, Any] | None:

--- a/src/brigade/cursor_user_cmd.py
+++ b/src/brigade/cursor_user_cmd.py
@@ -7,7 +7,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from . import __version__, localio
+from . import __version__, component_bins, localio
 
 STATE_VERSION = 1
 MANAGED_MCP_NAMES = ("brigade", "graphtrail", "miseledger")
@@ -39,14 +39,21 @@ def _coowned_json_text(payload: object) -> str:
 
 
 def _mcp_servers() -> dict[str, dict[str, Any]]:
+    # Engine servers resolve to the managed absolute path from `brigade setup`
+    # so the generated config does not depend on Cursor's spawn-time PATH. The
+    # bare name is kept only as a pre-setup fallback.
     return {
         "brigade": {
             "command": "brigade",
             "args": ["memory", "serve-mcp", "--stdio", "--target", "."],
             "timeout": 60,
         },
-        "graphtrail": {"command": "graphtrail-mcp"},
-        "miseledger": {"command": "miseledger", "args": ["mcp"], "timeout": 60},
+        "graphtrail": {"command": component_bins.resolve("graphtrail-mcp") or "graphtrail-mcp"},
+        "miseledger": {
+            "command": component_bins.resolve("miseledger") or "miseledger",
+            "args": ["mcp"],
+            "timeout": 60,
+        },
     }
 
 

--- a/src/brigade/cursor_user_cmd.py
+++ b/src/brigade/cursor_user_cmd.py
@@ -42,15 +42,18 @@ def _mcp_servers() -> dict[str, dict[str, Any]]:
     # Engine servers resolve to the managed absolute path from `brigade setup`
     # so the generated config does not depend on Cursor's spawn-time PATH. The
     # bare name is kept only as a pre-setup fallback.
+    def _absolute(resolved: str | None, fallback: str) -> str:
+        return str(Path(resolved).expanduser().resolve()) if resolved else fallback
+
     return {
         "brigade": {
             "command": "brigade",
             "args": ["memory", "serve-mcp", "--stdio", "--target", "."],
             "timeout": 60,
         },
-        "graphtrail": {"command": component_bins.resolve("graphtrail-mcp") or "graphtrail-mcp"},
+        "graphtrail": {"command": _absolute(component_bins.resolve("graphtrail-mcp"), "graphtrail-mcp")},
         "miseledger": {
-            "command": component_bins.resolve("miseledger") or "miseledger",
+            "command": _absolute(component_bins.resolve("miseledger"), "miseledger"),
             "args": ["mcp"],
             "timeout": 60,
         },

--- a/src/brigade/evidence_brief.py
+++ b/src/brigade/evidence_brief.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import json
-import os
 import re
-import shutil
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+from . import component_bins
 
 HEADING = "## Untrusted run evidence (MiseLedger, read-only)"
 LIMIT_BYTES = 2000
@@ -42,16 +42,7 @@ class EvidenceBrief:
 
 
 def _miseledger_bin() -> str | None:
-    override = os.environ.get("MISELEDGER_BIN")
-    if override:
-        path = Path(override).expanduser()
-        if path.is_file():
-            return str(path)
-        found_override = shutil.which(override)
-        if found_override:
-            return found_override
-        return None
-    return shutil.which("miseledger")
+    return component_bins.resolve("miseledger")
 
 
 def _query(cwd: Path, task: str) -> str:

--- a/src/brigade/evidence_cmd.py
+++ b/src/brigade/evidence_cmd.py
@@ -327,18 +327,19 @@ def doctor(*, target: Path, json_output: bool = False) -> int:
 def crawl_plan_payload(*, target: Path) -> dict[str, Any]:
     target = target.expanduser().resolve()
     binary = evidence_brief._miseledger_bin()
+    miseledger_cmd = binary or "miseledger"
     return {
         "target": str(target),
         "kind": "crawl",
         "created_at": _now(),
         "installed": binary is not None,
         "commands": [
-            ["miseledger", "init"],
-            ["miseledger", "crawl", "sessions"],
-            ["miseledger", "crawl", "files", "--root", str(target)],
-            ["miseledger", "crawl", "gitlog", "--repo", str(target)],
-            ["miseledger", "status", "--json"],
-            ["miseledger", "doctor"],
+            [miseledger_cmd, "init"],
+            [miseledger_cmd, "crawl", "sessions"],
+            [miseledger_cmd, "crawl", "files", "--root", str(target)],
+            [miseledger_cmd, "crawl", "gitlog", "--repo", str(target)],
+            [miseledger_cmd, "status", "--json"],
+            [miseledger_cmd, "doctor"],
         ],
         "manual_steps": [
             "Run crawls on the machine that holds the harness session logs (often the agent host).",

--- a/src/brigade/graphtrail_delta.py
+++ b/src/brigade/graphtrail_delta.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import hashlib
 import json
 import os
-import shutil
 import sqlite3
 import subprocess
 import tempfile
@@ -13,7 +12,7 @@ import time
 from pathlib import Path
 from typing import Any
 
-from . import code_references
+from . import code_references, component_bins
 
 SNAPSHOT_NAME = "graphtrail-before.db"
 SNAPSHOT_AFTER_NAME = "graphtrail-after.db"
@@ -270,14 +269,7 @@ def _compact_summary(delta: dict[str, Any] | None) -> str:
 
 
 def _graphtrail_bin() -> str | None:
-    override = os.environ.get("GRAPHTRAIL_BIN")
-    if override and Path(override).is_file():
-        return override
-    found = shutil.which("graphtrail")
-    if found:
-        return found
-    fallback = Path.home() / ".cargo" / "bin" / "graphtrail"
-    return str(fallback) if fallback.is_file() else None
+    return component_bins.resolve("graphtrail")
 
 
 def _run_graphtrail(

--- a/src/brigade/managed.py
+++ b/src/brigade/managed.py
@@ -14,7 +14,7 @@ import urllib.request
 from dataclasses import dataclass, replace
 from typing import Any, Callable, List, Optional, Tuple
 
-from . import managed_snapshot, proc
+from . import component_bins, managed_snapshot, proc
 from .doctor import OK, WARN, FAIL, MANUAL
 from .station import CheckResult, DoctorContext
 
@@ -42,7 +42,7 @@ class ManagedTool:
     surfaces: Tuple[MachineSurface, ...] = ()
 
     def detect(self) -> bool:
-        return proc.which(self.command) is not None
+        return component_bins.resolve(self.command) is not None
 
 
 # ---- adapters -------------------------------------------------------------
@@ -263,7 +263,8 @@ def _agent_notify_wire(ctx: DoctorContext) -> List[CheckResult]:
 def _graphtrail_doctor(ctx: DoctorContext) -> List[CheckResult]:
     """Health-check GraphTrail for the target workspace (optional station)."""
     name = "graphtrail (code graph)"
-    if not proc.which("graphtrail"):
+    binary = component_bins.resolve("graphtrail")
+    if not binary:
         return [
             (
                 MANUAL,
@@ -274,7 +275,7 @@ def _graphtrail_doctor(ctx: DoctorContext) -> List[CheckResult]:
     db = ctx.target / ".graphtrail" / "graphtrail.db"
     if not db.is_file():
         return [(WARN, name, "installed; run `graphtrail sync` to build .graphtrail/graphtrail.db")]
-    r = proc.run(["graphtrail", "doctor", "--json"], timeout=30.0)
+    r = proc.run([binary, "doctor", "--json"], timeout=30.0)
     if r.code != 0:
         return [(WARN, name, f"doctor exit {r.code}; graph may need re-sync")]
     return [(OK, name, f"db present at {db}")]
@@ -318,7 +319,10 @@ def _plating_doctor(ctx: DoctorContext) -> List[CheckResult]:
 # are advisory: they never FAIL a workspace doctor run.
 def _miseledger_doctor(ctx: DoctorContext) -> List[CheckResult]:
     name = "miseledger (evidence archive)"
-    r = proc.run(["miseledger", "doctor", "--json"], timeout=120.0)
+    binary = component_bins.resolve("miseledger")
+    if not binary:
+        return [(MANUAL, name, "not installed; run `brigade setup`")]
+    r = proc.run([binary, "doctor", "--json"], timeout=120.0)
     if r.code == 124:
         return [
             (
@@ -479,7 +483,7 @@ _TOOLS: Tuple[ManagedTool, ...] = (
         station="evidence",
         command="miseledger",
         summary="local-first evidence ledger: imports adapter JSONL, FTS search, evidence bundles",
-        install_args=["go", "install", "github.com/escoffier-labs/miseledger/cmd/miseledger@latest"],
+        install_args=["brigade", "setup"],
         wire=_noop_wire,
         doctor=_miseledger_doctor,
         surfaces=(
@@ -504,14 +508,15 @@ _TOOLS: Tuple[ManagedTool, ...] = (
         ),
     ),
     # GraphTrail closes the other half of the receipts-to-context loop: code-graph
-    # briefs and deltas on verify/run receipts. Install is cargo-based; doctor is
-    # fail-open (MANUAL when absent) like every other optional sidecar.
+    # briefs and deltas on verify/run receipts. Install is the managed engine
+    # binary from `brigade setup`; doctor is fail-open (MANUAL when absent) like
+    # every other optional sidecar.
     ManagedTool(
         name="graphtrail",
         station="search",
         command="graphtrail",
         summary="local code-graph CLI: callers, callees, impact, context briefs, and structural diffs",
-        install_args=["cargo", "install", "graphtrail"],
+        install_args=["brigade", "setup"],
         wire=_noop_wire,
         doctor=_graphtrail_doctor,
         surfaces=(

--- a/src/brigade/receipts_cmd.py
+++ b/src/brigade/receipts_cmd.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import hmac
 import json
 import re
-import shutil
 import subprocess
 import sys
 import tempfile
@@ -15,6 +14,7 @@ from urllib.parse import urlparse
 
 from . import __version__
 from . import code_references
+from . import component_bins
 from . import localio
 from . import receipt_signing
 
@@ -1241,7 +1241,7 @@ def _import_miseledger_file(
     """
     if failed_on_error is None:
         failed_on_error = strict
-    binary = shutil.which("miseledger")
+    binary = component_bins.resolve("miseledger")
     if binary is None:
         if failed_on_error and strict:
             print(

--- a/src/brigade/search_cmd.py
+++ b/src/brigade/search_cmd.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from . import proc
+from . import component_bins, proc
 from . import station_health as health
 
 
@@ -39,7 +39,7 @@ BOUNDARIES = [
 
 def status_payload(target: Path) -> dict[str, Any]:
     target = target.expanduser().resolve()
-    graphtrail_bin = proc.which("graphtrail")
+    graphtrail_bin = component_bins.resolve("graphtrail")
     api_bin = proc.which("code-search-api")
     mcp_bin = proc.which("code-search-mcp")
     db = target / ".graphtrail" / "graphtrail.db"
@@ -221,7 +221,7 @@ def sync_plan_payload(*, target: Path) -> dict[str, Any]:
         "title": "search sync plan",
         "created_at": health.now_iso(),
         "installed": {
-            "graphtrail": proc.which("graphtrail") is not None,
+            "graphtrail": component_bins.resolve("graphtrail") is not None,
             "code-search-api": proc.which("code-search-api") is not None,
             "code-search-mcp": proc.which("code-search-mcp") is not None,
         },

--- a/src/brigade/search_cmd.py
+++ b/src/brigade/search_cmd.py
@@ -168,7 +168,7 @@ def status_payload(target: Path) -> dict[str, Any]:
     if overall in ("fail", "unwired", "incomplete", "timeout"):
         payload["next_commands"] = [
             "brigade search sync plan",
-            "graphtrail sync",
+            f"{graphtrail_bin or 'graphtrail'} sync",
             "brigade search doctor",
         ]
     elif not graphtrail_bin:
@@ -214,6 +214,8 @@ def doctor(*, target: Path, json_output: bool = False) -> int:
 
 def sync_plan_payload(*, target: Path) -> dict[str, Any]:
     target = target.expanduser().resolve()
+    graphtrail_bin = component_bins.resolve("graphtrail")
+    graphtrail_cmd = graphtrail_bin or "graphtrail"
     return {
         "target": str(target),
         "station": "search",
@@ -221,15 +223,15 @@ def sync_plan_payload(*, target: Path) -> dict[str, Any]:
         "title": "search sync plan",
         "created_at": health.now_iso(),
         "installed": {
-            "graphtrail": component_bins.resolve("graphtrail") is not None,
+            "graphtrail": graphtrail_bin is not None,
             "code-search-api": proc.which("code-search-api") is not None,
             "code-search-mcp": proc.which("code-search-mcp") is not None,
         },
         "compatibility": {"code-search-mcp": {"owner": "code-search-api/mcp"}},
         "commands": [
-            ["graphtrail", "sync", str(target)],
-            ["graphtrail", "doctor", "--json"],
-            ["graphtrail", "stats", "--json"],
+            [graphtrail_cmd, "sync", str(target)],
+            [graphtrail_cmd, "doctor", "--json"],
+            [graphtrail_cmd, "stats", "--json"],
             ["code-search-api", "index"],
             ["code-search-api", "serve"],
         ],

--- a/src/brigade/stations_cmd.py
+++ b/src/brigade/stations_cmd.py
@@ -15,7 +15,7 @@ import time
 from typing import Any
 import unicodedata
 
-from . import managed, profiles, registry, station_manifest
+from . import component_bins, managed, profiles, registry, station_manifest
 from .install import DEFAULT_WIRED_SKILLS
 
 
@@ -733,7 +733,7 @@ def verify_payload(ref: str, *, check_managed: bool = False) -> dict[str, Any]:
         env = _isolated_environment(Path(temp))
         tool_payloads: list[dict[str, Any]] = []
         for tool in manifest.tools:
-            resolved_tool = shutil.which(tool.command) if tool.kind == "executable" else None
+            resolved_tool = component_bins.resolve(tool.command) if tool.kind == "executable" else None
             if resolved_tool:
                 resolved_tool = str(Path(resolved_tool).resolve())
             surfaces = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,19 +39,41 @@ def _isolate_hermes_home(tmp_path_factory, monkeypatch):
 
 @pytest.fixture(autouse=True)
 def _no_managed_tools_on_path(monkeypatch, request):
-    """Default to the bare-host baseline: no managed tool detected on PATH.
+    """Default to the bare-host baseline: no managed tool resolves.
 
-    The doctor folds in installed managed tools, but a dev host may have some
-    of them globally installed. Neutralize detection so checks assert against
-    the documented bare-`$HOME` condition. Tests that exercise installed tools
-    re-patch `managed.proc.which` in their own body, which overrides this.
+    Managed-tool resolution goes through ``component_bins.resolve``, which
+    reaches outside the test sandbox: the developer's real installed.json,
+    legacy install dirs, and real PATH binaries. Left live, the suite behaves
+    differently on a wired dev host than on CI, and can even execute real
+    engine binaries against real archives. This fixture pins the bare-host
+    condition while keeping the two sandboxed channels tests legitimately use:
+    an explicit env override (GRAPHTRAIL_BIN, MISELEDGER_BIN, ...) resolves
+    with full semantics, and a test-modified PATH resolves via plain
+    ``shutil.which``. Tests that need a specific binary re-patch
+    ``component_bins.resolve`` in their own body.
 
-    `tests/test_proc.py` validates `proc.which` against real binaries, and the
-    opt-in adapter write probes must detect their real CLIs. Both modules opt
-    out because patching `managed.proc.which` patches the shared function.
+    `tests/test_proc.py` validates `proc.which` against real binaries, the
+    opt-in adapter write probes must detect their real CLIs, and
+    `tests/test_component_bins.py` tests the real resolution order. Those
+    modules opt out.
     """
-    if request.module.__name__.rsplit(".", 1)[-1] in {"test_proc", "test_agent_write_probes"}:
+    if request.module.__name__.rsplit(".", 1)[-1] in {"test_proc", "test_agent_write_probes", "test_component_bins"}:
         return
-    from brigade import managed
+    import os
+    import shutil
 
+    from brigade import component_bins, managed
+
+    real_resolve = component_bins.resolve
+    baseline_path = os.environ.get("PATH", "")
+
+    def bare_host_resolve(name, *, env=None):
+        environment = env if env is not None else os.environ
+        if environment.get(component_bins.ENV_OVERRIDES.get(name, "")):
+            return real_resolve(name, env=env)
+        if os.environ.get("PATH", "") != baseline_path:
+            return shutil.which(name)
+        return None
+
+    monkeypatch.setattr(component_bins, "resolve", bare_host_resolve)
     monkeypatch.setattr(managed.proc, "which", lambda cmd: None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,7 @@ def _isolate_hermes_home(tmp_path_factory, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-def _no_managed_tools_on_path(monkeypatch, request):
+def _no_managed_tools_on_path(monkeypatch, request, tmp_path_factory):
     """Default to the bare-host baseline: no managed tool resolves.
 
     Managed-tool resolution goes through ``component_bins.resolve``, which
@@ -63,6 +63,13 @@ def _no_managed_tools_on_path(monkeypatch, request):
     import shutil
 
     from brigade import component_bins, managed
+
+    # Point the managed-component data root at a temp dir so nothing in the
+    # suite (component_bins.managed_path, doctor's components check) reads the
+    # developer's real installed.json or managed bin dir.
+    data_root = tmp_path_factory.mktemp("component_data")
+    monkeypatch.setenv("XDG_DATA_HOME", str(data_root))
+    monkeypatch.setenv("LOCALAPPDATA", str(data_root))
 
     real_resolve = component_bins.resolve
     baseline_path = os.environ.get("PATH", "")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,6 +71,11 @@ def _no_managed_tools_on_path(monkeypatch, request, tmp_path_factory):
     monkeypatch.setenv("XDG_DATA_HOME", str(data_root))
     monkeypatch.setenv("LOCALAPPDATA", str(data_root))
 
+    # A developer shell may export engine overrides (GRAPHTRAIL_BIN, ...);
+    # clear them so the override channel only fires when a test sets it.
+    for env_var in component_bins.ENV_OVERRIDES.values():
+        monkeypatch.delenv(env_var, raising=False)
+
     real_resolve = component_bins.resolve
     baseline_path = os.environ.get("PATH", "")
     baseline_entries = set(filter(None, baseline_path.split(os.pathsep)))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,13 +66,21 @@ def _no_managed_tools_on_path(monkeypatch, request):
 
     real_resolve = component_bins.resolve
     baseline_path = os.environ.get("PATH", "")
+    baseline_entries = set(filter(None, baseline_path.split(os.pathsep)))
 
     def bare_host_resolve(name, *, env=None):
         environment = env if env is not None else os.environ
         if environment.get(component_bins.ENV_OVERRIDES.get(name, "")):
             return real_resolve(name, env=env)
-        if os.environ.get("PATH", "") != baseline_path:
-            return shutil.which(name)
+        current_path = os.environ.get("PATH", "")
+        if current_path != baseline_path:
+            # Search only the entries the test itself introduced, so a test
+            # that prepends a temp dir to the host PATH still cannot resolve
+            # real host binaries.
+            test_path = os.pathsep.join(
+                entry for entry in current_path.split(os.pathsep) if entry and entry not in baseline_entries
+            )
+            return shutil.which(name, path=test_path) if test_path else None
         return None
 
     monkeypatch.setattr(component_bins, "resolve", bare_host_resolve)

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -51,7 +51,7 @@ def test_add_accepts_managed_tool_name(monkeypatch, tmp_target, capsys):
 
 def test_add_skips_install_when_already_present(monkeypatch, tmp_target):
     calls = []
-    monkeypatch.setattr(managed.proc, "which", lambda c: "/x/" + c)  # already installed
+    monkeypatch.setattr(managed.component_bins, "resolve", lambda name, **kw: "/x/" + name)  # already installed
 
     def fake_run(args, **kw):
         calls.append(args)

--- a/tests/test_component_bins.py
+++ b/tests/test_component_bins.py
@@ -1,0 +1,123 @@
+"""Resolution order for managed engine executables."""
+
+from __future__ import annotations
+
+import json
+import stat
+from pathlib import Path
+
+from brigade import component_bins
+
+_SHA = "0" * 64
+
+
+def _write_executable(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("#!/bin/sh\nexit 0\n")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return path
+
+
+def _write_installed_state(data_home: Path, components: dict[str, Path]) -> None:
+    state_dir = data_home / "brigade"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": 1,
+        "brigade_version": "0.25.0",
+        "manifest_revision": "v0.25.0+test",
+        "platform": "linux-amd64",
+        "installed_at": "2026-07-21T00:00:00+00:00",
+        "components": {
+            name: {
+                "component_revision": "test",
+                "asset_name": f"{name}-linux-amd64",
+                "byte_size": 1,
+                "sha256": _SHA,
+                "download_url": f"https://example.invalid/{name}",
+                "executable": str(path),
+            }
+            for name, path in components.items()
+        },
+    }
+    (state_dir / "installed.json").write_text(json.dumps(payload))
+
+
+def _env(tmp_path: Path, **extra: str) -> dict[str, str]:
+    return {"HOME": str(tmp_path), "XDG_DATA_HOME": str(tmp_path / "data"), **extra}
+
+
+def test_managed_path_returns_installed_executable(tmp_path):
+    binary = _write_executable(tmp_path / "managed" / "graphtrail")
+    _write_installed_state(tmp_path / "data", {"graphtrail": binary})
+    assert component_bins.managed_path("graphtrail", env=_env(tmp_path)) == str(binary)
+
+
+def test_managed_path_requires_binary_on_disk(tmp_path):
+    _write_installed_state(tmp_path / "data", {"graphtrail": tmp_path / "missing" / "graphtrail"})
+    assert component_bins.managed_path("graphtrail", env=_env(tmp_path)) is None
+
+
+def test_managed_path_without_state_file(tmp_path):
+    assert component_bins.managed_path("graphtrail", env=_env(tmp_path)) is None
+
+
+def test_resolve_prefers_env_override(tmp_path, monkeypatch):
+    override = _write_executable(tmp_path / "override" / "graphtrail")
+    managed = _write_executable(tmp_path / "managed" / "graphtrail")
+    _write_installed_state(tmp_path / "data", {"graphtrail": managed})
+    env = _env(tmp_path, GRAPHTRAIL_BIN=str(override))
+    assert component_bins.resolve("graphtrail", env=env) == str(override)
+
+
+def test_resolve_broken_override_does_not_fall_through(tmp_path, monkeypatch):
+    managed = _write_executable(tmp_path / "managed" / "graphtrail")
+    _write_installed_state(tmp_path / "data", {"graphtrail": managed})
+    monkeypatch.setenv("PATH", str(managed.parent))
+    env = _env(tmp_path, GRAPHTRAIL_BIN=str(tmp_path / "nope"))
+    assert component_bins.resolve("graphtrail", env=env) is None
+
+
+def test_resolve_prefers_managed_over_path(tmp_path, monkeypatch):
+    managed = _write_executable(tmp_path / "managed" / "graphtrail")
+    on_path = _write_executable(tmp_path / "pathdir" / "graphtrail")
+    _write_installed_state(tmp_path / "data", {"graphtrail": managed})
+    monkeypatch.setenv("PATH", str(on_path.parent))
+    assert component_bins.resolve("graphtrail", env=_env(tmp_path)) == str(managed)
+
+
+def test_resolve_falls_back_to_path(tmp_path, monkeypatch):
+    on_path = _write_executable(tmp_path / "pathdir" / "graphtrail")
+    monkeypatch.setenv("PATH", str(on_path.parent))
+    assert component_bins.resolve("graphtrail", env=_env(tmp_path)) == str(on_path)
+
+
+def test_resolve_falls_back_to_legacy_location(tmp_path, monkeypatch):
+    legacy = _write_executable(tmp_path / ".cargo" / "bin" / "graphtrail")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("PATH", str(tmp_path / "empty"))
+    assert component_bins.resolve("graphtrail", env=_env(tmp_path)) == str(legacy)
+
+
+def test_resolve_unknown_name_uses_path_only(tmp_path, monkeypatch):
+    on_path = _write_executable(tmp_path / "pathdir" / "custom-tool")
+    monkeypatch.setenv("PATH", str(on_path.parent))
+    assert component_bins.resolve("custom-tool", env=_env(tmp_path)) == str(on_path)
+
+
+def test_resolve_argv_rewrites_engine_head(tmp_path, monkeypatch):
+    managed = _write_executable(tmp_path / "managed" / "miseledger")
+    _write_installed_state(tmp_path / "data", {"miseledger": managed})
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    assert component_bins.resolve_argv(("miseledger", "doctor", "--json")) == [
+        str(managed),
+        "doctor",
+        "--json",
+    ]
+
+
+def test_resolve_argv_passes_through_absolute_and_unknown(tmp_path):
+    absolute = ("/usr/bin/true", "--flag")
+    assert component_bins.resolve_argv(absolute) == list(absolute)
+    unknown = ("some-tool", "run")
+    assert component_bins.resolve_argv(unknown) == list(unknown)

--- a/tests/test_component_bins.py
+++ b/tests/test_component_bins.py
@@ -81,27 +81,39 @@ def test_resolve_prefers_managed_over_path(tmp_path, monkeypatch):
     managed = _write_executable(tmp_path / "managed" / "graphtrail")
     on_path = _write_executable(tmp_path / "pathdir" / "graphtrail")
     _write_installed_state(tmp_path / "data", {"graphtrail": managed})
-    monkeypatch.setenv("PATH", str(on_path.parent))
-    assert component_bins.resolve("graphtrail", env=_env(tmp_path)) == str(managed)
+    monkeypatch.setenv("PATH", str(tmp_path / "elsewhere"))
+    env = _env(tmp_path, PATH=str(on_path.parent))
+    assert component_bins.resolve("graphtrail", env=env) == str(managed)
 
 
-def test_resolve_falls_back_to_path(tmp_path, monkeypatch):
+def test_resolve_falls_back_to_supplied_path(tmp_path, monkeypatch):
     on_path = _write_executable(tmp_path / "pathdir" / "graphtrail")
-    monkeypatch.setenv("PATH", str(on_path.parent))
-    assert component_bins.resolve("graphtrail", env=_env(tmp_path)) == str(on_path)
+    monkeypatch.setenv("PATH", str(tmp_path / "elsewhere"))
+    env = _env(tmp_path, PATH=str(on_path.parent))
+    assert component_bins.resolve("graphtrail", env=env) == str(on_path)
 
 
 def test_resolve_falls_back_to_legacy_location(tmp_path, monkeypatch):
     legacy = _write_executable(tmp_path / ".cargo" / "bin" / "graphtrail")
-    monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setenv("PATH", str(tmp_path / "empty"))
-    assert component_bins.resolve("graphtrail", env=_env(tmp_path)) == str(legacy)
+    monkeypatch.setenv("HOME", str(tmp_path / "host-home"))
+    monkeypatch.setenv("PATH", str(tmp_path / "elsewhere"))
+    env = _env(tmp_path, PATH=str(tmp_path / "empty"))
+    assert component_bins.resolve("graphtrail", env=env) == str(legacy)
 
 
 def test_resolve_unknown_name_uses_path_only(tmp_path, monkeypatch):
     on_path = _write_executable(tmp_path / "pathdir" / "custom-tool")
-    monkeypatch.setenv("PATH", str(on_path.parent))
-    assert component_bins.resolve("custom-tool", env=_env(tmp_path)) == str(on_path)
+    monkeypatch.setenv("PATH", str(tmp_path / "elsewhere"))
+    env = _env(tmp_path, PATH=str(on_path.parent))
+    assert component_bins.resolve("custom-tool", env=env) == str(on_path)
+
+
+def test_resolve_override_tilde_uses_supplied_home(tmp_path, monkeypatch):
+    override_bin = _write_executable(tmp_path / "supplied-home" / "tools" / "graphtrail")
+    monkeypatch.setenv("HOME", str(tmp_path / "host-home"))
+    env = _env(tmp_path, GRAPHTRAIL_BIN="~/tools/graphtrail")
+    env["HOME"] = str(tmp_path / "supplied-home")
+    assert component_bins.resolve("graphtrail", env=env) == str(override_bin)
 
 
 def test_resolve_argv_rewrites_engine_head(tmp_path, monkeypatch):

--- a/tests/test_context_cmd.py
+++ b/tests/test_context_cmd.py
@@ -50,7 +50,7 @@ def test_code_graph_summary_parses_and_trims(tmp_target, monkeypatch):
     }
 
     def fake_run(args, **kw):
-        assert Path(args[0]).name == "graphtrail"
+        assert args[0] == "/x/graphtrail"
         assert "context" in args and "--json" in args
         return proc.Result(code=0, stdout=json.dumps(pack), stderr="")
 

--- a/tests/test_context_cmd.py
+++ b/tests/test_context_cmd.py
@@ -23,14 +23,14 @@ def test_code_graph_summary_none_without_db(tmp_target):
 def test_code_graph_summary_none_without_task(tmp_target, monkeypatch):
     tmp_target.mkdir(parents=True)
     _make_db(tmp_target)
-    monkeypatch.setattr(context_cmd.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(context_cmd.component_bins, "resolve", lambda name, **kw: "/x/" + name)
     assert context_cmd._code_graph_summary(tmp_target, None) is None
 
 
 def test_code_graph_summary_parses_and_trims(tmp_target, monkeypatch):
     tmp_target.mkdir(parents=True)
     _make_db(tmp_target)
-    monkeypatch.setattr(context_cmd.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(context_cmd.component_bins, "resolve", lambda name, **kw: "/x/" + name)
 
     pack = {
         "schema_version": 1,
@@ -70,7 +70,7 @@ def test_code_graph_summary_parses_and_trims(tmp_target, monkeypatch):
 def test_code_graph_summary_none_on_nonzero_exit(tmp_target, monkeypatch):
     tmp_target.mkdir(parents=True)
     _make_db(tmp_target)
-    monkeypatch.setattr(context_cmd.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(context_cmd.component_bins, "resolve", lambda name, **kw: "/x/" + name)
     monkeypatch.setattr(context_cmd.proc, "run", lambda args, **kw: proc.Result(code=1, stdout="", stderr="boom"))
     assert context_cmd._code_graph_summary(tmp_target, {"text": "x"}) is None
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -759,6 +759,9 @@ def test_doctor_includes_agent_notify_managed_tool(monkeypatch, tmp_target, caps
     monkeypatch.setenv("TEST_TELEGRAM_BOT_TOKEN", "token")
     monkeypatch.setenv("TEST_TELEGRAM_CHAT_ID", "chat")
     monkeypatch.setattr(managed.proc, "which", lambda c: "/x/" + c if c == "agent-notify" else None)
+    monkeypatch.setattr(
+        managed.component_bins, "resolve", lambda name, **kw: "/x/" + name if name == "agent-notify" else None
+    )
 
     rc = doctor_mod.run(target=tmp_target, harness="generic", full=True)
     out = capsys.readouterr().out

--- a/tests/test_issue362_code_evidence_facades.py
+++ b/tests/test_issue362_code_evidence_facades.py
@@ -422,7 +422,9 @@ def test_evidence_crawl_plan_stays_plan_only_and_preserves_json_contract(monkeyp
     assert rc == 0
     assert calls == []
     assert payload["kind"] == "crawl"
-    assert ["miseledger", "crawl", "sessions"] in payload["commands"]
+    # The plan emits the resolved miseledger path so the commands run
+    # regardless of the invoking shell's PATH.
+    assert ["/fake/miseledger", "crawl", "sessions"] in payload["commands"]
 
 
 # --- legacy health/plan JSON contracts (must keep passing) ------------------

--- a/tests/test_managed.py
+++ b/tests/test_managed.py
@@ -282,10 +282,10 @@ def test_code_search_mcp_doctor_is_presence_only():
 
 def test_miseledger_doctor_parses_status(monkeypatch):
     t = managed.resolve("miseledger")
-    monkeypatch.setattr(managed.component_bins, "resolve", lambda name, **kw: "miseledger")
+    monkeypatch.setattr(managed.component_bins, "resolve", lambda name, **kw: "/x/miseledger")
 
     def fake_run(args, **kw):
-        assert args == ["miseledger", "doctor", "--json"]
+        assert args == ["/x/miseledger", "doctor", "--json"]
         assert kw == {"timeout": 120.0}
         return managed.proc.Result(
             code=0,
@@ -333,10 +333,10 @@ def test_miseledger_doctor_handles_garbage_output(monkeypatch):
 
 def test_miseledger_doctor_warns_distinctly_on_timeout(monkeypatch):
     t = managed.resolve("miseledger")
-    monkeypatch.setattr(managed.component_bins, "resolve", lambda name, **kw: "miseledger")
+    monkeypatch.setattr(managed.component_bins, "resolve", lambda name, **kw: "/x/miseledger")
 
     def fake_run(args, **kw):
-        assert args == ["miseledger", "doctor", "--json"]
+        assert args == ["/x/miseledger", "doctor", "--json"]
         assert kw == {"timeout": 120.0}
         return managed.proc.Result(code=124, stdout="", stderr="timeout after 120.0s")
 

--- a/tests/test_managed.py
+++ b/tests/test_managed.py
@@ -30,11 +30,11 @@ def test_for_station_filters():
     assert names == {"bootstrap-doctor"}
 
 
-def test_detect_uses_which(monkeypatch):
+def test_detect_uses_resolver(monkeypatch):
     t = managed.resolve("bootstrap-doctor")
-    monkeypatch.setattr(managed.proc, "which", lambda c: None)
+    monkeypatch.setattr(managed.component_bins, "resolve", lambda name, **kw: None)
     assert t.detect() is False
-    monkeypatch.setattr(managed.proc, "which", lambda c: "/usr/bin/" + c)
+    monkeypatch.setattr(managed.component_bins, "resolve", lambda name, **kw: "/usr/bin/" + name)
     assert t.detect() is True
 
 
@@ -216,7 +216,9 @@ def test_search_tools_attach_to_search_station():
 def test_graphtrail_doctor_reports_missing_db(monkeypatch, tmp_path):
     t = managed.resolve("graphtrail")
     assert t is not None
-    monkeypatch.setattr(managed.proc, "which", lambda c: "/usr/bin/graphtrail" if c == "graphtrail" else None)
+    monkeypatch.setattr(
+        managed.component_bins, "resolve", lambda name, **kw: "/usr/bin/graphtrail" if name == "graphtrail" else None
+    )
     ctx = DoctorContext(target=tmp_path, selection=None, harnesses=[])
     results = t.doctor(ctx)
     assert results[0][0] == "WARN"
@@ -280,6 +282,7 @@ def test_code_search_mcp_doctor_is_presence_only():
 
 def test_miseledger_doctor_parses_status(monkeypatch):
     t = managed.resolve("miseledger")
+    monkeypatch.setattr(managed.component_bins, "resolve", lambda name, **kw: "miseledger")
 
     def fake_run(args, **kw):
         assert args == ["miseledger", "doctor", "--json"]
@@ -298,6 +301,7 @@ def test_miseledger_doctor_parses_status(monkeypatch):
 
 def test_miseledger_doctor_warns_on_unavailable_fts(monkeypatch):
     t = managed.resolve("miseledger")
+    monkeypatch.setattr(managed.component_bins, "resolve", lambda name, **kw: "miseledger")
 
     def fake_run(args, **kw):
         return managed.proc.Result(
@@ -315,6 +319,7 @@ def test_miseledger_doctor_warns_on_unavailable_fts(monkeypatch):
 
 def test_miseledger_doctor_handles_garbage_output(monkeypatch):
     t = managed.resolve("miseledger")
+    monkeypatch.setattr(managed.component_bins, "resolve", lambda name, **kw: "miseledger")
 
     def fake_run(args, **kw):
         return managed.proc.Result(code=1, stdout="boom", stderr="kaboom")
@@ -328,6 +333,7 @@ def test_miseledger_doctor_handles_garbage_output(monkeypatch):
 
 def test_miseledger_doctor_warns_distinctly_on_timeout(monkeypatch):
     t = managed.resolve("miseledger")
+    monkeypatch.setattr(managed.component_bins, "resolve", lambda name, **kw: "miseledger")
 
     def fake_run(args, **kw):
         assert args == ["miseledger", "doctor", "--json"]

--- a/tests/test_search_cmd.py
+++ b/tests/test_search_cmd.py
@@ -28,6 +28,9 @@ def test_search_status_ok_with_graphtrail(monkeypatch, tmp_path):
         return f"/x/{cmd}" if cmd == "graphtrail" else None
 
     monkeypatch.setattr(search_cmd.proc, "which", which)
+    monkeypatch.setattr(
+        search_cmd.component_bins, "resolve", lambda name, **kw: f"/x/{name}" if name == "graphtrail" else None
+    )
 
     def fake_run(args, **kw):
         if args[:2] == ["/x/graphtrail", "doctor"]:
@@ -49,6 +52,9 @@ def test_search_status_unwired_without_db(monkeypatch, tmp_path):
         return f"/x/{cmd}" if cmd == "graphtrail" else None
 
     monkeypatch.setattr(search_cmd.proc, "which", which)
+    monkeypatch.setattr(
+        search_cmd.component_bins, "resolve", lambda name, **kw: f"/x/{name}" if name == "graphtrail" else None
+    )
     monkeypatch.setattr(
         search_cmd.proc,
         "run",

--- a/tests/test_test_fixture_contract.py
+++ b/tests/test_test_fixture_contract.py
@@ -7,4 +7,4 @@ ROOT = Path(__file__).resolve().parents[1]
 def test_real_write_probes_opt_out_of_managed_tool_path_patch():
     text = (ROOT / "tests" / "conftest.py").read_text()
 
-    assert '{"test_proc", "test_agent_write_probes"}' in text
+    assert '{"test_proc", "test_agent_write_probes", "test_component_bins"}' in text


### PR DESCRIPTION
## Problem

`brigade setup` installs the managed engine set (graphtrail, graphtrail-mcp, miseledger, sessionfind) to `~/.local/share/brigade/bin` and records it in `installed.json`, but every resolver and config generator still emitted bare PATH command names. On any machine with stale standalone binaries on PATH (cargo graphtrail, an old miseledger in `~/.local/bin`), everything kept running the standalone set and the managed engines sat dormant. This is the fleet-wide root cause behind the v0.25.0 consolidation not taking effect.

## Change

- New `component_bins` module, one shared resolver with a fixed order: env override (`GRAPHTRAIL_BIN`, `MISELEDGER_BIN`, ...) -> managed executable from `installed.json` -> PATH -> legacy standalone location (kept only as a migration-window fallback).
- All consumers route through it: the three duplicated per-module resolvers (`context_cmd`, `graphtrail_delta`, `evidence_brief`), receipts miseledger export, `search_cmd` status, station surface execution (`stations_cmd`), `ManagedTool.detect` plus the graphtrail/miseledger doctors, and the Cursor MCP generator (`cursor_user_cmd`), which now writes the managed absolute path into generated config.
- Stale `install_args` in `managed.py` (`cargo install graphtrail`, `go install .../miseledger`) become `brigade setup`.
- Broken env overrides no longer silently fall through to PATH; an explicit override that resolves nowhere is a miss.

**Deliberately unchanged:** `templates/stations/managed-snapshot.json` stays name-based. The snapshot is a committed, fleet-portable contract; name-to-absolute-path resolution happens at generation/execution time on each machine.

## Test isolation fix

The bare-host conftest fixture moved to the same seam. Before, it nulled `managed.proc.which` while other modules used `shutil.which`; with one resolver, that split is gone. The fixture now pins resolution to none while keeping the two sandboxed channels tests legitimately use (env overrides, test-created PATH dirs). Without this, the suite on a wired dev host resolved and **executed the real managed miseledger against the real evidence archive** during receipts tests.

## Verification

`./scripts/verify` green through `brigade work verify run` (captured receipt): ruff, format, version-sync, mypy, full pytest 3549 passed / 3 skipped, coverage 82.44% (floor 78%). GraphTrail impact run on `_graphtrail_bin`/`_miseledger_bin`/`_mcp_servers` callers before the change: aboyeur briefs, code_cmd, evidence_cmd, operator lifecycle, work verification graph delta, cursor install/doctor/adoption - all resolve-then-run or emit-config sites.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized executable discovery for managed tools, honoring per-binary env overrides, managed installs, system `PATH`, and legacy fallback locations.
  * GraphTrail/MiseLedger-related commands (including doctor/surface and MCP server entries) now use resolved executable paths.

* **Bug Fixes**
  * Improved detection/execution when binaries aren’t on `PATH`, and ensured health/doctor behavior aligns with resolved availability.

* **Tests**
  * Added coverage for resolution precedence, `~` expansion, and argv rewriting.
  * Updated existing command tests/mocks to use the new resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->