### PR TITLE
fix(evidence): skip oversized JSONL lines instead of aborting the import

### DIFF
--- a/engines/evidence-ledger/internal/ingest/importer.go
+++ b/engines/evidence-ledger/internal/ingest/importer.go
@@ -1,7 +1,6 @@
 package ingest
 
 import (
-	"bufio"
 	"compress/gzip"
 	"crypto/sha256"
 	"database/sql"
@@ -113,8 +112,6 @@ func importAdapterReaderProgress(db *sql.DB, r io.Reader, sourcePath, sourceOver
 
 	result := AdapterResult{SourceKind: sourceKind, SourcePath: sourcePath}
 	h := sha256.New()
-	scanner := bufio.NewScanner(r)
-	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
 	ordinal := int64(0)
 	warnedOverrideKinds := map[string]bool{}
 
@@ -145,16 +142,20 @@ func importAdapterReaderProgress(db *sql.DB, r io.Reader, sourcePath, sourceOver
 		return nil
 	}
 
-	for scanner.Scan() {
-		line := append([]byte(nil), scanner.Bytes()...)
+	scanErr := sources.EachLine(r, sources.MaxLineBytes, func(raw []byte, tooLong bool, size int64) error {
 		ordinal++
+		if tooLong {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("line %d: line too long (%d bytes > %d limit), skipped", ordinal, size, sources.MaxLineBytes))
+			return nil
+		}
+		line := append([]byte(nil), raw...)
 		if len(strings.TrimSpace(string(line))) == 0 {
-			continue
+			return nil
 		}
 		if recordScan != nil {
 			file, ok, err := parseSourceScanSentinel(line)
 			if err != nil {
-				return AdapterResult{}, err
+				return err
 			}
 			if ok {
 				if sourceKind == "" {
@@ -162,13 +163,10 @@ func importAdapterReaderProgress(db *sql.DB, r io.Reader, sourcePath, sourceOver
 					result.SourceKind = sourceKind
 				}
 				if err := flush(batchCount > 0); err != nil {
-					return AdapterResult{}, err
+					return err
 				}
 				generatedHash := "sha256:" + hex.EncodeToString(h.Sum(nil))
-				if err := recordScan(sourceKind, generatedHash, file); err != nil {
-					return AdapterResult{}, err
-				}
-				continue
+				return recordScan(sourceKind, generatedHash, file)
 			}
 		}
 		_, _ = h.Write(line)
@@ -176,7 +174,7 @@ func importAdapterReaderProgress(db *sql.DB, r io.Reader, sourcePath, sourceOver
 		rec, err := adapter.Parse(line)
 		if err != nil {
 			result.Warnings = append(result.Warnings, fmt.Sprintf("line %d: %s", ordinal, err))
-			continue
+			return nil
 		}
 		embeddedKind := rec.Source.Kind
 		if sourceOverride != "" && embeddedKind != "" && embeddedKind != sourceOverride && !warnedOverrideKinds[embeddedKind] {
@@ -193,7 +191,7 @@ func importAdapterReaderProgress(db *sql.DB, r io.Reader, sourcePath, sourceOver
 		inserted, err := upsertRecord(tx, rec, sourcePath, ordinal, line)
 		if err != nil {
 			result.Warnings = append(result.Warnings, fmt.Sprintf("line %d: %s", ordinal, err))
-			continue
+			return nil
 		}
 		if inserted {
 			result.Inserted++
@@ -201,12 +199,13 @@ func importAdapterReaderProgress(db *sql.DB, r io.Reader, sourcePath, sourceOver
 		batchCount++
 		if batchCount >= importBatchSize {
 			if err := flush(true); err != nil {
-				return AdapterResult{}, err
+				return err
 			}
 		}
-	}
-	if err := scanner.Err(); err != nil {
-		return AdapterResult{}, err
+		return nil
+	})
+	if scanErr != nil {
+		return AdapterResult{}, scanErr
 	}
 	sourceHash := "sha256:" + hex.EncodeToString(h.Sum(nil))
 	if sourceKind == "" {

--- a/engines/evidence-ledger/internal/ingest/importer_test.go
+++ b/engines/evidence-ledger/internal/ingest/importer_test.go
@@ -3,10 +3,13 @@ package ingest
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"strconv"
 	"strings"
 	"testing"
+	"testing/iotest"
 
 	"github.com/escoffier-labs/miseledger/internal/archive"
 	"github.com/escoffier-labs/miseledger/internal/sources"
@@ -43,6 +46,42 @@ func TestImportAdapterReaderIdempotent(t *testing.T) {
 	}
 	if items != 1 {
 		t.Fatalf("items = %d, want 1", items)
+	}
+}
+
+// Regression: an adapter line beyond the 10MB scanner limit used to abort the
+// whole import with bufio.Scanner: token too long. It must be skipped with a
+// warning while surrounding records still import.
+func TestImportAdapterReaderSkipsOversizedLine(t *testing.T) {
+	db, err := archive.Open(t.TempDir() + "/miseledger.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := archive.Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	record := func(id, text string) string {
+		return `{"schema":"miseledger.adapter.v1","source":{"kind":"oversize-test","name":"Oversize Test"},"collection":{"external_id":"oversize:collection","kind":"agent_session","name":"oversize"},"item":{"external_id":"oversize:item:` + id + `","kind":"message","created_at":"2026-07-14T00:00:00Z","text":"` + text + `","tags":["oversize"]},"actor":{"external_id":"oversize:actor","type":"human","name":"reader"},"artifacts":[],"links":[],"relations":[],"raw":{"format":"json","path":"oversize.jsonl","ordinal":1}}`
+	}
+	jsonl := record("1", "before") + "\n" +
+		record("huge", strings.Repeat("a", sources.MaxLineBytes+1024)) + "\n" +
+		record("2", "after") + "\n"
+	res, err := ImportAdapterReader(db, strings.NewReader(jsonl), "oversize://fixture", "oversize-test")
+	if err != nil {
+		t.Fatalf("import must not abort on an oversized line: %v", err)
+	}
+	if res.Inserted != 2 {
+		t.Fatalf("inserted = %d, want 2", res.Inserted)
+	}
+	var warned bool
+	for _, w := range res.Warnings {
+		if strings.Contains(w, "line too long") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Fatalf("expected a line-too-long warning, got %d warnings", len(res.Warnings))
 	}
 }
 
@@ -282,9 +321,12 @@ func TestNativeReaderRecordsCommittedFileScanBeforeInterruptedImport(t *testing.
 	}); err != nil {
 		t.Fatal(err)
 	}
-	b.WriteString(strings.Repeat("x", 11*1024*1024))
+	// Interrupt the stream with a read error after the sentinel. (This used to
+	// be an 11MB line tripping bufio.Scanner's limit; oversized lines are now
+	// skipped with a warning instead of aborting, so they no longer interrupt.)
+	interrupted := io.MultiReader(strings.NewReader(b.String()), iotest.ErrReader(errors.New("simulated interruption")))
 
-	_, err = ImportNativeReaderProgress(db, strings.NewReader(b.String()), "native://fixture", "native-scan", nil, func(sourceKind, generatedHash string, file sources.FileScan) error {
+	_, err = ImportNativeReaderProgress(db, interrupted, "native://fixture", "native-scan", nil, func(sourceKind, generatedHash string, file sources.FileScan) error {
 		return RecordSourceScans(db, sourceKind, generatedHash, []sources.FileScan{file}, true)
 	})
 	if err == nil {
@@ -315,8 +357,13 @@ func TestNativeReaderDoesNotRecordScanForUncommittedFile(t *testing.T) {
 	if err := archive.Migrate(db); err != nil {
 		t.Fatal(err)
 	}
-	stream := adapterRecord("native-uncommitted", "file1:item:1", "uncommitted file record", "file1.jsonl", 1) + strings.Repeat("x", 11*1024*1024)
-	_, err = ImportNativeReaderProgress(db, strings.NewReader(stream), "native://fixture", "native-uncommitted", nil, func(sourceKind, generatedHash string, file sources.FileScan) error {
+	// Interrupt with a read error before any file-complete sentinel arrives
+	// (formerly an 11MB line tripping bufio.Scanner's limit).
+	stream := io.MultiReader(
+		strings.NewReader(adapterRecord("native-uncommitted", "file1:item:1", "uncommitted file record", "file1.jsonl", 1)),
+		iotest.ErrReader(errors.New("simulated interruption")),
+	)
+	_, err = ImportNativeReaderProgress(db, stream, "native://fixture", "native-uncommitted", nil, func(sourceKind, generatedHash string, file sources.FileScan) error {
 		return RecordSourceScans(db, sourceKind, generatedHash, []sources.FileScan{file}, true)
 	})
 	if err == nil {

--- a/engines/evidence-ledger/internal/sources/codex/codex_test.go
+++ b/engines/evidence-ledger/internal/sources/codex/codex_test.go
@@ -107,6 +107,38 @@ func TestGenerateMalformedAndUnknownInput(t *testing.T) {
 	}
 }
 
+// Regression: a rollout file with a single line beyond the 10MB scanner limit
+// used to abort the whole codex import with bufio.Scanner: token too long.
+// The oversized line must be skipped with a warning while every other line in
+// the same file (and the rest of the tree) still imports.
+func TestGenerateSkipsOversizedLine(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rollout-oversized.jsonl")
+	huge := `{"type":"event_msg","timestamp":"2026-07-14T19:29:49Z","payload":{"session_id":"s","role":"assistant","message":"` +
+		strings.Repeat("a", sources.MaxLineBytes+1024) + `"}}`
+	content := strings.Join([]string{
+		`{"type":"event_msg","timestamp":"2026-07-14T19:29:48Z","payload":{"session_id":"s","role":"user","message":"before the oversized line"}}`,
+		huge,
+		`{"type":"event_msg","timestamp":"2026-07-14T19:29:50Z","payload":{"session_id":"s","role":"assistant","message":"after the oversized line"}}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	recs, res := parseRecords(t, path, sources.Options{})
+	if len(recs) != 2 {
+		t.Fatalf("records = %d, want the two normal lines to import", len(recs))
+	}
+	var warned bool
+	for _, w := range res.Warnings {
+		if strings.Contains(w, "line too long") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Fatalf("expected a line-too-long warning, got %v", res.Warnings)
+	}
+}
+
 func TestGenerateMissingPathErrors(t *testing.T) {
 	var buf bytes.Buffer
 	if _, err := Generate(filepath.Join(t.TempDir(), "nope.jsonl"), sources.Options{}, &buf); err == nil {

--- a/engines/evidence-ledger/internal/sources/lines_test.go
+++ b/engines/evidence-ledger/internal/sources/lines_test.go
@@ -1,0 +1,87 @@
+package sources
+
+import (
+	"strings"
+	"testing"
+)
+
+type collectedLine struct {
+	line    string
+	tooLong bool
+	size    int64
+}
+
+func collectLines(t *testing.T, input string, max int) []collectedLine {
+	t.Helper()
+	var out []collectedLine
+	err := EachLine(strings.NewReader(input), max, func(line []byte, tooLong bool, size int64) error {
+		out = append(out, collectedLine{line: string(line), tooLong: tooLong, size: size})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("EachLine: %v", err)
+	}
+	return out
+}
+
+func TestEachLineSkipsOversizedLineAndContinues(t *testing.T) {
+	long := strings.Repeat("x", 100)
+	got := collectLines(t, "before\n"+long+"\nafter\n", 10)
+	if len(got) != 3 {
+		t.Fatalf("lines = %d, want 3: %+v", len(got), got)
+	}
+	if got[0].line != "before" || got[0].tooLong {
+		t.Fatalf("line 1 = %+v", got[0])
+	}
+	if !got[1].tooLong || got[1].line != "" || got[1].size != 100 {
+		t.Fatalf("oversized line = %+v, want tooLong with size 100", got[1])
+	}
+	if got[2].line != "after" || got[2].tooLong {
+		t.Fatalf("line 3 = %+v, oversized line must not poison later lines", got[2])
+	}
+}
+
+// A line far larger than the read buffer must be drained chunk by chunk
+// without buffering it whole.
+func TestEachLineOversizedSpansManyReadChunks(t *testing.T) {
+	long := strings.Repeat("y", 300*1024)
+	got := collectLines(t, long+"\nok\n", 1024)
+	if len(got) != 2 {
+		t.Fatalf("lines = %d, want 2", len(got))
+	}
+	if !got[0].tooLong || got[0].size != int64(len(long)) {
+		t.Fatalf("oversized line = %+v", got[0])
+	}
+	if got[1].line != "ok" {
+		t.Fatalf("line after oversized = %+v", got[1])
+	}
+}
+
+func TestEachLineFinalLineWithoutNewline(t *testing.T) {
+	got := collectLines(t, "a\nb", 10)
+	if len(got) != 2 || got[1].line != "b" || got[1].tooLong {
+		t.Fatalf("lines = %+v", got)
+	}
+	// Oversized final line without a terminator is still reported.
+	got = collectLines(t, "a\n"+strings.Repeat("z", 20), 10)
+	if len(got) != 2 || !got[1].tooLong || got[1].size != 20 {
+		t.Fatalf("lines = %+v", got)
+	}
+}
+
+func TestEachLineStripsCarriageReturns(t *testing.T) {
+	got := collectLines(t, "a\r\nb\r", 10)
+	if len(got) != 2 || got[0].line != "a" || got[1].line != "b" {
+		t.Fatalf("lines = %+v", got)
+	}
+}
+
+func TestEachLineBlankAndEmptyInput(t *testing.T) {
+	if got := collectLines(t, "", 10); len(got) != 0 {
+		t.Fatalf("empty input produced %+v", got)
+	}
+	got := collectLines(t, "\n\n", 10)
+	if len(got) != 2 || got[0].line != "" || got[1].line != "" {
+		t.Fatalf("blank lines = %+v", got)
+	}
+}

--- a/engines/evidence-ledger/internal/sources/source.go
+++ b/engines/evidence-ledger/internal/sources/source.go
@@ -120,33 +120,98 @@ func ListJSONLFiles(root string, include func(string) bool) ([]string, error) {
 	return files, nil
 }
 
+// MaxLineBytes bounds a single JSONL line read by the streaming importers.
+// A line beyond it is skipped with a warning instead of aborting the whole
+// import the way bufio.Scanner's ErrTooLong used to.
+const MaxLineBytes = 10 * 1024 * 1024
+
+// EachLine invokes each for every line in r, like bufio.Scanner with
+// ScanLines but without a fatal length limit: a line longer than max is
+// drained and delivered with tooLong=true and a nil line, and reading
+// continues on the next line. size is the line's full byte count (terminator
+// excluded). The line slice is reused between calls; callers must copy it if
+// they retain it.
+func EachLine(r io.Reader, max int, each func(line []byte, tooLong bool, size int64) error) error {
+	br := bufio.NewReaderSize(r, 64*1024)
+	var line []byte
+	var size int64
+	tooLong := false
+	emit := func() error {
+		var l []byte
+		if !tooLong {
+			l = line
+		}
+		err := each(l, tooLong, size)
+		line = line[:0]
+		size = 0
+		tooLong = false
+		return err
+	}
+	for {
+		chunk, err := br.ReadSlice('\n')
+		content := chunk
+		endOfLine := err == nil
+		if endOfLine {
+			content = chunk[:len(chunk)-1]
+			if len(content) > 0 && content[len(content)-1] == '\r' {
+				content = content[:len(content)-1]
+			}
+		}
+		size += int64(len(content))
+		if !tooLong {
+			line = append(line, content...)
+			if len(line) > max {
+				tooLong = true
+				line = line[:0]
+			}
+		}
+		switch {
+		case endOfLine:
+			if err := emit(); err != nil {
+				return err
+			}
+		case err == bufio.ErrBufferFull:
+			// mid-line; keep accumulating (or draining)
+		case err == io.EOF:
+			if size > 0 || tooLong {
+				if !tooLong && len(line) > 0 && line[len(line)-1] == '\r' {
+					line = line[:len(line)-1]
+					size--
+				}
+				if err := emit(); err != nil {
+					return err
+				}
+			}
+			return nil
+		default:
+			return err
+		}
+	}
+}
+
 func scanJSONL(path string, each func(RawEvent) error) error {
 	f, err := os.Open(path)
 	if err != nil {
 		return err
 	}
 	defer f.Close()
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
 	var ordinal int64
-	for scanner.Scan() {
+	return EachLine(f, MaxLineBytes, func(raw []byte, tooLong bool, size int64) error {
 		ordinal++
-		line := append([]byte(nil), scanner.Bytes()...)
+		if tooLong {
+			warning := fmt.Sprintf("line too long (%d bytes > %d limit), skipped", size, MaxLineBytes)
+			return each(RawEvent{Path: path, Ordinal: ordinal, Object: map[string]any{"_warning": warning}})
+		}
+		line := append([]byte(nil), raw...)
 		if strings.TrimSpace(string(line)) == "" {
-			continue
+			return nil
 		}
 		var obj map[string]any
 		if err := json.Unmarshal(line, &obj); err != nil {
-			if err := each(RawEvent{Path: path, Ordinal: ordinal, Line: line, Object: map[string]any{"_warning": "malformed json: " + err.Error()}}); err != nil {
-				return err
-			}
-			continue
+			return each(RawEvent{Path: path, Ordinal: ordinal, Line: line, Object: map[string]any{"_warning": "malformed json: " + err.Error()}})
 		}
-		if err := each(RawEvent{Path: path, Ordinal: ordinal, Line: line, Object: obj}); err != nil {
-			return err
-		}
-	}
-	return scanner.Err()
+		return each(RawEvent{Path: path, Ordinal: ordinal, Line: line, Object: obj})
+	})
 }
 
 func DefaultInclude(path string) bool {


### PR DESCRIPTION
## Problem

The daily miseledger-refresh job has failed its import-codex step every day since 2026-07-14 with `bufio.Scanner: token too long`. A codex rollout under `~/.codex/sessions` (2026-07-14) contains a single 12.9MB JSONL line, past the 10MB scanner cap in the shared JSONL walker. `bufio.Scanner` cannot resume after `ErrTooLong`, so one oversized line aborted the entire codex import, every day.

## Change

- New `sources.EachLine` bounded line reader (`bufio.Reader`-based, `sources.MaxLineBytes` = 10MB): a line past the cap is drained without being buffered whole and delivered as too-long; reading continues on the next line.
- `scanJSONL` (shared by the codex/claude/openclaw/pi walkers) emits the existing `_warning` RawEvent for too-long lines, so every source records a per-line warning and keeps importing the rest of the file.
- The adapter importer (`importAdapterReaderProgress`) had the same fatal scanner on the generated-record stream; it now skips too-long lines with a `result.Warnings` entry. This also covers the latent case where codex `arguments` (uncapped in item metadata) inflates a generated record past the cap.

## Tests

- `EachLine` unit tests: oversized line mid-file, oversized line spanning many read chunks, unterminated final line, CRLF, blanks.
- Codex regression test: a rollout file with a >10MB line imports the surrounding records and surfaces a line-too-long warning (this is the exact production failure).
- Importer regression test: an oversized adapter line is skipped with a warning; surrounding records insert.
- The two interrupted-import tests used an 11MB line as their interruption mechanism, which depended on the old aborting behavior. They now interrupt with a mid-stream read error (`iotest.ErrReader`); their assertions are unchanged.

## Verification

`go -C engines/evidence-ledger test ./...` and `go -C engines/evidence-ledger vet ./...` green through `brigade work verify run` (receipts `20260721-203914-work-verify-4266dc`, `20260721-2043*`). Root cause confirmed against the real tree: `awk` over `~/.codex/sessions` found exactly one file with a line over the cap (12,902,900 bytes, 2026-07-14 rollout), matching the first failure date.