### PR TITLE
feat(mcp): gate user-scoped stdio sync on the process-multiplication warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `brigade mcp sync --user-scope` (and `brigade operator sync-mcp --user-scope`) no longer writes stdio MCP servers into a user-wide client config silently: interactive runs show the destination, stdio count, and the servers-times-sessions process formula and ask for confirmation, non-interactive and `--json` runs require `--allow-global-stdio`, and plan/sync items now carry `transport` and `scope`. (#349)
+
 ## [0.25.1] - 2026-07-21
 
 ### Added

--- a/docs/mcp-sync.md
+++ b/docs/mcp-sync.md
@@ -85,7 +85,7 @@ brigade mcp plan                       # preview what a sync would do (read-only
 brigade mcp sync                       # dry-run across every configured tool
 brigade mcp sync --write               # actually merge into each tool's config
 brigade mcp sync --write --verify      # write, then verify the selected runtimes
-brigade mcp sync --write --user-scope  # also write configured user-global targets
+brigade mcp sync --write --user-scope  # also write configured user-global targets (stdio servers gate; see below)
 brigade mcp sync --harness cursor --user-scope --write  # write ~/.cursor/mcp.json
 brigade mcp verify --harness cursor --name github  # bounded runtime handshake
 brigade mcp doctor                     # validate the catalog, report unsupported tools
@@ -97,6 +97,22 @@ Cursor stays project-scoped unless both `--harness cursor` and `--user-scope`
 are present. A user-scoped Cursor projection drops a GraphTrail `--db` argument
 when that database resolves inside the source repository, so the global client
 does not pin every workspace to one repository.
+
+## User-scoped stdio servers multiply processes
+
+A stdio MCP server is not a shared daemon. Every active client session starts
+its own child process for every stdio server in its configuration, so a
+user-wide config with `S` stdio servers costs `S x active sessions` processes.
+A desktop client holding nine sessions over a 20-server user catalog runs 180
+server processes before doing any work.
+
+Because of that, a user-scoped sync that would write one or more stdio servers
+never completes silently. Interactive runs print the destination, the stdio
+count, and the process formula, then ask for confirmation. Non-interactive and
+`--json` runs fail with exit 2 unless `--allow-global-stdio` is passed. Dry-run
+and plan output carry `transport` and `scope` on every item so the exposure is
+visible before writing. Prefer project-scoped configuration, or a shared
+HTTP/SSE transport where the client supports one; remote servers never gate.
 
 ## Runtime verification
 

--- a/src/brigade/cli/mcp.py
+++ b/src/brigade/cli/mcp.py
@@ -59,6 +59,11 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_sync.add_argument("--adopt", action="store_true", help="Take ownership of same-named foreign servers.")
     p_sync.add_argument("--user-scope", action="store_true", help="Include user-scoped targets (e.g. antigravity).")
     p_sync.add_argument(
+        "--allow-global-stdio",
+        action="store_true",
+        help="Acknowledge writing stdio MCP servers into a user-wide client config (one child process per stdio server per active client session).",
+    )
+    p_sync.add_argument(
         "--verify", action="store_true", help="After --write, verify runtime health for selected servers."
     )
     p_sync.add_argument(
@@ -136,6 +141,7 @@ def dispatch(args) -> int:
             prune=args.prune,
             adopt=args.adopt,
             user_scope=args.user_scope,
+            allow_global_stdio=args.allow_global_stdio,
             verify_runtime=args.verify,
             verify_timeout=args.verify_timeout,
             json_output=args.json,

--- a/src/brigade/cli/operator.py
+++ b/src/brigade/cli/operator.py
@@ -305,6 +305,11 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_operator_sync_mcp.add_argument(
         "--user-scope", action="store_true", help="Include user-scoped targets (e.g. antigravity)."
     )
+    p_operator_sync_mcp.add_argument(
+        "--allow-global-stdio",
+        action="store_true",
+        help="Acknowledge writing stdio MCP servers into a user-wide client config.",
+    )
     p_operator_sync_mcp.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
     p_operator_quickstart = operator_sub.add_parser(
         "quickstart", help="Prepare a new user workspace with Brigade configs, portable tools, and harness checks."
@@ -449,6 +454,7 @@ def dispatch(args) -> int:
             prune=args.prune,
             adopt=args.adopt,
             user_scope=args.user_scope,
+            allow_global_stdio=args.allow_global_stdio,
             json_output=args.json,
         )
     if args.operator_command == "quickstart":

--- a/src/brigade/mcp_cmd.py
+++ b/src/brigade/mcp_cmd.py
@@ -345,27 +345,46 @@ def _public_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return [{k: v for k, v in item.items() if not k.startswith("_")} for item in items]
 
 
-def _user_stdio_exposures(planned: list[tuple[str, list[dict[str, Any]]]]) -> list[dict[str, Any]]:
+def _user_stdio_exposures(planned: list[tuple[str, list[dict[str, Any]]]], target: Path) -> list[dict[str, Any]]:
     """Per user-scoped destination: stdio servers this sync writes and the total after.
 
     Every stdio server in a user-scoped client config is one child process per
     active client session, so writing them user-wide multiplies processes by
-    session count. Project-scoped destinations never gate.
+    session count. The total counts the destination file's preserved stdio
+    servers too (foreign and unmanaged definitions the merge keeps), not just
+    planner items, so the acknowledged exposure matches the real post-sync
+    config. Project-scoped destinations never gate.
     """
     exposures = []
     for harness, items in planned:
-        if not ADAPTERS[harness].user_scope:
+        adapter = ADAPTERS[harness]
+        if not adapter.user_scope:
             continue
         writes = [i for i in items if i["action"] in ("create", "update") and i.get("transport") == "stdio"]
         if not writes:
             continue
-        remaining = {i["server"] for i in items if i.get("transport") == "stdio" and i["action"] != "remove"}
+        removed = {i["server"] for i in items if i["action"] == "remove"}
+        stdio_after = {i["server"] for i in items if i.get("transport") == "stdio" and i["action"] != "remove"}
+        path = mcp_adapters.resolve_path(adapter, target)
+        try:
+            live = adapter.read_file(path.read_text() if path.is_file() else None)
+        except (OSError, ValueError):
+            live = {}
+        for name, provider in live.items():
+            if name in removed or name in stdio_after:
+                continue
+            try:
+                server, _ = adapter.from_provider(name, provider)
+            except (TypeError, ValueError, KeyError):
+                continue
+            if server.transport == "stdio":
+                stdio_after.add(name)
         exposures.append(
             {
                 "harness": harness,
-                "destination": items[0]["file"] if items else ADAPTERS[harness].path,
+                "destination": items[0]["file"] if items else adapter.path,
                 "stdio_writes": len(writes),
-                "stdio_total": len(remaining),
+                "stdio_total": len(stdio_after),
             }
         )
     return exposures
@@ -710,6 +729,7 @@ def sync(
     adopt: bool = False,
     user_scope: bool = False,
     allow_global_stdio: bool = False,
+    interactive: bool | None = None,
     verify_runtime: bool = False,
     verify_timeout: float | None = None,
     json_output: bool = False,
@@ -733,14 +753,17 @@ def sync(
         (h, _plan_for_harness(target, h, servers, state, force=force, prune=prune, adopt=adopt, name_filter=name))
         for h in harnesses
     ]
-    exposures = _user_stdio_exposures(planned)
+    exposures = _user_stdio_exposures(planned, target)
     if exposures:
         warning_lines = _stdio_exposure_lines(exposures)
         notes.extend(warning_lines)
         if write and not allow_global_stdio:
             # A user-scoped stdio sync never completes silently: interactive runs
             # confirm at the prompt, non-interactive runs need the explicit flag.
-            if json_output or not sys.stdin.isatty():
+            # Callers that capture stdout (operator sync-mcp) pass `interactive`
+            # explicitly; the prompt stays on stderr so captured JSON is clean.
+            is_interactive = interactive if interactive is not None else (not json_output and sys.stdin.isatty())
+            if not is_interactive:
                 message = (
                     "user-scoped sync would write stdio MCP servers into a user-wide client config; "
                     "re-run with --allow-global-stdio to acknowledge, or use project scope / an "
@@ -750,7 +773,8 @@ def sync(
                 return _emit({"errors": [message], "stdio_exposures": exposures, "notes": notes}, json_output, lines, 2)
             for line in warning_lines:
                 print(line, file=sys.stderr)
-            answer = input("Write stdio servers into the user-wide config? [y/N]: ").strip().lower()
+            print("Write stdio servers into the user-wide config? [y/N]: ", end="", file=sys.stderr, flush=True)
+            answer = input().strip().lower()
             if answer not in ("y", "yes"):
                 message = "aborted: user-scoped stdio sync not confirmed"
                 return _emit({"aborted": True, "stdio_exposures": exposures, "notes": notes}, json_output, [message], 1)

--- a/src/brigade/mcp_cmd.py
+++ b/src/brigade/mcp_cmd.py
@@ -754,32 +754,48 @@ def sync(
         for h in harnesses
     ]
     exposures = _user_stdio_exposures(planned, target)
+    gated: set[str] = set()
+    gate_error: str | None = None
+    gate_declined = False
     if exposures:
         warning_lines = _stdio_exposure_lines(exposures)
         notes.extend(warning_lines)
         if write and not allow_global_stdio:
             # A user-scoped stdio sync never completes silently: interactive runs
             # confirm at the prompt, non-interactive runs need the explicit flag.
-            # Callers that capture stdout (operator sync-mcp) pass `interactive`
-            # explicitly; the prompt stays on stderr so captured JSON is clean.
+            # Only the exposed user-scoped destinations gate; project-scoped
+            # harnesses in the same invocation still write. Callers that capture
+            # stdout (operator sync-mcp) pass `interactive` explicitly; the
+            # prompt stays on stderr so captured JSON is clean.
             is_interactive = interactive if interactive is not None else (not json_output and sys.stdin.isatty())
             if not is_interactive:
-                message = (
+                gated = {e["harness"] for e in exposures}
+                gate_error = (
                     "user-scoped sync would write stdio MCP servers into a user-wide client config; "
                     "re-run with --allow-global-stdio to acknowledge, or use project scope / an "
                     "HTTP-SSE transport"
                 )
-                lines = warning_lines + [f"error: {message}"]
-                return _emit({"errors": [message], "stdio_exposures": exposures, "notes": notes}, json_output, lines, 2)
-            for line in warning_lines:
-                print(line, file=sys.stderr)
-            print("Write stdio servers into the user-wide config? [y/N]: ", end="", file=sys.stderr, flush=True)
-            answer = input().strip().lower()
-            if answer not in ("y", "yes"):
-                message = "aborted: user-scoped stdio sync not confirmed"
-                return _emit({"aborted": True, "stdio_exposures": exposures, "notes": notes}, json_output, [message], 1)
+            else:
+                for line in warning_lines:
+                    print(line, file=sys.stderr)
+                print("Write stdio servers into the user-wide config? [y/N]: ", end="", file=sys.stderr, flush=True)
+                answer = input().strip().lower()
+                if answer not in ("y", "yes"):
+                    gated = {e["harness"] for e in exposures}
+                    gate_declined = True
+                    notes.append("user-scoped stdio destinations skipped: not confirmed at the prompt")
 
     for h, items in planned:
+        if h in gated:
+            # Preserve the plan for visibility, but nothing in this destination
+            # is written and no ownership state changes.
+            for item in items:
+                if item["action"] in ("create", "update", "remove"):
+                    item["action"] = "skip"
+                    suffix = "not written: user-scoped stdio not acknowledged"
+                    item["detail"] = f"{item['detail']}; {suffix}" if item["detail"] else suffix
+            all_items.extend(items)
+            continue
         all_items.extend(items)
         adapter = ADAPTERS[h]
         path = mcp_adapters.resolve_path(adapter, target)
@@ -871,6 +887,14 @@ def sync(
         lines.append(f"verification receipt: {payload['verification']['receipt_path']}")
     lines += notes
     rc = 1 if counts["conflict"] else 0
+    if gate_error:
+        payload["errors"] = [gate_error]
+        payload["stdio_gated"] = sorted(gated)
+        lines.append(f"error: {gate_error}")
+        rc = 2
+    elif gate_declined:
+        payload["stdio_gated"] = sorted(gated)
+        rc = 1
     if verify_rc != 0:
         rc = verify_rc
     return _emit(payload, json_output, lines, rc)

--- a/src/brigade/mcp_cmd.py
+++ b/src/brigade/mcp_cmd.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 import math
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -311,6 +312,11 @@ def _plan_for_harness(
                     harness, rel, name, "orphan", "skip", None, None, detail="removed from canonical; --prune to delete"
                 )
             )
+    adapter_scope = "user" if adapter.user_scope else "project"
+    for item in items:
+        item["scope"] = adapter_scope
+        server = servers.get(item["server"])
+        item["transport"] = server.transport if server is not None else None
     return items
 
 
@@ -337,6 +343,50 @@ def _counts(items: list[dict[str, Any]]) -> dict[str, int]:
 
 def _public_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return [{k: v for k, v in item.items() if not k.startswith("_")} for item in items]
+
+
+def _user_stdio_exposures(planned: list[tuple[str, list[dict[str, Any]]]]) -> list[dict[str, Any]]:
+    """Per user-scoped destination: stdio servers this sync writes and the total after.
+
+    Every stdio server in a user-scoped client config is one child process per
+    active client session, so writing them user-wide multiplies processes by
+    session count. Project-scoped destinations never gate.
+    """
+    exposures = []
+    for harness, items in planned:
+        if not ADAPTERS[harness].user_scope:
+            continue
+        writes = [i for i in items if i["action"] in ("create", "update") and i.get("transport") == "stdio"]
+        if not writes:
+            continue
+        remaining = {i["server"] for i in items if i.get("transport") == "stdio" and i["action"] != "remove"}
+        exposures.append(
+            {
+                "harness": harness,
+                "destination": items[0]["file"] if items else ADAPTERS[harness].path,
+                "stdio_writes": len(writes),
+                "stdio_total": len(remaining),
+            }
+        )
+    return exposures
+
+
+def _stdio_exposure_lines(exposures: list[dict[str, Any]]) -> list[str]:
+    lines = []
+    for e in exposures:
+        lines.append(
+            f"user-scope stdio warning: {e['destination']} gains {e['stdio_writes']} stdio MCP server(s) "
+            f"({e['stdio_total']} stdio total after sync)"
+        )
+        lines.append(
+            f"  each active {e['harness']} client session starts one child process per configured stdio "
+            f"server: {e['stdio_total']} stdio servers x active sessions"
+        )
+    lines.append(
+        "  prefer project-scoped config or a shared HTTP/SSE transport where the client supports it; "
+        "pass --allow-global-stdio to acknowledge"
+    )
+    return lines
 
 
 # --------------------------------------------------------------------------- #
@@ -659,6 +709,7 @@ def sync(
     prune: bool = False,
     adopt: bool = False,
     user_scope: bool = False,
+    allow_global_stdio: bool = False,
     verify_runtime: bool = False,
     verify_timeout: float | None = None,
     json_output: bool = False,
@@ -678,8 +729,33 @@ def sync(
     all_items: list[dict[str, Any]] = []
     files_written: list[str] = []
 
-    for h in harnesses:
-        items = _plan_for_harness(target, h, servers, state, force=force, prune=prune, adopt=adopt, name_filter=name)
+    planned = [
+        (h, _plan_for_harness(target, h, servers, state, force=force, prune=prune, adopt=adopt, name_filter=name))
+        for h in harnesses
+    ]
+    exposures = _user_stdio_exposures(planned)
+    if exposures:
+        warning_lines = _stdio_exposure_lines(exposures)
+        notes.extend(warning_lines)
+        if write and not allow_global_stdio:
+            # A user-scoped stdio sync never completes silently: interactive runs
+            # confirm at the prompt, non-interactive runs need the explicit flag.
+            if json_output or not sys.stdin.isatty():
+                message = (
+                    "user-scoped sync would write stdio MCP servers into a user-wide client config; "
+                    "re-run with --allow-global-stdio to acknowledge, or use project scope / an "
+                    "HTTP-SSE transport"
+                )
+                lines = warning_lines + [f"error: {message}"]
+                return _emit({"errors": [message], "stdio_exposures": exposures, "notes": notes}, json_output, lines, 2)
+            for line in warning_lines:
+                print(line, file=sys.stderr)
+            answer = input("Write stdio servers into the user-wide config? [y/N]: ").strip().lower()
+            if answer not in ("y", "yes"):
+                message = "aborted: user-scoped stdio sync not confirmed"
+                return _emit({"aborted": True, "stdio_exposures": exposures, "notes": notes}, json_output, [message], 1)
+
+    for h, items in planned:
         all_items.extend(items)
         adapter = ADAPTERS[h]
         path = mcp_adapters.resolve_path(adapter, target)
@@ -736,6 +812,7 @@ def sync(
         "wrote": write,
         "files_written": files_written,
         "notes": notes,
+        "stdio_exposures": exposures,
         "items": _public_items(all_items),
         "counts": counts,
     }

--- a/src/brigade/mcp_cmd.py
+++ b/src/brigade/mcp_cmd.py
@@ -857,9 +857,13 @@ def sync(
         "counts": counts,
     }
     if write and verify_runtime:
-        selected = _servers_for_verification(servers, harnesses, name_filter=name)
+        # Gated destinations were not written and their stdio servers were not
+        # acknowledged; never select them for verification (which would spawn
+        # the very processes the gate refused to configure).
+        verifiable = [h for h in harnesses if h not in gated]
+        selected = _servers_for_verification(servers, verifiable, name_filter=name) if verifiable else {}
         if selected:
-            config_current = _config_current_by_name(target, servers, harnesses, state, name_filter=name)
+            config_current = _config_current_by_name(target, servers, verifiable, state, name_filter=name)
             verification_payload, verify_rc = mcp_runtime.run_verification(
                 target,
                 selected,
@@ -887,6 +891,10 @@ def sync(
         lines.append(f"verification receipt: {payload['verification']['receipt_path']}")
     lines += notes
     rc = 1 if counts["conflict"] else 0
+    if verify_rc != 0:
+        rc = verify_rc
+    # The gate outcome wins over conflict and verification codes: an
+    # unacknowledged user-scoped stdio write is the error being reported.
     if gate_error:
         payload["errors"] = [gate_error]
         payload["stdio_gated"] = sorted(gated)
@@ -895,8 +903,6 @@ def sync(
     elif gate_declined:
         payload["stdio_gated"] = sorted(gated)
         rc = 1
-    if verify_rc != 0:
-        rc = verify_rc
     return _emit(payload, json_output, lines, rc)
 
 

--- a/src/brigade/operator_cmd/lifecycle.py
+++ b/src/brigade/operator_cmd/lifecycle.py
@@ -331,6 +331,9 @@ def sync_mcp(
         adopt=adopt,
         user_scope=user_scope,
         allow_global_stdio=allow_global_stdio,
+        # The JSON capture forces json_output; interactivity is decided by the
+        # operator invocation itself so a TTY run still gets the stdio prompt.
+        interactive=not json_output and sys.stdin.isatty(),
     )
     counts = sync_payload.get("counts") or {}
     ok = sync_rc == 0

--- a/src/brigade/operator_cmd/lifecycle.py
+++ b/src/brigade/operator_cmd/lifecycle.py
@@ -289,6 +289,7 @@ def sync_mcp(
     prune: bool = False,
     adopt: bool = False,
     user_scope: bool = False,
+    allow_global_stdio: bool = False,
     json_output: bool = False,
 ) -> int:
     """Validate the canonical MCP catalog, then sync it into each tool's config.
@@ -322,7 +323,14 @@ def sync_mcp(
                     print(f"error: {issue.get('message')}")
         return 1
     sync_rc, sync_payload = _capture_json_call(
-        mcp_cmd.sync, target=target, write=write, force=force, prune=prune, adopt=adopt, user_scope=user_scope
+        mcp_cmd.sync,
+        target=target,
+        write=write,
+        force=force,
+        prune=prune,
+        adopt=adopt,
+        user_scope=user_scope,
+        allow_global_stdio=allow_global_stdio,
     )
     counts = sync_payload.get("counts") or {}
     ok = sync_rc == 0

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -641,3 +641,25 @@ def test_combined_sync_gates_only_user_scoped_destinations(tmp_path, monkeypatch
     assert not (home / ".claude.json").exists()
     gated_items = [i for i in payload["items"] if i["harness"] in payload["stdio_gated"]]
     assert gated_items and all(i["action"] == "skip" for i in gated_items)
+
+
+def test_gated_sync_with_verify_never_spawns_gated_servers(tmp_path, monkeypatch, capsys):
+    home, repo = _seed_user_home(tmp_path, monkeypatch)
+    calls = []
+
+    def fake_run_verification(*args, **kwargs):
+        calls.append((args, kwargs))
+        return {"receipt_path": "unused", "results": []}, 0
+
+    monkeypatch.setattr(mcp_cmd.mcp_runtime, "run_verification", fake_run_verification)
+
+    capsys.readouterr()
+    rc = mcp_cmd.sync(target=repo, harness="cursor", user_scope=True, write=True, verify_runtime=True, json_output=True)
+    payload = json.loads(capsys.readouterr().out)
+
+    # The gate exit status survives the verification step, and no verification
+    # runs for a destination whose stdio servers were never acknowledged.
+    assert rc == 2
+    assert payload["stdio_gated"] == ["cursor-user"]
+    assert calls == []
+    assert not (home / ".cursor" / "mcp.json").exists()

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -579,3 +579,46 @@ def test_dry_run_items_carry_transport_and_scope(tmp_path, monkeypatch, capsys):
     assert item["scope"] == "user"
     assert payload["stdio_exposures"][0]["destination"] == item["file"]
     assert not (home / ".cursor" / "mcp.json").exists()
+
+
+def test_stdio_total_counts_preserved_unmanaged_servers(tmp_path, monkeypatch, capsys):
+    home, repo = _seed_user_home(tmp_path, monkeypatch)
+    cursor_config = home / ".cursor" / "mcp.json"
+    cursor_config.parent.mkdir(parents=True)
+    cursor_config.write_text(json.dumps({"mcpServers": {"legacy": {"command": "legacy-mcp"}}}))
+
+    capsys.readouterr()
+    rc = mcp_cmd.sync(target=repo, harness="cursor", user_scope=True, json_output=True)
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    exposure = payload["stdio_exposures"][0]
+    # github is the one write; the preserved unmanaged legacy server still
+    # counts toward the per-session process total being acknowledged.
+    assert exposure["stdio_writes"] == 1
+    assert exposure["stdio_total"] == 2
+
+
+def test_operator_sync_mcp_tty_prompts_despite_json_capture(tmp_path, monkeypatch, capsys):
+    home, repo = _seed_user_home(tmp_path, monkeypatch)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda prompt="": "y")
+
+    rc = operator_cmd.sync_mcp(target=repo, write=True, user_scope=True)
+
+    assert rc == 0
+    assert (home / ".cursor" / "mcp.json").is_file() or (home / ".gemini/config/mcp_config.json").is_file()
+    assert "user-scope stdio warning" in capsys.readouterr().err
+
+
+def test_operator_sync_mcp_non_tty_requires_allow_flag(tmp_path, monkeypatch, capsys):
+    home, repo = _seed_user_home(tmp_path, monkeypatch)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+    capsys.readouterr()
+    rc = operator_cmd.sync_mcp(target=repo, write=True, user_scope=True, json_output=True)
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 1
+    assert any("--allow-global-stdio" in e for e in payload["sync"]["errors"])
+    assert not (home / ".gemini/config/mcp_config.json").exists()

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -532,7 +532,7 @@ def test_user_scope_stdio_sync_interactive_decline_aborts(tmp_path, monkeypatch,
 
     assert rc == 1
     assert not (home / ".cursor" / "mcp.json").exists()
-    assert "aborted" in capsys.readouterr().out
+    assert "skipped" in capsys.readouterr().out
 
 
 def test_user_scope_remote_only_sync_does_not_gate(tmp_path, monkeypatch, capsys):
@@ -622,3 +622,22 @@ def test_operator_sync_mcp_non_tty_requires_allow_flag(tmp_path, monkeypatch, ca
     assert rc == 1
     assert any("--allow-global-stdio" in e for e in payload["sync"]["errors"])
     assert not (home / ".gemini/config/mcp_config.json").exists()
+
+
+def test_combined_sync_gates_only_user_scoped_destinations(tmp_path, monkeypatch, capsys):
+    home, repo = _seed_user_home(tmp_path, monkeypatch)
+
+    capsys.readouterr()
+    rc = mcp_cmd.sync(target=repo, user_scope=True, write=True, json_output=True)
+    payload = json.loads(capsys.readouterr().out)
+
+    # The exposed user-scoped destinations gate with exit 2, but project-scoped
+    # harnesses in the same invocation still write.
+    assert rc == 2
+    assert payload["stdio_gated"]
+    assert payload["files_written"]
+    assert all(f.startswith(str(repo)) for f in payload["files_written"])
+    assert not (home / ".gemini/config/mcp_config.json").exists()
+    assert not (home / ".claude.json").exists()
+    gated_items = [i for i in payload["items"] if i["harness"] in payload["stdio_gated"]]
+    assert gated_items and all(i["action"] == "skip" for i in gated_items)

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -36,7 +36,9 @@ def test_user_scope_antigravity_writes_home(tmp_path, monkeypatch):
     mcp_cmd.sync(target=repo, write=True, json_output=True)
     assert not (home / ".gemini/config/mcp_config.json").exists()
     # With --user-scope it writes under $HOME using serverUrl-style mcpServers.
-    mcp_cmd.sync(target=repo, harness="antigravity", user_scope=True, write=True, json_output=True)
+    mcp_cmd.sync(
+        target=repo, harness="antigravity", user_scope=True, allow_global_stdio=True, write=True, json_output=True
+    )
     cfg = home / ".gemini/config/mcp_config.json"
     assert cfg.is_file()
     assert "github" in json.loads(cfg.read_text())["mcpServers"]
@@ -63,6 +65,7 @@ def test_cursor_user_scope_uses_home_config_and_reports_paths(tmp_path, monkeypa
             target=repo,
             harness="cursor",
             user_scope=True,
+            allow_global_stdio=True,
             write=True,
             json_output=True,
         )
@@ -152,6 +155,7 @@ def test_cursor_user_scope_normalizes_repo_graphtrail_pin_and_preserves_config(t
             target=repo,
             harness="cursor",
             user_scope=True,
+            allow_global_stdio=True,
             write=True,
             json_output=True,
         )
@@ -185,7 +189,12 @@ def test_cursor_user_scope_preserves_relative_graphtrail_pin(tmp_path, monkeypat
         json_output=True,
     )
 
-    assert mcp_cmd.sync(target=repo, harness="cursor", user_scope=True, write=True, json_output=True) == 0
+    assert (
+        mcp_cmd.sync(
+            target=repo, harness="cursor", user_scope=True, allow_global_stdio=True, write=True, json_output=True
+        )
+        == 0
+    )
     written = json.loads((home / ".cursor" / "mcp.json").read_text())
     assert written["mcpServers"]["graphtrail"]["args"] == ["mcp", "--db", ".graphtrail/custom.db"]
 
@@ -244,7 +253,12 @@ def test_cursor_user_scope_rejects_invalid_existing_config(tmp_path, monkeypatch
     _seed(repo)
 
     capsys.readouterr()
-    assert mcp_cmd.sync(target=repo, harness="cursor", user_scope=True, write=True, json_output=True) == 2
+    assert (
+        mcp_cmd.sync(
+            target=repo, harness="cursor", user_scope=True, allow_global_stdio=True, write=True, json_output=True
+        )
+        == 2
+    )
     payload = json.loads(capsys.readouterr().out)
     assert payload["errors"] == [f"{cursor_config}: {error}"]
     assert cursor_config.read_text() == invalid
@@ -291,7 +305,12 @@ def test_user_scope_grok_writes_home(tmp_path, monkeypatch, capsys):
     plan_payload = json.loads(capsys.readouterr().out)
     assert any(item.get("harness") == "grok-user" for item in plan_payload.get("items", []))
     # With --user-scope it writes under $HOME using codex-shaped TOML mcp_servers.
-    assert mcp_cmd.sync(target=repo, harness="grok-user", user_scope=True, write=True, json_output=True) == 0
+    assert (
+        mcp_cmd.sync(
+            target=repo, harness="grok-user", user_scope=True, allow_global_stdio=True, write=True, json_output=True
+        )
+        == 0
+    )
     cfg = home / ".grok/config.toml"
     assert cfg.is_file()
     text = cfg.read_text()
@@ -330,7 +349,15 @@ def test_codex_user_stdio_no_args_never_stays_conflicted(tmp_path, monkeypatch, 
     mcp_cmd.add(target=repo, name="noargs", command="some-mcp-server", json_output=True)
 
     capsys.readouterr()
-    rc = mcp_cmd.sync(target=repo, harness="codex-user", user_scope=True, write=True, force=True, json_output=True)
+    rc = mcp_cmd.sync(
+        target=repo,
+        harness="codex-user",
+        user_scope=True,
+        allow_global_stdio=True,
+        write=True,
+        force=True,
+        json_output=True,
+    )
     assert rc == 0
     sync_payload = json.loads(capsys.readouterr().out)
     assert sync_payload["counts"]["conflict"] == 0
@@ -439,3 +466,116 @@ def test_mcp_station_doctor_info_when_uninitialized(tmp_path):
     ctx = doctor.build_context(tmp_path)
     results = doctor.mcp_station_checks(ctx)
     assert any(status == doctor.INFO for status, _, _ in results)
+
+
+# --- user-scoped stdio gate (#349): process-multiplication warning --------- #
+
+
+def _seed_user_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _seed(repo)
+    return home, repo
+
+
+def test_user_scope_stdio_sync_blocks_non_interactively(tmp_path, monkeypatch, capsys):
+    home, repo = _seed_user_home(tmp_path, monkeypatch)
+
+    capsys.readouterr()
+    rc = mcp_cmd.sync(target=repo, harness="cursor", user_scope=True, write=True, json_output=True)
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 2
+    assert not (home / ".cursor" / "mcp.json").exists()
+    assert any("--allow-global-stdio" in e for e in payload["errors"])
+    assert payload["stdio_exposures"][0]["stdio_writes"] == 1
+    assert payload["stdio_exposures"][0]["harness"] == "cursor-user"
+
+
+def test_user_scope_stdio_sync_allow_flag_writes_and_warns(tmp_path, monkeypatch, capsys):
+    home, repo = _seed_user_home(tmp_path, monkeypatch)
+
+    capsys.readouterr()
+    rc = mcp_cmd.sync(
+        target=repo, harness="cursor", user_scope=True, allow_global_stdio=True, write=True, json_output=True
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert (home / ".cursor" / "mcp.json").is_file()
+    assert any("user-scope stdio warning" in n for n in payload["notes"])
+    assert any("x active sessions" in n for n in payload["notes"])
+
+
+def test_user_scope_stdio_sync_interactive_confirm_writes(tmp_path, monkeypatch, capsys):
+    home, repo = _seed_user_home(tmp_path, monkeypatch)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda prompt="": "y")
+
+    rc = mcp_cmd.sync(target=repo, harness="cursor", user_scope=True, write=True)
+
+    assert rc == 0
+    assert (home / ".cursor" / "mcp.json").is_file()
+    err = capsys.readouterr().err
+    assert "user-scope stdio warning" in err
+
+
+def test_user_scope_stdio_sync_interactive_decline_aborts(tmp_path, monkeypatch, capsys):
+    home, repo = _seed_user_home(tmp_path, monkeypatch)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda prompt="": "n")
+
+    rc = mcp_cmd.sync(target=repo, harness="cursor", user_scope=True, write=True)
+
+    assert rc == 1
+    assert not (home / ".cursor" / "mcp.json").exists()
+    assert "aborted" in capsys.readouterr().out
+
+
+def test_user_scope_remote_only_sync_does_not_gate(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    mcp_cmd.init(target=repo, json_output=True)
+    mcp_cmd.add(target=repo, name="remote", transport="http", url="https://example.test/mcp", json_output=True)
+
+    capsys.readouterr()
+    rc = mcp_cmd.sync(target=repo, harness="cursor", user_scope=True, write=True, json_output=True)
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert payload["stdio_exposures"] == []
+    assert (home / ".cursor" / "mcp.json").is_file()
+
+
+def test_project_scope_stdio_sync_does_not_gate(tmp_path, capsys):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _seed(repo)
+
+    capsys.readouterr()
+    rc = mcp_cmd.sync(target=repo, write=True, json_output=True)
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert payload["stdio_exposures"] == []
+
+
+def test_dry_run_items_carry_transport_and_scope(tmp_path, monkeypatch, capsys):
+    home, repo = _seed_user_home(tmp_path, monkeypatch)
+
+    capsys.readouterr()
+    rc = mcp_cmd.sync(target=repo, harness="cursor", user_scope=True, json_output=True)
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    item = payload["items"][0]
+    assert item["transport"] == "stdio"
+    assert item["scope"] == "user"
+    assert payload["stdio_exposures"][0]["destination"] == item["file"]
+    assert not (home / ".cursor" / "mcp.json").exists()


### PR DESCRIPTION
Closes #349.

## What

A stdio MCP server is a per-client-session child process, not a shared daemon. `brigade mcp sync --user-scope --write` could put a whole catalog of stdio servers into a user-wide client config with no warning about the `stdio servers x active sessions` process multiplication (the 2026-07-18 incident: 20 stdio definitions, 9 sessions, 260 MCP processes, 27.9 GB client cgroup peak).

Per the issue's acceptance criteria:

- **User-scoped stdio sync cannot complete silently.** `sync` now plans all harnesses first and computes per-destination stdio exposure before writing anything. Interactive runs print the destination config, the stdio count being written, the total after sync, and the process formula, then require confirmation.
- **Non-interactive acknowledgement.** `--allow-global-stdio` on `brigade mcp sync` and `brigade operator sync-mcp`; without it, non-interactive and `--json` runs exit 2 naming the flag. `--json` always counts as non-interactive so pipelines never hit a prompt.
- **Dry-run identifies transport, destination, and scope.** Every plan/sync item now carries `transport` and `scope` ("user"/"project"), and payloads include a `stdio_exposures` block (also on dry-run).
- **Docs.** `docs/mcp-sync.md` gains a section on the per-session process model and the recommendation to prefer project scope or a shared HTTP/SSE transport.

Remote (http/sse) servers and project-scoped syncs never gate. Existing user-scope write tests updated to acknowledge; seven new tests cover block/allow/confirm/decline/remote/project/dry-run.

## Verification

`./scripts/verify` green through `brigade work verify run` (ruff, format, version-sync, mypy, full pytest + coverage floor).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `--allow-global-stdio` flag to MCP sync commands (including operator sync workflows).
  * Sync output now includes adapter scope/transport metadata and `stdio_exposures`; gating-related fields are included when applicable.
  * User-scope stdio writes are protected: non-interactive runs require the allow flag; interactive runs prompt to confirm.
* **Bug Fixes**
  * Prevented user-scope runs from writing user-wide stdio configuration by default; only intended destinations are gated.
* **Tests**
  * Added/expanded integration coverage for gating, warnings, preserved stdio totals, interactive accept/decline, and operator prompt behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->