### PR TITLE
feat(evidence): complete the branded evidence surface

### DIFF
--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -25,7 +25,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade daily`: 26 command path(s)
 - `brigade doctor`: 1 command path(s)
 - `brigade dogfood` (extras): 1 command path(s)
-- `brigade evidence`: 6 command path(s)
+- `brigade evidence`: 9 command path(s)
 - `brigade extras`: 3 command path(s)
 - `brigade friction` (extras): 3 command path(s)
 - `brigade guard`: 1 command path(s)
@@ -169,8 +169,11 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade evidence crawl`
 - `brigade evidence crawl plan`
 - `brigade evidence doctor`
+- `brigade evidence explain`
 - `brigade evidence export plan`
 - `brigade evidence search`
+- `brigade evidence show`
+- `brigade evidence stats`
 - `brigade evidence status`
 - `brigade extras off`
 - `brigade extras on`

--- a/src/brigade/cli/evidence.py
+++ b/src/brigade/cli/evidence.py
@@ -9,32 +9,45 @@ from pathlib import Path
 def register(sub: argparse._SubParsersAction) -> None:
     p_evidence = sub.add_parser(
         "evidence",
-        help="Inspect and plan MiseLedger evidence station health (crawl + receipt export).",
+        help="Inspect and query the evidence ledger: receipts, search, crawl and export plans.",
     )
     evidence_sub = p_evidence.add_subparsers(dest="evidence_command", metavar="<evidence-command>")
     evidence_sub.required = True
 
-    p_status = evidence_sub.add_parser("status", help="Show MiseLedger install and archive health.")
+    p_status = evidence_sub.add_parser("status", help="Show evidence engine install and archive health.")
     p_status.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
     p_status.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
 
     p_doctor = evidence_sub.add_parser(
         "doctor",
-        help="Advisory evidence health. Exits 1 on miseledger fail/incomplete/timeout.",
+        help="Advisory evidence health. Exits 1 on engine fail/incomplete/timeout.",
     )
     p_doctor.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
     p_doctor.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
 
-    p_crawl = evidence_sub.add_parser("crawl", help="Run `miseledger crawl`, or use `crawl plan` to preview it.")
+    p_crawl = evidence_sub.add_parser(
+        "crawl", help="Crawl sources into the evidence ledger, or use `crawl plan` to preview it."
+    )
     # Executable crawl arguments are intentionally opaque. `crawl plan` is
     # parsed in dispatch to preserve the established plan command contract.
     p_crawl.add_argument("engine_args", nargs=argparse.REMAINDER, help=argparse.SUPPRESS)
     p_crawl.set_defaults(_brigade_command_contract_leaf=True, _brigade_legacy_plan=True)
 
-    p_search = evidence_sub.add_parser("search", help="Run `miseledger search`.")
+    p_search = evidence_sub.add_parser("search", help="Search the evidence ledger.")
     p_search.add_argument("engine_args", nargs=argparse.REMAINDER, help=argparse.SUPPRESS)
 
-    p_export = evidence_sub.add_parser("export", help="Plan receipt export into MiseLedger without executing it.")
+    p_show = evidence_sub.add_parser("show", help="Show one evidence item by id.")
+    p_show.add_argument("engine_args", nargs=argparse.REMAINDER, help=argparse.SUPPRESS)
+
+    p_explain = evidence_sub.add_parser("explain", help="Explain how an evidence item was ingested and linked.")
+    p_explain.add_argument("engine_args", nargs=argparse.REMAINDER, help=argparse.SUPPRESS)
+
+    p_stats = evidence_sub.add_parser("stats", help="Show evidence ledger statistics.")
+    p_stats.add_argument("engine_args", nargs=argparse.REMAINDER, help=argparse.SUPPRESS)
+
+    p_export = evidence_sub.add_parser(
+        "export", help="Plan receipt export into the evidence ledger without executing it."
+    )
     export_sub = p_export.add_subparsers(dest="evidence_export_command", metavar="<export-command>")
     export_sub.required = True
     p_export_plan = export_sub.add_parser("plan", help="Plan brigade receipts export miseledger --new-only --import.")
@@ -61,6 +74,8 @@ def dispatch(args) -> int:
         return evidence_cmd.run_engine("crawl", args.engine_args)
     if args.evidence_command == "search":
         return evidence_cmd.run_engine("search", args.engine_args)
+    if args.evidence_command in ("show", "explain", "stats"):
+        return evidence_cmd.run_engine(args.evidence_command, args.engine_args)
     if args.evidence_command == "export":
         if args.evidence_export_command == "plan":
             return evidence_cmd.export_plan(target=args.target, write=args.write, json_output=args.json)

--- a/src/brigade/evidence_cmd.py
+++ b/src/brigade/evidence_cmd.py
@@ -20,8 +20,12 @@ from .localio import utc_now_iso as _now
 
 
 _SHORT_OPERATION_TIMEOUT_SECONDS = 30.0
+_SHORT_OPERATION_TIMEOUT_ENV = "BRIGADE_EVIDENCE_TIMEOUT_SECONDS"
 _CRAWL_TIMEOUT_SECONDS = 900.0
 _CRAWL_TIMEOUT_ENV = "BRIGADE_EVIDENCE_CRAWL_TIMEOUT_SECONDS"
+_STATUS_TIMEOUT_SECONDS = 120.0
+_STATUS_TIMEOUT_ENV = "BRIGADE_EVIDENCE_STATUS_TIMEOUT_SECONDS"
+_STATUS_RETRY_COMMAND = f"{_STATUS_TIMEOUT_ENV}=600 brigade evidence status"
 
 
 def _configured_timeout(environment_variable: str, default: float) -> float | None:
@@ -164,18 +168,18 @@ def _run_miseledger_result(
 ) -> proc.Result:
     """Run MiseLedger and return the raw result without printing."""
 
-    timeout = _SHORT_OPERATION_TIMEOUT_SECONDS
-    if verb == "crawl":
-        configured_timeout = _configured_timeout(_CRAWL_TIMEOUT_ENV, _CRAWL_TIMEOUT_SECONDS)
-        if configured_timeout is None:
-            print(f"error: {_CRAWL_TIMEOUT_ENV} must be a positive finite number of seconds", file=sys.stderr)
-            return proc.Result(2, "", "")
-        timeout = configured_timeout
+    timeout_env = _CRAWL_TIMEOUT_ENV if verb == "crawl" else _SHORT_OPERATION_TIMEOUT_ENV
+    timeout_default = _CRAWL_TIMEOUT_SECONDS if verb == "crawl" else _SHORT_OPERATION_TIMEOUT_SECONDS
+    configured_timeout = _configured_timeout(timeout_env, timeout_default)
+    if configured_timeout is None:
+        print(f"error: {timeout_env} must be a positive finite number of seconds", file=sys.stderr)
+        return proc.Result(2, "", "")
+    timeout = configured_timeout
 
     binary = evidence_brief._miseledger_bin()
     if binary is None:
-        print("error: miseledger is not installed; run `brigade setup`", file=sys.stderr)
-        return proc.Result(127, "", "miseledger is not installed; run `brigade setup`")
+        print("error: the evidence engine (miseledger) is not installed; run `brigade setup`", file=sys.stderr)
+        return proc.Result(127, "", "the evidence engine (miseledger) is not installed; run `brigade setup`")
     run_kwargs: dict[str, Any] = {}
     if env is not None:
         run_kwargs["env"] = env
@@ -190,6 +194,17 @@ def _run_miseledger(verb: str, arguments: list[str], *, env: dict[str, str] | No
         print(result.stdout, end="")
     if result.stderr:
         print(result.stderr, end="", file=sys.stderr)
+    if result.code == 124:
+        timeout_env = _CRAWL_TIMEOUT_ENV if verb == "crawl" else _SHORT_OPERATION_TIMEOUT_ENV
+        timeout_default = _CRAWL_TIMEOUT_SECONDS if verb == "crawl" else _SHORT_OPERATION_TIMEOUT_SECONDS
+        current = _configured_timeout(timeout_env, timeout_default) or timeout_default
+        suggested = int(max(current * 2, 300))
+        if result.stderr and not result.stderr.endswith("\n"):
+            print(file=sys.stderr)
+        print(
+            f"hint: large archive? retry with a longer timeout: {timeout_env}={suggested} brigade evidence {verb} ...",
+            file=sys.stderr,
+        )
     return result.code
 
 
@@ -315,7 +330,7 @@ def _build_status_payload(
         "installed": installed,
         "binary": binary,
         "health": "missing",
-        "summary": "miseledger not installed; run `brigade setup`",
+        "summary": "evidence engine not installed; run `brigade setup`",
         "status": None,
         "doctor": None,
         "export_cursor_present": cursor.is_file(),
@@ -327,18 +342,18 @@ def _build_status_payload(
             "brigade evidence doctor",
         ],
         "docs": {
-            "product": "https://brigade.tools/miseledger",
-            "repo": "https://github.com/escoffier-labs/miseledger",
+            "product": "https://brigade.tools/evidence-memory",
+            "repo": "https://github.com/escoffier-labs/brigade",
         },
         "boundaries": [
-            "Explicit user-invoked `brigade evidence crawl` and `brigade evidence search` execute MiseLedger across a process boundary.",
-            "Review-only `brigade evidence crawl plan` and `brigade evidence export plan` never execute MiseLedger.",
+            "Explicit user-invoked `brigade evidence crawl` and `brigade evidence search` execute the evidence engine across a process boundary.",
+            "Review-only `brigade evidence crawl plan` and `brigade evidence export plan` never execute the engine.",
             "Brigade does not start daemons or upload data; receipt export remains local.",
         ],
         "pipeline": [
-            "miseledger crawl (sessions|files|gitlog|...)",
+            "evidence crawl (sessions|files|gitlog|...)",
             "miseledger.adapter.v1 JSONL",
-            "miseledger SQLite ledger",
+            "evidence ledger (SQLite)",
             "brigade receipts export / run evidence briefs",
         ],
     }
@@ -354,10 +369,10 @@ def _build_status_payload(
         exit_code = status_result.get("exit_code")
         if exit_code == 124:
             payload["health"] = "timeout"
-            payload["summary"] = "miseledger status timed out"
+            payload["summary"] = "evidence engine status timed out"
         elif exit_code == 2:
             payload["health"] = "unwired"
-            payload["summary"] = "miseledger installed but archive not initialized"
+            payload["summary"] = "evidence engine installed but archive not initialized"
         elif exit_code == 0 and status_data:
             payload["health"] = "ok"
             item_count = next(
@@ -368,12 +383,14 @@ def _build_status_payload(
                 ),
                 None,
             )
-            payload["summary"] = "miseledger status ok" + (f", items={item_count}" if item_count is not None else "")
+            payload["summary"] = "evidence engine status ok" + (
+                f", items={item_count}" if item_count is not None else ""
+            )
         else:
             payload["health"] = "incomplete"
-            payload["summary"] = f"miseledger status unreadable (exit {exit_code})"
+            payload["summary"] = f"evidence engine status unreadable (exit {exit_code})"
         payload["next_commands"] = [
-            "miseledger status",
+            _STATUS_RETRY_COMMAND,
             "brigade evidence doctor",
             "brigade receipts export miseledger --target . --new-only --import",
         ]
@@ -397,8 +414,11 @@ def _build_status_payload(
 
     if status_result.get("exit_code") == 124 or doctor_result.get("exit_code") == 124:
         payload["health"] = "timeout"
-        payload["summary"] = "miseledger status/doctor timed out (large archive); run miseledger status manually"
-        payload["next_commands"] = ["miseledger status", "miseledger doctor", "brigade evidence crawl plan"]
+        payload["summary"] = (
+            "evidence engine status/doctor timed out (large archive); "
+            f"retry with a longer timeout: {_STATUS_RETRY_COMMAND}"
+        )
+        payload["next_commands"] = [_STATUS_RETRY_COMMAND, "brigade evidence crawl plan"]
         return payload
 
     # Uninitialized archive: binary present but no archive / not configured
@@ -406,9 +426,8 @@ def _build_status_payload(
         # exit 2 often means unwired; treat non-zero without JSON as unwired/incomplete
         if status_result.get("exit_code") == 2:
             payload["health"] = "unwired"
-            payload["summary"] = "miseledger installed but archive not initialized"
+            payload["summary"] = "evidence engine installed but archive not initialized"
             payload["next_commands"] = [
-                "miseledger init",
                 "brigade evidence crawl plan",
                 "brigade evidence doctor",
             ]
@@ -445,7 +464,7 @@ def _build_status_payload(
     else:
         payload["health"] = "incomplete"
 
-    parts = ["miseledger installed"]
+    parts = ["evidence engine installed"]
     if item_count is not None:
         parts.append(f"items={item_count}")
     if isinstance(sources, list):
@@ -466,8 +485,7 @@ def _build_status_payload(
     ]
     if payload["health"] in ("fail", "incomplete", "unwired"):
         payload["next_commands"] = [
-            "miseledger doctor",
-            "miseledger init",
+            "brigade evidence doctor",
             "brigade evidence crawl plan",
         ]
     elif not cursor.is_file():
@@ -490,8 +508,34 @@ def status_payload(
     return _enrich_crawler_health(payload, target)
 
 
+def _check_label(row: dict[str, Any]) -> str:
+    """Human label for one engine doctor check row.
+
+    The engine emits ``{"name", "detail", "ok": bool}`` rows; older builds used a
+    ``status`` string. Support both instead of printing ``None``.
+    """
+
+    status_value = row.get("status")
+    if isinstance(status_value, str) and status_value:
+        return status_value
+    ok = row.get("ok")
+    if isinstance(ok, bool):
+        return "OK" if ok else "FAIL"
+    return "?"
+
+
+def _status_timeout_or_error() -> float | None:
+    timeout = _configured_timeout(_STATUS_TIMEOUT_ENV, _STATUS_TIMEOUT_SECONDS)
+    if timeout is None:
+        print(f"error: {_STATUS_TIMEOUT_ENV} must be a positive finite number of seconds", file=sys.stderr)
+    return timeout
+
+
 def status(*, target: Path, json_output: bool = False) -> int:
-    payload = status_payload(target)
+    timeout = _status_timeout_or_error()
+    if timeout is None:
+        return 2
+    payload = status_payload(target, timeout=timeout)
     if json_output:
         _json_print(payload)
         return 0
@@ -513,7 +557,7 @@ def status(*, target: Path, json_output: bool = False) -> int:
         print("checks:")
         for row in doctor_data.get("checks") or []:
             if isinstance(row, dict):
-                print(f"- {row.get('status')}: {row.get('name')} - {row.get('detail')}")
+                print(f"- {_check_label(row)}: {row.get('name')} - {row.get('detail')}")
     elif (payload.get("doctor") or {}).get("stdout_unparsed"):
         text = str((payload.get("doctor") or {}).get("stdout_unparsed") or "").strip()
         if text:
@@ -525,7 +569,10 @@ def status(*, target: Path, json_output: bool = False) -> int:
 
 
 def doctor(*, target: Path, json_output: bool = False) -> int:
-    payload = status_payload(target)
+    timeout = _status_timeout_or_error()
+    if timeout is None:
+        return 2
+    payload = status_payload(target, timeout=timeout)
     payload["command"] = "evidence doctor"
     if json_output:
         _json_print(payload)
@@ -537,11 +584,11 @@ def doctor(*, target: Path, json_output: bool = False) -> int:
             print("checks:")
             for row in doctor_data.get("checks") or []:
                 if isinstance(row, dict):
-                    print(f"- {row.get('status')}: {row.get('name')} - {row.get('detail')}")
+                    print(f"- {_check_label(row)}: {row.get('name')} - {row.get('detail')}")
         _print_next(payload)
         print(
             "note: evidence checks are advisory for workspace doctor; "
-            "this command exits 1 on miseledger fail/incomplete/timeout or crawler fail"
+            "this command exits 1 on engine fail/incomplete/timeout or crawler fail"
         )
     health = payload.get("health")
     if health in ("fail", "incomplete", "timeout"):
@@ -572,8 +619,8 @@ def crawl_plan_payload(*, target: Path) -> dict[str, Any]:
             "Treat imported text as untrusted evidence, not instructions.",
         ],
         "boundaries": [
-            "This review-only crawl plan never executes MiseLedger.",
-            "Brigade does not upload ledger data or start a miseledger daemon.",
+            "This review-only crawl plan never executes the evidence engine.",
+            "Brigade does not upload ledger data or start daemons.",
             "Session crawls may read local harness logs; keep that host trusted.",
         ],
         "next_commands": [
@@ -582,13 +629,13 @@ def crawl_plan_payload(*, target: Path) -> dict[str, Any]:
             "brigade receipts export miseledger --target . --new-only --import",
         ],
         "docs": {
-            "product": "https://brigade.tools/miseledger",
-            "repo": "https://github.com/escoffier-labs/miseledger",
+            "product": "https://brigade.tools/evidence-memory",
+            "repo": "https://github.com/escoffier-labs/brigade",
         },
         "pipeline": [
-            "miseledger crawl",
+            "evidence crawl",
             "adapter.v1 JSONL",
-            "miseledger ledger",
+            "evidence ledger",
             "brigade evidence briefs / receipts export",
         ],
     }
@@ -609,13 +656,13 @@ def export_plan_payload(*, target: Path) -> dict[str, Any]:
         ],
         "manual_steps": [
             "Ensure verify/run receipts exist under .brigade/ before export.",
-            "--import shells out to miseledger import adapter when the binary is present.",
+            "--import shells out to the evidence engine's import adapter when the binary is present.",
             "Re-run with --new-only so the cursor only advances over new receipt hashes.",
         ],
         "boundaries": [
-            "This review-only export plan never executes MiseLedger.",
+            "This review-only export plan never executes the evidence engine.",
             "Export is local and reviewable; Brigade does not push ledger data anywhere.",
-            "Fail-open: missing miseledger skips import and still writes JSONL when requested.",
+            "Fail-open: a missing engine skips import and still writes JSONL when requested.",
         ],
         "next_commands": [
             "brigade receipts export miseledger --target . --new-only --import",
@@ -623,15 +670,15 @@ def export_plan_payload(*, target: Path) -> dict[str, Any]:
             "brigade outcome rank --target .",
         ],
         "docs": {
-            "product": "https://brigade.tools/miseledger",
-            "repo": "https://github.com/escoffier-labs/miseledger",
+            "product": "https://brigade.tools/evidence-memory",
+            "repo": "https://github.com/escoffier-labs/brigade",
         },
     }
 
 
 def _render_plan_md(payload: dict[str, Any]) -> str:
     lines = [
-        f"# miseledger {payload.get('kind')} plan",
+        f"# evidence {payload.get('kind')} plan",
         "",
         f"- target: {payload.get('target')}",
     ]

--- a/tests/test_evidence_branded_surface.py
+++ b/tests/test_evidence_branded_surface.py
@@ -1,0 +1,189 @@
+"""Branded evidence surface: show/explain/stats passthroughs, status timeout
+override, doctor check labels, and no engine-name leaks in user guidance.
+
+The evidence engine binary stays miseledger behind the process boundary; the
+`brigade evidence` surface is what users see and type.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from brigade import cli, evidence_brief, evidence_cmd, proc
+
+
+def _patch_engine(monkeypatch, *, run_calls: list | None = None):
+    def fake_run(args, timeout=30.0, **kwargs):
+        if run_calls is not None:
+            run_calls.append({"args": list(args), "timeout": timeout, "kwargs": kwargs})
+        exit_code = 0
+        if args and args[-1].isdigit() and len(args) >= 2 and args[-2] == "--test-exit":
+            exit_code = int(args[-1])
+        stdout = '{"ok": true}\n' if "--json" in args else "engine-stdout\n"
+        return proc.Result(exit_code, stdout, "")
+
+    monkeypatch.setattr(evidence_brief, "_miseledger_bin", lambda: "/fake/miseledger")
+    monkeypatch.setattr(proc, "run", fake_run)
+
+
+# --- show / explain / stats passthroughs ------------------------------------
+
+
+@pytest.mark.parametrize("verb", ("show", "explain", "stats"))
+def test_evidence_verb_forwards_exact_argv_and_stdout(monkeypatch, capsys, verb):
+    calls: list[dict] = []
+    _patch_engine(monkeypatch, run_calls=calls)
+
+    rc = cli.main(["evidence", verb, "18ae49710e71", "--json"])
+
+    assert rc == 0
+    assert calls == [{"args": ["/fake/miseledger", verb, "18ae49710e71", "--json"], "timeout": 30.0, "kwargs": {}}]
+    assert json.loads(capsys.readouterr().out) == {"ok": True}
+
+
+@pytest.mark.parametrize("verb", ("show", "explain", "stats"))
+def test_evidence_verb_propagates_child_exit_code(monkeypatch, verb):
+    calls: list[dict] = []
+    _patch_engine(monkeypatch, run_calls=calls)
+
+    rc = cli.main(["evidence", verb, "item", "--test-exit", "5"])
+
+    assert rc == 5
+    assert calls[0]["args"][:2] == ["/fake/miseledger", verb]
+
+
+@pytest.mark.parametrize("verb", ("show", "explain", "stats"))
+def test_evidence_verb_missing_engine_exits_127(monkeypatch, capsys, verb):
+    monkeypatch.setattr(evidence_brief, "_miseledger_bin", lambda: None)
+
+    rc = cli.main(["evidence", verb, "item"])
+
+    assert rc == 127
+    err = capsys.readouterr().err
+    assert "evidence engine" in err
+    assert "brigade setup" in err
+
+
+# --- query verb timeout override ---------------------------------------------
+
+
+@pytest.mark.parametrize("verb", ("search", "show", "explain", "stats"))
+def test_evidence_query_verbs_use_configured_timeout(monkeypatch, verb):
+    calls: list[dict] = []
+    _patch_engine(monkeypatch, run_calls=calls)
+    monkeypatch.setenv("BRIGADE_EVIDENCE_TIMEOUT_SECONDS", "300")
+
+    assert cli.main(["evidence", verb, "item"]) == 0
+    assert calls[0]["timeout"] == 300.0
+
+
+def test_evidence_query_verb_rejects_invalid_timeout_before_starting_engine(monkeypatch, capsys):
+    calls: list[dict] = []
+    _patch_engine(monkeypatch, run_calls=calls)
+    monkeypatch.setenv("BRIGADE_EVIDENCE_TIMEOUT_SECONDS", "nan")
+
+    assert cli.main(["evidence", "stats"]) == 2
+    assert calls == []
+    assert "BRIGADE_EVIDENCE_TIMEOUT_SECONDS" in capsys.readouterr().err
+
+
+def test_evidence_query_verb_timeout_prints_branded_retry_hint(monkeypatch, capsys):
+    monkeypatch.setattr(evidence_brief, "_miseledger_bin", lambda: "/fake/miseledger")
+    monkeypatch.setattr(proc, "run", lambda *a, **k: proc.Result(124, "", "timeout after 30.0s\n"))
+
+    rc = cli.main(["evidence", "stats"])
+    err = capsys.readouterr().err
+
+    assert rc == 124
+    assert "BRIGADE_EVIDENCE_TIMEOUT_SECONDS" in err
+    assert "brigade evidence stats" in err
+
+
+# --- status timeout override -------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ("", "zero", "0", "-1", "nan", "inf"))
+def test_evidence_status_rejects_invalid_timeout_before_starting_engine(monkeypatch, capsys, value):
+    calls: list[dict] = []
+    _patch_engine(monkeypatch, run_calls=calls)
+    monkeypatch.setenv("BRIGADE_EVIDENCE_STATUS_TIMEOUT_SECONDS", value)
+
+    assert cli.main(["evidence", "status", "--target", "."]) == 2
+    assert calls == []
+    assert "BRIGADE_EVIDENCE_STATUS_TIMEOUT_SECONDS" in capsys.readouterr().err
+
+
+def test_evidence_status_uses_configured_timeout(monkeypatch, tmp_path):
+    calls: list[dict] = []
+    _patch_engine(monkeypatch, run_calls=calls)
+    monkeypatch.setenv("BRIGADE_EVIDENCE_STATUS_TIMEOUT_SECONDS", "300")
+
+    assert cli.main(["evidence", "status", "--target", str(tmp_path)]) == 0
+    status_calls = [c for c in calls if c["args"][:2] == ["/fake/miseledger", "status"]]
+    assert status_calls
+    assert all(c["timeout"] == 300.0 for c in status_calls)
+
+
+def test_evidence_status_timeout_summary_offers_branded_retry(monkeypatch, tmp_path):
+    monkeypatch.setattr(evidence_brief, "_miseledger_bin", lambda: "/fake/miseledger")
+    monkeypatch.setattr(proc, "run", lambda *a, **k: proc.Result(124, "", "timeout\n"))
+
+    payload = evidence_cmd.status_payload(tmp_path)
+
+    assert payload["health"] == "timeout"
+    assert "BRIGADE_EVIDENCE_STATUS_TIMEOUT_SECONDS" in payload["summary"]
+    for command in payload["next_commands"]:
+        assert not command.startswith("miseledger")
+
+
+def test_evidence_status_next_commands_never_name_the_engine_binary(monkeypatch, tmp_path):
+    """No health state may tell the user to run the engine binary directly."""
+    monkeypatch.setattr(evidence_brief, "_miseledger_bin", lambda: "/fake/miseledger")
+
+    for exit_code in (0, 2, 3, 124):
+        monkeypatch.setattr(proc, "run", lambda *a, _code=exit_code, **k: proc.Result(_code, "", ""))
+        payload = evidence_cmd.status_payload(tmp_path)
+        for command in payload["next_commands"]:
+            assert not command.startswith("miseledger"), (exit_code, command)
+
+
+# --- doctor check labels ------------------------------------------------------
+
+
+def test_check_label_supports_ok_bool_rows():
+    assert evidence_cmd._check_label({"name": "paths", "ok": True}) == "OK"
+    assert evidence_cmd._check_label({"name": "paths", "ok": False}) == "FAIL"
+    assert evidence_cmd._check_label({"name": "paths", "status": "WARN"}) == "WARN"
+    assert evidence_cmd._check_label({"name": "paths"}) == "?"
+
+
+def test_evidence_status_renders_ok_bool_check_rows_without_none(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(evidence_brief, "_miseledger_bin", lambda: "/fake/miseledger")
+
+    def fake_run(args, timeout=30.0, **kwargs):
+        if "doctor" in args:
+            body = {"ok": True, "checks": [{"name": "paths", "detail": "/tmp/db", "ok": True}]}
+            return proc.Result(0, json.dumps(body) + "\n", "")
+        return proc.Result(0, '{"items": 3}\n', "")
+
+    monkeypatch.setattr(proc, "run", fake_run)
+
+    rc = evidence_cmd.status(target=tmp_path, json_output=False)
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "- OK: paths - /tmp/db" in out
+    assert "None:" not in out
+
+
+# --- branded help surface -----------------------------------------------------
+
+
+def test_evidence_group_help_does_not_name_the_engine_binary(capsys):
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["evidence", "--help"])
+
+    assert exc.value.code == 0
+    assert "miseledger" not in capsys.readouterr().out.lower()

--- a/tests/test_evidence_cmd.py
+++ b/tests/test_evidence_cmd.py
@@ -19,7 +19,7 @@ def test_evidence_status_reports_uninstalled(monkeypatch, tmp_path):
     assert payload["health"] == "missing"
     assert "brigade setup" in payload["summary"]
     assert "brigade evidence crawl plan" in payload["next_commands"]
-    assert payload["pipeline"][0].startswith("miseledger crawl")
+    assert payload["pipeline"][0].startswith("evidence crawl")
 
 
 def test_evidence_status_distinguishes_explicit_execution_from_review_only_plans(monkeypatch, tmp_path):
@@ -29,11 +29,11 @@ def test_evidence_status_distinguishes_explicit_execution_from_review_only_plans
     boundaries = payload["boundaries"]
 
     assert (
-        "Explicit user-invoked `brigade evidence crawl` and `brigade evidence search` execute MiseLedger across a process boundary."
+        "Explicit user-invoked `brigade evidence crawl` and `brigade evidence search` execute the evidence engine across a process boundary."
         in boundaries
     )
     assert (
-        "Review-only `brigade evidence crawl plan` and `brigade evidence export plan` never execute MiseLedger."
+        "Review-only `brigade evidence crawl plan` and `brigade evidence export plan` never execute the engine."
         in boundaries
     )
     assert "Brigade does not start daemons or upload data; receipt export remains local." in boundaries
@@ -149,7 +149,7 @@ def test_crawl_plan_is_review_only(tmp_path):
     rendered = evidence_cmd._render_plan_md(payload)
 
     assert ["miseledger", "crawl", "sessions"] in payload["commands"]
-    assert "review-only crawl plan never executes MiseLedger" in payload["boundaries"][0]
+    assert "review-only crawl plan never executes the evidence engine" in payload["boundaries"][0]
     assert "miseledger crawl sessions" in rendered
 
 


### PR DESCRIPTION
## What

Mirrors #427 for the Evidence side: users should never need the engine binary name.

- New passthroughs: `brigade evidence show`, `explain`, `stats` (same facade contract as `search`: exact argv forwarding, exit codes propagate, 30s default timeout).
- No engine-name leaks: help text, status summaries, doctor notes, and plan boundaries say "evidence engine"; no `next_commands` in any health state tells the user to run `miseledger` directly (regression test covers all four health states). The binary name survives only in the missing-binary diagnostic and review-only plan command lists, where it is load-bearing.
- Timeouts stop being dead ends: `BRIGADE_EVIDENCE_TIMEOUT_SECONDS` covers the query verbs, `BRIGADE_EVIDENCE_STATUS_TIMEOUT_SECONDS` covers status/doctor, and a 124 exit prints a branded retry hint that doubles the current timeout. (Follow-up: `brigade code` could gain the same general override; today it only has `BRIGADE_CODE_SYNC_TIMEOUT_SECONDS`.)
- Fixes the `- None: paths` doctor rendering: the engine emits `{ok: bool}` check rows, not `status` strings; both shapes now render.
- Stale docs links updated (engine source lives in `engines/evidence-ledger` here): capability page + this repo instead of the archived standalone.
- `docs/command-inventory.md` regenerated.

## Verification

- `./scripts/verify` green through `brigade work verify run` after rebase onto main (receipt 20260722-090102; 3,612 tests).
- Exercised live against the real ledger: `brigade evidence show <id>` returned the actual oversized-JSONL fix record; `BRIGADE_EVIDENCE_TIMEOUT_SECONDS=180 brigade evidence stats` honored the override and printed the branded hint on timeout.
- 189 lines of new tests in `tests/test_evidence_branded_surface.py`; 4 pinned UX strings updated in `tests/test_evidence_cmd.py` (intentional wording changes, contract meaning unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `show`, `explain`, and `stats` commands to the evidence CLI.
  * Added configurable timeouts for evidence queries, status checks, and large archives.
  * Added clearer retry guidance when evidence operations time out.

* **Bug Fixes**
  * Improved handling of missing evidence engines and invalid timeout settings.
  * Updated status and doctor output for clearer health reporting.

* **Documentation**
  * Refreshed CLI help, plan headings, and evidence-related terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->