### PR TITLE
fix(run): enforce sandbox and worktree isolation

### DIFF
--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -1464,7 +1464,14 @@ def build_ground_truth(
     # counts are left unavailable (they cannot be computed without baseline
     # contamination).
     if pre_run_snapshot is not None:
-        changed_names_list, untracked_files = runguard.changes_relative_to_snapshot(cwd, pre_run_snapshot)
+        try:
+            changed_names_list, untracked_files = runguard.changes_relative_to_snapshot(cwd, pre_run_snapshot)
+        except runguard.RunGuardError as exc:
+            # Fail closed: a final git query failure must not become an
+            # available clean result. Surface unavailable ground truth with a
+            # precise reason instead of charging (or clearing) the worker.
+            payload["reason"] = str(exc)
+            return payload
         changed_names = "\n".join(changed_names_list)
         baseline_dirty = bool(pre_run_snapshot.tracked_dirty_paths) or bool(pre_run_snapshot.untracked_paths)
         if baseline_dirty:

--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -1429,7 +1429,11 @@ def _verify_receipts_since(cwd: Path, started_at: datetime) -> list[dict[str, ob
     return receipts
 
 
-def build_ground_truth(cwd: Path | None, started_at: datetime) -> dict[str, object]:
+def build_ground_truth(
+    cwd: Path | None,
+    started_at: datetime,
+    pre_run_snapshot: runguard.PreRunSnapshot | None = None,
+) -> dict[str, object]:
     verify_receipts = _verify_receipts_since(cwd, started_at) if cwd is not None else []
     payload: dict[str, object] = {
         "available": False,
@@ -1450,23 +1454,49 @@ def build_ground_truth(cwd: Path | None, started_at: datetime) -> dict[str, obje
         payload["reason"] = error or "not a git worktree"
         return payload
 
-    diffstat, error = _git_stdout(cwd, "diff", "--stat", "HEAD")
-    if error is not None:
-        payload["reason"] = error
-        return payload
-    changed_names, error = _git_stdout(cwd, "diff", "--name-only", "HEAD")
-    if error is not None:
-        payload["reason"] = error
-        return payload
-    try:
-        untracked_files = runguard._untracked_files(cwd)
-    except runguard.RunGuardError as exc:
-        payload["reason"] = str(exc)
-        return payload
+    # When a pre-run snapshot exists, attribute only state changes relative to
+    # it so pre-existing dirty or untracked files (possible only in a linked
+    # worktree; the primary checkout rejects --allow-dirty) are not charged to
+    # the worker. For a clean baseline the full HEAD diffstat equals the worker
+    # delta and is preserved. For a dirty baseline the full HEAD diffstat is
+    # contaminated by pre-existing dirt, so it is never reused as the run delta:
+    # only content-changed paths relative to baseline are reported and line
+    # counts are left unavailable (they cannot be computed without baseline
+    # contamination).
+    if pre_run_snapshot is not None:
+        changed_names_list, untracked_files = runguard.changes_relative_to_snapshot(cwd, pre_run_snapshot)
+        changed_names = "\n".join(changed_names_list)
+        baseline_dirty = bool(pre_run_snapshot.tracked_dirty_paths) or bool(pre_run_snapshot.untracked_paths)
+        if baseline_dirty:
+            diffstat = ""
+            payload["diffstat_unavailable"] = True
+        else:
+            diffstat, error = _git_stdout(cwd, "diff", "--stat", "HEAD")
+            if error is not None:
+                payload["reason"] = error
+                return payload
+    else:
+        diffstat, error = _git_stdout(cwd, "diff", "--stat", "HEAD")
+        if error is not None:
+            payload["reason"] = error
+            return payload
+        changed_names, error = _git_stdout(cwd, "diff", "--name-only", "HEAD")
+        if error is not None:
+            payload["reason"] = error
+            return payload
+        try:
+            untracked_files = runguard._untracked_files(cwd)
+        except runguard.RunGuardError as exc:
+            payload["reason"] = str(exc)
+            return payload
 
     payload.update(
         {
             "available": True,
+            # Changes are observed during the run; the author is unknown. Brigade
+            # does not assert the worker authored them (a concurrent commit,
+            # branch switch, or pre-existing edit could also be the source).
+            "change_provenance": "observed-during-run-author-unknown",
             "diffstat": diffstat.strip(),
             "changed_files": [line for line in changed_names.splitlines() if line.strip()],
             "untracked_files": untracked_files,
@@ -1493,17 +1523,26 @@ def _ground_truth_facts(ground_truth: dict[str, object] | None) -> str:
     else:
         changed_files = _ground_truth_str_list(ground_truth, "changed_files")
         untracked_files = _ground_truth_str_list(ground_truth, "untracked_files")
-        diffstat = _one_line(str(ground_truth.get("diffstat") or "none"))
-        if len(diffstat) > 240:
-            diffstat = diffstat[:237] + "..."
+        # Ground truth describes changes *observed during the run*; the author is
+        # unknown. Brigade does not assert the worker authored them (a concurrent
+        # commit, branch switch, or pre-existing edit could also have produced
+        # them). Drift checks narrow this, but the provenance stays "author
+        # unknown" so synthesis never claims the worker wrote concurrent edits.
         lines.append(
-            f"- changed_files: {len(changed_files)}" + (f" ({', '.join(changed_files[:6])})" if changed_files else "")
+            "- changed_files: observed during the run, author unknown "
+            f"({len(changed_files)})" + (f": {', '.join(changed_files[:6])}" if changed_files else "")
         )
         lines.append(
-            f"- untracked_files: {len(untracked_files)}"
-            + (f" ({', '.join(untracked_files[:6])})" if untracked_files else "")
+            "- untracked_files: observed during the run, author unknown "
+            f"({len(untracked_files)})" + (f": {', '.join(untracked_files[:6])}" if untracked_files else "")
         )
-        lines.append(f"- diffstat: {diffstat}")
+        if ground_truth.get("diffstat_unavailable") is True:
+            lines.append("- diffstat: unavailable (dirty baseline; line counts would include pre-existing changes)")
+        else:
+            diffstat = _one_line(str(ground_truth.get("diffstat") or "none"))
+            if len(diffstat) > 240:
+                diffstat = diffstat[:237] + "..."
+            lines.append(f"- diffstat: {diffstat}")
     patch_ref = ground_truth.get("patch_ref")
     if isinstance(patch_ref, str) and patch_ref:
         lines.append(f"- patch_ref: {patch_ref}")
@@ -1903,6 +1942,7 @@ def _run_payload(
     route: RouteBrief | None = None,
     worker: str | None = None,
     include_git: bool = True,
+    pre_run_snapshot: dict[str, object] | None = None,
 ) -> dict[str, object]:
     payload: dict[str, object] = {
         "schema": "brigade.run.v1",
@@ -1945,6 +1985,8 @@ def _run_payload(
         git = _receipt_git_snapshot(cwd)
         if git is not None:
             payload["git"] = git
+    if pre_run_snapshot is not None:
+        payload["pre_run_snapshot"] = pre_run_snapshot
     if code_graph_delta is not None:
         payload["code_graph_delta"] = code_graph_delta
     if context_eval_payload is not None:
@@ -2205,7 +2247,48 @@ def run(
     direct_worker = worker is not None
 
     def _payload(**kwargs: Any) -> dict[str, object]:
-        return _run_payload(lock_workspace=lock_workspace, **kwargs)
+        return _run_payload(
+            lock_workspace=lock_workspace,
+            pre_run_snapshot=pre_run_snapshot_payload,
+            **kwargs,
+        )
+
+    # Capture pre-run git state before any worker touches the tree so ground
+    # truth can attribute only the worker's changes and a drift check can fail
+    # the run if branch or HEAD moves out from under it. The in-memory snapshot
+    # is captured now (before dispatch); the persisted copy is written once
+    # output_dir exists. A git work tree whose state cannot be read is a
+    # preflight failure (not a silent downgrade): the run refuses to start
+    # rather than running without isolation attribution.
+    try:
+        pre_run_snapshot = runguard.capture_pre_run_snapshot(cwd)
+    except runguard.RunGuardError as exc:
+        print(f"error: pre-run snapshot failed: {exc}", file=sys.stderr)
+        return 2
+    pre_run_snapshot_payload = runguard.snapshot_payload(pre_run_snapshot)
+
+    def _drift_failure_rc() -> int | None:
+        """Centralized branch/HEAD drift check across every return path.
+
+        Returns 2 (and records a run-isolation failure) when branch or HEAD
+        moved since the pre-run snapshot, else None so the caller can proceed.
+        Call this after planning, before any dry-run return, after worker
+        dispatch, after synthesis, and immediately before finalization.
+        """
+        detail = runguard.detect_branch_head_drift(cwd, pre_run_snapshot)
+        if detail is None:
+            return None
+        if output_dir is not None:
+            record_run_termination(
+                output_dir,
+                status="failed",
+                failure_phase="run-isolation",
+                failure_kind="branch-head-drift",
+                detail=detail,
+                seat=roster.orchestrator,
+            )
+        print(f"error: {detail}", file=sys.stderr)
+        return 2
 
     if worker is not None:
         worker_error = _direct_worker_error(worker, roster, read_only=read_only)
@@ -2259,6 +2342,8 @@ def run(
     code_graph_delta_before: dict[str, object] | None = None
     if output_dir is not None:
         output_dir.mkdir(parents=True, exist_ok=True)
+        if pre_run_snapshot_payload is not None:
+            _write_json(output_dir / "pre-run-snapshot.json", pre_run_snapshot_payload)
         if code_graph_delta is None and cwd is not None:
             code_graph_delta_before = graphtrail_delta.capture_before(cwd, output_dir)
             code_graph_delta = code_graph_delta_before
@@ -2380,6 +2465,13 @@ def run(
                 )
             print(f"error: {exc}", file=sys.stderr)
             return 2
+
+    # Drift checkpoint: after planning (and before any dry-run return). A
+    # concurrent commit or branch switch during planning must fail the run
+    # instead of letting a dry-run return a plan built on stale state.
+    drift_rc = _drift_failure_rc()
+    if drift_rc is not None:
+        return drift_rc
 
     if output_dir is not None:
         attempts_payload: dict[str, object] = {"attempts": plan_attempts or []}
@@ -2629,12 +2721,18 @@ def run(
             raise
     finally:
         close_server_resources()
+    # Drift checkpoint: after worker dispatch. A concurrent commit or branch
+    # switch during dispatch must fail the run before ground truth attributes
+    # the foreign state to the worker.
+    drift_rc = _drift_failure_rc()
+    if drift_rc is not None:
+        return drift_rc
     if output_dir is not None:
         record_result_processing(output_dir, seat=roster.orchestrator)
     if output_dir is not None and code_graph_delta_before is not None and cwd is not None:
         code_graph_delta = graphtrail_delta.capture_after_and_diff(cwd, output_dir, code_graph_delta_before)
     context_eval_payload = _context_eval_for_run(code_graph, code_graph_delta)
-    ground_truth = build_ground_truth(cwd, started_at)
+    ground_truth = build_ground_truth(cwd, started_at, pre_run_snapshot=pre_run_snapshot)
     if code_graph_delta is not None:
         ground_truth["code_graph_delta"] = code_graph_delta
     if context_eval_payload is not None:
@@ -2724,6 +2822,12 @@ def run(
             process_registry=process_registry,
         )
         final = replace(final, duration_seconds=max(0.0, round(time.monotonic() - synthesis_started, 3)))
+    # Drift checkpoint: after synthesis. A concurrent commit or branch switch
+    # during synthesis must fail the run before the synthesized answer is
+    # finalized on top of drifted state.
+    drift_rc = _drift_failure_rc()
+    if drift_rc is not None:
+        return drift_rc
     if output_dir is not None:
         if not direct_worker:
             final = _write_agent_logs(output_dir, "synthesis", final)
@@ -2794,6 +2898,12 @@ def run(
         else:
             print(f"error: orchestrator failed during synthesis: {final.detail}", file=sys.stderr)
         return 2
+    # Drift checkpoint: immediately before finalization. The final ok receipt
+    # must not be written on top of state a concurrent commit moved out from
+    # under the run.
+    drift_rc = _drift_failure_rc()
+    if drift_rc is not None:
+        return drift_rc
     if output_dir is not None:
         final_status = "artifact-collection" if defer_artifact_collection else "ok"
         pending_handoff = handoff_inbox is not None

--- a/src/brigade/agents.py
+++ b/src/brigade/agents.py
@@ -73,8 +73,53 @@ class _GrokFinal:
     stop_reason: str | None = None
 
 
+_CLAUDE_DISALLOWED_ALWAYS = "Task,Agent"
+_CLAUDE_DISALLOWED_READ_ONLY = "Task,Agent,Bash,Edit,Write,NotebookEdit"
+
+# Claude Code has no native workspace-write sandbox: headless `-p` either waits
+# on a permission prompt (hang) or, with --dangerously-skip-permissions, grants
+# full access. There is no truthful middle ground, so workspace-write is rejected
+# before launch rather than silently degrading or stalling the worker.
+_CLAUDE_WORKSPACE_WRITE_ERROR = (
+    "claude cannot enforce a workspace-write sandbox in headless mode. "
+    "Use --sandbox danger-full-access (or --read-only) for claude seats, "
+    "or run in a linked git worktree with --worktree."
+)
+
+# A write run with no explicit sandbox must not silently grant full access.
+# Headless claude without --dangerously-skip-permissions stalls on a prompt, and
+# adding it unprompted grants danger-full-access the user never asked for. Refuse
+# to guess: require an explicit --sandbox danger-full-access (or --read-only).
+_CLAUDE_NO_SANDBOX_ERROR = (
+    "claude write run requested without an explicit sandbox. "
+    "Use --sandbox danger-full-access to grant --dangerously-skip-permissions, "
+    "--read-only for a read-only run, or run in a linked git worktree with --worktree. "
+    "Headless claude has no native workspace-write sandbox: it would stall on a "
+    "permission prompt or require full access."
+)
+
+
 def _claude_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | None) -> List[str]:
-    return ["claude", "-p", prompt]
+    if read_only or sandbox == "read-only":
+        # --disallowedTools removes tools from the model's context entirely
+        # (a hard deny), so read-only is enforced by the CLI, not just the prompt.
+        return ["claude", "-p", "--disallowedTools", _CLAUDE_DISALLOWED_READ_ONLY, prompt]
+    if sandbox == "workspace-write":
+        raise ValueError(_CLAUDE_WORKSPACE_WRITE_ERROR)
+    if sandbox == "danger-full-access":
+        # Explicit full-access request: headless `-p` would stall on a permission
+        # prompt without --dangerously-skip-permissions; the deny list still
+        # removes subagent spawning so the worker cannot delegate.
+        return [
+            "claude",
+            "-p",
+            "--dangerously-skip-permissions",
+            "--disallowedTools",
+            _CLAUDE_DISALLOWED_ALWAYS,
+            prompt,
+        ]
+    # sandbox is None: refuse to guess between stalling and granting full access.
+    raise ValueError(_CLAUDE_NO_SANDBOX_ERROR)
 
 
 def _codex_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | None) -> List[str]:
@@ -229,7 +274,7 @@ READ_ONLY_ENFORCEMENT: dict[str, str] = {
     "grok": "hard",
     "amp": "soft",
     "crush": "soft",
-    "claude": "none",
+    "claude": "hard",
     "opencode": "none",
 }
 
@@ -861,16 +906,30 @@ def run_agent(
                 requested_model=model,
             )
 
-    argv = build_argv(
-        cli_ref,
-        prompt,
-        read_only=read_only,
-        sandbox=sandbox,
-        model=model,
-        reasoning=reasoning,
-        cwd=cwd,
-        resume_session_id=resume_session_id,
-    )
+    try:
+        argv = build_argv(
+            cli_ref,
+            prompt,
+            read_only=read_only,
+            sandbox=sandbox,
+            model=model,
+            reasoning=reasoning,
+            cwd=cwd,
+            resume_session_id=resume_session_id,
+        )
+    except ValueError as exc:
+        # A builder rejected the launch before spawning (e.g. claude
+        # workspace-write, which this CLI version cannot enforce). Fail the
+        # seat cleanly instead of crashing the run or stalling on a prompt.
+        return AgentResult(
+            text="",
+            ok=False,
+            detail=str(exc)[:200],
+            failure_phase="dispatch",
+            failure_kind="unsupported-sandbox",
+            requested_model=model,
+            reasoning=reasoning,
+        )
     structured_grok = cli_ref == "grok" and (read_only or sandbox == "read-only")
     if structured_grok:
         if argv[-2:] != ["--permission-mode", "plan"]:

--- a/src/brigade/agents.py
+++ b/src/brigade/agents.py
@@ -74,7 +74,23 @@ class _GrokFinal:
 
 
 _CLAUDE_DISALLOWED_ALWAYS = "Task,Agent"
-_CLAUDE_DISALLOWED_READ_ONLY = "Task,Agent,Bash,Edit,Write,NotebookEdit"
+# `mcp__*` removes every MCP/plugin tool from Claude's context so configured
+# extension write tools cannot bypass read-only (the built-in tool names alone
+# leave them available). Read-only is also enforced by `--permission-mode plan`,
+# the actual permission/sandbox mechanism, so a buggy `--disallowedTools` for
+# MCP tools cannot let a write through.
+_CLAUDE_DISALLOWED_READ_ONLY = "Task,Agent,Bash,Edit,Write,NotebookEdit,mcp__*"
+
+
+class UnsupportedSandboxError(ValueError):
+    """A builder rejected the launch because the sandbox cannot be enforced.
+
+    Subclasses ``ValueError`` so direct ``build_argv`` callers that test for the
+    historical ``ValueError`` keep working, while ``run_agent`` can classify this
+    distinctly from unrelated ``ValueError`` raised by other builders (unknown
+    cli, unsupported model/reasoning pin, bad resume-session args, ...).
+    """
+
 
 # Claude Code has no native workspace-write sandbox: headless `-p` either waits
 # on a permission prompt (hang) or, with --dangerously-skip-permissions, grants
@@ -101,11 +117,27 @@ _CLAUDE_NO_SANDBOX_ERROR = (
 
 def _claude_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | None) -> List[str]:
     if read_only or sandbox == "read-only":
-        # --disallowedTools removes tools from the model's context entirely
-        # (a hard deny), so read-only is enforced by the CLI, not just the prompt.
-        return ["claude", "-p", "--disallowedTools", _CLAUDE_DISALLOWED_READ_ONLY, prompt]
+        # Read-only is enforced two ways:
+        # 1. `--permission-mode plan` is Claude's actual permission/sandbox
+        #    mechanism: file edits and shell-write tools route to the permission
+        #    callback and are never auto-approved, so writes fail closed. This
+        #    catches MCP/plugin write tools that `--disallowedTools` cannot reach
+        #    (issue anthropics/claude-code#12863: --disallowedTools is silently
+        #    ignored for MCP server tools).
+        # 2. `--disallowedTools` removes the built-in mutating tools and every
+        #    MCP/plugin tool (`mcp__*`) from the model's context (a hard deny),
+        #    so read-only is not a prompt-only claim.
+        return [
+            "claude",
+            "-p",
+            "--permission-mode",
+            "plan",
+            "--disallowedTools",
+            _CLAUDE_DISALLOWED_READ_ONLY,
+            prompt,
+        ]
     if sandbox == "workspace-write":
-        raise ValueError(_CLAUDE_WORKSPACE_WRITE_ERROR)
+        raise UnsupportedSandboxError(_CLAUDE_WORKSPACE_WRITE_ERROR)
     if sandbox == "danger-full-access":
         # Explicit full-access request: headless `-p` would stall on a permission
         # prompt without --dangerously-skip-permissions; the deny list still
@@ -119,7 +151,7 @@ def _claude_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | 
             prompt,
         ]
     # sandbox is None: refuse to guess between stalling and granting full access.
-    raise ValueError(_CLAUDE_NO_SANDBOX_ERROR)
+    raise UnsupportedSandboxError(_CLAUDE_NO_SANDBOX_ERROR)
 
 
 def _codex_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | None) -> List[str]:
@@ -917,16 +949,31 @@ def run_agent(
             cwd=cwd,
             resume_session_id=resume_session_id,
         )
-    except ValueError as exc:
-        # A builder rejected the launch before spawning (e.g. claude
-        # workspace-write, which this CLI version cannot enforce). Fail the
-        # seat cleanly instead of crashing the run or stalling on a prompt.
+    except UnsupportedSandboxError as exc:
+        # A builder rejected the launch before spawning because the requested
+        # sandbox cannot be enforced (e.g. claude workspace-write or a claude
+        # write run with no explicit sandbox). Fail the seat cleanly instead of
+        # crashing the run or stalling on a prompt.
         return AgentResult(
             text="",
             ok=False,
             detail=str(exc)[:200],
             failure_phase="dispatch",
             failure_kind="unsupported-sandbox",
+            requested_model=model,
+            reasoning=reasoning,
+        )
+    except ValueError as exc:
+        # An unrelated builder rejected the launch before spawning (unknown
+        # cli, unsupported model/reasoning pin, bad resume-session args, ...).
+        # These are not sandbox failures; classify them accurately instead of
+        # mislabeling them unsupported-sandbox.
+        return AgentResult(
+            text="",
+            ok=False,
+            detail=str(exc)[:200],
+            failure_phase="dispatch",
+            failure_kind="invalid-dispatch-args",
             requested_model=model,
             reasoning=reasoning,
         )

--- a/src/brigade/cli/run.py
+++ b/src/brigade/cli/run.py
@@ -350,6 +350,28 @@ def dispatch(args) -> int:
     # work. Dry, read-only, and worktree runs never edit the tree, so reviewing
     # uncommitted changes stays possible without --allow-dirty.
     write_run = not args.dry_run and not args.read_only and effective_sandbox != "read-only"
+    # --allow-dirty in a dirty primary checkout would let ground truth attribute
+    # pre-existing work to the worker; require a linked worktree (or --worktree)
+    # so attribution stays clean. A clean tree, or a linked worktree the user
+    # created themselves, may still run dirty.
+    if (
+        args.allow_dirty
+        and write_run
+        and not args.worktree
+        and runguard.is_git_worktree(run_cwd)
+        and runguard.is_primary_checkout(run_cwd)
+    ):
+        try:
+            runguard.require_clean_worktree(run_cwd)
+        except runguard.DirtyWorktreeError:
+            print(
+                "error: --allow-dirty is not allowed in a primary checkout with uncommitted "
+                "changes; brigade would attribute pre-existing changes to the worker. "
+                "Commit or stash, use a linked git worktree, or pass --worktree to run in an "
+                "isolated checkout.",
+                file=sys.stderr,
+            )
+            return 2
     try:
         if write_run and not args.worktree and not args.allow_dirty and runguard.is_git_worktree(run_cwd):
             runguard.require_clean_worktree(run_cwd)

--- a/src/brigade/runguard.py
+++ b/src/brigade/runguard.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import contextlib
 import errno
+import hashlib
 import json
 import os
 import shutil
+import stat
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -573,6 +575,229 @@ def remove_worktree(repo: Path, worktree_path: Path) -> None:
     result = _git(root, "worktree", "remove", "--force", str(worktree_path), timeout=120.0)
     if result.code != 0:
         shutil.rmtree(worktree_path, ignore_errors=True)
+
+
+def is_primary_checkout(cwd: Path) -> bool:
+    """True when cwd is the main checkout rather than a linked git worktree.
+
+    In a primary checkout `--git-dir` and `--git-common-dir` resolve to the
+    same ``<toplevel>/.git`` directory; a linked worktree's ``--git-dir`` lives
+    under ``<common>/.git/worktrees/<name>`` and so differs from the common dir.
+    Returns False when cwd is not inside a work tree at all.
+    """
+    git_dir = _git(cwd, "rev-parse", "--git-dir")
+    common_dir = _git(cwd, "rev-parse", "--git-common-dir")
+    if git_dir.code != 0 or common_dir.code != 0:
+        return False
+    raw_git = git_dir.stdout.strip()
+    raw_common = common_dir.stdout.strip()
+    try:
+        git_path = (Path(raw_git) if Path(raw_git).is_absolute() else (cwd / raw_git)).resolve()
+        common_path = (Path(raw_common) if Path(raw_common).is_absolute() else (cwd / raw_common)).resolve()
+        return git_path == common_path
+    except OSError:
+        return False
+
+
+@dataclass(frozen=True)
+class PreRunSnapshot:
+    """Pre-run git state used to attribute only worker changes to the worker.
+
+    Captures branch, HEAD, and a content-sensitive fingerprint for every
+    tracked file already dirty and every untracked file already present, so
+    ground truth can compare final state to the baseline and attribute only
+    the paths the worker actually touched (a further edit to a file that was
+    already dirty is detected, while a baseline-dirty file the worker left
+    alone is excluded). Fingerprints encode content, filesystem type, and
+    mode, so deletions and type changes are detected too. Raw file contents
+    and secrets are never persisted: only a one-way digest per path is stored.
+    A branch/HEAD drift check can fail the run if the ref moves out from under
+    the worker.
+    """
+
+    branch: str
+    head: str
+    tracked_dirty: tuple[tuple[str, str], ...]
+    untracked: tuple[tuple[str, str], ...]
+
+    @property
+    def tracked_dirty_paths(self) -> tuple[str, ...]:
+        return tuple(path for path, _ in self.tracked_dirty)
+
+    @property
+    def untracked_paths(self) -> tuple[str, ...]:
+        return tuple(path for path, _ in self.untracked)
+
+
+def _tracked_dirty_paths(cwd: Path) -> list[str]:
+    result = _git(cwd, "diff", "--name-only", "HEAD")
+    if result.code != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise RunGuardError(f"failed to list tracked dirty files: {detail}")
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def _path_fingerprint(cwd: Path, relpath: str) -> str:
+    """Content- and type-sensitive fingerprint for a working-tree path.
+
+    Encodes filesystem type (regular file, symlink, directory, special, or
+    missing), mode, and content digest so a further edit, a deletion, or a
+    type/mode change to a baseline-dirty or untracked file is detected while an
+    untouched baseline file compares equal. Only a one-way digest is returned;
+    raw file contents are read transiently to hash and never persisted.
+    """
+    full = cwd / relpath
+    try:
+        st = full.lstat()
+    except FileNotFoundError:
+        return "missing"
+    except OSError:
+        return "unreadable"
+    mode = st.st_mode & 0o7777
+    if stat.S_ISLNK(st.st_mode):
+        try:
+            target = os.readlink(full)
+        except OSError:
+            return f"link:{mode}:unreadable"
+        return f"link:{mode}:{target}"
+    if stat.S_ISDIR(st.st_mode):
+        try:
+            entries = sorted(os.listdir(full))
+        except OSError:
+            return f"dir:{mode}:unreadable"
+        return f"dir:{mode}:{','.join(entries)}"
+    if not stat.S_ISREG(st.st_mode):
+        return f"special:{mode}"
+    h = hashlib.sha256()
+    try:
+        with full.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(65536), b""):
+                h.update(chunk)
+    except OSError:
+        return f"file:{mode}:unreadable"
+    return f"file:{mode}:{h.hexdigest()}"
+
+
+def _fingerprint_map(cwd: Path, paths: list[str]) -> tuple[tuple[str, str], ...]:
+    return tuple((path, _path_fingerprint(cwd, path)) for path in sorted(set(paths)))
+
+
+def capture_pre_run_snapshot(cwd: Path | None) -> PreRunSnapshot | None:
+    """Capture pre-run git state, or None when cwd is not a git work tree.
+
+    Raises RunGuardError when the tree is a git work tree but git state cannot
+    be read, so preflight fails loudly instead of silently disabling safety.
+    """
+    if cwd is None or not is_git_worktree(cwd):
+        return None
+    head = _git(cwd, "rev-parse", "HEAD")
+    branch = _git(cwd, "rev-parse", "--abbrev-ref", "HEAD")
+    # A repo with no commits has no HEAD; treat that as a non-snapshotable tree
+    # so ground truth falls back to its unavailable path rather than crashing.
+    if head.code != 0 or branch.code != 0:
+        return None
+    tracked_dirty_paths = _tracked_dirty_paths(cwd)
+    untracked_paths = _untracked_files(cwd)
+    return PreRunSnapshot(
+        head=head.stdout.strip(),
+        branch=branch.stdout.strip(),
+        tracked_dirty=_fingerprint_map(cwd, tracked_dirty_paths),
+        untracked=_fingerprint_map(cwd, untracked_paths),
+    )
+
+
+def snapshot_payload(snapshot: PreRunSnapshot | None) -> dict[str, object] | None:
+    if snapshot is None:
+        return None
+    return {
+        "schema": "brigade.pre_run_snapshot.v1",
+        "branch": snapshot.branch,
+        "head": snapshot.head,
+        "tracked_dirty_files": list(snapshot.tracked_dirty_paths),
+        "untracked_files": list(snapshot.untracked_paths),
+    }
+
+
+def detect_branch_head_drift(cwd: Path | None, snapshot: PreRunSnapshot | None) -> str | None:
+    """Return a human detail when branch or HEAD moved since the snapshot."""
+    if snapshot is None or cwd is None:
+        return None
+    head = _git(cwd, "rev-parse", "HEAD")
+    branch = _git(cwd, "rev-parse", "--abbrev-ref", "HEAD")
+    if head.code != 0 or branch.code != 0:
+        detail = head.stderr.strip() or branch.stderr.strip() or "git rev-parse failed"
+        return f"could not re-read git state after run: {detail}"
+    current_head = head.stdout.strip()
+    current_branch = branch.stdout.strip()
+    if current_head != snapshot.head and current_branch != snapshot.branch:
+        return (
+            f"git state drifted during run: branch {snapshot.branch!r} -> {current_branch!r}, "
+            f"HEAD {snapshot.head[:12]} -> {current_head[:12]}"
+        )
+    if current_head != snapshot.head:
+        return f"git HEAD drifted during run: {snapshot.head[:12]} -> {current_head[:12]}"
+    if current_branch != snapshot.branch:
+        return f"git branch drifted during run: {snapshot.branch!r} -> {current_branch!r}"
+    return None
+
+
+def changes_relative_to_snapshot(cwd: Path | None, snapshot: PreRunSnapshot | None) -> tuple[list[str], list[str]]:
+    """Changed/untracked files attributable to the worker, relative to snapshot.
+
+    Compares final working-tree state to the content-sensitive baseline so a
+    further edit, deletion, or type/mode change to a file that was already
+    dirty or untracked before the run is detected, while a baseline file the
+    worker left alone is excluded. Newly dirtied tracked files and new
+    untracked files are attributed to the worker. Returns ([], []) when no
+    snapshot is available.
+    """
+    if snapshot is None or cwd is None:
+        return [], []
+    try:
+        current_tracked = _tracked_dirty_paths(cwd)
+    except RunGuardError:
+        current_tracked = []
+    try:
+        current_untracked = _untracked_files(cwd)
+    except RunGuardError:
+        current_untracked = []
+    baseline_tracked = dict(snapshot.tracked_dirty)
+    baseline_untracked = dict(snapshot.untracked)
+
+    changed: list[str] = []
+    for path in current_tracked:
+        baseline = baseline_tracked.get(path)
+        if baseline is None:
+            # Newly dirtied by the worker.
+            changed.append(path)
+            continue
+        # Already dirty at baseline: attribute only if the worker touched it
+        # (content, deletion, or type/mode change).
+        if _path_fingerprint(cwd, path) != baseline:
+            changed.append(path)
+
+    untracked: list[str] = []
+    for path in current_untracked:
+        baseline = baseline_untracked.get(path)
+        if baseline is None:
+            # New untracked file created by the worker.
+            untracked.append(path)
+            continue
+        # Already untracked at baseline: attribute only if the worker mutated it.
+        if _path_fingerprint(cwd, path) != baseline:
+            untracked.append(path)
+
+    # A baseline untracked file the worker deleted is no longer listed by git,
+    # so compare final state explicitly and report it as an untracked-path
+    # change attributable to the worker.
+    current_untracked_set = set(current_untracked)
+    for path, baseline in baseline_untracked.items():
+        if path in current_untracked_set:
+            continue
+        if _path_fingerprint(cwd, path) != baseline:
+            untracked.append(path)
+
+    return changed, untracked
 
 
 def _tracked_diff(cwd: Path) -> tuple[str, int]:

--- a/src/brigade/runguard.py
+++ b/src/brigade/runguard.py
@@ -714,7 +714,13 @@ def snapshot_payload(snapshot: PreRunSnapshot | None) -> dict[str, object] | Non
         "branch": snapshot.branch,
         "head": snapshot.head,
         "tracked_dirty_files": list(snapshot.tracked_dirty_paths),
+        # Content-sensitive fingerprints per path so the persisted snapshot can
+        # audit and reproduce the worker-change comparison: a reviewer can re-run
+        # the baseline-vs-final fingerprint diff without recapturing the tree.
+        # Only one-way digests are stored; raw file contents are never persisted.
+        "tracked_dirty_fingerprints": dict(snapshot.tracked_dirty),
         "untracked_files": list(snapshot.untracked_paths),
+        "untracked_fingerprints": dict(snapshot.untracked),
     }
 
 
@@ -748,23 +754,31 @@ def changes_relative_to_snapshot(cwd: Path | None, snapshot: PreRunSnapshot | No
     further edit, deletion, or type/mode change to a file that was already
     dirty or untracked before the run is detected, while a baseline file the
     worker left alone is excluded. Newly dirtied tracked files and new
-    untracked files are attributed to the worker. Returns ([], []) when no
+    untracked files are attributed to the worker. The union of baseline and
+    final dirty/untracked paths is covered, so a baseline-dirty tracked file
+    the worker restored to HEAD (no longer listed by `git diff --name-only
+    HEAD`) is still detected as a content change. Returns ([], []) when no
     snapshot is available.
+
+    Fails closed: if a final git query fails, RunGuardError is raised with a
+    precise reason instead of returning an empty result the caller would treat
+    as an available clean run.
     """
     if snapshot is None or cwd is None:
         return [], []
     try:
         current_tracked = _tracked_dirty_paths(cwd)
-    except RunGuardError:
-        current_tracked = []
+    except RunGuardError as exc:
+        raise RunGuardError(f"could not re-read tracked dirty files after run: {exc}") from exc
     try:
         current_untracked = _untracked_files(cwd)
-    except RunGuardError:
-        current_untracked = []
+    except RunGuardError as exc:
+        raise RunGuardError(f"could not re-read untracked files after run: {exc}") from exc
     baseline_tracked = dict(snapshot.tracked_dirty)
     baseline_untracked = dict(snapshot.untracked)
 
     changed: list[str] = []
+    current_tracked_set = set(current_tracked)
     for path in current_tracked:
         baseline = baseline_tracked.get(path)
         if baseline is None:
@@ -775,8 +789,20 @@ def changes_relative_to_snapshot(cwd: Path | None, snapshot: PreRunSnapshot | No
         # (content, deletion, or type/mode change).
         if _path_fingerprint(cwd, path) != baseline:
             changed.append(path)
+    # A baseline-dirty tracked file the worker restored to HEAD is no longer
+    # listed by `git diff --name-only HEAD`, so it is absent from
+    # current_tracked. Compare its final fingerprint to the baseline and
+    # attribute the restore (a content change back to HEAD) to the worker. This
+    # covers the union of baseline and final dirty tracked paths, not just the
+    # final set.
+    for path, baseline in baseline_tracked.items():
+        if path in current_tracked_set:
+            continue
+        if _path_fingerprint(cwd, path) != baseline:
+            changed.append(path)
 
     untracked: list[str] = []
+    current_untracked_set = set(current_untracked)
     for path in current_untracked:
         baseline = baseline_untracked.get(path)
         if baseline is None:
@@ -790,7 +816,6 @@ def changes_relative_to_snapshot(cwd: Path | None, snapshot: PreRunSnapshot | No
     # A baseline untracked file the worker deleted is no longer listed by git,
     # so compare final state explicitly and report it as an untracked-path
     # change attributable to the worker.
-    current_untracked_set = set(current_untracked)
     for path, baseline in baseline_untracked.items():
         if path in current_untracked_set:
             continue

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -940,9 +940,14 @@ def test_run_json_records_disabled_code_graph(monkeypatch, tmp_path):
     db.parent.mkdir(parents=True)
     db.write_text("")
     monkeypatch.setattr(aboyeur, "_graphtrail_bin", lambda: "/bin/graphtrail")
-    monkeypatch.setattr(
-        aboyeur.proc, "run", lambda *args, **kw: (_ for _ in ()).throw(AssertionError("no graphtrail run"))
-    )
+    real_run = aboyeur.proc.run
+
+    def forbid_graphtrail(command, **kwargs):
+        if command[0] == "/bin/graphtrail":
+            raise AssertionError("no graphtrail run")
+        return real_run(command, **kwargs)
+
+    monkeypatch.setattr(aboyeur.proc, "run", forbid_graphtrail)
 
     def fake_run_agent(cli_ref, prompt, timeout=600.0, cwd=None, read_only=False):
         assert "## Code graph context" not in prompt
@@ -4330,3 +4335,335 @@ def test_plan_codex_stdin_hang_names_seat_and_transport(monkeypatch):
     ) as exc:
         aboyeur.plan("build feature", roster, codex_transport="app-server")
     assert "Reading additional input from stdin" not in str(exc.value)
+
+
+def test_build_ground_truth_subtracts_pre_run_snapshot(tmp_path):
+    # Contract: ground truth attributes only state changes relative to the
+    # pre-run snapshot, so pre-existing dirty/untracked files are not charged
+    # to the worker.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    (repo / "tracked.txt").write_text("base\n")
+    _commit_all(repo)
+    # Pre-existing work in progress (only possible in a linked worktree).
+    (repo / "preexisting.txt").write_text("already dirty\n")
+    snapshot = runguard.capture_pre_run_snapshot(repo)
+    # Worker makes its own changes; leaves the pre-existing file alone.
+    (repo / "tracked.txt").write_text("worker changed\n")
+    (repo / "worker_new.txt").write_text("worker created\n")
+
+    ground_truth = aboyeur.build_ground_truth(repo, datetime.now(timezone.utc), pre_run_snapshot=snapshot)
+
+    assert ground_truth["available"] is True
+    assert ground_truth["changed_files"] == ["tracked.txt"]
+    assert ground_truth["untracked_files"] == ["worker_new.txt"]
+
+
+def test_build_ground_truth_without_snapshot_attributes_all(tmp_path):
+    # Backward-compat: callers without a snapshot get the full diff (the
+    # historical behavior), so clean-run attribution is unchanged.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    (repo / "tracked.txt").write_text("base\n")
+    _commit_all(repo)
+    (repo / "tracked.txt").write_text("changed\n")
+    (repo / "new.txt").write_text("new\n")
+
+    ground_truth = aboyeur.build_ground_truth(repo, datetime.now(timezone.utc))
+
+    assert ground_truth["available"] is True
+    assert ground_truth["changed_files"] == ["tracked.txt"]
+    assert ground_truth["untracked_files"] == ["new.txt"]
+
+
+def test_run_persists_pre_run_snapshot(monkeypatch, tmp_path):
+    def fake_run_agent(cli_ref, prompt, timeout=600.0, cwd=None, read_only=False):
+        if "assignments" in prompt:
+            return agents.AgentResult(
+                text=json.dumps({"assignments": [{"worker": "coder", "task": "implement it"}]}),
+                ok=True,
+            )
+        if cli_ref == "ollama:llama3.3":
+            (cwd / "tracked.txt").write_text("changed by worker\n")
+            return agents.AgentResult(text="worker output", ok=True)
+        return agents.AgentResult(text="final answer", ok=True)
+
+    run_cwd = tmp_path / "work"
+    run_cwd.mkdir()
+    _init_git_repo(run_cwd)
+    (run_cwd / "tracked.txt").write_text("initial\n")
+    _commit_all(run_cwd)
+    output_dir = tmp_path / "run"
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+
+    assert aboyeur.run("build feature", _roster(), cwd=run_cwd, output_dir=output_dir) == 0
+
+    snapshot_file = output_dir / "pre-run-snapshot.json"
+    assert snapshot_file.is_file()
+    snapshot = json.loads(snapshot_file.read_text())
+    assert snapshot["schema"] == "brigade.pre_run_snapshot.v1"
+    assert snapshot["tracked_dirty_files"] == []
+    assert snapshot["untracked_files"] == []
+    assert len(snapshot["head"]) == 40
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["pre_run_snapshot"]["head"] == snapshot["head"]
+
+
+def test_run_fails_when_head_drifts_during_dispatch(monkeypatch, tmp_path, capsys):
+    # Contract: a concurrent commit (or branch switch) that moves HEAD during
+    # the run fails the run with a branch-head-drift failure instead of
+    # letting ground truth attribute the foreign state to the worker.
+    calls = []
+
+    def fake_run_agent(cli_ref, prompt, timeout=600.0, cwd=None, read_only=False):
+        calls.append((cli_ref, prompt))
+        if len(calls) == 1:
+            return agents.AgentResult(
+                text=json.dumps({"assignments": [{"worker": "coder", "task": "implement it"}]}),
+                ok=True,
+            )
+        if cli_ref == "ollama:llama3.3":
+            # A concurrent commit lands while the worker is running.
+            (cwd / "concurrent.txt").write_text("x\n")
+            subprocess.run(["git", "add", "concurrent.txt"], cwd=cwd, check=True, stdout=subprocess.DEVNULL)
+            subprocess.run(
+                [
+                    "git",
+                    "-c",
+                    "user.name=Test User",
+                    "-c",
+                    "user.email=test@example.invalid",
+                    "commit",
+                    "-m",
+                    "concurrent",
+                ],
+                cwd=cwd,
+                check=True,
+                stdout=subprocess.DEVNULL,
+            )
+            return agents.AgentResult(text="worker output", ok=True)
+        return agents.AgentResult(text="final answer", ok=True)
+
+    run_cwd = tmp_path / "work"
+    run_cwd.mkdir()
+    _init_git_repo(run_cwd)
+    (run_cwd / "tracked.txt").write_text("initial\n")
+    _commit_all(run_cwd)
+    output_dir = tmp_path / "run"
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+
+    rc = aboyeur.run("build feature", _roster(), cwd=run_cwd, output_dir=output_dir, code_graph_enabled=False)
+
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "drifted" in err
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "failed"
+    assert run_meta["failure"]["kind"] == "branch-head-drift"
+    assert run_meta["failure"]["phase"] == "run-isolation"
+    # The worker result must not have been written: the run failed before
+    # ground-truth attribution.
+    assert not (output_dir / "worker-results.json").exists()
+
+
+def _drift_repo(tmp_path):
+    run_cwd = tmp_path / "work"
+    run_cwd.mkdir()
+    _init_git_repo(run_cwd)
+    (run_cwd / "tracked.txt").write_text("initial\n")
+    _commit_all(run_cwd)
+    return run_cwd
+
+
+def _concurrent_commit(cwd):
+    (cwd / "concurrent.txt").write_text("x\n")
+    subprocess.run(["git", "add", "concurrent.txt"], cwd=cwd, check=True, stdout=subprocess.DEVNULL)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Test User",
+            "-c",
+            "user.email=test@example.invalid",
+            "commit",
+            "-m",
+            "concurrent",
+        ],
+        cwd=cwd,
+        check=True,
+        stdout=subprocess.DEVNULL,
+    )
+
+
+def test_run_fails_when_head_drifts_during_planning_including_dry_run(monkeypatch, tmp_path, capsys):
+    # Contract: drift during planning must fail the run on every return path,
+    # including a dry-run that would otherwise return a plan built on stale
+    # state.
+    calls = []
+
+    def fake_run_agent(cli_ref, prompt, timeout=600.0, cwd=None, read_only=False):
+        calls.append((cli_ref, prompt))
+        if len(calls) == 1:
+            # A concurrent commit lands during planning.
+            _concurrent_commit(cwd)
+            return agents.AgentResult(
+                text=json.dumps({"assignments": [{"worker": "coder", "task": "implement it"}]}),
+                ok=True,
+            )
+        return agents.AgentResult(text="final answer", ok=True)
+
+    run_cwd = _drift_repo(tmp_path)
+    output_dir = tmp_path / "run"
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+
+    rc = aboyeur.run(
+        "build feature",
+        _roster(),
+        cwd=run_cwd,
+        output_dir=output_dir,
+        dry_run=True,
+        code_graph_enabled=False,
+    )
+
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "drifted" in err
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "failed"
+    assert run_meta["failure"]["kind"] == "branch-head-drift"
+    assert run_meta["failure"]["phase"] == "run-isolation"
+    # The dry-run plan must not have been printed as a success.
+    assert not (output_dir / "plan.json").exists()
+
+
+def test_run_fails_when_head_drifts_during_synthesis(monkeypatch, tmp_path, capsys):
+    # Contract: drift during synthesis must fail the run before the synthesized
+    # answer is finalized on top of drifted state.
+    calls = []
+
+    def fake_run_agent(cli_ref, prompt, timeout=600.0, cwd=None, read_only=False):
+        calls.append((cli_ref, prompt))
+        if len(calls) == 1:
+            return agents.AgentResult(
+                text=json.dumps({"assignments": [{"worker": "coder", "task": "implement it"}]}),
+                ok=True,
+            )
+        if cli_ref == "ollama:llama3.3":
+            (cwd / "tracked.txt").write_text("changed by worker\n")
+            return agents.AgentResult(text="worker output", ok=True)
+        # Synthesis call: a concurrent commit lands while synthesizing.
+        _concurrent_commit(cwd)
+        return agents.AgentResult(text="final answer", ok=True)
+
+    run_cwd = _drift_repo(tmp_path)
+    output_dir = tmp_path / "run"
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+
+    rc = aboyeur.run("build feature", _roster(), cwd=run_cwd, output_dir=output_dir, code_graph_enabled=False)
+
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "drifted" in err
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "failed"
+    assert run_meta["failure"]["kind"] == "branch-head-drift"
+    assert run_meta["failure"]["phase"] == "run-isolation"
+    # The synthesized answer must not have been finalized as a success.
+    assert not (output_dir / "final.txt").exists()
+
+
+def test_run_fails_when_pre_run_snapshot_capture_fails(monkeypatch, tmp_path, capsys):
+    # Contract: a git work tree whose state cannot be read must fail preflight
+    # loudly instead of silently disabling run isolation.
+    run_cwd = _drift_repo(tmp_path)
+    output_dir = tmp_path / "run"
+
+    def boom(_cwd):
+        raise runguard.RunGuardError("could not read git state")
+
+    monkeypatch.setattr(aboyeur.runguard, "capture_pre_run_snapshot", boom)
+
+    rc = aboyeur.run("build feature", _roster(), cwd=run_cwd, output_dir=output_dir, code_graph_enabled=False)
+
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "pre-run snapshot failed" in err
+    assert "could not read git state" in err
+    # No run artifacts should have been written: preflight failed before start.
+    assert not (output_dir / "run.json").exists()
+    assert not (output_dir / "pre-run-snapshot.json").exists()
+
+
+def test_run_persists_pre_run_snapshot_before_worker_dispatch(monkeypatch, tmp_path):
+    # Contract: the pre-run snapshot is persisted immediately once the run
+    # artifact directory exists, before any worker is dispatched.
+    dispatched_with_snapshot = {"value": False}
+
+    def fake_run_agent(cli_ref, prompt, timeout=600.0, cwd=None, read_only=False):
+        if "assignments" in prompt:
+            return agents.AgentResult(
+                text=json.dumps({"assignments": [{"worker": "coder", "task": "implement it"}]}),
+                ok=True,
+            )
+        if cli_ref == "ollama:llama3.3":
+            # The snapshot must already be on disk by the time the worker runs.
+            dispatched_with_snapshot["value"] = (output_dir / "pre-run-snapshot.json").exists()
+            (cwd / "tracked.txt").write_text("changed by worker\n")
+            return agents.AgentResult(text="worker output", ok=True)
+        return agents.AgentResult(text="final answer", ok=True)
+
+    run_cwd = _drift_repo(tmp_path)
+    output_dir = tmp_path / "run"
+    monkeypatch.setattr(aboyeur.agents, "run_agent", fake_run_agent)
+
+    assert aboyeur.run("build feature", _roster(), cwd=run_cwd, output_dir=output_dir) == 0
+    assert dispatched_with_snapshot["value"] is True
+
+
+def test_build_ground_truth_dirty_baseline_leaves_diffstat_unavailable(tmp_path):
+    # Contract (finding 6): a dirty baseline must never reuse the full HEAD
+    # diffstat as the run delta. Only content-changed paths relative to
+    # baseline are reported and line counts are left unavailable.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    (repo / "tracked.txt").write_text("base\n")
+    _commit_all(repo)
+    # Dirty baseline: a tracked file already dirty before the run.
+    (repo / "tracked.txt").write_text("already dirty\n")
+    snapshot = runguard.capture_pre_run_snapshot(repo)
+    # Worker edits the already-dirty file further and adds a new file.
+    (repo / "tracked.txt").write_text("already dirty then worker changed\n")
+    (repo / "worker_new.txt").write_text("worker created\n")
+
+    ground_truth = aboyeur.build_ground_truth(repo, datetime.now(timezone.utc), pre_run_snapshot=snapshot)
+
+    assert ground_truth["available"] is True
+    assert ground_truth["changed_files"] == ["tracked.txt"]
+    assert ground_truth["untracked_files"] == ["worker_new.txt"]
+    assert ground_truth["diffstat"] == ""
+    assert ground_truth["diffstat_unavailable"] is True
+    assert ground_truth["change_provenance"] == "observed-during-run-author-unknown"
+
+
+def test_build_ground_truth_clean_baseline_preserves_diffstat(tmp_path):
+    # Contract (finding 6): a clean baseline preserves the full HEAD diffstat
+    # (it equals the worker delta), so existing clean-run behavior is unchanged.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    (repo / "tracked.txt").write_text("base\n")
+    _commit_all(repo)
+    snapshot = runguard.capture_pre_run_snapshot(repo)  # clean
+    (repo / "tracked.txt").write_text("worker changed\n")
+    (repo / "worker_new.txt").write_text("worker created\n")
+
+    ground_truth = aboyeur.build_ground_truth(repo, datetime.now(timezone.utc), pre_run_snapshot=snapshot)
+
+    assert ground_truth["available"] is True
+    assert ground_truth["changed_files"] == ["tracked.txt"]
+    assert ground_truth["untracked_files"] == ["worker_new.txt"]
+    assert ground_truth["diffstat"] != ""
+    assert "diffstat_unavailable" not in ground_truth

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -4667,3 +4667,28 @@ def test_build_ground_truth_clean_baseline_preserves_diffstat(tmp_path):
     assert ground_truth["untracked_files"] == ["worker_new.txt"]
     assert ground_truth["diffstat"] != ""
     assert "diffstat_unavailable" not in ground_truth
+
+
+def test_build_ground_truth_fails_closed_when_final_git_query_fails(tmp_path, monkeypatch):
+    # Regression for finding 3 (Greptile r3632423436): a final git query failure
+    # during snapshot comparison must not become an available clean result.
+    # Ground truth fails closed with available=False and a precise reason.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    (repo / "tracked.txt").write_text("base\n")
+    _commit_all(repo)
+    snapshot = runguard.capture_pre_run_snapshot(repo)
+    (repo / "tracked.txt").write_text("worker changed\n")
+
+    def boom(cwd, *args, **kwargs):
+        return proc.Result(128, "", "fatal: not a git object")
+
+    monkeypatch.setattr(runguard, "_git", boom)
+
+    ground_truth = aboyeur.build_ground_truth(repo, datetime.now(timezone.utc), pre_run_snapshot=snapshot)
+
+    assert ground_truth["available"] is False
+    assert "could not re-read tracked dirty files after run" in str(ground_truth["reason"])
+    assert ground_truth["changed_files"] == []
+    assert ground_truth["untracked_files"] == []

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -56,8 +56,10 @@ def test_build_argv_for_read_only_codex():
     assert agents.build_argv("claude", "hi", read_only=True) == [
         "claude",
         "-p",
+        "--permission-mode",
+        "plan",
         "--disallowedTools",
-        "Task,Agent,Bash,Edit,Write,NotebookEdit",
+        "Task,Agent,Bash,Edit,Write,NotebookEdit,mcp__*",
         "hi",
     ]
     assert agents.build_argv("opencode", "hi", read_only=True) == ["opencode", "run", "hi"]
@@ -109,13 +111,19 @@ def test_build_argv_for_read_only_codex():
 def test_claude_read_only_disallows_mutating_tools_and_subagents():
     # Contract: read-only must be enforced by the CLI (a hard deny), not just
     # the prompt. Subagents (Task, Agent) and every filesystem-mutating tool
-    # are removed from the model's context.
+    # are removed from the model's context, and every MCP/plugin tool is
+    # removed via `mcp__*` so configured extension write tools cannot bypass
+    # read-only. Read-only is also enforced by `--permission-mode plan`,
+    # Claude's actual permission/sandbox mechanism, so a buggy `--disallowedTools`
+    # for MCP tools (anthropics/claude-code#12863) cannot let a write through.
     argv = agents.build_argv("claude", "inspect it", read_only=True)
     assert argv == [
         "claude",
         "-p",
+        "--permission-mode",
+        "plan",
         "--disallowedTools",
-        "Task,Agent,Bash,Edit,Write,NotebookEdit",
+        "Task,Agent,Bash,Edit,Write,NotebookEdit,mcp__*",
         "inspect it",
     ]
 
@@ -124,8 +132,10 @@ def test_claude_read_only_sandbox_variant_matches_read_only_flag():
     assert agents.build_argv("claude", "inspect it", sandbox="read-only") == [
         "claude",
         "-p",
+        "--permission-mode",
+        "plan",
         "--disallowedTools",
-        "Task,Agent,Bash,Edit,Write,NotebookEdit",
+        "Task,Agent,Bash,Edit,Write,NotebookEdit,mcp__*",
         "inspect it",
     ]
 
@@ -209,6 +219,76 @@ def test_read_only_enforcement_claude_is_hard():
     assert agents.READ_ONLY_ENFORCEMENT["claude"] == "hard"
     assert agents.read_only_enforcement("claude") == "hard"
     assert agents.read_only_enforcement("claude", sandbox="read-only") == "hard"
+
+
+def test_run_agent_non_sandbox_value_error_is_not_unsupported_sandbox(monkeypatch):
+    # Regression for finding 1 (CodeRabbit r3632410930): a ValueError from
+    # build_argv that is NOT a sandbox rejection (here, an unsupported model pin
+    # on goose) must not be mislabeled unsupported-sandbox. Only the dedicated
+    # UnsupportedSandboxError maps to unsupported-sandbox; other ValueErrors map
+    # to invalid-dispatch-args.
+    spawned = []
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(agents.proc, "run", lambda argv, **kw: spawned.append(argv))
+
+    result = agents.run_agent("goose", "hi", model="anything")
+
+    assert result.ok is False
+    assert result.failure_phase == "dispatch"
+    assert result.failure_kind == "invalid-dispatch-args"
+    assert "does not support model pinning" in result.detail
+    assert spawned == []
+
+
+def test_run_agent_unknown_cli_value_error_is_not_unsupported_sandbox(monkeypatch):
+    # A second non-sandbox ValueError class: an unknown cli must be
+    # invalid-dispatch-args, not unsupported-sandbox.
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(agents.proc, "run", lambda argv, **kw: agents.proc.Result(0, "answer", ""))
+
+    result = agents.run_agent("nope", "hi")
+
+    assert result.ok is False
+    assert result.failure_phase == "dispatch"
+    assert result.failure_kind == "invalid-dispatch-args"
+    assert "unknown agent cli" in result.detail
+
+
+def test_unsupported_sandbox_error_is_value_error_subclass():
+    # Contract: direct build_argv callers historically caught ValueError; the
+    # dedicated sandbox error stays a ValueError subclass so they keep working.
+    assert issubclass(agents.UnsupportedSandboxError, ValueError)
+    with pytest.raises(ValueError, match="workspace-write"):
+        agents.build_argv("claude", "implement it", sandbox="workspace-write")
+    with pytest.raises(ValueError, match="explicit sandbox"):
+        agents.build_argv("claude", "implement it")
+
+
+def test_claude_read_only_enforces_permission_mode_plan_not_prompt_only():
+    # Regression for finding 5 (Greptile security r3632423694): Claude read-only
+    # must be enforced by Claude's actual permission/sandbox mechanism
+    # (`--permission-mode plan`), not a prompt-only claim. Plan mode routes file
+    # edits and shell-write tools to the permission callback and never
+    # auto-approves them, so configured MCP/plugin write tools -- which
+    # `--disallowedTools` cannot reach (anthropics/claude-code#12863) -- cannot
+    # bypass read-only. The deny list also strips every MCP/plugin tool via
+    # `mcp__*` as defense in depth.
+    argv = agents.build_argv("claude", "Write the secret to disk.", read_only=True)
+
+    # The actual permission/sandbox mechanism is present in the argv.
+    assert "--permission-mode" in argv
+    assert argv[argv.index("--permission-mode") + 1] == "plan"
+
+    # Every MCP/plugin tool is removed from context so extension write tools
+    # cannot bypass the built-in-only deny list.
+    disallowed = argv[argv.index("--disallowedTools") + 1].split(",")
+    assert "mcp__*" in disallowed
+    assert {"Task", "Agent", "Bash", "Edit", "Write", "NotebookEdit"}.issubset(disallowed)
+
+    # Read-only is NOT a prompt-only claim: the user prompt is passed through
+    # verbatim with no "do not modify" instruction injected by the adapter.
+    assert argv[-1] == "Write the secret to disk."
+    assert "Read-only planning run." not in argv[-1]
 
 
 def test_build_argv_antigravity_writable_uses_cwd_write_approval(tmp_path):

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -8,7 +8,10 @@ from brigade import agents
 
 
 def test_build_argv_for_known_clis():
-    assert agents.build_argv("claude", "hi") == ["claude", "-p", "hi"]
+    # A claude write run with no explicit sandbox must fail safely rather than
+    # silently grant full access (or stall on a permission prompt).
+    with pytest.raises(ValueError, match="explicit sandbox"):
+        agents.build_argv("claude", "hi")
     assert agents.build_argv("codex", "hi") == ["codex", "exec", "-"]
     assert agents.build_argv("opencode", "hi") == ["opencode", "run", "hi"]
     assert agents.build_argv("antigravity", "hi") == [
@@ -50,7 +53,13 @@ def test_build_argv_for_read_only_codex():
         "read-only",
         "-",
     ]
-    assert agents.build_argv("claude", "hi", read_only=True) == ["claude", "-p", "hi"]
+    assert agents.build_argv("claude", "hi", read_only=True) == [
+        "claude",
+        "-p",
+        "--disallowedTools",
+        "Task,Agent,Bash,Edit,Write,NotebookEdit",
+        "hi",
+    ]
     assert agents.build_argv("opencode", "hi", read_only=True) == ["opencode", "run", "hi"]
     assert agents.build_argv("antigravity", "hi", read_only=True) == ["agy", "--sandbox", "--print", "hi"]
     assert agents.build_argv("pi", "hi", read_only=True) == ["pi", "--tools", "read,grep,find,ls", "-p", "hi"]
@@ -95,6 +104,111 @@ def test_build_argv_for_read_only_codex():
         "llama3.3",
         "hi",
     ]
+
+
+def test_claude_read_only_disallows_mutating_tools_and_subagents():
+    # Contract: read-only must be enforced by the CLI (a hard deny), not just
+    # the prompt. Subagents (Task, Agent) and every filesystem-mutating tool
+    # are removed from the model's context.
+    argv = agents.build_argv("claude", "inspect it", read_only=True)
+    assert argv == [
+        "claude",
+        "-p",
+        "--disallowedTools",
+        "Task,Agent,Bash,Edit,Write,NotebookEdit",
+        "inspect it",
+    ]
+
+
+def test_claude_read_only_sandbox_variant_matches_read_only_flag():
+    assert agents.build_argv("claude", "inspect it", sandbox="read-only") == [
+        "claude",
+        "-p",
+        "--disallowedTools",
+        "Task,Agent,Bash,Edit,Write,NotebookEdit",
+        "inspect it",
+    ]
+
+
+def test_claude_write_run_uses_skip_permissions_and_disallows_subagents():
+    # Contract: only an explicit --sandbox danger-full-access request may add
+    # --dangerously-skip-permissions. A write run with no explicit sandbox must
+    # fail safely with actionable guidance instead of silently granting full
+    # access (or stalling on a permission prompt). The deny list always removes
+    # subagent spawning so the worker cannot delegate out of the seat.
+    expected = [
+        "claude",
+        "-p",
+        "--dangerously-skip-permissions",
+        "--disallowedTools",
+        "Task,Agent",
+        "implement it",
+    ]
+    assert agents.build_argv("claude", "implement it", sandbox="danger-full-access") == expected
+    with pytest.raises(ValueError, match="explicit sandbox"):
+        agents.build_argv("claude", "implement it")
+
+
+def test_claude_workspace_write_rejected_before_launch():
+    # Contract: workspace-write cannot be truthfully enforced by this CLI
+    # version, so it is rejected before launch with an actionable error.
+    with pytest.raises(ValueError, match="workspace-write"):
+        agents.build_argv("claude", "implement it", sandbox="workspace-write")
+
+
+def test_run_agent_claude_workspace_write_fails_without_spawn(monkeypatch):
+    spawned = []
+
+    def fake_run(argv, **kw):
+        spawned.append(argv)
+        return agents.proc.Result(0, "answer", "")
+
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(agents.proc, "run", fake_run)
+
+    res = agents.run_agent("claude", "implement it", sandbox="workspace-write")
+
+    assert res.ok is False
+    assert res.failure_phase == "dispatch"
+    assert res.failure_kind == "unsupported-sandbox"
+    assert "workspace-write" in res.detail
+    assert "danger-full-access" in res.detail
+    assert spawned == []  # never launched the claude process
+
+
+def test_run_agent_claude_write_without_sandbox_fails_safely(monkeypatch):
+    # Regression for finding 4: a claude write run with no explicit sandbox
+    # must fail safely with actionable guidance instead of silently adding
+    # --dangerously-skip-permissions (or stalling on a permission prompt). Only
+    # an explicit danger-full-access request may add the skip-permissions flag.
+    spawned = []
+
+    def fake_run(argv, **kw):
+        spawned.append(argv)
+        return agents.proc.Result(0, "answer", "")
+
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(agents.proc, "run", fake_run)
+
+    res = agents.run_agent("claude", "implement it")  # sandbox=None
+
+    assert res.ok is False
+    assert res.failure_phase == "dispatch"
+    assert res.failure_kind == "unsupported-sandbox"
+    assert "explicit sandbox" in res.detail
+    assert "danger-full-access" in res.detail
+    assert spawned == []  # never launched the claude process
+    # And the dangerous flag is not present anywhere it could have been added.
+    assert not any("--dangerously-skip-permissions" in argv for argv in spawned)
+
+
+def test_read_only_enforcement_claude_is_hard():
+    # Contract: claude now hard-enforces read-only via --disallowedTools, so the
+    # advisory table must report 'hard' (not 'none') so --read-only stops warning
+    # that claude cannot be constrained.
+    assert agents.READ_ONLY_ENFORCEMENT["claude"] == "hard"
+    assert agents.read_only_enforcement("claude") == "hard"
+    assert agents.read_only_enforcement("claude", sandbox="read-only") == "hard"
 
 
 def test_build_argv_antigravity_writable_uses_cwd_write_approval(tmp_path):
@@ -217,11 +331,14 @@ def test_build_argv_unknown_raises():
 
 
 def test_build_argv_pins_model_for_claude_and_codex():
-    assert agents.build_argv("claude", "hi", model="claude-fable-5") == [
+    assert agents.build_argv("claude", "hi", sandbox="danger-full-access", model="claude-fable-5") == [
         "claude",
         "--model",
         "claude-fable-5",
         "-p",
+        "--dangerously-skip-permissions",
+        "--disallowedTools",
+        "Task,Agent",
         "hi",
     ]
     assert agents.build_argv("codex", "hi", model="gpt-5.5-codex") == [
@@ -252,7 +369,14 @@ def test_build_argv_pins_model_for_claude_and_codex():
 
 
 def test_build_argv_without_model_is_unchanged():
-    assert agents.build_argv("claude", "hi", model=None) == ["claude", "-p", "hi"]
+    assert agents.build_argv("claude", "hi", sandbox="danger-full-access", model=None) == [
+        "claude",
+        "-p",
+        "--dangerously-skip-permissions",
+        "--disallowedTools",
+        "Task,Agent",
+        "hi",
+    ]
     assert agents.build_argv("codex", "hi", model=None) == ["codex", "exec", "-"]
 
 
@@ -635,9 +759,18 @@ def test_run_agent_forwards_model_to_argv(monkeypatch):
 
     monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
     monkeypatch.setattr(agents.proc, "run", fake_run)
-    res = agents.run_agent("claude", "hi", model="claude-fable-5")
+    res = agents.run_agent("claude", "hi", sandbox="danger-full-access", model="claude-fable-5")
     assert res.ok is True
-    assert captured["argv"] == ["/x/claude", "--model", "claude-fable-5", "-p", "hi"]
+    assert captured["argv"] == [
+        "/x/claude",
+        "--model",
+        "claude-fable-5",
+        "-p",
+        "--dangerously-skip-permissions",
+        "--disallowedTools",
+        "Task,Agent",
+        "hi",
+    ]
 
 
 def test_run_agent_codex_feeds_prompt_on_stdin(monkeypatch):
@@ -702,7 +835,7 @@ def test_build_argv_applies_reasoning(cli_ref, expected):
 
 def test_build_argv_rejects_reasoning_for_unsupported_adapter():
     with pytest.raises(ValueError, match="does not support reasoning"):
-        agents.build_argv("claude", "hi", reasoning="high")
+        agents.build_argv("claude", "hi", sandbox="danger-full-access", reasoning="high")
 
 
 def test_run_agent_threads_cwd_into_argv_builder(monkeypatch, tmp_path):
@@ -815,7 +948,7 @@ def test_run_agent_antigravity_with_no_cwd_allows_current_cwd(monkeypatch, tmp_p
 def test_run_agent_nonzero_is_not_ok(monkeypatch):
     monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
     monkeypatch.setattr(agents.proc, "run", lambda argv, **kw: agents.proc.Result(1, "", "boom"))
-    res = agents.run_agent("claude", "x")
+    res = agents.run_agent("claude", "x", sandbox="danger-full-access")
     assert res.ok is False
     assert "boom" in res.detail
     assert res.exit_code == 1
@@ -1197,6 +1330,7 @@ def test_run_agent_env_overrides_child_environment(monkeypatch):
     result = agents.run_agent(
         "claude",
         "hi",
+        sandbox="danger-full-access",
         env={"ANTHROPIC_BASE_URL": "https://api.example.com/anthropic"},
     )
     assert result.ok
@@ -1216,7 +1350,9 @@ def test_run_agent_env_ref_resolves_from_parent(monkeypatch):
     monkeypatch.setattr(agents.proc, "run", fake_run)
     monkeypatch.setenv("KIMI_API_KEY", "sk-resolved-value")
 
-    result = agents.run_agent("claude", "hi", env={"ANTHROPIC_AUTH_TOKEN_REF": "KIMI_API_KEY"})
+    result = agents.run_agent(
+        "claude", "hi", sandbox="danger-full-access", env={"ANTHROPIC_AUTH_TOKEN_REF": "KIMI_API_KEY"}
+    )
     assert result.ok
     assert captured["env"]["ANTHROPIC_AUTH_TOKEN"] == "sk-resolved-value"
     assert "ANTHROPIC_AUTH_TOKEN_REF" not in captured["env"]
@@ -1239,6 +1375,7 @@ def test_run_agent_env_file_ref_uses_runtime_environment_file(tmp_path, monkeypa
     result = agents.run_agent(
         "claude",
         "hi",
+        sandbox="danger-full-access",
         env={"ANTHROPIC_AUTH_TOKEN_REF": f"env-file:{environment_file}#CLIPROXY_API_KEY"},
     )
 
@@ -1257,6 +1394,7 @@ def test_run_agent_env_file_ref_unavailable_fails_before_spawn(tmp_path, monkeyp
     result = agents.run_agent(
         "claude",
         "hi",
+        sandbox="danger-full-access",
         env={"ANTHROPIC_AUTH_TOKEN_REF": f"env-file:{environment_file}#CLIPROXY_API_KEY"},
     )
 
@@ -1276,6 +1414,7 @@ def test_run_agent_malformed_env_file_ref_never_reads_parent_environment(monkeyp
     result = agents.run_agent(
         "claude",
         "hi",
+        sandbox="danger-full-access",
         env={"ANTHROPIC_AUTH_TOKEN_REF": "env-file:relative/path#CLIPROXY_API_KEY"},
     )
 
@@ -1302,6 +1441,7 @@ def test_run_agent_env_file_prefixed_parent_variable_still_resolves(monkeypatch)
     result = agents.run_agent(
         "claude",
         "hi",
+        sandbox="danger-full-access",
         env={"ANTHROPIC_AUTH_TOKEN_REF": "env-filed"},
     )
 
@@ -1327,6 +1467,7 @@ def test_run_agent_scrubs_resolved_env_values_from_success_output(monkeypatch):
     result = agents.run_agent(
         "claude",
         "hi",
+        sandbox="danger-full-access",
         env={"ANTHROPIC_BASE_URL": endpoint, "ANTHROPIC_AUTH_TOKEN_REF": "LANE_KEY"},
     )
 
@@ -1350,7 +1491,9 @@ def test_run_agent_scrubs_resolved_env_value_from_failure_detail(monkeypatch):
     )
     monkeypatch.setenv("LANE_KEY", token)
 
-    result = agents.run_agent("claude", "hi", env={"ANTHROPIC_AUTH_TOKEN_REF": "LANE_KEY"})
+    result = agents.run_agent(
+        "claude", "hi", sandbox="danger-full-access", env={"ANTHROPIC_AUTH_TOKEN_REF": "LANE_KEY"}
+    )
 
     assert not result.ok
     assert token not in result.text
@@ -1372,7 +1515,12 @@ def test_run_agent_scrubs_longer_overlapping_env_value_first(monkeypatch):
     monkeypatch.setenv("LANE_SECRET", secret)
     monkeypatch.setenv("LANE_FRAGMENT", fragment)
 
-    result = agents.run_agent("claude", "hi", env={"ENDPOINT_REF": "LANE_SECRET", "HOST_FRAGMENT_REF": "LANE_FRAGMENT"})
+    result = agents.run_agent(
+        "claude",
+        "hi",
+        sandbox="danger-full-access",
+        env={"ENDPOINT_REF": "LANE_SECRET", "HOST_FRAGMENT_REF": "LANE_FRAGMENT"},
+    )
 
     assert result.ok
     assert result.text == "connected to [ENDPOINT]"
@@ -1388,7 +1536,9 @@ def test_run_agent_scrubs_equal_env_values_with_stable_target(monkeypatch):
     )
     monkeypatch.setenv("LANE_SHARED", shared)
 
-    result = agents.run_agent("claude", "hi", env={"Z_MODE_REF": "LANE_SHARED", "A_MODE_REF": "LANE_SHARED"})
+    result = agents.run_agent(
+        "claude", "hi", sandbox="danger-full-access", env={"Z_MODE_REF": "LANE_SHARED", "A_MODE_REF": "LANE_SHARED"}
+    )
 
     assert result.ok
     assert result.text == "configured [A_MODE]"
@@ -1408,6 +1558,7 @@ def test_run_agent_never_scrubs_short_plain_flag_values(monkeypatch):
     result = agents.run_agent(
         "claude",
         "plan it",
+        sandbox="danger-full-access",
         env={
             "ANTHROPIC_BASE_URL": "https://proxy.local.test/anthropic",
             "ANTHROPIC_AUTH_TOKEN_REF": "CLIPROXY_API_KEY",
@@ -1428,7 +1579,7 @@ def test_run_agent_skips_short_secret_values(monkeypatch):
     )
     monkeypatch.setenv("LANE_SHORT", "1")
 
-    result = agents.run_agent("claude", "hi", env={"LANE_MODE_REF": "LANE_SHORT"})
+    result = agents.run_agent("claude", "hi", sandbox="danger-full-access", env={"LANE_MODE_REF": "LANE_SHORT"})
 
     assert result.ok
     assert result.text == "stage 1 of 3 done"
@@ -1444,7 +1595,7 @@ def test_run_agent_scrubs_alnum_secret_only_on_word_boundaries(monkeypatch):
     )
     monkeypatch.setenv("LANE_ALNUM", secret)
 
-    result = agents.run_agent("claude", "hi", env={"LANE_TOKEN_REF": "LANE_ALNUM"})
+    result = agents.run_agent("claude", "hi", sandbox="danger-full-access", env={"LANE_TOKEN_REF": "LANE_ALNUM"})
 
     assert result.ok
     assert result.text == "token [LANE_TOKEN] inside receiptabcd1234efghtail"
@@ -1461,7 +1612,7 @@ def test_run_agent_skips_alnum_secret_embedded_in_unicode_identifier(monkeypatch
     )
     monkeypatch.setenv("LANE_ALNUM", secret)
 
-    result = agents.run_agent("claude", "hi", env={"LANE_TOKEN_REF": "LANE_ALNUM"})
+    result = agents.run_agent("claude", "hi", sandbox="danger-full-access", env={"LANE_TOKEN_REF": "LANE_ALNUM"})
 
     assert result.ok
     assert result.text == f"token {embedded}"
@@ -1514,7 +1665,7 @@ def test_run_agent_skips_alnum_secret_embedded_with_decomposed_left_combining_ma
     )
     monkeypatch.setenv("LANE_ALNUM", secret)
 
-    result = agents.run_agent("claude", "hi", env={"LANE_TOKEN_REF": "LANE_ALNUM"})
+    result = agents.run_agent("claude", "hi", sandbox="danger-full-access", env={"LANE_TOKEN_REF": "LANE_ALNUM"})
 
     assert result.ok
     assert result.text == f"token {embedded}"
@@ -1531,7 +1682,7 @@ def test_run_agent_skips_alnum_secret_embedded_with_decomposed_right_combining_m
     )
     monkeypatch.setenv("LANE_ALNUM", secret)
 
-    result = agents.run_agent("claude", "hi", env={"LANE_TOKEN_REF": "LANE_ALNUM"})
+    result = agents.run_agent("claude", "hi", sandbox="danger-full-access", env={"LANE_TOKEN_REF": "LANE_ALNUM"})
 
     assert result.ok
     assert result.text == f"token {embedded}"
@@ -1548,7 +1699,7 @@ def test_run_agent_scrubs_alnum_secret_delimited_by_unicode_punctuation(monkeypa
     )
     monkeypatch.setenv("LANE_ALNUM", secret)
 
-    result = agents.run_agent("claude", "hi", env={"LANE_TOKEN_REF": "LANE_ALNUM"})
+    result = agents.run_agent("claude", "hi", sandbox="danger-full-access", env={"LANE_TOKEN_REF": "LANE_ALNUM"})
 
     assert result.ok
     assert result.text == "token 《[LANE_TOKEN]》"
@@ -1572,7 +1723,7 @@ def test_run_agent_scrubs_secret_only_on_identifier_edges(monkeypatch, secret, e
     )
     monkeypatch.setenv("LANE_SECRET", secret)
 
-    result = agents.run_agent("claude", "hi", env={"LANE_TOKEN_REF": "LANE_SECRET"})
+    result = agents.run_agent("claude", "hi", sandbox="danger-full-access", env={"LANE_TOKEN_REF": "LANE_SECRET"})
 
     assert result.ok
     assert result.text == f"token [LANE_TOKEN] done inside {embedded}"
@@ -1610,7 +1761,7 @@ def test_run_agent_classifies_output_before_scrubbing_env_values(monkeypatch):
     )
     monkeypatch.setenv("LANE_DIAGNOSTIC", diagnostic)
 
-    result = agents.run_agent("claude", "hi", env={"LANE_MODE_REF": "LANE_DIAGNOSTIC"})
+    result = agents.run_agent("claude", "hi", sandbox="danger-full-access", env={"LANE_MODE_REF": "LANE_DIAGNOSTIC"})
 
     assert not result.ok
     assert result.failure_kind == "rate-limit-error"
@@ -1662,7 +1813,7 @@ def test_run_agent_scrubs_long_env_value_before_detail_truncation(monkeypatch):
     )
     monkeypatch.setenv("LONG_LANE_TOKEN", token)
 
-    result = agents.run_agent("claude", "hi", env={"LANE_TOKEN_REF": "LONG_LANE_TOKEN"})
+    result = agents.run_agent("claude", "hi", sandbox="danger-full-access", env={"LANE_TOKEN_REF": "LONG_LANE_TOKEN"})
 
     assert not result.ok
     assert result.failure_kind == "rate-limit-error"
@@ -1708,7 +1859,7 @@ def test_run_agent_does_not_scrub_unrelated_parent_environment(monkeypatch):
     )
     monkeypatch.setenv("UNRELATED_VALUE", unrelated)
 
-    result = agents.run_agent("claude", "hi", env={"LANE_MODE": "test"})
+    result = agents.run_agent("claude", "hi", sandbox="danger-full-access", env={"LANE_MODE": "test"})
 
     assert result.ok
     assert unrelated in result.text
@@ -1720,7 +1871,9 @@ def test_run_agent_env_ref_missing_fails_before_spawn(monkeypatch):
     monkeypatch.setattr(agents.proc, "run", lambda argv, **kw: calls.append(argv))
     monkeypatch.delenv("MISSING_LANE_KEY", raising=False)
 
-    result = agents.run_agent("claude", "hi", env={"ANTHROPIC_AUTH_TOKEN_REF": "MISSING_LANE_KEY"})
+    result = agents.run_agent(
+        "claude", "hi", sandbox="danger-full-access", env={"ANTHROPIC_AUTH_TOKEN_REF": "MISSING_LANE_KEY"}
+    )
     assert not result.ok
     assert "MISSING_LANE_KEY" in result.detail
     assert "is not set" in result.detail
@@ -1737,14 +1890,16 @@ def test_run_agent_env_default_leaves_child_environment_alone(monkeypatch):
     monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
     monkeypatch.setattr(agents.proc, "run", fake_run)
 
-    assert agents.run_agent("claude", "hi").ok
+    assert agents.run_agent("claude", "hi", sandbox="danger-full-access").ok
     assert captured["env"] is None
 
 
 def test_run_agent_env_ref_missing_is_typed_failure(monkeypatch):
     monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
     monkeypatch.delenv("MISSING_LANE_KEY", raising=False)
-    result = agents.run_agent("claude", "hi", env={"ANTHROPIC_AUTH_TOKEN_REF": "MISSING_LANE_KEY"})
+    result = agents.run_agent(
+        "claude", "hi", sandbox="danger-full-access", env={"ANTHROPIC_AUTH_TOKEN_REF": "MISSING_LANE_KEY"}
+    )
     assert not result.ok
     assert result.failure_kind == "env-ref-missing"
 
@@ -1752,7 +1907,7 @@ def test_run_agent_env_ref_missing_is_typed_failure(monkeypatch):
 def test_run_agent_env_rejects_bare_ref_suffix(monkeypatch):
     monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
     monkeypatch.setenv("HOME_VAR", "value")
-    result = agents.run_agent("claude", "hi", env={"_REF": "HOME_VAR"})
+    result = agents.run_agent("claude", "hi", sandbox="danger-full-access", env={"_REF": "HOME_VAR"})
     assert not result.ok
     assert "empty" in result.detail
 
@@ -1760,7 +1915,9 @@ def test_run_agent_env_rejects_bare_ref_suffix(monkeypatch):
 def test_run_agent_env_ref_empty_value_is_typed_failure(monkeypatch):
     monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
     monkeypatch.setenv("EMPTY_LANE_KEY", "")
-    result = agents.run_agent("claude", "hi", env={"ANTHROPIC_AUTH_TOKEN_REF": "EMPTY_LANE_KEY"})
+    result = agents.run_agent(
+        "claude", "hi", sandbox="danger-full-access", env={"ANTHROPIC_AUTH_TOKEN_REF": "EMPTY_LANE_KEY"}
+    )
     assert not result.ok
     assert result.failure_kind == "env-ref-missing"
     assert "is not set or is empty" in result.detail

--- a/tests/test_agents_model_pin.py
+++ b/tests/test_agents_model_pin.py
@@ -144,11 +144,14 @@ def test_ollama_cloud_ref_keeps_full_model_name():
 
 
 def test_claude_and_codex_argv_unchanged_by_registry():
-    assert agents.build_argv("claude", "P", model="claude-fable-5") == [
+    assert agents.build_argv("claude", "P", sandbox="danger-full-access", model="claude-fable-5") == [
         "claude",
         "--model",
         "claude-fable-5",
         "-p",
+        "--dangerously-skip-permissions",
+        "--disallowedTools",
+        "Task,Agent",
         "P",
     ]
     assert agents.build_argv("codex", "P", model="gpt-5.5-codex") == [

--- a/tests/test_read_only_enforcement.py
+++ b/tests/test_read_only_enforcement.py
@@ -14,7 +14,7 @@ def test_read_only_enforcement_classification():
     assert agents.read_only_enforcement("goose") == "soft"
     assert agents.read_only_enforcement("crush") == "soft"
     assert agents.read_only_enforcement("kimi") == "soft"
-    assert agents.read_only_enforcement("claude") == "none"
+    assert agents.read_only_enforcement("claude") == "hard"
     assert agents.read_only_enforcement("opencode") == "none"
     assert agents.read_only_enforcement("ollama:llama3") == "none"
     assert agents.read_only_enforcement("totally-unknown") == "none"
@@ -40,7 +40,7 @@ def test_advisory_lists_non_hard_agents_including_orchestrator():
     assert "soft (goose)" in joined
     assert "open (opencode)" in joined
     assert "safe (codex)" not in joined  # natively sandboxed, hard-enforced
-    assert "lead (claude)" in joined  # the orchestrator runs too and claude does not enforce read-only
+    assert "lead (claude)" not in joined  # claude now hard-enforces read-only via --disallowedTools
 
 
 def test_writable_sandbox_override_only_downgrades_codex_exec():

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -946,9 +946,28 @@ def test_run_cli_dirty_guard_does_not_allocate_artifact_directory(tmp_path, monk
     assert not (repo / ".brigade" / "runs").exists()
 
 
-def test_run_cli_allow_dirty_passes_dirty_guard(tmp_path, monkeypatch):
+def test_run_cli_allow_dirty_rejected_in_dirty_primary_checkout(tmp_path, monkeypatch, capsys):
     repo = _git_repo_with_roster(tmp_path)
     (repo / "tracked.txt").write_text("dirty\n")
+
+    def fail_run(*args, **kwargs):
+        raise AssertionError("aboyeur.run should not be called")
+
+    monkeypatch.setattr(aboyeur, "run", fail_run)
+
+    rc = cli.main(["run", "x", "--cwd", str(repo), "--allow-dirty", "--no-artifacts"])
+
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "--allow-dirty is not allowed in a primary checkout" in err
+    assert "linked git worktree" in err
+    assert "--worktree" in err
+
+
+def test_run_cli_allow_dirty_passes_in_clean_primary_checkout(tmp_path, monkeypatch):
+    # A clean primary checkout with --allow-dirty has no pre-existing work to
+    # misattribute, so the guard stays open and the run proceeds.
+    repo = _git_repo_with_roster(tmp_path)
     seen = {}
 
     def fake_run(
@@ -970,6 +989,35 @@ def test_run_cli_allow_dirty_passes_dirty_guard(tmp_path, monkeypatch):
 
     assert cli.main(["run", "x", "--cwd", str(repo), "--allow-dirty", "--no-artifacts"]) == 0
     assert seen["cwd"] == repo
+
+
+def test_run_cli_allow_dirty_passes_in_linked_worktree(tmp_path, monkeypatch):
+    repo = _git_repo_with_roster(tmp_path)
+    (repo / "tracked.txt").write_text("dirty\n")
+    linked = tmp_path / "linked"
+    _git(repo, "worktree", "add", str(linked), "HEAD")
+    (linked / "tracked.txt").write_text("dirty-in-worktree\n")
+    seen = {}
+
+    def fake_run(
+        task,
+        loaded_roster,
+        dry_run=False,
+        show_plan=False,
+        verbose=False,
+        cwd=None,
+        output_dir=None,
+        handoff_inbox=None,
+        read_only=False,
+        sandbox=None,
+    ):
+        seen["cwd"] = cwd
+        return 0
+
+    monkeypatch.setattr(aboyeur, "run", fake_run)
+
+    assert cli.main(["run", "x", "--cwd", str(linked), "--allow-dirty", "--no-artifacts"]) == 0
+    assert seen["cwd"] == linked
 
 
 def test_run_cli_lock_conflict_errors(tmp_path, monkeypatch, capsys):
@@ -1167,13 +1215,19 @@ def test_run_cli_terminalizes_read_only_warning_write_failures(
     output_dir = repo / ".brigade" / "runs" / "warning-write"
     roster_path = repo / ".brigade" / "roster.toml"
     roster_path.write_text(
-        roster_path.read_text().replace('cli = "codex"\nrole = "code"', 'cli = "claude"\nrole = "code"')
+        roster_path.read_text().replace('cli = "codex"\nrole = "code"', 'cli = "ollama:llama3.3"\nrole = "code"')
     )
+    snapshot_calls = []
 
     def fail_warning_write(path, payload):
         raise error_type("warning write failed")
 
+    def snapshot_before_warning(_cwd):
+        snapshot_calls.append(_cwd)
+        raise AssertionError("snapshot must not run before the startup warning")
+
     monkeypatch.setattr(localio, "write_json", fail_warning_write)
+    monkeypatch.setattr(runguard, "capture_pre_run_snapshot", snapshot_before_warning)
 
     rc = cli.main(
         [
@@ -1194,6 +1248,7 @@ def test_run_cli_terminalizes_read_only_warning_write_failures(
     assert receipt["failure"]["phase"] == "startup"
     assert receipt["failure"]["kind"] == expected_kind
     assert not (output_dir / "read-only-enforcement.json").exists()
+    assert snapshot_calls == []
     assert not (repo / ".brigade" / "run.lock").exists()
 
 

--- a/tests/test_runguard.py
+++ b/tests/test_runguard.py
@@ -792,9 +792,34 @@ def test_snapshot_payload_shape(tmp_path):
         "branch": snapshot.branch,
         "head": snapshot.head,
         "tracked_dirty_files": [],
+        "tracked_dirty_fingerprints": {},
         "untracked_files": [],
+        "untracked_fingerprints": {},
     }
     assert runguard.snapshot_payload(None) is None
+
+
+def test_snapshot_payload_persists_content_sensitive_fingerprints(tmp_path):
+    # Regression for finding 4: the persisted pre-run snapshot must carry
+    # enough content-sensitive data to audit/reproduce the worker-change
+    # comparison, not just path lists. Fingerprints are one-way digests and
+    # never raw contents.
+    repo = _repo(tmp_path)
+    secret = "sk-super-secret-value-do-not-leak"
+    (repo / "tracked.txt").write_text(secret + "\n")
+    (repo / "new.txt").write_text("already here\n")
+    snapshot = runguard.capture_pre_run_snapshot(repo)
+
+    payload = runguard.snapshot_payload(snapshot)
+    assert payload is not None
+    assert payload["tracked_dirty_fingerprints"] == dict(snapshot.tracked_dirty)
+    assert payload["untracked_fingerprints"] == dict(snapshot.untracked)
+    assert payload["tracked_dirty_fingerprints"].keys() == {"tracked.txt"}
+    assert payload["untracked_fingerprints"].keys() == {"new.txt"}
+    # Persisted fingerprints are content-sensitive digests, not raw contents.
+    blob = json.dumps(payload)
+    assert secret not in blob
+    assert all(secret not in fp for fp in payload["tracked_dirty_fingerprints"].values())
 
 
 def test_changes_relative_to_snapshot_attributes_only_worker_changes(tmp_path):
@@ -929,6 +954,76 @@ def test_changes_relative_to_snapshot_detects_type_change_of_predirty_tracked(tm
 
     assert changed == ["tracked.txt"]
     assert untracked == []
+
+
+def test_changes_relative_to_snapshot_detects_predirty_tracked_restored_to_head(tmp_path):
+    # Regression for finding 2: a baseline-dirty tracked file the worker restores
+    # to HEAD is no longer listed by `git diff --name-only HEAD`, so it disappears
+    # from current_tracked. The restore is a content change (dirty baseline ->
+    # HEAD) and must be attributed to the worker by comparing the union of
+    # baseline and final dirty tracked paths with content fingerprints.
+    repo = _repo(tmp_path)
+    (repo / "tracked.txt").write_text("already dirty\n")  # baseline tracked dirt
+    snapshot = runguard.capture_pre_run_snapshot(repo)
+
+    # Worker restores the file to HEAD content (no longer dirty).
+    (repo / "tracked.txt").write_text("base\n")
+
+    changed, untracked = runguard.changes_relative_to_snapshot(repo, snapshot)
+
+    assert changed == ["tracked.txt"]
+    assert untracked == []
+
+
+def test_changes_relative_to_snapshot_excludes_predirty_tracked_unchanged(tmp_path):
+    # Companion to finding 2: a baseline-dirty tracked file the worker leaves
+    # dirty at the exact baseline content must NOT be attributed to the worker.
+    repo = _repo(tmp_path)
+    (repo / "tracked.txt").write_text("already dirty\n")
+    snapshot = runguard.capture_pre_run_snapshot(repo)
+
+    # Worker does not touch tracked.txt; only creates a new untracked file.
+    (repo / "worker_new.txt").write_text("worker created\n")
+
+    changed, untracked = runguard.changes_relative_to_snapshot(repo, snapshot)
+
+    assert changed == []
+    assert untracked == ["worker_new.txt"]
+
+
+def test_changes_relative_to_snapshot_fails_closed_when_tracked_query_fails(tmp_path, monkeypatch):
+    # Regression for finding 3: a final git query failure must not become an
+    # available clean result. Fail closed with RunGuardError and a precise reason.
+    repo = _repo(tmp_path)
+    snapshot = runguard.capture_pre_run_snapshot(repo)
+
+    def boom(cwd, *args, **kwargs):
+        return proc.Result(128, "", "fatal: not a git object")
+
+    monkeypatch.setattr(runguard, "_git", boom)
+
+    with pytest.raises(runguard.RunGuardError, match="could not re-read tracked dirty files after run"):
+        runguard.changes_relative_to_snapshot(repo, snapshot)
+
+
+def test_changes_relative_to_snapshot_fails_closed_when_untracked_query_fails(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    snapshot = runguard.capture_pre_run_snapshot(repo)
+
+    real_git = runguard._git
+    calls = {"n": 0}
+
+    def flaky(cwd, *args, **kwargs):
+        calls["n"] += 1
+        # First call (tracked dirty paths) succeeds; second (ls-files) fails.
+        if "ls-files" in args:
+            return proc.Result(128, "", "fatal: loose object")
+        return real_git(cwd, *args, **kwargs)
+
+    monkeypatch.setattr(runguard, "_git", flaky)
+
+    with pytest.raises(runguard.RunGuardError, match="could not re-read untracked files after run"):
+        runguard.changes_relative_to_snapshot(repo, snapshot)
 
 
 def test_capture_pre_run_snapshot_fingerprint_excludes_raw_content(tmp_path):

--- a/tests/test_runguard.py
+++ b/tests/test_runguard.py
@@ -721,3 +721,266 @@ def test_verify_changes_patch_accepts_empty_patch(tmp_path):
     runguard.collect_changes_patch(repo, patch_path)
 
     assert runguard.verify_changes_patch(repo, patch_path) is True
+
+
+def test_is_primary_checkout_true_for_main_repo(tmp_path):
+    repo = _repo(tmp_path)
+
+    assert runguard.is_primary_checkout(repo) is True
+
+
+def test_is_primary_checkout_false_for_linked_worktree(tmp_path):
+    repo = _repo(tmp_path)
+    linked = tmp_path / "linked"
+    _git(repo, "worktree", "add", str(linked), "HEAD")
+
+    assert runguard.is_primary_checkout(repo) is True
+    assert runguard.is_primary_checkout(linked) is False
+
+
+def test_is_primary_checkout_false_outside_git(tmp_path):
+    plain = tmp_path / "plain"
+    plain.mkdir()
+
+    assert runguard.is_primary_checkout(plain) is False
+
+
+def test_capture_pre_run_snapshot_records_clean_state(tmp_path):
+    repo = _repo(tmp_path)
+
+    snapshot = runguard.capture_pre_run_snapshot(repo)
+
+    assert snapshot is not None
+    assert snapshot.tracked_dirty == ()
+    assert snapshot.untracked == ()
+    assert len(snapshot.head) == 40
+    assert snapshot.branch in {"main", "master"}
+
+
+def test_capture_pre_run_snapshot_records_dirty_state(tmp_path):
+    repo = _repo(tmp_path)
+    (repo / "tracked.txt").write_text("dirty\n")
+    (repo / "new.txt").write_text("new\n")
+
+    snapshot = runguard.capture_pre_run_snapshot(repo)
+
+    assert snapshot is not None
+    # Fingerprints are content-sensitive and not raw contents; only the path
+    # sets are exposed for attribution comparison.
+    assert snapshot.tracked_dirty_paths == ("tracked.txt",)
+    assert snapshot.untracked_paths == ("new.txt",)
+    assert all(isinstance(fp, str) for _, fp in snapshot.tracked_dirty)
+    assert all(isinstance(fp, str) for _, fp in snapshot.untracked)
+
+
+def test_capture_pre_run_snapshot_none_outside_git(tmp_path):
+    plain = tmp_path / "plain"
+    plain.mkdir()
+
+    assert runguard.capture_pre_run_snapshot(plain) is None
+    assert runguard.capture_pre_run_snapshot(None) is None
+
+
+def test_snapshot_payload_shape(tmp_path):
+    repo = _repo(tmp_path)
+    snapshot = runguard.capture_pre_run_snapshot(repo)
+
+    payload = runguard.snapshot_payload(snapshot)
+
+    assert payload == {
+        "schema": "brigade.pre_run_snapshot.v1",
+        "branch": snapshot.branch,
+        "head": snapshot.head,
+        "tracked_dirty_files": [],
+        "untracked_files": [],
+    }
+    assert runguard.snapshot_payload(None) is None
+
+
+def test_changes_relative_to_snapshot_attributes_only_worker_changes(tmp_path):
+    repo = _repo(tmp_path)
+    # Pre-existing dirty state (allowed only in a linked worktree in practice).
+    (repo / "preexisting.txt").write_text("already dirty\n")
+    (repo / "preexisting_untracked.txt").write_text("already here\n")
+    snapshot = runguard.capture_pre_run_snapshot(repo)
+
+    # Worker makes its own changes; leaves the pre-existing files alone.
+    (repo / "tracked.txt").write_text("worker changed\n")
+    (repo / "worker_new.txt").write_text("worker created\n")
+
+    changed, untracked = runguard.changes_relative_to_snapshot(repo, snapshot)
+
+    assert changed == ["tracked.txt"]
+    assert untracked == ["worker_new.txt"]
+
+
+def test_changes_relative_to_snapshot_clean_run_attributes_everything(tmp_path):
+    repo = _repo(tmp_path)
+    snapshot = runguard.capture_pre_run_snapshot(repo)  # clean
+
+    (repo / "tracked.txt").write_text("worker changed\n")
+    (repo / "worker_new.txt").write_text("worker created\n")
+
+    changed, untracked = runguard.changes_relative_to_snapshot(repo, snapshot)
+
+    assert changed == ["tracked.txt"]
+    assert untracked == ["worker_new.txt"]
+
+
+def test_changes_relative_to_snapshot_no_snapshot_returns_empty(tmp_path):
+    repo = _repo(tmp_path)
+    (repo / "tracked.txt").write_text("changed\n")
+
+    changed, untracked = runguard.changes_relative_to_snapshot(repo, None)
+
+    assert changed == []
+    assert untracked == []
+
+
+def test_changes_relative_to_snapshot_detects_predirty_tracked_mutation(tmp_path):
+    # Regression for finding 1: path-set subtraction missed a further edit to a
+    # file already dirty before the run. The baseline fingerprint must differ
+    # from the final fingerprint so the worker's edit is detected.
+    repo = _repo(tmp_path)
+    (repo / "tracked.txt").write_text("already dirty\n")  # baseline tracked dirt
+    snapshot = runguard.capture_pre_run_snapshot(repo)
+
+    # Worker edits the already-dirty file further.
+    (repo / "tracked.txt").write_text("already dirty then worker changed\n")
+
+    changed, untracked = runguard.changes_relative_to_snapshot(repo, snapshot)
+
+    assert changed == ["tracked.txt"]
+    assert untracked == []
+
+
+def test_changes_relative_to_snapshot_detects_preexisting_untracked_mutation(tmp_path):
+    # Regression for finding 1: a pre-existing untracked file the worker
+    # mutates must be detected (path-set subtraction dropped it before).
+    repo = _repo(tmp_path)
+    (repo / "untracked.txt").write_text("already here\n")  # baseline untracked
+    snapshot = runguard.capture_pre_run_snapshot(repo)
+
+    (repo / "untracked.txt").write_text("already here then worker changed\n")
+
+    changed, untracked = runguard.changes_relative_to_snapshot(repo, snapshot)
+
+    assert changed == []
+    assert untracked == ["untracked.txt"]
+
+
+def test_changes_relative_to_snapshot_excludes_unchanged_baseline_dirt(tmp_path):
+    # Regression for finding 1: a baseline-dirty file the worker leaves alone
+    # must be excluded from attribution.
+    repo = _repo(tmp_path)
+    (repo / "tracked.txt").write_text("already dirty\n")
+    (repo / "untracked.txt").write_text("already here\n")
+    snapshot = runguard.capture_pre_run_snapshot(repo)
+
+    # Worker only creates a new file; leaves baseline dirt untouched.
+    (repo / "worker_new.txt").write_text("worker created\n")
+
+    changed, untracked = runguard.changes_relative_to_snapshot(repo, snapshot)
+
+    assert changed == []
+    assert untracked == ["worker_new.txt"]
+
+
+def test_changes_relative_to_snapshot_detects_deletion_of_predirty_tracked(tmp_path):
+    # Regression for finding 1: deleting a baseline-dirty tracked file is a
+    # worker edit (deletion) and must be detected.
+    repo = _repo(tmp_path)
+    (repo / "tracked.txt").write_text("already dirty\n")
+    snapshot = runguard.capture_pre_run_snapshot(repo)
+
+    (repo / "tracked.txt").unlink()
+
+    changed, untracked = runguard.changes_relative_to_snapshot(repo, snapshot)
+
+    assert changed == ["tracked.txt"]
+    assert untracked == []
+
+
+def test_changes_relative_to_snapshot_detects_deletion_of_preexisting_untracked(tmp_path):
+    # Regression for finding 1: deleting a baseline-untracked file is a worker
+    # edit and must be detected even though git no longer lists the path.
+    repo = _repo(tmp_path)
+    (repo / "untracked.txt").write_text("already here\n")
+    snapshot = runguard.capture_pre_run_snapshot(repo)
+
+    (repo / "untracked.txt").unlink()
+
+    changed, untracked = runguard.changes_relative_to_snapshot(repo, snapshot)
+
+    assert changed == []
+    assert untracked == ["untracked.txt"]
+
+
+def test_changes_relative_to_snapshot_detects_type_change_of_predirty_tracked(tmp_path):
+    # Regression for finding 1: a mode/type change (chmod +x) to a baseline-dirty
+    # tracked file is a worker edit and must be detected.
+    repo = _repo(tmp_path)
+    (repo / "tracked.txt").write_text("already dirty\n")
+    snapshot = runguard.capture_pre_run_snapshot(repo)
+
+    (repo / "tracked.txt").chmod(0o755)
+
+    changed, untracked = runguard.changes_relative_to_snapshot(repo, snapshot)
+
+    assert changed == ["tracked.txt"]
+    assert untracked == []
+
+
+def test_capture_pre_run_snapshot_fingerprint_excludes_raw_content(tmp_path):
+    # Contract: only a one-way digest is persisted, never raw file contents.
+    repo = _repo(tmp_path)
+    secret = "sk-super-secret-value-do-not-leak"
+    (repo / "tracked.txt").write_text(secret + "\n")
+    snapshot = runguard.capture_pre_run_snapshot(repo)
+
+    persisted = runguard.snapshot_payload(snapshot)
+    assert persisted is not None
+    assert "tracked_dirty_files" in persisted
+    assert secret not in json.dumps(persisted)
+    # The in-memory fingerprint is a digest, not the raw secret.
+    assert all(secret not in fp for _, fp in snapshot.tracked_dirty)
+
+
+def test_detect_branch_head_drift_clean_returns_none(tmp_path):
+    repo = _repo(tmp_path)
+    snapshot = runguard.capture_pre_run_snapshot(repo)
+
+    assert runguard.detect_branch_head_drift(repo, snapshot) is None
+
+
+def test_detect_branch_head_drift_on_head_move(tmp_path):
+    repo = _repo(tmp_path)
+    snapshot = runguard.capture_pre_run_snapshot(repo)
+
+    # A concurrent commit moves HEAD out from under the worker.
+    (repo / "concurrent.txt").write_text("x\n")
+    _git(repo, "add", "concurrent.txt")
+    _git(repo, "commit", "-m", "concurrent")
+
+    detail = runguard.detect_branch_head_drift(repo, snapshot)
+
+    assert detail is not None
+    assert "HEAD drifted" in detail
+
+
+def test_detect_branch_head_drift_on_branch_switch(tmp_path):
+    repo = _repo(tmp_path)
+    snapshot = runguard.capture_pre_run_snapshot(repo)
+
+    _git(repo, "checkout", "-b", "other-branch")
+    detail = runguard.detect_branch_head_drift(repo, snapshot)
+
+    assert detail is not None
+    assert "branch drifted" in detail
+
+
+def test_detect_branch_head_drift_no_snapshot_returns_none(tmp_path):
+    repo = _repo(tmp_path)
+
+    assert runguard.detect_branch_head_drift(repo, None) is None
+    assert runguard.detect_branch_head_drift(None, None) is None


### PR DESCRIPTION
## Summary

- Enforce Claude headless tool restrictions and reject sandbox modes that the installed Claude CLI cannot honor.
- Require an explicit `danger-full-access` request before adding permission bypass.
- Persist a content-sensitive pre-run Git snapshot without storing raw file contents.
- Detect branch and HEAD drift across planning, dispatch, synthesis, and finalization.
- Report only changes observed relative to the pre-run state, with author recorded as unknown.
- Reject dirty `--allow-dirty` runs in a primary checkout and direct callers to a linked worktree.

## Root cause

The Claude adapter ignored `read_only` and `sandbox`. Dirty-run ground truth compared the final worktree directly with HEAD, which mixed pre-existing changes into the receipt. Run finalization also lacked branch and HEAD invariants.

## Verification

- `brigade work verify run --target . --command "./scripts/verify" --capture brigade-work`
- Receipt: `20260722-171948-work-verify-20d6b2`
- Result: 3,742 passed, 3 skipped, coverage 82.60%, exit 0

Closes #437

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added run isolation checks to detect branch/commit drift during execution and stop affected runs safely.
  * Run receipts now include a saved pre-run repository snapshot for improved change attribution.
  * Ground-truth computation can subtract pre-existing modifications to isolate worker-caused changes.

* **Bug Fixes**
  * `brigade run --allow-dirty` is now rejected for dirty primary checkouts, while remaining supported for linked worktrees.
  * Claude sandbox enforcement now fails cleanly during dispatch for unsupported or implicit write sandboxes.
  * Claude read-only mode is now treated as hard-enforced with stricter tool restrictions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->