### PR TITLE
feat(compat): complete notify beta handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Imported `stations/notify` Go module into the Brigade monorepo. Unified release
+  manifests now enumerate five native components (25 platform assets plus
+  `component-manifest-v1.json` and `checksums.txt`) with managed resolution
+  through `brigade setup`.
+- Beta pre-pin compatibility: beta installs the CI-green `main` Brigade wheel but
+  reuses the last verified stable component manifest; `agent-notify` is omitted
+  from setup until a stable manifest publishes its assets. Stable validation
+  stays strict.
+- Public update-channel and component-manifest policy docs.
+- Agent Pantry compatibility probe: `brigade pantry` requires `agentpantry
+  version --json` `>=0.5.0` before invoking doctor, status, or inventory
+  surfaces. Pantry remains an external Go binary.
 - Passive update notice: after a successful command, brigade prints a one-line
   stderr notice (at most once per 24h) when a newer release is on PyPI.
   Anonymous, TTY-only, skipped in CI; disable with `BRIGADE_NO_UPDATE_CHECK=1`.
 - `brigade mcp sync --user-scope` (and `brigade operator sync-mcp --user-scope`) no longer writes stdio MCP servers into a user-wide client config silently: interactive runs show the destination, stdio count, and the servers-times-sessions process formula and ask for confirmation, non-interactive and `--json` runs require `--allow-global-stdio`, and plan/sync items now carry `transport` and `scope`. (#349)
+
+### Fixed
+- Agent Pantry version parsing stays non-throwing and bounded for arbitrarily
+  long numeric segments: the parser accepts ASCII-numeric semver triples only,
+  enforces a conservative per-segment digit bound, catches `int()` conversion
+  `ValueError`, and surfaces the fixed `invalid-version` label for oversized or
+  non-ASCII-digit input without ever echoing raw content. Added huge-segment and
+  non-ASCII-digit regressions covering observed/detail and adjacent stdout.
+- `docs/component-manifest-policy.md` no longer presents the five-component /
+  25-asset contract as a current stable release. It is now stated as the future
+  first stable manifest contract after `agent-notify` publication, with current
+  bundled `agent-notify` assets empty/unpublished and no stable release claimed.
 
 ## [0.25.1] - 2026-07-21
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ brigade prints a one-line notice when a new release is out (checked at most
 once a day via an anonymous request; set `BRIGADE_NO_UPDATE_CHECK=1` to
 disable - details in [docs/update-channels.md](docs/update-channels.md)).
 
+Stable pinners may deliberately install an exact release with
+`pipx install brigade-cli==X.Y.Z` or refresh through
+`brigade update --channel stable`. Channel ownership, beta rules, and when to
+use `brigade update` are in [docs/update-channels.md](docs/update-channels.md).
+
 `brigade operator doctor --target ./my-repo` prints `ready: yes` when the wiring is healthy. The default footprint is small: `AGENTS.md`, `SAFETY_RULES.md`, a handoff template, and `.brigade/` state. Add `--dry-run` to preview anything before it writes. Nothing leaves your machine.
 
 Per-OS setup (apt, Homebrew, Scoop, PowerShell), workspace depth, and multi-harness installs: [install guide](https://brigade.tools/docs/getting-started/install), [QUICKSTART.md](QUICKSTART.md), [first 10 minutes](docs/first-10-minutes.md). Homegrown setup already? `brigade operator adopt plan`.
@@ -165,6 +170,7 @@ Code intelligence, Evidence, and Content Guard (`brigade scrub`, a secrets and P
 | [Agent Pantry](https://github.com/escoffier-labs/agentpantry) | `brigade add pantry` | Encrypted browser-session and secret sync across machines |
 | [Token Glace](https://github.com/escoffier-labs/token-glace) | `brigade add tokens` | Compact noisy tool output before it burns context |
 | [Skillet](https://github.com/escoffier-labs/skillet) | optional roster | Portable skills that reconcile can promote or roll back |
+| Notifications | `brigade add notifications` | Optional `agent-notify` binary for Discord, Telegram, or Signal; status and setup planning only until you wire hooks or pass an explicit `--send` |
 
 Upgrading from the standalone GraphTrail or MiseLedger installs? `brigade setup` replaces both. The old `brigade add graphtrail` / `add evidence` paths remain as compatibility shims. Details: [wiring guide](docs/wiring-graphtrail-miseledger.md), [station contract](docs/station-contract.md).
 
@@ -188,7 +194,7 @@ Beyond the daily loop, the same review-and-receipt pattern covers cross-model ru
 
 ## What Brigade is not
 
-Brigade is not a hosted memory service, a daemon, or an automatic release bot. It does not run in the background or install schedulers (one scoped exception: `brigade tools runtime start` launches a local runtime process, only when you start it, until you stop it). It does not push to GitHub, publish packages, send notifications by default, save every note automatically, or skip review for ambiguous, risky, or failed notes. That pause is the point: agent memory should be useful, not noisy.
+Brigade is not a hosted memory service, a daemon, or an automatic release bot. It does not run in the background or install schedulers (one scoped exception: `brigade tools runtime start` launches a local runtime process, only when you start it, until you stop it). It does not push to GitHub, publish packages, save every note automatically, or skip review for ambiguous, risky, or failed notes. `brigade work brief` and related status surfaces may report notification readiness or suggest installing the notifications station, but Brigade never sends a message unless the operator uses an explicit send action such as `brigade pantry expiry-alert --send`. That pause is the point: agent memory should be useful, not noisy.
 
 And it is not the other projects that share the name. This Brigade is the AI-agent operator CLI from [`escoffier-labs/brigade`](https://github.com/escoffier-labs/brigade), installed with `pipx install brigade-cli`. It is not the CNCF/Microsoft Brigade for Kubernetes event scripting (archived 2022), the Spinabot Brigade agent crew, or the 2017 `brigade` Python package that became Nornir.
 

--- a/docs/component-manifest-policy.md
+++ b/docs/component-manifest-policy.md
@@ -5,12 +5,22 @@ from `brigade.station.v1` and `station_manifest.load`.
 
 ## Unified-release components
 
+The five-component / 25-asset contract below is the **future first stable manifest
+contract**, landing after `agent-notify` publication. No stable release yet contains
+this five-component / 25-asset `agent-notify` contract: the bundled compatibility
+manifest on `main` lists `agent-notify` as a known component with **empty/unpublished**
+assets, and the other four components have not yet shipped a stable manifest under
+this contract. Stable validation
+stays strict and will require every published component to carry the full
+five-platform matrix with matching digests and provenance.
+
 | Component id | Executable | Native release status |
 | --- | --- | --- |
 | `graphtrail` | `graphtrail` | built from the tagged Brigade commit |
 | `graphtrail-mcp` | `graphtrail-mcp` | built from the tagged Brigade commit |
 | `miseledger` | `miseledger` | built from the tagged Brigade commit |
 | `sessionfind` | `sessionfind` | built from the tagged Brigade commit |
+| `agent-notify` | `agent-notify` | bundled empty/unpublished on main; first stable manifest contract after `agent-notify` publication |
 
 Every component records the immutable 40-character tagged Brigade commit in `component_revision`.
 Every `source.repository` is `escoffier-labs/brigade`, and every `source.release_tag` is the same
@@ -50,16 +60,38 @@ download URL invariants, and a 40-character lowercase `component_revision` for e
 The revision must equal the immutable target commit of the resolved Brigade release. Unknown
 component ids remain a soft diagnostic; malformed known components are a hard failure.
 
-`scripts/generate_component_manifest.py` derives the final manifest in deterministic order from the
-tag, commit, exact 20 filenames, byte sizes, and SHA-256 values. It also writes `checksums.txt`,
-which contains exactly those 20 assets and `component-manifest-v1.json`.
+`scripts/generate_component_manifest.py` derives the future first stable
+manifest in deterministic order from the tag, commit, exact 25 filenames, byte
+sizes, and SHA-256 values. That 25-asset set is the contract the first stable
+manifest will publish after `agent-notify` publication; until then the bundled
+compatibility manifest on `main` carries empty/unpublished `agent-notify`
+assets and no stable release is claimed. The script also writes
+`checksums.txt`, which contains exactly those 25 assets and
+`component-manifest-v1.json`.
 
 The release gate runs `scripts/verify_component_manifest_provenance.py` after creating the release.
-It requires exactly one `escoffier-labs/brigade` tag for all four components, the complete five-platform
-matrix, exactly 20 native assets plus the manifest and checksum file, matching release API digests,
+It requires exactly one `escoffier-labs/brigade` tag for all five components, the complete five-platform
+matrix, exactly 25 native assets plus the manifest and checksum file, matching release API digests,
 the complete checksum map, matching fetched `checksums.txt` bytes, and a release-page manifest
-byte-for-byte equal to the packaged manifest. It uses injected fetchers in unit tests. Attestation verification is deliberately performed by `gh
+byte-for-byte equal to the packaged manifest. This is the future first stable manifest contract;
+it does not apply to the current bundled compatibility manifest, whose `agent-notify` assets remain
+empty/unpublished. It uses injected fetchers in unit tests. Attestation verification is deliberately performed by `gh
 attestation verify` in the release workflow rather than represented by an API boolean.
+
+## Pre-pin beta window
+
+Stable validation remains strict: every published component on a stable manifest must carry the full
+five-platform matrix with matching digests and provenance.
+
+Beta is the development channel for CI-green `main`. It installs the checked `main` Brigade wheel
+but reuses the last verified stable component manifest for native bytes, so beta and stable cannot
+install different native assets from two manifests at once.
+
+During the pre-pin window before `agent-notify` first appears on a stable manifest, main may list
+`agent-notify` as a known component with empty assets in the bundled compatibility manifest.
+`brigade setup` on beta skips a component explicitly unpublished on main until a stable manifest
+publishes real assets for it. Stable releases never ship with empty asset sets for a listed
+component.
 
 ## User-local path invariants
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -283,7 +283,7 @@ For safety:
 - import Content Guard findings into the work inbox for review
 - keep generated state ignored by default
 - avoid publishing, pushing, or mutating remotes automatically
-- keep notification sending opt-in
+- keep notification sending opt-in; `brigade work brief` may report readiness or suggest the station, but Brigade never sends unless the operator uses an explicit send action
 - make risky actions visible as operator decisions
 
 ## Ecosystem
@@ -337,7 +337,7 @@ Safety and operations tools:
 
 - Content Guard is embedded in Brigade and powers `brigade scrub`, publish checks, and the seeded pre-push hook. `CONTENT_GUARD_DIR` remains an explicit compatibility override for older standalone checkouts.
 - [Agent Pantry](https://github.com/escoffier-labs/agentpantry): encrypted browser session, cookie, and secret sync for agent machines.
-- [agent-notify](https://github.com/escoffier-labs/agent-notify): optional notification hooks for long-running agent work.
+- [agent-notify](https://github.com/escoffier-labs/agent-notify) (`stations/notify/` in this monorepo): optional notification hooks for long-running agent work. Released installs resolve the pinned managed `agent-notify` binary through `brigade setup` once a stable manifest publishes its assets. The standalone repository carries a migration notice and is not archived until a containing Brigade release ships and published acceptance passes.
 - [Token Glace](https://github.com/escoffier-labs/token-glace): output compaction for terminal-heavy agent workflows.
 - Built-in Scout skills: Brigade wires `brigade-work` and `ultra-work-scout` during `brigade init`; use Skillet when you want the full optional skill roster.
 
@@ -345,7 +345,7 @@ Evidence ledger tools:
 
 - [MiseLedger](https://github.com/escoffier-labs/miseledger): local-first evidence ledger. One binary crawls sessions, files, git history, and chat sources (`miseledger crawl ...`), stores `miseledger.adapter.v1` JSONL in SQLite with FTS5, and emits Brigade-ready evidence bundles. No separate exporter install.
 - Brigade station CLI (process boundary):
-  - `brigade setup` installs MiseLedger and SessionFind with GraphTrail and `graphtrail-mcp` from the exact release manifest
+  - `brigade setup` installs GraphTrail, `graphtrail-mcp`, MiseLedger, SessionFind, and `agent-notify` (when published on the release manifest) from the exact release manifest
   - `brigade add evidence` is a one-release compatibility fallback for an independent MiseLedger install
   - `brigade evidence status` / `doctor` — advisory health + next commands
   - `brigade evidence crawl <args...>` / `search <args...>` - transparent MiseLedger execution; engine output and exit code pass through
@@ -504,6 +504,24 @@ brigade pantry expiry-alert --send   # optional agent-notify (install notificati
 - `brigade pantry status` / `brigade pantry doctor` — advisory health with next commands.
 - `brigade pantry setup plan` / `service plan` — review-only plans under `.brigade/pantry/plans/`.
 - Pantry checks are advisory for workspace `doctor`. An unwired install warns but never fails a workspace run.
+
+## Notifications
+
+The `notifications` station wires optional `agent-notify` into the same operator workflow: private Discord, Telegram, or Signal delivery for long-running agent work. Source lives in [`stations/notify/`](../stations/notify/) in this repository. `agent-notify` stays a **separate Go binary** (process boundary). Brigade installs it, plans setup, and health-checks it; it does not send messages from doctor, status, or brief flows.
+
+Released pipx installs resolve `agent-notify` from the pinned unified release manifest through `brigade setup` once stable publishes its assets. `go install github.com/escoffier-labs/agent-notify/cmd/agent-notify@latest` is the explicit fallback when you are on a source checkout or the component is not yet published on the running manifest. The standalone [agent-notify](https://github.com/escoffier-labs/agent-notify) repository carries a migration notice pointing here; it is not archived until a containing Brigade release ships and published acceptance passes.
+
+```bash
+brigade add notifications
+brigade notifications status --json
+brigade notifications setup plan --profile operator
+# optional delivery after wiring:
+brigade pantry expiry-alert --send
+```
+
+- `brigade notifications status` / `brigade notifications setup plan` inspect wiring without sending.
+- `brigade work brief`, `brigade center status`, and `brigade daily status/plan` may surface notification readiness or suggest installing the station.
+- Brigade never sends unless the operator uses an explicit send action such as `brigade pantry expiry-alert --send`.
 
 ## For OpenClaw Users
 

--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -103,7 +103,7 @@ Brigade has grown from a bootstrap kit into a local control plane for agent work
 - Portable tool catalog: tool discovery, contracts, call planning, approval queues, explicit script and local MCP execution, run receipts, replay candidates, checkpoints, runtimes, host-local policy, parity, packs, sync, and projection health.
 - Shared skills: reviewed `SKILL.md` packs with metadata, provenance, linting, fingerprints, trust score, changelog, install history, diffs, portable packs, publish proposals, and one-command installation across Codex, Claude, OpenCode, Antigravity, Pi, Cursor, Aider, Goose, Continue, GitHub Copilot CLI, Qwen Code, Kimi Code, AdaL, OpenHands, Grok, Amp, Crush, OpenClaw, Hermes, and MCP-resource targets.
 - Local producers: memory care, chat export sweeps, backup health, code review, context packs, project consolidation, learning candidates and replay, and security scans.
-- Operator notifications: optional `agent-notify` status and setup planning for private Discord, Telegram, or Signal notifications, with no sending from doctor/status flows.
+- Operator notifications: optional `agent-notify` status and setup planning for private Discord, Telegram, or Signal notifications. `brigade work brief` and related status surfaces may report readiness or suggest the station; no command sends unless the operator uses an explicit send action.
 - Security and publish guards: content-guard integration, template audit, SARIF output, suppressions, accepted-risk closeouts, policy presets, prompt and instruction checks, MCP checks, supply-chain checks, and redacted reports.
 
 The common rule is deliberate friction: Brigade writes local receipts and review queues, but it does not start daemons, mutate remotes, edit canonical memory, run arbitrary commands, publish releases, or auto-promote findings without an explicit operator command.
@@ -872,7 +872,7 @@ Operator notification commands:
 - `brigade notifications status --json` inspects the local `agent-notify` binary, config file, selected profile, and referenced environment variables without sending.
 - `brigade notifications setup plan --profile operator` prints reviewed Codex and Claude Code hook snippets.
 - `brigade doctor` includes advisory `agent-notify` health under the notifications station.
-- `brigade center status`, `brigade work brief`, and `brigade daily status/plan` surface notification readiness as local advisory health.
+- `brigade center status`, `brigade work brief`, and `brigade daily status/plan` surface notification readiness as local advisory health. They may suggest installing the notifications station; they never send.
 
 Brigade does not send notifications, edit harness hook files, run hook snippets, or store webhook URLs/tokens from these commands. Keep channel secrets in environment variables referenced by `~/.config/agent-notify/config.toml`.
 
@@ -1341,7 +1341,7 @@ See [QUICKSTART.md](QUICKSTART.md) for setup, verification, and the ingest flow.
 > **In plain terms:** "stations" group built-in capabilities and optional tools Brigade can install and wire for you. Managed tools run as separate command-line processes. Content Guard is embedded in Brigade, so `brigade add guard` only offers the optional Plating helper.
 
 Some stations can install and wire external tools for you.
-Run `brigade setup` first to install GraphTrail, `graphtrail-mcp`, MiseLedger, and SessionFind from the running CLI's exact release manifest. `brigade add evidence`, `brigade add search`, and `brigade add graphtrail` remain one-release compatibility paths for independent installs; they are not required after setup. Use `brigade add <station>` for station-specific tools that setup does not manage, then wire their default config.
+Run `brigade setup` first to install GraphTrail, `graphtrail-mcp`, MiseLedger, SessionFind, and `agent-notify` (when published on the release manifest) from the running CLI's exact release manifest. `brigade add evidence`, `brigade add search`, and `brigade add graphtrail` remain one-release compatibility paths for independent installs; they are not required after setup. Use `brigade add <station>` for station-specific tools that setup does not manage, then wire their default config.
 Tools are never imported in process; Brigade shells out to each CLI, so the boundary stays model-neutral and mixed-language.
 `brigade add <path>` also discovers a local `station.json` manifest from an external station repo. The manifest path reports the station name, install command, and machine surfaces. Install commands from a manifest are not executed unless `--install` is passed.
 
@@ -1351,6 +1351,7 @@ brigade add guard    # embedded scrub path + optional plating
 brigade add tokens   # token-glace (+ optional usage-tracker)
 brigade add skills   # built-in skills + optional Skillet roster
 brigade add pantry   # agentpantry (extras surface)
+brigade add notifications   # agent-notify (extras surface)
 brigade stations discover --root ~/repos
 brigade add ../agentpantry   # inspect an external station.json
 ```
@@ -1376,6 +1377,11 @@ Like the memory satellites, agentpantry inspects host-global state, so its check
 Use `brigade pantry status` and `brigade pantry doctor` for pantry-specific health with explicit `next` commands, `brigade pantry setup plan --role source|sink` to preview or write a reviewed setup plan, and `brigade pantry service plan --role source|sink` to preview or write service setup steps.
 Use `brigade pantry expiry-alert` to report near-expiry sessions and preview the `agent-notify` message Brigade would send. Add `--send` only after `brigade add notifications` if you want delivery.
 These plan commands do not generate or copy PSKs, start services, or mutate browser, GitHub, OpenClaw, or other auth files. Product page: https://brigade.tools/agentpantry.
+
+`notifications` is the operator notification station. `agent-notify` remains a process-boundary Go binary; Brigade never imports it. Source lives in `stations/notify/` in this repository. Released pipx installs resolve `agent-notify` from the pinned unified release manifest through `brigade setup` once stable publishes its assets. `go install github.com/escoffier-labs/agent-notify/cmd/agent-notify@latest` is the explicit fallback when you are on a source checkout or the component is not yet published on the running manifest. The standalone [agent-notify](https://github.com/escoffier-labs/agent-notify) repository carries a migration notice pointing at the monorepo; it is not archived until a containing Brigade release ships and published acceptance passes.
+`brigade add notifications` installs `agent-notify` when missing and prints manual wiring steps.
+Use `brigade notifications status` and `brigade notifications setup plan` for advisory health and reviewed hook snippets without sending.
+`brigade work brief`, `brigade center status`, and `brigade daily status/plan` may surface notification readiness or suggest installing the station; Brigade never sends unless the operator uses an explicit send action such as `brigade pantry expiry-alert --send`.
 
 `evidence` (alias `ledger`) is the local evidence-ledger station. MiseLedger remains a process-boundary Go binary; Brigade never imports it.
 `brigade setup` installs MiseLedger and its SessionFind companion from the exact release manifest. `brigade add evidence` remains a one-release compatibility fallback for an independent install.

--- a/docs/update-channels.md
+++ b/docs/update-channels.md
@@ -1,6 +1,11 @@
 # Brigade update channels
 
-`brigade update` is the only supported user-global mutation path for a pipx-managed Brigade installation. It resolves immutable coordinates before changing pipx or native components, then publishes its state only after both commands succeed.
+`stable` is the immutable release and pinner channel. `beta` is the development channel for
+CI-green `main`. `brigade update` is the supported user-global mutation path for a pipx-managed
+Brigade installation once you want channel-managed upgrades. Deliberate initial or manual exact
+pins such as `pipx install brigade-cli==X.Y.Z` are valid and do not require `brigade update`
+until you choose to move. It resolves immutable coordinates before changing pipx or native
+components, then publishes its state only after both commands succeed.
 
 | Machine profile | Channel | Use |
 | --- | --- | --- |
@@ -13,7 +18,7 @@ Run `brigade update` for the production default. `brigade update --channel beta`
 
 The user-global state is `<Brigade data root>/brigade/update-state.json`, separate from component `installed.json`. Its strict schema records the selected channel, owner, exact CLI version or beta SHA, release id and tag, manifest URL and digest, and timestamp. The shared sibling lock `update.lock` covers both channels. A live owner causes a clear failure. Stale metadata is removed only after its recorded process is confirmed dead.
 
-Stable resolves `releases/latest` once, verifies the exact `component-manifest-v1.json` release asset by GitHub digest and size, and accepts only exact `escoffier-labs/brigade` release URLs at the resolved tag. Beta pins the CLI to a checked full `main` SHA but uses the same verified stable component manifest, so beta and stable cannot install different native bytes.
+Stable resolves `releases/latest` once, verifies the exact `component-manifest-v1.json` release asset by GitHub digest and size, and accepts only exact `escoffier-labs/brigade` release URLs at the resolved tag. Beta pins the CLI to a checked full `main` SHA but uses the same verified stable component manifest, so beta and stable cannot install different native bytes. During the pre-pin window before a new component such as `agent-notify` first ships on stable, beta may run newer Brigade Python from `main` while native setup still follows the last verified stable manifest; components omitted there are skipped until stable publishes their assets.
 
 The updater runs `pipx install --force` with an exact requirement, then calls the newly installed absolute `brigade` executable with `setup --manifest <verified-cache-path>`. It does not use the prior executable for setup. This sequence is not an atomic installation transaction: pipx replacement happens before component setup. State publication is transactional, so a failed pipx install or setup leaves the prior update state untouched; rerun the same update to repair components.
 

--- a/src/brigade/component_install.py
+++ b/src/brigade/component_install.py
@@ -108,12 +108,49 @@ def uses_bundled_compatibility_manifest() -> bool:
 def load_verified_exact_release_manifest(
     roots: SetupRoots,
 ) -> tuple[component_manifest.ComponentManifest, Path] | None:
-    """Read the current release manifest recorded in update state without mutating it."""
+    """Read the current release manifest recorded in update state without mutating it.
+
+    For ``stable`` state the cached manifest must pin the exact running
+    Brigade version (``state.component_tag == v{brigade.__version__}``); any
+    other stable state is treated as stale and returns ``None`` so the caller
+    re-resolves the release (online) or fails (offline).
+
+    For ``beta`` state the update transaction persisted the verified
+    last-stable release manifest coordinates. A later ``brigade setup``
+    reuses that stable cache instead of resolving an unreleased
+    ``v{brigade.__version__}`` tag (which fails online) or rejecting the
+    state as stale (which fails offline). The beta path validates the cached
+    manifest against its recorded stable ``component_tag``/version with
+    compatible missing-unpublished handling enabled, so a pre-agent-notify
+    stable manifest is accepted while every published component still pins.
+
+    Arbitrary state cannot opt in: :func:`update_cmd.load_update_state`
+    already validates the channel/state coordinates (channel in
+    {stable, beta}, semver ``component_tag``, 40-hex ``component_target_commit``,
+    exact release ``component_manifest_url`` matching ``component_tag``,
+    64-hex ``component_manifest_sha256``, ISO ``updated_at``); the digest
+    check below validates provenance, and ``validate_release_manifest_bytes``
+    validates the stable tag/version against the cached manifest.
+    """
     from brigade import update_cmd
 
     state_path = Path(component_paths.update_state_path(roots.data_root))
     state = update_cmd.load_update_state(state_path)
-    if state is None or state.component_tag != f"v{brigade.__version__}":
+    if state is None:
+        return None
+
+    if state.channel == "stable":
+        if state.component_tag != f"v{brigade.__version__}":
+            return None
+        compatible = False
+        release_version = brigade.__version__
+    elif state.channel == "beta":
+        stable_version = update_cmd._parse_tag(state.component_tag)
+        if stable_version is None:
+            return None
+        compatible = True
+        release_version = stable_version
+    else:
         return None
 
     cached = Path(component_paths.verified_manifest_path(roots.cache_root, state.component_manifest_sha256))
@@ -129,7 +166,7 @@ def load_verified_exact_release_manifest(
     release = update_cmd.ResolvedRelease(
         state.component_release_id,
         state.component_tag,
-        brigade.__version__,
+        release_version,
         state.component_target_commit,
         state.component_manifest_url,
         len(cached_bytes),
@@ -137,11 +174,15 @@ def load_verified_exact_release_manifest(
         cached_bytes,
     )
     try:
-        return update_cmd.validate_release_manifest_bytes(release), cached
+        if compatible:
+            manifest = update_cmd.validate_release_manifest_bytes(release, allow_compatible_stable_manifest=True)
+        else:
+            manifest = update_cmd.validate_release_manifest_bytes(release)
     except update_cmd.UpdateError as exc:
         raise ExactReleaseManifestError(str(exc), cached) from exc
     except ValueError as exc:
         raise ExactReleaseManifestError(f"cached exact-release manifest is invalid: {exc}", cached) from exc
+    return manifest, cached
 
 
 def build_setup_plan(
@@ -862,33 +903,82 @@ def _load_setup_manifest(
     offline: bool,
     opener: Callable[..., Any] | None,
     env: Mapping[str, str] | None,
-) -> tuple[component_manifest.ComponentManifest, Any | None]:
-    """Load an exact release manifest, with one standalone compatibility fallback."""
+    allow_compatible_stable_manifest: bool = False,
+) -> tuple[component_manifest.ComponentManifest, Any | None, str | None]:
+    """Load an exact release manifest, with one standalone compatibility fallback.
+
+    Returns ``(manifest, auto_release, auto_compatible_stable_version)``.
+    ``auto_release`` is the resolved release when the auto branch re-resolved
+    it online (used to publish state); ``None`` when a persisted verified
+    cache was reused or an explicit/standalone manifest was loaded.
+    ``auto_compatible_stable_version`` is the manifest's ``brigade_version``
+    when the auto branch reused a persisted beta-handoff cache whose stable
+    version predates the running Brigade version, so the caller can treat that
+    reuse as the narrowly named compatible-stable-manifest path; ``None``
+    otherwise (exact-release stable path stays strict).
+
+    The narrowly named ``allow_compatible_stable_manifest`` mode only applies
+    to the ``--manifest`` branch used by the beta handoff, which reuses the
+    verified last-stable release manifest. The auto branch resolves the exact
+    release for the installed Brigade version and stays strict, except that a
+    persisted beta-handoff state is the explicit compatible-stable-manifest
+    path and is reused rather than re-resolved.
+    """
     if manifest_path is not None:
-        return component_manifest.load(manifest_path), None
+        return (
+            component_manifest.load(
+                manifest_path,
+                allow_compatible_stable_manifest=allow_compatible_stable_manifest,
+            ),
+            None,
+            None,
+        )
     if manifest_source == "standalone":
-        return component_manifest.load(allow_standalone_legacy_revisions=True), None
+        return component_manifest.load(allow_standalone_legacy_revisions=True), None, None
     if manifest_source != "auto":
         raise ComponentInstallError("manifest source must be auto or standalone")
 
     if not uses_bundled_compatibility_manifest():
-        return component_manifest.load(), None
+        return component_manifest.load(), None, None
 
     from brigade import update_cmd
 
     roots = resolve_roots(env=env)
     try:
+        # Persisted update state supplies a verified manifest cache that
+        # ``brigade setup`` reuses instead of re-resolving the release.
+        cached_manifest = load_verified_exact_release_manifest(roots)
         if offline:
-            cached_manifest = load_verified_exact_release_manifest(roots)
+            # Offline setup must reuse any verified cache: the exact-release
+            # stable cache (state.component_tag == v{brigade.__version__}) or
+            # the beta handoff cache, which persists the verified last-stable
+            # release manifest coordinates and would otherwise fail offline.
             if cached_manifest is not None:
-                return cached_manifest[0], None
+                cached_manifest_obj, _cached_path = cached_manifest
+                auto_compatible = (
+                    cached_manifest_obj.brigade_version
+                    if cached_manifest_obj.brigade_version != brigade.__version__
+                    else None
+                )
+                return cached_manifest_obj, None, auto_compatible
             raise ComponentInstallError("offline setup requires a verified exact-release manifest cache")
+
+        # Online setup reuses the cache only for a persisted beta handoff,
+        # whose stable manifest tag predates the running Brigade version and
+        # would otherwise re-resolve an unreleased v{brigade.__version__} tag.
+        # Stable state retains exact current-version behavior: it re-resolves
+        # the exact current release as before.
+        if cached_manifest is not None:
+            state = update_cmd.load_update_state(Path(component_paths.update_state_path(roots.data_root)))
+            if state is not None and state.channel == "beta":
+                cached_manifest_obj, _cached_path = cached_manifest
+                return cached_manifest_obj, None, cached_manifest_obj.brigade_version
 
         release = update_cmd.resolve_release(update_cmd._DefaultHttp(), latest=False, tag=f"v{brigade.__version__}")
         update_cmd._cache_manifest(
             update_cmd.UpdatePaths(Path(roots.data_root), Path(roots.cache_root), Path("unused")), release
         )
-        return update_cmd.validate_release_manifest_bytes(release), release
+        return update_cmd.validate_release_manifest_bytes(release), release, None
     except (update_cmd.UpdateError, ExactReleaseManifestError, ValueError) as exc:
         raise ComponentInstallError(f"exact release manifest setup failed: {exc}") from exc
 
@@ -944,16 +1034,25 @@ def setup_native_components(
             raise ComponentInstallError("--allow-compatible-stable-manifest requires --manifest")
         if rollback:
             return _setup_rollback(env=env, runner=runner)
-        manifest, auto_release = _load_setup_manifest(
+        compatible_stable_manifest_requested = allow_compatible_stable_manifest is not None
+        manifest, auto_release, auto_compatible_stable_version = _load_setup_manifest(
             manifest_path=manifest_path,
             manifest_source=manifest_source,
             offline=offline,
             opener=opener,
             env=env,
+            allow_compatible_stable_manifest=compatible_stable_manifest_requested,
         )
+        # The explicit --allow-compatible-stable-manifest flag (beta handoff
+        # via --manifest) and the auto branch's reuse of a persisted beta
+        # cache both count as the narrowly named compatible-stable-manifest
+        # path; either way the manifest's brigade_version must match the
+        # recorded stable version, not the running Brigade version.
+        compatible_stable_version = allow_compatible_stable_manifest
+        if auto_compatible_stable_version is not None:
+            compatible_stable_version = auto_compatible_stable_version
         compatible_stable_manifest = (
-            allow_compatible_stable_manifest is not None
-            and allow_compatible_stable_manifest == manifest.brigade_version
+            compatible_stable_version is not None and compatible_stable_version == manifest.brigade_version
         )
         if manifest.brigade_version != brigade.__version__ and not compatible_stable_manifest:
             raise ComponentInstallError(

--- a/src/brigade/component_install.py
+++ b/src/brigade/component_install.py
@@ -107,6 +107,8 @@ def uses_bundled_compatibility_manifest() -> bool:
 
 def load_verified_exact_release_manifest(
     roots: SetupRoots,
+    *,
+    online_stable_cache_repair: bool = False,
 ) -> tuple[component_manifest.ComponentManifest, Path] | None:
     """Read the current release manifest recorded in update state without mutating it.
 
@@ -131,6 +133,18 @@ def load_verified_exact_release_manifest(
     64-hex ``component_manifest_sha256``, ISO ``updated_at``); the digest
     check below validates provenance, and ``validate_release_manifest_bytes``
     validates the stable tag/version against the cached manifest.
+
+    When ``online_stable_cache_repair`` is set and the persisted state is a
+    matching stable state (``state.component_tag == v{brigade.__version__}``),
+    a missing or corrupt verified cache returns ``None`` instead of raising
+    so an online ``brigade setup`` falls through to exact-release resolution
+    and repairs the cache. A corrupt cache entry (unreadable, digest
+    mismatch, or invalid manifest bytes) is removed in this mode so the
+    caller's re-cache write is not blocked by the stale corrupt file; this
+    only touches a file whose content already fails the recorded-digest
+    provenance check. This only relaxes the matching-stable path: offline
+    stable setup and every beta path stay fail-closed, because neither can
+    repair the cache and a beta handoff cannot re-resolve an unreleased tag.
     """
     from brigade import update_cmd
 
@@ -154,13 +168,35 @@ def load_verified_exact_release_manifest(
         return None
 
     cached = Path(component_paths.verified_manifest_path(roots.cache_root, state.component_manifest_sha256))
+    # Online stable setup tolerates a missing/corrupt verified cache so the
+    # caller can re-resolve the exact release and repair it. Offline stable
+    # and all beta paths remain fail-closed: neither can repair the cache,
+    # and a beta handoff cannot re-resolve an unreleased v{cli} tag. In repair
+    # mode a corrupt entry is removed so the caller's re-cache write is not
+    # blocked by a stale file that already fails the recorded-digest check.
+    tolerate_cache_repair = online_stable_cache_repair and state.channel == "stable"
+
+    def _drop_corrupt_cache() -> None:
+        try:
+            cached.unlink(missing_ok=True)
+        except OSError:
+            pass
+
     if not cached.is_file():
+        if tolerate_cache_repair:
+            return None
         raise ExactReleaseManifestError("cached exact-release manifest is missing", cached)
     try:
         cached_bytes = cached.read_bytes()
     except OSError as exc:
+        if tolerate_cache_repair:
+            _drop_corrupt_cache()
+            return None
         raise ExactReleaseManifestError(f"cached exact-release manifest cannot be read: {exc}", cached) from exc
     if hashlib.sha256(cached_bytes).hexdigest() != state.component_manifest_sha256:
+        if tolerate_cache_repair:
+            _drop_corrupt_cache()
+            return None
         raise ExactReleaseManifestError("cached exact-release manifest digest does not match update state", cached)
 
     release = update_cmd.ResolvedRelease(
@@ -179,8 +215,14 @@ def load_verified_exact_release_manifest(
         else:
             manifest = update_cmd.validate_release_manifest_bytes(release)
     except update_cmd.UpdateError as exc:
+        if tolerate_cache_repair:
+            _drop_corrupt_cache()
+            return None
         raise ExactReleaseManifestError(str(exc), cached) from exc
     except ValueError as exc:
+        if tolerate_cache_repair:
+            _drop_corrupt_cache()
+            return None
         raise ExactReleaseManifestError(f"cached exact-release manifest is invalid: {exc}", cached) from exc
     return manifest, cached
 
@@ -946,8 +988,11 @@ def _load_setup_manifest(
     roots = resolve_roots(env=env)
     try:
         # Persisted update state supplies a verified manifest cache that
-        # ``brigade setup`` reuses instead of re-resolving the release.
-        cached_manifest = load_verified_exact_release_manifest(roots)
+        # ``brigade setup`` reuses instead of re-resolving the release. Online
+        # stable setup tolerates a missing/corrupt cache so it can fall through
+        # to exact-release resolution and repair it; offline stable and all
+        # beta paths stay fail-closed.
+        cached_manifest = load_verified_exact_release_manifest(roots, online_stable_cache_repair=not offline)
         if offline:
             # Offline setup must reuse any verified cache: the exact-release
             # stable cache (state.component_tag == v{brigade.__version__}) or

--- a/src/brigade/component_manifest.py
+++ b/src/brigade/component_manifest.py
@@ -74,7 +74,12 @@ def manifest_path() -> Path:
     return templates.template_root() / "components" / "manifest-v1.json"
 
 
-def load(path: Path | None = None, *, allow_standalone_legacy_revisions: bool = False) -> ComponentManifest:
+def load(
+    path: Path | None = None,
+    *,
+    allow_standalone_legacy_revisions: bool = False,
+    allow_compatible_stable_manifest: bool = False,
+) -> ComponentManifest:
     source = path or manifest_path()
     try:
         raw = json.loads(source.read_text())
@@ -84,19 +89,37 @@ def load(path: Path | None = None, *, allow_standalone_legacy_revisions: bool = 
         source,
         raw,
         allow_standalone_legacy_revisions=allow_standalone_legacy_revisions or path is None,
+        allow_compatible_stable_manifest=allow_compatible_stable_manifest,
     )
 
 
-def load_bytes(content: bytes, *, source: Path, allow_standalone_legacy_revisions: bool = False) -> ComponentManifest:
+def load_bytes(
+    content: bytes,
+    *,
+    source: Path,
+    allow_standalone_legacy_revisions: bool = False,
+    allow_compatible_stable_manifest: bool = False,
+) -> ComponentManifest:
     """Parse an already verified manifest without writing it to disk."""
     try:
         raw = json.loads(content.decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise ValueError(f"component manifest could not be loaded: {source}") from exc
-    return _load_raw(source, raw, allow_standalone_legacy_revisions=allow_standalone_legacy_revisions)
+    return _load_raw(
+        source,
+        raw,
+        allow_standalone_legacy_revisions=allow_standalone_legacy_revisions,
+        allow_compatible_stable_manifest=allow_compatible_stable_manifest,
+    )
 
 
-def _load_raw(source: Path, raw: Any, *, allow_standalone_legacy_revisions: bool) -> ComponentManifest:
+def _load_raw(
+    source: Path,
+    raw: Any,
+    *,
+    allow_standalone_legacy_revisions: bool,
+    allow_compatible_stable_manifest: bool = False,
+) -> ComponentManifest:
     if not isinstance(raw, dict):
         raise ValueError(
             f"unsupported component manifest schema version {None!r}; this Brigade supports {SCHEMA_VERSION}"
@@ -142,8 +165,30 @@ def _load_raw(source: Path, raw: Any, *, allow_standalone_legacy_revisions: bool
 
     missing = [component_id for component_id in KNOWN_COMPONENT_IDS if component_id not in components]
     if missing:
-        missing_list = ", ".join(missing)
-        raise ValueError(f"component manifest is missing required components: {missing_list}")
+        # The beta handoff downloads the last stable release manifest, which
+        # predates any component id added to KNOWN_COMPONENT_IDS on main but
+        # not yet shipped from a stable release. In that narrowly named
+        # compatibility mode we tolerate only component ids explicitly
+        # declared currently unpublished (UNPUBLISHED_COMPONENT_IDS); every
+        # published component must still be present. Strict stable/release
+        # validation never enters this mode and rejects any missing id.
+        rejected = missing
+        if allow_compatible_stable_manifest:
+            rejected = [component_id for component_id in missing if component_id not in UNPUBLISHED_COMPONENT_IDS]
+        if rejected:
+            rejected_list = ", ".join(rejected)
+            raise ValueError(f"component manifest is missing required components: {rejected_list}")
+
+    # Compatibility mode is the narrowly named beta handoff path that reuses a
+    # verified last-stable release manifest. It must not accept component
+    # records the running Brigade does not know: an unknown id could carry
+    # arbitrary asset coordinates that bypass the strict release invariants.
+    # Reject any unknown id outright while preserving the diagnostic text.
+    # Strict stable/release validation never enters this mode and continues
+    # to ignore unknown ids with a diagnostic (see tests above).
+    if allow_compatible_stable_manifest and unknown_ids:
+        diagnostics = _unknown_component_diagnostics(unknown_ids)
+        raise ValueError("; ".join(diagnostics))
 
     diagnostics = _unknown_component_diagnostics(unknown_ids)
     return ComponentManifest(

--- a/src/brigade/managed.py
+++ b/src/brigade/managed.py
@@ -193,6 +193,17 @@ def _code_search_mcp_doctor(ctx: DoctorContext) -> List[CheckResult]:
 # workspace doctor run.
 def _agentpantry_doctor(ctx: DoctorContext) -> List[CheckResult]:
     name = "agentpantry (session auth sync)"
+    # Before invoking any installed agentpantry surface, probe the version and
+    # enforce the evidence-backed floor (AGENTPANTRY_MIN_VERSION = 0.5.0). A
+    # failed probe, malformed version, or below-floor version is advisory WARN
+    # here: never OK and never a workspace FAIL. Do not invoke doctor/status
+    # after incompatibility - the installed binary may not expose those
+    # surfaces. See brigade.pantry_compat for the shared probe/parser.
+    from . import pantry_compat
+
+    probe = pantry_compat.probe_agentpantry_version()
+    if probe.incompatible:
+        return [(WARN, name, probe.detail)]
     r = proc.run(["agentpantry", "doctor", "--json", "--no-net"])
     data = r.json()
     if data is not None:

--- a/src/brigade/pantry_cmd.py
+++ b/src/brigade/pantry_cmd.py
@@ -73,6 +73,27 @@ def status_payload(target: Path) -> dict[str, Any]:
     if not installed:
         return payload
 
+    # Before invoking any installed agentpantry status/doctor surface, probe
+    # the version and enforce the evidence-backed floor
+    # (AGENTPANTRY_MIN_VERSION = 0.5.0). v0.5.0 is the first release exposing
+    # every Brigade-invoked surface; v0.4.1 lacks inventory. On
+    # incompatibility Brigade must not invoke status/doctor and must report
+    # unhealthy rather than ``pantry: ok``. See brigade.pantry_compat.
+    from . import pantry_compat
+
+    probe = pantry_compat.probe_agentpantry_version()
+    payload["version"] = probe.observed
+    payload["version_compatible"] = probe.compatible
+    if probe.incompatible:
+        payload["health"] = "unhealthy"
+        payload["summary"] = probe.detail
+        payload["next_commands"] = [
+            "brigade add pantry",
+            "agentpantry version",
+            "brigade pantry doctor",
+        ]
+        return payload
+
     status_result = _run_json(["agentpantry", "status", "--json"])
     doctor_result = _run_json(["agentpantry", "doctor", "--json"])
     payload["status"] = status_result
@@ -181,6 +202,8 @@ def doctor(*, target: Path, json_output: bool = False) -> int:
         return 1
     if health == "incomplete":
         return 1
+    if health == "unhealthy":
+        return 1
     return 0
 
 
@@ -211,6 +234,20 @@ def expiry_alert_payload(*, expiry_days: int = 14, profile: str = "agent-stop", 
     if not payload["agentpantry_installed"]:
         payload["error"] = "agentpantry is not installed"
         payload["next_commands"] = ["brigade add pantry", "brigade pantry doctor"]
+        return payload
+
+    # Before invoking the installed agentpantry inventory surface, probe the
+    # version and enforce the evidence-backed floor. On incompatibility do not
+    # invoke inventory; return this command's structured failure path with a
+    # precise version compatibility error. See brigade.pantry_compat.
+    from . import pantry_compat
+
+    probe = pantry_compat.probe_agentpantry_version()
+    payload["version"] = probe.observed
+    payload["version_compatible"] = probe.compatible
+    if probe.incompatible:
+        payload["error"] = probe.detail
+        payload["next_commands"] = ["brigade add pantry", "agentpantry version", "brigade pantry doctor"]
         return payload
 
     inventory = _run_json(["agentpantry", "inventory", "--json", "--expiry-days", str(expiry_days)])

--- a/src/brigade/pantry_cmd.py
+++ b/src/brigade/pantry_cmd.py
@@ -195,7 +195,8 @@ def doctor(*, target: Path, json_output: bool = False) -> int:
                     print(f"- {row.get('status')}: {row.get('name')} - {row.get('detail')}")
         _print_next_commands(payload)
         print(
-            "note: pantry checks are advisory for workspace doctor; this command exits 1 only on agentpantry fail_count"
+            "note: pantry checks are advisory for workspace doctor; "
+            "status 1 occurs for unhealthy, incomplete, or nonzero agentpantry fail_count"
         )
     health = payload.get("health")
     if health == "fail":

--- a/src/brigade/pantry_compat.py
+++ b/src/brigade/pantry_compat.py
@@ -1,0 +1,191 @@
+"""Agent Pantry version compatibility probe (Brigade-side).
+
+Agent Pantry is a separate Go binary at a process boundary; Brigade never
+imports it. Before Brigade invokes any installed agentpantry ``doctor``,
+``status``, or ``inventory`` surface, it probes ``agentpantry version --json``
+and enforces an evidence-backed floor so a stale or malformed install is
+reported as incompatible rather than silently invoking surfaces the
+installed binary does not expose.
+
+This module is the single shared parser/comparator for that probe so the
+managed doctor, pantry status/doctor, and expiry-alert paths do not duplicate
+parsing. It adds no dependency and never raises: a missing binary, nonzero
+probe, malformed JSON, non-string version, prerelease-shaped, or below-floor
+version all collapse to an incompatible :class:`VersionProbe` with a precise
+detail string.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+from . import proc
+
+# v0.5.0 is the first tagged release exposing every Brigade-invoked surface:
+# ``doctor --json --no-net``, ``status --json``, ``inventory --json``, and
+# ``version --json``. v0.4.1 lacks ``inventory``. This floor is evidence-backed
+# and intentionally integer-compared so multi-digit segments (e.g. 0.10.3) sort
+# correctly rather than lexically.
+AGENTPANTRY_MIN_VERSION: Tuple[int, int, int] = (0, 5, 0)
+
+# Conservative per-segment length bound. Each numeric segment of a released
+# semver triple is realistically small; bounding the digit count keeps parsing
+# non-throwing and bounded for arbitrarily long numeric segments. A hostile or
+# malformed version field with a multi-megabyte numeric run would otherwise
+# drive unbounded regex matching and ``int()`` allocation. Oversized segments
+# collapse to the fixed :data:`_INVALID_VERSION_LABEL` via :func:`parse_version`
+# returning ``None``.
+_MAX_SEGMENT_DIGITS = 6
+
+# Strict ASCII numeric semver triple with an optional leading ``v``. ``[0-9]``
+# (not ``\d``) rejects Unicode digits so only ASCII numeric triples parse; a
+# non-ASCII-digit run (e.g. Arabic-Indic or fullwidth digits) fails to match and
+# collapses to :data:`_INVALID_VERSION_LABEL`. The ``{1,N}`` per-segment bound
+# and the ``$`` anchor reject prerelease-shaped (``0.5.0-rc.1``), dev (``dev``),
+# unknown (``unknown``), oversized, and any other non-triple strings. No
+# build/prerelease suffix is accepted: only released triples pass.
+_VERSION_RE = re.compile(
+    rf"^v?([0-9]{{1,{_MAX_SEGMENT_DIGITS}}})\.([0-9]{{1,{_MAX_SEGMENT_DIGITS}}})\.([0-9]{{1,{_MAX_SEGMENT_DIGITS}}})$"
+)
+
+# Longest strict semver triple: optional ``v`` plus three bounded segments and two
+# dots (e.g. ``v999999.999999.999999``). Reject overlong raw input before
+# ``strip`` or regex matching so hostile whitespace-padded strings cannot force
+# an unbounded scan.
+_MAX_RAW_VERSION_LEN = 1 + (3 * _MAX_SEGMENT_DIGITS) + 2
+
+# Fixed sanitized label for any unparsable version string (dev, unknown,
+# prerelease-shaped, arbitrary content, or anything that could carry secret
+# material). Never echo the raw invalid version field or any other stdout back
+# to callers; collapse to this constant so managed doctor / pantry JSON cannot
+# leak it. Successfully parsed triples (including below-floor ones) remain
+# normalized semver because that is bounded numeric data, not raw content.
+_INVALID_VERSION_LABEL = "invalid-version"
+
+
+@dataclass(frozen=True)
+class VersionProbe:
+    """Result of probing ``agentpantry version --json``.
+
+    ``compatible`` is True only when a parseable non-prerelease semver triple
+    was observed at or above :data:`AGENTPANTRY_MIN_VERSION`. ``observed``
+    carries the normalized semver triple for a successfully parsed version
+    (including below-floor ones, which are bounded numeric data), or a short
+    fixed label for a probe failure / unparsable value. For any unparsable
+    string (dev, unknown, prerelease-shaped, or arbitrary content up to and
+    including secret material) ``observed`` is the fixed sanitized label
+    :data:`_INVALID_VERSION_LABEL`; the raw invalid version field and any
+    other stdout never reach ``observed`` or ``detail``. ``detail`` always
+    contains the literal floor expectation and the observed value or probe
+    failure so callers can surface it verbatim.
+    """
+
+    compatible: bool
+    observed: str
+    detail: str
+
+    @property
+    def incompatible(self) -> bool:
+        return not self.compatible
+
+
+def floor_label() -> str:
+    """Return the human-readable floor expectation, e.g. ``expected >= 0.5.0``."""
+    major, minor, patch = AGENTPANTRY_MIN_VERSION
+    return f"expected >= {major}.{minor}.{patch}"
+
+
+def parse_version(value: object) -> Optional[Tuple[int, int, int]]:
+    """Parse a version value into an integer ``(major, minor, patch)`` triple.
+
+    Returns ``None`` for non-strings, missing values, prerelease-shaped, dev,
+    unknown, non-ASCII-digit, oversized, or otherwise unparsable inputs.
+    Comparison is integer, not lexical. Never raises: the per-segment digit
+    bound keeps ``int()`` conversion bounded, and a conversion ``ValueError``
+    is caught defensively and collapsed to ``None`` so the caller surfaces the
+    fixed :data:`_INVALID_VERSION_LABEL` rather than propagating an exception.
+    """
+    if not isinstance(value, str):
+        return None
+    if len(value) > _MAX_RAW_VERSION_LEN:
+        return None
+    match = _VERSION_RE.match(value.strip())
+    if match is None:
+        return None
+    try:
+        return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+    except ValueError:
+        return None
+
+
+def _format_triple(triple: Tuple[int, int, int]) -> str:
+    return ".".join(str(part) for part in triple)
+
+
+def _unparsable_observed_label(raw_version: object) -> str:
+    """Return a non-leaking observed label for an unparsable version value.
+
+    A missing field collapses to ``"missing"`` and a non-string value to
+    ``"non-string"``; neither carries raw stdout. Any string that fails
+    :func:`parse_version` (dev, unknown, prerelease-shaped, empty, oversized
+    numeric segments, non-ASCII digits, or arbitrary content up to and
+    including secret material) collapses to the fixed
+    :data:`_INVALID_VERSION_LABEL` so the raw value never reaches observed or
+    detail and therefore never reaches managed doctor / pantry JSON.
+    """
+    if raw_version is None:
+        return "missing"
+    if not isinstance(raw_version, str):
+        return "non-string"
+    return _INVALID_VERSION_LABEL
+
+
+def probe_agentpantry_version() -> VersionProbe:
+    """Probe ``agentpantry version --json`` and enforce the floor.
+
+    Never raises. The caller is responsible for gating on whether the binary
+    is installed/detected; this function only runs the probe and interprets it.
+    A nonzero probe exit (including command-not-found 127), non-JSON stdout, a
+    non-object JSON value, a missing/non-string/prerelease-shaped version
+    field, or a below-floor version all yield an incompatible probe.
+    """
+    expected = floor_label()
+    result = proc.run(["agentpantry", "version", "--json"], timeout=10.0)
+    if result.code != 0:
+        observed = f"probe exit {result.code}"
+        return VersionProbe(
+            compatible=False,
+            observed=observed,
+            detail=f"agentpantry version probe failed (probe exit {result.code}); {expected}",
+        )
+    data = result.json()
+    if not isinstance(data, dict):
+        observed = "malformed"
+        return VersionProbe(
+            compatible=False,
+            observed=observed,
+            detail=f"agentpantry version output is not a JSON object; {expected}",
+        )
+    raw_version = data.get("version")
+    parsed = parse_version(raw_version)
+    if parsed is None:
+        observed = _unparsable_observed_label(raw_version)
+        return VersionProbe(
+            compatible=False,
+            observed=observed,
+            detail=f"agentpantry version unparsable ({observed}); {expected}",
+        )
+    observed = _format_triple(parsed)
+    if parsed < AGENTPANTRY_MIN_VERSION:
+        return VersionProbe(
+            compatible=False,
+            observed=observed,
+            detail=f"agentpantry version {observed} below floor; {expected}",
+        )
+    return VersionProbe(
+        compatible=True,
+        observed=observed,
+        detail=f"agentpantry version {observed}; {expected}",
+    )

--- a/src/brigade/status.py
+++ b/src/brigade/status.py
@@ -42,6 +42,11 @@ def _normalize_payload_health(raw: object, *, installed: bool | None) -> str:
         "timeout": "degraded",
         "incomplete": "degraded",
         "unwired": "not-configured",
+        # A station that is installed but known-incompatible (e.g. agentpantry
+        # below the evidence-backed version floor) reports ``unhealthy``. That
+        # is a hard station failure, not an unknown value: map it to ``failed``
+        # so the aggregate stays red rather than collapsing to ``unchecked``.
+        "unhealthy": "failed",
     }.get(value, "unchecked")
 
 

--- a/src/brigade/update_cmd.py
+++ b/src/brigade/update_cmd.py
@@ -386,14 +386,30 @@ def _validate_manifest_coordinates(
     return manifest
 
 
-def validate_release_manifest(release: ResolvedRelease, path: Path) -> component_manifest.ComponentManifest:
-    return _validate_manifest_coordinates(release, component_manifest.load(path))
-
-
-def validate_release_manifest_bytes(release: ResolvedRelease) -> component_manifest.ComponentManifest:
+def validate_release_manifest(
+    release: ResolvedRelease,
+    path: Path,
+    *,
+    allow_compatible_stable_manifest: bool = False,
+) -> component_manifest.ComponentManifest:
     return _validate_manifest_coordinates(
         release,
-        component_manifest.load_bytes(release.manifest_bytes, source=Path(release.manifest_url)),
+        component_manifest.load(path, allow_compatible_stable_manifest=allow_compatible_stable_manifest),
+    )
+
+
+def validate_release_manifest_bytes(
+    release: ResolvedRelease,
+    *,
+    allow_compatible_stable_manifest: bool = False,
+) -> component_manifest.ComponentManifest:
+    return _validate_manifest_coordinates(
+        release,
+        component_manifest.load_bytes(
+            release.manifest_bytes,
+            source=Path(release.manifest_url),
+            allow_compatible_stable_manifest=allow_compatible_stable_manifest,
+        ),
     )
 
 
@@ -554,7 +570,10 @@ def run_update(
                 raise UpdateError(f"invalid update state: {state_path}")
             ensure_channel_ownership(current, channel, switch_channel=switch_channel)
             release = resolve_release(selected_http, latest=True)
-            manifest = validate_release_manifest_bytes(release)
+            manifest = validate_release_manifest_bytes(
+                release,
+                allow_compatible_stable_manifest=channel == "beta",
+            )
             coordinate = release.version if channel == "stable" else _check_beta(selected_http)
             compatible_manifest_version = manifest.brigade_version if channel == "beta" else None
             if compatible_manifest_version is not None and compatible_manifest_version != release.version:

--- a/tests/component_install_helpers.py
+++ b/tests/component_install_helpers.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 import hashlib
 import json
 from pathlib import Path
+from typing import Any
 
 from brigade import component_manifest
 
 GRAPHTRAIL_SHA = "64fcd2f9ec37f33e286708845a92e6cfa4abf3bb"
 GRAPHTRAIL_BASE = "https://github.com/escoffier-labs/graphtrail/releases/download/v0.4.0/"
 FIXTURE_REPOSITORY = "example/components"
+RELEASE_REPOSITORY = "escoffier-labs/brigade"
+MANIFEST_ASSET_NAME = "component-manifest-v1.json"
 
 
 def linux_env(root: Path) -> dict[str, str]:
@@ -217,3 +220,124 @@ class FakeOpener:
             response = _TrackingFakeResponse(payload)
         self.responses.append(response)
         return response
+
+
+def release_manifest_url(tag: str) -> str:
+    """The exact Brigade release manifest asset URL for ``tag``."""
+    return f"https://github.com/{RELEASE_REPOSITORY}/releases/download/{tag}/{MANIFEST_ASSET_NAME}"
+
+
+def release_component_asset_url(component_id: str, *, tag: str, platform: str) -> str:
+    """The exact Brigade release asset URL for one component on one platform."""
+    asset_name = fixture_asset_name(component_id, platform=platform)
+    return f"https://github.com/{RELEASE_REPOSITORY}/releases/download/{tag}/{asset_name}"
+
+
+def write_release_manifest(
+    path: Path, *, brigade_version: str, target_commit: str, drop_component: str | None = None
+) -> bytes:
+    """Write a manifest with real Brigade release coordinates.
+
+    Every component pins to ``target_commit`` and the real Brigade release
+    repository/tag/asset URLs so the real
+    :func:`brigade.update_cmd.validate_release_manifest_bytes` accepts it
+    against a release resolved for ``v{brigade_version}``.
+
+    ``drop_component`` omits one component id entirely so the manifest fails
+    ``load_bytes`` validation (``missing required components``) while remaining
+    otherwise well-formed; the returned bytes hash to their own digest so a
+    caller can persist a state recording that digest and exercise the
+    digest-matching-but-invalid path without violating content addressing.
+    """
+    tag = f"v{brigade_version}"
+    components: dict[str, object] = {}
+    for component_id in component_manifest.KNOWN_COMPONENT_IDS:
+        if component_id == drop_component:
+            continue
+        assets: dict[str, object] = {}
+        for platform in component_manifest.SUPPORTED_PLATFORMS:
+            _, byte_size, sha256 = fixture_payload(component_id, platform=platform)
+            asset_name = fixture_asset_name(component_id, platform=platform)
+            assets[platform] = {
+                "asset_name": asset_name,
+                "byte_size": byte_size,
+                "sha256": sha256,
+                "download_url": release_component_asset_url(component_id, tag=tag, platform=platform),
+            }
+        components[component_id] = {
+            "component_revision": target_commit,
+            "source": {"repository": RELEASE_REPOSITORY, "release_tag": tag},
+            "executable": component_id,
+            "assets": assets,
+        }
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "brigade_version": brigade_version,
+                "manifest_revision": f"{tag}+{target_commit}",
+                "supported_platforms": list(component_manifest.SUPPORTED_PLATFORMS),
+                "components": components,
+            }
+        )
+    )
+    return path.read_bytes()
+
+
+def all_release_payloads(*, tag: str, platform: str = "linux-amd64") -> dict[str, bytes]:
+    """``FakeOpener`` payloads keyed by the real Brigade release asset URLs."""
+    payloads: dict[str, bytes] = {}
+    for component_id in component_manifest.KNOWN_COMPONENT_IDS:
+        payload, _, _ = fixture_payload(component_id, platform=platform)
+        payloads[release_component_asset_url(component_id, tag=tag, platform=platform)] = payload
+    return payloads
+
+
+class FakeReleaseHttp:
+    """Fake GitHub HTTP transport for the real exact-tag release resolver.
+
+    Serves the release JSON, tag ref, and manifest bytes so
+    :func:`brigade.update_cmd.resolve_release` runs for real: it dereferences
+    the tag to ``target_commit``, verifies the manifest asset size and SHA-256
+    release digest, and downloads the manifest bytes. The component assets
+    themselves are still downloaded through the ``FakeOpener`` passed to
+    ``setup_native_components``.
+    """
+
+    def __init__(self, *, tag: str, manifest_bytes: bytes, target_commit: str, release_id: int = 42):
+        self.tag = tag
+        self.manifest_bytes = manifest_bytes
+        self.target_commit = target_commit
+        self.release_id = release_id
+        digest = hashlib.sha256(manifest_bytes).hexdigest()
+        self._release = {
+            "id": release_id,
+            "tag_name": tag,
+            "target_commitish": "main",
+            "draft": False,
+            "prerelease": False,
+            "assets": [
+                {
+                    "name": MANIFEST_ASSET_NAME,
+                    "size": len(manifest_bytes),
+                    "digest": f"sha256:{digest}",
+                    "browser_download_url": release_manifest_url(tag),
+                }
+            ],
+        }
+        self._ref = {"ref": f"refs/tags/{tag}", "object": {"type": "commit", "sha": target_commit}}
+        self.urls: list[str] = []
+
+    def json(self, url: str) -> Any:
+        self.urls.append(url)
+        if url == f"https://api.github.com/repos/{RELEASE_REPOSITORY}/releases/tags/{self.tag}":
+            return self._release
+        if url == f"https://api.github.com/repos/{RELEASE_REPOSITORY}/git/ref/tags/{self.tag}":
+            return self._ref
+        raise AssertionError(url)
+
+    def bytes(self, url: str) -> bytes:
+        self.urls.append(url)
+        if url != release_manifest_url(self.tag):
+            raise AssertionError(url)
+        return self.manifest_bytes

--- a/tests/test_component_install.py
+++ b/tests/test_component_install.py
@@ -34,13 +34,17 @@ from brigade.component_install import (
 
 from tests.component_install_helpers import (
     FakeOpener,
+    FakeReleaseHttp,
     FIXTURE_REPOSITORY,
     all_fixture_payloads,
+    all_release_payloads,
     fixture_component_revision,
     fixture_payload,
     linux_env,
+    release_manifest_url,
     smoke_stub_script,
     test_manifest_asset as manifest_asset_fixture,
+    write_release_manifest,
     write_test_manifest,
     write_verified_cache,
 )
@@ -116,6 +120,90 @@ def _prepare_auto_release_setup(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(component_manifest, "platform_key", lambda **_kwargs: "linux-amd64")
     return env, release
+
+
+def _prepare_auto_release_setup_real(tmp_path, monkeypatch):
+    """Route automatic setup through the real exact-tag release resolver.
+
+    Unlike :func:`_prepare_auto_release_setup`, this does NOT mock
+    ``resolve_release`` or ``validate_release_manifest_bytes``. A real-coordinate
+    manifest is bundled, ``update_cmd._DefaultHttp`` is replaced with a
+    :class:`FakeReleaseHttp` that serves the release JSON, tag ref, and manifest
+    bytes, so the real exact-tag resolver, digest/provenance validation, cache
+    rewrite, and state publication run end to end. Returns ``(env, http, tag,
+    target_commit, manifest_bytes)``.
+    """
+    env = linux_env(tmp_path)
+    target_commit = "a" * 40
+    tag = f"v{brigade.__version__}"
+    bundled = tmp_path / "templates" / "components" / "manifest-v1.json"
+    bundled.parent.mkdir(parents=True)
+    manifest_bytes = write_release_manifest(bundled, brigade_version=brigade.__version__, target_commit=target_commit)
+    http = FakeReleaseHttp(tag=tag, manifest_bytes=manifest_bytes, target_commit=target_commit)
+    monkeypatch.setattr(component_install.templates, "template_root", lambda: bundled.parents[1])
+    monkeypatch.setattr(component_manifest, "manifest_path", lambda: bundled)
+    monkeypatch.setattr(component_manifest, "platform_key", lambda **_kwargs: "linux-amd64")
+    monkeypatch.setattr(update_cmd, "_DefaultHttp", lambda: http)
+    return env, http, tag, target_commit, manifest_bytes
+
+
+def _persist_beta_state_real(
+    tmp_path,
+    monkeypatch,
+    *,
+    stable_version: str,
+    cli_version: str,
+    manifest_bytes: bytes,
+    target_commit: str,
+):
+    """Persist a beta-handoff update state over a real-coordinate stable manifest.
+
+    The beta CLI reports ``cli_version`` (newer than ``stable_version``); the
+    update transaction persisted the verified last-stable release manifest
+    bytes at their digest path and recorded their real Brigade release
+    coordinates. A later ``brigade setup`` must reuse that cache rather than
+    resolving an unreleased ``v{cli_version}`` tag. The real
+    ``validate_release_manifest_bytes`` (compatibility mode) runs against the
+    cached bytes; ``resolve_release`` is replaced with a boom to assert the
+    beta path never re-resolves the release.
+    """
+    env = linux_env(tmp_path)
+    bundled = tmp_path / "templates" / "components" / "manifest-v1.json"
+    bundled.parent.mkdir(parents=True, exist_ok=True)
+    bundled.write_bytes(manifest_bytes)
+    digest = hashlib.sha256(manifest_bytes).hexdigest()
+    monkeypatch.setattr(component_install.templates, "template_root", lambda: bundled.parents[1])
+    monkeypatch.setattr(component_manifest, "manifest_path", lambda: bundled)
+    monkeypatch.setattr(component_manifest, "platform_key", lambda **_kwargs: "linux-amd64")
+    monkeypatch.setattr("brigade.__version__", cli_version, raising=False)
+
+    def _boom_resolve(*_args, **_kwargs):
+        raise AssertionError("resolve_release must not be called when a verified beta cache is reused")
+
+    monkeypatch.setattr(update_cmd, "resolve_release", _boom_resolve)
+
+    roots = resolve_roots(env=env, system="linux")
+    cached = Path(component_paths.verified_manifest_path(roots.cache_root, digest))
+    cached.parent.mkdir(parents=True, exist_ok=True)
+    cached.write_bytes(manifest_bytes)
+    state_path = Path(component_paths.update_state_path(roots.data_root))
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    update_cmd.write_update_state(
+        state_path,
+        update_cmd.UpdateState(
+            1,
+            "beta",
+            "brigade update",
+            "b" * 40,
+            41,
+            f"v{stable_version}",
+            target_commit,
+            release_manifest_url(f"v{stable_version}"),
+            digest,
+            "2026-07-20T12:00:00+00:00",
+        ),
+    )
+    return env, digest
 
 
 def _managed_paths(env: dict[str, str]) -> dict[str, Path]:
@@ -862,6 +950,298 @@ def test_setup_auto_failure_does_not_publish_release_state(tmp_path, monkeypatch
 
     roots = resolve_roots(env=env, system="linux")
     assert not Path(component_paths.update_state_path(roots.data_root)).exists()
+
+
+def test_setup_auto_online_repairs_missing_stable_manifest_cache(tmp_path, monkeypatch):
+    # Greptile P1: online stable setup previously called
+    # load_verified_exact_release_manifest before online release resolution,
+    # so a matching stable state with a missing cache raised and prevented
+    # exact-release redownload/repair. Online stable must now fall through to
+    # exact-release resolution and repair the cache. This exercises the real
+    # exact-tag resolver, download, digest/provenance validation, cache rewrite,
+    # and state publication end to end (no resolve_release/validate mocks).
+    env, http, tag, _target_commit, manifest_bytes = _prepare_auto_release_setup_real(tmp_path, monkeypatch)
+    payloads = all_release_payloads(tag=tag)
+    digest = hashlib.sha256(manifest_bytes).hexdigest()
+    assert setup_native_components(env=env, opener=FakeOpener(payloads)) == 0
+    first_resolution = list(http.urls)
+
+    roots = resolve_roots(env=env, system="linux")
+    cached = Path(component_paths.verified_manifest_path(roots.cache_root, digest))
+    cached.unlink()
+    assert not cached.is_file()
+
+    # Online stable: the missing cache falls through to exact-release resolution.
+    assert setup_native_components(env=env, opener=FakeOpener(payloads)) == 0
+    # The real resolver re-ran (release JSON, tag ref, manifest bytes) to repair.
+    assert http.urls == first_resolution + first_resolution
+    # The verified cache is repaired in place at the recorded digest path.
+    assert cached.is_file()
+    assert hashlib.sha256(cached.read_bytes()).hexdigest() == digest
+    state = update_cmd.load_update_state(Path(component_paths.update_state_path(roots.data_root)))
+    assert state is not None
+    assert state.channel == "stable"
+    assert state.component_tag == tag
+    assert state.component_manifest_sha256 == digest
+    assert state.component_manifest_url == release_manifest_url(tag)
+
+
+def test_setup_auto_online_repairs_corrupt_stable_manifest_cache(tmp_path, monkeypatch):
+    # A corrupt (digest-mismatched) stable cache must also fall through to
+    # exact-release resolution and be repaired, rather than fail closed. The
+    # real resolver, digest verification, and cache rewrite run end to end.
+    env, http, tag, _target_commit, manifest_bytes = _prepare_auto_release_setup_real(tmp_path, monkeypatch)
+    payloads = all_release_payloads(tag=tag)
+    digest = hashlib.sha256(manifest_bytes).hexdigest()
+    assert setup_native_components(env=env, opener=FakeOpener(payloads)) == 0
+
+    roots = resolve_roots(env=env, system="linux")
+    cached = Path(component_paths.verified_manifest_path(roots.cache_root, digest))
+    corrupt = cached.read_bytes() + b"\n"
+    cached.write_bytes(corrupt)
+    assert hashlib.sha256(corrupt).hexdigest() != digest
+
+    assert setup_native_components(env=env, opener=FakeOpener(payloads)) == 0
+    # The repaired cache must match the verified digest again.
+    assert cached.is_file()
+    assert hashlib.sha256(cached.read_bytes()).hexdigest() == digest
+
+
+def test_setup_auto_online_repairs_unreadable_stable_manifest_cache(tmp_path, monkeypatch):
+    # An unreadable stable cache (read_bytes raises OSError) must fall through
+    # to exact-release resolution and be repaired online. The read failure is
+    # simulated by routing only the cached manifest path through a raising
+    # read_bytes; every other read (component assets, state) is unaffected, so
+    # the real repair path runs unchanged.
+    env, http, tag, _target_commit, manifest_bytes = _prepare_auto_release_setup_real(tmp_path, monkeypatch)
+    payloads = all_release_payloads(tag=tag)
+    digest = hashlib.sha256(manifest_bytes).hexdigest()
+    assert setup_native_components(env=env, opener=FakeOpener(payloads)) == 0
+
+    roots = resolve_roots(env=env, system="linux")
+    cached = Path(component_paths.verified_manifest_path(roots.cache_root, digest))
+    original_read_bytes = Path.read_bytes
+
+    def read_then_raise(path: Path) -> bytes:
+        if Path(path) == cached:
+            raise OSError("simulated unreadable cache")
+        return original_read_bytes(path)
+
+    monkeypatch.setattr(Path, "read_bytes", read_then_raise)
+
+    assert setup_native_components(env=env, opener=FakeOpener(payloads)) == 0
+    # The corrupt entry was dropped and the verified cache was rewritten.
+    monkeypatch.setattr(Path, "read_bytes", original_read_bytes)
+    assert cached.is_file()
+    assert hashlib.sha256(cached.read_bytes()).hexdigest() == digest
+
+
+def test_setup_auto_online_repairs_invalid_stable_manifest_cache(tmp_path, monkeypatch):
+    # A digest-matching-but-invalid stable cache: the cached bytes hash to the
+    # digest the state records (content addressing holds), but the manifest
+    # content fails validate_release_manifest_bytes (a published component is
+    # missing). Online stable repair drops the invalid entry, re-resolves the
+    # exact release, and rewrites the cache at the good release's digest path.
+    env = linux_env(tmp_path)
+    stable_version = brigade.__version__
+    target_commit = "a" * 40
+    tag = f"v{stable_version}"
+
+    # Invalid manifest: missing a published component, but real coordinates
+    # otherwise. Its bytes hash to their own digest; the state records that
+    # digest so the digest check passes while load_bytes fails.
+    invalid_bundled = tmp_path / "templates-invalid" / "components" / "manifest-v1.json"
+    invalid_bundled.parent.mkdir(parents=True)
+    invalid_bytes = write_release_manifest(
+        invalid_bundled, brigade_version=stable_version, target_commit=target_commit, drop_component="miseledger"
+    )
+    invalid_digest = hashlib.sha256(invalid_bytes).hexdigest()
+
+    # Good manifest bundled at the real template root for the resolver to serve.
+    bundled = tmp_path / "templates" / "components" / "manifest-v1.json"
+    bundled.parent.mkdir(parents=True)
+    good_bytes = write_release_manifest(bundled, brigade_version=stable_version, target_commit=target_commit)
+    good_digest = hashlib.sha256(good_bytes).hexdigest()
+    http = FakeReleaseHttp(tag=tag, manifest_bytes=good_bytes, target_commit=target_commit)
+    monkeypatch.setattr(component_install.templates, "template_root", lambda: bundled.parents[1])
+    monkeypatch.setattr(component_manifest, "manifest_path", lambda: bundled)
+    monkeypatch.setattr(component_manifest, "platform_key", lambda **_kwargs: "linux-amd64")
+    monkeypatch.setattr(update_cmd, "_DefaultHttp", lambda: http)
+
+    roots = resolve_roots(env=env, system="linux")
+    invalid_cache = Path(component_paths.verified_manifest_path(roots.cache_root, invalid_digest))
+    invalid_cache.parent.mkdir(parents=True, exist_ok=True)
+    invalid_cache.write_bytes(invalid_bytes)
+    state_path = Path(component_paths.update_state_path(roots.data_root))
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    update_cmd.write_update_state(
+        state_path,
+        update_cmd.UpdateState(
+            1,
+            "stable",
+            "brigade setup",
+            stable_version,
+            42,
+            tag,
+            target_commit,
+            release_manifest_url(tag),
+            invalid_digest,
+            "2026-07-20T12:00:00+00:00",
+        ),
+    )
+
+    payloads = all_release_payloads(tag=tag)
+    assert setup_native_components(env=env, opener=FakeOpener(payloads)) == 0
+    # The invalid cache was dropped; the good cache was written at its digest.
+    assert not invalid_cache.is_file()
+    good_cache = Path(component_paths.verified_manifest_path(roots.cache_root, good_digest))
+    assert good_cache.is_file()
+    assert hashlib.sha256(good_cache.read_bytes()).hexdigest() == good_digest
+    state = update_cmd.load_update_state(state_path)
+    assert state is not None
+    assert state.component_manifest_sha256 == good_digest
+
+
+def test_setup_auto_offline_keeps_stable_missing_cache_fail_closed(tmp_path, monkeypatch, capsys):
+    # Offline strictness is unchanged: a missing stable cache cannot be
+    # repaired offline and must remain fail-closed. The real resolver is wired
+    # (so a quiet fall-through would surface), but offline setup must never
+    # reach it: the missing cache fails closed before any release resolution.
+    env, http, tag, _target_commit, manifest_bytes = _prepare_auto_release_setup_real(tmp_path, monkeypatch)
+    payloads = all_release_payloads(tag=tag)
+    digest = hashlib.sha256(manifest_bytes).hexdigest()
+    assert setup_native_components(env=env, opener=FakeOpener(payloads)) == 0
+    assert http.urls  # the real resolver ran during the online publish
+
+    roots = resolve_roots(env=env, system="linux")
+    cached = Path(component_paths.verified_manifest_path(roots.cache_root, digest))
+    cached.unlink()
+    urls_before = list(http.urls)
+
+    assert setup_native_components(offline=True, env=env, opener=FakeOpener({})) == 1
+    # Offline setup must not re-resolve the release to repair the cache.
+    assert http.urls == urls_before
+    assert "cached exact-release manifest is missing" in capsys.readouterr().err
+
+
+def _beta_real_manifest_bytes(tmp_path, *, stable_version, target_commit):
+    bundled = tmp_path / "templates" / "components" / "manifest-v1.json"
+    bundled.parent.mkdir(parents=True, exist_ok=True)
+    return write_release_manifest(bundled, brigade_version=stable_version, target_commit=target_commit)
+
+
+def test_setup_auto_online_keeps_beta_missing_cache_fail_closed(tmp_path, monkeypatch, capsys):
+    # Beta strictness is unchanged: a missing beta cache must remain
+    # fail-closed even online, because a beta handoff cannot re-resolve an
+    # unreleased v{cli} tag. The real validate_release_manifest_bytes runs
+    # against the cached bytes; resolve_release is replaced with a boom so any
+    # fall-through surfaces as an AssertionError rather than a quiet repair.
+    stable_version = "0.25.0"
+    target_commit = "a" * 40
+    manifest_bytes = _beta_real_manifest_bytes(tmp_path, stable_version=stable_version, target_commit=target_commit)
+    env, digest = _persist_beta_state_real(
+        tmp_path,
+        monkeypatch,
+        stable_version=stable_version,
+        cli_version="0.25.1",
+        manifest_bytes=manifest_bytes,
+        target_commit=target_commit,
+    )
+    roots = resolve_roots(env=env, system="linux")
+    cached = Path(component_paths.verified_manifest_path(roots.cache_root, digest))
+    cached.unlink()
+    assert not cached.is_file()
+
+    assert setup_native_components(env=env, opener=FakeOpener(all_release_payloads(tag=f"v{stable_version}"))) == 1
+    assert "cached exact-release manifest is missing" in capsys.readouterr().err
+
+
+def test_setup_auto_online_keeps_beta_corrupt_cache_fail_closed(tmp_path, monkeypatch, capsys):
+    # A corrupt (digest-mismatched) beta cache must remain fail-closed online;
+    # the beta path never tolerates cache repair and never re-resolves.
+    stable_version = "0.25.0"
+    target_commit = "a" * 40
+    manifest_bytes = _beta_real_manifest_bytes(tmp_path, stable_version=stable_version, target_commit=target_commit)
+    env, digest = _persist_beta_state_real(
+        tmp_path,
+        monkeypatch,
+        stable_version=stable_version,
+        cli_version="0.25.1",
+        manifest_bytes=manifest_bytes,
+        target_commit=target_commit,
+    )
+    roots = resolve_roots(env=env, system="linux")
+    cached = Path(component_paths.verified_manifest_path(roots.cache_root, digest))
+    corrupt = cached.read_bytes() + b"\n"
+    cached.write_bytes(corrupt)
+    assert hashlib.sha256(corrupt).hexdigest() != digest
+
+    assert setup_native_components(env=env, opener=FakeOpener(all_release_payloads(tag=f"v{stable_version}"))) == 1
+    assert "cached exact-release manifest digest does not match update state" in capsys.readouterr().err
+    # The corrupt entry is not dropped on the fail-closed beta path.
+    assert cached.read_bytes() == corrupt
+
+
+def test_setup_auto_online_keeps_beta_unreadable_cache_fail_closed(tmp_path, monkeypatch, capsys):
+    # An unreadable beta cache must remain fail-closed online; the beta path
+    # never tolerates cache repair and never re-resolves. Only the cached
+    # manifest path routes through a raising read_bytes.
+    stable_version = "0.25.0"
+    target_commit = "a" * 40
+    manifest_bytes = _beta_real_manifest_bytes(tmp_path, stable_version=stable_version, target_commit=target_commit)
+    env, digest = _persist_beta_state_real(
+        tmp_path,
+        monkeypatch,
+        stable_version=stable_version,
+        cli_version="0.25.1",
+        manifest_bytes=manifest_bytes,
+        target_commit=target_commit,
+    )
+    roots = resolve_roots(env=env, system="linux")
+    cached = Path(component_paths.verified_manifest_path(roots.cache_root, digest))
+    original_read_bytes = Path.read_bytes
+
+    def read_then_raise(path: Path) -> bytes:
+        if Path(path) == cached:
+            raise OSError("simulated unreadable cache")
+        return original_read_bytes(path)
+
+    monkeypatch.setattr(Path, "read_bytes", read_then_raise)
+
+    assert setup_native_components(env=env, opener=FakeOpener(all_release_payloads(tag=f"v{stable_version}"))) == 1
+    assert "cached exact-release manifest cannot be read" in capsys.readouterr().err
+
+
+def test_setup_auto_online_keeps_beta_invalid_cache_fail_closed(tmp_path, monkeypatch, capsys):
+    # A digest-matching-but-invalid beta cache: the cached bytes hash to the
+    # digest the state records (content addressing holds), but the manifest
+    # content fails validate_release_manifest_bytes (a published component is
+    # missing). The beta path never tolerates repair, so the invalid cache is
+    # rejected and resolve_release is never called.
+    stable_version = "0.25.0"
+    target_commit = "a" * 40
+    # Invalid manifest: missing a published component, real coordinates else.
+    invalid_bundled = tmp_path / "templates" / "components" / "manifest-v1.json"
+    invalid_bundled.parent.mkdir(parents=True, exist_ok=True)
+    invalid_bytes = write_release_manifest(
+        invalid_bundled, brigade_version=stable_version, target_commit=target_commit, drop_component="miseledger"
+    )
+    env, _digest = _persist_beta_state_real(
+        tmp_path,
+        monkeypatch,
+        stable_version=stable_version,
+        cli_version="0.25.1",
+        manifest_bytes=invalid_bytes,
+        target_commit=target_commit,
+    )
+    # _persist_beta_state_real cached the (invalid) bytes at invalid_digest and
+    # recorded that digest in state, so the digest check passes while load_bytes
+    # fails. resolve_release is already boomed by the helper.
+
+    assert setup_native_components(env=env, opener=FakeOpener(all_release_payloads(tag=f"v{stable_version}"))) == 1
+    err = capsys.readouterr().err
+    assert "cached exact-release manifest is invalid" in err
+    assert "missing required components: miseledger" in err
 
 
 def _persist_beta_state(

--- a/tests/test_component_install.py
+++ b/tests/test_component_install.py
@@ -110,7 +110,9 @@ def _prepare_auto_release_setup(tmp_path, monkeypatch):
     monkeypatch.setattr(
         update_cmd,
         "validate_release_manifest_bytes",
-        lambda resolved: component_manifest.load_bytes(resolved.manifest_bytes, source=Path(resolved.manifest_url)),
+        lambda resolved, **_kwargs: component_manifest.load_bytes(
+            resolved.manifest_bytes, source=Path(resolved.manifest_url), **_kwargs
+        ),
     )
     monkeypatch.setattr(component_manifest, "platform_key", lambda **_kwargs: "linux-amd64")
     return env, release
@@ -791,7 +793,7 @@ def test_setup_auto_offline_validates_the_hashed_cached_bytes_after_path_replace
 
     monkeypatch.setattr(Path, "read_bytes", read_then_replace)
 
-    manifest, auto_release = component_install._load_setup_manifest(
+    manifest, auto_release, _auto_compatible = component_install._load_setup_manifest(
         manifest_path=None,
         manifest_source="auto",
         offline=True,
@@ -862,10 +864,55 @@ def test_setup_auto_failure_does_not_publish_release_state(tmp_path, monkeypatch
     assert not Path(component_paths.update_state_path(roots.data_root)).exists()
 
 
-def test_setup_auto_preserves_beta_channel_ownership_while_refreshing_components(tmp_path, monkeypatch):
-    env, release = _prepare_auto_release_setup(tmp_path, monkeypatch)
+def _persist_beta_state(
+    tmp_path,
+    monkeypatch,
+    *,
+    stable_version: str,
+    manifest_bytes: bytes,
+    target_commit: str,
+    cli_version: str = "0.25.1",
+):
+    """Persist a beta-handoff update state pointing at a verified stable cache.
+
+    The beta CLI reports ``cli_version`` (newer than ``stable_version``); the
+    update transaction persisted the verified last-stable release manifest
+    bytes at their digest path and recorded its coordinates. A later
+    ``brigade setup`` must reuse that cache rather than resolving an unreleased
+    ``v{cli_version}`` tag. ``validate_release_manifest_bytes`` is mocked to
+    skip release-coordinate validation (the fixture manifest uses
+    ``example.invalid`` URLs) while still exercising the compatible
+    missing-unpublished handling, mirroring ``_prepare_auto_release_setup``.
+    """
+    env = linux_env(tmp_path)
+    bundled = tmp_path / "templates" / "components" / "manifest-v1.json"
+    bundled.parent.mkdir(parents=True, exist_ok=True)
+    bundled.write_bytes(manifest_bytes)
+    digest = hashlib.sha256(manifest_bytes).hexdigest()
+    monkeypatch.setattr(component_install.templates, "template_root", lambda: bundled.parents[1])
+    monkeypatch.setattr(component_manifest, "manifest_path", lambda: bundled)
+    monkeypatch.setattr(component_manifest, "platform_key", lambda **_kwargs: "linux-amd64")
+    monkeypatch.setattr("brigade.__version__", cli_version, raising=False)
+    monkeypatch.setattr(
+        update_cmd,
+        "validate_release_manifest_bytes",
+        lambda resolved, **_kwargs: component_manifest.load_bytes(
+            resolved.manifest_bytes, source=Path(resolved.manifest_url), **_kwargs
+        ),
+    )
+
+    # If the verified cache is reused, the release must never be re-resolved.
+    def _boom_resolve(*_args, **_kwargs):
+        raise AssertionError("resolve_release must not be called when a verified beta cache is reused")
+
+    monkeypatch.setattr(update_cmd, "resolve_release", _boom_resolve)
+
     roots = resolve_roots(env=env, system="linux")
+    cached = Path(component_paths.verified_manifest_path(roots.cache_root, digest))
+    cached.parent.mkdir(parents=True, exist_ok=True)
+    cached.write_bytes(manifest_bytes)
     state_path = Path(component_paths.update_state_path(roots.data_root))
+    state_path.parent.mkdir(parents=True, exist_ok=True)
     update_cmd.write_update_state(
         state_path,
         update_cmd.UpdateState(
@@ -874,24 +921,224 @@ def test_setup_auto_preserves_beta_channel_ownership_while_refreshing_components
             "brigade update",
             "b" * 40,
             41,
-            "v1.2.2",
-            "a" * 40,
-            "https://github.com/escoffier-labs/brigade/releases/download/v1.2.2/component-manifest-v1.json",
-            "c" * 64,
+            f"v{stable_version}",
+            target_commit,
+            f"https://github.com/escoffier-labs/brigade/releases/download/v{stable_version}/component-manifest-v1.json",
+            digest,
             "2026-07-20T12:00:00+00:00",
         ),
+    )
+    return env, digest
+
+
+def _precache_fixture_assets(env: dict[str, str], cached_manifest_path: Path) -> component_manifest.ComponentManifest:
+    """Pre-cache every published asset for an offline setup reuse.
+
+    The cached manifest may be a pre-agent-notify stable manifest (missing the
+    unpublished agent-notify id), so load it in compatible mode to tolerate
+    that missing id while pinning every published component.
+    """
+    roots = resolve_roots(env=env, system="linux")
+    manifest = component_manifest.load(cached_manifest_path, allow_compatible_stable_manifest=True)
+    for component_id in component_manifest.published_component_ids(manifest):
+        asset = manifest.components[component_id].assets["linux-amd64"]
+        cache_path = Path(component_paths.cached_asset_path(roots.cache_root, asset.sha256, asset.asset_name))
+        write_verified_cache(cache_path, payload=fixture_payload(component_id)[0])
+    return manifest
+
+
+def test_setup_online_reuses_persisted_beta_stable_manifest_when_cli_advances(tmp_path, monkeypatch):
+    bundled = tmp_path / "templates" / "components" / "manifest-v1.json"
+    bundled.parent.mkdir(parents=True, exist_ok=True)
+    write_test_manifest(bundled, brigade_version="0.25.0")
+    manifest_bytes = bundled.read_bytes()
+    env, digest = _persist_beta_state(
+        tmp_path,
+        monkeypatch,
+        stable_version="0.25.0",
+        manifest_bytes=manifest_bytes,
+        target_commit=fixture_component_revision("graphtrail"),
     )
 
     assert setup_native_components(env=env, opener=FakeOpener(all_fixture_payloads())) == 0
 
-    state = update_cmd.load_update_state(state_path)
+    roots = resolve_roots(env=env, system="linux")
+    state = update_cmd.load_update_state(Path(component_paths.update_state_path(roots.data_root)))
+    assert state is not None
+    # Beta state coordinates are preserved exactly; setup reused the verified
+    # stable cache and did not re-resolve or republish state.
+    assert (state.channel, state.owner, state.cli_coordinate) == ("beta", "brigade update", "b" * 40)
+    assert (state.component_tag, state.component_manifest_sha256) == ("v0.25.0", digest)
+    installed = component_state.load_installed_state(Path(component_paths.installed_state_path(roots.data_root)))
+    assert installed is not None
+    assert set(installed.components) == set(component_manifest.KNOWN_COMPONENT_IDS)
+
+
+def test_setup_offline_reuses_persisted_beta_stable_manifest_when_cli_advances(tmp_path, monkeypatch):
+    bundled = tmp_path / "templates" / "components" / "manifest-v1.json"
+    bundled.parent.mkdir(parents=True, exist_ok=True)
+    write_test_manifest(bundled, brigade_version="0.25.0")
+    manifest_bytes = bundled.read_bytes()
+    env, digest = _persist_beta_state(
+        tmp_path,
+        monkeypatch,
+        stable_version="0.25.0",
+        manifest_bytes=manifest_bytes,
+        target_commit=fixture_component_revision("graphtrail"),
+    )
+    roots = resolve_roots(env=env, system="linux")
+    cached = Path(component_paths.verified_manifest_path(roots.cache_root, digest))
+    _precache_fixture_assets(env, cached)
+
+    assert setup_native_components(offline=True, env=env, opener=FakeOpener({})) == 0
+
+    state = update_cmd.load_update_state(Path(component_paths.update_state_path(roots.data_root)))
     assert state is not None
     assert (state.channel, state.owner, state.cli_coordinate) == ("beta", "brigade update", "b" * 40)
-    assert (state.component_release_id, state.component_tag, state.component_manifest_sha256) == (
-        release.release_id,
-        release.tag,
-        release.manifest_sha256,
+    assert (state.component_tag, state.component_manifest_sha256) == ("v0.25.0", digest)
+    installed = component_state.load_installed_state(Path(component_paths.installed_state_path(roots.data_root)))
+    assert installed is not None
+    assert set(installed.components) == set(component_manifest.KNOWN_COMPONENT_IDS)
+
+
+def test_setup_offline_reuses_persisted_beta_pre_agent_notify_stable_manifest(tmp_path, monkeypatch):
+    # The saved stable manifest predates agent-notify; compatible mode must
+    # tolerate the missing unpublished id while reusing the verified cache.
+    env, manifest_path = _install_fixture_manifest(tmp_path, monkeypatch)
+    _write_pre_agent_notify_manifest(manifest_path, brigade_version="0.25.0")
+    manifest_bytes = manifest_path.read_text().encode()
+    env, digest = _persist_beta_state(
+        tmp_path,
+        monkeypatch,
+        stable_version="0.25.0",
+        manifest_bytes=manifest_bytes,
+        target_commit=fixture_component_revision("graphtrail"),
     )
+    roots = resolve_roots(env=env, system="linux")
+    cached = Path(component_paths.verified_manifest_path(roots.cache_root, digest))
+    _precache_fixture_assets(env, cached)
+
+    assert setup_native_components(offline=True, env=env, opener=FakeOpener({})) == 0
+
+    installed = component_state.load_installed_state(Path(component_paths.installed_state_path(roots.data_root)))
+    assert installed is not None
+    expected = {"graphtrail", "graphtrail-mcp", "miseledger", "sessionfind"}
+    assert set(installed.components) == expected
+    assert "agent-notify" not in installed.components
+
+
+def test_setup_rejects_persisted_beta_state_with_tampered_manifest_cache(tmp_path, monkeypatch, capsys):
+    bundled = tmp_path / "templates" / "components" / "manifest-v1.json"
+    bundled.parent.mkdir(parents=True, exist_ok=True)
+    write_test_manifest(bundled, brigade_version="0.25.0")
+    manifest_bytes = bundled.read_bytes()
+    env, _digest = _persist_beta_state(
+        tmp_path,
+        monkeypatch,
+        stable_version="0.25.0",
+        manifest_bytes=manifest_bytes,
+        target_commit=fixture_component_revision("graphtrail"),
+    )
+    roots = resolve_roots(env=env, system="linux")
+    state = update_cmd.load_update_state(Path(component_paths.update_state_path(roots.data_root)))
+    assert state is not None
+    cached = Path(component_paths.verified_manifest_path(roots.cache_root, state.component_manifest_sha256))
+    cached.write_bytes(cached.read_bytes() + b"\n")
+
+    assert setup_native_components(offline=True, env=env, opener=FakeOpener({})) == 1
+    assert "cached exact-release manifest digest does not match update state" in capsys.readouterr().err
+
+
+def test_setup_rejects_persisted_beta_state_with_missing_manifest_cache(tmp_path, monkeypatch, capsys):
+    bundled = tmp_path / "templates" / "components" / "manifest-v1.json"
+    bundled.parent.mkdir(parents=True, exist_ok=True)
+    write_test_manifest(bundled, brigade_version="0.25.0")
+    manifest_bytes = bundled.read_bytes()
+    env, _digest = _persist_beta_state(
+        tmp_path,
+        monkeypatch,
+        stable_version="0.25.0",
+        manifest_bytes=manifest_bytes,
+        target_commit=fixture_component_revision("graphtrail"),
+    )
+    roots = resolve_roots(env=env, system="linux")
+    state = update_cmd.load_update_state(Path(component_paths.update_state_path(roots.data_root)))
+    assert state is not None
+    cached = Path(component_paths.verified_manifest_path(roots.cache_root, state.component_manifest_sha256))
+    cached.unlink()
+
+    assert setup_native_components(offline=True, env=env, opener=FakeOpener({})) == 1
+    assert "cached exact-release manifest is missing" in capsys.readouterr().err
+
+
+def test_setup_rejects_persisted_beta_state_with_mismatched_stable_version(tmp_path, monkeypatch, capsys):
+    # The cached manifest's brigade_version must match the state's recorded
+    # stable component_tag/version. Use real coordinate validation (no mock)
+    # with a manifest whose version disagrees with the persisted tag.
+    env = linux_env(tmp_path)
+    stable_version = "0.25.0"
+    mismatch_version = "0.24.0"
+    target_commit = "a" * 40
+    bundled = tmp_path / "templates" / "components" / "manifest-v1.json"
+    bundled.parent.mkdir(parents=True, exist_ok=True)
+    write_test_manifest(bundled, brigade_version=mismatch_version)
+    # Rewrite asset URLs/repo/release_tag to real release coordinates so the
+    # only coordinate failure is the brigade_version mismatch.
+    payload = json.loads(bundled.read_text())
+    for _component_id, component in payload["components"].items():
+        component["component_revision"] = target_commit
+        component["source"] = {
+            "repository": "escoffier-labs/brigade",
+            "release_tag": f"v{stable_version}",
+        }
+        for _platform, asset in component["assets"].items():
+            asset_name = asset["asset_name"]
+            asset["download_url"] = (
+                f"https://github.com/escoffier-labs/brigade/releases/download/v{stable_version}/{asset_name}"
+            )
+    bundled.write_text(json.dumps(payload))
+    manifest_bytes = bundled.read_bytes()
+    digest = hashlib.sha256(manifest_bytes).hexdigest()
+    monkeypatch.setattr(component_install.templates, "template_root", lambda: bundled.parents[1])
+    monkeypatch.setattr(component_manifest, "manifest_path", lambda: bundled)
+    monkeypatch.setattr(component_manifest, "platform_key", lambda **_kwargs: "linux-amd64")
+    monkeypatch.setattr("brigade.__version__", "0.25.1", raising=False)
+    roots = resolve_roots(env=env, system="linux")
+    cached = Path(component_paths.verified_manifest_path(roots.cache_root, digest))
+    cached.parent.mkdir(parents=True, exist_ok=True)
+    cached.write_bytes(manifest_bytes)
+    state_path = Path(component_paths.update_state_path(roots.data_root))
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    update_cmd.write_update_state(
+        state_path,
+        update_cmd.UpdateState(
+            1,
+            "beta",
+            "brigade update",
+            "b" * 40,
+            41,
+            f"v{stable_version}",
+            target_commit,
+            f"https://github.com/escoffier-labs/brigade/releases/download/v{stable_version}/component-manifest-v1.json",
+            digest,
+            "2026-07-20T12:00:00+00:00",
+        ),
+    )
+
+    assert setup_native_components(offline=True, env=env, opener=FakeOpener({})) == 1
+    assert "brigade_version" in capsys.readouterr().err
+
+
+def test_setup_strict_stable_state_still_rejects_advanced_cli_offline(tmp_path, monkeypatch, capsys):
+    # Stable state must retain exact current-version behavior: a stale stable
+    # state whose component_tag predates the running CLI version does NOT opt
+    # into the beta compatibility path; offline setup fails for a stale cache.
+    env, release = _prepare_auto_release_setup(tmp_path, monkeypatch)
+    assert setup_native_components(env=env, opener=FakeOpener(all_fixture_payloads())) == 0
+    monkeypatch.setattr("brigade.__version__", "0.25.2", raising=False)
+
+    assert setup_native_components(offline=True, env=env, opener=FakeOpener({})) == 1
+    assert "offline setup requires a verified exact-release manifest cache" in capsys.readouterr().err
 
 
 def test_explicit_setup_manifest_does_not_publish_unified_update_state(tmp_path, monkeypatch):
@@ -1393,6 +1640,122 @@ def test_setup_install_skips_unpublished_agent_notify_and_installs_four(tmp_path
     assert "agent-notify" not in state.components
     notify_path = Path(component_paths.managed_executable_path(roots.data_root, "agent-notify"))
     assert not notify_path.exists()
+
+
+def _write_pre_agent_notify_manifest(path: Path, *, brigade_version: str) -> None:
+    """Last-stable manifest predating the agent-notify KNOWN_COMPONENT_IDS entry.
+
+    Unlike ``_write_unpublished_notify_manifest``, this manifest has no
+    agent-notify entry at all, mirroring the real beta handoff that downloads
+    the most recent stable release published before agent-notify was added.
+    """
+    components: dict[str, object] = {}
+    for component_id in component_manifest.KNOWN_COMPONENT_IDS:
+        if component_id == "agent-notify":
+            continue
+        assets: dict[str, object] = {}
+        for platform in component_manifest.SUPPORTED_PLATFORMS:
+            _, byte_size, sha256 = fixture_payload(component_id, platform=platform)
+            asset = manifest_asset_fixture(component_id, platform=platform)
+            assets[platform] = {
+                "asset_name": asset.asset_name,
+                "byte_size": byte_size,
+                "sha256": sha256,
+                "download_url": asset.download_url,
+            }
+        components[component_id] = {
+            "component_revision": fixture_component_revision(component_id),
+            "source": {"repository": FIXTURE_REPOSITORY, "release_tag": "fixture"},
+            "executable": component_id,
+            "assets": assets,
+        }
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "brigade_version": brigade_version,
+                "manifest_revision": "fixture",
+                "supported_platforms": list(component_manifest.SUPPORTED_PLATFORMS),
+                "components": components,
+            }
+        )
+    )
+
+
+def test_setup_compatible_stable_manifest_skips_missing_unpublished_agent_notify(tmp_path, monkeypatch):
+    env = linux_env(tmp_path)
+    manifest_path = tmp_path / "manifest-v1.json"
+    _write_pre_agent_notify_manifest(manifest_path, brigade_version=brigade.__version__)
+    monkeypatch.setattr(component_manifest, "manifest_path", lambda: manifest_path)
+    monkeypatch.setattr(component_manifest, "platform_key", lambda **_kwargs: "linux-amd64")
+    opener = FakeOpener(all_fixture_payloads())
+
+    # The beta handoff reuses the verified last-stable asset set and omits
+    # agent-notify, which the manifest predates. The compatibility flag must
+    # match the manifest's brigade_version or setup rejects the handoff.
+    assert (
+        setup_native_components(
+            env=env,
+            opener=opener,
+            manifest_path=manifest_path,
+            allow_compatible_stable_manifest=brigade.__version__,
+        )
+        == 0
+    )
+
+    roots = resolve_roots(env=env, system="linux")
+    state_path = Path(component_paths.installed_state_path(roots.data_root))
+    state = component_state.load_installed_state(state_path)
+    assert state is not None
+    expected = {"graphtrail", "graphtrail-mcp", "miseledger", "sessionfind"}
+    assert set(state.components) == expected
+    assert "agent-notify" not in state.components
+    notify_path = Path(component_paths.managed_executable_path(roots.data_root, "agent-notify"))
+    assert not notify_path.exists()
+
+
+def test_setup_strict_manifest_rejects_pre_agent_notify_without_beta_handoff(tmp_path, monkeypatch, capsys):
+    env = linux_env(tmp_path)
+    manifest_path = tmp_path / "manifest-v1.json"
+    _write_pre_agent_notify_manifest(manifest_path, brigade_version=brigade.__version__)
+    monkeypatch.setattr(component_manifest, "manifest_path", lambda: manifest_path)
+    monkeypatch.setattr(component_manifest, "platform_key", lambda **_kwargs: "linux-amd64")
+
+    # Without the compatibility handoff, strict setup validation rejects the
+    # pre-agent-notify manifest for the missing required component.
+    assert (
+        setup_native_components(
+            env=env,
+            opener=FakeOpener(all_fixture_payloads()),
+            manifest_path=manifest_path,
+        )
+        == 1
+    )
+    assert "missing required components: agent-notify" in capsys.readouterr().err
+
+
+def test_setup_compatible_stable_manifest_rejects_missing_published_component(tmp_path, monkeypatch, capsys):
+    env = linux_env(tmp_path)
+    manifest_path = tmp_path / "manifest-v1.json"
+    _write_pre_agent_notify_manifest(manifest_path, brigade_version=brigade.__version__)
+    payload = json.loads(manifest_path.read_text())
+    del payload["components"]["miseledger"]
+    manifest_path.write_text(json.dumps(payload))
+    monkeypatch.setattr(component_manifest, "manifest_path", lambda: manifest_path)
+    monkeypatch.setattr(component_manifest, "platform_key", lambda **_kwargs: "linux-amd64")
+
+    # Compatibility mode tolerates only currently-unpublished missing ids; a
+    # missing published component (miseledger) still fails the handoff.
+    assert (
+        setup_native_components(
+            env=env,
+            opener=FakeOpener(all_fixture_payloads()),
+            manifest_path=manifest_path,
+            allow_compatible_stable_manifest=brigade.__version__,
+        )
+        == 1
+    )
+    assert "missing required components: miseledger" in capsys.readouterr().err
 
 
 def test_setup_state_is_absent_while_smoke_runs(tmp_path, monkeypatch):

--- a/tests/test_component_manifest.py
+++ b/tests/test_component_manifest.py
@@ -850,3 +850,86 @@ def test_platform_key_uses_go_names_and_rejects_unsupported_values():
 def test_platform_key_hard_failure_lists_supported_keys():
     with pytest.raises(ValueError, match="supported platform keys: linux-amd64"):
         component_manifest.platform_key(system="Plan9", machine="mips")
+
+
+def test_unpublished_component_ids_pinned_to_agent_notify_only():
+    # The compatibility handoff may tolerate only the component ids declared
+    # currently unpublished. At this commit that set is exactly agent-notify;
+    # pin the exact set so a future addition forces an explicit decision here.
+    assert component_manifest.UNPUBLISHED_COMPONENT_IDS == frozenset({"agent-notify"})
+    assert "agent-notify" in component_manifest.KNOWN_COMPONENT_IDS
+
+
+def _pre_agent_notify_manifest(tmp_path: Path) -> Path:
+    """Last-stable manifest that predates the agent-notify KNOWN_COMPONENT_IDS entry."""
+    base = json.loads(_write_manifest(tmp_path).read_text())
+    del base["components"]["agent-notify"]
+    path = tmp_path / "pre-agent-notify.json"
+    path.write_text(json.dumps(base))
+    return path
+
+
+def test_strict_manifest_rejects_pre_agent_notify_stable_manifest(tmp_path):
+    path = _pre_agent_notify_manifest(tmp_path)
+    with pytest.raises(ValueError, match="missing required components: agent-notify"):
+        component_manifest.load(path)
+
+
+def test_compatible_stable_manifest_tolerates_missing_unpublished_agent_notify(tmp_path):
+    path = _pre_agent_notify_manifest(tmp_path)
+
+    manifest = component_manifest.load(path, allow_compatible_stable_manifest=True)
+
+    assert "agent-notify" not in manifest.components
+    assert set(manifest.components) == set(component_manifest.KNOWN_COMPONENT_IDS) - {"agent-notify"}
+    assert component_manifest.published_component_ids(manifest) == (
+        "graphtrail",
+        "graphtrail-mcp",
+        "miseledger",
+        "sessionfind",
+    )
+    assert manifest.unknown_component_diagnostics == ()
+
+
+def test_compatible_stable_manifest_rejects_missing_published_component(tmp_path):
+    path = _pre_agent_notify_manifest(tmp_path)
+    base = json.loads(path.read_text())
+    del base["components"]["miseledger"]
+    path.write_text(json.dumps(base))
+
+    with pytest.raises(ValueError, match="missing required components: miseledger"):
+        component_manifest.load(path, allow_compatible_stable_manifest=True)
+
+
+def test_compatible_stable_manifest_still_rejects_malformed_assets(tmp_path):
+    path = _pre_agent_notify_manifest(tmp_path)
+    base = json.loads(path.read_text())
+    base["components"]["miseledger"]["assets"]["linux-amd64"]["sha256"] = "not-hex"
+    path.write_text(json.dumps(base))
+
+    with pytest.raises(ValueError, match="field 'sha256'"):
+        component_manifest.load(path, allow_compatible_stable_manifest=True)
+
+
+def test_compatible_stable_manifest_rejects_unknown_extras(tmp_path):
+    # Compatibility mode is the narrowly named beta handoff path. It must not
+    # accept component records the running Brigade does not know; an unknown
+    # id is rejected outright (preserving the diagnostic text) rather than
+    # ignored with a diagnostic. Strict mode still ignores unknowns (see
+    # test_manifest_ignores_unknown_components_with_deterministic_diagnostic).
+    path = _pre_agent_notify_manifest(tmp_path)
+    base = json.loads(path.read_text())
+    base["components"]["future-tool"] = {
+        "component_revision": "v9",
+        "source": {"repository": "example/future"},
+        "executable": "future-tool",
+        "assets": {},
+    }
+    path.write_text(json.dumps(base))
+
+    with pytest.raises(
+        ValueError,
+        match="component manifest lists unknown component 'future-tool'; known components: "
+        "agent-notify, graphtrail, graphtrail-mcp, miseledger, sessionfind",
+    ):
+        component_manifest.load(path, allow_compatible_stable_manifest=True)

--- a/tests/test_managed.py
+++ b/tests/test_managed.py
@@ -1,6 +1,8 @@
 import json
 from pathlib import Path
 
+import pytest
+
 from brigade import managed
 from brigade import station_manifest
 from brigade import stations_cmd
@@ -79,6 +81,8 @@ def test_agentpantry_doctor_unwired(monkeypatch):
     assert t is not None and t.station == "pantry"
 
     def fake_run(args, **kw):
+        if args == ["agentpantry", "version", "--json"]:
+            return managed.proc.Result(code=0, stdout='{"version": "0.5.0"}', stderr="")
         assert args == ["agentpantry", "doctor", "--json", "--no-net"]
         return managed.proc.Result(
             code=2, stdout='{"configured": false, "fail_count": 1, "warn_count": 0, "checks": []}', stderr=""
@@ -113,6 +117,8 @@ def test_agentpantry_doctor_parses_status(monkeypatch):
     t = managed.resolve("agentpantry")
 
     def fake_run(args, **kw):
+        if args == ["agentpantry", "version", "--json"]:
+            return managed.proc.Result(code=0, stdout='{"version": "0.5.0"}', stderr="")
         assert args == ["agentpantry", "doctor", "--json", "--no-net"]
         return managed.proc.Result(
             code=0,
@@ -133,6 +139,8 @@ def test_agentpantry_never_fails_workspace(monkeypatch):
     t = managed.resolve("agentpantry")
 
     def fake_run(args, **kw):
+        if args == ["agentpantry", "version", "--json"]:
+            return managed.proc.Result(code=0, stdout='{"version": "0.5.0"}', stderr="")
         assert args == ["agentpantry", "doctor", "--json", "--no-net"]
         return managed.proc.Result(
             code=1,
@@ -158,6 +166,8 @@ def test_agentpantry_doctor_handles_garbage_output(monkeypatch):
 
     def fake_run(args, **kw):
         calls.append(args)
+        if args == ["agentpantry", "version", "--json"]:
+            return managed.proc.Result(code=0, stdout='{"version": "0.5.0"}', stderr="")
         if args == ["agentpantry", "status", "--json"]:
             return managed.proc.Result(code=1, stdout="boom", stderr="kaboom")
         return managed.proc.Result(code=1, stdout="boom", stderr="kaboom")
@@ -167,7 +177,11 @@ def test_agentpantry_doctor_handles_garbage_output(monkeypatch):
     results = t.doctor(ctx)
     assert any(status == "WARN" and "unexpected output" in detail for status, _, detail in results)
     assert all(status != "FAIL" for status, _, _ in results)
-    assert calls == [["agentpantry", "doctor", "--json", "--no-net"], ["agentpantry", "status", "--json"]]
+    assert calls == [
+        ["agentpantry", "version", "--json"],
+        ["agentpantry", "doctor", "--json", "--no-net"],
+        ["agentpantry", "status", "--json"],
+    ]
 
 
 def test_agentpantry_doctor_falls_back_to_status_for_old_binary(monkeypatch):
@@ -176,6 +190,8 @@ def test_agentpantry_doctor_falls_back_to_status_for_old_binary(monkeypatch):
 
     def fake_run(args, **kw):
         calls.append(args)
+        if args == ["agentpantry", "version", "--json"]:
+            return managed.proc.Result(code=0, stdout='{"version": "0.5.0"}', stderr="")
         if args == ["agentpantry", "doctor", "--json", "--no-net"]:
             return managed.proc.Result(code=2, stdout="", stderr="flag provided but not defined: -json")
         return managed.proc.Result(
@@ -190,7 +206,174 @@ def test_agentpantry_doctor_falls_back_to_status_for_old_binary(monkeypatch):
     ctx = DoctorContext(target=Path("/tmp/ws"), selection=None, harnesses=[])
     results = t.doctor(ctx)
     assert any(status == "OK" and "role=sink" in detail for status, _, detail in results)
-    assert calls == [["agentpantry", "doctor", "--json", "--no-net"], ["agentpantry", "status", "--json"]]
+    assert calls == [
+        ["agentpantry", "version", "--json"],
+        ["agentpantry", "doctor", "--json", "--no-net"],
+        ["agentpantry", "status", "--json"],
+    ]
+
+
+def test_agentpantry_doctor_warns_on_below_floor_version(monkeypatch):
+    # v0.4.1 lacks inventory; the version probe must reject it as WARN and
+    # never invoke doctor/status afterwards.
+    t = managed.resolve("agentpantry")
+    calls = []
+
+    def fake_run(args, **kw):
+        calls.append(args)
+        assert args == ["agentpantry", "version", "--json"]
+        return managed.proc.Result(code=0, stdout='{"version": "0.4.1"}', stderr="")
+
+    monkeypatch.setattr(managed.proc, "run", fake_run)
+    ctx = DoctorContext(target=Path("/tmp/ws"), selection=None, harnesses=[])
+    results = t.doctor(ctx)
+    assert all(status != "FAIL" and status != "OK" for status, _, _ in results)
+    assert any(
+        status == "WARN" and "expected >= 0.5.0" in detail and "0.4.1" in detail for status, _, detail in results
+    )
+    assert calls == [["agentpantry", "version", "--json"]]
+
+
+def test_agentpantry_doctor_warns_on_nonzero_version_probe(monkeypatch):
+    t = managed.resolve("agentpantry")
+    calls = []
+
+    def fake_run(args, **kw):
+        calls.append(args)
+        assert args == ["agentpantry", "version", "--json"]
+        return managed.proc.Result(code=1, stdout="", stderr="version flag not defined")
+
+    monkeypatch.setattr(managed.proc, "run", fake_run)
+    ctx = DoctorContext(target=Path("/tmp/ws"), selection=None, harnesses=[])
+    results = t.doctor(ctx)
+    assert all(status != "FAIL" and status != "OK" for status, _, _ in results)
+    assert any(
+        status == "WARN" and "expected >= 0.5.0" in detail and "probe exit 1" in detail for status, _, detail in results
+    )
+    assert calls == [["agentpantry", "version", "--json"]]
+
+
+def test_agentpantry_doctor_warns_on_malformed_version_json(monkeypatch):
+    t = managed.resolve("agentpantry")
+    calls = []
+
+    def fake_run(args, **kw):
+        calls.append(args)
+        assert args == ["agentpantry", "version", "--json"]
+        return managed.proc.Result(code=0, stdout="not-json-at-all", stderr="")
+
+    monkeypatch.setattr(managed.proc, "run", fake_run)
+    ctx = DoctorContext(target=Path("/tmp/ws"), selection=None, harnesses=[])
+    results = t.doctor(ctx)
+    assert all(status != "FAIL" and status != "OK" for status, _, _ in results)
+    assert any(status == "WARN" and "expected >= 0.5.0" in detail for status, _, detail in results)
+    assert calls == [["agentpantry", "version", "--json"]]
+
+
+@pytest.mark.parametrize(
+    "version_value, observed",
+    [
+        ("dev", "invalid-version"),
+        ("unknown", "invalid-version"),
+        ("0.5.0-dev", "invalid-version"),
+        ("0.5.0-rc.1", "invalid-version"),
+        (None, "missing"),
+        (42, "non-string"),
+        ("", "invalid-version"),
+    ],
+)
+def test_agentpantry_doctor_warns_on_unparsable_version(monkeypatch, version_value, observed):
+    t = managed.resolve("agentpantry")
+    calls = []
+    stdout = json.dumps({"version": version_value}) if version_value is not None else json.dumps({})
+
+    def fake_run(args, **kw):
+        calls.append(args)
+        assert args == ["agentpantry", "version", "--json"]
+        return managed.proc.Result(code=0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(managed.proc, "run", fake_run)
+    ctx = DoctorContext(target=Path("/tmp/ws"), selection=None, harnesses=[])
+    results = t.doctor(ctx)
+    assert all(status != "FAIL" and status != "OK" for status, _, _ in results)
+    assert any(
+        status == "WARN" and "expected >= 0.5.0" in detail and observed in detail for status, _, detail in results
+    ), (version_value, observed, results)
+    # The raw invalid version field must not leak into any surfaced doctor detail.
+    raw = "" if version_value is None else str(version_value)
+    if raw:
+        assert all(raw not in detail for _, _, detail in results), (version_value, raw, results)
+    assert calls == [["agentpantry", "version", "--json"]]
+
+
+def test_agentpantry_doctor_never_leaks_secret_version_field(monkeypatch):
+    # Obvious secret material placed in the version field must not reach any
+    # surfaced doctor detail (the managed doctor surfaces probe.detail).
+    t = managed.resolve("agentpantry")
+    secret = "AKIA-DEADFAKE-SECRET-KEY-DO-NOT-LEAK"
+
+    def fake_run(args, **kw):
+        assert args == ["agentpantry", "version", "--json"]
+        return managed.proc.Result(code=0, stdout=json.dumps({"version": secret}), stderr="")
+
+    monkeypatch.setattr(managed.proc, "run", fake_run)
+    ctx = DoctorContext(target=Path("/tmp/ws"), selection=None, harnesses=[])
+    results = t.doctor(ctx)
+    assert all(status != "FAIL" and status != "OK" for status, _, _ in results)
+    assert any(
+        status == "WARN" and "invalid-version" in detail and "expected >= 0.5.0" in detail
+        for status, _, detail in results
+    ), results
+    assert all(secret not in detail for _, _, detail in results), results
+
+
+def test_agentpantry_doctor_accepts_exact_floor_and_proceeds(monkeypatch):
+    # Exact floor 0.5.0 is compatible; downstream doctor is invoked.
+    t = managed.resolve("agentpantry")
+    calls = []
+
+    def fake_run(args, **kw):
+        calls.append(args)
+        if args == ["agentpantry", "version", "--json"]:
+            return managed.proc.Result(code=0, stdout='{"version": "0.5.0"}', stderr="")
+        assert args == ["agentpantry", "doctor", "--json", "--no-net"]
+        return managed.proc.Result(
+            code=0,
+            stdout='{"role": "sink", "configured": true, "peer": "127.0.0.1:8787",'
+            ' "surfaces": ["sidecar"], "fail_count": 0, "warn_count": 0, "checks": []}',
+            stderr="",
+        )
+
+    monkeypatch.setattr(managed.proc, "run", fake_run)
+    ctx = DoctorContext(target=Path("/tmp/ws"), selection=None, harnesses=[])
+    results = t.doctor(ctx)
+    assert any(status == "OK" for status, _, _ in results)
+    assert calls[0] == ["agentpantry", "version", "--json"]
+    assert calls[1] == ["agentpantry", "doctor", "--json", "--no-net"]
+
+
+def test_agentpantry_doctor_accepts_multi_digit_above_floor(monkeypatch):
+    # Integer comparison: 0.10.3 must sort above 0.5.0 (lexical compare would fail).
+    t = managed.resolve("agentpantry")
+    calls = []
+
+    def fake_run(args, **kw):
+        calls.append(args)
+        if args == ["agentpantry", "version", "--json"]:
+            return managed.proc.Result(code=0, stdout='{"version": "v0.10.3"}', stderr="")
+        assert args == ["agentpantry", "doctor", "--json", "--no-net"]
+        return managed.proc.Result(
+            code=0,
+            stdout='{"role": "sink", "configured": true, "peer": "127.0.0.1:8787",'
+            ' "surfaces": ["sidecar"], "fail_count": 0, "warn_count": 0, "checks": []}',
+            stderr="",
+        )
+
+    monkeypatch.setattr(managed.proc, "run", fake_run)
+    ctx = DoctorContext(target=Path("/tmp/ws"), selection=None, harnesses=[])
+    results = t.doctor(ctx)
+    assert any(status == "OK" for status, _, _ in results)
+    assert calls[1] == ["agentpantry", "doctor", "--json", "--no-net"]
 
 
 def test_evidence_tools_attach_to_evidence_station():

--- a/tests/test_pantry_cmd.py
+++ b/tests/test_pantry_cmd.py
@@ -18,6 +18,8 @@ def test_pantry_status_combines_status_and_doctor(monkeypatch, tmp_path):
     monkeypatch.setattr(pantry_cmd.proc, "which", lambda cmd: "/x/agentpantry")
 
     def fake_run(args, **kw):
+        if args == ["agentpantry", "version", "--json"]:
+            return pantry_cmd.proc.Result(code=0, stdout='{"version": "0.5.0"}', stderr="")
         if args == ["agentpantry", "status", "--json"]:
             return pantry_cmd.proc.Result(
                 0,
@@ -54,6 +56,8 @@ def test_pantry_doctor_exits_nonzero_on_fail(monkeypatch, tmp_path):
     monkeypatch.setattr(pantry_cmd.proc, "which", lambda cmd: "/x/agentpantry")
 
     def fake_run(args, **kw):
+        if args == ["agentpantry", "version", "--json"]:
+            return pantry_cmd.proc.Result(code=0, stdout='{"version": "0.5.0"}', stderr="")
         if args == ["agentpantry", "status", "--json"]:
             return pantry_cmd.proc.Result(
                 0,
@@ -124,6 +128,8 @@ def test_expiry_alert_plans_notification_without_sending(monkeypatch):
     monkeypatch.setattr(pantry_cmd.proc, "which", lambda cmd: f"/x/{cmd}")
 
     def fake_run(args, **kw):
+        if args == ["agentpantry", "version", "--json"]:
+            return pantry_cmd.proc.Result(code=0, stdout='{"version": "0.5.0"}', stderr="")
         assert args == ["agentpantry", "inventory", "--json", "--expiry-days", "7"]
         return pantry_cmd.proc.Result(
             0,
@@ -148,6 +154,8 @@ def test_expiry_alert_send_invokes_agent_notify(monkeypatch):
 
     def fake_run(args, **kw):
         calls.append((args, kw))
+        if args == ["agentpantry", "version", "--json"]:
+            return pantry_cmd.proc.Result(code=0, stdout='{"version": "0.5.0"}', stderr="")
         if args[:2] == ["agentpantry", "inventory"]:
             return pantry_cmd.proc.Result(
                 0,
@@ -165,8 +173,10 @@ def test_expiry_alert_send_invokes_agent_notify(monkeypatch):
     payload = pantry_cmd.expiry_alert_payload(expiry_days=7, profile="agent-stop", send=True)
 
     assert payload["sent"] is True
-    assert calls[1][0][0:4] == ["agent-notify", "send", "--profile", "agent-stop"]
-    assert "example.com/sid" in calls[1][0][4]
+    # calls[0] is the version probe; calls[1] is inventory; calls[2] is agent-notify send.
+    assert calls[1][0][0:4] == ["agentpantry", "inventory", "--json", "--expiry-days"]
+    assert calls[2][0][0:4] == ["agent-notify", "send", "--profile", "agent-stop"]
+    assert "example.com/sid" in calls[2][0][4]
 
 
 def test_work_brief_includes_pantry_health(monkeypatch, tmp_path):
@@ -187,3 +197,218 @@ def test_center_status_includes_pantry_health(monkeypatch, tmp_path):
     payload = center_cmd.status_payload(tmp_path)
 
     assert payload["pantry"]["summary"] == "pantry center summary"
+
+
+def _pantry_installed(monkeypatch):
+    monkeypatch.setattr(pantry_cmd.proc, "which", lambda cmd: "/x/agentpantry" if cmd == "agentpantry" else None)
+
+
+def test_pantry_status_unhealthy_on_below_floor_version(monkeypatch, tmp_path):
+    _pantry_installed(monkeypatch)
+    calls = []
+
+    def fake_run(args, **kw):
+        calls.append(args)
+        assert args == ["agentpantry", "version", "--json"]
+        return pantry_cmd.proc.Result(code=0, stdout='{"version": "0.4.1"}', stderr="")
+
+    monkeypatch.setattr(pantry_cmd.proc, "run", fake_run)
+
+    payload = pantry_cmd.status_payload(tmp_path)
+
+    assert payload["installed"] is True
+    assert payload["health"] == "unhealthy"
+    assert payload["version"] == "0.4.1"
+    assert payload["version_compatible"] is False
+    assert "expected >= 0.5.0" in payload["summary"]
+    assert "0.4.1" in payload["summary"]
+    assert payload["status"] is None
+    assert payload["doctor"] is None
+    # No downstream status/doctor surface invoked after incompatibility.
+    assert calls == [["agentpantry", "version", "--json"]]
+
+
+def test_pantry_doctor_nonzero_on_below_floor_version(monkeypatch, tmp_path):
+    _pantry_installed(monkeypatch)
+    calls = []
+
+    def fake_run(args, **kw):
+        calls.append(args)
+        assert args == ["agentpantry", "version", "--json"]
+        return pantry_cmd.proc.Result(code=0, stdout='{"version": "0.4.1"}', stderr="")
+
+    monkeypatch.setattr(pantry_cmd.proc, "run", fake_run)
+
+    assert pantry_cmd.doctor(target=tmp_path) == 1
+    assert calls == [["agentpantry", "version", "--json"]]
+
+
+def test_pantry_status_unhealthy_on_nonzero_version_probe(monkeypatch, tmp_path):
+    _pantry_installed(monkeypatch)
+    calls = []
+
+    def fake_run(args, **kw):
+        calls.append(args)
+        assert args == ["agentpantry", "version", "--json"]
+        return pantry_cmd.proc.Result(code=1, stdout="", stderr="version flag not defined")
+
+    monkeypatch.setattr(pantry_cmd.proc, "run", fake_run)
+
+    payload = pantry_cmd.status_payload(tmp_path)
+
+    assert payload["health"] == "unhealthy"
+    assert "expected >= 0.5.0" in payload["summary"]
+    assert "probe exit 1" in payload["summary"]
+    assert calls == [["agentpantry", "version", "--json"]]
+
+
+def test_pantry_status_unhealthy_on_malformed_version_json(monkeypatch, tmp_path):
+    _pantry_installed(monkeypatch)
+    calls = []
+
+    def fake_run(args, **kw):
+        calls.append(args)
+        assert args == ["agentpantry", "version", "--json"]
+        return pantry_cmd.proc.Result(code=0, stdout="totally-not-json", stderr="")
+
+    monkeypatch.setattr(pantry_cmd.proc, "run", fake_run)
+
+    payload = pantry_cmd.status_payload(tmp_path)
+
+    assert payload["health"] == "unhealthy"
+    assert "expected >= 0.5.0" in payload["summary"]
+    assert calls == [["agentpantry", "version", "--json"]]
+
+
+def test_pantry_status_unhealthy_on_dev_version(monkeypatch, tmp_path):
+    _pantry_installed(monkeypatch)
+    calls = []
+
+    def fake_run(args, **kw):
+        calls.append(args)
+        assert args == ["agentpantry", "version", "--json"]
+        return pantry_cmd.proc.Result(code=0, stdout='{"version": "dev"}', stderr="")
+
+    monkeypatch.setattr(pantry_cmd.proc, "run", fake_run)
+
+    payload = pantry_cmd.status_payload(tmp_path)
+
+    assert payload["health"] == "unhealthy"
+    # An unparsable version string collapses to the fixed sanitized label and
+    # never leaks the raw value into the surfaced pantry payload.
+    assert payload["version"] == "invalid-version"
+    assert "expected >= 0.5.0" in payload["summary"]
+    assert "invalid-version" in payload["summary"]
+    assert "dev" not in payload["summary"]
+    assert "dev" not in payload["version"]
+    assert calls == [["agentpantry", "version", "--json"]]
+
+
+def test_pantry_status_never_leaks_secret_version_field(monkeypatch, tmp_path):
+    _pantry_installed(monkeypatch)
+    secret = "AKIA-DEADFAKE-SECRET-KEY-DO-NOT-LEAK"
+
+    def fake_run(args, **kw):
+        assert args == ["agentpantry", "version", "--json"]
+        return pantry_cmd.proc.Result(code=0, stdout=json.dumps({"version": secret}), stderr="")
+
+    monkeypatch.setattr(pantry_cmd.proc, "run", fake_run)
+
+    payload = pantry_cmd.status_payload(tmp_path)
+
+    assert payload["health"] == "unhealthy"
+    assert payload["version"] == "invalid-version"
+    assert secret not in payload["version"]
+    assert secret not in payload["summary"]
+    assert "invalid-version" in payload["summary"]
+
+
+def test_pantry_status_unhealthy_on_missing_version_field(monkeypatch, tmp_path):
+    _pantry_installed(monkeypatch)
+    calls = []
+
+    def fake_run(args, **kw):
+        calls.append(args)
+        assert args == ["agentpantry", "version", "--json"]
+        return pantry_cmd.proc.Result(code=0, stdout='{"other": "field"}', stderr="")
+
+    monkeypatch.setattr(pantry_cmd.proc, "run", fake_run)
+
+    payload = pantry_cmd.status_payload(tmp_path)
+
+    assert payload["health"] == "unhealthy"
+    assert payload["version"] == "missing"
+    assert "expected >= 0.5.0" in payload["summary"]
+    assert calls == [["agentpantry", "version", "--json"]]
+
+
+def test_pantry_status_compatible_above_floor_multi_digit(monkeypatch, tmp_path):
+    _pantry_installed(monkeypatch)
+
+    def fake_run(args, **kw):
+        if args == ["agentpantry", "version", "--json"]:
+            return pantry_cmd.proc.Result(code=0, stdout='{"version": "v0.10.3"}', stderr="")
+        if args == ["agentpantry", "status", "--json"]:
+            return pantry_cmd.proc.Result(
+                0,
+                json.dumps({"role": "sink", "peer": "127.0.0.1:8787", "surfaces": [], "last_sync": "never"}),
+                "",
+            )
+        if args == ["agentpantry", "doctor", "--json"]:
+            return pantry_cmd.proc.Result(
+                0, json.dumps({"configured": True, "fail_count": 0, "warn_count": 0, "checks": []}), ""
+            )
+        raise AssertionError(args)
+
+    monkeypatch.setattr(pantry_cmd.proc, "run", fake_run)
+
+    payload = pantry_cmd.status_payload(tmp_path)
+
+    assert payload["version_compatible"] is True
+    assert payload["version"] == "0.10.3"
+    assert payload["health"] == "ok"
+
+
+def test_expiry_alert_returns_structured_failure_on_incompatibility(monkeypatch):
+    _pantry_installed(monkeypatch)
+    calls = []
+
+    def fake_run(args, **kw):
+        calls.append(args)
+        assert args == ["agentpantry", "version", "--json"]
+        return pantry_cmd.proc.Result(code=0, stdout='{"version": "0.4.1"}', stderr="")
+
+    monkeypatch.setattr(pantry_cmd.proc, "run", fake_run)
+
+    payload = pantry_cmd.expiry_alert_payload(expiry_days=7, profile="agent-stop", send=False)
+
+    assert payload["version"] == "0.4.1"
+    assert payload["version_compatible"] is False
+    assert "expected >= 0.5.0" in payload["error"]
+    assert "0.4.1" in payload["error"]
+    assert "inventory" not in payload
+    assert payload["near_expiry_count"] == 0
+    assert payload["sent"] is False
+    # No downstream inventory surface invoked after incompatibility.
+    assert calls == [["agentpantry", "version", "--json"]]
+
+
+def test_expiry_alert_structured_failure_on_nonzero_probe(monkeypatch):
+    _pantry_installed(monkeypatch)
+    calls = []
+
+    def fake_run(args, **kw):
+        calls.append(args)
+        assert args == ["agentpantry", "version", "--json"]
+        return pantry_cmd.proc.Result(code=2, stdout="", stderr="flag not defined")
+
+    monkeypatch.setattr(pantry_cmd.proc, "run", fake_run)
+
+    payload = pantry_cmd.expiry_alert_payload(expiry_days=14, profile="agent-stop", send=True)
+
+    assert payload["version_compatible"] is False
+    assert "expected >= 0.5.0" in payload["error"]
+    assert "probe exit 2" in payload["error"]
+    assert "inventory" not in payload
+    assert payload["sent"] is False
+    assert calls == [["agentpantry", "version", "--json"]]

--- a/tests/test_pantry_cmd.py
+++ b/tests/test_pantry_cmd.py
@@ -52,7 +52,7 @@ def test_pantry_status_combines_status_and_doctor(monkeypatch, tmp_path):
     assert any("expiry-alert" in cmd for cmd in payload["next_commands"])
 
 
-def test_pantry_doctor_exits_nonzero_on_fail(monkeypatch, tmp_path):
+def test_pantry_doctor_exits_nonzero_on_fail(monkeypatch, tmp_path, capsys):
     monkeypatch.setattr(pantry_cmd.proc, "which", lambda cmd: "/x/agentpantry")
 
     def fake_run(args, **kw):
@@ -88,6 +88,10 @@ def test_pantry_doctor_exits_nonzero_on_fail(monkeypatch, tmp_path):
 
     monkeypatch.setattr(pantry_cmd.proc, "run", fake_run)
     assert pantry_cmd.doctor(target=tmp_path) == 1
+    assert (
+        "note: pantry checks are advisory for workspace doctor; "
+        "status 1 occurs for unhealthy, incomplete, or nonzero agentpantry fail_count" in capsys.readouterr().out
+    )
 
 
 def test_setup_plan_is_review_only(tmp_path):

--- a/tests/test_pantry_compat.py
+++ b/tests/test_pantry_compat.py
@@ -1,0 +1,272 @@
+"""Focused tests for the Brigade-side Agent Pantry version compatibility probe.
+
+The probe is the single shared parser/comparator used by the managed doctor,
+pantry status/doctor, and expiry-alert paths before any installed agentpantry
+surface is invoked. These tests pin the floor, the integer (not lexical)
+comparison, and the rejection rules for dev/unknown/missing/non-string/
+prerelease-shaped/unparsable versions, plus the no-leak guarantee: detail and
+observed never carry stdout beyond the version field.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from brigade import pantry_compat
+
+
+def test_floor_is_evidence_backed_0_5_0():
+    assert pantry_compat.AGENTPANTRY_MIN_VERSION == (0, 5, 0)
+    assert pantry_compat.floor_label() == "expected >= 0.5.0"
+
+
+def test_parse_version_accepts_plain_and_v_prefixed_triples():
+    assert pantry_compat.parse_version("0.5.0") == (0, 5, 0)
+    assert pantry_compat.parse_version("v0.5.0") == (0, 5, 0)
+    assert pantry_compat.parse_version("v0.10.3") == (0, 10, 3)
+    assert pantry_compat.parse_version("1.2.3") == (1, 2, 3)
+
+
+def test_parse_version_rejects_non_triples_and_prerelease_shapes():
+    assert pantry_compat.parse_version("dev") is None
+    assert pantry_compat.parse_version("unknown") is None
+    assert pantry_compat.parse_version("0.5") is None
+    assert pantry_compat.parse_version("0.5.0.0") is None
+    assert pantry_compat.parse_version("0.5.0-dev") is None
+    assert pantry_compat.parse_version("0.5.0-rc.1") is None
+    assert pantry_compat.parse_version("0.5.0+build.1") is None
+    assert pantry_compat.parse_version("") is None
+    assert pantry_compat.parse_version("  ") is None
+    assert pantry_compat.parse_version(None) is None
+    assert pantry_compat.parse_version(42) is None
+    assert pantry_compat.parse_version(["0.5.0"]) is None
+
+
+def _probe(monkeypatch, stdout: str, code: int = 0, stderr: str = ""):
+    monkeypatch.setattr(
+        pantry_compat.proc,
+        "run",
+        lambda args, **kw: pantry_compat.proc.Result(code=code, stdout=stdout, stderr=stderr),
+    )
+    return pantry_compat.probe_agentpantry_version()
+
+
+def test_probe_compatible_at_exact_floor(monkeypatch):
+    probe = _probe(monkeypatch, json.dumps({"version": "0.5.0"}))
+    assert probe.compatible is True
+    assert probe.incompatible is False
+    assert probe.observed == "0.5.0"
+    assert "expected >= 0.5.0" in probe.detail
+    assert "0.5.0" in probe.detail
+
+
+def test_probe_compatible_above_floor_multi_digit(monkeypatch):
+    # Integer comparison: 0.10.3 must sort above 0.5.0 (lexical compare would
+    # put "0.10.3" below "0.5.0" because "1" < "5").
+    probe = _probe(monkeypatch, json.dumps({"version": "v0.10.3"}))
+    assert probe.compatible is True
+    assert probe.observed == "0.10.3"
+
+
+def test_probe_incompatible_below_floor(monkeypatch):
+    probe = _probe(monkeypatch, json.dumps({"version": "0.4.1"}))
+    assert probe.compatible is False
+    assert probe.observed == "0.4.1"
+    assert "expected >= 0.5.0" in probe.detail
+    assert "0.4.1" in probe.detail
+    assert "below floor" in probe.detail
+
+
+def test_probe_incompatible_on_nonzero_exit(monkeypatch):
+    probe = _probe(monkeypatch, stdout="", code=1, stderr="flag not defined")
+    assert probe.compatible is False
+    assert "probe exit 1" in probe.observed
+    assert "expected >= 0.5.0" in probe.detail
+    assert "probe exit 1" in probe.detail
+
+
+def test_probe_incompatible_on_malformed_json(monkeypatch):
+    probe = _probe(monkeypatch, stdout="totally-not-json")
+    assert probe.compatible is False
+    assert probe.observed == "malformed"
+    assert "expected >= 0.5.0" in probe.detail
+
+
+def test_probe_incompatible_on_non_object_json(monkeypatch):
+    probe = _probe(monkeypatch, stdout=json.dumps(["0.5.0"]))
+    assert probe.compatible is False
+    assert probe.observed == "malformed"
+    assert "expected >= 0.5.0" in probe.detail
+
+
+def test_probe_incompatible_on_missing_version_field(monkeypatch):
+    probe = _probe(monkeypatch, stdout=json.dumps({"other": "field"}))
+    assert probe.compatible is False
+    assert probe.observed == "missing"
+    assert "expected >= 0.5.0" in probe.detail
+    assert "missing" in probe.detail
+
+
+def test_probe_incompatible_on_non_string_version(monkeypatch):
+    probe = _probe(monkeypatch, stdout=json.dumps({"version": 42}))
+    assert probe.compatible is False
+    assert probe.observed == "non-string"
+    assert "expected >= 0.5.0" in probe.detail
+    assert "non-string" in probe.detail
+
+
+@pytest.mark.parametrize("version", ["dev", "unknown", "0.5.0-dev", "0.5.0-rc.1", "0.5", ""])
+def test_probe_incompatible_on_unparsable_string_versions(monkeypatch, version):
+    probe = _probe(monkeypatch, stdout=json.dumps({"version": version}))
+    assert probe.compatible is False
+    assert "expected >= 0.5.0" in probe.detail
+    # Any unparsable string collapses to the fixed sanitized label; the raw
+    # invalid version field never reaches observed or detail.
+    assert probe.observed == "invalid-version"
+    # The raw value must not leak (skip the substring check for the empty
+    # string, which is vacuously a substring of every string).
+    if version:
+        assert version not in probe.observed
+        # detail always carries the fixed safe floor text, so a raw value that
+        # overlaps the floor (e.g. "0.5" is a substring of "expected >= 0.5.0")
+        # would make a bare substring assertion vacuously fail. Strip the fixed
+        # floor text first; the raw invalid field must not appear in the
+        # remainder, which still proves no raw content leaks.
+        assert version not in probe.detail.replace(pantry_compat.floor_label(), "")
+
+
+def test_probe_unparsable_secret_version_field_never_leaks(monkeypatch):
+    # Obvious secret material placed in the version field must not reach
+    # observed/detail (and therefore not reach managed doctor / pantry JSON).
+    secret = "AKIA-DEADFAKE-SECRET-KEY-DO-NOT-LEAK"
+    probe = _probe(monkeypatch, stdout=json.dumps({"version": secret}))
+    assert probe.compatible is False
+    assert probe.observed == "invalid-version"
+    assert secret not in probe.observed
+    assert secret not in probe.detail
+
+
+def test_probe_unparsable_version_field_never_leaks_other_stdout(monkeypatch):
+    # Even when stdout carries extra fields alongside an unparsable version,
+    # only the fixed sanitized label surfaces; no other stdout content leaks.
+    stdout = json.dumps({"version": "prerelease", "secret": "leak-me", "path": "/home/user/private"})
+    probe = _probe(monkeypatch, stdout=stdout)
+    assert probe.compatible is False
+    assert probe.observed == "invalid-version"
+    assert "leak-me" not in probe.observed
+    assert "leak-me" not in probe.detail
+    assert "/home/user/private" not in probe.observed
+    assert "/home/user/private" not in probe.detail
+    assert "prerelease" not in probe.observed
+    assert "prerelease" not in probe.detail
+
+
+def test_probe_below_floor_still_exposes_normalized_semver(monkeypatch):
+    # Successfully parsed versions (including below-floor ones) remain
+    # normalized semver because that is bounded numeric data, not raw content.
+    # Extra stdout fields never reach observed/detail regardless of parse.
+    stdout = json.dumps({"version": "0.4.1", "secret": "leak-me", "path": "/home/user/private"})
+    probe = _probe(monkeypatch, stdout=stdout)
+    assert probe.compatible is False
+    assert probe.observed == "0.4.1"
+    assert "0.4.1" in probe.detail
+    assert "below floor" in probe.detail
+    assert "leak-me" not in probe.observed
+    assert "leak-me" not in probe.detail
+    assert "/home/user/private" not in probe.observed
+    assert "/home/user/private" not in probe.detail
+
+
+def test_probe_uses_version_json_surface(monkeypatch):
+    seen = []
+
+    def fake_run(args, **kw):
+        seen.append((args, kw))
+        return pantry_compat.proc.Result(code=0, stdout='{"version": "0.5.0"}', stderr="")
+
+    monkeypatch.setattr(pantry_compat.proc, "run", fake_run)
+    probe = pantry_compat.probe_agentpantry_version()
+    assert probe.compatible is True
+    assert seen[0][0] == ["agentpantry", "version", "--json"]
+    # The probe is bounded so a hung binary cannot block doctor for long.
+    assert seen[0][1]["timeout"] == 10.0
+
+
+def test_parse_version_rejects_huge_whitespace_padded_input():
+    # Overlong raw input must fail before strip/regex so hostile padding cannot
+    # force an unbounded scan.
+    bound = pantry_compat._MAX_RAW_VERSION_LEN
+    padded = (" " * (bound * 1000)) + "0.5.0" + (" " * (bound * 1000))
+    assert len(padded) > bound
+    assert pantry_compat.parse_version(padded) is None
+
+
+def test_parse_version_rejects_oversized_numeric_segments():
+    # Arbitrarily long numeric segments must not throw or allocate unbounded
+    # ints; the conservative per-segment bound collapses them to None (which
+    # the probe surfaces as the fixed invalid-version label).
+    bound = pantry_compat._MAX_SEGMENT_DIGITS
+    oversized = "0" * (bound + 1)
+    assert pantry_compat.parse_version(f"{oversized}.5.0") is None
+    assert pantry_compat.parse_version(f"0.{oversized}.0") is None
+    assert pantry_compat.parse_version(f"0.5.{oversized}") is None
+    # A segment exactly at the bound still parses.
+    at_bound = "9" * bound
+    assert pantry_compat.parse_version(f"{at_bound}.5.0") == (int(at_bound), 5, 0)
+
+
+def test_parse_version_rejects_non_ascii_digits():
+    # ``\d`` would match Unicode digits; the parser accepts ASCII numerics only
+    # so Arabic-Indic and fullwidth digit runs collapse to None.
+    assert pantry_compat.parse_version("٠.٥.٠") is None
+    assert pantry_compat.parse_version("v٠.٥.٠") is None
+    assert pantry_compat.parse_version("１.２.３") is None
+    assert pantry_compat.parse_version("0.5.০") is None
+
+
+def test_probe_oversized_segment_collapses_to_invalid_version_label(monkeypatch):
+    # A hostile version field with an arbitrarily long numeric segment must not
+    # throw, allocate unbounded ints, or echo raw content. It collapses to the
+    # fixed sanitized label in observed/detail and never leaks the raw run.
+    bound = pantry_compat._MAX_SEGMENT_DIGITS
+    huge = "9" * (bound * 1000)
+    raw_version = f"{huge}.5.0"
+    probe = _probe(monkeypatch, stdout=json.dumps({"version": raw_version}))
+    assert probe.compatible is False
+    assert probe.observed == "invalid-version"
+    assert huge not in probe.observed
+    assert huge not in probe.detail
+    assert raw_version not in probe.observed
+    assert raw_version not in probe.detail
+    assert "expected >= 0.5.0" in probe.detail
+
+
+def test_probe_non_ascii_digit_version_collapses_to_invalid_version_label(monkeypatch):
+    # Non-ASCII-digit version fields must collapse to the fixed sanitized
+    # label without echoing the raw Unicode content.
+    raw_version = "٠.٥.٠"
+    probe = _probe(monkeypatch, stdout=json.dumps({"version": raw_version}))
+    assert probe.compatible is False
+    assert probe.observed == "invalid-version"
+    assert raw_version not in probe.observed
+    assert raw_version not in probe.detail
+    assert "expected >= 0.5.0" in probe.detail
+
+
+def test_probe_oversized_segment_never_leaks_other_stdout(monkeypatch):
+    # Even with an oversized segment alongside extra stdout fields, only the
+    # fixed sanitized label surfaces; no other stdout content leaks.
+    bound = pantry_compat._MAX_SEGMENT_DIGITS
+    huge = "7" * (bound * 500)
+    stdout = json.dumps({"version": f"{huge}.5.0", "secret": "leak-me", "path": "/home/user/private"})
+    probe = _probe(monkeypatch, stdout=stdout)
+    assert probe.compatible is False
+    assert probe.observed == "invalid-version"
+    assert huge not in probe.observed
+    assert huge not in probe.detail
+    assert "leak-me" not in probe.observed
+    assert "leak-me" not in probe.detail
+    assert "/home/user/private" not in probe.observed
+    assert "/home/user/private" not in probe.detail

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -24,6 +24,10 @@ from brigade.station import Station
         ("missing", True, "unchecked"),
         ("manual", False, "not-installed"),
         ("unknown", True, "unchecked"),
+        # A known-incompatible installed station reports ``unhealthy``; the
+        # aggregate must keep it red (``failed``) rather than collapsing an
+        # unrecognized value to ``unchecked``.
+        ("unhealthy", True, "failed"),
     ],
 )
 def test_normalize_payload_health(raw, installed, expected):
@@ -71,6 +75,31 @@ def test_status_warning_is_degraded(monkeypatch, tmp_target, capsys):
     row = json.loads(capsys.readouterr().out)["stations"][0]
     assert row["health"] == "degraded"
     assert row["warn"] == 1
+
+
+def test_status_pantry_incompatible_is_failed_not_unchecked(monkeypatch, tmp_target, capsys):
+    # Regression: pantry_cmd.status_payload reports health ``unhealthy`` for an
+    # installed-but-incompatible agentpantry. The shared aggregate normalizer
+    # must keep that known incompatibility red (``failed``) instead of mapping
+    # the unrecognized value to ``unchecked``.
+    pantry_station = Station(name="pantry", summary="agentpantry station", doctor=None)
+    monkeypatch.setattr(status_mod, "all_stations", lambda: (pantry_station,))
+    monkeypatch.setattr(
+        status_mod,
+        "_optional_station_payload",
+        lambda station, target: {
+            "installed": True,
+            "health": "unhealthy",
+            "summary": "agentpantry 0.4.1 below supported floor 0.5.0",
+        },
+    )
+
+    assert status_mod.run(tmp_target, json_output=True) == 0
+    row = json.loads(capsys.readouterr().out)["stations"][0]
+    assert row["health"] == "failed"
+    assert row["fail"] == 1
+    assert row["ok"] == 0
+    assert row["warn"] == 0
 
 
 def test_status_lists_stations_for_installed_workspace(tmp_target: Path, capsys):

--- a/tests/test_update_cmd.py
+++ b/tests/test_update_cmd.py
@@ -52,6 +52,50 @@ def _manifest() -> bytes:
     ).encode()
 
 
+def _pre_agent_notify_manifest() -> bytes:
+    """Last-stable manifest predating the agent-notify KNOWN_COMPONENT_IDS entry.
+
+    The beta handoff downloads the most recent stable release manifest, which
+    was published before agent-notify was added to KNOWN_COMPONENT_IDS on main
+    and therefore carries the four published native engines and no agent-notify
+    entry at all. Strict validation must reject this manifest; only the narrowly
+    named compatibility mode used by the beta handoff may accept it.
+    """
+    components = {}
+    for component in component_manifest.KNOWN_COMPONENT_IDS:
+        if component == "agent-notify":
+            continue
+        assets = {}
+        for platform in component_manifest.SUPPORTED_PLATFORMS:
+            name = f"{component}-{platform}" + (".exe" if platform == "windows-amd64" else "")
+            payload = name.encode()
+            assets[platform] = {
+                "asset_name": name,
+                "byte_size": len(payload),
+                "sha256": hashlib.sha256(payload).hexdigest(),
+                "download_url": BASE + name,
+            }
+        components[component] = {
+            "component_revision": "a" * 40,
+            "source": {"repository": "escoffier-labs/brigade", "release_tag": TAG},
+            "executable": component,
+            "assets": assets,
+        }
+    return (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "brigade_version": VERSION,
+                "manifest_revision": "v1.2.3+" + "a" * 40,
+                "supported_platforms": list(component_manifest.SUPPORTED_PLATFORMS),
+                "components": components,
+            },
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode()
+
+
 def _release(manifest: bytes) -> dict:
     digest = hashlib.sha256(manifest).hexdigest()
     return {
@@ -452,6 +496,91 @@ def test_beta_update_installs_full_main_sha_and_reuses_verified_stable_manifest(
     assert state.channel == "beta"
     assert state.cli_coordinate == sha
     assert (state.component_release_id, state.component_tag) == (42, TAG)
+
+
+def test_beta_update_accepts_pre_agent_notify_stable_manifest(tmp_path):
+    # The previous test is a false positive: its fixture gives every current
+    # component full assets. A real beta handoff right after agent-notify enters
+    # KNOWN_COMPONENT_IDS on main but before the first stable release publishing
+    # it downloads the last stable manifest, which has no agent-notify entry.
+    manifest = _pre_agent_notify_manifest()
+    sha = "b" * 40
+    commands = []
+    installed_binary = tmp_path / "bin" / "brigade"
+    paths = update_cmd.UpdatePaths(tmp_path / "data", tmp_path / "cache", installed_binary)
+
+    assert (
+        update_cmd.run_update(
+            channel="beta",
+            paths=paths,
+            http=_BetaHttp(_release(manifest), manifest, sha=sha),
+            runner=lambda argv: commands.append(argv) or 0,
+            now=lambda: "2026-07-20T12:00:00+00:00",
+        )
+        == 0
+    )
+    cache_path = paths.cache_root / "brigade" / "release-manifests" / f"{hashlib.sha256(manifest).hexdigest()}.json"
+    assert cache_path.read_bytes() == manifest
+    assert commands == [
+        ["pipx", "install", "--force", f"git+https://github.com/escoffier-labs/brigade@{sha}"],
+        [
+            str(installed_binary),
+            "setup",
+            "--manifest",
+            str(cache_path),
+            "--allow-compatible-stable-manifest",
+            VERSION,
+        ],
+    ]
+    state = update_cmd.load_update_state(paths.data_root / "brigade" / "update-state.json")
+    assert state is not None
+    assert state.channel == "beta"
+    assert state.cli_coordinate == sha
+    assert (state.component_release_id, state.component_tag) == (42, TAG)
+
+
+def test_release_manifest_still_rejects_missing_agent_notify_without_beta_handoff():
+    manifest = _pre_agent_notify_manifest()
+    release = update_cmd.ResolvedRelease(
+        42,
+        TAG,
+        VERSION,
+        "a" * 40,
+        BASE + "component-manifest-v1.json",
+        len(manifest),
+        hashlib.sha256(manifest).hexdigest(),
+        manifest,
+    )
+
+    # Strict validation (no compatibility handoff) rejects the missing
+    # agent-notify entry, preserving the stable/release invariant.
+    with pytest.raises(ValueError, match="missing required components: agent-notify"):
+        update_cmd.validate_release_manifest_bytes(release)
+
+    # The narrowly named compatibility mode is the only path that accepts it,
+    # and only because agent-notify is currently unpublished.
+    accepted = update_cmd.validate_release_manifest_bytes(release, allow_compatible_stable_manifest=True)
+    assert "agent-notify" not in accepted.components
+    assert set(accepted.components) == set(component_manifest.KNOWN_COMPONENT_IDS) - {"agent-notify"}
+
+
+def test_release_manifest_compatibility_mode_rejects_missing_published_component():
+    manifest = json.loads(_pre_agent_notify_manifest())
+    del manifest["components"]["miseledger"]
+    raw = (json.dumps(manifest, sort_keys=True) + "\n").encode()
+    release = update_cmd.ResolvedRelease(
+        42,
+        TAG,
+        VERSION,
+        "a" * 40,
+        BASE + "component-manifest-v1.json",
+        len(raw),
+        hashlib.sha256(raw).hexdigest(),
+        raw,
+    )
+
+    with pytest.raises(ValueError, match="missing required components: miseledger"):
+        update_cmd.validate_release_manifest_bytes(release, allow_compatible_stable_manifest=True)
 
 
 def test_beta_same_coordinates_are_a_noop(tmp_path):


### PR DESCRIPTION
## Summary

- reuse the last verified stable component manifest for beta installs when agent-notify is known on main but unpublished
- keep stable manifests strict, reject unknown component records, and tolerate only the explicitly unpublished agent-notify record
- require Agent Pantry 0.5.0 or newer before Brigade calls its doctor, status, or inventory surfaces
- sanitize malformed Pantry version output and document the stable and beta channel behavior

## Verification

- Brigade receipt: 20260722-191816-work-verify-8af881
- 3,858 passed, 3 skipped
- coverage: 82.66%

Phase 5 and the stable release pin are intentionally excluded.

Refs #431

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Beta updates can reuse compatible-stable component manifests, including during offline setup.
  * Added an Agent Pantry version compatibility probe that gates doctor/status/expiry-alert behavior.
* **Bug Fixes**
  * Improved manifest-cache handling: online stable repairs missing/corrupt verified cache entries; offline stable and beta remain fail-closed.
  * Compatibility manifest loading tolerates only the intended unpublished component; unknown IDs now fail immediately when compatibility is enabled.
  * “Unhealthy” station health now reports as failed in status output.
* **Documentation**
  * Updated release/manifest validation options to support compatible-stable behavior where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->