### PR TITLE
fix(doctor): treat unspecified harness as unknown, label adapter checks

### DIFF
--- a/src/brigade/doctor.py
+++ b/src/brigade/doctor.py
@@ -26,6 +26,12 @@ FAIL = "FAIL"
 MANUAL = "MANUAL"
 INFO = "INFO"
 DEFAULT_TEXT_CHECK_LIMIT = 50
+ADAPTER_CHECK_PREFIX = "adapter: "
+
+
+def _adapter_check_name(name: str) -> str:
+    """Label Brigade adapter/projection checks distinctly from native harness checks."""
+    return f"{ADAPTER_CHECK_PREFIX}{name}"
 
 
 def build_context(target: Path, harness: str = "generic") -> DoctorContext:
@@ -33,6 +39,7 @@ def build_context(target: Path, harness: str = "generic") -> DoctorContext:
     from .config import load_config
 
     sel = None
+    harnesses: list[str] = []
     try:
         cfg = load_config(target)
     except (ValueError, json.JSONDecodeError):
@@ -41,9 +48,7 @@ def build_context(target: Path, harness: str = "generic") -> DoctorContext:
         sel = cfg.selection
         harnesses = list(sel.harnesses)
     elif harness in ("openclaw", "hermes"):
-        harnesses = ["claude", harness]
-    else:
-        harnesses = ["claude"]
+        harnesses = [harness]
     return DoctorContext(target=target, selection=sel, harnesses=harnesses)
 
 
@@ -232,7 +237,10 @@ def run(target: Path, harness: str = "generic", *, json_output: bool = False, fu
         sel = ctx.selection
         print(f"  harnesses: {', '.join(sel.harnesses) or '(none)'} (owner={sel.owner}, depth={sel.depth})")
     else:
-        print(f"  harnesses: (legacy target, no config; assuming {', '.join(ctx.harnesses)})")
+        if ctx.harnesses:
+            print(f"  harnesses: (legacy target, no config; declared {', '.join(ctx.harnesses)})")
+        else:
+            print("  harnesses: (unspecified; no Brigade config and no explicit --harness)")
     return _report(checks, full=full)
 
 
@@ -363,7 +371,7 @@ def _check_default_wired_skills(target: Path, selected_harnesses: List[str]) -> 
                 missing.append((skill_id, str(rel_file)))
         if not present and not missing:
             continue
-        name = f"skills: {harness} default wired"
+        name = _adapter_check_name(f"skills: {harness} default wired")
         if missing:
             for skill_id, rel_file in missing:
                 results.append(
@@ -427,19 +435,19 @@ def _check_handoff_inboxes(target: Path, sel, selected_harnesses: List[str]) -> 
             continue  # reader harness, no inbox
         inbox = target / rel
         if inbox.is_dir():
-            results.append((OK, f"handoff: {h} inbox", str(inbox)))
+            results.append((OK, _adapter_check_name(f"handoff: {h} inbox"), str(inbox)))
         else:
-            results.append((FAIL, f"handoff: {h} inbox", f"missing at {inbox}"))
+            results.append((FAIL, _adapter_check_name(f"handoff: {h} inbox"), f"missing at {inbox}"))
         tmpl = inbox / "TEMPLATE.md"
         if tmpl.is_file():
-            results.append((OK, f"handoff: {h} TEMPLATE.md", str(tmpl)))
+            results.append((OK, _adapter_check_name(f"handoff: {h} TEMPLATE.md"), str(tmpl)))
         else:
-            results.append((WARN, f"handoff: {h} TEMPLATE.md", f"missing at {tmpl}"))
+            results.append((WARN, _adapter_check_name(f"handoff: {h} TEMPLATE.md"), f"missing at {tmpl}"))
         processed = inbox / "processed"
         if processed.is_dir():
-            results.append((OK, f"handoff: {h} processed/", str(processed)))
+            results.append((OK, _adapter_check_name(f"handoff: {h} processed/"), str(processed)))
         else:
-            results.append((WARN, f"handoff: {h} processed/", f"missing at {processed}"))
+            results.append((WARN, _adapter_check_name(f"handoff: {h} processed/"), f"missing at {processed}"))
     cards = target / "memory" / "cards"
     if cards.is_dir():
         card_count = len([path for path in cards.rglob("*.md") if path.is_file()])
@@ -569,7 +577,7 @@ def _check_orphan_inboxes(target: Path, selected_harnesses: List[str]) -> List[C
             results.append(
                 (
                     WARN,
-                    f"orphan: {h} inbox",
+                    _adapter_check_name(f"orphan: {h} inbox"),
                     f"{inbox} exists but {h} is not in config; remove or add to config (unselected harness)",
                 )
             )

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -619,9 +619,11 @@ def test_doctor_checks_codex_inbox_when_selected(tmp_target: Path, capsys):
     # or on check ordering, which the managed-tool additions can shift.
     doctor_mod.run(tmp_target, json_output=True)
     payload = json.loads(capsys.readouterr().out)
-    inbox_checks = {check["name"]: check for check in payload["checks"] if check["name"].startswith("handoff: codex")}
-    assert "handoff: codex inbox" in inbox_checks
-    codex_inbox = inbox_checks["handoff: codex inbox"]
+    inbox_checks = {
+        check["name"]: check for check in payload["checks"] if check["name"].startswith("adapter: handoff: codex")
+    }
+    assert "adapter: handoff: codex inbox" in inbox_checks
+    codex_inbox = inbox_checks["adapter: handoff: codex inbox"]
     assert codex_inbox["status"] == doctor_mod.OK
     assert ".codex/memory-handoffs" in codex_inbox["detail"]
 
@@ -641,10 +643,10 @@ def test_doctor_reports_default_wired_skills_for_selected_harnesses(tmp_target: 
     checks = {item["name"]: item for item in payload["checks"]}
 
     assert rc == 0
-    assert checks["skills: claude default wired"]["status"] == "OK"
-    assert "brigade-work" in checks["skills: claude default wired"]["detail"]
-    assert checks["skills: codex default wired"]["status"] == "OK"
-    assert ".codex/skills" in checks["skills: codex default wired"]["detail"]
+    assert checks["adapter: skills: claude default wired"]["status"] == "OK"
+    assert "brigade-work" in checks["adapter: skills: claude default wired"]["detail"]
+    assert checks["adapter: skills: codex default wired"]["status"] == "OK"
+    assert ".codex/skills" in checks["adapter: skills: codex default wired"]["detail"]
 
 
 def test_doctor_warns_when_default_wired_skill_is_missing(tmp_target: Path, capsys):
@@ -661,7 +663,7 @@ def test_doctor_warns_when_default_wired_skill_is_missing(tmp_target: Path, caps
     rc = doctor_mod.run(tmp_target, json_output=True)
     payload = json.loads(capsys.readouterr().out)
     checks = {item["name"]: item for item in payload["checks"]}
-    skill_check = checks["skills: codex default wired: ultra-work-scout"]
+    skill_check = checks["adapter: skills: codex default wired: ultra-work-scout"]
 
     assert rc == 0
     assert skill_check["status"] == "WARN"
@@ -711,6 +713,72 @@ def test_doctor_falls_back_to_v0_2_behavior_when_no_config(tmp_target: Path, cap
     doctor_mod.run(tmp_target)
     out = capsys.readouterr().out
     assert "doctor" in out
+
+
+def test_build_context_unspecified_harness_without_config(tmp_target: Path, capsys):
+    """Unconfigured targets must not inherit Claude harness checks by default."""
+    tmp_target.mkdir()
+    (tmp_target / "AGENTS.md").write_text("# Agents")
+
+    ctx = doctor_mod.build_context(tmp_target)
+    assert ctx.harnesses == []
+    assert ctx.selection is None
+
+    doctor_mod.run(target=tmp_target, harness="generic", json_output=True)
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["harnesses"] == []
+
+    names = {check["name"] for check in payload["checks"]}
+    assert "claude work loop" not in names
+    assert not any(name.startswith("adapter: handoff:") for name in names)
+    assert not any(name.startswith("adapter: skills:") for name in names)
+
+    capsys.readouterr()
+    doctor_mod.run(target=tmp_target, harness="generic")
+    out = capsys.readouterr().out
+    assert "unspecified" in out.lower()
+    assert "assuming claude" not in out.lower()
+
+
+def test_build_context_claude_declared_labels_adapter_checks(tmp_target: Path, capsys):
+    """Explicit Claude selection keeps native checks and labels adapter projections."""
+    install_selection(
+        tmp_target,
+        Selection(depth="repo", harnesses=["claude"], owner="claude", includes=[]),
+    )
+    capsys.readouterr()
+
+    ctx = doctor_mod.build_context(tmp_target)
+    assert ctx.harnesses == ["claude"]
+
+    doctor_mod.run(target=tmp_target, json_output=True)
+    payload = json.loads(capsys.readouterr().out)
+    names = {check["name"] for check in payload["checks"]}
+
+    assert "adapter: handoff: claude inbox" in names
+    assert "adapter: skills: claude default wired" in names
+    assert not any(name.startswith("adapter: handoff: codex") for name in names)
+
+
+def test_build_context_non_claude_harness_labels_adapter_checks_only(tmp_target: Path, capsys):
+    """Non-Claude harness selection must not run Claude-native doctor checks."""
+    install_selection(
+        tmp_target,
+        Selection(depth="repo", harnesses=["codex"], owner="codex", includes=[]),
+    )
+    capsys.readouterr()
+
+    ctx = doctor_mod.build_context(tmp_target)
+    assert ctx.harnesses == ["codex"]
+
+    doctor_mod.run(target=tmp_target, json_output=True)
+    payload = json.loads(capsys.readouterr().out)
+    names = {check["name"] for check in payload["checks"]}
+
+    assert "claude work loop" not in names
+    assert "adapter: handoff: codex inbox" in names
+    assert "adapter: skills: codex default wired" in names
+    assert not any(name.startswith("adapter: handoff: claude") for name in names)
 
 
 def test_doctor_includes_embedded_content_guard_without_external_binary(monkeypatch, tmp_target, capsys):


### PR DESCRIPTION
## Summary

Fixes #346 (follow-up to #258).

- `build_context` no longer defaults an unconfigured target to Claude; unspecified harness is `harnesses = []`.
- `--harness openclaw` / `hermes` without Brigade config declares only that harness (no implicit Claude).
- Doctor prefixes Brigade projection checks (`handoff:`, `skills:`, `orphan:`) with `adapter:` so they read distinctly from native harness checks like `claude work loop`.
- Adds three focused tests for unspecified, Claude-declared, and Codex-only contexts.

## Test plan

- [x] `brigade work verify run --target . --command "pytest -q tests/test_doctor.py" --capture brigade-work`
- [x] `brigade work verify run --target . --command "./scripts/verify" --capture brigade-work`

Closes #346

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `brigade doctor` now clearly distinguishes adapter-derived checks in its output by using an adapter-aware name prefix for skills and handoff-related checks.
  * JSON check names for adapter/projection scenarios now reflect the adapter context for easier troubleshooting.

* **Bug Fixes**
  * Updated harness context behavior: missing/unspecified harness configuration no longer yields unintended Claude-native checks.
  * Legacy handling for single-harness targets (e.g., OpenClaw/Hermes) prevents unexpected automatic fallback.
  * Harness selection now shows only the relevant adapter checks and avoids mixing unrelated native checks.

* **Tests**
  * Expanded coverage to validate the new naming convention and harness-selection matrix behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->