### PR TITLE
fix(harness): keep claude prompt out of variadic --disallowedTools

### DIFF
--- a/src/brigade/agents.py
+++ b/src/brigade/agents.py
@@ -127,6 +127,10 @@ def _claude_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | 
         # 2. `--disallowedTools` removes the built-in mutating tools and every
         #    MCP/plugin tool (`mcp__*`) from the model's context (a hard deny),
         #    so read-only is not a prompt-only claim.
+        # `--disallowedTools` is variadic: it greedily consumes every following
+        # non-flag argv element and splits each on whitespace, so a bare prompt
+        # placed right after it is shredded into deny rules (#446). The `--`
+        # end-of-options separator stops option parsing before the prompt.
         return [
             "claude",
             "-p",
@@ -134,6 +138,7 @@ def _claude_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | 
             "plan",
             "--disallowedTools",
             _CLAUDE_DISALLOWED_READ_ONLY,
+            "--",
             prompt,
         ]
     if sandbox == "workspace-write":
@@ -141,13 +146,16 @@ def _claude_argv(prompt: str, read_only: bool, sandbox: str | None, cwd: Path | 
     if sandbox == "danger-full-access":
         # Explicit full-access request: headless `-p` would stall on a permission
         # prompt without --dangerously-skip-permissions; the deny list still
-        # removes subagent spawning so the worker cannot delegate.
+        # removes subagent spawning so the worker cannot delegate. The variadic
+        # `--disallowedTools` would otherwise consume the trailing prompt as
+        # deny values (#446), so `--` ends option parsing first.
         return [
             "claude",
             "-p",
             "--dangerously-skip-permissions",
             "--disallowedTools",
             _CLAUDE_DISALLOWED_ALWAYS,
+            "--",
             prompt,
         ]
     # sandbox is None: refuse to guess between stalling and granting full access.

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -60,6 +60,7 @@ def test_build_argv_for_read_only_codex():
         "plan",
         "--disallowedTools",
         "Task,Agent,Bash,Edit,Write,NotebookEdit,mcp__*",
+        "--",
         "hi",
     ]
     assert agents.build_argv("opencode", "hi", read_only=True) == ["opencode", "run", "hi"]
@@ -124,6 +125,7 @@ def test_claude_read_only_disallows_mutating_tools_and_subagents():
         "plan",
         "--disallowedTools",
         "Task,Agent,Bash,Edit,Write,NotebookEdit,mcp__*",
+        "--",
         "inspect it",
     ]
 
@@ -136,6 +138,7 @@ def test_claude_read_only_sandbox_variant_matches_read_only_flag():
         "plan",
         "--disallowedTools",
         "Task,Agent,Bash,Edit,Write,NotebookEdit,mcp__*",
+        "--",
         "inspect it",
     ]
 
@@ -152,11 +155,48 @@ def test_claude_write_run_uses_skip_permissions_and_disallows_subagents():
         "--dangerously-skip-permissions",
         "--disallowedTools",
         "Task,Agent",
+        "--",
         "implement it",
     ]
     assert agents.build_argv("claude", "implement it", sandbox="danger-full-access") == expected
     with pytest.raises(ValueError, match="explicit sandbox"):
         agents.build_argv("claude", "implement it")
+
+
+def test_claude_read_only_prompt_is_not_consumed_by_disallowed_tools():
+    # Regression for #446: `--disallowedTools` is variadic and greedily consumes
+    # every following non-flag argv element, splitting each on whitespace, so a
+    # multi-word prompt placed right after the deny list was shredded into deny
+    # rules ("##", "Code", "graph", ...). The `--` end-of-options separator must
+    # sit between the deny list and the prompt so the prompt survives intact.
+    prompt = "## Code graph of src/brigade/router.py"
+    argv = agents.build_argv("claude", prompt, read_only=True)
+
+    # The prompt survives intact as the final positional.
+    assert argv[-1] == prompt
+    # The deny list is a single unsplit argument equal to the constant.
+    disallowed_index = argv.index("--disallowedTools")
+    assert argv[disallowed_index + 1] == agents._CLAUDE_DISALLOWED_READ_ONLY
+    # Ordering invariant: `--` separates the variadic deny list from the prompt,
+    # so nothing else (including any prompt word) can leak into deny values.
+    assert argv[disallowed_index + 2] == "--"
+    assert argv[disallowed_index + 1 : argv.index("--")] == [agents._CLAUDE_DISALLOWED_READ_ONLY]
+    # Read-only enforcement stays intact.
+    assert argv[argv.index("--permission-mode") + 1] == "plan"
+
+
+def test_claude_danger_full_access_prompt_is_not_consumed_by_disallowed_tools():
+    # Regression for #446, danger-full-access branch: same variadic
+    # `--disallowedTools` pitfall, same `--` separator guarantee.
+    prompt = "## Code graph of src/brigade/router.py"
+    argv = agents.build_argv("claude", prompt, sandbox="danger-full-access")
+
+    assert argv[-1] == prompt
+    disallowed_index = argv.index("--disallowedTools")
+    assert argv[disallowed_index + 1] == agents._CLAUDE_DISALLOWED_ALWAYS
+    assert argv[disallowed_index + 2] == "--"
+    assert argv[disallowed_index + 1 : argv.index("--")] == [agents._CLAUDE_DISALLOWED_ALWAYS]
+    assert "--dangerously-skip-permissions" in argv
 
 
 def test_claude_workspace_write_rejected_before_launch():
@@ -419,6 +459,7 @@ def test_build_argv_pins_model_for_claude_and_codex():
         "--dangerously-skip-permissions",
         "--disallowedTools",
         "Task,Agent",
+        "--",
         "hi",
     ]
     assert agents.build_argv("codex", "hi", model="gpt-5.5-codex") == [
@@ -455,6 +496,7 @@ def test_build_argv_without_model_is_unchanged():
         "--dangerously-skip-permissions",
         "--disallowedTools",
         "Task,Agent",
+        "--",
         "hi",
     ]
     assert agents.build_argv("codex", "hi", model=None) == ["codex", "exec", "-"]
@@ -849,6 +891,7 @@ def test_run_agent_forwards_model_to_argv(monkeypatch):
         "--dangerously-skip-permissions",
         "--disallowedTools",
         "Task,Agent",
+        "--",
         "hi",
     ]
 

--- a/tests/test_agents_model_pin.py
+++ b/tests/test_agents_model_pin.py
@@ -152,6 +152,7 @@ def test_claude_and_codex_argv_unchanged_by_registry():
         "--dangerously-skip-permissions",
         "--disallowedTools",
         "Task,Agent",
+        "--",
         "P",
     ]
     assert agents.build_argv("codex", "P", model="gpt-5.5-codex") == [


### PR DESCRIPTION
Fixes #446

## Root cause

`_claude_argv` placed the positional prompt immediately after the variadic `--disallowedTools <value>`. Claude Code's `--disallowedTools` greedily consumes every following non-flag argv element and splits each on whitespace, so a plan prompt like `## Code graph ...` was shredded into deny rules:

```
Permission deny rule "##" matches no known tool — check for typos.
Permission deny rule "Code" matches no known tool — check for typos.
Error: Input must be provided either through stdin or as a prompt argument when using --print
```

Reproduced on the exact reported stack (Brigade 0.25.1, Claude Code 2.1.217).

## Fix form: `--` separator (not the reorder fallback)

Both `_claude_argv` branches (read-only and danger-full-access) now insert a `--` end-of-options separator between the deny list and the prompt:

```
claude -p --permission-mode plan --disallowedTools Task,Agent,Bash,Edit,Write,NotebookEdit,mcp__* -- <prompt>
claude -p --dangerously-skip-permissions --disallowedTools Task,Agent -- <prompt>
```

Why `--` over reordering: verified empirically against Claude Code 2.1.217 (commander-based CLI) that option parsing stops at `--` — the deny list stays a single unsplit argument and the prompt survives intact as the final positional. Confirmed on both branches using a bogus `ANTHROPIC_API_KEY` so the run fails fast at auth after parsing (no tokens spent): zero deny-rule errors with `--`, full reproduction without it.

The deny list contents (`_CLAUDE_DISALLOWED_READ_ONLY` / `_CLAUDE_DISALLOWED_ALWAYS`) and `--permission-mode plan` enforcement are unchanged. Only `_claude_argv` was touched; no other adapter.

## Tests

- New: `test_claude_read_only_prompt_is_not_consumed_by_disallowed_tools` and `test_claude_danger_full_access_prompt_is_not_consumed_by_disallowed_tools` — build argv from the trigger prompt `## Code graph of src/brigade/router.py`, assert the prompt survives intact as the final positional, the deny list equals its constant unsplit, and `--` sits between them (ordering invariant guards the regression).
- Updated 8 existing exact-argv assertions in `tests/test_agents.py` and `tests/test_agents_model_pin.py` for the new separator.
- All assertions are on the built argv; nothing depends on a real claude binary.

## Verification (brigade-wired)

- `brigade work verify run --target . --command "pytest -q tests/test_agents.py" --capture brigade-work` → completed, exit=0, **156 passed**
- `brigade work verify run --target . --command "./scripts/verify" --capture brigade-work` → completed, exit=0: ruff clean, mypy clean (313 files), version-sync OK, **3882 passed, 3 skipped** (opt-in integration probes), coverage 82.66% (floor 78%)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Claude command execution so prompts are passed correctly when using read-only or full-access modes.
  * Prevented prompt text from being incorrectly interpreted as tool restrictions.
  * Improved handling when selecting or omitting a specific model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->