### PR TITLE
feat(harness): Pi MCP bridge (partial #438)

### DIFF
--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -36,7 +36,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade ingest`: 1 command path(s)
 - `brigade init`: 1 command path(s)
 - `brigade learn` (extras): 13 command path(s)
-- `brigade mcp`: 8 command path(s)
+- `brigade mcp`: 12 command path(s)
 - `brigade memory`: 14 command path(s)
 - `brigade model`: 6 command path(s)
 - `brigade notifications` (extras): 4 command path(s)
@@ -224,6 +224,10 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade mcp import`
 - `brigade mcp init`
 - `brigade mcp list`
+- `brigade mcp pi-bridge call`
+- `brigade mcp pi-bridge discover`
+- `brigade mcp pi-bridge install`
+- `brigade mcp pi-bridge uninstall`
 - `brigade mcp plan`
 - `brigade mcp sync`
 - `brigade mcp verify`

--- a/src/brigade/cli/mcp.py
+++ b/src/brigade/cli/mcp.py
@@ -11,6 +11,12 @@ def _target(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to operate on.")
 
 
+def _write_mode(parser: argparse.ArgumentParser) -> None:
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", action="store_true", help="Preview changes without writing (default).")
+    mode.add_argument("--write", action="store_true", help="Apply the planned changes.")
+
+
 def register(sub: argparse._SubParsersAction) -> None:
     p_mcp = sub.add_parser("mcp", help="Sync one canonical MCP server catalog into each tool's native config.")
     mcp_sub = p_mcp.add_subparsers(dest="mcp_command", metavar="<mcp-command>")
@@ -98,11 +104,59 @@ def register(sub: argparse._SubParsersAction) -> None:
     )
     p_import.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
 
+    p_pi_bridge = mcp_sub.add_parser(
+        "pi-bridge",
+        help="Bridge the canonical MCP catalog into Pi tools (discover, call, install, uninstall).",
+    )
+    pi_bridge_sub = p_pi_bridge.add_subparsers(dest="pi_bridge_command", metavar="<pi-bridge-command>")
+    pi_bridge_sub.required = True
+
+    p_pi_discover = pi_bridge_sub.add_parser("discover", help="List namespaced MCP tools from the canonical catalog.")
+    _target(p_pi_discover)
+    p_pi_discover.add_argument("--timeout", type=float, default=None, help="Per-server timeout in seconds.")
+    p_pi_discover.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+
+    p_pi_call = pi_bridge_sub.add_parser("call", help="Call one namespaced MCP tool.")
+    _target(p_pi_call)
+    p_pi_call.add_argument("--tool", required=True, help="Qualified tool name (server__tool).")
+    p_pi_call.add_argument("--args-json", default="{}", help="JSON object of tool arguments.")
+    p_pi_call.add_argument("--timeout", type=float, default=None, help="Per-call timeout in seconds.")
+    p_pi_call.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+
+    p_pi_install = pi_bridge_sub.add_parser(
+        "install", help="Install the generated Pi extension and catalog projection."
+    )
+    _target(p_pi_install)
+    _write_mode(p_pi_install)
+    p_pi_install.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+
+    p_pi_uninstall = pi_bridge_sub.add_parser("uninstall", help="Remove Brigade-owned Pi MCP bridge artifacts.")
+    _write_mode(p_pi_uninstall)
+    p_pi_uninstall.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+
     p_mcp.set_defaults(func=dispatch)
 
 
 def dispatch(args) -> int:
-    from .. import mcp_cmd
+    from .. import mcp_cmd, pi_mcp_cmd
+
+    if args.mcp_command == "pi-bridge":
+        if args.pi_bridge_command == "discover":
+            return pi_mcp_cmd.discover(target=args.target, timeout=args.timeout, json_output=args.json)
+        if args.pi_bridge_command == "call":
+            return pi_mcp_cmd.call(
+                target=args.target,
+                tool=args.tool,
+                args_json=args.args_json,
+                timeout=args.timeout,
+                json_output=args.json,
+            )
+        if args.pi_bridge_command == "install":
+            return pi_mcp_cmd.install(target=args.target, write=args.write, json_output=args.json)
+        if args.pi_bridge_command == "uninstall":
+            return pi_mcp_cmd.uninstall(write=args.write, json_output=args.json)
+        args._brigade_parser.error(f"unknown pi-bridge command: {args.pi_bridge_command}")
+        return 2
 
     if args.mcp_command == "init":
         return mcp_cmd.init(

--- a/src/brigade/pi_mcp_bridge.py
+++ b/src/brigade/pi_mcp_bridge.py
@@ -1,0 +1,509 @@
+"""Brigade MCP bridge for Pi: tool discovery and calls against the canonical catalog.
+
+Pi has no native MCP client. This module owns MCP initialization, tool discovery,
+tool calls, per-call timeouts, and process cleanup for stdio and HTTP transports
+defined in ``.brigade/mcp.json``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib import error as urlerror
+from urllib import request as urlrequest
+
+from . import mcp_cmd
+from .mcp_adapters import CanonicalServer
+from .mcp_runtime import (
+    MCP_PROTOCOL_VERSION,
+    MAX_HTTP_BODY_BYTES,
+    MAX_STREAM_BYTES,
+    _BoundedStreamReader,
+    _kill_process_group,
+    _read_json_response,
+    _read_one_sse_json_response,
+    _resolve_child_env,
+    _resolve_headers,
+    _rpc_result,
+    _send_json_line,
+    _validate_remote_url,
+)
+from .tools_cmd import HIGH_RISK_COMMAND_PATTERNS
+
+QUALIFIED_SEPARATOR = "__"
+DEFAULT_TIMEOUT_SECONDS = 30.0
+MAX_TIMEOUT_SECONDS = 300.0
+_READLINE_CHUNK_SIZE = 4096
+
+
+class _NoRedirectHandler(urlrequest.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[no-untyped-def]
+        raise urlerror.HTTPError(req.full_url, code, "redirects disabled", headers, fp)
+
+
+@dataclass(frozen=True)
+class QualifiedTool:
+    server: str
+    name: str
+    qualified_name: str
+    description: str
+    input_schema: dict[str, Any]
+
+    def to_public_dict(self) -> dict[str, Any]:
+        return {
+            "server": self.server,
+            "name": self.name,
+            "qualified_name": self.qualified_name,
+            "description": self.description,
+            "input_schema": self.input_schema,
+        }
+
+
+def qualify_tool_name(server_name: str, tool_name: str) -> str:
+    return f"{server_name}{QUALIFIED_SEPARATOR}{tool_name}"
+
+
+def split_qualified_name(qualified_name: str) -> tuple[str, str]:
+    if QUALIFIED_SEPARATOR not in qualified_name:
+        raise ValueError(f"qualified tool name must contain {QUALIFIED_SEPARATOR!r}: {qualified_name!r}")
+    server, tool = qualified_name.split(QUALIFIED_SEPARATOR, 1)
+    if not server or not tool:
+        raise ValueError(f"qualified tool name is invalid: {qualified_name!r}")
+    return server, tool
+
+
+def _normalize_timeout(timeout: float | None, server: CanonicalServer) -> float:
+    if timeout is not None:
+        return min(max(float(timeout), 0.001), MAX_TIMEOUT_SECONDS)
+    if server.timeout is not None:
+        return min(float(server.timeout), MAX_TIMEOUT_SECONDS)
+    return DEFAULT_TIMEOUT_SECONDS
+
+
+def _tool_error(
+    server: CanonicalServer,
+    tool_name: str,
+    *,
+    message: str,
+    failure_class: str,
+) -> dict[str, Any]:
+    return {
+        "error": True,
+        "server": server.name,
+        "tool": tool_name,
+        "qualified_name": qualify_tool_name(server.name, tool_name),
+        "failure_class": failure_class,
+        "message": message,
+    }
+
+
+def _normalize_input_schema(raw: object) -> dict[str, Any]:
+    if isinstance(raw, dict):
+        return raw
+    return {"type": "object", "properties": {}, "additionalProperties": True}
+
+
+def _normalize_tools(server: CanonicalServer, tools: object) -> tuple[list[QualifiedTool], str | None]:
+    if not isinstance(tools, list):
+        return [], "tools/list result missing tools array"
+    qualified: list[QualifiedTool] = []
+    seen: set[str] = set()
+    for item in tools:
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("name") or "").strip()
+        if not name:
+            continue
+        qualified_name = qualify_tool_name(server.name, name)
+        if qualified_name in seen:
+            continue
+        seen.add(qualified_name)
+        qualified.append(
+            QualifiedTool(
+                server=server.name,
+                name=name,
+                qualified_name=qualified_name,
+                description=str(item.get("description") or ""),
+                input_schema=_normalize_input_schema(item.get("inputSchema")),
+            )
+        )
+    return qualified, None
+
+
+def _stdio_messages_for_list() -> list[dict[str, Any]]:
+    return [
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": MCP_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "brigade-pi-bridge", "version": "1"},
+            },
+        },
+        {"jsonrpc": "2.0", "method": "notifications/initialized"},
+        {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+    ]
+
+
+def _stdio_messages_for_call(tool_name: str, arguments: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": MCP_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "brigade-pi-bridge", "version": "1"},
+            },
+        },
+        {"jsonrpc": "2.0", "method": "notifications/initialized"},
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {"name": tool_name, "arguments": arguments},
+        },
+    ]
+
+
+def _read_stdio_responses(
+    reader: _BoundedStreamReader,
+    proc: subprocess.Popen[str],
+    *,
+    timeout: float,
+    expected_ids: set[object],
+) -> tuple[dict[object, dict[str, Any]], str | None]:
+    deadline = time.monotonic() + timeout
+    responses: dict[object, dict[str, Any]] = {}
+
+    def remaining() -> float:
+        return max(0.0, deadline - time.monotonic())
+
+    while remaining() > 0 and len(responses) < len(expected_ids):
+        line, read_error = reader.read_line(remaining())
+        if read_error == "timeout":
+            return responses, "timeout"
+        if reader.overflow:
+            return responses, "output exceeded size limit"
+        if not line:
+            if proc.poll() is not None:
+                break
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            return responses, "invalid JSON response"
+        if not isinstance(payload, dict):
+            return responses, "response was not a JSON object"
+        request_id = payload.get("id")
+        if request_id in expected_ids and ("result" in payload or "error" in payload):
+            responses[request_id] = payload
+    missing = expected_ids - set(responses)
+    if missing:
+        first_missing = next(iter(missing))
+        return responses, f"missing JSON-RPC response for id={first_missing}"
+    return responses, None
+
+
+def _exchange_stdio(
+    server: CanonicalServer,
+    messages: list[dict[str, Any]],
+    *,
+    timeout: float,
+) -> tuple[dict[object, dict[str, Any]], str | None]:
+    if not server.command:
+        return {}, "stdio server is missing a command"
+    argv = [server.command, *server.args]
+    joined_argv = " ".join(argv)
+    if any(pattern.search(joined_argv) for pattern in HIGH_RISK_COMMAND_PATTERNS):
+        return {}, "command shape is high risk"
+    try:
+        proc = subprocess.Popen(
+            argv,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=_resolve_child_env(server),
+            shell=False,
+            text=True,
+            start_new_session=True,
+        )
+    except OSError:
+        return {}, "failed to start server process"
+    assert proc.stdout is not None
+    assert proc.stderr is not None
+    try:
+        pgid = os.getpgid(proc.pid)
+    except OSError:
+        pgid = None
+    reader = _BoundedStreamReader(proc.stdout, limit=MAX_STREAM_BYTES)
+    stderr_reader = _BoundedStreamReader(proc.stderr, limit=MAX_STREAM_BYTES)
+    expected_ids = {message["id"] for message in messages if "id" in message}
+    try:
+        for message in messages:
+            _send_json_line(proc, message)
+    except OSError:
+        return {}, "failed to communicate with server process"
+    try:
+        responses, error = _read_stdio_responses(reader, proc, timeout=timeout, expected_ids=expected_ids)
+        if stderr_reader.overflow:
+            return responses, error or "output exceeded size limit"
+        return responses, error
+    finally:
+        _kill_process_group(proc, pgid=pgid)
+
+
+def _exchange_http(
+    server: CanonicalServer,
+    messages: list[dict[str, Any]],
+    *,
+    timeout: float,
+) -> tuple[dict[object, dict[str, Any]], str | None]:
+    if not server.url:
+        return {}, "remote server is missing a URL"
+    url = server.url
+    url_error = _validate_remote_url(url)
+    if url_error:
+        return {}, url_error
+    opener = urlrequest.build_opener(_NoRedirectHandler())
+    headers = {"Content-Type": "application/json", "Accept": "application/json, text/event-stream"}
+    headers.update(_resolve_headers(server))
+    session_holder: dict[str, str | None] = {"id": None}
+    deadline = time.monotonic() + timeout
+    responses: dict[object, dict[str, Any]] = {}
+
+    def remaining() -> float:
+        return max(0.0, deadline - time.monotonic())
+
+    def post(message: dict[str, Any]) -> tuple[dict[str, Any] | None, str | None]:
+        req_timeout = remaining()
+        if req_timeout <= 0:
+            return None, "timeout"
+        body = json.dumps(message).encode("utf-8")
+        if len(body) > MAX_HTTP_BODY_BYTES:
+            return None, "request exceeded size limit"
+        req_headers = dict(headers)
+        if session_holder["id"]:
+            req_headers["Mcp-Session-Id"] = session_holder["id"]
+        try:
+            req = urlrequest.Request(url, data=body, headers=req_headers, method="POST")
+            with opener.open(req, timeout=req_timeout) as resp:
+                session_holder["id"] = resp.headers.get("Mcp-Session-Id") or session_holder["id"]
+                content_type = resp.headers.get("Content-Type", "").lower()
+                if "text/event-stream" in content_type:
+                    payload, parse_error = _read_one_sse_json_response(
+                        resp,
+                        deadline=deadline,
+                        expected_id=message.get("id"),
+                    )
+                else:
+                    raw = resp.read(MAX_HTTP_BODY_BYTES + 1)
+                    payload, parse_error = _read_json_response(raw)
+                return payload, parse_error
+        except urlerror.HTTPError as exc:
+            if exc.code in (301, 302, 303, 307, 308):
+                return None, "redirects are disabled"
+            return None, "HTTP request failed"
+        except urlerror.URLError as exc:
+            reason = getattr(exc, "reason", exc)
+            if isinstance(reason, (TimeoutError, OSError)):
+                return None, "timeout"
+            return None, "connection failed"
+        except (TimeoutError, OSError):
+            return None, "timeout"
+        except ValueError:
+            return None, "invalid HTTP request"
+
+    for message in messages:
+        if message.get("method", "").startswith("notifications/"):
+            _, notify_error = post(message)
+            if notify_error in {"timeout", "connection failed"}:
+                return responses, notify_error
+            continue
+        payload, post_error = post(message)
+        if post_error:
+            return responses, post_error
+        if payload is None:
+            return responses, "missing JSON-RPC response"
+        request_id = message.get("id")
+        if request_id is not None:
+            responses[request_id] = payload
+    return responses, None
+
+
+def _exchange(
+    server: CanonicalServer,
+    messages: list[dict[str, Any]],
+    *,
+    timeout: float,
+) -> tuple[dict[object, dict[str, Any]], str | None]:
+    if server.is_remote:
+        return _exchange_http(server, messages, timeout=timeout)
+    return _exchange_stdio(server, messages, timeout=timeout)
+
+
+def enabled_servers(target: Path) -> tuple[dict[str, CanonicalServer], list[str]]:
+    servers, errors, _warnings = mcp_cmd.load_canonical(target)
+    if errors:
+        return {}, errors
+    return {name: server for name, server in servers.items() if server.enabled}, []
+
+
+def list_server_tools(
+    server: CanonicalServer,
+    *,
+    timeout: float | None = None,
+) -> tuple[list[QualifiedTool], dict[str, Any] | None]:
+    effective_timeout = _normalize_timeout(timeout, server)
+    responses, error = _exchange(server, _stdio_messages_for_list(), timeout=effective_timeout)
+    if error:
+        return [], _tool_error(server, "", message=error, failure_class="protocol_failure")
+    init_payload = responses.get(1)
+    init_result, init_error = _rpc_result(init_payload or {})
+    if init_error or init_result is None:
+        return [], _tool_error(
+            server,
+            "",
+            message=init_error or "initialize failed",
+            failure_class="protocol_failure",
+        )
+    tools_payload = responses.get(2)
+    tools_result, tools_error = _rpc_result(tools_payload or {})
+    if tools_error or tools_result is None:
+        return [], _tool_error(
+            server,
+            "",
+            message=tools_error or "tools/list failed",
+            failure_class="protocol_failure",
+        )
+    tools, normalize_error = _normalize_tools(server, tools_result.get("tools"))
+    if normalize_error:
+        return [], _tool_error(server, "", message=normalize_error, failure_class="protocol_failure")
+    return tools, None
+
+
+def call_server_tool(
+    server: CanonicalServer,
+    tool_name: str,
+    arguments: dict[str, Any],
+    *,
+    timeout: float | None = None,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    effective_timeout = _normalize_timeout(timeout, server)
+    responses, error = _exchange(
+        server,
+        _stdio_messages_for_call(tool_name, arguments),
+        timeout=effective_timeout,
+    )
+    if error:
+        return None, _tool_error(server, tool_name, message=error, failure_class="protocol_failure")
+    call_payload = responses.get(3)
+    if not call_payload:
+        return None, _tool_error(
+            server,
+            tool_name,
+            message="missing tools/call response",
+            failure_class="protocol_failure",
+        )
+    if call_payload.get("error"):
+        error_obj = call_payload.get("error")
+        message = error_obj.get("message") if isinstance(error_obj, dict) else str(error_obj)
+        return None, _tool_error(
+            server,
+            tool_name,
+            message=str(message or "JSON-RPC error response"),
+            failure_class="tool_failure",
+        )
+    result = call_payload.get("result")
+    if not isinstance(result, dict):
+        return None, _tool_error(
+            server,
+            tool_name,
+            message="missing JSON-RPC result object",
+            failure_class="protocol_failure",
+        )
+    return result, None
+
+
+def discover_tools(target: Path, *, timeout: float | None = None) -> dict[str, Any]:
+    servers, errors = enabled_servers(target)
+    if errors:
+        return {"target": str(target), "tools": [], "servers": [], "errors": errors}
+    tools: list[QualifiedTool] = []
+    server_reports: list[dict[str, Any]] = []
+    seen_qualified: set[str] = set()
+    for name in sorted(servers):
+        server = servers[name]
+        server_tools, server_error = list_server_tools(server, timeout=timeout)
+        if server_error:
+            server_reports.append({"server": name, "status": "error", "error": server_error})
+            continue
+        collisions = [tool.qualified_name for tool in server_tools if tool.qualified_name in seen_qualified]
+        for tool in server_tools:
+            seen_qualified.add(tool.qualified_name)
+            tools.append(tool)
+        server_reports.append(
+            {
+                "server": name,
+                "status": "ok",
+                "transport": server.transport,
+                "tool_count": len(server_tools),
+                "collisions": collisions,
+            }
+        )
+    tools.sort(key=lambda item: item.qualified_name)
+    return {
+        "target": str(target),
+        "tools": [tool.to_public_dict() for tool in tools],
+        "servers": server_reports,
+        "errors": [],
+    }
+
+
+def call_qualified_tool(
+    target: Path,
+    qualified_name: str,
+    arguments: dict[str, Any],
+    *,
+    timeout: float | None = None,
+) -> dict[str, Any]:
+    try:
+        server_name, tool_name = split_qualified_name(qualified_name)
+    except ValueError as exc:
+        return {
+            "error": True,
+            "qualified_name": qualified_name,
+            "message": str(exc),
+            "failure_class": "invalid_tool",
+        }
+    servers, errors = enabled_servers(target)
+    if errors:
+        return {"error": True, "qualified_name": qualified_name, "message": errors[0], "failure_class": "catalog_error"}
+    server = servers.get(server_name)
+    if server is None:
+        return {
+            "error": True,
+            "server": server_name,
+            "tool": tool_name,
+            "qualified_name": qualified_name,
+            "message": f"unknown MCP server: {server_name}",
+            "failure_class": "unknown_server",
+        }
+    result, error = call_server_tool(server, tool_name, arguments, timeout=timeout)
+    if error:
+        return error
+    return {
+        "error": False,
+        "server": server_name,
+        "tool": tool_name,
+        "qualified_name": qualified_name,
+        "result": result,
+    }

--- a/src/brigade/pi_mcp_cmd.py
+++ b/src/brigade/pi_mcp_cmd.py
@@ -1,0 +1,314 @@
+"""Install, discover, and call MCP tools for Pi through the Brigade bridge."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from . import __version__, localio, mcp_cmd, pi_mcp_bridge
+from .render import emit as _emit
+
+STATE_VERSION = 1
+EXTENSION_REL = "extensions/brigade-mcp-bridge.js"
+CATALOG_PROJECTION_REL = "brigade/catalog-projection.json"
+STATE_REL = "brigade/install-state.json"
+
+
+def _home_dir() -> Path:
+    return Path.home()
+
+
+def _pi_agent_root() -> Path:
+    return _home_dir().expanduser().resolve() / ".pi" / "agent"
+
+
+def _digest_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _digest_value(value: object) -> str:
+    rendered = json.dumps(value, sort_keys=True, separators=(",", ":"))
+    return _digest_text(rendered)
+
+
+def _json_text(payload: object) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def _extension_source() -> str:
+    template = Path(__file__).parent / "templates" / "pi" / "extensions" / "brigade-mcp-bridge.js"
+    return template.read_text()
+
+
+def _catalog_projection(target: Path) -> dict[str, Any]:
+    servers, errors, warnings = mcp_cmd.load_canonical(target)
+    enabled = {name: server for name, server in servers.items() if server.enabled}
+    return {
+        "target": str(target.resolve()),
+        "catalog_fingerprint": _digest_value(
+            {
+                name: {
+                    "transport": server.transport,
+                    "enabled": server.enabled,
+                    "command": server.command,
+                    "args": list(server.args),
+                    "url": server.url,
+                    "timeout": server.timeout,
+                }
+                for name, server in sorted(enabled.items())
+            }
+        ),
+        "servers": [
+            {
+                "name": name,
+                "transport": server.transport,
+                "enabled": server.enabled,
+            }
+            for name, server in sorted(enabled.items())
+        ],
+        "errors": errors,
+        "warnings": warnings,
+    }
+
+
+def _desired_files(root: Path, target: Path) -> dict[Path, tuple[str, str]]:
+    return {
+        root / EXTENSION_REL: (_extension_source(), "extension"),
+        root / CATALOG_PROJECTION_REL: (_json_text(_catalog_projection(target)), "catalog-projection"),
+    }
+
+
+def _state_path(root: Path) -> Path:
+    return root / STATE_REL
+
+
+def _load_state(root: Path) -> dict[str, Any]:
+    path = _state_path(root)
+    empty: dict[str, Any] = {"version": STATE_VERSION, "files": {}}
+    if not path.exists():
+        return empty
+    payload = localio.read_json_dict(path)
+    if payload is None or payload.get("version") != STATE_VERSION or not isinstance(payload.get("files"), dict):
+        empty["_read_error"] = "ownership state is unreadable"
+        return empty
+    return payload
+
+
+def _relative(root: Path, path: Path) -> str:
+    return path.relative_to(root).as_posix()
+
+
+def _file_item(
+    root: Path,
+    path: Path,
+    text: str,
+    surface: str,
+    state: dict[str, Any],
+) -> dict[str, Any]:
+    desired = _digest_text(text)
+    stored = state["files"].get(_relative(root, path))
+    if not path.exists():
+        status, action = "missing", "create"
+    elif not path.is_file():
+        status, action = "conflict", "skip"
+    else:
+        try:
+            live = _digest_text(path.read_text())
+        except (OSError, UnicodeError) as exc:
+            return {
+                "surface": surface,
+                "path": str(path),
+                "status": "conflict",
+                "action": "skip",
+                "detail": str(exc),
+            }
+        if live == desired:
+            status, action = "current", "none"
+        elif stored == live:
+            status, action = "changed", "update"
+        else:
+            status, action = "conflict", "skip"
+    return {
+        "surface": surface,
+        "path": str(path),
+        "status": status,
+        "action": action,
+        "desired_fingerprint": desired,
+    }
+
+
+def _public(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [{key: value for key, value in item.items() if key != "desired_fingerprint"} for item in items]
+
+
+def discover(*, target: Path, timeout: float | None = None, json_output: bool = False) -> int:
+    payload = pi_mcp_bridge.discover_tools(target, timeout=timeout)
+    lines = [f"pi mcp bridge: discovered {len(payload.get('tools', []))} tool(s)"]
+    return _emit(payload, json_output, lines, 0 if not payload.get("errors") else 1)
+
+
+def call(
+    *,
+    target: Path,
+    tool: str,
+    args_json: str,
+    timeout: float | None = None,
+    json_output: bool = False,
+) -> int:
+    try:
+        arguments = json.loads(args_json or "{}")
+    except json.JSONDecodeError as exc:
+        payload = {
+            "error": True,
+            "qualified_name": tool,
+            "message": f"invalid --args-json: {exc.msg}",
+            "failure_class": "invalid_arguments",
+        }
+        return _emit(payload, json_output, [f"error: {payload['message']}"], 2)
+    if not isinstance(arguments, dict):
+        payload = {
+            "error": True,
+            "qualified_name": tool,
+            "message": "--args-json must decode to a JSON object",
+            "failure_class": "invalid_arguments",
+        }
+        return _emit(payload, json_output, [f"error: {payload['message']}"], 2)
+    payload = pi_mcp_bridge.call_qualified_tool(target, tool, arguments, timeout=timeout)
+    lines = [f"pi mcp bridge call: {tool}"]
+    if payload.get("error"):
+        lines.append(f"error: {payload.get('message')}")
+    return _emit(payload, json_output, lines, 1 if payload.get("error") else 0)
+
+
+def install(*, target: Path, write: bool = False, json_output: bool = False) -> int:
+    root = _pi_agent_root()
+    state = _load_state(root)
+    desired_files = _desired_files(root, target)
+    items = [_file_item(root, path, text, surface, state) for path, (text, surface) in desired_files.items()]
+    state_error = state.get("_read_error")
+    if state_error:
+        items.append(
+            {
+                "surface": "ownership-state",
+                "path": str(_state_path(root)),
+                "status": "conflict",
+                "action": "skip",
+                "detail": str(state_error),
+            }
+        )
+    files_written: list[str] = []
+    if write and not state_error:
+        next_state: dict[str, Any] = {
+            "version": STATE_VERSION,
+            "package_version": __version__,
+            "target": str(target.resolve()),
+            "files": {},
+        }
+        for path, (text, _surface) in desired_files.items():
+            item = next(item for item in items if item["path"] == str(path))
+            if item["action"] in {"create", "update"}:
+                localio.write_text_atomic(path, text)
+                files_written.append(str(path))
+            if item["status"] != "conflict":
+                next_state["files"][_relative(root, path)] = item["desired_fingerprint"]
+        state_path = _state_path(root)
+        if next_state != state:
+            localio.write_json(state_path, next_state)
+            files_written.append(str(state_path))
+
+    conflicts = [item for item in items if item["status"] == "conflict"]
+    catalog_errors = _catalog_projection(target).get("errors") or []
+    payload = {
+        "schema_version": 1,
+        "operation": "install",
+        "harness": "pi",
+        "scope": "user",
+        "home": str(_home_dir().expanduser().resolve()),
+        "target": str(target.resolve()),
+        "write": write,
+        "ready": not conflicts and not catalog_errors,
+        "reload_required": bool(write and files_written) or not write,
+        "files_written": files_written,
+        "items": _public(items),
+        "conflicts": _public(conflicts),
+        "catalog_errors": catalog_errors,
+    }
+    return _emit(
+        payload,
+        json_output,
+        [f"pi mcp bridge install: ready={payload['ready']}"],
+        1 if conflicts or catalog_errors else 0,
+    )
+
+
+def uninstall(*, write: bool = False, json_output: bool = False) -> int:
+    root = _pi_agent_root()
+    state = _load_state(root)
+    items: list[dict[str, Any]] = []
+    conflicts: list[dict[str, Any]] = []
+    files_removed: list[str] = []
+    state_error = state.get("_read_error")
+    if state_error:
+        state_item = {
+            "surface": "ownership-state",
+            "path": str(_state_path(root)),
+            "status": "conflict",
+            "action": "preserve",
+            "detail": str(state_error),
+        }
+        items.append(state_item)
+        conflicts.append(state_item)
+
+    for rel, fingerprint in sorted(state.get("files", {}).items()):
+        path = root / rel
+        item = {"surface": "owned-file", "path": str(path)}
+        if not path.exists():
+            item.update(status="absent", action="none")
+        elif path.is_file():
+            try:
+                live_fingerprint = _digest_text(path.read_text())
+            except (OSError, UnicodeError) as exc:
+                item.update(status="conflict", action="preserve", detail=str(exc))
+                conflicts.append(item)
+            else:
+                if live_fingerprint == fingerprint:
+                    item.update(status="managed", action="remove")
+                    if write:
+                        path.unlink()
+                        files_removed.append(str(path))
+                else:
+                    item.update(status="conflict", action="preserve")
+                    conflicts.append(item)
+        else:
+            item.update(status="conflict", action="preserve")
+            conflicts.append(item)
+        items.append(item)
+
+    if write and not conflicts:
+        _state_path(root).unlink(missing_ok=True)
+        for current in (root / "brigade", root / "extensions"):
+            if current.is_dir():
+                try:
+                    current.rmdir()
+                except OSError:
+                    pass
+
+    payload = {
+        "schema_version": 1,
+        "operation": "uninstall",
+        "harness": "pi",
+        "scope": "user",
+        "write": write,
+        "files_removed": files_removed,
+        "items": items,
+        "conflicts": conflicts,
+        "reload_required": bool(write and files_removed),
+    }
+    return _emit(
+        payload,
+        json_output,
+        [f"pi mcp bridge uninstall: removed {len(files_removed)} file(s)"],
+        1 if conflicts else 0,
+    )

--- a/src/brigade/templates/pi/extensions/brigade-mcp-bridge.js
+++ b/src/brigade/templates/pi/extensions/brigade-mcp-bridge.js
@@ -1,0 +1,109 @@
+import { spawnSync } from "node:child_process";
+
+const BRIDGE = ["mcp", "pi-bridge"];
+
+function runBridge(subcommand, target, extraArgs = []) {
+  const result = spawnSync(
+    "brigade",
+    [...BRIDGE, subcommand, "--target", target, "--json", ...extraArgs],
+    {
+      encoding: "utf8",
+      maxBuffer: 16 * 1024 * 1024,
+    },
+  );
+  if (result.error) {
+    throw result.error;
+  }
+  const stdout = (result.stdout || "").trim();
+  if (!stdout) {
+    throw new Error(`brigade ${subcommand} returned no output (exit ${result.status})`);
+  }
+  let payload;
+  try {
+    payload = JSON.parse(stdout);
+  } catch (error) {
+    throw new Error(`brigade ${subcommand} returned invalid JSON: ${error.message}`);
+  }
+  if (result.status !== 0 && !payload.error && !(payload.errors && payload.errors.length)) {
+    throw new Error(`brigade ${subcommand} failed with exit ${result.status}`);
+  }
+  return payload;
+}
+
+function schemaForTool(tool) {
+  const inputSchema = tool.input_schema && typeof tool.input_schema === "object" ? tool.input_schema : {};
+  const properties = inputSchema.properties && typeof inputSchema.properties === "object" ? inputSchema.properties : {};
+  const required = Array.isArray(inputSchema.required) ? inputSchema.required : [];
+  return {
+    type: "object",
+    properties,
+    required,
+    additionalProperties: inputSchema.additionalProperties !== false,
+  };
+}
+
+function registerDiscoveredTools(pi, target) {
+  const payload = runBridge("discover", target);
+  const tools = Array.isArray(payload.tools) ? payload.tools : [];
+  for (const tool of tools) {
+    if (!tool || typeof tool.qualified_name !== "string") {
+      continue;
+    }
+    const qualifiedName = tool.qualified_name;
+    const server = tool.server || qualifiedName.split("__")[0] || "unknown";
+    const nativeName = tool.name || qualifiedName.split("__").slice(1).join("__") || qualifiedName;
+    pi.registerTool({
+      name: qualifiedName,
+      label: qualifiedName,
+      description: tool.description || `MCP tool ${nativeName} from server ${server}`,
+      parameters: schemaForTool(tool),
+      async execute(_toolCallId, params) {
+        const argsJson = JSON.stringify(params || {});
+        const call = runBridge("call", target, ["--tool", qualifiedName, "--args-json", argsJson]);
+        if (call.error) {
+          const message = [
+            `MCP tool failed: ${qualifiedName}`,
+            `server: ${call.server || server}`,
+            `tool: ${call.tool || nativeName}`,
+            call.message || "unknown error",
+          ].join("\n");
+          return {
+            content: [{ type: "text", text: message }],
+            details: {
+              error: true,
+              server: call.server || server,
+              tool: call.tool || nativeName,
+              qualified_name: qualifiedName,
+              failure_class: call.failure_class || "tool_failure",
+            },
+            isError: true,
+          };
+        }
+        const text =
+          typeof call.result === "string"
+            ? call.result
+            : JSON.stringify(call.result ?? {}, null, 2);
+        return {
+          content: [{ type: "text", text }],
+          details: {
+            server: call.server || server,
+            tool: call.tool || nativeName,
+            qualified_name: qualifiedName,
+          },
+        };
+      },
+    });
+  }
+}
+
+export default function brigadeMcpBridge(pi) {
+  pi.on("session_start", async (_event, ctx) => {
+    const target = ctx.cwd || process.cwd();
+    try {
+      registerDiscoveredTools(pi, target);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      ctx.ui.notify(`Brigade MCP bridge failed to load tools: ${message}`, "error");
+    }
+  });
+}

--- a/tests/test_pi_mcp_bridge.py
+++ b/tests/test_pi_mcp_bridge.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+import json
+import sys
+import threading
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+from brigade import cli, mcp_cmd, pi_mcp_bridge, pi_mcp_cmd
+
+
+def _payload(capsys) -> dict:
+    return json.loads(capsys.readouterr().out)
+
+
+def _script(tmp_path: Path, name: str, source: str) -> Path:
+    path = tmp_path / name
+    path.write_text(source)
+    return path
+
+
+def _use_pi_home(monkeypatch, home: Path) -> None:
+    monkeypatch.setattr(pi_mcp_cmd, "_home_dir", lambda: home)
+
+
+DUAL_TOOL_STDIO = """
+import json
+import sys
+
+TOOLS = {
+    "echo": {"name": "echo", "description": "echo fixture", "inputSchema": {"type": "object"}},
+}
+
+for line in sys.stdin:
+    request = json.loads(line)
+    if request.get("id") == 1:
+        print(json.dumps({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "serverInfo": {"name": "fixture", "version": "1"},
+            },
+        }), flush=True)
+    elif request.get("method") == "tools/list":
+        print(json.dumps({
+            "jsonrpc": "2.0",
+            "id": request["id"],
+            "result": {"tools": list(TOOLS.values())},
+        }), flush=True)
+    elif request.get("method") == "tools/call":
+        args = request["params"]["arguments"]
+        print(json.dumps({
+            "jsonrpc": "2.0",
+            "id": request["id"],
+            "result": {
+                "content": [{"type": "text", "text": json.dumps(args)}],
+                "isError": False,
+            },
+        }), flush=True)
+"""
+
+
+FAILING_TOOL_STDIO = """
+import json
+import sys
+
+for line in sys.stdin:
+    request = json.loads(line)
+    if request.get("id") == 1:
+        print(json.dumps({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "serverInfo": {"name": "fixture", "version": "1"},
+            },
+        }), flush=True)
+    elif request.get("method") == "tools/list":
+        print(json.dumps({
+            "jsonrpc": "2.0",
+            "id": request["id"],
+            "result": {"tools": [{"name": "boom", "description": "fails"}]},
+        }), flush=True)
+    elif request.get("method") == "tools/call":
+        print(json.dumps({
+            "jsonrpc": "2.0",
+            "id": request["id"],
+            "error": {"code": -32000, "message": "tool exploded"},
+        }), flush=True)
+"""
+
+
+def _seed_catalog_stdio(target: Path, servers: dict[str, Path]) -> None:
+    mcp_cmd.init(target=target, json_output=True)
+    for name, script in servers.items():
+        mcp_cmd.add(
+            target=target,
+            name=name,
+            command=sys.executable,
+            args=[str(script)],
+            timeout=2,
+            json_output=True,
+        )
+
+
+class _McpHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def do_POST(self) -> None:  # noqa: N802 - stdlib handler API
+        length = int(self.headers.get("Content-Length", "0"))
+        request = json.loads(self.rfile.read(length))
+        if request.get("method") == "notifications/initialized":
+            self.send_response(202)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+        if request.get("method") == "initialize":
+            result = {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "serverInfo": {"name": "http-fixture", "version": "1"},
+            }
+        elif request.get("method") == "tools/call":
+            result = {
+                "content": [{"type": "text", "text": "ok"}],
+                "isError": False,
+            }
+        else:
+            result = {"tools": [{"name": "echo", "description": "http echo"}]}
+        body = json.dumps({"jsonrpc": "2.0", "id": request["id"], "result": result}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Mcp-Session-Id", "fixture-session")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: object) -> None:
+        return
+
+
+@contextmanager
+def _http_mcp_server():
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _McpHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}/mcp"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def test_qualify_tool_name_prevents_cross_server_collisions():
+    assert pi_mcp_bridge.qualify_tool_name("alpha", "echo") == "alpha__echo"
+    assert pi_mcp_bridge.qualify_tool_name("beta", "echo") == "beta__echo"
+    assert pi_mcp_bridge.qualify_tool_name("alpha", "echo") != pi_mcp_bridge.qualify_tool_name("beta", "echo")
+
+
+def test_discover_lists_stdio_and_http_tools_from_catalog(tmp_path, capsys):
+    script = _script(tmp_path, "stdio.py", DUAL_TOOL_STDIO)
+    _seed_catalog_stdio(tmp_path, {"stdio-a": script, "stdio-b": script})
+    with _http_mcp_server() as url:
+        mcp_cmd.add(target=tmp_path, name="remote", transport="http", url=url, timeout=2, json_output=True)
+
+        capsys.readouterr()
+        assert cli.main(["mcp", "pi-bridge", "discover", "--target", str(tmp_path), "--json"]) == 0
+        payload = _payload(capsys)
+
+    names = [tool["qualified_name"] for tool in payload["tools"]]
+    assert names == ["remote__echo", "stdio-a__echo", "stdio-b__echo"]
+    assert {item["transport"] for item in payload["servers"]} == {"http", "stdio"}
+
+
+def test_call_failure_preserves_server_and_tool_identity(tmp_path, capsys):
+    script = _script(tmp_path, "fail.py", FAILING_TOOL_STDIO)
+    _seed_catalog_stdio(tmp_path, {"broken": script})
+
+    capsys.readouterr()
+    assert (
+        cli.main(
+            [
+                "mcp",
+                "pi-bridge",
+                "call",
+                "--target",
+                str(tmp_path),
+                "--tool",
+                "broken__boom",
+                "--args-json",
+                "{}",
+                "--json",
+            ]
+        )
+        == 1
+    )
+    payload = _payload(capsys)
+    assert payload["error"] is True
+    assert payload["server"] == "broken"
+    assert payload["tool"] == "boom"
+    assert payload["qualified_name"] == "broken__boom"
+    assert "tool exploded" in payload["message"]
+
+
+def test_call_success_returns_structured_result(tmp_path, capsys):
+    script = _script(tmp_path, "ok.py", DUAL_TOOL_STDIO)
+    _seed_catalog_stdio(tmp_path, {"local": script})
+
+    capsys.readouterr()
+    assert (
+        cli.main(
+            [
+                "mcp",
+                "pi-bridge",
+                "call",
+                "--target",
+                str(tmp_path),
+                "--tool",
+                "local__echo",
+                "--args-json",
+                '{"value": 1}',
+                "--json",
+            ]
+        )
+        == 0
+    )
+    payload = _payload(capsys)
+    assert payload["error"] is False
+    assert payload["server"] == "local"
+    assert payload["tool"] == "echo"
+    assert payload["result"]["content"][0]["text"] == '{"value": 1}'
+
+
+def test_install_is_idempotent_and_writes_receipt(tmp_path, monkeypatch, capsys):
+    _use_pi_home(monkeypatch, tmp_path)
+    mcp_cmd.init(target=tmp_path, json_output=True)
+
+    capsys.readouterr()
+    assert cli.main(["mcp", "pi-bridge", "install", "--target", str(tmp_path), "--write", "--json"]) == 0
+    first = _payload(capsys)
+    agent = tmp_path / ".pi" / "agent"
+    extension = agent / "extensions" / "brigade-mcp-bridge.js"
+    projection = agent / "brigade" / "catalog-projection.json"
+    state = agent / "brigade" / "install-state.json"
+    assert extension.is_file()
+    assert projection.is_file()
+    assert state.is_file()
+    assert first["ready"] is True
+    assert "node:child_process" in extension.read_text()
+
+    capsys.readouterr()
+    assert cli.main(["mcp", "pi-bridge", "install", "--target", str(tmp_path), "--write", "--json"]) == 0
+    second = _payload(capsys)
+    assert second["files_written"] == []
+    assert all(item["status"] == "current" for item in second["items"])
+
+
+def test_uninstall_removes_only_managed_artifacts(tmp_path, monkeypatch, capsys):
+    _use_pi_home(monkeypatch, tmp_path)
+    mcp_cmd.init(target=tmp_path, json_output=True)
+    agent = tmp_path / ".pi" / "agent"
+    foreign = agent / "extensions" / "foreign.js"
+    foreign.parent.mkdir(parents=True)
+    foreign.write_text("export default function () {}\n")
+
+    assert cli.main(["mcp", "pi-bridge", "install", "--target", str(tmp_path), "--write", "--json"]) == 0
+    capsys.readouterr()
+
+    assert cli.main(["mcp", "pi-bridge", "uninstall", "--write", "--json"]) == 0
+    payload = _payload(capsys)
+    removed = {item["path"] for item in payload["items"] if item.get("action") == "remove"}
+    assert str(agent / "extensions" / "brigade-mcp-bridge.js") in removed
+    assert str(agent / "brigade" / "catalog-projection.json") in removed
+    assert not (agent / "extensions" / "brigade-mcp-bridge.js").exists()
+    assert not (agent / "brigade" / "install-state.json").exists()
+    assert foreign.is_file()
+
+
+def test_uninstall_preserves_user_edited_extension(tmp_path, monkeypatch, capsys):
+    _use_pi_home(monkeypatch, tmp_path)
+    mcp_cmd.init(target=tmp_path, json_output=True)
+    assert cli.main(["mcp", "pi-bridge", "install", "--target", str(tmp_path), "--write", "--json"]) == 0
+    capsys.readouterr()
+
+    extension = tmp_path / ".pi" / "agent" / "extensions" / "brigade-mcp-bridge.js"
+    extension.write_text(extension.read_text() + "\n// user edit\n")
+
+    assert cli.main(["mcp", "pi-bridge", "uninstall", "--write", "--json"]) == 1
+    payload = _payload(capsys)
+    assert payload["conflicts"]
+    assert extension.is_file()
+
+
+def test_extension_generation_uses_node_builtins_only(tmp_path, monkeypatch):
+    _use_pi_home(monkeypatch, tmp_path)
+    mcp_cmd.init(target=tmp_path, json_output=True)
+    assert pi_mcp_cmd.install(target=tmp_path, write=True, json_output=True) == 0
+    text = (tmp_path / ".pi" / "agent" / "extensions" / "brigade-mcp-bridge.js").read_text()
+    assert "node:child_process" in text
+    assert "require(" not in text
+    assert 'from "typebox"' not in text
+    assert "from 'typebox'" not in text


### PR DESCRIPTION
## Summary

- Adds `brigade mcp pi-bridge` with `discover`, `call`, `install`, and `uninstall` subcommands so Pi can use the canonical `.brigade/mcp.json` catalog without a native MCP client.
- Generates a Node-built-ins-only Pi extension at `~/.pi/agent/extensions/brigade-mcp-bridge.js` that registers MCP tools as normal Pi tools via the bridge command.
- Names tools `server__tool` to prevent cross-server collisions; tool failures preserve server and tool identity in returned errors.
- Installs and removes the extension plus catalog projection through the same fingerprint receipt model used by other harness artifacts (`~/.pi/agent/brigade/install-state.json`).

**This is a partial landing for #438.** Issue #438 stays open. This PR does **not** implement `brigade harness sync --scope user`, the shared profile layer, or the other seven harness parity surfaces — those collide with in-flight #344 and remain deferred.

## Test plan

- [x] `brigade work verify run --target . --command "pytest -q tests/test_pi_mcp_bridge.py" --capture brigade-work`
- [x] `brigade work verify run --target . --command "./scripts/verify" --capture brigade-work`
- [x] Stable `server__tool` naming across two stdio servers exposing the same tool name
- [x] Stdio and HTTP transports both sourced from the canonical catalog
- [x] Tool failure preserves server + tool identity in the error payload
- [x] Extension install is idempotent; uninstall removes only Brigade-owned artifacts


Made with [Cursor](https://cursor.com)