### PR TITLE
feat(roster): add shareable presets and fallback resolution

### DIFF
--- a/docs/issue-444-parts-3-4-plan.md
+++ b/docs/issue-444-parts-3-4-plan.md
@@ -1,0 +1,16 @@
+# Issue 444 Parts 3 and 4 Plan
+
+Parts 1 and 2 ship packaged presets plus a pure `resolve_capabilities()` helper. Parts 3 and 4 consume that resolver without changing dispatch behavior in this branch.
+
+## Part 3: Best-of-available assembly command
+
+- Add `brigade roster suggest` (or equivalent) that loads a chosen preset, calls `HostCapabilityProbe` and `resolve_capabilities()`, and prints every `SeatResolution` entry with requested seat, outcome, resolved seat, and reason.
+- Check `result.usable` before emission. When the orchestrator was dropped, print the report and refuse to emit an adoptable roster.
+- Emit the resolved roster TOML (or a concrete path) when the result is usable so operators can adopt the assembled result.
+- Reuse the same report in `brigade roster doctor` to warn when a seat's declared requirements no longer hold on the host.
+
+## Part 4: Evidence-backed stats overlay
+
+- Add `brigade roster stats` that reads worker receipt durations and statuses from `.brigade/runs/`.
+- Compute per-seat medians and failure rates from local evidence.
+- Overlay those stats in suggest/doctor output without mutating the packaged preset files; shipped `stats.source` remains the author default until local receipts override it in rendered output.

--- a/src/brigade/roster.py
+++ b/src/brigade/roster.py
@@ -450,6 +450,13 @@ def load_roster(path: Path, *, resolution: RosterResolution | None = None) -> Ro
                 )
             if agent_name == orchestrator and fallback_agent.transport == "acpx":
                 raise ValueError(f"agents.{agent_name}.fallback cannot alias an acpx worker into the orchestrator slot")
+            if agent_name == orchestrator and (
+                fallback_agent.cli is None or fallback_agent.cli.startswith("codex-cloud:")
+            ):
+                raise ValueError(
+                    f"agents.{agent_name}.fallback cannot alias worker-only seat {fallback_name!r} "
+                    "into the orchestrator slot"
+                )
             if agent_name != orchestrator and fallback_name == orchestrator:
                 raise ValueError(f"agents.{agent_name}.fallback cannot name the orchestrator {orchestrator!r}")
 

--- a/src/brigade/roster.py
+++ b/src/brigade/roster.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import fnmatch
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Literal
+from typing import Literal, Protocol
 
 from . import agents as agent_adapters
 from . import toml_compat
@@ -40,6 +40,11 @@ class Agent:
     env: dict[str, str] | None = None
     invalid_final_fallback: str | None = None
     read_only_capable: bool = True
+    purpose: str | None = None
+    requires: dict[str, str] | None = None
+    fallback: tuple[str, ...] = ()
+    stats: dict[str, str] | None = None
+    caveats: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -55,6 +60,66 @@ class Roster:
 
     def find_role(self, role: str) -> Agent | None:
         return next((a for a in self.agents.values() if a.role == role), None)
+
+
+@dataclass(frozen=True)
+class Capability:
+    installed: bool
+    authenticated: bool | None = None
+    detail: str = ""
+    auth_detail: str = ""
+
+
+class CapabilityProbe(Protocol):
+    def lookup(self, cli_ref: str) -> Capability: ...
+
+
+@dataclass(frozen=True)
+class SeatResolution:
+    requested: str
+    resolved: str | None
+    outcome: Literal["self", "fallback", "dropped"]
+    reason: str
+
+
+@dataclass(frozen=True)
+class RosterCapabilityResolution:
+    roster: Roster
+    report: tuple[SeatResolution, ...]
+
+    @property
+    def usable(self) -> bool:
+        return self.roster.orchestrator in self.roster.agents
+
+
+@dataclass(frozen=True)
+class HostCapabilityProbe:
+    def lookup(self, cli_ref: str) -> Capability:
+        binary = agent_adapters.command_for(cli_ref)
+        installed = agent_adapters.detect(cli_ref)
+        authenticated: bool | None = None
+        detail = ""
+        auth_detail = ""
+        if cli_ref == "cursor" and installed:
+            from . import acpx_adapter
+
+            auth = acpx_adapter.cursor_auth_status()
+            detail = auth.detail
+            auth_detail = auth.detail
+            if auth.state == "authenticated":
+                authenticated = True
+            elif auth.state == "unauthenticated":
+                authenticated = False
+        elif installed:
+            detail = f"{cli_ref} via {binary}"
+        else:
+            detail = f"{cli_ref} needs `{binary}` on PATH"
+        return Capability(
+            installed=installed,
+            authenticated=authenticated,
+            detail=detail,
+            auth_detail=auth_detail,
+        )
 
 
 def _as_str(value: object, field: str) -> str:
@@ -73,6 +138,49 @@ def _as_bool(value: object, field: str) -> bool:
     if not isinstance(value, bool):
         raise ValueError(f"{field} must be a boolean")
     return value
+
+
+def _as_optional_str(value: object, field: str) -> str | None:
+    if value is None:
+        return None
+    return _as_str(value, field)
+
+
+def _as_requires(value: object, agent_name: str) -> dict[str, str] | None:
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise ValueError(f"agents.{agent_name}.requires must be a TOML table")
+    allowed = frozenset({"cli", "auth"})
+    parsed: dict[str, str] = {}
+    for key, raw in value.items():
+        if key not in allowed:
+            raise ValueError(f"agents.{agent_name}.requires keys must be cli and/or auth")
+        parsed[key] = _as_str(raw, f"agents.{agent_name}.requires.{key}")
+    if "auth" in parsed and parsed["auth"] != "logged-in":
+        raise ValueError(f'agents.{agent_name}.requires.auth must be "logged-in"')
+    return parsed or None
+
+
+def _as_stats(value: object, agent_name: str) -> dict[str, str] | None:
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise ValueError(f"agents.{agent_name}.stats must be a TOML table")
+    parsed: dict[str, str] = {}
+    for key, raw in value.items():
+        if not isinstance(key, str) or not key.strip():
+            raise ValueError(f"agents.{agent_name}.stats keys must be non-empty strings")
+        parsed[key.strip()] = _as_str(raw, f"agents.{agent_name}.stats.{key}")
+    return parsed or None
+
+
+def _as_string_list(value: object, field: str) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError(f"{field} must be a list of strings")
+    return tuple(_as_str(item, field) for item in value)
 
 
 def _as_sandbox(value: object) -> str | None:
@@ -260,6 +368,11 @@ def load_roster(path: Path, *, resolution: RosterResolution | None = None) -> Ro
             raw_agent.get("read_only_capable", True),
             f"agents.{agent_name}.read_only_capable",
         )
+        purpose = _as_optional_str(raw_agent.get("purpose"), f"agents.{agent_name}.purpose")
+        requires = _as_requires(raw_agent.get("requires"), agent_name)
+        fallback = _as_string_list(raw_agent.get("fallback"), f"agents.{agent_name}.fallback")
+        stats = _as_stats(raw_agent.get("stats"), agent_name)
+        caveats = _as_string_list(raw_agent.get("caveats"), f"agents.{agent_name}.caveats")
 
         cli_raw = raw_agent.get("cli")
         has_endpoint = endpoint is not None and model is not None
@@ -316,27 +429,54 @@ def load_roster(path: Path, *, resolution: RosterResolution | None = None) -> Ro
             env=env,
             invalid_final_fallback=invalid_final_fallback,
             read_only_capable=read_only_capable,
+            purpose=purpose,
+            requires=requires,
+            fallback=fallback,
+            stats=stats,
+            caveats=caveats,
         )
 
     if orchestrator not in parsed_agents:
         raise ValueError(f"orchestrator {orchestrator!r} is not defined in [agents]")
 
     for agent_name, agent in parsed_agents.items():
-        fallback_name = agent.invalid_final_fallback
-        if fallback_name is None:
+        for fallback_name in agent.fallback:
+            if fallback_name not in parsed_agents:
+                raise ValueError(f"agents.{agent_name}.fallback references {fallback_name!r}, which is not defined")
+            fallback_agent = parsed_agents[fallback_name]
+            if fallback_agent.fallback:
+                raise ValueError(
+                    f"agents.{agent_name}.fallback target {fallback_name!r} must not define its own fallback"
+                )
+            if agent_name == orchestrator and fallback_agent.transport == "acpx":
+                raise ValueError(f"agents.{agent_name}.fallback cannot alias an acpx worker into the orchestrator slot")
+            if agent_name != orchestrator and fallback_name == orchestrator:
+                raise ValueError(f"agents.{agent_name}.fallback cannot name the orchestrator {orchestrator!r}")
+
+    for agent_name, agent in parsed_agents.items():
+        if agent.requires is not None and "cli" in agent.requires:
+            _validate_requires_cli(agent_name, agent)
+
+    for agent_name, agent in parsed_agents.items():
+        invalid_final_name = agent.invalid_final_fallback
+        if invalid_final_name is None:
             continue
         if agent.cli != "grok" or agent.transport != "direct":
             raise ValueError(f"agents.{agent_name}.invalid_final_fallback requires a direct grok seat")
-        fallback = parsed_agents.get(fallback_name)
-        if fallback is None:
+        invalid_final_agent = parsed_agents.get(invalid_final_name)
+        if invalid_final_agent is None:
             raise ValueError(
-                f"agents.{agent_name}.invalid_final_fallback references {fallback_name!r}, which is not defined"
+                f"agents.{agent_name}.invalid_final_fallback references {invalid_final_name!r}, which is not defined"
             )
-        if fallback_name == orchestrator or fallback.cli != "cursor" or fallback.transport != "acpx":
+        if (
+            invalid_final_name == orchestrator
+            or invalid_final_agent.cli != "cursor"
+            or invalid_final_agent.transport != "acpx"
+        ):
             raise ValueError(f"agents.{agent_name}.invalid_final_fallback must name a reviewed cursor-grok acpx seat")
-        if fallback.model is None or not fallback.model.lower().startswith("grok-"):
+        if invalid_final_agent.model is None or not invalid_final_agent.model.lower().startswith("grok-"):
             raise ValueError(f"agents.{agent_name}.invalid_final_fallback target must use a grok model")
-        if fallback.transport_version != ACPX_TRANSPORT_VERSION:
+        if invalid_final_agent.transport_version != ACPX_TRANSPORT_VERSION:
             raise ValueError(
                 f"agents.{agent_name}.invalid_final_fallback target requires reviewed acpx version "
                 f"{ACPX_TRANSPORT_VERSION}"
@@ -362,3 +502,189 @@ def read_only_capability_error(agent: Agent) -> str | None:
     if agent.read_only_capable:
         return None
     return f"worker {agent.name!r} cannot run in read-only mode: agents.{agent.name}.read_only_capable is false"
+
+
+def _seat_adapter_ref(agent: Agent) -> str | None:
+    if agent.cli is None:
+        return None
+    if agent.cli.startswith("ollama:"):
+        return "ollama"
+    if agent.cli.startswith("codex-cloud:"):
+        return "codex"
+    return agent.cli
+
+
+def _validate_requires_cli(agent_name: str, agent: Agent) -> None:
+    required = agent.requires["cli"] if agent.requires is not None else None
+    if required is None:
+        return
+    if agent.cli is None:
+        raise ValueError(f"agents.{agent_name}.requires.cli is not supported on endpoint seats")
+    adapter = _seat_adapter_ref(agent)
+    if adapter != required:
+        raise ValueError(f"agents.{agent_name}.requires.cli must match the seat adapter {adapter!r}, got {required!r}")
+
+
+def _referenced_fallback_names(agents: dict[str, Agent]) -> frozenset[str]:
+    referenced: set[str] = set()
+    for agent in agents.values():
+        referenced.update(agent.fallback)
+    return frozenset(referenced)
+
+
+def _requested_roots(roster: Roster) -> tuple[str, ...]:
+    referenced = _referenced_fallback_names(roster.agents)
+    return tuple(name for name in roster.agents if name == roster.orchestrator or name not in referenced)
+
+
+def _probe_lookup_ref(agent: Agent) -> str | None:
+    if agent.requires is None:
+        return None
+    if "cli" in agent.requires:
+        return agent.requires["cli"]
+    if agent.requires.get("auth") == "logged-in":
+        return agent.cli
+    return None
+
+
+def _requirements_satisfied(agent: Agent, probe: CapabilityProbe) -> tuple[bool, str]:
+    if agent.requires is None:
+        return True, ""
+    lookup_ref = _probe_lookup_ref(agent)
+    if lookup_ref is None:
+        return False, "logged-in auth requires a cli seat"
+    capability = probe.lookup(lookup_ref)
+    reasons: list[str] = []
+    if "cli" in agent.requires:
+        if not capability.installed:
+            reasons.append(capability.detail or f"{lookup_ref} is not installed")
+    if agent.requires.get("auth") == "logged-in" and not reasons:
+        if capability.authenticated is not True:
+            if capability.authenticated is False:
+                reasons.append(capability.auth_detail or capability.detail or f"{lookup_ref} is not authenticated")
+            elif capability.auth_detail:
+                reasons.append(capability.auth_detail)
+            else:
+                reasons.append(f"{lookup_ref} authentication is unknown")
+    return (not reasons, "; ".join(reasons))
+
+
+def _resolved_self_agent(agent: Agent) -> Agent:
+    return replace(agent, fallback=())
+
+
+def _resolved_fallback_agent(requested_agent: Agent, fallback_agent: Agent, requested_name: str) -> Agent:
+    return replace(
+        fallback_agent,
+        name=requested_name,
+        role=requested_agent.role,
+        purpose=requested_agent.purpose,
+        fallback=(),
+    )
+
+
+def _is_reviewed_invalid_final_fallback(agent: Agent) -> bool:
+    return (
+        agent.cli == "cursor"
+        and agent.transport == "acpx"
+        and agent.model is not None
+        and agent.model.lower().startswith("grok-")
+        and agent.transport_version == ACPX_TRANSPORT_VERSION
+    )
+
+
+def _ensure_invalid_final_fallback_deps(
+    roster: Roster,
+    resolved_agents: dict[str, Agent],
+    probe: CapabilityProbe,
+) -> dict[str, Agent]:
+    updated = dict(resolved_agents)
+    for name, agent in list(updated.items()):
+        dep_name = agent.invalid_final_fallback
+        if dep_name is None:
+            continue
+        if dep_name in updated:
+            if not _is_reviewed_invalid_final_fallback(updated[dep_name]):
+                updated[name] = replace(agent, invalid_final_fallback=None)
+            continue
+        dep_agent = roster.agents.get(dep_name)
+        if dep_agent is None:
+            continue
+        dep_ok, _ = _requirements_satisfied(dep_agent, probe)
+        if dep_ok:
+            updated[dep_name] = _resolved_self_agent(dep_agent)
+        else:
+            updated[name] = replace(agent, invalid_final_fallback=None)
+    return updated
+
+
+def resolve_capabilities(
+    roster: Roster,
+    probe: CapabilityProbe | None = None,
+) -> RosterCapabilityResolution:
+    active_probe = probe if probe is not None else HostCapabilityProbe()
+    resolved_agents: dict[str, Agent] = {}
+    report: list[SeatResolution] = []
+
+    for requested_name in _requested_roots(roster):
+        requested_agent = roster.agents[requested_name]
+        satisfied, self_reason = _requirements_satisfied(requested_agent, active_probe)
+        if satisfied:
+            resolved_agents[requested_name] = _resolved_self_agent(requested_agent)
+            report.append(
+                SeatResolution(
+                    requested=requested_name,
+                    resolved=requested_name,
+                    outcome="self",
+                    reason="requirements satisfied",
+                )
+            )
+            continue
+
+        fallback_reasons: list[str] = []
+        selected_fallback: str | None = None
+        for fallback_name in requested_agent.fallback:
+            fallback_agent = roster.agents.get(fallback_name)
+            if fallback_agent is None:
+                fallback_reasons.append(f"{fallback_name} is not defined")
+                continue
+            fallback_ok, fallback_reason = _requirements_satisfied(fallback_agent, active_probe)
+            if fallback_ok:
+                selected_fallback = fallback_name
+                resolved_agents[requested_name] = _resolved_fallback_agent(
+                    requested_agent,
+                    fallback_agent,
+                    requested_name,
+                )
+                reason_parts = [self_reason] if self_reason else []
+                reason_parts.extend(fallback_reasons)
+                reason_parts.append(f"selected fallback {fallback_name}")
+                report.append(
+                    SeatResolution(
+                        requested=requested_name,
+                        resolved=fallback_name,
+                        outcome="fallback",
+                        reason="; ".join(part for part in reason_parts if part),
+                    )
+                )
+                break
+            fallback_reasons.append(f"{fallback_name}: {fallback_reason}")
+
+        if selected_fallback is None:
+            reason_parts = [self_reason] if self_reason else []
+            reason_parts.extend(fallback_reasons)
+            report.append(
+                SeatResolution(
+                    requested=requested_name,
+                    resolved=None,
+                    outcome="dropped",
+                    reason="; ".join(part for part in reason_parts if part),
+                )
+            )
+
+    resolved_agents = _ensure_invalid_final_fallback_deps(roster, resolved_agents, active_probe)
+
+    return RosterCapabilityResolution(
+        roster=replace(roster, agents=resolved_agents),
+        report=tuple(report),
+    )

--- a/src/brigade/roster_cmd.py
+++ b/src/brigade/roster_cmd.py
@@ -9,6 +9,7 @@ from . import agents
 from . import doctor as doctor_mod
 from . import model_inventory
 from . import roster as roster_mod
+from . import templates
 
 DEFAULT_ROSTER_REL = ".brigade/roster.toml"
 
@@ -86,6 +87,11 @@ cli = "codex"
 model = "{review_model}"
 role = "Inspect code and reports, verify claims against the actual diff, and flag problems."
 """
+
+
+def preset_roster_paths() -> tuple[Path, ...]:
+    rosters_dir = templates.template_root() / "rosters"
+    return tuple(sorted(rosters_dir.glob("*.toml")))
 
 
 def init(

--- a/src/brigade/templates/rosters/budget-open-weight.toml
+++ b/src/brigade/templates/rosters/budget-open-weight.toml
@@ -1,0 +1,42 @@
+orchestrator = "chef"
+
+[agents.chef]
+cli = "codex"
+role = "Plan the work and route to affordable workers."
+purpose = "Subscription-backed planner with an open-weight fallback."
+requires = { cli = "codex" }
+fallback = ["chef_oss"]
+stats = { speed = "medium", source = "author-receipts-2026-07" }
+caveats = ["Codex seat drops when the subscription is unavailable."]
+
+[agents.chef_oss]
+cli = "ollama:llama3.2:3b"
+role = "Plan locally with open-weight models."
+purpose = "Local planner when Codex is unavailable."
+requires = { cli = "ollama" }
+fallback = []
+stats = { speed = "slow", source = "author-receipts-2026-07" }
+caveats = ["Requires a pulled ollama model."]
+
+[agents.coder]
+cli = "ollama:llama3.2:3b"
+role = "Implement changes with local open-weight models."
+purpose = "Budget coding seat that prefers local inference."
+requires = { cli = "ollama" }
+fallback = ["coder_codex"]
+stats = { speed = "slow", source = "author-receipts-2026-07" }
+caveats = ["Local latency varies with hardware."]
+
+[agents.coder_codex]
+cli = "codex"
+role = "Implement changes when Codex is available."
+purpose = "Subscription-backed coding fallback."
+requires = { cli = "codex" }
+fallback = []
+stats = { speed = "medium", source = "author-receipts-2026-07" }
+caveats = []
+
+[limits]
+max_workers = 3
+timeout_seconds = 900
+allow_models = ["codex", "ollama:*"]

--- a/src/brigade/templates/rosters/full-multi-lane.toml
+++ b/src/brigade/templates/rosters/full-multi-lane.toml
@@ -1,0 +1,59 @@
+orchestrator = "architect"
+
+[agents.architect]
+cli = "claude"
+model = "claude-opus-4-8"
+role = "Plan the work and route tasks across lanes."
+purpose = "High-context planning seat with Codex fallback."
+requires = { cli = "claude" }
+fallback = ["architect_codex"]
+stats = { speed = "medium", source = "author-receipts-2026-07" }
+caveats = ["Claude is optional on many machines."]
+
+[agents.architect_codex]
+cli = "codex"
+model = "gpt-5.6-terra"
+reasoning = "high"
+role = "Codex planning fallback."
+purpose = "Subscription-backed planner when Claude is unavailable."
+requires = { cli = "codex" }
+fallback = []
+stats = { speed = "medium", source = "author-receipts-2026-07" }
+caveats = []
+
+[agents.builder]
+cli = "cursor"
+model = "composer-2.5"
+transport = "acpx"
+transport_version = "0.12.0"
+role = "Fast implementation lane."
+purpose = "Primary builder using Cursor subscription capacity."
+requires = { cli = "cursor", auth = "logged-in" }
+fallback = ["builder_codex", "builder_oss"]
+stats = { speed = "fast", source = "author-receipts-2026-07" }
+caveats = ["ACP transport is version-pinned."]
+
+[agents.builder_codex]
+cli = "codex"
+model = "gpt-5.6-terra"
+reasoning = "high"
+role = "Codex implementation fallback."
+purpose = "Builder fallback for Codex subscribers."
+requires = { cli = "codex" }
+fallback = []
+stats = { speed = "medium", source = "author-receipts-2026-07" }
+caveats = []
+
+[agents.builder_oss]
+cli = "ollama:llama3.2:3b"
+role = "Local open-weight builder."
+purpose = "Last-resort local implementation seat."
+requires = { cli = "ollama" }
+fallback = []
+stats = { speed = "slow", source = "author-receipts-2026-07" }
+caveats = ["Requires a pulled ollama model."]
+
+[limits]
+max_workers = 4
+timeout_seconds = 900
+allow_models = ["claude", "codex", "cursor", "ollama:*"]

--- a/src/brigade/templates/rosters/minimal-single-cli.toml
+++ b/src/brigade/templates/rosters/minimal-single-cli.toml
@@ -1,0 +1,24 @@
+orchestrator = "chef"
+
+[agents.chef]
+cli = "codex"
+role = "Plan the work, choose useful workers, and synthesize the final answer."
+purpose = "Single-lane orchestration when only Codex is installed."
+requires = { cli = "codex" }
+fallback = []
+stats = { speed = "medium", source = "author-receipts-2026-07" }
+caveats = ["No review lane; quality depends on one model."]
+
+[agents.coder]
+cli = "codex"
+role = "Make precise code changes and report what changed."
+purpose = "Primary implementation seat for Codex-only setups."
+requires = { cli = "codex" }
+fallback = []
+stats = { speed = "medium", source = "author-receipts-2026-07" }
+caveats = []
+
+[limits]
+max_workers = 2
+timeout_seconds = 600
+allow_models = ["codex"]

--- a/src/brigade/templates/rosters/review-heavy.toml
+++ b/src/brigade/templates/rosters/review-heavy.toml
@@ -1,0 +1,59 @@
+orchestrator = "chef"
+
+[agents.chef]
+cli = "codex"
+role = "Plan the work and synthesize reviewed output."
+purpose = "Orchestrator for review-heavy workflows."
+requires = { cli = "codex" }
+fallback = []
+stats = { speed = "medium", source = "author-receipts-2026-07" }
+caveats = []
+
+[agents.reviewer]
+cli = "grok"
+model = "grok-4.5"
+reasoning = "high"
+role = "Inspect code and reports before merge."
+purpose = "Independent review lane with explicit fallbacks."
+requires = { cli = "grok" }
+fallback = ["reviewer_cursor", "reviewer_codex"]
+stats = { speed = "fast", source = "author-receipts-2026-07" }
+caveats = ["Grok review quality varies by task complexity."]
+
+[agents.reviewer_flash]
+cli = "antigravity"
+model = "Gemini 3.5 Flash (Low)"
+role = "Fast non-security review and summary lane."
+purpose = "Low-cost review and summary when premium lanes are saturated."
+requires = { cli = "antigravity" }
+fallback = []
+stats = { speed = "fast", source = "author-receipts-2026-07" }
+caveats = ["Refuses security-audit work; use grok or codex lanes for security review."]
+
+[agents.reviewer_cursor]
+cli = "cursor"
+model = "grok-4.5"
+transport = "acpx"
+transport_version = "0.12.0"
+role = "ACP-backed review fallback."
+purpose = "Review through Cursor when the Grok CLI is unavailable."
+requires = { cli = "cursor", auth = "logged-in" }
+fallback = []
+stats = { speed = "fast", source = "author-receipts-2026-07" }
+caveats = ["Requires cursor-agent login."]
+
+[agents.reviewer_codex]
+cli = "codex"
+model = "gpt-5.6-terra"
+reasoning = "high"
+role = "Codex review fallback."
+purpose = "Same-vendor review when premium lanes are unavailable."
+requires = { cli = "codex" }
+fallback = []
+stats = { speed = "medium", source = "author-receipts-2026-07" }
+caveats = []
+
+[limits]
+max_workers = 3
+timeout_seconds = 900
+allow_models = ["codex", "grok", "cursor", "antigravity"]

--- a/tests/test_roster.py
+++ b/tests/test_roster.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 
+from brigade import agents
 from brigade import cli
 from brigade import roster as roster_mod
 
@@ -605,3 +606,689 @@ def test_grok_invalid_final_fallback_names_reviewed_acpx_seat(tmp_path):
 def test_grok_invalid_final_fallback_rejects_unreviewed_routes(tmp_path, roster_text, match):
     with pytest.raises(ValueError, match=match):
         roster_mod.load_roster(_write(tmp_path, roster_text))
+
+
+METADATA_ROSTER = """
+orchestrator = "chef"
+
+[agents.chef]
+cli = "codex"
+role = "plan"
+purpose = "Orchestrate the run."
+requires = { cli = "codex" }
+fallback = ["coder"]
+stats = { speed = "fast", source = "author-receipts-2026-07" }
+caveats = ["Needs a Codex subscription."]
+
+[agents.coder]
+cli = "ollama:llama3.2:3b"
+role = "build"
+purpose = "Fallback builder."
+requires = { cli = "ollama" }
+stats = { speed = "slow", source = "author-receipts-2026-07" }
+caveats = []
+"""
+
+
+def test_legacy_roster_gets_empty_metadata_defaults(tmp_path):
+    loaded = roster_mod.load_roster(_write(tmp_path, VALID))
+
+    agent = loaded.agents["chef"]
+    assert agent.purpose is None
+    assert agent.requires is None
+    assert agent.fallback == ()
+    assert agent.stats is None
+    assert agent.caveats == ()
+
+
+def test_metadata_roster_parses_preset_fields(tmp_path):
+    loaded = roster_mod.load_roster(_write(tmp_path, METADATA_ROSTER))
+    chef = loaded.agents["chef"]
+
+    assert chef.purpose == "Orchestrate the run."
+    assert chef.requires == {"cli": "codex"}
+    assert chef.fallback == ("coder",)
+    assert chef.stats == {"speed": "fast", "source": "author-receipts-2026-07"}
+    assert chef.caveats == ("Needs a Codex subscription.",)
+
+
+def test_metadata_roster_rejects_unknown_requirement_keys(tmp_path):
+    invalid = METADATA_ROSTER.replace('requires = { cli = "codex" }', 'requires = { cli = "codex", lane = "fast" }')
+    with pytest.raises(ValueError, match=r"agents\.chef\.requires"):
+        roster_mod.load_roster(_write(tmp_path, invalid))
+
+
+def test_metadata_roster_rejects_unknown_auth_requirement(tmp_path):
+    invalid = METADATA_ROSTER.replace(
+        'requires = { cli = "codex" }',
+        'requires = { cli = "codex", auth = "api-key" }',
+    )
+    with pytest.raises(ValueError, match=r'auth must be "logged-in"'):
+        roster_mod.load_roster(_write(tmp_path, invalid))
+
+
+def test_metadata_roster_rejects_missing_fallback_target(tmp_path):
+    invalid = METADATA_ROSTER.replace('fallback = ["coder"]', 'fallback = ["missing"]')
+    with pytest.raises(ValueError, match="missing"):
+        roster_mod.load_roster(_write(tmp_path, invalid))
+
+
+def test_metadata_roster_rejects_fallback_cycle(tmp_path):
+    invalid = METADATA_ROSTER.replace(
+        'requires = { cli = "ollama" }\nstats',
+        'requires = { cli = "ollama" }\nfallback = ["coder"]\nstats',
+    )
+
+    with pytest.raises(ValueError, match="must not define its own fallback"):
+        roster_mod.load_roster(_write(tmp_path, invalid))
+
+
+def test_metadata_roster_rejects_nested_fallback_chain(tmp_path):
+    invalid = METADATA_ROSTER.replace(
+        'requires = { cli = "ollama" }\nstats',
+        'requires = { cli = "ollama" }\nfallback = ["local"]\nstats',
+    )
+    invalid += """
+
+[agents.local]
+cli = "ollama:llama3.2:3b"
+role = "last resort"
+requires = { cli = "ollama" }
+"""
+
+    with pytest.raises(ValueError, match="must not define its own fallback"):
+        roster_mod.load_roster(_write(tmp_path, invalid))
+
+
+def test_grok_invalid_final_fallback_still_validates_with_metadata_fields(tmp_path):
+    text = GROK_FALLBACK_ROSTER.replace(
+        'role = "review"',
+        'role = "review"\npurpose = "Review changes."\n'
+        'requires = { cli = "grok" }\n'
+        'stats = { speed = "fast", source = "author-receipts-2026-07" }\n'
+        "caveats = []\n",
+    )
+    loaded = roster_mod.load_roster(_write(tmp_path, text))
+    assert loaded.agents["grok-review"].invalid_final_fallback == "cursor-grok"
+
+
+class FakeProbe:
+    def __init__(self, capabilities: dict[str, roster_mod.Capability]):
+        self._capabilities = capabilities
+
+    def lookup(self, cli_ref: str) -> roster_mod.Capability:
+        return self._capabilities.get(
+            cli_ref,
+            roster_mod.Capability(installed=False, authenticated=None, detail=f"{cli_ref} missing"),
+        )
+
+
+def _metadata_roster_from_text(text: str, tmp_path) -> roster_mod.Roster:
+    return roster_mod.load_roster(_write(tmp_path, text))
+
+
+def test_resolve_capabilities_selects_self_when_requirements_pass(tmp_path):
+    roster = _metadata_roster_from_text(METADATA_ROSTER, tmp_path)
+    probe = FakeProbe(
+        {
+            "codex": roster_mod.Capability(installed=True),
+            "ollama": roster_mod.Capability(installed=True),
+        }
+    )
+
+    result = roster_mod.resolve_capabilities(roster, probe=probe)
+
+    assert "chef" in result.roster.agents
+    assert result.roster.agents["chef"].cli == "codex"
+    assert result.roster.agents["chef"].fallback == ()
+    assert len(result.report) == 1
+    chef_report = next(item for item in result.report if item.requested == "chef")
+    assert chef_report.outcome == "self"
+    assert chef_report.resolved == "chef"
+
+
+def test_resolve_capabilities_uses_first_satisfiable_fallback(tmp_path):
+    roster = _metadata_roster_from_text(METADATA_ROSTER, tmp_path)
+    probe = FakeProbe(
+        {
+            "codex": roster_mod.Capability(installed=False, detail="codex missing"),
+            "ollama": roster_mod.Capability(installed=True),
+        }
+    )
+
+    result = roster_mod.resolve_capabilities(roster, probe=probe)
+
+    chef = result.roster.agents["chef"]
+    assert chef.cli == "ollama:llama3.2:3b"
+    assert chef.role == "plan"
+    assert chef.purpose == "Orchestrate the run."
+    assert chef.requires == {"cli": "ollama"}
+    assert chef.stats == {"speed": "slow", "source": "author-receipts-2026-07"}
+    assert chef.caveats == ()
+    assert chef.fallback == ()
+    chef_report = next(item for item in result.report if item.requested == "chef")
+    assert chef_report.outcome == "fallback"
+    assert chef_report.resolved == "coder"
+    assert "codex missing" in chef_report.reason
+
+
+def test_resolve_capabilities_drops_unsatisfied_seat_with_reason(tmp_path):
+    roster = _metadata_roster_from_text(METADATA_ROSTER, tmp_path)
+    probe = FakeProbe(
+        {
+            "codex": roster_mod.Capability(installed=False, detail="codex missing"),
+            "ollama": roster_mod.Capability(installed=False, detail="ollama missing"),
+        }
+    )
+
+    result = roster_mod.resolve_capabilities(roster, probe=probe)
+
+    assert "chef" not in result.roster.agents
+    chef_report = next(item for item in result.report if item.requested == "chef")
+    assert chef_report.outcome == "dropped"
+    assert chef_report.resolved is None
+    assert "codex missing" in chef_report.reason
+    assert "ollama missing" in chef_report.reason
+
+
+def test_resolve_capabilities_emits_one_report_entry_per_requested_root(tmp_path):
+    roster = _metadata_roster_from_text(METADATA_ROSTER, tmp_path)
+    probe = FakeProbe({"codex": roster_mod.Capability(installed=True), "ollama": roster_mod.Capability(installed=True)})
+
+    result = roster_mod.resolve_capabilities(roster, probe=probe)
+
+    assert len(result.report) == 1
+    assert {item.requested for item in result.report} == {"chef"}
+
+
+def test_resolve_capabilities_keeps_no_requirement_endpoint_seats(tmp_path):
+    text = (
+        'orchestrator = "chef"\n'
+        '[agents.chef]\ncli = "codex"\nrole = "plan"\n'
+        '[agents.api]\nrole = "researcher"\nendpoint = "http://example.test/v1"\nmodel = "m"\n'
+    )
+    roster = _metadata_roster_from_text(text, tmp_path)
+    probe = FakeProbe({"codex": roster_mod.Capability(installed=False)})
+
+    result = roster_mod.resolve_capabilities(roster, probe=probe)
+
+    assert "api" in result.roster.agents
+    api_report = next(item for item in result.report if item.requested == "api")
+    assert api_report.outcome == "self"
+
+
+TWO_FALLBACK_ROSTER = """
+orchestrator = "chef"
+
+[agents.chef]
+cli = "codex"
+role = "plan"
+purpose = "Primary orchestrator."
+requires = { cli = "codex" }
+fallback = ["fallback_a", "fallback_b"]
+stats = { speed = "fast", source = "author-receipts-2026-07" }
+caveats = ["Primary seat caveat."]
+
+[agents.fallback_a]
+cli = "grok"
+model = "grok-4.5"
+role = "first fallback"
+purpose = "First fallback seat."
+requires = { cli = "grok" }
+fallback = []
+stats = { speed = "medium", source = "author-receipts-2026-07" }
+caveats = ["First fallback caveat."]
+
+[agents.fallback_b]
+cli = "ollama:llama3.2:3b"
+role = "second fallback"
+purpose = "Second fallback seat."
+requires = { cli = "ollama" }
+fallback = []
+stats = { speed = "slow", source = "author-receipts-2026-07" }
+caveats = ["Second fallback caveat."]
+"""
+
+
+def test_resolve_capabilities_selects_first_of_two_satisfiable_fallbacks(tmp_path):
+    roster = _metadata_roster_from_text(TWO_FALLBACK_ROSTER, tmp_path)
+    probe = FakeProbe(
+        {
+            "codex": roster_mod.Capability(installed=False, detail="codex missing"),
+            "grok": roster_mod.Capability(installed=True),
+            "ollama": roster_mod.Capability(installed=True),
+        }
+    )
+
+    result = roster_mod.resolve_capabilities(roster, probe=probe)
+
+    chef = result.roster.agents["chef"]
+    assert chef.cli == "grok"
+    assert chef.stats == {"speed": "medium", "source": "author-receipts-2026-07"}
+    assert chef.caveats == ("First fallback caveat.",)
+    assert chef.fallback == ()
+    chef_report = next(item for item in result.report if item.requested == "chef")
+    assert chef_report.outcome == "fallback"
+    assert chef_report.resolved == "fallback_a"
+    assert "codex missing" in chef_report.reason
+    assert "fallback_a" in chef_report.reason
+
+
+def test_resolve_capabilities_skips_failed_fallback_for_later_satisfiable_one(tmp_path):
+    roster = _metadata_roster_from_text(TWO_FALLBACK_ROSTER, tmp_path)
+    probe = FakeProbe(
+        {
+            "codex": roster_mod.Capability(installed=False, detail="codex missing"),
+            "grok": roster_mod.Capability(installed=False, detail="grok missing"),
+            "ollama": roster_mod.Capability(installed=True),
+        }
+    )
+
+    result = roster_mod.resolve_capabilities(roster, probe=probe)
+
+    chef = result.roster.agents["chef"]
+    assert chef.cli == "ollama:llama3.2:3b"
+    chef_report = next(item for item in result.report if item.requested == "chef")
+    assert chef_report.outcome == "fallback"
+    assert chef_report.resolved == "fallback_b"
+    assert "grok missing" in chef_report.reason
+
+
+AUTH_FALLBACK_ROSTER = """
+orchestrator = "chef"
+
+[agents.chef]
+cli = "cursor"
+model = "composer-2.5"
+role = "plan"
+purpose = "Primary orchestrator."
+requires = { cli = "cursor", auth = "logged-in" }
+fallback = ["chef_codex"]
+stats = { speed = "fast", source = "author-receipts-2026-07" }
+caveats = []
+
+[agents.chef_codex]
+cli = "codex"
+role = "codex fallback"
+purpose = "Codex fallback orchestrator."
+requires = { cli = "codex" }
+fallback = []
+stats = { speed = "medium", source = "author-receipts-2026-07" }
+caveats = ["Codex fallback caveat."]
+"""
+
+
+def test_resolve_capabilities_auth_failure_falls_back_with_detailed_reason(tmp_path):
+    roster = _metadata_roster_from_text(AUTH_FALLBACK_ROSTER, tmp_path)
+    probe = FakeProbe(
+        {
+            "cursor": roster_mod.Capability(
+                installed=True,
+                authenticated=False,
+                detail="cursor-agent CLI is not logged in; run cursor-agent login",
+            ),
+            "codex": roster_mod.Capability(installed=True, authenticated=True),
+        }
+    )
+
+    result = roster_mod.resolve_capabilities(roster, probe=probe)
+
+    chef = result.roster.agents["chef"]
+    assert chef.cli == "codex"
+    assert chef.caveats == ("Codex fallback caveat.",)
+    assert chef.fallback == ()
+    chef_report = next(item for item in result.report if item.requested == "chef")
+    assert chef_report.outcome == "fallback"
+    assert "cursor-agent CLI is not logged in" in chef_report.reason
+    assert "chef_codex" in chef_report.reason
+
+
+def test_resolve_capabilities_fallback_definitions_are_not_independent_report_entries(tmp_path):
+    roster = _metadata_roster_from_text(METADATA_ROSTER, tmp_path)
+    probe = FakeProbe(
+        {
+            "codex": roster_mod.Capability(installed=True),
+            "ollama": roster_mod.Capability(installed=True),
+        }
+    )
+
+    result = roster_mod.resolve_capabilities(roster, probe=probe)
+
+    assert {item.requested for item in result.report} == {"chef"}
+    assert "coder" not in result.roster.agents
+    assert "coder" not in {item.requested for item in result.report}
+
+
+def test_resolve_capabilities_self_selected_roots_clear_fallback_chain(tmp_path):
+    roster = _metadata_roster_from_text(METADATA_ROSTER, tmp_path)
+    probe = FakeProbe(
+        {
+            "codex": roster_mod.Capability(installed=True),
+            "ollama": roster_mod.Capability(installed=True),
+        }
+    )
+
+    result = roster_mod.resolve_capabilities(roster, probe=probe)
+
+    assert result.roster.agents["chef"].fallback == ()
+
+
+def test_resolve_capabilities_legacy_roster_is_unchanged_with_self_reports(tmp_path):
+    roster = roster_mod.load_roster(_write(tmp_path, VALID))
+    probe = FakeProbe({})
+
+    result = roster_mod.resolve_capabilities(roster, probe=probe)
+
+    assert result.roster == roster
+    assert result.usable is True
+    assert len(result.report) == len(roster.agents)
+    assert all(item.outcome == "self" for item in result.report)
+    assert {item.requested for item in result.report} == set(roster.agents)
+
+
+def test_resolve_capabilities_dropped_orchestrator_sets_usable_false(tmp_path):
+    roster = _metadata_roster_from_text(METADATA_ROSTER, tmp_path)
+    probe = FakeProbe(
+        {
+            "codex": roster_mod.Capability(installed=False, detail="codex missing"),
+            "ollama": roster_mod.Capability(installed=False, detail="ollama missing"),
+        }
+    )
+
+    result = roster_mod.resolve_capabilities(roster, probe=probe)
+
+    assert result.usable is False
+    assert "chef" not in result.roster.agents
+    chef_report = next(item for item in result.report if item.requested == "chef")
+    assert chef_report.outcome == "dropped"
+
+
+def test_load_rejects_orchestrator_fallback_to_acpx_worker(tmp_path):
+    text = (
+        'orchestrator = "chef"\n'
+        '[agents.chef]\ncli = "codex"\nrole = "plan"\n'
+        'requires = { cli = "codex" }\nfallback = ["cursor_worker"]\n'
+        '[agents.cursor_worker]\ncli = "cursor"\nmodel = "composer-2.5"\n'
+        'transport = "acpx"\ntransport_version = "0.12.0"\nrole = "worker"\n'
+        'requires = { cli = "cursor" }\n'
+    )
+    with pytest.raises(ValueError, match="acpx"):
+        roster_mod.load_roster(_write(tmp_path, text))
+
+
+def test_load_rejects_non_orchestrator_fallback_naming_orchestrator(tmp_path):
+    text = (
+        'orchestrator = "chef"\n'
+        '[agents.chef]\ncli = "codex"\nrole = "plan"\n'
+        'requires = { cli = "codex" }\n'
+        '[agents.reviewer]\ncli = "grok"\nmodel = "grok-4.5"\nrole = "review"\n'
+        'requires = { cli = "grok" }\nfallback = ["chef"]\n'
+    )
+    with pytest.raises(ValueError, match="orchestrator"):
+        roster_mod.load_roster(_write(tmp_path, text))
+
+
+@pytest.mark.parametrize(
+    ("requires_cli", "seat_cli", "should_load"),
+    [
+        ("ollama", "ollama:llama3.2:3b", True),
+        ("codex", "codex-cloud:brigade", True),
+        ("claude", "claude", True),
+        ("codex", "claude", False),
+    ],
+)
+def test_load_validates_requires_cli_against_seat_adapter(tmp_path, requires_cli, seat_cli, should_load):
+    text = (
+        'orchestrator = "chef"\n'
+        f'[agents.chef]\ncli = "{seat_cli}"\nrole = "plan"\n'
+        f'requires = {{ cli = "{requires_cli}" }}\n'
+    )
+    if seat_cli.startswith("codex-cloud"):
+        text += '\n[limits]\nallow_models = ["codex-cloud:*"]\n'
+    if should_load:
+        loaded = roster_mod.load_roster(_write(tmp_path, text))
+        assert loaded.agents["chef"].requires == {"cli": requires_cli}
+    else:
+        with pytest.raises(ValueError, match=r"requires\.cli"):
+            roster_mod.load_roster(_write(tmp_path, text))
+
+
+def test_load_rejects_requires_cli_on_endpoint_seat(tmp_path):
+    text = (
+        'orchestrator = "chef"\n'
+        '[agents.chef]\ncli = "codex"\nrole = "plan"\n'
+        '[agents.api]\nrole = "researcher"\nendpoint = "http://example.test/v1"\nmodel = "m"\n'
+        'requires = { cli = "codex" }\n'
+    )
+    with pytest.raises(ValueError, match=r"requires\.cli"):
+        roster_mod.load_roster(_write(tmp_path, text))
+
+
+INVALID_FINAL_RESOLUTION_ROSTER = """
+orchestrator = "chef"
+
+[agents.chef]
+cli = "codex"
+role = "plan"
+purpose = "Orchestrator."
+
+[agents.grok-review]
+cli = "grok"
+model = "grok-4.5"
+role = "review"
+purpose = "Review lane."
+requires = { cli = "grok" }
+invalid_final_fallback = "cursor-grok"
+stats = { speed = "fast", source = "author-receipts-2026-07" }
+caveats = []
+
+[agents.cursor-grok]
+cli = "cursor"
+model = "grok-4.5"
+transport = "acpx"
+transport_version = "0.12.0"
+role = "fallback review"
+purpose = "ACP fallback."
+requires = { cli = "cursor", auth = "logged-in" }
+stats = { speed = "fast", source = "author-receipts-2026-07" }
+caveats = []
+"""
+
+
+def test_resolve_capabilities_includes_invalid_final_fallback_dependency(tmp_path):
+    roster = _metadata_roster_from_text(INVALID_FINAL_RESOLUTION_ROSTER, tmp_path)
+    probe = FakeProbe(
+        {
+            "codex": roster_mod.Capability(installed=True),
+            "grok": roster_mod.Capability(installed=True),
+            "cursor": roster_mod.Capability(installed=True, authenticated=True),
+        }
+    )
+
+    result = roster_mod.resolve_capabilities(roster, probe=probe)
+
+    assert "grok-review" in result.roster.agents
+    assert result.roster.agents["grok-review"].invalid_final_fallback == "cursor-grok"
+    assert "cursor-grok" in result.roster.agents
+
+
+def test_resolve_capabilities_clears_invalid_final_fallback_when_dependency_unsatisfied(tmp_path):
+    roster = _metadata_roster_from_text(INVALID_FINAL_RESOLUTION_ROSTER, tmp_path)
+    probe = FakeProbe(
+        {
+            "codex": roster_mod.Capability(installed=True),
+            "grok": roster_mod.Capability(installed=True),
+            "cursor": roster_mod.Capability(installed=False, detail="cursor missing"),
+        }
+    )
+
+    result = roster_mod.resolve_capabilities(roster, probe=probe)
+
+    grok = result.roster.agents["grok-review"]
+    assert grok.invalid_final_fallback is None
+    assert "cursor-grok" not in result.roster.agents
+
+
+def test_resolve_capabilities_clears_invalid_final_fallback_when_target_resolves_to_incompatible_seat(tmp_path):
+    text = INVALID_FINAL_RESOLUTION_ROSTER.replace(
+        'requires = { cli = "cursor", auth = "logged-in" }\nstats',
+        'requires = { cli = "cursor", auth = "logged-in" }\nfallback = ["cursor-grok-codex"]\nstats',
+    )
+    text += """
+
+[agents.cursor-grok-codex]
+cli = "codex"
+model = "gpt-5.6-terra"
+role = "fallback review"
+requires = { cli = "codex" }
+"""
+    roster = _metadata_roster_from_text(text, tmp_path)
+    probe = FakeProbe(
+        {
+            "codex": roster_mod.Capability(installed=True),
+            "grok": roster_mod.Capability(installed=True),
+            "cursor": roster_mod.Capability(installed=False, detail="cursor missing"),
+        }
+    )
+
+    result = roster_mod.resolve_capabilities(roster, probe=probe)
+
+    assert result.roster.agents["cursor-grok"].cli == "codex"
+    assert result.roster.agents["grok-review"].invalid_final_fallback is None
+
+
+def test_host_capability_probe_uses_detect_and_command_for(monkeypatch):
+    calls: list[tuple[str, str]] = []
+
+    def fake_command_for(cli_ref: str) -> str:
+        calls.append(("command_for", cli_ref))
+        return f"bin-{cli_ref}"
+
+    def fake_detect(cli_ref: str) -> bool:
+        calls.append(("detect", cli_ref))
+        return cli_ref == "codex"
+
+    monkeypatch.setattr(agents, "command_for", fake_command_for)
+    monkeypatch.setattr(agents, "detect", fake_detect)
+
+    capability = roster_mod.HostCapabilityProbe().lookup("codex")
+
+    assert ("command_for", "codex") in calls
+    assert ("detect", "codex") in calls
+    assert capability.installed is True
+    assert capability.detail == "codex via bin-codex"
+
+
+def test_host_capability_probe_missing_cli_matches_doctor_style(monkeypatch):
+    monkeypatch.setattr(agents, "command_for", lambda cli_ref: "missing-bin")
+    monkeypatch.setattr(agents, "detect", lambda cli_ref: False)
+
+    capability = roster_mod.HostCapabilityProbe().lookup("codex")
+
+    assert capability.installed is False
+    assert capability.detail == "codex needs `missing-bin` on PATH"
+
+
+def test_host_capability_probe_cursor_auth_states(monkeypatch):
+    from brigade import acpx_adapter
+
+    monkeypatch.setattr(agents, "command_for", lambda cli_ref: "cursor-agent")
+    monkeypatch.setattr(agents, "detect", lambda cli_ref: True)
+    auth_calls: list[str] = []
+
+    def fake_auth_status():
+        auth_calls.append("called")
+        return acpx_adapter.CursorAuthStatus("authenticated", "logged in", "", "", 0)
+
+    monkeypatch.setattr(acpx_adapter, "cursor_auth_status", fake_auth_status)
+    authenticated = roster_mod.HostCapabilityProbe().lookup("cursor")
+    assert authenticated.authenticated is True
+    assert auth_calls == ["called"]
+
+    monkeypatch.setattr(
+        acpx_adapter,
+        "cursor_auth_status",
+        lambda: acpx_adapter.CursorAuthStatus("unauthenticated", "not logged in", "", "", 1),
+    )
+    unauthenticated = roster_mod.HostCapabilityProbe().lookup("cursor")
+    assert unauthenticated.authenticated is False
+
+    monkeypatch.setattr(
+        acpx_adapter,
+        "cursor_auth_status",
+        lambda: acpx_adapter.CursorAuthStatus("unavailable", "cursor-agent is not installed", "", "", 127),
+    )
+    unavailable = roster_mod.HostCapabilityProbe().lookup("cursor")
+    assert unavailable.authenticated is None
+    assert unavailable.detail == "cursor-agent is not installed"
+    assert unavailable.auth_detail == "cursor-agent is not installed"
+
+    monkeypatch.setattr(
+        acpx_adapter,
+        "cursor_auth_status",
+        lambda: acpx_adapter.CursorAuthStatus("unrecognized", "unexpected status payload", "", "", 0),
+    )
+    unrecognized = roster_mod.HostCapabilityProbe().lookup("cursor")
+    assert unrecognized.authenticated is None
+    assert unrecognized.detail == "unexpected status payload"
+    assert unrecognized.auth_detail == "unexpected status payload"
+
+
+def test_host_capability_probe_skips_cursor_auth_when_cursor_not_installed(monkeypatch):
+    from brigade import acpx_adapter
+
+    monkeypatch.setattr(agents, "command_for", lambda cli_ref: "cursor-agent")
+    monkeypatch.setattr(agents, "detect", lambda cli_ref: False)
+
+    def fail_auth():
+        raise AssertionError("cursor_auth_status must not run when cursor is not installed")
+
+    monkeypatch.setattr(acpx_adapter, "cursor_auth_status", fail_auth)
+
+    capability = roster_mod.HostCapabilityProbe().lookup("cursor")
+
+    assert capability.installed is False
+    assert capability.authenticated is None
+
+
+def test_resolve_capabilities_fake_probe_never_calls_host_functions(monkeypatch, tmp_path):
+    roster = _metadata_roster_from_text(METADATA_ROSTER, tmp_path)
+    probe = FakeProbe({"codex": roster_mod.Capability(installed=True), "ollama": roster_mod.Capability(installed=True)})
+
+    def fail_detect(cli_ref: str) -> bool:
+        raise AssertionError("detect must not run when a probe is injected")
+
+    monkeypatch.setattr(agents, "detect", fail_detect)
+
+    roster_mod.resolve_capabilities(roster, probe=probe)
+
+
+def test_requirements_satisfied_skips_redundant_auth_when_cli_missing():
+    probe = FakeProbe({"cursor": roster_mod.Capability(installed=False, detail="cursor missing")})
+    agent = roster_mod.Agent(
+        name="worker",
+        cli="cursor",
+        role="build",
+        requires={"cli": "cursor", "auth": "logged-in"},
+    )
+
+    ok, reason = roster_mod._requirements_satisfied(agent, probe)
+
+    assert ok is False
+    assert reason == "cursor missing"
+    assert "authenticated" not in reason.lower()
+
+
+def test_requirements_satisfied_reports_unknown_auth_separately_from_installation():
+    probe = FakeProbe({"codex": roster_mod.Capability(installed=True, detail="codex via codex")})
+    agent = roster_mod.Agent(
+        name="worker",
+        cli="codex",
+        role="build",
+        requires={"cli": "codex", "auth": "logged-in"},
+    )
+
+    ok, reason = roster_mod._requirements_satisfied(agent, probe)
+
+    assert ok is False
+    assert reason == "codex authentication is unknown"

--- a/tests/test_roster.py
+++ b/tests/test_roster.py
@@ -1016,6 +1016,31 @@ def test_load_rejects_orchestrator_fallback_to_acpx_worker(tmp_path):
         roster_mod.load_roster(_write(tmp_path, text))
 
 
+@pytest.mark.parametrize(
+    "fallback_definition",
+    [
+        (
+            '[agents.cloud_worker]\ncli = "codex-cloud:env"\nrole = "worker"\n'
+            'requires = { cli = "codex" }\n'
+            '[limits]\nallow_models = ["claude", "codex-cloud:*"]\n'
+        ),
+        ('[agents.endpoint_worker]\nrole = "worker"\nendpoint = "http://example.test/v1"\nmodel = "m"\n'),
+    ],
+)
+def test_load_rejects_orchestrator_fallback_to_other_worker_only_seats(tmp_path, fallback_definition):
+    fallback_name = "cloud_worker" if "cloud_worker" in fallback_definition else "endpoint_worker"
+    text = (
+        'orchestrator = "chef"\n'
+        '[agents.chef]\ncli = "claude"\nrole = "plan"\n'
+        'requires = { cli = "claude" }\n'
+        f'fallback = ["{fallback_name}"]\n'
+        f"{fallback_definition}"
+    )
+
+    with pytest.raises(ValueError, match="worker-only"):
+        roster_mod.load_roster(_write(tmp_path, text))
+
+
 def test_load_rejects_non_orchestrator_fallback_naming_orchestrator(tmp_path):
     text = (
         'orchestrator = "chef"\n'

--- a/tests/test_roster_cmd.py
+++ b/tests/test_roster_cmd.py
@@ -7,6 +7,7 @@ from brigade import cli
 from brigade import model_inventory
 from brigade import roster
 from brigade import roster_cmd
+from brigade import toml_compat
 
 
 def test_roster_init_writes_default_roster(tmp_target, capsys):
@@ -21,6 +22,35 @@ def test_roster_init_writes_default_roster(tmp_target, capsys):
     assert 'cli = "ollama:llama3.2:3b"' in text
     assert "timeout_seconds = 600" in text
     assert str(path) in out
+
+
+EXPECTED_PRESET_NAMES = (
+    "budget-open-weight.toml",
+    "full-multi-lane.toml",
+    "minimal-single-cli.toml",
+    "review-heavy.toml",
+)
+
+
+def test_preset_roster_paths_returns_four_packaged_presets():
+    paths = roster_cmd.preset_roster_paths()
+    assert tuple(path.name for path in paths) == EXPECTED_PRESET_NAMES
+    assert all(path.is_file() for path in paths)
+
+
+@pytest.mark.parametrize("preset_name", EXPECTED_PRESET_NAMES)
+def test_packaged_presets_parse(preset_name):
+    path = next(item for item in roster_cmd.preset_roster_paths() if item.name == preset_name)
+    raw = toml_compat.loads(path.read_text())
+    loaded = roster.load_roster(path)
+    assert loaded.orchestrator in loaded.agents
+    for name, agent in loaded.agents.items():
+        assert agent.purpose
+        assert agent.requires is not None
+        assert agent.stats is not None
+        assert "speed" in agent.stats
+        assert "source" in agent.stats
+        assert "caveats" in raw["agents"][name]
 
 
 def test_default_roster_ollama_model_is_small_and_documented():


### PR DESCRIPTION
## Summary

- Package four roster presets: minimal single-CLI, budget open-weight, review-heavy, and full multi-lane.
- Extend `Agent` and `load_roster()` with optional `purpose`, `requires`, `fallback`, `stats`, and `caveats` fields while preserving legacy roster behavior.
- Add injectable capability resolution backed by `agents.detect()`, `agents.command_for()`, and Cursor auth status. Every requested seat produces a report entry for self-selection, fallback selection, or a dropped seat with its reason.

## Resolution contract

Preset fallback entries are menu definitions, not independent requested workers. The resolver selects the first satisfactory one-hop fallback, aliases its runtime metadata into the requested seat name, and keeps the requested role and purpose. Nested fallback chains and cycles are rejected when loading the roster.

An unsatisfied seat is omitted without aborting the whole roster. A dropped orchestrator sets `result.usable` to false. The existing `invalid_final_fallback` behavior remains separate, and its pointer is cleared if capability resolution removes or changes the reviewed Cursor/Grok ACP target.

This slice does not wire resolution into dispatch.

## Verification

- `brigade work verify run --target . --command "pytest -q tests/test_roster.py tests/test_roster_cmd.py" --capture brigade-work`: `137 passed in 0.85s` (`20260723-020114-work-verify-62fa80`)
- `brigade work verify run --target . --command "./scripts/verify" --capture brigade-work`: `3960 passed, 3 skipped in 359.71s`, 82.65% coverage (`20260723-020131-work-verify-23bc73`)
- Independent review found no remaining Critical or Important correctness issues.

## Deferred work

Parts 3 and 4 remain out of scope. Part 3 will add `brigade roster suggest`, concrete roster emission only when `result.usable` is true, and doctor warnings for lapsed requirements. Part 4 will derive per-seat medians and failure rates from `.brigade/runs/` receipts. The implementation note is in `docs/issue-444-parts-3-4-plan.md`.

Refs #444
