### PR TITLE
feat(trials): freeze failure taxonomy, regrade path, and exit codes

### DIFF
--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -38,7 +38,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade learn` (extras): 13 command path(s)
 - `brigade mcp`: 12 command path(s)
 - `brigade memory`: 14 command path(s)
-- `brigade model`: 6 command path(s)
+- `brigade model`: 7 command path(s)
 - `brigade notifications` (extras): 4 command path(s)
 - `brigade openclaw-fragments` (extras): 1 command path(s)
 - `brigade operator`: 24 command path(s)
@@ -247,6 +247,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade memory status`
 - `brigade model scorecard`
 - `brigade model trial plan`
+- `brigade model trial regrade`
 - `brigade model trial resume`
 - `brigade model trial run`
 - `brigade model trial show`

--- a/docs/model-trial-taxonomy.md
+++ b/docs/model-trial-taxonomy.md
@@ -1,0 +1,53 @@
+# Model-trial outcome taxonomy (brigade.eval_cell.v1 / grader_result.v1)
+
+Status: frozen for the stable cut. Sibling: #434 (cell identity + resume). This document is the
+contract every downstream consumer (scorecard, outcome capture, evidence export) keys on.
+
+## The six terminal states
+
+| State | Set when | Class | Resume | Retry | Exit bucket |
+|---|---|---|---|---|---|
+| accepted | exit 0, every grader at score_max | deterministic — real result | terminal | no | 0 |
+| rejected | exit 0, ≥1 grader below score_max | deterministic — real result | terminal | no | 1 |
+| unscored | exit 0, no graders defined | deterministic — coverage gap | terminal | no | 0 |
+| execution_error | seat exited nonzero | deterministic — real result, unless failure_reason=timeout (then environmental) | terminal | only --retry-transient when failure_reason=timeout | 1 deterministic / 3 timeout |
+| adapter_error | worker-results.json ok:false, missing/zero adapter exit | environmental — apparatus fault | terminal → retry-eligible | --retry-transient | 3 |
+| grader_error | ≥1 grader failed to run (bad pattern, unreadable expected-file) | environmental — apparatus fault | terminal → regradeable | regrade only, no seat re-run | 3 |
+
+Deterministic = a real statement about the seat. Environmental = a measurement-apparatus fault.
+Consumers MUST NOT read an environmental state as seat performance.
+
+## measurement_failures
+summary.json reports measurement_failures (= adapter_error + grader_error + execution_error with
+failure_reason=timeout) separately from rejected.
+
+## failure_reason (additive)
+Optional machine-readable string on the cell payload; eval_cell.v1 stays valid. Canonical
+values: timeout (canonical transient), transport_drop / provider_5xx (adapter faults). Absent
+when not applicable.
+
+## Partial grader outcomes
+A cell with ≥1 grader_error resolves to grader_error at the cell level (fail safe). summary.json
+counts the other graders' real scores as partial, labeled as such — not silently folded into
+the headline score stats.
+
+## Process exit
+0 = only accepted/unscored. 1 = ≥1 deterministic non-pass (rejected or non-timeout
+execution_error), no measurement failures. 3 = any measurement failure; dominates 1 (matches
+brigade run exit-3).
+
+## Regrade
+brigade model trials regrade <output-dir> re-runs graders against stored run/final.txt (verified
+against output_digest) without re-running seats. Resume treats grader_error as regradeable.
+
+## grader_result.v1: exit_code removed
+The exit_code field (hardcoded 0/null) is REMOVED. If command-based graders arrive they add an
+honestly-populated field under a new schema revision.
+
+## Export privacy
+cell.json inlines the full prompt and absolute run_dir. Any export/projection path MUST
+strip/digest prompts and relativize paths by default. Enforced by test.
+
+## Deferred (post-freeze, additive)
+--retry-transient: opt-in re-run of adapter_error and timeout-reason cells as new attempts,
+failed attempt kept on disk. Default off. Not required for the freeze.

--- a/docs/model-trial-taxonomy.md
+++ b/docs/model-trial-taxonomy.md
@@ -37,7 +37,7 @@ execution_error), no measurement failures. 3 = any measurement failure; dominate
 brigade run exit-3).
 
 ## Regrade
-brigade model trials regrade <output-dir> re-runs graders against stored run/final.txt (verified
+brigade model trial regrade <output-dir> re-runs graders against stored run/final.txt (verified
 against output_digest) without re-running seats. Resume treats grader_error as regradeable.
 
 ## grader_result.v1: exit_code removed

--- a/docs/phase-eval-cell-identity.md
+++ b/docs/phase-eval-cell-identity.md
@@ -51,9 +51,13 @@ exact payload keys and the resulting digest, so an accidental change fails CI.
 `execute --resume` rebuilds the plan from the current manifest and decides per
 cell from the recorded `cell.json`:
 
-- `accepted`, `rejected`, `unscored`, `execution_error`, `adapter_error`,
-  `grader_error` (the terminal states): the cell is **skipped**; the existing
-  receipt stands.
+- `accepted`, `rejected`, `unscored`, `execution_error`, `adapter_error`
+  (terminal, non-regradeable): the cell is **skipped**; the existing receipt
+  stands.
+- `grader_error` (terminal, regradeable): graders are **re-run** against the
+  stored `run/final.txt` (verified against `output_digest`); the seat is not
+  re-executed. Use `brigade model trial regrade` for the same path outside
+  resume.
 - `running`: the cell **re-runs as a new attempt**. `running` means the
   previous process died mid-run (or, without a lock, is still executing in
   another process). Resume treats it as a crash and starts the next attempt,

--- a/src/brigade/cli/model.py
+++ b/src/brigade/cli/model.py
@@ -61,6 +61,11 @@ def register(sub: argparse._SubParsersAction) -> None:
         parser.add_argument("output_dir", type=Path, help="Trial artifact directory.")
         parser.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
         parser.set_defaults(func=_dispatch_trial)
+    p_regrade = trial_sub.add_parser(
+        "regrade", help="Re-run graders from stored trial output without re-running seats."
+    )
+    p_regrade.add_argument("output_dir", type=Path, help="Trial artifact directory.")
+    p_regrade.set_defaults(func=_dispatch_trial)
 
 
 def _dispatch_scorecard(args) -> int:
@@ -92,6 +97,8 @@ def _dispatch_trial(args) -> int:
             for state, count in payload["counts"].items():
                 print(f"{state}: {count}")
         return 0
+    if args.trial_command == "regrade":
+        return model_trials.regrade(args.output_dir)
 
     target = args.target.expanduser().resolve()
     try:

--- a/src/brigade/model_trials.py
+++ b/src/brigade/model_trials.py
@@ -21,6 +21,8 @@ CELL_SCHEMA = "brigade.eval_cell.v1"
 SUMMARY_SCHEMA = "brigade.eval_summary.v1"
 GRADER_SCHEMA = "brigade.grader_result.v1"
 TERMINAL_STATES = frozenset({"accepted", "rejected", "unscored", "execution_error", "adapter_error", "grader_error"})
+REGRADEABLE_STATES = frozenset({"grader_error"})
+MEASUREMENT_STATES = frozenset({"adapter_error", "grader_error"})
 
 
 @dataclass(frozen=True)
@@ -172,7 +174,6 @@ def _grader_result(kind: str, index: int, started: float, *, status: str, score:
         "grader_type": kind,
         "version": 1,
         "status": status,
-        "exit_code": 0 if status == "scored" else None,
         "score": score,
         "score_min": 0.0,
         "score_max": 1.0,
@@ -296,8 +297,18 @@ def _worker_result(run_dir: Path) -> dict[str, Any] | None:
     return results[0]
 
 
-def _state(exit_code: int, graders: list[dict[str, Any]], worker_result: dict[str, Any] | None = None) -> str:
+def _state(
+    exit_code: int,
+    graders: list[dict[str, Any]],
+    worker_result: dict[str, Any] | None = None,
+    *,
+    run_meta: dict[str, Any] | None = None,
+) -> str:
     if exit_code != 0:
+        if isinstance(run_meta, dict) and run_meta.get("failure_kind") == "timeout":
+            return "execution_error"
+        if worker_result is not None and worker_result.get("timed_out") is True:
+            return "execution_error"
         if worker_result is not None and worker_result.get("ok") is False:
             adapter_exit = worker_result.get("exit_code")
             if adapter_exit is None or adapter_exit == 0:
@@ -308,6 +319,234 @@ def _state(exit_code: int, graders: list[dict[str, Any]], worker_result: dict[st
     if any(item["status"] == "grader_error" for item in graders):
         return "grader_error"
     return "accepted" if all(item["score"] == item["score_max"] for item in graders) else "rejected"
+
+
+def _resume_skip_state(state: str) -> bool:
+    return state in TERMINAL_STATES and state not in REGRADEABLE_STATES
+
+
+def _output_digest(text: str) -> str:
+    return f"sha256:{hashlib.sha256(text.encode()).hexdigest()}"
+
+
+def _failure_reason(
+    *,
+    run_meta: dict[str, Any] | None,
+    worker_result: dict[str, Any] | None,
+    state: str,
+) -> str | None:
+    if isinstance(run_meta, dict) and run_meta.get("failure_kind") == "timeout":
+        return "timeout"
+    if isinstance(worker_result, dict) and worker_result.get("timed_out") is True:
+        return "timeout"
+    if state != "adapter_error":
+        return None
+    if not isinstance(worker_result, dict):
+        return "transport_drop"
+    failure_kind = str(worker_result.get("failure_kind") or "").lower()
+    detail = str(worker_result.get("detail") or "").lower()
+    if "5xx" in failure_kind or "5xx" in detail or "server error" in detail:
+        return "provider_5xx"
+    return "transport_drop"
+
+
+def _cell_is_measurement_failure(cell: dict[str, Any]) -> bool:
+    state = cell.get("state")
+    if state in MEASUREMENT_STATES:
+        return True
+    return state == "execution_error" and cell.get("failure_reason") == "timeout"
+
+
+def _attach_grader_output_refs(graders: list[dict[str, Any]], *, cell_id: str, output_digest: str) -> None:
+    for grader in graders:
+        grader["cell_id"] = cell_id
+        grader["output_digest"] = output_digest
+        grader["output_refs"] = [{"path": "run/final.txt", "sha256": output_digest}]
+
+
+def _finalize_cell_payload(
+    cell: CellSpec,
+    *,
+    plan: dict[str, Any],
+    attempt: int,
+    started_at: str,
+    exit_code: int,
+    run_dir: Path,
+    graders: list[dict[str, Any]],
+    text: str,
+    failure_reason: str | None,
+) -> dict[str, Any]:
+    output_digest = _output_digest(text)
+    _attach_grader_output_refs(graders, cell_id=cell.cell_id, output_digest=output_digest)
+    run_meta = _load_json(run_dir / "run.json") or {}
+    worker_result = _worker_result(run_dir)
+    state = _state(exit_code, graders, worker_result, run_meta=run_meta)
+    if failure_reason is None:
+        failure_reason = _failure_reason(run_meta=run_meta, worker_result=worker_result, state=state)
+    payload: dict[str, Any] = {
+        "schema": CELL_SCHEMA,
+        **cell.payload(),
+        "state": state,
+        "attempt": attempt,
+        "started_at": started_at,
+        "manifest_digest": plan["manifest_digest"],
+        "exit_code": exit_code,
+        "duration_seconds": run_meta.get("duration_seconds"),
+        "run_dir": str(run_dir),
+        "graders": graders,
+        "acceptance": {"state": "accepted" if state == "accepted" else "not-accepted"},
+    }
+    if failure_reason is not None:
+        payload["failure_reason"] = failure_reason
+    return payload
+
+
+def _write_cell_payload(cell_dir: Path, run_parent: Path, payload: dict[str, Any]) -> None:
+    cell_dir.mkdir(parents=True, exist_ok=True)
+    localio.write_json(cell_dir / "cell.json", payload)
+    localio.write_json(run_parent / "cell.json", payload)
+
+
+def _expected_output_digest(cell: dict[str, Any]) -> str | None:
+    graders = cell.get("graders")
+    if not isinstance(graders, list):
+        return None
+    for grader in graders:
+        if isinstance(grader, dict) and isinstance(grader.get("output_digest"), str):
+            return grader["output_digest"]
+    return None
+
+
+def _regrade_cell_from_disk(cell_dir: Path, cell: CellSpec, plan: dict[str, Any]) -> bool:
+    current = _load_json(cell_dir / "cell.json")
+    if current is None:
+        return False
+    run_dir_value = current.get("run_dir")
+    if not isinstance(run_dir_value, str) or not run_dir_value:
+        return False
+    run_dir = Path(run_dir_value)
+    try:
+        text = (run_dir / "final.txt").read_text()
+    except OSError:
+        return False
+    output_digest = _output_digest(text)
+    expected = _expected_output_digest(current)
+    if expected is not None and expected != output_digest:
+        raise ValueError(f"cell {cell.cell_id}: stored output digest mismatch for {run_dir / 'final.txt'}")
+    exit_code = current.get("exit_code")
+    if not isinstance(exit_code, int) or isinstance(exit_code, bool):
+        exit_code = 0
+    run_meta = _load_json(run_dir / "run.json") or {}
+    cwd_value = run_meta.get("cwd")
+    workspace = Path(cwd_value).expanduser().resolve() if isinstance(cwd_value, str) else run_dir
+    graders = grade_output(
+        graders=cell.graders,
+        text=text,
+        exit_code=exit_code,
+        workspace=workspace,
+        run_dir=run_dir,
+    )
+    attempt = current.get("attempt")
+    if not isinstance(attempt, int) or isinstance(attempt, bool) or attempt < 1:
+        attempt = 1
+    started_at = current.get("started_at")
+    if not isinstance(started_at, str):
+        started_at = datetime.now(timezone.utc).isoformat()
+    payload = _finalize_cell_payload(
+        cell,
+        plan=plan,
+        attempt=attempt,
+        started_at=started_at,
+        exit_code=exit_code,
+        run_dir=run_dir,
+        graders=graders,
+        text=text,
+        failure_reason=None,
+    )
+    _write_cell_payload(cell_dir, run_dir.parent, payload)
+    return True
+
+
+def regrade(output_dir: Path) -> int:
+    output_dir = output_dir.expanduser().resolve()
+    plan = _load_json(output_dir / "plan.json")
+    if plan is None:
+        print("error: no trial plan found", file=sys.stderr)
+        return 2
+    current_ids = {
+        item["cell_id"]
+        for item in plan.get("cells", [])
+        if isinstance(item, dict) and isinstance(item.get("cell_id"), str)
+    }
+    cells_by_id = {cell.cell_id: cell for cell in _cells_from_plan(plan)}
+    regraded = 0
+    for cell_id in sorted(current_ids):
+        cell = cells_by_id.get(cell_id)
+        if cell is None:
+            continue
+        cell_dir = output_dir / "cells" / cell_id
+        try:
+            if _regrade_cell_from_disk(cell_dir, cell, plan):
+                regraded += 1
+        except ValueError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+    localio.write_json(output_dir / "summary.json", summarize(output_dir))
+    return process_exit(summarize(output_dir))
+
+
+def _cells_from_plan(plan: dict[str, Any]) -> list[CellSpec]:
+    cells: list[CellSpec] = []
+    for raw in plan.get("cells", []):
+        if not isinstance(raw, dict):
+            continue
+        graders = raw.get("graders", [])
+        if not isinstance(graders, list):
+            graders = []
+        cells.append(
+            CellSpec(
+                cell_id=str(raw["cell_id"]),
+                coordinate=str(raw.get("coordinate", "")),
+                case_id=str(raw.get("case_id", "")),
+                prompt=str(raw.get("prompt", "")),
+                seat=str(raw.get("seat", "")),
+                trial=int(raw.get("trial", 1)),
+                graders=tuple(dict(item) for item in graders if isinstance(item, dict)),
+                execution_mode=str(raw.get("execution_mode", "read-only")),
+            )
+        )
+    return cells
+
+
+def project_cell(cell: dict[str, Any], *, base_dir: Path) -> dict[str, Any]:
+    projected = dict(cell)
+    prompt = projected.pop("prompt", None)
+    if isinstance(prompt, str):
+        projected["prompt_digest"] = _output_digest(prompt)
+    case = projected.get("case")
+    if isinstance(case, dict) and isinstance(case.get("prompt"), str):
+        case = dict(case)
+        case["prompt_digest"] = _output_digest(case["prompt"])
+        case.pop("prompt", None)
+        projected["case"] = case
+    run_dir = projected.get("run_dir")
+    if isinstance(run_dir, str):
+        try:
+            projected["run_dir"] = str(Path(run_dir).resolve().relative_to(base_dir.resolve()))
+        except ValueError:
+            projected["run_dir"] = Path(run_dir).name
+    return projected
+
+
+def process_exit(summary: dict[str, Any]) -> int:
+    if int(summary.get("measurement_failures", 0) or 0) > 0:
+        return 3
+    counts = summary.get("counts")
+    if not isinstance(counts, dict):
+        return 0
+    if counts.get("rejected", 0) > 0 or counts.get("execution_error", 0) > 0:
+        return 1
+    return 0
 
 
 def _trial_worktree_path(
@@ -409,18 +648,23 @@ def execute(
             f"note: {len(plan['stale_cells'])} stale cell(s) from the previous plan kept and counted in summary",
             file=sys.stderr,
         )
-    failures = 0
     for cell in cells:
         cell_dir = output_dir / "cells" / cell.cell_id
         current = _load_json(cell_dir / "cell.json")
-        if resume and current is not None and current.get("state") in TERMINAL_STATES:
+        if resume and current is not None and _resume_skip_state(str(current.get("state", ""))):
+            continue
+        if resume and current is not None and current.get("state") in REGRADEABLE_STATES:
+            try:
+                _regrade_cell_from_disk(cell_dir, cell, plan)
+            except ValueError as exc:
+                print(f"error: {exc}", file=sys.stderr)
+                return 2
             continue
         attempt = _attempt_number(cell_dir)
-        started_at = (
-            current.get("started_at")
-            if isinstance(current, dict) and isinstance(current.get("started_at"), str)
-            else datetime.now(timezone.utc).isoformat()
-        )
+        if isinstance(current, dict) and isinstance(current.get("started_at"), str):
+            started_at = current["started_at"]
+        else:
+            started_at = datetime.now(timezone.utc).isoformat()
         cell_dir.mkdir(parents=True, exist_ok=True)
         localio.write_json(
             cell_dir / "cell.json",
@@ -468,33 +712,21 @@ def execute(
         finally:
             if worktree_path is not None:
                 runguard.remove_worktree(workspace, worktree_path)
-        output_digest = hashlib.sha256(text.encode()).hexdigest()
-        for grader in graders:
-            grader["cell_id"] = cell.cell_id
-            grader["output_digest"] = f"sha256:{output_digest}"
-            grader["output_refs"] = [{"path": "run/final.txt", "sha256": grader["output_digest"]}]
-        state = _state(rc, graders, _worker_result(run_dir))
-        run_meta = _load_json(run_dir / "run.json") or {}
-        payload = {
-            "schema": CELL_SCHEMA,
-            **cell.payload(),
-            "state": state,
-            "attempt": attempt,
-            "started_at": started_at,
-            "manifest_digest": plan["manifest_digest"],
-            "exit_code": rc,
-            "duration_seconds": run_meta.get("duration_seconds"),
-            "run_dir": str(run_dir),
-            "graders": graders,
-            "acceptance": {"state": "accepted" if state == "accepted" else "not-accepted"},
-        }
-        cell_dir.mkdir(parents=True, exist_ok=True)
-        localio.write_json(cell_dir / "cell.json", payload)
-        localio.write_json(run_dir.parent / "cell.json", payload)
-        if state not in {"accepted", "unscored"}:
-            failures += 1
-    localio.write_json(output_dir / "summary.json", summarize(output_dir))
-    return 1 if failures else 0
+        payload = _finalize_cell_payload(
+            cell,
+            plan=plan,
+            attempt=attempt,
+            started_at=started_at,
+            exit_code=rc,
+            run_dir=run_dir,
+            graders=graders,
+            text=text,
+            failure_reason=None,
+        )
+        _write_cell_payload(cell_dir, run_dir.parent, payload)
+    summary = summarize(output_dir)
+    localio.write_json(output_dir / "summary.json", summary)
+    return process_exit(summary)
 
 
 def _stats(values: list[float]) -> dict[str, Any]:
@@ -515,7 +747,9 @@ def summarize(output_dir: Path) -> dict[str, Any]:
     counts: dict[str, int] = {}
     stale_counts: dict[str, int] = {}
     scores: list[float] = []
+    partial_scores: list[float] = []
     durations: list[float] = []
+    measurement_failures = 0
     cells_dir = output_dir / "cells"
     paths = sorted(cells_dir.glob("*/cell.json")) if cells_dir.is_dir() else []
     plan = _load_json(output_dir / "plan.json")
@@ -534,16 +768,28 @@ def summarize(output_dir: Path) -> dict[str, Any]:
             stale_counts[state] = stale_counts.get(state, 0) + 1
             continue
         counts[state] = counts.get(state, 0) + 1
+        if _cell_is_measurement_failure(cell):
+            measurement_failures += 1
         if isinstance(cell.get("duration_seconds"), (int, float)):
             durations.append(float(cell["duration_seconds"]))
+        cell_state = cell.get("state")
         for grader in cell.get("graders", []):
-            if isinstance(grader, dict) and isinstance(grader.get("score"), (int, float)):
-                scores.append(float(grader["score"]))
+            if not isinstance(grader, dict) or not isinstance(grader.get("score"), (int, float)):
+                continue
+            if grader.get("status") != "scored":
+                continue
+            value = float(grader["score"])
+            if cell_state == "grader_error":
+                partial_scores.append(value)
+            else:
+                scores.append(value)
     return {
         "schema": SUMMARY_SCHEMA,
         "counts": dict(sorted(counts.items())),
         "stale_counts": dict(sorted(stale_counts.items())),
+        "measurement_failures": measurement_failures,
         "scores": _stats(scores),
+        "partial_scores": _stats(partial_scores),
         "durations": _stats(durations),
     }
 

--- a/tests/test_model_trials.py
+++ b/tests/test_model_trials.py
@@ -185,11 +185,11 @@ def test_graders_distinguish_zero_score_from_error(tmp_path):
     assert results[0]["score"] == 0.0
     assert results[1]["status"] == "grader_error"
     assert results[1]["score"] is None
-    assert results[0]["exit_code"] == 0
+    assert "exit_code" not in results[0]
     assert results[0]["component_checks"] == [
         {"name": "exact_output", "passed": False, "detail": "output did not match"}
     ]
-    assert results[1]["exit_code"] is None
+    assert "exit_code" not in results[1]
 
 
 def test_execute_writes_running_marker_before_aboyeur_run(tmp_path, monkeypatch):
@@ -435,9 +435,10 @@ def test_adapter_failure_is_distinct_from_execution_failure(tmp_path, monkeypatc
 
     monkeypatch.setattr(model_trials.aboyeur, "run", fake_run)
     root = tmp_path / "results"
-    assert model_trials.execute(manifest_path, _roster(), workspace=tmp_path, output_dir=root, resume=False) == 1
+    assert model_trials.execute(manifest_path, _roster(), workspace=tmp_path, output_dir=root, resume=False) == 3
     cell = json.loads(next((root / "cells").glob("*/cell.json")).read_text())
     assert cell["state"] == "adapter_error"
+    assert cell["failure_reason"] == "transport_drop"
 
 
 def test_writable_trials_use_fresh_isolated_worktrees(tmp_path, monkeypatch):
@@ -514,3 +515,173 @@ def test_cli_trial_plan_uses_explicit_roster(tmp_path, capsys):
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)
     assert len(payload["cells"]) == 2
+
+
+def test_timeout_sets_failure_reason_and_measurement_exit(tmp_path, monkeypatch):
+    manifest_path = tmp_path / "eval.json"
+    manifest_path.write_text(json.dumps(_manifest()))
+
+    def fake_run(task, roster, **kwargs):
+        out = kwargs["output_dir"]
+        out.mkdir(parents=True, exist_ok=True)
+        (out / "final.txt").write_text("partial\n")
+        (out / "run.json").write_text(
+            json.dumps({"status": "timeout", "failure_kind": "timeout", "duration_seconds": 30.0})
+        )
+        (out / "worker-results.json").write_text(
+            json.dumps({"results": [{"worker": "cursor", "ok": False, "timed_out": True, "transport": "cli"}]})
+        )
+        return 124
+
+    monkeypatch.setattr(model_trials.aboyeur, "run", fake_run)
+    root = tmp_path / "results"
+    assert model_trials.execute(manifest_path, _roster(), workspace=tmp_path, output_dir=root, resume=False) == 3
+    cell = json.loads(next((root / "cells").glob("*/cell.json")).read_text())
+    assert cell["state"] == "execution_error"
+    assert cell["failure_reason"] == "timeout"
+    summary = model_trials.summarize(root)
+    assert summary["measurement_failures"] == 2
+
+
+def test_process_exit_measurement_dominates_deterministic_failure():
+    summary = {
+        "measurement_failures": 1,
+        "counts": {"rejected": 2, "adapter_error": 1},
+    }
+    assert model_trials.process_exit(summary) == 3
+    summary = {"measurement_failures": 0, "counts": {"rejected": 1}}
+    assert model_trials.process_exit(summary) == 1
+    summary = {"measurement_failures": 0, "counts": {"accepted": 2}}
+    assert model_trials.process_exit(summary) == 0
+
+
+def test_summarize_splits_partial_scores_from_headline_scores(tmp_path):
+    root = tmp_path / "results"
+    cell_dir = root / "cells" / "cell-a"
+    cell_dir.mkdir(parents=True)
+    localio = model_trials.localio
+    localio.write_json(
+        root / "plan.json",
+        {
+            "schema": model_trials.MANIFEST_SCHEMA,
+            "name": "partial",
+            "manifest_digest": "abc",
+            "cells": [{"cell_id": "cell-a", "coordinate": "x:cursor:1"}],
+        },
+    )
+    localio.write_json(
+        cell_dir / "cell.json",
+        {
+            "schema": model_trials.CELL_SCHEMA,
+            "cell_id": "cell-a",
+            "state": "grader_error",
+            "graders": [
+                {"status": "scored", "score": 1.0},
+                {"status": "grader_error", "score": None},
+            ],
+        },
+    )
+    summary = model_trials.summarize(root)
+    assert summary["measurement_failures"] == 1
+    assert summary["partial_scores"]["count"] == 1
+    assert summary["partial_scores"]["mean"] == 1.0
+    assert summary["scores"]["count"] == 0
+
+
+def test_regrade_rescores_grader_error_without_seat_rerun(tmp_path, monkeypatch):
+    manifest = _manifest()
+    manifest["trials"] = 1
+    manifest_path = tmp_path / "eval.json"
+    manifest_path.write_text(json.dumps(manifest))
+    root = tmp_path / "results"
+    cell = model_trials.expand_cells(manifest, _roster())[0]
+    run_dir = root / "cells" / cell.cell_id / "attempts" / "attempt-001" / "run"
+    run_dir.mkdir(parents=True)
+    (run_dir / "final.txt").write_text("hello\n")
+    (run_dir / "run.json").write_text(json.dumps({"status": "ok", "cwd": str(tmp_path), "duration_seconds": 0.1}))
+    digest = model_trials._output_digest("hello\n")
+    plan, _ = model_trials.build_plan(manifest_path, _roster(), root)
+    model_trials.localio.write_json(root / "plan.json", plan)
+    broken_graders = model_trials.grade_output(
+        graders=[{"type": "regex_output", "pattern": "["}],
+        text="hello\n",
+        exit_code=0,
+        workspace=tmp_path,
+        run_dir=run_dir,
+    )
+    payload = model_trials._finalize_cell_payload(
+        cell,
+        plan=plan,
+        attempt=1,
+        started_at="2026-01-01T00:00:00+00:00",
+        exit_code=0,
+        run_dir=run_dir,
+        graders=broken_graders,
+        text="hello\n",
+        failure_reason=None,
+    )
+    model_trials._write_cell_payload(root / "cells" / cell.cell_id, run_dir.parent, payload)
+    assert payload["state"] == "grader_error"
+
+    monkeypatch.setattr(
+        model_trials.aboyeur, "run", lambda *a, **k: (_ for _ in ()).throw(AssertionError("seat rerun"))
+    )
+    assert model_trials.regrade(root) == 0
+    regressed = json.loads((root / "cells" / cell.cell_id / "cell.json").read_text())
+    assert regressed["state"] == "accepted"
+    assert regressed["graders"][0]["output_digest"] == digest
+
+
+def test_resume_regrades_grader_error_cells(tmp_path, monkeypatch):
+    manifest = _manifest()
+    manifest["trials"] = 1
+    manifest_path = tmp_path / "eval.json"
+    manifest_path.write_text(json.dumps(manifest))
+    root = tmp_path / "results"
+    cell = model_trials.expand_cells(manifest, _roster())[0]
+    run_dir = root / "cells" / cell.cell_id / "attempts" / "attempt-001" / "run"
+    run_dir.mkdir(parents=True)
+    (run_dir / "final.txt").write_text("hello\n")
+    (run_dir / "run.json").write_text(json.dumps({"status": "ok", "cwd": str(tmp_path)}))
+    plan, _ = model_trials.build_plan(manifest_path, _roster(), root)
+    model_trials.localio.write_json(root / "plan.json", plan)
+    broken = model_trials.grade_output(
+        graders=[{"type": "regex_output", "pattern": "["}],
+        text="hello\n",
+        exit_code=0,
+        workspace=tmp_path,
+        run_dir=run_dir,
+    )
+    payload = model_trials._finalize_cell_payload(
+        cell,
+        plan=plan,
+        attempt=1,
+        started_at="2026-01-01T00:00:00+00:00",
+        exit_code=0,
+        run_dir=run_dir,
+        graders=broken,
+        text="hello\n",
+        failure_reason=None,
+    )
+    model_trials._write_cell_payload(root / "cells" / cell.cell_id, run_dir.parent, payload)
+    monkeypatch.setattr(
+        model_trials.aboyeur, "run", lambda *a, **k: (_ for _ in ()).throw(AssertionError("seat rerun"))
+    )
+    assert model_trials.execute(manifest_path, _roster(), workspace=tmp_path, output_dir=root, resume=True) == 0
+
+
+def test_project_cell_strips_prompt_and_relativizes_run_dir(tmp_path):
+    run_dir = tmp_path / "results" / "cells" / "abc" / "attempts" / "attempt-001" / "run"
+    cell = {
+        "schema": model_trials.CELL_SCHEMA,
+        "cell_id": "abc",
+        "prompt": "secret prompt",
+        "case": {"id": "hello", "prompt": "nested secret"},
+        "run_dir": str(run_dir),
+    }
+    projected = model_trials.project_cell(cell, base_dir=tmp_path / "results")
+    assert "prompt" not in projected
+    assert projected["prompt_digest"].startswith("sha256:")
+    assert projected["case"]["prompt_digest"].startswith("sha256:")
+    assert "prompt" not in projected["case"]
+    assert projected["run_dir"] == "cells/abc/attempts/attempt-001/run"


### PR DESCRIPTION
## Summary
- Freeze the model-trial outcome contract in `docs/model-trial-taxonomy.md` (#435).
- Add `failure_reason` on cells (`timeout`, `transport_drop`, `provider_5xx`), drop `exit_code` from `grader_result.v1`, and split `measurement_failures` / `partial_scores` in `summary.json`.
- Implement three-valued process exit (0/1/3), `brigade model trial regrade`, resume regrade for `grader_error`, and `project_cell` export privacy.

Closes #435.

## Test plan
- [x] `brigade work verify run --target . --command "pytest -q tests/ -k 'trial or model_trials or grader or eval'" --capture brigade-work`
- [x] `./scripts/verify` (3944 passed, 82.49% coverage)
- [x] New tests: regrade without seat rerun, timeout `failure_reason`, `process_exit` dominance, `project_cell` privacy, partial score split

## Notes
- `--retry-transient` intentionally deferred per #435.
- No version bump / release artifacts (contract-only cut).

Made with [Cursor](https://cursor.com)