### PR TITLE
test(harness): probe live discovery in isolated sandboxes

### DIFF
--- a/docs/proposals/harness-contract.v1.schema.json
+++ b/docs/proposals/harness-contract.v1.schema.json
@@ -121,18 +121,46 @@
         "platform"
       ],
       "properties": {
-        "instruction": {"const": "declared"},
-        "skill": {"const": "declared"},
-        "hook": {"const": "declared"},
-        "mcp": {"const": "declared"},
-        "workspace": {"const": "declared"},
-        "session": {"const": "declared"},
-        "verification": {"const": "declared"},
-        "handoff": {"const": "declared"},
-        "reload": {"const": "declared"},
-        "telemetry": {"const": "declared"},
-        "platform": {"const": "declared"}
+        "instruction": {"$ref": "#/definitions/deep_probe_entry"},
+        "skill": {"$ref": "#/definitions/deep_probe_entry"},
+        "hook": {"$ref": "#/definitions/deep_probe_entry"},
+        "mcp": {"$ref": "#/definitions/deep_probe_entry"},
+        "workspace": {"$ref": "#/definitions/deep_probe_entry"},
+        "session": {"$ref": "#/definitions/deep_probe_entry"},
+        "verification": {"$ref": "#/definitions/deep_probe_entry"},
+        "handoff": {"$ref": "#/definitions/deep_probe_entry"},
+        "reload": {"$ref": "#/definitions/deep_probe_entry"},
+        "telemetry": {"$ref": "#/definitions/deep_probe_entry"},
+        "platform": {"$ref": "#/definitions/deep_probe_entry"}
       }
+    }
+  },
+  "definitions": {
+    "deep_probe_discovery": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["command", "args"],
+      "properties": {
+        "command": {"type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9_.-]*$"},
+        "args": {
+          "type": "array",
+          "items": {"type": "string"}
+        }
+      }
+    },
+    "deep_probe_entry": {
+      "oneOf": [
+        {"const": "declared"},
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["state"],
+          "properties": {
+            "state": {"const": "declared"},
+            "discovery": {"$ref": "#/definitions/deep_probe_discovery"}
+          }
+        }
+      ]
     }
   },
   "allOf": [

--- a/docs/proposals/harness-contract.v1.schema.json
+++ b/docs/proposals/harness-contract.v1.schema.json
@@ -137,6 +137,7 @@
   },
   "definitions": {
     "deep_probe_discovery": {
+      "$comment": "validate_fixture mirrors this contract because the bundled validator does not resolve $ref or oneOf.",
       "type": "object",
       "additionalProperties": false,
       "required": ["command", "args"],
@@ -149,6 +150,7 @@
       }
     },
     "deep_probe_entry": {
+      "$comment": "validate_fixture mirrors this contract because the bundled validator does not resolve $ref or oneOf.",
       "oneOf": [
         {"const": "declared"},
         {

--- a/docs/research/fixtures/harness-contract.v1/codex-cli.json
+++ b/docs/research/fixtures/harness-contract.v1/codex-cli.json
@@ -15,5 +15,17 @@
     {"id": "telemetry", "claim": "Telemetry behavior was not probed.", "provenance": "unknown", "support_state": "unsupported", "implementation_layers": ["unknown"], "evidence": [{"kind": "probe_receipt", "reference": "probe_codex/.brigade/runs/20260718-044429-114cf3b9"}], "tested_version": "0.144.5", "platform": "linux", "scope": "unprobed"},
     {"id": "platform", "claim": "Codex CLI is documented for local desktop platforms.", "provenance": "documented", "support_state": "native", "implementation_layers": ["native"], "evidence": [{"kind": "vendor_documentation", "reference": "https://learn.chatgpt.com/docs/codex/cli"}], "tested_version": "0.144.5", "platform": "linux", "scope": "local"}
   ],
-  "deep_probes": {"instruction": "declared", "skill": "declared", "hook": "declared", "mcp": "declared", "workspace": "declared", "session": "declared", "verification": "declared", "handoff": "declared", "reload": "declared", "telemetry": "declared", "platform": "declared"}
+  "deep_probes": {
+    "instruction": {"state": "declared", "discovery": {"command": "codex", "args": ["--help"]}},
+    "skill": "declared",
+    "hook": "declared",
+    "mcp": "declared",
+    "workspace": "declared",
+    "session": "declared",
+    "verification": "declared",
+    "handoff": "declared",
+    "reload": "declared",
+    "telemetry": "declared",
+    "platform": "declared"
+  }
 }

--- a/tests/test_harness_conformance_probe.py
+++ b/tests/test_harness_conformance_probe.py
@@ -606,6 +606,410 @@ def test_deep_probes_are_returned_not_executed(probe, schema, fixtures) -> None:
         "telemetry",
         "platform",
     }
+    assert "deep_probe_receipts" not in result
+
+
+def test_schema_accepts_inline_discovery_spec(probe, schema, fixtures) -> None:
+    fixture = next(item for item in fixtures if item["harness"]["id"] == "codex-cli")
+    assert probe.validate_fixture(fixture, schema) == []
+    assert fixture["deep_probes"]["instruction"]["discovery"] == {
+        "command": "codex",
+        "args": ["--help"],
+    }
+
+
+def test_run_deep_probes_default_policy_stays_declared_only_not_executed(probe, schema, fixtures) -> None:
+    result = probe.probe_fixture(fixtures[0], schema, run_version=False, run_deep_probes=False, timeout_seconds=1.0)
+    assert "deep_probe_receipts" not in result
+
+
+def test_run_deep_probes_emits_one_receipt_per_declared_probe(probe, schema) -> None:
+    fixture = _fixture_with_deep_probes(
+        harness_id="receipt-count-cli",
+        deep_probes=_deep_probes_with_instruction_discovery(),
+    )
+    with (
+        mock.patch.object(probe.shutil, "which", return_value="/fake/bin/codex"),
+        mock.patch.object(probe, "_popen_probe_process", return_value=_fake_version_process()),
+        mock.patch.object(
+            probe,
+            "_collect_bounded_output",
+            return_value=(b"codex help output\n", False, None),
+        ),
+    ):
+        result = probe.probe_fixture(fixture, schema, run_version=False, run_deep_probes=True, timeout_seconds=1.0)
+    receipts = result["deep_probe_receipts"]
+    assert set(receipts) == set(_minimal_deep_probes())
+    assert len(receipts) == 11
+
+
+def test_run_deep_probes_declared_only_without_discovery_spec(probe, schema) -> None:
+    fixture = _fixture_with_deep_probes(harness_id="declared-only-cli", deep_probes=_minimal_deep_probes())
+    result = probe.probe_fixture(fixture, schema, run_version=False, run_deep_probes=True, timeout_seconds=1.0)
+    receipt = result["deep_probe_receipts"]["skill"]
+    assert receipt["probe_id"] == "skill"
+    assert receipt["state"] == "declared_only"
+    assert receipt["reason"] == "no_discovery_spec"
+    assert receipt["platform"] == sys.platform
+
+
+def test_run_deep_probes_executes_safe_discovery_spec(probe, schema, monkeypatch, tmp_path: Path) -> None:
+    fixture = _fixture_with_deep_probes(
+        harness_id="discovery-cli",
+        deep_probes=_deep_probes_with_instruction_discovery(),
+    )
+    real_home = tmp_path / "real-home"
+    real_home.mkdir()
+    monkeypatch.setenv("HOME", str(real_home))
+    monkeypatch.setenv("USERPROFILE", str(real_home))
+    process = _fake_version_process()
+    with (
+        mock.patch.object(probe.shutil, "which", return_value="/fake/bin/codex"),
+        mock.patch.object(probe, "_popen_probe_process", return_value=process) as popen,
+        mock.patch.object(
+            probe,
+            "_collect_bounded_output",
+            return_value=(
+                (
+                    f"codex help output\nhome={real_home}\n"
+                    "credential=fake-credential\n"
+                    "AWS_SECRET_ACCESS_KEY=fake-access-key\n"
+                    "private_key=fake-private-key\n"
+                    '{"AWS_SECRET_ACCESS_KEY":"fake-json-access-key",'
+                    '"apiKey":"fake-json-api-key",'
+                    '"private_key":"fake-escaped-\\"private-key"}\n'
+                ).encode(),
+                False,
+                None,
+            ),
+        ),
+    ):
+        result = probe.probe_fixture(fixture, schema, run_version=False, run_deep_probes=True, timeout_seconds=1.0)
+    popen.assert_called_once()
+    argv = popen.call_args[0][0]
+    kwargs = popen.call_args[1]
+    assert argv == ["/fake/bin/codex", "--help"]
+    sandbox_root = Path(kwargs["cwd"])
+    environment = kwargs["env"]
+    for variable in ("HOME", "USERPROFILE", "XDG_CONFIG_HOME", "XDG_CACHE_HOME", "XDG_DATA_HOME"):
+        assert Path(environment[variable]).is_relative_to(sandbox_root)
+        assert str(real_home) not in environment[variable]
+    receipt = result["deep_probe_receipts"]["instruction"]
+    assert receipt["state"] == "observed"
+    assert receipt["probe_id"] == "instruction"
+    assert receipt["command"] == "codex"
+    assert receipt["exit_code"] == 0
+    assert receipt["platform"] == sys.platform
+    assert "codex help output" in receipt["output"]
+    assert str(real_home) not in receipt["output"]
+    assert "fake-credential" not in receipt["output"]
+    assert "fake-access-key" not in receipt["output"]
+    assert "fake-private-key" not in receipt["output"]
+    assert "fake-json-access-key" not in receipt["output"]
+    assert "fake-json-api-key" not in receipt["output"]
+    assert "fake-escaped" not in receipt["output"]
+    assert receipt["output"].count("[REDACTED]") == 6
+    assert ('{"AWS_SECRET_ACCESS_KEY":"[REDACTED]","apiKey":"[REDACTED]","private_key":"[REDACTED]"}\n') in receipt[
+        "output"
+    ]
+
+
+def test_run_deep_probes_blocked_fixture_stays_declared_only(probe, schema) -> None:
+    fixture = _fixture_with_deep_probes(
+        harness_id="blocked-cli",
+        deep_probes=_deep_probes_with_instruction_discovery(),
+        command="missing-binary",
+    )
+    with (
+        mock.patch.object(probe.shutil, "which", return_value=None),
+        mock.patch.object(probe, "_popen_probe_process") as popen,
+    ):
+        result = probe.probe_fixture(fixture, schema, run_version=False, run_deep_probes=True, timeout_seconds=1.0)
+    popen.assert_not_called()
+    assert result["availability"]["state"] == "externally_blocked"
+    receipt = result["deep_probe_receipts"]["instruction"]
+    assert receipt["state"] == "declared_only"
+    assert receipt["reason"] == "externally_blocked_fixture"
+
+
+def test_run_deep_probes_invalid_fixture_emits_declared_only_receipts_without_launch(probe, schema) -> None:
+    fixture = _fixture_with_deep_probes(
+        harness_id="invalid-cli",
+        deep_probes=_deep_probes_with_instruction_discovery(),
+    )
+    fixture["unexpected"] = True
+    with mock.patch.object(probe, "_popen_probe_process") as popen:
+        result = probe.probe_fixture(fixture, schema, run_version=False, run_deep_probes=True, timeout_seconds=1.0)
+    popen.assert_not_called()
+    assert result["availability"]["state"] == "not_executable"
+    receipts = result["deep_probe_receipts"]
+    assert len(receipts) == len(_minimal_deep_probes())
+    assert {receipt["reason"] for receipt in receipts.values()} == {"invalid_fixture"}
+    assert {receipt["state"] for receipt in receipts.values()} == {"declared_only"}
+
+
+def test_run_deep_probes_invalid_nonobject_declarations_emit_receipts_without_launch(probe, schema) -> None:
+    fixture = _fixture_with_deep_probes(
+        harness_id="invalid-deep-probes-cli",
+        deep_probes=_minimal_deep_probes(),
+    )
+    fixture["deep_probes"] = "invalid"
+    with mock.patch.object(probe, "_popen_probe_process") as popen:
+        result = probe.probe_fixture(fixture, schema, run_version=False, run_deep_probes=True, timeout_seconds=1.0)
+    popen.assert_not_called()
+    assert result["availability"]["state"] == "not_executable"
+    receipts = result["deep_probe_receipts"]
+    assert len(receipts) == len(_minimal_deep_probes())
+    assert {receipt["reason"] for receipt in receipts.values()} == {"invalid_fixture"}
+    assert {receipt["state"] for receipt in receipts.values()} == {"declared_only"}
+
+
+def test_run_deep_probes_refuses_unsafe_command_before_launch(probe, schema) -> None:
+    fixture = _fixture_with_deep_probes(
+        harness_id="unsafe-command-cli",
+        deep_probes={
+            **_minimal_deep_probes(),
+            "instruction": {
+                "state": "declared",
+                "discovery": {"command": "/bin/sh", "args": ["--help"]},
+            },
+        },
+    )
+    with mock.patch.object(probe, "_popen_probe_process") as popen:
+        result = probe.probe_fixture(fixture, schema, run_version=False, run_deep_probes=True, timeout_seconds=1.0)
+    popen.assert_not_called()
+    receipt = result["deep_probe_receipts"]["instruction"]
+    assert receipt["state"] == "refused"
+    assert receipt["reason"] == "unsafe_command_name"
+
+
+def test_run_deep_probes_refuses_unsafe_args_before_launch(probe, schema) -> None:
+    fixture = _fixture_with_deep_probes(
+        harness_id="unsafe-args-cli",
+        deep_probes={
+            **_minimal_deep_probes(),
+            "instruction": {
+                "state": "declared",
+                "discovery": {"command": "codex", "args": ["-c", "print('x')"]},
+            },
+        },
+    )
+    with mock.patch.object(probe, "_popen_probe_process") as popen:
+        result = probe.probe_fixture(fixture, schema, run_version=False, run_deep_probes=True, timeout_seconds=1.0)
+    popen.assert_not_called()
+    receipt = result["deep_probe_receipts"]["instruction"]
+    assert receipt["state"] == "refused"
+    assert receipt["reason"] == "unsafe_discovery_arguments"
+
+
+def test_run_deep_probes_refuses_args_outside_exact_allowlist(probe, schema) -> None:
+    fixture = _fixture_with_deep_probes(
+        harness_id="unallowlisted-args-cli",
+        deep_probes={
+            **_minimal_deep_probes(),
+            "instruction": {
+                "state": "declared",
+                "discovery": {"command": "codex", "args": ["config", "--help"]},
+            },
+        },
+    )
+    with mock.patch.object(probe, "_popen_probe_process") as popen:
+        result = probe.probe_fixture(fixture, schema, run_version=False, run_deep_probes=True, timeout_seconds=1.0)
+    popen.assert_not_called()
+    receipt = result["deep_probe_receipts"]["instruction"]
+    assert receipt["state"] == "refused"
+    assert receipt["reason"] == "unsafe_discovery_arguments"
+
+
+def test_run_deep_probes_nonzero_exit_preserves_bounded_output(probe, schema, monkeypatch, tmp_path: Path) -> None:
+    fixture = _fixture_with_deep_probes(
+        harness_id="nonzero-discovery-cli",
+        deep_probes=_deep_probes_with_instruction_discovery(),
+    )
+    real_home = tmp_path / "real-home"
+    real_home.mkdir()
+    monkeypatch.setenv("HOME", str(real_home))
+    process = _fake_version_process(exit_code=2)
+    with (
+        mock.patch.object(probe.shutil, "which", return_value="/fake/bin/codex"),
+        mock.patch.object(probe, "_popen_probe_process", return_value=process),
+        mock.patch.object(
+            probe,
+            "_collect_bounded_output",
+            return_value=(
+                (f'token=abc123\nconfig={real_home}/.config/codex\n{{"apiKey":"fake-nonzero-json-key"}}\n').encode(),
+                False,
+                None,
+            ),
+        ),
+    ):
+        result = probe.probe_fixture(fixture, schema, run_version=False, run_deep_probes=True, timeout_seconds=1.0)
+    receipt = result["deep_probe_receipts"]["instruction"]
+    assert receipt["state"] == "nonzero_exit"
+    assert receipt["reason"] == "nonzero_exit"
+    assert receipt["exit_code"] == 2
+    assert "abc123" not in receipt["output"]
+    assert "fake-nonzero-json-key" not in receipt["output"]
+    assert str(real_home) not in receipt["output"]
+    assert "[REDACTED]" in receipt["output"]
+    assert "[HOME]/.config/codex" in receipt["output"]
+
+
+def test_run_deep_probes_timeout_preserves_bounded_output(probe, schema) -> None:
+    fixture = _fixture_with_deep_probes(
+        harness_id="timeout-discovery-cli",
+        deep_probes=_deep_probes_with_instruction_discovery(),
+    )
+    process = mock.Mock()
+    process.poll.return_value = None
+    process.pid = 5151
+    with (
+        mock.patch.object(probe.shutil, "which", return_value="/fake/bin/codex"),
+        mock.patch.object(probe, "_popen_probe_process", return_value=process),
+        mock.patch.object(
+            probe,
+            "_collect_bounded_output",
+            return_value=(
+                (
+                    "partial output\n"
+                    "credential=fake-timeout-credential\n"
+                    '{"AWS_SECRET_ACCESS_KEY":"fake-timeout-json-key"}\n'
+                ).encode(),
+                False,
+                "TimeoutExpired",
+            ),
+        ),
+    ):
+        result = probe.probe_fixture(fixture, schema, run_version=False, run_deep_probes=True, timeout_seconds=0.01)
+    receipt = result["deep_probe_receipts"]["instruction"]
+    assert receipt["state"] == "externally_blocked"
+    assert receipt["reason"] == "TimeoutExpired"
+    assert receipt["output"] == ('partial output\ncredential=[REDACTED]\n{"AWS_SECRET_ACCESS_KEY":"[REDACTED]"}\n')
+    assert "fake-timeout-credential" not in receipt["output"]
+    assert "fake-timeout-json-key" not in receipt["output"]
+
+
+def test_run_deep_probes_output_overflow_preserves_bounded_output(probe, schema) -> None:
+    fixture = _fixture_with_deep_probes(
+        harness_id="overflow-discovery-cli",
+        deep_probes=_deep_probes_with_instruction_discovery(),
+    )
+    process = mock.Mock()
+    process.poll.return_value = 0
+    process.pid = 5152
+    json_secret_line = '{"token":"x"}\n'
+    overflow_output = json_secret_line * (probe.OUTPUT_CAP_BYTES // len(json_secret_line))
+    overflow_output += "x" * (probe.OUTPUT_CAP_BYTES % len(json_secret_line))
+    assert len(overflow_output.encode()) == probe.OUTPUT_CAP_BYTES
+    with (
+        mock.patch.object(probe.shutil, "which", return_value="/fake/bin/codex"),
+        mock.patch.object(probe, "_popen_probe_process", return_value=process),
+        mock.patch.object(
+            probe,
+            "_collect_bounded_output",
+            return_value=(overflow_output.encode(), True, "output_overflow"),
+        ),
+    ):
+        result = probe.probe_fixture(fixture, schema, run_version=False, run_deep_probes=True, timeout_seconds=1.0)
+    receipt = result["deep_probe_receipts"]["instruction"]
+    assert receipt["state"] == "externally_blocked"
+    assert receipt["reason"] == "output_overflow"
+    assert json_secret_line not in receipt["output"]
+    assert receipt["output"].startswith('{"token":"[REDACTED]"}\n')
+    assert len(receipt["output"].encode()) <= probe.OUTPUT_CAP_BYTES
+
+
+def test_run_deep_probes_output_overflow_redacts_unterminated_json_at_boundary(probe, schema) -> None:
+    fixture = _fixture_with_deep_probes(
+        harness_id="overflow-partial-json-cli",
+        deep_probes=_deep_probes_with_instruction_discovery(),
+    )
+    process = mock.Mock()
+    process.poll.return_value = 0
+    process.pid = 5153
+    partial_secret = '{"apiKey":"partial-secret'
+    overflow_output = ("x" * (probe.OUTPUT_CAP_BYTES - len(partial_secret))) + partial_secret
+    with (
+        mock.patch.object(probe.shutil, "which", return_value="/fake/bin/codex"),
+        mock.patch.object(probe, "_popen_probe_process", return_value=process),
+        mock.patch.object(
+            probe,
+            "_collect_bounded_output",
+            return_value=(overflow_output.encode(), True, "output_overflow"),
+        ),
+    ):
+        result = probe.probe_fixture(fixture, schema, run_version=False, run_deep_probes=True, timeout_seconds=1.0)
+    receipt = result["deep_probe_receipts"]["instruction"]
+    assert receipt["state"] == "externally_blocked"
+    assert receipt["reason"] == "output_overflow"
+    assert "partial-secret" not in receipt["output"]
+    assert len(receipt["output"].encode()) <= probe.OUTPUT_CAP_BYTES
+
+
+def test_run_deep_probes_sandbox_routes_writes_away_from_real_home(probe, schema, monkeypatch, tmp_path: Path) -> None:
+    real_home = tmp_path / "real-home"
+    real_home.mkdir()
+    monkeypatch.setenv("HOME", str(real_home))
+    monkeypatch.setenv("USERPROFILE", str(real_home))
+    helper = tmp_path / "probe-home-check"
+    helper.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, os\n"
+        "from pathlib import Path\n"
+        'target = Path(os.environ["HOME"]) / ".probe-config" / "receipt"\n'
+        "target.parent.mkdir(parents=True)\n"
+        'target.write_text("sandboxed")\n'
+        "print(json.dumps({\n"
+        '    "target": str(target),\n'
+        '    "cwd": os.getcwd(),\n'
+        '    "exists": target.is_file(),\n'
+        "}))\n"
+    )
+    helper.chmod(0o755)
+    fixture = _fixture_with_deep_probes(
+        harness_id="sandbox-home-cli",
+        deep_probes={
+            **_minimal_deep_probes(),
+            "instruction": {
+                "state": "declared",
+                "discovery": {"command": "probe-home-check", "args": ["--help"]},
+            },
+        },
+    )
+    with mock.patch.object(probe.shutil, "which", return_value=str(helper)):
+        result = probe.probe_fixture(fixture, schema, run_version=False, run_deep_probes=True, timeout_seconds=2.0)
+    receipt = result["deep_probe_receipts"]["instruction"]
+    assert receipt["state"] == "observed"
+    assert '"exists": true' in receipt["output"]
+    assert "[HOME]/.probe-config/receipt" in receipt["output"]
+    assert '"cwd": "[HOME]"' in receipt["output"]
+    assert str(tmp_path) not in receipt["output"]
+    assert list(real_home.iterdir()) == []
+    assert not (real_home / ".probe-session").exists()
+
+
+def test_probe_script_reports_deep_probe_policy_and_opt_in_flag(probe) -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(PROBE_PATH),
+            "--fixtures-dir",
+            str(FIXTURES_DIR),
+            "--schema",
+            str(SCHEMA_PATH),
+            "--run-deep-probes",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PATH": ""},
+    )
+    assert completed.returncode == 0
+    payload = json.loads(completed.stdout)
+    assert payload["deep_probe_policy"] == "executed_when_specified"
+    assert payload["run_deep_probes"] is True
+    codex = next(item for item in payload["results"] if item["harness_id"] == "codex-cli")
+    assert len(codex["deep_probe_receipts"]) == 11
 
 
 def test_probe_script_is_tracked_under_tools() -> None:
@@ -626,7 +1030,33 @@ def test_probe_script_is_tracked_under_tools() -> None:
     assert completed.returncode == 0
     payload = json.loads(completed.stdout)
     assert payload["deep_probe_policy"] == "declared_only_not_executed"
+    assert payload["run_deep_probes"] is False
     assert len(payload["results"]) == 11
+
+
+def _fixture_with_deep_probes(
+    *,
+    harness_id: str,
+    deep_probes: dict[str, object],
+    command: str = "python3",
+) -> dict[str, object]:
+    return {
+        "schema": "harness-contract.v1",
+        "harness": {"id": harness_id, "surface": "cli"},
+        "binary": {"command": command, "version_args": ["--version"]},
+        "capabilities": _minimal_capabilities(),
+        "deep_probes": deep_probes,
+    }
+
+
+def _deep_probes_with_instruction_discovery() -> dict[str, object]:
+    return {
+        **_minimal_deep_probes(),
+        "instruction": {
+            "state": "declared",
+            "discovery": {"command": "codex", "args": ["--help"]},
+        },
+    }
 
 
 def _minimal_capabilities() -> list[dict[str, object]]:

--- a/tests/test_harness_conformance_probe.py
+++ b/tests/test_harness_conformance_probe.py
@@ -108,6 +108,83 @@ def test_additional_top_level_property_fails_schema_validation(probe, schema, fi
     assert any("additional property" in error for error in errors)
 
 
+@pytest.mark.parametrize(
+    ("entry", "expected_error"),
+    [
+        (42, "fixture.deep_probes.instruction: expected 'declared' or a declared probe object"),
+        ("observed", "fixture.deep_probes.instruction: expected 'declared' or a declared probe object"),
+        ({}, "fixture.deep_probes.instruction: missing required property 'state'"),
+        ({"state": "observed"}, "fixture.deep_probes.instruction.state: expected const 'declared'"),
+        (
+            {"state": "declared", "unexpected": True},
+            "fixture.deep_probes.instruction.unexpected: additional property is not allowed",
+        ),
+    ],
+)
+def test_validate_fixture_enforces_deep_probe_entry_invariants_without_one_of_or_ref(
+    probe,
+    schema,
+    entry: object,
+    expected_error: str,
+) -> None:
+    fixture = _fixture_with_deep_probes(harness_id="invalid-deep-probe-entry", deep_probes=_minimal_deep_probes())
+    fixture["deep_probes"]["instruction"] = entry  # type: ignore[index]
+
+    errors = probe.validate_fixture(fixture, schema)
+
+    assert expected_error in errors
+
+
+@pytest.mark.parametrize(
+    ("discovery", "expected_error"),
+    [
+        ("codex --help", "fixture.deep_probes.instruction.discovery: expected type 'object'"),
+        ({"args": ["--help"]}, "fixture.deep_probes.instruction.discovery: missing required property 'command'"),
+        ({"command": "codex"}, "fixture.deep_probes.instruction.discovery: missing required property 'args'"),
+        (
+            {"command": "codex", "args": ["--help"], "unexpected": True},
+            "fixture.deep_probes.instruction.discovery.unexpected: additional property is not allowed",
+        ),
+        (
+            {"command": 12, "args": ["--help"]},
+            "fixture.deep_probes.instruction.discovery.command: expected type 'string'",
+        ),
+        (
+            {"command": None, "args": ["--help"]},
+            "fixture.deep_probes.instruction.discovery.command: expected type 'string'",
+        ),
+        (
+            {"command": "/bin/sh", "args": ["--help"]},
+            "fixture.deep_probes.instruction.discovery.command: string does not match bare-command pattern",
+        ),
+        (
+            {"command": "codex", "args": "--help"},
+            "fixture.deep_probes.instruction.discovery.args: expected type 'array'",
+        ),
+        (
+            {"command": "codex", "args": None},
+            "fixture.deep_probes.instruction.discovery.args: expected type 'array'",
+        ),
+        (
+            {"command": "codex", "args": ["--help", 12]},
+            "fixture.deep_probes.instruction.discovery.args[1]: expected type 'string'",
+        ),
+    ],
+)
+def test_validate_fixture_enforces_deep_probe_discovery_invariants_without_ref(
+    probe,
+    schema,
+    discovery: object,
+    expected_error: str,
+) -> None:
+    fixture = _fixture_with_deep_probes(harness_id="invalid-deep-probe-discovery", deep_probes=_minimal_deep_probes())
+    fixture["deep_probes"]["instruction"] = {"state": "declared", "discovery": discovery}  # type: ignore[index]
+
+    errors = probe.validate_fixture(fixture, schema)
+
+    assert expected_error in errors
+
+
 def test_redact_text_removes_assignment_secrets_authorization_and_bearer(probe) -> None:
     sample = "\n".join(
         [
@@ -125,6 +202,104 @@ def test_redact_text_removes_assignment_secrets_authorization_and_bearer(probe) 
     assert "[REDACTED]" in result
     assert "Bearer [REDACTED]" in result
     assert '"token": "[REDACTED]"' in result
+
+
+def test_redact_text_removes_complete_whitespace_quoted_assignment_credentials(probe) -> None:
+    sample = "KEY = \"a b c\"\nprivate_key = 'one two three'"
+
+    result = probe.redact_text(sample)
+
+    assert "a b c" not in result
+    assert "one two three" not in result
+    assert "KEY = [REDACTED]" in result
+    assert "private_key = [REDACTED]" in result
+
+
+def test_redact_text_removes_multiline_quoted_assignment_credentials_without_over_redacting(probe) -> None:
+    sample = 'token = "first line\nsecond line"\nmessage = "first line\nsecond line"'
+
+    result = probe.redact_text(sample)
+
+    assert result == 'token = [REDACTED]\nmessage = "first line\nsecond line"'
+
+
+def test_redact_bounded_output_redacts_unterminated_whitespace_quoted_assignment_at_cap(probe) -> None:
+    unterminated_secret = 'KEY = "a b'
+    output = (b"x" * (probe.OUTPUT_CAP_BYTES - len(unterminated_secret) - 1)) + b"\n" + unterminated_secret.encode()
+
+    result = probe._redact_bounded_output(output)
+
+    assert "a b" not in result
+    assert result.endswith("KEY = [REDACTED]")
+    assert len(result.encode()) <= probe.OUTPUT_CAP_BYTES
+
+
+def test_redact_bounded_output_redacts_unterminated_multiline_assignment_at_cap(probe) -> None:
+    unterminated_secret = 'TOKEN = "first line\nsecond line'
+    output = (b"x" * (probe.OUTPUT_CAP_BYTES - len(unterminated_secret) - 1)) + b"\n" + unterminated_secret.encode()
+
+    result = probe._redact_bounded_output(output)
+
+    assert "first line" not in result
+    assert "second line" not in result
+    assert result.endswith("TOKEN = [REDACTED]")
+    assert len(result.encode()) <= probe.OUTPUT_CAP_BYTES
+
+
+def test_redact_text_removes_json_escaped_windows_private_paths_without_over_redacting(probe) -> None:
+    private_path = r'{"path":"C:\\Users\\name\\.ssh\\id_rsa"}'
+    benign_assignment = 'monkey = "a b c"'
+    benign_path = r'{"path":"D:\\workspace\\monkey\\keyboard"}'
+
+    result = probe.redact_text("\n".join([private_path, benign_assignment, benign_path]))
+
+    assert r"C:\\Users\\name" not in result
+    assert r'{"path":"[HOME]\\.ssh\\id_rsa"}' in result
+    assert benign_assignment in result
+    assert benign_path in result
+
+
+def test_redact_text_removes_forward_slash_and_mixed_windows_private_paths(probe) -> None:
+    forward_path = "C:/Users/name/.ssh/id_rsa"
+    mixed_path = r"C:\Users/name\.config\tool"
+
+    result = probe.redact_text(f"forward={forward_path}\nmixed={mixed_path}")
+
+    assert "C:/Users/name" not in result
+    assert r"C:\Users/name" not in result
+    assert "forward=[HOME]/.ssh/id_rsa" in result
+    assert r"mixed=[HOME]\.config\tool" in result
+
+
+@pytest.mark.parametrize(
+    "private_path",
+    [
+        r"C:\Users\Jane Doe\.ssh\id_rsa",
+        r"C:\\Users\\Jane Doe\\.ssh\\id_rsa",
+        "C:/Users/Jane Doe/.ssh/id_rsa",
+        r"C:\Users/Jane Doe/.ssh/id_rsa",
+    ],
+)
+def test_redact_text_removes_spaced_windows_home_prefix_for_all_separators(probe, private_path: str) -> None:
+    result = probe.redact_text(f"private={private_path}\nbenign=D:/workspace/Jane Doe/file")
+
+    assert "Jane" not in result.splitlines()[0]
+    assert "Doe" not in result.splitlines()[0]
+    assert result.splitlines()[0].startswith("private=[HOME]")
+    assert ".ssh" in result.splitlines()[0]
+    assert "benign=D:/workspace/Jane Doe/file" in result
+
+
+def test_redact_bounded_output_preserves_prefix_when_redaction_expands_at_cap(probe) -> None:
+    raw_secret = b'{"token":"x"}'
+    output = b"BEGIN-ERROR\n" + (b"x" * (probe.OUTPUT_CAP_BYTES - len(b"BEGIN-ERROR\n") - len(raw_secret))) + raw_secret
+
+    result = probe._redact_bounded_output(output)
+
+    assert result.startswith("BEGIN-ERROR\n")
+    assert result.endswith('[REDACTED]"}')
+    assert '"token":"x"' not in result
+    assert len(result.encode()) <= probe.OUTPUT_CAP_BYTES
 
 
 def test_redact_text_removes_real_and_temporary_home_segments(probe, monkeypatch, tmp_path: Path) -> None:
@@ -643,6 +818,57 @@ def test_run_deep_probes_emits_one_receipt_per_declared_probe(probe, schema) -> 
     assert len(receipts) == 11
 
 
+def test_run_deep_probes_launch_oserror_emits_bounded_redacted_receipt_and_continues(probe, schema) -> None:
+    fixture = _fixture_with_deep_probes(
+        harness_id="launch-oserror-cli",
+        deep_probes={
+            **_deep_probes_with_instruction_discovery(),
+            "skill": {
+                "state": "declared",
+                "discovery": {"command": "codex", "args": ["--help"]},
+            },
+        },
+    )
+    launch_error = OSError(r'KEY = "a b c"; {"path":"C:\\Users\\name\\.ssh\\id_rsa"}')
+    with (
+        mock.patch.object(probe.shutil, "which", return_value="/fake/bin/codex"),
+        mock.patch.object(
+            probe,
+            "_popen_probe_process",
+            side_effect=[launch_error, _fake_version_process()],
+        ) as popen,
+        mock.patch.object(
+            probe,
+            "_collect_bounded_output",
+            return_value=(b"skill help output\n", False, None),
+        ),
+    ):
+        result = probe.probe_fixture(fixture, schema, run_version=False, run_deep_probes=True, timeout_seconds=1.0)
+
+    receipts = result["deep_probe_receipts"]
+    assert set(receipts) == set(_minimal_deep_probes())
+    assert len(receipts) == len(fixture["deep_probes"])
+    assert popen.call_count == 2
+    assert receipts["instruction"] == {
+        "probe_id": "instruction",
+        "state": "externally_blocked",
+        "reason": "OSError",
+        "command": "codex",
+        "exit_code": None,
+        "platform": sys.platform,
+        "output": 'KEY = [REDACTED]; {"path":"[HOME]\\\\.ssh\\\\id_rsa"}',
+    }
+    assert len(receipts["instruction"]["output"].encode()) <= probe.OUTPUT_CAP_BYTES
+    assert receipts["skill"] == {
+        "probe_id": "skill",
+        "state": "observed",
+        "command": "codex",
+        "exit_code": 0,
+        "platform": sys.platform,
+        "output": "skill help output\n",
+    }
+
+
 def test_run_deep_probes_declared_only_without_discovery_spec(probe, schema) -> None:
     fixture = _fixture_with_deep_probes(harness_id="declared-only-cli", deep_probes=_minimal_deep_probes())
     result = probe.probe_fixture(fixture, schema, run_version=False, run_deep_probes=True, timeout_seconds=1.0)
@@ -732,6 +958,30 @@ def test_run_deep_probes_blocked_fixture_stays_declared_only(probe, schema) -> N
     assert receipt["reason"] == "externally_blocked_fixture"
 
 
+def test_run_deep_probes_non_fixture_not_executable_stays_declared_only(probe) -> None:
+    fixture = _fixture_with_deep_probes(
+        harness_id="policy-blocked-cli",
+        deep_probes={
+            **_minimal_deep_probes(),
+            "instruction": {
+                "state": "declared",
+                "discovery": {"command": "/bin/sh", "args": ["--help"]},
+            },
+        },
+    )
+
+    with mock.patch.object(probe, "_popen_probe_process") as popen:
+        receipts = probe.collect_deep_probe_receipts(
+            fixture,
+            {"state": "not_executable", "reason": "policy_blocked"},
+            timeout_seconds=1.0,
+        )
+
+    popen.assert_not_called()
+    assert receipts["instruction"]["state"] == "declared_only"
+    assert receipts["instruction"]["reason"] == "externally_blocked_fixture"
+
+
 def test_run_deep_probes_invalid_fixture_emits_declared_only_receipts_without_launch(probe, schema) -> None:
     fixture = _fixture_with_deep_probes(
         harness_id="invalid-cli",
@@ -746,6 +996,114 @@ def test_run_deep_probes_invalid_fixture_emits_declared_only_receipts_without_la
     assert len(receipts) == len(_minimal_deep_probes())
     assert {receipt["reason"] for receipt in receipts.values()} == {"invalid_fixture"}
     assert {receipt["state"] for receipt in receipts.values()} == {"declared_only"}
+
+
+def test_run_deep_probes_invalid_fixture_refuses_unsafe_discovery_command_without_launch(probe, schema) -> None:
+    fixture = _fixture_with_deep_probes(
+        harness_id="invalid-unsafe-discovery-cli",
+        deep_probes={
+            **_minimal_deep_probes(),
+            "instruction": {
+                "discovery": {"command": "/bin/sh", "args": ["--help"]},
+            },
+        },
+    )
+    fixture["unexpected"] = True
+
+    with mock.patch.object(probe, "_popen_probe_process") as popen:
+        result = probe.probe_fixture(fixture, schema, run_version=False, run_deep_probes=True, timeout_seconds=1.0)
+
+    popen.assert_not_called()
+    assert any("additional property" in error for error in result["validation_errors"])
+    assert any("missing required property 'state'" in error for error in result["validation_errors"])
+    assert any("bare-command pattern" in error for error in result["validation_errors"])
+    receipts = result["deep_probe_receipts"]
+    assert receipts["instruction"]["state"] == "refused"
+    assert receipts["instruction"]["reason"] == "unsafe_command_name"
+    assert {receipt["state"] for probe_id, receipt in receipts.items() if probe_id != "instruction"} == {
+        "declared_only"
+    }
+    assert {receipt["reason"] for probe_id, receipt in receipts.items() if probe_id != "instruction"} == {
+        "invalid_fixture"
+    }
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        "--help",
+        ["--help", 1],
+        ["config", "--help"],
+    ],
+)
+def test_run_deep_probes_invalid_fixture_refuses_unsafe_discovery_args_without_launch(
+    probe, schema, args: object
+) -> None:
+    fixture = _fixture_with_deep_probes(
+        harness_id="invalid-unsafe-args-cli",
+        deep_probes={
+            **_minimal_deep_probes(),
+            "instruction": {
+                "state": "declared",
+                "discovery": {"command": "codex", "args": args},
+            },
+        },
+    )
+    fixture["unexpected"] = True
+
+    with mock.patch.object(probe, "_popen_probe_process") as popen:
+        result = probe.probe_fixture(fixture, schema, run_version=False, run_deep_probes=True, timeout_seconds=1.0)
+
+    popen.assert_not_called()
+    receipt = result["deep_probe_receipts"]["instruction"]
+    assert receipt["state"] == "refused"
+    assert receipt["reason"] == "unsafe_discovery_arguments"
+
+
+def test_probe_fixture_redacts_invalid_deep_probe_echo_and_refused_command(probe, schema) -> None:
+    private_command = r"C:\Users\Jane Doe\bin\tool"
+    secret = "fake-credential-value"
+    fixture = _fixture_with_deep_probes(
+        harness_id="invalid-redacted-deep-probe-cli",
+        deep_probes={
+            **_minimal_deep_probes(),
+            "instruction": {
+                "state": "declared",
+                "discovery": {"command": private_command, "args": ["--help"]},
+                "credential": secret,
+            },
+        },
+    )
+    fixture["unexpected"] = True
+
+    result = probe.probe_fixture(fixture, schema, run_version=False, run_deep_probes=True, timeout_seconds=1.0)
+
+    serialized = json.dumps(result)
+    assert private_command not in serialized
+    assert "C:\\Users\\Jane Doe" not in serialized
+    assert secret not in serialized
+    assert result["deep_probes"]["instruction"]["discovery"]["command"] == r"[HOME]\bin\tool"
+    assert result["deep_probes"]["instruction"]["credential"] == "[REDACTED]"
+    assert result["deep_probe_receipts"]["instruction"]["command"] == r"[HOME]\bin\tool"
+
+
+def test_probe_fixture_sanitizes_credential_names_and_private_paths_in_validation_errors(probe, schema) -> None:
+    private_path = r"C:\Users\Jane Doe\.ssh\id_rsa"
+    fixture = _fixture_with_deep_probes(
+        harness_id="invalid-redacted-validation-errors-cli",
+        deep_probes={
+            **_minimal_deep_probes(),
+            "instruction": {"state": "declared", "api_key": "fake-credential-value"},
+        },
+    )
+    fixture["capabilities"][0]["id"] = private_path  # type: ignore[index]
+
+    result = probe.probe_fixture(fixture, schema, run_version=False, timeout_seconds=1.0)
+
+    validation_errors = "\n".join(result["validation_errors"])
+    assert "api_key" not in validation_errors
+    assert "C:\\Users\\Jane Doe" not in validation_errors
+    assert "[HOME]" in validation_errors
 
 
 def test_run_deep_probes_invalid_nonobject_declarations_emit_receipts_without_launch(probe, schema) -> None:
@@ -764,21 +1122,14 @@ def test_run_deep_probes_invalid_nonobject_declarations_emit_receipts_without_la
     assert {receipt["state"] for receipt in receipts.values()} == {"declared_only"}
 
 
-def test_run_deep_probes_refuses_unsafe_command_before_launch(probe, schema) -> None:
-    fixture = _fixture_with_deep_probes(
-        harness_id="unsafe-command-cli",
-        deep_probes={
-            **_minimal_deep_probes(),
-            "instruction": {
-                "state": "declared",
-                "discovery": {"command": "/bin/sh", "args": ["--help"]},
-            },
-        },
-    )
+def test_run_deep_probes_refuses_unsafe_command_before_launch(probe) -> None:
     with mock.patch.object(probe, "_popen_probe_process") as popen:
-        result = probe.probe_fixture(fixture, schema, run_version=False, run_deep_probes=True, timeout_seconds=1.0)
+        receipt = probe.run_deep_probe_discovery(
+            "instruction",
+            {"command": "/bin/sh", "args": ["--help"]},
+            timeout_seconds=1.0,
+        )
     popen.assert_not_called()
-    receipt = result["deep_probe_receipts"]["instruction"]
     assert receipt["state"] == "refused"
     assert receipt["reason"] == "unsafe_command_name"
 

--- a/tools/harness_conformance_probe.py
+++ b/tools/harness_conformance_probe.py
@@ -7,8 +7,9 @@ Even with those guards, executing a third-party binary can still read ambient
 environment data, perform network I/O, or run vendor-defined side effects.
 Treat ``--run-version`` as an explicit operator opt-in.
 
-Fixture-declared deep probes are never executed. Their declarations are echoed
-in probe output for harness-specific follow-up work.
+Fixture-declared deep probes are not executed unless ``--run-deep-probes`` is
+passed. Without that flag their declarations are echoed in probe output for
+harness-specific follow-up work.
 """
 
 from __future__ import annotations
@@ -44,10 +45,31 @@ CAPABILITY_IDS = {
     "platform",
 }
 BARE_COMMAND = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
-ASSIGNMENT_SECRET = re.compile(r"(?i)((?:api[_-]?key|token|secret|password)\s*[:=]\s*)[^\s]+")
+DISCOVERY_ARGS_ALLOWLIST = frozenset({("--help",), ("-h",)})
+DEEP_PROBE_IDS = (
+    "instruction",
+    "skill",
+    "hook",
+    "mcp",
+    "workspace",
+    "session",
+    "verification",
+    "handoff",
+    "reload",
+    "telemetry",
+    "platform",
+)
+CREDENTIAL_NAME = (
+    r"(?:api[_-]?key|token|secret|password|credential|private[_-]?key|"
+    r"secret[_-]?access[_-]?key|access[_-]?key)"
+)
+ASSIGNMENT_SECRET = re.compile(rf"(?i)((?:{CREDENTIAL_NAME})\s*[:=]\s*)[^\s]+")
 AUTHORIZATION_HEADER = re.compile(r"(?i)(Authorization\s*:\s*).+")
 BEARER_TOKEN = re.compile(r"(?i)\bBearer\s+([A-Za-z0-9._~+/=-]+)\b")
-JSON_QUOTED_CREDENTIAL = re.compile(r'(?i)("(?:api[_-]?key|token|secret|password)"\s*:\s*")[^"]+(")')
+JSON_QUOTED_CREDENTIAL = re.compile(rf'(?i)("[^"\r\n]*(?:{CREDENTIAL_NAME})[^"\r\n]*"\s*:\s*")((?:\\.|[^"\\])*)(")')
+JSON_UNTERMINATED_CREDENTIAL = re.compile(
+    rf'(?i)("[^"\r\n]*(?:{CREDENTIAL_NAME})[^"\r\n]*"\s*:\s*")((?:\\.|[^"\\])*)\\?\Z'
+)
 VERSION_LINE = re.compile(r"\d+\.\d+(?:\.\d+)?(?:[-+~][0-9A-Za-z][0-9A-Za-z.-]*)?")
 OUTPUT_CAP_BYTES = 65536
 DEFAULT_TIMEOUT_SECONDS = 10.0
@@ -80,8 +102,17 @@ def redact_text(value: str, *home_dirs: str | None) -> str:
     redacted = ASSIGNMENT_SECRET.sub(r"\1[REDACTED]", redacted)
     redacted = AUTHORIZATION_HEADER.sub(r"\1[REDACTED]", redacted)
     redacted = BEARER_TOKEN.sub("Bearer [REDACTED]", redacted)
-    redacted = JSON_QUOTED_CREDENTIAL.sub(r"\1[REDACTED]\2", redacted)
+    redacted = JSON_QUOTED_CREDENTIAL.sub(r"\1[REDACTED]\3", redacted)
+    redacted = JSON_UNTERMINATED_CREDENTIAL.sub(r'\1[REDACTED]"', redacted)
     return redacted
+
+
+def _redact_bounded_output(output_bytes: bytes, *private_paths: str | None) -> str:
+    output = redact_text(output_bytes.decode("utf-8", errors="replace"), *private_paths)
+    encoded = output.encode("utf-8")
+    if len(encoded) <= OUTPUT_CAP_BYTES:
+        return output
+    return encoded[:OUTPUT_CAP_BYTES].decode("utf-8", errors="ignore")
 
 
 def _extract_version_line(output: str) -> str | None:
@@ -128,6 +159,179 @@ def validate_fixture(fixture: dict[str, Any], schema: dict[str, Any]) -> list[st
 
 def _is_safe_command_name(command: str) -> bool:
     return BARE_COMMAND.fullmatch(command) is not None
+
+
+def _is_safe_discovery_args(args: list[str]) -> bool:
+    return tuple(args) in DISCOVERY_ARGS_ALLOWLIST
+
+
+def _normalize_deep_probe_entry(value: Any) -> dict[str, Any]:
+    if value == "declared":
+        return {"state": "declared"}
+    if isinstance(value, dict) and value.get("state") == "declared":
+        return value
+    return {"state": "unknown"}
+
+
+def _availability_blocks_deep_probe_execution(availability: dict[str, Any]) -> bool:
+    return availability.get("state") in {"externally_blocked", "external_only", "not_executable"}
+
+
+def _declared_only_receipt(probe_id: str, *, reason: str) -> dict[str, Any]:
+    return {
+        "probe_id": probe_id,
+        "state": "declared_only",
+        "reason": reason,
+        "platform": sys.platform,
+    }
+
+
+def run_deep_probe_discovery(
+    probe_id: str,
+    discovery: dict[str, Any],
+    *,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    timeout_seconds = _positive_finite_timeout(timeout_seconds)
+    command = discovery.get("command")
+    args = discovery.get("args")
+    if not isinstance(command, str) or not _is_safe_command_name(command):
+        return {
+            "probe_id": probe_id,
+            "state": "refused",
+            "reason": "unsafe_command_name",
+            "command": command,
+            "platform": sys.platform,
+        }
+    if not isinstance(args, list) or not all(isinstance(item, str) for item in args):
+        return {
+            "probe_id": probe_id,
+            "state": "refused",
+            "reason": "unsafe_discovery_arguments",
+            "command": command,
+            "platform": sys.platform,
+        }
+    if not _is_safe_discovery_args(args):
+        return {
+            "probe_id": probe_id,
+            "state": "refused",
+            "reason": "unsafe_discovery_arguments",
+            "command": command,
+            "platform": sys.platform,
+        }
+
+    executable = shutil.which(command)
+    if executable is None:
+        return {
+            "probe_id": probe_id,
+            "state": "externally_blocked",
+            "reason": "binary_not_found",
+            "command": command,
+            "platform": sys.platform,
+        }
+
+    with tempfile.TemporaryDirectory(prefix="harness-probe-") as tmpdir:
+        home_dir = Path(tmpdir) / "home"
+        home_dir.mkdir()
+        (home_dir / ".config").mkdir(parents=True, exist_ok=True)
+        environment = _minimal_environment(home_dir, executable)
+        process: subprocess.Popen[bytes] | None = None
+        output_bytes = b""
+        overflow = False
+        failure_reason: str | None = None
+        return_code: int | None = None
+        try:
+            process = _popen_probe_process(
+                [executable, *args],
+                cwd=tmpdir,
+                env=environment,
+            )
+            output_bytes, overflow, failure_reason = _collect_bounded_output(
+                process,
+                cap_bytes=OUTPUT_CAP_BYTES,
+                timeout_seconds=timeout_seconds,
+            )
+            return_code = process.poll()
+            if return_code is None:
+                try:
+                    return_code = process.wait(timeout=1)
+                except subprocess.TimeoutExpired:
+                    _terminate_process_group(process)
+                    return_code = process.wait(timeout=1)
+        finally:
+            if process is not None and process.poll() is None:
+                _terminate_process_group(process)
+                try:
+                    process.wait(timeout=1)
+                except subprocess.TimeoutExpired:
+                    pass
+
+        output = _redact_bounded_output(output_bytes, str(home_dir), tmpdir)
+        if failure_reason == "TimeoutExpired":
+            return {
+                "probe_id": probe_id,
+                "state": "externally_blocked",
+                "reason": "TimeoutExpired",
+                "command": command,
+                "exit_code": return_code,
+                "platform": sys.platform,
+                "output": output,
+            }
+        if overflow or failure_reason == "output_overflow":
+            return {
+                "probe_id": probe_id,
+                "state": "externally_blocked",
+                "reason": "output_overflow",
+                "command": command,
+                "exit_code": return_code,
+                "platform": sys.platform,
+                "output": output,
+            }
+        if return_code == 0:
+            return {
+                "probe_id": probe_id,
+                "state": "observed",
+                "command": command,
+                "exit_code": return_code,
+                "platform": sys.platform,
+                "output": output,
+            }
+        return {
+            "probe_id": probe_id,
+            "state": "nonzero_exit",
+            "reason": "nonzero_exit",
+            "command": command,
+            "exit_code": return_code,
+            "platform": sys.platform,
+            "output": output,
+        }
+
+
+def collect_deep_probe_receipts(
+    fixture: dict[str, Any],
+    availability: dict[str, Any],
+    *,
+    timeout_seconds: float,
+) -> dict[str, dict[str, Any]]:
+    timeout_seconds = _positive_finite_timeout(timeout_seconds)
+    blocked = _availability_blocks_deep_probe_execution(availability)
+    blocked_reason = (
+        "invalid_fixture" if availability.get("state") == "not_executable" else "externally_blocked_fixture"
+    )
+    declared_probes = fixture.get("deep_probes", {})
+    deep_probes = declared_probes if isinstance(declared_probes, dict) else {}
+    receipts: dict[str, dict[str, Any]] = {}
+    for probe_id in DEEP_PROBE_IDS:
+        entry = _normalize_deep_probe_entry(deep_probes.get(probe_id))
+        if blocked:
+            receipts[probe_id] = _declared_only_receipt(probe_id, reason=blocked_reason)
+            continue
+        discovery = entry.get("discovery")
+        if not isinstance(discovery, dict):
+            receipts[probe_id] = _declared_only_receipt(probe_id, reason="no_discovery_spec")
+            continue
+        receipts[probe_id] = run_deep_probe_discovery(probe_id, discovery, timeout_seconds=timeout_seconds)
+    return receipts
 
 
 def _command_candidates(fixture: dict[str, Any]) -> list[str]:
@@ -508,7 +712,7 @@ def run_version_probe(fixture: dict[str, Any], *, timeout_seconds: float = DEFAU
                 "command": probed_command,
             }
 
-        output = redact_text(output_bytes.decode("utf-8", errors="replace"), str(home_dir))
+        output = _redact_bounded_output(output_bytes, str(home_dir), tmpdir)
         if return_code == 0:
             return {
                 "harness_id": harness_id,
@@ -534,6 +738,7 @@ def probe_fixture(
     schema: dict[str, Any],
     *,
     run_version: bool,
+    run_deep_probes: bool = False,
     timeout_seconds: float,
 ) -> dict[str, Any]:
     timeout_seconds = _positive_finite_timeout(timeout_seconds)
@@ -554,6 +759,12 @@ def probe_fixture(
             "state": "not_executable",
             "reason": "invalid_fixture",
         }
+        if run_deep_probes:
+            payload["deep_probe_receipts"] = collect_deep_probe_receipts(
+                fixture,
+                payload["availability"],
+                timeout_seconds=timeout_seconds,
+            )
         return payload
 
     payload["availability"] = check_availability(fixture)
@@ -564,6 +775,12 @@ def probe_fixture(
             "state": "skipped",
             "reason": "availability_only_unless_run_version",
         }
+    if run_deep_probes and not errors:
+        payload["deep_probe_receipts"] = collect_deep_probe_receipts(
+            fixture,
+            payload["availability"],
+            timeout_seconds=timeout_seconds,
+        )
     return payload
 
 
@@ -580,6 +797,11 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Execute validated CLI fixtures with --version in an isolated sandbox.",
     )
+    parser.add_argument(
+        "--run-deep-probes",
+        action="store_true",
+        help="Execute fixture-declared deep probe discovery commands in an isolated sandbox.",
+    )
     parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT_SECONDS)
     args = parser.parse_args(argv)
 
@@ -591,6 +813,7 @@ def main(argv: list[str] | None = None) -> int:
             fixture,
             schema,
             run_version=args.run_version,
+            run_deep_probes=args.run_deep_probes,
             timeout_seconds=timeout_seconds,
         )
         for fixture in fixtures
@@ -599,7 +822,8 @@ def main(argv: list[str] | None = None) -> int:
         "schema": "harness-conformance-probe.v1",
         "fixtures": [fixture["harness"]["id"] for fixture in fixtures],
         "run_version": args.run_version,
-        "deep_probe_policy": "declared_only_not_executed",
+        "run_deep_probes": args.run_deep_probes,
+        "deep_probe_policy": ("executed_when_specified" if args.run_deep_probes else "declared_only_not_executed"),
         "results": results,
     }
     json.dump(payload, sys.stdout, indent=2, sort_keys=True)

--- a/tools/harness_conformance_probe.py
+++ b/tools/harness_conformance_probe.py
@@ -61,17 +61,22 @@ DEEP_PROBE_IDS = (
 )
 CREDENTIAL_NAME = (
     r"(?:api[_-]?key|token|secret|password|credential|private[_-]?key|"
-    r"secret[_-]?access[_-]?key|access[_-]?key)"
+    r"secret[_-]?access[_-]?key|access[_-]?key|(?<![A-Za-z0-9_])key(?![A-Za-z0-9_]))"
 )
-ASSIGNMENT_SECRET = re.compile(rf"(?i)((?:{CREDENTIAL_NAME})\s*[:=]\s*)[^\s]+")
+ASSIGNMENT_SECRET = re.compile(
+    rf"(?i)((?:{CREDENTIAL_NAME})\s*[:=]\s*)(?!\[REDACTED\])(?:\"(?:\\.|[^\"\\])*(?:\"|\Z)|'(?:\\.|[^'\\])*(?:'|\Z)|[^\s]+)"
+)
 AUTHORIZATION_HEADER = re.compile(r"(?i)(Authorization\s*:\s*).+")
 BEARER_TOKEN = re.compile(r"(?i)\bBearer\s+([A-Za-z0-9._~+/=-]+)\b")
 JSON_QUOTED_CREDENTIAL = re.compile(rf'(?i)("[^"\r\n]*(?:{CREDENTIAL_NAME})[^"\r\n]*"\s*:\s*")((?:\\.|[^"\\])*)(")')
 JSON_UNTERMINATED_CREDENTIAL = re.compile(
     rf'(?i)("[^"\r\n]*(?:{CREDENTIAL_NAME})[^"\r\n]*"\s*:\s*")((?:\\.|[^"\\])*)\\?\Z'
 )
+WINDOWS_HOME_PATH = re.compile(r"(?i)\b[A-Z]:(?:[\\/]+Users[\\/]+)[^\\/\"'\r\n]+")
+REDACTION_CONTEXT = re.compile(rb"(?i)(?:[A-Z_][A-Z0-9_-]*\s*[:=]\s*[\"']?)$")
 VERSION_LINE = re.compile(r"\d+\.\d+(?:\.\d+)?(?:[-+~][0-9A-Za-z][0-9A-Za-z.-]*)?")
 OUTPUT_CAP_BYTES = 65536
+REDACTION_CONTEXT_TAIL_BYTES = 256
 DEFAULT_TIMEOUT_SECONDS = 10.0
 
 
@@ -99,6 +104,7 @@ def redact_text(value: str, *home_dirs: str | None) -> str:
                 redacted = redacted.replace(segment, "[PATH]")
     for home in homes:
         redacted = redacted.replace(home, "[HOME]")
+    redacted = WINDOWS_HOME_PATH.sub("[HOME]", redacted)
     redacted = ASSIGNMENT_SECRET.sub(r"\1[REDACTED]", redacted)
     redacted = AUTHORIZATION_HEADER.sub(r"\1[REDACTED]", redacted)
     redacted = BEARER_TOKEN.sub("Bearer [REDACTED]", redacted)
@@ -112,6 +118,16 @@ def _redact_bounded_output(output_bytes: bytes, *private_paths: str | None) -> s
     encoded = output.encode("utf-8")
     if len(encoded) <= OUTPUT_CAP_BYTES:
         return output
+    marker = b"[REDACTED]"
+    marker_start = encoded.rfind(marker)
+    if marker_start >= 0:
+        line_start = encoded.rfind(b"\n", 0, marker_start) + 1
+        context_start = max(line_start, marker_start - REDACTION_CONTEXT_TAIL_BYTES)
+        context = REDACTION_CONTEXT.search(encoded[context_start:marker_start])
+        suffix = encoded[context_start + context.start() if context else marker_start :]
+        prefix_end = OUTPUT_CAP_BYTES - len(suffix)
+        if prefix_end >= 0:
+            return (encoded[:prefix_end] + suffix).decode("utf-8", errors="ignore")
     return encoded[:OUTPUT_CAP_BYTES].decode("utf-8", errors="ignore")
 
 
@@ -154,6 +170,58 @@ def validate_fixture(fixture: dict[str, Any], schema: dict[str, Any]) -> list[st
         unknown = set(identifiers) - CAPABILITY_IDS
         if unknown:
             errors.append(f"fixture.capabilities: unknown capability ids {sorted(unknown)!r}")
+    deep_probes = fixture.get("deep_probes")
+    if isinstance(deep_probes, dict):
+        for probe_id in DEEP_PROBE_IDS:
+            if probe_id in deep_probes:
+                errors.extend(_validate_deep_probe_entry(probe_id, deep_probes[probe_id]))
+    return errors
+
+
+def _validate_deep_probe_entry(probe_id: str, entry: Any) -> list[str]:
+    """Mirror the schema's deep-probe ``oneOf``/``$ref`` contract locally."""
+    path = f"fixture.deep_probes.{probe_id}"
+    if entry == "declared":
+        return []
+    if not isinstance(entry, dict):
+        return [f"{path}: expected 'declared' or a declared probe object"]
+
+    errors: list[str] = []
+    for key in entry:
+        if key not in {"state", "discovery"}:
+            errors.append(f"{path}.{key}: additional property is not allowed")
+    if "state" not in entry:
+        errors.append(f"{path}: missing required property 'state'")
+    elif entry["state"] != "declared":
+        errors.append(f"{path}.state: expected const 'declared'")
+
+    if "discovery" not in entry:
+        return errors
+    discovery = entry["discovery"]
+    discovery_path = f"{path}.discovery"
+    if not isinstance(discovery, dict):
+        return [*errors, f"{discovery_path}: expected type 'object'"]
+    for key in discovery:
+        if key not in {"command", "args"}:
+            errors.append(f"{discovery_path}.{key}: additional property is not allowed")
+    for key in ("command", "args"):
+        if key not in discovery:
+            errors.append(f"{discovery_path}: missing required property '{key}'")
+
+    if "command" in discovery:
+        command = discovery["command"]
+        if not isinstance(command, str):
+            errors.append(f"{discovery_path}.command: expected type 'string'")
+        elif not _is_safe_command_name(command):
+            errors.append(f"{discovery_path}.command: string does not match bare-command pattern")
+    if "args" in discovery:
+        args = discovery["args"]
+        if not isinstance(args, list):
+            errors.append(f"{discovery_path}.args: expected type 'array'")
+        else:
+            for index, arg in enumerate(args):
+                if not isinstance(arg, str):
+                    errors.append(f"{discovery_path}.args[{index}]: expected type 'string'")
     return errors
 
 
@@ -186,6 +254,73 @@ def _declared_only_receipt(probe_id: str, *, reason: str) -> dict[str, Any]:
     }
 
 
+def _redact_fixture_value(value: Any, *, secret_value: bool = False) -> Any:
+    if isinstance(value, str):
+        return "[REDACTED]" if secret_value else redact_text(value)
+    if isinstance(value, list):
+        return [_redact_fixture_value(item, secret_value=secret_value) for item in value]
+    if isinstance(value, dict):
+        return {
+            redact_text(key) if isinstance(key, str) else key: _redact_fixture_value(
+                item,
+                secret_value=secret_value
+                or (isinstance(key, str) and re.search(CREDENTIAL_NAME, key, flags=re.IGNORECASE) is not None),
+            )
+            for key, item in value.items()
+        }
+    return value
+
+
+def _sanitize_probe_payload(value: Any, *, validation_error: bool = False) -> Any:
+    """Apply the final redaction boundary without changing payload keys."""
+    if isinstance(value, str):
+        redacted = redact_text(value)
+        if validation_error:
+            return re.sub(CREDENTIAL_NAME, "[REDACTED]", redacted, flags=re.IGNORECASE)
+        return redacted
+    if isinstance(value, list):
+        return [_sanitize_probe_payload(item, validation_error=validation_error) for item in value]
+    if isinstance(value, dict):
+        return {
+            key: _sanitize_probe_payload(item, validation_error=validation_error or key == "validation_errors")
+            for key, item in value.items()
+        }
+    return value
+
+
+def _discovery_refusal_reason(discovery: dict[str, Any]) -> str | None:
+    command = discovery.get("command")
+    if not isinstance(command, str) or not _is_safe_command_name(command):
+        return "unsafe_command_name"
+    args = discovery.get("args")
+    if not isinstance(args, list) or not all(isinstance(item, str) for item in args):
+        return "unsafe_discovery_arguments"
+    if not _is_safe_discovery_args(args):
+        return "unsafe_discovery_arguments"
+    return None
+
+
+def _refused_discovery_receipt(probe_id: str, command: Any, reason: str) -> dict[str, Any]:
+    return {
+        "probe_id": probe_id,
+        "state": "refused",
+        "reason": reason,
+        "command": _redact_fixture_value(command),
+        "platform": sys.platform,
+    }
+
+
+def _invalid_fixture_unsafe_discovery_receipt(probe_id: str, entry: dict[str, Any]) -> dict[str, Any] | None:
+    """Refuse unsafe declared discovery without executing an invalid fixture."""
+    discovery = entry.get("discovery")
+    if not isinstance(discovery, dict):
+        return None
+    reason = _discovery_refusal_reason(discovery)
+    if reason is None:
+        return None
+    return _refused_discovery_receipt(probe_id, discovery.get("command"), reason)
+
+
 def run_deep_probe_discovery(
     probe_id: str,
     discovery: dict[str, Any],
@@ -194,31 +329,10 @@ def run_deep_probe_discovery(
 ) -> dict[str, Any]:
     timeout_seconds = _positive_finite_timeout(timeout_seconds)
     command = discovery.get("command")
-    args = discovery.get("args")
-    if not isinstance(command, str) or not _is_safe_command_name(command):
-        return {
-            "probe_id": probe_id,
-            "state": "refused",
-            "reason": "unsafe_command_name",
-            "command": command,
-            "platform": sys.platform,
-        }
-    if not isinstance(args, list) or not all(isinstance(item, str) for item in args):
-        return {
-            "probe_id": probe_id,
-            "state": "refused",
-            "reason": "unsafe_discovery_arguments",
-            "command": command,
-            "platform": sys.platform,
-        }
-    if not _is_safe_discovery_args(args):
-        return {
-            "probe_id": probe_id,
-            "state": "refused",
-            "reason": "unsafe_discovery_arguments",
-            "command": command,
-            "platform": sys.platform,
-        }
+    refusal_reason = _discovery_refusal_reason(discovery)
+    if refusal_reason is not None:
+        return _refused_discovery_receipt(probe_id, command, refusal_reason)
+    args = discovery["args"]
 
     executable = shutil.which(command)
     if executable is None:
@@ -241,11 +355,22 @@ def run_deep_probe_discovery(
         failure_reason: str | None = None
         return_code: int | None = None
         try:
-            process = _popen_probe_process(
-                [executable, *args],
-                cwd=tmpdir,
-                env=environment,
-            )
+            try:
+                process = _popen_probe_process(
+                    [executable, *args],
+                    cwd=tmpdir,
+                    env=environment,
+                )
+            except OSError as error:
+                return {
+                    "probe_id": probe_id,
+                    "state": "externally_blocked",
+                    "reason": "OSError",
+                    "command": command,
+                    "exit_code": None,
+                    "platform": sys.platform,
+                    "output": _redact_bounded_output(str(error).encode(), str(home_dir), tmpdir),
+                }
             output_bytes, overflow, failure_reason = _collect_bounded_output(
                 process,
                 cap_bytes=OUTPUT_CAP_BYTES,
@@ -315,15 +440,20 @@ def collect_deep_probe_receipts(
 ) -> dict[str, dict[str, Any]]:
     timeout_seconds = _positive_finite_timeout(timeout_seconds)
     blocked = _availability_blocks_deep_probe_execution(availability)
-    blocked_reason = (
-        "invalid_fixture" if availability.get("state") == "not_executable" else "externally_blocked_fixture"
-    )
+    invalid_fixture = availability.get("state") == "not_executable" and availability.get("reason") == "invalid_fixture"
+    blocked_reason = "invalid_fixture" if invalid_fixture else "externally_blocked_fixture"
     declared_probes = fixture.get("deep_probes", {})
     deep_probes = declared_probes if isinstance(declared_probes, dict) else {}
     receipts: dict[str, dict[str, Any]] = {}
     for probe_id in DEEP_PROBE_IDS:
-        entry = _normalize_deep_probe_entry(deep_probes.get(probe_id))
+        raw_entry = deep_probes.get(probe_id)
+        entry = _normalize_deep_probe_entry(raw_entry)
         if blocked:
+            if invalid_fixture and isinstance(raw_entry, dict):
+                receipt = _invalid_fixture_unsafe_discovery_receipt(probe_id, raw_entry)
+                if receipt is not None:
+                    receipts[probe_id] = receipt
+                    continue
             receipts[probe_id] = _declared_only_receipt(probe_id, reason=blocked_reason)
             continue
         discovery = entry.get("discovery")
@@ -748,7 +878,7 @@ def probe_fixture(
     payload: dict[str, Any] = {
         "harness_id": harness_id,
         "validation_errors": errors,
-        "deep_probes": fixture.get("deep_probes", {}),
+        "deep_probes": _redact_fixture_value(fixture.get("deep_probes", {})),
     }
     if errors:
         payload["availability"] = {
@@ -765,7 +895,7 @@ def probe_fixture(
                 payload["availability"],
                 timeout_seconds=timeout_seconds,
             )
-        return payload
+        return _sanitize_probe_payload(payload)
 
     payload["availability"] = check_availability(fixture)
     if run_version:
@@ -781,7 +911,7 @@ def probe_fixture(
             payload["availability"],
             timeout_seconds=timeout_seconds,
         )
-    return payload
+    return _sanitize_probe_payload(payload)
 
 
 def main(argv: list[str] | None = None) -> int:


### PR DESCRIPTION
## Summary

- Add `--run-deep-probes` as an explicit opt-in while preserving the default `declared_only_not_executed` policy.
- Extend deep-probe fixtures with optional inline `{command, args}` discovery specs and emit one receipt per declared probe.
- Run specified probes in throwaway HOME/XDG sandboxes with exact command and argument gates, bounded output, path scrubbing, and credential redaction.
- Keep spec-less, blocked, external-only, and invalid fixtures declared-only without process launch.

## Verification

- `brigade work verify run --target . --command "pytest -q tests/test_harness_conformance_probe.py" --capture brigade-work`
  - Receipt `20260723-152256-work-verify-1d1010`
  - `54 passed in 0.41s`
- `brigade work verify run --target . --command "./scripts/verify" --capture brigade-work`
  - Receipt `20260723-152316-work-verify-7abfb7`
  - `4014 passed, 3 skipped in 379.31s`
  - Coverage: `82.53%`

Closes #345.