### PR TITLE
feat(roster): add shareable presets and fallback resolution

### DIFF
--- a/docs/phase-roster-presets-parts-3-4.md
+++ b/docs/phase-roster-presets-parts-3-4.md
@@ -1,0 +1,24 @@
+# Roster Presets Follow-ups (Issue #444 Parts 3–4)
+
+Parts 1–2 ship bundled roster presets, per-seat metadata (`purpose`, `spec`, `requires`, `fallback`, `stats`, `caveats`), and `roster_resolution.resolve_seats()` for capability-aware fallback chains. This note plans only the remaining slices.
+
+## Part 3: `brigade roster suggest`
+
+Probe the host with the same CLI and auth preflights used by seat resolution, load a chosen bundled preset, and emit a concrete roster TOML plus a report of dropped or substituted seats and why.
+
+- Input: preset id (`minimal`, `budget-open-weight`, `review-heavy`, `full-multi-lane`) and optional output path.
+- Behavior: call `resolve_seats()` for every non-orchestrator seat in preset order; write the resolved seat names (or omit dropped seats) into a generated roster; print the resolution report to stderr or `--json`.
+- Out of scope here: mutating the operator's live `~/.brigade/roster.toml` without an explicit write flag.
+
+## Part 4: `brigade roster stats`
+
+Refresh preset `stats` annotations from local evidence instead of author defaults.
+
+- Input: optional roster path and receipt root (default `.brigade/runs/`).
+- Behavior: scan worker run receipts for per-seat duration medians, failure rates, and sample counts; emit a table or JSON summary; optionally write refreshed `stats.source` values back into a working copy of a preset or user roster.
+- Preset defaults (`source = "author-receipts-2026-07"`) remain the shipped baseline until local receipts override them.
+
+## Separately owned (excluded from this issue)
+
+- **`brigade roster doctor` / `doctor.py`**: subscription and seat health warnings stay in the doctor command; this issue does not add preset-aware doctor checks.
+- **`build_context`**: context assembly for harness runs is unrelated to preset loading or resolution.

--- a/src/brigade/roster.py
+++ b/src/brigade/roster.py
@@ -10,8 +10,10 @@ from typing import Literal
 
 from . import agents as agent_adapters
 from . import toml_compat
+from .templates import template_root
 
 SANDBOX_CHOICES = ("read-only", "workspace-write", "danger-full-access")
+BUNDLED_PRESET_IDS = frozenset({"minimal", "budget-open-weight", "review-heavy", "full-multi-lane"})
 CODEX_TRANSPORT_CHOICES = ("exec", "app-server")
 AGENT_TRANSPORT_CHOICES = ("direct", "acpx")
 ACPX_TRANSPORT_VERSION = "0.12.0"
@@ -23,6 +25,18 @@ class RosterResolution:
     path: Path
     source: RosterSource
     shadowed: tuple[Path, ...] = ()
+
+
+@dataclass(frozen=True)
+class SeatRequirements:
+    cli: str | None = None
+    auth: str | None = None
+
+
+@dataclass(frozen=True)
+class SeatStats:
+    speed: str
+    source: str
 
 
 @dataclass(frozen=True)
@@ -40,6 +54,12 @@ class Agent:
     env: dict[str, str] | None = None
     invalid_final_fallback: str | None = None
     read_only_capable: bool = True
+    purpose: str | None = None
+    spec: str | None = None
+    requires: SeatRequirements | None = None
+    fallback: tuple[str, ...] = ()
+    stats: SeatStats | None = None
+    caveats: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -82,6 +102,76 @@ def _as_sandbox(value: object) -> str | None:
         choices = ", ".join(SANDBOX_CHOICES)
         raise ValueError(f"limits.sandbox must be one of: {choices}")
     return value
+
+
+def _as_optional_str(value: object, field: str) -> str | None:
+    if value is None:
+        return None
+    return _as_str(value, field)
+
+
+def _as_string_list(value: object, field: str, *, allow_empty: bool = False) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        raise ValueError(f"{field} must be a list of strings")
+    if not value and not allow_empty:
+        raise ValueError(f"{field} must be a non-empty list of strings")
+    parsed: list[str] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, str) or not item.strip():
+            raise ValueError(f"{field}[{index}] must be a non-empty string")
+        parsed.append(item.strip())
+    return tuple(parsed)
+
+
+def _as_requires(value: object, agent_name: str) -> SeatRequirements | None:
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise ValueError(f"agents.{agent_name}.requires must be a TOML table")
+    if not value:
+        return None
+    unknown = set(value) - {"cli", "auth"}
+    if unknown:
+        keys = ", ".join(sorted(unknown))
+        raise ValueError(f"agents.{agent_name}.requires has unknown keys: {keys}")
+    cli = _as_optional_str(value.get("cli"), f"agents.{agent_name}.requires.cli")
+    auth = _as_optional_str(value.get("auth"), f"agents.{agent_name}.requires.auth")
+    if auth is not None and auth != "logged-in":
+        raise ValueError(f"agents.{agent_name}.requires.auth must be 'logged-in'")
+    if auth is not None and cli is None:
+        raise ValueError(f"agents.{agent_name}.requires.auth requires requires.cli")
+    if cli is None and auth is None:
+        return None
+    return SeatRequirements(cli=cli, auth=auth)
+
+
+def _as_stats(value: object, agent_name: str) -> SeatStats | None:
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise ValueError(f"agents.{agent_name}.stats must be a TOML table")
+    speed = _as_str(value.get("speed"), f"agents.{agent_name}.stats.speed")
+    source = _as_str(value.get("source"), f"agents.{agent_name}.stats.source")
+    unknown = set(value) - {"speed", "source"}
+    if unknown:
+        keys = ", ".join(sorted(unknown))
+        raise ValueError(f"agents.{agent_name}.stats has unknown keys: {keys}")
+    return SeatStats(speed=speed, source=source)
+
+
+def _as_caveats(value: object, agent_name: str) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        raise ValueError(f"agents.{agent_name}.caveats must be a list of strings")
+    parsed: list[str] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, str):
+            raise ValueError(f"agents.{agent_name}.caveats[{index}] must be a string")
+        parsed.append(item.strip())
+    return tuple(parsed)
 
 
 _ENV_NAME_RE = re.compile(r"^[A-Z][A-Z0-9_]*$")
@@ -178,6 +268,39 @@ def resolve_roster_path(target: Path, explicit: Path | None = None) -> Path:
     return resolve_roster(target, explicit).path
 
 
+def _validate_preset_id(preset_id: str) -> str:
+    normalized = preset_id.strip()
+    if not normalized:
+        raise ValueError("preset id must be a non-empty string")
+    if normalized != preset_id or normalized in {".", ".."} or "/" in normalized or "\\" in normalized:
+        raise ValueError(f"unknown preset: {preset_id!r}")
+    if normalized not in BUNDLED_PRESET_IDS:
+        raise ValueError(f"unknown preset: {preset_id!r}")
+    return normalized
+
+
+def preset_path(preset_id: str) -> Path:
+    """Return the packaged TOML path for a curated bundled roster preset."""
+
+    normalized = _validate_preset_id(preset_id)
+    return template_root() / "rosters" / f"{normalized}.toml"
+
+
+def load_preset(preset_id: str) -> Roster:
+    """Load a curated bundled roster preset by id."""
+
+    path = preset_path(preset_id)
+    if not path.is_file():
+        raise FileNotFoundError(f"preset not found: {preset_id!r} (looked at {path})")
+    return load_roster(path)
+
+
+def list_preset_ids() -> tuple[str, ...]:
+    """Return the stable bundled preset ids in catalog order."""
+
+    return tuple(sorted(BUNDLED_PRESET_IDS))
+
+
 def load_roster(path: Path, *, resolution: RosterResolution | None = None) -> Roster:
     path = path.expanduser().resolve()
     if not path.exists():
@@ -260,6 +383,16 @@ def load_roster(path: Path, *, resolution: RosterResolution | None = None) -> Ro
             raw_agent.get("read_only_capable", True),
             f"agents.{agent_name}.read_only_capable",
         )
+        purpose = _as_optional_str(raw_agent.get("purpose"), f"agents.{agent_name}.purpose")
+        spec = _as_optional_str(raw_agent.get("spec"), f"agents.{agent_name}.spec")
+        requires = _as_requires(raw_agent.get("requires"), agent_name)
+        seat_fallback_raw = raw_agent.get("fallback")
+        if seat_fallback_raw is None:
+            fallback: tuple[str, ...] = ()
+        else:
+            fallback = _as_string_list(seat_fallback_raw, f"agents.{agent_name}.fallback", allow_empty=True)
+        stats = _as_stats(raw_agent.get("stats"), agent_name)
+        caveats = _as_caveats(raw_agent.get("caveats"), agent_name)
 
         cli_raw = raw_agent.get("cli")
         has_endpoint = endpoint is not None and model is not None
@@ -316,6 +449,12 @@ def load_roster(path: Path, *, resolution: RosterResolution | None = None) -> Ro
             env=env,
             invalid_final_fallback=invalid_final_fallback,
             read_only_capable=read_only_capable,
+            purpose=purpose,
+            spec=spec,
+            requires=requires,
+            fallback=fallback,
+            stats=stats,
+            caveats=caveats,
         )
 
     if orchestrator not in parsed_agents:
@@ -327,16 +466,16 @@ def load_roster(path: Path, *, resolution: RosterResolution | None = None) -> Ro
             continue
         if agent.cli != "grok" or agent.transport != "direct":
             raise ValueError(f"agents.{agent_name}.invalid_final_fallback requires a direct grok seat")
-        fallback = parsed_agents.get(fallback_name)
-        if fallback is None:
+        fallback_agent = parsed_agents.get(fallback_name)
+        if fallback_agent is None:
             raise ValueError(
                 f"agents.{agent_name}.invalid_final_fallback references {fallback_name!r}, which is not defined"
             )
-        if fallback_name == orchestrator or fallback.cli != "cursor" or fallback.transport != "acpx":
+        if fallback_name == orchestrator or fallback_agent.cli != "cursor" or fallback_agent.transport != "acpx":
             raise ValueError(f"agents.{agent_name}.invalid_final_fallback must name a reviewed cursor-grok acpx seat")
-        if fallback.model is None or not fallback.model.lower().startswith("grok-"):
+        if fallback_agent.model is None or not fallback_agent.model.lower().startswith("grok-"):
             raise ValueError(f"agents.{agent_name}.invalid_final_fallback target must use a grok model")
-        if fallback.transport_version != ACPX_TRANSPORT_VERSION:
+        if fallback_agent.transport_version != ACPX_TRANSPORT_VERSION:
             raise ValueError(
                 f"agents.{agent_name}.invalid_final_fallback target requires reviewed acpx version "
                 f"{ACPX_TRANSPORT_VERSION}"

--- a/src/brigade/roster_resolution.py
+++ b/src/brigade/roster_resolution.py
@@ -1,0 +1,149 @@
+"""Resolve roster seats against host capabilities and fallback chains."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Literal, Protocol
+
+from . import agents as agent_adapters
+from . import acpx_adapter
+from .roster import Agent, Roster
+
+SeatStatus = Literal["resolved", "dropped"]
+
+
+@dataclass(frozen=True)
+class SeatResolutionEntry:
+    requested: str
+    selected: str | None
+    status: SeatStatus
+    reason: str
+    fallback_reasons: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class SeatResolutionReport:
+    entries: tuple[SeatResolutionEntry, ...]
+
+
+class CapabilityLookup(Protocol):
+    def check_requirements(self, agent: Agent) -> tuple[bool, str]:
+        """Return whether the seat's declared requirements are satisfied and why."""
+
+
+@dataclass(frozen=True)
+class DefaultCapabilityLookup:
+    """Probe installed CLIs and auth using the same preflights as roster doctor."""
+
+    cli_detect: Callable[[str], bool] = agent_adapters.detect
+    ollama_model_present: Callable[[str], tuple[bool, str]] = agent_adapters.ollama_model_present
+    cursor_auth_status: Callable[[], acpx_adapter.CursorAuthStatus] = acpx_adapter.cursor_auth_status
+
+    def check_requirements(self, agent: Agent) -> tuple[bool, str]:
+        if agent.requires is None or (agent.requires.cli is None and agent.requires.auth is None):
+            return True, "seat has no hard requirements"
+
+        req = agent.requires
+        if req.cli == "ollama":
+            if agent.cli is None or not agent.cli.startswith("ollama:"):
+                return False, "seat requires ollama but agents.{name}.cli is not ollama:<model>".replace(
+                    "{name}", agent.name
+                )
+            model = agent.cli[len("ollama:") :]
+            present, detail = self.ollama_model_present(model)
+            if not present:
+                return False, detail or f"ollama model {model!r} is not available locally"
+            return True, f"ollama model {model!r} is pulled locally"
+
+        if req.cli == "cursor":
+            if not self.cli_detect("cursor"):
+                return False, "cursor CLI is not installed"
+            if req.auth == "logged-in":
+                auth = self.cursor_auth_status()
+                if auth.state != "authenticated":
+                    return False, auth.detail or "cursor CLI is not authenticated"
+                return True, "cursor CLI is installed and authenticated"
+            return True, "cursor CLI is installed"
+
+        if req.cli is not None:
+            if not self.cli_detect(req.cli):
+                return False, f"{req.cli} CLI is not installed"
+            if req.auth == "logged-in":
+                return False, f"no authentication probe is available for {req.cli} CLI"
+            return True, f"{req.cli} CLI is installed"
+
+        if req.auth is not None:
+            return False, f"requires.auth={req.auth!r} needs requires.cli to probe authentication"
+
+        return True, "requirements satisfied"
+
+
+def resolve_seats(
+    roster: Roster,
+    *,
+    seat_names: Sequence[str] | None = None,
+    lookup: CapabilityLookup | None = None,
+) -> SeatResolutionReport:
+    """Resolve an ordered seat list to the first satisfiable seat per entry."""
+
+    if seat_names is None:
+        seat_names = [name for name in roster.agents if name != roster.orchestrator]
+    capability = lookup or DefaultCapabilityLookup()
+    return SeatResolutionReport(entries=tuple(_resolve_one(roster, name, capability) for name in seat_names))
+
+
+def _resolve_one(roster: Roster, requested: str, lookup: CapabilityLookup) -> SeatResolutionEntry:
+    agent = roster.agents.get(requested)
+    if agent is None:
+        return SeatResolutionEntry(
+            requested=requested,
+            selected=None,
+            status="dropped",
+            reason=f"seat {requested!r} is not defined in the roster",
+            fallback_reasons=(),
+        )
+
+    if agent.requires is None or (agent.requires.cli is None and agent.requires.auth is None):
+        return SeatResolutionEntry(
+            requested=requested,
+            selected=requested,
+            status="resolved",
+            reason="seat has no hard requirements",
+            fallback_reasons=(),
+        )
+
+    satisfied, reason = lookup.check_requirements(agent)
+    if satisfied:
+        return SeatResolutionEntry(
+            requested=requested,
+            selected=requested,
+            status="resolved",
+            reason=reason,
+            fallback_reasons=(),
+        )
+
+    fallback_reasons = [reason]
+    for fallback_name in agent.fallback:
+        fallback_agent = roster.agents.get(fallback_name)
+        if fallback_agent is None:
+            fallback_reasons.append(f"fallback {fallback_name!r} is not defined in the roster")
+            continue
+        fb_satisfied, fb_reason = lookup.check_requirements(fallback_agent)
+        if fb_satisfied:
+            return SeatResolutionEntry(
+                requested=requested,
+                selected=fallback_name,
+                status="resolved",
+                reason=fb_reason,
+                fallback_reasons=tuple(fallback_reasons),
+            )
+        fallback_reasons.append(fb_reason)
+
+    return SeatResolutionEntry(
+        requested=requested,
+        selected=None,
+        status="dropped",
+        reason=f"no satisfiable fallback for seat {requested!r}",
+        fallback_reasons=tuple(fallback_reasons),
+    )

--- a/src/brigade/templates/rosters/budget-open-weight.toml
+++ b/src/brigade/templates/rosters/budget-open-weight.toml
@@ -1,0 +1,35 @@
+# Budget open-weight preset: prefer local OSS, fall back to codex.
+orchestrator = "chef"
+
+[agents.chef]
+cli = "codex"
+role = "Plan the work, choose useful workers, and synthesize the final answer."
+purpose = "Orchestrate runs and synthesize worker output."
+spec = "Codex orchestrator for open-weight-first runs"
+requires = { cli = "codex" }
+stats = { speed = "medium", source = "author-receipts-2026-07" }
+caveats = []
+
+[agents.implement_oss]
+cli = "ollama:llama3.2:3b"
+role = "Implement changes with a local open-weight model."
+purpose = "Zero-marginal-cost implementation worker when the model is already pulled."
+spec = "Small local model; zero marginal API cost"
+requires = { cli = "ollama" }
+fallback = ["implement_codex"]
+stats = { speed = "slow", source = "author-receipts-2026-07" }
+caveats = ["Requires the model pulled locally; brigade never auto-pulls."]
+
+[agents.implement_codex]
+cli = "codex"
+role = "Make precise code changes and report what changed."
+purpose = "Cloud fallback when the local OSS model is unavailable."
+spec = "Codex fallback when the local model is unavailable"
+requires = { cli = "codex" }
+stats = { speed = "medium", source = "author-receipts-2026-07" }
+caveats = []
+
+[limits]
+max_workers = 3
+timeout_seconds = 600
+allow_models = ["codex", "ollama:*"]

--- a/src/brigade/templates/rosters/full-multi-lane.toml
+++ b/src/brigade/templates/rosters/full-multi-lane.toml
@@ -1,0 +1,97 @@
+# Full multi-lane preset: implement, scout, and review lanes with ordered fallbacks.
+orchestrator = "chef"
+
+[agents.chef]
+cli = "codex"
+role = "Plan the work, choose useful workers, and synthesize the final answer."
+purpose = "Orchestrate runs and synthesize worker output."
+spec = "Codex orchestrator for multi-lane runs"
+requires = { cli = "codex" }
+stats = { speed = "medium", source = "author-receipts-2026-07" }
+caveats = []
+
+[agents.implement]
+cli = "cursor"
+model = "composer-2.5"
+role = "Make precise code changes and report what changed."
+purpose = "Fast implementation worker on the flat Cursor subscription."
+spec = "Fast Cursor Composer implementation on the flat subscription"
+requires = { cli = "cursor", auth = "logged-in" }
+fallback = ["implement_codex", "implement_oss"]
+stats = { speed = "fast", source = "author-receipts-2026-07" }
+caveats = ["Composer models return empty text in read-only plan mode."]
+
+[agents.implement_codex]
+cli = "codex"
+role = "Make precise code changes and report what changed."
+purpose = "Codex fallback when Cursor is unavailable."
+spec = "Codex implementation fallback"
+requires = { cli = "codex" }
+stats = { speed = "medium", source = "author-receipts-2026-07" }
+caveats = []
+
+[agents.implement_oss]
+cli = "ollama:llama3.2:3b"
+role = "Implement changes with a local open-weight model."
+purpose = "Local OSS fallback when cloud implementation lanes are unavailable."
+spec = "Local OSS implementation fallback"
+requires = { cli = "ollama" }
+stats = { speed = "slow", source = "author-receipts-2026-07" }
+caveats = ["Requires the model pulled locally; brigade never auto-pulls."]
+
+[agents.scout]
+cli = "cursor"
+model = "gpt-5.4-mini-low"
+role = "Inventory files, grep, and summarize findings cheaply."
+purpose = "Cheap scout lane for triage that does not deserve a frontier model."
+spec = "Cheap Cursor scout for inventories and triage"
+requires = { cli = "cursor", auth = "logged-in" }
+fallback = ["scout_codex"]
+stats = { speed = "fast", source = "author-receipts-2026-07" }
+caveats = []
+
+[agents.scout_codex]
+cli = "codex"
+model = "gpt-5.4-mini-low"
+role = "Inventory files, grep, and summarize findings cheaply."
+purpose = "Codex fallback scout lane."
+spec = "Codex scout fallback"
+requires = { cli = "codex" }
+stats = { speed = "fast", source = "author-receipts-2026-07" }
+caveats = []
+
+[agents.review]
+cli = "codex"
+model = "gpt-5.6-sol-medium"
+role = "Inspect code and reports, verify claims against the diff, and flag problems."
+purpose = "Primary review lane with ordered cross-model fallbacks."
+spec = "Primary Codex cross-model reviewer"
+requires = { cli = "codex" }
+fallback = ["review_claude", "review_antigravity"]
+stats = { speed = "medium", source = "author-receipts-2026-07" }
+caveats = []
+
+[agents.review_claude]
+cli = "claude"
+model = "claude-sonnet-5"
+role = "Inspect code and reports from a different model family."
+purpose = "Claude fallback reviewer."
+spec = "Claude fallback reviewer"
+requires = { cli = "claude" }
+stats = { speed = "medium", source = "author-receipts-2026-07" }
+caveats = ["Keep one dispatch to one flat review pass; avoid internal subagent fan-out."]
+
+[agents.review_antigravity]
+cli = "antigravity"
+model = "Claude Sonnet 4.6 (Thinking)"
+role = "Inspect code and reports on the free Google lane."
+purpose = "Antigravity fallback reviewer when paid review lanes are unavailable."
+spec = "Free Antigravity fallback reviewer"
+requires = { cli = "antigravity" }
+stats = { speed = "medium", source = "author-receipts-2026-07" }
+caveats = []
+
+[limits]
+max_workers = 6
+timeout_seconds = 600
+allow_models = ["codex", "claude", "cursor", "antigravity", "ollama:*"]

--- a/src/brigade/templates/rosters/minimal.toml
+++ b/src/brigade/templates/rosters/minimal.toml
@@ -1,0 +1,25 @@
+# Minimal single-CLI preset: codex orchestrator plus one worker seat.
+orchestrator = "chef"
+
+[agents.chef]
+cli = "codex"
+role = "Plan the work, choose useful workers, and synthesize the final answer."
+purpose = "Orchestrate runs and synthesize worker output."
+spec = "Single-subscription orchestrator on the operator's primary Codex lane"
+requires = { cli = "codex" }
+stats = { speed = "medium", source = "author-receipts-2026-07" }
+caveats = []
+
+[agents.implement]
+cli = "codex"
+role = "Make precise code changes and report what changed."
+purpose = "Primary implementation worker for writable tasks."
+spec = "Same Codex CLI as the orchestrator; Brigade dispatches writable work here"
+requires = { cli = "codex" }
+stats = { speed = "medium", source = "author-receipts-2026-07" }
+caveats = []
+
+[limits]
+max_workers = 2
+timeout_seconds = 600
+allow_models = ["codex"]

--- a/src/brigade/templates/rosters/review-heavy.toml
+++ b/src/brigade/templates/rosters/review-heavy.toml
@@ -1,0 +1,46 @@
+# Review-heavy preset: separate reviewer seats with cross-model coverage.
+orchestrator = "chef"
+
+[agents.chef]
+cli = "codex"
+role = "Plan the work, choose useful workers, and synthesize the final answer."
+purpose = "Orchestrate runs and synthesize worker output."
+spec = "Codex orchestrator for review-heavy runs"
+requires = { cli = "codex" }
+stats = { speed = "medium", source = "author-receipts-2026-07" }
+caveats = []
+
+[agents.implement]
+cli = "codex"
+role = "Make precise code changes and report what changed."
+purpose = "Primary implementation worker for writable tasks."
+spec = "Primary Codex implementation worker"
+requires = { cli = "codex" }
+stats = { speed = "medium", source = "author-receipts-2026-07" }
+caveats = []
+
+[agents.reviewer]
+cli = "codex"
+model = "gpt-5.6-sol-medium"
+role = "Inspect code and reports, verify claims against the diff, and flag problems."
+purpose = "Primary cross-model reviewer on the codex lane."
+spec = "Primary Codex cross-model reviewer"
+requires = { cli = "codex" }
+fallback = ["reviewer_claude"]
+stats = { speed = "medium", source = "author-receipts-2026-07" }
+caveats = []
+
+[agents.reviewer_claude]
+cli = "claude"
+model = "claude-sonnet-5"
+role = "Inspect code and reports from a different model family."
+purpose = "Secondary reviewer when the codex reviewer lane is unavailable."
+spec = "Claude fallback reviewer"
+requires = { cli = "claude" }
+stats = { speed = "medium", source = "author-receipts-2026-07" }
+caveats = ["Keep one dispatch to one flat review pass; avoid internal subagent fan-out."]
+
+[limits]
+max_workers = 4
+timeout_seconds = 600
+allow_models = ["codex", "claude"]

--- a/tests/guard/test_cli.py
+++ b/tests/guard/test_cli.py
@@ -291,6 +291,7 @@ class CliTests(unittest.TestCase):
                     "-m",
                     "feat: example",
                     "-m",
+                    # content-guard: allow email
                     "Co-authored-by: Codex <codex@openai.com>",
                 ],
                 cwd=repo,

--- a/tests/test_roster_presets.py
+++ b/tests/test_roster_presets.py
@@ -1,0 +1,446 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from brigade import acpx_adapter
+from brigade import roster as roster_mod
+from brigade import roster_resolution as resolution_mod
+
+
+VALID_LEGACY = """
+orchestrator = "chef"
+
+[agents.chef]
+cli = "codex"
+role = "plan and synthesize"
+
+[agents.coder]
+cli = "ollama:llama3.3"
+role = "write code"
+timeout_seconds = 120
+
+[limits]
+max_workers = 4
+timeout_seconds = 300
+allow_models = ["codex", "ollama:*"]
+"""
+
+
+def _write(tmp_path, text: str):
+    path = tmp_path / "roster.toml"
+    path.write_text(text)
+    return path
+
+
+def test_legacy_roster_loads_without_preset_metadata(tmp_path):
+    loaded = roster_mod.load_roster(_write(tmp_path, VALID_LEGACY))
+    coder = loaded.agents["coder"]
+    assert coder.purpose is None
+    assert coder.spec is None
+    assert coder.requires is None
+    assert coder.fallback == ()
+    assert coder.stats is None
+    assert coder.caveats == ()
+
+
+@pytest.mark.parametrize(
+    "requires_text,match",
+    [
+        ('requires = "codex"', r"agents\.coder\.requires must be a TOML table"),
+        ("requires = {}", None),
+        ('requires = { auth = "logged-in" }', r"requires\.auth requires requires\.cli"),
+        ('requires = { cli = "codex", extra = true }', r"unknown keys: extra"),
+        ('requires = { cli = "" }', r"requires\.cli must be a non-empty string"),
+        ('requires = { cli = "codex", auth = "oauth" }', r"requires\.auth must be 'logged-in'"),
+        ('requires = { cli = "codex", auth = "" }', r"requires\.auth must be a non-empty string"),
+    ],
+)
+def test_malformed_requires_rejected(tmp_path, requires_text, match):
+    text = VALID_LEGACY.replace(
+        'role = "write code"',
+        f'role = "write code"\n{requires_text}',
+    )
+    if match is None:
+        loaded = roster_mod.load_roster(_write(tmp_path, text))
+        assert loaded.agents["coder"].requires is None
+        return
+    with pytest.raises(ValueError, match=match):
+        roster_mod.load_roster(_write(tmp_path, text))
+
+
+def test_preset_path_rejects_unknown_and_traversal():
+    with pytest.raises(ValueError, match="unknown preset: 'missing'"):
+        roster_mod.preset_path("missing")
+    with pytest.raises(ValueError, match="unknown preset: '../x'"):
+        roster_mod.preset_path("../x")
+    with pytest.raises(ValueError, match="unknown preset: 'minimal/nested'"):
+        roster_mod.preset_path("minimal/nested")
+
+
+def test_preset_path_returns_packaged_file():
+    path = roster_mod.preset_path("minimal")
+    assert path.name == "minimal.toml"
+    assert path.is_file()
+
+
+@pytest.mark.parametrize("preset_id", sorted(roster_mod.BUNDLED_PRESET_IDS))
+def test_bundled_presets_load_and_carry_required_metadata(preset_id):
+    loaded = roster_mod.load_preset(preset_id)
+    assert loaded.orchestrator in loaded.agents
+    for name, agent in loaded.agents.items():
+        assert agent.purpose, f"{preset_id}:{name} missing purpose"
+        assert agent.spec, f"{preset_id}:{name} missing spec"
+        assert agent.requires is not None and agent.requires.cli, f"{preset_id}:{name} missing hard requirements"
+        assert agent.stats is not None and agent.stats.speed and agent.stats.source, (
+            f"{preset_id}:{name} missing stats.speed/source"
+        )
+        assert agent.caveats is not None, f"{preset_id}:{name} missing caveats field"
+
+
+def test_minimal_preset_has_non_orchestrator_worker():
+    loaded = roster_mod.load_preset("minimal")
+    workers = roster_mod.workers(loaded)
+    assert workers
+    assert all(worker.name != loaded.orchestrator for worker in workers)
+    assert any(worker.name == "implement" for worker in workers)
+
+
+def test_full_multi_lane_preset_has_review_lane_with_ordered_fallbacks():
+    loaded = roster_mod.load_preset("full-multi-lane")
+    review = loaded.agents["review"]
+    assert review.fallback == ("review_claude", "review_antigravity")
+    assert "implement" in loaded.agents
+    assert "scout" in loaded.agents
+
+
+@dataclass(frozen=True)
+class FakeLookup:
+    installed: frozenset[str]
+    authenticated: bool = True
+    ollama_present: frozenset[str] = frozenset()
+
+    def check_requirements(self, agent: roster_mod.Agent) -> tuple[bool, str]:
+        req = agent.requires
+        if req is None or req.cli is None:
+            return True, "seat has no hard requirements"
+        if req.cli == "ollama":
+            model = (agent.cli or "")[len("ollama:") :]
+            if model in self.ollama_present:
+                return True, f"ollama model {model!r} is pulled locally"
+            return False, f"ollama model {model!r} is not pulled locally"
+        if req.cli == "cursor":
+            if "cursor" not in self.installed:
+                return False, "cursor CLI is not installed"
+            if req.auth == "logged-in" and not self.authenticated:
+                return False, "cursor CLI is not authenticated"
+            if req.auth == "logged-in":
+                return True, "cursor CLI is installed and authenticated"
+            return True, "cursor CLI is installed"
+        if req.cli in self.installed:
+            if req.auth == "logged-in":
+                return False, f"no authentication probe is available for {req.cli} CLI"
+            return True, f"{req.cli} CLI is installed"
+        return False, f"{req.cli} CLI is not installed"
+
+
+def _preset_roster(text: str, tmp_path):
+    return roster_mod.load_roster(_write(tmp_path, text))
+
+
+def test_resolution_emits_one_entry_per_requested_name_in_order(tmp_path):
+    roster = _preset_roster(
+        """
+orchestrator = "chef"
+[agents.chef]
+cli = "codex"
+role = "plan"
+[agents.alpha]
+cli = "codex"
+role = "a"
+[agents.beta]
+cli = "codex"
+role = "b"
+[limits]
+allow_models = ["codex"]
+""",
+        tmp_path,
+    )
+    report = resolution_mod.resolve_seats(roster, seat_names=["beta", "alpha", "missing"])
+    assert [entry.requested for entry in report.entries] == ["beta", "alpha", "missing"]
+    assert report.entries[0].selected == "beta"
+    assert report.entries[1].selected == "alpha"
+    assert report.entries[2].status == "dropped"
+    assert report.entries[2].reason
+
+
+def test_resolution_keeps_seat_without_requires(tmp_path):
+    roster = _preset_roster(
+        """
+orchestrator = "chef"
+[agents.chef]
+cli = "codex"
+role = "plan"
+[agents.plain]
+cli = "codex"
+role = "plain worker"
+[limits]
+allow_models = ["codex"]
+""",
+        tmp_path,
+    )
+    lookup = FakeLookup(installed=set())
+    report = resolution_mod.resolve_seats(roster, seat_names=["plain"], lookup=lookup)
+    entry = report.entries[0]
+    assert entry.requested == "plain"
+    assert entry.selected == "plain"
+    assert entry.status == "resolved"
+    assert entry.reason == "seat has no hard requirements"
+
+
+def test_default_resolution_uses_roster_workers_excluding_orchestrator(tmp_path):
+    roster = _preset_roster(
+        """
+orchestrator = "chef"
+[agents.chef]
+cli = "codex"
+role = "plan"
+[agents.worker]
+cli = "codex"
+role = "work"
+[limits]
+allow_models = ["codex"]
+""",
+        tmp_path,
+    )
+    report = resolution_mod.resolve_seats(roster)
+    assert [entry.requested for entry in report.entries] == ["worker"]
+
+
+def test_ollama_missing_model_falls_back_in_order(tmp_path):
+    roster = _preset_roster(
+        """
+orchestrator = "chef"
+[agents.chef]
+cli = "codex"
+role = "plan"
+requires = { cli = "codex" }
+[agents.implement_oss]
+cli = "ollama:llama3.2:3b"
+role = "oss"
+requires = { cli = "ollama" }
+fallback = ["implement_codex"]
+[agents.implement_codex]
+cli = "codex"
+role = "codex"
+requires = { cli = "codex" }
+[limits]
+allow_models = ["codex", "ollama:*"]
+""",
+        tmp_path,
+    )
+    lookup = FakeLookup(installed={"codex"}, ollama_present=set())
+    report = resolution_mod.resolve_seats(roster, seat_names=["implement_oss"], lookup=lookup)
+    entry = report.entries[0]
+    assert entry.status == "resolved"
+    assert entry.selected == "implement_codex"
+    assert entry.fallback_reasons[0].startswith("ollama model")
+    assert entry.reason == "codex CLI is installed"
+    assert all(reason for reason in entry.fallback_reasons)
+
+
+def test_ollama_present_model_self_resolves_without_host_calls(monkeypatch, tmp_path):
+    roster = _preset_roster(
+        """
+orchestrator = "chef"
+[agents.chef]
+cli = "codex"
+role = "plan"
+[agents.implement_oss]
+cli = "ollama:llama3.2:3b"
+role = "oss"
+requires = { cli = "ollama" }
+fallback = ["implement_codex"]
+[agents.implement_codex]
+cli = "codex"
+role = "codex"
+requires = { cli = "codex" }
+[limits]
+allow_models = ["codex", "ollama:*"]
+""",
+        tmp_path,
+    )
+
+    calls: list[str] = []
+
+    def fake_present(model: str) -> tuple[bool, str]:
+        calls.append(model)
+        return True, ""
+
+    lookup = resolution_mod.DefaultCapabilityLookup(
+        cli_detect=lambda cli: True,
+        ollama_model_present=fake_present,
+        cursor_auth_status=lambda: acpx_adapter.CursorAuthStatus(
+            "authenticated",
+            "cursor-agent CLI is authenticated",
+            "",
+            "",
+            0,
+        ),
+    )
+    report = resolution_mod.resolve_seats(roster, seat_names=["implement_oss"], lookup=lookup)
+    entry = report.entries[0]
+    assert entry.selected == "implement_oss"
+    assert calls == ["llama3.2:3b"]
+    assert "llama3.2:3b" in entry.reason
+
+
+def test_cursor_auth_probe_uses_requires_cli(monkeypatch, tmp_path):
+    roster = _preset_roster(
+        """
+orchestrator = "chef"
+[agents.chef]
+cli = "codex"
+role = "plan"
+[agents.implement]
+cli = "cursor"
+model = "composer-2.5"
+role = "implement"
+requires = { cli = "cursor", auth = "logged-in" }
+[limits]
+allow_models = ["codex", "cursor"]
+""",
+        tmp_path,
+    )
+    auth_calls: list[str] = []
+
+    def fake_auth():
+        auth_calls.append("called")
+        return acpx_adapter.CursorAuthStatus(
+            "unauthenticated",
+            "cursor-agent CLI is not logged in",
+            "",
+            "",
+            1,
+        )
+
+    lookup = resolution_mod.DefaultCapabilityLookup(
+        cli_detect=lambda cli: cli == "cursor",
+        ollama_model_present=lambda model: (True, ""),
+        cursor_auth_status=fake_auth,
+    )
+    report = resolution_mod.resolve_seats(roster, seat_names=["implement"], lookup=lookup)
+    entry = report.entries[0]
+    assert auth_calls == ["called"]
+    assert entry.status == "dropped"
+    assert entry.reason == "no satisfiable fallback for seat 'implement'"
+    assert "not logged in" in entry.fallback_reasons[0]
+
+
+def test_dropped_seat_preserves_ordered_fallback_reasons(tmp_path):
+    roster = _preset_roster(
+        """
+orchestrator = "chef"
+[agents.chef]
+cli = "codex"
+role = "plan"
+[agents.primary]
+cli = "cursor"
+model = "composer-2.5"
+role = "primary"
+requires = { cli = "cursor", auth = "logged-in" }
+fallback = ["missing", "secondary"]
+[agents.secondary]
+cli = "codex"
+role = "secondary"
+requires = { cli = "codex" }
+[limits]
+allow_models = ["cursor", "codex"]
+""",
+        tmp_path,
+    )
+    lookup = FakeLookup(installed=set(), authenticated=False)
+    report = resolution_mod.resolve_seats(roster, seat_names=["primary"], lookup=lookup)
+    entry = report.entries[0]
+    assert entry.status == "dropped"
+    assert entry.reason
+    assert entry.fallback_reasons == (
+        "cursor CLI is not installed",
+        "fallback 'missing' is not defined in the roster",
+        "codex CLI is not installed",
+    )
+
+
+def test_non_cursor_logged_in_auth_drops_without_treating_installed_as_authenticated(tmp_path):
+    roster = _preset_roster(
+        """
+orchestrator = "chef"
+[agents.chef]
+cli = "codex"
+role = "plan"
+[agents.primary]
+cli = "codex"
+role = "primary"
+requires = { cli = "codex", auth = "logged-in" }
+fallback = ["secondary"]
+[agents.secondary]
+cli = "claude"
+role = "secondary"
+requires = { cli = "claude" }
+[limits]
+allow_models = ["codex", "claude"]
+""",
+        tmp_path,
+    )
+    lookup = resolution_mod.DefaultCapabilityLookup(
+        cli_detect=lambda cli: cli in {"codex", "claude"},
+        ollama_model_present=lambda model: (True, ""),
+        cursor_auth_status=lambda: acpx_adapter.CursorAuthStatus(
+            "authenticated",
+            "cursor-agent CLI is authenticated",
+            "",
+            "",
+            0,
+        ),
+    )
+    report = resolution_mod.resolve_seats(roster, seat_names=["primary"], lookup=lookup)
+    entry = report.entries[0]
+    assert entry.status == "resolved"
+    assert entry.selected == "secondary"
+    assert entry.fallback_reasons[0] == "no authentication probe is available for codex CLI"
+    assert entry.reason == "claude CLI is installed"
+
+
+def test_non_cursor_logged_in_auth_drops_when_no_fallback(tmp_path):
+    roster = _preset_roster(
+        """
+orchestrator = "chef"
+[agents.chef]
+cli = "codex"
+role = "plan"
+[agents.primary]
+cli = "codex"
+role = "primary"
+requires = { cli = "codex", auth = "logged-in" }
+[limits]
+allow_models = ["codex"]
+""",
+        tmp_path,
+    )
+    lookup = resolution_mod.DefaultCapabilityLookup(
+        cli_detect=lambda cli: cli == "codex",
+        ollama_model_present=lambda model: (True, ""),
+        cursor_auth_status=lambda: acpx_adapter.CursorAuthStatus(
+            "authenticated",
+            "cursor-agent CLI is authenticated",
+            "",
+            "",
+            0,
+        ),
+    )
+    report = resolution_mod.resolve_seats(roster, seat_names=["primary"], lookup=lookup)
+    entry = report.entries[0]
+    assert entry.status == "dropped"
+    assert entry.selected is None
+    assert entry.fallback_reasons == ("no authentication probe is available for codex CLI",)


### PR DESCRIPTION
Implements parts 1 and 2 of #444. Parts 3 and 4 remain follow-up work.

## Summary

- ships 4 packaged roster presets: minimal single-CLI, budget open-weight, review-heavy, and full multi-lane
- extends roster seats with optional `purpose`, `spec`, `caveats`, `requires`, `fallback`, and `stats` fields while preserving legacy roster behavior
- adds injectable capability resolution for installed CLIs, Cursor authentication, and local Ollama model availability
- resolves every requested seat to itself, the first satisfiable fallback, or a dropped report entry with ordered reasons
- documents the proposed `roster suggest` and receipt-backed `roster stats` slices without touching doctor or `build_context`

## Tests

Focused roster coverage:

```text
87 passed in 0.72s
```

Full `./scripts/verify` gate:

```text
All checks passed!
520 files already formatted
Success: no issues found in 314 source files
version=0.25.1 checked=13 locations
managed snapshot: ok (6 manifests)
3902 passed, 3 skipped in 392.57s
Total coverage: 82.68%
```

## Compatibility

Current callers do not invoke capability resolution automatically. Existing untracked rosters with none of the new fields parse with the same values and defaults as before.

## Guard fixture

The second commit adds the repository-sanctioned content-guard allow comment to the existing public Codex co-author fixture. New remote branch creation otherwise fails because the global pre-push hook scans all tracked fixtures and full history. The branch-only history scan for `origin/main..HEAD` passed before push.
