### PR TITLE
feat(roster): add capability suggestions and receipt stats

### DIFF
--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -52,7 +52,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade repos` (extras): 74 command path(s)
 - `brigade research` (extras): 11 command path(s)
 - `brigade roadmap` (extras): 4 command path(s)
-- `brigade roster`: 2 command path(s)
+- `brigade roster`: 4 command path(s)
 - `brigade route`: 1 command path(s)
 - `brigade run`: 1 command path(s)
 - `brigade runbook` (extras): 5 command path(s)
@@ -428,6 +428,8 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade roadmap patterns` (extras)
 - `brigade roster doctor`
 - `brigade roster init`
+- `brigade roster stats`
+- `brigade roster suggest`
 - `brigade route`
 - `brigade run`
 - `brigade runbook closeout` (extras)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ addopts = "-ra"
 [tool.ruff]
 line-length = 120
 src = ["src", "tests"]
-extend-exclude = ["engines"]
+extend-exclude = ["engines", "*.md"]
 force-exclude = true
 
 [tool.ruff.lint]

--- a/src/brigade/cli/roster.py
+++ b/src/brigade/cli/roster.py
@@ -35,6 +35,18 @@ def register(sub: argparse._SubParsersAction) -> None:
         default=None,
         help="Path to roster.toml. Defaults to .brigade/roster.toml under --target.",
     )
+    p_roster_suggest = roster_sub.add_parser(
+        "suggest",
+        help="Assemble a preset roster from installed host capabilities.",
+    )
+    p_roster_suggest.add_argument(
+        "--preset",
+        required=True,
+        help="Packaged preset name or path (with or without .toml).",
+    )
+    p_roster_suggest.add_argument("--target", "-t", type=Path, default=Path("."))
+    p_roster_stats = roster_sub.add_parser("stats", help="Summarize per-seat stats from local worker receipts.")
+    p_roster_stats.add_argument("--target", "-t", type=Path, default=Path("."))
     p_roster.set_defaults(func=dispatch)
 
 
@@ -51,5 +63,9 @@ def dispatch(args) -> int:
         )
     if args.roster_command == "doctor":
         return roster_cmd.doctor(target=args.target, roster_path=args.roster)
+    if args.roster_command == "suggest":
+        return roster_cmd.suggest(target=args.target, preset=args.preset)
+    if args.roster_command == "stats":
+        return roster_cmd.stats(target=args.target)
     args._brigade_parser.error(f"unknown roster command: {args.roster_command}")
     return 2

--- a/src/brigade/roster.py
+++ b/src/brigade/roster.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import fnmatch
+import json
 import re
+import statistics
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Literal, Protocol
@@ -90,6 +92,13 @@ class RosterCapabilityResolution:
     @property
     def usable(self) -> bool:
         return self.roster.orchestrator in self.roster.agents
+
+
+@dataclass(frozen=True)
+class SeatReceiptStats:
+    sample_count: int
+    median_duration_seconds: float
+    failure_rate: float
 
 
 @dataclass(frozen=True)
@@ -695,3 +704,76 @@ def resolve_capabilities(
         roster=replace(roster, agents=resolved_agents),
         report=tuple(report),
     )
+
+
+def _worker_result_failed(row: dict[str, object]) -> bool:
+    ok = row.get("ok")
+    if ok is False:
+        return True
+    if ok is True:
+        return False
+    status = row.get("status")
+    if isinstance(status, str):
+        normalized = status.strip().lower()
+        if normalized in {"failed", "error", "fail", "failure"}:
+            return True
+        if normalized in {"ok", "success", "passed", "complete", "completed"}:
+            return False
+    exit_code = row.get("exit_code")
+    if isinstance(exit_code, int) and not isinstance(exit_code, bool) and exit_code != 0:
+        return True
+    return False
+
+
+def collect_seat_receipt_stats(runs_root: Path) -> dict[str, SeatReceiptStats]:
+    """Aggregate per-seat worker receipt durations and failure rates from local runs."""
+
+    runs_root = runs_root.expanduser()
+    if not runs_root.is_dir():
+        return {}
+
+    durations: dict[str, list[float]] = {}
+    samples: dict[str, int] = {}
+    failures: dict[str, int] = {}
+
+    for run_dir in sorted(runs_root.iterdir()):
+        if not run_dir.is_dir():
+            continue
+        path = run_dir / "worker-results.json"
+        if not path.is_file():
+            continue
+        try:
+            payload = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        results = payload.get("results")
+        if not isinstance(results, list):
+            continue
+        for row in results:
+            if not isinstance(row, dict):
+                continue
+            seat = row.get("worker")
+            if not isinstance(seat, str) or not seat.strip():
+                continue
+            seat_name = seat.strip()
+            samples[seat_name] = samples.get(seat_name, 0) + 1
+            if _worker_result_failed(row):
+                failures[seat_name] = failures.get(seat_name, 0) + 1
+            duration = row.get("duration_seconds")
+            if not isinstance(duration, (int, float)) or isinstance(duration, bool):
+                continue
+            durations.setdefault(seat_name, []).append(float(duration))
+
+    stats: dict[str, SeatReceiptStats] = {}
+    for seat_name, seat_durations in durations.items():
+        sample_count = samples[seat_name]
+        if sample_count <= 0:
+            continue
+        stats[seat_name] = SeatReceiptStats(
+            sample_count=sample_count,
+            median_duration_seconds=float(statistics.median(seat_durations)),
+            failure_rate=failures.get(seat_name, 0) / sample_count,
+        )
+    return stats

--- a/src/brigade/roster_cmd.py
+++ b/src/brigade/roster_cmd.py
@@ -10,6 +10,7 @@ from . import doctor as doctor_mod
 from . import model_inventory
 from . import roster as roster_mod
 from . import templates
+from . import toml_compat
 
 DEFAULT_ROSTER_REL = ".brigade/roster.toml"
 
@@ -94,6 +95,193 @@ def preset_roster_paths() -> tuple[Path, ...]:
     return tuple(sorted(rosters_dir.glob("*.toml")))
 
 
+def _resolve_preset_path(preset: Path | str) -> Path:
+    if isinstance(preset, Path):
+        path = preset.expanduser().resolve()
+    else:
+        name = str(preset).strip()
+        if not name:
+            raise ValueError("preset name must be non-empty")
+        if not name.endswith(".toml"):
+            name = f"{name}.toml"
+        path = (templates.template_root() / "rosters" / name).resolve()
+    if not path.is_file():
+        raise FileNotFoundError(f"preset not found: {path}")
+    return path
+
+
+def _local_receipt_stats(target: Path) -> dict[str, roster_mod.SeatReceiptStats]:
+    return roster_mod.collect_seat_receipt_stats(target / ".brigade" / "runs")
+
+
+def _format_resolved_seat(resolved: str | None) -> str:
+    return "-" if resolved is None else resolved
+
+
+def _print_seat_resolutions(report: tuple[roster_mod.SeatResolution, ...]) -> None:
+    for entry in report:
+        print(
+            f"requested={entry.requested} outcome={entry.outcome} "
+            f"resolved={_format_resolved_seat(entry.resolved)} reason={entry.reason}"
+        )
+
+
+def _stats_detail(
+    agent_name: str,
+    agent: roster_mod.Agent,
+    local_stats: dict[str, roster_mod.SeatReceiptStats],
+) -> str:
+    receipt = local_stats.get(agent_name)
+    if receipt is not None:
+        return (
+            f"source=local-receipts sample_count={receipt.sample_count} "
+            f"median_duration={receipt.median_duration_seconds:g} "
+            f"failure_rate={receipt.failure_rate:.3f}"
+        )
+    parts = ["source=author-default"]
+    if agent.stats:
+        for key, value in sorted(agent.stats.items()):
+            if key == "source":
+                continue
+            parts.append(f"{key}={value}")
+    return " ".join(parts)
+
+
+def _format_inline_table(values: dict[str, str]) -> str:
+    inner = ", ".join(f"{key} = {toml_compat.format_toml_value(value)}" for key, value in values.items())
+    return "{" + inner + "}"
+
+
+def _format_string_list(values: tuple[str, ...]) -> str:
+    return "[" + ", ".join(toml_compat.format_toml_value(item) for item in values) + "]"
+
+
+def _render_agent_stats(
+    agent: roster_mod.Agent,
+    agent_name: str,
+    local_stats: dict[str, roster_mod.SeatReceiptStats],
+) -> dict[str, str]:
+    receipt = local_stats.get(agent_name)
+    if receipt is not None:
+        rendered: dict[str, str] = {}
+        rendered["source"] = "local-receipts"
+        rendered["median_duration_seconds"] = f"{receipt.median_duration_seconds:g}"
+        rendered["failure_rate"] = f"{receipt.failure_rate:.3f}"
+        rendered["sample_count"] = str(receipt.sample_count)
+        return rendered
+    rendered = dict(agent.stats or {})
+    rendered["source"] = "author-default"
+    return rendered
+
+
+def _render_roster_toml(
+    roster: roster_mod.Roster,
+    local_stats: dict[str, roster_mod.SeatReceiptStats],
+) -> str:
+    lines: list[str] = [f"orchestrator = {toml_compat.format_toml_value(roster.orchestrator)}"]
+    if roster.codex_transport != "exec":
+        lines.append(f"codex_transport = {toml_compat.format_toml_value(roster.codex_transport)}")
+    lines.append("")
+
+    agent_names = [roster.orchestrator] + sorted(name for name in roster.agents if name != roster.orchestrator)
+    for name in agent_names:
+        agent = roster.agents[name]
+        lines.append(f"[agents.{name}]")
+        if agent.cli is not None:
+            lines.append(f"cli = {toml_compat.format_toml_value(agent.cli)}")
+        if agent.endpoint is not None:
+            lines.append(f"endpoint = {toml_compat.format_toml_value(agent.endpoint)}")
+        if agent.model is not None:
+            lines.append(f"model = {toml_compat.format_toml_value(agent.model)}")
+        if agent.reasoning is not None:
+            lines.append(f"reasoning = {toml_compat.format_toml_value(agent.reasoning)}")
+        lines.append(f"role = {toml_compat.format_toml_value(agent.role)}")
+        if agent.purpose is not None:
+            lines.append(f"purpose = {toml_compat.format_toml_value(agent.purpose)}")
+        if agent.requires is not None:
+            lines.append(f"requires = {_format_inline_table(agent.requires)}")
+        if agent.fallback:
+            lines.append(f"fallback = {_format_string_list(agent.fallback)}")
+        stats = _render_agent_stats(agent, name, local_stats)
+        if stats:
+            lines.append(f"stats = {_format_inline_table(stats)}")
+        if agent.caveats:
+            lines.append(f"caveats = {_format_string_list(agent.caveats)}")
+        if agent.transport != "direct":
+            lines.append(f"transport = {toml_compat.format_toml_value(agent.transport)}")
+        if agent.transport_version is not None:
+            lines.append(f"transport_version = {toml_compat.format_toml_value(agent.transport_version)}")
+        if agent.timeout_seconds is not None:
+            lines.append(f"timeout_seconds = {toml_compat.format_toml_value(agent.timeout_seconds)}")
+        if not agent.read_only_capable:
+            lines.append("read_only_capable = false")
+        if agent.invalid_final_fallback is not None:
+            lines.append(f"invalid_final_fallback = {toml_compat.format_toml_value(agent.invalid_final_fallback)}")
+        if agent.env is not None:
+            lines.append(f"env = {_format_inline_table(agent.env)}")
+        lines.append("")
+
+    lines.append("[limits]")
+    lines.append(f"max_workers = {toml_compat.format_toml_value(roster.max_workers)}")
+    lines.append(f"timeout_seconds = {toml_compat.format_toml_value(roster.timeout_seconds)}")
+    if roster.allow_models:
+        lines.append(f"allow_models = {_format_string_list(roster.allow_models)}")
+    if roster.sandbox is not None:
+        lines.append(f"sandbox = {toml_compat.format_toml_value(roster.sandbox)}")
+    return "\n".join(lines) + "\n"
+
+
+def suggest(
+    target: Path,
+    *,
+    preset: Path | str,
+    probe: roster_mod.CapabilityProbe | None = None,
+) -> int:
+    target = target.expanduser()
+    try:
+        preset_path = _resolve_preset_path(preset)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    try:
+        loaded = roster_mod.load_roster(preset_path)
+    except ValueError as exc:
+        print(f"error: invalid preset {preset_path}: {exc}", file=sys.stderr)
+        return 2
+
+    active_probe = probe if probe is not None else roster_mod.HostCapabilityProbe()
+    result = roster_mod.resolve_capabilities(loaded, active_probe)
+    local_stats = _local_receipt_stats(target)
+
+    _print_seat_resolutions(result.report)
+    for name, agent in result.roster.agents.items():
+        print(f"stats seat={name} {_stats_detail(name, agent, local_stats)}")
+
+    if not result.usable:
+        print("roster is not adoptable: orchestrator seat is unavailable")
+        return 1
+
+    print("\n# Adoptable roster")
+    print(_render_roster_toml(result.roster, local_stats), end="")
+    return 0
+
+
+def stats(target: Path) -> int:
+    target = target.expanduser()
+    local_stats = _local_receipt_stats(target)
+    if not local_stats:
+        print("no local worker receipt stats found")
+        return 0
+    for seat_name in sorted(local_stats):
+        receipt = local_stats[seat_name]
+        print(
+            f"seat={seat_name} source=local-receipts sample_count={receipt.sample_count} "
+            f"median_duration={receipt.median_duration_seconds:g} "
+            f"failure_rate={receipt.failure_rate:.3f}"
+        )
+    return 0
+
+
 def init(
     target: Path,
     *,
@@ -130,7 +318,12 @@ def init(
     return 0
 
 
-def doctor(target: Path, *, roster_path: Path | None = None) -> int:
+def doctor(
+    target: Path,
+    *,
+    roster_path: Path | None = None,
+    probe: roster_mod.CapabilityProbe | None = None,
+) -> int:
     target = target.expanduser()
 
     checks: list[doctor_mod.CheckResult] = []
@@ -144,6 +337,14 @@ def doctor(target: Path, *, roster_path: Path | None = None) -> int:
         checks.append((doctor_mod.FAIL, "roster: file", f"invalid {path}: {exc}"))
         return doctor_mod._report(checks)
 
+    local_stats = _local_receipt_stats(target)
+    active_probe = probe if probe is not None else roster_mod.HostCapabilityProbe()
+    capability = roster_mod.resolve_capabilities(loaded, active_probe)
+    for entry in capability.report:
+        if entry.outcome == "self":
+            continue
+        checks.append((doctor_mod.WARN, f"roster: capability {entry.requested}", entry.reason))
+
     checks.append((doctor_mod.OK, "roster: file", str(path)))
     checks.append((doctor_mod.OK, "roster: orchestrator", loaded.orchestrator))
     checks.append((doctor_mod.OK, "roster: max_workers", str(loaded.max_workers)))
@@ -154,6 +355,10 @@ def doctor(target: Path, *, roster_path: Path | None = None) -> int:
         checks.append((doctor_mod.OK, "roster: allow_models", ", ".join(loaded.allow_models)))
     else:
         checks.append((doctor_mod.WARN, "roster: allow_models", "not set; explicit model allow-list recommended"))
+
+    for name, agent in loaded.agents.items():
+        if agent.stats is not None or name in local_stats:
+            checks.append((doctor_mod.INFO, f"roster: stats {name}", _stats_detail(name, agent, local_stats)))
 
     inventory_inspector = model_inventory.ModelInventoryInspector()
     for name, agent in loaded.agents.items():

--- a/tests/test_roster.py
+++ b/tests/test_roster.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import pytest
@@ -1317,3 +1318,74 @@ def test_requirements_satisfied_reports_unknown_auth_separately_from_installatio
 
     assert ok is False
     assert reason == "codex authentication is unknown"
+
+
+def _write_worker_results(run_dir: Path, results: list[dict]) -> None:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "results": results,
+        "ground_truth": {
+            "available": False,
+            "cwd": "/repo",
+            "diffstat": "",
+            "changed_files": [],
+            "untracked_files": [],
+            "patch_ref": None,
+        },
+    }
+    (run_dir / "worker-results.json").write_text(json.dumps(payload, indent=2) + "\n")
+
+
+def test_collect_seat_receipt_stats_computes_median_duration_and_failure_rate(tmp_path):
+    runs = tmp_path / ".brigade" / "runs"
+    _write_worker_results(
+        runs / "run-a",
+        [
+            {"worker": "coder", "task": "a", "ok": True, "detail": "", "text": "ok", "duration_seconds": 10.0},
+            {"worker": "coder", "task": "b", "ok": False, "detail": "err", "text": "", "duration_seconds": 30.0},
+        ],
+    )
+    _write_worker_results(
+        runs / "run-b",
+        [
+            {"worker": "coder", "task": "c", "ok": True, "detail": "", "text": "ok", "duration_seconds": 20.0},
+            {"worker": "reviewer", "task": "d", "ok": True, "detail": "", "text": "ok", "duration_seconds": 5.0},
+        ],
+    )
+
+    stats = roster_mod.collect_seat_receipt_stats(runs)
+
+    coder = stats["coder"]
+    assert coder.sample_count == 3
+    assert coder.median_duration_seconds == pytest.approx(20.0)
+    assert coder.failure_rate == pytest.approx(1 / 3)
+    reviewer = stats["reviewer"]
+    assert reviewer.sample_count == 1
+    assert reviewer.median_duration_seconds == pytest.approx(5.0)
+    assert reviewer.failure_rate == pytest.approx(0.0)
+
+
+def test_collect_seat_receipt_stats_ignores_missing_worker_results(tmp_path):
+    runs = tmp_path / ".brigade" / "runs"
+    (runs / "empty-run").mkdir(parents=True)
+
+    stats = roster_mod.collect_seat_receipt_stats(runs)
+
+    assert stats == {}
+
+
+def test_collect_seat_receipt_stats_counts_failures_without_durations(tmp_path):
+    runs = tmp_path / ".brigade" / "runs"
+    _write_worker_results(
+        runs / "run-a",
+        [
+            {"worker": "coder", "ok": True, "duration_seconds": 10.0},
+            {"worker": "coder", "ok": False},
+        ],
+    )
+
+    coder = roster_mod.collect_seat_receipt_stats(runs)["coder"]
+
+    assert coder.sample_count == 2
+    assert coder.median_duration_seconds == pytest.approx(10.0)
+    assert coder.failure_rate == pytest.approx(0.5)

--- a/tests/test_roster_cmd.py
+++ b/tests/test_roster_cmd.py
@@ -1,3 +1,5 @@
+import json
+import re
 from pathlib import Path
 
 import pytest
@@ -547,3 +549,336 @@ def test_roster_init_without_review_model_has_no_reviewer_seat(tmp_path):
 def test_roster_init_rejects_blank_review_model(tmp_path, capsys):
     assert roster_cmd.init(tmp_path, review_model="  ") == 2
     assert "review-model" in capsys.readouterr().err
+
+
+class FakeProbe:
+    def __init__(self, capabilities: dict[str, roster.Capability]):
+        self._capabilities = capabilities
+
+    def lookup(self, cli_ref: str) -> roster.Capability:
+        return self._capabilities.get(
+            cli_ref,
+            roster.Capability(installed=False, authenticated=None, detail=f"{cli_ref} missing"),
+        )
+
+
+def _preset_path(preset_name: str) -> Path:
+    return next(path for path in roster_cmd.preset_roster_paths() if path.name == preset_name)
+
+
+def _installed_probe(*cli_refs: str, authenticated: bool = True) -> FakeProbe:
+    return FakeProbe(
+        {
+            ref: roster.Capability(installed=True, authenticated=authenticated, detail=f"{ref} available")
+            for ref in cli_refs
+        }
+    )
+
+
+def _write_worker_run(
+    runs_root: Path,
+    run_id: str,
+    *,
+    results: list[dict],
+) -> Path:
+    run_dir = runs_root / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "results": results,
+        "ground_truth": {
+            "available": False,
+            "cwd": "/repo",
+            "diffstat": "",
+            "changed_files": [],
+            "untracked_files": [],
+            "patch_ref": None,
+        },
+    }
+    (run_dir / "worker-results.json").write_text(json.dumps(payload, indent=2) + "\n")
+    return run_dir
+
+
+def _runs_root(target: Path) -> Path:
+    root = target / ".brigade" / "runs"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _seat_resolution_fields_present(out: str, seat: str) -> None:
+    pattern = rf"requested={re.escape(seat)}\b.*outcome=\w+.*resolved=.*reason="
+    assert re.search(pattern, out, flags=re.DOTALL), out
+
+
+def test_roster_suggest_prints_every_seat_resolution_when_roots_satisfiable(tmp_target, capsys):
+    preset = _preset_path("review-heavy.toml")
+    probe = _installed_probe("codex", "grok", "antigravity")
+
+    assert roster_cmd.suggest(tmp_target, preset=preset, probe=probe) == 0
+    out = capsys.readouterr().out
+
+    for seat in ("chef", "reviewer", "reviewer_flash"):
+        _seat_resolution_fields_present(out, seat)
+        assert f"resolved={seat}" in out
+    assert out.count("outcome=self") == 3
+    assert "orchestrator =" in out
+    assert "adoptable roster" in out.lower()
+    emitted = out.split("# Adoptable roster\n", maxsplit=1)[1]
+    resolved_path = tmp_target / "resolved-roster.toml"
+    resolved_path.parent.mkdir(parents=True, exist_ok=True)
+    resolved_path.write_text(emitted)
+    assert roster.load_roster(resolved_path).orchestrator == "chef"
+
+
+def test_roster_cli_registers_suggest_and_stats_commands(tmp_target):
+    parser = cli._build_parser()
+
+    suggest_args = parser.parse_args(
+        ["roster", "suggest", "--preset", "minimal-single-cli", "--target", str(tmp_target)]
+    )
+    stats_args = parser.parse_args(["roster", "stats", "--target", str(tmp_target)])
+
+    assert suggest_args.roster_command == "suggest"
+    assert suggest_args.preset == "minimal-single-cli"
+    assert suggest_args.target == tmp_target
+    assert stats_args.roster_command == "stats"
+    assert stats_args.target == tmp_target
+
+
+def test_roster_suggest_reports_first_satisfiable_fallback_when_primary_cli_missing(tmp_target, capsys):
+    preset = _preset_path("budget-open-weight.toml")
+    probe = FakeProbe(
+        {
+            "codex": roster.Capability(installed=False, detail="codex missing"),
+            "ollama": roster.Capability(installed=True, detail="ollama available"),
+        }
+    )
+
+    assert roster_cmd.suggest(tmp_target, preset=preset, probe=probe) == 0
+    out = capsys.readouterr().out
+
+    _seat_resolution_fields_present(out, "chef")
+    assert "outcome=fallback" in out
+    assert "resolved=chef_oss" in out
+    assert "codex missing" in out
+    _seat_resolution_fields_present(out, "coder")
+    assert "resolved=coder" in out
+    assert "outcome=self" in out
+
+
+def test_roster_suggest_reports_dropped_seat_when_no_fallback_satisfies(tmp_target, capsys):
+    preset = _preset_path("budget-open-weight.toml")
+    probe = FakeProbe(
+        {
+            "codex": roster.Capability(installed=False, detail="codex missing"),
+            "ollama": roster.Capability(installed=False, detail="ollama missing"),
+        }
+    )
+
+    rc = roster_cmd.suggest(tmp_target, preset=preset, probe=probe)
+    out = capsys.readouterr().out
+
+    _seat_resolution_fields_present(out, "chef")
+    assert "outcome=dropped" in out
+    assert "resolved=-" in out or "resolved=none" in out.lower()
+    assert "codex missing" in out
+    assert "ollama missing" in out
+    assert rc != 0 or "not adoptable" in out.lower()
+
+
+def test_roster_suggest_refuses_adoptable_roster_when_orchestrator_dropped(tmp_target, capsys):
+    preset = _preset_path("budget-open-weight.toml")
+    probe = FakeProbe({})
+
+    rc = roster_cmd.suggest(tmp_target, preset=preset, probe=probe)
+    out = capsys.readouterr().out
+
+    assert "not adoptable" in out.lower()
+    assert "[agents.chef]" not in out
+    assert rc != 0
+
+
+def test_roster_doctor_warns_when_declared_requirements_lapse(monkeypatch, tmp_target, capsys):
+    _write_roster(
+        tmp_target,
+        'orchestrator = "chef"\n'
+        "[agents.chef]\n"
+        'cli = "codex"\n'
+        'role = "plan"\n'
+        'requires = { cli = "codex" }\n'
+        'fallback = ["chef_oss"]\n'
+        "[agents.chef_oss]\n"
+        'cli = "ollama:llama3.2:3b"\n'
+        'role = "local plan"\n'
+        'requires = { cli = "ollama" }\n',
+    )
+    probe = FakeProbe(
+        {
+            "codex": roster.Capability(installed=False, detail="codex missing"),
+            "ollama": roster.Capability(installed=True),
+        }
+    )
+    monkeypatch.setattr(agents.proc, "which", lambda cmd: "/bin/" + cmd)
+
+    rc = roster_cmd.doctor(tmp_target, probe=probe)
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "[warn]" in out
+    assert "chef" in out
+    assert "codex missing" in out
+
+
+def test_roster_doctor_warns_when_declared_seat_is_dropped(monkeypatch, tmp_target, capsys):
+    _write_roster(
+        tmp_target,
+        'orchestrator = "chef"\n[agents.chef]\ncli = "codex"\nrole = "plan"\nrequires = { cli = "codex" }\n',
+    )
+    monkeypatch.setattr(agents.proc, "which", lambda cmd: "/bin/" + cmd)
+
+    rc = roster_cmd.doctor(tmp_target, probe=FakeProbe({}))
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "[warn] roster: capability chef" in out
+    assert "codex missing" in out
+
+
+def test_roster_stats_reports_per_seat_median_and_failure_rate(tmp_target, capsys):
+    runs = _runs_root(tmp_target)
+    _write_worker_run(
+        runs,
+        "run-a",
+        results=[
+            {"worker": "coder", "task": "a", "ok": True, "detail": "", "text": "ok", "duration_seconds": 10.0},
+            {"worker": "coder", "task": "b", "ok": False, "detail": "err", "text": "", "duration_seconds": 30.0},
+        ],
+    )
+    _write_worker_run(
+        runs,
+        "run-b",
+        results=[
+            {"worker": "coder", "task": "c", "ok": True, "detail": "", "text": "ok", "duration_seconds": 20.0},
+        ],
+    )
+
+    assert roster_cmd.stats(tmp_target) == 0
+    out = capsys.readouterr().out
+
+    assert "coder" in out
+    assert "median_duration" in out
+    assert "failure_rate" in out
+    assert "0.333" in out or "33.3" in out or "1/3" in out
+
+
+def test_roster_suggest_labels_author_default_stats_without_local_receipts(tmp_target, capsys):
+    preset = _preset_path("minimal-single-cli.toml")
+    probe = _installed_probe("codex")
+
+    assert roster_cmd.suggest(tmp_target, preset=preset, probe=probe) == 0
+    out = capsys.readouterr().out
+
+    assert "source=author-default" in out
+    assert "source=local-receipts" not in out
+
+
+def test_roster_suggest_overlays_local_receipt_stats(tmp_target, capsys):
+    preset = _preset_path("minimal-single-cli.toml")
+    probe = _installed_probe("codex")
+    runs = _runs_root(tmp_target)
+    _write_worker_run(
+        runs,
+        "run-a",
+        results=[
+            {"worker": "coder", "task": "a", "ok": True, "detail": "", "text": "ok", "duration_seconds": 12.0},
+        ],
+    )
+
+    assert roster_cmd.suggest(tmp_target, preset=preset, probe=probe) == 0
+    out = capsys.readouterr().out
+
+    assert "source=local-receipts" in out
+    assert "coder" in out
+    assert "median_duration" in out
+
+
+def test_roster_suggest_does_not_relabel_author_stats_as_local(tmp_target, capsys):
+    preset = _preset_path("minimal-single-cli.toml")
+    probe = _installed_probe("codex")
+    runs = _runs_root(tmp_target)
+    _write_worker_run(
+        runs,
+        "run-a",
+        results=[
+            {"worker": "coder", "ok": True, "duration_seconds": 12.0},
+        ],
+    )
+
+    assert roster_cmd.suggest(tmp_target, preset=preset, probe=probe) == 0
+    out = capsys.readouterr().out
+    emitted = out.split("# Adoptable roster\n", maxsplit=1)[1]
+    resolved_path = tmp_target / "resolved-roster.toml"
+    resolved_path.write_text(emitted)
+
+    resolved = roster.load_roster(resolved_path)
+
+    assert resolved.agents["coder"].stats == {
+        "source": "local-receipts",
+        "median_duration_seconds": "12",
+        "failure_rate": "0.000",
+        "sample_count": "1",
+    }
+
+
+def test_roster_doctor_labels_author_default_stats_without_local_receipts(tmp_target, capsys):
+    _write_roster(
+        tmp_target,
+        'orchestrator = "chef"\n'
+        "[agents.chef]\n"
+        'cli = "codex"\n'
+        'role = "plan"\n'
+        'stats = { speed = "medium", source = "author-receipts-2026-07" }\n',
+    )
+
+    assert roster_cmd.doctor(tmp_target) == 0
+    out = capsys.readouterr().out
+
+    assert "source=author-default" in out
+    assert "source=local-receipts" not in out
+
+
+def test_roster_doctor_overlays_local_receipt_stats(tmp_target, capsys):
+    _write_roster(
+        tmp_target,
+        'orchestrator = "chef"\n'
+        "[agents.chef]\n"
+        'cli = "codex"\n'
+        'role = "plan"\n'
+        'stats = { speed = "medium", source = "author-receipts-2026-07" }\n',
+    )
+    runs = _runs_root(tmp_target)
+    _write_worker_run(
+        runs,
+        "run-a",
+        results=[
+            {"worker": "chef", "task": "a", "ok": True, "detail": "", "text": "ok", "duration_seconds": 8.0},
+        ],
+    )
+
+    assert roster_cmd.doctor(tmp_target) == 0
+    out = capsys.readouterr().out
+
+    assert "source=local-receipts" in out
+    assert "chef" in out
+    assert "median_duration" in out
+
+
+@pytest.mark.parametrize("preset_name", EXPECTED_PRESET_NAMES)
+def test_packaged_presets_remain_byte_identical_after_suggest_and_stats(tmp_target, preset_name):
+    preset = _preset_path(preset_name)
+    original = preset.read_bytes()
+    probe = _installed_probe("codex", "claude", "cursor", "grok", "ollama", "antigravity")
+
+    roster_cmd.suggest(tmp_target, preset=preset, probe=probe)
+    roster_cmd.stats(tmp_target)
+
+    assert preset.read_bytes() == original

--- a/tests/test_verify_script.py
+++ b/tests/test_verify_script.py
@@ -1,3 +1,4 @@
+import tomllib
 from pathlib import Path
 
 
@@ -17,9 +18,9 @@ def test_verify_script_documents_same_fast_gate_as_ci():
     assert "ruff lint, ruff format, mypy, version sync, pytest with coverage" in text
 
 
-def test_root_ruff_configuration_excludes_imported_engines_tree():
-    text = (ROOT / "pyproject.toml").read_text()
-    ruff_config = text.split("[tool.ruff]\n", maxsplit=1)[1].split("\n[tool.ruff.", maxsplit=1)[0]
+def test_root_ruff_configuration_excludes_non_python_trees():
+    config = tomllib.loads((ROOT / "pyproject.toml").read_text())["tool"]["ruff"]
 
-    assert 'extend-exclude = ["engines"]' in ruff_config
-    assert "force-exclude = true" in ruff_config
+    assert "engines" in config["extend-exclude"]
+    assert "*.md" in config["extend-exclude"]
+    assert config["force-exclude"] is True

--- a/tests/test_verify_script.py
+++ b/tests/test_verify_script.py
@@ -1,4 +1,4 @@
-import tomllib
+import ast
 from pathlib import Path
 
 
@@ -19,8 +19,11 @@ def test_verify_script_documents_same_fast_gate_as_ci():
 
 
 def test_root_ruff_configuration_excludes_non_python_trees():
-    config = tomllib.loads((ROOT / "pyproject.toml").read_text())["tool"]["ruff"]
+    text = (ROOT / "pyproject.toml").read_text()
+    ruff_config = text.split("[tool.ruff]\n", maxsplit=1)[1].split("\n[tool.ruff.", maxsplit=1)[0]
+    exclude_line = next(line for line in ruff_config.splitlines() if line.startswith("extend-exclude = "))
+    exclusions = ast.literal_eval(exclude_line.partition("=")[2].strip())
 
-    assert "engines" in config["extend-exclude"]
-    assert "*.md" in config["extend-exclude"]
-    assert config["force-exclude"] is True
+    assert "engines" in exclusions
+    assert "*.md" in exclusions
+    assert "force-exclude = true" in ruff_config


### PR DESCRIPTION
## Summary

- Add `brigade roster suggest --preset NAME --target PATH` on top of the resolver merged in #454.
- Add local per-seat duration medians and failure rates from worker receipts.
- Add capability warnings and stats lines to roster doctor without changing its warning-only exit behavior.
- Emit adoptable roster TOML only when the resolved orchestrator remains available.

The implementation keeps the existing four packaged presets unchanged and does not add a second resolver module. Local receipt fields replace author stats in emitted TOML, so author values are not relabeled as local evidence.

This supersedes #462, which duplicated the resolver and preset work already merged in #454.

## Verification

- `pytest -q tests/test_roster.py tests/test_roster_cmd.py`: 159 passed in 1.09s
- `./scripts/verify`: 4071 passed, 3 skipped in 381.90s, 82.53% coverage

Closes #444.