### PR TITLE
fix(deliberation): stop passing --markdown/--limit to graph probe commands

### DIFF
--- a/src/brigade/deliberation.py
+++ b/src/brigade/deliberation.py
@@ -147,12 +147,15 @@ def _truncate_scope_text(text: str, limit: int = 3500) -> str:
     return clipped.rstrip() + note
 
 
-def _graphtrail_markdown(cwd: Path, db_path: Path, args: list[str]) -> str:
+def _graphtrail_scope_text(cwd: Path, db_path: Path, args: list[str], *, markdown: bool = False) -> str:
     binary = _graphtrail_bin()
     if binary is None:
         return ""
+    # Only `context` accepts --markdown/--limit; callers, callees, and impact
+    # reject them and would exit non-zero, leaving the planner one scope short.
+    extra = ["--markdown", "--limit", "8"] if markdown else []
     result = proc.run(
-        [binary, "--db", str(db_path), *args, "--markdown", "--limit", "8"],
+        [binary, "--db", str(db_path), *args, *extra],
         timeout=10.0,
         cwd=cwd,
     )
@@ -208,7 +211,7 @@ def _candidate_graphtrail_scopes(cwd: Path, task: str) -> list[EvidenceScope]:
     if not db_path.is_file():
         return []
     candidates: list[EvidenceScope] = []
-    context_text = _graphtrail_markdown(cwd, db_path, ["context", task])
+    context_text = _graphtrail_scope_text(cwd, db_path, ["context", task], markdown=True)
     if context_text:
         candidates.append(
             EvidenceScope(
@@ -228,7 +231,7 @@ def _candidate_graphtrail_scopes(cwd: Path, task: str) -> list[EvidenceScope]:
             ("graphtrail-callees", ["callees", symbol]),
             ("graphtrail-impact", ["impact", symbol]),
         ):
-            text = _graphtrail_markdown(cwd, db_path, command)
+            text = _graphtrail_scope_text(cwd, db_path, command)
             if not text:
                 continue
             candidates.append(

--- a/tests/test_deliberation.py
+++ b/tests/test_deliberation.py
@@ -631,3 +631,60 @@ def test_runs_show_and_watch_surface_deliberation(tmp_path, capsys):
     out = capsys.readouterr().out
     assert "deliberation:" in out
     assert meta is not None
+
+
+_FAKE_GRAPHTRAIL = """\
+#!/bin/sh
+# Mimics the installed graphtrail CLI's flag surface: `context` accepts
+# --markdown/--limit/--json, while callers/callees/impact reject them.
+shift 2
+cmd="$1"
+shift
+case "$cmd" in
+  context)
+    shift
+    for arg in "$@"; do
+      if [ "$arg" = "--json" ]; then
+        echo '{"entry_points":[{"qualified_name":"module.fn"}]}'
+        exit 0
+      fi
+    done
+    echo "# context pack"
+    exit 0
+    ;;
+  callers|callees|impact)
+    shift
+    for arg in "$@"; do
+      case "$arg" in
+        --markdown|--limit)
+          echo "error: unexpected argument '$arg' found" >&2
+          exit 2
+          ;;
+      esac
+    done
+    echo "$cmd edge list"
+    exit 0
+    ;;
+esac
+exit 2
+"""
+
+
+def test_candidate_scopes_survive_probe_flag_rejection(monkeypatch, tmp_path):
+    """Issue #442 experiment route C: callers/callees/impact reject --markdown
+    and --limit, so passing them left the planner with a single scope and every
+    deliberation plan was rejected before dispatch."""
+    fake = tmp_path / "fake-graphtrail"
+    fake.write_text(_FAKE_GRAPHTRAIL)
+    fake.chmod(0o755)
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(fake))
+    graph_dir = tmp_path / ".graphtrail"
+    graph_dir.mkdir()
+    (graph_dir / "graphtrail.db").write_text("")
+
+    scopes = deliberation._candidate_graphtrail_scopes(tmp_path, "migrate the queue")
+
+    kinds = {scope.kind for scope in scopes}
+    assert "graphtrail-context" in kinds
+    assert {"graphtrail-callers", "graphtrail-callees", "graphtrail-impact"} <= kinds
+    assert all(scope.grounded for scope in scopes)


### PR DESCRIPTION
## What

The deliberation scope planner appended `--markdown --limit 8` to every graphtrail call, but only `context` accepts those flags. `callers`, `callees`, and `impact` reject them and exit non-zero, so the planner always derived a single evidence scope and rejected every `--deliberate` plan before dispatch.

This is the direct cause of route C's 0/10 in the #442 experiment: 8/8 cases failed pre-dispatch with `deliberation could not assemble enough grounded GraphTrail evidence scopes` and route C never made a model call.

## Change

- `_graphtrail_markdown` is now `_graphtrail_scope_text` and only passes `--markdown --limit 8` on the context probe.
- Regression test with a fake graphtrail binary that mirrors the installed CLI's flag surface (rejects `--markdown`/`--limit` on the three probe commands). The existing tests mocked `derive_evidence_scopes` wholesale, which is why this was never caught.

## Verify

`./scripts/verify` passed locally (Brigade verify run `20260724-010851-work-verify-e2ec06`, exit 0). The new test fails on main and passes here.

## Notes for review

This fixes the mode's entry path; it takes no position on whether the flag stays. That call is tracked in #442 and the experiment scoring there was produced with the mode broken, so route C remains unmeasured until a rerun.

Refs #442