### PR TITLE
feat(run): allow limits.scheduler roster default for --scheduler

### DIFF
--- a/src/brigade/cli/run.py
+++ b/src/brigade/cli/run.py
@@ -256,8 +256,11 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_run.add_argument(
         "--scheduler",
         choices=("waves", "dag"),
-        default="waves",
-        help="Worker scheduling: fixed integer-stage waves (default) or router-DAG ready queue.",
+        default=None,
+        help=(
+            "Worker scheduling: fixed integer-stage waves or router-DAG ready queue. "
+            "Defaults to limits.scheduler from the roster, then waves."
+        ),
     )
     p_run.set_defaults(func=dispatch)
 
@@ -487,7 +490,7 @@ def dispatch(args) -> int:
             if args.deliberate:
                 run_kwargs["deliberation"] = True
             run_kwargs["fail_fast"] = not args.keep_going
-            run_kwargs["scheduler"] = args.scheduler
+            run_kwargs["scheduler"] = args.scheduler or loaded_roster.scheduler or "waves"
             try:
                 rc = aboyeur_mod.run(args.task, loaded_roster, **run_kwargs)
             except runguard.RetainRunLockError:

--- a/src/brigade/roster.py
+++ b/src/brigade/roster.py
@@ -57,6 +57,7 @@ class Roster:
     allow_models: tuple[str, ...] = ()
     timeout_seconds: float = 600.0
     sandbox: str | None = None
+    scheduler: str | None = None
     codex_transport: str = "exec"
     resolution: RosterResolution | None = None
 
@@ -321,6 +322,10 @@ def load_roster(path: Path, *, resolution: RosterResolution | None = None) -> Ro
     timeout_seconds = _as_positive_number(limits.get("timeout_seconds", 600.0), "limits.timeout_seconds")
     sandbox = _as_sandbox(limits.get("sandbox"))
 
+    scheduler = limits.get("scheduler")
+    if scheduler is not None and scheduler not in ("waves", "dag"):
+        raise ValueError("limits.scheduler must be one of: waves, dag")
+
     codex_transport = data.get("codex_transport", "exec")
     if codex_transport not in CODEX_TRANSPORT_CHOICES:
         choices = ", ".join(CODEX_TRANSPORT_CHOICES)
@@ -505,6 +510,7 @@ def load_roster(path: Path, *, resolution: RosterResolution | None = None) -> Ro
         allow_models=allow_models,
         timeout_seconds=timeout_seconds,
         sandbox=sandbox,
+        scheduler=scheduler,
         codex_transport=codex_transport,
         resolution=resolution,
     )

--- a/tests/test_roster.py
+++ b/tests/test_roster.py
@@ -1389,3 +1389,19 @@ def test_collect_seat_receipt_stats_counts_failures_without_durations(tmp_path):
     assert coder.sample_count == 2
     assert coder.median_duration_seconds == pytest.approx(10.0)
     assert coder.failure_rate == pytest.approx(0.5)
+
+
+def test_load_accepts_scheduler_limit(tmp_path):
+    for scheduler in ("waves", "dag"):
+        text = VALID.replace("[limits]\n", f'[limits]\nscheduler = "{scheduler}"\n')
+        assert roster_mod.load_roster(_write(tmp_path, text)).scheduler == scheduler
+
+
+def test_load_defaults_scheduler_to_none(tmp_path):
+    assert roster_mod.load_roster(_write(tmp_path, VALID)).scheduler is None
+
+
+def test_load_rejects_invalid_scheduler_limit(tmp_path):
+    text = VALID.replace("[limits]\n", '[limits]\nscheduler = "ready-queue"\n')
+    with pytest.raises(ValueError, match="limits.scheduler"):
+        roster_mod.load_roster(_write(tmp_path, text))

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -2894,3 +2894,50 @@ def test_run_cli_rejects_orchestrator_as_worker(tmp_path, monkeypatch, capsys):
     err = capsys.readouterr().err
     assert "chef" in err
     assert "orchestrator" in err.lower()
+
+
+def test_run_cli_scheduler_defaults_from_roster_limits(tmp_path, monkeypatch):
+    roster_path = tmp_path / "roster.toml"
+    roster_path.write_text(
+        """
+orchestrator = "chef"
+
+[limits]
+scheduler = "dag"
+
+[agents.chef]
+cli = "codex"
+role = "plan"
+
+[agents.coder]
+cli = "ollama:llama3.3"
+role = "code"
+"""
+    )
+    seen = {}
+
+    def fake_run(task, loaded_roster, **kwargs):
+        seen.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(aboyeur, "run", fake_run)
+    rc = cli.main(["run", "do something", "--roster", str(roster_path), "--cwd", str(tmp_path), "--no-artifacts"])
+    assert rc == 0
+    assert seen["scheduler"] == "dag"
+
+    seen.clear()
+    rc = cli.main(
+        [
+            "run",
+            "do something",
+            "--roster",
+            str(roster_path),
+            "--cwd",
+            str(tmp_path),
+            "--scheduler",
+            "waves",
+            "--no-artifacts",
+        ]
+    )
+    assert rc == 0
+    assert seen["scheduler"] == "waves"


### PR DESCRIPTION
## What

`--scheduler=dag` shipped in #447 but only as a per-invocation CLI flag with a hardcoded `waves` default, so real runs (runbooks, hooks, operator habit) never actually exercised the DAG scheduler. This adds a roster-level default: `scheduler = "waves" | "dag"` under `[limits]`.

Precedence: CLI flag > `limits.scheduler` > `waves`. Invalid values fail roster validation with the usual `limits.*` error shape.

## Why

Dogfooding the DAG scheduler is the gating step for any future routing work, and a flag nobody passes produces no dogfooding. Config-level defaults are how a mode actually gets turned on across runbooks and daily runs.

## Verify

`./scripts/verify` green through Brigade verify (run `20260724-030655` area, exit 0). New tests: roster accepts/rejects/defaults `limits.scheduler`; CLI resolves roster default and flag override.

Refs #447