### PR TITLE
docs: fix stale cli.py entry-point references (#482)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,8 +67,10 @@ Format: trigger, then the rule, then what to do instead.
 
 ## Orientation
 
-- `src/brigade/cli.py` is the entry point; commands live in sibling modules
-  (`doctor.py`, `selection.py`, `operator_cmd/`, `work_cmd/`, ...).
+- The CLI entry point is `brigade.cli:main` (`[project.scripts]` in `pyproject.toml`).
+  Command families live in `src/brigade/cli/` — one module per group (e.g. `doctor.py`,
+  `operator.py`, `init.py`, `work/`); `__init__.py` builds the parser and dispatches
+  to each module's `register`/`dispatch`.
 - New harness adapter? Follow the step list in `CONTRIBUTING.md` (manifest,
   templates, `KNOWN_HARNESSES`, CI matrix, README table).
 - Doctor checks return `OK`, `WARN`, `FAIL`, or `MANUAL`. Prefer `WARN` or

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ To add a harness:
 
 ## Adding a depth
 
-Depths live at `src/brigade/templates/depth/<id>.json` and may use `extends` to inherit from another depth. Add the id to `KNOWN_DEPTHS` in `selection.py` and to the `--depth` choices in `cli.py`.
+Depths live at `src/brigade/templates/depth/<id>.json` and may use `extends` to inherit from another depth. Add the id to `KNOWN_DEPTHS` in `selection.py` and to the `--depth` choices in `src/brigade/cli/init.py`.
 
 ## Adding an include
 

--- a/docs/audit/2026-06-10-line-check.md
+++ b/docs/audit/2026-06-10-line-check.md
@@ -36,7 +36,7 @@ Brigade is healthy. CI is green on main, all 1038 tests pass locally in 101 seco
 
 ### [MEDIUM] Continue the monolith split: five command modules near 5k lines
 - **Station:** Structure
-- **Where:** `src/brigade/work_cmd/services.py` (5983), `src/brigade/tools_cmd.py` (5729), `src/brigade/repos_cmd.py` (5092), `src/brigade/cli.py` (5056), `src/brigade/phases_cmd.py` (4719); plus `tests/test_work_cmd.py` (11417)
+- **Where:** `src/brigade/work_cmd/services.py` (5983), `src/brigade/tools_cmd.py` (5729), `src/brigade/repos_cmd.py` (5092), `src/brigade/cli/` (was a single ~5k-line `cli.py` module), `src/brigade/phases_cmd.py` (4719); plus `tests/test_work_cmd.py` (11417)
 - **What:** The 0.10.0 work_cmd package split was the right move, but five modules remain near or above 5k lines, and the single largest file in the repo is one test module. The project already tracks this in `docs/simplification-audit-plan.md` and `docs/work-cmd-split-plan.md`, so this is acknowledged, unfinished work, not news.
 - **Why it matters:** A newcomer (or agent) cannot predict where the next change belongs inside a 5k-line module, and an 11k-line test file makes targeted test runs and review diffs painful.
 - **Fix:** Repeat the work_cmd recipe (facade + frozen-surface test) on `tools_cmd.py` and `repos_cmd.py` next, and split `test_work_cmd.py` along the same package boundaries already created (`constants`/`helpers`/`ledger`/`config`/`services`/`session`).

--- a/docs/superpowers/plans/2026-06-02-deep-research-lane.md
+++ b/docs/superpowers/plans/2026-06-02-deep-research-lane.md
@@ -30,7 +30,7 @@ Create under `src/brigade/research/`:
 
 Modify:
 - `src/brigade/research_cmd.py` (Create) - CLI verb group.
-- `src/brigade/cli.py` - register the `research` group.
+- `src/brigade/cli/__init__.py` - register the `research` group.
 - `src/brigade/roster.py` - allow `endpoint`/`model` on the `researcher` agent.
 - `pyproject.toml` - `[project.optional-dependencies] research = ["playwright>=1.40"]`.
 - `README.md`, `CHANGELOG.md`, `ROADMAP.md`, `docs/command-inventory.md`.
@@ -1457,7 +1457,7 @@ git commit -m "feat(roster): researcher agent may declare endpoint+model or cli"
 
 **Files:**
 - Create: `src/brigade/research_cmd.py`
-- Modify: `src/brigade/cli.py`
+- Modify: `src/brigade/cli/__init__.py`
 - Test: `tests/test_research_cmd.py`
 
 Wires everything: `run` builds caps from config+flags, resolves the LLM backend,
@@ -1619,9 +1619,9 @@ def _new_run_id(question: str) -> str:
     return datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S-") + registry.slug(question)
 ```
 
-- [ ] **Step 4: Wire into cli.py**
+- [ ] **Step 4: Wire into `src/brigade/cli/__init__.py`**
 
-Read `src/brigade/cli.py`, find how an existing group (e.g. `context` or `learn`)
+Read `src/brigade/cli/__init__.py`, find how an existing group (e.g. `context` or `learn`)
 is registered (subparser + dispatch), and add a `research` group with verbs
 `run/list/show/cancel/resume/open` calling `research_cmd`. `run` flags:
 `question` (positional), `--corpus`, `--source` (append), `--web`, `--rounds`,
@@ -1647,7 +1647,7 @@ Expected: command parses and exits 0.
 - [ ] **Step 7: Commit**
 
 ```bash
-git add src/brigade/research_cmd.py src/brigade/cli.py tests/test_research_cmd.py
+git add src/brigade/cli/research.py src/brigade/cli/__init__.py tests/test_research_cmd.py
 git commit -m "feat(research): brigade research run/list/show/cancel/resume command group"
 ```
 


### PR DESCRIPTION
## Summary
- Update `AGENTS.md` Orientation to describe the real CLI layout: `brigade.cli:main` entry point and the `src/brigade/cli/` package (one module per command family).
- Sweep matching stale `src/brigade/cli.py` paths in `CONTRIBUTING.md`, an audit note, and a superpowers plan doc.

Closes #482.

## Test plan
- [x] `./scripts/verify` passed locally (docs-only; no code changes)
- [x] Grep confirms no remaining `src/brigade/cli.py` references outside intentional test fixtures


Made with [Cursor](https://cursor.com)