### PR TITLE
fix(operator): count guidance paths by filesystem type in adopt plan

### DIFF
--- a/src/brigade/operator_cmd/adoption.py
+++ b/src/brigade/operator_cmd/adoption.py
@@ -176,11 +176,22 @@ def _workspace_inventory(target: Path) -> dict[str, Any]:
         ".learnings",
         "memory/cards",
     ]
-    guidance_dirs = {"rules", ".learnings", "memory/cards"}
-    guidance = [
-        {"path": rel, "exists": (target / rel).exists(), "kind": "dir" if rel in guidance_dirs else "file"}
-        for rel in guidance_paths
-    ]
+    expected_guidance_dirs = {"rules", ".learnings", "memory/cards"}
+    guidance = []
+    for rel in guidance_paths:
+        path = target / rel
+        if path.is_file():
+            guidance.append({"path": rel, "exists": True, "kind": "file"})
+        elif path.is_dir():
+            guidance.append({"path": rel, "exists": True, "kind": "dir"})
+        else:
+            guidance.append(
+                {
+                    "path": rel,
+                    "exists": False,
+                    "kind": "dir" if rel in expected_guidance_dirs else "file",
+                }
+            )
     harness_rows = []
     for harness in KNOWN_HARNESSES:
         root = target / f".{harness}"
@@ -202,7 +213,7 @@ def _workspace_inventory(target: Path) -> dict[str, Any]:
         "pipeline",
         "memory-handoffs",
     ]
-    local_state = [{"path": rel, "exists": (target / rel).exists()} for rel in local_state_paths]
+    local_state = [{"path": rel, "exists": (target / rel).is_dir()} for rel in local_state_paths]
     brigade_root = target / ".brigade"
     return {
         "brigade": {
@@ -214,8 +225,12 @@ def _workspace_inventory(target: Path) -> dict[str, Any]:
         },
         "guidance": {
             "items": guidance,
-            "present_count": sum(1 for item in guidance if item["exists"] and item["kind"] == "file"),
-            "present_dir_count": sum(1 for item in guidance if item["exists"] and item["kind"] == "dir"),
+            "present_count": sum(
+                1 for item in guidance if item["kind"] == "file" and (target / item["path"]).is_file()
+            ),
+            "present_dir_count": sum(
+                1 for item in guidance if item["kind"] == "dir" and (target / item["path"]).is_dir()
+            ),
         },
         "harnesses": {
             "items": harness_rows,

--- a/tests/test_operator_cmd.py
+++ b/tests/test_operator_cmd.py
@@ -1658,10 +1658,20 @@ def test_local_operator_doctor_does_not_block_on_inactive_content_guard_hook(tmp
 
 def test_adopt_plan_counts_guidance_files_and_dirs_separately(tmp_path, capsys):
     (tmp_path / "CLAUDE.md").write_text("# rules\n")
-    (tmp_path / "memory" / "cards").mkdir(parents=True)
+    cards_dir = tmp_path / "memory" / "cards"
+    cards_dir.mkdir(parents=True)
+    for index in range(3):
+        (cards_dir / f"card-{index}.md").write_text(f"# card {index}\n")
 
     assert cli.main(["operator", "adopt", "plan", "--target", str(tmp_path), "--json"]) == 0
     payload = json.loads(capsys.readouterr().out)
     guidance = payload["workspace"]["guidance"]
     assert guidance["present_count"] == 1
     assert guidance["present_dir_count"] == 1
+    present = {item["path"]: item for item in guidance["items"] if item["exists"]}
+    assert present["CLAUDE.md"]["kind"] == "file"
+    assert present["memory/cards"]["kind"] == "dir"
+
+    assert cli.main(["operator", "adopt", "plan", "--target", str(tmp_path)]) == 0
+    out = capsys.readouterr().out
+    assert "guidance_files: 1 (+1 dirs)" in out


### PR DESCRIPTION
## Summary
- Fix `brigade operator adopt plan` guidance inventory so directories like `memory/cards` are classified with `is_dir()` and never inflate the `guidance_files` summary count.
- Count `present_count` / `present_dir_count` from actual filesystem types instead of a hardcoded path set.
- Apply the same directory-only rule to `local_state` inventory paths.
- Extend regression coverage with a fixture containing card files under `memory/cards/`.

Closes #479

## Test plan
- [x] `./scripts/verify`
- [x] `pytest tests/test_operator_cmd.py::test_adopt_plan_counts_guidance_files_and_dirs_separately -xvs`


Made with [Cursor](https://cursor.com)