### PR TITLE
docs: agents run install and the work loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@
 </p>
 
 <p align="center">
-  When an agent says tests passed, get a file with the real exit code, a <strong>code map</strong> of what the change touched (<code>brigade code</code>), and an <strong>evidence log</strong> you can search later (<code>brigade evidence</code>). Optional: one MCP and tools catalog synced across your coding agents, and shared session notes with a review gate. Local CLI. Plain files. No daemon. No lock-in.
+  <strong>Built for coding agents to run end to end</strong> (install, setup, verify, handoffs), not as a human day-to-day terminal app.
+  When an agent says tests passed, you get a file with the real exit code, a <strong>code map</strong> of what changed (<code>brigade code</code>), and an <strong>evidence log</strong> you can search later (<code>brigade evidence</code>).
+  Optional: one MCP and tools catalog across agents, and shared notes with a review gate.
+  Local files. No daemon. No lock-in.
 </p>
 
 <p align="center">

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -28,6 +28,8 @@ Brigade gives the setup a home base.
 
 The goal is not to make a giant automation machine. The goal is to make agent memory understandable, reviewable, and portable across harnesses.
 
+**Agents run the system.** Install, setup, verify, and handoffs are designed to be executed by coding agents (often from a paste into Claude Code, Codex, Cursor, or OpenClaw). Humans own policy and review when a gate is ambiguous or risky. You can type every command yourself; production use is agent-driven, not a human day-to-day terminal workflow.
+
 ## Mise En Place (brand metaphor)
 
 The product name comes from the kitchen. A *brigade de cuisine* is the staff that runs the line, and *mise en place*, pronounced "meez", means everything is in its place before the work starts. That metaphor lives in brand art and deep docs. The commands you type stay plain: `setup`, `verify`, `sync`, `code`, `evidence`.


### PR DESCRIPTION
## Summary
- README lead: built for coding agents end to end, not a human day-to-day terminal app.
- Install section: **paste into an agent first**; shell block is the same path agents run.
- Names section + overview: agents install/setup/verify/handoff; humans review gates.

## Test plan
- [x] Docs-only
- [ ] Confirm README on main after merge