### PR TITLE
fix(hooks): adopt unwired Claude user settings on work hooks install

### DIFF
--- a/src/brigade/claude_hooks/install_cmd.py
+++ b/src/brigade/claude_hooks/install_cmd.py
@@ -102,8 +102,6 @@ def _resolve_hooks_target(target: Path) -> tuple[Path | None, str | None]:
     try:
         config = load_config(target)
     except (OSError, ValueError, json.JSONDecodeError) as exc:
-        if settings_path.exists():
-            return target, None
         return None, f"unable to load Brigade config: {type(exc).__name__}: {exc}"
     if config is not None and "claude" in config.selection.harnesses:
         return target, None

--- a/src/brigade/claude_hooks/install_cmd.py
+++ b/src/brigade/claude_hooks/install_cmd.py
@@ -95,15 +95,25 @@ def _remove_settings(settings: dict[str, Any]) -> dict[str, Any]:
     return merged
 
 
-def _wired_for_claude(target: Path) -> tuple[Path | None, str | None]:
+def _resolve_hooks_target(target: Path) -> tuple[Path | None, str | None]:
+    """Allow install/update on Brigade-wired Claude targets or existing user settings."""
     target = target.expanduser().resolve()
+    settings_path = target / SETTINGS_REL_PATH
     try:
         config = load_config(target)
     except (OSError, ValueError, json.JSONDecodeError) as exc:
+        if settings_path.exists():
+            return target, None
         return None, f"unable to load Brigade config: {type(exc).__name__}: {exc}"
-    if config is None or "claude" not in config.selection.harnesses:
-        return None, f"target is not wired for Claude: {target}"
-    return target, None
+    if config is not None and "claude" in config.selection.harnesses:
+        return target, None
+    if settings_path.exists():
+        return target, None
+    return None, (
+        f"target is not wired for Claude and has no {SETTINGS_REL_PATH}: {target}; "
+        "run brigade init with the Claude harness, or point --target at a tree that "
+        f"already has {SETTINGS_REL_PATH}"
+    )
 
 
 def _sidecar(target: Path) -> dict[str, Any] | None:
@@ -111,7 +121,7 @@ def _sidecar(target: Path) -> dict[str, Any] | None:
 
 
 def _write_package(target: Path, *, action: str) -> tuple[dict[str, Any] | None, str | None]:
-    resolved, error = _wired_for_claude(target)
+    resolved, error = _resolve_hooks_target(target)
     if resolved is None:
         return None, error
     settings_path = resolved / SETTINGS_REL_PATH

--- a/tests/test_claude_hooks_settings_merge.py
+++ b/tests/test_claude_hooks_settings_merge.py
@@ -542,3 +542,88 @@ def test_status_payload_counts_legacy_and_foreign_as_disjoint(tmp_path: Path):
     assert status["legacy_handler_count"] == 2
     assert status["foreign_handler_count"] == 2
     assert status["legacy_events"] == ["SessionStart", "Stop"]
+
+
+def _unwired_with_settings(tmp_path: Path) -> Path:
+    """Home-like tree: Claude settings present, no Brigade config / Claude wiring."""
+    target = tmp_path / "home"
+    settings = target / ".claude" / "settings.json"
+    settings.parent.mkdir(parents=True)
+    seeded = {
+        "hooks": {
+            "SessionStart": [
+                {
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": (
+                                f"python3 {target / '.claude' / 'hooks' / 'brigade-work-loop.py'} "
+                                "--event SessionStart"
+                            ),
+                        }
+                    ]
+                }
+            ],
+            "PreToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": (
+                                f"python3 {target / '.claude' / 'hooks' / 'brigade-work-loop.py'} "
+                                "--event PreToolUse"
+                            ),
+                        },
+                        {"type": "command", "command": "echo foreign-pretool"},
+                    ],
+                }
+            ],
+            "Stop": [{"hooks": [_legacy_handler("Stop")]}],
+        }
+    }
+    settings.write_text(json.dumps(seeded, indent=2) + "\n")
+    return target
+
+
+def test_hooks_install_adopts_unwired_user_settings_with_legacy_handlers(tmp_path: Path):
+    target = _unwired_with_settings(tmp_path)
+    assert not (target / ".brigade").exists()
+
+    assert hooks_install(target=target) == 0
+
+    after = json.loads((target / ".claude" / "settings.json").read_text())
+    session_cmds = [
+        handler["command"]
+        for group in after["hooks"]["SessionStart"]
+        for handler in group.get("hooks", [])
+        if isinstance(handler, dict)
+    ]
+    pre_cmds = [
+        handler["command"]
+        for group in after["hooks"]["PreToolUse"]
+        for handler in group.get("hooks", [])
+        if isinstance(handler, dict)
+    ]
+    assert not any("brigade-work-loop.py" in cmd for cmd in session_cmds + pre_cmds)
+    assert any(cmd.startswith("brigade work hook-run") for cmd in session_cmds)
+    assert "echo foreign-pretool" in pre_cmds
+    sidecar = json.loads((target / ".brigade" / "claude-hooks.json").read_text())
+    assert sidecar["package_id"] == PACKAGE_ID
+    assert sidecar["package_version"] == PACKAGE_VERSION
+
+
+def test_hooks_install_still_refuses_unwired_target_without_settings(tmp_path: Path):
+    target = tmp_path / "empty"
+    target.mkdir()
+    assert hooks_install(target=target) == 2
+    assert not (target / ".claude" / "settings.json").exists()
+    assert not (target / ".brigade" / "claude-hooks.json").exists()
+
+
+def test_hooks_update_adopts_and_is_idempotent_on_unwired_user_settings(tmp_path: Path):
+    target = _unwired_with_settings(tmp_path)
+    assert hooks_install(target=target) == 0
+    before = (target / ".claude" / "settings.json").read_text()
+    assert hooks_update(target=target) == 0
+    assert (target / ".claude" / "settings.json").read_text() == before

--- a/tests/test_claude_hooks_settings_merge.py
+++ b/tests/test_claude_hooks_settings_merge.py
@@ -619,6 +619,19 @@ def test_hooks_install_still_refuses_unwired_target_without_settings(tmp_path: P
     assert not (target / ".brigade" / "claude-hooks.json").exists()
 
 
+def test_hooks_install_refuses_malformed_brigade_config_even_with_settings(tmp_path: Path, capsys):
+    target = _unwired_with_settings(tmp_path)
+    brigade = target / ".brigade"
+    brigade.mkdir()
+    (brigade / "config.json").write_text("{not-json\n")
+    before = (target / ".claude" / "settings.json").read_bytes()
+
+    assert hooks_install(target=target) == 2
+    assert "unable to load Brigade config" in capsys.readouterr().err
+    assert (target / ".claude" / "settings.json").read_bytes() == before
+    assert not (target / ".brigade" / "claude-hooks.json").exists()
+
+
 def test_hooks_update_adopts_and_is_idempotent_on_unwired_user_settings(tmp_path: Path):
     target = _unwired_with_settings(tmp_path)
     assert hooks_install(target=target) == 0

--- a/tests/test_claude_hooks_settings_merge.py
+++ b/tests/test_claude_hooks_settings_merge.py
@@ -557,8 +557,7 @@ def _unwired_with_settings(tmp_path: Path) -> Path:
                         {
                             "type": "command",
                             "command": (
-                                f"python3 {target / '.claude' / 'hooks' / 'brigade-work-loop.py'} "
-                                "--event SessionStart"
+                                f"python3 {target / '.claude' / 'hooks' / 'brigade-work-loop.py'} --event SessionStart"
                             ),
                         }
                     ]
@@ -571,8 +570,7 @@ def _unwired_with_settings(tmp_path: Path) -> Path:
                         {
                             "type": "command",
                             "command": (
-                                f"python3 {target / '.claude' / 'hooks' / 'brigade-work-loop.py'} "
-                                "--event PreToolUse"
+                                f"python3 {target / '.claude' / 'hooks' / 'brigade-work-loop.py'} --event PreToolUse"
                             ),
                         },
                         {"type": "command", "command": "echo foreign-pretool"},

--- a/tests/test_evidence_cmd.py
+++ b/tests/test_evidence_cmd.py
@@ -51,7 +51,7 @@ def test_evidence_status_distinguishes_explicit_execution_from_review_only_plans
     assert "brigade evidence export plan    # review-only" in quickstart
     assert "brigade code sync .             # preferred GraphTrail facade" in quickstart
     assert "brigade search sync|context|impact` remain compatibility aliases" in quickstart
-    assert "explicitly runs local MiseLedger for `brigade evidence crawl|search`" in station_contract
+    assert "runs the local evidence engine for `brigade evidence crawl|search`" in station_contract
     assert "crawl/export plans are review-only" in station_contract
     assert "Explicit user-invoked" in evidence_docstring
     assert "brigade code sync|context|impact" in search_docstring


### PR DESCRIPTION
## Summary
- Allow `brigade work hooks install` / `update` when `.claude/settings.json` already exists even if Claude is not in the Brigade harness selection (Fixes #519).
- Keep refusing unwired targets with no settings file, and still fail hard when `.brigade/config.json` exists but is unreadable (do not silently adopt).
- Includes a one-line evidence-test assertion update so local/`./scripts/verify` matches current `docs/station-contract.md` wording on this base.

## Test plan
- [x] `pytest tests/test_claude_hooks_settings_merge.py` (adoption, refusal, malformed-config, update idempotence)
- [ ] CI green on this PR
- [ ] After merge: optional `brigade work hooks status --target ~` then `install` only if you want live home recovery (not done in this PR)


Made with [Cursor](https://cursor.com)