### PR TITLE
docs: replace evidence ledger stack map

### DIFF
--- a/engines/evidence-ledger/README.md
+++ b/engines/evidence-ledger/README.md
@@ -124,60 +124,11 @@ MiseLedger follows one ingest path:
 
 ## Stack Map
 
-```mermaid
-flowchart TB
-    MISELEDGER["<b>MiseLedger</b><br/><i>archive, search, evidence layer</i>"]
-    SQLITE["<b>SQLite archive</b><br/>normalized records, FTS, relations, raw refs"]
-    MISELEDGER -->|owns| SQLITE
+<p align="center">
+  <img src="docs/assets/stack-map.svg" alt="MiseLedger stack map: agent sessions, local artifacts, and external crawlers pass through native adapters and adapter.v1 validation into a normalized SQLite ledger with FTS5, then reach CLI, evidence bundle, HTTP/MCP, and archive-operation readers" width="880">
+</p>
 
-    subgraph AGENTS [" agent-session crawlers "]
-        SESSIONS["<b>miseledger crawl sessions</b><br/>Codex, Claude, OpenClaw, OpenCode, Hermes, Cursor, Grok"]
-        COMPAT["<b>Native imports</b><br/>source-specific compatibility commands"]
-    end
-
-    subgraph LOCAL [" local artifact crawlers "]
-        ARTIFACTS["<b>miseledger crawl docs/files</b><br/>Markdown, text, logs, HTML"]
-        GITLOG["<b>miseledger crawl gitlog</b><br/>repository history"]
-        GENERIC["<b>Generic adapter records</b><br/>normalized source exports"]
-    end
-
-    subgraph CRAWLERS [" external crawler binaries "]
-        DISCRAWL["discrawl"]
-        GITCRAWL["gitcrawl"]
-        GRAINCRAWL["graincrawl"]
-        NOTCRAWL["notcrawl"]
-        SLACRAWL["slacrawl"]
-        MAILCRAWL["mailcrawl"]
-        TELECRAWL["telecrawl"]
-    end
-
-    SESSIONS & COMPAT == adapter JSONL ==> MISELEDGER
-    ARTIFACTS & GITLOG & GENERIC == adapter JSONL ==> MISELEDGER
-    DISCRAWL & GITCRAWL & GRAINCRAWL & NOTCRAWL & SLACRAWL & MAILCRAWL & TELECRAWL == adapter JSONL ==> MISELEDGER
-
-    subgraph READERS [" reader workflows "]
-        CLI["<b>miseledger CLI</b><br/>search, show, explain, export"]
-        EVIDENCE["<b>Evidence bundles</b><br/>Brigade-ready context"]
-        MCP["<b>Agent readers</b><br/>HTTP loopback, stdio MCP"]
-        OPS["<b>Archive operations</b><br/>doctor, stats, compact"]
-    end
-
-    SQLITE --> CLI
-    SQLITE --> EVIDENCE
-    SQLITE --> MCP
-    SQLITE --> OPS
-
-    classDef core fill:#2563eb,stroke:#1d4ed8,color:#fff;
-    classDef archive fill:#fff7ed,stroke:#ea580c,color:#7c2d12;
-    classDef source fill:#eff6ff,stroke:#2563eb,color:#1e3a8a;
-    classDef crawler fill:#ecfdf5,stroke:#059669,color:#064e3b;
-    classDef reader fill:#f1f5f9,stroke:#94a3b8,color:#334155;
-    class MISELEDGER core;
-    class SQLITE archive;
-    class SESSIONS,COMPAT,ARTIFACTS,GITLOG,GENERIC source;
-    class DISCRAWL,GITCRAWL,GRAINCRAWL,NOTCRAWL,SLACRAWL,MAILCRAWL,TELECRAWL crawler;
-    class CLI,EVIDENCE,MCP,OPS reader;
-```
+<p align="center"><em>Generated from <code>docs/assets/workflows/stack-map.json</code> with <code>plating workflow</code>.</em></p>
 
 MiseLedger owns local agent-session crawling, local artifact crawling, archive ingest, SQLite, FTS, relations, scan manifests, reader APIs, and evidence bundles.
 

--- a/engines/evidence-ledger/docs/assets/stack-map.svg
+++ b/engines/evidence-ledger/docs/assets/stack-map.svg
@@ -1,0 +1,74 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540" role="img" aria-labelledby="workflow-title workflow-desc">
+  <title id="workflow-title">From sources to searchable evidence</title>
+  <desc id="workflow-desc">Agent sessions, local artifacts, and external crawlers converge on one adapter contract before readers query the local ledger.</desc>
+  <defs>
+    <linearGradient id="workflow-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0d1014"/>
+      <stop offset="1" stop-color="#0f1318"/>
+    </linearGradient>
+    <linearGradient id="workflow-card" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#11161c"/>
+      <stop offset="1" stop-color="#0f1318"/>
+    </linearGradient>
+    <filter id="workflow-shadow" x="-10%" y="-10%" width="120%" height="130%">
+      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#000000" flood-opacity="0.38"/>
+    </filter>
+    <marker id="workflow-arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" fill="#e0a45c"/>
+    </marker>
+  </defs>
+  <rect width="960" height="540" fill="url(#workflow-bg)"/>
+  <circle cx="872" cy="52" r="220" fill="#e0a45c" opacity="0.07"/>
+  <circle cx="62" cy="506" r="180" fill="#e0a45c" opacity="0.04"/>
+  <rect x="36" y="28" width="888" height="484" rx="20" fill="url(#workflow-card)" stroke="#2a323d" filter="url(#workflow-shadow)"/>
+  <rect x="36" y="28" width="5" height="484" rx="2.5" fill="#e0a45c"/>
+  <text x="72" y="67" fill="#e0a45c" font-family="IBM Plex Mono, ui-monospace, monospace" font-size="11" font-weight="600" letter-spacing="2.4">MISELEDGER STACK MAP</text>
+  <text x="72" y="96" fill="#dde3ea" font-family="Inter, ui-sans-serif, sans-serif" font-size="21" font-weight="700" letter-spacing="-0.6">From sources to searchable evidence</text>
+  <text x="72" y="119" fill="#9aa4b2" font-family="IBM Plex Mono, ui-monospace, monospace" font-size="11">Agent sessions, local artifacts, and external crawlers converge on one adapter contract before readers query the local ledger.</text>
+  <text x="888" y="67" text-anchor="end" fill="#7d8590" font-family="IBM Plex Mono, ui-monospace, monospace" font-size="10">local SQLite · FTS5</text>
+  <line x1="72" y1="139" x2="888" y2="139" stroke="#1e242c"/>
+  <text x="72.0" y="164" fill="#e0a45c" font-family="IBM Plex Mono, ui-monospace, monospace" font-size="10" font-weight="600" letter-spacing="1.7">SOURCES</text>
+  <text x="283.5" y="164" fill="#e0a45c" font-family="IBM Plex Mono, ui-monospace, monospace" font-size="10" font-weight="600" letter-spacing="1.7">CONTRACT</text>
+  <text x="495.0" y="164" fill="#e0a45c" font-family="IBM Plex Mono, ui-monospace, monospace" font-size="10" font-weight="600" letter-spacing="1.7">LOCAL LEDGER</text>
+  <text x="706.5" y="164" fill="#e0a45c" font-family="IBM Plex Mono, ui-monospace, monospace" font-size="10" font-weight="600" letter-spacing="1.7">READERS</text>
+  <line class="workflow-edge" x1="253.5" y1="189.0" x2="283.5" y2="271.0" stroke="#e0a45c" stroke-width="1.5" opacity="0.9" marker-end="url(#workflow-arrow)"/>
+  <line class="workflow-edge" x1="253.5" y1="271.0" x2="283.5" y2="271.0" stroke="#e0a45c" stroke-width="1.5" opacity="0.9" marker-end="url(#workflow-arrow)"/>
+  <line class="workflow-edge" x1="253.5" y1="353.0" x2="283.5" y2="271.0" stroke="#e0a45c" stroke-width="1.5" opacity="0.9" marker-end="url(#workflow-arrow)"/>
+  <line class="workflow-edge" x1="465.0" y1="271.0" x2="495.0" y2="230.0" stroke="#e0a45c" stroke-width="1.5" opacity="0.9" marker-end="url(#workflow-arrow)"/>
+  <line class="workflow-edge" x1="465.0" y1="271.0" x2="495.0" y2="312.0" stroke="#e0a45c" stroke-width="1.5" opacity="0.9" marker-end="url(#workflow-arrow)"/>
+  <line class="workflow-edge" x1="676.5" y1="230.0" x2="706.5" y2="189.0" stroke="#e0a45c" stroke-width="1.5" opacity="0.9" marker-end="url(#workflow-arrow)"/>
+  <line class="workflow-edge" x1="676.5" y1="312.0" x2="706.5" y2="271.0" stroke="#e0a45c" stroke-width="1.5" opacity="0.9" marker-end="url(#workflow-arrow)"/>
+  <line class="workflow-edge" x1="676.5" y1="312.0" x2="706.5" y2="353.0" stroke="#e0a45c" stroke-width="1.5" opacity="0.9" marker-end="url(#workflow-arrow)"/>
+  <rect x="72.0" y="155.0" width="181.5" height="68" rx="12" fill="#11161c" stroke="#2a323d"/>
+  <text class="workflow-node-label" x="88.0" y="184.0" fill="#dde3ea" font-family="IBM Plex Mono, ui-monospace, monospace" font-size="14" font-weight="600">agent sessions</text>
+  <text x="88.0" y="204.0" fill="#9aa4b2" font-family="IBM Plex Mono, ui-monospace, monospace" font-size="10">Codex · Claude · 5 more</text>
+  <rect x="72.0" y="237.0" width="181.5" height="68" rx="12" fill="#11161c" stroke="#2a323d"/>
+  <text class="workflow-node-label" x="88.0" y="266.0" fill="#dde3ea" font-family="IBM Plex Mono, ui-monospace, monospace" font-size="14" font-weight="600">local artifacts</text>
+  <text x="88.0" y="286.0" fill="#9aa4b2" font-family="IBM Plex Mono, ui-monospace, monospace" font-size="10">docs · files · gitlog</text>
+  <rect x="72.0" y="319.0" width="181.5" height="68" rx="12" fill="#11161c" stroke="#2a323d"/>
+  <text class="workflow-node-label" x="88.0" y="348.0" fill="#dde3ea" font-family="IBM Plex Mono, ui-monospace, monospace" font-size="14" font-weight="600">external crawlers</text>
+  <text x="88.0" y="368.0" fill="#9aa4b2" font-family="IBM Plex Mono, ui-monospace, monospace" font-size="10">discrawl · gitcrawl · 5 more</text>
+  <rect x="283.5" y="237.0" width="181.5" height="68" rx="12" fill="#11161c" stroke="#e0a45c"/>
+  <text class="workflow-node-label" x="299.5" y="266.0" fill="#dde3ea" font-family="IBM Plex Mono, ui-monospace, monospace" font-size="14" font-weight="600">adapter.v1 JSONL</text>
+  <text x="299.5" y="286.0" fill="#9aa4b2" font-family="IBM Plex Mono, ui-monospace, monospace" font-size="10">validate · normalize</text>
+  <rect x="495.0" y="196.0" width="181.5" height="68" rx="12" fill="#0f1318" stroke="#e0a45c"/>
+  <text class="workflow-node-label" x="511.0" y="233.0" fill="#dde3ea" font-family="IBM Plex Mono, ui-monospace, monospace" font-size="14" font-weight="600">SQLite archive</text>
+  <text x="511.0" y="252.0" fill="#9aa4b2" font-family="IBM Plex Mono, ui-monospace, monospace" font-size="10">normalized records · raw refs</text>
+  <text class="workflow-badge" x="511.0" y="213.0" fill="#e0a45c" font-family="IBM Plex Mono, ui-monospace, monospace" font-size="8" font-weight="600" letter-spacing="1.2">LOCAL</text>
+  <rect x="495.0" y="278.0" width="181.5" height="68" rx="12" fill="#11161c" stroke="#2a323d"/>
+  <text class="workflow-node-label" x="511.0" y="307.0" fill="#dde3ea" font-family="IBM Plex Mono, ui-monospace, monospace" font-size="14" font-weight="600">search + scans</text>
+  <text x="511.0" y="327.0" fill="#9aa4b2" font-family="IBM Plex Mono, ui-monospace, monospace" font-size="10">FTS5 · relations · manifests</text>
+  <rect x="706.5" y="155.0" width="181.5" height="68" rx="12" fill="#11161c" stroke="#2a323d"/>
+  <text class="workflow-node-label" x="722.5" y="184.0" fill="#dde3ea" font-family="IBM Plex Mono, ui-monospace, monospace" font-size="14" font-weight="600">CLI</text>
+  <text x="722.5" y="204.0" fill="#9aa4b2" font-family="IBM Plex Mono, ui-monospace, monospace" font-size="10">search · explain · export</text>
+  <rect x="706.5" y="237.0" width="181.5" height="68" rx="12" fill="#11161c" stroke="#e0a45c"/>
+  <text class="workflow-node-label" x="722.5" y="266.0" fill="#dde3ea" font-family="IBM Plex Mono, ui-monospace, monospace" font-size="14" font-weight="600">evidence bundles</text>
+  <text x="722.5" y="286.0" fill="#9aa4b2" font-family="IBM Plex Mono, ui-monospace, monospace" font-size="10">Brigade-ready context</text>
+  <rect x="706.5" y="319.0" width="181.5" height="68" rx="12" fill="#11161c" stroke="#2a323d"/>
+  <text class="workflow-node-label" x="722.5" y="348.0" fill="#dde3ea" font-family="IBM Plex Mono, ui-monospace, monospace" font-size="14" font-weight="600">HTTP + MCP</text>
+  <text x="722.5" y="368.0" fill="#9aa4b2" font-family="IBM Plex Mono, ui-monospace, monospace" font-size="10">reader APIs · archive ops</text>
+  <line x1="72" y1="398" x2="888" y2="398" stroke="#1e242c"/>
+  <text x="72" y="427" fill="#e0a45c" font-family="IBM Plex Mono, ui-monospace, monospace" font-size="10" font-weight="600" letter-spacing="1.6">OWNERSHIP BOUNDARY</text>
+  <text x="72" y="455" fill="#dde3ea" font-family="IBM Plex Mono, ui-monospace, monospace" font-size="13" font-weight="600">external tools keep native sync/query · MiseLedger owns normalized local evidence</text>
+  <text x="72" y="478" fill="#7d8590" font-family="IBM Plex Mono, ui-monospace, monospace" font-size="10">After adapter ingest, imported text remains untrusted evidence, never instructions.</text>
+</svg>

--- a/engines/evidence-ledger/docs/assets/workflows/stack-map.json
+++ b/engines/evidence-ledger/docs/assets/workflows/stack-map.json
@@ -1,0 +1,116 @@
+{
+  "title": "From sources to searchable evidence",
+  "eyebrow": "MISELEDGER STACK MAP",
+  "description": "Agent sessions, local artifacts, and external crawlers converge on one adapter contract before readers query the local ledger.",
+  "meta": "local SQLite · FTS5",
+  "columns": [
+    {
+      "title": "SOURCES",
+      "nodes": [
+        {
+          "id": "sessions",
+          "label": "agent sessions",
+          "detail": "Codex · Claude · 5 more"
+        },
+        {
+          "id": "artifacts",
+          "label": "local artifacts",
+          "detail": "docs · files · gitlog"
+        },
+        {
+          "id": "crawlers",
+          "label": "external crawlers",
+          "detail": "discrawl · gitcrawl · 5 more"
+        }
+      ]
+    },
+    {
+      "title": "CONTRACT",
+      "nodes": [
+        {
+          "id": "adapter",
+          "label": "adapter.v1 JSONL",
+          "detail": "validate · normalize",
+          "kind": "accent"
+        }
+      ]
+    },
+    {
+      "title": "LOCAL LEDGER",
+      "nodes": [
+        {
+          "id": "sqlite",
+          "label": "SQLite archive",
+          "detail": "normalized records · raw refs",
+          "kind": "focus",
+          "badge": "local"
+        },
+        {
+          "id": "index",
+          "label": "search + scans",
+          "detail": "FTS5 · relations · manifests"
+        }
+      ]
+    },
+    {
+      "title": "READERS",
+      "nodes": [
+        {
+          "id": "cli",
+          "label": "CLI",
+          "detail": "search · explain · export"
+        },
+        {
+          "id": "evidence",
+          "label": "evidence bundles",
+          "detail": "Brigade-ready context",
+          "kind": "accent"
+        },
+        {
+          "id": "api",
+          "label": "HTTP + MCP",
+          "detail": "reader APIs · archive ops"
+        }
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "from": "sessions",
+      "to": "adapter"
+    },
+    {
+      "from": "artifacts",
+      "to": "adapter"
+    },
+    {
+      "from": "crawlers",
+      "to": "adapter"
+    },
+    {
+      "from": "adapter",
+      "to": "sqlite"
+    },
+    {
+      "from": "adapter",
+      "to": "index"
+    },
+    {
+      "from": "sqlite",
+      "to": "cli"
+    },
+    {
+      "from": "index",
+      "to": "evidence"
+    },
+    {
+      "from": "index",
+      "to": "api"
+    }
+  ],
+  "context": {
+    "title": "OWNERSHIP BOUNDARY",
+    "body": "external tools keep native sync/query · MiseLedger owns normalized local evidence",
+    "detail": "After adapter ingest, imported text remains untrusted evidence, never instructions."
+  }
+}


### PR DESCRIPTION
## Summary

- Replace the evidence ledger README's Mermaid stack map with a generated 960 by 540 SVG.
- Group the flow into sources, the adapter contract, the local ledger, and reader surfaces.
- Keep the JSON workflow source beside the SVG so later edits remain reproducible.

## Why

The old Mermaid map fed 12 source nodes into the center of one diagram. On GitHub, its edges crossed labels and the map needed pan and zoom controls. The replacement keeps the crawler coverage and ownership boundary while limiting each stage to three cards.

## Verification

- `./scripts/verify`
- `plating workflow docs/assets/workflows/stack-map.json --out docs/assets/stack-map.svg`
- Inspected desktop and 390 px responsive renders
