### PR TITLE
fix(evidence-ledger): stop writing unused config

### DIFF
--- a/engines/evidence-ledger/internal/app/app.go
+++ b/engines/evidence-ledger/internal/app/app.go
@@ -134,20 +134,11 @@ func openMigrated() (*sql.DB, Paths, error) {
 func cmdInit(args []string, out, errw io.Writer) int {
 	_ = args
 	paths := ResolvePaths()
-	if err := security.EnsurePrivateParent(paths.ConfigPath); err != nil {
-		return fatalf(errw, "init: %s", err)
-	}
 	if err := security.EnsurePrivateDir(paths.DataDir); err != nil {
 		return fatalf(errw, "init: %s", err)
 	}
 	if err := security.EnsurePrivateDir(paths.CacheDir); err != nil {
 		return fatalf(errw, "init: %s", err)
-	}
-	if _, err := os.Stat(paths.ConfigPath); errors.Is(err, os.ErrNotExist) {
-		body := fmt.Sprintf("db_path = %q\ncache_dir = %q\n", paths.DBPath, paths.CacheDir)
-		if err := security.WritePrivateFileAtomic(paths.ConfigPath, []byte(body)); err != nil {
-			return fatalf(errw, "init: %s", err)
-		}
 	}
 	db, err := archive.Open(paths.DBPath)
 	if err != nil {

--- a/engines/evidence-ledger/internal/app/app_test.go
+++ b/engines/evidence-ledger/internal/app/app_test.go
@@ -28,9 +28,12 @@ func TestInitCreatesPrivateDirsAndDoctorJSON(t *testing.T) {
 		t.Fatalf("init failed: code=%d err=%s", code, errb.String())
 	}
 	paths := ResolvePaths()
-	assertPrivate(t, filepath.Dir(paths.ConfigPath))
+	if _, err := os.Stat(paths.ConfigPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("init created config.toml at %s: %v", paths.ConfigPath, err)
+	}
 	assertPrivate(t, paths.DataDir)
 	assertPrivate(t, paths.CacheDir)
+	assertPrivate(t, paths.DBPath)
 
 	out.Reset()
 	errb.Reset()
@@ -43,6 +46,23 @@ func TestInitCreatesPrivateDirsAndDoctorJSON(t *testing.T) {
 	}
 	if got["ok"] != true {
 		t.Fatalf("doctor not ok: %v", got)
+	}
+}
+
+func TestInitLeavesExistingConfigUntouched(t *testing.T) {
+	withTempHome(t)
+	paths := ResolvePaths()
+	custom := "db_path = \"/custom/fork.db\"\ncache_dir = \"/custom/cache\"\n"
+	mustWrite(t, paths.ConfigPath, custom)
+
+	runOK(t, "init")
+
+	got, err := os.ReadFile(paths.ConfigPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if string(got) != custom {
+		t.Fatalf("init rewrote config.toml:\n got %q\nwant %q", got, custom)
 	}
 }
 


### PR DESCRIPTION
Closes #528.

## Summary

- Stop `miseledger init` from creating `config.toml` with unsupported `db_path` and `cache_dir` settings.
- Preserve existing user-created config files without modifying them.
- Add regression coverage for fresh initialization and existing config files.

## Root cause

`ResolvePaths` derives runtime paths from the XDG environment. Nothing parses the config file written by `init`, so editing `db_path` appeared successful while imports continued writing to the default database.

## Impact

Fresh initialization no longer advertises settings that MiseLedger ignores. Existing config files remain untouched and continue to have no effect on runtime path selection.

## Verification

- `PATH=/usr/local/go/bin:$PATH go test -race ./...`
- `./scripts/verify` (`4220 passed, 3 skipped`)