### PR TITLE
fix(security): honor exclusions and stabilize fingerprints

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -36,7 +36,8 @@ Supported fields:
 - `fail_on`: `none`, `low`, `medium`, `high`, or `critical`.
 - `include_templates`: whether public template files are scanned.
 - `enabled_checks`: any of `automation`, `mcp`, `permissions`, `prompt-injection`, `secrets`, and `supply-chain`.
-- `include_paths` and `exclude_paths`: relative path prefixes.
+- `include_paths`: relative path prefixes. Bracketed Next.js-style segments such as `app/[id]` are matched literally, not as globs.
+- `exclude_paths`: relative path prefixes. A trailing `/**` excludes the prefix and all descendants (for example `.brigade/**` covers `.brigade/security.toml` and nested files).
 - `severity_threshold`: minimum severity retained in reports.
 - `output_path`: relative path for the latest local evidence bundle.
 - `[suppressions]` and `[suppression_reasons]`: reviewed finding fingerprints and reasons.
@@ -56,7 +57,17 @@ brigade security unsuppress <finding-id-or-fingerprint>
 brigade security doctor
 ```
 
-Findings include stable `id`, `fingerprint`, `rule_id`, `severity`, `category`, `path`, `line`, `safe_excerpt`, `remediation_hint`, and optional `response_options` fields. Secret-looking values are redacted before JSON reports, Markdown reports, SARIF, work imports, docs, or session artifacts are written.
+Findings include stable `id`, `fingerprint`, `rule_id`, `severity`, `category`, `path`, `line`, `occurrence`, `safe_excerpt`, `remediation_hint`, and optional `response_options` fields. Secret-looking values are redacted before JSON reports, Markdown reports, SARIF, work imports, docs, or session artifacts are written.
+
+### Finding fingerprints and suppressions
+
+Finding fingerprints are content-addressed, not line-addressed. A fingerprint hashes `rule_id`, repo-relative `path`, a normalized redacted 96-character excerpt of the matched content, and a zero-based `occurrence` index for genuine duplicates of the same rule and text in one file. When more than one identical match exists in a file, the fingerprint also includes that group's `duplicate_count` so removing or adding a duplicate rekeys the remaining findings instead of transferring a suppression from a removed sibling. Singleton matches keep the pre-cardinality formula byte-for-byte unchanged. Absolute line numbers are reported for review but do not affect fingerprint identity, so suppressions survive unrelated edits above a finding.
+
+Each finding also carries a `legacy_fingerprint` alias computed with the pre-upgrade line-based formula (`category`, `title`, `path`, `line`, and a 96-character redacted excerpt). Suppressions, accepted-risk closeouts, and suppression-health checks match the content-addressed fingerprint and may also match the legacy alias only when the finding is a singleton (`duplicate_count = 1`, or the field is missing on historical reports). Duplicate groups never inherit a pre-upgrade singleton suppression or accepted-risk closeout through the shared legacy alias. On the first exact legacy match for a singleton, a scan migrates the configured suppression to the primary fingerprint, writes a local legacy-to-primary map under `.brigade/security/fingerprint-migration-map.json`, and health records the primary fingerprint in an accepted-risk closeout. Review, findings, show, suppress, and unsuppress consult that map bidirectionally so an older evidence bundle that still lists only the legacy fingerprint remains manageable after migration and later line movement. `security.toml` stays canonical: legacy suppression entries are removed and only the primary fingerprint is retained; old evidence bundles are not rewritten.
+
+When the same rule matches identical redacted text twice in one file, the first match uses `occurrence = 0`, the second `occurrence = 1`, and so on, and both carry `duplicate_count = 2`. Occurrence order follows ascending scan line number, which keeps duplicate strings distinct without tying identity to a single absolute line. If one duplicate is removed, the survivor's `duplicate_count` drops to `1` and its fingerprint changes, so a suppression on the removed instance does not quiet the remaining match.
+
+**One-time migration edge case:** a legacy suppression or accepted-risk record for a finding that already moved before its first upgraded scan cannot be mapped automatically, because the legacy alias depends on the original line number. Re-review that finding once under its new content-addressed fingerprint. Findings that stayed at the same location keep working through the legacy alias without manual rework.
 
 Secret findings include a small response playbook. Typical options are moving active credentials into a gitignored `.env` file or environment variable, scrubbing tracked files and rotating exposed values, showing the redacted finding to the operator so they can preserve the real value in KeePass before deciding, and redacting or archiving chat/session transcripts when a session log contains an exposed key.
 

--- a/src/brigade/security_cmd/commands.py
+++ b/src/brigade/security_cmd/commands.py
@@ -60,6 +60,7 @@ def show_config(*, target: Path, json_output: bool = False) -> int:
 
 def health(target: Path, *, suppression_cache_only: bool = False) -> dict[str, Any]:
     target = target.expanduser().resolve()
+    migration_map = _read_fingerprint_migration_map(target)
     checks: list[dict[str, Any]] = []
     closeouts = _read_closeouts(target)
     latest_closeout = closeouts[0] if closeouts else None
@@ -75,6 +76,8 @@ def health(target: Path, *, suppression_cache_only: bool = False) -> dict[str, A
         and latest_closeout["policy_pack"].get("accepted_risk") is True
         else set()
     )
+    if accepted_fingerprints:
+        accepted_fingerprints = _expand_suppression_fingerprints(accepted_fingerprints, migration_map)
     config_ok = True
     try:
         loaded = load_config(target)
@@ -144,11 +147,30 @@ def health(target: Path, *, suppression_cache_only: bool = False) -> dict[str, A
     eligible_harness_findings = [
         item for item in raw_harness_findings if include_templates or item.get("confidence") != "template"
     ]
+    if isinstance(latest_closeout, dict) and eligible_harness_findings:
+        matched_harness_findings = [
+            item
+            for item in eligible_harness_findings
+            if _finding_matches_fingerprints(item, accepted_fingerprints, migration_map=migration_map)
+        ]
+        migrated_closeout = _migrate_closeout_fingerprints(latest_closeout, matched_harness_findings)
+        if migrated_closeout is not None:
+            latest_closeout = migrated_closeout
+            accepted_fingerprints = {
+                str(fingerprint)
+                for fingerprint in latest_closeout.get("source_fingerprints", [])
+                if isinstance(fingerprint, str) and fingerprint
+            }
+            accepted_fingerprints = _expand_suppression_fingerprints(accepted_fingerprints, migration_map)
     active_harness_findings = [
-        item for item in eligible_harness_findings if str(item.get("fingerprint") or "") not in accepted_fingerprints
+        item
+        for item in eligible_harness_findings
+        if not _finding_matches_fingerprints(item, accepted_fingerprints, migration_map=migration_map)
     ]
     quieted_harness_findings = [
-        item for item in eligible_harness_findings if str(item.get("fingerprint") or "") in accepted_fingerprints
+        item
+        for item in eligible_harness_findings
+        if _finding_matches_fingerprints(item, accepted_fingerprints, migration_map=migration_map)
     ]
     harness_wiring = {
         **raw_harness_wiring,
@@ -233,10 +255,24 @@ def health(target: Path, *, suppression_cache_only: bool = False) -> dict[str, A
         except (OSError, ValueError, json.JSONDecodeError):
             raw_open_findings = []
         quieted_findings = [
-            item for item in raw_open_findings if str(item.get("fingerprint") or "") in accepted_fingerprints
+            item
+            for item in raw_open_findings
+            if _finding_matches_fingerprints(item, accepted_fingerprints, migration_map=migration_map)
         ]
+        if isinstance(latest_closeout, dict) and quieted_findings:
+            migrated_closeout = _migrate_closeout_fingerprints(latest_closeout, quieted_findings)
+            if migrated_closeout is not None:
+                latest_closeout = migrated_closeout
+                accepted_fingerprints = {
+                    str(fingerprint)
+                    for fingerprint in latest_closeout.get("source_fingerprints", [])
+                    if isinstance(fingerprint, str) and fingerprint
+                }
+                accepted_fingerprints = _expand_suppression_fingerprints(accepted_fingerprints, migration_map)
         records = [
-            item for item in raw_open_findings if str(item.get("fingerprint") or "") not in accepted_fingerprints
+            item
+            for item in raw_open_findings
+            if not _finding_matches_fingerprints(item, accepted_fingerprints, migration_map=migration_map)
         ]
         if records:
             top_finding = records[0]
@@ -411,6 +447,22 @@ def scan(
         exclude_paths=effective.exclude_paths,
         severity_threshold=effective.severity_threshold,
     )
+    suppression_migrations: list[dict[str, str]] = []
+    if effective.config_loaded:
+        loaded = load_config(target)
+        if loaded is not None:
+            migrated_config, suppression_migrations = _migrate_legacy_suppressions(loaded, report)
+            if suppression_migrations:
+                if _merge_fingerprint_migration_map(target, suppression_migrations):
+                    write_config(target, migrated_config)
+                    effective = _effective_policy(
+                        target,
+                        policy=policy,
+                        fail_on=fail_on,
+                        include_templates=include_templates,
+                    )
+                else:
+                    suppression_migrations = []
     report["policy"] = effective.policy
     report["scan_profile"] = effective.scan_profile
     report["fail_on"] = effective.fail_on
@@ -422,6 +474,8 @@ def scan(
     report["config"] = str(effective.config_path)
     report["config_loaded"] = effective.config_loaded
     report["generated_at"] = _utc_iso()
+    if suppression_migrations:
+        report["suppression_migrations"] = suppression_migrations
     _write_suppression_health_cache_from_report(target, effective, report)
     configured_output_dir = target / effective.output_path
     requested_output_dir = output_dir

--- a/src/brigade/security_cmd/models.py
+++ b/src/brigade/security_cmd/models.py
@@ -41,6 +41,12 @@ ARTIFACTS_REL_PATH = ".brigade/security/latest"
 SUPPRESSION_HEALTH_CACHE_REL_PATH = ".brigade/security/suppression-health-cache.json"
 
 
+FINGERPRINT_MIGRATION_MAP_REL_PATH = ".brigade/security/fingerprint-migration-map.json"
+
+
+FINGERPRINT_MIGRATION_MAP_SCHEMA = "brigade.security.fingerprint-migration-map.v1"
+
+
 SUPPRESSION_HEALTH_CACHE_VERSION = 1
 
 
@@ -373,21 +379,133 @@ def suppression_health_cache_path(target: Path) -> Path:
     return target / SUPPRESSION_HEALTH_CACHE_REL_PATH
 
 
+def fingerprint_migration_map_path(target: Path) -> Path:
+    return target / FINGERPRINT_MIGRATION_MAP_REL_PATH
+
+
+def _workspace_state_path_is_safe(target: Path, path: Path) -> bool:
+    target_resolved = target.expanduser().resolve()
+    try:
+        relative = path.relative_to(target_resolved)
+    except ValueError:
+        return False
+    candidate = target_resolved
+    for part in relative.parts:
+        candidate /= part
+        if candidate.is_symlink():
+            return False
+    try:
+        path.resolve(strict=False).relative_to(target_resolved)
+    except (OSError, ValueError):
+        return False
+    return True
+
+
+def _closeout_path_is_symlink(path: Path) -> bool:
+    return path.is_symlink()
+
+
+def _closeout_path_contained_in(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+    except (OSError, ValueError):
+        return False
+    return True
+
+
 def _closeouts_root(target: Path) -> Path:
     return target / ".brigade" / "security" / "closeouts"
 
 
+def _read_fingerprint_migration_map(target: Path) -> dict[str, str]:
+    target_resolved = target.expanduser().resolve()
+    path = fingerprint_migration_map_path(target_resolved)
+    if not _workspace_state_path_is_safe(target_resolved, path):
+        return {}
+    payload = localio.read_json_dict(path)
+    if payload is None:
+        return {}
+    if payload.get("schema") != FINGERPRINT_MIGRATION_MAP_SCHEMA:
+        return {}
+    raw_migrations = payload.get("migrations")
+    if not isinstance(raw_migrations, dict):
+        return {}
+    migrations: dict[str, str] = {}
+    for legacy, primary in raw_migrations.items():
+        if not isinstance(legacy, str) or not isinstance(primary, str):
+            continue
+        legacy = legacy.strip()
+        primary = primary.strip()
+        if FINGERPRINT_RE.fullmatch(legacy) and FINGERPRINT_RE.fullmatch(primary):
+            migrations[legacy] = primary
+    return migrations
+
+
+def _write_fingerprint_migration_map(target: Path, migrations: dict[str, str]) -> bool:
+    if not migrations:
+        return True
+    target_resolved = target.expanduser().resolve()
+    path = fingerprint_migration_map_path(target_resolved)
+    if not _workspace_state_path_is_safe(target_resolved, path):
+        return False
+    _write_json(
+        path,
+        {
+            "schema": FINGERPRINT_MIGRATION_MAP_SCHEMA,
+            "migrations": dict(sorted(migrations.items())),
+        },
+    )
+    return True
+
+
+def _merge_fingerprint_migration_map(target: Path, entries: list[dict[str, str]]) -> bool:
+    merged = _read_fingerprint_migration_map(target)
+    changed = False
+    for entry in entries:
+        legacy = str(entry.get("from") or "").strip()
+        primary = str(entry.get("to") or "").strip()
+        if not legacy or not primary:
+            continue
+        if merged.get(legacy) == primary:
+            continue
+        merged[legacy] = primary
+        changed = True
+    if changed:
+        return _write_fingerprint_migration_map(target, merged)
+    return True
+
+
 def _read_closeouts(target: Path) -> list[dict[str, Any]]:
-    root = _closeouts_root(target.expanduser().resolve())
+    target_resolved = target.expanduser().resolve()
+    root = _closeouts_root(target_resolved)
     receipts: list[dict[str, Any]] = []
-    if not root.is_dir():
+    if not root.is_dir() or _closeout_path_is_symlink(root):
         return receipts
-    for path in sorted(root.glob("*/closeout.json")):
-        payload = _read_json(path)
+    if not _closeout_path_contained_in(root, target_resolved):
+        return receipts
+    try:
+        root_resolved = root.resolve()
+    except OSError:
+        return receipts
+    for closeout_dir in sorted(item for item in root.iterdir() if item.is_dir()):
+        if _closeout_path_is_symlink(closeout_dir):
+            continue
+        if not _closeout_path_contained_in(closeout_dir, root_resolved):
+            continue
+        closeout_json = closeout_dir / "closeout.json"
+        if not closeout_json.is_file() or _closeout_path_is_symlink(closeout_json):
+            continue
+        try:
+            trusted_path = closeout_json.resolve()
+        except OSError:
+            continue
+        if not _closeout_path_contained_in(trusted_path, root_resolved):
+            continue
+        payload = _read_json(trusted_path)
         if payload is None:
             continue
-        payload.setdefault("closeout_id", path.parent.name)
-        payload.setdefault("path", str(path))
+        payload.setdefault("closeout_id", closeout_dir.name)
+        payload["path"] = str(trusted_path)
         receipts.append(payload)
     return sorted(receipts, key=lambda item: str(item.get("created_at") or item.get("closeout_id") or ""), reverse=True)
 

--- a/src/brigade/security_cmd/reports.py
+++ b/src/brigade/security_cmd/reports.py
@@ -44,26 +44,33 @@ def _load_report_file(path: Path) -> dict[str, Any]:
 
 def _report_findings_for_review(target: Path, report: dict[str, Any]) -> list[dict[str, Any]]:
     config = load_config(target) or SecurityConfig()
+    migration_map = _read_fingerprint_migration_map(target)
     suppressed = set(config.suppressions)
     reasons = config.suppression_reasons
     records: list[dict[str, Any]] = []
     for finding in report.get("findings", []):
         if not isinstance(finding, dict):
             continue
-        fingerprint = str(finding.get("fingerprint") or "")
         record = dict(finding)
-        record["status"] = "suppressed" if fingerprint in suppressed else "open"
-        if fingerprint in reasons:
-            record["reason"] = reasons[fingerprint]
+        record["status"] = (
+            "suppressed" if _finding_matches_fingerprints(finding, suppressed, migration_map=migration_map) else "open"
+        )
+        reason = _suppression_reason_for_finding(
+            finding, suppressions=suppressed, reasons=reasons, migration_map=migration_map
+        )
+        if reason:
+            record["reason"] = reason
         records.append(record)
     for finding in report.get("suppressed_findings", []):
         if not isinstance(finding, dict):
             continue
-        fingerprint = str(finding.get("fingerprint") or "")
         record = dict(finding)
         record["status"] = "suppressed"
-        if fingerprint in reasons:
-            record["reason"] = reasons[fingerprint]
+        reason = _suppression_reason_for_finding(
+            finding, suppressions=suppressed, reasons=reasons, migration_map=migration_map
+        )
+        if reason:
+            record["reason"] = reason
         records.append(record)
     records.sort(
         key=lambda item: (
@@ -150,6 +157,71 @@ def _diff_finding_key(record: dict[str, Any]) -> str:
     return "|".join(str(record.get(field) or "") for field in ("category", "path", "line", "title"))
 
 
+def _identifier_match_candidates(identifier: str, migration_map: dict[str, str] | None = None) -> set[str]:
+    needle = identifier.strip()
+    if not needle:
+        return set()
+    candidates = {needle}
+    fingerprint = needle.removeprefix("security-")
+    if FINGERPRINT_RE.fullmatch(fingerprint):
+        candidates.add(fingerprint)
+    if migration_map and FINGERPRINT_RE.fullmatch(fingerprint):
+        aliases = _expand_suppression_fingerprints({fingerprint}, migration_map)
+        candidates.update(aliases)
+        candidates.update(f"security-{alias}" for alias in aliases)
+    return candidates
+
+
+def _diff_finding_alias_keys(
+    record: dict[str, Any],
+    migration_map: dict[str, str] | None = None,
+) -> set[str]:
+    keys: set[str] = set()
+    fingerprint = str(record.get("fingerprint") or "")
+    if fingerprint:
+        keys.add(fingerprint)
+    duplicate_count = record.get("duplicate_count")
+    is_singleton = duplicate_count is None or (isinstance(duplicate_count, int) and duplicate_count <= 1)
+    if is_singleton:
+        legacy = str(record.get("legacy_fingerprint") or "")
+        if legacy:
+            keys.add(legacy)
+        if migration_map:
+            keys = _expand_suppression_fingerprints(keys, migration_map)
+    if keys:
+        return keys
+    return {_diff_finding_key(record)}
+
+
+def _diff_records_match(
+    left: dict[str, Any],
+    right: dict[str, Any],
+    migration_map: dict[str, str] | None = None,
+) -> bool:
+    return bool(_diff_finding_alias_keys(left, migration_map) & _diff_finding_alias_keys(right, migration_map))
+
+
+def _diff_record_matches_any(
+    record: dict[str, Any],
+    candidates: list[dict[str, Any]],
+    migration_map: dict[str, str] | None = None,
+) -> bool:
+    return any(_diff_records_match(record, candidate, migration_map) for candidate in candidates)
+
+
+def _finding_identifier_matches(
+    record: dict[str, Any],
+    identifier: str,
+    migration_map: dict[str, str] | None = None,
+) -> bool:
+    for needle in _identifier_match_candidates(identifier, migration_map):
+        for field_name in ("id", "fingerprint", "legacy_fingerprint"):
+            value = str(record.get(field_name) or "")
+            if value == needle or value.startswith(needle):
+                return True
+    return False
+
+
 def diff(
     *,
     target: Path,
@@ -179,14 +251,15 @@ def diff(
         print(f"error: invalid security report: {exc}", file=sys.stderr)
         return 2
 
+    migration_map = _read_fingerprint_migration_map(target)
     base_records = _report_findings_for_review(target, base_report)
     against_records = _report_findings_for_review(target, against_report)
-    base_keys = {_diff_finding_key(record) for record in base_records}
-    against_keys = {_diff_finding_key(record) for record in against_records}
 
-    new = [record for record in against_records if _diff_finding_key(record) not in base_keys]
-    resolved = [record for record in base_records if _diff_finding_key(record) not in against_keys]
-    persisting = [record for record in against_records if _diff_finding_key(record) in base_keys]
+    new = [record for record in against_records if not _diff_record_matches_any(record, base_records, migration_map)]
+    resolved = [
+        record for record in base_records if not _diff_record_matches_any(record, against_records, migration_map)
+    ]
+    persisting = [record for record in against_records if _diff_record_matches_any(record, base_records, migration_map)]
 
     payload = {
         "base": str(base_dir),
@@ -255,6 +328,7 @@ def _resolve_finding_record(
     target: Path, identifier: str, output_dir: Path | None = None
 ) -> tuple[dict[str, Any] | None, str | None]:
     artifacts_dir = output_dir.expanduser().resolve() if output_dir is not None else default_artifacts_dir(target)
+    migration_map = _read_fingerprint_migration_map(target)
     try:
         report = _load_report(artifacts_dir)
         records = _report_findings_for_review(target, report)
@@ -263,17 +337,7 @@ def _resolve_finding_record(
     except (ValueError, json.JSONDecodeError) as exc:
         return None, f"invalid security report: {exc}"
     needle = identifier.strip()
-    matches = [
-        item
-        for item in records
-        if needle
-        and (
-            str(item.get("id") or "") == needle
-            or str(item.get("fingerprint") or "") == needle
-            or str(item.get("id") or "").startswith(needle)
-            or str(item.get("fingerprint") or "").startswith(needle)
-        )
-    ]
+    matches = [item for item in records if _finding_identifier_matches(item, needle, migration_map)]
     if not matches:
         return None, f"finding not found: {identifier}"
     if len(matches) > 1:

--- a/src/brigade/security_cmd/scan_engine.py
+++ b/src/brigade/security_cmd/scan_engine.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import ast
+import fnmatch
 import hashlib
 import json
 import os
@@ -1170,7 +1171,15 @@ def _path_matches_any(rel_path: str, patterns: tuple[str, ...]) -> bool:
         clean = pattern.strip().replace("\\", "/").strip("/")
         if not clean:
             continue
-        if normalized == clean or normalized.startswith(clean.rstrip("/") + "/"):
+        if clean.endswith("/**"):
+            prefix = clean[:-3].rstrip("/")
+            if normalized == prefix or normalized.startswith(prefix + "/"):
+                return True
+        if fnmatch.fnmatchcase(normalized, clean):
+            return True
+        if not any(char in clean for char in "*?[") and (
+            normalized == clean or normalized.startswith(clean.rstrip("/") + "/")
+        ):
             return True
     return False
 

--- a/src/brigade/security_cmd/scan_engine.py
+++ b/src/brigade/security_cmd/scan_engine.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import ast
-import fnmatch
 import hashlib
 import json
 import os
@@ -906,9 +905,357 @@ def _secret_response_options(path: Path, target: Path) -> list[str]:
     return options
 
 
-def _fingerprint(*, category: str, title: str, rel_path: Path, line: int, evidence: str) -> str:
-    stable = "\n".join([category, title, str(rel_path), str(line), _short(evidence, limit=96)])
+def _normalized_matched_content(evidence: str) -> str:
+    return _short(evidence, limit=96)
+
+
+def _fingerprint(
+    *,
+    rule_id: str,
+    rel_path: str,
+    matched_content: str,
+    occurrence: int,
+    duplicate_count: int = 1,
+) -> str:
+    if duplicate_count > 1:
+        stable = "\n".join([rule_id, rel_path, matched_content, str(duplicate_count), str(occurrence)])
+    else:
+        stable = "\n".join([rule_id, rel_path, matched_content, str(occurrence)])
     return hashlib.sha256(stable.encode()).hexdigest()[:16]
+
+
+def _legacy_fingerprint(*, category: str, title: str, rel_path: str, line: int, evidence: str) -> str:
+    stable = "\n".join([category, title, rel_path, str(line), _short(evidence, limit=96)])
+    return hashlib.sha256(stable.encode()).hexdigest()[:16]
+
+
+def _finding_duplicate_count(finding: dict[str, Any]) -> int:
+    duplicate_count = finding.get("duplicate_count")
+    if isinstance(duplicate_count, int) and duplicate_count > 0:
+        return duplicate_count
+    return 1
+
+
+def _safe_fingerprint_aliases(finding: dict[str, Any]) -> tuple[str, ...]:
+    aliases: list[str] = []
+    primary = str(finding.get("fingerprint") or "")
+    if primary:
+        aliases.append(primary)
+    if _finding_duplicate_count(finding) <= 1:
+        legacy = str(finding.get("legacy_fingerprint") or "")
+        if legacy and legacy not in aliases:
+            aliases.append(legacy)
+    return tuple(aliases)
+
+
+def _finding_fingerprint_aliases(finding: dict[str, Any]) -> tuple[str, ...]:
+    return _safe_fingerprint_aliases(finding)
+
+
+def _display_fingerprint_aliases(finding: dict[str, Any]) -> tuple[str, ...]:
+    aliases: list[str] = []
+    primary = str(finding.get("fingerprint") or "")
+    if primary:
+        aliases.append(primary)
+    legacy = str(finding.get("legacy_fingerprint") or "")
+    if legacy and legacy not in aliases:
+        aliases.append(legacy)
+    return tuple(aliases)
+
+
+def _expand_suppression_fingerprints(fingerprints: set[str], migration_map: dict[str, str] | None = None) -> set[str]:
+    expanded = set(fingerprints)
+    if not migration_map:
+        return expanded
+    for legacy, primary in migration_map.items():
+        if primary in fingerprints:
+            expanded.add(legacy)
+        if legacy in fingerprints:
+            expanded.add(primary)
+    return expanded
+
+
+def _suppression_reason_for_configured_fingerprint(
+    fingerprint: str, *, reasons: dict[str, str], migration_map: dict[str, str] | None = None
+) -> str | None:
+    reason = reasons.get(fingerprint)
+    if reason:
+        return reason
+    if not migration_map:
+        return None
+    primary = migration_map.get(fingerprint)
+    if primary:
+        return reasons.get(primary)
+    for legacy, mapped_primary in migration_map.items():
+        if mapped_primary == fingerprint:
+            mapped_reason = reasons.get(mapped_primary) or reasons.get(legacy)
+            if mapped_reason:
+                return mapped_reason
+    return None
+
+
+def _finding_matches_fingerprints(
+    finding: dict[str, Any],
+    fingerprints: set[str],
+    *,
+    migration_map: dict[str, str] | None = None,
+) -> bool:
+    if not fingerprints:
+        return False
+    effective = _expand_suppression_fingerprints(fingerprints, migration_map)
+    return any(alias in effective for alias in _safe_fingerprint_aliases(finding))
+
+
+def _suppression_reason_for_finding(
+    finding: dict[str, Any],
+    *,
+    suppressions: set[str],
+    reasons: dict[str, str],
+    migration_map: dict[str, str] | None = None,
+) -> str | None:
+    aliases = _safe_fingerprint_aliases(finding)
+    effective = _expand_suppression_fingerprints(suppressions, migration_map)
+    if not any(alias in effective for alias in aliases):
+        return None
+    for alias in aliases:
+        reason = _suppression_reason_for_configured_fingerprint(alias, reasons=reasons, migration_map=migration_map)
+        if reason:
+            return reason
+    return None
+
+
+def _expand_finding_suppression_aliases(
+    finding: dict[str, Any],
+    *,
+    migration_map: dict[str, str] | None = None,
+) -> set[str]:
+    aliases = set(_safe_fingerprint_aliases(finding))
+    if not migration_map:
+        return aliases
+    return _expand_suppression_fingerprints(aliases, migration_map)
+
+
+def _configured_suppression_aliases(
+    finding: dict[str, Any],
+    *,
+    suppressions: set[str],
+    reasons: dict[str, str] | None = None,
+    migration_map: dict[str, str] | None = None,
+) -> tuple[str, ...]:
+    configured = _expand_suppression_fingerprints(set(suppressions), migration_map)
+    if reasons is not None:
+        configured.update(_expand_suppression_fingerprints(set(reasons), migration_map))
+    finding_aliases = _expand_finding_suppression_aliases(finding, migration_map=migration_map)
+    return tuple(sorted(alias for alias in configured if alias in finding_aliases))
+
+
+def _migrate_legacy_suppressions(
+    config: SecurityConfig,
+    report: dict[str, Any],
+) -> tuple[SecurityConfig, list[dict[str, str]]]:
+    migrations: list[dict[str, str]] = []
+    suppressions = list(config.suppressions)
+    suppression_set = set(suppressions)
+    reasons = dict(config.suppression_reasons)
+    migrated_from: set[str] = set()
+    seen_findings: set[tuple[str, str]] = set()
+
+    for bucket in ("findings", "suppressed_findings"):
+        for finding in report.get(bucket) or []:
+            if not isinstance(finding, dict):
+                continue
+            primary = str(finding.get("fingerprint") or "")
+            legacy = str(finding.get("legacy_fingerprint") or "")
+            if not primary or not legacy or legacy not in suppression_set:
+                continue
+            if _finding_duplicate_count(finding) > 1:
+                continue
+            identity = (primary, legacy)
+            if identity in seen_findings or legacy in migrated_from:
+                continue
+            seen_findings.add(identity)
+            reason = reasons.get(legacy) or reasons.get(primary)
+            suppressions = [item for item in suppressions if item != legacy]
+            if primary not in suppressions:
+                suppressions.append(primary)
+            reasons.pop(legacy, None)
+            if reason:
+                reasons[primary] = reason
+            migrations.append({"from": legacy, "to": primary})
+            migrated_from.add(legacy)
+            suppression_set.discard(legacy)
+            suppression_set.add(primary)
+
+    if not migrations:
+        return config, migrations
+
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for fingerprint in suppressions:
+        if fingerprint in seen:
+            continue
+        seen.add(fingerprint)
+        deduped.append(fingerprint)
+
+    migrated = SecurityConfig(
+        policy=config.policy,
+        scan_profile=config.scan_profile,
+        fail_on=config.fail_on,
+        include_templates=config.include_templates,
+        enabled_checks=config.enabled_checks,
+        include_paths=config.include_paths,
+        exclude_paths=config.exclude_paths,
+        severity_threshold=config.severity_threshold,
+        output_path=config.output_path,
+        suppressions=tuple(deduped),
+        suppression_reasons=reasons,
+        enrichment=config.enrichment,
+    )
+    return migrated, migrations
+
+
+def _migrate_closeout_fingerprints(
+    closeout: dict[str, Any],
+    quieted_findings: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    if closeout.get("status") != "accepted-risk":
+        return None
+    source_fingerprints = [
+        str(item) for item in closeout.get("source_fingerprints", []) if isinstance(item, str) and item.strip()
+    ]
+    source_set = set(source_fingerprints)
+    raw_migrations = closeout.get("fingerprint_migrations")
+    migrations = dict(raw_migrations) if isinstance(raw_migrations, dict) else {}
+    changed = False
+    for finding in quieted_findings:
+        if not isinstance(finding, dict):
+            continue
+        primary = str(finding.get("fingerprint") or "")
+        legacy = str(finding.get("legacy_fingerprint") or "")
+        if not primary or not legacy or legacy not in source_set or primary in source_set:
+            continue
+        if _finding_duplicate_count(finding) > 1:
+            continue
+        source_fingerprints.append(primary)
+        source_set.add(primary)
+        migrations[legacy] = primary
+        changed = True
+    if not changed:
+        return None
+    updated = dict(closeout)
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for fingerprint in source_fingerprints:
+        if fingerprint in seen:
+            continue
+        seen.add(fingerprint)
+        deduped.append(fingerprint)
+    updated["source_fingerprints"] = deduped
+    updated["fingerprint_migrations"] = migrations
+    closeout_path = closeout.get("path")
+    if isinstance(closeout_path, str) and closeout_path.strip():
+        trusted_path = Path(closeout_path).expanduser().resolve()
+        _write_json(trusted_path, updated)
+    return updated
+
+
+def _import_content_identity(
+    *,
+    rule_id: str,
+    rel_path: str,
+    safe_detail: str,
+    occurrence: int,
+    duplicate_count: int,
+) -> tuple[str, str, str, int, int]:
+    return (
+        rule_id,
+        rel_path,
+        _normalized_matched_content(safe_detail),
+        duplicate_count,
+        occurrence,
+    )
+
+
+def _import_content_base_identity(
+    *,
+    rule_id: str,
+    rel_path: str,
+    safe_detail: str,
+) -> tuple[str, str, str]:
+    return (
+        rule_id,
+        rel_path,
+        _normalized_matched_content(safe_detail),
+    )
+
+
+def _finding_import_content_identity(finding: dict[str, Any]) -> tuple[str, str, str, int, int]:
+    safe_detail = str(finding.get("safe_excerpt") or finding.get("evidence") or "")
+    return _import_content_identity(
+        rule_id=str(finding.get("rule_id") or ""),
+        rel_path=str(finding.get("path") or ""),
+        safe_detail=safe_detail,
+        occurrence=int(finding.get("occurrence") or 0),
+        duplicate_count=int(finding.get("duplicate_count") or 1),
+    )
+
+
+def _import_metadata_content_identity(metadata: dict[str, Any]) -> tuple[str, str, str, int, int] | None:
+    occurrence = metadata.get("occurrence")
+    duplicate_count = metadata.get("duplicate_count")
+    if not isinstance(occurrence, int) or not isinstance(duplicate_count, int):
+        return None
+    safe_detail = str(metadata.get("safe_detail") or metadata.get("safe_excerpt") or "")
+    return _import_content_identity(
+        rule_id=str(metadata.get("rule_id") or ""),
+        rel_path=str(metadata.get("path") or ""),
+        safe_detail=safe_detail,
+        occurrence=occurrence,
+        duplicate_count=duplicate_count,
+    )
+
+
+def _import_metadata_content_base_identity(metadata: dict[str, Any]) -> tuple[str, str, str]:
+    safe_detail = str(metadata.get("safe_detail") or metadata.get("safe_excerpt") or "")
+    return _import_content_base_identity(
+        rule_id=str(metadata.get("rule_id") or ""),
+        rel_path=str(metadata.get("path") or ""),
+        safe_detail=safe_detail,
+    )
+
+
+def _assign_fingerprints(findings: list[dict[str, Any]]) -> None:
+    groups: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
+    for finding in findings:
+        key = (
+            str(finding.get("rule_id") or ""),
+            str(finding.get("path") or ""),
+            str(finding.get("_fingerprint_content") or finding.get("safe_excerpt") or finding.get("evidence") or ""),
+        )
+        groups.setdefault(key, []).append(finding)
+    for (_, _, matched_content), items in groups.items():
+        items.sort(key=lambda finding: (int(finding.get("line") or 0), str(finding.get("id") or "")))
+        duplicate_count = len(items)
+        for occurrence, finding in enumerate(items):
+            fingerprint = _fingerprint(
+                rule_id=str(finding.get("rule_id") or ""),
+                rel_path=str(finding.get("path") or ""),
+                matched_content=matched_content,
+                occurrence=occurrence,
+                duplicate_count=duplicate_count,
+            )
+            finding["occurrence"] = occurrence
+            finding["duplicate_count"] = duplicate_count
+            finding["fingerprint"] = fingerprint
+            finding["legacy_fingerprint"] = _legacy_fingerprint(
+                category=str(finding.get("category") or ""),
+                title=str(finding.get("title") or ""),
+                rel_path=str(finding.get("path") or ""),
+                line=int(finding.get("line") or 0),
+                evidence=str(finding.get("safe_excerpt") or finding.get("evidence") or ""),
+            )
+            finding["id"] = f"security-{fingerprint}"
+            finding.pop("_fingerprint_content", None)
 
 
 def _finding(
@@ -928,13 +1275,11 @@ def _finding(
     rel = path.relative_to(target)
     file_classification = classification or _classification_for(path, target)
     safe_excerpt = _short(evidence)
-    fingerprint = _fingerprint(category=category, title=title, rel_path=rel, line=line, evidence=safe_excerpt)
-    finding_id = f"security-{fingerprint}"
+    matched_content = _normalized_matched_content(evidence)
+    rule = _rule_id(category, title)
     findings.append(
         {
-            "id": finding_id,
-            "fingerprint": fingerprint,
-            "rule_id": _rule_id(category, title),
+            "rule_id": rule,
             "severity": severity,
             "category": category,
             "title": title,
@@ -944,6 +1289,7 @@ def _finding(
             "confidence": file_classification.confidence,
             "evidence": safe_excerpt,
             "safe_excerpt": safe_excerpt,
+            "_fingerprint_content": matched_content,
             "suggestion": suggestion,
             "remediation_hint": suggestion,
             "response_options": response_options or [],
@@ -1175,11 +1521,8 @@ def _path_matches_any(rel_path: str, patterns: tuple[str, ...]) -> bool:
             prefix = clean[:-3].rstrip("/")
             if normalized == prefix or normalized.startswith(prefix + "/"):
                 return True
-        if fnmatch.fnmatchcase(normalized, clean):
-            return True
-        if not any(char in clean for char in "*?[") and (
-            normalized == clean or normalized.startswith(clean.rstrip("/") + "/")
-        ):
+            continue
+        if normalized == clean or normalized.startswith(clean.rstrip("/") + "/"):
             return True
     return False
 
@@ -1305,6 +1648,7 @@ def scan_target(
         _scan_package_json(findings, target=target, path=path, text=text, classification=classification)
         _scan_github_actions(findings, target=target, path=path, text=text, classification=classification)
         _scan_python_project(findings, target=target, path=path, text=text, classification=classification)
+    _assign_fingerprints(findings)
     findings = _filter_findings(
         findings,
         enabled_checks=enabled_checks,
@@ -1312,8 +1656,16 @@ def scan_target(
         exclude_paths=exclude_paths,
         severity_threshold=severity_threshold,
     )
-    suppressed = [finding for finding in findings if finding.get("fingerprint") in suppressions]
-    findings = [finding for finding in findings if finding.get("fingerprint") not in suppressions]
+    migration_map = _read_fingerprint_migration_map(target)
+    suppression_set = set(suppressions)
+    suppressed = []
+    open_findings = []
+    for finding in findings:
+        if _finding_matches_fingerprints(finding, suppression_set, migration_map=migration_map):
+            suppressed.append(finding)
+        else:
+            open_findings.append(finding)
+    findings = open_findings
     counts: dict[str, int] = {}
     for finding in findings:
         severity = str(finding["severity"])
@@ -1343,25 +1695,45 @@ def _import_findings(
     *,
     evidence_path: Path | None = None,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
-    existing_fingerprints = {
-        str(item.get("metadata", {}).get("fingerprint"))
-        for item in work_cmd._pending_imports(target)
-        if isinstance(item, dict)
-        and item.get("source") == "security-scan"
-        and isinstance(item.get("metadata"), dict)
-        and item.get("metadata", {}).get("fingerprint")
-    }
+    existing_identities: dict[tuple[str, str, str, int, int], set[str]] = {}
+    legacy_counts: dict[tuple[str, str, str], dict[str, int]] = {}
+    for item in work_cmd._read_imports(target):
+        if not isinstance(item, dict) or item.get("source") != "security-scan":
+            continue
+        metadata = item.get("metadata")
+        if not isinstance(metadata, dict):
+            continue
+        severity = str(metadata.get("severity") or "")
+        identity = _import_metadata_content_identity(metadata)
+        if identity is not None:
+            existing_identities.setdefault(identity, set()).add(severity)
+            continue
+        base_identity = _import_metadata_content_base_identity(metadata)
+        severity_counts = legacy_counts.setdefault(base_identity, {})
+        severity_counts[severity] = severity_counts.get(severity, 0) + 1
     records = []
     skipped: list[dict[str, Any]] = []
+    legacy_remaining = {key: counts.copy() for key, counts in legacy_counts.items()}
     for finding in findings:
-        fingerprint = str(finding.get("fingerprint") or "")
-        if fingerprint and fingerprint in existing_fingerprints:
+        content_identity = _finding_import_content_identity(finding)
+        base_identity = content_identity[:3]
+        severity = str(finding.get("severity") or "")
+        known_severities = existing_identities.get(content_identity)
+        if known_severities is not None and severity in known_severities:
+            skipped.append(finding)
+            continue
+        duplicate_count = int(finding.get("duplicate_count") or 1)
+        original_severity_counts = legacy_counts.get(base_identity, {})
+        original_legacy_count = sum(original_severity_counts.values())
+        remaining_severity_counts = legacy_remaining.get(base_identity, {})
+        remaining_legacy = remaining_severity_counts.get(severity, 0)
+        if remaining_legacy > 0 and original_legacy_count == duplicate_count:
+            remaining_severity_counts[severity] = remaining_legacy - 1
             skipped.append(finding)
             continue
         path = finding.get("path")
         line = finding.get("line")
         title = finding.get("title")
-        severity = finding.get("severity")
         category = finding.get("category")
         kind = "incident" if SEVERITY_ORDER.get(str(severity), 0) >= SEVERITY_ORDER["high"] else "finding"
         acceptance = [
@@ -1375,7 +1747,10 @@ def _import_findings(
             )
         records.append(
             {
-                "text": f"Review security finding [{severity}] {category} in {path}:{line}: {title}",
+                "text": (
+                    f"Review security finding [{severity}] {category} in {path}:{line}: {title} "
+                    f"[{finding.get('fingerprint')}]"
+                ),
                 "kind": kind,
                 "source": "security-scan",
                 "type": "security",
@@ -1387,14 +1762,33 @@ def _import_findings(
                     "rule_id": finding.get("rule_id"),
                     "issue_type": category,
                     "fingerprint": finding.get("fingerprint"),
-                    "source_item_key": f"security-scan:{finding.get('fingerprint')}",
+                    "legacy_fingerprint": finding.get("legacy_fingerprint"),
+                    "occurrence": finding.get("occurrence", 0),
+                    "duplicate_count": finding.get("duplicate_count", 1),
+                    "source_item_key": (
+                        "security-scan:"
+                        + work_cmd._stable_hash(
+                            {
+                                "rule_id": finding.get("rule_id"),
+                                "path": path,
+                                "safe_detail": _normalized_matched_content(
+                                    str(finding.get("safe_excerpt") or finding.get("evidence") or "")
+                                ),
+                                "occurrence": finding.get("occurrence", 0),
+                                "duplicate_count": finding.get("duplicate_count", 1),
+                            }
+                        )
+                    ),
                     "source_fingerprint": work_cmd._stable_hash(
                         {
                             "rule_id": finding.get("rule_id"),
                             "fingerprint": finding.get("fingerprint"),
+                            "legacy_fingerprint": finding.get("legacy_fingerprint"),
                             "severity": severity,
                             "path": path,
                             "line": line,
+                            "occurrence": finding.get("occurrence", 0),
+                            "duplicate_count": finding.get("duplicate_count", 1),
                             "safe_excerpt": finding.get("safe_excerpt") or finding.get("evidence"),
                         }
                     ),
@@ -1412,8 +1806,7 @@ def _import_findings(
                 },
             }
         )
-        if fingerprint:
-            existing_fingerprints.add(fingerprint)
+        existing_identities.setdefault(content_identity, set()).add(severity)
     imported, duplicate_records, dismissed_records = work_cmd._append_import_records(target, records)
     skipped.extend(duplicate_records)
     skipped.extend(dismissed_records)

--- a/src/brigade/security_cmd/suppression.py
+++ b/src/brigade/security_cmd/suppression.py
@@ -34,6 +34,7 @@ def suppress(*, target: Path, fingerprint: str, reason: str, json_output: bool =
         return 2
     fingerprint = fingerprint.strip()
     cleaned_reason = _clean_reason(reason)
+    finding: dict[str, Any] | None = None
     if not FINGERPRINT_RE.match(fingerprint):
         finding, message = _resolve_finding_record(target, fingerprint)
         if finding is None or not FINGERPRINT_RE.match(str(finding.get("fingerprint") or "")):
@@ -48,10 +49,26 @@ def suppress(*, target: Path, fingerprint: str, reason: str, json_output: bool =
     except ValueError as exc:
         print(f"error: invalid security config: {exc}", file=sys.stderr)
         return 2
+    migration_map = _read_fingerprint_migration_map(target)
+    fingerprint = migration_map.get(fingerprint, fingerprint)
     suppressions = list(config.suppressions)
+    reasons = dict(config.suppression_reasons)
+    related_aliases = {legacy for legacy, primary in migration_map.items() if primary == fingerprint}
+    if finding is not None:
+        related_aliases.update(
+            _configured_suppression_aliases(
+                finding, suppressions=set(suppressions), reasons=reasons, migration_map=migration_map
+            )
+        )
+    for alias in related_aliases:
+        if alias == fingerprint:
+            continue
+        suppressions = [item for item in suppressions if item != alias]
+        inherited_reason = reasons.pop(alias, None)
+        if inherited_reason and fingerprint not in reasons:
+            reasons[fingerprint] = inherited_reason
     if fingerprint not in suppressions:
         suppressions.append(fingerprint)
-    reasons = dict(config.suppression_reasons)
     reasons[fingerprint] = cleaned_reason
     path = write_config(
         target,
@@ -96,6 +113,7 @@ def unsuppress(*, target: Path, fingerprint: str, json_output: bool = False) -> 
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
     fingerprint = fingerprint.strip()
+    finding: dict[str, Any] | None = None
     if not FINGERPRINT_RE.match(fingerprint):
         finding, message = _resolve_finding_record(target, fingerprint)
         if finding is None or not FINGERPRINT_RE.match(str(finding.get("fingerprint") or "")):
@@ -107,12 +125,43 @@ def unsuppress(*, target: Path, fingerprint: str, json_output: bool = False) -> 
     except ValueError as exc:
         print(f"error: invalid security config: {exc}", file=sys.stderr)
         return 2
-    if fingerprint not in config.suppressions and fingerprint not in config.suppression_reasons:
+    migration_map = _read_fingerprint_migration_map(target)
+    fingerprint = migration_map.get(fingerprint, fingerprint)
+    configured_aliases: tuple[str, ...]
+    if finding is not None:
+        configured_aliases = _configured_suppression_aliases(
+            finding,
+            suppressions=set(config.suppressions),
+            reasons=config.suppression_reasons,
+            migration_map=migration_map,
+        )
+    else:
+        configured = _expand_suppression_fingerprints(
+            set(config.suppressions) | set(config.suppression_reasons),
+            migration_map,
+        )
+        if fingerprint not in configured:
+            configured_aliases = ()
+        else:
+            related = {fingerprint}
+            mapped_primary = migration_map.get(fingerprint)
+            if mapped_primary:
+                related.add(mapped_primary)
+            for legacy, primary in migration_map.items():
+                if primary == fingerprint:
+                    related.add(legacy)
+            configured_aliases = tuple(
+                sorted(
+                    alias for alias in related if alias in config.suppressions or alias in config.suppression_reasons
+                )
+            )
+    if not configured_aliases:
         print(f"error: suppression not found: {fingerprint}", file=sys.stderr)
         return 1
-    suppressions = tuple(item for item in config.suppressions if item != fingerprint)
+    suppressions = tuple(item for item in config.suppressions if item not in configured_aliases)
     reasons = dict(config.suppression_reasons)
-    reasons.pop(fingerprint, None)
+    for alias in configured_aliases:
+        reasons.pop(alias, None)
     path = write_config(
         target,
         SecurityConfig(
@@ -226,6 +275,15 @@ def _suppression_health_from_active(config: SecurityConfig, active: set[str]) ->
     }
 
 
+def _active_fingerprint_aliases(report: dict[str, Any]) -> set[str]:
+    active: set[str] = set()
+    for finding in list(report.get("findings") or []) + list(report.get("suppressed_findings") or []):
+        if not isinstance(finding, dict):
+            continue
+        active.update(_safe_fingerprint_aliases(finding))
+    return active
+
+
 def _write_suppression_health_cache(target: Path, effective: EffectivePolicy, health: dict[str, Any]) -> None:
     config = load_config(target)
     if config is None or not effective.config_loaded or not effective.suppressions:
@@ -244,11 +302,7 @@ def _write_suppression_health_cache_from_report(
     config = load_config(target)
     if config is None or not config.suppressions:
         return
-    active = {
-        str(item.get("fingerprint"))
-        for item in list(report.get("findings") or []) + list(report.get("suppressed_findings") or [])
-        if item.get("fingerprint")
-    }
+    active = _active_fingerprint_aliases(report)
     _write_suppression_health_cache(target, effective, _suppression_health_from_active(config, active))
 
 
@@ -336,7 +390,7 @@ def suppression_health(target: Path) -> dict[str, Any]:
         exclude_paths=effective.exclude_paths,
         severity_threshold=effective.severity_threshold,
     )
-    active = {str(item.get("fingerprint")) for item in report["findings"] if item.get("fingerprint")}
+    active = _active_fingerprint_aliases(report)
     health = _suppression_health_from_active(config, active)
     _write_suppression_health_cache(target, effective, health)
     return health

--- a/src/brigade/security_cmd/template_audit_ops.py
+++ b/src/brigade/security_cmd/template_audit_ops.py
@@ -205,6 +205,7 @@ def harness_wiring_payload(target: Path) -> dict[str, Any]:
             text=text,
             classification=_classification_for(path, target),
         )
+    _assign_fingerprints(findings)
     findings = _filter_findings(
         findings,
         enabled_checks=SECURITY_CHECKS,

--- a/tests/test_security_cmd.py
+++ b/tests/test_security_cmd.py
@@ -652,6 +652,66 @@ def test_security_scan_does_not_open_excluded_paths(tmp_path, monkeypatch):
     assert "excluded/secret.txt" not in opened
 
 
+def test_security_scan_cli_excludes_brigade_glob_from_self_scan(tmp_path, capsys):
+    (tmp_path / "hooks" / "install.sh").parent.mkdir(parents=True)
+    (tmp_path / "hooks" / "install.sh").write_text("curl https://example.invalid/install.sh | sh\n")
+    evidence_dir = tmp_path / ".brigade" / "center" / "reports" / "operator-one"
+    evidence_dir.mkdir(parents=True)
+    (evidence_dir / "CENTER_EVIDENCE.json").write_text(
+        json.dumps(
+            {
+                "findings": [
+                    {
+                        "path": "README.md",
+                        "line": 42,
+                        "safe_excerpt": "npx -y @example/unpinned-package",
+                        "category": "supply-chain",
+                        "title": "Unpinned remote package execution",
+                    }
+                ]
+            }
+        )
+        + "\n"
+    )
+    config = tmp_path / ".brigade" / "security.toml"
+    config.write_text(
+        "\n".join(
+            [
+                'policy = "personal"',
+                'scan_profile = "local-only-audit"',
+                'fail_on = "none"',
+                "include_templates = false",
+                'enabled_checks = ["automation", "supply-chain"]',
+                "include_paths = []",
+                'exclude_paths = [".brigade/**"]',
+                'severity_threshold = "low"',
+                'output_path = ".brigade/security/latest"',
+                "",
+                "[suppressions]",
+                "fingerprints = []",
+                "",
+                "[suppression_reasons]",
+                "",
+            ]
+        )
+    )
+
+    assert cli.main(["security", "config", "--target", str(tmp_path), "--json"]) == 0
+    config_payload = json.loads(capsys.readouterr().out)
+    assert config_payload["config"]["exclude_paths"] == [".brigade/**"]
+
+    assert cli.main(["security", "scan", "--target", str(tmp_path), "--json", "--fail-on", "none"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    finding_paths = {finding["path"] for finding in payload["findings"]}
+    scanned_paths = set(payload["scanned_files"])
+    assert finding_paths == {"hooks/install.sh"}
+    assert not any(path.startswith(".brigade/") for path in finding_paths)
+    assert not any(path.startswith(".brigade/") for path in scanned_paths)
+    assert ".brigade/security.toml" not in scanned_paths
+    assert ".brigade/center/reports/operator-one/CENTER_EVIDENCE.json" not in scanned_paths
+    assert not security_cmd._path_matches_any("nested/.brigade/evidence.json", (".brigade/**",))
+
+
 def test_security_scan_include_paths_do_not_open_unrelated_files(tmp_path, monkeypatch):
     included = tmp_path / "included"
     included.mkdir()

--- a/tests/test_security_cmd.py
+++ b/tests/test_security_cmd.py
@@ -821,6 +821,1205 @@ def test_security_scan_classifies_each_file_once(tmp_path, monkeypatch):
     assert confidence_calls == ["script.sh"]
 
 
+def test_security_suppression_fingerprint_survives_line_shift(tmp_path, capsys):
+    readme = tmp_path / "README.md"
+    needle = "npx -y @example/unpinned-package\n"
+    readme.write_text("# Title\n\n" + needle)
+    first = security_cmd.scan_target(tmp_path)
+    finding = next(item for item in first["findings"] if item["category"] == "supply-chain")
+    fingerprint = finding["fingerprint"]
+
+    assert security_cmd.suppress(target=tmp_path, fingerprint=fingerprint, reason="reviewed docs example") == 0
+    capsys.readouterr()
+
+    readme.write_text("# Title\n\n| col | val |\n| --- | --- |\n| a | b |\n\n" + needle)
+    second = security_cmd.scan_target(tmp_path, suppressions=security_cmd.load_config(tmp_path).suppressions)
+
+    assert second["finding_count"] == 0
+    assert second["suppressed_count"] == 1
+    suppressed = second["suppressed_findings"][0]
+    assert suppressed["fingerprint"] == fingerprint
+    assert suppressed["line"] != finding["line"]
+
+
+def test_security_fingerprint_distinguishes_identical_duplicates(tmp_path):
+    line = "npx -y @example/unpinned-package\n"
+    (tmp_path / "dup.txt").write_text(line + "middle section\n" + line)
+
+    report = security_cmd.scan_target(tmp_path)
+    findings = [item for item in report["findings"] if item["category"] == "supply-chain"]
+
+    assert len(findings) == 2
+    assert findings[0]["fingerprint"] != findings[1]["fingerprint"]
+    assert findings[0]["occurrence"] == 0
+    assert findings[1]["occurrence"] == 1
+    assert findings[0]["safe_excerpt"] == findings[1]["safe_excerpt"]
+
+    suppressed = security_cmd.scan_target(tmp_path, suppressions=(findings[0]["fingerprint"],))
+    assert suppressed["finding_count"] == 1
+    assert suppressed["suppressed_count"] == 1
+    assert suppressed["findings"][0]["fingerprint"] == findings[1]["fingerprint"]
+    assert suppressed["suppressed_findings"][0]["fingerprint"] == findings[0]["fingerprint"]
+    assert findings[0]["duplicate_count"] == 2
+    assert findings[1]["duplicate_count"] == 2
+
+
+def test_security_suppression_does_not_transfer_when_duplicate_removed(tmp_path, capsys):
+    line = "npx -y @example/unpinned-package\n"
+    dup_path = tmp_path / "dup.txt"
+    dup_path.write_text(line + "middle section\n" + line)
+
+    first = security_cmd.scan_target(tmp_path)
+    findings = [item for item in first["findings"] if item["category"] == "supply-chain"]
+    assert len(findings) == 2
+
+    assert security_cmd.suppress(target=tmp_path, fingerprint=findings[0]["fingerprint"], reason="reviewed first") == 0
+    capsys.readouterr()
+
+    dup_path.write_text("middle section\n" + line)
+    after = security_cmd.scan_target(tmp_path, suppressions=security_cmd.load_config(tmp_path).suppressions)
+    assert after["finding_count"] == 1
+    assert after["suppressed_count"] == 0
+
+
+def test_security_suppression_does_not_transfer_when_duplicate_inserted(tmp_path, capsys):
+    line = "npx -y @example/unpinned-package\n"
+    dup_path = tmp_path / "dup.txt"
+    dup_path.write_text(line)
+
+    first = security_cmd.scan_target(tmp_path)
+    finding = next(item for item in first["findings"] if item["category"] == "supply-chain")
+    assert finding["duplicate_count"] == 1
+
+    assert security_cmd.suppress(target=tmp_path, fingerprint=finding["fingerprint"], reason="reviewed single") == 0
+    capsys.readouterr()
+
+    dup_path.write_text(line + "middle section\n" + line)
+    after = security_cmd.scan_target(tmp_path, suppressions=security_cmd.load_config(tmp_path).suppressions)
+    open_findings = [item for item in after["findings"] if item["category"] == "supply-chain"]
+    assert after["finding_count"] == 2
+    assert after["suppressed_count"] == 0
+    assert len(open_findings) == 2
+    assert {item["duplicate_count"] for item in open_findings} == {2}
+
+
+def test_security_scan_import_rekeys_when_duplicate_group_changes(tmp_path, capsys):
+    line = "npx -y @example/unpinned-package\n"
+    dup_path = tmp_path / "dup.txt"
+    dup_path.write_text(line)
+
+    assert security_cmd.scan(target=tmp_path, fail_on="none", import_findings=True) == 0
+    capsys.readouterr()
+    imports_path = tmp_path / ".brigade" / "work" / "imports" / "inbox.jsonl"
+    first_import = json.loads(imports_path.read_text().splitlines()[0])
+    assert first_import["metadata"]["duplicate_count"] == 1
+
+    dup_path.write_text(line + "middle section\n" + line)
+    assert security_cmd.scan(target=tmp_path, fail_on="none", import_findings=True) == 0
+    out = capsys.readouterr().out
+    assert "imported_findings: 2" in out
+    imports = [json.loads(raw) for raw in imports_path.read_text().splitlines()]
+    assert len(imports) == 3
+    assert [item["metadata"]["duplicate_count"] for item in imports] == [1, 2, 2]
+
+
+def test_security_health_migrates_closeout_using_discovered_path_not_payload_path(tmp_path, capsys):
+    assert security_cmd.init(target=tmp_path) == 0
+    capsys.readouterr()
+    readme = tmp_path / "README.md"
+    needle = "npx -y @example/unpinned-package\n"
+    readme.write_text("# Title\n\n" + needle)
+
+    assert security_cmd.scan(target=tmp_path, fail_on="none", json_output=True) == 0
+    scan = json.loads(capsys.readouterr().out)
+    finding = next(item for item in scan["findings"] if item["category"] == "supply-chain")
+    legacy = finding["legacy_fingerprint"]
+    primary = finding["fingerprint"]
+
+    outside_path = tmp_path.parent / "crafted-outside-closeout.json"
+    closeout_dir = tmp_path / ".brigade" / "security" / "closeouts" / "trusted-closeout"
+    closeout_dir.mkdir(parents=True)
+    closeout_path = closeout_dir / "closeout.json"
+    closeout_path.write_text(
+        json.dumps(
+            {
+                "status": "accepted-risk",
+                "created_at": "2026-07-01T00:00:00Z",
+                "source_fingerprints": [legacy],
+                "policy_pack": {"accepted_risk": True},
+                "path": str(outside_path),
+            }
+        )
+        + "\n"
+    )
+
+    health = security_cmd.health(tmp_path)
+    assert health["quieted_finding_count"] == 1
+    assert not outside_path.exists()
+
+    migrated = json.loads(closeout_path.read_text())
+    assert migrated["path"] == str(closeout_path)
+    assert primary in migrated["source_fingerprints"]
+    assert migrated["fingerprint_migrations"] == {legacy: primary}
+
+
+def test_security_read_closeouts_rejects_symlinked_entries(tmp_path, monkeypatch):
+    from pathlib import Path
+
+    from brigade.security_cmd import models as security_models
+
+    assert security_cmd.init(target=tmp_path) == 0
+    outside = tmp_path.parent / "outside-closeout.json"
+    closeout_root = tmp_path / ".brigade" / "security" / "closeouts"
+    trusted_dir = closeout_root / "trusted-closeout"
+    trusted_dir.mkdir(parents=True)
+    trusted_path = trusted_dir / "closeout.json"
+    trusted_path.write_text(
+        json.dumps(
+            {
+                "status": "accepted-risk",
+                "created_at": "2026-07-01T00:00:00Z",
+                "source_fingerprints": ["abc123"],
+                "policy_pack": {"accepted_risk": True},
+            }
+        )
+        + "\n"
+    )
+
+    for symlinked_path in (closeout_root, trusted_dir, trusted_path):
+        monkeypatch.setattr(
+            security_models,
+            "_closeout_path_is_symlink",
+            lambda path, symlinked_path=symlinked_path: path == symlinked_path,
+        )
+        assert security_models._read_closeouts(tmp_path) == []
+
+    monkeypatch.setattr(security_models, "_closeout_path_is_symlink", Path.is_symlink)
+    outside_payload = {
+        "status": "accepted-risk",
+        "created_at": "2026-07-02T00:00:00Z",
+        "source_fingerprints": ["def456"],
+        "policy_pack": {"accepted_risk": True},
+        "path": str(outside),
+    }
+    outside.write_text(json.dumps(outside_payload) + "\n")
+    trusted_path.write_text(
+        json.dumps({**outside_payload, "source_fingerprints": ["abc123"], "path": str(outside)}) + "\n"
+    )
+
+    closeouts = security_models._read_closeouts(tmp_path)
+    assert len(closeouts) == 1
+    assert closeouts[0]["source_fingerprints"] == ["abc123"]
+    assert closeouts[0]["path"] == str(trusted_path.resolve())
+    assert closeouts[0]["path"] != str(outside)
+
+
+def test_security_scan_does_not_migrate_through_unsafe_state_path(tmp_path, capsys, monkeypatch):
+    from brigade.security_cmd import models as security_models
+
+    line = "npx -y @example/unpinned-package\n"
+    (tmp_path / "README.md").write_text(line)
+    finding = next(
+        item for item in security_cmd.scan_target(tmp_path)["findings"] if item["category"] == "supply-chain"
+    )
+    legacy = finding["legacy_fingerprint"]
+    config = tmp_path / ".brigade" / "security.toml"
+    config.parent.mkdir(parents=True)
+    config.write_text(
+        "\n".join(
+            [
+                'policy = "personal"',
+                'fail_on = "none"',
+                "include_templates = false",
+                "",
+                "[suppressions]",
+                f'fingerprints = ["{legacy}"]',
+                "",
+            ]
+        )
+    )
+    monkeypatch.setattr(security_models, "_workspace_state_path_is_safe", lambda _target, _path: False)
+
+    assert security_cmd.scan(target=tmp_path, fail_on="none", json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["suppressed_count"] == 1
+    assert payload.get("suppression_migrations") is None
+    loaded = security_cmd.load_config(tmp_path)
+    assert loaded is not None
+    assert loaded.suppressions == (legacy,)
+    assert not security_models.fingerprint_migration_map_path(tmp_path).exists()
+
+
+def test_security_singleton_suppression_stays_open_when_duplicate_added_before_upgrade(tmp_path, capsys):
+    line = "npx -y @example/unpinned-package\n"
+    dup_path = tmp_path / "dup.txt"
+    dup_path.write_text(line)
+
+    first = security_cmd.scan_target(tmp_path)
+    finding = next(item for item in first["findings"] if item["category"] == "supply-chain")
+    legacy = finding["legacy_fingerprint"]
+    assert finding["duplicate_count"] == 1
+
+    config = tmp_path / ".brigade" / "security.toml"
+    config.parent.mkdir(parents=True, exist_ok=True)
+    config.write_text(
+        "\n".join(
+            [
+                'policy = "personal"',
+                'fail_on = "none"',
+                "include_templates = false",
+                'enabled_checks = ["supply-chain"]',
+                "include_paths = []",
+                "exclude_paths = []",
+                'severity_threshold = "low"',
+                'output_path = ".brigade/security/latest"',
+                "",
+                "[suppressions]",
+                f'fingerprints = ["{legacy}"]',
+                "",
+                "[suppression_reasons]",
+                f'{legacy} = "singleton legacy suppression"',
+                "",
+            ]
+        )
+    )
+
+    dup_path.write_text(line + "middle section\n" + line)
+    assert security_cmd.scan(target=tmp_path, fail_on="none", json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    open_findings = [item for item in payload["findings"] if item["category"] == "supply-chain"]
+    assert payload["suppressed_count"] == 0
+    assert len(open_findings) == 2
+    assert payload.get("suppression_migrations") is None
+    loaded = security_cmd.load_config(tmp_path)
+    assert loaded is not None
+    assert legacy in loaded.suppressions
+    assert legacy in loaded.suppression_reasons
+
+
+def test_security_diff_treats_duplicate_cardinality_change_as_re_review(tmp_path, capsys):
+    line = "npx -y @example/unpinned-package\n"
+    dup_path = tmp_path / "dup.txt"
+    dup_path.write_text(line)
+    singleton = security_cmd.scan_target(tmp_path)
+    finding = next(item for item in singleton["findings"] if item["category"] == "supply-chain")
+    legacy = finding["legacy_fingerprint"]
+
+    dup_path.write_text(line + "middle section\n" + line)
+    duplicate_group = security_cmd.scan_target(tmp_path)
+    duplicate_findings = [item for item in duplicate_group["findings"] if item["category"] == "supply-chain"]
+    assert len(duplicate_findings) == 2
+
+    base_dir = tmp_path / ".brigade" / "security" / "base"
+    against_dir = tmp_path / ".brigade" / "security" / "against"
+    base_dir.mkdir(parents=True)
+    against_dir.mkdir(parents=True)
+    (base_dir / "security-report.json").write_text(json.dumps(singleton, indent=2, sort_keys=True) + "\n")
+    (against_dir / "security-report.json").write_text(json.dumps(duplicate_group, indent=2, sort_keys=True) + "\n")
+
+    assert security_cmd.diff(target=tmp_path, base_dir=base_dir, against_dir=against_dir, json_output=True) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["persisting_count"] == 0
+    assert payload["new_count"] == 2
+    assert payload["resolved_count"] == 1
+    assert legacy not in {item.get("fingerprint") for item in payload["persisting"]}
+
+
+def test_security_scan_import_reimports_when_legacy_singleton_becomes_duplicate_group(tmp_path, capsys):
+    line = "npx -y @example/unpinned-package\n"
+    dup_path = tmp_path / "dup.txt"
+    dup_path.write_text(line)
+
+    assert security_cmd.scan(target=tmp_path, fail_on="none", import_findings=True) == 0
+    capsys.readouterr()
+    imports_path = tmp_path / ".brigade" / "work" / "imports" / "inbox.jsonl"
+    first_import = json.loads(imports_path.read_text().splitlines()[0])
+    legacy = first_import["metadata"]["legacy_fingerprint"]
+    first_import["text"] = first_import["text"].rsplit(" [", 1)[0]
+    first_import["metadata"].pop("occurrence")
+    first_import["metadata"].pop("duplicate_count")
+    first_import["metadata"].pop("legacy_fingerprint")
+    first_import["metadata"]["fingerprint"] = legacy
+    first_import["metadata"]["finding_id"] = f"security-{legacy}"
+    first_import["metadata"]["source_item_key"] = f"security-scan:{legacy}"
+    imports_path.write_text(json.dumps(first_import) + "\n")
+
+    dup_path.write_text(line + "middle section\n" + line)
+    assert security_cmd.scan(target=tmp_path, fail_on="none", import_findings=True) == 0
+    out = capsys.readouterr().out
+    assert "imported_findings: 2" in out
+    assert len(imports_path.read_text().splitlines()) == 3
+
+
+def test_security_review_old_report_after_migration_and_line_shift(tmp_path, capsys):
+    readme = tmp_path / "README.md"
+    needle = "npx -y @example/unpinned-package\n"
+    readme.write_text("# Title\n\n" + needle)
+    output_dir = tmp_path / ".brigade" / "security" / "latest"
+    assert security_cmd.scan(target=tmp_path, fail_on="none", output_dir=output_dir) == 0
+    capsys.readouterr()
+    current = json.loads((output_dir / "security-report.json").read_text())
+    finding = next(item for item in current["findings"] if item["category"] == "supply-chain")
+    legacy = finding["legacy_fingerprint"]
+    primary = finding["fingerprint"]
+
+    config = tmp_path / ".brigade" / "security.toml"
+    config.write_text(
+        "\n".join(
+            [
+                'policy = "personal"',
+                'fail_on = "none"',
+                "include_templates = false",
+                "",
+                "[suppressions]",
+                f'fingerprints = ["{legacy}"]',
+                "",
+                "[suppression_reasons]",
+                f'{legacy} = "legacy bundle reason"',
+                "",
+            ]
+        )
+    )
+
+    assert security_cmd.scan(target=tmp_path, fail_on="none", output_dir=output_dir) == 0
+    capsys.readouterr()
+    migration_map_path = tmp_path / ".brigade" / "security" / "fingerprint-migration-map.json"
+    migration_map = json.loads(migration_map_path.read_text())
+    assert migration_map["migrations"][legacy] == primary
+    loaded = security_cmd.load_config(tmp_path)
+    assert loaded is not None
+    assert loaded.suppressions == (primary,)
+    assert legacy not in loaded.suppressions
+
+    old_bundle_dir = tmp_path / ".brigade" / "security" / "old-bundle"
+    old_bundle_dir.mkdir(parents=True)
+    old_finding = dict(finding)
+    old_finding["fingerprint"] = legacy
+    old_finding.pop("legacy_fingerprint", None)
+    old_report = dict(current)
+    old_report["findings"] = [old_finding]
+    old_report["finding_count"] = 1
+    (old_bundle_dir / "security-report.json").write_text(json.dumps(old_report, indent=2, sort_keys=True) + "\n")
+    (old_bundle_dir / "security-report.md").write_text("# old bundle\n")
+
+    assert security_cmd.review(target=tmp_path, output_dir=old_bundle_dir, json_output=True) == 0
+    review_payload = json.loads(capsys.readouterr().out)
+    assert review_payload["suppressed_count"] == 1
+    assert review_payload["findings"][0]["status"] == "suppressed"
+    assert review_payload["findings"][0]["reason"] == "legacy bundle reason"
+
+    readme.write_text("# Title\n\n| col | val |\n| --- | --- |\n| a | b |\n\n" + needle)
+    assert security_cmd.scan(target=tmp_path, fail_on="none", output_dir=output_dir) == 0
+    capsys.readouterr()
+    assert security_cmd.review(target=tmp_path, output_dir=old_bundle_dir, json_output=True) == 0
+    shifted_review = json.loads(capsys.readouterr().out)
+    assert shifted_review["suppressed_count"] == 1
+
+    assert security_cmd.unsuppress(target=tmp_path, fingerprint=legacy, json_output=True) == 0
+    capsys.readouterr()
+    reloaded = security_cmd.load_config(tmp_path)
+    assert reloaded is not None
+    assert reloaded.suppressions == ()
+    assert primary not in reloaded.suppression_reasons
+
+    assert (
+        security_cmd.suppress(
+            target=tmp_path,
+            fingerprint=legacy,
+            reason="re-suppressed through legacy alias",
+            json_output=True,
+        )
+        == 0
+    )
+    suppress_payload = json.loads(capsys.readouterr().out)
+    assert suppress_payload["fingerprint"] == primary
+    reloaded = security_cmd.load_config(tmp_path)
+    assert reloaded is not None
+    assert reloaded.suppressions == (primary,)
+    assert reloaded.suppression_reasons == {primary: "re-suppressed through legacy alias"}
+
+
+def test_security_line_based_suppression_matches_legacy_alias(tmp_path, capsys):
+    import hashlib
+
+    from brigade.security_cmd import scan_engine as scan_engine
+
+    readme = tmp_path / "README.md"
+    needle = "npx -y @example/unpinned-package\n"
+    readme.write_text("# Title\n\n" + needle)
+    current = security_cmd.scan_target(tmp_path)
+    finding = next(item for item in current["findings"] if item["category"] == "supply-chain")
+
+    legacy = hashlib.sha256(
+        "\n".join(
+            [
+                finding["category"],
+                finding["title"],
+                finding["path"],
+                str(finding["line"]),
+                scan_engine._short(needle.strip(), limit=96),
+            ]
+        ).encode()
+    ).hexdigest()[:16]
+    assert legacy == finding["legacy_fingerprint"]
+    assert legacy != finding["fingerprint"]
+
+    config = tmp_path / ".brigade" / "security.toml"
+    config.parent.mkdir(parents=True)
+    config.write_text(
+        "\n".join(
+            [
+                'policy = "personal"',
+                'scan_profile = "local-only-audit"',
+                'fail_on = "none"',
+                "include_templates = false",
+                'enabled_checks = ["supply-chain"]',
+                "include_paths = []",
+                "exclude_paths = []",
+                'severity_threshold = "low"',
+                'output_path = ".brigade/security/latest"',
+                "",
+                "[suppressions]",
+                f'fingerprints = ["{legacy}"]',
+                "",
+                "[suppression_reasons]",
+                f'{legacy} = "legacy line-based suppression"',
+                "",
+            ]
+        )
+    )
+
+    with_legacy = security_cmd.scan(target=tmp_path, fail_on="none", json_output=True)
+    assert with_legacy == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["finding_count"] == 0
+    assert payload["suppressed_count"] == 1
+    assert payload["suppressed_findings"][0]["fingerprint"] == finding["fingerprint"]
+
+
+def test_security_scan_migrates_legacy_suppression_to_primary(tmp_path, capsys):
+    readme = tmp_path / "README.md"
+    needle = "npx -y @example/unpinned-package\n"
+    readme.write_text("# Title\n\n" + needle)
+    current = security_cmd.scan_target(tmp_path)
+    finding = next(item for item in current["findings"] if item["category"] == "supply-chain")
+    legacy = finding["legacy_fingerprint"]
+    primary = finding["fingerprint"]
+
+    config = tmp_path / ".brigade" / "security.toml"
+    config.parent.mkdir(parents=True)
+    config.write_text(
+        "\n".join(
+            [
+                'policy = "personal"',
+                'scan_profile = "local-only-audit"',
+                'fail_on = "none"',
+                "include_templates = false",
+                'enabled_checks = ["supply-chain"]',
+                "include_paths = []",
+                "exclude_paths = []",
+                'severity_threshold = "low"',
+                'output_path = ".brigade/security/latest"',
+                "",
+                "[suppressions]",
+                f'fingerprints = ["{legacy}", "{legacy}"]',
+                "",
+                "[suppression_reasons]",
+                f'{legacy} = "legacy line-based suppression"',
+                "",
+            ]
+        )
+    )
+
+    assert security_cmd.scan(target=tmp_path, fail_on="none", json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["suppression_migrations"] == [{"from": legacy, "to": primary}]
+    loaded = security_cmd.load_config(tmp_path)
+    assert loaded is not None
+    assert loaded.suppressions == (primary,)
+    assert loaded.suppression_reasons[primary] == "legacy line-based suppression"
+    assert legacy not in loaded.suppressions
+    assert legacy not in loaded.suppression_reasons
+
+    readme.write_text("# Title\n\n| col | val |\n| --- | --- |\n| a | b |\n\n" + needle)
+    assert security_cmd.scan(target=tmp_path, fail_on="none", json_output=True) == 0
+    shifted = json.loads(capsys.readouterr().out)
+    assert shifted["finding_count"] == 0
+    assert shifted["suppressed_count"] == 1
+    assert shifted.get("suppression_migrations") is None
+
+
+def test_security_scan_suppression_uses_migration_map_when_config_stays_legacy(tmp_path, capsys):
+    readme = tmp_path / "README.md"
+    needle = "npx -y @example/unpinned-package\n"
+    readme.write_text("# Title\n\n" + needle)
+    current = security_cmd.scan_target(tmp_path)
+    finding = next(item for item in current["findings"] if item["category"] == "supply-chain")
+    legacy = finding["legacy_fingerprint"]
+    primary = finding["fingerprint"]
+
+    config = tmp_path / ".brigade" / "security.toml"
+    config.parent.mkdir(parents=True, exist_ok=True)
+    config.write_text(
+        "\n".join(
+            [
+                'policy = "personal"',
+                'scan_profile = "local-only-audit"',
+                'fail_on = "none"',
+                "include_templates = false",
+                'enabled_checks = ["supply-chain"]',
+                "include_paths = []",
+                "exclude_paths = []",
+                'severity_threshold = "low"',
+                'output_path = ".brigade/security/latest"',
+                "",
+                "[suppressions]",
+                f'fingerprints = ["{legacy}"]',
+                "",
+                "[suppression_reasons]",
+                f'{legacy} = "legacy line-based suppression"',
+                "",
+            ]
+        )
+    )
+
+    assert security_cmd.scan(target=tmp_path, fail_on="none", json_output=True) == 0
+    capsys.readouterr()
+    migration_map_path = tmp_path / ".brigade" / "security" / "fingerprint-migration-map.json"
+    assert json.loads(migration_map_path.read_text())["migrations"][legacy] == primary
+
+    config.write_text(
+        "\n".join(
+            [
+                'policy = "personal"',
+                'scan_profile = "local-only-audit"',
+                'fail_on = "none"',
+                "include_templates = false",
+                'enabled_checks = ["supply-chain"]',
+                "include_paths = []",
+                "exclude_paths = []",
+                'severity_threshold = "low"',
+                'output_path = ".brigade/security/latest"',
+                "",
+                "[suppressions]",
+                f'fingerprints = ["{legacy}"]',
+                "",
+                "[suppression_reasons]",
+                f'{legacy} = "legacy line-based suppression"',
+                "",
+            ]
+        )
+    )
+
+    readme.write_text("# Title\n\n| col | val |\n| --- | --- |\n| a | b |\n\n" + needle)
+    assert security_cmd.scan(target=tmp_path, fail_on="none", json_output=True) == 0
+    shifted = json.loads(capsys.readouterr().out)
+    assert shifted["finding_count"] == 0
+    assert shifted["suppressed_count"] == 1
+    assert shifted.get("suppression_migrations") is None
+    loaded = security_cmd.load_config(tmp_path)
+    assert loaded is not None
+    assert legacy in loaded.suppressions
+    assert primary not in loaded.suppressions
+
+
+def test_security_scan_import_reimports_on_severity_escalation(tmp_path, capsys):
+    from brigade.security_cmd import scan_engine as scan_engine_mod
+
+    readme = tmp_path / "README.md"
+    needle = "npx -y @example/unpinned-package\n"
+    readme.write_text(needle)
+    finding = next(
+        item for item in security_cmd.scan_target(tmp_path)["findings"] if item["category"] == "supply-chain"
+    )
+    assert finding["severity"] == "medium"
+
+    imported, skipped = scan_engine_mod._import_findings(tmp_path, [finding])
+    assert len(imported) == 1
+    assert skipped == []
+    assert imported[0]["kind"] == "finding"
+
+    escalated = dict(finding)
+    escalated["severity"] = "high"
+    reimported, reskipped = scan_engine_mod._import_findings(tmp_path, [escalated])
+    assert len(reimported) == 1
+    assert reskipped == []
+    assert reimported[0]["metadata"]["severity"] == "high"
+    assert reimported[0]["kind"] == "incident"
+    assert reimported[0]["metadata"]["source_item_key"] == imported[0]["metadata"]["source_item_key"]
+
+    unchanged, unchanged_skipped = scan_engine_mod._import_findings(tmp_path, [escalated])
+    assert unchanged == []
+    assert len(unchanged_skipped) == 1
+
+
+def test_security_scan_import_reimports_dismissed_on_severity_escalation(tmp_path, capsys):
+    from brigade.security_cmd import scan_engine as scan_engine_mod
+
+    readme = tmp_path / "README.md"
+    needle = "npx -y @example/unpinned-package\n"
+    readme.write_text(needle)
+    finding = next(
+        item for item in security_cmd.scan_target(tmp_path)["findings"] if item["category"] == "supply-chain"
+    )
+
+    imported, _ = scan_engine_mod._import_findings(tmp_path, [finding])
+    assert work_cmd.import_dismiss(target=tmp_path, import_id=imported[0]["id"], reason="accepted risk") == 0
+    capsys.readouterr()
+
+    same_severity, skipped = scan_engine_mod._import_findings(tmp_path, [finding])
+    assert same_severity == []
+    assert len(skipped) == 1
+
+    escalated = dict(finding)
+    escalated["severity"] = "high"
+    reimported, reskipped = scan_engine_mod._import_findings(tmp_path, [escalated])
+    assert len(reimported) == 1
+    assert reskipped == []
+    assert reimported[0]["status"] == "pending"
+    assert reimported[0]["metadata"]["severity"] == "high"
+    imports_path = tmp_path / ".brigade" / "work" / "imports" / "inbox.jsonl"
+    imports = [json.loads(line) for line in imports_path.read_text().splitlines()]
+    assert len(imports) == 2
+    assert imports[0]["status"] == "dismissed"
+
+
+def test_security_show_and_unsuppress_resolve_legacy_alias(tmp_path, capsys):
+    readme = tmp_path / "README.md"
+    needle = "npx -y @example/unpinned-package\n"
+    readme.write_text("# Title\n\n" + needle)
+    output_dir = tmp_path / ".brigade" / "security" / "latest"
+    assert security_cmd.scan(target=tmp_path, fail_on="none", output_dir=output_dir) == 0
+    capsys.readouterr()
+    finding = next(
+        item
+        for item in json.loads((output_dir / "security-report.json").read_text())["findings"]
+        if item["category"] == "supply-chain"
+    )
+    legacy = finding["legacy_fingerprint"]
+    primary = finding["fingerprint"]
+
+    config = tmp_path / ".brigade" / "security.toml"
+    config.write_text(
+        "\n".join(
+            [
+                'policy = "personal"',
+                'fail_on = "none"',
+                "include_templates = false",
+                "",
+                "[suppressions]",
+                f'fingerprints = ["{legacy}"]',
+                "",
+                "[suppression_reasons]",
+                f'{primary} = "legacy alias reason"',
+                "",
+            ]
+        )
+    )
+
+    assert security_cmd.show(target=tmp_path, finding_id=f"security-{legacy}", json_output=True) == 0
+    show_payload = json.loads(capsys.readouterr().out)
+    assert show_payload["finding"]["fingerprint"] == primary
+    assert show_payload["finding"]["reason"] == "legacy alias reason"
+
+    assert security_cmd.unsuppress(target=tmp_path, fingerprint=finding["id"]) == 0
+    out = capsys.readouterr().out
+    assert f"unsuppressed: {primary}" in out
+    loaded = security_cmd.load_config(tmp_path)
+    assert loaded is not None
+    assert loaded.suppressions == ()
+    assert primary not in loaded.suppression_reasons
+    assert legacy not in loaded.suppression_reasons
+
+
+def test_security_show_resolves_migrated_legacy_after_line_shift(tmp_path, capsys):
+    readme = tmp_path / "README.md"
+    needle = "npx -y @example/unpinned-package\n"
+    readme.write_text("# Title\n\n" + needle)
+    output_dir = tmp_path / ".brigade" / "security" / "latest"
+    assert security_cmd.scan(target=tmp_path, fail_on="none", output_dir=output_dir) == 0
+    capsys.readouterr()
+    finding = next(
+        item
+        for item in json.loads((output_dir / "security-report.json").read_text())["findings"]
+        if item["category"] == "supply-chain"
+    )
+    legacy = finding["legacy_fingerprint"]
+    primary = finding["fingerprint"]
+
+    config = tmp_path / ".brigade" / "security.toml"
+    config.write_text(
+        "\n".join(
+            [
+                'policy = "personal"',
+                'fail_on = "none"',
+                "include_templates = false",
+                "",
+                "[suppressions]",
+                f'fingerprints = ["{legacy}"]',
+                "",
+            ]
+        )
+    )
+    assert security_cmd.scan(target=tmp_path, fail_on="none", output_dir=output_dir) == 0
+    capsys.readouterr()
+
+    readme.write_text("# Title\n\n| col | val |\n| --- | --- |\n| a | b |\n\n" + needle)
+    assert security_cmd.scan(target=tmp_path, fail_on="none", output_dir=output_dir) == 0
+    capsys.readouterr()
+
+    assert security_cmd.show(target=tmp_path, finding_id=legacy, json_output=True) == 0
+    show_payload = json.loads(capsys.readouterr().out)
+    assert show_payload["finding"]["fingerprint"] == primary
+
+
+def test_security_diff_expands_migration_map_without_duplicate_legacy_match(tmp_path, capsys):
+    line = "npx -y @example/unpinned-package\n"
+    dup_path = tmp_path / "dup.txt"
+    dup_path.write_text(line)
+    singleton = security_cmd.scan_target(tmp_path)
+    finding = next(item for item in singleton["findings"] if item["category"] == "supply-chain")
+    legacy = finding["legacy_fingerprint"]
+    primary = finding["fingerprint"]
+
+    config = tmp_path / ".brigade" / "security.toml"
+    config.parent.mkdir(parents=True, exist_ok=True)
+    config.write_text(
+        "\n".join(
+            [
+                'policy = "personal"',
+                'fail_on = "none"',
+                "include_templates = false",
+                "",
+                "[suppressions]",
+                f'fingerprints = ["{legacy}"]',
+                "",
+            ]
+        )
+    )
+    security_cmd.scan(target=tmp_path, fail_on="none")
+    capsys.readouterr()
+
+    base_dir = tmp_path / ".brigade" / "security" / "base"
+    against_dir = tmp_path / ".brigade" / "security" / "against"
+    base_dir.mkdir(parents=True)
+    against_dir.mkdir(parents=True)
+    base_finding = {**finding, "fingerprint": legacy}
+    base_finding.pop("legacy_fingerprint", None)
+    base_report = dict(singleton)
+    base_report["findings"] = [base_finding]
+    base_report["finding_count"] = 1
+    (base_dir / "security-report.json").write_text(json.dumps(base_report, indent=2, sort_keys=True) + "\n")
+
+    against_report = dict(singleton)
+    against_report["generated_at"] = "2026-07-02T00:00:00Z"
+    (against_dir / "security-report.json").write_text(json.dumps(against_report, indent=2, sort_keys=True) + "\n")
+
+    assert security_cmd.diff(target=tmp_path, base_dir=base_dir, against_dir=against_dir, json_output=True) == 0
+    migrated = json.loads(capsys.readouterr().out)
+    assert migrated["persisting_count"] == 1
+    assert migrated["new_count"] == 0
+    assert migrated["resolved_count"] == 0
+    assert migrated["persisting"][0]["fingerprint"] == primary
+
+    dup_path.write_text(line)
+    singleton_rescan = security_cmd.scan_target(tmp_path)
+    dup_path.write_text(line + "middle section\n" + line)
+    duplicate_rescan = security_cmd.scan_target(tmp_path)
+    (base_dir / "security-report.json").write_text(json.dumps(singleton_rescan, indent=2, sort_keys=True) + "\n")
+    (against_dir / "security-report.json").write_text(json.dumps(duplicate_rescan, indent=2, sort_keys=True) + "\n")
+
+    assert security_cmd.diff(target=tmp_path, base_dir=base_dir, against_dir=against_dir, json_output=True) == 1
+    cardinality = json.loads(capsys.readouterr().out)
+    assert cardinality["persisting_count"] == 0
+    assert cardinality["new_count"] == 2
+    assert cardinality["resolved_count"] == 1
+
+
+def test_security_health_matches_accepted_risk_via_migration_map(tmp_path, capsys):
+    assert security_cmd.init(target=tmp_path) == 0
+    capsys.readouterr()
+    readme = tmp_path / "README.md"
+    needle = "npx -y @example/unpinned-package\n"
+    readme.write_text("# Title\n\n" + needle)
+
+    assert security_cmd.scan(target=tmp_path, fail_on="none", json_output=True) == 0
+    scan = json.loads(capsys.readouterr().out)
+    finding = next(item for item in scan["findings"] if item["category"] == "supply-chain")
+    legacy = finding["legacy_fingerprint"]
+    primary = finding["fingerprint"]
+
+    config = tmp_path / ".brigade" / "security.toml"
+    config.write_text(
+        "\n".join(
+            [
+                'policy = "personal"',
+                'fail_on = "none"',
+                "include_templates = false",
+                "",
+                "[suppressions]",
+                f'fingerprints = ["{legacy}"]',
+                "",
+            ]
+        )
+    )
+    assert security_cmd.scan(target=tmp_path, fail_on="none") == 0
+    capsys.readouterr()
+
+    closeout_dir = tmp_path / ".brigade" / "security" / "closeouts" / "current-closeout"
+    closeout_dir.mkdir(parents=True)
+    (closeout_dir / "closeout.json").write_text(
+        json.dumps(
+            {
+                "status": "accepted-risk",
+                "created_at": "2026-07-01T00:00:00Z",
+                "source_fingerprints": [primary],
+                "policy_pack": {"accepted_risk": True},
+            }
+        )
+        + "\n"
+    )
+
+    config.write_text(
+        "\n".join(
+            [
+                'policy = "personal"',
+                'fail_on = "none"',
+                "include_templates = false",
+                "",
+                "[suppressions]",
+                "fingerprints = []",
+                "",
+            ]
+        )
+    )
+
+    stale_finding = dict(finding)
+    stale_finding["id"] = f"security-{legacy}"
+    stale_finding["fingerprint"] = legacy
+    stale_finding.pop("legacy_fingerprint", None)
+    stale_report = dict(scan)
+    stale_report["findings"] = [stale_finding]
+    stale_report["suppressed_findings"] = []
+    stale_report["finding_count"] = 1
+    stale_report["suppressed_count"] = 0
+    output_dir = tmp_path / ".brigade" / "security" / "latest"
+    (output_dir / "security-report.json").write_text(json.dumps(stale_report, indent=2, sort_keys=True) + "\n")
+    (output_dir / "security-report.md").write_text("# stale security report\n")
+
+    health = security_cmd.health(tmp_path)
+    assert health["quieted_finding_count"] == 1
+    assert health["top_finding"] is None
+
+
+def test_security_unsuppress_stale_legacy_finding_removes_primary_suppression(tmp_path, capsys):
+    readme = tmp_path / "README.md"
+    needle = "npx -y @example/unpinned-package\n"
+    readme.write_text("# Title\n\n" + needle)
+    output_dir = tmp_path / ".brigade" / "security" / "latest"
+    assert security_cmd.scan(target=tmp_path, fail_on="none", output_dir=output_dir) == 0
+    capsys.readouterr()
+    finding = next(
+        item
+        for item in json.loads((output_dir / "security-report.json").read_text())["findings"]
+        if item["category"] == "supply-chain"
+    )
+    legacy = finding["legacy_fingerprint"]
+    primary = finding["fingerprint"]
+
+    config = tmp_path / ".brigade" / "security.toml"
+    config.write_text(
+        "\n".join(
+            [
+                'policy = "personal"',
+                'fail_on = "none"',
+                "include_templates = false",
+                "",
+                "[suppressions]",
+                f'fingerprints = ["{legacy}"]',
+                "",
+                "[suppression_reasons]",
+                f'{legacy} = "legacy bundle reason"',
+                "",
+            ]
+        )
+    )
+    assert security_cmd.scan(target=tmp_path, fail_on="none", output_dir=output_dir) == 0
+    capsys.readouterr()
+
+    stale_finding = dict(finding)
+    stale_finding["id"] = f"security-{legacy}"
+    stale_finding["fingerprint"] = legacy
+    stale_finding.pop("legacy_fingerprint", None)
+    stale_report = {
+        "findings": [stale_finding],
+        "suppressed_findings": [],
+        "finding_count": 1,
+        "suppressed_count": 0,
+    }
+    (output_dir / "security-report.json").write_text(json.dumps(stale_report, indent=2, sort_keys=True) + "\n")
+    (output_dir / "security-report.md").write_text("# stale security report\n")
+
+    assert security_cmd.unsuppress(target=tmp_path, fingerprint=stale_finding["id"]) == 0
+    capsys.readouterr()
+    loaded = security_cmd.load_config(tmp_path)
+    assert loaded is not None
+    assert loaded.suppressions == ()
+    assert primary not in loaded.suppression_reasons
+    assert legacy not in loaded.suppression_reasons
+
+
+def test_security_diff_treats_legacy_alias_intersection_as_persisting(tmp_path, capsys):
+    readme = tmp_path / "README.md"
+    needle = "npx -y @example/unpinned-package\n"
+    readme.write_text("# Title\n\n" + needle)
+    current = security_cmd.scan_target(tmp_path)
+    finding = next(item for item in current["findings"] if item["category"] == "supply-chain")
+    legacy = finding["legacy_fingerprint"]
+    primary = finding["fingerprint"]
+
+    base_dir = tmp_path / ".brigade" / "security" / "base"
+    against_dir = tmp_path / ".brigade" / "security" / "against"
+    base_dir.mkdir(parents=True)
+    against_dir.mkdir(parents=True)
+    base_report = dict(current)
+    legacy_finding = {**finding, "fingerprint": legacy}
+    legacy_finding.pop("legacy_fingerprint")
+    base_report["findings"] = [legacy_finding]
+    base_report["finding_count"] = 1
+    for bucket in ("suppressed_findings",):
+        base_report.pop(bucket, None)
+    against_report = dict(current)
+    against_report["generated_at"] = "2026-07-02T00:00:00Z"
+    (base_dir / "security-report.json").write_text(json.dumps(base_report, indent=2, sort_keys=True) + "\n")
+    (against_dir / "security-report.json").write_text(json.dumps(against_report, indent=2, sort_keys=True) + "\n")
+
+    assert security_cmd.diff(target=tmp_path, base_dir=base_dir, against_dir=against_dir, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["new_count"] == 0
+    assert payload["resolved_count"] == 0
+    assert payload["persisting_count"] == 1
+    assert payload["persisting"][0]["fingerprint"] == primary
+
+
+def test_security_diff_falls_back_without_fingerprints(tmp_path, capsys):
+    base_dir = tmp_path / ".brigade" / "security" / "base"
+    against_dir = tmp_path / ".brigade" / "security" / "against"
+    base_dir.mkdir(parents=True)
+    against_dir.mkdir(parents=True)
+    shared = {
+        "category": "supply-chain",
+        "path": "README.md",
+        "line": 3,
+        "title": "Unpinned remote package execution",
+        "severity": "medium",
+    }
+    (base_dir / "security-report.json").write_text(
+        json.dumps({"findings": [dict(shared)], "suppressed_findings": []}, indent=2, sort_keys=True) + "\n"
+    )
+    (against_dir / "security-report.json").write_text(
+        json.dumps({"findings": [dict(shared)], "suppressed_findings": []}, indent=2, sort_keys=True) + "\n"
+    )
+
+    assert security_cmd.diff(target=tmp_path, base_dir=base_dir, against_dir=against_dir, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["new_count"] == 0
+    assert payload["resolved_count"] == 0
+    assert payload["persisting_count"] == 1
+
+
+def test_security_accepted_risk_closeout_migrates_legacy_fingerprint(tmp_path, capsys):
+    assert security_cmd.init(target=tmp_path) == 0
+    capsys.readouterr()
+    readme = tmp_path / "README.md"
+    needle = "npx -y @example/unpinned-package\n"
+    readme.write_text("# Title\n\n" + needle)
+
+    assert security_cmd.scan(target=tmp_path, fail_on="none", json_output=True) == 0
+    scan = json.loads(capsys.readouterr().out)
+    finding = next(item for item in scan["findings"] if item["category"] == "supply-chain")
+    legacy = finding["legacy_fingerprint"]
+    primary = finding["fingerprint"]
+
+    closeout_dir = tmp_path / ".brigade" / "security" / "closeouts" / "legacy-closeout"
+    closeout_dir.mkdir(parents=True)
+    closeout_path = closeout_dir / "closeout.json"
+    closeout_path.write_text(
+        json.dumps(
+            {
+                "status": "accepted-risk",
+                "created_at": "2026-07-01T00:00:00Z",
+                "source_fingerprints": [legacy],
+                "policy_pack": {"accepted_risk": True},
+                "path": str(closeout_path),
+            }
+        )
+        + "\n"
+    )
+
+    health = security_cmd.health(tmp_path)
+    assert health["quieted_finding_count"] == 1
+    migrated = json.loads(closeout_path.read_text())
+    assert primary in migrated["source_fingerprints"]
+    assert migrated["fingerprint_migrations"] == {legacy: primary}
+
+    readme.write_text("# Title\n\n| col | val |\n| --- | --- |\n| a | b |\n\n" + needle)
+    assert security_cmd.scan(target=tmp_path, fail_on="none", json_output=True) == 0
+    capsys.readouterr()
+    after_shift = security_cmd.health(tmp_path)
+    assert after_shift["quieted_finding_count"] == 1
+    assert after_shift["top_finding"] is None
+
+
+def test_security_health_migrates_legacy_harness_closeout_fingerprint(tmp_path):
+    harness_dir = tmp_path / ".brigade" / "hermes"
+    harness_dir.mkdir(parents=True)
+    (harness_dir / "workspace.harness.json").write_text(json.dumps({"endpoint": "https://agent.invalid/api"}, indent=2))
+    wiring = security_cmd.harness_wiring_payload(tmp_path)
+    finding = wiring["findings"][0]
+    legacy = finding["legacy_fingerprint"]
+    primary = finding["fingerprint"]
+
+    closeout_dir = tmp_path / ".brigade" / "security" / "closeouts" / "legacy-harness-closeout"
+    closeout_dir.mkdir(parents=True)
+    closeout_path = closeout_dir / "closeout.json"
+    closeout_path.write_text(
+        json.dumps(
+            {
+                "status": "accepted-risk",
+                "created_at": "2026-07-01T00:00:00Z",
+                "source_fingerprints": [legacy],
+                "policy_pack": {"accepted_risk": True},
+            }
+        )
+        + "\n"
+    )
+
+    health = security_cmd.health(tmp_path)
+    assert health["harness_wiring"]["quieted_finding_count"] == 1
+    migrated = json.loads(closeout_path.read_text())
+    assert primary in migrated["source_fingerprints"]
+    assert migrated["fingerprint_migrations"] == {legacy: primary}
+
+
+def test_security_include_paths_match_literal_bracket_segments(tmp_path):
+    route_dir = tmp_path / "app" / "[id]"
+    route_dir.mkdir(parents=True)
+    other_dir = tmp_path / "app" / "settings"
+    other_dir.mkdir(parents=True)
+    (route_dir / "page.txt").write_text("npx -y @example/unpinned-package\n")
+    (other_dir / "page.txt").write_text("npx -y @example/other-unpinned-package\n")
+
+    report = security_cmd.scan_target(tmp_path, include_paths=("app/[id]",), enabled_checks=("supply-chain",))
+
+    assert report["finding_count"] == 1
+    assert report["findings"][0]["path"] == "app/[id]/page.txt"
+    assert "app/settings/page.txt" not in report["scanned_files"]
+
+
+def test_security_accepted_risk_closeout_matches_legacy_fingerprint(tmp_path, capsys):
+    assert security_cmd.init(target=tmp_path) == 0
+    capsys.readouterr()
+    readme = tmp_path / "README.md"
+    needle = "npx -y @example/unpinned-package\n"
+    readme.write_text("# Title\n\n" + needle)
+
+    assert security_cmd.scan(target=tmp_path, fail_on="none", json_output=True) == 0
+    scan = json.loads(capsys.readouterr().out)
+    finding = next(item for item in scan["findings"] if item["category"] == "supply-chain")
+    legacy = finding["legacy_fingerprint"]
+
+    closeout_dir = tmp_path / ".brigade" / "security" / "closeouts" / "legacy-closeout"
+    closeout_dir.mkdir(parents=True)
+    (closeout_dir / "closeout.json").write_text(
+        json.dumps(
+            {
+                "status": "accepted-risk",
+                "created_at": "2026-07-01T00:00:00Z",
+                "source_fingerprints": [legacy],
+                "policy_pack": {"accepted_risk": True},
+            }
+        )
+        + "\n"
+    )
+
+    health = security_cmd.health(tmp_path)
+    assert health["quieted_finding_count"] == 1
+    assert health["top_finding"] is None
+
+
+def test_security_scan_import_dedupes_after_line_shift(tmp_path, capsys):
+    readme = tmp_path / "README.md"
+    needle = "npx -y @example/unpinned-package\n"
+    readme.write_text("# Title\n\n" + needle)
+
+    assert security_cmd.scan(target=tmp_path, fail_on="none", import_findings=True) == 0
+    capsys.readouterr()
+    imports_path = tmp_path / ".brigade" / "work" / "imports" / "inbox.jsonl"
+    first_import = json.loads(imports_path.read_text().splitlines()[0])
+    assert first_import["metadata"]["occurrence"] == 0
+    legacy = first_import["metadata"]["legacy_fingerprint"]
+    first_import["text"] = first_import["text"].rsplit(" [", 1)[0]
+    first_import["metadata"].pop("occurrence")
+    first_import["metadata"].pop("legacy_fingerprint")
+    first_import["metadata"]["fingerprint"] = legacy
+    first_import["metadata"]["finding_id"] = f"security-{legacy}"
+    first_import["metadata"]["source_item_key"] = f"security-scan:{legacy}"
+    imports_path.write_text(json.dumps(first_import) + "\n")
+
+    readme.write_text("# Title\n\n| col | val |\n| --- | --- |\n| a | b |\n\n" + needle)
+    assert security_cmd.scan(target=tmp_path, fail_on="none", import_findings=True) == 0
+    out = capsys.readouterr().out
+    assert "imported_findings: 0" in out
+    assert "skipped_duplicate_imports: 1" in out
+    assert len(imports_path.read_text().splitlines()) == 1
+
+
+def test_security_scan_import_counts_identical_legacy_duplicates(tmp_path, capsys):
+    readme = tmp_path / "README.md"
+    needle = "npx -y @example/unpinned-package\n"
+    readme.write_text(needle + "middle section\n" + needle)
+
+    assert security_cmd.scan(target=tmp_path, fail_on="none", import_findings=True) == 0
+    capsys.readouterr()
+    imports_path = tmp_path / ".brigade" / "work" / "imports" / "inbox.jsonl"
+    legacy_imports = []
+    for raw in imports_path.read_text().splitlines():
+        item = json.loads(raw)
+        legacy = item["metadata"]["legacy_fingerprint"]
+        item["text"] = item["text"].rsplit(" [", 1)[0]
+        item["metadata"].pop("occurrence")
+        item["metadata"].pop("legacy_fingerprint")
+        item["metadata"]["fingerprint"] = legacy
+        item["metadata"]["finding_id"] = f"security-{legacy}"
+        item["metadata"]["source_item_key"] = f"security-scan:{legacy}"
+        legacy_imports.append(item)
+    assert len(legacy_imports) == 2
+    imports_path.write_text("\n".join(json.dumps(item) for item in legacy_imports) + "\n")
+
+    readme.write_text("# Inserted above\n\n" + needle + "middle section\n" + needle)
+    assert security_cmd.scan(target=tmp_path, fail_on="none", import_findings=True) == 0
+    out = capsys.readouterr().out
+    assert "imported_findings: 0" in out
+    assert "skipped_duplicate_imports: 2" in out
+    assert len(imports_path.read_text().splitlines()) == 2
+
+
+def test_security_scan_import_distinguishes_changed_evidence(tmp_path, capsys):
+    readme = tmp_path / "README.md"
+    readme.write_text("npx -y @example/unpinned-package\n")
+
+    assert security_cmd.scan(target=tmp_path, fail_on="none", import_findings=True) == 0
+    capsys.readouterr()
+
+    readme.write_text("npx -y @example/other-unpinned-package\n")
+    assert security_cmd.scan(target=tmp_path, fail_on="none", import_findings=True) == 0
+    out = capsys.readouterr().out
+    assert "imported_findings: 1" in out
+    imports_path = tmp_path / ".brigade" / "work" / "imports" / "inbox.jsonl"
+    assert len(imports_path.read_text().splitlines()) == 2
+
+
 def test_security_review_suppress_and_unsuppress(tmp_path, capsys):
     (tmp_path / ".env").write_text("SERVICE_TOKEN=abcd1234abcd1234abcd1234\n")
     output_dir = tmp_path / ".brigade" / "security" / "latest"


### PR DESCRIPTION
## Summary

- make `.brigade/**` and other trailing `/**` exclusions prune their repo-relative subtree before files are opened
- replace line-addressed finding fingerprints with rule, path, redacted matched content, duplicate cardinality, and duplicate occurrence
- preserve exact legacy singleton suppressions across the upgrade with a validated local legacy-to-primary map
- keep show, suppress, unsuppress, report review, diff, accepted-risk health, and work imports consistent with the new identity

## #529 root cause

`exclude_paths` was already parsed, resolved, applied by the scan engine, and projected into reports. The failure was in `_path_matches_any`: it treated `.brigade/**` as literal path text, so neither `.brigade` nor its descendants matched and the walk entered evidence bundles.

The reported `null` config clue did not identify dropped plumbing. `brigade security config --json` nests resolved settings under `.config`, so the resolved value is `.config.exclude_paths`, not a top-level field.

The matcher keeps path settings as literal repo-relative prefixes. Only a trailing `/**` is accepted as an alias for the same prefix, including the named root. Bracketed paths such as `app/[id]` remain literal.

## #530 identity and migration

The primary fingerprint no longer contains the absolute line. It hashes `rule_id`, repo-relative path, a normalized redacted excerpt, and occurrence. Identical matches in one file include duplicate cardinality and occurrence, so suppressing one does not hide another. Adding or removing an identical duplicate rekeys that group and requires review instead of transferring a suppression.

Each finding also carries the old line-based fingerprint. An exact legacy singleton suppression is migrated to the primary fingerprint and recorded in `.brigade/security/fingerprint-migration-map.json`. Duplicate groups never inherit a singleton legacy alias. Old report bundles and direct legacy IDs remain manageable through the map.

For the observed fingerprints, `68041634653069ec` and `3076e8de762703a9` remain legacy line-based identities. If the first upgraded scan sees the finding at the original location, `68041634653069ec` maps to one content fingerprint; after lines move, that primary stays unchanged and `3076e8de762703a9` is only the current legacy alias. If the first upgraded scan happens after the move, the old fingerprint cannot be matched safely and needs one review under the content identity.

This stops new history entries caused only by unrelated line shifts. Existing reports, imported history, and historical totals are not rewritten.

## Verification

```text
brigade work verify run --target . --command "./scripts/verify" --capture brigade-work

All checks passed!
532 files already formatted
Success: no issues found in 317 source files
version=0.25.1 checked=13 locations
managed snapshot: ok (6 manifests)
4252 passed, 3 skipped in 327.34s (0:05:27)
Total coverage: 82.77%
```

Codex review found and drove regression coverage for duplicate cardinality, symlinked closeout state, historical report IDs and diffs, accepted-risk health, stale-report unsuppression, scan-time map use, and severity changes in work imports.

Closes #529
Closes #530
