### PR TITLE
fix(receipts): add MiseLedger project metadata

### DIFF
--- a/src/brigade/receipts_cmd.py
+++ b/src/brigade/receipts_cmd.py
@@ -734,6 +734,13 @@ def _code_reference_repository(target: Path) -> str | None:
     return f"{owner}/{repository}"
 
 
+def _miseledger_project(target: Path) -> str:
+    repository = _code_reference_repository(target)
+    if repository is None:
+        return target.name
+    return repository.rsplit("/", 1)[-1]
+
+
 def _code_references_from_delta(payload: dict[str, Any], target: Path) -> tuple[list[dict[str, Any]], int, bool]:
     delta = payload.get("code_graph_delta")
     git = _receipt_git(payload)
@@ -1015,6 +1022,8 @@ def _verify_miseledger_item(payload: dict[str, Any], path: Path, target: Path, o
         "run_id": run_id,
         "status": payload.get("status"),
         "target": payload.get("target"),
+        "project": _miseledger_project(target),
+        "workspace_dir": str(target),
         "path": _rel(path, target),
         "digest": receipt_hash,
         "digest_source": digest_source,
@@ -1075,6 +1084,8 @@ def _run_miseledger_item(payload: dict[str, Any], path: Path, target: Path, ordi
         "run_id": run_id,
         "status": payload.get("status"),
         "cwd": payload.get("cwd"),
+        "project": _miseledger_project(target),
+        "workspace_dir": str(target),
         "path": _rel(path, target),
         "digest": receipt_hash,
         "digest_source": digest_source,

--- a/tests/test_receipts_cmd.py
+++ b/tests/test_receipts_cmd.py
@@ -387,6 +387,12 @@ def test_receipts_export_recomputes_inconsistent_compact_code_reference_metadata
 
 
 def test_receipts_export_miseledger_exports_run_and_digestless_verify_receipts(tmp_path, capsys):
+    _init_git_repo_with_head(tmp_path)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "https://github.com/example-org/example-repo.git"],
+        cwd=tmp_path,
+        check=True,
+    )
     verify_path = _write_verify_export_receipt(
         tmp_path,
         "20260708-110000-work-verify-def456",
@@ -410,8 +416,12 @@ def test_receipts_export_miseledger_exports_run_and_digestless_verify_receipts(t
     ]
     assert rows[0]["collection"]["external_id"] == "brigade:runs"
     assert rows[0]["item"]["external_id"] == "brigade:run:20260708-130000-aabbccdd"
+    assert rows[0]["item"]["metadata"]["project"] == "example-repo"
+    assert rows[0]["item"]["metadata"]["workspace_dir"] == str(tmp_path.resolve())
     assert rows[0]["raw"]["hash"] == "sha256:" + json.loads(run_path.read_text())["digests"]["receipt_sha256"]
     assert rows[0]["item"]["metadata"]["code_graph_delta_summary"] == "changed_symbols=1"
+    assert rows[1]["item"]["metadata"]["project"] == "example-repo"
+    assert rows[1]["item"]["metadata"]["workspace_dir"] == str(tmp_path.resolve())
     assert rows[1]["raw"]["hash"] == "sha256:" + localio.file_sha256(verify_path)
     assert rows[1]["item"]["metadata"]["digest_source"] == "file_sha256"
 


### PR DESCRIPTION
## Summary

- add MiseLedger `project` and `workspace_dir` metadata to Brigade run and work-verify receipt exports
- derive the project name from the GitHub origin, with the resolved target directory as a fallback
- cover both receipt types in the export test

## Verification

- `brigade work verify run --target . --command ".venv/bin/python -m pytest -q tests/test_receipts_cmd.py" --capture brigade-work` - 58 passed
- `brigade work verify run --target . --command "./scripts/verify" --capture brigade-work` - 4,229 passed, 3 skipped, 82.74% coverage
- re-exported existing receipts and confirmed `search_evidence(project="brigade")` returns the final verification receipt as evidence `7dbfb69d7a8d927675b7479d`