### PR TITLE
feat(run): record the resolved scheduler in run receipts

### DIFF
--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -1188,6 +1188,7 @@ def dispatch(
     route_held: dict[str, list[str]] | None = None,
     on_stage_start: Callable[[int, tuple[str, ...]], None] | None = None,
     on_interrupt: Callable[[], None] | None = None,
+    on_scheduler_resolved: Callable[[str, str | None], None] | None = None,
     process_registry: proc.ProcessRegistry | None = None,
     build_prompt: Callable[..., str] | None = None,
 ) -> list[WorkerResult]:
@@ -1218,6 +1219,7 @@ def dispatch(
         route_held=route_held,
         on_stage_start=on_stage_start,
         on_interrupt=on_interrupt,
+        on_scheduler_resolved=on_scheduler_resolved,
         process_registry=process_registry,
     )
 
@@ -2006,6 +2008,7 @@ def _run_payload(
     worker: str | None = None,
     include_git: bool = True,
     pre_run_snapshot: dict[str, object] | None = None,
+    scheduler: dict[str, object] | None = None,
 ) -> dict[str, object]:
     payload: dict[str, object] = {
         "schema": "brigade.run.v1",
@@ -2036,6 +2039,8 @@ def _run_payload(
             "attached": list(brief_set.attached) if brief_set is not None else [],
         },
     }
+    if scheduler is not None:
+        payload["scheduler"] = scheduler
     if resolution := _roster_resolution_payload(roster):
         payload["roster"] = resolution
     if lock_workspace is not None:
@@ -2117,8 +2122,15 @@ def record_run_start(
     lock_workspace: Path | None = None,
     codex_transport: str | None = None,
     started_at: datetime | None = None,
+    scheduler: str | None = None,
 ) -> None:
-    """Write the minimal typed receipt needed before optional or blocking work."""
+    """Write the minimal typed receipt needed before optional or blocking work.
+
+    The requested scheduler is recorded here so a run that dies before dispatch
+    still says what it was asked to do; ``used`` stays None until dispatch
+    resolves it. ``record_run_termination`` merges into this payload, so the
+    field survives a startup failure.
+    """
 
     output_dir = output_dir.expanduser().resolve()
     started_at = started_at or datetime.now(timezone.utc)
@@ -2141,6 +2153,9 @@ def record_run_start(
             codex_transport=codex_transport or roster.codex_transport,
             worker=worker,
             include_git=False,
+            scheduler=(
+                {"requested": scheduler, "used": None, "fallback_reason": None} if scheduler is not None else None
+            ),
         ),
     )
     _write_json(output_dir / "roster.json", _roster_payload(roster))
@@ -2311,10 +2326,24 @@ def run(
     handoff_inbox = handoff_inbox.expanduser() if handoff_inbox is not None else None
     direct_worker = worker is not None
 
+    # What the roster/flag asked for vs what dispatch actually ran. `used` stays
+    # None until dispatch resolves it, so a run that dies before dispatch reads
+    # as "requested dag, never got there" rather than falsely claiming a mode.
+    scheduler_resolution: dict[str, object] = {
+        "requested": scheduler,
+        "used": None,
+        "fallback_reason": None,
+    }
+
+    def scheduler_resolved(used: str, fallback_reason: str | None) -> None:
+        scheduler_resolution["used"] = used
+        scheduler_resolution["fallback_reason"] = fallback_reason
+
     def _payload(**kwargs: Any) -> dict[str, object]:
         return _run_payload(
             lock_workspace=lock_workspace,
             pre_run_snapshot=pre_run_snapshot_payload,
+            scheduler=dict(scheduler_resolution),
             **kwargs,
         )
 
@@ -2372,6 +2401,7 @@ def run(
             lock_workspace=lock_workspace,
             codex_transport=transport_for_payload,
             started_at=started_at,
+            scheduler=scheduler,
         )
     if code_graph is None:
         code_graph = code_graph_brief(cwd, task) if code_graph_enabled else CodeGraphBrief(attached=False)
@@ -2743,6 +2773,7 @@ def run(
                 route_held=dict(route.held) if route is not None and route.attached else None,
                 on_stage_start=stage_started,
                 on_interrupt=dispatch_interrupted,
+                on_scheduler_resolved=scheduler_resolved,
                 process_registry=process_registry,
             )
         except runguard.RetainRunLockError:

--- a/src/brigade/cli/run.py
+++ b/src/brigade/cli/run.py
@@ -257,6 +257,11 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_run.set_defaults(func=dispatch)
 
 
+def _resolved_scheduler(args, roster) -> str:
+    """Scheduler precedence: --scheduler flag, then roster limits.scheduler, then waves."""
+    return args.scheduler or roster.scheduler or "waves"
+
+
 def dispatch(args) -> int:
     from .. import aboyeur as aboyeur_mod
     from .. import runguard
@@ -426,6 +431,7 @@ def dispatch(args) -> int:
                     dry_run=args.dry_run,
                     lock_workspace=run_cwd,
                     codex_transport=args.codex_transport or loaded_roster.codex_transport,
+                    scheduler=_resolved_scheduler(args, loaded_roster),
                 )
             if output_dir is not None and (advisory or output_warnings):
                 from .. import localio
@@ -477,7 +483,7 @@ def dispatch(args) -> int:
             if args.route_signals:
                 run_kwargs["route_overrides"] = tuple(args.route_signals)
             run_kwargs["fail_fast"] = not args.keep_going
-            run_kwargs["scheduler"] = args.scheduler or loaded_roster.scheduler or "waves"
+            run_kwargs["scheduler"] = _resolved_scheduler(args, loaded_roster)
             try:
                 rc = aboyeur_mod.run(args.task, loaded_roster, **run_kwargs)
             except runguard.RetainRunLockError:
@@ -669,6 +675,7 @@ def _dispatch_detached(args, *, run_cwd: Path, roster_resolution, roster, output
                 roster=roster,
                 read_only=args.read_only,
                 worker=args.worker,
+                scheduler=_resolved_scheduler(args, roster),
             )
             initial_receipt = (output_dir / "run.json").read_bytes()
             log_path = output_dir / "detached.log"

--- a/src/brigade/run_transport.py
+++ b/src/brigade/run_transport.py
@@ -257,9 +257,16 @@ def dispatch(
     route_held: dict[str, list[str]] | None = None,
     on_stage_start: Callable[[int, tuple[str, ...]], None] | None = None,
     on_interrupt: Callable[[], None] | None = None,
+    on_scheduler_resolved: Callable[[str, str | None], None] | None = None,
     process_registry: proc.ProcessRegistry | None = None,
 ) -> list[WorkerResult]:
-    """Dispatch staged assignments while keeping transport policy in one module."""
+    """Dispatch staged assignments while keeping transport policy in one module.
+
+    ``on_scheduler_resolved`` receives the scheduler that actually ran and the
+    fallback reason, so a receipt can distinguish a real DAG dispatch from a
+    silent degrade to waves. Without it the fallback is stderr-only and the run
+    record cannot tell the two apart.
+    """
 
     process_registry = process_registry or proc.ProcessRegistry()
 
@@ -624,6 +631,8 @@ def dispatch(
     if scheduler == "dag":
         placement_error = _dag_placement_error(assignments, route_dependencies)
         if placement_error is None:
+            if on_scheduler_resolved is not None:
+                on_scheduler_resolved("dag", None)
             return _dag_dispatch(
                 assignments,
                 roster,
@@ -634,10 +643,14 @@ def dispatch(
                 route_dependencies=route_dependencies or {},
                 route_held=route_held or {},
             )
+        if on_scheduler_resolved is not None:
+            on_scheduler_resolved("waves", placement_error)
         print(
             f"warning: dag scheduler: {placement_error}; falling back to wave scheduler",
             file=sys.stderr,
         )
+    elif on_scheduler_resolved is not None:
+        on_scheduler_resolved("waves", None)
 
     stage_order = sorted({assignment.stage for assignment in assignments})
     abort_after_stage: int | None = None

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -1219,6 +1219,47 @@ def test_run_cli_terminalizes_roster_snapshot_write_failure(tmp_path, monkeypatc
     }
 
 
+def test_run_cli_records_requested_scheduler_before_dispatch(tmp_path, monkeypatch):
+    # A run that dies before dispatch must still say which scheduler was asked
+    # for, and must not claim one ran. Without this the receipt cannot tell a
+    # real DAG dispatch from a silent fallback to waves.
+    repo = _git_repo_with_roster(tmp_path)
+    output_dir = repo / ".brigade" / "runs" / "scheduler-requested"
+    real_write_json = aboyeur._write_json
+
+    def fail_roster_write(path, payload):
+        if path.name == "roster.json":
+            raise OSError("roster snapshot denied")
+        return real_write_json(path, payload)
+
+    monkeypatch.setattr(aboyeur, "_write_json", fail_roster_write)
+
+    assert (
+        cli.main(
+            [
+                "run",
+                "x",
+                "--cwd",
+                str(repo),
+                "--output-dir",
+                str(output_dir),
+                "--worker",
+                "coder",
+                "--scheduler",
+                "dag",
+            ]
+        )
+        == 2
+    )
+
+    receipt = json.loads((output_dir / "run.json").read_text())
+    assert receipt["scheduler"] == {
+        "requested": "dag",
+        "used": None,
+        "fallback_reason": None,
+    }
+
+
 def test_run_cli_terminalizes_sigterm_during_roster_snapshot(tmp_path, monkeypatch):
     repo = _git_repo_with_roster(tmp_path)
     output_dir = repo / ".brigade" / "runs" / "roster-signal"

--- a/tests/test_run_transport_dag.py
+++ b/tests/test_run_transport_dag.py
@@ -50,6 +50,7 @@ class _DagHarness:
         outcomes=None,
         held=None,
         slow_workers=None,
+        on_scheduler_resolved=None,
     ):
         outcomes = outcomes or {}
         slow_workers = slow_workers or {}
@@ -80,6 +81,7 @@ class _DagHarness:
             scheduler="dag",
             route_dependencies=dict(dependencies),
             route_held=held or {},
+            on_scheduler_resolved=on_scheduler_resolved,
         )
 
     @property
@@ -159,6 +161,38 @@ def test_partially_unknown_covers_falls_back_to_waves(dag_harness, capsys):
     )
     assert "falling back to wave scheduler" in capsys.readouterr().err
     assert len(results) == 1
+
+
+def test_scheduler_resolution_reported_when_dag_engages(dag_harness):
+    # The receipt must be able to say the DAG actually ran, not just that it was
+    # asked for: stderr-only reporting left run.json unable to tell the two apart.
+    resolved = []
+    dag_harness(
+        assignments=[_a("p", 1, ["plan"]), _a("i", 2, ["implement"])],
+        dependencies=DEPS,
+        on_scheduler_resolved=lambda used, reason: resolved.append((used, reason)),
+    )
+    assert resolved == [("dag", None)]
+
+
+def test_scheduler_resolution_reports_wave_fallback(dag_harness):
+    resolved = []
+    dag_harness(
+        assignments=[_a("p", 1, ["plan"]), Assignment(worker="x", task="t", stage=2)],
+        dependencies=DEPS,
+        on_scheduler_resolved=lambda used, reason: resolved.append((used, reason)),
+    )
+    assert resolved == [("waves", "plan not fully covered")]
+
+
+def test_scheduler_resolution_reports_missing_route_dependencies(dag_harness):
+    resolved = []
+    dag_harness(
+        assignments=[_a("p", 1, ["plan"])],
+        dependencies={},
+        on_scheduler_resolved=lambda used, reason: resolved.append((used, reason)),
+    )
+    assert resolved == [("waves", "no route dependencies available")]
 
 
 DEPS_REDUNDANT = {


### PR DESCRIPTION
## Summary

The DAG ready-queue scheduler (#447) became the roster default via `limits.scheduler` (#472), but `run.json` never recorded which scheduler actually ran. The DAG-to-waves fallback printed only to stderr, so a receipt could not tell a real DAG dispatch from a silent degrade to waves.

`run.json` now carries:

```json
"scheduler": {"requested": "dag", "used": "dag", "fallback_reason": null}
```

- `requested` is written at `record_run_start`, so a run that dies before dispatch says what it was asked to do rather than claiming a mode it never reached. `record_run_termination` merges into the existing payload, so the field survives startup failures.
- `used` / `fallback_reason` are filled by a new `on_scheduler_resolved` callback out of `run_transport.dispatch`, following the existing `on_stage_start` / `on_interrupt` callback pattern. `used` stays `null` until dispatch resolves it.
- Scheduler precedence (`--scheduler`, then roster `limits.scheduler`, then `waves`) now lives in one helper, `cli/run.py::_resolved_scheduler`.

## Why this was blocking

An audit of the 25 most recent runs in the maintainer's checkout found that of the 20 with a parsed plan, only **2 were DAG-eligible**, and only **1 of those ran after the roster flip**. The other 18 were single-worker (`--worker`) runs whose assignments carry no `covers`, so `_dag_placement_error` returns `"plan not fully covered"` and they degrade to waves every time.

That degrade is correct behavior, but it means any DAG-vs-waves comparison must use multi-seat runs only. Counting all runs understates DAG engagement to near zero. Without the scheduler field there was no way to establish that from receipts, which left the route-recomposition decision (`docs/proposals/route-recomposition.md`) undecidable.

## Blast radius

Established with GraphTrail before the first edit:

- `_dag_placement_error` <- `run_transport.dispatch:625` <- `aboyeur.dispatch:1196`. Two hops, contained.
- `_run_payload` <- `record_run_start:2128` and the `aboyeur.run._payload` closure:2315, which `aboyeur.run` calls at 11 sites. Injecting the field in the closure covers all 11 at once rather than editing each.
- Downstream `run.json` consumers (`release_cmd/candidate.py`, `release_cmd/commands.py`) read existing keys only; the new key is additive.

## Tests

Four new tests, written red-first (failing receipt `20260726-065836-work-verify-e65eb5`, exit 1, before implementation):

- `test_scheduler_resolution_reported_when_dag_engages`
- `test_scheduler_resolution_reports_wave_fallback`
- `test_scheduler_resolution_reports_missing_route_dependencies`
- `test_run_cli_records_requested_scheduler_before_dispatch`

## Verification

`brigade work verify run --target . --command "./scripts/verify" --capture brigade-work`

Receipt `20260726-070342-work-verify-edd4dd`: `completed`, exit 0, 505.3s, 4218 passed / 3 skipped, coverage 82.67% (floor 78%). Tree fingerprint `54dc40a635bcac6411bca7b88fa1f54a078c79c97cfa8de4bbf995860c5f8fd5`.

Smoke against the branch source wrote `"scheduler": {"requested": "dag", "used": null, "fallback_reason": null}` to a dry-run `run.json` (`used` null is correct: a dry run never dispatches).

**Caveat:** that green predates #542. `./scripts/verify` currently fails on this machine with 6 failures in `tests/test_repos_sweep_health_cmd.py`, which reproduce on a clean checkout of `main` and are unrelated to this diff. The gate should be re-run once #542 is resolved.

## Follow-ups

- Live `brigade` is pipx 0.25.1 and still writes scheduler-less receipts; `pipx install --force` is needed before this affects real runs.
- #501 (typed, receipted route decisions) is the same seam and could fold in.
