### PR TITLE
fix(repos): use package root for sweep subprocesses

### DIFF
--- a/src/brigade/repos_cmd/sweeps.py
+++ b/src/brigade/repos_cmd/sweeps.py
@@ -516,7 +516,7 @@ def _run_sweep_command(entry: constants.RepoEntry, command: constants.SweepComma
     command_dir = sweep_dir / "logs" / entry.repo_id / command.label
     command_dir.mkdir(parents=True, exist_ok=True)
     env = os.environ.copy()
-    source_path = Path(__file__).resolve().parents[1]
+    source_path = Path(__file__).resolve().parents[2]
     env["PYTHONPATH"] = str(source_path) + (os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else "")
     try:
         result = subprocess.run(

--- a/tests/test_repos_sweep_health_cmd.py
+++ b/tests/test_repos_sweep_health_cmd.py
@@ -209,6 +209,33 @@ def test_repos_sweep_failed_repo_does_not_block_other_repo(tmp_path, capsys):
     assert sweep["failed_count"] == 1
 
 
+def test_repos_sweep_injects_src_pythonpath_for_built_in_commands(tmp_path, monkeypatch, capsys):
+    # Regression for issue #542: _run_sweep_command must prepend src/ (parents[2]),
+    # not src/brigade (parents[1]), so a built-in `python -m brigade ...` command
+    # imports the package from the injected PYTHONPATH alone. `-S` disables
+    # site-packages so the subprocess can only resolve `brigade` via PYTHONPATH.
+    repo = tmp_path / "repo-alpha"
+    _init_repo(repo)
+    _seed_workspace(tmp_path, repo)
+    monkeypatch.setattr(
+        repos_cmd,
+        "_sweep_commands",
+        lambda: [
+            repos_cmd.SweepCommand(
+                "work-brief-no-site",
+                [sys.executable, "-S", "-m", "brigade", "work", "brief", "--json"],
+            ),
+        ],
+    )
+
+    assert repos_cmd.sweep_run(target=tmp_path, repo_ids=["alpha"], json_output=True) == 0
+    sweep = json.loads(capsys.readouterr().out)
+    commands = {command["label"]: command for command in sweep["repos"][0]["commands"]}
+    assert commands["work-brief-no-site"]["status"] == "completed"
+    assert commands["work-brief-no-site"]["exit_code"] == 0
+    assert "No module named brigade" not in commands["work-brief-no-site"]["stderr_summary"]
+
+
 def test_repos_sweep_records_nonzero_and_timeout_commands(tmp_path, monkeypatch, capsys):
     repo = tmp_path / "repo-alpha"
     _init_repo(repo)


### PR DESCRIPTION
## Summary

- Inject the `src` package root into repo sweep subprocesses so built-in commands import the same Brigade checkout as the parent process.
- Add a regression test that disables site-packages and proves the subprocess resolves `brigade` through the injected `PYTHONPATH`.

## Root cause

`_run_sweep_command` prepended `src/brigade` to `PYTHONPATH`. Python needs that package directory's parent, `src`, to resolve `python -m brigade`. A valid editable install masked the bad path until its worktree target was removed.

## Verification

`brigade work verify run --target . --command "./scripts/verify" --capture brigade-work`

- Receipt: `20260726-185900-work-verify-0530e5`
- Exit code: `0`
- Result: `4288 passed, 3 skipped in 470.01s`
- Coverage: `82.78%`

Closes #542