### PR TITLE
fix(cli): use bundled TOML parser under no-site Python

### DIFF
--- a/src/brigade/research/config.py
+++ b/src/brigade/research/config.py
@@ -2,10 +2,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, List
 
-try:
-    import tomllib  # py3.11+
-except ModuleNotFoundError:  # py3.10
-    import tomli as tomllib  # type: ignore
+from .. import toml_compat as tomllib
 
 
 class ResearchConfig:


### PR DESCRIPTION
## Summary

- use Brigade's bundled TOML reader in research configuration
- keep `python -S` subprocesses self-contained on Python 3.10
- restore the Python 3.10 repository sweep test

## Verification

- `brigade work verify run --target . --command "pytest -q tests/test_repos_sweep_health_cmd.py::test_repos_sweep_injects_src_pythonpath_for_built_in_commands" --capture brigade-work`
- `brigade work verify run --target . --command "pytest -q tests/test_toml_compat.py" --capture brigade-work`
- `brigade work verify run --target . --command "./scripts/verify" --capture brigade-work`
- 4,297 passed, 3 skipped
