### PR TITLE
fix(tests): keep sweep import probe portable on Python 3.10

### DIFF
--- a/tests/test_repos_sweep_health_cmd.py
+++ b/tests/test_repos_sweep_health_cmd.py
@@ -209,21 +209,27 @@ def test_repos_sweep_failed_repo_does_not_block_other_repo(tmp_path, capsys):
     assert sweep["failed_count"] == 1
 
 
-def test_repos_sweep_injects_src_pythonpath_for_built_in_commands(tmp_path, monkeypatch, capsys):
+def test_repos_sweep_injects_src_pythonpath_so_brigade_resolves_under_no_site_packages(tmp_path, monkeypatch, capsys):
     # Regression for issue #542: _run_sweep_command must prepend src/ (parents[2]),
-    # not src/brigade (parents[1]), so a built-in `python -m brigade ...` command
-    # imports the package from the injected PYTHONPATH alone. `-S` disables
-    # site-packages so the subprocess can only resolve `brigade` via PYTHONPATH.
+    # not src/brigade (parents[1]), so a subprocess launched with site-packages
+    # disabled can resolve the `brigade` package from the injected PYTHONPATH alone.
+    # This proves package discovery without booting the full Brigade CLI under
+    # `python -S`, which is what regressed Python 3.10 CI in PR #545: `find_spec`
+    # locates the package on sys.path without executing its __init__, so the
+    # subprocess exits nonzero only when the spec is missing.
     repo = tmp_path / "repo-alpha"
     _init_repo(repo)
     _seed_workspace(tmp_path, repo)
+    discovery_check = (
+        "import importlib.util, sys; sys.exit(0 if importlib.util.find_spec('brigade') is not None else 1)"
+    )
     monkeypatch.setattr(
         repos_cmd,
         "_sweep_commands",
         lambda: [
             repos_cmd.SweepCommand(
-                "work-brief-no-site",
-                [sys.executable, "-S", "-m", "brigade", "work", "brief", "--json"],
+                "brigade-discovery-no-site",
+                [sys.executable, "-S", "-c", discovery_check],
             ),
         ],
     )
@@ -231,9 +237,9 @@ def test_repos_sweep_injects_src_pythonpath_for_built_in_commands(tmp_path, monk
     assert repos_cmd.sweep_run(target=tmp_path, repo_ids=["alpha"], json_output=True) == 0
     sweep = json.loads(capsys.readouterr().out)
     commands = {command["label"]: command for command in sweep["repos"][0]["commands"]}
-    assert commands["work-brief-no-site"]["status"] == "completed"
-    assert commands["work-brief-no-site"]["exit_code"] == 0
-    assert "No module named brigade" not in commands["work-brief-no-site"]["stderr_summary"]
+    assert commands["brigade-discovery-no-site"]["status"] == "completed"
+    assert commands["brigade-discovery-no-site"]["exit_code"] == 0
+    assert "No module named brigade" not in commands["brigade-discovery-no-site"]["stderr_summary"]
 
 
 def test_repos_sweep_records_nonzero_and_timeout_commands(tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
## Summary

- Replace the full `python -S -m brigade` regression command with a standard-library package-discovery probe.
- Preserve issue #542 coverage by proving the sweep subprocess receives `src/` on `PYTHONPATH`.
- Avoid booting the full CLI without site-packages, which fails on Python 3.10 before the import-root assertion is reached.

## Root cause

PR #545’s regression test disabled site-packages and then started the full Brigade CLI. Python 3.10 has no standard-library `tomllib`, while `python -S` also hides the installed `tomli` fallback. The test therefore failed during CLI startup instead of checking the sweep subprocess import root.

## Verification

- `brigade work verify run --target . --command "./scripts/verify" --capture brigade-work`
- Receipt: `20260726-194952-work-verify-60c994`
- Exit code: `0`
- Result: `4297 passed, 3 skipped` with 82.80% coverage

Follow-up to #545.