### PR TITLE
fix(verify): propagate harness session past extra env prefixes

### DIFF
--- a/src/brigade/work_cmd/verification.py
+++ b/src/brigade/work_cmd/verification.py
@@ -507,6 +507,13 @@ def _fingerprint_segment(hasher, label: str, data: bytes) -> None:
     hasher.update(str(len(data)).encode() + b":" + data)
 
 
+def _stamp_harness_session(receipt: dict[str, Any]) -> None:
+    """Record the caller's Claude harness session when BRIGADE_CLAUDE_SESSION is valid 16-hex."""
+    claude_session = os.environ.get("BRIGADE_CLAUDE_SESSION")
+    if claude_session and re.fullmatch(r"[0-9a-f]{16}", claude_session):
+        receipt["harness_session"] = {"harness": "claude", "fingerprint": claude_session}
+
+
 def _tree_fingerprint(target: Path) -> str | None:
     """Content hash of HEAD + tracked diff + untracked files. None outside git."""
     try:
@@ -563,9 +570,7 @@ def _run_verify_commands(
             "tree_fingerprint": _tree_fingerprint(target),
             "planned_commands": [shlex.join(c) if isinstance(c, list) else c for c in commands],
         }
-        claude_session = os.environ.get("BRIGADE_CLAUDE_SESSION")
-        if claude_session and re.fullmatch(r"[0-9a-f]{16}", claude_session):
-            receipt["harness_session"] = {"harness": "claude", "fingerprint": claude_session}
+        _stamp_harness_session(receipt)
         try:
             graph_delta_before = graphtrail_delta.capture_before(target, run_dir, timeout=graphtrail_timeout)
         except KeyboardInterrupt:
@@ -719,6 +724,7 @@ def _write_reused_receipt(
         "tree_fingerprint": fingerprint,
         "planned_commands": planned_display,
     }
+    _stamp_harness_session(receipt)
     git = _receipt_git_snapshot(target)
     if git is not None:
         receipt["git"] = git

--- a/tests/test_work_cmd_verification.py
+++ b/tests/test_work_cmd_verification.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shlex
 import sqlite3
 import subprocess
 import sys
@@ -239,6 +240,79 @@ def test_work_verify_plan_run_list_show(tmp_path, capsys):
 def _init_verify_target_with_head(target):
     target.mkdir(parents=True, exist_ok=True)
     _init_git_repo_with_head(target)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="requires POSIX shell env-prefix invocation")
+def test_verify_reused_receipt_stamps_harness_session_from_outer_env_prefix(tmp_target, monkeypatch):
+    """Regression #541: cache-hit receipts must stamp outer BRIGADE_CLAUDE_SESSION."""
+    from brigade.claude_hooks.runtime import _session_fingerprint
+    from brigade.work_cmd import verification
+
+    _init_verify_target_with_head(tmp_target)
+    graphtrail_bin = str(tmp_target / "missing-graphtrail")
+    monkeypatch.setenv("GRAPHTRAIL_BIN", graphtrail_bin)
+
+    fingerprint_a = _session_fingerprint("session-a-outer-prefix")
+    fingerprint_b = _session_fingerprint("session-b-outer-prefix")
+    verify_command = "true"
+    target = str(tmp_target)
+    brigade_cli = (
+        f"{shlex.quote(sys.executable)} -m brigade work verify run "
+        f"--target {shlex.quote(target)} --command {shlex.quote(verify_command)}"
+    )
+    subprocess_env = {**os.environ, "GRAPHTRAIL_BIN": graphtrail_bin}
+
+    case_a = subprocess.run(
+        ["/bin/sh", "-c", f"BRIGADE_CLAUDE_SESSION={fingerprint_a} {brigade_cli}"],
+        cwd=tmp_target,
+        env=subprocess_env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert case_a.returncode == 0, case_a.stderr
+
+    case_b = subprocess.run(
+        [
+            "/bin/sh",
+            "-c",
+            f"BRIGADE_CLAUDE_SESSION={fingerprint_b} PY=/fake/path {brigade_cli}",
+        ],
+        cwd=tmp_target,
+        env=subprocess_env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert case_b.returncode == 0, case_b.stderr
+
+    receipts = verification._verify_receipts(tmp_target)
+    assert len(receipts) == 2
+    reused = receipts[0]
+    fresh = receipts[1]
+    assert reused["reused_from"] == fresh["run_id"]
+    assert fresh["harness_session"] == {"harness": "claude", "fingerprint": fingerprint_a}
+    assert reused["harness_session"] == {"harness": "claude", "fingerprint": fingerprint_b}
+    assert reused["planned_commands"] == [verify_command]
+
+
+def test_verify_reused_receipt_records_env_assignments_inside_command(tmp_target, monkeypatch):
+    from brigade.work_cmd import verification
+
+    _init_verify_target_with_head(tmp_target)
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(tmp_target / "missing-graphtrail"))
+    command = f'FOO=bar BAZ=qux {sys.executable} -c "print(1)"'
+
+    assert verification.verify_run(target=tmp_target, commands=[command], timeout=60) == 0
+    assert verification.verify_run(target=tmp_target, commands=[command], timeout=60) == 0
+
+    receipts = verification._verify_receipts(tmp_target)
+    assert len(receipts) == 2
+    reused = receipts[0]
+    fresh = receipts[1]
+    assert reused["reused_from"] == fresh["run_id"]
+    assert reused["commands"][0]["env"] == ["BAZ", "FOO"]
+    assert reused["planned_commands"] == [command]
 
 
 def test_verify_reuses_identical_tree(tmp_target, monkeypatch):


### PR DESCRIPTION
## Root cause

The shell and Brigade process received both environment assignments. The second invocation hit verify result reuse because its command and tree matched case A. `_write_reused_receipt` built the cache-hit receipt without stamping `BRIGADE_CLAUDE_SESSION`; only `_run_verify_commands` stamped fresh receipts.

The fix moves the existing 16-hex stamping rule into `_stamp_harness_session` and calls it from both fresh and reused receipt writers.

## Reproduction after the fix

Case A, fresh receipt:

```json
{
  "run_id": "20260726-203955-work-verify-f16366",
  "reused_from": null,
  "harness_session": {
    "harness": "claude",
    "fingerprint": "0123456789abcdef"
  }
}
```

Case B, two outer environment prefixes and a reused receipt:

```json
{
  "run_id": "20260726-203956-work-verify-0bc5b3",
  "reused_from": "20260726-203955-work-verify-f16366",
  "harness_session": {
    "harness": "claude",
    "fingerprint": "fedcba9876543210"
  }
}
```

The regression test invokes the real CLI through `/bin/sh` for both shapes. Existing behavior for environment assignments inside `--command` remains covered.

## Verification

- Full gate: `./scripts/verify`
- Brigade receipt: `20260726-203339-work-verify-d83604`
- Status: `completed`
- Exit code: `0`

Closes #541.