### PR TITLE
fix(handoff): fail content guard lint on injection warnings

### DIFF
--- a/src/brigade/handoff_cmd/linting.py
+++ b/src/brigade/handoff_cmd/linting.py
@@ -41,6 +41,21 @@ def _injection_messages(hits: tuple[Any, ...]) -> tuple[str, ...]:
     return tuple(messages)
 
 
+def _egress_verdict(exit_code: Any) -> str:
+    return OK if exit_code == 0 else FAIL
+
+
+def _injection_verdict(hits: tuple[Any, ...]) -> str:
+    return FAIL if any(hit.severity == "warning" for hit in hits) else OK
+
+
+def _injection_detail(*, warning_count: int) -> str:
+    if warning_count:
+        label = "warning" if warning_count == 1 else "warnings"
+        return f"{warning_count} injection {label}"
+    return "clean"
+
+
 def _read_handoff_text(path: Path) -> str | None:
     try:
         return path.read_text(errors="replace")
@@ -71,8 +86,10 @@ def lint(
             hits = scan_handoff_injection_heuristics(text or "") if text is not None else ()
             guard_item["injection_heuristics"] = [_injection_hit_dict(hit) for hit in hits]
             guard_item["injection_warning_count"] = len([hit for hit in hits if hit.severity == "warning"])
+            guard_item["egress_verdict"] = _egress_verdict(guard_item.get("exit_code"))
+            guard_item["injection_verdict"] = _injection_verdict(hits)
             guard_results.append(guard_item)
-    guard_ok = all(item.get("exit_code") == 0 for item in guard_results)
+    guard_ok = all(item.get("egress_verdict") == OK and item.get("injection_verdict") == OK for item in guard_results)
     injection_counts: dict[str, int] = {}
     injection_hits_by_path: dict[str, tuple[Any, ...]] = {}
     enriched_results: list[HandoffLintResult] = []
@@ -110,7 +127,7 @@ def lint(
         hits = injection_hits_by_path.get(path_key, ())
         row["injection_heuristics"] = [_injection_hit_dict(hit) for hit in hits]
         result_dicts.append(row)
-    payload = {
+    payload: dict[str, Any] = {
         "target": str(target),
         "count": len(results),
         "valid": all(result.valid for result in results) and guard_ok,
@@ -118,6 +135,13 @@ def lint(
         "results": result_dicts,
         "content_guard": guard_results,
     }
+    if content_guard:
+        payload["content_guard_egress"] = (
+            OK if all(item.get("egress_verdict") == OK for item in guard_results) else FAIL
+        )
+        payload["content_guard_injection"] = (
+            OK if all(item.get("injection_verdict") == OK for item in guard_results) else FAIL
+        )
     if json_output:
         print(json.dumps(payload, indent=2, sort_keys=True))
         return 0 if payload["valid"] else 1
@@ -137,14 +161,18 @@ def lint(
             else:
                 print(f"  warning: {warning}")
     if content_guard:
-        print(f"content_guard_policy: {guard_policy} (leak scan + injection heuristics)")
+        print(f"content_guard_policy: {guard_policy} (egress leak scan + injection heuristics)")
         for item in guard_results:
-            leak_status = OK if item.get("exit_code") == 0 else FAIL
-            print(f"[{leak_status}] content_guard leaks: {item.get('path')} {item.get('detail')}")
+            hits = item.get("injection_heuristics") or []
+            egress_status = item.get("egress_verdict", OK)
+            print(f"[{egress_status}] content_guard egress: {item.get('path')} {item.get('detail')}")
+            injection_status = item.get("injection_verdict", OK)
             warning_count = int(item.get("injection_warning_count") or 0)
-            if warning_count:
-                print(f"  warning: {warning_count} injection heuristic hit(s)")
-            for hit in item.get("injection_heuristics") or []:
+            print(
+                f"[{injection_status}] content_guard injection: {item.get('path')} "
+                f"{_injection_detail(warning_count=warning_count)}"
+            )
+            for hit in hits:
                 if hit.get("severity") == "info":
                     print(f"  line {hit['line']}: info: [{hit['rule']}] {hit['excerpt']}")
                 elif hit.get("severity") == "warning":

--- a/tests/test_handoff_injection_lint.py
+++ b/tests/test_handoff_injection_lint.py
@@ -14,6 +14,28 @@ EVIL_FIXTURES = sorted(FIXTURE_DIR.glob("evil-*.md"))
 BENIGN_FIXTURES = sorted(FIXTURE_DIR.glob("benign-*.md"))
 
 
+def _clean_egress_scan(*args, **kwargs):
+    return {
+        "available": True,
+        "status": "ok",
+        "exit_code": 0,
+        "detail": "clean",
+        "stdout": "",
+        "stderr": "",
+    }
+
+
+def _leaky_egress_scan(*args, **kwargs):
+    return {
+        "available": True,
+        "status": "blocked",
+        "exit_code": 1,
+        "detail": "content-guard reported findings",
+        "stdout": "finding in handoff",
+        "stderr": "",
+    }
+
+
 @pytest.mark.parametrize("fixture_path", EVIL_FIXTURES, ids=lambda path: path.name)
 def test_injection_fixture_flags_warning(fixture_path: Path):
     text = fixture_path.read_text()
@@ -31,31 +53,83 @@ def test_benign_injection_fixture_has_no_warnings(fixture_path: Path):
     assert not warnings, f"benign fixture should not warn: {warnings}"
 
 
-def test_handoff_lint_content_guard_reports_injection_with_line_numbers(tmp_path, capsys, monkeypatch):
+def test_handoff_lint_content_guard_fails_on_injection_laden_egress_clean(tmp_path, capsys, monkeypatch):
     evil = FIXTURE_DIR / "evil-ignore-previous.md"
     path = tmp_path / "evil.md"
     path.write_text(evil.read_text())
 
-    def fake_run_scan(scan_target, *, repo_target=None, policy="public-repo"):
-        return {
-            "available": True,
-            "status": "ok",
-            "exit_code": 0,
-            "detail": "clean",
-            "stdout": "",
-            "stderr": "",
-        }
-
-    monkeypatch.setattr("brigade.scrub.run_scan", fake_run_scan)
-    assert handoff_cmd.lint(target=tmp_path, paths=[path], content_guard=True, json_output=True) == 0
+    monkeypatch.setattr("brigade.scrub.run_scan", _clean_egress_scan)
+    assert handoff_cmd.lint(target=tmp_path, paths=[path], content_guard=True, json_output=True) == 1
     payload = json.loads(capsys.readouterr().out)
+    assert payload["valid"] is False
+    assert payload["content_guard_egress"] == "ok"
+    assert payload["content_guard_injection"] == "fail"
     heuristics = payload["results"][0]["injection_heuristics"]
     assert heuristics
     assert any(item["severity"] == "warning" for item in heuristics)
     assert all("line" in item and item["line"] >= 1 for item in heuristics)
     guard = payload["content_guard"][0]
+    assert guard["egress_verdict"] == "ok"
+    assert guard["injection_verdict"] == "fail"
     assert guard["injection_warning_count"] >= 1
     assert guard["injection_heuristics"]
+
+
+def test_handoff_lint_content_guard_fails_on_egress_leaky_injection_free(tmp_path, capsys, monkeypatch):
+    benign = FIXTURE_DIR / "benign-about-injection.md"
+    path = tmp_path / "benign.md"
+    path.write_text(benign.read_text())
+
+    monkeypatch.setattr("brigade.scrub.run_scan", _leaky_egress_scan)
+    assert handoff_cmd.lint(target=tmp_path, paths=[path], content_guard=True, json_output=True) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["valid"] is False
+    assert payload["content_guard_egress"] == "fail"
+    assert payload["content_guard_injection"] == "ok"
+    guard = payload["content_guard"][0]
+    assert guard["egress_verdict"] == "fail"
+    assert guard["injection_verdict"] == "ok"
+    assert guard["exit_code"] == 1
+    assert guard["injection_warning_count"] == 0
+
+
+def test_handoff_lint_content_guard_clean_passes_with_both_axes_named(tmp_path, capsys, monkeypatch):
+    benign = FIXTURE_DIR / "benign-about-injection.md"
+    path = tmp_path / "benign.md"
+    path.write_text(benign.read_text())
+
+    monkeypatch.setattr("brigade.scrub.run_scan", _clean_egress_scan)
+    assert handoff_cmd.lint(target=tmp_path, paths=[path], content_guard=True, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["valid"] is True
+    assert payload["content_guard_egress"] == "ok"
+    assert payload["content_guard_injection"] == "ok"
+    guard = payload["content_guard"][0]
+    assert guard["egress_verdict"] == "ok"
+    assert guard["injection_verdict"] == "ok"
+
+    handoff_cmd.lint(target=tmp_path, paths=[path], content_guard=True)
+    out = capsys.readouterr().out
+    assert "content_guard egress:" in out
+    assert "content_guard injection:" in out
+    assert "[ok] content_guard egress:" in out
+    assert "[ok] content_guard injection:" in out
+
+
+def test_handoff_lint_content_guard_info_only_injection_does_not_fail(tmp_path, capsys, monkeypatch):
+    benign = FIXTURE_DIR / "benign-quoted-payload.md"
+    path = tmp_path / "benign.md"
+    path.write_text(benign.read_text())
+
+    monkeypatch.setattr("brigade.scrub.run_scan", _clean_egress_scan)
+    assert handoff_cmd.lint(target=tmp_path, paths=[path], content_guard=True, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["valid"] is True
+    assert payload["content_guard_injection"] == "ok"
+    guard = payload["content_guard"][0]
+    assert guard["injection_verdict"] == "ok"
+    assert guard["injection_warning_count"] == 0
+    assert any(hit["severity"] == "info" for hit in guard["injection_heuristics"])
 
 
 def test_handoff_lint_content_guard_prints_injection_scope(tmp_path, capsys, monkeypatch):
@@ -63,19 +137,11 @@ def test_handoff_lint_content_guard_prints_injection_scope(tmp_path, capsys, mon
     path = tmp_path / "evil.md"
     path.write_text(evil.read_text())
 
-    monkeypatch.setattr(
-        "brigade.scrub.run_scan",
-        lambda *args, **kwargs: {
-            "available": True,
-            "status": "ok",
-            "exit_code": 0,
-            "detail": "clean",
-            "stdout": "",
-            "stderr": "",
-        },
-    )
+    monkeypatch.setattr("brigade.scrub.run_scan", _clean_egress_scan)
     handoff_cmd.lint(target=tmp_path, paths=[path], content_guard=True)
     out = capsys.readouterr().out
-    assert "leak scan + injection heuristics" in out
+    assert "egress leak scan + injection heuristics" in out
+    assert "[ok] content_guard egress:" in out
+    assert "[fail] content_guard injection:" in out
     assert "line " in out
     assert "disregard-system-prompt" in out or "classic-injection" in out


### PR DESCRIPTION
## Summary

- Make warning-level handoff-injection findings fail `brigade handoff lint --content-guard`.
- Report egress and injection as separate verdicts in text and JSON output.
- Add lint tests for injection-only failure, egress-only failure, a clean two-axis pass, and non-blocking info findings.

## Wiring choice

This uses the in-guard option. `--content-guard` already calls the canonical `scan_handoff_injection_heuristics()` detector, so its combined verdict now fails when either egress or injection fails. Info-only discussion remains non-blocking. No second detector was added.

## Before and after

Before, an egress-clean injection fixture printed warnings but exited 0:

```text
[ok] content_guard leaks: .../evil-ignore-previous.md clean
  warning: 2 injection heuristic hit(s)
exit: 0
```

After, each axis has its own verdict and the command exits 1:

```text
[ok] content_guard egress: .../evil-ignore-previous.md clean
[fail] content_guard injection: .../evil-ignore-previous.md 2 injection warnings
exit: 1
```

The before output is recorded in Brigade receipt `20260726-210033-work-verify-08af8a`.

## Coordination

Issue #490 owns the model_trials adversarial fixture. This PR does not change model_trials or add another fixture corpus. It uses the existing sample under `tests/fixtures/handoff_lint/injection/`.

This is a follow-up to #477 and #515, which added the scanner but left warning-level injection findings outside the command verdict.

Closes #555.

## Verification

- `./scripts/verify`: 4,309 passed, 3 skipped, 82.84% coverage. Brigade receipt `20260726-210442-work-verify-21bcd1`.
- `pytest tests/test_handoff_injection_lint.py -q`: passed. Brigade receipt `20260726-210426-work-verify-98da75`.
- Embedded content guard over all six inert attack fixtures: passed. Brigade receipt `20260726-211101-work-verify-f34c42`.
- Memory handoff lint with `--content-guard`: passed. Brigade receipt `20260726-211138-work-verify-5eb8a7`.