### PR TITLE
feat(work): capture-before-retry enforcement for failed verifies

### DIFF
--- a/src/brigade/config.py
+++ b/src/brigade/config.py
@@ -16,6 +16,8 @@ LEGACY_WORKSPACE_DIRNAMES = (".solo-mise",)
 CONFIG_REL_PATH = f"{WORKSPACE_DIRNAME}/config.json"
 SUPPORTED_VERSIONS = (1,)
 DEFAULT_GRAPHTRAIL_DELTA_TIMEOUT_SECONDS = 10.0
+CAPTURE_BEFORE_RETRY_MODES = ("warn", "block", "off")
+DEFAULT_CAPTURE_BEFORE_RETRY = "warn"
 
 
 @dataclass
@@ -23,6 +25,7 @@ class Config:
     version: int
     selection: Selection
     graphtrail_delta_timeout_seconds: float = DEFAULT_GRAPHTRAIL_DELTA_TIMEOUT_SECONDS
+    capture_before_retry: str = DEFAULT_CAPTURE_BEFORE_RETRY
 
 
 def validate_graphtrail_delta_timeout(value: Any) -> float:
@@ -32,6 +35,22 @@ def validate_graphtrail_delta_timeout(value: Any) -> float:
     if not math.isfinite(timeout) or timeout <= 0:
         raise ValueError("graphtrail_delta_timeout_seconds must be a positive number")
     return timeout
+
+
+def validate_capture_before_retry(value: Any) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"capture_before_retry must be one of: {', '.join(CAPTURE_BEFORE_RETRY_MODES)}")
+    mode = value.strip().lower()
+    if mode not in CAPTURE_BEFORE_RETRY_MODES:
+        raise ValueError(f"capture_before_retry must be one of: {', '.join(CAPTURE_BEFORE_RETRY_MODES)}")
+    return mode
+
+
+def resolve_capture_before_retry(target: Path) -> str:
+    cfg = load_config(target)
+    if cfg is not None:
+        return cfg.capture_before_retry
+    return DEFAULT_CAPTURE_BEFORE_RETRY
 
 
 def resolve_graphtrail_delta_timeout(target: Path, cli_override: float | None = None) -> float:
@@ -64,6 +83,9 @@ def write_config(target: Path, cfg: Config) -> None:
     }
     if graphtrail_timeout != DEFAULT_GRAPHTRAIL_DELTA_TIMEOUT_SECONDS:
         payload["graphtrail_delta_timeout_seconds"] = graphtrail_timeout
+    capture_before_retry = validate_capture_before_retry(cfg.capture_before_retry)
+    if capture_before_retry != DEFAULT_CAPTURE_BEFORE_RETRY:
+        payload["capture_before_retry"] = capture_before_retry
     path.write_text(json.dumps(payload, indent=2) + "\n")
 
 
@@ -90,4 +112,10 @@ def load_config(target: Path) -> Optional[Config]:
     sel.validate()
     timeout_raw = data.get("graphtrail_delta_timeout_seconds", DEFAULT_GRAPHTRAIL_DELTA_TIMEOUT_SECONDS)
     timeout = validate_graphtrail_delta_timeout(timeout_raw)
-    return Config(version=version, selection=sel, graphtrail_delta_timeout_seconds=timeout)
+    capture_before_retry = validate_capture_before_retry(data.get("capture_before_retry", DEFAULT_CAPTURE_BEFORE_RETRY))
+    return Config(
+        version=version,
+        selection=sel,
+        graphtrail_delta_timeout_seconds=timeout,
+        capture_before_retry=capture_before_retry,
+    )

--- a/src/brigade/work_cmd/verification.py
+++ b/src/brigade/work_cmd/verification.py
@@ -344,6 +344,102 @@ def _prune_verify_runs(target: Path, keep: int = VERIFY_RUNS_KEEP) -> int:
     return removed
 
 
+def _normalize_command_identity(command: str | list[str]) -> str:
+    """Canonicalize one command without discarding execution-affecting prefixes."""
+    if isinstance(command, list):
+        return shlex.join(command)
+    try:
+        return shlex.join(shlex.split(command))
+    except ValueError:
+        return command
+
+
+def _planned_commands_display(commands: list[str | list[str]]) -> list[str]:
+    return [shlex.join(command) if isinstance(command, list) else command for command in commands]
+
+
+def _planned_commands_identity(commands: list[str | list[str]]) -> list[str]:
+    return [_normalize_command_identity(command) for command in commands]
+
+
+def _receipt_planned_commands_identity(receipt: dict[str, Any]) -> list[str] | None:
+    """Return normalized command identity from a verify receipt."""
+    planned = receipt.get("planned_commands")
+    if isinstance(planned, list) and all(isinstance(item, str) for item in planned):
+        return [_normalize_command_identity(item) for item in planned]
+    commands = receipt.get("commands")
+    if not isinstance(commands, list):
+        return None
+    display: list[str] = []
+    for command in commands:
+        if isinstance(command, dict):
+            command_text = command.get("command")
+            if isinstance(command_text, str):
+                display.append(_normalize_command_identity(command_text))
+    return display or None
+
+
+def _verify_receipt_evidence_ref(receipt: dict[str, Any]) -> str:
+    path = receipt.get("path")
+    if isinstance(path, str) and path:
+        return str(Path(path) / "receipt.json")
+    run_id = receipt.get("run_id")
+    target = receipt.get("target")
+    if isinstance(run_id, str) and run_id and isinstance(target, str) and target:
+        return str(Path(target) / ".brigade" / "work" / "verify-runs" / run_id / "receipt.json")
+    return ""
+
+
+def _verify_receipt_has_outcome_capture(target: Path, receipt: dict[str, Any]) -> bool:
+    from .. import outcome_cmd
+
+    evidence_ref = _verify_receipt_evidence_ref(receipt)
+    if not evidence_ref:
+        return False
+    resolved = Path(evidence_ref).expanduser().resolve()
+    for record in outcome_cmd.load_records(target):
+        if not record.evidence_ref:
+            continue
+        try:
+            if Path(record.evidence_ref).expanduser().resolve() == resolved:
+                return True
+        except OSError:
+            if record.evidence_ref == evidence_ref:
+                return True
+    return False
+
+
+def _find_uncaptured_failed_verify_receipt(target: Path, planned_identity: list[str]) -> dict[str, Any] | None:
+    for receipt in _verify_receipts(target):
+        if _receipt_planned_commands_identity(receipt) != planned_identity:
+            continue
+        if receipt.get("status") != "failed":
+            return None
+        if _verify_receipt_has_outcome_capture(target, receipt):
+            return None
+        return receipt
+    return None
+
+
+def _capture_before_retry_message(run_id: str) -> str:
+    return f"brigade outcome capture brigade-work --run-id {run_id}"
+
+
+def _enforce_capture_before_retry(target: Path, planned_identity: list[str], *, mode: str) -> int | None:
+    """Block or warn when the latest matching failed receipt has no outcome capture."""
+    if mode == "off":
+        return None
+    failed = _find_uncaptured_failed_verify_receipt(target, planned_identity)
+    if failed is None:
+        return None
+    message = _capture_before_retry_message(str(failed.get("run_id") or ""))
+    if mode == "block":
+        print(f"error: {message}", file=sys.stderr)
+        return 1
+    print(f"warning: {message}", file=sys.stderr)
+    return None
+
+
 def _latest_verify_receipt(target: Path) -> dict[str, Any] | None:
     receipts = _verify_receipts(target)
     return receipts[0] if receipts else None
@@ -568,7 +664,7 @@ def _run_verify_commands(
             "evidence": _verification_evidence_payload(target),
             "commands": [],
             "tree_fingerprint": _tree_fingerprint(target),
-            "planned_commands": [shlex.join(c) if isinstance(c, list) else c for c in commands],
+            "planned_commands": _planned_commands_display(commands),
         }
         _stamp_harness_session(receipt)
         try:
@@ -943,12 +1039,21 @@ def verify_run(
     if not planned:
         print("error: no verification commands found; pass --command", file=sys.stderr)
         return 2
+    planned_display = _planned_commands_display(planned)
+    planned_identity = _planned_commands_identity(planned)
+    try:
+        capture_before_retry = config.resolve_capture_before_retry(target)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    blocked_rc = _enforce_capture_before_retry(target, planned_identity, mode=capture_before_retry)
+    if blocked_rc is not None:
+        return blocked_rc
     try:
         receipt = None
         if reuse:
             fingerprint = _tree_fingerprint(target)
             latest = _latest_verify_receipt(target)
-            planned_display = [shlex.join(c) if isinstance(c, list) else c for c in planned]
             if (
                 fingerprint is not None
                 and latest is not None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -146,3 +146,53 @@ def test_load_config_rejects_invalid_graphtrail_delta_timeout_seconds(tmp_path, 
     )
     with pytest.raises(ValueError, match="graphtrail_delta_timeout_seconds must be a positive number"):
         load_config(tmp_path)
+
+
+def test_load_config_defaults_capture_before_retry(tmp_path):
+    sel = Selection(depth="repo", harnesses=["claude"], owner="claude", includes=[])
+    write_config(tmp_path, Config(version=1, selection=sel))
+    loaded = load_config(tmp_path)
+    assert loaded is not None
+    assert loaded.capture_before_retry == "warn"
+
+
+def test_load_config_reads_capture_before_retry(tmp_path):
+    path = tmp_path / ".brigade" / "config.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "depth": "repo",
+                "harnesses": ["claude"],
+                "owner": "claude",
+                "includes": [],
+                "capture_before_retry": "block",
+            }
+        )
+        + "\n"
+    )
+    loaded = load_config(tmp_path)
+    assert loaded is not None
+    assert loaded.capture_before_retry == "block"
+
+
+@pytest.mark.parametrize("value", ["maybe", 1, True])
+def test_load_config_rejects_invalid_capture_before_retry(tmp_path, value):
+    path = tmp_path / ".brigade" / "config.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "depth": "repo",
+                "harnesses": ["claude"],
+                "owner": "claude",
+                "includes": [],
+                "capture_before_retry": value,
+            }
+        )
+        + "\n"
+    )
+    with pytest.raises(ValueError, match="capture_before_retry must be one of"):
+        load_config(tmp_path)

--- a/tests/test_work_cmd_verification.py
+++ b/tests/test_work_cmd_verification.py
@@ -372,6 +372,139 @@ def test_verify_failed_receipt_not_reused(tmp_target, monkeypatch):
     assert "reused_from" not in receipts[0]
 
 
+def test_verify_warns_before_retrying_uncaptured_failed_command(tmp_target, monkeypatch, capsys):
+    from brigade.work_cmd import verification
+
+    _init_verify_target_with_head(tmp_target)
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(tmp_target / "missing-graphtrail"))
+
+    verification.verify_run(target=tmp_target, commands=["false"], timeout=60)
+    failed = verification._verify_receipts(tmp_target)[0]
+    rc = verification.verify_run(target=tmp_target, commands=["false"], timeout=60)
+    assert rc != 0
+    err = capsys.readouterr().err
+    assert f"warning: brigade outcome capture brigade-work --run-id {failed['run_id']}" in err
+
+
+def test_verify_blocks_before_retrying_uncaptured_failed_command(tmp_target, monkeypatch, capsys):
+    from brigade.work_cmd import verification
+
+    _init_verify_target_with_head(tmp_target)
+    _write_brigade_config(tmp_target, capture_before_retry="block")
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(tmp_target / "missing-graphtrail"))
+
+    verification.verify_run(target=tmp_target, commands=["false"], timeout=60)
+    failed = verification._verify_receipts(tmp_target)[0]
+    before = _count_verify_run_dirs(tmp_target)
+    rc = verification.verify_run(target=tmp_target, commands=["false"], timeout=60)
+    assert rc == 1
+    assert _count_verify_run_dirs(tmp_target) == before
+    err = capsys.readouterr().err
+    assert f"error: brigade outcome capture brigade-work --run-id {failed['run_id']}" in err
+
+
+def test_verify_off_allows_silent_retry_of_uncaptured_failed_command(tmp_target, monkeypatch, capsys):
+    from brigade.work_cmd import verification
+
+    _init_verify_target_with_head(tmp_target)
+    _write_brigade_config(tmp_target, capture_before_retry="off")
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(tmp_target / "missing-graphtrail"))
+
+    verification.verify_run(target=tmp_target, commands=["false"], timeout=60)
+    rc = verification.verify_run(target=tmp_target, commands=["false"], timeout=60)
+    assert rc != 0
+    err = capsys.readouterr().err
+    assert "brigade outcome capture" not in err
+
+
+def test_verify_captured_failed_command_retries_silently(tmp_target, monkeypatch, capsys):
+    from brigade import outcome_cmd
+    from brigade.work_cmd import verification
+
+    _init_verify_target_with_head(tmp_target)
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(tmp_target / "missing-graphtrail"))
+
+    verification.verify_run(target=tmp_target, commands=["false"], timeout=60)
+    failed = verification._verify_receipts(tmp_target)[0]
+    assert outcome_cmd.capture(target=tmp_target, artifact_id="brigade-work", run_id=failed["run_id"]) == 0
+    capsys.readouterr()
+    rc = verification.verify_run(target=tmp_target, commands=["false"], timeout=60)
+    assert rc != 0
+    err = capsys.readouterr().err
+    assert "brigade outcome capture" not in err
+
+
+def test_verify_first_run_and_passed_retry_stay_silent(tmp_target, monkeypatch, capsys):
+    from brigade.work_cmd import verification
+
+    _init_verify_target_with_head(tmp_target)
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(tmp_target / "missing-graphtrail"))
+
+    rc = verification.verify_run(target=tmp_target, commands=["true"], timeout=60)
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "brigade outcome capture" not in err
+
+    rc = verification.verify_run(target=tmp_target, commands=["true"], timeout=60, reuse=False)
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "brigade outcome capture" not in err
+
+
+def test_verify_pass_after_failure_makes_next_retry_silent(tmp_target, monkeypatch, capsys):
+    from brigade.work_cmd import verification
+
+    _init_verify_target_with_head(tmp_target)
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(tmp_target / "missing-graphtrail"))
+    (tmp_target / "check.py").write_text(
+        "from pathlib import Path\n"
+        "marker = Path('passed-once')\n"
+        "if not marker.exists():\n"
+        "    marker.write_text('ready')\n"
+        "    raise SystemExit(1)\n"
+    )
+
+    command = "python3 check.py"
+    assert verification.verify_run(target=tmp_target, commands=[command], timeout=60) != 0
+    assert verification.verify_run(target=tmp_target, commands=[command], timeout=60) == 0
+    capsys.readouterr()
+
+    assert verification.verify_run(target=tmp_target, commands=[command], timeout=60, reuse=False) == 0
+    assert "brigade outcome capture" not in capsys.readouterr().err
+
+
+def test_verify_capture_before_retry_matches_exact_command_identity(tmp_target, monkeypatch, capsys):
+    from brigade.work_cmd import verification
+
+    _init_verify_target_with_head(tmp_target)
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(tmp_target / "missing-graphtrail"))
+
+    verification.verify_run(target=tmp_target, commands=["VAR=1 false"], timeout=60)
+    failed = verification._verify_receipts(tmp_target)[0]
+    rc = verification.verify_run(target=tmp_target, commands=["false"], timeout=60)
+    assert rc != 0
+    err = capsys.readouterr().err
+    assert "brigade outcome capture" not in err
+
+    rc = verification.verify_run(target=tmp_target, commands=["VAR=1 false"], timeout=60)
+    assert rc != 0
+    err = capsys.readouterr().err
+    assert f"warning: brigade outcome capture brigade-work --run-id {failed['run_id']}" in err
+
+
+def test_verify_command_identity_normalizes_whitespace(tmp_target, monkeypatch, capsys):
+    from brigade.work_cmd import verification
+
+    _init_verify_target_with_head(tmp_target)
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(tmp_target / "missing-graphtrail"))
+
+    verification.verify_run(target=tmp_target, commands=["VAR=1  false"], timeout=60)
+    failed = verification._verify_receipts(tmp_target)[0]
+    verification.verify_run(target=tmp_target, commands=["VAR=1 false"], timeout=60)
+    err = capsys.readouterr().err
+    assert f"warning: brigade outcome capture brigade-work --run-id {failed['run_id']}" in err
+
+
 def _init_git_repo_with_fixed_head(path):
     """Init a git repo whose HEAD commit hash is deterministic across calls.
 
@@ -750,7 +883,12 @@ def test_work_verify_receipt_omits_git_state_outside_git_repo(tmp_path, capsys, 
     assert receipt["digests"]["receipt_sha256"] == localio.canonical_json_digest(receipt, exclude_keys={"digests"})
 
 
-def _write_brigade_config(tmp_path, *, graphtrail_delta_timeout_seconds: float | None = None) -> None:
+def _write_brigade_config(
+    tmp_path,
+    *,
+    graphtrail_delta_timeout_seconds: float | None = None,
+    capture_before_retry: str | None = None,
+) -> None:
     payload = {
         "version": 1,
         "depth": "repo",
@@ -760,6 +898,8 @@ def _write_brigade_config(tmp_path, *, graphtrail_delta_timeout_seconds: float |
     }
     if graphtrail_delta_timeout_seconds is not None:
         payload["graphtrail_delta_timeout_seconds"] = graphtrail_delta_timeout_seconds
+    if capture_before_retry is not None:
+        payload["capture_before_retry"] = capture_before_retry
     brigade = tmp_path / ".brigade"
     brigade.mkdir(parents=True, exist_ok=True)
     (brigade / "config.json").write_text(json.dumps(payload, indent=2) + "\n")


### PR DESCRIPTION
## Summary

- Check the latest verify receipt with the same command identity before starting a retry.
- Warn by default when that receipt failed without an outcome capture. The configured `block` mode exits before creating a run, while `off` keeps the prior behavior.
- Print an executable remediation command with the failed receipt ID.

## Command identity

Identity is the ordered command list within one target repository. Each command is normalized with `shlex.split` and `shlex.join`, so whitespace and equivalent quoting do not create a new identity.

Environment assignments inside `--command` remain part of identity because they affect execution. For example, `VAR=1 false` and `false` are different commands. This follows the command handling implicated by #541.

Exact matching does not stop an agent from changing the command string to bypass the check. Fuzzy matching is outside this issue.

## Config

The existing `.brigade/config.json` surface accepts:

```json
{
  "capture_before_retry": "warn"
}
```

Allowed values are `warn`, `block`, and `off`. The default is `warn`, and the default value is omitted when Brigade writes the config.

## Tests

- Failed verify, then the same command: default warning.
- Failed verify in `block` mode: exit 1 without creating a run.
- Captured failed receipt: retry proceeds silently.
- First run and passing reruns: no warning.
- Passing receipt after an earlier failure: later retry remains silent.
- `off` mode: prior behavior.
- Environment prefixes remain part of identity.
- Whitespace is normalized for identity.
- Config default, explicit value, and invalid values.
- Receipt storage remains compatible with #541 after rebasing onto current `main`.

## Verification

Final Brigade receipt: `20260726-210751-work-verify-dfeb03`, exit 0.

```text
./scripts/verify
4319 passed, 3 skipped in 364.17s
Required test coverage of 78% reached. Total coverage: 82.81%
```

Manual scratch-repository demo:

```text
$ .venv/bin/brigade work verify run --target /tmp/brigade-475-demo.a3ayVw --command false
warning: brigade outcome capture brigade-work --run-id 20260726-204615-work-verify-3c7e80
work verify run: /tmp/brigade-475-demo.a3ayVw
run: 20260726-204622-work-verify-8b743c
status: failed
- false [failed] exit=1

$ .venv/bin/brigade outcome capture brigade-work --target /tmp/brigade-475-demo.a3ayVw --run-id 20260726-204622-work-verify-8b743c
outcome capture: brigade-work
source: verify [failed] signal=-1
evidence: /tmp/brigade-475-demo.a3ayVw/.brigade/work/verify-runs/20260726-204622-work-verify-8b743c/receipt.json

$ .venv/bin/brigade work verify run --target /tmp/brigade-475-demo.a3ayVw --command false
work verify run: /tmp/brigade-475-demo.a3ayVw
run: 20260726-204628-work-verify-fe2fc9
status: failed
- false [failed] exit=1
```

The final run starts without a capture warning.

Closes #475.
