### PR TITLE
fix(doctor): scope checks and group actionable output

### DIFF
--- a/src/brigade/doctor.py
+++ b/src/brigade/doctor.py
@@ -9,7 +9,7 @@ import shlex
 import shutil
 from datetime import date, datetime, timezone
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Sequence, Tuple
 
 from .budgets import (
     BOOTSTRAP_BUDGETS,
@@ -20,18 +20,44 @@ from .selection import WRITER_INBOXES
 from .station import DoctorContext
 
 CheckResult = Tuple[str, str, str]  # (status, name, detail)
+ScopedCheckResult = Tuple[str, str, str, str]  # (status, name, detail, scope)
 OK = "OK"
 WARN = "WARN"
 FAIL = "FAIL"
 MANUAL = "MANUAL"
 INFO = "INFO"
-DEFAULT_TEXT_CHECK_LIMIT = 50
+SCOPE_TARGET = "target"
+SCOPE_OPERATOR = "operator"
+ACTIONABLE_STATUSES = frozenset({FAIL, WARN, MANUAL})
 ADAPTER_CHECK_PREFIX = "adapter: "
 
 
 def _adapter_check_name(name: str) -> str:
     """Label Brigade adapter/projection checks distinctly from native harness checks."""
     return f"{ADAPTER_CHECK_PREFIX}{name}"
+
+
+def _scoped_check(status: str, name: str, detail: str, scope: str = SCOPE_TARGET) -> ScopedCheckResult:
+    return (status, name, detail, scope)
+
+
+def _operator_check(status: str, name: str, detail: str) -> ScopedCheckResult:
+    return _scoped_check(status, name, detail, SCOPE_OPERATOR)
+
+
+def _normalize_scoped_check(
+    check: CheckResult | ScopedCheckResult,
+    *,
+    default_scope: str = SCOPE_TARGET,
+) -> ScopedCheckResult:
+    if len(check) == 4:
+        return check  # type: ignore[return-value]
+    status, name, detail = check
+    return _scoped_check(status, name, detail, default_scope)
+
+
+def _check_scope(check: CheckResult | ScopedCheckResult) -> str:
+    return check[3] if len(check) == 4 else SCOPE_TARGET
 
 
 def build_context(target: Path, harness: str = "generic") -> DoctorContext:
@@ -62,7 +88,7 @@ def core_station_checks(ctx: DoctorContext) -> List[CheckResult]:
         if check is not None:
             checks.append(check)
     if "openclaw" in ctx.harnesses:
-        checks.extend(_check_openclaw())
+        checks.extend(_operator_check(status, name, detail) for status, name, detail in _check_openclaw())
     if "hermes" in ctx.harnesses:
         checks.extend(_check_hermes(ctx.target))
     checks.extend(_check_orphan_inboxes(ctx.target, ctx.harnesses))
@@ -255,35 +281,40 @@ def run(
     return _report(checks, full=full, target=ctx.target, operator=operator)
 
 
-def _gather_checks(ctx: DoctorContext) -> List[CheckResult]:
+def _gather_checks(ctx: DoctorContext) -> List[ScopedCheckResult]:
     from . import component_report
     from .registry import all_stations
     from . import managed
 
-    checks: List[CheckResult] = []
-    checks.extend(component_report.doctor_checks())
+    checks: List[ScopedCheckResult] = []
+    for status, name, detail in component_report.doctor_checks():
+        checks.append(_operator_check(status, name, detail))
     missing_tools: List[Tuple[str, str]] = []
     for station in all_stations():
         if station.doctor is not None:
-            checks.extend(station.doctor(ctx))
+            for check in station.doctor(ctx):
+                checks.append(_normalize_scoped_check(check))
         for tool in managed.for_station(station.name):
             if tool.detect():
-                checks.extend(tool.doctor(ctx))
+                for check in tool.doctor(ctx):
+                    checks.append(_operator_check(check[0], check[1], check[2]))
             else:
                 missing_tools.append((station.name, tool.name))
     if len(missing_tools) == 1:
         station_name, tool_name = missing_tools[0]
-        checks.append((MANUAL, f"{station_name}: {tool_name}", f"not installed; run `brigade add {station_name}`"))
+        checks.append(
+            _operator_check(MANUAL, f"{station_name}: {tool_name}", f"not installed; run `brigade add {station_name}`")
+        )
     elif missing_tools:
         stations = sorted({station for station, _ in missing_tools})
         checks.append(
-            (
+            _operator_check(
                 MANUAL,
                 "managed tools",
                 f"{len(missing_tools)} managed tools not installed ({', '.join(stations)}); optional, install with `brigade add <station>`",
             )
         )
-    checks.append(_check_receipts(ctx.target))
+    checks.append(_normalize_scoped_check(_check_receipts(ctx.target)))
     return checks
 
 
@@ -813,9 +844,13 @@ def _check_publish_gate(target: Path) -> List[CheckResult]:
     scanner_dir = scrub.scanner_dir()
     if scanner_dir.is_dir():
         label = "external compatibility override" if os.environ.get("CONTENT_GUARD_DIR") else "embedded content guard"
-        results.append((OK, "guard: embedded content guard", f"{label}: {scanner_dir}"))
+        results.append(_operator_check(OK, "guard: embedded content guard", f"{label}: {scanner_dir}"))
     else:
-        results.append((MANUAL, "guard: embedded content guard", f"not found at {scanner_dir}; reinstall brigade-cli"))
+        results.append(
+            _operator_check(
+                MANUAL, "guard: embedded content guard", f"not found at {scanner_dir}; reinstall brigade-cli"
+            )
+        )
     return results
 
 
@@ -968,58 +1003,28 @@ _MARKERS = {
     INFO: "  [info]",
 }
 
-# Checks about host-global / operator state rather than the --target workspace.
-# Hidden by default (#478); pass --operator to include them in the report.
-_OPERATOR_SCOPED_PREFIXES = (
-    "openclaw:",
-    "components:",
-    "bootstrap-doctor",
-    "agentpantry",
-    "miseledger",
-    "usage-tracker",
-    "code-search-api",
-    "code-search-mcp",
-    "token-glace",
-    "agent-notify",
-    "plating",
-)
-_OPERATOR_SCOPED_EXACT = {"guard: embedded content guard", "managed tools"}
-_MANAGED_OPERATOR_TOOL_SLUGS = {
-    "bootstrap-doctor",
-    "token-glace",
-    "code-search-api",
-    "code-search-mcp",
-    "agentpantry",
-    "agent-notify",
-    "miseledger",
-    "usage-tracker",
-    "plating",
+_SEVERITY_ORDER = (FAIL, WARN, MANUAL, INFO, OK)
+_SEVERITY_GROUP_LABELS = {
+    FAIL: "failures:",
+    WARN: "warnings:",
+    MANUAL: "manual actions:",
+    INFO: "info:",
+    OK: "ok:",
 }
+_OPERATOR_SECTION_HEADER = "operator/host (not specific to this target):"
 
 
-def _is_operator_scoped(name: str) -> bool:
-    if name in _OPERATOR_SCOPED_EXACT:
-        return True
-    if name.startswith(_OPERATOR_SCOPED_PREFIXES):
-        return True
-    if ": " in name:
-        _, rhs = name.split(": ", 1)
-        slug = rhs.split()[0]
-        if slug in _MANAGED_OPERATOR_TOOL_SLUGS:
-            return True
-    return False
-
-
-def _filter_target_scoped_checks(checks: List[CheckResult]) -> List[CheckResult]:
-    return [check for check in checks if not _is_operator_scoped(check[1])]
+def _filter_target_scoped_checks(checks: List[ScopedCheckResult]) -> List[ScopedCheckResult]:
+    return [check for check in checks if _check_scope(check) == SCOPE_TARGET]
 
 
 def _target_detail_prefix(target: Path) -> str:
     return f"target={target}: "
 
 
-def _annotate_target_detail(target: Path, name: str, detail: str) -> str:
-    if _is_operator_scoped(name):
+def _annotate_target_detail(target: Path, check: CheckResult | ScopedCheckResult) -> str:
+    status, name, detail, scope = _normalize_scoped_check(check)
+    if scope == SCOPE_OPERATOR:
         return detail
     prefix = _target_detail_prefix(target)
     if detail.startswith(prefix) or detail.startswith(str(target)):
@@ -1027,53 +1032,78 @@ def _annotate_target_detail(target: Path, name: str, detail: str) -> str:
     return f"{prefix}{detail}"
 
 
-def _report(checks: List[CheckResult], *, full: bool = True, target: Path | None = None, operator: bool = False) -> int:
-    width = max((len(name) for _, name, _ in checks), default=20)
-    counts = _status_counts(checks)
+def _report(
+    checks: Sequence[CheckResult | ScopedCheckResult],
+    *,
+    full: bool = True,
+    target: Path | None = None,
+    operator: bool = False,
+) -> int:
+    scoped_checks = [_normalize_scoped_check(check) for check in checks]
+    width = max((len(check[1]) for check in scoped_checks), default=20)
+    counts = _status_counts(scoped_checks)
     print(
-        f"triage: {len(checks)} checks, {counts[OK]} ok, {counts[WARN]} warn, "
+        f"triage: {len(scoped_checks)} checks, {counts[OK]} ok, {counts[WARN]} warn, "
         f"{counts[FAIL]} failed, {counts[MANUAL]} manual, {counts[INFO]} info"
     )
 
-    condensed = not full and len(checks) > DEFAULT_TEXT_CHECK_LIMIT
-    visible_checks = [check for check in checks if check[0] in {FAIL, WARN, MANUAL}] if condensed else checks
-    target_checks = [check for check in visible_checks if not _is_operator_scoped(check[1])]
-    operator_checks = [check for check in visible_checks if _is_operator_scoped(check[1])]
+    visible_statuses = set(_SEVERITY_ORDER) if full else ACTIONABLE_STATUSES
+    visible_checks = [check for check in scoped_checks if check[0] in visible_statuses]
+    target_checks = [check for check in visible_checks if _check_scope(check) == SCOPE_TARGET]
+    operator_checks = [check for check in visible_checks if _check_scope(check) == SCOPE_OPERATOR]
+    hidden_detail = not full and any(check[0] not in ACTIONABLE_STATUSES for check in scoped_checks)
 
-    def _emit(items: List[CheckResult]) -> None:
-        for status, name, detail in items:
+    def _emit(items: List[ScopedCheckResult]) -> None:
+        for status, name, detail, scope in items:
+            annotated_detail = detail
             if target is not None:
-                detail = _annotate_target_detail(target, name, detail)
-            print(f"{_MARKERS[status]} {name.ljust(width)}  {detail}")
+                annotated_detail = _annotate_target_detail(target, (status, name, detail, scope))
+            print(f"{_MARKERS[status]} {name.ljust(width)}  {annotated_detail}")
+
+    def _emit_grouped(items: List[ScopedCheckResult]) -> bool:
+        emitted = False
+        for status in _SEVERITY_ORDER:
+            if status not in visible_statuses:
+                continue
+            group = [check for check in items if check[0] == status]
+            if not group:
+                continue
+            emitted = True
+            print(_SEVERITY_GROUP_LABELS[status])
+            _emit(group)
+        return emitted
 
     print()
     if visible_checks:
-        _emit(target_checks)
+        if not _emit_grouped(target_checks):
+            print("  no failures, warnings, or manual actions")
     else:
         print("  no failures, warnings, or manual actions")
     if operator and operator_checks:
         print()
-        print("operator/host (not specific to this target):")
-        _emit(operator_checks)
+        print(_OPERATOR_SECTION_HEADER)
+        _emit_grouped(operator_checks)
 
-    if condensed:
+    if hidden_detail:
         print()
         print(f"showing {len(visible_checks)} actionable checks; run `brigade doctor --full` to show all checks")
 
     print()
-    print(f"summary: {len(checks)} checks, {counts[FAIL]} failed, {counts[MANUAL]} manual")
+    print(f"summary: {len(scoped_checks)} checks, {counts[FAIL]} failed, {counts[MANUAL]} manual")
     return 1 if counts[FAIL] else 0
 
 
-def _status_counts(checks: List[CheckResult]) -> dict[str, int]:
+def _status_counts(checks: List[CheckResult | ScopedCheckResult]) -> dict[str, int]:
     counts = {OK: 0, WARN: 0, FAIL: 0, MANUAL: 0, INFO: 0}
-    for status, _, _ in checks:
+    for check in checks:
+        status = check[0]
         counts[status] = counts.get(status, 0) + 1
     return counts
 
 
-def _report_json(ctx: DoctorContext, checks: List[CheckResult], *, operator: bool = False) -> int:
-    counts = _status_counts(checks)
+def _report_json(ctx: DoctorContext, checks: List[CheckResult | ScopedCheckResult], *, operator: bool = False) -> int:
+    scoped_checks = [_normalize_scoped_check(check) for check in checks]
+    counts = _status_counts(scoped_checks)
     sel = ctx.selection
     payload = {
         "target": str(ctx.target),
@@ -1085,13 +1115,13 @@ def _report_json(ctx: DoctorContext, checks: List[CheckResult], *, operator: boo
             {
                 "status": status,
                 "name": name,
-                "detail": _annotate_target_detail(ctx.target, name, detail),
-                "scope": "operator" if _is_operator_scoped(name) else "target",
+                "detail": _annotate_target_detail(ctx.target, (status, name, detail, scope)),
+                "scope": scope,
             }
-            for status, name, detail in checks
+            for status, name, detail, scope in scoped_checks
         ],
         "summary": {
-            "total": len(checks),
+            "total": len(scoped_checks),
             "ok": counts[OK],
             "warn": counts[WARN],
             "manual": counts[MANUAL],

--- a/src/brigade/status.py
+++ b/src/brigade/status.py
@@ -51,7 +51,7 @@ def _normalize_payload_health(raw: object, *, installed: bool | None) -> str:
 
 
 def _health_from_checks(checks: list[_doctor.CheckResult]) -> str:
-    levels = {status for status, _name, _detail in checks}
+    levels = {check[0] for check in checks}
     if _doctor.FAIL in levels:
         return "failed"
     if _doctor.WARN in levels:
@@ -105,9 +105,9 @@ def run(target: Path, *, json_output: bool = False) -> int:
             summary = str(payload.get("summary") or station.summary)
         else:
             checks = station.doctor(ctx) if station.doctor else []
-            ok = sum(1 for s, _, _ in checks if s == _doctor.OK)
-            warn = sum(1 for s, _, _ in checks if s == _doctor.WARN)
-            fail = sum(1 for s, _, _ in checks if s == _doctor.FAIL)
+            ok = sum(1 for check in checks if check[0] == _doctor.OK)
+            warn = sum(1 for check in checks if check[0] == _doctor.WARN)
+            fail = sum(1 for check in checks if check[0] == _doctor.FAIL)
             health = _health_from_checks(checks)
             summary = station.summary
         rows.append(

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -93,10 +93,27 @@ def test_doctor_triages_long_output_by_default(tmp_target: Path, capsys, monkeyp
     assert doctor_mod.run(target=tmp_target) == 1
     out = capsys.readouterr().out
     assert "triage: 51 checks, 48 ok, 1 warn, 1 failed, 1 manual, 0 info" in out
+    assert "failures:" in out
+    assert "warnings:" in out
+    assert "manual actions:" in out
+    assert out.index("failures:") < out.index("warnings:") < out.index("manual actions:")
     assert "warning-check" in out
     assert "failed-check" in out
     assert "manual-check" in out
     assert "check-0" not in out
+    assert "run `brigade doctor --full` to show all checks" in out
+
+
+def test_doctor_default_hides_ok_even_below_condensation_threshold(tmp_target: Path, capsys, monkeypatch):
+    checks = [(doctor_mod.OK, f"check-{index}", "ready") for index in range(10)]
+    checks.append((doctor_mod.WARN, "warning-check", "needs attention"))
+    monkeypatch.setattr(doctor_mod, "_gather_checks", lambda _ctx: checks)
+
+    doctor_mod.run(target=tmp_target)
+    out = capsys.readouterr().out
+    assert "check-0" not in out
+    assert "warning-check" in out
+    assert "warnings:" in out
     assert "run `brigade doctor --full` to show all checks" in out
 
 
@@ -106,6 +123,7 @@ def test_doctor_full_preserves_exhaustive_text_output(tmp_target: Path, capsys, 
 
     assert doctor_mod.run(target=tmp_target, full=True) == 0
     out = capsys.readouterr().out
+    assert "ok:" in out
     assert "check-0" in out
     assert "check-50" in out
     assert "brigade doctor --full" not in out
@@ -116,6 +134,7 @@ def test_doctor_shared_reporter_is_exhaustive_by_default(capsys):
 
     assert doctor_mod._report(checks) == 0
     out = capsys.readouterr().out
+    assert "ok:" in out
     assert "shared-check-0" in out
     assert "shared-check-50" in out
     assert "brigade doctor --full" not in out
@@ -200,6 +219,65 @@ def test_doctor_json_tags_operator_scope_when_requested(tmp_target: Path, capsys
     scopes = {c["name"]: c["scope"] for c in payload["checks"]}
     assert scopes.get("guard: embedded content guard") == "operator"
     assert any(scope == "target" for scope in scopes.values())
+
+
+def test_doctor_first_contact_condenses_actionable_target_checks(tmp_target: Path, capsys):
+    install_selection(
+        tmp_target,
+        Selection(depth="workspace", harnesses=["claude"], owner="claude", includes=[]),
+    )
+    capsys.readouterr()
+    rc = doctor_mod.run(target=tmp_target, harness="generic", json_output=True)
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["summary"]["total"] >= 40
+    assert rc == (0 if payload["ready"] else 1)
+
+    capsys.readouterr()
+    doctor_mod.run(target=tmp_target, harness="generic")
+    out = capsys.readouterr().out
+    assert "[ok]" not in out
+    assert "ok:" not in out
+    assert "run `brigade doctor --full` to show all checks" in out
+
+
+def test_doctor_selected_scope_counts_and_exit_unchanged(tmp_target: Path, capsys):
+    install_selection(
+        tmp_target,
+        Selection(depth="workspace", harnesses=["claude"], owner="claude", includes=[]),
+    )
+    capsys.readouterr()
+    rc_default = doctor_mod.run(target=tmp_target, harness="generic", json_output=True)
+    default_payload = json.loads(capsys.readouterr().out)
+    capsys.readouterr()
+    rc_operator = doctor_mod.run(target=tmp_target, harness="generic", json_output=True, operator=True)
+    operator_payload = json.loads(capsys.readouterr().out)
+
+    assert default_payload["summary"]["total"] < operator_payload["summary"]["total"]
+    assert all(check["scope"] == "target" for check in default_payload["checks"])
+    assert any(check["scope"] == "operator" for check in operator_payload["checks"])
+    assert rc_default == (0 if default_payload["summary"]["failed"] == 0 else 1)
+    assert rc_operator == (0 if operator_payload["summary"]["failed"] == 0 else 1)
+
+
+def test_doctor_explicit_operator_scope_not_name_inferred(tmp_target: Path, capsys, monkeypatch):
+    from brigade import component_report
+
+    marker = "ISSUE556_EXPLICIT_SCOPE_MARKER"
+
+    def fake_component_checks(**kwargs):
+        return [(doctor_mod.OK, "target-looking-name", marker)]
+
+    install_selection(
+        tmp_target,
+        Selection(depth="workspace", harnesses=["claude"], owner="claude", includes=[]),
+    )
+    monkeypatch.setattr(component_report, "doctor_checks", fake_component_checks)
+    capsys.readouterr()
+    doctor_mod.run(target=tmp_target, harness="generic", json_output=True, operator=True)
+    payload = json.loads(capsys.readouterr().out)
+    host_check = next(check for check in payload["checks"] if check["name"] == "target-looking-name")
+    assert host_check["scope"] == "operator"
+    assert marker in host_check["detail"]
 
 
 def test_doctor_json_omits_operator_checks_by_default(tmp_target: Path, capsys, monkeypatch):


### PR DESCRIPTION
## Summary

- Carry explicit `target` or `operator` scope with every check after doctor aggregation.
- Remove scope inference based on check names.
- Show only FAIL, WARN, and MANUAL target findings by default, grouped under severity labels.
- Keep `--operator` for host findings and `--full` for OK and INFO detail.
- Preserve legacy three-field station checks and make `brigade status` accept optional scope metadata.

Closes #556.

## Scratch workspace reproduction

The same initialized scratch workspace was checked against current `main` and this branch on a host with operator state.

### Before

Current `main` printed 51 lines with 44 visible target checks because the old condensation threshold was 50:

```console
$ brigade doctor --target <scratch-workspace>
brigade doctor: target <scratch-workspace>
  scope: target workspace only (pass --operator for host-global checks)
triage: 44 checks, 31 ok, 10 warn, 0 failed, 2 manual, 1 info

  [ok]   ...
  [warn] ...
  ...
summary: 44 checks, 0 failed, 2 manual
```

### After

The default report is 16 lines with six actionable target findings:

```console
$ brigade doctor --target <scratch-workspace>
brigade doctor: target <scratch-workspace>
  scope: target workspace only (pass --operator for host-global checks)
triage: 43 checks, 36 ok, 6 warn, 0 failed, 0 manual, 1 info

warnings:
  [warn] bootstrap: CLAUDE.md
  [warn] memory-care: scan-latest
  [warn] memory-care: refresh-queue
  [warn] security: config
  [warn] security: evidence bundle
  [warn] security: evidence ignored

showing 6 actionable checks; run `brigade doctor --full` to show all checks

summary: 43 checks, 0 failed, 0 manual
```

`--operator --json` reports 43 target checks and nine operator checks. Text output places the visible host findings under:

```console
operator/host (not specific to this target):
warnings:
  [warn] graphtrail (code graph) ...
manual actions:
  [todo] components: graphtrail ...
  [todo] components: graphtrail-mcp ...
  [todo] components: miseledger ...
  [todo] components: sessionfind ...
  [todo] managed tools ...
```

## Verification

```console
$ brigade work verify run --target . --command "./scripts/verify" --capture brigade-work
run: 20260726-212344-work-verify-ff41e0
status: completed
commands: 1
- ./scripts/verify [completed] exit=0
```

The full gate passed 4,355 tests with three expected skips and 82.82% coverage.
