### PR TITLE
feat(receipts): bind receipts to patch identity

### DIFF
--- a/src/brigade/work_cmd/verification.py
+++ b/src/brigade/work_cmd/verification.py
@@ -10,10 +10,11 @@ import shlex
 import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
-from .. import config, graphtrail_delta, localio, proc, receipt_signing
+from .. import config, graphtrail_delta, localio, proc, receipt_signing, runguard
 from . import constants, helpers, ledger as ledger_mod
 from . import reviews as reviews_mod
 from . import scanners as scanners_mod
@@ -132,6 +133,7 @@ def _verify_execution_argv(argv: list[str], target: Path) -> list[str]:
 _VERIFY_CANCELED_RC = 130
 _VERIFY_INTERRUPTED_COMMAND_STATUS = "interrupted"
 _VERIFY_CANCELED_RECEIPT_STATUS = "canceled"
+_VERIFY_RECEIPT_SCHEMA_VERSION = 2
 
 
 def _verify_child_popen_kwargs() -> dict[str, Any]:
@@ -576,9 +578,16 @@ def _write_verify_markdown(run_dir: Path, receipt: dict[str, Any]) -> None:
         f"- Started: {receipt.get('started_at')}",
         f"- Completed: {receipt.get('completed_at')}",
         "",
-        "## Commands",
-        "",
     ]
+    lines.extend(_verify_identity_lines(receipt))
+    if lines[-1] != "":
+        lines.append("")
+    lines.extend(
+        [
+            "## Commands",
+            "",
+        ]
+    )
     for command in receipt.get("commands", []):
         if not isinstance(command, dict):
             continue
@@ -597,10 +606,56 @@ def _write_verify_markdown(run_dir: Path, receipt: dict[str, Any]) -> None:
     (run_dir / "summary.md").write_text("\n".join(lines) + "\n")
 
 
-def _fingerprint_segment(hasher, label: str, data: bytes) -> None:
-    encoded_label = label.encode()
-    hasher.update(str(len(encoded_label)).encode() + b":" + encoded_label)
-    hasher.update(str(len(data)).encode() + b":" + data)
+def _verify_identity_binding(receipt: dict[str, Any]) -> str | None:
+    baseline = receipt.get("baseline_commit")
+    fingerprint = receipt.get("tree_fingerprint")
+    patch_hash = receipt.get("changes_patch_sha256")
+    if not isinstance(baseline, str) or not baseline:
+        return None
+    if not isinstance(fingerprint, str) or not fingerprint:
+        return None
+    if not isinstance(patch_hash, str) or not patch_hash:
+        return None
+    return f"verified tree {fingerprint} = baseline {baseline} + patch {patch_hash}"
+
+
+def _verify_identity_lines(receipt: dict[str, Any]) -> list[str]:
+    baseline = receipt.get("baseline_commit")
+    fingerprint = receipt.get("tree_fingerprint")
+    patch_hash = receipt.get("changes_patch_sha256")
+    if not isinstance(baseline, str) or not baseline:
+        return []
+    if not isinstance(fingerprint, str) or not fingerprint:
+        return []
+    if not isinstance(patch_hash, str) or not patch_hash:
+        return []
+    binding = _verify_identity_binding(receipt)
+    assert binding is not None
+    return [
+        f"- Baseline commit: `{baseline}`",
+        f"- Tree fingerprint: `{fingerprint}`",
+        f"- Patch hash: `{patch_hash}`",
+        f"- {binding}",
+    ]
+
+
+def _git_with_index(target: Path, index_file: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, "GIT_INDEX_FILE": str(index_file)}
+    try:
+        return subprocess.run(
+            ["git", "-C", str(target), *args],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            stdin=subprocess.DEVNULL,
+            timeout=30,
+            env=env,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return subprocess.CompletedProcess(exc.cmd, 124, stdout="", stderr=f"git timed out after {exc.timeout:g}s")
+    except OSError:
+        return subprocess.CompletedProcess(["git"], 127, stdout="", stderr="git unavailable")
 
 
 def _stamp_harness_session(receipt: dict[str, Any]) -> None:
@@ -611,30 +666,55 @@ def _stamp_harness_session(receipt: dict[str, Any]) -> None:
 
 
 def _tree_fingerprint(target: Path) -> str | None:
-    """Content hash of HEAD + tracked diff + untracked files. None outside git."""
+    """Git tree object for HEAD plus tracked and non-ignored untracked files."""
     try:
-        head = helpers._git(target, "rev-parse", "HEAD")
-        if head.returncode != 0:
-            return None
-        diff = helpers._git(target, "diff", "HEAD")
-        untracked = helpers._git(target, "ls-files", "--others", "--exclude-standard")
-        if diff.returncode != 0 or untracked.returncode != 0:
-            return None
+        with tempfile.TemporaryDirectory() as tmpdir:
+            index_file = Path(tmpdir) / "index"
+            read_tree = _git_with_index(target, index_file, "read-tree", "HEAD")
+            if read_tree.returncode != 0:
+                return None
+            add_all = _git_with_index(target, index_file, "add", "-A")
+            if add_all.returncode != 0:
+                return None
+            write_tree = _git_with_index(target, index_file, "write-tree")
+            if write_tree.returncode != 0:
+                return None
+            value = write_tree.stdout.strip()
+            return value or None
     except OSError:
-        # helpers._git only catches TimeoutExpired; a missing git binary (e.g. a
-        # test that restricts PATH) raises FileNotFoundError, an OSError subclass.
         return None
-    hasher = hashlib.sha256()
-    _fingerprint_segment(hasher, "head", head.stdout.encode())
-    _fingerprint_segment(hasher, "diff", diff.stdout.encode())
-    for name in sorted(untracked.stdout.splitlines()):
-        path = target / name
-        try:
-            data = path.read_bytes()
-        except OSError:
-            return None
-        _fingerprint_segment(hasher, f"untracked:{name}", data)
-    return hasher.hexdigest()
+
+
+def _capture_verify_identity(target: Path, run_dir: Path) -> dict[str, Any]:
+    unavailable: dict[str, Any] = {
+        "schema_version": _VERIFY_RECEIPT_SCHEMA_VERSION,
+        "baseline_commit": None,
+        "tree_fingerprint": None,
+        "changes_patch_sha256": None,
+    }
+    patch_path = run_dir / "changes.patch"
+    try:
+        baseline_commit = helpers._git_value(target, "rev-parse", "HEAD")
+        tree_fingerprint = _tree_fingerprint(target)
+        if baseline_commit is None or tree_fingerprint is None:
+            return unavailable
+        runguard.collect_changes_patch(target, patch_path)
+        patch_bytes = patch_path.read_bytes()
+        if (
+            helpers._git_value(target, "rev-parse", "HEAD") != baseline_commit
+            or _tree_fingerprint(target) != tree_fingerprint
+        ):
+            patch_path.unlink(missing_ok=True)
+            return unavailable
+    except (OSError, runguard.RunGuardError):
+        patch_path.unlink(missing_ok=True)
+        return unavailable
+    return {
+        "schema_version": _VERIFY_RECEIPT_SCHEMA_VERSION,
+        "baseline_commit": baseline_commit,
+        "tree_fingerprint": tree_fingerprint,
+        "changes_patch_sha256": hashlib.sha256(patch_bytes).hexdigest(),
+    }
 
 
 def _run_verify_commands(
@@ -654,6 +734,7 @@ def _run_verify_commands(
     finalized = False
     try:
         run_dir.mkdir(parents=True, exist_ok=False)
+        identity = _capture_verify_identity(target, run_dir)
         receipt = {
             "run_id": run_id,
             "target": str(target),
@@ -663,9 +744,9 @@ def _run_verify_commands(
             "path": str(run_dir),
             "evidence": _verification_evidence_payload(target),
             "commands": [],
-            "tree_fingerprint": _tree_fingerprint(target),
             "planned_commands": _planned_commands_display(commands),
         }
+        receipt.update(identity)
         _stamp_harness_session(receipt)
         try:
             graph_delta_before = graphtrail_delta.capture_before(target, run_dir, timeout=graphtrail_timeout)
@@ -796,7 +877,6 @@ def _run_verify_commands(
 def _write_reused_receipt(
     target: Path,
     latest: dict[str, Any],
-    fingerprint: str | None,
     planned_display: list[str],
     timeout: int,
 ) -> tuple[dict[str, Any], int]:
@@ -805,6 +885,7 @@ def _write_reused_receipt(
     run_id = f"{started.strftime('%Y%m%d-%H%M%S')}-work-verify-{uuid4().hex[:6]}"
     run_dir = helpers._verify_runs_root(target) / run_id
     run_dir.mkdir(parents=True, exist_ok=False)
+    identity = _capture_verify_identity(target, run_dir)
     completed_at = helpers._now()
     receipt: dict[str, Any] = {
         "run_id": run_id,
@@ -817,9 +898,9 @@ def _write_reused_receipt(
         "path": str(run_dir),
         "commands": copy.deepcopy(latest.get("commands", [])),
         "reused_from": latest.get("run_id"),
-        "tree_fingerprint": fingerprint,
         "planned_commands": planned_display,
     }
+    receipt.update(identity)
     _stamp_harness_session(receipt)
     git = _receipt_git_snapshot(target)
     if git is not None:
@@ -1082,7 +1163,7 @@ def verify_run(
                 and latest.get("tree_fingerprint") == fingerprint
                 and latest.get("planned_commands") == planned_display
             ):
-                receipt, rc = _write_reused_receipt(target, latest, fingerprint, planned_display, timeout)
+                receipt, rc = _write_reused_receipt(target, latest, planned_display, timeout)
         if receipt is None:
             receipt, rc = _run_verify_commands(
                 target, planned, timeout, graphtrail_timeout=effective_graphtrail_timeout
@@ -1175,6 +1256,23 @@ def verify_show(*, target: Path, run_id: str, json_output: bool = False) -> int:
     print(f"target: {run.get('target')}")
     print(f"started: {run.get('started_at')}")
     print(f"completed: {run.get('completed_at')}")
+    baseline = run.get("baseline_commit")
+    fingerprint = run.get("tree_fingerprint")
+    patch_hash = run.get("changes_patch_sha256")
+    if (
+        isinstance(baseline, str)
+        and baseline
+        and isinstance(fingerprint, str)
+        and fingerprint
+        and isinstance(patch_hash, str)
+        and patch_hash
+    ):
+        print(f"baseline commit: {baseline}")
+        print(f"tree fingerprint: {fingerprint}")
+        print(f"patch hash: {patch_hash}")
+        binding = _verify_identity_binding(run)
+        if binding:
+            print(binding)
     for command in run.get("commands", []):
         if isinstance(command, dict):
             print(f"- {command.get('command')} [{command.get('status')}] exit={command.get('exit_code')}")

--- a/tests/test_work_cmd_verification.py
+++ b/tests/test_work_cmd_verification.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import os
 import shlex
@@ -2047,3 +2048,222 @@ def test_tree_fingerprint_distinguishes_tracked_binary_changes(tmp_path):
     assert fp_a is not None
     assert fp_b is not None
     assert fp_a != fp_b
+
+
+EMPTY_PATCH_SHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+
+def _run_verify_with_graphtrail_disabled(target, monkeypatch, *, commands=None, reuse=True):
+    from brigade.work_cmd import verification
+
+    monkeypatch.setenv("GRAPHTRAIL_BIN", str(target / "missing-graphtrail"))
+    return verification.verify_run(
+        target=target,
+        commands=commands or ["true"],
+        timeout=60,
+        reuse=reuse,
+        json_output=True,
+    )
+
+
+def test_verify_receipt_identity_same_tree_twice(tmp_target, monkeypatch, capsys):
+    _init_verify_target_with_head(tmp_target)
+    assert _run_verify_with_graphtrail_disabled(tmp_target, monkeypatch) == 0
+    first = json.loads(capsys.readouterr().out)
+    assert _run_verify_with_graphtrail_disabled(tmp_target, monkeypatch) == 0
+    second = json.loads(capsys.readouterr().out)
+    assert first["tree_fingerprint"] == second["tree_fingerprint"]
+    assert first["baseline_commit"] == second["baseline_commit"]
+    assert first["changes_patch_sha256"] == second["changes_patch_sha256"]
+
+
+def test_verify_receipt_identity_changed_file_differs(tmp_target, monkeypatch, capsys):
+    _init_verify_target_with_head(tmp_target)
+    assert _run_verify_with_graphtrail_disabled(tmp_target, monkeypatch) == 0
+    clean = json.loads(capsys.readouterr().out)
+    (tmp_target / "tracked.txt").write_text("changed\n")
+    assert _run_verify_with_graphtrail_disabled(tmp_target, monkeypatch, reuse=False) == 0
+    dirty = json.loads(capsys.readouterr().out)
+    assert dirty["tree_fingerprint"] != clean["tree_fingerprint"]
+    assert dirty["baseline_commit"] == clean["baseline_commit"]
+    assert dirty["changes_patch_sha256"] != clean["changes_patch_sha256"]
+
+
+def test_verify_receipt_identity_ignores_gitignored_untracked(tmp_target, monkeypatch, capsys):
+    _init_verify_target_with_head(tmp_target)
+    (tmp_target / ".gitignore").write_text(".brigade/\nignored.txt\n")
+    subprocess.run(["git", "add", ".gitignore"], cwd=tmp_target, check=True, stdout=subprocess.DEVNULL)
+    subprocess.run(
+        ["git", "-c", "user.name=Test User", "-c", "user.email=test@example.invalid", "commit", "-m", "ignore"],
+        cwd=tmp_target,
+        check=True,
+        stdout=subprocess.DEVNULL,
+    )
+    assert _run_verify_with_graphtrail_disabled(tmp_target, monkeypatch) == 0
+    baseline = json.loads(capsys.readouterr().out)
+    (tmp_target / "ignored.txt").write_text("secret\n")
+    (tmp_target / "visible.txt").write_text("visible\n")
+    assert _run_verify_with_graphtrail_disabled(tmp_target, monkeypatch, reuse=False) == 0
+    with_visible = json.loads(capsys.readouterr().out)
+    patch_text = Path(with_visible["path"], "changes.patch").read_text()
+    assert "visible.txt" in patch_text
+    assert "ignored.txt" not in patch_text
+    (tmp_target / "visible.txt").unlink()
+    assert _run_verify_with_graphtrail_disabled(tmp_target, monkeypatch, reuse=False) == 0
+    ignored_only = json.loads(capsys.readouterr().out)
+    assert ignored_only["tree_fingerprint"] == baseline["tree_fingerprint"]
+    assert ignored_only["changes_patch_sha256"] == baseline["changes_patch_sha256"]
+
+
+def test_verify_receipt_identity_includes_unignored_untracked(tmp_target, monkeypatch, capsys):
+    _init_verify_target_with_head(tmp_target)
+    (tmp_target / "new.txt").write_text("fresh\n")
+    assert _run_verify_with_graphtrail_disabled(tmp_target, monkeypatch, reuse=False) == 0
+    receipt = json.loads(capsys.readouterr().out)
+    patch_text = Path(receipt["path"], "changes.patch").read_text()
+    assert "new.txt" in patch_text
+    assert receipt["changes_patch_sha256"] == hashlib.sha256(patch_text.encode()).hexdigest()
+
+
+def test_verify_receipt_changes_patch_sha256_matches_file(tmp_target, monkeypatch, capsys):
+    _init_verify_target_with_head(tmp_target)
+    (tmp_target / "delta.txt").write_text("delta\n")
+    assert _run_verify_with_graphtrail_disabled(tmp_target, monkeypatch, reuse=False) == 0
+    receipt = json.loads(capsys.readouterr().out)
+    patch_bytes = (Path(receipt["path"]) / "changes.patch").read_bytes()
+    assert receipt["changes_patch_sha256"] == hashlib.sha256(patch_bytes).hexdigest()
+
+
+def test_verify_receipt_clean_tree_empty_patch(tmp_target, monkeypatch, capsys):
+    _init_verify_target_with_head(tmp_target)
+    assert _run_verify_with_graphtrail_disabled(tmp_target, monkeypatch) == 0
+    receipt = json.loads(capsys.readouterr().out)
+    patch_path = Path(receipt["path"]) / "changes.patch"
+    assert patch_path.is_file()
+    assert patch_path.read_bytes() == b""
+    assert receipt["changes_patch_sha256"] == EMPTY_PATCH_SHA256
+
+
+def test_verify_receipt_schema_version_two(tmp_target, monkeypatch, capsys):
+    _init_verify_target_with_head(tmp_target)
+    assert _run_verify_with_graphtrail_disabled(tmp_target, monkeypatch) == 0
+    receipt = json.loads(capsys.readouterr().out)
+    assert receipt["schema_version"] == 2
+
+
+def test_verify_show_old_format_receipt_without_identity_fields(tmp_target, capsys):
+    from brigade.work_cmd import helpers, verification
+
+    _init_verify_target_with_head(tmp_target)
+    run_dir = helpers._verify_runs_root(tmp_target) / "20260101-000000-work-verify-legacy"
+    run_dir.mkdir(parents=True)
+    legacy = {
+        "run_id": run_dir.name,
+        "target": str(tmp_target),
+        "status": "completed",
+        "started_at": "2026-01-01T00:00:00+00:00",
+        "completed_at": "2026-01-01T00:00:01+00:00",
+        "path": str(run_dir),
+        "commands": [{"command": "true", "status": "completed", "exit_code": 0}],
+    }
+    helpers._write_json(run_dir / "receipt.json", legacy)
+    assert verification.verify_show(target=tmp_target, run_id=run_dir.name) == 0
+    out = capsys.readouterr().out
+    assert "baseline" not in out.lower()
+    assert "verified tree" not in out
+
+
+def test_verify_show_renders_identity_binding(tmp_target, monkeypatch, capsys):
+    from brigade.work_cmd import verification
+
+    _init_verify_target_with_head(tmp_target)
+    assert _run_verify_with_graphtrail_disabled(tmp_target, monkeypatch) == 0
+    receipt = json.loads(capsys.readouterr().out)
+    assert verification.verify_show(target=tmp_target, run_id=receipt["run_id"]) == 0
+    out = capsys.readouterr().out
+    assert f"baseline commit: {receipt['baseline_commit']}" in out
+    assert f"tree fingerprint: {receipt['tree_fingerprint']}" in out
+    assert f"patch hash: {receipt['changes_patch_sha256']}" in out
+    assert (
+        f"verified tree {receipt['tree_fingerprint']} = baseline {receipt['baseline_commit']} + patch {receipt['changes_patch_sha256']}"
+        in out
+    )
+
+
+def test_verify_markdown_renders_identity_binding(tmp_target, monkeypatch, capsys):
+    _init_verify_target_with_head(tmp_target)
+    assert _run_verify_with_graphtrail_disabled(tmp_target, monkeypatch) == 0
+    receipt = json.loads(capsys.readouterr().out)
+    summary = Path(receipt["path"], "summary.md").read_text()
+    assert f"baseline {receipt['baseline_commit']}" in summary.lower()
+    assert receipt["tree_fingerprint"] in summary
+    assert receipt["changes_patch_sha256"] in summary
+    assert (
+        f"verified tree {receipt['tree_fingerprint']} = baseline {receipt['baseline_commit']} + patch {receipt['changes_patch_sha256']}"
+        in summary
+    )
+
+
+def test_verify_reused_receipt_captures_identity_binding(tmp_target, monkeypatch, capsys):
+    _init_verify_target_with_head(tmp_target)
+    assert _run_verify_with_graphtrail_disabled(tmp_target, monkeypatch) == 0
+    capsys.readouterr()
+    assert _run_verify_with_graphtrail_disabled(tmp_target, monkeypatch) == 0
+    reused = json.loads(capsys.readouterr().out)
+    assert reused.get("reused_from")
+    assert reused["schema_version"] == 2
+    assert reused["baseline_commit"]
+    assert reused["tree_fingerprint"]
+    assert reused["changes_patch_sha256"] == EMPTY_PATCH_SHA256
+    patch_path = Path(reused["path"]) / "changes.patch"
+    assert patch_path.is_file()
+    assert patch_path.read_bytes() == b""
+    assert (
+        f"verified tree {reused['tree_fingerprint']} = baseline {reused['baseline_commit']} + patch {reused['changes_patch_sha256']}"
+        in (Path(reused["path"]) / "summary.md").read_text()
+    )
+
+
+def test_verify_receipt_identity_patch_collection_failure_is_explicit(tmp_target, monkeypatch, capsys):
+    from brigade import runguard
+
+    _init_verify_target_with_head(tmp_target)
+
+    def fail_patch_collection(*_args, **_kwargs):
+        raise runguard.RunGuardError("simulated patch collection failure")
+
+    monkeypatch.setattr(runguard, "collect_changes_patch", fail_patch_collection)
+    assert _run_verify_with_graphtrail_disabled(tmp_target, monkeypatch, reuse=False) == 0
+    receipt = json.loads(capsys.readouterr().out)
+    assert receipt["schema_version"] == 2
+    assert receipt["baseline_commit"] is None
+    assert receipt["tree_fingerprint"] is None
+    assert receipt["changes_patch_sha256"] is None
+
+
+def test_verify_receipt_identity_preserves_real_index(tmp_target, monkeypatch, capsys):
+    _init_verify_target_with_head(tmp_target)
+    (tmp_target / "tracked.txt").write_text("staged\n")
+    subprocess.run(
+        ["git", "add", "tracked.txt"],
+        cwd=tmp_target,
+        check=True,
+        stdout=subprocess.DEVNULL,
+    )
+    before = subprocess.run(
+        ["git", "diff", "--cached", "--binary"],
+        cwd=tmp_target,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert _run_verify_with_graphtrail_disabled(tmp_target, monkeypatch, reuse=False) == 0
+    capsys.readouterr()
+    after = subprocess.run(
+        ["git", "diff", "--cached", "--binary"],
+        cwd=tmp_target,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert after == before


### PR DESCRIPTION
## Summary

Verification receipts now bind a passing command to the Git state it checked. Each new receipt records:

- `baseline_commit`
- `tree_fingerprint`
- `changes_patch_sha256`

The verify run retains the exact patch bytes as `changes.patch`. Both fresh and reused receipts use the same capture path.

## Fingerprint and untracked-file policy

The tree fingerprint is the object ID returned by Git plumbing against a temporary index:

1. `git read-tree HEAD`
2. `git add -A`
3. `git write-tree`

The temporary index includes tracked state and every non-ignored untracked file. Gitignored files are excluded. The caller's real index is unchanged. Capture rechecks both `HEAD` and the generated tree after writing the patch. If either changes or patch collection fails, the receipt records null identity fields and does not print a derived binding.

`changes_patch_sha256` is SHA-256 over the retained `changes.patch` bytes. A clean tree is represented by a zero-byte patch, whose digest is `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`.

## Schema compatibility

New verification receipts use `schema_version: 2`. The fields are additive, deterministic, and written through the existing sorted-key serializer. Existing stored receipts without a schema version or identity fields still load and display. Identity lines are omitted when the three binding values are unavailable.

## Tests

- identical trees produce identical fingerprints
- tracked or relevant untracked changes produce a different fingerprint
- ignored untracked files do not affect the fingerprint or patch
- patch hashes match an independent SHA-256 calculation
- clean trees retain a zero-byte patch
- the temporary index preserves staged content in the real index
- patch-collection failures produce explicit null identity fields
- legacy receipts load and display without identity fields
- fresh and reused receipt displays render the binding
- issue #475 capture-before-retry tests pass with the new receipt fields

## Verification

`./scripts/verify`

- receipt: `20260726-213137-work-verify-042161`
- exit code: `0`
- result: `4383 passed, 3 skipped`
- coverage: `82.79%`

Sample receipt excerpt:

```text
schema_version: 2
baseline_commit: 872a96c06333e0b0c4ab09a9603fb5ad64729833
tree_fingerprint: 6e37153141287f2ed84709298c21cff8675322a0
changes_patch_sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
status: completed
exit_code: 0
verified tree 6e37153141287f2ed84709298c21cff8675322a0 = baseline 872a96c06333e0b0c4ab09a9603fb5ad64729833 + patch e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
```

Closes #485.
