### PR TITLE
feat(telemetry): project verify and outcome receipts

### DIFF
--- a/src/brigade/telemetry_export.py
+++ b/src/brigade/telemetry_export.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
+import shlex
 import sys
 from pathlib import Path
 from typing import Any
 
-from . import localio
+from . import localio, outcome
+from .outcome_cmd import _fingerprint_cohorts_by_artifact, _record_from_dict
+from .selection import KNOWN_HARNESSES
 
 OTEL_MAPPING = {
     "name": "otel-genai",
@@ -20,6 +24,9 @@ OPENINFERENCE_MAPPING = {
     "mapping_version": 1,
     "upstream_revision": "audited-2026-07-12",
 }
+_SHA256_HEX = re.compile(r"^[0-9a-f]{64}$")
+_FINGERPRINT_HEX = re.compile(r"^[0-9a-f]{16}$")
+_OUTCOME_SCALAR_KEYS = ("artifact_id", "artifact_kind", "task_id", "source", "evidence_ref", "ts")
 
 
 def _object(path: Path) -> dict[str, Any] | None:
@@ -36,14 +43,46 @@ def _ids(run_id: str, seat: str, ordinal: int) -> tuple[str, str]:
     return trace, span
 
 
+def _receipt_trace_id(receipt_id: str) -> str:
+    return hashlib.sha256(f"brigade:receipt:{receipt_id}".encode()).hexdigest()[:32]
+
+
+def _receipt_span_id(receipt_id: str, ordinal: int) -> str:
+    return hashlib.sha256(f"brigade:receipt:{receipt_id}:{ordinal}".encode()).hexdigest()[:16]
+
+
+def _outcome_record_id(record: dict[str, Any], line_no: int) -> str:
+    digest = _valid_outcome_digest(record)
+    if digest is not None:
+        return digest
+    identity = ":".join((str(line_no), record["ts"], record["artifact_id"], record["evidence_ref"]))
+    return hashlib.sha256(f"brigade:outcome:{identity}".encode()).hexdigest()
+
+
+def _valid_outcome_digest(record: dict[str, Any]) -> str | None:
+    digest = record.get("digest")
+    if not isinstance(digest, str) or not _SHA256_HEX.fullmatch(digest):
+        return None
+    expected = localio.canonical_json_digest(record, exclude_keys={"digest"})
+    if digest != expected:
+        return None
+    return digest
+
+
+def _valid_outcome_fields(payload: dict[str, Any]) -> bool:
+    for key in _OUTCOME_SCALAR_KEYS:
+        if not isinstance(payload.get(key), str) or not payload[key]:
+            return False
+    signal = payload.get("signal_value")
+    return isinstance(signal, int) and not isinstance(signal, bool) and signal in (-1, 0, 1)
+
+
+def _outcome_span_id(record_id: str, ordinal: int) -> str:
+    return hashlib.sha256(f"brigade:outcome:span:{record_id}:{ordinal}".encode()).hexdigest()[:16]
+
+
 def _provider(cli: str) -> str | None:
-    if cli == "codex":
-        return "openai"
-    if cli == "claude":
-        return "anthropic"
-    if cli == "grok":
-        return "x_ai"
-    return None
+    return {"codex": "openai", "claude": "anthropic", "grok": "x_ai"}.get(cli)
 
 
 def _error_type(result: dict[str, Any]) -> str | None:
@@ -55,6 +94,57 @@ def _error_type(result: dict[str, Any]) -> str | None:
     if isinstance(exit_code, int) and not isinstance(exit_code, bool):
         return "process_error"
     return "worker_error"
+
+
+def _resolve_under_target(target: Path, ref: str) -> Path | None:
+    if not ref:
+        return None
+    path = Path(ref)
+    if path.is_absolute():
+        try:
+            return path.resolve().relative_to(target)
+        except ValueError:
+            return None
+    return Path(ref)
+
+
+def _as_num(value: Any) -> float | int | None:
+    return value if isinstance(value, (int, float)) and not isinstance(value, bool) else None
+
+
+def _as_str(value: Any, *, iso: bool = False) -> str | None:
+    if not isinstance(value, str) or not value:
+        return None
+    if iso and localio.parse_iso_datetime(value) is None:
+        return None
+    return value
+
+
+def _valid_harness_session(value: Any) -> tuple[str, str] | None:
+    if not isinstance(value, dict):
+        return None
+    harness = value.get("harness")
+    fingerprint = value.get("fingerprint")
+    if not isinstance(harness, str) or not harness or harness not in KNOWN_HARNESSES:
+        return None
+    if not isinstance(fingerprint, str) or not _FINGERPRINT_HEX.fullmatch(fingerprint):
+        return None
+    return harness, fingerprint
+
+
+def _verify_executable(command: str) -> str | None:
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        return None
+    if not parts:
+        return None
+    argv = list(parts)
+    while argv and re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", argv[0]):
+        argv.pop(0)
+    if not argv:
+        return None
+    return Path(argv[0]).name or None
 
 
 def _base(run_id: str, run: dict[str, Any], seat: str, result: dict[str, Any], ordinal: int) -> dict[str, Any]:
@@ -78,46 +168,104 @@ def _base(run_id: str, run: dict[str, Any], seat: str, result: dict[str, Any], o
     }
 
 
-def _otel(base: dict[str, Any], cli: str) -> dict[str, Any]:
-    attributes: dict[str, Any] = {
-        "gen_ai.operation.name": "invoke_agent",
-        "brigade.seat.name": base["seat"],
-        "brigade.adapter.name": base["adapter"],
-    }
-    provider = _provider(cli)
-    if provider is not None:
-        attributes["gen_ai.provider.name"] = provider
-    if base["requested_model"] is not None:
-        attributes["gen_ai.request.model"] = base["requested_model"]
-    if base["effective_model"] is not None:
-        attributes["gen_ai.response.model"] = base["effective_model"]
-    if base["stop_reason"] is not None:
-        attributes["gen_ai.response.finish_reasons"] = [base["stop_reason"]]
+def _tool_row(
+    projection: str,
+    base: dict[str, Any],
+    *,
+    tool_name: str,
+    tool_call_id: str,
+    brigade_attrs: dict[str, Any],
+) -> dict[str, Any]:
+    otel = projection == "otel-genai"
+    mapping = OTEL_MAPPING if otel else OPENINFERENCE_MAPPING
+    schema = "brigade.otel_genai_projection.v1" if otel else "brigade.openinference_projection.v1"
+    attributes = (
+        {
+            "gen_ai.operation.name": "execute_tool",
+            "gen_ai.tool.name": tool_name,
+            "gen_ai.tool.call.id": tool_call_id,
+            **brigade_attrs,
+        }
+        if otel
+        else {"openinference.span.kind": "TOOL", "tool.name": tool_name, "tool.id": tool_call_id, **brigade_attrs}
+    )
     if base["error_type"] is not None:
         attributes["error.type"] = base["error_type"]
-    return {"schema": "brigade.otel_genai_projection.v1", "mapping": OTEL_MAPPING, **base, "attributes": attributes}
-
-
-def _openinference(base: dict[str, Any]) -> dict[str, Any]:
-    attributes: dict[str, Any] = {
-        "openinference.span.kind": "AGENT",
-        "brigade.seat.name": base["seat"],
-        "brigade.adapter.name": base["adapter"],
-    }
-    model = base["effective_model"] or base["requested_model"]
-    if model is not None:
-        attributes["llm.model_name"] = model
     return {
-        "schema": "brigade.openinference_projection.v1",
-        "mapping": OPENINFERENCE_MAPPING,
-        **base,
+        "schema": schema,
+        "mapping": mapping,
+        "trace_id": base["trace_id"],
+        "span_id": base["span_id"],
+        "parent_span_id": base.get("parent_span_id"),
+        "name": f"execute_tool {tool_name}" if otel else tool_name,
+        "start_time": base["start_time"],
+        "end_time": base["end_time"],
+        "duration_seconds": base["duration_seconds"],
+        "status": base["status"],
+        "error_type": base["error_type"],
         "attributes": attributes,
     }
 
 
-def records(target: Path, projection: str) -> list[dict[str, Any]]:
-    target = target.expanduser().resolve()
+def _run_row(base: dict[str, Any], cli: str, projection: str) -> dict[str, Any]:
+    otel = projection == "otel-genai"
+    attributes: dict[str, Any] = {
+        "brigade.seat.name": base["seat"],
+        "brigade.adapter.name": base["adapter"],
+    }
+    if otel:
+        attributes["gen_ai.operation.name"] = "invoke_agent"
+        if (provider := _provider(cli)) is not None:
+            attributes["gen_ai.provider.name"] = provider
+        if base["requested_model"] is not None:
+            attributes["gen_ai.request.model"] = base["requested_model"]
+        if base["effective_model"] is not None:
+            attributes["gen_ai.response.model"] = base["effective_model"]
+        if base["stop_reason"] is not None:
+            attributes["gen_ai.response.finish_reasons"] = [base["stop_reason"]]
+        if base["error_type"] is not None:
+            attributes["error.type"] = base["error_type"]
+    else:
+        attributes["openinference.span.kind"] = "AGENT"
+        if (model := base["effective_model"] or base["requested_model"]) is not None:
+            attributes["llm.model_name"] = model
+    schema = "brigade.otel_genai_projection.v1" if otel else "brigade.openinference_projection.v1"
+    mapping = OTEL_MAPPING if otel else OPENINFERENCE_MAPPING
+    return {"schema": schema, "mapping": mapping, **base, "attributes": attributes}
+
+
+def _outcome_parentage(
+    target: Path,
+    record: dict[str, Any],
+    run_anchors: dict[str, tuple[str, str]],
+    verify_parents: dict[str, tuple[str, str]],
+) -> tuple[str, str | None] | None:
+    rel = _resolve_under_target(target, record["evidence_ref"])
+    if rel is None:
+        return None
+    parts = rel.parts
+    if len(parts) == 4 and parts[0] == ".brigade" and parts[1] == "runs" and parts[-1] == "run.json":
+        return run_anchors.get(parts[2])
+    if (
+        len(parts) == 5
+        and parts[0] == ".brigade"
+        and parts[1] == "work"
+        and parts[2] == "verify-runs"
+        and parts[-1] == "receipt.json"
+    ):
+        verify_id = parts[3]
+        anchor = verify_parents.get(verify_id)
+        return anchor if anchor is not None else (_receipt_trace_id(verify_id), None)
+    return None
+
+
+def _project_runs(
+    target: Path, projection: str
+) -> tuple[list[dict[str, Any]], dict[str, tuple[str, str]], dict[str, tuple[str, str]]]:
     rows: list[dict[str, Any]] = []
+    run_anchors: dict[str, tuple[str, str]] = {}
+    verify_parents: dict[str, tuple[str, str]] = {}
+    ambiguous_verify: set[str] = set()
     root = target / ".brigade" / "runs"
     for run_dir in sorted(root.iterdir()) if root.is_dir() else []:
         if not run_dir.is_dir():
@@ -130,6 +278,7 @@ def records(target: Path, projection: str) -> list[dict[str, Any]]:
         agents = roster.get("agents")
         if not isinstance(agents, dict):
             continue
+        anchor: tuple[str, str] | None = None
         for ordinal, result in enumerate(workers.get("results", []), start=1):
             if not isinstance(result, dict) or not isinstance(result.get("worker"), str):
                 continue
@@ -139,7 +288,202 @@ def records(target: Path, projection: str) -> list[dict[str, Any]]:
                 continue
             cli = str(agent.get("cli") or "unknown")
             base = _base(run_dir.name, run, seat, result, ordinal)
-            rows.append(_otel(base, cli) if projection == "otel-genai" else _openinference(base))
+            if anchor is None:
+                anchor = (base["trace_id"], base["span_id"])
+            rows.append(_run_row(base, cli, projection))
+        if anchor is not None:
+            run_anchors[run_dir.name] = anchor
+            ground_truth = workers.get("ground_truth")
+            if isinstance(ground_truth, dict):
+                verify_receipts = ground_truth.get("verify_receipts")
+                if isinstance(verify_receipts, list):
+                    for entry in verify_receipts:
+                        if not isinstance(entry, dict):
+                            continue
+                        run_id = entry.get("run_id")
+                        if not isinstance(run_id, str) or not run_id or run_id in ambiguous_verify:
+                            continue
+                        existing = verify_parents.get(run_id)
+                        if existing is None:
+                            verify_parents[run_id] = anchor
+                        elif existing != anchor:
+                            ambiguous_verify.add(run_id)
+                            verify_parents.pop(run_id, None)
+    return rows, run_anchors, verify_parents
+
+
+def _project_verify(
+    target: Path,
+    projection: str,
+    verify_parents: dict[str, tuple[str, str]],
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    target_name = target.name
+    root = target / ".brigade" / "work" / "verify-runs"
+    for run_dir in sorted(root.iterdir()) if root.is_dir() else []:
+        if not run_dir.is_dir():
+            continue
+        receipt = _object(run_dir / "receipt.json")
+        if receipt is None:
+            continue
+        receipt_id = receipt.get("run_id")
+        if not isinstance(receipt_id, str) or not receipt_id or receipt_id != run_dir.name:
+            continue
+        commands = receipt.get("commands")
+        if not isinstance(commands, list):
+            continue
+        anchor = verify_parents.get(receipt_id)
+        trace_id, parent_span_id = anchor if anchor is not None else (_receipt_trace_id(receipt_id), None)
+        harness_session = _valid_harness_session(receipt.get("harness_session"))
+        harness = fingerprint = None
+        if harness_session is not None:
+            harness, fingerprint = harness_session
+        receipt_status = _as_str(receipt.get("status"))
+        receipt_started_at = _as_str(receipt.get("started_at"), iso=True)
+        receipt_completed_at = _as_str(receipt.get("completed_at"), iso=True)
+        for ordinal, command in enumerate(commands, start=1):
+            if not isinstance(command, dict):
+                continue
+            raw_command = command.get("command")
+            if not isinstance(raw_command, str) or not raw_command:
+                continue
+            if (executable := _verify_executable(raw_command)) is None:
+                continue
+            if "status" in command:
+                status = _as_str(command.get("status"))
+                if status is None:
+                    continue
+            else:
+                status = receipt_status
+                if status is None:
+                    continue
+            start_time = _as_str(command.get("started_at"), iso=True) or receipt_started_at
+            end_time = _as_str(command.get("completed_at"), iso=True) or receipt_completed_at
+            if start_time is None or end_time is None:
+                continue
+            exit_code = command.get("exit_code")
+            duration = _as_num(command.get("duration_seconds"))
+            if duration is None:
+                duration = _as_num(receipt.get("duration_seconds"))
+            base = {
+                "trace_id": trace_id,
+                "span_id": _receipt_span_id(receipt_id, ordinal),
+                "parent_span_id": parent_span_id,
+                "name": "brigade.work.verify",
+                "start_time": start_time,
+                "end_time": end_time,
+                "duration_seconds": duration,
+                "status": "OK" if status == "completed" else "ERROR",
+                "error_type": None if status == "completed" else "process_error",
+            }
+            brigade_attrs: dict[str, Any] = {
+                "brigade.receipt.id": receipt_id,
+                "brigade.target.repo": target_name,
+                "brigade.verify.command.executable": executable,
+                "brigade.verify.status": status,
+            }
+            if isinstance(exit_code, int) and not isinstance(exit_code, bool):
+                brigade_attrs["brigade.verify.exit_code"] = exit_code
+            if harness is not None:
+                brigade_attrs["brigade.harness.session.harness"] = harness
+            if fingerprint is not None:
+                brigade_attrs["brigade.harness.session.fingerprint"] = fingerprint
+            rows.append(
+                _tool_row(
+                    projection,
+                    base,
+                    tool_name="brigade.work.verify",
+                    tool_call_id=f"{receipt_id}:{ordinal}",
+                    brigade_attrs=brigade_attrs,
+                )
+            )
+    return rows
+
+
+def _project_outcomes(
+    target: Path,
+    projection: str,
+    run_anchors: dict[str, tuple[str, str]],
+    verify_parents: dict[str, tuple[str, str]],
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    path = target / "memory" / "outcome" / "records.jsonl"
+    if not path.is_file():
+        return rows
+    status_payload = localio.read_json_dict(target / "memory" / "outcome" / "status.json") or {}
+    status_by_artifact = status_payload.get("artifacts")
+    if not isinstance(status_by_artifact, dict):
+        status_by_artifact = {}
+    entries: list[tuple[int, dict[str, Any], outcome.OutcomeRecord]] = []
+    for line_no, line in enumerate(localio.read_jsonl_dicts(path), start=1):
+        if not _valid_outcome_fields(line):
+            continue
+        record = _record_from_dict(line)
+        if record is None:
+            continue
+        entries.append((line_no, line, record))
+    cohorts_by_artifact = _fingerprint_cohorts_by_artifact(target, [record for _, _, record in entries])
+    target_name = target.name
+    seen_digests: set[str] = set()
+    for line_no, line, record in entries:
+        digest = _valid_outcome_digest(line)
+        if digest is not None:
+            if digest in seen_digests:
+                continue
+            seen_digests.add(digest)
+        parentage = _outcome_parentage(target, line, run_anchors, verify_parents)
+        if parentage is None:
+            continue
+        trace_id, parent_span_id = parentage
+        record_id = _outcome_record_id(line, line_no)
+        artifact_id = record.artifact_id
+        cohorts = cohorts_by_artifact.get(artifact_id)
+        score_obj = cohorts.current if cohorts is not None else outcome.score_records(artifact_id, [])
+        promotion = status_by_artifact.get(artifact_id)
+        current_status = promotion.get("status") if isinstance(promotion, dict) else None
+        base = {
+            "trace_id": trace_id,
+            "span_id": _outcome_span_id(record_id, 1),
+            "parent_span_id": parent_span_id,
+            "name": "brigade.outcome.capture",
+            "start_time": record.ts,
+            "end_time": record.ts,
+            "duration_seconds": None,
+            "status": "OK",
+            "error_type": None,
+        }
+        brigade_attrs: dict[str, Any] = {
+            "brigade.target.repo": target_name,
+            "brigade.outcome.artifact.id": artifact_id,
+            "brigade.outcome.artifact.kind": record.artifact_kind,
+            "brigade.outcome.source": record.source,
+            "brigade.outcome.signal": record.signal_value,
+            "brigade.outcome.current.score": score_obj.score,
+            "brigade.outcome.current.helped": score_obj.helped,
+            "brigade.outcome.current.hurt": score_obj.hurt,
+            "brigade.outcome.current.neutral": score_obj.neutral,
+        }
+        if digest is not None:
+            brigade_attrs["brigade.receipt.id"] = digest
+        if isinstance(current_status, str) and current_status:
+            brigade_attrs["brigade.outcome.current.status"] = current_status
+        rows.append(
+            _tool_row(
+                projection,
+                base,
+                tool_name="brigade.outcome.capture",
+                tool_call_id=record_id,
+                brigade_attrs=brigade_attrs,
+            )
+        )
+    return rows
+
+
+def records(target: Path, projection: str) -> list[dict[str, Any]]:
+    target = target.expanduser().resolve()
+    rows, run_anchors, verify_parents = _project_runs(target, projection)
+    rows.extend(_project_verify(target, projection, verify_parents))
+    rows.extend(_project_outcomes(target, projection, run_anchors, verify_parents))
     return rows
 
 

--- a/tests/test_telemetry_export.py
+++ b/tests/test_telemetry_export.py
@@ -1,86 +1,577 @@
 from __future__ import annotations
 
+import hashlib
 import json
 
-from brigade import cli
+import pytest
+
+from brigade import cli, localio, outcome as outcome_core
+from brigade import telemetry_export
+
+_RUN_ONLY_OTEL_ROW = json.loads(
+    '{"adapter":"acpx","attributes":{"brigade.adapter.name":"acpx","brigade.seat.name":"worker","gen_ai.operation.name":"invoke_agent","gen_ai.provider.name":"x_ai","gen_ai.request.model":"grok-4.5","gen_ai.response.finish_reasons":["end_turn"],"gen_ai.response.model":"grok-4.5"},"duration_seconds":2.0,"effective_model":"grok-4.5","end_time":"2026-01-01T00:00:02Z","error_type":null,"exit_code":0,"mapping":{"mapping_version":1,"name":"otel-genai","upstream_revision":"opentelemetry-semconv-1.43.0"},"name":"brigade.run.worker","reasoning":null,"requested_model":"grok-4.5","schema":"brigade.otel_genai_projection.v1","seat":"worker","span_id":"dc8c20677f4f195d","start_time":"2026-01-01T00:00:00Z","status":"OK","stop_reason":"end_turn","trace_id":"9f319429aa7ee1e464fb955454290143"}'
+)
+_RUN_ONLY_OPENINFERENCE_ROW = json.loads(
+    '{"adapter":"acpx","attributes":{"brigade.adapter.name":"acpx","brigade.seat.name":"worker","llm.model_name":"grok-4.5","openinference.span.kind":"AGENT"},"duration_seconds":2.0,"effective_model":"grok-4.5","end_time":"2026-01-01T00:00:02Z","error_type":null,"exit_code":0,"mapping":{"mapping_version":1,"name":"openinference","upstream_revision":"audited-2026-07-12"},"name":"brigade.run.worker","reasoning":null,"requested_model":"grok-4.5","schema":"brigade.openinference_projection.v1","seat":"worker","span_id":"dc8c20677f4f195d","start_time":"2026-01-01T00:00:00Z","status":"OK","stop_reason":"end_turn","trace_id":"9f319429aa7ee1e464fb955454290143"}'
+)
+_RUN_ONLY_OTEL_FAILED_ROW = json.loads(
+    '{"adapter":"acpx","attributes":{"brigade.adapter.name":"acpx","brigade.seat.name":"worker","error.type":"process_error","gen_ai.operation.name":"invoke_agent","gen_ai.provider.name":"x_ai","gen_ai.request.model":"grok-4.5","gen_ai.response.finish_reasons":["end_turn"],"gen_ai.response.model":"grok-4.5"},"duration_seconds":2.0,"effective_model":"grok-4.5","end_time":"2026-01-01T00:00:02Z","error_type":"process_error","exit_code":1,"mapping":{"mapping_version":1,"name":"otel-genai","upstream_revision":"opentelemetry-semconv-1.43.0"},"name":"brigade.run.worker","reasoning":null,"requested_model":"grok-4.5","schema":"brigade.otel_genai_projection.v1","seat":"worker","span_id":"dc8c20677f4f195d","start_time":"2026-01-01T00:00:00Z","status":"ERROR","stop_reason":"end_turn","trace_id":"9f319429aa7ee1e464fb955454290143"}'
+)
+_RUN_ONLY_OPENINFERENCE_FAILED_ROW = json.loads(
+    '{"adapter":"acpx","attributes":{"brigade.adapter.name":"acpx","brigade.seat.name":"worker","llm.model_name":"grok-4.5","openinference.span.kind":"AGENT"},"duration_seconds":2.0,"effective_model":"grok-4.5","end_time":"2026-01-01T00:00:02Z","error_type":"process_error","exit_code":1,"mapping":{"mapping_version":1,"name":"openinference","upstream_revision":"audited-2026-07-12"},"name":"brigade.run.worker","reasoning":null,"requested_model":"grok-4.5","schema":"brigade.openinference_projection.v1","seat":"worker","span_id":"dc8c20677f4f195d","start_time":"2026-01-01T00:00:00Z","status":"ERROR","stop_reason":"end_turn","trace_id":"9f319429aa7ee1e464fb955454290143"}'
+)
 
 
-def _run(tmp_path):
-    run = tmp_path / ".brigade" / "runs" / "run-1"
+def _run(tmp_path, *, run_id="run-1", verify_receipts=None):
+    run = tmp_path / ".brigade" / "runs" / run_id
     run.mkdir(parents=True)
+    workers = {
+        "results": [
+            {
+                "worker": "worker",
+                "ok": True,
+                "text": "PRIVATE OUTPUT",
+                "duration_seconds": 2.0,
+                "transport": "acpx",
+                "requested_model": "grok-4.5",
+                "effective_model": "grok-4.5",
+                "stop_reason": "end_turn",
+                "exit_code": 0,
+            }
+        ],
+    }
+    if verify_receipts is not None:
+        workers["ground_truth"] = {"available": True, "verify_receipts": verify_receipts}
     (run / "run.json").write_text(
         json.dumps({"started_at": "2026-01-01T00:00:00Z", "finished_at": "2026-01-01T00:00:02Z", "task": "SECRET"})
     )
     (run / "roster.json").write_text(json.dumps({"agents": {"worker": {"cli": "grok", "model": "grok-4.5"}}}))
-    (run / "worker-results.json").write_text(
-        json.dumps(
+    (run / "worker-results.json").write_text(json.dumps(workers))
+    return run
+
+
+def _verify_receipt(tmp_path, run_id, *, receipt_run_id=None, signed=True, **overrides):
+    run_dir = tmp_path / ".brigade" / "work" / "verify-runs" / run_id
+    run_dir.mkdir(parents=True)
+    receipt = {
+        "run_id": receipt_run_id or run_id,
+        "target": str(tmp_path),
+        "status": "completed",
+        "started_at": "2026-01-01T00:00:01Z",
+        "completed_at": "2026-01-01T00:00:03Z",
+        "duration_seconds": 2.0,
+        "commands": [
             {
-                "results": [
-                    {
-                        "worker": "worker",
-                        "ok": True,
-                        "text": "PRIVATE OUTPUT",
-                        "duration_seconds": 2.0,
-                        "transport": "acpx",
-                        "requested_model": "grok-4.5",
-                        "effective_model": "grok-4.5",
-                        "stop_reason": "end_turn",
-                        "exit_code": 0,
-                    }
-                ]
+                "command": overrides.pop("command", "pytest -q"),
+                "status": overrides.pop("status", "completed"),
+                "exit_code": overrides.pop("exit_code", 0),
+                "duration_seconds": overrides.pop("duration_seconds", 1.5),
+                "started_at": overrides.pop("command_started_at", "2026-01-01T00:00:01Z"),
+                "completed_at": overrides.pop("command_completed_at", "2026-01-01T00:00:02Z"),
             }
+        ],
+        **overrides,
+    }
+    if signed:
+        receipt["digests"] = {
+            "algorithm": "sha256",
+            "logs": {},
+            "receipt_sha256": localio.canonical_json_digest(receipt, exclude_keys={"digests"}),
+        }
+    localio.write_json(run_dir / "receipt.json", receipt)
+    return run_dir / "receipt.json"
+
+
+def _outcome_payload(*, evidence_ref, artifact_id="brigade-work", signal_value=1, source="verify", **extra):
+    return {
+        "artifact_id": artifact_id,
+        "artifact_kind": "skill",
+        "task_id": "task-1",
+        "source": source,
+        "signal_value": signal_value,
+        "evidence_ref": evidence_ref,
+        "ts": "2026-01-01T00:00:04Z",
+        **extra,
+    }
+
+
+def _write_outcome_raw(tmp_path, *records):
+    path = tmp_path / "memory" / "outcome" / "records.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(record, sort_keys=True) + "\n" for record in records))
+
+
+def _write_outcomes(tmp_path, *records, artifact_id="brigade-work"):
+    path = tmp_path / "memory" / "outcome" / "records.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines, prev_digest = [], None
+    for record in records:
+        row = dict(record)
+        for key, default in (
+            ("artifact_id", artifact_id),
+            ("artifact_kind", "skill"),
+            ("task_id", "task-1"),
+            ("source", "verify"),
+            ("signal_value", 1),
+            ("ts", "2026-01-01T00:00:04Z"),
+        ):
+            row.setdefault(key, default)
+        row["prev_digest"] = prev_digest
+        row["digest"] = localio.canonical_json_digest(row, exclude_keys={"digest"})
+        prev_digest = row["digest"]
+        lines.append(json.dumps(row, sort_keys=True))
+    path.write_text("\n".join(lines) + "\n")
+    (tmp_path / "memory" / "outcome" / "status.json").write_text(
+        json.dumps(
+            {"artifacts": {artifact_id: {"status": "promoted", "last_action_ts": "2026-01-01T00:00:05Z"}}},
+            sort_keys=True,
         )
     )
 
 
-def test_otel_projection_uses_genai_names_and_omits_content(tmp_path, capsys):
+def _rows(tmp_path, projection):
+    return telemetry_export.records(tmp_path, projection)
+
+
+def _find(rows, name, *, projection="otel-genai", tool=None):
+    if tool is not None:
+        name = f"execute_tool {tool}" if projection == "otel-genai" else tool
+    return next(row for row in rows if row["name"] == name)
+
+
+def _no_tool(rows, tool, projection="otel-genai"):
+    name = f"execute_tool {tool}" if projection == "otel-genai" else tool
+    assert all(row["name"] != name for row in rows)
+
+
+def _linked_verify(tmp_path, verify_id, **receipt_overrides):
+    _run(
+        tmp_path,
+        verify_receipts=[{"run_id": verify_id, "status": "completed", "commands": [{"command": "pytest -q"}]}],
+    )
+    return _verify_receipt(tmp_path, verify_id, **receipt_overrides)
+
+
+def _parented_tool(rows, projection, tool):
+    worker = _find(rows, "brigade.run.worker")
+    child = _find(rows, "", projection=projection, tool=tool)
+    assert child["trace_id"] == worker["trace_id"]
+    assert child["parent_span_id"] == worker["span_id"]
+    return child
+
+
+@pytest.mark.parametrize(
+    "projection,attrs,forbidden",
+    [
+        (
+            "otel-genai",
+            {
+                "gen_ai.operation.name": "invoke_agent",
+                "gen_ai.provider.name": "x_ai",
+                "gen_ai.request.model": "grok-4.5",
+            },
+            ("SECRET", "PRIVATE OUTPUT"),
+        ),
+        (
+            "openinference",
+            {"openinference.span.kind": "AGENT", "llm.model_name": "grok-4.5"},
+            ("SECRET", "PRIVATE OUTPUT", "input.value", "output.value"),
+        ),
+    ],
+)
+def test_run_projection_content_free(tmp_path, capsys, projection, attrs, forbidden):
     _run(tmp_path)
-    assert cli.main(["receipts", "export", "otel-genai", "--target", str(tmp_path)]) == 0
+    assert cli.main(["receipts", "export", projection, "--target", str(tmp_path)]) == 0
     raw = capsys.readouterr().out
     row = json.loads(raw)
-    assert row["attributes"]["gen_ai.operation.name"] == "invoke_agent"
-    assert row["attributes"]["gen_ai.provider.name"] == "x_ai"
-    assert row["attributes"]["gen_ai.request.model"] == "grok-4.5"
-    assert "SECRET" not in raw and "PRIVATE OUTPUT" not in raw
+    for key, value in attrs.items():
+        assert row["attributes"][key] == value
+    for token in forbidden:
+        assert token not in raw
 
 
-def test_openinference_projection_is_content_free(tmp_path, capsys):
-    _run(tmp_path)
-    assert cli.main(["receipts", "export", "openinference", "--target", str(tmp_path)]) == 0
-    raw = capsys.readouterr().out
-    row = json.loads(raw)
-    assert row["attributes"]["openinference.span.kind"] == "AGENT"
-    assert row["attributes"]["llm.model_name"] == "grok-4.5"
-    assert "input.value" not in raw and "output.value" not in raw
-
-
-def test_failed_projection_uses_normalized_error_without_detail(tmp_path, capsys):
+def _failed_run(tmp_path):
     _run(tmp_path)
     path = tmp_path / ".brigade" / "runs" / "run-1" / "worker-results.json"
     payload = json.loads(path.read_text())
     payload["results"][0].update(
-        {
-            "ok": False,
-            "detail": "Bearer secret-token at /home/example/private",
-            "exit_code": 1,
-        }
+        {"ok": False, "detail": "Bearer secret-token at /home/example/private", "exit_code": 1}
     )
     path.write_text(json.dumps(payload))
 
+
+def test_failed_projection_uses_normalized_error_without_detail(tmp_path, capsys):
+    _failed_run(tmp_path)
     assert cli.main(["receipts", "export", "otel-genai", "--target", str(tmp_path)]) == 0
     raw = capsys.readouterr().out
     row = json.loads(raw)
     assert row["error_type"] == "process_error"
     assert row["attributes"]["error.type"] == "process_error"
-    assert "secret-token" not in raw
-    assert "/home/example" not in raw
+    assert "secret-token" not in raw and "/home/example" not in raw
+
+
+def test_failed_run_only_projection_is_unchanged(tmp_path):
+    _failed_run(tmp_path)
+    otel_rows = _rows(tmp_path, "otel-genai")
+    oi_rows = _rows(tmp_path, "openinference")
+    assert otel_rows[0] == _RUN_ONLY_OTEL_FAILED_ROW
+    assert oi_rows[0] == _RUN_ONLY_OPENINFERENCE_FAILED_ROW
+    assert "error.type" not in oi_rows[0]["attributes"]
 
 
 def test_multiprovider_cli_does_not_guess_provider(tmp_path, capsys):
     _run(tmp_path)
-    roster_path = tmp_path / ".brigade" / "runs" / "run-1" / "roster.json"
-    roster_path.write_text(json.dumps({"agents": {"worker": {"cli": "opencode", "model": "anthropic/claude"}}}))
-
+    (tmp_path / ".brigade" / "runs" / "run-1" / "roster.json").write_text(
+        json.dumps({"agents": {"worker": {"cli": "opencode", "model": "anthropic/claude"}}})
+    )
     assert cli.main(["receipts", "export", "otel-genai", "--target", str(tmp_path)]) == 0
-    row = json.loads(capsys.readouterr().out)
-    assert "gen_ai.provider.name" not in row["attributes"]
+    assert "gen_ai.provider.name" not in json.loads(capsys.readouterr().out)["attributes"]
+
+
+def test_verify_tool_projection_contracts(tmp_path):
+    verify_id = "20260101-000000-work-verify-abc"
+    _linked_verify(
+        tmp_path,
+        verify_id,
+        harness_session={"harness": "claude", "fingerprint": "0123456789abcdef"},
+    )
+    for projection, tool_attr, tool_id_attr in (
+        ("otel-genai", "gen_ai.tool.name", "gen_ai.tool.call.id"),
+        ("openinference", "tool.name", "tool.id"),
+    ):
+        rows = _rows(tmp_path, projection)
+        verify = _parented_tool(rows, projection, "brigade.work.verify")
+        assert verify["name"] == (
+            "execute_tool brigade.work.verify" if projection == "otel-genai" else "brigade.work.verify"
+        )
+        assert verify["attributes"][tool_attr] == "brigade.work.verify"
+        assert verify["attributes"][tool_id_attr] == f"{verify_id}:1"
+    verify = _find(_rows(tmp_path, "otel-genai"), "", projection="otel-genai", tool="brigade.work.verify")
+    assert verify["attributes"]["gen_ai.operation.name"] == "execute_tool"
+    assert verify["start_time"] == "2026-01-01T00:00:01Z"
+    assert verify["end_time"] == "2026-01-01T00:00:02Z"
+    assert verify["duration_seconds"] == 1.5
+    assert verify["attributes"]["brigade.receipt.id"] == verify_id
+    assert verify["attributes"]["brigade.verify.command.executable"] == "pytest"
+    assert verify["attributes"]["brigade.harness.session.harness"] == "claude"
+    assert verify["attributes"]["brigade.harness.session.fingerprint"] == "0123456789abcdef"
+    assert str(tmp_path) not in json.dumps(verify)
+
+    zero_path = tmp_path / "zero-duration"
+    zero_path.mkdir()
+    _verify_receipt(zero_path, "20260101-000000-work-verify-zero", duration_seconds=0.0)
+    assert (
+        _find(_rows(zero_path, "otel-genai"), "", projection="otel-genai", tool="brigade.work.verify")[
+            "duration_seconds"
+        ]
+        == 0.0
+    )
+
+    secret_path = tmp_path / "secret"
+    secret_path.mkdir()
+    _verify_receipt(
+        secret_path,
+        "20260101-000000-work-verify-secret",
+        command="/private/bin/check --token secret-value",
+    )
+    secret = _find(_rows(secret_path, "otel-genai"), "", projection="otel-genai", tool="brigade.work.verify")
+    secret_raw = json.dumps(secret)
+    assert secret["attributes"]["brigade.verify.command.executable"] == "check"
+    assert "/private" not in secret_raw and "secret-value" not in secret_raw
+
+    orphan_path = tmp_path / "orphan"
+    orphan_path.mkdir()
+    orphan_id = "20260101-000000-work-verify-orphan"
+    _verify_receipt(orphan_path, orphan_id)
+    for projection in ("otel-genai", "openinference"):
+        orphan = _find(_rows(orphan_path, projection), "", projection=projection, tool="brigade.work.verify")
+        assert orphan["trace_id"] == telemetry_export._receipt_trace_id(orphan_id)
+        assert orphan["parent_span_id"] is None
+
+    ambiguous_path = tmp_path / "ambiguous"
+    ambiguous_path.mkdir()
+    ambiguous_id = "20260101-000000-work-verify-ambiguous"
+    link = [{"run_id": ambiguous_id, "status": "completed", "commands": [{"command": "pytest -q"}]}]
+    _run(ambiguous_path, run_id="run-a", verify_receipts=link)
+    _run(ambiguous_path, run_id="run-b", verify_receipts=link)
+    _verify_receipt(ambiguous_path, ambiguous_id)
+    worker_a = _find(_rows(ambiguous_path, "otel-genai"), "brigade.run.worker")
+    ambiguous = _find(_rows(ambiguous_path, "otel-genai"), "", projection="otel-genai", tool="brigade.work.verify")
+    assert ambiguous["trace_id"] == telemetry_export._receipt_trace_id(ambiguous_id)
+    assert ambiguous["parent_span_id"] is None
+    assert ambiguous["trace_id"] != worker_a["trace_id"]
+
+    sanitize_path = tmp_path / "sanitize"
+    sanitize_path.mkdir()
+    sanitize_id = "20260101-000000-work-verify-sanitize"
+    _verify_receipt(
+        sanitize_path,
+        sanitize_id,
+        signed=False,
+        started_at={"nested": "2026-01-01T00:00:01Z"},
+        harness_session={"harness": "/private/harness", "fingerprint": "not-hex"},
+        commands=[
+            {
+                "command": "pytest -q",
+                "status": "completed",
+                "exit_code": 0,
+                "started_at": {"nested": "2026-01-01T00:00:01Z"},
+                "completed_at": "2026-01-01T00:00:02Z",
+            }
+        ],
+    )
+    _no_tool(_rows(sanitize_path, "otel-genai"), "brigade.work.verify")
+    partial_id = f"{sanitize_id}-partial"
+    _verify_receipt(
+        sanitize_path,
+        partial_id,
+        signed=False,
+        harness_session={"harness": "claude", "fingerprint": "0123456789abcdef"},
+        commands=[
+            {
+                "command": "pytest -q",
+                "status": "completed",
+                "exit_code": 0,
+                "started_at": "2026-01-01T00:00:01Z",
+                "completed_at": "2026-01-01T00:00:02Z",
+            }
+        ],
+    )
+    partial = _find(_rows(sanitize_path, "otel-genai"), "", projection="otel-genai", tool="brigade.work.verify")
+    partial_raw = json.dumps(partial)
+    assert partial["start_time"] == "2026-01-01T00:00:01Z"
+    assert partial["end_time"] == "2026-01-01T00:00:02Z"
+    assert partial["attributes"]["brigade.harness.session.harness"] == "claude"
+    assert partial["attributes"]["brigade.harness.session.fingerprint"] == "0123456789abcdef"
+    assert "/private" not in partial_raw and "not-hex" not in partial_raw and "nested" not in partial_raw
+
+    for index, mutation in enumerate(({"status": {"nested": "completed"}}, {"command": 123})):
+        bad_path = tmp_path / f"verify-bad-{index}"
+        bad_path.mkdir()
+        bad_id = f"20260101-000000-work-verify-bad-{index}"
+        command = {
+            "command": "pytest -q",
+            "status": "completed",
+            "exit_code": 0,
+            "duration_seconds": 1.0,
+            "started_at": "2026-01-01T00:00:01Z",
+            "completed_at": "2026-01-01T00:00:02Z",
+            **mutation,
+        }
+        _verify_receipt(bad_path, bad_id, signed=False, commands=[command])
+        _no_tool(_rows(bad_path, "otel-genai"), "brigade.work.verify")
+    mismatch_path = tmp_path / "verify-mismatch"
+    mismatch_path.mkdir()
+    _verify_receipt(
+        mismatch_path,
+        "20260101-000000-work-verify-mismatch",
+        signed=False,
+        receipt_run_id="different-id",
+    )
+    _no_tool(_rows(mismatch_path, "otel-genai"), "brigade.work.verify")
+
+
+def test_outcome_tool_projection_contracts(tmp_path):
+    inherits_path = tmp_path / "inherits"
+    inherits_path.mkdir()
+    verify_id = "20260101-000000-work-verify-outcome"
+    receipt_path = _linked_verify(inherits_path, verify_id)
+    payload = _outcome_payload(evidence_ref=str(receipt_path))
+    _write_outcomes(inherits_path, payload)
+    digest = localio.canonical_json_digest({**payload, "prev_digest": None}, exclude_keys={"digest"})
+    outcome_row = _parented_tool(_rows(inherits_path, "otel-genai"), "otel-genai", "brigade.outcome.capture")
+    assert outcome_row["name"] == "execute_tool brigade.outcome.capture"
+    attrs = outcome_row["attributes"]
+    assert attrs["gen_ai.tool.call.id"] == digest == attrs["brigade.receipt.id"]
+    assert attrs["brigade.outcome.artifact.id"] == "brigade-work"
+    assert attrs["brigade.outcome.current.status"] == "promoted"
+    expected = outcome_core.score_records(
+        "brigade-work",
+        [outcome_core.OutcomeRecord("brigade-work", "skill", "task-1", "verify", 1, str(receipt_path), payload["ts"])],
+    )
+    assert attrs["brigade.outcome.current.score"] == expected.score
+    assert attrs["brigade.outcome.current.helped"] == expected.helped
+    assert "task-1" not in json.dumps(outcome_row)
+    _parented_tool(_rows(inherits_path, "openinference"), "openinference", "brigade.outcome.capture")
+
+    cohort_path = tmp_path / "cohort"
+    cohort_path.mkdir()
+    skill_dir = cohort_path / ".brigade" / "skills" / "registry" / "brigade-work"
+    skill_dir.mkdir(parents=True)
+    skill_md = skill_dir / "SKILL.md"
+    skill_md.write_text("# v1\n")
+    old_fp = hashlib.sha256(skill_md.read_bytes()).hexdigest()
+    cohort_receipt = _linked_verify(cohort_path, "20260101-000000-work-verify-cohort")
+    skill_md.write_text("# v2\n")
+    new_fp = hashlib.sha256(skill_md.read_bytes()).hexdigest()
+    _write_outcomes(
+        cohort_path,
+        _outcome_payload(
+            evidence_ref=str(cohort_receipt),
+            signal_value=1,
+            task_id="t-old",
+            content_fingerprint=old_fp,
+            ts="2026-06-20T00:00:00Z",
+        ),
+        _outcome_payload(
+            evidence_ref=str(cohort_receipt),
+            signal_value=-1,
+            task_id="t-new",
+            content_fingerprint=new_fp,
+            ts="2026-06-20T01:00:00Z",
+        ),
+    )
+    cohort_attrs = _find(_rows(cohort_path, "otel-genai"), "", projection="otel-genai", tool="brigade.outcome.capture")[
+        "attributes"
+    ]
+    assert cohort_attrs["brigade.outcome.current.helped"] == 0
+    assert cohort_attrs["brigade.outcome.current.hurt"] == 1
+    assert cohort_attrs["brigade.outcome.current.score"] == outcome_core.wilson_lower_bound(0, 1)
+    lifetime = outcome_core.score_records(
+        "brigade-work",
+        [
+            outcome_core.OutcomeRecord(
+                "brigade-work",
+                "skill",
+                "t-old",
+                "verify",
+                1,
+                str(cohort_receipt),
+                "2026-06-20T00:00:00Z",
+                content_fingerprint=old_fp,
+            ),
+            outcome_core.OutcomeRecord(
+                "brigade-work",
+                "skill",
+                "t-new",
+                "verify",
+                -1,
+                str(cohort_receipt),
+                "2026-06-20T01:00:00Z",
+                content_fingerprint=new_fp,
+            ),
+        ],
+    )
+    assert lifetime.helped == 1 and lifetime.hurt == 1
+
+    for signal_value, source in ((1, "run"), (-1, "verify")):
+        case_path = tmp_path / f"case-{source}"
+        case_path.mkdir()
+        if source == "run":
+            evidence_ref = str(_run(case_path) / "run.json")
+        else:
+            evidence_ref = str(_linked_verify(case_path, "20260101-000000-work-verify-fail"))
+        _write_outcomes(
+            case_path,
+            _outcome_payload(evidence_ref=evidence_ref, signal_value=signal_value, source=source),
+        )
+        case_outcome = _parented_tool(_rows(case_path, "otel-genai"), "otel-genai", "brigade.outcome.capture")
+        assert case_outcome["status"] == "OK"
+        assert case_outcome["attributes"]["brigade.outcome.source"] == source
+        assert case_outcome["attributes"]["brigade.outcome.signal"] == signal_value
+
+    for case, projections, digest in (
+        ("collision", ("otel-genai",), "USE_VERIFY_ID"),
+        ("forged", ("otel-genai",), "a" * 64),
+        ("digestless", ("otel-genai", "openinference"), None),
+    ):
+        case_path = tmp_path / f"identity-{case}"
+        case_path.mkdir()
+        identity_id = f"20260101-000000-work-verify-{case}"
+        identity_receipt = _linked_verify(case_path, identity_id)
+        identity_payload = _outcome_payload(evidence_ref=str(identity_receipt))
+        if digest == "USE_VERIFY_ID":
+            identity_payload["digest"] = identity_id
+        elif digest is not None:
+            identity_payload["digest"] = digest
+        _write_outcome_raw(case_path, identity_payload)
+        for projection in projections:
+            rows = _rows(case_path, projection)
+            tool_id_attr = "gen_ai.tool.call.id" if projection == "otel-genai" else "tool.id"
+            outcome = _find(rows, "", projection=projection, tool="brigade.outcome.capture")
+            assert "brigade.receipt.id" not in outcome["attributes"]
+            correlation_id = outcome["attributes"][tool_id_attr]
+            if case == "collision":
+                verify = _find(rows, "", projection=projection, tool="brigade.work.verify")
+                assert correlation_id != identity_id
+                assert outcome["span_id"] != verify["span_id"]
+                assert outcome["span_id"] != telemetry_export._receipt_span_id(identity_id, 1)
+            elif case == "forged":
+                assert correlation_id != digest
+                assert correlation_id == telemetry_export._outcome_record_id(identity_payload, 1)
+            else:
+                assert telemetry_export._SHA256_HEX.fullmatch(correlation_id)
+            assert outcome["span_id"] == telemetry_export._outcome_span_id(correlation_id, 1)
+
+    dedup_path = tmp_path / "dedup"
+    dedup_path.mkdir()
+    dedup_receipt = _linked_verify(dedup_path, "20260101-000000-work-verify-dedup")
+    first = _outcome_payload(evidence_ref=str(dedup_receipt), task_id="task-first", signal_value=1)
+    first["prev_digest"] = None
+    dedup_digest = localio.canonical_json_digest(first, exclude_keys={"digest"})
+    first["digest"] = dedup_digest
+    _write_outcome_raw(dedup_path, first, dict(first))
+    (dedup_path / "memory" / "outcome" / "status.json").write_text(
+        json.dumps(
+            {"artifacts": {"brigade-work": {"status": "promoted", "last_action_ts": "2026-01-01T00:00:05Z"}}},
+            sort_keys=True,
+        )
+    )
+    outcomes = [row for row in _rows(dedup_path, "otel-genai") if row["name"] == "execute_tool brigade.outcome.capture"]
+    assert len(outcomes) == 1
+    assert outcomes[0]["attributes"]["gen_ai.tool.call.id"] == dedup_digest
+    assert outcomes[0]["attributes"]["brigade.outcome.signal"] == 1
+
+    extra_path_root = tmp_path / "extra-path"
+    extra_path_root.mkdir()
+    run_dir = _run(extra_path_root, run_id="extra-path-run")
+    extra_path = run_dir / "extra" / "run.json"
+    extra_path.parent.mkdir()
+    extra_path.write_text((run_dir / "run.json").read_text())
+    _write_outcomes(extra_path_root, _outcome_payload(evidence_ref=str(extra_path)))
+    _no_tool(_rows(extra_path_root, "otel-genai"), "brigade.outcome.capture")
+
+    for index, mutation in enumerate(
+        (
+            {"signal_value": {"bad": True}},
+            {"artifact_id": {"nested": "x"}},
+            {"artifact_kind": ""},
+            {"task_id": 1},
+            {"source": None},
+            {"evidence_ref": ""},
+            {"ts": ["2026-01-01T00:00:04Z"]},
+            {"signal_value": 2},
+            {"signal_value": True},
+        )
+    ):
+        bad_path = tmp_path / f"bad-outcome-{index}"
+        bad_path.mkdir()
+        bad_receipt = _verify_receipt(bad_path, f"20260101-000000-work-verify-bad-{index}")
+        bad_payload = _outcome_payload(evidence_ref=str(bad_receipt))
+        bad_payload.update(mutation)
+        _write_outcome_raw(bad_path, bad_payload)
+        _no_tool(_rows(bad_path, "otel-genai"), "brigade.outcome.capture")
+
+
+def test_run_only_projection_is_unchanged(tmp_path):
+    _run(tmp_path)
+    otel_rows = _rows(tmp_path, "otel-genai")
+    oi_rows = _rows(tmp_path, "openinference")
+    assert otel_rows[0] == _RUN_ONLY_OTEL_ROW
+    assert oi_rows[0] == _RUN_ONLY_OPENINFERENCE_ROW
+    verify_id = "20260101-000000-work-verify-extra"
+    _run(
+        tmp_path,
+        run_id="run-2",
+        verify_receipts=[{"run_id": verify_id, "status": "completed", "commands": [{"command": "pytest -q"}]}],
+    )
+    _verify_receipt(tmp_path, verify_id)
+    _write_outcomes(
+        tmp_path,
+        _outcome_payload(evidence_ref=str(tmp_path / ".brigade" / "work" / "verify-runs" / verify_id / "receipt.json")),
+    )
+    otel_with_extra = _rows(tmp_path, "otel-genai")
+    oi_with_extra = _rows(tmp_path, "openinference")
+    assert otel_with_extra[0] == _RUN_ONLY_OTEL_ROW
+    assert oi_with_extra[0] == _RUN_ONLY_OPENINFERENCE_ROW
+    assert len(otel_with_extra) > 1 and len(oi_with_extra) > 1


### PR DESCRIPTION
Closes #491

## Parentage and envelope version

- A verify receipt named by `worker-results.json` shares the owning run's trace ID and uses the first valid projected worker span as its parent.
- An orphan verify receipt is a deterministic root span with `parent_span_id: null`. If separate runs claim the same receipt ID, the ownership is ambiguous and the receipt follows the same orphan rule.
- Outcome records inherit the run anchor resolved from an exact run or verify receipt evidence path.
- Both envelope schemas remain at v1. Receipt rows are additive, and literal success and failure snapshots pin the existing run-only output.

## Attribute map

| Receipt | Projected fields |
| --- | --- |
| Verify | executable basename, exit code, receipt status, duration, target repo, receipt ID, harness name, harness fingerprint |
| Outcome | artifact ID and kind, source, signal, current fingerprint-cohort score counts, current promotion status, target repo |

OTel rows use `gen_ai.operation.name=execute_tool`, `gen_ai.tool.name`, and `gen_ai.tool.call.id`. OpenInference rows use `openinference.span.kind=TOOL`, `tool.name`, and `tool.id`. Brigade fields stay under `brigade.*`.

Only a canonical outcome ledger digest is exposed as `brigade.receipt.id`. Digestless or forged records get a deterministic correlation ID without claiming it is a receipt ID. Verify commands export the executable basename instead of raw arguments.

## Tests

- Verify receipt inside a run in both formats, including trace and parent span
- Outcome receipt with run and verify evidence links in both formats
- Deterministic orphan and ambiguous-owner behavior
- Current fingerprint-cohort score and promotion attributes
- Canonical, forged, digestless, and duplicate outcome identities
- Receipt privacy and malformed-field handling
- Literal success and failure snapshots for unchanged run-only consumers

## Verification

Command:

```text
brigade work verify run --target . --command './scripts/verify' --capture brigade-work
```

- Receipt: `20260726-215908-work-verify-17a0b5`
- Exit code: `0`
- Suite: `4374 passed, 3 skipped`
- Coverage: `82.81%`
- MiseLedger evidence: `f3e6699e9965e3c33ef2383b`

## Real linked projections

The source pair is run `20260726-issue491-implementation` and verify receipt `20260726-205418-work-verify-d32500`.

OTel GenAI:

```json
{"attributes":{"brigade.receipt.id":"20260726-205418-work-verify-d32500","brigade.target.repo":"brigade-491-receipt-telemetry","brigade.verify.command.executable":"pytest","brigade.verify.exit_code":0,"brigade.verify.status":"completed","gen_ai.operation.name":"execute_tool","gen_ai.tool.call.id":"20260726-205418-work-verify-d32500:1","gen_ai.tool.name":"brigade.work.verify"},"duration_seconds":0.731811,"end_time":"2026-07-26T20:54:20.401969+00:00","error_type":null,"mapping":{"mapping_version":1,"name":"otel-genai","upstream_revision":"opentelemetry-semconv-1.43.0"},"name":"execute_tool brigade.work.verify","parent_span_id":"394b57b2349b7611","schema":"brigade.otel_genai_projection.v1","span_id":"03fd83e0ed1599a4","start_time":"2026-07-26T20:54:19.670019+00:00","status":"OK","trace_id":"3e1f5b04740e5bb51d2cc2fed3231dc4"}
```

OpenInference:

```json
{"attributes":{"brigade.receipt.id":"20260726-205418-work-verify-d32500","brigade.target.repo":"brigade-491-receipt-telemetry","brigade.verify.command.executable":"pytest","brigade.verify.exit_code":0,"brigade.verify.status":"completed","openinference.span.kind":"TOOL","tool.id":"20260726-205418-work-verify-d32500:1","tool.name":"brigade.work.verify"},"duration_seconds":0.731811,"end_time":"2026-07-26T20:54:20.401969+00:00","error_type":null,"mapping":{"mapping_version":1,"name":"openinference","upstream_revision":"audited-2026-07-12"},"name":"brigade.work.verify","parent_span_id":"394b57b2349b7611","schema":"brigade.openinference_projection.v1","span_id":"03fd83e0ed1599a4","start_time":"2026-07-26T20:54:19.670019+00:00","status":"OK","trace_id":"3e1f5b04740e5bb51d2cc2fed3231dc4"}
```
