### PR TITLE
feat(run): type worker failure receipts

### DIFF
--- a/src/brigade/run_receipts.py
+++ b/src/brigade/run_receipts.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from . import agents, localio
 from .run_transport import Assignment, WorkerAttempt, WorkerResult
+from .worker_failure import normalized_failure
 
 
 def assignment_payload(assignments: list[Assignment]) -> list[dict[str, object]]:
@@ -38,6 +39,16 @@ def worker_payload(results: list[WorkerResult]) -> list[dict[str, object]]:
             entry["failure_phase"] = result.failure_phase
         if result.failure_kind is not None:
             entry["failure_kind"] = result.failure_kind
+        if not result.ok:
+            failure = normalized_failure(
+                failure_phase=result.failure_phase,
+                failure_kind=result.failure_kind,
+                detail=result.detail,
+                timed_out=result.timed_out,
+                status=result.status,
+            )
+            if failure is not None:
+                entry["failure"] = failure.payload()
         if result.transport_warning is not None:
             entry["transport_warning"] = dict(result.transport_warning)
         if result.thread_id is not None:
@@ -73,12 +84,15 @@ def worker_payload(results: list[WorkerResult]) -> list[dict[str, object]]:
         if result.endpoint_host is not None:
             entry["endpoint_host"] = result.endpoint_host
         if result.attempts:
-            entry["attempts"] = [_attempt_payload(attempt) for attempt in result.attempts]
+            entry["attempts"] = [
+                _attempt_payload(attempt, attempt_number=index)
+                for index, attempt in enumerate(result.attempts, start=1)
+            ]
         payload.append(entry)
     return payload
 
 
-def _attempt_payload(attempt: WorkerAttempt) -> dict[str, object]:
+def _attempt_payload(attempt: WorkerAttempt, *, attempt_number: int) -> dict[str, object]:
     payload: dict[str, object] = {
         "kind": attempt.kind,
         "worker": attempt.worker,
@@ -99,6 +113,17 @@ def _attempt_payload(attempt: WorkerAttempt) -> dict[str, object]:
         payload["stdout_log"] = attempt.stdout_log
     if attempt.stderr_log is not None:
         payload["stderr_log"] = attempt.stderr_log
+    if not attempt.ok or attempt.failure_phase is not None or attempt.failure_kind is not None:
+        failure = normalized_failure(
+            failure_phase=attempt.failure_phase,
+            failure_kind=attempt.failure_kind,
+            detail=attempt.detail,
+            timed_out=attempt.timed_out,
+            status="",
+            attempt=attempt_number,
+        )
+        if failure is not None:
+            payload["failure"] = failure.payload()
     return payload
 
 

--- a/src/brigade/run_transport.py
+++ b/src/brigade/run_transport.py
@@ -50,6 +50,9 @@ class WorkerAttempt:
     stderr: str | None = None
     stdout_log: str | None = None
     stderr_log: str | None = None
+    detail: str = ""
+    ok: bool = True
+    timed_out: bool = False
 
 
 def _attempt_timestamp() -> str:
@@ -123,6 +126,9 @@ def _worker_attempt(
         selected=selected,
         stdout=result.stdout,
         stderr=result.stderr,
+        detail=result.detail,
+        ok=result.ok,
+        timed_out=result.timed_out,
     )
 
 

--- a/src/brigade/worker_failure.py
+++ b/src/brigade/worker_failure.py
@@ -1,0 +1,333 @@
+"""Closed worker-failure taxonomy and legacy receipt compatibility."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+
+
+SCHEMA = "brigade.worker_failure.v1"
+DETAIL_LIMIT = 200
+
+
+class FailureClass(str, Enum):
+    CONFIGURATION_INVALID = "configuration-invalid"
+    EXECUTABLE_UNAVAILABLE = "executable-unavailable"
+    AUTH_REQUIRED = "auth-required"
+    ENTITLEMENT_DENIED = "entitlement-denied"
+    VERSION_GATE = "version-gate"
+    MODEL_UNAVAILABLE = "model-unavailable"
+    CAPACITY_EXHAUSTED = "capacity-exhausted"
+    NETWORK_UNAVAILABLE = "network-unavailable"
+    TRANSPORT_UNAVAILABLE = "transport-unavailable"
+    TRANSPORT_HANG = "transport-hang"
+    INTERACTIVE_BLOCKED = "interactive-blocked"
+    WORKER_CRASH = "worker-crash"
+    TIMEOUT = "timeout"
+    ISOLATION_BREACH = "isolation-breach"
+    OUTPUT_CONTRACT_VIOLATION = "output-contract-violation"
+    PROVIDER_REJECTED = "provider-rejected"
+    UNCLASSIFIED = "unclassified"
+
+
+class FailurePhase(str, Enum):
+    PREFLIGHT = "preflight"
+    DISPATCH = "dispatch"
+    POSTFLIGHT = "postflight"
+    VALIDATION = "validation"
+
+
+class RetryDisposition(str, Enum):
+    NEVER = "never"
+    AFTER_REMEDIATION = "after-remediation"
+    FALLBACK = "fallback"
+    SAME_SEAT_ONCE = "same-seat-once"
+
+
+class FailureDomain(str, Enum):
+    INFRASTRUCTURE = "infrastructure"
+
+
+@dataclass(frozen=True)
+class FailureClassSpec:
+    allowed_retries: frozenset[RetryDisposition]
+    default_retry: RetryDisposition
+    phases: frozenset[FailurePhase]
+    default_phase: FailurePhase
+
+    def __post_init__(self) -> None:
+        if not self.allowed_retries:
+            raise ValueError("allowed_retries must not be empty")
+        if self.default_retry not in self.allowed_retries:
+            raise ValueError("default_retry must be included in allowed_retries")
+
+
+FAILURE_CLASS_SPECS: dict[FailureClass, FailureClassSpec] = {
+    FailureClass.CONFIGURATION_INVALID: FailureClassSpec(
+        frozenset({RetryDisposition.AFTER_REMEDIATION}),
+        RetryDisposition.AFTER_REMEDIATION,
+        frozenset({FailurePhase.PREFLIGHT}),
+        FailurePhase.PREFLIGHT,
+    ),
+    FailureClass.EXECUTABLE_UNAVAILABLE: FailureClassSpec(
+        frozenset({RetryDisposition.AFTER_REMEDIATION}),
+        RetryDisposition.AFTER_REMEDIATION,
+        frozenset({FailurePhase.PREFLIGHT}),
+        FailurePhase.PREFLIGHT,
+    ),
+    FailureClass.AUTH_REQUIRED: FailureClassSpec(
+        frozenset({RetryDisposition.AFTER_REMEDIATION}),
+        RetryDisposition.AFTER_REMEDIATION,
+        frozenset({FailurePhase.PREFLIGHT, FailurePhase.DISPATCH}),
+        FailurePhase.PREFLIGHT,
+    ),
+    FailureClass.ENTITLEMENT_DENIED: FailureClassSpec(
+        frozenset({RetryDisposition.AFTER_REMEDIATION}),
+        RetryDisposition.AFTER_REMEDIATION,
+        frozenset({FailurePhase.PREFLIGHT, FailurePhase.DISPATCH}),
+        FailurePhase.DISPATCH,
+    ),
+    FailureClass.VERSION_GATE: FailureClassSpec(
+        frozenset({RetryDisposition.AFTER_REMEDIATION}),
+        RetryDisposition.AFTER_REMEDIATION,
+        frozenset({FailurePhase.PREFLIGHT}),
+        FailurePhase.PREFLIGHT,
+    ),
+    FailureClass.MODEL_UNAVAILABLE: FailureClassSpec(
+        frozenset({RetryDisposition.FALLBACK}),
+        RetryDisposition.FALLBACK,
+        frozenset({FailurePhase.PREFLIGHT}),
+        FailurePhase.PREFLIGHT,
+    ),
+    FailureClass.CAPACITY_EXHAUSTED: FailureClassSpec(
+        frozenset({RetryDisposition.FALLBACK, RetryDisposition.SAME_SEAT_ONCE}),
+        RetryDisposition.FALLBACK,
+        frozenset({FailurePhase.DISPATCH}),
+        FailurePhase.DISPATCH,
+    ),
+    FailureClass.NETWORK_UNAVAILABLE: FailureClassSpec(
+        frozenset({RetryDisposition.SAME_SEAT_ONCE}),
+        RetryDisposition.SAME_SEAT_ONCE,
+        frozenset({FailurePhase.PREFLIGHT, FailurePhase.DISPATCH}),
+        FailurePhase.DISPATCH,
+    ),
+    FailureClass.TRANSPORT_UNAVAILABLE: FailureClassSpec(
+        frozenset({RetryDisposition.SAME_SEAT_ONCE}),
+        RetryDisposition.SAME_SEAT_ONCE,
+        frozenset({FailurePhase.PREFLIGHT, FailurePhase.DISPATCH}),
+        FailurePhase.DISPATCH,
+    ),
+    FailureClass.TRANSPORT_HANG: FailureClassSpec(
+        frozenset({RetryDisposition.FALLBACK}),
+        RetryDisposition.FALLBACK,
+        frozenset({FailurePhase.PREFLIGHT, FailurePhase.DISPATCH}),
+        FailurePhase.DISPATCH,
+    ),
+    FailureClass.INTERACTIVE_BLOCKED: FailureClassSpec(
+        frozenset({RetryDisposition.NEVER}),
+        RetryDisposition.NEVER,
+        frozenset({FailurePhase.PREFLIGHT, FailurePhase.DISPATCH}),
+        FailurePhase.DISPATCH,
+    ),
+    FailureClass.WORKER_CRASH: FailureClassSpec(
+        frozenset({RetryDisposition.FALLBACK}),
+        RetryDisposition.FALLBACK,
+        frozenset({FailurePhase.DISPATCH}),
+        FailurePhase.DISPATCH,
+    ),
+    FailureClass.TIMEOUT: FailureClassSpec(
+        frozenset({RetryDisposition.FALLBACK}),
+        RetryDisposition.FALLBACK,
+        frozenset({FailurePhase.DISPATCH}),
+        FailurePhase.DISPATCH,
+    ),
+    FailureClass.ISOLATION_BREACH: FailureClassSpec(
+        frozenset({RetryDisposition.NEVER}),
+        RetryDisposition.NEVER,
+        frozenset({FailurePhase.POSTFLIGHT}),
+        FailurePhase.POSTFLIGHT,
+    ),
+    FailureClass.OUTPUT_CONTRACT_VIOLATION: FailureClassSpec(
+        frozenset({RetryDisposition.NEVER, RetryDisposition.FALLBACK}),
+        RetryDisposition.NEVER,
+        frozenset({FailurePhase.VALIDATION}),
+        FailurePhase.VALIDATION,
+    ),
+    FailureClass.PROVIDER_REJECTED: FailureClassSpec(
+        frozenset({RetryDisposition.FALLBACK}),
+        RetryDisposition.FALLBACK,
+        frozenset({FailurePhase.DISPATCH}),
+        FailurePhase.DISPATCH,
+    ),
+    FailureClass.UNCLASSIFIED: FailureClassSpec(
+        frozenset({RetryDisposition.NEVER}),
+        RetryDisposition.NEVER,
+        frozenset(FailurePhase),
+        FailurePhase.DISPATCH,
+    ),
+}
+
+
+# Every value emitted by a worker adapter is mapped here. New adapter kinds must
+# be added deliberately; unrecognized values map to ``unclassified`` below.
+LEGACY_FAILURE_KIND_MAP: dict[str, FailureClass] = {
+    "authentication-error": FailureClass.AUTH_REQUIRED,
+    "auth-status-unavailable": FailureClass.UNCLASSIFIED,
+    "auth-status-unrecognized": FailureClass.UNCLASSIFIED,
+    "browser-auth": FailureClass.AUTH_REQUIRED,
+    "command-not-found": FailureClass.EXECUTABLE_UNAVAILABLE,
+    "decode-failure": FailureClass.TRANSPORT_UNAVAILABLE,
+    "empty-output": FailureClass.OUTPUT_CONTRACT_VIOLATION,
+    "env-ref-missing": FailureClass.CONFIGURATION_INVALID,
+    "grok-fallback-missing": FailureClass.CONFIGURATION_INVALID,
+    "grok-session-missing": FailureClass.OUTPUT_CONTRACT_VIOLATION,
+    "invalid-dispatch-args": FailureClass.CONFIGURATION_INVALID,
+    "invalid-session-continuation": FailureClass.CONFIGURATION_INVALID,
+    "malformed-final-output": FailureClass.OUTPUT_CONTRACT_VIOLATION,
+    "malformed-transport": FailureClass.OUTPUT_CONTRACT_VIOLATION,
+    "missing-executable": FailureClass.EXECUTABLE_UNAVAILABLE,
+    "network-error": FailureClass.NETWORK_UNAVAILABLE,
+    "non-final-output": FailureClass.OUTPUT_CONTRACT_VIOLATION,
+    "non-final-stop": FailureClass.OUTPUT_CONTRACT_VIOLATION,
+    "permission-denied": FailureClass.INTERACTIVE_BLOCKED,
+    "permission-error": FailureClass.INTERACTIVE_BLOCKED,
+    "provider-auth": FailureClass.AUTH_REQUIRED,
+    "provider-config": FailureClass.CONFIGURATION_INVALID,
+    "provider-error": FailureClass.PROVIDER_REJECTED,
+    "provider-setting-error": FailureClass.MODEL_UNAVAILABLE,
+    "provider-startup": FailureClass.TRANSPORT_UNAVAILABLE,
+    "rate-limit-error": FailureClass.CAPACITY_EXHAUSTED,
+    "timeout": FailureClass.TIMEOUT,
+    "tool-only-output": FailureClass.OUTPUT_CONTRACT_VIOLATION,
+    "transport-error": FailureClass.TRANSPORT_UNAVAILABLE,
+    "unsafe-worktree": FailureClass.CONFIGURATION_INVALID,
+    "unsupported-command-shim": FailureClass.EXECUTABLE_UNAVAILABLE,
+    "unsupported-sandbox": FailureClass.CONFIGURATION_INVALID,
+    "version-mismatch": FailureClass.VERSION_GATE,
+    "workspace-trust": FailureClass.INTERACTIVE_BLOCKED,
+}
+
+_LEGACY_PHASE_MAP = {
+    "preflight": FailurePhase.PREFLIGHT,
+    "provider-preflight": FailurePhase.PREFLIGHT,
+    "dispatch": FailurePhase.DISPATCH,
+    "harness": FailurePhase.DISPATCH,
+    "inference": FailurePhase.DISPATCH,
+    "postflight": FailurePhase.POSTFLIGHT,
+    "output-validation": FailurePhase.VALIDATION,
+    "validation": FailurePhase.VALIDATION,
+}
+_NON_WORKER_STATUSES = frozenset({"skipped", "held", "canceled", "abandoned"})
+_RUN_OWNED_FAILURE_KINDS = frozenset(
+    {
+        "agent-error",
+        "branch-head-drift",
+        "collection-error",
+        "dirty-worktree",
+        "early-exit",
+        "handoff-write-error",
+        "interrupted",
+        "invalid-patch",
+        "invalid-plan",
+        "keyboard-interrupt",
+        "orchestrator-error",
+        "planner-failure",
+        "receipt-update-error",
+        "receipt-write-failure",
+        "signal",
+        "spawn-error",
+        "unexpected-error",
+        "verification-failure",
+        "worker-failure",
+    }
+)
+_URL_CREDENTIALS = re.compile(r"(?P<scheme>https?://)[^/@\s:]+:[^/@\s]+@", re.IGNORECASE)
+_URL_QUERY = re.compile(r"(?P<url>https?://[^\s?#]+)(?:\?[^\s#]*)?(?:#[^\s]*)?", re.IGNORECASE)
+_SECRET_ASSIGNMENT = re.compile(
+    r"\b(?P<name>api[_-]?key|token|password|secret|authorization)\s*(?P<separator>=|:)\s*[^\s,;]+",
+    re.IGNORECASE,
+)
+_BEARER_TOKEN = re.compile(r"\bBearer\s+[^\s,;]+", re.IGNORECASE)
+
+
+def safe_detail(detail: str) -> str:
+    """Return bounded receipt detail without common credential forms."""
+
+    redacted = _URL_CREDENTIALS.sub(r"\g<scheme>[redacted]@", detail)
+    redacted = _URL_QUERY.sub(r"\g<url>", redacted)
+    redacted = _SECRET_ASSIGNMENT.sub(r"\g<name>\g<separator>[redacted]", redacted)
+    redacted = _BEARER_TOKEN.sub("Bearer [redacted]", redacted)
+    return redacted[:DETAIL_LIMIT]
+
+
+@dataclass(frozen=True)
+class WorkerFailure:
+    """A normalized, public worker failure suitable for an additive receipt."""
+
+    failure_class: FailureClass
+    phase: FailurePhase
+    retry: RetryDisposition
+    detected_by: str
+    detail: str
+    cause_code: str | None = None
+    attempt: int | None = None
+    domain: FailureDomain = FailureDomain.INFRASTRUCTURE
+
+    def __post_init__(self) -> None:
+        spec = FAILURE_CLASS_SPECS[self.failure_class]
+        if self.phase not in spec.phases:
+            raise ValueError(f"{self.failure_class.value} is not valid during {self.phase.value}")
+        if self.retry not in spec.allowed_retries:
+            allowed = ", ".join(sorted(retry.value for retry in spec.allowed_retries))
+            raise ValueError(f"{self.failure_class.value} must use one of: {allowed}")
+
+    def payload(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "schema": SCHEMA,
+            "class": self.failure_class.value,
+            "domain": self.domain.value,
+            "phase": self.phase.value,
+            "retry": self.retry.value,
+            "detected_by": self.detected_by,
+            "detail": safe_detail(self.detail),
+        }
+        if self.cause_code is not None:
+            payload["cause_code"] = self.cause_code
+        if self.attempt is not None:
+            payload["attempt"] = self.attempt
+        return payload
+
+
+def normalized_failure(
+    *,
+    failure_phase: str | None,
+    failure_kind: str | None,
+    detail: str,
+    timed_out: bool = False,
+    status: str = "",
+    attempt: int | None = None,
+) -> WorkerFailure | None:
+    """Map a legacy worker receipt value without changing its original fields."""
+
+    normalized_status = status.strip().lower()
+    normalized_kind = failure_kind.strip().lower() if failure_kind else None
+    if normalized_status in _NON_WORKER_STATUSES or normalized_kind in _RUN_OWNED_FAILURE_KINDS:
+        return None
+
+    if normalized_kind is None and timed_out:
+        failure_class = FailureClass.TIMEOUT
+    else:
+        failure_class = LEGACY_FAILURE_KIND_MAP.get(normalized_kind or "", FailureClass.UNCLASSIFIED)
+    spec = FAILURE_CLASS_SPECS[failure_class]
+    legacy_phase = _LEGACY_PHASE_MAP.get((failure_phase or "").strip().lower(), FailurePhase.DISPATCH)
+    phase = legacy_phase if legacy_phase in spec.phases else spec.default_phase
+    return WorkerFailure(
+        failure_class=failure_class,
+        phase=phase,
+        retry=spec.default_retry,
+        detected_by="legacy-failure-kind" if normalized_kind else "receipt-fallback",
+        detail=detail,
+        cause_code=normalized_kind,
+        attempt=attempt,
+    )

--- a/tests/test_run_transport_recovery.py
+++ b/tests/test_run_transport_recovery.py
@@ -51,6 +51,17 @@ def test_worker_payload_serializes_required_attempt_fields_with_null_exit_code()
         "terminal_reason": "malformed-final-output",
         "failure_phase": "output-validation",
         "failure_kind": "malformed-final-output",
+        "failure": {
+            "schema": "brigade.worker_failure.v1",
+            "class": "output-contract-violation",
+            "domain": "infrastructure",
+            "phase": "validation",
+            "retry": "never",
+            "detected_by": "legacy-failure-kind",
+            "cause_code": "malformed-final-output",
+            "detail": "",
+            "attempt": 1,
+        },
         "session_id": "019f0000-0000-7000-8000-000000000001",
         "selected": False,
     }

--- a/tests/test_worker_failure.py
+++ b/tests/test_worker_failure.py
@@ -1,0 +1,310 @@
+import pytest
+
+from brigade.worker_failure import (
+    FAILURE_CLASS_SPECS,
+    LEGACY_FAILURE_KIND_MAP,
+    FailureClass,
+    FailurePhase,
+    RetryDisposition,
+    WorkerFailure,
+    normalized_failure,
+    safe_detail,
+)
+from brigade.run_receipts import worker_payload
+from brigade.run_transport import WorkerAttempt, WorkerResult
+
+
+EXPECTED_PUBLIC_CLASSES = {
+    "configuration-invalid",
+    "executable-unavailable",
+    "auth-required",
+    "entitlement-denied",
+    "version-gate",
+    "model-unavailable",
+    "capacity-exhausted",
+    "network-unavailable",
+    "transport-unavailable",
+    "transport-hang",
+    "interactive-blocked",
+    "worker-crash",
+    "timeout",
+    "isolation-breach",
+    "output-contract-violation",
+    "provider-rejected",
+    "unclassified",
+}
+EXPECTED_LEGACY_CLASSIFICATIONS = {
+    "authentication-error": FailureClass.AUTH_REQUIRED,
+    "auth-status-unavailable": FailureClass.UNCLASSIFIED,
+    "auth-status-unrecognized": FailureClass.UNCLASSIFIED,
+    "browser-auth": FailureClass.AUTH_REQUIRED,
+    "command-not-found": FailureClass.EXECUTABLE_UNAVAILABLE,
+    "decode-failure": FailureClass.TRANSPORT_UNAVAILABLE,
+    "empty-output": FailureClass.OUTPUT_CONTRACT_VIOLATION,
+    "env-ref-missing": FailureClass.CONFIGURATION_INVALID,
+    "grok-fallback-missing": FailureClass.CONFIGURATION_INVALID,
+    "grok-session-missing": FailureClass.OUTPUT_CONTRACT_VIOLATION,
+    "invalid-dispatch-args": FailureClass.CONFIGURATION_INVALID,
+    "invalid-session-continuation": FailureClass.CONFIGURATION_INVALID,
+    "malformed-final-output": FailureClass.OUTPUT_CONTRACT_VIOLATION,
+    "malformed-transport": FailureClass.OUTPUT_CONTRACT_VIOLATION,
+    "missing-executable": FailureClass.EXECUTABLE_UNAVAILABLE,
+    "network-error": FailureClass.NETWORK_UNAVAILABLE,
+    "non-final-output": FailureClass.OUTPUT_CONTRACT_VIOLATION,
+    "non-final-stop": FailureClass.OUTPUT_CONTRACT_VIOLATION,
+    "permission-denied": FailureClass.INTERACTIVE_BLOCKED,
+    "permission-error": FailureClass.INTERACTIVE_BLOCKED,
+    "provider-auth": FailureClass.AUTH_REQUIRED,
+    "provider-config": FailureClass.CONFIGURATION_INVALID,
+    "provider-error": FailureClass.PROVIDER_REJECTED,
+    "provider-setting-error": FailureClass.MODEL_UNAVAILABLE,
+    "provider-startup": FailureClass.TRANSPORT_UNAVAILABLE,
+    "rate-limit-error": FailureClass.CAPACITY_EXHAUSTED,
+    "timeout": FailureClass.TIMEOUT,
+    "tool-only-output": FailureClass.OUTPUT_CONTRACT_VIOLATION,
+    "transport-error": FailureClass.TRANSPORT_UNAVAILABLE,
+    "unsafe-worktree": FailureClass.CONFIGURATION_INVALID,
+    "unsupported-command-shim": FailureClass.EXECUTABLE_UNAVAILABLE,
+    "unsupported-sandbox": FailureClass.CONFIGURATION_INVALID,
+    "version-mismatch": FailureClass.VERSION_GATE,
+    "workspace-trust": FailureClass.INTERACTIVE_BLOCKED,
+}
+
+EXPECTED_RETRY_POLICIES = {
+    FailureClass.CONFIGURATION_INVALID: ({RetryDisposition.AFTER_REMEDIATION}, RetryDisposition.AFTER_REMEDIATION),
+    FailureClass.EXECUTABLE_UNAVAILABLE: ({RetryDisposition.AFTER_REMEDIATION}, RetryDisposition.AFTER_REMEDIATION),
+    FailureClass.AUTH_REQUIRED: ({RetryDisposition.AFTER_REMEDIATION}, RetryDisposition.AFTER_REMEDIATION),
+    FailureClass.ENTITLEMENT_DENIED: ({RetryDisposition.AFTER_REMEDIATION}, RetryDisposition.AFTER_REMEDIATION),
+    FailureClass.VERSION_GATE: ({RetryDisposition.AFTER_REMEDIATION}, RetryDisposition.AFTER_REMEDIATION),
+    FailureClass.MODEL_UNAVAILABLE: ({RetryDisposition.FALLBACK}, RetryDisposition.FALLBACK),
+    FailureClass.CAPACITY_EXHAUSTED: (
+        {RetryDisposition.FALLBACK, RetryDisposition.SAME_SEAT_ONCE},
+        RetryDisposition.FALLBACK,
+    ),
+    FailureClass.NETWORK_UNAVAILABLE: ({RetryDisposition.SAME_SEAT_ONCE}, RetryDisposition.SAME_SEAT_ONCE),
+    FailureClass.TRANSPORT_UNAVAILABLE: ({RetryDisposition.SAME_SEAT_ONCE}, RetryDisposition.SAME_SEAT_ONCE),
+    FailureClass.TRANSPORT_HANG: ({RetryDisposition.FALLBACK}, RetryDisposition.FALLBACK),
+    FailureClass.INTERACTIVE_BLOCKED: ({RetryDisposition.NEVER}, RetryDisposition.NEVER),
+    FailureClass.WORKER_CRASH: ({RetryDisposition.FALLBACK}, RetryDisposition.FALLBACK),
+    FailureClass.TIMEOUT: ({RetryDisposition.FALLBACK}, RetryDisposition.FALLBACK),
+    FailureClass.ISOLATION_BREACH: ({RetryDisposition.NEVER}, RetryDisposition.NEVER),
+    FailureClass.OUTPUT_CONTRACT_VIOLATION: (
+        {RetryDisposition.NEVER, RetryDisposition.FALLBACK},
+        RetryDisposition.NEVER,
+    ),
+    FailureClass.PROVIDER_REJECTED: ({RetryDisposition.FALLBACK}, RetryDisposition.FALLBACK),
+    FailureClass.UNCLASSIFIED: ({RetryDisposition.NEVER}, RetryDisposition.NEVER),
+}
+
+
+def test_public_taxonomy_has_exactly_the_17_proposed_classes():
+    assert {failure_class.value for failure_class in FailureClass} == EXPECTED_PUBLIC_CLASSES
+
+
+@pytest.mark.parametrize("failure_class, spec", FAILURE_CLASS_SPECS.items())
+def test_every_public_failure_class_has_a_valid_default_phase_and_retry(failure_class, spec):
+    allowed_retries, default_retry = EXPECTED_RETRY_POLICIES[failure_class]
+    failure = WorkerFailure(
+        failure_class=failure_class,
+        phase=spec.default_phase,
+        retry=spec.default_retry,
+        detected_by="fake-adapter",
+        detail="fake fixture detail",
+    )
+
+    assert spec.allowed_retries == frozenset(allowed_retries)
+    assert spec.default_retry is default_retry
+    assert failure.payload()["schema"] == "brigade.worker_failure.v1"
+    assert failure.payload()["class"] == failure_class.value
+    assert failure.payload()["domain"] == "infrastructure"
+
+
+def test_capacity_exhausted_allows_same_seat_once_when_a_provider_supplies_a_retry_delay():
+    failure = WorkerFailure(
+        failure_class=FailureClass.CAPACITY_EXHAUSTED,
+        phase=FailurePhase.DISPATCH,
+        retry=RetryDisposition.SAME_SEAT_ONCE,
+        detected_by="fake-provider-delay",
+        detail="retry after 30 seconds",
+    )
+
+    assert failure.retry is RetryDisposition.SAME_SEAT_ONCE
+
+
+def test_output_contract_violation_allows_reviewed_invalid_final_fallback():
+    failure = WorkerFailure(
+        failure_class=FailureClass.OUTPUT_CONTRACT_VIOLATION,
+        phase=FailurePhase.VALIDATION,
+        retry=RetryDisposition.FALLBACK,
+        detected_by="fake-reviewed-invalid-final-fallback",
+        detail="final output was invalid",
+    )
+
+    assert failure.retry is RetryDisposition.FALLBACK
+
+
+@pytest.mark.parametrize(
+    ("failure_kind", "expected_class", "expected_retry"),
+    [
+        ("rate-limit-error", FailureClass.CAPACITY_EXHAUSTED, RetryDisposition.FALLBACK),
+        ("empty-output", FailureClass.OUTPUT_CONTRACT_VIOLATION, RetryDisposition.NEVER),
+    ],
+)
+def test_normalized_contextual_failures_use_their_conservative_defaults(failure_kind, expected_class, expected_retry):
+    failure = normalized_failure(
+        failure_phase="dispatch",
+        failure_kind=failure_kind,
+        detail="fake adapter failure",
+    )
+
+    assert failure is not None
+    assert failure.failure_class is expected_class
+    assert failure.retry is expected_retry
+
+
+@pytest.mark.parametrize("failure_class, spec", FAILURE_CLASS_SPECS.items())
+def test_worker_failure_rejects_a_retry_outside_the_class_allowed_set(failure_class, spec):
+    invalid_retry = next(retry for retry in RetryDisposition if retry not in spec.allowed_retries)
+
+    with pytest.raises(ValueError, match="must use one of"):
+        WorkerFailure(
+            failure_class=failure_class,
+            phase=spec.default_phase,
+            retry=invalid_retry,
+            detected_by="fake-adapter",
+            detail="fake fixture detail",
+        )
+
+
+@pytest.mark.parametrize("legacy_kind, expected_class", EXPECTED_LEGACY_CLASSIFICATIONS.items())
+def test_every_known_legacy_failure_kind_maps_to_a_closed_class(legacy_kind, expected_class):
+    failure = normalized_failure(
+        failure_phase="dispatch",
+        failure_kind=legacy_kind,
+        detail="fake adapter failure",
+    )
+
+    assert failure is not None
+    assert failure.failure_class is expected_class
+    assert failure.cause_code == legacy_kind
+
+
+def test_legacy_compatibility_table_covers_only_currently_emitted_adapter_kinds():
+    assert LEGACY_FAILURE_KIND_MAP == EXPECTED_LEGACY_CLASSIFICATIONS
+
+
+def test_unknown_legacy_failure_is_unclassified_with_actual_normalized_phase():
+    failure = normalized_failure(
+        failure_phase="output-validation",
+        failure_kind="future-adapter-code",
+        detail="fake future error",
+    )
+
+    assert failure is not None
+    assert failure.failure_class is FailureClass.UNCLASSIFIED
+    assert failure.phase is FailurePhase.VALIDATION
+    assert failure.retry.value == "never"
+    assert failure.cause_code == "future-adapter-code"
+
+
+@pytest.mark.parametrize(
+    ("status", "failure_kind"),
+    [
+        ("skipped", None),
+        ("held", None),
+        ("canceled", "interrupted"),
+        ("failed", "keyboard-interrupt"),
+        ("failed", "branch-head-drift"),
+    ],
+)
+def test_run_and_operator_failures_stay_outside_worker_taxonomy(status, failure_kind):
+    assert (
+        normalized_failure(
+            failure_phase="dispatch",
+            failure_kind=failure_kind,
+            detail="fake non-worker failure",
+            status=status,
+        )
+        is None
+    )
+
+
+def test_normalized_failure_detail_is_bounded_and_redacted():
+    raw = "token=fake-token-value https://fake-user:fake-password@fake.example.test/v1?api_key=fake-key"
+
+    detail = safe_detail(raw)
+
+    assert "fake-token-value" not in detail
+    assert "fake-password" not in detail
+    assert "fake-key" not in detail
+    assert "[redacted]" in detail
+    assert len(safe_detail("x" * 400)) == 200
+
+
+def test_failed_result_and_attempt_serialize_additive_normalized_failures():
+    attempt = WorkerAttempt(
+        kind="initial",
+        worker="fake-worker",
+        task="fake task",
+        transport="fake-transport",
+        model=None,
+        reasoning=None,
+        started_at="2026-07-26T00:00:00Z",
+        finished_at="2026-07-26T00:00:01Z",
+        exit_code=7,
+        terminal_reason="network-error",
+        failure_phase="dispatch",
+        failure_kind="network-error",
+        session_id=None,
+        detail="token=fake-token-value",
+    )
+    result = WorkerResult(
+        worker="fake-worker",
+        task="fake task",
+        text="",
+        ok=False,
+        detail="token=fake-token-value",
+        failure_phase="dispatch",
+        failure_kind="network-error",
+        attempts=(attempt,),
+    )
+
+    payload = worker_payload([result])[0]
+
+    assert payload["failure"]["class"] == "network-unavailable"
+    assert payload["failure"]["detail"] == "token=[redacted]"
+    assert payload["attempts"][0]["failure"] == {
+        **payload["failure"],
+        "attempt": 1,
+    }
+
+
+def test_successful_result_does_not_receive_a_failure_object():
+    payload = worker_payload([WorkerResult(worker="fake-worker", task="fake task", text="done", ok=True)])[0]
+
+    assert "failure" not in payload
+
+
+def test_failed_attempt_without_a_legacy_kind_is_unclassified():
+    attempt = WorkerAttempt(
+        kind="initial",
+        worker="fake-worker",
+        task="fake task",
+        transport="fake-transport",
+        model=None,
+        reasoning=None,
+        started_at="2026-07-26T00:00:00Z",
+        finished_at="2026-07-26T00:00:01Z",
+        exit_code=7,
+        terminal_reason="failed",
+        failure_phase=None,
+        failure_kind=None,
+        session_id=None,
+        ok=False,
+    )
+    result = WorkerResult(worker="fake-worker", task="fake task", text="", ok=False, attempts=(attempt,))
+
+    payload = worker_payload([result])[0]
+
+    assert payload["failure"]["class"] == "unclassified"
+    assert payload["attempts"][0]["failure"]["class"] == "unclassified"


### PR DESCRIPTION
Closes #576. Parent tracking issue: #474.

## What changed

- define the closed 17-class worker-failure taxonomy and valid phase/retry contracts
- map current adapter failure kinds to normalized `brigade.worker_failure.v1` values
- add normalized failures to failed worker and attempt receipts while retaining legacy fields
- keep run lifecycle, cancellation, skipped, held, and run-owned failures outside the worker taxonomy
- redact and bound normalized receipt detail

The two contextual retry cases remain expressible for later routing work: capacity failures may retry once when the provider supplies a delay, and reviewed invalid-final fallbacks may handle output-contract violations. Legacy receipts use conservative defaults.

## Verification

`brigade work verify run --target . --command "./scripts/verify" --capture brigade-work`

Completed receipt: `20260726-233147-work-verify-cfdf0b`.