### PR TITLE
feat(run): add unified seat health probe

### DIFF
--- a/src/brigade/roster_cmd.py
+++ b/src/brigade/roster_cmd.py
@@ -9,6 +9,7 @@ from . import agents
 from . import doctor as doctor_mod
 from . import model_inventory
 from . import roster as roster_mod
+from . import seat_health
 from . import templates
 from . import toml_compat
 
@@ -323,6 +324,7 @@ def doctor(
     *,
     roster_path: Path | None = None,
     probe: roster_mod.CapabilityProbe | None = None,
+    health_probe: seat_health.SeatHealthProbe | None = None,
 ) -> int:
     target = target.expanduser()
 
@@ -355,6 +357,20 @@ def doctor(
         checks.append((doctor_mod.OK, "roster: allow_models", ", ".join(loaded.allow_models)))
     else:
         checks.append((doctor_mod.WARN, "roster: allow_models", "not set; explicit model allow-list recommended"))
+
+    # Use the common coordinator for the health summary, but leave legacy
+    # capability and per-model labels below intact for one compatibility
+    # release.  Doctor never sends model smoke prompts.
+    shared_health = (health_probe or seat_health.SeatHealthProbe(collect_executable_version=False)).probe_roster(
+        loaded, workspace=target, allow_model_smoke=False
+    )
+    for result in shared_health:
+        status = doctor_mod.OK if result.status == "healthy" else doctor_mod.WARN
+        detail = (
+            "; ".join(f"{check.name}={check.status}" for check in result.checks if check.status != "passed")
+            or "all applicable checks passed"
+        )
+        checks.append((status, f"agent: {result.seat} health", detail))
 
     for name, agent in loaded.agents.items():
         if agent.stats is not None or name in local_stats:

--- a/src/brigade/seat_health.py
+++ b/src/brigade/seat_health.py
@@ -1,0 +1,729 @@
+"""Shared, redacted seat-health probes.
+
+This module deliberately has no run-admission policy.  It answers whether a
+declared seat is healthy now and writes a receipt that later routing work can
+consume.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+import tempfile
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Callable, Literal, Protocol
+from urllib.parse import urlsplit
+
+from . import acpx_adapter, agents, model_inventory, proc
+from .worker_failure import (
+    FAILURE_CLASS_SPECS,
+    FailureClass,
+    FailurePhase,
+    WorkerFailure,
+    safe_detail,
+)
+
+SCHEMA = "brigade.seat_health.v1"
+PER_SEAT_TIMEOUT_SECONDS = 30.0
+OVERALL_TIMEOUT_SECONDS = 35.0
+MODEL_REACHABILITY_TIMEOUT_SECONDS = 15.0
+HEALTHY_CACHE_TTL_SECONDS = 5 * 60.0
+UNHEALTHY_CACHE_TTL_SECONDS = 30.0
+DETAIL_LIMIT = 240
+_MODEL_SMOKE_MARKER = "BRIGADE_SEAT_HEALTH_EXACT_MARKER"
+_MODEL_SMOKE_PROMPT = (
+    "Return exactly BRIGADE_SEAT_HEALTH_EXACT_MARKER and nothing else. Do not use tools. Do not write files."
+)
+
+CheckName = Literal[
+    "declaration",
+    "executable-identity",
+    "authentication-entitlement",
+    "transport-liveness",
+    "version-gates",
+    "model-reachability",
+    "isolation-compatibility",
+]
+CheckStatus = Literal["passed", "degraded", "failed"]
+HealthStatus = Literal["healthy", "degraded", "unhealthy"]
+
+CHECK_NAMES: tuple[CheckName, ...] = (
+    "declaration",
+    "executable-identity",
+    "authentication-entitlement",
+    "transport-liveness",
+    "version-gates",
+    "model-reachability",
+    "isolation-compatibility",
+)
+
+# Explicitly public, rather than inferred from the roster, so new adapters
+# cannot silently skip health checks.
+ADAPTER_CHECK_MATRIX: dict[str, tuple[CheckName, ...]] = {
+    "direct": CHECK_NAMES,
+    "endpoint": ("declaration", "authentication-entitlement", "transport-liveness", "model-reachability"),
+    "codex-exec": CHECK_NAMES,
+    "codex-app-server": CHECK_NAMES,
+    "cursor-acpx": CHECK_NAMES,
+}
+
+
+@dataclass(frozen=True)
+class SeatHealthCheck:
+    name: CheckName
+    status: CheckStatus
+    detail: str = ""
+    duration_seconds: float = 0.0
+    cause_code: str | None = None
+
+    def payload(self) -> dict[str, object]:
+        result: dict[str, object] = {
+            "name": self.name,
+            "status": self.status,
+            "duration_seconds": round(max(self.duration_seconds, 0.0), 3),
+        }
+        if self.detail:
+            result["detail"] = safe_detail(self.detail)[:DETAIL_LIMIT]
+        if self.cause_code:
+            result["cause_code"] = self.cause_code[:80]
+        return result
+
+
+@dataclass(frozen=True)
+class SeatHealthResult:
+    probe_id: str
+    seat: str
+    fingerprint: str
+    status: HealthStatus
+    requested: dict[str, str | None]
+    checks: tuple[SeatHealthCheck, ...]
+    started_at: float
+    finished_at: float
+    started_wall_at: float
+    finished_wall_at: float
+    cached: bool = False
+    cache_age_seconds: float | None = None
+    failure: WorkerFailure | None = None
+    resolution: dict[str, str] | None = None
+
+    def payload(self) -> dict[str, object]:
+        result: dict[str, object] = {
+            "probe_id": self.probe_id,
+            "seat": self.seat,
+            "fingerprint": self.fingerprint,
+            "status": self.status,
+            "started_at": _timestamp(self.started_wall_at),
+            "finished_at": _timestamp(self.finished_wall_at),
+            "duration_seconds": round(max(self.finished_at - self.started_at, 0.0), 3),
+            "cached": self.cached,
+            "requested": {key: value for key, value in self.requested.items() if value is not None},
+            "checks": [check.payload() for check in self.checks],
+        }
+        if self.cache_age_seconds is not None:
+            result["cache_age_seconds"] = round(max(self.cache_age_seconds, 0.0), 3)
+        if self.failure is not None:
+            failure = self.failure.payload()
+            failure["probe_id"] = self.probe_id
+            result["failure"] = failure
+        if self.resolution is not None:
+            result["resolution"] = dict(self.resolution)
+        return result
+
+
+class AdapterChecks(Protocol):
+    """Adapter-owned checks, injectable so probe tests never require a live seat."""
+
+    def check(
+        self,
+        name: CheckName,
+        *,
+        seat: Any,
+        roster: Any,
+        workspace: Path | None,
+        timeout_seconds: float,
+    ) -> SeatHealthCheck: ...
+
+
+@dataclass(frozen=True)
+class _CacheEntry:
+    result: SeatHealthResult
+    stored_at: float
+
+
+class SeatHealthProbe:
+    """Probe declared roots and fallbacks with bounded parallel work.
+
+    ``adapter`` is normally omitted, which uses the existing CLI, inventory,
+    ACPX, and app-server primitives.  Fixture adapters supply all checks in
+    tests, preventing credentials and network calls.
+    """
+
+    def __init__(
+        self,
+        *,
+        adapter: AdapterChecks | None = None,
+        clock: Callable[[], float] = time.monotonic,
+        wall_clock: Callable[[], float] = time.time,
+        model_smoke: Callable[[Any, Any, Path, float], SeatHealthCheck] | None = None,
+        collect_executable_version: bool = True,
+    ) -> None:
+        self._adapter = adapter
+        self._clock = clock
+        self._wall_clock = wall_clock
+        self._model_smoke = model_smoke
+        self._collect_executable_version = collect_executable_version
+        self._cache: dict[str, _CacheEntry] = {}
+        self._cache_lock = threading.Lock()
+
+    def probe(
+        self,
+        seat: Any,
+        roster: Any,
+        *,
+        workspace: Path | None = None,
+        allow_model_smoke: bool = True,
+    ) -> SeatHealthResult:
+        """Probe one seat.  The caller decides whether to serialize the result."""
+        started = self._clock()
+        started_wall_at = self._wall_clock()
+        requested = _requested(seat, roster)
+        fingerprint = seat_fingerprint(seat, roster, executable_version=self._executable_version(seat))
+        cached = self._cached(fingerprint, started)
+        if cached is not None:
+            # Workspace and isolation state are intentionally recomputed.
+            retained = tuple(check for check in cached.checks if check.name != "isolation-compatibility")
+            isolation = self._run_check(
+                "isolation-compatibility", seat, roster, workspace, PER_SEAT_TIMEOUT_SECONDS, allow_model_smoke
+            )
+            cached_checks = (*retained, isolation)
+            return _result(
+                cached.probe_id,
+                seat.name,
+                fingerprint,
+                requested,
+                cached_checks,
+                started,
+                self._clock(),
+                started_wall_at,
+                self._wall_clock(),
+                cached=True,
+                cache_age_seconds=started - cached.started_at,
+            )
+
+        deadline = started + PER_SEAT_TIMEOUT_SECONDS
+        checks: list[SeatHealthCheck] = []
+        for name in ADAPTER_CHECK_MATRIX[_adapter_kind(seat, roster)]:
+            remaining = deadline - self._clock()
+            if remaining <= 0:
+                checks.append(_timeout_check(name))
+                break
+            budget = min(remaining, MODEL_REACHABILITY_TIMEOUT_SECONDS) if name == "model-reachability" else remaining
+            checks.append(self._run_check(name, seat, roster, workspace, budget, allow_model_smoke))
+        result = _result(
+            _probe_id(seat.name, started),
+            seat.name,
+            fingerprint,
+            requested,
+            tuple(checks),
+            started,
+            self._clock(),
+            started_wall_at,
+            self._wall_clock(),
+        )
+        with self._cache_lock:
+            self._cache[fingerprint] = _CacheEntry(result, self._clock())
+        return result
+
+    def probe_roster(
+        self,
+        roster: Any,
+        *,
+        workspace: Path | None = None,
+        allow_model_smoke: bool = True,
+    ) -> tuple[SeatHealthResult, ...]:
+        """Probe every requested root and every declared fallback in parallel."""
+        names = _seat_chain_names(roster)
+        deadline = self._clock() + OVERALL_TIMEOUT_SECONDS
+        results: dict[str, SeatHealthResult] = {}
+        executor = ThreadPoolExecutor(max_workers=max(1, len(names)), thread_name_prefix="seat-health")
+        try:
+            futures = {
+                executor.submit(
+                    self.probe, roster.agents[name], roster, workspace=workspace, allow_model_smoke=allow_model_smoke
+                ): name
+                for name in names
+            }
+            try:
+                for future in as_completed(futures, timeout=max(deadline - self._clock(), 0.0)):
+                    name = futures[future]
+                    try:
+                        results[name] = future.result()
+                    except Exception as exc:  # adapter bugs must be receipted, not crash doctor
+                        results[name] = _exception_result(name, roster, self._clock(), self._wall_clock(), exc)
+            except TimeoutError:
+                pass
+            for future, name in futures.items():
+                if name not in results:
+                    future.cancel()
+                    results[name] = _overall_timeout_result(name, roster, self._clock(), self._wall_clock())
+        finally:
+            # A hung provider must not turn the 35-second admission deadline
+            # into an unbounded executor shutdown.  Running checks are bounded
+            # independently and their results are discarded after this phase.
+            executor.shutdown(wait=False, cancel_futures=True)
+        return tuple(results[name] for name in names)
+
+    def _cached(self, fingerprint: str, now: float) -> SeatHealthResult | None:
+        with self._cache_lock:
+            entry = self._cache.get(fingerprint)
+        if entry is None:
+            return None
+        ttl = HEALTHY_CACHE_TTL_SECONDS if entry.result.status == "healthy" else UNHEALTHY_CACHE_TTL_SECONDS
+        return entry.result if now - entry.stored_at <= ttl else None
+
+    def _executable_version(self, seat: Any) -> str | None:
+        if not self._collect_executable_version or self._adapter is not None or getattr(seat, "cli", None) is None:
+            return None
+        identity = agents.resolve_agent_executable(seat.cli)
+        if not identity.runnable:
+            return None
+        try:
+            result = proc.run([identity.command, "--version"], timeout=2.0)
+        except OSError:
+            return None
+        match = re.search(r"\b\d+(?:\.\d+){1,3}\b", f"{result.stdout}\n{result.stderr}")
+        return match.group(0) if result.code == 0 and match is not None else None
+
+    def _run_check(
+        self,
+        name: CheckName,
+        seat: Any,
+        roster: Any,
+        workspace: Path | None,
+        timeout_seconds: float,
+        allow_model_smoke: bool,
+    ) -> SeatHealthCheck:
+        started = self._clock()
+        try:
+            if self._adapter is not None:
+                check = self._adapter.check(
+                    name, seat=seat, roster=roster, workspace=workspace, timeout_seconds=timeout_seconds
+                )
+            else:
+                check = self._default_check(name, seat, roster, workspace, timeout_seconds, allow_model_smoke)
+        except TimeoutError:
+            return _timeout_check(name, self._clock() - started)
+        except Exception as exc:  # provider APIs are not allowed to escape the health boundary
+            return SeatHealthCheck(name, "failed", safe_detail(str(exc)), self._clock() - started, "check-exception")
+        return replace(check, duration_seconds=max(check.duration_seconds, self._clock() - started))
+
+    def _default_check(
+        self,
+        name: CheckName,
+        seat: Any,
+        roster: Any,
+        workspace: Path | None,
+        timeout_seconds: float,
+        allow_model_smoke: bool,
+    ) -> SeatHealthCheck:
+        if name == "declaration":
+            return SeatHealthCheck(name, "passed", "roster declaration validated")
+        if name == "executable-identity":
+            if seat.cli is None:
+                return SeatHealthCheck(name, "degraded", "endpoint seat has no local executable")
+            identity = agents.resolve_agent_executable(seat.cli)
+            if not identity.runnable:
+                return SeatHealthCheck(name, "failed", identity.detail, cause_code="missing-executable")
+            return SeatHealthCheck(name, "passed", f"{identity.command} ({identity.kind})")
+        if name == "authentication-entitlement":
+            if seat.transport == "acpx":
+                auth = acpx_adapter.cursor_auth_status()
+                if auth.state == "authenticated":
+                    return SeatHealthCheck(name, "passed", auth.detail)
+                if auth.state == "unauthenticated":
+                    return SeatHealthCheck(name, "failed", auth.detail, cause_code="auth-required")
+                return SeatHealthCheck(name, "degraded", auth.detail, cause_code="auth-status-unavailable")
+            return SeatHealthCheck(name, "degraded", "adapter has no prompt-free authentication status check")
+        if name == "transport-liveness":
+            return self._transport_check(seat, roster, workspace, timeout_seconds)
+        if name == "version-gates":
+            if seat.transport == "acpx":
+                version, detail = acpx_adapter.installed_version()
+                if version == seat.transport_version:
+                    return SeatHealthCheck(name, "passed", f"acpx version {version}")
+                return SeatHealthCheck(
+                    name,
+                    "failed",
+                    f"requires {seat.transport_version}; found {version or detail}",
+                    cause_code="version-mismatch",
+                )
+            return SeatHealthCheck(name, "degraded", "adapter has no reviewed version gate")
+        if name == "model-reachability":
+            return self._model_check(seat, roster, workspace, timeout_seconds, allow_model_smoke)
+        if name == "isolation-compatibility":
+            enforcement = (
+                "endpoint"
+                if seat.cli is None
+                else agents.read_only_enforcement(seat.cli, sandbox=roster.sandbox, transport=seat.transport)
+            )
+            if enforcement == "hard":
+                return SeatHealthCheck(name, "passed", "declared read-only enforcement is hard")
+            return SeatHealthCheck(
+                name, "degraded", f"declared read-only enforcement is {enforcement}; postflight is deferred"
+            )
+        raise AssertionError(name)
+
+    def _transport_check(
+        self, seat: Any, roster: Any, workspace: Path | None, timeout_seconds: float
+    ) -> SeatHealthCheck:
+        if seat.transport == "acpx":
+            if proc.which("acpx") is None:
+                return SeatHealthCheck(
+                    "transport-liveness", "failed", "acpx is not installed", cause_code="missing-transport"
+                )
+            return SeatHealthCheck("transport-liveness", "passed", "acpx transport executable is available")
+        if seat.cli == "codex" and roster.codex_transport == "app-server":
+            # A start-thread request is still a provider transport smoke. It
+            # must never point the app-server at the caller's worktree.
+            root = _temporary_git_repo()
+            try:
+                with _app_server(root) as server:
+                    server.start_thread(cwd=root, model=seat.model, sandbox=roster.sandbox)
+                return SeatHealthCheck("transport-liveness", "passed", "app-server initialized and accepted a thread")
+            except Exception as exc:  # AppServerError has no stable public subclasses
+                detail = safe_detail(str(exc))
+                code = "initialize-no-progress" if "timed out" in detail else "app-server-unavailable"
+                return SeatHealthCheck("transport-liveness", "failed", detail, cause_code=code)
+            finally:
+                _remove_temp_repo(root)
+        if seat.cli is None:
+            return SeatHealthCheck(
+                "transport-liveness", "degraded", "endpoint liveness requires a provider-safe status operation"
+            )
+        identity = agents.resolve_agent_executable(seat.cli)
+        if not identity.runnable:
+            return SeatHealthCheck("transport-liveness", "failed", identity.detail, cause_code="missing-executable")
+        return SeatHealthCheck("transport-liveness", "passed", "direct executable is runnable")
+
+    def _model_check(
+        self, seat: Any, roster: Any, workspace: Path | None, timeout_seconds: float, allow_model_smoke: bool
+    ) -> SeatHealthCheck:
+        if seat.model is None:
+            return SeatHealthCheck("model-reachability", "degraded", "seat has no exact model declaration")
+        # Roster doctor retains its established inventory rendering below.  It
+        # asks the shared coordinator for all other facts without duplicating a
+        # provider inventory call, and it deliberately never sends a smoke
+        # request while merely inspecting a workspace.
+        if not allow_model_smoke:
+            return SeatHealthCheck("model-reachability", "degraded", "model check is owned by roster doctor inventory")
+        if seat.transport == "direct" and seat.cli is not None:
+            inspected = model_inventory.ModelInventoryInspector().inspect(seat.cli, seat.model)
+            if inspected is not None:
+                if inspected.state == "exact":
+                    return SeatHealthCheck("model-reachability", "passed", inspected.detail)
+                if inspected.state == "missing":
+                    return SeatHealthCheck(
+                        "model-reachability", "failed", inspected.detail, cause_code="model-unavailable"
+                    )
+                return SeatHealthCheck("model-reachability", "degraded", inspected.detail, cause_code=inspected.state)
+        root = _temporary_git_repo()
+        try:
+            if self._model_smoke is not None:
+                return self._model_smoke(seat, roster, root, timeout_seconds)
+            if seat.cli is None:
+                return SeatHealthCheck(
+                    "model-reachability", "degraded", "endpoint has no provider-safe exact model smoke implementation"
+                )
+            if seat.transport == "acpx":
+                result = acpx_adapter.run_cursor(
+                    _MODEL_SMOKE_PROMPT,
+                    cwd=root,
+                    timeout=timeout_seconds,
+                    model=seat.model,
+                    version=seat.transport_version,
+                    read_only=True,
+                )
+            elif seat.cli == "codex" and roster.codex_transport == "app-server":
+                return self._app_server_model_smoke(seat, roster, root, timeout_seconds)
+            else:
+                result = agents.run_agent(
+                    seat.cli,
+                    _MODEL_SMOKE_PROMPT,
+                    timeout=timeout_seconds,
+                    cwd=root,
+                    read_only=True,
+                    sandbox="read-only",
+                    model=seat.model,
+                    reasoning=seat.reasoning,
+                    env=seat.env,
+                )
+            return _model_smoke_result(result.ok, result.text, result.detail, result.failure_kind, result.timed_out)
+        finally:
+            _remove_temp_repo(root)
+
+    def _app_server_model_smoke(self, seat: Any, roster: Any, root: Path, timeout_seconds: float) -> SeatHealthCheck:
+        try:
+            with _app_server(root) as server:
+                thread = server.start_thread(cwd=root, model=seat.model, sandbox="read-only")
+                result = thread.run_turn(_MODEL_SMOKE_PROMPT, timeout=timeout_seconds, effort=seat.reasoning)
+        except Exception as exc:  # app-server owns its protocol detail
+            return SeatHealthCheck(
+                "model-reachability", "failed", safe_detail(str(exc)), cause_code="app-server-unavailable"
+            )
+        cause = "timeout" if result.timed_out else "model-unavailable"
+        return _model_smoke_result(result.ok, result.text, result.detail, cause, result.timed_out)
+
+
+def seat_fingerprint(seat: Any, roster: Any, *, executable_version: str | None = None) -> str:
+    """Hash only stable, redacted probe inputs.  Never include executable paths or secrets."""
+    cli = getattr(seat, "cli", None)
+    identity = agents.resolve_agent_executable(cli) if cli else None
+    env = getattr(seat, "env", None) or {}
+    env_presence = {str(key): bool(os.environ.get(_env_target(str(key)))) for key in env}
+    endpoint = _redacted_endpoint(getattr(seat, "endpoint", None))
+    data = {
+        "executable": None
+        if identity is None
+        else {
+            "command": identity.command,
+            "kind": identity.kind,
+            "runnable": identity.runnable,
+            "version": executable_version,
+        },
+        "adapter": cli,
+        "transport": _requested(seat, roster)["transport"],
+        "transport_version": getattr(seat, "transport_version", None),
+        "model": getattr(seat, "model", None),
+        "reasoning": getattr(seat, "reasoning", None),
+        "env_present": env_presence,
+        "sandbox": getattr(roster, "sandbox", None),
+        "workspace_mode": "detached" if getattr(seat, "transport", "direct") == "acpx" else "workspace",
+        "endpoint": endpoint,
+    }
+    encoded = json.dumps(data, sort_keys=True, separators=(",", ":")).encode()
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def write_seat_health_receipt(
+    path: Path, results: tuple[SeatHealthResult, ...] | list[SeatHealthResult], *, run_id: str | None = None
+) -> None:
+    """Atomically write the additive seat-health receipt for a caller-owned run directory."""
+    started = min((result.started_wall_at for result in results), default=time.time())
+    finished = max((result.finished_wall_at for result in results), default=started)
+    payload: dict[str, object] = {
+        "schema": SCHEMA,
+        "started_at": _timestamp(started),
+        "finished_at": _timestamp(finished),
+        "results": [result.payload() for result in results],
+    }
+    if run_id is not None:
+        payload["run_id"] = run_id
+    path = path.expanduser()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        mode="w", encoding="utf-8", dir=path.parent, prefix=f".{path.name}.", suffix=".tmp", delete=False
+    ) as handle:
+        temporary = Path(handle.name)
+        handle.write(json.dumps(payload, sort_keys=True, indent=2) + "\n")
+    os.replace(temporary, path)
+
+
+def _requested(seat: Any, roster: Any) -> dict[str, str | None]:
+    cli = getattr(seat, "cli", None)
+    if cli is None:
+        adapter = "endpoint"
+        transport = "endpoint"
+    elif cli == "codex":
+        adapter = "codex"
+        transport = getattr(roster, "codex_transport", "exec")
+    else:
+        adapter = cli
+        transport = getattr(seat, "transport", "direct")
+    return {
+        "adapter": adapter,
+        "transport": transport,
+        "model": getattr(seat, "model", None),
+        "reasoning": getattr(seat, "reasoning", None),
+    }
+
+
+def _adapter_kind(seat: Any, roster: Any) -> str:
+    if getattr(seat, "cli", None) is None:
+        return "endpoint"
+    if seat.cli == "codex":
+        return "codex-app-server" if roster.codex_transport == "app-server" else "codex-exec"
+    return "cursor-acpx" if seat.transport == "acpx" else "direct"
+
+
+def _result(
+    probe_id: str,
+    seat: str,
+    fingerprint: str,
+    requested: dict[str, str | None],
+    checks: tuple[SeatHealthCheck, ...],
+    started: float,
+    finished: float,
+    started_wall_at: float,
+    finished_wall_at: float,
+    *,
+    cached: bool = False,
+    cache_age_seconds: float | None = None,
+) -> SeatHealthResult:
+    failed = next((check for check in checks if check.status == "failed"), None)
+    status: HealthStatus = (
+        "unhealthy" if failed else ("degraded" if any(check.status == "degraded" for check in checks) else "healthy")
+    )
+    failure = _failure_for(failed) if failed is not None else None
+    return SeatHealthResult(
+        probe_id,
+        seat,
+        fingerprint,
+        status,
+        requested,
+        checks,
+        started,
+        finished,
+        started_wall_at,
+        finished_wall_at,
+        cached,
+        cache_age_seconds,
+        failure,
+    )
+
+
+def _failure_for(check: SeatHealthCheck) -> WorkerFailure:
+    cause = check.cause_code or "health-check-failed"
+    mapping = {
+        "missing-executable": FailureClass.EXECUTABLE_UNAVAILABLE,
+        "auth-required": FailureClass.AUTH_REQUIRED,
+        "entitlement-denied": FailureClass.ENTITLEMENT_DENIED,
+        "version-mismatch": FailureClass.VERSION_GATE,
+        "model-unavailable": FailureClass.MODEL_UNAVAILABLE,
+        "missing-transport": FailureClass.TRANSPORT_UNAVAILABLE,
+        "app-server-unavailable": FailureClass.TRANSPORT_UNAVAILABLE,
+        "initialize-no-progress": FailureClass.TRANSPORT_HANG,
+        "timeout": FailureClass.TIMEOUT,
+    }
+    failure_class = mapping.get(cause, FailureClass.UNCLASSIFIED)
+    spec = FAILURE_CLASS_SPECS[failure_class]
+    phase = FailurePhase.PREFLIGHT if FailurePhase.PREFLIGHT in spec.phases else spec.default_phase
+    return WorkerFailure(failure_class, phase, spec.default_retry, f"seat-health:{check.name}", check.detail, cause)
+
+
+def _model_smoke_result(ok: bool, text: str, detail: str, failure_kind: str | None, timed_out: bool) -> SeatHealthCheck:
+    if ok and text.strip() == _MODEL_SMOKE_MARKER:
+        return SeatHealthCheck("model-reachability", "passed", "exact marker returned")
+    cause = "timeout" if timed_out else _smoke_cause(failure_kind)
+    safe = safe_detail(detail or "exact marker was not returned")
+    return SeatHealthCheck("model-reachability", "failed", safe, cause_code=cause)
+
+
+def _smoke_cause(failure_kind: str | None) -> str:
+    known = {
+        "authentication-error": "auth-required",
+        "command-not-found": "missing-executable",
+        "provider-auth": "auth-required",
+        "provider-setting-error": "model-unavailable",
+        "provider-startup": "app-server-unavailable",
+        "timeout": "timeout",
+        "version-mismatch": "version-mismatch",
+    }
+    return known.get(failure_kind or "", "model-unavailable")
+
+
+def _timeout_check(name: CheckName, duration: float = 0.0) -> SeatHealthCheck:
+    return SeatHealthCheck(name, "failed", "health check timed out", duration, "timeout")
+
+
+def _seat_chain_names(roster: Any) -> tuple[str, ...]:
+    referenced = {fallback for seat in roster.agents.values() for fallback in seat.fallback}
+    roots = [name for name in roster.agents if name == roster.orchestrator or name not in referenced]
+    names: list[str] = []
+    for root in roots:
+        if root not in names:
+            names.append(root)
+        for fallback in roster.agents[root].fallback:
+            if fallback not in names:
+                names.append(fallback)
+    return tuple(names)
+
+
+def _exception_result(name: str, roster: Any, now: float, wall_now: float, exc: Exception) -> SeatHealthResult:
+    seat = roster.agents[name]
+    check = SeatHealthCheck("declaration", "failed", safe_detail(str(exc)), cause_code="probe-exception")
+    return _result(
+        _probe_id(name, now),
+        name,
+        seat_fingerprint(seat, roster),
+        _requested(seat, roster),
+        (check,),
+        now,
+        now,
+        wall_now,
+        wall_now,
+    )
+
+
+def _overall_timeout_result(name: str, roster: Any, now: float, wall_now: float) -> SeatHealthResult:
+    seat = roster.agents[name]
+    return _result(
+        _probe_id(name, now),
+        name,
+        seat_fingerprint(seat, roster),
+        _requested(seat, roster),
+        (_timeout_check("declaration"),),
+        now,
+        now,
+        wall_now,
+        wall_now,
+    )
+
+
+def _probe_id(name: str, started: float) -> str:
+    digest = hashlib.sha256(f"{name}:{started:.9f}".encode()).hexdigest()[:10]
+    return f"probe-{digest}"
+
+
+def _timestamp(value: float) -> str:
+    return datetime.fromtimestamp(value, UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def _env_target(key: str) -> str:
+    return key[:-4] if key.endswith("_REF") else key
+
+
+def _redacted_endpoint(value: str | None) -> str | None:
+    if not value:
+        return None
+    parsed = urlsplit(value)
+    return parsed.hostname or "endpoint"
+
+
+def _temporary_git_repo() -> Path:
+    root = Path(tempfile.mkdtemp(prefix="brigade-seat-health-"))
+    subprocess.run(["git", "init", "--quiet", str(root)], check=True, capture_output=True, text=True)
+    return root
+
+
+def _remove_temp_repo(root: Path) -> None:
+    # The directory contains only probe-created files.  Avoid a broad recursive shell command.
+    for child in sorted(root.rglob("*"), reverse=True):
+        if child.is_file() or child.is_symlink():
+            child.unlink(missing_ok=True)
+        elif child.is_dir():
+            child.rmdir()
+    root.rmdir()
+
+
+def _app_server(root: Path):
+    from .codex_appserver import AppServer
+
+    return AppServer(cwd=root)

--- a/src/brigade/seat_health.py
+++ b/src/brigade/seat_health.py
@@ -15,6 +15,7 @@ import subprocess
 import tempfile
 import threading
 import time
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
@@ -268,7 +269,7 @@ class SeatHealthProbe:
                         results[name] = future.result()
                     except Exception as exc:  # adapter bugs must be receipted, not crash doctor
                         results[name] = _exception_result(name, roster, self._clock(), self._wall_clock(), exc)
-            except TimeoutError:
+            except FuturesTimeoutError:
                 pass
             for future, name in futures.items():
                 if name not in results:

--- a/src/brigade/seat_health.py
+++ b/src/brigade/seat_health.py
@@ -17,7 +17,7 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, replace
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Literal, Protocol
 from urllib.parse import urlsplit
@@ -693,7 +693,7 @@ def _probe_id(name: str, started: float) -> str:
 
 
 def _timestamp(value: float) -> str:
-    return datetime.fromtimestamp(value, UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+    return datetime.fromtimestamp(value, timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
 
 
 def _env_target(key: str) -> str:

--- a/tests/test_roster_cmd.py
+++ b/tests/test_roster_cmd.py
@@ -126,6 +126,24 @@ def test_roster_doctor_validates_agents(monkeypatch, tmp_target, capsys):
     assert "[warn]" in out
 
 
+def test_roster_doctor_renders_shared_health_without_replacing_legacy_labels(tmp_target, capsys):
+    from brigade.seat_health import SeatHealthCheck, SeatHealthProbe
+
+    _write_roster(
+        tmp_target,
+        'orchestrator = "chef"\n[agents.chef]\nendpoint = "https://example.test/v1"\nmodel = "model"\nrole = "plan"\n',
+    )
+
+    class FakeHealth:
+        def check(self, name, **kwargs):
+            return SeatHealthCheck(name, "passed", "fixture")
+
+    assert roster_cmd.doctor(tmp_target, health_probe=SeatHealthProbe(adapter=FakeHealth())) == 0
+    out = capsys.readouterr().out
+    assert "agent: chef health" in out
+    assert "agent: chef" in out
+
+
 def test_roster_doctor_claude_missing_is_optional_warning(monkeypatch, tmp_target, capsys):
     path = tmp_target / ".brigade" / "roster.toml"
     path.parent.mkdir(parents=True)

--- a/tests/test_seat_health.py
+++ b/tests/test_seat_health.py
@@ -1,0 +1,195 @@
+import json
+import time
+from dataclasses import replace
+
+from brigade import roster
+from brigade import seat_health
+from brigade import proc
+from brigade import agents
+from brigade.seat_health import (
+    CHECK_NAMES,
+    HEALTHY_CACHE_TTL_SECONDS,
+    UNHEALTHY_CACHE_TTL_SECONDS,
+    SeatHealthCheck,
+    SeatHealthProbe,
+    seat_fingerprint,
+    write_seat_health_receipt,
+)
+
+
+class FakeAdapter:
+    def __init__(self, statuses=None):
+        self.statuses = statuses or {}
+        self.calls = []
+
+    def check(self, name, *, seat, roster, workspace, timeout_seconds):
+        self.calls.append((seat.name, name, timeout_seconds, workspace))
+        value = self.statuses.get((seat.name, name), self.statuses.get(name, ("passed", "ok", None)))
+        return SeatHealthCheck(name, value[0], value[1], cause_code=value[2])
+
+
+def _roster():
+    primary = roster.Agent(
+        "primary", "codex", "plan", model="gpt-test", fallback=("backup",), env={"TOKEN_REF": "TOKEN"}
+    )
+    backup = roster.Agent("backup", "cursor", "work", model="gpt-test", transport="acpx", transport_version="0.12.0")
+    return roster.Roster("primary", {"primary": primary, "backup": backup}, sandbox="read-only", codex_transport="exec")
+
+
+def test_probe_runs_all_adapter_checks_and_maps_health_states():
+    fake = FakeAdapter({"authentication-entitlement": ("degraded", "no status API", None)})
+    result = SeatHealthProbe(adapter=fake).probe(_roster().agents["primary"], _roster(), allow_model_smoke=False)
+    assert result.status == "degraded"
+    assert tuple(check.name for check in result.checks) == CHECK_NAMES
+    assert {name for _, name, _, _ in fake.calls} == set(CHECK_NAMES)
+
+
+def test_probe_normalizes_auth_version_model_transport_hang_and_timeout_failures():
+    cases = [
+        ("authentication-entitlement", "auth-required", "auth-required"),
+        ("authentication-entitlement", "entitlement-denied", "entitlement-denied"),
+        ("version-gates", "version-mismatch", "version-gate"),
+        ("model-reachability", "model-unavailable", "model-unavailable"),
+        ("transport-liveness", "missing-transport", "transport-unavailable"),
+        ("transport-liveness", "initialize-no-progress", "transport-hang"),
+        ("declaration", "timeout", "timeout"),
+    ]
+    for name, cause, expected in cases:
+        fake = FakeAdapter({name: ("failed", "token=secret-value", cause)})
+        result = SeatHealthProbe(adapter=fake).probe(_roster().agents["primary"], _roster())
+        assert result.status == "unhealthy"
+        assert result.failure is not None
+        assert result.failure.failure_class.value == expected
+        assert "secret-value" not in result.failure.payload()["detail"]
+
+
+def test_probe_roster_includes_fallbacks_and_cache_ttls(monkeypatch):
+    now = [10.0]
+    fake = FakeAdapter()
+    probe = SeatHealthProbe(adapter=fake, clock=lambda: now[0])
+    results = probe.probe_roster(_roster())
+    assert [result.seat for result in results] == ["primary", "backup"]
+    first_calls = len(fake.calls)
+    assert probe.probe(_roster().agents["primary"], _roster()).cached
+    assert len(fake.calls) == first_calls + 1  # isolation compatibility is never cached
+    now[0] += HEALTHY_CACHE_TTL_SECONDS + 1
+    assert not probe.probe(_roster().agents["primary"], _roster()).cached
+
+    unhealthy = SeatHealthProbe(
+        adapter=FakeAdapter({"declaration": ("failed", "bad", "timeout")}), clock=lambda: now[0]
+    )
+    unhealthy.probe(_roster().agents["primary"], _roster())
+    now[0] += UNHEALTHY_CACHE_TTL_SECONDS + 1
+    assert not unhealthy.probe(_roster().agents["primary"], _roster()).cached
+
+
+def test_fingerprint_uses_presence_not_secret_values(monkeypatch):
+    roster_value = _roster()
+    monkeypatch.setenv("TOKEN", "first-secret")
+    first = seat_fingerprint(roster_value.agents["primary"], roster_value)
+    monkeypatch.setenv("TOKEN", "second-secret")
+    assert seat_fingerprint(roster_value.agents["primary"], roster_value) == first
+    changed = replace(roster_value.agents["primary"], model="other")
+    assert seat_fingerprint(changed, roster_value) != first
+
+
+def test_receipt_is_atomic_bounded_and_redacted(tmp_path):
+    fake = FakeAdapter({"declaration": ("failed", "https://user:pass@example.test/x?token=secret", "timeout")})
+    result = SeatHealthProbe(adapter=fake).probe(_roster().agents["primary"], _roster())
+    path = tmp_path / "seat-health.json"
+    write_seat_health_receipt(path, [result], run_id="run-test")
+    payload = json.loads(path.read_text())
+    assert payload["schema"] == "brigade.seat_health.v1"
+    text = path.read_text()
+    assert "secret" not in text and "user:pass" not in text
+    assert not list(tmp_path.glob(".seat-health.json.*.tmp"))
+
+
+def test_receipt_timestamps_use_captured_wall_clock_values_and_monotonic_duration(tmp_path):
+    monotonic = [10.0]
+
+    def clock():
+        value = monotonic[0]
+        monotonic[0] += 0.25
+        return value
+
+    wall_values = iter((1_700_000_000.0, 1_700_000_002.0))
+    result = SeatHealthProbe(adapter=FakeAdapter(), clock=clock, wall_clock=lambda: next(wall_values)).probe(
+        _roster().agents["primary"], _roster()
+    )
+    path = tmp_path / "seat-health.json"
+    write_seat_health_receipt(path, [result])
+
+    payload = json.loads(path.read_text())
+    expected_started = "2023-11-14T22:13:20.000Z"
+    expected_finished = "2023-11-14T22:13:22.000Z"
+    assert payload["started_at"] == expected_started
+    assert payload["finished_at"] == expected_finished
+    assert payload["started_at"] < payload["finished_at"]
+    assert payload["results"][0]["started_at"] == expected_started
+    assert payload["results"][0]["finished_at"] == expected_finished
+    assert payload["results"][0]["duration_seconds"] != 2.0
+
+
+def test_model_smoke_runs_only_in_a_temporary_git_repository(monkeypatch):
+    roster_value = _roster()
+    seat = replace(roster_value.agents["primary"], cli="aider")
+    seen = []
+    monkeypatch.setattr(
+        seat_health.agents,
+        "resolve_agent_executable",
+        lambda cli: proc.ExecutableIdentity(cli, None, "fixture", True, "fixture"),
+    )
+    monkeypatch.setattr(seat_health.proc, "run", lambda *args, **kwargs: proc.Result(0, "1.2.3", ""))
+
+    def smoke(agent, roster_value, workspace, timeout):
+        seen.append(workspace)
+        assert (workspace / ".git").is_dir()
+        return SeatHealthCheck("model-reachability", "passed", "exact marker returned")
+
+    result = SeatHealthProbe(model_smoke=smoke).probe(seat, roster_value)
+    assert result.status == "degraded"  # auth and version are advisory for direct fixture seats
+    assert len(seen) == 1
+    assert not seen[0].exists()
+
+
+def test_default_direct_smoke_is_no_tools_no_write_exact_marker(monkeypatch):
+    roster_value = _roster()
+    seat = replace(roster_value.agents["primary"], cli="aider")
+    calls = []
+    monkeypatch.setattr(
+        seat_health.agents,
+        "resolve_agent_executable",
+        lambda cli: proc.ExecutableIdentity(cli, None, "fixture", True, "fixture"),
+    )
+    monkeypatch.setattr(seat_health.proc, "run", lambda *args, **kwargs: proc.Result(0, "1.2.3", ""))
+
+    def fake_run_agent(cli, prompt, **kwargs):
+        calls.append((cli, prompt, kwargs))
+        return agents.AgentResult(seat_health._MODEL_SMOKE_MARKER, True)
+
+    monkeypatch.setattr(seat_health.agents, "run_agent", fake_run_agent)
+    result = SeatHealthProbe().probe(seat, roster_value)
+    assert next(check for check in result.checks if check.name == "model-reachability").status == "passed"
+    _, prompt, kwargs = calls[0]
+    assert "Do not use tools" in prompt and "Do not write files" in prompt
+    assert kwargs["read_only"] and kwargs["sandbox"] == "read-only"
+    assert (kwargs["cwd"] / ".git").is_dir() is False  # cleaned after the smoke completes
+
+
+def test_overall_deadline_returns_timeout_results_without_serial_wait(monkeypatch):
+    monkeypatch.setattr(seat_health, "OVERALL_TIMEOUT_SECONDS", 0.01)
+
+    class HangingAdapter(FakeAdapter):
+        def check(self, name, **kwargs):
+            time.sleep(0.05)
+            return super().check(name, **kwargs)
+
+    started = time.monotonic()
+    results = SeatHealthProbe(adapter=HangingAdapter()).probe_roster(_roster())
+    assert time.monotonic() - started < 0.04
+    assert len(results) == 2
+    assert [result.seat for result in results] == ["primary", "backup"]
+    assert len({result.seat for result in results}) == len(results)
+    assert all(result.status == "unhealthy" for result in results)
+    assert all(result.failure and result.failure.failure_class.value == "timeout" for result in results)


### PR DESCRIPTION
Closes #577

Implements the shared seat-health coordinator from #474 and the accepted proposal in `docs/proposals/2026-07-26-seat-health-probe-and-worker-failure-taxonomy.md`.

- probes requested seats and declared fallbacks in parallel
- covers declaration, executable, auth, transport, version, model, and isolation checks through an explicit adapter matrix
- enforces 30-second per-seat, 15-second model, and 35-second roster budgets
- caches by redacted seat fingerprint and always recomputes isolation compatibility
- writes atomic `brigade.seat_health.v1` receipts with dual-clock timestamp handling
- adds the shared result to roster doctor without removing existing labels

Verification: `./scripts/verify` passed through `brigade work verify run`, receipt `20260727-000622-work-verify-600d75` (4,506 passed, 3 skipped).