### PR TITLE
feat(receipts): archive verification evidence before retention pruning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Verify-run retention now archives receipt evidence before pruning (#565).
+  When `.brigade/work/verify-runs/` grows past the retention cap, each run
+  directory is copied into the verify archive (default
+  `.brigade/work/verify-archive/<run-id>/`) and an append-only
+  `index.jsonl` entry (`brigade.verify_archive_index.v1`) records the
+  receipt's digest, signature, key id, and schema version before the local
+  copy is deleted. Archival re-verifies the copied receipt bytes and the
+  receipt's self-declared `digests.receipt_sha256`; a run directory whose
+  archival fails or whose receipt no longer re-hashes is kept locally, so
+  pruning never destroys unpreserved evidence. New `.brigade/config.json`
+  keys: `verify_runs_keep` (default 50), `verify_archive_enabled` (default
+  true), and `verify_archive_dir` (default `.brigade/work/verify-archive`).
+
 ### Removed
 - Removed the opt-in `brigade run --deliberate` grounded-deliberation mode
   (planner, `brigade.deliberation.v1` artifact emission, and related runs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   copy is deleted. Archival re-verifies the copied receipt bytes and the
   receipt's self-declared `digests.receipt_sha256`; a run directory whose
   archival fails or whose receipt no longer re-hashes is kept locally, so
-  pruning never destroys unpreserved evidence. New `.brigade/config.json`
+  pruning never destroys unpreserved evidence. Archive paths that overlap the
+  local run root, partial or symlinked archive destinations, and source trees
+  containing symlinks or special files are rejected without pruning. New
+  `.brigade/config.json`
   keys: `verify_runs_keep` (default 50), `verify_archive_enabled` (default
   true), and `verify_archive_dir` (default `.brigade/work/verify-archive`).
 

--- a/docs/receipt-schemas.md
+++ b/docs/receipt-schemas.md
@@ -124,7 +124,10 @@ appended. A run directory whose archival fails is kept locally, so pruning never
 destroys receipt evidence that was not preserved first. Archival re-checks integrity
 both ways: the archived `receipt.json` bytes must hash to the source bytes, and a
 receipt carrying `digests.receipt_sha256` must still re-hash to that value after the
-copy.
+copy. The archive root must not overlap the local verify-runs root in either direction,
+including through a symlink alias. Source trees containing symlinks or special files
+are kept locally. An existing archive destination is reused only when it is a regular
+directory with the same files and file hashes as the source.
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |

--- a/docs/receipt-schemas.md
+++ b/docs/receipt-schemas.md
@@ -111,6 +111,41 @@ receipts or routing authority.
 
 ---
 
+## `brigade.verify_archive_index.v1`: `schema_version: 1`
+
+**Path:** `<verify-archive-root>/index.jsonl` (one JSON object per line, append-only,
+sorted keys per line). The default archive root is `.brigade/work/verify-archive`;
+`.brigade/config.json` keys `verify_archive_enabled` and `verify_archive_dir` override it.
+
+Retention prunes the local `.brigade/work/verify-runs/` directory down to the newest
+`verify_runs_keep` runs (default 50). Before any run directory is deleted it is copied
+into the archive root as `<verify-archive-root>/<run-id>/` and one index line is
+appended. A run directory whose archival fails is kept locally, so pruning never
+destroys receipt evidence that was not preserved first. Archival re-checks integrity
+both ways: the archived `receipt.json` bytes must hash to the source bytes, and a
+receipt carrying `digests.receipt_sha256` must still re-hash to that value after the
+copy.
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `schema` | string | yes | Always `brigade.verify_archive_index.v1` |
+| `schema_version` | integer | yes | Always `1` for this contract |
+| `run_id` | string | yes | Run directory name that was archived |
+| `archived_at` | string (ISO-8601) | yes | When the archival completed |
+| `source_run_dir` | string | yes | Original run directory path |
+| `archive_run_dir` | string | yes | Archived copy path |
+| `already_archived` | boolean | yes | `true` when an identical archive already existed |
+| `receipt_file_sha256` | string \| null | yes | SHA-256 of the archived `receipt.json` bytes; `null` when the run dir had no receipt |
+| `receipt_schema_version` | integer \| null | yes | The receipt's own `schema_version`; `null` for legacy receipts without one |
+| `receipt_sha256` | string \| null | yes | The receipt's self-declared canonical digest; `null` when absent |
+| `signature` | string \| null | yes | Receipt signature when the run was signed; `null` otherwise |
+| `key_id` | string \| null | yes | Signing key id paired with `signature`; `null` otherwise |
+| `status` | string \| null | yes | Receipt status at archival time |
+| `started_at` | string \| null | yes | Receipt start timestamp |
+| `completed_at` | string \| null | yes | Receipt completion timestamp |
+
+---
+
 ## `brigade.work_closeout`: `schema_version: 1`
 
 **Path:** `.brigade/work/closeouts/<closeout-id>/closeout.json`

--- a/src/brigade/config.py
+++ b/src/brigade/config.py
@@ -18,6 +18,9 @@ SUPPORTED_VERSIONS = (1,)
 DEFAULT_GRAPHTRAIL_DELTA_TIMEOUT_SECONDS = 10.0
 CAPTURE_BEFORE_RETRY_MODES = ("warn", "block", "off")
 DEFAULT_CAPTURE_BEFORE_RETRY = "warn"
+DEFAULT_VERIFY_RUNS_KEEP = 50
+DEFAULT_VERIFY_ARCHIVE_ENABLED = True
+DEFAULT_VERIFY_ARCHIVE_DIR = ".brigade/work/verify-archive"
 
 
 @dataclass
@@ -26,6 +29,9 @@ class Config:
     selection: Selection
     graphtrail_delta_timeout_seconds: float = DEFAULT_GRAPHTRAIL_DELTA_TIMEOUT_SECONDS
     capture_before_retry: str = DEFAULT_CAPTURE_BEFORE_RETRY
+    verify_runs_keep: int = DEFAULT_VERIFY_RUNS_KEEP
+    verify_archive_enabled: bool = DEFAULT_VERIFY_ARCHIVE_ENABLED
+    verify_archive_dir: str = DEFAULT_VERIFY_ARCHIVE_DIR
 
 
 def validate_graphtrail_delta_timeout(value: Any) -> float:
@@ -65,6 +71,42 @@ def resolve_graphtrail_delta_timeout(target: Path, cli_override: float | None = 
     return DEFAULT_GRAPHTRAIL_DELTA_TIMEOUT_SECONDS
 
 
+def validate_verify_runs_keep(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError("verify_runs_keep must be a positive integer")
+    return value
+
+
+def validate_verify_archive_enabled(value: Any) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError("verify_archive_enabled must be true or false")
+    return value
+
+
+def validate_verify_archive_dir(value: Any) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("verify_archive_dir must be a non-empty string")
+    return value.strip()
+
+
+def resolve_verify_runs_keep(target: Path) -> int:
+    cfg = load_config(target)
+    if cfg is not None:
+        return cfg.verify_runs_keep
+    return DEFAULT_VERIFY_RUNS_KEEP
+
+
+def resolve_verify_archive(target: Path) -> tuple[bool, Path]:
+    """Return (enabled, archive root) for verify-run evidence archival."""
+    cfg = load_config(target)
+    enabled = cfg.verify_archive_enabled if cfg is not None else DEFAULT_VERIFY_ARCHIVE_ENABLED
+    raw = cfg.verify_archive_dir if cfg is not None else DEFAULT_VERIFY_ARCHIVE_DIR
+    path = Path(raw).expanduser()
+    if not path.is_absolute():
+        path = target / path
+    return enabled, path
+
+
 def config_path(target: Path) -> Path:
     return target / CONFIG_REL_PATH
 
@@ -86,6 +128,15 @@ def write_config(target: Path, cfg: Config) -> None:
     capture_before_retry = validate_capture_before_retry(cfg.capture_before_retry)
     if capture_before_retry != DEFAULT_CAPTURE_BEFORE_RETRY:
         payload["capture_before_retry"] = capture_before_retry
+    verify_runs_keep = validate_verify_runs_keep(cfg.verify_runs_keep)
+    if verify_runs_keep != DEFAULT_VERIFY_RUNS_KEEP:
+        payload["verify_runs_keep"] = verify_runs_keep
+    verify_archive_enabled = validate_verify_archive_enabled(cfg.verify_archive_enabled)
+    if verify_archive_enabled != DEFAULT_VERIFY_ARCHIVE_ENABLED:
+        payload["verify_archive_enabled"] = verify_archive_enabled
+    verify_archive_dir = validate_verify_archive_dir(cfg.verify_archive_dir)
+    if verify_archive_dir != DEFAULT_VERIFY_ARCHIVE_DIR:
+        payload["verify_archive_dir"] = verify_archive_dir
     path.write_text(json.dumps(payload, indent=2) + "\n")
 
 
@@ -113,9 +164,17 @@ def load_config(target: Path) -> Optional[Config]:
     timeout_raw = data.get("graphtrail_delta_timeout_seconds", DEFAULT_GRAPHTRAIL_DELTA_TIMEOUT_SECONDS)
     timeout = validate_graphtrail_delta_timeout(timeout_raw)
     capture_before_retry = validate_capture_before_retry(data.get("capture_before_retry", DEFAULT_CAPTURE_BEFORE_RETRY))
+    verify_runs_keep = validate_verify_runs_keep(data.get("verify_runs_keep", DEFAULT_VERIFY_RUNS_KEEP))
+    verify_archive_enabled = validate_verify_archive_enabled(
+        data.get("verify_archive_enabled", DEFAULT_VERIFY_ARCHIVE_ENABLED)
+    )
+    verify_archive_dir = validate_verify_archive_dir(data.get("verify_archive_dir", DEFAULT_VERIFY_ARCHIVE_DIR))
     return Config(
         version=version,
         selection=sel,
         graphtrail_delta_timeout_seconds=timeout,
         capture_before_retry=capture_before_retry,
+        verify_runs_keep=verify_runs_keep,
+        verify_archive_enabled=verify_archive_enabled,
+        verify_archive_dir=verify_archive_dir,
     )

--- a/src/brigade/work_cmd/verification.py
+++ b/src/brigade/work_cmd/verification.py
@@ -429,22 +429,151 @@ def _safe_finalize_verify_receipt(
         return receipt, rc
 
 
-VERIFY_RUNS_KEEP = 50
+VERIFY_RUNS_KEEP = config.DEFAULT_VERIFY_RUNS_KEEP
+
+VERIFY_ARCHIVE_INDEX_NAME = "index.jsonl"
+VERIFY_ARCHIVE_INDEX_SCHEMA = "brigade.verify_archive_index.v1"
+VERIFY_ARCHIVE_INDEX_SCHEMA_VERSION = 1
 
 
-def _prune_verify_runs(target: Path, keep: int = VERIFY_RUNS_KEEP) -> int:
-    """Cap retained verify-run directories so receipts + raw logs don't grow without bound.
+def _verify_archive_root(target: Path, archive_root: Path | None = None) -> Path | None:
+    """Resolve the verify-evidence archive root, or None when archival is disabled."""
+    if archive_root is not None:
+        return archive_root
+    enabled, resolved = config.resolve_verify_archive(target)
+    if not enabled:
+        return None
+    return resolved
+
+
+def _verify_archive_index_entry(
+    run_dir: Path,
+    dest: Path,
+    receipt_file_sha256: str | None,
+    *,
+    already_archived: bool,
+) -> dict[str, Any]:
+    receipt = _verify_read_receipt(run_dir)
+    digests = receipt.get("digests") if receipt is not None and isinstance(receipt.get("digests"), dict) else {}
+    return {
+        "schema": VERIFY_ARCHIVE_INDEX_SCHEMA,
+        "schema_version": VERIFY_ARCHIVE_INDEX_SCHEMA_VERSION,
+        "run_id": run_dir.name,
+        "archived_at": helpers._now().isoformat(),
+        "source_run_dir": str(run_dir),
+        "archive_run_dir": str(dest),
+        "already_archived": already_archived,
+        "receipt_file_sha256": receipt_file_sha256,
+        "receipt_schema_version": receipt.get("schema_version") if receipt is not None else None,
+        "receipt_sha256": digests.get("receipt_sha256"),
+        "signature": digests.get("signature"),
+        "key_id": digests.get("key_id"),
+        "status": receipt.get("status") if receipt is not None else None,
+        "started_at": receipt.get("started_at") if receipt is not None else None,
+        "completed_at": receipt.get("completed_at") if receipt is not None else None,
+    }
+
+
+def _append_verify_archive_index(archive_root: Path, entry: dict[str, Any]) -> None:
+    index_path = archive_root / VERIFY_ARCHIVE_INDEX_NAME
+    with index_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry, sort_keys=True, default=str) + "\n")
+
+
+def _assert_archived_receipt_integrity(archived_receipt: Path) -> None:
+    """Re-verify a copied receipt's self-declared digest against its archived bytes."""
+    try:
+        payload = json.loads(archived_receipt.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise OSError(f"verify archive receipt is unreadable: {archived_receipt}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise OSError(f"verify archive receipt is not a JSON object: {archived_receipt}")
+    digests = payload.get("digests")
+    if not isinstance(digests, dict):
+        return  # legacy receipts without a digests block have no self-digest to re-verify
+    expected = digests.get("receipt_sha256")
+    if not isinstance(expected, str) or not expected:
+        return
+    actual = localio.canonical_json_digest(payload, exclude_keys={"digests"})
+    if actual != expected:
+        raise OSError(f"verify archive receipt digest mismatch: {archived_receipt}")
+
+
+def _archive_verify_run(run_dir: Path, archive_root: Path) -> dict[str, Any]:
+    """Copy one run dir into the archive and append an index entry. Raises on failure.
+
+    Integrity is checked twice: the archived receipt bytes must match the source
+    bytes, and a receipt that carries ``digests.receipt_sha256`` must still
+    re-hash to that value after the copy. Callers must treat any exception as
+    "do not delete the original".
+    """
+    run_id = run_dir.name
+    dest = archive_root / run_id
+    receipt_path = run_dir / "receipt.json"
+    source_receipt_sha = localio.file_sha256(receipt_path) if receipt_path.is_file() else None
+    if dest.exists():
+        # Re-archive of the same run id is only safe when the evidence is identical.
+        dest_receipt = dest / "receipt.json"
+        dest_sha = localio.file_sha256(dest_receipt) if dest_receipt.is_file() else None
+        if source_receipt_sha is None or dest_sha != source_receipt_sha:
+            raise OSError(f"verify archive conflict: {dest} already exists with different evidence")
+        entry = _verify_archive_index_entry(run_dir, dest, source_receipt_sha, already_archived=True)
+        _append_verify_archive_index(archive_root, entry)
+        return entry
+    archive_root.mkdir(parents=True, exist_ok=True)
+    staging = archive_root / f".{run_id}.staging-{uuid4().hex[:8]}"
+    shutil.copytree(run_dir, staging)
+    try:
+        if source_receipt_sha is not None:
+            copied_sha = localio.file_sha256(staging / "receipt.json")
+            if copied_sha != source_receipt_sha:
+                raise OSError(f"verify archive copy integrity check failed: {run_id}")
+            _assert_archived_receipt_integrity(staging / "receipt.json")
+        os.rename(staging, dest)
+    except BaseException:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+    entry = _verify_archive_index_entry(run_dir, dest, source_receipt_sha, already_archived=False)
+    _append_verify_archive_index(archive_root, entry)
+    return entry
+
+
+def _prune_verify_runs(target: Path, keep: int | None = None, archive_root: Path | None = None) -> int:
+    """Cap retained verify-run directories, archiving receipt evidence before deletion.
 
     Run dirs are timestamp-prefixed (sortable by name); the newest ``keep`` are
-    retained and older ones removed. Best-effort: a removal error never aborts a
-    verify run.
+    retained locally. Older dirs are first copied into the verify archive (with
+    an append-only index entry carrying the receipt digest, signature, and
+    schema version) and only then removed, so pruning never destroys receipt
+    evidence. A run dir whose archival fails is kept locally. Best-effort: an
+    archival or removal error never aborts a verify run.
     """
+    if keep is None:
+        try:
+            keep = config.resolve_verify_runs_keep(target)
+        except Exception:
+            keep = VERIFY_RUNS_KEEP
     root = helpers._verify_runs_root(target)
     if not root.is_dir():
         return 0
+    try:
+        resolved_archive = _verify_archive_root(target, archive_root)
+    except Exception:
+        resolved_archive = None
     run_dirs = sorted((child for child in root.iterdir() if child.is_dir()), key=lambda p: p.name, reverse=True)
     removed = 0
-    for stale in run_dirs[keep:]:
+    # Oldest first so the append-only archive index grows in chronological order.
+    for stale in reversed(run_dirs[keep:]):
+        if resolved_archive is not None:
+            try:
+                resolved_archive.relative_to(stale)
+                continue  # the archive root itself lives under the runs root; never prune it
+            except ValueError:
+                pass
+            try:
+                _archive_verify_run(stale, resolved_archive)
+            except Exception:
+                continue  # prune safety: never delete evidence that failed to archive
         try:
             shutil.rmtree(stale)
             removed += 1
@@ -1055,7 +1184,10 @@ def _write_reused_receipt(
         receipt["digests"]["key_id"] = key_id
     helpers._write_json(run_dir / "receipt.json", receipt)
     _write_verify_markdown(run_dir, receipt)
-    _prune_verify_runs(target)
+    try:
+        _prune_verify_runs(target)
+    except Exception:
+        pass
     return receipt, 0
 
 

--- a/src/brigade/work_cmd/verification.py
+++ b/src/brigade/work_cmd/verification.py
@@ -8,6 +8,7 @@ import os
 import re
 import shlex
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -438,11 +439,27 @@ VERIFY_ARCHIVE_INDEX_SCHEMA_VERSION = 1
 
 def _verify_archive_root(target: Path, archive_root: Path | None = None) -> Path | None:
     """Resolve the verify-evidence archive root, or None when archival is disabled."""
-    if archive_root is not None:
-        return archive_root
-    enabled, resolved = config.resolve_verify_archive(target)
-    if not enabled:
-        return None
+    if archive_root is None:
+        enabled, resolved = config.resolve_verify_archive(target)
+        if not enabled:
+            return None
+    else:
+        resolved = archive_root.expanduser()
+        if not resolved.is_absolute():
+            resolved = target / resolved
+    runs_root = helpers._verify_runs_root(target).resolve(strict=False)
+    resolved = resolved.resolve(strict=False)
+    try:
+        resolved.relative_to(runs_root)
+        overlaps = True
+    except ValueError:
+        try:
+            runs_root.relative_to(resolved)
+            overlaps = True
+        except ValueError:
+            overlaps = False
+    if overlaps:
+        raise ValueError(f"verify archive root overlaps verify runs root: {resolved}")
     return resolved
 
 
@@ -453,7 +470,7 @@ def _verify_archive_index_entry(
     *,
     already_archived: bool,
 ) -> dict[str, Any]:
-    receipt = _verify_read_receipt(run_dir)
+    receipt = _verify_read_receipt(dest)
     digests = receipt.get("digests") if receipt is not None and isinstance(receipt.get("digests"), dict) else {}
     return {
         "schema": VERIFY_ARCHIVE_INDEX_SCHEMA,
@@ -499,6 +516,41 @@ def _assert_archived_receipt_integrity(archived_receipt: Path) -> None:
         raise OSError(f"verify archive receipt digest mismatch: {archived_receipt}")
 
 
+def _verify_archive_tree_manifest(root: Path) -> dict[str, tuple[str, str | None]]:
+    """Hash one regular directory tree, rejecting links and special files."""
+    try:
+        root_stat = root.lstat()
+    except OSError as exc:
+        raise OSError(f"verify archive tree is unreadable: {root}: {exc}") from exc
+    if stat.S_ISLNK(root_stat.st_mode) or not stat.S_ISDIR(root_stat.st_mode):
+        raise OSError(f"verify archive tree is not a regular directory: {root}")
+    manifest: dict[str, tuple[str, str | None]] = {}
+    pending = [root]
+    while pending:
+        directory = pending.pop()
+        try:
+            children = sorted(directory.iterdir(), key=lambda path: path.name)
+        except OSError as exc:
+            raise OSError(f"verify archive tree is unreadable: {directory}: {exc}") from exc
+        for child in children:
+            relative = child.relative_to(root).as_posix()
+            try:
+                child_stat = child.lstat()
+            except OSError as exc:
+                raise OSError(f"verify archive entry is unreadable: {child}: {exc}") from exc
+            if stat.S_ISLNK(child_stat.st_mode):
+                raise OSError(f"verify archive tree contains a symlink: {child}")
+            if stat.S_ISDIR(child_stat.st_mode):
+                manifest[relative] = ("directory", None)
+                pending.append(child)
+                continue
+            if stat.S_ISREG(child_stat.st_mode):
+                manifest[relative] = ("file", localio.file_sha256(child))
+                continue
+            raise OSError(f"verify archive tree contains a special file: {child}")
+    return manifest
+
+
 def _archive_verify_run(run_dir: Path, archive_root: Path) -> dict[str, Any]:
     """Copy one run dir into the archive and append an index entry. Raises on failure.
 
@@ -509,31 +561,43 @@ def _archive_verify_run(run_dir: Path, archive_root: Path) -> dict[str, Any]:
     """
     run_id = run_dir.name
     dest = archive_root / run_id
+    source_manifest = _verify_archive_tree_manifest(run_dir)
     receipt_path = run_dir / "receipt.json"
     source_receipt_sha = localio.file_sha256(receipt_path) if receipt_path.is_file() else None
+    if dest.is_symlink():
+        raise OSError(f"verify archive conflict: {dest} is a symlink")
     if dest.exists():
         # Re-archive of the same run id is only safe when the evidence is identical.
+        if _verify_archive_tree_manifest(dest) != source_manifest:
+            raise OSError(f"verify archive conflict: {dest} already exists with different evidence")
         dest_receipt = dest / "receipt.json"
         dest_sha = localio.file_sha256(dest_receipt) if dest_receipt.is_file() else None
-        if source_receipt_sha is None or dest_sha != source_receipt_sha:
+        if dest_sha != source_receipt_sha:
             raise OSError(f"verify archive conflict: {dest} already exists with different evidence")
-        entry = _verify_archive_index_entry(run_dir, dest, source_receipt_sha, already_archived=True)
+        if dest_sha is not None:
+            _assert_archived_receipt_integrity(dest_receipt)
+        entry = _verify_archive_index_entry(run_dir, dest, dest_sha, already_archived=True)
         _append_verify_archive_index(archive_root, entry)
         return entry
     archive_root.mkdir(parents=True, exist_ok=True)
     staging = archive_root / f".{run_id}.staging-{uuid4().hex[:8]}"
-    shutil.copytree(run_dir, staging)
+    shutil.copytree(run_dir, staging, symlinks=True)
     try:
+        if _verify_archive_tree_manifest(staging) != source_manifest:
+            raise OSError(f"verify archive copy tree mismatch: {run_id}")
         if source_receipt_sha is not None:
             copied_sha = localio.file_sha256(staging / "receipt.json")
             if copied_sha != source_receipt_sha:
                 raise OSError(f"verify archive copy integrity check failed: {run_id}")
             _assert_archived_receipt_integrity(staging / "receipt.json")
         os.rename(staging, dest)
+        if _verify_archive_tree_manifest(run_dir) != source_manifest:
+            raise OSError(f"verify archive source changed during copy: {run_id}")
     except BaseException:
         shutil.rmtree(staging, ignore_errors=True)
         raise
-    entry = _verify_archive_index_entry(run_dir, dest, source_receipt_sha, already_archived=False)
+    archived_receipt_sha = localio.file_sha256(dest / "receipt.json") if source_receipt_sha is not None else None
+    entry = _verify_archive_index_entry(run_dir, dest, archived_receipt_sha, already_archived=False)
     _append_verify_archive_index(archive_root, entry)
     return entry
 
@@ -559,17 +623,12 @@ def _prune_verify_runs(target: Path, keep: int | None = None, archive_root: Path
     try:
         resolved_archive = _verify_archive_root(target, archive_root)
     except Exception:
-        resolved_archive = None
+        return 0
     run_dirs = sorted((child for child in root.iterdir() if child.is_dir()), key=lambda p: p.name, reverse=True)
     removed = 0
     # Oldest first so the append-only archive index grows in chronological order.
     for stale in reversed(run_dirs[keep:]):
         if resolved_archive is not None:
-            try:
-                resolved_archive.relative_to(stale)
-                continue  # the archive root itself lives under the runs root; never prune it
-            except ValueError:
-                pass
             try:
                 _archive_verify_run(stale, resolved_archive)
             except Exception:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -196,3 +196,103 @@ def test_load_config_rejects_invalid_capture_before_retry(tmp_path, value):
     )
     with pytest.raises(ValueError, match="capture_before_retry must be one of"):
         load_config(tmp_path)
+
+
+def _write_config_json(tmp_path, **overrides):
+    payload = {
+        "version": 1,
+        "depth": "repo",
+        "harnesses": ["claude"],
+        "owner": "claude",
+        "includes": [],
+    }
+    payload.update(overrides)
+    path = tmp_path / ".brigade" / "config.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload) + "\n")
+
+
+def test_load_config_defaults_verify_retention_settings(tmp_path):
+    _write_config_json(tmp_path)
+    loaded = load_config(tmp_path)
+    assert loaded is not None
+    assert loaded.verify_runs_keep == 50
+    assert loaded.verify_archive_enabled is True
+    assert loaded.verify_archive_dir == ".brigade/work/verify-archive"
+
+
+def test_load_config_reads_verify_retention_settings(tmp_path):
+    _write_config_json(
+        tmp_path,
+        verify_runs_keep=10,
+        verify_archive_enabled=False,
+        verify_archive_dir="evidence/verify-archive",
+    )
+    loaded = load_config(tmp_path)
+    assert loaded is not None
+    assert loaded.verify_runs_keep == 10
+    assert loaded.verify_archive_enabled is False
+    assert loaded.verify_archive_dir == "evidence/verify-archive"
+
+
+def test_write_then_load_round_trip_preserves_verify_retention_settings(tmp_path):
+    sel = Selection(depth="repo", harnesses=["claude"], owner="claude", includes=[])
+    cfg = Config(
+        version=1,
+        selection=sel,
+        verify_runs_keep=10,
+        verify_archive_enabled=False,
+        verify_archive_dir="evidence/verify-archive",
+    )
+    write_config(tmp_path, cfg)
+
+    loaded = load_config(tmp_path)
+    assert loaded is not None
+    assert loaded.verify_runs_keep == 10
+    assert loaded.verify_archive_enabled is False
+    assert loaded.verify_archive_dir == "evidence/verify-archive"
+
+
+@pytest.mark.parametrize("value", [0, -1, "many", True, 2.5])
+def test_load_config_rejects_invalid_verify_runs_keep(tmp_path, value):
+    _write_config_json(tmp_path, verify_runs_keep=value)
+    with pytest.raises(ValueError, match="verify_runs_keep must be a positive integer"):
+        load_config(tmp_path)
+
+
+@pytest.mark.parametrize("value", ["yes", 1, 0])
+def test_load_config_rejects_invalid_verify_archive_enabled(tmp_path, value):
+    _write_config_json(tmp_path, verify_archive_enabled=value)
+    with pytest.raises(ValueError, match="verify_archive_enabled must be true or false"):
+        load_config(tmp_path)
+
+
+@pytest.mark.parametrize("value", ["", "   ", 123])
+def test_load_config_rejects_invalid_verify_archive_dir(tmp_path, value):
+    _write_config_json(tmp_path, verify_archive_dir=value)
+    with pytest.raises(ValueError, match="verify_archive_dir must be a non-empty string"):
+        load_config(tmp_path)
+
+
+def test_resolve_verify_runs_keep_defaults_without_config(tmp_path):
+    from brigade.config import resolve_verify_runs_keep
+
+    assert resolve_verify_runs_keep(tmp_path) == 50
+
+
+def test_resolve_verify_archive_defaults_without_config(tmp_path):
+    from brigade.config import resolve_verify_archive
+
+    enabled, root = resolve_verify_archive(tmp_path)
+    assert enabled is True
+    assert root == tmp_path / ".brigade" / "work" / "verify-archive"
+
+
+def test_resolve_verify_archive_honors_absolute_dir(tmp_path):
+    from brigade.config import resolve_verify_archive
+
+    destination = tmp_path / "elsewhere" / "archive"
+    _write_config_json(tmp_path, verify_archive_dir=str(destination))
+    enabled, root = resolve_verify_archive(tmp_path)
+    assert enabled is True
+    assert root == destination

--- a/tests/test_work_cmd_verification.py
+++ b/tests/test_work_cmd_verification.py
@@ -292,6 +292,45 @@ def test_prune_verify_runs_archive_failure_keeps_run_dir(tmp_path, monkeypatch):
     assert sorted(p.name for p in root.iterdir()) == names
 
 
+def test_prune_verify_runs_invalid_archive_config_keeps_run_dir(tmp_path):
+    from brigade.work_cmd import helpers, verification
+
+    root = helpers._verify_runs_root(tmp_path)
+    root.mkdir(parents=True)
+    _write_verify_run_dir(root, "20260101-000001-a")
+    _write_verify_run_dir(root, "20260101-000002-b")
+    _write_verify_retention_config(tmp_path, verify_archive_dir="")
+
+    removed = verification._prune_verify_runs(tmp_path, keep=1)
+
+    assert removed == 0
+    assert (root / "20260101-000001-a" / "receipt.json").is_file()
+
+
+@pytest.mark.parametrize("archive_location", ["equal", "ancestor", "descendant", "symlink-alias"])
+def test_prune_verify_runs_rejects_archive_overlap(tmp_path, archive_location):
+    from brigade.work_cmd import helpers, verification
+
+    root = helpers._verify_runs_root(tmp_path)
+    root.mkdir(parents=True)
+    _write_verify_run_dir(root, "20260101-000001-a")
+    _write_verify_run_dir(root, "20260101-000002-b")
+    if archive_location == "equal":
+        archive_root = root
+    elif archive_location == "ancestor":
+        archive_root = root.parent
+    elif archive_location == "descendant":
+        archive_root = root / "archive"
+    else:
+        archive_root = tmp_path / "archive-alias"
+        archive_root.symlink_to(root, target_is_directory=True)
+
+    removed = verification._prune_verify_runs(tmp_path, keep=1, archive_root=archive_root)
+
+    assert removed == 0
+    assert (root / "20260101-000001-a" / "receipt.json").is_file()
+
+
 def test_prune_verify_runs_tampered_receipt_keeps_run_dir(tmp_path):
     from brigade.work_cmd import helpers, verification
 
@@ -330,6 +369,45 @@ def test_prune_verify_runs_archive_conflict_keeps_run_dir(tmp_path):
     assert (root / "20260101-000001-a").is_dir()
 
 
+def test_prune_verify_runs_partial_existing_archive_keeps_run_dir(tmp_path):
+    from brigade.work_cmd import helpers, verification
+
+    root = helpers._verify_runs_root(tmp_path)
+    root.mkdir(parents=True)
+    run_dir, _ = _write_verify_run_dir(root, "20260101-000001-a")
+    _write_verify_run_dir(root, "20260101-000002-b")
+
+    archive_root = tmp_path / "verify-archive"
+    archived = archive_root / run_dir.name
+    archived.mkdir(parents=True)
+    (archived / "receipt.json").write_bytes((run_dir / "receipt.json").read_bytes())
+
+    removed = verification._prune_verify_runs(tmp_path, keep=1, archive_root=archive_root)
+
+    assert removed == 0
+    assert run_dir.is_dir()
+    assert not (archived / "command-1-stdout.log").exists()
+
+
+def test_prune_verify_runs_symlink_existing_archive_keeps_run_dir(tmp_path):
+    from brigade.work_cmd import helpers, verification
+
+    root = helpers._verify_runs_root(tmp_path)
+    root.mkdir(parents=True)
+    run_dir, _ = _write_verify_run_dir(root, "20260101-000001-a")
+    _write_verify_run_dir(root, "20260101-000002-b")
+
+    archive_root = tmp_path / "verify-archive"
+    archive_root.mkdir()
+    (archive_root / run_dir.name).symlink_to(run_dir, target_is_directory=True)
+
+    removed = verification._prune_verify_runs(tmp_path, keep=1, archive_root=archive_root)
+
+    assert removed == 0
+    assert run_dir.is_dir()
+    assert (run_dir / "receipt.json").is_file()
+
+
 def test_prune_verify_runs_rearchive_identical_evidence_is_safe(tmp_path):
     from brigade.work_cmd import helpers, verification
 
@@ -351,6 +429,49 @@ def test_prune_verify_runs_rearchive_identical_evidence_is_safe(tmp_path):
     assert len(entries) == 1
     assert entries[0]["already_archived"] is True
     assert entries[0]["receipt_sha256"] == receipt["digests"]["receipt_sha256"]
+
+
+def test_prune_verify_runs_source_symlink_keeps_run_dir(tmp_path):
+    from brigade.work_cmd import helpers, verification
+
+    root = helpers._verify_runs_root(tmp_path)
+    root.mkdir(parents=True)
+    run_dir, _ = _write_verify_run_dir(root, "20260101-000001-a")
+    _write_verify_run_dir(root, "20260101-000002-b")
+    outside = tmp_path / "private.log"
+    outside.write_text("private evidence\n")
+    (run_dir / "linked.log").symlink_to(outside)
+
+    archive_root = tmp_path / "verify-archive"
+    removed = verification._prune_verify_runs(tmp_path, keep=1, archive_root=archive_root)
+
+    assert removed == 0
+    assert run_dir.is_dir()
+    assert not (archive_root / run_dir.name).exists()
+
+
+@pytest.mark.skipif(os.name != "posix", reason="requires POSIX FIFO support")
+def test_prune_verify_runs_source_special_file_keeps_run_dir(tmp_path, monkeypatch):
+    from brigade.work_cmd import helpers, verification
+
+    root = helpers._verify_runs_root(tmp_path)
+    root.mkdir(parents=True)
+    run_dir, _ = _write_verify_run_dir(root, "20260101-000001-a")
+    _write_verify_run_dir(root, "20260101-000002-b")
+    os.mkfifo(run_dir / "stream")
+    copy_attempted = False
+
+    def _unexpected_copytree(*args, **kwargs):
+        nonlocal copy_attempted
+        copy_attempted = True
+        raise OSError("copytree must not receive special files")
+
+    monkeypatch.setattr(verification.shutil, "copytree", _unexpected_copytree)
+    removed = verification._prune_verify_runs(tmp_path, keep=1, archive_root=tmp_path / "verify-archive")
+
+    assert removed == 0
+    assert copy_attempted is False
+    assert run_dir.is_dir()
 
 
 def test_prune_verify_runs_without_receipt_archives_with_null_metadata(tmp_path):

--- a/tests/test_work_cmd_verification.py
+++ b/tests/test_work_cmd_verification.py
@@ -194,6 +194,280 @@ def test_prune_verify_runs_keeps_newest(tmp_path):
     assert sorted(p.name for p in root.iterdir()) == ["20260101-000002-b", "20260101-000003-c"]
 
 
+def _write_verify_run_dir(root, name, *, schema_version=2, sign=False, tamper=False):
+    """Build a run dir whose receipt carries a self-consistent digests block."""
+    run_dir = root / name
+    run_dir.mkdir(parents=True)
+    log_path = run_dir / "command-1-stdout.log"
+    log_path.write_text(f"stdout for {name}\n")
+    receipt = {
+        "schema_version": schema_version,
+        "run_id": name,
+        "target": str(root),
+        "status": "completed",
+        "started_at": "2026-01-01T00:00:00+00:00",
+        "completed_at": "2026-01-01T00:00:01+00:00",
+        "path": str(run_dir),
+        "commands": [],
+    }
+    digests = {
+        "algorithm": "sha256",
+        "logs": {"command-1-stdout.log": localio.file_sha256(log_path)},
+        "receipt_sha256": localio.canonical_json_digest(receipt, exclude_keys={"digests"}),
+    }
+    if sign:
+        digests["signature"] = f"sig-{name}"
+        digests["key_id"] = "test-key"
+    if tamper:
+        digests["receipt_sha256"] = "0" * 64
+    receipt["digests"] = digests
+    (run_dir / "receipt.json").write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n")
+    return run_dir, receipt
+
+
+def _read_archive_index(archive_root):
+    return localio.read_jsonl_dicts(archive_root / "index.jsonl")
+
+
+def test_prune_verify_runs_archives_evidence_before_delete(tmp_path):
+    from brigade.work_cmd import helpers, verification
+
+    root = helpers._verify_runs_root(tmp_path)
+    root.mkdir(parents=True)
+    names = ["20260101-000001-a", "20260101-000002-b", "20260101-000003-c", "20260101-000004-d"]
+    source_bytes = {}
+    receipts = {}
+    for name in names:
+        _, receipt = _write_verify_run_dir(root, name, sign=True)
+        receipts[name] = receipt
+        source_bytes[name] = (root / name / "receipt.json").read_bytes()
+
+    archive_root = tmp_path / "verify-archive"
+    removed = verification._prune_verify_runs(tmp_path, keep=2, archive_root=archive_root)
+
+    assert removed == 2
+    assert sorted(p.name for p in root.iterdir()) == ["20260101-000003-c", "20260101-000004-d"]
+    # Evidence for the pruned runs survives in the archive, byte-identical.
+    for name in ("20260101-000001-a", "20260101-000002-b"):
+        archived = archive_root / name
+        assert (archived / "receipt.json").read_bytes() == source_bytes[name]
+        assert (archived / "command-1-stdout.log").is_file()
+    # The append-only index records one line per archived run, oldest first,
+    # carrying the receipt's integrity metadata and schema version.
+    entries = _read_archive_index(archive_root)
+    assert [entry["run_id"] for entry in entries] == ["20260101-000001-a", "20260101-000002-b"]
+    for entry in entries:
+        receipt = receipts[entry["run_id"]]
+        assert entry["schema"] == "brigade.verify_archive_index.v1"
+        assert entry["schema_version"] == 1
+        assert entry["already_archived"] is False
+        assert entry["receipt_schema_version"] == 2
+        assert entry["receipt_sha256"] == receipt["digests"]["receipt_sha256"]
+        assert entry["signature"] == receipt["digests"]["signature"]
+        assert entry["key_id"] == "test-key"
+        assert entry["receipt_file_sha256"] == hashlib.sha256(source_bytes[entry["run_id"]]).hexdigest()
+        assert entry["status"] == "completed"
+    # Archived receipts still verify against their own integrity metadata.
+    for name in ("20260101-000001-a", "20260101-000002-b"):
+        payload = json.loads((archive_root / name / "receipt.json").read_text())
+        assert localio.canonical_json_digest(payload, exclude_keys={"digests"}) == payload["digests"]["receipt_sha256"]
+
+
+def test_prune_verify_runs_archive_failure_keeps_run_dir(tmp_path, monkeypatch):
+    from brigade.work_cmd import helpers, verification
+
+    root = helpers._verify_runs_root(tmp_path)
+    root.mkdir(parents=True)
+    names = ["20260101-000001-a", "20260101-000002-b", "20260101-000003-c"]
+    for name in names:
+        _write_verify_run_dir(root, name)
+
+    def _failing_archive(run_dir, archive_root):
+        raise OSError("archive destination unavailable")
+
+    monkeypatch.setattr(verification, "_archive_verify_run", _failing_archive)
+    removed = verification._prune_verify_runs(tmp_path, keep=1, archive_root=tmp_path / "verify-archive")
+
+    assert removed == 0
+    assert sorted(p.name for p in root.iterdir()) == names
+
+
+def test_prune_verify_runs_tampered_receipt_keeps_run_dir(tmp_path):
+    from brigade.work_cmd import helpers, verification
+
+    root = helpers._verify_runs_root(tmp_path)
+    root.mkdir(parents=True)
+    _write_verify_run_dir(root, "20260101-000001-a", tamper=True)
+    _write_verify_run_dir(root, "20260101-000002-b")
+
+    archive_root = tmp_path / "verify-archive"
+    removed = verification._prune_verify_runs(tmp_path, keep=1, archive_root=archive_root)
+
+    # The tampered receipt fails the post-copy integrity re-check, so its run
+    # dir is kept locally and no archive copy is left behind.
+    assert removed == 0
+    assert sorted(p.name for p in root.iterdir()) == ["20260101-000001-a", "20260101-000002-b"]
+    assert not (archive_root / "20260101-000001-a").exists()
+    assert _read_archive_index(archive_root) == []
+
+
+def test_prune_verify_runs_archive_conflict_keeps_run_dir(tmp_path):
+    from brigade.work_cmd import helpers, verification
+
+    root = helpers._verify_runs_root(tmp_path)
+    root.mkdir(parents=True)
+    _write_verify_run_dir(root, "20260101-000001-a")
+    _write_verify_run_dir(root, "20260101-000002-b")
+
+    archive_root = tmp_path / "verify-archive"
+    conflicting = archive_root / "20260101-000001-a"
+    conflicting.mkdir(parents=True)
+    (conflicting / "receipt.json").write_text('{"run_id": "different-evidence"}\n')
+
+    removed = verification._prune_verify_runs(tmp_path, keep=1, archive_root=archive_root)
+
+    assert removed == 0
+    assert (root / "20260101-000001-a").is_dir()
+
+
+def test_prune_verify_runs_rearchive_identical_evidence_is_safe(tmp_path):
+    from brigade.work_cmd import helpers, verification
+
+    root = helpers._verify_runs_root(tmp_path)
+    root.mkdir(parents=True)
+    run_dir, receipt = _write_verify_run_dir(root, "20260101-000001-a")
+    _write_verify_run_dir(root, "20260101-000002-b")
+
+    archive_root = tmp_path / "verify-archive"
+    import shutil as _shutil
+
+    _shutil.copytree(run_dir, archive_root / "20260101-000001-a")
+
+    removed = verification._prune_verify_runs(tmp_path, keep=1, archive_root=archive_root)
+
+    assert removed == 1
+    assert not (root / "20260101-000001-a").exists()
+    entries = _read_archive_index(archive_root)
+    assert len(entries) == 1
+    assert entries[0]["already_archived"] is True
+    assert entries[0]["receipt_sha256"] == receipt["digests"]["receipt_sha256"]
+
+
+def test_prune_verify_runs_without_receipt_archives_with_null_metadata(tmp_path):
+    from brigade.work_cmd import helpers, verification
+
+    root = helpers._verify_runs_root(tmp_path)
+    root.mkdir(parents=True)
+    legacy = root / "20260101-000001-a"
+    legacy.mkdir()
+    (legacy / "command-1-stdout.log").write_text("partial run\n")
+    _write_verify_run_dir(root, "20260101-000002-b")
+
+    archive_root = tmp_path / "verify-archive"
+    removed = verification._prune_verify_runs(tmp_path, keep=1, archive_root=archive_root)
+
+    assert removed == 1
+    assert (archive_root / "20260101-000001-a" / "command-1-stdout.log").is_file()
+    entries = _read_archive_index(archive_root)
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["run_id"] == "20260101-000001-a"
+    assert entry["receipt_file_sha256"] is None
+    assert entry["receipt_sha256"] is None
+    assert entry["receipt_schema_version"] is None
+    assert entry["signature"] is None
+    assert entry["status"] is None
+
+
+def _write_verify_retention_config(tmp_path, **overrides):
+    payload = {
+        "version": 1,
+        "depth": "repo",
+        "harnesses": ["claude"],
+        "owner": "claude",
+        "includes": [],
+    }
+    payload.update(overrides)
+    path = tmp_path / ".brigade" / "config.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload) + "\n")
+
+
+def test_prune_verify_runs_respects_configured_keep_and_archive_dir(tmp_path):
+    from brigade.work_cmd import helpers, verification
+
+    root = helpers._verify_runs_root(tmp_path)
+    root.mkdir(parents=True)
+    names = ["20260101-000001-a", "20260101-000002-b", "20260101-000003-c"]
+    for name in names:
+        _write_verify_run_dir(root, name)
+    _write_verify_retention_config(tmp_path, verify_runs_keep=1, verify_archive_dir="evidence/verify-archive")
+
+    removed = verification._prune_verify_runs(tmp_path)
+
+    assert removed == 2
+    assert sorted(p.name for p in root.iterdir()) == ["20260101-000003-c"]
+    archive_root = tmp_path / "evidence" / "verify-archive"
+    assert (archive_root / "20260101-000001-a" / "receipt.json").is_file()
+    assert (archive_root / "20260101-000002-b" / "receipt.json").is_file()
+    assert len(_read_archive_index(archive_root)) == 2
+
+
+def test_prune_verify_runs_defaults_archive_next_to_runs_root(tmp_path):
+    from brigade.work_cmd import helpers, verification
+
+    root = helpers._verify_runs_root(tmp_path)
+    root.mkdir(parents=True)
+    for name in ("20260101-000001-a", "20260101-000002-b"):
+        _write_verify_run_dir(root, name)
+
+    removed = verification._prune_verify_runs(tmp_path, keep=1)
+
+    assert removed == 1
+    default_archive = tmp_path / ".brigade" / "work" / "verify-archive"
+    assert (default_archive / "20260101-000001-a" / "receipt.json").is_file()
+    assert len(_read_archive_index(default_archive)) == 1
+
+
+def test_prune_verify_runs_archive_disabled_matches_legacy_delete(tmp_path):
+    from brigade.work_cmd import helpers, verification
+
+    root = helpers._verify_runs_root(tmp_path)
+    root.mkdir(parents=True)
+    names = ["20260101-000001-a", "20260101-000002-b", "20260101-000003-c"]
+    for name in names:
+        _write_verify_run_dir(root, name)
+    _write_verify_retention_config(tmp_path, verify_runs_keep=1, verify_archive_enabled=False)
+
+    removed = verification._prune_verify_runs(tmp_path)
+
+    assert removed == 2
+    assert sorted(p.name for p in root.iterdir()) == ["20260101-000003-c"]
+    assert not (tmp_path / ".brigade" / "work" / "verify-archive").exists()
+
+
+def test_verify_run_finalization_archives_pruned_runs(tmp_path):
+    from brigade.work_cmd import helpers
+
+    _init_git_repo(tmp_path)
+    root = helpers._verify_runs_root(tmp_path)
+    root.mkdir(parents=True)
+    # Seed the runs root at the retention cap so the new run triggers pruning.
+    for index in range(50):
+        _write_verify_run_dir(root, f"20260101-0000{index:02d}-seed")
+
+    assert work_cmd.verify_run(target=tmp_path, commands=["python3 -c \"print('ok')\""]) == 0
+
+    run_dirs = sorted(p.name for p in root.iterdir())
+    assert len(run_dirs) == 50
+    assert "20260101-000000-seed" not in run_dirs
+    default_archive = tmp_path / ".brigade" / "work" / "verify-archive"
+    assert (default_archive / "20260101-000000-seed" / "receipt.json").is_file()
+    entries = _read_archive_index(default_archive)
+    assert [entry["run_id"] for entry in entries] == ["20260101-000000-seed"]
+    assert entries[0]["receipt_schema_version"] == 2
+
+
 def test_outcome_health_flags_dormant_then_half_fed(tmp_path):
     from brigade import outcome_cmd
 


### PR DESCRIPTION
Closes #565

## Summary

Verification retention kept the newest 50 run directories and deleted older receipt evidence, which conflicts with append-only audit storage. This adds an archival path that preserves receipt evidence before local pruning runs.

- archival path runs before local pruning
- receipt integrity metadata and schema version preserved through archival
- local retention limit stays configurable
- tests cover archive-before-prune ordering and integrity preservation

## Provenance

Produced by `brigade run --worker k3 --worktree`, run `20260727-211319-f7ca4eae`. That run is recorded as `failed` due to the isolation-guard misclassification filed as #597; the worker rebased its own worktree onto `origin/main`, which is why this patch applies to main cleanly.

## Verification

`brigade work verify run` on `tests/test_work_cmd_verification.py tests/test_config.py`, receipt `20260727-215705-work-verify-dc6fa9`: **137 passed, 1 failed**.

The single failure is `test_verify_reused_receipt_stamps_harness_session_from_outer_env_prefix`, which fails identically on **unpatched `origin/main`** in a worktree (`No module named brigade` in a spawned subprocess, because a worktree lacks the editable install). It is pre-existing and environmental, not introduced here. CI runs against a proper install and should be the deciding gate.