### PR TITLE
docs(code-graph): remove archived GraphTrail install guidance

### DIFF
--- a/engines/code-graph/README.md
+++ b/engines/code-graph/README.md
@@ -38,7 +38,8 @@ brigade setup
 ```
 
 The standalone GraphTrail repository was archived on 2026-07-21. For source
-development, build the maintained copy in this repository:
+development, Rust 1.85 or newer is required. Build the maintained copy in this
+repository:
 
 ```bash
 cd engines/code-graph

--- a/engines/code-graph/README.md
+++ b/engines/code-graph/README.md
@@ -31,28 +31,18 @@
 
 ## Install
 
-When using Brigade, install GraphTrail and `graphtrail-mcp` through Brigade's verified managed manifest:
+Install GraphTrail and `graphtrail-mcp` through Brigade's verified managed manifest:
 
 ```bash
 brigade setup
 ```
 
-For independent use, GraphTrail also supports a one-release compatibility installation. Rust 1.85 or newer is required. This does not replace `brigade setup`. The crates.io badge above is the source of truth for the version installed from the registry; a GitHub tag is not treated as registry-available until that exact version is verified. From [crates.io](https://crates.io/crates/graphtrail):
+The standalone GraphTrail repository was archived on 2026-07-21. For source
+development, build the maintained copy in this repository:
 
 ```bash
-cargo install graphtrail
-```
-
-Independent development from git or a clone:
-
-```bash
-# Install the exact v0.4.0 GitHub release independently of registry availability.
-cargo install --git https://github.com/escoffier-labs/graphtrail --tag v0.4.0
-# Or install current master for development, not the default path.
-cargo install --git https://github.com/escoffier-labs/graphtrail
-# or
-git clone https://github.com/escoffier-labs/graphtrail.git
-cd graphtrail && cargo build --release
+cd engines/code-graph
+cargo build --release
 ```
 
 ## Release support

--- a/engines/code-graph/tests/repository_contract.rs
+++ b/engines/code-graph/tests/repository_contract.rs
@@ -140,8 +140,10 @@ fn supported_toolchain_and_agent_workflow_are_documented() {
 
     let readme = repository_file("README.md");
     assert!(
-        readme.contains("Rust 1.85 or newer"),
-        "README must state the supported Rust version"
+        readme.contains(
+            "Install GraphTrail and `graphtrail-mcp` through Brigade's verified managed manifest"
+        ),
+        "README must direct installation through Brigade's managed manifest"
     );
     assert!(
         readme.contains("`refresh: true` starts an incremental graph-index write"),
@@ -449,10 +451,12 @@ fn release_publication_is_preflighted_protected_and_recoverable() {
         "README crate badge must reflect the registry dynamically"
     );
     assert!(
-        readme.contains(
-            "cargo install --git https://github.com/escoffier-labs/graphtrail --tag v0.4.0"
-        ),
-        "README must distinguish the v0.4.0 Git tag from the registry install"
+        readme.contains("The standalone GraphTrail repository was archived on 2026-07-21"),
+        "README must state that the standalone GraphTrail repository is archived"
+    );
+    assert!(
+        !readme.contains("cargo install"),
+        "README must not restore standalone Cargo install guidance"
     );
 
     let recovery = repository_file("docs/releasing.md");

--- a/engines/code-graph/tests/repository_contract.rs
+++ b/engines/code-graph/tests/repository_contract.rs
@@ -146,6 +146,10 @@ fn supported_toolchain_and_agent_workflow_are_documented() {
         "README must direct installation through Brigade's managed manifest"
     );
     assert!(
+        readme.contains("Rust 1.85 or newer is required"),
+        "README must state the supported Rust version for source development"
+    );
+    assert!(
         readme.contains("`refresh: true` starts an incremental graph-index write"),
         "README must name when the opt-in MCP write starts"
     );
@@ -455,8 +459,10 @@ fn release_publication_is_preflighted_protected_and_recoverable() {
         "README must state that the standalone GraphTrail repository is archived"
     );
     assert!(
-        !readme.contains("cargo install"),
-        "README must not restore standalone Cargo install guidance"
+        !readme
+            .lines()
+            .any(|line| line.trim().starts_with("cargo install")),
+        "README must not restore executable standalone Cargo install guidance"
     );
 
     let recovery = repository_file("docs/releasing.md");


### PR DESCRIPTION
## Summary

- remove `cargo install` and clone instructions that direct readers to the archived standalone GraphTrail repository
- keep `brigade setup` as the supported installation path
- direct source contributors to build the maintained copy under `engines/code-graph`

## Verification

- Brigade verification confirmed that the Install section contains no `cargo install` guidance or archived repository URL, retains `brigade setup`, and points to the existing local Cargo project

## Issue

References #365.

The crates.io deprecation and freeze wording, plus disposition of `escoffier-labs/miseledger#43`, remain outside this PR.