### PR TITLE
fix(outcome): serialize digest-chain appends

### DIFF
--- a/src/brigade/outcome_cmd.py
+++ b/src/brigade/outcome_cmd.py
@@ -17,10 +17,22 @@ import os
 import platform as platform_mod
 import secrets
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
 from . import localio, outcome as core, receipt_schema, scorecard as scorecard_mod
+
+_LOCK_WAIT_SECONDS = 30.0
+_LOCK_SENTINEL_BYTE = b"\0"
+
+
+class OutcomeLedgerError(RuntimeError):
+    """Outcome ledger persistence failed; callers must not assume the append succeeded."""
+
+
+def _records_lock_path(target: Path) -> Path:
+    return _records_path(target).parent / ".records.lock"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -577,11 +589,191 @@ def load_records(target: Path) -> list[core.OutcomeRecord]:
 
 
 def _last_record_digest(path: Path) -> str | None:
-    for row in reversed(localio.read_jsonl_dicts(path)):
-        digest = row.get("digest")
-        if isinstance(digest, str) and digest:
-            return digest
-    return None
+    return _validate_completed_ledger(path)
+
+
+def _validate_completed_ledger(path: Path) -> str | None:
+    """Validate every completed ledger row and return the last signed digest."""
+    if not path.is_file():
+        return None
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        raise OutcomeLedgerError(f"could not read outcome ledger: {path}: {exc}") from exc
+    if not raw:
+        return None
+    if not raw.endswith(b"\n"):
+        raise OutcomeLedgerError(f"outcome ledger has incomplete trailing record: {path}")
+    previous_digest: str | None = None
+    for line_no, line in enumerate(raw.splitlines(), start=1):
+        if not line.strip():
+            raise OutcomeLedgerError(f"outcome ledger line {line_no} is empty: {path}")
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise OutcomeLedgerError(f"outcome ledger line {line_no} is not valid JSON: {path}: {exc}") from exc
+        if not isinstance(row, dict):
+            raise OutcomeLedgerError(f"outcome ledger line {line_no} is not an object: {path}")
+        recorded_digest = row.get("digest")
+        if not isinstance(recorded_digest, str) or not recorded_digest:
+            continue
+        recomputed = localio.canonical_json_digest(row, exclude_keys={"digest"})
+        if recomputed != recorded_digest:
+            raise OutcomeLedgerError(f"outcome ledger line {line_no} digest mismatch: {path}")
+        if "prev_digest" not in row:
+            previous_digest = recorded_digest
+            continue
+        actual_prev = row.get("prev_digest")
+        if actual_prev != previous_digest:
+            raise OutcomeLedgerError(f"outcome ledger line {line_no} digest chain break: {path}")
+        previous_digest = recorded_digest
+    return previous_digest
+
+
+def _windows_lock_seek(handle) -> None:
+    handle.seek(0)
+
+
+def _ensure_lock_sentinel(handle) -> None:
+    handle.seek(0, os.SEEK_END)
+    if handle.tell() == 0:
+        handle.write(_LOCK_SENTINEL_BYTE)
+        handle.flush()
+
+
+def _acquire_file_lock(handle, *, wait_seconds: float) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        _windows_lock_seek(handle)
+        if wait_seconds <= 0:
+            try:
+                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)  # type: ignore[attr-defined]
+            except OSError as exc:
+                raise BlockingIOError from exc
+            return
+        deadline = time.monotonic() + wait_seconds
+        while True:
+            _windows_lock_seek(handle)
+            try:
+                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)  # type: ignore[attr-defined]
+                return
+            except OSError:
+                if time.monotonic() >= deadline:
+                    raise TimeoutError from None
+                time.sleep(0.01)
+    else:
+        import fcntl
+
+        flags = fcntl.LOCK_EX
+        if wait_seconds <= 0:
+            flags |= fcntl.LOCK_NB
+            fcntl.flock(handle.fileno(), flags)
+            return
+        deadline = time.monotonic() + wait_seconds
+        while True:
+            try:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                return
+            except BlockingIOError:
+                if time.monotonic() >= deadline:
+                    raise TimeoutError from None
+                time.sleep(0.01)
+
+
+def _release_file_lock(handle) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        _windows_lock_seek(handle)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)  # type: ignore[attr-defined]
+        return
+    import fcntl
+
+    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+@contextlib.contextmanager
+def _records_append_lock(lock_path: Path, *, wait_seconds: float | None = None):
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    timeout = _LOCK_WAIT_SECONDS if wait_seconds is None else wait_seconds
+    try:
+        handle = lock_path.open("a+b")
+    except OSError as exc:
+        raise OutcomeLedgerError(f"could not open outcome ledger lock: {lock_path}: {exc}") from exc
+    acquired = False
+    try:
+        try:
+            _ensure_lock_sentinel(handle)
+            _acquire_file_lock(handle, wait_seconds=timeout)
+        except (BlockingIOError, TimeoutError) as exc:
+            raise OutcomeLedgerError(f"could not acquire outcome ledger lock: {lock_path}") from exc
+        except OSError as exc:
+            raise OutcomeLedgerError(f"could not acquire outcome ledger lock: {lock_path}: {exc}") from exc
+        acquired = True
+        yield
+    finally:
+        body_had_error = sys.exc_info()[0] is not None
+        cleanup_error: OutcomeLedgerError | None = None
+        if acquired:
+            try:
+                _release_file_lock(handle)
+            except OSError as exc:
+                cleanup_error = OutcomeLedgerError(f"could not release outcome ledger lock: {lock_path}: {exc}")
+                cleanup_error.__cause__ = exc
+        try:
+            handle.close()
+        except OSError as exc:
+            if cleanup_error is None:
+                cleanup_error = OutcomeLedgerError(f"could not close outcome ledger lock: {lock_path}: {exc}")
+                cleanup_error.__cause__ = exc
+        if not body_had_error and cleanup_error is not None:
+            raise cleanup_error
+
+
+def _recover_interrupted_append(path: Path) -> None:
+    """Drop a partial trailing JSONL line left by an interrupted append."""
+    if not path.is_file():
+        return
+    action = "recover"
+    try:
+        with path.open("r+b") as handle:
+            handle.seek(0, os.SEEK_END)
+            if handle.tell() == 0:
+                return
+            handle.seek(-1, os.SEEK_END)
+            if handle.read(1) == b"\n":
+                return
+            handle.seek(0)
+            data = handle.read()
+            last_newline = data.rfind(b"\n")
+            if last_newline < 0:
+                tail = data
+                truncate_to = 0
+            else:
+                tail = data[last_newline + 1 :]
+                truncate_to = last_newline + 1
+            if not tail:
+                return
+            try:
+                payload = json.loads(tail.decode("utf-8"))
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                payload = None
+            if isinstance(payload, dict):
+                action = "finalize"
+                handle.seek(0, os.SEEK_END)
+                handle.write(b"\n")
+            else:
+                handle.truncate(truncate_to)
+            handle.flush()
+            os.fsync(handle.fileno())
+    except OSError as exc:
+        detail = (
+            "could not finalize interrupted outcome ledger row"
+            if action == "finalize"
+            else "could not recover interrupted outcome ledger write"
+        )
+        raise OutcomeLedgerError(f"{detail}: {path}: {exc}") from exc
 
 
 def _record_payload(record: core.OutcomeRecord) -> dict:
@@ -605,16 +797,33 @@ def _record_payload(record: core.OutcomeRecord) -> dict:
 
 
 def append_records(target: Path, records: list[core.OutcomeRecord]) -> None:
+    """Append outcome records under an exclusive lock with interrupted-write recovery.
+
+    Recovery is row-scoped, not transactional: every completed JSONL line that
+    ends with a newline remains durable and stays in the digest chain. Only an
+    incomplete trailing line is discarded or finalized on the next append.
+    A multi-record ``append_records`` call is therefore not all-or-nothing; an
+    interrupted batch may leave earlier rows from that call on disk while the
+    partial tail is removed before validation and the next append proceeds.
+    """
     path = _records_path(target)
+    lock_path = _records_lock_path(target)
     path.parent.mkdir(parents=True, exist_ok=True)
-    prev_digest = _last_record_digest(path)
-    with path.open("a", encoding="utf-8") as handle:
-        for record in records:
-            row = _record_payload(record)
-            row["prev_digest"] = prev_digest
-            row["digest"] = localio.canonical_json_digest(row, exclude_keys={"digest"})
-            handle.write(json.dumps(row, sort_keys=True) + "\n")
-            prev_digest = row["digest"]
+    with _records_append_lock(lock_path):
+        _recover_interrupted_append(path)
+        prev_digest = _validate_completed_ledger(path)
+        try:
+            with path.open("a", encoding="utf-8") as handle:
+                for record in records:
+                    row = _record_payload(record)
+                    row["prev_digest"] = prev_digest
+                    row["digest"] = localio.canonical_json_digest(row, exclude_keys={"digest"})
+                    handle.write(json.dumps(row, sort_keys=True) + "\n")
+                    prev_digest = row["digest"]
+                handle.flush()
+                os.fsync(handle.fileno())
+        except OSError as exc:
+            raise OutcomeLedgerError(f"could not append outcome ledger records: {path}: {exc}") from exc
 
 
 def _compact_code_graph_delta(receipt: dict) -> dict | None:

--- a/src/brigade/outcome_cmd.py
+++ b/src/brigade/outcome_cmd.py
@@ -592,14 +592,8 @@ def _last_record_digest(path: Path) -> str | None:
     return _validate_completed_ledger(path)
 
 
-def _validate_completed_ledger(path: Path) -> str | None:
-    """Validate every completed ledger row and return the last signed digest."""
-    if not path.is_file():
-        return None
-    try:
-        raw = path.read_bytes()
-    except OSError as exc:
-        raise OutcomeLedgerError(f"could not read outcome ledger: {path}: {exc}") from exc
+def _validate_completed_ledger_bytes(raw: bytes, path: Path) -> str | None:
+    """Validate every completed ledger row in ``raw`` and return the last signed digest."""
     if not raw:
         return None
     if not raw.endswith(b"\n"):
@@ -628,6 +622,32 @@ def _validate_completed_ledger(path: Path) -> str | None:
             raise OutcomeLedgerError(f"outcome ledger line {line_no} digest chain break: {path}")
         previous_digest = recorded_digest
     return previous_digest
+
+
+def _validate_completed_ledger(path: Path) -> str | None:
+    """Validate every completed ledger row and return the last signed digest."""
+    if not path.is_file():
+        return None
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        raise OutcomeLedgerError(f"could not read outcome ledger: {path}: {exc}") from exc
+    return _validate_completed_ledger_bytes(raw, path)
+
+
+def _recoverable_trailing_record(payload: dict, prefix: bytes, path: Path) -> bool:
+    recorded_digest = payload.get("digest")
+    if not isinstance(recorded_digest, str) or not recorded_digest:
+        return False
+    if localio.canonical_json_digest(payload, exclude_keys={"digest"}) != recorded_digest:
+        return False
+    if "prev_digest" not in payload:
+        return False
+    try:
+        expected_prev = _validate_completed_ledger_bytes(prefix, path) if prefix else None
+    except OutcomeLedgerError:
+        return False
+    return payload.get("prev_digest") == expected_prev
 
 
 def _windows_lock_seek(handle) -> None:
@@ -759,7 +779,7 @@ def _recover_interrupted_append(path: Path) -> None:
                 payload = json.loads(tail.decode("utf-8"))
             except (UnicodeDecodeError, json.JSONDecodeError):
                 payload = None
-            if isinstance(payload, dict):
+            if isinstance(payload, dict) and _recoverable_trailing_record(payload, data[:truncate_to], path):
                 action = "finalize"
                 handle.seek(0, os.SEEK_END)
                 handle.write(b"\n")

--- a/tests/test_outcome_cmd.py
+++ b/tests/test_outcome_cmd.py
@@ -2479,6 +2479,104 @@ def test_windows_lock_helpers_use_existing_fixed_byte_at_offset_zero(tmp_path, m
     assert all(position == 0 for position in seek_positions)
 
 
+def _append_incomplete_trailing_row(
+    path: Path, prev_digest: str | None, record: outcome.OutcomeRecord, **row_overrides
+):
+    row = outcome_cmd._record_payload(record)
+    row["prev_digest"] = prev_digest
+    row["digest"] = localio.canonical_json_digest(row, exclude_keys={"digest"})
+    row.update(row_overrides)
+    if row_overrides.get("digest") is None and "digest" in row_overrides:
+        row.pop("digest", None)
+    trailing = json.dumps(row, sort_keys=True).encode("utf-8")
+    with path.open("ab") as handle:
+        handle.write(trailing)
+    return trailing
+
+
+def _assert_recovery_truncates_invalid_tail_and_append_succeeds(
+    tmp_path,
+    path: Path,
+    *,
+    trailing: bytes,
+    prefix_evidence_ref: str,
+    follow_up_evidence_ref: str,
+):
+    follow_up = outcome.OutcomeRecord(
+        "skill-x", "skill", "t3", "verify", 1, follow_up_evidence_ref, "2026-06-20T03:00:00+00:00"
+    )
+    outcome_cmd.append_records(tmp_path, [follow_up])
+
+    rows = [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+    assert len(rows) == 2
+    assert rows[0]["evidence_ref"] == prefix_evidence_ref
+    assert rows[1]["evidence_ref"] == follow_up_evidence_ref
+    assert rows[1]["prev_digest"] == rows[0]["digest"]
+    assert trailing not in path.read_bytes()
+    assert receipts_cmd.verify(target=tmp_path, json_output=True) == 0
+
+
+def test_recovery_truncates_parseable_tail_missing_digest(tmp_path):
+    first = outcome.OutcomeRecord("skill-x", "skill", "t0", "verify", 1, "ref-0", "2026-06-20T00:00:00+00:00")
+    outcome_cmd.append_records(tmp_path, [first])
+    path = tmp_path / "memory" / "outcome" / "records.jsonl"
+    prev_digest = json.loads(path.read_text().splitlines()[0])["digest"]
+    trailing = _append_incomplete_trailing_row(
+        path,
+        prev_digest,
+        outcome.OutcomeRecord("skill-x", "skill", "t1", "verify", 1, "ref-1", "2026-06-20T01:00:00+00:00"),
+        digest=None,
+    )
+
+    _assert_recovery_truncates_invalid_tail_and_append_succeeds(
+        tmp_path,
+        path,
+        trailing=trailing,
+        prefix_evidence_ref="ref-0",
+        follow_up_evidence_ref="ref-3",
+    )
+
+
+def test_recovery_truncates_parseable_tail_wrong_digest(tmp_path):
+    first = outcome.OutcomeRecord("skill-x", "skill", "t0", "verify", 1, "ref-0", "2026-06-20T00:00:00+00:00")
+    outcome_cmd.append_records(tmp_path, [first])
+    path = tmp_path / "memory" / "outcome" / "records.jsonl"
+    prev_digest = json.loads(path.read_text().splitlines()[0])["digest"]
+    trailing = _append_incomplete_trailing_row(
+        path,
+        prev_digest,
+        outcome.OutcomeRecord("skill-x", "skill", "t1", "verify", 1, "ref-1", "2026-06-20T01:00:00+00:00"),
+        digest="wrong-digest",
+    )
+
+    _assert_recovery_truncates_invalid_tail_and_append_succeeds(
+        tmp_path,
+        path,
+        trailing=trailing,
+        prefix_evidence_ref="ref-0",
+        follow_up_evidence_ref="ref-3",
+    )
+
+
+def test_recovery_truncates_parseable_tail_broken_prev_digest_chain(tmp_path):
+    first = outcome.OutcomeRecord("skill-x", "skill", "t0", "verify", 1, "ref-0", "2026-06-20T00:00:00+00:00")
+    outcome_cmd.append_records(tmp_path, [first])
+    path = tmp_path / "memory" / "outcome" / "records.jsonl"
+    trailing = _append_incomplete_trailing_row(
+        path,
+        "broken-prev-digest",
+        outcome.OutcomeRecord("skill-x", "skill", "t1", "verify", 1, "ref-1", "2026-06-20T01:00:00+00:00"),
+    )
+
+    _assert_recovery_truncates_invalid_tail_and_append_succeeds(
+        tmp_path,
+        path,
+        trailing=trailing,
+        prefix_evidence_ref="ref-0",
+        follow_up_evidence_ref="ref-3",
+    )
+
+
 def test_recovery_preserves_and_finalizes_complete_trailing_json_object(tmp_path):
     first = outcome.OutcomeRecord("skill-x", "skill", "t0", "verify", 1, "ref-0", "2026-06-20T00:00:00+00:00")
     outcome_cmd.append_records(tmp_path, [first])

--- a/tests/test_outcome_cmd.py
+++ b/tests/test_outcome_cmd.py
@@ -1,7 +1,13 @@
 import datetime as dt
 import json
+import multiprocessing
+import os
+import sys
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -2301,3 +2307,298 @@ def test_load_transitions_still_reads_legacy_second_resolution_receipts(tmp_path
     assert len(transitions) == 1
     assert transitions[0].artifact_id == "skill-legacy"
     assert transitions[0].new_status == "promoted"
+
+
+def _concurrent_append_worker(args: tuple[str, int, str]) -> None:
+    target_str, index, go_path_str = args
+    from brigade import outcome, outcome_cmd
+
+    go_path = Path(go_path_str)
+    while not go_path.exists():
+        time.sleep(0.001)
+    outcome_cmd.append_records(
+        Path(target_str),
+        [
+            outcome.OutcomeRecord(
+                "skill-x",
+                "skill",
+                f"t{index}",
+                "verify",
+                1,
+                f"ref-{index}",
+                f"2026-06-20T{index:02d}:00:00+00:00",
+            )
+        ],
+    )
+
+
+def _hold_records_lock_worker(lock_path_str: str, release_path_str: str, ready_path_str: str) -> None:
+    lock_path = Path(lock_path_str)
+    release_path = Path(release_path_str)
+    ready_path = Path(ready_path_str)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with outcome_cmd._records_append_lock(lock_path, wait_seconds=30.0):
+        ready_path.touch()
+        while not release_path.exists():
+            time.sleep(0.01)
+
+
+def test_concurrent_append_records_serialize_digest_chain(tmp_path):
+    seed = outcome.OutcomeRecord("skill-x", "skill", "t0", "verify", 1, "ref-0", "2026-06-20T00:00:00+00:00")
+    outcome_cmd.append_records(tmp_path, [seed])
+    sync_dir = tmp_path / "sync"
+    sync_dir.mkdir()
+    go_path = sync_dir / "go"
+    worker_count = 8
+    ctx = multiprocessing.get_context("spawn")
+    processes = [
+        ctx.Process(target=_concurrent_append_worker, args=((str(tmp_path), index, str(go_path)),))
+        for index in range(1, worker_count + 1)
+    ]
+    for proc in processes:
+        proc.start()
+    time.sleep(0.05)
+    go_path.touch()
+    for proc in processes:
+        proc.join(timeout=30)
+        assert proc.exitcode == 0, f"worker failed with exit code {proc.exitcode}"
+
+    path = tmp_path / "memory" / "outcome" / "records.jsonl"
+    rows = [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+    assert len(rows) == worker_count + 1
+    assert receipts_cmd.verify(target=tmp_path, json_output=True) == 0
+
+
+def test_append_records_recovers_interrupted_trailing_write(tmp_path):
+    first = outcome.OutcomeRecord("skill-x", "skill", "t0", "verify", 1, "ref-0", "2026-06-20T00:00:00+00:00")
+    outcome_cmd.append_records(tmp_path, [first])
+    path = tmp_path / "memory" / "outcome" / "records.jsonl"
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write('{"artifact_id": "skill-x", "signal_value": 1, "partial": true')
+
+    second = outcome.OutcomeRecord("skill-x", "skill", "t1", "verify", 1, "ref-1", "2026-06-20T01:00:00+00:00")
+    outcome_cmd.append_records(tmp_path, [second])
+
+    rows = [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+    assert len(rows) == 2
+    assert rows[0]["evidence_ref"] == "ref-0"
+    assert rows[1]["evidence_ref"] == "ref-1"
+    assert rows[1]["prev_digest"] == rows[0]["digest"]
+    assert receipts_cmd.verify(target=tmp_path, json_output=True) == 0
+
+
+def test_recovery_mutation_failure_preserves_every_completed_byte_and_fails_closed(tmp_path, monkeypatch):
+    first = outcome.OutcomeRecord("skill-x", "skill", "t0", "verify", 1, "ref-0", "2026-06-20T00:00:00+00:00")
+    second = outcome.OutcomeRecord("skill-x", "skill", "t1", "verify", 1, "ref-1", "2026-06-20T01:00:00+00:00")
+    outcome_cmd.append_records(tmp_path, [first, second])
+    path = tmp_path / "memory" / "outcome" / "records.jsonl"
+    with path.open("ab") as handle:
+        handle.write(b'{"artifact_id": "skill-x", "partial": true')
+    before = path.read_bytes()
+    real_open = Path.open
+
+    def guarded_open(self, mode="r", *args, **kwargs):
+        handle = real_open(self, mode, *args, **kwargs)
+        if self == path and mode == "r+b":
+
+            def fail_truncate(size=None):
+                raise OSError("simulated recovery truncate failure")
+
+            handle.truncate = fail_truncate
+        return handle
+
+    monkeypatch.setattr(Path, "open", guarded_open)
+    third = outcome.OutcomeRecord("skill-x", "skill", "t2", "verify", 1, "ref-2", "2026-06-20T02:00:00+00:00")
+    with pytest.raises(outcome_cmd.OutcomeLedgerError, match="could not recover interrupted outcome ledger write"):
+        outcome_cmd.append_records(tmp_path, [third])
+
+    assert path.read_bytes() == before
+    loaded = outcome_cmd.load_records(tmp_path)
+    assert [record.evidence_ref for record in loaded] == ["ref-0", "ref-1"]
+
+
+def test_append_fails_closed_on_malformed_terminated_json_without_changing_file(tmp_path):
+    path = tmp_path / "memory" / "outcome" / "records.jsonl"
+    path.parent.mkdir(parents=True)
+    valid = {
+        "artifact_id": "skill-x",
+        "artifact_kind": "skill",
+        "task_id": "t0",
+        "source": "verify",
+        "signal_value": 1,
+        "evidence_ref": "ref-0",
+        "ts": "2026-06-20T00:00:00+00:00",
+    }
+    path.write_text(json.dumps(valid, sort_keys=True) + "\nnot-json-at-all\n")
+    before = path.read_bytes()
+    record = outcome.OutcomeRecord("skill-x", "skill", "t1", "verify", 1, "ref-1", "2026-06-20T01:00:00+00:00")
+
+    with pytest.raises(outcome_cmd.OutcomeLedgerError, match="is not valid JSON"):
+        outcome_cmd.append_records(tmp_path, [record])
+
+    assert path.read_bytes() == before
+
+
+def test_append_fails_closed_on_tampered_digest_chain_without_changing_file(tmp_path):
+    first = outcome.OutcomeRecord("skill-x", "skill", "t0", "verify", 1, "ref-0", "2026-06-20T00:00:00+00:00")
+    outcome_cmd.append_records(tmp_path, [first])
+    path = tmp_path / "memory" / "outcome" / "records.jsonl"
+    row = json.loads(path.read_text().splitlines()[0])
+    row["digest"] = "tampered-digest"
+    path.write_text(json.dumps(row, sort_keys=True) + "\n")
+    before = path.read_bytes()
+    record = outcome.OutcomeRecord("skill-x", "skill", "t1", "verify", 1, "ref-1", "2026-06-20T01:00:00+00:00")
+
+    with pytest.raises(outcome_cmd.OutcomeLedgerError, match="digest mismatch"):
+        outcome_cmd.append_records(tmp_path, [record])
+
+    assert path.read_bytes() == before
+
+
+def test_windows_lock_helpers_use_existing_fixed_byte_at_offset_zero(tmp_path, monkeypatch):
+    monkeypatch.setattr(os, "name", "nt")
+    lock_path = tmp_path / "memory" / "outcome" / ".records.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    seek_positions: list[int] = []
+
+    fake_msvcrt = mock.Mock()
+    fake_msvcrt.LK_NBLCK = 1
+    fake_msvcrt.LK_UNLCK = 2
+
+    def spy_locking(fd, _mode, _nbytes):
+        seek_positions.append(os.lseek(fd, 0, os.SEEK_CUR))
+
+    fake_msvcrt.locking = spy_locking
+    monkeypatch.setitem(sys.modules, "msvcrt", fake_msvcrt)
+
+    with outcome_cmd._records_append_lock(lock_path):
+        pass
+
+    assert lock_path.read_bytes()[:1] == b"\0"
+    assert seek_positions
+    assert all(position == 0 for position in seek_positions)
+
+
+def test_recovery_preserves_and_finalizes_complete_trailing_json_object(tmp_path):
+    first = outcome.OutcomeRecord("skill-x", "skill", "t0", "verify", 1, "ref-0", "2026-06-20T00:00:00+00:00")
+    outcome_cmd.append_records(tmp_path, [first])
+    path = tmp_path / "memory" / "outcome" / "records.jsonl"
+    first_bytes = path.read_bytes()
+    second = outcome.OutcomeRecord("skill-x", "skill", "t1", "verify", 1, "ref-1", "2026-06-20T01:00:00+00:00")
+    row = outcome_cmd._record_payload(second)
+    row["prev_digest"] = json.loads(first_bytes.splitlines()[0].decode())["digest"]
+    row["digest"] = localio.canonical_json_digest(row, exclude_keys={"digest"})
+    trailing = json.dumps(row, sort_keys=True).encode("utf-8")
+    with path.open("ab") as handle:
+        handle.write(trailing)
+
+    third = outcome.OutcomeRecord("skill-x", "skill", "t2", "verify", 1, "ref-2", "2026-06-20T02:00:00+00:00")
+    outcome_cmd.append_records(tmp_path, [third])
+
+    data = path.read_bytes()
+    assert data.startswith(first_bytes)
+    assert first_bytes + trailing + b"\n" in data
+    rows = [json.loads(line) for line in data.splitlines() if line.strip()]
+    assert len(rows) == 3
+    assert rows[1]["evidence_ref"] == "ref-1"
+    assert rows[2]["evidence_ref"] == "ref-2"
+    assert rows[2]["prev_digest"] == rows[1]["digest"]
+
+
+def test_lock_release_failure_raises_outcome_ledger_error(tmp_path, monkeypatch):
+    def fail_release(_handle):
+        raise OSError("simulated lock release failure")
+
+    monkeypatch.setattr(outcome_cmd, "_release_file_lock", fail_release)
+    record = outcome.OutcomeRecord("skill-x", "skill", "t1", "verify", 1, "ref-1", "2026-06-20T01:00:00+00:00")
+    with pytest.raises(outcome_cmd.OutcomeLedgerError, match="could not release outcome ledger lock"):
+        outcome_cmd.append_records(tmp_path, [record])
+
+
+def test_lock_cleanup_preserves_body_error_when_release_fails(tmp_path, monkeypatch):
+    lock_path = outcome_cmd._records_lock_path(tmp_path)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    close_attempts: list[Path] = []
+    real_open = Path.open
+
+    def tracking_open(self, mode="r", *args, **kwargs):
+        handle = real_open(self, mode, *args, **kwargs)
+        if self == lock_path:
+            real_close = handle.close
+
+            def tracked_close():
+                close_attempts.append(self)
+                return real_close()
+
+            handle.close = tracked_close
+        return handle
+
+    def fail_release(_handle):
+        raise OSError("simulated lock release failure")
+
+    monkeypatch.setattr(Path, "open", tracking_open)
+    monkeypatch.setattr(outcome_cmd, "_release_file_lock", fail_release)
+    with pytest.raises(outcome_cmd.OutcomeLedgerError, match="simulated body failure"):
+        with outcome_cmd._records_append_lock(lock_path):
+            raise outcome_cmd.OutcomeLedgerError("simulated body failure")
+
+    assert close_attempts == [lock_path]
+
+
+def test_append_records_interrupted_multi_record_batch_preserves_completed_rows(tmp_path):
+    seed = outcome.OutcomeRecord("skill-x", "skill", "t0", "verify", 1, "ref-0", "2026-06-20T00:00:00+00:00")
+    outcome_cmd.append_records(tmp_path, [seed])
+    path = tmp_path / "memory" / "outcome" / "records.jsonl"
+    seed_rows = [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+    prev_digest = seed_rows[-1]["digest"]
+
+    batch_first = outcome.OutcomeRecord("skill-x", "skill", "t1", "verify", 1, "ref-1", "2026-06-20T01:00:00+00:00")
+    batch_second = outcome.OutcomeRecord("skill-x", "skill", "t2", "verify", 1, "ref-2", "2026-06-20T02:00:00+00:00")
+    completed_row = outcome_cmd._record_payload(batch_first)
+    completed_row["prev_digest"] = prev_digest
+    completed_row["digest"] = localio.canonical_json_digest(completed_row, exclude_keys={"digest"})
+    partial_row = outcome_cmd._record_payload(batch_second)
+    partial_row["prev_digest"] = completed_row["digest"]
+    partial_row["digest"] = localio.canonical_json_digest(partial_row, exclude_keys={"digest"})
+    with path.open("ab") as handle:
+        handle.write(json.dumps(completed_row, sort_keys=True).encode("utf-8") + b"\n")
+        handle.write(json.dumps(partial_row, sort_keys=True).encode("utf-8")[:40])
+
+    before = path.read_bytes()
+    follow_up = outcome.OutcomeRecord("skill-x", "skill", "t3", "verify", 1, "ref-3", "2026-06-20T03:00:00+00:00")
+    outcome_cmd.append_records(tmp_path, [follow_up])
+
+    rows = [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+    assert len(rows) == 3
+    assert path.read_bytes().startswith(before[: before.rfind(b"\n") + 1])
+    assert rows[1]["evidence_ref"] == "ref-1"
+    assert rows[1]["prev_digest"] == prev_digest
+    assert rows[2]["evidence_ref"] == "ref-3"
+    assert rows[2]["prev_digest"] == rows[1]["digest"]
+    assert receipts_cmd.verify(target=tmp_path, json_output=True) == 0
+
+
+def test_append_records_fails_closed_when_lock_is_held(tmp_path, monkeypatch):
+    monkeypatch.setattr(outcome_cmd, "_LOCK_WAIT_SECONDS", 0.5)
+    lock_path = outcome_cmd._records_lock_path(tmp_path)
+    release_path = tmp_path / "release-lock"
+    ready_path = tmp_path / "holder-ready"
+    ctx = multiprocessing.get_context("spawn")
+    holder = ctx.Process(
+        target=_hold_records_lock_worker,
+        args=(str(lock_path), str(release_path), str(ready_path)),
+    )
+    holder.start()
+    try:
+        deadline = time.monotonic() + 5
+        while not ready_path.exists():
+            if time.monotonic() >= deadline:
+                pytest.fail("lock holder never acquired the records lock")
+            time.sleep(0.02)
+        record = outcome.OutcomeRecord("skill-x", "skill", "t1", "verify", 1, "ref-1", "2026-06-20T01:00:00+00:00")
+        with pytest.raises(outcome_cmd.OutcomeLedgerError, match="could not acquire outcome ledger lock"):
+            outcome_cmd.append_records(tmp_path, [record])
+    finally:
+        release_path.touch()
+        holder.join(timeout=10)
+        assert holder.exitcode == 0


### PR DESCRIPTION
## Summary

Concurrent outcome writers could read the same predecessor digest before either process appended its record. Both records then pointed to the same predecessor, forking the digest chain and breaking its single-chain ordering guarantee.

This change:

- holds a cross-process file lock across interrupted-write recovery, ledger validation, predecessor selection, append, flush, and `fsync`
- uses `fcntl.flock` on POSIX and `msvcrt.locking` on a fixed sentinel byte on Windows
- preserves legacy digestless rows and every completed JSONL row during recovery
- rejects malformed JSON and signed-chain corruption before extending the ledger
- defines multi-record appends as row-durable rather than transactional

## Tests

- Added multiprocessing coverage for concurrent writers and digest-chain verification.
- Added recovery tests for partial tails, complete rows missing a newline, failed truncation, and partially completed multi-record batches.
- Added fail-closed coverage for lock acquisition, cleanup, malformed rows, and tampered digests.
- Added Windows lock offset and sentinel coverage.

## Verification

- `pytest -q tests/test_outcome_cmd.py`: 121 passed in 3.06s
- `./scripts/verify`: 4,906 passed, 3 skipped in 479.60s with 82.98% coverage

Closes #566

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved outcome ledger reliability during concurrent writes.
  * Added recovery for interrupted or partially written records while preserving completed entries.
  * Added validation to detect malformed or tampered ledger data before changes are appended.
  * Improved error handling when ledger access or locking fails.
  * Ensured appended records are flushed and durably saved to disk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->