### PR TITLE
Harden native release artifact preflight

### DIFF
--- a/.claude/memory-handoffs/20260729-155845-release-tooling-preflight.md
+++ b/.claude/memory-handoffs/20260729-155845-release-tooling-preflight.md
@@ -1,0 +1,46 @@
+# Memory Handoff
+
+## Type
+
+workflow
+
+## Title
+
+Release tooling preflight for published native assets
+
+## Summary
+
+The future stable release path now proves that Unix published acceptance cannot resolve Go before managed setup or managed-binary smoke. Darwin amd64 acceptance also executes and validates agent-notify under Rosetta, agent-notify build dates derive from the tagged commit, and the release guide records the 25-native-asset and 27-file inventory.
+
+## Durable facts
+
+- Unix published acceptance removes PATH directories containing `go`, then checks `shutil.which("go", path=...)` immediately before online setup and immediately before managed-component smoke.
+- Darwin amd64 acceptance runs `arch -x86_64 <agent-notify> version --json` and applies the same version, commit, and UTC build-date validation as the managed host binary.
+- The publish workflow derives agent-notify `BUILD_DATE` from the committer timestamp of `github.sha`, so strict release-asset resume checks can reproduce binary metadata.
+- A complete GitHub release contains five managed components across five platforms, for 25 native assets and 27 files after `component-manifest-v1.json` and `checksums.txt`.
+- Package version `0.25.1`, changelog headings, component manifest hashes, issue state, and publication state were intentionally unchanged.
+
+## Evidence
+
+- files changed: `.github/workflows/publish.yml`, `RELEASE.md`, `scripts/published-artifact-acceptance.py`, `tests/test_publish_workflow.py`, `tests/test_published_artifact_acceptance.py`, `tests/test_release_checklist.py`
+- Brigade implementation run: `20260729-193355-10e68a42`, with `code_graph_brief.attached=true`
+- focused verification: `brigade work verify run --target . --command '.venv/bin/pytest -q tests/test_published_artifact_acceptance.py tests/test_publish_workflow.py tests/test_release_checklist.py' --capture brigade-work`
+- focused receipt: `20260729-195000-work-verify-7142ca`
+- full verification: `brigade work verify run --target . --command './scripts/verify' --capture brigade-work`
+- full receipt: `20260729-195037-work-verify-1cbdad`
+- full result: `4905 passed, 3 skipped in 460.33s`, total coverage `82.98%`
+- corrected fast-gate error: `unformatted: File would be reformatted`
+
+## Recommended memory action
+
+no-card
+
+## Target document
+
+TOOLS.md
+
+## Suggested document content
+
+### Brigade stable-release native asset preflight
+
+Published Unix acceptance must construct a Go-free PATH and confirm `shutil.which("go", path=...)` returns `None` immediately before managed setup and managed-binary smoke. Darwin amd64 acceptance must run agent-notify with `arch -x86_64 ... version --json` and validate its version, commit SHA, and UTC build date. Agent-notify `BUILD_DATE` comes from the tagged commit timestamp. The release inventory is 25 native assets and 27 total GitHub release files after the generated manifest and checksum file.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -185,11 +185,12 @@ jobs:
           suffix=""
           if [ "$GOOS" = windows ]; then suffix=.exe; fi
           # Tag version without the leading v, the full release commit SHA, and
-          # one UTC build timestamp shared by every ldflags -X injection so the
-          # five platform assets report identical release metadata instead of
-          # the dev/unknown/unknown defaults a bare `go build` leaves behind.
+          # one UTC build timestamp derived from the tagged commit's committer
+          # timestamp (not wall-clock time) so the five platform assets report
+          # identical, reproducible release metadata instead of the
+          # dev/unknown/unknown defaults a bare `go build` leaves behind.
           VERSION="${AGENT_NOTIFY_TAG#v}"
-          BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          BUILD_DATE="$(date -u -d "@$(git show -s --format=%ct ${AGENT_NOTIFY_COMMIT})" +%Y-%m-%dT%H:%M:%SZ)"
           go build -trimpath -ldflags "-X main.version=${VERSION} -X main.commit=${AGENT_NOTIFY_COMMIT} -X main.buildDate=${BUILD_DATE} -s -w" -o "$GITHUB_WORKSPACE/release-assets/agent-notify-${{ matrix.platform }}$suffix" ./cmd/agent-notify
       - uses: actions/upload-artifact@v4
         with:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -66,11 +66,13 @@ Fetch `origin/main`, confirm its declared version, create an annotated tag on th
 )
 ```
 
-The publish workflow builds `graphtrail`, `graphtrail-mcp`, `miseledger`, and `sessionfind` for
-`linux-amd64`, `linux-arm64`, `darwin-amd64`, `darwin-arm64`, and `windows-amd64`. It creates one
-Brigade release with exactly 20 native assets, `component-manifest-v1.json`, and `checksums.txt`.
-The release body names `brigade-cli==<version>`. Rust builds run on the exact native runner for
-each platform; Go builds are pure-Go cross builds with `CGO_ENABLED=0`.
+The publish workflow builds the five managed components (`agent-notify`, `graphtrail`,
+`graphtrail-mcp`, `miseledger`, and `sessionfind`) for `linux-amd64`, `linux-arm64`,
+`darwin-amd64`, `darwin-arm64`, and `windows-amd64`. It creates one Brigade release with
+exactly 25 native assets (5 components × 5 platforms) and exactly 27 total GitHub release files,
+counting the 25 native assets plus `component-manifest-v1.json` and `checksums.txt`.
+The release body names `brigade-cli==<version>`. Rust builds run on the exact native runner
+for each platform; Go builds are pure-Go cross builds with `CGO_ENABLED=0`.
 
 The generated manifest and all component URLs must point to
 `escoffier-labs/brigade` at the exact tag. The workflow fails before PyPI publication if inventory,

--- a/scripts/published-artifact-acceptance.py
+++ b/scripts/published-artifact-acceptance.py
@@ -8,6 +8,7 @@ import json
 import os
 import re
 import shlex
+import shutil
 import stat
 import subprocess
 import sys
@@ -358,7 +359,7 @@ def smoke_managed_components(
     validate_agent_notify_version_payload(agent_notify_payload, version)
 
 
-def smoke_rosetta_darwin_amd64(native_paths: Mapping[str, Mapping[str, Path]], *, runner: Runner) -> None:
+def smoke_rosetta_darwin_amd64(native_paths: Mapping[str, Mapping[str, Path]], *, runner: Runner, version: str) -> None:
     if sys.platform != "darwin":
         raise AcceptanceError("--rosetta-darwin-amd64 requires macOS")
     paths = {component: native_paths[component]["darwin-amd64"] for component in COMPONENT_IDS}
@@ -378,11 +379,40 @@ def smoke_rosetta_darwin_amd64(native_paths: Mapping[str, Mapping[str, Path]], *
         raise AcceptanceError("Rosetta graphtrail-mcp smoke returned invalid JSON-RPC")
     run_checked(["arch", "-x86_64", paths["miseledger"], "version"], runner=runner)
     run_checked(["arch", "-x86_64", paths["sessionfind"], "--help"], runner=runner)
+    agent_notify = run_checked(["arch", "-x86_64", paths["agent-notify"], "version", "--json"], runner=runner)
+    try:
+        agent_notify_payload = json.loads(agent_notify.stdout)
+    except json.JSONDecodeError as exc:
+        raise AcceptanceError("Rosetta agent-notify smoke returned malformed JSON") from exc
+    validate_agent_notify_version_payload(agent_notify_payload, version)
 
 
 def assert_no_poison_invocation(marker: Path) -> None:
     if marker.exists() and marker.read_text().strip():
         raise AcceptanceError(f"poison component binary was invoked: {marker.read_text().strip()}")
+
+
+def build_go_free_path(original_path: str, poison_dir: Path, pipx_bin: Path) -> str:
+    """Build a Unix PATH that keeps the poison and pipx entries plus every system
+    directory from ``original_path`` while dropping any directory that ships a
+    ``go`` binary. Managed setup must download release assets instead of building
+    the Go components from source, so the toolchain has to be unreachable.
+    """
+    entries: list[str] = [str(poison_dir), str(pipx_bin)]
+    for entry in original_path.split(os.pathsep):
+        if not entry or entry in entries:
+            continue
+        if (Path(entry) / "go").exists():
+            continue
+        entries.append(entry)
+    return os.pathsep.join(entries)
+
+
+def assert_go_unavailable(*, env: Mapping[str, str]) -> None:
+    """Prove ``go`` cannot resolve from the published-acceptance ``PATH``."""
+    resolved = shutil.which("go", path=env.get("PATH", ""))
+    if resolved is not None:
+        raise AcceptanceError(f"go must be absent from PATH for published acceptance, but it resolves to {resolved}")
 
 
 def _write_poison_binaries(poison_dir: Path, marker: Path) -> None:
@@ -421,7 +451,7 @@ def run_acceptance(version: str, *, runner: Runner = subprocess.run, rosetta_dar
                 "XDG_CACHE_HOME": str(root / "xdg-cache"),
                 "PIPX_HOME": str(pipx_home),
                 "PIPX_BIN_DIR": str(pipx_bin),
-                "PATH": os.pathsep.join((str(poison_dir), env.get("PATH", ""))),
+                "PATH": build_go_free_path(env.get("PATH", ""), poison_dir, pipx_bin),
             }
         )
         managed_brigade = pipx_bin / "brigade"
@@ -435,6 +465,7 @@ def run_acceptance(version: str, *, runner: Runner = subprocess.run, rosetta_dar
             version_output = run_checked([managed_brigade, "--version"], runner=runner, env=env).stdout.strip()
             if version_output != f"brigade {version}":
                 raise AcceptanceError(f"installed brigade version mismatch: expected {version}, got {version_output}")
+            assert_go_unavailable(env=env)
             run_checked([managed_brigade, "setup"], runner=runner, env=env)
             run_checked([managed_brigade, "setup", "--offline"], runner=runner, env=env)
             report_output = run_checked([managed_brigade, "version", "--components", "--json"], runner=runner, env=env)
@@ -444,9 +475,10 @@ def run_acceptance(version: str, *, runner: Runner = subprocess.run, rosetta_dar
                 raise AcceptanceError("brigade version --components --json returned malformed JSON") from exc
             managed_paths = validate_component_report(report, managed_bin_path(data_home, profile))
             verify_managed_component_digests(release["manifest"], managed_paths, host_platform_key())
+            assert_go_unavailable(env=env)
             smoke_managed_components(managed_paths, version=version, runner=runner, env=env)
             if rosetta_darwin_amd64:
-                smoke_rosetta_darwin_amd64(release["native_paths"], runner=runner)
+                smoke_rosetta_darwin_amd64(release["native_paths"], runner=runner, version=version)
         finally:
             assert_no_poison_invocation(marker)
 

--- a/tests/test_publish_workflow.py
+++ b/tests/test_publish_workflow.py
@@ -188,7 +188,13 @@ def test_publish_workflow_builds_five_agent_notify_binaries_with_release_metadat
     assert "${AGENT_NOTIFY_TAG#v}" in section
     assert "${{ github.sha }}" in section
     assert "AGENT_NOTIFY_COMMIT" in section
-    assert "date -u +%Y-%m-%dT%H:%M:%SZ" in section
+    # BUILD_DATE is derived deterministically from the tagged commit's committer
+    # timestamp, not from wall-clock time, so re-runs reproduce the same metadata.
+    assert "git show -s --format=%ct" in section
+    assert 'date -u -d "@$(git show -s --format=%ct ${AGENT_NOTIFY_COMMIT})" +%Y-%m-%dT%H:%M:%SZ' in section
+    # The wall-clock form must be absent so a re-run cannot drift the build date.
+    assert 'BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"' not in section
+    assert "date -u +%Y-%m-%dT%H:%M:%SZ" not in section
     assert "actions/upload-artifact@v4" in section
     assert "if-no-files-found: error" in section
 

--- a/tests/test_published_artifact_acceptance.py
+++ b/tests/test_published_artifact_acceptance.py
@@ -1,6 +1,7 @@
 import importlib.util
 import hashlib
 import json
+import os
 import stat
 import subprocess
 from pathlib import Path
@@ -486,3 +487,148 @@ def test_smoke_managed_components_requires_version_keyword(acceptance_module, tm
     signature = inspect.signature(acceptance_module.smoke_managed_components)
     assert "version" in signature.parameters
     assert signature.parameters["version"].kind == inspect.Parameter.KEYWORD_ONLY
+
+
+def _rosetta_native_paths(acceptance_module, tmp_path):
+    native = {}
+    for component_id in acceptance_module.COMPONENT_IDS:
+        executable = tmp_path / f"{component_id}-darwin-amd64"
+        executable.write_text("#!/bin/sh\nexit 0\n")
+        executable.chmod(0o755)
+        native[component_id] = {"darwin-amd64": executable}
+    return native
+
+
+def _rosetta_runner(tmp_path, agent_notify_stdout):
+    def runner(argv, **kwargs):
+        # argv is ["arch", "-x86_64", <path>, ...args]
+        assert argv[0] == "arch"
+        assert argv[1] == "-x86_64"
+        name = Path(argv[2]).name
+        if name.startswith("graphtrail-mcp"):
+            return subprocess.CompletedProcess(argv, 0, '{"jsonrpc":"2.0","id":1,"result":{}}', "")
+        if name.startswith("sessionfind"):
+            return subprocess.CompletedProcess(argv, 0, "usage: sessionfind", "")
+        if name.startswith("agent-notify"):
+            return subprocess.CompletedProcess(argv, 0, agent_notify_stdout, "")
+        return subprocess.CompletedProcess(argv, 0, "ok", "")
+
+    return runner
+
+
+def test_smoke_rosetta_darwin_amd64_requires_version_keyword(acceptance_module):
+    import inspect
+
+    signature = inspect.signature(acceptance_module.smoke_rosetta_darwin_amd64)
+    assert "version" in signature.parameters
+    assert signature.parameters["version"].kind == inspect.Parameter.KEYWORD_ONLY
+
+
+def test_smoke_rosetta_darwin_amd64_smokes_agent_notify_via_arch_x86_64(acceptance_module, tmp_path, monkeypatch):
+    monkeypatch.setattr(acceptance_module.sys, "platform", "darwin")
+    native = _rosetta_native_paths(acceptance_module, tmp_path)
+    payload = '{"version":"1.2.3","commit":"abc123def456","build_date":"2026-07-22T13:29:00Z"}'
+    runner = _rosetta_runner(tmp_path, payload)
+
+    acceptance_module.smoke_rosetta_darwin_amd64(native, runner=runner, version="1.2.3")
+
+
+def test_smoke_rosetta_darwin_amd64_rejects_malformed_agent_notify_json(acceptance_module, tmp_path, monkeypatch):
+    monkeypatch.setattr(acceptance_module.sys, "platform", "darwin")
+    native = _rosetta_native_paths(acceptance_module, tmp_path)
+    runner = _rosetta_runner(tmp_path, "not-json")
+
+    with pytest.raises(acceptance_module.AcceptanceError, match="malformed JSON"):
+        acceptance_module.smoke_rosetta_darwin_amd64(native, runner=runner, version="1.2.3")
+
+
+def test_smoke_rosetta_darwin_amd64_rejects_agent_notify_version_mismatch(acceptance_module, tmp_path, monkeypatch):
+    monkeypatch.setattr(acceptance_module.sys, "platform", "darwin")
+    native = _rosetta_native_paths(acceptance_module, tmp_path)
+    payload = '{"version":"1.2.4","commit":"abc123def456","build_date":"2026-07-22T13:29:00Z"}'
+    runner = _rosetta_runner(tmp_path, payload)
+
+    with pytest.raises(acceptance_module.AcceptanceError, match="version mismatch"):
+        acceptance_module.smoke_rosetta_darwin_amd64(native, runner=runner, version="1.2.3")
+
+
+def test_assert_go_unavailable_passes_when_go_is_not_on_path(acceptance_module, tmp_path):
+    acceptance_module.assert_go_unavailable(env={"PATH": str(tmp_path)})
+
+
+def test_assert_go_unavailable_fails_when_go_resolves_from_path(acceptance_module, tmp_path):
+    go = tmp_path / "go"
+    go.write_text("#!/bin/sh\nexit 1\n")
+    go.chmod(go.stat().st_mode | stat.S_IXUSR)
+
+    with pytest.raises(acceptance_module.AcceptanceError, match="go must be absent from PATH"):
+        acceptance_module.assert_go_unavailable(env={"PATH": str(tmp_path)})
+
+
+def test_build_go_free_path_drops_directories_containing_go_but_keeps_system_dirs(acceptance_module, tmp_path):
+    go_dir = tmp_path / "go-bin"
+    go_dir.mkdir()
+    (go_dir / "go").write_text("#!/bin/sh\nexit 0\n")
+    (go_dir / "gofmt").write_text("#!/bin/sh\nexit 0\n")
+    safe_dir = tmp_path / "safe-bin"
+    safe_dir.mkdir()
+    (safe_dir / "ls").write_text("#!/bin/sh\nexit 0\n")
+    poison_dir = tmp_path / "poison-bin"
+    poison_dir.mkdir()
+    pipx_bin = tmp_path / "pipx-bin"
+    pipx_bin.mkdir()
+    original = os.pathsep.join((str(go_dir), str(safe_dir), str(tmp_path / "missing")))
+
+    path = acceptance_module.build_go_free_path(original, poison_dir, pipx_bin)
+
+    entries = path.split(os.pathsep)
+    # poison and pipx entries come first so a stray component name resolves to the poison binary.
+    assert entries[0] == str(poison_dir)
+    assert entries[1] == str(pipx_bin)
+    assert str(go_dir) not in entries
+    assert str(safe_dir) in entries
+    # A missing directory is harmless and is preserved so required system executables stay reachable.
+    assert str(tmp_path / "missing") in entries
+
+
+def test_build_go_free_path_drops_go_symlink_directory(acceptance_module, tmp_path):
+    go_dir = tmp_path / "go-bin"
+    go_dir.mkdir()
+    (go_dir / "go").symlink_to("/usr/bin/true")
+    poison_dir = tmp_path / "poison-bin"
+    poison_dir.mkdir()
+    pipx_bin = tmp_path / "pipx-bin"
+    pipx_bin.mkdir()
+    original = os.pathsep.join((str(go_dir), "/usr/bin"))
+
+    path = acceptance_module.build_go_free_path(original, poison_dir, pipx_bin)
+
+    assert str(go_dir) not in path.split(os.pathsep)
+
+
+def test_run_acceptance_proves_go_unavailable_immediately_before_setup_and_smoke(acceptance_module):
+    """run_acceptance must prove `go` is unavailable immediately before the managed
+    brigade setup call and immediately before smoke_managed_components, using a PATH
+    that excludes Go."""
+    source = SCRIPT.read_text()
+    run_acceptance_body = source[source.index("def run_acceptance(") :]
+    setup_call = run_acceptance_body.index('run_checked([managed_brigade, "setup"], runner=runner, env=env)')
+    smoke_call = run_acceptance_body.index(
+        "smoke_managed_components(managed_paths, version=version, runner=runner, env=env)"
+    )
+
+    before_setup = run_acceptance_body.index("assert_go_unavailable(env=env)")
+    before_smoke = run_acceptance_body.rindex("assert_go_unavailable(env=env)")
+
+    assert before_setup < setup_call
+    # No other run_checked/brigade call sits between the go proof and the setup call.
+    between = run_acceptance_body[before_setup:setup_call]
+    assert "run_checked(" not in between
+    assert "smoke_managed_components" not in between
+
+    assert before_smoke < smoke_call
+    # No smoke invocation sits between the go proof and the smoke call.
+    between_smoke = run_acceptance_body[before_smoke + len("assert_go_unavailable(env=env)") : smoke_call]
+    assert "smoke_managed_components" not in between_smoke
+    # The PATH used in run_acceptance is built through build_go_free_path so Go is excluded.
+    assert "build_go_free_path(" in run_acceptance_body

--- a/tests/test_release_checklist.py
+++ b/tests/test_release_checklist.py
@@ -34,3 +34,16 @@ def test_release_checklist_verifies_pypi_version():
 
     assert tag_push < workflow_wait < pypi_check
     assert "published != expected" in text
+
+
+def test_release_checklist_documents_five_components_25_native_assets_27_release_files():
+    text = (ROOT / "RELEASE.md").read_text()
+
+    for component in ("agent-notify", "graphtrail", "graphtrail-mcp", "miseledger", "sessionfind"):
+        assert component in text
+    assert "25 native assets" in text
+    assert "27 total GitHub release files" in text
+    assert "component-manifest-v1.json" in text
+    assert "checksums.txt" in text
+    # The stale 20-asset count must be gone.
+    assert "20 native assets" not in text


### PR DESCRIPTION
## Summary

This closes the four scoped release-tooling gaps from #431:

- Unix published acceptance removes Go-bearing directories from `PATH` and proves `go` cannot resolve immediately before managed setup and managed-binary smoke.
- Darwin amd64 acceptance executes `agent-notify` under Rosetta and validates its release version, commit, and build date.
- The publish workflow derives `BUILD_DATE` from the tagged commit timestamp.
- The release guide and regression tests require 25 native assets and 27 total GitHub release files.

This PR does not bump the package to `0.26.0`, create a tag, publish artifacts, or archive repositories.

## Files

- `.github/workflows/publish.yml`
- `RELEASE.md`
- `scripts/published-artifact-acceptance.py`
- `tests/test_publish_workflow.py`
- `tests/test_published_artifact_acceptance.py`
- `tests/test_release_checklist.py`
- `.claude/memory-handoffs/20260729-155845-release-tooling-preflight.md`

## Checks and evidence

- Focused release-tooling tests: 51 passed in 1.37s. Receipt `20260729-195000-work-verify-7142ca`, MiseLedger `a212db5fe9e81628e68d5cba`.
- Full `./scripts/verify`: 4905 passed, 3 skipped in 460.33s with 82.98% coverage. Receipt `20260729-195037-work-verify-1cbdad`, MiseLedger `c82bf16abad62d77f9d0daeb`.
- Brigade implementation run: `20260729-193355-10e68a42`, MiseLedger `fc60fc6d604b4d00f349bae5`.
- Memory Handoff lint: receipt `20260729-195910-work-verify-3fff5a`, MiseLedger `5ce69aeeb313e52a92a6c2de`.
- Commit-range content guard: receipt `20260729-200428-work-verify-a93882`.

## Remaining release sequence

1. Merge this focused PR after its required checks pass.
2. Prepare a separate `0.26.0` release commit that updates every stamped version and turns the current unreleased notes into the release entry.
3. Merge that release commit, tag the exact merged `origin/main` commit, and run the publish workflow.
4. Verify the 27 release files, attestations, PyPI package, and published Unix and Windows acceptance jobs.
5. Archive any superseded standalone repositories only after the stable release and acceptance evidence are complete.