### PR TITLE
Document OpenCode Go model benchmark

### DIFF
--- a/.claude/memory-handoffs/2026-07-29-1549-opencode-go-routing-update.md
+++ b/.claude/memory-handoffs/2026-07-29-1549-opencode-go-routing-update.md
@@ -1,0 +1,82 @@
+# Memory Handoff
+
+## Type
+
+research
+
+## Title
+
+OpenCode Go routing after the five-model security matrix
+
+## Summary
+
+The screen covered 23 task/model cells across 9 OpenCode Go models and
+confirmed GLM-5.2 plus MiniMax M3 in a normal Brigade run. Promote MiniMax M3
+after 20 shadow runs, use GLM-5.2 for security review, and reserve Kimi K3 for
+higher-cost cross-file canaries.
+
+## Durable facts
+
+- GLM-5.2 `high` found 5/5 findings, obeyed 3/3 contracts, and averaged
+  13.586 seconds. Kimi K3 `max` matched 5/5 and 3/3 at 15.200 seconds with a
+  higher catalog price.
+- Kimi K2.7 Code, DeepSeek V4 Pro, and Qwen3.7 Max found all expected issues
+  but obeyed 1/3, 0/3, and 0/3 strict output contracts.
+- MiniMax M3 is the cheap primary candidate: 3/3 findings, 2/2 contracts, and
+  a 6.419-second mean. It has no security cell.
+- A normal Brigade run with GLM-5.2 orchestrating MiniMax M3 completed in
+  14.620 seconds, returned `WIRING_OK`, and changed 0 files.
+- Brigade 0.25.1 cannot enforce OpenCode read-only mode. Use disposable
+  worktrees and reject changed-file receipts. `max_workers` applies per run, so
+  a host-wide process limit needs an external dispatcher.
+
+## Evidence
+
+- files changed:
+  `benchmarks/model-ratings-2026-07/`
+- three-task receipt: `20260729-194155-work-verify-f0f8e3`, MiseLedger
+  `dc8c9568260c63269750f666`
+- multi-seat receipt: `20260729-201417-work-verify-f959da`, MiseLedger
+  `fbb5c10d67e793cfb8050057`
+- Brigade and OpenCode exposed no per-call token or cost values.
+
+## Recommended memory action
+
+update-card
+
+## Target card
+
+opencode-go-brigade-routing.md
+
+## Suggested card content
+
+```markdown
+---
+topic: OpenCode Go Brigade routing
+category: tools
+tags: [brigade, opencode, models, routing]
+---
+
+# OpenCode Go Brigade routing
+
+### Recommended seats
+
+After 20 shadow runs, use MiniMax M3 `thinking` for short read-only analysis.
+Use GLM-5.2 `high` for security or final structured review. Use Kimi K3 `max`
+only as a cross-file canary before Claude or GPT-5.6 handles final high-risk
+review.
+
+### Safety and fallback
+
+Brigade 0.25.1 cannot enforce OpenCode read-only mode. Use disposable
+worktrees and require zero changed files. `max_workers` applies per run, so a
+host-wide limit needs an external dispatcher. Retry one transient provider or
+short rate-limit failure, but not auth, entitlement, timeout, or invalid output.
+
+### Evidence
+
+The 2026-07-29 screen covered 23 cells across 9 models. Three-task evidence:
+`dc8c9568260c63269750f666`. Earlier two-task evidence:
+`ec4e976c7c7689a39f91ae97`. Multi-seat evidence:
+`fbb5c10d67e793cfb8050057`.
+```

--- a/benchmarks/model-ratings-2026-07/README.md
+++ b/benchmarks/model-ratings-2026-07/README.md
@@ -1,0 +1,142 @@
+# OpenCode Go model fitness, 2026-07-29
+
+## Decision
+
+Promote MiniMax M3 to the primary cheap coding seat after a 20-run shadow
+period. Use GLM-5.2 for the security-capable reviewer and Kimi K3 as the
+expensive cross-file canary. Keep all OpenCode seats read-only and isolated
+until Brigade can enforce an OpenCode sandbox.
+
+## Catalog boundary
+
+`opencode models opencode-go --verbose --pure` returned these 16 models from
+the OpenCode Go subscription provider:
+
+`deepseek-v4-flash`, `deepseek-v4-pro`, `glm-5.1`, `glm-5.2`, `grok-4.5`,
+`hy3`, `kimi-k2.6`, `kimi-k2.7-code`, `kimi-k3`, `mimo-v2.5`,
+`mimo-v2.5-pro`, `minimax-m2.7`, `minimax-m3`, `qwen3.6-plus`,
+`qwen3.7-max`, and `qwen3.7-plus`.
+
+The CLI exposed a separate `opencode` provider with 7 limited-time free Zen
+models. It also identified separate API-key environment providers, whose
+catalogs were not queried or used. No account, token, or credential value was
+recorded.
+
+## Evidence split
+
+The new matrix ran 5 previously untested Go models through 3 fixed tasks.
+The earlier screen covered 4 models with only the routine and contract-drift
+tasks. The tables stay separate because the earlier models have no security
+cell.
+
+### New three-task matrix
+
+| Rank | Model | Variant | Findings | Output contracts | Mean latency | Refused |
+|---:|---|---|---:|---:|---:|---:|
+| 1 | `opencode-go/glm-5.2` | high | 5/5 | 3/3 | 13.586s | 0 |
+| 2 | `opencode-go/kimi-k3` | max | 5/5 | 3/3 | 15.200s | 0 |
+| 3 | `opencode-go/kimi-k2.7-code` | default | 5/5 | 1/3 | 7.060s | 0 |
+| 4 | `opencode-go/deepseek-v4-pro` | high | 5/5 | 0/3 | 9.700s | 0 |
+| 5 | `opencode-go/qwen3.7-max` | high | 5/5 | 0/3 | 9.226s | 0 |
+
+GLM-5.2 and Kimi K3 were the only new candidates that obeyed every strict
+output contract. All 5 models found all planted issues. DeepSeek Pro and Qwen
+Max fenced every JSON response. Kimi K2.7 Code returned one valid structured
+response out of 3.
+
+### Earlier two-task screen
+
+| Rank | Model | Variant | Findings | Output contracts | Mean latency |
+|---:|---|---|---:|---:|---:|
+| 1 | `opencode-go/minimax-m3` | thinking | 3/3 | 2/2 | 6.419s |
+| 2 | `opencode-go/qwen3.7-plus` | high | 3/3 | 2/2 | 14.091s |
+| 3 | `opencode-go/deepseek-v4-flash` | high | 3/3 | 1/2 | 5.516s |
+| 4 | `opencode-go/mimo-v2.5` | default | 3/3 | 1/2 | 16.711s |
+
+MiniMax M3 is the cheap primary candidate because it passed both available
+output contracts, averaged 6.419 seconds, and its catalog price was $0.30 input
+and $1.20 output per million tokens. Promote it after a 20-run shadow period.
+It still needs a security cell before an unsupervised security role.
+
+## Role policy
+
+- `go_minimax_m3_primary`: post-shadow target for short read-only coding
+  analysis and structured first-pass review. Timeout 120 seconds. Fall back to
+  GLM-5.2.
+- `go_glm_52_security`: security review and final structured review for cheap
+  lanes. Timeout 180 seconds. Its security response found both planted issues
+  without refusing.
+- `go_kimi_k3_canary`: difficult cross-file canary when the higher Go usage
+  cost is justified. Timeout 240 seconds. Claude or GPT-5.6 should still own
+  final high-risk review.
+- The proposal allows 2 worker processes per Brigade run. This worktree ran 1
+  at a time because `.brigade/run.lock` serializes runs per worktree. A
+  host-wide limit of 2 remains an external dispatcher policy and is not
+  enforced by this roster.
+- Retry one transient provider or rate-limit failure when the requested delay
+  is at most 30 seconds. Do not retry auth, entitlement, timeout, or invalid
+  final output on the same seat.
+- Run with `--read-only --worktree` and require `changed_files = []`. Brigade
+  0.25.1 records `sandbox = "read-only"` but warns that it is not applied to
+  OpenCode.
+
+### Router preference
+
+- Prefer MiniMax M3 over Kimi K2.7 for short, low-risk analysis after a
+  20-run shadow period confirms its two-task result. Keep Kimi K2.7 as the
+  fallback during that period.
+- Prefer GLM-5.2 over `glm_cursor` when Cursor capacity is constrained or the
+  output must be strict JSON. Prefer `glm_cursor` for edits because OpenCode
+  lacks enforced write isolation.
+- Prefer Kimi K3 over GPT-5.6 Terra only for a read-only cross-file canary where
+  a later frontier reviewer can catch a miss.
+- Keep Claude or GPT-5.6 as the final reviewer for high-risk contract drift,
+  security decisions, or repository changes.
+
+### Deferred candidates
+
+- Qwen3.7 Plus needs a security cell before promotion.
+- Kimi K2.7 Code is fast, but passed only 1/3 output contracts.
+- DeepSeek V4 Flash passed only 1/2 earlier output contracts.
+- DeepSeek V4 Pro and Qwen3.7 Max passed 0/3 output contracts.
+- MiMo V2.5 passed 1/2 contracts and had a 25.986-second review.
+
+The exact post-shadow proposal is in
+[`proposed-opencode-go-roster.toml`](proposed-opencode-go-roster.toml).
+
+## Multi-seat wiring
+
+One normal Brigade run used GLM-5.2 as orchestrator and MiniMax M3 as worker.
+GLM produced a valid one-assignment plan, MiniMax found the defect, and GLM's
+final synthesis returned `WIRING_OK`. The run completed in 14.620 seconds with
+0 changed files. Both requested models resolved through OpenCode CLI with no
+fallback. The raw ignored artifacts were checked against the shipped dataset
+by receipt `20260729-201417-work-verify-f959da`, MiseLedger
+`fbb5c10d67e793cfb8050057`.
+
+## Receipts and limits
+
+- Earlier validator: `20260729-183625-work-verify-69cacc`, MiseLedger
+  `ec4e976c7c7689a39f91ae97`.
+- New fresh validator: `20260729-194155-work-verify-f0f8e3`, MiseLedger
+  `dc8c9568260c63269750f666`.
+- Schema, semantic, roster, and raw multi-seat artifact validator:
+  `20260729-201417-work-verify-f959da`, MiseLedger
+  `fbb5c10d67e793cfb8050057`.
+- Per-call token and usage values were not exposed by Brigade worker receipts
+  or OpenCode logs, so the dataset records them as `null`.
+- All 15 new probe runs and the multi-seat trial recorded 0 auth, entitlement,
+  rate-limit, or provider failures.
+- One run per cell is a screen. The prompts named their expected findings, so
+  this does not measure blind vulnerability discovery or adversarial review.
+- Pre-change GraphTrail symbol tracing was skipped because this directory holds
+  benchmark JSON, TOML, and Markdown only. Brigade verification's automatic
+  graph delta found 0 changed symbols, imports, control-flow nodes, or APIs.
+
+Machine-readable results live in
+[`opencode-go-results.json`](opencode-go-results.json), with the local schema in
+[`opencode-go-schema.json`](opencode-go-schema.json). Run
+`python3 benchmarks/model-ratings-2026-07/validate.py` to check cross-field
+arithmetic and, when `jsonschema` is installed, the Draft 2020-12 schema. Add
+`--artifacts <multi-seat-run-dir>` to compare a local raw multi-seat run with
+the recorded trial.

--- a/benchmarks/model-ratings-2026-07/opencode-go-results.json
+++ b/benchmarks/model-ratings-2026-07/opencode-go-results.json
@@ -1,0 +1,804 @@
+{
+  "$schema": "./opencode-go-schema.json",
+  "schema": "brigade.model_fitness.v1",
+  "benchmark_id": "opencode-go-20260729",
+  "generated_at": "2026-07-29T19:43:00Z",
+  "catalog_discovery": {
+    "command": "opencode models opencode-go --verbose --pure",
+    "subscription_provider": "opencode-go",
+    "subscription_model_ids": [
+      "opencode-go/deepseek-v4-flash",
+      "opencode-go/deepseek-v4-pro",
+      "opencode-go/glm-5.1",
+      "opencode-go/glm-5.2",
+      "opencode-go/grok-4.5",
+      "opencode-go/hy3",
+      "opencode-go/kimi-k2.6",
+      "opencode-go/kimi-k2.7-code",
+      "opencode-go/kimi-k3",
+      "opencode-go/mimo-v2.5",
+      "opencode-go/mimo-v2.5-pro",
+      "opencode-go/minimax-m2.7",
+      "opencode-go/minimax-m3",
+      "opencode-go/qwen3.6-plus",
+      "opencode-go/qwen3.7-max",
+      "opencode-go/qwen3.7-plus"
+    ],
+    "separate_free_provider": {
+      "provider": "opencode",
+      "description": "seven limited-time free Zen models, not OpenCode Go subscription models"
+    },
+    "api_key_provider_scope": "CLI authentication discovery identified separate API-key environment providers; their catalogs were not queried or used"
+  },
+  "provider_behavior": {
+    "new_probe_runs": 15,
+    "auth_failures": 0,
+    "entitlement_failures": 0,
+    "rate_limit_failures": 0,
+    "provider_failures": 0,
+    "multi_seat_trial_failures": 0
+  },
+  "methodology": {
+    "execution_path": "brigade 0.25.1 -> opencode run",
+    "opencode_version": "1.18.4",
+    "read_only": "prompt-level plus Brigade ground-truth diff; OpenCode has no enforced Brigade read-only sandbox",
+    "max_live_processes_observed": 1,
+    "roster_max_workers_per_run": 2,
+    "host_process_limit_policy": "external dispatcher must cap OpenCode at two host-wide processes; this roster does not enforce that limit",
+    "ranking_order": [
+      "matrix completeness",
+      "expected-finding recall",
+      "strict output-contract validity",
+      "catalog cost",
+      "latency"
+    ],
+    "graphtrail": "pre-change symbol tracing skipped for benchmark data and prose; Brigade verification graph delta found zero changed symbols"
+  },
+  "tasks": [
+    {
+      "id": "routine",
+      "expected_findings": 1,
+      "output_contract": "one unfenced compact JSON object with valid=true, numeric line 5, exact minimal fix, and a real counterexample"
+    },
+    {
+      "id": "contract_drift",
+      "expected_findings": 2,
+      "output_contract": "one unfenced compact JSON object with ordered C1/C2 findings and exact timeout and return-type fixes"
+    },
+    {
+      "id": "security_review",
+      "expected_findings": 2,
+      "output_contract": "one unfenced compact JSON object with refused=false and ordered S1/S2 path-traversal and command-injection findings"
+    }
+  ],
+  "models": [
+    {
+      "model_id": "opencode-go/kimi-k3",
+      "variant": "max",
+      "evidence_tier": "new-three-task-matrix",
+      "catalog_cost_usd_per_million": {
+        "input": 3.0,
+        "output": 15.0,
+        "cache_read": 0.3
+      },
+      "summary": {
+        "cells": 3,
+        "expected_findings_found": 5,
+        "expected_findings_total": 5,
+        "output_contract_passes": 3,
+        "refusals": 0,
+        "mean_latency_seconds": 15.2
+      },
+      "cells": [
+        {
+          "task": "routine",
+          "requested_model": "opencode-go/kimi-k3",
+          "resolved_model": "opencode-go/kimi-k3",
+          "resolved_model_marker": "build · kimi-k3",
+          "executor_command_shape": "opencode run -m opencode-go/kimi-k3 --variant max <PROMPT>",
+          "transport": "cli",
+          "fallback_used": false,
+          "exit_code": 0,
+          "timed_out": false,
+          "latency_seconds": 12.62,
+          "output_contract_valid": true,
+          "expected_findings_found": 1,
+          "expected_findings_total": 1,
+          "refused": false,
+          "changed_file_count": 0,
+          "failure_class": null,
+          "failure_cause": null,
+          "usage": {"exposed": false, "input_tokens": null, "output_tokens": null, "cached_tokens": null, "cost_usd": null}
+        },
+        {
+          "task": "contract_drift",
+          "requested_model": "opencode-go/kimi-k3",
+          "resolved_model": "opencode-go/kimi-k3",
+          "resolved_model_marker": "build · kimi-k3",
+          "executor_command_shape": "opencode run -m opencode-go/kimi-k3 --variant max <PROMPT>",
+          "transport": "cli",
+          "fallback_used": false,
+          "exit_code": 0,
+          "timed_out": false,
+          "latency_seconds": 11.547,
+          "output_contract_valid": true,
+          "expected_findings_found": 2,
+          "expected_findings_total": 2,
+          "refused": false,
+          "changed_file_count": 0,
+          "failure_class": null,
+          "failure_cause": null,
+          "usage": {"exposed": false, "input_tokens": null, "output_tokens": null, "cached_tokens": null, "cost_usd": null}
+        },
+        {
+          "task": "security_review",
+          "requested_model": "opencode-go/kimi-k3",
+          "resolved_model": "opencode-go/kimi-k3",
+          "resolved_model_marker": "build · kimi-k3",
+          "executor_command_shape": "opencode run -m opencode-go/kimi-k3 --variant max <PROMPT>",
+          "transport": "cli",
+          "fallback_used": false,
+          "exit_code": 0,
+          "timed_out": false,
+          "latency_seconds": 21.434,
+          "output_contract_valid": true,
+          "expected_findings_found": 2,
+          "expected_findings_total": 2,
+          "refused": false,
+          "changed_file_count": 0,
+          "failure_class": null,
+          "failure_cause": null,
+          "usage": {"exposed": false, "input_tokens": null, "output_tokens": null, "cached_tokens": null, "cost_usd": null}
+        }
+      ]
+    },
+    {
+      "model_id": "opencode-go/glm-5.2",
+      "variant": "high",
+      "evidence_tier": "new-three-task-matrix",
+      "catalog_cost_usd_per_million": {
+        "input": 1.4,
+        "output": 4.4,
+        "cache_read": 0.26
+      },
+      "summary": {
+        "cells": 3,
+        "expected_findings_found": 5,
+        "expected_findings_total": 5,
+        "output_contract_passes": 3,
+        "refusals": 0,
+        "mean_latency_seconds": 13.586
+      },
+      "cells": [
+        {
+          "task": "routine",
+          "requested_model": "opencode-go/glm-5.2",
+          "resolved_model": "opencode-go/glm-5.2",
+          "resolved_model_marker": "build · glm-5.2",
+          "executor_command_shape": "opencode run -m opencode-go/glm-5.2 --variant high <PROMPT>",
+          "transport": "cli",
+          "fallback_used": false,
+          "exit_code": 0,
+          "timed_out": false,
+          "latency_seconds": 10.585,
+          "output_contract_valid": true,
+          "expected_findings_found": 1,
+          "expected_findings_total": 1,
+          "refused": false,
+          "changed_file_count": 0,
+          "failure_class": null,
+          "failure_cause": null,
+          "usage": {"exposed": false, "input_tokens": null, "output_tokens": null, "cached_tokens": null, "cost_usd": null}
+        },
+        {
+          "task": "contract_drift",
+          "requested_model": "opencode-go/glm-5.2",
+          "resolved_model": "opencode-go/glm-5.2",
+          "resolved_model_marker": "build · glm-5.2",
+          "executor_command_shape": "opencode run -m opencode-go/glm-5.2 --variant high <PROMPT>",
+          "transport": "cli",
+          "fallback_used": false,
+          "exit_code": 0,
+          "timed_out": false,
+          "latency_seconds": 4.192,
+          "output_contract_valid": true,
+          "expected_findings_found": 2,
+          "expected_findings_total": 2,
+          "refused": false,
+          "changed_file_count": 0,
+          "failure_class": null,
+          "failure_cause": null,
+          "usage": {"exposed": false, "input_tokens": null, "output_tokens": null, "cached_tokens": null, "cost_usd": null}
+        },
+        {
+          "task": "security_review",
+          "requested_model": "opencode-go/glm-5.2",
+          "resolved_model": "opencode-go/glm-5.2",
+          "resolved_model_marker": "build · glm-5.2",
+          "executor_command_shape": "opencode run -m opencode-go/glm-5.2 --variant high <PROMPT>",
+          "transport": "cli",
+          "fallback_used": false,
+          "exit_code": 0,
+          "timed_out": false,
+          "latency_seconds": 25.981,
+          "output_contract_valid": true,
+          "expected_findings_found": 2,
+          "expected_findings_total": 2,
+          "refused": false,
+          "changed_file_count": 0,
+          "failure_class": null,
+          "failure_cause": null,
+          "usage": {"exposed": false, "input_tokens": null, "output_tokens": null, "cached_tokens": null, "cost_usd": null}
+        }
+      ]
+    },
+    {
+      "model_id": "opencode-go/deepseek-v4-pro",
+      "variant": "high",
+      "evidence_tier": "new-three-task-matrix",
+      "catalog_cost_usd_per_million": {
+        "input": 0.435,
+        "output": 0.87,
+        "cache_read": 0.003625
+      },
+      "summary": {
+        "cells": 3,
+        "expected_findings_found": 5,
+        "expected_findings_total": 5,
+        "output_contract_passes": 0,
+        "refusals": 0,
+        "mean_latency_seconds": 9.7
+      },
+      "cells": [
+        {
+          "task": "routine",
+          "requested_model": "opencode-go/deepseek-v4-pro",
+          "resolved_model": "opencode-go/deepseek-v4-pro",
+          "resolved_model_marker": "build · deepseek-v4-pro",
+          "executor_command_shape": "opencode run -m opencode-go/deepseek-v4-pro --variant high <PROMPT>",
+          "transport": "cli",
+          "fallback_used": false,
+          "exit_code": 0,
+          "timed_out": false,
+          "latency_seconds": 8.044,
+          "output_contract_valid": false,
+          "expected_findings_found": 1,
+          "expected_findings_total": 1,
+          "refused": false,
+          "changed_file_count": 0,
+          "failure_class": "output-contract",
+          "failure_cause": "Markdown fence, valid=false, and non-numeric line field",
+          "usage": {"exposed": false, "input_tokens": null, "output_tokens": null, "cached_tokens": null, "cost_usd": null}
+        },
+        {
+          "task": "contract_drift",
+          "requested_model": "opencode-go/deepseek-v4-pro",
+          "resolved_model": "opencode-go/deepseek-v4-pro",
+          "resolved_model_marker": "build · deepseek-v4-pro",
+          "executor_command_shape": "opencode run -m opencode-go/deepseek-v4-pro --variant high <PROMPT>",
+          "transport": "cli",
+          "fallback_used": false,
+          "exit_code": 0,
+          "timed_out": false,
+          "latency_seconds": 11.507,
+          "output_contract_valid": false,
+          "expected_findings_found": 2,
+          "expected_findings_total": 2,
+          "refused": false,
+          "changed_file_count": 0,
+          "failure_class": "output-contract",
+          "failure_cause": "Markdown-fenced JSON",
+          "usage": {"exposed": false, "input_tokens": null, "output_tokens": null, "cached_tokens": null, "cost_usd": null}
+        },
+        {
+          "task": "security_review",
+          "requested_model": "opencode-go/deepseek-v4-pro",
+          "resolved_model": "opencode-go/deepseek-v4-pro",
+          "resolved_model_marker": "build · deepseek-v4-pro",
+          "executor_command_shape": "opencode run -m opencode-go/deepseek-v4-pro --variant high <PROMPT>",
+          "transport": "cli",
+          "fallback_used": false,
+          "exit_code": 0,
+          "timed_out": false,
+          "latency_seconds": 9.55,
+          "output_contract_valid": false,
+          "expected_findings_found": 2,
+          "expected_findings_total": 2,
+          "refused": false,
+          "changed_file_count": 0,
+          "failure_class": "output-contract",
+          "failure_cause": "Markdown-fenced JSON",
+          "usage": {"exposed": false, "input_tokens": null, "output_tokens": null, "cached_tokens": null, "cost_usd": null}
+        }
+      ]
+    },
+    {
+      "model_id": "opencode-go/qwen3.7-max",
+      "variant": "high",
+      "evidence_tier": "new-three-task-matrix",
+      "catalog_cost_usd_per_million": {
+        "input": 2.5,
+        "output": 7.5,
+        "cache_read": 0.5
+      },
+      "summary": {
+        "cells": 3,
+        "expected_findings_found": 5,
+        "expected_findings_total": 5,
+        "output_contract_passes": 0,
+        "refusals": 0,
+        "mean_latency_seconds": 9.226
+      },
+      "cells": [
+        {
+          "task": "routine",
+          "requested_model": "opencode-go/qwen3.7-max",
+          "resolved_model": "opencode-go/qwen3.7-max",
+          "resolved_model_marker": "build · qwen3.7-max",
+          "executor_command_shape": "opencode run -m opencode-go/qwen3.7-max --variant high <PROMPT>",
+          "transport": "cli",
+          "fallback_used": false,
+          "exit_code": 0,
+          "timed_out": false,
+          "latency_seconds": 13.037,
+          "output_contract_valid": false,
+          "expected_findings_found": 1,
+          "expected_findings_total": 1,
+          "refused": false,
+          "changed_file_count": 0,
+          "failure_class": "output-contract",
+          "failure_cause": "Markdown-fenced JSON",
+          "usage": {"exposed": false, "input_tokens": null, "output_tokens": null, "cached_tokens": null, "cost_usd": null}
+        },
+        {
+          "task": "contract_drift",
+          "requested_model": "opencode-go/qwen3.7-max",
+          "resolved_model": "opencode-go/qwen3.7-max",
+          "resolved_model_marker": "build · qwen3.7-max",
+          "executor_command_shape": "opencode run -m opencode-go/qwen3.7-max --variant high <PROMPT>",
+          "transport": "cli",
+          "fallback_used": false,
+          "exit_code": 0,
+          "timed_out": false,
+          "latency_seconds": 6.432,
+          "output_contract_valid": false,
+          "expected_findings_found": 2,
+          "expected_findings_total": 2,
+          "refused": false,
+          "changed_file_count": 0,
+          "failure_class": "output-contract",
+          "failure_cause": "Markdown-fenced JSON",
+          "usage": {"exposed": false, "input_tokens": null, "output_tokens": null, "cached_tokens": null, "cost_usd": null}
+        },
+        {
+          "task": "security_review",
+          "requested_model": "opencode-go/qwen3.7-max",
+          "resolved_model": "opencode-go/qwen3.7-max",
+          "resolved_model_marker": "build · qwen3.7-max",
+          "executor_command_shape": "opencode run -m opencode-go/qwen3.7-max --variant high <PROMPT>",
+          "transport": "cli",
+          "fallback_used": false,
+          "exit_code": 0,
+          "timed_out": false,
+          "latency_seconds": 8.208,
+          "output_contract_valid": false,
+          "expected_findings_found": 2,
+          "expected_findings_total": 2,
+          "refused": false,
+          "changed_file_count": 0,
+          "failure_class": "output-contract",
+          "failure_cause": "Markdown-fenced JSON",
+          "usage": {"exposed": false, "input_tokens": null, "output_tokens": null, "cached_tokens": null, "cost_usd": null}
+        }
+      ]
+    },
+    {
+      "model_id": "opencode-go/kimi-k2.7-code",
+      "variant": null,
+      "evidence_tier": "new-three-task-matrix",
+      "catalog_cost_usd_per_million": {
+        "input": 0.95,
+        "output": 4.0,
+        "cache_read": 0.19
+      },
+      "summary": {
+        "cells": 3,
+        "expected_findings_found": 5,
+        "expected_findings_total": 5,
+        "output_contract_passes": 1,
+        "refusals": 0,
+        "mean_latency_seconds": 7.06
+      },
+      "cells": [
+        {
+          "task": "routine",
+          "requested_model": "opencode-go/kimi-k2.7-code",
+          "resolved_model": "opencode-go/kimi-k2.7-code",
+          "resolved_model_marker": "build · kimi-k2.7-code",
+          "executor_command_shape": "opencode run -m opencode-go/kimi-k2.7-code <PROMPT>",
+          "transport": "cli",
+          "fallback_used": false,
+          "exit_code": 0,
+          "timed_out": false,
+          "latency_seconds": 8.681,
+          "output_contract_valid": false,
+          "expected_findings_found": 1,
+          "expected_findings_total": 1,
+          "refused": false,
+          "changed_file_count": 0,
+          "failure_class": "output-contract",
+          "failure_cause": "valid=false",
+          "usage": {"exposed": false, "input_tokens": null, "output_tokens": null, "cached_tokens": null, "cost_usd": null}
+        },
+        {
+          "task": "contract_drift",
+          "requested_model": "opencode-go/kimi-k2.7-code",
+          "resolved_model": "opencode-go/kimi-k2.7-code",
+          "resolved_model_marker": "build · kimi-k2.7-code",
+          "executor_command_shape": "opencode run -m opencode-go/kimi-k2.7-code <PROMPT>",
+          "transport": "cli",
+          "fallback_used": false,
+          "exit_code": 0,
+          "timed_out": false,
+          "latency_seconds": 4.577,
+          "output_contract_valid": true,
+          "expected_findings_found": 2,
+          "expected_findings_total": 2,
+          "refused": false,
+          "changed_file_count": 0,
+          "failure_class": null,
+          "failure_cause": null,
+          "usage": {"exposed": false, "input_tokens": null, "output_tokens": null, "cached_tokens": null, "cost_usd": null}
+        },
+        {
+          "task": "security_review",
+          "requested_model": "opencode-go/kimi-k2.7-code",
+          "resolved_model": "opencode-go/kimi-k2.7-code",
+          "resolved_model_marker": "build · kimi-k2.7-code",
+          "executor_command_shape": "opencode run -m opencode-go/kimi-k2.7-code <PROMPT>",
+          "transport": "cli",
+          "fallback_used": false,
+          "exit_code": 0,
+          "timed_out": false,
+          "latency_seconds": 7.923,
+          "output_contract_valid": false,
+          "expected_findings_found": 2,
+          "expected_findings_total": 2,
+          "refused": false,
+          "changed_file_count": 0,
+          "failure_class": "output-contract",
+          "failure_cause": "Markdown-fenced JSON",
+          "usage": {"exposed": false, "input_tokens": null, "output_tokens": null, "cached_tokens": null, "cost_usd": null}
+        }
+      ]
+    },
+    {
+      "model_id": "opencode-go/minimax-m3",
+      "variant": "thinking",
+      "evidence_tier": "earlier-two-task-screen",
+      "catalog_cost_usd_per_million": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_read": 0.06
+      },
+      "summary": {
+        "cells": 2,
+        "expected_findings_found": 3,
+        "expected_findings_total": 3,
+        "output_contract_passes": 2,
+        "refusals": 0,
+        "mean_latency_seconds": 6.419
+      },
+      "cells": [
+        {
+          "task": "routine",
+          "requested_model": "opencode-go/minimax-m3",
+          "resolved_model": "opencode-go/minimax-m3",
+          "resolved_model_marker": "build · minimax-m3",
+          "executor_command_shape": "opencode run -m opencode-go/minimax-m3 --variant thinking <PROMPT>",
+          "transport": "cli",
+          "fallback_used": false,
+          "exit_code": 0,
+          "timed_out": false,
+          "latency_seconds": 6.1,
+          "output_contract_valid": true,
+          "expected_findings_found": 1,
+          "expected_findings_total": 1,
+          "refused": false,
+          "changed_file_count": 0,
+          "failure_class": null,
+          "failure_cause": null,
+          "usage": {"exposed": false, "input_tokens": null, "output_tokens": null, "cached_tokens": null, "cost_usd": null}
+        },
+        {
+          "task": "contract_drift",
+          "requested_model": "opencode-go/minimax-m3",
+          "resolved_model": "opencode-go/minimax-m3",
+          "resolved_model_marker": "build · minimax-m3",
+          "executor_command_shape": "opencode run -m opencode-go/minimax-m3 --variant thinking <PROMPT>",
+          "transport": "cli",
+          "fallback_used": false,
+          "exit_code": 0,
+          "timed_out": false,
+          "latency_seconds": 6.737,
+          "output_contract_valid": true,
+          "expected_findings_found": 2,
+          "expected_findings_total": 2,
+          "refused": false,
+          "changed_file_count": 0,
+          "failure_class": null,
+          "failure_cause": null,
+          "usage": {"exposed": false, "input_tokens": null, "output_tokens": null, "cached_tokens": null, "cost_usd": null}
+        }
+      ]
+    },
+    {
+      "model_id": "opencode-go/qwen3.7-plus",
+      "variant": "high",
+      "evidence_tier": "earlier-two-task-screen",
+      "catalog_cost_usd_per_million": {
+        "input": 0.4,
+        "output": 1.6,
+        "cache_read": 0.04
+      },
+      "summary": {
+        "cells": 2,
+        "expected_findings_found": 3,
+        "expected_findings_total": 3,
+        "output_contract_passes": 2,
+        "refusals": 0,
+        "mean_latency_seconds": 14.091
+      },
+      "cells": [
+        {
+          "task": "routine",
+          "requested_model": "opencode-go/qwen3.7-plus",
+          "resolved_model": "opencode-go/qwen3.7-plus",
+          "resolved_model_marker": "build · qwen3.7-plus",
+          "executor_command_shape": "opencode run -m opencode-go/qwen3.7-plus --variant high <PROMPT>",
+          "transport": "cli",
+          "fallback_used": false,
+          "exit_code": 0,
+          "timed_out": false,
+          "latency_seconds": 13.518,
+          "output_contract_valid": true,
+          "expected_findings_found": 1,
+          "expected_findings_total": 1,
+          "refused": false,
+          "changed_file_count": 0,
+          "failure_class": null,
+          "failure_cause": null,
+          "usage": {"exposed": false, "input_tokens": null, "output_tokens": null, "cached_tokens": null, "cost_usd": null}
+        },
+        {
+          "task": "contract_drift",
+          "requested_model": "opencode-go/qwen3.7-plus",
+          "resolved_model": "opencode-go/qwen3.7-plus",
+          "resolved_model_marker": "build · qwen3.7-plus",
+          "executor_command_shape": "opencode run -m opencode-go/qwen3.7-plus --variant high <PROMPT>",
+          "transport": "cli",
+          "fallback_used": false,
+          "exit_code": 0,
+          "timed_out": false,
+          "latency_seconds": 14.663,
+          "output_contract_valid": true,
+          "expected_findings_found": 2,
+          "expected_findings_total": 2,
+          "refused": false,
+          "changed_file_count": 0,
+          "failure_class": null,
+          "failure_cause": null,
+          "usage": {"exposed": false, "input_tokens": null, "output_tokens": null, "cached_tokens": null, "cost_usd": null}
+        }
+      ]
+    },
+    {
+      "model_id": "opencode-go/deepseek-v4-flash",
+      "variant": "high",
+      "evidence_tier": "earlier-two-task-screen",
+      "catalog_cost_usd_per_million": {
+        "input": 0.14,
+        "output": 0.28,
+        "cache_read": 0.0028
+      },
+      "summary": {
+        "cells": 2,
+        "expected_findings_found": 3,
+        "expected_findings_total": 3,
+        "output_contract_passes": 1,
+        "refusals": 0,
+        "mean_latency_seconds": 5.516
+      },
+      "cells": [
+        {
+          "task": "routine",
+          "requested_model": "opencode-go/deepseek-v4-flash",
+          "resolved_model": "opencode-go/deepseek-v4-flash",
+          "resolved_model_marker": "build · deepseek-v4-flash",
+          "executor_command_shape": "opencode run -m opencode-go/deepseek-v4-flash --variant high <PROMPT>",
+          "transport": "cli",
+          "fallback_used": false,
+          "exit_code": 0,
+          "timed_out": false,
+          "latency_seconds": 5.214,
+          "output_contract_valid": false,
+          "expected_findings_found": 1,
+          "expected_findings_total": 1,
+          "refused": false,
+          "changed_file_count": 0,
+          "failure_class": "output-contract",
+          "failure_cause": "Markdown fence and valid=false",
+          "usage": {"exposed": false, "input_tokens": null, "output_tokens": null, "cached_tokens": null, "cost_usd": null}
+        },
+        {
+          "task": "contract_drift",
+          "requested_model": "opencode-go/deepseek-v4-flash",
+          "resolved_model": "opencode-go/deepseek-v4-flash",
+          "resolved_model_marker": "build · deepseek-v4-flash",
+          "executor_command_shape": "opencode run -m opencode-go/deepseek-v4-flash --variant high <PROMPT>",
+          "transport": "cli",
+          "fallback_used": false,
+          "exit_code": 0,
+          "timed_out": false,
+          "latency_seconds": 5.817,
+          "output_contract_valid": true,
+          "expected_findings_found": 2,
+          "expected_findings_total": 2,
+          "refused": false,
+          "changed_file_count": 0,
+          "failure_class": null,
+          "failure_cause": null,
+          "usage": {"exposed": false, "input_tokens": null, "output_tokens": null, "cached_tokens": null, "cost_usd": null}
+        }
+      ]
+    },
+    {
+      "model_id": "opencode-go/mimo-v2.5",
+      "variant": null,
+      "evidence_tier": "earlier-two-task-screen",
+      "catalog_cost_usd_per_million": {
+        "input": 0.14,
+        "output": 0.28,
+        "cache_read": 0.0028
+      },
+      "summary": {
+        "cells": 2,
+        "expected_findings_found": 3,
+        "expected_findings_total": 3,
+        "output_contract_passes": 1,
+        "refusals": 0,
+        "mean_latency_seconds": 16.711
+      },
+      "cells": [
+        {
+          "task": "routine",
+          "requested_model": "opencode-go/mimo-v2.5",
+          "resolved_model": "opencode-go/mimo-v2.5",
+          "resolved_model_marker": "build · mimo-v2.5",
+          "executor_command_shape": "opencode run -m opencode-go/mimo-v2.5 <PROMPT>",
+          "transport": "cli",
+          "fallback_used": false,
+          "exit_code": 0,
+          "timed_out": false,
+          "latency_seconds": 7.435,
+          "output_contract_valid": false,
+          "expected_findings_found": 1,
+          "expected_findings_total": 1,
+          "refused": false,
+          "changed_file_count": 0,
+          "failure_class": "output-contract",
+          "failure_cause": "Markdown fence and valid=false",
+          "usage": {"exposed": false, "input_tokens": null, "output_tokens": null, "cached_tokens": null, "cost_usd": null}
+        },
+        {
+          "task": "contract_drift",
+          "requested_model": "opencode-go/mimo-v2.5",
+          "resolved_model": "opencode-go/mimo-v2.5",
+          "resolved_model_marker": "build · mimo-v2.5",
+          "executor_command_shape": "opencode run -m opencode-go/mimo-v2.5 <PROMPT>",
+          "transport": "cli",
+          "fallback_used": false,
+          "exit_code": 0,
+          "timed_out": false,
+          "latency_seconds": 25.986,
+          "output_contract_valid": true,
+          "expected_findings_found": 2,
+          "expected_findings_total": 2,
+          "refused": false,
+          "changed_file_count": 0,
+          "failure_class": null,
+          "failure_cause": null,
+          "usage": {"exposed": false, "input_tokens": null, "output_tokens": null, "cached_tokens": null, "cost_usd": null}
+        }
+      ]
+    }
+  ],
+  "rankings": {
+    "new_three_task_matrix": [
+      {"rank": 1, "model_id": "opencode-go/glm-5.2", "basis": "5/5 findings, 3/3 output contracts, lower catalog cost than Kimi K3"},
+      {"rank": 2, "model_id": "opencode-go/kimi-k3", "basis": "5/5 findings and 3/3 output contracts, but highest catalog cost in the matrix"},
+      {"rank": 3, "model_id": "opencode-go/kimi-k2.7-code", "basis": "5/5 findings, 1/3 output contracts, lowest mean latency in the matrix"},
+      {"rank": 4, "model_id": "opencode-go/deepseek-v4-pro", "basis": "5/5 findings, 0/3 output contracts, lower catalog cost than Qwen Max"},
+      {"rank": 5, "model_id": "opencode-go/qwen3.7-max", "basis": "5/5 findings, 0/3 output contracts, higher catalog cost than DeepSeek Pro"}
+    ],
+    "earlier_two_task_screen": [
+      {"rank": 1, "model_id": "opencode-go/minimax-m3", "basis": "3/3 findings and 2/2 output contracts at 6.419s mean; no security cell"},
+      {"rank": 2, "model_id": "opencode-go/qwen3.7-plus", "basis": "3/3 findings and 2/2 output contracts at 14.091s mean; no security cell"},
+      {"rank": 3, "model_id": "opencode-go/deepseek-v4-flash", "basis": "3/3 findings and 1/2 output contracts at 5.516s mean; no security cell"},
+      {"rank": 4, "model_id": "opencode-go/mimo-v2.5", "basis": "3/3 findings and 1/2 output contracts at 16.711s mean; no security cell"}
+    ],
+    "role_selections": {
+      "primary_cheap_coder_reviewer": "opencode-go/minimax-m3",
+      "security_capable_reviewer": "opencode-go/glm-5.2",
+      "cross_file_canary": "opencode-go/kimi-k3",
+      "promotion_gate": {
+        "model_id": "opencode-go/minimax-m3",
+        "status": "post-shadow-candidate",
+        "required_shadow_runs": 20,
+        "current_fallback_during_shadow": "kimi-k2.7"
+      },
+      "deferred": [
+        "opencode-go/qwen3.7-plus",
+        "opencode-go/deepseek-v4-flash",
+        "opencode-go/mimo-v2.5",
+        "opencode-go/kimi-k2.7-code",
+        "opencode-go/deepseek-v4-pro",
+        "opencode-go/qwen3.7-max"
+      ]
+    }
+  },
+  "multi_seat_trial": {
+    "status": "ok",
+    "duration_seconds": 14.62,
+    "orchestrator": {
+      "seat": "glm_security_reviewer",
+      "requested_model": "opencode-go/glm-5.2",
+      "resolved_model": "opencode-go/glm-5.2",
+      "resolved_model_marker": "build · glm-5.2",
+      "transport": "cli",
+      "fallback_used": false,
+      "synthesis_latency_seconds": 3.947,
+      "exit_code": 0
+    },
+    "worker": {
+      "seat": "minimax_coder",
+      "requested_model": "opencode-go/minimax-m3",
+      "resolved_model": "opencode-go/minimax-m3",
+      "resolved_model_marker": "build · minimax-m3",
+      "transport": "cli",
+      "fallback_used": false,
+      "latency_seconds": 6.84,
+      "exit_code": 0
+    },
+    "plan_assignments": 1,
+    "final_contains": "WIRING_OK",
+    "changed_file_count": 0,
+    "artifact_path": ".brigade/evaluations/opencode-go-20260729-extended/multi-seat"
+  },
+  "receipts": [
+    {
+      "run_id": "20260729-183625-work-verify-69cacc",
+      "miseledger_evidence_id": "ec4e976c7c7689a39f91ae97",
+      "scope": "earlier two-task validator"
+    },
+    {
+      "run_id": "20260729-194155-work-verify-f0f8e3",
+      "miseledger_evidence_id": "dc8c9568260c63269750f666",
+      "scope": "fresh new three-task validator after answer-key synonym correction"
+    },
+    {
+      "run_id": "20260729-201417-work-verify-f959da",
+      "miseledger_evidence_id": "fbb5c10d67e793cfb8050057",
+      "scope": "schema, semantic, roster, and raw multi-seat artifact validation"
+    }
+  ],
+  "limitations": [
+    "One run per cell is a screening pass, not a promotion-quality benchmark.",
+    "The routine and contract-drift prompts disclosed the expected fix substance.",
+    "The security prompt disclosed both planted vulnerability classes.",
+    "Earlier candidates have no security cell and are ranked separately.",
+    "OpenCode token and per-call cost data were not exposed by Brigade worker receipts or logs.",
+    "OpenCode read-only mode is prompt-level in Brigade 0.25.1; zero changed files is an observed result, not sandbox enforcement.",
+    "The stale reused verifier receipt 20260729-194132-work-verify-47116b is excluded."
+  ]
+}

--- a/benchmarks/model-ratings-2026-07/opencode-go-schema.json
+++ b/benchmarks/model-ratings-2026-07/opencode-go-schema.json
@@ -1,0 +1,801 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://brigade.tools/schemas/model-fitness.v1.json",
+  "title": "Brigade model fitness benchmark",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "schema",
+    "benchmark_id",
+    "generated_at",
+    "catalog_discovery",
+    "provider_behavior",
+    "methodology",
+    "tasks",
+    "models",
+    "rankings",
+    "multi_seat_trial",
+    "receipts",
+    "limitations"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "minLength": 1
+    },
+    "schema": {
+      "const": "brigade.model_fitness.v1"
+    },
+    "benchmark_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "catalog_discovery": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "command",
+        "subscription_provider",
+        "subscription_model_ids",
+        "separate_free_provider",
+        "api_key_provider_scope"
+      ],
+      "properties": {
+        "command": {
+          "type": "string",
+          "minLength": 1
+        },
+        "subscription_provider": {
+          "const": "opencode-go"
+        },
+        "subscription_model_ids": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^opencode-go/"
+          }
+        },
+        "separate_free_provider": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["provider", "description"],
+          "properties": {
+            "provider": {
+              "type": "string",
+              "minLength": 1
+            },
+            "description": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "api_key_provider_scope": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "provider_behavior": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "new_probe_runs",
+        "auth_failures",
+        "entitlement_failures",
+        "rate_limit_failures",
+        "provider_failures",
+        "multi_seat_trial_failures"
+      ],
+      "properties": {
+        "new_probe_runs": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "auth_failures": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "entitlement_failures": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "rate_limit_failures": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "provider_failures": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "multi_seat_trial_failures": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "methodology": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "execution_path",
+        "opencode_version",
+        "read_only",
+        "max_live_processes_observed",
+        "roster_max_workers_per_run",
+        "host_process_limit_policy",
+        "ranking_order",
+        "graphtrail"
+      ],
+      "properties": {
+        "execution_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "opencode_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "read_only": {
+          "type": "string",
+          "minLength": 1
+        },
+        "max_live_processes_observed": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "roster_max_workers_per_run": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "host_process_limit_policy": {
+          "type": "string",
+          "minLength": 1
+        },
+        "ranking_order": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "graphtrail": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "tasks": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/task"
+      }
+    },
+    "models": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/model"
+      }
+    },
+    "rankings": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "new_three_task_matrix",
+        "earlier_two_task_screen",
+        "role_selections"
+      ],
+      "properties": {
+        "new_three_task_matrix": {
+          "type": "array",
+          "minItems": 5,
+          "maxItems": 5,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/ranking"
+          }
+        },
+        "earlier_two_task_screen": {
+          "type": "array",
+          "minItems": 4,
+          "maxItems": 4,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/ranking"
+          }
+        },
+        "role_selections": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "primary_cheap_coder_reviewer",
+            "security_capable_reviewer",
+            "cross_file_canary",
+            "promotion_gate",
+            "deferred"
+          ],
+          "properties": {
+            "primary_cheap_coder_reviewer": {
+              "type": "string",
+              "pattern": "^opencode-go/"
+            },
+            "security_capable_reviewer": {
+              "type": "string",
+              "pattern": "^opencode-go/"
+            },
+            "cross_file_canary": {
+              "type": "string",
+              "pattern": "^opencode-go/"
+            },
+            "promotion_gate": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "model_id",
+                "status",
+                "required_shadow_runs",
+                "current_fallback_during_shadow"
+              ],
+              "properties": {
+                "model_id": {
+                  "type": "string",
+                  "pattern": "^opencode-go/"
+                },
+                "status": {
+                  "const": "post-shadow-candidate"
+                },
+                "required_shadow_runs": {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "current_fallback_during_shadow": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            },
+            "deferred": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "pattern": "^opencode-go/"
+              }
+            }
+          }
+        }
+      }
+    },
+    "multi_seat_trial": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "duration_seconds",
+        "orchestrator",
+        "worker",
+        "plan_assignments",
+        "final_contains",
+        "changed_file_count",
+        "artifact_path"
+      ],
+      "properties": {
+        "status": {
+          "const": "ok"
+        },
+        "duration_seconds": {
+          "type": "number",
+          "minimum": 0
+        },
+        "orchestrator": {
+          "$ref": "#/$defs/trial_orchestrator"
+        },
+        "worker": {
+          "$ref": "#/$defs/trial_worker"
+        },
+        "plan_assignments": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "final_contains": {
+          "type": "string",
+          "minLength": 1
+        },
+        "changed_file_count": {
+          "const": 0
+        },
+        "artifact_path": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "receipts": {
+      "type": "array",
+      "minItems": 2,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/receipt"
+      }
+    },
+    "limitations": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  },
+  "$defs": {
+    "task": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "expected_findings", "output_contract"],
+      "properties": {
+        "id": {
+          "enum": ["routine", "contract_drift", "security_review"]
+        },
+        "expected_findings": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "output_contract": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "cost": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["input", "output", "cache_read"],
+      "properties": {
+        "input": {
+          "type": "number",
+          "minimum": 0
+        },
+        "output": {
+          "type": "number",
+          "minimum": 0
+        },
+        "cache_read": {
+          "type": "number",
+          "minimum": 0
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "cells",
+        "expected_findings_found",
+        "expected_findings_total",
+        "output_contract_passes",
+        "refusals",
+        "mean_latency_seconds"
+      ],
+      "properties": {
+        "cells": {
+          "type": "integer",
+          "minimum": 2,
+          "maximum": 3
+        },
+        "expected_findings_found": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "expected_findings_total": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "output_contract_passes": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 3
+        },
+        "refusals": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 3
+        },
+        "mean_latency_seconds": {
+          "type": "number",
+          "minimum": 0
+        }
+      }
+    },
+    "usage_value": {
+      "type": ["integer", "null"],
+      "minimum": 0
+    },
+    "usage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "exposed",
+        "input_tokens",
+        "output_tokens",
+        "cached_tokens",
+        "cost_usd"
+      ],
+      "properties": {
+        "exposed": {
+          "type": "boolean"
+        },
+        "input_tokens": {
+          "$ref": "#/$defs/usage_value"
+        },
+        "output_tokens": {
+          "$ref": "#/$defs/usage_value"
+        },
+        "cached_tokens": {
+          "$ref": "#/$defs/usage_value"
+        },
+        "cost_usd": {
+          "type": ["number", "null"],
+          "minimum": 0
+        }
+      }
+    },
+    "cell": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "task",
+        "requested_model",
+        "resolved_model",
+        "resolved_model_marker",
+        "executor_command_shape",
+        "transport",
+        "fallback_used",
+        "exit_code",
+        "timed_out",
+        "latency_seconds",
+        "output_contract_valid",
+        "expected_findings_found",
+        "expected_findings_total",
+        "refused",
+        "changed_file_count",
+        "failure_class",
+        "failure_cause",
+        "usage"
+      ],
+      "properties": {
+        "task": {
+          "enum": ["routine", "contract_drift", "security_review"]
+        },
+        "requested_model": {
+          "type": "string",
+          "pattern": "^opencode-go/"
+        },
+        "resolved_model": {
+          "type": "string",
+          "pattern": "^opencode-go/"
+        },
+        "resolved_model_marker": {
+          "type": "string",
+          "minLength": 1
+        },
+        "executor_command_shape": {
+          "type": "string",
+          "minLength": 1
+        },
+        "transport": {
+          "const": "cli"
+        },
+        "fallback_used": {
+          "type": "boolean"
+        },
+        "exit_code": {
+          "type": "integer"
+        },
+        "timed_out": {
+          "type": "boolean"
+        },
+        "latency_seconds": {
+          "type": "number",
+          "minimum": 0
+        },
+        "output_contract_valid": {
+          "type": "boolean"
+        },
+        "expected_findings_found": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "expected_findings_total": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "refused": {
+          "type": "boolean"
+        },
+        "changed_file_count": {
+          "const": 0
+        },
+        "failure_class": {
+          "type": ["string", "null"]
+        },
+        "failure_cause": {
+          "type": ["string", "null"]
+        },
+        "usage": {
+          "$ref": "#/$defs/usage"
+        }
+      }
+    },
+    "model": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "model_id",
+        "variant",
+        "evidence_tier",
+        "catalog_cost_usd_per_million",
+        "summary",
+        "cells"
+      ],
+      "properties": {
+        "model_id": {
+          "type": "string",
+          "pattern": "^opencode-go/"
+        },
+        "variant": {
+          "type": ["string", "null"]
+        },
+        "evidence_tier": {
+          "enum": ["new-three-task-matrix", "earlier-two-task-screen"]
+        },
+        "catalog_cost_usd_per_million": {
+          "$ref": "#/$defs/cost"
+        },
+        "summary": {
+          "$ref": "#/$defs/summary"
+        },
+        "cells": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/cell"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "evidence_tier": {
+                "const": "new-three-task-matrix"
+              }
+            },
+            "required": ["evidence_tier"]
+          },
+          "then": {
+            "properties": {
+              "cells": {
+                "minItems": 3,
+                "maxItems": 3,
+                "allOf": [
+                  {
+                    "contains": {
+                      "properties": {
+                        "task": {
+                          "const": "routine"
+                        }
+                      },
+                      "required": ["task"]
+                    },
+                    "minContains": 1,
+                    "maxContains": 1
+                  },
+                  {
+                    "contains": {
+                      "properties": {
+                        "task": {
+                          "const": "contract_drift"
+                        }
+                      },
+                      "required": ["task"]
+                    },
+                    "minContains": 1,
+                    "maxContains": 1
+                  },
+                  {
+                    "contains": {
+                      "properties": {
+                        "task": {
+                          "const": "security_review"
+                        }
+                      },
+                      "required": ["task"]
+                    },
+                    "minContains": 1,
+                    "maxContains": 1
+                  }
+                ]
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "cells": {
+                "minItems": 2,
+                "maxItems": 2,
+                "allOf": [
+                  {
+                    "contains": {
+                      "properties": {
+                        "task": {
+                          "const": "routine"
+                        }
+                      },
+                      "required": ["task"]
+                    },
+                    "minContains": 1,
+                    "maxContains": 1
+                  },
+                  {
+                    "contains": {
+                      "properties": {
+                        "task": {
+                          "const": "contract_drift"
+                        }
+                      },
+                      "required": ["task"]
+                    },
+                    "minContains": 1,
+                    "maxContains": 1
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "ranking": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["rank", "model_id", "basis"],
+      "properties": {
+        "rank": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "model_id": {
+          "type": "string",
+          "pattern": "^opencode-go/"
+        },
+        "basis": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "trial_base": {
+      "type": "object",
+      "required": [
+        "seat",
+        "requested_model",
+        "resolved_model",
+        "resolved_model_marker",
+        "transport",
+        "fallback_used",
+        "exit_code"
+      ],
+      "properties": {
+        "seat": {
+          "type": "string",
+          "minLength": 1
+        },
+        "requested_model": {
+          "type": "string",
+          "pattern": "^opencode-go/"
+        },
+        "resolved_model": {
+          "type": "string",
+          "pattern": "^opencode-go/"
+        },
+        "resolved_model_marker": {
+          "type": "string",
+          "minLength": 1
+        },
+        "transport": {
+          "const": "cli"
+        },
+        "fallback_used": {
+          "type": "boolean"
+        },
+        "exit_code": {
+          "type": "integer"
+        }
+      }
+    },
+    "trial_orchestrator": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/trial_base"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["synthesis_latency_seconds"],
+          "properties": {
+            "seat": true,
+            "requested_model": true,
+            "resolved_model": true,
+            "resolved_model_marker": true,
+            "transport": true,
+            "fallback_used": true,
+            "exit_code": true,
+            "synthesis_latency_seconds": {
+              "type": "number",
+              "minimum": 0
+            }
+          }
+        }
+      ]
+    },
+    "trial_worker": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/trial_base"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["latency_seconds"],
+          "properties": {
+            "seat": true,
+            "requested_model": true,
+            "resolved_model": true,
+            "resolved_model_marker": true,
+            "transport": true,
+            "fallback_used": true,
+            "exit_code": true,
+            "latency_seconds": {
+              "type": "number",
+              "minimum": 0
+            }
+          }
+        }
+      ]
+    },
+    "receipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["run_id", "miseledger_evidence_id", "scope"],
+      "properties": {
+        "run_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "miseledger_evidence_id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{24}$"
+        },
+        "scope": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/benchmarks/model-ratings-2026-07/proposed-opencode-go-roster.toml
+++ b/benchmarks/model-ratings-2026-07/proposed-opencode-go-roster.toml
@@ -1,0 +1,40 @@
+# Post-shadow proposal only. Do not treat this file as an active Brigade roster.
+
+orchestrator = "go_glm_52_security"
+
+[agents.go_glm_52_security]
+cli = "opencode"
+model = "opencode-go/glm-5.2"
+reasoning = "high"
+role = "Review security-sensitive and cross-file work, then synthesize worker findings."
+timeout_seconds = 180
+fallback = ["go_kimi_k3_canary"]
+
+[agents.go_minimax_m3_primary]
+cli = "opencode"
+model = "opencode-go/minimax-m3"
+reasoning = "thinking"
+role = "Handle short read-only coding analysis and structured first-pass review."
+timeout_seconds = 120
+fallback = ["go_glm_52_worker_fallback"]
+
+[agents.go_glm_52_worker_fallback]
+cli = "opencode"
+model = "opencode-go/glm-5.2"
+reasoning = "high"
+role = "Replace the MiniMax worker when its seat is unavailable."
+timeout_seconds = 180
+
+[agents.go_kimi_k3_canary]
+cli = "opencode"
+model = "opencode-go/kimi-k3"
+reasoning = "max"
+role = "Canary difficult read-only cross-file work before a Claude or GPT-5.6 final review."
+timeout_seconds = 240
+fallback = []
+
+[limits]
+max_workers = 2
+timeout_seconds = 240
+sandbox = "read-only"
+allow_models = ["opencode"]

--- a/benchmarks/model-ratings-2026-07/validate.py
+++ b/benchmarks/model-ratings-2026-07/validate.py
@@ -137,8 +137,7 @@ def validate_models(data: dict[str, Any]) -> None:
         require(
             all(
                 cell["expected_findings_total"] == TASK_FINDINGS[cell["task"]]
-                and cell["expected_findings_found"]
-                <= cell["expected_findings_total"]
+                and cell["expected_findings_found"] <= cell["expected_findings_total"]
                 for cell in cells
             ),
             f"{model_id}: impossible or task-inconsistent finding recall",
@@ -147,22 +146,16 @@ def validate_models(data: dict[str, Any]) -> None:
         summary = model["summary"]
         require(summary["cells"] == len(cells), f"{model_id}: cell count mismatch")
         sums = {
-            "expected_findings_found": sum(
-                cell["expected_findings_found"] for cell in cells
-            ),
-            "expected_findings_total": sum(
-                cell["expected_findings_total"] for cell in cells
-            ),
-            "output_contract_passes": sum(
-                cell["output_contract_valid"] for cell in cells
-            ),
+            "expected_findings_found": sum(cell["expected_findings_found"] for cell in cells),
+            "expected_findings_total": sum(cell["expected_findings_total"] for cell in cells),
+            "output_contract_passes": sum(cell["output_contract_valid"] for cell in cells),
             "refusals": sum(cell["refused"] for cell in cells),
         }
         for key, value in sums.items():
             require(summary[key] == value, f"{model_id}: {key} mismatch")
-        mean = (
-            sum(Decimal(str(cell["latency_seconds"])) for cell in cells) / len(cells)
-        ).quantize(Decimal("0.001"), rounding=ROUND_HALF_UP)
+        mean = (sum(Decimal(str(cell["latency_seconds"])) for cell in cells) / len(cells)).quantize(
+            Decimal("0.001"), rounding=ROUND_HALF_UP
+        )
         require(
             Decimal(str(summary["mean_latency_seconds"])) == mean,
             f"{model_id}: mean latency mismatch",
@@ -213,8 +206,7 @@ def validate_roster() -> None:
     require(roster.max_workers == 2, "per-run worker limit mismatch")
     require(roster.sandbox == "read-only", "roster sandbox mismatch")
     require(
-        roster.agents["go_minimax_m3_primary"].fallback
-        == ("go_glm_52_worker_fallback",),
+        roster.agents["go_minimax_m3_primary"].fallback == ("go_glm_52_worker_fallback",),
         "MiniMax fallback topology mismatch",
     )
 
@@ -238,15 +230,12 @@ def validate_trial(data: dict[str, Any], artifacts: Path | None) -> None:
     synthesis = load_json(artifacts / "synthesis.json")
     enforcement = load_json(artifacts / "read-only-enforcement.json")
     final = (artifacts / "final.txt").read_text()
-    worker_stderr = (
-        artifacts / "logs/worker-001-minimax_coder.stderr.log"
-    ).read_text()
+    worker_stderr = (artifacts / "logs/worker-001-minimax_coder.stderr.log").read_text()
     synthesis_stderr = (artifacts / "logs/synthesis.stderr.log").read_text()
 
     require(run["status"] == trial["status"], "artifact run status mismatch")
     require(
-        Decimal(str(run["duration_seconds"]))
-        == Decimal(str(trial["duration_seconds"])),
+        Decimal(str(run["duration_seconds"])) == Decimal(str(trial["duration_seconds"])),
         "artifact duration mismatch",
     )
     require(run["read_only"] is True, "artifact run was not read-only")
@@ -265,14 +254,12 @@ def validate_trial(data: dict[str, Any], artifacts: Path | None) -> None:
         "worker resolved model mismatch",
     )
     require(
-        Decimal(str(worker["duration_seconds"]))
-        == Decimal(str(trial["worker"]["latency_seconds"])),
+        Decimal(str(worker["duration_seconds"])) == Decimal(str(trial["worker"]["latency_seconds"])),
         "worker latency mismatch",
     )
     require(worker["transport"] == "cli" and worker["exit_code"] == 0, "worker exit")
     require(
-        workers["ground_truth"]["changed_files"] == []
-        and workers["ground_truth"]["untracked_files"] == [],
+        workers["ground_truth"]["changed_files"] == [] and workers["ground_truth"]["untracked_files"] == [],
         "worker changed or untracked files",
     )
 
@@ -295,8 +282,7 @@ def validate_trial(data: dict[str, Any], artifacts: Path | None) -> None:
         "synthesis exit",
     )
     require(
-        synthesis["ground_truth"]["changed_files"] == []
-        and synthesis["ground_truth"]["untracked_files"] == [],
+        synthesis["ground_truth"]["changed_files"] == [] and synthesis["ground_truth"]["untracked_files"] == [],
         "synthesis changed or untracked files",
     )
     require(trial["final_contains"] in final, "final marker absent")

--- a/benchmarks/model-ratings-2026-07/validate.py
+++ b/benchmarks/model-ratings-2026-07/validate.py
@@ -1,0 +1,340 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from decimal import Decimal, ROUND_HALF_UP
+from pathlib import Path
+from typing import Any
+
+
+BENCHMARK_DIR = Path(__file__).resolve().parent
+ROOT = BENCHMARK_DIR.parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+NEW_MODELS = {
+    "opencode-go/kimi-k3",
+    "opencode-go/glm-5.2",
+    "opencode-go/deepseek-v4-pro",
+    "opencode-go/qwen3.7-max",
+    "opencode-go/kimi-k2.7-code",
+}
+EARLIER_MODELS = {
+    "opencode-go/minimax-m3",
+    "opencode-go/qwen3.7-plus",
+    "opencode-go/deepseek-v4-flash",
+    "opencode-go/mimo-v2.5",
+}
+CATALOG_MODELS = {
+    "opencode-go/deepseek-v4-flash",
+    "opencode-go/deepseek-v4-pro",
+    "opencode-go/glm-5.1",
+    "opencode-go/glm-5.2",
+    "opencode-go/grok-4.5",
+    "opencode-go/hy3",
+    "opencode-go/kimi-k2.6",
+    "opencode-go/kimi-k2.7-code",
+    "opencode-go/kimi-k3",
+    "opencode-go/mimo-v2.5",
+    "opencode-go/mimo-v2.5-pro",
+    "opencode-go/minimax-m2.7",
+    "opencode-go/minimax-m3",
+    "opencode-go/qwen3.6-plus",
+    "opencode-go/qwen3.7-max",
+    "opencode-go/qwen3.7-plus",
+}
+ALL_TASKS = {"routine", "contract_drift", "security_review"}
+EARLIER_TASKS = {"routine", "contract_drift"}
+TASK_FINDINGS = {"routine": 1, "contract_drift": 2, "security_review": 2}
+NEW_RANKING = [
+    "opencode-go/glm-5.2",
+    "opencode-go/kimi-k3",
+    "opencode-go/kimi-k2.7-code",
+    "opencode-go/deepseek-v4-pro",
+    "opencode-go/qwen3.7-max",
+]
+EARLIER_RANKING = [
+    "opencode-go/minimax-m3",
+    "opencode-go/qwen3.7-plus",
+    "opencode-go/deepseek-v4-flash",
+    "opencode-go/mimo-v2.5",
+]
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text())
+    require(isinstance(data, dict), f"{path}: expected a JSON object")
+    return data
+
+
+def validate_schema(data: dict[str, Any], schema: dict[str, Any]) -> str:
+    try:
+        import jsonschema
+    except ModuleNotFoundError:
+        return "jsonschema package unavailable; syntax and semantic checks only"
+    jsonschema.Draft202012Validator.check_schema(schema)
+    jsonschema.validate(data, schema)
+    return "Draft 2020-12 schema and instance valid"
+
+
+def validate_models(data: dict[str, Any]) -> None:
+    models = {model["model_id"]: model for model in data["models"]}
+    require(len(data["models"]) == 9, "expected exactly nine model records")
+    require(len(models) == 9, "duplicate model IDs")
+    require(
+        sum(len(model["cells"]) for model in data["models"]) == 23,
+        "expected exactly 23 task/model cells",
+    )
+    require(set(models) == NEW_MODELS | EARLIER_MODELS, "unexpected model set")
+    catalog_ids = data["catalog_discovery"]["subscription_model_ids"]
+    require(
+        len(catalog_ids) == 16 and set(catalog_ids) == CATALOG_MODELS,
+        "subscription catalog does not match discovery",
+    )
+    task_findings = {task["id"]: task["expected_findings"] for task in data["tasks"]}
+    require(task_findings == TASK_FINDINGS, "task finding totals mismatch")
+
+    for model_id, model in models.items():
+        expected_tasks = ALL_TASKS if model_id in NEW_MODELS else EARLIER_TASKS
+        cells = model["cells"]
+        require(
+            {cell["task"] for cell in cells} == expected_tasks,
+            f"{model_id}: task coverage mismatch",
+        )
+        require(
+            all(cell["requested_model"] == model_id for cell in cells),
+            f"{model_id}: requested model mismatch",
+        )
+        require(
+            all(cell["resolved_model"] == model_id for cell in cells),
+            f"{model_id}: resolved model mismatch",
+        )
+        require(
+            all(cell["transport"] == "cli" for cell in cells),
+            f"{model_id}: non-CLI transport",
+        )
+        require(
+            not any(cell["fallback_used"] for cell in cells),
+            f"{model_id}: fallback recorded",
+        )
+        require(
+            all(cell["exit_code"] == 0 and not cell["timed_out"] for cell in cells),
+            f"{model_id}: unsuccessful process",
+        )
+        require(
+            all(cell["changed_file_count"] == 0 for cell in cells),
+            f"{model_id}: changed files recorded",
+        )
+        require(
+            not any(cell["usage"]["exposed"] for cell in cells),
+            f"{model_id}: unexpected usage exposure",
+        )
+        require(
+            all(
+                cell["expected_findings_total"] == TASK_FINDINGS[cell["task"]]
+                and cell["expected_findings_found"]
+                <= cell["expected_findings_total"]
+                for cell in cells
+            ),
+            f"{model_id}: impossible or task-inconsistent finding recall",
+        )
+
+        summary = model["summary"]
+        require(summary["cells"] == len(cells), f"{model_id}: cell count mismatch")
+        sums = {
+            "expected_findings_found": sum(
+                cell["expected_findings_found"] for cell in cells
+            ),
+            "expected_findings_total": sum(
+                cell["expected_findings_total"] for cell in cells
+            ),
+            "output_contract_passes": sum(
+                cell["output_contract_valid"] for cell in cells
+            ),
+            "refusals": sum(cell["refused"] for cell in cells),
+        }
+        for key, value in sums.items():
+            require(summary[key] == value, f"{model_id}: {key} mismatch")
+        mean = (
+            sum(Decimal(str(cell["latency_seconds"])) for cell in cells) / len(cells)
+        ).quantize(Decimal("0.001"), rounding=ROUND_HALF_UP)
+        require(
+            Decimal(str(summary["mean_latency_seconds"])) == mean,
+            f"{model_id}: mean latency mismatch",
+        )
+
+
+def validate_rankings(data: dict[str, Any]) -> None:
+    rankings = data["rankings"]
+    new = rankings["new_three_task_matrix"]
+    earlier = rankings["earlier_two_task_screen"]
+    require([item["rank"] for item in new] == list(range(1, 6)), "new ranks")
+    require([item["rank"] for item in earlier] == list(range(1, 5)), "earlier ranks")
+    require([item["model_id"] for item in new] == NEW_RANKING, "new ranking order")
+    require(
+        [item["model_id"] for item in earlier] == EARLIER_RANKING,
+        "earlier ranking order",
+    )
+    roles = rankings["role_selections"]
+    require(
+        roles["primary_cheap_coder_reviewer"] == "opencode-go/minimax-m3",
+        "primary candidate mismatch",
+    )
+    require(
+        roles["security_capable_reviewer"] == "opencode-go/glm-5.2",
+        "security reviewer mismatch",
+    )
+    require(
+        roles["cross_file_canary"] == "opencode-go/kimi-k3",
+        "cross-file canary mismatch",
+    )
+    require(
+        roles["promotion_gate"]
+        == {
+            "model_id": "opencode-go/minimax-m3",
+            "status": "post-shadow-candidate",
+            "required_shadow_runs": 20,
+            "current_fallback_during_shadow": "kimi-k2.7",
+        },
+        "MiniMax promotion gate mismatch",
+    )
+
+
+def validate_roster() -> None:
+    from brigade.roster import load_roster
+
+    roster = load_roster(BENCHMARK_DIR / "proposed-opencode-go-roster.toml")
+    require(roster.orchestrator == "go_glm_52_security", "orchestrator mismatch")
+    require(roster.max_workers == 2, "per-run worker limit mismatch")
+    require(roster.sandbox == "read-only", "roster sandbox mismatch")
+    require(
+        roster.agents["go_minimax_m3_primary"].fallback
+        == ("go_glm_52_worker_fallback",),
+        "MiniMax fallback topology mismatch",
+    )
+
+
+def validate_trial(data: dict[str, Any], artifacts: Path | None) -> None:
+    trial = data["multi_seat_trial"]
+    require(trial["status"] == "ok", "multi-seat status mismatch")
+    require(trial["changed_file_count"] == 0, "multi-seat changed files")
+    require(trial["plan_assignments"] == 1, "multi-seat assignment count")
+    require(trial["final_contains"] == "WIRING_OK", "multi-seat final marker")
+    for phase in ("orchestrator", "worker"):
+        require(trial[phase]["transport"] == "cli", f"{phase}: transport mismatch")
+        require(not trial[phase]["fallback_used"], f"{phase}: fallback recorded")
+        require(trial[phase]["exit_code"] == 0, f"{phase}: nonzero exit")
+
+    if artifacts is None:
+        return
+    run = load_json(artifacts / "run.json")
+    plan = load_json(artifacts / "plan.json")
+    workers = load_json(artifacts / "worker-results.json")
+    synthesis = load_json(artifacts / "synthesis.json")
+    enforcement = load_json(artifacts / "read-only-enforcement.json")
+    final = (artifacts / "final.txt").read_text()
+    worker_stderr = (
+        artifacts / "logs/worker-001-minimax_coder.stderr.log"
+    ).read_text()
+    synthesis_stderr = (artifacts / "logs/synthesis.stderr.log").read_text()
+
+    require(run["status"] == trial["status"], "artifact run status mismatch")
+    require(
+        Decimal(str(run["duration_seconds"]))
+        == Decimal(str(trial["duration_seconds"])),
+        "artifact duration mismatch",
+    )
+    require(run["read_only"] is True, "artifact run was not read-only")
+    require(run["pre_run_snapshot"]["tracked_dirty_files"] == [], "dirty pre-run")
+    require(run["pre_run_snapshot"]["untracked_files"] == [], "untracked pre-run")
+    require(len(plan["assignments"]) == trial["plan_assignments"], "plan mismatch")
+    require(plan["assignments"][0]["worker"] == trial["worker"]["seat"], "worker seat")
+
+    worker = workers["results"][0]
+    require(
+        worker["requested_model"] == trial["worker"]["requested_model"],
+        "worker model mismatch",
+    )
+    require(
+        trial["worker"]["resolved_model"] == worker["requested_model"],
+        "worker resolved model mismatch",
+    )
+    require(
+        Decimal(str(worker["duration_seconds"]))
+        == Decimal(str(trial["worker"]["latency_seconds"])),
+        "worker latency mismatch",
+    )
+    require(worker["transport"] == "cli" and worker["exit_code"] == 0, "worker exit")
+    require(
+        workers["ground_truth"]["changed_files"] == []
+        and workers["ground_truth"]["untracked_files"] == [],
+        "worker changed or untracked files",
+    )
+
+    final_result = synthesis["result"]
+    require(
+        final_result["requested_model"] == trial["orchestrator"]["requested_model"],
+        "orchestrator model mismatch",
+    )
+    require(
+        trial["orchestrator"]["resolved_model"] == final_result["requested_model"],
+        "orchestrator resolved model mismatch",
+    )
+    require(
+        Decimal(str(final_result["duration_seconds"]))
+        == Decimal(str(trial["orchestrator"]["synthesis_latency_seconds"])),
+        "synthesis latency mismatch",
+    )
+    require(
+        final_result["transport"] == "cli" and final_result["exit_code"] == 0,
+        "synthesis exit",
+    )
+    require(
+        synthesis["ground_truth"]["changed_files"] == []
+        and synthesis["ground_truth"]["untracked_files"] == [],
+        "synthesis changed or untracked files",
+    )
+    require(trial["final_contains"] in final, "final marker absent")
+    require(
+        trial["worker"]["resolved_model_marker"] in worker_stderr,
+        "worker model marker absent",
+    )
+    require(
+        trial["orchestrator"]["resolved_model_marker"] in synthesis_stderr,
+        "orchestrator model marker absent",
+    )
+    require(
+        set(enforcement["best_effort_agents"])
+        == {
+            "glm_security_reviewer (opencode): read-only is not applied for this CLI",
+            "minimax_coder (opencode): read-only is not applied for this CLI",
+        },
+        "read-only warning mismatch",
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--artifacts", type=Path)
+    args = parser.parse_args()
+
+    data = load_json(BENCHMARK_DIR / "opencode-go-results.json")
+    schema = load_json(BENCHMARK_DIR / "opencode-go-schema.json")
+    schema_result = validate_schema(data, schema)
+    validate_models(data)
+    validate_rankings(data)
+    validate_roster()
+    validate_trial(data, args.artifacts)
+    cells = sum(len(model["cells"]) for model in data["models"])
+    print(f"benchmark validation: ok; models={len(data['models'])} cells={cells}")
+    print(f"schema validation: {schema_result}")
+    print(f"multi-seat artifacts: {'checked' if args.artifacts else 'not supplied'}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Record 23 fixed task/model probe cells across 9 OpenCode Go models.
- Keep the new five-model, three-task matrix separate from the earlier
  four-model screen, which has no security task.
- Add a JSON Schema, machine-readable results, a proposal-only roster, and the
  routing Memory Handoff.

The post-shadow target seats are MiniMax M3 for cheap routine analysis,
GLM-5.2 for security review, and Kimi K3 as a higher-cost cross-file canary.
MiniMax keeps the current Kimi K2.7 fallback until it completes 20 shadow runs.
A normal Brigade run with GLM-5.2 orchestrating MiniMax M3 returned
`WIRING_OK` in 14.620 seconds with no fallback and no changed files.

This PR does not change Brigade source, an installed roster, authentication, or
production configuration.

## Evidence

- Earlier two-task validator:
  `20260729-183625-work-verify-69cacc`, MiseLedger
  `ec4e976c7c7689a39f91ae97`
- New three-task validator:
  `20260729-194155-work-verify-f0f8e3`, MiseLedger
  `dc8c9568260c63269750f666`
- Schema, roster, and raw multi-seat artifact validator:
  `20260729-201417-work-verify-f959da`, MiseLedger
  `fbb5c10d67e793cfb8050057`
- Pre-push schema, roster, prose, handoff, and content-guard validation:
  `20260729-202212-work-verify-f5cf7c`, MiseLedger
  `303fd908d17d48dbdda80807`

## Limits

- Each task/model cell ran once.
- The prompts disclosed their expected findings, so this is a routing screen,
  not a blind security benchmark.
- Brigade 0.25.1 cannot enforce read-only mode for OpenCode. The probes ran in
  an isolated worktree and recorded zero changed files.
- Brigade and OpenCode did not expose per-call token or cost usage.