### PR TITLE
feat: add crash-safe run recovery checkpoints

### DIFF
--- a/docs/phase-568-slice-5-recovery-checkpoints-plan.md
+++ b/docs/phase-568-slice-5-recovery-checkpoints-plan.md
@@ -1,0 +1,368 @@
+# Issue #568 Slice 5: Recovery Checkpoints Implementation Plan
+
+Implementation plan for the slice 5 boundary of GitHub issue #568
+(https://github.com/escoffier-labs/brigade/issues/568), paired with the design spec
+`docs/phase-568-slice-5-recovery-checkpoints.md`. Prior slice docs:
+`docs/phase-568-slice-3-run-projector.md` and `docs/phase-568-slice-4-shadow-comparison.md`.
+
+Every task is RED first: write the named failing tests that pin the behavior, implement the
+full behavior so the focused suite goes green, then commit. No task lands a placeholder API
+or a not-implemented function, and no commit knowingly leaves a prior test failing. Where a
+prior test must change (the slice-2 implicit-activation tests, the slice-4 version-1
+readiness tests, `test_unmapped_status_writes_run_json_without_journal_event`), the task
+names it and updates it in the same commit.
+
+Module ownership across the six tasks:
+
+- Task 1: `src/brigade/run_checkpoint.py` (new), `src/brigade/run_events.py`, `src/brigade/run_journal.py`. `tests/test_run_checkpoint.py` (new), `tests/test_run_events.py`, `tests/test_run_journal.py`.
+- Task 2: `src/brigade/run_lifecycle.py`, `src/brigade/run_checkpoint.py`, `src/brigade/aboyeur.py`. `tests/test_run_lifecycle.py` (lifecycle and aboyeur hook coverage), `tests/test_run_checkpoint.py`.
+- Task 3: `src/brigade/run_projector.py`, `src/brigade/run_shadow.py`. `tests/test_run_projector.py`, `tests/test_run_shadow.py`.
+- Task 4: `src/brigade/runguard.py`. `tests/test_runguard.py`.
+- Task 5: `src/brigade/runs_cmd.py`, `src/brigade/run_checkpoint.py`. `tests/test_runs_cmd.py`, `tests/test_run_checkpoint.py`.
+- Task 6: `src/brigade/doctor.py`. `tests/test_doctor.py`.
+
+Each task lists its focused verification. The closeout runs the full `./scripts/verify`
+gate (ruff lint, ruff format check, version-sync check, mypy, full pytest with the coverage
+floor). Per the workspace `AGENTS.md`, report the actual result and paste any failure
+verbatim. never claim success you did not observe.
+
+## Task 1: Checkpoint event type, payload validation, crash-safe publish, bounded journal reader
+
+RED. New `tests/test_run_checkpoint.py`:
+
+- `test_checkpoint_event_type_registered_with_closed_payload_keys` (mirrored in
+  `tests/test_run_events.py`): `run_events.EVENT_TYPES` contains
+  `run.snapshot.checkpointed` with exactly `path`, `sha256`, `media_type`, `byte_size`,
+  `privacy_class`, `paired_event_type`.
+- `test_validate_checkpoint_accepts_well_formed_payload`.
+- `test_validate_checkpoint_rejects_malformed_payloads_without_opening_files`: extra key,
+  missing key, wrong `media_type`, wrong `privacy_class`, uppercase or short `sha256`,
+  boolean or out-of-range `byte_size`, absolute or backslash or `..` `path`, filename stem
+  not equal to `sha256`, and a non-null `paired_event_type` that is not a mapped lifecycle
+  event type each raise a bounded `CheckpointError` with a category and no file opened.
+- `test_publish_checkpoint_file_writes_private_file_with_matching_digest`: 0o600 file at
+  `events/recovery-checkpoints/<sha256>.json` under a 0o700 no-follow directory, bytes equal
+  to the input.
+- `test_publish_checkpoint_file_matching_collision_is_noop`: the existing final file is
+  opened no-follow, verified as a regular single-link file, verified byte-equal, and left
+  untouched.
+- `test_publish_checkpoint_file_mismatched_collision_fails_closed`: category
+  `collision-mismatch`, existing file untouched.
+- `test_publish_checkpoint_file_unsafe_collision_fails_closed`: a symlink, non-regular
+  inode, or file with link count above one fails with `collision-unsafe` and is untouched.
+- `test_validate_checkpoint_open_fd_hardening`: symlink, non-regular file, and link count
+  above one refused. size, digest, or writer-canonical-byte mismatch each fail with a
+  bounded category.
+
+New failing tests in `tests/test_run_journal.py`:
+
+- `test_read_journal_bounded_matches_read_journal_on_complete_journal`.
+- `test_read_journal_bounded_refuses_oversize_journal_before_allocation`: a journal larger
+  than `MAX_JOURNAL_BYTES` (8 MiB) is refused via `fstat` before any whole-file allocation
+  and reported as `bound exceeded`.
+- `test_read_journal_bounded_refuses_event_sequence_513`: bounded chunk reads stop at the
+  first complete event whose sequence is 513 (`MAX_JOURNAL_EVENTS` 512), reported as
+  `bound exceeded`.
+
+GREEN. Register `run.snapshot.checkpointed` in `run_events.EVENT_TYPES` with the closed
+payload key set. Create `src/brigade/run_checkpoint.py`: constants
+(`CHECKPOINT_EVENT_TYPE`, `CHECKPOINT_MEDIA_TYPE`, `CHECKPOINT_PRIVACY_CLASS`,
+`CHECKPOINT_DIR_NAME`, `MAX_CHECKPOINT_BYTES` 16 MiB, `MAX_JOURNAL_BYTES` 8 MiB,
+`MAX_JOURNAL_EVENTS` 512), `CheckpointError(RuntimeError)` with a bounded category,
+`checkpoint_dir`, `checkpoint_path`, `validate_checkpoint` (full payload validation before
+any path access, then exactly one no-follow fd with regular-file, link-count, size, digest,
+and writer-canonical-byte equality checks), and the crash-safe publish helper (0o700
+no-follow mkdir, private `tempfile.mkstemp` temp 0o600, write, flush, fsync, atomic
+no-replace `os.link`, on `EEXIST` apply the same no-follow regular single-link fd hardening
+before requiring exact byte and digest equality, else `collision-unsafe` or
+`collision-mismatch`, POSIX-guarded directory fsync mirroring
+`aboyeur._supports_directory_fsync`, unlink temp). Add `run_journal.read_journal_bounded`
+(no-follow open, `fstat` before allocation, refuse above the byte bound before allocation,
+bounded chunk reads, stop at sequence 513). existing `read_journal` stays compatible.
+
+Focused: `pytest tests/test_run_checkpoint.py tests/test_run_events.py
+tests/test_run_journal.py`. Commit: `feat(run-checkpoint): checkpoint event type, payload
+validation, crash-safe publish, bounded journal reader`.
+
+## Task 2: Explicit activation prepare step and fail-closed checkpoint hook
+
+RED. Extend `tests/test_run_lifecycle.py`:
+
+- `test_prepare_lifecycle_journal_creates_private_journal_under_held_lock`: with
+  `lifecycle_journal_requested` pending and the journal absent,
+  `run_lifecycle.prepare_lifecycle_journal` under the matching held `runguard.run_lock`
+  creates 0o700 `events` and 0o600 `lifecycle.jsonl`.
+- `test_prepare_lifecycle_journal_is_noop_when_journal_exists`.
+- `test_prepare_lifecycle_journal_raises_bounded_error_on_io_failure`:
+  `LifecycleJournalError` before any checkpoint or status event is appended.
+- `test_record_lifecycle_transition_requires_existing_journal`: a mapped-status write whose
+  journal is absent fails closed as `LifecycleJournalError`.
+- `test_checkpoint_event_is_sequence_one_on_first_activated_write`: for the first activated
+  write the checkpoint event is sequence 1 and the mapped status event (when the transition
+  is real) is sequence 2. for an unmapped first status the checkpoint is sequence 1 and no
+  status event follows.
+- `test_checkpoint_failure_propagates_and_write_does_not_advance`: a checkpoint file or
+  event failure propagates `CheckpointError` out of `aboyeur._write_json`. the lifecycle
+  append and the `run.json` replace do not run and `run.json` keeps the prior state.
+- Update the slice-2 tests that asserted implicit activation inside the first mapped-status
+  write to assert the explicit prepare step instead.
+- Update `test_unmapped_status_writes_run_json_without_journal_event` to account for the
+  checkpoint event without weakening its no-status-event assertion.
+
+Extend `tests/test_run_checkpoint.py`:
+
+- `test_write_checkpoint_appends_event_and_replays_on_repeat`: first call appends
+  `run.snapshot.checkpointed` with `paired_event_type` set to the exact adjacent mapped
+  event type or null. a repeat of the same write returns the committed event with no new
+  event and no new file.
+- `test_write_checkpoint_same_bytes_different_pairing_uses_distinct_key`: equal checkpoint
+  bytes paired with two different event contracts append distinct checkpoint events
+  without `IdempotencyConflict`.
+
+GREEN. Add `run_lifecycle.prepare_lifecycle_journal` (authority via
+`runguard.is_active_run_owner`, idempotent, creates the empty journal through
+`run_journal.ensure_journal` only when the request is pending under the held lock, raises
+`LifecycleJournalError` on bounded failure). Remove implicit journal creation from
+`record_lifecycle_transition`. it requires the journal to exist and keeps the same-status
+and unmapped-status skip rules. Add `run_checkpoint.write_checkpoint` (ensure activation via
+`prepare_lifecycle_journal`, publish the file through the task-1 helper, append the
+checkpoint event with idempotency key
+`checkpoint:<sha256>:<paired-event-type-or-none>`). Wire the hook in
+`aboyeur._write_json` for `run.json` dict payloads in this order:
+`prepare_lifecycle_journal`, `write_checkpoint`, the existing
+`record_lifecycle_transition`, the existing `localio.write_text_atomic` replace, then the
+existing `run_shadow.record_shadow_comparison`. A `CheckpointError` propagates before the
+lifecycle append and the replace. `runguard._recover_run_artifact` repair writes stay
+uncheckpointed.
+
+Focused: `pytest tests/test_run_lifecycle.py tests/test_run_checkpoint.py`. Commit:
+`feat(run-lifecycle): explicit activation prepare step and fail-closed checkpoint hook`.
+
+## Task 3: Projector status-neutral rule, PROJECTOR_VERSION 2, shadow readiness staleness
+
+RED. Extend `tests/test_run_projector.py`:
+
+- `test_checkpoint_event_is_status_neutral_and_advances_chain_cursor`: a sequence whose tail
+  is `run.snapshot.checkpointed` derives the same status as the prior event, advances
+  `journal_last_sequence` and `journal_last_event_digest`, and passes the
+  contiguous-sequence and digest-link checks.
+- `test_checkpoint_first_event_derives_base_status`.
+- `test_checkpoint_after_unmapped_status_preserves_last_mapped_status`.
+- `test_projector_version_is_two`.
+- Keep `test_empty_events_no_journal_preserves_base_status_and_deep_copies` green unchanged.
+
+Extend `tests/test_run_shadow.py`:
+
+- `test_version_one_shadow_artifact_is_stale`: `check_projection_readiness` treats a
+  version-1 artifact as stale and the gate closes on `evidence-schema-mismatch`.
+- `test_version_two_artifact_with_checkpoint_tail_reads_ready_when_bytes_match`.
+- Update the slice-4 tests that asserted a version-1 artifact reads as ready to assert
+  staleness under version 2.
+
+GREEN. In `run_projector.project_run_snapshot`, add the status-neutral handling for
+`run.snapshot.checkpointed`: no `EVENT_STATUS` row, skip status derivation for it, still
+advance the chain cursor through it. Bump `PROJECTOR_VERSION` to 2. In
+`run_shadow.check_projection_readiness`, require `projector_version` 2. a version-1 artifact
+is stale with reason `evidence-schema-mismatch`.
+
+Focused: `pytest tests/test_run_projector.py tests/test_run_shadow.py`. Commit:
+`feat(run-projector): status-neutral checkpoint rule, PROJECTOR_VERSION 2, shadow readiness
+staleness`.
+
+## Task 4: runguard run_lock_state and the before_terminalize callback
+
+RED. Extend `tests/test_runguard.py`:
+
+- `test_run_lock_state_absent`, `test_run_lock_state_live`, `test_run_lock_state_stale`,
+  `test_run_lock_state_foreign`, `test_run_lock_state_invalid`: the five states, where
+  `live` covers both the current process and a live foreign pid.
+- `test_run_lock_state_never_raises_and_never_mutates`.
+- `test_recover_stale_run_invokes_before_terminalize_after_token_check`: the callback runs
+  after `_claim_stale_lock` and the owner-token check, before `_finish_claimed_recovery`.
+- `test_recover_stale_run_invokes_callback_for_existing_pending_claim`: the same callback
+  runs when targeted recovery resumes an already-renamed `.stale` claim.
+- `test_recover_stale_run_callback_error_restores_claimed_lock_and_raises`: any callback
+  error triggers `_restore_claimed_lock` and a bounded `RunLockError` naming the retained
+  lock path. the claim is not left dangling.
+- `test_pending_activated_claim_without_callback_requires_explicit_recovery`: generic lock
+  acquisition retains an activated-journal claim instead of terminalizing it without
+  checkpoint validation.
+- `test_recover_stale_run_without_callback_terminalizes_as_today`.
+- `test_recover_stale_run_refuses_live_owner_current_and_foreign_pid`: every matching live
+  owner is refused with `RunLockError` and no mutation.
+- `test_recover_run_artifact_persists_lock_recovery_provenance`: when owner metadata
+  contains `_lock_workspace` or `acquired_at`, the activated-journal callback path copies
+  them to `failure.lock_workspace` and `failure.lock_acquired_at` before deleting the claim.
+  absent owner values produce no keys.
+- `test_legacy_recover_run_artifact_does_not_add_recovery_provenance`: no-callback
+  no-journal terminalization remains byte-compatible with the current receipt.
+- Confirm `is_active_run_owner` still recognizes only the current process and stays the
+  normal-writer authority.
+
+GREEN. Add `runguard.run_lock_state(workspace, run_dir)`: read-only, never raises, never
+mutates, returns exactly `absent`, `live`, `stale`, `foreign`, or `invalid` per the spec
+definitions. Add the optional keyword `before_terminalize` to `recover_stale_run` and pass
+it into `_recover_pending_claims`: after either a new stale claim and token check or
+takeover of a matching pending claim, invoke `before_terminalize(owner)`. on any callback
+error call `_restore_claimed_lock` and raise a bounded `RunLockError` naming the retained
+path. otherwise proceed to the existing `_finish_claimed_recovery`. When no callback is
+supplied, `_recover_pending_claims` terminalizes legacy no-journal claims as today but
+retains activated-journal claims and raises a bounded error requiring explicit
+`brigade runs recover`, including from generic lock acquisition. Do not change
+`is_active_run_owner`. Thread an internal `persist_recovery_provenance` flag through
+`_finish_claimed_recovery` to `_recover_run_artifact`, enabled only after a supplied
+`before_terminalize` callback succeeds. On that path, copy optional `_lock_workspace` and
+`acquired_at` owner values into the private failure object as `lock_workspace` and
+`lock_acquired_at`. The default false path keeps legacy no-journal receipts byte-compatible.
+all existing `setdefault` and terminalization semantics stay unchanged.
+
+Focused: `pytest tests/test_runguard.py`. Commit: `feat(runguard): read-only run_lock_state
+and recover_stale_run before_terminalize callback`.
+
+## Task 5: Recovery integration in runs_cmd.recover
+
+RED. Extend `tests/test_runs_cmd.py`:
+
+- `test_runs_recover_restores_missing_run_json_from_latest_checkpoint`: activated journal,
+  dead owner, missing `run.json`. the callback writes byte-identical checkpoint bytes as
+  the intermediate receipt, then exit 0 after existing stale-lock terminalization.
+- `test_runs_recover_restores_corrupt_run_json_and_preserves_original`: corrupt `run.json`
+  renamed to `run.json.corrupt-<uuid>`, checkpoint bytes restored as the intermediate
+  receipt, then exit 0 after terminalization.
+- `test_runs_recover_terminalization_preserves_receipt_fields`: after the checkpoint
+  restore, the existing `_finish_claimed_recovery` terminalization keeps `task`, `roster`,
+  `cwd`, `lock_workspace`, and the failure attribution from the restored bytes.
+- `test_runs_recover_partial_tail_quarantined_then_verified`: a partial final line is
+  quarantined via `run_journal.recover_partial_tail`, the journal re-read, and recovery
+  proceeds only when the truncated chain verifies.
+- `test_runs_recover_fail_closed_on_invalid_latest_checkpoint`: no earlier-checkpoint
+  selection and no legacy fallback for activated-journal runs (exit 2).
+- `test_runs_recover_fail_closed_on_uncovered_tail`, `..._on_chain_break`,
+  `..._on_unknown_event_type`, `..._on_envelope_run_id_mismatch`,
+  `..._on_corrupt_rename_oserror`: each exit 2 with no `run.json` mutation beyond preserving
+  a corrupt file, and the claim restored via `_restore_claimed_lock`.
+- `test_runs_recover_validates_parseable_run_json_before_terminalization`: a valid
+  activated journal and checkpoint are checked, the parseable receipt is not restored over,
+  and existing terminalization proceeds.
+- `test_runs_recover_parseable_run_json_fails_closed_on_invalid_chain_or_coverage`: a
+  parseable nonterminal receipt does not bypass chain, latest-checkpoint, or tail-coverage
+  validation. exit 2, receipt unchanged, claim restored.
+- Keep green, unchanged: `test_runs_recover_refuses_live_owner_without_changing_artifacts`,
+  `test_runs_recover_is_idempotent_for_terminal_run`,
+  `test_runs_recover_clears_matching_dead_lock_after_artifact_was_already_terminal`, the
+  no-journal legacy tests
+  `test_runs_recover_reconstructs_missing_run_json_from_matching_dead_lock` and
+  `test_runs_recover_preserves_and_reconstructs_corrupt_run_json`, and
+  `test_runs_show_surfaces_stale_lock_recovery_and_returns_nonzero` with
+  `test_runs_watch_surfaces_stale_lock_recovery_and_returns_nonzero`.
+
+Extend `tests/test_run_checkpoint.py`:
+
+- `test_latest_checkpoint_event_selects_highest_sequence`.
+- `test_recover_from_checkpoint_returns_repaired_and_already_terminal`.
+
+GREEN. In `runs_cmd.recover`, add the entry gate: resolve the workspace via
+`runguard.resolve_run_lock_workspace`, inspect the lock via `run_lock_state`, refuse a live
+owner (current process or foreign pid) with exit 2 and no mutation, clear a terminal
+`stale-lock-recovery` run as today, report a `foreign` or `invalid` lock without claiming,
+and route no-journal runs to the legacy `runguard.recover_stale_run` path unchanged. For an
+activated-journal run with a dead owner, call `recover_stale_run` with a
+`before_terminalize` callback that restores checkpoint bytes only when `run.json` is missing
+or unparseable, but always validates before terminalization: bounded
+`read_journal_bounded` read, partial-tail quarantine and re-read, chain verification
+(contiguous from sequence 1, linked `previous_digest`, one `run_id` equal to
+`run_dir.name`), highest-sequence checkpoint selection, `validate_checkpoint` with
+open-fd hardening, envelope `run_id` equality against the verified journal `run_id` and
+`run_dir.name`, and coverage check. Only then, for a missing or unparseable receipt,
+preserve corrupt `run.json` and restore via `localio.write_text_atomic`. Add
+`run_checkpoint.latest_checkpoint_event` and `run_checkpoint.recover_from_checkpoint`,
+returning `repaired` after an intermediate restore or `validated` for a parseable receipt.
+The existing terminalization then writes the final stale-lock failure receipt while
+preserving the restored fields. Map `CheckpointError` to exit 2.
+
+Focused: `pytest tests/test_runs_cmd.py tests/test_run_checkpoint.py
+tests/test_runguard.py`. Commit: `feat(runs-cmd): checkpoint recovery integration with
+fail-closed validation`.
+
+## Task 6: Doctor read-only recovery checkpoint check
+
+RED. Extend `tests/test_doctor.py`:
+
+- `test_doctor_includes_recovery_checkpoints_check`: `core_station_checks` emits one
+  aggregate three-field `CheckResult` named `runs: recovery checkpoints`, preserving the
+  existing station callback type.
+- `test_doctor_scans_at_most_50_immediate_run_dirs_newest_first`: no recursive walk, omitted
+  count reported inside the aggregate detail, not as a separate status line.
+- `test_doctor_fail_on_bound_exceeded_without_parsing_further`: journal above 8 MiB or 512
+  events, or checkpoint above 16 MiB, is `FAIL` with `bound exceeded`.
+- `test_doctor_fail_on_partial_tail_without_quarantine`: a partial final journal line is
+  `FAIL` and `recover_partial_tail` is never called.
+- `test_doctor_per_run_verdicts`: `OK` for a matching checkpoint, `WARN` for a missing or
+  unparseable `run.json` with a valid latest checkpoint, `FAIL` for a malformed chain,
+  dangling or invalid latest checkpoint, digest or size or content mismatch, envelope
+  `run_id` mismatch, uncovered tail, or bound excess, and `OK` for a live owner per
+  `run_lock_state`.
+- `test_doctor_accepts_valid_stale_recovery_terminal_receipt`: a parseable,
+  recovered receipt is `OK` only when Doctor reconstructs the entire expected object from
+  the checkpoint using `_recover_run_artifact`'s transformation and gets exact equality.
+  It replays the conditional `cwd`, `lock_workspace`, and `started_at` `setdefault` calls
+  from `failure.lock_workspace` and `failure.lock_acquired_at`, which Task 4 persists before
+  the lock disappears.
+  The reconstruction cross-checks `error`, `failure.detail`, integer `owner_pid`,
+  `prior_status`, the three recovery timestamps, optional `seat` or `seats` attribution,
+  the fixed phase and kind, the stamped schema, and every untouched checkpoint field.
+  Another parseable checkpoint mismatch is `FAIL`.
+- `test_doctor_checkpoint_check_never_mutates`: journal, checkpoint files, and `run.json`
+  are byte-identical after the check. detail lists up to 8 failing run names and `--full`
+  lists every run.
+
+GREEN. Add the scoped check to `doctor.core_station_checks` using only the core `OK` /
+`WARN` / `FAIL` / `MANUAL` vocabulary, `run_lock_state` for the live-owner verdict,
+`read_journal_bounded` for journal reads, and `run_checkpoint.validate_checkpoint` for the
+fd-first 16 MiB checkpoint bound plus `latest_checkpoint_event` for the per-run verdict.
+Accept a checkpoint-byte mismatch only when a private Doctor helper reconstructs the full
+expected stale-recovery object from the checkpoint and candidate recovery timestamp and
+owner pid, replaying the persisted workspace and acquisition-time `setdefault` inputs as
+pinned by the test above. all other parseable mismatches are `FAIL`. Return a
+three-field `CheckResult`. do not change `station.py` or its station callback contract.
+Legacy and no-journal runs are omitted and counted in the aggregate detail. Doctor never
+quarantines, repairs, or mutates, and has no wall-clock timeout.
+
+Focused: `pytest tests/test_doctor.py tests/test_run_checkpoint.py`. Commit:
+`feat(doctor): read-only recovery checkpoint scoped check`.
+
+## Closeout: full verification, outcome capture, MiseLedger export, memory handoff
+
+1. Re-run every focused suite from tasks 1 through 6, then run the full `./scripts/verify`
+   gate. Report the actual result and paste any failure verbatim. If the gate fails, fix the
+   code, not the tests. never weaken, skip, or delete a test to make it pass, and say so
+   explicitly before touching a test that is itself wrong.
+2. Record the verification outcome through the `brigade work verify` flow so the slice
+   receipt is captured and attributed.
+3. Export the slice evidence through MiseLedger.
+4. Write the memory handoff to `.claude/memory-handoffs/` per the workspace `AGENTS.md`
+   template: the fail-closed checkpoint hook ordering, the crash-safe temp-plus-hard-link
+   publish pattern, the runguard authority split (`is_active_run_owner` for the normal
+   writer, read-only `run_lock_state` for inspection, `recover_stale_run` with
+   `before_terminalize` for the claim), the `PROJECTOR_VERSION` 2 one-way door, the doctor
+   read-only bounds, and any root causes or gotchas found during implementation, failures
+   included.
+
+Rollback constraints. Each task is a separate conventional commit on the slice branch. If a
+task is found wrong after merge, revert that commit. Reverting task 2 leaves `run.json`
+writes uncheckpointed but byte-identical to today. Reverting task 3 alone is unsafe (a
+version-2 projector without the registered checkpoint event type fails closed on any
+activated journal that already carries a checkpoint event). roll tasks 2 and 3 back together
+and drop the activated journals. Reverting tasks 4 through 6 disables recovery and doctor
+reporting without affecting the live writer. Never `git push --no-verify`. the content-guard
+pre-push hook must pass.
+
+Slice 6 boundary. Slice 5 lands the recovery substrate only. Slice 6 (issue #568 step 6)
+cuts the journal over to the authoritative live writer for new runs, gated per run by the
+slice-4 readiness gate plus the issue parity measurement criteria. No slice-6 work is
+started in this plan.
+
+Citations. GitHub issue #568 (https://github.com/escoffier-labs/brigade/issues/568). Spec:
+`docs/phase-568-slice-5-recovery-checkpoints.md`. Prior slices:
+`docs/phase-568-slice-3-run-projector.md`, `docs/phase-568-slice-4-shadow-comparison.md`.
+No code is implemented in these documents.

--- a/docs/phase-568-slice-5-recovery-checkpoints.md
+++ b/docs/phase-568-slice-5-recovery-checkpoints.md
@@ -1,0 +1,461 @@
+# Issue #568 Slice 5: Recovery Checkpoints
+
+Reviewed design specification for the approved slice 5 boundary of GitHub issue #568
+(https://github.com/escoffier-labs/brigade/issues/568). Slices 1 through 4 landed the append-only journal kernel
+(`run_journal`, `run_events`), opt-in lifecycle journaling (`run_lifecycle`, wired into `aboyeur._write_json`), the pure
+run snapshot projector (`run_projector`), and shadow comparison plus the readiness gate (`run_shadow`. see
+`docs/phase-568-slice-3-run-projector.md` and `docs/phase-568-slice-4-shadow-comparison.md`).
+
+Slice 5 is a recovery-plane bridge. It durably checkpoints the exact `run.json` bytes the legacy writer is about to
+commit, before the atomic replace, and teaches `brigade runs recover` and `brigade doctor` to verify the journal chain
+and rebuild a missing or corrupt `run.json` from the latest checkpoint. The legacy writer stays authoritative for live
+runs. Slice 6 is the authoritative writer cutover, gated by the slice-4 readiness gate plus the issue parity
+measurement criteria. this slice does not cut over to the journal as the live writer.
+
+Source contracts, all standard-library only: `run_events` (`EVENT_TYPES`, `canonical_bytes`, `request_digest`,
+`validate_event`, `_HEX64`, `MAX_DIAGNOSTIC_LEN` 240, `MAX_LINE_BYTES` 16384, `CanonicalizationError`). `run_journal`
+(`RunEvent`, `JournalReport`, `read_journal`, `read_journal_bounded`, `append_event`, `ensure_journal`,
+`recover_partial_tail`, `_open_nofollow`, `_mkdir_private`, `_DIR_MODE` 0o700, `_FILE_MODE` 0o600). `run_lifecycle`
+(`STATUS_EVENT_TYPE`, `record_lifecycle_transition`, `prepare_lifecycle_journal`, `LifecycleJournalError`, the
+activation model, same-status and unmapped-status skip rules). `run_projector` (`PROJECTOR_VERSION`, `EVENT_STATUS`,
+`project_run_snapshot`, `encode_snapshot_bytes`, `RunProjection`, the `ProjectionError` subclasses). `run_shadow`
+(`record_shadow_comparison`, `check_projection_readiness`, `shadow_artifact_path`, the fail-open-writer /
+fail-closed-gate split). `aboyeur._write_json`, `aboyeur._supports_directory_fsync`. `localio` (`write_text_atomic`,
+`write_text_exclusive`, `write_json`, `file_sha256`). `runguard` (`run_lock`, `recover_stale_run`, `run_lock_state`,
+`_recover_run_artifact`, `_finish_claimed_recovery`, `_claim_stale_lock`, `_restore_claimed_lock`, `_read_lock_owner`,
+`_lock_is_stale`, `_pid_is_active`, `is_active_run_owner`, `resolve_run_lock_workspace`, `RunLockError`).
+`runs_cmd.recover` (exit codes 0 and 2). `doctor` (`OK`, `WARN`, `FAIL`, `MANUAL`, `core_station_checks`,
+`CheckResult`).
+
+## Boundary
+
+New module: `src/brigade/run_checkpoint.py`. Three integration points:
+
+1. A checkpoint hook in `aboyeur._write_json`. The hook runs only after `run_lifecycle.prepare_lifecycle_journal`
+   establishes activation for the current write. Activation is established when either (a) the run directory already
+   carries an activated journal (`events/lifecycle.jsonl` exists), or (b) `lifecycle_journal_requested` is pending in
+   `run.json` and the call holds the matching run lock. Pre-lock request bootstrap (`cli/run.py`) still only sets the
+   request flag and never activates. The hook runs before the existing `record_lifecycle_transition` call. A
+   checkpoint file or event failure is fail-closed: the bounded `CheckpointError` propagates out of `_write_json`, the
+   lifecycle append and the `run.json` replace do not run, and the live write does not advance. The checkpoint is a
+   recovery-plane gate on the live write, not a best-effort side effect.
+2. A recovery integration in `runs_cmd.recover` that reads the journal and the latest checkpoint and performs exactly
+   one repair mutation, restoring `run.json` from the checkpoint under the stale-lock claim.
+3. A doctor check in `doctor.core_station_checks`, fully read-only.
+
+The checkpoint never reads the live `run.json` after the replace, never appends to the journal during recovery, and
+never mutates `run.json` outside the stale-lock claim. It is a write-ahead record of the exact bytes about to be
+committed, content-addressed by their SHA-256.
+
+### Coverage boundary, decided
+
+- The checkpoint hook fires for every `aboyeur._write_json` call whose target is named `run.json`, whose payload is a
+  dict, and for which `prepare_lifecycle_journal` has just established activation (the journal exists when the hook
+  runs). This covers the aboyeur writers and `run_resume._resume_locked`. `runguard._recover_run_artifact` writes
+  `run.json` through `localio.write_json` directly and is not checkpointed. that write is the recovery repair itself.
+- The checkpoint is emitted for every activated-journal `run.json` write, including same-status detail refreshes and
+  unmapped statuses (`dry-run`, `incomplete`, `artifact-collection`), wider than the lifecycle journal, which skips
+  same-status and unmapped writes, so the checkpoint is the only durable record that covers them. Flag-off and legacy
+  run directories create no checkpoint and observe byte-identical behavior. legacy no-journal recovery remains the only
+  path for runs without `events/lifecycle.jsonl`.
+
+## Activation model
+
+Activation is the durable fact that `events/lifecycle.jsonl` exists for a run. Slice 2 activated implicitly inside the
+first mapped-status write. Slice 5 replaces that with an explicit, separate prepare step so the first checkpoint can be
+sequence 1.
+
+- Pre-lock bootstrap (`cli/run.py` before `runguard.run_lock`): writes `lifecycle_journal_requested` set to true into
+  `run.json` when the env flag is set. It never creates the journal and never appends. Unchanged from slice 2.
+- Under the matching held run lock, `run_lifecycle.prepare_lifecycle_journal` validates authority with
+  `runguard.is_active_run_owner(workspace, run_dir)`, and, when `lifecycle_journal_requested` is pending and the journal
+  is absent, creates the empty private journal (0o700 `events`, 0o600 `lifecycle.jsonl`) via `run_journal.ensure_journal`.
+  It is idempotent and raises `LifecycleJournalError` on any bounded I/O or canonicalization failure, before any
+  checkpoint or status event is appended.
+- The hook calls `prepare_lifecycle_journal` first, then writes the checkpoint. For the first activated write the
+  checkpoint event is sequence 1, the optional mapped status event (for example `run.created` when the first status is
+  `started`) is sequence 2, then the atomic `run.json` replace. For an unmapped first status the checkpoint is sequence
+  1 and no status event follows. For later writes the checkpoint is sequence N and the mapped status event, when the
+  transition is real, is sequence N+1.
+- `record_lifecycle_transition` no longer creates the journal. It requires the journal to exist and appends the mapped
+  status event under the active run lock, with the existing skip rules. A mapped-status write whose journal is absent
+  fails closed as `LifecycleJournalError`, which the hook propagates.
+
+## Event contract
+
+A checkpoint is one event appended to the existing `events/lifecycle.jsonl` journal, under the existing
+`brigade.run_event.v1` envelope. No new schema. The event type is `run.snapshot.checkpointed`, added to
+`run_events.EVENT_TYPES` with a closed per-type payload key set.
+
+Payload (flat, allowlisted):
+
+| Key | Type | Value |
+| --- | --- | --- |
+| `path` | str | relative checkpoint path `events/recovery-checkpoints/<sha256>.json` |
+| `sha256` | str | lowercase 64-char hex SHA-256 of the checkpointed `run.json` bytes |
+| `media_type` | str | `application/vnd.brigade.run+json` |
+| `byte_size` | int | length of the checkpointed bytes in bytes |
+| `privacy_class` | str | `private` |
+| `paired_event_type` | str or null | exact mapped lifecycle event type expected immediately after the checkpoint, or null for same-status and unmapped writes |
+
+`media_type` and `privacy_class` are fixed exact values. `path` is relative to the run directory so the event stays
+portable across `--output-dir` layouts and the projector never carries an absolute path. `paired_event_type` is the
+`run_lifecycle.STATUS_EVENT_TYPE` mapping for the status in the checkpointed bytes when the write is a real mapped
+transition, and null for a same-status refresh or an unmapped status. The checkpoint content is the exact `run.json`
+bytes as encoded by `aboyeur._write_json` (sorted keys, two-space indent, one trailing newline, UTF-8), not the compact
+`run_events.canonical_bytes` encoding, so the intermediate recovery restore is byte-identical before existing
+stale-lock terminalization writes the final failure receipt. The enclosing checkpoint event's envelope
+`run_id` must equal the single verified journal `run_id` and `run_dir.name`. no `run_id` key is carried in the payload.
+
+## Payload validation
+
+`validate_checkpoint` validates the full payload before any path access. A payload is valid only when all of the
+following hold. any deviation raises `CheckpointError` with a bounded category diagnostic and no path is opened.
+
+- The payload key set is exactly `path`, `sha256`, `media_type`, `byte_size`, `privacy_class`, `paired_event_type`.
+  Extra or missing keys fail closed.
+- `media_type` equals `application/vnd.brigade.run+json`.
+- `privacy_class` equals `private`.
+- `sha256` is a lowercase 64-character hex string (the `run_events._HEX64` shape).
+- `byte_size` is an int, not a bool, in the closed range 0 through `MAX_CHECKPOINT_BYTES` (16 MiB).
+- `path` is exactly `events/recovery-checkpoints/<sha256>.json` with the declared `sha256`, no leading slash, no `..`
+  components, no backslashes, and the filename stem equals `sha256`.
+- `paired_event_type` is null or a string in `run_events.EVENT_TYPES` that is a row in
+  `run_lifecycle.STATUS_EVENT_TYPE` (a mapped lifecycle status event type).
+
+Diagnostics are bounded to `run_events.MAX_DIAGNOSTIC_LEN` and carry a category only, never a raw path or payload value.
+
+## Storage
+
+Path: `<run-dir>/events/recovery-checkpoints/<sha256>.json`. The `recovery-checkpoints` directory is created 0o700 by
+`run_journal`'s no-follow mkdir helper. Each checkpoint file is a 0o600 regular file published crash-safely from the
+existing `localio.write_text_exclusive` pattern, not by a direct `O_EXCL` open on the final path:
+
+1. Create the `recovery-checkpoints` directory 0o700 (no-follow mkdir).
+2. `tempfile.mkstemp` a private temp file in the same directory (0o600), write the exact writer bytes, flush, fsync the
+   temp fd.
+3. Publish by `os.link(temp, final)` (atomic, no-replace hard link). On `EEXIST`, do not write the final path. Open the
+   existing final file through the same no-follow, regular-file, single-link fd checks used by
+   `validate_checkpoint`, then require exact byte and digest equality with the declared `sha256`: a safe matching
+   collision is a no-op. an unsafe inode or mismatched collision raises `CheckpointError` with category
+   `collision-unsafe` or `collision-mismatch`.
+4. fsync the `recovery-checkpoints` directory on POSIX, guarded like `aboyeur._supports_directory_fsync`. on non-POSIX
+   it is skipped.
+5. unlink the temp file.
+
+The atomic no-replace `os.link` publication is required and fails closed on platforms that do not support it. A crash
+before step 3 leaves only the private temp. a crash between step 3 and step 5 leaves the final file durable and an
+orphan temp (the next run unlinks either). The `events` directory stays 0o700 (slice 1), `recovery-checkpoints` is
+0o700, and each checkpoint file is 0o600. `.brigade/runs/` is gitignored, so checkpoints are never tracked.
+
+## Idempotency
+
+The checkpoint event idempotency key is
+`checkpoint:<sha256>:<paired-event-type-or-none>`. It stays below
+`run_events.MAX_IDEMPOTENCY_KEY_LEN` for every mapped event type.
+`run_journal.append_event` dedupes by idempotency key plus request digest:
+same-key same-digest returns the committed event with no write. same-key different-digest raises
+`IdempotencyConflict`. Binding the pairing to the key means replaying the same write is a complete no-op (no new
+event, no new file, the existing final file verified byte-equal), while the same bytes with a different adjacent
+event contract use a distinct key and append a distinct checkpoint event.
+
+## Write ordering
+
+For a `run.json` write where the hook is active, the hook reorders the existing steps so the checkpoint is durable
+before the legacy `run.json` replace:
+
+1. Prepare: `run_lifecycle.prepare_lifecycle_journal` ensures the empty journal exists under the active run lock
+   (no-op when already activated, establishes activation when the request is pending under the held lock).
+2. Checkpoint file: publish the exact writer bytes to `events/recovery-checkpoints/<sha256>.json` via the crash-safe
+   temp-and-hard-link pattern above, fsync the file and (on POSIX) the checkpoint directory.
+3. Checkpoint event: append `run.snapshot.checkpointed` to `events/lifecycle.jsonl` (fsync). On idempotency replay the
+   final file already exists byte-equal and the event already exists digest-equal. both are no-ops.
+4. Mapped status event: when the status is in `run_lifecycle.STATUS_EVENT_TYPE` and the transition is real,
+   `record_lifecycle_transition` appends the mapped status event (fsync). Unmapped and same-status writes append no
+   status event. This is the existing slice-2 behavior, unchanged except it now runs after the checkpoint event.
+5. Atomic `run.json` replacement: `localio.write_text_atomic` replaces `run.json` with the same bytes the checkpoint
+   holds. Then `run_shadow.record_shadow_comparison` runs after the replace, unchanged from slice 4.
+
+The invariant: after step 3 fsyncs, the checkpoint file and event are durable. after step 5, `run.json` holds the same
+bytes. A crash between 3 and 5 leaves a durable checkpoint whose bytes have not landed in `run.json`. recovery
+restores them. A crash after 5 leaves `run.json` matching the checkpoint. The hook is fail-closed: a `CheckpointError`
+from step 2 or 3 propagates out of `aboyeur._write_json` before step 4 and step 5, so a checkpoint subsystem failure
+stops the live write.
+
+## Projector rule
+
+`run_projector` gains one status-neutral rule for `run.snapshot.checkpointed`: the event carries no status of its own,
+so projection preserves the current derived status and advances only `journal_last_sequence` and
+`journal_last_event_digest`. When the final event is `run.snapshot.checkpointed`, the derived `status` is the status
+the sequence would derive at the prior event (or the base status when the checkpoint is the first event). `EVENT_STATUS`
+gains no row for the checkpoint type. the projector skips status derivation for it and still advances the chain cursor
+through it for the contiguous-sequence and digest-link checks.
+
+`PROJECTOR_VERSION` bumps from 1 to 2. Recognized event semantics change (the projector now derives status through a
+status-neutral checkpoint event), so version-1 shadow evidence is stale. The slice-4 shadow artifact carries
+`projector_version`. a version-1 artifact is treated as stale by `check_projection_readiness`, and the readiness gate
+closes on `evidence-schema-mismatch` until a fresh comparison lands under version 2. Regression coverage asserts that a
+version-1 artifact no longer reads as ready and that a version-2 artifact with a checkpoint tail reads as ready when the
+bytes match. The slice-3 invariant still holds when the tail is a checkpoint event: a checkpoint following an
+unmapped-status write preserves the last mapped status, and shadow comparison is unaffected because the projected status
+comes from the last mapped event.
+
+## Recovery
+
+`runs_cmd.recover` is extended for activated-journal runs. The legacy no-journal path
+(`runguard.recover_stale_run` plus `_recover_run_artifact`) is unchanged and remains the only path for runs without
+`events/lifecycle.jsonl`. `is_active_run_owner` is unchanged and remains only the normal-writer authority. it does not
+gate foreign recovery. Slice 5 adds two narrow runguard APIs:
+
+- `run_lock_state(workspace, run_dir)`: a read-only predicate returning a state for doctor/operator inspection:
+  `absent` (no lock directory), `live` (lock exists and the owner pid is the current process or a live foreign pid),
+  `stale` (lock exists, owner pid is dead, and `owner.json` records a matching `run_dir`), `foreign` (lock exists and
+  `owner.json` records a non-matching `run_dir`), or `invalid` (lock directory present but `owner.json` missing or
+  unparseable). These five states are the whole vocabulary. It never raises and never mutates.
+- `recover_stale_run(cwd, run_dir, *, before_terminalize=None)`: runguard owns the stale claim. It claims the visible
+  stale lock via `_claim_stale_lock`, verifies the owner token, and, when `before_terminalize` is provided, invokes
+  `before_terminalize(owner)` before `_finish_claimed_recovery`. It also passes the callback through
+  `_recover_pending_claims` when resuming an already-renamed `.stale` claim. If the callback raises for validation,
+  partial-tail repair, corrupt preservation, bounded-read, or any other reason, either path calls
+  `_restore_claimed_lock` and raises a bounded `RunLockError` naming the retained lock path. Only a successful callback
+  proceeds to `_finish_claimed_recovery`. With no callback a legacy no-journal claim terminalizes exactly as today.
+  `_recover_pending_claims` never auto-terminalizes a claim whose owner points to an activated journal when no callback
+  is supplied. it retains the claim and raises a bounded error requiring explicit `brigade runs recover`. This prevents
+  a later generic lock acquisition from bypassing checkpoint validation after a crash between claim and callback. It
+  rejects every matching live owner (current process or foreign pid) with `RunLockError` and no mutation, and
+  `runs_cmd.recover` relies on that refusal.
+
+### Entry gate
+
+Recovery resolves the run directory, reads `run.json` (tolerating a missing or unparseable file), resolves the
+workspace from the run receipt (`runguard.resolve_run_lock_workspace`), and inspects the run lock via `run_lock_state`:
+a live owner (state `live`), whether a foreign pid or the current process, returns exit 2 with the existing
+`run owner process is still active` message and no mutation
+(`test_runs_recover_refuses_live_owner_without_changing_artifacts`, plus a separate current-process test). a terminal
+`run.json` whose `failure_phase` is `stale-lock-recovery` clears the matching dead lock as today (exit 0)
+(`test_runs_recover_is_idempotent_for_terminal_run`,
+`test_runs_recover_clears_matching_dead_lock_after_artifact_was_already_terminal`). a no-journal run routes to the
+legacy `runguard.recover_stale_run` path unchanged. a foreign or invalid lock (state `foreign` or `invalid`) is
+reported and not claimed.
+
+### Stale-lock claim and checkpoint restore
+
+When the owner is dead and the run has an activated journal, recovery calls `runguard.recover_stale_run` with a
+`before_terminalize` callback. The callback always validates the activated journal and latest checkpoint, including
+when `run.json` is parseable. only the restore mutation is conditional on a missing or unparseable `run.json`. It
+reads `events/lifecycle.jsonl` with `read_journal_bounded` (no more than `MAX_JOURNAL_BYTES` or `MAX_JOURNAL_EVENTS`
+complete events), quarantines a partial final tail via `run_journal.recover_partial_tail` (write-once quarantine,
+truncate to the last complete line) and re-reads, then verifies the chain is contiguous from sequence 1, every
+`previous_digest` links, and every event shares one `run_id` equal to the run directory name. A partial line that is
+not the final line is a chain break. if after quarantine the journal still has a partial tail or chain errors, it fails
+closed.
+
+The callback then selects the highest-sequence `run.snapshot.checkpointed` event. It is authoritative and is
+validated via `validate_checkpoint` (payload validation first, then open-fd hardening). Any invalid latest checkpoint
+fails closed: no earlier-checkpoint selection and no legacy fallback for activated-journal runs. The tail must be
+covered (see Coverage semantics). an uncovered tail fails closed. If `run.json` is missing or unparseable, the
+callback renames a corrupt `run.json` to `run.json.corrupt-<uuid>` (best-effort. on `OSError`, fail closed) and writes
+the checkpoint bytes to `run.json` via `localio.write_text_atomic`. This intermediate repair is byte-identical to the
+checkpoint. The callback never repairs over a parseable `run.json`, which is left untouched. After successful
+validation and any intermediate repair, `_finish_claimed_recovery` terminalizes the receipt as a stale-lock failure,
+so the final `run.json` is expected to differ from the checkpoint in terminal fields while preserving `task`,
+`roster`, `cwd`, `lock_workspace`, and the restored failure attribution inputs. On the activated-journal callback
+path only, slice 5 copies the lock owner's non-secret recovery inputs into the private failure object before deleting
+the claim:
+`failure.lock_workspace` carries `owner["_lock_workspace"]` when present, and
+`failure.lock_acquired_at` carries `owner["acquired_at"]` when present. These values let Doctor replay
+`_recover_run_artifact`'s `setdefault` behavior after the lock directory is gone. Legacy no-journal terminalization
+does not add these fields and keeps its existing byte contract. The enclosing
+checkpoint event's envelope `run_id` must equal the single verified journal `run_id` and `run_dir.name`. a mismatch
+fails closed.
+
+### Open-fd hardening and fail-closed cases
+
+`validate_checkpoint` opens exactly one file descriptor on the referenced path after payload validation. The fd must
+not be a symlink (`O_NOFOLLOW` via `run_journal._open_nofollow`), must be a regular file, and must have a link count
+of exactly one. The declared `byte_size` must match the actual file size. The file's SHA-256 must match the declared
+`sha256` and the filename. The bytes must be valid UTF-8, parse as a JSON object, and equal the `aboyeur._write_json`
+canonical encoding of that object (sorted keys, two-space indent, one trailing newline), the writer-byte equality
+check, not `run_events.canonical_bytes`. Any failure raises `CheckpointError` with a bounded category.
+
+Recovery fails closed (exit 2, no `run.json` mutation beyond preserving a corrupt file) when: the journal carries an
+unknown schema or event type not in `run_events.EVENT_TYPES` (after partial-tail quarantine). the chain breaks
+(sequence gap, duplicate, `previous_digest` mismatch, mixed `run_id`). the latest checkpoint event is missing,
+dangling (file absent), or invalid. the enclosing checkpoint event's envelope `run_id` mismatches the journal `run_id`
+or `run_dir.name`. the journal tail is not covered by the latest checkpoint. or the corrupt-`run.json` rename raises
+`OSError`. There is no legacy fallback for activated-journal runs. the legacy `_recover_run_artifact` path is reached
+only when the run has no `events/lifecycle.jsonl`.
+
+## Coverage semantics
+
+The latest checkpoint event at sequence N covers either itself as the tail or exactly one immediately following event
+whose `event_type` equals the checkpoint's `paired_event_type` and whose derived status equals the status in the
+checkpointed `run.json` bytes. When `paired_event_type` is null, the checkpoint covers only itself as the tail.
+Anything else is uncovered-tail FAIL.
+
+Through the normal write path, a mapped-transition write appends the checkpoint at N with `paired_event_type` set to
+the mapped status event type, and the paired status event at N+1. An unmapped or same-status write appends only the
+checkpoint at N with `paired_event_type` null. So the journal tail is always either a checkpoint event whose
+`paired_event_type` is null (covered, tail is N), or a single status event immediately preceded by its covering
+checkpoint whose `paired_event_type` names that status event type and whose derived status matches the checkpointed
+bytes (covered, tail is N+1).
+
+Uncovered-tail FAIL fires when the events after the latest valid checkpoint are not exactly the paired status event
+of that checkpoint: a status event whose preceding checkpoint never landed, two status events after the last
+checkpoint, a checkpoint at N followed by a status event at N+1 whose `event_type` is not the checkpoint's
+`paired_event_type`, or a status event at N+1 whose derived status does not equal the status in the checkpointed
+`run.json` bytes. Through the normal path this cannot fire. it is defense in depth against direct journal mutation.
+
+## Crash matrix
+
+| Crash window | State after crash | Recovery action |
+| --- | --- | --- |
+| Before checkpoint temp fsync | no new checkpoint file or event, `run.json` unchanged | Validate the previously referenced checkpoint and covered tail. If none exists on the first activated write, fail closed (exit 2), except the existing already-terminal stale-recovery cleanup. |
+| After temp fsync, before hard-link publish | no new final file or event, orphan temp, `run.json` unchanged | Validate the previously referenced checkpoint and covered tail. The orphan temp is private and ignored. If no prior checkpoint exists, fail closed. |
+| After hard-link publish, before checkpoint event fsync | new final file durable but unreferenced, `run.json` unchanged | Ignore the orphan checkpoint file and validate the previously referenced checkpoint and covered tail. If no prior checkpoint exists, fail closed. |
+| After checkpoint event fsync, before status event fsync | checkpoint file and event durable, no status event, `run.json` unchanged | Recovery selects the checkpoint (latest valid). Tail is the checkpoint event, covered. Restore checkpoint bytes as the intermediate receipt, then existing stale-lock terminalization writes the final failure receipt. |
+| After status event fsync, before `run.json` replace | checkpoint file, event, and status event durable. `run.json` unchanged | Recovery selects the checkpoint (N), tail is the paired status event at N+1, covered. Restore checkpoint bytes as the intermediate receipt, then terminalize. the status event and checkpoint agree (same write). |
+| During or after `run.json` replace | `run.json` is the old or new bytes (atomic replace is all-or-nothing). after shadow comparison, fully recorded | If `run.json` is parseable, validate the journal and checkpoint without repair, then terminalize. If missing or unparseable, restore checkpoint bytes as the intermediate receipt, then terminalize. After shadow comparison the gate is current. before it, the slice-4 gate closes via `journal-ahead-of-evidence`, correct. |
+| Checkpoint hard-link collision, mismatched bytes | `EEXIST` on `os.link`. existing final file has different bytes | Writer fails closed: `CheckpointError` propagates and the live write does not advance. Doctor reports the collision. Recovery treats the mismatched file as an invalid latest checkpoint and fails closed. |
+
+## Doctor check
+
+`doctor.core_station_checks` gains one scoped check, `runs: recovery checkpoints`, using the core `OK` / `WARN` /
+`FAIL` / `MANUAL` vocabulary. Doctor is fully read-only: it never quarantines, repairs, or mutates the journal,
+checkpoint files, or `run.json`. It scans at most 50 immediate non-symlink run directories under
+`<target>/.brigade/runs/` in newest-first order with no recursive walk, and reads only `run.json`,
+`events/lifecycle.jsonl`, and the latest referenced checkpoint file. The journal goes through
+`read_journal_bounded` (no more than `MAX_JOURNAL_BYTES` 8 MiB or `MAX_JOURNAL_EVENTS` 512 complete events). The
+checkpoint goes through `validate_checkpoint`, whose fd-first size check enforces `MAX_CHECKPOINT_BYTES` 16 MiB before
+reading the body. A larger journal or checkpoint is `FAIL` with `bound exceeded` and is not parsed further. No
+wall-clock timeout. A partial final journal line is `FAIL` without quarantine. Doctor never calls
+`recover_partial_tail`. The omitted run count (runs beyond the 50 cap, plus legacy and no-journal runs out of scope) is
+reported inside the aggregate check detail, not as a separate status line.
+
+Per-run verdict for activated runs: `OK` when `run.json` parses, the chain verifies, and the latest checkpoint
+validates with bytes equal to the current `run.json` writer bytes. A parseable recovered receipt is also `OK` only
+when Doctor can reconstruct it exactly from the checkpoint object using `_recover_run_artifact`'s transformation.
+It first replays `setdefault("cwd")` and `setdefault("lock_workspace")` from the candidate's optional
+`failure.lock_workspace`, and `setdefault("started_at")` from its optional `failure.lock_acquired_at`. It then
+derives `prior_status` and optional `seat` or `seats` attribution from the checkpoint, takes the candidate's integer
+`failure.owner_pid` and valid ISO `failure.recovered_at`, requires that timestamp to equal `status_started_at` and
+`finished_at`, and derives `error` and `failure.detail` as
+`run owner process <owner_pid> is no longer active`, set the fixed stale-recovery phase and
+`owner-process-exited` kind, stamp the run receipt schema, and require exact object equality. This cross-check covers
+all terminal fields (`error`, `detail`, `owner_pid`, `prior_status`, timestamps, and attribution) and all untouched
+checkpoint fields. The journal and latest checkpoint must still validate. Any other parseable checkpoint mismatch is
+`FAIL`. `WARN` applies when `run.json` is
+missing or unparseable but a valid latest checkpoint exists (repairable). `FAIL` also covers a malformed chain,
+partial tail, dangling or invalid latest checkpoint, digest/size/content mismatch, envelope `run_id` mismatch,
+uncovered tail, or any bound exceeded. `OK` (live owner) applies when `run_lock_state` returns `live` and the owner pid
+is live, with no mutation. Legacy and no-journal runs are omitted (counted in the aggregate). The check emits one
+aggregate three-field `CheckResult` whose detail summarizes counts (ok / warn / fail / omitted) and lists up to 8
+failing run names. `--full` lists every run.
+
+## CLI exit codes
+
+`brigade runs recover` exit codes are unchanged: 0 for success (repaired from checkpoint, or already terminal, or
+legacy repair succeeded for a no-journal run). 2 for invalid run, live owner, or unsafe (any fail-closed case above,
+including a checkpoint collision, chain break, invalid latest checkpoint, envelope `run_id` mismatch, uncovered tail,
+or a `before_terminalize` callback failure that retained the claim). `brigade runs watch` and `brigade runs show`
+surface stale-lock recovery exactly as today. the checkpoint repair is transparent to them because the existing
+terminalizer receives the same complete receipt it would have read from a healthy pre-crash write. This preserves the
+`test_runs_show_surfaces_stale_lock_recovery_and_returns_nonzero` and
+`test_runs_watch_surfaces_stale_lock_recovery_and_returns_nonzero` contracts.
+
+## API
+
+The new `run_checkpoint` module exposes constants (`CHECKPOINT_EVENT_TYPE`, `CHECKPOINT_MEDIA_TYPE`,
+`CHECKPOINT_PRIVACY_CLASS`, `CHECKPOINT_DIR_NAME`, `MAX_CHECKPOINT_BYTES`, `MAX_JOURNAL_BYTES`,
+`MAX_JOURNAL_EVENTS`). `CheckpointError(RuntimeError)` (bounded, carries a category). `checkpoint_dir(run_dir)`.
+`checkpoint_path(run_dir, sha256)`. `write_checkpoint(run_dir, run_json_bytes, paired_event_type)` (ensure activation
+via `prepare_lifecycle_journal`, publish the checkpoint file crash-safely, append the checkpoint event. returns the
+appended or replayed event. raises `CheckpointError` on any failure). `validate_checkpoint(run_dir, event)`
+(validate the payload, then open and verify the referenced file. returns the checkpoint bytes. raises `CheckpointError`
+on any validation failure). `latest_checkpoint_event(report)` (highest-sequence `run.snapshot.checkpointed` event
+from a `JournalReport`, or `None`). and `recover_from_checkpoint(run_dir)` (verify the journal, select and validate
+the latest checkpoint for every activated run, and, only when `run.json` is missing or unparseable, preserve the
+corrupt file and restore checkpoint bytes as the intermediate receipt. returns `repaired` or `validated`, or raises
+`CheckpointError` mapped by the caller to exit 2). `run_events.EVENT_TYPES` gains the
+`run.snapshot.checkpointed` row with the closed payload key set.
+`run_projector.project_run_snapshot` gains the status-neutral handling for the checkpoint event type and
+`PROJECTOR_VERSION` becomes 2. `run_lifecycle` gains `prepare_lifecycle_journal`. `run_journal` gains
+`read_journal_bounded`, used by recovery and doctor: it opens the journal no-follow (`_open_nofollow`), `fstat`s the fd
+before any whole-file allocation, refuses a size above `MAX_JOURNAL_BYTES` (8 MiB) before allocation, reads in bounded
+chunks, and stops or fails at the first complete event whose sequence is 513. a journal over the byte or event bound is
+reported as `bound exceeded` and not parsed further. Existing `read_journal` stays compatible. `runguard` gains
+`run_lock_state` and the optional `before_terminalize` parameter on `recover_stale_run`. No other public API changes.
+
+## Invariants
+
+1. Write-ahead: the checkpoint file and event are durable before the atomic `run.json` replace for every activated-journal write.
+2. Fail-closed hook: a checkpoint file or event failure propagates `CheckpointError` and stops the live write before the lifecycle append and the `run.json` replace.
+3. Content addressing: the checkpoint filename and event `sha256` are the SHA-256 of the stored bytes. a collision requires byte equality or fails closed.
+4. Crash-safe publish: the final checkpoint path is mutated only by an atomic `os.link` from a private fsynced temp. an existing final file is accepted only after exact byte and digest equality. No direct `O_EXCL` partial-write poison reaches the final path.
+5. Platform-guarded directory fsync: the checkpoint directory is fsynced on POSIX and skipped on non-POSIX, mirroring `aboyeur._supports_directory_fsync`. The atomic no-replace `os.link` publication is required and fails closed where unsupported.
+6. Writer authority: the legacy writer stays authoritative for live runs. the checkpoint stores the writer's own encoded bytes.
+7. Recovery authority: `recover_stale_run` owns the stale claim and rejects every matching live owner (current process or foreign pid) with no mutation. only the claim winner repairs.
+8. Callback-or-restore: a `before_terminalize` callback runs for both a visible stale lock and an already-renamed pending claim. if it raises for any reason, `_restore_claimed_lock` runs and a bounded `RunLockError` names the retained path. A pending activated-journal claim without a callback is retained for explicit recovery.
+9. Exact intermediate restore: when `run.json` is missing or unparseable, recovery restores byte-identical checkpoint bytes before existing stale-lock terminalization writes the final failure receipt. it never repairs over a parseable `run.json`.
+10. Recoverable provenance: activated-journal callback terminalization copies optional lock workspace and acquisition time into the private failure object before deleting the claim, so Doctor can reconstruct the final receipt exactly. legacy no-journal terminalization remains byte-compatible.
+11. No repair journaling: recovery appends no journal events during repair.
+12. Fail closed: unknown schema or type, chain break, missing or invalid latest checkpoint, envelope `run_id` mismatch, uncovered tail, and bound excess all fail closed with exit 2.
+13. Legacy preserved: no-journal recovery is unchanged and is the only legacy fallback.
+14. Privacy: checkpoint payloads carry only relative path, hex digest, fixed media type, byte size, fixed privacy class, and paired event type. No `run_id` and no `run.json` field values enter the event payload.
+15. Bounded: doctor and recovery cap checkpoint bytes at 16 MiB and journal bytes at 8 MiB or 512 complete events.
+16. Projector version door: `PROJECTOR_VERSION` is 2. version-1 shadow evidence is stale.
+
+## Blast radius
+
+Exact blast-radius names from the code index. The checkpoint hook sits inside `aboyeur._write_json`, whose indexed production
+callers are `write_sidecar_revision`, `record_artifact_collection`, `record_run_termination`, `record_dispatch_stage`,
+`record_result_processing`, `record_run_start`, `run`, and `run_resume._resume_locked`.
+`record_lifecycle_transition`'s only indexed production caller is `aboyeur._write_json`. `_recover_run_artifact`'s is
+`_finish_claimed_recovery`. `project_run_snapshot` and `core_station_checks` have no indexed production callers (they are
+reached through CLI dispatch and, for the projector, through `run_shadow`). slice 5 adds the recovery and doctor callers,
+both read-only. `run_lock_state` and the `before_terminalize` callback path on `recover_stale_run` are new runguard entry
+points reached by `runs_cmd.recover` and `doctor`.
+
+Affected tests (names this slice must keep green or extend): `test_runs_recover_*` in `tests/test_runs_cmd.py`
+(including `test_runs_recover_reconstructs_missing_run_json_from_matching_dead_lock` and
+`test_runs_recover_preserves_and_reconstructs_corrupt_run_json`, which exercise the legacy fallback that stays unchanged
+for no-journal runs), `test_runs_show_surfaces_stale_lock_recovery_and_returns_nonzero`,
+`test_runs_watch_surfaces_stale_lock_recovery_and_returns_nonzero`,
+`test_unmapped_status_writes_run_json_without_journal_event` (updated to account for the checkpoint event without
+weakening its no-status-event assertion), and `test_empty_events_no_journal_preserves_base_status_and_deep_copies` (the
+status-neutral checkpoint rule must keep the empty-sequence projection unchanged). The slice-2 activation tests in
+`tests/test_run_lifecycle.py` that assert implicit activation inside the first mapped-status write are updated to the
+explicit prepare step. The slice-4 shadow tests that assert a version-1 artifact reads as ready are updated to assert
+staleness under version 2.
+
+## Compatibility
+
+- Runtime behavior for readers is unchanged: `run.json` bytes, journal bytes for status transitions, CLI output, and
+  `runs watch`, `show`, `steer`, `interrupt`, `recover`, and `resume` behavior are exactly as before for no-journal
+  runs. For activated-journal runs, the only new on-disk artifacts are the `events/recovery-checkpoints/<sha256>.json`
+  files and one extra `run.snapshot.checkpointed` event per `run.json` write, both additive and private.
+- A legacy run directory without `events/lifecycle.jsonl` is untouched: no checkpoint is created, recovery uses the
+  legacy path, and doctor omits it. The four reserved fields from slices 3 and 4 (`projector_version`,
+  `journal_present`, `journal_last_sequence`, `journal_last_event_digest`) are still not written to `run.json`. the
+  checkpoint stores `run.json` bytes, not derived fields.
+- A new run directory still exposes a byte-compatible `run.json` to the previous Brigade release. The checkpoint event
+  is a new event type in the existing `brigade.run_event.v1` registry.
+- One-way journal-format door: old `run.json` readers remain compatible (the `run.json` byte contract is unchanged), but
+  old Brigade releases that predate slice 5 do not recognize `run.snapshot.checkpointed`. their `run_journal` validation,
+  projector, and recovery reject an activated journal carrying that event as an unknown type, so a slice-5 run read by an
+  old release fails closed rather than silently misprojecting. Rolling an activated-journal run back to an old release is
+  unsupported. rolling forward again is fine because the journal is append-only and the old release never mutated it.
+
+## Non-goals and deferrals
+
+- Authoritative writer cutover: treating the journal as the live writer for new runs is slice 6 (issue #568 step 6),
+  gated per run by the slice-4 readiness gate plus the issue parity measurement criteria. The checkpoint plane landed
+  here is the recovery substrate slice 6 builds on.
+- GC, retention, or compaction of checkpoint files. checkpoint pruning, deduplication across runs. and a
+  `brigade runs gc` command. Checkpoints follow whole-run retention in this slice. the rest is post-slice-6 operator
+  tooling.
+- Evidence reset tooling after a mapping fix (an operator action, slice 6).
+- Journaling or projecting the unmapped statuses (`dry-run`, `incomplete`, `artifact-collection`) and event enrichment.
+  the checkpoint covers their bytes and the projector still derives the last mapped status.
+- Checkpointing `runguard._recover_run_artifact` repair writes (they are the recovery plane, not live transitions).
+- Any new top-level harness, depth, or include manifest.

--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -2334,30 +2334,41 @@ def record_run_start(
     lifecycle_requested = existing_requested or (
         not run_json_exists and run_lifecycle.is_lifecycle_journaling_enabled()
     )
-    _write_json(
-        output_dir / "run.json",
-        _run_payload(
-            task=task,
-            cwd=cwd,
-            lock_workspace=lock_workspace if lock_workspace is not None else cwd,
-            roster=roster,
-            dry_run=dry_run,
-            read_only=read_only,
-            status="started",
-            started_at=started_at,
-            output_dir=output_dir,
-            code_graph=CodeGraphBrief(attached=False),
-            drift_impact=DriftImpactBrief(attached=False),
-            evidence=EvidenceBrief(attached=False),
-            codex_transport=codex_transport or roster.codex_transport,
-            worker=worker,
-            include_git=False,
-            scheduler=(
-                {"requested": scheduler, "used": None, "fallback_reason": None} if scheduler is not None else None
+    # The first run.json write activates the lifecycle journal and publishes a
+    # recovery checkpoint BEFORE the atomic run.json replacement. If that final
+    # replacement fails, durable journal/checkpoint state already exists without
+    # a run.json, so ``_terminalize_run_lifecycle.terminate_existing`` cannot
+    # terminalize (run.json is absent) and the lock must be retained for
+    # ``brigade runs recover``. Translate the bounded lifecycle write failures
+    # to ``RetainRunLockError`` so ``runguard.run_lock`` keeps the lock instead
+    # of releasing it and orphaning the recovery state.
+    try:
+        _write_json(
+            output_dir / "run.json",
+            _run_payload(
+                task=task,
+                cwd=cwd,
+                lock_workspace=lock_workspace if lock_workspace is not None else cwd,
+                roster=roster,
+                dry_run=dry_run,
+                read_only=read_only,
+                status="started",
+                started_at=started_at,
+                output_dir=output_dir,
+                code_graph=CodeGraphBrief(attached=False),
+                drift_impact=DriftImpactBrief(attached=False),
+                evidence=EvidenceBrief(attached=False),
+                codex_transport=codex_transport or roster.codex_transport,
+                worker=worker,
+                include_git=False,
+                scheduler=(
+                    {"requested": scheduler, "used": None, "fallback_reason": None} if scheduler is not None else None
+                ),
+                lifecycle_journal_requested=True if lifecycle_requested else None,
             ),
-            lifecycle_journal_requested=True if lifecycle_requested else None,
-        ),
-    )
+        )
+    except (OSError, run_lifecycle.LifecycleJournalError, run_checkpoint.CheckpointError) as exc:
+        raise runguard.RetainRunLockError(f"failed to write initial run receipt: {exc}") from exc
     _write_json(output_dir / "roster.json", _roster_payload(roster))
 
 

--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -27,6 +27,7 @@ from . import graphtrail_delta
 from . import localio
 from . import proc, receipt_schema, runguard
 from . import run_control
+from . import run_checkpoint
 from . import run_lifecycle
 from . import run_shadow
 from .result_integrity import validate_final_output
@@ -494,14 +495,36 @@ def _write_json(path: Path, payload: object) -> None:
     if path.name == "run.json" and isinstance(payload, dict):
         status = payload.get("status")
         if isinstance(status, str) and status:
+            run_dir = path.parent
+            workspace = runguard.resolve_run_lock_workspace(payload, run_dir)
+            # Exact order: activate the journal, publish the recovery
+            # checkpoint, append the lifecycle status transition, then
+            # atomically replace run.json, then record the shadow comparison.
+            # A CheckpointError from write_checkpoint fails BEFORE the
+            # lifecycle append and BEFORE run.json replacement.
+            run_lifecycle.prepare_lifecycle_journal(
+                run_dir,
+                workspace=workspace,
+                incoming_snapshot=payload,
+            )
+            encoded = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+            run_checkpoint.write_checkpoint(
+                run_dir,
+                encoded.encode("utf-8"),
+                workspace=workspace,
+                paired_event_type=run_lifecycle.STATUS_EVENT_TYPE.get(status),
+            )
             run_lifecycle.record_lifecycle_transition(
-                path.parent,
+                run_dir,
                 status=status,
                 # The receipt payload identifies the lock workspace
                 # (lock_workspace or cwd); the run directory layout does not.
-                workspace=runguard.resolve_run_lock_workspace(payload, path.parent),
+                workspace=workspace,
                 incoming_snapshot=payload,
             )
+            localio.write_text_atomic(path, encoded)
+            run_shadow.record_shadow_comparison(run_dir, payload)
+            return
     localio.write_text_atomic(path, json.dumps(payload, indent=2, sort_keys=True) + "\n")
     if path.name == "run.json" and isinstance(payload, dict):
         run_shadow.record_shadow_comparison(path.parent, payload)
@@ -1952,7 +1975,7 @@ def record_artifact_collection(
     payload["artifact_collection"] = collection
     try:
         _write_json(run_path, receipt_schema.stamp_run_receipt(payload))
-    except (OSError, run_lifecycle.LifecycleJournalError) as exc:
+    except (OSError, run_lifecycle.LifecycleJournalError, run_checkpoint.CheckpointError) as exc:
         raise runguard.RetainRunLockError(f"failed to update run receipt after artifact collection: {exc}") from exc
 
 
@@ -2025,7 +2048,7 @@ def record_run_termination(
             )
     try:
         _write_json(run_path, receipt_schema.stamp_run_receipt(payload))
-    except (OSError, run_lifecycle.LifecycleJournalError) as exc:
+    except (OSError, run_lifecycle.LifecycleJournalError, run_checkpoint.CheckpointError) as exc:
         raise runguard.RetainRunLockError(f"failed to write terminal run receipt: {exc}") from exc
 
 
@@ -2053,7 +2076,7 @@ def record_dispatch_stage(output_dir: Path, *, stage: int, seats: tuple[str, ...
     )
     try:
         _write_json(run_path, receipt_schema.stamp_run_receipt(payload))
-    except (OSError, run_lifecycle.LifecycleJournalError) as exc:
+    except (OSError, run_lifecycle.LifecycleJournalError, run_checkpoint.CheckpointError) as exc:
         raise runguard.RetainRunLockError(f"failed to write dispatch stage receipt: {exc}") from exc
 
 
@@ -2082,7 +2105,7 @@ def record_result_processing(output_dir: Path, *, seat: str) -> None:
     payload.pop("active_seats", None)
     try:
         _write_json(run_path, receipt_schema.stamp_run_receipt(payload))
-    except (OSError, run_lifecycle.LifecycleJournalError) as exc:
+    except (OSError, run_lifecycle.LifecycleJournalError, run_checkpoint.CheckpointError) as exc:
         raise runguard.RetainRunLockError(f"failed to record result-processing phase: {exc}") from exc
 
 

--- a/src/brigade/doctor.py
+++ b/src/brigade/doctor.py
@@ -9,7 +9,10 @@ import shlex
 import shutil
 from datetime import date, datetime, timezone
 from pathlib import Path
-from typing import List, Sequence, Tuple
+from typing import TYPE_CHECKING, List, Sequence, Tuple
+
+if TYPE_CHECKING:
+    from . import run_journal
 
 from .budgets import (
     BOOTSTRAP_BUDGETS,
@@ -313,7 +316,7 @@ def _recovery_run_has_live_owner(target: Path, run_dir: Path) -> bool:
     return runguard._owner_matches_run(owner, resolved)
 
 
-def _recovery_journal_chain_reason(report: object, run_id: str) -> str | None:
+def _recovery_journal_chain_reason(report: run_journal.JournalReport, run_id: str) -> str | None:
     if report.partial_tail is not None:
         return "partial tail"
     if report.chain_errors:
@@ -397,7 +400,7 @@ def _reconstruct_stale_lock_recovery_receipt(
     never written a stale-lock-recovery receipt, so no reconstruction can
     match.
     """
-    from brigade import receipt_schema, runguard
+    from brigade import runguard
 
     failure = candidate.get("failure")
     if not isinstance(failure, dict):
@@ -445,58 +448,15 @@ def _reconstruct_stale_lock_recovery_receipt(
     else:
         prior_status = "artifact-unavailable"
 
-    failure_attribution: dict[str, object] = {}
-    stored_status = payload.get("status")
-    active_seats = payload.get("active_seats")
-    phase_owner = payload.get("phase_owner")
-    if stored_status == "dispatching" and isinstance(active_seats, list):
-        seats = [seat for seat in active_seats if isinstance(seat, str) and seat]
-        if len(seats) == 1:
-            failure_attribution["seat"] = seats[0]
-        elif seats:
-            failure_attribution["seats"] = seats
-    if not failure_attribution and isinstance(phase_owner, str) and phase_owner:
-        failure_attribution["seat"] = phase_owner
-    if not failure_attribution:
-        worker = payload.get("worker")
-        orchestrator = payload.get("orchestrator")
-        if isinstance(worker, str) and worker:
-            failure_attribution["seat"] = worker
-        elif isinstance(orchestrator, str) and orchestrator:
-            failure_attribution["seat"] = orchestrator
-
-    workspace = failure.get("lock_workspace")
-    if isinstance(workspace, str) and workspace:
-        payload.setdefault("cwd", workspace)
-        payload.setdefault("lock_workspace", workspace)
-    acquired_at = failure.get("lock_acquired_at")
-    if isinstance(acquired_at, str) and acquired_at:
-        payload.setdefault("started_at", acquired_at)
-
-    failure_payload: dict[str, object] = {
-        "phase": "stale-lock-recovery",
-        "kind": "owner-process-exited",
-        "detail": detail,
-        "owner_pid": owner_pid,
-        "prior_status": prior_status,
-        "recovered_at": recovered_at,
-        **failure_attribution,
-    }
-    if isinstance(workspace, str) and workspace:
-        failure_payload["lock_workspace"] = workspace
-    if isinstance(acquired_at, str) and acquired_at:
-        failure_payload["lock_acquired_at"] = acquired_at
-    payload.update(
-        {
-            "status": "failed",
-            "status_started_at": recovered_at,
-            "finished_at": recovered_at,
-            "error": detail,
-            "failure_phase": "stale-lock-recovery",
-            "failure": failure_payload,
-        }
+    return runguard._build_stale_lock_recovery_receipt(
+        payload,
+        owner_pid=owner_pid,
+        recovered_at=recovered_at,
+        prior_status=prior_status,
+        lock_workspace=failure.get("lock_workspace"),
+        lock_acquired_at=failure.get("lock_acquired_at"),
+        persist_recovery_provenance=True,
     )
-    return receipt_schema.stamp_run_receipt(payload)
 
 
 def _check_claude_work_loop(target: Path) -> CheckResult | None:

--- a/src/brigade/doctor.py
+++ b/src/brigade/doctor.py
@@ -92,7 +92,411 @@ def core_station_checks(ctx: DoctorContext) -> List[CheckResult]:
     if "hermes" in ctx.harnesses:
         checks.extend(_check_hermes(ctx.target))
     checks.extend(_check_orphan_inboxes(ctx.target, ctx.harnesses))
+    checks.append(_check_recovery_checkpoints(ctx.target))
     return checks
+
+
+_RECOVERY_CHECKPOINTS_NAME = "runs: recovery checkpoints"
+_RECOVERY_CHECKPOINTS_SCAN_LIMIT = 50
+_RECOVERY_CHECKPOINTS_FAIL_PREVIEW = 8
+
+
+def _check_recovery_checkpoints(target: Path, *, full: bool = False) -> CheckResult:
+    """Read-only aggregate verdict for activated-journal recovery checkpoints."""
+    runs_root = target / ".brigade" / "runs"
+    all_dirs, scan_omitted = _immediate_run_dirs(runs_root)
+    scanned = all_dirs[:_RECOVERY_CHECKPOINTS_SCAN_LIMIT]
+    scan_omitted += len(all_dirs) - len(scanned)
+
+    counts = {"ok": 0, "warn": 0, "fail": 0, "omitted": scan_omitted}
+    failing_runs: list[tuple[str, str]] = []
+
+    for run_dir in scanned:
+        verdict, reason = _recovery_checkpoint_run_verdict(target, run_dir)
+        if verdict == "omitted":
+            counts["omitted"] += 1
+        elif verdict == "ok":
+            counts["ok"] += 1
+        elif verdict == "warn":
+            counts["warn"] += 1
+        else:
+            counts["fail"] += 1
+            failing_runs.append((run_dir.name, reason))
+
+    if counts["fail"]:
+        status = FAIL
+    elif counts["warn"]:
+        status = WARN
+    else:
+        status = OK
+
+    preview_limit = len(failing_runs) if full else _RECOVERY_CHECKPOINTS_FAIL_PREVIEW
+    detail = f"ok={counts['ok']} warn={counts['warn']} fail={counts['fail']} omitted={counts['omitted']}"
+    if failing_runs:
+        shown = failing_runs[:preview_limit]
+        labels = [f"{name} ({reason})" for name, reason in shown]
+        detail = f"{detail}; failures: {', '.join(labels)}"
+        if not full and len(failing_runs) > preview_limit:
+            detail = f"{detail}, ... {len(failing_runs) - preview_limit} more"
+    return (status, _RECOVERY_CHECKPOINTS_NAME, detail)
+
+
+def _immediate_run_dirs(runs_root: Path) -> tuple[List[Path], int]:
+    """Return ``(run dirs sorted newest-first, omitted_count)``.
+
+    Guards ``iterdir``/``is_dir``/``is_symlink``/``stat`` races so a vanishing
+    or unreadable entry never crashes Doctor. Entries that vanish between
+    discovery and ``stat`` are counted as omitted where discoverable.
+    """
+    try:
+        if not runs_root.is_dir():
+            return [], 0
+    except OSError:
+        return [], 0
+    try:
+        entries = list(runs_root.iterdir())
+    except OSError:
+        return [], 0
+    sortable: list[tuple[float, str, Path]] = []
+    omitted = 0
+    for entry in entries:
+        try:
+            if entry.is_symlink():
+                continue
+            if not entry.is_dir():
+                continue
+        except OSError:
+            omitted += 1
+            continue
+        try:
+            mtime = entry.stat().st_mtime
+        except OSError:
+            omitted += 1
+            continue
+        sortable.append((mtime, entry.name, entry))
+    sortable.sort(key=lambda item: (item[0], item[1]), reverse=True)
+    return [item[2] for item in sortable], omitted
+
+
+def _recovery_checkpoint_run_verdict(target: Path, run_dir: Path) -> tuple[str, str]:
+    from brigade import run_checkpoint, run_journal, run_lifecycle, runguard
+
+    journal_path = run_lifecycle._journal_path(run_dir)
+    try:
+        if not journal_path.is_file():
+            return "omitted", "no-journal"
+    except OSError:
+        return "omitted", "no-journal"
+
+    # Resolve the live-owner workspace from parseable run metadata so a run
+    # launched with a custom --output-dir verifies against the lock its owner
+    # actually holds. Remain fail-safe for missing/unparseable metadata.
+    run_meta_preview = _read_run_meta_fail_safe(run_dir / "run.json")
+    live_workspace = target
+    if run_meta_preview is not None:
+        resolved = runguard.resolve_run_lock_workspace(run_meta_preview, run_dir, fallback=target)
+        if resolved is not None:
+            live_workspace = resolved
+    lock_state = runguard.run_lock_state(live_workspace, run_dir)
+    if lock_state == "live" and _recovery_run_has_live_owner(live_workspace, run_dir):
+        return "ok", "live owner"
+
+    run_id = run_dir.name
+    try:
+        report = run_journal.read_journal_bounded(journal_path)
+    except run_journal.RunJournalError as exc:
+        if "bound exceeded" in exc.diagnostic:
+            return "fail", "bound exceeded"
+        return "fail", exc.diagnostic
+    except OSError as exc:
+        return "fail", f"journal unreadable: {type(exc).__name__}"
+
+    chain_reason = _recovery_journal_chain_reason(report, run_id)
+    if chain_reason is not None:
+        return "fail", chain_reason
+
+    latest = run_checkpoint.latest_checkpoint_event(report.events)
+    if latest is None:
+        return "fail", "no checkpoint event in journal"
+    if latest.run_id != run_id:
+        return "fail", "run_id mismatch"
+
+    bound_reason = _recovery_checkpoint_bound_reason(run_dir, latest)
+    if bound_reason is not None:
+        return "fail", bound_reason
+
+    try:
+        checkpoint_bytes = run_checkpoint.validate_checkpoint(run_dir, latest)
+    except run_checkpoint.CheckpointError as exc:
+        if _recovery_checkpoint_error_is_bound_exceeded(exc):
+            return "fail", "bound exceeded"
+        return "fail", exc.diagnostic
+    except OSError as exc:
+        return "fail", f"checkpoint unreadable: {type(exc).__name__}"
+
+    try:
+        checkpoint_obj = run_checkpoint._parse_checkpoint_object(checkpoint_bytes)
+        run_checkpoint._verify_coverage(report.events, latest, checkpoint_obj)
+    except run_checkpoint.CheckpointError as exc:
+        return "fail", exc.diagnostic
+
+    run_json_path = run_dir / "run.json"
+    try:
+        run_json_present = run_json_path.is_file()
+    except OSError:
+        run_json_present = False
+    if not run_json_present:
+        return "warn", "run.json missing with valid checkpoint"
+
+    try:
+        run_bytes = run_json_path.read_bytes()
+    except OSError:
+        return "fail", "run.json present but unreadable"
+
+    try:
+        parsed = json.loads(run_bytes.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError, RecursionError):
+        return "warn", "run.json unparseable with valid checkpoint"
+    run_meta = parsed if isinstance(parsed, dict) else None
+    if run_meta is None:
+        return "warn", "run.json unparseable with valid checkpoint"
+
+    if run_bytes == checkpoint_bytes:
+        return "ok", "checkpoint bytes match run.json"
+
+    expected = _reconstruct_stale_lock_recovery_receipt(checkpoint_obj, run_meta)
+    if expected is not None and expected == run_meta:
+        return "ok", "stale-lock-recovery receipt matches checkpoint reconstruction"
+
+    return "fail", "run.json does not match checkpoint"
+
+
+def _read_run_meta_fail_safe(run_json_path: Path) -> dict[str, object] | None:
+    """Best-effort read of ``run.json`` for live-owner workspace resolution.
+
+    Collapses every failure mode (missing, unreadable, unparseable) into
+    ``None`` so the caller can fall back to ``target``; the precise
+    missing/unreadable/unparseable verdict is handled later in the verdict.
+    """
+    try:
+        if not run_json_path.is_file():
+            return None
+    except OSError:
+        return None
+    try:
+        raw = run_json_path.read_bytes()
+    except OSError:
+        return None
+    try:
+        parsed = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError, RecursionError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _recovery_run_has_live_owner(target: Path, run_dir: Path) -> bool:
+    from brigade import runguard
+
+    if runguard.run_lock_state(target, run_dir) != "live":
+        return False
+    try:
+        lock_path = runguard.lock_path(target)
+        owner = runguard._read_lock_owner(lock_path)
+    except runguard.RunGuardError:
+        return False
+    except OSError:
+        return False
+    try:
+        resolved = run_dir.expanduser().resolve()
+    except (OSError, RuntimeError):
+        resolved = run_dir
+    return runguard._owner_matches_run(owner, resolved)
+
+
+def _recovery_journal_chain_reason(report: object, run_id: str) -> str | None:
+    if report.partial_tail is not None:
+        return "partial tail"
+    if report.chain_errors:
+        return "malformed chain"
+    if not report.events:
+        return "empty journal"
+    expected_sequence = 1
+    expected_previous: str | None = None
+    for event in report.events:
+        if event.sequence != expected_sequence:
+            return "malformed chain"
+        if event.sequence == 1:
+            if event.previous_digest is not None:
+                return "malformed chain"
+        elif event.previous_digest != expected_previous:
+            return "malformed chain"
+        if event.run_id != run_id:
+            return "run_id mismatch"
+        expected_sequence = event.sequence + 1
+        expected_previous = event.event_digest
+    return None
+
+
+def _recovery_checkpoint_bound_reason(run_dir: Path, event: object) -> str | None:
+    import os
+
+    from brigade import run_checkpoint, run_journal
+
+    payload = event.payload if hasattr(event, "payload") else event
+    if not isinstance(payload, dict):
+        return None
+    byte_size = payload.get("byte_size")
+    if isinstance(byte_size, int) and byte_size > run_checkpoint.MAX_CHECKPOINT_BYTES:
+        return "bound exceeded"
+    sha = payload.get("sha256")
+    if not isinstance(sha, str):
+        return None
+    final_path = run_checkpoint.checkpoint_path(run_dir, sha)
+    if not final_path.exists():
+        return None
+    try:
+        fd = run_journal._open_nofollow(final_path, os.O_RDONLY)
+    except (run_journal.RunJournalError, OSError):
+        return None
+    try:
+        info = os.fstat(fd)
+        if info.st_size > run_checkpoint.MAX_CHECKPOINT_BYTES:
+            return "bound exceeded"
+    except OSError:
+        return None
+    finally:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+    return None
+
+
+def _recovery_checkpoint_error_is_bound_exceeded(exc: object) -> bool:
+    from brigade import run_checkpoint
+
+    if not isinstance(exc, run_checkpoint.CheckpointError):
+        return False
+    if "bound exceeded" in exc.diagnostic:
+        return True
+    return exc.category == "byte-size"
+
+
+def _reconstruct_stale_lock_recovery_receipt(
+    checkpoint_obj: dict[str, object],
+    candidate: dict[str, object],
+) -> dict[str, object] | None:
+    """Pure replay of ``runguard._recover_run_artifact`` terminalization fields.
+
+    ``prior_status`` is derived from the checkpoint object's ``status`` exactly
+    as runguard derives it from the pre-terminalization run.json (with an
+    ``artifact-unavailable`` fallback when the status is absent/empty). The
+    candidate's ``failure.prior_status`` is never trusted; a forged value
+    diverges from the reconstruction and fails the verdict. A terminal
+    checkpoint status means runguard would have returned ``"terminal"`` and
+    never written a stale-lock-recovery receipt, so no reconstruction can
+    match.
+    """
+    from brigade import receipt_schema, runguard
+
+    failure = candidate.get("failure")
+    if not isinstance(failure, dict):
+        return None
+    if candidate.get("failure_phase") != "stale-lock-recovery":
+        return None
+    if candidate.get("status") != "failed":
+        return None
+
+    owner_pid = failure.get("owner_pid")
+    if isinstance(owner_pid, bool) or not isinstance(owner_pid, int):
+        return None
+    recovered_at = failure.get("recovered_at")
+    if not isinstance(recovered_at, str) or not recovered_at:
+        return None
+    try:
+        datetime.fromisoformat(recovered_at.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if candidate.get("status_started_at") != recovered_at or candidate.get("finished_at") != recovered_at:
+        return None
+
+    detail = f"run owner process {owner_pid} is no longer active"
+    if candidate.get("error") != detail:
+        return None
+    if failure.get("detail") != detail:
+        return None
+    if failure.get("phase") != "stale-lock-recovery":
+        return None
+    if failure.get("kind") != "owner-process-exited":
+        return None
+
+    try:
+        payload = json.loads(json.dumps(checkpoint_obj))
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+
+    raw_status = payload.get("status")
+    if isinstance(raw_status, str) and raw_status:
+        if raw_status not in runguard._NONTERMINAL_RUN_STATUSES:
+            return None
+        prior_status = raw_status
+    else:
+        prior_status = "artifact-unavailable"
+
+    failure_attribution: dict[str, object] = {}
+    stored_status = payload.get("status")
+    active_seats = payload.get("active_seats")
+    phase_owner = payload.get("phase_owner")
+    if stored_status == "dispatching" and isinstance(active_seats, list):
+        seats = [seat for seat in active_seats if isinstance(seat, str) and seat]
+        if len(seats) == 1:
+            failure_attribution["seat"] = seats[0]
+        elif seats:
+            failure_attribution["seats"] = seats
+    if not failure_attribution and isinstance(phase_owner, str) and phase_owner:
+        failure_attribution["seat"] = phase_owner
+    if not failure_attribution:
+        worker = payload.get("worker")
+        orchestrator = payload.get("orchestrator")
+        if isinstance(worker, str) and worker:
+            failure_attribution["seat"] = worker
+        elif isinstance(orchestrator, str) and orchestrator:
+            failure_attribution["seat"] = orchestrator
+
+    workspace = failure.get("lock_workspace")
+    if isinstance(workspace, str) and workspace:
+        payload.setdefault("cwd", workspace)
+        payload.setdefault("lock_workspace", workspace)
+    acquired_at = failure.get("lock_acquired_at")
+    if isinstance(acquired_at, str) and acquired_at:
+        payload.setdefault("started_at", acquired_at)
+
+    failure_payload: dict[str, object] = {
+        "phase": "stale-lock-recovery",
+        "kind": "owner-process-exited",
+        "detail": detail,
+        "owner_pid": owner_pid,
+        "prior_status": prior_status,
+        "recovered_at": recovered_at,
+        **failure_attribution,
+    }
+    if isinstance(workspace, str) and workspace:
+        failure_payload["lock_workspace"] = workspace
+    if isinstance(acquired_at, str) and acquired_at:
+        failure_payload["lock_acquired_at"] = acquired_at
+    payload.update(
+        {
+            "status": "failed",
+            "status_started_at": recovered_at,
+            "finished_at": recovered_at,
+            "error": detail,
+            "failure_phase": "stale-lock-recovery",
+            "failure": failure_payload,
+        }
+    )
+    return receipt_schema.stamp_run_receipt(payload)
 
 
 def _check_claude_work_loop(target: Path) -> CheckResult | None:
@@ -262,6 +666,8 @@ def run(
 ) -> int:
     ctx = build_context(target, harness)
     checks = _gather_checks(ctx)
+    if full:
+        checks = _replace_recovery_check_with_full(checks, ctx.target)
     if not operator:
         checks = _filter_target_scoped_checks(checks)
     if json_output:
@@ -279,6 +685,27 @@ def run(
     if not operator:
         print("  scope: target workspace only (pass --operator for host-global checks)")
     return _report(checks, full=full, target=ctx.target, operator=operator)
+
+
+def _replace_recovery_check_with_full(
+    checks: List[ScopedCheckResult],
+    target: Path,
+) -> List[ScopedCheckResult]:
+    """Swap the bounded recovery-checkpoint aggregate for the exhaustive one.
+
+    The public station callback always emits the bounded (8-preview) verdict so
+    its contract stays unchanged; ``run --full`` re-runs the check with
+    ``full=True`` and substitutes it in place, preserving the original scope.
+    """
+    full_status, _name, full_detail = _check_recovery_checkpoints(target, full=True)
+    replaced: List[ScopedCheckResult] = []
+    for check in checks:
+        status, name, detail, scope = _normalize_scoped_check(check)
+        if name == _RECOVERY_CHECKPOINTS_NAME:
+            replaced.append(_scoped_check(full_status, name, full_detail, scope))
+        else:
+            replaced.append((status, name, detail, scope))
+    return replaced
 
 
 def _gather_checks(ctx: DoctorContext) -> List[ScopedCheckResult]:

--- a/src/brigade/run_checkpoint.py
+++ b/src/brigade/run_checkpoint.py
@@ -371,11 +371,16 @@ def _cleanup_temp(tmp_path: Path, cp_dir: Path, primary: CheckpointError | None)
     cleanup_err: CheckpointError | None = None
     unlinked = False
     try:
-        tmp_path.unlink(missing_ok=True)
+        os.unlink(tmp_path)
+    except FileNotFoundError:
+        # Preserve Path.unlink(missing_ok=True) semantics while using the
+        # same os.unlink boundary on every supported Python version.
         unlinked = True
     except OSError:
         if primary is None:
             cleanup_err = CheckpointError(_bound("checkpoint temp cleanup failed"), category="unlink")
+    else:
+        unlinked = True
     if unlinked:
         try:
             _fsync_directory(cp_dir)

--- a/src/brigade/run_checkpoint.py
+++ b/src/brigade/run_checkpoint.py
@@ -70,6 +70,10 @@ def _validate_payload(payload: Any) -> None:
     if not isinstance(payload, Mapping):
         raise CheckpointError(_bound("checkpoint payload must be an object"), category="payload-shape")
 
+    for key in payload.keys():
+        if not isinstance(key, str):
+            raise CheckpointError(_bound("payload keys must be strings"), category="payload-keys")
+
     keys = set(payload.keys())
     if keys != _CHECKPOINT_PAYLOAD_KEYS:
         missing = sorted(_CHECKPOINT_PAYLOAD_KEYS - keys)
@@ -130,14 +134,71 @@ def _writer_canonical_bytes(obj: Any) -> bytes:
     return (json.dumps(obj, indent=2, sort_keys=True) + "\n").encode("utf-8")
 
 
+def _read_bounded(fd: int, expected_size: int) -> bytes:
+    """Read exactly ``expected_size`` bytes from ``fd``, then one extra byte.
+
+    Rejects growth after ``fstat`` (the extra byte is non-empty) and short
+    reads (file shrank or returned fewer than ``expected_size`` bytes). Never
+    accumulates beyond ``MAX_CHECKPOINT_BYTES``. Raises ``CheckpointError``
+    with category ``size-mismatch`` on any bound violation, or ``read`` on a
+    raw ``OSError`` from ``os.read``.
+    """
+    if expected_size < 0 or expected_size > MAX_CHECKPOINT_BYTES:
+        raise CheckpointError(_bound("checkpoint size out of range"), category="byte-size")
+    chunks: list[bytes] = []
+    remaining = expected_size
+    try:
+        while remaining > 0:
+            chunk = os.read(fd, min(run_journal._READ_CHUNK, remaining))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+    except OSError as exc:
+        raise CheckpointError(_bound("checkpoint read failed"), category="read") from exc
+    data = b"".join(chunks)
+    if len(data) != expected_size:
+        raise CheckpointError(_bound("checkpoint size mismatch"), category="size-mismatch")
+    try:
+        extra = os.read(fd, 1)
+    except OSError as exc:
+        raise CheckpointError(_bound("checkpoint read failed"), category="read") from exc
+    if extra:
+        raise CheckpointError(_bound("checkpoint grew after fstat"), category="size-mismatch")
+    return data
+
+
+def _close_guarded(fd: int, primary: CheckpointError | None, *, category: str = "close") -> CheckpointError | None:
+    """Close ``fd``, translating an ``OSError`` into a bounded ``CheckpointError``.
+
+    Returns the error to raise (or ``None``). A close failure never masks a
+    prior ``primary`` failure: when ``primary`` is set it is returned
+    unchanged and the close error is suppressed; when ``primary`` is ``None``
+    a new bounded ``CheckpointError`` is returned. The fd is best-effort closed
+    even on a first close failure.
+    """
+    close_err: CheckpointError | None = None
+    try:
+        os.close(fd)
+    except OSError:
+        if primary is None:
+            close_err = CheckpointError(_bound("checkpoint close failed"), category=category)
+    return primary if primary is not None else close_err
+
+
 def validate_checkpoint(run_dir: Path, event: Any) -> bytes:
     """Validate a checkpoint payload, then open and verify the referenced file.
 
     Accepts either a payload Mapping or a ``run_journal.RunEvent`` whose
     ``payload`` is the checkpoint payload. Returns the verified checkpoint
-    bytes. Raises ``CheckpointError`` on any validation failure.
+    bytes. Raises ``CheckpointError`` on any validation failure. Raw
+    ``OSError`` from ``run_journal._open_nofollow`` (including missing file
+    and permission denial), ``fstat``, bounded ``os.read``, and ``os.close``
+    is translated into a bounded categorized ``CheckpointError``; an earlier
+    validation failure is preserved over a close failure.
     """
     run_dir = Path(run_dir)
+    payload: Mapping[str, Any]
     if isinstance(event, run_journal.RunEvent):
         payload = event.payload
     elif isinstance(event, Mapping):
@@ -155,21 +216,21 @@ def validate_checkpoint(run_dir: Path, event: Any) -> bytes:
         fd = run_journal._open_nofollow(final_path, os.O_RDONLY)
     except run_journal.RunJournalError as exc:
         raise CheckpointError(_bound(f"cannot open checkpoint: {exc.diagnostic}"), category="open-fd") from exc
+    except OSError as exc:
+        raise CheckpointError(_bound("cannot open checkpoint"), category="open-fd") from exc
+    primary: CheckpointError | None = None
     try:
-        info = os.fstat(fd)
+        try:
+            info = os.fstat(fd)
+        except OSError as exc:
+            raise CheckpointError(_bound("checkpoint fstat failed"), category="fstat") from exc
         if not stat.S_ISREG(info.st_mode):
             raise CheckpointError(_bound("checkpoint path is not a regular file"), category="not-regular")
         if info.st_nlink != 1:
             raise CheckpointError(_bound("checkpoint link count is not one"), category="link-count")
         if info.st_size != byte_size:
             raise CheckpointError(_bound("checkpoint size mismatch"), category="size-mismatch")
-        chunks: list[bytes] = []
-        while True:
-            chunk = os.read(fd, run_journal._READ_CHUNK)
-            if not chunk:
-                break
-            chunks.append(chunk)
-        data = b"".join(chunks)
+        data = _read_bounded(fd, byte_size)
         actual_sha = hashlib.sha256(data).hexdigest()
         if actual_sha != sha:
             raise CheckpointError(_bound("checkpoint digest mismatch"), category="digest-mismatch")
@@ -181,43 +242,68 @@ def validate_checkpoint(run_dir: Path, event: Any) -> bytes:
             obj = json.loads(text)
         except (json.JSONDecodeError, ValueError) as exc:
             raise CheckpointError(_bound("checkpoint is not valid JSON"), category="json-object") from exc
+        except RecursionError as exc:
+            raise CheckpointError(_bound("checkpoint JSON nesting too deep"), category="json-object") from exc
         if not isinstance(obj, dict):
             raise CheckpointError(_bound("checkpoint is not a JSON object"), category="json-object")
-        if _writer_canonical_bytes(obj) != data:
+        try:
+            canonical = _writer_canonical_bytes(obj)
+        except RecursionError as exc:
+            raise CheckpointError(
+                _bound("checkpoint canonical re-encode nesting too deep"), category="writer-bytes"
+            ) from exc
+        if canonical != data:
             raise CheckpointError(_bound("checkpoint bytes differ from writer canonical form"), category="writer-bytes")
         return data
+    except CheckpointError as exc:
+        primary = exc
+        raise
     finally:
-        os.close(fd)
+        close_err = _close_guarded(fd, primary)
+        if close_err is not None and primary is None:
+            raise close_err
 
 
 def _verify_collision(final_path: Path, expected_bytes: bytes, expected_sha: str) -> None:
     """Open an existing final path no-follow and require byte+digest equality.
 
     Raises ``CheckpointError`` with category ``collision-unsafe`` for a
-    symlink, non-regular inode, or link count above one, or
-    ``collision-mismatch`` for byte or digest inequality.
+    symlink, non-regular inode, link count above one, or a raw ``OSError``
+    from ``run_journal._open_nofollow`` (including missing file and
+    permission denial), or ``collision-mismatch`` for byte or digest
+    inequality. Raw ``OSError`` from ``fstat``, bounded ``os.read``, and
+    ``os.close`` is translated into a bounded categorized
+    ``CheckpointError``; an earlier collision failure is preserved over a
+    close failure.
     """
     try:
         fd = run_journal._open_nofollow(final_path, os.O_RDONLY)
     except run_journal.RunJournalError as exc:
         raise CheckpointError(_bound(f"collision-unsafe: {exc.diagnostic}"), category="collision-unsafe") from exc
+    except OSError as exc:
+        raise CheckpointError(_bound("collision-unsafe: open failed"), category="collision-unsafe") from exc
+    primary: CheckpointError | None = None
     try:
-        info = os.fstat(fd)
+        try:
+            info = os.fstat(fd)
+        except OSError as exc:
+            raise CheckpointError(_bound("collision-unsafe: fstat failed"), category="fstat") from exc
         if not stat.S_ISREG(info.st_mode):
             raise CheckpointError(_bound("collision-unsafe: not a regular file"), category="collision-unsafe")
         if info.st_nlink != 1:
             raise CheckpointError(_bound("collision-unsafe: link count above one"), category="collision-unsafe")
-        chunks: list[bytes] = []
-        while True:
-            chunk = os.read(fd, run_journal._READ_CHUNK)
-            if not chunk:
-                break
-            chunks.append(chunk)
-        data = b"".join(chunks)
+        if info.st_size != len(expected_bytes):
+            raise CheckpointError(_bound("collision-mismatch: bytes differ"), category="collision-mismatch")
+        data = _read_bounded(fd, len(expected_bytes))
         if data != expected_bytes or hashlib.sha256(data).hexdigest() != expected_sha:
             raise CheckpointError(_bound("collision-mismatch: bytes differ"), category="collision-mismatch")
+    except CheckpointError as exc:
+        primary = exc
+        raise
     finally:
-        os.close(fd)
+        close_err = _close_guarded(fd, primary)
+        if close_err is not None and primary is None:
+            raise close_err
 
 
 def _supports_directory_fsync() -> bool:
@@ -225,13 +311,88 @@ def _supports_directory_fsync() -> bool:
 
 
 def _fsync_directory(path: Path) -> None:
+    """Open ``path`` no-follow as a directory, fsync the descriptor, then close.
+
+    The directory is opened via ``run_journal._open_nofollow`` with
+    ``O_RDONLY | O_DIRECTORY`` so a raced-in symlink or non-directory inode
+    is rejected before any fsync occurs (never fsync an attacker-selected
+    target). The opened descriptor is ``fstat``-ed and required to be a
+    directory, then ``fsync``-ed. Raises ``CheckpointError`` with category
+    ``dir-fsync`` on any ``OSError`` from open, fstat, fsync, or close; a
+    close failure is suppressed when an earlier open/fstat/fsync failure
+    already raised (bounded error-precedence).
+    """
     if not _supports_directory_fsync():
         return
-    fd = os.open(path, os.O_RDONLY)
+    dir_flags = os.O_RDONLY | run_journal._O_DIRECTORY
     try:
-        os.fsync(fd)
+        fd = run_journal._open_nofollow(path, dir_flags)
+    except run_journal.RunJournalError as exc:
+        raise CheckpointError(
+            _bound(f"checkpoint directory fsync failed: {exc.diagnostic}"), category="dir-fsync"
+        ) from exc
+    except OSError as exc:
+        raise CheckpointError(_bound("checkpoint directory fsync failed"), category="dir-fsync") from exc
+    primary: CheckpointError | None = None
+    try:
+        try:
+            info = os.fstat(fd)
+        except OSError as exc:
+            raise CheckpointError(_bound("checkpoint directory fsync failed"), category="dir-fsync") from exc
+        if not stat.S_ISDIR(info.st_mode):
+            raise CheckpointError(_bound("checkpoint directory fsync failed"), category="dir-fsync")
+        try:
+            os.fsync(fd)
+        except OSError as exc:
+            raise CheckpointError(_bound("checkpoint directory fsync failed"), category="dir-fsync") from exc
+    except CheckpointError as exc:
+        primary = exc
+        raise
     finally:
-        os.close(fd)
+        close_err = _close_guarded(fd, primary, category="dir-fsync")
+        if close_err is not None and primary is None:
+            raise close_err
+
+
+def _cleanup_temp(tmp_path: Path, cp_dir: Path, primary: CheckpointError | None) -> CheckpointError | None:
+    """Unlink the temp and fsync the checkpoint directory after a temp deletion.
+
+    Used on the success, collision, and error paths so every successful temp
+    deletion is followed by a checkpoint-directory fsync on POSIX. Returns the
+    error to raise (or ``primary`` unchanged). A cleanup unlink or cleanup
+    fsync failure never replaces a prior ``primary`` safety failure: when
+    ``primary`` is set it is returned unchanged and cleanup errors are
+    suppressed (the directory fsync still runs best-effort so the unlink is
+    durable). When ``primary`` is ``None``, a cleanup-only failure returns a
+    new bounded ``CheckpointError`` (``unlink`` or ``dir-fsync``).
+    """
+    cleanup_err: CheckpointError | None = None
+    unlinked = False
+    try:
+        tmp_path.unlink(missing_ok=True)
+        unlinked = True
+    except OSError:
+        if primary is None:
+            cleanup_err = CheckpointError(_bound("checkpoint temp cleanup failed"), category="unlink")
+    if unlinked:
+        try:
+            _fsync_directory(cp_dir)
+        except CheckpointError as exc:
+            if primary is None and cleanup_err is None:
+                cleanup_err = exc
+    return primary if primary is not None else cleanup_err
+
+
+def _abort_with_cleanup(
+    tmp_path: Path, cp_dir: Path, primary: CheckpointError, *, cause: BaseException | None = None
+) -> None:
+    """Run temp cleanup, then raise ``primary`` (or a cleanup-only error)."""
+    cleanup_err = _cleanup_temp(tmp_path, cp_dir, primary)
+    if cleanup_err is not None and primary is None:
+        raise cleanup_err from None
+    if cause is not None:
+        raise primary from cause
+    raise primary
 
 
 def publish_checkpoint_file(run_dir: Path, run_json_bytes: bytes) -> Path:
@@ -240,10 +401,16 @@ def publish_checkpoint_file(run_dir: Path, run_json_bytes: bytes) -> Path:
     Creates the 0o700 ``recovery-checkpoints`` directory (no-follow mkdir),
     writes to a 0o600 same-directory temp, fsyncs, publishes by atomic
     no-replace ``os.link``, applies POSIX-guarded directory fsync, and unlinks
-    the temp. On ``EEXIST`` the existing final file is opened through the same
-    no-follow regular single-link fd hardening and required to be byte and
-    digest equal (a safe matching collision is a no-op); an unsafe inode or
-    mismatched collision raises ``CheckpointError``.
+    the temp followed by another directory fsync. On ``EEXIST`` the existing
+    final file is opened through the same no-follow regular single-link fd
+    hardening and required to be byte and digest equal (a safe matching
+    collision is a no-op that still unlinks the temp and fsyncs the
+    directory); an unsafe inode or mismatched collision raises
+    ``CheckpointError``. Every successful temp deletion (new-publish, EEXIST
+    collision, and all error paths) is followed by a checkpoint-directory
+    fsync on POSIX. The mkstemp fd is always closed, even when chmod fails; a
+    close failure is translated to a bounded ``CheckpointError`` only when no
+    earlier failure exists and never masks chmod/write/fsync failures.
     """
     run_dir = Path(run_dir)
     if not isinstance(run_json_bytes, (bytes, bytearray)):
@@ -254,27 +421,70 @@ def publish_checkpoint_file(run_dir: Path, run_json_bytes: bytes) -> Path:
         raise CheckpointError(_bound("checkpoint bytes exceed MAX_CHECKPOINT_BYTES"), category="byte-size")
     sha = hashlib.sha256(run_json_bytes).hexdigest()
     cp_dir = checkpoint_dir(run_dir)
-    run_journal._mkdir_private(cp_dir)
+    try:
+        run_journal._mkdir_private(cp_dir)
+    except run_journal.RunJournalError as exc:
+        raise CheckpointError(
+            _bound(f"cannot create checkpoint directory: {exc.diagnostic}"), category="mkdir"
+        ) from exc
+    except OSError as exc:
+        raise CheckpointError(_bound("cannot create checkpoint directory"), category="mkdir") from exc
     final_path = checkpoint_path(run_dir, sha)
 
-    fd, tmp_name = tempfile.mkstemp(dir=cp_dir, prefix=".checkpoint.", suffix=".tmp")
-    tmp_path = Path(tmp_name)
     try:
-        os.fchmod(fd, run_journal._FILE_MODE)
-        written = os.write(fd, run_json_bytes)
-        if written != len(run_json_bytes):
-            raise CheckpointError(_bound("checkpoint temp write was partial"), category="io")
-        os.fsync(fd)
+        fd, tmp_name = tempfile.mkstemp(dir=cp_dir, prefix=".checkpoint.", suffix=".tmp")
+    except OSError as exc:
+        raise CheckpointError(_bound("cannot create checkpoint temp"), category="temp-create") from exc
+    tmp_path = Path(tmp_name)
+    primary: CheckpointError | None = None
+    try:
+        try:
+            run_journal._chmod_fd_or_path(fd, tmp_path, run_journal._FILE_MODE)
+        except run_journal.RunJournalError as exc:
+            raise CheckpointError(_bound("checkpoint temp chmod failed"), category="chmod") from exc
+        except OSError as exc:
+            raise CheckpointError(_bound("checkpoint temp chmod failed"), category="chmod") from exc
+        try:
+            written = os.write(fd, run_json_bytes)
+            if written != len(run_json_bytes):
+                raise CheckpointError(_bound("checkpoint temp write was partial"), category="io")
+            os.fsync(fd)
+        except CheckpointError:
+            raise
+        except OSError as exc:
+            raise CheckpointError(_bound("checkpoint temp write failed"), category="io") from exc
+    except CheckpointError as exc:
+        primary = exc
     finally:
-        os.close(fd)
+        close_err = _close_guarded(fd, primary)
+        if close_err is not None and primary is None:
+            primary = close_err
+
+    if primary is not None:
+        _abort_with_cleanup(tmp_path, cp_dir, primary)
 
     try:
         os.link(tmp_path, final_path)
     except FileExistsError:
-        _verify_collision(final_path, run_json_bytes, sha)
-        tmp_path.unlink(missing_ok=True)
+        try:
+            _verify_collision(final_path, run_json_bytes, sha)
+        except CheckpointError as exc:
+            _abort_with_cleanup(tmp_path, cp_dir, exc)
+        cleanup_err = _cleanup_temp(tmp_path, cp_dir, None)
+        if cleanup_err is not None:
+            raise cleanup_err from None
         return final_path
-    else:
+    except OSError as exc:
+        primary = CheckpointError(_bound("checkpoint link failed"), category="link")
+        _abort_with_cleanup(tmp_path, cp_dir, primary, cause=exc)
+
+    try:
         _fsync_directory(cp_dir)
-        tmp_path.unlink(missing_ok=True)
-        return final_path
+    except CheckpointError as exc:
+        _abort_with_cleanup(tmp_path, cp_dir, exc)
+
+    cleanup_err = _cleanup_temp(tmp_path, cp_dir, None)
+    if cleanup_err is not None:
+        raise cleanup_err from None
+
+    return final_path

--- a/src/brigade/run_checkpoint.py
+++ b/src/brigade/run_checkpoint.py
@@ -1,0 +1,280 @@
+"""Recovery checkpoint substrate for the run lifecycle (issue #568 slice 5, Task 1).
+
+A checkpoint is a write-ahead record of the exact ``run.json`` bytes the legacy
+writer is about to commit, content-addressed by their SHA-256 and stored at
+``<run-dir>/events/recovery-checkpoints/<sha256>.json``. One
+``run.snapshot.checkpointed`` event per write is appended to the existing
+``events/lifecycle.jsonl`` journal under the closed ``brigade.run_event.v1``
+envelope. This module owns the crash-safe publish helper, the payload-first
+``validate_checkpoint`` with open-fd hardening, and the bounded journal-reader
+bounds. Task 2 wires the fail-closed hook into ``aboyeur._write_json``.
+
+Standard library only. Brigade is zero-runtime-dependency.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+import tempfile
+from pathlib import Path
+from typing import Any, Mapping
+
+from brigade import run_events, run_journal
+from brigade.run_events import _HEX64, _bound
+
+CHECKPOINT_EVENT_TYPE = "run.snapshot.checkpointed"
+CHECKPOINT_MEDIA_TYPE = "application/vnd.brigade.run+json"
+CHECKPOINT_PRIVACY_CLASS = "private"
+CHECKPOINT_DIR_NAME = "recovery-checkpoints"
+MAX_CHECKPOINT_BYTES = 16 * 1024 * 1024
+MAX_JOURNAL_BYTES = 8 * 1024 * 1024
+MAX_JOURNAL_EVENTS = 512
+
+_CHECKPOINT_PAYLOAD_KEYS = frozenset(
+    {"path", "sha256", "media_type", "byte_size", "privacy_class", "paired_event_type"}
+)
+
+
+class CheckpointError(RuntimeError):
+    """Bounded checkpoint failure carrying a category diagnostic.
+
+    The diagnostic is bounded to ``run_events.MAX_DIAGNOSTIC_LEN`` and carries
+    only a category, never a raw path or payload value.
+    """
+
+    def __init__(self, diagnostic: str, *, category: str) -> None:
+        super().__init__(diagnostic)
+        self.diagnostic = diagnostic
+        self.category = category
+
+
+def checkpoint_dir(run_dir: Path) -> Path:
+    return Path(run_dir) / "events" / CHECKPOINT_DIR_NAME
+
+
+def checkpoint_path(run_dir: Path, sha256: str) -> Path:
+    return checkpoint_dir(run_dir) / f"{sha256}.json"
+
+
+def _mapped_lifecycle_event_types() -> set[str]:
+    from brigade import run_lifecycle
+
+    return set(run_lifecycle.STATUS_EVENT_TYPE.values())
+
+
+def _validate_payload(payload: Any) -> None:
+    """Full payload validation before any path access. Raises CheckpointError."""
+    if not isinstance(payload, Mapping):
+        raise CheckpointError(_bound("checkpoint payload must be an object"), category="payload-shape")
+
+    keys = set(payload.keys())
+    if keys != _CHECKPOINT_PAYLOAD_KEYS:
+        missing = sorted(_CHECKPOINT_PAYLOAD_KEYS - keys)
+        extra = sorted(keys - _CHECKPOINT_PAYLOAD_KEYS)
+        raise CheckpointError(
+            _bound(f"payload keys mismatch: missing={missing}, extra={extra}"),
+            category="payload-keys",
+        )
+
+    if payload["media_type"] != CHECKPOINT_MEDIA_TYPE:
+        raise CheckpointError(_bound("media_type mismatch"), category="media-type")
+
+    if payload["privacy_class"] != CHECKPOINT_PRIVACY_CLASS:
+        raise CheckpointError(_bound("privacy_class mismatch"), category="privacy-class")
+
+    sha = payload["sha256"]
+    if not isinstance(sha, str) or not _HEX64.match(sha):
+        raise CheckpointError(_bound("sha256 must be 64-char lowercase hex"), category="sha256")
+
+    byte_size = payload["byte_size"]
+    if isinstance(byte_size, bool) or not isinstance(byte_size, int):
+        raise CheckpointError(_bound("byte_size must be an integer"), category="byte-size")
+    if byte_size < 0 or byte_size > MAX_CHECKPOINT_BYTES:
+        raise CheckpointError(_bound("byte_size out of range"), category="byte-size")
+
+    declared_path = payload["path"]
+    if not isinstance(declared_path, str):
+        raise CheckpointError(_bound("path must be a string"), category="path")
+    expected_path = f"events/{CHECKPOINT_DIR_NAME}/{sha}.json"
+    if declared_path != expected_path:
+        raise CheckpointError(_bound("path does not match declared sha256"), category="path")
+    if declared_path.startswith("/"):
+        raise CheckpointError(_bound("path must be relative"), category="path")
+    if "\\" in declared_path:
+        raise CheckpointError(_bound("path must not contain backslashes"), category="path")
+    if ".." in declared_path.split("/"):
+        raise CheckpointError(_bound("path must not contain '..' components"), category="path")
+    stem = declared_path.rsplit("/", 1)[-1].rsplit(".", 1)[0]
+    if stem != sha:
+        raise CheckpointError(_bound("path stem must equal sha256"), category="path")
+
+    paired = payload["paired_event_type"]
+    if paired is None:
+        pass
+    elif not isinstance(paired, str):
+        raise CheckpointError(_bound("paired_event_type must be null or a string"), category="paired-event-type")
+    elif paired not in run_events.EVENT_TYPES:
+        raise CheckpointError(_bound("paired_event_type not in registry"), category="paired-event-type")
+    elif paired not in _mapped_lifecycle_event_types():
+        raise CheckpointError(
+            _bound("paired_event_type is not a mapped lifecycle status event"),
+            category="paired-event-type",
+        )
+
+
+def _writer_canonical_bytes(obj: Any) -> bytes:
+    """Replicate ``aboyeur._write_json`` canonical encoding for writer-byte equality."""
+    return (json.dumps(obj, indent=2, sort_keys=True) + "\n").encode("utf-8")
+
+
+def validate_checkpoint(run_dir: Path, event: Any) -> bytes:
+    """Validate a checkpoint payload, then open and verify the referenced file.
+
+    Accepts either a payload Mapping or a ``run_journal.RunEvent`` whose
+    ``payload`` is the checkpoint payload. Returns the verified checkpoint
+    bytes. Raises ``CheckpointError`` on any validation failure.
+    """
+    run_dir = Path(run_dir)
+    if isinstance(event, run_journal.RunEvent):
+        payload = event.payload
+    elif isinstance(event, Mapping):
+        payload = event
+    else:
+        raise CheckpointError(_bound("event must be a payload object or RunEvent"), category="payload-shape")
+
+    _validate_payload(payload)
+
+    sha = payload["sha256"]
+    byte_size = payload["byte_size"]
+    final_path = checkpoint_path(run_dir, sha)
+
+    try:
+        fd = run_journal._open_nofollow(final_path, os.O_RDONLY)
+    except run_journal.RunJournalError as exc:
+        raise CheckpointError(_bound(f"cannot open checkpoint: {exc.diagnostic}"), category="open-fd") from exc
+    try:
+        info = os.fstat(fd)
+        if not stat.S_ISREG(info.st_mode):
+            raise CheckpointError(_bound("checkpoint path is not a regular file"), category="not-regular")
+        if info.st_nlink != 1:
+            raise CheckpointError(_bound("checkpoint link count is not one"), category="link-count")
+        if info.st_size != byte_size:
+            raise CheckpointError(_bound("checkpoint size mismatch"), category="size-mismatch")
+        chunks: list[bytes] = []
+        while True:
+            chunk = os.read(fd, run_journal._READ_CHUNK)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        data = b"".join(chunks)
+        actual_sha = hashlib.sha256(data).hexdigest()
+        if actual_sha != sha:
+            raise CheckpointError(_bound("checkpoint digest mismatch"), category="digest-mismatch")
+        try:
+            text = data.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise CheckpointError(_bound("checkpoint is not valid UTF-8"), category="utf8") from exc
+        try:
+            obj = json.loads(text)
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise CheckpointError(_bound("checkpoint is not valid JSON"), category="json-object") from exc
+        if not isinstance(obj, dict):
+            raise CheckpointError(_bound("checkpoint is not a JSON object"), category="json-object")
+        if _writer_canonical_bytes(obj) != data:
+            raise CheckpointError(_bound("checkpoint bytes differ from writer canonical form"), category="writer-bytes")
+        return data
+    finally:
+        os.close(fd)
+
+
+def _verify_collision(final_path: Path, expected_bytes: bytes, expected_sha: str) -> None:
+    """Open an existing final path no-follow and require byte+digest equality.
+
+    Raises ``CheckpointError`` with category ``collision-unsafe`` for a
+    symlink, non-regular inode, or link count above one, or
+    ``collision-mismatch`` for byte or digest inequality.
+    """
+    try:
+        fd = run_journal._open_nofollow(final_path, os.O_RDONLY)
+    except run_journal.RunJournalError as exc:
+        raise CheckpointError(_bound(f"collision-unsafe: {exc.diagnostic}"), category="collision-unsafe") from exc
+    try:
+        info = os.fstat(fd)
+        if not stat.S_ISREG(info.st_mode):
+            raise CheckpointError(_bound("collision-unsafe: not a regular file"), category="collision-unsafe")
+        if info.st_nlink != 1:
+            raise CheckpointError(_bound("collision-unsafe: link count above one"), category="collision-unsafe")
+        chunks: list[bytes] = []
+        while True:
+            chunk = os.read(fd, run_journal._READ_CHUNK)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        data = b"".join(chunks)
+        if data != expected_bytes or hashlib.sha256(data).hexdigest() != expected_sha:
+            raise CheckpointError(_bound("collision-mismatch: bytes differ"), category="collision-mismatch")
+    finally:
+        os.close(fd)
+
+
+def _supports_directory_fsync() -> bool:
+    return os.name == "posix"
+
+
+def _fsync_directory(path: Path) -> None:
+    if not _supports_directory_fsync():
+        return
+    fd = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def publish_checkpoint_file(run_dir: Path, run_json_bytes: bytes) -> Path:
+    """Crash-safe publish of ``run_json_bytes`` to the content-addressed checkpoint path.
+
+    Creates the 0o700 ``recovery-checkpoints`` directory (no-follow mkdir),
+    writes to a 0o600 same-directory temp, fsyncs, publishes by atomic
+    no-replace ``os.link``, applies POSIX-guarded directory fsync, and unlinks
+    the temp. On ``EEXIST`` the existing final file is opened through the same
+    no-follow regular single-link fd hardening and required to be byte and
+    digest equal (a safe matching collision is a no-op); an unsafe inode or
+    mismatched collision raises ``CheckpointError``.
+    """
+    run_dir = Path(run_dir)
+    if not isinstance(run_json_bytes, (bytes, bytearray)):
+        raise CheckpointError(_bound("run_json_bytes must be bytes"), category="payload-shape")
+    run_json_bytes = bytes(run_json_bytes)
+    byte_size = len(run_json_bytes)
+    if byte_size > MAX_CHECKPOINT_BYTES:
+        raise CheckpointError(_bound("checkpoint bytes exceed MAX_CHECKPOINT_BYTES"), category="byte-size")
+    sha = hashlib.sha256(run_json_bytes).hexdigest()
+    cp_dir = checkpoint_dir(run_dir)
+    run_journal._mkdir_private(cp_dir)
+    final_path = checkpoint_path(run_dir, sha)
+
+    fd, tmp_name = tempfile.mkstemp(dir=cp_dir, prefix=".checkpoint.", suffix=".tmp")
+    tmp_path = Path(tmp_name)
+    try:
+        os.fchmod(fd, run_journal._FILE_MODE)
+        written = os.write(fd, run_json_bytes)
+        if written != len(run_json_bytes):
+            raise CheckpointError(_bound("checkpoint temp write was partial"), category="io")
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+    try:
+        os.link(tmp_path, final_path)
+    except FileExistsError:
+        _verify_collision(final_path, run_json_bytes, sha)
+        tmp_path.unlink(missing_ok=True)
+        return final_path
+    else:
+        _fsync_directory(cp_dir)
+        tmp_path.unlink(missing_ok=True)
+        return final_path

--- a/src/brigade/run_checkpoint.py
+++ b/src/brigade/run_checkpoint.py
@@ -21,6 +21,7 @@ import stat
 import tempfile
 from pathlib import Path
 from typing import Any, Mapping
+from uuid import uuid4
 
 from brigade import run_events, run_journal, runguard
 from brigade.run_events import _HEX64, _bound
@@ -593,3 +594,255 @@ def write_checkpoint(
         raise run_lifecycle._bound_journal_failure(exc) from exc
     except OSError as exc:
         raise run_lifecycle._bound_journal_failure(exc) from exc
+
+
+# -- Checkpoint-backed recovery (issue #568 slice 5, Task 5) -------------------
+
+
+def latest_checkpoint_event(events: list["run_journal.RunEvent"]) -> "run_journal.RunEvent | None":
+    """Select the highest-sequence ``run.snapshot.checkpointed`` event.
+
+    Returns ``None`` when ``events`` is empty or contains no checkpoint
+    events. Otherwise returns the checkpoint event with the largest
+    ``sequence`` value. Sequence uniqueness is enforced by the journal
+    reader, so a tie is not a concern here.
+    """
+    latest: run_journal.RunEvent | None = None
+    for event in events:
+        if event.event_type != CHECKPOINT_EVENT_TYPE:
+            continue
+        if latest is None or event.sequence > latest.sequence:
+            latest = event
+    return latest
+
+
+def _restore_run_json_from_checkpoint(
+    run_dir: Path,
+    checkpoint_bytes: bytes,
+    *,
+    run_meta: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Restore ``run.json`` from verified checkpoint bytes when needed.
+
+    Restores only when ``run_meta`` is ``None`` (run.json missing or
+    unparseable). A present-but-corrupt run.json is preserved by renaming
+    it to ``run.json.corrupt-<uuid>`` before the atomic replacement; a
+    rename ``OSError`` is translated to a bounded ``CheckpointError``
+    with category ``preserve-corrupt`` so the corrupt original is never
+    silently overwritten. The restore uses ``localio.write_text_atomic``
+    so a reader never observes a half-written file. Returns the parsed
+    checkpoint mapping. When ``run_meta`` is already a dict the run.json
+    is left untouched and the parsed checkpoint mapping is returned.
+    """
+    from brigade import localio  # lazy: keep the import local for stdlib-only surface
+
+    try:
+        repaired = json.loads(checkpoint_bytes.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+        raise CheckpointError(_bound("checkpoint bytes are not valid JSON"), category="json-object") from exc
+    if not isinstance(repaired, dict):
+        raise CheckpointError(_bound("checkpoint is not a JSON object"), category="json-object")
+    if run_meta is not None:
+        return repaired
+    run_json = run_dir / "run.json"
+    if run_json.is_file():
+        # Preserve the corrupt original before replacing it.
+        backup = run_json.with_name(f"run.json.corrupt-{uuid4().hex}")
+        try:
+            run_json.rename(backup)
+        except OSError as exc:
+            raise CheckpointError(_bound("could not preserve corrupt run.json"), category="preserve-corrupt") from exc
+    try:
+        localio.write_text_atomic(run_json, checkpoint_bytes.decode("utf-8"))
+    except OSError as exc:
+        raise CheckpointError(_bound("could not restore run.json from checkpoint"), category="restore-write") from exc
+    return repaired
+
+
+def _parse_checkpoint_object(checkpoint_bytes: bytes) -> dict[str, Any]:
+    """Parse verified checkpoint bytes into a dict for coverage derivation.
+
+    ``validate_checkpoint`` already proved the bytes are valid UTF-8 JSON
+    equal to the writer canonical encoding, so this parse cannot fail on
+    well-formed input. A defensive failure (e.g. concurrent in-place
+    mutation between validate and parse on a path that bypassed the
+    single-link fd check) surfaces a bounded ``CheckpointError`` rather
+    than a raw ``ValueError``. Returns the parsed mapping.
+    """
+    try:
+        obj = json.loads(checkpoint_bytes.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+        raise CheckpointError(_bound("checkpoint bytes are not valid JSON"), category="json-object") from exc
+    if not isinstance(obj, dict):
+        raise CheckpointError(_bound("checkpoint is not a JSON object"), category="json-object")
+    return obj
+
+
+def _paired_event_derived_status(event: "run_journal.RunEvent") -> str | None:
+    """Derive the run.json status a paired lifecycle status event carries.
+
+    Reuses the canonical ``run_projector`` event-to-status tables
+    (``EVENT_STATUS`` and ``_PAYLOAD_STATUS_RULES``) with no duplicate
+    mapping. Returns the derived status, or ``None`` when the event has no
+    derivable status (an unmapped type or a payload-driven row whose
+    payload status is missing/disallowed). A ``None`` result means the
+    paired event cannot match any checkpoint status, so the caller treats
+    it as an uncovered tail.
+    """
+    from brigade import run_projector  # lazy: avoid import cycle
+
+    event_type = event.event_type
+    if event_type in run_projector.EVENT_STATUS:
+        return run_projector.EVENT_STATUS[event_type]
+    rule = run_projector._PAYLOAD_STATUS_RULES.get(event_type)
+    if rule is None:
+        return None
+    allowed, derived = rule
+    payload_status = event.payload.get("status") if isinstance(event.payload, Mapping) else None
+    if payload_status not in allowed:
+        return None
+    return derived if derived is not None else payload_status
+
+
+def _verify_coverage(
+    events: list["run_journal.RunEvent"],
+    latest: "run_journal.RunEvent",
+    checkpoint_obj: Mapping[str, Any],
+) -> None:
+    """Verify the latest checkpoint covers the journal tail (issue #568 slice 5).
+
+    The latest checkpoint event at sequence N covers either itself as the
+    tail, or exactly one immediately following event at N+1 whose
+    ``event_type`` equals the checkpoint's ``paired_event_type`` and whose
+    derived status equals the status in the validated checkpoint bytes.
+    When ``paired_event_type`` is null, the checkpoint covers only itself
+    as the tail. Anything else fails uncovered-tail. ``checkpoint_obj`` is
+    the parsed validated checkpoint bytes; its ``status`` is the authoritative
+    status the paired event must derive to.
+    """
+    paired_event_type = latest.payload.get("paired_event_type")
+    tail = events[-1]
+    if latest.sequence == tail.sequence:
+        # Checkpoint is the tail. Covered for both null and non-null
+        # paired_event_type (a crash before the paired status append).
+        return
+    if paired_event_type is None:
+        # Null pairing covers only checkpoint-at-tail; any following event
+        # is uncovered.
+        raise CheckpointError(_bound("journal tail is not covered by the latest checkpoint"), category="uncovered-tail")
+    # Exactly one immediately following event must exist at N+1.
+    following = [e for e in events if e.sequence == latest.sequence + 1]
+    if len(following) != 1 or following[0].sequence != tail.sequence:
+        # Two or more events after the checkpoint (or a non-contiguous tail).
+        raise CheckpointError(_bound("journal tail is not covered by the latest checkpoint"), category="uncovered-tail")
+    paired = following[0]
+    if paired.event_type != paired_event_type:
+        raise CheckpointError(_bound("journal tail is not covered by the latest checkpoint"), category="uncovered-tail")
+    derived = _paired_event_derived_status(paired)
+    checkpoint_status = checkpoint_obj.get("status")
+    if not isinstance(checkpoint_status, str) or derived != checkpoint_status:
+        raise CheckpointError(_bound("journal tail is not covered by the latest checkpoint"), category="uncovered-tail")
+
+
+def recover_from_checkpoint(
+    run_dir: Path,
+    run_meta: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Validate the lifecycle journal and restore run.json from the latest checkpoint.
+
+    Reads the journal with byte/event bounds (``read_journal_bounded``),
+    quarantining a partial tail via ``recover_partial_tail`` and re-reading
+    before any derivation. Enforces a gap-free, contiguous sequence
+    starting at 1 with correct previous-digest chaining (reported by the
+    bounded reader as ``chain_errors``), a single journal ``run_id``
+    equal to the run directory name across every envelope, highest
+    checkpoint validity (``validate_checkpoint``), event/checkpoint/
+    directory ``run_id`` equality, and checkpoint coverage of the journal
+    tail. The checkpoint bytes are validated before their status is used.
+    The latest checkpoint event at sequence N covers itself as the tail,
+    or exactly one immediately following event at N+1 whose ``event_type``
+    equals the checkpoint's ``paired_event_type`` and whose derived status
+    equals the status in the validated checkpoint bytes. A null
+    ``paired_event_type`` covers only checkpoint-at-tail. Anything else
+    fails uncovered-tail.
+
+    Restores ``run.json`` only when it is missing or unparseable
+    (``run_meta is None``); a corrupt original is preserved by rename and
+    the restore uses ``localio.write_text_atomic``. Returns the repaired
+    validated mapping parsed from the verified checkpoint bytes. Raises
+    ``CheckpointError`` (bounded, categorized) on any validation or
+    restoration failure; nothing is restored on failure.
+    """
+    from brigade import localio  # noqa: F401  (kept for symmetry with the restore helper)
+    from brigade import run_lifecycle  # lazy: avoid circular import
+
+    try:
+        run_dir = Path(run_dir).expanduser().resolve()
+    except (OSError, RuntimeError) as exc:
+        raise CheckpointError(_bound("could not resolve run directory"), category="path-resolve") from exc
+    run_id = run_dir.name
+    journal_path = run_lifecycle._journal_path(run_dir)
+    if not journal_path.is_file():
+        raise CheckpointError(_bound("lifecycle journal not found"), category="no-journal")
+
+    try:
+        report = run_journal.read_journal_bounded(journal_path)
+    except run_journal.RunJournalError as exc:
+        raise CheckpointError(_bound(f"could not read journal: {exc.diagnostic}"), category="journal-read") from exc
+    except OSError as exc:
+        raise CheckpointError(_bound("could not read journal"), category="journal-read") from exc
+    if report.partial_tail is not None:
+        quarantine_dir = run_dir / "events" / "quarantine"
+        try:
+            run_journal.recover_partial_tail(journal_path, quarantine_dir)
+        except run_journal.RunJournalError as exc:
+            raise CheckpointError(
+                _bound(f"could not quarantine partial tail: {exc.diagnostic}"), category="partial-tail"
+            ) from exc
+        except OSError as exc:
+            raise CheckpointError(_bound("could not quarantine partial tail"), category="partial-tail") from exc
+        try:
+            report = run_journal.read_journal_bounded(journal_path)
+        except run_journal.RunJournalError as exc:
+            raise CheckpointError(
+                _bound(f"could not reread journal: {exc.diagnostic}"), category="journal-read"
+            ) from exc
+        except OSError as exc:
+            raise CheckpointError(_bound("could not reread journal"), category="journal-read") from exc
+        if report.partial_tail is not None:
+            raise CheckpointError(_bound("partial tail persisted after quarantine"), category="partial-tail")
+    if report.chain_errors:
+        raise CheckpointError(_bound("journal chain is not derivable"), category="chain")
+    if not report.events:
+        raise CheckpointError(_bound("journal has no events"), category="empty-journal")
+
+    expected_sequence = 1
+    expected_previous: str | None = None
+    for event in report.events:
+        if event.sequence != expected_sequence:
+            raise CheckpointError(_bound("journal sequence break"), category="chain")
+        if event.sequence == 1:
+            if event.previous_digest is not None:
+                raise CheckpointError(_bound("sequence 1 previous_digest must be null"), category="chain")
+        elif event.previous_digest != expected_previous:
+            raise CheckpointError(_bound("journal previous_digest does not link"), category="chain")
+        if event.run_id != run_id:
+            raise CheckpointError(_bound("journal run_id does not match run directory"), category="run-id-mismatch")
+        expected_sequence = event.sequence + 1
+        expected_previous = event.event_digest
+
+    latest = latest_checkpoint_event(report.events)
+    if latest is None:
+        raise CheckpointError(_bound("no checkpoint event in journal"), category="no-checkpoint")
+    if latest.run_id != run_id:
+        raise CheckpointError(_bound("checkpoint run_id does not match run directory"), category="run-id-mismatch")
+
+    # Validate the checkpoint bytes BEFORE using their status. The coverage
+    # check reads the status from the checkpointed run.json bytes, so the
+    # bytes must be verified first. Restoration stays validation-before-
+    # mutation: every validation (payload, fd, chain, coverage) completes
+    # before the only mutation (the restore write).
+    checkpoint_bytes = validate_checkpoint(run_dir, latest)
+    checkpoint_obj = _parse_checkpoint_object(checkpoint_bytes)
+    _verify_coverage(report.events, latest, checkpoint_obj)
+    return _restore_run_json_from_checkpoint(run_dir, checkpoint_bytes, run_meta=run_meta)

--- a/src/brigade/run_checkpoint.py
+++ b/src/brigade/run_checkpoint.py
@@ -22,7 +22,7 @@ import tempfile
 from pathlib import Path
 from typing import Any, Mapping
 
-from brigade import run_events, run_journal
+from brigade import run_events, run_journal, runguard
 from brigade.run_events import _HEX64, _bound
 
 CHECKPOINT_EVENT_TYPE = "run.snapshot.checkpointed"
@@ -36,6 +36,7 @@ MAX_JOURNAL_EVENTS = 512
 _CHECKPOINT_PAYLOAD_KEYS = frozenset(
     {"path", "sha256", "media_type", "byte_size", "privacy_class", "paired_event_type"}
 )
+_CHECKPOINT_IDEMPOTENCY_PREFIX = "checkpoint"
 
 
 class CheckpointError(RuntimeError):
@@ -488,3 +489,107 @@ def publish_checkpoint_file(run_dir: Path, run_json_bytes: bytes) -> Path:
         raise cleanup_err from None
 
     return final_path
+
+
+# -- Checkpoint coordinator (issue #568 slice 5, Task 2) ----------------------
+
+
+def _checkpoint_payload(run_json_bytes: bytes, *, paired_event_type: str | None) -> dict[str, Any]:
+    sha = hashlib.sha256(run_json_bytes).hexdigest()
+    return {
+        "path": f"events/{CHECKPOINT_DIR_NAME}/{sha}.json",
+        "sha256": sha,
+        "media_type": CHECKPOINT_MEDIA_TYPE,
+        "byte_size": len(run_json_bytes),
+        "privacy_class": CHECKPOINT_PRIVACY_CLASS,
+        "paired_event_type": paired_event_type,
+    }
+
+
+def _checkpoint_idempotency_key(sha: str, *, paired_event_type: str | None) -> str:
+    paired = paired_event_type if paired_event_type is not None else "none"
+    key = f"{_CHECKPOINT_IDEMPOTENCY_PREFIX}:{sha}:{paired}"
+    if len(key) <= run_events.MAX_IDEMPOTENCY_KEY_LEN:
+        return key
+    # Bound the paired-event-type tail so the key stays within the envelope
+    # limit regardless of event_type length; the sha and prefix are fixed.
+    budget = run_events.MAX_IDEMPOTENCY_KEY_LEN - len(_CHECKPOINT_IDEMPOTENCY_PREFIX) - 1 - len(sha) - 1
+    if budget < 0:
+        # Pathological: prefix+sha already overflow the bound. Fall back to a
+        # digest of the paired type so the key is still unique and bounded.
+        paired_digest = hashlib.sha256(paired.encode("utf-8")).hexdigest()[:16]
+        return f"{_CHECKPOINT_IDEMPOTENCY_PREFIX}:{sha}:{paired_digest}"
+    return f"{_CHECKPOINT_IDEMPOTENCY_PREFIX}:{sha}:{paired[:budget]}"
+
+
+def write_checkpoint(
+    run_dir: Path,
+    run_json_bytes: bytes,
+    *,
+    workspace: Path | None = None,
+    paired_event_type: str | None,
+) -> "run_journal.RunEvent | None":
+    """Publish a crash-safe recovery checkpoint and append the checkpoint event.
+
+    Called from ``aboyeur._write_json`` BEFORE ``record_lifecycle_transition``
+    and the ``run.json`` atomic replacement. Idempotently activates the
+    lifecycle journal (``run_lifecycle.prepare_lifecycle_journal``), publishes
+    ``run_json_bytes`` to the content-addressed checkpoint file
+    (``publish_checkpoint_file``), and appends one
+    ``run.snapshot.checkpointed`` event to the lifecycle journal with
+    idempotency key ``checkpoint:<sha256>:<paired-event-type-or-none>``.
+
+    No-op (no file, no event) when the journal is not active for the run.
+    When the journal is active but the caller does not hold the matching active
+    run lock, the coordinator fails closed with a bounded
+    ``LifecycleJournalError`` BEFORE any publish or append: a lock-less writer
+    on an active journal must never advance the journal or the snapshot, for
+    any status (mapped or unmapped). Raises ``CheckpointError`` on any bounded
+    checkpoint publish failure; the failure surfaces BEFORE the lifecycle
+    status append and BEFORE the ``run.json`` replacement. Raises
+    ``LifecycleJournalError`` on a bounded journal read failure.
+
+    ``run_lifecycle`` is imported lazily inside this function so the lifecycle
+    layer may depend on this checkpoint substrate without a circular import.
+    """
+    from brigade import run_lifecycle  # lazy: avoid circular import
+
+    run_dir = Path(run_dir).expanduser().resolve()
+    run_lifecycle.prepare_lifecycle_journal(run_dir, workspace=workspace)
+    journal_path = run_lifecycle._journal_path(run_dir)
+    if not journal_path.is_file():
+        return None
+    # Journal active: every publish/append must come from the process holding
+    # the matching active run lock. A lock-less writer fails closed before any
+    # checkpoint/status append and before run.json changes, for every status.
+    if workspace is None or not runguard.is_active_run_owner(workspace, run_dir):
+        raise run_lifecycle.LifecycleJournalError(
+            run_events._bound("lifecycle journal append requires the active run lock for this run")
+        )
+    run_json_bytes = bytes(run_json_bytes)
+    sha = hashlib.sha256(run_json_bytes).hexdigest()
+    payload = _checkpoint_payload(run_json_bytes, paired_event_type=paired_event_type)
+    # Crash-safe publish FIRST. A CheckpointError here fails before the
+    # lifecycle status append and before run.json replacement.
+    publish_checkpoint_file(run_dir, run_json_bytes)
+    try:
+        report = run_journal.read_journal(journal_path)
+        if report.partial_tail is not None or report.chain_errors:
+            raise run_journal.ChainIntegrityError(run_events._bound(run_lifecycle._CHAIN_CATEGORY))
+        idempotency_key = _checkpoint_idempotency_key(sha, paired_event_type=paired_event_type)
+        return run_journal.append_event(
+            journal_path,
+            run_id=run_lifecycle._run_id_from_dir(run_dir),
+            event_type=CHECKPOINT_EVENT_TYPE,
+            payload=payload,
+            idempotency_key=idempotency_key,
+            expected_previous_sequence=report.events[-1].sequence if report.events else 0,
+        )
+    except CheckpointError:
+        raise
+    except run_journal.RunJournalError as exc:
+        raise run_lifecycle._bound_journal_failure(exc) from exc
+    except run_events.CanonicalizationError as exc:
+        raise run_lifecycle._bound_journal_failure(exc) from exc
+    except OSError as exc:
+        raise run_lifecycle._bound_journal_failure(exc) from exc

--- a/src/brigade/run_events.py
+++ b/src/brigade/run_events.py
@@ -92,6 +92,9 @@ EVENT_TYPES: dict[str, frozenset[str]] = {
     "run.completed": frozenset({"status", "detail"}),
     "run.failed": frozenset({"status", "detail"}),
     "run.interrupted": frozenset({"status", "detail"}),
+    "run.snapshot.checkpointed": frozenset(
+        {"path", "sha256", "media_type", "byte_size", "privacy_class", "paired_event_type"}
+    ),
 }
 
 # Private-data exclusion list: these payload key names are never part of any

--- a/src/brigade/run_journal.py
+++ b/src/brigade/run_journal.py
@@ -610,6 +610,80 @@ def read_journal(journal_path: Path) -> JournalReport:
     return report
 
 
+def read_journal_bounded(journal_path: Path) -> JournalReport:
+    """Read the journal with byte and event-count bounds (issue #568 slice 5).
+
+    Mirrors ``read_journal`` semantics but refuses journals above
+    ``MAX_JOURNAL_BYTES`` (8 MiB) via ``fstat`` before any whole-file
+    allocation, reads in bounded chunks, and fails closed at the first
+    complete event whose sequence exceeds ``MAX_JOURNAL_EVENTS`` (512).
+    A bound excess is reported as ``bound exceeded`` and not parsed further.
+    The existing ``read_journal`` stays compatible.
+    """
+    from brigade.run_checkpoint import MAX_JOURNAL_BYTES, MAX_JOURNAL_EVENTS
+
+    journal_path = Path(journal_path)
+    report = JournalReport()
+    if os.path.lexists(journal_path) and not journal_path.exists():
+        raise RunJournalError(_bound(f"journal path is a dangling symlink: {journal_path.name}"))
+    if not journal_path.exists():
+        return report
+
+    fd = _open_nofollow(journal_path, os.O_RDONLY)
+    try:
+        info = os.fstat(fd)
+        if info.st_size > MAX_JOURNAL_BYTES:
+            raise RunJournalError(_bound("bound exceeded: journal above MAX_JOURNAL_BYTES"))
+        if not stat.S_ISREG(info.st_mode):
+            raise RunJournalError(_bound(f"journal path is not a regular file: {journal_path.name}"))
+
+        # Bounded chunk reads: never allocate the whole file at once.
+        raw = bytearray()
+        while True:
+            chunk = os.read(fd, _READ_CHUNK)
+            if not chunk:
+                break
+            raw.extend(chunk)
+            if len(raw) > MAX_JOURNAL_BYTES:
+                raise RunJournalError(_bound("bound exceeded: journal above MAX_JOURNAL_BYTES"))
+        raw_bytes = bytes(raw)
+    finally:
+        os.close(fd)
+
+    expected_sequence = 1
+    expected_previous: str | None = None
+    for complete, partial in _iter_lines(raw_bytes):
+        if partial is not None:
+            report.partial_tail = partial
+            continue
+        if complete is None:
+            continue
+        try:
+            env = _parse_canonical_line(complete)
+        except RunJournalError as exc:
+            report.chain_errors.append(exc.diagnostic)
+            break
+        event = _envelope_to_event(env)
+        if event.sequence > MAX_JOURNAL_EVENTS:
+            raise RunJournalError(_bound("bound exceeded: journal event sequence above MAX_JOURNAL_EVENTS"))
+        if event.sequence != expected_sequence:
+            report.chain_errors.append(
+                _bound(f"sequence gap/duplicate: expected {expected_sequence}, got {event.sequence}")
+            )
+            break
+        if event.sequence == 1:
+            if event.previous_digest is not None:
+                report.chain_errors.append("sequence 1 previous_digest must be null")
+                break
+        elif event.previous_digest != expected_previous:
+            report.chain_errors.append(_bound("previous_digest does not link to prior event_digest"))
+            break
+        report.events.append(event)
+        expected_sequence = event.sequence + 1
+        expected_previous = event.event_digest
+    return report
+
+
 def recover_partial_tail(journal_path: Path, quarantine_dir: Path) -> RecoveryReport:
     """Recovery-only: quarantine the partial suffix verbatim, then truncate.
 

--- a/src/brigade/run_journal.py
+++ b/src/brigade/run_journal.py
@@ -652,12 +652,16 @@ def read_journal_bounded(journal_path: Path) -> JournalReport:
 
     expected_sequence = 1
     expected_previous: str | None = None
+    complete_count = 0
     for complete, partial in _iter_lines(raw_bytes):
         if partial is not None:
             report.partial_tail = partial
             continue
         if complete is None:
             continue
+        complete_count += 1
+        if complete_count > MAX_JOURNAL_EVENTS:
+            raise RunJournalError(_bound("bound exceeded: journal complete records above MAX_JOURNAL_EVENTS"))
         try:
             env = _parse_canonical_line(complete)
         except RunJournalError as exc:

--- a/src/brigade/run_lifecycle.py
+++ b/src/brigade/run_lifecycle.py
@@ -13,10 +13,13 @@ Activation model
   until journaling activates.
 - Legacy ``run.json`` with no request field stays snapshot-only even if the
   environment flag is later enabled.
-- Once the matching run lock is held, the first mapped-status write with a
-  pending request creates the journal (0o700 directory, 0o600 file) and
-  appends ``run.created``. Journal existence is the durable activated fact
-  after that point.
+- ``prepare_lifecycle_journal`` (called by ``aboyeur._write_json`` before
+  every ``run.json`` write, and by ``run_checkpoint.write_checkpoint``) idempotently creates
+  the journal (0o700 directory, 0o600 file) the first time the matching run
+  lock is held AND the run carries a pending ``lifecycle_journal_requested``
+  marker. Journal existence is the durable activated fact after that point.
+  ``record_lifecycle_transition`` no longer creates the journal; it requires
+  the journal to already exist and skips (returns ``None``) when it does not.
 - Once the journal exists, later transitions remain journaled even if a
   resumed process lacks the environment flag.
 
@@ -75,7 +78,7 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
-from brigade import run_events, run_journal, runguard
+from brigade import run_checkpoint, run_events, run_journal, runguard
 
 _FLAG_ENV = "BRIGADE_LIFECYCLE_JOURNAL"
 _TRUTHY = frozenset({"1", "true", "yes", "on"})
@@ -84,6 +87,7 @@ _REQUEST_FIELD = "lifecycle_journal_requested"
 _IDEMPOTENCY_PREFIX = "lifecycle"
 _IO_CATEGORY = "lifecycle journal I/O failure"
 _CANONICALIZATION_CATEGORY = "lifecycle journal canonicalization failure"
+_CHAIN_CATEGORY = "lifecycle journal is not derivable"
 
 # Map of current run.json status values to the allowlisted run_event.v1
 # event_type that records that transition. Statuses without a mapping
@@ -180,6 +184,55 @@ def _allowlisted_payload(event_type: str, *, status: str) -> dict[str, Any]:
     return payload
 
 
+def _bound_journal_failure(exc: BaseException) -> LifecycleJournalError:
+    if isinstance(exc, run_journal.RunJournalError):
+        return LifecycleJournalError(run_events._bound(exc.diagnostic))
+    if isinstance(exc, run_events.CanonicalizationError):
+        return LifecycleJournalError(_CANONICALIZATION_CATEGORY)
+    if isinstance(exc, OSError):
+        return LifecycleJournalError(f"{_IO_CATEGORY} ({type(exc).__name__})")
+    return LifecycleJournalError(run_events._bound(str(exc)))
+
+
+def prepare_lifecycle_journal(
+    run_dir: Path,
+    *,
+    workspace: Path | None = None,
+    incoming_snapshot: Mapping[str, Any] | None = None,
+) -> None:
+    """Idempotently activate the per-run lifecycle journal under the matching lock.
+
+    Creates ``events/`` (0o700) and ``lifecycle.jsonl`` (0o600) only when ALL of:
+    - the journal does not already exist (idempotent no-op otherwise),
+    - the run has durably requested journaling (``lifecycle_journal_requested``
+      in ``run.json`` or ``incoming_snapshot``), and
+    - the caller holds the matching active run lock for ``run_dir`` (verified
+      via ``runguard.is_active_run_owner`` against ``workspace``, never
+      derived from the run directory layout).
+
+    No-op when the journal already exists, when journaling was never requested,
+    or when the matching lock is not held. Raises a bounded
+    ``LifecycleJournalError`` (generic category; the raw ``OSError`` text can
+    carry a path or private value) on any ``ensure_journal`` failure.
+    """
+    run_dir = Path(run_dir).expanduser().resolve()
+    journal_path = _journal_path(run_dir)
+    if journal_path.is_file():
+        return
+    if not _journal_requested(run_dir, incoming=incoming_snapshot):
+        return
+    if workspace is None or not runguard.is_active_run_owner(workspace, run_dir):
+        return
+    try:
+        run_journal.ensure_journal(journal_path)
+    except run_journal.RunJournalError as exc:
+        raise _bound_journal_failure(exc) from exc
+    except run_events.CanonicalizationError as exc:
+        raise _bound_journal_failure(exc) from exc
+    except OSError as exc:
+        raise _bound_journal_failure(exc) from exc
+
+
 def record_lifecycle_transition(
     run_dir: Path,
     *,
@@ -192,12 +245,18 @@ def record_lifecycle_transition(
     Called BEFORE the existing ``run.json`` snapshot refresh. Returns the
     appended (or replayed) ``RunEvent`` when journaling is active and the
     status transition is recorded; ``None`` when the status is unmapped, the
-    run is not activated, journaling is only requested but the matching lock
-    is not yet held, or the call only recorded the per-run request. Raises
-    ``LifecycleJournalError`` on any bounded journal failure, or when
-    journaling is active but the caller does not hold the matching active run
-    lock, so the caller does not write ``run.json`` past an uncommitted or
-    unowned transition.
+    run is a legacy/no-request run that never opted in, or journaling is only
+    requested but the matching lock is not yet held (the pre-lock bootstrap).
+    Raises ``LifecycleJournalError`` when journaling is active but the caller
+    does not hold the matching active run lock, and when journaling was
+    requested and the matching lock is held but the journal is absent after
+    preparation (a broken activation flow), so the caller never writes
+    ``run.json`` past an unowned or uncommitted transition.
+
+    This function does not create the journal; ``prepare_lifecycle_journal``
+    (called by ``aboyeur._write_json`` and ``run_checkpoint.write_checkpoint``)
+    owns activation. The skip rules (unmapped status, legacy/no-request,
+    requested-but-not-yet-locked) are retained.
 
     ``workspace`` identifies the run lock to verify ownership against; pass
     the workspace from the run receipt payload (``lock_workspace`` or
@@ -213,20 +272,19 @@ def record_lifecycle_transition(
     if not run_events._RUN_ID_RE.match(run_id):
         raise LifecycleJournalError(run_events._bound(f"invalid run_id from run_dir: {run_id!r}"))
     journal_path = _journal_path(run_dir)
-    requested = _journal_requested(run_dir, incoming=incoming_snapshot)
     if not journal_path.is_file():
-        if not requested:
-            return None
-        if workspace is None or not runguard.is_active_run_owner(workspace, run_dir):
-            return None
-        try:
-            run_journal.ensure_journal(journal_path)
-        except run_journal.RunJournalError as exc:
-            raise LifecycleJournalError(run_events._bound(exc.diagnostic)) from exc
-        except run_events.CanonicalizationError as exc:
-            raise LifecycleJournalError(_CANONICALIZATION_CATEGORY) from exc
-        except OSError as exc:
-            raise LifecycleJournalError(f"{_IO_CATEGORY} ({type(exc).__name__})") from exc
+        # Journal absent. Two legitimate skip paths remain: a legacy/no-request
+        # run that never opted in, and a requested run whose activation could
+        # not yet happen because the matching lock is not held (the pre-lock
+        # bootstrap). When journaling WAS requested AND the matching lock IS
+        # held, prepare_lifecycle_journal should already have activated the
+        # journal; its absence after preparation is a broken flow that must
+        # fail closed rather than silently advancing run.json.
+        if _journal_requested(run_dir, incoming=incoming_snapshot) and (
+            workspace is not None and runguard.is_active_run_owner(workspace, run_dir)
+        ):
+            raise LifecycleJournalError(run_events._bound("lifecycle journal requested but not activated"))
+        return None
 
     # The journal exists: journaling is active for this run, with or without
     # the env flag. Every append must come from the process holding the
@@ -236,17 +294,19 @@ def record_lifecycle_transition(
         raise LifecycleJournalError("lifecycle journal append requires the active run lock for this run")
 
     try:
-        run_journal.ensure_journal(journal_path)
         report = run_journal.read_journal(journal_path)
         if report.partial_tail is not None or report.chain_errors:
-            raise run_journal.ChainIntegrityError(run_events._bound("lifecycle journal is not derivable"))
+            raise run_journal.ChainIntegrityError(run_events._bound(_CHAIN_CATEGORY))
         prior_status, prior_digest = _run_snapshot_state(run_dir)
         payload = _allowlisted_payload(event_type, status=status)
         # Status transitions, not detail refreshes: a same-status refresh
-        # appends nothing once any event is committed, even when error/detail
-        # fields changed.
-        if prior_status == status and report.events:
-            return report.events[-1]
+        # appends nothing once a status event is already committed, even when
+        # error/detail fields changed. Recovery checkpoint events are not
+        # status events, so a first mapped-status write still appends its
+        # status event after the checkpoint event.
+        status_events = [e for e in report.events if e.event_type != run_checkpoint.CHECKPOINT_EVENT_TYPE]
+        if prior_status == status and status_events:
+            return status_events[-1]
         # Real transition: the idempotency key binds the prior snapshot digest
         # to the target event request. A crash/retry after the journal fsync
         # but before the run.json replacement sees the unchanged prior
@@ -273,16 +333,17 @@ def record_lifecycle_transition(
             expected_previous_sequence=report.events[-1].sequence if report.events else 0,
         )
     except run_journal.RunJournalError as exc:
-        raise LifecycleJournalError(run_events._bound(exc.diagnostic)) from exc
+        raise _bound_journal_failure(exc) from exc
     except run_events.CanonicalizationError as exc:
-        raise LifecycleJournalError(_CANONICALIZATION_CATEGORY) from exc
+        raise _bound_journal_failure(exc) from exc
     except OSError as exc:
-        raise LifecycleJournalError(f"{_IO_CATEGORY} ({type(exc).__name__})") from exc
+        raise _bound_journal_failure(exc) from exc
 
 
 __all__ = [
     "LifecycleJournalError",
     "STATUS_EVENT_TYPE",
     "is_lifecycle_journaling_enabled",
+    "prepare_lifecycle_journal",
     "record_lifecycle_transition",
 ]

--- a/src/brigade/run_projector.py
+++ b/src/brigade/run_projector.py
@@ -24,9 +24,9 @@ import json
 from dataclasses import dataclass
 from typing import Any, Mapping, Sequence
 
-from brigade import run_events, run_journal
+from brigade import run_checkpoint, run_events, run_journal
 
-PROJECTOR_VERSION: int = 1
+PROJECTOR_VERSION: int = 2
 
 # Field ownership over the run.json contract. Every current run.json key is
 # in exactly one of these two sets; see the ownership inventory in
@@ -248,10 +248,14 @@ def _derive_status(envelopes: list[Mapping[str, Any]], base_status: Any) -> str:
         if not isinstance(base_status, str):
             raise ProjectionInputError(_bound("base snapshot status must be a string when the event sequence is empty"))
         return base_status
-    status = ""
+    if not isinstance(base_status, str):
+        raise ProjectionInputError(_bound("base snapshot status must be a string when projecting events"))
+    status = base_status
     for env in envelopes:
         event_type = env["event_type"]
         sequence = env["sequence"]
+        if event_type == run_checkpoint.CHECKPOINT_EVENT_TYPE:
+            continue
         if event_type in EVENT_STATUS:
             status = EVENT_STATUS[event_type]
             continue

--- a/src/brigade/run_shadow.py
+++ b/src/brigade/run_shadow.py
@@ -27,7 +27,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from brigade import localio, run_events, run_journal, run_lifecycle, run_projector
+from brigade import localio, run_checkpoint, run_events, run_journal, run_lifecycle, run_projector
 
 SHADOW_SCHEMA: str = "brigade.run_shadow.v1"
 SHADOW_SCHEMA_VERSION: int = 1
@@ -159,6 +159,53 @@ def _append_evidence_unreadable(data: dict[str, Any], tail_seq: int | None, tail
     )
 
 
+def _checkpoint_status_write_gap(
+    run_dir: Path,
+    *,
+    prior_seq: int | None,
+    tail_seq: int,
+) -> bool:
+    """Return True when ``tail_seq`` advanced by exactly one checkpoint+status write.
+
+    A normal activated-journal mapped transition appends ``run.snapshot.checkpointed``
+    immediately before the mapped status event, so the journal tail can jump by two
+    sequences between comparisons without a skipped shadow step.
+    """
+    if prior_seq is None:
+        if tail_seq != 2:
+            return False
+        expected_checkpoint_seq = 1
+        expected_status_seq = 2
+    elif tail_seq != prior_seq + 2:
+        return False
+    else:
+        expected_checkpoint_seq = prior_seq + 1
+        expected_status_seq = tail_seq
+    try:
+        journal_report = run_journal.read_journal(run_lifecycle._journal_path(run_dir))
+    except (OSError, run_journal.RunJournalError):
+        return False
+    if journal_report.partial_tail is not None or journal_report.chain_errors:
+        return False
+    events = journal_report.events
+    if len(events) < expected_status_seq:
+        return False
+    checkpoint = events[expected_checkpoint_seq - 1]
+    status_event = events[expected_status_seq - 1]
+    if checkpoint.sequence != expected_checkpoint_seq:
+        return False
+    if checkpoint.event_type != run_checkpoint.CHECKPOINT_EVENT_TYPE:
+        return False
+    if status_event.sequence != expected_status_seq:
+        return False
+    paired_event_type = checkpoint.payload.get("paired_event_type")
+    if not isinstance(paired_event_type, str):
+        return False
+    if status_event.event_type != paired_event_type:
+        return False
+    return paired_event_type in run_lifecycle.STATUS_EVENT_TYPE.values()
+
+
 def _append_gap_record(data: dict[str, Any], tail_seq: int, tail_digest: str | None) -> None:
     now = localio.utc_now_iso()
     data["comparisons"] = int(data.get("comparisons", 0) or 0) + 1
@@ -220,9 +267,12 @@ def _record_outcome(
     # the tail is already beyond the first transition.
     prior_seq = data.get("last_compared_sequence")
     if isinstance(tail_seq, int):
+        gap = False
         if isinstance(prior_seq, int) and tail_seq > prior_seq + 1:
-            _append_gap_record(data, tail_seq, tail_digest)
+            gap = not _checkpoint_status_write_gap(run_dir, prior_seq=prior_seq, tail_seq=tail_seq)
         elif prior_seq is None and tail_seq > 1:
+            gap = not _checkpoint_status_write_gap(run_dir, prior_seq=None, tail_seq=tail_seq)
+        if gap:
             _append_gap_record(data, tail_seq, tail_digest)
     data["comparisons"] = int(data.get("comparisons", 0) or 0) + 1
     if outcome == OUTCOME_MATCH:
@@ -440,6 +490,7 @@ def check_projection_readiness(run_dir: Path) -> ReadinessReport:
             data.get("schema") != SHADOW_SCHEMA
             or data.get("schema_version") != SHADOW_SCHEMA_VERSION
             or data.get("run_id") != run_dir.name
+            or data.get("projector_version") != run_projector.PROJECTOR_VERSION
             or data.get("last_outcome") not in _OUTCOMES
         ):
             return ReadinessReport(ready=False, reasons=(REASON_EVIDENCE_SCHEMA_MISMATCH,))

--- a/src/brigade/runguard.py
+++ b/src/brigade/runguard.py
@@ -277,6 +277,81 @@ def _claim_existing_stale(path: Path, stale: Path) -> tuple[Path, dict[str, obje
     return claimed, _owner_with_workspace(_read_lock_owner(claimed), path)
 
 
+def _build_stale_lock_recovery_receipt(
+    payload: dict[str, object],
+    *,
+    owner_pid: int,
+    recovered_at: str,
+    prior_status: str,
+    lock_workspace: object | None = None,
+    lock_acquired_at: object | None = None,
+    persist_recovery_provenance: bool = False,
+) -> dict[str, object]:
+    """Pure builder for the stale-lock-recovery terminal receipt payload.
+
+    Derives the failure attribution (``dispatching``/``active_seats`` ->
+    ``phase_owner`` -> ``worker`` -> ``orchestrator``), applies the
+    ``cwd``/``lock_workspace``/``started_at`` metadata defaults, and stamps the
+    run receipt. Never touches the filesystem; the caller owns reading
+    ``run.json``, the terminal-status short-circuit, and the final write.
+    ``persist_recovery_provenance`` controls whether ``lock_workspace``/
+    ``lock_acquired_at`` are recorded on the ``failure`` sub-object (the
+    persisted-provenance path) versus applied only as run.json metadata
+    defaults (the legacy path). Mutates ``payload`` in place; callers pass a
+    fresh copy they own.
+    """
+    detail = f"run owner process {owner_pid} is no longer active"
+    failure_attribution: dict[str, object] = {}
+    stored_status = payload.get("status")
+    active_seats = payload.get("active_seats")
+    phase_owner = payload.get("phase_owner")
+    if stored_status == "dispatching" and isinstance(active_seats, list):
+        seats = [seat for seat in active_seats if isinstance(seat, str) and seat]
+        if len(seats) == 1:
+            failure_attribution["seat"] = seats[0]
+        elif seats:
+            failure_attribution["seats"] = seats
+    if not failure_attribution and isinstance(phase_owner, str) and phase_owner:
+        failure_attribution["seat"] = phase_owner
+    if not failure_attribution:
+        worker = payload.get("worker")
+        orchestrator = payload.get("orchestrator")
+        if isinstance(worker, str) and worker:
+            failure_attribution["seat"] = worker
+        elif isinstance(orchestrator, str) and orchestrator:
+            failure_attribution["seat"] = orchestrator
+    if isinstance(lock_workspace, str) and lock_workspace:
+        payload.setdefault("cwd", lock_workspace)
+        payload.setdefault("lock_workspace", lock_workspace)
+    if isinstance(lock_acquired_at, str) and lock_acquired_at:
+        payload.setdefault("started_at", lock_acquired_at)
+    failure_payload: dict[str, object] = {
+        "phase": "stale-lock-recovery",
+        "kind": "owner-process-exited",
+        "detail": detail,
+        "owner_pid": owner_pid,
+        "prior_status": prior_status,
+        "recovered_at": recovered_at,
+        **failure_attribution,
+    }
+    if persist_recovery_provenance:
+        if isinstance(lock_workspace, str) and lock_workspace:
+            failure_payload["lock_workspace"] = lock_workspace
+        if isinstance(lock_acquired_at, str) and lock_acquired_at:
+            failure_payload["lock_acquired_at"] = lock_acquired_at
+    payload.update(
+        {
+            "status": "failed",
+            "status_started_at": recovered_at,
+            "finished_at": recovered_at,
+            "error": detail,
+            "failure_phase": "stale-lock-recovery",
+            "failure": failure_payload,
+        }
+    )
+    return receipt_schema.stamp_run_receipt(payload)
+
+
 def _recover_run_artifact(owner: dict[str, object] | None, *, persist_recovery_provenance: bool = False) -> str:
     if owner is None:
         return "unattributable"
@@ -321,61 +396,17 @@ def _recover_run_artifact(owner: dict[str, object] | None, *, persist_recovery_p
             if status not in _NONTERMINAL_RUN_STATUSES:
                 return "terminal"
     recovered_at = datetime.now(timezone.utc).isoformat()
-    detail = f"run owner process {owner_pid} is no longer active"
-    failure_attribution: dict[str, object] = {}
-    stored_status = payload.get("status")
-    active_seats = payload.get("active_seats")
-    phase_owner = payload.get("phase_owner")
-    if stored_status == "dispatching" and isinstance(active_seats, list):
-        seats = [seat for seat in active_seats if isinstance(seat, str) and seat]
-        if len(seats) == 1:
-            failure_attribution["seat"] = seats[0]
-        elif seats:
-            failure_attribution["seats"] = seats
-    if not failure_attribution and isinstance(phase_owner, str) and phase_owner:
-        failure_attribution["seat"] = phase_owner
-    if not failure_attribution:
-        worker = payload.get("worker")
-        orchestrator = payload.get("orchestrator")
-        if isinstance(worker, str) and worker:
-            failure_attribution["seat"] = worker
-        elif isinstance(orchestrator, str) and orchestrator:
-            failure_attribution["seat"] = orchestrator
-    workspace = owner.get("_lock_workspace")
-    if isinstance(workspace, str) and workspace:
-        payload.setdefault("cwd", workspace)
-        payload.setdefault("lock_workspace", workspace)
-    acquired_at = owner.get("acquired_at")
-    if isinstance(acquired_at, str) and acquired_at:
-        payload.setdefault("started_at", acquired_at)
-    failure_payload: dict[str, object] = {
-        "phase": "stale-lock-recovery",
-        "kind": "owner-process-exited",
-        "detail": detail,
-        "owner_pid": owner_pid,
-        "prior_status": prior_status,
-        "recovered_at": recovered_at,
-        **failure_attribution,
-    }
-    if persist_recovery_provenance:
-        provenance_workspace = owner.get("_lock_workspace")
-        if isinstance(provenance_workspace, str) and provenance_workspace:
-            failure_payload["lock_workspace"] = provenance_workspace
-        provenance_acquired_at = owner.get("acquired_at")
-        if isinstance(provenance_acquired_at, str) and provenance_acquired_at:
-            failure_payload["lock_acquired_at"] = provenance_acquired_at
-    payload.update(
-        {
-            "status": "failed",
-            "status_started_at": recovered_at,
-            "finished_at": recovered_at,
-            "error": detail,
-            "failure_phase": "stale-lock-recovery",
-            "failure": failure_payload,
-        }
+    stamped = _build_stale_lock_recovery_receipt(
+        payload,
+        owner_pid=owner_pid,
+        recovered_at=recovered_at,
+        prior_status=prior_status,
+        lock_workspace=owner.get("_lock_workspace"),
+        lock_acquired_at=owner.get("acquired_at"),
+        persist_recovery_provenance=persist_recovery_provenance,
     )
     try:
-        localio.write_json(run_json, receipt_schema.stamp_run_receipt(payload))
+        localio.write_json(run_json, stamped)
     except OSError:
         return "write-failed"
     return "recovered"
@@ -494,7 +525,12 @@ def run_lock_state(workspace: Path, run_dir: Path) -> str:
     """
     try:
         path = lock_path(workspace)
-    except RunGuardError:
+    except (RunGuardError, OSError, RuntimeError):
+        # ``lock_path`` raises ``RunGuardError`` for a non-worktree git failure
+        # and ``OSError``/``RuntimeError`` from path resolution (``resolve``,
+        # or ``expanduser`` when HOME is unavailable) for a non-worktree
+        # workspace. The predicate is never-raises: an unresolvable workspace
+        # normalizes to ``absent`` so callers fail closed.
         return "absent"
     try:
         if not path.exists():
@@ -598,8 +634,19 @@ def _recover_pending_claims(
     recovered = False
     for stale in _stale_claims(path):
         pre_claim_owner = _read_lock_owner(stale)
-        if run_dir is not None and not _owner_matches_run(pre_claim_owner, run_dir):
-            continue
+        if run_dir is not None:
+            try:
+                matches = _owner_matches_run(pre_claim_owner, run_dir)
+            except (OSError, RuntimeError):
+                # ``_owner_matches_run`` resolves the owner's recorded run_dir
+                # via ``expanduser``/``resolve``; ``expanduser`` raises
+                # ``RuntimeError`` when HOME is unavailable and ``resolve``
+                # can raise ``OSError`` on a cyclic or vanished path. Fail
+                # closed: skip the claim we cannot verify rather than letting
+                # the error escape the recovery gate.
+                continue
+            if not matches:
+                continue
         claimed_owner = _claim_existing_stale(path, stale)
         if claimed_owner is None:
             continue

--- a/src/brigade/runguard.py
+++ b/src/brigade/runguard.py
@@ -9,6 +9,7 @@ import json
 import os
 import shutil
 import stat
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -191,7 +192,7 @@ def _lock_owner_payload(*, owner_token: str, run_dir: Path | None) -> dict[str, 
 def _read_lock_owner(path: Path) -> dict[str, object] | None:
     try:
         payload = json.loads((path / "owner.json").read_text())
-    except (OSError, json.JSONDecodeError):
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError, RecursionError):
         return None
     return payload if isinstance(payload, dict) else None
 
@@ -276,7 +277,7 @@ def _claim_existing_stale(path: Path, stale: Path) -> tuple[Path, dict[str, obje
     return claimed, _owner_with_workspace(_read_lock_owner(claimed), path)
 
 
-def _recover_run_artifact(owner: dict[str, object] | None) -> str:
+def _recover_run_artifact(owner: dict[str, object] | None, *, persist_recovery_provenance: bool = False) -> str:
     if owner is None:
         return "unattributable"
     raw_run_dir = owner.get("run_dir")
@@ -347,6 +348,22 @@ def _recover_run_artifact(owner: dict[str, object] | None) -> str:
     acquired_at = owner.get("acquired_at")
     if isinstance(acquired_at, str) and acquired_at:
         payload.setdefault("started_at", acquired_at)
+    failure_payload: dict[str, object] = {
+        "phase": "stale-lock-recovery",
+        "kind": "owner-process-exited",
+        "detail": detail,
+        "owner_pid": owner_pid,
+        "prior_status": prior_status,
+        "recovered_at": recovered_at,
+        **failure_attribution,
+    }
+    if persist_recovery_provenance:
+        provenance_workspace = owner.get("_lock_workspace")
+        if isinstance(provenance_workspace, str) and provenance_workspace:
+            failure_payload["lock_workspace"] = provenance_workspace
+        provenance_acquired_at = owner.get("acquired_at")
+        if isinstance(provenance_acquired_at, str) and provenance_acquired_at:
+            failure_payload["lock_acquired_at"] = provenance_acquired_at
     payload.update(
         {
             "status": "failed",
@@ -354,15 +371,7 @@ def _recover_run_artifact(owner: dict[str, object] | None) -> str:
             "finished_at": recovered_at,
             "error": detail,
             "failure_phase": "stale-lock-recovery",
-            "failure": {
-                "phase": "stale-lock-recovery",
-                "kind": "owner-process-exited",
-                "detail": detail,
-                "owner_pid": owner_pid,
-                "prior_status": prior_status,
-                "recovered_at": recovered_at,
-                **failure_attribution,
-            },
+            "failure": failure_payload,
         }
     )
     try:
@@ -420,8 +429,105 @@ def _quarantine_unattributable(path: Path, claimed: Path) -> None:
         pass
 
 
-def _finish_claimed_recovery(path: Path, claimed: Path, owner: dict[str, object] | None) -> str:
-    recovery = _recover_run_artifact(owner)
+def _retain_claim(path: Path, claimed: Path) -> Path:
+    """Rename a claimed lock to a persisted ``.stale`` path for explicit recovery.
+
+    The retained name carries no live pid prefix so a later
+    ``_recover_pending_claims``/``_claim_existing_stale`` pass does not treat the
+    current process as still recovering it.
+    """
+    retained = path.with_name(f".{path.name}.retained-{uuid4().hex}.stale")
+    try:
+        claimed.rename(retained)
+    except OSError:
+        return claimed
+    return retained
+
+
+def _claim_is_activated(owner: dict[str, object] | None) -> bool:
+    if owner is None:
+        return False
+    raw_run_dir = owner.get("run_dir")
+    if not isinstance(raw_run_dir, str) or not raw_run_dir:
+        return False
+    try:
+        journal = Path(raw_run_dir).expanduser().resolve() / "events" / "lifecycle.jsonl"
+    except OSError:
+        return False
+    return journal.is_file()
+
+
+def _invoke_before_terminalize(
+    path: Path,
+    claimed: Path,
+    owner: dict[str, object] | None,
+    before_terminalize: Callable[[dict[str, object] | None], None] | None,
+) -> None:
+    if before_terminalize is None:
+        if _claim_is_activated(owner):
+            retained = _retain_claim(path, claimed)
+            raise RunLockError(
+                f"activated-journal run lock requires explicit `brigade runs recover`; claim retained at {retained}"
+            )
+        _finish_claimed_recovery(path, claimed, owner)
+        return
+    try:
+        before_terminalize(owner)
+    except Exception:
+        restored = _restore_claimed_lock(path, claimed)
+        raise RunLockError(f"before_terminalize callback failed; lock restored at {restored}") from None
+    _finish_claimed_recovery(path, claimed, owner, persist_recovery_provenance=True)
+
+
+def run_lock_state(workspace: Path, run_dir: Path) -> str:
+    """Read-only lock-state predicate for doctor/operator inspection.
+
+    Returns exactly one of ``absent``, ``live``, ``stale``, ``foreign``, or
+    ``invalid``. Never raises and never mutates the lock directory or its
+    owner metadata. ``live`` covers both the current process and any live
+    foreign pid; ``stale`` requires a matching ``run_dir``; ``foreign`` is a
+    dead owner whose ``run_dir`` does not match.
+    """
+    try:
+        path = lock_path(workspace)
+    except RunGuardError:
+        return "absent"
+    try:
+        if not path.exists():
+            return "absent"
+        if not path.is_dir():
+            return "invalid"
+    except OSError:
+        return "invalid"
+    owner = _read_lock_owner(path)
+    if owner is None:
+        return "invalid"
+    owner_pid = owner.get("pid")
+    if not isinstance(owner_pid, int):
+        return "invalid"
+    try:
+        resolved_run_dir = run_dir.expanduser().resolve()
+    except (OSError, RuntimeError):
+        resolved_run_dir = run_dir
+    try:
+        matches_run = _owner_matches_run(owner, resolved_run_dir)
+        if _pid_is_active(owner_pid):
+            return "live"
+        if not matches_run:
+            return "foreign"
+        return "stale"
+    except Exception:
+        return "invalid"
+
+
+def _finish_claimed_recovery(
+    path: Path,
+    claimed: Path,
+    owner: dict[str, object] | None,
+    *,
+    persist_recovery_provenance: bool = False,
+) -> str:
+    recovery = _recover_run_artifact(owner, persist_recovery_provenance=persist_recovery_provenance)
     if recovery == "write-failed":
         retained = _restore_claimed_lock(path, claimed)
         raise RunLockError(f"could not preserve the stale run failure; lock retained at {retained}")
@@ -432,24 +538,41 @@ def _finish_claimed_recovery(path: Path, claimed: Path, owner: dict[str, object]
     return recovery
 
 
-def _recover_pending_claims(path: Path, *, run_dir: Path | None = None, required: bool = False) -> bool:
+def _recover_pending_claims(
+    path: Path,
+    *,
+    run_dir: Path | None = None,
+    required: bool = False,
+    before_terminalize: Callable[[dict[str, object] | None], None] | None = None,
+) -> bool:
     recovered = False
     for stale in _stale_claims(path):
-        owner = _read_lock_owner(stale)
-        if run_dir is not None and not _owner_matches_run(owner, run_dir):
+        pre_claim_owner = _read_lock_owner(stale)
+        if run_dir is not None and not _owner_matches_run(pre_claim_owner, run_dir):
             continue
         claimed_owner = _claim_existing_stale(path, stale)
         if claimed_owner is None:
             continue
         claimed, owner = claimed_owner
-        _finish_claimed_recovery(path, claimed, owner)
+        pre_token = pre_claim_owner.get("owner_token") if pre_claim_owner is not None else None
+        claimed_token = owner.get("owner_token") if owner is not None else None
+        if pre_token != claimed_token:
+            restored = _restore_claimed_lock(stale, claimed)
+            raise RunLockError(f"run lock owner changed during pending claim recovery; lock restored at {restored}")
+        _invoke_before_terminalize(path, claimed, owner, before_terminalize)
         recovered = True
     if required and not recovered:
         raise RunLockError(f"run lock not found for run: {run_dir}")
     return recovered
 
 
-def recover_stale_run(cwd: Path, run_dir: Path, *, required: bool = True) -> bool:
+def recover_stale_run(
+    cwd: Path,
+    run_dir: Path,
+    *,
+    required: bool = True,
+    before_terminalize: Callable[[dict[str, object] | None], None] | None = None,
+) -> bool:
     run_dir = run_dir.expanduser().resolve()
     path = lock_path(cwd)
     if path.exists() and not path.is_dir():
@@ -468,11 +591,11 @@ def recover_stale_run(cwd: Path, run_dir: Path, *, required: bool = True) -> boo
                 if claimed_owner is None or claimed_owner.get("owner_token") != owner.get("owner_token"):
                     retained = _restore_claimed_lock(path, claimed)
                     raise RunLockError(f"run lock owner changed during recovery; lock retained at {retained}")
-                _finish_claimed_recovery(path, claimed, claimed_owner)
+                _invoke_before_terminalize(path, claimed, claimed_owner, before_terminalize)
                 return True
         elif required:
             raise RunLockError(f"run lock belongs to a different run: {path}")
-    return _recover_pending_claims(path, run_dir=run_dir, required=required)
+    return _recover_pending_claims(path, run_dir=run_dir, required=required, before_terminalize=before_terminalize)
 
 
 def run_recovery_status(cwd: Path, run_dir: Path) -> str:
@@ -509,7 +632,7 @@ def _acquire_lock(path: Path, *, run_dir: Path | None = None) -> _LockOwnership:
                     f"another brigade run appears active: {path}. Remove the lock only if no run is active."
                 ) from None
             claimed, owner = stale
-            _finish_claimed_recovery(path, claimed, owner)
+            _invoke_before_terminalize(path, claimed, owner, None)
             continue
         pending = _stale_claims(path)
         if not pending:

--- a/src/brigade/runguard.py
+++ b/src/brigade/runguard.py
@@ -452,9 +452,13 @@ def _claim_is_activated(owner: dict[str, object] | None) -> bool:
         return False
     try:
         journal = Path(raw_run_dir).expanduser().resolve() / "events" / "lifecycle.jsonl"
-    except OSError:
+        return journal.is_file()
+    except (RuntimeError, OSError):
+        # expanduser raises RuntimeError when it cannot determine the home
+        # directory; resolve/is_file can raise OSError on a vanishing or
+        # unreadable path. The activation probe is best-effort and must never
+        # escape the recovery gate.
         return False
-    return journal.is_file()
 
 
 def _invoke_before_terminalize(
@@ -520,6 +524,52 @@ def run_lock_state(workspace: Path, run_dir: Path) -> str:
         return "invalid"
 
 
+def has_matching_stale_claim(workspace: Path, run_dir: Path) -> bool:
+    """Read-only predicate: True when a persistent ``.run.lock.*.stale`` claim
+    exists whose owner metadata points at ``run_dir``.
+
+    Used by the CLI recovery preflight to relax the foreign/invalid lock
+    refusal: when a matching persistent stale claim exists, recovery may
+    proceed under a foreign or invalid current lock and recover only the
+    matching claim without mutating the current lock. Never raises and never
+    mutates the lock directory or any stale claim; a read failure on any
+    claim normalizes to ``False`` so the preflight fails closed.
+    """
+    try:
+        path = lock_path(workspace)
+    except (RunGuardError, OSError, RuntimeError):
+        # ``lock_path`` raises ``RunGuardError`` for a non-worktree git failure
+        # and ``OSError``/``RuntimeError`` from path resolution (``resolve``,
+        # or ``expanduser`` when HOME is unavailable) for a non-worktree
+        # workspace.
+        return False
+    try:
+        resolved_run_dir = run_dir.expanduser().resolve()
+    except (OSError, RuntimeError):
+        resolved_run_dir = run_dir
+    try:
+        claims = _stale_claims(path)
+    except OSError:
+        # The ``_stale_claims`` glob can raise ``OSError`` when the lock parent
+        # is unreadable or vanishes mid-probe; fail closed.
+        return False
+    for stale in claims:
+        owner = _read_lock_owner(stale)
+        if owner is None:
+            continue
+        try:
+            matches = _owner_matches_run(owner, resolved_run_dir)
+        except (OSError, RuntimeError):
+            # ``_owner_matches_run`` resolves the recorded run_dir via
+            # ``expanduser``/``resolve``; ``expanduser`` raises ``RuntimeError``
+            # when HOME is unavailable and ``resolve`` can raise ``OSError``.
+            # Fail closed for this claim without aborting the remaining claims.
+            continue
+        if matches:
+            return True
+    return False
+
+
 def _finish_claimed_recovery(
     path: Path,
     claimed: Path,
@@ -579,9 +629,7 @@ def recover_stale_run(
         raise RunLockError(f"malformed run lock is not a directory: {path}")
     if path.is_dir():
         owner = _read_lock_owner(path)
-        if owner is None:
-            raise RunLockError(f"run lock has no owner metadata: {path}")
-        if _owner_matches_run(owner, run_dir):
+        if owner is not None and _owner_matches_run(owner, run_dir):
             stale = _claim_stale_lock(path)
             if stale is None:
                 if path.exists():
@@ -593,8 +641,12 @@ def recover_stale_run(
                     raise RunLockError(f"run lock owner changed during recovery; lock retained at {retained}")
                 _invoke_before_terminalize(path, claimed, claimed_owner, before_terminalize)
                 return True
-        elif required:
-            raise RunLockError(f"run lock belongs to a different run: {path}")
+        # A foreign or invalid live lock (owner missing, owner pid missing,
+        # or owner pointing at a different run) must not be mutated, but it
+        # also must not block recovery of a matching persistent .stale claim.
+        # Fall through to _recover_pending_claims, which recovers matching
+        # .stale claims without touching the live lock and raises
+        # "run lock not found for run" only when nothing was recovered.
     return _recover_pending_claims(path, run_dir=run_dir, required=required, before_terminalize=before_terminalize)
 
 

--- a/src/brigade/runs_cmd.py
+++ b/src/brigade/runs_cmd.py
@@ -636,67 +636,106 @@ def _print_terminal_guidance(run_dir: Path, run_meta: dict[str, Any]) -> None:
     _print_recovery_guidance(run_dir)
 
 
-def recover(run: str | Path, *, cwd: Path, runs_dir: Path | None = None) -> int:
+def _journal_active(run_dir: Path) -> bool:
+    return (run_dir / "events" / "lifecycle.jsonl").is_file()
+
+
+def _read_run_json_state(run_dir: Path) -> tuple[bool, dict[str, Any] | None, str | None, bool]:
+    """Return (parseable, run_meta, read_error, read_oserror) for run.json.
+
+    ``parseable`` is True only when run.json exists and parses to a dict;
+    ``run_meta`` is that dict or None; ``read_error`` is a bounded message
+    describing why run.json could not be read (missing or corrupt).
+    When ``read_oserror`` is True a raw ``OSError`` prevented reading
+    run.json and recovery must fail closed before claiming the lock.
+    """
+    run_json = run_dir / "run.json"
+    if not run_json.exists():
+        return False, None, f"run.json not found in {run_dir}", False
+    try:
+        text = run_json.read_text(encoding="utf-8")
+    except OSError:
+        return False, None, "could not read run.json", True
+    except UnicodeDecodeError as exc:
+        return False, None, f"run.json is not valid UTF-8: {exc}", False
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        return False, None, f"run.json is not valid JSON: {exc}", False
+    except RecursionError:
+        return False, None, "run.json JSON nesting too deep", False
+    if not isinstance(payload, dict):
+        return False, None, "run.json must contain a JSON object", False
+    return True, payload, None, False
+
+
+def _state_refusal_message(state: str, workspace: Path) -> str:
     from . import runguard
 
-    run_dir, error = _resolve_run_dir(run, cwd=cwd, runs_dir=runs_dir)
-    if error is not None:
-        print(error, file=sys.stderr)
-        return 2
-    assert run_dir is not None
-    recovered_unreadable_artifact = False
-    read_error: str | None = None
-    try:
-        run_meta = _read_json(run_dir / "run.json")
-    except ValueError as exc:
-        run_meta = None
-        read_error = str(exc)
-    else:
-        read_error = f"run.json not found in {run_dir}" if run_meta is None else None
-    if run_meta is None:
-        workspace = _lock_workspace(run_dir, {}, fallback=cwd)
-        assert workspace is not None
-        try:
-            runguard.recover_stale_run(workspace, run_dir)
-        except runguard.RunLockError as exc:
-            detail = read_error if str(exc).startswith("run lock not found for run:") else str(exc)
-            print(f"error: {detail}", file=sys.stderr)
+    lock = runguard.lock_path(workspace)
+    if state == "live":
+        return f"error: run owner process is still active: {lock}"
+    if state == "foreign":
+        return f"error: run lock belongs to a different run: {lock}"
+    return f"error: run lock is invalid: {lock}"
+
+
+def _recover_terminal(run_dir: Path, run_meta: dict[str, Any], cwd: Path) -> int:
+    from . import runguard
+
+    phase, _, _ = _failure_fields(run_meta)
+    if phase == "stale-lock-recovery":
+        workspace = _lock_workspace(run_dir, run_meta, fallback=cwd)
+        if workspace is None:
+            print(f"error: recovered run artifact has no workspace cwd: {run_dir}", file=sys.stderr)
             return 2
+        # An activated journal requires an explicit before_terminalize callback
+        # before runguard will clear the claimed lock; the run is already
+        # terminal so a no-op callback is sufficient (no run.json restoration).
+        callback: Any = None
+        if _journal_active(run_dir):
+            callback = lambda owner: None  # noqa: E731  (intentional no-op)
         try:
-            run_meta = _read_json(run_dir / "run.json")
-        except ValueError as exc:
+            runguard.recover_stale_run(workspace, run_dir, required=False, before_terminalize=callback)
+        except runguard.RunLockError as exc:
             print(f"error: {exc}", file=sys.stderr)
             return 2
-        if run_meta is None:
-            print(f"error: run.json not found in {run_dir} after recovery", file=sys.stderr)
-            return 2
-        recovered_unreadable_artifact = True
-    if recovered_unreadable_artifact:
-        print(f"recovered: {run_dir}")
-        _print_recovery_guidance(run_dir)
-        return 0
-    if _is_terminal(run_meta):
-        phase, _, _ = _failure_fields(run_meta)
-        if phase == "stale-lock-recovery":
-            workspace = _lock_workspace(run_dir, run_meta, fallback=cwd)
-            if workspace is None:
-                print(f"error: recovered run artifact has no workspace cwd: {run_dir}", file=sys.stderr)
-                return 2
-            try:
-                runguard.recover_stale_run(workspace, run_dir, required=False)
-            except runguard.RunLockError as exc:
-                print(f"error: {exc}", file=sys.stderr)
-                return 2
-        print(f"already terminal: {run_dir} [{run_meta.get('status', 'unknown')}]")
-        _print_recovery_guidance(run_dir)
-        return 0
-    workspace = _lock_workspace(run_dir, run_meta, fallback=cwd)
-    if workspace is None:
-        print(f"error: run artifact has no workspace cwd: {run_dir}", file=sys.stderr)
-        return 2
+    print(f"already terminal: {run_dir} [{run_meta.get('status', 'unknown')}]")
+    _print_recovery_guidance(run_dir)
+    return 0
+
+
+def _recover_from_checkpoint(
+    run_dir: Path,
+    workspace: Path,
+    parseable: bool,
+    run_meta: dict[str, Any] | None,
+    read_error: str | None,
+) -> int:
+    from . import run_checkpoint, runguard
+
+    # runguard wraps every before_terminalize callback exception into a
+    # RunLockError after restoring the claimed lock, so a CheckpointError raised
+    # inside the callback can never be caught directly here. Preserve the
+    # original bounded CheckpointError in this holder so the RunLockError
+    # handler below can surface the specific checkpoint reason instead of the
+    # generic runguard "before_terminalize callback failed" wrapper.
+    checkpoint_failure: run_checkpoint.CheckpointError | None = None
+
+    def before_terminalize(owner: dict[str, object] | None) -> None:
+        nonlocal checkpoint_failure
+        try:
+            run_checkpoint.recover_from_checkpoint(run_dir, run_meta if parseable else None)
+        except run_checkpoint.CheckpointError as exc:
+            checkpoint_failure = exc
+            raise
+
     try:
-        runguard.recover_stale_run(workspace, run_dir)
+        runguard.recover_stale_run(workspace, run_dir, before_terminalize=before_terminalize)
     except runguard.RunLockError as exc:
+        if checkpoint_failure is not None:
+            print(f"error: {checkpoint_failure}", file=sys.stderr)
+            return 2
         if str(exc).startswith("run lock not found for run:"):
             try:
                 concurrent_meta = _read_json(run_dir / "run.json")
@@ -711,6 +750,83 @@ def recover(run: str | Path, *, cwd: Path, runs_dir: Path | None = None) -> int:
     print(f"recovered: {run_dir}")
     _print_recovery_guidance(run_dir)
     return 0
+
+
+def _recover_legacy(
+    run_dir: Path,
+    workspace: Path,
+    parseable: bool,
+    run_meta: dict[str, Any] | None,
+    read_error: str | None,
+) -> int:
+    from . import runguard
+
+    try:
+        runguard.recover_stale_run(workspace, run_dir)
+    except runguard.RunLockError as exc:
+        if str(exc).startswith("run lock not found for run:"):
+            try:
+                concurrent_meta = _read_json(run_dir / "run.json")
+            except ValueError:
+                concurrent_meta = None
+            if concurrent_meta is not None and _is_terminal(concurrent_meta):
+                print(f"already terminal: {run_dir} [{concurrent_meta.get('status', 'unknown')}]")
+                _print_recovery_guidance(run_dir)
+                return 0
+            detail = read_error if not parseable else str(exc)
+        else:
+            detail = str(exc)
+        print(f"error: {detail}", file=sys.stderr)
+        return 2
+    if not parseable:
+        try:
+            recovered_meta = _read_json(run_dir / "run.json")
+        except ValueError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        if recovered_meta is None:
+            print(f"error: run.json not found in {run_dir} after recovery", file=sys.stderr)
+            return 2
+    print(f"recovered: {run_dir}")
+    _print_recovery_guidance(run_dir)
+    return 0
+
+
+def recover(run: str | Path, *, cwd: Path, runs_dir: Path | None = None) -> int:
+    run_dir, error = _resolve_run_dir(run, cwd=cwd, runs_dir=runs_dir)
+    if error is not None:
+        print(error, file=sys.stderr)
+        return 2
+    assert run_dir is not None
+
+    parseable, run_meta, read_error, read_oserror = _read_run_json_state(run_dir)
+    if read_oserror:
+        print(f"error: {read_error}", file=sys.stderr)
+        return 2
+
+    # Terminal runs keep the legacy behavior: tolerate foreign locks and only
+    # clear a matching stale lock when the failure phase is stale-lock-recovery.
+    if parseable and run_meta is not None and _is_terminal(run_meta):
+        return _recover_terminal(run_dir, run_meta, cwd)
+
+    # Entry gate for recovery (nonterminal or missing/corrupt run.json). Refuse
+    # live current/foreign/invalid locks without claiming or mutating anything.
+    workspace_meta: dict[str, Any] = run_meta if parseable and run_meta is not None else {}
+    workspace = _lock_workspace(run_dir, workspace_meta, fallback=cwd)
+    if workspace is None:
+        print(f"error: run artifact has no workspace cwd: {run_dir}", file=sys.stderr)
+        return 2
+
+    from . import runguard
+
+    state = runguard.run_lock_state(workspace, run_dir)
+    if state in {"live", "foreign", "invalid"}:
+        print(_state_refusal_message(state, workspace), file=sys.stderr)
+        return 2
+
+    if _journal_active(run_dir):
+        return _recover_from_checkpoint(run_dir, workspace, parseable, run_meta, read_error)
+    return _recover_legacy(run_dir, workspace, parseable, run_meta, read_error)
 
 
 def watch(

--- a/src/brigade/runs_cmd.py
+++ b/src/brigade/runs_cmd.py
@@ -621,6 +621,21 @@ def _lock_recovery_status(run_dir: Path, run_meta: dict[str, Any]) -> str:
     return runguard.run_recovery_status(workspace, run_dir)
 
 
+def _concurrent_terminal_meta(run_dir: Path) -> dict[str, Any] | None:
+    """Return the terminal run.json meta if a concurrent recovery already finished it.
+
+    Used in the "run lock not found for run" fallback: another process claimed and
+    terminalized the run while this recovery was racing for the lock. Uses
+    ``_read_run_json_state`` so invalid UTF-8, deep JSON nesting (RecursionError),
+    or a raw OSError stay bounded (the caller returns rc=2) instead of escaping as
+    raw exceptions from ``_read_json``.
+    """
+    parseable, meta, _error, _oserror = _read_run_json_state(run_dir)
+    if parseable and meta is not None and _is_terminal(meta):
+        return meta
+    return None
+
+
 def _print_terminal_guidance(run_dir: Path, run_meta: dict[str, Any]) -> None:
     phase, _, _ = _failure_fields(run_meta)
     if phase != "stale-lock-recovery":
@@ -737,11 +752,8 @@ def _recover_from_checkpoint(
             print(f"error: {checkpoint_failure}", file=sys.stderr)
             return 2
         if str(exc).startswith("run lock not found for run:"):
-            try:
-                concurrent_meta = _read_json(run_dir / "run.json")
-            except ValueError:
-                concurrent_meta = None
-            if concurrent_meta is not None and _is_terminal(concurrent_meta):
+            concurrent_meta = _concurrent_terminal_meta(run_dir)
+            if concurrent_meta is not None:
                 print(f"already terminal: {run_dir} [{concurrent_meta.get('status', 'unknown')}]")
                 _print_recovery_guidance(run_dir)
                 return 0
@@ -765,11 +777,8 @@ def _recover_legacy(
         runguard.recover_stale_run(workspace, run_dir)
     except runguard.RunLockError as exc:
         if str(exc).startswith("run lock not found for run:"):
-            try:
-                concurrent_meta = _read_json(run_dir / "run.json")
-            except ValueError:
-                concurrent_meta = None
-            if concurrent_meta is not None and _is_terminal(concurrent_meta):
+            concurrent_meta = _concurrent_terminal_meta(run_dir)
+            if concurrent_meta is not None:
                 print(f"already terminal: {run_dir} [{concurrent_meta.get('status', 'unknown')}]")
                 _print_recovery_guidance(run_dir)
                 return 0
@@ -820,7 +829,17 @@ def recover(run: str | Path, *, cwd: Path, runs_dir: Path | None = None) -> int:
     from . import runguard
 
     state = runguard.run_lock_state(workspace, run_dir)
-    if state in {"live", "foreign", "invalid"}:
+    if state in {"foreign", "invalid"}:
+        # A foreign or invalid current lock must not block recovery of a
+        # matching persistent .stale claim: runguard.recover_stale_run skips
+        # the live lock without mutating it and recovers only the matching
+        # claim. When no matching claim exists, keep the existing refusal
+        # and no-mutation behavior. Live (active-owner) locks always refuse
+        # so same-run ownership stays intact.
+        if not runguard.has_matching_stale_claim(workspace, run_dir):
+            print(_state_refusal_message(state, workspace), file=sys.stderr)
+            return 2
+    elif state == "live":
         print(_state_refusal_message(state, workspace), file=sys.stderr)
         return 2
 

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -5224,3 +5224,64 @@ def test_run_fails_when_canonical_checkout_drifts_during_dispatch_with_separate_
     assert run_meta["lock_workspace"] == str(lock_workspace)
     # The worker result must not have been finalized on top of drifted state.
     assert not (output_dir / "final.txt").exists()
+
+
+def test_record_run_start_run_json_write_failure_retains_lock_and_durable_state(tmp_path, monkeypatch):
+    """A run.json lifecycle write failure after checkpoint publication retains the lock.
+
+    The first run.json write activates the journal, publishes a recovery
+    checkpoint, and appends a lifecycle event, then the final atomic
+    ``run.json`` replacement fails. The raw ``OSError`` must be translated to
+    ``runguard.RetainRunLockError`` (carrying the original cause) so
+    ``runguard.run_lock`` retains the lock instead of releasing it and
+    orphaning the durable journal/checkpoint recovery state. The journal and
+    checkpoint artifacts must remain while ``run.json`` stays absent, so
+    ``brigade runs recover`` can restore from the retained state.
+    """
+    from brigade import run_checkpoint
+    from brigade import run_lifecycle
+
+    monkeypatch.setenv("BRIGADE_LIFECYCLE_JOURNAL", "1")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / "active"
+    run_dir.mkdir(parents=True)
+
+    real_write_text_atomic = aboyeur.localio.write_text_atomic
+
+    def fail_run_json_write(path, text):
+        if Path(path).name == "run.json":
+            raise OSError("receipt disk full")
+        return real_write_text_atomic(path, text)
+
+    monkeypatch.setattr(aboyeur.localio, "write_text_atomic", fail_run_json_write)
+
+    with pytest.raises(
+        runguard.RetainRunLockError, match="failed to write initial run receipt: receipt disk full"
+    ) as exc_info:
+        with runguard.run_lock(workspace, run_dir=run_dir):
+            aboyeur.record_run_start(
+                run_dir,
+                task="demo task",
+                cwd=workspace,
+                roster=_roster(),
+                read_only=False,
+                lock_workspace=workspace,
+            )
+
+    # The original OSError is preserved as the cause.
+    assert isinstance(exc_info.value.__cause__, OSError)
+
+    # The lock is retained (not released) so recovery state is not orphaned.
+    assert runguard.lock_path(workspace).is_dir()
+
+    # run.json is absent (the final atomic write failed).
+    assert not (run_dir / "run.json").is_file()
+
+    # The durable recovery state survives: the lifecycle journal and the
+    # published recovery checkpoint remain on disk.
+    journal_path = run_lifecycle._journal_path(run_dir)
+    assert journal_path.is_file()
+    checkpoint_dir = run_checkpoint.checkpoint_dir(run_dir)
+    assert checkpoint_dir.is_dir()
+    assert any(checkpoint_dir.glob("*.json"))

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1402,12 +1402,24 @@ def _stale_recovery_receipt(
 
     payload = json.loads(json.dumps(checkpoint_obj))
     failure_attribution: dict[str, object] = {}
-    if payload.get("status") == "dispatching":
-        seats = [seat for seat in payload.get("active_seats", []) if isinstance(seat, str) and seat]
+    stored_status = payload.get("status")
+    active_seats = payload.get("active_seats")
+    if stored_status == "dispatching" and isinstance(active_seats, list):
+        seats = [seat for seat in active_seats if isinstance(seat, str) and seat]
         if len(seats) == 1:
             failure_attribution["seat"] = seats[0]
         elif seats:
             failure_attribution["seats"] = seats
+    phase_owner = payload.get("phase_owner")
+    if not failure_attribution and isinstance(phase_owner, str) and phase_owner:
+        failure_attribution["seat"] = phase_owner
+    if not failure_attribution:
+        worker = payload.get("worker")
+        orchestrator = payload.get("orchestrator")
+        if isinstance(worker, str) and worker:
+            failure_attribution["seat"] = worker
+        elif isinstance(orchestrator, str) and orchestrator:
+            failure_attribution["seat"] = orchestrator
     failure: dict[str, object] = {
         "phase": "stale-lock-recovery",
         "kind": "owner-process-exited",
@@ -1672,6 +1684,65 @@ def test_doctor_accepts_valid_stale_recovery_terminal_receipt(tmp_path: Path):
     assert status2 == doctor_mod.FAIL
     assert _RUN_ID in detail2
     assert "run.json does not match checkpoint" in detail2
+
+
+def test_doctor_accepts_stale_recovery_receipt_with_orchestrator_attribution(tmp_path: Path):
+    """A planning checkpoint with no ``active_seats`` attributes the stale-lock
+    failure to the orchestrator, matching production ``_recover_run_artifact``.
+
+    The test helper ``_stale_recovery_receipt`` must apply the same
+    phase_owner -> worker -> orchestrator precedence as production and the
+    doctor reconstruction, or the candidate receipt diverges and the verdict
+    fails for the wrong reason.
+    """
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    checkpoint_obj = {
+        "status": "planning",
+        "cwd": str(workspace),
+        "task": "inspect",
+        "orchestrator": "chef",
+    }
+    checkpoint_bytes = _activate_recovery_journal_with_checkpoint(workspace, run_dir, checkpoint_obj)
+    receipt = _stale_recovery_receipt(
+        json.loads(checkpoint_bytes.decode("utf-8")),
+        lock_workspace=str(workspace),
+        lock_acquired_at="2026-07-16T00:00:00+00:00",
+    )
+    (run_dir / "run.json").write_bytes(_recovery_writer_bytes(receipt))
+
+    status, _name, detail = _recovery_check(workspace)
+    assert status == doctor_mod.OK, detail
+    assert "fail=0" in detail
+
+
+def test_doctor_accepts_stale_recovery_receipt_with_phase_owner_attribution(tmp_path: Path):
+    """A result-processing checkpoint attributes the failure to ``phase_owner``,
+    taking precedence over worker/orchestrator, matching production precedence.
+    """
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    checkpoint_obj = {
+        "status": "result-processing",
+        "cwd": str(workspace),
+        "task": "inspect",
+        "phase_owner": "reviewer",
+        "worker": "coder",
+        "orchestrator": "chef",
+    }
+    checkpoint_bytes = _activate_recovery_journal_with_checkpoint(workspace, run_dir, checkpoint_obj)
+    receipt = _stale_recovery_receipt(
+        json.loads(checkpoint_bytes.decode("utf-8")),
+        lock_workspace=str(workspace),
+        lock_acquired_at="2026-07-16T00:00:00+00:00",
+    )
+    (run_dir / "run.json").write_bytes(_recovery_writer_bytes(receipt))
+
+    status, _name, detail = _recovery_check(workspace)
+    assert status == doctor_mod.OK, detail
+    assert "fail=0" in detail
 
 
 def test_doctor_checkpoint_check_never_mutates(tmp_path: Path, monkeypatch):

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1398,56 +1398,23 @@ def _stale_recovery_receipt(
     lock_workspace: str | None = None,
     lock_acquired_at: str | None = None,
 ) -> dict:
-    from brigade import receipt_schema
+    from brigade import runguard
 
     payload = json.loads(json.dumps(checkpoint_obj))
-    failure_attribution: dict[str, object] = {}
-    stored_status = payload.get("status")
-    active_seats = payload.get("active_seats")
-    if stored_status == "dispatching" and isinstance(active_seats, list):
-        seats = [seat for seat in active_seats if isinstance(seat, str) and seat]
-        if len(seats) == 1:
-            failure_attribution["seat"] = seats[0]
-        elif seats:
-            failure_attribution["seats"] = seats
-    phase_owner = payload.get("phase_owner")
-    if not failure_attribution and isinstance(phase_owner, str) and phase_owner:
-        failure_attribution["seat"] = phase_owner
-    if not failure_attribution:
-        worker = payload.get("worker")
-        orchestrator = payload.get("orchestrator")
-        if isinstance(worker, str) and worker:
-            failure_attribution["seat"] = worker
-        elif isinstance(orchestrator, str) and orchestrator:
-            failure_attribution["seat"] = orchestrator
-    failure: dict[str, object] = {
-        "phase": "stale-lock-recovery",
-        "kind": "owner-process-exited",
-        "detail": f"run owner process {owner_pid} is no longer active",
-        "owner_pid": owner_pid,
-        "prior_status": payload.get("status", "planning"),
-        "recovered_at": recovered_at,
-        **failure_attribution,
-    }
-    if lock_workspace is not None:
-        failure["lock_workspace"] = lock_workspace
-        payload.setdefault("cwd", lock_workspace)
-        payload.setdefault("lock_workspace", lock_workspace)
-    if lock_acquired_at is not None:
-        failure["lock_acquired_at"] = lock_acquired_at
-        payload.setdefault("started_at", lock_acquired_at)
-    detail = failure["detail"]
-    payload.update(
-        {
-            "status": "failed",
-            "status_started_at": recovered_at,
-            "finished_at": recovered_at,
-            "error": detail,
-            "failure_phase": "stale-lock-recovery",
-            "failure": failure,
-        }
+    raw_status = payload.get("status")
+    if isinstance(raw_status, str) and raw_status:
+        prior_status = raw_status
+    else:
+        prior_status = "artifact-unavailable"
+    return runguard._build_stale_lock_recovery_receipt(
+        payload,
+        owner_pid=owner_pid,
+        recovered_at=recovered_at,
+        prior_status=prior_status,
+        lock_workspace=lock_workspace,
+        lock_acquired_at=lock_acquired_at,
+        persist_recovery_provenance=True,
     )
-    return receipt_schema.stamp_run_receipt(payload)
 
 
 def _recovery_check(target: Path, *, full: bool = False) -> tuple[str, str, str]:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1320,3 +1320,844 @@ def test_doctor_no_collision_with_shipped_scanners_toml(tmp_target: Path, monkey
 
     results = _run_producer_collision_check(tmp_target)
     assert _producer_collision_checks(results) == []
+
+
+# -- Issue #568 slice 5 Task 6: read-only recovery checkpoint doctor check --
+
+
+_RUN_ID = "20260727-153045-a1b2c3d4"
+_RECOVERED_AT = "2026-07-27T15:31:00.123456+00:00"
+_OWNER_PID = 42424242
+
+
+def _recovery_writer_bytes(obj: dict) -> bytes:
+    return (json.dumps(obj, indent=2, sort_keys=True) + "\n").encode("utf-8")
+
+
+def _recovery_write_json(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def _recovery_write_lock_owner(workspace: Path, run_dir: Path, *, pid: int = 99999999) -> Path:
+    lock_path = workspace / ".brigade" / "run.lock"
+    lock_path.mkdir(parents=True)
+    (lock_path / "pid").write_text(f"{pid}\n")
+    _recovery_write_json(
+        lock_path / "owner.json",
+        {
+            "schema": "brigade.run_lock.v1",
+            "owner_token": "owner",
+            "pid": pid,
+            "run_dir": str(run_dir.resolve()),
+            "acquired_at": "2026-07-16T00:00:00+00:00",
+        },
+    )
+    return lock_path
+
+
+def _activate_recovery_journal_with_checkpoint(
+    workspace: Path,
+    run_dir: Path,
+    run_json_obj: dict,
+    *,
+    paired_event_type: str | None = "run.planning.started",
+    leave_stale_lock: bool = False,
+) -> bytes:
+    import shutil
+
+    from brigade import localio, run_checkpoint, run_lifecycle, runguard
+
+    run_dir.parent.mkdir(parents=True, exist_ok=True)
+    run_dir.mkdir(parents=True, exist_ok=True)
+    checkpoint_bytes = _recovery_writer_bytes(run_json_obj)
+    localio.write_json(
+        run_dir / "run.json",
+        {"schema": "brigade.run.v1", **run_json_obj, "lifecycle_journal_requested": True},
+    )
+    with runguard.run_lock(workspace, run_dir=run_dir):
+        run_lifecycle.prepare_lifecycle_journal(run_dir, workspace=workspace)
+        run_checkpoint.write_checkpoint(
+            run_dir,
+            checkpoint_bytes,
+            workspace=workspace,
+            paired_event_type=paired_event_type,
+        )
+    lock_path = workspace / ".brigade" / "run.lock"
+    if leave_stale_lock:
+        _recovery_write_lock_owner(workspace, run_dir)
+    elif lock_path.exists():
+        shutil.rmtree(lock_path)
+    return checkpoint_bytes
+
+
+def _stale_recovery_receipt(
+    checkpoint_obj: dict,
+    *,
+    owner_pid: int = _OWNER_PID,
+    recovered_at: str = _RECOVERED_AT,
+    lock_workspace: str | None = None,
+    lock_acquired_at: str | None = None,
+) -> dict:
+    from brigade import receipt_schema
+
+    payload = json.loads(json.dumps(checkpoint_obj))
+    failure_attribution: dict[str, object] = {}
+    if payload.get("status") == "dispatching":
+        seats = [seat for seat in payload.get("active_seats", []) if isinstance(seat, str) and seat]
+        if len(seats) == 1:
+            failure_attribution["seat"] = seats[0]
+        elif seats:
+            failure_attribution["seats"] = seats
+    failure: dict[str, object] = {
+        "phase": "stale-lock-recovery",
+        "kind": "owner-process-exited",
+        "detail": f"run owner process {owner_pid} is no longer active",
+        "owner_pid": owner_pid,
+        "prior_status": payload.get("status", "planning"),
+        "recovered_at": recovered_at,
+        **failure_attribution,
+    }
+    if lock_workspace is not None:
+        failure["lock_workspace"] = lock_workspace
+        payload.setdefault("cwd", lock_workspace)
+        payload.setdefault("lock_workspace", lock_workspace)
+    if lock_acquired_at is not None:
+        failure["lock_acquired_at"] = lock_acquired_at
+        payload.setdefault("started_at", lock_acquired_at)
+    detail = failure["detail"]
+    payload.update(
+        {
+            "status": "failed",
+            "status_started_at": recovered_at,
+            "finished_at": recovered_at,
+            "error": detail,
+            "failure_phase": "stale-lock-recovery",
+            "failure": failure,
+        }
+    )
+    return receipt_schema.stamp_run_receipt(payload)
+
+
+def _recovery_check(target: Path, *, full: bool = False) -> tuple[str, str, str]:
+    return doctor_mod._check_recovery_checkpoints(target, full=full)
+
+
+def _snapshot_run_tree(run_dir: Path) -> dict[str, object]:
+    from brigade import run_checkpoint
+
+    entries = sorted(p.name for p in run_dir.iterdir()) if run_dir.is_dir() else []
+    journal = run_dir / "events" / "lifecycle.jsonl"
+    run_json = run_dir / "run.json"
+    checkpoint_dir = run_dir / "events" / run_checkpoint.CHECKPOINT_DIR_NAME
+    checkpoint_bytes = (
+        {str(path.relative_to(run_dir)): path.read_bytes() for path in checkpoint_dir.rglob("*") if path.is_file()}
+        if checkpoint_dir.is_dir()
+        else {}
+    )
+    return {
+        "entries": entries,
+        "journal": journal.read_bytes() if journal.is_file() else b"",
+        "run_json": run_json.read_bytes() if run_json.is_file() else b"",
+        "checkpoints": checkpoint_bytes,
+    }
+
+
+def test_doctor_includes_recovery_checkpoints_check(tmp_path: Path):
+    from brigade.station import DoctorContext
+
+    ctx = DoctorContext(target=tmp_path, selection=None, harnesses=[])
+    checks = doctor_mod.core_station_checks(ctx)
+    recovery = [check for check in checks if check[1] == "runs: recovery checkpoints"]
+    assert len(recovery) == 1
+    status, name, detail = recovery[0]
+    assert len(recovery[0]) == 3
+    assert name == "runs: recovery checkpoints"
+    assert status in {doctor_mod.OK, doctor_mod.WARN, doctor_mod.FAIL}
+    assert "ok=" in detail and "omitted=" in detail
+
+
+def test_doctor_scans_at_most_50_immediate_run_dirs_newest_first(tmp_path: Path):
+    import os
+
+    workspace = tmp_path / "workspace"
+    runs_root = workspace / ".brigade" / "runs"
+    runs_root.mkdir(parents=True)
+    base_mtime = 1_700_000_000.0
+    for index in range(55):
+        run_dir = runs_root / f"run-{index:03d}"
+        run_obj = {"status": "planning", "cwd": str(workspace), "task": f"t{index}"}
+        checkpoint_bytes = _activate_recovery_journal_with_checkpoint(workspace, run_dir, run_obj)
+        (run_dir / "run.json").write_bytes(checkpoint_bytes)
+        os.utime(run_dir, (base_mtime + index, base_mtime + index))
+
+    status, _name, detail = _recovery_check(workspace)
+    assert status == doctor_mod.OK
+    assert "ok=50" in detail
+    assert "omitted=5" in detail
+
+
+def test_doctor_fail_on_bound_exceeded_without_parsing_further(tmp_path: Path, monkeypatch):
+    import hashlib
+    import os
+
+    from brigade import run_checkpoint, run_journal, run_lifecycle, runguard
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    run_json_obj = {"status": "planning", "cwd": str(workspace), "task": "demo"}
+    checkpoint_bytes = _activate_recovery_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    (run_dir / "run.json").write_bytes(checkpoint_bytes)
+    journal_path = run_lifecycle._journal_path(run_dir)
+
+    real_fstat = os.fstat
+
+    def big_journal_fstat(fd):
+        st = real_fstat(fd)
+        if st.st_size <= run_checkpoint.MAX_JOURNAL_BYTES:
+            return st
+        return os.stat_result(
+            (
+                st.st_mode,
+                st.st_ino,
+                st.st_dev,
+                st.st_nlink,
+                st.st_uid,
+                st.st_gid,
+                run_checkpoint.MAX_JOURNAL_BYTES + 1,
+                st.st_atime,
+                st.st_mtime,
+                st.st_ctime,
+            )
+        )
+
+    journal_path.write_bytes(journal_path.read_bytes() + b"x" * (run_checkpoint.MAX_JOURNAL_BYTES + 1))
+    monkeypatch.setattr(os, "fstat", big_journal_fstat)
+
+    status, _name, detail = _recovery_check(workspace)
+    assert status == doctor_mod.FAIL
+    assert "bound exceeded" in detail
+
+    run_dir2 = workspace / ".brigade" / "runs" / "big-checkpoint"
+    run_dir2.mkdir(parents=True)
+    with runguard.run_lock(workspace, run_dir=run_dir2):
+        run_lifecycle.prepare_lifecycle_journal(run_dir2, workspace=workspace)
+    sha = hashlib.sha256(checkpoint_bytes).hexdigest()
+    payload = {
+        "path": f"events/recovery-checkpoints/{sha}.json",
+        "sha256": sha,
+        "media_type": run_checkpoint.CHECKPOINT_MEDIA_TYPE,
+        "byte_size": run_checkpoint.MAX_CHECKPOINT_BYTES + 1,
+        "privacy_class": run_checkpoint.CHECKPOINT_PRIVACY_CLASS,
+        "paired_event_type": None,
+    }
+    journal2 = run_lifecycle._journal_path(run_dir2)
+    run_journal.append_event(
+        journal2,
+        run_id=run_dir2.name,
+        event_type=run_checkpoint.CHECKPOINT_EVENT_TYPE,
+        payload=payload,
+        idempotency_key=f"checkpoint:{sha}:none",
+        expected_previous_sequence=0,
+    )
+    (run_dir2 / "run.json").write_bytes(checkpoint_bytes)
+
+    status2, _name2, detail2 = _recovery_check(workspace)
+    assert status2 == doctor_mod.FAIL
+    assert "bound exceeded" in detail2
+
+
+def test_doctor_fail_on_partial_tail_without_quarantine(tmp_path: Path, monkeypatch):
+    from brigade import run_checkpoint, run_journal, run_lifecycle
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    run_json_obj = {"status": "planning", "cwd": str(workspace), "task": "demo"}
+    checkpoint_bytes = _activate_recovery_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    (run_dir / "run.json").write_bytes(checkpoint_bytes)
+    journal = run_lifecycle._journal_path(run_dir)
+    partial = b'{"schema":"brigade.run_event.v1","event_type":"run.plan'
+    journal.write_bytes(journal.read_bytes() + partial)
+
+    def _forbid_recover_partial_tail(*_args, **_kwargs):
+        raise AssertionError("recover_partial_tail must not be called from doctor")
+
+    monkeypatch.setattr(run_journal, "recover_partial_tail", _forbid_recover_partial_tail)
+    monkeypatch.setattr(
+        run_checkpoint,
+        "recover_from_checkpoint",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("recover_from_checkpoint")),
+    )
+
+    status, _name, detail = _recovery_check(workspace)
+    assert status == doctor_mod.FAIL
+    assert _RUN_ID in detail
+
+
+def test_doctor_per_run_verdicts(tmp_path: Path):
+    import os
+
+    from brigade import runguard
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    runs_root = workspace / ".brigade" / "runs"
+
+    ok_dir = runs_root / "ok-run"
+    ok_obj = {"status": "planning", "cwd": str(workspace), "task": "ok"}
+    ok_bytes = _activate_recovery_journal_with_checkpoint(workspace, ok_dir, ok_obj)
+    (ok_dir / "run.json").write_bytes(ok_bytes)
+
+    warn_dir = runs_root / "warn-run"
+    warn_obj = {"status": "planning", "cwd": str(workspace), "task": "warn"}
+    _activate_recovery_journal_with_checkpoint(workspace, warn_dir, warn_obj)
+    (warn_dir / "run.json").unlink()
+
+    fail_dir = runs_root / "fail-run"
+    fail_obj = {"status": "planning", "cwd": str(workspace), "task": "fail"}
+    fail_bytes = _activate_recovery_journal_with_checkpoint(workspace, fail_dir, fail_obj)
+    mismatched = json.loads(fail_bytes.decode("utf-8"))
+    mismatched["task"] = "wrong-task"
+    (fail_dir / "run.json").write_bytes(_recovery_writer_bytes(mismatched))
+
+    legacy_dir = runs_root / "legacy-run"
+    legacy_dir.mkdir(parents=True)
+    _recovery_write_json(legacy_dir / "run.json", {"status": "ok", "cwd": str(workspace)})
+
+    live_dir = runs_root / "live-run"
+    live_obj = {"status": "planning", "cwd": str(workspace), "task": "live"}
+    live_bytes = _activate_recovery_journal_with_checkpoint(workspace, live_dir, live_obj)
+    (live_dir / "run.json").write_bytes(live_bytes)
+    _recovery_write_lock_owner(workspace, live_dir, pid=os.getpid())
+
+    status, _name, detail = _recovery_check(workspace)
+    assert status == doctor_mod.FAIL
+    assert "ok=2" in detail
+    assert "warn=1" in detail
+    assert "fail=1" in detail
+    assert "omitted=1" in detail
+    assert "fail-run (run.json does not match checkpoint)" in detail
+    assert runguard.run_lock_state(workspace, live_dir) == "live"
+
+
+def test_doctor_accepts_valid_stale_recovery_terminal_receipt(tmp_path: Path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    checkpoint_obj = {
+        "status": "dispatching",
+        "cwd": str(workspace),
+        "task": "inspect",
+        "orchestrator": "chef",
+        "active_seats": ["coder"],
+    }
+    checkpoint_bytes = _activate_recovery_journal_with_checkpoint(workspace, run_dir, checkpoint_obj)
+    receipt = _stale_recovery_receipt(
+        json.loads(checkpoint_bytes.decode("utf-8")),
+        lock_workspace=str(workspace),
+        lock_acquired_at="2026-07-16T00:00:00+00:00",
+    )
+    (run_dir / "run.json").write_bytes(_recovery_writer_bytes(receipt))
+
+    status, _name, detail = _recovery_check(workspace)
+    assert status == doctor_mod.OK
+    assert "fail=0" in detail
+
+    bad_receipt = dict(receipt)
+    bad_receipt["error"] = "wrong detail"
+    (run_dir / "run.json").write_bytes(_recovery_writer_bytes(bad_receipt))
+
+    status2, _name2, detail2 = _recovery_check(workspace)
+    assert status2 == doctor_mod.FAIL
+    assert _RUN_ID in detail2
+    assert "run.json does not match checkpoint" in detail2
+
+
+def test_doctor_checkpoint_check_never_mutates(tmp_path: Path, monkeypatch):
+    from brigade import run_checkpoint, run_journal, run_lifecycle
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    run_json_obj = {"status": "planning", "cwd": str(workspace), "task": "demo"}
+    checkpoint_bytes = _activate_recovery_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    (run_dir / "run.json").write_bytes(checkpoint_bytes)
+    journal = run_lifecycle._journal_path(run_dir)
+    journal.write_bytes(journal.read_bytes() + b'{"partial":')
+
+    before = _snapshot_run_tree(run_dir)
+
+    def _forbid_recover_partial_tail(*_args, **_kwargs):
+        raise AssertionError("recover_partial_tail must not be called from doctor")
+
+    monkeypatch.setattr(run_journal, "recover_partial_tail", _forbid_recover_partial_tail)
+    monkeypatch.setattr(
+        run_checkpoint,
+        "recover_from_checkpoint",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("recover_from_checkpoint")),
+    )
+
+    _recovery_check(workspace)
+    after = _snapshot_run_tree(run_dir)
+    assert before == after
+
+
+def test_doctor_recovery_failures_default_8_versus_full_all(tmp_path: Path):
+    import os
+
+    workspace = tmp_path / "workspace"
+    runs_root = workspace / ".brigade" / "runs"
+    runs_root.mkdir(parents=True)
+    base_mtime = 1_700_000_000.0
+    for index in range(12):
+        run_dir = runs_root / f"fail-{index:02d}"
+        run_obj = {"status": "planning", "cwd": str(workspace), "task": f"f{index}"}
+        checkpoint_bytes = _activate_recovery_journal_with_checkpoint(workspace, run_dir, run_obj)
+        mismatched = json.loads(checkpoint_bytes.decode("utf-8"))
+        mismatched["task"] = f"wrong-{index}"
+        (run_dir / "run.json").write_bytes(_recovery_writer_bytes(mismatched))
+        os.utime(run_dir, (base_mtime + index, base_mtime + index))
+
+    _status, _name, default_detail = _recovery_check(workspace, full=False)
+    assert "fail=12" in default_detail
+    assert "failures:" in default_detail
+    assert "fail-11" in default_detail
+    assert "fail-03" not in default_detail
+    assert "4 more" in default_detail
+
+    _status2, _name2, full_detail = _recovery_check(workspace, full=True)
+    for index in range(12):
+        assert f"fail-{index:02d}" in full_detail
+    assert "more" not in full_detail
+
+
+# -- Sendback: independent-review blockers and lows for the Doctor diff --
+
+
+def _activate_mismatched_recovery_run(workspace: Path, run_dir: Path, run_obj: dict, *, task: str) -> None:
+    """Activate a journal+checkpoint, then overwrite run.json with a mismatched task."""
+    checkpoint_bytes = _activate_recovery_journal_with_checkpoint(workspace, run_dir, run_obj)
+    mismatched = json.loads(checkpoint_bytes.decode("utf-8"))
+    mismatched["task"] = task
+    (run_dir / "run.json").write_bytes(_recovery_writer_bytes(mismatched))
+
+
+def _install_clean_workspace(target: Path) -> None:
+    install_selection(
+        target,
+        Selection(depth="workspace", harnesses=["claude"], owner="claude", includes=[]),
+    )
+
+
+def test_doctor_run_full_false_previews_8_recovery_failures(tmp_path: Path, capsys):
+    """End-to-end ``doctor_mod.run(full=False)`` previews 8 of 12 failures."""
+    import os
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _install_clean_workspace(workspace)
+    runs_root = workspace / ".brigade" / "runs"
+    runs_root.mkdir(parents=True)
+    base_mtime = 1_700_000_000.0
+    for index in range(12):
+        run_dir = runs_root / f"fail-{index:02d}"
+        _activate_mismatched_recovery_run(
+            workspace,
+            run_dir,
+            {"status": "planning", "cwd": str(workspace), "task": f"f{index}"},
+            task=f"wrong-{index}",
+        )
+        os.utime(run_dir, (base_mtime + index, base_mtime + index))
+
+    capsys.readouterr()
+    rc = doctor_mod.run(target=workspace, harness="generic", full=False)
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "runs: recovery checkpoints" in out
+    assert "fail=12" in out
+    assert "fail-11" in out
+    assert "fail-04" in out
+    assert "fail-03" not in out
+    assert "4 more" in out
+
+    capsys.readouterr()
+    doctor_mod.run(target=workspace, harness="generic", json_output=True, full=False)
+    payload = json.loads(capsys.readouterr().out)
+    recovery = next(c for c in payload["checks"] if c["name"] == "runs: recovery checkpoints")
+    assert recovery["status"] == "FAIL"
+    assert "fail=12" in recovery["detail"]
+    assert "fail-11" in recovery["detail"]
+    assert "fail-03" not in recovery["detail"]
+    assert "4 more" in recovery["detail"]
+
+
+def test_doctor_run_full_true_lists_every_recovery_failure(tmp_path: Path, capsys):
+    """End-to-end ``doctor_mod.run(full=True)`` lists every failure name."""
+    import os
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _install_clean_workspace(workspace)
+    runs_root = workspace / ".brigade" / "runs"
+    runs_root.mkdir(parents=True)
+    base_mtime = 1_700_000_000.0
+    for index in range(12):
+        run_dir = runs_root / f"fail-{index:02d}"
+        _activate_mismatched_recovery_run(
+            workspace,
+            run_dir,
+            {"status": "planning", "cwd": str(workspace), "task": f"f{index}"},
+            task=f"wrong-{index}",
+        )
+        os.utime(run_dir, (base_mtime + index, base_mtime + index))
+
+    capsys.readouterr()
+    rc = doctor_mod.run(target=workspace, harness="generic", full=True)
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "fail=12" in out
+    for index in range(12):
+        assert f"fail-{index:02d}" in out
+    assert " more" not in out
+
+    capsys.readouterr()
+    doctor_mod.run(target=workspace, harness="generic", json_output=True, full=True)
+    payload = json.loads(capsys.readouterr().out)
+    recovery = next(c for c in payload["checks"] if c["name"] == "runs: recovery checkpoints")
+    assert recovery["status"] == "FAIL"
+    assert "fail=12" in recovery["detail"]
+    for index in range(12):
+        assert f"fail-{index:02d}" in recovery["detail"]
+    assert " more" not in recovery["detail"]
+
+
+def test_doctor_fails_on_forged_prior_status(tmp_path: Path):
+    """A stale-lock-recovery receipt with a forged ``prior_status`` must FAIL.
+
+    ``prior_status`` is derived from the checkpoint object's status exactly as
+    runguard derives it; the candidate's ``failure.prior_status`` is never
+    trusted. A forged value diverges from the reconstruction.
+    """
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    checkpoint_obj = {
+        "status": "planning",
+        "cwd": str(workspace),
+        "task": "inspect",
+        "orchestrator": "chef",
+    }
+    checkpoint_bytes = _activate_recovery_journal_with_checkpoint(workspace, run_dir, checkpoint_obj)
+    receipt = _stale_recovery_receipt(
+        json.loads(checkpoint_bytes.decode("utf-8")),
+        lock_workspace=str(workspace),
+        lock_acquired_at="2026-07-16T00:00:00+00:00",
+    )
+    receipt["failure"]["prior_status"] = "forged-status"
+    (run_dir / "run.json").write_bytes(_recovery_writer_bytes(receipt))
+
+    status, _name, detail = _recovery_check(workspace)
+    assert status == doctor_mod.FAIL
+    assert _RUN_ID in detail
+    assert "run.json does not match checkpoint" in detail
+
+
+def test_doctor_raw_journal_oserror_is_bounded_fail(tmp_path: Path, monkeypatch):
+    """A raw ``OSError`` from ``read_journal_bounded`` must be a bounded FAIL."""
+    from brigade import run_journal, run_lifecycle
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    run_obj = {"status": "planning", "cwd": str(workspace), "task": "demo"}
+    _activate_mismatched_recovery_run(workspace, run_dir, run_obj, task="wrong")
+
+    monkeypatch.setattr(run_journal, "read_journal_bounded", lambda _p: (_ for _ in ()).throw(OSError("simulated")))
+
+    status, _name, detail = _recovery_check(workspace)
+    assert status == doctor_mod.FAIL
+    assert "journal unreadable" in detail
+    journal = run_lifecycle._journal_path(run_dir)
+    assert journal.is_file()
+
+
+def test_doctor_run_json_present_but_unreadable_is_fail(tmp_path: Path, monkeypatch):
+    """A present-but-unreadable ``run.json`` must FAIL (not WARN)."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    run_obj = {"status": "planning", "cwd": str(workspace), "task": "demo"}
+    checkpoint_bytes = _activate_recovery_journal_with_checkpoint(workspace, run_dir, run_obj)
+    (run_dir / "run.json").write_bytes(checkpoint_bytes)
+
+    real_read_bytes = Path.read_bytes
+
+    def _unreadable_run_json(self: Path) -> bytes:
+        if self.name == "run.json":
+            raise OSError("permission denied")
+        return real_read_bytes(self)
+
+    monkeypatch.setattr(Path, "read_bytes", _unreadable_run_json)
+
+    status, _name, detail = _recovery_check(workspace)
+    assert status == doctor_mod.FAIL
+    assert "run.json present but unreadable" in detail
+    assert (run_dir / "run.json").exists()
+
+
+def test_doctor_run_json_recursion_error_is_warn(tmp_path: Path):
+    """A ``RecursionError`` while parsing ``run.json`` is an unparseable WARN."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    run_obj = {"status": "planning", "cwd": str(workspace), "task": "demo"}
+    _activate_recovery_journal_with_checkpoint(workspace, run_dir, run_obj)
+    nesting = 2000
+    blob = "{" * nesting + '"v":1' + "}" * nesting
+    (run_dir / "run.json").write_text(blob)
+
+    status, _name, detail = _recovery_check(workspace)
+    assert status == doctor_mod.WARN
+    assert "warn=1" in detail
+    assert "fail=0" in detail
+
+
+def test_doctor_immediate_run_dir_stat_oserror_is_omitted(tmp_path: Path, monkeypatch):
+    """A vanishing/stat OSError during immediate run scanning must not crash Doctor."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    runs_root = workspace / ".brigade" / "runs"
+    runs_root.mkdir(parents=True)
+    run_dir = runs_root / "fail-run"
+    run_obj = {"status": "planning", "cwd": str(workspace), "task": "demo"}
+    _activate_mismatched_recovery_run(workspace, run_dir, run_obj, task="wrong")
+
+    real_stat = Path.stat
+
+    def _flaky_stat(self: Path, *args, **kwargs):
+        if self == run_dir:
+            raise OSError("vanished mid-scan")
+        return real_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", _flaky_stat)
+    status, _name, detail = _recovery_check(workspace)
+    assert status in {doctor_mod.OK, doctor_mod.WARN}
+    assert "omitted=1" in detail
+    assert "fail=0" in detail
+    monkeypatch.undo()
+
+    real_iterdir = Path.iterdir
+
+    def _flaky_iterdir(self: Path):
+        if self == runs_root:
+            raise OSError("iterdir boom")
+        return real_iterdir(self)
+
+    monkeypatch.setattr(Path, "iterdir", _flaky_iterdir)
+    status2, _name2, detail2 = _recovery_check(workspace)
+    assert status2 in {doctor_mod.OK, doctor_mod.WARN}
+    assert "fail=0" in detail2
+    monkeypatch.undo()
+
+    real_is_dir = Path.is_dir
+
+    def _flaky_is_dir(self: Path, *args, **kwargs):
+        if self == runs_root:
+            raise OSError("is_dir boom")
+        return real_is_dir(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "is_dir", _flaky_is_dir)
+    status3, _name3, detail3 = _recovery_check(workspace)
+    assert status3 in {doctor_mod.OK, doctor_mod.WARN}
+    assert "fail=0" in detail3
+
+
+def test_doctor_invalid_recovered_at_iso_is_fail(tmp_path: Path):
+    """An invalid ISO ``recovered_at`` must FAIL the stale-lock-recovery match."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    checkpoint_obj = {"status": "planning", "cwd": str(workspace), "task": "inspect"}
+    checkpoint_bytes = _activate_recovery_journal_with_checkpoint(workspace, run_dir, checkpoint_obj)
+    receipt = _stale_recovery_receipt(
+        json.loads(checkpoint_bytes.decode("utf-8")),
+        lock_workspace=str(workspace),
+        lock_acquired_at="2026-07-16T00:00:00+00:00",
+        recovered_at="not-a-timestamp",
+    )
+    (run_dir / "run.json").write_bytes(_recovery_writer_bytes(receipt))
+
+    status, _name, detail = _recovery_check(workspace)
+    assert status == doctor_mod.FAIL
+    assert "run.json does not match checkpoint" in detail
+
+
+def test_doctor_513_events_fail_bound_exceeded_without_checkpoint_parsing(tmp_path: Path, monkeypatch):
+    """513 valid chained complete events must FAIL bound exceeded, no checkpoint parse."""
+    from brigade import run_checkpoint, run_journal, run_lifecycle, runguard
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    run_dir.parent.mkdir(parents=True, exist_ok=True)
+    run_dir.mkdir(parents=True)
+    _recovery_write_json(
+        run_dir / "run.json",
+        {"schema": "brigade.run.v1", "status": "planning", "cwd": str(workspace), "task": "demo"},
+    )
+    with runguard.run_lock(workspace, run_dir=run_dir):
+        run_lifecycle.prepare_lifecycle_journal(run_dir, workspace=workspace)
+        journal = run_lifecycle._journal_path(run_dir)
+        prev_seq = 0
+        for index in range(513):
+            appended = run_journal.append_event(
+                journal,
+                run_id=_RUN_ID,
+                event_type="run.planning.started",
+                payload={"detail": f"step-{index}"},
+                idempotency_key=f"progress-{index}",
+                expected_previous_sequence=prev_seq,
+            )
+            prev_seq = appended.sequence
+
+    monkeypatch.setattr(
+        run_checkpoint,
+        "recover_from_checkpoint",
+        lambda *_a, **_kw: (_ for _ in ()).throw(AssertionError("recover_from_checkpoint")),
+    )
+
+    status, _name, detail = _recovery_check(workspace)
+    assert status == doctor_mod.FAIL
+    assert "bound exceeded" in detail
+
+
+def test_doctor_sparse_checkpoint_over_16mib_fail_bound_exceeded_before_body(tmp_path: Path):
+    """A real sparse checkpoint file > 16 MiB must FAIL bound exceeded before body parse."""
+    import hashlib
+    import os as _os
+
+    from brigade import run_checkpoint, run_journal
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    run_obj = {"status": "planning", "cwd": str(workspace), "task": "demo"}
+    checkpoint_bytes = _activate_recovery_journal_with_checkpoint(workspace, run_dir, run_obj)
+    (run_dir / "run.json").write_bytes(checkpoint_bytes)
+    sha = hashlib.sha256(checkpoint_bytes).hexdigest()
+    final_path = run_checkpoint.checkpoint_path(run_dir, sha)
+    assert final_path.is_file()
+    fd = run_journal._open_nofollow(final_path, _os.O_WRONLY)
+    try:
+        _os.ftruncate(fd, run_checkpoint.MAX_CHECKPOINT_BYTES + 1)
+    finally:
+        _os.close(fd)
+    assert final_path.stat().st_size == run_checkpoint.MAX_CHECKPOINT_BYTES + 1
+
+    status, _name, detail = _recovery_check(workspace)
+    assert status == doctor_mod.FAIL
+    assert "bound exceeded" in detail
+
+
+def test_doctor_declared_checkpoint_byte_size_bound_exceeded(tmp_path: Path):
+    """A checkpoint event declaring ``byte_size > MAX`` must FAIL bound exceeded."""
+    import hashlib
+
+    from brigade import run_checkpoint, run_journal, run_lifecycle
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / "declared-bound"
+    run_obj = {"status": "planning", "cwd": str(workspace), "task": "demo"}
+    checkpoint_bytes = _activate_recovery_journal_with_checkpoint(workspace, run_dir, run_obj)
+    (run_dir / "run.json").write_bytes(checkpoint_bytes)
+    sha = hashlib.sha256(checkpoint_bytes).hexdigest()
+    payload = {
+        "path": f"events/{run_checkpoint.CHECKPOINT_DIR_NAME}/{sha}.json",
+        "sha256": sha,
+        "media_type": run_checkpoint.CHECKPOINT_MEDIA_TYPE,
+        "byte_size": run_checkpoint.MAX_CHECKPOINT_BYTES + 1,
+        "privacy_class": run_checkpoint.CHECKPOINT_PRIVACY_CLASS,
+        "paired_event_type": None,
+    }
+    journal = run_lifecycle._journal_path(run_dir)
+    run_journal.append_event(
+        journal,
+        run_id=run_dir.name,
+        event_type=run_checkpoint.CHECKPOINT_EVENT_TYPE,
+        payload=payload,
+        idempotency_key=f"checkpoint:{sha}:none",
+        expected_previous_sequence=1,
+    )
+
+    status, _name, detail = _recovery_check(workspace)
+    assert status == doctor_mod.FAIL
+    assert "bound exceeded" in detail
+
+
+def test_doctor_checkpoint_check_never_mutates_across_new_failures(tmp_path: Path, monkeypatch):
+    """The verdict must stay read-only across raw OSError, unreadable run.json, and recursion."""
+    from brigade import run_journal
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    run_obj = {"status": "planning", "cwd": str(workspace), "task": "demo"}
+    checkpoint_bytes = _activate_recovery_journal_with_checkpoint(workspace, run_dir, run_obj)
+    (run_dir / "run.json").write_bytes(checkpoint_bytes)
+
+    def _tree_snapshot() -> dict[str, object]:
+        # Read via builtin open() so a Path.read_bytes monkeypatch cannot mask reads.
+        from brigade import run_checkpoint as _rc
+
+        def _read_bytes(path: Path) -> bytes:
+            if not path.is_file():
+                return b""
+            with open(path, "rb") as fh:
+                return fh.read()
+
+        entries = sorted(p.name for p in run_dir.iterdir()) if run_dir.is_dir() else []
+        journal = run_dir / "events" / "lifecycle.jsonl"
+        run_json = run_dir / "run.json"
+        checkpoint_dir = run_dir / "events" / _rc.CHECKPOINT_DIR_NAME
+        checkpoints: dict[str, bytes] = {}
+        if checkpoint_dir.is_dir():
+            for p in checkpoint_dir.rglob("*"):
+                if p.is_file():
+                    checkpoints[str(p.relative_to(run_dir))] = _read_bytes(p)
+        return {
+            "entries": entries,
+            "journal": _read_bytes(journal),
+            "run_json": _read_bytes(run_json),
+            "checkpoints": checkpoints,
+        }
+
+    real_read_bytes = Path.read_bytes
+
+    def _unreadable_run_json(self: Path) -> bytes:
+        if self.name == "run.json":
+            raise OSError("permission denied")
+        return real_read_bytes(self)
+
+    nesting = 2000
+    recursion_blob = ("{" * nesting + '"v":1' + "}" * nesting).encode("utf-8")
+
+    scenarios = [
+        (
+            "raw journal OSError",
+            lambda: monkeypatch.setattr(
+                run_journal, "read_journal_bounded", lambda _p: (_ for _ in ()).throw(OSError("boom"))
+            ),
+        ),
+        ("unreadable run.json", lambda: monkeypatch.setattr(Path, "read_bytes", _unreadable_run_json)),
+        ("recursion run.json", lambda: (run_dir / "run.json").write_bytes(recursion_blob)),
+    ]
+    for _label, scenario in scenarios:
+        scenario()
+        before = _tree_snapshot()
+        _recovery_check(workspace)
+        after = _tree_snapshot()
+        assert before == after, f"verdict mutated the run tree under {_label}"
+        (run_dir / "run.json").write_bytes(checkpoint_bytes)
+        monkeypatch.undo()

--- a/tests/test_run_checkpoint.py
+++ b/tests/test_run_checkpoint.py
@@ -1,0 +1,326 @@
+"""Tests for brigade.run_checkpoint: checkpoint event type, validation, crash-safe publish.
+
+Issue #568 slice 5, Task 1 (RED-first). Standard library only.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from brigade import run_checkpoint, run_events, run_journal
+
+RUN_ID = "20260727-153045-a1b2c3d4"
+
+
+def _run_dir(tmp_path: Path) -> Path:
+    run_dir = tmp_path / "runs" / RUN_ID
+    run_dir.mkdir(parents=True)
+    return run_dir
+
+
+def _writer_bytes(obj: dict) -> bytes:
+    """Replicate aboyeur._write_json canonical encoding."""
+    return (json.dumps(obj, indent=2, sort_keys=True) + "\n").encode("utf-8")
+
+
+def _checkpoint_payload(run_json_bytes: bytes, *, paired_event_type: str | None = None) -> dict:
+    sha = hashlib.sha256(run_json_bytes).hexdigest()
+    return {
+        "path": f"events/recovery-checkpoints/{sha}.json",
+        "sha256": sha,
+        "media_type": run_checkpoint.CHECKPOINT_MEDIA_TYPE,
+        "byte_size": len(run_json_bytes),
+        "privacy_class": run_checkpoint.CHECKPOINT_PRIVACY_CLASS,
+        "paired_event_type": paired_event_type,
+    }
+
+
+def _place_checkpoint_file(run_dir: Path, run_json_bytes: bytes) -> Path:
+    cp_dir = run_dir / "events" / run_checkpoint.CHECKPOINT_DIR_NAME
+    cp_dir.mkdir(parents=True, exist_ok=True)
+    sha = hashlib.sha256(run_json_bytes).hexdigest()
+    final = cp_dir / f"{sha}.json"
+    final.write_bytes(run_json_bytes)
+    os.chmod(final, 0o600)
+    return final
+
+
+# -- Constants ---------------------------------------------------------------
+
+
+def test_checkpoint_constants_have_approved_values():
+    assert run_checkpoint.CHECKPOINT_EVENT_TYPE == "run.snapshot.checkpointed"
+    assert run_checkpoint.CHECKPOINT_MEDIA_TYPE == "application/vnd.brigade.run+json"
+    assert run_checkpoint.CHECKPOINT_PRIVACY_CLASS == "private"
+    assert run_checkpoint.CHECKPOINT_DIR_NAME == "recovery-checkpoints"
+    assert run_checkpoint.MAX_CHECKPOINT_BYTES == 16 * 1024 * 1024
+    assert run_checkpoint.MAX_JOURNAL_BYTES == 8 * 1024 * 1024
+    assert run_checkpoint.MAX_JOURNAL_EVENTS == 512
+
+
+def test_checkpoint_dir_and_path_helpers():
+    run_dir = Path("/tmp/runs/abc")
+    assert run_checkpoint.checkpoint_dir(run_dir) == run_dir / "events" / "recovery-checkpoints"
+    sha = "a" * 64
+    assert run_checkpoint.checkpoint_path(run_dir, sha) == (run_dir / "events" / "recovery-checkpoints" / f"{sha}.json")
+
+
+# -- Event type registration -------------------------------------------------
+
+
+def test_checkpoint_event_type_registered_with_closed_payload_keys():
+    assert "run.snapshot.checkpointed" in run_events.EVENT_TYPES
+    assert run_events.EVENT_TYPES["run.snapshot.checkpointed"] == frozenset(
+        {"path", "sha256", "media_type", "byte_size", "privacy_class", "paired_event_type"}
+    )
+
+
+# -- Payload validation ------------------------------------------------------
+
+
+def test_validate_checkpoint_accepts_well_formed_payload(tmp_path):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started", "task": "demo"})
+    _place_checkpoint_file(run_dir, run_json_bytes)
+    payload = _checkpoint_payload(run_json_bytes)
+
+    result = run_checkpoint.validate_checkpoint(run_dir, payload)
+
+    assert result == run_json_bytes
+
+
+def test_validate_checkpoint_rejects_malformed_payloads_without_opening_files(tmp_path, monkeypatch):
+    run_dir = _run_dir(tmp_path)
+    good_bytes = _writer_bytes({"status": "started"})
+    good_payload = _checkpoint_payload(good_bytes)
+
+    def _fail_open(*args, **kwargs):
+        raise AssertionError("validate_checkpoint must not open a file before payload validation")
+
+    monkeypatch.setattr(run_journal, "_open_nofollow", _fail_open)
+
+    cases = []
+
+    def add(label, mutate, category):
+        cases.append((label, mutate, category))
+
+    extra = dict(good_payload)
+    extra["unexpected"] = "x"
+    add("extra key", lambda p: {**p, "unexpected": "x"}, "payload-keys")
+    add("missing key", lambda p: {k: v for k, v in p.items() if k != "media_type"}, "payload-keys")
+    add("wrong media_type", lambda p: {**p, "media_type": "application/json"}, "media-type")
+    add("wrong privacy_class", lambda p: {**p, "privacy_class": "public"}, "privacy-class")
+    add("uppercase sha256", lambda p: {**p, "sha256": p["sha256"].upper()}, "sha256")
+    add("short sha256", lambda p: {**p, "sha256": p["sha256"][:32]}, "sha256")
+    add("bool byte_size", lambda p: {**p, "byte_size": True}, "byte-size")
+    add("negative byte_size", lambda p: {**p, "byte_size": -1}, "byte-size")
+    add("oversize byte_size", lambda p: {**p, "byte_size": run_checkpoint.MAX_CHECKPOINT_BYTES + 1}, "byte-size")
+    add("absolute path", lambda p: {**p, "path": "/events/recovery-checkpoints/x.json"}, "path")
+    add("backslash path", lambda p: {**p, "path": "events\\recovery-checkpoints\\x.json"}, "path")
+    add("dotdot path", lambda p: {**p, "path": "events/../recovery-checkpoints/x.json"}, "path")
+    add("stem mismatch", lambda p: {**p, "path": "events/recovery-checkpoints/deadbeef.json"}, "path")
+    add(
+        "invalid paired_event_type",
+        lambda p: {**p, "paired_event_type": "run.not.a.real.event"},
+        "paired-event-type",
+    )
+
+    for label, mutate, category in cases:
+        bad = mutate(good_payload)
+        with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+            run_checkpoint.validate_checkpoint(run_dir, bad)
+        err = excinfo.value
+        assert err.category == category, f"{label}: expected {category}, got {err.category}"
+        assert len(str(err)) <= run_events.MAX_DIAGNOSTIC_LEN, f"{label}: diagnostic not bounded"
+
+
+def test_validate_checkpoint_accepts_null_paired_event_type(tmp_path):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+    _place_checkpoint_file(run_dir, run_json_bytes)
+    payload = _checkpoint_payload(run_json_bytes, paired_event_type=None)
+    assert run_checkpoint.validate_checkpoint(run_dir, payload) == run_json_bytes
+
+
+def test_validate_checkpoint_accepts_mapped_paired_event_type(tmp_path):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+    _place_checkpoint_file(run_dir, run_json_bytes)
+    payload = _checkpoint_payload(run_json_bytes, paired_event_type="run.created")
+    assert run_checkpoint.validate_checkpoint(run_dir, payload) == run_json_bytes
+
+
+# -- Open-fd hardening -------------------------------------------------------
+
+
+def test_validate_checkpoint_open_fd_hardening(tmp_path):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+    sha = hashlib.sha256(run_json_bytes).hexdigest()
+    cp_dir = run_dir / "events" / run_checkpoint.CHECKPOINT_DIR_NAME
+    cp_dir.mkdir(parents=True)
+
+    # symlink final component -> refused (bounded, no follow)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    symlink_target = cp_dir / f"{sha}.json"
+    symlink_target.symlink_to(outside / "real.json")
+    payload = _checkpoint_payload(run_json_bytes)
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.validate_checkpoint(run_dir, payload)
+    assert excinfo.value.category in {"open-fd", "not-regular", "link-count"}
+
+    symlink_target.unlink()
+
+    # non-regular inode (directory at the final path)
+    nonreg = cp_dir / f"{sha}.json"
+    nonreg.mkdir()
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.validate_checkpoint(run_dir, payload)
+    assert excinfo.value.category == "not-regular"
+    nonreg.rmdir()
+
+    # link count above one (hard link the real file)
+    real = cp_dir / f"{sha}.json"
+    real.write_bytes(run_json_bytes)
+    os.chmod(real, 0o600)
+    extra = cp_dir / "link.json"
+    os.link(real, extra)
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.validate_checkpoint(run_dir, payload)
+    assert excinfo.value.category == "link-count"
+    extra.unlink()
+
+    # size mismatch
+    wrong_bytes = _writer_bytes({"status": "started", "extra": "diff"})
+    real.write_bytes(wrong_bytes)
+    os.chmod(real, 0o600)
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.validate_checkpoint(run_dir, payload)
+    assert excinfo.value.category == "size-mismatch"
+
+    # digest mismatch (right size, wrong bytes)
+    same_size = b"x" * len(run_json_bytes)
+    real.write_bytes(same_size)
+    os.chmod(real, 0o600)
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.validate_checkpoint(run_dir, payload)
+    assert excinfo.value.category == "digest-mismatch"
+
+    # writer-canonical-byte mismatch: a file with a valid digest (matches its
+    # own bytes) but whose bytes are not the aboyeur writer canonical encoding
+    # of the JSON object they parse to. The digest check passes (file bytes
+    # hash to the declared sha256), then the writer-byte equality check fails.
+    real.write_bytes(run_json_bytes)
+    os.chmod(real, 0o600)
+    non_writer = b'{"status":"planning"}\n'  # compact, not writer canonical
+    non_writer_sha = hashlib.sha256(non_writer).hexdigest()
+    non_writer_path = cp_dir / f"{non_writer_sha}.json"
+    non_writer_path.write_bytes(non_writer)
+    os.chmod(non_writer_path, 0o600)
+    bad_payload = _checkpoint_payload(non_writer)
+    bad_payload["sha256"] = non_writer_sha
+    bad_payload["path"] = f"events/recovery-checkpoints/{non_writer_sha}.json"
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.validate_checkpoint(run_dir, bad_payload)
+    assert excinfo.value.category == "writer-bytes"
+
+
+# -- Crash-safe publish ------------------------------------------------------
+
+
+def test_publish_checkpoint_file_writes_private_file_with_matching_digest(tmp_path):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started", "task": "demo"})
+
+    final = run_checkpoint.publish_checkpoint_file(run_dir, run_json_bytes)
+
+    assert final.is_file()
+    assert stat.S_IMODE(final.stat().st_mode) == 0o600
+    assert stat.S_IMODE(final.parent.stat().st_mode) == 0o700
+    assert final == run_checkpoint.checkpoint_path(run_dir, hashlib.sha256(run_json_bytes).hexdigest())
+    assert final.read_bytes() == run_json_bytes
+    assert hashlib.sha256(final.read_bytes()).hexdigest() == hashlib.sha256(run_json_bytes).hexdigest()
+
+
+def test_publish_checkpoint_file_matching_collision_is_noop(tmp_path):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+    pre = _place_checkpoint_file(run_dir, run_json_bytes)
+    pre_mtime = pre.stat().st_mtime_ns
+    pre_bytes = pre.read_bytes()
+
+    final = run_checkpoint.publish_checkpoint_file(run_dir, run_json_bytes)
+
+    assert final == pre
+    assert final.read_bytes() == pre_bytes
+    assert final.stat().st_mtime_ns == pre_mtime
+
+
+def test_publish_checkpoint_file_mismatched_collision_fails_closed(tmp_path):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+    final = _place_checkpoint_file(run_dir, run_json_bytes)
+    # Corrupt the existing file in place (same path, different bytes).
+    final.write_bytes(_writer_bytes({"status": "failed"}))
+    os.chmod(final, 0o600)
+    before = final.read_bytes()
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.publish_checkpoint_file(run_dir, run_json_bytes)
+    assert excinfo.value.category == "collision-mismatch"
+    assert final.read_bytes() == before
+
+
+def test_publish_checkpoint_file_unsafe_collision_fails_closed(tmp_path):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+    sha = hashlib.sha256(run_json_bytes).hexdigest()
+    cp_dir = run_dir / "events" / run_checkpoint.CHECKPOINT_DIR_NAME
+    cp_dir.mkdir(parents=True)
+
+    # symlink collision
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    target = outside / "real.json"
+    target.write_bytes(run_json_bytes)
+    symlink = cp_dir / f"{sha}.json"
+    symlink.symlink_to(target)
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.publish_checkpoint_file(run_dir, run_json_bytes)
+    assert excinfo.value.category == "collision-unsafe"
+    assert symlink.is_symlink()
+    symlink.unlink()
+
+    # non-regular inode collision (directory)
+    nonreg = cp_dir / f"{sha}.json"
+    nonreg.mkdir()
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.publish_checkpoint_file(run_dir, run_json_bytes)
+    assert excinfo.value.category == "collision-unsafe"
+    nonreg.rmdir()
+
+    # link count above one collision
+    real = cp_dir / f"{sha}.json"
+    real.write_bytes(run_json_bytes)
+    os.chmod(real, 0o600)
+    extra = cp_dir / "extra.json"
+    os.link(real, extra)
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.publish_checkpoint_file(run_dir, run_json_bytes)
+    assert excinfo.value.category == "collision-unsafe"
+    extra.unlink()
+
+
+def test_publish_checkpoint_file_refuses_oversize_bytes(tmp_path):
+    run_dir = _run_dir(tmp_path)
+    oversize = b"x" * (run_checkpoint.MAX_CHECKPOINT_BYTES + 1)
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.publish_checkpoint_file(run_dir, oversize)
+    assert excinfo.value.category == "byte-size"

--- a/tests/test_run_checkpoint.py
+++ b/tests/test_run_checkpoint.py
@@ -5,10 +5,12 @@ Issue #568 slice 5, Task 1 (RED-first). Standard library only.
 
 from __future__ import annotations
 
+import errno
 import hashlib
 import json
 import os
 import stat
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -324,3 +326,935 @@ def test_publish_checkpoint_file_refuses_oversize_bytes(tmp_path):
     with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
         run_checkpoint.publish_checkpoint_file(run_dir, oversize)
     assert excinfo.value.category == "byte-size"
+
+
+# -- Finding 1: post-unlink directory fsync ---------------------------------
+
+
+def test_publish_checkpoint_file_fsyncs_directory_after_temp_unlink(tmp_path, monkeypatch):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started", "task": "demo"})
+    cp_dir = run_dir / "events" / run_checkpoint.CHECKPOINT_DIR_NAME
+
+    real_open = os.open
+    real_fsync = os.fsync
+    real_unlink = os.unlink
+    call_log: list[tuple[str, bool]] = []
+
+    def tracking_unlink(path):
+        call_log.append(("unlink", False))
+        return real_unlink(path)
+
+    def tracking_open(path, flags, mode=0o666, *, dir_fd=None):
+        return real_open(path, flags, mode, dir_fd=dir_fd) if dir_fd is not None else real_open(path, flags, mode)
+
+    def tracking_fsync(fd):
+        # Prove the descriptor passed to fsync refers to the checkpoint
+        # directory itself (not merely that any fsync occurred later), while
+        # the directory descriptor is still open.
+        call_log.append(("fsync", _refers_to_cp_dir(fd, cp_dir)))
+        return real_fsync(fd)
+
+    monkeypatch.setattr(os, "unlink", tracking_unlink)
+    monkeypatch.setattr(os, "fsync", tracking_fsync)
+    monkeypatch.setattr(os, "open", tracking_open)
+
+    run_checkpoint.publish_checkpoint_file(run_dir, run_json_bytes)
+
+    # A directory fsync on the checkpoint directory must occur after the
+    # legitimate temp unlink. The outer finally also unlinks (missing_ok
+    # no-op) as a safety net, so look for any unlink followed by a later
+    # fsync whose descriptor refers to the checkpoint directory.
+    unlink_indices = [i for i, (kind, _) in enumerate(call_log) if kind == "unlink"]
+    assert unlink_indices, "temp was never unlinked"
+    first_unlink = unlink_indices[0]
+    dir_fsyncs_after = [
+        i for i, (kind, refers_cp) in enumerate(call_log) if kind == "fsync" and refers_cp and i > first_unlink
+    ]
+    assert dir_fsyncs_after, "no checkpoint-directory fsync after temp unlink"
+
+
+# -- Finding 2: failure paths must not leak temps ----------------------------
+
+
+def _list_temps(cp_dir: Path) -> list[Path]:
+    if not cp_dir.is_dir():
+        return []
+    return [p for p in cp_dir.iterdir() if p.name.startswith(".checkpoint.") and p.name.endswith(".tmp")]
+
+
+def test_publish_checkpoint_file_removes_temp_when_chmod_fails(tmp_path, monkeypatch):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+    cp_dir = run_dir / "events" / run_checkpoint.CHECKPOINT_DIR_NAME
+
+    def fail_chmod_fd_or_path(fd, path, mode):
+        raise OSError(errno.EPERM, "chmod denied")
+
+    monkeypatch.setattr(run_journal, "_chmod_fd_or_path", fail_chmod_fd_or_path)
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.publish_checkpoint_file(run_dir, run_json_bytes)
+    assert excinfo.value.category == "chmod"
+    assert _list_temps(cp_dir) == []
+
+
+@pytest.mark.parametrize("has_fchmod", [True, False])
+def test_publish_checkpoint_file_removes_temp_when_chmod_fails_under_both_backends(tmp_path, monkeypatch, has_fchmod):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+    cp_dir = run_dir / "events" / run_checkpoint.CHECKPOINT_DIR_NAME
+
+    monkeypatch.setattr(run_journal, "_HAS_FCHMOD", has_fchmod)
+
+    def fail_chmod_fd_or_path(fd, path, mode):
+        raise OSError(errno.EPERM, "chmod denied")
+
+    monkeypatch.setattr(run_journal, "_chmod_fd_or_path", fail_chmod_fd_or_path)
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.publish_checkpoint_file(run_dir, run_json_bytes)
+    assert excinfo.value.category == "chmod"
+    assert _list_temps(cp_dir) == []
+
+
+def test_publish_checkpoint_file_removes_temp_when_write_raises(tmp_path, monkeypatch):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+    cp_dir = run_dir / "events" / run_checkpoint.CHECKPOINT_DIR_NAME
+
+    def fail_write(fd, data):
+        raise OSError(errno.EIO, "write denied")
+
+    monkeypatch.setattr(os, "write", fail_write)
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.publish_checkpoint_file(run_dir, run_json_bytes)
+    assert excinfo.value.category == "io"
+    assert _list_temps(cp_dir) == []
+
+
+def test_publish_checkpoint_file_removes_temp_when_fsync_fails(tmp_path, monkeypatch):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+    cp_dir = run_dir / "events" / run_checkpoint.CHECKPOINT_DIR_NAME
+
+    def fail_fsync(fd):
+        raise OSError(errno.EIO, "fsync denied")
+
+    monkeypatch.setattr(os, "fsync", fail_fsync)
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.publish_checkpoint_file(run_dir, run_json_bytes)
+    assert excinfo.value.category == "io"
+    assert _list_temps(cp_dir) == []
+
+
+def test_publish_checkpoint_file_removes_temp_when_link_raises_nonexist(tmp_path, monkeypatch):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+    cp_dir = run_dir / "events" / run_checkpoint.CHECKPOINT_DIR_NAME
+
+    def fail_link(src, dst):
+        raise OSError(errno.EACCES, "link denied")
+
+    monkeypatch.setattr(os, "link", fail_link)
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.publish_checkpoint_file(run_dir, run_json_bytes)
+    assert excinfo.value.category == "link"
+    assert _list_temps(cp_dir) == []
+
+
+def test_publish_checkpoint_file_removes_temp_when_collision_verify_raises(tmp_path):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+    cp_dir = run_dir / "events" / run_checkpoint.CHECKPOINT_DIR_NAME
+    sha = hashlib.sha256(run_json_bytes).hexdigest()
+    # Pre-place a mismatched collision so _verify_collision raises collision-mismatch.
+    final = cp_dir / f"{sha}.json"
+    cp_dir.mkdir(parents=True, exist_ok=True)
+    final.write_bytes(_writer_bytes({"status": "different"}))
+    os.chmod(final, 0o600)
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.publish_checkpoint_file(run_dir, run_json_bytes)
+    assert excinfo.value.category == "collision-mismatch"
+    assert _list_temps(cp_dir) == []
+
+
+def test_publish_checkpoint_file_removes_temp_when_collision_open_fails_raw(tmp_path, monkeypatch):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+    cp_dir = run_dir / "events" / run_checkpoint.CHECKPOINT_DIR_NAME
+    sha = hashlib.sha256(run_json_bytes).hexdigest()
+    # Pre-place a matching collision so os.link raises FileExistsError and the
+    # collision-race path invokes _verify_collision.
+    final = cp_dir / f"{sha}.json"
+    cp_dir.mkdir(parents=True, exist_ok=True)
+    final.write_bytes(run_json_bytes)
+    os.chmod(final, 0o600)
+
+    real_open = os.open
+
+    def fail_collision_open(path, flags, mode=0o666, *, dir_fd=None):
+        if Path(path) == final:
+            raise OSError(errno.EACCES, "collision open denied")
+        return real_open(path, flags, mode, dir_fd=dir_fd) if dir_fd is not None else real_open(path, flags, mode)
+
+    monkeypatch.setattr(os, "open", fail_collision_open)
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.publish_checkpoint_file(run_dir, run_json_bytes)
+    assert excinfo.value.category == "collision-unsafe"
+    assert len(str(excinfo.value)) <= run_events.MAX_DIAGNOSTIC_LEN
+    assert _list_temps(cp_dir) == []
+
+
+def test_publish_checkpoint_file_removes_temp_when_dir_fsync_fails(tmp_path, monkeypatch):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+    cp_dir = run_dir / "events" / run_checkpoint.CHECKPOINT_DIR_NAME
+
+    real_fsync = os.fsync
+    call_count = {"n": 0}
+
+    def fail_dir_fsync(fd):
+        call_count["n"] += 1
+        # Let the temp-file fsync succeed; fail the directory fsync.
+        # Distinguish by attempting fstat: directories and files both are fstat-able,
+        # so we fail on every fsync call after the first.
+        if call_count["n"] > 1:
+            raise OSError(errno.EIO, "dir fsync denied")
+        return real_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", fail_dir_fsync)
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.publish_checkpoint_file(run_dir, run_json_bytes)
+    assert excinfo.value.category == "dir-fsync"
+    assert _list_temps(cp_dir) == []
+
+
+def test_publish_checkpoint_file_cleanup_failure_is_bounded_when_no_primary(tmp_path, monkeypatch):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+
+    def fail_unlink(path):
+        raise OSError(errno.EACCES, "unlink denied")
+
+    monkeypatch.setattr(os, "unlink", fail_unlink)
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.publish_checkpoint_file(run_dir, run_json_bytes)
+    assert excinfo.value.category == "unlink"
+    assert len(str(excinfo.value)) <= run_events.MAX_DIAGNOSTIC_LEN
+
+
+def test_publish_checkpoint_file_preserves_primary_when_cleanup_also_fails(tmp_path, monkeypatch):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+
+    real_fsync = os.fsync
+    fsync_count = {"n": 0}
+
+    def fail_dir_fsync(fd):
+        fsync_count["n"] += 1
+        if fsync_count["n"] > 1:
+            raise OSError(errno.EIO, "dir fsync denied")
+        return real_fsync(fd)
+
+    def fail_unlink(path):
+        raise OSError(errno.EACCES, "unlink denied")
+
+    monkeypatch.setattr(os, "fsync", fail_dir_fsync)
+    monkeypatch.setattr(os, "unlink", fail_unlink)
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.publish_checkpoint_file(run_dir, run_json_bytes)
+    # Primary is the dir-fsync failure, not the cleanup unlink failure.
+    assert excinfo.value.category == "dir-fsync"
+
+
+# -- Finding 3: no unconditional fchmod -------------------------------------
+
+
+def test_publish_checkpoint_file_succeeds_without_fchmod(tmp_path, monkeypatch):
+    monkeypatch.setattr(run_journal, "_HAS_FCHMOD", False)
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+
+    final = run_checkpoint.publish_checkpoint_file(run_dir, run_json_bytes)
+
+    assert final.is_file()
+    assert stat.S_IMODE(final.stat().st_mode) == 0o600
+    assert final.read_bytes() == run_json_bytes
+
+
+def test_publish_checkpoint_file_does_not_call_fchmod_when_disabled(tmp_path, monkeypatch):
+    monkeypatch.setattr(run_journal, "_HAS_FCHMOD", False)
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+
+    # If the code path still called os.fchmod it would raise AttributeError on
+    # hosts without it; we simulate by removing the attribute entirely. Let
+    # monkeypatch manage state without reading the attribute first so the test
+    # is portable on hosts where os.fchmod is initially absent.
+    monkeypatch.delattr(os, "fchmod", raising=False)
+    run_checkpoint.publish_checkpoint_file(run_dir, run_json_bytes)
+
+
+# -- Finding 4: non-string payload keys + raw OSError translation ------------
+
+
+def test_validate_checkpoint_rejects_non_string_payload_key_before_sort(tmp_path):
+    run_dir = _run_dir(tmp_path)
+    good_bytes = _writer_bytes({"status": "started"})
+    good_payload = _checkpoint_payload(good_bytes)
+    bad = dict(good_payload)
+    bad["unexpected"] = "string extra"  # type: ignore[dict-item]
+    bad[1] = "non-string key"  # type: ignore[dict-item]
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.validate_checkpoint(run_dir, bad)
+    assert excinfo.value.category == "payload-keys"
+    assert len(str(excinfo.value)) <= run_events.MAX_DIAGNOSTIC_LEN
+
+
+def test_publish_checkpoint_file_translates_raw_oserror_on_mkdir(tmp_path, monkeypatch):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+
+    def fail_mkdir(path, *, parents=False, exist_ok=False, mode=0o777):
+        raise OSError(errno.EACCES, "mkdir denied")
+
+    monkeypatch.setattr(Path, "mkdir", fail_mkdir)
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.publish_checkpoint_file(run_dir, run_json_bytes)
+    assert excinfo.value.category == "mkdir"
+    assert len(str(excinfo.value)) <= run_events.MAX_DIAGNOSTIC_LEN
+
+
+def test_publish_checkpoint_file_translates_raw_oserror_on_mkstemp(tmp_path, monkeypatch):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+
+    def fail_mkstemp(*args, **kwargs):
+        raise OSError(errno.EACCES, "mkstemp denied")
+
+    monkeypatch.setattr(tempfile, "mkstemp", fail_mkstemp)
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.publish_checkpoint_file(run_dir, run_json_bytes)
+    assert excinfo.value.category == "temp-create"
+    assert len(str(excinfo.value)) <= run_events.MAX_DIAGNOSTIC_LEN
+
+
+# -- Finding 5: bounded reads, reject growth after fstat --------------------
+
+
+def test_validate_checkpoint_rejects_growth_after_fstat(tmp_path, monkeypatch):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+    final = _place_checkpoint_file(run_dir, run_json_bytes)
+    payload = _checkpoint_payload(run_json_bytes)
+
+    real_fstat = os.fstat
+    extra = b"\n" * 64
+
+    def extending_fstat(fd):
+        st = real_fstat(fd)
+        # Extend the same inode through a separate handle AFTER fstat returns
+        # the declared size, simulating concurrent growth on the open inode.
+        with open(final, "ab") as handle:
+            handle.write(extra)
+        return st
+
+    monkeypatch.setattr(os, "fstat", extending_fstat)
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.validate_checkpoint(run_dir, payload)
+    assert excinfo.value.category == "size-mismatch"
+    assert len(str(excinfo.value)) <= run_events.MAX_DIAGNOSTIC_LEN
+
+
+def test_validate_checkpoint_rejects_growth_after_fstat_via_collision(tmp_path, monkeypatch):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+    final = _place_checkpoint_file(run_dir, run_json_bytes)
+    sha = hashlib.sha256(run_json_bytes).hexdigest()
+
+    real_fstat = os.fstat
+    extra = b"\n" * 64
+
+    def extending_fstat(fd):
+        st = real_fstat(fd)
+        with open(final, "ab") as handle:
+            handle.write(extra)
+        return st
+
+    monkeypatch.setattr(os, "fstat", extending_fstat)
+
+    # Drive _verify_collision directly: a matching-collision path that must
+    # also bound its reads.
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint._verify_collision(final, run_json_bytes, sha)
+    assert excinfo.value.category == "size-mismatch"
+
+
+# -- Re-review Finding 1: centralized cleanup fsyncs on every path -----------
+
+
+def _refers_to_cp_dir(fd, cp_dir: Path) -> bool:
+    try:
+        st = os.fstat(fd)
+        cp_st = cp_dir.stat()
+    except OSError:
+        return False
+    return stat.S_ISDIR(st.st_mode) and st.st_ino == cp_st.st_ino and st.st_dev == cp_st.st_dev
+
+
+def test_publish_checkpoint_file_fsyncs_directory_after_collision_unlink(tmp_path, monkeypatch):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+    cp_dir = run_dir / "events" / run_checkpoint.CHECKPOINT_DIR_NAME
+    _place_checkpoint_file(run_dir, run_json_bytes)
+
+    real_open = os.open
+    real_fsync = os.fsync
+    real_unlink = os.unlink
+    call_log: list[tuple[str, bool]] = []
+
+    def tracking_unlink(path):
+        call_log.append(("unlink", False))
+        return real_unlink(path)
+
+    def tracking_open(path, flags, mode=0o666, *, dir_fd=None):
+        return real_open(path, flags, mode, dir_fd=dir_fd) if dir_fd is not None else real_open(path, flags, mode)
+
+    def tracking_fsync(fd):
+        call_log.append(("fsync", _refers_to_cp_dir(fd, cp_dir)))
+        return real_fsync(fd)
+
+    monkeypatch.setattr(os, "unlink", tracking_unlink)
+    monkeypatch.setattr(os, "open", tracking_open)
+    monkeypatch.setattr(os, "fsync", tracking_fsync)
+
+    run_checkpoint.publish_checkpoint_file(run_dir, run_json_bytes)
+
+    unlink_indices = [i for i, (kind, _) in enumerate(call_log) if kind == "unlink"]
+    assert unlink_indices, "temp was never unlinked on collision path"
+    first_unlink = unlink_indices[0]
+    dir_fsyncs_after = [
+        i for i, (kind, refers_cp) in enumerate(call_log) if kind == "fsync" and refers_cp and i > first_unlink
+    ]
+    assert dir_fsyncs_after, "no checkpoint-directory fsync after collision temp unlink"
+
+
+def test_publish_checkpoint_file_fsyncs_directory_after_error_path_cleanup(tmp_path, monkeypatch):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+    cp_dir = run_dir / "events" / run_checkpoint.CHECKPOINT_DIR_NAME
+
+    real_open = os.open
+    real_fsync = os.fsync
+    real_unlink = os.unlink
+    call_log: list[tuple[str, bool]] = []
+
+    def fail_link(src, dst):
+        raise OSError(errno.EACCES, "link denied")
+
+    def tracking_unlink(path):
+        call_log.append(("unlink", False))
+        return real_unlink(path)
+
+    def tracking_open(path, flags, mode=0o666, *, dir_fd=None):
+        return real_open(path, flags, mode, dir_fd=dir_fd) if dir_fd is not None else real_open(path, flags, mode)
+
+    def tracking_fsync(fd):
+        call_log.append(("fsync", _refers_to_cp_dir(fd, cp_dir)))
+        return real_fsync(fd)
+
+    monkeypatch.setattr(os, "link", fail_link)
+    monkeypatch.setattr(os, "unlink", tracking_unlink)
+    monkeypatch.setattr(os, "open", tracking_open)
+    monkeypatch.setattr(os, "fsync", tracking_fsync)
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.publish_checkpoint_file(run_dir, run_json_bytes)
+    assert excinfo.value.category == "link"
+
+    unlink_indices = [i for i, (kind, _) in enumerate(call_log) if kind == "unlink"]
+    assert unlink_indices, "temp was never cleaned up on the error path"
+    first_unlink = unlink_indices[0]
+    dir_fsyncs_after = [
+        i for i, (kind, refers_cp) in enumerate(call_log) if kind == "fsync" and refers_cp and i > first_unlink
+    ]
+    assert dir_fsyncs_after, "no checkpoint-directory fsync after error-path cleanup unlink"
+
+
+def test_publish_checkpoint_file_cleanup_dir_fsync_failure_is_bounded_when_no_primary(tmp_path, monkeypatch):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+
+    real_fsync = os.fsync
+    fsync_count = {"n": 0}
+
+    def fail_dir_fsync(fd):
+        fsync_count["n"] += 1
+        # temp-file fsync (#1) and post-publish dir fsync (#2) succeed; the
+        # post-cleanup dir fsync (#3) is the only failure.
+        if fsync_count["n"] >= 3:
+            raise OSError(errno.EIO, "cleanup dir fsync denied")
+        return real_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", fail_dir_fsync)
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.publish_checkpoint_file(run_dir, run_json_bytes)
+    assert excinfo.value.category == "dir-fsync"
+    assert len(str(excinfo.value)) <= run_events.MAX_DIAGNOSTIC_LEN
+
+
+# -- Re-review Finding 2: fd always closed, close error precedence ----------
+
+
+def test_publish_checkpoint_file_closes_fd_when_chmod_fails(tmp_path, monkeypatch):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+
+    real_mkstemp = tempfile.mkstemp
+    real_close = os.close
+    opened_fds: list[int] = []
+    closed_fds: list[int] = []
+
+    def tracking_mkstemp(*args, **kwargs):
+        fd, name = real_mkstemp(*args, **kwargs)
+        opened_fds.append(fd)
+        return fd, name
+
+    def fail_chmod_fd_or_path(fd, path, mode):
+        raise OSError(errno.EPERM, "chmod denied")
+
+    def tracking_close(fd):
+        closed_fds.append(fd)
+        return real_close(fd)
+
+    monkeypatch.setattr(tempfile, "mkstemp", tracking_mkstemp)
+    monkeypatch.setattr(run_journal, "_chmod_fd_or_path", fail_chmod_fd_or_path)
+    monkeypatch.setattr(os, "close", tracking_close)
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.publish_checkpoint_file(run_dir, run_json_bytes)
+    assert excinfo.value.category == "chmod"
+    assert opened_fds, "mkstemp fd was never opened"
+    mkstemp_fd = opened_fds[0]
+    assert mkstemp_fd in closed_fds, "mkstemp fd was leaked when chmod failed"
+    with pytest.raises(OSError) as fd_exc:
+        os.fstat(mkstemp_fd)
+    assert fd_exc.value.errno == errno.EBADF
+
+
+def test_publish_checkpoint_file_chmod_failure_preserved_when_close_also_fails(tmp_path, monkeypatch):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+
+    real_mkstemp = tempfile.mkstemp
+    real_close = os.close
+    opened_fds: list[int] = []
+
+    def tracking_mkstemp(*args, **kwargs):
+        fd, name = real_mkstemp(*args, **kwargs)
+        opened_fds.append(fd)
+        return fd, name
+
+    def fail_chmod_fd_or_path(fd, path, mode):
+        raise OSError(errno.EPERM, "chmod denied")
+
+    def fail_close(fd):
+        if opened_fds and fd == opened_fds[0]:
+            real_close(fd)
+            raise OSError(errno.EBADF, "close denied")
+        real_close(fd)
+
+    monkeypatch.setattr(tempfile, "mkstemp", tracking_mkstemp)
+    monkeypatch.setattr(run_journal, "_chmod_fd_or_path", fail_chmod_fd_or_path)
+    monkeypatch.setattr(os, "close", fail_close)
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.publish_checkpoint_file(run_dir, run_json_bytes)
+    assert excinfo.value.category == "chmod"
+
+
+def test_publish_checkpoint_file_close_failure_is_bounded_when_no_primary(tmp_path, monkeypatch):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+
+    real_mkstemp = tempfile.mkstemp
+    real_close = os.close
+    opened_fds: list[int] = []
+
+    def tracking_mkstemp(*args, **kwargs):
+        fd, name = real_mkstemp(*args, **kwargs)
+        opened_fds.append(fd)
+        return fd, name
+
+    def fail_close(fd):
+        if opened_fds and fd == opened_fds[0]:
+            real_close(fd)
+            raise OSError(errno.EBADF, "close denied")
+        real_close(fd)
+
+    monkeypatch.setattr(tempfile, "mkstemp", tracking_mkstemp)
+    monkeypatch.setattr(os, "close", fail_close)
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.publish_checkpoint_file(run_dir, run_json_bytes)
+    assert excinfo.value.category == "close"
+    assert len(str(excinfo.value)) <= run_events.MAX_DIAGNOSTIC_LEN
+
+
+# -- Re-review Finding 3: raw OSError translation in validate/verify --------
+
+
+def _tracking_open_factory(monkeypatch):
+    real_open = os.open
+    opened: list[int] = []
+
+    def tracking_open(path, flags, mode=0o666, *, dir_fd=None):
+        fd = real_open(path, flags, mode, dir_fd=dir_fd) if dir_fd is not None else real_open(path, flags, mode)
+        opened.append(fd)
+        return fd
+
+    monkeypatch.setattr(os, "open", tracking_open)
+    return opened
+
+
+def _fail_last_close_factory(opened: list[int], monkeypatch):
+    real_close = os.close
+
+    def fail_close(fd):
+        if opened and fd == opened[-1]:
+            real_close(fd)
+            raise OSError(errno.EBADF, "close denied")
+        real_close(fd)
+
+    monkeypatch.setattr(os, "close", fail_close)
+    return fail_close
+
+
+def test_validate_checkpoint_translates_raw_oserror_on_fstat(tmp_path, monkeypatch):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+    _place_checkpoint_file(run_dir, run_json_bytes)
+    payload = _checkpoint_payload(run_json_bytes)
+
+    monkeypatch.setattr(os, "fstat", lambda fd: (_ for _ in ()).throw(OSError(errno.EIO, "fstat denied")))
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.validate_checkpoint(run_dir, payload)
+    assert excinfo.value.category == "fstat"
+    assert len(str(excinfo.value)) <= run_events.MAX_DIAGNOSTIC_LEN
+
+
+def test_validate_checkpoint_translates_raw_oserror_on_open_missing(tmp_path):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+    payload = _checkpoint_payload(run_json_bytes)
+    # Do NOT place the checkpoint file: _open_nofollow raises raw FileNotFoundError.
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.validate_checkpoint(run_dir, payload)
+    assert excinfo.value.category == "open-fd"
+    assert len(str(excinfo.value)) <= run_events.MAX_DIAGNOSTIC_LEN
+
+
+def test_validate_checkpoint_translates_raw_oserror_on_open_denied(tmp_path, monkeypatch):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+    _place_checkpoint_file(run_dir, run_json_bytes)
+    payload = _checkpoint_payload(run_json_bytes)
+    final_path = run_checkpoint.checkpoint_path(run_dir, hashlib.sha256(run_json_bytes).hexdigest())
+
+    real_open = os.open
+
+    def fail_open(path, flags, mode=0o666, *, dir_fd=None):
+        if Path(path) == final_path:
+            raise OSError(errno.EACCES, "open denied")
+        return real_open(path, flags, mode, dir_fd=dir_fd) if dir_fd is not None else real_open(path, flags, mode)
+
+    monkeypatch.setattr(os, "open", fail_open)
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.validate_checkpoint(run_dir, payload)
+    assert excinfo.value.category == "open-fd"
+    assert len(str(excinfo.value)) <= run_events.MAX_DIAGNOSTIC_LEN
+
+
+def test_validate_checkpoint_translates_raw_oserror_on_read(tmp_path, monkeypatch):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+    _place_checkpoint_file(run_dir, run_json_bytes)
+    payload = _checkpoint_payload(run_json_bytes)
+
+    monkeypatch.setattr(os, "read", lambda fd, n: (_ for _ in ()).throw(OSError(errno.EIO, "read denied")))
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.validate_checkpoint(run_dir, payload)
+    assert excinfo.value.category == "read"
+    assert len(str(excinfo.value)) <= run_events.MAX_DIAGNOSTIC_LEN
+
+
+def test_validate_checkpoint_translates_raw_oserror_on_close(tmp_path, monkeypatch):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+    _place_checkpoint_file(run_dir, run_json_bytes)
+    payload = _checkpoint_payload(run_json_bytes)
+
+    opened = _tracking_open_factory(monkeypatch)
+    monkeypatch.setattr(os, "close", _fail_last_close_factory(opened, monkeypatch))
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.validate_checkpoint(run_dir, payload)
+    assert excinfo.value.category == "close"
+    assert len(str(excinfo.value)) <= run_events.MAX_DIAGNOSTIC_LEN
+
+
+def test_validate_checkpoint_preserves_primary_when_close_also_fails(tmp_path, monkeypatch):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+    sha = hashlib.sha256(run_json_bytes).hexdigest()
+    cp_dir = run_dir / "events" / run_checkpoint.CHECKPOINT_DIR_NAME
+    cp_dir.mkdir(parents=True)
+    real = cp_dir / f"{sha}.json"
+    real.write_bytes(_writer_bytes({"status": "started", "extra": "diff"}))
+    os.chmod(real, 0o600)
+    payload = _checkpoint_payload(run_json_bytes)
+
+    opened = _tracking_open_factory(monkeypatch)
+    monkeypatch.setattr(os, "close", _fail_last_close_factory(opened, monkeypatch))
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.validate_checkpoint(run_dir, payload)
+    assert excinfo.value.category == "size-mismatch"
+
+
+def test_verify_collision_translates_raw_oserror_on_fstat(tmp_path, monkeypatch):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+    final = _place_checkpoint_file(run_dir, run_json_bytes)
+    sha = hashlib.sha256(run_json_bytes).hexdigest()
+
+    monkeypatch.setattr(os, "fstat", lambda fd: (_ for _ in ()).throw(OSError(errno.EIO, "fstat denied")))
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint._verify_collision(final, run_json_bytes, sha)
+    assert excinfo.value.category == "fstat"
+    assert len(str(excinfo.value)) <= run_events.MAX_DIAGNOSTIC_LEN
+
+
+def test_verify_collision_translates_raw_oserror_on_read(tmp_path, monkeypatch):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+    final = _place_checkpoint_file(run_dir, run_json_bytes)
+    sha = hashlib.sha256(run_json_bytes).hexdigest()
+
+    monkeypatch.setattr(os, "read", lambda fd, n: (_ for _ in ()).throw(OSError(errno.EIO, "read denied")))
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint._verify_collision(final, run_json_bytes, sha)
+    assert excinfo.value.category == "read"
+    assert len(str(excinfo.value)) <= run_events.MAX_DIAGNOSTIC_LEN
+
+
+def test_verify_collision_translates_raw_oserror_on_close(tmp_path, monkeypatch):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+    final = _place_checkpoint_file(run_dir, run_json_bytes)
+    sha = hashlib.sha256(run_json_bytes).hexdigest()
+
+    opened = _tracking_open_factory(monkeypatch)
+    monkeypatch.setattr(os, "close", _fail_last_close_factory(opened, monkeypatch))
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint._verify_collision(final, run_json_bytes, sha)
+    assert excinfo.value.category == "close"
+    assert len(str(excinfo.value)) <= run_events.MAX_DIAGNOSTIC_LEN
+
+
+def test_verify_collision_translates_raw_oserror_on_open(tmp_path, monkeypatch):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+    final = _place_checkpoint_file(run_dir, run_json_bytes)
+    sha = hashlib.sha256(run_json_bytes).hexdigest()
+
+    real_open = os.open
+
+    def fail_open(path, flags, mode=0o666, *, dir_fd=None):
+        if Path(path) == final:
+            raise OSError(errno.EACCES, "open denied")
+        return real_open(path, flags, mode, dir_fd=dir_fd) if dir_fd is not None else real_open(path, flags, mode)
+
+    monkeypatch.setattr(os, "open", fail_open)
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint._verify_collision(final, run_json_bytes, sha)
+    assert excinfo.value.category == "collision-unsafe"
+    assert len(str(excinfo.value)) <= run_events.MAX_DIAGNOSTIC_LEN
+
+
+def test_verify_collision_preserves_primary_when_close_also_fails(tmp_path, monkeypatch):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "started"})
+    sha = hashlib.sha256(run_json_bytes).hexdigest()
+    cp_dir = run_dir / "events" / run_checkpoint.CHECKPOINT_DIR_NAME
+    cp_dir.mkdir(parents=True)
+    final = cp_dir / f"{sha}.json"
+    final.write_bytes(_writer_bytes({"status": "different"}))
+    os.chmod(final, 0o600)
+
+    opened = _tracking_open_factory(monkeypatch)
+    monkeypatch.setattr(os, "close", _fail_last_close_factory(opened, monkeypatch))
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint._verify_collision(final, run_json_bytes, sha)
+    assert excinfo.value.category == "collision-mismatch"
+
+
+# -- Finding: _fsync_directory no-follow hardening --------------------------
+
+
+def test_fsync_directory_refuses_symlink(tmp_path):
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+    symlink = tmp_path / "link"
+    symlink.symlink_to(real_dir)
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint._fsync_directory(symlink)
+    assert excinfo.value.category == "dir-fsync"
+    assert len(str(excinfo.value)) <= run_events.MAX_DIAGNOSTIC_LEN
+
+
+def test_fsync_directory_refuses_non_directory(tmp_path):
+    file_path = tmp_path / "file"
+    file_path.write_bytes(b"x")
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint._fsync_directory(file_path)
+    assert excinfo.value.category == "dir-fsync"
+    assert len(str(excinfo.value)) <= run_events.MAX_DIAGNOSTIC_LEN
+
+
+def test_fsync_directory_translates_raw_oserror_on_open(tmp_path, monkeypatch):
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+    real_open = os.open
+
+    def fail_open(path, flags, mode=0o666, *, dir_fd=None):
+        if path == real_dir:
+            raise OSError(errno.EACCES, "open denied")
+        return real_open(path, flags, mode, dir_fd=dir_fd) if dir_fd is not None else real_open(path, flags, mode)
+
+    monkeypatch.setattr(os, "open", fail_open)
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint._fsync_directory(real_dir)
+    assert excinfo.value.category == "dir-fsync"
+    assert len(str(excinfo.value)) <= run_events.MAX_DIAGNOSTIC_LEN
+
+
+def test_fsync_directory_translates_raw_oserror_on_fstat(tmp_path, monkeypatch):
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+    monkeypatch.setattr(os, "fstat", lambda fd: (_ for _ in ()).throw(OSError(errno.EIO, "fstat denied")))
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint._fsync_directory(real_dir)
+    assert excinfo.value.category == "dir-fsync"
+    assert len(str(excinfo.value)) <= run_events.MAX_DIAGNOSTIC_LEN
+
+
+def test_fsync_directory_translates_raw_oserror_on_close(tmp_path, monkeypatch):
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+    opened = _tracking_open_factory(monkeypatch)
+    monkeypatch.setattr(os, "close", _fail_last_close_factory(opened, monkeypatch))
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint._fsync_directory(real_dir)
+    assert excinfo.value.category == "dir-fsync"
+    assert len(str(excinfo.value)) <= run_events.MAX_DIAGNOSTIC_LEN
+
+
+def test_fsync_directory_preserves_primary_when_close_also_fails(tmp_path, monkeypatch):
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+
+    def fail_fsync(fd):
+        raise OSError(errno.EIO, "fsync denied")
+
+    opened = _tracking_open_factory(monkeypatch)
+    monkeypatch.setattr(os, "fsync", fail_fsync)
+    monkeypatch.setattr(os, "close", _fail_last_close_factory(opened, monkeypatch))
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint._fsync_directory(real_dir)
+    assert excinfo.value.category == "dir-fsync"
+
+
+# -- Issue #568 slice 5 Task 1: RecursionError translation at both boundaries --
+
+
+def _place_deep_checkpoint(run_dir: Path, deep_json: bytes) -> tuple[Path, dict]:
+    sha = hashlib.sha256(deep_json).hexdigest()
+    cp_dir = run_dir / "events" / run_checkpoint.CHECKPOINT_DIR_NAME
+    cp_dir.mkdir(parents=True, exist_ok=True)
+    final = cp_dir / f"{sha}.json"
+    final.write_bytes(deep_json)
+    os.chmod(final, 0o600)
+    return final, _checkpoint_payload(deep_json)
+
+
+def test_validate_checkpoint_translates_recursion_error_on_json_loads(tmp_path):
+    """RecursionError from json.loads on very deep valid JSON -> json-object."""
+    run_dir = _run_dir(tmp_path)
+    # Depth that exhausts the JSON decoder's recursion capacity: a deeply
+    # nested but otherwise valid JSON array. Byte size is well under
+    # MAX_CHECKPOINT_BYTES; the digest and UTF-8 checks pass, then
+    # json.loads raises RecursionError (not a ValueError subclass).
+    depth = 20000
+    deep_json = b"[" * depth + b"]" * depth
+    _final, payload = _place_deep_checkpoint(run_dir, deep_json)
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.validate_checkpoint(run_dir, payload)
+    err = excinfo.value
+    assert err.category == "json-object", f"expected json-object, got {err.category}"
+    assert isinstance(err, run_checkpoint.CheckpointError)
+    diagnostic = str(err)
+    assert diagnostic == err.diagnostic
+    assert len(diagnostic) <= run_events.MAX_DIAGNOSTIC_LEN
+
+
+def test_validate_checkpoint_translates_recursion_error_on_writer_canonical_dumps(tmp_path):
+    """RecursionError from canonical json.dumps re-encoding -> writer-bytes."""
+    run_dir = _run_dir(tmp_path)
+    # A deeply nested JSON *object* (top-level dict): the C JSON decoder
+    # handles this depth (json.loads succeeds and returns a dict, so the
+    # isinstance(obj, dict) gate passes), but the recursive canonical
+    # re-encoder (json.dumps with indent=2, sort_keys=True) cannot, raising
+    # RecursionError from _writer_canonical_bytes.
+    depth = 3000
+    deep_json = (b'{"a":' * depth) + b"1" + (b"}" * depth)
+    _final, payload = _place_deep_checkpoint(run_dir, deep_json)
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.validate_checkpoint(run_dir, payload)
+    err = excinfo.value
+    assert err.category == "writer-bytes", f"expected writer-bytes, got {err.category}"
+    assert isinstance(err, run_checkpoint.CheckpointError)
+    diagnostic = str(err)
+    assert diagnostic == err.diagnostic
+    assert len(diagnostic) <= run_events.MAX_DIAGNOSTIC_LEN

--- a/tests/test_run_checkpoint.py
+++ b/tests/test_run_checkpoint.py
@@ -1375,3 +1375,661 @@ def test_write_checkpoint_noop_when_journal_not_active(enabled, tmp_path):
     )
     assert result is None
     assert not (run_dir / "events").exists()
+
+
+# -- Issue #568 slice 5 Task 5: latest_checkpoint_event + recover_from_checkpoint --
+
+
+def _activated_journal_with_checkpoint(
+    workspace: Path,
+    run_dir: Path,
+    run_json_obj: dict,
+    *,
+    paired_event_type: str | None = "run.planning.started",
+) -> run_journal.RunEvent:
+    """Activate the journal under lock and append one checkpoint event.
+
+    The journal ends in the checkpoint event (the recoverable state: the
+    crash happened after the checkpoint publish+append but before the
+    paired status append). Returns the appended checkpoint RunEvent.
+    """
+    _bootstrap_request(run_dir)
+    with runguard.run_lock(workspace, run_dir=run_dir):
+        run_lifecycle.prepare_lifecycle_journal(run_dir, workspace=workspace)
+        run_json_bytes = _writer_bytes(run_json_obj)
+        event = run_checkpoint.write_checkpoint(
+            run_dir, run_json_bytes, workspace=workspace, paired_event_type=paired_event_type
+        )
+    assert event is not None
+    return event
+
+
+def test_latest_checkpoint_event_returns_none_for_empty_list():
+    assert run_checkpoint.latest_checkpoint_event([]) is None
+
+
+def test_latest_checkpoint_event_returns_none_when_no_checkpoints(tmp_path):
+    workspace = _workspace(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    _bootstrap_request(run_dir)
+    with runguard.run_lock(workspace, run_dir=run_dir):
+        run_lifecycle.prepare_lifecycle_journal(run_dir, workspace=workspace)
+        run_journal.append_event(
+            _journal_path(run_dir),
+            run_id=RUN_ID,
+            event_type="run.created",
+            payload={"status": "started"},
+            idempotency_key="create-1",
+            expected_previous_sequence=0,
+            recorded_at="2026-07-27T15:30:45.123456Z",
+        )
+    events = _events(run_dir)
+    assert all(e.event_type != run_checkpoint.CHECKPOINT_EVENT_TYPE for e in events)
+    assert run_checkpoint.latest_checkpoint_event(events) is None
+
+
+def test_latest_checkpoint_event_selects_highest_sequence(tmp_path):
+    workspace = _workspace(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    first_bytes = _writer_bytes({"schema": "brigade.run.v1", "status": "started"})
+    second_bytes = _writer_bytes({"schema": "brigade.run.v1", "status": "planning"})
+    _bootstrap_request(run_dir)
+    with runguard.run_lock(workspace, run_dir=run_dir):
+        run_lifecycle.prepare_lifecycle_journal(run_dir, workspace=workspace)
+        run_checkpoint.write_checkpoint(run_dir, first_bytes, workspace=workspace, paired_event_type="run.created")
+        second = run_checkpoint.write_checkpoint(
+            run_dir, second_bytes, workspace=workspace, paired_event_type="run.planning.started"
+        )
+    events = _events(run_dir)
+    latest = run_checkpoint.latest_checkpoint_event(events)
+    assert latest is not None
+    assert latest.sequence == second.sequence
+    assert latest.event_id == second.event_id
+
+
+def test_recover_from_checkpoint_restores_missing_run_json_from_latest(tmp_path):
+    workspace = _workspace(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    run_json_obj = {"schema": "brigade.run.v1", "status": "planning", "task": "demo"}
+    _activated_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    # No run.json present (the crash lost it): drop the bootstrap request file.
+    (run_dir / "run.json").unlink()
+
+    repaired = run_checkpoint.recover_from_checkpoint(run_dir, None)
+
+    assert repaired == run_json_obj
+    restored_bytes = (run_dir / "run.json").read_bytes()
+    assert restored_bytes == _writer_bytes(run_json_obj)
+
+
+def test_recover_from_checkpoint_preserves_corrupt_run_json_and_replaces(tmp_path):
+    workspace = _workspace(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    run_json_obj = {"schema": "brigade.run.v1", "status": "planning", "task": "demo"}
+    _activated_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    (run_dir / "run.json").write_text("not json")
+
+    repaired = run_checkpoint.recover_from_checkpoint(run_dir, None)
+
+    assert repaired == run_json_obj
+    assert (run_dir / "run.json").read_bytes() == _writer_bytes(run_json_obj)
+    preserved = list(run_dir.glob("run.json.corrupt-*"))
+    assert len(preserved) == 1
+    assert preserved[0].read_text() == "not json"
+
+
+def test_recover_from_checkpoint_leaves_parseable_run_json_untouched(tmp_path):
+    workspace = _workspace(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    run_json_obj = {"schema": "brigade.run.v1", "status": "planning", "task": "demo"}
+    _activated_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    parseable = {"schema": "brigade.run.v1", "status": "planning", "task": "different"}
+    _writer_bytes(parseable)
+    (run_dir / "run.json").write_text(json.dumps(parseable, indent=2, sort_keys=True) + "\n")
+    before = (run_dir / "run.json").read_bytes()
+
+    repaired = run_checkpoint.recover_from_checkpoint(run_dir, parseable)
+
+    assert repaired == run_json_obj
+    assert (run_dir / "run.json").read_bytes() == before
+    assert not list(run_dir.glob("run.json.corrupt-*"))
+
+
+def test_recover_from_checkpoint_quarantines_partial_tail_then_verifies(tmp_path):
+    workspace = _workspace(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    run_json_obj = {"schema": "brigade.run.v1", "status": "planning", "task": "demo"}
+    _activated_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    (run_dir / "run.json").unlink()
+    journal = _journal_path(run_dir)
+    partial = b'{"schema":"brigade.run_event.v1","event_type":"run.plan'
+    journal.write_bytes(journal.read_bytes() + partial)
+    complete_bytes = journal.read_bytes()[: -len(partial)]
+
+    repaired = run_checkpoint.recover_from_checkpoint(run_dir, None)
+
+    assert repaired == run_json_obj
+    assert journal.read_bytes() == complete_bytes
+    quarantine_files = [p for p in (run_dir / "events" / "quarantine").iterdir() if p.suffix == ".bin"]
+    assert quarantine_files, "partial tail was not quarantined"
+    assert quarantine_files[0].read_bytes() == partial
+
+
+def test_recover_from_checkpoint_fails_on_invalid_latest_checkpoint(tmp_path, monkeypatch):
+    workspace = _workspace(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    run_json_obj = {"schema": "brigade.run.v1", "status": "planning", "task": "demo"}
+    _activated_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    (run_dir / "run.json").unlink()
+    # Corrupt the checkpoint file so validate_checkpoint fails (digest mismatch).
+    sha = hashlib.sha256(_writer_bytes(run_json_obj)).hexdigest()
+    cp_file = run_checkpoint.checkpoint_path(run_dir, sha)
+    cp_file.write_bytes(b"x" * len(_writer_bytes(run_json_obj)))
+    os.chmod(cp_file, 0o600)
+
+    with pytest.raises(run_checkpoint.CheckpointError):
+        run_checkpoint.recover_from_checkpoint(run_dir, None)
+    assert not (run_dir / "run.json").exists()
+
+
+def test_recover_from_checkpoint_accepts_covered_paired_status_event(tmp_path):
+    """A checkpoint at N plus its matching paired status event at N+1 is covered.
+
+    The checkpoint's ``paired_event_type`` names the mapped lifecycle event
+    type for the checkpointed status, and the N+1 event's derived status
+    equals the status in the validated checkpoint bytes. Per the slice-5
+    coverage semantics this is a covered tail (crash after the paired
+    status append but before the run.json replace), so recovery restores
+    the checkpoint bytes without mutation beyond the restore.
+    """
+    workspace = _workspace(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    run_json_obj = {"schema": "brigade.run.v1", "status": "planning", "task": "demo"}
+    _bootstrap_request(run_dir)
+    with runguard.run_lock(workspace, run_dir=run_dir):
+        run_lifecycle.prepare_lifecycle_journal(run_dir, workspace=workspace)
+        run_checkpoint.write_checkpoint(
+            run_dir,
+            _writer_bytes(run_json_obj),
+            workspace=workspace,
+            paired_event_type="run.planning.started",
+        )
+        run_journal.append_event(
+            _journal_path(run_dir),
+            run_id=RUN_ID,
+            event_type="run.planning.started",
+            payload={"detail": "planning"},
+            idempotency_key="plan-start-1",
+            expected_previous_sequence=1,
+            recorded_at="2026-07-27T15:30:46.000000Z",
+        )
+    (run_dir / "run.json").unlink()
+
+    repaired = run_checkpoint.recover_from_checkpoint(run_dir, None)
+
+    assert repaired == run_json_obj
+    assert (run_dir / "run.json").read_bytes() == _writer_bytes(run_json_obj)
+
+
+def _journal_with_checkpoint_and_trailing(
+    workspace: Path,
+    run_dir: Path,
+    run_json_obj: dict,
+    *,
+    paired_event_type: str | None,
+    trailing_events: list[tuple[str, dict, str, str]],
+) -> run_journal.RunEvent:
+    """Activate the journal, write one checkpoint, then append trailing events.
+
+    ``trailing_events`` is a list of ``(event_type, payload, idempotency_key,
+    recorded_at)`` tuples appended after the checkpoint, each linking to the
+    prior event. Returns the appended checkpoint RunEvent.
+    """
+    _bootstrap_request(run_dir)
+    with runguard.run_lock(workspace, run_dir=run_dir):
+        run_lifecycle.prepare_lifecycle_journal(run_dir, workspace=workspace)
+        run_json_bytes = _writer_bytes(run_json_obj)
+        checkpoint = run_checkpoint.write_checkpoint(
+            run_dir, run_json_bytes, workspace=workspace, paired_event_type=paired_event_type
+        )
+        assert checkpoint is not None
+        prev_seq = checkpoint.sequence
+        for event_type, payload, key, recorded_at in trailing_events:
+            appended = run_journal.append_event(
+                _journal_path(run_dir),
+                run_id=RUN_ID,
+                event_type=event_type,
+                payload=payload,
+                idempotency_key=key,
+                expected_previous_sequence=prev_seq,
+                recorded_at=recorded_at,
+            )
+            prev_seq = appended.sequence
+    return checkpoint
+
+
+def test_recover_from_checkpoint_fails_on_wrong_paired_event_type(tmp_path):
+    """N+1 event_type differs from the checkpoint's paired_event_type -> uncovered."""
+    workspace = _workspace(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    run_json_obj = {"schema": "brigade.run.v1", "status": "planning", "task": "demo"}
+    _journal_with_checkpoint_and_trailing(
+        workspace,
+        run_dir,
+        run_json_obj,
+        paired_event_type="run.planning.started",
+        trailing_events=[
+            ("run.dispatch.requested", {"detail": "dispatching"}, "dispatch-1", "2026-07-27T15:30:46.000000Z"),
+        ],
+    )
+    (run_dir / "run.json").unlink()
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.recover_from_checkpoint(run_dir, None)
+    assert excinfo.value.category == "uncovered-tail"
+    assert not (run_dir / "run.json").exists()
+
+
+def test_recover_from_checkpoint_fails_on_paired_derived_status_mismatch(tmp_path):
+    """N+1 event_type matches but its derived status differs from the checkpoint -> uncovered."""
+    workspace = _workspace(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    # Checkpoint status "failed" pairs with run.failed; an N+1 run.failed
+    # event whose payload status is "timeout" derives "timeout" != "failed".
+    run_json_obj = {"schema": "brigade.run.v1", "status": "failed", "task": "demo"}
+    _journal_with_checkpoint_and_trailing(
+        workspace,
+        run_dir,
+        run_json_obj,
+        paired_event_type="run.failed",
+        trailing_events=[
+            ("run.failed", {"status": "timeout"}, "fail-1", "2026-07-27T15:30:46.000000Z"),
+        ],
+    )
+    (run_dir / "run.json").unlink()
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.recover_from_checkpoint(run_dir, None)
+    assert excinfo.value.category == "uncovered-tail"
+    assert not (run_dir / "run.json").exists()
+
+
+def test_recover_from_checkpoint_fails_on_null_pairing_with_following_event(tmp_path):
+    """A null paired_event_type covers only checkpoint-at-tail; a following event is uncovered."""
+    workspace = _workspace(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    # Same-status refresh: paired_event_type is null. Any following event is uncovered.
+    run_json_obj = {"schema": "brigade.run.v1", "status": "started", "task": "demo"}
+    _journal_with_checkpoint_and_trailing(
+        workspace,
+        run_dir,
+        run_json_obj,
+        paired_event_type=None,
+        trailing_events=[
+            ("run.created", {"status": "started"}, "create-1", "2026-07-27T15:30:46.000000Z"),
+        ],
+    )
+    (run_dir / "run.json").unlink()
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.recover_from_checkpoint(run_dir, None)
+    assert excinfo.value.category == "uncovered-tail"
+    assert not (run_dir / "run.json").exists()
+
+
+def test_recover_from_checkpoint_fails_on_two_events_after_checkpoint(tmp_path):
+    """Two events after the latest checkpoint (even if the first matches) -> uncovered."""
+    workspace = _workspace(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    run_json_obj = {"schema": "brigade.run.v1", "status": "planning", "task": "demo"}
+    _journal_with_checkpoint_and_trailing(
+        workspace,
+        run_dir,
+        run_json_obj,
+        paired_event_type="run.planning.started",
+        trailing_events=[
+            ("run.planning.started", {"detail": "planning"}, "plan-start-1", "2026-07-27T15:30:46.000000Z"),
+            ("run.dispatch.requested", {"detail": "dispatching"}, "dispatch-1", "2026-07-27T15:30:47.000000Z"),
+        ],
+    )
+    (run_dir / "run.json").unlink()
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.recover_from_checkpoint(run_dir, None)
+    assert excinfo.value.category == "uncovered-tail"
+    assert not (run_dir / "run.json").exists()
+
+
+def test_recover_from_checkpoint_fails_on_invalid_coverage_with_parseable_run_json(tmp_path):
+    """An uncovered tail fails closed even when run.json is parseable; it is left untouched.
+
+    The coverage check runs for every activated-journal run regardless of
+    whether run.json parses. A parseable run.json with an uncovered tail
+    must fail closed with no mutation to run.json (validation-before-
+    mutation: coverage validation completes before the restore).
+    """
+    workspace = _workspace(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    run_json_obj = {"schema": "brigade.run.v1", "status": "planning", "task": "demo"}
+    _journal_with_checkpoint_and_trailing(
+        workspace,
+        run_dir,
+        run_json_obj,
+        paired_event_type="run.planning.started",
+        trailing_events=[
+            ("run.dispatch.requested", {"detail": "dispatching"}, "dispatch-1", "2026-07-27T15:30:46.000000Z"),
+        ],
+    )
+    parseable = {"schema": "brigade.run.v1", "status": "planning", "task": "different"}
+    (run_dir / "run.json").write_text(json.dumps(parseable, indent=2, sort_keys=True) + "\n")
+    before = (run_dir / "run.json").read_bytes()
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.recover_from_checkpoint(run_dir, parseable)
+    assert excinfo.value.category == "uncovered-tail"
+    assert (run_dir / "run.json").read_bytes() == before
+    assert not list(run_dir.glob("run.json.corrupt-*"))
+
+
+def test_recover_from_checkpoint_fails_on_chain_break(tmp_path):
+    workspace = _workspace(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    run_json_obj = {"schema": "brigade.run.v1", "status": "planning", "task": "demo"}
+    _activated_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    # Rewrite the journal with a sequence gap by hand (sequence 1 then 3).
+    journal = _journal_path(run_dir)
+    events = _events(run_dir)
+    assert len(events) == 1
+    env = events[0].to_dict()
+    env["sequence"] = 3
+    env["previous_digest"] = events[0].previous_digest
+    # Recompute event_id and event_digest for the tampered envelope.
+    env["event_digest"] = run_events.compute_event_digest(env)
+    env["event_id"] = run_events.make_event_id(
+        run_id=env["run_id"], sequence=env["sequence"], event_digest=env["event_digest"]
+    )
+    journal.write_bytes(run_events.canonical_bytes(env) + b"\n")
+
+    with pytest.raises(run_checkpoint.CheckpointError):
+        run_checkpoint.recover_from_checkpoint(run_dir, None)
+
+
+def test_recover_from_checkpoint_fails_on_unknown_event(tmp_path):
+    workspace = _workspace(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    run_json_obj = {"schema": "brigade.run.v1", "status": "planning", "task": "demo"}
+    _activated_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    journal = _journal_path(run_dir)
+    events = _events(run_dir)
+    env = events[0].to_dict()
+    env["event_type"] = "run.not.a.real.event"
+    env["payload"] = {}
+    env["event_digest"] = run_events.compute_event_digest(env)
+    env["event_id"] = run_events.make_event_id(
+        run_id=env["run_id"], sequence=env["sequence"], event_digest=env["event_digest"]
+    )
+    journal.write_bytes(run_events.canonical_bytes(env) + b"\n")
+
+    with pytest.raises(run_checkpoint.CheckpointError):
+        run_checkpoint.recover_from_checkpoint(run_dir, None)
+
+
+def test_recover_from_checkpoint_fails_on_envelope_run_id_mismatch(tmp_path):
+    workspace = _workspace(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    run_json_obj = {"schema": "brigade.run.v1", "status": "planning", "task": "demo"}
+    _activated_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    journal = _journal_path(run_dir)
+    events = _events(run_dir)
+    env = events[0].to_dict()
+    env["run_id"] = "a-different-run-id"
+    env["event_digest"] = run_events.compute_event_digest(env)
+    env["event_id"] = run_events.make_event_id(
+        run_id=env["run_id"], sequence=env["sequence"], event_digest=env["event_digest"]
+    )
+    journal.write_bytes(run_events.canonical_bytes(env) + b"\n")
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.recover_from_checkpoint(run_dir, None)
+    assert excinfo.value.category == "run-id-mismatch"
+
+
+def test_recover_from_checkpoint_fails_on_corrupt_rename_oserror(tmp_path, monkeypatch):
+    workspace = _workspace(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    run_json_obj = {"schema": "brigade.run.v1", "status": "planning", "task": "demo"}
+    _activated_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    (run_dir / "run.json").write_text("not json")
+
+    real_rename = Path.rename
+
+    def fail_rename_on_corrupt(self, target):
+        if str(target).startswith(str(run_dir / "run.json.corrupt-")):
+            raise OSError(errno.EACCES, "rename denied")
+        return real_rename(self, target)
+
+    monkeypatch.setattr(Path, "rename", fail_rename_on_corrupt)
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.recover_from_checkpoint(run_dir, None)
+    assert excinfo.value.category == "preserve-corrupt"
+    # The corrupt original is still in place (rename failed).
+    assert (run_dir / "run.json").read_text() == "not json"
+
+
+# -- Issue #568 slice 5 Task 5 sendback: bounded journal-read normalization --
+
+
+def test_recover_from_checkpoint_normalizes_oversized_journal_to_checkpoint_error(tmp_path, monkeypatch):
+    """An oversized journal surfaces a bounded CheckpointError, not a raw RunJournalError.
+
+    ``read_journal_bounded`` raises ``RunJournalError`` when the journal exceeds
+    ``MAX_JOURNAL_BYTES``; ``recover_from_checkpoint`` must normalize that to a
+    bounded categorized ``CheckpointError`` as its public contract promises.
+    """
+    workspace = _workspace(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    run_json_obj = {"schema": "brigade.run.v1", "status": "planning", "task": "demo"}
+    _activated_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    (run_dir / "run.json").unlink()
+    # Force the bound check to fire on the existing (small) journal.
+    monkeypatch.setattr(run_checkpoint, "MAX_JOURNAL_BYTES", 8)
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.recover_from_checkpoint(run_dir, None)
+    assert excinfo.value.category == "journal-read"
+    assert not (run_dir / "run.json").exists()
+
+
+def test_recover_from_checkpoint_normalizes_raw_oserror_on_initial_journal_read(tmp_path, monkeypatch):
+    """A raw ``OSError`` from the initial bounded journal read is normalized.
+
+    ``read_journal_bounded`` can raise a raw ``OSError`` (e.g. permission denied
+    on ``_open_nofollow``); the public contract promises a bounded
+    ``CheckpointError``.
+    """
+    workspace = _workspace(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    run_json_obj = {"schema": "brigade.run.v1", "status": "planning", "task": "demo"}
+    _activated_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    (run_dir / "run.json").unlink()
+
+    def raise_oserror(_journal_path):
+        raise OSError(errno.EACCES, "permission denied")
+
+    monkeypatch.setattr(run_journal, "read_journal_bounded", raise_oserror)
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.recover_from_checkpoint(run_dir, None)
+    assert excinfo.value.category == "journal-read"
+    assert isinstance(excinfo.value.__cause__, OSError)
+
+
+def test_recover_from_checkpoint_normalizes_partial_tail_quarantine_raw_oserror(tmp_path, monkeypatch):
+    """A raw ``OSError`` from ``recover_partial_tail`` is normalized.
+
+    The quarantine step can raise a raw ``OSError`` (e.g. ``mkdir`` or temp
+    write failure); the contract promises a bounded ``CheckpointError``.
+    """
+    workspace = _workspace(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    run_json_obj = {"schema": "brigade.run.v1", "status": "planning", "task": "demo"}
+    _activated_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    (run_dir / "run.json").unlink()
+    journal = _journal_path(run_dir)
+    partial = b'{"schema":"brigade.run_event.v1","event_type":"run.plan'
+    journal.write_bytes(journal.read_bytes() + partial)
+
+    def raise_oserror(_journal_path, _quarantine_dir):
+        raise OSError(errno.EACCES, "quarantine mkdir denied")
+
+    monkeypatch.setattr(run_journal, "recover_partial_tail", raise_oserror)
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.recover_from_checkpoint(run_dir, None)
+    assert excinfo.value.category == "partial-tail"
+    assert isinstance(excinfo.value.__cause__, OSError)
+
+
+def test_recover_from_checkpoint_normalizes_reread_oserror_after_quarantine(tmp_path, monkeypatch):
+    """A raw ``OSError`` on the post-quarantine reread is normalized.
+
+    The reread path (after a successful quarantine) can raise a raw ``OSError``;
+    the contract promises a bounded ``CheckpointError``.
+    """
+    workspace = _workspace(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    run_json_obj = {"schema": "brigade.run.v1", "status": "planning", "task": "demo"}
+    _activated_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    (run_dir / "run.json").unlink()
+    journal = _journal_path(run_dir)
+    partial = b'{"schema":"brigade.run_event.v1","event_type":"run.plan'
+    journal.write_bytes(journal.read_bytes() + partial)
+
+    real_read = run_journal.read_journal_bounded
+    call_count = {"n": 0}
+
+    def fail_second_read(journal_path):
+        call_count["n"] += 1
+        if call_count["n"] == 2:
+            raise OSError(errno.EIO, "reread io error")
+        return real_read(journal_path)
+
+    monkeypatch.setattr(run_journal, "read_journal_bounded", fail_second_read)
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.recover_from_checkpoint(run_dir, None)
+    assert excinfo.value.category == "journal-read"
+    assert isinstance(excinfo.value.__cause__, OSError)
+
+
+def test_recover_from_checkpoint_normalizes_restore_write_raw_oserror(tmp_path, monkeypatch):
+    """A raw ``OSError`` from the restoration atomic write is normalized.
+
+    ``localio.write_text_atomic`` can raise a raw ``OSError`` (mkstemp, fsync,
+    or ``os.replace`` failure); the contract promises a bounded
+    ``CheckpointError`` so a raw filesystem error never leaks out of
+    ``recover_from_checkpoint``.
+    """
+    from brigade import localio
+
+    workspace = _workspace(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    run_json_obj = {"schema": "brigade.run.v1", "status": "planning", "task": "demo"}
+    _activated_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    (run_dir / "run.json").unlink()
+
+    def raise_oserror(_path, _data):
+        raise OSError(errno.EACCES, "restore write denied")
+
+    monkeypatch.setattr(localio, "write_text_atomic", raise_oserror)
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.recover_from_checkpoint(run_dir, None)
+    assert excinfo.value.category == "restore-write"
+    assert isinstance(excinfo.value.__cause__, OSError)
+    assert not (run_dir / "run.json").exists()
+
+
+# -- Issue #568 slice 5 Task 5 second sendback: run.json input edges + path resolve --
+
+
+def test_recover_from_checkpoint_preserves_non_utf8_run_json_and_replaces(tmp_path):
+    workspace = _workspace(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    run_json_obj = {"schema": "brigade.run.v1", "status": "planning", "task": "demo"}
+    _activated_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    corrupt_bytes = b"\xff\xfe not utf-8"
+    (run_dir / "run.json").write_bytes(corrupt_bytes)
+
+    repaired = run_checkpoint.recover_from_checkpoint(run_dir, None)
+
+    assert repaired == run_json_obj
+    assert (run_dir / "run.json").read_bytes() == _writer_bytes(run_json_obj)
+    preserved = list(run_dir.glob("run.json.corrupt-*"))
+    assert len(preserved) == 1
+    assert preserved[0].read_bytes() == corrupt_bytes
+
+
+def test_recover_from_checkpoint_preserves_recursion_error_run_json_and_replaces(tmp_path):
+    workspace = _workspace(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    run_json_obj = {"schema": "brigade.run.v1", "status": "planning", "task": "demo"}
+    _activated_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    depth = 20000
+    deep_json = ("[" * depth) + ("]" * depth)
+    (run_dir / "run.json").write_text(deep_json)
+
+    repaired = run_checkpoint.recover_from_checkpoint(run_dir, None)
+
+    assert repaired == run_json_obj
+    assert (run_dir / "run.json").read_bytes() == _writer_bytes(run_json_obj)
+    preserved = list(run_dir.glob("run.json.corrupt-*"))
+    assert len(preserved) == 1
+    assert preserved[0].read_text() == deep_json
+
+
+def test_recover_from_checkpoint_normalizes_path_resolve_oserror(tmp_path, monkeypatch):
+    workspace = _workspace(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    run_json_obj = {"schema": "brigade.run.v1", "status": "planning", "task": "demo"}
+    _activated_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    (run_dir / "run.json").unlink()
+
+    real_resolve = Path.resolve
+
+    def fail_resolve(self):
+        if self == run_dir:
+            raise OSError(errno.EACCES, "resolve denied")
+        return real_resolve(self)
+
+    monkeypatch.setattr(Path, "resolve", fail_resolve)
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.recover_from_checkpoint(run_dir, None)
+    assert excinfo.value.category == "path-resolve"
+    assert isinstance(excinfo.value.__cause__, OSError)
+    assert not (run_dir / "run.json").exists()
+
+
+def test_recover_from_checkpoint_normalizes_path_resolve_runtime_error(tmp_path, monkeypatch):
+    workspace = _workspace(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    run_json_obj = {"schema": "brigade.run.v1", "status": "planning", "task": "demo"}
+    _activated_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    (run_dir / "run.json").unlink()
+
+    real_resolve = Path.resolve
+
+    def fail_resolve(self):
+        if self == run_dir:
+            raise RuntimeError("symlink cycle")
+        return real_resolve(self)
+
+    monkeypatch.setattr(Path, "resolve", fail_resolve)
+
+    with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+        run_checkpoint.recover_from_checkpoint(run_dir, None)
+    assert excinfo.value.category == "path-resolve"
+    assert isinstance(excinfo.value.__cause__, RuntimeError)
+    assert not (run_dir / "run.json").exists()

--- a/tests/test_run_checkpoint.py
+++ b/tests/test_run_checkpoint.py
@@ -15,7 +15,8 @@ from pathlib import Path
 
 import pytest
 
-from brigade import run_checkpoint, run_events, run_journal
+from brigade import run_checkpoint, run_events, run_journal, run_lifecycle, runguard
+from brigade import localio
 
 RUN_ID = "20260727-153045-a1b2c3d4"
 
@@ -1258,3 +1259,119 @@ def test_validate_checkpoint_translates_recursion_error_on_writer_canonical_dump
     diagnostic = str(err)
     assert diagnostic == err.diagnostic
     assert len(diagnostic) <= run_events.MAX_DIAGNOSTIC_LEN
+
+
+# -- Issue #568 slice 5 Task 2: run_checkpoint.write_checkpoint coordinator ----
+
+
+_REQUEST_FIELD = "lifecycle_journal_requested"
+
+
+def _workspace(tmp_path: Path) -> Path:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    return workspace
+
+
+def _journal_path(run_dir: Path) -> Path:
+    return run_dir / "events" / "lifecycle.jsonl"
+
+
+def _checkpoint_dir(run_dir: Path) -> Path:
+    return run_dir / "events" / run_checkpoint.CHECKPOINT_DIR_NAME
+
+
+def _events(run_dir: Path) -> list[run_journal.RunEvent]:
+    return run_journal.read_journal(_journal_path(run_dir)).events
+
+
+def _checkpoint_events(run_dir: Path) -> list[run_journal.RunEvent]:
+    return [e for e in _events(run_dir) if e.event_type == run_checkpoint.CHECKPOINT_EVENT_TYPE]
+
+
+def _bootstrap_request(run_dir: Path, status: str = "started") -> None:
+    """Pre-lock bootstrap: write run.json with the durable request, no journal."""
+    localio.write_json(
+        run_dir / "run.json",
+        {"schema": "brigade.run.v1", "status": status, _REQUEST_FIELD: True},
+    )
+
+
+@pytest.fixture
+def enabled(monkeypatch):
+    monkeypatch.setenv("BRIGADE_LIFECYCLE_JOURNAL", "1")
+    yield
+    monkeypatch.delenv("BRIGADE_LIFECYCLE_JOURNAL", raising=False)
+
+
+def test_write_checkpoint_append_then_replay(enabled, tmp_path):
+    workspace = _workspace(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    _bootstrap_request(run_dir)
+    with runguard.run_lock(workspace, run_dir=run_dir):
+        run_lifecycle.prepare_lifecycle_journal(run_dir, workspace=workspace)
+
+    run_json_bytes = _writer_bytes({"schema": "brigade.run.v1", "status": "planning"})
+    with runguard.run_lock(workspace, run_dir=run_dir):
+        run_checkpoint.write_checkpoint(
+            run_dir, run_json_bytes, workspace=workspace, paired_event_type="run.planning.started"
+        )
+    events_after_first = _events(run_dir)
+    files_after_first = sorted(_checkpoint_dir(run_dir).iterdir())
+    journal_after_first = _journal_path(run_dir).read_bytes()
+
+    # Replay: same bytes + same pairing derive the same idempotency key, so
+    # no new file and no new event.
+    with runguard.run_lock(workspace, run_dir=run_dir):
+        run_checkpoint.write_checkpoint(
+            run_dir, run_json_bytes, workspace=workspace, paired_event_type="run.planning.started"
+        )
+
+    assert _events(run_dir) == events_after_first
+    assert sorted(_checkpoint_dir(run_dir).iterdir()) == files_after_first
+    assert _journal_path(run_dir).read_bytes() == journal_after_first
+
+
+def test_write_checkpoint_same_bytes_different_pairing_distinct_events(enabled, tmp_path):
+    workspace = _workspace(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    _bootstrap_request(run_dir)
+    with runguard.run_lock(workspace, run_dir=run_dir):
+        run_lifecycle.prepare_lifecycle_journal(run_dir, workspace=workspace)
+
+    run_json_bytes = _writer_bytes({"schema": "brigade.run.v1", "status": "planning"})
+    with runguard.run_lock(workspace, run_dir=run_dir):
+        first = run_checkpoint.write_checkpoint(
+            run_dir, run_json_bytes, workspace=workspace, paired_event_type="run.planning.started"
+        )
+    with runguard.run_lock(workspace, run_dir=run_dir):
+        second = run_checkpoint.write_checkpoint(
+            run_dir, run_json_bytes, workspace=workspace, paired_event_type="run.dispatch.requested"
+        )
+
+    checkpoints = _checkpoint_events(run_dir)
+    assert len(checkpoints) == 2
+    assert [e.sequence for e in checkpoints] == [1, 2]
+    assert first.event_id == checkpoints[0].event_id
+    assert second.event_id == checkpoints[1].event_id
+    assert first.idempotency_key != second.idempotency_key
+    assert first.idempotency_key.endswith(":run.planning.started")
+    assert second.idempotency_key.endswith(":run.dispatch.requested")
+    # Same bytes -> same content-addressed file (collision-noop), one file.
+    sha = hashlib.sha256(run_json_bytes).hexdigest()
+    assert sorted(p.name for p in _checkpoint_dir(run_dir).iterdir()) == [f"{sha}.json"]
+
+
+def test_write_checkpoint_noop_when_journal_not_active(enabled, tmp_path):
+    workspace = _workspace(tmp_path)
+    run_dir = _run_dir(tmp_path)
+    _bootstrap_request(run_dir)  # pre-lock bootstrap: request only, no journal
+
+    run_json_bytes = _writer_bytes({"schema": "brigade.run.v1", "status": "planning"})
+    # No lock held: prepare is a no-op, the journal stays absent, and
+    # write_checkpoint no-ops (no file, no event).
+    result = run_checkpoint.write_checkpoint(
+        run_dir, run_json_bytes, workspace=workspace, paired_event_type="run.planning.started"
+    )
+    assert result is None
+    assert not (run_dir / "events").exists()

--- a/tests/test_run_checkpoint.py
+++ b/tests/test_run_checkpoint.py
@@ -363,8 +363,7 @@ def test_publish_checkpoint_file_fsyncs_directory_after_temp_unlink(tmp_path, mo
     run_checkpoint.publish_checkpoint_file(run_dir, run_json_bytes)
 
     # A directory fsync on the checkpoint directory must occur after the
-    # legitimate temp unlink. The outer finally also unlinks (missing_ok
-    # no-op) as a safety net, so look for any unlink followed by a later
+    # legitimate temp unlink, so look for an unlink followed by a later
     # fsync whose descriptor refers to the checkpoint directory.
     unlink_indices = [i for i, (kind, _) in enumerate(call_log) if kind == "unlink"]
     assert unlink_indices, "temp was never unlinked"

--- a/tests/test_run_checkpoint.py
+++ b/tests/test_run_checkpoint.py
@@ -1239,17 +1239,17 @@ def test_validate_checkpoint_translates_recursion_error_on_json_loads(tmp_path):
     assert len(diagnostic) <= run_events.MAX_DIAGNOSTIC_LEN
 
 
-def test_validate_checkpoint_translates_recursion_error_on_writer_canonical_dumps(tmp_path):
+def test_validate_checkpoint_translates_recursion_error_on_writer_canonical_dumps(tmp_path, monkeypatch):
     """RecursionError from canonical json.dumps re-encoding -> writer-bytes."""
     run_dir = _run_dir(tmp_path)
-    # A deeply nested JSON *object* (top-level dict): the C JSON decoder
-    # handles this depth (json.loads succeeds and returns a dict, so the
-    # isinstance(obj, dict) gate passes), but the recursive canonical
-    # re-encoder (json.dumps with indent=2, sort_keys=True) cannot, raising
-    # RecursionError from _writer_canonical_bytes.
-    depth = 3000
-    deep_json = (b'{"a":' * depth) + b"1" + (b"}" * depth)
-    _final, payload = _place_deep_checkpoint(run_dir, deep_json)
+    canonical = _writer_bytes({"status": "running"})
+    _place_checkpoint_file(run_dir, canonical)
+    payload = _checkpoint_payload(canonical)
+
+    def fail_writer_canonical_bytes(_obj):
+        raise RecursionError("canonical writer nesting too deep")
+
+    monkeypatch.setattr(run_checkpoint, "_writer_canonical_bytes", fail_writer_canonical_bytes)
 
     with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
         run_checkpoint.validate_checkpoint(run_dir, payload)

--- a/tests/test_run_detach.py
+++ b/tests/test_run_detach.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pytest
 
-from brigade import aboyeur, cli, proc, run_journal
+from brigade import aboyeur, cli, proc, run_checkpoint, run_journal
 from brigade import roster as roster_mod
 from brigade import runguard
 from brigade.cli import run as run_cli
@@ -556,7 +556,7 @@ def test_detach_lifecycle_parent_child_pre_lock_writes_request_not_journal(lifec
     assert child_pre_meta["lifecycle_journal_requested"] is True
     assert not (run_dir / "events").exists()
 
-    # Child in-lock start activates journaling and appends run.created.
+    # Child in-lock start activates journaling, checkpoints, then appends run.created.
     with runguard.run_lock(repo, run_dir=run_dir):
         aboyeur.record_run_start(
             run_dir,
@@ -569,8 +569,11 @@ def test_detach_lifecycle_parent_child_pre_lock_writes_request_not_journal(lifec
 
     assert _journal_path(run_dir).is_file()
     journal_events = run_journal.read_journal(_journal_path(run_dir)).events
-    assert len(journal_events) == 1
-    assert journal_events[0].event_type == "run.created"
+    assert [event.sequence for event in journal_events] == [1, 2]
+    assert [event.event_type for event in journal_events] == [
+        run_checkpoint.CHECKPOINT_EVENT_TYPE,
+        "run.created",
+    ]
 
 
 def test_detach_lifecycle_pre_lock_sigterm_writes_terminal_without_journal(lifecycle_enabled, tmp_path, monkeypatch):

--- a/tests/test_run_events.py
+++ b/tests/test_run_events.py
@@ -242,6 +242,13 @@ def test_event_type_registry_includes_run_created_with_status_only():
     assert run_events.EVENT_TYPES["run.created"] == frozenset({"status"})
 
 
+def test_checkpoint_event_type_registered_with_closed_payload_keys():
+    assert "run.snapshot.checkpointed" in run_events.EVENT_TYPES
+    assert run_events.EVENT_TYPES["run.snapshot.checkpointed"] == frozenset(
+        {"path", "sha256", "media_type", "byte_size", "privacy_class", "paired_event_type"}
+    )
+
+
 def test_build_event_rejects_payload_with_non_integer_numbers():
     with pytest.raises(run_events.CanonicalizationError):
         run_events.build_event(

--- a/tests/test_run_journal.py
+++ b/tests/test_run_journal.py
@@ -990,7 +990,11 @@ def test_read_journal_bounded_refuses_oversize_journal_before_allocation(tmp_pat
         run_journal.read_journal_bounded(journal_path)
 
     assert "bound exceeded" in excinfo.value.diagnostic
-    # No whole-file allocation: the only open is the no-follow read fd.
+    # No whole-file allocation: the only open is the no-follow read fd. The
+    # ``opened`` list must be non-empty so the ``all(...)`` guard is non-vacuous
+    # (a regression that short-circuited before opening would pass vacuously
+    # otherwise).
+    assert opened, "read_journal_bounded must open the journal fd before the bound check"
     assert all(p.name == "lifecycle.jsonl" for p, _ in opened)
 
 

--- a/tests/test_run_journal.py
+++ b/tests/test_run_journal.py
@@ -1034,3 +1034,49 @@ def test_read_journal_stays_compatible_after_bounded_reader(tmp_path):
     # read_journal stays compatible on the same journal.
     plain = run_journal.read_journal(journal_path)
     assert len(plain.events) == 2
+
+
+# -- Finding 6: read_journal_bounded must count complete records, not trust sequence --
+
+
+def test_read_journal_bounded_rejects_complete_record_513_even_with_repeated_sequence(tmp_path):
+    journal_path = _journal_path(_run_dir(tmp_path))
+    journal_path.parent.mkdir(parents=True, exist_ok=True)
+    previous_digest: str | None = None
+    for sequence in range(1, 513):
+        event_type = "run.planning.started" if sequence % 2 == 0 else "run.dispatch.observed"
+        payload = (
+            {"detail": "n"} if event_type == "run.planning.started" else {"seat": "c", "attempt": 1, "detail": "n"}
+        )
+        env = run_events.build_event(
+            run_id=RUN_ID,
+            sequence=sequence,
+            event_type=event_type,
+            payload=payload,
+            idempotency_key=f"ev-{sequence}",
+            recorded_at="2026-07-27T15:30:45.000000Z",
+            previous_digest=previous_digest,
+        )
+        with journal_path.open("ab") as handle:
+            handle.write(run_events.canonical_bytes(env) + b"\n")
+        previous_digest = env["event_digest"]
+
+    # 513th complete record: its envelope repeats sequence 1 (and a matching
+    # previous_digest is null), so a sequence-trusting reader would treat it as
+    # a duplicate/chain break rather than a bound excess.
+    env_513 = run_events.build_event(
+        run_id=RUN_ID,
+        sequence=1,
+        event_type="run.created",
+        payload={"status": "started"},
+        idempotency_key="ev-513-repeated",
+        recorded_at="2026-07-27T15:30:45.000000Z",
+        previous_digest=None,
+    )
+    with journal_path.open("ab") as handle:
+        handle.write(run_events.canonical_bytes(env_513) + b"\n")
+
+    with pytest.raises(run_journal.RunJournalError) as excinfo:
+        run_journal.read_journal_bounded(journal_path)
+
+    assert "bound exceeded" in excinfo.value.diagnostic

--- a/tests/test_run_journal.py
+++ b/tests/test_run_journal.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 
 from brigade import run_events, run_journal
+from brigade import run_checkpoint
 
 FIXTURES = Path(__file__).resolve().parent / "fixtures" / "run-lifecycle"
 GOLDEN_LIFECYCLE_PATH = FIXTURES / "golden-lifecycle.jsonl"
@@ -930,3 +931,106 @@ def test_fallback_enforce_dir_mode_skips_open_without_o_directory(tmp_path, monk
 
     assert journal_path.is_file()
     assert stat.S_IMODE(events_dir.stat().st_mode) == 0o700
+
+
+# -- read_journal_bounded (issue #568 slice 5, Task 1) ------------------------
+
+
+def test_read_journal_bounded_matches_read_journal_on_complete_journal(tmp_path):
+    journal_path = _journal_path(_run_dir(tmp_path))
+    _append_first_event(journal_path)
+    _append_second_event(journal_path)
+
+    bounded = run_journal.read_journal_bounded(journal_path)
+    plain = run_journal.read_journal(journal_path)
+
+    assert bounded.partial_tail == plain.partial_tail
+    assert bounded.chain_errors == plain.chain_errors
+    assert [e.event_id for e in bounded.events] == [e.event_id for e in plain.events]
+
+
+def test_read_journal_bounded_refuses_oversize_journal_before_allocation(tmp_path, monkeypatch):
+    journal_path = _journal_path(_run_dir(tmp_path))
+    _append_first_event(journal_path)
+
+    real_open = os.open
+    opened: list[tuple] = []
+
+    def tracking_open(path, flags, mode=0o777, *, dir_fd=None):
+        fd = real_open(path, flags, mode, dir_fd=dir_fd) if dir_fd is not None else real_open(path, flags, mode)
+        opened.append((Path(path), flags))
+        return fd
+
+    monkeypatch.setattr(os, "open", tracking_open)
+
+    # Pretend fstat reports a journal larger than MAX_JOURNAL_BYTES.
+    real_fstat = os.fstat
+
+    def big_fstat(fd):
+        st = real_fstat(fd)
+        st = os.stat_result(
+            (
+                st.st_mode,
+                st.st_ino,
+                st.st_dev,
+                st.st_nlink,
+                st.st_uid,
+                st.st_gid,
+                run_checkpoint.MAX_JOURNAL_BYTES + 1,  # st_size
+                st.st_atime,
+                st.st_mtime,
+                st.st_ctime,
+            )
+        )
+        return st
+
+    monkeypatch.setattr(os, "fstat", big_fstat)
+
+    with pytest.raises(run_journal.RunJournalError) as excinfo:
+        run_journal.read_journal_bounded(journal_path)
+
+    assert "bound exceeded" in excinfo.value.diagnostic
+    # No whole-file allocation: the only open is the no-follow read fd.
+    assert all(p.name == "lifecycle.jsonl" for p, _ in opened)
+
+
+def test_read_journal_bounded_refuses_event_sequence_513(tmp_path):
+    journal_path = _journal_path(_run_dir(tmp_path))
+    journal_path.parent.mkdir(parents=True, exist_ok=True)
+    previous_digest: str | None = None
+    for sequence in range(1, 514):
+        event_type = "run.planning.started" if sequence % 2 == 0 else "run.dispatch.observed"
+        payload = (
+            {"detail": "n"} if event_type == "run.planning.started" else {"seat": "c", "attempt": 1, "detail": "n"}
+        )
+        env = run_events.build_event(
+            run_id=RUN_ID,
+            sequence=sequence,
+            event_type=event_type,
+            payload=payload,
+            idempotency_key=f"ev-{sequence}",
+            recorded_at="2026-07-27T15:30:45.000000Z",
+            previous_digest=previous_digest,
+        )
+        with journal_path.open("ab") as handle:
+            handle.write(run_events.canonical_bytes(env) + b"\n")
+        previous_digest = env["event_digest"]
+
+    with pytest.raises(run_journal.RunJournalError) as excinfo:
+        run_journal.read_journal_bounded(journal_path)
+
+    assert "bound exceeded" in excinfo.value.diagnostic
+
+
+def test_read_journal_stays_compatible_after_bounded_reader(tmp_path):
+    """read_journal must still parse a journal that read_journal_bounded refuses on bounds."""
+    journal_path = _journal_path(_run_dir(tmp_path))
+    _append_first_event(journal_path)
+    _append_second_event(journal_path)
+
+    # read_journal_bounded succeeds on a small journal.
+    bounded = run_journal.read_journal_bounded(journal_path)
+    assert len(bounded.events) == 2
+    # read_journal stays compatible on the same journal.
+    plain = run_journal.read_journal(journal_path)
+    assert len(plain.events) == 2

--- a/tests/test_run_journal.py
+++ b/tests/test_run_journal.py
@@ -1027,17 +1027,48 @@ def test_read_journal_bounded_refuses_event_sequence_513(tmp_path):
 
 
 def test_read_journal_stays_compatible_after_bounded_reader(tmp_path):
-    """read_journal must still parse a journal that read_journal_bounded refuses on bounds."""
-    journal_path = _journal_path(_run_dir(tmp_path))
-    _append_first_event(journal_path)
-    _append_second_event(journal_path)
+    """read_journal must still parse a journal that read_journal_bounded refuses on bounds.
 
-    # read_journal_bounded succeeds on a small journal.
-    bounded = run_journal.read_journal_bounded(journal_path)
-    assert len(bounded.events) == 2
-    # read_journal stays compatible on the same journal.
+    Builds a 513-event journal with efficient direct canonical construction
+    (``run_events.build_event`` + a single appending ``write`` per line, no
+    ``append_event`` fsyncs). ``read_journal_bounded`` refuses it on the 513th
+    complete record (``MAX_JOURNAL_EVENTS`` is 512); ``read_journal`` has no
+    event-count bound and must read the full chain cleanly.
+    """
+    journal_path = _journal_path(_run_dir(tmp_path))
+    journal_path.parent.mkdir(parents=True, exist_ok=True)
+    previous_digest: str | None = None
+    with journal_path.open("ab") as handle:
+        for sequence in range(1, 514):
+            event_type = "run.planning.started" if sequence % 2 == 0 else "run.dispatch.observed"
+            payload = (
+                {"detail": "n"} if event_type == "run.planning.started" else {"seat": "c", "attempt": 1, "detail": "n"}
+            )
+            env = run_events.build_event(
+                run_id=RUN_ID,
+                sequence=sequence,
+                event_type=event_type,
+                payload=payload,
+                idempotency_key=f"ev-{sequence}",
+                recorded_at="2026-07-27T15:30:45.000000Z",
+                previous_digest=previous_digest,
+            )
+            handle.write(run_events.canonical_bytes(env) + b"\n")
+            previous_digest = env["event_digest"]
+
+    # read_journal_bounded refuses the journal on bounds.
+    with pytest.raises(run_journal.RunJournalError) as excinfo:
+        run_journal.read_journal_bounded(journal_path)
+    assert "bound exceeded" in excinfo.value.diagnostic
+
+    # read_journal stays compatible: it has no event-count bound and reads the
+    # full gap-free, digest-linked chain without raising or reporting errors.
     plain = run_journal.read_journal(journal_path)
-    assert len(plain.events) == 2
+    assert len(plain.events) == 513
+    assert plain.partial_tail is None
+    assert plain.chain_errors == []
+    assert plain.events[0].sequence == 1
+    assert plain.events[-1].sequence == 513
 
 
 # -- Finding 6: read_journal_bounded must count complete records, not trust sequence --

--- a/tests/test_run_lifecycle.py
+++ b/tests/test_run_lifecycle.py
@@ -16,11 +16,21 @@ categories that block the snapshot. Every journaling append runs under the real
 from __future__ import annotations
 
 import json
+import stat
 from pathlib import Path
 
 import pytest
 
-from brigade import aboyeur, localio, proc, run_events, run_journal, run_lifecycle, runguard
+from brigade import (
+    aboyeur,
+    localio,
+    proc,
+    run_checkpoint,
+    run_events,
+    run_journal,
+    run_lifecycle,
+    runguard,
+)
 from brigade import roster as roster_mod
 
 _REQUEST_FIELD = "lifecycle_journal_requested"
@@ -135,6 +145,19 @@ def _events(run_dir: Path) -> list[run_journal.RunEvent]:
     return run_journal.read_journal(_journal_path(run_dir)).events
 
 
+def _status_events(run_dir: Path) -> list[run_journal.RunEvent]:
+    """Lifecycle status-transition events, excluding recovery checkpoint events."""
+    return [e for e in _events(run_dir) if e.event_type != run_checkpoint.CHECKPOINT_EVENT_TYPE]
+
+
+def _checkpoint_events(run_dir: Path) -> list[run_journal.RunEvent]:
+    return [e for e in _events(run_dir) if e.event_type == run_checkpoint.CHECKPOINT_EVENT_TYPE]
+
+
+def _checkpoint_dir(run_dir: Path) -> Path:
+    return run_dir / "events" / run_checkpoint.CHECKPOINT_DIR_NAME
+
+
 @pytest.fixture
 def enabled(monkeypatch):
     monkeypatch.setenv("BRIGADE_LIFECYCLE_JOURNAL", "1")
@@ -184,6 +207,7 @@ def test_no_journal_file_until_lock_held(enabled, tmp_path):
     assert _journal_path(run_dir).is_file()
     assert sorted(path.name for path in (run_dir / "events").iterdir()) == [
         "lifecycle.jsonl",
+        "recovery-checkpoints",
         "shadow-comparison.json",
     ]
 
@@ -193,14 +217,14 @@ def test_in_lock_write_appends_run_created(enabled, tmp_path):
     run_dir = _run_dir(repo)
 
     _write_run_json(run_dir, "started")  # pre-lock bootstrap: request only
-    _write_run_json_locked(repo, run_dir, "started")  # in-lock: append run.created
+    _write_run_json_locked(repo, run_dir, "started")  # in-lock: checkpoint then run.created
 
     events = _events(run_dir)
-    assert len(events) == 1
-    assert events[0].event_type == "run.created"
-    assert events[0].payload == {"status": "started"}
-    assert events[0].sequence == 1
+    assert [e.event_type for e in events] == ["run.snapshot.checkpointed", "run.created"]
+    assert [e.sequence for e in events] == [1, 2]
+    assert events[1].payload == {"status": "started"}
     assert events[0].previous_digest is None
+    assert events[1].previous_digest == events[0].event_digest
 
 
 def test_recording_without_matching_lock_fails_closed(enabled, tmp_path):
@@ -208,18 +232,44 @@ def test_recording_without_matching_lock_fails_closed(enabled, tmp_path):
     run_dir = _run_dir(repo)
 
     _write_run_json(run_dir, "started")  # pre-lock bootstrap: request only
-    _write_run_json_locked(repo, run_dir, "started")  # in-lock: run.created
+    _write_run_json_locked(repo, run_dir, "started")  # in-lock: checkpoint + run.created
     run_before = (run_dir / "run.json").read_bytes()
     journal_before = _journal_path(run_dir).read_bytes()
 
     # Activated run, but no lock held: the write fails closed and neither the
-    # journal nor the run.json snapshot advances.
+    # journal nor the run.json snapshot advances. write_checkpoint skips its
+    # publish/append under the missing lock so no spurious checkpoint event
+    # is appended before record_lifecycle_transition raises.
     with pytest.raises(run_lifecycle.LifecycleJournalError):
         _write_run_json(run_dir, "planning")
 
     assert (run_dir / "run.json").read_bytes() == run_before
     assert _journal_path(run_dir).read_bytes() == journal_before
-    assert [e.event_type for e in _events(run_dir)] == ["run.created"]
+    assert [e.event_type for e in _status_events(run_dir)] == ["run.created"]
+
+
+def test_unmapped_status_on_active_journal_without_lock_fails_closed(enabled, tmp_path):
+    repo = _repo(tmp_path)
+    run_dir = _run_dir(repo)
+
+    _write_run_json(run_dir, "started")
+    _write_run_json_locked(repo, run_dir, "started")  # activate journal
+    run_before = (run_dir / "run.json").read_bytes()
+    journal_before = _journal_path(run_dir).read_bytes()
+    files_before = sorted(_checkpoint_dir(run_dir).iterdir())
+
+    # No lock held on the active journal. An unmapped status has no status
+    # event, but it must NOT mutate the snapshot unlocked: when the journal is
+    # active, missing matching ownership must fail closed for every status.
+    # The bounded error surfaces before any checkpoint/status append and before
+    # run.json changes.
+    with pytest.raises((run_lifecycle.LifecycleJournalError, run_checkpoint.CheckpointError)):
+        _write_run_json(run_dir, "artifact-collection")
+
+    assert (run_dir / "run.json").read_bytes() == run_before
+    assert _journal_path(run_dir).read_bytes() == journal_before
+    assert sorted(_checkpoint_dir(run_dir).iterdir()) == files_before
+    assert [e.event_type for e in _status_events(run_dir)] == ["run.created"]
 
 
 def test_custom_output_dir_appends_under_matching_lock(enabled, tmp_path):
@@ -234,7 +284,7 @@ def test_custom_output_dir_appends_under_matching_lock(enabled, tmp_path):
     _write_run_json_locked(repo, run_dir, "started", lock_workspace=repo)
 
     events = _events(run_dir)
-    assert [e.event_type for e in events] == ["run.created"]
+    assert [e.event_type for e in events] == ["run.snapshot.checkpointed", "run.created"]
 
 
 def test_long_custom_output_dir_final_component_journals(enabled, tmp_path):
@@ -247,10 +297,13 @@ def test_long_custom_output_dir_final_component_journals(enabled, tmp_path):
     _write_run_json_locked(repo, run_dir, "started", lock_workspace=repo)
 
     events = _events(run_dir)
-    assert len(events) == 1
-    assert events[0].event_type == "run.created"
-    assert len(events[0].idempotency_key) <= run_events.MAX_IDEMPOTENCY_KEY_LEN
-    assert events[0].idempotency_key.startswith("lifecycle:")
+    assert [e.event_type for e in events] == ["run.snapshot.checkpointed", "run.created"]
+    created = [e for e in events if e.event_type == "run.created"][0]
+    assert len(created.idempotency_key) <= run_events.MAX_IDEMPOTENCY_KEY_LEN
+    assert created.idempotency_key.startswith("lifecycle:")
+    checkpoint = [e for e in events if e.event_type == "run.snapshot.checkpointed"][0]
+    assert len(checkpoint.idempotency_key) <= run_events.MAX_IDEMPOTENCY_KEY_LEN
+    assert checkpoint.idempotency_key.startswith("checkpoint:")
 
 
 def test_mismatched_workspace_skips_journal_until_correct_lock(enabled, tmp_path):
@@ -307,13 +360,12 @@ def test_activated_run_continues_without_env_flag(enabled, tmp_path, monkeypatch
     run_dir = _run_dir(repo)
 
     _write_run_json(run_dir, "started")  # pre-lock bootstrap: request only
-    _write_run_json_locked(repo, run_dir, "started")  # in-lock: run.created
+    _write_run_json_locked(repo, run_dir, "started")  # in-lock: checkpoint + run.created
 
     monkeypatch.delenv("BRIGADE_LIFECYCLE_JOURNAL", raising=False)
     _write_run_json_locked(repo, run_dir, "planning")
 
-    events = _events(run_dir)
-    assert [e.event_type for e in events] == ["run.created", "run.planning.started"]
+    assert [e.event_type for e in _status_events(run_dir)] == ["run.created", "run.planning.started"]
 
 
 def test_same_status_refresh_is_noop(enabled, tmp_path):
@@ -324,12 +376,16 @@ def test_same_status_refresh_is_noop(enabled, tmp_path):
     _write_run_json_locked(repo, run_dir, "started")
     _write_run_json_locked(repo, run_dir, "started")  # same-status refresh
 
+    # The status event does not repeat (same prior status), and the checkpoint
+    # replays: identical run.json bytes + identical paired_event_type derive
+    # the same checkpoint idempotency key, so no new file or event.
     events = _events(run_dir)
-    assert len(events) == 1
-    assert events[0].event_type == "run.created"
+    assert [e.event_type for e in events] == ["run.snapshot.checkpointed", "run.created"]
+    assert len(_checkpoint_events(run_dir)) == 1
+    assert [e.event_type for e in _status_events(run_dir)] == ["run.created"]
 
 
-def test_same_status_with_changed_detail_appends_nothing(enabled, tmp_path):
+def test_same_status_with_changed_detail_appends_no_status_event(enabled, tmp_path):
     repo = _repo(tmp_path)
     run_dir = _run_dir(repo)
     secret_error = "SECRET_TOKEN=/super/private/path"
@@ -337,16 +393,18 @@ def test_same_status_with_changed_detail_appends_nothing(enabled, tmp_path):
     _write_run_json(run_dir, "started")
     _write_run_json_locked(repo, run_dir, "started")
     _write_run_json_locked(repo, run_dir, "failed", error=secret_error)
-    journal_before = _journal_path(run_dir).read_bytes()
+    status_before = [e.event_type for e in _status_events(run_dir)]
 
-    # A detail refresh is not a status transition: the journal must not grow,
-    # but the run.json snapshot refresh still proceeds.
+    # A detail refresh is not a status transition: no new status event appends,
+    # but the run.json snapshot refresh still proceeds. The checkpoint event
+    # DOES append because the run.json bytes changed (new error string), so the
+    # full journal grows by one checkpoint event with a fresh content hash.
     _write_run_json_locked(repo, run_dir, "failed", error="different failure")
 
-    assert _journal_path(run_dir).read_bytes() == journal_before
-    events = _events(run_dir)
-    assert [e.event_type for e in events] == ["run.created", "run.failed"]
-    assert events[1].payload == {"status": "failed", "detail": "failed"}
+    assert [e.event_type for e in _status_events(run_dir)] == status_before
+    assert [e.event_type for e in _status_events(run_dir)] == ["run.created", "run.failed"]
+    failed = [e for e in _status_events(run_dir) if e.event_type == "run.failed"][0]
+    assert failed.payload == {"status": "failed", "detail": "failed"}
     journal_text = _journal_path(run_dir).read_text()
     assert secret_error not in journal_text
     assert "/super/private/path" not in journal_text
@@ -365,15 +423,29 @@ def test_aba_recurrence_appends_all_three_occurrences(enabled, tmp_path):
     _write_run_json_locked(repo, run_dir, "result-processing")
     _write_run_json_locked(repo, run_dir, "dispatching")  # A-B-A recurrence
 
-    events = _events(run_dir)
-    assert [e.event_type for e in events] == [
+    assert [e.event_type for e in _status_events(run_dir)] == [
         "run.created",
         "run.dispatch.requested",
         "run.dispatch.completed",
         "run.dispatch.requested",
     ]
-    assert [e.sequence for e in events] == [1, 2, 3, 4]
+    # Checkpoints interleave before each status event, but a checkpoint
+    # replays when the run.json bytes + paired_event_type repeat. The second
+    # "dispatching" write produces identical run.json bytes to the first, so
+    # its checkpoint replays and only the status event appends.
+    events = _events(run_dir)
+    assert [e.event_type for e in events] == [
+        "run.snapshot.checkpointed",
+        "run.created",
+        "run.snapshot.checkpointed",
+        "run.dispatch.requested",
+        "run.snapshot.checkpointed",
+        "run.dispatch.completed",
+        "run.dispatch.requested",
+    ]
+    assert [e.sequence for e in events] == [1, 2, 3, 4, 5, 6, 7]
     assert events[3].previous_digest == events[2].event_digest
+    assert events[6].previous_digest == events[5].event_digest
 
 
 def test_unmapped_intermediate_status_still_appends_the_second_a(enabled, tmp_path):
@@ -383,23 +455,39 @@ def test_unmapped_intermediate_status_still_appends_the_second_a(enabled, tmp_pa
     _write_run_json(run_dir, "started")
     _write_run_json_locked(repo, run_dir, "started")
     _write_run_json_locked(repo, run_dir, "dispatching")
-    # Unmapped status: no event, but run.json still advances to it.
+    # Unmapped status: no status event, but a checkpoint event still appends
+    # and run.json still advances to it.
     _write_run_json_locked(repo, run_dir, "artifact-collection")
     # A-unmapped-B-A: the second dispatching is a real transition from the
     # artifact-collection snapshot and must append even though the journal
-    # tail payload matches.
+    # tail status payload matches.
     _write_run_json_locked(repo, run_dir, "dispatching")
 
     meta = json.loads((run_dir / "run.json").read_text())
     assert meta["status"] == "dispatching"
-    events = _events(run_dir)
-    assert [e.event_type for e in events] == [
+    assert [e.event_type for e in _status_events(run_dir)] == [
         "run.created",
         "run.dispatch.requested",
         "run.dispatch.requested",
     ]
-    assert [e.sequence for e in events] == [1, 2, 3]
-    assert events[2].previous_digest == events[1].event_digest
+    events = _events(run_dir)
+    # The second "dispatching" produces identical run.json bytes to the first,
+    # so its checkpoint replays; only the status event appends. The
+    # artifact-collection (unmapped) checkpoint uses a null paired_event_type.
+    assert [e.event_type for e in events] == [
+        "run.snapshot.checkpointed",
+        "run.created",
+        "run.snapshot.checkpointed",
+        "run.dispatch.requested",
+        "run.snapshot.checkpointed",
+        "run.dispatch.requested",
+    ]
+    assert [e.sequence for e in events] == [1, 2, 3, 4, 5, 6]
+    # The second run.dispatch.requested links to the artifact-collection
+    # checkpoint immediately before it, not to the prior status event.
+    assert events[5].previous_digest == events[4].event_digest
+    # The artifact-collection checkpoint is paired with null (unmapped status).
+    assert events[4].payload["paired_event_type"] is None
 
 
 def test_retry_after_interruption_reuses_committed_event(enabled, tmp_path):
@@ -424,9 +512,12 @@ def test_retry_after_interruption_reuses_committed_event(enabled, tmp_path):
 
     assert replay is not None
     events = _events(run_dir)
-    assert len(events) == 2
-    assert [e.event_type for e in events] == ["run.created", "run.dispatch.completed"]
-    assert replay.event_id == events[1].event_id
+    assert [e.event_type for e in events] == [
+        "run.snapshot.checkpointed",
+        "run.created",
+        "run.dispatch.completed",
+    ]
+    assert replay.event_id == events[2].event_id
     assert _journal_path(run_dir).read_bytes() == journal_before
 
 
@@ -440,11 +531,20 @@ def test_distinct_statuses_produce_distinct_sequence_linked_events(enabled, tmp_
     _write_run_json_locked(repo, run_dir, "failed", error="boom")
 
     events = _events(run_dir)
-    assert [e.sequence for e in events] == [1, 2, 3]
+    assert [e.event_type for e in events] == [
+        "run.snapshot.checkpointed",
+        "run.created",
+        "run.snapshot.checkpointed",
+        "run.planning.started",
+        "run.snapshot.checkpointed",
+        "run.failed",
+    ]
+    assert [e.sequence for e in events] == [1, 2, 3, 4, 5, 6]
     assert events[0].previous_digest is None
     assert events[1].previous_digest == events[0].event_digest
-    assert events[2].previous_digest == events[1].event_digest
-    assert events[2].payload == {"status": "failed", "detail": "failed"}
+    assert events[5].previous_digest == events[4].event_digest
+    failed = [e for e in events if e.event_type == "run.failed"][0]
+    assert failed.payload == {"status": "failed", "detail": "failed"}
     assert "boom" not in _journal_path(run_dir).read_text()
 
 
@@ -462,16 +562,16 @@ def test_terminal_status_transitions_produce_allowlisted_events(enabled, tmp_pat
         _write_run_json_locked(repo, run_dir, "started")
         _write_run_json_locked(repo, run_dir, status, error=f"boom {status}")
 
-        events = _events(run_dir)
-        assert [e.event_type for e in events] == ["run.created", expected_type]
-        tail = events[1]
+        status_events = _status_events(run_dir)
+        assert [e.event_type for e in status_events] == ["run.created", expected_type]
+        tail = status_events[1]
         assert tail.payload == {"status": status, "detail": status}
         allowed = run_events.EVENT_TYPES[expected_type]
         assert set(tail.payload.keys()) <= allowed
         assert f"boom {status}" not in _journal_path(run_dir).read_text()
 
 
-def test_unmapped_status_writes_run_json_without_journal_event(enabled, tmp_path):
+def test_unmapped_status_writes_run_json_without_status_event(enabled, tmp_path):
     repo = _repo(tmp_path)
     run_dir = _run_dir(repo)
 
@@ -481,7 +581,10 @@ def test_unmapped_status_writes_run_json_without_journal_event(enabled, tmp_path
     _write_run_json_locked(repo, run_dir, "artifact-collection")
 
     assert (run_dir / "run.json").is_file()
-    assert _events(run_dir) == [_events(run_dir)[0]]
+    # Unmapped statuses append no status event, but each distinct run.json
+    # snapshot still publishes a checkpoint event.
+    assert [e.event_type for e in _status_events(run_dir)] == ["run.created"]
+    assert len(_checkpoint_events(run_dir)) == 3
 
 
 def test_recovery_writer_does_not_append(enabled, tmp_path):
@@ -518,8 +621,7 @@ def test_raw_oserror_is_bounded_and_blocks_run_json(enabled, tmp_path, monkeypat
     # generic bounded category surfaces.
     assert "simulated disk failure" not in str(excinfo.value)
     assert (run_dir / "run.json").read_bytes() == before
-    events = _events(run_dir)
-    assert [e.event_type for e in events] == ["run.created"]
+    assert [e.event_type for e in _status_events(run_dir)] == ["run.created"]
 
 
 def test_canonicalization_error_is_bounded_and_blocks_run_json(enabled, tmp_path, monkeypatch):
@@ -542,8 +644,7 @@ def test_canonicalization_error_is_bounded_and_blocks_run_json(enabled, tmp_path
 
     assert "simulated canonicalization failure" not in str(excinfo.value)
     assert (run_dir / "run.json").read_bytes() == before
-    events = _events(run_dir)
-    assert [e.event_type for e in events] == ["run.created"]
+    assert [e.event_type for e in _status_events(run_dir)] == ["run.created"]
 
 
 def test_journal_corruption_blocks_run_json_advance(enabled, tmp_path):
@@ -563,3 +664,210 @@ def test_journal_corruption_blocks_run_json_advance(enabled, tmp_path):
     assert (run_dir / "run.json").read_bytes() == before
     meta = json.loads((run_dir / "run.json").read_text())
     assert meta["status"] == "started"
+
+
+# -- Issue #568 slice 5 Task 2: prepare_lifecycle_journal / write_checkpoint --------
+
+
+def test_prepare_lifecycle_journal_private_journal_under_matching_held_run_lock(enabled, tmp_path):
+    repo = _repo(tmp_path)
+    run_dir = _run_dir(repo)
+    # Pre-lock bootstrap records the durable request without creating the journal.
+    _write_run_json(run_dir, "started")
+    assert not _journal_path(run_dir).exists()
+
+    with runguard.run_lock(repo, run_dir=run_dir):
+        run_lifecycle.prepare_lifecycle_journal(run_dir, workspace=repo, incoming_snapshot=None)
+
+    journal = _journal_path(run_dir)
+    assert journal.is_file()
+    assert stat.S_IMODE(journal.stat().st_mode) == 0o600
+    assert stat.S_IMODE(journal.parent.stat().st_mode) == 0o700
+    # prepare only activates; it appends no event.
+    assert _events(run_dir) == []
+
+
+def test_prepare_lifecycle_journal_noop_when_journal_exists(enabled, tmp_path):
+    repo = _repo(tmp_path)
+    run_dir = _run_dir(repo)
+    _write_run_json(run_dir, "started")
+    with runguard.run_lock(repo, run_dir=run_dir):
+        run_lifecycle.prepare_lifecycle_journal(run_dir, workspace=repo)
+    journal_before = _journal_path(run_dir).read_bytes()
+    mtime_before = _journal_path(run_dir).stat().st_mtime_ns
+
+    with runguard.run_lock(repo, run_dir=run_dir):
+        run_lifecycle.prepare_lifecycle_journal(run_dir, workspace=repo)
+
+    assert _journal_path(run_dir).read_bytes() == journal_before
+    assert _journal_path(run_dir).stat().st_mtime_ns == mtime_before
+
+
+def test_prepare_lifecycle_journal_bounded_io_error(enabled, tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    run_dir = _run_dir(repo)
+    _write_run_json(run_dir, "started")
+
+    def raise_oserror(path: Path) -> None:
+        raise OSError("simulated disk failure")
+
+    monkeypatch.setattr(run_journal, "ensure_journal", raise_oserror)
+
+    with runguard.run_lock(repo, run_dir=run_dir):
+        with pytest.raises(run_lifecycle.LifecycleJournalError) as excinfo:
+            run_lifecycle.prepare_lifecycle_journal(run_dir, workspace=repo)
+    assert "simulated disk failure" not in str(excinfo.value)
+    assert len(str(excinfo.value)) <= run_events.MAX_DIAGNOSTIC_LEN
+
+
+def test_record_lifecycle_transition_requires_existing_journal(enabled, tmp_path):
+    repo = _repo(tmp_path)
+    run_dir = _run_dir(repo)
+    _write_run_json(run_dir, "started")  # request only, no journal
+
+    # Journaling was durably requested, the matching lock is held, so
+    # prepare_lifecycle_journal should have activated the journal. Its absence
+    # after preparation is a broken flow: record_lifecycle_transition must
+    # fail closed with a bounded LifecycleJournalError rather than silently
+    # returning None and letting run.json advance past an unowned transition.
+    with runguard.run_lock(repo, run_dir=run_dir):
+        with pytest.raises(run_lifecycle.LifecycleJournalError) as excinfo:
+            run_lifecycle.record_lifecycle_transition(run_dir, status="planning", workspace=repo)
+    assert len(str(excinfo.value)) <= run_events.MAX_DIAGNOSTIC_LEN
+    assert not _journal_path(run_dir).exists()
+
+
+def test_first_activated_mapped_write_checkpoint_seq1_then_status_seq2(enabled, tmp_path):
+    repo = _repo(tmp_path)
+    run_dir = _run_dir(repo)
+    _write_run_json(run_dir, "started")
+    _write_run_json_locked(repo, run_dir, "started")
+
+    events = _events(run_dir)
+    assert [e.event_type for e in events] == ["run.snapshot.checkpointed", "run.created"]
+    assert [e.sequence for e in events] == [1, 2]
+    assert events[0].payload["paired_event_type"] == "run.created"
+    assert events[1].previous_digest == events[0].event_digest
+
+
+def test_unmapped_activated_write_checkpoint_seq1_no_status_event(enabled, tmp_path):
+    repo = _repo(tmp_path)
+    run_dir = _run_dir(repo)
+    _write_run_json(run_dir, "started")
+    _write_run_json_locked(repo, run_dir, "started")  # activate + run.created
+    # An unmapped status under the active journal: checkpoint event appends
+    # (paired null), no status event.
+    _write_run_json_locked(repo, run_dir, "artifact-collection")
+
+    events = _events(run_dir)
+    assert [e.event_type for e in events] == [
+        "run.snapshot.checkpointed",
+        "run.created",
+        "run.snapshot.checkpointed",
+    ]
+    assert [e.sequence for e in events] == [1, 2, 3]
+    assert events[2].payload["paired_event_type"] is None
+    assert [e.event_type for e in _status_events(run_dir)] == ["run.created"]
+
+
+def test_checkpoint_failure_leaves_journal_and_run_json_unchanged(enabled, tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    run_dir = _run_dir(repo)
+    _write_run_json(run_dir, "started")
+    _write_run_json_locked(repo, run_dir, "started")  # activate
+    run_before = (run_dir / "run.json").read_bytes()
+    journal_before = _journal_path(run_dir).read_bytes()
+
+    def raise_checkpoint(run_dir_arg, run_json_bytes):
+        raise run_checkpoint.CheckpointError("simulated publish failure", category="link")
+
+    monkeypatch.setattr(run_checkpoint, "publish_checkpoint_file", raise_checkpoint)
+
+    # CheckpointError fails BEFORE the lifecycle status append and BEFORE
+    # run.json replacement: neither the journal nor run.json advances.
+    with runguard.run_lock(repo, run_dir=run_dir):
+        with pytest.raises(run_checkpoint.CheckpointError) as excinfo:
+            _write_run_json(run_dir, "planning")
+    assert excinfo.value.category == "link"
+    assert (run_dir / "run.json").read_bytes() == run_before
+    assert _journal_path(run_dir).read_bytes() == journal_before
+    assert [e.event_type for e in _status_events(run_dir)] == ["run.created"]
+
+
+# -- Issue #568 slice 5 Task 2 sendback: CheckpointError -> RetainRunLockError ----
+
+
+_RECEIPT_UPDATE_HELPERS = [
+    "record_artifact_collection",
+    "record_run_termination",
+    "record_dispatch_stage",
+    "record_result_processing",
+]
+
+
+def _call_receipt_update_helper(helper_name: str, output_dir: Path) -> None:
+    if helper_name == "record_artifact_collection":
+        aboyeur.record_artifact_collection(
+            output_dir,
+            status="failed",
+            failure_phase="artifact-validation",
+            failure_kind="invalid-patch",
+            detail="changes.patch failed validation",
+        )
+    elif helper_name == "record_run_termination":
+        aboyeur.record_run_termination(
+            output_dir,
+            status="failed",
+            failure_phase="dispatch",
+            failure_kind="unexpected-error",
+            detail="provider failed",
+            seat="coder",
+        )
+    elif helper_name == "record_dispatch_stage":
+        aboyeur.record_dispatch_stage(output_dir, stage=1, seats=("coder",))
+    elif helper_name == "record_result_processing":
+        aboyeur.record_result_processing(output_dir, seat="coder")
+
+
+@pytest.mark.parametrize("helper_name", _RECEIPT_UPDATE_HELPERS)
+def test_receipt_update_helper_translates_checkpoint_error_to_retain_run_lock(
+    enabled, tmp_path, monkeypatch, helper_name
+):
+    """A CheckpointError during a terminal/phase receipt-update write inside a held
+    runguard.run_lock must surface as a bounded RetainRunLockError (never a raw
+    CheckpointError) and must retain the matching run lock, so a crash mid
+    receipt-update keeps the lock held for stale-lock recovery and the bounded
+    category diagnostic is all that escapes the public helper.
+    """
+    repo = _repo(tmp_path)
+    run_dir = _run_dir(repo)
+    _write_run_json(run_dir, "started", lock_workspace=repo)
+    _write_run_json_locked(repo, run_dir, "started", lock_workspace=repo)  # activate journal
+    run_before = (run_dir / "run.json").read_bytes()
+    journal_before = _journal_path(run_dir).read_bytes()
+
+    def raise_checkpoint(run_dir_arg: Path, run_json_bytes: bytes) -> Path:
+        raise run_checkpoint.CheckpointError("simulated publish failure", category="link")
+
+    monkeypatch.setattr(run_checkpoint, "publish_checkpoint_file", raise_checkpoint)
+
+    lock_path = runguard.lock_path(repo)
+    assert not lock_path.exists()
+
+    with pytest.raises(runguard.RetainRunLockError) as excinfo:
+        with runguard.run_lock(repo, run_dir=run_dir):
+            _call_receipt_update_helper(helper_name, run_dir)
+
+    # The public helper raises a bounded RetainRunLockError, never the raw
+    # CheckpointError type. The original bounded CheckpointError diagnostic is
+    # chained as the cause (preserved chaining behavior, matching the existing
+    # OSError / LifecycleJournalError translation at the same boundary).
+    assert not isinstance(excinfo.value, run_checkpoint.CheckpointError)
+    assert isinstance(excinfo.value.__cause__, run_checkpoint.CheckpointError)
+    assert excinfo.value.__cause__.category == "link"
+    # The matching run lock is retained for stale-lock recovery.
+    assert lock_path.is_dir()
+    # Neither the journal nor run.json advanced past the failure.
+    assert (run_dir / "run.json").read_bytes() == run_before
+    assert _journal_path(run_dir).read_bytes() == journal_before
+    assert [e.event_type for e in _status_events(run_dir)] == ["run.created"]

--- a/tests/test_run_projector.py
+++ b/tests/test_run_projector.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from brigade import run_events, run_journal
+from brigade import run_checkpoint, run_events, run_journal
 from brigade.run_projector import (
     DERIVED_FIELDS,
     EVENT_STATUS,
@@ -223,6 +223,35 @@ def _events_ending_with_interrupted(*, status: str) -> list[dict]:
     return [created, interrupted]
 
 
+def _build_checkpoint_event(
+    sequence: int,
+    previous_digest: str | None,
+    *,
+    paired_event_type: str | None = "run.created",
+    recorded_at: str = RECORDED_AT,
+) -> dict:
+    """Build a validated checkpoint envelope."""
+    sha = "a" * 64
+    payload = {
+        "path": f"events/recovery-checkpoints/{sha}.json",
+        "sha256": sha,
+        "media_type": run_checkpoint.CHECKPOINT_MEDIA_TYPE,
+        "byte_size": 128,
+        "privacy_class": run_checkpoint.CHECKPOINT_PRIVACY_CLASS,
+        "paired_event_type": paired_event_type,
+    }
+    paired = paired_event_type if paired_event_type is not None else "none"
+    return run_events.build_event(
+        run_id=RUN_ID,
+        sequence=sequence,
+        event_type=run_checkpoint.CHECKPOINT_EVENT_TYPE,
+        payload=payload,
+        idempotency_key=f"checkpoint:{sha}:{paired}",
+        recorded_at=recorded_at,
+        previous_digest=previous_digest,
+    )
+
+
 def _assert_bounded_projection_error(excinfo: pytest.ExceptionInfo[ProjectionError]) -> None:
     assert len(excinfo.value.diagnostic) <= run_events.MAX_DIAGNOSTIC_LEN
 
@@ -233,7 +262,9 @@ def test_golden_replay_matches_expected_bytes():
     if not GOLDEN_EXPECTED_PATH.is_file():
         pytest.fail(f"missing golden expected fixture: {GOLDEN_EXPECTED_PATH}")
     base = json.loads(GOLDEN_BASE_PATH.read_text())
-    expected = GOLDEN_EXPECTED_PATH.read_bytes()
+    expected_obj = json.loads(GOLDEN_EXPECTED_PATH.read_text())
+    expected_obj["projector_version"] = PROJECTOR_VERSION
+    expected = encode_snapshot_bytes(expected_obj)
     projection = project_run_snapshot(base, _golden_events(), journal_present=True)
     assert projection.to_bytes() == expected
 
@@ -452,3 +483,62 @@ def test_non_boolean_journal_present_raises_projection_input_error():
         with pytest.raises(ProjectionInputError) as excinfo:
             project_run_snapshot(_minimal_base_snapshot(), [], journal_present=value)
         _assert_bounded_projection_error(excinfo)
+
+
+def test_checkpoint_event_is_status_neutral_and_advances_chain_cursor():
+    created = _build_event(1, "run.created", {"status": "started"}, "create-1", RECORDED_AT, None)
+    checkpoint = _build_checkpoint_event(
+        2,
+        created["event_digest"],
+        paired_event_type="run.planning.started",
+        recorded_at="2026-07-27T15:30:46.000000Z",
+    )
+    projection = project_run_snapshot(_minimal_base_snapshot(), [created, checkpoint], journal_present=True)
+    assert projection.status == "started"
+    assert projection.snapshot["status"] == "started"
+    assert projection.last_sequence == 2
+    assert projection.last_event_digest == checkpoint["event_digest"]
+    assert projection.snapshot["journal_last_sequence"] == 2
+    assert projection.snapshot["journal_last_event_digest"] == checkpoint["event_digest"]
+
+
+def test_checkpoint_first_event_derives_base_status():
+    checkpoint = _build_checkpoint_event(1, None, paired_event_type="run.created")
+    projection = project_run_snapshot(_minimal_base_snapshot(status="planning"), [checkpoint], journal_present=True)
+    assert projection.status == "planning"
+    assert projection.snapshot["status"] == "planning"
+    assert projection.last_sequence == 1
+    assert projection.last_event_digest == checkpoint["event_digest"]
+
+
+def test_checkpoint_after_unmapped_status_preserves_last_mapped_status():
+    created = _build_event(1, "run.created", {"status": "started"}, "create-1", RECORDED_AT, None)
+    planning = _build_event(
+        2,
+        "run.planning.started",
+        {"detail": "planning"},
+        "plan-2",
+        "2026-07-27T15:30:46.000000Z",
+        created["event_digest"],
+    )
+    unmapped_checkpoint = _build_checkpoint_event(
+        3,
+        planning["event_digest"],
+        paired_event_type=None,
+        recorded_at="2026-07-27T15:30:47.000000Z",
+    )
+    projection = project_run_snapshot(
+        _minimal_base_snapshot(),
+        [created, planning, unmapped_checkpoint],
+        journal_present=True,
+    )
+    assert projection.status == "planning"
+    assert projection.snapshot["status"] == "planning"
+    assert projection.last_sequence == 3
+    assert projection.last_event_digest == unmapped_checkpoint["event_digest"]
+
+
+def test_projector_version_is_two():
+    projection = project_run_snapshot(_minimal_base_snapshot(), [], journal_present=False)
+    assert PROJECTOR_VERSION == 2
+    assert projection.snapshot["projector_version"] == 2

--- a/tests/test_run_shadow.py
+++ b/tests/test_run_shadow.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 
 import pytest
 
-from brigade import aboyeur, localio, proc, run_journal, run_lifecycle, runguard
+from brigade import aboyeur, localio, proc, run_checkpoint, run_journal, run_lifecycle, runguard
 from brigade import roster as roster_mod
 from brigade import run_projector
 from brigade import run_shadow  # RED: module does not exist yet
@@ -116,6 +117,75 @@ def _events(run_dir: Path) -> list[run_journal.RunEvent]:
     return run_journal.read_journal(_journal_path(run_dir)).events
 
 
+def _minimal_event_payload(event_type: str) -> dict[str, object]:
+    if event_type == "run.created":
+        return {"status": "started"}
+    if event_type == "run.completed":
+        return {"status": "ok"}
+    if event_type == "run.failed":
+        return {"status": "failed", "detail": "failed"}
+    if event_type == "run.interrupted":
+        return {"status": "canceled"}
+    return {}
+
+
+def _append_forged_checkpoint_status_pair(
+    repo: Path,
+    run_dir: Path,
+    *,
+    paired_event_type: str | None,
+    status_event_type: str,
+    snapshot_status: str,
+) -> None:
+    """Append a checkpoint+status pair that advances the tail by exactly two."""
+    with runguard.run_lock(repo, run_dir=run_dir):
+        report = run_journal.read_journal(_journal_path(run_dir))
+        prev_seq = report.events[-1].sequence
+        run_json_bytes = (run_dir / "run.json").read_bytes()
+        sha = hashlib.sha256(run_json_bytes).hexdigest()
+        paired = paired_event_type if paired_event_type is not None else "none"
+        checkpoint_payload = {
+            "path": f"events/{run_checkpoint.CHECKPOINT_DIR_NAME}/{sha}.json",
+            "sha256": sha,
+            "media_type": run_checkpoint.CHECKPOINT_MEDIA_TYPE,
+            "byte_size": len(run_json_bytes),
+            "privacy_class": run_checkpoint.CHECKPOINT_PRIVACY_CLASS,
+            "paired_event_type": paired_event_type,
+        }
+        run_journal.append_event(
+            _journal_path(run_dir),
+            run_id=_RUN_ID,
+            event_type=run_checkpoint.CHECKPOINT_EVENT_TYPE,
+            payload=checkpoint_payload,
+            idempotency_key=f"checkpoint-forged:{sha}:{paired}",
+            expected_previous_sequence=prev_seq,
+        )
+        report = run_journal.read_journal(_journal_path(run_dir))
+        run_journal.append_event(
+            _journal_path(run_dir),
+            run_id=_RUN_ID,
+            event_type=status_event_type,
+            payload=_minimal_event_payload(status_event_type),
+            idempotency_key=f"lifecycle:forged:{status_event_type}",
+            expected_previous_sequence=report.events[-1].sequence,
+        )
+        localio.write_json(
+            run_dir / "run.json",
+            _apply_lifecycle_request(run_dir, _run_payload(snapshot_status)),
+        )
+
+
+def _gap_records(data: dict[str, object]) -> list[dict[str, object]]:
+    recent = data.get("recent_records")
+    if not isinstance(recent, list):
+        return []
+    return [
+        record
+        for record in recent
+        if isinstance(record, dict) and record.get("outcome") == "error" and record.get("category") == "comparison-gap"
+    ]
+
+
 @pytest.fixture
 def enabled(monkeypatch):
     monkeypatch.setenv("BRIGADE_LIFECYCLE_JOURNAL", "1")
@@ -175,7 +245,7 @@ def test_first_locked_write_records_match(enabled, tmp_path):
     assert data["mismatches"] == 0
     assert data["lags"] == 0
     assert data["errors"] == 0
-    assert data["last_compared_sequence"] == 1
+    assert data["last_compared_sequence"] == 2
     assert data["last_outcome"] == "match"
     assert data["last_shadow_digest"] == data["last_projected_digest"]
     assert data["last_differing_fields"] == []
@@ -209,8 +279,8 @@ def test_unmapped_status_after_handoff_is_lag(enabled, tmp_path):
     assert data["errors"] == 0
     assert data["last_outcome"] == "lag"
     assert data["last_differing_fields"] == ["status"]
-    # journal sequence unchanged by the unmapped write (slice 2 skips it)
-    assert data["last_compared_sequence"] == 6
+    # unmapped write appends a checkpoint event; status event is skipped
+    assert data["last_compared_sequence"] == 13
     report = run_shadow.check_projection_readiness(run_dir)
     assert report.ready is False
     assert REASON_STATUS_LAG_CURRENT in report.reasons
@@ -343,8 +413,8 @@ def test_crash_window_records_comparison_gap(enabled, tmp_path):
     run_dir = _run_dir(repo)
 
     _write_run_json(run_dir, "started")
-    _write_run_json_locked(repo, run_dir, "started")  # run.created, seq 1
-    _write_run_json_locked(repo, run_dir, "planning")  # run.planning.started, seq 2
+    _write_run_json_locked(repo, run_dir, "started")  # checkpoint seq 1, run.created seq 2
+    _write_run_json_locked(repo, run_dir, "planning")  # checkpoint seq 3, planning seq 4
 
     # Simulate a crash: append run.dispatch.requested (seq 3) directly to the
     # journal, write run.json directly so the shadow hook does NOT run, then
@@ -369,8 +439,8 @@ def test_crash_window_records_comparison_gap(enabled, tmp_path):
             },
         )
 
-    # Later locked write: shadow hook runs and detects the gap (tail seq 4
-    # vs prior last_compared_sequence 2, advanced by more than one).
+    # Later locked write: shadow hook runs and detects the gap (tail seq 7
+    # vs prior last_compared_sequence 4, advanced by more than one checkpoint+status write).
     _write_run_json_locked(repo, run_dir, "result-processing")
 
     data = json.loads(run_shadow.shadow_artifact_path(run_dir).read_text())
@@ -393,8 +463,8 @@ def test_absent_prior_evidence_with_tail_above_one_records_gap(enabled, tmp_path
     # Build a journal with two events but no shadow artifact, simulating a
     # crash that lost the first comparison.
     _write_run_json(run_dir, "started")
-    _write_run_json_locked(repo, run_dir, "started")  # run.created, seq 1
-    _write_run_json_locked(repo, run_dir, "planning")  # run.planning.started, seq 2
+    _write_run_json_locked(repo, run_dir, "started")  # checkpoint seq 1, run.created seq 2
+    _write_run_json_locked(repo, run_dir, "planning")  # checkpoint seq 3, planning seq 4
     # Remove the artifact so the next comparison sees no prior evidence.
     run_shadow.shadow_artifact_path(run_dir).unlink()
     # Advance the journal one more step without the hook running.
@@ -418,7 +488,7 @@ def test_absent_prior_evidence_with_tail_above_one_records_gap(enabled, tmp_path
             },
         )
 
-    # Direct call: prior evidence absent, tail seq == 3 > 1 -> comparison-gap.
+    # Direct call: prior evidence absent, tail seq == 5 > 2 -> comparison-gap.
     run_shadow.record_shadow_comparison(
         run_dir,
         {
@@ -534,12 +604,14 @@ def test_gate_reason_coverage(tmp_path):
     data = json.loads(run_shadow.shadow_artifact_path(run_dir).read_text())
     data["schema"] = "brigade.run_shadow.v1"
     data["run_id"] = "other"
+    data["projector_version"] = 2
     run_shadow.shadow_artifact_path(run_dir).write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
     assert REASON_EVIDENCE_SCHEMA_MISMATCH in run_shadow.check_projection_readiness(run_dir).reasons
 
     # Zero comparisons.
     data["run_id"] = _RUN_ID
     data["comparisons"] = 0
+    data["projector_version"] = 2
     run_shadow.shadow_artifact_path(run_dir).write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
     assert REASON_NO_COMPARISONS in run_shadow.check_projection_readiness(run_dir).reasons
 
@@ -585,8 +657,8 @@ def test_changed_preserved_detail_records_fresh_match_at_same_tail(enabled, tmp_
     run_dir = _run_dir(repo)
 
     _write_run_json(run_dir, "started")
-    _write_run_json_locked(repo, run_dir, "started")  # run.created, seq 1
-    _write_run_json_locked(repo, run_dir, "planning")  # run.planning.started, seq 2
+    _write_run_json_locked(repo, run_dir, "started")  # checkpoint seq 1, run.created seq 2
+    _write_run_json_locked(repo, run_dir, "planning")  # checkpoint seq 3, planning seq 4
     artifact = run_shadow.shadow_artifact_path(run_dir)
     bytes_before = artifact.read_bytes()
     digests_before = (
@@ -607,7 +679,7 @@ def test_changed_preserved_detail_records_fresh_match_at_same_tail(enabled, tmp_
     data = json.loads(artifact.read_text())
     assert data["comparisons"] == 3
     assert data["matches"] == 3
-    assert data["last_compared_sequence"] == 2  # journal tail unchanged
+    assert data["last_compared_sequence"] == 5  # checkpoint appended for detail refresh
     assert (data["last_shadow_digest"], data["last_projected_digest"]) != digests_before
     assert data["last_shadow_digest"] == data["last_projected_digest"]
 
@@ -627,7 +699,7 @@ def test_full_mapped_chain_records_seven_matches(enabled, tmp_path):
     assert data["mismatches"] == 0
     assert data["lags"] == 0
     assert data["errors"] == 0
-    assert data["last_compared_sequence"] == 7
+    assert data["last_compared_sequence"] == 14
     assert data["last_outcome"] == "match"
     report = run_shadow.check_projection_readiness(run_dir)
     assert report.ready is True
@@ -744,7 +816,7 @@ def test_run_journal_error_in_shadow_is_contained(enabled, tmp_path, monkeypatch
 
     def raising_read(path):
         calls["n"] += 1
-        if calls["n"] >= 2:
+        if calls["n"] >= 3:
             raise run_journal.RunJournalError("simulated chain failure")
         return original_read(path)
 
@@ -888,7 +960,7 @@ def test_same_tail_different_unmapped_status_counts_distinct_lags(enabled, tmp_p
     data = json.loads(run_shadow.shadow_artifact_path(run_dir).read_text())
     assert data["lags"] == 2
     assert data["last_outcome"] == "lag"
-    assert data["last_compared_sequence"] == 6
+    assert data["last_compared_sequence"] == 12
 
 
 def test_non_run_json_write_leaves_artifact_untouched(enabled, tmp_path):
@@ -904,3 +976,154 @@ def test_non_run_json_write_leaves_artifact_untouched(enabled, tmp_path):
     aboyeur._write_json(run_dir / "roster.json", {"orchestrator": "chef"})
 
     assert artifact.read_bytes() == bytes_before
+
+
+def test_invalid_plus_two_suffix_null_paired_records_comparison_gap(enabled, tmp_path):
+    repo = _repo(tmp_path)
+    run_dir = _run_dir(repo)
+
+    _write_run_json(run_dir, "started")
+    _write_run_json_locked(repo, run_dir, "started")
+    _append_forged_checkpoint_status_pair(
+        repo,
+        run_dir,
+        paired_event_type=None,
+        status_event_type="run.planning.started",
+        snapshot_status="planning",
+    )
+
+    run_shadow.record_shadow_comparison(
+        run_dir,
+        {
+            "schema": "brigade.run.v1",
+            "schema_version": 1,
+            "status": "planning",
+            "task": "forged-null-paired",
+        },
+    )
+
+    data = json.loads(run_shadow.shadow_artifact_path(run_dir).read_text())
+    assert _gap_records(data)
+    report = run_shadow.check_projection_readiness(run_dir)
+    assert report.ready is False
+    assert REASON_ERROR_RECORDED in report.reasons
+
+
+def test_invalid_plus_two_suffix_mismatched_paired_records_comparison_gap(enabled, tmp_path):
+    repo = _repo(tmp_path)
+    run_dir = _run_dir(repo)
+
+    _write_run_json(run_dir, "started")
+    _write_run_json_locked(repo, run_dir, "started")
+    _append_forged_checkpoint_status_pair(
+        repo,
+        run_dir,
+        paired_event_type="run.planning.started",
+        status_event_type="run.dispatch.requested",
+        snapshot_status="dispatching",
+    )
+
+    run_shadow.record_shadow_comparison(
+        run_dir,
+        {
+            "schema": "brigade.run.v1",
+            "schema_version": 1,
+            "status": "dispatching",
+            "task": "forged-mismatched-paired",
+        },
+    )
+
+    data = json.loads(run_shadow.shadow_artifact_path(run_dir).read_text())
+    assert _gap_records(data)
+    report = run_shadow.check_projection_readiness(run_dir)
+    assert report.ready is False
+    assert REASON_ERROR_RECORDED in report.reasons
+
+
+def test_invalid_plus_two_suffix_unmapped_successor_records_comparison_gap(enabled, tmp_path):
+    repo = _repo(tmp_path)
+    run_dir = _run_dir(repo)
+
+    _write_run_json(run_dir, "started")
+    _write_run_json_locked(repo, run_dir, "started")
+    _append_forged_checkpoint_status_pair(
+        repo,
+        run_dir,
+        paired_event_type="run.created",
+        status_event_type="run.paused",
+        snapshot_status="planning",
+    )
+
+    run_shadow.record_shadow_comparison(
+        run_dir,
+        {
+            "schema": "brigade.run.v1",
+            "schema_version": 1,
+            "status": "planning",
+            "task": "forged-unmapped-successor",
+        },
+    )
+
+    data = json.loads(run_shadow.shadow_artifact_path(run_dir).read_text())
+    assert _gap_records(data)
+    report = run_shadow.check_projection_readiness(run_dir)
+    assert report.ready is False
+    assert REASON_ERROR_RECORDED in report.reasons
+
+
+def test_second_mapped_write_does_not_record_comparison_gap(enabled, tmp_path):
+    repo = _repo(tmp_path)
+    run_dir = _run_dir(repo)
+
+    _write_run_json(run_dir, "started")
+    _write_run_json_locked(repo, run_dir, "started")  # checkpoint seq 1, run.created seq 2
+    _write_run_json_locked(repo, run_dir, "planning")  # checkpoint seq 3, planning seq 4
+
+    data = json.loads(run_shadow.shadow_artifact_path(run_dir).read_text())
+    gap_records = [r for r in data["recent_records"] if r["outcome"] == "error" and r["category"] == "comparison-gap"]
+    assert not gap_records
+    assert data["errors"] == 0
+    assert data["matches"] == 2
+    assert data["last_compared_sequence"] == 4
+    report = run_shadow.check_projection_readiness(run_dir)
+    assert report.ready is True
+    assert report.reasons == ()
+
+
+def test_version_one_shadow_artifact_is_stale(enabled, tmp_path):
+    repo = _repo(tmp_path)
+    run_dir = _run_dir(repo)
+
+    _write_run_json(run_dir, "started")
+    _write_run_json_locked(repo, run_dir, "started")
+
+    artifact = run_shadow.shadow_artifact_path(run_dir)
+    data = json.loads(artifact.read_text())
+    data["projector_version"] = 1
+    artifact.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
+
+    report = run_shadow.check_projection_readiness(run_dir)
+    assert report.ready is False
+    assert REASON_EVIDENCE_SCHEMA_MISMATCH in report.reasons
+
+
+def test_version_two_artifact_with_checkpoint_tail_reads_ready_when_bytes_match(enabled, tmp_path):
+    repo = _repo(tmp_path)
+    run_dir = _run_dir(repo)
+
+    _write_run_json(run_dir, "started")
+    _write_run_json_locked(repo, run_dir, "started")
+
+    events = _events(run_dir)
+    assert events[-1].event_type == "run.created"
+    assert events[0].event_type == "run.snapshot.checkpointed"
+
+    artifact = run_shadow.shadow_artifact_path(run_dir)
+    data = json.loads(artifact.read_text())
+    assert data["projector_version"] == 2
+    assert data["last_compared_sequence"] == 2
+    assert data["last_outcome"] == "match"
+
+    report = run_shadow.check_projection_readiness(run_dir)
+    assert report.ready is True
+    assert report.reasons == ()

--- a/tests/test_run_shadow.py
+++ b/tests/test_run_shadow.py
@@ -416,7 +416,7 @@ def test_crash_window_records_comparison_gap(enabled, tmp_path):
     _write_run_json_locked(repo, run_dir, "started")  # checkpoint seq 1, run.created seq 2
     _write_run_json_locked(repo, run_dir, "planning")  # checkpoint seq 3, planning seq 4
 
-    # Simulate a crash: append run.dispatch.requested (seq 3) directly to the
+    # Simulate a crash: append run.dispatch.requested (seq 5) directly to the
     # journal, write run.json directly so the shadow hook does NOT run, then
     # trigger a later locked write that does run the hook.
     with runguard.run_lock(repo, run_dir=run_dir):

--- a/tests/test_runguard.py
+++ b/tests/test_runguard.py
@@ -1323,6 +1323,39 @@ def test_run_lock_state_returns_invalid_for_cyclic_requested_run_dir(tmp_path, m
     assert (lock_path / "owner.json").read_bytes() == snapshot_owner_bytes
 
 
+@pytest.mark.parametrize("exc", [OSError("resolve boom"), RuntimeError("resolve boom")])
+def test_run_lock_state_never_raises_for_lock_path_resolution_errors(tmp_path, monkeypatch, exc):
+    """``OSError``/``RuntimeError`` from ``lock_path`` resolution (``cwd.resolve``
+    on a cyclic or vanished workspace, or ``expanduser`` with no HOME) must not
+    escape the never-raises predicate; the lock normalizes to ``absent`` so
+    callers fail closed, mirroring ``has_matching_stale_claim``."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    real_lock_path = runguard.lock_path
+
+    def boom(cwd):
+        if cwd == workspace:
+            raise exc
+        return real_lock_path(cwd)
+
+    monkeypatch.setattr(runguard, "lock_path", boom)
+
+    assert runguard.run_lock_state(workspace, run_dir) == "absent"
+
+
+def test_run_lock_state_never_raises_for_unresolvable_workspace(tmp_path, monkeypatch):
+    """A real unresolvable workspace (cyclic symlink) must normalize to
+    ``absent`` rather than escape ``run_lock_state`` with ``OSError``."""
+    cyclic = tmp_path / "cyclic"
+    cyclic.symlink_to(cyclic, target_is_directory=True)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+
+    assert runguard.run_lock_state(cyclic, run_dir) == "absent"
+
+
 def test_recover_stale_run_invokes_before_terminalize_after_token_check(tmp_path, monkeypatch):
     repo = _repo(tmp_path)
     run_dir = tmp_path / "abandoned-run"
@@ -1797,6 +1830,29 @@ def test_recover_stale_run_still_raises_when_foreign_lock_and_no_matching_claim(
         runguard.recover_stale_run(repo, run_dir)
     assert lock_path.is_dir()
     assert json.loads((lock_path / "owner.json").read_text())["owner_token"] == "foreign"
+
+
+@pytest.mark.parametrize("exc", [OSError("resolve boom"), RuntimeError("expanduser boom")])
+def test_recover_pending_claims_skips_claim_when_owner_matches_run_raises(tmp_path, monkeypatch, exc):
+    """When ``_owner_matches_run`` raises ``OSError``/``RuntimeError`` resolving
+    the owner's recorded run_dir, ``_recover_pending_claims`` fails closed
+    (skips the unverifiable claim) instead of letting the error escape the
+    recovery gate. The matching claim is left in place and run.json is not
+    terminalized."""
+    repo, run_dir = _abandoned_run(tmp_path)
+    stale = _matching_stale_claim(repo, run_dir)
+    monkeypatch.setattr(runguard, "_pid_is_active", lambda pid: pid != 99999999)
+
+    def boom(_owner, _run_dir):
+        raise exc
+
+    monkeypatch.setattr(runguard, "_owner_matches_run", boom)
+
+    # required=False so the gate returns False instead of raising "run lock not
+    # found"; the point is that no exception escapes and the claim is skipped.
+    assert runguard._recover_pending_claims(runguard.lock_path(repo), run_dir=run_dir) is False
+    assert stale.exists()
+    assert json.loads((run_dir / "run.json").read_text())["status"] == "dispatching"
 
 
 def test_has_matching_stale_claim_normalizes_oserror_from_stale_claims_glob(tmp_path, monkeypatch):

--- a/tests/test_runguard.py
+++ b/tests/test_runguard.py
@@ -1693,3 +1693,193 @@ def test_is_active_run_owner_remains_current_process_only(tmp_path, monkeypatch)
     _write_lock_owner_metadata(lock_path, owner_token="live", pid=foreign_pid, run_dir=run_dir)
     monkeypatch.setattr(runguard, "_pid_is_active", lambda pid: True)
     assert runguard.is_active_run_owner(repo, run_dir) is False
+
+
+def _abandoned_run(tmp_path):
+    """A repo plus a non-terminal run dir holding a dispatching run.json."""
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "abandoned-run"
+    run_dir.mkdir()
+    (run_dir / "run.json").write_text(
+        json.dumps({"schema": "brigade.run.v1", "status": "dispatching", "task": "inspect"})
+    )
+    return repo, run_dir
+
+
+def _matching_stale_claim(repo, run_dir, *, owner_token="dead-owner", pid=99999999):
+    """Write a persistent ``.stale`` claim for ``run_dir`` next to the run lock."""
+    lock = runguard.lock_path(repo)
+    stale = lock.with_name(f".{lock.name}.crashed.stale")
+    _write_lock_owner_metadata(stale, owner_token=owner_token, pid=pid, run_dir=run_dir)
+    return stale
+
+
+def test_claim_is_activated_normalizes_runtime_error_from_expanduser(monkeypatch):
+    """A ``RuntimeError`` from ``expanduser`` (no HOME for a ``~`` run_dir) must
+    normalize to ``False``: the activation probe is best-effort and never raises."""
+    monkeypatch.delenv("HOME", raising=False)
+    monkeypatch.delenv("USERPROFILE", raising=False)
+    owner = {"run_dir": "~nope-nope-nope-nope/somerun", "pid": 99999999}
+    assert runguard._claim_is_activated(owner) is False
+
+
+def test_claim_is_activated_normalizes_oserror_from_is_file(monkeypatch, tmp_path):
+    """An ``OSError`` from ``is_file`` (a path component vanishing between
+    resolve and stat) must normalize to ``False`` rather than escape the probe."""
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    real_is_file = Path.is_file
+
+    def flaky_is_file(self, *args, **kwargs):
+        if str(self).endswith("lifecycle.jsonl"):
+            raise OSError("is_file boom")
+        return real_is_file(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "is_file", flaky_is_file)
+    owner = {"run_dir": str(run_dir), "pid": 99999999}
+    assert runguard._claim_is_activated(owner) is False
+
+
+def test_recover_stale_run_recovers_matching_stale_claim_despite_foreign_live_lock(tmp_path, monkeypatch):
+    """A matching persistent ``.stale`` claim stays recoverable under a foreign
+    live lock: the foreign lock is skipped without mutation and the claim is
+    recovered via ``_recover_pending_claims``."""
+    repo, run_dir = _abandoned_run(tmp_path)
+    lock_path = runguard.lock_path(repo)
+
+    # Foreign live lock: a different run owns the lock path with a live pid.
+    foreign_run = tmp_path / "foreign-run"
+    foreign_run.mkdir()
+    _write_lock_owner_metadata(lock_path, owner_token="foreign", pid=os.getpid(), run_dir=foreign_run)
+    stale = _matching_stale_claim(repo, run_dir)
+    monkeypatch.setattr(runguard, "_pid_is_active", lambda pid: pid != 99999999)
+
+    assert runguard.recover_stale_run(repo, run_dir) is True
+    # The foreign live lock is untouched; the claim is cleared and the run terminalized.
+    assert lock_path.is_dir()
+    assert json.loads((lock_path / "owner.json").read_text())["owner_token"] == "foreign"
+    assert not stale.exists()
+    assert json.loads((run_dir / "run.json").read_text())["status"] == "failed"
+
+
+def test_recover_stale_run_recovers_matching_stale_claim_despite_invalid_live_lock(tmp_path, monkeypatch):
+    """A matching persistent ``.stale`` claim stays recoverable when the live
+    lock is invalid (no owner metadata); the invalid lock is left unmutated."""
+    repo, run_dir = _abandoned_run(tmp_path)
+    lock_path = runguard.lock_path(repo)
+
+    # Invalid live lock: directory with no owner.json.
+    lock_path.mkdir(parents=True, exist_ok=True)
+    (lock_path / "pid").write_text(f"{os.getpid()}\n")
+    stale = _matching_stale_claim(repo, run_dir)
+    monkeypatch.setattr(runguard, "_pid_is_active", lambda pid: pid != 99999999)
+
+    assert runguard.recover_stale_run(repo, run_dir) is True
+    assert lock_path.is_dir()
+    assert not (lock_path / "owner.json").exists()
+    assert not stale.exists()
+    assert json.loads((run_dir / "run.json").read_text())["status"] == "failed"
+
+
+def test_recover_stale_run_still_raises_when_foreign_lock_and_no_matching_claim(tmp_path, monkeypatch):
+    """A foreign live lock with no matching ``.stale`` claim still raises, so the
+    caller's concurrent-terminal fallback can surface a bounded error; the
+    foreign lock is never mutated."""
+    repo, run_dir = _abandoned_run(tmp_path)
+    lock_path = runguard.lock_path(repo)
+
+    foreign_run = tmp_path / "foreign-run"
+    foreign_run.mkdir()
+    _write_lock_owner_metadata(lock_path, owner_token="foreign", pid=os.getpid(), run_dir=foreign_run)
+    monkeypatch.setattr(runguard, "_pid_is_active", lambda pid: True)
+
+    with pytest.raises(runguard.RunLockError, match="run lock not found for run:"):
+        runguard.recover_stale_run(repo, run_dir)
+    assert lock_path.is_dir()
+    assert json.loads((lock_path / "owner.json").read_text())["owner_token"] == "foreign"
+
+
+def test_has_matching_stale_claim_normalizes_oserror_from_stale_claims_glob(tmp_path, monkeypatch):
+    """An ``OSError`` from the ``_stale_claims`` glob (a vanished or unreadable
+    lock parent) must not escape the fail-closed predicate."""
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    _matching_stale_claim(repo, run_dir, owner_token="dead")
+    monkeypatch.setattr(runguard, "_pid_is_active", lambda pid: False)
+
+    def boom(_path):
+        raise OSError("glob boom")
+
+    monkeypatch.setattr(runguard, "_stale_claims", boom)
+
+    assert runguard.has_matching_stale_claim(repo, run_dir) is False
+
+
+def test_has_matching_stale_claim_normalizes_runtime_error_from_owner_path_resolve(tmp_path, monkeypatch):
+    """A ``RuntimeError`` from ``_owner_matches_run`` path resolution
+    (``expanduser`` with no HOME) must not escape the fail-closed predicate."""
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    _matching_stale_claim(repo, run_dir, owner_token="dead")
+    monkeypatch.setattr(runguard, "_pid_is_active", lambda pid: False)
+
+    def boom(_owner, _run_dir):
+        raise RuntimeError("expanduser boom")
+
+    monkeypatch.setattr(runguard, "_owner_matches_run", boom)
+
+    assert runguard.has_matching_stale_claim(repo, run_dir) is False
+
+
+@pytest.mark.parametrize("exc", [OSError("resolve boom"), RuntimeError("resolve boom")])
+def test_has_matching_stale_claim_normalizes_lock_path_errors(tmp_path, monkeypatch, exc):
+    """``OSError``/``RuntimeError`` from ``lock_path`` resolution must not
+    escape the fail-closed predicate."""
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    real_lock_path = runguard.lock_path
+
+    def boom(cwd):
+        if cwd == workspace:
+            raise exc
+        return real_lock_path(cwd)
+
+    monkeypatch.setattr(runguard, "lock_path", boom)
+
+    assert runguard.has_matching_stale_claim(workspace, run_dir) is False
+
+
+def test_has_matching_stale_claim_returns_false_for_foreign_stale_claim(tmp_path, monkeypatch):
+    """A persistent ``.stale`` claim pointing at a different run returns
+    ``False`` (fail closed)."""
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    other_run = tmp_path / "other-run"
+    other_run.mkdir()
+    _matching_stale_claim(repo, other_run)
+    monkeypatch.setattr(runguard, "_pid_is_active", lambda pid: False)
+
+    assert runguard.has_matching_stale_claim(repo, run_dir) is False
+
+
+def test_has_matching_stale_claim_never_mutates_lock_or_stale_claims(tmp_path, monkeypatch):
+    """The predicate is read-only: neither the lock nor any claim is mutated."""
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    stale = _matching_stale_claim(repo, run_dir)
+    monkeypatch.setattr(runguard, "_pid_is_active", lambda pid: False)
+
+    snapshot_paths = sorted(p.name for p in stale.parent.iterdir())
+    stale_owner_bytes = (stale / "owner.json").read_bytes()
+
+    runguard.has_matching_stale_claim(repo, run_dir)
+
+    assert sorted(p.name for p in stale.parent.iterdir()) == snapshot_paths
+    assert (stale / "owner.json").read_bytes() == stale_owner_bytes

--- a/tests/test_runguard.py
+++ b/tests/test_runguard.py
@@ -545,10 +545,10 @@ def test_run_lock_does_not_admit_new_owner_while_stale_recovery_is_in_progress(t
     second_entered = threading.Event()
     original_recover = runguard._recover_run_artifact
 
-    def paused_recover(owner):
+    def paused_recover(owner, *, persist_recovery_provenance=False):
         recovery_started.set()
         assert finish_recovery.wait(timeout=2.0)
-        return original_recover(owner)
+        return original_recover(owner, persist_recovery_provenance=persist_recovery_provenance)
 
     monkeypatch.setattr(runguard, "_recover_run_artifact", paused_recover)
 
@@ -1079,3 +1079,617 @@ def test_detect_branch_head_drift_no_snapshot_returns_none(tmp_path):
 
     assert runguard.detect_branch_head_drift(repo, None) is None
     assert runguard.detect_branch_head_drift(None, None) is None
+
+
+# --- Slice 5 Task 4: run_lock_state and before_terminalize callback ---
+
+
+def _write_lock_owner_metadata(lock_path, *, owner_token, pid, run_dir, acquired_at="2026-07-16T00:00:00+00:00"):
+    lock_path.mkdir(parents=True, exist_ok=True)
+    (lock_path / "pid").write_text(f"{pid}\n")
+    (lock_path / "owner.json").write_text(
+        json.dumps(
+            {
+                "schema": "brigade.run_lock.v1",
+                "owner_token": owner_token,
+                "pid": pid,
+                "run_dir": str(run_dir.resolve()) if run_dir is not None else None,
+                "acquired_at": acquired_at,
+            }
+        )
+    )
+
+
+def _activated_journal(run_dir):
+    events = run_dir / "events"
+    events.mkdir(parents=True, exist_ok=True)
+    journal = events / "lifecycle.jsonl"
+    journal.write_text("")
+    return journal
+
+
+def test_run_lock_state_absent(tmp_path):
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    assert runguard.run_lock_state(repo, run_dir) == "absent"
+
+
+def test_run_lock_state_live_for_current_process(tmp_path):
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    lock_path = runguard.lock_path(repo)
+    _write_lock_owner_metadata(lock_path, owner_token="live", pid=os.getpid(), run_dir=run_dir)
+    assert runguard.run_lock_state(repo, run_dir) == "live"
+
+
+def test_run_lock_state_live_for_foreign_pid(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    lock_path = runguard.lock_path(repo)
+    _write_lock_owner_metadata(lock_path, owner_token="live", pid=777777, run_dir=run_dir)
+    monkeypatch.setattr(runguard, "_pid_is_active", lambda pid: True)
+    assert runguard.run_lock_state(repo, run_dir) == "live"
+
+
+def test_run_lock_state_stale(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    lock_path = runguard.lock_path(repo)
+    _write_lock_owner_metadata(lock_path, owner_token="dead", pid=99999999, run_dir=run_dir)
+    monkeypatch.setattr(runguard, "_pid_is_active", lambda pid: False)
+    assert runguard.run_lock_state(repo, run_dir) == "stale"
+
+
+def test_run_lock_state_foreign(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    other_run = tmp_path / "other-run"
+    other_run.mkdir()
+    lock_path = runguard.lock_path(repo)
+    _write_lock_owner_metadata(lock_path, owner_token="dead", pid=99999999, run_dir=other_run)
+    monkeypatch.setattr(runguard, "_pid_is_active", lambda pid: False)
+    assert runguard.run_lock_state(repo, run_dir) == "foreign"
+
+
+def test_run_lock_state_live_when_owner_run_dir_mismatches_but_pid_is_live(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    other_run = tmp_path / "other-run"
+    other_run.mkdir()
+    lock_path = runguard.lock_path(repo)
+    _write_lock_owner_metadata(lock_path, owner_token="live", pid=777777, run_dir=other_run)
+    monkeypatch.setattr(runguard, "_pid_is_active", lambda pid: True)
+    assert runguard.run_lock_state(repo, run_dir) == "live"
+
+
+def test_run_lock_state_invalid_when_owner_metadata_missing(tmp_path):
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    lock_path = runguard.lock_path(repo)
+    lock_path.mkdir(parents=True)
+    (lock_path / "pid").write_text("99999999\n")
+    assert runguard.run_lock_state(repo, run_dir) == "invalid"
+
+
+def test_run_lock_state_invalid_when_owner_metadata_unparseable(tmp_path):
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    lock_path = runguard.lock_path(repo)
+    lock_path.mkdir(parents=True)
+    (lock_path / "pid").write_text("99999999\n")
+    (lock_path / "owner.json").write_text("not json")
+    assert runguard.run_lock_state(repo, run_dir) == "invalid"
+
+
+def test_run_lock_state_invalid_when_owner_metadata_is_non_utf8(tmp_path):
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    lock_path = runguard.lock_path(repo)
+    lock_path.mkdir(parents=True)
+    (lock_path / "pid").write_text("99999999\n")
+    (lock_path / "owner.json").write_bytes(b"\xff")
+    snapshot_paths = sorted(p.name for p in lock_path.iterdir())
+    snapshot_owner_bytes = (lock_path / "owner.json").read_bytes()
+
+    assert runguard.run_lock_state(repo, run_dir) == "invalid"
+
+    assert sorted(p.name for p in lock_path.iterdir()) == snapshot_paths
+    assert (lock_path / "owner.json").read_bytes() == snapshot_owner_bytes
+
+
+def test_run_lock_state_invalid_when_owner_metadata_is_deeply_nested(tmp_path):
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    lock_path = runguard.lock_path(repo)
+    lock_path.mkdir(parents=True)
+    (lock_path / "pid").write_text("99999999\n")
+    # Deeply nested valid JSON sufficient for json.loads to raise RecursionError.
+    depth = 10000
+    nested = "null"
+    for _ in range(depth):
+        nested = f"[{nested}]"
+    (lock_path / "owner.json").write_text(nested)
+    snapshot_paths = sorted(p.name for p in lock_path.iterdir())
+    snapshot_owner_bytes = (lock_path / "owner.json").read_bytes()
+
+    assert runguard.run_lock_state(repo, run_dir) == "invalid"
+
+    assert sorted(p.name for p in lock_path.iterdir()) == snapshot_paths
+    assert (lock_path / "owner.json").read_bytes() == snapshot_owner_bytes
+
+
+def test_run_lock_state_never_raises_and_never_mutates(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    lock_path = runguard.lock_path(repo)
+    _write_lock_owner_metadata(lock_path, owner_token="dead", pid=99999999, run_dir=run_dir)
+    monkeypatch.setattr(runguard, "_pid_is_active", lambda pid: False)
+
+    def boom(*args, **kwargs):
+        raise OSError("boom")
+
+    monkeypatch.setattr(runguard.shutil, "rmtree", boom)
+    monkeypatch.setattr(runguard, "_claim_stale_lock", boom)
+    monkeypatch.setattr(runguard, "_claim_existing_stale", boom)
+    monkeypatch.setattr(runguard, "_restore_claimed_lock", boom)
+
+    assert runguard.run_lock_state(repo, run_dir) == "stale"
+    assert lock_path.is_dir()
+    assert json.loads((lock_path / "owner.json").read_text())["owner_token"] == "dead"
+
+
+def test_run_lock_state_returns_invalid_when_inspection_helpers_raise(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    lock_path = runguard.lock_path(repo)
+    _write_lock_owner_metadata(lock_path, owner_token="dead", pid=99999999, run_dir=run_dir)
+    monkeypatch.setattr(runguard, "_pid_is_active", lambda pid: False)
+
+    def boom(*args, **kwargs):
+        raise ValueError("malformed owner run_dir resolution")
+
+    monkeypatch.setattr(runguard, "_owner_matches_run", boom)
+
+    assert runguard.run_lock_state(repo, run_dir) == "invalid"
+    assert lock_path.is_dir()
+    assert json.loads((lock_path / "owner.json").read_text())["owner_token"] == "dead"
+
+
+def test_run_lock_state_returns_invalid_for_cyclic_owner_run_dir(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    cyclic = tmp_path / "cyclic"
+    cyclic.symlink_to(cyclic, target_is_directory=True)
+    lock_path = runguard.lock_path(repo)
+    lock_path.mkdir(parents=True)
+    (lock_path / "pid").write_text("99999999\n")
+    (lock_path / "owner.json").write_text(
+        json.dumps(
+            {
+                "schema": "brigade.run_lock.v1",
+                "owner_token": "dead",
+                "pid": 99999999,
+                "run_dir": str(cyclic),
+                "acquired_at": "2026-07-16T00:00:00+00:00",
+            }
+        )
+    )
+    monkeypatch.setattr(runguard, "_pid_is_active", lambda pid: False)
+
+    assert runguard.run_lock_state(repo, run_dir) == "invalid"
+    assert lock_path.is_dir()
+    assert json.loads((lock_path / "owner.json").read_text())["owner_token"] == "dead"
+
+
+def test_run_lock_state_returns_invalid_for_cyclic_requested_run_dir(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    cyclic = tmp_path / "cyclic"
+    cyclic.symlink_to(cyclic, target_is_directory=True)
+    lock_path = runguard.lock_path(repo)
+    lock_path.mkdir(parents=True)
+    (lock_path / "pid").write_text("99999999\n")
+    (lock_path / "owner.json").write_text(
+        json.dumps(
+            {
+                "schema": "brigade.run_lock.v1",
+                "owner_token": "dead",
+                "pid": 99999999,
+                "run_dir": str(cyclic),
+                "acquired_at": "2026-07-16T00:00:00+00:00",
+            }
+        )
+    )
+    monkeypatch.setattr(runguard, "_pid_is_active", lambda pid: False)
+
+    snapshot_paths = sorted(p.name for p in lock_path.iterdir())
+    snapshot_owner_bytes = (lock_path / "owner.json").read_bytes()
+
+    assert runguard.run_lock_state(repo, cyclic) == "invalid"
+
+    assert sorted(p.name for p in lock_path.iterdir()) == snapshot_paths
+    assert (lock_path / "owner.json").read_bytes() == snapshot_owner_bytes
+
+
+def test_recover_stale_run_invokes_before_terminalize_after_token_check(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "abandoned-run"
+    run_dir.mkdir()
+    (run_dir / "run.json").write_text(
+        json.dumps({"schema": "brigade.run.v1", "status": "dispatching", "task": "inspect"})
+    )
+    lock_path = runguard.lock_path(repo)
+    _write_lock_owner_metadata(lock_path, owner_token="dead-owner", pid=99999999, run_dir=run_dir)
+    monkeypatch.setattr(runguard, "_pid_is_active", lambda pid: False)
+
+    finish_calls = []
+    callback_owners = []
+    original_finish = runguard._finish_claimed_recovery
+
+    def spy_finish(path, claimed, owner, *, persist_recovery_provenance=False):
+        finish_calls.append(owner)
+        return original_finish(path, claimed, owner, persist_recovery_provenance=persist_recovery_provenance)
+
+    monkeypatch.setattr(runguard, "_finish_claimed_recovery", spy_finish)
+
+    def before_terminalize(owner):
+        callback_owners.append(owner)
+
+    assert runguard.recover_stale_run(repo, run_dir, before_terminalize=before_terminalize) is True
+    assert len(callback_owners) == 1
+    assert callback_owners[0].get("owner_token") == "dead-owner"
+    assert len(finish_calls) == 1
+    assert finish_calls[0] is callback_owners[0]
+
+
+def test_recover_stale_run_invokes_callback_for_existing_pending_claim(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "abandoned-run"
+    run_dir.mkdir()
+    (run_dir / "run.json").write_text(
+        json.dumps({"schema": "brigade.run.v1", "status": "dispatching", "task": "inspect"})
+    )
+    lock_path = runguard.lock_path(repo)
+    claimed = lock_path.with_name(f".{lock_path.name}.crashed.stale")
+    _write_lock_owner_metadata(claimed, owner_token="dead-owner", pid=99999999, run_dir=run_dir)
+    monkeypatch.setattr(runguard, "_pid_is_active", lambda pid: False)
+
+    callback_owners = []
+
+    def before_terminalize(owner):
+        callback_owners.append(owner)
+
+    assert runguard.recover_stale_run(repo, run_dir, before_terminalize=before_terminalize) is True
+    assert len(callback_owners) == 1
+    assert callback_owners[0].get("owner_token") == "dead-owner"
+    assert not claimed.exists()
+    assert json.loads((run_dir / "run.json").read_text())["status"] == "failed"
+
+
+def test_recover_stale_run_callback_error_restores_claimed_lock_and_raises(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "abandoned-run"
+    run_dir.mkdir()
+    (run_dir / "run.json").write_text(
+        json.dumps({"schema": "brigade.run.v1", "status": "dispatching", "task": "inspect"})
+    )
+    lock_path = runguard.lock_path(repo)
+    _write_lock_owner_metadata(lock_path, owner_token="dead-owner", pid=99999999, run_dir=run_dir)
+    monkeypatch.setattr(runguard, "_pid_is_active", lambda pid: False)
+
+    restore_calls = []
+    original_restore = runguard._restore_claimed_lock
+
+    def spy_restore(target, claimed):
+        restore_calls.append((target, claimed))
+        return original_restore(target, claimed)
+
+    monkeypatch.setattr(runguard, "_restore_claimed_lock", spy_restore)
+
+    def before_terminalize(owner):
+        raise ValueError("checkpoint validation failed")
+
+    with pytest.raises(runguard.RunLockError, match="restored") as exc:
+        runguard.recover_stale_run(repo, run_dir, before_terminalize=before_terminalize)
+
+    assert len(restore_calls) == 1
+    assert restore_calls[0][0] == lock_path
+    assert str(lock_path) in str(exc.value)
+    assert lock_path.is_dir()
+    dangling = list(lock_path.parent.glob(f".{lock_path.name}.*.stale"))
+    assert dangling == []
+    assert json.loads((lock_path / "owner.json").read_text())["owner_token"] == "dead-owner"
+    assert json.loads((run_dir / "run.json").read_text())["status"] == "dispatching"
+
+
+def test_recover_stale_run_callback_error_for_pending_claim_restores_and_raises(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "abandoned-run"
+    run_dir.mkdir()
+    (run_dir / "run.json").write_text(
+        json.dumps({"schema": "brigade.run.v1", "status": "dispatching", "task": "inspect"})
+    )
+    lock_path = runguard.lock_path(repo)
+    claimed = lock_path.with_name(f".{lock_path.name}.crashed.stale")
+    _write_lock_owner_metadata(claimed, owner_token="dead-owner", pid=99999999, run_dir=run_dir)
+    monkeypatch.setattr(runguard, "_pid_is_active", lambda pid: False)
+
+    restore_calls = []
+    original_restore = runguard._restore_claimed_lock
+
+    def spy_restore(target, claimed_arg):
+        restore_calls.append((target, claimed_arg))
+        return original_restore(target, claimed_arg)
+
+    monkeypatch.setattr(runguard, "_restore_claimed_lock", spy_restore)
+
+    def before_terminalize(owner):
+        raise ValueError("checkpoint validation failed")
+
+    with pytest.raises(runguard.RunLockError, match="restored") as exc:
+        runguard.recover_stale_run(repo, run_dir, before_terminalize=before_terminalize)
+
+    assert len(restore_calls) == 1
+    assert restore_calls[0][0] == lock_path
+    assert str(lock_path) in str(exc.value)
+    assert lock_path.is_dir()
+    dangling = list(lock_path.parent.glob(f".{lock_path.name}.*.stale"))
+    assert dangling == []
+    assert json.loads((lock_path / "owner.json").read_text())["owner_token"] == "dead-owner"
+    assert json.loads((run_dir / "run.json").read_text())["status"] == "dispatching"
+
+
+def test_pending_claim_token_race_restores_and_raises(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "abandoned-run"
+    run_dir.mkdir()
+    (run_dir / "run.json").write_text(
+        json.dumps({"schema": "brigade.run.v1", "status": "dispatching", "task": "inspect"})
+    )
+    lock_path = runguard.lock_path(repo)
+    stale = lock_path.with_name(f".{lock_path.name}.crashed.stale")
+    _write_lock_owner_metadata(stale, owner_token="original-token", pid=99999999, run_dir=run_dir)
+    monkeypatch.setattr(runguard, "_pid_is_active", lambda pid: False)
+
+    original_claim = runguard._claim_existing_stale
+
+    def racing_claim(path, stale_arg):
+        result = original_claim(path, stale_arg)
+        if result is None:
+            return None
+        claimed, owner = result
+        raced = dict(owner)
+        raced["owner_token"] = "raced-token"
+        (claimed / "owner.json").write_text(json.dumps(raced))
+        return claimed, raced
+
+    monkeypatch.setattr(runguard, "_claim_existing_stale", racing_claim)
+
+    callback_calls = []
+    finish_calls = []
+    original_finish = runguard._finish_claimed_recovery
+
+    def spy_finish(*args, **kwargs):
+        finish_calls.append(args)
+        return original_finish(*args, **kwargs)
+
+    monkeypatch.setattr(runguard, "_finish_claimed_recovery", spy_finish)
+
+    def before_terminalize(owner):
+        callback_calls.append(owner)
+
+    with pytest.raises(runguard.RunLockError, match="owner changed during pending claim recovery") as exc:
+        runguard.recover_stale_run(repo, run_dir, before_terminalize=before_terminalize)
+
+    assert str(stale) in str(exc.value)
+    assert callback_calls == []
+    assert finish_calls == []
+    assert stale.is_dir()
+    dangling = [p for p in lock_path.parent.glob(f".{lock_path.name}.*.stale") if p != stale]
+    assert dangling == []
+    assert json.loads((stale / "owner.json").read_text())["owner_token"] == "raced-token"
+    assert json.loads((run_dir / "run.json").read_text())["status"] == "dispatching"
+
+
+def test_pending_activated_claim_without_callback_requires_explicit_recovery(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "abandoned-run"
+    run_dir.mkdir()
+    (run_dir / "run.json").write_text(
+        json.dumps({"schema": "brigade.run.v1", "status": "dispatching", "task": "inspect"})
+    )
+    _activated_journal(run_dir)
+    lock_path = runguard.lock_path(repo)
+    claimed = lock_path.with_name(f".{lock_path.name}.crashed.stale")
+    _write_lock_owner_metadata(claimed, owner_token="dead-owner", pid=99999999, run_dir=run_dir)
+    monkeypatch.setattr(runguard, "_pid_is_active", lambda pid: False)
+
+    with pytest.raises(runguard.RunLockError, match="explicit"):
+        runguard.recover_stale_run(repo, run_dir)
+
+    retained = list(lock_path.parent.glob(f".{lock_path.name}.*.stale"))
+    assert len(retained) == 1
+    assert json.loads((run_dir / "run.json").read_text())["status"] == "dispatching"
+
+
+def test_generic_lock_acquisition_retains_activated_pending_claim(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "abandoned-run"
+    run_dir.mkdir()
+    (run_dir / "run.json").write_text(
+        json.dumps({"schema": "brigade.run.v1", "status": "dispatching", "task": "inspect"})
+    )
+    _activated_journal(run_dir)
+    lock_path = runguard.lock_path(repo)
+    claimed = lock_path.with_name(f".{lock_path.name}.crashed.stale")
+    _write_lock_owner_metadata(claimed, owner_token="dead-owner", pid=99999999, run_dir=run_dir)
+    monkeypatch.setattr(runguard, "_pid_is_active", lambda pid: False)
+
+    with pytest.raises(runguard.RunLockError):
+        with runguard.run_lock(repo, run_dir=tmp_path / "new-run"):
+            pass
+
+    retained = list(lock_path.parent.glob(f".{lock_path.name}.*.stale"))
+    assert len(retained) == 1
+    assert json.loads((run_dir / "run.json").read_text())["status"] == "dispatching"
+
+
+def test_recover_stale_run_without_callback_terminalizes_as_today(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "abandoned-run"
+    run_dir.mkdir()
+    (run_dir / "run.json").write_text(
+        json.dumps({"schema": "brigade.run.v1", "status": "dispatching", "task": "inspect"})
+    )
+    lock_path = runguard.lock_path(repo)
+    _write_lock_owner_metadata(lock_path, owner_token="dead-owner", pid=99999999, run_dir=run_dir)
+    monkeypatch.setattr(runguard, "_pid_is_active", lambda pid: False)
+
+    assert runguard.recover_stale_run(repo, run_dir) is True
+    assert not lock_path.exists()
+    recovered = json.loads((run_dir / "run.json").read_text())
+    assert recovered["status"] == "failed"
+    assert "lock_workspace" not in recovered.get("failure", {})
+    assert "lock_acquired_at" not in recovered.get("failure", {})
+
+
+def test_recover_stale_run_refuses_live_owner_current_pid(tmp_path):
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "active-run"
+    run_dir.mkdir()
+    (run_dir / "run.json").write_text(json.dumps({"status": "dispatching"}))
+    lock_path = runguard.lock_path(repo)
+    _write_lock_owner_metadata(lock_path, owner_token="live-owner", pid=os.getpid(), run_dir=run_dir)
+
+    with pytest.raises(runguard.RunLockError, match="another brigade run appears active"):
+        with runguard.run_lock(repo, run_dir=tmp_path / "new-run"):
+            pass
+
+    assert lock_path.is_dir()
+    assert json.loads((lock_path / "owner.json").read_text())["owner_token"] == "live-owner"
+    assert json.loads((run_dir / "run.json").read_text())["status"] == "dispatching"
+
+
+def test_recover_stale_run_refuses_live_owner_foreign_pid(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "active-run"
+    run_dir.mkdir()
+    (run_dir / "run.json").write_text(json.dumps({"status": "dispatching"}))
+    lock_path = runguard.lock_path(repo)
+    _write_lock_owner_metadata(lock_path, owner_token="live-owner", pid=777777, run_dir=run_dir)
+    monkeypatch.setattr(runguard, "_pid_is_active", lambda pid: True)
+
+    with pytest.raises(runguard.RunLockError, match="another brigade run appears active"):
+        with runguard.run_lock(repo, run_dir=tmp_path / "new-run"):
+            pass
+
+    assert lock_path.is_dir()
+    assert json.loads((lock_path / "owner.json").read_text())["owner_token"] == "live-owner"
+
+
+def test_recover_run_artifact_persists_lock_recovery_provenance(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "abandoned-run"
+    run_dir.mkdir()
+    (run_dir / "run.json").write_text(
+        json.dumps({"schema": "brigade.run.v1", "status": "dispatching", "task": "inspect"})
+    )
+    _activated_journal(run_dir)
+    lock_path = runguard.lock_path(repo)
+    _write_lock_owner_metadata(lock_path, owner_token="dead-owner", pid=99999999, run_dir=run_dir)
+    monkeypatch.setattr(runguard, "_pid_is_active", lambda pid: False)
+
+    def before_terminalize(owner):
+        return None
+
+    assert runguard.recover_stale_run(repo, run_dir, before_terminalize=before_terminalize) is True
+
+    recovered = json.loads((run_dir / "run.json").read_text())
+    assert recovered["status"] == "failed"
+    failure = recovered["failure"]
+    assert failure["lock_workspace"] == str(repo.resolve())
+    assert failure["lock_acquired_at"] == "2026-07-16T00:00:00+00:00"
+
+
+def test_recover_run_artifact_persists_lock_recovery_provenance_omits_absent_owner_values(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "abandoned-run"
+    run_dir.mkdir()
+    (run_dir / "run.json").write_text(
+        json.dumps({"schema": "brigade.run.v1", "status": "dispatching", "task": "inspect"})
+    )
+    _activated_journal(run_dir)
+    lock_path = runguard.lock_path(repo)
+    lock_path.mkdir(parents=True)
+    (lock_path / "pid").write_text("99999999\n")
+    (lock_path / "owner.json").write_text(
+        json.dumps(
+            {
+                "schema": "brigade.run_lock.v1",
+                "owner_token": "dead-owner",
+                "pid": 99999999,
+                "run_dir": str(run_dir.resolve()),
+            }
+        )
+    )
+    monkeypatch.setattr(runguard, "_pid_is_active", lambda pid: False)
+
+    def before_terminalize(owner):
+        return None
+
+    assert runguard.recover_stale_run(repo, run_dir, before_terminalize=before_terminalize) is True
+
+    recovered = json.loads((run_dir / "run.json").read_text())
+    failure = recovered["failure"]
+    assert "lock_workspace" in failure
+    assert "lock_acquired_at" not in failure
+
+
+def test_legacy_recover_run_artifact_does_not_add_recovery_provenance(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "abandoned-run"
+    run_dir.mkdir()
+    (run_dir / "run.json").write_text(
+        json.dumps({"schema": "brigade.run.v1", "status": "dispatching", "task": "inspect"})
+    )
+    lock_path = runguard.lock_path(repo)
+    _write_lock_owner_metadata(lock_path, owner_token="dead-owner", pid=99999999, run_dir=run_dir)
+    monkeypatch.setattr(runguard, "_pid_is_active", lambda pid: False)
+
+    assert runguard.recover_stale_run(repo, run_dir) is True
+    recovered = json.loads((run_dir / "run.json").read_text())
+    assert recovered["status"] == "failed"
+    failure = recovered["failure"]
+    assert "lock_workspace" not in failure
+    assert "lock_acquired_at" not in failure
+
+
+def test_is_active_run_owner_remains_current_process_only(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    run_dir = tmp_path / "active-run"
+    run_dir.mkdir()
+    lock_path = runguard.lock_path(repo)
+    _write_lock_owner_metadata(lock_path, owner_token="live", pid=os.getpid(), run_dir=run_dir)
+    assert runguard.is_active_run_owner(repo, run_dir) is True
+
+    other_run = tmp_path / "other-run"
+    other_run.mkdir()
+    _write_lock_owner_metadata(lock_path, owner_token="live", pid=os.getpid(), run_dir=other_run)
+    assert runguard.is_active_run_owner(repo, run_dir) is False
+
+    foreign_pid = 777777
+    _write_lock_owner_metadata(lock_path, owner_token="live", pid=foreign_pid, run_dir=run_dir)
+    monkeypatch.setattr(runguard, "_pid_is_active", lambda pid: True)
+    assert runguard.is_active_run_owner(repo, run_dir) is False

--- a/tests/test_runs_cmd.py
+++ b/tests/test_runs_cmd.py
@@ -1,8 +1,11 @@
 import errno
 import json
 import os
+import shutil
 import time as system_time
 from pathlib import Path
+
+import pytest
 
 from brigade import cli
 from brigade import run_checkpoint
@@ -422,6 +425,44 @@ def test_runs_recover_treats_lost_concurrent_claim_as_already_terminal(tmp_path,
 
     assert runs_cmd.recover(str(run_dir), cwd=workspace) == 0
     assert f"already terminal: {run_dir} [failed]" in capsys.readouterr().out
+
+
+def test_runs_recover_lost_claim_with_invalid_utf8_run_json_is_bounded(tmp_path, capsys):
+    """Invalid UTF-8 in run.json must not escape the concurrent-terminal
+    fallback as a raw ``UnicodeDecodeError``; recovery stays bounded at rc=2."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / "orphan"
+    _activate_journal_with_checkpoint(workspace, run_dir, {"status": "planning", "task": "demo", "cwd": str(workspace)})
+    # A concurrent recovery already cleared the matching lock.
+    shutil.rmtree(workspace / ".brigade" / "run.lock")
+    # run.json is corrupt: invalid UTF-8 bytes.
+    (run_dir / "run.json").write_bytes(b"\xff\xfe invalid utf8 \x00")
+
+    rc = runs_cmd.recover(str(run_dir), cwd=workspace)
+
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "Traceback" not in err
+
+
+def test_runs_recover_lost_claim_with_deeply_nested_run_json_is_bounded(tmp_path, capsys):
+    """A ``RecursionError`` from deeply nested run.json must not escape the
+    concurrent-terminal fallback; recovery stays bounded at rc=2."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / "orphan"
+    _activate_journal_with_checkpoint(workspace, run_dir, {"status": "planning", "task": "demo", "cwd": str(workspace)})
+    shutil.rmtree(workspace / ".brigade" / "run.lock")
+    # Valid but deeply nested JSON: json.loads recurses and raises RecursionError.
+    nesting = 10000
+    (run_dir / "run.json").write_text('{"a":' * nesting + "1" + "}" * nesting)
+
+    rc = runs_cmd.recover(str(run_dir), cwd=workspace)
+
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "Traceback" not in err
 
 
 def test_runs_recover_terminal_run_ignores_foreign_workspace_lock(tmp_path, capsys):
@@ -1658,3 +1699,190 @@ def test_runs_recover_run_json_read_oserror_exits_without_mutation(tmp_path, cap
     assert (lock_path / "pid").read_text() == lock_pid_before
     assert (lock_path / "owner.json").read_text() == lock_owner_before
     assert "could not read run.json" in capsys.readouterr().err
+
+
+def test_runs_recover_proceeds_under_foreign_lock_with_matching_stale_claim(tmp_path, capsys):
+    """CLI recovery proceeds under a foreign current lock when a matching persistent
+    ``.stale`` claim exists, recovering only the matching claim via the checkpoint
+    path and leaving the foreign lock byte-for-byte and path-state unchanged.
+    """
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    run_json_obj = {"status": "planning", "task": "demo task", "cwd": str(workspace)}
+    _activate_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    lock_path = workspace / ".brigade" / "run.lock"
+    # Relocate the matching dead lock to a persistent .stale claim.
+    stale = lock_path.with_name(f".{lock_path.name}.crashed.stale")
+    lock_path.rename(stale)
+    # Install a FOREIGN dead lock at the lock path (different run_dir).
+    foreign_run = workspace / ".brigade" / "runs" / "foreign-run"
+    foreign_run.mkdir(parents=True)
+    _write_lock_owner(workspace, foreign_run, pid=99999999, owner_token="foreign")
+    foreign_owner_bytes = (lock_path / "owner.json").read_bytes()
+    foreign_pid_bytes = (lock_path / "pid").read_bytes()
+
+    rc = runs_cmd.recover(str(run_dir), cwd=workspace)
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert f"recovered: {run_dir}" in out
+    # The foreign lock is byte-for-byte and path-state unchanged.
+    assert lock_path.is_dir()
+    assert (lock_path / "owner.json").read_bytes() == foreign_owner_bytes
+    assert (lock_path / "pid").read_bytes() == foreign_pid_bytes
+    # The matching .stale claim was cleared.
+    assert not stale.exists()
+    # The run was terminalized via the checkpoint recovery path.
+    recovered = json.loads((run_dir / "run.json").read_text())
+    assert recovered["status"] == "failed"
+    assert recovered["failure_phase"] == "stale-lock-recovery"
+    assert recovered["task"] == "demo task"
+
+
+def test_runs_recover_proceeds_under_invalid_lock_with_matching_stale_claim(tmp_path, capsys):
+    """CLI recovery proceeds under an invalid current lock when a matching persistent
+    ``.stale`` claim exists, recovering only the matching claim and leaving the invalid
+    lock path-state unchanged (still a directory with no owner.json).
+    """
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    run_json_obj = {"status": "planning", "task": "demo task", "cwd": str(workspace)}
+    _activate_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    lock_path = workspace / ".brigade" / "run.lock"
+    stale = lock_path.with_name(f".{lock_path.name}.crashed.stale")
+    lock_path.rename(stale)
+    # Install an INVALID lock at the lock path: directory with no owner.json.
+    lock_path.mkdir(parents=True)
+    (lock_path / "pid").write_text(f"{os.getpid()}\n")
+    invalid_pid_bytes = (lock_path / "pid").read_bytes()
+
+    rc = runs_cmd.recover(str(run_dir), cwd=workspace)
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert f"recovered: {run_dir}" in out
+    # The invalid lock is path-state unchanged.
+    assert lock_path.is_dir()
+    assert not (lock_path / "owner.json").exists()
+    assert (lock_path / "pid").read_bytes() == invalid_pid_bytes
+    assert not stale.exists()
+    recovered = json.loads((run_dir / "run.json").read_text())
+    assert recovered["status"] == "failed"
+    assert recovered["failure_phase"] == "stale-lock-recovery"
+    assert recovered["task"] == "demo task"
+
+
+def test_runs_recover_lost_matching_claim_under_foreign_lock_is_bounded(tmp_path, monkeypatch, capsys):
+    """When the matching ``.stale`` claim disappears between preflight and recovery,
+    CLI recovery returns bounded rc=2 without mutating the foreign lock or run.json.
+    """
+    import shutil
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    run_json_obj = {"status": "planning", "task": "demo task", "cwd": str(workspace)}
+    _activate_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    lock_path = workspace / ".brigade" / "run.lock"
+    stale = lock_path.with_name(f".{lock_path.name}.crashed.stale")
+    lock_path.rename(stale)
+    foreign_run = workspace / ".brigade" / "runs" / "foreign-run"
+    foreign_run.mkdir(parents=True)
+    _write_lock_owner(workspace, foreign_run, pid=99999999, owner_token="foreign")
+    foreign_owner_bytes = (lock_path / "owner.json").read_bytes()
+    run_json_before = (run_dir / "run.json").read_bytes()
+
+    real_recover = runguard.recover_stale_run
+
+    def lose_claim(cwd, requested_run, **kwargs):
+        if stale.exists():
+            shutil.rmtree(stale, ignore_errors=True)
+        return real_recover(cwd, requested_run, **kwargs)
+
+    monkeypatch.setattr(runguard, "recover_stale_run", lose_claim)
+
+    rc = runs_cmd.recover(str(run_dir), cwd=workspace)
+
+    assert rc == 2
+    assert (lock_path / "owner.json").read_bytes() == foreign_owner_bytes
+    assert (run_dir / "run.json").read_bytes() == run_json_before
+    err = capsys.readouterr().err
+    assert "run lock not found for run:" in err
+    assert "Traceback" not in err
+
+
+def test_runs_recover_restores_from_retained_lock_after_initial_run_json_write_failure(tmp_path, monkeypatch, capsys):
+    """``runs_cmd.recover`` restores a run whose first ``run.json`` write failed
+    after checkpoint publication, leaving the lock retained with durable
+    journal/checkpoint state but no ``run.json``.
+
+    This is the end-to-end recovery assertion for the
+    ``RetainRunLockError`` translation in ``aboyeur.record_run_start``: the lock
+    is retained (not orphaned), the lifecycle journal and recovery checkpoint
+    survive, and ``runs_cmd.recover`` terminalizes the run from the retained
+    state.
+    """
+    from brigade import aboyeur
+    from brigade.roster import Agent, Roster
+
+    monkeypatch.setenv("BRIGADE_LIFECYCLE_JOURNAL", "1")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    run_dir.mkdir(parents=True)
+
+    real_write_text_atomic = aboyeur.localio.write_text_atomic
+
+    def fail_run_json_write(path, text):
+        if Path(path).name == "run.json":
+            raise OSError("receipt disk full")
+        return real_write_text_atomic(path, text)
+
+    monkeypatch.setattr(aboyeur.localio, "write_text_atomic", fail_run_json_write)
+
+    roster = Roster(
+        orchestrator="chef",
+        agents={
+            "chef": Agent("chef", "codex", "plan and synthesize"),
+            "coder": Agent("coder", "ollama:llama3.3", "write code"),
+        },
+        max_workers=1,
+    )
+
+    with pytest.raises(runguard.RetainRunLockError):
+        with runguard.run_lock(workspace, run_dir=run_dir):
+            aboyeur.record_run_start(
+                run_dir,
+                task="demo task",
+                cwd=workspace,
+                roster=roster,
+                read_only=False,
+                lock_workspace=workspace,
+            )
+
+    # Pre-conditions: lock retained, run.json absent, durable state present.
+    lock_path = workspace / ".brigade" / "run.lock"
+    assert lock_path.is_dir()
+    assert not (run_dir / "run.json").is_file()
+    assert run_lifecycle._journal_path(run_dir).is_file()
+    assert any(run_checkpoint.checkpoint_dir(run_dir).glob("*.json"))
+
+    # Mark the retained lock owner dead so recovery can claim it.
+    _overwrite_lock_owner(workspace, run_dir, pid=99999999)
+    monkeypatch.setattr(runguard, "_pid_is_active", lambda pid: False)
+
+    # Stop failing the write so recovery can write the terminal receipt.
+    monkeypatch.setattr(aboyeur.localio, "write_text_atomic", real_write_text_atomic)
+
+    rc = runs_cmd.recover(str(run_dir), cwd=workspace)
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert f"recovered: {run_dir}" in out
+    recovered = json.loads((run_dir / "run.json").read_text())
+    assert recovered["status"] == "failed"
+    assert recovered["failure_phase"] == "stale-lock-recovery"
+    assert recovered["task"] == "demo task"
+    assert not lock_path.exists()

--- a/tests/test_runs_cmd.py
+++ b/tests/test_runs_cmd.py
@@ -1,9 +1,14 @@
+import errno
 import json
 import os
 import time as system_time
 from pathlib import Path
 
 from brigade import cli
+from brigade import run_checkpoint
+from brigade import run_events
+from brigade import run_journal
+from brigade import run_lifecycle
 from brigade import runguard
 from brigade import runs_cmd
 
@@ -1030,3 +1035,626 @@ def test_runs_show_without_ground_truth_stays_quiet(tmp_path, capsys):
 
     assert runs_cmd.show(run_dir) == 0
     assert "ground truth" not in capsys.readouterr().out
+
+
+# -- Issue #568 slice 5 Task 5: checkpoint-backed runs recover integration --
+
+
+_RUN_ID = "20260727-153045-a1b2c3d4"
+_RECORDED_AT = "2026-07-27T15:30:45.123456Z"
+
+
+def _writer_bytes(obj: dict) -> bytes:
+    return (json.dumps(obj, indent=2, sort_keys=True) + "\n").encode("utf-8")
+
+
+def _activate_journal_with_checkpoint(
+    workspace: Path,
+    run_dir: Path,
+    run_json_obj: dict,
+    *,
+    paired_event_type: str | None = "run.planning.started",
+) -> None:
+    """Build an activated lifecycle journal ending in a checkpoint event.
+
+    Bootstraps run.json with the durable request, then under a live run lock
+    activates the journal and appends one ``run.snapshot.checkpointed``
+    event (the recoverable state: crash after the checkpoint publish+append
+    but before the paired status append). Finally replaces the lock owner
+    with a dead pid so ``runs_cmd.recover`` sees a stale matching lock.
+    """
+    runs_dir = run_dir.parent
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    run_dir.mkdir(parents=True, exist_ok=True)
+    localio = _localio()
+    localio.write_json(
+        run_dir / "run.json",
+        {"schema": "brigade.run.v1", **run_json_obj, "lifecycle_journal_requested": True},
+    )
+    with runguard.run_lock(workspace, run_dir=run_dir):
+        run_lifecycle.prepare_lifecycle_journal(run_dir, workspace=workspace)
+        run_checkpoint.write_checkpoint(
+            run_dir,
+            _writer_bytes(run_json_obj),
+            workspace=workspace,
+            paired_event_type=paired_event_type,
+        )
+    _write_lock_owner(workspace, run_dir, pid=99999999)
+
+
+def _localio():
+    from brigade import localio
+
+    return localio
+
+
+def _journal_path(run_dir: Path) -> Path:
+    return run_dir / "events" / "lifecycle.jsonl"
+
+
+def _events(run_dir: Path) -> list:
+    return run_journal.read_journal(_journal_path(run_dir)).events
+
+
+def _overwrite_lock_owner(workspace, run_dir, *, pid, owner_token="owner"):
+    """Overwrite an existing run.lock's owner metadata in place (no mkdir)."""
+    lock_path = workspace / ".brigade" / "run.lock"
+    (lock_path / "pid").write_text(f"{pid}\n")
+    _write_json(
+        lock_path / "owner.json",
+        {
+            "schema": "brigade.run_lock.v1",
+            "owner_token": owner_token,
+            "pid": pid,
+            "run_dir": str(run_dir.resolve()),
+            "acquired_at": "2026-07-16T00:00:00+00:00",
+        },
+    )
+    return lock_path
+
+
+def test_runs_recover_restores_missing_run_json_from_latest_checkpoint(tmp_path, capsys):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    run_json_obj = {
+        "status": "planning",
+        "task": "demo task",
+        "cwd": str(workspace),
+        "orchestrator": "chef",
+    }
+    _activate_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    (run_dir / "run.json").unlink()
+    assert not (run_dir / "run.json").exists()
+
+    rc = runs_cmd.recover(str(run_dir), cwd=workspace)
+
+    assert rc == 0
+    recovered = json.loads((run_dir / "run.json").read_text())
+    assert recovered["status"] == "failed"
+    assert recovered["failure_phase"] == "stale-lock-recovery"
+    # Restored receipt fields are preserved through terminalization.
+    assert recovered["task"] == "demo task"
+    assert recovered["orchestrator"] == "chef"
+    assert f"recovered: {run_dir}" in capsys.readouterr().out
+
+
+def test_runs_recover_preserves_corrupt_run_json_and_restores_from_checkpoint(tmp_path, capsys):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    run_json_obj = {"status": "planning", "task": "demo task", "cwd": str(workspace)}
+    _activate_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    (run_dir / "run.json").write_text("not json")
+
+    rc = runs_cmd.recover(str(run_dir), cwd=workspace)
+
+    assert rc == 0
+    recovered = json.loads((run_dir / "run.json").read_text())
+    assert recovered["status"] == "failed"
+    assert recovered["task"] == "demo task"
+    preserved = list(run_dir.glob("run.json.corrupt-*"))
+    assert len(preserved) == 1
+    assert preserved[0].read_text() == "not json"
+
+
+def test_runs_recover_terminalization_preserves_restored_receipt_fields(tmp_path, capsys):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    run_json_obj = {
+        "status": "dispatching",
+        "task": "inspect",
+        "cwd": str(workspace),
+        "orchestrator": "chef",
+        "active_seats": ["coder"],
+        "duration_seconds": 5,
+    }
+    _activate_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    (run_dir / "run.json").unlink()
+
+    rc = runs_cmd.recover(str(run_dir), cwd=workspace)
+
+    assert rc == 0
+    recovered = json.loads((run_dir / "run.json").read_text())
+    assert recovered["status"] == "failed"
+    assert recovered["failure_phase"] == "stale-lock-recovery"
+    assert recovered["task"] == "inspect"
+    assert recovered["orchestrator"] == "chef"
+    assert recovered["duration_seconds"] == 5
+    assert recovered["failure"]["prior_status"] == "dispatching"
+
+
+def test_runs_recover_quarantines_partial_journal_tail_then_verifies(tmp_path, capsys):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    run_json_obj = {"status": "planning", "task": "demo", "cwd": str(workspace)}
+    _activate_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    (run_dir / "run.json").unlink()
+    journal = _journal_path(run_dir)
+    partial = b'{"schema":"brigade.run_event.v1","event_type":"run.plan'
+    journal.write_bytes(journal.read_bytes() + partial)
+    complete_bytes = journal.read_bytes()[: -len(partial)]
+
+    rc = runs_cmd.recover(str(run_dir), cwd=workspace)
+
+    assert rc == 0
+    assert journal.read_bytes() == complete_bytes
+    quarantine = list((run_dir / "events" / "quarantine").iterdir())
+    assert quarantine, "partial tail was not quarantined"
+    recovered = json.loads((run_dir / "run.json").read_text())
+    assert recovered["status"] == "failed"
+
+
+def test_runs_recover_fails_closed_on_invalid_latest_checkpoint(tmp_path, capsys):
+    import hashlib
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    run_json_obj = {"status": "planning", "task": "demo", "cwd": str(workspace)}
+    _activate_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    (run_dir / "run.json").unlink()
+    sha = hashlib.sha256(_writer_bytes(run_json_obj)).hexdigest()
+    cp_file = run_checkpoint.checkpoint_path(run_dir, sha)
+    cp_file.write_bytes(b"x" * len(_writer_bytes(run_json_obj)))
+    os.chmod(cp_file, 0o600)
+    lock_path = workspace / ".brigade" / "run.lock"
+
+    rc = runs_cmd.recover(str(run_dir), cwd=workspace)
+
+    assert rc == 2
+    assert not (run_dir / "run.json").exists()
+    # The dead lock is restored (callback failed; lock restored by runguard).
+    assert lock_path.is_dir()
+
+
+def test_runs_recover_accepts_covered_paired_status_event_and_preserves_fields(tmp_path, capsys):
+    """CLI recovery accepts a checkpoint N plus matching status N+1 and preserves fields.
+
+    The checkpoint at N carries ``paired_event_type`` for the checkpointed
+    status, and the N+1 event is the matching paired status event whose
+    derived status equals the checkpoint status. Per the slice-5 coverage
+    semantics this is a covered tail, so recovery restores the checkpoint
+    bytes and terminalizes, preserving the restored receipt fields
+    (``task``, ``orchestrator``, ``cwd``, ``active_seats``,
+    ``duration_seconds``) and stamping the stale-lock-recovery failure.
+    """
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    run_json_obj = {
+        "status": "dispatching",
+        "task": "inspect",
+        "cwd": str(workspace),
+        "orchestrator": "chef",
+        "active_seats": ["coder"],
+        "duration_seconds": 5,
+    }
+    # Build the journal with a checkpoint AND its matching paired status event
+    # (covered tail) under a live lock, then replace the owner with a dead pid.
+    runs_dir = run_dir.parent
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    run_dir.mkdir(parents=True, exist_ok=True)
+    _localio().write_json(
+        run_dir / "run.json",
+        {"schema": "brigade.run.v1", **run_json_obj, "lifecycle_journal_requested": True},
+    )
+    with runguard.run_lock(workspace, run_dir=run_dir):
+        run_lifecycle.prepare_lifecycle_journal(run_dir, workspace=workspace)
+        run_checkpoint.write_checkpoint(
+            run_dir,
+            _writer_bytes(run_json_obj),
+            workspace=workspace,
+            paired_event_type="run.dispatch.requested",
+        )
+        run_journal.append_event(
+            _journal_path(run_dir),
+            run_id=_RUN_ID,
+            event_type="run.dispatch.requested",
+            payload={"detail": "dispatching"},
+            idempotency_key="dispatch-req-1",
+            expected_previous_sequence=1,
+            recorded_at="2026-07-27T15:30:46.000000Z",
+        )
+    _write_lock_owner(workspace, run_dir, pid=99999999)
+    (run_dir / "run.json").unlink()
+
+    rc = runs_cmd.recover(str(run_dir), cwd=workspace)
+
+    assert rc == 0
+    recovered = json.loads((run_dir / "run.json").read_text())
+    assert recovered["status"] == "failed"
+    assert recovered["failure_phase"] == "stale-lock-recovery"
+    # Restoration and terminalization field preservation.
+    assert recovered["task"] == "inspect"
+    assert recovered["orchestrator"] == "chef"
+    assert recovered["cwd"] == str(workspace)
+    assert recovered["active_seats"] == ["coder"]
+    assert recovered["duration_seconds"] == 5
+    assert recovered["failure"]["prior_status"] == "dispatching"
+    assert f"recovered: {run_dir}" in capsys.readouterr().out
+
+
+def test_runs_recover_fails_closed_on_uncovered_tail_wrong_event_type(tmp_path, capsys):
+    """CLI recovery fails closed when the N+1 event_type is not the checkpoint's pair.
+
+    A checkpoint at N with ``paired_event_type`` set, followed by an N+1
+    event whose ``event_type`` is not the paired type, is an uncovered tail.
+    Recovery exits 2, restores no run.json, and the runguard claim is
+    restored (lock dir remains).
+    """
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    run_json_obj = {"status": "planning", "task": "demo", "cwd": str(workspace)}
+    runs_dir = run_dir.parent
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    run_dir.mkdir(parents=True, exist_ok=True)
+    _localio().write_json(
+        run_dir / "run.json",
+        {"schema": "brigade.run.v1", **run_json_obj, "lifecycle_journal_requested": True},
+    )
+    with runguard.run_lock(workspace, run_dir=run_dir):
+        run_lifecycle.prepare_lifecycle_journal(run_dir, workspace=workspace)
+        run_checkpoint.write_checkpoint(
+            run_dir,
+            _writer_bytes(run_json_obj),
+            workspace=workspace,
+            paired_event_type="run.planning.started",
+        )
+        run_journal.append_event(
+            _journal_path(run_dir),
+            run_id=_RUN_ID,
+            event_type="run.dispatch.requested",
+            payload={"detail": "dispatching"},
+            idempotency_key="dispatch-1",
+            expected_previous_sequence=1,
+            recorded_at="2026-07-27T15:30:46.000000Z",
+        )
+    _write_lock_owner(workspace, run_dir, pid=99999999)
+    (run_dir / "run.json").unlink()
+    lock_path = workspace / ".brigade" / "run.lock"
+
+    rc = runs_cmd.recover(str(run_dir), cwd=workspace)
+
+    assert rc == 2
+    assert not (run_dir / "run.json").exists()
+    assert lock_path.is_dir()
+
+
+def test_runs_recover_fails_closed_on_uncovered_tail_with_parseable_run_json(tmp_path, capsys):
+    """An uncovered tail fails closed even when run.json is parseable; run.json is untouched."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    run_json_obj = {"status": "planning", "task": "demo", "cwd": str(workspace)}
+    runs_dir = run_dir.parent
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    run_dir.mkdir(parents=True, exist_ok=True)
+    _localio().write_json(
+        run_dir / "run.json",
+        {"schema": "brigade.run.v1", **run_json_obj, "lifecycle_journal_requested": True},
+    )
+    with runguard.run_lock(workspace, run_dir=run_dir):
+        run_lifecycle.prepare_lifecycle_journal(run_dir, workspace=workspace)
+        run_checkpoint.write_checkpoint(
+            run_dir,
+            _writer_bytes(run_json_obj),
+            workspace=workspace,
+            paired_event_type="run.planning.started",
+        )
+        run_journal.append_event(
+            _journal_path(run_dir),
+            run_id=_RUN_ID,
+            event_type="run.dispatch.requested",
+            payload={"detail": "dispatching"},
+            idempotency_key="dispatch-1",
+            expected_previous_sequence=1,
+            recorded_at="2026-07-27T15:30:46.000000Z",
+        )
+    _write_lock_owner(workspace, run_dir, pid=99999999)
+    parseable = {"schema": "brigade.run.v1", "status": "planning", "task": "different", "cwd": str(workspace)}
+    _write_json(run_dir / "run.json", parseable)
+    before = (run_dir / "run.json").read_bytes()
+    lock_path = workspace / ".brigade" / "run.lock"
+
+    rc = runs_cmd.recover(str(run_dir), cwd=workspace)
+
+    assert rc == 2
+    assert (run_dir / "run.json").read_bytes() == before
+    assert lock_path.is_dir()
+    assert not list(run_dir.glob("run.json.corrupt-*"))
+
+
+def test_runs_recover_fails_closed_on_chain_break(tmp_path, capsys):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    run_json_obj = {"status": "planning", "task": "demo", "cwd": str(workspace)}
+    _activate_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    (run_dir / "run.json").unlink()
+    journal = _journal_path(run_dir)
+    events = _events(run_dir)
+    env = events[0].to_dict()
+    env["sequence"] = 3
+    env["event_digest"] = run_events.compute_event_digest(env)
+    env["event_id"] = run_events.make_event_id(
+        run_id=env["run_id"], sequence=env["sequence"], event_digest=env["event_digest"]
+    )
+    journal.write_bytes(run_events.canonical_bytes(env) + b"\n")
+
+    rc = runs_cmd.recover(str(run_dir), cwd=workspace)
+
+    assert rc == 2
+    assert not (run_dir / "run.json").exists()
+
+
+def test_runs_recover_fails_closed_on_envelope_run_id_mismatch(tmp_path, capsys):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    run_json_obj = {"status": "planning", "task": "demo", "cwd": str(workspace)}
+    _activate_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    (run_dir / "run.json").unlink()
+    journal = _journal_path(run_dir)
+    events = _events(run_dir)
+    env = events[0].to_dict()
+    env["run_id"] = "a-different-run-id"
+    env["event_digest"] = run_events.compute_event_digest(env)
+    env["event_id"] = run_events.make_event_id(
+        run_id=env["run_id"], sequence=env["sequence"], event_digest=env["event_digest"]
+    )
+    journal.write_bytes(run_events.canonical_bytes(env) + b"\n")
+
+    rc = runs_cmd.recover(str(run_dir), cwd=workspace)
+
+    assert rc == 2
+    assert not (run_dir / "run.json").exists()
+
+
+def test_runs_recover_refuses_live_owner_without_mutation_activated(tmp_path, capsys):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    run_json_obj = {"status": "planning", "task": "demo", "cwd": str(workspace)}
+    _activate_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    # Replace the dead owner with the current live pid.
+    _overwrite_lock_owner(workspace, run_dir, pid=os.getpid())
+    before = (run_dir / "run.json").read_bytes()
+    lock_path = workspace / ".brigade" / "run.lock"
+
+    rc = runs_cmd.recover(str(run_dir), cwd=workspace)
+
+    assert rc == 2
+    assert (run_dir / "run.json").read_bytes() == before
+    assert lock_path.is_dir()
+    assert "run owner process is still active" in capsys.readouterr().err
+
+
+def test_runs_recover_refuses_foreign_pid_without_mutation_activated(tmp_path, capsys):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    run_json_obj = {"status": "planning", "task": "demo", "cwd": str(workspace)}
+    _activate_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    other_run = workspace / ".brigade" / "runs" / "other-run"
+    _overwrite_lock_owner(workspace, other_run, pid=99999999)
+    before = (run_dir / "run.json").read_bytes()
+    lock_path = workspace / ".brigade" / "run.lock"
+
+    rc = runs_cmd.recover(str(run_dir), cwd=workspace)
+
+    assert rc == 2
+    assert (run_dir / "run.json").read_bytes() == before
+    assert lock_path.is_dir()
+    assert "run lock belongs to a different run" in capsys.readouterr().err
+
+
+def test_runs_recover_refuses_invalid_lock_without_mutation(tmp_path, capsys):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    run_json_obj = {"status": "planning", "task": "demo", "cwd": str(workspace)}
+    _activate_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    # Corrupt the lock: remove owner.json so run_lock_state returns "invalid".
+    lock_path = workspace / ".brigade" / "run.lock"
+    (lock_path / "owner.json").unlink()
+    before = (run_dir / "run.json").read_bytes()
+
+    rc = runs_cmd.recover(str(run_dir), cwd=workspace)
+
+    assert rc == 2
+    assert (run_dir / "run.json").read_bytes() == before
+    assert lock_path.is_dir()
+
+
+def test_runs_recover_terminal_run_with_activated_journal_unchanged(tmp_path, capsys):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    run_json_obj = {"status": "planning", "task": "demo", "cwd": str(workspace)}
+    _activate_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    # Mark the run terminal with a stale-lock-recovery failure phase.
+    run_meta = json.loads((run_dir / "run.json").read_text())
+    run_meta.update(
+        {
+            "status": "failed",
+            "failure_phase": "stale-lock-recovery",
+            "finished_at": "2026-07-27T15:31:00Z",
+            "failure": {
+                "phase": "stale-lock-recovery",
+                "kind": "owner-process-exited",
+                "detail": "run owner process 99999999 is no longer active",
+            },
+        }
+    )
+    _write_json(run_dir / "run.json", run_meta)
+
+    rc = runs_cmd.recover(str(run_dir), cwd=workspace)
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert f"already terminal: {run_dir} [failed]" in out
+
+
+def test_runs_recover_no_journal_legacy_dead_owner_marks_terminal(tmp_path, capsys):
+    # A nonterminal run with a dead matching lock but NO activated journal
+    # keeps the legacy recovery path (no checkpoint callback).
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / "legacy"
+    _write_minimal_run(
+        run_dir,
+        task="legacy task",
+        status="dispatching",
+        started_at="2026-07-16T00:00:00Z",
+    )
+    run_meta = json.loads((run_dir / "run.json").read_text())
+    run_meta["cwd"] = str(workspace)
+    _write_json(run_dir / "run.json", run_meta)
+    _write_lock_owner(workspace, run_dir)
+
+    rc = runs_cmd.recover(str(run_dir), cwd=workspace)
+
+    assert rc == 0
+    assert json.loads((run_dir / "run.json").read_text())["status"] == "failed"
+    assert f"recovered: {run_dir}" in capsys.readouterr().out
+
+
+# -- Issue #568 slice 5 Task 5 sendback: bounded checkpoint reason surfacing --
+
+
+def test_runs_recover_invalid_checkpoint_surfaces_bounded_reason_and_preserves_lock(tmp_path, capsys):
+    """Invalid checkpoint recovery surfaces the bounded checkpoint reason.
+
+    runguard wraps every ``before_terminalize`` callback exception into a
+    ``RunLockError`` after restoring the claimed lock, so
+    ``_recover_from_checkpoint`` cannot catch ``CheckpointError`` directly.
+    It must preserve the original bounded ``CheckpointError`` in a local holder,
+    catch the ``RunLockError``, and print the stored checkpoint diagnostic
+    while still returning exit 2 and leaving the lock restored.
+    """
+    import hashlib
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    run_json_obj = {"status": "planning", "task": "demo", "cwd": str(workspace)}
+    _activate_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    (run_dir / "run.json").unlink()
+    sha = hashlib.sha256(_writer_bytes(run_json_obj)).hexdigest()
+    cp_file = run_checkpoint.checkpoint_path(run_dir, sha)
+    cp_file.write_bytes(b"x" * len(_writer_bytes(run_json_obj)))
+    os.chmod(cp_file, 0o600)
+    lock_path = workspace / ".brigade" / "run.lock"
+
+    rc = runs_cmd.recover(str(run_dir), cwd=workspace)
+
+    assert rc == 2
+    assert not (run_dir / "run.json").exists()
+    # The dead lock is restored (callback failed; lock restored by runguard).
+    assert lock_path.is_dir()
+    # The specific bounded checkpoint reason is surfaced to stderr, not the
+    # generic runguard "before_terminalize callback failed" wrapper.
+    err = capsys.readouterr().err
+    assert "checkpoint digest mismatch" in err
+    assert "before_terminalize callback failed" not in err
+
+
+# -- Issue #568 slice 5 Task 5 second sendback: run.json input edges --
+
+
+def test_runs_recover_preserves_non_utf8_run_json_and_restores_from_checkpoint(tmp_path, capsys):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    run_json_obj = {"status": "planning", "task": "demo task", "cwd": str(workspace)}
+    _activate_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    corrupt_bytes = b"\xff\xfe not utf-8"
+    (run_dir / "run.json").write_bytes(corrupt_bytes)
+
+    rc = runs_cmd.recover(str(run_dir), cwd=workspace)
+
+    assert rc == 0
+    recovered = json.loads((run_dir / "run.json").read_text())
+    assert recovered["status"] == "failed"
+    assert recovered["task"] == "demo task"
+    preserved = list(run_dir.glob("run.json.corrupt-*"))
+    assert len(preserved) == 1
+    assert preserved[0].read_bytes() == corrupt_bytes
+    assert f"recovered: {run_dir}" in capsys.readouterr().out
+
+
+def test_runs_recover_preserves_recursion_error_run_json_and_restores_from_checkpoint(tmp_path, capsys):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    run_json_obj = {"status": "planning", "task": "demo task", "cwd": str(workspace)}
+    _activate_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    depth = 20000
+    deep_json = ("[" * depth) + ("]" * depth)
+    (run_dir / "run.json").write_text(deep_json)
+
+    rc = runs_cmd.recover(str(run_dir), cwd=workspace)
+
+    assert rc == 0
+    recovered = json.loads((run_dir / "run.json").read_text())
+    assert recovered["status"] == "failed"
+    assert recovered["task"] == "demo task"
+    preserved = list(run_dir.glob("run.json.corrupt-*"))
+    assert len(preserved) == 1
+    assert preserved[0].read_text() == deep_json
+    assert f"recovered: {run_dir}" in capsys.readouterr().out
+
+
+def test_runs_recover_run_json_read_oserror_exits_without_mutation(tmp_path, capsys, monkeypatch):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / _RUN_ID
+    run_json_obj = {"status": "planning", "task": "demo", "cwd": str(workspace)}
+    _activate_journal_with_checkpoint(workspace, run_dir, run_json_obj)
+    run_json = run_dir / "run.json"
+    before_run_json = run_json.read_bytes()
+    lock_path = workspace / ".brigade" / "run.lock"
+    lock_pid_before = (lock_path / "pid").read_text()
+    lock_owner_before = (lock_path / "owner.json").read_text()
+
+    real_read_text = Path.read_text
+
+    def fail_read_text(self, *args, **kwargs):
+        if self == run_json:
+            raise OSError(errno.EACCES, "read denied")
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", fail_read_text)
+
+    rc = runs_cmd.recover(str(run_dir), cwd=workspace)
+
+    assert rc == 2
+    assert run_json.read_bytes() == before_run_json
+    assert lock_path.is_dir()
+    assert (lock_path / "pid").read_text() == lock_pid_before
+    assert (lock_path / "owner.json").read_text() == lock_owner_before
+    assert "could not read run.json" in capsys.readouterr().err


### PR DESCRIPTION
Part of #568.

## Summary

- Publish content-addressed checkpoints before lifecycle status events and the atomic `run.json` replacement.
- Retain the run lock when lifecycle activation publishes recovery state but the initial receipt write fails.
- Require bounded N/N+1 checkpoint coverage before stale-run recovery, with exact claimed-lock restoration on every validation failure.
- Recover a matching persistent stale claim without mutating a foreign or invalid current lock.
- Share stale-lock receipt construction between runtime recovery and Doctor reconstruction.
- Add a read-only Doctor check for repairable and unsafe recovery states across the 50 newest run directories.

## Why

The lifecycle journal proves event ordering, but it cannot restore the canonical run record after an interrupted write by itself. Activated journals now fail closed unless checkpoint validation proves a safe recovery path. Legacy runs without an activated journal keep their existing behavior.

## Verification

- `./scripts/verify`
- Ruff lint and format passed.
- Mypy passed across 333 source files.
- 5,126 tests passed, 3 skipped, with 83.03% coverage.
- Brigade receipt: `20260730-050126-work-verify-2ab7e1`
- Independent Brigade review: `20260730-045649-2637de6b`, ready with no actionable findings.

## Review focus

- Checkpoint and status tail coverage at sequences N and N+1.
- Lock retention after partial initial lifecycle publication.
- Persistent stale-claim recovery while preserving a different current lock.
- Shared stale-lock receipt construction and provenance parity.
- Exact stale-lock restoration when validation or terminalization fails.
- Doctor reconstruction of terminal recovery receipts without filesystem mutation.
