### PR TITLE
chore: BrigadeClaw contributor connectivity check

### DIFF
--- a/CONNECTIVITY-CHECK.md
+++ b/CONNECTIVITY-CHECK.md
@@ -1,0 +1,5 @@
+BrigadeClaw contributor connectivity check.
+
+Opened by the @brigadeclaw account to prove it can push to its own fork and
+open a pull request upstream. It holds no write access to escoffier-labs/brigade
+and cannot merge. Close this; nothing here is meant to land.


### PR DESCRIPTION
Connectivity check for the BrigadeClaw contributor path. @solomonneas

Proves the intended shape works end to end:
- commit authored by the `brigadeclaw` account, from its own fork
- opened as a pull request, because the account has no write access here
- cannot merge this itself, by absence of a grant rather than by a rule

Nothing in this branch is meant to land. Close it.