### PR TITLE
docs: fix three relative links that 404 on the rendered pages

### DIFF
--- a/docs/roadmap-archive.md
+++ b/docs/roadmap-archive.md
@@ -419,6 +419,6 @@ The workspace on top of the bones:
 
 Status: foundation queue cleared.
 
-The detailed working queue for phases 61-100 lives in [`docs/phase-61-100-plan.md`](docs/phase-61-100-plan.md). That queue now serves as completion evidence for the foundation hardening pass: roadmap audit precision, deferred-item ownership, command documentation contracts, cross-producer provenance, privacy regression coverage, chat export hardening, backup and tool closeouts, context and learning receipts, security report compatibility, issue/TDD repair imports, memory and handoff hardening, release evidence schemas, operator-center schemas, fleet release reports, CI platform warnings, install smoke receipts, public template privacy, and local operator readiness closeout.
+The detailed working queue for phases 61-100 lives in [`docs/phase-61-100-plan.md`](phase-61-100-plan.md). That queue now serves as completion evidence for the foundation hardening pass: roadmap audit precision, deferred-item ownership, command documentation contracts, cross-producer provenance, privacy regression coverage, chat export hardening, backup and tool closeouts, context and learning receipts, security report compatibility, issue/TDD repair imports, memory and handoff hardening, release evidence schemas, operator-center schemas, fleet release reports, CI platform warnings, install smoke receipts, public template privacy, and local operator readiness closeout.
 
-Closed roadmap items move to [`docs/roadmap-archive.md`](docs/roadmap-archive.md) so this file stays focused on current direction.
+Closed roadmap items move to [`docs/roadmap-archive.md`](roadmap-archive.md) so this file stays focused on current direction.

--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -1378,7 +1378,7 @@ Re-running `brigade init` against an existing target is safe.
 It refuses to overwrite tracked files without `--force`.
 The managed `.gitignore` block is replaced between its markers without touching the rest of your file.
 
-See [QUICKSTART.md](QUICKSTART.md) for setup, verification, and the ingest flow.
+See [QUICKSTART.md](../QUICKSTART.md) for setup, verification, and the ingest flow.
 
 ## Managed stations
 


### PR DESCRIPTION
Found by the doc-freshness sweep. Links inside `docs/` were written repo-root-relative, so GitHub resolves them against `docs/` and they 404 on the rendered pages:

- `docs/roadmap-archive.md` L422: `docs/phase-61-100-plan.md` -> `phase-61-100-plan.md`
- `docs/roadmap-archive.md` L424: `docs/roadmap-archive.md` -> `roadmap-archive.md`
- `docs/technical-guide.md` L1381: `QUICKSTART.md` -> `../QUICKSTART.md`

All three corrected targets exist in the tree; no prose changes. @solomonneas