### PR TITLE
fix(run): harden journal durability

### DIFF
--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -2738,14 +2738,23 @@ def record_run_start(
     existing_authority_requested = False
     if run_json_exists:
         try:
-            existing = json.loads(run_json.read_text())
-        except (OSError, json.JSONDecodeError):
-            existing = None
-        if isinstance(existing, dict):
-            if existing.get("lifecycle_journal_requested") is True:
-                existing_lifecycle_requested = True
-            if existing.get(_AUTHORITY_REQUEST_FIELD) is True:
-                existing_authority_requested = True
+            existing = json.loads(run_json.read_text(encoding="utf-8"))
+        except (UnicodeDecodeError, ValueError, RecursionError) as exc:
+            raise runguard.RetainRunLockError(
+                "existing run.json is unreadable as JSON; refusing to overwrite unknown durable enrollment state"
+            ) from exc
+        except OSError as exc:
+            raise runguard.RetainRunLockError(
+                "failed to read existing run.json; refusing to overwrite unknown durable enrollment state"
+            ) from exc
+        if not isinstance(existing, dict):
+            raise runguard.RetainRunLockError(
+                "existing run.json is not a JSON object; refusing to overwrite unknown durable enrollment state"
+            )
+        if existing.get("lifecycle_journal_requested") is True:
+            existing_lifecycle_requested = True
+        if existing.get(_AUTHORITY_REQUEST_FIELD) is True:
+            existing_authority_requested = True
     # A new run enrolls in lifecycle journaling when the lifecycle-journal flag
     # is set OR when the authority opt-in is set: BRIGADE_RUN_JOURNAL_AUTHORITY=1
     # implies lifecycle journaling even when BRIGADE_LIFECYCLE_JOURNAL is unset,

--- a/src/brigade/run_journal.py
+++ b/src/brigade/run_journal.py
@@ -34,7 +34,10 @@ import errno
 import hashlib
 import json
 import os
+import signal
 import stat
+import threading
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterator
@@ -56,6 +59,81 @@ if _HAS_O_NOFOLLOW:
     _OPEN_FLAGS |= _O_NOFOLLOW
 _READ_CHUNK = 65536
 _MAX_QUARANTINE_ATTEMPTS = 16
+
+# SIGTERM deferral plus a process-wide lock around the append critical section.
+# ``signal.pthread_sigmask`` is thread-local, so deferral alone cannot stop a
+# main-thread handler from appending from a stale tail while a worker thread is
+# mid-append. A process lock guards the full read-check-build-write-fsync window;
+# it is acquired inside ``_defer_sigterm`` so the lock is released before the
+# prior signal mask is restored. On hosts without ``pthread_sigmask`` (or without
+# ``SIG_BLOCK``/``SIG_SETMASK``) deferral is a no-op and same-thread recursive
+# entry is rejected with a bounded error instead of deadlocking on the lock.
+_HAS_PTHREAD_SIGMASK = (
+    hasattr(signal, "pthread_sigmask") and hasattr(signal, "SIG_BLOCK") and hasattr(signal, "SIG_SETMASK")
+)
+_DEFERRED_SIGNALS = frozenset({signal.SIGTERM}) if _HAS_PTHREAD_SIGMASK else frozenset()
+_APPEND_LOCK = threading.Lock()
+_APPEND_TLS = threading.local()
+
+
+@contextmanager
+def _defer_sigterm() -> Iterator[None]:
+    """Defer SIGTERM delivery around a critical section.
+
+    Blocks SIGTERM via ``pthread_sigmask(SIG_BLOCK, ...)`` on entry and restores
+    the exact prior signal mask in ``finally`` on every exit (normal return,
+    exception, or early return inside the block). A SIGTERM delivered while the
+    mask is in place stays pending and fires only after the prior mask is
+    restored, so a handler cannot run between tail derivation and durable
+    completion. On hosts without ``pthread_sigmask`` (or without
+    ``SIG_BLOCK``/``SIG_SETMASK``) this is a no-op and never fails at import or
+    runtime.
+    """
+    if not _HAS_PTHREAD_SIGMASK:
+        yield
+        return
+    try:
+        prior = signal.pthread_sigmask(signal.SIG_BLOCK, _DEFERRED_SIGNALS)
+    except OSError as exc:
+        raise RunJournalError(_bound("SIGTERM mask block failed")) from exc
+    primary: BaseException | None = None
+    try:
+        yield
+    except BaseException as exc:
+        primary = exc
+        raise
+    finally:
+        try:
+            signal.pthread_sigmask(signal.SIG_SETMASK, prior)
+        except OSError as exc:
+            if primary is None:
+                raise RunJournalError(_bound("SIGTERM mask restoration failed")) from exc
+
+
+@contextmanager
+def _append_critical_section() -> Iterator[None]:
+    """Process-wide append guard with per-thread SIGTERM deferral.
+
+    ``pthread_sigmask`` is thread-local: a worker inside ``append_event`` does
+    not block SIGTERM delivery to the main thread, so a handler can recurse
+    into ``append_event`` from a stale tail unless the full read-check-build-
+    write-fsync window is also guarded by a process lock. The lock is acquired
+    inside ``_defer_sigterm`` so it is released before the prior signal mask is
+    restored; a pending main-thread SIGTERM then runs only after the lock is
+    free. On hosts without ``pthread_sigmask``, same-thread recursive entry is
+    rejected with a bounded error instead of deadlocking on the lock.
+    """
+    with _defer_sigterm():
+        if not _HAS_PTHREAD_SIGMASK:
+            if getattr(_APPEND_TLS, "in_append", False):
+                raise RunJournalError(_bound("recursive append during signal delivery"))
+            _APPEND_TLS.in_append = True
+        try:
+            with _APPEND_LOCK:
+                yield
+        finally:
+            if not _HAS_PTHREAD_SIGMASK:
+                _APPEND_TLS.in_append = False
 
 
 class RunJournalError(RuntimeError):
@@ -198,6 +276,67 @@ def _chmod_fd_or_path(fd: int, path: Path, mode: int) -> None:
     os.chmod(path, mode)
 
 
+def _close_guarded(fd: int, primary: RunJournalError | None) -> RunJournalError | None:
+    """Close ``fd``, translating an ``OSError`` into a bounded ``RunJournalError``.
+
+    Returns the error to raise (or ``None``). A close failure never masks a
+    prior ``primary`` failure: when ``primary`` is set it is returned
+    unchanged and the close error is suppressed; when ``primary`` is ``None``
+    a new bounded ``RunJournalError`` is returned.
+    """
+    close_err: RunJournalError | None = None
+    try:
+        os.close(fd)
+    except OSError:
+        if primary is None:
+            close_err = RunJournalError(_bound("journal close failed"))
+    return primary if primary is not None else close_err
+
+
+def _supports_directory_fsync() -> bool:
+    return os.name == "posix"
+
+
+def _fsync_directory(path: Path) -> None:
+    """Open ``path`` no-follow as a directory, fsync the descriptor, then close.
+
+    The directory is opened via ``_open_nofollow`` with ``O_RDONLY |
+    O_DIRECTORY`` so a raced-in symlink or non-directory inode is rejected
+    before any fsync occurs. The opened descriptor is ``fstat``-ed and required
+    to be a directory, then ``fsync``-ed. Raises ``RunJournalError`` on any
+    ``OSError`` from open, fstat, fsync, or close; a close failure is
+    suppressed when an earlier open/fstat/fsync failure already raised.
+    """
+    if not _supports_directory_fsync():
+        return
+    dir_flags = os.O_RDONLY | _O_DIRECTORY if _HAS_O_DIRECTORY else os.O_RDONLY
+    try:
+        fd = _open_nofollow(path, dir_flags)
+    except RunJournalError:
+        raise
+    except OSError as exc:
+        raise RunJournalError(_bound("journal directory fsync failed")) from exc
+    primary: RunJournalError | None = None
+    try:
+        try:
+            info = os.fstat(fd)
+        except OSError as exc:
+            raise RunJournalError(_bound("journal directory fsync failed")) from exc
+        if not stat.S_ISDIR(info.st_mode):
+            raise RunJournalError(_bound("journal directory fsync failed"))
+        try:
+            os.fsync(fd)
+        except OSError as exc:
+            raise RunJournalError(_bound("journal directory fsync failed")) from exc
+    except RunJournalError as exc:
+        primary = exc
+        raise
+    finally:
+        close_err = _close_guarded(fd, primary)
+        if close_err is not None and primary is None:
+            raise close_err
+
+
 def _open_nofollow(path: Path, flags: int, mode: int = 0o666) -> int:
     """Open a path without following a symlinked final component.
 
@@ -324,11 +463,16 @@ def ensure_journal(journal_path: Path) -> None:
     inode identity verification, and path ``chmod``.
     """
     journal_path = Path(journal_path)
-    _mkdir_private(journal_path.parent)
+    events_dir = journal_path.parent
+    _mkdir_private(events_dir)
+    created = False
     if not journal_path.exists():
         fd = _open_nofollow(journal_path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, _FILE_MODE)
         os.close(fd)
+        created = True
     _enforce_file_mode(journal_path)
+    if created:
+        _fsync_directory(events_dir)
 
 
 class _DuplicateKeyError(ValueError):
@@ -389,8 +533,8 @@ def _parse_canonical_line(line: bytes) -> dict[str, Any]:
 
 def _read_tail_state(
     journal_path: Path,
-) -> tuple[int, str | None, dict[str, dict[str, Any]], bytes | None]:
-    """Return (last_sequence, last_event_digest, idempotency_index, partial_tail).
+) -> tuple[int, str | None, dict[str, dict[str, Any]], bytes | None, int]:
+    """Return (last_sequence, last_event_digest, idempotency_index, partial_tail, journal_bytes).
 
     Fail closed: every complete line must be a validated canonical envelope
     (see ``_parse_canonical_line``) continuing a strict, gap-free,
@@ -403,23 +547,58 @@ def _read_tail_state(
     newline is returned as ``partial_tail`` so the append path can refuse to
     write over it (appending over a partial tail would glue the new line to
     the partial bytes and corrupt the journal).
+
+    Applies the same ``MAX_JOURNAL_BYTES`` and ``MAX_JOURNAL_EVENTS`` bounds
+    as ``read_journal_bounded``: refuses oversize journals via ``fstat`` before
+    allocation, reads in bounded chunks, and fails closed when complete-record
+    or sequence limits are exceeded.
     """
+    from brigade.run_checkpoint import MAX_JOURNAL_BYTES, MAX_JOURNAL_EVENTS
+
     last_sequence = 0
     last_digest: str | None = None
     index: dict[str, dict[str, Any]] = {}
     partial_tail: bytes | None = None
+    journal_bytes = 0
     if os.path.lexists(journal_path) and not journal_path.exists():
         raise RunJournalError(_bound(f"journal path is a dangling symlink: {journal_path.name}"))
     if not journal_path.exists():
-        return last_sequence, last_digest, index, partial_tail
-    raw = _read_bytes_nofollow(journal_path)
-    segments = raw.split(b"\n")
+        return last_sequence, last_digest, index, partial_tail, journal_bytes
+
+    fd = _open_nofollow(journal_path, os.O_RDONLY)
+    try:
+        info = os.fstat(fd)
+        if info.st_size > MAX_JOURNAL_BYTES:
+            raise RunJournalError(_bound("bound exceeded: journal above MAX_JOURNAL_BYTES"))
+        if not stat.S_ISREG(info.st_mode):
+            raise RunJournalError(_bound(f"journal path is not a regular file: {journal_path.name}"))
+
+        raw = bytearray()
+        while True:
+            chunk = os.read(fd, _READ_CHUNK)
+            if not chunk:
+                break
+            raw.extend(chunk)
+            if len(raw) > MAX_JOURNAL_BYTES:
+                raise RunJournalError(_bound("bound exceeded: journal above MAX_JOURNAL_BYTES"))
+        raw_bytes = bytes(raw)
+    finally:
+        os.close(fd)
+
+    journal_bytes = len(raw_bytes)
+    segments = raw_bytes.split(b"\n")
     # A non-empty final segment after the last newline is a partial tail.
     if segments[-1]:
         partial_tail = segments[-1]
+    complete_count = 0
     for line in segments[:-1]:
+        complete_count += 1
+        if complete_count > MAX_JOURNAL_EVENTS:
+            raise RunJournalError(_bound("bound exceeded: journal complete records above MAX_JOURNAL_EVENTS"))
         env = _parse_canonical_line(line)
         sequence = env["sequence"]
+        if sequence > MAX_JOURNAL_EVENTS:
+            raise RunJournalError(_bound("bound exceeded: journal event sequence above MAX_JOURNAL_EVENTS"))
         if sequence != last_sequence + 1:
             raise ChainIntegrityError(_bound(f"journal sequence break: expected {last_sequence + 1}, got {sequence}"))
         if sequence > 1 and env["previous_digest"] != last_digest:
@@ -430,7 +609,7 @@ def _read_tail_state(
         index[key] = env
         last_sequence = sequence
         last_digest = env["event_digest"]
-    return last_sequence, last_digest, index, partial_tail
+    return last_sequence, last_digest, index, partial_tail, journal_bytes
 
 
 def _envelope_to_event(env: dict[str, Any]) -> RunEvent:
@@ -487,58 +666,66 @@ def append_event(
 
     rd = run_events.request_digest(event_type=event_type, payload=payload, idempotency_key=idempotency_key)
 
-    last_sequence, last_digest, index, partial_tail = _read_tail_state(journal_path)
+    with _append_critical_section():
+        last_sequence, last_digest, index, partial_tail, journal_bytes = _read_tail_state(journal_path)
 
-    if partial_tail is not None:
-        raise PartialTailError(_bound("journal ends in a partial line; run recover_partial_tail before appending"))
+        if partial_tail is not None:
+            raise PartialTailError(_bound("journal ends in a partial line; run recover_partial_tail before appending"))
 
-    existing = index.get(idempotency_key)
-    if existing is not None:
-        existing_rd = existing.get("request_digest")
-        if not isinstance(existing_rd, str):
-            raise ChainIntegrityError(_bound("indexed journal event is missing request_digest"))
-        if existing_rd == rd:
-            return _envelope_to_event(existing)
-        existing_event_id = existing.get("event_id")
-        if not isinstance(existing_event_id, str):
-            raise ChainIntegrityError(_bound("indexed journal event is missing event_id"))
-        raise IdempotencyConflict(
-            _bound(f"idempotency key {idempotency_key!r} conflict"),
-            existing_event_id=existing_event_id,
-            request_digest=rd,
-            existing_request_digest=existing_rd,
+        existing = index.get(idempotency_key)
+        if existing is not None:
+            existing_rd = existing.get("request_digest")
+            if not isinstance(existing_rd, str):
+                raise ChainIntegrityError(_bound("indexed journal event is missing request_digest"))
+            if existing_rd == rd:
+                return _envelope_to_event(existing)
+            existing_event_id = existing.get("event_id")
+            if not isinstance(existing_event_id, str):
+                raise ChainIntegrityError(_bound("indexed journal event is missing event_id"))
+            raise IdempotencyConflict(
+                _bound(f"idempotency key {idempotency_key!r} conflict"),
+                existing_event_id=existing_event_id,
+                request_digest=rd,
+                existing_request_digest=existing_rd,
+            )
+
+        if expected_previous_sequence != last_sequence:
+            raise StaleSequenceError(
+                _bound(f"stale sequence: expected previous {expected_previous_sequence}, actual {last_sequence}")
+            )
+
+        sequence = last_sequence + 1
+        envelope = run_events.build_event(
+            run_id=run_id,
+            sequence=sequence,
+            event_type=event_type,
+            payload=payload,
+            idempotency_key=idempotency_key,
+            recorded_at=recorded_at,
+            previous_digest=last_digest,
+            request_digest_value=rd,
         )
 
-    if expected_previous_sequence != last_sequence:
-        raise StaleSequenceError(
-            _bound(f"stale sequence: expected previous {expected_previous_sequence}, actual {last_sequence}")
-        )
+        line = canonical_bytes(envelope) + b"\n"
+        if len(line) > run_events.MAX_LINE_BYTES:
+            raise CanonicalizationError(_bound(f"canonical line exceeds {run_events.MAX_LINE_BYTES} bytes"))
 
-    sequence = last_sequence + 1
-    envelope = run_events.build_event(
-        run_id=run_id,
-        sequence=sequence,
-        event_type=event_type,
-        payload=payload,
-        idempotency_key=idempotency_key,
-        recorded_at=recorded_at,
-        previous_digest=last_digest,
-        request_digest_value=rd,
-    )
+        from brigade.run_checkpoint import MAX_JOURNAL_BYTES, MAX_JOURNAL_EVENTS
 
-    line = canonical_bytes(envelope) + b"\n"
-    if len(line) > run_events.MAX_LINE_BYTES:
-        raise CanonicalizationError(_bound(f"canonical line exceeds {run_events.MAX_LINE_BYTES} bytes"))
+        if sequence > MAX_JOURNAL_EVENTS:
+            raise RunJournalError(_bound("bound exceeded: journal event sequence above MAX_JOURNAL_EVENTS"))
+        if journal_bytes + len(line) > MAX_JOURNAL_BYTES:
+            raise RunJournalError(_bound("bound exceeded: journal above MAX_JOURNAL_BYTES"))
 
-    fd = _open_nofollow(journal_path, _OPEN_FLAGS, _FILE_MODE)
-    try:
-        _chmod_fd_or_path(fd, journal_path, _FILE_MODE)
-        written = os.write(fd, line)
-        if written != len(line):
-            raise PartialWriteError(_bound(f"partial write: wrote {written} of {len(line)} bytes"))
-        os.fsync(fd)
-    finally:
-        os.close(fd)
+        fd = _open_nofollow(journal_path, _OPEN_FLAGS, _FILE_MODE)
+        try:
+            _chmod_fd_or_path(fd, journal_path, _FILE_MODE)
+            written = os.write(fd, line)
+            if written != len(line):
+                raise PartialWriteError(_bound(f"partial write: wrote {written} of {len(line)} bytes"))
+            os.fsync(fd)
+        finally:
+            os.close(fd)
 
     return _envelope_to_event(envelope)
 
@@ -742,6 +929,8 @@ def recover_partial_tail(journal_path: Path, quarantine_dir: Path) -> RecoveryRe
         break
     if quarantine_path is None:
         raise RunJournalError(_bound("no collision-free quarantine name available"))
+
+    _fsync_directory(quarantine_dir)
 
     jfd = _open_nofollow(journal_path, os.O_RDWR)
     try:

--- a/src/brigade/run_shadow.py
+++ b/src/brigade/run_shadow.py
@@ -85,18 +85,46 @@ def _valid_counter(value: object) -> bool:
 def _has_invalid_counters(data: object) -> bool:
     """True when a current-v3 artifact carries an untrustworthy counter.
 
-    Only ``comparisons``, ``mismatches``, and ``errors`` feed the readiness
-    gate and the carry accumulator; a bool, negative, or non-int value for
-    any of the three is structurally broken and must fail closed as
+    ``_record_outcome`` accumulates ``comparisons``, ``matches``,
+    ``mismatches``, ``lags``, and ``errors``. A bool, negative, or non-int
+    value for any of the five is structurally broken and must fail closed as
     evidence-unreadable rather than be carried forward.
     """
     if not isinstance(data, dict):
         return True
     return not (
         _valid_counter(data.get("comparisons"))
+        and _valid_counter(data.get("matches"))
         and _valid_counter(data.get("mismatches"))
+        and _valid_counter(data.get("lags"))
         and _valid_counter(data.get("errors"))
     )
+
+
+def _has_invalid_recent_records(data: object) -> bool:
+    """True when ``recent_records`` is not a list of record-shaped mappings.
+
+    ``_record_outcome`` indexes the tail entry and calls ``.get`` on
+    ``sequence``, ``shadow_digest``, ``projected_digest``, ``outcome``, and
+    ``category``; a dict, string, or list containing non-mappings must be
+    rejected before any indexing or appending.
+    """
+    if not isinstance(data, dict):
+        return True
+    recent = data.get("recent_records")
+    if not isinstance(recent, list):
+        return True
+    return any(not isinstance(entry, Mapping) for entry in recent)
+
+
+def _has_invalid_artifact_structure(data: object) -> bool:
+    """True when a current-v3 artifact is structurally untrustworthy.
+
+    Invalid gated counters and malformed ``recent_records`` both close the
+    carry path: quarantine the prior, start a fresh artifact, and record an
+    evidence-unreadable side record before the requested outcome.
+    """
+    return _has_invalid_counters(data) or _has_invalid_recent_records(data)
 
 
 def shadow_artifact_path(run_dir: Path) -> Path:
@@ -190,14 +218,24 @@ def _verify_stale_baseline(
 
 
 def _load_prior_artifact(artifact_path: Path) -> tuple[dict[str, Any] | None, bool]:
-    """Return (parsed artifact, was_corrupt). Absent -> (None, False)."""
+    """Return (parsed artifact, was_corrupt). Absent -> (None, False).
+
+    A parseable but non-object JSON payload (list, string, number, etc.) is
+    rejected before any caller can call ``.get`` on it: the file is quarantined
+    aside and reported as corrupt so the carry path starts fresh with an
+    evidence-unreadable side record instead of raising ``AttributeError``.
+    """
     if not artifact_path.is_file():
         return None, False
     try:
-        return json.loads(artifact_path.read_text()), False
+        parsed = json.loads(artifact_path.read_text())
     except (OSError, ValueError):
         _quarantine_corrupt(artifact_path)
         return None, True
+    if not isinstance(parsed, dict):
+        _quarantine_corrupt(artifact_path)
+        return None, True
+    return parsed, False
 
 
 def _write_artifact(run_dir: Path, data: dict[str, Any]) -> None:
@@ -327,7 +365,7 @@ def _record_outcome(
     differing_fields: list[str],
 ) -> None:
     prior, was_corrupt = _load_prior_artifact(shadow_artifact_path(run_dir))
-    invalid_counters = False
+    structurally_invalid = False
     if prior is None or was_corrupt:
         data = _empty_artifact(run_id)
     else:
@@ -359,17 +397,16 @@ def _record_outcome(
             # Current-version artifact: counters and records only accumulate,
             # never reset (mismatches/errors from a current-v3 artifact are
             # preserved across later comparisons). A current-v3 artifact with
-            # an invalid counter (bool, negative, or non-int for comparisons,
-            # mismatches, or errors) is structurally broken and must not be
+            # invalid counters (bool, negative, or non-int for comparisons,
+            # matches, mismatches, lags, or errors) or malformed
+            # ``recent_records`` is structurally broken and must not be
             # trusted: quarantine it aside, start a fresh artifact, and record
-            # an evidence-unreadable side record so the invalid counters never
-            # flow into the accumulators (a forged False must not satisfy
-            # ``== 0`` and a negative comparisons must not bypass the
-            # no-comparisons gate once re-read).
-            if _has_invalid_counters(prior):
+            # an evidence-unreadable side record so the invalid state never
+            # flows into the accumulators.
+            if _has_invalid_artifact_structure(prior):
                 _quarantine_corrupt(shadow_artifact_path(run_dir))
                 data = _empty_artifact(run_id)
-                invalid_counters = True
+                structurally_invalid = True
             else:
                 data = prior
     key = (tail_seq, shadow_digest, projected_digest, outcome, category)
@@ -387,10 +424,10 @@ def _record_outcome(
             return  # idempotent: same tail sequence, digests, outcome, and category
     # A present-but-unparseable prior artifact is quarantined and treated as
     # absent; record an evidence-unreadable error before the main record. A
-    # current-v3 prior with invalid counters is treated the same way: the
-    # forged counters are dropped and an evidence-unreadable side record
-    # explains the fresh start.
-    if was_corrupt or invalid_counters:
+    # current-v3 prior with invalid structure is treated the same way: forged
+    # counters or malformed recent_records are dropped and an
+    # evidence-unreadable side record explains the fresh start.
+    if was_corrupt or structurally_invalid:
         _append_evidence_unreadable(data, tail_seq, tail_digest)
     # Comparison-gap defense: if the journal tail advanced by more than one
     # since the last recorded comparison, a committed transition's shadow
@@ -636,15 +673,12 @@ def check_projection_readiness(run_dir: Path) -> ReadinessReport:
             or data.get("run_id") != run_dir.name
         ):
             return ReadinessReport(ready=False, reasons=(REASON_EVIDENCE_SCHEMA_MISMATCH,))
-        # Strict counter validation: a current-v3 artifact accepts only
-        # non-bool nonnegative ints for comparisons, mismatches, and errors.
-        # A bool (``True``/``False``), negative, or non-int counter is
-        # structurally broken and closes the gate as evidence-unreadable
-        # BEFORE the no-comparisons or mismatch/error branches can misread it
-        # (``False`` must not satisfy ``== 0``; ``True`` must not satisfy a
-        # truthy mismatch/error check; a negative comparisons must not bypass
-        # the no-comparisons gate).
-        if _has_invalid_counters(data):
+        # Strict structure validation: a current-v3 artifact accepts only
+        # non-bool nonnegative counters and a list of mapping-shaped recent
+        # records. A forged counter or malformed/missing ``recent_records``
+        # is structurally broken and closes the gate as evidence-unreadable
+        # BEFORE the no-comparisons or mismatch/error branches can misread it.
+        if _has_invalid_artifact_structure(data):
             return ReadinessReport(ready=False, reasons=(REASON_EVIDENCE_UNREADABLE,))
         if not isinstance(data.get("comparisons"), int) or data["comparisons"] < 1:
             return ReadinessReport(ready=False, reasons=(REASON_NO_COMPARISONS,))

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -5626,3 +5626,197 @@ def test_run_preserves_authority_enrollment_through_first_follow_up_receipt_rewr
     # still true and no projection metadata has been published yet, so
     # _resolve_authority_state classifies it as authority-requested.
     assert aboyeur._resolve_authority_state(output_dir) == "authority-requested"
+
+
+# -- Issue #568 slice 7 assignment 3: durable enrollment fail-closed ------------
+
+_CORRUPT_RUN_JSON_CASES = [
+    pytest.param(
+        "{not valid json",
+        id="invalid-json",
+    ),
+    pytest.param(
+        '{"schema": "brigade.run.v1", "status": "start',
+        id="truncated-json",
+    ),
+    pytest.param(
+        '["not", "an", "object"]',
+        id="non-object-json",
+    ),
+    pytest.param(
+        '"a bare json string"',
+        id="non-object-json-string",
+    ),
+    pytest.param(
+        None,
+        id="read-oserror",
+    ),
+]
+
+
+def _corrupt_run_dir(tmp_path: Path) -> tuple[Path, Path]:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    run_dir = workspace / ".brigade" / "runs" / "20260730-123000-deadbeef"
+    run_dir.mkdir(parents=True)
+    return workspace, run_dir
+
+
+@pytest.mark.parametrize("corrupt_content", _CORRUPT_RUN_JSON_CASES)
+def test_record_run_start_retains_lock_on_corrupt_existing_run_json(tmp_path, monkeypatch, corrupt_content):
+    """Issue #568 slice 7 assignment 3: an existing run.json that exists but
+    cannot be read and parsed as a dict carries unknown durable enrollment
+    state. Environment flags cannot infer that state. record_run_start must
+    raise runguard.RetainRunLockError BEFORE rewriting run.json, preserve the
+    readable original bytes on disk, and must not create roster.json. The
+    diagnostic must be bounded and must not echo corrupt content.
+    """
+    workspace, run_dir = _corrupt_run_dir(tmp_path)
+
+    if corrupt_content is None:
+        # Simulate a read OSError (e.g. permission denied) on run.json only.
+        original_read_text = Path.read_text
+        written_bytes = '{"schema": "brigade.run.v1"}'
+        (run_dir / "run.json").write_text(written_bytes)
+        original_bytes = written_bytes
+
+        def failing_read_text(self, *args, **kwargs):
+            if self == run_dir / "run.json":
+                raise OSError("permission denied")
+            return original_read_text(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", failing_read_text)
+    else:
+        (run_dir / "run.json").write_text(corrupt_content)
+        original_bytes = corrupt_content
+
+    # Environment flags are set to prove they cannot infer unknown durable
+    # state and rescue a corrupt run.json.
+    monkeypatch.setenv("BRIGADE_LIFECYCLE_JOURNAL", "1")
+    monkeypatch.setenv("BRIGADE_RUN_JOURNAL_AUTHORITY", "1")
+
+    with pytest.raises(runguard.RetainRunLockError):
+        with runguard.run_lock(workspace, run_dir=run_dir):
+            aboyeur.record_run_start(
+                run_dir,
+                task="resume run",
+                cwd=workspace,
+                roster=_roster(),
+                read_only=False,
+                lock_workspace=workspace,
+            )
+
+    # The readable original bytes are preserved on disk (no overwrite). Use
+    # read_bytes (never patched) so the read-oserror case still verifies.
+    assert (run_dir / "run.json").read_bytes().decode() == original_bytes
+
+    # roster.json must not have been created: the run never enrolled.
+    assert not (run_dir / "roster.json").exists()
+
+    # The lock is retained (not released) so recovery can intervene.
+    assert runguard.lock_path(workspace).is_dir()
+
+
+def test_record_run_start_retains_lock_on_invalid_utf8_existing_run_json(tmp_path, monkeypatch):
+    """Invalid UTF-8 leaves durable enrollment unknown and must fail closed."""
+    workspace, run_dir = _corrupt_run_dir(tmp_path)
+    original_bytes = b'{"schema":"brigade.run.v1","lifecycle_journal_requested":true}\xff'
+    (run_dir / "run.json").write_bytes(original_bytes)
+
+    # Neither environment flag may replace the unreadable durable state with
+    # inferred enrollment during a re-record attempt.
+    monkeypatch.setenv("BRIGADE_LIFECYCLE_JOURNAL", "1")
+    monkeypatch.setenv("BRIGADE_RUN_JOURNAL_AUTHORITY", "1")
+
+    with pytest.raises(
+        runguard.RetainRunLockError,
+        match=("existing run.json is unreadable as JSON; refusing to overwrite unknown durable enrollment state"),
+    ):
+        with runguard.run_lock(workspace, run_dir=run_dir):
+            aboyeur.record_run_start(
+                run_dir,
+                task="resume run",
+                cwd=workspace,
+                roster=_roster(),
+                read_only=False,
+                lock_workspace=workspace,
+            )
+
+    assert (run_dir / "run.json").read_bytes() == original_bytes
+    assert not (run_dir / "roster.json").exists()
+    assert runguard.lock_path(workspace).is_dir()
+
+
+@pytest.mark.parametrize(
+    "parse_error",
+    [
+        pytest.param(ValueError, id="value-error"),
+        pytest.param(RecursionError, id="recursion-error"),
+    ],
+)
+def test_record_run_start_retains_lock_on_other_json_parse_failures(tmp_path, monkeypatch, parse_error):
+    """Parser limits and recursion failures leave enrollment unknown too.
+
+    Monkeypatching keeps this independent of JSON parser limits that differ
+    across supported Python versions.
+    """
+    workspace, run_dir = _corrupt_run_dir(tmp_path)
+    original_bytes = b'{"schema":"brigade.run.v1","lifecycle_journal_requested":true}\n'
+    (run_dir / "run.json").write_bytes(original_bytes)
+
+    def failing_loads(*args, **kwargs):
+        raise parse_error("synthetic JSON parser failure")
+
+    monkeypatch.setattr(aboyeur.json, "loads", failing_loads)
+    monkeypatch.setenv("BRIGADE_LIFECYCLE_JOURNAL", "1")
+    monkeypatch.setenv("BRIGADE_RUN_JOURNAL_AUTHORITY", "1")
+
+    with pytest.raises(
+        runguard.RetainRunLockError,
+        match=("existing run.json is unreadable as JSON; refusing to overwrite unknown durable enrollment state"),
+    ):
+        with runguard.run_lock(workspace, run_dir=run_dir):
+            aboyeur.record_run_start(
+                run_dir,
+                task="resume run",
+                cwd=workspace,
+                roster=_roster(),
+                read_only=False,
+                lock_workspace=workspace,
+            )
+
+    assert (run_dir / "run.json").read_bytes() == original_bytes
+    assert not (run_dir / "roster.json").exists()
+    assert runguard.lock_path(workspace).is_dir()
+
+
+def test_record_run_start_preserves_valid_legacy_existing_run_enrollment(tmp_path, monkeypatch):
+    """Control: a valid existing legacy run.json object (no durable opt-in
+    fields) is still treated as unenrolled, but record_run_start must NOT
+    raise. It rewrites run.json preserving the no-later-opt-in behavior: no
+    lifecycle_journal_requested, no run_journal_authority_requested, and no
+    roster.json durable enrollment flip from environment flags alone on an
+    existing run. This is the existing legacy-object control kept green.
+    """
+    workspace, run_dir = _corrupt_run_dir(tmp_path)
+    (run_dir / "run.json").write_text(json.dumps(_legacy_status_payload("started")))
+
+    # Environment flags are set, but an existing run never enrolls from
+    # environment changes alone.
+    monkeypatch.setenv("BRIGADE_LIFECYCLE_JOURNAL", "1")
+    monkeypatch.setenv("BRIGADE_RUN_JOURNAL_AUTHORITY", "1")
+
+    with runguard.run_lock(workspace, run_dir=run_dir):
+        aboyeur.record_run_start(
+            run_dir,
+            task="legacy run",
+            cwd=workspace,
+            roster=_roster(),
+            read_only=False,
+            lock_workspace=workspace,
+        )
+
+    receipt = json.loads((run_dir / "run.json").read_text())
+    assert _LIFECYCLE_REQUEST_FIELD not in receipt
+    assert _AUTHORITY_REQUEST_FIELD not in receipt
+    assert (run_dir / "roster.json").is_file()

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -2033,7 +2033,7 @@ def test_doctor_invalid_recovered_at_iso_is_fail(tmp_path: Path):
 
 def test_doctor_513_events_fail_bound_exceeded_without_checkpoint_parsing(tmp_path: Path, monkeypatch):
     """513 valid chained complete events must FAIL bound exceeded, no checkpoint parse."""
-    from brigade import run_checkpoint, run_journal, run_lifecycle, runguard
+    from brigade import run_checkpoint, run_events, run_lifecycle
 
     workspace = tmp_path / "workspace"
     workspace.mkdir()
@@ -2044,25 +2044,27 @@ def test_doctor_513_events_fail_bound_exceeded_without_checkpoint_parsing(tmp_pa
         run_dir / "run.json",
         {"schema": "brigade.run.v1", "status": "planning", "cwd": str(workspace), "task": "demo"},
     )
-    with runguard.run_lock(workspace, run_dir=run_dir):
-        run_lifecycle.prepare_lifecycle_journal(run_dir, workspace=workspace)
-        journal = run_lifecycle._journal_path(run_dir)
-        prev_seq = 0
+    journal = run_lifecycle._journal_path(run_dir)
+    journal.parent.mkdir(parents=True, exist_ok=True)
+    previous_digest: str | None = None
+    with journal.open("ab") as handle:
         for index in range(513):
-            appended = run_journal.append_event(
-                journal,
+            env = run_events.build_event(
                 run_id=_RUN_ID,
+                sequence=index + 1,
                 event_type="run.planning.started",
                 payload={"detail": f"step-{index}"},
                 idempotency_key=f"progress-{index}",
-                expected_previous_sequence=prev_seq,
+                recorded_at="2026-07-27T15:30:45.000000Z",
+                previous_digest=previous_digest,
             )
-            prev_seq = appended.sequence
+            handle.write(run_events.canonical_bytes(env) + b"\n")
+            previous_digest = env["event_digest"]
 
     monkeypatch.setattr(
         run_checkpoint,
-        "recover_from_checkpoint",
-        lambda *_a, **_kw: (_ for _ in ()).throw(AssertionError("recover_from_checkpoint")),
+        "validate_checkpoint",
+        lambda *_a, **_kw: (_ for _ in ()).throw(AssertionError("validate_checkpoint")),
     )
 
     status, _name, detail = _recovery_check(workspace)

--- a/tests/test_run_checkpoint.py
+++ b/tests/test_run_checkpoint.py
@@ -9,8 +9,12 @@ import errno
 import hashlib
 import json
 import os
+import signal
 import stat
+import subprocess
+import sys
 import tempfile
+import time
 from pathlib import Path
 
 import pytest
@@ -2986,3 +2990,150 @@ def test_recover_from_checkpoint_base_stripped_projection_failure_is_bounded(tmp
     assert isinstance(excinfo.value.__cause__, run_projector.ProjectionError)
     # No restore, no fallback to the earlier legacy-full checkpoint.
     assert not (run_dir / "run.json").exists()
+
+
+# -- Issue #568 slice 7 assignment 6: localio.write_text_atomic SIGKILL crash window --
+
+
+_CHILD_WRITE_ATOMIC_CRASH_SCRIPT = """
+import sys
+from pathlib import Path
+
+from brigade import localio
+
+target = Path(sys.argv[1])
+ready = Path(sys.argv[2])
+new_text = Path(sys.argv[3]).read_text(encoding="utf-8")
+
+ready.write_text("ready", encoding="utf-8")
+while True:
+    localio.write_text_atomic(target, new_text)
+"""
+
+
+def _write_text_atomic_temp_paths(run_dir: Path, target_name: str = "run.json") -> list[Path]:
+    prefix = f".{target_name}."
+    return sorted(
+        path
+        for path in run_dir.iterdir()
+        if path.is_file() and path.name.startswith(prefix) and path.name.endswith(".tmp")
+    )
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX SIGKILL crash window requires os.kill")
+def test_write_text_atomic_sigkill_during_temp_window_preserves_one_valid_payload(tmp_path):
+    """A real SIGKILL during the temp-file window leaves one valid run.json.
+
+    Exercises ``localio.write_text_atomic`` (write -> fsync -> replace) in a child
+    subprocess without monkeypatching ``os.write``, ``os.fsync``, ``os.replace``,
+    ``tempfile``, or ``localio``. A successful attempt must leave the real
+    ``.run.json.*.tmp`` sibling after the killed child is reaped. That proves
+    ``SIGKILL`` landed before ``os.replace`` or exception cleanup could remove
+    the temp file. Fresh-directory retries keep the scheduling stress bounded.
+    """
+    old_obj = {
+        "schema": "brigade.run.v1",
+        "status": "planning",
+        "task": "crash-window",
+        "run_id": RUN_ID,
+    }
+    old_bytes = _writer_bytes(old_obj)
+
+    new_obj = {
+        "schema": "brigade.run.v1",
+        "status": "running",
+        "task": "crash-window",
+        "run_id": RUN_ID,
+        "padding": "x" * (2 * 1024 * 1024),
+    }
+    new_bytes = _writer_bytes(new_obj)
+    new_text_path = tmp_path / "new_payload.json"
+    new_text_path.write_bytes(new_bytes)
+
+    repo_root = Path(__file__).resolve().parents[1]
+    child_env = os.environ.copy()
+    child_env["PYTHONPATH"] = str(repo_root / "src")
+
+    successful_leftovers: list[str] = []
+    attempt_diagnostics: list[str] = []
+    attempt_run_dirs: list[Path] = []
+    for attempt in range(1, 6):
+        run_dir = _run_dir(tmp_path / f"attempt-{attempt}")
+        attempt_run_dirs.append(run_dir)
+        target = run_dir / "run.json"
+        target.write_bytes(old_bytes)
+        ready_path = run_dir / "child.ready"
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                _CHILD_WRITE_ATOMIC_CRASH_SCRIPT,
+                str(target),
+                str(ready_path),
+                str(new_text_path),
+            ],
+            env=child_env,
+        )
+        try:
+            ready_deadline = time.monotonic() + 2
+            while not ready_path.is_file():
+                if proc.poll() is not None:
+                    pytest.fail(f"child exited before signaling ready: returncode={proc.returncode}")
+                if time.monotonic() >= ready_deadline:
+                    pytest.fail("timed out waiting for child ready signal")
+                time.sleep(0.001)
+
+            temp_observed = False
+            kill_deadline = time.monotonic() + 2
+            while time.monotonic() < kill_deadline:
+                if proc.poll() is not None:
+                    break
+                if _write_text_atomic_temp_paths(run_dir):
+                    temp_observed = True
+                    os.kill(proc.pid, signal.SIGKILL)
+                    break
+                time.sleep(0.001)
+            if not temp_observed and proc.poll() is None:
+                os.kill(proc.pid, signal.SIGKILL)
+
+            try:
+                proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=2)
+                pytest.fail("child did not exit after SIGKILL")
+
+            assert proc.returncode == -signal.SIGKILL, (
+                f"expected SIGKILL exit (-{signal.SIGKILL}), got {proc.returncode}"
+            )
+
+            assert target.is_file(), "authoritative run.json disappeared after crash"
+            actual = target.read_bytes()
+            assert actual in (old_bytes, new_bytes), (
+                "run.json bytes are neither the complete old payload nor the complete new payload"
+            )
+            parsed = json.loads(actual.decode("utf-8"))
+            assert parsed["schema"] == "brigade.run.v1"
+            assert parsed["task"] == "crash-window"
+            assert parsed["run_id"] == RUN_ID
+            assert parsed["status"] in ("planning", "running")
+
+            leftovers = _write_text_atomic_temp_paths(run_dir)
+            attempt_diagnostics.append(
+                f"attempt={attempt} observed={temp_observed} leftovers={[path.name for path in leftovers]!r}"
+            )
+            if leftovers:
+                successful_leftovers = [path.name for path in leftovers]
+                break
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
+            for leftover in _write_text_atomic_temp_paths(run_dir):
+                leftover.unlink()
+
+    assert successful_leftovers, (
+        f"SIGKILL never left a crash-window temp file after child reaping; attempts={attempt_diagnostics!r}"
+    )
+    for run_dir in attempt_run_dirs:
+        assert _write_text_atomic_temp_paths(run_dir) == []

--- a/tests/test_run_journal.py
+++ b/tests/test_run_journal.py
@@ -6,7 +6,10 @@ import errno
 import hashlib
 import json
 import os
+import signal
 import stat
+import subprocess
+import sys
 from copy import deepcopy
 from pathlib import Path
 
@@ -910,15 +913,14 @@ def test_fallback_open_nofollow_closes_fd_when_verify_identity_raises(tmp_path, 
     assert excinfo.value.errno == errno.EBADF
 
 
-def test_fallback_enforce_dir_mode_skips_open_without_o_directory(tmp_path, monkeypatch):
+def test_fallback_enforce_dir_mode_corrects_via_lstat_without_o_directory(tmp_path, monkeypatch):
     _disable_posix_open_guards(monkeypatch)
-    journal_path = _journal_path(_run_dir(tmp_path))
-    events_dir = journal_path.parent
+    events_dir = _journal_path(_run_dir(tmp_path)).parent
     real_open = os.open
 
     def guard_open(path, flags, mode=0o777, *, dir_fd=None):
         if Path(path) == events_dir:
-            raise AssertionError("os.open must not be called for the events directory without O_DIRECTORY")
+            raise AssertionError("directory mode fallback must not open the events directory")
         if dir_fd is not None:
             return real_open(path, flags, mode, dir_fd=dir_fd)
         return real_open(path, flags, mode)
@@ -927,9 +929,8 @@ def test_fallback_enforce_dir_mode_skips_open_without_o_directory(tmp_path, monk
     events_dir.mkdir(parents=True, exist_ok=True)
     os.chmod(events_dir, 0o755)
 
-    run_journal.ensure_journal(journal_path)
+    run_journal._enforce_dir_mode(events_dir)
 
-    assert journal_path.is_file()
     assert stat.S_IMODE(events_dir.stat().st_mode) == 0o700
 
 
@@ -1115,3 +1116,798 @@ def test_read_journal_bounded_rejects_complete_record_513_even_with_repeated_seq
         run_journal.read_journal_bounded(journal_path)
 
     assert "bound exceeded" in excinfo.value.diagnostic
+
+
+# -- Slice 7 assignment 5: append-side bounds --------------------------------
+
+
+def _write_journal_events(journal_path: Path, count: int) -> dict:
+    """Write ``count`` canonical events directly (no append_event fsyncs)."""
+    journal_path.parent.mkdir(parents=True, exist_ok=True)
+    previous_digest: str | None = None
+    last_env: dict | None = None
+    with journal_path.open("ab") as handle:
+        for sequence in range(1, count + 1):
+            event_type = "run.planning.started" if sequence % 2 == 0 else "run.dispatch.observed"
+            payload = (
+                {"detail": "n"} if event_type == "run.planning.started" else {"seat": "c", "attempt": 1, "detail": "n"}
+            )
+            env = run_events.build_event(
+                run_id=RUN_ID,
+                sequence=sequence,
+                event_type=event_type,
+                payload=payload,
+                idempotency_key=f"ev-{sequence}",
+                recorded_at="2026-07-27T15:30:45.000000Z",
+                previous_digest=previous_digest,
+            )
+            handle.write(run_events.canonical_bytes(env) + b"\n")
+            previous_digest = env["event_digest"]
+            last_env = env
+    assert last_env is not None
+    return last_env
+
+
+def _tracking_write(monkeypatch) -> list[bytes]:
+    """Monkeypatch os.write and return a list that collects write payloads."""
+    original_write = os.write
+    write_calls: list[bytes] = []
+
+    def _record_write(fd, data):
+        write_calls.append(data)
+        return original_write(fd, data)
+
+    monkeypatch.setattr(os, "write", _record_write)
+    return write_calls
+
+
+def test_append_event_refuses_513th_distinct_event_before_write(tmp_path, monkeypatch):
+    journal_path = _journal_path(_run_dir(tmp_path))
+    _write_journal_events(journal_path, run_checkpoint.MAX_JOURNAL_EVENTS)
+    before = journal_path.read_bytes()
+    write_calls = _tracking_write(monkeypatch)
+
+    with pytest.raises(run_journal.RunJournalError) as excinfo:
+        run_journal.append_event(
+            journal_path,
+            run_id=RUN_ID,
+            event_type="run.created",
+            payload={"status": "started"},
+            idempotency_key="ev-513",
+            expected_previous_sequence=run_checkpoint.MAX_JOURNAL_EVENTS,
+            recorded_at="2026-07-27T15:30:50.000000Z",
+        )
+
+    assert "bound exceeded" in excinfo.value.diagnostic
+    assert not write_calls
+    assert journal_path.read_bytes() == before
+
+
+def test_append_event_refuses_growth_past_max_journal_bytes_before_write(tmp_path, monkeypatch):
+    journal_path = _journal_path(_run_dir(tmp_path))
+    _append_first_event(journal_path)
+    before = journal_path.read_bytes()
+    monkeypatch.setattr(run_checkpoint, "MAX_JOURNAL_BYTES", len(before) + 64)
+    write_calls = _tracking_write(monkeypatch)
+
+    with pytest.raises(run_journal.RunJournalError) as excinfo:
+        _append_second_event(journal_path)
+
+    assert excinfo.value.diagnostic == "bound exceeded: journal above MAX_JOURNAL_BYTES"
+    assert not write_calls
+    assert journal_path.read_bytes() == before
+
+
+def test_append_event_allows_idempotent_replay_of_512th_event_when_full(tmp_path, monkeypatch):
+    journal_path = _journal_path(_run_dir(tmp_path))
+    last_env = _write_journal_events(journal_path, run_checkpoint.MAX_JOURNAL_EVENTS)
+    before = journal_path.read_bytes()
+    write_calls = _tracking_write(monkeypatch)
+
+    replay = run_journal.append_event(
+        journal_path,
+        run_id=RUN_ID,
+        event_type=last_env["event_type"],
+        payload=dict(last_env["payload"]),
+        idempotency_key=last_env["idempotency_key"],
+        expected_previous_sequence=run_checkpoint.MAX_JOURNAL_EVENTS,
+        recorded_at=last_env["recorded_at"],
+    )
+
+    assert replay.sequence == run_checkpoint.MAX_JOURNAL_EVENTS
+    assert replay.event_id == last_env["event_id"]
+    assert not write_calls
+    assert journal_path.read_bytes() == before
+
+
+def test_append_event_allows_idempotent_replay_at_exact_byte_bound(tmp_path, monkeypatch):
+    journal_path = _journal_path(_run_dir(tmp_path))
+    existing = _append_first_event(journal_path)
+    before = journal_path.read_bytes()
+    monkeypatch.setattr(run_checkpoint, "MAX_JOURNAL_BYTES", len(before))
+    write_calls = _tracking_write(monkeypatch)
+
+    replay = _append_first_event(journal_path)
+
+    assert replay == existing
+    assert replay.request_digest == existing.request_digest
+    assert not write_calls
+    assert journal_path.read_bytes() == before
+
+
+def test_append_event_refuses_oversize_journal_consistent_with_read_journal_bounded(tmp_path, monkeypatch):
+    journal_path = _journal_path(_run_dir(tmp_path))
+    _append_first_event(journal_path)
+    padding = b"\n" * (run_checkpoint.MAX_JOURNAL_BYTES + 1024)
+    journal_path.write_bytes(journal_path.read_bytes() + padding)
+    before = journal_path.read_bytes()
+    write_calls = _tracking_write(monkeypatch)
+
+    with pytest.raises(run_journal.RunJournalError) as append_exc:
+        _append_second_event(journal_path)
+
+    with pytest.raises(run_journal.RunJournalError) as read_exc:
+        run_journal.read_journal_bounded(journal_path)
+
+    assert append_exc.value.diagnostic == read_exc.value.diagnostic
+    assert "bound exceeded" in append_exc.value.diagnostic
+    assert not write_calls
+    assert journal_path.read_bytes() == before
+
+
+def test_append_event_refuses_journal_with_513_complete_records_before_write(tmp_path, monkeypatch):
+    journal_path = _journal_path(_run_dir(tmp_path))
+    journal_path.parent.mkdir(parents=True, exist_ok=True)
+    previous_digest: str | None = None
+    with journal_path.open("ab") as handle:
+        for sequence in range(1, 514):
+            event_type = "run.planning.started" if sequence % 2 == 0 else "run.dispatch.observed"
+            payload = (
+                {"detail": "n"} if event_type == "run.planning.started" else {"seat": "c", "attempt": 1, "detail": "n"}
+            )
+            env = run_events.build_event(
+                run_id=RUN_ID,
+                sequence=sequence,
+                event_type=event_type,
+                payload=payload,
+                idempotency_key=f"ev-{sequence}",
+                recorded_at="2026-07-27T15:30:45.000000Z",
+                previous_digest=previous_digest,
+            )
+            handle.write(run_events.canonical_bytes(env) + b"\n")
+            previous_digest = env["event_digest"]
+    before = journal_path.read_bytes()
+    write_calls = _tracking_write(monkeypatch)
+
+    with pytest.raises(run_journal.RunJournalError) as append_exc:
+        run_journal.append_event(
+            journal_path,
+            run_id=RUN_ID,
+            event_type="run.created",
+            payload={"status": "started"},
+            idempotency_key="ev-new",
+            expected_previous_sequence=513,
+            recorded_at="2026-07-27T15:30:50.000000Z",
+        )
+
+    with pytest.raises(run_journal.RunJournalError) as read_exc:
+        run_journal.read_journal_bounded(journal_path)
+
+    assert append_exc.value.diagnostic == read_exc.value.diagnostic
+    assert "bound exceeded" in append_exc.value.diagnostic
+    assert not write_calls
+    assert journal_path.read_bytes() == before
+
+
+# -- Slice 7 assignment 1: signal atomicity ----------------------------------
+
+
+def _run_isolated_child(
+    script: str,
+    *args: str,
+    timeout: float = 5.0,
+) -> tuple[int, str, str]:
+    child_env = os.environ.copy()
+    child_env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
+    proc = subprocess.Popen(
+        [sys.executable, "-c", script, *args],
+        env=child_env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        stdout, stderr = proc.communicate(timeout=2.0)
+        pytest.fail(
+            f"isolated signal/lock child timed out and was killed and reaped\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        )
+    return proc.returncode, stdout, stderr
+
+
+def _install_fake_pthread_sigmask_api(monkeypatch) -> tuple[object, object]:
+    block_mode = object()
+    restore_mode = object()
+    monkeypatch.setattr(signal, "SIG_BLOCK", block_mode, raising=False)
+    monkeypatch.setattr(signal, "SIG_SETMASK", restore_mode, raising=False)
+    monkeypatch.setattr(run_journal, "_HAS_PTHREAD_SIGMASK", True)
+    monkeypatch.setattr(run_journal, "_DEFERRED_SIGNALS", frozenset({signal.SIGTERM}))
+    return block_mode, restore_mode
+
+
+def test_defer_sigterm_translates_mask_block_oserror(monkeypatch):
+    block_mode, _ = _install_fake_pthread_sigmask_api(monkeypatch)
+
+    def fail_block(how, _mask):
+        assert how is block_mode
+        raise OSError("block failed")
+
+    monkeypatch.setattr(signal, "pthread_sigmask", fail_block, raising=False)
+
+    with pytest.raises(run_journal.RunJournalError) as excinfo:
+        with run_journal._defer_sigterm():
+            pytest.fail("body must not run after mask block failure")
+
+    assert excinfo.value.diagnostic == "SIGTERM mask block failed"
+    assert isinstance(excinfo.value.__cause__, OSError)
+
+
+def test_defer_sigterm_translates_mask_restore_oserror(monkeypatch):
+    block_mode, restore_mode = _install_fake_pthread_sigmask_api(monkeypatch)
+    prior = {signal.SIGINT}
+
+    def fail_restore(how, _mask):
+        if how is block_mode:
+            return prior
+        assert how is restore_mode
+        raise OSError("restore failed")
+
+    monkeypatch.setattr(signal, "pthread_sigmask", fail_restore, raising=False)
+
+    with pytest.raises(run_journal.RunJournalError) as excinfo:
+        with run_journal._defer_sigterm():
+            pass
+
+    assert excinfo.value.diagnostic == "SIGTERM mask restoration failed"
+    assert isinstance(excinfo.value.__cause__, OSError)
+
+
+def test_defer_sigterm_restore_oserror_does_not_mask_primary_base_exception(monkeypatch):
+    block_mode, restore_mode = _install_fake_pthread_sigmask_api(monkeypatch)
+    primary = KeyboardInterrupt("primary body failure")
+
+    def fail_restore(how, _mask):
+        if how is block_mode:
+            return {signal.SIGINT}
+        assert how is restore_mode
+        raise OSError("restore failed")
+
+    monkeypatch.setattr(signal, "pthread_sigmask", fail_restore, raising=False)
+
+    with pytest.raises(KeyboardInterrupt) as excinfo:
+        with run_journal._defer_sigterm():
+            raise primary
+
+    assert excinfo.value is primary
+
+
+@pytest.mark.parametrize("body_raises", [False, True], ids=["success", "body-exception"])
+def test_append_critical_section_restores_exact_prior_signal_mask_in_subprocess(body_raises):
+    if not run_journal._HAS_PTHREAD_SIGMASK:
+        pytest.skip("signal.pthread_sigmask unavailable on this platform")
+
+    script = r"""
+import json
+import signal
+import sys
+from brigade import run_journal
+
+body_raises = sys.argv[1] == "true"
+seed_signal = signal.SIGUSR1 if hasattr(signal, "SIGUSR1") else signal.SIGINT
+original = signal.pthread_sigmask(signal.SIG_BLOCK, set())
+seeded = set(original)
+seeded.add(seed_signal)
+signal.pthread_sigmask(signal.SIG_SETMASK, seeded)
+
+class BodyFailure(BaseException):
+    pass
+
+caught = False
+try:
+    try:
+        with run_journal._append_critical_section():
+            inside = set(signal.pthread_sigmask(signal.SIG_BLOCK, set()))
+            if signal.SIGTERM not in inside:
+                raise RuntimeError("SIGTERM was not blocked inside critical section")
+            if not seeded.issubset(inside):
+                raise RuntimeError("seeded prior mask was not preserved inside critical section")
+            if body_raises:
+                raise BodyFailure()
+    except BodyFailure:
+        caught = True
+    restored = set(signal.pthread_sigmask(signal.SIG_BLOCK, set()))
+    print(json.dumps({
+        "caught": caught,
+        "restored_exactly": restored == seeded,
+        "seeded_nonempty": bool(seeded),
+    }))
+finally:
+    signal.pthread_sigmask(signal.SIG_SETMASK, original)
+"""
+    rc, stdout, stderr = _run_isolated_child(script, str(body_raises).lower())
+
+    assert rc == 0, f"child exited {rc}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    result = json.loads(stdout)
+    assert result == {
+        "caught": body_raises,
+        "restored_exactly": True,
+        "seeded_nonempty": True,
+    }
+
+
+def test_append_event_signal_deferral_prevents_duplicate_sequence_in_subprocess(tmp_path):
+    """A regression fails by child timeout instead of hanging the pytest process."""
+    if not run_journal._HAS_PTHREAD_SIGMASK:
+        pytest.skip("signal.pthread_sigmask unavailable on this platform")
+
+    script = r"""
+import json
+import os
+from pathlib import Path
+import signal
+import sys
+from brigade import run_journal
+
+journal_path = Path(sys.argv[1])
+run_id = "20260727-153045-a1b2c3d4"
+signal.pthread_sigmask(signal.SIG_UNBLOCK, {signal.SIGTERM})
+run_journal.append_event(
+    journal_path,
+    run_id=run_id,
+    event_type="run.created",
+    payload={"status": "started"},
+    idempotency_key="create-1",
+    expected_previous_sequence=0,
+    recorded_at="2026-07-27T15:30:45.123456Z",
+)
+
+handler_results = []
+def handler(_signum, _frame):
+    try:
+        run_journal.append_event(
+            journal_path,
+            run_id=run_id,
+            event_type="run.interrupted",
+            payload={"status": "interrupted", "detail": "sigterm"},
+            idempotency_key="term-1",
+            expected_previous_sequence=1,
+            recorded_at="2026-07-27T15:30:50.000000Z",
+        )
+        handler_results.append(["appended"])
+    except run_journal.StaleSequenceError as exc:
+        handler_results.append(["stale", exc.diagnostic])
+    except BaseException as exc:
+        handler_results.append(["error", type(exc).__name__, str(exc)])
+
+old_handler = signal.signal(signal.SIGTERM, handler)
+fired = False
+real_read_tail = run_journal._read_tail_state
+def tracking_read_tail(path):
+    global fired
+    result = real_read_tail(path)
+    if not fired:
+        fired = True
+        os.kill(os.getpid(), signal.SIGTERM)
+    return result
+run_journal._read_tail_state = tracking_read_tail
+
+try:
+    run_journal.append_event(
+        journal_path,
+        run_id=run_id,
+        event_type="run.planning.started",
+        payload={"detail": "planning"},
+        idempotency_key="plan-1",
+        expected_previous_sequence=1,
+        recorded_at="2026-07-27T15:30:46.000000Z",
+    )
+finally:
+    signal.signal(signal.SIGTERM, old_handler)
+
+report = run_journal.read_journal(journal_path)
+print(json.dumps({
+    "chain_errors": report.chain_errors,
+    "sequences": [event.sequence for event in report.events],
+    "handler_results": handler_results,
+}))
+"""
+    journal_path = _journal_path(_run_dir(tmp_path))
+    rc, stdout, stderr = _run_isolated_child(script, str(journal_path))
+
+    assert rc == 0, f"child exited {rc}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    result = json.loads(stdout)
+    assert result["chain_errors"] == []
+    assert result["sequences"] == [1, 2]
+    assert result["handler_results"]
+    assert result["handler_results"][0][0] == "stale"
+    assert result["handler_results"][0][1] == "stale sequence: expected previous 1, actual 2"
+
+
+def test_append_critical_section_rejects_same_thread_nested_entry_without_pthread_sigmask():
+    """Without pthread_sigmask, nested same-thread entry must fail fast, not deadlock."""
+    script = """
+from contextlib import contextmanager
+from brigade import run_journal
+
+run_journal._HAS_PTHREAD_SIGMASK = False
+
+@contextmanager
+def nested():
+    with run_journal._append_critical_section():
+        with run_journal._append_critical_section():
+            yield
+
+try:
+    with nested():
+        pass
+except run_journal.RunJournalError as exc:
+    if len(exc.diagnostic) > 240:
+        raise SystemExit(2)
+    if "recursive append" not in exc.diagnostic:
+        raise SystemExit(3)
+    raise SystemExit(0)
+raise SystemExit(1)
+"""
+    rc, stdout, stderr = _run_isolated_child(script, timeout=2.0)
+    assert rc == 0, f"child exited {rc}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+
+
+def test_append_event_process_lock_prevents_worker_main_sigterm_duplicate_in_subprocess(tmp_path):
+    """Worker-thread append holds the process lock while SIGTERM runs on the main
+    thread: the handler blocks until the worker finishes, then sees a fresh tail
+    and raises StaleSequenceError instead of duplicating sequence 2.
+    """
+    if not run_journal._HAS_PTHREAD_SIGMASK:
+        pytest.skip("signal.pthread_sigmask unavailable on this platform")
+
+    script = r"""
+import json
+import os
+from pathlib import Path
+import signal
+import sys
+import threading
+from brigade import run_journal
+
+journal_path = Path(sys.argv[1])
+run_id = "20260727-153045-a1b2c3d4"
+signal.pthread_sigmask(signal.SIG_UNBLOCK, {signal.SIGTERM})
+run_journal.append_event(
+    journal_path,
+    run_id=run_id,
+    event_type="run.created",
+    payload={"status": "started"},
+    idempotency_key="create-1",
+    expected_previous_sequence=0,
+    recorded_at="2026-07-27T15:30:45.123456Z",
+)
+
+handler_results = []
+handler_started = threading.Event()
+worker_past_tail = threading.Event()
+worker_done = threading.Event()
+worker_errors = []
+def handler(_signum, _frame):
+    handler_started.set()
+    try:
+        run_journal.append_event(
+            journal_path,
+            run_id=run_id,
+            event_type="run.interrupted",
+            payload={"status": "interrupted", "detail": "sigterm"},
+            idempotency_key="term-worker-1",
+            expected_previous_sequence=1,
+            recorded_at="2026-07-27T15:30:50.000000Z",
+        )
+        handler_results.append(["appended"])
+    except run_journal.StaleSequenceError as exc:
+        handler_results.append(["stale", exc.diagnostic])
+    except BaseException as exc:
+        handler_results.append(["error", type(exc).__name__, str(exc)])
+
+old_handler = signal.signal(signal.SIGTERM, handler)
+real_read_tail = run_journal._read_tail_state
+fired = False
+def tracking_read_tail(path):
+    global fired
+    result = real_read_tail(path)
+    if threading.current_thread().name == "append-worker" and not fired:
+        fired = True
+        worker_past_tail.set()
+        os.kill(os.getpid(), signal.SIGTERM)
+    return result
+run_journal._read_tail_state = tracking_read_tail
+
+def worker_append():
+    try:
+        run_journal.append_event(
+            journal_path,
+            run_id=run_id,
+            event_type="run.planning.started",
+            payload={"detail": "planning"},
+            idempotency_key="plan-1",
+            expected_previous_sequence=1,
+            recorded_at="2026-07-27T15:30:46.000000Z",
+        )
+    except BaseException as exc:
+        worker_errors.append([type(exc).__name__, str(exc)])
+    finally:
+        worker_done.set()
+
+worker = threading.Thread(target=worker_append, name="append-worker")
+worker.start()
+if not worker_past_tail.wait(timeout=2.0):
+    raise RuntimeError("worker did not reach tail read")
+worker.join(timeout=2.0)
+if worker.is_alive() or not worker_done.is_set():
+    raise RuntimeError("worker append did not finish")
+if not handler_started.wait(timeout=0.2):
+    raise RuntimeError("SIGTERM handler did not run")
+signal.signal(signal.SIGTERM, old_handler)
+
+report = run_journal.read_journal(journal_path)
+print(json.dumps({
+    "chain_errors": report.chain_errors,
+    "sequences": [event.sequence for event in report.events],
+    "handler_results": handler_results,
+    "worker_errors": worker_errors,
+}))
+"""
+    journal_path = _journal_path(_run_dir(tmp_path))
+    rc, stdout, stderr = _run_isolated_child(script, str(journal_path))
+
+    assert rc == 0, f"child exited {rc}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    result = json.loads(stdout)
+    assert result["worker_errors"] == []
+    assert result["chain_errors"] == []
+    assert result["sequences"] == [1, 2]
+    assert result["handler_results"]
+    assert result["handler_results"][0][0] == "stale"
+    assert result["handler_results"][0][1] == "stale sequence: expected previous 1, actual 2"
+
+
+def test_append_event_process_lock_serializes_workers_without_pthread_sigmask(tmp_path):
+    script = r"""
+import json
+from pathlib import Path
+import sys
+import threading
+from brigade import run_journal
+
+journal_path = Path(sys.argv[1])
+run_id = "20260727-153045-a1b2c3d4"
+run_journal.append_event(
+    journal_path,
+    run_id=run_id,
+    event_type="run.created",
+    payload={"status": "started"},
+    idempotency_key="create-1",
+    expected_previous_sequence=0,
+    recorded_at="2026-07-27T15:30:45.123456Z",
+)
+run_journal._HAS_PTHREAD_SIGMASK = False
+
+first_reached_tail = threading.Event()
+release_first = threading.Event()
+second_started = threading.Event()
+second_reached_tail = threading.Event()
+results = {}
+real_read_tail = run_journal._read_tail_state
+def tracking_read_tail(path):
+    result = real_read_tail(path)
+    name = threading.current_thread().name
+    if name == "first-worker":
+        first_reached_tail.set()
+        if not release_first.wait(timeout=2.0):
+            raise RuntimeError("first worker release timed out")
+    elif name == "second-worker":
+        second_reached_tail.set()
+    return result
+run_journal._read_tail_state = tracking_read_tail
+
+def append_from(name, key):
+    if name == "second":
+        second_started.set()
+    try:
+        event = run_journal.append_event(
+            journal_path,
+            run_id=run_id,
+            event_type="run.planning.started",
+            payload={"detail": name},
+            idempotency_key=key,
+            expected_previous_sequence=1,
+            recorded_at="2026-07-27T15:30:46.000000Z",
+        )
+        results[name] = ["appended", event.sequence]
+    except run_journal.StaleSequenceError as exc:
+        results[name] = ["stale", exc.diagnostic]
+    except BaseException as exc:
+        results[name] = ["error", type(exc).__name__, str(exc)]
+
+first = threading.Thread(target=append_from, args=("first", "plan-1"), name="first-worker")
+second = threading.Thread(target=append_from, args=("second", "plan-2"), name="second-worker")
+first.start()
+if not first_reached_tail.wait(timeout=1.0):
+    raise RuntimeError("first worker did not reach tail read")
+second.start()
+if not second_started.wait(timeout=1.0):
+    raise RuntimeError("second worker did not start")
+serialized = not second_reached_tail.wait(timeout=0.2)
+release_first.set()
+first.join(timeout=2.0)
+second.join(timeout=2.0)
+if first.is_alive() or second.is_alive():
+    raise RuntimeError("worker did not finish")
+
+report = run_journal.read_journal(journal_path)
+print(json.dumps({
+    "serialized": serialized,
+    "results": results,
+    "chain_errors": report.chain_errors,
+    "sequences": [event.sequence for event in report.events],
+}))
+"""
+    journal_path = _journal_path(_run_dir(tmp_path))
+    rc, stdout, stderr = _run_isolated_child(script, str(journal_path))
+
+    assert rc == 0, f"child exited {rc}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    result = json.loads(stdout)
+    assert result["serialized"] is True
+    assert result["results"]["first"] == ["appended", 2]
+    assert result["results"]["second"] == [
+        "stale",
+        "stale sequence: expected previous 1, actual 2",
+    ]
+    assert result["chain_errors"] == []
+    assert result["sequences"] == [1, 2]
+
+
+# -- Slice 7 assignment 2: journal directory durability ----------------------
+
+
+_POSIX_DIRECTORY_FSYNC_ONLY = pytest.mark.skipif(
+    os.name != "posix",
+    reason="directory fsync is intentionally a no-op off POSIX",
+)
+
+
+def _refers_to_directory(fd: int, directory: Path) -> bool:
+    try:
+        st = os.fstat(fd)
+        dir_st = directory.stat()
+    except OSError:
+        return False
+    return stat.S_ISDIR(st.st_mode) and st.st_ino == dir_st.st_ino and st.st_dev == dir_st.st_dev
+
+
+@_POSIX_DIRECTORY_FSYNC_ONLY
+def test_ensure_journal_directory_fsync_after_creating_lifecycle_file(tmp_path, monkeypatch):
+    journal_path = _journal_path(_run_dir(tmp_path))
+    events_dir = journal_path.parent
+
+    real_fsync = os.fsync
+    call_log: list[tuple[str, bool]] = []
+
+    def tracking_fsync(fd):
+        call_log.append(("fsync", _refers_to_directory(fd, events_dir)))
+        return real_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", tracking_fsync)
+
+    run_journal.ensure_journal(journal_path)
+
+    dir_fsyncs = [i for i, (kind, refers_events) in enumerate(call_log) if kind == "fsync" and refers_events]
+    assert dir_fsyncs, "events directory was not fsynced after creating lifecycle.jsonl"
+    assert journal_path.is_file()
+
+
+@_POSIX_DIRECTORY_FSYNC_ONLY
+def test_ensure_journal_skips_creation_directory_fsync_for_existing_journal(tmp_path, monkeypatch):
+    journal_path = _journal_path(_run_dir(tmp_path))
+    events_dir = journal_path.parent
+    run_journal.ensure_journal(journal_path)
+
+    real_fsync = os.fsync
+    call_log: list[tuple[str, bool]] = []
+
+    def tracking_fsync(fd):
+        call_log.append(("fsync", _refers_to_directory(fd, events_dir)))
+        return real_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", tracking_fsync)
+
+    run_journal.ensure_journal(journal_path)
+
+    dir_fsyncs = [i for i, (kind, refers_events) in enumerate(call_log) if kind == "fsync" and refers_events]
+    assert not dir_fsyncs, "existing journal must not trigger a creation directory fsync"
+
+
+@_POSIX_DIRECTORY_FSYNC_ONLY
+def test_recover_partial_tail_directory_fsyncs_quarantine_dir_before_truncating(tmp_path, monkeypatch):
+    journal_path = _journal_path(_run_dir(tmp_path))
+    _append_first_event(journal_path)
+    partial_suffix = b'{"schema":"brigade.run_event.v1","event_type":"run.plan'
+    journal_path.write_bytes(journal_path.read_bytes() + partial_suffix)
+    quarantine_dir = tmp_path / "quarantine"
+
+    real_fsync = os.fsync
+    real_ftruncate = os.ftruncate
+    call_log: list[tuple[str, bool | None]] = []
+
+    def tracking_fsync(fd):
+        call_log.append(("fsync", _refers_to_directory(fd, quarantine_dir)))
+        return real_fsync(fd)
+
+    def tracking_ftruncate(fd, length):
+        call_log.append(("ftruncate", None))
+        return real_ftruncate(fd, length)
+
+    monkeypatch.setattr(os, "fsync", tracking_fsync)
+    monkeypatch.setattr(os, "ftruncate", tracking_ftruncate)
+
+    run_journal.recover_partial_tail(journal_path, quarantine_dir)
+
+    truncate_indices = [i for i, (kind, _) in enumerate(call_log) if kind == "ftruncate"]
+    assert truncate_indices, "journal was never truncated"
+    first_truncate = truncate_indices[0]
+    quarantine_dir_fsyncs_before_truncate = [
+        i for i, (kind, refers_q) in enumerate(call_log) if kind == "fsync" and refers_q and i < first_truncate
+    ]
+    assert quarantine_dir_fsyncs_before_truncate, (
+        "quarantine directory was not fsynced after quarantine file close and before journal truncate"
+    )
+
+
+@_POSIX_DIRECTORY_FSYNC_ONLY
+def test_fsync_directory_refuses_symlink(tmp_path):
+    real_dir = tmp_path / "events"
+    real_dir.mkdir()
+    symlink = tmp_path / "events-link"
+    symlink.symlink_to(real_dir)
+
+    with pytest.raises(run_journal.RunJournalError):
+        run_journal._fsync_directory(symlink)
+
+
+@_POSIX_DIRECTORY_FSYNC_ONLY
+def test_fsync_directory_refuses_non_directory(tmp_path):
+    file_path = tmp_path / "lifecycle.jsonl"
+    file_path.write_bytes(b"")
+
+    with pytest.raises(run_journal.RunJournalError):
+        run_journal._fsync_directory(file_path)
+
+
+def test_fsync_directory_without_o_directory_opens_readonly_and_fsyncs(tmp_path, monkeypatch):
+    if os.name != "posix":
+        pytest.skip("POSIX directory fsync fallback is not exercised on this platform")
+
+    events_dir = tmp_path / "events"
+    events_dir.mkdir()
+    monkeypatch.setattr(run_journal, "_HAS_O_DIRECTORY", False)
+
+    real_fsync = os.fsync
+    fsynced: list[bool] = []
+
+    def tracking_fsync(fd):
+        fsynced.append(_refers_to_directory(fd, events_dir))
+        return real_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", tracking_fsync)
+
+    run_journal._fsync_directory(events_dir)
+
+    assert fsynced
+    assert fsynced[0]

--- a/tests/test_run_shadow.py
+++ b/tests/test_run_shadow.py
@@ -1798,6 +1798,11 @@ def _write_current_artifact(run_dir: Path, data: dict[str, object]) -> None:
     run_shadow.shadow_artifact_path(run_dir).write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
 
 
+# Sentinel distinguishing "delete the recent_records key" from a forged
+# ``None``/falsy value in readiness and carry-path regression tests.
+_ABSENT_RECENT_RECORDS = object()
+
+
 def _gate_artifact_ready(run_dir: Path) -> None:
     """Stand up an empty journal and a current artifact so the gate reaches the
     counter checks (past the no-journal, no-evidence, version, and schema doors)."""
@@ -1896,6 +1901,40 @@ def test_gate_accepts_zero_mismatches_and_zero_errors_as_valid(tmp_path):
     assert REASON_NO_COMPARISONS not in report.reasons
 
 
+@pytest.mark.parametrize(
+    "malformed_recent_records",
+    [
+        pytest.param(_ABSENT_RECENT_RECORDS, id="absent"),
+        pytest.param("not-a-list", id="string"),
+        pytest.param({"outcome": "match"}, id="mapping"),
+        pytest.param(["not-a-record"], id="list_non_mapping"),
+    ],
+)
+def test_gate_rejects_malformed_recent_records_as_evidence_unreadable(enabled, tmp_path, malformed_recent_records):
+    """Readiness must reject malformed records before the tail check.
+
+    The artifact starts as a real current-v3 match with its cursor equal to
+    the journal tail. Only ``recent_records`` is forged, so the expected
+    result cannot be attributed to an earlier readiness gate.
+    """
+    repo = _repo(tmp_path)
+    run_dir = _run_dir(repo)
+    _write_run_json(run_dir, "started")
+    _write_run_json_locked(repo, run_dir, "started")
+
+    artifact = run_shadow.shadow_artifact_path(run_dir)
+    forged = json.loads(artifact.read_text())
+    if malformed_recent_records is _ABSENT_RECENT_RECORDS:
+        forged.pop("recent_records", None)
+    else:
+        forged["recent_records"] = malformed_recent_records
+    artifact.write_text(json.dumps(forged, indent=2, sort_keys=True) + "\n")
+
+    report = run_shadow.check_projection_readiness(run_dir)
+    assert report.ready is False
+    assert report.reasons == (REASON_EVIDENCE_UNREADABLE,)
+
+
 def test_record_outcome_does_not_trust_invalid_counters_on_carry(enabled, tmp_path):
     """Blocker #2 carry side: a current-v3 prior artifact with invalid counters
     (bool / negative / non-int) must not be trusted when a new comparison
@@ -1973,3 +2012,188 @@ def test_record_outcome_does_not_trust_negative_counters_on_carry(enabled, tmp_p
     assert fresh["comparisons"] >= 1
     assert fresh["comparisons"] == fresh["matches"] + fresh["mismatches"] + fresh["lags"] + fresh["errors"]
     assert list((run_dir / "events").glob("*.corrupt-*"))
+
+
+@pytest.mark.parametrize(
+    "field, invalid_value",
+    [
+        pytest.param("matches", True, id="matches-bool"),
+        pytest.param("matches", -1, id="matches-negative"),
+        pytest.param("matches", "1", id="matches-string"),
+        pytest.param("lags", False, id="lags-bool"),
+        pytest.param("lags", -1, id="lags-negative"),
+        pytest.param("lags", "0", id="lags-string"),
+    ],
+)
+def test_record_shadow_comparison_quarantines_invalid_accumulated_counter(enabled, tmp_path, field, invalid_value):
+    """Every counter read by the carry accumulator must be trusted first."""
+    repo = _repo(tmp_path)
+    run_dir = _run_dir(repo)
+
+    _write_run_json(run_dir, "started")
+    _write_run_json_locked(repo, run_dir, "started")
+
+    artifact = run_shadow.shadow_artifact_path(run_dir)
+    forged = json.loads(artifact.read_text())
+    forged["projector_version"] = run_projector.PROJECTOR_VERSION
+    forged[field] = invalid_value
+    artifact.write_text(json.dumps(forged, indent=2, sort_keys=True) + "\n")
+
+    snapshot = json.loads((run_dir / "run.json").read_text())
+    run_shadow.record_shadow_comparison(run_dir, snapshot)
+
+    fresh = json.loads(artifact.read_text())
+    assert list((run_dir / "events").glob("*.corrupt-*"))
+    assert fresh["comparisons"] == 2
+    assert fresh["matches"] == 1
+    assert fresh["mismatches"] == 0
+    assert fresh["lags"] == 0
+    assert fresh["errors"] == 1
+    assert fresh["comparisons"] == fresh["matches"] + fresh["mismatches"] + fresh["lags"] + fresh["errors"]
+    assert fresh["recent_records"][0]["outcome"] == run_shadow.OUTCOME_ERROR
+    assert fresh["recent_records"][0]["category"] == "evidence-unreadable"
+    assert fresh["recent_records"][-1]["outcome"] == run_shadow.OUTCOME_MATCH
+
+
+# -- Issue #568 slice 7 assignment 4: recent_records structural validation -----
+
+
+@pytest.mark.parametrize(
+    "malformed_recent_records",
+    [
+        pytest.param({"outcome": "match"}, id="mapping"),
+        pytest.param("not-a-list", id="string"),
+        pytest.param(["string-entry"], id="list_non_mapping"),
+        pytest.param([{"outcome": "match"}, 42], id="list_mixed_non_mapping"),
+        pytest.param(_ABSENT_RECENT_RECORDS, id="absent"),
+    ],
+)
+def test_malformed_recent_records_quarantined_via_record_shadow_comparison(enabled, tmp_path, malformed_recent_records):
+    """A current-v3 artifact with valid counters but malformed recent_records
+    must not crash record_shadow_comparison. The prior is quarantined, counters
+    are not carried, evidence-unreadable precedes the new outcome, and
+    recent_records is a bounded list of dict records."""
+    repo = _repo(tmp_path)
+    run_dir = _run_dir(repo)
+
+    _write_run_json(run_dir, "started")
+    _write_run_json_locked(repo, run_dir, "started")  # ck 1, run.created 2
+
+    artifact = run_shadow.shadow_artifact_path(run_dir)
+    forged = json.loads(artifact.read_text())
+    forged["projector_version"] = run_projector.PROJECTOR_VERSION
+    forged["comparisons"] = 7
+    forged["matches"] = 5
+    forged["mismatches"] = 1
+    forged["errors"] = 1
+    if malformed_recent_records is _ABSENT_RECENT_RECORDS:
+        forged.pop("recent_records", None)
+    else:
+        forged["recent_records"] = malformed_recent_records
+    artifact.write_text(json.dumps(forged, indent=2, sort_keys=True) + "\n")
+
+    # Exercise the public writer path through a valid journal/snapshot.
+    _write_run_json_locked(repo, run_dir, "planning")  # ck 3, planning 4
+
+    assert artifact.is_file()
+    fresh = json.loads(artifact.read_text())
+    assert list((run_dir / "events").glob("*.corrupt-*"))
+    assert fresh["schema"] == run_shadow.SHADOW_SCHEMA
+    assert fresh["projector_version"] == run_projector.PROJECTOR_VERSION
+    # Forged counters must not be carried forward.
+    assert fresh["comparisons"] != 7
+    assert fresh["matches"] != 5
+    assert fresh["mismatches"] != 1
+    assert fresh["errors"] >= 1
+    assert fresh["comparisons"] == fresh["matches"] + fresh["mismatches"] + fresh["lags"] + fresh["errors"]
+    recent = fresh["recent_records"]
+    assert isinstance(recent, list)
+    assert len(recent) <= run_shadow.MAX_RECENT_RECORDS
+    assert all(isinstance(record, dict) for record in recent)
+    unreadable = [r for r in recent if r.get("outcome") == "error" and r.get("category") == "evidence-unreadable"]
+    assert unreadable
+    assert unreadable[0] is recent[0]
+    assert recent[-1]["outcome"] == run_shadow.OUTCOME_MATCH
+
+
+def test_recent_records_structure_valid_artifact_accumulates_and_dedupes(enabled, tmp_path):
+    """Control: a structurally valid current artifact still accumulates new
+    comparisons and idempotently dedupes repeated calls at the same tail."""
+    repo = _repo(tmp_path)
+    run_dir = _run_dir(repo)
+
+    _write_run_json(run_dir, "started")
+    _write_run_json_locked(repo, run_dir, "started")  # ck 1, run.created 2
+
+    artifact = run_shadow.shadow_artifact_path(run_dir)
+    baseline = json.loads(artifact.read_text())
+    baseline_comparisons = baseline["comparisons"]
+
+    # Reuse the exact legacy payload aboyeur just wrote so the shadow and
+    # projected digests match the baseline record byte-for-byte; a hand-rolled
+    # snapshot with a different field set would project to a different digest
+    # and fail to dedupe.
+    snapshot = json.loads((run_dir / "run.json").read_text())
+    run_shadow.record_shadow_comparison(run_dir, snapshot)
+    run_shadow.record_shadow_comparison(run_dir, snapshot)
+
+    after_dedupe = json.loads(artifact.read_text())
+    assert after_dedupe["comparisons"] == baseline_comparisons
+
+    _write_run_json_locked(repo, run_dir, "planning")  # ck 3, planning 4
+
+    after_advance = json.loads(artifact.read_text())
+    assert after_advance["comparisons"] == baseline_comparisons + 1
+    recent = after_advance["recent_records"]
+    assert isinstance(recent, list)
+    assert all(isinstance(record, dict) for record in recent)
+    assert (
+        after_advance["comparisons"]
+        == after_advance["matches"] + after_advance["mismatches"] + after_advance["lags"] + after_advance["errors"]
+    )
+
+
+@pytest.mark.parametrize(
+    "non_object_payload",
+    [
+        pytest.param("[1, 2, 3]", id="list"),
+        pytest.param('"not-an-object"', id="string"),
+        pytest.param("42", id="number"),
+        pytest.param("true", id="bool"),
+        pytest.param("null", id="null"),
+    ],
+)
+def test_non_object_shadow_artifact_quarantined_via_record_shadow_comparison(enabled, tmp_path, non_object_payload):
+    """A parseable but non-object top-level JSON artifact (list, string,
+    number, bool, null) must be rejected before any ``.get`` call on the
+    carry path. The prior is quarantined, a fresh artifact starts, and an
+    evidence-unreadable side record precedes the new match."""
+    repo = _repo(tmp_path)
+    run_dir = _run_dir(repo)
+
+    _write_run_json(run_dir, "started")
+    _write_run_json_locked(repo, run_dir, "started")  # ck 1, run.created 2
+
+    artifact = run_shadow.shadow_artifact_path(run_dir)
+    # Overwrite the valid current-v3 artifact with a non-object JSON payload.
+    artifact.write_text(non_object_payload + "\n")
+
+    # Exercise the public writer path through a valid journal/snapshot.
+    _write_run_json_locked(repo, run_dir, "planning")  # ck 3, planning 4
+
+    assert artifact.is_file()
+    fresh = json.loads(artifact.read_text())
+    # The non-object prior was quarantined aside.
+    assert list((run_dir / "events").glob("*.corrupt-*"))
+    assert fresh["schema"] == run_shadow.SHADOW_SCHEMA
+    assert fresh["projector_version"] == run_projector.PROJECTOR_VERSION
+    assert isinstance(fresh["comparisons"], int) and not isinstance(fresh["comparisons"], bool)
+    assert fresh["errors"] >= 1
+    assert fresh["comparisons"] == fresh["matches"] + fresh["mismatches"] + fresh["lags"] + fresh["errors"]
+    recent = fresh["recent_records"]
+    assert isinstance(recent, list)
+    assert all(isinstance(record, dict) for record in recent)
+    unreadable = [r for r in recent if r.get("outcome") == "error" and r.get("category") == "evidence-unreadable"]
+    assert unreadable
+    assert unreadable[0] is recent[0]
+    assert recent[-1]["outcome"] == run_shadow.OUTCOME_MATCH


### PR DESCRIPTION
## Summary

- serialize journal appends across threads while deferring SIGTERM through the read-check-write-fsync window
- enforce the authority reader's event and byte limits on append, while keeping exact-limit idempotent replay valid
- fsync directory entries after journal creation and quarantine publication
- retain the run lock when an existing `run.json` cannot be decoded, parsed, or classified as an object
- reject malformed shadow counters and `recent_records` before readiness or outcome recording
- exercise the atomic replacement path with a real subprocess SIGKILL test

## Verification

- `./scripts/verify`
- `5326 passed, 3 skipped`
- coverage: `83.04%`
- Brigade receipt: `20260730-181316-work-verify-10a5a2`
- independent closure review: clean

Refs #568