### PR TITLE
feat(run): pause and resume for approvals

### DIFF
--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -17,7 +17,7 @@ from datetime import datetime, timezone
 from functools import partial, wraps
 from json import JSONDecoder
 from pathlib import Path
-from typing import Any, Callable, Iterator
+from typing import Any, Callable, Iterator, Mapping
 from uuid import uuid4
 
 from . import agents
@@ -737,6 +737,22 @@ def _write_json_inner(path: Path, payload: object) -> None:
     if path.name == "run.json" and isinstance(payload, dict):
         status = payload.get("status")
         if isinstance(status, str) and status:
+            transition_status = status
+            approval_reference = payload.get("approval_reference")
+            if status == "running" and isinstance(approval_reference, Mapping):
+                decision_state = approval_reference.get("decision_state")
+                if decision_state == "pending":
+                    # Keep the compatibility snapshot on a status understood
+                    # by the previous reader while journaling the intentional
+                    # pause.
+                    transition_status = "paused"
+                elif decision_state in {"approved", "rejected", "held", "consumed"}:
+                    # Approval facts own these state changes. Treat their
+                    # compatibility snapshot refreshes as neutral so a
+                    # same-status write cannot leave a checkpoint promising a
+                    # run.resumed event that record_lifecycle_transition
+                    # correctly suppresses.
+                    transition_status = "approval-state-refresh"
             run_dir = path.parent
             workspace = runguard.resolve_run_lock_workspace(payload, run_dir)
             # Cheap payload classification BEFORE the filesystem authority
@@ -807,12 +823,12 @@ def _write_json_inner(path: Path, payload: object) -> None:
                 run_dir,
                 base_bytes,
                 workspace=workspace,
-                paired_event_type=run_lifecycle.STATUS_EVENT_TYPE.get(status),
+                paired_event_type=run_lifecycle.STATUS_EVENT_TYPE.get(transition_status),
                 body_kind=body_kind,
             )
             run_lifecycle.record_lifecycle_transition(
                 run_dir,
-                status=status,
+                status=transition_status,
                 # The receipt payload identifies the lock workspace
                 # (lock_workspace or cwd); the run directory layout does not.
                 workspace=workspace,
@@ -1548,7 +1564,24 @@ def _worker_prompt(
     return _prepend_optional_briefs(prompt, code_graph=code_graph, drift_impact=drift_impact, evidence=evidence)
 
 
-def _worker_event_writer(events_dir: Path | None, worker: str, *, verbose: bool = False):
+def _redact_event_marker(value: Any, marker: str) -> Any:
+    if isinstance(value, str):
+        return value.replace(marker, "[redacted]")
+    if isinstance(value, list):
+        return [_redact_event_marker(item, marker) for item in value]
+    if isinstance(value, dict):
+        return {key: _redact_event_marker(item, marker) for key, item in value.items()}
+    return value
+
+
+def _worker_event_writer(
+    events_dir: Path | None,
+    worker: str,
+    *,
+    verbose: bool = False,
+    workspace: Path | None = None,
+    correlation_marker: str | None = None,
+):
     """Append lifecycle notifications to events/<worker>.jsonl; optionally narrate."""
     if events_dir is None and not verbose:
         return None
@@ -1558,11 +1591,39 @@ def _worker_event_writer(events_dir: Path | None, worker: str, *, verbose: bool 
         path = events_dir / f"{_slug(worker)}.jsonl"
 
     def on_event(msg: dict) -> None:
+        safe_msg = msg
+        if correlation_marker is not None:
+            params = msg.get("params") if isinstance(msg, dict) else None
+            item = params.get("item") if isinstance(params, dict) else None
+            rendered = json.dumps(msg, sort_keys=True, default=str)
+            if (
+                msg.get("method") == "item/completed"
+                and isinstance(item, dict)
+                and item.get("type") == "commandExecution"
+                and correlation_marker in rendered
+                and workspace is not None
+            ):
+                thread_id = params.get("threadId")
+                turn_id = params.get("turnId")
+                if isinstance(thread_id, str) and isinstance(turn_id, str):
+                    from . import runs_cmd
+
+                    try:
+                        runs_cmd._bind_approval_pause_request(
+                            workspace,
+                            correlation_marker=correlation_marker,
+                            worker=worker,
+                            thread_id=thread_id,
+                            turn_id=turn_id,
+                        )
+                    except runs_cmd.ApprovalResumeError:
+                        pass
+            safe_msg = _redact_event_marker(msg, correlation_marker)
         if path is not None:
             with path.open("a") as fh:
-                fh.write(json.dumps(msg) + "\n")
-        if verbose and msg.get("method") == "item/completed":
-            item = (msg.get("params") or {}).get("item") or {}
+                fh.write(json.dumps(safe_msg) + "\n")
+        if verbose and safe_msg.get("method") == "item/completed":
+            item = (safe_msg.get("params") or {}).get("item") or {}
             print(f"worker {worker}: {item.get('type', 'item')} completed", file=sys.stderr)
 
     return on_event
@@ -2390,6 +2451,95 @@ def record_run_termination(
         _write_json(run_path, receipt_schema.stamp_run_receipt(payload))
     except (OSError, run_lifecycle.LifecycleJournalError, run_checkpoint.CheckpointError) as exc:
         raise runguard.RetainRunLockError(f"failed to write terminal run receipt: {exc}") from exc
+
+
+def record_approval_pause(output_dir: Path, approval_reference: Mapping[str, Any]) -> None:
+    """Commit an approval wait and refresh its compatibility snapshot.
+
+    The caller must hold the matching normal run lock. Successful return is
+    intentionally non-exceptional so the surrounding ``run_lock`` context
+    releases ownership and the process can exit cleanly.
+    """
+    run_dir = output_dir.expanduser().resolve()
+    run_path = run_dir / "run.json"
+    try:
+        raw = json.loads(run_path.read_text())
+    except OSError as exc:
+        raise runguard.RetainRunLockError(f"failed to read run receipt before approval pause: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise runguard.RetainRunLockError(f"run receipt is invalid before approval pause: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise runguard.RetainRunLockError("run receipt must contain an object before approval pause")
+    try:
+        reference = run_lifecycle.normalize_approval_reference(approval_reference)
+        workspace = runguard.resolve_run_lock_workspace(raw, run_dir)
+        if workspace is None or not runguard.is_active_run_owner(workspace, run_dir):
+            raise run_lifecycle.LifecycleJournalError("approval pause requires the active run lock for this run")
+        run_lifecycle.prepare_lifecycle_journal(
+            run_dir,
+            workspace=workspace,
+            incoming_snapshot=raw,
+        )
+        run_lifecycle.record_lifecycle_event(
+            run_dir,
+            event_type="approval.requested",
+            payload={
+                "approval_id": reference["approval_id"],
+                "source": reference["source"],
+                "contract_fingerprint": reference["contract_fingerprint"],
+            },
+            idempotency_key=run_lifecycle.approval_idempotency_key(reference["approval_id"], "requested"),
+            workspace=workspace,
+        )
+        raw["status"] = "running"
+        raw["status_started_at"] = _utc_iso(datetime.now(timezone.utc))
+        raw["approval_reference"] = {
+            **reference,
+            "decision_state": "pending",
+        }
+        raw.pop("finished_at", None)
+        raw.pop("duration_seconds", None)
+        _write_json(run_path, receipt_schema.stamp_run_receipt(raw))
+    except (OSError, run_lifecycle.LifecycleJournalError, run_checkpoint.CheckpointError) as exc:
+        raise runguard.RetainRunLockError(f"failed to record approval pause: {exc}") from exc
+
+
+def write_approval_resume_handoff(
+    output_dir: Path,
+    worker_results: list[WorkerResult],
+    *,
+    requester_worker: str,
+    requester_thread_id: str,
+) -> None:
+    """Persist only the closed worker coordinates needed by approval resume."""
+    matching = [
+        result
+        for result in worker_results
+        if isinstance(result.thread_id, str)
+        and bool(result.thread_id)
+        and result.worker == requester_worker
+        and result.thread_id == requester_thread_id
+    ]
+    if len(matching) != 1:
+        raise runguard.RetainRunLockError("approval pause requester did not match exactly one worker thread")
+    requester = matching[0]
+    resumable = [
+        {
+            "worker": requester.worker,
+            "task": requester.task,
+            "ok": False,
+            "thread_id": requester.thread_id,
+            "status": "interrupted",
+        }
+    ]
+    try:
+        write_sidecar_revision(
+            output_dir,
+            "worker-results.json",
+            receipt_schema.worker_results_document(resumable),
+        )
+    except (OSError, TypeError, ValueError) as exc:
+        raise runguard.RetainRunLockError("failed to persist approval resume handoff") from exc
 
 
 def record_dispatch_stage(output_dir: Path, *, stage: int, seats: tuple[str, ...]) -> None:
@@ -3525,6 +3675,26 @@ def run(
             raise
     finally:
         close_server_resources()
+    if (
+        output_dir is not None
+        and lock_workspace is not None
+        and runguard.is_active_run_owner(lock_workspace, output_dir)
+    ):
+        from . import runs_cmd
+
+        approval_reference = runs_cmd._approval_pause_reference_for_owned_run(
+            lock_workspace,
+            output_dir,
+        )
+        if approval_reference is not None:
+            write_approval_resume_handoff(
+                output_dir,
+                worker_results,
+                requester_worker=approval_reference.requester_worker,
+                requester_thread_id=approval_reference.requester_thread_id,
+            )
+            record_approval_pause(output_dir, approval_reference)
+            return 0
     # Drift checkpoint: after worker dispatch. A concurrent commit or branch
     # switch during dispatch must fail the run before ground truth attributes
     # the foreign state to the worker.

--- a/src/brigade/cli/runs.py
+++ b/src/brigade/cli/runs.py
@@ -149,9 +149,7 @@ def dispatch(args) -> int:
     if args.runs_command == "recover":
         return runs_cmd.recover(args.run, cwd=args.cwd, runs_dir=args.runs_dir)
     if args.runs_command == "resume":
-        from .. import run_resume
-
-        return run_resume.resume(args.run_dir)
+        return runs_cmd.resume(args.run_dir)
     args._brigade_parser.error(f"unknown runs command: {args.runs_command}")
     return 2
 

--- a/src/brigade/codex_appserver.py
+++ b/src/brigade/codex_appserver.py
@@ -66,10 +66,12 @@ class AppServer:
         argv: list[str] | None = None,
         cwd: Path | None = None,
         process_registry: proc_mod.ProcessRegistry | None = None,
+        env: dict[str, str] | None = None,
     ) -> None:
         self._argv = argv or ["codex", "app-server"]
         self._cwd = cwd
         self._process_registry = process_registry or proc_mod.ProcessRegistry()
+        self._env = env
         self._proc: subprocess.Popen | None = None
         self._write_lock = threading.Lock()
         self._state_lock = threading.Lock()
@@ -97,6 +99,10 @@ class AppServer:
                 0x00000200,
             )
         try:
+            child_env = None
+            if self._env is not None:
+                child_env = dict(os.environ)
+                child_env.update(self._env)
             self._proc = subprocess.Popen(
                 self._argv,
                 stdin=subprocess.PIPE,
@@ -104,6 +110,7 @@ class AppServer:
                 stderr=subprocess.DEVNULL,
                 text=True,
                 cwd=self._cwd,
+                env=child_env,
                 **process_group_kwargs,
             )
             self._process_registry.register(cast("subprocess.Popen[bytes]", self._proc))

--- a/src/brigade/daily_cmd/approvals.py
+++ b/src/brigade/daily_cmd/approvals.py
@@ -12,8 +12,10 @@ import subprocess
 import sys
 import threading
 import time
-from contextlib import redirect_stdout
+from contextlib import contextmanager, redirect_stdout
 from collections import Counter
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from io import StringIO
 from pathlib import Path
@@ -32,12 +34,33 @@ from .. import (
     tools_cmd,
     work_cmd,
 )
+from .. import runguard
 from ..localio import read_json_dict as _read_json, utc_now as _now, write_json as _write_json
 from ..render import emit
 
 from . import config as _family_base
 
 globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
+
+_APPROVAL_REFERENCE_FIELDS = (
+    "approval_id",
+    "source",
+    "fingerprint",
+    "source_fingerprint",
+    "contract_fingerprint",
+    "evidence_fingerprint",
+)
+
+
+class ApprovalClaimError(RuntimeError):
+    """A Daily approval could not be claimed from its current stored state."""
+
+
+@dataclass(frozen=True)
+class ApprovalClaim:
+    decided_at: str
+    claimed_at: str
+    already_claimed: bool
 
 
 def _config_fingerprint(config: dict[str, Any]) -> str:
@@ -62,15 +85,36 @@ def _approval_path(target: Path, approval_id: str) -> Path:
     return _approvals_root(target) / approval_id / "approval.json"
 
 
+def _approval_lock_path(target: Path, approval_id: str) -> Path:
+    return _approvals_root(target).parent / ".approval-locks" / f"{approval_id}.lock"
+
+
+@contextmanager
+def _approval_store_lock(target: Path, approval_id: str) -> Iterator[None]:
+    path = _approval_lock_path(target, approval_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ownership = runguard._acquire_lock(path)
+    try:
+        yield
+    finally:
+        runguard._release_lock(path, ownership)
+
+
 def _read_approvals(target: Path) -> tuple[list[dict[str, Any]], list[dict[str, str]]]:
     return _iter_receipts(_approvals_root(target), "approval.json")
 
 
-def _write_approval(target: Path, approval: dict[str, Any]) -> dict[str, Any]:
+def _write_approval_unlocked(target: Path, approval: dict[str, Any]) -> dict[str, Any]:
     approval_id = str(approval["approval_id"])
     approval["path"] = str(_approvals_root(target) / approval_id)
     _write_json(_approval_path(target, approval_id), approval)
     return approval
+
+
+def _write_approval(target: Path, approval: dict[str, Any]) -> dict[str, Any]:
+    approval_id = str(approval["approval_id"])
+    with _approval_store_lock(target, approval_id):
+        return _write_approval_unlocked(target, approval)
 
 
 def _find_approval(target: Path, approval_id: str) -> dict[str, Any] | None:
@@ -92,40 +136,39 @@ def _matching_approvals(target: Path, action: dict[str, Any], config: dict[str, 
 def _ensure_approval(
     target: Path, plan_data: dict[str, Any], action: dict[str, Any], config: dict[str, Any]
 ) -> dict[str, Any]:
-    matches = _matching_approvals(target, action, config)
-    for status in ("pending", "approved"):
-        existing = next((approval for approval in matches if approval.get("status") == status), None)
-        if existing:
-            return existing
-    for status in ("rejected", "held", "consumed"):
-        existing = next((approval for approval in matches if approval.get("status") == status), None)
-        if existing:
-            return existing
-    approval = {
-        "schema_version": SCHEMA_VERSION,
-        "approval_id": _approval_id(action, config),
-        "created_at": _now().isoformat(),
-        "status": "pending",
-        "source_plan_id": plan_data.get("plan_id"),
-        "selected_action_id": action.get("action_id"),
-        "selected_action": action,
-        "selected_adapter": _adapter_for(action),
-        "source_subsystem": action.get("source_subsystem"),
-        "source_local_id": action.get("source_local_id"),
-        "source_fingerprint": action.get("source_fingerprint"),
-        "config_fingerprint": _config_fingerprint(config),
-        "acceptance": action.get("acceptance") if isinstance(action.get("acceptance"), list) else [],
-        "safe_summary": action.get("safe_summary"),
-        "evidence_refs": action.get("evidence_refs") if isinstance(action.get("evidence_refs"), list) else [],
-        "risk_level": action.get("risk_level"),
-        "approval_reason": action.get("approval_reason") or "explicit approval required",
-        "config": config,
-        "suggested_next_command": action.get("suggested_next_command"),
-        "reviewed_at": None,
-        "review_reason": None,
-        "consumed_run_id": None,
-    }
-    return _write_approval(target, approval)
+    approval_id = _approval_id(action, config)
+    with _approval_store_lock(target, approval_id):
+        matches = _matching_approvals(target, action, config)
+        for status in ("pending", "approved", "rejected", "held", "consumed"):
+            existing = next((approval for approval in matches if approval.get("status") == status), None)
+            if existing is not None:
+                return existing
+        evidence_refs = action.get("evidence_refs")
+        approval = {
+            "schema_version": SCHEMA_VERSION,
+            "approval_id": approval_id,
+            "created_at": _now().isoformat(),
+            "status": "pending",
+            "source_plan_id": plan_data.get("plan_id"),
+            "selected_action_id": action.get("action_id"),
+            "selected_action": action,
+            "selected_adapter": _adapter_for(action),
+            "source_subsystem": action.get("source_subsystem"),
+            "source_local_id": action.get("source_local_id"),
+            "source_fingerprint": action.get("source_fingerprint"),
+            "config_fingerprint": _config_fingerprint(config),
+            "acceptance": action.get("acceptance") if isinstance(action.get("acceptance"), list) else [],
+            "safe_summary": action.get("safe_summary"),
+            "evidence_refs": evidence_refs if isinstance(evidence_refs, list) else [],
+            "risk_level": action.get("risk_level"),
+            "approval_reason": action.get("approval_reason") or "explicit approval required",
+            "config": config,
+            "suggested_next_command": action.get("suggested_next_command"),
+            "reviewed_at": None,
+            "review_reason": None,
+            "consumed_run_id": None,
+        }
+        return _write_approval_unlocked(target, approval)
 
 
 def _current_action_for_approval(target: Path, approval: dict[str, Any]) -> dict[str, Any] | None:
@@ -168,8 +211,180 @@ def _approval_blockers(target: Path, approval: dict[str, Any], config: dict[str,
     return list(dict.fromkeys(blockers))
 
 
+def _approval_claim_reference(approval: Mapping[str, Any]) -> dict[str, str]:
+    components = {
+        "approval_id": approval.get("approval_id"),
+        "source": "daily",
+        "source_fingerprint": approval.get("source_fingerprint"),
+        "contract_fingerprint": approval.get("config_fingerprint"),
+        "evidence_fingerprint": _fingerprint(approval.get("evidence_refs", [])),
+    }
+    if any(not isinstance(value, str) or not value for value in components.values()):
+        raise ApprovalClaimError("daily approval record is missing required fingerprints")
+    return {
+        **{key: str(value) for key, value in components.items()},
+        "fingerprint": _fingerprint(components),
+    }
+
+
+def claim_for_run(
+    target: Path,
+    approval_id: str,
+    reference: Mapping[str, str],
+    run_id: str,
+) -> ApprovalClaim:
+    """Atomically validate and claim one approved Daily record for a run."""
+    with _approval_store_lock(target, approval_id):
+        approval = _find_approval(target, approval_id)
+        if approval is None:
+            raise ApprovalClaimError(f"daily approval not found: {approval_id}")
+        actual = _approval_claim_reference(approval)
+        if any(reference.get(field) != actual[field] for field in _APPROVAL_REFERENCE_FIELDS):
+            raise ApprovalClaimError("daily approval fingerprints changed before claim")
+        status = str(approval.get("status") or "")
+        consumed_by = approval.get("consumed_run_id")
+        if status == "consumed" and consumed_by == run_id:
+            decided_at = approval.get("reviewed_at")
+            if not isinstance(decided_at, str) or not decided_at:
+                raise ApprovalClaimError("daily approval decision has no review timestamp")
+            claimed_at = approval.get("consumed_at")
+            if not isinstance(claimed_at, str) or not claimed_at:
+                raise ApprovalClaimError("daily approval claim has no consumption timestamp")
+            return ApprovalClaim(
+                decided_at=decided_at,
+                claimed_at=claimed_at,
+                already_claimed=True,
+            )
+        if status != "approved":
+            raise ApprovalClaimError(f"daily approval is {status or 'pending'}")
+        config, _ = _load_config(target)
+        blockers = _approval_blockers(target, approval, config)
+        if blockers:
+            raise ApprovalClaimError(f"daily approval is stale or blocked: {blockers[0]}")
+        decided_at = approval.get("reviewed_at")
+        if not isinstance(decided_at, str) or not decided_at:
+            raise ApprovalClaimError("daily approval decision has no review timestamp")
+        claimed_at = _now().isoformat()
+        approval["status"] = "consumed"
+        approval["consumed_run_id"] = run_id
+        approval["consumed_at"] = claimed_at
+        _write_approval_unlocked(target, approval)
+        return ApprovalClaim(
+            decided_at=decided_at,
+            claimed_at=claimed_at,
+            already_claimed=False,
+        )
+
+
+def reserve_for_run(
+    target: Path,
+    approval_id: str,
+    reference: Mapping[str, str],
+    run_id: str,
+    token_fingerprint: str,
+) -> ApprovalClaim:
+    """Reserve a rotatable one-shot approval claim without consuming it."""
+    with _approval_store_lock(target, approval_id):
+        approval = _find_approval(target, approval_id)
+        if approval is None:
+            raise ApprovalClaimError(f"daily approval not found: {approval_id}")
+        actual = _approval_claim_reference(approval)
+        if any(reference.get(field) != actual[field] for field in _APPROVAL_REFERENCE_FIELDS):
+            raise ApprovalClaimError("daily approval fingerprints changed before reservation")
+        existing = approval.get("approval_claim")
+        if existing is not None:
+            if not isinstance(existing, Mapping):
+                raise ApprovalClaimError("daily approval claim is malformed")
+            existing_state = existing.get("state")
+            existing_run_id = existing.get("run_id")
+            if existing_state == "redeemed":
+                raise ApprovalClaimError("daily approval claim is already redeemed")
+            if existing_state != "reserved" or not isinstance(existing_run_id, str):
+                raise ApprovalClaimError("daily approval claim is malformed")
+            if existing_run_id != run_id:
+                raise ApprovalClaimError(f"daily approval claim is reserved by {existing_run_id}")
+        if approval.get("status") != "approved":
+            raise ApprovalClaimError(f"daily approval is {approval.get('status') or 'pending'}")
+        config, _ = _load_config(target)
+        blockers = _approval_blockers(target, approval, config)
+        if blockers:
+            raise ApprovalClaimError(f"daily approval is stale or blocked: {blockers[0]}")
+        decided_at = approval.get("reviewed_at")
+        if not isinstance(decided_at, str) or not decided_at:
+            raise ApprovalClaimError("daily approval decision has no review timestamp")
+        reserved_at = _now().isoformat()
+        approval["approval_claim"] = {
+            "run_id": run_id,
+            "state": "reserved",
+            "reserved_at": reserved_at,
+            "token_fingerprint": token_fingerprint,
+            "redeemed_at": None,
+        }
+        _write_approval_unlocked(target, approval)
+        return ApprovalClaim(
+            decided_at=decided_at,
+            claimed_at=reserved_at,
+            already_claimed=isinstance(existing, Mapping),
+        )
+
+
+def redeem_for_run(target: Path, approval_id: str, reference: Mapping[str, str], token: str) -> ApprovalClaim:
+    """CAS one reserved claim to redeemed immediately before its action."""
+    from .. import runs_cmd
+
+    with _approval_store_lock(target, approval_id):
+        approval = _find_approval(target, approval_id)
+        if approval is None:
+            raise ApprovalClaimError(f"daily approval not found: {approval_id}")
+        actual = _approval_claim_reference(approval)
+        if any(reference.get(field) != actual[field] for field in _APPROVAL_REFERENCE_FIELDS):
+            raise ApprovalClaimError("daily approval fingerprints changed before redemption")
+        claim = approval.get("approval_claim")
+        if not isinstance(claim, dict) or claim.get("state") != "reserved":
+            raise ApprovalClaimError("daily approval claim is not reserved")
+        if claim.get("token_fingerprint") != runs_cmd._request_digest(token):
+            raise ApprovalClaimError("daily approval claim token does not match")
+        run_id = claim.get("run_id")
+        if not isinstance(run_id, str) or not run_id:
+            raise ApprovalClaimError("daily approval claim has no run id")
+        status = str(approval.get("status") or "")
+        if status != "approved":
+            raise ApprovalClaimError(f"daily approval is {status or 'pending'}")
+        config, _ = _load_config(target)
+        blockers = _approval_blockers(target, approval, config)
+        if blockers:
+            raise ApprovalClaimError(f"daily approval is stale or blocked: {blockers[0]}")
+        redeemed_at = _now().isoformat()
+        claim["state"] = "redeemed"
+        claim["redeemed_at"] = redeemed_at
+        approval["status"] = "consumed"
+        approval["consumed_run_id"] = run_id
+        approval["consumed_at"] = redeemed_at
+        _write_approval_unlocked(target, approval)
+        decided_at = approval.get("reviewed_at")
+        if not isinstance(decided_at, str) or not decided_at:
+            raise ApprovalClaimError("daily approval decision has no review timestamp")
+        return ApprovalClaim(decided_at=decided_at, claimed_at=redeemed_at, already_claimed=False)
+
+
 def _consume_approval(target: Path, approval: dict[str, Any], run_id: str) -> None:
-    approval["status"] = "consumed"
-    approval["consumed_run_id"] = run_id
-    approval["consumed_at"] = _now().isoformat()
-    _write_approval(target, approval)
+    claim = approval.get("approval_claim")
+    if isinstance(claim, Mapping) and claim.get("state") == "reserved":
+        from .. import runs_cmd
+
+        token = runs_cmd._approval_marker_from_env(runs_cmd._APPROVAL_RESUME_TOKEN_ENV)
+        if token is None:
+            raise ApprovalClaimError("daily approval resume token is missing")
+        redeem_for_run(
+            target,
+            str(approval.get("approval_id") or ""),
+            _approval_claim_reference(approval),
+            token,
+        )
+        return
+    claim_for_run(
+        target,
+        str(approval.get("approval_id") or ""),
+        _approval_claim_reference(approval),
+        run_id,
+    )

--- a/src/brigade/daily_cmd/run_loop.py
+++ b/src/brigade/daily_cmd/run_loop.py
@@ -310,6 +310,16 @@ def run(
         )
     if action.get("approval_required") and not approval_granted:
         approval = _ensure_approval(target, plan_data, action, config)
+        from .. import runs_cmd
+
+        approval_id = str(approval.get("approval_id") or "")
+        with _approval_store_lock(target, approval_id):
+            current_approval = _find_approval(target, approval_id)
+            if current_approval is None:
+                raise ApprovalClaimError(f"daily approval not found: {approval_id}")
+            if runs_cmd._attach_approval_pause_request(target, "daily", current_approval):
+                _write_approval_unlocked(target, current_approval)
+            approval = current_approval
         blockers = [str(action.get("approval_reason") or "explicit approval required")]
         if approval.get("status") not in {"pending", "approved"}:
             blockers.append(f"approval status is {approval.get('status')}")

--- a/src/brigade/daily_cmd/telemetry_ops.py
+++ b/src/brigade/daily_cmd/telemetry_ops.py
@@ -87,17 +87,18 @@ def _review_approval(
         print(f"error: invalid approval status: {status}", file=sys.stderr)
         return 2
     target = target.expanduser().resolve()
-    approval = _find_approval(target, approval_id)
-    if approval is None:
-        print(f"error: approval not found: {approval_id}", file=sys.stderr)
-        return 1
-    if approval.get("status") == "consumed":
-        print(f"error: approval already consumed: {approval_id}", file=sys.stderr)
-        return 1
-    approval["status"] = status
-    approval["reviewed_at"] = _now().isoformat()
-    approval["review_reason"] = reason
-    _write_approval(target, approval)
+    with _approval_store_lock(target, approval_id):
+        approval = _find_approval(target, approval_id)
+        if approval is None:
+            print(f"error: approval not found: {approval_id}", file=sys.stderr)
+            return 1
+        if approval.get("status") == "consumed":
+            print(f"error: approval already consumed: {approval_id}", file=sys.stderr)
+            return 1
+        approval["status"] = status
+        approval["reviewed_at"] = _now().isoformat()
+        approval["review_reason"] = reason
+        _write_approval_unlocked(target, approval)
     if json_output:
         print(json.dumps(approval, indent=2, sort_keys=True))
     else:
@@ -184,20 +185,24 @@ def approvals_archive(*, target: Path, consumed: bool = False, json_output: bool
         if approval.get("status") not in archiveable:
             continue
         approval_id = str(approval.get("approval_id") or "")
-        source = _approvals_root(target) / approval_id
-        destination = _approvals_archive_root(target) / approval_id
-        if not source.is_dir() or destination.exists():
-            continue
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        shutil.move(str(source), str(destination))
-        record = {
-            "approval_id": approval_id,
-            "status": approval.get("status"),
-            "archived_at": _now().isoformat(),
-            "archive_path": str(destination),
-        }
-        _write_json(destination / "archive.json", record)
-        archived.append(record)
+        with _approval_store_lock(target, approval_id):
+            current = _find_approval(target, approval_id)
+            if current is None or current.get("status") not in archiveable:
+                continue
+            source = _approvals_root(target) / approval_id
+            destination = _approvals_archive_root(target) / approval_id
+            if not source.is_dir() or destination.exists():
+                continue
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(source), str(destination))
+            record = {
+                "approval_id": approval_id,
+                "status": current.get("status"),
+                "archived_at": _now().isoformat(),
+                "archive_path": str(destination),
+            }
+            _write_json(destination / "archive.json", record)
+            archived.append(record)
     payload = {
         "schema_version": SCHEMA_VERSION,
         "schema": {"name": "daily-approval-archive", "version": SCHEMA_VERSION},

--- a/src/brigade/run_checkpoint.py
+++ b/src/brigade/run_checkpoint.py
@@ -101,6 +101,12 @@ def _mapped_lifecycle_event_types() -> set[str]:
     return set(run_lifecycle.STATUS_EVENT_TYPE.values())
 
 
+def _status_neutral_event_types() -> set[str]:
+    from brigade import run_projector
+
+    return set(run_projector._STATUS_NEUTRAL_EVENT_TYPES)
+
+
 def _validate_payload(payload: Any) -> None:
     """Full payload validation before any path access. Raises CheckpointError."""
     if not isinstance(payload, Mapping):
@@ -174,9 +180,13 @@ def _validate_payload(payload: Any) -> None:
         raise CheckpointError(_bound("paired_event_type must be null or a string"), category="paired-event-type")
     elif paired not in run_events.EVENT_TYPES:
         raise CheckpointError(_bound("paired_event_type not in registry"), category="paired-event-type")
-    elif paired not in _mapped_lifecycle_event_types() and paired not in _DISPATCH_FACT_EVENT_TYPES:
+    elif (
+        paired not in _mapped_lifecycle_event_types()
+        and paired not in _DISPATCH_FACT_EVENT_TYPES
+        and paired not in _status_neutral_event_types()
+    ):
         raise CheckpointError(
-            _bound("paired_event_type is not a mapped lifecycle or dispatch fact event"),
+            _bound("paired_event_type is not a mapped lifecycle, neutral approval, or dispatch fact event"),
             category="paired-event-type",
         )
 
@@ -1012,6 +1022,14 @@ def _verify_coverage(
         # Identity-bearing dispatch facts are status-neutral. Their paired
         # checkpoint preserves the aggregate status already in run.json, so
         # no event-derived status comparison applies.
+        return
+    if paired.event_type in _status_neutral_event_types():
+        checkpoint_status = checkpoint_obj.get("status")
+        if not isinstance(checkpoint_status, str) or not checkpoint_status:
+            raise CheckpointError(
+                _bound("status-neutral checkpoint has no aggregate status"),
+                category="uncovered-tail",
+            )
         return
     derived = _paired_event_derived_status(paired)
     checkpoint_status = checkpoint_obj.get("status")

--- a/src/brigade/run_events.py
+++ b/src/brigade/run_events.py
@@ -108,6 +108,12 @@ EVENT_TYPES: dict[str, frozenset[str]] = {
     ),
     "run.artifact_collection.started": frozenset({"detail"}),
 }
+APPROVAL_DECISION_STATES = frozenset({"pending", "approved", "rejected", "held", "consumed"})
+APPROVAL_DECISION_EVENT_STATES = {
+    "approval.granted": "approved",
+    "approval.rejected": "rejected",
+    "approval.held": "held",
+}
 
 # Private-data exclusion list: these payload key names are never part of any
 # allowlist and are rejected explicitly if a caller attempts to set them.
@@ -206,6 +212,23 @@ def request_digest(*, event_type: str, payload: Mapping[str, Any], idempotency_k
     return _sha256_hex(canonical_bytes(request))
 
 
+def validate_event_request(
+    *,
+    event_type: str,
+    payload: Mapping[str, Any],
+    idempotency_key: str,
+) -> None:
+    """Validate a caller request before any journal-side mutation."""
+    if event_type not in EVENT_TYPES:
+        raise CanonicalizationError(_bound(f"unknown event_type {event_type!r}"))
+    if not isinstance(idempotency_key, str) or not idempotency_key:
+        raise CanonicalizationError("idempotency_key must be a non-empty string")
+    if len(idempotency_key) > MAX_IDEMPOTENCY_KEY_LEN:
+        raise CanonicalizationError(_bound(f"idempotency_key exceeds {MAX_IDEMPOTENCY_KEY_LEN} chars"))
+    _validate_payload(event_type, payload)
+    request_digest(event_type=event_type, payload=payload, idempotency_key=idempotency_key)
+
+
 def compute_event_digest(envelope: Mapping[str, Any]) -> str:
     """SHA-256 of the canonical envelope excluding ``event_digest`` and ``event_id``.
 
@@ -242,12 +265,11 @@ def build_event(
         raise CanonicalizationError(_bound(f"invalid run_id {run_id!r}"))
     if not isinstance(sequence, int) or isinstance(sequence, bool) or sequence < 1:
         raise CanonicalizationError(_bound(f"invalid sequence {sequence!r}"))
-    if event_type not in EVENT_TYPES:
-        raise CanonicalizationError(_bound(f"unknown event_type {event_type!r}"))
-    if not isinstance(idempotency_key, str) or not idempotency_key:
-        raise CanonicalizationError("idempotency_key must be a non-empty string")
-    if len(idempotency_key) > MAX_IDEMPOTENCY_KEY_LEN:
-        raise CanonicalizationError(_bound(f"idempotency_key exceeds {MAX_IDEMPOTENCY_KEY_LEN} chars"))
+    validate_event_request(
+        event_type=event_type,
+        payload=payload,
+        idempotency_key=idempotency_key,
+    )
     if not is_valid_recorded_at(recorded_at):
         raise CanonicalizationError(_bound(f"invalid recorded_at {recorded_at!r}"))
     if previous_digest is not None and not (isinstance(previous_digest, str) and bool(_HEX64.match(previous_digest))):
@@ -256,8 +278,6 @@ def build_event(
         raise CanonicalizationError("previous_digest must be null at sequence 1")
     if sequence > 1 and previous_digest is None:
         raise CanonicalizationError("previous_digest must not be null after sequence 1")
-
-    _validate_payload(event_type, payload)
 
     rd = request_digest_value or request_digest(event_type=event_type, payload=payload, idempotency_key=idempotency_key)
     if not (isinstance(rd, str) and bool(_HEX64.match(rd))):
@@ -308,6 +328,9 @@ def _validate_payload(event_type: str, payload: Any) -> None:
                 raise CanonicalizationError(_bound(f"payload {key!r} exceeds {MAX_PAYLOAD_STR_LEN} chars"))
             continue
         raise CanonicalizationError(_bound(f"payload {key!r} has unsupported type {type(value).__name__}"))
+    expected_decision = APPROVAL_DECISION_EVENT_STATES.get(event_type)
+    if expected_decision is not None and payload.get("decision_state") != expected_decision:
+        raise CanonicalizationError(_bound(f"{event_type} requires decision_state {expected_decision!r}"))
 
 
 def validate_event(env: Any) -> list[str]:
@@ -396,6 +419,9 @@ def validate_event(env: Any) -> list[str]:
                     errors.append(_bound(f"payload {key!r} exceeds {MAX_PAYLOAD_STR_LEN} chars"))
             else:
                 errors.append(_bound(f"payload {key!r} has unsupported type"))
+        expected_decision = APPROVAL_DECISION_EVENT_STATES.get(str(event_type))
+        if expected_decision is not None and payload.get("decision_state") != expected_decision:
+            errors.append(_bound(f"{event_type} requires decision_state {expected_decision!r}"))
 
     if errors:
         return errors

--- a/src/brigade/run_journal.py
+++ b/src/brigade/run_journal.py
@@ -637,6 +637,52 @@ def _envelope_to_event(env: dict[str, Any]) -> RunEvent:
         raise ChainIntegrityError(_bound(f"envelope fields are malformed: {exc}")) from exc
 
 
+def _idempotent_event(
+    index: dict[str, dict[str, Any]],
+    *,
+    idempotency_key: str,
+    request_digest: str,
+) -> RunEvent | None:
+    existing = index.get(idempotency_key)
+    if existing is None:
+        return None
+    existing_rd = existing.get("request_digest")
+    if not isinstance(existing_rd, str):
+        raise ChainIntegrityError(_bound("indexed journal event is missing request_digest"))
+    if existing_rd == request_digest:
+        return _envelope_to_event(existing)
+    existing_event_id = existing.get("event_id")
+    if not isinstance(existing_event_id, str):
+        raise ChainIntegrityError(_bound("indexed journal event is missing event_id"))
+    raise IdempotencyConflict(
+        _bound(f"idempotency key {idempotency_key!r} conflict"),
+        existing_event_id=existing_event_id,
+        request_digest=request_digest,
+        existing_request_digest=existing_rd,
+    )
+
+
+def lookup_idempotent_event(
+    journal_path: Path,
+    *,
+    event_type: str,
+    payload: dict[str, Any],
+    idempotency_key: str,
+) -> RunEvent | None:
+    """Return an exact replay or fail on conflict without mutating the journal."""
+    journal_path = Path(journal_path)
+    rd = run_events.request_digest(event_type=event_type, payload=payload, idempotency_key=idempotency_key)
+    with _append_critical_section():
+        _sequence, _digest, index, partial_tail, _journal_bytes = _read_tail_state(journal_path)
+        if partial_tail is not None:
+            raise PartialTailError(_bound("journal ends in a partial line; run recover_partial_tail before appending"))
+        return _idempotent_event(
+            index,
+            idempotency_key=idempotency_key,
+            request_digest=rd,
+        )
+
+
 def append_event(
     journal_path: Path,
     *,
@@ -672,22 +718,13 @@ def append_event(
         if partial_tail is not None:
             raise PartialTailError(_bound("journal ends in a partial line; run recover_partial_tail before appending"))
 
-        existing = index.get(idempotency_key)
+        existing = _idempotent_event(
+            index,
+            idempotency_key=idempotency_key,
+            request_digest=rd,
+        )
         if existing is not None:
-            existing_rd = existing.get("request_digest")
-            if not isinstance(existing_rd, str):
-                raise ChainIntegrityError(_bound("indexed journal event is missing request_digest"))
-            if existing_rd == rd:
-                return _envelope_to_event(existing)
-            existing_event_id = existing.get("event_id")
-            if not isinstance(existing_event_id, str):
-                raise ChainIntegrityError(_bound("indexed journal event is missing event_id"))
-            raise IdempotencyConflict(
-                _bound(f"idempotency key {idempotency_key!r} conflict"),
-                existing_event_id=existing_event_id,
-                request_digest=rd,
-                existing_request_digest=existing_rd,
-            )
+            return existing
 
         if expected_previous_sequence != last_sequence:
             raise StaleSequenceError(

--- a/src/brigade/run_lifecycle.py
+++ b/src/brigade/run_lifecycle.py
@@ -95,10 +95,9 @@ _CANONICALIZATION_CATEGORY = "lifecycle journal canonicalization failure"
 _CHAIN_CATEGORY = "lifecycle journal is not derivable"
 
 # Map of current run.json status values to the allowlisted run_event.v1
-# event_type that records that transition. Statuses without a mapping
-# (e.g. "running") are skipped: no event is appended and the run.json
-# snapshot refresh proceeds unchanged. This keeps the integration to the
-# current status transitions and the existing event registry -- no new schemas.
+# event_type that records that transition. Statuses without a mapping are
+# skipped: no event is appended and the run.json snapshot refresh proceeds
+# unchanged.
 STATUS_EVENT_TYPE: dict[str, str] = {
     "started": "run.created",
     "planning": "run.planning.started",
@@ -113,6 +112,8 @@ STATUS_EVENT_TYPE: dict[str, str] = {
     "dry-run": "run.completed",
     "incomplete": "run.failed",
     "artifact-collection": "run.artifact_collection.started",
+    "paused": "run.paused",
+    "running": "run.resumed",
 }
 
 _CHECKPOINT_EVENT_PAIR_LOCK = threading.Lock()
@@ -125,6 +126,24 @@ _DISPATCH_FACT_TYPES = frozenset(
         "run.dispatch.failed",
     }
 )
+APPROVAL_REFERENCE_REQUIRED_FIELDS = frozenset(
+    {
+        "approval_id",
+        "source",
+        "fingerprint",
+        "source_fingerprint",
+        "contract_fingerprint",
+        "evidence_fingerprint",
+    }
+)
+APPROVAL_REFERENCE_OPTIONAL_FIELDS = frozenset(
+    {
+        "decision_state",
+        "decided_at",
+        "consuming_run_id",
+    }
+)
+APPROVAL_REFERENCE_FIELDS = APPROVAL_REFERENCE_REQUIRED_FIELDS | APPROVAL_REFERENCE_OPTIONAL_FIELDS
 
 
 class LifecycleJournalError(RuntimeError):
@@ -430,7 +449,62 @@ def record_dispatch_fact(
             raise _bound_journal_failure(exc) from exc
 
 
-def _allowlisted_payload(event_type: str, *, status: str) -> dict[str, Any]:
+def normalize_approval_reference(reference: Mapping[str, Any]) -> dict[str, str]:
+    """Validate and copy the closed, reference-only approval snapshot shape."""
+    if not isinstance(reference, Mapping):
+        raise LifecycleJournalError("approval reference must be an object")
+    unknown = sorted(set(reference) - APPROVAL_REFERENCE_FIELDS)
+    if unknown:
+        raise LifecycleJournalError(run_events._bound(f"approval reference has unknown fields: {unknown[:8]}"))
+    missing = sorted(APPROVAL_REFERENCE_REQUIRED_FIELDS - set(reference))
+    if missing:
+        raise LifecycleJournalError(run_events._bound(f"approval reference is missing fields: {missing}"))
+    normalized: dict[str, str] = {}
+    for key in APPROVAL_REFERENCE_FIELDS:
+        if key not in reference:
+            continue
+        value = reference[key]
+        if not isinstance(value, str) or not value:
+            raise LifecycleJournalError(run_events._bound(f"approval reference field {key!r} must be non-empty text"))
+        if len(value) > run_events.MAX_PAYLOAD_STR_LEN:
+            raise LifecycleJournalError(
+                run_events._bound(f"approval reference field {key!r} exceeds {run_events.MAX_PAYLOAD_STR_LEN} chars")
+            )
+        if key == "decision_state" and value not in run_events.APPROVAL_DECISION_STATES:
+            raise LifecycleJournalError(run_events._bound(f"approval reference has invalid decision_state {value!r}"))
+        normalized[key] = value
+    return normalized
+
+
+def approval_idempotency_key(approval_id: str, fact: str, *, scope: str | None = None) -> str:
+    """Return a bounded key without copying approval identifiers into metadata."""
+    digest = hashlib.sha256(
+        run_events.canonical_bytes(
+            {
+                "approval_id": approval_id,
+                "fact": fact,
+                "scope": scope,
+            }
+        )
+    ).hexdigest()
+    return f"approval:{fact}:{digest[:32]}"
+
+
+def _approval_reference(incoming_snapshot: Mapping[str, Any] | None) -> dict[str, str] | None:
+    if incoming_snapshot is None or "approval_reference" not in incoming_snapshot:
+        return None
+    raw = incoming_snapshot.get("approval_reference")
+    if not isinstance(raw, Mapping):
+        raise LifecycleJournalError("approval reference must be an object")
+    return normalize_approval_reference(raw)
+
+
+def _allowlisted_payload(
+    event_type: str,
+    *,
+    status: str,
+    incoming_snapshot: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
     """Build a payload carrying only keys in the closed per-type allowlist."""
     allowed = run_events.EVENT_TYPES[event_type]
     payload: dict[str, Any] = {}
@@ -441,6 +515,13 @@ def _allowlisted_payload(event_type: str, *, status: str) -> dict[str, Any]:
         if len(text) > run_events.MAX_PAYLOAD_STR_LEN:
             text = text[: run_events.MAX_PAYLOAD_STR_LEN]
         payload["detail"] = text
+    if event_type in {"run.paused", "run.resumed"}:
+        reference = _approval_reference(incoming_snapshot)
+        if reference is None:
+            raise LifecycleJournalError(f"{event_type} requires an approval reference")
+        payload["approval_id"] = reference["approval_id"]
+        if event_type == "run.paused":
+            payload["reason"] = "approval-required"
     return payload
 
 
@@ -491,6 +572,89 @@ def prepare_lifecycle_journal(
         raise _bound_journal_failure(exc) from exc
     except OSError as exc:
         raise _bound_journal_failure(exc) from exc
+
+
+def record_lifecycle_event(
+    run_dir: Path,
+    *,
+    event_type: str,
+    payload: Mapping[str, Any],
+    idempotency_key: str,
+    workspace: Path | None,
+) -> run_journal.RunEvent:
+    """Append or replay one checkpoint-paired fact under the active run lock."""
+    run_dir = Path(run_dir).expanduser().resolve()
+    run_id = _run_id_from_dir(run_dir)
+    if not run_events._RUN_ID_RE.match(run_id):
+        raise LifecycleJournalError(run_events._bound(f"invalid run_id from run_dir: {run_id!r}"))
+    try:
+        run_events.validate_event_request(
+            event_type=event_type,
+            payload=payload,
+            idempotency_key=idempotency_key,
+        )
+    except run_events.CanonicalizationError as exc:
+        raise _bound_journal_failure(exc) from exc
+    with checkpoint_event_pair():
+        journal_path = _journal_path(run_dir)
+        if not journal_path.is_file():
+            raise LifecycleJournalError("lifecycle journal is not active for this run")
+        if workspace is None or not runguard.is_active_run_owner(workspace, run_dir):
+            raise LifecycleJournalError("lifecycle journal append requires the active run lock for this run")
+        try:
+            existing = run_journal.lookup_idempotent_event(
+                journal_path,
+                event_type=event_type,
+                payload=dict(payload),
+                idempotency_key=idempotency_key,
+            )
+            if existing is not None:
+                return existing
+            # Keep every explicit fact recoverable under the same authoritative
+            # prior gate used by status and per-worker dispatch pairs.
+            from brigade import aboyeur, run_shadow
+
+            snapshot = (run_dir / "run.json").read_bytes()
+            try:
+                snapshot_obj = json.loads(snapshot)
+            except (ValueError, UnicodeDecodeError) as exc:
+                raise LifecycleJournalError(run_events._bound("lifecycle run receipt is not valid JSON")) from exc
+            if not isinstance(snapshot_obj, dict):
+                raise LifecycleJournalError(run_events._bound("lifecycle run receipt is not a JSON object"))
+            if aboyeur._resolve_authority_state(run_dir) == "authoritative":
+                aboyeur._authoritative_prior_decision(run_dir, snapshot_obj)
+            checkpoint = run_checkpoint.write_checkpoint(
+                run_dir,
+                snapshot,
+                workspace=workspace,
+                paired_event_type=event_type,
+                body_kind=(
+                    run_checkpoint._BODY_KIND_BASE_STRIPPED
+                    if snapshot_obj.get("run_journal_authority_requested") is True
+                    else None
+                ),
+            )
+            if checkpoint is None:
+                raise LifecycleJournalError(run_events._bound("enrolled lifecycle journal checkpoint was not recorded"))
+            report = run_journal.read_journal(journal_path)
+            if report.partial_tail is not None or report.chain_errors:
+                raise run_journal.ChainIntegrityError(run_events._bound(_CHAIN_CATEGORY))
+            event = run_journal.append_event(
+                journal_path,
+                run_id=run_id,
+                event_type=event_type,
+                payload=dict(payload),
+                idempotency_key=idempotency_key,
+                expected_previous_sequence=report.events[-1].sequence if report.events else 0,
+            )
+            run_shadow.record_shadow_comparison(run_dir, snapshot_obj)
+            return event
+        except run_journal.RunJournalError as exc:
+            raise _bound_journal_failure(exc) from exc
+        except run_events.CanonicalizationError as exc:
+            raise _bound_journal_failure(exc) from exc
+        except OSError as exc:
+            raise _bound_journal_failure(exc) from exc
 
 
 def record_lifecycle_transition(
@@ -558,13 +722,18 @@ def record_lifecycle_transition(
         if report.partial_tail is not None or report.chain_errors:
             raise run_journal.ChainIntegrityError(run_events._bound(_CHAIN_CATEGORY))
         prior_status, prior_digest = _run_snapshot_state(run_dir)
-        payload = _allowlisted_payload(event_type, status=status)
+        payload = _allowlisted_payload(
+            event_type,
+            status=status,
+            incoming_snapshot=incoming_snapshot,
+        )
         # Status transitions, not detail refreshes: a same-status refresh
         # appends nothing once a status event is already committed, even when
         # error/detail fields changed. Recovery checkpoint events are not
         # status events, so a first mapped-status write still appends its
         # status event after the checkpoint event.
-        status_events = [e for e in report.events if e.event_type != run_checkpoint.CHECKPOINT_EVENT_TYPE]
+        mapped_event_types = frozenset(STATUS_EVENT_TYPE.values())
+        status_events = [e for e in report.events if e.event_type in mapped_event_types]
         if prior_status == status and status_events:
             return status_events[-1]
         # Real transition: the idempotency key binds the prior snapshot digest
@@ -603,10 +772,13 @@ def record_lifecycle_transition(
 __all__ = [
     "LifecycleJournalError",
     "STATUS_EVENT_TYPE",
+    "approval_idempotency_key",
     "checkpoint_event_pair",
     "is_lifecycle_journaling_enabled",
+    "normalize_approval_reference",
     "pending_dispatch_requests",
     "prepare_lifecycle_journal",
     "record_dispatch_fact",
+    "record_lifecycle_event",
     "record_lifecycle_transition",
 ]

--- a/src/brigade/run_projector.py
+++ b/src/brigade/run_projector.py
@@ -26,7 +26,7 @@ from typing import Any, Mapping, Sequence
 
 from brigade import run_checkpoint, run_events, run_journal
 
-PROJECTOR_VERSION: int = 4
+PROJECTOR_VERSION: int = 5
 
 # Field ownership over the run.json contract. Every current run.json key is
 # in exactly one of these two sets; see the ownership inventory in
@@ -59,6 +59,7 @@ PRESERVED_FIELDS: frozenset[str] = frozenset(
         "codex_transport",
         "lifecycle_journal_requested",
         "run_journal_authority_requested",
+        "approval_reference",
         # Timing
         "started_at",
         "status_started_at",
@@ -115,6 +116,10 @@ EVENT_STATUS: dict[str, str] = {
     "run.synthesis.started": "synthesizing",
     "run.synthesis.completed": "handoff",
     "run.artifact_collection.started": "artifact-collection",
+    # Approval waits retain the documented previous-reader nonterminal status.
+    # Current readers distinguish the wait through the approval reference.
+    "run.paused": "running",
+    "run.resumed": "running",
 }
 
 
@@ -128,6 +133,19 @@ def _has_dispatch_identity(payload: Any) -> bool:
         and payload["attempt"] > 0
     )
 
+
+# Approval observations do not themselves change the compatibility status.
+# ``run.paused`` and ``run.resumed`` own the status transition; the approval
+# facts between them only advance the verified journal cursor.
+_STATUS_NEUTRAL_EVENT_TYPES: frozenset[str] = frozenset(
+    {
+        "approval.requested",
+        "approval.granted",
+        "approval.rejected",
+        "approval.held",
+        "approval.consumed",
+    }
+)
 
 # Payload-driven rows: event_type -> (allowed payload status values, derived
 # status). A None derived status means the payload status value is used
@@ -274,6 +292,8 @@ def _derive_status(envelopes: list[Mapping[str, Any]], base_status: Any) -> str:
         sequence = env["sequence"]
         if event_type == run_checkpoint.CHECKPOINT_EVENT_TYPE:
             continue
+        if event_type in _STATUS_NEUTRAL_EVENT_TYPES:
+            continue
         # Slice-9 per-worker facts are status-neutral: a worker terminal
         # result must not advance the aggregate run while other seats remain
         # active. Older aggregate envelopes lacked an identity and retain
@@ -323,6 +343,13 @@ def project_run_snapshot(
         raise ProjectionInputError(_bound("journal_present must be a boolean"))
     if not isinstance(base_snapshot, Mapping):
         raise ProjectionInputError(_bound("base_snapshot must be a mapping"))
+    approval_reference = base_snapshot.get("approval_reference")
+    if approval_reference is not None:
+        if not isinstance(approval_reference, Mapping):
+            raise ProjectionInputError(_bound("base snapshot approval_reference must be a mapping"))
+        decision_state = approval_reference.get("decision_state")
+        if decision_state is not None and decision_state not in run_events.APPROVAL_DECISION_STATES:
+            raise ProjectionInputError(_bound("base snapshot approval_reference has invalid decision_state"))
 
     unknown = sorted(set(base_snapshot.keys()) - OWNED_FIELDS)
     if unknown:

--- a/src/brigade/run_resume.py
+++ b/src/brigade/run_resume.py
@@ -104,7 +104,12 @@ def resume(run_dir: Path) -> int:
         return 2
 
 
-def _resume_locked(run_dir: Path) -> int:
+def _resume_locked(
+    run_dir: Path,
+    *,
+    approval_resume: bool = False,
+    approval_token: str | None = None,
+) -> int:
     run_dir = run_dir.expanduser().resolve()
     run_meta = _load_json(run_dir, "run.json")
     roster_snapshot = _load_json(run_dir, "roster.json")
@@ -116,7 +121,16 @@ def _resume_locked(run_dir: Path) -> int:
         )
         return 2
     status = run_meta.get("status")
-    if not isinstance(status, str) or status in _NONTERMINAL_RUN_STATUSES:
+    approval_reference = run_meta.get("approval_reference")
+    approval_reserved = (
+        status == "running"
+        and isinstance(approval_reference, dict)
+        and approval_reference.get("decision_state") == "approved"
+    )
+    invalid_status = (
+        not approval_reserved if approval_resume else not isinstance(status, str) or status in _NONTERMINAL_RUN_STATUSES
+    )
+    if invalid_status:
         print("error: run is not terminal; recover or wait for the active run before resuming", file=sys.stderr)
         return 2
     raw_cwd = run_meta.get("cwd")
@@ -147,12 +161,31 @@ def _resume_locked(run_dir: Path) -> int:
 
     read_only = bool(run_meta.get("read_only"))
     sandbox = roster_snapshot.get("sandbox")
+    if approval_resume:
+        from . import runs_cmd
 
-    server = codex_appserver.AppServer(cwd=cwd)
+        if approval_token is None or not runs_cmd._APPROVAL_MARKER_RE.fullmatch(approval_token):
+            print("error: approval resume token is missing or invalid", file=sys.stderr)
+            return 2
+        server = codex_appserver.AppServer(
+            cwd=cwd,
+            env={runs_cmd._APPROVAL_RESUME_TOKEN_ENV: approval_token},
+        )
+    else:
+        server = codex_appserver.AppServer(cwd=cwd)
+
+    def redact_approval_token(value: str) -> str:
+        if approval_resume and approval_token is not None:
+            return value.replace(approval_token, "[redacted]")
+        return value
+
     try:
         server.start()
     except codex_appserver.AppServerError as exc:
-        print(f"error: codex app-server unavailable: {exc}", file=sys.stderr)
+        print(
+            f"error: codex app-server unavailable: {redact_approval_token(str(exc))}",
+            file=sys.stderr,
+        )
         return 2
     try:
         for entry in resumable:
@@ -176,15 +209,22 @@ def _resume_locked(run_dir: Path) -> int:
                 else:
                     turn = thread.run_turn(_continuation_prompt(entry.get("task", "")), timeout=timeout)
             except codex_appserver.AppServerError as exc:
-                entry["detail"] = str(exc)[:200]
+                entry["detail"] = redact_approval_token(str(exc))[:200]
                 entry["status"] = "failed"
                 continue
-            entry["text"] = turn.text.strip()
+            entry["text"] = redact_approval_token(turn.text).strip()
             entry["ok"] = turn.ok and bool(turn.text.strip())
-            entry["detail"] = "" if entry["ok"] else (turn.detail or f"turn {turn.status}")[:200]
+            entry["detail"] = "" if entry["ok"] else redact_approval_token(turn.detail or f"turn {turn.status}")[:200]
             entry["status"] = turn.status
     finally:
         server.close()
+
+    if approval_resume:
+        from . import runs_cmd
+
+        assert isinstance(approval_reference, dict)
+        reference = run_lifecycle.normalize_approval_reference(approval_reference)
+        runs_cmd._finalize_redeemed_approval(run_dir, cwd, reference)
 
     worker_results = [
         aboyeur.WorkerResult(

--- a/src/brigade/run_shadow.py
+++ b/src/brigade/run_shadow.py
@@ -347,6 +347,8 @@ def _checkpoint_status_write_gap(
         ):
             return False
         return pairing_key == run_checkpoint.dispatch_pairing_key(status_event.event_type, seat, attempt)
+    if status_event.event_type in run_checkpoint._status_neutral_event_types():
+        return True
     return run_checkpoint._paired_event_derived_status(status_event) is not None
 
 

--- a/src/brigade/run_transport.py
+++ b/src/brigade/run_transport.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import inspect
 import os
+import secrets
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -234,7 +235,13 @@ class AppserverRunner(Protocol):
 
 class EventWriter(Protocol):
     def __call__(
-        self, events_dir: Path | None, worker: str, *, verbose: bool = False
+        self,
+        events_dir: Path | None,
+        worker: str,
+        *,
+        verbose: bool = False,
+        workspace: Path | None = None,
+        correlation_marker: str | None = None,
     ) -> Callable[[dict[str, Any]], None] | None: ...
 
 
@@ -338,6 +345,7 @@ def dispatch(
         )
         started = time.monotonic()
         effective_read_only = read_only if sandbox_read_only is None else sandbox_read_only
+        approval_correlation_marker = secrets.token_urlsafe(32)
 
         def _invoke_external(
             selected_agent: Agent,
@@ -395,18 +403,50 @@ def dispatch(
                     **env_kwargs,
                 )
             if selected_agent.cli == "codex" and appserver is not None:
-                on_event = event_writer(events_dir, selected_agent.name, verbose=verbose)
-                return run_appserver_worker(
+                approval_prompt = (
+                    f"{selected_prompt}\n\n"
+                    "Approval correlation rule: prefix every Brigade CLI command in this turn with "
+                    f"`BRIGADE_APPROVAL_CORRELATION={approval_correlation_marker}`. "
+                    "Do not print or return that marker."
+                )
+                try:
+                    on_event = event_writer(
+                        events_dir,
+                        selected_agent.name,
+                        verbose=verbose,
+                        workspace=cwd,
+                        correlation_marker=approval_correlation_marker,
+                    )
+                except TypeError as exc:
+                    if "workspace" not in str(exc) and "correlation_marker" not in str(exc):
+                        raise
+                    on_event = event_writer(events_dir, selected_agent.name, verbose=verbose)
+                result = run_appserver_worker(
                     appserver,
                     selected_agent,
                     selected_agent.name,
-                    selected_prompt,
+                    approval_prompt,
                     timeout=timeout_for(selected_agent, roster),
                     cwd=cwd,
                     read_only=effective_read_only,
                     sandbox=sandbox,
                     registry=control_registry,
                     on_event=on_event,
+                )
+                return replace(
+                    result,
+                    text=result.text.replace(approval_correlation_marker, "[redacted]"),
+                    detail=result.detail.replace(approval_correlation_marker, "[redacted]"),
+                    stdout=(
+                        result.stdout.replace(approval_correlation_marker, "[redacted]")
+                        if result.stdout is not None
+                        else None
+                    ),
+                    stderr=(
+                        result.stderr.replace(approval_correlation_marker, "[redacted]")
+                        if result.stderr is not None
+                        else None
+                    ),
                 )
 
             timeout = timeout_for(selected_agent, roster)

--- a/src/brigade/runs_cmd.py
+++ b/src/brigade/runs_cmd.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
+import os
+import re
+import secrets
 import sys
 import time
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable, Mapping
 
 _NONTERMINAL_STATUSES = frozenset(
     {
@@ -22,6 +27,73 @@ _NONTERMINAL_STATUSES = frozenset(
     }
 )
 _SUCCESS_STATUSES = frozenset({"ok", "dry-run"})
+_APPROVAL_REFERENCE_FIELDS = (
+    "approval_id",
+    "source",
+    "fingerprint",
+    "source_fingerprint",
+    "contract_fingerprint",
+    "evidence_fingerprint",
+)
+_APPROVAL_PAUSE_REQUEST_FIELD = "brigade_approval_pause_request"
+_APPROVAL_PAUSE_REQUEST_SCHEMA = "brigade.approval_pause_request.v2"
+_APPROVAL_PAUSE_REQUEST_FIELDS = frozenset(
+    {
+        "schema",
+        "run_id",
+        "run_dir_fingerprint",
+        "owner_fingerprint",
+        "correlation_fingerprint",
+        "requester_worker",
+        "requester_thread_id",
+        "requester_turn_id",
+        "approval_reference",
+    }
+)
+_APPROVAL_CORRELATION_ENV = "BRIGADE_APPROVAL_CORRELATION"
+_APPROVAL_RESUME_TOKEN_ENV = "BRIGADE_APPROVAL_RESUME_TOKEN"
+_APPROVAL_MARKER_RE = re.compile(r"^[A-Za-z0-9_-]{32,128}$")
+_REQUESTER_COORDINATE_RE = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+
+
+class ApprovalResumeError(RuntimeError):
+    """An approval-paused run cannot safely resume."""
+
+
+class _ApprovalPauseReference(dict[str, str]):
+    """Closed approval reference with its in-memory requester correlation."""
+
+    requester_worker: str
+    requester_thread_id: str
+    requester_turn_id: str
+
+    def __init__(
+        self,
+        reference: Mapping[str, str],
+        *,
+        requester_worker: str,
+        requester_thread_id: str,
+        requester_turn_id: str,
+    ) -> None:
+        super().__init__(reference)
+        self.requester_worker = requester_worker
+        self.requester_thread_id = requester_thread_id
+        self.requester_turn_id = requester_turn_id
+
+
+@dataclass(frozen=True)
+class _ApprovalAuthorization:
+    status: str
+    decided_at: str | None
+    consumed_by: str | None
+    claimed_at: str | None = None
+
+
+@dataclass(frozen=True)
+class _ApprovalReservation:
+    decided_at: str
+    reserved_at: str
+    token: str
 
 
 def _read_json(path: Path) -> dict[str, Any] | None:
@@ -203,6 +275,796 @@ def _is_terminal(meta: dict[str, Any]) -> bool:
     if meta.get("finished_at"):
         return True
     return isinstance(status, str) and status not in _NONTERMINAL_STATUSES
+
+
+def _approval_resume_state(meta: Mapping[str, Any]) -> str | None:
+    reference = meta.get("approval_reference")
+    if not isinstance(reference, Mapping):
+        return None
+    state = reference.get("decision_state")
+    if meta.get("status") == "paused" and state is None:
+        return "pending"
+    if meta.get("status") == "running" and isinstance(state, str) and state:
+        return str(state)
+    return None
+
+
+def _is_intentional_approval_pause(meta: Mapping[str, Any]) -> bool:
+    state = _approval_resume_state(meta)
+    return state is not None and state != "consumed"
+
+
+def _approval_needs_reconciliation(meta: Mapping[str, Any]) -> bool:
+    return _approval_resume_state(meta) == "consumed"
+
+
+def _approval_reference_from_record(source: str, record: Mapping[str, Any]) -> dict[str, str]:
+    """Build the closed reference shape from an existing approval record."""
+    approval_id: object
+    source_fingerprint: object
+    contract_fingerprint: object
+    evidence_fingerprint: object
+    fingerprint_fn: Callable[[Any], str]
+    if source == "daily":
+        from .daily_cmd import config as daily_config
+
+        approval_id = record.get("approval_id")
+        source_fingerprint = record.get("source_fingerprint")
+        contract_fingerprint = record.get("config_fingerprint")
+        evidence_fingerprint = daily_config._fingerprint(record.get("evidence_refs", []))
+        fingerprint_fn = daily_config._fingerprint
+    elif source == "tool":
+        from .tools_cmd import helpers as tool_helpers
+
+        approval_id = record.get("id")
+        source_fingerprint = record.get("source_fingerprint") or tool_helpers._stable_hash({"source": None})
+        contract_fingerprint = record.get("contract_fingerprint")
+        evidence_fingerprint = record.get("call_fingerprint")
+        fingerprint_fn = tool_helpers._stable_hash
+    else:
+        raise ApprovalResumeError(f"unsupported approval source: {source}")
+    components = {
+        "approval_id": approval_id,
+        "source": source,
+        "source_fingerprint": source_fingerprint,
+        "contract_fingerprint": contract_fingerprint,
+        "evidence_fingerprint": evidence_fingerprint,
+    }
+    if any(not isinstance(value, str) or not value for value in components.values()):
+        raise ApprovalResumeError(f"{source} approval record is missing required fingerprints")
+    reference = {
+        **components,
+        "fingerprint": fingerprint_fn(components),
+    }
+    return {key: str(value) for key, value in reference.items()}
+
+
+def _reference_matches_record(reference: Mapping[str, str], record: Mapping[str, Any]) -> None:
+    actual = _approval_reference_from_record(reference["source"], record)
+    if any(reference.get(field) != actual[field] for field in _APPROVAL_REFERENCE_FIELDS):
+        raise ApprovalResumeError("approval fingerprints changed after the run paused")
+
+
+def _request_digest(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def _active_run_request_binding(workspace: Path) -> tuple[Path, str] | None:
+    """Return the live run and lock token visible to a child process."""
+    from . import runguard
+
+    workspace = workspace.expanduser().resolve()
+    owner = runguard._read_lock_owner(runguard.lock_path(workspace))
+    if owner is None:
+        return None
+    raw_run_dir = owner.get("run_dir")
+    owner_token = owner.get("owner_token")
+    if not isinstance(raw_run_dir, str) or not raw_run_dir:
+        return None
+    if not isinstance(owner_token, str) or not owner_token:
+        return None
+    try:
+        run_dir = Path(raw_run_dir).expanduser().resolve()
+    except (OSError, RuntimeError):
+        return None
+    if runguard.run_lock_state(workspace, run_dir) != "live":
+        return None
+    return run_dir, owner_token
+
+
+def _approval_marker_from_env(name: str) -> str | None:
+    value = os.environ.get(name)
+    if not isinstance(value, str) or not _APPROVAL_MARKER_RE.fullmatch(value):
+        return None
+    return value
+
+
+def _attach_approval_pause_request(workspace: Path, source: str, record: dict[str, Any]) -> bool:
+    """Attach a bounded request to an existing approval artifact.
+
+    The child never appends to the parent journal. The active owner later
+    validates this request against its exact lock acquisition and records the
+    pause itself.
+    """
+    binding = _active_run_request_binding(workspace)
+    correlation_marker = _approval_marker_from_env(_APPROVAL_CORRELATION_ENV)
+    if binding is None or correlation_marker is None:
+        return False
+    run_dir, owner_token = binding
+    reference = _approval_reference_from_record(source, record)
+    record[_APPROVAL_PAUSE_REQUEST_FIELD] = {
+        "schema": _APPROVAL_PAUSE_REQUEST_SCHEMA,
+        "run_id": run_dir.name,
+        "run_dir_fingerprint": _request_digest(str(run_dir)),
+        "owner_fingerprint": _request_digest(owner_token),
+        "correlation_fingerprint": _request_digest(correlation_marker),
+        "requester_worker": None,
+        "requester_thread_id": None,
+        "requester_turn_id": None,
+        "approval_reference": reference,
+    }
+    return True
+
+
+def _request_matches_active_binding(
+    request: Mapping[str, Any],
+    *,
+    run_dir: Path,
+    owner_token: str,
+) -> bool:
+    return (
+        set(request) == _APPROVAL_PAUSE_REQUEST_FIELDS
+        and request.get("schema") == _APPROVAL_PAUSE_REQUEST_SCHEMA
+        and request.get("run_id") == run_dir.name
+        and request.get("run_dir_fingerprint") == _request_digest(str(run_dir))
+        and request.get("owner_fingerprint") == _request_digest(owner_token)
+    )
+
+
+def _unbound_request_for_update(
+    workspace: Path,
+    request: object,
+    *,
+    source: str,
+    record: Mapping[str, Any],
+    run_dir: Path,
+    owner_token: str,
+    correlation_fingerprint: str,
+) -> dict[str, Any]:
+    """Revalidate one scanned request under its source-store lock."""
+    current_binding = _active_run_request_binding(workspace)
+    if current_binding != (run_dir, owner_token):
+        raise ApprovalResumeError("approval pause active binding changed before requester update")
+    if (
+        not isinstance(request, dict)
+        or not _request_matches_active_binding(request, run_dir=run_dir, owner_token=owner_token)
+        or request.get("correlation_fingerprint") != correlation_fingerprint
+    ):
+        raise ApprovalResumeError("approval pause request changed before requester update")
+    raw_reference = request.get("approval_reference")
+    if not isinstance(raw_reference, Mapping):
+        raise ApprovalResumeError("approval pause request lost its approval reference")
+    from . import run_lifecycle
+
+    try:
+        request_reference = run_lifecycle.normalize_approval_reference(raw_reference)
+    except run_lifecycle.LifecycleJournalError as exc:
+        raise ApprovalResumeError("approval pause request reference changed before requester update") from exc
+    if request_reference != _approval_reference_from_record(source, record):
+        raise ApprovalResumeError("approval pause request reference changed before requester update")
+    coordinate_fields = ("requester_worker", "requester_thread_id", "requester_turn_id")
+    if any(request.get(field) is not None for field in coordinate_fields):
+        raise ApprovalResumeError("approval pause request is already bound")
+    return request
+
+
+def _bind_approval_pause_request(
+    workspace: Path,
+    *,
+    correlation_marker: str,
+    worker: str,
+    thread_id: str,
+    turn_id: str,
+) -> None:
+    """Atomically bind one child request to its completed command coordinates."""
+    coordinates = (worker, thread_id, turn_id)
+    if not _APPROVAL_MARKER_RE.fullmatch(correlation_marker) or any(
+        not _REQUESTER_COORDINATE_RE.fullmatch(value) for value in coordinates
+    ):
+        raise ApprovalResumeError("approval pause requester binding is invalid")
+    binding = _active_run_request_binding(workspace)
+    if binding is None:
+        raise ApprovalResumeError("approval pause requester binding requires an active run")
+    run_dir, owner_token = binding
+    correlation_fingerprint = _request_digest(correlation_marker)
+    from .daily_cmd import approvals as daily_approvals
+    from .tools_cmd import calls as tool_calls
+
+    candidates: list[tuple[str, str]] = []
+    daily_records, _ = daily_approvals._read_approvals(workspace)
+    for daily_record in daily_records:
+        request = daily_record.get(_APPROVAL_PAUSE_REQUEST_FIELD)
+        if (
+            isinstance(request, Mapping)
+            and _request_matches_active_binding(request, run_dir=run_dir, owner_token=owner_token)
+            and request.get("correlation_fingerprint") == correlation_fingerprint
+        ):
+            candidates.append(("daily", str(daily_record.get("approval_id") or "")))
+    for tool_record in tool_calls._read_calls(workspace):
+        request = tool_record.get(_APPROVAL_PAUSE_REQUEST_FIELD)
+        if (
+            isinstance(request, Mapping)
+            and _request_matches_active_binding(request, run_dir=run_dir, owner_token=owner_token)
+            and request.get("correlation_fingerprint") == correlation_fingerprint
+        ):
+            candidates.append(("tool", str(tool_record.get("id") or "")))
+    if len(candidates) != 1 or not candidates[0][1]:
+        raise ApprovalResumeError("approval pause correlation did not match exactly one request")
+    source, approval_id = candidates[0]
+    coordinate_fields = ("requester_worker", "requester_thread_id", "requester_turn_id")
+    if source == "daily":
+        with daily_approvals._approval_store_lock(workspace, approval_id):
+            bound_daily_record = daily_approvals._find_approval(workspace, approval_id)
+            if bound_daily_record is None:
+                raise ApprovalResumeError("daily approval disappeared during requester binding")
+            request = _unbound_request_for_update(
+                workspace,
+                bound_daily_record.get(_APPROVAL_PAUSE_REQUEST_FIELD),
+                source=source,
+                record=bound_daily_record,
+                run_dir=run_dir,
+                owner_token=owner_token,
+                correlation_fingerprint=correlation_fingerprint,
+            )
+            request.update(dict(zip(coordinate_fields, coordinates, strict=True)))
+            daily_approvals._write_approval_unlocked(workspace, bound_daily_record)
+        return
+    with tool_calls._calls_store_lock(workspace):
+        bound_tool_record, calls, error = tool_calls._resolve_call(workspace, approval_id)
+        if bound_tool_record is None:
+            raise ApprovalResumeError(error or "tool approval disappeared during requester binding")
+        request = _unbound_request_for_update(
+            workspace,
+            bound_tool_record.get(_APPROVAL_PAUSE_REQUEST_FIELD),
+            source=source,
+            record=bound_tool_record,
+            run_dir=run_dir,
+            owner_token=owner_token,
+            correlation_fingerprint=correlation_fingerprint,
+        )
+        request.update(dict(zip(coordinate_fields, coordinates, strict=True)))
+        tool_calls._write_calls_unlocked(workspace, calls)
+
+
+def _request_reference_for_owned_run(
+    request: object,
+    *,
+    source: str,
+    record: Mapping[str, Any],
+    run_dir: Path,
+    owner_token: str,
+) -> _ApprovalPauseReference | None:
+    from . import run_lifecycle
+
+    if not isinstance(request, Mapping):
+        return None
+    if request.get("run_id") != run_dir.name:
+        return None
+    if set(request) != _APPROVAL_PAUSE_REQUEST_FIELDS:
+        raise ApprovalResumeError("approval pause request has an invalid shape")
+    if request.get("schema") != _APPROVAL_PAUSE_REQUEST_SCHEMA:
+        raise ApprovalResumeError("approval pause request has an unsupported schema")
+    if request.get("run_dir_fingerprint") != _request_digest(str(run_dir)):
+        raise ApprovalResumeError("approval pause request targets a different run directory")
+    if request.get("owner_fingerprint") != _request_digest(owner_token):
+        raise ApprovalResumeError("approval pause request targets a different lock acquisition")
+    correlation_fingerprint = request.get("correlation_fingerprint")
+    if not isinstance(correlation_fingerprint, str) or not re.fullmatch(r"[0-9a-f]{64}", correlation_fingerprint):
+        raise ApprovalResumeError("approval pause request has an invalid correlation fingerprint")
+    requester_worker = request.get("requester_worker")
+    requester_thread_id = request.get("requester_thread_id")
+    requester_turn_id = request.get("requester_turn_id")
+    if any(
+        not isinstance(value, str) or not _REQUESTER_COORDINATE_RE.fullmatch(value)
+        for value in (requester_worker, requester_thread_id, requester_turn_id)
+    ):
+        raise ApprovalResumeError("approval pause request is not bound to a valid requester")
+    raw_reference = request.get("approval_reference")
+    if not isinstance(raw_reference, Mapping):
+        raise ApprovalResumeError("approval pause request has no approval reference")
+    try:
+        reference = run_lifecycle.normalize_approval_reference(raw_reference)
+    except run_lifecycle.LifecycleJournalError as exc:
+        raise ApprovalResumeError(f"approval pause request reference is invalid: {exc}") from exc
+    if reference["source"] != source:
+        raise ApprovalResumeError("approval pause request source does not match its artifact")
+    _reference_matches_record(reference, record)
+    assert isinstance(requester_worker, str)
+    assert isinstance(requester_thread_id, str)
+    assert isinstance(requester_turn_id, str)
+    return _ApprovalPauseReference(
+        reference,
+        requester_worker=requester_worker,
+        requester_thread_id=requester_thread_id,
+        requester_turn_id=requester_turn_id,
+    )
+
+
+def _approval_pause_reference_for_owned_run(workspace: Path, run_dir: Path) -> _ApprovalPauseReference | None:
+    """Resolve one child request while the current process owns the run lock."""
+    from . import runguard
+    from .daily_cmd import approvals as daily_approvals
+    from .tools_cmd import calls as tool_calls
+
+    workspace = workspace.expanduser().resolve()
+    run_dir = run_dir.expanduser().resolve()
+    if not runguard.is_active_run_owner(workspace, run_dir):
+        raise ApprovalResumeError("approval pause request requires the active run owner")
+    owner = runguard._read_lock_owner(runguard.lock_path(workspace))
+    owner_token = owner.get("owner_token") if owner is not None else None
+    if not isinstance(owner_token, str) or not owner_token:
+        raise ApprovalResumeError("active run lock has no owner token")
+
+    candidates: list[_ApprovalPauseReference] = []
+    daily_records, _ = daily_approvals._read_approvals(workspace)
+    for record in daily_records:
+        reference = _request_reference_for_owned_run(
+            record.get(_APPROVAL_PAUSE_REQUEST_FIELD),
+            source="daily",
+            record=record,
+            run_dir=run_dir,
+            owner_token=owner_token,
+        )
+        if reference is not None:
+            candidates.append(reference)
+    for record in tool_calls._read_calls(workspace):
+        reference = _request_reference_for_owned_run(
+            record.get(_APPROVAL_PAUSE_REQUEST_FIELD),
+            source="tool",
+            record=record,
+            run_dir=run_dir,
+            owner_token=owner_token,
+        )
+        if reference is not None:
+            candidates.append(reference)
+    if not candidates:
+        return None
+    unique = {
+        (
+            json.dumps(reference, sort_keys=True),
+            reference.requester_worker,
+            reference.requester_thread_id,
+            reference.requester_turn_id,
+        )
+        for reference in candidates
+    }
+    if len(unique) != 1:
+        raise ApprovalResumeError("multiple approval pause requests target the active run")
+    return candidates[0]
+
+
+def _daily_authorization(
+    workspace: Path,
+    reference: Mapping[str, str],
+    *,
+    run_id: str,
+) -> _ApprovalAuthorization:
+    from .daily_cmd import approvals as daily_approvals
+    from .daily_cmd import config as daily_config
+
+    approval = daily_approvals._find_approval(workspace, reference["approval_id"])
+    if not isinstance(approval, dict):
+        raise ApprovalResumeError(f"daily approval not found: {reference['approval_id']}")
+    _reference_matches_record(reference, approval)
+    status = str(approval.get("status") or "")
+    decided_at = approval.get("reviewed_at")
+    decided_text = decided_at if isinstance(decided_at, str) and decided_at else None
+    consumed = approval.get("consumed_run_id")
+    consumed_by = consumed if isinstance(consumed, str) and consumed else None
+    claim = approval.get("approval_claim")
+    if isinstance(claim, Mapping):
+        claim_run_id = claim.get("run_id")
+        claim_state = claim.get("state")
+        claim_time = claim.get("redeemed_at") if claim_state == "redeemed" else claim.get("reserved_at")
+        return _ApprovalAuthorization(
+            status=str(claim_state or ""),
+            decided_at=decided_text,
+            consumed_by=claim_run_id if isinstance(claim_run_id, str) else None,
+            claimed_at=claim_time if isinstance(claim_time, str) else None,
+        )
+    if status == "approved":
+        config, _ = daily_config._load_config(workspace)
+        blockers = daily_approvals._approval_blockers(workspace, approval, config)
+        if blockers:
+            raise ApprovalResumeError(f"daily approval is stale or blocked: {blockers[0]}")
+        return _ApprovalAuthorization(
+            status=status,
+            decided_at=decided_text,
+            consumed_by=None,
+        )
+    if status == "consumed" and consumed_by == run_id:
+        config, _ = daily_config._load_config(workspace)
+        revalidation = dict(approval)
+        revalidation["status"] = "approved"
+        revalidation["consumed_run_id"] = None
+        blockers = daily_approvals._approval_blockers(workspace, revalidation, config)
+        if blockers:
+            raise ApprovalResumeError(f"daily approval is stale or blocked: {blockers[0]}")
+    return _ApprovalAuthorization(
+        status=status,
+        decided_at=decided_text,
+        consumed_by=consumed_by,
+    )
+
+
+def _tool_authorization(
+    workspace: Path,
+    reference: Mapping[str, str],
+    *,
+    run_id: str,
+) -> _ApprovalAuthorization:
+    from .tools_cmd import calls as tool_calls
+
+    call, _calls, error = tool_calls._resolve_call(workspace, reference["approval_id"])
+    if call is None:
+        raise ApprovalResumeError(error or f"tool approval not found: {reference['approval_id']}")
+    _reference_matches_record(reference, call)
+    status = str(call.get("status") or "")
+    decided_at = call.get("reviewed_at")
+    decided_text = decided_at if isinstance(decided_at, str) and decided_at else None
+    stored_run_id = call.get("run_id")
+    consumed_by = stored_run_id if isinstance(stored_run_id, str) and stored_run_id else None
+    claim = call.get("approval_claim")
+    if isinstance(claim, Mapping):
+        claim_run_id = claim.get("run_id")
+        claim_state = claim.get("state")
+        claim_time = claim.get("redeemed_at") if claim_state == "redeemed" else claim.get("reserved_at")
+        return _ApprovalAuthorization(
+            status=str(claim_state or ""),
+            decided_at=decided_text,
+            consumed_by=claim_run_id if isinstance(claim_run_id, str) else None,
+            claimed_at=claim_time if isinstance(claim_time, str) else None,
+        )
+    if status == "approved":
+        blockers = tool_calls._call_run_blockers(workspace, call)
+        if blockers:
+            raise ApprovalResumeError(f"tool approval is stale or blocked: {blockers[0]}")
+
+        return _ApprovalAuthorization(
+            status=status,
+            decided_at=decided_text,
+            consumed_by=None,
+        )
+    if status == "running":
+        if consumed_by == run_id:
+            revalidation = dict(call)
+            revalidation["status"] = "approved"
+            revalidation["run_id"] = None
+            revalidation["started_at"] = None
+            revalidation["completed_at"] = None
+            blockers = tool_calls._call_run_blockers(workspace, revalidation)
+            if blockers:
+                raise ApprovalResumeError(f"tool approval is stale or blocked: {blockers[0]}")
+        status = "consumed"
+    return _ApprovalAuthorization(
+        status=status,
+        decided_at=decided_text,
+        consumed_by=consumed_by,
+    )
+
+
+def _load_approval_authorization(
+    workspace: Path,
+    reference: Mapping[str, str],
+    *,
+    run_id: str,
+) -> _ApprovalAuthorization:
+    source = reference["source"]
+    if source == "daily":
+        return _daily_authorization(workspace, reference, run_id=run_id)
+    if source == "tool":
+        return _tool_authorization(workspace, reference, run_id=run_id)
+    raise ApprovalResumeError(f"unsupported approval source: {source}")
+
+
+def _reserve_approval(
+    workspace: Path,
+    reference: Mapping[str, str],
+    *,
+    run_id: str,
+) -> _ApprovalReservation:
+    token = secrets.token_urlsafe(32)
+    token_fingerprint = _request_digest(token)
+    source = reference["source"]
+    if source == "daily":
+        from .daily_cmd import approvals as daily_approvals
+
+        try:
+            claim = daily_approvals.reserve_for_run(
+                workspace,
+                reference["approval_id"],
+                reference,
+                run_id,
+                token_fingerprint,
+            )
+        except daily_approvals.ApprovalClaimError as exc:
+            raise ApprovalResumeError(str(exc)) from exc
+        return _ApprovalReservation(
+            decided_at=claim.decided_at,
+            reserved_at=claim.claimed_at,
+            token=token,
+        )
+    elif source == "tool":
+        from .tools_cmd import calls as tool_calls
+
+        try:
+            tool_claim = tool_calls.reserve_for_run(
+                workspace,
+                reference["approval_id"],
+                reference,
+                run_id,
+                token_fingerprint,
+            )
+        except tool_calls.CallClaimError as exc:
+            raise ApprovalResumeError(str(exc)) from exc
+        return _ApprovalReservation(
+            decided_at=tool_claim.decided_at,
+            reserved_at=tool_claim.claimed_at,
+            token=token,
+        )
+    raise ApprovalResumeError(f"unsupported approval source: {source}")
+
+
+def _record_approval_decision(
+    run_dir: Path,
+    workspace: Path,
+    reference: Mapping[str, str],
+    authorization: _ApprovalAuthorization,
+) -> None:
+    from . import run_lifecycle
+
+    if authorization.decided_at is None:
+        raise ApprovalResumeError("approval decision has no review timestamp")
+    event_decision = "granted" if authorization.status == "approved" else authorization.status
+    run_lifecycle.record_lifecycle_event(
+        run_dir,
+        event_type=f"approval.{event_decision}",
+        payload={
+            "approval_id": reference["approval_id"],
+            "decided_at": authorization.decided_at,
+            "decision_state": authorization.status,
+        },
+        idempotency_key=run_lifecycle.approval_idempotency_key(
+            reference["approval_id"],
+            event_decision,
+        ),
+        workspace=workspace,
+    )
+
+
+def _refresh_paused_snapshot(
+    run_dir: Path,
+    meta: Mapping[str, Any],
+    reference: Mapping[str, str],
+    *,
+    decision_state: str = "pending",
+    decided_at: str | None = None,
+) -> None:
+    from . import aboyeur, receipt_schema
+
+    refreshed = dict(meta)
+    refreshed["status"] = "running"
+    refreshed_reference = {
+        **reference,
+        "decision_state": decision_state,
+    }
+    if decided_at is not None:
+        refreshed_reference["decided_at"] = decided_at
+    refreshed["approval_reference"] = refreshed_reference
+    aboyeur._write_json(run_dir / "run.json", receipt_schema.stamp_run_receipt(refreshed))
+
+
+def _refresh_resumed_snapshot(
+    run_dir: Path,
+    meta: Mapping[str, Any],
+    reference: Mapping[str, str],
+    *,
+    decided_at: str | None,
+    claimed_at: str,
+) -> None:
+    from . import aboyeur, receipt_schema
+
+    refreshed = dict(meta)
+    refreshed["status"] = "running"
+    refreshed["status_started_at"] = claimed_at
+    refreshed.pop("finished_at", None)
+    refreshed.pop("duration_seconds", None)
+    resumed_reference = {
+        **reference,
+        "decision_state": "consumed",
+        "consuming_run_id": run_dir.name,
+    }
+    if decided_at is not None:
+        resumed_reference["decided_at"] = decided_at
+    refreshed["approval_reference"] = resumed_reference
+    aboyeur._write_json(run_dir / "run.json", receipt_schema.stamp_run_receipt(refreshed))
+
+
+def _finalize_redeemed_approval(
+    run_dir: Path,
+    workspace: Path,
+    reference: Mapping[str, str],
+) -> None:
+    """Commit consumed/resumed facts only after the source CAS redeemed."""
+    from . import run_lifecycle
+
+    run_id = run_dir.name
+    source = reference["source"]
+    record: Mapping[str, Any] | None
+    if source == "daily":
+        from .daily_cmd import approvals as daily_approvals
+
+        record = daily_approvals._find_approval(workspace, reference["approval_id"])
+    elif source == "tool":
+        from .tools_cmd import calls as tool_calls
+
+        record, _calls, _error = tool_calls._resolve_call(workspace, reference["approval_id"])
+    else:
+        raise ApprovalResumeError(f"unsupported approval source: {source}")
+    if not isinstance(record, Mapping):
+        raise ApprovalResumeError("approval source record disappeared after resumed action")
+    _reference_matches_record(reference, record)
+    claim = record.get("approval_claim")
+    if (
+        not isinstance(claim, Mapping)
+        or claim.get("run_id") != run_id
+        or claim.get("state") != "redeemed"
+        or not isinstance(claim.get("redeemed_at"), str)
+    ):
+        raise ApprovalResumeError("approval action did not redeem its reserved claim")
+    run_lifecycle.record_lifecycle_event(
+        run_dir,
+        event_type="approval.consumed",
+        payload={
+            "approval_id": reference["approval_id"],
+            "consuming_run_id": run_id,
+        },
+        idempotency_key=run_lifecycle.approval_idempotency_key(
+            reference["approval_id"],
+            "consumed",
+            scope=run_id,
+        ),
+        workspace=workspace,
+    )
+    run_lifecycle.record_lifecycle_event(
+        run_dir,
+        event_type="run.resumed",
+        payload={"approval_id": reference["approval_id"]},
+        idempotency_key=run_lifecycle.approval_idempotency_key(
+            reference["approval_id"],
+            "resumed",
+            scope=run_id,
+        ),
+        workspace=workspace,
+    )
+    meta = _read_json(run_dir / "run.json")
+    if meta is None:
+        raise ApprovalResumeError("approval run receipt disappeared after resumed action")
+    decided_at = record.get("reviewed_at")
+    _refresh_resumed_snapshot(
+        run_dir,
+        meta,
+        reference,
+        decided_at=decided_at if isinstance(decided_at, str) else None,
+        claimed_at=str(claim["redeemed_at"]),
+    )
+
+
+def resume(run_dir: Path) -> int:
+    """Resume a legacy run or consume an approval before a paused continuation."""
+    from . import run_lifecycle, run_resume, runguard
+
+    run_dir = run_dir.expanduser().resolve()
+    try:
+        meta = _read_json(run_dir / "run.json")
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    if meta is None or _approval_resume_state(meta) is None:
+        return run_resume.resume(run_dir)
+    raw_reference = meta.get("approval_reference")
+    if not isinstance(raw_reference, Mapping):
+        print("error: approval-paused run has no approval reference", file=sys.stderr)
+        return 2
+    try:
+        reference = run_lifecycle.normalize_approval_reference(raw_reference)
+    except run_lifecycle.LifecycleJournalError as exc:
+        print(f"error: invalid approval reference: {exc}", file=sys.stderr)
+        return 2
+    workspace = runguard.resolve_run_lock_workspace(meta, run_dir)
+    if workspace is None:
+        print("error: run artifact has no workspace cwd; cannot acquire resume lock", file=sys.stderr)
+        return 2
+    state = runguard.run_lock_state(workspace, run_dir)
+    if state != "absent":
+        print(
+            f"error: approval-paused run requires an absent lock before resume; found {state}",
+            file=sys.stderr,
+        )
+        return 2
+    try:
+        with runguard.run_lock(workspace, run_dir=run_dir):
+            current = _read_json(run_dir / "run.json")
+            if current is None or _approval_resume_state(current) is None:
+                raise ApprovalResumeError("approval-paused run changed before resume lock acquisition")
+            current_raw_reference = current.get("approval_reference")
+            if not isinstance(current_raw_reference, Mapping):
+                raise ApprovalResumeError("approval-paused run lost its approval reference")
+            current_reference = run_lifecycle.normalize_approval_reference(current_raw_reference)
+            if current_reference != reference:
+                raise ApprovalResumeError("approval reference changed before resume lock acquisition")
+            current_decision_state = _approval_resume_state(current)
+            if current_decision_state == "rejected":
+                raise ApprovalResumeError("approval is rejected")
+            authorization = _load_approval_authorization(
+                workspace,
+                reference,
+                run_id=run_dir.name,
+            )
+            if authorization.status in {"rejected", "held"}:
+                _record_approval_decision(run_dir, workspace, reference, authorization)
+                _refresh_paused_snapshot(
+                    run_dir,
+                    current,
+                    reference,
+                    decision_state=authorization.status,
+                    decided_at=authorization.decided_at,
+                )
+                raise ApprovalResumeError(f"approval is {authorization.status}")
+            if authorization.status == "redeemed":
+                raise ApprovalResumeError("approval claim is already redeemed; outcome reconciliation is required")
+            if authorization.status in {"consumed", "reserved"}:
+                if authorization.consumed_by != run_dir.name:
+                    owner = authorization.consumed_by or "another run"
+                    raise ApprovalResumeError(f"approval was already consumed by {owner}")
+            elif authorization.status != "approved":
+                raise ApprovalResumeError(f"approval is {authorization.status or 'pending'}")
+            reservation = _reserve_approval(
+                workspace,
+                reference,
+                run_id=run_dir.name,
+            )
+            _record_approval_decision(
+                run_dir,
+                workspace,
+                reference,
+                _ApprovalAuthorization(
+                    status="approved",
+                    decided_at=reservation.decided_at,
+                    consumed_by=run_dir.name,
+                ),
+            )
+            _refresh_paused_snapshot(
+                run_dir,
+                current,
+                reference,
+                decision_state="approved",
+                decided_at=reservation.decided_at,
+            )
+            return run_resume._resume_locked(
+                run_dir,
+                approval_resume=True,
+                approval_token=reservation.token,
+            )
+    except (
+        ApprovalResumeError,
+        ValueError,
+        OSError,
+        runguard.RunGuardError,
+        run_lifecycle.LifecycleJournalError,
+    ) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
 
 
 def _failure_fields(meta: dict[str, Any]) -> tuple[object, object, object]:
@@ -842,6 +1704,21 @@ def recover(run: str | Path, *, cwd: Path, runs_dir: Path | None = None) -> int:
     from . import runguard
 
     state = runguard.run_lock_state(workspace, run_dir)
+    if parseable and run_meta is not None and _approval_resume_state(run_meta) is not None:
+        if state == "live":
+            print(_state_refusal_message(state, workspace), file=sys.stderr)
+            return 2
+        if _approval_needs_reconciliation(run_meta):
+            print(
+                f"error: approval resume requires reconciliation; run `brigade runs resume {run_dir}`",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                f"error: approval wait is intentional; run `brigade runs resume {run_dir}` after review",
+                file=sys.stderr,
+            )
+        return 2
     if state in {"foreign", "invalid"}:
         # A foreign or invalid current lock must not block recovery of a
         # matching persistent .stale claim: runguard.recover_stale_run skips
@@ -919,6 +1796,34 @@ def watch(
                     if "owner process is still active" not in detail and "recovery is still active" not in detail:
                         print(f"error: artifact-collection recovery failed: {detail}", file=sys.stderr)
                         return 2
+        approval_state = _approval_resume_state(run_meta)
+        if approval_state is not None:
+            workspace = _lock_workspace(run_dir, run_meta, fallback=cwd)
+            if workspace is None:
+                print(f"error: approval run has no workspace cwd: {run_dir}", file=sys.stderr)
+                return 2
+            from . import runguard
+
+            lock_state = runguard.run_lock_state(workspace, run_dir)
+            if lock_state == "live":
+                time.sleep(interval)
+                continue
+            if _approval_needs_reconciliation(run_meta):
+                print(
+                    f"error: approval resume requires reconciliation; run `brigade runs resume {run_dir}`",
+                    file=sys.stderr,
+                )
+                return 2
+            if lock_state != "absent":
+                print(
+                    f"error: approval wait has unexpected run lock state {lock_state}",
+                    file=sys.stderr,
+                )
+                return 2
+            if not summary_emitted:
+                _emit_summary(run_dir, run_meta, json_output=json_output)
+                summary_emitted = True
+            return _watch_return_code(run_meta.get("status"))
         if _is_terminal(run_meta):
             if not summary_emitted:
                 _emit_summary(run_dir, run_meta, json_output=json_output)

--- a/src/brigade/tools_cmd/calls.py
+++ b/src/brigade/tools_cmd/calls.py
@@ -5,11 +5,35 @@ from __future__ import annotations
 import json
 import re
 import sys
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from .. import localio, runguard
 from ..render import emit
 from . import constants, helpers, paths, projections, runtimes, safety
+
+_APPROVAL_REFERENCE_FIELDS = (
+    "approval_id",
+    "source",
+    "fingerprint",
+    "source_fingerprint",
+    "contract_fingerprint",
+    "evidence_fingerprint",
+)
+
+
+class CallClaimError(RuntimeError):
+    """A Tool approval could not be claimed from its current stored state."""
+
+
+@dataclass(frozen=True)
+class CallClaim:
+    decided_at: str
+    claimed_at: str
+    already_claimed: bool
 
 
 def _describe_payload(target: Path, tool_id: str) -> dict[str, Any]:
@@ -189,6 +213,22 @@ def _call_plan_payload(
     }
 
 
+def _calls_lock_path(target: Path) -> Path:
+    path = paths.calls_path(target)
+    return path.with_name(f"{path.name}.lock")
+
+
+@contextmanager
+def _calls_store_lock(target: Path) -> Iterator[None]:
+    path = _calls_lock_path(target)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ownership = runguard._acquire_lock(path)
+    try:
+        yield
+    finally:
+        runguard._release_lock(path, ownership)
+
+
 def _read_calls(target: Path) -> list[dict[str, Any]]:
     path = paths.calls_path(target)
     if not path.is_file():
@@ -206,11 +246,16 @@ def _read_calls(target: Path) -> list[dict[str, Any]]:
     return calls
 
 
-def _write_calls(target: Path, calls: list[dict[str, Any]]) -> None:
+def _write_calls_unlocked(target: Path, calls: list[dict[str, Any]]) -> None:
     path = paths.calls_path(target)
     path.parent.mkdir(parents=True, exist_ok=True)
     text = "".join(json.dumps(item, sort_keys=True, separators=(",", ":")) + "\n" for item in calls)
-    path.write_text(text)
+    localio.write_text_atomic(path, text)
+
+
+def _write_calls(target: Path, calls: list[dict[str, Any]]) -> None:
+    with _calls_store_lock(target):
+        _write_calls_unlocked(target, calls)
 
 
 def _call_fingerprint(plan_payload: dict[str, Any]) -> str:
@@ -272,6 +317,148 @@ def _approval_fingerprint(call: dict[str, Any]) -> str:
             "source_fingerprint": call.get("source_fingerprint"),
         }
     )
+
+
+def _approval_claim_reference(call: Mapping[str, Any]) -> dict[str, str]:
+    components = {
+        "approval_id": call.get("id"),
+        "source": "tool",
+        "source_fingerprint": call.get("source_fingerprint") or helpers._stable_hash({"source": None}),
+        "contract_fingerprint": call.get("contract_fingerprint"),
+        "evidence_fingerprint": call.get("call_fingerprint"),
+    }
+    if any(not isinstance(value, str) or not value for value in components.values()):
+        raise CallClaimError("tool approval record is missing required fingerprints")
+    return {
+        **{key: str(value) for key, value in components.items()},
+        "fingerprint": helpers._stable_hash(components),
+    }
+
+
+def claim_for_run(
+    target: Path,
+    approval_id: str,
+    reference: Mapping[str, str],
+    run_id: str,
+) -> CallClaim:
+    """Atomically validate and claim one approved Tool call for a run."""
+    with _calls_store_lock(target):
+        call, calls, error = _resolve_call(target, approval_id)
+        if call is None:
+            raise CallClaimError(error or f"tool approval not found: {approval_id}")
+        actual = _approval_claim_reference(call)
+        if any(reference.get(field) != actual[field] for field in _APPROVAL_REFERENCE_FIELDS):
+            raise CallClaimError("tool approval fingerprints changed before claim")
+        status = str(call.get("status") or "")
+        consumed_by = call.get("run_id")
+        if status == "running" and consumed_by == run_id:
+            revalidation = dict(call)
+            revalidation["status"] = "approved"
+            revalidation["run_id"] = None
+            revalidation["started_at"] = None
+            revalidation["completed_at"] = None
+            blockers = _call_run_blockers(target, revalidation)
+            if blockers:
+                raise CallClaimError(f"tool approval is stale or blocked: {blockers[0]}")
+            decided_at = call.get("reviewed_at")
+            if not isinstance(decided_at, str) or not decided_at:
+                raise CallClaimError("tool approval decision has no review timestamp")
+            claimed_at = call.get("started_at")
+            if not isinstance(claimed_at, str) or not claimed_at:
+                raise CallClaimError("tool approval claim has no start timestamp")
+            return CallClaim(
+                decided_at=decided_at,
+                claimed_at=claimed_at,
+                already_claimed=True,
+            )
+        if status != "approved":
+            raise CallClaimError(f"tool approval is {status or 'pending'}")
+        blockers = _call_run_blockers(target, call)
+        if blockers:
+            raise CallClaimError(f"tool approval is stale or blocked: {blockers[0]}")
+        decided_at = call.get("reviewed_at")
+        if not isinstance(decided_at, str) or not decided_at:
+            raise CallClaimError("tool approval decision has no review timestamp")
+        claimed_at = helpers._now().isoformat()
+        call["status"] = "running"
+        call["started_at"] = claimed_at
+        call["completed_at"] = None
+        call["run_id"] = run_id
+        _write_calls_unlocked(target, calls)
+        return CallClaim(
+            decided_at=decided_at,
+            claimed_at=claimed_at,
+            already_claimed=False,
+        )
+
+
+def reserve_for_run(
+    target: Path,
+    approval_id: str,
+    reference: Mapping[str, str],
+    run_id: str,
+    token_fingerprint: str,
+) -> CallClaim:
+    """Reserve a rotatable one-shot Tool claim without changing call status."""
+    with _calls_store_lock(target):
+        call, calls, error = _resolve_call(target, approval_id)
+        if call is None:
+            raise CallClaimError(error or f"tool approval not found: {approval_id}")
+        actual = _approval_claim_reference(call)
+        if any(reference.get(field) != actual[field] for field in _APPROVAL_REFERENCE_FIELDS):
+            raise CallClaimError("tool approval fingerprints changed before reservation")
+        existing = call.get("approval_claim")
+        if existing is not None:
+            if not isinstance(existing, Mapping):
+                raise CallClaimError("tool approval claim is malformed")
+            existing_state = existing.get("state")
+            existing_run_id = existing.get("run_id")
+            if existing_state == "redeemed":
+                raise CallClaimError("tool approval claim is already redeemed")
+            if existing_state != "reserved" or not isinstance(existing_run_id, str):
+                raise CallClaimError("tool approval claim is malformed")
+            if existing_run_id != run_id:
+                raise CallClaimError(f"tool approval claim is reserved by {existing_run_id}")
+        if call.get("status") != "approved":
+            raise CallClaimError(f"tool approval is {call.get('status') or 'pending'}")
+        blockers = _call_run_blockers(target, call)
+        if blockers:
+            raise CallClaimError(f"tool approval is stale or blocked: {blockers[0]}")
+        decided_at = call.get("reviewed_at")
+        if not isinstance(decided_at, str) or not decided_at:
+            raise CallClaimError("tool approval decision has no review timestamp")
+        reserved_at = helpers._now().isoformat()
+        call["approval_claim"] = {
+            "run_id": run_id,
+            "state": "reserved",
+            "reserved_at": reserved_at,
+            "token_fingerprint": token_fingerprint,
+            "redeemed_at": None,
+        }
+        _write_calls_unlocked(target, calls)
+        return CallClaim(
+            decided_at=decided_at,
+            claimed_at=reserved_at,
+            already_claimed=isinstance(existing, Mapping),
+        )
+
+
+def redeem_for_run_unlocked(call: dict[str, Any], token: str) -> str:
+    """CAS a reserved Tool claim while the caller holds the call-store lock."""
+    from .. import runs_cmd
+
+    claim = call.get("approval_claim")
+    if not isinstance(claim, dict) or claim.get("state") != "reserved":
+        raise CallClaimError("tool approval claim is not reserved")
+    if claim.get("token_fingerprint") != runs_cmd._request_digest(token):
+        raise CallClaimError("tool approval claim token does not match")
+    run_id = claim.get("run_id")
+    if not isinstance(run_id, str) or not run_id:
+        raise CallClaimError("tool approval claim has no run id")
+    redeemed_at = helpers._now().isoformat()
+    claim["state"] = "redeemed"
+    claim["redeemed_at"] = redeemed_at
+    return redeemed_at
 
 
 def _make_call_record(plan_payload: dict[str, Any]) -> dict[str, Any]:
@@ -340,46 +527,48 @@ def _queue_call_payload(
             "call": record,
             "reason": "blocked call plans require --include-blocked",
         }, 1
-    calls = _read_calls(target)
-    for existing in calls:
-        if existing.get("call_fingerprint") != record["call_fingerprint"]:
-            continue
-        if existing.get("status") in {"pending", "approved"}:
-            return {
-                "target": str(target),
-                "calls_path": str(paths.calls_path(target)),
-                "created": 0,
-                "skipped": 1,
-                "blocked": 0,
-                "call": existing,
-                "reason": f"equivalent call already {existing.get('status')}",
-            }, 0
-        if existing.get("status") == "rejected":
-            return {
-                "target": str(target),
-                "calls_path": str(paths.calls_path(target)),
-                "created": 0,
-                "skipped": 1,
-                "blocked": 0,
-                "call": existing,
-                "reason": "equivalent rejected call requires changed args or contract fingerprint",
-            }, 0
-    existing_ids = {str(existing.get("id")) for existing in calls}
-    if record["id"] in existing_ids:
-        record["id"] = (
-            f"{record['id']}-queued-{helpers._stable_hash({'created_at': record['created_at'], 'count': len(calls)})}"
-        )
-    calls.append(record)
-    _write_calls(target, calls)
-    return {
-        "target": str(target),
-        "calls_path": str(paths.calls_path(target)),
-        "created": 1,
-        "skipped": 0,
-        "blocked": 0,
-        "call": record,
-        "reason": None,
-    }, 0
+    with _calls_store_lock(target):
+        calls = _read_calls(target)
+        for existing in calls:
+            if existing.get("call_fingerprint") != record["call_fingerprint"]:
+                continue
+            if existing.get("status") in {"pending", "approved"}:
+                return {
+                    "target": str(target),
+                    "calls_path": str(paths.calls_path(target)),
+                    "created": 0,
+                    "skipped": 1,
+                    "blocked": 0,
+                    "call": existing,
+                    "reason": f"equivalent call already {existing.get('status')}",
+                }, 0
+            if existing.get("status") == "rejected":
+                return {
+                    "target": str(target),
+                    "calls_path": str(paths.calls_path(target)),
+                    "created": 0,
+                    "skipped": 1,
+                    "blocked": 0,
+                    "call": existing,
+                    "reason": "equivalent rejected call requires changed args or contract fingerprint",
+                }, 0
+        existing_ids = {str(existing.get("id")) for existing in calls}
+        if record["id"] in existing_ids:
+            record["id"] = (
+                f"{record['id']}-queued-"
+                f"{helpers._stable_hash({'created_at': record['created_at'], 'count': len(calls)})}"
+            )
+        calls.append(record)
+        _write_calls_unlocked(target, calls)
+        return {
+            "target": str(target),
+            "calls_path": str(paths.calls_path(target)),
+            "created": 1,
+            "skipped": 0,
+            "blocked": 0,
+            "call": record,
+            "reason": None,
+        }, 0
 
 
 def _resolve_call(target: Path, call_id: str) -> tuple[dict[str, Any] | None, list[dict[str, Any]], str | None]:
@@ -743,27 +932,35 @@ def _call_review(
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
-    call, calls, error = _resolve_call(target, call_id)
-    payload: dict[str, Any]
-    if call is None:
-        payload = {"target": str(target), "error": error}
-        if json_output:
-            print(json.dumps(payload, indent=2, sort_keys=True))
-        else:
-            print(f"error: {error}", file=sys.stderr)
-        return 1
-    if status == "approved" and call.get("blockers"):
-        payload = {"target": str(target), "error": "blocked calls cannot be approved", "call": call}
-        if json_output:
-            print(json.dumps(payload, indent=2, sort_keys=True))
-        else:
-            print("error: blocked calls cannot be approved", file=sys.stderr)
-        return 1
-    call["status"] = status
-    call["reviewed_at"] = helpers._now().isoformat()
-    call["review_reason"] = reason
-    call["approval_fingerprint"] = _approval_fingerprint(call) if status == "approved" else None
-    _write_calls(target, calls)
+    with _calls_store_lock(target):
+        call, calls, error = _resolve_call(target, call_id)
+        payload: dict[str, Any]
+        if call is None:
+            payload = {"target": str(target), "error": error}
+            if json_output:
+                print(json.dumps(payload, indent=2, sort_keys=True))
+            else:
+                print(f"error: {error}", file=sys.stderr)
+            return 1
+        if call.get("status") == "running":
+            payload = {"target": str(target), "error": "running calls cannot be reviewed", "call": call}
+            if json_output:
+                print(json.dumps(payload, indent=2, sort_keys=True))
+            else:
+                print("error: running calls cannot be reviewed", file=sys.stderr)
+            return 1
+        if status == "approved" and call.get("blockers"):
+            payload = {"target": str(target), "error": "blocked calls cannot be approved", "call": call}
+            if json_output:
+                print(json.dumps(payload, indent=2, sort_keys=True))
+            else:
+                print("error: blocked calls cannot be approved", file=sys.stderr)
+            return 1
+        call["status"] = status
+        call["reviewed_at"] = helpers._now().isoformat()
+        call["review_reason"] = reason
+        call["approval_fingerprint"] = _approval_fingerprint(call) if status == "approved" else None
+        _write_calls_unlocked(target, calls)
     payload = {"target": str(target), "calls_path": str(paths.calls_path(target)), "call": call}
     if json_output:
         print(json.dumps(payload, indent=2, sort_keys=True))

--- a/src/brigade/tools_cmd/checkpoints.py
+++ b/src/brigade/tools_cmd/checkpoints.py
@@ -170,38 +170,42 @@ def _resume_checkpoint_payload(target: Path, checkpoint_id: str) -> tuple[dict[s
     checkpoint, error = checkpoint_store._resolve_checkpoint(target, checkpoint_id)
     if checkpoint is None:
         return {"target": str(target), "checkpoints_path": str(paths.checkpoints_path(target)), "error": error}, 1
-    blockers, call, calls = _checkpoint_resume_blockers(target, checkpoint)
-    if blockers or call is None:
-        return {
-            "target": str(target),
-            "checkpoints_path": str(paths.checkpoints_path(target)),
-            "checkpoint": checkpoint_store._checkpoint_public_summary(checkpoint),
-            "blockers": blockers,
-            "error": "checkpoint is not resumable",
-        }, 1
-    raw_contract = call.get("contract")
-    contract = raw_contract if isinstance(raw_contract, dict) else {}
-    cwd_value = contract.get("cwd")
-    cwd = helpers._as_path(target, cwd_value) if cwd_value else target
-    assert cwd is not None
-    argv = safety._command_parts(call.get("command"))
-    raw_arguments = call.get("arguments")
-    arguments = raw_arguments if isinstance(raw_arguments, dict) else {}
-    for key in sorted(arguments.keys()):
-        value = arguments[key]
-        if value is None:
-            continue
-        argv.extend(shlex.split(str(value)))
-    started_at = helpers._now().isoformat()
-    run_id = calls_mod._run_id_for_call({**call, "id": f"{call.get('id')}:resume:{checkpoint.get('id')}"}, started_at)
-    receipt_path = paths.runs_path(target) / f"{run_id}.json"
-    call["status"] = "running"
-    call["started_at"] = started_at
-    call["completed_at"] = None
-    call["run_id"] = run_id
-    call["receipt_path"] = str(receipt_path)
-    call["exit_code"] = None
-    calls_mod._write_calls(target, calls)
+    with calls_mod._calls_store_lock(target):
+        blockers, call, calls = _checkpoint_resume_blockers(target, checkpoint)
+        if blockers or call is None:
+            return {
+                "target": str(target),
+                "checkpoints_path": str(paths.checkpoints_path(target)),
+                "checkpoint": checkpoint_store._checkpoint_public_summary(checkpoint),
+                "blockers": blockers,
+                "error": "checkpoint is not resumable",
+            }, 1
+        raw_contract = call.get("contract")
+        contract = raw_contract if isinstance(raw_contract, dict) else {}
+        cwd_value = contract.get("cwd")
+        cwd = helpers._as_path(target, cwd_value) if cwd_value else target
+        assert cwd is not None
+        argv = safety._command_parts(call.get("command"))
+        raw_arguments = call.get("arguments")
+        arguments = raw_arguments if isinstance(raw_arguments, dict) else {}
+        for key in sorted(arguments.keys()):
+            value = arguments[key]
+            if value is None:
+                continue
+            argv.extend(shlex.split(str(value)))
+        started_at = helpers._now().isoformat()
+        run_id = calls_mod._run_id_for_call(
+            {**call, "id": f"{call.get('id')}:resume:{checkpoint.get('id')}"},
+            started_at,
+        )
+        receipt_path = paths.runs_path(target) / f"{run_id}.json"
+        call["status"] = "running"
+        call["started_at"] = started_at
+        call["completed_at"] = None
+        call["run_id"] = run_id
+        call["receipt_path"] = str(receipt_path)
+        call["exit_code"] = None
+        calls_mod._write_calls_unlocked(target, calls)
 
     timeout = contract.get("timeout")
     timeout_value = float(timeout) if isinstance(timeout, (int, float)) and not isinstance(timeout, bool) else None
@@ -274,13 +278,27 @@ def _resume_checkpoint_payload(target: Path, checkpoint_id: str) -> tuple[dict[s
             },
         },
     )
-    call["status"] = status
-    call["completed_at"] = completed_at
-    call["exit_code"] = exit_code
-    call["timed_out"] = timed_out
-    call["receipt_path"] = receipt["receipt_path"]
-    call["resume_checkpoint_id"] = checkpoint.get("id")
-    calls_mod._write_calls(target, calls)
+    with calls_mod._calls_store_lock(target):
+        current, current_calls, call_error = calls_mod._resolve_call(target, str(call.get("id") or ""))
+        if current is None or current.get("status") != "running" or current.get("run_id") != run_id:
+            return {
+                "target": str(target),
+                "calls_path": str(paths.calls_path(target)),
+                "checkpoints_path": str(paths.checkpoints_path(target)),
+                "runs_path": str(paths.runs_path(target)),
+                "checkpoint": checkpoint_store._checkpoint_public_summary(checkpoint),
+                "call": current or call,
+                "receipt": receipt,
+                "error": call_error or "call state changed while checkpoint resume was running",
+            }, 1
+        current["status"] = status
+        current["completed_at"] = completed_at
+        current["exit_code"] = exit_code
+        current["timed_out"] = timed_out
+        current["receipt_path"] = receipt["receipt_path"]
+        current["resume_checkpoint_id"] = checkpoint.get("id")
+        calls_mod._write_calls_unlocked(target, current_calls)
+        call = current
     checkpoint["status"] = "resumed" if status == "resumed" else "failed"
     checkpoint["resume_run_id"] = run_id
     checkpoint_store._write_checkpoint(target, checkpoint)
@@ -372,35 +390,69 @@ def _checkpoint_review(
         else:
             print(f"error: {error}", file=sys.stderr)
         return 1
-    if status == "approved":
-        choices = [str(item) for item in checkpoint.get("choices", []) if isinstance(item, str)]
-        if choices and choice not in choices:
+    call: dict[str, Any] | None = None
+    with calls_mod._calls_store_lock(target):
+        checkpoint, error = checkpoint_store._resolve_checkpoint(target, checkpoint_id)
+        if checkpoint is None:
+            payload = {"target": str(target), "error": error or "checkpoint disappeared during review"}
+            if json_output:
+                print(json.dumps(payload, indent=2, sort_keys=True))
+            else:
+                print(f"error: {payload['error']}", file=sys.stderr)
+            return 1
+        if checkpoint.get("status") != "pending":
             payload = {
                 "target": str(target),
-                "error": "choice is not allowed",
+                "error": "checkpoint state changed before review",
                 "checkpoint": checkpoint_store._checkpoint_public_summary(checkpoint),
             }
             if json_output:
                 print(json.dumps(payload, indent=2, sort_keys=True))
             else:
-                print("error: choice is not allowed", file=sys.stderr)
+                print(f"error: {payload['error']}", file=sys.stderr)
             return 1
-    checkpoint["status"] = status
-    checkpoint["reviewed_at"] = helpers._now().isoformat()
-    checkpoint["review_reason"] = reason
-    if status == "approved":
-        checkpoint["selected_choice"] = choice
-    checkpoint_store._write_checkpoint(target, checkpoint)
-    call: dict[str, Any] | None = None
-    calls: list[dict[str, Any]] = []
-    call_id = checkpoint.get("call_id")
-    if isinstance(call_id, str) and call_id:
-        call, calls, _ = calls_mod._resolve_call(target, call_id)
-    if call is not None and status == "approved":
-        call["status"] = "resume-pending"
-        call["checkpoint_id"] = checkpoint.get("id")
-        call["approval_fingerprint"] = calls_mod._approval_fingerprint(call)
-        calls_mod._write_calls(target, calls)
+        if status == "approved":
+            choices = [str(item) for item in checkpoint.get("choices", []) if isinstance(item, str)]
+            if choices and choice not in choices:
+                payload = {
+                    "target": str(target),
+                    "error": "choice is not allowed",
+                    "checkpoint": checkpoint_store._checkpoint_public_summary(checkpoint),
+                }
+                if json_output:
+                    print(json.dumps(payload, indent=2, sort_keys=True))
+                else:
+                    print("error: choice is not allowed", file=sys.stderr)
+                return 1
+        calls: list[dict[str, Any]] = []
+        call_id = checkpoint.get("call_id")
+        if isinstance(call_id, str) and call_id:
+            call, calls, _ = calls_mod._resolve_call(target, call_id)
+            expected_checkpoint_id = checkpoint.get("id")
+            if call is None or call.get("status") != "waiting" or call.get("checkpoint_id") != expected_checkpoint_id:
+                payload = {
+                    "target": str(target),
+                    "error": "checkpoint or linked call state changed before review",
+                    "checkpoint": checkpoint_store._checkpoint_public_summary(checkpoint),
+                    "call": call,
+                }
+                if json_output:
+                    print(json.dumps(payload, indent=2, sort_keys=True))
+                else:
+                    print(f"error: {payload['error']}", file=sys.stderr)
+                return 1
+        checkpoint["status"] = status
+        checkpoint["reviewed_at"] = helpers._now().isoformat()
+        checkpoint["review_reason"] = reason
+        if status == "approved":
+            checkpoint["selected_choice"] = choice
+        checkpoint_store._write_checkpoint(target, checkpoint)
+        if call is not None and status == "approved":
+            expected_checkpoint_id = checkpoint.get("id")
+            call["status"] = "resume-pending"
+            call["checkpoint_id"] = expected_checkpoint_id
+            call["approval_fingerprint"] = calls_mod._approval_fingerprint(call)
+            calls_mod._write_calls_unlocked(target, calls)
     payload = {
         "target": str(target),
         "checkpoints_path": str(paths.checkpoints_path(target)),

--- a/src/brigade/tools_cmd/runs.py
+++ b/src/brigade/tools_cmd/runs.py
@@ -245,14 +245,16 @@ def _replay_call_payload(target: Path, run_id: str) -> tuple[dict[str, Any], int
     record["replay_of_run_id"] = receipt.get("id")
     record["replay_source_call_id"] = receipt.get("call_id")
     record["replay_created_at"] = helpers._now().isoformat()
-    calls = calls_mod._read_calls(target)
-    existing_ids = {str(call.get("id")) for call in calls}
-    if record["id"] in existing_ids:
-        record["id"] = (
-            f"{record['id']}-replay-{helpers._stable_hash({'run_id': receipt.get('id'), 'created_at': record['replay_created_at']})}"
-        )
-    calls.append(record)
-    calls_mod._write_calls(target, calls)
+    with calls_mod._calls_store_lock(target):
+        calls = calls_mod._read_calls(target)
+        existing_ids = {str(call.get("id")) for call in calls}
+        if record["id"] in existing_ids:
+            record["id"] = (
+                f"{record['id']}-replay-"
+                f"{helpers._stable_hash({'run_id': receipt.get('id'), 'created_at': record['replay_created_at']})}"
+            )
+        calls.append(record)
+        calls_mod._write_calls_unlocked(target, calls)
     payload["call"] = record
     payload["created"] = 1
     return payload, 0
@@ -373,54 +375,82 @@ def _run_call_payload(
     target: Path, *, call_id: str | None = None, next_call: bool = False
 ) -> tuple[dict[str, Any], int]:
     target = target.expanduser().resolve()
-    calls = calls_mod._read_calls(target)
-    call: dict[str, Any] | None
-    error: str | None = None
-    if next_call:
-        call = _next_approved_call(calls)
+    with calls_mod._calls_store_lock(target):
+        calls = calls_mod._read_calls(target)
+        call: dict[str, Any] | None
+        error: str | None = None
+        if next_call:
+            call = _next_approved_call(calls)
+            if call is None:
+                error = "no approved calls available"
+        elif call_id:
+            call, calls, error = calls_mod._resolve_call(target, call_id)
+        else:
+            call = None
+            error = "pass a call id or --next"
         if call is None:
-            error = "no approved calls available"
-    elif call_id:
-        call, calls, error = calls_mod._resolve_call(target, call_id)
-    else:
-        call = None
-        error = "pass a call id or --next"
-    if call is None:
-        return {"target": str(target), "calls_path": str(paths.calls_path(target)), "error": error}, 1
-    blockers = calls_mod._call_run_blockers(target, call)
-    if blockers:
-        return {
-            "target": str(target),
-            "calls_path": str(paths.calls_path(target)),
-            "call": call,
-            "blockers": blockers,
-            "error": "call is not runnable",
-        }, 1
-    raw_contract = call.get("contract")
-    contract = raw_contract if isinstance(raw_contract, dict) else {}
-    cwd_value = contract.get("cwd")
-    cwd = helpers._as_path(target, cwd_value) if cwd_value else target
-    assert cwd is not None
-    argv = safety._command_parts(call.get("command"))
-    if call.get("family") != "mcp":
-        raw_arguments = call.get("arguments")
-        arguments = raw_arguments if isinstance(raw_arguments, dict) else {}
-        for key in sorted(arguments.keys()):
-            value = arguments[key]
-            if value is None:
-                continue
-            argv.extend(shlex.split(str(value)))
-    started_at = helpers._now().isoformat()
-    run_id = calls_mod._run_id_for_call(call, started_at)
-    receipt_path = paths.runs_path(target) / f"{run_id}.json"
-    paths.checkpoints_path(target).mkdir(parents=True, exist_ok=True)
-    call["status"] = "running"
-    call["started_at"] = started_at
-    call["completed_at"] = None
-    call["run_id"] = run_id
-    call["receipt_path"] = str(receipt_path)
-    call["exit_code"] = None
-    calls_mod._write_calls(target, calls)
+            return {"target": str(target), "calls_path": str(paths.calls_path(target)), "error": error}, 1
+        blockers = calls_mod._call_run_blockers(target, call)
+        if blockers:
+            if call.get("status") == "pending":
+                from .. import runs_cmd
+
+                if runs_cmd._attach_approval_pause_request(target, "tool", call):
+                    calls_mod._write_calls_unlocked(target, calls)
+            return {
+                "target": str(target),
+                "calls_path": str(paths.calls_path(target)),
+                "call": call,
+                "blockers": blockers,
+                "error": "call is not runnable",
+            }, 1
+        approval_claim = call.get("approval_claim")
+        if isinstance(approval_claim, dict):
+            from .. import runs_cmd
+
+            token = runs_cmd._approval_marker_from_env(runs_cmd._APPROVAL_RESUME_TOKEN_ENV)
+            if token is None:
+                return {
+                    "target": str(target),
+                    "calls_path": str(paths.calls_path(target)),
+                    "call": call,
+                    "error": "approval resume token is missing",
+                }, 1
+            try:
+                calls_mod.redeem_for_run_unlocked(call, token)
+            except calls_mod.CallClaimError as exc:
+                return {
+                    "target": str(target),
+                    "calls_path": str(paths.calls_path(target)),
+                    "call": call,
+                    "error": str(exc),
+                }, 1
+            calls_mod._write_calls_unlocked(target, calls)
+        raw_contract = call.get("contract")
+        contract = raw_contract if isinstance(raw_contract, dict) else {}
+        cwd_value = contract.get("cwd")
+        cwd = helpers._as_path(target, cwd_value) if cwd_value else target
+        assert cwd is not None
+        argv = safety._command_parts(call.get("command"))
+        if call.get("family") != "mcp":
+            raw_arguments = call.get("arguments")
+            arguments = raw_arguments if isinstance(raw_arguments, dict) else {}
+            for key in sorted(arguments.keys()):
+                value = arguments[key]
+                if value is None:
+                    continue
+                argv.extend(shlex.split(str(value)))
+        started_at = helpers._now().isoformat()
+        run_id = calls_mod._run_id_for_call(call, started_at)
+        receipt_path = paths.runs_path(target) / f"{run_id}.json"
+        paths.checkpoints_path(target).mkdir(parents=True, exist_ok=True)
+        call["status"] = "running"
+        call["started_at"] = started_at
+        call["completed_at"] = None
+        call["run_id"] = run_id
+        call["receipt_path"] = str(receipt_path)
+        call["exit_code"] = None
+        calls_mod._write_calls_unlocked(target, calls)
 
     timeout = contract.get("timeout")
     timeout_value = float(timeout) if isinstance(timeout, (int, float)) and not isinstance(timeout, bool) else None
@@ -505,14 +535,26 @@ def _run_call_payload(
         policy_decision=policy_decision,
         extra=extra_receipt,
     )
-    call["status"] = status
-    call["completed_at"] = completed_at
-    call["exit_code"] = exit_code
-    call["timed_out"] = timed_out
-    call["receipt_path"] = receipt["receipt_path"]
-    if checkpoint is not None:
-        call["checkpoint_id"] = checkpoint.get("id")
-    calls_mod._write_calls(target, calls)
+    with calls_mod._calls_store_lock(target):
+        current, current_calls, error = calls_mod._resolve_call(target, str(call.get("id") or ""))
+        if current is None or current.get("status") != "running" or current.get("run_id") != run_id:
+            return {
+                "target": str(target),
+                "calls_path": str(paths.calls_path(target)),
+                "runs_path": str(paths.runs_path(target)),
+                "call": current or call,
+                "receipt": receipt,
+                "error": error or "call state changed while execution was running",
+            }, 1
+        current["status"] = status
+        current["completed_at"] = completed_at
+        current["exit_code"] = exit_code
+        current["timed_out"] = timed_out
+        current["receipt_path"] = receipt["receipt_path"]
+        if checkpoint is not None:
+            current["checkpoint_id"] = checkpoint.get("id")
+        calls_mod._write_calls_unlocked(target, current_calls)
+        call = current
     return {
         "target": str(target),
         "calls_path": str(paths.calls_path(target)),

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -36,6 +36,53 @@ def _sidecar_revisions(run_dir: Path, sidecar: str) -> list[Path]:
     return sorted((run_dir / "revisions" / sidecar).glob("*.json"))
 
 
+def test_approval_handoff_selects_completed_requester_not_unrelated_workers(tmp_path):
+    results = [
+        aboyeur.WorkerResult(
+            worker="successful-other",
+            task="other success",
+            text="done",
+            ok=True,
+            thread_id="thread-success",
+            status="complete",
+        ),
+        aboyeur.WorkerResult(
+            worker="failed-other",
+            task="other failure",
+            text="",
+            ok=False,
+            thread_id="thread-failed",
+            status="failed",
+        ),
+        aboyeur.WorkerResult(
+            worker="requester",
+            task="request approval",
+            text="approval is required",
+            ok=True,
+            thread_id="thread-requester",
+            status="complete",
+        ),
+    ]
+
+    aboyeur.write_approval_resume_handoff(
+        tmp_path,
+        results,
+        requester_worker="requester",
+        requester_thread_id="thread-requester",
+    )
+
+    payload = json.loads((tmp_path / "worker-results.json").read_text())
+    assert payload["results"] == [
+        {
+            "ok": False,
+            "status": "interrupted",
+            "task": "request approval",
+            "thread_id": "thread-requester",
+            "worker": "requester",
+        }
+    ]
+
+
 def _roster_with_incapable_worker():
     return Roster(
         orchestrator="chef",

--- a/tests/test_daily_driver_cmd.py
+++ b/tests/test_daily_driver_cmd.py
@@ -1,8 +1,27 @@
 import json
+import os
 import time
+from contextlib import contextmanager
 from pathlib import Path
 
-from brigade import center_cmd, cli, daily_cmd, handoff_cmd, phases_cmd, release_cmd, repos_cmd, work_cmd
+import pytest
+
+from brigade import (
+    aboyeur,
+    center_cmd,
+    cli,
+    daily_cmd,
+    handoff_cmd,
+    phases_cmd,
+    release_cmd,
+    repos_cmd,
+    runguard,
+    run_journal,
+    run_resume,
+    runs_cmd,
+    work_cmd,
+)
+from brigade.roster import Agent, Roster
 
 
 def _write_command_inventory(path, capsys=None):
@@ -500,6 +519,298 @@ def test_daily_run_refuses_approval_required_import_and_promotes_when_approved(t
         "push" in command["command"] or "tag" in command["command"] for command in receipt["commands_invoked"]
     )
     assert work_cmd._pending_tasks(tmp_path)
+
+
+def test_daily_approval_boundary_does_not_request_pause_without_active_run(tmp_path, capsys):
+    _seed_ready_repo(tmp_path, capsys)
+    work_cmd._append_import_records(
+        tmp_path,
+        [
+            {
+                "text": "Pause for review",
+                "kind": "task",
+                "source": "scanner",
+                "priority": "high",
+                "acceptance": ["Approval is recorded."],
+                "metadata": {"source_fingerprint": "pause-fp"},
+            }
+        ],
+    )
+    assert daily_cmd.run(target=tmp_path, json_output=True) == 1
+    blocked = json.loads(capsys.readouterr().out)
+
+    approval = daily_cmd._find_approval(tmp_path, blocked["approval_id"])
+    assert "brigade_approval_pause_request" not in approval
+
+
+def test_daily_approval_pauses_real_run_and_cli_resume_consumes_store_once(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    _seed_ready_repo(tmp_path, capsys)
+    imported, _, _ = work_cmd._append_import_records(
+        tmp_path,
+        [
+            {
+                "text": "Resume after review",
+                "kind": "task",
+                "source": "scanner",
+                "priority": "high",
+                "acceptance": ["The paused run resumes."],
+                "metadata": {"source_fingerprint": "resume-fp"},
+            }
+        ],
+    )
+    monkeypatch.setenv("BRIGADE_RUN_JOURNAL_AUTHORITY", "1")
+    monkeypatch.setenv("BRIGADE_LIFECYCLE_JOURNAL", "1")
+    marker = "d" * 43
+    monkeypatch.setenv(runs_cmd._APPROVAL_CORRELATION_ENV, marker)
+    run_dir = tmp_path / ".brigade" / "runs" / "daily-approval-run"
+    roster = Roster(
+        orchestrator="chef",
+        agents={"chef": Agent("chef", "codex", "plan")},
+    )
+
+    with runguard.run_lock(tmp_path, run_dir=run_dir):
+        aboyeur.record_run_start(
+            run_dir,
+            task="daily approval",
+            cwd=tmp_path,
+            roster=roster,
+            read_only=False,
+            lock_workspace=tmp_path,
+        )
+        assert daily_cmd.run(target=tmp_path, json_output=True) == 1
+        blocked = json.loads(capsys.readouterr().out)
+        assert runguard.is_active_run_owner(tmp_path, run_dir)
+        runs_cmd._bind_approval_pause_request(
+            tmp_path,
+            correlation_marker=marker,
+            worker="daily-worker",
+            thread_id="daily-thread",
+            turn_id="daily-turn",
+        )
+        reference = runs_cmd._approval_pause_reference_for_owned_run(tmp_path, run_dir)
+        assert reference["source"] == "daily"
+        assert reference["approval_id"] == blocked["approval_id"]
+        aboyeur.record_approval_pause(run_dir, reference)
+
+    assert runguard.run_lock_state(tmp_path, run_dir) == "absent"
+    paused = json.loads((run_dir / "run.json").read_text())
+    assert paused["status"] == "running"
+    assert paused["approval_reference"]["decision_state"] == "pending"
+    events = run_journal.read_journal(run_dir / "events" / "lifecycle.jsonl").events
+    assert [event.event_type for event in events][-4:] == [
+        "run.snapshot.checkpointed",
+        "approval.requested",
+        "run.snapshot.checkpointed",
+        "run.paused",
+    ]
+
+    approval_id = blocked["approval_id"]
+    assert daily_cmd.approvals_approve(target=tmp_path, approval_id=approval_id, json_output=True) == 0
+    capsys.readouterr()
+    continued = []
+    action_calls = []
+    original_promote = work_cmd.import_promote
+
+    def tracked_promote(*args, **kwargs):
+        action_calls.append((args, kwargs))
+        return original_promote(*args, **kwargs)
+
+    monkeypatch.setattr(work_cmd, "import_promote", tracked_promote)
+
+    def continue_daily(path, *, approval_resume, approval_token):
+        continued.append((path, approval_resume))
+        previous = os.environ.get(runs_cmd._APPROVAL_RESUME_TOKEN_ENV)
+        os.environ[runs_cmd._APPROVAL_RESUME_TOKEN_ENV] = approval_token
+        try:
+            assert daily_cmd.run(target=tmp_path, approval_id=approval_id, json_output=True) == 0
+            capsys.readouterr()
+            assert daily_cmd.run(target=tmp_path, approval_id=approval_id, json_output=True) == 1
+            capsys.readouterr()
+        finally:
+            if previous is None:
+                os.environ.pop(runs_cmd._APPROVAL_RESUME_TOKEN_ENV, None)
+            else:
+                os.environ[runs_cmd._APPROVAL_RESUME_TOKEN_ENV] = previous
+        runs_cmd._finalize_redeemed_approval(run_dir, tmp_path, reference)
+        return 0
+
+    monkeypatch.setattr(run_resume, "_resume_locked", continue_daily)
+
+    assert cli.main(["runs", "resume", str(run_dir)]) == 0
+    assert continued == [(run_dir, True)]
+    assert len(action_calls) == 1
+    consumed = daily_cmd._find_approval(tmp_path, approval_id)
+    assert consumed["status"] == "consumed"
+    assert consumed["consumed_run_id"] == run_dir.name
+    assert consumed["approval_claim"]["state"] == "redeemed"
+    event_types = [
+        event.event_type for event in run_journal.read_journal(run_dir / "events" / "lifecycle.jsonl").events
+    ]
+    for fact in ("approval.granted", "approval.consumed", "run.resumed"):
+        assert event_types.count(fact) == 1
+        fact_index = event_types.index(fact)
+        assert event_types[fact_index - 1] == "run.snapshot.checkpointed"
+
+
+@pytest.mark.parametrize("review_status", ["held", "rejected"])
+def test_daily_reserved_claim_rechecks_review_state_before_action(
+    tmp_path,
+    monkeypatch,
+    capsys,
+    review_status,
+):
+    _seed_ready_repo(tmp_path, capsys)
+    work_cmd._append_import_records(
+        tmp_path,
+        [
+            {
+                "text": "Review before redemption",
+                "kind": "task",
+                "source": "scanner",
+                "priority": "high",
+                "acceptance": ["Concurrent review prevents the action."],
+                "metadata": {"source_fingerprint": "redeem-review-fp"},
+            }
+        ],
+    )
+    assert daily_cmd.run(target=tmp_path, json_output=True) == 1
+    approval_id = json.loads(capsys.readouterr().out)["approval_id"]
+    assert daily_cmd.approvals_approve(target=tmp_path, approval_id=approval_id, json_output=True) == 0
+    capsys.readouterr()
+    approval = daily_cmd._find_approval(tmp_path, approval_id)
+    assert approval is not None
+    reference = runs_cmd._approval_reference_from_record("daily", approval)
+    token = "v" * 43
+    daily_cmd.approvals.reserve_for_run(
+        tmp_path,
+        approval_id,
+        reference,
+        "parent-run",
+        runs_cmd._request_digest(token),
+    )
+    original_lock = daily_cmd._approval_store_lock
+    review_injected = False
+
+    @contextmanager
+    def review_before_redeem(target, current_approval_id):
+        nonlocal review_injected
+        with original_lock(target, current_approval_id):
+            if not review_injected:
+                current = daily_cmd._find_approval(target, current_approval_id)
+                assert current is not None
+                current["status"] = review_status
+                current["reviewed_at"] = "2026-07-30T22:00:00+00:00"
+                current["review_reason"] = "concurrent review"
+                daily_cmd._write_approval_unlocked(target, current)
+                review_injected = True
+            yield
+
+    action_calls = []
+    original_promote = work_cmd.import_promote
+
+    def tracked_promote(*args, **kwargs):
+        action_calls.append((args, kwargs))
+        return original_promote(*args, **kwargs)
+
+    monkeypatch.setattr(daily_cmd, "_approval_store_lock", review_before_redeem)
+    monkeypatch.setattr(work_cmd, "import_promote", tracked_promote)
+    monkeypatch.setenv(runs_cmd._APPROVAL_RESUME_TOKEN_ENV, token)
+
+    with pytest.raises(daily_cmd.ApprovalClaimError, match=f"daily approval is {review_status}"):
+        daily_cmd.run(target=tmp_path, approval_id=approval_id, json_output=True)
+
+    assert review_injected is True
+    assert action_calls == []
+    stored = daily_cmd._find_approval(tmp_path, approval_id)
+    assert stored is not None
+    assert stored["status"] == review_status
+    assert stored["approval_claim"]["state"] == "reserved"
+
+
+def test_daily_rejected_pause_stays_rejected_after_store_is_approved(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    _seed_ready_repo(tmp_path, capsys)
+    work_cmd._append_import_records(
+        tmp_path,
+        [
+            {
+                "text": "Reject this resume",
+                "kind": "task",
+                "source": "scanner",
+                "priority": "high",
+                "acceptance": ["The rejected run remains rejected."],
+                "metadata": {"source_fingerprint": "reject-resume-fp"},
+            }
+        ],
+    )
+    monkeypatch.setenv("BRIGADE_RUN_JOURNAL_AUTHORITY", "1")
+    monkeypatch.setenv("BRIGADE_LIFECYCLE_JOURNAL", "1")
+    marker = "e" * 43
+    monkeypatch.setenv(runs_cmd._APPROVAL_CORRELATION_ENV, marker)
+    run_dir = tmp_path / ".brigade" / "runs" / "daily-rejected-approval-run"
+    roster = Roster(
+        orchestrator="chef",
+        agents={"chef": Agent("chef", "codex", "plan")},
+    )
+
+    with runguard.run_lock(tmp_path, run_dir=run_dir):
+        aboyeur.record_run_start(
+            run_dir,
+            task="daily rejection",
+            cwd=tmp_path,
+            roster=roster,
+            read_only=False,
+            lock_workspace=tmp_path,
+        )
+        assert daily_cmd.run(target=tmp_path, json_output=True) == 1
+        blocked = json.loads(capsys.readouterr().out)
+        runs_cmd._bind_approval_pause_request(
+            tmp_path,
+            correlation_marker=marker,
+            worker="daily-worker",
+            thread_id="daily-rejected-thread",
+            turn_id="daily-rejected-turn",
+        )
+        reference = runs_cmd._approval_pause_reference_for_owned_run(tmp_path, run_dir)
+        assert reference is not None
+        aboyeur.record_approval_pause(run_dir, reference)
+
+    approval_id = blocked["approval_id"]
+    assert (
+        daily_cmd.approvals_reject(
+            target=tmp_path,
+            approval_id=approval_id,
+            reason="denied",
+            json_output=True,
+        )
+        == 0
+    )
+    capsys.readouterr()
+    continued = []
+    monkeypatch.setattr(
+        run_resume,
+        "_resume_locked",
+        lambda path, *, approval_resume, approval_token: continued.append((path, approval_resume, approval_token)) or 0,
+    )
+
+    assert cli.main(["runs", "resume", str(run_dir)]) == 2
+    capsys.readouterr()
+    rejected = json.loads((run_dir / "run.json").read_text())
+    assert rejected["approval_reference"]["decision_state"] == "rejected"
+
+    assert daily_cmd.approvals_approve(target=tmp_path, approval_id=approval_id, json_output=True) == 0
+    capsys.readouterr()
+    assert cli.main(["runs", "resume", str(run_dir)]) == 2
+    assert continued == []
+    still_rejected = json.loads((run_dir / "run.json").read_text())
+    assert still_rejected["approval_reference"]["decision_state"] == "rejected"
 
 
 def test_daily_approvals_list_show_review_and_no_execution(tmp_path, capsys):

--- a/tests/test_run_checkpoint.py
+++ b/tests/test_run_checkpoint.py
@@ -172,6 +172,27 @@ def test_validate_checkpoint_accepts_mapped_paired_event_type(tmp_path):
     assert run_checkpoint.validate_checkpoint(run_dir, payload) == run_json_bytes
 
 
+def test_validate_checkpoint_accepts_registered_status_neutral_approval_type(tmp_path):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "running"})
+    _place_checkpoint_file(run_dir, run_json_bytes)
+    payload = _checkpoint_payload(run_json_bytes, paired_event_type="approval.requested")
+
+    assert run_checkpoint.validate_checkpoint(run_dir, payload) == run_json_bytes
+
+
+def test_validate_checkpoint_rejects_unregistered_approval_type(tmp_path):
+    run_dir = _run_dir(tmp_path)
+    run_json_bytes = _writer_bytes({"status": "running"})
+    _place_checkpoint_file(run_dir, run_json_bytes)
+    payload = _checkpoint_payload(run_json_bytes, paired_event_type="approval.forged")
+
+    with pytest.raises(run_checkpoint.CheckpointError, match="not in registry") as excinfo:
+        run_checkpoint.validate_checkpoint(run_dir, payload)
+
+    assert excinfo.value.category == "paired-event-type"
+
+
 # -- Open-fd hardening -------------------------------------------------------
 
 

--- a/tests/test_run_lifecycle.py
+++ b/tests/test_run_lifecycle.py
@@ -1211,6 +1211,210 @@ def test_unpaired_journal_ahead_fails_closed_before_status_append(tmp_path, monk
     assert _journal_path(run_dir).read_bytes() == journal_before
 
 
+def test_record_approval_pause_commits_events_snapshot_and_releases_lock(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    run_dir = _run_dir(repo)
+    _enroll_and_authorize(repo, run_dir, monkeypatch)
+    approval_reference = {
+        "approval_id": "approval-1",
+        "source": "daily",
+        "fingerprint": "approval-fingerprint-1",
+        "source_fingerprint": "source-fingerprint-1",
+        "contract_fingerprint": "contract-fingerprint-1",
+        "evidence_fingerprint": "evidence-fingerprint-1",
+    }
+
+    with runguard.run_lock(repo, run_dir=run_dir):
+        aboyeur.record_approval_pause(run_dir, approval_reference)
+        assert runguard.is_active_run_owner(repo, run_dir)
+
+    assert runguard.run_lock_state(repo, run_dir) == "absent"
+    events = _events(run_dir)
+    assert [event.event_type for event in events[-4:]] == [
+        run_checkpoint.CHECKPOINT_EVENT_TYPE,
+        "approval.requested",
+        run_checkpoint.CHECKPOINT_EVENT_TYPE,
+        "run.paused",
+    ]
+    _, requested, _, paused = events[-4:]
+    assert requested.payload == {
+        "approval_id": "approval-1",
+        "source": "daily",
+        "contract_fingerprint": "contract-fingerprint-1",
+    }
+    assert paused.payload == {
+        "approval_id": "approval-1",
+        "reason": "approval-required",
+    }
+    snapshot = json.loads((run_dir / "run.json").read_text())
+    assert snapshot["status"] == "running"
+    assert snapshot["approval_reference"] == {
+        **approval_reference,
+        "decision_state": "pending",
+    }
+    assert snapshot["journal_last_sequence"] == paused.sequence
+    assert snapshot["journal_last_event_digest"] == paused.event_digest
+
+
+def test_status_neutral_approval_event_is_checkpoint_paired_and_recoverable(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    run_dir = _run_dir(repo)
+    _enroll_and_authorize(repo, run_dir, monkeypatch)
+
+    with runguard.run_lock(repo, run_dir=run_dir):
+        requested = run_lifecycle.record_lifecycle_event(
+            run_dir,
+            event_type="approval.requested",
+            payload={
+                "approval_id": "approval-1",
+                "source": "daily",
+                "contract_fingerprint": "contract-fingerprint-1",
+            },
+            idempotency_key="approval:requested:test",
+            workspace=repo,
+        )
+
+    events = _events(run_dir)
+    checkpoint = events[-2]
+    assert checkpoint.event_type == run_checkpoint.CHECKPOINT_EVENT_TYPE
+    assert checkpoint.payload["paired_event_type"] == "approval.requested"
+    assert requested == events[-1]
+    assert run_shadow.check_projection_readiness(run_dir).ready is True
+
+    (run_dir / "run.json").unlink()
+    repaired = run_checkpoint.recover_from_checkpoint(run_dir, None)
+    assert repaired["status"] == "planning"
+    assert repaired["journal_last_sequence"] == requested.sequence
+    assert repaired["journal_last_event_digest"] == requested.event_digest
+
+
+def test_status_neutral_event_replay_and_conflict_do_not_append_checkpoint(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    run_dir = _run_dir(repo)
+    _enroll_and_authorize(repo, run_dir, monkeypatch)
+    payload = {
+        "approval_id": "approval-1",
+        "source": "daily",
+        "contract_fingerprint": "contract-fingerprint-1",
+    }
+
+    with runguard.run_lock(repo, run_dir=run_dir):
+        recorded = run_lifecycle.record_lifecycle_event(
+            run_dir,
+            event_type="approval.requested",
+            payload=payload,
+            idempotency_key="approval:requested:stable",
+            workspace=repo,
+        )
+        _write_run_json_authority(run_dir, "dispatching", lock_workspace=repo)
+    journal_path = _journal_path(run_dir)
+    journal_before = journal_path.read_bytes()
+    checkpoint_count = len(_checkpoint_events(run_dir))
+
+    with runguard.run_lock(repo, run_dir=run_dir):
+        replayed = run_lifecycle.record_lifecycle_event(
+            run_dir,
+            event_type="approval.requested",
+            payload=payload,
+            idempotency_key="approval:requested:stable",
+            workspace=repo,
+        )
+    assert replayed == recorded
+    assert journal_path.read_bytes() == journal_before
+    assert len(_checkpoint_events(run_dir)) == checkpoint_count
+
+    with runguard.run_lock(repo, run_dir=run_dir):
+        with pytest.raises(run_lifecycle.LifecycleJournalError, match="idempotency key"):
+            run_lifecycle.record_lifecycle_event(
+                run_dir,
+                event_type="approval.requested",
+                payload={**payload, "source": "tool"},
+                idempotency_key="approval:requested:stable",
+                workspace=repo,
+            )
+    assert journal_path.read_bytes() == journal_before
+    assert len(_checkpoint_events(run_dir)) == checkpoint_count
+
+
+@pytest.mark.parametrize(
+    ("event_type", "payload"),
+    [
+        ("approval.forged", {"approval_id": "approval-1"}),
+        (
+            "approval.rejected",
+            {
+                "approval_id": "approval-1",
+                "decided_at": "2026-07-30T18:00:00+00:00",
+                "decision_state": "approved",
+            },
+        ),
+    ],
+)
+def test_invalid_approval_event_request_has_zero_journal_or_checkpoint_mutation(
+    tmp_path,
+    monkeypatch,
+    event_type,
+    payload,
+):
+    repo = _repo(tmp_path)
+    run_dir = _run_dir(repo)
+    _enroll_and_authorize(repo, run_dir, monkeypatch)
+    journal_path = _journal_path(run_dir)
+    journal_before = journal_path.read_bytes()
+    checkpoint_count = len(_checkpoint_events(run_dir))
+
+    with runguard.run_lock(repo, run_dir=run_dir):
+        with pytest.raises(run_lifecycle.LifecycleJournalError, match="canonicalization"):
+            run_lifecycle.record_lifecycle_event(
+                run_dir,
+                event_type=event_type,
+                payload=payload,
+                idempotency_key="approval:invalid:test",
+                workspace=repo,
+            )
+
+    assert journal_path.read_bytes() == journal_before
+    assert len(_checkpoint_events(run_dir)) == checkpoint_count
+
+
+def test_approval_reference_rejects_unknown_decision_state():
+    reference = {
+        "approval_id": "approval-1",
+        "source": "daily",
+        "fingerprint": "approval-fingerprint-1",
+        "source_fingerprint": "source-fingerprint-1",
+        "contract_fingerprint": "contract-fingerprint-1",
+        "evidence_fingerprint": "evidence-fingerprint-1",
+        "decision_state": "garbage",
+    }
+
+    with pytest.raises(run_lifecycle.LifecycleJournalError, match="invalid decision_state"):
+        run_lifecycle.normalize_approval_reference(reference)
+
+
+def test_approval_idempotency_key_is_bounded_and_reference_only():
+    approval_id = "private-approval-id-" + ("x" * 500)
+
+    key = run_lifecycle.approval_idempotency_key(
+        approval_id,
+        "consumed",
+        scope="run-approval-1",
+    )
+
+    assert len(key) <= run_events.MAX_IDEMPOTENCY_KEY_LEN
+    assert approval_id not in key
+    assert key == run_lifecycle.approval_idempotency_key(
+        approval_id,
+        "consumed",
+        scope="run-approval-1",
+    )
+    assert key != run_lifecycle.approval_idempotency_key(
+        approval_id,
+        "consumed",
+        scope="run-approval-2",
+    )
+
+
 def test_current_version_mismatch_fail_closed(tmp_path, monkeypatch):
     repo = _repo(tmp_path)
     run_dir = _run_dir(repo)
@@ -1507,7 +1711,7 @@ def test_first_authority_started_write_projects_on_first_write(tmp_path, monkeyp
     # Finding 2: authority-requested first-write authorization uses the
     # post-parity readiness report. A ready first comparison projects that
     # same write, so the single first "started" write after enrollment already
-    # carries projector_version 3, journal_present true, and the journal has
+    # carries the current projector version, journal_present true, and the journal has
     # checkpoint seq1 + run.created seq2.
     repo = _repo(tmp_path)
     run_dir = _run_dir(repo)

--- a/tests/test_run_projector.py
+++ b/tests/test_run_projector.py
@@ -22,7 +22,6 @@ from brigade.run_projector import (
     RunProjection,
     SnapshotEncodingError,
     UnknownSnapshotFieldError,
-    UnmappedEventTypeError,
     encode_snapshot_bytes,
     project_run_snapshot,
 )
@@ -99,6 +98,11 @@ def _full_base_snapshot() -> dict:
         "lock_workspace": True,
         "codex_transport": "app-server",
         "lifecycle_journal_requested": True,
+        "approval_reference": {
+            "approval_id": "approval-1",
+            "source": "daily",
+            "fingerprint": "approval-fingerprint",
+        },
         "started_at": "2026-07-27T15:30:00.000000Z",
         "status_started_at": "2026-07-27T15:30:00.000000Z",
         "finished_at": None,
@@ -369,19 +373,116 @@ def test_unknown_base_key_raises_bounded_unknown_snapshot_field_error():
     assert "unknown_field" in excinfo.value.diagnostic
 
 
-def test_registered_unmapped_run_paused_raises_bounded_unmapped_event_type_error():
+def test_forged_approval_snapshot_decision_state_fails_closed():
+    base = _minimal_base_snapshot()
+    base["approval_reference"] = {
+        "approval_id": "approval-1",
+        "decision_state": "garbage",
+    }
+
+    with pytest.raises(ProjectionInputError, match="invalid decision_state"):
+        project_run_snapshot(base, [], journal_present=False)
+
+
+def test_approval_pause_resume_events_are_all_mapped_and_reconstruct_status():
+    created = _build_event(1, "run.created", {"status": "started"}, "create-1", RECORDED_AT, None)
+    requested = _build_event(
+        2,
+        "approval.requested",
+        {"approval_id": "a-1", "source": "daily", "contract_fingerprint": "fp-1"},
+        "approval-requested-1",
+        "2026-07-27T15:30:46.000000Z",
+        created["event_digest"],
+    )
+    paused = _build_event(
+        3,
+        "run.paused",
+        {"approval_id": "a-1", "reason": "approval-required"},
+        "pause-1",
+        "2026-07-27T15:30:47.000000Z",
+        requested["event_digest"],
+    )
+    granted = _build_event(
+        4,
+        "approval.granted",
+        {
+            "approval_id": "a-1",
+            "decided_at": "2026-07-27T15:31:00+00:00",
+            "decision_state": "approved",
+        },
+        "approval-granted-1",
+        "2026-07-27T15:31:00.000000Z",
+        paused["event_digest"],
+    )
+    consumed = _build_event(
+        5,
+        "approval.consumed",
+        {"approval_id": "a-1", "consuming_run_id": RUN_ID},
+        "approval-consumed-1",
+        "2026-07-27T15:31:01.000000Z",
+        granted["event_digest"],
+    )
+    resumed = _build_event(
+        6,
+        "run.resumed",
+        {"approval_id": "a-1"},
+        "resume-1",
+        "2026-07-27T15:31:02.000000Z",
+        consumed["event_digest"],
+    )
+    projection = project_run_snapshot(
+        _minimal_base_snapshot(),
+        [created, requested, paused, granted, consumed, resumed],
+        journal_present=True,
+    )
+    assert projection.status == "running"
+    assert projection.snapshot["status"] == "running"
+    assert projection.last_sequence == 6
+    assert projection.last_event_digest == resumed["event_digest"]
+
+
+@pytest.mark.parametrize(
+    ("event_type", "payload"),
+    [
+        (
+            "approval.rejected",
+            {
+                "approval_id": "a-1",
+                "decided_at": "2026-07-27T15:31:00+00:00",
+                "decision_state": "rejected",
+            },
+        ),
+        (
+            "approval.held",
+            {
+                "approval_id": "a-1",
+                "decided_at": "2026-07-27T15:31:00+00:00",
+                "decision_state": "held",
+            },
+        ),
+    ],
+)
+def test_terminal_approval_decisions_preserve_compatibility_status(event_type, payload):
     created = _build_event(1, "run.created", {"status": "started"}, "create-1", RECORDED_AT, None)
     paused = _build_event(
         2,
         "run.paused",
-        {"approval_id": "a-1", "reason": "wait"},
+        {"approval_id": "a-1", "reason": "approval-required"},
         "pause-1",
         "2026-07-27T15:30:46.000000Z",
         created["event_digest"],
     )
-    with pytest.raises(UnmappedEventTypeError) as excinfo:
-        project_run_snapshot(_minimal_base_snapshot(), [created, paused], journal_present=True)
-    _assert_bounded_projection_error(excinfo)
+    decision = _build_event(
+        3,
+        event_type,
+        payload,
+        f"{event_type}-1",
+        "2026-07-27T15:31:00.000000Z",
+        paused["event_digest"],
+    )
+    projection = project_run_snapshot(_minimal_base_snapshot(), [created, paused, decision], journal_present=True)
+    assert projection.status == "running"
+    assert projection.snapshot["status"] == "running"
 
 
 @pytest.mark.parametrize(
@@ -422,7 +523,7 @@ def test_dataclasses_replace_mutation_of_typed_run_event_raises_event_chain_erro
 
 def test_full_field_fixture_preserves_deep_equality_and_copies_nested_values():
     base = _full_base_snapshot()
-    assert len(PRESERVED_FIELDS) == 45
+    assert len(PRESERVED_FIELDS) == 46
     assert DERIVED_FIELDS == {
         "status",
         "projector_version",
@@ -441,6 +542,8 @@ def test_full_field_fixture_preserves_deep_equality_and_copies_nested_values():
         "run.synthesis.started": "synthesizing",
         "run.synthesis.completed": "handoff",
         "run.artifact_collection.started": "artifact-collection",
+        "run.paused": "running",
+        "run.resumed": "running",
     }
     projection = project_run_snapshot(base, [], journal_present=False)
     for field in PRESERVED_FIELDS:
@@ -450,6 +553,7 @@ def test_full_field_fixture_preserves_deep_equality_and_copies_nested_values():
     assert projection.snapshot["recovery_history"] is not base["recovery_history"]
     assert projection.snapshot["active_seats"] is not base["active_seats"]
     assert projection.snapshot["code_graph_brief"] is not base["code_graph_brief"]
+    assert projection.snapshot["approval_reference"] is not base["approval_reference"]
     assert set(projection.snapshot.keys()) <= OWNED_FIELDS
 
 
@@ -558,10 +662,14 @@ def test_checkpoint_after_unmapped_status_preserves_last_mapped_status():
     assert projection.last_event_digest == unmapped_checkpoint["event_digest"]
 
 
-def test_projector_version_is_four():
-    projection = project_run_snapshot(_minimal_base_snapshot(), [], journal_present=False)
-    assert PROJECTOR_VERSION == 4
-    assert projection.snapshot["projector_version"] == 4
+def test_projector_version_is_five_and_replaces_stale_v4():
+    base = _minimal_base_snapshot()
+    base["projector_version"] = 4
+
+    projection = project_run_snapshot(base, [], journal_present=False)
+
+    assert PROJECTOR_VERSION == 5
+    assert projection.snapshot["projector_version"] == 5
 
 
 def _events_ending_with_completed(*, status: str | None) -> list[dict]:

--- a/tests/test_run_resume.py
+++ b/tests/test_run_resume.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from brigade import agents, codex_appserver, runguard, run_resume
+from brigade import agents, codex_appserver, runguard, run_resume, runs_cmd
 
 
 def _write_run_dir(tmp_path: Path, *, results: list[dict]) -> Path:
@@ -227,6 +227,136 @@ def test_resume_with_nothing_resumable_reports_and_exits_2(tmp_path, capsys):
     assert "cook" in err  # names the non-resumable failure
 
 
+def test_approval_resume_requires_reserved_snapshot_before_provider_start(tmp_path, monkeypatch):
+    run_dir = _write_run_dir(
+        tmp_path,
+        results=[
+            {
+                "worker": "cook",
+                "task": "write code",
+                "ok": False,
+                "detail": "approval required",
+                "text": "",
+                "thread_id": "t-1",
+                "status": "interrupted",
+            },
+        ],
+    )
+    meta = json.loads((run_dir / "run.json").read_text())
+    meta["status"] = "running"
+    meta["approval_reference"] = {
+        "approval_id": "approval-1",
+        "source": "daily",
+        "fingerprint": "approval-fingerprint",
+        "source_fingerprint": "source-fingerprint",
+        "contract_fingerprint": "contract-fingerprint",
+        "evidence_fingerprint": "evidence-fingerprint",
+        "decision_state": "approved",
+    }
+    (run_dir / "run.json").write_text(json.dumps(meta))
+    writes = []
+    token = "a" * 43
+
+    def write_json(path, payload):
+        if path.name == "run.json":
+            writes.append(payload["status"])
+        path.write_text(json.dumps(payload))
+
+    class OrderedServer(_StubServer):
+        def __init__(self, *args, **kwargs):
+            assert kwargs["env"] == {runs_cmd._APPROVAL_RESUME_TOKEN_ENV: token}
+            super().__init__(*args, **kwargs)
+
+        def start(self):
+            assert writes == []
+
+        def resume_thread(self, thread_id, *, cwd, model=None, sandbox=None):
+            class TokenEchoThread(_StubThread):
+                def run_turn(self, prompt, *, timeout, on_event=None):
+                    result = super().run_turn(prompt, timeout=timeout, on_event=on_event)
+                    return codex_appserver.TurnResult(
+                        text=f"{result.text} {token}",
+                        ok=result.ok,
+                        status=result.status,
+                        thread_id=result.thread_id,
+                    )
+
+            return TokenEchoThread(thread_id)
+
+    monkeypatch.setattr(run_resume.aboyeur, "_write_json", write_json)
+    monkeypatch.setattr(run_resume.codex_appserver, "AppServer", OrderedServer)
+    monkeypatch.setattr(
+        run_resume.agents,
+        "run_agent",
+        lambda *args, **kwargs: agents.AgentResult(text="approved result", ok=True),
+    )
+    monkeypatch.setattr(runs_cmd, "_finalize_redeemed_approval", lambda *args, **kwargs: None)
+
+    assert run_resume._resume_locked(run_dir, approval_resume=True, approval_token=token) == 0
+    assert writes == ["ok"]
+    worker_results = (run_dir / "worker-results.json").read_text()
+    assert token not in worker_results
+    assert "[redacted]" in worker_results
+
+
+def test_approval_resume_retries_after_app_server_start_failure_without_provider_duplication(
+    tmp_path,
+    monkeypatch,
+):
+    run_dir = _write_run_dir(
+        tmp_path,
+        results=[
+            {
+                "worker": "cook",
+                "task": "write code",
+                "ok": False,
+                "detail": "approval required",
+                "text": "",
+                "thread_id": "t-1",
+                "status": "interrupted",
+            },
+        ],
+    )
+    meta = json.loads((run_dir / "run.json").read_text())
+    meta["status"] = "running"
+    meta["approval_reference"] = {
+        "approval_id": "approval-1",
+        "source": "daily",
+        "fingerprint": "approval-fingerprint",
+        "source_fingerprint": "source-fingerprint",
+        "contract_fingerprint": "contract-fingerprint",
+        "evidence_fingerprint": "evidence-fingerprint",
+        "decision_state": "approved",
+    }
+    (run_dir / "run.json").write_text(json.dumps(meta))
+    starts = []
+    provider_calls = []
+    token = "b" * 43
+
+    class FlakyServer(_StubServer):
+        def start(self):
+            starts.append("start")
+            if len(starts) == 1:
+                raise codex_appserver.AppServerError("not ready")
+
+        def resume_thread(self, thread_id, *, cwd, model=None, sandbox=None):
+            provider_calls.append(thread_id)
+            return super().resume_thread(thread_id, cwd=cwd, model=model, sandbox=sandbox)
+
+    monkeypatch.setattr(run_resume.codex_appserver, "AppServer", FlakyServer)
+    monkeypatch.setattr(
+        run_resume.agents,
+        "run_agent",
+        lambda *args, **kwargs: agents.AgentResult(text="approved result", ok=True),
+    )
+    monkeypatch.setattr(runs_cmd, "_finalize_redeemed_approval", lambda *args, **kwargs: None)
+
+    assert run_resume._resume_locked(run_dir, approval_resume=True, approval_token=token) == 2
+    assert run_resume._resume_locked(run_dir, approval_resume=True, approval_token=token) == 0
+    assert starts == ["start", "start"]
+    assert provider_calls == ["t-1"]
+
+
 def test_resume_missing_artifacts_errors(tmp_path, capsys):
     empty = tmp_path / "empty"
     empty.mkdir()
@@ -366,9 +496,10 @@ def test_resume_infers_lock_workspace_for_legacy_worktree_run(tmp_path, monkeypa
 
 def test_runs_resume_cli_dispatches(tmp_path, monkeypatch):
     from brigade import cli
+    from brigade import runs_cmd
 
     seen = {}
-    monkeypatch.setattr(run_resume, "resume", lambda run_dir: seen.update(run_dir=run_dir) or 0)
+    monkeypatch.setattr(runs_cmd, "resume", lambda run_dir: seen.update(run_dir=run_dir) or 0)
     rc = cli.main(["runs", "resume", str(tmp_path)])
     assert rc == 0
     assert seen["run_dir"] == tmp_path

--- a/tests/test_run_shadow.py
+++ b/tests/test_run_shadow.py
@@ -290,7 +290,7 @@ def test_artifact_collection_after_handoff_is_mapped_no_lag(enabled, tmp_path):
 def test_mapped_ok_after_lag_restores_readiness(enabled, tmp_path):
     repo = _repo(tmp_path)
     run_dir = _run_dir(repo)
-    # "running" remains an unmapped status, so it produces a lag; the
+    # A legacy status without an event mapping produces a lag; the
     # subsequent mapped "ok" restores readiness.
     chain = [
         "started",
@@ -299,7 +299,7 @@ def test_mapped_ok_after_lag_restores_readiness(enabled, tmp_path):
         "result-processing",
         "synthesizing",
         "handoff",
-        "running",
+        "legacy-unmapped",
         "ok",
     ]
 
@@ -361,9 +361,9 @@ def test_unmapped_event_type_records_projection_error(enabled, tmp_path):
         run_journal.append_event(
             _journal_path(run_dir),
             run_id=_RUN_ID,
-            event_type="run.paused",
-            payload={},
-            idempotency_key="lifecycle:paused-test",
+            event_type="run.recovery.started",
+            payload={"detail": "recovering"},
+            idempotency_key="lifecycle:recovery-test",
             expected_previous_sequence=report.events[-1].sequence,
         )
 
@@ -932,8 +932,8 @@ def test_same_tail_distinct_unmapped_shadow_states_count_distinct_lags(enabled, 
     for status in chain:
         _write_run_json_locked(repo, run_dir, status)
 
-    # "running" remains an unmapped status. Two shadow candidates with the
-    # same unmapped status but distinct preserved detail (task) produce
+    # Two candidates with the same legacy unmapped status but distinct
+    # preserved detail (task) produce
     # distinct shadow_digests at the same journal tail (seq 12), so they are
     # distinct lag states and must both be counted -- idempotency keys on
     # (tail sequence, shadow digest, projected digest, outcome, category),
@@ -943,7 +943,7 @@ def test_same_tail_distinct_unmapped_shadow_states_count_distinct_lags(enabled, 
         {
             "schema": "brigade.run.v1",
             "schema_version": 1,
-            "status": "running",
+            "status": "legacy-unmapped",
             "task": "direct-a",
         },
     )
@@ -952,7 +952,7 @@ def test_same_tail_distinct_unmapped_shadow_states_count_distinct_lags(enabled, 
         {
             "schema": "brigade.run.v1",
             "schema_version": 1,
-            "status": "running",
+            "status": "legacy-unmapped",
             "task": "direct-b",
         },
     )
@@ -1133,16 +1133,16 @@ def test_version_one_shadow_artifact_is_stale(enabled, tmp_path):
     assert fresh["last_compared_sequence"] != stale_seq
 
 
-def test_dispatch_semantics_v4_quarantines_old_v3_shadow_artifact(enabled, tmp_path):
+def test_approval_semantics_v5_quarantines_old_v4_shadow_artifact(enabled, tmp_path):
     repo = _repo(tmp_path)
     run_dir = _run_dir(repo)
-    assert run_projector.PROJECTOR_VERSION == 4
+    assert run_projector.PROJECTOR_VERSION == 5
 
     _write_run_json(run_dir, "started")
     _write_run_json_locked(repo, run_dir, "started")
     artifact = run_shadow.shadow_artifact_path(run_dir)
     stale = json.loads(artifact.read_text())
-    stale["projector_version"] = 3
+    stale["projector_version"] = 4
     artifact.write_text(json.dumps(stale, indent=2, sort_keys=True) + "\n")
     stale_bytes = artifact.read_bytes()
 
@@ -1154,7 +1154,7 @@ def test_dispatch_semantics_v4_quarantines_old_v3_shadow_artifact(enabled, tmp_p
     assert quarantined
     assert quarantined[0].read_bytes() == stale_bytes
     fresh = json.loads(artifact.read_text())
-    assert fresh["projector_version"] == 4
+    assert fresh["projector_version"] == 5
     assert fresh["errors"] == 0
 
 

--- a/tests/test_runs_cmd.py
+++ b/tests/test_runs_cmd.py
@@ -2,18 +2,24 @@ import errno
 import json
 import os
 import shutil
+import threading
 import time as system_time
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
 
+from brigade import aboyeur
 from brigade import cli
+from brigade import daily_cmd
 from brigade import run_checkpoint
 from brigade import run_events
 from brigade import run_journal
 from brigade import run_lifecycle
+from brigade import run_resume
 from brigade import runguard
 from brigade import runs_cmd
+from brigade import tools_cmd
 
 
 def _write_json(path, payload):
@@ -27,6 +33,567 @@ def test_artifact_collection_status_is_nonterminal():
 
 def test_legacy_handoff_failed_status_remains_terminal():
     assert runs_cmd._is_terminal({"status": "handoff-failed"}) is True
+
+
+def test_approval_wait_uses_previous_reader_nonterminal_status():
+    meta = {
+        "status": "running",
+        "approval_reference": {
+            "decision_state": "pending",
+        },
+    }
+
+    assert meta["status"] in run_resume._NONTERMINAL_RUN_STATUSES
+    assert runs_cmd._is_terminal(meta) is False
+    assert runs_cmd._is_intentional_approval_pause(meta) is True
+    assert runs_cmd._approval_needs_reconciliation(meta) is False
+
+
+def test_consumed_approval_marker_is_nonterminal_and_needs_reconciliation():
+    meta = {
+        "status": "running",
+        "approval_reference": {
+            "decision_state": "consumed",
+        },
+    }
+
+    assert runs_cmd._is_terminal(meta) is False
+    assert runs_cmd._is_intentional_approval_pause(meta) is False
+    assert runs_cmd._approval_needs_reconciliation(meta) is True
+
+
+def test_true_terminal_status_remains_terminal_with_approval_reference():
+    assert (
+        runs_cmd._is_terminal(
+            {
+                "status": "ok",
+                "finished_at": "2026-07-30T18:00:00+00:00",
+                "approval_reference": {"decision_state": "consumed"},
+            }
+        )
+        is True
+    )
+
+
+def test_previous_resume_reader_refuses_new_approval_wait_before_provider(tmp_path, monkeypatch, capsys):
+    approval = _daily_approval()
+    run_dir, _ = _approval_run(tmp_path, source="daily", record=approval)
+
+    monkeypatch.setattr(
+        run_resume.codex_appserver,
+        "AppServer",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("previous reader must not reach provider")),
+    )
+
+    assert run_resume.resume(run_dir) == 2
+    assert "run is not terminal" in capsys.readouterr().err
+
+
+def _approval_run(tmp_path, *, source, record):
+    run_dir = tmp_path / ".brigade" / "runs" / "run-approval-1"
+    run_dir.mkdir(parents=True)
+    reference = runs_cmd._approval_reference_from_record(source, record)
+    _write_json(
+        run_dir / "run.json",
+        {
+            "status": "running",
+            "cwd": str(tmp_path),
+            "lock_workspace": str(tmp_path),
+            "approval_reference": {**reference, "decision_state": "pending"},
+        },
+    )
+    return run_dir, reference
+
+
+def _daily_approval(*, status="approved", consumed_run_id=None):
+    return {
+        "approval_id": "daily-approval-1",
+        "status": status,
+        "reviewed_at": "2026-07-30T18:00:00+00:00",
+        "selected_action_id": "daily-action-1",
+        "source_fingerprint": "daily-source-fingerprint",
+        "config_fingerprint": "daily-config-fingerprint",
+        "evidence_refs": ["receipt:daily-1"],
+        "consumed_run_id": consumed_run_id,
+        "consumed_at": "2026-07-30T18:01:00+00:00" if consumed_run_id else None,
+    }
+
+
+def _patch_daily_store(monkeypatch, approval, *, blockers=None):
+    monkeypatch.setattr(daily_cmd.approvals, "_find_approval", lambda target, approval_id: approval)
+    monkeypatch.setattr(daily_cmd.config, "_load_config", lambda target: ({}, []))
+    monkeypatch.setattr(
+        daily_cmd.approvals,
+        "_approval_blockers",
+        lambda target, record, config: list(blockers or []),
+    )
+
+
+def test_approval_pause_marker_binds_exact_event_and_redacts_artifact(tmp_path, monkeypatch):
+    approval = _daily_approval(status="pending")
+    marker = "m" * 43
+    run_dir = tmp_path / ".brigade" / "runs" / "marker-run"
+    daily_cmd.approvals._write_approval(tmp_path, approval)
+    monkeypatch.setenv(runs_cmd._APPROVAL_CORRELATION_ENV, marker)
+
+    with runguard.run_lock(tmp_path, run_dir=run_dir):
+        stored = daily_cmd.approvals._find_approval(tmp_path, approval["approval_id"])
+        assert stored is not None
+        assert runs_cmd._attach_approval_pause_request(tmp_path, "daily", stored) is True
+        daily_cmd.approvals._write_approval(tmp_path, stored)
+        writer = aboyeur._worker_event_writer(
+            run_dir / "events",
+            "requester",
+            workspace=tmp_path,
+            correlation_marker=marker,
+        )
+        assert writer is not None
+        writer(
+            {
+                "method": "item/completed",
+                "params": {
+                    "threadId": "thread-requester",
+                    "turnId": "turn-requester",
+                    "item": {
+                        "id": "command-1",
+                        "type": "commandExecution",
+                        "command": f"{runs_cmd._APPROVAL_CORRELATION_ENV}={marker} brigade daily run",
+                    },
+                },
+            }
+        )
+        reference = runs_cmd._approval_pause_reference_for_owned_run(tmp_path, run_dir)
+        assert reference is not None
+        assert reference.requester_worker == "requester"
+        assert reference.requester_thread_id == "thread-requester"
+        assert reference.requester_turn_id == "turn-requester"
+        with pytest.raises(runs_cmd.ApprovalResumeError, match="already bound"):
+            runs_cmd._bind_approval_pause_request(
+                tmp_path,
+                correlation_marker=marker,
+                worker="requester",
+                thread_id="thread-requester",
+                turn_id="turn-requester",
+            )
+        with pytest.raises(runs_cmd.ApprovalResumeError, match="exactly one request"):
+            runs_cmd._bind_approval_pause_request(
+                tmp_path,
+                correlation_marker="x" * 43,
+                worker="other",
+                thread_id="thread-other",
+                turn_id="turn-other",
+            )
+
+    event_text = (run_dir / "events" / "requester.jsonl").read_text()
+    approval_text = daily_cmd.approvals._approval_path(tmp_path, approval["approval_id"]).read_text()
+    assert marker not in event_text
+    assert marker not in approval_text
+    assert "[redacted]" in event_text
+
+
+@pytest.mark.parametrize("source", ["daily", "tool"])
+def test_approval_pause_binding_rejects_request_replaced_before_source_lock(
+    tmp_path,
+    monkeypatch,
+    source,
+):
+    marker = "n" * 43
+    run_dir = tmp_path / ".brigade" / "runs" / f"{source}-replacement-run"
+    record = _daily_approval(status="pending") if source == "daily" else _tool_call()
+    monkeypatch.setenv(runs_cmd._APPROVAL_CORRELATION_ENV, marker)
+
+    with runguard.run_lock(tmp_path, run_dir=run_dir):
+        assert runs_cmd._attach_approval_pause_request(tmp_path, source, record) is True
+        request = record[runs_cmd._APPROVAL_PAUSE_REQUEST_FIELD]
+        original_reference = dict(request["approval_reference"])
+        replaced = False
+
+        @contextmanager
+        def replace_before_locked_reread(*args, **kwargs):
+            nonlocal replaced
+            assert replaced is False
+            request["approval_reference"] = {
+                **original_reference,
+                "fingerprint": "replacement-fingerprint",
+            }
+            replaced = True
+            yield
+
+        if source == "daily":
+            monkeypatch.setattr(daily_cmd.approvals, "_read_approvals", lambda target: ([record], []))
+            monkeypatch.setattr(daily_cmd.approvals, "_approval_store_lock", replace_before_locked_reread)
+            monkeypatch.setattr(daily_cmd.approvals, "_find_approval", lambda target, approval_id: record)
+            monkeypatch.setattr(
+                daily_cmd.approvals,
+                "_write_approval_unlocked",
+                lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("replaced request was bound")),
+            )
+            monkeypatch.setattr(tools_cmd.calls, "_read_calls", lambda target: [])
+        else:
+            monkeypatch.setattr(daily_cmd.approvals, "_read_approvals", lambda target: ([], []))
+            monkeypatch.setattr(tools_cmd.calls, "_read_calls", lambda target: [record])
+            monkeypatch.setattr(tools_cmd.calls, "_calls_store_lock", replace_before_locked_reread)
+            monkeypatch.setattr(
+                tools_cmd.calls,
+                "_resolve_call",
+                lambda target, approval_id: (record, [record], None),
+            )
+            monkeypatch.setattr(
+                tools_cmd.calls,
+                "_write_calls_unlocked",
+                lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("replaced request was bound")),
+            )
+
+        with pytest.raises(runs_cmd.ApprovalResumeError, match="reference changed"):
+            runs_cmd._bind_approval_pause_request(
+                tmp_path,
+                correlation_marker=marker,
+                worker="requester",
+                thread_id="replacement-thread",
+                turn_id="replacement-turn",
+            )
+
+    assert replaced is True
+    assert request["requester_worker"] is None
+    assert request["requester_thread_id"] is None
+    assert request["requester_turn_id"] is None
+
+
+def test_resume_paused_daily_consumes_once_under_fresh_lock(tmp_path, monkeypatch):
+    approval = _daily_approval()
+    run_dir, _ = _approval_run(tmp_path, source="daily", record=approval)
+    observed = []
+
+    _patch_daily_store(monkeypatch, approval)
+
+    original_reserve = daily_cmd.approvals.reserve_for_run
+
+    def reserve(target, approval_id, reference, run_id, token_fingerprint):
+        observed.append(("reserve", runguard.run_lock_state(tmp_path, run_dir), run_id))
+        return original_reserve(target, approval_id, reference, run_id, token_fingerprint)
+
+    monkeypatch.setattr(daily_cmd.approvals, "reserve_for_run", reserve)
+    monkeypatch.setattr(
+        run_lifecycle,
+        "record_lifecycle_event",
+        lambda *args, event_type, **kwargs: observed.append(("event", event_type)),
+    )
+
+    def continue_run(path, *, approval_resume, approval_token):
+        assert isinstance(approval_token, str)
+        observed.append(("continue", runguard.run_lock_state(tmp_path, run_dir), approval_resume))
+        return 0
+
+    monkeypatch.setattr(run_resume, "_resume_locked", continue_run)
+
+    assert runs_cmd.resume(run_dir) == 0
+    assert observed == [
+        ("reserve", "live", run_dir.name),
+        ("event", "approval.granted"),
+        ("continue", "live", True),
+    ]
+    assert runguard.run_lock_state(tmp_path, run_dir) == "absent"
+
+
+def test_daily_reservation_rotation_refuses_foreign_run(tmp_path, monkeypatch):
+    approval = _daily_approval()
+    reference = runs_cmd._approval_reference_from_record("daily", approval)
+    approval["approval_claim"] = {
+        "run_id": "other-run",
+        "state": "reserved",
+        "reserved_at": "2026-07-30T18:01:00+00:00",
+        "token_fingerprint": "a" * 64,
+        "redeemed_at": None,
+    }
+    _patch_daily_store(monkeypatch, approval)
+
+    with pytest.raises(daily_cmd.approvals.ApprovalClaimError, match="reserved by other-run"):
+        daily_cmd.approvals.reserve_for_run(
+            tmp_path,
+            approval["approval_id"],
+            reference,
+            "requesting-run",
+            "b" * 64,
+        )
+
+    assert approval["approval_claim"]["run_id"] == "other-run"
+    assert approval["approval_claim"]["token_fingerprint"] == "a" * 64
+
+
+def test_resume_paused_daily_legacy_consumed_store_fails_closed(tmp_path, monkeypatch, capsys):
+    approval = _daily_approval(status="consumed", consumed_run_id="run-approval-1")
+    run_dir, _ = _approval_run(tmp_path, source="daily", record=approval)
+    events = []
+
+    _patch_daily_store(monkeypatch, approval)
+    monkeypatch.setattr(
+        run_lifecycle,
+        "record_lifecycle_event",
+        lambda *args, event_type, **kwargs: events.append(event_type),
+    )
+    monkeypatch.setattr(
+        run_resume,
+        "_resume_locked",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("legacy claim reached provider")),
+    )
+
+    assert runs_cmd.resume(run_dir) == 2
+    assert events == []
+    assert "daily approval is consumed" in capsys.readouterr().err
+
+
+def test_resume_paused_legacy_consumed_store_does_not_rewrite_snapshot(tmp_path, monkeypatch):
+    approval = _daily_approval(status="consumed", consumed_run_id="run-approval-1")
+    run_dir, _ = _approval_run(tmp_path, source="daily", record=approval)
+    continued = []
+
+    _patch_daily_store(monkeypatch, approval)
+    monkeypatch.setattr(run_lifecycle, "record_lifecycle_event", lambda *args, **kwargs: None)
+    before = (run_dir / "run.json").read_bytes()
+    monkeypatch.setattr(run_resume, "_resume_locked", lambda *args, **kwargs: continued.append(args) or 0)
+
+    assert runs_cmd.resume(run_dir) == 2
+    assert continued == []
+    assert (run_dir / "run.json").read_bytes() == before
+
+
+def test_consumed_daily_reconciliation_revalidates_live_evidence(tmp_path, monkeypatch, capsys):
+    approval = _daily_approval(status="consumed", consumed_run_id="run-approval-1")
+    run_dir, _ = _approval_run(tmp_path, source="daily", record=approval)
+    checked = []
+
+    monkeypatch.setattr(daily_cmd.approvals, "_find_approval", lambda target, approval_id: approval)
+    monkeypatch.setattr(daily_cmd.config, "_load_config", lambda target: ({}, []))
+
+    def blockers(target, record, config):
+        checked.append((record["status"], record.get("consumed_run_id")))
+        return ["selected action fingerprint changed since approval"]
+
+    monkeypatch.setattr(daily_cmd.approvals, "_approval_blockers", blockers)
+    monkeypatch.setattr(
+        run_resume,
+        "_resume_locked",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("stale evidence must not reach provider")),
+    )
+
+    assert runs_cmd.resume(run_dir) == 2
+    assert checked == [("approved", None)]
+    assert "selected action fingerprint changed" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("status", ["rejected", "held"])
+def test_resume_paused_records_terminal_daily_decision_without_consuming(tmp_path, monkeypatch, capsys, status):
+    approval = _daily_approval(status=status)
+    run_dir, _ = _approval_run(tmp_path, source="daily", record=approval)
+    events = []
+
+    _patch_daily_store(monkeypatch, approval)
+    monkeypatch.setattr(
+        daily_cmd.approvals,
+        "_consume_approval",
+        lambda *args: (_ for _ in ()).throw(AssertionError("terminal decision must not consume")),
+    )
+    monkeypatch.setattr(
+        run_lifecycle,
+        "record_lifecycle_event",
+        lambda *args, event_type, **kwargs: events.append(event_type),
+    )
+    monkeypatch.setattr(runs_cmd, "_refresh_paused_snapshot", lambda *args, **kwargs: None)
+
+    assert runs_cmd.resume(run_dir) == 2
+    assert events == [f"approval.{status}"]
+    assert f"approval is {status}" in capsys.readouterr().err
+
+
+def test_held_marker_stays_approval_aware_and_resumes_after_store_grant(tmp_path, monkeypatch, capsys):
+    approval = _daily_approval(status="held")
+    run_dir, _ = _approval_run(tmp_path, source="daily", record=approval)
+    continued = []
+    claims = []
+
+    _patch_daily_store(monkeypatch, approval)
+    monkeypatch.setattr(run_lifecycle, "record_lifecycle_event", lambda *args, **kwargs: None)
+    original_reserve = daily_cmd.approvals.reserve_for_run
+
+    def reserve(target, approval_id, reference, run_id, token_fingerprint):
+        claims.append(run_id)
+        return original_reserve(target, approval_id, reference, run_id, token_fingerprint)
+
+    monkeypatch.setattr(daily_cmd.approvals, "reserve_for_run", reserve)
+    monkeypatch.setattr(
+        run_resume,
+        "_resume_locked",
+        lambda path, *, approval_resume, approval_token: continued.append((path, approval_resume)) or 0,
+    )
+
+    assert runs_cmd.resume(run_dir) == 2
+    assert "approval is held" in capsys.readouterr().err
+    held = json.loads((run_dir / "run.json").read_text())
+    assert held["approval_reference"]["decision_state"] == "held"
+    assert runs_cmd._approval_resume_state(held) == "held"
+
+    approval["status"] = "approved"
+    approval["reviewed_at"] = "2026-07-30T18:05:00+00:00"
+    assert runs_cmd.resume(run_dir) == 0
+    assert continued == [(run_dir, True)]
+    assert claims == [run_dir.name]
+    assert approval["status"] == "approved"
+    assert approval["approval_claim"]["state"] == "reserved"
+    assert approval["approval_claim"]["run_id"] == run_dir.name
+
+
+def test_rejected_marker_stays_approval_aware_and_never_reaches_provider(tmp_path, monkeypatch, capsys):
+    approval = _daily_approval(status="rejected")
+    run_dir, _ = _approval_run(tmp_path, source="daily", record=approval)
+
+    _patch_daily_store(monkeypatch, approval)
+    monkeypatch.setattr(run_lifecycle, "record_lifecycle_event", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        run_resume,
+        "_resume_locked",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("rejected approval reached provider")),
+    )
+
+    assert runs_cmd.resume(run_dir) == 2
+    assert "approval is rejected" in capsys.readouterr().err
+    rejected = json.loads((run_dir / "run.json").read_text())
+    assert rejected["approval_reference"]["decision_state"] == "rejected"
+    assert runs_cmd._approval_resume_state(rejected) == "rejected"
+
+    assert runs_cmd.resume(run_dir) == 2
+    assert "approval is rejected" in capsys.readouterr().err
+
+
+def test_resume_paused_refuses_stale_daily_reference_before_consuming(tmp_path, monkeypatch, capsys):
+    approval = _daily_approval()
+    run_dir, reference = _approval_run(tmp_path, source="daily", record=approval)
+    reference["evidence_fingerprint"] = "stale"
+    meta = json.loads((run_dir / "run.json").read_text())
+    meta["approval_reference"] = {**reference, "decision_state": "pending"}
+    _write_json(run_dir / "run.json", meta)
+
+    _patch_daily_store(monkeypatch, approval)
+    monkeypatch.setattr(
+        daily_cmd.approvals,
+        "_consume_approval",
+        lambda *args: (_ for _ in ()).throw(AssertionError("stale approval must not consume")),
+    )
+
+    assert runs_cmd.resume(run_dir) == 2
+    assert "approval fingerprints changed" in capsys.readouterr().err
+
+
+def _tool_call():
+    call = {
+        "id": "call-approval-1",
+        "status": "approved",
+        "reviewed_at": "2026-07-30T18:00:00+00:00",
+        "tool_id": "fake-tool",
+        "source_fingerprint": "tool-source-fingerprint",
+        "contract_fingerprint": "tool-contract-fingerprint",
+        "call_fingerprint": "tool-call-fingerprint",
+        "approval_fingerprint": "approved-fingerprint",
+    }
+    return call
+
+
+def test_resume_paused_tool_consumes_existing_call_record_once(tmp_path, monkeypatch):
+    call = _tool_call()
+    run_dir, _ = _approval_run(tmp_path, source="tool", record=call)
+    writes = []
+
+    monkeypatch.setattr(tools_cmd.calls, "_resolve_call", lambda target, call_id: (call, [call], None))
+    monkeypatch.setattr(tools_cmd.calls, "_call_run_blockers", lambda target, record: [])
+    monkeypatch.setattr(
+        tools_cmd.calls,
+        "_write_calls_unlocked",
+        lambda target, calls: writes.append([dict(item) for item in calls]),
+    )
+    monkeypatch.setattr(
+        run_lifecycle,
+        "record_lifecycle_event",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        run_resume,
+        "_resume_locked",
+        lambda path, *, approval_resume, approval_token: 0,
+    )
+
+    assert runs_cmd.resume(run_dir) == 0
+    assert len(writes) == 1
+    assert writes[0][0]["status"] == "approved"
+    assert writes[0][0].get("run_id") is None
+    assert writes[0][0]["approval_claim"]["state"] == "reserved"
+    assert writes[0][0]["approval_claim"]["run_id"] == run_dir.name
+
+
+def test_tool_reservation_rotation_refuses_foreign_run(tmp_path, monkeypatch):
+    call = _tool_call()
+    reference = runs_cmd._approval_reference_from_record("tool", call)
+    call["approval_claim"] = {
+        "run_id": "other-run",
+        "state": "reserved",
+        "reserved_at": "2026-07-30T18:01:00+00:00",
+        "token_fingerprint": "a" * 64,
+        "redeemed_at": None,
+    }
+    writes = []
+    monkeypatch.setattr(tools_cmd.calls, "_resolve_call", lambda target, call_id: (call, [call], None))
+    monkeypatch.setattr(tools_cmd.calls, "_call_run_blockers", lambda target, record: [])
+    monkeypatch.setattr(
+        tools_cmd.calls,
+        "_write_calls_unlocked",
+        lambda target, calls: writes.append([dict(item) for item in calls]),
+    )
+
+    with pytest.raises(tools_cmd.calls.CallClaimError, match="reserved by other-run"):
+        tools_cmd.calls.reserve_for_run(
+            tmp_path,
+            call["id"],
+            reference,
+            "requesting-run",
+            "b" * 64,
+        )
+
+    assert writes == []
+    assert call["approval_claim"]["run_id"] == "other-run"
+    assert call["approval_claim"]["token_fingerprint"] == "a" * 64
+
+
+def test_consumed_tool_reconciliation_revalidates_live_contract(tmp_path, monkeypatch, capsys):
+    call = _tool_call()
+    call.update({"status": "running", "run_id": "run-approval-1"})
+    run_dir, _ = _approval_run(tmp_path, source="tool", record=call)
+    checked = []
+
+    monkeypatch.setattr(tools_cmd.calls, "_resolve_call", lambda target, call_id: (call, [call], None))
+
+    def blockers(target, record):
+        checked.append((record["status"], record.get("run_id")))
+        return ["contract fingerprint is stale"]
+
+    monkeypatch.setattr(tools_cmd.calls, "_call_run_blockers", blockers)
+    monkeypatch.setattr(
+        run_resume,
+        "_resume_locked",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("stale contract must not reach provider")),
+    )
+
+    assert runs_cmd.resume(run_dir) == 2
+    assert checked == [("approved", None)]
+    assert "contract fingerprint is stale" in capsys.readouterr().err
+
+
+def test_resume_nonapproval_run_uses_legacy_fallback(tmp_path, monkeypatch):
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    _write_json(run_dir / "run.json", {"status": "failed"})
+    seen = []
+    monkeypatch.setattr(run_resume, "resume", lambda path: seen.append(path) or 0)
+
+    assert runs_cmd.resume(run_dir) == 0
+    assert seen == [run_dir]
 
 
 def test_watch_reports_unrecoverable_artifact_collection_lock_error(tmp_path, monkeypatch, capsys):
@@ -89,6 +656,101 @@ def test_watch_handles_artifact_collection_completion_race(tmp_path, monkeypatch
     monkeypatch.setattr(runguard, "recover_stale_run", finish_without_recovery)
 
     assert runs_cmd.watch(run_dir, cwd=tmp_path, interval=0) == 0
+
+
+def test_watch_stops_on_pending_approval_with_no_lock(tmp_path, capsys):
+    approval = _daily_approval(status="pending")
+    run_dir, _ = _approval_run(tmp_path, source="daily", record=approval)
+
+    assert runguard.run_lock_state(tmp_path, run_dir) == "absent"
+    assert runs_cmd.watch(run_dir, cwd=tmp_path, interval=0) == 1
+    assert "summary: running" in capsys.readouterr().out
+
+
+def test_watch_waits_for_consumed_approval_while_provider_lock_is_live(tmp_path, monkeypatch):
+    approval = _daily_approval(status="consumed", consumed_run_id="run-approval-1")
+    run_dir, _ = _approval_run(tmp_path, source="daily", record=approval)
+    run_path = run_dir / "run.json"
+    meta = json.loads(run_path.read_text())
+    meta["approval_reference"]["decision_state"] = "consumed"
+    meta["approval_reference"]["consuming_run_id"] = run_dir.name
+    _write_json(run_path, meta)
+
+    consumed_observed = threading.Event()
+    original_poll = runs_cmd._poll_watch_artifacts
+
+    def observe_poll(*args, **kwargs):
+        result = original_poll(*args, **kwargs)
+        current = result[0]
+        if current is not None and runs_cmd._approval_needs_reconciliation(current):
+            consumed_observed.set()
+        return result
+
+    monkeypatch.setattr(runs_cmd, "_poll_watch_artifacts", observe_poll)
+
+    def finish_provider():
+        assert consumed_observed.wait(timeout=2)
+        finished = json.loads(run_path.read_text())
+        finished["status"] = "ok"
+        finished["finished_at"] = "2026-07-30T18:10:00+00:00"
+        _write_json(run_path, finished)
+
+    worker = threading.Thread(target=finish_provider)
+    with runguard.run_lock(tmp_path, run_dir=run_dir):
+        worker.start()
+        assert runs_cmd.watch(run_dir, cwd=tmp_path, interval=0.001) == 0
+    worker.join(timeout=2)
+    assert not worker.is_alive()
+
+
+def test_watch_consumed_approval_without_lock_requests_resume_reconciliation(tmp_path, capsys):
+    approval = _daily_approval(status="consumed", consumed_run_id="run-approval-1")
+    run_dir, _ = _approval_run(tmp_path, source="daily", record=approval)
+    meta = json.loads((run_dir / "run.json").read_text())
+    meta["approval_reference"]["decision_state"] = "consumed"
+    meta["approval_reference"]["consuming_run_id"] = run_dir.name
+    _write_json(run_dir / "run.json", meta)
+
+    assert runguard.run_lock_state(tmp_path, run_dir) == "absent"
+    assert runs_cmd.watch(run_dir, cwd=tmp_path, interval=0) == 2
+    assert "approval resume requires reconciliation" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    ("state", "expected"),
+    [
+        ("pending", "approval wait is intentional"),
+        ("consumed", "approval resume requires reconciliation"),
+    ],
+)
+def test_recover_refuses_approval_control_states_without_terminalizing(tmp_path, capsys, state, expected):
+    approval = _daily_approval(
+        status="consumed" if state == "consumed" else "pending",
+        consumed_run_id="run-approval-1" if state == "consumed" else None,
+    )
+    run_dir, _ = _approval_run(tmp_path, source="daily", record=approval)
+    meta = json.loads((run_dir / "run.json").read_text())
+    meta["approval_reference"]["decision_state"] = state
+    if state == "consumed":
+        meta["approval_reference"]["consuming_run_id"] = run_dir.name
+    _write_json(run_dir / "run.json", meta)
+
+    assert runs_cmd.recover(run_dir, cwd=tmp_path) == 2
+    assert expected in capsys.readouterr().err
+    assert json.loads((run_dir / "run.json").read_text())["status"] == "running"
+
+
+def test_recover_consumed_approval_refuses_live_provider_lock(tmp_path, capsys):
+    approval = _daily_approval(status="consumed", consumed_run_id="run-approval-1")
+    run_dir, _ = _approval_run(tmp_path, source="daily", record=approval)
+    meta = json.loads((run_dir / "run.json").read_text())
+    meta["approval_reference"]["decision_state"] = "consumed"
+    meta["approval_reference"]["consuming_run_id"] = run_dir.name
+    _write_json(run_dir / "run.json", meta)
+
+    with runguard.run_lock(tmp_path, run_dir=run_dir):
+        assert runs_cmd.recover(run_dir, cwd=tmp_path) == 2
+    assert "run owner process is still active" in capsys.readouterr().err
 
 
 def _write_run_artifacts(run_dir):

--- a/tests/test_work_cmd_services.py
+++ b/tests/test_work_cmd_services.py
@@ -3,17 +3,29 @@ import os
 import socket
 import subprocess
 import sys
+from contextlib import contextmanager, redirect_stdout
 from datetime import date, datetime, timezone
+from io import StringIO
 from pathlib import Path
 
+import pytest
+
+from brigade import aboyeur
+from brigade import agents
 from brigade import cli
 from brigade import dogfood_cmd
 from brigade import localio
 from brigade import repos_cmd
 from brigade import roadmap_cmd
+from brigade import runguard
+from brigade import run_journal
+from brigade import run_resume
+from brigade import runs_cmd
 from brigade import security_cmd
 from brigade import tools_cmd
 from brigade import work_cmd
+from brigade.roster import Agent, Roster
+from brigade.tools_cmd import calls as tool_calls_mod
 
 from tests.work_cmd_test_helpers import (
     _write_json,
@@ -28,6 +40,32 @@ from tests.work_cmd_test_helpers import (
     _fake_mcp_server_script,
     _queue_and_approve_mcp,
 )
+
+
+def _inject_call_update_on_next_store_lock(
+    monkeypatch,
+    target: Path,
+    call_id: str,
+    *,
+    field: str,
+    value: object,
+) -> None:
+    original_lock = tool_calls_mod._calls_store_lock
+    injected = False
+
+    @contextmanager
+    def interleaved_lock(current_target):
+        nonlocal injected
+        with original_lock(current_target):
+            if not injected:
+                calls = tool_calls_mod._read_calls(target)
+                call = next(item for item in calls if item["id"] == call_id)
+                call[field] = value
+                tool_calls_mod._write_calls_unlocked(target, calls)
+                injected = True
+            yield
+
+    monkeypatch.setattr(tool_calls_mod, "_calls_store_lock", interleaved_lock)
 
 
 def test_tools_init_list_show_search_doctor_and_json(tmp_path, monkeypatch, capsys):
@@ -1030,6 +1068,56 @@ supported_harnesses = []
     assert payload["call"]["review_reason"] == "not needed"
 
 
+def test_tools_call_review_preserves_update_completed_before_store_lock(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    _init_git_repo(tmp_path)
+    _write_script_tool_config(tmp_path, script='print("ok")\n')
+    assert (
+        tools_cmd.call_queue(
+            target=tmp_path,
+            tool_id="runner",
+            args='{"path":"reviewed"}',
+            json_output=True,
+        )
+        == 0
+    )
+    reviewed = json.loads(capsys.readouterr().out)["call"]
+    assert (
+        tools_cmd.call_queue(
+            target=tmp_path,
+            tool_id="runner",
+            args='{"path":"concurrent"}',
+            json_output=True,
+        )
+        == 0
+    )
+    concurrent = json.loads(capsys.readouterr().out)["call"]
+    _inject_call_update_on_next_store_lock(
+        monkeypatch,
+        tmp_path,
+        concurrent["id"],
+        field="review_reason",
+        value="concurrent update",
+    )
+
+    assert (
+        tools_cmd.call_approve(
+            target=tmp_path,
+            call_id=reviewed["id"],
+            json_output=True,
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    stored = {item["id"]: item for item in tools_cmd._read_calls(tmp_path)}
+    assert stored[reviewed["id"]]["status"] == "approved"
+    assert stored[concurrent["id"]]["review_reason"] == "concurrent update"
+
+
 def test_tools_call_queue_blocked_requires_include_blocked_and_cannot_approve(tmp_path, capsys):
     _init_git_repo(tmp_path)
     config = tmp_path / ".brigade" / "tools.toml"
@@ -1154,6 +1242,47 @@ def test_tools_call_run_approved_script_writes_receipt_and_redacts_output(tmp_pa
     assert "status: completed" in out
 
 
+def test_tools_call_run_preserves_update_completed_before_store_lock(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    _init_git_repo(tmp_path)
+    _write_script_tool_config(tmp_path, script='print("ok")\n')
+    runnable = _queue_and_approve_runner(tmp_path, capsys, args='{"path":"runnable"}')
+    assert (
+        tools_cmd.call_queue(
+            target=tmp_path,
+            tool_id="runner",
+            args='{"path":"concurrent"}',
+            json_output=True,
+        )
+        == 0
+    )
+    concurrent = json.loads(capsys.readouterr().out)["call"]
+    _inject_call_update_on_next_store_lock(
+        monkeypatch,
+        tmp_path,
+        concurrent["id"],
+        field="review_reason",
+        value="concurrent update",
+    )
+
+    assert (
+        tools_cmd.call_run(
+            target=tmp_path,
+            call_id=runnable["id"],
+            json_output=True,
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    stored = {item["id"]: item for item in tools_cmd._read_calls(tmp_path)}
+    assert stored[runnable["id"]]["status"] == "completed"
+    assert stored[concurrent["id"]]["review_reason"] == "concurrent update"
+
+
 def test_tools_call_run_refuses_non_runnable_statuses_and_stale_records(tmp_path, capsys):
     _init_git_repo(tmp_path)
     _write_script_tool_config(tmp_path, script='print("ok")\n')
@@ -1216,6 +1345,694 @@ supported_harnesses = []
     capsys.readouterr()
     assert tools_cmd.call_run(target=tmp_path, call_id=completed["id"], json_output=True) == 1
     assert "completed calls cannot be run again" in " ".join(json.loads(capsys.readouterr().out)["blockers"])
+
+
+def test_tools_pending_approval_boundary_does_not_request_pause_without_active_run(tmp_path, capsys):
+    _init_git_repo(tmp_path)
+    _write_script_tool_config(tmp_path, script='print("ok")\n')
+    assert tools_cmd.call_queue(target=tmp_path, tool_id="runner", args='{"path":"pending"}', json_output=True) == 0
+    pending = json.loads(capsys.readouterr().out)["call"]
+    assert tools_cmd.call_run(target=tmp_path, call_id=pending["id"], json_output=True) == 1
+    capsys.readouterr()
+
+    stored = next(item for item in tools_cmd._read_calls(tmp_path) if item["id"] == pending["id"])
+    assert "brigade_approval_pause_request" not in stored
+
+
+def test_tools_child_process_requests_owner_process_pause_and_releases_parent_lock(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    _init_git_repo(tmp_path)
+    subprocess.run(["git", "config", "user.email", "test@example.invalid"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=tmp_path, check=True)
+    _write_script_tool_config(
+        tmp_path,
+        script=(
+            "import sys\n"
+            "from pathlib import Path\n"
+            "path = Path(sys.argv[1])\n"
+            "count = int(path.read_text()) if path.exists() else 0\n"
+            "path.write_text(str(count + 1))\n"
+            "print('executed')\n"
+        ),
+    )
+    assert (
+        tools_cmd.call_queue(
+            target=tmp_path,
+            tool_id="runner",
+            args='{"path":"private-argument-value"}',
+            json_output=True,
+        )
+        == 0
+    )
+    pending = json.loads(capsys.readouterr().out)["call"]
+    (tmp_path / ".brigade" / "roster.toml").write_text(
+        """
+orchestrator = "chef"
+
+[agents.chef]
+cli = "codex"
+role = "plan"
+
+[agents.coder]
+cli = "codex"
+role = "code"
+"""
+    )
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-m", "test fixture"], cwd=tmp_path, check=True)
+
+    child_pid_path = tmp_path.parent / f"{tmp_path.name}-approval-child.pid"
+    source_root = Path(__file__).resolve().parents[1] / "src"
+    correlation_marker = "c" * 43
+    run_dir = tmp_path / ".brigade" / "runs" / "tool-child-approval-run"
+
+    def dispatch_with_approval_request(*args, **kwargs):
+        child_code = (
+            "import os,sys\n"
+            "from pathlib import Path\n"
+            "Path(sys.argv[1]).write_text(str(os.getpid()))\n"
+            "from brigade import cli\n"
+            "raise SystemExit(cli.main(sys.argv[2:]))\n"
+        )
+        environment = dict(os.environ)
+        environment["PYTHONPATH"] = str(source_root)
+        environment[runs_cmd._APPROVAL_CORRELATION_ENV] = correlation_marker
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                child_code,
+                str(child_pid_path),
+                "tools",
+                "call",
+                "run",
+                pending["id"],
+                "--target",
+                str(tmp_path),
+                "--json",
+            ],
+            cwd=tmp_path,
+            env=environment,
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        assert completed.returncode == 1
+        writer = aboyeur._worker_event_writer(
+            run_dir / "events",
+            "coder",
+            workspace=tmp_path,
+            correlation_marker=correlation_marker,
+        )
+        assert writer is not None
+        writer(
+            {
+                "method": "item/completed",
+                "params": {
+                    "threadId": "tool-approval-thread",
+                    "turnId": "tool-approval-turn",
+                    "item": {
+                        "id": "command-approval",
+                        "type": "commandExecution",
+                        "command": (
+                            f"{runs_cmd._APPROVAL_CORRELATION_ENV}={correlation_marker} "
+                            f"brigade tools call run {pending['id']}"
+                        ),
+                    },
+                },
+            }
+        )
+        return [
+            aboyeur.WorkerResult(
+                worker="unrelated-success",
+                task="other",
+                text="done",
+                ok=True,
+                thread_id="unrelated-thread",
+                status="complete",
+            ),
+            aboyeur.WorkerResult(
+                worker="unrelated-failure",
+                task="other failure",
+                text="",
+                ok=False,
+                thread_id="unrelated-failed-thread",
+                status="failed",
+            ),
+            aboyeur.WorkerResult(
+                worker="coder",
+                task="request tool approval",
+                text="approval is required",
+                ok=True,
+                thread_id="tool-approval-thread",
+                status="complete",
+            ),
+        ]
+
+    monkeypatch.setattr(aboyeur, "dispatch", dispatch_with_approval_request)
+    monkeypatch.setenv("BRIGADE_RUN_JOURNAL_AUTHORITY", "1")
+    monkeypatch.setenv("BRIGADE_LIFECYCLE_JOURNAL", "1")
+
+    assert (
+        cli.main(
+            [
+                "run",
+                "request tool approval",
+                "--cwd",
+                str(tmp_path),
+                "--output-dir",
+                str(run_dir),
+                "--worker",
+                "coder",
+                "--no-code-graph",
+                "--no-evidence",
+                "--no-route",
+            ]
+        )
+        == 0
+    )
+
+    assert int(child_pid_path.read_text()) != os.getpid()
+    assert runguard.run_lock_state(tmp_path, run_dir) == "absent"
+    paused = json.loads((run_dir / "run.json").read_text())
+    assert paused["status"] == "running"
+    assert paused["approval_reference"]["decision_state"] == "pending"
+    assert paused["approval_reference"]["approval_id"] == pending["id"]
+    journal_path = run_dir / "events" / "lifecycle.jsonl"
+    events = run_journal.read_journal(journal_path).events
+    assert [event.event_type for event in events][-4:] == [
+        "run.snapshot.checkpointed",
+        "approval.requested",
+        "run.snapshot.checkpointed",
+        "run.paused",
+    ]
+    assert "private-argument-value" not in journal_path.read_text()
+    assert (run_dir / "worker-results.json").is_file()
+    handoff = json.loads((run_dir / "worker-results.json").read_text())
+    assert handoff["results"] == [
+        {
+            "worker": "coder",
+            "task": "request tool approval",
+            "ok": False,
+            "thread_id": "tool-approval-thread",
+            "status": "interrupted",
+        }
+    ]
+    assert not (run_dir / "logs").exists()
+    handoff_paths = [
+        run_dir / "worker-results.json",
+        *sorted((run_dir / "revisions" / "worker-results").glob("*.json")),
+    ]
+    assert len(handoff_paths) == 2
+    assert all("private-argument-value" not in path.read_text() for path in handoff_paths)
+
+    resume_tokens = []
+
+    class ResumedThread:
+        def __init__(self, token):
+            self.token = token
+
+        def run_turn(self, prompt, *, timeout):
+            assert "request tool approval" in prompt
+            resume_tokens.append(self.token)
+            previous = os.environ.get(runs_cmd._APPROVAL_RESUME_TOKEN_ENV)
+            os.environ[runs_cmd._APPROVAL_RESUME_TOKEN_ENV] = self.token
+            try:
+                with redirect_stdout(StringIO()):
+                    assert tools_cmd.call_run(target=tmp_path, call_id=pending["id"], json_output=True) == 0
+                    assert tools_cmd.call_run(target=tmp_path, call_id=pending["id"], json_output=True) == 1
+            finally:
+                if previous is None:
+                    os.environ.pop(runs_cmd._APPROVAL_RESUME_TOKEN_ENV, None)
+                else:
+                    os.environ[runs_cmd._APPROVAL_RESUME_TOKEN_ENV] = previous
+            assert (tmp_path / "private-argument-value").read_text() == "1"
+            return run_resume.codex_appserver.TurnResult(
+                text="approval continuation complete",
+                ok=True,
+                status="complete",
+                thread_id="tool-approval-thread",
+            )
+
+    class ResumeServer:
+        def __init__(self, *args, **kwargs):
+            self.token = kwargs["env"][runs_cmd._APPROVAL_RESUME_TOKEN_ENV]
+
+        def start(self):
+            pass
+
+        def close(self):
+            pass
+
+        def resume_thread(self, thread_id, *, cwd, model=None, sandbox=None):
+            assert thread_id == "tool-approval-thread"
+            assert cwd == tmp_path
+            return ResumedThread(self.token)
+
+    assert tools_cmd.call_approve(target=tmp_path, call_id=pending["id"], json_output=True) == 0
+    capsys.readouterr()
+    monkeypatch.setattr(
+        run_resume.agents,
+        "run_agent",
+        lambda *args, **kwargs: agents.AgentResult(text="resumed synthesis", ok=True),
+    )
+
+    start_failure_tokens = []
+
+    class StartFailureServer:
+        def __init__(self, *args, **kwargs):
+            start_failure_tokens.append(kwargs["env"][runs_cmd._APPROVAL_RESUME_TOKEN_ENV])
+
+        def start(self):
+            raise run_resume.codex_appserver.AppServerError("injected start failure")
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_resume.codex_appserver, "AppServer", StartFailureServer)
+    assert cli.main(["runs", "resume", str(run_dir)]) == 2
+    reserved = next(item for item in tools_cmd._read_calls(tmp_path) if item["id"] == pending["id"])
+    assert reserved["status"] == "approved"
+    assert reserved["approval_claim"]["state"] == "reserved"
+    assert start_failure_tokens[0] not in json.dumps(reserved)
+
+    monkeypatch.setattr(run_resume.codex_appserver, "AppServer", ResumeServer)
+    assert cli.main(["runs", "resume", str(run_dir)]) == 0
+    assert (run_dir / "final.txt").read_text().strip() == "resumed synthesis"
+    resumed = json.loads((run_dir / "run.json").read_text())
+    assert resumed["status"] == "ok"
+    assert len(resume_tokens) == 1
+    assert resume_tokens[0] != start_failure_tokens[0]
+    stored_call = next(item for item in tools_cmd._read_calls(tmp_path) if item["id"] == pending["id"])
+    assert stored_call["status"] == "completed"
+    assert stored_call["approval_claim"]["state"] == "redeemed"
+    assert stored_call["approval_claim"]["run_id"] == run_dir.name
+    serialized_artifacts = "\n".join(
+        path.read_text(errors="replace")
+        for path in [
+            run_dir / "run.json",
+            run_dir / "worker-results.json",
+            journal_path,
+            tmp_path / ".brigade" / "tools" / "calls.jsonl",
+        ]
+    )
+    assert correlation_marker not in serialized_artifacts
+    assert resume_tokens[0] not in serialized_artifacts
+
+
+def test_tools_resume_claim_rechecks_store_after_authorization(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    _init_git_repo(tmp_path)
+    _write_script_tool_config(tmp_path, script='print("ok")\n')
+    assert tools_cmd.call_queue(target=tmp_path, tool_id="runner", args='{"path":"pending"}', json_output=True) == 0
+    pending = json.loads(capsys.readouterr().out)["call"]
+    monkeypatch.setenv("BRIGADE_RUN_JOURNAL_AUTHORITY", "1")
+    monkeypatch.setenv("BRIGADE_LIFECYCLE_JOURNAL", "1")
+    marker = "q" * 43
+    monkeypatch.setenv(runs_cmd._APPROVAL_CORRELATION_ENV, marker)
+    run_dir = tmp_path / ".brigade" / "runs" / "tool-claim-race-run"
+    roster = Roster(
+        orchestrator="chef",
+        agents={"chef": Agent("chef", "codex", "plan")},
+    )
+
+    with runguard.run_lock(tmp_path, run_dir=run_dir):
+        aboyeur.record_run_start(
+            run_dir,
+            task="tool claim race",
+            cwd=tmp_path,
+            roster=roster,
+            read_only=False,
+            lock_workspace=tmp_path,
+        )
+        assert tools_cmd.call_run(target=tmp_path, call_id=pending["id"], json_output=True) == 1
+        capsys.readouterr()
+        runs_cmd._bind_approval_pause_request(
+            tmp_path,
+            correlation_marker=marker,
+            worker="coder",
+            thread_id="tool-race-thread",
+            turn_id="tool-race-turn",
+        )
+        reference = runs_cmd._approval_pause_reference_for_owned_run(tmp_path, run_dir)
+        assert reference is not None
+        aboyeur.record_approval_pause(run_dir, reference)
+
+    assert tools_cmd.call_approve(target=tmp_path, call_id=pending["id"], json_output=True) == 0
+    capsys.readouterr()
+    original_load = runs_cmd._load_approval_authorization
+
+    def authorize_then_hold(workspace, reference, *, run_id):
+        authorization = original_load(workspace, reference, run_id=run_id)
+        assert (
+            tools_cmd.call_hold(
+                target=tmp_path,
+                call_id=pending["id"],
+                reason="concurrent review",
+                json_output=True,
+            )
+            == 0
+        )
+        capsys.readouterr()
+        return authorization
+
+    continued = []
+    monkeypatch.setattr(runs_cmd, "_load_approval_authorization", authorize_then_hold)
+    monkeypatch.setattr(
+        run_resume,
+        "_resume_locked",
+        lambda path, *, approval_resume, approval_token: continued.append((path, approval_resume, approval_token)) or 0,
+    )
+
+    assert cli.main(["runs", "resume", str(run_dir)]) == 2
+    assert continued == []
+    stored = next(item for item in tools_cmd._read_calls(tmp_path) if item["id"] == pending["id"])
+    assert stored["status"] == "held"
+    event_types = [
+        event.event_type for event in run_journal.read_journal(run_dir / "events" / "lifecycle.jsonl").events
+    ]
+    assert "approval.granted" not in event_types
+
+
+def test_tools_reserved_claim_rechecks_contract_before_redemption_and_action(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    _init_git_repo(tmp_path)
+    _write_script_tool_config(
+        tmp_path,
+        script=(
+            "import sys\n"
+            "from pathlib import Path\n"
+            "path = Path(sys.argv[1])\n"
+            "count = int(path.read_text()) if path.exists() else 0\n"
+            "path.write_text(str(count + 1))\n"
+        ),
+    )
+    assert (
+        tools_cmd.call_queue(
+            target=tmp_path,
+            tool_id="runner",
+            args='{"path":"stale-redeem-count"}',
+            json_output=True,
+        )
+        == 0
+    )
+    pending = json.loads(capsys.readouterr().out)["call"]
+    monkeypatch.setenv("BRIGADE_RUN_JOURNAL_AUTHORITY", "1")
+    monkeypatch.setenv("BRIGADE_LIFECYCLE_JOURNAL", "1")
+    marker = "s" * 43
+    monkeypatch.setenv(runs_cmd._APPROVAL_CORRELATION_ENV, marker)
+    run_dir = tmp_path / ".brigade" / "runs" / "tool-stale-redemption-run"
+    roster = Roster(orchestrator="chef", agents={"chef": Agent("chef", "codex", "plan")})
+
+    with runguard.run_lock(tmp_path, run_dir=run_dir):
+        aboyeur.record_run_start(
+            run_dir,
+            task="tool stale redemption",
+            cwd=tmp_path,
+            roster=roster,
+            read_only=False,
+            lock_workspace=tmp_path,
+        )
+        assert tools_cmd.call_run(target=tmp_path, call_id=pending["id"], json_output=True) == 1
+        capsys.readouterr()
+        runs_cmd._bind_approval_pause_request(
+            tmp_path,
+            correlation_marker=marker,
+            worker="coder",
+            thread_id="stale-redemption-thread",
+            turn_id="stale-redemption-turn",
+        )
+        reference = runs_cmd._approval_pause_reference_for_owned_run(tmp_path, run_dir)
+        assert reference is not None
+        aboyeur.record_approval_pause(run_dir, reference)
+
+    assert tools_cmd.call_approve(target=tmp_path, call_id=pending["id"], json_output=True) == 0
+    capsys.readouterr()
+
+    def stale_before_redeem(path, *, approval_resume, approval_token):
+        assert path == run_dir
+        assert approval_resume is True
+        (tmp_path / "tools" / "input.schema.json").write_text(
+            json.dumps(
+                {
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string"},
+                        "mode": {"type": "string"},
+                    },
+                }
+            )
+        )
+        previous = os.environ.get(runs_cmd._APPROVAL_RESUME_TOKEN_ENV)
+        os.environ[runs_cmd._APPROVAL_RESUME_TOKEN_ENV] = approval_token
+        try:
+            with redirect_stdout(StringIO()):
+                assert tools_cmd.call_run(target=tmp_path, call_id=pending["id"], json_output=True) == 1
+        finally:
+            if previous is None:
+                os.environ.pop(runs_cmd._APPROVAL_RESUME_TOKEN_ENV, None)
+            else:
+                os.environ[runs_cmd._APPROVAL_RESUME_TOKEN_ENV] = previous
+        runs_cmd._finalize_redeemed_approval(run_dir, tmp_path, reference)
+        return 0
+
+    monkeypatch.setattr(run_resume, "_resume_locked", stale_before_redeem)
+
+    assert cli.main(["runs", "resume", str(run_dir)]) == 2
+    assert not (tmp_path / "stale-redeem-count").exists()
+    stored = next(item for item in tools_cmd._read_calls(tmp_path) if item["id"] == pending["id"])
+    assert stored["status"] == "approved"
+    assert stored["approval_claim"]["state"] == "reserved"
+    event_types = [
+        event.event_type for event in run_journal.read_journal(run_dir / "events" / "lifecycle.jsonl").events
+    ]
+    assert event_types.count("approval.granted") == 1
+    assert "approval.consumed" not in event_types
+    assert "run.resumed" not in event_types
+
+
+def test_tools_redeemed_action_crash_fails_closed_without_second_execution(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    _init_git_repo(tmp_path)
+    _write_script_tool_config(
+        tmp_path,
+        script=(
+            "import sys\n"
+            "from pathlib import Path\n"
+            "path = Path(sys.argv[1])\n"
+            "count = int(path.read_text()) if path.exists() else 0\n"
+            "path.write_text(str(count + 1))\n"
+        ),
+    )
+    assert (
+        tools_cmd.call_queue(
+            target=tmp_path,
+            tool_id="runner",
+            args='{"path":"redeemed-count"}',
+            json_output=True,
+        )
+        == 0
+    )
+    pending = json.loads(capsys.readouterr().out)["call"]
+    monkeypatch.setenv("BRIGADE_RUN_JOURNAL_AUTHORITY", "1")
+    monkeypatch.setenv("BRIGADE_LIFECYCLE_JOURNAL", "1")
+    marker = "r" * 43
+    monkeypatch.setenv(runs_cmd._APPROVAL_CORRELATION_ENV, marker)
+    run_dir = tmp_path / ".brigade" / "runs" / "tool-redeemed-crash-run"
+    roster = Roster(orchestrator="chef", agents={"chef": Agent("chef", "codex", "plan")})
+
+    with runguard.run_lock(tmp_path, run_dir=run_dir):
+        aboyeur.record_run_start(
+            run_dir,
+            task="tool redeemed crash",
+            cwd=tmp_path,
+            roster=roster,
+            read_only=False,
+            lock_workspace=tmp_path,
+        )
+        assert tools_cmd.call_run(target=tmp_path, call_id=pending["id"], json_output=True) == 1
+        capsys.readouterr()
+        runs_cmd._bind_approval_pause_request(
+            tmp_path,
+            correlation_marker=marker,
+            worker="coder",
+            thread_id="redeemed-thread",
+            turn_id="redeemed-turn",
+        )
+        reference = runs_cmd._approval_pause_reference_for_owned_run(tmp_path, run_dir)
+        assert reference is not None
+        aboyeur.write_approval_resume_handoff(
+            run_dir,
+            [
+                aboyeur.WorkerResult(
+                    worker="coder",
+                    task="run approved tool",
+                    text="approval required",
+                    ok=True,
+                    thread_id="redeemed-thread",
+                    status="complete",
+                )
+            ],
+            requester_worker="coder",
+            requester_thread_id="redeemed-thread",
+        )
+        aboyeur.record_approval_pause(run_dir, reference)
+
+    assert tools_cmd.call_approve(target=tmp_path, call_id=pending["id"], json_output=True) == 0
+    capsys.readouterr()
+    provider_calls = []
+    raw_tokens = []
+
+    def redeem_then_crash(path, *, approval_resume, approval_token):
+        provider_calls.append(path)
+        raw_tokens.append(approval_token)
+        previous = os.environ.get(runs_cmd._APPROVAL_RESUME_TOKEN_ENV)
+        os.environ[runs_cmd._APPROVAL_RESUME_TOKEN_ENV] = approval_token
+        try:
+            with redirect_stdout(StringIO()):
+                assert tools_cmd.call_run(target=tmp_path, call_id=pending["id"], json_output=True) == 0
+        finally:
+            if previous is None:
+                os.environ.pop(runs_cmd._APPROVAL_RESUME_TOKEN_ENV, None)
+            else:
+                os.environ[runs_cmd._APPROVAL_RESUME_TOKEN_ENV] = previous
+        raise runs_cmd.ApprovalResumeError("injected outcome persistence crash")
+
+    monkeypatch.setattr(run_resume, "_resume_locked", redeem_then_crash)
+
+    assert cli.main(["runs", "resume", str(run_dir)]) == 2
+    assert (tmp_path / "redeemed-count").read_text() == "1"
+    assert cli.main(["runs", "resume", str(run_dir)]) == 2
+    assert (tmp_path / "redeemed-count").read_text() == "1"
+    assert provider_calls == [run_dir]
+    stored = next(item for item in tools_cmd._read_calls(tmp_path) if item["id"] == pending["id"])
+    assert stored["approval_claim"]["state"] == "redeemed"
+    assert raw_tokens[0] not in json.dumps(stored)
+    assert "outcome reconciliation is required" in capsys.readouterr().err
+
+
+def test_tools_approval_pauses_real_run_and_cli_resume_consumes_store_once(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    _init_git_repo(tmp_path)
+    _write_script_tool_config(
+        tmp_path,
+        script=(
+            "import sys\n"
+            "from pathlib import Path\n"
+            "path = Path(sys.argv[1])\n"
+            "count = int(path.read_text()) if path.exists() else 0\n"
+            "path.write_text(str(count + 1))\n"
+        ),
+    )
+    assert (
+        tools_cmd.call_queue(
+            target=tmp_path,
+            tool_id="runner",
+            args='{"path":"tool-approval-count"}',
+            json_output=True,
+        )
+        == 0
+    )
+    pending = json.loads(capsys.readouterr().out)["call"]
+    monkeypatch.setenv("BRIGADE_RUN_JOURNAL_AUTHORITY", "1")
+    monkeypatch.setenv("BRIGADE_LIFECYCLE_JOURNAL", "1")
+    marker = "t" * 43
+    monkeypatch.setenv(runs_cmd._APPROVAL_CORRELATION_ENV, marker)
+    run_dir = tmp_path / ".brigade" / "runs" / "tool-approval-run"
+    roster = Roster(
+        orchestrator="chef",
+        agents={"chef": Agent("chef", "codex", "plan")},
+    )
+
+    with runguard.run_lock(tmp_path, run_dir=run_dir):
+        aboyeur.record_run_start(
+            run_dir,
+            task="tool approval",
+            cwd=tmp_path,
+            roster=roster,
+            read_only=False,
+            lock_workspace=tmp_path,
+        )
+        assert tools_cmd.call_run(target=tmp_path, call_id=pending["id"], json_output=True) == 1
+        capsys.readouterr()
+        assert runguard.is_active_run_owner(tmp_path, run_dir)
+        runs_cmd._bind_approval_pause_request(
+            tmp_path,
+            correlation_marker=marker,
+            worker="coder",
+            thread_id="tool-approval-thread",
+            turn_id="tool-approval-turn",
+        )
+        reference = runs_cmd._approval_pause_reference_for_owned_run(tmp_path, run_dir)
+        assert reference["source"] == "tool"
+        assert reference["approval_id"] == pending["id"]
+        aboyeur.record_approval_pause(run_dir, reference)
+
+    assert runguard.run_lock_state(tmp_path, run_dir) == "absent"
+    paused = json.loads((run_dir / "run.json").read_text())
+    assert paused["status"] == "running"
+    assert paused["approval_reference"]["decision_state"] == "pending"
+    events = run_journal.read_journal(run_dir / "events" / "lifecycle.jsonl").events
+    assert [event.event_type for event in events][-4:] == [
+        "run.snapshot.checkpointed",
+        "approval.requested",
+        "run.snapshot.checkpointed",
+        "run.paused",
+    ]
+
+    assert tools_cmd.call_approve(target=tmp_path, call_id=pending["id"], json_output=True) == 0
+    capsys.readouterr()
+    continued = []
+
+    def continue_tool(path, *, approval_resume, approval_token):
+        continued.append((path, approval_resume))
+        previous = os.environ.get(runs_cmd._APPROVAL_RESUME_TOKEN_ENV)
+        os.environ[runs_cmd._APPROVAL_RESUME_TOKEN_ENV] = approval_token
+        try:
+            with redirect_stdout(StringIO()):
+                assert tools_cmd.call_run(target=tmp_path, call_id=pending["id"], json_output=True) == 0
+                assert tools_cmd.call_run(target=tmp_path, call_id=pending["id"], json_output=True) == 1
+        finally:
+            if previous is None:
+                os.environ.pop(runs_cmd._APPROVAL_RESUME_TOKEN_ENV, None)
+            else:
+                os.environ[runs_cmd._APPROVAL_RESUME_TOKEN_ENV] = previous
+        runs_cmd._finalize_redeemed_approval(run_dir, tmp_path, reference)
+        return 0
+
+    monkeypatch.setattr(run_resume, "_resume_locked", continue_tool)
+
+    assert cli.main(["runs", "resume", str(run_dir)]) == 0
+    assert continued == [(run_dir, True)]
+    assert (tmp_path / "tool-approval-count").read_text() == "1"
+    consumed = next(item for item in tools_cmd._read_calls(tmp_path) if item["id"] == pending["id"])
+    assert consumed["status"] == "completed"
+    assert consumed["approval_claim"]["state"] == "redeemed"
+    assert consumed["approval_claim"]["run_id"] == run_dir.name
+    assert consumed["run_id"] != run_dir.name
+    event_types = [
+        event.event_type for event in run_journal.read_journal(run_dir / "events" / "lifecycle.jsonl").events
+    ]
+    for fact in ("approval.granted", "approval.consumed", "run.resumed"):
+        assert event_types.count(fact) == 1
+        fact_index = event_types.index(fact)
+        assert event_types[fact_index - 1] == "run.snapshot.checkpointed"
 
 
 def test_tools_run_history_list_show_latest_and_json(tmp_path, capsys):
@@ -1411,6 +2228,133 @@ def test_tools_checkpoint_approve_reject_and_successful_resume(tmp_path, capsys)
     payload = json.loads(capsys.readouterr().out)
     assert payload["checkpoint"]["status"] == "rejected"
     assert payload["checkpoint"]["review_reason"] == "not now"
+
+
+def test_tools_checkpoint_review_preserves_update_completed_before_store_lock(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    _init_git_repo(tmp_path)
+    _, checkpoint_id, _ = _create_waiting_checkpoint(tmp_path, capsys)
+    assert (
+        tools_cmd.call_queue(
+            target=tmp_path,
+            tool_id="runner",
+            args='{"path":"concurrent"}',
+            json_output=True,
+        )
+        == 0
+    )
+    concurrent = json.loads(capsys.readouterr().out)["call"]
+    _inject_call_update_on_next_store_lock(
+        monkeypatch,
+        tmp_path,
+        concurrent["id"],
+        field="review_reason",
+        value="concurrent update",
+    )
+
+    assert (
+        tools_cmd.checkpoint_approve(
+            target=tmp_path,
+            checkpoint_id=checkpoint_id,
+            choice="continue",
+            json_output=True,
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    stored = {item["id"]: item for item in tools_cmd._read_calls(tmp_path)}
+    assert stored[concurrent["id"]]["review_reason"] == "concurrent update"
+
+
+@pytest.mark.parametrize("changed_status", ["running", "rejected"])
+def test_tools_checkpoint_approve_cas_refuses_changed_linked_call_without_mutation(
+    tmp_path,
+    capsys,
+    changed_status,
+):
+    _init_git_repo(tmp_path)
+    call, checkpoint_id, _ = _create_waiting_checkpoint(tmp_path, capsys)
+    checkpoint_path = tmp_path / ".brigade" / "tools" / "checkpoints" / f"{checkpoint_id}.json"
+    checkpoint_before = checkpoint_path.read_bytes()
+    calls = tools_cmd._read_calls(tmp_path)
+    stored = next(item for item in calls if item["id"] == call["id"])
+    stored["status"] = changed_status
+    stored["approval_fingerprint"] = tools_cmd._approval_fingerprint(stored)
+    tools_cmd._write_calls(tmp_path, calls)
+    call_before = next(item for item in tools_cmd._read_calls(tmp_path) if item["id"] == call["id"])
+
+    assert (
+        tools_cmd.checkpoint_approve(
+            target=tmp_path,
+            checkpoint_id=checkpoint_id,
+            choice="continue",
+            json_output=True,
+        )
+        == 1
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error"] == "checkpoint or linked call state changed before review"
+    assert checkpoint_path.read_bytes() == checkpoint_before
+    assert next(item for item in tools_cmd._read_calls(tmp_path) if item["id"] == call["id"]) == call_before
+
+
+def test_tools_checkpoint_approve_wins_before_stale_reject_under_shared_lock(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    _init_git_repo(tmp_path)
+    call, checkpoint_id, _ = _create_waiting_checkpoint(tmp_path, capsys)
+    original_lock = tool_calls_mod._calls_store_lock
+    winner = []
+
+    @contextmanager
+    def approve_before_reject(target):
+        if not winner:
+            monkeypatch.setattr(tool_calls_mod, "_calls_store_lock", original_lock)
+            try:
+                assert (
+                    tools_cmd.checkpoint_approve(
+                        target=tmp_path,
+                        checkpoint_id=checkpoint_id,
+                        choice="continue",
+                        json_output=True,
+                    )
+                    == 0
+                )
+                capsys.readouterr()
+                winner.append("approved")
+            finally:
+                monkeypatch.setattr(tool_calls_mod, "_calls_store_lock", approve_before_reject)
+        with original_lock(target):
+            yield
+
+    monkeypatch.setattr(tool_calls_mod, "_calls_store_lock", approve_before_reject)
+
+    assert (
+        tools_cmd.checkpoint_reject(
+            target=tmp_path,
+            checkpoint_id=checkpoint_id,
+            reason="stale rejection",
+            json_output=True,
+        )
+        == 1
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error"] == "checkpoint state changed before review"
+    checkpoint, error = tools_cmd._resolve_checkpoint(tmp_path, checkpoint_id)
+    assert error is None
+    assert checkpoint is not None
+    assert checkpoint["status"] == "approved"
+    assert checkpoint["selected_choice"] == "continue"
+    stored_call = next(item for item in tools_cmd._read_calls(tmp_path) if item["id"] == call["id"])
+    assert stored_call["status"] == "resume-pending"
+    assert stored_call["checkpoint_id"] == checkpoint_id
+    assert winner == ["approved"]
 
 
 def test_tools_checkpoint_resume_refuses_unapproved_expired_stale_blocked_and_policy_denied(tmp_path, capsys):


### PR DESCRIPTION
## Summary

- pause enrolled runs at existing Daily and Tool approval boundaries before releasing the run lock
- bind the exact requesting worker, thread, and turn through a hashed, redacted command marker
- reserve approval under the existing source store, resume one requester under a fresh run lock, and redeem once immediately before the approved action
- keep rejected decisions sticky, allow held decisions to be reviewed again, and fail closed on stale references or foreign reservations
- emit the registered approval, pause, and resume lifecycle facts with projector v5
- reconcile reservation, redemption, journal, snapshot, and AppServer crash windows without a second approval consumption or action launch

## Issue #568 acceptance criteria

- approval request and pause facts are synced before lock release with a compatibility-safe snapshot: `test_record_approval_pause_commits_events_snapshot_and_releases_lock` and `test_previous_resume_reader_refuses_new_approval_wait_before_provider`
- the exact requester is bound and resumed without persisting raw arguments, marker secrets, or reservation tokens: `test_approval_pause_marker_binds_exact_event_and_redacts_artifact` and `test_approval_handoff_selects_completed_requester_not_unrelated_workers`
- Daily and Tool reuse their existing stores and execute the approved action once: `test_daily_approval_pauses_real_run_and_cli_resume_consumes_store_once` and `test_tools_child_process_requests_owner_process_pause_and_releases_parent_lock`
- held, rejected, stale, consumed, and foreign-reservation states fail or resume according to the bounded state matrix: `test_held_marker_stays_approval_aware_and_resumes_after_store_grant`, `test_daily_rejected_pause_stays_rejected_after_store_is_approved`, and `test_tool_reservation_rotation_refuses_foreign_run`
- AppServer start and redeemed-action crash windows reconcile without duplicate provider work: `test_approval_resume_retries_after_app_server_start_failure_without_provider_duplication` and `test_tools_redeemed_action_crash_fails_closed_without_second_execution`
- source-store and checkpoint races use locked rereads and compare-and-swap transitions: `test_approval_pause_binding_rejects_request_replaced_before_source_lock`, `test_tools_resume_claim_rechecks_store_after_authorization`, and `test_tools_checkpoint_approve_wins_before_stale_reject_under_shared_lock`
- all registered approval, pause, and resume facts project deterministically while forged states and events fail before mutation: `test_approval_pause_resume_events_are_all_mapped_and_reconstruct_status`, `test_projector_version_is_five_and_replaces_stale_v4`, and `test_invalid_approval_event_request_has_zero_journal_or_checkpoint_mutation`

## Verification

- `./scripts/verify`
- result: `5419 passed, 3 skipped`, coverage `83.02%`
- Brigade receipt: `20260730-231824-work-verify-6e5d31`
- independent closure review: clean

Refs #568
