### PR TITLE
feat(runs): offline coordinator decision audit (#595)

### DIFF
--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -56,7 +56,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade route`: 1 command path(s)
 - `brigade run`: 1 command path(s)
 - `brigade runbook` (extras): 5 command path(s)
-- `brigade runs`: 10 command path(s)
+- `brigade runs`: 11 command path(s)
 - `brigade scrub`: 1 command path(s)
 - `brigade search`: 6 command path(s)
 - `brigade security`: 15 command path(s)
@@ -439,6 +439,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade runbook plan` (extras)
 - `brigade runbook resume` (extras)
 - `brigade runbook run` (extras)
+- `brigade runs audit`
 - `brigade runs events`
 - `brigade runs interrupt`
 - `brigade runs latest`

--- a/src/brigade/cli/runs.py
+++ b/src/brigade/cli/runs.py
@@ -201,7 +201,11 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_runs_resume.add_argument("run_dir", type=Path, help="Path to a Brigade run artifact directory.")
     p_runs_audit = runs_sub.add_parser(
         "audit",
-        help="Offline coordinator decision audit from recorded lifecycle evidence.",
+        help=(
+            "Offline coordinator decision audit from recorded lifecycle evidence. "
+            "Exit 0 on match, 1 on divergence or corrupt journal evidence, "
+            "2 when the run is not auditable or the run id cannot be resolved."
+        ),
     )
     p_runs_audit.add_argument("run", help="Run directory path, run id under --runs-dir, or 'latest'.")
     p_runs_audit.add_argument(

--- a/src/brigade/cli/runs.py
+++ b/src/brigade/cli/runs.py
@@ -199,6 +199,24 @@ def register(sub: argparse._SubParsersAction) -> None:
         "resume", help="Re-attach interrupted app-server workers from a run and re-synthesize."
     )
     p_runs_resume.add_argument("run_dir", type=Path, help="Path to a Brigade run artifact directory.")
+    p_runs_audit = runs_sub.add_parser(
+        "audit",
+        help="Offline coordinator decision audit from recorded lifecycle evidence.",
+    )
+    p_runs_audit.add_argument("run", help="Run directory path, run id under --runs-dir, or 'latest'.")
+    p_runs_audit.add_argument(
+        "--cwd",
+        type=Path,
+        default=Path("."),
+        help="Workspace whose default .brigade/runs directory should be used for run ids.",
+    )
+    p_runs_audit.add_argument(
+        "--runs-dir",
+        type=Path,
+        default=None,
+        help="Explicit runs directory for run ids. Defaults to .brigade/runs under --cwd.",
+    )
+    p_runs_audit.add_argument("--json", action="store_true", help="Emit the audit receipt as JSON.")
     p_runs.set_defaults(func=dispatch)
 
 
@@ -262,6 +280,13 @@ def dispatch(args) -> int:
         )
     if args.runs_command == "resume":
         return runs_cmd.resume(args.run_dir)
+    if args.runs_command == "audit":
+        return runs_cmd.audit(
+            args.run,
+            cwd=args.cwd,
+            runs_dir=args.runs_dir,
+            json_output=args.json,
+        )
     args._brigade_parser.error(f"unknown runs command: {args.runs_command}")
     return 2
 

--- a/src/brigade/run_audit.py
+++ b/src/brigade/run_audit.py
@@ -110,6 +110,10 @@ TRANSPORT_COVERAGE: dict[str, dict[str, Any]] = {
     },
 }
 
+# Coordinator-owned lifecycle events audited in the first slice. ``control.*``
+# events from #641 (control.requested / observed / failed) are intentionally
+# outside this set: they record transport observations, not coordinator routing
+# or approval decisions replayed here.
 _COORDINATOR_EVENT_TYPES = frozenset(
     {
         "run.dispatch.requested",
@@ -255,6 +259,8 @@ def _read_json_object(path: Path) -> dict[str, Any] | None:
         raise AuditError(_bound(f"cannot stat evidence: {path.name}")) from exc
     if stat.S_ISLNK(info.st_mode):
         raise AuditError(_bound(f"refusing symlinked evidence: {path.name}"))
+    if not stat.S_ISREG(info.st_mode):
+        raise AuditError(_bound(f"evidence is not a regular file: {path.name}"))
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
@@ -718,21 +724,20 @@ def _routing_drift(
             requested.append(seat)
     if not requested:
         return None
-    if requested != planned_seats[: len(requested)] and set(requested) != set(planned_seats):
-        # Allow subset prefix (partial dispatch) when order matches.
-        if requested != planned_seats[: len(requested)]:
-            return Divergence(
-                divergence_class=CLASS_POLICY_OR_ROUTING_DRIFT,
-                sequence=next(
-                    (e.sequence for e in events if e.event_type == "run.dispatch.requested"),
-                    None,
-                ),
-                event_type="run.dispatch.requested",
-                expected={"seats": planned_seats},
-                observed={"seats": requested},
-                detail=_bound("dispatch seat routing drift versus plan.json assignments"),
-            )
-    return None
+    prefix = planned_seats[: len(requested)]
+    if requested == prefix:
+        return None
+    return Divergence(
+        divergence_class=CLASS_POLICY_OR_ROUTING_DRIFT,
+        sequence=next(
+            (e.sequence for e in events if e.event_type == "run.dispatch.requested"),
+            None,
+        ),
+        event_type="run.dispatch.requested",
+        expected={"seats": planned_seats},
+        observed={"seats": requested},
+        detail=_bound("dispatch seat routing drift versus plan.json assignments"),
+    )
 
 
 def audit_run(
@@ -880,7 +885,7 @@ def audit_run(
             CLASS_MISSING_OR_CORRUPT_FIXTURE,
             report.chain_errors[0],
             artifact=str(JOURNAL_REL),
-            sequence=1,
+            sequence=_chain_error_sequence(report),
             transport=_transport_coverage(run_meta.get("codex_transport")),
         )
     if not report.events:
@@ -1043,14 +1048,28 @@ def audit_run(
     )
 
 
+def _chain_error_sequence(report: run_journal.JournalReport) -> int | None:
+    """Best-effort sequence for the first journal chain error."""
+    if report.events:
+        return report.events[-1].sequence + 1
+    return None
+
+
 def _safe_digests(run_dir: Path, *, journal_present: bool) -> dict[str, str]:
+    """Return evidence digests, skipping artifacts that cannot be hashed safely."""
     digests: dict[str, str] = {}
     for name in (RUN_JSON_NAME, PLAN_JSON_NAME, ROSTER_JSON_NAME):
-        digest = _digest_file(run_dir / name)
+        try:
+            digest = _digest_file(run_dir / name)
+        except AuditError:
+            continue
         if digest is not None:
             digests[name] = digest
     if journal_present:
-        digest = _digest_file(run_dir / JOURNAL_REL)
+        try:
+            digest = _digest_file(run_dir / JOURNAL_REL)
+        except AuditError:
+            digest = None
         if digest is not None:
             digests[str(JOURNAL_REL)] = digest
     return digests

--- a/src/brigade/run_audit.py
+++ b/src/brigade/run_audit.py
@@ -1,0 +1,1104 @@
+"""Offline coordinator decision audit from recorded lifecycle evidence (#595).
+
+Read-only consumer of the per-run lifecycle journal and archived run artifacts.
+Builds on ``run_journal.read_journal_bounded``, ``run_events.validate_event``,
+and ``run_projector.project_run_snapshot``.
+
+Hard safety boundary:
+- Never writes to any run directory (journal, run.json, quarantine, or sidecars).
+- Never constructs provider adapters or subprocess runners.
+- Never appends lifecycle events or invents live fallback evidence.
+- Reports contain safe summaries, fingerprints, and classified references only.
+
+Standard library only. Brigade is zero-runtime-dependency.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from brigade import __version__ as BRIGADE_VERSION
+from brigade import run_events, run_journal, run_projector
+from brigade.run_events import CanonicalizationError, canonical_bytes
+
+AUDIT_SCHEMA = "brigade.run_audit.v1"
+AUDIT_SCHEMA_VERSION = 1
+AUDIT_NORMALIZATION_VERSION = 1
+WORKER_PROMPT_TEMPLATE_REVISION = "brigade.worker_prompt.v1"
+
+JOURNAL_REL = Path("events") / "lifecycle.jsonl"
+RUN_JSON_NAME = "run.json"
+PLAN_JSON_NAME = "plan.json"
+ROSTER_JSON_NAME = "roster.json"
+
+RESULT_MATCH = "match"
+RESULT_DIVERGE = "diverge"
+RESULT_NOT_AUDITABLE = "not_auditable"
+RESULT_ERROR = "error"
+
+# Initial divergence classes from issue #595.
+CLASS_LIFECYCLE_PROJECTION_DRIFT = "lifecycle_projection_drift"
+CLASS_PROMPT_TEMPLATE_DRIFT = "prompt_template_drift"
+CLASS_POLICY_OR_ROUTING_DRIFT = "policy_or_routing_drift"
+CLASS_APPROVAL_STATE_DRIFT = "approval_state_drift"
+CLASS_ADAPTER_IDENTITY_DRIFT = "adapter_identity_drift"
+CLASS_MISSING_OR_CORRUPT_FIXTURE = "missing_or_corrupt_fixture"
+CLASS_EXTRA_OR_MISSING_OPERATION = "extra_or_missing_coordinator_operation"
+CLASS_ATTEMPTED_LIVE_SIDE_EFFECT = "attempted_live_side_effect"
+CLASS_UNSUPPORTED_SCHEMA = "unsupported_schema_or_projector_version"
+
+DIVERGENCE_CLASSES = frozenset(
+    {
+        CLASS_LIFECYCLE_PROJECTION_DRIFT,
+        CLASS_PROMPT_TEMPLATE_DRIFT,
+        CLASS_POLICY_OR_ROUTING_DRIFT,
+        CLASS_APPROVAL_STATE_DRIFT,
+        CLASS_ADAPTER_IDENTITY_DRIFT,
+        CLASS_MISSING_OR_CORRUPT_FIXTURE,
+        CLASS_EXTRA_OR_MISSING_OPERATION,
+        CLASS_ATTEMPTED_LIVE_SIDE_EFFECT,
+        CLASS_UNSUPPORTED_SCHEMA,
+    }
+)
+
+# Byte comparison excludes fields that are expected to vary. Versioned with
+# AUDIT_NORMALIZATION_VERSION; covered by golden fixtures.
+NORMALIZATION_EXCLUSIONS: frozenset[str] = frozenset(
+    {
+        "recorded_at",
+        "duration_seconds",
+        "started_at",
+        "status_started_at",
+        "finished_at",
+        "resumed_at",
+        "decided_at",
+        "cwd",
+        "lock_workspace",
+        "artifacts",
+        "handoff",
+        "control_socket",
+        "recovery_preserved_artifact",
+        "path",  # checkpoint absolute/relative path noise
+    }
+)
+
+# First-slice audit coverage by transport. Structured app-server response
+# fixture comparison is a follow-up (#592); unsupported transports must state
+# coverage instead of claiming full replay.
+TRANSPORT_COVERAGE: dict[str, dict[str, Any]] = {
+    "app-server": {
+        "coordinator_decisions": True,
+        "lifecycle_projection": True,
+        "composed_prompt_fingerprints": True,
+        "provider_response_fixtures": False,
+        "worker_event_streams": False,
+        "note": "coordinator-only slice; provider response fixtures deferred",
+    },
+    "exec": {
+        "coordinator_decisions": True,
+        "lifecycle_projection": True,
+        "composed_prompt_fingerprints": True,
+        "provider_response_fixtures": False,
+        "worker_event_streams": False,
+        "note": "exec transport has no recorded worker stream; coordinator-only coverage",
+    },
+}
+
+_COORDINATOR_EVENT_TYPES = frozenset(
+    {
+        "run.dispatch.requested",
+        "run.dispatch.observed",
+        "run.dispatch.completed",
+        "run.dispatch.failed",
+        "run.paused",
+        "run.resumed",
+        "approval.requested",
+        "approval.granted",
+        "approval.rejected",
+        "approval.held",
+        "approval.consumed",
+    }
+)
+
+_APPROVAL_EVENT_TYPES = frozenset(
+    {
+        "approval.requested",
+        "approval.granted",
+        "approval.rejected",
+        "approval.held",
+        "approval.consumed",
+    }
+)
+
+_DISPATCH_EVENT_TYPES = frozenset(
+    {
+        "run.dispatch.requested",
+        "run.dispatch.observed",
+        "run.dispatch.completed",
+        "run.dispatch.failed",
+    }
+)
+
+
+class AuditError(RuntimeError):
+    """Bounded audit failure. Carries a ``diagnostic`` safe for reports."""
+
+    def __init__(self, diagnostic: str) -> None:
+        super().__init__(diagnostic)
+        self.diagnostic = diagnostic
+
+
+class AttemptedSideEffectError(AuditError):
+    """Audit code attempted a forbidden live side effect."""
+
+
+@dataclass(frozen=True)
+class Divergence:
+    """First (or only) coordinator decision divergence."""
+
+    divergence_class: str
+    sequence: int | None
+    event_type: str | None
+    expected: Any
+    observed: Any
+    detail: str
+
+
+@dataclass
+class AuditReport:
+    """Bounded offline audit result. Safe for stdout / receipt persistence."""
+
+    result: str
+    source_run_id: str
+    projector_version: int
+    code_revision: str
+    normalization_version: int
+    audit_schema_version: int
+    evidence_digests: dict[str, str] = field(default_factory=dict)
+    transport_coverage: dict[str, Any] = field(default_factory=dict)
+    normalized_events: list[dict[str, Any]] = field(default_factory=list)
+    first_divergence: Divergence | None = None
+    not_auditable_reason: str | None = None
+    graphtrail_note: str = "GraphTrail deltas are timing-dependent and fail-open; absence is not coordinator divergence"
+
+    def to_receipt(self) -> dict[str, Any]:
+        """Receipt fields required by issue #595 acceptance criteria."""
+        receipt: dict[str, Any] = {
+            "schema": AUDIT_SCHEMA,
+            "schema_version": AUDIT_SCHEMA_VERSION,
+            "source_run": self.source_run_id,
+            "projector_version": self.projector_version,
+            "code_revision": self.code_revision,
+            "normalization_version": self.normalization_version,
+            "result": self.result,
+            "first_divergence": None,
+            "evidence_digests": dict(self.evidence_digests),
+            "transport_coverage": dict(self.transport_coverage),
+            "graphtrail_note": self.graphtrail_note,
+        }
+        if self.first_divergence is not None:
+            receipt["first_divergence"] = {
+                "class": self.first_divergence.divergence_class,
+                "sequence": self.first_divergence.sequence,
+                "event_type": self.first_divergence.event_type,
+                "expected": self.first_divergence.expected,
+                "observed": self.first_divergence.observed,
+                "detail": self.first_divergence.detail,
+            }
+        if self.not_auditable_reason is not None:
+            receipt["not_auditable_reason"] = self.not_auditable_reason
+        return receipt
+
+    def normalized_events_bytes(self) -> bytes:
+        """Canonical bytes of the normalized coordinator event sequence."""
+        return canonical_bytes(_canonicalize_for_fingerprint(self.normalized_events)) + b"\n"
+
+
+def _bound(msg: str) -> str:
+    limit = run_events.MAX_DIAGNOSTIC_LEN
+    if len(msg) <= limit:
+        return msg
+    return msg[: limit - 1] + "…"
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _digest_file(path: Path) -> str | None:
+    """Return SHA-256 of a regular file, or None when absent. Never follows a symlink final component."""
+    if not path.exists():
+        return None
+    try:
+        info = os.lstat(path)
+    except OSError as exc:
+        raise AuditError(_bound(f"cannot stat evidence: {path.name}")) from exc
+    if stat.S_ISLNK(info.st_mode):
+        raise AuditError(_bound(f"refusing symlinked evidence: {path.name}"))
+    if not stat.S_ISREG(info.st_mode):
+        raise AuditError(_bound(f"evidence is not a regular file: {path.name}"))
+    return _sha256_hex(path.read_bytes())
+
+
+def _read_json_object(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        info = os.lstat(path)
+    except OSError as exc:
+        raise AuditError(_bound(f"cannot stat evidence: {path.name}")) from exc
+    if stat.S_ISLNK(info.st_mode):
+        raise AuditError(_bound(f"refusing symlinked evidence: {path.name}"))
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise AuditError(_bound(f"corrupt evidence: {path.name}")) from exc
+    if not isinstance(payload, dict):
+        raise AuditError(_bound(f"evidence is not a JSON object: {path.name}"))
+    return payload
+
+
+def _strip_exclusions(value: Any) -> Any:
+    """Recursively drop normalization-excluded keys from mappings."""
+    if isinstance(value, Mapping):
+        return {key: _strip_exclusions(child) for key, child in value.items() if key not in NORMALIZATION_EXCLUSIONS}
+    if isinstance(value, list):
+        return [_strip_exclusions(item) for item in value]
+    return value
+
+
+def _canonicalize_for_fingerprint(value: Any) -> Any:
+    """Convert values into the strict canonical form used by ``canonical_bytes``.
+
+    Lifecycle envelopes forbid booleans; archived run.json / plan / roster
+    payloads still carry them. Fingerprints map ``True``/``False`` to ``1``/``0``
+    so audit digests stay deterministic without widening the journal contract.
+    """
+    if isinstance(value, bool):
+        return 1 if value else 0
+    if isinstance(value, Mapping):
+        return {str(key): _canonicalize_for_fingerprint(child) for key, child in value.items()}
+    if isinstance(value, list):
+        return [_canonicalize_for_fingerprint(item) for item in value]
+    if isinstance(value, tuple):
+        return [_canonicalize_for_fingerprint(item) for item in value]
+    return value
+
+
+def _fingerprint(obj: Any) -> str:
+    try:
+        return _sha256_hex(canonical_bytes(_canonicalize_for_fingerprint(_strip_exclusions(obj))))
+    except CanonicalizationError as exc:
+        raise AuditError(_bound(f"value cannot be fingerprinted: {exc}")) from exc
+
+
+def composed_prompt_fingerprint(
+    *,
+    worker: str,
+    role: str,
+    task: str,
+    read_only: bool,
+    skill_policy: Any,
+    template_revision: str = WORKER_PROMPT_TEMPLATE_REVISION,
+) -> str:
+    """Fingerprint a coordinator-composed worker prompt without retaining prompt text.
+
+    The material is the template revision plus the coordinator-owned inputs that
+    enter ``aboyeur._worker_prompt``. Changing ``template_revision`` (or any
+    input) changes the digest; the raw prompt never appears in audit output.
+    """
+    material = {
+        "kind": "composed_worker_prompt",
+        "template_revision": template_revision,
+        "worker": worker,
+        "role": role,
+        "task": task,
+        "read_only": 1 if read_only else 0,
+        "skill_policy": _strip_exclusions(skill_policy),
+    }
+    return _fingerprint(material)
+
+
+def _transport_coverage(transport: Any) -> dict[str, Any]:
+    if not isinstance(transport, str) or not transport:
+        return {
+            "transport": None,
+            "supported": False,
+            "coverage": {
+                "coordinator_decisions": False,
+                "lifecycle_projection": True,
+                "composed_prompt_fingerprints": False,
+                "provider_response_fixtures": False,
+                "worker_event_streams": False,
+                "note": "transport identity missing; lifecycle projection only",
+            },
+        }
+    known = TRANSPORT_COVERAGE.get(transport)
+    if known is None:
+        return {
+            "transport": transport,
+            "supported": False,
+            "coverage": {
+                "coordinator_decisions": True,
+                "lifecycle_projection": True,
+                "composed_prompt_fingerprints": False,
+                "provider_response_fixtures": False,
+                "worker_event_streams": False,
+                "note": f"unsupported transport {transport!r}; coordinator routing/approval only",
+            },
+        }
+    return {"transport": transport, "supported": True, "coverage": dict(known)}
+
+
+def _base_snapshot_for_projection(run_meta: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a projector-safe base snapshot (derived fields omitted)."""
+    base: dict[str, Any] = {}
+    for key, value in run_meta.items():
+        if key in run_projector.DERIVED_FIELDS:
+            continue
+        if key not in run_projector.OWNED_FIELDS:
+            # Unknown keys fail closed at project time; surface as unsupported.
+            continue
+        base[key] = value
+    if "status" not in base:
+        base["status"] = "started"
+    return base
+
+
+def _unknown_run_fields(run_meta: Mapping[str, Any]) -> list[str]:
+    return sorted(set(run_meta.keys()) - run_projector.OWNED_FIELDS)
+
+
+def _role_for_worker(roster: Mapping[str, Any] | None, worker: str) -> str | None:
+    if roster is None:
+        return None
+    agents = roster.get("agents")
+    if not isinstance(agents, Mapping):
+        return None
+    agent = agents.get(worker)
+    if not isinstance(agent, Mapping):
+        return None
+    role = agent.get("role")
+    return role if isinstance(role, str) and role else None
+
+
+def _plan_assignments(plan: Mapping[str, Any] | None) -> list[dict[str, str]]:
+    if plan is None:
+        return []
+    raw = plan.get("assignments")
+    if not isinstance(raw, list):
+        return []
+    out: list[dict[str, str]] = []
+    for item in raw:
+        if not isinstance(item, Mapping):
+            continue
+        worker = item.get("worker")
+        task = item.get("task")
+        if isinstance(worker, str) and worker and isinstance(task, str):
+            out.append({"worker": worker, "task": task})
+    return out
+
+
+def _normalize_lifecycle_event(event: run_journal.RunEvent) -> dict[str, Any] | None:
+    """Normalize one coordinator-owned lifecycle event, or None if not coordinator-owned."""
+    if event.event_type not in _COORDINATOR_EVENT_TYPES:
+        return None
+    payload = _strip_exclusions(event.payload)
+    kind = "approval" if event.event_type in _APPROVAL_EVENT_TYPES else "dispatch"
+    if event.event_type in {"run.paused", "run.resumed"}:
+        kind = "approval_lifecycle"
+    record = {
+        "kind": kind,
+        "sequence": event.sequence,
+        "event_type": event.event_type,
+        "payload": payload,
+        "request_digest": event.request_digest,
+        "event_digest": event.event_digest,
+    }
+    return record
+
+
+def _build_normalized_events(
+    *,
+    events: Sequence[run_journal.RunEvent],
+    run_meta: Mapping[str, Any],
+    plan: Mapping[str, Any] | None,
+    roster: Mapping[str, Any] | None,
+    projection: run_projector.RunProjection,
+    template_revision: str,
+) -> list[dict[str, Any]]:
+    """Build the ordered normalized coordinator decision event sequence."""
+    normalized: list[dict[str, Any]] = []
+
+    route_material = {
+        "kind": "route_policy",
+        "route": _strip_exclusions(run_meta.get("route")),
+        "skill_route_policy": _strip_exclusions(run_meta.get("skill_route_policy")),
+        "worker": run_meta.get("worker"),
+        "orchestrator": run_meta.get("orchestrator"),
+        "scheduler": _strip_exclusions(run_meta.get("scheduler")),
+    }
+    normalized.append(
+        {
+            "kind": "route_policy",
+            "sequence": 0,
+            "event_type": None,
+            "fingerprint": _fingerprint(route_material),
+            "values": route_material,
+        }
+    )
+
+    adapter_material = {
+        "kind": "adapter_identity",
+        "codex_transport": run_meta.get("codex_transport"),
+        "control_transport": _strip_exclusions(run_meta.get("control_transport")),
+    }
+    normalized.append(
+        {
+            "kind": "adapter_identity",
+            "sequence": 0,
+            "event_type": None,
+            "fingerprint": _fingerprint(adapter_material),
+            "values": adapter_material,
+        }
+    )
+
+    read_only = bool(run_meta.get("read_only"))
+    skill_policy = run_meta.get("skill_route_policy")
+    for index, assignment in enumerate(_plan_assignments(plan), start=1):
+        worker = assignment["worker"]
+        role = _role_for_worker(roster, worker)
+        if role is None:
+            # Missing role evidence: still emit a decision marker so absence is visible.
+            normalized.append(
+                {
+                    "kind": "composed_prompt",
+                    "sequence": index,
+                    "event_type": None,
+                    "fingerprint": None,
+                    "values": {
+                        "worker": worker,
+                        "role_present": 0,
+                        "template_revision": template_revision,
+                    },
+                    "evidence": "missing_roster_role",
+                }
+            )
+            continue
+        digest = composed_prompt_fingerprint(
+            worker=worker,
+            role=role,
+            task=assignment["task"],
+            read_only=read_only,
+            skill_policy=skill_policy,
+            template_revision=template_revision,
+        )
+        normalized.append(
+            {
+                "kind": "composed_prompt",
+                "sequence": index,
+                "event_type": None,
+                "fingerprint": digest,
+                "values": {
+                    "worker": worker,
+                    "role_present": 1,
+                    "template_revision": template_revision,
+                    "task_fingerprint": _fingerprint(assignment["task"]),
+                    "read_only": 1 if read_only else 0,
+                    "skill_policy_fingerprint": _fingerprint(skill_policy) if skill_policy is not None else None,
+                },
+            }
+        )
+
+    for event in events:
+        record = _normalize_lifecycle_event(event)
+        if record is None:
+            continue
+        record["fingerprint"] = _fingerprint(
+            {
+                "event_type": record["event_type"],
+                "payload": record["payload"],
+                "request_digest": record["request_digest"],
+            }
+        )
+        # Drop raw digests of private-adjacent payloads from the public values
+        # surface; keep fingerprints + allowlisted payload keys only.
+        public = {
+            "kind": record["kind"],
+            "sequence": record["sequence"],
+            "event_type": record["event_type"],
+            "fingerprint": record["fingerprint"],
+            "payload": record["payload"],
+        }
+        normalized.append(public)
+
+    projection_material = {
+        "kind": "lifecycle_projection",
+        "status": projection.status,
+        "projector_version": projection.snapshot.get("projector_version"),
+        "journal_present": 1 if projection.journal_present else 0,
+        "journal_last_sequence": projection.last_sequence,
+        "journal_last_event_digest": projection.last_event_digest,
+    }
+    normalized.append(
+        {
+            "kind": "lifecycle_projection",
+            "sequence": projection.last_sequence,
+            "event_type": None,
+            "fingerprint": _fingerprint(projection_material),
+            "values": projection_material,
+        }
+    )
+    return normalized
+
+
+def _compare_normalized(
+    expected: Sequence[Mapping[str, Any]],
+    observed: Sequence[Mapping[str, Any]],
+) -> Divergence | None:
+    """Return the first divergence between expected and observed normalized events."""
+    exp_list = [dict(item) for item in expected]
+    obs_list = [dict(item) for item in observed]
+    limit = max(len(exp_list), len(obs_list))
+    for index in range(limit):
+        if index >= len(exp_list):
+            item = obs_list[index]
+            return Divergence(
+                divergence_class=CLASS_EXTRA_OR_MISSING_OPERATION,
+                sequence=item.get("sequence") if isinstance(item.get("sequence"), int) else None,
+                event_type=item.get("event_type") if isinstance(item.get("event_type"), str) else None,
+                expected=None,
+                observed={"kind": item.get("kind"), "fingerprint": item.get("fingerprint")},
+                detail=_bound(f"extra coordinator operation at normalized index {index}"),
+            )
+        if index >= len(obs_list):
+            item = exp_list[index]
+            return Divergence(
+                divergence_class=CLASS_EXTRA_OR_MISSING_OPERATION,
+                sequence=item.get("sequence") if isinstance(item.get("sequence"), int) else None,
+                event_type=item.get("event_type") if isinstance(item.get("event_type"), str) else None,
+                expected={"kind": item.get("kind"), "fingerprint": item.get("fingerprint")},
+                observed=None,
+                detail=_bound(f"missing coordinator operation at normalized index {index}"),
+            )
+        exp = exp_list[index]
+        obs = obs_list[index]
+        if exp == obs:
+            continue
+        divergence_class = _classify_pair_drift(exp, obs)
+        return Divergence(
+            divergence_class=divergence_class,
+            sequence=obs.get("sequence") if isinstance(obs.get("sequence"), int) else None,
+            event_type=obs.get("event_type") if isinstance(obs.get("event_type"), str) else None,
+            expected={"kind": exp.get("kind"), "fingerprint": exp.get("fingerprint"), "values": exp.get("values")},
+            observed={"kind": obs.get("kind"), "fingerprint": obs.get("fingerprint"), "values": obs.get("values")},
+            detail=_bound(f"coordinator decision drift at normalized index {index} kind={obs.get('kind')!r}"),
+        )
+    return None
+
+
+def _classify_pair_drift(expected: Mapping[str, Any], observed: Mapping[str, Any]) -> str:
+    kind = observed.get("kind") or expected.get("kind")
+    if kind == "composed_prompt":
+        return CLASS_PROMPT_TEMPLATE_DRIFT
+    if kind == "route_policy" or kind == "dispatch":
+        return CLASS_POLICY_OR_ROUTING_DRIFT
+    if kind in {"approval", "approval_lifecycle"}:
+        return CLASS_APPROVAL_STATE_DRIFT
+    if kind == "adapter_identity":
+        return CLASS_ADAPTER_IDENTITY_DRIFT
+    if kind == "lifecycle_projection":
+        return CLASS_LIFECYCLE_PROJECTION_DRIFT
+    return CLASS_POLICY_OR_ROUTING_DRIFT
+
+
+def _projection_drift(
+    run_meta: Mapping[str, Any],
+    projection: run_projector.RunProjection,
+) -> Divergence | None:
+    """Compare projector-derived fields against the archived run.json values."""
+    checks = (
+        ("status", projection.status, run_meta.get("status")),
+        ("projector_version", run_projector.PROJECTOR_VERSION, run_meta.get("projector_version")),
+        ("journal_present", True, run_meta.get("journal_present")),
+        ("journal_last_sequence", projection.last_sequence, run_meta.get("journal_last_sequence")),
+        (
+            "journal_last_event_digest",
+            projection.last_event_digest,
+            run_meta.get("journal_last_event_digest"),
+        ),
+    )
+    # Legacy run.json may omit journal_* fields written only after authority
+    # graduation. Absence of those fields is not projection drift when the
+    # status itself matches the projected status; presence with a mismatch is.
+    for name, expected, observed in checks:
+        if name in {"projector_version", "journal_present", "journal_last_sequence", "journal_last_event_digest"}:
+            if name not in run_meta:
+                continue
+        if expected != observed:
+            return Divergence(
+                divergence_class=CLASS_LIFECYCLE_PROJECTION_DRIFT,
+                sequence=projection.last_sequence or None,
+                event_type=None,
+                expected={name: expected},
+                observed={name: observed},
+                detail=_bound(f"lifecycle projection drift on field {name}"),
+            )
+    return None
+
+
+def _approval_state_drift(
+    events: Sequence[run_journal.RunEvent],
+    run_meta: Mapping[str, Any],
+) -> Divergence | None:
+    """Compare the last approval decision in the journal to run.json approval_reference."""
+    reference = run_meta.get("approval_reference")
+    last_approval: run_journal.RunEvent | None = None
+    for event in events:
+        if event.event_type in _APPROVAL_EVENT_TYPES:
+            last_approval = event
+    if last_approval is None:
+        return None
+    if not isinstance(reference, Mapping):
+        return Divergence(
+            divergence_class=CLASS_APPROVAL_STATE_DRIFT,
+            sequence=last_approval.sequence,
+            event_type=last_approval.event_type,
+            expected={"approval_reference": "present"},
+            observed={"approval_reference": None},
+            detail=_bound("approval events present but run.json approval_reference missing"),
+        )
+    expected_id = last_approval.payload.get("approval_id")
+    observed_id = reference.get("approval_id")
+    if expected_id != observed_id:
+        return Divergence(
+            divergence_class=CLASS_APPROVAL_STATE_DRIFT,
+            sequence=last_approval.sequence,
+            event_type=last_approval.event_type,
+            expected={"approval_id": expected_id},
+            observed={"approval_id": observed_id},
+            detail=_bound("approval_id drift between journal and run.json"),
+        )
+    # decision_state on granted/rejected/held events is authoritative when present.
+    decision = last_approval.payload.get("decision_state")
+    observed_decision = reference.get("decision_state")
+    if isinstance(decision, str) and observed_decision is not None and decision != observed_decision:
+        return Divergence(
+            divergence_class=CLASS_APPROVAL_STATE_DRIFT,
+            sequence=last_approval.sequence,
+            event_type=last_approval.event_type,
+            expected={"decision_state": decision},
+            observed={"decision_state": observed_decision},
+            detail=_bound("approval decision_state drift between journal and run.json"),
+        )
+    return None
+
+
+def _routing_drift(
+    events: Sequence[run_journal.RunEvent],
+    plan: Mapping[str, Any] | None,
+) -> Divergence | None:
+    """Compare plan assignments to recorded dispatch.requested seats."""
+    assignments = _plan_assignments(plan)
+    if not assignments:
+        return None
+    planned_seats = [item["worker"] for item in assignments]
+    requested: list[str] = []
+    for event in events:
+        if event.event_type != "run.dispatch.requested":
+            continue
+        seat = event.payload.get("seat")
+        if isinstance(seat, str) and seat:
+            requested.append(seat)
+    if not requested:
+        return None
+    if requested != planned_seats[: len(requested)] and set(requested) != set(planned_seats):
+        # Allow subset prefix (partial dispatch) when order matches.
+        if requested != planned_seats[: len(requested)]:
+            return Divergence(
+                divergence_class=CLASS_POLICY_OR_ROUTING_DRIFT,
+                sequence=next(
+                    (e.sequence for e in events if e.event_type == "run.dispatch.requested"),
+                    None,
+                ),
+                event_type="run.dispatch.requested",
+                expected={"seats": planned_seats},
+                observed={"seats": requested},
+                detail=_bound("dispatch seat routing drift versus plan.json assignments"),
+            )
+    return None
+
+
+def audit_run(
+    run_dir: Path,
+    *,
+    expected_normalized_events: Sequence[Mapping[str, Any]] | None = None,
+    code_revision: str | None = None,
+    template_revision: str = WORKER_PROMPT_TEMPLATE_REVISION,
+    supported_projector_version: int | None = None,
+) -> AuditReport:
+    """Audit coordinator-owned decisions for one archived run.
+
+    Pure with respect to the run directory: reads only. ``expected_normalized_events``
+    enables golden / regression comparison; when omitted, the audit checks
+    internal consistency (projection, approval, routing) against archived
+    artifacts and returns the normalized event sequence for byte-stable replay.
+    """
+    run_dir = Path(run_dir)
+    revision = code_revision if code_revision is not None else BRIGADE_VERSION
+    projector_floor = (
+        supported_projector_version if supported_projector_version is not None else run_projector.PROJECTOR_VERSION
+    )
+
+    if not run_dir.is_dir():
+        return AuditReport(
+            result=RESULT_NOT_AUDITABLE,
+            source_run_id=run_dir.name,
+            projector_version=run_projector.PROJECTOR_VERSION,
+            code_revision=revision,
+            normalization_version=AUDIT_NORMALIZATION_VERSION,
+            audit_schema_version=AUDIT_SCHEMA_VERSION,
+            not_auditable_reason=_bound(f"run directory not found: {run_dir.name}"),
+            first_divergence=Divergence(
+                divergence_class=CLASS_MISSING_OR_CORRUPT_FIXTURE,
+                sequence=None,
+                event_type=None,
+                expected={"run_dir": "directory"},
+                observed=None,
+                detail=_bound(f"run directory not found: {run_dir.name}"),
+            ),
+        )
+
+    source_run_id = run_dir.name
+    journal_path = run_dir / JOURNAL_REL
+    run_json_path = run_dir / RUN_JSON_NAME
+
+    try:
+        run_meta = _read_json_object(run_json_path)
+    except AuditError as exc:
+        return _error_report(
+            source_run_id,
+            revision,
+            CLASS_MISSING_OR_CORRUPT_FIXTURE,
+            exc.diagnostic,
+            artifact=RUN_JSON_NAME,
+        )
+
+    if run_meta is None:
+        return AuditReport(
+            result=RESULT_NOT_AUDITABLE,
+            source_run_id=source_run_id,
+            projector_version=run_projector.PROJECTOR_VERSION,
+            code_revision=revision,
+            normalization_version=AUDIT_NORMALIZATION_VERSION,
+            audit_schema_version=AUDIT_SCHEMA_VERSION,
+            not_auditable_reason=_bound("legacy run missing run.json"),
+            first_divergence=Divergence(
+                divergence_class=CLASS_MISSING_OR_CORRUPT_FIXTURE,
+                sequence=None,
+                event_type=None,
+                expected={"artifact": RUN_JSON_NAME},
+                observed=None,
+                detail=_bound(f"missing evidence artifact: {RUN_JSON_NAME}"),
+            ),
+        )
+
+    schema = run_meta.get("schema")
+    schema_version = run_meta.get("schema_version")
+    if schema != "brigade.run.v1" or schema_version != 1:
+        return AuditReport(
+            result=RESULT_NOT_AUDITABLE,
+            source_run_id=source_run_id,
+            projector_version=run_projector.PROJECTOR_VERSION,
+            code_revision=revision,
+            normalization_version=AUDIT_NORMALIZATION_VERSION,
+            audit_schema_version=AUDIT_SCHEMA_VERSION,
+            not_auditable_reason=_bound(f"unsupported run schema {schema!r} version {schema_version!r}"),
+            first_divergence=Divergence(
+                divergence_class=CLASS_UNSUPPORTED_SCHEMA,
+                sequence=None,
+                event_type=None,
+                expected={"schema": "brigade.run.v1", "schema_version": 1},
+                observed={"schema": schema, "schema_version": schema_version},
+                detail=_bound("unsupported run.json schema or version"),
+            ),
+            transport_coverage=_transport_coverage(run_meta.get("codex_transport")),
+        )
+
+    if not journal_path.exists():
+        return AuditReport(
+            result=RESULT_NOT_AUDITABLE,
+            source_run_id=source_run_id,
+            projector_version=run_projector.PROJECTOR_VERSION,
+            code_revision=revision,
+            normalization_version=AUDIT_NORMALIZATION_VERSION,
+            audit_schema_version=AUDIT_SCHEMA_VERSION,
+            not_auditable_reason=_bound("legacy run without lifecycle journal"),
+            first_divergence=Divergence(
+                divergence_class=CLASS_MISSING_OR_CORRUPT_FIXTURE,
+                sequence=None,
+                event_type=None,
+                expected={"artifact": str(JOURNAL_REL)},
+                observed=None,
+                detail=_bound(f"missing evidence artifact: {JOURNAL_REL}"),
+            ),
+            transport_coverage=_transport_coverage(run_meta.get("codex_transport")),
+            evidence_digests=_safe_digests(run_dir, journal_present=False),
+        )
+
+    try:
+        report = run_journal.read_journal_bounded(journal_path)
+    except run_journal.RunJournalError as exc:
+        return _error_report(
+            source_run_id,
+            revision,
+            CLASS_MISSING_OR_CORRUPT_FIXTURE,
+            exc.diagnostic,
+            artifact=str(JOURNAL_REL),
+            transport=_transport_coverage(run_meta.get("codex_transport")),
+        )
+
+    if report.partial_tail is not None:
+        return _error_report(
+            source_run_id,
+            revision,
+            CLASS_MISSING_OR_CORRUPT_FIXTURE,
+            _bound("lifecycle journal ends in a partial line"),
+            artifact=str(JOURNAL_REL),
+            transport=_transport_coverage(run_meta.get("codex_transport")),
+        )
+    if report.chain_errors:
+        return _error_report(
+            source_run_id,
+            revision,
+            CLASS_MISSING_OR_CORRUPT_FIXTURE,
+            report.chain_errors[0],
+            artifact=str(JOURNAL_REL),
+            sequence=1,
+            transport=_transport_coverage(run_meta.get("codex_transport")),
+        )
+    if not report.events:
+        return AuditReport(
+            result=RESULT_NOT_AUDITABLE,
+            source_run_id=source_run_id,
+            projector_version=run_projector.PROJECTOR_VERSION,
+            code_revision=revision,
+            normalization_version=AUDIT_NORMALIZATION_VERSION,
+            audit_schema_version=AUDIT_SCHEMA_VERSION,
+            not_auditable_reason=_bound("lifecycle journal is empty"),
+            first_divergence=Divergence(
+                divergence_class=CLASS_MISSING_OR_CORRUPT_FIXTURE,
+                sequence=None,
+                event_type=None,
+                expected={"events": "non-empty"},
+                observed={"events": 0},
+                detail=_bound(f"empty evidence artifact: {JOURNAL_REL}"),
+            ),
+            transport_coverage=_transport_coverage(run_meta.get("codex_transport")),
+            evidence_digests=_safe_digests(run_dir, journal_present=True),
+        )
+
+    # Fail closed on any envelope the journal reader accepted but validate_event rejects.
+    for event in report.events:
+        errors = run_events.validate_event(event.to_dict())
+        if errors:
+            return _error_report(
+                source_run_id,
+                revision,
+                CLASS_MISSING_OR_CORRUPT_FIXTURE,
+                _bound(f"event sequence {event.sequence} failed validation: {errors[0]}"),
+                artifact=str(JOURNAL_REL),
+                sequence=event.sequence,
+                event_type=event.event_type,
+                transport=_transport_coverage(run_meta.get("codex_transport")),
+            )
+
+    source_run_id = report.events[0].run_id
+    unknown = _unknown_run_fields(run_meta)
+    if unknown:
+        return AuditReport(
+            result=RESULT_NOT_AUDITABLE,
+            source_run_id=source_run_id,
+            projector_version=run_projector.PROJECTOR_VERSION,
+            code_revision=revision,
+            normalization_version=AUDIT_NORMALIZATION_VERSION,
+            audit_schema_version=AUDIT_SCHEMA_VERSION,
+            not_auditable_reason=_bound(f"unsupported run.json fields for projector: {', '.join(unknown[:8])}"),
+            first_divergence=Divergence(
+                divergence_class=CLASS_UNSUPPORTED_SCHEMA,
+                sequence=None,
+                event_type=None,
+                expected={"owned_fields": "subset"},
+                observed={"unknown_fields": unknown[:8]},
+                detail=_bound("run.json carries fields outside projector ownership map"),
+            ),
+            transport_coverage=_transport_coverage(run_meta.get("codex_transport")),
+            evidence_digests=_safe_digests(run_dir, journal_present=True),
+        )
+
+    recorded_projector = run_meta.get("projector_version")
+    if isinstance(recorded_projector, int) and not isinstance(recorded_projector, bool):
+        if recorded_projector != projector_floor:
+            return AuditReport(
+                result=RESULT_NOT_AUDITABLE,
+                source_run_id=source_run_id,
+                projector_version=run_projector.PROJECTOR_VERSION,
+                code_revision=revision,
+                normalization_version=AUDIT_NORMALIZATION_VERSION,
+                audit_schema_version=AUDIT_SCHEMA_VERSION,
+                not_auditable_reason=_bound(
+                    f"unsupported projector version {recorded_projector}; audit supports {projector_floor}"
+                ),
+                first_divergence=Divergence(
+                    divergence_class=CLASS_UNSUPPORTED_SCHEMA,
+                    sequence=None,
+                    event_type=None,
+                    expected={"projector_version": projector_floor},
+                    observed={"projector_version": recorded_projector},
+                    detail=_bound("unsupported projector version for audit"),
+                ),
+                transport_coverage=_transport_coverage(run_meta.get("codex_transport")),
+                evidence_digests=_safe_digests(run_dir, journal_present=True),
+            )
+
+    try:
+        plan = _read_json_object(run_dir / PLAN_JSON_NAME)
+        roster = _read_json_object(run_dir / ROSTER_JSON_NAME)
+    except AuditError as exc:
+        return _error_report(
+            source_run_id,
+            revision,
+            CLASS_MISSING_OR_CORRUPT_FIXTURE,
+            exc.diagnostic,
+            artifact=exc.diagnostic,
+            transport=_transport_coverage(run_meta.get("codex_transport")),
+        )
+
+    try:
+        projection = run_projector.project_run_snapshot(
+            _base_snapshot_for_projection(run_meta),
+            report.events,
+            journal_present=True,
+        )
+    except run_projector.ProjectionError as exc:
+        return _error_report(
+            source_run_id,
+            revision,
+            CLASS_LIFECYCLE_PROJECTION_DRIFT,
+            exc.diagnostic,
+            artifact=str(JOURNAL_REL),
+            transport=_transport_coverage(run_meta.get("codex_transport")),
+        )
+
+    try:
+        normalized = _build_normalized_events(
+            events=report.events,
+            run_meta=run_meta,
+            plan=plan,
+            roster=roster,
+            projection=projection,
+            template_revision=template_revision,
+        )
+    except AuditError as exc:
+        return _error_report(
+            source_run_id,
+            revision,
+            CLASS_MISSING_OR_CORRUPT_FIXTURE,
+            exc.diagnostic,
+            transport=_transport_coverage(run_meta.get("codex_transport")),
+        )
+
+    evidence_digests = _safe_digests(run_dir, journal_present=True)
+    evidence_digests["normalized_events"] = _sha256_hex(canonical_bytes(_canonicalize_for_fingerprint(normalized)))
+    coverage = _transport_coverage(run_meta.get("codex_transport"))
+
+    divergence: Divergence | None = None
+    if expected_normalized_events is not None:
+        divergence = _compare_normalized(expected_normalized_events, normalized)
+    else:
+        divergence = _projection_drift(run_meta, projection)
+        if divergence is None:
+            divergence = _approval_state_drift(report.events, run_meta)
+        if divergence is None:
+            divergence = _routing_drift(report.events, plan)
+
+    result = RESULT_MATCH if divergence is None else RESULT_DIVERGE
+    return AuditReport(
+        result=result,
+        source_run_id=source_run_id,
+        projector_version=run_projector.PROJECTOR_VERSION,
+        code_revision=revision,
+        normalization_version=AUDIT_NORMALIZATION_VERSION,
+        audit_schema_version=AUDIT_SCHEMA_VERSION,
+        evidence_digests=evidence_digests,
+        transport_coverage=coverage,
+        normalized_events=normalized,
+        first_divergence=divergence,
+    )
+
+
+def _safe_digests(run_dir: Path, *, journal_present: bool) -> dict[str, str]:
+    digests: dict[str, str] = {}
+    for name in (RUN_JSON_NAME, PLAN_JSON_NAME, ROSTER_JSON_NAME):
+        digest = _digest_file(run_dir / name)
+        if digest is not None:
+            digests[name] = digest
+    if journal_present:
+        digest = _digest_file(run_dir / JOURNAL_REL)
+        if digest is not None:
+            digests[str(JOURNAL_REL)] = digest
+    return digests
+
+
+def _error_report(
+    source_run_id: str,
+    revision: str,
+    divergence_class: str,
+    detail: str,
+    *,
+    artifact: str | None = None,
+    sequence: int | None = None,
+    event_type: str | None = None,
+    transport: dict[str, Any] | None = None,
+) -> AuditReport:
+    expected: Any = {"artifact": artifact} if artifact is not None else None
+    return AuditReport(
+        result=RESULT_ERROR if divergence_class == CLASS_MISSING_OR_CORRUPT_FIXTURE else RESULT_DIVERGE,
+        source_run_id=source_run_id,
+        projector_version=run_projector.PROJECTOR_VERSION,
+        code_revision=revision,
+        normalization_version=AUDIT_NORMALIZATION_VERSION,
+        audit_schema_version=AUDIT_SCHEMA_VERSION,
+        transport_coverage=transport or {},
+        first_divergence=Divergence(
+            divergence_class=divergence_class,
+            sequence=sequence,
+            event_type=event_type,
+            expected=expected,
+            observed=None,
+            detail=_bound(detail),
+        ),
+        not_auditable_reason=_bound(detail)
+        if divergence_class in {CLASS_MISSING_OR_CORRUPT_FIXTURE, CLASS_UNSUPPORTED_SCHEMA}
+        else None,
+    )
+
+
+def forbid_live_side_effects() -> None:
+    """Raise if this module ever grows live side-effect imports.
+
+    Called by the sentinel test and available for defensive callers. The audit
+    path must remain offline: no subprocess, socket, urllib, or AppServer.
+    """
+    banned = ("subprocess", "socket", "urllib", "http.client", "codex_appserver")
+    source = Path(__file__).read_text(encoding="utf-8")
+    for name in banned:
+        # Match import forms only; comments mentioning the ban are allowed.
+        if f"import {name}" in source or f"from {name}" in source:
+            raise AttemptedSideEffectError(_bound(f"audit module imports forbidden module {name}"))

--- a/src/brigade/runs_cmd.py
+++ b/src/brigade/runs_cmd.py
@@ -2043,6 +2043,49 @@ def watch(
         time.sleep(interval)
 
 
+def audit(
+    run: str | Path,
+    *,
+    cwd: Path,
+    runs_dir: Path | None = None,
+    json_output: bool = False,
+) -> int:
+    """Offline coordinator decision audit (#595). Thin wrapper over run_audit."""
+    run_dir, error = _resolve_run_dir(run, cwd=cwd, runs_dir=runs_dir)
+    if error is not None:
+        print(error, file=sys.stderr)
+        return 2
+    assert run_dir is not None
+
+    from . import run_audit
+
+    report = run_audit.audit_run(run_dir)
+    receipt = report.to_receipt()
+    if json_output:
+        print(json.dumps(receipt, indent=2, sort_keys=True))
+    else:
+        print(f"audit: {report.result}")
+        print(f"run: {report.source_run_id}")
+        print(f"projector_version: {report.projector_version}")
+        print(f"code_revision: {report.code_revision}")
+        if report.not_auditable_reason:
+            print(f"not_auditable: {report.not_auditable_reason}")
+        if report.first_divergence is not None:
+            print(f"divergence_class: {report.first_divergence.divergence_class}")
+            print(f"divergence: {report.first_divergence.detail}")
+        transport = report.transport_coverage.get("transport")
+        if transport is not None:
+            print(f"transport: {transport}")
+        coverage = report.transport_coverage.get("coverage")
+        if isinstance(coverage, dict) and isinstance(coverage.get("note"), str):
+            print(f"coverage: {coverage['note']}")
+    if report.result == run_audit.RESULT_MATCH:
+        return 0
+    if report.result == run_audit.RESULT_NOT_AUDITABLE:
+        return 2
+    return 1
+
+
 def show(run_dir: Path) -> int:
     run_dir = run_dir.expanduser()
     if not run_dir.is_dir():

--- a/tests/test_run_audit.py
+++ b/tests/test_run_audit.py
@@ -1,0 +1,333 @@
+"""Acceptance tests for offline coordinator decision audit (issue #595)."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from brigade import cli, run_audit, run_events, run_journal, run_projector
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "run-lifecycle"
+GOLDEN_LIFECYCLE = FIXTURES / "golden-lifecycle.jsonl"
+GOLDEN_BASE = FIXTURES / "golden-projection.base.json"
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _copy_golden_journal(dest: Path) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(GOLDEN_LIFECYCLE, dest)
+
+
+def _golden_run_dir(tmp_path: Path, *, mutate_run: dict | None = None) -> Path:
+    """Build an auditable run directory from the golden lifecycle fixtures."""
+    run_id = "20260727-153045-a1b2c3d4"
+    run_dir = tmp_path / ".brigade" / "runs" / run_id
+    run_dir.mkdir(parents=True)
+    base = json.loads(GOLDEN_BASE.read_text(encoding="utf-8"))
+    # Project so journal_* derived fields are present for consistency checks.
+    report = run_journal.read_journal(GOLDEN_LIFECYCLE)
+    assert report.chain_errors == []
+    projection = run_projector.project_run_snapshot(base, report.events, journal_present=True)
+    run_meta = dict(projection.snapshot)
+    if mutate_run:
+        run_meta.update(mutate_run)
+    _write_json(run_dir / "run.json", run_meta)
+    _copy_golden_journal(run_dir / "events" / "lifecycle.jsonl")
+    _write_json(
+        run_dir / "plan.json",
+        {
+            "assignments": [
+                {"worker": "coder", "task": "Implement the projector"},
+            ]
+        },
+    )
+    _write_json(
+        run_dir / "roster.json",
+        {
+            "orchestrator": "chef",
+            "agents": {
+                "coder": {"cli": "codex", "role": "Implement code changes"},
+                "chef": {"cli": "codex", "role": "Plan and synthesize"},
+            },
+        },
+    )
+    return run_dir
+
+
+def test_forbid_live_side_effects_sentinel():
+    """The audit path cannot construct a provider adapter or subprocess runner."""
+    run_audit.forbid_live_side_effects()
+    source = Path(run_audit.__file__).read_text(encoding="utf-8")
+    for banned in (
+        "import subprocess",
+        "from subprocess",
+        "import socket",
+        "from socket",
+        "import urllib",
+        "from urllib",
+        "codex_appserver",
+    ):
+        # Comments may mention the ban; import forms must not appear.
+        if banned.startswith("import ") or banned.startswith("from "):
+            assert banned not in source
+        else:
+            assert f"import {banned}" not in source
+            assert f"from {banned}" not in source
+
+
+def test_golden_run_audits_twice_to_byte_identical_normalized_events(tmp_path: Path):
+    """AC: A golden run audits twice to byte-identical normalized coordinator events."""
+    run_dir = _golden_run_dir(tmp_path)
+    first = run_audit.audit_run(run_dir)
+    second = run_audit.audit_run(run_dir)
+    assert first.result == run_audit.RESULT_MATCH
+    assert second.result == run_audit.RESULT_MATCH
+    assert first.normalized_events_bytes() == second.normalized_events_bytes()
+    assert first.evidence_digests["normalized_events"] == second.evidence_digests["normalized_events"]
+
+
+def test_changing_prompt_template_stops_at_first_composed_prompt(tmp_path: Path):
+    """AC: Changing a prompt template stops at the first affected composed worker prompt."""
+    run_dir = _golden_run_dir(tmp_path)
+    baseline = run_audit.audit_run(run_dir)
+    assert baseline.result == run_audit.RESULT_MATCH
+    drifted = run_audit.audit_run(
+        run_dir,
+        expected_normalized_events=baseline.normalized_events,
+        template_revision="brigade.worker_prompt.v1-mutated",
+    )
+    assert drifted.result == run_audit.RESULT_DIVERGE
+    assert drifted.first_divergence is not None
+    assert drifted.first_divergence.divergence_class == run_audit.CLASS_PROMPT_TEMPLATE_DRIFT
+    assert drifted.first_divergence.observed is not None
+    assert drifted.first_divergence.observed.get("kind") == "composed_prompt"
+
+
+def test_changing_route_selection_stops_at_first_coordinator_decision(tmp_path: Path):
+    """AC: Changing route selection stops at the first affected coordinator decision."""
+    run_dir = _golden_run_dir(tmp_path)
+    baseline = run_audit.audit_run(run_dir)
+    run_meta = json.loads((run_dir / "run.json").read_text(encoding="utf-8"))
+    run_meta["route"] = {"skill": "mutated-route", "matched": ["x"], "score": 99}
+    _write_json(run_dir / "run.json", run_meta)
+    drifted = run_audit.audit_run(run_dir, expected_normalized_events=baseline.normalized_events)
+    assert drifted.result == run_audit.RESULT_DIVERGE
+    assert drifted.first_divergence is not None
+    assert drifted.first_divergence.divergence_class == run_audit.CLASS_POLICY_OR_ROUTING_DRIFT
+
+
+def test_changing_approval_state_stops_at_first_coordinator_decision(tmp_path: Path):
+    """AC: Changing approval state stops at the first affected coordinator decision."""
+    run_dir = tmp_path / "approval-run"
+    run_dir.mkdir()
+    run_id = "approval-run-1"
+    created = run_events.build_event(
+        run_id=run_id,
+        sequence=1,
+        event_type="run.created",
+        payload={"status": "started"},
+        idempotency_key="create-1",
+        recorded_at="2026-07-27T15:30:45.123456Z",
+        previous_digest=None,
+    )
+    paused = run_events.build_event(
+        run_id=run_id,
+        sequence=2,
+        event_type="run.paused",
+        payload={"approval_id": "appr-1", "reason": "approval-wait"},
+        idempotency_key="pause-1",
+        recorded_at="2026-07-27T15:30:46.000000Z",
+        previous_digest=created["event_digest"],
+    )
+    requested = run_events.build_event(
+        run_id=run_id,
+        sequence=3,
+        event_type="approval.requested",
+        payload={
+            "approval_id": "appr-1",
+            "source": "daily",
+            "contract_fingerprint": "a" * 64,
+        },
+        idempotency_key="appr-req-1",
+        recorded_at="2026-07-27T15:30:46.123456Z",
+        previous_digest=paused["event_digest"],
+    )
+    granted = run_events.build_event(
+        run_id=run_id,
+        sequence=4,
+        event_type="approval.granted",
+        payload={
+            "approval_id": "appr-1",
+            "decided_at": "2026-07-27T15:30:47.123456Z",
+            "decision_state": "approved",
+        },
+        idempotency_key="appr-grant-1",
+        recorded_at="2026-07-27T15:30:47.123456Z",
+        previous_digest=requested["event_digest"],
+    )
+    events_dir = run_dir / "events"
+    events_dir.mkdir()
+    journal = events_dir / "lifecycle.jsonl"
+    with journal.open("wb") as handle:
+        for env in (created, paused, requested, granted):
+            handle.write(run_events.canonical_bytes(env) + b"\n")
+    _write_json(
+        run_dir / "run.json",
+        {
+            "schema": "brigade.run.v1",
+            "schema_version": 1,
+            "status": "running",
+            "task": "approve something",
+            "orchestrator": "chef",
+            "roster": "default",
+            "worker": "coder",
+            "scheduler": "immediate",
+            "codex_transport": "app-server",
+            "approval_reference": {
+                "approval_id": "appr-1",
+                "source": "daily",
+                "fingerprint": "fp",
+                "source_fingerprint": "sfp",
+                "contract_fingerprint": "a" * 64,
+                "evidence_fingerprint": "efp",
+                "decision_state": "approved",
+            },
+        },
+    )
+    baseline = run_audit.audit_run(run_dir)
+    assert baseline.result == run_audit.RESULT_MATCH
+    # Mutate archived approval decision_state.
+    run_meta = json.loads((run_dir / "run.json").read_text(encoding="utf-8"))
+    run_meta["approval_reference"]["decision_state"] = "rejected"
+    _write_json(run_dir / "run.json", run_meta)
+    drifted = run_audit.audit_run(run_dir)
+    assert drifted.result == run_audit.RESULT_DIVERGE
+    assert drifted.first_divergence is not None
+    assert drifted.first_divergence.divergence_class == run_audit.CLASS_APPROVAL_STATE_DRIFT
+
+
+def test_missing_corrupt_evidence_reports_exact_artifact(tmp_path: Path):
+    """AC: Missing or corrupt evidence reports the exact artifact and event."""
+    run_dir = tmp_path / "corrupt-run"
+    run_dir.mkdir()
+    _write_json(
+        run_dir / "run.json",
+        {
+            "schema": "brigade.run.v1",
+            "schema_version": 1,
+            "status": "started",
+            "task": "t",
+            "orchestrator": "chef",
+            "roster": "r",
+            "worker": "coder",
+            "scheduler": "immediate",
+        },
+    )
+    events = run_dir / "events"
+    events.mkdir()
+    (events / "lifecycle.jsonl").write_text("{not-json\n", encoding="utf-8")
+    report = run_audit.audit_run(run_dir)
+    assert report.result == run_audit.RESULT_ERROR
+    assert report.first_divergence is not None
+    assert report.first_divergence.divergence_class == run_audit.CLASS_MISSING_OR_CORRUPT_FIXTURE
+    assert report.first_divergence.expected == {"artifact": "events/lifecycle.jsonl"}
+
+
+def test_unsupported_transport_states_coverage(tmp_path: Path):
+    """AC: Unsupported transports state their coverage instead of claiming full replay."""
+    run_dir = _golden_run_dir(tmp_path, mutate_run={"codex_transport": "mystery-bus"})
+    report = run_audit.audit_run(run_dir)
+    assert report.transport_coverage["supported"] is False
+    assert report.transport_coverage["coverage"]["provider_response_fixtures"] is False
+    assert "unsupported transport" in report.transport_coverage["coverage"]["note"]
+
+
+def test_unsupported_projector_version_stops_with_compatibility_diagnostics(tmp_path: Path):
+    """AC: Unsupported lifecycle or audit schema versions stop with bounded diagnostics."""
+    run_dir = _golden_run_dir(tmp_path, mutate_run={"projector_version": 999})
+    report = run_audit.audit_run(run_dir)
+    assert report.result == run_audit.RESULT_NOT_AUDITABLE
+    assert report.first_divergence is not None
+    assert report.first_divergence.divergence_class == run_audit.CLASS_UNSUPPORTED_SCHEMA
+    assert "unsupported projector version" in (report.not_auditable_reason or "")
+
+
+def test_legacy_run_without_journal_reports_not_auditable(tmp_path: Path):
+    """AC: Legacy runs without required evidence report not auditable."""
+    run_dir = tmp_path / "legacy"
+    run_dir.mkdir()
+    _write_json(
+        run_dir / "run.json",
+        {
+            "schema": "brigade.run.v1",
+            "schema_version": 1,
+            "status": "ok",
+            "task": "legacy",
+            "orchestrator": "chef",
+            "roster": "r",
+            "worker": "coder",
+            "scheduler": "immediate",
+        },
+    )
+    report = run_audit.audit_run(run_dir)
+    assert report.result == run_audit.RESULT_NOT_AUDITABLE
+    assert report.not_auditable_reason is not None
+    assert "lifecycle journal" in report.not_auditable_reason
+
+
+def test_private_data_fixtures_expose_only_safe_summaries(tmp_path: Path):
+    """AC: Reports expose only safe summaries, fingerprints, and classified references."""
+    secret = "SUPER-SECRET-PROMPT-BODY-do-not-leak"
+    run_dir = _golden_run_dir(tmp_path)
+    _write_json(
+        run_dir / "plan.json",
+        {"assignments": [{"worker": "coder", "task": secret}]},
+    )
+    report = run_audit.audit_run(run_dir)
+    receipt_text = json.dumps(report.to_receipt(), sort_keys=True)
+    events_text = json.dumps(report.normalized_events, sort_keys=True)
+    assert secret not in receipt_text
+    assert secret not in events_text
+    assert "fingerprint" in events_text
+
+
+def test_receipt_records_required_fields(tmp_path: Path):
+    """AC: Receipt records source run, projector version, code revision, result, divergence, digests."""
+    run_dir = _golden_run_dir(tmp_path)
+    report = run_audit.audit_run(run_dir, code_revision="test-rev")
+    receipt = report.to_receipt()
+    assert receipt["schema"] == run_audit.AUDIT_SCHEMA
+    assert receipt["source_run"] == "20260727-153045-a1b2c3d4"
+    assert receipt["projector_version"] == run_projector.PROJECTOR_VERSION
+    assert receipt["code_revision"] == "test-rev"
+    assert receipt["result"] == run_audit.RESULT_MATCH
+    assert receipt["first_divergence"] is None
+    assert "events/lifecycle.jsonl" in receipt["evidence_digests"]
+    assert "run.json" in receipt["evidence_digests"]
+    assert "normalized_events" in receipt["evidence_digests"]
+
+
+def test_audit_does_not_write_run_directory(tmp_path: Path):
+    """Hard constraint: audit mode cannot mutate the run directory."""
+    run_dir = _golden_run_dir(tmp_path)
+    before = {path.relative_to(run_dir): path.read_bytes() for path in run_dir.rglob("*") if path.is_file()}
+    run_audit.audit_run(run_dir)
+    after = {path.relative_to(run_dir): path.read_bytes() for path in run_dir.rglob("*") if path.is_file()}
+    assert before == after
+
+
+def test_cli_runs_audit_json(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    run_dir = _golden_run_dir(tmp_path)
+    rc = cli.main(["runs", "audit", str(run_dir), "--json"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    payload = json.loads(captured.out)
+    assert payload["result"] == "match"
+    assert payload["source_run"] == "20260727-153045-a1b2c3d4"

--- a/tests/test_run_audit.py
+++ b/tests/test_run_audit.py
@@ -282,6 +282,82 @@ def test_legacy_run_without_journal_reports_not_auditable(tmp_path: Path):
     assert "lifecycle journal" in report.not_auditable_reason
 
 
+def test_legacy_run_symlinked_plan_json_returns_bounded_not_auditable(tmp_path: Path):
+    """Symlinked sidecar evidence must not crash digest computation on legacy runs."""
+    run_dir = tmp_path / "legacy-symlink-plan"
+    run_dir.mkdir()
+    _write_json(
+        run_dir / "run.json",
+        {
+            "schema": "brigade.run.v1",
+            "schema_version": 1,
+            "status": "ok",
+            "task": "legacy",
+            "orchestrator": "chef",
+            "roster": "r",
+            "worker": "coder",
+            "scheduler": "immediate",
+        },
+    )
+    real_plan = tmp_path / "real-plan.json"
+    _write_json(real_plan, {"assignments": [{"worker": "coder", "task": "t"}]})
+    (run_dir / "plan.json").symlink_to(real_plan)
+    report = run_audit.audit_run(run_dir)
+    assert report.result == run_audit.RESULT_NOT_AUDITABLE
+    assert report.not_auditable_reason is not None
+    assert "lifecycle journal" in report.not_auditable_reason
+    assert "run.json" in report.evidence_digests
+    assert "plan.json" not in report.evidence_digests
+
+
+def test_seat_order_permutation_reports_routing_drift(tmp_path: Path):
+    """Dispatch seat order must match plan.json assignments, not just the seat set."""
+    run_dir = _golden_run_dir(tmp_path)
+    _write_json(
+        run_dir / "plan.json",
+        {
+            "assignments": [
+                {"worker": "coder", "task": "first"},
+                {"worker": "chef", "task": "second"},
+            ]
+        },
+    )
+    report = run_journal.read_journal(run_dir / "events" / "lifecycle.jsonl")
+    assert report.chain_errors == []
+    created = report.events[0]
+    # Build a journal with dispatch seats reversed versus plan order.
+    dispatch_chef = run_events.build_event(
+        run_id=created.run_id,
+        sequence=3,
+        event_type="run.dispatch.requested",
+        payload={"attempt": 1, "seat": "chef"},
+        idempotency_key="dispatch-chef",
+        recorded_at="2026-07-27T15:30:47.000000Z",
+        previous_digest=report.events[1].event_digest,
+    )
+    dispatch_coder = run_events.build_event(
+        run_id=created.run_id,
+        sequence=4,
+        event_type="run.dispatch.requested",
+        payload={"attempt": 1, "seat": "coder"},
+        idempotency_key="dispatch-coder",
+        recorded_at="2026-07-27T15:30:48.000000Z",
+        previous_digest=dispatch_chef["event_digest"],
+    )
+    journal = run_dir / "events" / "lifecycle.jsonl"
+    with journal.open("wb") as handle:
+        for env in (report.events[0].to_dict(), report.events[1].to_dict(), dispatch_chef, dispatch_coder):
+            handle.write(run_events.canonical_bytes(env) + b"\n")
+    journal_report = run_journal.read_journal(journal)
+    base = json.loads(GOLDEN_BASE.read_text(encoding="utf-8"))
+    projection = run_projector.project_run_snapshot(base, journal_report.events, journal_present=True)
+    _write_json(run_dir / "run.json", dict(projection.snapshot))
+    drifted = run_audit.audit_run(run_dir)
+    assert drifted.result == run_audit.RESULT_DIVERGE
+    assert drifted.first_divergence is not None
+    assert drifted.first_divergence.divergence_class == run_audit.CLASS_POLICY_OR_ROUTING_DRIFT
+
+
 def test_private_data_fixtures_expose_only_safe_summaries(tmp_path: Path):
     """AC: Reports expose only safe summaries, fingerprints, and classified references."""
     secret = "SUPER-SECRET-PROMPT-BODY-do-not-leak"


### PR DESCRIPTION
## Summary
- Add `brigade runs audit <run-id>` as a read-only lifecycle-journal consumer (`src/brigade/run_audit.py`) that re-projects via `project_run_snapshot`, fingerprints coordinator-owned route/policy, dispatch, approval, adapter, and composed-prompt decisions, and stops at the first divergence.
- Hard safety boundary: no writes to any run directory, no new event types, no changes to `run_journal.py` / `run_events.py` / `run_projector.py` / `run_lifecycle.py`, and no provider-adapter or subprocess construction.
- CLI registration is a minimal hunk in `cli/runs.py` + thin `runs_cmd.audit` wrapper so it rebases cleanly beside concurrent #604 work.

## Acceptance criteria → tests
- [x] Golden run audits twice to byte-identical normalized events → `test_golden_run_audits_twice_to_byte_identical_normalized_events`
- [x] Changing a prompt template stops at first composed prompt → `test_changing_prompt_template_stops_at_first_composed_prompt`
- [x] Changing route selection / approval state stops at first decision → `test_changing_route_selection_stops_at_first_coordinator_decision`, `test_changing_approval_state_stops_at_first_coordinator_decision`
- [x] Audit path cannot construct provider adapter or subprocess → `test_forbid_live_side_effects_sentinel`
- [x] Missing/corrupt evidence reports exact artifact → `test_missing_corrupt_evidence_reports_exact_artifact`
- [x] Unsupported transports state coverage → `test_unsupported_transport_states_coverage`
- [x] Unsupported projector/schema versions stop with diagnostics → `test_unsupported_projector_version_stops_with_compatibility_diagnostics`
- [x] Legacy runs without journal report `not_auditable` → `test_legacy_run_without_journal_reports_not_auditable`
- [x] Private-data fixtures expose only safe summaries/fingerprints → `test_private_data_fixtures_expose_only_safe_summaries`
- [x] Receipt records source run, projector version, code revision, result, first divergence, evidence digests → `test_receipt_records_required_fields`

## Test plan
- [x] `brigade work verify run --target . --command "./scripts/verify" --capture brigade-work`
- Receipt: `20260801-034500-work-verify-13980f` (exit=0)
- [ ] External grader review before merge

Closes #595


Made with [Cursor](https://cursor.com)