### PR TITLE
fix(outcome): dedupe reused verify receipts via reused_from

### DIFF
--- a/src/brigade/outcome_cmd.py
+++ b/src/brigade/outcome_cmd.py
@@ -588,6 +588,38 @@ def load_records(target: Path) -> list[core.OutcomeRecord]:
     return [record for record in records if record is not None]
 
 
+def _canonical_verify_evidence_ref(target: Path, evidence_ref: str) -> str:
+    """Follow ``reused_from`` when ``evidence_ref`` names a verify receipt path."""
+    if not evidence_ref:
+        return evidence_ref
+    path = Path(evidence_ref).expanduser()
+    if path.name != "receipt.json":
+        return evidence_ref
+    payload = localio.read_json_dict(path)
+    if not isinstance(payload, dict):
+        return evidence_ref
+    from .work_cmd import verification as verify_mod
+
+    return verify_mod.canonical_verify_evidence_ref(target, payload)
+
+
+def _with_canonical_verify_evidence(target: Path, record: core.OutcomeRecord) -> core.OutcomeRecord:
+    canonical = _canonical_verify_evidence_ref(target, record.evidence_ref)
+    if canonical == record.evidence_ref:
+        return record
+    return dataclasses.replace(record, evidence_ref=canonical)
+
+
+def load_scoring_records(target: Path) -> list[core.OutcomeRecord]:
+    """Load ledger rows with verify evidence canonicalized through ``reused_from``.
+
+    Append-only disk rows stay untouched; scoring/rank/explain/reconcile see one
+    signal for an original receipt and any reused twin.
+    """
+    target = target.expanduser().resolve()
+    return [_with_canonical_verify_evidence(target, record) for record in load_records(target)]
+
+
 def _last_record_digest(path: Path) -> str | None:
     return _validate_completed_ledger(path)
 
@@ -1029,7 +1061,7 @@ def fork(
     """
     target = target.expanduser().resolve()
     config = config or core.ReconcileConfig()
-    records = load_records(target)
+    records = load_scoring_records(target)
     cohorts_by_artifact = _fingerprint_cohorts_by_artifact(target, records)
     scorecards = _scorecards_by_artifact(target)
     kinds = _artifact_kinds(records, {}, scorecards)
@@ -1343,7 +1375,7 @@ def _capability_breakdown(records: list[core.OutcomeRecord]) -> list[dict] | Non
 
 def score(*, target: Path, artifact_id: str | None = None, json_output: bool = False) -> int:
     target = target.expanduser().resolve()
-    scores = _scores_by_artifact(load_records(target))
+    scores = _scores_by_artifact(load_scoring_records(target))
     if artifact_id is not None:
         scores = {artifact_id: scores.get(artifact_id, core.score_records(artifact_id, []))}
     ordered = sorted(scores.values(), key=lambda item: item.artifact_id)
@@ -1371,7 +1403,7 @@ def explain(*, target: Path, artifact_id: str, json_output: bool = False) -> int
     its pre-fingerprint shape.
     """
     target = target.expanduser().resolve()
-    records = [record for record in load_records(target) if record.artifact_id == artifact_id]
+    records = [record for record in load_scoring_records(target) if record.artifact_id == artifact_id]
     kind = next((r.artifact_kind for r in records if r.artifact_kind), "skill")
     cohorts = core.split_by_fingerprint(artifact_id, records, artifact_fingerprint(target, artifact_id, kind))
     score_obj = cohorts.current
@@ -1558,7 +1590,7 @@ def capture(
             print(f"error: {error}", file=sys.stderr)
             return 1
         effective_status = str(receipt.get("status") or "")
-        evidence_ref = str(Path(str(receipt.get("path", ""))) / "receipt.json")
+        evidence_ref = verify_mod.canonical_verify_evidence_ref(target, receipt)
         ts = str(receipt.get("completed_at") or receipt.get("started_at") or localio.utc_now_iso())
         code_graph_delta = _compact_code_graph_delta(receipt)
     manifest = context_manifest(run_agent)
@@ -1665,7 +1697,7 @@ def reconcile(
     """
     target = target.expanduser().resolve()
     config = config or core.ReconcileConfig()
-    records = load_records(target)
+    records = load_scoring_records(target)
     cohorts_by_artifact = _fingerprint_cohorts_by_artifact(target, records)
     scorecards = _scorecards_by_artifact(target)
     graph_counts = _graph_delta_counts_by_artifact(records)
@@ -1885,7 +1917,7 @@ def rank(
     output). The ratchet never uses recency; this is retrieval only.
     """
     target = target.expanduser().resolve()
-    records = load_records(target)
+    records = load_scoring_records(target)
     cohorts_by_artifact = _fingerprint_cohorts_by_artifact(target, records)
     current_capability = capability_fingerprint(context_manifest())
     now = now or localio.utc_now()
@@ -2109,7 +2141,7 @@ def health(target: Path) -> dict:
     from .work_cmd import helpers as work_helpers
 
     records = load_records(target)
-    scores = _scores_by_artifact(records)
+    scores = _scores_by_artifact(load_scoring_records(target))
     runs_root = work_helpers._verify_runs_root(target)
     verify_run_count = sum(1 for child in runs_root.iterdir() if child.is_dir()) if runs_root.is_dir() else 0
     record_count = len(records)

--- a/src/brigade/work_cmd/verification.py
+++ b/src/brigade/work_cmd/verification.py
@@ -687,18 +687,45 @@ def _verify_receipt_evidence_ref(receipt: dict[str, Any]) -> str:
     return ""
 
 
+def canonical_verify_evidence_ref(target: Path, receipt: dict[str, Any]) -> str:
+    """Return the stable verification identity, following ``reused_from`` when present.
+
+    A reused receipt points at an earlier command result. Scoring and capture must
+    key both paths as one signal so the same verification cannot inflate helped
+    counts. Receipts that merely share content without ``reused_from`` stay distinct.
+    """
+    target = target.expanduser().resolve()
+    current = receipt
+    seen: set[str] = set()
+    while True:
+        reused = current.get("reused_from")
+        if not isinstance(reused, str) or not reused.strip():
+            return _verify_receipt_evidence_ref(current)
+        run_id = reused.strip()
+        if run_id in seen:
+            return _verify_receipt_evidence_ref(current)
+        seen.add(run_id)
+        next_receipt, _error = _resolve_verify_receipt(target, run_id)
+        if next_receipt is None:
+            return str(helpers._verify_runs_root(target) / run_id / "receipt.json")
+        current = next_receipt
+
+
 def _verify_receipt_has_outcome_capture(target: Path, receipt: dict[str, Any]) -> bool:
     from .. import outcome_cmd
 
-    evidence_ref = _verify_receipt_evidence_ref(receipt)
+    evidence_ref = canonical_verify_evidence_ref(target, receipt)
     if not evidence_ref:
         return False
-    resolved = Path(evidence_ref).expanduser().resolve()
-    for record in outcome_cmd.load_records(target):
+    try:
+        resolved = Path(evidence_ref).expanduser().resolve()
+    except OSError:
+        resolved = None
+    for record in outcome_cmd.load_scoring_records(target):
         if not record.evidence_ref:
             continue
         try:
-            if Path(record.evidence_ref).expanduser().resolve() == resolved:
+            if resolved is not None and Path(record.evidence_ref).expanduser().resolve() == resolved:
                 return True
         except OSError:
             if record.evidence_ref == evidence_ref:

--- a/tests/test_outcome_reused_receipt_dedup.py
+++ b/tests/test_outcome_reused_receipt_dedup.py
@@ -1,0 +1,124 @@
+"""Regression coverage for reused verify receipt outcome dedup (#634)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from brigade import outcome, outcome_cmd
+from brigade.work_cmd import verification
+
+
+def _write_receipt(target: Path, run_id: str, *, reused_from: str | None = None, status: str = "completed") -> Path:
+    run_dir = target / ".brigade" / "work" / "verify-runs" / run_id
+    run_dir.mkdir(parents=True)
+    receipt = {
+        "run_id": run_id,
+        "target": str(target),
+        "status": status,
+        "started_at": "2026-07-25T02:00:00+00:00",
+        "completed_at": "2026-07-25T02:00:05+00:00",
+        "path": str(run_dir),
+        "commands": [{"command": "true", "status": status, "exit_code": 0 if status == "completed" else 1}],
+        "planned_commands": ["true"],
+    }
+    if reused_from is not None:
+        receipt["reused_from"] = reused_from
+    (run_dir / "receipt.json").write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n")
+    return run_dir
+
+
+def test_capture_follows_reused_from_to_original_evidence_ref(tmp_path):
+    original = _write_receipt(tmp_path, "20260725-020358-work-verify-bc82bb")
+    reused = _write_receipt(
+        tmp_path,
+        "20260725-020602-work-verify-3622db",
+        reused_from="20260725-020358-work-verify-bc82bb",
+    )
+    skill = tmp_path / ".claude" / "skills" / "taste"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("# taste\n")
+
+    assert outcome_cmd.capture(target=tmp_path, artifact_id="taste", run_id=reused.name) == 0
+    rows = [json.loads(line) for line in (tmp_path / "memory" / "outcome" / "records.jsonl").read_text().splitlines()]
+    assert len(rows) == 1
+    assert rows[0]["evidence_ref"] == str(original / "receipt.json")
+    assert rows[0]["evidence_ref"] != str(reused / "receipt.json")
+
+
+def test_score_counts_original_and_reused_receipt_as_one_signal(tmp_path):
+    original = _write_receipt(tmp_path, "orig-run")
+    reused = _write_receipt(tmp_path, "reuse-run", reused_from="orig-run")
+    skill = tmp_path / ".claude" / "skills" / "taste"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("# taste\n")
+
+    assert outcome_cmd.capture(target=tmp_path, artifact_id="taste", run_id="orig-run") == 0
+    # Second capture still appends a row (append-only), but both point at the
+    # original identity so scoring collapses them to one helped signal.
+    assert outcome_cmd.capture(target=tmp_path, artifact_id="taste", run_id="reuse-run") == 0
+    raw = outcome_cmd.load_records(tmp_path)
+    assert len(raw) == 2
+    assert {record.evidence_ref for record in raw} == {str(original / "receipt.json")}
+    assert str(reused / "receipt.json") not in {record.evidence_ref for record in raw}
+
+    scored = outcome_cmd.load_scoring_records(tmp_path)
+    score = outcome.score_records("taste", [r for r in scored if r.artifact_id == "taste"])
+    assert score.helped == 1
+    assert score.hurt == 0
+
+    import contextlib
+    import io
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        assert outcome_cmd.rank(target=tmp_path, json_output=True) == 0
+    payload = json.loads(buf.getvalue())
+    entry = next(item for item in payload["ranking"] if item["artifact_id"] == "taste")
+    assert entry["helped"] == 1
+
+
+def test_distinct_receipts_without_reused_from_remain_separate_signals(tmp_path):
+    _write_receipt(tmp_path, "run-a")
+    _write_receipt(tmp_path, "run-b")
+    skill = tmp_path / ".claude" / "skills" / "taste"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("# taste\n")
+
+    assert outcome_cmd.capture(target=tmp_path, artifact_id="taste", run_id="run-a") == 0
+    assert outcome_cmd.capture(target=tmp_path, artifact_id="taste", run_id="run-b") == 0
+    scored = outcome_cmd.load_scoring_records(tmp_path)
+    score = outcome.score_records("taste", [r for r in scored if r.artifact_id == "taste"])
+    assert score.helped == 2
+
+
+def test_canonical_verify_evidence_ref_follows_chain(tmp_path):
+    _write_receipt(tmp_path, "root")
+    mid = _write_receipt(tmp_path, "mid", reused_from="root")
+    leaf = _write_receipt(tmp_path, "leaf", reused_from="mid")
+    leaf_receipt = json.loads((leaf / "receipt.json").read_text())
+    assert verification.canonical_verify_evidence_ref(tmp_path, leaf_receipt) == str(
+        tmp_path / ".brigade" / "work" / "verify-runs" / "root" / "receipt.json"
+    )
+    mid_receipt = json.loads((mid / "receipt.json").read_text())
+    assert verification.canonical_verify_evidence_ref(tmp_path, mid_receipt).endswith("/root/receipt.json")
+
+
+def test_scoring_canonicalizes_legacy_rows_that_stored_reused_path(tmp_path):
+    """Already-written rows keep their bytes; scoring still collapses via reused_from."""
+    original = _write_receipt(tmp_path, "orig-run")
+    reused = _write_receipt(tmp_path, "reuse-run", reused_from="orig-run")
+    path = tmp_path / "memory" / "outcome" / "records.jsonl"
+    path.parent.mkdir(parents=True)
+    first = outcome.OutcomeRecord(
+        "taste", "skill", "", "verify", 1, str(original / "receipt.json"), "2026-07-25T02:00:00+00:00"
+    )
+    second = outcome.OutcomeRecord(
+        "taste", "skill", "", "verify", 1, str(reused / "receipt.json"), "2026-07-25T02:06:00+00:00"
+    )
+    outcome_cmd.append_records(tmp_path, [first, second])
+    before = path.read_bytes()
+    scored = outcome_cmd.load_scoring_records(tmp_path)
+    score = outcome.score_records("taste", scored)
+    assert score.helped == 1
+    assert path.read_bytes() == before


### PR DESCRIPTION
## Summary
- Follow `reused_from` to a stable original verification identity when capturing and when scoring outcome signals.
- Append-only ledger rows stay intact; `load_scoring_records` canonicalizes evidence for rank/explain/reconcile.
- Receipts that share content but do not declare `reused_from` remain distinct signals.

Closes #634.

## Verify receipt
`20260801-050320-work-verify-f3f261`

```bash
brigade work verify run --target . --command "./scripts/verify" --capture brigade-work
```

## Acceptance criteria → tests
| Criterion | Test |
|---|---|
| Capture follows `reused_from` to original evidence | `test_capture_follows_reused_from_to_original_evidence_ref` |
| Original + reused count as one helped signal | `test_score_counts_original_and_reused_receipt_as_one_signal` |
| No `reused_from` keeps distinct signals | `test_distinct_receipts_without_reused_from_remain_separate_signals` |
| Legacy rows with reused paths still collapse at score time | `test_scoring_canonicalizes_legacy_rows_that_stored_reused_path` |
| Chain of reuse resolves to root | `test_canonical_verify_evidence_ref_follows_chain` |

## Test plan
- [x] `tests/test_outcome_reused_receipt_dedup.py` green
- [x] `brigade work verify run --target . --command "./scripts/verify" --capture brigade-work`
- [ ] External grader review before merge


Made with [Cursor](https://cursor.com)