### PR TITLE
fix(redaction): survive crash between parent retirement and child realign (#652)

### DIFF
--- a/src/brigade/run_redaction.py
+++ b/src/brigade/run_redaction.py
@@ -1481,20 +1481,97 @@ def _refresh_chained_anchors(
         limit=run_checkpoint.MAX_JOURNAL_BYTES,
         category="journal",
     )
+    # Ownership is asserted even on the no-op path so a stale lock cannot
+    # claim a successful refresh without re-checking active ownership.
+    _assert_active_owner(workspace, run_dir)
     if current == data:
         # Anchor payloads already match the record digests; skip journal and
         # projection rewrites so a second verify/cleanup pass is a no-op.
         return _digest(data)
-    _assert_active_owner(workspace, run_dir)
     _replace_journal(journal_path, data)
     snapshot = _load_json_object(run_dir / "run.json", limit=MAX_RUN_JSON_BYTES, category="run projection")
     _replace_projection(run_dir, _projection(snapshot, rewritten))
     return _digest(data)
 
 
+def _preretirement_parent_record_digest(
+    record: Mapping[str, Any],
+    *,
+    operation_id: str,
+    run_id: str,
+    rewritten_sha256: str,
+) -> str:
+    """Reconstruct the parent record digest from before retirement was recorded.
+
+    During the mid-flight window after the parent record gains
+    ``rewritten_digest_retired_by`` but before the child is realigned, the
+    child's ``parent_record_sha256`` still names this prior digest. The prior
+    record is fully determined by validated parent fields plus the still-present
+    state-side rewritten digest.
+    """
+    return _digest(
+        _record_bytes(
+            operation_id=operation_id,
+            run_id=run_id,
+            sequence_start=record["sequence_start"],
+            sequence_end=record["sequence_end"],
+            reason=record["reason_code"],
+            rewritten_sha256=rewritten_sha256,
+            quarantine_retained=record["quarantine_retained"],
+            parent_operation_id=record.get("parent_operation_id"),
+            parent_record_sha256=record.get("parent_record_sha256"),
+            rewritten_digest_retired_by=None,
+        )
+    )
+
+
+def _accepted_parent_record_digests_for_retirement(
+    *,
+    parent_operation_id: str,
+    run_id: str,
+    parent_record: Mapping[str, Any],
+    parent_state: Mapping[str, Any] | None,
+    current_digest: str | None,
+) -> set[str]:
+    """Return digests a retiring child may name for this parent.
+
+    Always includes the current parent record digest when present. During the
+    validated mid-flight split (record already carries
+    ``rewritten_digest_retired_by``, state still holds ``rewritten_sha256``),
+    also accepts the exact pre-retirement digest reconstructed from those
+    fields. Outside that window only the current digest is accepted.
+    """
+    accepted: set[str] = set()
+    if isinstance(current_digest, str) and re.fullmatch(r"[0-9a-f]{64}", current_digest):
+        accepted.add(current_digest)
+    if parent_state is None:
+        return accepted
+    record_retired_by = parent_record.get("rewritten_digest_retired_by")
+    state_digest = parent_state.get("rewritten_sha256")
+    state_retired_by = parent_state.get("rewritten_digest_retired_by")
+    if (
+        isinstance(record_retired_by, str)
+        and state_retired_by is None
+        and isinstance(state_digest, str)
+        and re.fullmatch(r"[0-9a-f]{64}", state_digest)
+    ):
+        accepted.add(
+            _preretirement_parent_record_digest(
+                parent_record,
+                operation_id=parent_operation_id,
+                run_id=run_id,
+                rewritten_sha256=state_digest,
+            )
+        )
+    return accepted
+
+
 def _validate_lineage_graph(
     records: Mapping[str, Mapping[str, Any]],
     record_digests: Mapping[str, str] | None = None,
+    *,
+    states: Mapping[str, Mapping[str, Any]] | None = None,
+    run_id: str | None = None,
 ) -> None:
     if not records:
         return
@@ -1518,11 +1595,18 @@ def _validate_lineage_graph(
         if retired_by is not None and retired_by != descendants[0]:
             raise RedactionError("redaction lineage retirement mismatch")
         # Digest cross-check applies to split/full retirement edges: the child
-        # must name the parent's current record digest after retirement rewrite.
+        # must name the parent's current record digest after retirement rewrite,
+        # or the exact pre-retirement digest during the mid-flight window only.
         if record_digests is not None and retired_by is not None:
             child = records[descendants[0]]
-            expected = record_digests.get(parent)
-            if expected is None or child.get("parent_record_sha256") != expected:
+            accepted = _accepted_parent_record_digests_for_retirement(
+                parent_operation_id=parent,
+                run_id=run_id or "",
+                parent_record=records[parent],
+                parent_state=None if states is None else states.get(parent),
+                current_digest=record_digests.get(parent),
+            )
+            if child.get("parent_record_sha256") not in accepted:
                 raise RedactionError("redaction lineage digest mismatch")
 
     tips = set(records) - set(children)
@@ -1662,6 +1746,13 @@ def _load_operation_inventory(
                 raise RedactionError("redaction transaction state/record mismatch")
             child_state = states.get(split_retired_by)
             child_record = records.get(split_retired_by)
+            accepted_parent_digests = _accepted_parent_record_digests_for_retirement(
+                parent_operation_id=operation_id,
+                run_id=run_id,
+                parent_record=record,
+                parent_state=state,
+                current_digest=record_digests.get(operation_id),
+            )
             if (
                 split_retired_by != resumable_operation_id
                 or child_state is None
@@ -1669,7 +1760,7 @@ def _load_operation_inventory(
                 or child_state.get("phase") != "cleanup-authorized"
                 or child_state.get("parent_operation_id") != operation_id
                 or child_record.get("parent_operation_id") != operation_id
-                or child_record.get("parent_record_sha256") != record_digests.get(operation_id)
+                or child_record.get("parent_record_sha256") not in accepted_parent_digests
                 or not isinstance(split_digest, str)
                 or not re.fullmatch(r"[0-9a-f]{64}", split_digest)
             ):
@@ -1700,7 +1791,7 @@ def _load_operation_inventory(
                 raise RedactionError("redaction lineage parent reference is invalid")
         elif phase not in {"cleanup-authorized", "cleaned"}:
             raise RedactionError("redaction lineage child quarantine is missing")
-    _validate_lineage_graph(records, record_digests)
+    _validate_lineage_graph(records, record_digests, states=states, run_id=run_id)
     return records, states, record_digests
 
 

--- a/tests/test_run_redaction.py
+++ b/tests/test_run_redaction.py
@@ -1861,6 +1861,77 @@ def test_cleanup_retry_converges_parent_record_state_retirement_split(tmp_path, 
     assert first_digest.encode() not in first_state_path.read_bytes()
 
 
+def test_cleanup_retry_after_parent_retirement_before_child_realign_crash(tmp_path, monkeypatch):
+    """Crash between parent retirement write and child realign must stay recoverable."""
+    run_dir, _, _ = _authority_run(tmp_path)
+    first = run_redaction.redact_journal(
+        run_dir,
+        sequence_start=2,
+        sequence_end=2,
+        reason=REASON_CODE,
+        operator_confirmed=True,
+    )
+    second = run_redaction.redact_journal(
+        run_dir,
+        sequence_start=4,
+        sequence_end=4,
+        reason="personal-data-exposure",
+        operator_confirmed=True,
+    )
+    preretirement_parent_digest = json.loads(second.record_path.read_text())["parent_record_sha256"]
+    real_realign = run_redaction._realign_child_parent_record_digest
+    failed = False
+
+    def fail_after_parent_record_write(*args, **kwargs):
+        nonlocal failed
+        if not failed:
+            failed = True
+            raise run_redaction.RedactionError("simulated child parent-digest realign failure")
+        return real_realign(*args, **kwargs)
+
+    monkeypatch.setattr(run_redaction, "_realign_child_parent_record_digest", fail_after_parent_record_write)
+    with pytest.raises(run_redaction.RedactionError, match="parent-digest realign"):
+        run_redaction.cleanup_redaction_quarantine(
+            run_dir,
+            operation_id=second.operation_id,
+            operator_confirmed=True,
+        )
+
+    assert not second.quarantine_path.exists()
+    assert json.loads((second.record_path.parent / "state.json").read_text())["phase"] == "cleanup-authorized"
+    assert json.loads(first.record_path.read_text())["rewritten_digest_retired_by"] == second.operation_id
+    assert json.loads(second.record_path.read_text())["parent_record_sha256"] == preretirement_parent_digest
+    current_parent_digest = run_redaction._redaction_record_sha256(first.record_path)
+    assert current_parent_digest != preretirement_parent_digest
+    first_state = json.loads((first.record_path.parent / "state.json").read_text())
+    assert "rewritten_sha256" in first_state
+    assert first_state.get("rewritten_digest_retired_by") is None
+
+    # Retry inventory load must accept the mid-flight split (pre-retirement child
+    # parent_record_sha256) instead of permanently fail-closing the lineage.
+    records, states, record_digests = run_redaction._load_operation_inventory(
+        run_dir / "events" / "redactions",
+        run_dir.name,
+        resumable_operation_id=second.operation_id,
+    )
+    assert first.operation_id in records
+    assert second.operation_id in records
+    assert records[second.operation_id]["parent_record_sha256"] == preretirement_parent_digest
+    assert record_digests[first.operation_id] == current_parent_digest
+    assert states[second.operation_id]["phase"] == "cleanup-authorized"
+
+    monkeypatch.setattr(run_redaction, "_realign_child_parent_record_digest", real_realign)
+    cleaned = run_redaction.cleanup_redaction_quarantine(
+        run_dir,
+        operation_id=second.operation_id,
+        operator_confirmed=True,
+    )
+    assert cleaned.cleaned is True
+    assert json.loads(second.record_path.read_text())["parent_record_sha256"] == run_redaction._redaction_record_sha256(
+        first.record_path
+    )
+
+
 def test_cleanup_retry_finishes_after_child_record_before_cleaned_state(tmp_path, monkeypatch):
     run_dir, _, _ = _authority_run(tmp_path)
     first = run_redaction.redact_journal(
@@ -1989,6 +2060,57 @@ def test_second_cleanup_verify_pass_performs_zero_anchor_refresh_writes(tmp_path
     )
     assert again.cleaned is True
     assert writes == []
+
+
+def test_refresh_chained_anchors_asserts_owner_on_noop_early_return(tmp_path, monkeypatch):
+    """No-op anchor refresh must still call _assert_active_owner before returning."""
+    run_dir, _, _ = _authority_run(tmp_path)
+    workspace = tmp_path / "workspace"
+    report = run_redaction.redact_journal(
+        run_dir,
+        sequence_start=2,
+        sequence_end=2,
+        reason=REASON_CODE,
+        operator_confirmed=True,
+    )
+    cleaned = run_redaction.cleanup_redaction_quarantine(
+        run_dir,
+        operation_id=report.operation_id,
+        operator_confirmed=True,
+    )
+    assert cleaned.cleaned is True
+
+    owner_calls: list[tuple[Path, Path]] = []
+
+    def track_owner(workspace_arg, run_dir_arg):
+        owner_calls.append((workspace_arg, run_dir_arg))
+
+    journal_writes = 0
+    projection_writes = 0
+
+    def track_journal(path, data):
+        nonlocal journal_writes
+        journal_writes += 1
+        raise AssertionError("no-op refresh must not rewrite the journal")
+
+    def track_projection(run_dir_arg, projection):
+        nonlocal projection_writes
+        projection_writes += 1
+        raise AssertionError("no-op refresh must not rewrite the projection")
+
+    monkeypatch.setattr(run_redaction, "_assert_active_owner", track_owner)
+    monkeypatch.setattr(run_redaction, "_replace_journal", track_journal)
+    monkeypatch.setattr(run_redaction, "_replace_projection", track_projection)
+
+    digest = run_redaction._refresh_chained_anchors(
+        run_dir,
+        workspace=workspace,
+        resumable_operation_id=report.operation_id,
+    )
+    assert isinstance(digest, str) and len(digest) == 64
+    assert owner_calls == [(workspace, run_dir)]
+    assert journal_writes == 0
+    assert projection_writes == 0
 
 
 def test_tampered_split_retirement_record_fails_digest_cross_check(tmp_path):


### PR DESCRIPTION
## Summary

- Keep run-redaction lineage retryable if cleanup stops after the parent retirement record write and before child digest realignment.
- Accept the exact pre-retirement parent record digest only when validated record and state markers identify that in-flight split.
- Assert active ownership before `_refresh_chained_anchors` returns from its no-op path.

## Issue mapping

- Crash between parent retirement and child realignment: `test_cleanup_retry_after_parent_retirement_before_child_realign_crash`
- Ownership assertion on no-op anchor refresh: `test_refresh_chained_anchors_asserts_owner_on_noop_early_return`
- Existing tamper rejection remains covered by `test_tampered_split_retirement_record_fails_digest_cross_check`.

## Verification

- Brigade receipt `20260801-185244-work-verify-dad88f`: `./scripts/verify`, exit 0
- Result: 5,678 passed, 3 skipped, 83.04% coverage
- Outcome capture completed with signal `+1`. It emitted the known warning that `brigade-work` is not installed, but the receipt was written successfully.

The passing receipt came from a fresh Linux checkout at `5d6e81a6f964c4f014eda869d0a396fc2e84e701` with byte-identical copies of the two changed files. The exact command was first attempted locally, where Windows returned `[WinError 193] %1 is not a valid Win32 application` for the POSIX script.

Fixes #652.