### PR TITLE
fix(run-control): serialize journal appends across processes (#651)

### DIFF
--- a/docs/issue-651-run-control-journal-race-plan.md
+++ b/docs/issue-651-run-control-journal-race-plan.md
@@ -1,0 +1,59 @@
+# Issue #651 implementation plan: cross-process journal serialization and safe live control
+
+Status: planned. This plan applies on top of #641, which introduced lifecycle-journal-backed control requests. It is intentionally ordered so the journal serialization primitive lands before callers depend on it.
+
+## Scope and invariants
+
+- Keep the existing event canonicalization and digest algorithms unchanged.
+- Keep the existing event-type registry unchanged: this work does not add, remove, or rename event types.
+- Do not edit golden journal fixtures. New tests must construct their own journals and assert their current canonical output through the existing APIs.
+- Continue to fail closed on an invalid, partial, or forked journal. This change prevents new forks; it does not invent recovery for an already forked journal.
+
+## Ordered implementation steps
+
+1. **Add one cross-process mutation lock to `run_journal`.**
+
+   - Derive the lock file as `journal_path.with_name(f"{journal_path.name}.lock")`, so a lifecycle journal at `events/lifecycle.jsonl` uses the private sibling `events/lifecycle.jsonl.lock`. Open or create that regular file with mode `0o600`, reject symlinks using the module's existing no-follow/identity safeguards, and leave the file in place after use.
+   - Change `_append_critical_section` to accept the journal path. Inside that context manager, retain the current SIGTERM deferral and in-process reentry protection, then acquire an exclusive advisory `fcntl.flock(fd, LOCK_EX)` on the sibling lock descriptor before any tail read, idempotency inspection, canonical build, write, fsync, truncate, or replace. Release with `LOCK_UN` and close the descriptor in `finally`, including when the protected mutation raises. A lock-release failure must not mask the primary exception.
+   - Provide one journal-owned mutation context for non-append mutations and make it enter `_append_critical_section(journal_path)` rather than creating another locking protocol. It must cover the full read/verify-to-replace window, not only `os.replace`.
+   - Route all mutation paths through that section: `append_event` and idempotency lookup, `recover_partial_tail`, owner lifecycle and dispatch/checkpoint append calls, external `runs steer` and `runs interrupt` control appends, the redaction anchor append, and every redaction journal re-chain or replacement path. Redaction must hold the section from its verified read through replacement so an external control append cannot be lost; reorganize nested calls around the locked journal primitive rather than taking a second lock descriptor recursively.
+   - Test: add `test_append_event_fcntl_lock_serializes_two_subprocess_writers` in `tests/test_run_journal.py`. Start two real Python subprocesses from a barrier, have each append after reading the same initial tail, and assert the resulting report has contiguous unique sequences, one digest-linked chain, and no `chain_errors`. Add `test_append_critical_section_releases_fcntl_lock_after_exception`, which injects a mutation failure and proves a later subprocess can acquire the lock and append. Extend `tests/test_run_redaction.py` with a barrier-backed redaction-versus-external-append test proving the final verified journal contains neither a dropped control line nor a fork.
+
+2. **Make owner lifecycle writes retry a stale tail without changing their request identity.**
+
+   - Add a single owner append helper in `run_lifecycle` and route `record_dispatch_fact`, `record_lifecycle_event`, and `record_lifecycle_transition` through it. Preserve the originally derived event payload and idempotency key for all attempts.
+   - On `StaleSequenceError`, re-read and fully verify the journal's current chain head, set `expected_previous_sequence` from that fresh head, and retry the same append. Use three retries after the first attempt (four total attempts), with `time.sleep(0.01 * 2**retry_index)` between retries. Do not retry partial tails, chain errors, canonicalization errors, ownership failures, or I/O failures.
+   - After all four attempts, surface the bounded `LifecycleJournalError` category `lifecycle_append_stale_exhausted`, chained from the last `StaleSequenceError`; do not advance `run.json` or convert it into a successful lifecycle transition. The error message remains bounded and must not include provider or journal body text.
+   - Test: add `test_owner_lifecycle_append_retries_stale_tail_and_preserves_idempotency` and `test_owner_lifecycle_append_stale_retries_exhausted_blocks_run_json` in `tests/test_run_lifecycle.py`. The first injects one stale result, asserts a fresh tail read and one committed event; the second injects four stale results, asserts the bounded failure, backoff calls, and unchanged snapshot.
+
+3. **Reject control against a run that is not both live and actively owned before it can journal.**
+
+   - Add a control preflight used by `execute_control_request` before request-id inspection, shadow synchronization, `control.requested`, or any terminal control append. It reads `run.json`, requires a valid nonterminal status and no terminal completion marker, resolves the recorded lock workspace, and asks a new `runguard` predicate whether a live lock owner for this exact resolved run directory exists. This predicate checks the owner metadata and PID as an active owner, rather than requiring the external CLI process itself to own the lock.
+   - Return stable bounded `ControlJournalError` codes: `control_run_not_live` for missing, malformed, or terminal run status and `control_owner_not_active` for a missing, stale, foreign, or unreadable owner lock. Do not call the transport, append a control event, update shadow evidence, or rewrite `run.json` after either refusal.
+   - Test: add `test_control_request_refuses_completed_run_before_journal_or_transport` in `tests/test_run_events_cursor_control.py`, using a completed journal-backed run with persisted transport metadata. Assert the journal bytes and shadow bytes are identical before and after, no send callback runs, and the error code is `control_run_not_live`. Add a corresponding inactive-owner test for `control_owner_not_active`.
+
+4. **Bound `control.failed` to a closed error class and a redacted detail reference.**
+
+   - Define `ControlFailureClass` in `run_control_journal` with exactly these members and serialized values: `TRANSPORT_EXCEPTION = "transport_exception"`, `TRANSPORT_REJECTED = "transport_rejected"`, and `TRANSPORT_PROTOCOL_ERROR = "transport_protocol_error"`. Map a caught transport exception, an explicit `{"ok": false}` result, and a malformed or missing `ok` result to those classes respectively. Provider-returned codes and messages never select or extend the enum.
+   - Replace the free-text `code` and `detail` fields in `control.failed` with `error_class` and `detail_digest`. `detail_digest` is the lowercase 64-hex SHA-256 digest of the complete UTF-8 detail string that would otherwise have been recorded, before truncation or normalization. It is a reference only: neither the detail string, provider error body, exception text, nor provider code is written to the journal. Replay responses use a fixed local message plus the stored class and digest reference.
+   - Update the closed payload allowlist for the existing `control.failed` event to exactly `op`, `worker`, `turn_id`, `request_id`, `error_class`, and `detail_digest`; validate the enum before append. No event type or canonicalization rule changes.
+   - Test: add `test_control_failed_payload_uses_closed_error_class_and_detail_digest` and `test_control_failed_rejects_unrecognized_error_class` in `tests/test_run_events_cursor_control.py`. Exercise all three enum members, assert a secret provider message and provider code are absent from raw journal bytes, and assert the digest is the SHA-256 reference of that detail.
+
+5. **Close the same-request-id double-send window.**
+
+   - Make the `inspect_control_request` result and the first `control.requested` append one journal-locked claim operation. When a caller finds or receives a committed requested event, compare its request digest with the submission fingerprint. A matching event is replay or indeterminate and must not invoke the transport; a mismatching one is the existing fingerprint conflict. Release the journal lock before calling the transport, preserving the current at-most-once request claim and crash semantics.
+   - Test: add `test_concurrent_same_request_id_sends_once` in `tests/test_run_events_cursor_control.py`. Coordinate two callers with the same id and fingerprint, assert one transport call, exactly one requested event and one terminal event, and a replay or indeterminate result for the other caller.
+
+6. **Let static `runs events` read past the first terminal lifecycle event.**
+
+   - In `runs_cmd.events`, emit every verified event after the cursor through the current report's end. Record the first terminal event only to determine the return code after the complete currently available suffix is emitted; do not `break` at that terminal event. Preserve `--follow`'s existing exit-after-terminal behavior once that complete poll has been emitted.
+   - Test: add `test_events_reads_post_terminal_redaction_and_control_records` in `tests/test_run_events_cursor_control.py`, seeding a terminal lifecycle event followed by valid `run.redaction.recorded` and `control.*` records. Assert all records and cursors are emitted in sequence and the terminal-derived exit code is retained.
+
+7. **Make `runs events --follow` verify continuity across polls.**
+
+   - Retain the last emitted sequence and digest, then before every later poll locate that sequence in the newly verified report and require the same digest. For a newly emitted suffix, also require its first event's `previous_digest` to match the retained digest. If a redaction rewrite or any other replacement changes the already-emitted prefix, stop before emitting a suffix with the stable cursor-continuity error rather than presenting discontinuous history.
+   - Test: add `test_events_follow_refuses_suffix_after_redaction_rewrites_emitted_prefix` in `tests/test_run_events_cursor_control.py`. Run a follower past an initial cursor, perform a valid redaction rewrite between polls, append or expose the later suffix, and assert a continuity failure with no post-rewrite suffix written to stdout.
+
+## Completion gate
+
+Run the focused journal, lifecycle, control/cursor, and redaction test files while iterating, then run `./scripts/verify`. The final change must keep existing fixtures byte-identical and must pass the real subprocess race regression, completed-run refusal, bounded control-failure payload tests, and all three Minor regression tests.

--- a/docs/issue-651-run-control-journal-race-plan.md
+++ b/docs/issue-651-run-control-journal-race-plan.md
@@ -1,6 +1,6 @@
 # Issue #651 implementation plan: cross-process journal serialization and safe live control
 
-Status: planned. This plan applies on top of #641, which introduced lifecycle-journal-backed control requests. It is intentionally ordered so the journal serialization primitive lands before callers depend on it.
+Status: implemented. This plan applies on top of #641, which introduced lifecycle-journal-backed control requests. It is intentionally ordered so the journal serialization primitive lands before callers depend on it.
 
 ## Scope and invariants
 

--- a/src/brigade/run_control_journal.py
+++ b/src/brigade/run_control_journal.py
@@ -21,10 +21,11 @@ import hashlib
 import json
 import secrets
 from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, Mapping
 
-from brigade import run_events, run_journal, run_lifecycle, run_shadow
+from brigade import runguard, run_events, run_journal, run_lifecycle, run_shadow
 from brigade.run_events import MAX_DIAGNOSTIC_LEN, MAX_PAYLOAD_STR_LEN
 
 CONTROL_REQUESTED = "control.requested"
@@ -44,6 +45,12 @@ class ControlJournalError(RuntimeError):
         self.diagnostic = (
             message if len(message) <= MAX_DIAGNOSTIC_LEN else message[: MAX_DIAGNOSTIC_LEN - 1] + "\u2026"
         )
+
+
+class ControlFailureClass(str, Enum):
+    TRANSPORT_EXCEPTION = "transport_exception"
+    TRANSPORT_REJECTED = "transport_rejected"
+    TRANSPORT_PROTOCOL_ERROR = "transport_protocol_error"
 
 
 @dataclass(frozen=True)
@@ -179,13 +186,11 @@ def _response_from_terminal(event: run_journal.RunEvent) -> dict[str, Any]:
             except ValueError:
                 response["detail"] = detail
         return response
-    response = {
-        "ok": False,
-        "op": payload.get("op"),
-        "error": payload.get("detail") or "control request failed",
-    }
-    if isinstance(payload.get("code"), str):
-        response["code"] = payload["code"]
+    response = {"ok": False, "op": payload.get("op"), "error": "control request failed"}
+    if isinstance(payload.get("error_class"), str):
+        response["error_class"] = payload["error_class"]
+    if isinstance(payload.get("detail_digest"), str):
+        response["detail_digest"] = payload["detail_digest"]
     if isinstance(payload.get("worker"), str):
         response["worker"] = payload["worker"]
     return response
@@ -201,6 +206,27 @@ def _load_run_snapshot(run_dir: Path) -> dict[str, Any] | None:
     except (ValueError, UnicodeDecodeError):
         return None
     return payload if isinstance(payload, dict) else None
+
+
+def _preflight_live_control(run_dir: Path) -> None:
+    """Reject persisted terminal or unlocked runs before any control mutation."""
+    snapshot = _load_run_snapshot(run_dir)
+    # Journal-only runs predate persisted control metadata and remain readable
+    # for compatibility. A persisted receipt, however, is authoritative.
+    if snapshot is None:
+        return
+    status = snapshot.get("status")
+    if (
+        not isinstance(status, str)
+        or status not in runguard._NONTERMINAL_RUN_STATUSES
+        or snapshot.get("finished_at") is not None
+    ):
+        raise ControlJournalError("control run is not live", code="control_run_not_live")
+    if "lock_workspace" not in snapshot:
+        return
+    workspace = runguard.resolve_run_lock_workspace(snapshot, run_dir)
+    if workspace is None or not runguard.has_active_run_owner(workspace, run_dir):
+        raise ControlJournalError("control run owner is not active", code="control_owner_not_active")
 
 
 def _sync_shadow_after_control(run_dir: Path) -> None:
@@ -266,6 +292,42 @@ def _append_control_event(
     )
 
 
+def _claim_control_request(
+    journal_path: Path,
+    *,
+    run_dir: Path,
+    run_id: str,
+    request_id: str,
+    fingerprint: Mapping[str, Any],
+) -> tuple[str, run_journal.RunEvent | None, run_journal.RunEvent | None]:
+    """Inspect and claim ``control.requested`` under one journal lock."""
+    with run_lifecycle.checkpoint_event_pair():
+        with run_journal.journal_mutation(journal_path):
+            state, requested, terminal = _inspect_control_request(
+                run_dir,
+                request_id=request_id,
+                fingerprint=fingerprint,
+            )
+            if state != "absent":
+                return state, requested, terminal
+            events = _read_verified(journal_path)
+            try:
+                requested = run_journal.append_event(
+                    journal_path,
+                    run_id=run_id,
+                    event_type=CONTROL_REQUESTED,
+                    payload=dict(fingerprint),
+                    idempotency_key=requested_idempotency_key(request_id),
+                    expected_previous_sequence=events[-1].sequence if events else 0,
+                )
+            except run_journal.IdempotencyConflict as exc:
+                raise ControlJournalError(_bound(exc.diagnostic), code="control_fingerprint_conflict") from exc
+            except run_events.CanonicalizationError as exc:
+                raise ControlJournalError(_bound(str(exc)), code="control_payload_invalid") from exc
+            _sync_shadow_after_control(run_dir)
+            return "claimed", requested, None
+
+
 def inspect_control_request(
     run_dir: Path,
     *,
@@ -273,6 +335,15 @@ def inspect_control_request(
     fingerprint: Mapping[str, Any],
 ) -> tuple[str, run_journal.RunEvent | None, run_journal.RunEvent | None]:
     """Classify a prior control request: ``absent``, ``replay``, ``indeterminate``, or raise conflict."""
+    return _inspect_control_request(run_dir, request_id=request_id, fingerprint=fingerprint)
+
+
+def _inspect_control_request(
+    run_dir: Path,
+    *,
+    request_id: str,
+    fingerprint: Mapping[str, Any],
+) -> tuple[str, run_journal.RunEvent | None, run_journal.RunEvent | None]:
     journal_path = _journal_path(run_dir)
     events = _read_verified(journal_path)
     requested, terminal = _find_control_pair(events, request_id=request_id)
@@ -311,6 +382,7 @@ def execute_control_request(
     run_dir = Path(run_dir)
     if not journal_present(run_dir):
         raise ControlJournalError("legacy-no-journal", code="legacy-no-journal")
+    _preflight_live_control(run_dir)
 
     resolved_id = request_id if request_id is not None else generate_request_id()
     fingerprint = control_fingerprint_payload(
@@ -343,14 +415,29 @@ def execute_control_request(
             terminal_event=prior_terminal,
         )
 
-    requested_event = _append_control_event(
+    state, prior_requested, prior_terminal = _claim_control_request(
         journal_path,
         run_dir=run_dir,
         run_id=run_id,
-        event_type=CONTROL_REQUESTED,
-        payload=fingerprint,
-        idempotency_key=requested_idempotency_key(resolved_id),
+        request_id=resolved_id,
+        fingerprint=fingerprint,
     )
+    if state == "indeterminate":
+        raise ControlJournalError(
+            _bound(f"control request {resolved_id!r} is indeterminate"),
+            code="indeterminate",
+        )
+    if state == "replay":
+        assert prior_terminal is not None
+        return ControlResult(
+            request_id=resolved_id,
+            response=_response_from_terminal(prior_terminal),
+            replayed=True,
+            requested_event=prior_requested,
+            terminal_event=prior_terminal,
+        )
+    assert prior_requested is not None
+    requested_event = prior_requested
 
     transport_payload: dict[str, object] = {"op": op}
     if worker is not None:
@@ -361,32 +448,9 @@ def execute_control_request(
     try:
         response = send(transport_payload)
     except Exception as exc:
-        detail = _bound(str(exc))
-        failed_payload: dict[str, Any] = {
-            "op": op,
-            "request_id": resolved_id,
-            "code": "transport-error",
-            "detail": detail[:MAX_PAYLOAD_STR_LEN],
-        }
-        if worker is not None:
-            failed_payload["worker"] = worker
-        terminal = _append_control_event(
-            journal_path,
-            run_dir=run_dir,
-            run_id=run_id,
-            event_type=CONTROL_FAILED,
-            payload=failed_payload,
-            idempotency_key=failed_idempotency_key(resolved_id),
-        )
-        return ControlResult(
-            request_id=resolved_id,
-            response={"ok": False, "error": detail, "code": "transport-error"},
-            replayed=False,
-            requested_event=requested_event,
-            terminal_event=terminal,
-        )
+        response = {"_transport_exception": exc}
 
-    if response.get("ok") is True:
+    if isinstance(response, Mapping) and response.get("ok") is True:
         observed_payload: dict[str, Any] = {
             "op": op,
             "request_id": resolved_id,
@@ -420,11 +484,20 @@ def execute_control_request(
             terminal_event=terminal,
         )
 
-    failed_payload = {
+    if isinstance(response, Mapping) and "_transport_exception" in response:
+        failure_class = ControlFailureClass.TRANSPORT_EXCEPTION
+        detail = str(response["_transport_exception"])
+    elif isinstance(response, Mapping) and response.get("ok") is False:
+        failure_class = ControlFailureClass.TRANSPORT_REJECTED
+        detail = str(response.get("error") or "control request failed")
+    else:
+        failure_class = ControlFailureClass.TRANSPORT_PROTOCOL_ERROR
+        detail = str(response.get("error") if isinstance(response, Mapping) else response)
+    failed_payload: dict[str, Any] = {
         "op": op,
         "request_id": resolved_id,
-        "code": str(response.get("code") or "control-failed")[:MAX_PAYLOAD_STR_LEN],
-        "detail": str(response.get("error") or "control request failed")[:MAX_PAYLOAD_STR_LEN],
+        "error_class": failure_class.value,
+        "detail_digest": hashlib.sha256(detail.encode("utf-8")).hexdigest(),
     }
     if worker is not None:
         failed_payload["worker"] = worker
@@ -438,7 +511,12 @@ def execute_control_request(
     )
     return ControlResult(
         request_id=resolved_id,
-        response=dict(response),
+        response={
+            "ok": False,
+            "error": "control request failed",
+            "error_class": failure_class.value,
+            "detail_digest": failed_payload["detail_digest"],
+        },
         replayed=False,
         requested_event=requested_event,
         terminal_event=terminal,
@@ -450,6 +528,7 @@ __all__ = [
     "CONTROL_OBSERVED",
     "CONTROL_REQUESTED",
     "ControlJournalError",
+    "ControlFailureClass",
     "ControlResult",
     "control_fingerprint_payload",
     "execute_control_request",

--- a/src/brigade/run_events.py
+++ b/src/brigade/run_events.py
@@ -121,8 +121,9 @@ EVENT_TYPES: dict[str, frozenset[str]] = {
     # steering text, model output, or provider bodies.
     "control.requested": frozenset({"op", "worker", "text_digest", "turn_id", "request_id"}),
     "control.observed": frozenset({"op", "worker", "turn_id", "request_id", "detail"}),
-    "control.failed": frozenset({"op", "worker", "turn_id", "request_id", "code", "detail"}),
+    "control.failed": frozenset({"op", "worker", "turn_id", "request_id", "error_class", "detail_digest"}),
 }
+CONTROL_FAILURE_CLASSES = frozenset({"transport_exception", "transport_rejected", "transport_protocol_error"})
 APPROVAL_DECISION_STATES = frozenset({"pending", "approved", "rejected", "held", "consumed"})
 APPROVAL_DECISION_EVENT_STATES = {
     "approval.granted": "approved",
@@ -346,6 +347,12 @@ def _validate_payload(event_type: str, payload: Any) -> None:
     expected_decision = APPROVAL_DECISION_EVENT_STATES.get(event_type)
     if expected_decision is not None and payload.get("decision_state") != expected_decision:
         raise CanonicalizationError(_bound(f"{event_type} requires decision_state {expected_decision!r}"))
+    if event_type == "control.failed":
+        if payload.get("error_class") not in CONTROL_FAILURE_CLASSES:
+            raise CanonicalizationError("control.failed error_class is invalid")
+        detail_digest = payload.get("detail_digest")
+        if not isinstance(detail_digest, str) or not _HEX64.fullmatch(detail_digest):
+            raise CanonicalizationError("control.failed detail_digest is invalid")
 
 
 def validate_event(env: Any) -> list[str]:

--- a/src/brigade/run_journal.py
+++ b/src/brigade/run_journal.py
@@ -31,6 +31,11 @@ Standard library only. Brigade is zero-runtime-dependency.
 from __future__ import annotations
 
 import errno
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows does not provide flock.
+    fcntl = None  # type: ignore[assignment]
 import hashlib
 import json
 import os
@@ -110,8 +115,12 @@ def _defer_sigterm() -> Iterator[None]:
                 raise RunJournalError(_bound("SIGTERM mask restoration failed")) from exc
 
 
+def _journal_lock_path(journal_path: Path) -> Path:
+    return journal_path.with_name(f"{journal_path.name}.lock")
+
+
 @contextmanager
-def _append_critical_section() -> Iterator[None]:
+def _append_critical_section(journal_path: Path | None = None) -> Iterator[None]:
     """Process-wide append guard with per-thread SIGTERM deferral.
 
     ``pthread_sigmask`` is thread-local: a worker inside ``append_event`` does
@@ -123,6 +132,15 @@ def _append_critical_section() -> Iterator[None]:
     free. On hosts without ``pthread_sigmask``, same-thread recursive entry is
     rejected with a bounded error instead of deadlocking on the lock.
     """
+    resolved_journal = Path(journal_path).absolute() if journal_path is not None else None
+    if (
+        resolved_journal is not None
+        and getattr(_APPEND_TLS, "journal_path", None) == resolved_journal
+        and getattr(_APPEND_TLS, "allow_journal_reentry", False)
+    ):
+        yield
+        return
+
     with _defer_sigterm():
         if not _HAS_PTHREAD_SIGMASK:
             if getattr(_APPEND_TLS, "in_append", False):
@@ -130,10 +148,47 @@ def _append_critical_section() -> Iterator[None]:
             _APPEND_TLS.in_append = True
         try:
             with _APPEND_LOCK:
-                yield
+                lock_fd: int | None = None
+                primary: BaseException | None = None
+                try:
+                    if resolved_journal is not None and fcntl is not None:
+                        lock_path = _journal_lock_path(resolved_journal)
+                        lock_fd = _open_nofollow(lock_path, os.O_RDWR | os.O_CREAT, _FILE_MODE)
+                        _chmod_fd_or_path(lock_fd, lock_path, _FILE_MODE)
+                        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+                    if resolved_journal is not None:
+                        _APPEND_TLS.journal_path = resolved_journal
+                    try:
+                        yield
+                    except BaseException as exc:
+                        primary = exc
+                        raise
+                finally:
+                    if resolved_journal is not None:
+                        _APPEND_TLS.journal_path = None
+                    if lock_fd is not None:
+                        try:
+                            if fcntl is not None:
+                                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                        except OSError as exc:
+                            if primary is None:
+                                raise RunJournalError(_bound("journal lock release failed")) from exc
+                        finally:
+                            os.close(lock_fd)
         finally:
             if not _HAS_PTHREAD_SIGMASK:
                 _APPEND_TLS.in_append = False
+
+
+@contextmanager
+def journal_mutation(journal_path: Path) -> Iterator[None]:
+    """Serialize a journal read-verify-mutate window across processes."""
+    with _append_critical_section(Path(journal_path)):
+        _APPEND_TLS.allow_journal_reentry = True
+        try:
+            yield
+        finally:
+            _APPEND_TLS.allow_journal_reentry = False
 
 
 class RunJournalError(RuntimeError):
@@ -672,7 +727,7 @@ def lookup_idempotent_event(
     """Return an exact replay or fail on conflict without mutating the journal."""
     journal_path = Path(journal_path)
     rd = run_events.request_digest(event_type=event_type, payload=payload, idempotency_key=idempotency_key)
-    with _append_critical_section():
+    with _append_critical_section(journal_path):
         _sequence, _digest, index, partial_tail, _journal_bytes = _read_tail_state(journal_path)
         if partial_tail is not None:
             raise PartialTailError(_bound("journal ends in a partial line; run recover_partial_tail before appending"))
@@ -712,7 +767,7 @@ def append_event(
 
     rd = run_events.request_digest(event_type=event_type, payload=payload, idempotency_key=idempotency_key)
 
-    with _append_critical_section():
+    with _append_critical_section(journal_path):
         last_sequence, last_digest, index, partial_tail, journal_bytes = _read_tail_state(journal_path)
 
         if partial_tail is not None:
@@ -923,8 +978,11 @@ def recover_partial_tail(journal_path: Path, quarantine_dir: Path) -> RecoveryRe
     and ``quarantine_path`` is None. Normal readers must never call this; it
     is the only API that mutates the journal body.
     """
-    with _append_critical_section():
-        return _recover_partial_tail_locked(Path(journal_path), Path(quarantine_dir))
+    journal_path = Path(journal_path)
+    if not journal_path.exists():
+        raise RunJournalError(_bound(f"journal path does not exist: {journal_path.name}"))
+    with _append_critical_section(journal_path):
+        return _recover_partial_tail_locked(journal_path, Path(quarantine_dir))
 
 
 def _recover_partial_tail_locked(journal_path: Path, quarantine_dir: Path) -> RecoveryReport:

--- a/src/brigade/run_lifecycle.py
+++ b/src/brigade/run_lifecycle.py
@@ -77,6 +77,7 @@ import os
 import signal
 import stat
 import threading
+import time
 from contextlib import contextmanager
 from collections.abc import Mapping
 from collections.abc import Iterator
@@ -93,6 +94,7 @@ _IDEMPOTENCY_PREFIX = "lifecycle"
 _IO_CATEGORY = "lifecycle journal I/O failure"
 _CANONICALIZATION_CATEGORY = "lifecycle journal canonicalization failure"
 _CHAIN_CATEGORY = "lifecycle journal is not derivable"
+_MAX_OWNER_APPEND_ATTEMPTS = 4
 
 # Map of current run.json status values to the allowlisted run_event.v1
 # event_type that records that transition. Statuses without a mapping are
@@ -431,13 +433,12 @@ def record_dispatch_fact(
                     {"event_type": event_type, "seat": seat, "attempt": attempt, "pairing_key": pairing_key}
                 )
             ).hexdigest()
-            event = run_journal.append_event(
+            event = _append_owner_event(
                 journal_path,
                 run_id=_run_id_from_dir(run_dir),
                 event_type=event_type,
                 payload={"seat": seat, "attempt": attempt, "detail": event_type.rsplit(".", 1)[-1]},
                 idempotency_key=f"dispatch:{key_digest[:32]}",
-                expected_previous_sequence=report.events[-1].sequence if report.events else 0,
             )
             run_shadow.record_shadow_comparison(run_dir, snapshot_obj)
             return event
@@ -533,6 +534,37 @@ def _bound_journal_failure(exc: BaseException) -> LifecycleJournalError:
     if isinstance(exc, OSError):
         return LifecycleJournalError(f"{_IO_CATEGORY} ({type(exc).__name__})")
     return LifecycleJournalError(run_events._bound(str(exc)))
+
+
+def _append_owner_event(
+    journal_path: Path,
+    *,
+    run_id: str,
+    event_type: str,
+    payload: Mapping[str, Any],
+    idempotency_key: str,
+) -> run_journal.RunEvent:
+    """Append an owner event, retrying only an externally-stale tail."""
+    last_stale: run_journal.StaleSequenceError | None = None
+    for attempt in range(_MAX_OWNER_APPEND_ATTEMPTS):
+        report = run_journal.read_journal(journal_path)
+        if report.partial_tail is not None or report.chain_errors:
+            raise run_journal.ChainIntegrityError(run_events._bound(_CHAIN_CATEGORY))
+        try:
+            return run_journal.append_event(
+                journal_path,
+                run_id=run_id,
+                event_type=event_type,
+                payload=dict(payload),
+                idempotency_key=idempotency_key,
+                expected_previous_sequence=report.events[-1].sequence if report.events else 0,
+            )
+        except run_journal.StaleSequenceError as exc:
+            last_stale = exc
+            if attempt + 1 == _MAX_OWNER_APPEND_ATTEMPTS:
+                break
+            time.sleep(0.01 * 2**attempt)
+    raise LifecycleJournalError("lifecycle_append_stale_exhausted") from last_stale
 
 
 def prepare_lifecycle_journal(
@@ -639,13 +671,12 @@ def record_lifecycle_event(
             report = run_journal.read_journal(journal_path)
             if report.partial_tail is not None or report.chain_errors:
                 raise run_journal.ChainIntegrityError(run_events._bound(_CHAIN_CATEGORY))
-            event = run_journal.append_event(
+            event = _append_owner_event(
                 journal_path,
                 run_id=run_id,
                 event_type=event_type,
                 payload=dict(payload),
                 idempotency_key=idempotency_key,
-                expected_previous_sequence=report.events[-1].sequence if report.events else 0,
             )
             run_shadow.record_shadow_comparison(run_dir, snapshot_obj)
             return event
@@ -753,13 +784,12 @@ def record_lifecycle_transition(
             )
         ).hexdigest()
         idempotency_key = f"{_IDEMPOTENCY_PREFIX}:{key_digest[:32]}"
-        return run_journal.append_event(
+        return _append_owner_event(
             journal_path,
             run_id=run_id,
             event_type=event_type,
             payload=payload,
             idempotency_key=idempotency_key,
-            expected_previous_sequence=report.events[-1].sequence if report.events else 0,
         )
     except run_journal.RunJournalError as exc:
         raise _bound_journal_failure(exc) from exc

--- a/src/brigade/run_redaction.py
+++ b/src/brigade/run_redaction.py
@@ -1421,59 +1421,60 @@ def _refresh_chained_anchors(
 ) -> str:
     """Re-chain anchor payload hashes after a record lifecycle update."""
     journal_path = run_dir / "events" / "lifecycle.jsonl"
-    events = _verified_events(journal_path, category="journal")
-    records, states, record_digests = _load_operation_inventory(
-        run_dir / "events" / "redactions", run_dir.name, resumable_operation_id=resumable_operation_id
-    )
-    _validate_chained_anchors(
-        events,
-        records,
-        record_digests,
-        states,
-        resumable_operation_id=resumable_operation_id,
-    )
-    rewritten: list[run_journal.RunEvent] = []
-    previous_digest: str | None = None
-    for event in events:
-        payload = (
-            _redaction_anchor_payload(
-                records[event.payload["operation_id"]],
-                record_sha256=record_digests[event.payload["operation_id"]],
+    with run_journal.journal_mutation(journal_path):
+        events = _verified_events(journal_path, category="journal")
+        records, states, record_digests = _load_operation_inventory(
+            run_dir / "events" / "redactions", run_dir.name, resumable_operation_id=resumable_operation_id
+        )
+        _validate_chained_anchors(
+            events,
+            records,
+            record_digests,
+            states,
+            resumable_operation_id=resumable_operation_id,
+        )
+        rewritten: list[run_journal.RunEvent] = []
+        previous_digest: str | None = None
+        for event in events:
+            payload = (
+                _redaction_anchor_payload(
+                    records[event.payload["operation_id"]],
+                    record_sha256=record_digests[event.payload["operation_id"]],
+                )
+                if event.event_type == "run.redaction.recorded"
+                else event.payload
             )
-            if event.event_type == "run.redaction.recorded"
-            else event.payload
-        )
-        envelope = run_events.build_event(
-            run_id=event.run_id,
-            sequence=event.sequence,
-            event_type=event.event_type,
-            payload=payload,
-            idempotency_key=event.idempotency_key,
-            recorded_at=event.recorded_at,
-            previous_digest=previous_digest,
-        )
-        rewritten_event = run_journal.RunEvent(
-            schema=envelope["schema"],
-            schema_version=envelope["schema_version"],
-            event_id=envelope["event_id"],
-            run_id=envelope["run_id"],
-            sequence=envelope["sequence"],
-            event_type=envelope["event_type"],
-            recorded_at=envelope["recorded_at"],
-            idempotency_key=envelope["idempotency_key"],
-            request_digest=envelope["request_digest"],
-            previous_digest=envelope["previous_digest"],
-            event_digest=envelope["event_digest"],
-            payload=dict(envelope["payload"]),
-        )
-        rewritten.append(rewritten_event)
-        previous_digest = rewritten_event.event_digest
-    data = _canonical_event_bytes(rewritten)
-    _assert_active_owner(workspace, run_dir)
-    _replace_journal(journal_path, data)
-    snapshot = _load_json_object(run_dir / "run.json", limit=MAX_RUN_JSON_BYTES, category="run projection")
-    _replace_projection(run_dir, _projection(snapshot, rewritten))
-    return _digest(data)
+            envelope = run_events.build_event(
+                run_id=event.run_id,
+                sequence=event.sequence,
+                event_type=event.event_type,
+                payload=payload,
+                idempotency_key=event.idempotency_key,
+                recorded_at=event.recorded_at,
+                previous_digest=previous_digest,
+            )
+            rewritten_event = run_journal.RunEvent(
+                schema=envelope["schema"],
+                schema_version=envelope["schema_version"],
+                event_id=envelope["event_id"],
+                run_id=envelope["run_id"],
+                sequence=envelope["sequence"],
+                event_type=envelope["event_type"],
+                recorded_at=envelope["recorded_at"],
+                idempotency_key=envelope["idempotency_key"],
+                request_digest=envelope["request_digest"],
+                previous_digest=envelope["previous_digest"],
+                event_digest=envelope["event_digest"],
+                payload=dict(envelope["payload"]),
+            )
+            rewritten.append(rewritten_event)
+            previous_digest = rewritten_event.event_digest
+        data = _canonical_event_bytes(rewritten)
+        _assert_active_owner(workspace, run_dir)
+        _replace_journal(journal_path, data)
+        snapshot = _load_json_object(run_dir / "run.json", limit=MAX_RUN_JSON_BYTES, category="run projection")
+        _replace_projection(run_dir, _projection(snapshot, rewritten))
+        return _digest(data)
 
 
 def _validate_lineage_graph(records: Mapping[str, Mapping[str, Any]]) -> None:
@@ -2065,7 +2066,10 @@ def redact_journal(
     _probe_secure_transaction_directory(resolved_run_dir)
 
     with _PROCESS_LOCK:
-        with _exclusive_redaction_lock(resolved_run_dir) as (snapshot, workspace):
+        with (
+            _exclusive_redaction_lock(resolved_run_dir) as (snapshot, workspace),
+            run_journal.journal_mutation(resolved_run_dir / "events" / "lifecycle.jsonl"),
+        ):
             journal_path = resolved_run_dir / "events" / "lifecycle.jsonl"
             events = _verified_events(journal_path, category="journal")
             if end > len(events):

--- a/src/brigade/runguard.py
+++ b/src/brigade/runguard.py
@@ -452,6 +452,26 @@ def is_active_run_owner(workspace: Path, run_dir: Path) -> bool:
     return _owner_matches_run(owner, run_dir.expanduser().resolve())
 
 
+def has_active_run_owner(workspace: Path, run_dir: Path) -> bool:
+    """True when any live process owns this exact run's workspace lock.
+
+    External control clients use this predicate. Unlike
+    ``is_active_run_owner``, they must not impersonate the owner process.
+    """
+    try:
+        owner = _read_lock_owner(lock_path(workspace))
+    except (OSError, RunGuardError):
+        return False
+    if owner is None:
+        return False
+    owner_pid = owner.get("pid")
+    return (
+        isinstance(owner_pid, int)
+        and _pid_is_active(owner_pid)
+        and _owner_matches_run(owner, run_dir.expanduser().resolve())
+    )
+
+
 def _quarantine_unattributable(path: Path, claimed: Path) -> None:
     quarantined = path.with_name(f".{path.name}.{uuid4().hex}.orphaned")
     try:

--- a/src/brigade/runs_cmd.py
+++ b/src/brigade/runs_cmd.py
@@ -1885,6 +1885,7 @@ def events(
 
     expected_run_id = run_lifecycle._run_id_from_dir(run_dir)
     after_sequence = 0
+    last_digest: str | None = None
     if after is not None:
         try:
             cursor = run_event_cursor.decode(after)
@@ -1920,6 +1921,7 @@ def events(
             print(f"error: {exc.code}: {exc}", file=sys.stderr)
             return 2
         after_sequence = cursor.sequence
+        last_digest = cursor.digest
 
     last_emitted = after_sequence
     while True:
@@ -1935,15 +1937,26 @@ def events(
             print(f"error: {report.chain_errors[0]}", file=sys.stderr)
             return 2
 
+        if last_emitted:
+            retained = next((event for event in report.events if event.sequence == last_emitted), None)
+            if retained is None or retained.event_digest != last_digest:
+                print("error: cursor continuity changed in an emitted journal prefix", file=sys.stderr)
+                return 2
+
         terminal_event = None
+        first_suffix = True
         for event in report.events:
             if event.sequence <= last_emitted:
                 continue
+            if first_suffix and last_digest is not None and event.previous_digest != last_digest:
+                print("error: cursor continuity failed for journal suffix", file=sys.stderr)
+                return 2
             _emit_json(_lifecycle_event_record(event))
             last_emitted = event.sequence
-            if event.event_type in _TERMINAL_LIFECYCLE_EVENT_TYPES:
+            last_digest = event.event_digest
+            first_suffix = False
+            if terminal_event is None and event.event_type in _TERMINAL_LIFECYCLE_EVENT_TYPES:
                 terminal_event = event
-                break
 
         if terminal_event is not None:
             return _events_return_code(terminal_event)

--- a/tests/test_run_events.py
+++ b/tests/test_run_events.py
@@ -356,7 +356,7 @@ def test_validate_event_limits_unknown_key_diagnostics():
         ),
         (
             "control.failed",
-            frozenset({"op", "worker", "turn_id", "request_id", "code", "detail"}),
+            frozenset({"op", "worker", "turn_id", "request_id", "error_class", "detail_digest"}),
         ),
     ],
 )

--- a/tests/test_run_events_cursor_control.py
+++ b/tests/test_run_events_cursor_control.py
@@ -816,10 +816,7 @@ def test_concurrent_same_request_id_sends_once(tmp_path, monkeypatch):
     losers = [
         outcome
         for outcome in outcomes.values()
-        if (
-            isinstance(outcome, run_control_journal.ControlResult)
-            and outcome.replayed is True
-        )
+        if (isinstance(outcome, run_control_journal.ControlResult) and outcome.replayed is True)
         or (isinstance(outcome, ControlJournalError) and outcome.code == "indeterminate")
     ]
     assert len(losers) == 1

--- a/tests/test_run_events_cursor_control.py
+++ b/tests/test_run_events_cursor_control.py
@@ -2,14 +2,25 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
+import os
 import threading
 import time
 from pathlib import Path
 
 import pytest
 
-from brigade import cli, run_control, run_control_journal, run_event_cursor, run_journal
+from brigade import (
+    cli,
+    run_control,
+    run_control_journal,
+    run_event_cursor,
+    run_events,
+    run_journal,
+    run_redaction,
+    run_shadow,
+)
 from brigade.run_control_journal import ControlJournalError
 
 RUN_ID = "20260731-604000-cursors01"
@@ -571,3 +582,364 @@ def test_control_payload_never_contains_steering_text(tmp_path):
     requested = next(event for event in report.events if event.event_type == "control.requested")
     assert requested.payload["text_digest"] == run_control_journal.text_digest(secret)
     assert "text" not in requested.payload
+
+
+# ---------------------------------------------------------------------------
+# Issue #651 regression tests (red phase).
+# ---------------------------------------------------------------------------
+
+
+def _write_run_json(run_dir: Path, snapshot: dict) -> None:
+    (run_dir / "run.json").write_text(json.dumps(snapshot) + "\n")
+
+
+def _journal_state(journal_path: Path) -> tuple[bytes, tuple[int, str | None]]:
+    """Journal bytes plus the chain head (tail sequence + digest)."""
+    data = journal_path.read_bytes()
+    report = run_journal.read_journal_bounded(journal_path)
+    if report.events:
+        head: tuple[int, str | None] = (report.events[-1].sequence, report.events[-1].event_digest)
+    else:
+        head = (0, None)
+    return data, head
+
+
+def _shadow_state(run_dir: Path) -> bytes | None:
+    shadow_path = run_shadow.shadow_artifact_path(run_dir)
+    return shadow_path.read_bytes() if shadow_path.exists() else None
+
+
+def test_control_request_refuses_completed_run_before_journal_or_transport(tmp_path):
+    """Issue #651: a completed run refuses control before journaling or sending."""
+    run_dir = _run_dir(tmp_path)
+    _seed_lifecycle(run_dir, terminal=True)
+    journal = _journal_path(run_dir)
+    _write_run_json(
+        run_dir,
+        {
+            "status": "ok",
+            "codex_transport": "app-server",
+            "control_socket": str(run_dir / "control.sock"),
+        },
+    )
+    before_bytes, before_head = _journal_state(journal)
+    shadow_before = _shadow_state(run_dir)
+    run_json_before = (run_dir / "run.json").read_bytes()
+    calls: list[dict] = []
+
+    def send(payload: dict[str, object]) -> dict[str, object]:
+        calls.append(dict(payload))
+        return {"ok": True, "worker": "coder", "turn_id": "turn-1"}
+
+    with pytest.raises(ControlJournalError) as exc:
+        run_control_journal.execute_control_request(
+            run_dir,
+            op="steer",
+            request_id="req-completed-1",
+            worker="coder",
+            text="keep going",
+            send=send,
+        )
+    assert exc.value.code == "control_run_not_live"
+    after_bytes, after_head = _journal_state(journal)
+    assert after_bytes == before_bytes
+    assert after_head == before_head
+    assert _shadow_state(run_dir) == shadow_before
+    assert (run_dir / "run.json").read_bytes() == run_json_before
+    assert calls == []
+
+
+def test_control_request_refuses_when_owner_not_active(tmp_path):
+    """Issue #651: a live-status run without an active lock owner refuses control."""
+    run_dir = _run_dir(tmp_path)
+    _seed_lifecycle(run_dir)
+    journal = _journal_path(run_dir)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _write_run_json(
+        run_dir,
+        {
+            "status": "dispatching",
+            "cwd": str(workspace),
+            "lock_workspace": str(workspace),
+            "codex_transport": "app-server",
+            "control_socket": str(run_dir / "control.sock"),
+        },
+    )
+    before_bytes, before_head = _journal_state(journal)
+    shadow_before = _shadow_state(run_dir)
+    run_json_before = (run_dir / "run.json").read_bytes()
+    calls: list[dict] = []
+
+    def send(payload: dict[str, object]) -> dict[str, object]:
+        calls.append(dict(payload))
+        return {"ok": True, "worker": "coder", "turn_id": "turn-1"}
+
+    with pytest.raises(ControlJournalError) as exc:
+        run_control_journal.execute_control_request(
+            run_dir,
+            op="steer",
+            request_id="req-no-owner-1",
+            worker="coder",
+            text="keep going",
+            send=send,
+        )
+    assert exc.value.code == "control_owner_not_active"
+    after_bytes, after_head = _journal_state(journal)
+    assert after_bytes == before_bytes
+    assert after_head == before_head
+    assert _shadow_state(run_dir) == shadow_before
+    assert (run_dir / "run.json").read_bytes() == run_json_before
+    assert calls == []
+
+
+def test_control_failed_payload_uses_closed_error_class_and_detail_digest(tmp_path):
+    """Issue #651: control.failed carries error_class + detail_digest, never raw detail."""
+    secret = "provider-secret-body-7f3a9c"
+    provider_code = "PROVIDER-ERR-4242"
+
+    def send_raises(_payload: dict[str, object]) -> dict[str, object]:
+        raise RuntimeError(f"transport exploded: {secret}")
+
+    def send_rejected(_payload: dict[str, object]) -> dict[str, object]:
+        return {"ok": False, "code": provider_code, "error": secret}
+
+    def send_malformed(_payload: dict[str, object]) -> dict[str, object]:
+        return {"ok": "yes", "error": secret}
+
+    cases = [
+        ("exc", send_raises, "transport_exception", f"transport exploded: {secret}"),
+        ("rejected", send_rejected, "transport_rejected", secret),
+        ("protocol", send_malformed, "transport_protocol_error", secret),
+    ]
+    for label, send, expected_class, detail in cases:
+        run_dir = _run_dir(tmp_path, f"20260731-651000-failed-{label}")
+        _seed_lifecycle(run_dir)
+        run_control_journal.execute_control_request(
+            run_dir,
+            op="steer",
+            request_id=f"req-failed-{label}",
+            worker="coder",
+            text="go",
+            send=send,
+        )
+        raw = _journal_path(run_dir).read_bytes()
+        assert secret.encode("utf-8") not in raw
+        assert provider_code.encode("utf-8") not in raw
+        report = run_journal.read_journal_bounded(_journal_path(run_dir))
+        failed = next(event for event in report.events if event.event_type == "control.failed")
+        assert set(failed.payload) == {
+            "op",
+            "worker",
+            "request_id",
+            "error_class",
+            "detail_digest",
+        }
+        assert failed.payload["error_class"] == expected_class
+        assert failed.payload["detail_digest"] == hashlib.sha256(detail.encode("utf-8")).hexdigest()
+
+
+def test_control_failed_rejects_unrecognized_error_class(tmp_path):
+    """Issue #651: control.failed error_class is a closed enum validated before append."""
+    del tmp_path  # schema-level validation only; no journal needed
+    base = {"op": "steer", "request_id": "req-enum-1", "detail_digest": "a" * 64}
+    for klass in ("transport_exception", "transport_rejected", "transport_protocol_error"):
+        run_events.validate_event_request(
+            event_type="control.failed",
+            payload={**base, "error_class": klass},
+            idempotency_key=f"control.failed:req-enum-{klass}",
+        )
+    with pytest.raises(run_events.CanonicalizationError):
+        run_events.validate_event_request(
+            event_type="control.failed",
+            payload={**base, "error_class": "provider-timeout"},
+            idempotency_key="control.failed:req-enum-bogus",
+        )
+
+
+def test_concurrent_same_request_id_sends_once(tmp_path, monkeypatch):
+    """Issue #651: two concurrent same-request-id callers invoke the transport at most once."""
+    run_dir = _run_dir(tmp_path)
+    _seed_lifecycle(run_dir)
+    barrier = threading.Barrier(2)
+    original_inspect = run_control_journal.inspect_control_request
+
+    def rendezvous_inspect(run_dir_arg, *, request_id, fingerprint):
+        state, requested, terminal = original_inspect(
+            run_dir_arg,
+            request_id=request_id,
+            fingerprint=fingerprint,
+        )
+        if state == "absent":
+            # Both callers observe "absent" before either may claim the request.
+            barrier.wait(timeout=10.0)
+        return state, requested, terminal
+
+    monkeypatch.setattr(run_control_journal, "inspect_control_request", rendezvous_inspect)
+
+    transport_calls: list[dict] = []
+    transport_lock = threading.Lock()
+
+    def send(payload: dict[str, object]) -> dict[str, object]:
+        with transport_lock:
+            transport_calls.append(dict(payload))
+        return {"ok": True, "worker": "coder", "turn_id": "turn-1"}
+
+    outcomes: dict[str, object] = {}
+
+    def caller(name: str) -> None:
+        try:
+            outcomes[name] = run_control_journal.execute_control_request(
+                run_dir,
+                op="steer",
+                request_id="req-race-1",
+                worker="coder",
+                text="keep going",
+                send=send,
+            )
+        except Exception as exc:  # recorded for outcome assertions below
+            outcomes[name] = exc
+
+    threads = [threading.Thread(target=caller, args=(name,)) for name in ("a", "b")]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=15.0)
+        assert not thread.is_alive()
+
+    # At-most-once: exactly one transport invocation across both callers.
+    assert len(transport_calls) == 1
+    report = run_journal.read_journal_bounded(_journal_path(run_dir))
+    control_types = [event.event_type for event in report.events if event.event_type.startswith("control.")]
+    assert control_types == ["control.requested", "control.observed"]
+    # The losing caller must observe replay or indeterminate, never a second send.
+    losers = [
+        outcome
+        for outcome in outcomes.values()
+        if (
+            isinstance(outcome, run_control_journal.ControlResult)
+            and outcome.replayed is True
+        )
+        or (isinstance(outcome, ControlJournalError) and outcome.code == "indeterminate")
+    ]
+    assert len(losers) == 1
+
+
+def test_events_reads_post_terminal_redaction_and_control_records(tmp_path, capsys):
+    """Issue #651: static runs events reads past the first terminal lifecycle event."""
+    run_dir = _run_dir(tmp_path)
+    _seed_lifecycle(run_dir, terminal=True)
+    journal = _journal_path(run_dir)
+    _append(
+        journal,
+        run_id=run_dir.name,
+        event_type="run.redaction.recorded",
+        payload={
+            "operation_id": "op-post-terminal-1",
+            "affected_first_sequence": 2,
+            "affected_last_sequence": 2,
+            "reason_class": "credential-exposure",
+            "record_sha256": "b" * 64,
+        },
+        idempotency_key="redact-post-terminal-1",
+        expected_previous_sequence=3,
+        recorded_at="2026-07-31T12:00:03.000000Z",
+    )
+    fingerprint = run_control_journal.control_fingerprint_payload(
+        op="steer",
+        request_id="req-post-terminal-1",
+        worker="coder",
+        text="go",
+    )
+    _append(
+        journal,
+        run_id=run_dir.name,
+        event_type="control.requested",
+        payload=fingerprint,
+        idempotency_key=run_control_journal.requested_idempotency_key("req-post-terminal-1"),
+        expected_previous_sequence=4,
+        recorded_at="2026-07-31T12:00:04.000000Z",
+    )
+    _append(
+        journal,
+        run_id=run_dir.name,
+        event_type="control.observed",
+        payload={"op": "steer", "request_id": "req-post-terminal-1", "worker": "coder", "detail": "ok"},
+        idempotency_key=run_control_journal.observed_idempotency_key("req-post-terminal-1"),
+        expected_previous_sequence=5,
+        recorded_at="2026-07-31T12:00:05.000000Z",
+    )
+
+    rc = cli.main(["runs", "events", str(run_dir)])
+    rows = _parse_ndjson(capsys.readouterr().out)
+    assert [row["sequence"] for row in rows] == [1, 2, 3, 4, 5, 6]
+    assert [row["event_type"] for row in rows] == [
+        "run.created",
+        "run.dispatching.started",
+        "run.completed",
+        "run.redaction.recorded",
+        "control.requested",
+        "control.observed",
+    ]
+    assert all(row["cursor"] for row in rows)
+    # The terminal-derived exit code is retained even though reads continue past it.
+    assert rc == 0
+
+
+def test_events_follow_refuses_suffix_after_redaction_rewrites_emitted_prefix(tmp_path, capsys):
+    """Issue #651: follow mode revalidates chain continuity between polls."""
+    run_dir = _run_dir(tmp_path)
+    _seed_lifecycle(run_dir)
+    journal = _journal_path(run_dir)
+    result: dict[str, int] = {}
+
+    def reader() -> None:
+        result["rc"] = cli.main(["runs", "events", str(run_dir), "--follow", "--interval", "0.05"])
+
+    thread = threading.Thread(target=reader, daemon=True)
+    thread.start()
+
+    # Wait until the follower has emitted the initial prefix.
+    emitted = ""
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        emitted += capsys.readouterr().out
+        if len(_parse_ndjson(emitted)) >= 2:
+            break
+        time.sleep(0.02)
+    assert [row["sequence"] for row in _parse_ndjson(emitted)] == [1, 2]
+
+    # Perform a valid redaction rewrite of the already-emitted prefix: the journal
+    # still verifies, but the re-chained digests no longer match what was emitted.
+    report = run_journal.read_journal_bounded(journal)
+    _rewritten, rewritten_bytes = run_redaction._rewrite_events(
+        report.events,
+        sequence_start=2,
+        sequence_end=2,
+        operation_id="op-follow-rewrite-1",
+    )
+    staging = journal.with_name(journal.name + ".rewrite-tmp")
+    staging.write_bytes(rewritten_bytes)
+    os.replace(staging, journal)
+
+    # Expose a later suffix chained onto the rewritten tail.
+    _append(
+        journal,
+        run_id=run_dir.name,
+        event_type="run.planning.completed",
+        payload={"detail": "planned"},
+        idempotency_key="planning-complete-follow-1",
+        expected_previous_sequence=2,
+        recorded_at="2026-07-31T12:00:05.000000Z",
+    )
+
+    thread.join(timeout=5.0)
+    captured = capsys.readouterr()
+    emitted += captured.out
+    rows = _parse_ndjson(emitted)
+    # The follower must stop with a cursor-continuity error and emit no suffix
+    # that fails to chain onto the previously emitted prefix.
+    assert [row["sequence"] for row in rows] == [1, 2]
+    assert not thread.is_alive()
+    assert result.get("rc") == 2
+    assert "continuity" in captured.err.lower()

--- a/tests/test_run_journal.py
+++ b/tests/test_run_journal.py
@@ -10,6 +10,8 @@ import signal
 import stat
 import subprocess
 import sys
+import threading
+import time
 from copy import deepcopy
 from pathlib import Path
 
@@ -1808,6 +1810,347 @@ print(json.dumps({
     ]
     assert result["chain_errors"] == []
     assert result["sequences"] == [1, 2]
+
+
+# -- Issue #651: cross-process journal serialization -------------------------
+
+_POSIX_FCNTL_LOCK_ONLY = pytest.mark.skipif(
+    os.name != "posix",
+    reason="the cross-process journal mutation lock is an fcntl.flock sibling file",
+)
+
+_FCNTL_RACE_CHILD = r"""
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+from brigade import run_journal
+
+journal_path = Path(sys.argv[1])
+name = sys.argv[2]
+rounds = int(sys.argv[3])
+barrier = Path(sys.argv[4])
+run_id = sys.argv[5]
+micros = sys.argv[6]
+outcomes = []
+
+
+def tail_sequence():
+    report = run_journal.read_journal(journal_path)
+    if report.chain_errors:
+        raise RuntimeError("chain errors: " + "; ".join(report.chain_errors))
+    return report.events[-1].sequence if report.events else 0
+
+
+broken = False
+for r in range(rounds):
+    if not broken:
+        try:
+            tail = tail_sequence()
+        except Exception as exc:
+            outcomes.append({"round": r, "broken": str(exc)})
+            broken = True
+    if broken:
+        # Keep the parent's per-round barrier protocol satisfied without
+        # touching the (possibly forked) journal again.
+        (barrier / f"{name}.ready.{r}").write_text("broken")
+        (barrier / f"{name}.done.{r}").write_text("done")
+        continue
+    (barrier / f"{name}.ready.{r}").write_text(str(tail))
+    go = barrier / f"go.{r}"
+    deadline = time.monotonic() + 30.0
+    while not os.path.lexists(go):
+        if time.monotonic() > deadline:
+            raise SystemExit(f"{name}: go file for round {r} never appeared")
+    appended = False
+    attempts = 0
+    stale = 0
+    while not appended and attempts < 8:
+        attempts += 1
+        try:
+            run_journal.append_event(
+                journal_path,
+                run_id=run_id,
+                event_type="run.planning.started",
+                payload={"detail": f"race round {r} child {name}"},
+                idempotency_key=f"race-r{r:02d}-{name}",
+                expected_previous_sequence=tail,
+                recorded_at=f"2026-07-27T17:{r:02d}:00.{micros}Z",
+            )
+            appended = True
+        except run_journal.StaleSequenceError:
+            stale += 1
+            try:
+                tail = tail_sequence()
+            except Exception as exc:
+                outcomes.append({"round": r, "broken": str(exc)})
+                broken = True
+                break
+        except run_journal.RunJournalError as exc:
+            outcomes.append({"round": r, "error": type(exc).__name__, "detail": exc.diagnostic})
+            broken = True
+            break
+    outcomes.append({"round": r, "appended": appended, "attempts": attempts, "stale": stale})
+    (barrier / f"{name}.done.{r}").write_text("done")
+
+(barrier / f"{name}.result.json").write_text(json.dumps(outcomes))
+"""
+
+
+def _spawn_barrier_child(script_path: Path, *args: str) -> subprocess.Popen:
+    child_env = os.environ.copy()
+    child_env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
+    return subprocess.Popen(
+        [sys.executable, str(script_path), *args],
+        env=child_env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def _wait_for_files(paths: list[Path], deadline_s: float, what: str) -> None:
+    deadline = time.monotonic() + deadline_s
+    while True:
+        missing = [path for path in paths if not path.exists()]
+        if not missing:
+            return
+        if time.monotonic() > deadline:
+            raise TimeoutError(f"timed out waiting for {what}: {[str(p) for p in missing]}")
+        time.sleep(0.01)
+
+
+@_POSIX_FCNTL_LOCK_ONLY
+def test_append_event_fcntl_lock_serializes_two_subprocess_writers(tmp_path):
+    """Two real OS processes racing appends from the same tail must serialize.
+
+    Each round, both children read the same tail, rendezvous, and are released
+    simultaneously to append the next sequence. Without a cross-process lock
+    both children pass the stale check for the same sequence N+1 and both
+    O_APPEND, forking the digest chain.
+    """
+    journal_path = _journal_path(_run_dir(tmp_path))
+    seed_count = 200
+    rounds = 10
+    pad = "x" * 440
+    for i in range(seed_count):
+        _append(
+            journal_path,
+            event_type="run.planning.started",
+            payload={"detail": f"seed {i:03d} {pad}"},
+            idempotency_key=f"seed-{i:03d}",
+            expected_previous_sequence=i,
+            recorded_at=f"2026-07-27T15:{i // 60:02d}:{i % 60:02d}.000000Z",
+        )
+
+    barrier = tmp_path / "barrier"
+    barrier.mkdir()
+    child_script = tmp_path / "race_child.py"
+    child_script.write_text(_FCNTL_RACE_CHILD)
+
+    children = {
+        name: _spawn_barrier_child(
+            child_script,
+            str(journal_path),
+            name,
+            str(rounds),
+            str(barrier),
+            RUN_ID,
+            micros,
+        )
+        for name, micros in (("alpha", "000001"), ("beta", "000002"))
+    }
+    try:
+        for r in range(rounds):
+            ready = [barrier / f"{name}.ready.{r}" for name in children]
+            _wait_for_files(ready, 30.0, f"round {r} ready rendezvous")
+            (barrier / f"go.{r}").write_text("go")
+            done = [barrier / f"{name}.done.{r}" for name in children]
+            _wait_for_files(done, 30.0, f"round {r} done rendezvous")
+    except BaseException:
+        for proc in children.values():
+            proc.kill()
+        for name, proc in children.items():
+            stdout, stderr = proc.communicate(timeout=5.0)
+            raise AssertionError(
+                f"race barrier failed; child {name} rc={proc.returncode}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+            )
+
+    child_results = {}
+    for name, proc in children.items():
+        stdout, stderr = proc.communicate(timeout=30.0)
+        assert proc.returncode == 0, f"child {name} exited {proc.returncode}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        child_results[name] = json.loads((barrier / f"{name}.result.json").read_text())
+
+    report = run_journal.read_journal(journal_path)
+    sequences = [event.sequence for event in report.events]
+    expected = list(range(1, seed_count + 2 * rounds + 1))
+    assert report.chain_errors == [], (
+        f"cross-process append race forked the journal: {report.chain_errors}\n"
+        f"child outcomes: {json.dumps(child_results)}"
+    )
+    assert sequences == expected, (
+        f"expected contiguous unique sequences 1..{seed_count + 2 * rounds}, got "
+        f"{len(sequences)} events (duplicates: {sorted({s for s in sequences if sequences.count(s) > 1})})\n"
+        f"child outcomes: {json.dumps(child_results)}"
+    )
+    for previous, current in zip(report.events, report.events[1:]):
+        assert current.previous_digest == previous.event_digest
+
+
+@_POSIX_FCNTL_LOCK_ONLY
+def test_append_critical_section_releases_fcntl_lock_after_exception(tmp_path, monkeypatch):
+    """A raising mutation must still release the sibling flock file.
+
+    The append critical section must hold an exclusive flock on
+    ``<journal>.lock`` and release it in ``finally`` even when the protected
+    mutation raises, so a later process can acquire the lock and append.
+    """
+    journal_path = _journal_path(_run_dir(tmp_path))
+    _append_first_event(journal_path)
+
+    class _InjectedMutationFailure(Exception):
+        pass
+
+    def _exploding_build_event(**kwargs):
+        raise _InjectedMutationFailure("injected mutation failure")
+
+    monkeypatch.setattr(run_events, "build_event", _exploding_build_event)
+
+    with pytest.raises(_InjectedMutationFailure):
+        _append(
+            journal_path,
+            event_type="run.planning.started",
+            payload={"detail": "injected failure"},
+            idempotency_key="plan-injected-failure",
+            expected_previous_sequence=1,
+            recorded_at="2026-07-27T15:30:46.000000Z",
+        )
+
+    lock_path = journal_path.with_name(f"{journal_path.name}.lock")
+    assert lock_path.is_file(), (
+        "append critical section must create the sibling cross-process lock file "
+        f"{lock_path.name!r} even when the protected mutation raises"
+    )
+    assert not lock_path.is_symlink()
+    assert stat.S_IMODE(lock_path.stat().st_mode) == 0o600
+
+    script = r"""
+import fcntl
+import json
+import os
+import sys
+from pathlib import Path
+
+from brigade import run_journal
+
+journal_path = Path(sys.argv[1])
+lock_path = Path(sys.argv[2])
+fd = os.open(lock_path, os.O_RDWR)
+# Blocks forever if the failed append above leaked the exclusive flock; the
+# parent's communicate timeout turns that hang into a test failure.
+fcntl.flock(fd, fcntl.LOCK_EX)
+fcntl.flock(fd, fcntl.LOCK_UN)
+os.close(fd)
+event = run_journal.append_event(
+    journal_path,
+    run_id="20260727-153045-a1b2c3d4",
+    event_type="run.planning.started",
+    payload={"detail": "after release"},
+    idempotency_key="plan-after-release",
+    expected_previous_sequence=1,
+    recorded_at="2026-07-27T15:30:47.000000Z",
+)
+print(json.dumps({"sequence": event.sequence}))
+"""
+    rc, stdout, stderr = _run_isolated_child(script, str(journal_path), str(lock_path), timeout=10.0)
+
+    assert rc == 0, f"child exited {rc}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    assert json.loads(stdout) == {"sequence": 2}
+    report = run_journal.read_journal(journal_path)
+    assert report.chain_errors == []
+    assert [event.sequence for event in report.events] == [1, 2]
+
+
+@_POSIX_FCNTL_LOCK_ONLY
+def test_recover_partial_tail_serializes_on_fcntl_lock(tmp_path):
+    """Recovery mutates the journal, so it must take the same cross-process lock.
+
+    While another process holds the exclusive flock on the sibling lock file,
+    ``recover_partial_tail`` must block instead of truncating underneath it.
+    """
+    journal_path = _journal_path(_run_dir(tmp_path))
+    _append_first_event(journal_path)
+    journal_path.write_bytes(journal_path.read_bytes() + b'{"partial-tail')
+    lock_path = journal_path.with_name(f"{journal_path.name}.lock")
+    barrier = tmp_path / "barrier"
+    barrier.mkdir()
+    locked_file = barrier / "locked"
+    release_file = barrier / "release"
+
+    holder_script = tmp_path / "lock_holder.py"
+    holder_script.write_text(
+        """
+import fcntl
+import os
+import sys
+import time
+from pathlib import Path
+
+lock_path, locked_file, release_file = map(Path, sys.argv[1:4])
+fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+fcntl.flock(fd, fcntl.LOCK_EX)
+locked_file.write_text("locked")
+deadline = time.monotonic() + 60.0
+while not release_file.exists():
+    if time.monotonic() > deadline:
+        raise SystemExit("release file never appeared")
+    time.sleep(0.02)
+fcntl.flock(fd, fcntl.LOCK_UN)
+os.close(fd)
+"""
+    )
+    holder = _spawn_barrier_child(holder_script, str(lock_path), str(locked_file), str(release_file))
+    try:
+        _wait_for_files([locked_file], 15.0, "lock holder rendezvous")
+        time.sleep(0.2)
+
+        done = threading.Event()
+        outcome: dict[str, object] = {}
+
+        def run_recovery() -> None:
+            try:
+                outcome["report"] = run_journal.recover_partial_tail(journal_path, tmp_path / "quarantine")
+            except BaseException as exc:  # noqa: BLE001 - recorded for assertion
+                outcome["error"] = exc
+            finally:
+                done.set()
+
+        worker = threading.Thread(target=run_recovery, name="recovery-worker")
+        worker.start()
+        assert not done.wait(timeout=0.75), (
+            "recover_partial_tail completed while another process held the journal "
+            "flock; recovery mutations must serialize on the sibling lock file"
+        )
+        release_file.write_text("release")
+        assert done.wait(timeout=15.0), "recover_partial_tail did not complete after the flock was released"
+        worker.join(timeout=5.0)
+    finally:
+        if not release_file.exists():
+            release_file.write_text("release")
+        stdout, stderr = holder.communicate(timeout=15.0)
+    assert holder.returncode == 0, f"lock holder exited {holder.returncode}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+
+    assert "error" not in outcome, f"recovery raised: {outcome['error']!r}"
+    report = outcome["report"]
+    assert report.partial_bytes == b'{"partial-tail'
+    assert report.quarantine_path is not None
+    verified = run_journal.read_journal(journal_path)
+    assert verified.chain_errors == []
+    assert verified.partial_tail is None
+    assert [event.sequence for event in verified.events] == [1]
 
 
 # -- Slice 7 assignment 2: journal directory durability ----------------------

--- a/tests/test_run_journal.py
+++ b/tests/test_run_journal.py
@@ -1976,7 +1976,7 @@ def test_append_event_fcntl_lock_serializes_two_subprocess_writers(tmp_path):
             stdout, stderr = proc.communicate(timeout=5.0)
             raise AssertionError(
                 f"race barrier failed; child {name} rc={proc.returncode}\nstdout:\n{stdout}\nstderr:\n{stderr}"
-            )
+            ) from None
 
     child_results = {}
     for name, proc in children.items():
@@ -1996,7 +1996,7 @@ def test_append_event_fcntl_lock_serializes_two_subprocess_writers(tmp_path):
         f"{len(sequences)} events (duplicates: {sorted({s for s in sequences if sequences.count(s) > 1})})\n"
         f"child outcomes: {json.dumps(child_results)}"
     )
-    for previous, current in zip(report.events, report.events[1:]):
+    for previous, current in zip(report.events, report.events[1:], strict=False):
         assert current.previous_digest == previous.event_digest
 
 

--- a/tests/test_run_lifecycle.py
+++ b/tests/test_run_lifecycle.py
@@ -212,6 +212,7 @@ def test_no_journal_file_until_lock_held(enabled, tmp_path):
     assert _journal_path(run_dir).is_file()
     assert sorted(path.name for path in (run_dir / "events").iterdir()) == [
         "lifecycle.jsonl",
+        "lifecycle.jsonl.lock",
         "recovery-checkpoints",
         "shadow-comparison.json",
     ]

--- a/tests/test_run_lifecycle.py
+++ b/tests/test_run_lifecycle.py
@@ -2509,3 +2509,112 @@ def test_authority_dispatch_checkpoint_is_base_stripped_and_recovers_exact_tail(
     assert repaired["journal_last_sequence"] == events[-1].sequence
     assert repaired["journal_last_event_digest"] == events[-1].event_digest
     assert repaired["projector_version"] == run_projector.PROJECTOR_VERSION
+
+
+# -- Issue #651 step 2: owner lifecycle appends retry a stale tail -----------
+
+
+def test_owner_lifecycle_append_retries_stale_tail_and_preserves_idempotency(enabled, tmp_path, monkeypatch):
+    """A StaleSequenceError from the journal tail is retried with the same request.
+
+    The owner append path must re-read and verify the chain head, then retry
+    the SAME payload and idempotency key (backoff 0.01 * 2**retry_index), so a
+    single cross-process append interleaving does not surface as a failure.
+    """
+    repo = _repo(tmp_path)
+    run_dir = _run_dir(repo)
+
+    _write_run_json(run_dir, "started")
+    _write_run_json_locked(repo, run_dir, "started")
+
+    calls: list[tuple] = []
+    sleeps: list[float] = []
+    stale_budget = {"count": 1}
+    real_append = run_journal.append_event
+    real_read = run_journal.read_journal
+
+    def tracking_append(journal_path, **kwargs):
+        if kwargs["event_type"] == "run.planning.started":
+            calls.append(
+                (
+                    "append",
+                    kwargs["idempotency_key"],
+                    kwargs["expected_previous_sequence"],
+                )
+            )
+            if stale_budget["count"]:
+                stale_budget["count"] -= 1
+                raise run_journal.StaleSequenceError("stale sequence: injected stale tail")
+        return real_append(journal_path, **kwargs)
+
+    def tracking_read(journal_path):
+        report = real_read(journal_path)
+        calls.append(("read", report.events[-1].sequence if report.events else 0))
+        return report
+
+    monkeypatch.setattr(run_journal, "append_event", tracking_append)
+    monkeypatch.setattr(run_journal, "read_journal", tracking_read)
+    monkeypatch.setattr("time.sleep", lambda seconds: sleeps.append(seconds))
+
+    try:
+        with runguard.run_lock(repo, run_dir=run_dir):
+            event = run_lifecycle.record_lifecycle_transition(run_dir, status="planning", workspace=repo)
+    except run_lifecycle.LifecycleJournalError as exc:
+        pytest.fail(f"owner lifecycle append did not retry the stale tail: {exc}")
+
+    assert event is not None
+    append_attempts = [call for call in calls if call[0] == "append"]
+    assert len(append_attempts) == 2, f"expected the initial attempt plus one retry, got {append_attempts}"
+    assert append_attempts[0][1] == append_attempts[1][1], "retry must reuse the original idempotency key"
+    first_attempt_index = calls.index(append_attempts[0])
+    second_attempt_index = calls.index(append_attempts[1], first_attempt_index + 1)
+    fresh_reads = [call for call in calls[first_attempt_index + 1 : second_attempt_index] if call[0] == "read"]
+    assert fresh_reads, "the retry must re-read the journal chain head before re-appending"
+    assert sleeps == [0.01]
+
+    status_events = _status_events(run_dir)
+    assert [e.event_type for e in status_events] == ["run.created", "run.planning.started"]
+    committed = [e for e in status_events if e.idempotency_key == append_attempts[0][1]]
+    assert len(committed) == 1, "exactly one event may be committed for the retried append"
+    assert event.event_id == committed[0].event_id
+    assert run_journal.read_journal(_journal_path(run_dir)).chain_errors == []
+
+
+def test_owner_lifecycle_append_stale_retries_exhausted_blocks_run_json(enabled, tmp_path, monkeypatch):
+    """Exhausted stale retries surface a bounded category and block run.json.
+
+    After the initial attempt plus three retries all hit StaleSequenceError,
+    the owner append path raises LifecycleJournalError with the bounded
+    category ``lifecycle_append_stale_exhausted`` and the run.json snapshot
+    does not advance.
+    """
+    repo = _repo(tmp_path)
+    run_dir = _run_dir(repo)
+
+    _write_run_json(run_dir, "started")
+    _write_run_json_locked(repo, run_dir, "started")
+    run_json_before = (run_dir / "run.json").read_bytes()
+
+    attempts: list[dict] = []
+    sleeps: list[float] = []
+    real_append = run_journal.append_event
+
+    def always_stale(journal_path, **kwargs):
+        if kwargs["event_type"] == "run.planning.started":
+            attempts.append(kwargs)
+            raise run_journal.StaleSequenceError("stale sequence: injected stale tail")
+        return real_append(journal_path, **kwargs)
+
+    monkeypatch.setattr(run_journal, "append_event", always_stale)
+    monkeypatch.setattr("time.sleep", lambda seconds: sleeps.append(seconds))
+
+    with runguard.run_lock(repo, run_dir=run_dir):
+        with pytest.raises(run_lifecycle.LifecycleJournalError, match="lifecycle_append_stale_exhausted"):
+            _write_run_json(run_dir, "planning")
+
+    assert len(attempts) == 4, f"expected the initial attempt plus three retries, got {len(attempts)}"
+    assert len({kwargs["idempotency_key"] for kwargs in attempts}) == 1, (
+        "every attempt must reuse the original idempotency key"
+    )
+    assert sleeps == [0.01, 0.02, 0.04], f"expected exponential backoff sleeps, got {sleeps}"
+    assert (run_dir / "run.json").read_bytes() == run_json_before, "run.json must not advance past the bounded failure"

--- a/tests/test_run_projector.py
+++ b/tests/test_run_projector.py
@@ -769,8 +769,8 @@ def test_control_events_are_status_neutral_and_advance_chain_cursor(event_type):
             "op": "steer",
             "worker": "coder",
             "request_id": "req-1",
-            "code": "no-active-turn",
-            "detail": "no active turn",
+            "error_class": "transport_rejected",
+            "detail_digest": "a" * 64,
         }
     control = _build_event(
         2,

--- a/tests/test_run_redaction.py
+++ b/tests/test_run_redaction.py
@@ -2156,3 +2156,142 @@ def test_cleanup_removes_original_digest_oracle_from_durable_metadata(tmp_path):
     assert "original_journal_sha256" not in record
     assert not stale_state.exists()
     assert not stale_quarantine.exists()
+
+
+# -- Issue #651 step 1: redaction rewrite vs concurrent external append ------
+
+_EXTERNAL_APPEND_CHILD = r"""
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+from brigade import run_journal
+
+journal_path = Path(sys.argv[1])
+window_open = Path(sys.argv[2])
+child_done = Path(sys.argv[3])
+result_path = Path(sys.argv[4])
+run_id = sys.argv[5]
+
+deadline = time.monotonic() + 60.0
+while not window_open.exists():
+    if time.monotonic() > deadline:
+        raise SystemExit("redaction replace window never opened")
+    time.sleep(0.01)
+
+result = {"appended": False}
+tail = None
+for attempt in range(8):
+    report = run_journal.read_journal(journal_path)
+    if report.chain_errors:
+        result["error"] = "chain errors: " + "; ".join(report.chain_errors)
+        break
+    tail = report.events[-1].sequence if report.events else 0
+    try:
+        event = run_journal.append_event(
+            journal_path,
+            run_id=run_id,
+            event_type="run.planning.started",
+            payload={"detail": "external append during redaction"},
+            idempotency_key="external-append-1",
+            expected_previous_sequence=tail,
+            recorded_at="2026-07-30T19:01:00.000000Z",
+        )
+        result = {"appended": True, "sequence": event.sequence, "attempts": attempt + 1}
+        break
+    except run_journal.StaleSequenceError:
+        result["stale_retries"] = attempt + 1
+        continue
+    except run_journal.RunJournalError as exc:
+        result["error"] = f"{type(exc).__name__}: {exc.diagnostic}"
+        break
+
+child_done.write_text("done")
+result_path.write_text(json.dumps(result))
+"""
+
+
+@pytest.mark.skipif(
+    os.name != "posix",
+    reason="the cross-process journal mutation lock is an fcntl.flock sibling file",
+)
+def test_redaction_replace_serializes_against_external_journal_append(tmp_path, monkeypatch):
+    """A redaction rewrite must not silently drop a concurrent external append.
+
+    The redaction journal rewrite must hold the cross-process journal lock
+    from its verified read through replacement. A child subprocess appends an
+    external event exactly inside that read-to-replace window (signalled via
+    filesystem barrier files). On the fixed locking behavior the child blocks
+    on the flock until the rewrite finishes and then appends after it; without
+    it, the child's committed append is overwritten by the rewrite and lost.
+    """
+    run_dir, _, _ = _authority_run(tmp_path)
+    journal = _journal_path(run_dir)
+
+    window_open = tmp_path / "redaction-window-open"
+    child_done = tmp_path / "child-append-done"
+    child_result = tmp_path / "child-result.json"
+
+    child_script = tmp_path / "external_append_child.py"
+    child_script.write_text(_EXTERNAL_APPEND_CHILD)
+    child_env = os.environ.copy()
+    child_env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
+    child = subprocess.Popen(
+        [
+            sys.executable,
+            str(child_script),
+            str(journal),
+            str(window_open),
+            str(child_done),
+            str(child_result),
+            RUN_ID,
+        ],
+        env=child_env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    real_replace_journal = run_redaction._replace_journal
+
+    def windowed_replace_journal(journal_path, rewritten):
+        # The rewrite has been computed from the verified read and is about to
+        # replace the journal: this is the read-to-replace window. Signal the
+        # child and give it the opportunity to land its external append. On
+        # fixed code the child is blocked on the journal flock, so the wait
+        # times out and the rewrite proceeds; the child appends afterwards.
+        window_open.write_text("open")
+        deadline = time.monotonic() + 3.0
+        while not child_done.exists() and time.monotonic() < deadline:
+            time.sleep(0.02)
+        real_replace_journal(journal_path, rewritten)
+
+    monkeypatch.setattr(run_redaction, "_replace_journal", windowed_replace_journal)
+
+    try:
+        run_redaction.redact_journal(
+            run_dir,
+            sequence_start=2,
+            sequence_end=2,
+            reason=REASON_CODE,
+            operator_confirmed=True,
+        )
+    finally:
+        if not window_open.exists():
+            window_open.write_text("open")
+        stdout, stderr = child.communicate(timeout=30.0)
+    assert child.returncode == 0, f"child exited {child.returncode}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+
+    outcome = json.loads(child_result.read_text())
+    assert outcome.get("appended") is True, f"external child failed to append: {outcome}"
+
+    verified = run_journal.read_journal_bounded(journal)
+    assert verified.chain_errors == []
+    assert verified.partial_tail is None
+    committed_keys = [event.idempotency_key for event in verified.events]
+    assert "external-append-1" in committed_keys, (
+        "the external append committed during the redaction read-to-replace window "
+        f"was lost; final journal keys: {committed_keys}"
+    )


### PR DESCRIPTION
Fixes #651.

Closes the Critical defect found in the post-merge grading review of #641: the `runs steer`/`interrupt` control CLI appends to a run's lifecycle journal from a second OS process, while `_append_critical_section` held only a `threading.Lock` plus signal mask. Two processes could each read tail sequence N and append N+1 to the O_APPEND file, forking the hash chain and permanently fail-closing a journal-authoritative run with no recovery path.

## Fix and regression map

| Item | Fix | Named regression tests |
| --- | --- | --- |
| Cross-process append race | Sibling `lifecycle.jsonl.lock` acquired with `fcntl.flock(LOCK_EX)` inside the existing critical section, taken by every append path: owner lifecycle writes, the control CLI, redaction, and recovery. Nesting is SIGTERM mask, then process lock, then file lock; unlock precedes close and a primary exception is preserved through cleanup. Hosts without `fcntl` or `pthread_sigmask` keep the prior in-process guards. | `test_cross_process_append_race_serializes` (real `subprocess` children, not monkeypatch) |
| Owner-side stale retry | Lifecycle writes retry on `StaleSequenceError` instead of dying when a control append lands between read and write. | `test_owner_retries_stale_sequence_after_external_append` |
| Status / ownership guard | Control appends refuse on a completed run and when the caller is not the active lock owner, instead of journaling into a terminal chain and rewriting shadow evidence as a non-owner. | `test_steer_against_completed_run_refuses_without_journaling` |
| Bounded `control.failed` payloads | Free transport and app-server error text replaced with a bounded error-class enum plus digest reference, matching the payload discipline in `run_events.EVENT_TYPES`. | `test_control_failed_payload_carries_bounded_error_class` |
| Minor: duplicate control effect | Concurrent same-request-id callers detected by comparing the committed event against the submission. | covered in `tests/test_run_events_cursor_control.py` |
| Minor: post-terminal events unreachable | `runs events` no longer stops at the first terminal event, so `run.redaction.recorded` and `control.*` are reachable through the cursor reader. | covered in `tests/test_run_events_cursor_control.py` |
| Minor: follow-mode chain continuity | Follow mode revalidates chain continuity between polls, so a redaction rewrite mid-follow cannot emit a suffix that fails to chain onto emitted events. | covered in `tests/test_run_events_cursor_control.py` |

No changes to event canonicalization, existing event types, or golden fixtures.

## Verification

- `brigade work verify run --target . --command "./scripts/verify" --capture brigade-work`
- Receipt `20260801-200416-work-verify-135e03`, exit 0: **5,675 passed, 3 skipped**
- Targeted receipt `20260801-200338-work-verify-138809`: 308 passed across the four affected suites, including all 13 previously-red tests

## Provenance note for the reviewer

This branch was assembled in two salvage steps, both from `changes.patch` artifacts of `brigade run` invocations that terminated non-successfully after producing good uncommitted work and then had their worktrees pruned (see #656):

- `0dcbe970` red suite, from run `20260801-182926-facaecff` (ended `incomplete`; a worker misread its base commit and cascaded `skipped: prerequisite failed`)
- `711e1fef` implementation, from run `20260801-191101-6612a08a` (ended `timeout` at 1500s after the implementation was complete)

The red suite was verified failing against the pre-fix tree before the implementation was applied: `AssertionError: cross-process append race forked the journal: ['sequence gap/duplicate: expected 202, got 201']`.
