### PR TITLE
fix(dispatch): bound ledger root, name missing interpreters, surface stale inventory (#657)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,7 +296,15 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e ".[dev]"
       - name: Command Inventory
-        run: brigade roadmap commands --check
+        run: |
+          set +e
+          brigade roadmap commands --check
+          status=$?
+          set -e
+          if [ "$status" -ne 0 ]; then
+            echo "::error file=docs/command-inventory.md::docs/command-inventory.md is stale; regenerate with BRIGADE_EXTRAS=1 brigade roadmap commands --write"
+          fi
+          exit "$status"
         env:
           BRIGADE_EXTRAS: "1"
       - name: Template Audit

--- a/src/brigade/outcome_cmd.py
+++ b/src/brigade/outcome_cmd.py
@@ -858,6 +858,17 @@ def append_records(target: Path, records: list[core.OutcomeRecord]) -> None:
     interrupted batch may leave earlier rows from that call on disk while the
     partial tail is removed before validation and the next append proceeds.
     """
+    resolved_target = target.expanduser().resolve()
+    from .work_cmd import helpers as work_helpers
+
+    repo_root = work_helpers._git_value(resolved_target, "rev-parse", "--show-toplevel")
+    if repo_root is not None:
+        resolved_root = Path(repo_root).resolve()
+        if resolved_target != resolved_root and not (resolved_target / ".brigade" / "config.json").is_file():
+            raise OutcomeLedgerError(
+                f"outcome ledger target {resolved_target} is inside git repository {resolved_root} "
+                f"but lacks .brigade/config.json; rerun with --target {resolved_root}"
+            )
     path = _records_path(target)
     lock_path = _records_lock_path(target)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -1611,7 +1622,11 @@ def capture(
         route=route,
         route_fingerprint=route_fingerprint(route),
     )
-    append_records(target, [record])
+    try:
+        append_records(target, [record])
+    except OutcomeLedgerError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
     if json_output:
         print(json.dumps({"target": str(target), "record": _record_payload(record)}, indent=2, sort_keys=True))
         return 0
@@ -2121,7 +2136,11 @@ def record(
         context=manifest,
         capability_fingerprint=capability_fingerprint(manifest),
     )
-    append_records(target, [new_record])
+    try:
+        append_records(target, [new_record])
+    except OutcomeLedgerError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
     if json_output:
         print(json.dumps({"target": str(target), "record": _record_payload(new_record)}, indent=2, sort_keys=True))
         return 0

--- a/src/brigade/run_transport.py
+++ b/src/brigade/run_transport.py
@@ -799,7 +799,9 @@ def _dag_placement_error(
         return "no route dependencies available"
     known = set(route_dependencies)
     for assignment in assignments:
-        if not assignment.covers or not set(assignment.covers) <= known:
+        # Empty covers are an independent DAG root; only nonempty covers must
+        # name known route stages.
+        if assignment.covers and not set(assignment.covers) <= known:
             return "plan not fully covered"
     return None
 

--- a/src/brigade/work_cmd/verification.py
+++ b/src/brigade/work_cmd/verification.py
@@ -62,6 +62,14 @@ def _high_risk_command_message(executable: str) -> str:
     )
 
 
+def _missing_python_interpreter_message() -> str:
+    return "verification command interpreter python was not found on PATH; use available interpreter python3 instead"
+
+
+def _unresolvable_command_message(executable: str) -> str:
+    return f"verification command is not resolvable: {executable}"
+
+
 def _verify_parse_command(command: str, target: Path) -> tuple[list[str] | None, dict[str, str], str | None]:
     try:
         parts = shlex.split(command)
@@ -93,9 +101,13 @@ def _verify_parse_command(command: str, target: Path) -> tuple[list[str] | None,
         if not executable_path.is_absolute():
             executable_path = target / executable_path
         if not executable_path.exists():
-            return None, env, f"verification command is not resolvable: {argv[0]}"
-    elif shutil.which(argv[0]) is None:
-        return None, env, f"verification command is not resolvable: {argv[0]}"
+            return None, env, _unresolvable_command_message(argv[0])
+    else:
+        path_override = env.get("PATH")
+        if shutil.which(argv[0], path=path_override) is None:
+            if argv[0] == "python" and shutil.which("python3", path=path_override) is not None:
+                return None, env, _missing_python_interpreter_message()
+            return None, env, _unresolvable_command_message(argv[0])
     return argv, env, None
 
 
@@ -116,9 +128,11 @@ def _verify_parse_argv(argv: list[str], target: Path) -> tuple[list[str] | None,
         if not executable_path.is_absolute():
             executable_path = target / executable_path
         if not executable_path.exists():
-            return None, {}, f"verification command is not resolvable: {argv[0]}"
+            return None, {}, _unresolvable_command_message(argv[0])
     elif shutil.which(argv[0]) is None:
-        return None, {}, f"verification command is not resolvable: {argv[0]}"
+        if argv[0] == "python" and shutil.which("python3") is not None:
+            return None, {}, _missing_python_interpreter_message()
+        return None, {}, _unresolvable_command_message(argv[0])
     return list(argv), {}, None
 
 

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -182,6 +182,21 @@ def test_ci_workflow_does_not_skip_docs_only_content_guard():
     assert "python -m content_guard scan" in text
 
 
+def test_repo_metadata_command_inventory_failure_is_actionable_and_preserves_status():
+    text = (ROOT / ".github/workflows/ci.yml").read_text()
+    section = _workflow_job_section(text, "repo-metadata")
+
+    assert "set +e" in section
+    assert "brigade roadmap commands --check" in section
+    assert "status=$?" in section
+    assert "set -e" in section
+    assert (
+        'echo "::error file=docs/command-inventory.md::docs/command-inventory.md is stale; '
+        'regenerate with BRIGADE_EXTRAS=1 brigade roadmap commands --write"'
+    ) in section
+    assert 'exit "$status"' in section
+
+
 def test_ci_component_manifest_provenance_job_installs_dev_test_dependencies():
     text = (ROOT / ".github/workflows/ci.yml").read_text()
     section = _workflow_job_section(text, "component-manifest-provenance")

--- a/tests/test_outcome_cmd.py
+++ b/tests/test_outcome_cmd.py
@@ -94,6 +94,80 @@ def test_records_persist_under_git_tracked_memory_dir(tmp_path):
     assert not (tmp_path / ".brigade" / "outcome" / "records.jsonl").exists()
 
 
+def test_append_records_rejects_unconfigured_nested_git_target(tmp_path):
+    _init_git_repo(tmp_path)
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    record = outcome.OutcomeRecord("c", "card", "t", "verify", 1, "r", "2026-06-20T00:00:00+00:00")
+
+    with pytest.raises(outcome_cmd.OutcomeLedgerError) as exc_info:
+        outcome_cmd.append_records(nested, [record])
+
+    assert str(nested) in str(exc_info.value)
+    assert str(tmp_path) in str(exc_info.value)
+    assert f"rerun with --target {tmp_path}" in str(exc_info.value)
+    assert not (nested / "memory" / "outcome" / "records.jsonl").exists()
+
+
+def test_append_records_allows_configured_nested_git_target(tmp_path):
+    _init_git_repo(tmp_path)
+    nested = tmp_path / "nested"
+    (nested / ".brigade").mkdir(parents=True)
+    (nested / ".brigade" / "config.json").write_text("{}")
+
+    _seed(nested, [outcome.OutcomeRecord("c", "card", "t", "verify", 1, "r", "2026-06-20T00:00:00+00:00")])
+
+    assert (nested / "memory" / "outcome" / "records.jsonl").is_file()
+
+
+def test_outcome_capture_reports_bounded_error_for_nested_git_target(tmp_path, capsys):
+    _init_git_repo(tmp_path)
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    _write_verify_receipt(nested)
+
+    rc = outcome_cmd.capture(target=nested, artifact_id="skill-x", json_output=True)
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    resolved_nested = nested.resolve()
+    resolved_root = tmp_path.resolve()
+    assert str(resolved_nested) in captured.err
+    assert str(resolved_root) in captured.err
+    assert f"rerun with --target {resolved_root}" in captured.err
+    assert "Traceback" not in captured.err
+    assert not (nested / "memory" / "outcome" / "records.jsonl").exists()
+
+
+def test_cli_outcome_record_from_nested_cwd_rejects_unconfigured_git_target(tmp_path, monkeypatch, capsys):
+    _init_git_repo(tmp_path)
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    monkeypatch.chdir(nested)
+
+    rc = cli.main(
+        [
+            "outcome",
+            "record",
+            "skill-x",
+            "--source",
+            "friction",
+            "--status",
+            "cleared",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    resolved_nested = nested.resolve()
+    resolved_root = tmp_path.resolve()
+    assert str(resolved_nested) in captured.err
+    assert str(resolved_root) in captured.err
+    assert f"rerun with --target {resolved_root}" in captured.err
+    assert "Traceback" not in captured.err
+    assert not (nested / "memory" / "outcome" / "records.jsonl").exists()
+
+
 def test_appended_records_carry_tamper_evident_digest_chain(tmp_path):
     first = outcome.OutcomeRecord("skill-x", "skill", "t1", "verify", 1, "ref1", "2026-06-20T00:00:00+00:00")
     second = outcome.OutcomeRecord("skill-x", "skill", "t2", "verify", -1, "ref2", "2026-06-20T01:00:00+00:00")

--- a/tests/test_run_transport_dag.py
+++ b/tests/test_run_transport_dag.py
@@ -143,13 +143,22 @@ def test_held_stage_never_dispatched(dag_harness, capsys):
     assert "falling back" not in capsys.readouterr().err
 
 
-def test_uncovered_assignment_falls_back_to_waves(dag_harness, capsys):
+def test_empty_covers_runs_as_independent_dag_root(dag_harness, capsys):
+    # An assignment with no covers is an independent DAG root when every
+    # nonempty covers list names known route stages. Mixed plans must engage
+    # the DAG (no wave-fallback warning).
+    resolved = []
     results = dag_harness(
         assignments=[_a("p", 1, ["plan"]), Assignment(worker="x", task="t", stage=2)],
         dependencies=DEPS,
+        on_scheduler_resolved=lambda used, reason: resolved.append((used, reason)),
     )
-    assert "falling back to wave scheduler" in capsys.readouterr().err
+    err = capsys.readouterr().err
+    assert "falling back to wave scheduler" not in err
+    assert resolved == [("dag", None)]
     assert len(results) == 2
+    assert {r.worker for r in results} == {"p", "x"}
+    assert dag_harness.invocations_set == {"p", "x"}
 
 
 def test_partially_unknown_covers_falls_back_to_waves(dag_harness, capsys):
@@ -161,6 +170,19 @@ def test_partially_unknown_covers_falls_back_to_waves(dag_harness, capsys):
     )
     assert "falling back to wave scheduler" in capsys.readouterr().err
     assert len(results) == 1
+
+
+def test_unknown_covers_still_rejected(dag_harness, capsys):
+    # Empty covers are allowed, but unknown cover stage names still force waves.
+    resolved = []
+    results = dag_harness(
+        assignments=[_a("p", 1, ["plan"]), _a("x", 2, ["made-up-stage"])],
+        dependencies=DEPS,
+        on_scheduler_resolved=lambda used, reason: resolved.append((used, reason)),
+    )
+    assert "falling back to wave scheduler" in capsys.readouterr().err
+    assert resolved == [("waves", "plan not fully covered")]
+    assert len(results) == 2
 
 
 def test_scheduler_resolution_reported_when_dag_engages(dag_harness):
@@ -178,7 +200,7 @@ def test_scheduler_resolution_reported_when_dag_engages(dag_harness):
 def test_scheduler_resolution_reports_wave_fallback(dag_harness):
     resolved = []
     dag_harness(
-        assignments=[_a("p", 1, ["plan"]), Assignment(worker="x", task="t", stage=2)],
+        assignments=[_a("p", 1, ["plan", "made-up-stage"])],
         dependencies=DEPS,
         on_scheduler_resolved=lambda used, reason: resolved.append((used, reason)),
     )

--- a/tests/test_work_cmd_verification.py
+++ b/tests/test_work_cmd_verification.py
@@ -51,6 +51,79 @@ def test_verify_run_marks_parser_rejected_command_as_rejected_not_failed(tmp_pat
     assert record["signal_value"] == 0
 
 
+_PYTHON_MISSING_PYTHON3_SUGGESTION = (
+    "verification command interpreter python was not found on PATH; use available interpreter python3 instead"
+)
+
+
+def test_verify_run_rejects_missing_python_with_python3_suggestion(tmp_path, capsys, monkeypatch):
+    _init_git_repo(tmp_path)
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    python3_stub = bin_dir / "python3"
+    python3_stub.write_text(f"#!{sys.executable}\nimport sys\nsys.exit(0)\n")
+    python3_stub.chmod(0o755)
+    monkeypatch.setenv("PATH", str(bin_dir))
+
+    rc = work_cmd.verify_run(
+        target=tmp_path,
+        commands=["python -m pytest -q"],
+        json_output=True,
+    )
+    receipt = json.loads(capsys.readouterr().out)
+    assert rc == 2
+    assert receipt["status"] == "rejected"
+    command = receipt["commands"][0]
+    assert command["status"] == "rejected"
+    assert command["stderr_summary"] == _PYTHON_MISSING_PYTHON3_SUGGESTION
+
+
+def test_verify_run_rejects_missing_python_with_inline_path_and_python3_suggestion(tmp_path, capsys, monkeypatch):
+    _init_git_repo(tmp_path)
+    parent_bin = tmp_path / "parent_bin"
+    parent_bin.mkdir()
+    fake_python = parent_bin / "python"
+    fake_python.write_text(f"#!{sys.executable}\nimport sys\nsys.exit(0)\n")
+    fake_python.chmod(0o755)
+    monkeypatch.setenv("PATH", str(parent_bin))
+
+    inline_bin = tmp_path / "inline_bin"
+    inline_bin.mkdir()
+    python3_stub = inline_bin / "python3"
+    python3_stub.write_text(f"#!{sys.executable}\nimport sys\nsys.exit(0)\n")
+    python3_stub.chmod(0o755)
+
+    rc = work_cmd.verify_run(
+        target=tmp_path,
+        commands=[f"PATH={inline_bin} python -m pytest -q", f"PATH={inline_bin} nonexistenttool"],
+        json_output=True,
+    )
+    receipt = json.loads(capsys.readouterr().out)
+    assert rc == 2
+    assert receipt["status"] == "rejected"
+    command0 = receipt["commands"][0]
+    assert command0["status"] == "rejected"
+    assert command0["stderr_summary"] == _PYTHON_MISSING_PYTHON3_SUGGESTION
+
+    command1 = receipt["commands"][1]
+    assert command1["status"] == "rejected"
+    assert command1["stderr_summary"] == "verification command is not resolvable: nonexistenttool"
+
+
+def test_verify_run_rejects_missing_relative_executable_with_full_path_message(tmp_path, capsys):
+    _init_git_repo(tmp_path)
+    rc = work_cmd.verify_run(
+        target=tmp_path,
+        commands=["./scripts/missing-verify.sh"],
+        json_output=True,
+    )
+    receipt = json.loads(capsys.readouterr().out)
+    assert rc == 2
+    assert receipt["commands"][0]["stderr_summary"] == (
+        "verification command is not resolvable: ./scripts/missing-verify.sh"
+    )
+
+
 def test_verify_run_capture_records_outcome_in_one_step(tmp_path, capsys):
     _init_git_repo(tmp_path)
     from brigade import outcome_cmd


### PR DESCRIPTION
## What and why

Bound outcome writes to configured targets, make missing Python interpreters actionable, and annotate stale command inventory failures with the regeneration command. The DAG investigation also found that admission rejected safe coversless root assignments, so that narrow check is corrected here.

Closes #657

## Regression coverage

- Nested outcome ledger: `test_outcome_capture_reports_bounded_error_for_nested_git_target` verifies the bounded nested-target error and absence of a misplaced ledger. `test_append_records_allows_configured_nested_git_target` protects configured nested targets.
- Missing interpreter: `test_verify_run_rejects_missing_python_with_python3_suggestion` pins the actionable Python 3 text. `test_verify_run_rejects_missing_python_with_inline_path_and_python3_suggestion` covers the command's effective PATH.
- Stale command inventory: `test_repo_metadata_command_inventory_failure_is_actionable_and_preserves_status` pins the GitHub error annotation, `docs/command-inventory.md`, the exact regeneration command, and preserved exit status.
- DAG fallback: `test_empty_covers_runs_as_independent_dag_root` confirms a coversless assignment runs as an independent root without a wave fallback. Existing and added unknown-cover tests keep malformed plans on the fallback path.

## Verification

`brigade work verify run --target . --command "./scripts/verify" --capture brigade-work`

Receipt: `20260801-211405-work-verify-0b99de`

Result: 5,687 passed, 3 skipped; coverage 83.04%. Ruff, Ruff format, version sync, mypy, managed snapshots, and the full pytest suite passed.

## Checklist

- [x] Bug fix
- [x] Added regression tests covering each error message
- [x] No new runtime dependencies
- [x] No command inventory regeneration in this branch
- [x] Conventional commit
