### PR TITLE
fix(run): retain the worktree of a failed run with uncommitted work (#656)

### DIFF
--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -233,9 +233,14 @@ takes a local `.brigade/run.lock` (stale locks from dead processes are
 replaced automatically) so two runs do not mutate the same checkout at once.
 Use `--worktree` to run agents in a detached checkout from `HEAD` under
 `~/.cache/brigade/worktrees/`; Brigade writes the resulting diff to
-`changes.patch` in the run artifacts, removes the temporary checkout, and
-leaves the original checkout unchanged. `--worktree` requires run artifacts,
-so it cannot be combined with `--no-artifacts`.
+`changes.patch` in the run artifacts and leaves the original checkout
+unchanged. Successful runs and clean non-success runs remove the temporary
+checkout; failed, timed-out, canceled, and incomplete runs with uncommitted
+changes retain it for recovery. The next successful `--worktree` run for the
+same target prunes older retained entries. Terminal output shows the
+`changes.patch` file count and, when a checkout is retained, its path.
+`--worktree` requires run artifacts, so it cannot be combined with
+`--no-artifacts`.
 
 Start with a roster:
 

--- a/src/brigade/cli/run.py
+++ b/src/brigade/cli/run.py
@@ -599,7 +599,7 @@ def dispatch(args) -> int:
                         tracked_count=summary.tracked_count,
                         untracked_count=summary.untracked_count,
                     )
-                    keep_worktree = False
+                    keep_worktree = rc != 0 and summary.changed
                     if summary.changed:
                         print(
                             f"changes: {summary.path} ({summary.tracked_count + summary.untracked_count} file(s))",
@@ -607,6 +607,11 @@ def dispatch(args) -> int:
                         )
                     else:
                         print(f"changes: none ({summary.path})", file=sys.stderr)
+                    if keep_worktree:
+                        print(f"worktree kept for recovery: {worktree_cwd}", file=sys.stderr)
+                    elif rc == 0:
+                        for pruned in _prune_retained_worktrees(runguard.git_root(run_cwd), effective_cwd):
+                            print(f"worktree pruned: {pruned}", file=sys.stderr)
     except KeyboardInterrupt:
         print("error: run canceled by user", file=sys.stderr)
         if worktree_cwd is not None and keep_worktree:
@@ -862,6 +867,39 @@ def _poll_detached_start(proc: Popen, output_dir: Path, *, initial_receipt: byte
             return exit_code, False
         time.sleep(_DETACH_POLL_INTERVAL_SECONDS)
     return None, False
+
+
+def _prune_retained_worktrees(repo_root: Path, current_worktree: Path) -> list[Path]:
+    from .. import proc
+    from .. import runguard
+
+    repo_root = repo_root.expanduser().resolve()
+    current_worktree = current_worktree.expanduser().resolve()
+    cache_parent = current_worktree.parent
+    prefix = f"{repo_root.name}-"
+
+    result = proc.run(["git", "worktree", "list", "--porcelain"], cwd=repo_root)
+    if result.code != 0:
+        return []
+
+    candidates: list[Path] = []
+    for line in result.stdout.splitlines():
+        if not line.startswith("worktree "):
+            continue
+        path = Path(line.removeprefix("worktree ").strip()).expanduser().resolve()
+        if path == current_worktree:
+            continue
+        if path.parent != cache_parent:
+            continue
+        if not path.name.startswith(prefix):
+            continue
+        candidates.append(path)
+
+    pruned: list[Path] = []
+    for path in candidates:
+        runguard.remove_worktree(repo_root, path)
+        pruned.append(path)
+    return pruned
 
 
 def _worktree_checkout_path(repo_root: Path, output_dir: Path) -> Path:

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -2241,6 +2241,41 @@ def _write_successful_worktree_run(output_dir: Path, cwd: Path, *, final: str = 
     (output_dir / "final.txt").write_text(final + "\n")
 
 
+def _write_terminal_failed_worktree_run(
+    output_dir: Path,
+    cwd: Path,
+    *,
+    final: str = "provider diagnostic",
+    phase: str = "dispatch",
+    kind: str = "provider-error",
+    detail: str = "provider inference failed",
+) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "run.json").write_text(
+        json.dumps(
+            {
+                "schema": "brigade.run.v1",
+                "task": "x",
+                "cwd": str(cwd),
+                "status": "failed",
+                "started_at": "2026-07-09T12:00:00Z",
+                "finished_at": "2026-07-09T12:00:01Z",
+                "duration_seconds": 1,
+                "artifacts": str(output_dir),
+                "error": detail,
+                "failure_phase": phase,
+                "failure": {
+                    "phase": phase,
+                    "kind": kind,
+                    "detail": detail,
+                },
+            }
+        )
+        + "\n"
+    )
+    (output_dir / "final.txt").write_text(final + "\n")
+
+
 def test_run_cli_worktree_passes_detached_cwd_and_writes_changes_patch(tmp_path, monkeypatch):
     repo = _git_repo_with_roster(tmp_path)
     output_dir = tmp_path / "run"
@@ -2309,6 +2344,144 @@ def test_run_cli_worktree_passes_detached_cwd_and_writes_changes_patch(tmp_path,
     }
     assert json.loads((output_dir / "worker-results.json").read_text())["ground_truth"]["patch_ref"] == "changes.patch"
     assert json.loads((output_dir / "synthesis.json").read_text())["ground_truth"]["patch_ref"] == "changes.patch"
+
+
+def test_run_cli_worktree_retains_failed_checkout_with_changes(tmp_path, monkeypatch, capsys):
+    repo = _git_repo_with_roster(tmp_path)
+    output_dir = tmp_path / "run"
+
+    def fake_run(task, loaded_roster, **kwargs):
+        cwd = kwargs["cwd"]
+        (cwd / "tracked.txt").write_text("changed in worktree\n")
+        _write_terminal_failed_worktree_run(kwargs["output_dir"], cwd)
+        return 2
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    monkeypatch.setattr(aboyeur, "run", fake_run)
+
+    rc = cli.main(["run", "x", "--cwd", str(repo), "--output-dir", str(output_dir), "--worktree"])
+
+    err = capsys.readouterr().err
+    checkout = tmp_path / "home" / ".cache" / "brigade" / "worktrees" / f"{repo.name}-{output_dir.name}"
+    patch_path = output_dir / "changes.patch"
+    assert rc == 2
+    assert checkout.exists()
+    assert (checkout / "tracked.txt").read_text() == "changed in worktree\n"
+    assert "tracked.txt" in patch_path.read_text()
+    assert f"changes: {patch_path} (1 file(s))" in err
+    assert f"worktree kept for recovery: {checkout}" in err
+
+
+def test_run_cli_worktree_prunes_failed_checkout_without_changes(tmp_path, monkeypatch, capsys):
+    repo = _git_repo_with_roster(tmp_path)
+    output_dir = tmp_path / "run"
+
+    def fake_run(task, loaded_roster, **kwargs):
+        _write_terminal_failed_worktree_run(kwargs["output_dir"], kwargs["cwd"])
+        return 2
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    monkeypatch.setattr(aboyeur, "run", fake_run)
+
+    rc = cli.main(["run", "x", "--cwd", str(repo), "--output-dir", str(output_dir), "--worktree"])
+
+    err = capsys.readouterr().err
+    checkout = tmp_path / "home" / ".cache" / "brigade" / "worktrees" / f"{repo.name}-{output_dir.name}"
+    patch_path = output_dir / "changes.patch"
+    assert rc == 2
+    assert not checkout.exists()
+    assert patch_path.read_text() == ""
+    assert f"changes: none ({patch_path})" in err
+    assert "worktree kept for recovery" not in err
+
+
+def test_run_cli_success_prunes_retained_worktree_for_same_target(tmp_path, monkeypatch, capsys):
+    repo = _git_repo_with_roster(tmp_path)
+    output_dir_failed = tmp_path / "run-failed"
+    output_dir_success = tmp_path / "run-success"
+    checkout_failed = tmp_path / "home" / ".cache" / "brigade" / "worktrees" / f"{repo.name}-{output_dir_failed.name}"
+    checkout_success = tmp_path / "home" / ".cache" / "brigade" / "worktrees" / f"{repo.name}-{output_dir_success.name}"
+
+    def fake_run(task, loaded_roster, **kwargs):
+        cwd = kwargs["cwd"]
+        output = kwargs["output_dir"]
+        if output == output_dir_failed:
+            (cwd / "tracked.txt").write_text("changed in worktree\n")
+            _write_terminal_failed_worktree_run(output, cwd)
+            return 2
+        assert output == output_dir_success
+        _write_successful_worktree_run(output, cwd)
+        (output / "worker-results.json").write_text(
+            json.dumps({"results": [], "ground_truth": {"available": True, "patch_ref": None}}) + "\n"
+        )
+        (output / "synthesis.json").write_text(
+            json.dumps({"orchestrator": "chef", "result": {"ok": True}, "ground_truth": {"patch_ref": None}}) + "\n"
+        )
+        return 0
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    monkeypatch.setattr(aboyeur, "run", fake_run)
+
+    assert cli.main(["run", "x", "--cwd", str(repo), "--output-dir", str(output_dir_failed), "--worktree"]) == 2
+    assert checkout_failed.exists()
+
+    assert cli.main(["run", "x", "--cwd", str(repo), "--output-dir", str(output_dir_success), "--worktree"]) == 0
+
+    err = capsys.readouterr().err
+    assert not checkout_failed.exists()
+    assert not checkout_success.exists()
+    assert f"worktree pruned: {checkout_failed}" in err
+
+
+def test_run_cli_success_prunes_retained_worktree_for_same_target_from_subdirectory(tmp_path, monkeypatch, capsys):
+    repo = _git_repo_with_roster(tmp_path)
+    repo_src = repo / "src"
+    repo_src.mkdir()
+    roster_path = repo / ".brigade" / "roster.toml"
+    output_dir_failed = tmp_path / "run-failed"
+    output_dir_success = tmp_path / "run-success"
+    checkout_failed = tmp_path / "home" / ".cache" / "brigade" / "worktrees" / f"{repo.name}-{output_dir_failed.name}"
+    checkout_success = tmp_path / "home" / ".cache" / "brigade" / "worktrees" / f"{repo.name}-{output_dir_success.name}"
+
+    def fake_run(task, loaded_roster, **kwargs):
+        cwd = kwargs["cwd"]
+        output = kwargs["output_dir"]
+        if output == output_dir_failed:
+            (cwd / "tracked.txt").write_text("changed in worktree\n")
+            _write_terminal_failed_worktree_run(output, cwd)
+            return 2
+        assert output == output_dir_success
+        _write_successful_worktree_run(output, cwd)
+        (output / "worker-results.json").write_text(
+            json.dumps({"results": [], "ground_truth": {"available": True, "patch_ref": None}}) + "\n"
+        )
+        (output / "synthesis.json").write_text(
+            json.dumps({"orchestrator": "chef", "result": {"ok": True}, "ground_truth": {"patch_ref": None}}) + "\n"
+        )
+        return 0
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    monkeypatch.setattr(aboyeur, "run", fake_run)
+
+    run_args = [
+        "run",
+        "x",
+        "--roster",
+        str(roster_path),
+        "--cwd",
+        str(repo_src),
+        "--worktree",
+    ]
+
+    assert cli.main([*run_args, "--output-dir", str(output_dir_failed)]) == 2
+    assert checkout_failed.exists()
+
+    assert cli.main([*run_args, "--output-dir", str(output_dir_success)]) == 0
+
+    err = capsys.readouterr().err
+    assert not checkout_failed.exists()
+    assert not checkout_success.exists()
+    assert f"worktree pruned: {checkout_failed}" in err
 
 
 def test_run_cli_worktree_warns_on_empty_changes_patch_noop(tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
Closes #656.

## Summary

- Retain a `brigade run --worktree` checkout when the run returns a non-success
  code and its validated `changes.patch` is non-empty.
- Keep the existing cleanup path for successful runs and non-success runs with
  clean worktrees.
- Print the patch file count and retained checkout path in terminal output.
- Document the retained-worktree lifecycle in the technical guide.

## Retention lifecycle

This PR prunes older retained worktrees on the next successful `--worktree`
run for the same target. Cleanup reads Git's registered worktrees from the git
root and removes only older Brigade cache entries with that target's prefix.
If Git cannot list worktrees, the successful run stays successful and the older
checkout remains available for a later cleanup attempt.

## Acceptance coverage

| Criterion | Regression test |
| --- | --- |
| A non-success run with uncommitted changes leaves a recoverable checkout and prints the real patch file count. | `test_run_cli_worktree_retains_failed_checkout_with_changes` |
| A non-success run with a clean checkout prunes it as before. | `test_run_cli_worktree_prunes_failed_checkout_without_changes` |
| The next successful run for the same target prunes an older retained checkout. | `test_run_cli_success_prunes_retained_worktree_for_same_target` |
| Same-target cleanup also works when `--cwd` is a repository subdirectory. | `test_run_cli_success_prunes_retained_worktree_for_same_target_from_subdirectory` |

## Verification

Command:

```text
brigade work verify run --target . --command "./scripts/verify" --capture brigade-work
```

Receipt: `20260801-211802-work-verify-fe92bd`

Result: 5,682 passed, 3 skipped, 83.04% coverage.
