### PR TITLE
fix(checkpoint): harden verification archive export

### DIFF
--- a/.claude/memory-handoffs/2026-08-02-0739-pr668-fix-temp-decoding-retention-gap.md
+++ b/.claude/memory-handoffs/2026-08-02-0739-pr668-fix-temp-decoding-retention-gap.md
@@ -1,0 +1,55 @@
+# Memory Handoff
+
+## Type
+
+bugfix
+
+## Title
+
+PR #668: classify crashed checkpoint temps before decoding; tolerate decoder resource failures on hash-named checkpoints
+
+## Summary
+
+Fixed the native Codex P2 in PR #668 by reordering `_expected_verify_archive_manifest` so `.checkpoint.*.tmp` files are classified and omitted before any bytes are read or JSON-decoded. Also hardened JSON parsing in `_expected_verify_archive_manifest` and `strip_checkpoint_bodies_for_export` so `UnicodeDecodeError`, `JSONDecodeError`, `ValueError`, `RecursionError`, and `MemoryError` are treated as non-reference checkpoint content and continue to hash/filename validation instead of aborting archival. This prevents a deeply nested crashed temp from pinning a stale run, while allowing legitimate deeply nested hash-named checkpoints to export as artifact references.
+
+## Durable facts
+
+- `.checkpoint.*.tmp` files have no canonical `{sha256}.json` path and must be omitted from the archive export tree unconditionally; this decision can be made from the filename alone.
+- JSON decoding of checkpoint bodies is only used to detect an already-canonical artifact reference. Decoder/resource failures on `.json` files must not abort archival or pin retention; they should fall through to content-hash/filename validation.
+- `strip_checkpoint_bodies_for_export` needs the same error handling as `_expected_verify_archive_manifest`; otherwise a hash-named deeply nested checkpoint would raise `RecursionError` during staging export even though the expected manifest was computed successfully.
+- Canonical artifact-reference filename validation is unchanged: a reference payload is only accepted as canonical at `<sha256>.json`; any other filename still falls through to hash validation and is omitted as a mismatch.
+
+## Evidence
+
+- files changed: `src/brigade/work_cmd/verification.py`, `src/brigade/run_checkpoint.py`, `tests/test_work_cmd_verification.py`
+- commands run:
+  - `brigade work verify run --target . --command "python3 -m pytest tests/test_work_cmd_verification.py -k 'archive or prune or checkpoint' -q" --capture brigade-work` (31 passed)
+  - `brigade work verify run --target . --command "ruff check src/brigade/work_cmd/verification.py src/brigade/run_checkpoint.py tests/test_work_cmd_verification.py" --capture brigade-work` (All checks passed!)
+  - `brigade work verify run --target . --command "ruff format --check src/brigade/work_cmd/verification.py src/brigade/run_checkpoint.py tests/test_work_cmd_verification.py" --capture brigade-work` (3 files already formatted)
+  - `brigade work verify run --target . --command ".venv/bin/mypy src/brigade/work_cmd/verification.py src/brigade/run_checkpoint.py" --capture brigade-work` (Success: no issues found in 2 source files)
+  - `brigade work verify run --target . --command "git diff --check" --capture brigade-work` (clean)
+- tests added:
+  - `test_archive_verify_run_omits_deeply_nested_crashed_checkpoint_temp`
+  - `test_archive_verify_run_exports_deeply_nested_hash_named_checkpoint_as_reference`
+
+## Recommended memory action
+
+no-card
+
+## Target document
+
+.learnings/LEARNINGS.md
+
+## Suggested document content
+
+### Verification archive: classify crashed checkpoint temps before decoding
+
+In `_expected_verify_archive_manifest`, always classify and omit `.checkpoint.*.tmp` files from the verify-archive export based on the filename alone, before reading or decoding their arbitrary body bytes. Crashed temp bytes are private and uncanonical; decoding them first can raise `RecursionError` or other decoder exceptions, which aborts archival and leaves the stale run unprunable on every retry.
+
+### Decoder/resource failures on checkpoint JSON are non-reference, not fatal
+
+When checking whether a non-temp `.json` checkpoint is already an artifact reference, catch `UnicodeDecodeError`, `JSONDecodeError`, `ValueError`, `RecursionError`, and `MemoryError` and treat the result as non-reference content. Continue to content-hash/filename validation so a valid hash-named checkpoint still exports as an artifact reference, while a malformed or mismatched file is omitted with a bounded diagnostic. Apply the same exception handling in `strip_checkpoint_bodies_for_export` so the staging export does not abort after the expected manifest has been computed.
+
+### Do not weaken canonical artifact-reference filename validation
+
+An artifact-reference payload is only accepted as already-canonical when it lives at its declared `<sha256>.json` path. A reference-shaped payload under any other filename must still fall through to hash/filename validation and be omitted as a hash mismatch.

--- a/src/brigade/run_checkpoint.py
+++ b/src/brigade/run_checkpoint.py
@@ -1183,6 +1183,7 @@ def recover_from_checkpoint(
 # -- Export boundary (issue #636) ---------------------------------------------
 
 _ARTIFACT_REFERENCE_KEYS = frozenset({"path", "sha256", "media_type", "byte_size", "privacy_class"})
+_CHECKPOINT_TEMP_GLOB = ".checkpoint.*.tmp"
 
 
 def checkpoint_artifact_reference(*, sha256: str, byte_size: int) -> dict[str, Any]:
@@ -1238,7 +1239,8 @@ def strip_checkpoint_bodies_for_export(run_dir: Path) -> list[dict[str, Any]]:
     if not cp_dir.is_dir():
         return []
     replaced: list[dict[str, Any]] = []
-    for path in sorted(cp_dir.glob("*.json")):
+    paths = sorted((*cp_dir.glob("*.json"), *cp_dir.glob(_CHECKPOINT_TEMP_GLOB)))
+    for path in paths:
         if not path.is_file() or path.is_symlink():
             refuse_checkpoint_body_export(reason="checkpoint export path is not a regular file")
         raw = path.read_bytes()
@@ -1250,7 +1252,7 @@ def strip_checkpoint_bodies_for_export(run_dir: Path) -> list[dict[str, Any]]:
             replaced.append(dict(parsed))
             continue
         sha = hashlib.sha256(raw).hexdigest()
-        if path.name != f"{sha}.json":
+        if path.suffix == ".json" and path.name != f"{sha}.json":
             refuse_checkpoint_body_export(reason="checkpoint export filename digest mismatch")
         reference = checkpoint_artifact_reference(sha256=sha, byte_size=len(raw))
         path.write_text(json.dumps(reference, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -1261,7 +1263,14 @@ def strip_checkpoint_bodies_for_export(run_dir: Path) -> list[dict[str, Any]]:
 
 def assert_export_tree_has_no_checkpoint_bodies(root: Path) -> None:
     """Fail closed if any recovery-checkpoint file under root still holds a body."""
-    for path in sorted(Path(root).rglob(f"*/{CHECKPOINT_DIR_NAME}/*.json")):
+    root = Path(root)
+    paths = sorted(
+        (
+            *root.rglob(f"*/{CHECKPOINT_DIR_NAME}/*.json"),
+            *root.rglob(f"*/{CHECKPOINT_DIR_NAME}/{_CHECKPOINT_TEMP_GLOB}"),
+        )
+    )
+    for path in paths:
         if not path.is_file():
             continue
         try:

--- a/src/brigade/run_checkpoint.py
+++ b/src/brigade/run_checkpoint.py
@@ -1239,8 +1239,11 @@ def strip_checkpoint_bodies_for_export(run_dir: Path) -> list[dict[str, Any]]:
     if not cp_dir.is_dir():
         return []
     replaced: list[dict[str, Any]] = []
-    paths = sorted((*cp_dir.glob("*.json"), *cp_dir.glob(_CHECKPOINT_TEMP_GLOB)))
-    for path in paths:
+    # Only content-addressed ``{sha}.json`` bodies can be rewritten to a truthful
+    # artifact reference. Crashed ``.checkpoint.*.tmp`` temp bodies have no
+    # canonical hash path, so callers omit them from the export tree before this
+    # runs (see verification._archive_verify_run); they are never rewritten here.
+    for path in sorted(cp_dir.glob("*.json")):
         if not path.is_file() or path.is_symlink():
             refuse_checkpoint_body_export(reason="checkpoint export path is not a regular file")
         raw = path.read_bytes()
@@ -1252,7 +1255,7 @@ def strip_checkpoint_bodies_for_export(run_dir: Path) -> list[dict[str, Any]]:
             replaced.append(dict(parsed))
             continue
         sha = hashlib.sha256(raw).hexdigest()
-        if path.suffix == ".json" and path.name != f"{sha}.json":
+        if path.name != f"{sha}.json":
             refuse_checkpoint_body_export(reason="checkpoint export filename digest mismatch")
         reference = checkpoint_artifact_reference(sha256=sha, byte_size=len(raw))
         path.write_text(json.dumps(reference, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/src/brigade/run_checkpoint.py
+++ b/src/brigade/run_checkpoint.py
@@ -1249,7 +1249,11 @@ def strip_checkpoint_bodies_for_export(run_dir: Path) -> list[dict[str, Any]]:
         raw = path.read_bytes()
         try:
             parsed = json.loads(raw.decode("utf-8"))
-        except (UnicodeDecodeError, json.JSONDecodeError):
+        except (UnicodeDecodeError, json.JSONDecodeError, ValueError, RecursionError, MemoryError):
+            # JSON parsing here is only used to detect an already-canonical
+            # artifact reference. Decoder/resource failures are treated as
+            # non-reference checkpoint content and continue to hash/filename
+            # validation (PR #668).
             parsed = None
         if isinstance(parsed, dict) and is_checkpoint_artifact_reference(parsed):
             replaced.append(dict(parsed))

--- a/src/brigade/work_cmd/verification.py
+++ b/src/brigade/work_cmd/verification.py
@@ -583,13 +583,12 @@ def _exported_checkpoint_errors(omissions: list[dict[str, str]]) -> list[dict[st
 
     The internal record carries the raw checkpoint relative path so the archive
     writer can locate the body to omit. The exported shape must never leak that
-    path (a private filename): it emits only a bounded category, a
-    non-reversible content digest, and a constant per-category detail string.
+    path (a private filename) or a raw-body digest: it emits only a bounded
+    category and a constant per-category detail string.
     """
     return [
         {
             "category": omission["category"],
-            "digest": omission["digest"],
             "detail": _CHECKPOINT_OMISSION_DETAIL[omission["category"]],
         }
         for omission in omissions
@@ -602,9 +601,9 @@ def _expected_verify_archive_manifest(
     """Return the privacy-normalized manifest and internal checkpoint omissions.
 
     Omission records carry ``relative`` (the raw path, for the archive writer to
-    delete the body) alongside a bounded ``category`` and a non-reversible
-    content ``digest``. Callers export only the privacy-safe projection via
-    ``_exported_checkpoint_errors``; the raw path never leaves this module.
+    delete the body) alongside a bounded ``category``. Callers export only the
+    privacy-safe projection via ``_exported_checkpoint_errors``; the raw path
+    is used only while writing the staging tree and never reaches the index.
     """
     from brigade import run_checkpoint
 
@@ -630,11 +629,11 @@ def _expected_verify_archive_manifest(
             # cannot be rewritten to a truthful artifact reference. Omit the
             # private body from the export tree and record a bounded diagnostic.
             expected.pop(relative)
-            omissions.append({"category": "checkpoint-crashed-temp", "relative": relative, "digest": sha})
+            omissions.append({"category": "checkpoint-crashed-temp", "relative": relative})
             continue
         if path.name != f"{sha}.json":
             expected.pop(relative)
-            omissions.append({"category": "checkpoint-hash-mismatch", "relative": relative, "digest": sha})
+            omissions.append({"category": "checkpoint-hash-mismatch", "relative": relative})
             continue
         reference = run_checkpoint.checkpoint_artifact_reference(sha256=sha, byte_size=len(raw))
         ref_bytes = (json.dumps(reference, indent=2, sort_keys=True) + "\n").encode("utf-8")
@@ -664,10 +663,11 @@ def _archive_verify_run(run_dir: Path, archive_root: Path) -> dict[str, Any]:
     if dest.is_symlink():
         raise OSError(f"verify archive conflict: {dest} is a symlink")
     if dest.exists():
-        # Re-archive is safe when evidence matches the source, or when the
-        # existing archive is already the privacy-normalized export of source.
+        # Existing archives are immutable. Re-archive only when the destination
+        # is already the exact privacy-normalized export of the source. A legacy
+        # raw destination must fail closed so it cannot be normalized in place.
         dest_manifest = _verify_archive_tree_manifest(dest)
-        if dest_manifest not in (source_manifest, expected_manifest):
+        if dest_manifest != expected_manifest:
             raise OSError(f"verify archive conflict: {dest} already exists with different evidence")
         dest_receipt = dest / "receipt.json"
         dest_sha = localio.file_sha256(dest_receipt) if dest_receipt.is_file() else None
@@ -675,13 +675,8 @@ def _archive_verify_run(run_dir: Path, archive_root: Path) -> dict[str, Any]:
             raise OSError(f"verify archive conflict: {dest} already exists with different evidence")
         if dest_sha is not None:
             _assert_archived_receipt_integrity(dest_receipt)
-        # No pathname unlink here: dest_manifest already matched source_manifest
-        # or expected_manifest, which proves the omitted bodies are absent from
-        # (or already normalized in) the destination. Deleting by pathname would
-        # be redundant and would race a concurrent reader of the live archive.
-        # strip is idempotent on an already-normalized tree (references skip)
-        # and assert is read-only, so a re-archive never mutates the destination.
-        run_checkpoint.strip_checkpoint_bodies_for_export(dest)
+        # The equal manifest proves normalization has already happened. Do not
+        # call a writer on this live destination: archival retries are read-only.
         run_checkpoint.assert_export_tree_has_no_checkpoint_bodies(dest)
         entry = _verify_archive_index_entry(
             run_dir,

--- a/src/brigade/work_cmd/verification.py
+++ b/src/brigade/work_cmd/verification.py
@@ -483,10 +483,11 @@ def _verify_archive_index_entry(
     receipt_file_sha256: str | None,
     *,
     already_archived: bool,
+    checkpoint_errors: list[dict[str, str]] | None = None,
 ) -> dict[str, Any]:
     receipt = _verify_read_receipt(dest)
     digests = receipt.get("digests") if receipt is not None and isinstance(receipt.get("digests"), dict) else {}
-    return {
+    entry: dict[str, Any] = {
         "schema": VERIFY_ARCHIVE_INDEX_SCHEMA,
         "schema_version": VERIFY_ARCHIVE_INDEX_SCHEMA_VERSION,
         "run_id": run_dir.name,
@@ -503,6 +504,9 @@ def _verify_archive_index_entry(
         "started_at": receipt.get("started_at") if receipt is not None else None,
         "completed_at": receipt.get("completed_at") if receipt is not None else None,
     }
+    if checkpoint_errors:
+        entry["checkpoint_errors"] = checkpoint_errors
+    return entry
 
 
 def _append_verify_archive_index(archive_root: Path, entry: dict[str, Any]) -> None:
@@ -567,14 +571,17 @@ def _verify_archive_tree_manifest(root: Path) -> dict[str, tuple[str, str | None
 
 def _expected_verify_archive_manifest(
     run_dir: Path, source_manifest: dict[str, tuple[str, str | None]]
-) -> dict[str, tuple[str, str | None]]:
-    """Return the tree manifest after recovery-checkpoint export stripping (#636)."""
+) -> tuple[dict[str, tuple[str, str | None]], list[dict[str, str]]]:
+    """Return the privacy-normalized manifest and bounded checkpoint errors."""
     from brigade import run_checkpoint
 
     expected = dict(source_manifest)
+    checkpoint_errors: list[dict[str, str]] = []
     prefix = f"events/{run_checkpoint.CHECKPOINT_DIR_NAME}/"
     for relative, (kind, _digest) in list(expected.items()):
-        if kind != "file" or not relative.startswith(prefix) or not relative.endswith(".json"):
+        name = Path(relative).name
+        is_temp = name.startswith(".checkpoint.") and name.endswith(".tmp")
+        if kind != "file" or not relative.startswith(prefix) or not (relative.endswith(".json") or is_temp):
             continue
         path = run_dir / relative
         raw = path.read_bytes()
@@ -585,12 +592,20 @@ def _expected_verify_archive_manifest(
         if isinstance(parsed, dict) and run_checkpoint.is_checkpoint_artifact_reference(parsed):
             continue
         sha = hashlib.sha256(raw).hexdigest()
-        if path.name != f"{sha}.json":
-            raise OSError(f"verify archive checkpoint export filename digest mismatch: {relative}")
+        if not is_temp and path.name != f"{sha}.json":
+            expected.pop(relative)
+            checkpoint_errors.append(
+                {
+                    "category": "checkpoint-hash-mismatch",
+                    "path": relative,
+                    "error": "checkpoint content hash does not match filename; omitted from verification archive",
+                }
+            )
+            continue
         reference = run_checkpoint.checkpoint_artifact_reference(sha256=sha, byte_size=len(raw))
         ref_bytes = (json.dumps(reference, indent=2, sort_keys=True) + "\n").encode("utf-8")
         expected[relative] = ("file", hashlib.sha256(ref_bytes).hexdigest())
-    return expected
+    return expected, checkpoint_errors
 
 
 def _archive_verify_run(run_dir: Path, archive_root: Path) -> dict[str, Any]:
@@ -608,7 +623,7 @@ def _archive_verify_run(run_dir: Path, archive_root: Path) -> dict[str, Any]:
     run_id = run_dir.name
     dest = archive_root / run_id
     source_manifest = _verify_archive_tree_manifest(run_dir)
-    expected_manifest = _expected_verify_archive_manifest(run_dir, source_manifest)
+    expected_manifest, checkpoint_errors = _expected_verify_archive_manifest(run_dir, source_manifest)
     receipt_path = run_dir / "receipt.json"
     source_receipt_sha = localio.file_sha256(receipt_path) if receipt_path.is_file() else None
     if dest.is_symlink():
@@ -625,9 +640,17 @@ def _archive_verify_run(run_dir: Path, archive_root: Path) -> dict[str, Any]:
             raise OSError(f"verify archive conflict: {dest} already exists with different evidence")
         if dest_sha is not None:
             _assert_archived_receipt_integrity(dest_receipt)
+        for checkpoint_error in checkpoint_errors:
+            (dest / checkpoint_error["path"]).unlink(missing_ok=True)
         run_checkpoint.strip_checkpoint_bodies_for_export(dest)
         run_checkpoint.assert_export_tree_has_no_checkpoint_bodies(dest)
-        entry = _verify_archive_index_entry(run_dir, dest, dest_sha, already_archived=True)
+        entry = _verify_archive_index_entry(
+            run_dir,
+            dest,
+            dest_sha,
+            already_archived=True,
+            checkpoint_errors=checkpoint_errors,
+        )
         _append_verify_archive_index(archive_root, entry)
         return entry
     archive_root.mkdir(parents=True, exist_ok=True)
@@ -641,6 +664,11 @@ def _archive_verify_run(run_dir: Path, archive_root: Path) -> dict[str, Any]:
             if copied_sha != source_receipt_sha:
                 raise OSError(f"verify archive copy integrity check failed: {run_id}")
             _assert_archived_receipt_integrity(staging / "receipt.json")
+        # A hash-mismatched checkpoint cannot be represented truthfully. Omit
+        # only that private body from the archive and record the bounded error
+        # in the archive index so one corrupt checkpoint cannot pin the run.
+        for checkpoint_error in checkpoint_errors:
+            (staging / checkpoint_error["path"]).unlink()
         # Export boundary (#636): never archive private recovery-checkpoint
         # bodies. Replace them with the closed artifact-reference shape after
         # the byte-identical copy check so local recovery semantics stay intact.
@@ -655,7 +683,13 @@ def _archive_verify_run(run_dir: Path, archive_root: Path) -> dict[str, Any]:
         shutil.rmtree(staging, ignore_errors=True)
         raise
     archived_receipt_sha = localio.file_sha256(dest / "receipt.json") if source_receipt_sha is not None else None
-    entry = _verify_archive_index_entry(run_dir, dest, archived_receipt_sha, already_archived=False)
+    entry = _verify_archive_index_entry(
+        run_dir,
+        dest,
+        archived_receipt_sha,
+        already_archived=False,
+        checkpoint_errors=checkpoint_errors,
+    )
     _append_verify_archive_index(archive_root, entry)
     return entry
 

--- a/src/brigade/work_cmd/verification.py
+++ b/src/brigade/work_cmd/verification.py
@@ -615,31 +615,32 @@ def _expected_verify_archive_manifest(
         is_temp = name.startswith(".checkpoint.") and name.endswith(".tmp")
         if kind != "file" or not relative.startswith(prefix) or not (relative.endswith(".json") or is_temp):
             continue
+        # A crashed temp has no canonical hash path; classify and omit it before
+        # reading or decoding its arbitrary body bytes (PR #668).
+        if is_temp:
+            expected.pop(relative)
+            omissions.append({"category": "checkpoint-crashed-temp", "relative": relative})
+            continue
         path = run_dir / relative
         raw = path.read_bytes()
         try:
             parsed = json.loads(raw.decode("utf-8"))
-        except (UnicodeDecodeError, json.JSONDecodeError):
+        except (UnicodeDecodeError, json.JSONDecodeError, ValueError, RecursionError, MemoryError):
+            # JSON parsing here is only used to detect an already-canonical
+            # artifact reference. Decoder/resource failures are treated as
+            # non-reference checkpoint content and continue to hash/filename
+            # validation; they never pin retention (PR #668).
             parsed = None
         if (
-            not is_temp
-            and isinstance(parsed, dict)
+            isinstance(parsed, dict)
             and run_checkpoint.is_checkpoint_artifact_reference(parsed)
             and path.name == f"{parsed['sha256']}.json"
         ):
             # Already the canonical export shape at its canonical ``{sha}.json``
-            # path. A crashed temp is never canonical, and a reference under any
-            # other filename must fall through to the hash/filename validation
-            # below so it is omitted when invalid.
+            # path. A reference under any other filename must fall through to
+            # the hash/filename validation below so it is omitted when invalid.
             continue
         sha = hashlib.sha256(raw).hexdigest()
-        if is_temp:
-            # A crashed temp body has no canonical ``{sha}.json`` path, so it
-            # cannot be rewritten to a truthful artifact reference. Omit the
-            # private body from the export tree and record a bounded diagnostic.
-            expected.pop(relative)
-            omissions.append({"category": "checkpoint-crashed-temp", "relative": relative})
-            continue
         if path.name != f"{sha}.json":
             expected.pop(relative)
             omissions.append({"category": "checkpoint-hash-mismatch", "relative": relative})

--- a/src/brigade/work_cmd/verification.py
+++ b/src/brigade/work_cmd/verification.py
@@ -569,14 +569,47 @@ def _verify_archive_tree_manifest(root: Path) -> dict[str, tuple[str, str | None
     return manifest
 
 
+# Bounded, constant diagnostics recorded when a checkpoint body cannot be
+# exported as a truthful artifact reference. The text is a fixed per-category
+# string; it never carries the private checkpoint filename or body.
+_CHECKPOINT_OMISSION_DETAIL = {
+    "checkpoint-hash-mismatch": "checkpoint content hash does not match filename; omitted from verification archive",
+    "checkpoint-crashed-temp": "crashed checkpoint temp has no canonical hash path; omitted from verification archive",
+}
+
+
+def _exported_checkpoint_errors(omissions: list[dict[str, str]]) -> list[dict[str, str]]:
+    """Project internal omission records into a privacy-safe index diagnostic.
+
+    The internal record carries the raw checkpoint relative path so the archive
+    writer can locate the body to omit. The exported shape must never leak that
+    path (a private filename): it emits only a bounded category, a
+    non-reversible content digest, and a constant per-category detail string.
+    """
+    return [
+        {
+            "category": omission["category"],
+            "digest": omission["digest"],
+            "detail": _CHECKPOINT_OMISSION_DETAIL[omission["category"]],
+        }
+        for omission in omissions
+    ]
+
+
 def _expected_verify_archive_manifest(
     run_dir: Path, source_manifest: dict[str, tuple[str, str | None]]
 ) -> tuple[dict[str, tuple[str, str | None]], list[dict[str, str]]]:
-    """Return the privacy-normalized manifest and bounded checkpoint errors."""
+    """Return the privacy-normalized manifest and internal checkpoint omissions.
+
+    Omission records carry ``relative`` (the raw path, for the archive writer to
+    delete the body) alongside a bounded ``category`` and a non-reversible
+    content ``digest``. Callers export only the privacy-safe projection via
+    ``_exported_checkpoint_errors``; the raw path never leaves this module.
+    """
     from brigade import run_checkpoint
 
     expected = dict(source_manifest)
-    checkpoint_errors: list[dict[str, str]] = []
+    omissions: list[dict[str, str]] = []
     prefix = f"events/{run_checkpoint.CHECKPOINT_DIR_NAME}/"
     for relative, (kind, _digest) in list(expected.items()):
         name = Path(relative).name
@@ -592,20 +625,21 @@ def _expected_verify_archive_manifest(
         if isinstance(parsed, dict) and run_checkpoint.is_checkpoint_artifact_reference(parsed):
             continue
         sha = hashlib.sha256(raw).hexdigest()
-        if not is_temp and path.name != f"{sha}.json":
+        if is_temp:
+            # A crashed temp body has no canonical ``{sha}.json`` path, so it
+            # cannot be rewritten to a truthful artifact reference. Omit the
+            # private body from the export tree and record a bounded diagnostic.
             expected.pop(relative)
-            checkpoint_errors.append(
-                {
-                    "category": "checkpoint-hash-mismatch",
-                    "path": relative,
-                    "error": "checkpoint content hash does not match filename; omitted from verification archive",
-                }
-            )
+            omissions.append({"category": "checkpoint-crashed-temp", "relative": relative, "digest": sha})
+            continue
+        if path.name != f"{sha}.json":
+            expected.pop(relative)
+            omissions.append({"category": "checkpoint-hash-mismatch", "relative": relative, "digest": sha})
             continue
         reference = run_checkpoint.checkpoint_artifact_reference(sha256=sha, byte_size=len(raw))
         ref_bytes = (json.dumps(reference, indent=2, sort_keys=True) + "\n").encode("utf-8")
         expected[relative] = ("file", hashlib.sha256(ref_bytes).hexdigest())
-    return expected, checkpoint_errors
+    return expected, omissions
 
 
 def _archive_verify_run(run_dir: Path, archive_root: Path) -> dict[str, Any]:
@@ -623,7 +657,8 @@ def _archive_verify_run(run_dir: Path, archive_root: Path) -> dict[str, Any]:
     run_id = run_dir.name
     dest = archive_root / run_id
     source_manifest = _verify_archive_tree_manifest(run_dir)
-    expected_manifest, checkpoint_errors = _expected_verify_archive_manifest(run_dir, source_manifest)
+    expected_manifest, omissions = _expected_verify_archive_manifest(run_dir, source_manifest)
+    checkpoint_errors = _exported_checkpoint_errors(omissions)
     receipt_path = run_dir / "receipt.json"
     source_receipt_sha = localio.file_sha256(receipt_path) if receipt_path.is_file() else None
     if dest.is_symlink():
@@ -640,8 +675,12 @@ def _archive_verify_run(run_dir: Path, archive_root: Path) -> dict[str, Any]:
             raise OSError(f"verify archive conflict: {dest} already exists with different evidence")
         if dest_sha is not None:
             _assert_archived_receipt_integrity(dest_receipt)
-        for checkpoint_error in checkpoint_errors:
-            (dest / checkpoint_error["path"]).unlink(missing_ok=True)
+        # No pathname unlink here: dest_manifest already matched source_manifest
+        # or expected_manifest, which proves the omitted bodies are absent from
+        # (or already normalized in) the destination. Deleting by pathname would
+        # be redundant and would race a concurrent reader of the live archive.
+        # strip is idempotent on an already-normalized tree (references skip)
+        # and assert is read-only, so a re-archive never mutates the destination.
         run_checkpoint.strip_checkpoint_bodies_for_export(dest)
         run_checkpoint.assert_export_tree_has_no_checkpoint_bodies(dest)
         entry = _verify_archive_index_entry(
@@ -664,11 +703,13 @@ def _archive_verify_run(run_dir: Path, archive_root: Path) -> dict[str, Any]:
             if copied_sha != source_receipt_sha:
                 raise OSError(f"verify archive copy integrity check failed: {run_id}")
             _assert_archived_receipt_integrity(staging / "receipt.json")
-        # A hash-mismatched checkpoint cannot be represented truthfully. Omit
-        # only that private body from the archive and record the bounded error
-        # in the archive index so one corrupt checkpoint cannot pin the run.
-        for checkpoint_error in checkpoint_errors:
-            (staging / checkpoint_error["path"]).unlink()
+        # A hash-mismatched or crashed-temp checkpoint cannot be represented as
+        # a truthful artifact reference. Omit only that private body from the
+        # archive and record the bounded diagnostic in the archive index so one
+        # corrupt checkpoint cannot pin the run. The raw relative path is used
+        # here only to locate the staged body; it never reaches the index.
+        for omission in omissions:
+            (staging / omission["relative"]).unlink()
         # Export boundary (#636): never archive private recovery-checkpoint
         # bodies. Replace them with the closed artifact-reference shape after
         # the byte-identical copy check so local recovery semantics stay intact.

--- a/src/brigade/work_cmd/verification.py
+++ b/src/brigade/work_cmd/verification.py
@@ -621,7 +621,16 @@ def _expected_verify_archive_manifest(
             parsed = json.loads(raw.decode("utf-8"))
         except (UnicodeDecodeError, json.JSONDecodeError):
             parsed = None
-        if isinstance(parsed, dict) and run_checkpoint.is_checkpoint_artifact_reference(parsed):
+        if (
+            not is_temp
+            and isinstance(parsed, dict)
+            and run_checkpoint.is_checkpoint_artifact_reference(parsed)
+            and path.name == f"{parsed['sha256']}.json"
+        ):
+            # Already the canonical export shape at its canonical ``{sha}.json``
+            # path. A crashed temp is never canonical, and a reference under any
+            # other filename must fall through to the hash/filename validation
+            # below so it is omitted when invalid.
             continue
         sha = hashlib.sha256(raw).hexdigest()
         if is_temp:

--- a/tests/test_work_cmd_verification.py
+++ b/tests/test_work_cmd_verification.py
@@ -2,7 +2,9 @@ import hashlib
 import json
 import os
 import shlex
+import shutil
 import sqlite3
+import stat
 import subprocess
 import sys
 from pathlib import Path
@@ -2814,7 +2816,6 @@ def test_archive_verify_run_omits_crashed_checkpoint_temp(tmp_path):
     assert entry["checkpoint_errors"] == [
         {
             "category": "checkpoint-crashed-temp",
-            "digest": hashlib.sha256(body).hexdigest(),
             "detail": "crashed checkpoint temp has no canonical hash path; omitted from verification archive",
         }
     ]
@@ -2881,7 +2882,6 @@ def test_prune_verify_runs_omits_hash_mismatched_checkpoint_and_remains_bounded(
     assert bad_entry["checkpoint_errors"] == [
         {
             "category": "checkpoint-hash-mismatch",
-            "digest": hashlib.sha256(body.encode("utf-8")).hexdigest(),
             "detail": "checkpoint content hash does not match filename; omitted from verification archive",
         }
     ]
@@ -2929,6 +2929,47 @@ def test_archive_verify_run_does_not_mutate_already_archived_destination(tmp_pat
     )
     assert not (dest / "events" / run_checkpoint.CHECKPOINT_DIR_NAME / ".checkpoint.crashed.tmp").exists()
     assert (cp_dir / f"{good_sha}.json").read_bytes() == good_body
+
+
+@pytest.mark.parametrize("checkpoint_name", ["valid", "crashed-temp"])
+def test_archive_verify_run_rejects_legacy_raw_destination_without_mutation(tmp_path, checkpoint_name):
+    """Existing legacy raw archives fail closed and remain byte-for-byte immutable."""
+    from brigade import run_checkpoint
+    from brigade.work_cmd import helpers, verification
+
+    root = helpers._verify_runs_root(tmp_path)
+    root.mkdir(parents=True)
+    run_dir, _ = _write_verify_run_dir(root, "20260101-000001-a", sign=True)
+    cp_dir = run_dir / "events" / run_checkpoint.CHECKPOINT_DIR_NAME
+    cp_dir.mkdir(parents=True)
+    body = b'{"task":"legacy checkpoint body"}\n'
+    if checkpoint_name == "valid":
+        sha = hashlib.sha256(body).hexdigest()
+        checkpoint = cp_dir / f"{sha}.json"
+    else:
+        checkpoint = cp_dir / ".checkpoint.crashed.tmp"
+    checkpoint.write_bytes(body)
+    os.chmod(checkpoint, 0o640)
+
+    archive_root = tmp_path / "verify-archive"
+    archive_root.mkdir()
+    dest = archive_root / run_dir.name
+    shutil.copytree(run_dir, dest)
+
+    def _snapshot(tree):
+        return {
+            path.relative_to(tree).as_posix(): (
+                stat.S_IMODE(path.lstat().st_mode),
+                path.read_bytes() if path.is_file() else None,
+            )
+            for path in sorted((tree, *tree.rglob("*")), key=lambda path: path.as_posix())
+        }
+
+    before = _snapshot(dest)
+    for _attempt in range(2):
+        with pytest.raises(OSError, match="already exists with different evidence"):
+            verification._archive_verify_run(run_dir, archive_root)
+        assert _snapshot(dest) == before
 
 
 def test_capture_before_retry_uses_receipt_stamped_artifact(tmp_target, monkeypatch, capsys):

--- a/tests/test_work_cmd_verification.py
+++ b/tests/test_work_cmd_verification.py
@@ -2776,7 +2776,10 @@ def test_archive_verify_run_strips_recovery_checkpoint_bodies(tmp_path):
     assert not (root / "20260101-000001-a").exists()
 
 
-def test_archive_verify_run_strips_crashed_checkpoint_temp(tmp_path):
+def test_archive_verify_run_omits_crashed_checkpoint_temp(tmp_path):
+    """A crashed .checkpoint.*.tmp has no canonical hash path, so it is omitted
+    from the export tree (not rewritten to a bogus artifact reference) and a
+    bounded, privacy-safe diagnostic is recorded in the archive index (#654)."""
     from brigade import run_checkpoint
     from brigade.work_cmd import helpers, verification
 
@@ -2788,22 +2791,38 @@ def test_archive_verify_run_strips_crashed_checkpoint_temp(tmp_path):
     cp_dir.mkdir(parents=True)
     private_task = "SECRET_CRASHED_CHECKPOINT_must_not_archive"
     body = (json.dumps({"task": private_task}, sort_keys=True) + "\n").encode()
-    crashed_temp = cp_dir / ".checkpoint.crashed.tmp"
+    crashed_temp = cp_dir / ".checkpoint.secret-tenant-acme.tmp"
     crashed_temp.write_bytes(body)
 
     archive_root = tmp_path / "verify-archive"
     removed = verification._prune_verify_runs(tmp_path, keep=1, archive_root=archive_root)
 
     assert removed == 1
-    archived_temp = archive_root / run_dir.name / "events" / run_checkpoint.CHECKPOINT_DIR_NAME / crashed_temp.name
-    payload = json.loads(archived_temp.read_text(encoding="utf-8"))
-    assert run_checkpoint.is_checkpoint_artifact_reference(payload)
-    assert payload["sha256"] == hashlib.sha256(body).hexdigest()
-    assert private_task not in archived_temp.read_text(encoding="utf-8")
-    run_checkpoint.assert_export_tree_has_no_checkpoint_bodies(archive_root / run_dir.name)
+    archived_run = archive_root / run_dir.name
+    # The crashed temp body is absent from the archive tree, not rewritten.
+    archived_temp = archived_run / "events" / run_checkpoint.CHECKPOINT_DIR_NAME / crashed_temp.name
+    assert not archived_temp.exists()
+    for path in archived_run.rglob("*"):
+        if path.is_file():
+            assert private_task not in path.read_text(encoding="utf-8", errors="ignore")
+    run_checkpoint.assert_export_tree_has_no_checkpoint_bodies(archived_run)
+    # A bounded, non-reversible diagnostic is recorded; the private temp filename
+    # never reaches the index.
+    index_text = (archive_root / "index.jsonl").read_text(encoding="utf-8")
+    assert "secret-tenant-acme" not in index_text
+    entry = next(e for e in _read_archive_index(archive_root) if e["run_id"] == run_dir.name)
+    assert entry["checkpoint_errors"] == [
+        {
+            "category": "checkpoint-crashed-temp",
+            "digest": hashlib.sha256(body).hexdigest(),
+            "detail": "crashed checkpoint temp has no canonical hash path; omitted from verification archive",
+        }
+    ]
 
 
-def test_archive_verify_run_asserts_when_crashed_temp_stripping_is_bypassed(tmp_path, monkeypatch):
+def test_archive_verify_run_fails_closed_when_crashed_temp_not_omitted(tmp_path, monkeypatch):
+    """If the omission step is bypassed, the export-boundary assert must fail
+    closed rather than archive a private crashed-temp body."""
     from brigade import run_checkpoint
     from brigade.work_cmd import helpers, verification
 
@@ -2813,7 +2832,13 @@ def test_archive_verify_run_asserts_when_crashed_temp_stripping_is_bypassed(tmp_
     cp_dir = run_dir / "events" / run_checkpoint.CHECKPOINT_DIR_NAME
     cp_dir.mkdir(parents=True)
     (cp_dir / ".checkpoint.crashed.tmp").write_text('{"task":"SECRET_PRIVATE_BODY"}\n')
-    monkeypatch.setattr(run_checkpoint, "strip_checkpoint_bodies_for_export", lambda _run_dir: [])
+
+    # Simulate a regression that forgets to omit the crashed temp: return the raw
+    # manifest with no omissions, so nothing is unlinked before the assert runs.
+    def _no_omissions(_run_dir, source_manifest):
+        return source_manifest, []
+
+    monkeypatch.setattr(verification, "_expected_verify_archive_manifest", _no_omissions)
 
     archive_root = tmp_path / "verify-archive"
     with pytest.raises(run_checkpoint.CheckpointError, match="checkpoint body crossed an export boundary"):
@@ -2823,6 +2848,9 @@ def test_archive_verify_run_asserts_when_crashed_temp_stripping_is_bypassed(tmp_
 
 
 def test_prune_verify_runs_omits_hash_mismatched_checkpoint_and_remains_bounded(tmp_path):
+    """A hash-mismatched checkpoint is omitted and recorded with a bounded,
+    non-reversible diagnostic; a secret-bearing filename never leaks into the
+    archive index (#654)."""
     from brigade import run_checkpoint
     from brigade.work_cmd import helpers, verification
 
@@ -2833,23 +2861,74 @@ def test_prune_verify_runs_omits_hash_mismatched_checkpoint_and_remains_bounded(
     _write_verify_run_dir(root, "20260101-000003-c")
     cp_dir = bad_run / "events" / run_checkpoint.CHECKPOINT_DIR_NAME
     cp_dir.mkdir(parents=True)
-    mismatched = cp_dir / f"{'0' * 64}.json"
-    mismatched.write_text('{"task":"PRIVATE_HASH_MISMATCH"}\n')
+    # Filename carries a secret; its digest does not match its content, so it is
+    # treated as a hash-mismatched checkpoint and omitted.
+    secret_name = "private-tenant-acme-invoice.json"
+    body = '{"task":"PRIVATE_HASH_MISMATCH"}\n'
+    mismatched = cp_dir / secret_name
+    mismatched.write_text(body)
 
     archive_root = tmp_path / "verify-archive"
     removed = verification._prune_verify_runs(tmp_path, keep=1, archive_root=archive_root)
 
     assert removed == 2
     assert [path.name for path in root.iterdir()] == ["20260101-000003-c"]
-    assert not (archive_root / bad_run.name / "events" / run_checkpoint.CHECKPOINT_DIR_NAME / mismatched.name).exists()
+    assert not (archive_root / bad_run.name / "events" / run_checkpoint.CHECKPOINT_DIR_NAME / secret_name).exists()
+    # The secret filename must not appear anywhere in the append-only index.
+    index_text = (archive_root / "index.jsonl").read_text(encoding="utf-8")
+    assert "private-tenant-acme-invoice" not in index_text
     bad_entry = next(entry for entry in _read_archive_index(archive_root) if entry["run_id"] == bad_run.name)
     assert bad_entry["checkpoint_errors"] == [
         {
             "category": "checkpoint-hash-mismatch",
-            "path": f"events/{run_checkpoint.CHECKPOINT_DIR_NAME}/{mismatched.name}",
-            "error": "checkpoint content hash does not match filename; omitted from verification archive",
+            "digest": hashlib.sha256(body.encode("utf-8")).hexdigest(),
+            "detail": "checkpoint content hash does not match filename; omitted from verification archive",
         }
     ]
+
+
+def test_archive_verify_run_does_not_mutate_already_archived_destination(tmp_path):
+    """Re-archiving an already-archived destination must not touch its bytes: the
+    removed post-validation unlink loop was redundant and raced live readers
+    (#654)."""
+    from brigade import run_checkpoint
+    from brigade.work_cmd import helpers, verification
+
+    root = helpers._verify_runs_root(tmp_path)
+    root.mkdir(parents=True)
+    run_dir, _ = _write_verify_run_dir(root, "20260101-000001-a", sign=True)
+    cp_dir = run_dir / "events" / run_checkpoint.CHECKPOINT_DIR_NAME
+    cp_dir.mkdir(parents=True)
+    # A good content-addressed body (normalized to a reference) and a crashed
+    # temp (omitted) so both export code paths are exercised on re-archive.
+    good_body = (json.dumps({"task": "recover-me"}, sort_keys=True) + "\n").encode()
+    good_sha = hashlib.sha256(good_body).hexdigest()
+    (cp_dir / f"{good_sha}.json").write_bytes(good_body)
+    (cp_dir / ".checkpoint.crashed.tmp").write_bytes(b'{"task":"omit-me"}\n')
+
+    archive_root = tmp_path / "verify-archive"
+    verification._archive_verify_run(run_dir, archive_root)
+    dest = archive_root / run_dir.name
+
+    def _snapshot(tree):
+        return {
+            path.relative_to(tree).as_posix(): path.read_bytes() for path in sorted(tree.rglob("*")) if path.is_file()
+        }
+
+    before = _snapshot(dest)
+    # Re-archiving the same source with the destination already present must be a
+    # read-only no-op against the destination tree.
+    verification._archive_verify_run(run_dir, archive_root)
+    after = _snapshot(dest)
+
+    assert before == after
+    # The good body is present as a normalized reference; the crashed temp stays
+    # absent; local recovery input under the source run dir is untouched.
+    assert run_checkpoint.is_checkpoint_artifact_reference(
+        json.loads((dest / "events" / run_checkpoint.CHECKPOINT_DIR_NAME / f"{good_sha}.json").read_text())
+    )
+    assert not (dest / "events" / run_checkpoint.CHECKPOINT_DIR_NAME / ".checkpoint.crashed.tmp").exists()
+    assert (cp_dir / f"{good_sha}.json").read_bytes() == good_body
 
 
 def test_capture_before_retry_uses_receipt_stamped_artifact(tmp_target, monkeypatch, capsys):

--- a/tests/test_work_cmd_verification.py
+++ b/tests/test_work_cmd_verification.py
@@ -304,6 +304,11 @@ def _read_archive_index(archive_root):
     return localio.read_jsonl_dicts(archive_root / "index.jsonl")
 
 
+def _deeply_nested_json(depth: int) -> str:
+    """Return a JSON string nested ``depth`` levels deep."""
+    return '{"a":' * depth + '"x"' + "}" * depth
+
+
 def test_prune_verify_runs_archives_evidence_before_delete(tmp_path):
     from brigade.work_cmd import helpers, verification
 
@@ -2857,6 +2862,78 @@ def test_archive_verify_run_omits_artifact_reference_shaped_crashed_temp(tmp_pat
             "detail": "crashed checkpoint temp has no canonical hash path; omitted from verification archive",
         }
     ]
+
+
+def test_archive_verify_run_omits_deeply_nested_crashed_checkpoint_temp(tmp_path):
+    """A deeply nested crashed .checkpoint.*.tmp must be omitted before JSON
+    decoding raises RecursionError; pruning succeeds and no private temp body
+    or filename enters the archive or index (PR #668)."""
+    from brigade import run_checkpoint
+    from brigade.work_cmd import helpers, verification
+
+    root = helpers._verify_runs_root(tmp_path)
+    root.mkdir(parents=True)
+    run_dir, _ = _write_verify_run_dir(root, "20260101-000001-a", sign=True)
+    _write_verify_run_dir(root, "20260101-000002-b")
+    cp_dir = run_dir / "events" / run_checkpoint.CHECKPOINT_DIR_NAME
+    cp_dir.mkdir(parents=True)
+    private_task = "SECRET_NESTED_CRASHED_CHECKPOINT_must_not_archive"
+    body = _deeply_nested_json(1100).replace('"x"', f'"task":"{private_task}"')
+    crashed_temp = cp_dir / ".checkpoint.secret-tenant-acme.tmp"
+    crashed_temp.write_text(body, encoding="utf-8")
+
+    archive_root = tmp_path / "verify-archive"
+    removed = verification._prune_verify_runs(tmp_path, keep=1, archive_root=archive_root)
+
+    assert removed == 1
+    archived_run = archive_root / run_dir.name
+    archived_temp = archived_run / "events" / run_checkpoint.CHECKPOINT_DIR_NAME / crashed_temp.name
+    assert not archived_temp.exists()
+    for path in archived_run.rglob("*"):
+        if path.is_file():
+            assert private_task not in path.read_text(encoding="utf-8", errors="ignore")
+    run_checkpoint.assert_export_tree_has_no_checkpoint_bodies(archived_run)
+    index_text = (archive_root / "index.jsonl").read_text(encoding="utf-8")
+    assert "secret-tenant-acme" not in index_text
+    entry = next(e for e in _read_archive_index(archive_root) if e["run_id"] == run_dir.name)
+    assert entry["checkpoint_errors"] == [
+        {
+            "category": "checkpoint-crashed-temp",
+            "detail": "crashed checkpoint temp has no canonical hash path; omitted from verification archive",
+        }
+    ]
+
+
+def test_archive_verify_run_exports_deeply_nested_hash_named_checkpoint_as_reference(tmp_path):
+    """A canonical hash-named checkpoint whose JSON body nests beyond the decoder
+    recursion limit must still be rewritten to an artifact reference and archived
+    without aborting (PR #668)."""
+    from brigade import run_checkpoint
+    from brigade.work_cmd import helpers, verification
+
+    root = helpers._verify_runs_root(tmp_path)
+    root.mkdir(parents=True)
+    run_dir, _ = _write_verify_run_dir(root, "20260101-000001-a", sign=True)
+    _write_verify_run_dir(root, "20260101-000002-b")
+    cp_dir = run_dir / "events" / run_checkpoint.CHECKPOINT_DIR_NAME
+    cp_dir.mkdir(parents=True)
+    body = _deeply_nested_json(1100).encode("utf-8")
+    sha = hashlib.sha256(body).hexdigest()
+    (cp_dir / f"{sha}.json").write_bytes(body)
+
+    archive_root = tmp_path / "verify-archive"
+    removed = verification._prune_verify_runs(tmp_path, keep=1, archive_root=archive_root)
+
+    assert removed == 1
+    archived_run = archive_root / run_dir.name
+    archived_cp = archived_run / "events" / run_checkpoint.CHECKPOINT_DIR_NAME / f"{sha}.json"
+    assert archived_cp.is_file()
+    payload = json.loads(archived_cp.read_text(encoding="utf-8"))
+    assert run_checkpoint.is_checkpoint_artifact_reference(payload)
+    assert payload["sha256"] == sha
+    assert payload["byte_size"] == len(body)
+    entry = next(e for e in _read_archive_index(archive_root) if e["run_id"] == run_dir.name)
+    assert entry.get("checkpoint_errors", []) == []
 
 
 def test_archive_verify_run_omits_misnamed_artifact_reference(tmp_path):

--- a/tests/test_work_cmd_verification.py
+++ b/tests/test_work_cmd_verification.py
@@ -2776,6 +2776,82 @@ def test_archive_verify_run_strips_recovery_checkpoint_bodies(tmp_path):
     assert not (root / "20260101-000001-a").exists()
 
 
+def test_archive_verify_run_strips_crashed_checkpoint_temp(tmp_path):
+    from brigade import run_checkpoint
+    from brigade.work_cmd import helpers, verification
+
+    root = helpers._verify_runs_root(tmp_path)
+    root.mkdir(parents=True)
+    run_dir, _ = _write_verify_run_dir(root, "20260101-000001-a", sign=True)
+    _write_verify_run_dir(root, "20260101-000002-b")
+    cp_dir = run_dir / "events" / run_checkpoint.CHECKPOINT_DIR_NAME
+    cp_dir.mkdir(parents=True)
+    private_task = "SECRET_CRASHED_CHECKPOINT_must_not_archive"
+    body = (json.dumps({"task": private_task}, sort_keys=True) + "\n").encode()
+    crashed_temp = cp_dir / ".checkpoint.crashed.tmp"
+    crashed_temp.write_bytes(body)
+
+    archive_root = tmp_path / "verify-archive"
+    removed = verification._prune_verify_runs(tmp_path, keep=1, archive_root=archive_root)
+
+    assert removed == 1
+    archived_temp = archive_root / run_dir.name / "events" / run_checkpoint.CHECKPOINT_DIR_NAME / crashed_temp.name
+    payload = json.loads(archived_temp.read_text(encoding="utf-8"))
+    assert run_checkpoint.is_checkpoint_artifact_reference(payload)
+    assert payload["sha256"] == hashlib.sha256(body).hexdigest()
+    assert private_task not in archived_temp.read_text(encoding="utf-8")
+    run_checkpoint.assert_export_tree_has_no_checkpoint_bodies(archive_root / run_dir.name)
+
+
+def test_archive_verify_run_asserts_when_crashed_temp_stripping_is_bypassed(tmp_path, monkeypatch):
+    from brigade import run_checkpoint
+    from brigade.work_cmd import helpers, verification
+
+    root = helpers._verify_runs_root(tmp_path)
+    root.mkdir(parents=True)
+    run_dir, _ = _write_verify_run_dir(root, "20260101-000001-a", sign=True)
+    cp_dir = run_dir / "events" / run_checkpoint.CHECKPOINT_DIR_NAME
+    cp_dir.mkdir(parents=True)
+    (cp_dir / ".checkpoint.crashed.tmp").write_text('{"task":"SECRET_PRIVATE_BODY"}\n')
+    monkeypatch.setattr(run_checkpoint, "strip_checkpoint_bodies_for_export", lambda _run_dir: [])
+
+    archive_root = tmp_path / "verify-archive"
+    with pytest.raises(run_checkpoint.CheckpointError, match="checkpoint body crossed an export boundary"):
+        verification._archive_verify_run(run_dir, archive_root)
+
+    assert not (archive_root / run_dir.name).exists()
+
+
+def test_prune_verify_runs_omits_hash_mismatched_checkpoint_and_remains_bounded(tmp_path):
+    from brigade import run_checkpoint
+    from brigade.work_cmd import helpers, verification
+
+    root = helpers._verify_runs_root(tmp_path)
+    root.mkdir(parents=True)
+    bad_run, _ = _write_verify_run_dir(root, "20260101-000001-a", sign=True)
+    _write_verify_run_dir(root, "20260101-000002-b")
+    _write_verify_run_dir(root, "20260101-000003-c")
+    cp_dir = bad_run / "events" / run_checkpoint.CHECKPOINT_DIR_NAME
+    cp_dir.mkdir(parents=True)
+    mismatched = cp_dir / f"{'0' * 64}.json"
+    mismatched.write_text('{"task":"PRIVATE_HASH_MISMATCH"}\n')
+
+    archive_root = tmp_path / "verify-archive"
+    removed = verification._prune_verify_runs(tmp_path, keep=1, archive_root=archive_root)
+
+    assert removed == 2
+    assert [path.name for path in root.iterdir()] == ["20260101-000003-c"]
+    assert not (archive_root / bad_run.name / "events" / run_checkpoint.CHECKPOINT_DIR_NAME / mismatched.name).exists()
+    bad_entry = next(entry for entry in _read_archive_index(archive_root) if entry["run_id"] == bad_run.name)
+    assert bad_entry["checkpoint_errors"] == [
+        {
+            "category": "checkpoint-hash-mismatch",
+            "path": f"events/{run_checkpoint.CHECKPOINT_DIR_NAME}/{mismatched.name}",
+            "error": "checkpoint content hash does not match filename; omitted from verification archive",
+        }
+    ]
+
+
 def test_capture_before_retry_uses_receipt_stamped_artifact(tmp_target, monkeypatch, capsys):
     from brigade.work_cmd import verification
 

--- a/tests/test_work_cmd_verification.py
+++ b/tests/test_work_cmd_verification.py
@@ -2821,6 +2821,81 @@ def test_archive_verify_run_omits_crashed_checkpoint_temp(tmp_path):
     ]
 
 
+def test_archive_verify_run_omits_artifact_reference_shaped_crashed_temp(tmp_path):
+    """A crashed temp whose body happens to parse as an artifact reference is
+    still a crashed temp: it has no canonical hash path, so it must be omitted
+    rather than early-accepted as already canonical (PR #668)."""
+    from brigade import run_checkpoint
+    from brigade.work_cmd import helpers, verification
+
+    root = helpers._verify_runs_root(tmp_path)
+    root.mkdir(parents=True)
+    run_dir, _ = _write_verify_run_dir(root, "20260101-000001-a", sign=True)
+    _write_verify_run_dir(root, "20260101-000002-b")
+    cp_dir = run_dir / "events" / run_checkpoint.CHECKPOINT_DIR_NAME
+    cp_dir.mkdir(parents=True)
+    reference = run_checkpoint.checkpoint_artifact_reference(sha256="a" * 64, byte_size=7)
+    crashed_temp = cp_dir / ".checkpoint.secret-tenant-acme.tmp"
+    crashed_temp.write_text(json.dumps(reference, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    archive_root = tmp_path / "verify-archive"
+    removed = verification._prune_verify_runs(tmp_path, keep=1, archive_root=archive_root)
+
+    assert removed == 1
+    archived_run = archive_root / run_dir.name
+    # The reference-shaped crashed temp is omitted, not kept as canonical.
+    archived_temp = archived_run / "events" / run_checkpoint.CHECKPOINT_DIR_NAME / crashed_temp.name
+    assert not archived_temp.exists()
+    run_checkpoint.assert_export_tree_has_no_checkpoint_bodies(archived_run)
+    # The private temp filename never reaches the index.
+    index_text = (archive_root / "index.jsonl").read_text(encoding="utf-8")
+    assert "secret-tenant-acme" not in index_text
+    entry = next(e for e in _read_archive_index(archive_root) if e["run_id"] == run_dir.name)
+    assert entry["checkpoint_errors"] == [
+        {
+            "category": "checkpoint-crashed-temp",
+            "detail": "crashed checkpoint temp has no canonical hash path; omitted from verification archive",
+        }
+    ]
+
+
+def test_archive_verify_run_omits_misnamed_artifact_reference(tmp_path):
+    """An artifact-reference payload is canonical only at ``<sha256>.json``. A
+    reference under any other filename must fall through to hash/filename
+    validation and be omitted as a hash mismatch (PR #668)."""
+    from brigade import run_checkpoint
+    from brigade.work_cmd import helpers, verification
+
+    root = helpers._verify_runs_root(tmp_path)
+    root.mkdir(parents=True)
+    run_dir, _ = _write_verify_run_dir(root, "20260101-000001-a", sign=True)
+    _write_verify_run_dir(root, "20260101-000002-b")
+    cp_dir = run_dir / "events" / run_checkpoint.CHECKPOINT_DIR_NAME
+    cp_dir.mkdir(parents=True)
+    reference = run_checkpoint.checkpoint_artifact_reference(sha256="b" * 64, byte_size=7)
+    secret_name = "private-tenant-acme-reference.json"
+    (cp_dir / secret_name).write_text(json.dumps(reference, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    archive_root = tmp_path / "verify-archive"
+    removed = verification._prune_verify_runs(tmp_path, keep=1, archive_root=archive_root)
+
+    assert removed == 1
+    archived_run = archive_root / run_dir.name
+    # The misnamed reference is omitted, not early-accepted as canonical.
+    assert not (archived_run / "events" / run_checkpoint.CHECKPOINT_DIR_NAME / secret_name).exists()
+    run_checkpoint.assert_export_tree_has_no_checkpoint_bodies(archived_run)
+    # The secret-bearing filename never reaches the index.
+    index_text = (archive_root / "index.jsonl").read_text(encoding="utf-8")
+    assert "private-tenant-acme-reference" not in index_text
+    entry = next(e for e in _read_archive_index(archive_root) if e["run_id"] == run_dir.name)
+    assert entry["checkpoint_errors"] == [
+        {
+            "category": "checkpoint-hash-mismatch",
+            "detail": "checkpoint content hash does not match filename; omitted from verification archive",
+        }
+    ]
+
+
 def test_archive_verify_run_fails_closed_when_crashed_temp_not_omitted(tmp_path, monkeypatch):
     """If the omission step is bypassed, the export-boundary assert must fail
     closed rather than archive a private crashed-temp body."""


### PR DESCRIPTION
## Summary

- Replace exported checkpoint bodies with bounded artifact references.
- Keep raw checkpoint paths, temp names, bodies, and body digests out of the verification archive index.
- Make existing archive destinations immutable and fail closed on legacy raw archives.
- Add byte-and-mode immutability tests for valid bodies and crashed temp files across retries.

## Verification

- `tests/test_work_cmd_verification.py`: 125 passed
- `tests/test_run_checkpoint.py`: 138 passed
- `./scripts/verify` through Brigade before the current-main merge: pass
- Focused archive/checkpoint suites after the current-main merge: pass
- Independent security review: no blocking findings

Refs #654

This is the checkpoint-export slice only and does not close the broader batch issue.