### PR TITLE
fix(journal): raise event ceiling with bounded runtime reads

### DIFF
--- a/docs/measurements/issue-635-journal-ceiling.json
+++ b/docs/measurements/issue-635-journal-ceiling.json
@@ -1,0 +1,124 @@
+{
+  "bounds": {
+    "max_journal_bytes": 8388608,
+    "max_journal_events": 2048
+  },
+  "environment": {
+    "directory_fsync_supported": true,
+    "filesystem_type": "ext4",
+    "platform": "Linux-6.17.0-1030-oem-x86_64-with-glibc2.39",
+    "python_version": "3.12.3 (main, Jun 19 2026, 12:46:00) [GCC 13.3.0]"
+  },
+  "issue": 635,
+  "kind": "journal-volume",
+  "representative_synthetic": {
+    "config": {
+      "attempts_per_seat": 1,
+      "pause_cycles": 0,
+      "seats": 1
+    },
+    "event_count": 11,
+    "event_type_counts": {
+      "run.completed": 1,
+      "run.dispatch.completed": 1,
+      "run.dispatch.observed": 1,
+      "run.dispatch.requested": 1,
+      "run.dispatching.started": 1,
+      "run.planning.started": 1,
+      "run.result-processing.started": 1,
+      "run.snapshot.checkpointed": 3,
+      "run.synthesis.started": 1
+    },
+    "headroom_bytes": 8380828,
+    "headroom_events": 2037,
+    "hit_byte_ceiling": false,
+    "hit_event_ceiling": false,
+    "journal_bytes": 7780,
+    "label": "representative",
+    "path": "runs/representative/events/lifecycle.jsonl",
+    "pct_bytes": 0.092745,
+    "pct_events": 0.5371,
+    "stopped_reason": null
+  },
+  "roster_sized_synthetic": {
+    "config": {
+      "attempts_per_seat": 2,
+      "pause_cycles": 3,
+      "seats": 11
+    },
+    "event_count": 155,
+    "event_type_counts": {
+      "approval.consumed": 3,
+      "approval.requested": 3,
+      "run.completed": 1,
+      "run.dispatch.completed": 11,
+      "run.dispatch.failed": 11,
+      "run.dispatch.observed": 22,
+      "run.dispatch.requested": 22,
+      "run.dispatching.started": 1,
+      "run.paused": 3,
+      "run.planning.started": 1,
+      "run.result-processing.started": 1,
+      "run.resumed": 3,
+      "run.snapshot.checkpointed": 72,
+      "run.synthesis.started": 1
+    },
+    "headroom_bytes": 8263831,
+    "headroom_events": 1893,
+    "hit_byte_ceiling": false,
+    "hit_event_ceiling": false,
+    "journal_bytes": 124777,
+    "label": "roster-sized",
+    "path": "runs/roster-sized/events/lifecycle.jsonl",
+    "pct_bytes": 1.487458,
+    "pct_events": 7.5684,
+    "stopped_reason": null
+  },
+  "scanned_real_runs": {
+    "aggregate": {
+      "event_count_max": 0,
+      "event_count_p50": 0,
+      "event_count_p95": 0,
+      "journal_bytes_max": 0,
+      "journal_bytes_p50": 0,
+      "journal_bytes_p95": 0,
+      "runs": 0
+    },
+    "per_run": [],
+    "roots": []
+  },
+  "worst_case_synthetic": {
+    "config": {
+      "attempts_per_seat": 3,
+      "pause_cycles": 8,
+      "seats": 32
+    },
+    "event_count": 629,
+    "event_type_counts": {
+      "approval.consumed": 8,
+      "approval.requested": 8,
+      "run.completed": 1,
+      "run.dispatch.completed": 32,
+      "run.dispatch.failed": 64,
+      "run.dispatch.observed": 96,
+      "run.dispatch.requested": 96,
+      "run.dispatching.started": 1,
+      "run.paused": 8,
+      "run.planning.started": 1,
+      "run.result-processing.started": 1,
+      "run.resumed": 8,
+      "run.snapshot.checkpointed": 304,
+      "run.synthesis.started": 1
+    },
+    "headroom_bytes": 7877708,
+    "headroom_events": 1419,
+    "hit_byte_ceiling": false,
+    "hit_event_ceiling": false,
+    "journal_bytes": 510900,
+    "label": "worst-case",
+    "path": "runs/worst-case/events/lifecycle.jsonl",
+    "pct_bytes": 6.090403,
+    "pct_events": 30.7129,
+    "stopped_reason": null
+  }
+}

--- a/docs/phase-635-journal-ceiling-decision.md
+++ b/docs/phase-635-journal-ceiling-decision.md
@@ -1,21 +1,20 @@
 # Issue #635: journal ceiling decision (measure, then design)
 
-Status: design decision awaiting grading. No production implementation in this change.
+Status: implemented by issue #653.
 
 ## Measured numbers
 
-Artifact: `.brigade/measurements/issue-635-journal-ceiling.json` (local, same shape family as `issue-568-slice6.json`: environment metadata plus structured aggregates; volume mode adds bounds and scenario blocks).
+Artifact: `docs/measurements/issue-635-journal-ceiling.json`, SHA-256 `db9a585b6c2b80ca5e5bfc2c1411d678754cecc2f8f6911685da5cc00a381c89`.
 
-Current hard bounds: `MAX_JOURNAL_EVENTS = 512`, `MAX_JOURNAL_BYTES = 8 MiB`.
+Current hard bounds: `MAX_JOURNAL_EVENTS = 2048`, `MAX_JOURNAL_BYTES = 8 MiB`.
 
 | Scenario | Events | Bytes | % event ceiling | % byte ceiling | Hit ceiling? |
 | --- | ---: | ---: | ---: | ---: | --- |
-| Scanned real runs (n=13, single-seat journal-hardening runs) | p50/max 17 | p50 14,279 / max 14,286 | 3.3% | 0.17% | no |
-| Synthetic representative (1 seat, 1 attempt, 0 pauses) | 11 | 7,780 | 2.1% | 0.09% | no |
-| Synthetic roster-sized (11 seats, 2 attempts, 3 pause/resume cycles) | 155 | 124,777 | 30.3% | 1.5% | no |
-| Synthetic worst case (32 seats, 3 attempts, 8 pause cycles) | 512 | 420,683 | 100% | 5.0% | yes, mid-dispatch |
+| Synthetic representative (1 seat, 1 attempt, 0 pauses) | 11 | 7,780 | 0.54% | 0.09% | no |
+| Synthetic roster-sized (11 seats, 2 attempts, 3 pause/resume cycles) | 155 | 124,777 | 7.57% | 1.49% | no |
+| Synthetic worst case (32 seats, 3 attempts, 8 pause/resume cycles) | 629 | 510,900 | 30.71% | 6.09% | no |
 
-Worst-case stop reason: `LifecycleJournalError: bound exceeded: journal event sequence above MAX_JOURNAL_EVENTS` at `seat-28` attempt 1. Bytes were still ~5% of the 8 MiB cap.
+The captured synthetic scenarios completed without a stop reason. The artifact has no scanned real-run inputs; supplied scan roots now fail when missing, unreadable, or empty.
 
 ## Decision
 
@@ -23,16 +22,16 @@ Raise the event bound. Do not segment the journal yet.
 
 Reasoning:
 
-1. Event count is the binding constraint. At a full 512-event journal the file is only ~0.4 MiB.
-2. Realistic and roster-sized load stays far from 512 (3% real, 30% for 11 seats with retries and three approval cycles).
-3. The ceiling is reachable, but only under a synthetic fleet larger than today's 11-seat roster with three attempts per seat.
-4. Segmentation (cross-linked `lifecycle.NNNNN.jsonl`, reader/projector/doctor/recovery awareness) is a large surface change. The measured gap does not justify that cost before a cheaper bound raise plus a soft warning.
-5. Keep segmentation as the explicit escape hatch if #593 budget events or larger fleets push roster-sized runs past ~50% of the raised ceiling.
+1. Event count remains the binding constraint. The worst synthetic run reaches 629 events while using 510,900 bytes.
+2. The 11-seat roster scenario reaches 7.57% of the raised event ceiling.
+3. The 32-seat scenario records all eight pause/resume cycles and reaches 30.71% of the raised event ceiling.
+4. At the measured worst-case average event size, 2,048 events consume about one fifth of the byte bound, leaving about 5x byte headroom.
+5. Segmentation remains the escape hatch if #593 budget events or larger fleets push roster-sized runs past about 50% of the raised ceiling.
 
-Recommended production change (separate implementation issue, after this design is graded):
+Implemented production change:
 
 - Raise `MAX_JOURNAL_EVENTS` from 512 to 2048 (4x).
-- Leave `MAX_JOURNAL_BYTES` at 8 MiB for now (still ~20x headroom at 2048 median-sized events).
+- Leave `MAX_JOURNAL_BYTES` at 8 MiB for now (about 5x byte headroom at 2,048 measured-size events).
 - Add a doctor soft threshold at 75% of the event bound (1536 of 2048): `WARN`, not `FAIL`.
 - Keep the hard refuse-to-append behavior only at the new ceiling, and make that failure visible (already true today via `LifecycleJournalError`).
 
@@ -68,6 +67,7 @@ After the bound raise ships:
 ```bash
 python scripts/measure_run_journal.py \
   --mode volume \
-  --scan /path/to/.brigade/runs \
-  --output .brigade/measurements/issue-635-journal-ceiling.json
+  --output docs/measurements/issue-635-journal-ceiling.json
 ```
+
+Add `--scan /path/to/.brigade/runs` only for an existing readable root that contains lifecycle journals.

--- a/scripts/measure_run_journal.py
+++ b/scripts/measure_run_journal.py
@@ -21,6 +21,7 @@ no third-party runtime dependencies.
 from __future__ import annotations
 
 import argparse
+import codecs
 import json
 import math
 import os
@@ -31,6 +32,7 @@ import sys
 import tempfile
 import time
 from collections import Counter
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -47,6 +49,17 @@ _DEFAULT_WORST_PAUSE_CYCLES = 8
 
 class MeasurementInputError(RuntimeError):
     """Measurement input or scenario state is missing, unreadable, or incomplete."""
+
+
+@dataclass(frozen=True)
+class _JournalMeasurement:
+    """Raw volume data plus the validity of the matching bounded parse."""
+
+    event_count: int
+    event_types: dict[str, int]
+    omitted: bool = False
+    error: str | None = None
+    integrity_error: str | None = None
 
 
 def _bootstrap_run(run_dir: Path) -> bytes:
@@ -97,11 +110,13 @@ def _measure_run(run_dir: Path, workspace: Path) -> dict[str, Any]:
         )
         latencies.append(time.perf_counter_ns() - start)
     journal_path = run_dir / "events" / "lifecycle.jsonl"
-    journal_bytes = journal_path.stat().st_size
-    event_count = _count_journal_events(journal_path)
+    journal_entry = _journal_volume_entry(journal_path, label=run_dir.name)
+    if journal_entry["omitted"] or journal_entry["integrity_error"]:
+        detail = journal_entry["error"] or journal_entry["integrity_error"]
+        raise MeasurementInputError(f"measurement journal could not be verified: {detail}")
     return {
-        "journal_bytes": journal_bytes,
-        "event_count": event_count,
+        "journal_bytes": journal_entry["journal_bytes"],
+        "event_count": journal_entry["event_count"],
         "append_latencies_ns": latencies,
     }
 
@@ -215,45 +230,146 @@ def _lock_workspace_parent(root: Path, staging_root: Path) -> Path | None:
     return staging_root
 
 
-def _count_journal_events(journal_path: Path) -> int:
-    """Count complete journal events, preferring the journal reader.
+def _stream_count_complete_nonblank_records(journal_path: Path) -> tuple[int, bool]:
+    """Return complete raw record count and whether the bytes decode as UTF-8.
 
-    Falls back to nonempty line count when the reader rejects the file (bound
-    exceeded, corrupt chain) or returns no parseable events while the file
-    still has content. Volume surveys must not abort on a single bad journal.
+    The counter is deliberately independent of JSON parsing. It reads fixed
+    chunks, preserves a record's nonblank state across chunk boundaries, and
+    counts only records terminated by a newline. A partial tail is therefore
+    never treated as a complete event.
     """
-    line_count = 0
+    decoder = codecs.getincrementaldecoder("utf-8")()
+    decodable = True
+    complete_count = 0
+    pending_nonblank = False
+    with journal_path.open("rb") as handle:
+        while chunk := handle.read(65536):
+            if decodable:
+                try:
+                    decoder.decode(chunk)
+                except UnicodeDecodeError:
+                    decodable = False
+            parts = chunk.split(b"\n")
+            for record in parts[:-1]:
+                if pending_nonblank or record.strip():
+                    complete_count += 1
+                pending_nonblank = False
+            pending_nonblank = pending_nonblank or bool(parts[-1].strip())
+    if decodable:
+        try:
+            decoder.decode(b"", final=True)
+        except UnicodeDecodeError:
+            decodable = False
+    return complete_count, decodable
+
+
+def _measure_journal_events(journal_path: Path) -> _JournalMeasurement:
+    """Measure raw volume and parse health without silently converting errors to zero."""
+    raw_count, decodable = _stream_count_complete_nonblank_records(journal_path)
+    if not decodable:
+        return _JournalMeasurement(raw_count, {}, omitted=True, error="undecodable journal")
     try:
-        line_count = sum(1 for line in journal_path.read_text(encoding="utf-8").splitlines() if line.strip())
-        report = run_journal.read_journal(journal_path)
-    except (run_journal.RunJournalError, OSError, UnicodeError):
-        return line_count
-    if report.events:
-        return len(report.events)
-    return line_count
+        report = run_journal.read_journal_bounded(journal_path)
+    except OSError as exc:
+        return _JournalMeasurement(
+            raw_count,
+            {},
+            omitted=True,
+            error=f"journal read failed: {type(exc).__name__}: {exc}",
+        )
+    except run_journal.RunJournalError as exc:
+        return _JournalMeasurement(raw_count, {}, integrity_error=exc.diagnostic)
+    if report.chain_errors:
+        return _JournalMeasurement(raw_count, {}, integrity_error="; ".join(report.chain_errors))
+    if report.partial_tail is not None:
+        return _JournalMeasurement(raw_count, {}, integrity_error="journal has a partial tail")
+    return _JournalMeasurement(
+        len(report.events),
+        dict(sorted(Counter(event.event_type for event in report.events).items())),
+    )
+
+
+def _count_journal_events(journal_path: Path) -> int:
+    """Return the measurement count, preserving raw-count fallback for corrupt journals."""
+    return _measure_journal_events(journal_path).event_count
+
+
+def _journal_entry(
+    *,
+    label: str,
+    path: str,
+    journal_bytes: int | None,
+    measurement: _JournalMeasurement | None,
+    error: str | None = None,
+) -> dict[str, Any]:
+    """Build one stable report entry, including explicit omitted/error state."""
+    bounds = _bounds()
+    event_count = measurement.event_count if measurement is not None else None
+    omitted = error is not None or (measurement is not None and measurement.omitted)
+    entry_error = error if error is not None else (measurement.error if measurement is not None else None)
+    integrity_error = measurement.integrity_error if measurement is not None else None
+    return {
+        "label": label,
+        "path": path,
+        "event_count": event_count,
+        "journal_bytes": journal_bytes,
+        "event_type_counts": measurement.event_types if measurement is not None else {},
+        "headroom_events": bounds["max_journal_events"] - event_count if event_count is not None else None,
+        "headroom_bytes": bounds["max_journal_bytes"] - journal_bytes if journal_bytes is not None else None,
+        "pct_events": round(100.0 * event_count / bounds["max_journal_events"], 4) if event_count is not None else None,
+        "pct_bytes": round(100.0 * journal_bytes / bounds["max_journal_bytes"], 6)
+        if journal_bytes is not None
+        else None,
+        "omitted": omitted,
+        "error": entry_error,
+        "integrity_error": integrity_error,
+    }
 
 
 def _journal_volume_entry(journal_path: Path, *, label: str, display_path: str | None = None) -> dict[str, Any]:
-    journal_bytes = journal_path.stat().st_size
-    event_count = _count_journal_events(journal_path)
-    event_types: dict[str, int] = {}
+    """Measure one journal, omitting unreadable or changing files from aggregates."""
+    display = display_path or str(journal_path)
     try:
-        report = run_journal.read_journal(journal_path)
-        event_types = dict(sorted(Counter(event.event_type for event in report.events).items()))
-    except run_journal.RunJournalError:
-        event_types = {}
-    bounds = _bounds()
-    return {
-        "label": label,
-        "path": display_path or str(journal_path),
-        "event_count": event_count,
-        "journal_bytes": journal_bytes,
-        "event_type_counts": event_types,
-        "headroom_events": bounds["max_journal_events"] - event_count,
-        "headroom_bytes": bounds["max_journal_bytes"] - journal_bytes,
-        "pct_events": round(100.0 * event_count / bounds["max_journal_events"], 4),
-        "pct_bytes": round(100.0 * journal_bytes / bounds["max_journal_bytes"], 6),
-    }
+        before = journal_path.stat()
+    except OSError as exc:
+        return _journal_entry(
+            label=label,
+            path=display,
+            journal_bytes=None,
+            measurement=None,
+            error=f"journal stat failed: {type(exc).__name__}: {exc}",
+        )
+    try:
+        measurement = _measure_journal_events(journal_path)
+    except OSError as exc:
+        return _journal_entry(
+            label=label,
+            path=display,
+            journal_bytes=before.st_size,
+            measurement=None,
+            error=f"journal read failed: {type(exc).__name__}: {exc}",
+        )
+    try:
+        after = journal_path.stat()
+    except OSError as exc:
+        return _journal_entry(
+            label=label,
+            path=display,
+            journal_bytes=before.st_size,
+            measurement=measurement,
+            error=f"journal stat failed after read: {type(exc).__name__}: {exc}",
+        )
+    before_identity = (before.st_dev, before.st_ino, before.st_size, before.st_mtime_ns)
+    after_identity = (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns)
+    if before_identity != after_identity:
+        return _journal_entry(
+            label=label,
+            path=display,
+            journal_bytes=after.st_size,
+            measurement=measurement,
+            error="journal changed during measurement",
+        )
+    return _journal_entry(label=label, path=display, journal_bytes=after.st_size, measurement=measurement)
 
 
 def scan_lifecycle_journals(roots: list[Path]) -> dict[str, Any]:
@@ -273,12 +389,14 @@ def scan_lifecycle_journals(roots: list[Path]) -> dict[str, Any]:
             raise MeasurementInputError(f"measurement input stale: no lifecycle journals under {root}")
         journals.extend(discovered)
     per_run = [_journal_volume_entry(path, label=path.parent.parent.name) for path in journals]
-    event_counts = sorted(entry["event_count"] for entry in per_run)
-    byte_counts = sorted(entry["journal_bytes"] for entry in per_run)
+    healthy_entries = [entry for entry in per_run if not entry["omitted"]]
+    event_counts = sorted(entry["event_count"] for entry in healthy_entries)
+    byte_counts = sorted(entry["journal_bytes"] for entry in healthy_entries)
     aggregate: dict[str, Any]
     if event_counts:
         aggregate = {
-            "runs": len(per_run),
+            "runs": len(healthy_entries),
+            "omitted_runs": len(per_run) - len(healthy_entries),
             "event_count_p50": _percentile_nearest_rank(event_counts, 50),
             "event_count_p95": _percentile_nearest_rank(event_counts, 95),
             "event_count_max": int(event_counts[-1]),
@@ -289,6 +407,7 @@ def scan_lifecycle_journals(roots: list[Path]) -> dict[str, Any]:
     else:
         aggregate = {
             "runs": 0,
+            "omitted_runs": len(per_run),
             "event_count_p50": 0,
             "event_count_p95": 0,
             "event_count_max": 0,

--- a/scripts/measure_run_journal.py
+++ b/scripts/measure_run_journal.py
@@ -222,8 +222,9 @@ def _count_journal_events(journal_path: Path) -> int:
     exceeded, corrupt chain) or returns no parseable events while the file
     still has content. Volume surveys must not abort on a single bad journal.
     """
-    line_count = sum(1 for line in journal_path.read_text(encoding="utf-8").splitlines() if line.strip())
+    line_count = 0
     try:
+        line_count = sum(1 for line in journal_path.read_text(encoding="utf-8").splitlines() if line.strip())
         report = run_journal.read_journal(journal_path)
     except (run_journal.RunJournalError, OSError, UnicodeError):
         return line_count

--- a/scripts/measure_run_journal.py
+++ b/scripts/measure_run_journal.py
@@ -45,6 +45,10 @@ _DEFAULT_WORST_ATTEMPTS = 3
 _DEFAULT_WORST_PAUSE_CYCLES = 8
 
 
+class MeasurementInputError(RuntimeError):
+    """Measurement input or scenario state is missing, unreadable, or incomplete."""
+
+
 def _bootstrap_run(run_dir: Path) -> bytes:
     """Write the minimal canonical run.json carrying both durable request fields.
 
@@ -228,7 +232,7 @@ def _count_journal_events(journal_path: Path) -> int:
     return line_count
 
 
-def _journal_volume_entry(journal_path: Path, *, label: str) -> dict[str, Any]:
+def _journal_volume_entry(journal_path: Path, *, label: str, display_path: str | None = None) -> dict[str, Any]:
     journal_bytes = journal_path.stat().st_size
     event_count = _count_journal_events(journal_path)
     event_types: dict[str, int] = {}
@@ -240,7 +244,7 @@ def _journal_volume_entry(journal_path: Path, *, label: str) -> dict[str, Any]:
     bounds = _bounds()
     return {
         "label": label,
-        "path": str(journal_path),
+        "path": display_path or str(journal_path),
         "event_count": event_count,
         "journal_bytes": journal_bytes,
         "event_type_counts": event_types,
@@ -256,9 +260,17 @@ def scan_lifecycle_journals(roots: list[Path]) -> dict[str, Any]:
     journals: list[Path] = []
     for root in roots:
         root = root.expanduser().resolve()
-        if not root.exists():
-            continue
-        journals.extend(sorted(root.rglob("lifecycle.jsonl")))
+        try:
+            if not root.is_dir():
+                raise MeasurementInputError(f"measurement input missing: {root}")
+            discovered = sorted(root.rglob("lifecycle.jsonl"))
+        except MeasurementInputError:
+            raise
+        except OSError as exc:
+            raise MeasurementInputError(f"measurement input unreadable: {root}") from exc
+        if not discovered:
+            raise MeasurementInputError(f"measurement input stale: no lifecycle journals under {root}")
+        journals.extend(discovered)
     per_run = [_journal_volume_entry(path, label=path.parent.parent.name) for path in journals]
     event_counts = sorted(entry["event_count"] for entry in per_run)
     byte_counts = sorted(entry["journal_bytes"] for entry in per_run)
@@ -414,7 +426,11 @@ def _drive_volume_scenario(
                     break
 
     journal_path = run_dir / "events" / "lifecycle.jsonl"
-    entry = _journal_volume_entry(journal_path, label=run_dir.name)
+    entry = _journal_volume_entry(
+        journal_path,
+        label=run_dir.name,
+        display_path=f"runs/{run_dir.name}/events/lifecycle.jsonl",
+    )
     entry["config"] = {
         "seats": seats,
         "attempts_per_seat": attempts_per_seat,
@@ -423,6 +439,8 @@ def _drive_volume_scenario(
     entry["stopped_reason"] = stopped_reason
     entry["hit_event_ceiling"] = entry["event_count"] >= run_checkpoint.MAX_JOURNAL_EVENTS
     entry["hit_byte_ceiling"] = entry["journal_bytes"] >= run_checkpoint.MAX_JOURNAL_BYTES
+    if stopped_reason is not None:
+        raise MeasurementInputError(f"measurement scenario did not complete: {stopped_reason}")
     return entry
 
 
@@ -521,6 +539,11 @@ def measure_volume(
                 attempts_per_seat=worst_attempts_per_seat,
                 pause_cycles=worst_pause_cycles,
             )
+
+    for scenario in (representative, roster_sized, worst_case):
+        stopped_reason = scenario.get("stopped_reason")
+        if stopped_reason is not None:
+            raise MeasurementInputError(f"measurement scenario did not complete: {stopped_reason}")
 
     return {
         "issue": 635,

--- a/src/brigade/doctor.py
+++ b/src/brigade/doctor.py
@@ -109,7 +109,7 @@ _JOURNAL_EVENT_HEADROOM_DENOMINATOR = 4
 
 
 def _check_journal_event_headroom(target: Path) -> List[CheckResult]:
-    """Warn for readable journals at least 75% full and below their hard limit."""
+    """Warn for chain-valid journals at least 75% full through the hard limit."""
     from brigade import run_checkpoint, run_journal, run_lifecycle
 
     threshold = (
@@ -122,11 +122,14 @@ def _check_journal_event_headroom(target: Path) -> List[CheckResult]:
         try:
             if not journal_path.is_file():
                 continue
-            event_count = len(run_journal.read_journal_bounded(journal_path).events)
+            report = run_journal.read_journal_bounded(journal_path)
         except (OSError, run_journal.RunJournalError):
             # Recovery checkpoints own malformed and over-limit journal errors.
             continue
-        if threshold <= event_count < run_checkpoint.MAX_JOURNAL_EVENTS:
+        if report.partial_tail is not None or report.chain_errors:
+            continue
+        event_count = len(report.events)
+        if threshold <= event_count <= run_checkpoint.MAX_JOURNAL_EVENTS:
             pct = event_count * 100 // run_checkpoint.MAX_JOURNAL_EVENTS
             checks.append(
                 (

--- a/src/brigade/doctor.py
+++ b/src/brigade/doctor.py
@@ -96,12 +96,47 @@ def core_station_checks(ctx: DoctorContext) -> List[CheckResult]:
         checks.extend(_check_hermes(ctx.target))
     checks.extend(_check_orphan_inboxes(ctx.target, ctx.harnesses))
     checks.append(_check_recovery_checkpoints(ctx.target))
+    checks.extend(_check_journal_event_headroom(ctx.target))
     return checks
 
 
 _RECOVERY_CHECKPOINTS_NAME = "runs: recovery checkpoints"
 _RECOVERY_CHECKPOINTS_SCAN_LIMIT = 50
 _RECOVERY_CHECKPOINTS_FAIL_PREVIEW = 8
+_JOURNAL_EVENT_HEADROOM_NAME = "runs: journal event headroom"
+_JOURNAL_EVENT_HEADROOM_NUMERATOR = 3
+_JOURNAL_EVENT_HEADROOM_DENOMINATOR = 4
+
+
+def _check_journal_event_headroom(target: Path) -> List[CheckResult]:
+    """Warn for readable journals at least 75% full and below their hard limit."""
+    from brigade import run_checkpoint, run_journal, run_lifecycle
+
+    threshold = (
+        run_checkpoint.MAX_JOURNAL_EVENTS * _JOURNAL_EVENT_HEADROOM_NUMERATOR + _JOURNAL_EVENT_HEADROOM_DENOMINATOR - 1
+    ) // _JOURNAL_EVENT_HEADROOM_DENOMINATOR
+    checks: List[CheckResult] = []
+    run_dirs, _omitted = _immediate_run_dirs(target / ".brigade" / "runs")
+    for run_dir in run_dirs:
+        journal_path = run_lifecycle._journal_path(run_dir)
+        try:
+            if not journal_path.is_file():
+                continue
+            event_count = len(run_journal.read_journal_bounded(journal_path).events)
+        except (OSError, run_journal.RunJournalError):
+            # Recovery checkpoints own malformed and over-limit journal errors.
+            continue
+        if threshold <= event_count < run_checkpoint.MAX_JOURNAL_EVENTS:
+            pct = event_count * 100 // run_checkpoint.MAX_JOURNAL_EVENTS
+            checks.append(
+                (
+                    WARN,
+                    _JOURNAL_EVENT_HEADROOM_NAME,
+                    f"lifecycle journal at {event_count}/{run_checkpoint.MAX_JOURNAL_EVENTS} events "
+                    f"({pct}%); raise or segment before the hard ceiling halts appends",
+                )
+            )
+    return checks
 
 
 def _check_recovery_checkpoints(target: Path, *, full: bool = False) -> CheckResult:

--- a/src/brigade/run_checkpoint.py
+++ b/src/brigade/run_checkpoint.py
@@ -32,7 +32,7 @@ CHECKPOINT_PRIVACY_CLASS = "private"
 CHECKPOINT_DIR_NAME = "recovery-checkpoints"
 MAX_CHECKPOINT_BYTES = 16 * 1024 * 1024
 MAX_JOURNAL_BYTES = 8 * 1024 * 1024
-MAX_JOURNAL_EVENTS = 512
+MAX_JOURNAL_EVENTS = 2048
 
 _CHECKPOINT_PAYLOAD_REQUIRED_KEYS = frozenset(
     {"path", "sha256", "media_type", "byte_size", "privacy_class", "paired_event_type"}

--- a/src/brigade/run_checkpoint.py
+++ b/src/brigade/run_checkpoint.py
@@ -824,7 +824,7 @@ def write_checkpoint(
     # lifecycle status append and before run.json replacement.
     publish_checkpoint_file(run_dir, publish_bytes)
     try:
-        report = run_journal.read_journal(journal_path)
+        report = run_journal.read_journal_bounded(journal_path)
         if report.partial_tail is not None or report.chain_errors:
             raise run_journal.ChainIntegrityError(run_events._bound(run_lifecycle._CHAIN_CATEGORY))
         idempotency_key = _checkpoint_idempotency_key(

--- a/src/brigade/run_journal.py
+++ b/src/brigade/run_journal.py
@@ -838,7 +838,12 @@ def _iter_lines(raw: bytes) -> Iterator[tuple[bytes | None, bytes | None]]:
 
 
 def read_journal(journal_path: Path) -> JournalReport:
-    """Read the journal without mutating it.
+    """Forensically read the journal without mutating it.
+
+    This compatibility API deliberately has no byte or event-count ceiling and
+    may allocate the complete journal. It is for offline inspection only;
+    runtime mutation and control paths must use ``read_journal_bounded`` so
+    they enforce the shared journal ceilings before allocation.
 
     Each complete line must be a validated canonical envelope; lines that are
     malformed, carry duplicate JSON keys, or differ byte-wise from canonical

--- a/src/brigade/run_journal.py
+++ b/src/brigade/run_journal.py
@@ -895,7 +895,7 @@ def read_journal_bounded(journal_path: Path) -> JournalReport:
     Mirrors ``read_journal`` semantics but refuses journals above
     ``MAX_JOURNAL_BYTES`` (8 MiB) via ``fstat`` before any whole-file
     allocation, reads in bounded chunks, and fails closed at the first
-    complete event whose sequence exceeds ``MAX_JOURNAL_EVENTS`` (512).
+    complete event whose sequence exceeds ``MAX_JOURNAL_EVENTS`` (2048).
     A bound excess is reported as ``bound exceeded`` and not parsed further.
     The existing ``read_journal`` stays compatible.
     """

--- a/src/brigade/run_lifecycle.py
+++ b/src/brigade/run_lifecycle.py
@@ -396,7 +396,7 @@ def record_dispatch_fact(
                 # status pair can advance the journal again.
                 aboyeur._authoritative_prior_decision(run_dir, snapshot_obj)
             if attempt is None:
-                report = run_journal.read_journal(journal_path)
+                report = run_journal.read_journal_bounded(journal_path)
                 if report.partial_tail is not None or report.chain_errors:
                     raise run_journal.ChainIntegrityError(run_events._bound(_CHAIN_CATEGORY))
                 attempts: list[int] = []
@@ -425,7 +425,7 @@ def record_dispatch_fact(
             )
             if checkpoint is None:
                 raise LifecycleJournalError(run_events._bound("enrolled lifecycle journal checkpoint was not recorded"))
-            report = run_journal.read_journal(journal_path)
+            report = run_journal.read_journal_bounded(journal_path)
             if report.partial_tail is not None or report.chain_errors:
                 raise run_journal.ChainIntegrityError(run_events._bound(_CHAIN_CATEGORY))
             key_digest = hashlib.sha256(
@@ -547,7 +547,7 @@ def _append_owner_event(
     """Append an owner event, retrying only an externally-stale tail."""
     last_stale: run_journal.StaleSequenceError | None = None
     for attempt in range(_MAX_OWNER_APPEND_ATTEMPTS):
-        report = run_journal.read_journal(journal_path)
+        report = run_journal.read_journal_bounded(journal_path)
         if report.partial_tail is not None or report.chain_errors:
             raise run_journal.ChainIntegrityError(run_events._bound(_CHAIN_CATEGORY))
         try:
@@ -668,7 +668,7 @@ def record_lifecycle_event(
             )
             if checkpoint is None:
                 raise LifecycleJournalError(run_events._bound("enrolled lifecycle journal checkpoint was not recorded"))
-            report = run_journal.read_journal(journal_path)
+            report = run_journal.read_journal_bounded(journal_path)
             if report.partial_tail is not None or report.chain_errors:
                 raise run_journal.ChainIntegrityError(run_events._bound(_CHAIN_CATEGORY))
             event = _append_owner_event(
@@ -749,7 +749,7 @@ def record_lifecycle_transition(
         raise LifecycleJournalError("lifecycle journal append requires the active run lock for this run")
 
     try:
-        report = run_journal.read_journal(journal_path)
+        report = run_journal.read_journal_bounded(journal_path)
         if report.partial_tail is not None or report.chain_errors:
             raise run_journal.ChainIntegrityError(run_events._bound(_CHAIN_CATEGORY))
         prior_status, prior_digest = _run_snapshot_state(run_dir)

--- a/src/brigade/run_lifecycle.py
+++ b/src/brigade/run_lifecycle.py
@@ -390,27 +390,47 @@ def record_dispatch_fact(
             if not isinstance(snapshot_obj, dict):
                 raise LifecycleJournalError(run_events._bound("dispatch run receipt is not a JSON object"))
             authority_state = aboyeur._resolve_authority_state(run_dir)
-            if authority_state == "authoritative":
-                # The shared prior gate catches up exactly one verified
-                # checkpoint/event pair before any new dispatch or aggregate
-                # status pair can advance the journal again.
-                aboyeur._authoritative_prior_decision(run_dir, snapshot_obj)
+            report = run_journal.read_journal_bounded(journal_path)
+            if report.partial_tail is not None or report.chain_errors:
+                raise run_journal.ChainIntegrityError(run_events._bound(_CHAIN_CATEGORY))
             if attempt is None:
-                report = run_journal.read_journal_bounded(journal_path)
-                if report.partial_tail is not None or report.chain_errors:
-                    raise run_journal.ChainIntegrityError(run_events._bound(_CHAIN_CATEGORY))
                 attempts: list[int] = []
-                for event in report.events:
-                    candidate = event.payload.get("attempt")
+                for prior_event in report.events:
+                    candidate = prior_event.payload.get("attempt")
                     if (
-                        event.payload.get("seat") == seat
+                        prior_event.payload.get("seat") == seat
                         and isinstance(candidate, int)
                         and not isinstance(candidate, bool)
                     ):
                         attempts.append(candidate)
                 attempt = max(attempts, default=0) + 1
             assert attempt is not None
+            payload = {"seat": seat, "attempt": attempt, "detail": event_type.rsplit(".", 1)[-1]}
             pairing_key = run_checkpoint.dispatch_pairing_key(event_type, seat, attempt)
+            key_digest = hashlib.sha256(
+                run_events.canonical_bytes(
+                    {"event_type": event_type, "seat": seat, "attempt": attempt, "pairing_key": pairing_key}
+                )
+            ).hexdigest()
+            idempotency_key = f"dispatch:{key_digest[:32]}"
+            if authority_state == "authoritative":
+                recovered = _recover_authoritative_dispatch_checkpoint(
+                    run_dir,
+                    journal_path=journal_path,
+                    journal_report=report,
+                    snapshot=snapshot,
+                    snapshot_obj=snapshot_obj,
+                    event_type=event_type,
+                    pairing_key=pairing_key,
+                    payload=payload,
+                    idempotency_key=idempotency_key,
+                )
+                if recovered is not None:
+                    return recovered
+                # The shared prior gate catches up exactly one verified
+                # checkpoint/event pair before any new dispatch or aggregate
+                # status pair can advance the journal again.
+                aboyeur._authoritative_prior_decision(run_dir, snapshot_obj)
             checkpoint = run_checkpoint.write_checkpoint(
                 run_dir,
                 snapshot,
@@ -428,17 +448,12 @@ def record_dispatch_fact(
             report = run_journal.read_journal_bounded(journal_path)
             if report.partial_tail is not None or report.chain_errors:
                 raise run_journal.ChainIntegrityError(run_events._bound(_CHAIN_CATEGORY))
-            key_digest = hashlib.sha256(
-                run_events.canonical_bytes(
-                    {"event_type": event_type, "seat": seat, "attempt": attempt, "pairing_key": pairing_key}
-                )
-            ).hexdigest()
             event = _append_owner_event(
                 journal_path,
                 run_id=_run_id_from_dir(run_dir),
                 event_type=event_type,
-                payload={"seat": seat, "attempt": attempt, "detail": event_type.rsplit(".", 1)[-1]},
-                idempotency_key=f"dispatch:{key_digest[:32]}",
+                payload=payload,
+                idempotency_key=idempotency_key,
             )
             run_shadow.record_shadow_comparison(run_dir, snapshot_obj)
             return event
@@ -448,6 +463,94 @@ def record_dispatch_fact(
             raise _bound_journal_failure(exc) from exc
         except OSError as exc:
             raise _bound_journal_failure(exc) from exc
+
+
+def _recover_authoritative_dispatch_checkpoint(
+    run_dir: Path,
+    *,
+    journal_path: Path,
+    journal_report: run_journal.JournalReport,
+    snapshot: bytes,
+    snapshot_obj: dict[str, object],
+    event_type: str,
+    pairing_key: str,
+    payload: dict[str, object],
+    idempotency_key: str,
+) -> run_journal.RunEvent | None:
+    """Finish only the exact dispatch fact left after its durable checkpoint.
+
+    A checkpoint-only tail is a narrow crash window: the original dispatch
+    request identity is recoverable, but a generic authority catch-up would
+    treat it as ordinary journal-ahead evidence. Every field below binds the
+    missing fact to this run's current base-stripped receipt. Any divergence
+    raises before a new checkpoint, retry, shadow write, or run.json write.
+    """
+    from brigade import run_shadow
+
+    readiness = run_shadow.check_projection_readiness(run_dir)
+    if readiness.reasons != (run_shadow.REASON_JOURNAL_AHEAD,):
+        return None
+    if not journal_report.events or journal_report.events[-1].event_type != run_checkpoint.CHECKPOINT_EVENT_TYPE:
+        return None
+
+    checkpoint = journal_report.events[-1]
+    artifact_path = run_shadow.shadow_artifact_path(run_dir)
+    try:
+        artifact = json.loads(artifact_path.read_text())
+    except (OSError, ValueError) as exc:
+        raise LifecycleJournalError(
+            run_events._bound("authoritative dispatch checkpoint recovery evidence is unreadable")
+        ) from exc
+    if not isinstance(artifact, dict):
+        raise LifecycleJournalError(run_events._bound("authoritative dispatch checkpoint recovery evidence is invalid"))
+    baseline = run_shadow._verify_stale_baseline(
+        run_dir,
+        run_dir.name,
+        artifact.get("last_compared_sequence"),
+        artifact.get("last_compared_event_digest"),
+    )
+    if baseline is None or checkpoint.sequence != baseline[0] + 1:
+        raise LifecycleJournalError(run_events._bound("authoritative dispatch checkpoint recovery is not exact"))
+    if run_checkpoint._writer_canonical_bytes(snapshot_obj) != snapshot:
+        raise LifecycleJournalError(run_events._bound("authoritative dispatch checkpoint recovery is not exact"))
+    try:
+        expected_bytes = run_checkpoint._strip_journal_metadata_from_base(snapshot)
+        checkpoint_bytes = run_checkpoint.validate_checkpoint(run_dir, checkpoint)
+    except (run_checkpoint.CheckpointError, RecursionError) as exc:
+        raise LifecycleJournalError(
+            run_events._bound("authoritative dispatch checkpoint recovery is not exact")
+        ) from exc
+
+    expected_payload = run_checkpoint._checkpoint_payload(
+        expected_bytes,
+        paired_event_type=event_type,
+        body_kind=run_checkpoint._BODY_KIND_BASE_STRIPPED,
+        pairing_key=pairing_key,
+    )
+    expected_checkpoint_key = run_checkpoint._checkpoint_idempotency_key(
+        expected_payload["sha256"],
+        paired_event_type=event_type,
+        body_kind=run_checkpoint._BODY_KIND_BASE_STRIPPED,
+        pairing_key=pairing_key,
+    )
+    if (
+        checkpoint.run_id != run_dir.name
+        or checkpoint.event_type != run_checkpoint.CHECKPOINT_EVENT_TYPE
+        or checkpoint.payload != expected_payload
+        or checkpoint.idempotency_key != expected_checkpoint_key
+        or checkpoint_bytes != expected_bytes
+    ):
+        raise LifecycleJournalError(run_events._bound("authoritative dispatch checkpoint recovery is not exact"))
+    event = run_journal.append_event(
+        journal_path,
+        run_id=run_dir.name,
+        event_type=event_type,
+        payload=payload,
+        idempotency_key=idempotency_key,
+        expected_previous_sequence=checkpoint.sequence,
+    )
+    run_shadow.record_shadow_comparison(run_dir, snapshot_obj)
+    return event
 
 
 def normalize_approval_reference(reference: Mapping[str, Any]) -> dict[str, str]:

--- a/src/brigade/runs_cmd.py
+++ b/src/brigade/runs_cmd.py
@@ -1553,7 +1553,7 @@ def _print_pending_dispatch_recovery(run_dir: Path) -> None:
     from . import run_journal, run_lifecycle
 
     try:
-        events = run_journal.read_journal(run_lifecycle._journal_path(run_dir)).events
+        events = run_journal.read_journal_bounded(run_lifecycle._journal_path(run_dir)).events
     except (OSError, run_journal.RunJournalError):
         return
     for seat, attempt in run_lifecycle.pending_dispatch_requests(events):

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1424,6 +1424,54 @@ def _recovery_check(target: Path, *, full: bool = False) -> tuple[str, str, str]
     return doctor_mod._check_recovery_checkpoints(target, full=full)
 
 
+def _write_headroom_journal(run_dir: Path, event_count: int) -> None:
+    from brigade import run_events
+
+    journal = run_dir / "events" / "lifecycle.jsonl"
+    journal.parent.mkdir(parents=True, exist_ok=True)
+    previous_digest: str | None = None
+    with journal.open("ab") as handle:
+        for sequence in range(1, event_count + 1):
+            envelope = run_events.build_event(
+                run_id=run_dir.name,
+                sequence=sequence,
+                event_type="run.planning.started",
+                payload={"detail": "measurement"},
+                idempotency_key=f"headroom-{sequence}",
+                recorded_at="2026-07-27T15:30:45.000000Z",
+                previous_digest=previous_digest,
+            )
+            handle.write(run_events.canonical_bytes(envelope) + b"\n")
+            previous_digest = envelope["event_digest"]
+
+
+@pytest.mark.parametrize(
+    ("event_count", "expected"),
+    [(1535, []), (1536, [doctor_mod.WARN]), (1537, [doctor_mod.WARN])],
+)
+def test_doctor_journal_event_headroom_warns_at_75_percent_boundary(
+    tmp_path: Path, event_count: int, expected: list[str]
+):
+    from brigade import run_checkpoint
+
+    assert run_checkpoint.MAX_JOURNAL_EVENTS == 2048
+    workspace = tmp_path / "workspace"
+    run_dir = workspace / ".brigade" / "runs" / f"headroom-{event_count}"
+    _write_headroom_journal(run_dir, event_count)
+
+    checks = doctor_mod._check_journal_event_headroom(workspace)
+
+    assert [status for status, _name, _detail in checks] == expected
+    if expected:
+        status, name, detail = checks[0]
+        assert status == doctor_mod.WARN
+        assert name == "runs: journal event headroom"
+        assert detail == (
+            f"lifecycle journal at {event_count}/2048 events "
+            f"({event_count * 100 // 2048}%); raise or segment before the hard ceiling halts appends"
+        )
+
+
 def test_doctor_validates_checkpoint_before_reporting_pending_dispatch(tmp_path: Path):
     from brigade import run_checkpoint, run_journal, run_lifecycle, runguard
 
@@ -2108,8 +2156,8 @@ def test_doctor_invalid_recovered_at_iso_is_fail(tmp_path: Path):
     assert "run.json does not match checkpoint" in detail
 
 
-def test_doctor_513_events_fail_bound_exceeded_without_checkpoint_parsing(tmp_path: Path, monkeypatch):
-    """513 valid chained complete events must FAIL bound exceeded, no checkpoint parse."""
+def test_doctor_events_above_ceiling_fail_bound_exceeded_without_checkpoint_parsing(tmp_path: Path, monkeypatch):
+    """A valid chain above the ceiling must FAIL before checkpoint parsing."""
     from brigade import run_checkpoint, run_events, run_lifecycle
 
     workspace = tmp_path / "workspace"
@@ -2125,7 +2173,7 @@ def test_doctor_513_events_fail_bound_exceeded_without_checkpoint_parsing(tmp_pa
     journal.parent.mkdir(parents=True, exist_ok=True)
     previous_digest: str | None = None
     with journal.open("ab") as handle:
-        for index in range(513):
+        for index in range(run_checkpoint.MAX_JOURNAL_EVENTS + 1):
             env = run_events.build_event(
                 run_id=_RUN_ID,
                 sequence=index + 1,

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1447,7 +1447,7 @@ def _write_headroom_journal(run_dir: Path, event_count: int) -> None:
 
 @pytest.mark.parametrize(
     ("event_count", "expected"),
-    [(1535, []), (1536, [doctor_mod.WARN]), (1537, [doctor_mod.WARN])],
+    [(1535, []), (1536, [doctor_mod.WARN]), (1537, [doctor_mod.WARN]), (2048, [doctor_mod.WARN])],
 )
 def test_doctor_journal_event_headroom_warns_at_75_percent_boundary(
     tmp_path: Path, event_count: int, expected: list[str]
@@ -1470,6 +1470,24 @@ def test_doctor_journal_event_headroom_warns_at_75_percent_boundary(
             f"lifecycle journal at {event_count}/2048 events "
             f"({event_count * 100 // 2048}%); raise or segment before the hard ceiling halts appends"
         )
+
+
+def test_doctor_journal_event_headroom_skips_partial_tail_and_chain_errors(tmp_path: Path):
+    from brigade import run_journal
+
+    workspace = tmp_path / "workspace"
+    partial_run = workspace / ".brigade" / "runs" / "partial"
+    chain_run = workspace / ".brigade" / "runs" / "chain"
+    _write_headroom_journal(partial_run, 1536)
+    _write_headroom_journal(chain_run, 1536)
+    partial_journal = partial_run / "events" / "lifecycle.jsonl"
+    chain_journal = chain_run / "events" / "lifecycle.jsonl"
+    partial_journal.write_bytes(partial_journal.read_bytes() + b'{"partial":')
+    chain_journal.write_bytes(chain_journal.read_bytes().replace(b'"previous_digest":"', b'"previous_digest":"f', 1))
+
+    assert run_journal.read_journal_bounded(partial_journal).partial_tail is not None
+    assert run_journal.read_journal_bounded(chain_journal).chain_errors
+    assert doctor_mod._check_journal_event_headroom(workspace) == []
 
 
 def test_doctor_validates_checkpoint_before_reporting_pending_dispatch(tmp_path: Path):

--- a/tests/test_run_checkpoint.py
+++ b/tests/test_run_checkpoint.py
@@ -69,7 +69,7 @@ def test_checkpoint_constants_have_approved_values():
     assert run_checkpoint.CHECKPOINT_DIR_NAME == "recovery-checkpoints"
     assert run_checkpoint.MAX_CHECKPOINT_BYTES == 16 * 1024 * 1024
     assert run_checkpoint.MAX_JOURNAL_BYTES == 8 * 1024 * 1024
-    assert run_checkpoint.MAX_JOURNAL_EVENTS == 512
+    assert run_checkpoint.MAX_JOURNAL_EVENTS == 2048
 
 
 def test_checkpoint_dir_and_path_helpers():

--- a/tests/test_run_journal.py
+++ b/tests/test_run_journal.py
@@ -1001,11 +1001,11 @@ def test_read_journal_bounded_refuses_oversize_journal_before_allocation(tmp_pat
     assert all(p.name == "lifecycle.jsonl" for p, _ in opened)
 
 
-def test_read_journal_bounded_refuses_event_sequence_513(tmp_path):
+def test_read_journal_bounded_refuses_event_sequence_above_ceiling(tmp_path):
     journal_path = _journal_path(_run_dir(tmp_path))
     journal_path.parent.mkdir(parents=True, exist_ok=True)
     previous_digest: str | None = None
-    for sequence in range(1, 514):
+    for sequence in range(1, run_checkpoint.MAX_JOURNAL_EVENTS + 2):
         event_type = "run.planning.started" if sequence % 2 == 0 else "run.dispatch.observed"
         payload = (
             {"detail": "n"} if event_type == "run.planning.started" else {"seat": "c", "attempt": 1, "detail": "n"}
@@ -1032,17 +1032,17 @@ def test_read_journal_bounded_refuses_event_sequence_513(tmp_path):
 def test_read_journal_stays_compatible_after_bounded_reader(tmp_path):
     """read_journal must still parse a journal that read_journal_bounded refuses on bounds.
 
-    Builds a 513-event journal with efficient direct canonical construction
+    Builds a journal one event past the ceiling with efficient direct canonical construction
     (``run_events.build_event`` + a single appending ``write`` per line, no
-    ``append_event`` fsyncs). ``read_journal_bounded`` refuses it on the 513th
-    complete record (``MAX_JOURNAL_EVENTS`` is 512); ``read_journal`` has no
+    ``append_event`` fsyncs). ``read_journal_bounded`` refuses its first event
+    past ``MAX_JOURNAL_EVENTS``; ``read_journal`` has no
     event-count bound and must read the full chain cleanly.
     """
     journal_path = _journal_path(_run_dir(tmp_path))
     journal_path.parent.mkdir(parents=True, exist_ok=True)
     previous_digest: str | None = None
     with journal_path.open("ab") as handle:
-        for sequence in range(1, 514):
+        for sequence in range(1, run_checkpoint.MAX_JOURNAL_EVENTS + 2):
             event_type = "run.planning.started" if sequence % 2 == 0 else "run.dispatch.observed"
             payload = (
                 {"detail": "n"} if event_type == "run.planning.started" else {"seat": "c", "attempt": 1, "detail": "n"}
@@ -1067,21 +1067,21 @@ def test_read_journal_stays_compatible_after_bounded_reader(tmp_path):
     # read_journal stays compatible: it has no event-count bound and reads the
     # full gap-free, digest-linked chain without raising or reporting errors.
     plain = run_journal.read_journal(journal_path)
-    assert len(plain.events) == 513
+    assert len(plain.events) == run_checkpoint.MAX_JOURNAL_EVENTS + 1
     assert plain.partial_tail is None
     assert plain.chain_errors == []
     assert plain.events[0].sequence == 1
-    assert plain.events[-1].sequence == 513
+    assert plain.events[-1].sequence == run_checkpoint.MAX_JOURNAL_EVENTS + 1
 
 
 # -- Finding 6: read_journal_bounded must count complete records, not trust sequence --
 
 
-def test_read_journal_bounded_rejects_complete_record_513_even_with_repeated_sequence(tmp_path):
+def test_read_journal_bounded_rejects_complete_record_above_ceiling_even_with_repeated_sequence(tmp_path):
     journal_path = _journal_path(_run_dir(tmp_path))
     journal_path.parent.mkdir(parents=True, exist_ok=True)
     previous_digest: str | None = None
-    for sequence in range(1, 513):
+    for sequence in range(1, run_checkpoint.MAX_JOURNAL_EVENTS + 1):
         event_type = "run.planning.started" if sequence % 2 == 0 else "run.dispatch.observed"
         payload = (
             {"detail": "n"} if event_type == "run.planning.started" else {"seat": "c", "attempt": 1, "detail": "n"}
@@ -1107,7 +1107,7 @@ def test_read_journal_bounded_rejects_complete_record_513_even_with_repeated_seq
         sequence=1,
         event_type="run.created",
         payload={"status": "started"},
-        idempotency_key="ev-513-repeated",
+        idempotency_key="ev-above-ceiling-repeated",
         recorded_at="2026-07-27T15:30:45.000000Z",
         previous_digest=None,
     )
@@ -1163,7 +1163,7 @@ def _tracking_write(monkeypatch) -> list[bytes]:
     return write_calls
 
 
-def test_append_event_refuses_513th_distinct_event_before_write(tmp_path, monkeypatch):
+def test_append_event_refuses_distinct_event_above_ceiling_before_write(tmp_path, monkeypatch):
     journal_path = _journal_path(_run_dir(tmp_path))
     _write_journal_events(journal_path, run_checkpoint.MAX_JOURNAL_EVENTS)
     before = journal_path.read_bytes()
@@ -1175,7 +1175,7 @@ def test_append_event_refuses_513th_distinct_event_before_write(tmp_path, monkey
             run_id=RUN_ID,
             event_type="run.created",
             payload={"status": "started"},
-            idempotency_key="ev-513",
+            idempotency_key="ev-above-ceiling",
             expected_previous_sequence=run_checkpoint.MAX_JOURNAL_EVENTS,
             recorded_at="2026-07-27T15:30:50.000000Z",
         )
@@ -1183,6 +1183,29 @@ def test_append_event_refuses_513th_distinct_event_before_write(tmp_path, monkey
     assert "bound exceeded" in excinfo.value.diagnostic
     assert not write_calls
     assert journal_path.read_bytes() == before
+
+
+def test_old_sequence_512_journal_recovers_and_appends_513_without_renumbering(tmp_path):
+    """A chain stopped at the pre-upgrade ceiling remains appendable after the bump."""
+    assert run_checkpoint.MAX_JOURNAL_EVENTS == 2048
+    journal_path = _journal_path(_run_dir(tmp_path))
+    _write_journal_events(journal_path, 512)
+
+    appended = run_journal.append_event(
+        journal_path,
+        run_id=RUN_ID,
+        event_type="run.created",
+        payload={"status": "started"},
+        idempotency_key="ev-513-after-upgrade",
+        expected_previous_sequence=512,
+        recorded_at="2026-07-27T15:30:50.000000Z",
+    )
+
+    report = run_journal.read_journal_bounded(journal_path)
+    assert appended.sequence == 513
+    assert [event.sequence for event in report.events] == list(range(1, 514))
+    assert report.events[511].idempotency_key == "ev-512"
+    assert report.events[512].idempotency_key == "ev-513-after-upgrade"
 
 
 def test_append_event_refuses_growth_past_max_journal_bytes_before_write(tmp_path, monkeypatch):
@@ -1257,12 +1280,12 @@ def test_append_event_refuses_oversize_journal_consistent_with_read_journal_boun
     assert journal_path.read_bytes() == before
 
 
-def test_append_event_refuses_journal_with_513_complete_records_before_write(tmp_path, monkeypatch):
+def test_append_event_refuses_journal_with_records_above_ceiling_before_write(tmp_path, monkeypatch):
     journal_path = _journal_path(_run_dir(tmp_path))
     journal_path.parent.mkdir(parents=True, exist_ok=True)
     previous_digest: str | None = None
     with journal_path.open("ab") as handle:
-        for sequence in range(1, 514):
+        for sequence in range(1, run_checkpoint.MAX_JOURNAL_EVENTS + 2):
             event_type = "run.planning.started" if sequence % 2 == 0 else "run.dispatch.observed"
             payload = (
                 {"detail": "n"} if event_type == "run.planning.started" else {"seat": "c", "attempt": 1, "detail": "n"}
@@ -1288,7 +1311,7 @@ def test_append_event_refuses_journal_with_513_complete_records_before_write(tmp
             event_type="run.created",
             payload={"status": "started"},
             idempotency_key="ev-new",
-            expected_previous_sequence=513,
+            expected_previous_sequence=run_checkpoint.MAX_JOURNAL_EVENTS + 1,
             recorded_at="2026-07-27T15:30:50.000000Z",
         )
 

--- a/tests/test_run_journal.py
+++ b/tests/test_run_journal.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import errno
+import ast
 import hashlib
 import json
 import os
@@ -1029,14 +1030,15 @@ def test_read_journal_bounded_refuses_event_sequence_above_ceiling(tmp_path):
     assert "bound exceeded" in excinfo.value.diagnostic
 
 
-def test_read_journal_stays_compatible_after_bounded_reader(tmp_path):
-    """read_journal must still parse a journal that read_journal_bounded refuses on bounds.
+def test_read_journal_is_forensic_api_after_bounded_reader(tmp_path):
+    """The forensic reader may inspect an over-limit journal without becoming a runtime path.
 
     Builds a journal one event past the ceiling with efficient direct canonical construction
     (``run_events.build_event`` + a single appending ``write`` per line, no
     ``append_event`` fsyncs). ``read_journal_bounded`` refuses its first event
-    past ``MAX_JOURNAL_EVENTS``; ``read_journal`` has no
-    event-count bound and must read the full chain cleanly.
+    past ``MAX_JOURNAL_EVENTS``. ``read_journal`` intentionally remains an
+    unbounded forensic API, while runtime control and mutation paths are
+    required to call ``read_journal_bounded`` instead.
     """
     journal_path = _journal_path(_run_dir(tmp_path))
     journal_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1074,6 +1076,75 @@ def test_read_journal_stays_compatible_after_bounded_reader(tmp_path):
     assert plain.events[-1].sequence == run_checkpoint.MAX_JOURNAL_EVENTS + 1
 
 
+def test_runtime_journal_paths_do_not_call_the_unbounded_forensic_reader():
+    """Runtime mutation and recovery control paths must enforce shared reader bounds."""
+    runtime_modules = (
+        "doctor.py",
+        "run_lifecycle.py",
+        "run_checkpoint.py",
+        "run_shadow.py",
+        "runs_cmd.py",
+    )
+    source_root = Path(run_journal.__file__).parent
+    offenders: list[str] = []
+    for module_name in runtime_modules:
+        tree = ast.parse((source_root / module_name).read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "run_journal"
+                and node.func.attr == "read_journal"
+            ):
+                offenders.append(f"{module_name}:{node.lineno}")
+    assert offenders == []
+
+
+def test_near_event_ceiling_idempotency_index_and_duplicate_replay_stay_within_budget(tmp_path, record_property):
+    """A 2,047-event journal keeps index construction and exact replay bounded."""
+    journal_path = _journal_path(_run_dir(tmp_path))
+    journal_path.parent.mkdir(parents=True, exist_ok=True)
+    previous_digest: str | None = None
+    event_count = run_checkpoint.MAX_JOURNAL_EVENTS - 1
+    with journal_path.open("ab") as handle:
+        for sequence in range(1, event_count + 1):
+            env = run_events.build_event(
+                run_id=RUN_ID,
+                sequence=sequence,
+                event_type="run.planning.started",
+                payload={"detail": "performance"},
+                idempotency_key=f"performance-{sequence}",
+                recorded_at="2026-07-27T15:30:45.000000Z",
+                previous_digest=previous_digest,
+            )
+            handle.write(run_events.canonical_bytes(env) + b"\n")
+            previous_digest = env["event_digest"]
+
+    budget_ns = 5_000_000_000
+    started_ns = time.perf_counter_ns()
+    _sequence, _digest, index, partial_tail, _journal_bytes = run_journal._read_tail_state(journal_path)
+    index_build_ns = time.perf_counter_ns() - started_ns
+
+    started_ns = time.perf_counter_ns()
+    replay = run_journal.lookup_idempotent_event(
+        journal_path,
+        event_type="run.planning.started",
+        payload={"detail": "performance"},
+        idempotency_key=f"performance-{event_count}",
+    )
+    duplicate_replay_ns = time.perf_counter_ns() - started_ns
+
+    record_property("idempotency_index_build_ns", index_build_ns)
+    record_property("idempotency_duplicate_replay_ns", duplicate_replay_ns)
+    record_property("idempotency_performance_budget_ns", budget_ns)
+    assert partial_tail is None
+    assert len(index) == event_count
+    assert replay is not None and replay.sequence == event_count
+    assert index_build_ns <= budget_ns, f"idempotency index build took {index_build_ns}ns (budget {budget_ns}ns)"
+    assert duplicate_replay_ns <= budget_ns, f"duplicate replay took {duplicate_replay_ns}ns (budget {budget_ns}ns)"
+
+
 # -- Finding 6: read_journal_bounded must count complete records, not trust sequence --
 
 
@@ -1099,10 +1170,10 @@ def test_read_journal_bounded_rejects_complete_record_above_ceiling_even_with_re
             handle.write(run_events.canonical_bytes(env) + b"\n")
         previous_digest = env["event_digest"]
 
-    # 513th complete record: its envelope repeats sequence 1 (and a matching
-    # previous_digest is null), so a sequence-trusting reader would treat it as
-    # a duplicate/chain break rather than a bound excess.
-    env_513 = run_events.build_event(
+    # The first complete record above the shared ceiling repeats sequence 1
+    # with a null previous digest. A sequence-trusting reader would treat it as
+    # a duplicate or chain break instead of a bound excess.
+    env_above_ceiling = run_events.build_event(
         run_id=RUN_ID,
         sequence=1,
         event_type="run.created",
@@ -1112,7 +1183,7 @@ def test_read_journal_bounded_rejects_complete_record_above_ceiling_even_with_re
         previous_digest=None,
     )
     with journal_path.open("ab") as handle:
-        handle.write(run_events.canonical_bytes(env_513) + b"\n")
+        handle.write(run_events.canonical_bytes(env_above_ceiling) + b"\n")
 
     with pytest.raises(run_journal.RunJournalError) as excinfo:
         run_journal.read_journal_bounded(journal_path)

--- a/tests/test_run_journal_measurement.py
+++ b/tests/test_run_journal_measurement.py
@@ -326,7 +326,7 @@ def test_scan_lifecycle_journals_omits_undecodable_journal_without_zeroing_it(tm
     assert scanned["aggregate"]["omitted_runs"] == 1
 
 
-def test_scan_lifecycle_journals_omits_stat_failure(tmp_path, monkeypatch):
+def test_journal_volume_entry_omits_stat_failure(tmp_path, monkeypatch):
     module = _load_measure_run_journal_module()
     journal = tmp_path / "runs" / "run-a" / "events" / "lifecycle.jsonl"
     journal.parent.mkdir(parents=True)
@@ -340,14 +340,11 @@ def test_scan_lifecycle_journals_omits_stat_failure(tmp_path, monkeypatch):
 
     monkeypatch.setattr(Path, "stat", fail_journal_stat)
 
-    scanned = module.scan_lifecycle_journals([tmp_path])
-
-    entry = scanned["per_run"][0]
+    entry = module._journal_volume_entry(journal, label="run-a")
     assert entry["event_count"] is None
     assert entry["journal_bytes"] is None
     assert entry["omitted"] is True
     assert entry["error"].startswith("journal stat failed:")
-    assert scanned["aggregate"]["runs"] == 0
 
 
 def test_scan_lifecycle_journals_omits_second_read_failure(tmp_path, monkeypatch):

--- a/tests/test_run_journal_measurement.py
+++ b/tests/test_run_journal_measurement.py
@@ -245,6 +245,48 @@ def test_scan_lifecycle_journals_reads_existing_files(tmp_path):
     assert scanned["per_run"][0]["journal_bytes"] == journal.stat().st_size
 
 
+@pytest.mark.parametrize(
+    ("prepare", "message"),
+    [
+        (lambda root: None, "missing"),
+        (lambda root: root.mkdir(), "stale"),
+    ],
+)
+def test_scan_lifecycle_journals_fails_closed_for_missing_or_stale_input(tmp_path, prepare, message):
+    module = _load_measure_run_journal_module()
+    scan_root = tmp_path / "scan-input"
+    prepare(scan_root)
+
+    with pytest.raises(module.MeasurementInputError, match=message):
+        module.scan_lifecycle_journals([scan_root])
+
+
+def test_scan_lifecycle_journals_fails_closed_for_unreadable_input(tmp_path, monkeypatch):
+    module = _load_measure_run_journal_module()
+    scan_root = tmp_path / "scan-input"
+    scan_root.mkdir()
+
+    def _raise_unreadable(_self, _pattern):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "rglob", _raise_unreadable)
+
+    with pytest.raises(module.MeasurementInputError, match="unreadable"):
+        module.scan_lifecycle_journals([scan_root])
+
+
+def test_measure_volume_fails_closed_when_a_scenario_stops_early(tmp_path, monkeypatch):
+    module = _load_measure_run_journal_module()
+
+    def _stopped_scenario(*_args, **_kwargs):
+        return {"stopped_reason": "dispatch failed", "event_count": 0, "journal_bytes": 0}
+
+    monkeypatch.setattr(module, "_drive_volume_scenario", _stopped_scenario)
+
+    with pytest.raises(module.MeasurementInputError, match="scenario did not complete"):
+        module.measure_volume(tmp_path)
+
+
 def test_cli_volume_mode_writes_report(tmp_path):
     output = tmp_path / "out" / "volume.json"
 

--- a/tests/test_run_journal_measurement.py
+++ b/tests/test_run_journal_measurement.py
@@ -275,6 +275,26 @@ def test_scan_lifecycle_journals_fails_closed_for_unreadable_input(tmp_path, mon
         module.scan_lifecycle_journals([scan_root])
 
 
+def test_count_journal_events_unreadable_or_undecodable_fallback(tmp_path, monkeypatch):
+    module = _load_measure_run_journal_module()
+    undecodable_journal = tmp_path / "undecodable.jsonl"
+    undecodable_journal.write_bytes(b"\x80abc\n\xff")
+
+    # Non-UTF-8 bytes fail read_text and fall back to zero without aborting the survey.
+    assert module._count_journal_events(undecodable_journal) == 0
+
+    unreadable_journal = tmp_path / "unreadable.jsonl"
+    unreadable_journal.write_text("line 1\nline 2\n")
+
+    def _raise_oserror(*_args, **_kwargs):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "read_text", _raise_oserror)
+
+    # Read errors fail safely without aborting the survey.
+    assert module._count_journal_events(unreadable_journal) == 0
+
+
 def test_measure_volume_fails_closed_when_a_scenario_stops_early(tmp_path, monkeypatch):
     module = _load_measure_run_journal_module()
 

--- a/tests/test_run_journal_measurement.py
+++ b/tests/test_run_journal_measurement.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import pytest
 
-from brigade import runguard
+from brigade import run_events, runguard
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "measure_run_journal.py"
@@ -275,24 +275,99 @@ def test_scan_lifecycle_journals_fails_closed_for_unreadable_input(tmp_path, mon
         module.scan_lifecycle_journals([scan_root])
 
 
-def test_count_journal_events_unreadable_or_undecodable_fallback(tmp_path, monkeypatch):
+def test_scan_lifecycle_journals_uses_complete_raw_count_after_valid_prefix_corruption(tmp_path):
     module = _load_measure_run_journal_module()
-    undecodable_journal = tmp_path / "undecodable.jsonl"
-    undecodable_journal.write_bytes(b"\x80abc\n\xff")
+    journal = tmp_path / "runs" / "run-a" / "events" / "lifecycle.jsonl"
+    journal.parent.mkdir(parents=True)
+    first = run_events.build_event(
+        run_id="20260727-153045-a1b2c3d4",
+        sequence=1,
+        event_type="run.created",
+        payload={"status": "started"},
+        idempotency_key="first",
+        recorded_at="2026-07-27T15:30:45.000000Z",
+        previous_digest=None,
+    )
+    second = run_events.build_event(
+        run_id="20260727-153045-a1b2c3d4",
+        sequence=2,
+        event_type="run.planning.started",
+        payload={"detail": "planning"},
+        idempotency_key="second",
+        recorded_at="2026-07-27T15:30:46.000000Z",
+        previous_digest=first["event_digest"],
+    )
+    journal.write_bytes(
+        run_events.canonical_bytes(first) + b"\n{not-json}\n" + run_events.canonical_bytes(second) + b"\n"
+    )
 
-    # Non-UTF-8 bytes fail read_text and fall back to zero without aborting the survey.
-    assert module._count_journal_events(undecodable_journal) == 0
+    scanned = module.scan_lifecycle_journals([tmp_path])
 
-    unreadable_journal = tmp_path / "unreadable.jsonl"
-    unreadable_journal.write_text("line 1\nline 2\n")
+    assert scanned["per_run"][0]["event_count"] == 3
+    assert scanned["per_run"][0]["omitted"] is False
+    assert scanned["per_run"][0]["integrity_error"]
+    assert scanned["aggregate"]["runs"] == 1
+    assert scanned["aggregate"]["event_count_max"] == 3
 
-    def _raise_oserror(*_args, **_kwargs):
-        raise OSError("permission denied")
 
-    monkeypatch.setattr(Path, "read_text", _raise_oserror)
+def test_scan_lifecycle_journals_omits_undecodable_journal_without_zeroing_it(tmp_path):
+    module = _load_measure_run_journal_module()
+    journal = tmp_path / "runs" / "run-a" / "events" / "lifecycle.jsonl"
+    journal.parent.mkdir(parents=True)
+    journal.write_bytes(b"\x80abc\n\xff")
 
-    # Read errors fail safely without aborting the survey.
-    assert module._count_journal_events(unreadable_journal) == 0
+    scanned = module.scan_lifecycle_journals([tmp_path])
+
+    entry = scanned["per_run"][0]
+    assert entry["event_count"] == 1
+    assert entry["omitted"] is True
+    assert entry["error"] == "undecodable journal"
+    assert scanned["aggregate"]["runs"] == 0
+    assert scanned["aggregate"]["omitted_runs"] == 1
+
+
+def test_scan_lifecycle_journals_omits_stat_failure(tmp_path, monkeypatch):
+    module = _load_measure_run_journal_module()
+    journal = tmp_path / "runs" / "run-a" / "events" / "lifecycle.jsonl"
+    journal.parent.mkdir(parents=True)
+    journal.write_text("record\n")
+    real_stat = Path.stat
+
+    def fail_journal_stat(self, *args, **kwargs):
+        if self == journal:
+            raise OSError("stat race")
+        return real_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", fail_journal_stat)
+
+    scanned = module.scan_lifecycle_journals([tmp_path])
+
+    entry = scanned["per_run"][0]
+    assert entry["event_count"] is None
+    assert entry["journal_bytes"] is None
+    assert entry["omitted"] is True
+    assert entry["error"].startswith("journal stat failed:")
+    assert scanned["aggregate"]["runs"] == 0
+
+
+def test_scan_lifecycle_journals_omits_second_read_failure(tmp_path, monkeypatch):
+    module = _load_measure_run_journal_module()
+    journal = tmp_path / "runs" / "run-a" / "events" / "lifecycle.jsonl"
+    journal.parent.mkdir(parents=True)
+    journal.write_text("record\n")
+
+    def fail_second_read(*_args, **_kwargs):
+        raise OSError("second read race")
+
+    monkeypatch.setattr(module.run_journal, "read_journal_bounded", fail_second_read)
+
+    scanned = module.scan_lifecycle_journals([tmp_path])
+
+    entry = scanned["per_run"][0]
+    assert entry["event_count"] == 1
+    assert entry["omitted"] is True
+    assert entry["error"].startswith("journal read failed:")
+    assert scanned["aggregate"]["runs"] == 0
 
 
 def test_measure_volume_fails_closed_when_a_scenario_stops_early(tmp_path, monkeypatch):

--- a/tests/test_run_lifecycle.py
+++ b/tests/test_run_lifecycle.py
@@ -2512,6 +2512,179 @@ def test_authority_dispatch_checkpoint_is_base_stripped_and_recovers_exact_tail(
     assert repaired["projector_version"] == run_projector.PROJECTOR_VERSION
 
 
+def test_authoritative_dispatch_requested_recovers_exact_old_ceiling_checkpoint(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    run_dir = _run_dir(repo)
+    _enroll_and_authorize(repo, run_dir, monkeypatch)
+
+    with runguard.run_lock(repo, run_dir=run_dir):
+        snapshot = (run_dir / "run.json").read_bytes()
+        pairing_key = run_checkpoint.dispatch_pairing_key("run.dispatch.requested", "coder", 1)
+        checkpoint = run_checkpoint.write_checkpoint(
+            run_dir,
+            snapshot,
+            workspace=repo,
+            paired_event_type="run.dispatch.requested",
+            body_kind=run_checkpoint._BODY_KIND_BASE_STRIPPED,
+            pairing_key=pairing_key,
+        )
+        assert checkpoint is not None
+        real_write_checkpoint = run_checkpoint.write_checkpoint
+        monkeypatch.setattr(
+            run_checkpoint,
+            "write_checkpoint",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("new checkpoint")),
+        )
+
+        requested = run_lifecycle.record_dispatch_fact(
+            run_dir,
+            workspace=repo,
+            event_type="run.dispatch.requested",
+            seat="coder",
+        )
+        monkeypatch.setattr(run_checkpoint, "write_checkpoint", real_write_checkpoint)
+
+    assert requested is not None
+    assert requested.sequence == checkpoint.sequence + 1
+    assert requested.payload == {"seat": "coder", "attempt": 1, "detail": "requested"}
+    assert requested.idempotency_key.startswith("dispatch:")
+    assert _events(run_dir)[-2].sequence == checkpoint.sequence
+    assert run_shadow.check_projection_readiness(run_dir).ready is True
+
+
+@pytest.mark.parametrize("mismatch", ["checkpoint-bytes", "checkpoint-payload", "checkpoint-key", "forged-cursor"])
+def test_authoritative_dispatch_rejects_nonexact_incomplete_checkpoint(tmp_path, monkeypatch, mismatch):
+    repo = _repo(tmp_path)
+    run_dir = _run_dir(repo)
+    _enroll_and_authorize(repo, run_dir, monkeypatch)
+
+    with runguard.run_lock(repo, run_dir=run_dir):
+        snapshot = (run_dir / "run.json").read_bytes()
+        if mismatch == "checkpoint-bytes":
+            snapshot_obj = json.loads(snapshot)
+            snapshot_obj["task"] = "other-task"
+            checkpoint_snapshot = (json.dumps(snapshot_obj, indent=2, sort_keys=True) + "\n").encode()
+            pairing_key = run_checkpoint.dispatch_pairing_key("run.dispatch.requested", "coder", 1)
+            run_checkpoint.write_checkpoint(
+                run_dir,
+                checkpoint_snapshot,
+                workspace=repo,
+                paired_event_type="run.dispatch.requested",
+                body_kind=run_checkpoint._BODY_KIND_BASE_STRIPPED,
+                pairing_key=pairing_key,
+            )
+        elif mismatch == "checkpoint-payload":
+            pairing_key = run_checkpoint.dispatch_pairing_key("run.dispatch.observed", "coder", 1)
+            run_checkpoint.write_checkpoint(
+                run_dir,
+                snapshot,
+                workspace=repo,
+                paired_event_type="run.dispatch.observed",
+                body_kind=run_checkpoint._BODY_KIND_BASE_STRIPPED,
+                pairing_key=pairing_key,
+            )
+        elif mismatch == "checkpoint-key":
+            pairing_key = run_checkpoint.dispatch_pairing_key("run.dispatch.requested", "coder", 1)
+            stripped = run_checkpoint._strip_journal_metadata_from_base(snapshot)
+            run_checkpoint.publish_checkpoint_file(run_dir, stripped)
+            report = run_journal.read_journal_bounded(_journal_path(run_dir))
+            run_journal.append_event(
+                _journal_path(run_dir),
+                run_id=run_dir.name,
+                event_type=run_checkpoint.CHECKPOINT_EVENT_TYPE,
+                payload=run_checkpoint._checkpoint_payload(
+                    stripped,
+                    paired_event_type="run.dispatch.requested",
+                    body_kind=run_checkpoint._BODY_KIND_BASE_STRIPPED,
+                    pairing_key=pairing_key,
+                ),
+                idempotency_key="forged-checkpoint-key",
+                expected_previous_sequence=report.events[-1].sequence,
+            )
+        else:
+            pairing_key = run_checkpoint.dispatch_pairing_key("run.dispatch.requested", "coder", 1)
+            run_checkpoint.write_checkpoint(
+                run_dir,
+                snapshot,
+                workspace=repo,
+                paired_event_type="run.dispatch.requested",
+                body_kind=run_checkpoint._BODY_KIND_BASE_STRIPPED,
+                pairing_key=pairing_key,
+            )
+            artifact_path = run_shadow.shadow_artifact_path(run_dir)
+            artifact = json.loads(artifact_path.read_text())
+            artifact["last_compared_event_digest"] = "f" * 64
+            artifact_path.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n")
+
+        run_json_before = (run_dir / "run.json").read_bytes()
+        journal_before = _journal_path(run_dir).read_bytes()
+        shadow_before = run_shadow.shadow_artifact_path(run_dir).read_bytes()
+        with pytest.raises(run_lifecycle.LifecycleJournalError):
+            run_lifecycle.record_dispatch_fact(
+                run_dir,
+                workspace=repo,
+                event_type="run.dispatch.requested",
+                seat="coder",
+            )
+
+    assert (run_dir / "run.json").read_bytes() == run_json_before
+    assert _journal_path(run_dir).read_bytes() == journal_before
+    assert run_shadow.shadow_artifact_path(run_dir).read_bytes() == shadow_before
+
+
+def test_authoritative_dispatch_checkpoint_recovery_does_not_retry_an_interleaving_tail(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    run_dir = _run_dir(repo)
+    _enroll_and_authorize(repo, run_dir, monkeypatch)
+
+    with runguard.run_lock(repo, run_dir=run_dir):
+        snapshot = (run_dir / "run.json").read_bytes()
+        pairing_key = run_checkpoint.dispatch_pairing_key("run.dispatch.requested", "coder", 1)
+        checkpoint = run_checkpoint.write_checkpoint(
+            run_dir,
+            snapshot,
+            workspace=repo,
+            paired_event_type="run.dispatch.requested",
+            body_kind=run_checkpoint._BODY_KIND_BASE_STRIPPED,
+            pairing_key=pairing_key,
+        )
+        assert checkpoint is not None
+        run_json_before = (run_dir / "run.json").read_bytes()
+        shadow_before = run_shadow.shadow_artifact_path(run_dir).read_bytes()
+        real_append = run_journal.append_event
+        calls = 0
+
+        def interleaving_append(path, **kwargs):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                real_append(
+                    path,
+                    run_id=run_dir.name,
+                    event_type="run.dispatch.requested",
+                    payload={"seat": "other", "attempt": 1, "detail": "requested"},
+                    idempotency_key="interleaving-dispatch",
+                    expected_previous_sequence=checkpoint.sequence,
+                )
+            return real_append(path, **kwargs)
+
+        monkeypatch.setattr(run_journal, "append_event", interleaving_append)
+        with pytest.raises(run_lifecycle.LifecycleJournalError):
+            run_lifecycle.record_dispatch_fact(
+                run_dir,
+                workspace=repo,
+                event_type="run.dispatch.requested",
+                seat="coder",
+            )
+
+    assert calls == 1
+    assert (run_dir / "run.json").read_bytes() == run_json_before
+    assert run_shadow.shadow_artifact_path(run_dir).read_bytes() == shadow_before
+    events = _events(run_dir)
+    assert events[-1].payload["seat"] == "other"
+    assert all(event.payload.get("seat") != "coder" for event in events[checkpoint.sequence :])
+
+
 # -- Issue #651 step 2: owner lifecycle appends retry a stale tail -----------
 
 

--- a/tests/test_run_lifecycle.py
+++ b/tests/test_run_lifecycle.py
@@ -2532,7 +2532,7 @@ def test_owner_lifecycle_append_retries_stale_tail_and_preserves_idempotency(ena
     sleeps: list[float] = []
     stale_budget = {"count": 1}
     real_append = run_journal.append_event
-    real_read = run_journal.read_journal
+    real_read = run_journal.read_journal_bounded
 
     def tracking_append(journal_path, **kwargs):
         if kwargs["event_type"] == "run.planning.started":
@@ -2554,7 +2554,7 @@ def test_owner_lifecycle_append_retries_stale_tail_and_preserves_idempotency(ena
         return report
 
     monkeypatch.setattr(run_journal, "append_event", tracking_append)
-    monkeypatch.setattr(run_journal, "read_journal", tracking_read)
+    monkeypatch.setattr(run_journal, "read_journal_bounded", tracking_read)
     monkeypatch.setattr("time.sleep", lambda seconds: sleeps.append(seconds))
 
     try:
@@ -2578,7 +2578,7 @@ def test_owner_lifecycle_append_retries_stale_tail_and_preserves_idempotency(ena
     committed = [e for e in status_events if e.idempotency_key == append_attempts[0][1]]
     assert len(committed) == 1, "exactly one event may be committed for the retried append"
     assert event.event_id == committed[0].event_id
-    assert run_journal.read_journal(_journal_path(run_dir)).chain_errors == []
+    assert run_journal.read_journal_bounded(_journal_path(run_dir)).chain_errors == []
 
 
 def test_owner_lifecycle_append_stale_retries_exhausted_blocks_run_json(enabled, tmp_path, monkeypatch):

--- a/tests/test_run_shadow.py
+++ b/tests/test_run_shadow.py
@@ -811,19 +811,19 @@ def test_run_journal_error_in_shadow_is_contained(enabled, tmp_path, monkeypatch
     _write_run_json(run_dir, "started")
     _write_run_json_locked(repo, run_dir, "started")  # match, seq 1
 
-    # The shadow path reads the journal through read_journal_bounded; the
-    # legacy lifecycle path (record_lifecycle_transition) still reads through
-    # read_journal. Raise only on the bounded read so the legacy write still
-    # commits, then the shadow hook sees the RunJournalError and must contain
-    # it as journal-unreadable.
+    # Runtime lifecycle writes also use the bounded reader, so first make the
+    # normal write. Then inject the bounded-read failure into the observational
+    # shadow hook, which must contain it as journal-unreadable.
+    run_before = (run_dir / "run.json").read_bytes()
+    _write_run_json_locked(repo, run_dir, "planning")
+    assert (run_dir / "run.json").read_bytes() != run_before
+
     def raising_bounded(path):
         raise run_journal.RunJournalError("simulated chain failure")
 
     monkeypatch.setattr(run_journal, "read_journal_bounded", raising_bounded)
 
-    run_before = (run_dir / "run.json").read_bytes()
-    _write_run_json_locked(repo, run_dir, "planning")  # legacy write must still advance
-    assert (run_dir / "run.json").read_bytes() != run_before
+    run_shadow.record_shadow_comparison(run_dir, json.loads((run_dir / "run.json").read_text()))
     data = json.loads(run_shadow.shadow_artifact_path(run_dir).read_text())
     assert data["errors"] >= 1
     assert data["last_error_category"] == "journal-unreadable"
@@ -1462,19 +1462,20 @@ def test_bounded_journal_reads_map_bound_failure_to_journal_unreadable(enabled, 
     _write_run_json_locked(repo, run_dir, "started")  # clean current-version artifact
 
     # A bound-exceeded journal read must map to journal-unreadable on both the
-    # comparison path and the readiness path. read_journal_bounded is the
-    # only journal reader run_shadow uses; the legacy lifecycle path keeps
-    # using unbounded read_journal, so the legacy write still commits.
+    # comparison path and the readiness path. The lifecycle write itself uses
+    # the same bounded reader, so complete it before injecting the observer's
+    # read failure.
+    run_before = (run_dir / "run.json").read_bytes()
+    _write_run_json_locked(repo, run_dir, "planning")
+    assert (run_dir / "run.json").read_bytes() != run_before
+
     def raising_bounded(path):
         raise run_journal.RunJournalError("bound exceeded: journal above MAX_JOURNAL_BYTES")
 
     monkeypatch.setattr(run_journal, "read_journal_bounded", raising_bounded)
 
-    # Comparison path: legacy write still advances, shadow records
-    # journal-unreadable.
-    run_before = (run_dir / "run.json").read_bytes()
-    _write_run_json_locked(repo, run_dir, "planning")
-    assert (run_dir / "run.json").read_bytes() != run_before
+    # Comparison path: shadow records journal-unreadable without propagating.
+    run_shadow.record_shadow_comparison(run_dir, json.loads((run_dir / "run.json").read_text()))
     data = json.loads(run_shadow.shadow_artifact_path(run_dir).read_text())
     assert data["errors"] >= 1
     assert data["last_error_category"] == "journal-unreadable"


### PR DESCRIPTION
## Summary

- raise the lifecycle journal ceiling from 512 to 2048 events while keeping the 8 MiB byte bound
- warn at 75% event usage and allow runs stopped at the old ceiling to recover and append from sequence 513
- route runtime mutation and control paths through the shared bounded reader
- store the measurement artifact, correct its headroom arithmetic, and fail closed on unreadable or incomplete inputs

## Why

Measurements showed that event count reaches the old ceiling well before journal bytes become binding. Raising the shared event bound preserves the current single-file journal design while the 75% warning gives operators time to react before append refuses a transition.

## Verification

- journal, measurement, lifecycle, and shadow suites: 193 passed on the code-equivalent tree before the documentation-only #667 merge, receipt `20260802-013725-work-verify-512672`
- `./scripts/verify`: passed on that tree, receipt `20260802-013803-work-verify-1820ab`
- independent review reported no blocking findings and identified 2 test-hardening changes that are included in the final branch

Closes #653
Closes #635
