### PR TITLE
fix(guard): validate revision range operands

### DIFF
--- a/src/brigade/guard/git_commits.py
+++ b/src/brigade/guard/git_commits.py
@@ -119,16 +119,31 @@ def _commit_revs(args: argparse.Namespace) -> list[str]:
 
 
 def _default_range() -> str:
-    proc = subprocess.run(
-        ["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    upstream = proc.stdout.strip()
-    if proc.returncode == 0 and upstream:
-        return f"{upstream}..HEAD"
-    return "HEAD"
+    try:
+        upstream = subprocess.run(
+            ["git", "rev-parse", "--symbolic-full-name", "@{upstream}"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if upstream.returncode != 0 or not upstream.stdout.strip():
+            return "HEAD"
+
+        resolved = subprocess.run(
+            ["git", "rev-parse", "--verify", "@{upstream}^{commit}"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        print("git command failed", file=sys.stderr)
+        raise SystemExit(2) from None
+
+    upstream_commit = resolved.stdout.strip()
+    if resolved.returncode != 0 or not upstream_commit:
+        print("git rev-parse failed", file=sys.stderr)
+        raise SystemExit(2)
+    return f"{upstream_commit}..HEAD"
 
 
 def _git(args: list[str], *, bounded_error: str | None = None) -> str:

--- a/src/brigade/guard/git_commits.py
+++ b/src/brigade/guard/git_commits.py
@@ -8,6 +8,7 @@ import sys
 from .engine import scan_text
 from .policy import Policy, load_policy
 from .report import to_text
+from .rev_range import validate_rev_range_operand
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -99,9 +100,13 @@ def _commit_revs(args: argparse.Namespace) -> list[str]:
     if args.all:
         cmd = ["rev-list", "--reverse", "--all"]
     else:
-        if not args.rev_range and not _has_head():
-            return []
-        rev_range = args.rev_range or _default_range()
+        if args.rev_range is not None:
+            validate_rev_range_operand(args.rev_range)
+            rev_range = args.rev_range
+        else:
+            if not _has_head():
+                return []
+            rev_range = _default_range()
         cmd = ["rev-list", "--reverse", rev_range]
 
     output = _git(cmd)

--- a/src/brigade/guard/git_commits.py
+++ b/src/brigade/guard/git_commits.py
@@ -17,8 +17,11 @@ def main(argv: list[str] | None = None) -> int:
         description="Scan Git commit messages before publishing or pushing.",
     )
     parser.add_argument("--policy", help="JSON policy file")
-    parser.add_argument("--range", dest="rev_range", help="revision range to scan, for example origin/main..HEAD")
-    parser.add_argument("--all", action="store_true", help="scan all reachable commits")
+    history_source = parser.add_mutually_exclusive_group()
+    history_source.add_argument(
+        "--range", dest="rev_range", help="revision range to scan, for example origin/main..HEAD"
+    )
+    history_source.add_argument("--all", action="store_true", help="scan all reachable commits")
     parser.add_argument("--json", action="store_true", help="emit JSON report")
     args = parser.parse_args(argv)
 
@@ -97,11 +100,12 @@ def _default_commit_policy() -> Policy:
 
 
 def _commit_revs(args: argparse.Namespace) -> list[str]:
+    if args.rev_range is not None:
+        validate_rev_range_operand(args.rev_range)
     if args.all:
         cmd = ["rev-list", "--reverse", "--all"]
     else:
         if args.rev_range is not None:
-            validate_rev_range_operand(args.rev_range)
             rev_range = args.rev_range
         else:
             if not _has_head():

--- a/src/brigade/guard/git_commits.py
+++ b/src/brigade/guard/git_commits.py
@@ -8,7 +8,7 @@ import sys
 from .engine import scan_text
 from .policy import Policy, load_policy
 from .report import to_text
-from .rev_range import validate_rev_range_operand
+from .rev_range import fail_invalid_rev_range_operand, git_has_head, validate_rev_range_operand
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -108,12 +108,12 @@ def _commit_revs(args: argparse.Namespace) -> list[str]:
         if args.rev_range is not None:
             rev_range = args.rev_range
         else:
-            if not _has_head():
+            if not git_has_head():
                 return []
             rev_range = _default_range()
-        cmd = ["rev-list", "--reverse", rev_range]
+        cmd = ["rev-list", "--reverse", "--end-of-options", rev_range]
 
-    output = _git(cmd)
+    output = _git(cmd, invalid_range_on_error=args.rev_range is not None)
     return [line for line in output.splitlines() if line.strip()]
 
 
@@ -130,14 +130,17 @@ def _default_range() -> str:
     return "HEAD"
 
 
-def _has_head() -> bool:
-    proc = subprocess.run(["git", "rev-parse", "--verify", "HEAD"], capture_output=True, text=True, check=False)
-    return proc.returncode == 0
-
-
-def _git(args: list[str]) -> str:
-    proc = subprocess.run(["git", *args], capture_output=True, text=True, check=False)
+def _git(args: list[str], *, invalid_range_on_error: bool = False) -> str:
+    try:
+        proc = subprocess.run(["git", *args], capture_output=True, text=True, check=False)
+    except OSError:
+        if invalid_range_on_error:
+            fail_invalid_rev_range_operand()
+        print("git command failed", file=sys.stderr)
+        raise SystemExit(2) from None
     if proc.returncode != 0:
+        if invalid_range_on_error:
+            fail_invalid_rev_range_operand()
         print((proc.stderr or proc.stdout or "git command failed").strip(), file=sys.stderr)
         raise SystemExit(2)
     return proc.stdout

--- a/src/brigade/guard/git_commits.py
+++ b/src/brigade/guard/git_commits.py
@@ -8,7 +8,7 @@ import sys
 from .engine import scan_text
 from .policy import Policy, load_policy
 from .report import to_text
-from .rev_range import fail_invalid_rev_range_operand, git_has_head, validate_rev_range_operand
+from .rev_range import git_has_head, validate_rev_range_operand
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -111,9 +111,10 @@ def _commit_revs(args: argparse.Namespace) -> list[str]:
             if not git_has_head():
                 return []
             rev_range = _default_range()
-        cmd = ["rev-list", "--reverse", "--end-of-options", rev_range]
+        cmd = ["rev-list", "--reverse", rev_range]
 
-    output = _git(cmd, invalid_range_on_error=args.rev_range is not None)
+    bounded_error = "git rev-list failed" if args.rev_range is not None else None
+    output = _git(cmd, bounded_error=bounded_error)
     return [line for line in output.splitlines() if line.strip()]
 
 
@@ -130,17 +131,16 @@ def _default_range() -> str:
     return "HEAD"
 
 
-def _git(args: list[str], *, invalid_range_on_error: bool = False) -> str:
+def _git(args: list[str], *, bounded_error: str | None = None) -> str:
     try:
         proc = subprocess.run(["git", *args], capture_output=True, text=True, check=False)
     except OSError:
-        if invalid_range_on_error:
-            fail_invalid_rev_range_operand()
         print("git command failed", file=sys.stderr)
         raise SystemExit(2) from None
     if proc.returncode != 0:
-        if invalid_range_on_error:
-            fail_invalid_rev_range_operand()
+        if bounded_error is not None:
+            print(bounded_error, file=sys.stderr)
+            raise SystemExit(2)
         print((proc.stderr or proc.stdout or "git command failed").strip(), file=sys.stderr)
         raise SystemExit(2)
     return proc.stdout

--- a/src/brigade/guard/git_scan.py
+++ b/src/brigade/guard/git_scan.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from .engine import scan_text
 from .policy import Policy, default_policy, load_policy
 from .report import to_text
-from .rev_range import fail_invalid_rev_range_operand, git_has_head, validate_rev_range_operand
+from .rev_range import git_has_head, validate_rev_range_operand
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -57,6 +57,10 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--json", action="store_true", help="emit JSON report")
     args = parser.parse_args(argv)
+    if args.rev_range is not None and not args.history:
+        parser.error("--range requires --history")
+    if args.all and not args.history:
+        parser.error("--all requires --history")
     if args.revs_stdin and not args.history:
         parser.error("--revs-stdin requires --history")
 
@@ -182,7 +186,7 @@ def _history_revs(args: argparse.Namespace) -> list[str]:
         cmd = ["git", "rev-list", "--all"]
     elif args.rev_range is not None:
         validate_rev_range_operand(args.rev_range)
-        cmd = ["git", "rev-list", "--end-of-options", args.rev_range]
+        cmd = ["git", "rev-list", args.rev_range]
     else:
         if not git_has_head():
             return []
@@ -190,13 +194,12 @@ def _history_revs(args: argparse.Namespace) -> list[str]:
     try:
         proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
     except OSError:
-        if args.rev_range is not None:
-            fail_invalid_rev_range_operand()
         print("git rev-list failed", file=sys.stderr)
         raise SystemExit(2) from None
     if proc.returncode != 0:
         if args.rev_range is not None:
-            fail_invalid_rev_range_operand()
+            print("git rev-list failed", file=sys.stderr)
+            raise SystemExit(2)
         print((proc.stderr or "git rev-list failed").strip(), file=sys.stderr)
         raise SystemExit(2)
     return [line for line in proc.stdout.splitlines() if line.strip()]

--- a/src/brigade/guard/git_scan.py
+++ b/src/brigade/guard/git_scan.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from .engine import scan_text
 from .policy import Policy, default_policy, load_policy
 from .report import to_text
+from .rev_range import validate_rev_range_operand
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -179,7 +180,8 @@ def _history_revs(args: argparse.Namespace) -> list[str]:
         return revs
     if args.all:
         cmd = ["git", "rev-list", "--all"]
-    elif args.rev_range:
+    elif args.rev_range is not None:
+        validate_rev_range_operand(args.rev_range)
         cmd = ["git", "rev-list", args.rev_range]
     else:
         cmd = ["git", "rev-list", "HEAD"]

--- a/src/brigade/guard/git_scan.py
+++ b/src/brigade/guard/git_scan.py
@@ -184,12 +184,19 @@ def _history_revs(args: argparse.Namespace) -> list[str]:
         validate_rev_range_operand(args.rev_range)
         cmd = ["git", "rev-list", args.rev_range]
     else:
+        if not _has_head():
+            return []
         cmd = ["git", "rev-list", "HEAD"]
     proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
     if proc.returncode != 0:
         print((proc.stderr or "git rev-list failed").strip(), file=sys.stderr)
         raise SystemExit(2)
     return [line for line in proc.stdout.splitlines() if line.strip()]
+
+
+def _has_head() -> bool:
+    proc = subprocess.run(["git", "rev-parse", "--verify", "HEAD"], capture_output=True, text=True, check=False)
+    return proc.returncode == 0
 
 
 def _added_lines(rev: str) -> str:

--- a/src/brigade/guard/git_scan.py
+++ b/src/brigade/guard/git_scan.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from .engine import scan_text
 from .policy import Policy, default_policy, load_policy
 from .report import to_text
-from .rev_range import validate_rev_range_operand
+from .rev_range import fail_invalid_rev_range_operand, git_has_head, validate_rev_range_operand
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -182,37 +182,24 @@ def _history_revs(args: argparse.Namespace) -> list[str]:
         cmd = ["git", "rev-list", "--all"]
     elif args.rev_range is not None:
         validate_rev_range_operand(args.rev_range)
-        cmd = ["git", "rev-list", args.rev_range]
+        cmd = ["git", "rev-list", "--end-of-options", args.rev_range]
     else:
-        if not _has_head():
+        if not git_has_head():
             return []
         cmd = ["git", "rev-list", "HEAD"]
-    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    except OSError:
+        if args.rev_range is not None:
+            fail_invalid_rev_range_operand()
+        print("git rev-list failed", file=sys.stderr)
+        raise SystemExit(2) from None
     if proc.returncode != 0:
+        if args.rev_range is not None:
+            fail_invalid_rev_range_operand()
         print((proc.stderr or "git rev-list failed").strip(), file=sys.stderr)
         raise SystemExit(2)
     return [line for line in proc.stdout.splitlines() if line.strip()]
-
-
-def _has_head() -> bool:
-    head = subprocess.run(["git", "rev-parse", "--verify", "HEAD"], capture_output=True, text=True, check=False)
-    if head.returncode == 0:
-        return True
-
-    symbolic = subprocess.run(["git", "symbolic-ref", "-q", "HEAD"], capture_output=True, text=True, check=False)
-    branch_ref = symbolic.stdout.strip()
-    if symbolic.returncode == 0 and branch_ref:
-        branch = subprocess.run(
-            ["git", "show-ref", "--verify", "--quiet", branch_ref],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if branch.returncode == 1:
-            return False
-
-    print((head.stderr or symbolic.stderr or "git rev-parse failed").strip(), file=sys.stderr)
-    raise SystemExit(2)
 
 
 def _added_lines(rev: str) -> str:

--- a/src/brigade/guard/git_scan.py
+++ b/src/brigade/guard/git_scan.py
@@ -195,8 +195,24 @@ def _history_revs(args: argparse.Namespace) -> list[str]:
 
 
 def _has_head() -> bool:
-    proc = subprocess.run(["git", "rev-parse", "--verify", "HEAD"], capture_output=True, text=True, check=False)
-    return proc.returncode == 0
+    head = subprocess.run(["git", "rev-parse", "--verify", "HEAD"], capture_output=True, text=True, check=False)
+    if head.returncode == 0:
+        return True
+
+    symbolic = subprocess.run(["git", "symbolic-ref", "-q", "HEAD"], capture_output=True, text=True, check=False)
+    branch_ref = symbolic.stdout.strip()
+    if symbolic.returncode == 0 and branch_ref:
+        branch = subprocess.run(
+            ["git", "show-ref", "--verify", "--quiet", branch_ref],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if branch.returncode == 1:
+            return False
+
+    print((head.stderr or symbolic.stderr or "git rev-parse failed").strip(), file=sys.stderr)
+    raise SystemExit(2)
 
 
 def _added_lines(rev: str) -> str:

--- a/src/brigade/guard/publish_check.py
+++ b/src/brigade/guard/publish_check.py
@@ -30,8 +30,9 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--repo-policy", help="repo policy file, default: policies/public-repo.json near project root")
     parser.add_argument("--out-dir", help="PR body output directory, default: .content-guard/pr-drafts")
     parser.add_argument("--name", help="PR body output basename, default: PR body stem")
-    parser.add_argument("--commit-range", dest="rev_range", help="commit revision range to scan")
-    parser.add_argument("--all-commits", action="store_true", help="scan all reachable commit messages")
+    commit_source = parser.add_mutually_exclusive_group()
+    commit_source.add_argument("--commit-range", dest="rev_range", help="commit revision range to scan")
+    commit_source.add_argument("--all-commits", action="store_true", help="scan all reachable commit messages")
     parser.add_argument("--all-tracked", action="store_true", help="also scan all tracked files")
     parser.add_argument(
         "--include-git-config", action="store_true", help="include .git/config in file scans when present"

--- a/src/brigade/guard/rev_range.py
+++ b/src/brigade/guard/rev_range.py
@@ -31,6 +31,8 @@ def _operand_invalid(operand: str) -> bool:
     for component in components:
         if not component or component[0] == "-":
             return True
+        if component == "." or component.startswith("./"):
+            return True
         if not all(ch in _ALLOWED_CHARS for ch in component):
             return True
     return False
@@ -47,6 +49,6 @@ def _split_rev_range(operand: str) -> list[str] | None:
         return None
     left = operand[: separator.start()]
     right = operand[separator.end() :]
-    if not left or not right:
+    if not left and not right:
         return None
-    return [left, right]
+    return [component for component in (left, right) if component]

--- a/src/brigade/guard/rev_range.py
+++ b/src/brigade/guard/rev_range.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import sys
+
+_INVALID_OPERAND = "invalid revision range operand"
+
+_ALLOWED_CHARS = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._~/^:@{}-")
+_FORBIDDEN_METACHAR = frozenset(";|&$`()<>\\\"' \t\n\r*?[]!%=")
+
+
+def validate_rev_range_operand(operand: str) -> None:
+    """Reject user-controlled revision/range operands before git rev-list."""
+    if _operand_invalid(operand):
+        print(_INVALID_OPERAND, file=sys.stderr)
+        raise SystemExit(2)
+
+
+def _operand_invalid(operand: str) -> bool:
+    if not operand or operand != operand.strip():
+        return True
+    if operand[0] == "-":
+        return True
+    if any(ord(ch) < 32 or ord(ch) == 127 for ch in operand):
+        return True
+    if any(ch in _FORBIDDEN_METACHAR for ch in operand):
+        return True
+    components = _split_rev_range(operand)
+    if components is None:
+        return True
+    for component in components:
+        if not component or component[0] == "-":
+            return True
+        if not all(ch in _ALLOWED_CHARS for ch in component):
+            return True
+    return False
+
+
+def _split_rev_range(operand: str) -> list[str] | None:
+    if "..." in operand:
+        if operand.count("...") != 1:
+            return None
+        left, _, right = operand.partition("...")
+        if not left or not right:
+            return None
+        return [left, right]
+    if ".." in operand:
+        if operand.count("..") != 1:
+            return None
+        left, _, right = operand.partition("..")
+        if not left or not right:
+            return None
+        return [left, right]
+    return [operand]

--- a/src/brigade/guard/rev_range.py
+++ b/src/brigade/guard/rev_range.py
@@ -1,54 +1,58 @@
 from __future__ import annotations
 
-import re
+import os
+import subprocess
 import sys
+from typing import NoReturn
 
 _INVALID_OPERAND = "invalid revision range operand"
-
-_ALLOWED_CHARS = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._~/^:@{}-+!")
-_FORBIDDEN_METACHAR = frozenset(";|&$`()<>\\\"' \t\n\r*?[]%=")
+_MAX_OPERAND_BYTES = 65_536
 
 
 def validate_rev_range_operand(operand: str) -> None:
-    """Reject user-controlled revision/range operands before git rev-list."""
+    """Reject option-shaped or unbounded operands before git rev-list."""
     if _operand_invalid(operand):
-        print(_INVALID_OPERAND, file=sys.stderr)
-        raise SystemExit(2)
+        fail_invalid_rev_range_operand()
 
 
 def _operand_invalid(operand: str) -> bool:
-    if not operand or operand != operand.strip():
+    if not operand or operand.isspace():
         return True
     if operand[0] == "-":
         return True
     if any(ord(ch) < 32 or ord(ch) == 127 for ch in operand):
         return True
-    if any(ch in _FORBIDDEN_METACHAR for ch in operand):
+    if len(os.fsencode(operand)) > _MAX_OPERAND_BYTES:
         return True
-    components = _split_rev_range(operand)
-    if components is None:
-        return True
-    for component in components:
-        if not component or component[0] == "-":
-            return True
-        if component == "." or component.startswith("./"):
-            return True
-        if not all(ch in _ALLOWED_CHARS for ch in component):
-            return True
     return False
 
 
-def _split_rev_range(operand: str) -> list[str] | None:
-    separators = list(re.finditer(r"\.{2,}", operand))
-    if not separators:
-        return [operand]
-    if len(separators) != 1:
-        return None
-    separator = separators[0]
-    if separator.end() - separator.start() not in (2, 3):
-        return None
-    left = operand[: separator.start()]
-    right = operand[separator.end() :]
-    if not left and not right:
-        return None
-    return [component for component in (left, right) if component]
+def fail_invalid_rev_range_operand() -> NoReturn:
+    print(_INVALID_OPERAND, file=sys.stderr)
+    raise SystemExit(2)
+
+
+def git_has_head() -> bool:
+    """Return false only for an unborn branch; fail on other Git errors."""
+    try:
+        head = subprocess.run(["git", "rev-parse", "--verify", "HEAD"], capture_output=True, text=True, check=False)
+        if head.returncode == 0:
+            return True
+
+        symbolic = subprocess.run(["git", "symbolic-ref", "-q", "HEAD"], capture_output=True, text=True, check=False)
+        branch_ref = symbolic.stdout.strip()
+        if symbolic.returncode == 0 and branch_ref:
+            branch = subprocess.run(
+                ["git", "show-ref", "--verify", "--quiet", branch_ref],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if branch.returncode == 1:
+                return False
+    except OSError:
+        print("git command failed", file=sys.stderr)
+        raise SystemExit(2) from None
+
+    print((head.stderr or symbolic.stderr or "git rev-parse failed").strip(), file=sys.stderr)
+    raise SystemExit(2)

--- a/src/brigade/guard/rev_range.py
+++ b/src/brigade/guard/rev_range.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import re
 import sys
 
 _INVALID_OPERAND = "invalid revision range operand"
 
-_ALLOWED_CHARS = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._~/^:@{}-")
-_FORBIDDEN_METACHAR = frozenset(";|&$`()<>\\\"' \t\n\r*?[]!%=")
+_ALLOWED_CHARS = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._~/^:@{}-+!")
+_FORBIDDEN_METACHAR = frozenset(";|&$`()<>\\\"' \t\n\r*?[]%=")
 
 
 def validate_rev_range_operand(operand: str) -> None:
@@ -36,18 +37,16 @@ def _operand_invalid(operand: str) -> bool:
 
 
 def _split_rev_range(operand: str) -> list[str] | None:
-    if "..." in operand:
-        if operand.count("...") != 1:
-            return None
-        left, _, right = operand.partition("...")
-        if not left or not right:
-            return None
-        return [left, right]
-    if ".." in operand:
-        if operand.count("..") != 1:
-            return None
-        left, _, right = operand.partition("..")
-        if not left or not right:
-            return None
-        return [left, right]
-    return [operand]
+    separators = list(re.finditer(r"\.{2,}", operand))
+    if not separators:
+        return [operand]
+    if len(separators) != 1:
+        return None
+    separator = separators[0]
+    if separator.end() - separator.start() not in (2, 3):
+        return None
+    left = operand[: separator.start()]
+    right = operand[separator.end() :]
+    if not left or not right:
+        return None
+    return [left, right]

--- a/src/brigade/guard/rev_range.py
+++ b/src/brigade/guard/rev_range.py
@@ -48,7 +48,7 @@ def git_has_head() -> bool:
                 text=True,
                 check=False,
             )
-            if branch.returncode == 1:
+            if branch.returncode == 1 and branch_ref.startswith("refs/heads/"):
                 return False
     except OSError:
         print("git command failed", file=sys.stderr)

--- a/tests/guard/test_rev_range.py
+++ b/tests/guard/test_rev_range.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+from brigade.guard.git_commits import _commit_revs
+from brigade.guard.git_scan import _history_revs
+from brigade.guard.rev_range import validate_rev_range_operand
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class RevRangeValidationTests(unittest.TestCase):
+    def test_rejects_option_injection_operands(self) -> None:
+        for operand in (
+            "--max-count=0",
+            "--all",
+            " --max-count=0",
+            "--max-count=0 ",
+            "-HEAD",
+            "",
+            "   ",
+            "origin/main..",
+            "..HEAD",
+            "HEAD;id",
+            "HEAD|id",
+            "HEAD\n--all",
+        ):
+            with self.subTest(operand=operand):
+                with self.assertRaises(SystemExit) as ctx:
+                    validate_rev_range_operand(operand)
+                self.assertEqual(ctx.exception.code, 2)
+
+    def test_accepts_common_revision_operands(self) -> None:
+        for operand in (
+            "HEAD",
+            "origin/main..HEAD",
+            "HEAD~1..HEAD",
+            "refs/tags/v1.2.3",
+            "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+            "feature/foo_bar",
+            "main...HEAD",
+            "^HEAD",
+            "@{upstream}",
+        ):
+            with self.subTest(operand=operand):
+                validate_rev_range_operand(operand)
+
+    def test_history_revs_rejects_injection_before_rev_list(self) -> None:
+        import argparse
+
+        args = argparse.Namespace(rev_range="--max-count=0", all=False, revs_stdin=False)
+        with mock.patch("brigade.guard.git_scan.subprocess.run") as run:
+            with self.assertRaises(SystemExit) as ctx:
+                _history_revs(args)
+            run.assert_not_called()
+        self.assertEqual(ctx.exception.code, 2)
+
+    def test_history_revs_rejects_explicit_empty_range_before_rev_list(self) -> None:
+        import argparse
+
+        for operand in ("", "   "):
+            with self.subTest(operand=operand):
+                args = argparse.Namespace(rev_range=operand, all=False, revs_stdin=False)
+                with mock.patch("brigade.guard.git_scan.subprocess.run") as run:
+                    with self.assertRaises(SystemExit) as ctx:
+                        _history_revs(args)
+                    run.assert_not_called()
+                self.assertEqual(ctx.exception.code, 2)
+
+    def test_commit_revs_rejects_injection_before_rev_list(self) -> None:
+        import argparse
+
+        args = argparse.Namespace(rev_range="--max-count=0", all=False)
+        with mock.patch("brigade.guard.git_commits.subprocess.run") as run:
+            with self.assertRaises(SystemExit) as ctx:
+                _commit_revs(args)
+            run.assert_not_called()
+        self.assertEqual(ctx.exception.code, 2)
+
+    def test_commit_revs_rejects_explicit_empty_range_before_rev_list(self) -> None:
+        import argparse
+
+        for operand in ("", "   "):
+            with self.subTest(operand=operand):
+                args = argparse.Namespace(rev_range=operand, all=False)
+                with (
+                    mock.patch("brigade.guard.git_commits._has_head") as has_head,
+                    mock.patch("brigade.guard.git_commits._git") as git,
+                ):
+                    with self.assertRaises(SystemExit) as ctx:
+                        _commit_revs(args)
+                    has_head.assert_not_called()
+                    git.assert_not_called()
+                self.assertEqual(ctx.exception.code, 2)
+
+    def test_git_scan_history_rejects_injected_range_cli(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            self._init_repo(repo)
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "brigade.guard.git_scan",
+                    "--history",
+                    "--range=--max-count=0",
+                    "--json",
+                ],
+                cwd=repo,
+                env={"PYTHONPATH": str(ROOT / "src")},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn("invalid revision range operand", proc.stderr)
+        self.assertNotIn("Clean", proc.stdout)
+
+    def test_git_scan_history_rejects_explicit_empty_range_cli(self) -> None:
+        for operand in ("", "   "):
+            with self.subTest(operand=operand), TemporaryDirectory() as tmp:
+                repo = Path(tmp)
+                self._init_repo(repo)
+                proc = subprocess.run(
+                    [
+                        sys.executable,
+                        "-m",
+                        "brigade.guard.git_scan",
+                        "--history",
+                        f"--range={operand}",
+                        "--json",
+                    ],
+                    cwd=repo,
+                    env={"PYTHONPATH": str(ROOT / "src")},
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+            self.assertEqual(proc.returncode, 2)
+            self.assertIn("invalid revision range operand", proc.stderr)
+            self.assertEqual(proc.stdout, "")
+
+    def test_git_commits_rejects_injected_range_cli(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            self._init_repo(repo)
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "brigade.guard.git_commits",
+                    "--range=--max-count=0",
+                    "--json",
+                ],
+                cwd=repo,
+                env={"PYTHONPATH": str(ROOT / "src")},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn("invalid revision range operand", proc.stderr)
+        self.assertNotIn("Clean", proc.stdout)
+
+    def test_publish_check_rejects_injected_commit_range_cli(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            self._init_repo(repo)
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "brigade.guard.publish_check",
+                    "--commit-range=--max-count=0",
+                    "--json",
+                ],
+                cwd=repo,
+                env={"PYTHONPATH": str(ROOT / "src")},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn("invalid revision range operand", proc.stderr)
+        self.assertEqual(proc.stdout, "")
+
+    def test_publish_check_rejects_explicit_empty_commit_range_cli(self) -> None:
+        for operand in ("", "   "):
+            with self.subTest(operand=operand), TemporaryDirectory() as tmp:
+                repo = Path(tmp)
+                self._init_repo(repo)
+                proc = subprocess.run(
+                    [
+                        sys.executable,
+                        "-m",
+                        "brigade.guard.publish_check",
+                        f"--commit-range={operand}",
+                        "--json",
+                    ],
+                    cwd=repo,
+                    env={"PYTHONPATH": str(ROOT / "src")},
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+            self.assertEqual(proc.returncode, 2)
+            self.assertIn("invalid revision range operand", proc.stderr)
+            self.assertEqual(proc.stdout, "")
+
+    def test_git_scan_history_accepts_valid_range_cli(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            self._init_repo(repo)
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "brigade.guard.git_scan",
+                    "--history",
+                    "--range",
+                    "HEAD",
+                    "--json",
+                ],
+                cwd=repo,
+                env={"PYTHONPATH": str(ROOT / "src")},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+        payload = __import__("json").loads(proc.stdout)
+        self.assertGreaterEqual(payload["commits_scanned"], 1)
+
+    def _init_repo(self, repo: Path) -> None:
+        subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
+        subprocess.run(["git", "config", "user.name", "Example User"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.email", "user@example"], cwd=repo, check=True)
+        (repo / "README.md").write_text("example\n")
+        subprocess.run(["git", "add", "README.md"], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-m", "feat: example"], cwd=repo, check=True, capture_output=True, text=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/guard/test_rev_range.py
+++ b/tests/guard/test_rev_range.py
@@ -22,21 +22,10 @@ class RevRangeValidationTests(unittest.TestCase):
         for operand in (
             "--max-count=0",
             "--all",
-            " --max-count=0",
             "--max-count=0 ",
             "-HEAD",
             "",
             "   ",
-            "..",
-            "...",
-            "a....b",
-            "a.....b",
-            "a...b..c",
-            "a..b...c",
-            ".",
-            "./README.md",
-            "HEAD;id",
-            "HEAD|id",
             "HEAD\n--all",
         ):
             with self.subTest(operand=operand):
@@ -61,6 +50,11 @@ class RevRangeValidationTests(unittest.TestCase):
             "HEAD^!",
             "@{upstream}",
             "v1.0.0+build.1",
+            "café",
+            "feature#1",
+            "release(v1)",
+            "foo=bar",
+            ":/search text",
         ):
             with self.subTest(operand=operand):
                 validate_rev_range_operand(operand)
@@ -111,7 +105,7 @@ class RevRangeValidationTests(unittest.TestCase):
             with self.subTest(operand=operand):
                 args = argparse.Namespace(rev_range=operand, all=False)
                 with (
-                    mock.patch("brigade.guard.git_commits._has_head") as has_head,
+                    mock.patch("brigade.guard.git_commits.git_has_head") as has_head,
                     mock.patch("brigade.guard.git_commits._git") as git,
                 ):
                     with self.assertRaises(SystemExit) as ctx:
@@ -328,6 +322,53 @@ class RevRangeValidationTests(unittest.TestCase):
                 )
             self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
 
+    def test_history_clis_accept_valid_punctuation_and_unicode_refs(self) -> None:
+        invocations = (
+            ("brigade.guard.git_scan", "--history", "--range="),
+            ("brigade.guard.git_commits", "--range="),
+            ("brigade.guard.publish_check", "--commit-range="),
+        )
+        for ref_name in ("café", "feature#1", "release(v1)", "foo=bar"):
+            for module, *prefix in invocations:
+                with self.subTest(module=module, ref_name=ref_name), TemporaryDirectory() as tmp:
+                    repo = Path(tmp)
+                    self._init_repo(repo)
+                    subprocess.run(["git", "branch", ref_name], cwd=repo, check=True)
+                    range_arg = f"{prefix[-1]}{ref_name}"
+                    proc = subprocess.run(
+                        [sys.executable, "-m", module, *prefix[:-1], range_arg, "--json"],
+                        cwd=repo,
+                        env={"PYTHONPATH": str(ROOT / "src")},
+                        capture_output=True,
+                        text=True,
+                        check=False,
+                    )
+                self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+
+    def test_history_clis_bound_git_errors_for_user_ranges(self) -> None:
+        invocations = (
+            ("brigade.guard.git_scan", "--history", "--range="),
+            ("brigade.guard.git_commits", "--range="),
+            ("brigade.guard.publish_check", "--commit-range="),
+        )
+        for operand in (".", "./README.md", "a....b", "A" * 10_000):
+            for module, *prefix in invocations:
+                with self.subTest(module=module, operand=operand[:20]), TemporaryDirectory() as tmp:
+                    repo = Path(tmp)
+                    self._init_repo(repo)
+                    range_arg = f"{prefix[-1]}{operand}"
+                    proc = subprocess.run(
+                        [sys.executable, "-m", module, *prefix[:-1], range_arg, "--json"],
+                        cwd=repo,
+                        env={"PYTHONPATH": str(ROOT / "src")},
+                        capture_output=True,
+                        text=True,
+                        check=False,
+                    )
+                self.assertEqual(proc.returncode, 2)
+                self.assertEqual(proc.stderr, "invalid revision range operand\n")
+                self.assertEqual(proc.stdout, "")
+
     def test_git_scan_history_handles_repository_without_head(self) -> None:
         with TemporaryDirectory() as tmp:
             repo = Path(tmp)
@@ -361,6 +402,20 @@ class RevRangeValidationTests(unittest.TestCase):
                     "--history",
                     "--json",
                 ],
+                cwd=tmp,
+                env={"PYTHONPATH": str(ROOT / "src")},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn("not a git repository", proc.stderr)
+        self.assertEqual(proc.stdout, "")
+
+    def test_git_commits_fails_outside_repository(self) -> None:
+        with TemporaryDirectory() as tmp:
+            proc = subprocess.run(
+                [sys.executable, "-m", "brigade.guard.git_commits", "--json"],
                 cwd=tmp,
                 env={"PYTHONPATH": str(ROOT / "src")},
                 capture_output=True,

--- a/tests/guard/test_rev_range.py
+++ b/tests/guard/test_rev_range.py
@@ -66,6 +66,13 @@ class RevRangeValidationTests(unittest.TestCase):
         self.assertEqual(ctx.exception.code, 2)
         self.assertEqual(stderr.getvalue(), "invalid revision range operand\n")
 
+    def test_rejects_an_operand_larger_than_the_process_bound(self) -> None:
+        stderr = io.StringIO()
+        with redirect_stderr(stderr), self.assertRaises(SystemExit) as ctx:
+            validate_rev_range_operand("A" * 65_537)
+        self.assertEqual(ctx.exception.code, 2)
+        self.assertEqual(stderr.getvalue(), "invalid revision range operand\n")
+
     def test_history_revs_rejects_injection_before_rev_list(self) -> None:
         import argparse
 
@@ -123,6 +130,46 @@ class RevRangeValidationTests(unittest.TestCase):
                 _commit_revs(args)
             git.assert_not_called()
         self.assertEqual(ctx.exception.code, 2)
+
+    def test_default_commit_scan_does_not_require_end_of_options(self) -> None:
+        import argparse
+
+        args = argparse.Namespace(rev_range=None, all=False)
+        with (
+            mock.patch("brigade.guard.git_commits.git_has_head", return_value=True),
+            mock.patch("brigade.guard.git_commits._default_range", return_value="HEAD"),
+            mock.patch("brigade.guard.git_commits._git", return_value="") as git,
+        ):
+            self.assertEqual(_commit_revs(args), [])
+        git.assert_called_once_with(["rev-list", "--reverse", "HEAD"], bounded_error=None)
+
+    def test_history_revs_reports_process_failure_separately_from_invalid_range(self) -> None:
+        import argparse
+
+        args = argparse.Namespace(rev_range="HEAD", all=False, revs_stdin=False)
+        stderr = io.StringIO()
+        with (
+            mock.patch("brigade.guard.git_scan.subprocess.run", side_effect=OSError),
+            redirect_stderr(stderr),
+            self.assertRaises(SystemExit) as ctx,
+        ):
+            _history_revs(args)
+        self.assertEqual(ctx.exception.code, 2)
+        self.assertEqual(stderr.getvalue(), "git rev-list failed\n")
+
+    def test_commit_revs_reports_process_failure_separately_from_invalid_range(self) -> None:
+        import argparse
+
+        args = argparse.Namespace(rev_range="HEAD", all=False)
+        stderr = io.StringIO()
+        with (
+            mock.patch("brigade.guard.git_commits.subprocess.run", side_effect=OSError),
+            redirect_stderr(stderr),
+            self.assertRaises(SystemExit) as ctx,
+        ):
+            _commit_revs(args)
+        self.assertEqual(ctx.exception.code, 2)
+        self.assertEqual(stderr.getvalue(), "git command failed\n")
 
     def test_git_scan_history_rejects_injected_range_cli(self) -> None:
         with TemporaryDirectory() as tmp:
@@ -366,8 +413,25 @@ class RevRangeValidationTests(unittest.TestCase):
                         check=False,
                     )
                 self.assertEqual(proc.returncode, 2)
-                self.assertEqual(proc.stderr, "invalid revision range operand\n")
+                self.assertEqual(proc.stderr, "git rev-list failed\n")
                 self.assertEqual(proc.stdout, "")
+
+    def test_git_scan_range_and_all_require_history_mode(self) -> None:
+        for source_arg in ("--range=HEAD", "--all"):
+            with self.subTest(source_arg=source_arg), TemporaryDirectory() as tmp:
+                repo = Path(tmp)
+                self._init_repo(repo)
+                proc = subprocess.run(
+                    [sys.executable, "-m", "brigade.guard.git_scan", source_arg, "--json"],
+                    cwd=repo,
+                    env={"PYTHONPATH": str(ROOT / "src")},
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+            self.assertEqual(proc.returncode, 2)
+            self.assertIn("requires --history", proc.stderr)
+            self.assertEqual(proc.stdout, "")
 
     def test_git_scan_history_handles_repository_without_head(self) -> None:
         with TemporaryDirectory() as tmp:
@@ -425,6 +489,32 @@ class RevRangeValidationTests(unittest.TestCase):
         self.assertEqual(proc.returncode, 2)
         self.assertIn("not a git repository", proc.stderr)
         self.assertEqual(proc.stdout, "")
+
+    def test_history_clis_reject_missing_non_branch_head_target(self) -> None:
+        invocations = (
+            ("brigade.guard.git_scan", "--history"),
+            ("brigade.guard.git_commits",),
+        )
+        for invocation in invocations:
+            with self.subTest(module=invocation[0]), TemporaryDirectory() as tmp:
+                repo = Path(tmp)
+                self._init_repo(repo)
+                subprocess.run(
+                    ["git", "symbolic-ref", "HEAD", "refs/tags/missing"],
+                    cwd=repo,
+                    check=True,
+                )
+                proc = subprocess.run(
+                    [sys.executable, "-m", *invocation, "--json"],
+                    cwd=repo,
+                    env={"PYTHONPATH": str(ROOT / "src")},
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+            self.assertEqual(proc.returncode, 2)
+            self.assertNotIn("invalid revision range operand", proc.stderr)
+            self.assertEqual(proc.stdout, "")
 
     def _init_repo(self, repo: Path) -> None:
         subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)

--- a/tests/guard/test_rev_range.py
+++ b/tests/guard/test_rev_range.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import io
 import subprocess
 import sys
 import unittest
+from contextlib import redirect_stderr
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import mock
@@ -25,12 +27,14 @@ class RevRangeValidationTests(unittest.TestCase):
             "-HEAD",
             "",
             "   ",
-            "origin/main..",
-            "..HEAD",
+            "..",
+            "...",
             "a....b",
             "a.....b",
             "a...b..c",
             "a..b...c",
+            ".",
+            "./README.md",
             "HEAD;id",
             "HEAD|id",
             "HEAD\n--all",
@@ -44,11 +48,15 @@ class RevRangeValidationTests(unittest.TestCase):
         for operand in (
             "HEAD",
             "origin/main..HEAD",
+            "origin/main..",
+            "..HEAD",
             "HEAD~1..HEAD",
             "refs/tags/v1.2.3",
             "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
             "feature/foo_bar",
             "main...HEAD",
+            "main...",
+            "...HEAD",
             "^HEAD",
             "HEAD^!",
             "@{upstream}",
@@ -56,6 +64,13 @@ class RevRangeValidationTests(unittest.TestCase):
         ):
             with self.subTest(operand=operand):
                 validate_rev_range_operand(operand)
+
+    def test_rejection_uses_a_fixed_bounded_error(self) -> None:
+        stderr = io.StringIO()
+        with redirect_stderr(stderr), self.assertRaises(SystemExit) as ctx:
+            validate_rev_range_operand("-" + "x" * 10_000)
+        self.assertEqual(ctx.exception.code, 2)
+        self.assertEqual(stderr.getvalue(), "invalid revision range operand\n")
 
     def test_history_revs_rejects_injection_before_rev_list(self) -> None:
         import argparse
@@ -104,6 +119,16 @@ class RevRangeValidationTests(unittest.TestCase):
                     has_head.assert_not_called()
                     git.assert_not_called()
                 self.assertEqual(ctx.exception.code, 2)
+
+    def test_commit_revs_validates_range_even_when_all_is_set(self) -> None:
+        import argparse
+
+        args = argparse.Namespace(rev_range="--max-count=0", all=True)
+        with mock.patch("brigade.guard.git_commits._git") as git:
+            with self.assertRaises(SystemExit) as ctx:
+                _commit_revs(args)
+            git.assert_not_called()
+        self.assertEqual(ctx.exception.code, 2)
 
     def test_git_scan_history_rejects_injected_range_cli(self) -> None:
         with TemporaryDirectory() as tmp:
@@ -174,6 +199,26 @@ class RevRangeValidationTests(unittest.TestCase):
         self.assertIn("invalid revision range operand", proc.stderr)
         self.assertNotIn("Clean", proc.stdout)
 
+    def test_git_commits_rejects_all_with_range_cli(self) -> None:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "brigade.guard.git_commits",
+                "--all",
+                "--range=HEAD",
+                "--json",
+            ],
+            cwd=ROOT,
+            env={"PYTHONPATH": str(ROOT / "src")},
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn("not allowed with argument", proc.stderr)
+        self.assertEqual(proc.stdout, "")
+
     def test_publish_check_rejects_injected_commit_range_cli(self) -> None:
         with TemporaryDirectory() as tmp:
             repo = Path(tmp)
@@ -194,6 +239,26 @@ class RevRangeValidationTests(unittest.TestCase):
             )
         self.assertEqual(proc.returncode, 2)
         self.assertIn("invalid revision range operand", proc.stderr)
+        self.assertEqual(proc.stdout, "")
+
+    def test_publish_check_rejects_all_commits_with_commit_range_cli(self) -> None:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "brigade.guard.publish_check",
+                "--all-commits",
+                "--commit-range=HEAD",
+                "--json",
+            ],
+            cwd=ROOT,
+            env={"PYTHONPATH": str(ROOT / "src")},
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn("not allowed with argument", proc.stderr)
         self.assertEqual(proc.stdout, "")
 
     def test_publish_check_rejects_explicit_empty_commit_range_cli(self) -> None:
@@ -243,6 +308,26 @@ class RevRangeValidationTests(unittest.TestCase):
         payload = __import__("json").loads(proc.stdout)
         self.assertGreaterEqual(payload["commits_scanned"], 1)
 
+    def test_history_clis_accept_range_with_omitted_endpoint(self) -> None:
+        invocations = (
+            ("brigade.guard.git_scan", "--history", "--range=HEAD.."),
+            ("brigade.guard.git_commits", "--range=HEAD.."),
+            ("brigade.guard.publish_check", "--commit-range=HEAD.."),
+        )
+        for invocation in invocations:
+            with self.subTest(module=invocation[0]), TemporaryDirectory() as tmp:
+                repo = Path(tmp)
+                self._init_repo(repo)
+                proc = subprocess.run(
+                    [sys.executable, "-m", *invocation, "--json"],
+                    cwd=repo,
+                    env={"PYTHONPATH": str(ROOT / "src")},
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+            self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+
     def test_git_scan_history_handles_repository_without_head(self) -> None:
         with TemporaryDirectory() as tmp:
             repo = Path(tmp)
@@ -265,6 +350,26 @@ class RevRangeValidationTests(unittest.TestCase):
         payload = __import__("json").loads(proc.stdout)
         self.assertEqual(payload["commits_scanned"], 0)
         self.assertEqual(payload["commits_with_findings"], 0)
+
+    def test_git_scan_history_fails_outside_repository(self) -> None:
+        with TemporaryDirectory() as tmp:
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "brigade.guard.git_scan",
+                    "--history",
+                    "--json",
+                ],
+                cwd=tmp,
+                env={"PYTHONPATH": str(ROOT / "src")},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn("not a git repository", proc.stderr)
+        self.assertEqual(proc.stdout, "")
 
     def _init_repo(self, repo: Path) -> None:
         subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)

--- a/tests/guard/test_rev_range.py
+++ b/tests/guard/test_rev_range.py
@@ -27,6 +27,10 @@ class RevRangeValidationTests(unittest.TestCase):
             "   ",
             "origin/main..",
             "..HEAD",
+            "a....b",
+            "a.....b",
+            "a...b..c",
+            "a..b...c",
             "HEAD;id",
             "HEAD|id",
             "HEAD\n--all",
@@ -46,7 +50,9 @@ class RevRangeValidationTests(unittest.TestCase):
             "feature/foo_bar",
             "main...HEAD",
             "^HEAD",
+            "HEAD^!",
             "@{upstream}",
+            "v1.0.0+build.1",
         ):
             with self.subTest(operand=operand):
                 validate_rev_range_operand(operand)
@@ -236,6 +242,29 @@ class RevRangeValidationTests(unittest.TestCase):
         self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
         payload = __import__("json").loads(proc.stdout)
         self.assertGreaterEqual(payload["commits_scanned"], 1)
+
+    def test_git_scan_history_handles_repository_without_head(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "brigade.guard.git_scan",
+                    "--history",
+                    "--json",
+                ],
+                cwd=repo,
+                env={"PYTHONPATH": str(ROOT / "src")},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+        payload = __import__("json").loads(proc.stdout)
+        self.assertEqual(payload["commits_scanned"], 0)
+        self.assertEqual(payload["commits_with_findings"], 0)
 
     def _init_repo(self, repo: Path) -> None:
         subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)

--- a/tests/guard/test_rev_range.py
+++ b/tests/guard/test_rev_range.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import os
 import subprocess
 import sys
 import unittest
@@ -9,7 +10,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import mock
 
-from brigade.guard.git_commits import _commit_revs
+from brigade.guard.git_commits import _commit_revs, _default_range
 from brigade.guard.git_scan import _history_revs
 from brigade.guard.rev_range import validate_rev_range_operand
 
@@ -142,6 +143,80 @@ class RevRangeValidationTests(unittest.TestCase):
         ):
             self.assertEqual(_commit_revs(args), [])
         git.assert_called_once_with(["rev-list", "--reverse", "HEAD"], bounded_error=None)
+
+    def test_default_commit_range_preserves_option_shaped_upstream_ref(self) -> None:
+        for upstream in (
+            "refs/heads/--glob=refs/heads/NOMATCH",
+            "--glob=refs/heads/NOMATCH/x",
+        ):
+            with self.subTest(upstream=upstream):
+                self._assert_default_commit_range_scans_head(upstream)
+
+    def test_default_range_fails_when_configured_upstream_cannot_resolve(self) -> None:
+        def run(args: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            if "--symbolic-full-name" in args:
+                return subprocess.CompletedProcess(args, 0, "refs/remotes/origin/main\n", "")
+            return subprocess.CompletedProcess(args, 128, "", "fatal: needed a single revision\n")
+
+        stderr = io.StringIO()
+        with (
+            mock.patch("brigade.guard.git_commits.subprocess.run", side_effect=run),
+            redirect_stderr(stderr),
+            self.assertRaises(SystemExit) as ctx,
+        ):
+            _default_range()
+        self.assertEqual(ctx.exception.code, 2)
+        self.assertEqual(stderr.getvalue(), "git rev-parse failed\n")
+
+    def _assert_default_commit_range_scans_head(self, upstream: str) -> None:
+        import argparse
+
+        with TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            self._init_repo(repo)
+            old = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            (repo / "README.md").write_text("changed\n")
+            subprocess.run(["git", "commit", "-am", "fix: changed"], cwd=repo, check=True)
+            head = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            subprocess.run(["git", "update-ref", "--", upstream, old], cwd=repo, check=True)
+            branch = subprocess.run(
+                ["git", "symbolic-ref", "--short", "HEAD"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            subprocess.run(
+                ["git", "config", f"branch.{branch}.remote", "."],
+                cwd=repo,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "config", f"branch.{branch}.merge", upstream],
+                cwd=repo,
+                check=True,
+            )
+
+            previous = Path.cwd()
+            try:
+                os.chdir(repo)
+                actual = _commit_revs(argparse.Namespace(rev_range=None, all=False))
+            finally:
+                os.chdir(previous)
+
+        self.assertEqual(actual, [head])
 
     def test_history_revs_reports_process_failure_separately_from_invalid_range(self) -> None:
         import argparse


### PR DESCRIPTION
Closes #676.

## Summary

- reject option-shaped, empty, control-character, and oversized revision operands before Git
- preserve Git revision grammar, including omitted endpoints, caret-bang expressions, Unicode and punctuation-bearing refs, and commit-message searches
- resolve automatically derived upstreams to commit object IDs before building a range
- fail closed when a configured upstream exists but cannot resolve to a commit
- fail closed on repository-state errors while keeping genuine unborn repositories as zero-commit scans
- reject conflicting history-source flags and keep user-controlled Git diagnostics bounded

## Verification

- `./scripts/verify`
- 5,773 passed, 3 skipped, 68 subtests passed
- 83.05% coverage
