### PR TITLE
fix(handoff): report unscanned injection verdict for unreadable paths

### DIFF
--- a/src/brigade/handoff_cmd/linting.py
+++ b/src/brigade/handoff_cmd/linting.py
@@ -49,7 +49,9 @@ def _injection_verdict(hits: tuple[Any, ...]) -> str:
     return FAIL if any(hit.severity == "warning" for hit in hits) else OK
 
 
-def _injection_detail(*, warning_count: int) -> str:
+def _injection_detail(*, warning_count: int, unscanned: bool = False) -> str:
+    if unscanned:
+        return "unscanned"
     if warning_count:
         label = "warning" if warning_count == 1 else "warnings"
         return f"{warning_count} injection {label}"
@@ -83,11 +85,18 @@ def lint(
         for result in results:
             guard_item = _guard_handoff_path(result.path, target=target, policy=guard_policy)
             text = _read_handoff_text(result.path)
-            hits = scan_handoff_injection_heuristics(text or "") if text is not None else ()
-            guard_item["injection_heuristics"] = [_injection_hit_dict(hit) for hit in hits]
-            guard_item["injection_warning_count"] = len([hit for hit in hits if hit.severity == "warning"])
-            guard_item["egress_verdict"] = _egress_verdict(guard_item.get("exit_code"))
-            guard_item["injection_verdict"] = _injection_verdict(hits)
+            if text is None:
+                guard_item["injection_heuristics"] = []
+                guard_item["injection_warning_count"] = 0
+                guard_item["injection_unscanned"] = True
+                guard_item["egress_verdict"] = _egress_verdict(guard_item.get("exit_code"))
+                guard_item["injection_verdict"] = FAIL
+            else:
+                hits = scan_handoff_injection_heuristics(text)
+                guard_item["injection_heuristics"] = [_injection_hit_dict(hit) for hit in hits]
+                guard_item["injection_warning_count"] = len([hit for hit in hits if hit.severity == "warning"])
+                guard_item["egress_verdict"] = _egress_verdict(guard_item.get("exit_code"))
+                guard_item["injection_verdict"] = _injection_verdict(hits)
             guard_results.append(guard_item)
     guard_ok = all(item.get("egress_verdict") == OK and item.get("injection_verdict") == OK for item in guard_results)
     injection_counts: dict[str, int] = {}
@@ -168,9 +177,10 @@ def lint(
             print(f"[{egress_status}] content_guard egress: {item.get('path')} {item.get('detail')}")
             injection_status = item.get("injection_verdict", OK)
             warning_count = int(item.get("injection_warning_count") or 0)
+            unscanned = bool(item.get("injection_unscanned"))
             print(
                 f"[{injection_status}] content_guard injection: {item.get('path')} "
-                f"{_injection_detail(warning_count=warning_count)}"
+                f"{_injection_detail(warning_count=warning_count, unscanned=unscanned)}"
             )
             for hit in hits:
                 if hit.get("severity") == "info":

--- a/tests/test_handoff_injection_lint.py
+++ b/tests/test_handoff_injection_lint.py
@@ -133,7 +133,9 @@ def test_handoff_lint_content_guard_info_only_injection_does_not_fail(tmp_path, 
 
 
 def test_handoff_lint_content_guard_unreadable_path_not_clean_injection_verdict(
-    tmp_path, capsys, monkeypatch,
+    tmp_path,
+    capsys,
+    monkeypatch,
 ):
     unreadable = tmp_path / "not-a-handoff"
     unreadable.mkdir()

--- a/tests/test_handoff_injection_lint.py
+++ b/tests/test_handoff_injection_lint.py
@@ -132,6 +132,28 @@ def test_handoff_lint_content_guard_info_only_injection_does_not_fail(tmp_path, 
     assert any(hit["severity"] == "info" for hit in guard["injection_heuristics"])
 
 
+def test_handoff_lint_content_guard_unreadable_path_not_clean_injection_verdict(
+    tmp_path, capsys, monkeypatch,
+):
+    unreadable = tmp_path / "not-a-handoff"
+    unreadable.mkdir()
+
+    monkeypatch.setattr("brigade.scrub.run_scan", _clean_egress_scan)
+    assert handoff_cmd.lint(target=tmp_path, paths=[unreadable], content_guard=True, json_output=True) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["content_guard_injection"] == "fail"
+    guard = payload["content_guard"][0]
+    assert guard["injection_verdict"] == "fail"
+    assert guard["injection_warning_count"] == 0
+    assert not guard["injection_heuristics"]
+
+    handoff_cmd.lint(target=tmp_path, paths=[unreadable], content_guard=True)
+    out = capsys.readouterr().out
+    assert "cannot read handoff file" in out
+    assert "[fail] content_guard injection:" in out
+    assert "[ok] content_guard injection:" not in out
+
+
 def test_handoff_lint_content_guard_prints_injection_scope(tmp_path, capsys, monkeypatch):
     evil = FIXTURE_DIR / "evil-disregard-system.md"
     path = tmp_path / "evil.md"


### PR DESCRIPTION
## Problem

`brigade handoff lint --content-guard` reported a clean injection verdict for handoffs it had failed to read.

In `lint()`, when `_read_handoff_text()` returns `None` the heuristic scan was skipped and `hits` stayed empty, so `_injection_verdict(())` returned `OK`. Both the printed line and the `content_guard_injection` JSON field then claimed a clean result for a file that was never scanned.

## Reproduce

```
mkdir /tmp/probe
brigade handoff lint /tmp/probe --content-guard
```

```
[fail] /tmp/probe
  - cannot read handoff file: [Errno 21] Is a directory: '/tmp/probe'
[ok] content_guard injection: /tmp/probe clean      <-- unearned
```

## Fix

An unreadable path now yields a FAIL injection verdict rendered as `unscanned`:

```
[fail] content_guard injection: /tmp/probe unscanned
```

Readable handoffs are unchanged: a handoff carrying injected instructions still reports `[fail] content_guard injection: ... 5 injection warnings` with named heuristics and line numbers.

## Scope

The overall command already exited non-zero for this input, so a caller checking only the exit code was never misled. The defect is in the per-axis verdict and the JSON field, which a human reader or a machine consumer of `content_guard_injection` could reasonably trust.

## Verification

`.venv/bin/python -m pytest tests/test_handoff_injection_lint.py tests/test_handoff_cmd.py -q` passes (Brigade verify receipt `20260803-004556-work-verify-537c23`). Includes a regression test asserting an unreadable path does not produce a clean injection verdict.

## Provenance

Found while triaging a 2026-06-10 cold-start report that claimed `--content-guard` reports injection-laden handoffs as clean. That broader claim is **stale** - the reported case is fixed on main. This narrower unreadable-path case is the part that still reproduced.