### PR TITLE
fix(outcome): keep worker infrastructure failures outcome-neutral

### DIFF
--- a/src/brigade/friction_cmd.py
+++ b/src/brigade/friction_cmd.py
@@ -603,6 +603,7 @@ def _structured_candidate(
     detail: str,
     adapter: str | None = None,
     error_class: str | None = None,
+    cause_code: str | None = None,
 ) -> dict[str, Any]:
     try:
         source = str(path.resolve().relative_to(target))
@@ -627,6 +628,7 @@ def _structured_candidate(
         "workflow": _workflow_from_path(target, path),
         "adapter": adapter,
         "error_class": error_class,
+        "cause_code": cause_code,
         "operation": operation,
         "recurrence_key": recurrence_key,
         "evidence": {"path": source, "line": 1, "snippet": snippet},
@@ -689,6 +691,16 @@ def _structured_families(
             if not isinstance(result, dict) or result.get("ok") is True:
                 continue
             detail = str(result.get("detail") or "worker failed")
+            from .worker_failure import worker_result_failure
+
+            failure = worker_result_failure(result)
+            if failure is not None:
+                error_class = failure.failure_class.value
+                cause_code = failure.cause_code
+            else:
+                error_class = "timeout" if result.get("timed_out") else "adapter_error"
+                failure_kind = result.get("failure_kind")
+                cause_code = str(failure_kind) if failure_kind else None
             families["run"].append(
                 _structured_candidate(
                     target=target,
@@ -700,7 +712,8 @@ def _structured_families(
                     operation=f"run.worker.{result.get('worker') or 'unknown'}",
                     detail=detail,
                     adapter=str(result.get("transport") or "direct"),
-                    error_class="timeout" if result.get("timed_out") else "adapter_error",
+                    error_class=error_class,
+                    cause_code=cause_code,
                 )
             )
     eval_root = target / ".brigade" / "evals"

--- a/src/brigade/outcome.py
+++ b/src/brigade/outcome.py
@@ -129,6 +129,25 @@ def signal_value(source: str, status: str) -> int:
     return SIGNAL_RULES.get((source, status), 0)
 
 
+RUN_INFRASTRUCTURE_NEUTRAL_STATUSES = frozenset({"failed", "error", "incomplete"})
+
+
+def run_capture_signal_value(
+    status: str,
+    *,
+    infrastructure_only: bool,
+    verifier_failed: bool,
+) -> int:
+    """Return the run-receipt capture weight, neutralizing infrastructure-only failures."""
+    if status in ("dry-run", "read-only"):
+        return 0
+    if verifier_failed:
+        return -1
+    if infrastructure_only and status in RUN_INFRASTRUCTURE_NEUTRAL_STATUSES:
+        return 0
+    return signal_value("run", status)
+
+
 def scored_records(records: list[OutcomeRecord]) -> list[OutcomeRecord]:
     """Return the de-duplicated records that contribute to scoring.
 

--- a/src/brigade/outcome_cmd.py
+++ b/src/brigade/outcome_cmd.py
@@ -21,7 +21,7 @@ import time
 from pathlib import Path
 from typing import Any
 
-from . import localio, outcome as core, receipt_schema, scorecard as scorecard_mod
+from . import localio, outcome as core, receipt_schema, scorecard as scorecard_mod, verify_trial
 
 _LOCK_WAIT_SECONDS = 30.0
 _LOCK_SENTINEL_BYTE = b"\0"
@@ -1011,6 +1011,143 @@ def _run_receipt_signal_status(receipt: dict) -> str:
     return str(receipt.get("status") or "")
 
 
+def _load_worker_results(run_json: Path) -> list[dict[str, Any]]:
+    worker_results_path = run_json.parent / "worker-results.json"
+    if not worker_results_path.is_file():
+        return []
+    payload = localio.read_json_dict(worker_results_path)
+    if payload is None:
+        return []
+    results = payload.get("results")
+    if not isinstance(results, list):
+        return []
+    return [item for item in results if isinstance(item, dict)]
+
+
+def _worker_results_ground_truth(run_json: Path) -> dict[str, Any] | None:
+    worker_results_path = run_json.parent / "worker-results.json"
+    if not worker_results_path.is_file():
+        return None
+    payload = localio.read_json_dict(worker_results_path)
+    if payload is None:
+        return None
+    ground_truth = payload.get("ground_truth")
+    return ground_truth if isinstance(ground_truth, dict) else None
+
+
+def worker_result_failure(result: dict[str, Any]):
+    """Read-time worker failure attribution for a worker-results entry."""
+    from .worker_failure import worker_result_failure as _worker_result_failure
+
+    return _worker_result_failure(result)
+
+
+def _verify_summary_failed_verification(summary: dict[str, Any]) -> bool:
+    """Return True when a verify receipt blames the subject rather than the harness.
+
+    The failure-class vocabulary is owned by ``verify_trial``, which is what stamps
+    these receipts. Read it from there rather than matching literals, so adding a
+    class there cannot silently reclassify runs here.
+    """
+    failure_class = summary.get("failure_class")
+    if failure_class in verify_trial.VERIFY_SKILL_FAILURE_CLASSES:
+        return True
+    commands = summary.get("commands")
+    if isinstance(commands, list):
+        stamped = [command for command in commands if isinstance(command, dict) and command.get("failure_class")]
+        if any(command.get("failure_class") in verify_trial.VERIFY_SKILL_FAILURE_CLASSES for command in stamped):
+            return True
+        if stamped:
+            return False
+    status = str(summary.get("status") or "")
+    if status == "failed":
+        return failure_class not in verify_trial.VERIFY_INFRASTRUCTURE_FAILURE_CLASSES
+    return False
+
+
+def _resolve_verify_summary(target: Path, summary: dict[str, Any]) -> dict[str, Any]:
+    run_id = summary.get("run_id")
+    if not isinstance(run_id, str) or not run_id:
+        return summary
+    from .work_cmd import verification as verify_mod
+
+    receipt, error = verify_mod._resolve_verify_receipt(target, run_id)
+    if receipt is None:
+        return summary
+    return receipt
+
+
+def _run_has_verifier_failure(target: Path, run_json: Path, receipt: dict[str, Any]) -> bool:
+    ground_truth = _worker_results_ground_truth(run_json)
+    if ground_truth is not None and ("latest_verify" in ground_truth or "verify_receipts" in ground_truth):
+        # The run recorded which verifications belong to it. Trust that record and never
+        # fall back to the workspace-wide latest receipt, which may belong to a later,
+        # unrelated verification run.
+        latest_verify = ground_truth.get("latest_verify")
+        if isinstance(latest_verify, dict):
+            resolved = _resolve_verify_summary(target, latest_verify)
+            if _verify_summary_failed_verification(resolved):
+                return True
+        verify_receipts = ground_truth.get("verify_receipts")
+        if isinstance(verify_receipts, list):
+            for item in verify_receipts:
+                if isinstance(item, dict) and _verify_summary_failed_verification(
+                    _resolve_verify_summary(target, item)
+                ):
+                    return True
+        return False
+    started_at = receipt.get("started_at")
+    if not isinstance(started_at, str):
+        return False
+    from .work_cmd import verification as verify_mod
+
+    verify_receipt, error = verify_mod._resolve_verify_receipt(target, "latest")
+    if verify_receipt is None:
+        return False
+    verify_started = str(verify_receipt.get("started_at") or "")
+    if verify_started < started_at:
+        return False
+    return _verify_summary_failed_verification(verify_receipt)
+
+
+_RUN_INFRASTRUCTURE_FAILURE_KINDS = frozenset({"worker-failure", None})
+
+
+def _run_infrastructure_only(receipt: dict[str, Any], worker_results: list[dict[str, Any]]) -> bool:
+    status = _run_receipt_signal_status(receipt)
+    if status not in core.RUN_INFRASTRUCTURE_NEUTRAL_STATUSES:
+        return False
+    failure_kind = receipt.get("failure_kind")
+    if failure_kind not in _RUN_INFRASTRUCTURE_FAILURE_KINDS:
+        return False
+    failed_workers = [result for result in worker_results if result.get("ok") is False]
+    if not failed_workers:
+        return failure_kind == "worker-failure"
+    for result in failed_workers:
+        failure = worker_result_failure(result)
+        if failure is None:
+            return False
+        if failure.domain.value != "infrastructure":
+            return False
+    return True
+
+
+def _run_capture_signal_value(
+    target: Path,
+    run_json: Path,
+    receipt: dict[str, Any],
+    effective_status: str,
+) -> int:
+    worker_results = _load_worker_results(run_json)
+    infrastructure_only = _run_infrastructure_only(receipt, worker_results)
+    verifier_failed = _run_has_verifier_failure(target, run_json, receipt)
+    return core.run_capture_signal_value(
+        effective_status,
+        infrastructure_only=infrastructure_only,
+        verifier_failed=verifier_failed,
+    )
+
+
 def _decisions_dir(target: Path) -> Path:
     return target / "memory" / "outcome" / "decisions"
 
@@ -1609,6 +1746,7 @@ def capture(
     source = "verify"
     effective_status = ""
     evidence_ref = ""
+    signal: int | None = None
     ts = localio.utc_now_iso()
     code_graph_delta: dict[str, Any] | None = None
     context_eval: dict[str, Any] | None = None
@@ -1623,6 +1761,7 @@ def capture(
         source = "run"
         effective_status = _run_receipt_signal_status(receipt)
         evidence_ref = str(run_json)
+        signal = _run_capture_signal_value(target, run_json, receipt, effective_status)
         ts = str(receipt.get("completed_at") or receipt.get("started_at") or localio.utc_now_iso())
         code_graph_delta = _compact_code_graph_delta(receipt)
         context_eval = _compact_context_eval(receipt)
@@ -1641,14 +1780,17 @@ def capture(
         evidence_ref = verify_mod.canonical_verify_evidence_ref(target, receipt)
         ts = str(receipt.get("completed_at") or receipt.get("started_at") or localio.utc_now_iso())
         code_graph_delta = _compact_code_graph_delta(receipt)
+        signal = core.signal_value(source, effective_status)
     manifest = context_manifest(run_agent)
     route = route_manifest(route_run_payload, route_run_json)
+    if signal is None:
+        signal = core.signal_value(source, effective_status)
     record = core.OutcomeRecord(
         artifact_id=artifact_id,
         artifact_kind=artifact_kind,
         task_id=task_id or "",
         source=source,
-        signal_value=core.signal_value(source, effective_status),
+        signal_value=signal,
         evidence_ref=evidence_ref,
         ts=ts,
         code_graph_delta=code_graph_delta,

--- a/src/brigade/worker_failure.py
+++ b/src/brigade/worker_failure.py
@@ -299,6 +299,71 @@ class WorkerFailure:
         return payload
 
 
+def failure_from_payload(payload: dict[str, object]) -> WorkerFailure | None:
+    """Parse a serialized ``brigade.worker_failure.v1`` object without mutating it."""
+
+    if payload.get("schema") != SCHEMA:
+        return None
+    failure_class_raw = payload.get("class")
+    phase_raw = payload.get("phase")
+    retry_raw = payload.get("retry")
+    detected_by = payload.get("detected_by")
+    detail = payload.get("detail")
+    if not isinstance(failure_class_raw, str) or not isinstance(phase_raw, str) or not isinstance(retry_raw, str):
+        return None
+    if not isinstance(detected_by, str) or not isinstance(detail, str):
+        return None
+    try:
+        failure_class = FailureClass(failure_class_raw)
+        phase = FailurePhase(phase_raw)
+        retry = RetryDisposition(retry_raw)
+    except ValueError:
+        return None
+    domain_raw = payload.get("domain")
+    domain = FailureDomain.INFRASTRUCTURE
+    if isinstance(domain_raw, str):
+        try:
+            domain = FailureDomain(domain_raw)
+        except ValueError:
+            return None
+    cause_code = payload.get("cause_code")
+    attempt = payload.get("attempt")
+    return WorkerFailure(
+        failure_class=failure_class,
+        phase=phase,
+        retry=retry,
+        detected_by=detected_by,
+        detail=detail,
+        cause_code=cause_code if isinstance(cause_code, str) else None,
+        attempt=attempt if isinstance(attempt, int) and not isinstance(attempt, bool) else None,
+        domain=domain,
+    )
+
+
+def worker_result_failure(result: dict[str, object]) -> WorkerFailure | None:
+    """Return the normalized worker failure for a worker-results entry at read time."""
+
+    if result.get("ok") is True:
+        return None
+    failure_payload = result.get("failure")
+    if isinstance(failure_payload, dict) and failure_payload.get("schema") == SCHEMA:
+        # A structured payload is authoritative. Never fall back to the legacy mapping,
+        # which would relabel an unreadable or non-infrastructure domain as infrastructure.
+        return failure_from_payload(failure_payload)
+    failure_phase = result.get("failure_phase")
+    failure_kind = result.get("failure_kind")
+    detail = result.get("detail")
+    timed_out = result.get("timed_out")
+    status = result.get("status")
+    return normalized_failure(
+        failure_phase=failure_phase if isinstance(failure_phase, str) else None,
+        failure_kind=failure_kind if isinstance(failure_kind, str) else None,
+        detail=str(detail or ""),
+        timed_out=bool(timed_out),
+        status=str(status or ""),
+    )
+
+
 def normalized_failure(
     *,
     failure_phase: str | None,

--- a/tests/test_outcome_infrastructure_attribution.py
+++ b/tests/test_outcome_infrastructure_attribution.py
@@ -1,0 +1,377 @@
+"""Outcome and friction attribution for worker infrastructure failures (#580)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from brigade import friction_cmd, localio, outcome, outcome_cmd, verify_trial
+
+from tests.test_outcome_cmd import _write_run_receipt, _write_verify_receipt
+
+
+def _write_worker_results(
+    target: Path,
+    run_id: str,
+    *,
+    results: list[dict],
+    ground_truth: dict | None = None,
+) -> Path:
+    run_dir = target / ".brigade" / "runs" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    payload: dict = {"results": results}
+    if ground_truth is not None:
+        payload["ground_truth"] = ground_truth
+    path = run_dir / "worker-results.json"
+    localio.write_json(path, payload)
+    return path
+
+
+def _infra_worker(
+    *,
+    worker: str = "implementer",
+    failure_class: str = "transport-hang",
+    cause_code: str = "initialize-no-progress",
+    phase: str = "preflight",
+) -> dict:
+    if failure_class == "timeout":
+        phase = "dispatch"
+    return {
+        "worker": worker,
+        "task": "fixture task",
+        "ok": False,
+        "detail": "transport made no progress",
+        "transport": "app-server",
+        "failure": {
+            "schema": "brigade.worker_failure.v1",
+            "class": failure_class,
+            "domain": "infrastructure",
+            "phase": phase,
+            "retry": "fallback",
+            "detected_by": "fixture",
+            "detail": "transport made no progress",
+            "cause_code": cause_code,
+        },
+    }
+
+
+def test_infrastructure_only_failed_run_is_neutral_with_evidence_ref(tmp_path, capsys):
+    run_json = _write_run_receipt(tmp_path, run_id="infra-failed", status="failed")
+    _write_worker_results(tmp_path, "infra-failed", results=[_infra_worker()])
+
+    assert (
+        outcome_cmd.capture(target=tmp_path, artifact_id="skill-x", run_receipt="infra-failed", json_output=True) == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["record"]["signal_value"] == 0
+    assert payload["record"]["source"] == "run"
+    assert payload["record"]["evidence_ref"] == str(run_json)
+
+
+def test_infrastructure_only_incomplete_run_is_neutral_with_evidence_ref(tmp_path, capsys):
+    run_json = _write_run_receipt(tmp_path, run_id="infra-incomplete", status="incomplete")
+    _write_worker_results(tmp_path, "infra-incomplete", results=[_infra_worker(failure_class="timeout")])
+
+    assert (
+        outcome_cmd.capture(target=tmp_path, artifact_id="skill-x", run_receipt="infra-incomplete", json_output=True)
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["record"]["signal_value"] == 0
+    assert payload["record"]["evidence_ref"] == str(run_json)
+
+
+def test_verify_failure_remains_negative_with_verify_source(tmp_path, capsys):
+    _write_verify_receipt(tmp_path, run_id="verify-failed", status="failed")
+
+    assert outcome_cmd.capture(target=tmp_path, artifact_id="skill-x", run_id="verify-failed", json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["record"]["signal_value"] == -1
+    assert payload["record"]["source"] == "verify"
+
+
+def test_verify_success_remains_positive(tmp_path, capsys):
+    _write_verify_receipt(tmp_path, run_id="verify-ok", status="completed")
+
+    assert outcome_cmd.capture(target=tmp_path, artifact_id="skill-x", run_id="verify-ok", json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["record"]["signal_value"] == 1
+    assert payload["record"]["source"] == "verify"
+
+
+def test_mixed_infra_failure_without_completed_verifier_is_neutral(tmp_path, capsys):
+    run_json = _write_run_receipt(
+        tmp_path,
+        run_id="mixed-no-verify",
+        status="incomplete",
+        started_at="2026-06-20T00:00:00+00:00",
+    )
+    _write_worker_results(
+        tmp_path,
+        "mixed-no-verify",
+        results=[_infra_worker()],
+        ground_truth={"verify_receipts": [], "latest_verify": None},
+    )
+
+    assert (
+        outcome_cmd.capture(target=tmp_path, artifact_id="skill-x", run_receipt="mixed-no-verify", json_output=True)
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["record"]["signal_value"] == 0
+    assert payload["record"]["evidence_ref"] == str(run_json)
+
+
+def test_mixed_infra_failure_with_verifier_failure_remains_negative(tmp_path, capsys):
+    verify_path = _write_verify_receipt(
+        tmp_path,
+        run_id="verify-mixed-fail",
+        status="failed",
+        started_at="2026-06-20T01:00:00+00:00",
+    )
+    verify_payload = json.loads(verify_path.read_text())
+    from brigade.verify_trial import stamp_verify_receipt_failure_taxonomy
+
+    stamp_verify_receipt_failure_taxonomy(verify_payload)
+    localio.write_json(verify_path, verify_payload)
+
+    run_json = _write_run_receipt(
+        tmp_path,
+        run_id="mixed-verify-fail",
+        status="incomplete",
+        started_at="2026-06-20T00:00:00+00:00",
+    )
+    _write_worker_results(
+        tmp_path,
+        "mixed-verify-fail",
+        results=[_infra_worker()],
+        ground_truth={
+            "verify_receipts": [json.loads(verify_path.read_text())],
+            "latest_verify": {
+                "run_id": "verify-mixed-fail",
+                "status": "failed",
+                "failure_class": "verification",
+            },
+        },
+    )
+
+    assert (
+        outcome_cmd.capture(target=tmp_path, artifact_id="skill-x", run_receipt="mixed-verify-fail", json_output=True)
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["record"]["signal_value"] == -1
+    assert payload["record"]["evidence_ref"] == str(run_json)
+
+
+def test_successful_run_capture_unchanged(tmp_path, capsys):
+    run_json = _write_run_receipt(tmp_path, run_id="ok-run", status="ok")
+    _write_worker_results(
+        tmp_path,
+        "ok-run",
+        results=[{"worker": "implementer", "task": "fixture", "ok": True, "detail": "done", "text": "done"}],
+    )
+
+    assert outcome_cmd.capture(target=tmp_path, artifact_id="skill-x", run_receipt="ok-run", json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["record"]["signal_value"] == 1
+    assert payload["record"]["evidence_ref"] == str(run_json)
+
+
+def test_legacy_worker_result_maps_unknown_kind_at_read_time_without_mutation(tmp_path):
+    run_dir = tmp_path / ".brigade" / "runs" / "legacy"
+    run_dir.mkdir(parents=True)
+    fixture = {
+        "results": [
+            {
+                "worker": "implementer",
+                "ok": False,
+                "detail": "mystery adapter failure",
+                "failure_phase": "dispatch",
+                "failure_kind": "future-adapter-code",
+            }
+        ]
+    }
+    path = run_dir / "worker-results.json"
+    original_bytes = (json.dumps(fixture, indent=2) + "\n").encode()
+    path.write_bytes(original_bytes)
+
+    failure = outcome_cmd.worker_result_failure(fixture["results"][0])
+
+    assert failure is not None
+    assert failure.failure_class.value == "unclassified"
+    assert path.read_bytes() == original_bytes
+
+
+def test_run_capture_signal_value_unit_cases():
+    assert outcome.run_capture_signal_value("failed", infrastructure_only=True, verifier_failed=False) == 0
+    assert outcome.run_capture_signal_value("incomplete", infrastructure_only=True, verifier_failed=False) == 0
+    assert outcome.run_capture_signal_value("failed", infrastructure_only=True, verifier_failed=True) == -1
+    assert outcome.run_capture_signal_value("ok", infrastructure_only=False, verifier_failed=False) == 1
+    assert outcome.run_capture_signal_value("error", infrastructure_only=False, verifier_failed=False) == -1
+
+
+def test_friction_adapter_failure_uses_failure_class_and_cause_code(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        friction_cmd,
+        "_now",
+        lambda: datetime(2026, 6, 11, 12, 0, 0, tzinfo=timezone.utc),
+    )
+    run = tmp_path / ".brigade" / "runs" / "r-timeout"
+    run.mkdir(parents=True)
+    (run / "worker-results.json").write_text(
+        json.dumps(
+            {
+                "results": [
+                    {
+                        "worker": "composer",
+                        "ok": False,
+                        "detail": "deadline exceeded",
+                        "transport": "direct",
+                        "timed_out": True,
+                        "failure_phase": "dispatch",
+                        "failure_kind": "timeout",
+                        "failure": {
+                            "schema": "brigade.worker_failure.v1",
+                            "class": "timeout",
+                            "domain": "infrastructure",
+                            "phase": "dispatch",
+                            "retry": "fallback",
+                            "detected_by": "legacy-failure-kind",
+                            "detail": "deadline exceeded",
+                            "cause_code": "timeout",
+                        },
+                    }
+                ]
+            }
+        )
+    )
+    run2 = tmp_path / ".brigade" / "runs" / "r-adapter"
+    run2.mkdir(parents=True)
+    (run2 / "worker-results.json").write_text(
+        json.dumps(
+            {
+                "results": [
+                    {
+                        "worker": "composer",
+                        "ok": False,
+                        "detail": "decode failure",
+                        "transport": "cursor-acpx",
+                        "failure_phase": "dispatch",
+                        "failure_kind": "decode-failure",
+                        "failure": {
+                            "schema": "brigade.worker_failure.v1",
+                            "class": "transport-unavailable",
+                            "domain": "infrastructure",
+                            "phase": "dispatch",
+                            "retry": "same-seat-once",
+                            "detected_by": "legacy-failure-kind",
+                            "detail": "decode failure",
+                            "cause_code": "decode-failure",
+                        },
+                    }
+                ]
+            }
+        )
+    )
+
+    families = friction_cmd._structured_families(tmp_path, None, since=datetime(2026, 1, 1, tzinfo=timezone.utc))
+    run_candidates = families["run"]
+    by_class = {item["error_class"]: item for item in run_candidates}
+
+    assert by_class["timeout"]["cause_code"] == "timeout"
+    assert by_class["transport-unavailable"]["cause_code"] == "decode-failure"
+
+
+def test_infra_run_ignores_unrelated_later_verify_receipt(tmp_path, capsys):
+    """Ground truth saying "no verification" must not be overridden by a later verify run."""
+
+    run_json = _write_run_receipt(
+        tmp_path,
+        run_id="infra-no-verify",
+        status="failed",
+        started_at="2026-06-20T00:00:00+00:00",
+    )
+    _write_worker_results(
+        tmp_path,
+        "infra-no-verify",
+        results=[_infra_worker()],
+        ground_truth={"verify_receipts": [], "latest_verify": None},
+    )
+    verify_path = _write_verify_receipt(
+        tmp_path,
+        run_id="verify-later-unrelated",
+        status="failed",
+        started_at="2026-06-20T02:00:00+00:00",
+    )
+    verify_payload = json.loads(verify_path.read_text())
+    verify_payload["failure_class"] = "verification"
+    localio.write_json(verify_path, verify_payload)
+
+    assert (
+        outcome_cmd.capture(target=tmp_path, artifact_id="skill-x", run_receipt="infra-no-verify", json_output=True)
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["record"]["signal_value"] == 0
+    assert payload["record"]["evidence_ref"] == str(run_json)
+
+
+def test_non_infrastructure_domain_is_not_neutralized(tmp_path, capsys):
+    run_json = _write_run_receipt(tmp_path, run_id="product-failed", status="failed")
+    worker = _infra_worker()
+    worker["failure"]["domain"] = "product"
+    worker["failure_kind"] = "timeout"
+    worker["failure_phase"] = "dispatch"
+    _write_worker_results(tmp_path, "product-failed", results=[worker])
+
+    assert (
+        outcome_cmd.capture(target=tmp_path, artifact_id="skill-x", run_receipt="product-failed", json_output=True) == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["record"]["signal_value"] == -1
+    assert payload["record"]["evidence_ref"] == str(run_json)
+
+
+def test_verify_summary_with_empty_commands_falls_back_to_status():
+    assert outcome_cmd._verify_summary_failed_verification({"status": "failed", "commands": []}) is True
+    assert (
+        outcome_cmd._verify_summary_failed_verification(
+            {"status": "failed", "failure_class": "infrastructure", "commands": []}
+        )
+        is False
+    )
+    assert (
+        outcome_cmd._verify_summary_failed_verification(
+            {"status": "failed", "commands": [{"failure_class": "infrastructure"}]}
+        )
+        is False
+    )
+
+
+def test_verify_failure_classes_are_read_from_verify_trial(monkeypatch):
+    """The vocabulary must come from verify_trial, not from literals copied into outcome_cmd.
+
+    verify_trial stamps these receipts, so it owns the class names. If a future class is
+    added there and this module still matches "verification"/"infrastructure" literally,
+    runs get silently misclassified. Extending the frozensets must change behaviour here.
+    """
+    monkeypatch.setattr(verify_trial, "VERIFY_SKILL_FAILURE_CLASSES", frozenset({"assertion"}))
+    monkeypatch.setattr(verify_trial, "VERIFY_INFRASTRUCTURE_FAILURE_CLASSES", frozenset({"harness"}))
+
+    # A class that is only "skill-blaming" under the patched vocabulary.
+    assert outcome_cmd._verify_summary_failed_verification({"failure_class": "assertion"}) is True
+    # The real literal is no longer a skill class, so it must stop counting as one.
+    assert outcome_cmd._verify_summary_failed_verification({"failure_class": "verification"}) is False
+    # The status fallback must consult the patched infrastructure set.
+    assert outcome_cmd._verify_summary_failed_verification({"status": "failed", "failure_class": "harness"}) is False


### PR DESCRIPTION
Closes #580. Parent #474. Design: `docs/proposals/2026-07-26-seat-health-probe-and-worker-failure-taxonomy.md`.

## What changed

An infrastructure-only failed or incomplete run captures as a **neutral** signal instead of counting against the artifact, while keeping its `evidence_ref`. A verifier failure stays negative and a verifier success stays positive, so a run that genuinely failed its checks is unaffected.

Friction records read the normalized `failure.class` as `error_class` and retain the adapter's original code as an optional `cause_code`.

Legacy receipts map at read time, unknown kinds becoming `unclassified`. No historical receipt is rewritten.

## Acceptance criteria

- [x] Friction records use `failure.class` as `error_class` and retain an optional adapter `cause_code`.
- [x] An infrastructure-only failed or incomplete run produces neutral artifact evidence while retaining its evidence reference.
- [x] A #500 verifier failure remains negative evidence and verifier success remains positive.
- [x] A mixed run with infrastructure failure and no completed verifier is neutral.
- [x] Legacy receipt fixtures map at read time, with unknown values becoming `unclassified`; no historical receipt is rewritten.
- [x] Tests cover infrastructure, verifier, mixed, successful, and legacy cases.
- [x] `./scripts/verify` passes through `brigade work verify run`.

## Two deliberate decisions

**The friction `recurrence_key` tuple is unchanged.** Recurrence groups on the stable taxonomy class, so the same class arriving under different adapter codes still collapses to one finding. `cause_code` is diagnostic metadata, emitted in the candidate dict but excluded from dedup.

**The verify failure-class vocabulary is read from `verify_trial`**, not matched as string literals. `verify_trial` is the module that stamps these receipts, so it owns `VERIFY_SKILL_FAILURE_CLASSES` and `VERIFY_INFRASTRUCTURE_FAILURE_CLASSES`. Copying `"verification"` / `"infrastructure"` into `outcome_cmd` would mean a class added there silently reclassifies runs here. `test_verify_failure_classes_are_read_from_verify_trial` pins this by patching the frozensets and asserting behaviour follows.

## Known gap, deliberately out of scope

This issue is scoped to **worker** infrastructure failures. A run whose failure is **run-owned** is not neutralized, and it should be tracked with #579.

Measured on 351 real run receipts in this workspace (56 failed):

| field | observation |
| --- | --- |
| top-level `failure_kind` | absent on **40 of 56** failed runs; only **1 run ever** carried `worker-failure` |
| nested `failure.kind` | carries the real taxonomy: `agent-error` (16), `orchestrator-error` (5), `unexpected-error` (5), `provider-error` (2), `transport-error`, `owner-process-exited`, `branch-head-drift` |

`_run_infrastructure_only` reads only the top-level field. A concrete case surfaced while building this PR: brigade run `run-580` failed with `failure.kind = branch-head-drift`, `failure.phase = run-isolation`, and **both workers succeeded**. That is an infrastructure-only failure by any reading, and it still scores `-1`:

```
run status            : failed
top-level failure_kind: None
nested failure.kind   : 'branch-head-drift'
workers               : [('composer', True), ('grok', True)]
infrastructure_only   : False
RESULTING SIGNAL      : -1
```

Widening this to run-owned failures needs the run-level taxonomy that #579 introduces (`ISOLATION_BREACH` is exactly this case), so it is not folded in here rather than expanding #580's scope silently.

## Verification

`./scripts/verify` through `brigade work verify run`, receipt `20260803-020056-work-verify-31a157`, exit 0:

```
5860 passed, 3 skipped, 68 subtests passed in 717.72s (0:11:57)
Required test coverage of 78% reached. Total coverage: 83.10%
```

Run against this branch's source, confirmed by `IMPORTING: /tmp/w580/src/brigade/__init__.py`, not the editable install of the main clone.

## Provenance

Implemented by a Cursor composer-2.5 seat via `brigade run`, independently reviewed by a grok-4.5 seat in the same run, which returned FAIL on two criteria and drove a revision pass. The taxonomy-reuse change and the run-owned gap above were found in review afterwards.
