### PR TITLE
feat(run): probe seat health after the initial run receipt, before planning

### DIFF
--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -34,6 +34,7 @@ from . import run_journal
 from . import run_lifecycle
 from . import run_projector
 from . import run_shadow
+from . import seat_health
 from .result_integrity import validate_final_output
 from .run_receipts import (
     agent_result_from_worker as _agent_result_from_worker,
@@ -2998,6 +2999,37 @@ def _terminalize_run_lifecycle(function: Callable[..., int]) -> Callable[..., in
     return wrapped
 
 
+def _write_run_seat_health_receipt(
+    output_dir: Path,
+    roster: Roster,
+    *,
+    cwd: Path | None = None,
+    probe: seat_health.SeatHealthProbe | None = None,
+) -> None:
+    """Probe declared seats and write seat-health.json beside run.json.
+
+    Observation only: the run receipt is already on disk when this runs, and
+    nothing here changes seat selection or aborts the run.  A probe that raises
+    is receipted as a failed seat instead of propagating, so probe trouble can
+    never take down a run that has already been receipted.  ``allow_model_smoke``
+    stays off: paying for a model call per seat on every run is a routing
+    decision that does not belong to admission.
+    """
+    active_probe = probe or seat_health.SeatHealthProbe(collect_executable_version=False)
+    try:
+        results = active_probe.probe_roster(roster, workspace=cwd, allow_model_smoke=False)
+    except Exception as exc:
+        results = seat_health.exception_results_for_probe_failure(roster, exc)
+    try:
+        seat_health.write_seat_health_receipt(
+            output_dir / "seat-health.json",
+            results,
+            run_id=output_dir.name,
+        )
+    except OSError as exc:
+        print(f"error: seat health receipt failed: {exc}", file=sys.stderr)
+
+
 @_terminalize_run_lifecycle
 def run(
     task: str,
@@ -3234,6 +3266,8 @@ def run(
                 worker=worker,
             ),
         )
+        # After the initial run receipt, before planning: a probe failure stays receipted.
+        _write_run_seat_health_receipt(output_dir, roster, cwd=cwd)
 
     if cwd is not None and route is not None and route.attached:
         from .route_policy import decide_route_skills, route_policy_extensions_from_decision

--- a/src/brigade/seat_health.py
+++ b/src/brigade/seat_health.py
@@ -657,6 +657,19 @@ def _seat_chain_names(roster: Any) -> tuple[str, ...]:
     return tuple(names)
 
 
+def exception_results_for_probe_failure(roster: Any, exc: Exception) -> tuple[SeatHealthResult, ...]:
+    """Return one failed result per declared seat when the probe itself blew up.
+
+    ``probe_roster`` normally covers the whole seat chain, so a caller that recorded
+    only the orchestrator would leave every other seat with no row at all. A reader
+    cannot tell a missing row from a healthy one, so cover the same chain here and
+    mark each seat failed with the probe's own cause.
+    """
+    now = time.monotonic()
+    wall_now = time.time()
+    return tuple(_exception_result(name, roster, now, wall_now, exc) for name in _seat_chain_names(roster))
+
+
 def _exception_result(name: str, roster: Any, now: float, wall_now: float, exc: Exception) -> SeatHealthResult:
     seat = roster.agents[name]
     check = SeatHealthCheck("declaration", "failed", safe_detail(str(exc)), cause_code="probe-exception")

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -4304,6 +4304,7 @@ def test_appserver_error_fallback_closes_partially_started_candidate(monkeypatch
 
     class FailingAppServer:
         def __init__(self, *, cwd):
+            self.cwd = cwd
             self.closed = 0
             instances.append(self)
 
@@ -4331,7 +4332,12 @@ def test_appserver_error_fallback_closes_partially_started_candidate(monkeypatch
         )
         == 0
     )
-    assert instances[0].closed == 1
+    # The seat-health probe (#578 slice A) also builds an AppServer, against its own
+    # throwaway repo rather than the caller's tree, so select this run's candidate by
+    # cwd instead of construction order.
+    run_candidates = [instance for instance in instances if instance.cwd == tmp_path]
+    assert len(run_candidates) == 1
+    assert run_candidates[0].closed == 1
 
 
 def test_control_error_closes_partial_server_and_preserves_warning_fallback(monkeypatch, tmp_path, capsys):

--- a/tests/test_aboyeur_seat_health_probe.py
+++ b/tests/test_aboyeur_seat_health_probe.py
@@ -1,0 +1,137 @@
+import json
+
+from brigade import aboyeur
+from brigade import agents
+from brigade.roster import Agent, Roster
+from brigade.seat_health import SeatHealthCheck, SeatHealthProbe
+from tests.run_test_helpers import run_aboyeur_guarded
+
+
+class FakeAdapter:
+    def __init__(self, *, on_check=None):
+        self.on_check = on_check
+
+    def check(self, name, *, seat, roster, workspace, timeout_seconds):
+        if self.on_check is not None:
+            self.on_check(name, seat=seat, roster=roster, workspace=workspace)
+        return SeatHealthCheck(name, "passed", "ok")
+
+
+class RaisingProbe:
+    def probe_roster(self, *args, **kwargs):
+        raise RuntimeError("probe failed")
+
+
+def _roster():
+    return Roster(
+        orchestrator="chef",
+        agents={
+            "chef": Agent("chef", "codex", "plan and synthesize"),
+            "coder": Agent("coder", "codex", "write code"),
+        },
+        max_workers=1,
+    )
+
+
+def _stub_run_phases(monkeypatch):
+    monkeypatch.setattr(
+        aboyeur,
+        "plan",
+        lambda *args, **kwargs: [aboyeur.Assignment(worker="coder", task="implement")],
+    )
+    monkeypatch.setattr(
+        aboyeur,
+        "dispatch",
+        lambda *args, **kwargs: [aboyeur.WorkerResult(worker="coder", task="implement", text="done", ok=True)],
+    )
+    monkeypatch.setattr(
+        aboyeur,
+        "_run_orchestrator",
+        lambda *args, **kwargs: agents.AgentResult(text="final answer", ok=True),
+    )
+
+
+def test_run_writes_seat_health_receipt(monkeypatch, tmp_path):
+    _stub_run_phases(monkeypatch)
+    output_dir = tmp_path / "run-abc"
+    monkeypatch.setattr(
+        aboyeur.seat_health,
+        "SeatHealthProbe",
+        lambda **kwargs: SeatHealthProbe(adapter=FakeAdapter()),
+    )
+
+    assert (
+        run_aboyeur_guarded(
+            "build feature",
+            _roster(),
+            output_dir=output_dir,
+            code_graph_enabled=False,
+            route_enabled=False,
+        )
+        == 0
+    )
+
+    receipt = json.loads((output_dir / "seat-health.json").read_text())
+    assert receipt["schema"] == "brigade.seat_health.v1"
+    assert receipt["run_id"] == "run-abc"
+    assert receipt["results"]
+
+
+def test_probe_failure_still_receipts_without_crashing(monkeypatch, tmp_path):
+    _stub_run_phases(monkeypatch)
+    output_dir = tmp_path / "run-fail"
+    monkeypatch.setattr(aboyeur.seat_health, "SeatHealthProbe", lambda **kwargs: RaisingProbe())
+
+    assert (
+        run_aboyeur_guarded(
+            "build feature",
+            _roster(),
+            output_dir=output_dir,
+            code_graph_enabled=False,
+            route_enabled=False,
+        )
+        == 0
+    )
+
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "ok"
+    receipt = json.loads((output_dir / "seat-health.json").read_text())
+    assert receipt["run_id"] == "run-fail"
+    # Every declared seat must appear. A reader cannot distinguish a missing row from a
+    # healthy one, so a blown-up probe records the whole chain rather than one seat.
+    assert {result["seat"] for result in receipt["results"]} == {"chef", "coder"}
+    assert all(result["status"] == "unhealthy" for result in receipt["results"])
+    assert all(result["checks"][0]["cause_code"] == "probe-exception" for result in receipt["results"])
+
+
+def test_seat_health_probe_runs_after_started_run_json(monkeypatch, tmp_path):
+    _stub_run_phases(monkeypatch)
+    output_dir = tmp_path / "run-order"
+    observed = []
+
+    def on_check(name, *, seat, roster, workspace):
+        run_path = output_dir / "run.json"
+        observed.append(run_path.is_file())
+        if run_path.is_file():
+            observed.append(json.loads(run_path.read_text())["status"])
+
+    monkeypatch.setattr(
+        aboyeur.seat_health,
+        "SeatHealthProbe",
+        lambda **kwargs: SeatHealthProbe(adapter=FakeAdapter(on_check=on_check)),
+    )
+
+    assert (
+        run_aboyeur_guarded(
+            "build feature",
+            _roster(),
+            output_dir=output_dir,
+            code_graph_enabled=False,
+            route_enabled=False,
+        )
+        == 0
+    )
+
+    assert observed
+    assert all(flag is True for flag in observed if isinstance(flag, bool))
+    assert "started" in observed

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -1954,6 +1954,11 @@ codex_cloud.run_cloud_task = blocked_cloud
 import sys
 from brigade import aboyeur, acpx_adapter, agents, cli, codex_cloud, proc
 from brigade.proc import ExecutableIdentity
+# This test measures how fast the run reaches a blocked phase and then cancels it, on a
+# 5s deadline. The #578 slice A seat-health probe runs before that phase and does real
+# transport work, which pushes the phase past the deadline. Seat health is not under
+# test here, so neutralize it for this child process only.
+aboyeur._write_run_seat_health_receipt = lambda *args, **kwargs: None
 {setup}
 raise SystemExit(cli.main([
     "run", "blocked", "--cwd", {str(repo)!r},


### PR DESCRIPTION
**Part of #578.** Parent #474. This covers **one of the four** acceptance criteria on that issue, per the [four-part partition](https://github.com/escoffier-labs/brigade/issues/578#issuecomment-5161735988) posted there. It does **not** close #578.

The criterion implemented here:

> Write the initial run receipt, then probe before planning so probe failures remain receipted.

## What changed

`SeatHealthProbe` was finished in #577 but had exactly one consumer: doctor, at `roster_cmd.py:364`. There was no `seat_health` import in `aboyeur.py`. This wires it into run admission.

The probe runs after the initial `run.json` (`status="started"`) is on disk and before planning, so a probe that fails, hangs, or raises is still receipted rather than taking down a run that was already recorded. Results land in an additive `seat-health.json` beside `run.json`. `run.json` itself is unchanged.

Ordering, by line: initial `run.json` write at `aboyeur.py:3264` → probe at `3278` → `assignments = _call_with_process_registry(...)` at `3363`.

## Deliberately out of scope

Observation and receipting only. Seat selection, abort behaviour, and the roster handed to the planner are untouched. Routing on these results is slices B and C.

`allow_model_smoke` stays **off**. A model smoke prompt is a real model call per seat on every run; whether admission should pay that is a routing decision belonging to a later slice.

## What admission actually costs now

Worth stating precisely, because it changed two existing tests.

**No model calls.** `allow_model_smoke=False` means `_model_check` short-circuits at `seat_health.py:426` to `"model check is owned by roster doctor inventory"`. No provider inventory call, no smoke request, no model reachability traffic per seat.

**But transport liveness is not gated by that flag.** `_transport_check` takes no `allow_model_smoke` parameter (`seat_health.py:385-387`), and `_default_check` calls it without one (`:357`). For a codex seat on the `app-server` transport it creates a throwaway git repo and starts a real app-server (`:396-401`), deliberately pointed at its own temp repo rather than the caller's worktree. So on a **cache miss**, admission does start a subprocess for such a seat.

This is not theoretical: it is why `test_appserver_error_fallback_closes_partially_started_candidate` failed on this branch with `allow_model_smoke=False` already in place. That test asserts on an `AppServer` the probe now constructs first, and it could not fail if no extra server were built.

**What bounds it.** Seats are probed in parallel via `ThreadPoolExecutor(max_workers=len(names))` with a 30s per-seat cap (`PER_SEAT_TIMEOUT_SECONDS`) and a 35s overall cap, so wall time is roughly constant in roster size rather than linear. Results are cached by seat fingerprint for 5 minutes (`HEALTHY_CACHE_TTL_SECONDS`), and a cache hit retains every prior check except `isolation-compatibility`, which is recomputed (`:203-206`). So the app-server smoke runs on a cache miss, not on every run.

"Observation only" describes the *effect* on routing, which is genuinely unchanged, but it undersells the admission cost. The accurate summary is: no model traffic, one bounded and cached transport smoke per seat, and no change to seat selection.

Two pre-existing tests depended on nothing else constructing an `AppServer`. Both were updated narrowly, preserving their original intent, with no global or autouse stubbing:

- `test_appserver_error_fallback_closes_partially_started_candidate` asserted `instances[0].closed == 1`. The probe's `AppServer` is now constructed first. The test now selects this run's candidate **by `cwd`** rather than by construction order, which is a sharper assertion than before.
- `test_run_cli_cancels_blocked_phase_process_before_releasing_lock[acpx-preflight]` waits 5s for a run to reach a blocked phase. Probe latency pushed it past the deadline. Seat health is not under test there, so the probe is neutralized inside that one test's child script only.

An earlier attempt at this slice used `allow_model_smoke = not dry_run` and handled the resulting breakage by adding an **autouse** fixture to `tests/conftest.py` that monkeypatched `SeatHealthProbe` for every test module in the repo. Both were rejected: this patch mandates `False`, and `conftest.py` is untouched.

## Review

Independently reviewed by a grok-4.5 seat against the applied diff, verdict **PASS** on the acceptance criterion, with two findings, both addressed:

- **Important:** the raise path recorded only one seat, so on a 5-seat roster a reader could not distinguish "never probed" from "healthy". Fixed by a new public `seat_health.exception_results_for_probe_failure(roster, exc)` that covers the full chain via `_seat_chain_names`.
- **Minor:** `aboyeur` called the private `seat_health._exception_result`. The same public helper removes the boundary violation.

The reviewer also confirmed `_exception_result`'s monotonic/wall argument order is not swapped, that `except Exception` does not swallow `KeyboardInterrupt`/`SystemExit`, and that `test_probe_failure_still_receipts_without_crashing` genuinely fails if the guard is removed.

One reviewer observation left as-is: `test_seat_health_probe_runs_after_started_run_json` proves the probe runs while status is `started`, but `run_aboyeur_guarded` calls `record_run_start` first, so the test would still pass if the probe moved earlier within `run()`. The structural placement is pinned by the line numbers above; tightening the test further is not worth coupling it to internal write order.

## Verification

`./scripts/verify` through `brigade work verify run`, receipt `20260803-150527-work-verify-c296e4`, exit 0, `reused_from` **absent** (a real run, not a reused receipt):

```
5863 passed, 3 skipped, 68 subtests passed in 673.15s (0:11:13)
Required test coverage of 78% reached. Total coverage: 83.13%
```

Confirmed to have run against this branch's source, not the main clone's editable install: `IMPORTING: /tmp/w578a/src/brigade/__init__.py`.

## Provenance

Implemented by a Cursor composer-2.5 seat via `brigade run`. That run was reported as a timeout, but its `changes.patch` was complete and applied cleanly; the patch was salvaged rather than regenerated. Because the implementer timed out, the reviewer seat in that run was skipped with `prerequisite failed`, so review was dispatched separately against the applied diff.

