### PR TITLE
fix(outcome): read nested failure.kind so run-owned infrastructure failures go neutral

### DIFF
--- a/src/brigade/outcome_cmd.py
+++ b/src/brigade/outcome_cmd.py
@@ -1117,7 +1117,14 @@ def _run_infrastructure_only(receipt: dict[str, Any], worker_results: list[dict[
     status = _run_receipt_signal_status(receipt)
     if status not in core.RUN_INFRASTRUCTURE_NEUTRAL_STATUSES:
         return False
-    failure_kind = receipt.get("failure_kind")
+    from .worker_failure import resolve_run_failure_taxonomy, run_failure_is_infrastructure_at_read_time
+
+    failure_kind, failure_phase = resolve_run_failure_taxonomy(receipt)
+    run_level_infrastructure = run_failure_is_infrastructure_at_read_time(failure_kind, failure_phase)
+    if run_level_infrastructure is True:
+        return True
+    if run_level_infrastructure is False:
+        return False
     if failure_kind not in _RUN_INFRASTRUCTURE_FAILURE_KINDS:
         return False
     failed_workers = [result for result in worker_results if result.get("ok") is False]

--- a/src/brigade/worker_failure.py
+++ b/src/brigade/worker_failure.py
@@ -242,6 +242,45 @@ _RUN_OWNED_FAILURE_KINDS = frozenset(
         "worker-failure",
     }
 )
+
+# Run-receipt failure taxonomy for outcome capture (#683). Read-time only; never mutate receipts.
+RUN_UNAMBIGUOUS_INFRASTRUCTURE_FAILURE_KINDS = frozenset(
+    {
+        "branch-head-drift",
+        "owner-process-exited",
+        "transport-error",
+        "provider-error",
+        "unsupported-sandbox",
+    }
+)
+RUN_MODEL_CONTRACT_FAILURE_KINDS = frozenset(
+    {
+        "invalid-plan",
+        "non-final-output",
+    }
+)
+RUN_CATCH_ALL_FAILURE_KINDS = frozenset(
+    {
+        "agent-error",
+        "orchestrator-error",
+        "unexpected-error",
+    }
+)
+RUN_INFRASTRUCTURE_FAILURE_PHASES = frozenset(
+    {
+        "startup",
+        "run-isolation",
+        "stale-lock-recovery",
+        "dispatch",
+    }
+)
+RUN_MODEL_FAILURE_PHASES = frozenset(
+    {
+        "planning",
+        "inference",
+        "output-validation",
+    }
+)
 _URL_CREDENTIALS = re.compile(r"(?P<scheme>https?://)[^/@\s:]+:[^/@\s]+@", re.IGNORECASE)
 _URL_QUERY = re.compile(r"(?P<url>https?://[^\s?#]+)(?:\?[^\s#]*)?(?:#[^\s]*)?", re.IGNORECASE)
 _SECRET_ASSIGNMENT = re.compile(
@@ -396,3 +435,60 @@ def normalized_failure(
         cause_code=normalized_kind,
         attempt=attempt,
     )
+
+
+def _normalize_receipt_field(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    return normalized or None
+
+
+def resolve_run_failure_taxonomy(receipt: dict[str, object]) -> tuple[str | None, str | None]:
+    """Read nested run failure kind/phase with fallback to legacy top-level fields."""
+
+    failure = receipt.get("failure")
+    if isinstance(failure, dict):
+        nested_kind = _normalize_receipt_field(failure.get("kind"))
+        if nested_kind is not None:
+            # Resolve kind and phase as a unit. Falling back field-by-field could pair a
+            # legacy top-level kind with a nested phase, and the catch-all rule gates one
+            # on the other, so a mixed read can flip the verdict.
+            return nested_kind, _normalize_receipt_field(failure.get("phase"))
+
+    return (
+        _normalize_receipt_field(receipt.get("failure_kind")),
+        _normalize_receipt_field(receipt.get("failure_phase")),
+    )
+
+
+def _is_run_catch_all_failure_kind(kind: str) -> bool:
+    if kind in RUN_CATCH_ALL_FAILURE_KINDS:
+        return True
+    if kind not in _RUN_OWNED_FAILURE_KINDS:
+        return False
+    return (
+        kind not in RUN_UNAMBIGUOUS_INFRASTRUCTURE_FAILURE_KINDS
+        and kind not in RUN_MODEL_CONTRACT_FAILURE_KINDS
+        and kind != "worker-failure"
+    )
+
+
+def run_failure_is_infrastructure_at_read_time(kind: str | None, phase: str | None) -> bool | None:
+    """Return whether a run-owned failure is infrastructure-neutral at read time.
+
+    ``True`` and ``False`` are definitive. ``None`` means defer to the legacy
+    worker-failure / missing-kind path in outcome capture.
+    """
+
+    if kind is None:
+        return None
+    if kind in RUN_MODEL_CONTRACT_FAILURE_KINDS:
+        return False
+    if kind in RUN_UNAMBIGUOUS_INFRASTRUCTURE_FAILURE_KINDS:
+        return True
+    if kind == "worker-failure":
+        return None
+    if _is_run_catch_all_failure_kind(kind):
+        return phase in RUN_INFRASTRUCTURE_FAILURE_PHASES
+    return False

--- a/tests/test_outcome_infrastructure_attribution.py
+++ b/tests/test_outcome_infrastructure_attribution.py
@@ -6,9 +6,69 @@ import json
 from datetime import datetime, timezone
 from pathlib import Path
 
-from brigade import friction_cmd, localio, outcome, outcome_cmd, verify_trial
+import pytest
+
+from brigade import friction_cmd, localio, outcome, outcome_cmd, verify_trial, worker_failure
 
 from tests.test_outcome_cmd import _write_run_receipt, _write_verify_receipt
+
+
+def _write_run_receipt_with_failure(
+    target: Path,
+    run_id: str,
+    *,
+    status: str = "failed",
+    failure_kind: str | None = None,
+    failure_phase: str | None = None,
+    failure: dict | None = None,
+    started_at: str = "2026-06-20T00:00:00+00:00",
+) -> Path:
+    run_dir = target / ".brigade" / "runs" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    receipt: dict = {
+        "task": "fixture task",
+        "cwd": str(target),
+        "status": status,
+        "dry_run": False,
+        "read_only": False,
+        "started_at": started_at,
+        "completed_at": started_at,
+        "artifacts": str(run_dir),
+    }
+    if failure_kind is not None:
+        receipt["failure_kind"] = failure_kind
+    if failure_phase is not None:
+        receipt["failure_phase"] = failure_phase
+    if failure is not None:
+        receipt["failure"] = failure
+    path = run_dir / "run.json"
+    localio.write_json(path, receipt)
+    return path
+
+
+def _ok_worker(*, worker: str = "implementer") -> dict:
+    return {
+        "worker": worker,
+        "task": "fixture task",
+        "ok": True,
+        "detail": "done",
+        "text": "done",
+    }
+
+
+def _capture_signal(tmp_path, run_id: str) -> tuple[int, dict]:
+    import io
+    import sys
+
+    buffer = io.StringIO()
+    old_stdout = sys.stdout
+    sys.stdout = buffer
+    try:
+        rc = outcome_cmd.capture(target=tmp_path, artifact_id="skill-x", run_receipt=run_id, json_output=True)
+    finally:
+        sys.stdout = old_stdout
+    payload = json.loads(buffer.getvalue())
+    return rc, payload
 
 
 def _write_worker_results(
@@ -375,3 +435,237 @@ def test_verify_failure_classes_are_read_from_verify_trial(monkeypatch):
     assert outcome_cmd._verify_summary_failed_verification({"failure_class": "verification"}) is False
     # The status fallback must consult the patched infrastructure set.
     assert outcome_cmd._verify_summary_failed_verification({"status": "failed", "failure_class": "harness"}) is False
+
+
+def test_nested_only_infrastructure_kind_is_neutral_with_evidence_ref(tmp_path):
+    run_json = _write_run_receipt_with_failure(
+        tmp_path,
+        "nested-branch-drift",
+        status="failed",
+        failure={"kind": "branch-head-drift", "phase": "run-isolation"},
+    )
+    _write_worker_results(tmp_path, "nested-branch-drift", results=[_ok_worker()])
+
+    rc, payload = _capture_signal(tmp_path, "nested-branch-drift")
+
+    assert rc == 0
+    assert payload["record"]["signal_value"] == 0
+    assert payload["record"]["evidence_ref"] == str(run_json)
+
+
+def test_legacy_top_level_failure_kind_fallback_still_works(tmp_path):
+    run_json = _write_run_receipt_with_failure(
+        tmp_path,
+        "legacy-worker-failure",
+        status="failed",
+        failure_kind="worker-failure",
+    )
+    _write_worker_results(tmp_path, "legacy-worker-failure", results=[_infra_worker()])
+
+    rc, payload = _capture_signal(tmp_path, "legacy-worker-failure")
+
+    assert rc == 0
+    assert payload["record"]["signal_value"] == 0
+    assert payload["record"]["evidence_ref"] == str(run_json)
+
+
+def test_legacy_top_level_only_infrastructure_kind_is_neutral(tmp_path):
+    # A receipt written before nested failure taxonomy existed: top-level kind only,
+    # no nested failure block. The fallback must still neutralize it.
+    run_json = _write_run_receipt_with_failure(
+        tmp_path,
+        "legacy-branch-drift",
+        status="failed",
+        failure_kind="branch-head-drift",
+    )
+    _write_worker_results(tmp_path, "legacy-branch-drift", results=[_ok_worker()])
+
+    rc, payload = _capture_signal(tmp_path, "legacy-branch-drift")
+
+    assert rc == 0
+    assert payload["record"]["signal_value"] == 0
+    assert payload["record"]["evidence_ref"] == str(run_json)
+
+
+def test_legacy_top_level_catch_all_uses_top_level_phase(tmp_path):
+    # Top-level kind + top-level phase, no nested block: catch-all in a model phase
+    # must stay negative rather than fall through to the legacy neutral path.
+    run_json = _write_run_receipt_with_failure(
+        tmp_path,
+        "legacy-agent-error-planning",
+        status="failed",
+        failure_kind="agent-error",
+        failure_phase="planning",
+    )
+    _write_worker_results(tmp_path, "legacy-agent-error-planning", results=[_ok_worker()])
+
+    rc, payload = _capture_signal(tmp_path, "legacy-agent-error-planning")
+
+    assert rc == 0
+    assert payload["record"]["signal_value"] == -1
+    assert payload["record"]["evidence_ref"] == str(run_json)
+
+
+def test_nested_failure_kind_wins_when_both_present(tmp_path):
+    run_json = _write_run_receipt_with_failure(
+        tmp_path,
+        "nested-wins",
+        status="failed",
+        failure_kind="orchestrator-error",
+        failure_phase="planning",
+        failure={"kind": "branch-head-drift", "phase": "run-isolation"},
+    )
+    _write_worker_results(tmp_path, "nested-wins", results=[_ok_worker()])
+
+    rc, payload = _capture_signal(tmp_path, "nested-wins")
+
+    assert rc == 0
+    assert payload["record"]["signal_value"] == 0
+    assert payload["record"]["evidence_ref"] == str(run_json)
+
+
+def test_catch_all_in_infrastructure_phase_is_neutral(tmp_path):
+    run_json = _write_run_receipt_with_failure(
+        tmp_path,
+        "agent-error-dispatch",
+        status="failed",
+        failure={"kind": "agent-error", "phase": "dispatch"},
+    )
+    _write_worker_results(tmp_path, "agent-error-dispatch", results=[_ok_worker()])
+
+    rc, payload = _capture_signal(tmp_path, "agent-error-dispatch")
+
+    assert rc == 0
+    assert payload["record"]["signal_value"] == 0
+    assert payload["record"]["evidence_ref"] == str(run_json)
+
+
+def test_catch_all_in_model_phase_stays_negative(tmp_path):
+    run_json = _write_run_receipt_with_failure(
+        tmp_path,
+        "orchestrator-planning",
+        status="failed",
+        failure={"kind": "orchestrator-error", "phase": "planning"},
+    )
+    _write_worker_results(tmp_path, "orchestrator-planning", results=[_ok_worker()])
+
+    rc, payload = _capture_signal(tmp_path, "orchestrator-planning")
+
+    assert rc == 0
+    assert payload["record"]["signal_value"] == -1
+    assert payload["record"]["evidence_ref"] == str(run_json)
+
+
+def test_catch_all_with_missing_phase_stays_negative(tmp_path):
+    run_json = _write_run_receipt_with_failure(
+        tmp_path,
+        "agent-error-no-phase",
+        status="failed",
+        failure={"kind": "agent-error"},
+    )
+    _write_worker_results(tmp_path, "agent-error-no-phase", results=[_ok_worker()])
+
+    rc, payload = _capture_signal(tmp_path, "agent-error-no-phase")
+
+    assert rc == 0
+    assert payload["record"]["signal_value"] == -1
+    assert payload["record"]["evidence_ref"] == str(run_json)
+
+
+def test_catch_all_with_unknown_phase_stays_negative(tmp_path):
+    run_json = _write_run_receipt_with_failure(
+        tmp_path,
+        "unexpected-unknown-phase",
+        status="failed",
+        failure={"kind": "unexpected-error", "phase": "artifact-collection"},
+    )
+    _write_worker_results(tmp_path, "unexpected-unknown-phase", results=[_ok_worker()])
+
+    rc, payload = _capture_signal(tmp_path, "unexpected-unknown-phase")
+
+    assert rc == 0
+    assert payload["record"]["signal_value"] == -1
+    assert payload["record"]["evidence_ref"] == str(run_json)
+
+
+@pytest.mark.parametrize(
+    ("kind", "phase"),
+    [
+        ("invalid-plan", "dispatch"),
+        ("non-final-output", "run-isolation"),
+    ],
+)
+def test_model_contract_failures_stay_negative_even_in_infrastructure_phase(tmp_path, kind, phase):
+    run_id = f"model-contract-{kind}"
+    run_json = _write_run_receipt_with_failure(
+        tmp_path,
+        run_id,
+        status="failed",
+        failure={"kind": kind, "phase": phase},
+    )
+    _write_worker_results(tmp_path, run_id, results=[_ok_worker()])
+
+    rc, payload = _capture_signal(tmp_path, run_id)
+
+    assert rc == 0
+    assert payload["record"]["signal_value"] == -1
+    assert payload["record"]["evidence_ref"] == str(run_json)
+
+
+def test_neither_failure_field_present_behavior_unchanged(tmp_path):
+    run_json = _write_run_receipt_with_failure(tmp_path, "no-failure-fields", status="failed")
+    _write_worker_results(tmp_path, "no-failure-fields", results=[_ok_worker()])
+
+    rc, payload = _capture_signal(tmp_path, "no-failure-fields")
+
+    assert rc == 0
+    assert payload["record"]["signal_value"] == -1
+    assert payload["record"]["evidence_ref"] == str(run_json)
+
+
+def test_run_580_regression_nested_branch_head_drift_all_workers_ok(tmp_path):
+    run_json = _write_run_receipt_with_failure(
+        tmp_path,
+        "run-580-regression",
+        status="failed",
+        failure={"kind": "branch-head-drift", "phase": "run-isolation"},
+    )
+    _write_worker_results(
+        tmp_path,
+        "run-580-regression",
+        results=[_ok_worker(worker="planner"), _ok_worker(worker="implementer")],
+    )
+
+    rc, payload = _capture_signal(tmp_path, "run-580-regression")
+
+    assert rc == 0
+    assert payload["record"]["signal_value"] == 0
+    assert payload["record"]["evidence_ref"] == str(run_json)
+
+
+def test_run_failure_phase_sets_are_disjoint():
+    """The two phase sets must not overlap, or the catch-all rule is ambiguous."""
+    assert not (worker_failure.RUN_INFRASTRUCTURE_FAILURE_PHASES & worker_failure.RUN_MODEL_FAILURE_PHASES)
+
+
+@pytest.mark.parametrize("phase", sorted(worker_failure.RUN_MODEL_FAILURE_PHASES))
+def test_catch_all_in_every_declared_model_phase_stays_negative(tmp_path, phase):
+    """Pins the enumerated policy: no model phase may neutralize a catch-all kind.
+
+    The rule is implemented as "not an infrastructure phase", so this locks the
+    declared model phases against someone later adding one to the infra set.
+    """
+    run_id = f"catch-all-{phase}"
+    run_json = _write_run_receipt_with_failure(
+        tmp_path,
+        run_id,
+        status="failed",
+        failure={"kind": "agent-error", "phase": phase},
+    )
+    _write_worker_results(tmp_path, run_id, results=[_ok_worker()])
+
+    rc, payload = _capture_signal(tmp_path, run_id)
+
+    assert rc == 0
+    assert payload["record"]["signal_value"] == -1
+    assert payload["record"]["evidence_ref"] == str(run_json)


### PR DESCRIPTION
Closes #683. 0.26.0 ship blocker.

## The bug

`_run_infrastructure_only` read only the **top-level** `failure_kind`. Run-owned failures record their taxonomy **nested** under `failure.kind` / `failure.phase`, so an infrastructure-only run still scored `-1` against the artifact, and #580 — the release's headline feature — mostly did not fire.

Measured across 351 real run receipts, 56 of them failed:

| shape | count |
| --- | --- |
| **only** nested `failure.kind` | **19** — invisible to the old code |
| both nested and top-level | 16 |
| neither | 21 — nothing to read either way |

That second row is why the legacy field is kept: 16 receipts still populate it, and dropping the fallback would regress them.

## Why kind alone is not enough

The two largest buckets are **catch-alls, not infrastructure evidence**:

- `agent-error` (16 occurrences) is the else-fallback at `aboyeur.py:3891`, used when a failed agent result carries no more specific `failure_kind`.
- `orchestrator-error` (5) is the else-branch at `aboyeur.py:3380`, used when the orchestrator's final attempt has no specific kind and is not a parse error.

Neutralizing those on kind alone would forgive genuine model failures — the same error #580 fixes, pointed the other way. `FailureDomain` also has exactly one member (`INFRASTRUCTURE`), so domain cannot answer the question for run-owned kinds.

`failure.phase` supplies the missing discriminator.

## Policy

| kind class | behaviour |
| --- | --- |
| Unambiguous infrastructure — `branch-head-drift`, `owner-process-exited`, `transport-error`, `provider-error`, `unsupported-sandbox` | neutral regardless of phase |
| Catch-all — `agent-error`, `orchestrator-error`, `unexpected-error`, other run-owned | neutral **only** in an infrastructure phase (`startup`, `run-isolation`, `stale-lock-recovery`, `dispatch`); negative in a model phase, and **negative when the phase is missing or unrecognized** |
| Model contract — `invalid-plan`, `non-final-output` | always negative, every phase |
| `worker-failure` | unchanged; defers to the existing per-worker check |
| neither field present | unchanged |

Fail-closed throughout: an unknown phase never neutralizes.

Read-time only. No receipt is rewritten, migrated, or mutated. Vocabularies live beside the existing sets in `worker_failure.py`, so `outcome_cmd` cannot drift from them.

## Kind and phase resolve as a unit

`resolve_run_failure_taxonomy` originally fell back field-by-field (`nested_kind or top_kind, nested_phase or top_phase`). That can pair a legacy top-level kind with a nested phase, and since the catch-all rule gates one on the other, a mixed read could flip the verdict. It now resolves both from the same source: nested when nested carries a kind, otherwise both from top-level.

## Tests

28 tests in `tests/test_outcome_infrastructure_attribution.py`, covering nested-only, legacy-top-level-only, both-present, neither-present, catch-all in infrastructure vs model vs unknown phase, model-contract kinds, and the `worker-failure` deferral.

Two lock the policy rather than a single case:

- `test_run_failure_phase_sets_are_disjoint` — the infrastructure and model phase sets must not overlap, or the catch-all rule is ambiguous.
- `test_catch_all_in_every_declared_model_phase_stays_negative` — parametrized over every declared model phase, so adding one to the infrastructure set breaks the build.

Plus a real regression fixture: a receipt shaped like the run-580 failure (`status: failed`, no top-level kind, `failure.kind: branch-head-drift`, `failure.phase: run-isolation`, **all workers `ok: true`**) now scores `0`.

## Review

Independently reviewed by a grok-4.5 seat: **"ship-ready for 0.26.0, no blockers."**

Two of its notes were acted on. It flagged that `RUN_MODEL_FAILURE_PHASES` was defined but unused — rather than delete it, the two tests above turn it into an enforced invariant. It also flagged the independent kind/phase fallback, fixed above.

One of its findings did not hold up on inspection: it reported that the legacy top-level-only fallback was not locked by a test. `test_legacy_top_level_only_infrastructure_kind_is_neutral` already covers exactly that case — top-level `branch-head-drift`, no nested block, all workers ok. It appears to have read the `worker-failure` test above it and missed the two below.

## Verification

`./scripts/verify` through `brigade work verify run`, receipt `20260803-170137-work-verify-9d020f`, exit 0, `reused_from` **absent**:

```
5880 passed, 3 skipped, 68 subtests passed in 707.53s (0:11:47)
Required test coverage of 78% reached. Total coverage: 83.13%
```

Confirmed against this branch's source: `IMPORTING: /tmp/w683/src/brigade/__init__.py`.
