### PR TITLE
feat(run): route the orchestrator seat from probe health before planning

### DIFF
--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -2999,26 +2999,123 @@ def _terminalize_run_lifecycle(function: Callable[..., int]) -> Callable[..., in
     return wrapped
 
 
+@dataclass(frozen=True)
+class OrchestratorHealthRoutingDecision:
+    roster: Roster
+    warning: str | None = None
+    abort_detail: str | None = None
+    abort_failure_phase: str = "preflight"
+    abort_failure_kind: str = "unclassified"
+    receipt: dict[str, object] | None = None
+
+
+def _seat_health_result_for(
+    results: tuple[seat_health.SeatHealthResult, ...] | None,
+    seat: str,
+) -> seat_health.SeatHealthResult | None:
+    if results is None:
+        return None
+    return next((result for result in results if result.seat == seat), None)
+
+
+def _seat_health_typed_cause(result: seat_health.SeatHealthResult) -> str:
+    if result.failure is not None:
+        return result.failure.failure_class.value
+    failed = next((check for check in result.checks if check.status == "failed"), None)
+    if failed is not None and failed.cause_code:
+        return failed.cause_code
+    return "unclassified"
+
+
+def resolve_orchestrator_health_routing(
+    roster: Roster,
+    results: tuple[seat_health.SeatHealthResult, ...] | None,
+) -> OrchestratorHealthRoutingDecision:
+    """Return the effective roster and any orchestrator fallback or abort action."""
+    orchestrator_result = _seat_health_result_for(results, roster.orchestrator)
+    if orchestrator_result is None or orchestrator_result.status != "unhealthy":
+        return OrchestratorHealthRoutingDecision(roster=roster)
+
+    requested = roster.orchestrator
+    typed_cause = _seat_health_typed_cause(orchestrator_result)
+    failure = orchestrator_result.failure
+    rejected: list[dict[str, str]] = []
+
+    for fallback_name in roster.agents[requested].fallback:
+        if fallback_name not in roster.agents:
+            continue
+        fallback_result = _seat_health_result_for(results, fallback_name)
+        if fallback_result is not None and fallback_result.status == "healthy":
+            return OrchestratorHealthRoutingDecision(
+                roster=replace(roster, orchestrator=fallback_name),
+                warning=(
+                    f"warning: orchestrator {requested} is unhealthy [{typed_cause}]; "
+                    f"using declared fallback {fallback_name}"
+                ),
+                receipt={
+                    "schema": "brigade.seat_routing.v1",
+                    "requested_orchestrator": requested,
+                    "effective_orchestrator": fallback_name,
+                    "outcome": "fallback",
+                    "typed_cause": typed_cause,
+                    "rejected_fallbacks": rejected,
+                },
+            )
+        status = fallback_result.status if fallback_result is not None else "missing"
+        cause = _seat_health_typed_cause(fallback_result) if fallback_result is not None else "missing"
+        rejected.append({"seat": fallback_name, "status": status, "cause": cause})
+
+    if rejected:
+        rejected_detail = "; rejected fallbacks: " + ", ".join(
+            f"{entry['seat']} ({entry['status']}[{entry['cause']}])" for entry in rejected
+        )
+    else:
+        rejected_detail = "; no declared fallbacks"
+    detail = f"orchestrator {requested} is unhealthy [{typed_cause}]{rejected_detail}"
+    return OrchestratorHealthRoutingDecision(
+        roster=roster,
+        abort_detail=detail,
+        abort_failure_phase=failure.phase.value if failure is not None else "preflight",
+        abort_failure_kind=failure.failure_class.value if failure is not None else "unclassified",
+        receipt={
+            "schema": "brigade.seat_routing.v1",
+            "requested_orchestrator": requested,
+            "effective_orchestrator": None,
+            "outcome": "abort",
+            "typed_cause": typed_cause,
+            "rejected_fallbacks": rejected,
+        },
+    )
+
+
+def _write_seat_routing_receipt(output_dir: Path, receipt: dict[str, object]) -> None:
+    try:
+        _write_json(output_dir / "seat-routing.json", receipt)
+    except OSError as exc:
+        print(f"error: seat routing receipt failed: {exc}", file=sys.stderr)
+
+
 def _write_run_seat_health_receipt(
     output_dir: Path,
     roster: Roster,
     *,
     cwd: Path | None = None,
     probe: seat_health.SeatHealthProbe | None = None,
-) -> None:
+) -> tuple[seat_health.SeatHealthResult, ...] | None:
     """Probe declared seats and write seat-health.json beside run.json.
 
-    Observation only: the run receipt is already on disk when this runs, and
-    nothing here changes seat selection or aborts the run.  A probe that raises
-    is receipted as a failed seat instead of propagating, so probe trouble can
-    never take down a run that has already been receipted.  ``allow_model_smoke``
-    stays off: paying for a model call per seat on every run is a routing
-    decision that does not belong to admission.
+    Returns probe results on success, including when the receipt write fails.
+    Returns ``None`` when the probe itself raised so routing treats the run as
+    observation-only.  ``allow_model_smoke`` stays off: paying for a model call
+    per seat on every run is a routing decision that does not belong to
+    admission.
     """
     active_probe = probe or seat_health.SeatHealthProbe(collect_executable_version=False)
+    probe_failed = False
     try:
         results = active_probe.probe_roster(roster, workspace=cwd, allow_model_smoke=False)
     except Exception as exc:
+        probe_failed = True
         results = seat_health.exception_results_for_probe_failure(roster, exc)
     try:
         seat_health.write_seat_health_receipt(
@@ -3028,6 +3125,9 @@ def _write_run_seat_health_receipt(
         )
     except OSError as exc:
         print(f"error: seat health receipt failed: {exc}", file=sys.stderr)
+    if probe_failed:
+        return None
+    return results
 
 
 @_terminalize_run_lifecycle
@@ -3267,7 +3367,26 @@ def run(
             ),
         )
         # After the initial run receipt, before planning: a probe failure stays receipted.
-        _write_run_seat_health_receipt(output_dir, roster, cwd=cwd)
+        health_results = _write_run_seat_health_receipt(output_dir, roster, cwd=cwd)
+        routing = resolve_orchestrator_health_routing(roster, health_results)
+        roster = routing.roster
+        if routing.warning is not None:
+            print(routing.warning, file=sys.stderr)
+        if routing.receipt is not None:
+            routing_receipt = dict(routing.receipt)
+            routing_receipt["run_id"] = output_dir.name
+            _write_seat_routing_receipt(output_dir, routing_receipt)
+        if routing.abort_detail is not None:
+            record_run_termination(
+                output_dir,
+                status="failed",
+                failure_phase=routing.abort_failure_phase,
+                failure_kind=routing.abort_failure_kind,
+                detail=routing.abort_detail,
+                seat=roster.orchestrator,
+            )
+            print(f"error: {routing.abort_detail}", file=sys.stderr)
+            return 2
 
     if cwd is not None and route is not None and route.attached:
         from .route_policy import decide_route_skills, route_policy_extensions_from_decision

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,44 @@ def _extras_enabled_for_suite(monkeypatch, request):
 
 
 @pytest.fixture(autouse=True)
+def _seat_health_probe_reports_healthy(monkeypatch, request):
+    """Report declared seats healthy so the bare-host baseline cannot abort runs.
+
+    ``_no_managed_tools_on_path`` deliberately pins the condition that no host
+    binary resolves, so under pytest every declared seat probes
+    ``executable-unavailable``.  Since #578 slice B an unhealthy orchestrator
+    with no healthy declared fallback aborts before planning, which is right in
+    production and, here, only a statement about the sandbox: these tests stub
+    ``agents.run_agent`` and never launch a CLI.  Left live, ~90 tests that
+    exercise ``run()`` fail on an abort unrelated to what they assert.
+
+    This hides one behaviour: ``run()`` rerouting or aborting on an unhealthy
+    orchestrator.  The modules below opt out and drive the probe themselves, so
+    that behaviour stays covered rather than stubbed away everywhere.
+    """
+    if request.module.__name__.rsplit(".", 1)[-1] in {
+        "test_seat_health",
+        "test_aboyeur_seat_health_probe",
+        "test_aboyeur_orchestrator_health_routing",
+    }:
+        return
+
+    from brigade import seat_health
+
+    real_probe = seat_health.SeatHealthProbe
+
+    class _HealthyAdapter:
+        def check(self, name, *, seat, roster, workspace, timeout_seconds):
+            return seat_health.SeatHealthCheck(name, "passed", "healthy under test")
+
+    monkeypatch.setattr(
+        seat_health,
+        "SeatHealthProbe",
+        lambda **kwargs: real_probe(adapter=_HealthyAdapter()),
+    )
+
+
+@pytest.fixture(autouse=True)
 def _isolate_hermes_home(tmp_path_factory, monkeypatch):
     """Point HERMES_HOME at a dedicated temp dir (outside the test's tmp_path so
     it never pollutes workspace assertions) so hermes-harness skill installs

--- a/tests/run_test_helpers.py
+++ b/tests/run_test_helpers.py
@@ -31,6 +31,30 @@ def _ignore_brigade_runtime(workspace: Path) -> None:
     exclude_path.write_text(f"{existing}{separator}{pattern}\n")
 
 
+# Pin seat health healthy inside a child script that must reach a later phase.
+#
+# A child process inherits none of tests/conftest.py, so the autouse
+# _seat_health_probe_reports_healthy fixture cannot reach it. What the child
+# does inherit is the bare-host condition: no seat CLI resolves on a clean
+# runner, so every declared seat probes executable-unavailable and #578 slice B
+# aborts the run before planning. A subprocess test that waits on a phase past
+# admission never sees it. Tests that only need the run to start, and care about
+# how fast it gets there, stub _write_run_seat_health_receipt instead.
+HEALTHY_SEAT_HEALTH_CHILD_SETUP = """
+from brigade import seat_health as _seat_health
+
+_real_seat_health_probe = _seat_health.SeatHealthProbe
+
+
+class _HealthySeatAdapter:
+    def check(self, name, *, seat, roster, workspace, timeout_seconds):
+        return _seat_health.SeatHealthCheck(name, "passed", "healthy under test")
+
+
+_seat_health.SeatHealthProbe = lambda **kwargs: _real_seat_health_probe(adapter=_HealthySeatAdapter())
+"""
+
+
 def run_aboyeur_guarded(*args: Any, **kwargs: Any) -> int:
     """Call ``aboyeur.run`` under the same run guard used by the CLI."""
     output_dir = kwargs.get("output_dir")

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -17,7 +17,7 @@ from brigade import evidence_brief
 from brigade import proc
 from brigade import runguard
 from brigade.roster import Agent, Roster
-from tests.run_test_helpers import run_aboyeur_guarded
+from tests.run_test_helpers import HEALTHY_SEAT_HEALTH_CHILD_SETUP, run_aboyeur_guarded
 from tests.work_cmd_test_helpers import _init_git_repo
 
 
@@ -2085,7 +2085,7 @@ import time
 from pathlib import Path
 from brigade import aboyeur, runguard
 from brigade.roster import Agent, Roster
-
+{HEALTHY_SEAT_HEALTH_CHILD_SETUP}
 run_dir = Path({str(output_dir)!r})
 workspace = run_dir.parent / "workspace"
 workspace.mkdir()
@@ -3834,7 +3834,7 @@ import time
 from pathlib import Path
 from brigade import aboyeur, agents, runguard
 from brigade.roster import Agent, Roster
-
+{HEALTHY_SEAT_HEALTH_CHILD_SETUP}
 run_dir = Path({str(output_dir)!r})
 workspace = run_dir.parent / "workspace"
 workspace.mkdir()

--- a/tests/test_aboyeur_orchestrator_health_routing.py
+++ b/tests/test_aboyeur_orchestrator_health_routing.py
@@ -1,0 +1,205 @@
+import json
+
+from brigade import aboyeur
+from brigade import agents
+from brigade.roster import Agent, Roster
+from brigade.seat_health import SeatHealthCheck, SeatHealthProbe
+from tests.run_test_helpers import run_aboyeur_guarded
+
+
+class PerSeatFakeAdapter:
+    """Return per-seat health by failing or degrading the first check only."""
+
+    def __init__(self, *, unhealthy: frozenset[str] = frozenset(), degraded: frozenset[str] = frozenset()):
+        self.unhealthy = unhealthy
+        self.degraded = degraded
+
+    def check(self, name, *, seat, roster, workspace, timeout_seconds):
+        if seat.name in self.unhealthy:
+            return SeatHealthCheck(name, "failed", "auth required", cause_code="auth-required")
+        if seat.name in self.degraded:
+            return SeatHealthCheck(name, "degraded", "auth status unavailable", cause_code="auth-status-unavailable")
+        return SeatHealthCheck(name, "passed", "ok")
+
+
+class RaisingProbe:
+    def probe_roster(self, *args, **kwargs):
+        raise RuntimeError("probe failed")
+
+
+def _roster(*, fallback: tuple[str, ...] = ()):
+    agents = {
+        "chef": Agent("chef", "codex", "plan and synthesize", fallback=fallback),
+        "chef-fallback": Agent("chef-fallback", "claude", "plan and synthesize"),
+        "coder": Agent("coder", "codex", "write code"),
+    }
+    return Roster(orchestrator="chef", agents=agents, max_workers=1)
+
+
+def _stub_run_phases(monkeypatch, *, plan_calls=None):
+    if plan_calls is None:
+        plan_calls = []
+
+    def capture_plan(task, roster, **kwargs):
+        plan_calls.append(roster)
+        return [aboyeur.Assignment(worker="coder", task="implement")]
+
+    monkeypatch.setattr(aboyeur, "plan", capture_plan)
+    monkeypatch.setattr(
+        aboyeur,
+        "dispatch",
+        lambda *args, **kwargs: [aboyeur.WorkerResult(worker="coder", task="implement", text="done", ok=True)],
+    )
+    monkeypatch.setattr(
+        aboyeur,
+        "_run_orchestrator",
+        lambda *args, **kwargs: agents.AgentResult(text="final answer", ok=True),
+    )
+    return plan_calls
+
+
+def _install_probe(monkeypatch, adapter: PerSeatFakeAdapter):
+    monkeypatch.setattr(
+        aboyeur.seat_health,
+        "SeatHealthProbe",
+        lambda **kwargs: SeatHealthProbe(adapter=adapter),
+    )
+
+
+def test_unhealthy_orchestrator_uses_healthy_declared_fallback(monkeypatch, tmp_path, capsys):
+    plan_calls = _stub_run_phases(monkeypatch)
+    output_dir = tmp_path / "run-fallback"
+    _install_probe(monkeypatch, PerSeatFakeAdapter(unhealthy=frozenset({"chef"})))
+
+    assert (
+        run_aboyeur_guarded(
+            "build feature",
+            _roster(fallback=("chef-fallback",)),
+            output_dir=output_dir,
+            code_graph_enabled=False,
+            route_enabled=False,
+        )
+        == 0
+    )
+
+    assert len(plan_calls) == 1
+    assert plan_calls[0].orchestrator == "chef-fallback"
+    stderr = capsys.readouterr().err
+    assert "warning: orchestrator chef is unhealthy [auth-required]; using declared fallback chef-fallback" in stderr
+
+    routing = json.loads((output_dir / "seat-routing.json").read_text())
+    assert routing["schema"] == "brigade.seat_routing.v1"
+    assert routing["run_id"] == "run-fallback"
+    assert routing["requested_orchestrator"] == "chef"
+    assert routing["effective_orchestrator"] == "chef-fallback"
+    assert routing["outcome"] == "fallback"
+    assert routing["typed_cause"] == "auth-required"
+
+
+def test_unhealthy_orchestrator_without_declared_fallback_aborts(monkeypatch, tmp_path, capsys):
+    plan_calls = _stub_run_phases(monkeypatch)
+    output_dir = tmp_path / "run-no-fallback"
+    _install_probe(monkeypatch, PerSeatFakeAdapter(unhealthy=frozenset({"chef"})))
+
+    assert (
+        run_aboyeur_guarded(
+            "build feature",
+            _roster(),
+            output_dir=output_dir,
+            code_graph_enabled=False,
+            route_enabled=False,
+        )
+        == 2
+    )
+
+    assert plan_calls == []
+    stderr = capsys.readouterr().err
+    assert "error: orchestrator chef is unhealthy [auth-required]" in stderr
+
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "failed"
+    assert run_meta["failure"]["kind"] == "auth-required"
+
+    routing = json.loads((output_dir / "seat-routing.json").read_text())
+    assert routing["outcome"] == "abort"
+    assert routing["effective_orchestrator"] is None
+
+
+def test_unhealthy_orchestrator_with_unhealthy_declared_fallback_aborts(monkeypatch, tmp_path, capsys):
+    plan_calls = _stub_run_phases(monkeypatch)
+    output_dir = tmp_path / "run-bad-fallback"
+    _install_probe(monkeypatch, PerSeatFakeAdapter(unhealthy=frozenset({"chef", "chef-fallback"})))
+
+    assert (
+        run_aboyeur_guarded(
+            "build feature",
+            _roster(fallback=("chef-fallback",)),
+            output_dir=output_dir,
+            code_graph_enabled=False,
+            route_enabled=False,
+        )
+        == 2
+    )
+
+    assert plan_calls == []
+    stderr = capsys.readouterr().err
+    assert "chef-fallback (unhealthy[auth-required])" in stderr
+
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "failed"
+    assert run_meta["failure"]["kind"] == "auth-required"
+
+    routing = json.loads((output_dir / "seat-routing.json").read_text())
+    assert routing["outcome"] == "abort"
+    assert routing["rejected_fallbacks"] == [
+        {"seat": "chef-fallback", "status": "unhealthy", "cause": "auth-required"},
+    ]
+
+
+def test_degraded_orchestrator_proceeds_without_reroute(monkeypatch, tmp_path, capsys):
+    plan_calls = _stub_run_phases(monkeypatch)
+    output_dir = tmp_path / "run-degraded"
+    _install_probe(monkeypatch, PerSeatFakeAdapter(degraded=frozenset({"chef"})))
+
+    assert (
+        run_aboyeur_guarded(
+            "build feature",
+            _roster(fallback=("chef-fallback",)),
+            output_dir=output_dir,
+            code_graph_enabled=False,
+            route_enabled=False,
+        )
+        == 0
+    )
+
+    assert len(plan_calls) == 1
+    assert plan_calls[0].orchestrator == "chef"
+    stderr = capsys.readouterr().err
+    assert "warning: orchestrator" not in stderr
+    assert not (output_dir / "seat-routing.json").exists()
+
+
+def test_probe_exception_proceeds_without_abort(monkeypatch, tmp_path, capsys):
+    plan_calls = _stub_run_phases(monkeypatch)
+    output_dir = tmp_path / "run-probe-exc"
+    monkeypatch.setattr(aboyeur.seat_health, "SeatHealthProbe", lambda **kwargs: RaisingProbe())
+
+    assert (
+        run_aboyeur_guarded(
+            "build feature",
+            _roster(fallback=("chef-fallback",)),
+            output_dir=output_dir,
+            code_graph_enabled=False,
+            route_enabled=False,
+        )
+        == 0
+    )
+
+    assert len(plan_calls) == 1
+    assert plan_calls[0].orchestrator == "chef"
+    stderr = capsys.readouterr().err
+    assert "error: orchestrator" not in stderr
+    assert not (output_dir / "seat-routing.json").exists()
+
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "ok"

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -17,6 +17,7 @@ from brigade import proc
 from brigade import roster
 from brigade import runguard
 from brigade import runs_cmd
+from tests.run_test_helpers import HEALTHY_SEAT_HEALTH_CHILD_SETUP
 
 
 def test_run_cli_missing_roster_errors(tmp_path, capsys, monkeypatch):
@@ -1575,7 +1576,7 @@ import time
 from pathlib import Path
 from brigade import aboyeur, cli
 from brigade.codex_appserver import AppServer
-
+{HEALTHY_SEAT_HEALTH_CHILD_SETUP}
 class RecordingAppServer(AppServer):
     def __init__(self, *, cwd):
         super().__init__(argv=[sys.executable, "-c", {stubborn_appserver!r}], cwd=cwd)


### PR DESCRIPTION
Part of #578 (parent #474). Slice B of four: a failed orchestrator selects a healthy declared fallback, or aborts with the typed cause, before planning.

## What changes

The seat-health probe wired in #685 was observation only. Its results now drive one decision, evaluated after the initial run receipt and before planning:

- **Unhealthy orchestrator, healthy declared fallback** - walk the orchestrator's own `fallback` chain in declared order, take the first seat whose probe came back `healthy`, rebind the roster so the planner and every later phase use it, and print one warning naming requested seat, typed cause, and selected seat.
- **Unhealthy orchestrator, no healthy declared fallback** - abort before planning. The probe's typed `FailureClass` becomes the run failure kind, and the run returns the existing admission exit code 2. No new exit code.
- **Anything else** - unchanged.

Brigade never invents a fallback the roster did not declare, and never reorders the declared chain.

The decision lands in an additive `seat-routing.json` beside `run.json`. `run.json` and `roster.json` keep their existing shape.

## Two decisions worth reviewing

**Only `unhealthy` counts as failed.** An installed but unsmoked seat probes `degraded` in normal use (degraded authentication-entitlement, version-gates, model-reachability), so routing on `degraded` would reroute or abort ordinary runs.

**A probe that raises returns no routing information at all.** `exception_results_for_probe_failure` marks the whole declared chain unhealthy because the probe blew up, not because the seats are bad. Acting on it would let probe trouble take down a run that was already receipted, which is exactly what #685 guarantees it cannot.

## Why tests/conftest.py is in this diff

The suite pins a bare-host baseline in `_no_managed_tools_on_path`, deliberately, so no managed tool or host PATH binary resolves and the suite behaves the same on a wired dev host as on CI. Under that baseline every declared seat probes `executable-unavailable`, so the first run of the gate on this change produced **90 failures from one cause**:

```
error: orchestrator chef is unhealthy [executable-unavailable]; no declared fallbacks
```

95 occurrences, one message. Those tests stub `agents.run_agent` and never launch a CLI, so for them the missing executable is a fact about the sandbox rather than the code under test.

The new `_seat_health_probe_reports_healthy` fixture reports declared seats healthy and opts out `test_seat_health`, `test_aboyeur_seat_health_probe`, and `test_aboyeur_orchestrator_health_routing`, which drive the probe themselves. It is a global stub, so naming what it hides: `run()` rerouting or aborting on an unhealthy orchestrator is invisible to tests outside those three modules. That behaviour is covered there rather than stubbed away everywhere.

## Known interaction with #687

This is the first writer to put a `FailureClass` value into run-level `failure.kind`. All 17 of those values currently classify as non-infrastructure in `run_failure_is_infrastructure_at_read_time`, so until #687 lands, a seat-health abort scores as a real failure in outcome capture rather than a neutral infrastructure one. Filed separately rather than widened into this PR.

## Verification

`brigade work verify run --command "./scripts/verify"`, `reused_from: None`:

```
./scripts/verify [completed] exit=0
5885 passed, 3 skipped, 68 subtests passed in 658.99s (0:10:58)
Required test coverage of 78% reached. Total coverage: 83.09%
```

Slices C and D of #578 remain open.