### PR TITLE
fix(outcome): classify FailureClass run failure kinds as infrastructure

### DIFF
--- a/src/brigade/worker_failure.py
+++ b/src/brigade/worker_failure.py
@@ -491,4 +491,8 @@ def run_failure_is_infrastructure_at_read_time(kind: str | None, phase: str | No
         return None
     if _is_run_catch_all_failure_kind(kind):
         return phase in RUN_INFRASTRUCTURE_FAILURE_PHASES
-    return False
+    try:
+        FailureClass(kind)
+    except ValueError:
+        return False
+    return True

--- a/tests/test_outcome_infrastructure_attribution.py
+++ b/tests/test_outcome_infrastructure_attribution.py
@@ -669,3 +669,51 @@ def test_catch_all_in_every_declared_model_phase_stays_negative(tmp_path, phase)
     assert rc == 0
     assert payload["record"]["signal_value"] == -1
     assert payload["record"]["evidence_ref"] == str(run_json)
+
+
+@pytest.mark.parametrize("failure_class", list(worker_failure.FailureClass))
+def test_failure_class_kind_is_infrastructure_at_read_time(failure_class):
+    """Typed abort receipts write FailureClass values; all are infrastructure-neutral."""
+
+    assert worker_failure.run_failure_is_infrastructure_at_read_time(failure_class.value, "preflight") is True
+
+
+def test_isolation_breach_failure_class_is_infrastructure_at_read_time():
+    assert worker_failure.run_failure_is_infrastructure_at_read_time("isolation-breach", "postflight") is True
+
+
+def test_model_contract_kind_wins_over_legacy_failure_class_map():
+    # ``non-final-output`` maps to ``output-contract-violation`` in LEGACY_FAILURE_KIND_MAP,
+    # but RUN_MODEL_CONTRACT_FAILURE_KINDS must win before the FailureClass check.
+    assert worker_failure.run_failure_is_infrastructure_at_read_time("non-final-output", "run-isolation") is False
+    assert worker_failure.run_failure_is_infrastructure_at_read_time("invalid-plan", "dispatch") is False
+
+
+def test_catch_all_classifier_in_model_phase_stays_negative():
+    assert worker_failure.run_failure_is_infrastructure_at_read_time("agent-error", "planning") is False
+
+
+def test_catch_all_classifier_missing_phase_fails_closed():
+    assert worker_failure.run_failure_is_infrastructure_at_read_time("agent-error", None) is False
+
+
+def test_catch_all_classifier_unknown_phase_fails_closed():
+    assert worker_failure.run_failure_is_infrastructure_at_read_time("unexpected-error", "artifact-collection") is False
+
+
+def test_slice_b_typed_failure_class_run_receipt_is_neutral(tmp_path):
+    """Slice-B abort writes FailureClass values into nested failure.kind; capture stays neutral."""
+
+    run_json = _write_run_receipt_with_failure(
+        tmp_path,
+        "slice-b-auth-required",
+        status="failed",
+        failure={"kind": "auth-required", "phase": "preflight"},
+    )
+    _write_worker_results(tmp_path, "slice-b-auth-required", results=[_ok_worker()])
+
+    rc, payload = _capture_signal(tmp_path, "slice-b-auth-required")
+
+    assert rc == 0
+    assert payload["record"]["signal_value"] == 0
+    assert payload["record"]["evidence_ref"] == str(run_json)


### PR DESCRIPTION
Closes #687. 0.26.0 ship blocker, and live rather than theoretical since #688 merged.

## The bug

`run_failure_is_infrastructure_at_read_time` classifies **run-owned failure kinds**. The typed seat-health taxonomy uses a different, **completely disjoint** vocabulary: `FailureClass` values. Every one fell through to the terminal `return False`, so a run aborted with a typed cause scored `-1` as a real skill failure, contradicting #682 and #686.

Measured before the fix:

```
classify("auth-required", "startup") -> False
NOT treated as infrastructure: 17 of 17
FailureClass values that are also run-owned kinds: NONE
```

Sharpest illustration: `transport-error` (a legacy run kind) classified as infrastructure, while `transport-unavailable` — the `FailureClass` it maps to — did not. Same failure, two names, opposite verdicts.

## Why it was live

Slice B (#688) added the typed abort. `aboyeur.py:3079` sets `abort_failure_kind = failure.failure_class.value`, which reaches `record_run_termination(failure_kind=...)` at `:3384` and lands in the receipt's nested kind at `:2416`. So every seat-health abort was already scoring `-1`.

## The fix

Five lines. After the existing checks, parse the kind as a `FailureClass`; if it parses, it is infrastructure.

```python
    try:
        FailureClass(kind)
    except ValueError:
        return False
    return True
```

`FailureDomain` has exactly one member, `INFRASTRUCTURE`, so anything parsing as a `FailureClass` is infrastructure by construction. This closes all 17 at once rather than relying on every future writer to remember.

**Ordering is load-bearing.** `RUN_MODEL_CONTRACT_FAILURE_KINDS` still wins first, because `non-final-output` is **both** a legacy model-contract run kind **and** a key in `LEGACY_FAILURE_KIND_MAP`. Placing the new check last keeps it negative. Full order: model-contract → unambiguous-infra → `worker-failure` → catch-all phase gate → `FailureClass` parse → `False`.

Legacy behaviour is untouched: catch-all phase gating, the fail-closed unknown-phase rule, and `worker-failure` still returning `None`.

## `unclassified` is treated as infrastructure, with evidence

`FailureClass.UNCLASSIFIED` is also slice B's abort default when `failure is None`, so this needed deciding rather than assuming. The only run-level writers of `"unclassified"` into `failure.kind` are that slice B abort path (`aboyeur.py:3079` → `3384` → `2416`). No other production writer puts it there, and the abort path is infrastructure by construction since the run never planned. So it is `True`.

## Known compat note

`"timeout"` is both a pre-#688 CLI run kind and `FailureClass.TIMEOUT`, so historical `timeout` receipts flip from `False` to `True` at read time. This is inherent to the accepted widening and is arguably a correction — a worker timeout is infrastructure — but it does shift scores derived from history. Nothing is rewritten; the mapping is read-time only, consistent with #683. Flagged rather than buried.

## Tests

Parametrized over `list(worker_failure.FailureClass)`, so it is enum-driven and adding a class later cannot silently land in the wrong bucket. Also covers `isolation-breach` (so #579 does not inherit the bug), the model-contract ordering, catch-all fail-closed behaviour, and an end-to-end capture: a receipt shaped like slice B's abort (`auth-required`, phase `preflight`, all workers ok) scores `0` and keeps its `evidence_ref`.

No existing assertion was changed.

## Verification

Reviewed independently by a grok-4.5 seat: **APPROVED**, no blockers. It also raised the `timeout` compat note above, which is carried here rather than dropped.

I ran the gate myself regardless of that verdict, because a passing review is not a passing gate. `./scripts/verify` through `brigade work verify run`, receipt `20260804-003827-work-verify-b6ec58`, exit 0, `reused_from` **absent**:

```
5908 passed, 3 skipped, 68 subtests passed in 680.92s (0:11:20)
Required test coverage of 78% reached. Total coverage: 83.10%
```

Confirmed against this branch's source: `IMPORTING: /tmp/w687/src/brigade/__init__.py`.

## Provenance

Implemented by a Cursor composer-2.5 seat and reviewed by a grok-4.5 seat in one `brigade run`. The seat committed inside its worktree, so `changes.patch` was empty and the worktree was auto-removed on success; the commit was recovered from the shared object store.
