### PR TITLE
fix(security): repair secret detectors instead of suppressing findings

### DIFF
--- a/src/brigade/security_cmd/models.py
+++ b/src/brigade/security_cmd/models.py
@@ -204,8 +204,25 @@ SECRETS_TITLE_RANK = {
 
 
 def _is_runtime_secret_value(value: str) -> bool:
-    """True when the assigned value is generated or read at runtime instead of committed."""
-    return RUNTIME_SECRET_VALUE_RE.match(value.strip().strip("'\"")) is not None
+    """True when the assigned value is generated or read at runtime instead of committed.
+
+    Quotes are deliberately not stripped here. A quoted value is a committed literal even
+    when its text opens with a runtime expression, so ``api_key = "os.environ.sk-live-..."``
+    must stay reportable. Callers that can still see the source line decide whether the
+    value was quoted; see :func:`_match_value_is_quoted`.
+    """
+    return RUNTIME_SECRET_VALUE_RE.match(value.strip()) is not None
+
+
+def _match_value_is_quoted(line: str, match: re.Match[str]) -> bool:
+    """True when the captured secret value was wrapped in quotes on the source line.
+
+    ``SECRET_VALUE_RE`` and ``PLAINTEXT_PASSWORD_RE`` both put the optional quote *outside*
+    their value group, so the quote never reaches the captured text and has to be read back
+    off the line.
+    """
+    start = match.start(2)
+    return start > 0 and line[start - 1] in "'\""
 
 
 def _is_attribute_secret_value(value: str) -> bool:

--- a/src/brigade/security_cmd/models.py
+++ b/src/brigade/security_cmd/models.py
@@ -193,6 +193,75 @@ PRIVATE_KEY_RE = re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----")
 
 ENV_ASSIGNMENT_RE = re.compile(r"(?i)\b[A-Z0-9_]*(TOKEN|SECRET|PASSWORD|API_KEY)\s*=\s*[A-Za-z0-9_./+=:-]{16,}")
 
+RUNTIME_SECRET_VALUE_RE = re.compile(r"(?i)^(?:secrets\.\w+|os\.environ|os\.getenv|[\w.]*_from_env)\b")
+ATTRIBUTE_SECRET_VALUE_RE = re.compile(r"^[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)+$")
+SECRETS_TITLE_RANK = {
+    "Session chat contains exposed credential": 40,
+    "Plaintext password": 30,
+    "Possible hardcoded credential": 20,
+    "Possible sensitive secret material": 10,
+}
+
+
+def _is_runtime_secret_value(value: str) -> bool:
+    """True when the assigned value is generated or read at runtime instead of committed."""
+    return RUNTIME_SECRET_VALUE_RE.match(value.strip().strip("'\"")) is not None
+
+
+def _is_attribute_secret_value(value: str) -> bool:
+    """True when the assigned value is another object's attribute rather than a literal.
+
+    A committed JWT is also dot-separated and can be purely alphanumeric, so
+    JWT-shaped values (base64url header always starts with ``eyJ``, segments far
+    longer than identifier hops) must still report.
+    """
+    candidate = value.strip()
+    if ATTRIBUTE_SECRET_VALUE_RE.match(candidate) is None:
+        return False
+    if candidate.startswith("eyJ"):
+        return False
+    return all(len(part) <= 32 for part in candidate.split("."))
+
+
+def _env_assignment_value(match: re.Match[str]) -> str:
+    _, _, value = match.group(0).partition("=")
+    return value.strip()
+
+
+def _secrets_title_rank(title: str) -> int:
+    return SECRETS_TITLE_RANK.get(title, 0)
+
+
+def _is_security_scanner_literal(path: Path, line: str, target: Path) -> bool:
+    try:
+        rel = path.relative_to(target).as_posix()
+    except ValueError:
+        rel = path.as_posix()
+    if not (rel.startswith("src/brigade/security_cmd/") and rel.endswith(".py")):
+        return False
+    stripped = line.strip()
+    scanner_tokens = (
+        "danger-full-access",
+        "sandbox_permissions",
+        "require_escalated",
+        "npx package",
+        "PLAINTEXT_PASSWORD_RE",
+        "Environment dump or exfiltration pattern",
+        "Plaintext password",
+        "Possible hardcoded credential",
+        "Possible sensitive secret material",
+        "Session chat contains exposed credential",
+    )
+    if any(token in stripped for token in scanner_tokens):
+        return True
+    if stripped.startswith("suggestion=") or stripped.startswith("title="):
+        return True
+    if stripped.startswith(("password_match =", "password_emitted =")):
+        return True
+    return stripped.startswith("if ") and (
+        '"danger-full-access"' in stripped or '"sandbox_permissions"' in stripped or '"require_escalated"' in stripped
+    )
+
 
 REMOTE_SHELL_RE = re.compile(r"\b(curl|wget)\b[^\n|;]*(\||;)\s*(sh|bash)\b")
 

--- a/src/brigade/security_cmd/scan_engine.py
+++ b/src/brigade/security_cmd/scan_engine.py
@@ -1305,7 +1305,9 @@ def _first_committed_secret_match(pattern: re.Pattern[str], line: str) -> re.Mat
     """
     for match in pattern.finditer(line):
         value = match.group(2)
-        if _is_placeholder(value) or _is_runtime_secret_value(value):
+        if _is_placeholder(value):
+            continue
+        if not _match_value_is_quoted(line, match) and _is_runtime_secret_value(value):
             continue
         return match
     return None

--- a/src/brigade/security_cmd/scan_engine.py
+++ b/src/brigade/security_cmd/scan_engine.py
@@ -1297,31 +1297,27 @@ def _finding(
     )
 
 
-def _is_security_scanner_literal(path: Path, line: str) -> bool:
-    if not path.as_posix().endswith("src/brigade/security_cmd.py"):
-        return False
-    stripped = line.strip()
-    scanner_tokens = (
-        "danger-full-access",
-        "sandbox_permissions",
-        "require_escalated",
-        "npx package",
-        "PLAINTEXT_PASSWORD_RE",
-        "Environment dump or exfiltration pattern",
-        "Plaintext password",
-        "Possible hardcoded credential",
-        "Possible sensitive secret material",
-        "Session chat contains exposed credential",
-    )
-    if any(token in stripped for token in scanner_tokens):
-        return True
-    if stripped.startswith("suggestion=") or stripped.startswith("title="):
-        return True
-    if stripped.startswith(("password_match =", "password_emitted =")):
-        return True
-    return stripped.startswith("if ") and (
-        '"danger-full-access"' in stripped or '"sandbox_permissions"' in stripped or '"require_escalated"' in stripped
-    )
+def _first_committed_secret_match(pattern: re.Pattern[str], line: str) -> re.Match[str] | None:
+    """First match on the line whose value is a committed literal, not a placeholder or runtime read.
+
+    Scoped to the matched value so a line that mixes a real credential with a
+    ``secrets.token_hex()`` call or an environment read still reports the credential.
+    """
+    for match in pattern.finditer(line):
+        value = match.group(2)
+        if _is_placeholder(value) or _is_runtime_secret_value(value):
+            continue
+        return match
+    return None
+
+
+def _first_committed_env_assignment(line: str) -> re.Match[str] | None:
+    for match in ENV_ASSIGNMENT_RE.finditer(line):
+        value = _env_assignment_value(match)
+        if _is_runtime_secret_value(value) or _is_attribute_secret_value(value):
+            continue
+        return match
+    return None
 
 
 def _scan_line(
@@ -1334,48 +1330,52 @@ def _scan_line(
     classification: FileClassification | None = None,
 ) -> None:
     file_classification = classification or _classification_for(path, target)
-    if _is_security_scanner_literal(path, line):
+    if _is_security_scanner_literal(path, line, target):
         return
-    secret_match = SECRET_VALUE_RE.search(line)
-    password_match = PLAINTEXT_PASSWORD_RE.search(line)
-    password_emitted = bool(password_match and not _is_placeholder(password_match.group(2)))
-    if password_emitted:
-        _finding(
-            findings,
-            target=target,
-            path=path,
-            line=line_number,
-            severity="high",
-            category="secrets",
-            title="Plaintext password",
-            evidence=_redact_secret_evidence(line),
-            suggestion="Move the password into local secret storage or a gitignored environment file, then scrub the raw value from shared files.",
-            classification=file_classification,
-            response_options=_secret_response_options(path, target),
-        )
-    if secret_match and not password_emitted and not _is_placeholder(secret_match.group(2)):
+    best_secret: tuple[str, str] | None = None
+
+    def consider_secret(title: str, suggestion: str) -> None:
+        nonlocal best_secret
+        if best_secret is None or _secrets_title_rank(title) > _secrets_title_rank(best_secret[0]):
+            best_secret = (title, suggestion)
+
+    try:
+        rel_path = path.relative_to(target).as_posix()
+    except ValueError:
+        rel_path = path.as_posix()
+    if not rel_path.startswith("src/brigade/guard/examples/"):
+        secret_match = _first_committed_secret_match(SECRET_VALUE_RE, line)
+        password_match = _first_committed_secret_match(PLAINTEXT_PASSWORD_RE, line)
+        password_emitted = password_match is not None
         session_chat = _is_session_chat_path(path, target)
-        _finding(
-            findings,
-            target=target,
-            path=path,
-            line=line_number,
-            severity="high",
-            category="secrets",
-            title="Session chat contains exposed credential" if session_chat else "Possible hardcoded credential",
-            evidence=_redact_secret_evidence(line),
-            suggestion=(
-                "Redact or archive the session transcript, rotate the credential if real, and move active use to .env, environment variables, or KeePass."
-                if session_chat
-                else "Move the value into local environment or secret storage and commit only a placeholder."
-            ),
-            response_options=_secret_response_options(path, target),
-            classification=file_classification,
+        session_suggestion = (
+            "Redact or archive the session transcript, rotate the credential if real, "
+            "and move active use to .env, environment variables, or KeePass."
         )
-    if _contains_private_key_material(line) or (
-        ENV_ASSIGNMENT_RE.search(line) and not password_emitted and not _is_placeholder(line)
-    ):
-        session_chat = _is_session_chat_path(path, target)
+        if password_emitted:
+            consider_secret(
+                "Plaintext password",
+                "Move the password into local secret storage or a gitignored environment file, "
+                "then scrub the raw value from shared files.",
+            )
+        if secret_match and not password_emitted:
+            consider_secret(
+                "Session chat contains exposed credential" if session_chat else "Possible hardcoded credential",
+                session_suggestion
+                if session_chat
+                else "Move the value into local environment or secret storage and commit only a placeholder.",
+            )
+        if _contains_private_key_material(line) or (
+            _first_committed_env_assignment(line) is not None and not password_emitted and not _is_placeholder(line)
+        ):
+            consider_secret(
+                "Session chat contains exposed credential" if session_chat else "Possible sensitive secret material",
+                session_suggestion
+                if session_chat
+                else "Remove secret material from the repo and rotate the credential if it was real.",
+            )
+    if best_secret is not None:
+        title, suggestion = best_secret
         _finding(
             findings,
             target=target,
@@ -1383,15 +1383,11 @@ def _scan_line(
             line=line_number,
             severity="high",
             category="secrets",
-            title="Session chat contains exposed credential" if session_chat else "Possible sensitive secret material",
+            title=title,
             evidence=_redact_secret_evidence(line),
-            suggestion=(
-                "Redact or archive the session transcript, rotate the credential if real, and move active use to .env, environment variables, or KeePass."
-                if session_chat
-                else "Remove secret material from the repo and rotate the credential if it was real."
-            ),
-            response_options=_secret_response_options(path, target),
+            suggestion=suggestion,
             classification=file_classification,
+            response_options=_secret_response_options(path, target),
         )
     if "danger-full-access" in line or "sandbox_permissions" in line and "require_escalated" in line:
         _finding(

--- a/tests/test_security_cmd.py
+++ b/tests/test_security_cmd.py
@@ -105,7 +105,7 @@ def test_security_scan_avoids_source_false_positives(tmp_path):
 
 def test_security_scan_ignores_own_detector_literals():
     findings = []
-    path = security_cmd.Path("src/brigade/security_cmd.py")
+    path = security_cmd.Path("src/brigade/security_cmd/scan_engine.py")
     lines = [
         '                suggestion="Pin npx package versions or move execution behind a reviewed lockfile.",',
         '    if "danger-full-access" in line or "sandbox_permissions" in line and "require_escalated" in line:',
@@ -128,6 +128,76 @@ def test_security_scan_ignores_own_detector_literals():
         line="Use sandbox_permissions require_escalated for all tasks.",
     )
     assert findings
+
+
+def test_security_scan_secrets_false_positive_suppressions(tmp_path):
+    """Regression guards for secrets-scanner false-positive fixes."""
+    target = tmp_path
+    (target / "secrets_module.py").write_text(
+        "\n".join(
+            [
+                "import secrets",
+                "token = secrets.token_hex(16)",
+                "token = secrets.token_urlsafe(32)",
+                "owner_token = secrets.token_hex(16)",
+                "",
+            ]
+        )
+    )
+    (target / "env_read.py").write_text(
+        "\n".join(
+            [
+                "import os",
+                "token = os.environ['SERVICE_TOKEN']",
+                "api_key = os.getenv('API_KEY')",
+                "token = runs_cmd._approval_marker_from_env(runs_cmd._APPROVAL_RESUME_TOKEN_ENV)",
+                "",
+            ]
+        )
+    )
+    (target / "real_secret.py").write_text('api_key = "sk-live-abcd1234efgh5678"\n')
+    (target / "jwt.env").write_text(
+        "AUTH_TOKEN=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJVadQssw5c\n"
+    )
+    (target / "dual_match.py").write_text("token=abc123abc123abc123abc123abc123\n")
+    (target / "attribute_read.py").write_text("approval_token=reservation.token,\n")
+    (target / "mixed_line.py").write_text(
+        "\n".join(
+            [
+                'client = Client(api_key="sk-live-abcd1234efgh5678", base=os.environ["URL"])',
+                'api_key = "sk-live-abcd1234efgh5678"; nonce = secrets.token_hex(4)',
+                "",
+            ]
+        )
+    )
+    guard_examples = target / "src" / "brigade" / "guard" / "examples" / "fixture"
+    guard_examples.mkdir(parents=True)
+    (guard_examples / "blocked-secret-token.json").write_text('{"text": "token=abc123abc123abc123abc123abc123"}\n')
+    scanner_pkg = target / "src" / "brigade" / "security_cmd"
+    scanner_pkg.mkdir(parents=True)
+    (scanner_pkg / "models.py").write_text("PLAINTEXT_PASSWORD_RE = re.compile(\n")
+    (scanner_pkg / "scan_engine.py").write_text(
+        "    password_match = PLAINTEXT_PASSWORD_RE.search(line)\n"
+        "    password_emitted = bool(password_match and not _is_placeholder(password_match.group(2)))\n"
+    )
+
+    report = security_cmd.scan_target(target)
+    secrets = [f for f in report["findings"] if f["category"] == "secrets" and f["severity"] == "high"]
+    paths_lines = {(f["path"], f["line"]) for f in secrets}
+
+    assert "secrets_module.py" not in {p for p, _ in paths_lines}
+    assert "env_read.py" not in {p for p, _ in paths_lines}
+    assert "attribute_read.py" not in {p for p, _ in paths_lines}
+    assert ("real_secret.py", 1) in paths_lines
+    # JWT-shaped values are dot-separated like attribute reads but must still report.
+    assert ("jwt.env", 1) in paths_lines
+    assert ("dual_match.py", 1) in paths_lines
+    assert sum(1 for f in secrets if f["path"] == "dual_match.py" and f["line"] == 1) == 1
+    # A runtime read on the same line must not mask a committed credential.
+    assert ("mixed_line.py", 1) in paths_lines
+    assert ("mixed_line.py", 2) in paths_lines
+    assert not any("guard/examples" in f["path"] for f in secrets)
+    assert not any("security_cmd" in f["path"] for f in secrets)
 
 
 def test_security_policy_presets_and_template_inclusion(tmp_path, capsys):

--- a/tests/test_security_cmd.py
+++ b/tests/test_security_cmd.py
@@ -161,6 +161,17 @@ def test_security_scan_secrets_false_positive_suppressions(tmp_path):
     )
     (target / "dual_match.py").write_text("token=abc123abc123abc123abc123abc123\n")
     (target / "attribute_read.py").write_text("approval_token=reservation.token,\n")
+    # A quoted value is a committed literal even when its text opens with a runtime
+    # expression, so the runtime exemption must not reach inside the quotes.
+    (target / "quoted_runtime_prefix.py").write_text(
+        "\n".join(
+            [
+                'api_key = "os.environ.sk-live-abcd1234efgh5678"',
+                "token = 'secrets.token_hex_abcd1234efgh5678'",
+                "",
+            ]
+        )
+    )
     (target / "mixed_line.py").write_text(
         "\n".join(
             [
@@ -196,6 +207,11 @@ def test_security_scan_secrets_false_positive_suppressions(tmp_path):
     # A runtime read on the same line must not mask a committed credential.
     assert ("mixed_line.py", 1) in paths_lines
     assert ("mixed_line.py", 2) in paths_lines
+    # A quoted literal that merely starts with a runtime expression still reports, once.
+    assert ("quoted_runtime_prefix.py", 1) in paths_lines
+    assert ("quoted_runtime_prefix.py", 2) in paths_lines
+    assert sum(1 for f in secrets if f["path"] == "quoted_runtime_prefix.py" and f["line"] == 1) == 1
+    assert sum(1 for f in secrets if f["path"] == "quoted_runtime_prefix.py" and f["line"] == 2) == 1
     assert not any("guard/examples" in f["path"] for f in secrets)
     assert not any("security_cmd" in f["path"] for f in secrets)
 


### PR DESCRIPTION
Fixes #696.

Five false-positive classes, fixed in the detectors rather than by adding suppressions.
`.brigade/security.toml` still carries zero suppression fingerprints after this change.

## Root cause of the largest class

`_is_security_scanner_literal` existed to stop the scanner flagging its own rule
definitions. It gated on:

```python
path.as_posix().endswith("src/brigade/security_cmd.py")
```

`security_cmd.py` was later split into the `src/brigade/security_cmd/` **package**. No
file carries that name any more, so the guard could never return `True`. It had been dead
since the split, and because it fails open there was no signal: the scanner just quietly
flagged its own `title=` / `suggestion=` literals. It now tests a target-relative prefix,
`src/brigade/security_cmd/` plus a `.py` suffix, and takes `target` as a third argument so
the check works for any checkout path.

## The other four

| Class | Fix |
|---|---|
| `secrets.token_hex()` and friends | `RUNTIME_SECRET_VALUE_RE` |
| environment reads (`os.environ`, `os.getenv`, `*_from_env`) | same regex |
| deliberate fixtures under `src/brigade/guard/examples/` | path-prefix skip of the secrets block |
| duplicate emission | `SECRETS_TITLE_RANK`, exactly one finding per line |

Duplicate emission was real and measurable: `src/brigade/daily_cmd/approvals.py:568`
produced two findings from one line, "Possible hardcoded credential" and "Possible
sensitive secret material".

Because dotted values are treated as attribute reads, JWTs need a carve-out.
`_is_attribute_secret_value` refuses to suppress anything starting with `eyJ` or carrying
a dot-separated segment longer than 32 characters.

## Verification

`./scripts/verify` green: **5919 passed, 3 skipped, 68 subtests passed** in 12:24.
Receipt `20260804-235725-work-verify-27bb06`, `reused_from: null`, baseline `431d9903`.

Scanning the patched worktree directly is misleading, because a fresh `brigade init`
writes a default `security.toml` without this repo's tuned exclusions. The measurement
that isolates the detector change is an A/B of both scanner builds against one fixed
target:

| Scanner | high findings |
|---|---|
| before | **16** |
| after | **0** |

A positive-control corpus confirms real credentials still report, one finding per line:

| Input | Reports |
|---|---|
| `api_key = "sk-live-abcd1234efgh5678"` | yes |
| `AUTH_TOKEN=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dQw4w9…` | yes |
| `api_key = "os.environ.sk-live-abcd1234efgh5678"` | yes |
| `token = os.environ["SERVICE_TOKEN"]` | no |
| `api_key = os.getenv("API_KEY")` | no |
| `session_token = secrets.token_hex(16)` | no |
| `runs_cmd._approval_marker_from_env(...)` | no |

A note on writing these fixtures: `quoted_api_key = "..."` reports nothing, because
`\bapi[_-]?key\b` cannot match inside `quoted_api_key`. That is a naming artifact, not a
suppression. Every negative case above is paired with a positive control in the same scan,
so a silent result means the detector ran and declined rather than never matching.

## Known limits

An adversarial review pass returned BLOCK. Each claim was reproduced against a positive
control in the same scan, so silence is real suppression and not a dead scan. Results:

| Case | Status |
|---|---|
| `api_key = "os.environ.sk-live-abcd1234efgh5678"` | **fixed in this PR** |
| `AUTH_TOKEN=prod.service.credential.abc123` | suppressed, inherent to treating unquoted dotted values as attribute reads |
| real secret under `guard/examples/` | suppressed, intended for that fixture tree |
| real secret in `security_cmd/` | still reports; only a secret sharing a line with a scanner token is suppressed |
| two credentials on one line | safe, evidence keeps the full redacted line |
| placeholder first, real credential later | safe, `finditer` walk finds the real one |

The first row is resolved. The runtime exemption used to reach inside quotes, so a
committed credential whose text merely opened with `os.environ` or `secrets.` was dropped.
A quoted value is now always treated as a committed literal.

Removing the quote-strip before the runtime match, the obvious one-liner, would have fixed
nothing. `SECRET_VALUE_RE` and `PLAINTEXT_PASSWORD_RE` put the optional quote *outside*
their value group, so the captured text never contained a quote and that strip was already
dead code. The quote only survives on the source line, so `_match_value_is_quoted` reads it
back from the character preceding the value.

Unquoted runtime expressions are unchanged, and the distinction is not academic:
`os.environ[...]` and `os.getenv(...)` never match `SECRET_VALUE_RE` at all, while
`secrets.token_hex` (17 in-class characters) genuinely depends on the runtime exemption and
still relies on it.

Row 2 remains true and is the deliberate cost of treating unquoted dotted values as
attribute reads. The JWT carve-out is what keeps that from swallowing real tokens.

## Not included

Two follow-ups from the earlier review are deliberately out of scope and being filed
separately: suppression-aware coalescing for two-credential lines, and rank/fingerprint
pinning tests.

