### PR TITLE
fix(update): run the background version refresh on piped stderr

### DIFF
--- a/docs/update-channels.md
+++ b/docs/update-channels.md
@@ -42,8 +42,11 @@ background process sends one HTTPS GET to
 `https://check.brigade.tools/v1/version`. The request has no query
 parameters, no body, and no install id. The User-Agent carries the brigade
 version and OS name. Raw IPs are never stored server-side (a weekly-salted
-hash backs an aggregate weekly-active count). The notice is skipped entirely
-when stderr is not a TTY, when `CI` is set, or when the command failed.
+hash backs an aggregate weekly-active count). The stderr notice is skipped
+when stderr is not a TTY, when `CI` is set, or when the command failed. The
+background cache refresh still runs when stderr is piped (agent harnesses) so
+`work brief` can surface available updates; it is skipped when `CI` is set or
+`BRIGADE_NO_UPDATE_CHECK` is set.
 
 Opt out completely (no notice, no network, ever):
 

--- a/src/brigade/update_notify.py
+++ b/src/brigade/update_notify.py
@@ -5,6 +5,10 @@ detached child process so no user command ever waits on it. The endpoint
 request carries no parameters and no install id - the User-Agent (version +
 OS) plus the request itself is the entire signal. BRIGADE_NO_UPDATE_CHECK
 disables both the notice and all network activity.
+
+The stderr notice is TTY-only (interactive shells). The background cache
+refresh runs even when stderr is piped so agent harness installs populate
+the on-disk cache for ``available_update()`` / work-brief.
 """
 
 from __future__ import annotations
@@ -78,7 +82,7 @@ def available_update(*, env: Mapping[str, str] | None = None, now: float | None 
         return None
 
 
-def _gated(argv: list[str], exit_code: int, env: Mapping[str, str], stderr: Any) -> bool:
+def _notice_gated(argv: list[str], exit_code: int, env: Mapping[str, str], stderr: Any) -> bool:
     if env.get("BRIGADE_NO_UPDATE_CHECK") or env.get("CI"):
         return True
     if exit_code != 0:
@@ -87,6 +91,14 @@ def _gated(argv: list[str], exit_code: int, env: Mapping[str, str], stderr: Any)
         return True
     isatty = getattr(stderr, "isatty", None)
     return not callable(isatty) or not isatty()
+
+
+def _refresh_gated(argv: list[str], env: Mapping[str, str]) -> bool:
+    if env.get("BRIGADE_NO_UPDATE_CHECK") or env.get("CI"):
+        return True
+    if argv and argv[0] in _SKIP_COMMANDS:
+        return True
+    return False
 
 
 def _spawn_refresh() -> None:
@@ -113,37 +125,48 @@ def maybe_notify(
 ) -> None:
     """Print a cached update notice and kick off a background refresh.
 
-    Never raises, never blocks on the network, never alters the exit code.
+    The notice honors all interactive gates (TTY, success exit, opt-out, CI,
+    skip commands). The background refresh ignores TTY and exit code so piped
+    agent harnesses still populate the cache; it still honors opt-out, CI, and
+    skip commands. Never raises, never blocks on the network, never alters the
+    exit code.
     """
     try:
         environment = os.environ if env is None else env
         err = sys.stderr if stderr is None else stderr
         current_time = time.time() if now is None else now
         spawn_refresh = _spawn_refresh if spawn is None else spawn
-        if _gated(list(argv), exit_code, environment, err):
-            return
+        command_argv = list(argv)
 
         path = cache_path(environment)
         state = localio.read_json_dict(path) or {}
 
-        latest = state.get("latest")
-        if isinstance(latest, str) and is_newer(latest, __version__):
-            notified_at = state.get("notified_at")
-            notified_recently = (
-                isinstance(notified_at, (int, float)) and current_time - float(notified_at) < NOTIFY_INTERVAL_SECONDS
-            )
-            if not notified_recently:
-                err.write(
-                    f'A new brigade release is available: {latest} (installed {__version__}). Run "brigade update".\n'
+        if not _notice_gated(command_argv, exit_code, environment, err):
+            latest = state.get("latest")
+            if isinstance(latest, str) and is_newer(latest, __version__):
+                notified_at = state.get("notified_at")
+                notified_recently = (
+                    isinstance(notified_at, (int, float))
+                    and current_time - float(notified_at) < NOTIFY_INTERVAL_SECONDS
                 )
-                state["notified_at"] = current_time
-                state["notified_version"] = latest
-                localio.write_json(path, state)
+                if not notified_recently:
+                    err.write(
+                        f'A new brigade release is available: {latest} (installed {__version__}). Run "brigade update".\n'
+                    )
+                    state["notified_at"] = current_time
+                    state["notified_version"] = latest
+                    localio.write_json(path, state)
 
-        checked_at = state.get("checked_at")
-        stale = not isinstance(checked_at, (int, float)) or current_time - float(checked_at) >= CHECK_INTERVAL_SECONDS
-        if stale:
-            spawn_refresh()
+        # Exit code is intentionally not gated here: failed agent commands should
+        # still warm the cache so work-brief can surface available updates.
+        if not _refresh_gated(command_argv, environment):
+            checked_at = state.get("checked_at")
+            stale = (
+                not isinstance(checked_at, (int, float))
+                or current_time - float(checked_at) >= CHECK_INTERVAL_SECONDS
+            )
+            if stale:
+                spawn_refresh()
     except Exception:
         return
 

--- a/src/brigade/update_notify.py
+++ b/src/brigade/update_notify.py
@@ -162,8 +162,7 @@ def maybe_notify(
         if not _refresh_gated(command_argv, environment):
             checked_at = state.get("checked_at")
             stale = (
-                not isinstance(checked_at, (int, float))
-                or current_time - float(checked_at) >= CHECK_INTERVAL_SECONDS
+                not isinstance(checked_at, (int, float)) or current_time - float(checked_at) >= CHECK_INTERVAL_SECONDS
             )
             if stale:
                 spawn_refresh()

--- a/tests/test_update_notify.py
+++ b/tests/test_update_notify.py
@@ -41,7 +41,7 @@ def test_is_newer_table():
     assert not update_notify.is_newer("0.26.0", "garbage")
 
 
-def test_gates_skip_everything(tmp_path):
+def test_optout_and_ci_skip_notice_and_refresh(tmp_path):
     err = _Tty()
     calls: list[str] = []
 
@@ -52,13 +52,50 @@ def test_gates_skip_everything(tmp_path):
 
     update_notify.maybe_notify(["work"], 0, **{**base, "env": _env(tmp_path, BRIGADE_NO_UPDATE_CHECK="1")})
     update_notify.maybe_notify(["work"], 0, **{**base, "env": _env(tmp_path, CI="true")})
-    update_notify.maybe_notify(["work"], 1, **base)
     update_notify.maybe_notify(["update"], 0, **base)
     update_notify.maybe_notify(["completions"], 0, **base)
-    update_notify.maybe_notify(["work"], 0, **{**base, "stderr": io.StringIO()})  # not a tty
 
     assert calls == []
     assert err.getvalue() == ""
+
+
+def test_nonzero_exit_skips_notice_but_still_spawns_refresh(tmp_path):
+    _write_state(tmp_path, checked_at=0.0, latest="99.0.0")
+    err = _Tty()
+    calls: list[str] = []
+
+    def spawn() -> None:
+        calls.append("spawned")
+
+    update_notify.maybe_notify(["work"], 1, env=_env(tmp_path), now=1_000_000.0, stderr=err, spawn=spawn)
+    assert err.getvalue() == ""
+    assert calls == ["spawned"]
+
+
+def test_piped_stderr_spawns_refresh_without_notice(tmp_path):
+    _write_state(tmp_path, checked_at=0.0, latest="99.0.0")
+    err = io.StringIO()  # not a tty
+    calls: list[str] = []
+
+    def spawn() -> None:
+        calls.append("spawned")
+
+    update_notify.maybe_notify(["work"], 0, env=_env(tmp_path), now=1_000_000.0, stderr=err, spawn=spawn)
+    assert err.getvalue() == ""
+    assert calls == ["spawned"]
+
+
+def test_piped_stderr_exit_zero_spawns_refresh(tmp_path):
+    calls: list[str] = []
+    update_notify.maybe_notify(
+        ["work"],
+        0,
+        env=_env(tmp_path),
+        now=1.0,
+        stderr=io.StringIO(),
+        spawn=lambda: calls.append("spawned"),
+    )
+    assert calls == ["spawned"]
 
 
 def test_notifies_from_cache_and_throttles(tmp_path):


### PR DESCRIPTION
Fixes #698. Splits the single update-notice gate into a notice gate (unchanged: TTY, exit 0, CI, opt-out, skip commands) and a refresh gate (opt-out, CI, update/completions only), so agent-only installs finally populate the version cache that the work brief's update_available surface (#699) reads.

Verified: focused tests replaced the monolithic gate test (26 pass), full ./scripts/verify green via brigade work verify run (fresh receipt, reused_from null). The deliberate call: the refresh is NOT gated on exit code, so failed agent commands still warm the cache; rationale in the module docstring.

Part of the 0.26.0 release-readiness push; recommend milestone 0.26.0 per the 2026-08-04 assessment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)