### PR TITLE
fix(outcome): count model-quality failures against seats

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ $ brigade outcome rank
 - `brigade outcome reconcile` is the gate: dry-run by default, `--apply` installs a skill that earned it or rolls a regressed one back.
 - `brigade outcome explain` prints the full signal trail behind any decision, so every promotion is as auditable as the runs that earned it.
 
+Scores are recomputed from the stored receipts every time you read them, so upgrading Brigade can move numbers with no new runs. Which failures count against a seat and which neutralize is in [docs/outcome-scoring.md](docs/outcome-scoring.md).
+
 The ledger is plain JSON and markdown under `memory/outcome/`, tracked in git, readable without Brigade. `brigade init` wires a `brigade-work` skill into each harness so agents run this loop without being told. With Claude Code it also installs project-scoped hooks that redirect raw test commands through verify runs.
 
 ## Optional stations

--- a/docs/outcome-scoring.md
+++ b/docs/outcome-scoring.md
@@ -1,0 +1,68 @@
+# Outcome scoring
+
+Outcome capture scores runs at read time from stored receipts. The score is not frozen when the receipt is written. Upgrading Brigade changes how `outcome capture` and `outcome rank` classify the same historical `run.json` and `worker-results.json` files.
+
+## Read-time recomputation
+
+`brigade outcome capture` loads the run receipt, worker results, and any linked verify receipt, then applies the current classifier in `worker_failure.py` and `outcome_cmd.py`. The `signal_value` on the outcome record reflects that read-time classification, not the wording stamped on the receipt at run completion.
+
+Reinstalling or upgrading Brigade therefore re-scores existing history the next time capture runs or when ranking reconciles against stored runs.
+
+## Verdict rules
+
+For failed or incomplete runs:
+
+- `infrastructure_only=True` with no verifier failure scores **0** (neutral).
+- `infrastructure_only=False` scores **-1** (negative).
+- Successful runs score **+1**.
+
+Verifier failure on a completed verify receipt after the run started forces **-1** even when worker failures are infrastructure-only.
+
+## Kind to domain to verdict
+
+Run-level classification uses `run_failure_is_infrastructure_at_read_time`. Worker-level classification uses `normalized_failure` / `worker_result_failure` and the `domain` field on structured failures. Capture consults run level first; when run level defers (`worker-failure` or no kind), it aggregates failed workers by domain.
+
+### Run-owned failure kinds (nested `failure.kind` or legacy top-level `failure_kind`)
+
+| Kind | Infrastructure at run level | Capture verdict (failed/incomplete, no verifier failure) |
+| --- | --- | --- |
+| `invalid-plan`, `non-final-output`, `empty-output`, `malformed-final-output`, `tool-only-output`, `suspected-noop-run` | no | -1 |
+| `branch-head-drift`, `owner-process-exited`, `transport-error`, `provider-error`, `unsupported-sandbox`, `unexpected-error` | yes | 0 |
+| `worker-failure` | defer to workers | see worker table |
+| `agent-error`, `orchestrator-error` | yes only when `failure.phase` is `startup`, `run-isolation`, `stale-lock-recovery`, or `dispatch` | 0 or -1 by phase |
+| `planning`, `inference`, `output-validation` with catch-all kinds above | no | -1 |
+| missing or unknown `failure.phase` with catch-all kinds above | no | -1 |
+| Other run-owned kinds (`interrupted`, `spawn-error`, `planner-failure`, etc.) | same catch-all phase rule | 0 or -1 by phase |
+| Unknown string kind | no | -1 |
+| No failure kind present | defer | -1 if no qualifying worker infra |
+
+### Run-level `FailureClass` values (`failure.kind` equals class name)
+
+| Class | On infrastructure allowlist | Capture verdict |
+| --- | --- | --- |
+| `configuration-invalid`, `executable-unavailable`, `auth-required`, `entitlement-denied`, `version-gate`, `model-unavailable`, `capacity-exhausted`, `network-unavailable`, `transport-unavailable`, `transport-hang`, `interactive-blocked`, `worker-crash`, `timeout`, `provider-rejected` | yes | 0 |
+| `output-contract-violation`, `unclassified`, `isolation-breach` | no | -1 |
+
+### Worker adapter kinds (legacy `failure_kind` on worker-results entries)
+
+| Kind or input | `FailureClass` | Domain | Capture verdict when this worker failed |
+| --- | --- | --- | --- |
+| `empty-output`, `malformed-final-output`, `tool-only-output`, `non-final-output`, `non-final-stop`, `malformed-transport`, `grok-session-missing`, `suspected-noop-run` | `output-contract-violation` | `model-output` | -1 |
+| Unknown adapter kind (not in `LEGACY_FAILURE_KIND_MAP`) | `unclassified` | `model-output` | -1 |
+| `auth-status-unavailable`, `auth-status-unrecognized` | `unclassified` | `infrastructure` | 0 when all failed workers are infrastructure |
+| Other mapped adapter kinds (e.g. `timeout`, `decode-failure`, `network-error`) | mapped class | `infrastructure` | 0 when all failed workers are infrastructure |
+| Structured `brigade.worker_failure.v1` payload | from payload | from payload (`infrastructure` default when omitted) | 0 if all failed workers have `domain=infrastructure`, else -1 |
+
+The two `auth-status-*` kinds are mapped to `unclassified` deliberately: they record a probe Brigade could not run, not output a seat produced. Only kinds absent from `LEGACY_FAILURE_KIND_MAP` fall to the `model-output` domain.
+
+### Suspected no-op runs
+
+A run whose seats all exited ok but produced no non-`.brigade` file changes is recorded on the run receipt as `suspected_noop: true`. Capture reads that flag and scores the run **-1** even though its status is `ok`, because a seat that ships no deliverable did not do the work. Dry runs and read-only runs are exempt and keep their neutral **0**. Receipts that name the failure kind `suspected-noop-run` directly reach the same verdict through the model-quality kind set.
+
+### Status-only outcomes
+
+| Run status | Capture verdict |
+| --- | --- |
+| `ok` | +1 |
+| `error` | -1 |
+| `failed` / `incomplete` without infrastructure-only attribution | -1 |

--- a/src/brigade/cli/run.py
+++ b/src/brigade/cli/run.py
@@ -72,6 +72,11 @@ def _terminalize_escaped_run(
             aboyeur_mod.record_run_termination(
                 output_dir,
                 status="failed",
+                # #711: unexpected-error is infrastructure-neutral at kind level; phase is omitted
+                # because record_run_termination derives a status-based phase that may fall outside
+                # RUN_INFRASTRUCTURE_FAILURE_PHASES. Kind-level membership in
+                # RUN_UNAMBIGUOUS_INFRASTRUCTURE_FAILURE_KINDS keeps outcome capture neutral here
+                # and in run_failure_is_infrastructure_at_read_time regardless of stamped phase.
                 failure_phase=None,
                 failure_kind="unexpected-error",
                 detail=detail,
@@ -915,8 +920,10 @@ def _print_suspected_noop_warning(output_dir: Path) -> None:
     except (OSError, json.JSONDecodeError):
         return
     if isinstance(payload, dict) and payload.get("suspected_noop") is True:
+        # #703: name the scoring consequence here so the negative capture is not a surprise.
         print(
-            "warning: suspected no-op run; ok workers produced no non-.brigade file changes.",
+            "warning: suspected no-op run; ok workers produced no non-.brigade file changes. "
+            "outcome capture scores this run negative (see docs/outcome-scoring.md).",
             file=sys.stderr,
         )
 

--- a/src/brigade/outcome_cmd.py
+++ b/src/brigade/outcome_cmd.py
@@ -1114,6 +1114,12 @@ _RUN_INFRASTRUCTURE_FAILURE_KINDS = frozenset({"worker-failure", None})
 
 
 def _run_infrastructure_only(receipt: dict[str, Any], worker_results: list[dict[str, Any]]) -> bool:
+    """Return whether a failed/incomplete run scores neutral (infrastructure-only).
+
+    Classification is read-time only; see docs/outcome-scoring.md. Run-level kinds
+    are resolved by ``run_failure_is_infrastructure_at_read_time``; deferred kinds
+    consult worker ``domain`` (``infrastructure`` neutralizes, ``model-output`` scores negative).
+    """
     status = _run_receipt_signal_status(receipt)
     if status not in core.RUN_INFRASTRUCTURE_NEUTRAL_STATUSES:
         return False
@@ -1139,12 +1145,29 @@ def _run_infrastructure_only(receipt: dict[str, Any], worker_results: list[dict[
     return True
 
 
+def _run_is_suspected_noop(receipt: dict[str, Any], effective_status: str) -> bool:
+    """Return whether the run receipt records a seat that produced no deliverable (#703).
+
+    Dry runs and read-only runs are expected to change nothing, so they keep their own
+    neutral statuses and never reach this check.
+    """
+    if effective_status in ("dry-run", "read-only"):
+        return False
+    return receipt.get("suspected_noop") is True
+
+
 def _run_capture_signal_value(
     target: Path,
     run_json: Path,
     receipt: dict[str, Any],
     effective_status: str,
 ) -> int:
+    if _run_is_suspected_noop(receipt, effective_status):
+        # #703: the seat exited clean but shipped nothing. That is a model-quality
+        # failure, so the run scores against the seat instead of counting as a success.
+        # ``suspected-noop-run`` carries the same direction in MODEL_QUALITY_FAILURE_KINDS
+        # for receipts that name the kind directly.
+        return core.signal_value("run", "failed")
     worker_results = _load_worker_results(run_json)
     infrastructure_only = _run_infrastructure_only(receipt, worker_results)
     verifier_failed = _run_has_verifier_failure(target, run_json, receipt)

--- a/src/brigade/worker_failure.py
+++ b/src/brigade/worker_failure.py
@@ -47,6 +47,7 @@ class RetryDisposition(str, Enum):
 
 class FailureDomain(str, Enum):
     INFRASTRUCTURE = "infrastructure"
+    MODEL_OUTPUT = "model-output"
 
 
 @dataclass(frozen=True)
@@ -200,6 +201,7 @@ LEGACY_FAILURE_KIND_MAP: dict[str, FailureClass] = {
     "rate-limit-error": FailureClass.CAPACITY_EXHAUSTED,
     "timeout": FailureClass.TIMEOUT,
     "tool-only-output": FailureClass.OUTPUT_CONTRACT_VIOLATION,
+    "suspected-noop-run": FailureClass.OUTPUT_CONTRACT_VIOLATION,
     "transport-error": FailureClass.TRANSPORT_UNAVAILABLE,
     "unsafe-worktree": FailureClass.CONFIGURATION_INVALID,
     "unsupported-command-shim": FailureClass.EXECUTABLE_UNAVAILABLE,
@@ -251,19 +253,47 @@ RUN_UNAMBIGUOUS_INFRASTRUCTURE_FAILURE_KINDS = frozenset(
         "transport-error",
         "provider-error",
         "unsupported-sandbox",
+        # #711: Brigade-internal unexpected-error is infrastructure at kind level regardless of phase.
+        "unexpected-error",
     }
 )
-RUN_MODEL_CONTRACT_FAILURE_KINDS = frozenset(
+# #703: a seat that produced no deliverable. Detected on the run receipt as ``suspected_noop``
+# and read back through this kind so it scores like any other model-quality failure.
+SUSPECTED_NOOP_FAILURE_KIND = "suspected-noop-run"
+# Unified model-quality kind set (#707, #709): run-receipt path and worker-results path share this.
+MODEL_QUALITY_FAILURE_KINDS = frozenset(
     {
         "invalid-plan",
         "non-final-output",
+        "empty-output",
+        "malformed-final-output",
+        "tool-only-output",
+        SUSPECTED_NOOP_FAILURE_KIND,
     }
 )
+RUN_MODEL_CONTRACT_FAILURE_KINDS = MODEL_QUALITY_FAILURE_KINDS
 RUN_CATCH_ALL_FAILURE_KINDS = frozenset(
     {
         "agent-error",
         "orchestrator-error",
-        "unexpected-error",
+    }
+)
+RUN_LEVEL_INFRASTRUCTURE_FAILURE_CLASS_ALLOWLIST = frozenset(
+    {
+        "configuration-invalid",
+        "executable-unavailable",
+        "auth-required",
+        "entitlement-denied",
+        "version-gate",
+        "model-unavailable",
+        "capacity-exhausted",
+        "network-unavailable",
+        "transport-unavailable",
+        "transport-hang",
+        "interactive-blocked",
+        "worker-crash",
+        "timeout",
+        "provider-rejected",
     }
 )
 RUN_INFRASTRUCTURE_FAILURE_PHASES = frozenset(
@@ -403,6 +433,30 @@ def worker_result_failure(result: dict[str, object]) -> WorkerFailure | None:
     )
 
 
+def is_model_quality_failure_kind(kind: str | None) -> bool:
+    """Return whether a failure kind counts against the seat (model-quality), not infrastructure."""
+
+    return kind is not None and kind in MODEL_QUALITY_FAILURE_KINDS
+
+
+def failure_domain_for_legacy_kind(
+    normalized_kind: str | None,
+    failure_class: FailureClass,
+) -> FailureDomain:
+    """Map a legacy worker adapter kind to an outcome domain at read time."""
+
+    if is_model_quality_failure_kind(normalized_kind):
+        return FailureDomain.MODEL_OUTPUT
+    if failure_class == FailureClass.OUTPUT_CONTRACT_VIOLATION:
+        return FailureDomain.MODEL_OUTPUT
+    # #712: an adapter kind nobody mapped counts against the seat, not infrastructure. Kinds
+    # mapped to ``unclassified`` on purpose (the auth-status probe results) stay infrastructure,
+    # because they describe a probe Brigade could not run, not output the seat produced.
+    if failure_class == FailureClass.UNCLASSIFIED and normalized_kind not in LEGACY_FAILURE_KIND_MAP:
+        return FailureDomain.MODEL_OUTPUT
+    return FailureDomain.INFRASTRUCTURE
+
+
 def normalized_failure(
     *,
     failure_phase: str | None,
@@ -422,10 +476,12 @@ def normalized_failure(
     if normalized_kind is None and timed_out:
         failure_class = FailureClass.TIMEOUT
     else:
+        # #712: unknown adapter kinds count against the seat (model-output domain), not infrastructure.
         failure_class = LEGACY_FAILURE_KIND_MAP.get(normalized_kind or "", FailureClass.UNCLASSIFIED)
     spec = FAILURE_CLASS_SPECS[failure_class]
     legacy_phase = _LEGACY_PHASE_MAP.get((failure_phase or "").strip().lower(), FailurePhase.DISPATCH)
     phase = legacy_phase if legacy_phase in spec.phases else spec.default_phase
+    domain = failure_domain_for_legacy_kind(normalized_kind, failure_class)
     return WorkerFailure(
         failure_class=failure_class,
         phase=phase,
@@ -434,6 +490,7 @@ def normalized_failure(
         detail=detail,
         cause_code=normalized_kind,
         attempt=attempt,
+        domain=domain,
     )
 
 
@@ -483,16 +540,21 @@ def run_failure_is_infrastructure_at_read_time(kind: str | None, phase: str | No
 
     if kind is None:
         return None
-    if kind in RUN_MODEL_CONTRACT_FAILURE_KINDS:
+    if is_model_quality_failure_kind(kind):
         return False
     if kind in RUN_UNAMBIGUOUS_INFRASTRUCTURE_FAILURE_KINDS:
         return True
     if kind == "worker-failure":
         return None
     if _is_run_catch_all_failure_kind(kind):
+        # #710: explicit model phases stay negative; infrastructure phases neutralize; unknown fails closed.
+        if phase in RUN_MODEL_FAILURE_PHASES:
+            return False
         return phase in RUN_INFRASTRUCTURE_FAILURE_PHASES
     try:
-        FailureClass(kind)
+        failure_class = FailureClass(kind)
     except ValueError:
+        # #712: unrecognized run-level kinds count against the seat (same direction as worker level).
         return False
-    return True
+    # #708: only explicit infrastructure classes neutralize; no blanket FailureClass fallthrough.
+    return failure_class.value in RUN_LEVEL_INFRASTRUCTURE_FAILURE_CLASS_ALLOWLIST

--- a/tests/test_outcome.py
+++ b/tests/test_outcome.py
@@ -38,6 +38,13 @@ def test_signal_value_treats_weak_or_unknown_signals_as_neutral():
     assert outcome.signal_value("mystery", "whatever") == 0
 
 
+def test_run_capture_signal_value_distinguishes_infrastructure_from_model_quality():
+    """#707: only infrastructure-only failures neutralize; model-quality failures score negative."""
+
+    assert outcome.run_capture_signal_value("failed", infrastructure_only=False, verifier_failed=False) == -1
+    assert outcome.run_capture_signal_value("failed", infrastructure_only=True, verifier_failed=False) == 0
+
+
 def test_score_records_folds_counts_wilson_and_last_signal():
     records = [
         outcome.OutcomeRecord("skill-x", "skill", "t1", "verify", 1, "ref1", "2026-06-20T00:00:00+00:00"),

--- a/tests/test_outcome_infrastructure_attribution.py
+++ b/tests/test_outcome_infrastructure_attribution.py
@@ -12,6 +12,36 @@ from brigade import friction_cmd, localio, outcome, outcome_cmd, verify_trial, w
 
 from tests.test_outcome_cmd import _write_run_receipt, _write_verify_receipt
 
+# #708: only these FailureClass values may neutralize at run level; all others score negative.
+RUN_LEVEL_INFRASTRUCTURE_FAILURE_CLASS_ALLOWLIST = frozenset(
+    {
+        "configuration-invalid",
+        "executable-unavailable",
+        "auth-required",
+        "entitlement-denied",
+        "version-gate",
+        "model-unavailable",
+        "capacity-exhausted",
+        "network-unavailable",
+        "transport-unavailable",
+        "transport-hang",
+        "interactive-blocked",
+        "worker-crash",
+        "timeout",
+        "provider-rejected",
+    }
+)
+
+# #707: legacy adapter kinds that must map to model-output domain and score negative.
+MODEL_OUTPUT_LEGACY_KINDS = frozenset(
+    {
+        "empty-output",
+        "malformed-final-output",
+        "tool-only-output",
+        "non-final-output",
+    }
+)
+
 
 def _write_run_receipt_with_failure(
     target: Path,
@@ -86,6 +116,22 @@ def _write_worker_results(
     path = run_dir / "worker-results.json"
     localio.write_json(path, payload)
     return path
+
+
+def _legacy_model_output_worker(
+    *,
+    worker: str = "implementer",
+    failure_kind: str = "non-final-output",
+    failure_phase: str = "dispatch",
+) -> dict:
+    return {
+        "worker": worker,
+        "task": "fixture task",
+        "ok": False,
+        "detail": "model output contract violated",
+        "failure_kind": failure_kind,
+        "failure_phase": failure_phase,
+    }
 
 
 def _infra_worker(
@@ -268,6 +314,8 @@ def test_legacy_worker_result_maps_unknown_kind_at_read_time_without_mutation(tm
 
     assert failure is not None
     assert failure.failure_class.value == "unclassified"
+    # #712: unknown adapter kinds count against the seat at worker level (model-output domain).
+    assert failure.domain.value == "model-output"
     assert path.read_bytes() == original_bytes
 
 
@@ -389,7 +437,8 @@ def test_infra_run_ignores_unrelated_later_verify_receipt(tmp_path, capsys):
 def test_non_infrastructure_domain_is_not_neutralized(tmp_path, capsys):
     run_json = _write_run_receipt(tmp_path, run_id="product-failed", status="failed")
     worker = _infra_worker()
-    worker["failure"]["domain"] = "product"
+    # #707: model-output domain failures must not neutralize even when class is infrastructure-shaped.
+    worker["failure"]["domain"] = "model-output"
     worker["failure_kind"] = "timeout"
     worker["failure_phase"] = "dispatch"
     _write_worker_results(tmp_path, "product-failed", results=[worker])
@@ -572,6 +621,29 @@ def test_catch_all_with_missing_phase_stays_negative(tmp_path):
     assert payload["record"]["evidence_ref"] == str(run_json)
 
 
+@pytest.mark.parametrize("phase", [None, "dispatch", "artifact-collection"])
+def test_unexpected_error_one_verdict_regardless_of_phase(tmp_path, phase):
+    """#711: Brigade-internal unexpected-error must not flip verdict based on phase presence."""
+    run_id = f"unexpected-error-phase-{phase or 'none'}"
+    failure: dict = {"kind": "unexpected-error"}
+    if phase is not None:
+        failure["phase"] = phase
+    run_json = _write_run_receipt_with_failure(
+        tmp_path,
+        run_id,
+        status="failed",
+        failure=failure,
+    )
+    _write_worker_results(tmp_path, run_id, results=[_ok_worker()])
+
+    rc, payload = _capture_signal(tmp_path, run_id)
+
+    assert rc == 0
+    # #711: same neutral verdict as dispatch-phase receipts (cli/run.py failure_phase=None path).
+    assert payload["record"]["signal_value"] == 0
+    assert payload["record"]["evidence_ref"] == str(run_json)
+
+
 def test_catch_all_with_unknown_phase_stays_negative(tmp_path):
     run_json = _write_run_receipt_with_failure(
         tmp_path,
@@ -584,7 +656,8 @@ def test_catch_all_with_unknown_phase_stays_negative(tmp_path):
     rc, payload = _capture_signal(tmp_path, "unexpected-unknown-phase")
 
     assert rc == 0
-    assert payload["record"]["signal_value"] == -1
+    # #711: unexpected-error is infrastructure-neutral regardless of phase (was -1 via fail-closed).
+    assert payload["record"]["signal_value"] == 0
     assert payload["record"]["evidence_ref"] == str(run_json)
 
 
@@ -673,13 +746,20 @@ def test_catch_all_in_every_declared_model_phase_stays_negative(tmp_path, phase)
 
 @pytest.mark.parametrize("failure_class", list(worker_failure.FailureClass))
 def test_failure_class_kind_is_infrastructure_at_read_time(failure_class):
-    """Typed abort receipts write FailureClass values; all are infrastructure-neutral."""
+    """Typed abort receipts write FailureClass values; only #708 allowlist classes neutralize."""
 
-    assert worker_failure.run_failure_is_infrastructure_at_read_time(failure_class.value, "preflight") is True
+    if failure_class.value in RUN_LEVEL_INFRASTRUCTURE_FAILURE_CLASS_ALLOWLIST:
+        # #708: explicit infrastructure allowlist still neutralizes at run level.
+        expected = True
+    else:
+        # #708: output-contract-violation, unclassified, isolation-breach, and others score negative.
+        expected = False
+    assert worker_failure.run_failure_is_infrastructure_at_read_time(failure_class.value, "preflight") is expected
 
 
 def test_isolation_breach_failure_class_is_infrastructure_at_read_time():
-    assert worker_failure.run_failure_is_infrastructure_at_read_time("isolation-breach", "postflight") is True
+    # #708: isolation-breach is not on the infrastructure allowlist; must not neutralize.
+    assert worker_failure.run_failure_is_infrastructure_at_read_time("isolation-breach", "postflight") is False
 
 
 def test_model_contract_kind_wins_over_legacy_failure_class_map():
@@ -698,7 +778,8 @@ def test_catch_all_classifier_missing_phase_fails_closed():
 
 
 def test_catch_all_classifier_unknown_phase_fails_closed():
-    assert worker_failure.run_failure_is_infrastructure_at_read_time("unexpected-error", "artifact-collection") is False
+    # #711: unexpected-error is infrastructure-neutral even when phase is outside both phase sets.
+    assert worker_failure.run_failure_is_infrastructure_at_read_time("unexpected-error", "artifact-collection") is True
 
 
 def test_slice_b_typed_failure_class_run_receipt_is_neutral(tmp_path):
@@ -717,3 +798,295 @@ def test_slice_b_typed_failure_class_run_receipt_is_neutral(tmp_path):
     assert rc == 0
     assert payload["record"]["signal_value"] == 0
     assert payload["record"]["evidence_ref"] == str(run_json)
+
+
+@pytest.mark.parametrize("failure_kind", sorted(MODEL_OUTPUT_LEGACY_KINDS))
+def test_model_output_legacy_kinds_use_model_output_domain(failure_kind):
+    """#707: output-contract adapter kinds map to model-output domain at worker read time."""
+
+    failure = worker_failure.normalized_failure(
+        failure_phase="dispatch",
+        failure_kind=failure_kind,
+        detail="contract violated",
+    )
+
+    assert failure is not None
+    assert failure.failure_class == worker_failure.FailureClass.OUTPUT_CONTRACT_VIOLATION
+    assert failure.domain.value == "model-output"
+
+
+@pytest.mark.parametrize("failure_kind", sorted(MODEL_OUTPUT_LEGACY_KINDS))
+def test_model_output_legacy_kinds_score_negative_via_worker_results(tmp_path, failure_kind):
+    """#707: model-quality output failures count against the seat via worker-results path."""
+
+    run_id = f"model-output-{failure_kind}"
+    run_json = _write_run_receipt(
+        tmp_path,
+        run_id=run_id,
+        status="failed",
+    )
+    _write_worker_results(
+        tmp_path,
+        run_id,
+        results=[_legacy_model_output_worker(failure_kind=failure_kind)],
+    )
+
+    rc, payload = _capture_signal(tmp_path, run_id)
+
+    assert rc == 0
+    assert payload["record"]["signal_value"] == -1
+    assert payload["record"]["evidence_ref"] == str(run_json)
+
+
+def test_non_final_output_run_and_worker_paths_agree_negative(tmp_path):
+    """#709: non-final-output scores negative on both run-receipt and worker-results paths."""
+
+    run_id = "non-final-output-both-paths"
+    # Run-level receipt carries non-final-output directly (run path).
+    run_json_run_level = _write_run_receipt_with_failure(
+        tmp_path,
+        f"{run_id}-run-receipt",
+        status="failed",
+        failure={"kind": "non-final-output", "phase": "run-isolation"},
+    )
+    _write_worker_results(tmp_path, f"{run_id}-run-receipt", results=[_ok_worker()])
+
+    rc, payload = _capture_signal(tmp_path, f"{run_id}-run-receipt")
+
+    assert rc == 0
+    assert payload["record"]["signal_value"] == -1
+    assert payload["record"]["evidence_ref"] == str(run_json_run_level)
+
+    # Worker-results path: defer via worker-failure so capture consults failed workers.
+    run_json_worker_level = _write_run_receipt_with_failure(
+        tmp_path,
+        f"{run_id}-worker-results",
+        status="failed",
+        failure_kind="worker-failure",
+    )
+    _write_worker_results(
+        tmp_path,
+        f"{run_id}-worker-results",
+        results=[_legacy_model_output_worker(failure_kind="non-final-output")],
+    )
+
+    rc, payload = _capture_signal(tmp_path, f"{run_id}-worker-results")
+
+    assert rc == 0
+    # #709: worker-results path must match the run-receipt path.
+    assert payload["record"]["signal_value"] == -1
+    assert payload["record"]["evidence_ref"] == str(run_json_worker_level)
+
+
+@pytest.mark.parametrize("phase", [None, "dispatch", "artifact-collection"])
+def test_unexpected_error_classifier_one_verdict_regardless_of_phase(phase):
+    """#711: classify_run_failure_kind must not flip unexpected-error on phase presence."""
+
+    assert worker_failure.run_failure_is_infrastructure_at_read_time("unexpected-error", phase) is True
+
+
+def test_unknown_run_failure_kind_is_not_infrastructure_at_read_time():
+    """#712: unrecognized run-level kinds count against the seat (same direction as worker level)."""
+
+    assert worker_failure.run_failure_is_infrastructure_at_read_time("future-run-kind", "dispatch") is False
+
+
+def test_unknown_run_failure_kind_capture_scores_negative(tmp_path):
+    """#712: unknown run-level failure kinds must score negative at capture time."""
+
+    run_json = _write_run_receipt_with_failure(
+        tmp_path,
+        "unknown-run-kind",
+        status="failed",
+        failure={"kind": "future-run-kind", "phase": "dispatch"},
+    )
+    _write_worker_results(tmp_path, "unknown-run-kind", results=[_ok_worker()])
+
+    rc, payload = _capture_signal(tmp_path, "unknown-run-kind")
+
+    assert rc == 0
+    assert payload["record"]["signal_value"] == -1
+    assert payload["record"]["evidence_ref"] == str(run_json)
+
+
+def test_unknown_worker_kind_capture_scores_negative(tmp_path):
+    """#712: unknown worker adapter kinds must score negative (aligned with run-level default)."""
+
+    run_json = _write_run_receipt(tmp_path, run_id="unknown-worker-kind", status="failed")
+    _write_worker_results(
+        tmp_path,
+        "unknown-worker-kind",
+        results=[
+            {
+                "worker": "implementer",
+                "ok": False,
+                "detail": "mystery adapter failure",
+                "failure_phase": "dispatch",
+                "failure_kind": "future-adapter-code",
+            }
+        ],
+    )
+
+    rc, payload = _capture_signal(tmp_path, "unknown-worker-kind")
+
+    assert rc == 0
+    assert payload["record"]["signal_value"] == -1
+    assert payload["record"]["evidence_ref"] == str(run_json)
+
+
+def test_output_contract_violation_run_receipt_scores_negative(tmp_path):
+    """#708: output-contract-violation is not on the infrastructure allowlist."""
+
+    run_json = _write_run_receipt_with_failure(
+        tmp_path,
+        "ocv-run-receipt",
+        status="failed",
+        failure={"kind": "output-contract-violation", "phase": "validation"},
+    )
+    _write_worker_results(tmp_path, "ocv-run-receipt", results=[_ok_worker()])
+
+    rc, payload = _capture_signal(tmp_path, "ocv-run-receipt")
+
+    assert rc == 0
+    assert payload["record"]["signal_value"] == -1
+    assert payload["record"]["evidence_ref"] == str(run_json)
+
+
+def test_suspected_noop_run_worker_kind_scores_negative(tmp_path):
+    """#703: suspected no-op seats must score negative in the model-quality domain."""
+
+    run_json = _write_run_receipt(
+        tmp_path,
+        run_id="suspected-noop-run",
+        status="failed",
+    )
+    _write_worker_results(
+        tmp_path,
+        "suspected-noop-run",
+        results=[
+            {
+                "worker": "implementer",
+                "task": "fixture task",
+                "ok": False,
+                "detail": "ok worker produced no non-.brigade file changes",
+                "failure_kind": "suspected-noop-run",
+                "failure_phase": "dispatch",
+            }
+        ],
+    )
+
+    failure = outcome_cmd.worker_result_failure(
+        {
+            "worker": "implementer",
+            "ok": False,
+            "detail": "ok worker produced no non-.brigade file changes",
+            "failure_kind": "suspected-noop-run",
+            "failure_phase": "dispatch",
+        }
+    )
+    assert failure is not None
+    assert failure.failure_class == worker_failure.FailureClass.OUTPUT_CONTRACT_VIOLATION
+    # #703 depends on #707 model-output domain for negative capture scoring.
+    assert failure.domain.value == "model-output"
+
+    rc, payload = _capture_signal(tmp_path, "suspected-noop-run")
+
+    assert rc == 0
+    assert payload["record"]["signal_value"] == -1
+    assert payload["record"]["evidence_ref"] == str(run_json)
+
+
+def test_timeout_failure_class_on_allowlist_still_neutralizes(tmp_path):
+    """#708: allowlisted infrastructure classes (timeout) still neutralize at capture time."""
+
+    run_json = _write_run_receipt_with_failure(
+        tmp_path,
+        "timeout-allowlist",
+        status="failed",
+        failure={"kind": "timeout", "phase": "dispatch"},
+    )
+    _write_worker_results(tmp_path, "timeout-allowlist", results=[_ok_worker()])
+
+    rc, payload = _capture_signal(tmp_path, "timeout-allowlist")
+
+    assert rc == 0
+    assert payload["record"]["signal_value"] == 0
+    assert payload["record"]["evidence_ref"] == str(run_json)
+
+
+@pytest.mark.parametrize("failure_kind", ["auth-status-unavailable", "auth-status-unrecognized"])
+def test_deliberately_unclassified_probe_kinds_stay_infrastructure(tmp_path, failure_kind):
+    """#712 boundary: kinds mapped to unclassified on purpose are probe failures, not seat output.
+
+    Only kinds absent from LEGACY_FAILURE_KIND_MAP count against the seat.
+    """
+
+    failure = outcome_cmd.worker_result_failure(
+        {
+            "worker": "implementer",
+            "ok": False,
+            "detail": "auth status probe did not report",
+            "failure_kind": failure_kind,
+            "failure_phase": "preflight",
+        }
+    )
+    assert failure is not None
+    assert failure.failure_class == worker_failure.FailureClass.UNCLASSIFIED
+    assert failure.domain.value == "infrastructure"
+
+    run_json = _write_run_receipt(tmp_path, run_id=f"probe-{failure_kind}", status="failed")
+    _write_worker_results(
+        tmp_path,
+        f"probe-{failure_kind}",
+        results=[
+            {
+                "worker": "implementer",
+                "task": "fixture task",
+                "ok": False,
+                "detail": "auth status probe did not report",
+                "failure_kind": failure_kind,
+                "failure_phase": "preflight",
+            }
+        ],
+    )
+
+    rc, payload = _capture_signal(tmp_path, f"probe-{failure_kind}")
+
+    assert rc == 0
+    assert payload["record"]["signal_value"] == 0
+    assert payload["record"]["evidence_ref"] == str(run_json)
+
+
+def _write_noop_run_receipt(target: Path, run_id: str, *, status: str = "ok", **flags) -> Path:
+    run_json = _write_run_receipt(target, run_id=run_id, status=status, **flags)
+    receipt = localio.read_json_dict(run_json) or {}
+    receipt["suspected_noop"] = True
+    localio.write_json(run_json, receipt)
+    return run_json
+
+
+def test_suspected_noop_ok_run_receipt_scores_negative(tmp_path):
+    """#703: an ok run whose seats shipped no deliverable scores against the seat, not +1."""
+
+    run_json = _write_noop_run_receipt(tmp_path, "noop-ok-run")
+    _write_worker_results(tmp_path, "noop-ok-run", results=[_ok_worker()])
+
+    rc, payload = _capture_signal(tmp_path, "noop-ok-run")
+
+    assert rc == 0
+    assert payload["record"]["signal_value"] == -1
+    assert payload["record"]["evidence_ref"] == str(run_json)
+
+
+@pytest.mark.parametrize("flags", [{"dry_run": True}, {"read_only": True}])
+def test_suspected_noop_dry_and_read_only_runs_stay_neutral(tmp_path, flags):
+    """#703: runs that are expected to change nothing keep their existing neutral verdict."""
+
+    run_id = "noop-" + "-".join(sorted(flags))
+    _write_noop_run_receipt(tmp_path, run_id, **flags)
+    _write_worker_results(tmp_path, run_id, results=[_ok_worker()])
+
+    rc, payload = _capture_signal(tmp_path, run_id)
+
+    assert rc == 0
+    assert payload["record"]["signal_value"] == 0

--- a/tests/test_run_transport_recovery.py
+++ b/tests/test_run_transport_recovery.py
@@ -54,7 +54,8 @@ def test_worker_payload_serializes_required_attempt_fields_with_null_exit_code()
         "failure": {
             "schema": "brigade.worker_failure.v1",
             "class": "output-contract-violation",
-            "domain": "infrastructure",
+            # #707: malformed-final-output is model output, so it no longer neutralizes.
+            "domain": "model-output",
             "phase": "validation",
             "retry": "never",
             "detected_by": "legacy-failure-kind",

--- a/tests/test_worker_failure.py
+++ b/tests/test_worker_failure.py
@@ -62,6 +62,8 @@ EXPECTED_LEGACY_CLASSIFICATIONS = {
     "rate-limit-error": FailureClass.CAPACITY_EXHAUSTED,
     "timeout": FailureClass.TIMEOUT,
     "tool-only-output": FailureClass.OUTPUT_CONTRACT_VIOLATION,
+    # #703: a seat that calls no tools and ships no deliverable is a model-quality failure.
+    "suspected-noop-run": FailureClass.OUTPUT_CONTRACT_VIOLATION,
     "transport-error": FailureClass.TRANSPORT_UNAVAILABLE,
     "unsafe-worktree": FailureClass.CONFIGURATION_INVALID,
     "unsupported-command-shim": FailureClass.EXECUTABLE_UNAVAILABLE,


### PR DESCRIPTION
Fixes #703, fixes #707, fixes #708, fixes #709, fixes #710, fixes #711, fixes #712, fixes #713.

Closes the outcome-scoring reconciliation gaps as one coherent change (the issues interlock in worker_failure.py):

- `FailureDomain` gains `MODEL_OUTPUT`; empty-output, malformed-final-output, tool-only-output, and non-final-output route there and score negative instead of neutralizing (#707).
- The blanket `FailureClass(kind) -> infrastructure` fallthrough becomes an explicit allowlist (#708), and `RUN_MODEL_FAILURE_PHASES` is consumed by the classifier instead of sitting dead (#709).
- non-final-output gets the same negative verdict on the run and worker-results paths (#710); unexpected-error scores one verdict regardless of phase (#711); unknown kinds fail closed to negative on both levels (#712).
- suspected-no-op becomes a model-quality failure kind that scores negative (#703) - a seat that calls no tools and returns no answer is a failed seat.
- `docs/outcome-scoring.md` documents read-time re-scoring with the kind-to-verdict table (#713).

**Re-scoring safety, measured not argued**: scores recompute from stored receipts at read time, so this PR re-scores history. An old-vs-new verdict census over the 46 failed receipts in the operator corpus shows **zero run-level verdict changes** - every historical unexpected-error record carries phase `startup` (neutral under both versions) and non-final-output was already negative at run level. The behavioral deltas live on the worker-results path and are pinned by the ~20 new tests.

Gate: `./scripts/verify` green in the lane worktree (5946 passed; Brigade receipts captured in-run by the workers and post-commit by the orchestrator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)