### PR TITLE
feat(release): verify the version-check endpoint after publish and warn on unreleased version bumps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -386,6 +386,10 @@ jobs:
         run: python -m build
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+      - name: Verify check.brigade.tools reports the published version
+        env:
+          EXPECTED_VERSION: ${{ github.ref_name }}
+        run: python scripts/verify_version_check_endpoint.py --expected-version "${EXPECTED_VERSION#v}"
 
   published-artifact-acceptance:
     name: published-artifact-acceptance (${{ matrix.platform }})

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ Thumbs.db
 !/scripts/windows-native-acceptance.ps1
 !/scripts/published-artifact-acceptance.py
 !/scripts/generate_component_manifest.py
+!/scripts/verify_version_check_endpoint.py
 !/scripts/hyper-v-native-acceptance.ps1
 /skills/
 

--- a/scripts/verify_version_check_endpoint.py
+++ b/scripts/verify_version_check_endpoint.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Verify the public version-check endpoint reports the just-published release.
+
+The publish workflow has no credentials to update the endpoint, so this check
+is verify-only: a mismatch fails the job with instructions to update the
+endpoint and rerun. Without it the endpoint drifts silently and update
+discovery lags every release (issue #702; on 2026-08-04 it still reported
+0.25.0 while a 0.25.1 version number existed in pyproject with no release).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.request
+
+ENDPOINT = "https://check.brigade.tools/v1/version"
+
+
+def fetch_latest(timeout: float = 10.0) -> str:
+    # A bare urllib User-Agent gets a 403 from the endpoint's edge.
+    request = urllib.request.Request(
+        ENDPOINT,
+        headers={"User-Agent": "brigade-publish-verify/1.0"},
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    latest = payload.get("latest") if isinstance(payload, dict) else None
+    if not isinstance(latest, str) or not latest:
+        raise ValueError(f"endpoint payload has no usable 'latest': {payload!r}")
+    return latest
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--expected-version",
+        required=True,
+        help="version the endpoint must report (without the leading v)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        latest = fetch_latest()
+    except Exception as error:  # noqa: BLE001 - any fetch failure fails the gate loudly
+        print(f"::error::version check endpoint fetch failed: {error}")
+        return 1
+
+    if latest == args.expected_version:
+        print(f"version check endpoint reports {latest}: ok")
+        return 0
+
+    print(
+        f"::error::{ENDPOINT} reports latest={latest!r} but this release is "
+        f"{args.expected_version!r}. Update the endpoint to the new version, "
+        "then rerun this job so update discovery does not lag the release."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/brigade/release_cmd/evidence.py
+++ b/src/brigade/release_cmd/evidence.py
@@ -38,6 +38,7 @@ from ..localio import (
 )
 
 from . import paths as _family_base
+from .version_guard import version_tag_check
 
 globals().update({name: value for name, value in vars(_family_base).items() if not name.startswith("__")})
 
@@ -650,6 +651,7 @@ def _payload(target: Path, *, base_ref: str | None, run_checks: bool, policy: st
         checks.append(_run_content_guard_check(target, name="tip", policy=policy, base_ref=base_ref))
         if base_ref:
             checks.append(_run_content_guard_check(target, name="introduced", policy=policy, base_ref=base_ref))
+        checks.append(version_tag_check(target))
     elif not _content_guard_available(target):
         checks.append(
             {"name": "content_guard", "status": WARN, "detail": "content-guard not available", "available": False}

--- a/src/brigade/release_cmd/version_guard.py
+++ b/src/brigade/release_cmd/version_guard.py
@@ -1,0 +1,64 @@
+"""Release doctor checks for declared version vs git tag alignment."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from .. import toml_compat
+from .paths import OK, WARN, _git
+
+VERSION_TAG_CHECK_NAME = "declared_version_without_git_tag"
+VERSION_TAG_CHECK_DESCRIPTION = (
+    "Warn when pyproject.toml version has no matching vX.Y.Z git tag (unreleased version bump)."
+)
+
+
+def declared_project_version(target: Path) -> str | None:
+    pyproject = target / "pyproject.toml"
+    if not pyproject.is_file():
+        return None
+    try:
+        data = toml_compat.loads(pyproject.read_text())
+    except Exception:
+        return None
+    project = data.get("project")
+    if not isinstance(project, dict):
+        return None
+    version = project.get("version")
+    return version if isinstance(version, str) and version.strip() else None
+
+
+def git_tag_exists(target: Path, tag: str) -> bool:
+    return _git(target, "rev-parse", "-q", "--verify", f"refs/tags/{tag}^{{commit}}").returncode == 0
+
+
+def version_tag_check(
+    target: Path,
+    *,
+    tag_exists: Callable[[Path, str], bool] | None = None,
+) -> dict[str, Any]:
+    lookup = tag_exists or git_tag_exists
+    version = declared_project_version(target)
+    if version is None:
+        return {
+            "name": VERSION_TAG_CHECK_NAME,
+            "status": WARN,
+            "detail": "could not read project.version from pyproject.toml",
+            "description": VERSION_TAG_CHECK_DESCRIPTION,
+        }
+    tag = f"v{version}"
+    if lookup(target, tag):
+        return {
+            "name": VERSION_TAG_CHECK_NAME,
+            "status": OK,
+            "detail": f"{tag} exists",
+            "description": VERSION_TAG_CHECK_DESCRIPTION,
+        }
+    return {
+        "name": VERSION_TAG_CHECK_NAME,
+        "status": WARN,
+        "detail": f"pyproject.toml declares {version} but {tag} is missing",
+        "description": VERSION_TAG_CHECK_DESCRIPTION,
+    }

--- a/tests/test_publish_workflow.py
+++ b/tests/test_publish_workflow.py
@@ -1,5 +1,6 @@
 from pathlib import Path
-
+import subprocess
+import sys
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -215,3 +216,36 @@ def test_publish_release_gate_requires_27_release_assets():
     text = (ROOT / ".github" / "workflows" / "publish.yml").read_text()
     gate = text[text.index("  release-asset-gate:") : text.index("  build-and-publish:")]
     assert 'test "$(find release-assets -maxdepth 1 -type f | wc -l)" -eq 27' in gate
+
+
+def _load_workflow_yaml(path: Path):
+    try:
+        import yaml
+    except ImportError:
+        subprocess.check_call(
+            [sys.executable, "-m", "pip", "install", "pyyaml", "-q"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        import yaml
+    return yaml.safe_load(path.read_text())
+
+
+def test_publish_workflow_yaml_is_valid():
+    _load_workflow_yaml(ROOT / ".github" / "workflows" / "publish.yml")
+
+
+def test_publish_workflow_verifies_version_check_endpoint_after_pypi_upload():
+    text = (ROOT / ".github" / "workflows" / "publish.yml").read_text()
+    publish = text.index("      - name: Publish to PyPI")
+    verify = text.index("      - name: Verify check.brigade.tools reports the published version")
+    acceptance = text.index("  published-artifact-acceptance:")
+
+    assert publish < verify < acceptance
+    section = text[verify : text.index("  published-artifact-acceptance:")]
+    assert "scripts/verify_version_check_endpoint.py" in section
+    assert "EXPECTED_VERSION: ${{ github.ref_name }}" in section
+    assert '--expected-version "${EXPECTED_VERSION#v}"' in section
+    assert "https://check.brigade.tools/v1/version" in (
+        ROOT / "scripts" / "verify_version_check_endpoint.py"
+    ).read_text()

--- a/tests/test_publish_workflow.py
+++ b/tests/test_publish_workflow.py
@@ -246,6 +246,6 @@ def test_publish_workflow_verifies_version_check_endpoint_after_pypi_upload():
     assert "scripts/verify_version_check_endpoint.py" in section
     assert "EXPECTED_VERSION: ${{ github.ref_name }}" in section
     assert '--expected-version "${EXPECTED_VERSION#v}"' in section
-    assert "https://check.brigade.tools/v1/version" in (
-        ROOT / "scripts" / "verify_version_check_endpoint.py"
-    ).read_text()
+    assert (
+        "https://check.brigade.tools/v1/version" in (ROOT / "scripts" / "verify_version_check_endpoint.py").read_text()
+    )

--- a/tests/test_release_version_guard.py
+++ b/tests/test_release_version_guard.py
@@ -1,0 +1,89 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+from brigade import release_cmd
+from brigade.release_cmd import version_guard
+
+
+def _write_pyproject(root: Path, version: str) -> None:
+    (root / "pyproject.toml").write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "demo"',
+                f'version = "{version}"',
+            ]
+        )
+        + "\n"
+    )
+
+
+def test_version_tag_check_ok_when_matching_tag_exists(tmp_path):
+    _write_pyproject(tmp_path, "1.2.3")
+
+    check = version_guard.version_tag_check(
+        tmp_path,
+        tag_exists=lambda _target, tag: tag == "v1.2.3",
+    )
+
+    assert check["name"] == version_guard.VERSION_TAG_CHECK_NAME
+    assert check["status"] == version_guard.OK
+    assert check["description"] == version_guard.VERSION_TAG_CHECK_DESCRIPTION
+    assert check["detail"] == "v1.2.3 exists"
+
+
+def test_version_tag_check_warns_when_declared_version_has_no_tag(tmp_path):
+    _write_pyproject(tmp_path, "0.25.1")
+
+    check = version_guard.version_tag_check(tmp_path, tag_exists=lambda _target, _tag: False)
+
+    assert check["status"] == version_guard.WARN
+    assert "0.25.1" in check["detail"]
+    assert "v0.25.1 is missing" in check["detail"]
+    assert check["description"] == version_guard.VERSION_TAG_CHECK_DESCRIPTION
+
+
+def test_version_tag_check_warns_when_pyproject_version_missing(tmp_path):
+    check = version_guard.version_tag_check(tmp_path, tag_exists=lambda _target, _tag: True)
+
+    assert check["status"] == version_guard.WARN
+    assert "could not read project.version" in check["detail"]
+
+
+def test_release_doctor_surfaces_version_tag_warning(tmp_path, monkeypatch, capsys):
+    _write_pyproject(tmp_path, "9.9.9")
+    monkeypatch.setattr(version_guard, "git_tag_exists", lambda _target, _tag: False)
+    monkeypatch.setattr(release_cmd, "version_tag_check", version_guard.version_tag_check)
+    monkeypatch.setattr(
+        release_cmd,
+        "_run_content_guard_check",
+        lambda *_args, **_kwargs: {
+            "name": "content_guard_tip",
+            "status": release_cmd.OK,
+            "detail": "clean",
+            "available": True,
+        },
+    )
+    monkeypatch.setattr(release_cmd, "_content_guard_available", lambda _target: True)
+
+    rc = release_cmd.doctor(target=tmp_path, base_ref=None, json_output=True)
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 1
+    matching = [item for item in payload["checks"] if item["name"] == version_guard.VERSION_TAG_CHECK_NAME]
+    assert len(matching) == 1
+    assert matching[0]["status"] == version_guard.WARN
+    assert any(version_guard.VERSION_TAG_CHECK_NAME in warning for warning in payload["warnings"])
+
+
+def test_git_tag_exists_uses_git_rev_parse(tmp_path, monkeypatch):
+    calls: list[list[str]] = []
+
+    def fake_git(target, *args):
+        calls.append(list(args))
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(version_guard, "_git", fake_git)
+    assert version_guard.git_tag_exists(tmp_path, "v1.0.0") is True
+    assert calls == [["rev-parse", "-q", "--verify", "refs/tags/v1.0.0^{commit}"]]


### PR DESCRIPTION
Fixes #702.

Two guards against the failure modes found in the 0.26.0 readiness assessment:

1. **publish.yml gains a post-publish verify step**: after the PyPI upload, `scripts/verify_version_check_endpoint.py` fetches https://check.brigade.tools/v1/version and fails the job with an update-and-rerun message when `latest` does not match the just-published tag. Verify-only by design - the workflow holds no endpoint credentials, so drift is loud instead of silent. Smoke-tested live in both directions (matching version exits 0, mismatched exits 1).
2. **release doctor warns on version-bump-without-release**: new WARN check `declared_version_without_git_tag` fires when pyproject's version has no matching `vX.Y.Z` tag - the 0.25.1 case, where a version number existed in pyproject for weeks with no PyPI release behind it. WARN not FAIL, since dev trees legitimately carry unreleased bumps mid-cycle.

Gate: `./scripts/verify` green in the lane worktree (Brigade receipt, reused_from null). Not executable locally: the real publish path (tag push, native matrix, PyPI environment); the workflow step itself runs first on the 0.26.0 tag.

Provenance note: the endpoint script was recreated by the orchestrator after the worker's original fell to the repo's `/scripts/*` gitignore rule during patch capture; `.gitignore` now carries the explicit exception, matching the convention used by every other tracked script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)