### PR TITLE
fix(cli): print the start-here block on bare invocation

### DIFF
--- a/src/brigade/cli/__init__.py
+++ b/src/brigade/cli/__init__.py
@@ -219,6 +219,8 @@ def main(argv=None) -> int:
     raw_argv = list(sys.argv[1:] if argv is None else argv)
     parse_argv, engine_args = _peel_passthrough_engine_args(raw_argv)
     parser = _build_parser()
+    if not parse_argv:
+        print(_START_HERE, file=sys.stderr)
     args = parser.parse_args(parse_argv)
     if engine_args is not None:
         args.engine_args = engine_args

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -30,6 +30,17 @@ def test_top_level_help_lists_all_commands_and_group_titles():
         assert name in help_text
 
 
+def test_bare_invocation_prints_start_here_then_usage_error(capsys):
+    with pytest.raises(SystemExit) as exc:
+        cli.main([])
+    assert exc.value.code == 2
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "Start here:" in combined
+    assert "operator quickstart" in combined
+    assert "the following arguments are required" in combined
+
+
 def test_top_level_help_has_start_here_block():
     parser = cli._build_parser()
     help_text = parser.format_help()


### PR DESCRIPTION
Fixes #714.

A bare `brigade` printed only `the following arguments are required: <command>` - a first-contact dead end verified on a clean install during the 0.26.0 readiness assessment. Now the existing `_START_HERE` block prints to stderr before argparse exits 2, so the very first thing a new user or agent sees names the quickstart command. Pinned by test.

Gate: full `./scripts/verify` green in the lane worktree (Brigade receipt).

Provenance: the change was authored by a t3-fleet session on a fleet host that completed the edit and then hung in its verification step for 12 hours; the diff was salvaged from its worktree, re-gated locally, and committed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)