### PR TITLE
docs(security): reword the runtime-value docstring so the scanner does not flag its own example

### DIFF
--- a/src/brigade/security_cmd/models.py
+++ b/src/brigade/security_cmd/models.py
@@ -207,9 +207,10 @@ def _is_runtime_secret_value(value: str) -> bool:
     """True when the assigned value is generated or read at runtime instead of committed.
 
     Quotes are deliberately not stripped here. A quoted value is a committed literal even
-    when its text opens with a runtime expression, so ``api_key = "os.environ.sk-live-..."``
-    must stay reportable. Callers that can still see the source line decide whether the
-    value was quoted; see :func:`_match_value_is_quoted`.
+    when its text opens with a runtime expression: a string literal whose contents begin
+    with ``os.environ.`` followed by key material must stay reportable. Callers that can
+    still see the source line decide whether the value was quoted; see
+    :func:`_match_value_is_quoted`.
     """
     return RUNTIME_SECRET_VALUE_RE.match(value.strip()) is not None
 


### PR DESCRIPTION
The quoted-prefix explanation in `_is_runtime_secret_value` (added in #701) used a literal `api_key` assignment as its example, which SECRET_VALUE_RE matches - so the release doctor blocked on the scanner reading its own documentation. Describes the case in prose instead.

Gate: full `./scripts/verify` green in the lane worktree (Brigade receipt). Scoped rescan with the repo's security config confirms zero high findings in `src/brigade` after the reword; the sk-live and JWT canaries in the test suite still assert detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)