### PR TITLE
feat(center): add a read-only local dashboard server with a security floor

### DIFF
--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -17,7 +17,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 
 - `brigade add`: 1 command path(s)
 - `brigade budgets` (extras): 2 command path(s)
-- `brigade center` (extras): 29 command path(s)
+- `brigade center` (extras): 30 command path(s)
 - `brigade chat` (extras): 7 command path(s)
 - `brigade code`: 16 command path(s)
 - `brigade completions`: 1 command path(s)
@@ -104,6 +104,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade center report show` (extras)
 - `brigade center reviews` (extras)
 - `brigade center schema` (extras)
+- `brigade center serve` (extras)
 - `brigade center status` (extras)
 - `brigade center templates` (extras)
 - `brigade chat surfaces doctor` (extras)

--- a/src/brigade/center_cmd/__init__.py
+++ b/src/brigade/center_cmd/__init__.py
@@ -15,6 +15,7 @@ _MODULE_NAMES = (
     "reports",
     "report_review",
     "actions",
+    "serve",
 )
 _MODULE_ALIASES = {
     "schema": "schema_ops",
@@ -89,6 +90,7 @@ _module_readiness = importlib.import_module(f"{__name__}.readiness")
 _module_reports = importlib.import_module(f"{__name__}.reports")
 _module_report_review = _facade_module("report_review")
 _module_actions = importlib.import_module(f"{__name__}.actions")
+_module_serve = importlib.import_module(f"{__name__}.serve")
 
 from .schema_ops import *
 from .core import *
@@ -96,6 +98,7 @@ from .readiness import *
 from .reports import *
 from .report_review_ops import *
 from .actions import *
+from .serve import *
 
 _MODULES = (
     _module_schema,
@@ -104,6 +107,7 @@ _MODULES = (
     _module_reports,
     _module_report_review,
     _module_actions,
+    _module_serve,
 )
 
 

--- a/src/brigade/center_cmd/serve.py
+++ b/src/brigade/center_cmd/serve.py
@@ -1,0 +1,312 @@
+"""Local operator dashboard server skeleton."""
+
+from __future__ import annotations
+
+import hmac
+import html
+import ipaddress
+import secrets
+import socket
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Sequence
+
+_DEFAULT_PORT = 8765
+
+_INDEX_TEMPLATE = """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{title}</title>
+<style nonce="{nonce}">
+body {{
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  line-height: 1.5;
+  margin: 2rem;
+  color: #111;
+  background: #fff;
+}}
+h1 {{
+  font-size: 1.5rem;
+  color: #0066cc;
+}}
+button {{
+  background: #0066cc;
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 0.25rem;
+  cursor: pointer;
+}}
+</style>
+</head>
+<body>
+<h1>{title}</h1>
+<p>Dashboard views will land in a follow-up.</p>
+<button type="button" data-action="demo">Show greeting</button>
+<script nonce="{nonce}">
+document.addEventListener("DOMContentLoaded", function() {{
+  document.body.addEventListener("click", function(e) {{
+    var target = e.target.closest('[data-action="demo"]');
+    if (!target) return;
+    target.textContent = "Hello from the dashboard skeleton";
+  }});
+}});
+</script>
+</body>
+</html>
+"""
+
+
+def _has_port(host: str) -> bool:
+    """Return True if a Host header value carries an explicit ``:port``."""
+    if host.startswith("["):
+        return "]:" in host
+    return host.count(":") == 1
+
+
+def _is_loopback(host: str) -> bool:
+    """Return True if *host* resolves only to loopback addresses."""
+    lowered = host.strip().lower()
+    if lowered == "localhost":
+        return True
+    try:
+        addr = ipaddress.ip_address(lowered)
+        return addr.is_loopback
+    except ValueError:
+        pass
+    try:
+        infos = socket.getaddrinfo(lowered, None, type=socket.SOCK_STREAM)
+    except socket.gaierror:
+        return False
+    if not infos:
+        return False
+    for family, _, _, _, sockaddr in infos:
+        ip_str = sockaddr[0]
+        if family == socket.AF_INET6 and "%" in ip_str:
+            ip_str = ip_str.split("%", 1)[0]
+        try:
+            addr = ipaddress.ip_address(ip_str)
+        except ValueError:
+            return False
+        if not addr.is_loopback:
+            return False
+    return True
+
+
+def validate_bind_security(
+    host: str,
+    token: str | None,
+    allowed_hosts: Sequence[str] | None,
+) -> None:
+    """Refuse to bind to a non-loopback address without a token and allowed hosts."""
+    if _is_loopback(host):
+        return
+    if not token:
+        raise ValueError(
+            f"Refusing to bind to non-loopback host {host!r}: set --token and one or more --allowed-host values."
+        )
+    if not allowed_hosts:
+        raise ValueError(
+            f"Refusing to bind to non-loopback host {host!r}: --allowed-host is required when a token is set."
+        )
+
+
+class _DashboardHandler(BaseHTTPRequestHandler):
+    _token: str | None = None
+    _allowed_exact: set[str] = set()
+    _allowed_bare: set[str] = set()
+
+    def _write_response(
+        self,
+        status: int,
+        body: bytes | str = b"",
+        content_type: str = "text/plain; charset=utf-8",
+        nonce: str | None = None,
+    ) -> None:
+        if nonce is None:
+            nonce = secrets.token_urlsafe(16)
+        csp = (
+            f"default-src 'none'; "
+            f"script-src 'nonce-{nonce}'; "
+            "script-src-attr 'none'; "
+            f"style-src 'nonce-{nonce}'; "
+            "img-src 'none'; "
+            "connect-src 'self'; "
+            "base-uri 'none'; "
+            "form-action 'none'; "
+            "frame-ancestors 'none'"
+        )
+        data = body.encode("utf-8") if isinstance(body, str) else body
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Security-Policy", csp)
+        self.send_header("X-Content-Type-Options", "nosniff")
+        self.send_header("Referrer-Policy", "no-referrer")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(data)
+
+    def _guard(self) -> bool:
+        host_header = self.headers.get("Host")
+        if host_header is None:
+            self._write_response(403, "Forbidden: missing Host header.\n")
+            return False
+        host = host_header.strip().lower()
+        host_bare = host.rsplit(":", 1)[0] if _has_port(host) else host
+        if host not in self._allowed_exact and host_bare not in self._allowed_bare:
+            self._write_response(403, "Forbidden: invalid Host header.\n")
+            return False
+        if self._token is not None:
+            auth = self.headers.get("Authorization", "")
+            if not auth.startswith("Bearer "):
+                self._write_response(401, "Unauthorized.\n")
+                return False
+            presented = auth[7:].encode("utf-8", "surrogatepass")
+            expected = self._token.encode("utf-8", "surrogatepass")
+            if not hmac.compare_digest(presented, expected):
+                self._write_response(401, "Unauthorized.\n")
+                return False
+        return True
+
+    def handle_one_request(self) -> None:
+        """Parse one request, then guard it before any handler can run.
+
+        The Host allowlist and bearer check live here rather than in each
+        ``do_*`` method so that no verb - including ones this class does not
+        implement, like OPTIONS or TRACE - can reach a response path that
+        skips them or that omits the security headers.
+        """
+        try:
+            self.raw_requestline = self.rfile.readline(65537)
+            if len(self.raw_requestline) > 65536:
+                self.requestline = ""
+                self.request_version = ""
+                self.command = ""
+                self.send_error(414)
+                return
+            if not self.raw_requestline:
+                self.close_connection = True
+                return
+            if not self.parse_request():
+                return
+            if not self._guard():
+                self.wfile.flush()
+                return
+            handler_name = f"do_{self.command}"
+            handler = getattr(self, handler_name, None)
+            if handler is None:
+                self._write_response(405, "Method not allowed.\n")
+                self.wfile.flush()
+                return
+            handler()
+            self.wfile.flush()
+        except TimeoutError as exc:
+            self.log_error("Request timed out: %r", exc)
+            self.close_connection = True
+
+    def _render_index(self, nonce: str) -> bytes:
+        title = html.escape("Brigade Center", quote=True)
+        nonce_escaped = html.escape(nonce, quote=True)
+        page = _INDEX_TEMPLATE.format(title=title, nonce=nonce_escaped)
+        return page.encode("utf-8")
+
+    def do_GET(self) -> None:
+        if self.path != "/":
+            self._write_response(404, "Not found.\n")
+            return
+        nonce = secrets.token_urlsafe(16)
+        body = self._render_index(nonce)
+        self._write_response(200, body, "text/html; charset=utf-8", nonce)
+
+    def do_HEAD(self) -> None:
+        if self.path != "/":
+            self._write_response(404, b"")
+            return
+        self._write_response(200, b"", "text/html; charset=utf-8")
+
+    def log_message(self, format: str, *args: object) -> None:
+        pass
+
+
+def _make_server(
+    *,
+    host: str = "127.0.0.1",
+    port: int = _DEFAULT_PORT,
+    token: str | None = None,
+    allowed_hosts: Sequence[str] | None = None,
+) -> ThreadingHTTPServer:
+    """Build and bind the server without starting it."""
+    validate_bind_security(host, token, allowed_hosts)
+
+    allowed_exact: set[str] = set()
+    allowed_bare: set[str] = set()
+    for value in allowed_hosts or []:
+        value_lc = value.strip().lower()
+        if _has_port(value_lc):
+            allowed_exact.add(value_lc)
+        else:
+            # An operator-supplied name with no port matches any port, which is
+            # what a reverse-proxied deployment needs.
+            allowed_bare.add(value_lc)
+
+    class _BoundHandler(_DashboardHandler):
+        _token = token
+
+    host_lc = host.strip().lower()
+    server = ThreadingHTTPServer((host, port), _BoundHandler)
+    server.daemon_threads = True
+    actual_host, actual_port = server.server_address[0], server.server_address[1]
+    actual_host_lc = str(actual_host).lower()
+
+    # Names the operator can legitimately type for THIS bind. Each is pinned to
+    # the bound port: a bare entry would let `Host: 127.0.0.1:1` through, and the
+    # bound address is not something an attacker can point a DNS name at.
+    names = {host_lc, actual_host_lc}
+    if _is_loopback(actual_host_lc):
+        names |= {"127.0.0.1", "localhost", "[::1]", "::1"}
+    for name in names:
+        allowed_exact.add(f"{name}:{actual_port}")
+        if actual_port == 80:
+            allowed_bare.add(name)
+
+    _BoundHandler._allowed_exact = allowed_exact
+    _BoundHandler._allowed_bare = allowed_bare
+    return server
+
+
+def serve(
+    *,
+    target: Path,
+    host: str = "127.0.0.1",
+    port: int = _DEFAULT_PORT,
+    token: str | None = None,
+    allowed_hosts: Sequence[str] | None = None,
+) -> int:
+    """Start the local operator dashboard server.
+
+    Prints the bound URL and runs until interrupted, then returns 0.
+    """
+    try:
+        server = _make_server(host=host, port=port, token=token, allowed_hosts=allowed_hosts)
+    except ValueError as exc:
+        print(f"brigade center serve: {exc}", file=sys.stderr)
+        return 2
+    except OSError as exc:
+        print(f"brigade center serve: cannot bind {host}:{port}: {exc}", file=sys.stderr)
+        return 2
+
+    actual_host, actual_port = server.server_address[0], server.server_address[1]
+    print(f"http://{actual_host}:{actual_port}/", flush=True)
+    print("Read-only dashboard. Press ctrl-c to stop.", flush=True)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+    return 0

--- a/src/brigade/cli/center.py
+++ b/src/brigade/cli/center.py
@@ -223,6 +223,17 @@ def register(sub: argparse._SubParsersAction) -> None:
         "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update."
     )
     p_center_actions_archive.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_center_serve = center_sub.add_parser("serve", help="Serve the local operator dashboard.")
+    p_center_serve.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
+    p_center_serve.add_argument("--host", default="127.0.0.1", help="Bind host.")
+    p_center_serve.add_argument("--port", type=int, default=8765, help="Bind port.")
+    p_center_serve.add_argument("--token", default=None, help="Bearer token required for access.")
+    p_center_serve.add_argument(
+        "--allowed-host",
+        action="append",
+        default=None,
+        help="Allowed Host header value. May be repeated.",
+    )
     p_center.set_defaults(func=dispatch)
 
 
@@ -322,5 +333,13 @@ def dispatch(args) -> int:
             return center_cmd.actions_archive_completed(target=args.target, json_output=args.json)
         args._brigade_parser.error(f"unknown center actions command: {args.center_actions_command}")
         return 2
+    if args.center_command == "serve":
+        return center_cmd.serve(
+            target=args.target,
+            host=args.host,
+            port=args.port,
+            token=args.token,
+            allowed_hosts=args.allowed_host,
+        )
     args._brigade_parser.error(f"unknown center command: {args.center_command}")
     return 2

--- a/tests/test_center_serve.py
+++ b/tests/test_center_serve.py
@@ -1,0 +1,237 @@
+import re
+import socket
+import threading
+import time
+
+import pytest
+
+from brigade.center_cmd.serve import _make_server, serve, validate_bind_security
+
+
+_FAKE_TOKEN = "fake-token-placeholder"
+
+
+def _wait_until_ready(server, timeout: float = 5.0) -> None:
+    host, port = server.server_address
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=0.5):
+                return
+        except OSError:
+            time.sleep(0.05)
+    raise RuntimeError("server did not start")
+
+
+def _raw_request(
+    server,
+    host_header: str,
+    *,
+    method: str = "GET",
+    path: str = "/",
+    auth: str | None = None,
+) -> str:
+    host, port = server.server_address
+    lines = [f"{method} {path} HTTP/1.1", f"Host: {host_header}"]
+    if auth is not None:
+        lines.append(f"Authorization: Bearer {auth}")
+    lines.append("")
+    lines.append("")
+    request = "\r\n".join(lines).encode("utf-8")
+    with socket.create_connection((host, port), timeout=5) as sock:
+        sock.sendall(request)
+        sock.shutdown(socket.SHUT_WR)
+        response = b""
+        while True:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            response += chunk
+    return response.decode("utf-8", errors="replace")
+
+
+def _status_line(response: str) -> str:
+    return response.splitlines()[0]
+
+
+def _headers_and_body(response: str):
+    parts = response.split("\r\n\r\n", 1)
+    if len(parts) != 2:
+        return parts[0], ""
+    return parts[0], parts[1]
+
+
+@pytest.fixture
+def no_token_server(tmp_target):
+    server = _make_server(
+        host="127.0.0.1",
+        port=0,
+        token=None,
+        allowed_hosts=None,
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    _wait_until_ready(server)
+    yield server
+    server.shutdown()
+    server.server_close()
+
+
+@pytest.fixture
+def token_server(tmp_target):
+    server = _make_server(
+        host="127.0.0.1",
+        port=0,
+        token=_FAKE_TOKEN,
+        allowed_hosts=None,
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    _wait_until_ready(server)
+    yield server
+    server.shutdown()
+    server.server_close()
+
+
+def _status_code(response: str) -> str:
+    return _status_line(response).split()[1]
+
+
+def test_forged_host_returns_403(no_token_server):
+    response = _raw_request(no_token_server, "evil.example.invalid")
+    assert _status_code(response) == "403"
+
+
+def test_good_host_returns_200(no_token_server):
+    host, port = no_token_server.server_address
+    response = _raw_request(no_token_server, f"{host}:{port}")
+    assert _status_code(response) == "200"
+
+
+def test_host_check_applies_to_unknown_paths(no_token_server):
+    host, port = no_token_server.server_address
+    bad = _raw_request(no_token_server, "evil.example.invalid", path="/missing")
+    good_missing = _raw_request(no_token_server, f"{host}:{port}", path="/missing")
+    assert _status_code(bad) == "403"
+    assert _status_code(good_missing) == "404"
+
+
+@pytest.mark.parametrize(
+    ("host", "token", "allowed_hosts", "should_raise"),
+    [
+        ("192.0.2.1", None, None, True),
+        ("192.0.2.1", _FAKE_TOKEN, None, True),
+        ("192.0.2.1", None, ["dashboard.example.invalid"], True),
+        ("192.0.2.1", _FAKE_TOKEN, ["dashboard.example.invalid"], False),
+        ("0.0.0.0", _FAKE_TOKEN, ["dashboard.example.invalid"], False),
+        ("::", _FAKE_TOKEN, ["dashboard.example.invalid"], False),
+        ("127.0.0.1", None, None, False),
+        ("localhost", None, None, False),
+    ],
+)
+def test_bind_refusal(host, token, allowed_hosts, should_raise):
+    if should_raise:
+        with pytest.raises(ValueError):
+            validate_bind_security(host, token, allowed_hosts)
+    else:
+        validate_bind_security(host, token, allowed_hosts)
+
+
+def test_csp_headers_present_and_nonce_rotates(no_token_server):
+    host, port = no_token_server.server_address
+    first = _raw_request(no_token_server, f"{host}:{port}")
+    second = _raw_request(no_token_server, f"{host}:{port}")
+
+    for response in (first, second):
+        headers, _ = _headers_and_body(response)
+        assert "Content-Security-Policy:" in headers
+        assert "default-src 'none'" in headers
+        assert "script-src-attr 'none'" in headers
+        assert re.search(r"script-src 'nonce-[^'\s]+'", headers)
+
+    nonce_re = re.compile(r"script-src 'nonce-([^'\s]+)'")
+    first_nonce = nonce_re.search(_headers_and_body(first)[0]).group(1)
+    second_nonce = nonce_re.search(_headers_and_body(second)[0]).group(1)
+    assert first_nonce != second_nonce
+
+
+def test_html_has_no_inline_event_handlers_and_nonce_matches(no_token_server):
+    host, port = no_token_server.server_address
+    response = _raw_request(no_token_server, f"{host}:{port}")
+    headers, body = _headers_and_body(response)
+
+    assert re.search(r"\bon\w+\s*=", body, re.IGNORECASE) is None
+
+    nonce_match = re.search(r"script-src 'nonce-([^'\s]+)'", headers)
+    assert nonce_match is not None
+    nonce = nonce_match.group(1)
+    assert f'<script nonce="{nonce}"' in body
+
+
+def test_token_required_for_access(token_server):
+    host, port = token_server.server_address
+    host_header = f"{host}:{port}"
+
+    missing = _raw_request(token_server, host_header)
+    wrong = _raw_request(token_server, host_header, auth="wrong-token")
+    correct = _raw_request(token_server, host_header, auth=_FAKE_TOKEN)
+
+    assert _status_code(missing) == "401"
+    assert _status_code(wrong) == "401"
+    assert _status_code(correct) == "200"
+
+
+@pytest.mark.parametrize("method", ["POST", "DELETE", "PUT", "PATCH", "OPTIONS", "TRACE"])
+def test_unsupported_methods_return_405(no_token_server, method):
+    host, port = no_token_server.server_address
+    response = _raw_request(no_token_server, f"{host}:{port}", method=method)
+    assert _status_code(response) == "405"
+
+
+@pytest.mark.parametrize("method", ["OPTIONS", "TRACE", "POST"])
+def test_host_guard_precedes_method_handling(no_token_server, method):
+    """A forged Host is rejected before any verb dispatch, and still gets CSP."""
+    response = _raw_request(no_token_server, "evil.example.invalid", method=method)
+    headers, _ = _headers_and_body(response)
+    assert _status_code(response) == "403"
+    assert "default-src 'none'" in headers
+    assert "script-src-attr 'none'" in headers
+
+
+def test_localhost_host_header_is_accepted_on_loopback_bind(no_token_server):
+    """The operator may type localhost even though the bind prints 127.0.0.1."""
+    _, port = no_token_server.server_address
+    response = _raw_request(no_token_server, f"localhost:{port}")
+    assert _status_code(response) == "200"
+
+
+def test_bound_host_does_not_match_a_different_port(no_token_server):
+    """Allowlist entries are pinned to the bound port, not bare hostnames."""
+    host, port = no_token_server.server_address
+    response = _raw_request(no_token_server, f"{host}:{port + 1}")
+    assert _status_code(response) == "403"
+
+
+def test_missing_host_header_is_rejected(no_token_server):
+    host, port = no_token_server.server_address
+    request = b"GET / HTTP/1.0\r\n\r\n"
+    with socket.create_connection((host, port), timeout=5) as sock:
+        sock.sendall(request)
+        sock.shutdown(socket.SHUT_WR)
+        response = b""
+        while True:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            response += chunk
+    assert _status_code(response.decode("utf-8", errors="replace")) == "403"
+
+
+def test_serve_refuses_non_loopback_bind_with_clear_error(capsys, tmp_target):
+    """The CLI path must print an actionable error, not raise a traceback."""
+    exit_code = serve(target=tmp_target, host="192.0.2.1", port=0, token=None, allowed_hosts=None)
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "192.0.2.1" in captured.err
+    assert "--token" in captured.err
+    assert "--allowed-host" in captured.err


### PR DESCRIPTION
First slice of #721. This lands the transport and its security floor before any
view exists, so the guards are in place before there is anything to attack.

Deliberately no dashboard views here. `GET /` returns a placeholder page whose
only job is to prove the nonce and delegated-listener wiring works. The six
views follow in a second PR, which will close the issue.

## What it does

`brigade center serve` starts on an explicit command, binds `127.0.0.1`, prints
the URL, and stops on ctrl-c. Python standard library only: no new dependency,
no build step, no daemon, no mutating route. Registered under the existing
extras-gated `center` group, following the `register`/`dispatch` pattern and the
`center_cmd` facade's `_MODULE_NAMES` tuple.

## Security floor

Threat model is DNS rebinding plus XSS from card and handoff text, which are
attacker-influenced input.

- **Host allowlist on every request**, enforced in `handle_one_request` after
  `parse_request()` and before verb dispatch. Placement matters: a guard called
  from each `do_*` method leaves any verb without a handler falling through to
  `BaseHTTPRequestHandler`'s built-in 501 responder, which consults no allowlist
  and emits none of the security headers. `OPTIONS` and `TRACE` were answerable
  with a forged Host under the per-method arrangement.
- **Port-pinned entries.** Allowlist values derived from the bind carry the bound
  port, so `Host: 127.0.0.1:1` does not pass. Bare any-port matching is reserved
  for operator-supplied `--allowed-host` values, where a reverse proxy makes it
  meaningful. Loopback binds also accept `localhost` and `::1`, which are not
  attacker-controllable names.
- **Bind refusal.** A non-loopback `--host` is refused unless both `--token` and
  at least one `--allowed-host` are set. `0.0.0.0` and `::` count as non-loopback.
  Refusal is a clear stderr message and exit 2, not a traceback.
- **CSP**: `default-src 'none'`, `script-src 'nonce-<per-response>'`,
  `script-src-attr 'none'`, plus `nosniff`, `no-referrer`, `no-store`. The nonce
  is generated per response and shared by the header and the `<script>` tag.
- **No inline event handlers.** The page uses one delegated listener keyed off a
  `data-action` attribute.
- **Constant-time token comparison** via `hmac.compare_digest` over encoded
  bytes, so a non-ASCII token cannot turn a wrong password into a 500.
- **Read-only**: every verb other than GET/HEAD returns 405.

`ThreadingHTTPServer` rather than `HTTPServer`, so one stuck client cannot wedge
the polling refresh the views will rely on.

## Tests

`tests/test_center_serve.py`, 27 cases. The Host tests drive a **raw socket**
because `urllib`/`http.client` rewrite the Host header and would pass against a
broken guard.

- forged Host returns 403, with a good-Host 200 control
- the guard applies to unknown paths and to `OPTIONS`/`TRACE`/`POST`, and those
  403s still carry CSP
- `localhost` accepted on a loopback bind; a different port rejected; a missing
  Host header rejected
- bind-refusal matrix, including the command-level exit code and stderr text
- CSP assertions, and that the nonce differs between two responses
- HTML scanned for `on\w+\s*=`, asserting zero matches, and the body nonce
  matching the header nonce
- token: missing 401, wrong 401, correct 200
- every non-GET verb returns 405

## Docs

`docs/command-inventory.md` regenerated with the repo's generator
(`BRIGADE_EXTRAS=1 brigade roadmap commands --write`), run from this worktree's
venv so it reads the local parser. `--check` reported the inventory stale
beforehand. The diff is exactly the new `brigade center serve` path and the
group count moving 29 to 30.

## Verification

```
brigade work verify run --target . --command "./scripts/verify" --capture brigade-work
```

`./scripts/verify [completed] exit=0` - 5990 passed, 3 skipped, 68 subtests
passed in 684.64s. Coverage 83.09% against the 78% floor.
Receipt: `20260805-163215-work-verify-f0749b`.

Refs #721.
