### PR TITLE
ci: pin dtolnay/rust-toolchain to a commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
           toolchain: stable
-        with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,9 @@ jobs:
         working-directory: engines/code-graph
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@1.85.0
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: 1.85.0
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: engines/code-graph
@@ -64,7 +66,9 @@ jobs:
         working-directory: engines/code-graph
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: stable
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
@@ -105,7 +109,9 @@ jobs:
         working-directory: engines/code-graph
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: engines/code-graph
@@ -122,7 +128,9 @@ jobs:
         working-directory: engines/code-graph
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: engines/code-graph

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,9 @@ jobs:
         working-directory: engines/code-graph
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: stable
       - name: Build exact native GraphTrail binaries
         if: runner.os != 'Windows'
         run: cargo build --release --locked --bin graphtrail --bin graphtrail-mcp


### PR DESCRIPTION
The action was referenced by floating refs (`@stable` x4, `@1.85.0`) in ci.yml and publish.yml - and publish.yml handles PyPI publishing, where an action-repo compromise is a supply-chain vector. All five uses now pin to the action's master commit SHA and select the toolchain via the documented `toolchain:` input, preserving the exact prior semantics (this action treats its ref as the toolchain selector, so a naive SHA swap would change behavior).

Surfaced by the release doctor's open-findings gate during 0.26.0 prep. Gate: full `./scripts/verify` green in the lane worktree (Brigade receipt); both workflows YAML-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)