### PR TITLE
feat(roster): resolve linked-worktree rosters from the parent clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Roster resolution now understands linked git worktrees: when a worktree has
+  no `.brigade/roster.toml` of its own, `brigade run` and `roster doctor` fall
+  back to the parent clone's roster (new `worktree-parent` source, reported in
+  the run provenance line) before the user roster at `~/.brigade/roster.toml`.
+  A fresh worktree of a wired repo keeps the repo's seats instead of silently
+  downgrading to whatever the user roster or a scaffold provides. (#741)
+- `brigade roster init` refuses to scaffold a starter roster when a fallback
+  roster already applies to the target (the parent clone's roster in a linked
+  worktree, or `~/.brigade/roster.toml`), since the codex+ollama-only starter
+  would shadow every seat configured there. Pass `--force` to scaffold a
+  workspace roster anyway. `brigade research` now resolves its roster through
+  the same fallback chain instead of requiring a workspace roster. (#741)
 - `brigade status --json` carries the same `available_update` field the work
   brief gained, so machine consumers can watch for releases without parsing the
   brief. Cache-read only; never touches the network. (#717)

--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -249,6 +249,12 @@ brigade roster init
 brigade roster doctor
 ```
 
+`roster init` refuses to scaffold when a roster already applies to the target
+through fallback, either the parent clone's roster (when the target is a linked
+git worktree) or the user roster at `~/.brigade/roster.toml`, because the
+minimal starter would shadow every seat that roster configures. Pass `--force`
+to scaffold a workspace roster anyway.
+
 Pass `--review-model <id>` to add a reviewer seat pinned to a different model than the coder (for example `brigade roster init --review-model gpt-5.3-codex-spark`). A same-model reviewer tends to agree with the coder's narration; pinning the review seat to another model makes that independence structural, and `roster doctor` validates the pin like any other seat.
 
 That writes `.brigade/roster.toml` with a Codex orchestrator, a Codex coder, and an optional Ollama local researcher:

--- a/src/brigade/cli/model.py
+++ b/src/brigade/cli/model.py
@@ -52,7 +52,10 @@ def register(sub: argparse._SubParsersAction) -> None:
         parser.add_argument("manifest", type=Path, help="brigade.eval_manifest.v1 JSON file.")
         parser.add_argument("--target", "-t", type=Path, default=Path("."), help="Workspace used by trial runs.")
         parser.add_argument(
-            "--roster", type=Path, default=None, help="Roster path. Uses normal workspace/worktree-parent/user fallback."
+            "--roster",
+            type=Path,
+            default=None,
+            help="Roster path. Uses normal workspace/worktree-parent/user fallback.",
         )
         parser.add_argument("--output-dir", type=Path, default=None, help="Trial artifact directory.")
         parser.set_defaults(func=_dispatch_trial)

--- a/src/brigade/cli/model.py
+++ b/src/brigade/cli/model.py
@@ -52,7 +52,7 @@ def register(sub: argparse._SubParsersAction) -> None:
         parser.add_argument("manifest", type=Path, help="brigade.eval_manifest.v1 JSON file.")
         parser.add_argument("--target", "-t", type=Path, default=Path("."), help="Workspace used by trial runs.")
         parser.add_argument(
-            "--roster", type=Path, default=None, help="Roster path. Uses normal workspace/user fallback."
+            "--roster", type=Path, default=None, help="Roster path. Uses normal workspace/worktree-parent/user fallback."
         )
         parser.add_argument("--output-dir", type=Path, default=None, help="Trial artifact directory.")
         parser.set_defaults(func=_dispatch_trial)

--- a/src/brigade/cli/roster.py
+++ b/src/brigade/cli/roster.py
@@ -13,7 +13,12 @@ def register(sub: argparse._SubParsersAction) -> None:
     roster_sub.required = True
     p_roster_init = roster_sub.add_parser("init", help="Write a starter .brigade/roster.toml.")
     p_roster_init.add_argument("--target", "-t", type=Path, default=Path("."))
-    p_roster_init.add_argument("--force", action="store_true", help="Overwrite an existing roster.")
+    p_roster_init.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite an existing roster, or scaffold over a fallback roster "
+        "(worktree-parent or user) that already applies to this target.",
+    )
     p_roster_init.add_argument(
         "--ollama-model",
         default=None,

--- a/src/brigade/cli/run.py
+++ b/src/brigade/cli/run.py
@@ -117,7 +117,7 @@ def register(sub: argparse._SubParsersAction) -> None:
     )
     p_run.add_argument(
         "--resolved-roster-source",
-        choices=("explicit", "workspace", "user"),
+        choices=("explicit", "workspace", "worktree-parent", "user"),
         default=None,
         help=argparse.SUPPRESS,
     )
@@ -333,12 +333,15 @@ def dispatch(args) -> int:
         print(f"error: invalid roster at {roster_path}: {exc}", file=sys.stderr)
         return 2
     print(f"roster: {roster_resolution.path} ({roster_resolution.source})", file=sys.stderr)
-    for shadowed in roster_resolution.shadowed:
-        print(
-            f"warning: workspace roster {roster_resolution.path} shadows user roster {shadowed}; "
-            "pass --roster PATH to choose either file explicitly.",
-            file=sys.stderr,
-        )
+    # A worktree-parent roster shadowing the user roster is the designed
+    # outcome for worktrees of a wired repo, so only a workspace roster warns.
+    if roster_resolution.source == "workspace":
+        for shadowed in roster_resolution.shadowed:
+            print(
+                f"warning: workspace roster {roster_resolution.path} shadows user roster {shadowed}; "
+                "pass --roster PATH to choose either file explicitly.",
+                file=sys.stderr,
+            )
     if args.worker is not None:
         worker_error = _direct_worker_error(
             args.worker,

--- a/src/brigade/research_cmd.py
+++ b/src/brigade/research_cmd.py
@@ -28,7 +28,7 @@ def _resolve_backend(target: Path):
     from . import roster as roster_mod
     from .research import llm
 
-    r = roster_mod.load_roster(target / ".brigade" / "roster.toml")
+    r = roster_mod.load_roster(roster_mod.resolve_roster_path(target))
     return llm.resolve_backend(r)
 
 

--- a/src/brigade/roster.py
+++ b/src/brigade/roster.py
@@ -17,7 +17,7 @@ SANDBOX_CHOICES = ("read-only", "workspace-write", "danger-full-access")
 CODEX_TRANSPORT_CHOICES = ("exec", "app-server")
 AGENT_TRANSPORT_CHOICES = ("direct", "acpx")
 ACPX_TRANSPORT_VERSION = "0.12.0"
-RosterSource = Literal["explicit", "workspace", "user"]
+RosterSource = Literal["explicit", "workspace", "worktree-parent", "user"]
 
 
 @dataclass(frozen=True)
@@ -273,6 +273,41 @@ def _allowed(cli_ref: str, patterns: tuple[str, ...]) -> bool:
     return any(fnmatch.fnmatchcase(cli_ref, pattern) for pattern in patterns)
 
 
+def _linked_worktree_parent(target: Path) -> Path | None:
+    """Root of the parent clone when target is a linked git worktree, else None.
+
+    A linked worktree has a `.git` FILE with a "gitdir:" pointer into the parent
+    clone's admin dir (`<clone>/.git/worktrees/<name>`), which in turn holds a
+    `commondir` file naming the shared `.git` dir. A submodule's `.git` file
+    points at `.git/modules/<name>`, which has no `commondir`, so it (and any
+    malformed pointer) resolves to None.
+    """
+    git_file = target / ".git"
+    if not git_file.is_file():
+        return None
+    try:
+        content = git_file.read_text().strip()
+    except OSError:
+        return None
+    if not content.startswith("gitdir:"):
+        return None
+    gitdir = Path(content.split(":", 1)[1].strip())
+    if not gitdir.is_absolute():
+        gitdir = (target / gitdir).resolve()
+    try:
+        common_raw = (gitdir / "commondir").read_text().strip()
+    except OSError:
+        return None
+    common = Path(common_raw)
+    if not common.is_absolute():
+        common = (gitdir / common).resolve()
+    if common.name != ".git" or not common.is_dir():
+        # A bare repo's shared dir is the repo itself (foo.git), so its parent
+        # is just whatever directory contains the repo, not a clone root.
+        return None
+    return common.parent
+
+
 def resolve_roster(target: Path, explicit: Path | None = None) -> RosterResolution:
     if explicit is not None:
         path = explicit.expanduser().resolve()
@@ -280,14 +315,23 @@ def resolve_roster(target: Path, explicit: Path | None = None) -> RosterResoluti
             return RosterResolution(path=path, source="explicit")
         raise FileNotFoundError(f"roster not found: {path}")
 
-    workspace_path = (target.expanduser() / ".brigade" / "roster.toml").resolve()
+    target = target.expanduser()
+    workspace_path = (target / ".brigade" / "roster.toml").resolve()
     user_path = (Path.home() / ".brigade" / "roster.toml").expanduser().resolve()
+    parent_root = _linked_worktree_parent(target)
+    parent_path = (parent_root / ".brigade" / "roster.toml").resolve() if parent_root is not None else None
+    if parent_path in (workspace_path, user_path):
+        parent_path = None
     if workspace_path.exists():
         shadowed = (user_path,) if user_path != workspace_path and user_path.exists() else ()
         return RosterResolution(path=workspace_path, source="workspace", shadowed=shadowed)
+    if parent_path is not None and parent_path.exists():
+        shadowed = (user_path,) if user_path != parent_path and user_path.exists() else ()
+        return RosterResolution(path=parent_path, source="worktree-parent", shadowed=shadowed)
     if user_path.exists():
         return RosterResolution(path=user_path, source="user")
-    raise FileNotFoundError(f"roster not found: checked {workspace_path} and {user_path}")
+    checked = [workspace_path] + ([parent_path] if parent_path is not None else []) + [user_path]
+    raise FileNotFoundError("roster not found: checked " + " and ".join(str(path) for path in checked))
 
 
 def resolve_roster_path(target: Path, explicit: Path | None = None) -> Path:

--- a/src/brigade/roster_cmd.py
+++ b/src/brigade/roster_cmd.py
@@ -306,6 +306,19 @@ def init(
     if path.exists() and not force:
         print(f"error: roster already exists at {path}; pass --force to overwrite", file=sys.stderr)
         return 2
+    if not path.exists() and not force:
+        try:
+            fallback = roster_mod.resolve_roster(target)
+        except FileNotFoundError:
+            fallback = None
+        if fallback is not None:
+            print(
+                f"error: {fallback.source} roster {fallback.path} already applies here via fallback; "
+                f"a starter at {path} would shadow it with codex+ollama-only seats. "
+                "Pass --force to scaffold a workspace roster anyway.",
+                file=sys.stderr,
+            )
+            return 2
 
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(

--- a/tests/test_roster.py
+++ b/tests/test_roster.py
@@ -177,6 +177,174 @@ def test_resolve_roster_reports_user_fallback_source(monkeypatch, tmp_path):
     assert resolution.shadowed == ()
 
 
+def _make_linked_worktree(tmp_path):
+    """Lay out a parent clone and a linked git worktree the way git does."""
+    parent = tmp_path / "clone"
+    admin = parent / ".git" / "worktrees" / "wt"
+    admin.mkdir(parents=True)
+    (admin / "commondir").write_text("../..\n")
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    (worktree / ".git").write_text(f"gitdir: {admin}\n")
+    return parent, worktree
+
+
+def test_resolve_roster_worktree_falls_back_to_parent_clone(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    parent, worktree = _make_linked_worktree(tmp_path)
+    parent_roster = parent / ".brigade" / "roster.toml"
+    parent_roster.parent.mkdir(parents=True)
+    parent_roster.write_text(VALID)
+    monkeypatch.setattr(Path, "home", lambda: home)
+
+    resolution = roster_mod.resolve_roster(worktree)
+
+    assert resolution.path == parent_roster.resolve()
+    assert resolution.source == "worktree-parent"
+    assert resolution.shadowed == ()
+
+
+def test_resolve_roster_worktree_parent_shadows_user_roster(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    parent, worktree = _make_linked_worktree(tmp_path)
+    parent_roster = parent / ".brigade" / "roster.toml"
+    user = home / ".brigade" / "roster.toml"
+    parent_roster.parent.mkdir(parents=True)
+    user.parent.mkdir(parents=True)
+    parent_roster.write_text(VALID)
+    user.write_text(VALID)
+    monkeypatch.setattr(Path, "home", lambda: home)
+
+    resolution = roster_mod.resolve_roster(worktree)
+
+    assert resolution.path == parent_roster.resolve()
+    assert resolution.source == "worktree-parent"
+    assert resolution.shadowed == (user.resolve(),)
+
+
+def test_resolve_roster_worktree_own_workspace_roster_wins(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    parent, worktree = _make_linked_worktree(tmp_path)
+    parent_roster = parent / ".brigade" / "roster.toml"
+    local = worktree / ".brigade" / "roster.toml"
+    parent_roster.parent.mkdir(parents=True)
+    local.parent.mkdir(parents=True)
+    parent_roster.write_text(VALID)
+    local.write_text(VALID)
+    monkeypatch.setattr(Path, "home", lambda: home)
+
+    resolution = roster_mod.resolve_roster(worktree)
+
+    assert resolution.path == local.resolve()
+    assert resolution.source == "workspace"
+
+
+def test_resolve_roster_worktree_without_parent_roster_uses_user(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    _parent, worktree = _make_linked_worktree(tmp_path)
+    user = home / ".brigade" / "roster.toml"
+    user.parent.mkdir(parents=True)
+    user.write_text(VALID)
+    monkeypatch.setattr(Path, "home", lambda: home)
+
+    resolution = roster_mod.resolve_roster(worktree)
+
+    assert resolution.path == user.resolve()
+    assert resolution.source == "user"
+
+
+def test_resolve_roster_relative_gitdir_pointer_finds_parent(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    parent = tmp_path / "clone"
+    admin = parent / ".git" / "worktrees" / "wt"
+    admin.mkdir(parents=True)
+    (admin / "commondir").write_text("../..\n")
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    (worktree / ".git").write_text("gitdir: ../clone/.git/worktrees/wt\n")
+    parent_roster = parent / ".brigade" / "roster.toml"
+    parent_roster.parent.mkdir(parents=True)
+    parent_roster.write_text(VALID)
+    monkeypatch.setattr(Path, "home", lambda: home)
+
+    resolution = roster_mod.resolve_roster(worktree)
+
+    assert resolution.path == parent_roster.resolve()
+    assert resolution.source == "worktree-parent"
+
+
+def test_resolve_roster_bare_repo_worktree_has_no_parent_tier(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    admin = tmp_path / "bare.git" / "worktrees" / "wt"
+    admin.mkdir(parents=True)
+    (admin / "commondir").write_text("../..\n")
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    (worktree / ".git").write_text(f"gitdir: {admin}\n")
+    # A roster in the directory that merely CONTAINS the bare repo is not the
+    # parent clone's roster and must not be adopted.
+    stray = tmp_path / ".brigade" / "roster.toml"
+    stray.parent.mkdir()
+    stray.write_text(VALID)
+    user = home / ".brigade" / "roster.toml"
+    user.parent.mkdir(parents=True)
+    user.write_text(VALID)
+    monkeypatch.setattr(Path, "home", lambda: home)
+
+    resolution = roster_mod.resolve_roster(worktree)
+
+    assert resolution.path == user.resolve()
+    assert resolution.source == "user"
+
+
+def test_resolve_roster_parent_same_as_user_reports_user(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    admin = home / ".git" / "worktrees" / "wt"
+    admin.mkdir(parents=True)
+    (admin / "commondir").write_text("../..\n")
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    (worktree / ".git").write_text(f"gitdir: {admin}\n")
+    user = home / ".brigade" / "roster.toml"
+    user.parent.mkdir(parents=True)
+    user.write_text(VALID)
+    monkeypatch.setattr(Path, "home", lambda: home)
+
+    resolution = roster_mod.resolve_roster(worktree)
+
+    assert resolution.path == user.resolve()
+    assert resolution.source == "user"
+    assert resolution.shadowed == ()
+
+
+def test_resolve_roster_malformed_git_file_is_not_a_worktree(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / ".git").write_text("not a gitdir pointer\n")
+    user = home / ".brigade" / "roster.toml"
+    user.parent.mkdir(parents=True)
+    user.write_text(VALID)
+    monkeypatch.setattr(Path, "home", lambda: home)
+
+    resolution = roster_mod.resolve_roster(workspace)
+
+    assert resolution.path == user.resolve()
+    assert resolution.source == "user"
+
+
+def test_resolve_roster_worktree_missing_names_parent_candidate(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    parent, worktree = _make_linked_worktree(tmp_path)
+    monkeypatch.setattr(Path, "home", lambda: home)
+    with pytest.raises(FileNotFoundError) as exc:
+        roster_mod.resolve_roster(worktree)
+    message = str(exc.value)
+    assert str(worktree / ".brigade" / "roster.toml") in message
+    assert str((parent / ".brigade" / "roster.toml").resolve()) in message
+    assert str(home / ".brigade" / "roster.toml") in message
+
+
 def test_resolve_roster_path_explicit_never_falls_back(monkeypatch, tmp_path):
     home = tmp_path / "home"
     user = home / ".brigade" / "roster.toml"

--- a/tests/test_roster_cmd.py
+++ b/tests/test_roster_cmd.py
@@ -100,7 +100,7 @@ def test_roster_init_force_overwrites_with_options(tmp_target):
 def test_roster_init_refuses_to_shadow_user_roster(_hermetic_home, tmp_target, capsys):
     user = _hermetic_home / ".brigade" / "roster.toml"
     user.parent.mkdir(parents=True)
-    user.write_text("orchestrator = \"chef\"\n[agents.chef]\ncli = \"claude\"\n")
+    user.write_text('orchestrator = "chef"\n[agents.chef]\ncli = "claude"\n')
 
     rc = roster_cmd.init(tmp_target)
 
@@ -122,7 +122,7 @@ def test_roster_init_refuses_to_shadow_worktree_parent_roster(_hermetic_home, tm
     (worktree / ".git").write_text(f"gitdir: {admin}\n")
     parent_roster = parent / ".brigade" / "roster.toml"
     parent_roster.parent.mkdir(parents=True)
-    parent_roster.write_text("orchestrator = \"chef\"\n[agents.chef]\ncli = \"claude\"\n")
+    parent_roster.write_text('orchestrator = "chef"\n[agents.chef]\ncli = "claude"\n')
 
     rc = roster_cmd.init(worktree)
 
@@ -137,7 +137,7 @@ def test_roster_init_refuses_to_shadow_worktree_parent_roster(_hermetic_home, tm
 def test_roster_init_force_scaffolds_despite_user_roster(_hermetic_home, tmp_target):
     user = _hermetic_home / ".brigade" / "roster.toml"
     user.parent.mkdir(parents=True)
-    user.write_text("orchestrator = \"chef\"\n[agents.chef]\ncli = \"claude\"\n")
+    user.write_text('orchestrator = "chef"\n[agents.chef]\ncli = "claude"\n')
 
     assert roster_cmd.init(tmp_target, force=True) == 0
     assert (tmp_target / ".brigade" / "roster.toml").is_file()

--- a/tests/test_roster_cmd.py
+++ b/tests/test_roster_cmd.py
@@ -12,6 +12,18 @@ from brigade import roster_cmd
 from brigade import toml_compat
 
 
+@pytest.fixture(autouse=True)
+def _hermetic_home(tmp_path_factory, monkeypatch):
+    """Keep the machine's real ~/.brigade/roster.toml out of init's shadow guard.
+
+    Tests that need a specific home (with or without a user roster) re-patch
+    Path.home in their own body, which takes precedence over this fixture.
+    """
+    home = tmp_path_factory.mktemp("roster-cmd-home")
+    monkeypatch.setattr(Path, "home", lambda: home)
+    return home
+
+
 def test_roster_init_writes_default_roster(tmp_target, capsys):
     rc = roster_cmd.init(tmp_target)
     out = capsys.readouterr().out
@@ -83,6 +95,52 @@ def test_roster_init_force_overwrites_with_options(tmp_target):
     text = (tmp_target / ".brigade" / "roster.toml").read_text()
     assert 'cli = "ollama:mistral"' in text
     assert "max_workers = 2" in text
+
+
+def test_roster_init_refuses_to_shadow_user_roster(_hermetic_home, tmp_target, capsys):
+    user = _hermetic_home / ".brigade" / "roster.toml"
+    user.parent.mkdir(parents=True)
+    user.write_text("orchestrator = \"chef\"\n[agents.chef]\ncli = \"claude\"\n")
+
+    rc = roster_cmd.init(tmp_target)
+
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert not (tmp_target / ".brigade" / "roster.toml").exists()
+    assert str(user) in err
+    assert "shadow" in err
+    assert "--force" in err
+
+
+def test_roster_init_refuses_to_shadow_worktree_parent_roster(_hermetic_home, tmp_path, capsys):
+    parent = tmp_path / "clone"
+    admin = parent / ".git" / "worktrees" / "wt"
+    admin.mkdir(parents=True)
+    (admin / "commondir").write_text("../..\n")
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    (worktree / ".git").write_text(f"gitdir: {admin}\n")
+    parent_roster = parent / ".brigade" / "roster.toml"
+    parent_roster.parent.mkdir(parents=True)
+    parent_roster.write_text("orchestrator = \"chef\"\n[agents.chef]\ncli = \"claude\"\n")
+
+    rc = roster_cmd.init(worktree)
+
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert not (worktree / ".brigade" / "roster.toml").exists()
+    assert str(parent_roster.resolve()) in err
+    assert "worktree-parent" in err
+    assert "--force" in err
+
+
+def test_roster_init_force_scaffolds_despite_user_roster(_hermetic_home, tmp_target):
+    user = _hermetic_home / ".brigade" / "roster.toml"
+    user.parent.mkdir(parents=True)
+    user.write_text("orchestrator = \"chef\"\n[agents.chef]\ncli = \"claude\"\n")
+
+    assert roster_cmd.init(tmp_target, force=True) == 0
+    assert (tmp_target / ".brigade" / "roster.toml").is_file()
 
 
 def test_roster_doctor_missing_file_fails(monkeypatch, tmp_target, tmp_path, capsys):

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -637,6 +637,66 @@ def test_run_cli_records_workspace_roster_provenance_and_shadow_warning(tmp_path
     }
 
 
+def test_run_cli_worktree_parent_roster_resolves_without_shadow_warning(tmp_path, monkeypatch, capsys):
+    parent = tmp_path / "clone"
+    admin = parent / ".git" / "worktrees" / "wt"
+    admin.mkdir(parents=True)
+    (admin / "commondir").write_text("../..\n")
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    (worktree / ".git").write_text(f"gitdir: {admin}\n")
+    parent_roster = parent / ".brigade" / "roster.toml"
+    home = tmp_path / "home"
+    user_roster = home / ".brigade" / "roster.toml"
+    parent_roster.parent.mkdir(parents=True)
+    user_roster.parent.mkdir(parents=True)
+    roster_text = (
+        'orchestrator = "chef"\n'
+        '[agents.chef]\ncli = "codex"\nrole = "plan"\n'
+        '[agents.coder]\ncli = "codex"\nrole = "code"\n'
+    )
+    parent_roster.write_text(roster_text)
+    user_roster.write_text(roster_text)
+    output_dir = tmp_path / "run"
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setattr(
+        aboyeur.agents,
+        "run_agent",
+        lambda *args, **kwargs: agents.AgentResult(
+            text=json.dumps({"assignments": [{"worker": "coder", "task": "inspect"}]}),
+            ok=True,
+        ),
+    )
+
+    rc = cli.main(
+        [
+            "run",
+            "inspect",
+            "--cwd",
+            str(worktree),
+            "--output-dir",
+            str(output_dir),
+            "--dry-run",
+            "--no-code-graph",
+            "--no-evidence",
+            "--no-route",
+        ]
+    )
+
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert f"roster: {parent_roster.resolve()} (worktree-parent)" in err
+    # Falling back to the parent clone's roster with a user roster present is
+    # the designed outcome, not a conflict worth warning about on every run.
+    assert "shadows user roster" not in err
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["roster"] == {
+        "path": str(parent_roster.resolve()),
+        "source": "worktree-parent",
+        "shadowed": [str(user_roster.resolve())],
+    }
+
+
 def test_run_cli_explicit_direct_worker_reports_choice_without_shadow_warning(tmp_path, monkeypatch, capsys):
     home = tmp_path / "home"
     user_roster = home / ".brigade" / "roster.toml"


### PR DESCRIPTION
## What

A fresh linked git worktree of a wired repo has no `.brigade/` directory (it is git-excluded), so roster resolution skipped the repo roster entirely: `brigade run` fell through to `~/.brigade/roster.toml`, and a scaffolded starter roster could shadow every configured seat with the codex+ollama defaults. Observed as a worktree session reporting missing kimi and cursor seats right after wiring.

- Roster resolution gains a `worktree-parent` tier between workspace and user: when the target's `.git` is a `gitdir:` pointer file whose admin dir holds a `commondir`, the parent clone's `.brigade/roster.toml` applies. Bare-repo and submodule pointers are rejected (no `commondir`, or the shared dir is not a `.git` working-clone dir).
- `brigade roster init` refuses (exit 2) to scaffold a starter when a fallback roster already applies, naming the roster it would shadow; `--force` overrides.
- The run provenance line reports the new source. The shadow warning only fires for a workspace roster now, since a worktree-parent roster shadowing the user roster is the designed outcome.
- `brigade research` resolves its roster through the shared resolver instead of a hard-coded workspace path (pre-existing divergence: it had no fallback at all).

## How verified

- TDD throughout: every behavior landed with a failing test first; 13 new tests across `test_roster.py`, `test_roster_cmd.py`, `test_run_cli.py`.
- Full suite through Brigade verify receipts: 5976 passed, 3 skipped (environment-gated), 0 failed. `ruff check src tests` clean.
- Independent review pass found no blockers; its should-fixes (bare-repo guard, init guard covering the worktree-parent tier, `--force` help text, docs drift, `research_cmd` divergence) are all folded in.

## Review focus

`_linked_worktree_parent` in `src/brigade/roster.py` gates which git layouts get the new tier - the `commondir` + `.git`-dir checks are the load-bearing part.

## Follow-up (not in this PR)

`gitdir:` pointer parsing now exists in three modules (`roster.py`, `install.py`, `security_cmd/models.py`); consolidating into `runguard` would stop them drifting.