### PR TITLE
fix(run): stop the DAG scheduler deadlocking on shared covers sets

### DIFF
--- a/src/brigade/run_transport.py
+++ b/src/brigade/run_transport.py
@@ -836,7 +836,14 @@ def _dag_dispatch(
         groups: dict[str, tuple[int, ...]] = {}
         for stage_name in a.covers:
             for dep_stage in route_dependencies.get(stage_name, ()):
-                others = tuple(idx for idx in coverers.get(dep_stage, ()) if idx != i)
+                dep_coverers = coverers.get(dep_stage, ())
+                if i in dep_coverers:
+                    # This assignment covers the dependency stage itself, so the edge
+                    # is satisfied within its own execution. Without this, every
+                    # parallel assignment sharing a composite covers set waits on its
+                    # peers and the whole plan deadlocks on the first sweep.
+                    continue
+                others = tuple(idx for idx in dep_coverers if idx != i)
                 if not others:
                     # Nobody else covers it (or only this assignment does):
                     # vacuously satisfied, same leniency as wave mode.

--- a/tests/test_run_transport_dag.py
+++ b/tests/test_run_transport_dag.py
@@ -257,3 +257,70 @@ def test_all_redundant_coverers_failed_skips_dependents(dag_harness):
     by_worker = {r.worker: r for r in results}
     assert by_worker["i"].status == "skipped"
     assert "i" not in dag_harness.invocations_set
+
+
+DEPS_COMPOSITE = {
+    "test-author": (),
+    "implement": ("test-author",),
+}
+
+
+def test_parallel_composite_covers_no_deadlock(dag_harness):
+    """Regression: N parallel seats sharing a composite covers set must all run."""
+    assignments = [_a(f"w{i}", 1, ["test-author", "implement"]) for i in range(4)]
+    results = dag_harness(assignments, dependencies=DEPS_COMPOSITE)
+    by_worker = {r.worker: r for r in results}
+    for i in range(4):
+        worker = f"w{i}"
+        assert by_worker[worker].ok is True, by_worker[worker].detail
+        assert "cycle" not in (by_worker[worker].detail or "").lower()
+    assert dag_harness.invocations_set == {f"w{i}" for i in range(4)}
+
+
+def test_cross_assignment_dependency_enforced(dag_harness):
+    """Cross-assignment edges still order work and skip dependents on failure."""
+    assignments = [_a("ta", 1, ["test-author"]), _a("im", 2, ["implement"])]
+    order = dag_harness.start_order_for(
+        assignments,
+        dependencies=DEPS_COMPOSITE,
+        slow_workers={"ta": 0.3},
+    )
+    assert order.index("ta") < order.index("im")
+
+    results = dag_harness(
+        assignments,
+        dependencies=DEPS_COMPOSITE,
+        outcomes={"ta": WorkerResult(worker="ta", task="task-ta", text="", ok=False, detail="boom")},
+    )
+    by_worker = {r.worker: r for r in results}
+    assert by_worker["im"].status == "skipped"
+    assert "im" not in dag_harness.invocations_set
+
+
+def test_redundant_test_author_coverer_semantics(dag_harness):
+    """Implement runs when either test-author coverer succeeds; skipped only when both fail."""
+    assignments = [
+        _a("ta1", 1, ["test-author"]),
+        _a("ta2", 1, ["test-author"]),
+        _a("im", 2, ["implement"]),
+    ]
+    results = dag_harness(
+        assignments,
+        dependencies=DEPS_COMPOSITE,
+        outcomes={"ta1": WorkerResult(worker="ta1", task="task-ta1", text="", ok=False, detail="boom")},
+    )
+    by_worker = {r.worker: r for r in results}
+    assert by_worker["im"].ok is True
+    assert "im" in dag_harness.invocations_set
+
+    results = dag_harness(
+        assignments,
+        dependencies=DEPS_COMPOSITE,
+        outcomes={
+            "ta1": WorkerResult(worker="ta1", task="task-ta1", text="", ok=False, detail="boom"),
+            "ta2": WorkerResult(worker="ta2", task="task-ta2", text="", ok=False, detail="boom"),
+        },
+    )
+    by_worker = {r.worker: r for r in results}
+    assert by_worker["im"].status == "skipped"
+    assert "im" not in dag_harness.invocations_set


### PR DESCRIPTION
Found while fanning six independent tasks across seats for #721: every worker
was skipped with `unresolvable dependency cycle in plan` and the run wrote zero
files. The plan was valid; the scheduler deadlocked on it.

## The bug

`_dag_dispatch` builds each assignment's prerequisite groups from the *other*
coverers of every stage it depends on, and skips that wait only when the
assignment is the **sole** coverer of the dependency stage:

```python
others = tuple(idx for idx in coverers.get(dep_stage, ()) if idx != i)
if not others:
    continue          # sole coverer -> vacuously satisfied
groups[dep_stage] = others
```

`implement` depends on `test-author`. Give four parallel assignments the same
`covers: [..., "test-author", "implement"]` and each waits on the other three:
assignment 0 on {1,2,3}, assignment 1 on {0,2,3}, and so on. Nothing is
`ready()`, nothing is `doomed()`, no progress is made on the first sweep, and
the plan is declared a cycle.

This hits any plan that gives two or more parallel assignments a `covers` set
spanning a dependency edge, which is the natural shape for "N seats each
implementing one slice with its own tests".

## The fix

An assignment covering both the dependency stage and the dependent stage
satisfies that edge within its own execution, so it should not wait on peer
coverers. That extends the existing sole-coverer leniency to the
self-coverage case.

The cycle detection is untouched and was never wrong - it was correctly
reporting a deadlock that the prerequisite construction had created.

## Tests

Three cases in `tests/test_run_transport_dag.py`, using the file's existing
`dag_harness`:

1. **The regression** - four parallel assignments sharing a composite `covers`
   set all run, none skipped. Verified failing before the fix with exactly
   `AssertionError: skipped: unresolvable dependency cycle in plan`, and
   passing after.
2. **Cross-assignment ordering still enforced** - a `test-author`-only
   assignment starts before an `implement`-only one, and the dependent is
   skipped when the prerequisite fails. This proves the fix did not just
   switch dependency ordering off.
3. **Redundant-coverer semantics preserved** - with two `test-author`
   coverers, `implement` runs when either succeeds and is skipped only when
   both fail.

No existing test was weakened or deleted; the module's other 11 tests pass
unchanged.

## Verification

```
brigade work verify run --target . --command "./scripts/verify" --capture brigade-work
```

`./scripts/verify [completed] exit=0` - 5966 passed, 3 skipped, 68 subtests
passed in 682.54s. Receipt `20260805-191730-work-verify-0aebb0`.

One note for transparency: an earlier full-gate run went red on
`test_pre_push_hook.py::test_stale_local_tracking_ref_does_not_over_exclude`
with `OSError: [Errno 39] Directory not empty` during tempdir teardown. That
file passes in isolation and the failure is a filesystem race in the hook
test's cleanup, unreachable from this change; the re-run above is clean.
