### PR TITLE
fix(hooks): hint brigade init at session start in unwired git repos

### DIFF
--- a/src/brigade/claude_hooks/runtime.py
+++ b/src/brigade/claude_hooks/runtime.py
@@ -1822,9 +1822,37 @@ def _additional_context(event: str, text: str) -> dict[str, Any]:
     return {"hookSpecificOutput": {"hookEventName": event, "additionalContext": text}}
 
 
+def _unwired_init_hint(payload: dict[str, Any]) -> dict[str, Any] | None:
+    """Suggest wiring an unwired git repo at session start.
+
+    The user-scope hooks promise one-and-done onboarding: an agent entering an
+    unwired repo must be told the exact init command instead of silence. Only
+    SessionStart hints, only for a real git checkout, and never for the user's
+    home directory itself.
+    """
+    raw_cwd = payload.get("cwd")
+    if not isinstance(raw_cwd, str) or not raw_cwd:
+        return None
+    try:
+        cwd = Path(raw_cwd).expanduser().resolve(strict=False)
+    except OSError:
+        return None
+    if cwd == Path.home() or not (cwd / ".git").exists():
+        return None
+    command = f"brigade init --target {cwd} --depth repo --harnesses claude --owner claude --git-exclude"
+    return _additional_context(
+        "SessionStart",
+        "This git repository is not Brigade-wired. Configure it before real work so "
+        f"verification and memory are captured: {command}\n"
+        "Then start with: brigade work brief --target .",
+    )
+
+
 def handle_payload(event: str, payload: dict[str, Any]) -> dict[str, Any] | None:
     target = wired_target_from_payload(payload)
     if target is None:
+        if event == "SessionStart":
+            return _unwired_init_hint(payload)
         return None
     session_id = payload.get("session_id")
     if not isinstance(session_id, str) or not session_id:

--- a/tests/test_claude_hooks_runtime.py
+++ b/tests/test_claude_hooks_runtime.py
@@ -84,6 +84,36 @@ def test_all_events_are_inert_for_unwired_repo(tmp_path: Path, monkeypatch):
     assert runtime.handle_payload("Stop", _payload(tmp_path, "Stop", stop_hook_active=False)) is None
 
 
+def test_session_start_hints_init_for_unwired_git_repo(tmp_path: Path):
+    repo = tmp_path / "fresh-repo"
+    (repo / ".git").mkdir(parents=True)
+    result = runtime.handle_payload("SessionStart", _payload(repo, "SessionStart"))
+    context = result["hookSpecificOutput"]["additionalContext"]
+    assert f"brigade init --target {repo.resolve()}" in context
+    assert "--harnesses claude" in context
+    assert "brigade work brief" in context
+
+
+def test_session_start_stays_silent_for_home_directory(tmp_path: Path, monkeypatch):
+    home = tmp_path / "home"
+    (home / ".git").mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: home.resolve()))
+    assert runtime.handle_payload("SessionStart", _payload(home, "SessionStart")) is None
+
+
+def test_other_events_stay_silent_for_unwired_git_repo(tmp_path: Path):
+    repo = tmp_path / "fresh-repo-2"
+    (repo / ".git").mkdir(parents=True)
+    assert (
+        runtime.handle_payload(
+            "PreToolUse",
+            _payload(repo, "PreToolUse", tool_name="Bash", tool_input={"command": "pytest"}),
+        )
+        is None
+    )
+    assert runtime.handle_payload("Stop", _payload(repo, "Stop", stop_hook_active=False)) is None
+
+
 def test_pretooluse_denies_raw_verification_with_exact_replacement(tmp_path: Path):
     target = _wired_claude(tmp_path)
     result = runtime.handle_payload(


### PR DESCRIPTION
Found by the clean-guest E2E (LXC brigade-e2e-0260): the user-scope work-loop hooks injected the brief in wired repos but were silent in unwired ones - `handle_payload` returned None when no wired target resolved, so the one-and-done promise held only where wiring already existed. The behavior everyone experienced locally came from a hand-wired personal hook script, not the packaged runtime; only a clean environment could catch it.

SessionStart now returns additionalContext naming the exact `brigade init` command when the cwd is a real git checkout (never the home directory, never non-git dirs, other events stay silent), matching what the README documents. Three new tests pin the hint, the home-dir guard, and other-event silence; the pre-existing inert-unwired test (non-git tmp_path) still passes untouched.

Gate: full `./scripts/verify` green (Brigade receipt), targeted hook suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)