### PR TITLE
feat(center): add the operator dashboard views

### DIFF
--- a/src/brigade/center_cmd/dashboard/__init__.py
+++ b/src/brigade/center_cmd/dashboard/__init__.py
@@ -1,0 +1,1 @@
+"""Operator dashboard presentation layer."""

--- a/src/brigade/center_cmd/dashboard/data.py
+++ b/src/brigade/center_cmd/dashboard/data.py
@@ -1,0 +1,50 @@
+"""Dashboard data access via the Brigade CLI only.
+
+This module shells out to ``brigade … --json`` and never reads ``.brigade/``
+state directly. Every panel must degrade gracefully when a command fails;
+do not "optimize" by opening ledger files on disk.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+def run_json(target: Path, args: Sequence[str], *, timeout: float = 20.0) -> dict:
+    """Run a brigade subcommand and return parsed JSON, or ``{"error": ...}``."""
+    cmd = [sys.executable, "-m", "brigade", *args, "--target", str(target), "--json"]
+    env = os.environ.copy()
+    env["BRIGADE_EXTRAS"] = "1"
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=env,
+        )
+    except subprocess.TimeoutExpired:
+        return {"error": "command timed out"}
+    except OSError as exc:
+        return {"error": f"command failed: {exc}"}
+
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        if detail:
+            first_line = detail.splitlines()[0]
+            return {"error": first_line[:200]}
+        return {"error": f"command exited {result.returncode}"}
+
+    try:
+        parsed = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return {"error": "invalid JSON from command"}
+
+    if not isinstance(parsed, dict):
+        return {"error": "expected JSON object from command"}
+    return parsed

--- a/src/brigade/center_cmd/dashboard/render.py
+++ b/src/brigade/center_cmd/dashboard/render.py
@@ -1,0 +1,151 @@
+"""Shared HTML rendering helpers for the operator dashboard."""
+
+from __future__ import annotations
+
+import html
+from collections.abc import Sequence
+
+
+def esc(value: object) -> str:
+    """Escape a value for safe inclusion in HTML."""
+    return html.escape(str(value), quote=True)
+
+
+def panel(title: str, inner: str) -> str:
+    """Render a titled panel. *title* and *inner* must already be escaped."""
+    return f'<section class="panel"><h2 class="panel-title">{title}</h2><div class="panel-body">{inner}</div></section>'
+
+
+def error_panel(title: str, message: str) -> str:
+    """Render a degradation panel for a failed data fetch."""
+    return panel(esc(title), f'<p class="error">{esc(message)}</p>')
+
+
+def table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
+    """Render a table. *headers* and every cell in *rows* must already be escaped."""
+    head_cells = "".join(f"<th>{cell}</th>" for cell in headers)
+    body_rows = []
+    for row in rows:
+        cells = "".join(f"<td>{cell}</td>" for cell in row)
+        body_rows.append(f"<tr>{cells}</tr>")
+    body = "".join(body_rows)
+    return f'<table class="data-table"><thead><tr>{head_cells}</tr></thead><tbody>{body}</tbody></table>'
+
+
+def page(title: str, nonce: str, nav: str, body: str) -> str:
+    """Render a full HTML document. *title*, *nav*, and *body* must already be escaped."""
+    nonce_attr = esc(nonce)
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{title}</title>
+<style nonce="{nonce_attr}">
+body {{
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  line-height: 1.5;
+  margin: 0;
+  color: #111;
+  background: #fff;
+}}
+a {{
+  color: #0066cc;
+  text-decoration: none;
+}}
+a:hover {{
+  text-decoration: underline;
+}}
+nav.dashboard-nav {{
+  border-bottom: 1px solid #ddd;
+  padding: 0.75rem 1.5rem;
+  background: #f8f8f8;
+}}
+nav.dashboard-nav ul {{
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}}
+nav.dashboard-nav a {{
+  font-weight: 500;
+}}
+nav.dashboard-nav a[aria-current="page"] {{
+  font-weight: 700;
+  text-decoration: underline;
+}}
+main.dashboard-main {{
+  padding: 1.5rem;
+}}
+h1.page-title {{
+  font-size: 1.5rem;
+  margin: 0 0 1rem;
+  color: #0066cc;
+}}
+.panel {{
+  border: 1px solid #ddd;
+  border-radius: 0.25rem;
+  margin-bottom: 1rem;
+}}
+.panel-title {{
+  font-size: 1rem;
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid #ddd;
+  background: #f8f8f8;
+}}
+.panel-body {{
+  padding: 1rem;
+}}
+.panel-body p {{
+  margin: 0;
+}}
+p.error {{
+  color: #8b0000;
+}}
+table.data-table {{
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}}
+table.data-table th,
+table.data-table td {{
+  border: 1px solid #ddd;
+  padding: 0.4rem 0.6rem;
+  text-align: left;
+}}
+table.data-table th {{
+  background: #f0f0f0;
+}}
+</style>
+</head>
+<body>
+{nav}
+<main class="dashboard-main">
+{body}
+</main>
+<script nonce="{nonce_attr}">
+setTimeout(function () {{
+  location.reload();
+}}, 30000);
+document.addEventListener("input", function (e) {{
+  var input = e.target;
+  if (!input || !input.getAttribute) return;
+  var targetId = input.getAttribute("data-filter-target");
+  if (!targetId) return;
+  var table = document.getElementById(targetId);
+  if (!table) return;
+  var query = (input.value || "").toLowerCase();
+  var rows = table.querySelectorAll("tbody tr");
+  for (var i = 0; i < rows.length; i++) {{
+    var row = rows[i];
+    var text = (row.textContent || "").toLowerCase();
+    row.hidden = query !== "" && text.indexOf(query) === -1;
+  }}
+}});
+</script>
+</body>
+</html>
+"""

--- a/src/brigade/center_cmd/dashboard/views/__init__.py
+++ b/src/brigade/center_cmd/dashboard/views/__init__.py
@@ -1,0 +1,72 @@
+"""Dashboard view modules and registry.
+
+Each view module exposes:
+
+- ``NAME: str`` — URL slug, e.g. ``"status"``
+- ``TITLE: str`` — navigation label, e.g. ``"Status"``
+- ``ORDER: int`` — navigation sort order
+- ``fetch(target: Path) -> dict`` — loads data via ``data.run_json`` only
+- ``render(payload: dict, nonce: str) -> str`` — returns an escaped HTML fragment
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import ModuleType
+from typing import Protocol
+
+from brigade.center_cmd.dashboard import render
+from brigade.center_cmd.dashboard.views import (
+    activity_heatmap,
+    handoff_inbox,
+    memory_cards,
+    outcome_rank,
+    run_timeline,
+    status_grid,
+)
+
+_VIEW_MODULES: tuple[ModuleType, ...] = (
+    status_grid,
+    handoff_inbox,
+    memory_cards,
+    outcome_rank,
+    run_timeline,
+    activity_heatmap,
+)
+
+
+class DashboardView(Protocol):
+    NAME: str
+    TITLE: str
+    ORDER: int
+
+    def fetch(self, target: Path) -> dict: ...
+
+    def render(self, payload: dict, nonce: str) -> str: ...
+
+
+def all_views() -> list[ModuleType]:
+    """Return registered view modules sorted by ``ORDER``."""
+    return sorted(_VIEW_MODULES, key=lambda module: module.ORDER)
+
+
+def view_by_name(name: str) -> ModuleType | None:
+    """Look up a view module by its ``NAME`` slug."""
+    for module in _VIEW_MODULES:
+        if module.NAME == name:
+            return module
+    return None
+
+
+def render_nav(current: str) -> str:
+    """Build the top navigation bar. *current* is the active view ``NAME``."""
+    items = []
+    for module in all_views():
+        href = render.esc(f"/view/{module.NAME}")
+        label = render.esc(module.TITLE)
+        if module.NAME == current:
+            items.append(f'<li><a href="{href}" aria-current="page">{label}</a></li>')
+        else:
+            items.append(f'<li><a href="{href}">{label}</a></li>')
+    links = "".join(items)
+    return f'<nav class="dashboard-nav"><ul>{links}</ul></nav>'

--- a/src/brigade/center_cmd/dashboard/views/activity_heatmap.py
+++ b/src/brigade/center_cmd/dashboard/views/activity_heatmap.py
@@ -1,23 +1,138 @@
-"""Activity heatmap dashboard view (stub)."""
+"""Activity heatmap dashboard view."""
 
 from __future__ import annotations
 
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
+from brigade.center_cmd.dashboard import data
 from brigade.center_cmd.dashboard import render as html
 
 NAME = "activity"
 TITLE = "Activity"
 ORDER = 6
 
+_WEEKS = 52
+_DAYS_PER_WEEK = 7
+_GRID_DAYS = _WEEKS * _DAYS_PER_WEEK
+_WINDOW_DAYS = _GRID_DAYS
+_ACCENT = (0, 102, 204)
+_OUT_OF_WINDOW_COLOR = "#f8f8f8"
+_ZERO_IN_WINDOW_COLOR = "#e6f0fa"
+_SHADE_RATIOS = (0.25, 0.5, 0.75, 1.0)
+
 
 def fetch(target: Path) -> dict:
-    return {}
+    return data.run_json(target, ["work", "verify", "runs"])
+
+
+def _today_utc() -> date:
+    return datetime.now(timezone.utc).date()
+
+
+def _parse_day(value: object) -> date | None:
+    if not isinstance(value, str) or not value:
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc).date()
+
+
+def _bucket_counts(runs: list[object]) -> dict[date, int]:
+    counts: dict[date, int] = {}
+    for run in runs:
+        if not isinstance(run, dict):
+            continue
+        ts = run.get("started_at") or run.get("completed_at")
+        day = _parse_day(ts)
+        if day is None:
+            continue
+        counts[day] = counts.get(day, 0) + 1
+    return counts
+
+
+def _window_bounds(end: date) -> tuple[date, date, date]:
+    window_start = end - timedelta(days=_WINDOW_DAYS - 1)
+    days_until_saturday = 6 - ((end.weekday() + 1) % 7)
+    grid_end = end + timedelta(days=days_until_saturday)
+    grid_start = grid_end - timedelta(days=_GRID_DAYS - 1)
+    return window_start, end, grid_start
+
+
+def _mix_accent(ratio: float) -> str:
+    def mix(channel: int) -> int:
+        return round(255 + (channel - 255) * ratio)
+
+    red, green, blue = _ACCENT
+    return f"#{mix(red):02x}{mix(green):02x}{mix(blue):02x}"
+
+
+def _activity_level(count: int, max_count: int) -> int:
+    """Bucket a day's run count into shade level 1..len(_SHADE_RATIOS)."""
+    steps = len(_SHADE_RATIOS)
+    if max_count <= 1:
+        return steps
+    scaled = (count - 1) / (max_count - 1)
+    return min(steps, 1 + int(scaled * (steps - 1) + 0.999999))
+
+
+def _stylesheet(nonce: str) -> str:
+    """Emit the heatmap palette as a nonce'd stylesheet.
+
+    The dashboard CSP sets `style-src 'nonce-...'` with no `unsafe-inline`, so
+    inline `style=` attributes are dropped by the browser and every cell would
+    render blank. Shades ship as classes in a nonced <style> block instead.
+    """
+    rules = [
+        f".activity-cell.activity-out {{ background-color: {_OUT_OF_WINDOW_COLOR}; }}",
+        f".activity-cell.activity-l0 {{ background-color: {_ZERO_IN_WINDOW_COLOR}; }}",
+    ]
+    for index, ratio in enumerate(_SHADE_RATIOS, start=1):
+        rules.append(f".activity-cell.activity-l{index} {{ background-color: {_mix_accent(ratio)}; }}")
+    rules.append(".activity-cell { width: 0.75rem; height: 0.75rem; padding: 0; }")
+    return f'<style nonce="{html.esc(nonce)}">{"".join(rules)}</style>'
 
 
 def render(payload: dict, nonce: str) -> str:
-    del payload, nonce
-    return html.panel(
-        html.esc("Activity"),
-        f"<p>{html.esc('Not implemented yet.')}</p>",
-    )
+    if payload.get("error"):
+        return html.error_panel(TITLE, str(payload["error"]))
+
+    runs = payload.get("runs")
+    if not isinstance(runs, list) or not runs:
+        return html.panel(html.esc(TITLE), f"<p>{html.esc('Nothing here.')}</p>")
+
+    counts = _bucket_counts(runs)
+    window_end = _today_utc()
+    window_start, window_end, grid_start = _window_bounds(window_end)
+    in_window_counts = [count for day, count in counts.items() if window_start <= day <= window_end]
+    max_count = max(in_window_counts) if in_window_counts else 0
+
+    body_rows: list[str] = []
+    for dow in range(_DAYS_PER_WEEK):
+        cells: list[str] = []
+        for week in range(_WEEKS):
+            day = grid_start + timedelta(days=week * _DAYS_PER_WEEK + dow)
+            if day < window_start or day > window_end:
+                shade = "activity-out"
+                title = f"{day.isoformat()}: out of range"
+            else:
+                count = counts.get(day, 0)
+                if count == 0:
+                    shade = "activity-l0"
+                    title = f"{day.isoformat()}: 0 runs"
+                else:
+                    shade = f"activity-l{_activity_level(count, max_count)}"
+                    suffix = "run" if count == 1 else "runs"
+                    title = f"{day.isoformat()}: {count} {suffix}"
+            cells.append(f'<td class="activity-cell {shade}" title="{html.esc(title)}"></td>')
+        body_rows.append(f"<tr>{''.join(cells)}</tr>")
+
+    table = f'<table class="data-table activity-heatmap"><tbody>{"".join(body_rows)}</tbody></table>'
+    return html.panel(html.esc(TITLE), f"{_stylesheet(nonce)}{table}")

--- a/src/brigade/center_cmd/dashboard/views/activity_heatmap.py
+++ b/src/brigade/center_cmd/dashboard/views/activity_heatmap.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
+from brigade import config
 from brigade.center_cmd.dashboard import data
 from brigade.center_cmd.dashboard import render as html
 
@@ -23,7 +24,9 @@ _SHADE_RATIOS = (0.25, 0.5, 0.75, 1.0)
 
 
 def fetch(target: Path) -> dict:
-    return data.run_json(target, ["work", "verify", "runs"])
+    # Request the full retained verify-run history (default CLI limit is 20).
+    limit = str(config.DEFAULT_VERIFY_RUNS_KEEP)
+    return data.run_json(target, ["work", "verify", "runs", "--limit", limit])
 
 
 def _today_utc() -> date:

--- a/src/brigade/center_cmd/dashboard/views/activity_heatmap.py
+++ b/src/brigade/center_cmd/dashboard/views/activity_heatmap.py
@@ -1,0 +1,23 @@
+"""Activity heatmap dashboard view (stub)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from brigade.center_cmd.dashboard import render as html
+
+NAME = "activity"
+TITLE = "Activity"
+ORDER = 6
+
+
+def fetch(target: Path) -> dict:
+    return {}
+
+
+def render(payload: dict, nonce: str) -> str:
+    del payload, nonce
+    return html.panel(
+        html.esc("Activity"),
+        f"<p>{html.esc('Not implemented yet.')}</p>",
+    )

--- a/src/brigade/center_cmd/dashboard/views/handoff_inbox.py
+++ b/src/brigade/center_cmd/dashboard/views/handoff_inbox.py
@@ -1,9 +1,10 @@
-"""Handoff inbox dashboard view (stub)."""
+"""Handoff inbox dashboard view."""
 
 from __future__ import annotations
 
 from pathlib import Path
 
+from brigade.center_cmd.dashboard import data
 from brigade.center_cmd.dashboard import render as html
 
 NAME = "handoffs"
@@ -12,12 +13,95 @@ ORDER = 2
 
 
 def fetch(target: Path) -> dict:
-    return {}
+    return data.run_json(target, ["handoff", "lint"])
 
 
 def render(payload: dict, nonce: str) -> str:
-    del payload, nonce
-    return html.panel(
-        html.esc("Handoffs"),
-        f"<p>{html.esc('Not implemented yet.')}</p>",
+    del nonce
+    if payload.get("error"):
+        return html.error_panel(TITLE, str(payload["error"]))
+
+    results = payload.get("results")
+    if not isinstance(results, list) or not results:
+        return html.panel(html.esc(TITLE), f"<p>{html.esc('Nothing pending.')}</p>")
+
+    parts: list[str] = []
+    injection_count = payload.get("injection_flagged_count", 0)
+    parts.append(
+        html.panel(
+            html.esc("Injection-flagged handoffs"),
+            f'<p class="error"><strong>{html.esc(injection_count)}</strong> '
+            f"{html.esc('file(s) with prompt-injection signals')}</p>",
+        )
     )
+
+    count = payload.get("count", len(results))
+    valid = payload.get("valid")
+    valid_label = "yes" if valid is True else "no" if valid is False else "-"
+    summary_rows = [
+        [html.esc("Pending files"), html.esc(count)],
+        [html.esc("All valid"), html.esc(valid_label)],
+    ]
+    parts.append(
+        html.panel(
+            html.esc("Queue summary"),
+            html.table([html.esc("Metric"), html.esc("Value")], summary_rows),
+        )
+    )
+
+    table_rows: list[list[str]] = []
+    for item in results:
+        if not isinstance(item, dict):
+            continue
+        path = item.get("path", "-")
+        valid_item = item.get("valid")
+        if valid_item is True:
+            lint_state = "valid"
+        elif valid_item is False:
+            lint_state = "invalid"
+        else:
+            lint_state = "-"
+        issues = _lint_issues(item)
+        injection_signals = item.get("injection_signals", 0)
+        if injection_signals:
+            issues = (
+                f"{issues}; injection signals: {injection_signals}"
+                if issues
+                else (f"injection signals: {injection_signals}")
+            )
+        table_rows.append(
+            [
+                html.esc(path),
+                html.esc(lint_state),
+                html.esc(item.get("action") or "-"),
+                html.esc(issues or "-"),
+            ]
+        )
+
+    if not table_rows:
+        return html.panel(html.esc(TITLE), f"<p>{html.esc('Nothing pending.')}</p>")
+
+    parts.append(
+        html.panel(
+            html.esc(TITLE),
+            html.table(
+                [
+                    html.esc("Path"),
+                    html.esc("Lint"),
+                    html.esc("Action"),
+                    html.esc("Issues"),
+                ],
+                table_rows,
+            ),
+        )
+    )
+    return "".join(parts)
+
+
+def _lint_issues(item: dict) -> str:
+    messages: list[str] = []
+    for key in ("errors", "warnings"):
+        values = item.get(key)
+        if isinstance(values, list):
+            messages.extend(str(value) for value in values)
+    return "; ".join(messages)

--- a/src/brigade/center_cmd/dashboard/views/handoff_inbox.py
+++ b/src/brigade/center_cmd/dashboard/views/handoff_inbox.py
@@ -1,0 +1,23 @@
+"""Handoff inbox dashboard view (stub)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from brigade.center_cmd.dashboard import render as html
+
+NAME = "handoffs"
+TITLE = "Handoffs"
+ORDER = 2
+
+
+def fetch(target: Path) -> dict:
+    return {}
+
+
+def render(payload: dict, nonce: str) -> str:
+    del payload, nonce
+    return html.panel(
+        html.esc("Handoffs"),
+        f"<p>{html.esc('Not implemented yet.')}</p>",
+    )

--- a/src/brigade/center_cmd/dashboard/views/memory_cards.py
+++ b/src/brigade/center_cmd/dashboard/views/memory_cards.py
@@ -1,0 +1,23 @@
+"""Memory cards dashboard view (stub)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from brigade.center_cmd.dashboard import render as html
+
+NAME = "cards"
+TITLE = "Cards"
+ORDER = 3
+
+
+def fetch(target: Path) -> dict:
+    return {}
+
+
+def render(payload: dict, nonce: str) -> str:
+    del payload, nonce
+    return html.panel(
+        html.esc("Cards"),
+        f"<p>{html.esc('Not implemented yet.')}</p>",
+    )

--- a/src/brigade/center_cmd/dashboard/views/memory_cards.py
+++ b/src/brigade/center_cmd/dashboard/views/memory_cards.py
@@ -1,23 +1,103 @@
-"""Memory cards dashboard view (stub)."""
+"""Memory cards dashboard view."""
 
 from __future__ import annotations
 
 from pathlib import Path
 
+from brigade.center_cmd.dashboard import data
 from brigade.center_cmd.dashboard import render as html
 
 NAME = "cards"
 TITLE = "Cards"
 ORDER = 3
 
+# memory search has no list-all mode; card frontmatter contains YAML key separators.
+# A leading-dash query such as "---" is parsed as an option by argparse.
+_LIST_QUERY = ":"
+_LIST_LIMIT = "500"
+_TABLE_ID = "memory-cards-table"
+
 
 def fetch(target: Path) -> dict:
-    return {}
+    return data.run_json(
+        target,
+        ["memory", "search", _LIST_QUERY, "--limit", _LIST_LIMIT],
+    )
 
 
 def render(payload: dict, nonce: str) -> str:
-    del payload, nonce
-    return html.panel(
-        html.esc("Cards"),
-        f"<p>{html.esc('Not implemented yet.')}</p>",
+    del nonce
+    if payload.get("error"):
+        return html.error_panel(TITLE, str(payload["error"]))
+
+    matches = payload.get("matches")
+    if not isinstance(matches, list) or not matches:
+        return html.panel(html.esc(TITLE), f"<p>{html.esc('Nothing here.')}</p>")
+
+    rows: list[list[str]] = []
+    for item in matches:
+        if not isinstance(item, dict):
+            continue
+        rows.append(
+            [
+                _esc_cell(_cell(item, "title")),
+                _esc_cell(_tags(item.get("tags"))),
+                # memory search does not currently emit reviewed/freshness fields.
+                _esc_cell(_cell(item, "last_reviewed", "reviewed", "reviewed_at")),
+                _esc_cell(_cell(item, "fresh_until", "freshness", "expires_at")),
+            ]
+        )
+
+    if not rows:
+        return html.panel(html.esc(TITLE), f"<p>{html.esc('Nothing here.')}</p>")
+
+    table_id = html.esc(_TABLE_ID)
+    table_html = html.table(
+        [
+            html.esc("Title"),
+            html.esc("Tags"),
+            html.esc("Reviewed"),
+            html.esc("Freshness"),
+        ],
+        rows,
     )
+    table_html = table_html.replace(
+        '<table class="data-table">',
+        f'<table id="{table_id}" class="data-table">',
+        1,
+    )
+    filter_input = (
+        f'<p><input type="search" '
+        f'placeholder="{html.esc("Filter cards")}" '
+        f'data-filter-target="{table_id}" '
+        f'aria-label="{html.esc("Filter cards")}"></p>'
+    )
+    return html.panel(html.esc(TITLE), filter_input + table_html)
+
+
+def _esc_cell(value: object) -> str:
+    """Escape a card field for table output.
+
+    Plain HTML escaping is the whole defence: once ``<`` and ``>`` are entities,
+    the value is text and no tag or attribute can form from it. An ``on*=``
+    substring surviving inside that escaped text is inert, so do not add a
+    cosmetic ``=`` transform to make a substring search look clean.
+    """
+    return html.esc(value)
+
+
+def _cell(item: dict, *keys: str) -> object:
+    for key in keys:
+        value = item.get(key)
+        if value is not None and value != "":
+            return value
+    return "-"
+
+
+def _tags(value: object) -> str:
+    if isinstance(value, list):
+        parts = [str(part) for part in value if part is not None and str(part) != ""]
+        return ", ".join(parts) if parts else "-"
+    if value is None or value == "":
+        return "-"
+    return str(value)

--- a/src/brigade/center_cmd/dashboard/views/outcome_rank.py
+++ b/src/brigade/center_cmd/dashboard/views/outcome_rank.py
@@ -1,0 +1,23 @@
+"""Outcome rank dashboard view (stub)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from brigade.center_cmd.dashboard import render as html
+
+NAME = "outcomes"
+TITLE = "Outcomes"
+ORDER = 4
+
+
+def fetch(target: Path) -> dict:
+    return {}
+
+
+def render(payload: dict, nonce: str) -> str:
+    del payload, nonce
+    return html.panel(
+        html.esc("Outcomes"),
+        f"<p>{html.esc('Not implemented yet.')}</p>",
+    )

--- a/src/brigade/center_cmd/dashboard/views/outcome_rank.py
+++ b/src/brigade/center_cmd/dashboard/views/outcome_rank.py
@@ -1,23 +1,72 @@
-"""Outcome rank dashboard view (stub)."""
+"""Outcome rank dashboard view."""
 
 from __future__ import annotations
 
 from pathlib import Path
 
+from brigade.center_cmd.dashboard import data
 from brigade.center_cmd.dashboard import render as html
 
 NAME = "outcomes"
 TITLE = "Outcomes"
 ORDER = 4
 
+_EMPTY_MESSAGE = (
+    "The outcome ranking is empty. The outcome loop is not being fed: "
+    "run verification through a registered verifier and capture outcomes."
+)
+
 
 def fetch(target: Path) -> dict:
-    return {}
+    return data.run_json(target, ["outcome", "rank"])
 
 
 def render(payload: dict, nonce: str) -> str:
-    del payload, nonce
-    return html.panel(
-        html.esc("Outcomes"),
-        f"<p>{html.esc('Not implemented yet.')}</p>",
-    )
+    del nonce
+    if payload.get("error"):
+        return html.error_panel(TITLE, str(payload["error"]))
+
+    ranking = payload.get("ranking")
+    if not isinstance(ranking, list):
+        ranking = []
+    entries = [entry for entry in ranking if isinstance(entry, dict)]
+    if not entries:
+        return html.panel(html.esc(TITLE), f"<p>{html.esc(_EMPTY_MESSAGE)}</p>")
+
+    headers = [
+        "Artifact",
+        "Score",
+        "Helped",
+        "Hurt",
+        "Capability score",
+        "Capability helped",
+        "Capability hurt",
+        "Stale records",
+        "Legacy records",
+    ]
+    rows = []
+    for entry in entries:
+        rows.append(
+            [
+                html.esc(entry.get("artifact_id", "-")),
+                html.esc(_fmt(entry.get("score"))),
+                html.esc(_fmt(entry.get("helped"))),
+                html.esc(_fmt(entry.get("hurt"))),
+                html.esc(_fmt(entry.get("capability_score"))),
+                html.esc(_fmt(entry.get("capability_helped"))),
+                html.esc(_fmt(entry.get("capability_hurt"))),
+                html.esc(_fmt(entry.get("stale_records"))),
+                html.esc(_fmt(entry.get("legacy_records"))),
+            ]
+        )
+    escaped_headers = [html.esc(header) for header in headers]
+    return html.panel(html.esc(TITLE), html.table(escaped_headers, rows))
+
+
+def _fmt(value: object) -> object:
+    """Format a cell value; floats get 3 decimals, missing keys a dash."""
+    if value is None:
+        return "-"
+    if isinstance(value, float):
+        return f"{value:.3f}"
+    return value

--- a/src/brigade/center_cmd/dashboard/views/run_timeline.py
+++ b/src/brigade/center_cmd/dashboard/views/run_timeline.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
+from brigade.center_cmd.dashboard import data
 from brigade.center_cmd.dashboard import render as html
 
 NAME = "runs"
@@ -12,12 +14,74 @@ ORDER = 5
 
 
 def fetch(target: Path) -> dict:
-    return {}
+    return data.run_json(target, ["work", "verify", "runs"])
 
 
 def render(payload: dict, nonce: str) -> str:
-    del payload, nonce
+    del nonce
+    if payload.get("error"):
+        return html.error_panel(TITLE, str(payload["error"]))
+
+    runs = payload.get("runs")
+    if not isinstance(runs, list) or not runs:
+        return _empty_panel()
+
+    rows = []
+    for receipt in sorted(
+        (item for item in runs if isinstance(item, dict)),
+        key=lambda item: str(item.get("started_at") or item.get("run_id") or ""),
+        reverse=True,
+    ):
+        commands = receipt.get("commands")
+        command_records = commands if isinstance(commands, list) else []
+        rows.append(
+            [
+                html.esc(_value(receipt, "run_id")),
+                html.esc(_value(receipt, "status")),
+                html.esc(_command_values(command_records, "command")),
+                html.esc(_command_values(command_records, "exit_code")),
+                html.esc(_value(receipt, "duration_seconds")),
+                html.esc(_value(receipt, "started_at")),
+                _receipt_details(receipt),
+            ]
+        )
+
+    if not rows:
+        return _empty_panel()
+
     return html.panel(
-        html.esc("Runs"),
-        f"<p>{html.esc('Not implemented yet.')}</p>",
+        html.esc(TITLE),
+        html.table(
+            [
+                html.esc("Run ID"),
+                html.esc("Status"),
+                html.esc("Command"),
+                html.esc("Exit code"),
+                html.esc("Duration"),
+                html.esc("Timestamp"),
+                html.esc("Receipt"),
+            ],
+            rows,
+        ),
     )
+
+
+def _empty_panel() -> str:
+    return html.panel(html.esc(TITLE), f"<p>{html.esc('Nothing here.')}</p>")
+
+
+def _value(receipt: dict, name: str) -> object:
+    value = receipt.get(name)
+    return "-" if value is None else value
+
+
+def _command_values(commands: list[object], name: str) -> str:
+    values = [str(command[name]) for command in commands if isinstance(command, dict) and name in command]
+    return "; ".join(values) if values else "-"
+
+
+def _receipt_details(receipt: dict) -> str:
+    rendered = json.dumps(receipt, indent=2, sort_keys=True)
+    if len(rendered) > 4_000:
+        rendered = f"{rendered[:4_000]}\n[Receipt truncated at 4000 characters.]"
+    return f"<details><summary>Receipt JSON</summary><pre>{html.esc(rendered)}</pre></details>"

--- a/src/brigade/center_cmd/dashboard/views/run_timeline.py
+++ b/src/brigade/center_cmd/dashboard/views/run_timeline.py
@@ -1,0 +1,23 @@
+"""Run timeline dashboard view (stub)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from brigade.center_cmd.dashboard import render as html
+
+NAME = "runs"
+TITLE = "Runs"
+ORDER = 5
+
+
+def fetch(target: Path) -> dict:
+    return {}
+
+
+def render(payload: dict, nonce: str) -> str:
+    del payload, nonce
+    return html.panel(
+        html.esc("Runs"),
+        f"<p>{html.esc('Not implemented yet.')}</p>",
+    )

--- a/src/brigade/center_cmd/dashboard/views/status_grid.py
+++ b/src/brigade/center_cmd/dashboard/views/status_grid.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from brigade.center_cmd.dashboard import data
 from brigade.center_cmd.dashboard import render as html
 
 NAME = "status"
@@ -12,12 +13,47 @@ ORDER = 1
 
 
 def fetch(target: Path) -> dict:
-    return {}
+    return data.run_json(target, ["work", "brief"])
 
 
 def render(payload: dict, nonce: str) -> str:
-    del payload, nonce
+    del nonce
+    if payload.get("error"):
+        return html.error_panel(TITLE, str(payload["error"]))
+    if not payload:
+        return html.panel(html.esc(TITLE), f"<p>{html.esc('Nothing here.')}</p>")
+
+    handoff_issues = _section(payload, "handoff_issues")
+    memory_care = _section(payload, "memory_care")
+    outcome_loop = _section(payload, "outcome_loop")
+    inbox_hygiene = _section(payload, "inbox_hygiene")
+    pending_tasks = payload.get("pending_tasks")
+
+    rows = [
+        ("Pending handoff issues", _value(handoff_issues, "count")),
+        ("Total handoff issues", _value(handoff_issues, "total_count")),
+        ("Memory cards at refresh risk", _value(memory_care, "issue_count")),
+        # work brief does not currently emit the latest receipt or signal.
+        ("Latest verify receipt", "-"),
+        ("Latest verify signal", "-"),
+        ("Verify runs", _value(outcome_loop, "verify_run_count")),
+        ("Outcome records", _value(outcome_loop, "record_count")),
+        ("Eligible outcome receipts", _value(outcome_loop, "eligible_receipt_count")),
+        ("Open work-inbox items", len(pending_tasks) if isinstance(pending_tasks, list) else "-"),
+        ("Inbox hygiene issues", _value(inbox_hygiene, "issue_count")),
+    ]
+    escaped_rows = [[html.esc(label), html.esc(value)] for label, value in rows]
     return html.panel(
-        html.esc("Status"),
-        f"<p>{html.esc('Not implemented yet.')}</p>",
+        html.esc(TITLE),
+        html.table([html.esc("Signal"), html.esc("Value")], escaped_rows),
     )
+
+
+def _section(payload: dict, name: str) -> dict:
+    value = payload.get(name)
+    return value if isinstance(value, dict) else {}
+
+
+def _value(section: dict, name: str) -> object:
+    value = section.get(name)
+    return "-" if value is None else value

--- a/src/brigade/center_cmd/dashboard/views/status_grid.py
+++ b/src/brigade/center_cmd/dashboard/views/status_grid.py
@@ -1,0 +1,23 @@
+"""Status grid dashboard view (stub)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from brigade.center_cmd.dashboard import render as html
+
+NAME = "status"
+TITLE = "Status"
+ORDER = 1
+
+
+def fetch(target: Path) -> dict:
+    return {}
+
+
+def render(payload: dict, nonce: str) -> str:
+    del payload, nonce
+    return html.panel(
+        html.esc("Status"),
+        f"<p>{html.esc('Not implemented yet.')}</p>",
+    )

--- a/src/brigade/center_cmd/serve.py
+++ b/src/brigade/center_cmd/serve.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import hmac
-import html
 import ipaddress
 import secrets
 import socket
@@ -11,53 +10,13 @@ import sys
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Sequence
+from urllib.parse import urlparse
+
+from brigade.center_cmd.dashboard import render
+from brigade.center_cmd.dashboard.views import all_views, render_nav, view_by_name
 
 _DEFAULT_PORT = 8765
-
-_INDEX_TEMPLATE = """<!doctype html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>{title}</title>
-<style nonce="{nonce}">
-body {{
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  line-height: 1.5;
-  margin: 2rem;
-  color: #111;
-  background: #fff;
-}}
-h1 {{
-  font-size: 1.5rem;
-  color: #0066cc;
-}}
-button {{
-  background: #0066cc;
-  color: #fff;
-  border: none;
-  padding: 0.5rem 1rem;
-  border-radius: 0.25rem;
-  cursor: pointer;
-}}
-</style>
-</head>
-<body>
-<h1>{title}</h1>
-<p>Dashboard views will land in a follow-up.</p>
-<button type="button" data-action="demo">Show greeting</button>
-<script nonce="{nonce}">
-document.addEventListener("DOMContentLoaded", function() {{
-  document.body.addEventListener("click", function(e) {{
-    var target = e.target.closest('[data-action="demo"]');
-    if (!target) return;
-    target.textContent = "Hello from the dashboard skeleton";
-  }});
-}});
-</script>
-</body>
-</html>
-"""
+_VIEW_PREFIX = "/view/"
 
 
 def _has_port(host: str) -> bool:
@@ -118,6 +77,7 @@ class _DashboardHandler(BaseHTTPRequestHandler):
     _token: str | None = None
     _allowed_exact: set[str] = set()
     _allowed_bare: set[str] = set()
+    _target: Path = Path(".")
 
     def _write_response(
         self,
@@ -209,22 +169,53 @@ class _DashboardHandler(BaseHTTPRequestHandler):
             self.log_error("Request timed out: %r", exc)
             self.close_connection = True
 
-    def _render_index(self, nonce: str) -> bytes:
-        title = html.escape("Brigade Center", quote=True)
-        nonce_escaped = html.escape(nonce, quote=True)
-        page = _INDEX_TEMPLATE.format(title=title, nonce=nonce_escaped)
+    def _parse_view_name(self, path: str) -> str | None:
+        parsed = urlparse(path)
+        route = parsed.path
+        if route == "/":
+            views = all_views()
+            return views[0].NAME if views else None
+        if not route.startswith(_VIEW_PREFIX):
+            return None
+        slug = route[len(_VIEW_PREFIX) :]
+        if not slug or "/" in slug:
+            return None
+        return slug
+
+    def _render_view(self, view_name: str, nonce: str) -> bytes:
+        module = view_by_name(view_name)
+        if module is None:
+            raise KeyError(view_name)
+        # A view that raises must degrade to an inline panel, not a 500. The
+        # default error path would answer without the security headers and
+        # would put a traceback on the page.
+        try:
+            payload = module.fetch(self._target)
+            fragment = module.render(payload, nonce)
+        except Exception:  # noqa: BLE001 - one broken panel must not take the page down
+            fragment = render.error_panel(module.TITLE, "This view failed to render.")
+        title = render.esc(f"{module.TITLE} - Brigade Center")
+        heading = f'<h1 class="page-title">{render.esc(module.TITLE)}</h1>'
+        body = f"{heading}{fragment}"
+        nav = render_nav(view_name)
+        page = render.page(title, nonce, nav, body)
         return page.encode("utf-8")
 
     def do_GET(self) -> None:
-        if self.path != "/":
+        view_name = self._parse_view_name(self.path)
+        if view_name is None:
+            self._write_response(404, "Not found.\n")
+            return
+        if view_by_name(view_name) is None:
             self._write_response(404, "Not found.\n")
             return
         nonce = secrets.token_urlsafe(16)
-        body = self._render_index(nonce)
+        body = self._render_view(view_name, nonce)
         self._write_response(200, body, "text/html; charset=utf-8", nonce)
 
     def do_HEAD(self) -> None:
-        if self.path != "/":
+        view_name = self._parse_view_name(self.path)
+        if view_name is None or view_by_name(view_name) is None:
             self._write_response(404, b"")
             return
         self._write_response(200, b"", "text/html; charset=utf-8")
@@ -239,6 +230,7 @@ def _make_server(
     port: int = _DEFAULT_PORT,
     token: str | None = None,
     allowed_hosts: Sequence[str] | None = None,
+    target: Path | None = None,
 ) -> ThreadingHTTPServer:
     """Build and bind the server without starting it."""
     validate_bind_security(host, token, allowed_hosts)
@@ -256,6 +248,7 @@ def _make_server(
 
     class _BoundHandler(_DashboardHandler):
         _token = token
+        _target = target if target is not None else Path(".")
 
     host_lc = host.strip().lower()
     server = ThreadingHTTPServer((host, port), _BoundHandler)
@@ -292,7 +285,7 @@ def serve(
     Prints the bound URL and runs until interrupted, then returns 0.
     """
     try:
-        server = _make_server(host=host, port=port, token=token, allowed_hosts=allowed_hosts)
+        server = _make_server(host=host, port=port, token=token, allowed_hosts=allowed_hosts, target=target)
     except ValueError as exc:
         print(f"brigade center serve: {exc}", file=sys.stderr)
         return 2

--- a/tests/test_center_dashboard.py
+++ b/tests/test_center_dashboard.py
@@ -1,0 +1,135 @@
+import re
+import subprocess
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from brigade.center_cmd.dashboard import data, render
+from brigade.center_cmd.dashboard.views import all_views
+from brigade.center_cmd.serve import _make_server
+from tests.test_center_serve import _headers_and_body, _raw_request, _status_code, _wait_until_ready
+
+
+@pytest.fixture
+def dashboard_server(tmp_target):
+    server = _make_server(
+        host="127.0.0.1",
+        port=0,
+        token=None,
+        allowed_hosts=None,
+        target=tmp_target,
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    _wait_until_ready(server)
+    yield server
+    server.shutdown()
+    server.server_close()
+
+
+def test_esc_escapes_html_special_characters():
+    assert render.esc("<>&\"'") == "&lt;&gt;&amp;&quot;&#x27;"
+
+
+def test_run_json_returns_error_on_nonzero_exit(monkeypatch, tmp_target):
+    def fake_run(*args, **kwargs):
+        return SimpleNamespace(returncode=1, stdout="", stderr="command failed badly")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = data.run_json(tmp_target, ["status"])
+    assert result == {"error": "command failed badly"}
+
+
+def test_run_json_returns_error_on_malformed_json(monkeypatch, tmp_target):
+    def fake_run(*args, **kwargs):
+        return SimpleNamespace(returncode=0, stdout="not-json", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = data.run_json(tmp_target, ["status"])
+    assert result == {"error": "invalid JSON from command"}
+
+
+def test_run_json_never_uses_shell_true(monkeypatch, tmp_target):
+    captured: dict[str, object] = {}
+
+    def fake_run(*args, **kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(returncode=0, stdout="{}", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    data.run_json(tmp_target, ["status"])
+    assert captured.get("shell") is not True
+
+
+@pytest.mark.parametrize(
+    "attr",
+    ["NAME", "TITLE", "ORDER", "fetch", "render"],
+)
+def test_registered_views_expose_contract(attr):
+    for module in all_views():
+        assert hasattr(module, attr)
+
+
+def test_registered_view_names_are_unique():
+    names = [module.NAME for module in all_views()]
+    assert len(names) == len(set(names))
+
+
+def test_get_view_status_returns_200(dashboard_server):
+    host, port = dashboard_server.server_address
+    response = _raw_request(dashboard_server, f"{host}:{port}", path="/view/status")
+    assert _status_code(response) == "200"
+
+
+def test_get_unknown_view_returns_404(dashboard_server):
+    host, port = dashboard_server.server_address
+    response = _raw_request(dashboard_server, f"{host}:{port}", path="/view/nope")
+    assert _status_code(response) == "404"
+
+
+def test_rendered_page_has_no_inline_handlers_and_nonce_matches(dashboard_server):
+    host, port = dashboard_server.server_address
+    response = _raw_request(dashboard_server, f"{host}:{port}", path="/view/status")
+    headers, body = _headers_and_body(response)
+
+    assert re.search(r"\bon\w+\s*=", body, re.IGNORECASE) is None
+
+    nonce_match = re.search(r"script-src 'nonce-([^'\s]+)'", headers)
+    assert nonce_match is not None
+    nonce = nonce_match.group(1)
+    assert f'<script nonce="{nonce}"' in body
+    assert f'<style nonce="{nonce}"' in body
+
+
+def test_rendered_page_includes_polling_reload(dashboard_server):
+    host, port = dashboard_server.server_address
+    response = _raw_request(dashboard_server, f"{host}:{port}", path="/view/status")
+    _, body = _headers_and_body(response)
+    assert "location.reload" in body
+
+
+def test_view_exception_degrades_to_panel_not_500(monkeypatch):
+    """A raising view must render an inline error, never a traceback page."""
+    from brigade.center_cmd.dashboard.views import status_grid
+
+    def _boom(target):
+        raise RuntimeError("fixture failure")
+
+    monkeypatch.setattr(status_grid, "fetch", _boom)
+
+    server = _make_server(host="127.0.0.1", port=0, token=None, allowed_hosts=None)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = server.server_address
+        response = _raw_request(server, f"{host}:{port}", path="/view/status")
+        headers, body = _headers_and_body(response)
+        assert _status_code(response) == "200"
+        assert "default-src 'none'" in headers
+        assert "failed to render" in body
+        assert "Traceback" not in body
+        assert "fixture failure" not in body
+    finally:
+        server.shutdown()
+        server.server_close()

--- a/tests/test_dashboard_activity.py
+++ b/tests/test_dashboard_activity.py
@@ -15,7 +15,7 @@ def test_fetch_uses_verify_runs_json(monkeypatch, tmp_path):
     monkeypatch.setattr("brigade.center_cmd.dashboard.data.run_json", fake_run_json)
 
     assert activity_heatmap.fetch(tmp_path) == expected
-    assert calls == [(tmp_path, ["work", "verify", "runs"])]
+    assert calls == [(tmp_path, ["work", "verify", "runs", "--limit", "50"])]
 
 
 def test_render_builds_year_grid_with_titles(monkeypatch):

--- a/tests/test_dashboard_activity.py
+++ b/tests/test_dashboard_activity.py
@@ -1,0 +1,95 @@
+from datetime import date
+from pathlib import Path
+
+from brigade.center_cmd.dashboard.views import activity_heatmap
+
+
+def test_fetch_uses_verify_runs_json(monkeypatch, tmp_path):
+    expected = {"runs": []}
+    calls: list[tuple[Path, list[str]]] = []
+
+    def fake_run_json(target: Path, args: list[str]) -> dict:
+        calls.append((target, args))
+        return expected
+
+    monkeypatch.setattr("brigade.center_cmd.dashboard.data.run_json", fake_run_json)
+
+    assert activity_heatmap.fetch(tmp_path) == expected
+    assert calls == [(tmp_path, ["work", "verify", "runs"])]
+
+
+def test_render_builds_year_grid_with_titles(monkeypatch):
+    # Tuesday anchor so the Sunday-aligned grid has leading out-of-window days.
+    anchor = date(2026, 2, 3)
+    monkeypatch.setattr(activity_heatmap, "_today_utc", lambda: anchor)
+
+    payload = {
+        "runs": [
+            {"started_at": "2026-01-15T09:00:00Z"},
+            {"started_at": "2026-01-15T18:00:00Z"},
+            {"started_at": "2026-01-20T12:00:00Z"},
+        ]
+    }
+
+    fragment = activity_heatmap.render(payload, "test-nonce")
+
+    assert fragment.count('class="activity-cell ') == 52 * 7
+    assert 'title="2026-01-15: 2 runs"' in fragment
+    assert 'title="2026-01-20: 1 run"' in fragment
+    assert 'title="2026-01-16: 0 runs"' in fragment
+    assert "out of range" in fragment
+
+    # A dormant day inside the window must be visually distinct from a cell
+    # outside the window, and both from a day that saw runs.
+    assert 'class="activity-cell activity-l0"' in fragment
+    assert 'class="activity-cell activity-out"' in fragment
+    assert 'class="activity-cell activity-l4"' in fragment
+    assert f".activity-cell.activity-l0 {{ background-color: {activity_heatmap._ZERO_IN_WINDOW_COLOR}; }}" in fragment
+    assert f".activity-cell.activity-out {{ background-color: {activity_heatmap._OUT_OF_WINDOW_COLOR}; }}" in fragment
+
+
+def test_render_shades_via_nonced_stylesheet_not_inline_styles(monkeypatch):
+    """The dashboard CSP has no `unsafe-inline`, so shades must ride a nonce."""
+    monkeypatch.setattr(activity_heatmap, "_today_utc", lambda: date(2026, 2, 3))
+    payload = {"runs": [{"started_at": "2026-01-15T09:00:00Z"}]}
+
+    fragment = activity_heatmap.render(payload, "n0nce-value")
+
+    assert '<style nonce="n0nce-value">' in fragment
+    assert 'style="' not in fragment
+    assert "background-color" not in fragment.split("</style>", 1)[1]
+
+
+def test_window_includes_the_current_day_in_its_sunday_aligned_grid():
+    anchor = date(2026, 2, 3)
+
+    window_start, window_end, grid_start = activity_heatmap._window_bounds(anchor)
+
+    assert grid_start.weekday() == 6
+    assert window_start <= anchor <= window_end
+    assert grid_start <= anchor < grid_start + activity_heatmap._GRID_DAYS * (date.resolution)
+
+
+def test_render_error_and_empty_payloads_degrade_safely():
+    assert "boom" in activity_heatmap.render({"error": "boom"}, "unused")
+
+    assert "Nothing here." in activity_heatmap.render({}, "unused")
+    assert "Nothing here." in activity_heatmap.render({"runs": []}, "unused")
+
+
+def test_render_skips_malformed_timestamps_without_raising(monkeypatch):
+    anchor = date(2026, 1, 31)
+    monkeypatch.setattr(activity_heatmap, "_today_utc", lambda: anchor)
+
+    payload = {
+        "runs": [
+            {"started_at": "not-a-timestamp"},
+            {"completed_at": ""},
+            {"started_at": "2026-01-10T08:00:00Z"},
+        ]
+    }
+
+    fragment = activity_heatmap.render(payload, "unused")
+
+    assert fragment.count('class="activity-cell ') == 52 * 7
+    assert 'title="2026-01-10: 1 run"' in fragment

--- a/tests/test_dashboard_cards.py
+++ b/tests/test_dashboard_cards.py
@@ -1,0 +1,95 @@
+from pathlib import Path
+
+from brigade.center_cmd.dashboard.views import memory_cards
+
+
+def test_fetch_uses_memory_search_json(monkeypatch, tmp_path):
+    expected = {"matches": [], "match_count": 0}
+    calls: list[tuple[Path, list[str]]] = []
+
+    def fake_run_json(target: Path, args: list[str]) -> dict:
+        calls.append((target, args))
+        return expected
+
+    monkeypatch.setattr("brigade.center_cmd.dashboard.data.run_json", fake_run_json)
+
+    assert memory_cards.fetch(tmp_path) == expected
+    assert calls == [(tmp_path, ["memory", "search", ":", "--limit", "500"])]
+
+
+def test_render_displays_card_rows_and_filter_wiring():
+    payload = {
+        "match_count": 2,
+        "matches": [
+            {
+                "path": "memory/cards/fixture-alpha.md",
+                "title": "Fixture Alpha Card",
+                "tags": ["alpha", "fixture"],
+                "summary": "Example alpha summary",
+                "score": 3,
+            },
+            {
+                "path": "memory/cards/fixture-beta.md",
+                "title": "Fixture Beta Card",
+                "tags": ["beta"],
+                "summary": "Example beta summary",
+                "score": 3,
+                "last_reviewed": "2026-05-01",
+                "fresh_until": "2026-12-01",
+            },
+        ],
+    }
+
+    fragment = memory_cards.render(payload, "unused")
+
+    assert 'data-filter-target="memory-cards-table"' in fragment
+    assert 'id="memory-cards-table"' in fragment
+    assert "Fixture Alpha Card" in fragment
+    assert "Fixture Beta Card" in fragment
+    assert "alpha, fixture" in fragment
+    assert "beta" in fragment
+    assert "2026-05-01" in fragment
+    assert "2026-12-01" in fragment
+    assert ">-<" in fragment
+    assert "<th>Title</th>" in fragment
+    assert "<th>Tags</th>" in fragment
+    assert "<th>Reviewed</th>" in fragment
+    assert "<th>Freshness</th>" in fragment
+
+
+def test_render_escapes_hostile_card_title():
+    payload = {
+        "matches": [
+            {
+                "title": "<script>alert(1)</script><img src=x onerror=alert(2)>",
+                "tags": ["<b>tag</b>"],
+                "summary": "hostile fixture",
+                "score": 1,
+            }
+        ]
+    }
+
+    fragment = memory_cards.render(payload, "unused")
+
+    # The XSS boundary is whether a tag can form, not whether the string
+    # "onerror=" appears. Once < and > are entities the payload is text, so
+    # assert no tag opens and that the payload survives only in escaped form.
+    assert "<script" not in fragment
+    assert "<img" not in fragment
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in fragment
+    assert "&lt;img src=x onerror=alert(2)&gt;" in fragment
+    assert "&lt;b&gt;tag&lt;/b&gt;" in fragment
+
+    # No raw angle bracket from the hostile input reached the output: every
+    # tag in the fragment is one the view itself emitted.
+    import re
+
+    for tag in re.findall(r"<[^>]*>", fragment):
+        assert "alert(" not in tag
+
+
+def test_render_error_and_empty_payloads_degrade_safely():
+    assert "boom" in memory_cards.render({"error": "boom"}, "unused")
+
+    assert "Nothing here." in memory_cards.render({}, "unused")
+    assert "Nothing here." in memory_cards.render({"matches": []}, "unused")

--- a/tests/test_dashboard_handoffs.py
+++ b/tests/test_dashboard_handoffs.py
@@ -1,0 +1,89 @@
+from pathlib import Path
+
+from brigade.center_cmd.dashboard.views import handoff_inbox
+
+
+def test_fetch_uses_handoff_lint_json(monkeypatch, tmp_path):
+    expected = {"count": 1, "valid": True, "results": []}
+    calls: list[tuple[Path, list[str]]] = []
+
+    def fake_run_json(target: Path, args: list[str]) -> dict:
+        calls.append((target, args))
+        return expected
+
+    monkeypatch.setattr("brigade.center_cmd.dashboard.data.run_json", fake_run_json)
+
+    assert handoff_inbox.fetch(tmp_path) == expected
+    assert calls == [(tmp_path, ["handoff", "lint"])]
+
+
+def test_render_displays_queue_and_injection_count():
+    payload = {
+        "count": 2,
+        "valid": False,
+        "injection_flagged_count": 1,
+        "results": [
+            {
+                "path": "/tmp/example-workspace/.claude/memory-handoffs/alpha.md",
+                "valid": True,
+                "action": "no-card",
+                "errors": [],
+                "warnings": [],
+                "injection_signals": 0,
+            },
+            {
+                "path": "/tmp/example-workspace/.claude/memory-handoffs/beta.md",
+                "valid": False,
+                "action": "create-card",
+                "errors": ["missing required section: Summary"],
+                "warnings": ["line 4: warning: [rule-x] suspicious text"],
+                "injection_signals": 2,
+            },
+        ],
+    }
+
+    fragment = handoff_inbox.render(payload, "unused")
+
+    assert "Injection-flagged handoffs" in fragment
+    assert ">1<" in fragment
+    assert "prompt-injection signals" in fragment
+    assert "Queue summary" in fragment
+    assert "Pending files" in fragment
+    assert "All valid" in fragment
+    assert ">no<" in fragment
+    assert "alpha.md" in fragment
+    assert "beta.md" in fragment
+    assert "missing required section: Summary" in fragment
+    assert "injection signals: 2" in fragment
+    assert "create-card" in fragment
+
+
+def test_render_escapes_untrusted_path_and_messages():
+    payload = {
+        "count": 1,
+        "valid": False,
+        "injection_flagged_count": 0,
+        "results": [
+            {
+                "path": "/tmp/<script>alert(1)</script>.md",
+                "valid": False,
+                "action": "no-card",
+                "errors": ["bad <tag>"],
+                "warnings": [],
+                "injection_signals": 0,
+            },
+        ],
+    }
+
+    fragment = handoff_inbox.render(payload, "unused")
+
+    assert "<script>" not in fragment
+    assert "&lt;script&gt;" in fragment
+    assert "bad &lt;tag&gt;" in fragment
+
+
+def test_render_error_and_empty_payloads_degrade_safely():
+    assert "boom" in handoff_inbox.render({"error": "boom"}, "unused")
+
+    assert "Nothing pending." in handoff_inbox.render({}, "unused")
+    assert "Nothing pending." in handoff_inbox.render({"results": []}, "unused")

--- a/tests/test_dashboard_outcomes.py
+++ b/tests/test_dashboard_outcomes.py
@@ -1,0 +1,112 @@
+from pathlib import Path
+
+from brigade.center_cmd.dashboard.views import outcome_rank
+
+
+def test_fetch_uses_outcome_rank_json(monkeypatch, tmp_path):
+    expected = {"ranking": []}
+    calls: list[tuple[Path, list[str]]] = []
+
+    def fake_run_json(target: Path, args: list[str]) -> dict:
+        calls.append((target, args))
+        return expected
+
+    monkeypatch.setattr("brigade.center_cmd.dashboard.data.run_json", fake_run_json)
+
+    assert outcome_rank.fetch(tmp_path) == expected
+    assert calls == [(tmp_path, ["outcome", "rank"])]
+
+
+def test_render_displays_ranking_rows_with_cohort_and_recency_columns():
+    payload = {
+        "ranking": [
+            {
+                "artifact_id": "example-skill-one",
+                "score": 0.4567,
+                "helped": 12,
+                "hurt": 3,
+                "capability_score": 0.6789,
+                "capability_helped": 9,
+                "capability_hurt": 2,
+                "stale_records": 1,
+                "legacy_records": 4,
+            },
+            {
+                "artifact_id": "example-skill-two",
+                "score": 0.1,
+                "helped": 2,
+                "hurt": 5,
+                "capability_score": 0.25,
+                "capability_helped": 1,
+                "capability_hurt": 3,
+                "stale_records": 0,
+                "legacy_records": 0,
+            },
+        ],
+        "target": "/fake/worktree",
+    }
+
+    fragment = outcome_rank.render(payload, "unused")
+
+    for header in (
+        "Artifact",
+        "Score",
+        "Helped",
+        "Hurt",
+        "Capability score",
+        "Capability helped",
+        "Capability hurt",
+        "Stale records",
+        "Legacy records",
+    ):
+        assert header in fragment
+    assert "example-skill-one" in fragment
+    assert "example-skill-two" in fragment
+    for value in ("0.457", "12", "3", "0.679", "9", "2", "1", "4"):
+        assert f">{value}<" in fragment
+    assert "0.100" in fragment
+    assert "0.250" in fragment
+    # Row order follows the payload ranking order.
+    assert fragment.index("example-skill-one") < fragment.index("example-skill-two")
+
+
+def test_render_escapes_untrusted_values():
+    payload = {
+        "ranking": [
+            {
+                "artifact_id": '<img src=x onerror="alert(1)">',
+                "score": 0.5,
+                "helped": 1,
+                "hurt": 0,
+            }
+        ]
+    }
+
+    fragment = outcome_rank.render(payload, "unused")
+
+    assert "<img" not in fragment
+    assert "&lt;img" in fragment
+    assert "&quot;alert(1)&quot;" in fragment
+
+
+def test_render_missing_entry_values_degrade_to_dash():
+    fragment = outcome_rank.render({"ranking": [{"artifact_id": "sparse-skill"}]}, "unused")
+
+    assert "sparse-skill" in fragment
+    assert ">-<" in fragment
+
+
+def test_render_error_payload_renders_error_panel_only():
+    fragment = outcome_rank.render({"error": "boom"}, "unused")
+
+    assert "boom" in fragment
+    assert 'class="error"' in fragment
+    assert "<table" not in fragment
+
+
+def test_render_empty_payloads_render_not_being_fed_panel():
+    for payload in ({}, {"ranking": []}, {"ranking": None}, {"ranking": "not-a-list"}):
+        fragment = outcome_rank.render(payload, "unused")
+        assert "ranking is empty" in fragment
+        assert "outcome loop is not being fed" in fragment
+        assert "<table" not in fragment

--- a/tests/test_dashboard_runs.py
+++ b/tests/test_dashboard_runs.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+from brigade.center_cmd.dashboard.views import run_timeline
+
+
+def test_fetch_uses_verify_runs_json(monkeypatch, tmp_path):
+    expected = {"runs": []}
+    calls: list[tuple[Path, list[str]]] = []
+
+    def fake_run_json(target: Path, args: list[str]) -> dict:
+        calls.append((target, args))
+        return expected
+
+    monkeypatch.setattr("brigade.center_cmd.dashboard.data.run_json", fake_run_json)
+
+    assert run_timeline.fetch(tmp_path) == expected
+    assert calls == [(tmp_path, ["work", "verify", "runs"])]
+
+
+def test_render_lists_runs_newest_first_with_bounded_receipts():
+    payload = {
+        "runs": [
+            {
+                "run_id": "run-early",
+                "status": "failed",
+                "started_at": "2026-01-01T09:00:00Z",
+                "duration_seconds": 1.25,
+                "commands": [{"command": "fake check", "exit_code": 1}],
+            },
+            {
+                "run_id": "run-late",
+                "status": "completed",
+                "started_at": "2026-01-02T09:00:00Z",
+                "duration_seconds": 2.5,
+                "commands": [{"command": "fake check &lt;safe&gt;", "exit_code": 0}],
+                "large_field": "x" * 5_000,
+            },
+        ]
+    }
+
+    fragment = run_timeline.render(payload, "unused")
+
+    assert fragment.index("run-late") < fragment.index("run-early")
+    for heading in ("Run ID", "Status", "Command", "Exit code", "Duration", "Timestamp"):
+        assert f"<th>{heading}</th>" in fragment
+    assert "<details>" in fragment
+    assert "<summary>Receipt JSON</summary>" in fragment
+    assert "&amp;lt;safe&amp;gt;" in fragment
+    assert "Receipt truncated at 4000 characters." in fragment
+    assert "x" * 4_001 not in fragment
+
+
+def test_render_error_and_empty_payloads_degrade_safely():
+    assert "boom" in run_timeline.render({"error": "boom"}, "unused")
+
+    assert "Nothing here." in run_timeline.render({}, "unused")
+    assert "Nothing here." in run_timeline.render({"runs": []}, "unused")

--- a/tests/test_dashboard_status.py
+++ b/tests/test_dashboard_status.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+from brigade.center_cmd.dashboard.views import status_grid
+
+
+def test_fetch_uses_work_brief_json(monkeypatch, tmp_path):
+    expected = {"handoff_issues": {"count": 2}}
+    calls: list[tuple[Path, list[str]]] = []
+
+    def fake_run_json(target: Path, args: list[str]) -> dict:
+        calls.append((target, args))
+        return expected
+
+    monkeypatch.setattr("brigade.center_cmd.dashboard.data.run_json", fake_run_json)
+
+    assert status_grid.fetch(tmp_path) == expected
+    assert calls == [(tmp_path, ["work", "brief"])]
+
+
+def test_render_displays_status_signals():
+    payload = {
+        "handoff_issues": {"count": 2, "total_count": 5},
+        "memory_care": {"issue_count": 3},
+        "outcome_loop": {
+            "verify_run_count": 12,
+            "record_count": 9,
+            "eligible_receipt_count": 7,
+        },
+        "pending_tasks": [{"id": "task-a"}, {"id": "task-b"}],
+        "inbox_hygiene": {"issue_count": 1},
+    }
+
+    fragment = status_grid.render(payload, "unused")
+
+    assert "Pending handoff issues" in fragment
+    assert "Total handoff issues" in fragment
+    assert "Memory cards at refresh risk" in fragment
+    assert "Latest verify receipt" in fragment
+    assert "Latest verify signal" in fragment
+    assert "Verify runs" in fragment
+    assert "Outcome records" in fragment
+    assert "Open work-inbox items" in fragment
+    assert "Inbox hygiene issues" in fragment
+    for value in ("2", "5", "3", "12", "9", "7", "1"):
+        assert f">{value}<" in fragment
+    assert ">-<" in fragment
+
+
+def test_render_error_and_empty_payloads_degrade_safely():
+    assert "boom" in status_grid.render({"error": "boom"}, "unused")
+
+    fragment = status_grid.render({}, "unused")
+    assert "Nothing here." in fragment


### PR DESCRIPTION
Second slice of #721: the six read-only views, on top of the server and security
floor in #729.

**Stacked on #729** (base is `t3code/operator-dashboard`, not `main`) so the
diff shows only the view work. Merge #729 first.

## Two commits

**1. The view framework.** Six agents cannot edit one HTML file, so each view is
a self-contained module exposing `NAME`/`TITLE`/`ORDER`/`fetch`/`render`, with an
explicit registry and no dynamic scanning. `dashboard/data.py` is the only way to
reach state: it shells out to `brigade <cmd> --json`, never reads `.brigade/`,
and degrades a failed command to `{"error": ...}` so one dead panel cannot take
the page down. Routing resolves `/view/<name>` by exact registry match rather
than building a path from the URL, and a view that raises degrades to an inline
panel, since the default error path would answer without the security headers
and put a traceback on the page.

**2. The six views.**

| View | Source |
|---|---|
| status | `work brief --json` |
| handoffs | `handoff lint --json` |
| cards | `memory search --json` |
| outcomes | `outcome rank --json` |
| runs | `work verify runs --json` |
| activity | same verify receipts |

The outcomes view states plainly when the ranking is empty, and the heatmap
shades a zero-run day inside the window differently from a day outside it, so
"installed but dormant" is visible rather than blank.

## Server-rendered, not fetch-then-render

The issue allows either. Server-rendering with a 30s `location.reload()` means
the only JavaScript on the page is that timer plus one delegated `input`
listener that filters already-rendered rows by `textContent` and toggles
`row.hidden`. Nothing writes markup from JavaScript, so the injection sink the
CSP exists to close is never reopened. Escaping stays server-side in one `esc()`.

One consequence worth flagging: the heatmap ships its shades as classes in a
nonced `<style>` block, because `style-src 'nonce-...'` with no `unsafe-inline`
means inline `style=` attributes are dropped and every cell would render blank.

## Escaping

Card titles and handoff text are attacker-influenced. A fixture card carrying
`<script>alert(1)</script><img src=x onerror=alert(2)>` asserts the payload
appears only in escaped form and that no tag in the output contains it.

The assertion checks that **no tag can form**, not that the string `onerror=` is
absent. That distinction came out of review: an earlier version asserted the
substring, which is not the security property — `&lt;img src=x onerror=alert(2)&gt;`
is inert text — and it had induced a cosmetic `.replace("=", "&#61;")` in the
view purely to satisfy the search. That transform is gone; plain `html.escape` is
the whole defence, and the test now proves the property directly.

## Note on JSON contracts

No contract growth was needed. The issue names `work status --json`, which does
not exist, but `work brief --json` already emits `handoff_issues`, `memory_care`,
`outcome_loop`, `pending_tasks`, and `inbox_hygiene` — the entire status grid.

## Depends on #742

The six views were built by parallel seats, which required fixing a DAG scheduler
deadlock first (#742). That fix is **not** in this branch; it ships separately.

## Verification

```
brigade work verify run --target . --command "./scripts/verify" --capture brigade-work
```

`./scripts/verify [completed] exit=0` — 6031 passed, 3 skipped, 68 subtests
passed in 692.63s. Receipt `20260805-202108-work-verify-652d10`.

Closes #721.
