### PR TITLE
docs: one-and-done onboarding, E2E fixes, and 0.26.0 cut-line changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   would shadow every seat configured there. Pass `--force` to scaffold a
   workspace roster anyway. `brigade research` now resolves its roster through
   the same fallback chain instead of requiring a workspace roster. (#741)
+- One-and-done onboarding: `brigade work hooks install|update|status|uninstall`
+  gain `--scope user` (default `project`, prior behavior unchanged), installing
+  the managed Claude work-loop hooks once at user scope so every repo the agent
+  opens gets the work brief injected and an unwired repo gets the exact
+  `brigade init` command printed. User settings merge non-destructively,
+  Brigade-owned entries are tagged so uninstall removes only them, and status
+  detects a stale script by hash. `operator quickstart` now suggests the
+  user-scope install once when wiring the claude harness, and the README
+  documents the flow. (#740)
 - `brigade status --json` carries the same `available_update` field the work
   brief gained, so machine consumers can watch for releases without parsing the
   brief. Cache-read only; never touches the network. (#717)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,12 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - One-and-done onboarding: `brigade work hooks install|update|status|uninstall`
   gain `--scope user` (default `project`, prior behavior unchanged), installing
   the managed Claude work-loop hooks once at user scope so every repo the agent
-  opens gets the work brief injected and an unwired repo gets the exact
-  `brigade init` command printed. User settings merge non-destructively,
-  Brigade-owned entries are tagged so uninstall removes only them, and status
-  detects a stale script by hash. `operator quickstart` now suggests the
-  user-scope install once when wiring the claude harness, and the README
-  documents the flow. (#740)
+  opens gets the work brief injected and an unwired git repo gets the exact
+  `brigade init` command printed at session start. User settings merge
+  non-destructively, Brigade-owned entries are tagged so uninstall removes
+  only them, and status detects a stale script by hash. `operator quickstart`
+  now suggests the user-scope install once when wiring the claude harness, and
+  the README documents the flow. (#740, #743)
 - `brigade status --json` carries the same `available_update` field the work
   brief gained, so machine consumers can watch for releases without parsing the
   brief. Cache-read only; never touches the network. (#717)

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Stable pinners may deliberately install an exact release with
 `brigade update --channel stable`. Channel ownership, beta rules, and when to
 use `brigade update` are in [docs/update-channels.md](docs/update-channels.md).
 
-`brigade operator doctor --target ./my-repo` prints `ready: yes` when the wiring is healthy. The default footprint is small: `AGENTS.md`, `SAFETY_RULES.md`, a handoff template, and `.brigade/` state. Add `--dry-run` to preview anything before it writes. Nothing leaves your machine.
+`brigade operator doctor --target ./my-repo --profile local-operator` prints `ready: yes` when the wiring is healthy (without the profile flag, doctor runs the stricter internal-dogfood checks and a fresh repo reports not ready). The default footprint is small: `AGENTS.md`, `SAFETY_RULES.md`, a handoff template, and `.brigade/` state. Add `--dry-run` to preview anything before it writes. Nothing leaves your machine.
 
 Per-OS setup (apt, Homebrew, Scoop, PowerShell), workspace depth, and multi-harness installs: [install guide](https://brigade.tools/docs/getting-started/install), [QUICKSTART.md](QUICKSTART.md), [first 10 minutes](docs/first-10-minutes.md). Homegrown setup already? `brigade operator adopt plan`.
 

--- a/README.md
+++ b/README.md
@@ -64,11 +64,25 @@ The agent installs, runs `brigade setup`, wires harnesses, and leaves files on d
 **If you prefer a shell** (same commands the agent would run):
 
 ```bash
-pipx install brigade-cli
+pipx install brigade-cli  # or: uv tool install brigade-cli
 pipx ensurepath           # then open a new shell so `brigade` is on PATH
 brigade setup             # install the verified native engines
 brigade operator quickstart --target ./my-repo --harnesses codex
 ```
+
+**One and done (Claude Code).** Instead of wiring repos one at a time, install
+the work-loop hooks once at user scope:
+
+```bash
+brigade work hooks install --scope user
+```
+
+From then on, every repo the agent opens gets the work brief injected at
+session start, and an unwired repo gets the exact `brigade init` command
+printed for the agent to run - so agents wire new repos themselves and the
+verified-work loop closes everywhere without another human command. Remove it
+any time with `brigade work hooks uninstall --scope user`; only Brigade-owned
+hook entries are touched.
 
 Brigade prints a one-line notice when a new release is out. It checks at most
 once a day through an anonymous request. Set `BRIGADE_NO_UPDATE_CHECK=1` to

--- a/src/brigade/operator_cmd/lifecycle.py
+++ b/src/brigade/operator_cmd/lifecycle.py
@@ -646,6 +646,10 @@ def _quickstart_next_commands(harnesses: list[str], *, dry_run: bool) -> list[st
         for harness in harnesses
         if harness in WRITER_INBOXES
     )
+    if "claude" in harnesses:
+        commands.append(
+            "brigade work hooks install --scope user  # once per machine: every repo the agent opens self-wires"
+        )
     return commands
 
 


### PR DESCRIPTION
The last PR before the 0.26.0 candidate re-roll:

- README gains the one-and-done section (`brigade work hooks install --scope user`), a `uv tool install brigade-cli` alternative, and the corrected doctor claim naming `--profile local-operator` - the top friction finding from the clean-guest E2E (LXC brigade-e2e-0260).
- `operator quickstart` suggests the user-scope hooks install once when wiring the claude harness.
- Changelog entries for the cut-line merges: #740/#743 (user-scope hooks + unwired init hint), #741 (linked-worktree roster resolution).

Gate: full `./scripts/verify` green in the lane worktree (Brigade receipt) on the rebased head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)