### PR TITLE
fix(hooks): shell-quote interpolated paths in hint, handler, and brief text

### DIFF
--- a/src/brigade/claude_hooks/package.py
+++ b/src/brigade/claude_hooks/package.py
@@ -66,7 +66,7 @@ def hook_script_text() -> str:
 
 
 def managed_user_command(event: str, script_path: Path) -> str:
-    return f"{script_path} --event {event}"
+    return f"{shlex.quote(str(script_path))} --event {event}"
 
 
 def managed_user_handler(event: str, script_path: Path) -> dict[str, Any]:

--- a/src/brigade/claude_hooks/runtime.py
+++ b/src/brigade/claude_hooks/runtime.py
@@ -582,10 +582,16 @@ def _run_brief(target: Path) -> str:
             timeout=BRIEF_TIMEOUT_SECONDS,
         )
     except (OSError, subprocess.TimeoutExpired):
-        return f"Brigade is wired for this repo. Run `brigade work brief --target {target}` before real work."
+        return (
+            "Brigade is wired for this repo. Run `brigade work brief --target "
+            f"{shlex.quote(str(target))}` before real work."
+        )
     text = result.stdout.strip()
     if result.returncode != 0 or not text:
-        return f"Brigade is wired for this repo. Run `brigade work brief --target {target}` before real work."
+        return (
+            "Brigade is wired for this repo. Run `brigade work brief --target "
+            f"{shlex.quote(str(target))}` before real work."
+        )
     if len(text) > BRIEF_MAX_CHARS:
         text = text[:BRIEF_MAX_CHARS] + "\n[Brigade brief truncated]"
     return text

--- a/src/brigade/claude_hooks/runtime.py
+++ b/src/brigade/claude_hooks/runtime.py
@@ -1839,7 +1839,9 @@ def _unwired_init_hint(payload: dict[str, Any]) -> dict[str, Any] | None:
         return None
     if cwd == Path.home() or not (cwd / ".git").exists():
         return None
-    command = f"brigade init --target {cwd} --depth repo --harnesses claude --owner claude --git-exclude"
+    command = (
+        f"brigade init --target {shlex.quote(str(cwd))} --depth repo --harnesses claude --owner claude --git-exclude"
+    )
     return _additional_context(
         "SessionStart",
         "This git repository is not Brigade-wired. Configure it before real work so "

--- a/tests/test_claude_hooks_runtime.py
+++ b/tests/test_claude_hooks_runtime.py
@@ -1911,3 +1911,16 @@ def test_posttooluse_routed_verify_records_capture_artifact(tmp_path: Path):
     state = runtime.read_session_state(target, "session-1")
     assert state is not None
     assert state["exercised_artifact_id"] == "ultra-work-scout"
+
+
+def test_init_hint_quotes_hostile_directory_names(tmp_path: Path):
+    repo = tmp_path / "evil;rm -rf tmp"
+    (repo / ".git").mkdir(parents=True)
+    result = runtime.handle_payload("SessionStart", _payload(repo, "SessionStart"))
+    context = result["hookSpecificOutput"]["additionalContext"]
+    import shlex as _shlex
+
+    assert _shlex.quote(str(repo.resolve())) in context
+    tokens = _shlex.split(context.split(": brigade ", 1)[1].splitlines()[0])
+    assert tokens[:2] == ["init", "--target"]
+    assert tokens[2] == str(repo.resolve())

--- a/tests/test_claude_hooks_user_scope.py
+++ b/tests/test_claude_hooks_user_scope.py
@@ -215,3 +215,13 @@ def test_user_hooks_uninstall_preserves_edited_script(claude_home: Path):
     script.write_text("# user-edited\n")
     assert hooks_uninstall(target=Path("."), scope="user") == 0
     assert script.read_text() == "# user-edited\n"
+
+
+def test_managed_user_command_quotes_paths_with_spaces(tmp_path):
+    import shlex
+
+    script = tmp_path / "Application Support" / "hooks" / "brigade-work-loop.py"
+    command = managed_user_command("SessionStart", script)
+    tokens = shlex.split(command)
+    assert tokens[0] == str(script)
+    assert tokens[1:] == ["--event", "SessionStart"]


### PR DESCRIPTION
Findings from the dual adversarial pre-tag review (k3 + glm-5.2 seats), all one class: filesystem paths interpolated unquoted into shell-destined strings.

- The SessionStart init hint (runtime.py, from #743): a hostile directory name (`evil;rm -rf tmp`, `$(...)`) smuggles content into the command an agent pastes verbatim. Now `shlex.quote`d, with a semicolon-bearing-repo-name test asserting the quoted form parses back to the intended argv.
- `managed_user_command` (package.py, from #740): a Claude home containing spaces broke the user-scope settings handler - the carve-out lane A itself recorded. Quoting lives in the single builder both the writer and the is-managed matcher share, so install/status/uninstall stay consistent (existing matcher tests pass unchanged).
- The wired-repo brief fallback text (runtime.py:585/588, pre-existing): same class, flagged by k3.

Gates: targeted hook suites green after each change; full `./scripts/verify` green on the final head (Brigade receipts, reused_from null).

🤖 Generated with [Claude Code](https://claude.com/claude-code)