### PR TITLE
ci: make the publish workflow rerunnable end to end

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -406,10 +406,12 @@ jobs:
         run: python -m build
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+        with:
+          skip-existing: true
       - name: Verify check.brigade.tools reports the published version
         env:
           EXPECTED_VERSION: ${{ github.ref_name }}
-        run: python scripts/verify_version_check_endpoint.py --expected-version "${EXPECTED_VERSION#v}"
+        run: python scripts/verify_version_check_endpoint.py --expected-version "${EXPECTED_VERSION#v}" --wait-seconds 1500
 
   published-artifact-acceptance:
     name: published-artifact-acceptance (${{ matrix.platform }})

--- a/scripts/verify_version_check_endpoint.py
+++ b/scripts/verify_version_check_endpoint.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+import time
 import urllib.request
 
 ENDPOINT = "https://check.brigade.tools/v1/version"
@@ -39,22 +40,56 @@ def main(argv: list[str] | None = None) -> int:
         required=True,
         help="version the endpoint must report (without the leading v)",
     )
+    parser.add_argument(
+        "--wait-seconds",
+        type=int,
+        default=0,
+        help=(
+            "keep polling for up to this many seconds before failing; the endpoint "
+            "refreshes from PyPI on a 15-minute cache, so a fresh publish is always "
+            "briefly stale"
+        ),
+    )
+    parser.add_argument(
+        "--poll-interval",
+        type=int,
+        default=60,
+        help="seconds between polls while waiting",
+    )
     args = parser.parse_args(argv)
 
-    try:
-        latest = fetch_latest()
-    except Exception as error:  # noqa: BLE001 - any fetch failure fails the gate loudly
-        print(f"::error::version check endpoint fetch failed: {error}")
+    deadline = time.monotonic() + max(args.wait_seconds, 0)
+    latest: str | None = None
+    last_error: Exception | None = None
+    while True:
+        try:
+            latest = fetch_latest()
+            last_error = None
+        except Exception as error:  # noqa: BLE001 - any fetch failure fails the gate loudly
+            latest = None
+            last_error = error
+
+        if latest == args.expected_version:
+            print(f"version check endpoint reports {latest}: ok")
+            return 0
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        status = f"latest={latest!r}" if last_error is None else f"fetch failed: {last_error}"
+        print(
+            f"endpoint not caught up yet ({status}); expected {args.expected_version!r}, "
+            f"retrying for {int(remaining)}s more"
+        )
+        time.sleep(min(args.poll_interval, max(int(remaining), 1)))
+
+    if last_error is not None:
+        print(f"::error::version check endpoint fetch failed: {last_error}")
         return 1
-
-    if latest == args.expected_version:
-        print(f"version check endpoint reports {latest}: ok")
-        return 0
-
     print(
         f"::error::{ENDPOINT} reports latest={latest!r} but this release is "
-        f"{args.expected_version!r}. Update the endpoint to the new version, "
-        "then rerun this job so update discovery does not lag the release."
+        f"{args.expected_version!r}. The endpoint refreshes from PyPI on a "
+        "15-minute cache; if this failed after waiting, check the worker, then "
+        "rerun this job."
     )
     return 1
 

--- a/tests/test_publish_workflow.py
+++ b/tests/test_publish_workflow.py
@@ -404,7 +404,8 @@ def test_publish_workflow_verifies_version_check_endpoint_after_pypi_upload():
     section = text[verify : text.index("  published-artifact-acceptance:")]
     assert "scripts/verify_version_check_endpoint.py" in section
     assert "EXPECTED_VERSION: ${{ github.ref_name }}" in section
-    assert '--expected-version "${EXPECTED_VERSION#v}"' in section
+    assert '--expected-version "${EXPECTED_VERSION#v}" --wait-seconds 1500' in section
+    assert "skip-existing: true" in text
     assert (
         "https://check.brigade.tools/v1/version" in (ROOT / "scripts" / "verify_version_check_endpoint.py").read_text()
     )


### PR DESCRIPTION
Fixes #749.

The v0.26.0 publish run went red twice for process reasons while every artifact shipped correctly: the endpoint verify step ran inside the version-check worker's 15-minute PyPI cache and failed on the stale value, and the rerun then re-uploaded to PyPI, which returns `400 File already exists` - so the run could never be greened.

- `pypa/gh-action-pypi-publish` gains `skip-existing: true`, making reruns idempotent past the upload.
- `scripts/verify_version_check_endpoint.py` gains `--wait-seconds`/`--poll-interval` polling; the workflow passes 1500s so the verify rides out the cache window instead of failing on the first read. Smoke-tested live against the real endpoint: matching version exits 0 immediately, mismatched version polls the window then exits 1 with the corrected remediation text.

Gate: full `./scripts/verify` green in the lane worktree (Brigade receipt); workflow YAML strict-validated (duplicate-key-safe); `test_publish_workflow.py` assertions updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)