### PR TITLE
fix(release): refresh stale candidate readiness

### DIFF
--- a/src/brigade/release_cmd/candidate.py
+++ b/src/brigade/release_cmd/candidate.py
@@ -112,9 +112,17 @@ def _changelog_unreleased(path: Path) -> list[str]:
     return items
 
 
+def _release_receipt_matches_head(receipt: dict[str, Any], target: Path) -> bool:
+    evidence = receipt.get("evidence") if isinstance(receipt.get("evidence"), dict) else {}
+    git = evidence.get("git") if isinstance(evidence.get("git"), dict) else {}
+    receipt_head = git.get("head")
+    current_head = _git_value(target, "rev-parse", "HEAD")
+    return bool(receipt_head and current_head and receipt_head == current_head)
+
+
 def _latest_release_or_payload(target: Path, *, base_ref: str | None) -> dict[str, Any]:
     latest = _latest_release_receipt(target)
-    if latest is not None:
+    if latest is not None and _release_receipt_matches_head(latest, target):
         return latest
     payload = _payload(target, base_ref=base_ref, run_checks=True)
     return {

--- a/tests/test_release_cmd.py
+++ b/tests/test_release_cmd.py
@@ -1180,3 +1180,46 @@ def test_release_readiness_names_failing_checks_and_remediation(tmp_path, monkey
     assert "security_harness_wiring" in warnings
     assert "brigade security doctor --json" in warnings
     assert "security has open issue(s)" not in combined
+
+
+def test_release_candidate_build_refreshes_stale_readiness_receipt(tmp_path, monkeypatch, capsys):
+    _init_repo(tmp_path)
+    _seed_ready_evidence(tmp_path)
+    _patch_clean_health(monkeypatch)
+    _patch_content_guard(monkeypatch)
+
+    old_head = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=tmp_path, text=True).strip()
+
+    assert release_cmd.run(target=tmp_path, base_ref=None, json_output=True) == 0
+    stale_receipt = json.loads(capsys.readouterr().out)
+    stale_run_id = stale_receipt["run_id"]
+    assert stale_receipt["evidence"]["git"]["head"] == old_head
+
+    (tmp_path / "new-commit.txt").write_text("advance head\n")
+    subprocess.run(["git", "add", "new-commit.txt"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-m", "advance head"], cwd=tmp_path, check=True, stdout=subprocess.DEVNULL)
+    new_head = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=tmp_path, text=True).strip()
+    assert new_head != old_head
+
+    assert release_cmd.candidate_build(target=tmp_path, base_ref=None, json_output=True) == 0
+    candidate = json.loads(capsys.readouterr().out)
+
+    assert candidate["git"]["head"] == new_head
+    assert candidate["release_readiness_receipt"]["run_id"] != stale_run_id
+    assert candidate["release_readiness"]["run_id"] == "inline-readiness"
+
+
+def test_release_candidate_build_reuses_fresh_readiness_receipt(tmp_path, monkeypatch, capsys):
+    _init_repo(tmp_path)
+    _seed_ready_evidence(tmp_path)
+    _patch_clean_health(monkeypatch)
+    _patch_content_guard(monkeypatch)
+
+    assert release_cmd.run(target=tmp_path, base_ref=None, json_output=True) == 0
+    release_receipt = json.loads(capsys.readouterr().out)
+
+    assert release_cmd.candidate_build(target=tmp_path, base_ref=None, json_output=True) == 0
+    candidate = json.loads(capsys.readouterr().out)
+
+    assert candidate["release_readiness_receipt"]["run_id"] == release_receipt["run_id"]
+    assert candidate["git"]["head"] == release_receipt["evidence"]["git"]["head"]


### PR DESCRIPTION
Fixes #695.

Release candidate builds now reuse stored readiness only when its recorded Git HEAD matches the current HEAD. Stale or malformed receipt metadata triggers the existing inline readiness checks.

Verification: ./scripts/verify via Brigade receipt 20260808-153059-work-verify-602a0f.