### PR TITLE
fix(windows): read repo docs as UTF-8 to stop work brief crash

### DIFF
--- a/src/brigade/agent_skill_format.py
+++ b/src/brigade/agent_skill_format.py
@@ -48,7 +48,7 @@ def validate(skill_dir: Path, *, mode: str) -> Validation:
     path = skill_dir / "SKILL.md"
     if not path.is_file():
         return Validation({}, (f"SKILL.md not found: {path}",), ())
-    lines, framing_error = _frontmatter(path.read_text(errors="replace"))
+    lines, framing_error = _frontmatter(path.read_text(encoding="utf-8", errors="replace"))
     if lines is None:
         if mode == "lenient":
             return Validation({}, (), (framing_error or "invalid frontmatter",))

--- a/src/brigade/claude_hooks/classify.py
+++ b/src/brigade/claude_hooks/classify.py
@@ -27,7 +27,7 @@ def _is_wired_for_claude(target: Path) -> bool:
 def _instruction_import_current(target: Path) -> bool:
     path = target / "CLAUDE.md"
     try:
-        return any(line.strip() == "@AGENTS.md" for line in path.read_text().splitlines())
+        return any(line.strip() == "@AGENTS.md" for line in path.read_text(encoding="utf-8").splitlines())
     except OSError:
         return False
 

--- a/src/brigade/cursor_user_cmd.py
+++ b/src/brigade/cursor_user_cmd.py
@@ -610,7 +610,7 @@ def doctor(*, json_output: bool = False) -> int:
 
 def _read_text(path: Path) -> str:
     try:
-        return path.read_text()
+        return path.read_text(encoding="utf-8")
     except (OSError, UnicodeError):
         return ""
 

--- a/src/brigade/handoff.py
+++ b/src/brigade/handoff.py
@@ -14,11 +14,11 @@ def run(target: Path | None = None) -> int:
     if target is not None:
         local = target.expanduser().resolve() / ".claude" / "memory-handoffs" / "TEMPLATE.md"
         if local.is_file():
-            sys.stdout.write(local.read_text())
+            sys.stdout.write(local.read_text(encoding="utf-8"))
             return 0
     packaged = template_root() / "claude" / "memory-handoffs" / "TEMPLATE.md"
     if not packaged.is_file():
         print("error: packaged TEMPLATE.md missing", file=sys.stderr)
         return 1
-    sys.stdout.write(packaged.read_text())
+    sys.stdout.write(packaged.read_text(encoding="utf-8"))
     return 0

--- a/src/brigade/handoff_cmd/drafts.py
+++ b/src/brigade/handoff_cmd/drafts.py
@@ -810,7 +810,7 @@ def draft(
         suggested_content=suggested_content,
     )
     inbox_path.mkdir(parents=True, exist_ok=True)
-    path.write_text(text)
+    path.write_text(text, encoding="utf-8")
     lint_result = lint_file(path)
     guard_result = _guard_handoff_path(path, target=target, policy=guard_policy) if guard else None
     payload = {

--- a/src/brigade/handoff_cmd/drafts.py
+++ b/src/brigade/handoff_cmd/drafts.py
@@ -375,7 +375,7 @@ def _draft_summary(
 ) -> HandoffDraft:
     path = path.expanduser().resolve()
     try:
-        text = path.read_text(errors="replace")
+        text = path.read_text(encoding="utf-8", errors="replace")
     except OSError:
         text = ""
     raw_sections = _parse_markdown_sections(text)
@@ -457,7 +457,7 @@ def _archive_records(target: Path) -> list[dict[str, Any]]:
         return []
     records: list[dict[str, Any]] = []
     try:
-        lines = path.read_text().splitlines()
+        lines = path.read_text(encoding="utf-8").splitlines()
     except OSError:
         return []
     for line in lines:
@@ -676,7 +676,7 @@ def _read_suggested_content(content: str | None, content_file: Path | None) -> s
     if content_file is None:
         raise ValueError("--content or --content-file is required")
     try:
-        return content_file.expanduser().read_text(errors="replace").strip()
+        return content_file.expanduser().read_text(encoding="utf-8", errors="replace").strip()
     except OSError as exc:
         raise ValueError(f"cannot read --content-file: {exc}") from exc
 

--- a/src/brigade/handoff_cmd/linting.py
+++ b/src/brigade/handoff_cmd/linting.py
@@ -81,7 +81,7 @@ def _injection_detail(*, warning_count: int, unscanned: bool = False) -> str:
 
 def _read_handoff_text(path: Path) -> str | None:
     try:
-        return path.read_text(errors="replace")
+        return path.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return None
 
@@ -271,7 +271,7 @@ def lint_file(path: Path) -> HandoffLintResult:
     hints: list[str] = []
     action: str | None = None
     try:
-        text = path.read_text(errors="replace")
+        text = path.read_text(encoding="utf-8", errors="replace")
     except OSError as exc:
         return HandoffLintResult(
             path=path,

--- a/src/brigade/handoff_cmd/migrate_ops.py
+++ b/src/brigade/handoff_cmd/migrate_ops.py
@@ -84,11 +84,11 @@ def migrate(*, target: Path, inbox: str | None = None, apply: bool = False, json
             if apply:
                 originals = inbox_path / "migrated-originals"
                 originals.mkdir(parents=True, exist_ok=True)
-                (originals / path.name).write_text(text)
-                path.write_text(rendered)
+                (originals / path.name).write_text(text, encoding="utf-8")
+                path.write_text(rendered, encoding="utf-8")
                 converted = lint_file(path)
                 if not converted.valid:
-                    path.write_text(text)
+                    path.write_text(text, encoding="utf-8")
                     (originals / path.name).unlink()
                     item["status"] = "unmigratable"
                     item["missing"] = list(converted.errors)

--- a/src/brigade/handoff_cmd/migrate_ops.py
+++ b/src/brigade/handoff_cmd/migrate_ops.py
@@ -52,7 +52,7 @@ def migrate(*, target: Path, inbox: str | None = None, apply: bool = False, json
             if lint_file(path).valid:
                 continue
             rel = str(path.relative_to(target))
-            text = path.read_text(errors="replace")
+            text = path.read_text(encoding="utf-8", errors="replace")
             item: dict[str, Any] = {"file": rel}
             if scan_untrusted(text).flagged:
                 item["status"] = "blocked-injection"

--- a/src/brigade/handoff_cmd/receipts.py
+++ b/src/brigade/handoff_cmd/receipts.py
@@ -348,7 +348,7 @@ def reconcile(*, target: Path, sources: Path | None = None, json_output: bool = 
         print(f"error: ingestor last_run_log not found: {log_path}", file=sys.stderr)
         return 1
     try:
-        text = log_path.read_text(errors="replace")
+        text = log_path.read_text(encoding="utf-8", errors="replace")
     except OSError as exc:
         print(f"error: cannot read ingestor log: {exc}", file=sys.stderr)
         return 1

--- a/src/brigade/handoff_cmd/sources.py
+++ b/src/brigade/handoff_cmd/sources.py
@@ -35,7 +35,7 @@ def _source_config_for_checks(target: Path, sources_path: Path | None) -> Source
 
 def _parse_ingestor_log_issues(log_path: Path) -> list[HandoffIssue]:
     try:
-        lines = log_path.read_text(errors="replace").splitlines()
+        lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
     except OSError as exc:
         return [
             _make_issue(
@@ -403,7 +403,7 @@ def _inspect_ingestor(config: IngestorConfig | None) -> IngestorHealth:
             warnings=(f"handoff ingestor log is configured but missing at {config.log_path}",),
         )
     try:
-        text = config.log_path.read_text(errors="replace")
+        text = config.log_path.read_text(encoding="utf-8", errors="replace")
         mtime = config.log_path.stat().st_mtime
     except OSError as exc:
         return IngestorHealth(

--- a/src/brigade/ingest.py
+++ b/src/brigade/ingest.py
@@ -317,7 +317,7 @@ def _execute(
         summary = f"promote → {dest.relative_to(target)}  ({name})"
         if not dry_run:
             dest.parent.mkdir(parents=True, exist_ok=True)
-            dest.write_text(content)
+            dest.write_text(content, encoding="utf-8")
             _archive(handoff_path, processed_dir)
         return Action("promoted", summary)
 
@@ -346,7 +346,7 @@ def _execute(
             header = (
                 f"<!-- routed from {handoff_path.name}\n     reason: {outcome.reason}\n     routed-at: {slug} -->\n\n"
             )
-            dest.write_text(header + original)
+            dest.write_text(header + original, encoding="utf-8")
             _archive(handoff_path, processed_dir)
         # Both inboxed and skipped are now archived; classify them uniformly.
         return Action("inboxed", summary)

--- a/src/brigade/ingest.py
+++ b/src/brigade/ingest.py
@@ -171,7 +171,7 @@ def ingest_into(
 
 def parse(path: Path) -> Dict[str, str]:
     """Split a handoff into sections keyed by lowercased ## heading."""
-    body = path.read_text()
+    body = path.read_text(encoding="utf-8")
     sections: Dict[str, str] = {}
     last_name = None
     last_pos = 0
@@ -259,7 +259,7 @@ def decide(
         dest = target / document
         # Dedupe: never re-append content that is already present in the target.
         # Without this, a re-routed handoff duplicates its content on every run.
-        existing = dest.read_text() if dest.is_file() else ""
+        existing = dest.read_text(encoding="utf-8") if dest.is_file() else ""
         normalized_existing = _normalize_for_dedupe(existing)
         normalized_suggested = _normalize_for_dedupe(content)
         if normalized_suggested and normalized_suggested in normalized_existing:
@@ -328,7 +328,7 @@ def _execute(
         summary = f"append → {dest.relative_to(target)}  ({name})"
         if not dry_run:
             dest.parent.mkdir(parents=True, exist_ok=True)
-            with dest.open("a") as f:
+            with dest.open("a", encoding="utf-8") as f:
                 f.write("\n\n" + content + "\n")
             _archive(handoff_path, processed_dir)
         return Action("routed", summary)
@@ -342,7 +342,7 @@ def _execute(
             inbox_dir.mkdir(parents=True, exist_ok=True)
             # Copy the original file verbatim so reviewers see what the
             # harness actually wrote, not a reconstruction.
-            original = handoff_path.read_text()
+            original = handoff_path.read_text(encoding="utf-8")
             header = (
                 f"<!-- routed from {handoff_path.name}\n     reason: {outcome.reason}\n     routed-at: {slug} -->\n\n"
             )

--- a/src/brigade/install.py
+++ b/src/brigade/install.py
@@ -153,7 +153,7 @@ def _git_info_dir(target: Path) -> Path | None:
         return git_path / "info"
     if git_path.is_file():
         try:
-            content = git_path.read_text().strip()
+            content = git_path.read_text(encoding="utf-8").strip()
         except OSError:
             return None
         if content.startswith("gitdir:"):
@@ -183,7 +183,7 @@ def apply_gitignore(target: Path, selection: Selection, *, use_git_exclude: bool
         gi = target / ".gitignore"
         location = ".gitignore"
     if not gi.exists():
-        gi.write_text(block)
+        gi.write_text(block, encoding="utf-8")
         return f"created ({location})"
     existing = gi.read_text(encoding="utf-8")
     markers = (
@@ -192,10 +192,10 @@ def apply_gitignore(target: Path, selection: Selection, *, use_git_exclude: bool
     )
     new_text, replaced = _replace_managed_gitignore_blocks(existing, block, markers)
     if replaced:
-        gi.write_text(new_text)
+        gi.write_text(new_text, encoding="utf-8")
         return f"updated ({location})"
     sep = "" if existing.endswith("\n") else "\n"
-    gi.write_text(existing + sep + "\n" + block)
+    gi.write_text(existing + sep + "\n" + block, encoding="utf-8")
     return f"updated ({location})"
 
 
@@ -304,7 +304,7 @@ def _write_surface_evidence(target: Path, selection: Selection, *, projection_on
             for surface in selection.surfaces
         },
     }
-    path.write_text(json.dumps(payload, indent=2) + "\n")
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
 
 def install_selection(

--- a/src/brigade/install.py
+++ b/src/brigade/install.py
@@ -185,7 +185,7 @@ def apply_gitignore(target: Path, selection: Selection, *, use_git_exclude: bool
     if not gi.exists():
         gi.write_text(block)
         return f"created ({location})"
-    existing = gi.read_text()
+    existing = gi.read_text(encoding="utf-8")
     markers = (
         (GITIGNORE_BEGIN, GITIGNORE_END),
         (LEGACY_GITIGNORE_BEGIN, LEGACY_GITIGNORE_END),
@@ -385,7 +385,7 @@ def install_selection(
             continue
         dst.parent.mkdir(parents=True, exist_ok=True)
         if is_text(entry["src"]):
-            dst.write_text(render(src.read_text(), context))
+            dst.write_text(render(src.read_text(encoding="utf-8"), context), encoding="utf-8")
         else:
             shutil.copyfile(src, dst)
         mode_str = entry.get("mode")
@@ -418,7 +418,7 @@ def install_selection(
                     continue
                 dst = target / rel / "SKILL.md"
                 dst.parent.mkdir(parents=True, exist_ok=True)
-                dst.write_text(skill_src.read_text())
+                dst.write_text(skill_src.read_text(encoding="utf-8"), encoding="utf-8")
                 wired_skills.append((h, skill_id))
 
     # Claude Code project hooks enforce the same work loop described by the

--- a/src/brigade/memory_cmd.py
+++ b/src/brigade/memory_cmd.py
@@ -230,7 +230,7 @@ def init(*, target: Path, force: bool = False, update_gitignore: bool = True) ->
         print(f"error: memory-care config already exists: {path}", file=sys.stderr)
         return 1
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(_format_config())
+    path.write_text(_format_config(), encoding="utf-8")
     if update_gitignore:
         apply_gitignore(target, Selection(depth="repo", harnesses=[], owner="this-repo", includes=[]))
     print(f"memory_care_config: {path}")
@@ -320,7 +320,7 @@ def _index_links(target: Path, config: MemoryCareConfig) -> set[str]:
             continue
         try:
             text = path.read_text(encoding="utf-8")
-        except OSError:
+        except (OSError, UnicodeDecodeError):
             continue
         links.update(match.group("path") for match in pattern.finditer(text))
     return links
@@ -744,8 +744,8 @@ def _write_scan_outputs(target: Path, config: MemoryCareConfig, payload: dict[st
     output.mkdir(parents=True, exist_ok=True)
     scan_path = output / "scan-latest.json"
     queue_path = output / "refresh-queue.json"
-    scan_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
-    queue_path.write_text(json.dumps(_queue_payload(payload), indent=2, sort_keys=True) + "\n")
+    scan_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    queue_path.write_text(json.dumps(_queue_payload(payload), indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return scan_path, queue_path
 
 

--- a/src/brigade/memory_cmd.py
+++ b/src/brigade/memory_cmd.py
@@ -1175,7 +1175,7 @@ def _backfill_write(target: Path, candidate: dict[str, Any]) -> None:
     # just before its closing fence, leaving every other byte untouched.
     closing = next(i for i, line in enumerate(lines[1:], start=1) if line.strip() == "---")
     additions = [f"{field}: {candidate[field]}" for field in candidate["fields"]]
-    path.write_text("\n".join(lines[:closing] + additions + lines[closing:]))
+    path.write_text("\n".join(lines[:closing] + additions + lines[closing:]), encoding="utf-8")
 
 
 def backfill(*, target: Path, apply: bool = False, json_output: bool = False) -> int:

--- a/src/brigade/memory_cmd.py
+++ b/src/brigade/memory_cmd.py
@@ -319,7 +319,7 @@ def _index_links(target: Path, config: MemoryCareConfig) -> set[str]:
         if not path.is_file():
             continue
         try:
-            text = path.read_text()
+            text = path.read_text(encoding="utf-8")
         except OSError:
             continue
         links.update(match.group("path") for match in pattern.finditer(text))
@@ -508,7 +508,7 @@ def _scan_payload(target: Path, config: MemoryCareConfig) -> dict[str, Any]:
 
     for path in cards:
         rel = str(path.relative_to(target))
-        text = path.read_text(errors="replace")
+        text = path.read_text(encoding="utf-8", errors="replace")
         meta, has_frontmatter = _parse_frontmatter(text)
         card_id = str(_frontmatter_value(meta, "id", "card_id", "topic") or Path(rel).stem)
         by_id.setdefault(card_id, []).append(rel)
@@ -775,7 +775,7 @@ def _autofix_plan_item(issue: dict[str, Any], *, target: Path, scan_date: str) -
         blockers.append("card-file-missing")
     else:
         try:
-            text = path.read_text(errors="replace")
+            text = path.read_text(encoding="utf-8", errors="replace")
         except OSError:
             blockers.append("card-file-unreadable")
         else:
@@ -1133,7 +1133,7 @@ def _backfill_candidates(target: Path, config: MemoryCareConfig) -> tuple[list[d
     skipped_no_frontmatter = 0
     for path in _iter_cards(target, config):
         rel = str(path.relative_to(target))
-        text = path.read_text(errors="replace")
+        text = path.read_text(encoding="utf-8", errors="replace")
         meta, has_frontmatter = _parse_frontmatter(text)
         if not has_frontmatter:
             skipped_no_frontmatter += 1
@@ -1169,7 +1169,7 @@ def _backfill_candidates(target: Path, config: MemoryCareConfig) -> tuple[list[d
 
 def _backfill_write(target: Path, candidate: dict[str, Any]) -> None:
     path = target / candidate["file"]
-    text = path.read_text(errors="replace")
+    text = path.read_text(encoding="utf-8", errors="replace")
     lines = text.split("\n")
     # _parse_frontmatter guarantees a leading `---` block; insert the new keys
     # just before its closing fence, leaving every other byte untouched.
@@ -1324,7 +1324,7 @@ def closeout(*, target: Path, reason: str | None = None, defer: bool = False, js
 
 def _card_search_fields(path: Path, target: Path) -> dict[str, Any]:
     try:
-        text = path.read_text(errors="replace")
+        text = path.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return {}
     frontmatter, _ = _parse_frontmatter(text)
@@ -1430,7 +1430,7 @@ def _mcp_read_card(target: Path, config: MemoryCareConfig, uri: str) -> tuple[st
             continue
         if path.resolve() == candidate:
             try:
-                return path.read_text(errors="replace"), "text/markdown"
+                return path.read_text(encoding="utf-8", errors="replace"), "text/markdown"
             except OSError:
                 return None, None
     return None, None

--- a/src/brigade/memory_doctor/compact.py
+++ b/src/brigade/memory_doctor/compact.py
@@ -275,7 +275,7 @@ def _apply_flatten(memory_dir: Path, plan: CompactionPlan) -> None:
             target_path = resolve_card_target(memory_dir, flatten.target_name)
         except UnsafeTargetError:
             continue
-        existing = target_path.read_text()
+        existing = target_path.read_text(encoding="utf-8")
         marker = _flatten_marker(today, flatten)
         if marker in existing:
             # Already applied for this title/date - skip the topic append but
@@ -302,7 +302,7 @@ def _apply_flatten(memory_dir: Path, plan: CompactionPlan) -> None:
             # Dangling link: index may be the only record. Do not move; the
             # whole-file normalization pass below still scrubs unicode in place.
             continue
-        existing = target_path.read_text()
+        existing = target_path.read_text(encoding="utf-8")
         marker = _tighten_marker(today, tighten)
         if marker not in existing:
             sep = "" if existing.endswith("\n\n") else ("\n" if existing.endswith("\n") else "\n\n")

--- a/src/brigade/memory_doctor/lint.py
+++ b/src/brigade/memory_doctor/lint.py
@@ -62,7 +62,7 @@ def scan_dead_links(memory_dir: Path) -> list[DeadLink]:
     pool = sorted(slugs)
     out: list[DeadLink] = []
     for p in _card_paths(memory_dir):
-        text = p.read_text(errors="replace")
+        text = p.read_text(encoding="utf-8", errors="replace")
         for raw_link in extract_wiki_links(text):
             slug = raw_link.lower().removesuffix(".md")
             # Accept wiki links that include a cards/ prefix.

--- a/src/brigade/memory_doctor/parsing.py
+++ b/src/brigade/memory_doctor/parsing.py
@@ -86,7 +86,7 @@ def _first_nonblank_line(lines: list[str]) -> str:
 
 
 def parse_handoff(path: Path) -> ParsedHandoff:
-    text = path.read_text()
+    text = path.read_text(encoding="utf-8")
 
     action_lines = _section_lines(text, "Recommended memory action")
     if action_lines is None:

--- a/src/brigade/outcome_cmd.py
+++ b/src/brigade/outcome_cmd.py
@@ -214,7 +214,7 @@ def _linked_card_closure(cards_dir: Path, root_id: str) -> list[str]:
         card_path = cards_dir / f"{current}.md"
         if not card_path.is_file():
             continue
-        for raw in extract_wiki_links(card_path.read_text(errors="replace")):
+        for raw in extract_wiki_links(card_path.read_text(encoding="utf-8", errors="replace")):
             slug = _link_target_slug(raw).lower()
             if not slug or slug in visited:
                 continue

--- a/src/brigade/pi_mcp_cmd.py
+++ b/src/brigade/pi_mcp_cmd.py
@@ -39,7 +39,7 @@ def _json_text(payload: object) -> str:
 
 def _extension_source() -> str:
     template = Path(__file__).parent / "templates" / "pi" / "extensions" / "brigade-mcp-bridge.js"
-    return template.read_text()
+    return template.read_text(encoding="utf-8")
 
 
 def _catalog_projection(target: Path) -> dict[str, Any]:

--- a/src/brigade/release_cmd/candidate.py
+++ b/src/brigade/release_cmd/candidate.py
@@ -96,7 +96,7 @@ def _changelog_unreleased(path: Path) -> list[str]:
     changelog = path / "CHANGELOG.md"
     if not changelog.is_file():
         return []
-    lines = changelog.read_text().splitlines()
+    lines = changelog.read_text(encoding="utf-8").splitlines()
     capture = False
     items: list[str] = []
     for line in lines:

--- a/src/brigade/repos_cmd/adoption.py
+++ b/src/brigade/repos_cmd/adoption.py
@@ -342,7 +342,7 @@ def _cursor_wiring(target: Path) -> tuple[dict[str, Any], list[str], bool, bool]
             issues.append("missing Brigade ownership state")
 
     try:
-        guidance_text = (target / "AGENTS.md").read_text().casefold()
+        guidance_text = (target / "AGENTS.md").read_text(encoding="utf-8").casefold()
         guidance_current = "brigade-wired" in guidance_text and "brigade-work" in guidance_text
     except OSError:
         guidance_current = False

--- a/src/brigade/research/sources/local.py
+++ b/src/brigade/research/sources/local.py
@@ -18,7 +18,7 @@ def _tok(text: str) -> List[str]:
 def _read_text(path: Path) -> str:
     if path.suffix.lower() in {".md", ".txt", ""}:
         try:
-            return path.read_text(errors="ignore")
+            return path.read_text(encoding="utf-8", errors="ignore")
         except OSError:
             return ""
     return ""  # other types (e.g. pdf) skipped here; logged by caller

--- a/src/brigade/research_cmd.py
+++ b/src/brigade/research_cmd.py
@@ -339,7 +339,7 @@ def export_handoff(
         blockers.append(f"handoff artifact missing: {artifact_path}")
         handoff_text = ""
     else:
-        handoff_text = artifact_path.read_text(errors="replace")
+        handoff_text = artifact_path.read_text(encoding="utf-8", errors="replace")
     destination, inbox_label, destination_blockers = _resolve_handoff_destination(
         target, inbox=inbox, handoff_inbox=handoff_inbox
     )
@@ -363,7 +363,7 @@ def export_handoff(
     export_text = _augment_handoff_for_export(handoff_text, rec, source_fingerprint)
     filename = f"{_safe_filename(run_id)}-research-handoff.md"
     out_path = destination / filename
-    if out_path.exists() and out_path.read_text(errors="replace") != export_text and not force:
+    if out_path.exists() and out_path.read_text(encoding="utf-8", errors="replace") != export_text and not force:
         return {
             "status": "blocked",
             "run_id": run_id,
@@ -434,7 +434,7 @@ def handoff_status_payload(*, target: Path) -> dict[str, Any]:
             status = "missing-artifact"
             fingerprint = None
         else:
-            text = artifact_path.read_text(errors="replace")
+            text = artifact_path.read_text(encoding="utf-8", errors="replace")
             fingerprint = _fingerprint_json(_export_source_payload(target, rec, text))
             exports = [item for item in rec.get("handoff_exports", []) if isinstance(item, dict)]
             if not exports:

--- a/src/brigade/research_cmd.py
+++ b/src/brigade/research_cmd.py
@@ -180,9 +180,9 @@ def run(
     ho = handoffmod.render_handoff(
         question=question, markdown_report=result.report, findings=result.findings, stats=result.stats
     )
-    (d / "report.md").write_text(md)
-    (d / "report.html").write_text(html)
-    (d / "handoff.md").write_text(ho)
+    (d / "report.md").write_text(md, encoding="utf-8")
+    (d / "report.html").write_text(html, encoding="utf-8")
+    (d / "handoff.md").write_text(ho, encoding="utf-8")
     registry.finish_run(
         target,
         run_id,
@@ -372,7 +372,7 @@ def export_handoff(
             "inbox": inbox_label,
             "blockers": ["export path already exists with different content; pass --force to replace"],
         }
-    out_path.write_text(export_text)
+    out_path.write_text(export_text, encoding="utf-8")
 
     from . import handoff_cmd
 

--- a/src/brigade/roadmap_cmd.py
+++ b/src/brigade/roadmap_cmd.py
@@ -538,9 +538,8 @@ def _target_owns_brigade_cli(target: Path) -> bool:
     audited against brigade's own command surface, which otherwise reports
     hundreds of "undocumented" commands it never owned.
     """
-    try:
-        text = (target / "pyproject.toml").read_text(encoding="utf-8")
-    except OSError:
+    text = _read_text(target / "pyproject.toml")
+    if not text:
         return False
     return re.search(r'(?m)^\s*name\s*=\s*"brigade-cli"\s*$', text) is not None
 

--- a/src/brigade/roadmap_cmd.py
+++ b/src/brigade/roadmap_cmd.py
@@ -326,8 +326,8 @@ def _command_inventory_path(target: Path) -> Path:
 
 def _read_text(path: Path) -> str:
     try:
-        return path.read_text()
-    except OSError:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
         return ""
 
 
@@ -539,7 +539,7 @@ def _target_owns_brigade_cli(target: Path) -> bool:
     hundreds of "undocumented" commands it never owned.
     """
     try:
-        text = (target / "pyproject.toml").read_text()
+        text = (target / "pyproject.toml").read_text(encoding="utf-8")
     except OSError:
         return False
     return re.search(r'(?m)^\s*name\s*=\s*"brigade-cli"\s*$', text) is not None

--- a/src/brigade/skills_cmd.py
+++ b/src/brigade/skills_cmd.py
@@ -262,7 +262,7 @@ def _copy_skill_for_harness(
         rendered = _render_skill_text_for_harness(
             source_skill.read_text(encoding="utf-8", errors="replace"), metadata, skill_id, harness
         )
-        _skill_md_path(dest).write_text(rendered)
+        _skill_md_path(dest).write_text(rendered, encoding="utf-8")
 
 
 def _read_json(path: Path) -> dict[str, Any]:
@@ -1710,7 +1710,8 @@ def pack_build(*, target: Path, json_output: bool = False) -> int:
         f"# Skill Pack {pack_id}\n\n"
         f"- skills: {payload['skill_count']}\n"
         f"- fingerprint: {payload['evidence_fingerprint']}\n"
-        f"- import: brigade skills pack import {pack_dir}\n"
+        f"- import: brigade skills pack import {pack_dir}\n",
+        encoding="utf-8",
     )
     payload["path"] = str(pack_dir)
     if json_output:

--- a/src/brigade/skills_cmd.py
+++ b/src/brigade/skills_cmd.py
@@ -259,7 +259,9 @@ def _copy_skill_for_harness(
     shutil.copytree(source_dir, dest)
     source_skill = _skill_md_path(source_dir)
     if source_skill.is_file():
-        rendered = _render_skill_text_for_harness(source_skill.read_text(encoding="utf-8", errors="replace"), metadata, skill_id, harness)
+        rendered = _render_skill_text_for_harness(
+            source_skill.read_text(encoding="utf-8", errors="replace"), metadata, skill_id, harness
+        )
         _skill_md_path(dest).write_text(rendered)
 
 
@@ -1023,7 +1025,9 @@ def install(
         dest.parent.mkdir(parents=True, exist_ok=True)
         _copy_skill_for_harness(source_dir, dest, metadata, skill_id, install_target)
         installed_fingerprint = _fingerprint(dest)
-        installed_skill_fingerprint = _text_fingerprint(_skill_md_path(dest).read_text(encoding="utf-8", errors="replace"))
+        installed_skill_fingerprint = _text_fingerprint(
+            _skill_md_path(dest).read_text(encoding="utf-8", errors="replace")
+        )
         installed_metadata_fingerprint = _file_fingerprint(_metadata_path(dest))
         installed_at = _now()
         receipt = {

--- a/src/brigade/skills_cmd.py
+++ b/src/brigade/skills_cmd.py
@@ -259,7 +259,7 @@ def _copy_skill_for_harness(
     shutil.copytree(source_dir, dest)
     source_skill = _skill_md_path(source_dir)
     if source_skill.is_file():
-        rendered = _render_skill_text_for_harness(source_skill.read_text(errors="replace"), metadata, skill_id, harness)
+        rendered = _render_skill_text_for_harness(source_skill.read_text(encoding="utf-8", errors="replace"), metadata, skill_id, harness)
         _skill_md_path(dest).write_text(rendered)
 
 
@@ -298,7 +298,7 @@ def _read_jsonl(path: Path) -> list[dict[str, Any]]:
     if not path.is_file():
         return rows
     try:
-        lines = path.read_text(errors="replace").splitlines()
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
     except OSError:
         return rows
     for line in lines:
@@ -330,7 +330,7 @@ def _changelog_payload(skill_dir: Path, metadata: dict[str, Any]) -> dict[str, A
     headings: list[str] = []
     fingerprint: str | None = None
     if path is not None:
-        text = path.read_text(errors="replace")
+        text = path.read_text(encoding="utf-8", errors="replace")
         fingerprint = _text_fingerprint(text)
         headings = [line.strip("# ").strip() for line in text.splitlines() if line.startswith("#")][:8]
     return {
@@ -567,7 +567,7 @@ def _lint_payload(
         errors.append(f"SKILL.md not found: {skill_md}")
         text = ""
     else:
-        text = skill_md.read_text(errors="replace")
+        text = skill_md.read_text(encoding="utf-8", errors="replace")
         if not text.strip():
             errors.append("SKILL.md is empty")
         if len(text) > 40_000:
@@ -884,7 +884,7 @@ def _drift_payload(
     receipt = _latest_install_receipt(target, skill_id, harness)
     installed_skill = _skill_md_path(installed_dir)
     installed_present = installed_skill.is_file()
-    installed_text = installed_skill.read_text(errors="replace") if installed_present else ""
+    installed_text = installed_skill.read_text(encoding="utf-8", errors="replace") if installed_present else ""
     current_source = lint_payload.get("source") if isinstance(lint_payload.get("source"), dict) else {}
     current_render = _renderer_contract(target, harness)
     current_render_fingerprint = _text_fingerprint(rendered)
@@ -983,7 +983,7 @@ def install(
             skipped.append({"target": "hermes", "reason": "Hermes home not found (is Hermes installed?)"})
             continue
         dest = _install_dir(workspace, install_target, skill_id)
-        source_text = _skill_md_path(source_dir).read_text(errors="replace")
+        source_text = _skill_md_path(source_dir).read_text(encoding="utf-8", errors="replace")
         rendered_text = _render_skill_text_for_harness(source_text, metadata, skill_id, install_target)
         render_fingerprint = _text_fingerprint(rendered_text)
         render_contract = _renderer_contract(workspace, install_target)
@@ -1023,7 +1023,7 @@ def install(
         dest.parent.mkdir(parents=True, exist_ok=True)
         _copy_skill_for_harness(source_dir, dest, metadata, skill_id, install_target)
         installed_fingerprint = _fingerprint(dest)
-        installed_skill_fingerprint = _text_fingerprint(_skill_md_path(dest).read_text(errors="replace"))
+        installed_skill_fingerprint = _text_fingerprint(_skill_md_path(dest).read_text(encoding="utf-8", errors="replace"))
         installed_metadata_fingerprint = _file_fingerprint(_metadata_path(dest))
         installed_at = _now()
         receipt = {
@@ -1155,7 +1155,7 @@ def _sync_plan(*, workspace: Path, harness: str, trust: str) -> tuple[list[dict[
                 items.append(item)
                 continue
             source_dir = Path(str(lint_payload["skill_dir"]))
-            source_text = _skill_md_path(source_dir).read_text(errors="replace")
+            source_text = _skill_md_path(source_dir).read_text(encoding="utf-8", errors="replace")
             rendered = _render_skill_text_for_harness(source_text, metadata, skill_id, install_target)
             render_errors = _rendered_skill_validation(rendered, install_target)
             if render_errors:
@@ -1295,7 +1295,7 @@ def _user_profile_package(
         return None
     skill_md_path = _skill_md_path(skill_dir)
     if "SKILL.md" in files and skill_md_path.is_file():
-        source_text = skill_md_path.read_text(errors="replace")
+        source_text = skill_md_path.read_text(encoding="utf-8", errors="replace")
         rendered = _render_skill_text_for_harness(source_text, metadata, skill_id, harness)
         if _rendered_skill_validation(rendered, harness):
             return None
@@ -1593,11 +1593,11 @@ def diff(*, target: Path, skill: str, harness: str, against: str = "bundled", js
         return 2
     source_dir = Path(str(lint_payload["skill_dir"]))
     metadata = lint_payload.get("metadata") if isinstance(lint_payload.get("metadata"), dict) else {}
-    source_text = _skill_md_path(source_dir).read_text(errors="replace")
+    source_text = _skill_md_path(source_dir).read_text(encoding="utf-8", errors="replace")
     rendered = _render_skill_text_for_harness(source_text, metadata, skill_id, harness)
     installed_dir = _install_dir(target, harness, skill_id)
     installed_skill = _skill_md_path(installed_dir)
-    installed_text = installed_skill.read_text(errors="replace") if installed_skill.is_file() else ""
+    installed_text = installed_skill.read_text(encoding="utf-8", errors="replace") if installed_skill.is_file() else ""
     source = lint_payload.get("source") if isinstance(lint_payload.get("source"), dict) else {}
     diff_lines = list(
         difflib.unified_diff(
@@ -1955,13 +1955,13 @@ def _mcp_read_resource(target: Path, uri: str) -> tuple[str, str] | tuple[None, 
     metadata = _read_json(_metadata_path(skill_dir))
     if name == "SKILL.md":
         path = _skill_md_path(skill_dir)
-        return (path.read_text(errors="replace"), "text/markdown") if path.is_file() else (None, None)
+        return (path.read_text(encoding="utf-8", errors="replace"), "text/markdown") if path.is_file() else (None, None)
     if name == "skill.json":
         return json.dumps(metadata, indent=2, sort_keys=True) + "\n", "application/json"
     if name == "CHANGELOG.md":
         changelog = _changelog_payload(skill_dir, metadata)
         path = Path(str(changelog.get("path") or ""))
-        return (path.read_text(errors="replace"), "text/markdown") if path.is_file() else (None, None)
+        return (path.read_text(encoding="utf-8", errors="replace"), "text/markdown") if path.is_file() else (None, None)
     if name == "compatibility.json":
         return (
             json.dumps(_compatibility_payload(target, f"registry:{skill_id}"), indent=2, sort_keys=True) + "\n",
@@ -2164,7 +2164,7 @@ def _compatibility_payload(target: Path, skill: str) -> dict[str, Any]:
     skill_dir = Path(str(lint_payload.get("skill_dir") or ""))
     skill_md = _skill_md_path(skill_dir)
     if skill_md.is_file():
-        source_text = skill_md.read_text(errors="replace")
+        source_text = skill_md.read_text(encoding="utf-8", errors="replace")
     adapters = []
     for adapter_id, adapter in _adapter_map(target).items():
         install_path = adapter.get("install_path")
@@ -2425,7 +2425,7 @@ def _fleet_status_payload(target: Path) -> dict[str, Any]:
             continue
         source_dir = Path(str(lint_payload["skill_dir"]))
         metadata = lint_payload.get("metadata") if isinstance(lint_payload.get("metadata"), dict) else {}
-        source_text = _skill_md_path(source_dir).read_text(errors="replace")
+        source_text = _skill_md_path(source_dir).read_text(encoding="utf-8", errors="replace")
         supported = metadata.get("supported_harnesses") if isinstance(metadata.get("supported_harnesses"), list) else []
         source = lint_payload.get("source") if isinstance(lint_payload.get("source"), dict) else {}
         supported_state = harness in supported or not supported
@@ -2854,8 +2854,8 @@ def inbox_diff(*, target: Path, proposal_id: str, json_output: bool = False) -> 
         return 2
     proposed = _proposal_skill_path(path) / "SKILL.md"
     existing = _skill_path(target, str(proposal.get("skill_id") or path.name)) / "SKILL.md"
-    before = existing.read_text(errors="replace").splitlines() if existing.is_file() else []
-    after = proposed.read_text(errors="replace").splitlines() if proposed.is_file() else []
+    before = existing.read_text(encoding="utf-8", errors="replace").splitlines() if existing.is_file() else []
+    after = proposed.read_text(encoding="utf-8", errors="replace").splitlines() if proposed.is_file() else []
     diff = list(difflib.unified_diff(before, after, fromfile=str(existing), tofile=str(proposed), lineterm=""))
     payload = {
         "target": str(target),

--- a/src/brigade/work_cmd/imports.py
+++ b/src/brigade/work_cmd/imports.py
@@ -139,8 +139,8 @@ def _append_active_context_note(target: Path, rendered: str) -> Path | None:
     helpers._write_json(session_json, payload)
 
     notes_path = session_dir / "notes.md"
-    prefix = "" if notes_path.exists() and notes_path.read_text().endswith("\n") else "\n"
-    with notes_path.open("a") as handle:
+    prefix = "" if notes_path.exists() and notes_path.read_text(encoding="utf-8").endswith("\n") else "\n"
+    with notes_path.open("a", encoding="utf-8") as handle:
         if notes_path.stat().st_size == 0:
             handle.write("# Brigade Work Session Notes\n")
         else:

--- a/src/brigade/work_cmd/imports.py
+++ b/src/brigade/work_cmd/imports.py
@@ -123,7 +123,7 @@ def _append_active_context_note(target: Path, rendered: str) -> Path | None:
         return None
     session_json = session_dir / "session.json"
     try:
-        payload = json.loads(session_json.read_text())
+        payload = json.loads(session_json.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return None
     if not isinstance(payload, dict):

--- a/src/brigade/work_cmd/imports.py
+++ b/src/brigade/work_cmd/imports.py
@@ -74,7 +74,7 @@ def import_context(
     if from_file is not None:
         body_path = Path(from_file).expanduser()
         try:
-            raw = body_path.read_text()
+            raw = body_path.read_text(encoding="utf-8")
         except OSError as exc:
             print(f"error: cannot read --from-file: {exc}", file=sys.stderr)
             return 2

--- a/src/brigade/work_cmd/imports.py
+++ b/src/brigade/work_cmd/imports.py
@@ -75,7 +75,7 @@ def import_context(
         body_path = Path(from_file).expanduser()
         try:
             raw = body_path.read_text(encoding="utf-8")
-        except OSError as exc:
+        except (OSError, UnicodeError) as exc:
             print(f"error: cannot read --from-file: {exc}", file=sys.stderr)
             return 2
     else:

--- a/src/brigade/work_cmd/session/lifecycle.py
+++ b/src/brigade/work_cmd/session/lifecycle.py
@@ -258,7 +258,7 @@ def _write_session_markdown(path: Path, *, title: str, payload: dict[str, Any], 
         lines.append(f"- Latest run: {latest.get('started_at')} [{latest.get('status')}] {latest.get('path')}")
     if dogfood.get("next"):
         lines.append(f"- Next: {dogfood['next']}")
-    path.write_text("\n".join(lines) + "\n")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
 def _write_work_handoff(target: Path, session_dir: Path, payload: dict[str, Any], inbox: Path) -> Path:
@@ -336,7 +336,7 @@ no-card
 {document_content.strip()}
 """
     inbox.mkdir(parents=True, exist_ok=True)
-    path.write_text(body)
+    path.write_text(body, encoding="utf-8")
     return path
 
 

--- a/src/brigade/work_cmd/session/lifecycle.py
+++ b/src/brigade/work_cmd/session/lifecycle.py
@@ -468,8 +468,8 @@ def note(*, target: Path, text: str) -> int:
     helpers._write_json(session_json, payload)
 
     notes_path = session_dir / "notes.md"
-    prefix = "" if notes_path.exists() and notes_path.read_text().endswith("\n") else "\n"
-    with notes_path.open("a") as handle:
+    prefix = "" if notes_path.exists() and notes_path.read_text(encoding="utf-8").endswith("\n") else "\n"
+    with notes_path.open("a", encoding="utf-8") as handle:
         if notes_path.stat().st_size == 0:
             handle.write("# Brigade Work Session Notes\n")
         else:

--- a/tests/test_memory_cmd.py
+++ b/tests/test_memory_cmd.py
@@ -454,6 +454,19 @@ def test_memory_care_cli(tmp_path, monkeypatch):
     ]
 
 
+def test_memory_care_scan_tolerates_malformed_utf8_index(tmp_path, capsys):
+    cards = tmp_path / "memory" / "cards"
+    _write_card(
+        cards / "ok.md",
+        {"topic": "ok", "last_reviewed": "2026-05-20", "confidence": "high", "evidence": ["README.md"]},
+    )
+    (tmp_path / "MEMORY.md").write_bytes(b"# index\n\xff not utf-8\n")
+
+    assert memory_cmd.scan(target=tmp_path, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["issue_count"] >= 0
+
+
 def test_memory_care_scan_default_output_lives_under_brigade_state(tmp_path, capsys):
     cards = tmp_path / "memory" / "cards"
     cards.mkdir(parents=True)

--- a/tests/test_roadmap_cmd.py
+++ b/tests/test_roadmap_cmd.py
@@ -41,6 +41,11 @@ def test_read_text_returns_empty_on_undecodable_utf8(tmp_path):
     assert roadmap_cmd._read_text(path) == ""
 
 
+def test_target_owns_brigade_cli_ignores_malformed_pyproject(tmp_path):
+    tmp_path.joinpath("pyproject.toml").write_bytes(b'name = "brigade-cli"\xff')
+    assert roadmap_cmd._target_owns_brigade_cli(tmp_path) is False
+
+
 def test_roadmap_audit_classifies_stale_sections_and_command_mismatch(tmp_path):
     (tmp_path / "ROADMAP.md").write_text(
         "# Roadmap\n\n"

--- a/tests/test_roadmap_cmd.py
+++ b/tests/test_roadmap_cmd.py
@@ -5,6 +5,42 @@ from brigade import cli
 from brigade import roadmap_cmd
 
 
+def test_read_text_reads_utf8_docs_when_locale_codec_is_cp1252(tmp_path, monkeypatch):
+    """Regression for #752: Windows locale default (cp1252) must not decode repo docs.
+
+    Forces the Path.read_text default codec to cp1252 (as on Windows) so this
+    fails on Linux CI too if encoding=\"utf-8\" is dropped from _read_text.
+    """
+    path = tmp_path / "README.md"
+    # U+2510 BOX DRAWINGS LIGHT DOWN AND LEFT — UTF-8 e2 94 90; byte 0x90 is
+    # undefined in cp1252 and raises UnicodeDecodeError under that codec.
+    box = "\u2510"
+    path.write_bytes(f"Run `brigade work brief` near {box}\n".encode("utf-8"))
+
+    real_read_text = Path.read_text
+
+    def read_text_locale_default(self, *args, encoding=None, errors=None, **kwargs):
+        if encoding is None:
+            encoding = "cp1252"
+        return real_read_text(self, *args, encoding=encoding, errors=errors, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", read_text_locale_default)
+
+    text = roadmap_cmd._read_text(path)
+    assert box in text
+    assert "brigade work brief" in text
+
+    (tmp_path / "ROADMAP.md").write_bytes(b"# Roadmap\n")
+    documented = roadmap_cmd._documented_brigade_commands(tmp_path)
+    assert "brigade work brief" in documented
+
+
+def test_read_text_returns_empty_on_undecodable_utf8(tmp_path):
+    path = tmp_path / "broken.md"
+    path.write_bytes(b"ok\xff\xfe not utf-8")
+    assert roadmap_cmd._read_text(path) == ""
+
+
 def test_roadmap_audit_classifies_stale_sections_and_command_mismatch(tmp_path):
     (tmp_path / "ROADMAP.md").write_text(
         "# Roadmap\n\n"

--- a/tests/test_work_cmd_imports.py
+++ b/tests/test_work_cmd_imports.py
@@ -3106,6 +3106,25 @@ def test_import_context_missing_from_file_errors(tmp_path, capsys):
     assert work_cmd._read_imports(tmp_path) == []
 
 
+def test_import_context_invalid_utf8_from_file_errors(tmp_path, capsys):
+    tmp_path.mkdir(exist_ok=True)
+    body_file = tmp_path / "invalid-utf8.txt"
+    body_file.write_bytes(b"\xff\xfe not valid utf-8")
+
+    assert (
+        work_cmd.import_context(
+            target=tmp_path,
+            text="",
+            context_kind="note",
+            from_file=body_file,
+        )
+        == 2
+    )
+    captured = capsys.readouterr()
+    assert "error: cannot read --from-file:" in captured.err
+    assert work_cmd._read_imports(tmp_path) == []
+
+
 def test_import_context_rejects_non_directory_target(tmp_path, capsys):
     missing = tmp_path / "nope"
     assert work_cmd.import_context(target=missing, text="ctx", context_kind="note") == 2


### PR DESCRIPTION
## Summary
- `roadmap_cmd._read_text()` (and the same class of doc/user text readers) now use `encoding="utf-8"` so Windows locale cp1252 cannot crash `brigade work brief` on UTF-8 box-drawing / smart-quote docs.
- `_read_text` also catches `UnicodeDecodeError` so one undecodable file returns empty string instead of aborting the command.
- Regression test forces `Path.read_text` default codec to cp1252 and feeds a box-drawing README, so Linux CI fails if `encoding="utf-8"` is dropped.

## Repro (native Windows, Python 3.14.6)

**Before** (`brigade work brief --target .`, PYTHONUTF8 unset):
```
File ".../brigade/roadmap_cmd.py", line 329, in _read_text
    return path.read_text()
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 2221: character maps to <undefined>
EXIT: 1
```

**After** (same command on this branch):
```
work brief: C:\burndown\brigade
branch: fix/752-utf8-read-text
EXIT: 0
```

## Test plan
- [x] `pytest tests/test_roadmap_cmd.py` on Windows (12 passed)
- [x] Full `pytest -q` on Windows recorded (4542 passed / 1312 failed; large pre-existing Windows/POSIX skew + late KeyboardInterrupt during verification tests — not introduced by this UTF-8 read sweep; Linux CI is the merge gate)
- [ ] CI green on this PR

Fixes #752


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized text-file reading and writing to UTF-8 across documentation, handoffs, skills, memory, sessions, and related workflows.
  - Improved consistency when processing files containing non-ASCII characters across different system locales.
  - Preserved graceful handling of invalid or undecodable file content.

- **Tests**
  - Added regression coverage for UTF-8 handling under non-UTF-8 system locales and invalid file content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->