### PR TITLE
fix(windows): host shebang and native scripts in work verify run

### DIFF
--- a/src/brigade/work_cmd/verification.py
+++ b/src/brigade/work_cmd/verification.py
@@ -27,6 +27,35 @@ def _verification_is_windows() -> bool:
     return os.name == "nt"
 
 
+_VERIFICATION_WINDOWS_SHELL_META_RE = constants.SCANNER_SHELL_META_RE
+_VERIFICATION_POSIX_SHELL_META_RE = re.compile(r"[;&|`<>\\]|\$\(")
+
+
+def _verification_shell_meta_re() -> re.Pattern[str]:
+    """Shell-metacharacter guard for raw ``--command`` parsing.
+
+    On POSIX, backslash is treated as an escape/separator and rejected. On Windows,
+    backslash is an ordinary path separator and only true shell metacharacters match.
+    """
+    if _verification_is_windows():
+        return _VERIFICATION_WINDOWS_SHELL_META_RE
+    return _VERIFICATION_POSIX_SHELL_META_RE
+
+
+def _verification_strip_outer_quotes(token: str) -> str:
+    if len(token) >= 2 and token[0] == token[-1] and token[0] in {'"', "'"}:
+        return token[1:-1]
+    return token
+
+
+def _verification_split_command(command: str) -> list[str]:
+    """Split a raw ``--command`` string with platform-aware shlex rules."""
+    parts = shlex.split(command, posix=not _verification_is_windows())
+    if _verification_is_windows():
+        parts = [_verification_strip_outer_quotes(token) for token in parts]
+    return parts
+
+
 def _default_verify_commands(target: Path) -> list[str]:
     if (target / "pyproject.toml").is_file() and (target / "tests").is_dir():
         if (target / "src").is_dir():
@@ -212,7 +241,7 @@ def _windows_script_execution_argv(script: Path, script_args: list[str]) -> list
 
 def _verify_parse_command(command: str, target: Path) -> tuple[list[str] | None, dict[str, str], str | None]:
     try:
-        parts = shlex.split(command)
+        parts = _verification_split_command(command)
     except ValueError as exc:
         return None, {}, f"invalid command: {exc}"
     if not parts:
@@ -227,7 +256,7 @@ def _verify_parse_command(command: str, target: Path) -> tuple[list[str] | None,
     executable = Path(argv[0]).name
     if executable in constants.SCANNER_HIGH_RISK_COMMANDS:
         return None, env, _high_risk_command_message(executable)
-    if any(constants.SCANNER_SHELL_META_RE.search(part) for part in argv):
+    if any(_verification_shell_meta_re().search(part) for part in argv):
         return (
             None,
             env,

--- a/src/brigade/work_cmd/verification.py
+++ b/src/brigade/work_cmd/verification.py
@@ -27,19 +27,14 @@ def _verification_is_windows() -> bool:
     return os.name == "nt"
 
 
-_VERIFICATION_WINDOWS_SHELL_META_RE = constants.SCANNER_SHELL_META_RE
-_VERIFICATION_POSIX_SHELL_META_RE = re.compile(r"[;&|`<>\\]|\$\(")
-
-
 def _verification_shell_meta_re() -> re.Pattern[str]:
     """Shell-metacharacter guard for raw ``--command`` parsing.
 
-    On POSIX, backslash is treated as an escape/separator and rejected. On Windows,
-    backslash is an ordinary path separator and only true shell metacharacters match.
+    Uses the same pattern as ``constants.SCANNER_SHELL_META_RE`` on every platform.
+    After shlex splitting, literal backslashes in argv tokens (regex escapes, Windows
+    paths, Python ``-c`` strings) are ordinary characters and must not be rejected.
     """
-    if _verification_is_windows():
-        return _VERIFICATION_WINDOWS_SHELL_META_RE
-    return _VERIFICATION_POSIX_SHELL_META_RE
+    return constants.SCANNER_SHELL_META_RE
 
 
 def _verification_strip_outer_quotes(token: str) -> str:

--- a/src/brigade/work_cmd/verification.py
+++ b/src/brigade/work_cmd/verification.py
@@ -109,9 +109,7 @@ def _unresolvable_command_message(executable: str) -> str:
 
 def _verify_token_is_path(token: str) -> bool:
     """True when *token* should be resolved relative to --target, not via PATH."""
-    if "/" in token or (
-        _verification_is_windows() and ("\\" in token or (len(token) >= 2 and token[1] == ":"))
-    ):
+    if "/" in token or (_verification_is_windows() and ("\\" in token or (len(token) >= 2 and token[1] == ":"))):
         return True
     return False
 

--- a/src/brigade/work_cmd/verification.py
+++ b/src/brigade/work_cmd/verification.py
@@ -53,12 +53,20 @@ def _high_risk_command_message(executable: str) -> str:
     command directly with no shell, so a shell interpreter is never a valid
     executable. ``--argv-json`` is deliberately not suggested here because that
     path applies the same high-risk block, so the fix is a resolvable non-shell
-    executable, e.g. a chmod +x script invoked by its path.
+    executable invoked by its path. Advice is platform-aware: POSIX CreateProcess
+    honors shebang +x scripts; Windows needs an explicit host (.ps1/.cmd) or a
+    shebang'd script path that verify rewrites to the interpreter.
     """
+    if os.name == "nt":
+        remedy = (
+            "python script.py, a .ps1/.cmd run by its path like .\\scripts\\check.ps1, "
+            "or a shebang'd script path like ./scripts/check.sh"
+        )
+    else:
+        remedy = "a chmod +x script run by its path like ./scripts/check.sh"
     return (
         f"high-risk verification command: {executable} "
-        "(verify runs with no shell; use a resolvable executable, e.g. a "
-        "chmod +x script run by its path like ./scripts/check.sh)"
+        f"(verify runs with no shell; use a resolvable executable, e.g. {remedy})"
     )
 
 
@@ -68,6 +76,131 @@ def _missing_python_interpreter_message() -> str:
 
 def _unresolvable_command_message(executable: str) -> str:
     return f"verification command is not resolvable: {executable}"
+
+
+def _verify_token_is_path(token: str) -> bool:
+    """True when *token* should be resolved relative to --target, not via PATH."""
+    if "/" in token or (os.name == "nt" and ("\\" in token or (len(token) >= 2 and token[1] == ":"))):
+        return True
+    return False
+
+
+def _shebang_interpreter_token(shebang_line: str) -> str | None:
+    """Return the interpreter program token from a shebang line.
+
+    Platform-independent pure parser used by Windows script launching and tests.
+    ``#!/usr/bin/env bash`` -> ``bash``; ``#!/bin/sh`` -> ``/bin/sh``.
+    """
+    line = shebang_line.strip()
+    if not line.startswith("#!"):
+        return None
+    line = line[2:].lstrip()
+    if not line:
+        return None
+    try:
+        parts = shlex.split(line, posix=True)
+    except ValueError:
+        parts = line.split()
+    if not parts:
+        return None
+    if Path(parts[0]).name == "env":
+        for part in parts[1:]:
+            if not part.startswith("-"):
+                return part
+        return None
+    return parts[0]
+
+
+def _read_script_shebang_token(script: Path) -> str | None:
+    try:
+        with script.open("rb") as handle:
+            first = handle.readline(512)
+    except OSError:
+        return None
+    if not first.startswith(b"#!"):
+        return None
+    return _shebang_interpreter_token(first.decode("utf-8", errors="replace"))
+
+
+def _is_wsl_bash(path: str) -> bool:
+    normalized = path.replace("/", "\\").lower()
+    return normalized.endswith("\\system32\\bash.exe") or "\\windowsapps\\bash.exe" in normalized
+
+
+def _windows_git_shell_candidates(name: str) -> list[Path]:
+    """Likely Git-for-Windows locations for bash/sh (prefer over WSL bash.exe)."""
+    roots: list[Path] = []
+    for key in ("ProgramFiles", "ProgramFiles(x86)", "LOCALAPPDATA"):
+        value = os.environ.get(key)
+        if value:
+            roots.append(Path(value) / "Git")
+    roots.append(Path(r"C:\Program Files\Git"))
+    roots.append(Path(r"C:\Program Files (x86)\Git"))
+    exe = f"{name}.exe"
+    out: list[Path] = []
+    for root in roots:
+        out.extend(
+            (
+                root / "bin" / exe,
+                root / "usr" / "bin" / exe,
+            )
+        )
+    return out
+
+
+def _windows_resolve_interpreter(token: str) -> str | None:
+    """Resolve a shebang interpreter token to a Windows executable path."""
+    candidate = Path(token)
+    if candidate.is_file():
+        return str(candidate)
+    name = candidate.name
+    if name.lower().endswith(".exe"):
+        name = name[:-4]
+    if name in {"bash", "sh"}:
+        for path in _windows_git_shell_candidates(name):
+            if path.is_file():
+                return str(path)
+    found = shutil.which(name)
+    if found and not (name in {"bash", "sh"} and _is_wsl_bash(found)):
+        return found
+    if name in {"bash", "sh"}:
+        # Last resort: whatever which found (may be WSL).
+        return found
+    return shutil.which(token)
+
+
+def _windows_native_script_host(script: Path) -> list[str] | None:
+    """Return argv prefix for .ps1/.cmd/.bat via their native hosts, or None."""
+    suffix = script.suffix.lower()
+    if suffix == ".ps1":
+        host = shutil.which("pwsh") or shutil.which("powershell")
+        if host is None:
+            return None
+        return [host, "-NoProfile", "-File", str(script)]
+    if suffix in {".cmd", ".bat"}:
+        comspec = os.environ.get("ComSpec") or shutil.which("cmd")
+        if comspec is None:
+            return None
+        return [comspec, "/c", str(script)]
+    return None
+
+
+def _windows_script_execution_argv(script: Path, script_args: list[str]) -> list[str] | None:
+    """Rewrite a script path into an explicitly hosted argv on Windows.
+
+    CreateProcess does not honor shebang; without this rewrite, ``./scripts/check.sh``
+    fails with WinError 193 / exit 127 even though the high-risk guard recommended it.
+    """
+    native = _windows_native_script_host(script)
+    if native is not None:
+        return native + list(script_args)
+    token = _read_script_shebang_token(script)
+    if token is None:
+        return None
+    interpreter = _windows_resolve_interpreter(token)
+    if interpreter is None:
+        return None
+    return [interpreter, str(script), *script_args]
 
 
 def _verify_parse_command(command: str, target: Path) -> tuple[list[str] | None, dict[str, str], str | None]:
@@ -96,7 +229,7 @@ def _verify_parse_command(command: str, target: Path) -> tuple[list[str] | None,
                 "(use --argv-json to pass a pre-parsed argv list instead)"
             ),
         )
-    if "/" in argv[0]:
+    if _verify_token_is_path(argv[0]):
         executable_path = Path(argv[0]).expanduser()
         if not executable_path.is_absolute():
             executable_path = target / executable_path
@@ -123,7 +256,7 @@ def _verify_parse_argv(argv: list[str], target: Path) -> tuple[list[str] | None,
     executable = Path(argv[0]).name
     if executable in constants.SCANNER_HIGH_RISK_COMMANDS:
         return None, {}, _high_risk_command_message(executable)
-    if "/" in argv[0]:
+    if _verify_token_is_path(argv[0]):
         executable_path = Path(argv[0]).expanduser()
         if not executable_path.is_absolute():
             executable_path = target / executable_path
@@ -138,11 +271,16 @@ def _verify_parse_argv(argv: list[str], target: Path) -> tuple[list[str] | None,
 
 def _verify_execution_argv(argv: list[str], target: Path) -> list[str]:
     execution_argv = list(argv)
-    if "/" in execution_argv[0]:
-        executable_path = Path(execution_argv[0]).expanduser()
-        if not executable_path.is_absolute():
-            executable_path = target / executable_path
-        execution_argv[0] = str(executable_path)
+    if not _verify_token_is_path(execution_argv[0]):
+        return execution_argv
+    executable_path = Path(execution_argv[0]).expanduser()
+    if not executable_path.is_absolute():
+        executable_path = target / executable_path
+    execution_argv[0] = str(executable_path)
+    if os.name == "nt":
+        hosted = _windows_script_execution_argv(executable_path, execution_argv[1:])
+        if hosted is not None:
+            return hosted
     return execution_argv
 
 

--- a/src/brigade/work_cmd/verification.py
+++ b/src/brigade/work_cmd/verification.py
@@ -22,6 +22,11 @@ from . import reviews as reviews_mod
 from . import scanners as scanners_mod
 
 
+def _verification_is_windows() -> bool:
+    """True on Windows; patchable in tests without mutating the shared os module."""
+    return os.name == "nt"
+
+
 def _default_verify_commands(target: Path) -> list[str]:
     if (target / "pyproject.toml").is_file() and (target / "tests").is_dir():
         if (target / "src").is_dir():
@@ -57,7 +62,7 @@ def _high_risk_command_message(executable: str) -> str:
     honors shebang +x scripts; Windows needs an explicit host (.ps1/.cmd) or a
     shebang'd script path that verify rewrites to the interpreter.
     """
-    if os.name == "nt":
+    if _verification_is_windows():
         remedy = (
             "python script.py, a .ps1/.cmd run by its path like .\\scripts\\check.ps1, "
             "or a shebang'd script path like ./scripts/check.sh"
@@ -80,7 +85,9 @@ def _unresolvable_command_message(executable: str) -> str:
 
 def _verify_token_is_path(token: str) -> bool:
     """True when *token* should be resolved relative to --target, not via PATH."""
-    if "/" in token or (os.name == "nt" and ("\\" in token or (len(token) >= 2 and token[1] == ":"))):
+    if "/" in token or (
+        _verification_is_windows() and ("\\" in token or (len(token) >= 2 and token[1] == ":"))
+    ):
         return True
     return False
 
@@ -277,7 +284,7 @@ def _verify_execution_argv(argv: list[str], target: Path) -> list[str]:
     if not executable_path.is_absolute():
         executable_path = target / executable_path
     execution_argv[0] = str(executable_path)
-    if os.name == "nt":
+    if _verification_is_windows():
         hosted = _windows_script_execution_argv(executable_path, execution_argv[1:])
         if hosted is not None:
             return hosted

--- a/tests/test_work_cmd_verification.py
+++ b/tests/test_work_cmd_verification.py
@@ -1234,7 +1234,6 @@ def test_shebang_interpreter_token_parses_env_and_absolute_forms():
 def test_windows_script_execution_argv_hosts_shebang_and_native_suffixes(tmp_path, monkeypatch):
     from brigade.work_cmd import verification
 
-    monkeypatch.setattr(verification.os, "name", "nt")
     script = tmp_path / "check.sh"
     script.write_bytes(b"#!/usr/bin/env bash\necho hi\n")
     fake_bash = tmp_path / "bash.exe"
@@ -1293,10 +1292,10 @@ def test_verify_execution_argv_expands_shebang_only_on_windows(tmp_path, monkeyp
         lambda token: str(fake_bash) if token == "bash" else None,
     )
 
-    monkeypatch.setattr(verification.os, "name", "posix")
+    monkeypatch.setattr(verification, "_verification_is_windows", lambda: False)
     assert verification._verify_execution_argv(["./scripts/check.sh"], target) == [str(script)]
 
-    monkeypatch.setattr(verification.os, "name", "nt")
+    monkeypatch.setattr(verification, "_verification_is_windows", lambda: True)
     assert verification._verify_execution_argv(["./scripts/check.sh", "x"], target) == [
         str(fake_bash),
         str(script),
@@ -1307,12 +1306,12 @@ def test_verify_execution_argv_expands_shebang_only_on_windows(tmp_path, monkeyp
 def test_high_risk_command_message_is_platform_aware(monkeypatch):
     from brigade.work_cmd import verification
 
-    monkeypatch.setattr(verification.os, "name", "posix")
+    monkeypatch.setattr(verification, "_verification_is_windows", lambda: False)
     posix_msg = verification._high_risk_command_message("bash")
     assert "chmod +x" in posix_msg
     assert "./scripts/check.sh" in posix_msg
 
-    monkeypatch.setattr(verification.os, "name", "nt")
+    monkeypatch.setattr(verification, "_verification_is_windows", lambda: True)
     win_msg = verification._high_risk_command_message("bash")
     assert "python script.py" in win_msg
     assert ".ps1" in win_msg

--- a/tests/test_work_cmd_verification.py
+++ b/tests/test_work_cmd_verification.py
@@ -1337,18 +1337,25 @@ def test_verification_split_command_keeps_posix_shlex_behavior(monkeypatch):
     assert verification._verification_split_command('python3 -c "print(1)"') == ["python3", "-c", "print(1)"]
 
 
-def test_verification_shell_meta_allows_backslash_only_on_windows(monkeypatch):
+def test_verification_shell_meta_allows_literal_backslashes(monkeypatch):
     from brigade.work_cmd import verification
 
-    path_token = r".\scripts\check.ps1"
-    monkeypatch.setattr(verification, "_verification_is_windows", lambda: True)
-    assert verification._verification_shell_meta_re().search(path_token) is None
+    for is_windows in (True, False):
+        monkeypatch.setattr(verification, "_verification_is_windows", lambda w=is_windows: w)
+        assert verification._verification_shell_meta_re().search(r".\scripts\check.ps1") is None
+        assert verification._verification_shell_meta_re().search(r"[\d]+") is None
+        assert verification._verification_shell_meta_re().search(r"foo\bar") is None
+        assert verification._verification_shell_meta_re().search("foo;bar") is not None
+        assert verification._verification_shell_meta_re().search("a|b") is not None
+
+
+def test_verify_parse_command_allows_posix_literal_backslash_arguments(monkeypatch):
+    from brigade.work_cmd import verification
 
     monkeypatch.setattr(verification, "_verification_is_windows", lambda: False)
-    assert verification._verification_shell_meta_re().search(path_token) is not None
-
-    monkeypatch.setattr(verification, "_verification_is_windows", lambda: True)
-    assert verification._verification_shell_meta_re().search("foo;bar") is not None
+    command = r'python3 -c "re.match(r\"\\d+\", \"123\")"'
+    parts = verification._verification_split_command(command)
+    assert not any(verification._verification_shell_meta_re().search(part) for part in parts)
 
 
 def test_verify_parse_command_treats_windows_backslash_tokens_as_paths(tmp_path, monkeypatch):

--- a/tests/test_work_cmd_verification.py
+++ b/tests/test_work_cmd_verification.py
@@ -1349,13 +1349,21 @@ def test_verification_shell_meta_allows_literal_backslashes(monkeypatch):
         assert verification._verification_shell_meta_re().search("a|b") is not None
 
 
-def test_verify_parse_command_allows_posix_literal_backslash_arguments(monkeypatch):
+def test_verify_parse_command_allows_posix_literal_backslash_arguments(tmp_path, monkeypatch):
     from brigade.work_cmd import verification
 
     monkeypatch.setattr(verification, "_verification_is_windows", lambda: False)
     command = r'python3 -c "re.match(r\"\\d+\", \"123\")"'
-    parts = verification._verification_split_command(command)
-    assert not any(verification._verification_shell_meta_re().search(part) for part in parts)
+    expected_argv = ["python3", "-c", r're.match(r"\d+", "123")']
+
+    assert verification._verification_split_command(command) == expected_argv
+
+    target = tmp_path / "repo"
+    target.mkdir()
+    argv, env, error = verification._verify_parse_command(command, target)
+    assert argv == expected_argv
+    assert env == {}
+    assert error is None
 
 
 def test_verify_parse_command_treats_windows_backslash_tokens_as_paths(tmp_path, monkeypatch):

--- a/tests/test_work_cmd_verification.py
+++ b/tests/test_work_cmd_verification.py
@@ -1318,6 +1318,61 @@ def test_high_risk_command_message_is_platform_aware(monkeypatch):
     assert "chmod +x" not in win_msg
 
 
+def test_verification_split_command_preserves_windows_backslash_paths(monkeypatch):
+    from brigade.work_cmd import verification
+
+    monkeypatch.setattr(verification, "_verification_is_windows", lambda: True)
+    assert verification._verification_split_command(r".\scripts\check.ps1") == [r".\scripts\check.ps1"]
+    assert verification._verification_split_command(r"C:\repo\scripts\check.ps1") == [r"C:\repo\scripts\check.ps1"]
+    assert verification._verification_split_command(r'".\scripts\with spaces\check.ps1"') == [
+        r".\scripts\with spaces\check.ps1"
+    ]
+
+
+def test_verification_split_command_keeps_posix_shlex_behavior(monkeypatch):
+    from brigade.work_cmd import verification
+
+    monkeypatch.setattr(verification, "_verification_is_windows", lambda: False)
+    assert verification._verification_split_command("./scripts/check.sh") == ["./scripts/check.sh"]
+    assert verification._verification_split_command('python3 -c "print(1)"') == ["python3", "-c", "print(1)"]
+
+
+def test_verification_shell_meta_allows_backslash_only_on_windows(monkeypatch):
+    from brigade.work_cmd import verification
+
+    path_token = r".\scripts\check.ps1"
+    monkeypatch.setattr(verification, "_verification_is_windows", lambda: True)
+    assert verification._verification_shell_meta_re().search(path_token) is None
+
+    monkeypatch.setattr(verification, "_verification_is_windows", lambda: False)
+    assert verification._verification_shell_meta_re().search(path_token) is not None
+
+    monkeypatch.setattr(verification, "_verification_is_windows", lambda: True)
+    assert verification._verification_shell_meta_re().search("foo;bar") is not None
+
+
+def test_verify_parse_command_treats_windows_backslash_tokens_as_paths(tmp_path, monkeypatch):
+    """Parsing and path-token classification; pathlib resolution is covered on Windows CI."""
+    from brigade.work_cmd import verification
+
+    target = tmp_path / "repo"
+    target.mkdir()
+    monkeypatch.setattr(verification, "_verification_is_windows", lambda: True)
+
+    for command in (
+        r".\scripts\check.ps1",
+        r'".\scripts\check.ps1"',
+        r"C:\repo\scripts\check.ps1",
+    ):
+        token = verification._verification_split_command(command)[0]
+        assert verification._verify_token_is_path(token)
+        argv, env, error = verification._verify_parse_command(command, target)
+        assert argv is None
+        assert env == {}
+        assert "shell metacharacters" not in (error or "")
+        assert error == verification._unresolvable_command_message(token)
+
+
 def test_work_verify_run_records_target_relative_process_start_failure(tmp_path, monkeypatch, capsys):
     target = tmp_path / "repo"
     caller = tmp_path / "caller"

--- a/tests/test_work_cmd_verification.py
+++ b/tests/test_work_cmd_verification.py
@@ -1203,19 +1203,120 @@ def test_work_verify_run_resolves_relative_executable_from_target(tmp_path, monk
     assert receipt["commands"][0]["stdout_summary"] == "target-ok"
 
 
-def test_work_verify_execution_argv_uses_resolved_target_path(tmp_path):
+def test_work_verify_execution_argv_uses_resolved_target_path(tmp_path, monkeypatch):
     from brigade.work_cmd import verification
 
     target = tmp_path / "repo"
     script = target / "scripts" / "verify"
     script.parent.mkdir(parents=True)
-    script.write_text("#!/bin/sh\n")
+    # No shebang: keep this assertion POSIX/Windows-identical (Windows shebang
+    # hosting is covered by dedicated unit tests below).
+    script.write_text("printf ok\n")
     relative_argv = ["./scripts/verify", "--quick"]
 
     assert verification._verify_execution_argv(relative_argv, target) == [str(script), "--quick"]
     assert relative_argv == ["./scripts/verify", "--quick"]
     assert verification._verify_execution_argv([str(script), "--quick"], target) == [str(script), "--quick"]
     assert verification._verify_execution_argv(["python3", "-V"], target) == ["python3", "-V"]
+
+
+def test_shebang_interpreter_token_parses_env_and_absolute_forms():
+    from brigade.work_cmd import verification
+
+    assert verification._shebang_interpreter_token("#!/usr/bin/env bash") == "bash"
+    assert verification._shebang_interpreter_token("#!/usr/bin/env python3") == "python3"
+    assert verification._shebang_interpreter_token("#!/bin/sh") == "/bin/sh"
+    assert verification._shebang_interpreter_token("#! /usr/bin/env -S bash -e") == "bash"
+    assert verification._shebang_interpreter_token("not a shebang") is None
+    assert verification._shebang_interpreter_token("#!") is None
+
+
+def test_windows_script_execution_argv_hosts_shebang_and_native_suffixes(tmp_path, monkeypatch):
+    from brigade.work_cmd import verification
+
+    monkeypatch.setattr(verification.os, "name", "nt")
+    script = tmp_path / "check.sh"
+    script.write_bytes(b"#!/usr/bin/env bash\necho hi\n")
+    fake_bash = tmp_path / "bash.exe"
+    fake_bash.write_text("")
+    monkeypatch.setattr(
+        verification,
+        "_windows_resolve_interpreter",
+        lambda token: str(fake_bash) if token in {"bash", "/bin/bash"} else None,
+    )
+
+    assert verification._windows_script_execution_argv(script, ["--flag"]) == [
+        str(fake_bash),
+        str(script),
+        "--flag",
+    ]
+
+    ps1 = tmp_path / "check.ps1"
+    ps1.write_text("Write-Output hi\n")
+    fake_pwsh = tmp_path / "pwsh.exe"
+    fake_pwsh.write_text("")
+
+    def which(name, path=None):
+        if name == "pwsh":
+            return str(fake_pwsh)
+        return None
+
+    monkeypatch.setattr(verification.shutil, "which", which)
+    assert verification._windows_script_execution_argv(ps1, ["a"]) == [
+        str(fake_pwsh),
+        "-NoProfile",
+        "-File",
+        str(ps1),
+        "a",
+    ]
+
+    cmd = tmp_path / "check.cmd"
+    cmd.write_text("@echo hi\n")
+    fake_cmd = tmp_path / "cmd.exe"
+    fake_cmd.write_text("")
+    monkeypatch.setenv("ComSpec", str(fake_cmd))
+    assert verification._windows_script_execution_argv(cmd, []) == [str(fake_cmd), "/c", str(cmd)]
+
+
+def test_verify_execution_argv_expands_shebang_only_on_windows(tmp_path, monkeypatch):
+    from brigade.work_cmd import verification
+
+    target = tmp_path / "repo"
+    script = target / "scripts" / "check.sh"
+    script.parent.mkdir(parents=True)
+    script.write_bytes(b"#!/usr/bin/env bash\necho hi\n")
+    fake_bash = tmp_path / "bash.exe"
+    fake_bash.write_text("")
+    monkeypatch.setattr(
+        verification,
+        "_windows_resolve_interpreter",
+        lambda token: str(fake_bash) if token == "bash" else None,
+    )
+
+    monkeypatch.setattr(verification.os, "name", "posix")
+    assert verification._verify_execution_argv(["./scripts/check.sh"], target) == [str(script)]
+
+    monkeypatch.setattr(verification.os, "name", "nt")
+    assert verification._verify_execution_argv(["./scripts/check.sh", "x"], target) == [
+        str(fake_bash),
+        str(script),
+        "x",
+    ]
+
+
+def test_high_risk_command_message_is_platform_aware(monkeypatch):
+    from brigade.work_cmd import verification
+
+    monkeypatch.setattr(verification.os, "name", "posix")
+    posix_msg = verification._high_risk_command_message("bash")
+    assert "chmod +x" in posix_msg
+    assert "./scripts/check.sh" in posix_msg
+
+    monkeypatch.setattr(verification.os, "name", "nt")
+    win_msg = verification._high_risk_command_message("bash")
+    assert "python script.py" in win_msg
+    assert ".ps1" in win_msg
+    assert "chmod +x" not in win_msg
 
 
 def test_work_verify_run_records_target_relative_process_start_failure(tmp_path, monkeypatch, capsys):
@@ -1226,7 +1327,10 @@ def test_work_verify_run_records_target_relative_process_start_failure(tmp_path,
     _init_git_repo(target)
     script = target / "scripts" / "verify"
     script.parent.mkdir()
-    script.write_text("#!/bin/sh\n")
+    # No shebang / not a native PE or +x script: CreateProcess/exec must fail so
+    # the receipt records a process-start failure. (A shebang'd script is now
+    # launchable on Windows via explicit interpreter hosting.)
+    script.write_text("not-an-executable\n")
     monkeypatch.chdir(caller)
 
     rc = cli.main(


### PR DESCRIPTION
## Summary
- On Windows, `brigade work verify run` now hosts path-based scripts explicitly: shebang lines are resolved to a real interpreter (preferring Git Bash over WSL `System32\bash.exe`), and `.ps1` / `.cmd` / `.bat` use their native hosts.
- POSIX behavior is unchanged: bare shell interpreters stay rejected by the high-risk guard, and shebang hosting is `os.name == "nt"` only (CreateProcess does not honor shebang; POSIX already does).
- High-risk rejection copy is platform-aware so Windows users are not told that `./scripts/check.sh` alone is enough without hosting.
- No new CLI knobs (0.26.0 stability promise).

## Repro (native Windows, Python 3.14.6, PYTHONUTF8=1)

**Before**
```
brigade work verify run --target . --command "bash -n media"
-> status: rejected (high-risk; advice named ./scripts/check.sh)

brigade work verify run --target . --command "./_repro.sh"
-> status: failed exit=127
   stderr_summary: [WinError 193] %1 is not a valid Win32 application
```

**After**
```
brigade work verify run --target . --command "bash -n media"
-> status: rejected (still blocked; advice names python/.ps1/shebang path)

brigade work verify run --target . --command "./_repro.sh"
-> status: completed exit=0
   stdout_summary: hi
```

## Test plan
- [x] Platform-independent unit tests for shebang parsing + Windows hosting rewrite (monkeypatch `os.name`)
- [x] Focused verification tests on Windows (10 passed)
- [x] Live Windows repro before/after pasted above
- [x] Full `pytest -q` on Windows recorded (4558 passed / 1310 failed / 37 skipped; large pre-existing Windows/POSIX skew + KeyboardInterrupt in `test_work_verify_run_canceled_status_is_neutral_not_a_regression_signal` — same profile as #752’s Windows run; Linux CI is the merge gate)
- [ ] CI green on this PR

Fixes #754


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command verification across POSIX and Windows environments.
  * Added support for Windows PowerShell, CMD, and batch scripts.
  * Improved handling of shebang-based scripts and interpreter resolution.
  * Enhanced high-risk command guidance with platform-specific executable recommendations.
  * Improved detection of relative, drive-based, and separator-specific paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->