### PR TITLE
feat(skills): add memory-care handoff and refresh skills

### DIFF
--- a/src/brigade/agent_skill_format.py
+++ b/src/brigade/agent_skill_format.py
@@ -31,6 +31,39 @@ def _scalar(value: str) -> str:
     return value
 
 
+def _split_allowed_tools(allowed: str) -> tuple[str, ...]:
+    """Split comma/whitespace tool lists while preserving parenthesized scopes.
+
+    Claude-style entries such as ``Bash(brigade handoff list:*)`` must stay one
+    token. A naive ``re.split(r"[\\s,]+")`` shreds them into nonsense.
+    """
+    items: list[str] = []
+    buf: list[str] = []
+    depth = 0
+    for ch in allowed:
+        if ch == "(":
+            depth += 1
+            buf.append(ch)
+            continue
+        if ch == ")":
+            depth = max(0, depth - 1)
+            buf.append(ch)
+            continue
+        if ch in ", \t\r\n" and depth == 0:
+            if buf:
+                item = "".join(buf).strip()
+                if item:
+                    items.append(item)
+                buf = []
+            continue
+        buf.append(ch)
+    if buf:
+        item = "".join(buf).strip()
+        if item:
+            items.append(item)
+    return tuple(items)
+
+
 def _frontmatter(text: str) -> tuple[list[str] | None, str | None]:
     lines = text.splitlines()
     if not lines or lines[0] != "---":
@@ -121,7 +154,7 @@ def validate(skill_dir: Path, *, mode: str) -> Validation:
         (errors if mode == "strict" else diagnostics).append(message)
     allowed = fields.get("allowed-tools")
     if isinstance(allowed, str):
-        fields["allowed-tools"] = tuple(item for item in re.split(r"[\s,]+", allowed) if item)
+        fields["allowed-tools"] = _split_allowed_tools(allowed)
     elif allowed is not None:
         errors.append("frontmatter allowed-tools must be a string declaration")
     fields.update(unknown)

--- a/src/brigade/templates/skills/card-refresh/CHANGELOG.md
+++ b/src/brigade/templates/skills/card-refresh/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Initial bundled card-refresh skill: allowlist-bound care-queue refresh with grounded edits, never-delete retention, and manual dedup pending #724.
+- Scope Bash to named `brigade memory care …` commands; document missing-queue / empty / malformed failure paths.

--- a/src/brigade/templates/skills/card-refresh/SKILL.md
+++ b/src/brigade/templates/skills/card-refresh/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: card-refresh
+description: Use when refreshing stale Brigade memory cards from the care refresh queue - category allowlist, grounded edits that cite on-disk sources of truth, archive-only retention, and manual dedup until #724. Never delete, remove, or prune.
+allowed-tools: Read, Grep, Bash(brigade memory care status:*), Bash(brigade memory care plan-fixes:*), Bash(brigade memory care closeout:*)
+compatibility: Brigade-wired workspaces with memory care scan output; operator-scheduled headless harnesses.
+---
+
+# card-refresh
+
+Safely refresh stale memory cards that memory care already queued. Brigade does not run the agent; this skill is the allowlist-bound recipe an operator invokes on their own harness and schedule.
+
+## When this applies
+
+- `brigade memory care scan` (or import-issues) has produced a refresh queue.
+- An operator schedules a headless harness against this skill for safe auto-refresh.
+- Card categories in scope are on the operator's category allowlist.
+
+## Allowlist
+
+Work only through this allowlist:
+
+- Read the care refresh queue (`.brigade/memory-care/decay/refresh-queue.json` or the workspace's configured legacy path)
+- `brigade memory care status`
+- `brigade memory care plan-fixes` (planning only; writes no cards)
+- `brigade memory care closeout` when finishing reviewed queue items
+- Read/Grep of the card file, its cited evidence paths, and related on-disk sources of truth
+- Edit only cards whose category is on the operator allowlist for this run
+
+Bash is scoped to those `brigade memory care …` commands only. Do not touch cards outside the category allowlist. Stay inside the allowlist above; do not follow `..` or symlinks out of the card / care-queue roots.
+
+## Grounded-edit rules
+
+Refreshes must be grounded. Edit or refresh a card only when you can cite existing on-disk content that verifies the change (the card body, linked evidence files, handoffs, or other local sources of truth). Never date-bump alone. If you cannot verify a claim against on-disk material, skip the card and leave it queued for a human.
+
+## Retention (never delete)
+
+- Never delete memory cards.
+- Never remove cards from the corpus with destructive ops.
+- Never prune the refresh queue or card trees by hand.
+- Archive only when an operator-approved archive path already exists; otherwise leave stale-but-unverified cards for human review and use `care closeout` for items you actually refreshed.
+
+## Manual dedup (pending #724)
+
+Until #724 lands fingerprint-based reinforcement, perform manual dedup before writing a refreshed or sibling card:
+
+1. Search for near-duplicate cards covering the same fact.
+2. Reinforce the strongest existing card (cite the on-disk sources) instead of splitting.
+3. If duplicates are ambiguous, stop and mark needs-human rather than merging blindly.
+
+## Process
+
+1. Read the refresh queue and filter to the category allowlist.
+2. For each candidate, open the card and its evidence paths on disk.
+3. Apply a grounded edit only when on-disk sources confirm the update; cite those sources in the edit notes or handoff.
+4. Close out completed queue items with care closeout; leave the rest.
+5. Capture outcomes against `card-refresh` when verification is part of the run.
+
+## Failure paths
+
+- Missing refresh queue or memory-care config: stop. Report the missing path/config; do not invent a queue.
+- Empty queue / no category-allowlisted candidates: exit cleanly with "nothing to refresh"; do not invent cards.
+- Malformed queue entry or card (bad JSON, missing path, unreadable frontmatter): skip that entry, leave it for a human, continue with the rest. Never delete or rewrite malformed files just to clear the queue.
+
+## Out of scope
+
+- `session-sweep` (blocked on #466)
+- Scheduler or model-dispatch integration
+- Refreshing categories outside the allowlist

--- a/src/brigade/templates/skills/card-refresh/skill.json
+++ b/src/brigade/templates/skills/card-refresh/skill.json
@@ -1,0 +1,14 @@
+{
+  "id": "card-refresh",
+  "title": "card-refresh",
+  "version": "0.1.0",
+  "description": "Allowlist-bound care-queue card refresh: grounded edits that cite on-disk sources, archive-only retention, and manual dedup until #724.",
+  "required_tools": [
+    "Read",
+    "Grep",
+    "Bash(brigade memory care status:*)",
+    "Bash(brigade memory care plan-fixes:*)",
+    "Bash(brigade memory care closeout:*)"
+  ],
+  "tests": ["brigade skills lint card-refresh"]
+}

--- a/src/brigade/templates/skills/handoff-inbox-drain/CHANGELOG.md
+++ b/src/brigade/templates/skills/handoff-inbox-drain/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Initial bundled handoff-inbox-drain skill: allowlist-bound inbox triage with grounded edits, never-delete retention, and manual dedup pending #724.
+- Scope Bash to named `brigade handoff …` commands; document missing-inbox / empty / malformed failure paths.

--- a/src/brigade/templates/skills/handoff-inbox-drain/SKILL.md
+++ b/src/brigade/templates/skills/handoff-inbox-drain/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: handoff-inbox-drain
+description: Use when draining a Brigade handoff review inbox - triage drafts with allowlist-bound Brigade handoff commands, grounded edits that cite on-disk content, archive-only retention, and manual dedup until #724. Never delete, remove, or prune.
+allowed-tools: Read, Grep, Bash(brigade handoff list:*), Bash(brigade handoff show:*), Bash(brigade handoff archive:*), Bash(brigade handoff closeout:*), Bash(brigade handoff lint:*), Bash(brigade handoff doctor:*)
+compatibility: Brigade-wired workspaces with handoff inboxes; operator-scheduled headless harnesses.
+---
+
+# handoff-inbox-drain
+
+Drain a handoff review inbox with judgment, without owning a scheduler. Brigade stays invoke-only; this skill is the allowlist-bound agent recipe for triage.
+
+## When this applies
+
+- A handoff draft inbox has pending or reviewed items to triage.
+- An operator schedules a headless harness (`claude -p`, `codex exec`, or equivalent) against this skill.
+- You are reinforcing existing memory, not inventing a parallel corpus.
+
+## Allowlist
+
+Work only through this allowlist of Brigade surfaces and local reads:
+
+- `brigade handoff list`
+- `brigade handoff show <id>`
+- `brigade handoff archive <id>`
+- `brigade handoff closeout` (when the workspace supports it)
+- `brigade handoff lint` / `brigade handoff doctor` for health checks
+- Read/Grep of on-disk handoff files, `memory/cards/`, and related indexes already present in the target
+
+Bash is scoped to those `brigade handoff …` commands only. Do not expand into arbitrary filesystem writes, remote APIs, unscoped shell, or tools outside this allowlist. Stay inside the handoff inbox / `memory/cards/` roots; do not follow `..` or symlinks out of those trees.
+
+## Grounded-edit rules
+
+Every edit must be grounded. You must cite existing on-disk content (handoff body, card text, or index entry) before changing anything. Prefer reinforce-in-place: edit or refresh only what you can verify against a local source of truth. Date-bumps alone are not grounded edits.
+
+## Retention (never delete)
+
+- Never delete handoff drafts or memory cards.
+- Never remove inbox items by destructive filesystem ops.
+- Never prune archives, queues, or card trees.
+- Archive only: uncertain or done items go through archive/closeout paths, or a needs-human file the operator already uses.
+
+## Manual dedup (pending #724)
+
+Until #724 lands fingerprint-based reinforcement, perform manual dedup before filing near-duplicates:
+
+1. Search existing cards and recent handoffs for the same fact or decision.
+2. If a close match exists, reinforce that card (cite the on-disk source) instead of creating a sibling.
+3. If unsure, leave the draft for human review rather than splitting the corpus.
+
+## Process
+
+1. List pending drafts with the allowlist commands.
+2. For each item, read the on-disk handoff and related cards.
+3. Triage: archive noise, closeout completed review, reinforce an existing card when the fact matches, or park uncertain items for a human.
+4. Capture outcomes against `handoff-inbox-drain` when verification is part of the run.
+5. Stop when the inbox is drained or only needs-human items remain.
+
+## Failure paths
+
+- Missing inbox or handoff source config: stop. Report the missing path/config; do not invent an inbox or create one.
+- Empty inbox / no pending drafts: exit cleanly with "nothing to drain"; do not invent work.
+- Malformed handoff entry (unreadable frontmatter, missing id, broken body): skip that item, leave it for a human, continue with the rest. Never rewrite a malformed file just to make the loop continue.
+
+## Out of scope
+
+- `session-sweep` (blocked on #466)
+- Scheduler or model-dispatch integration
+- Automatic card creation without an on-disk citation

--- a/src/brigade/templates/skills/handoff-inbox-drain/skill.json
+++ b/src/brigade/templates/skills/handoff-inbox-drain/skill.json
@@ -1,0 +1,17 @@
+{
+  "id": "handoff-inbox-drain",
+  "title": "handoff-inbox-drain",
+  "version": "0.1.0",
+  "description": "Allowlist-bound handoff inbox triage: grounded edits that cite on-disk content, archive-only retention, and manual dedup until #724.",
+  "required_tools": [
+    "Read",
+    "Grep",
+    "Bash(brigade handoff list:*)",
+    "Bash(brigade handoff show:*)",
+    "Bash(brigade handoff archive:*)",
+    "Bash(brigade handoff closeout:*)",
+    "Bash(brigade handoff lint:*)",
+    "Bash(brigade handoff doctor:*)"
+  ],
+  "tests": ["brigade skills lint handoff-inbox-drain"]
+}

--- a/tests/test_agent_skill_format.py
+++ b/tests/test_agent_skill_format.py
@@ -27,6 +27,24 @@ def test_strict_accepts_agent_skills_fields_and_treats_tools_as_requirements(tmp
     assert result.fields["metadata"] == {"owner": "team"}
 
 
+def test_allowed_tools_preserve_parenthesized_command_scopes(tmp_path):
+    directory = _skill(
+        tmp_path,
+        "scoped-bash",
+        "name: scoped-bash\n"
+        "description: Scope bash to named commands.\n"
+        "allowed-tools: Read, Grep, Bash(brigade handoff list:*), Bash(brigade memory care status:*)\n",
+    )
+    result = agent_skill_format.validate(directory, mode="strict")
+    assert result.errors == ()
+    assert result.fields["allowed-tools"] == (
+        "Read",
+        "Grep",
+        "Bash(brigade handoff list:*)",
+        "Bash(brigade memory care status:*)",
+    )
+
+
 def test_strict_rejects_unknown_and_lenient_retains_diagnostic(tmp_path):
     directory = _skill(
         tmp_path,

--- a/tests/test_memory_care_skills.py
+++ b/tests/test_memory_care_skills.py
@@ -1,0 +1,189 @@
+"""Contract tests for the memory-care skill pack (#766 / Track A).
+
+Ship exactly two bundled registry skills: handoff-inbox-drain and card-refresh.
+session-sweep stays out of scope until #466 defines capture-at-source.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from brigade import agent_skill_format, skills_cmd
+from brigade.templates import template_root
+
+MEMORY_CARE_SKILLS = ("handoff-inbox-drain", "card-refresh")
+BLOCKED_SESSION_SWEEP = "session-sweep"
+# Closed allowlist: bare Bash / Write / Edit / WebFetch and similar must fail.
+PERMITTED_BASE_TOOLS = frozenset({"Read", "Grep"})
+SCOPED_BRIGADE_BASH_RE = re.compile(r"^Bash\(brigade .+:\*\)$")
+EXPECTED_SCOPED_BASH = {
+    "handoff-inbox-drain": frozenset(
+        {
+            "Bash(brigade handoff list:*)",
+            "Bash(brigade handoff show:*)",
+            "Bash(brigade handoff archive:*)",
+            "Bash(brigade handoff closeout:*)",
+            "Bash(brigade handoff lint:*)",
+            "Bash(brigade handoff doctor:*)",
+        }
+    ),
+    "card-refresh": frozenset(
+        {
+            "Bash(brigade memory care status:*)",
+            "Bash(brigade memory care plan-fixes:*)",
+            "Bash(brigade memory care closeout:*)",
+        }
+    ),
+}
+
+
+def _bundled_skill_dir(skill_id: str) -> Path:
+    return template_root() / "skills" / skill_id
+
+
+def _require_bundled_skill_md(skill_id: str) -> Path:
+    path = _bundled_skill_dir(skill_id) / "SKILL.md"
+    assert path.is_file(), f"missing bundled SKILL.md for {skill_id}"
+    return path
+
+
+def _skill_text(skill_id: str) -> str:
+    return _require_bundled_skill_md(skill_id).read_text(encoding="utf-8")
+
+
+def _skill_metadata(skill_id: str) -> dict:
+    path = _bundled_skill_dir(skill_id) / "skill.json"
+    assert path.is_file(), f"missing bundled skill.json for {skill_id}"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _tool_is_permitted(tool: str) -> bool:
+    if tool in PERMITTED_BASE_TOOLS:
+        return True
+    return SCOPED_BRIGADE_BASH_RE.fullmatch(tool) is not None
+
+
+def _bundled_skill_ids() -> set[str]:
+    root = template_root() / "skills"
+    if not root.is_dir():
+        return set()
+    return {path.name for path in root.iterdir() if path.is_dir() and (path / "SKILL.md").is_file()}
+
+
+@pytest.mark.parametrize("skill_id", MEMORY_CARE_SKILLS)
+def test_memory_care_skill_is_present_in_bundled_registry(skill_id, tmp_path, capsys):
+    source = _bundled_skill_dir(skill_id)
+    assert (source / "SKILL.md").is_file(), f"missing bundled SKILL.md for {skill_id}"
+    assert (source / "skill.json").is_file(), f"missing bundled skill.json for {skill_id}"
+
+    metadata = _skill_metadata(skill_id)
+    assert metadata.get("id") == skill_id
+
+    assert skills_cmd.lint(target=tmp_path, skill=skill_id, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["valid"] is True
+    assert payload["skill_id"] == skill_id
+    assert payload["source"]["kind"] == "brigade-bundle"
+    assert payload["source"]["identity"] == f"brigade://bundled-skills/{skill_id}"
+
+    assert skills_cmd.import_skill(target=tmp_path, source=source, json_output=True) == 0
+    capsys.readouterr()
+    assert skills_cmd.search(target=tmp_path, query=skill_id, json_output=True) == 0
+    search = json.loads(capsys.readouterr().out)
+    assert search["count"] >= 1
+    assert any(row["metadata"].get("id") == skill_id for row in search["skills"])
+
+
+@pytest.mark.parametrize("skill_id", MEMORY_CARE_SKILLS)
+def test_memory_care_skill_is_allowlist_bound(skill_id):
+    source = _bundled_skill_dir(skill_id)
+    _require_bundled_skill_md(skill_id)
+
+    format_result = agent_skill_format.validate(source, mode="strict")
+    assert format_result.errors == ()
+    allowed = format_result.fields.get("allowed-tools")
+    assert isinstance(allowed, tuple) and allowed, f"{skill_id} must declare non-empty allowed-tools"
+    assert "Bash" not in allowed, f"{skill_id} must not grant unscoped Bash: {allowed}"
+    assert all(_tool_is_permitted(str(tool)) for tool in allowed), (
+        f"{skill_id} allowed-tools outside closed permit set: {allowed}"
+    )
+    assert PERMITTED_BASE_TOOLS.issubset(set(allowed)), (
+        f"{skill_id} must include Read and Grep in allowed-tools: {allowed}"
+    )
+    assert EXPECTED_SCOPED_BASH[skill_id].issubset(set(allowed)), (
+        f"{skill_id} missing scoped Bash allowlist entries: {EXPECTED_SCOPED_BASH[skill_id] - set(allowed)}"
+    )
+    assert set(allowed) == PERMITTED_BASE_TOOLS | EXPECTED_SCOPED_BASH[skill_id], (
+        f"{skill_id} allowed-tools must equal the closed permit set, got {allowed}"
+    )
+
+    metadata = _skill_metadata(skill_id)
+    required_tools = metadata.get("required_tools")
+    assert isinstance(required_tools, list) and required_tools
+    assert "Bash" not in required_tools, f"{skill_id} required_tools must not grant unscoped Bash"
+    assert all(_tool_is_permitted(str(tool)) for tool in required_tools), (
+        f"{skill_id} required_tools outside closed permit set: {required_tools}"
+    )
+    assert set(required_tools) == set(allowed), f"{skill_id} required_tools must match allowed-tools exactly"
+
+    text = _skill_text(skill_id)
+    assert re.search(r"(?i)\ballowlist\b", text), f"{skill_id} must bind work to an allowlist"
+    assert re.search(r"(?i)failure paths?", text), f"{skill_id} must document failure paths"
+    assert re.search(r"(?i)missing", text), f"{skill_id} must handle a missing inbox/queue"
+    assert re.search(r"(?i)\bempty\b", text), f"{skill_id} must handle an empty set"
+    assert re.search(r"(?i)malformed", text), f"{skill_id} must handle malformed entries"
+
+
+@pytest.mark.parametrize("skill_id", MEMORY_CARE_SKILLS)
+def test_memory_care_skill_enforces_grounded_edit_rules(skill_id):
+    text = _skill_text(skill_id)
+    assert re.search(r"(?i)grounded", text), f"{skill_id} must state grounded-edit rules"
+    assert re.search(r"(?i)\bcite\b", text), f"{skill_id} must require edits to cite sources"
+    assert re.search(r"(?i)on[- ]disk", text), f"{skill_id} must require citations of on-disk content"
+    assert re.search(
+        r"(?i)(edit|change|refresh).{0,80}(only|must).{0,80}(cite|verif|source of truth|on[- ]disk)",
+        text,
+        flags=re.DOTALL,
+    ) or re.search(
+        r"(?i)(cite|verif).{0,80}(existing|on[- ]disk|source of truth)",
+        text,
+        flags=re.DOTALL,
+    ), f"{skill_id} must require edits to cite existing on-disk content"
+
+
+@pytest.mark.parametrize("skill_id", MEMORY_CARE_SKILLS)
+def test_memory_care_skill_never_deletes(skill_id):
+    text = _skill_text(skill_id)
+    for operation in ("delete", "remove", "prune"):
+        assert re.search(
+            rf"(?i)(?:(never|do\s+not|must\s+not|no)\s+{operation}\b|"
+            rf"\b{operation}\b.{{0,40}}(not\s+permitted|forbidden|prohibited))",
+            text,
+        ), f"{skill_id} must forbid {operation} operations"
+    assert re.search(r"(?i)archive(\s+only)?", text), f"{skill_id} should prefer archive-only retention"
+
+
+@pytest.mark.parametrize("skill_id", MEMORY_CARE_SKILLS)
+def test_memory_care_skill_carries_manual_dedup_pending_724(skill_id):
+    text = _skill_text(skill_id)
+    assert re.search(r"(?i)manual\s+dedup", text), f"{skill_id} must carry manual dedup instructions"
+    assert re.search(r"#\s*724\b", text), f"{skill_id} must note manual dedup is pending #724"
+
+
+def test_session_sweep_is_not_built_or_registered(tmp_path, capsys):
+    """session-sweep is the #466 backstop and must not ship in this pack."""
+    bundled = _bundled_skill_ids()
+    assert BLOCKED_SESSION_SWEEP not in bundled
+    assert not (_bundled_skill_dir(BLOCKED_SESSION_SWEEP) / "SKILL.md").exists()
+    assert not skills_cmd._bundled_skill_exists(BLOCKED_SESSION_SWEEP)
+
+    rc = skills_cmd.lint(target=tmp_path, skill=BLOCKED_SESSION_SWEEP, json_output=True)
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 1
+    assert payload["valid"] is False
+    assert payload["source"]["kind"] != "brigade-bundle"
+    assert any("SKILL.md not found" in error for error in payload["errors"])

--- a/tests/test_skill_templates_metadata.py
+++ b/tests/test_skill_templates_metadata.py
@@ -7,7 +7,13 @@ import pytest
 from brigade import skills_cmd
 from brigade.templates import template_root
 
-BUNDLED_TEMPLATES = ("brigade-work", "note", "ultra-work-scout")
+BUNDLED_TEMPLATES = (
+    "brigade-work",
+    "note",
+    "ultra-work-scout",
+    "handoff-inbox-drain",
+    "card-refresh",
+)
 
 
 def _doctor_issue_names(skill_id, target, capsys):


### PR DESCRIPTION
Closes #766

## Summary

Adds exactly two memory-care skills to the skill templates, `handoff-inbox-drain` and `card-refresh`, plus the parser support they need for command-scoped `allowed-tools`.

- `handoff-inbox-drain`: works a handoff review inbox, archive only, never delete, uncertain items routed to needs-human.
- `card-refresh`: grounded refresh of stale cards under a category allowlist, edits only what a local source of truth verifies, no date bump on its own.
- `src/brigade/agent_skill_format.py`: `allowed-tools` was split on `[\s,]+`, which shredded `Bash(brigade handoff list:*)` into four junk tokens. The parser now preserves parenthesized scopes, so both skills can bind `Read`, `Grep`, and command-scoped Bash with no bare `Bash`.

Out of scope and deliberately absent: there is no `session-sweep` skill (#466), no scheduler, and no model dispatch. The operator runs these from their own harness. Dedup stays manual pending #724.

## Tests and lint

New tests cover both skills: closed permit sets, grounded-edit and never-delete contracts, manual dedup pending #724, and a negative test asserting `session-sweep` stays absent. `tests/test_agent_skill_format.py` covers the parenthesized-scope parse. `skill lint` reports `handoff-inbox-drain` and `card-refresh` valid, and `session-sweep` not found.

## Verification

Full suite green at commit `de2add971ff057c624dcff405a3b53b5a16d67be`:

```
brigade work verify run --target . --command "./scripts/verify" --capture brigade-work
run: 20260809-005844-work-verify-5f60d2   status: completed   ./scripts/verify exit=0
6050 passed, 3 skipped, 68 subtests passed in 770.12s
Total coverage: 83.14%
```

A non-author Composer cross-review of the same commit returned APPROVED, with no blocking findings.

One thing to know about a later run: a verification-only worktree could not start `./scripts/verify` at all, exiting 127 because `.venv` was absent and the script calls `.venv/bin/ruff` by relative path. That run made no edits, the commit was unchanged, and `git diff origin/main...HEAD` still showed the same 10 files, 427 insertions, 2 deletions. The suite simply did not run there, so the green result above is the one that stands.

## Scope note

`allowed-tools` here is declarative harness metadata. Brigade parses and lints it, and `skills_cmd.py` reports `allowed_tools_are_permissions: false`. Nothing consults it at execution time. Runtime capability enforcement needs a capability runner and is outside the scope of #766.