### PR TITLE
fix(handoff): classify salvageable notes distinctly in lint

### DIFF
--- a/src/brigade/handoff_cmd/linting.py
+++ b/src/brigade/handoff_cmd/linting.py
@@ -270,6 +270,7 @@ def lint_file(path: Path) -> HandoffLintResult:
     warnings: list[str] = []
     hints: list[str] = []
     action: str | None = None
+    salvageable = False
     try:
         text = path.read_text(errors="replace")
     except OSError as exc:
@@ -282,6 +283,11 @@ def lint_file(path: Path) -> HandoffLintResult:
         )
 
     raw_sections = _parse_markdown_sections(text)
+    # Use the same structural boundary as ingest: a note with several populated
+    # Markdown sections can be preserved for review, unlike unstructured text.
+    from ..ingest import has_salvageable_structure
+
+    salvageable = has_salvageable_structure(raw_sections)
     sections, collision_errors, noncanonical_headings = _canonicalize_sections(raw_sections)
     errors.extend(collision_errors)
     heading_warnings, heading_hints = _lint_noncanonical_heading_messages(noncanonical_headings)
@@ -301,6 +307,12 @@ def lint_file(path: Path) -> HandoffLintResult:
 
             if not scan_untrusted(text).flagged:
                 hints.append("this looks like a freeform note; try `brigade handoff migrate --target .`")
+        elif salvageable:
+            from ..untrusted import scan_untrusted
+
+            if not scan_untrusted(text).flagged:
+                expected = ", ".join(f"## {name}" for name in CANONICAL_HANDOFF_SECTION_HEADINGS)
+                hints.append(f"structured note detected; use Brigade handoff sections: {expected}")
 
     action_value = _section_value(sections, "Recommended memory action")
     if action_value:
@@ -324,6 +336,7 @@ def lint_file(path: Path) -> HandoffLintResult:
         warnings=tuple(warnings),
         hints=tuple(hints),
         readability=readability,
+        salvageable=salvageable,
     )
 
 

--- a/src/brigade/handoff_cmd/models.py
+++ b/src/brigade/handoff_cmd/models.py
@@ -183,6 +183,7 @@ class HandoffLintResult:
     warnings: tuple[str, ...]
     hints: tuple[str, ...] = ()
     readability: tuple[ReadabilityFinding, ...] = ()
+    salvageable: bool = False
 
     def as_dict(self) -> dict[str, Any]:
         return {
@@ -192,6 +193,7 @@ class HandoffLintResult:
             "errors": list(self.errors),
             "warnings": list(self.warnings),
             "hints": list(self.hints),
+            "salvageable": self.salvageable,
             "readability": [finding.as_dict() for finding in self.readability],
         }
 

--- a/src/brigade/ingest.py
+++ b/src/brigade/ingest.py
@@ -49,6 +49,17 @@ KNOWN_SECTIONS = {
 }
 
 
+def has_salvageable_structure(sections: Dict[str, str]) -> bool:
+    """Return whether parsed Markdown has enough structure for manual recovery.
+
+    Ingest preserves notes with multiple populated sections in the review inbox,
+    even when their headings are not Brigade headings.  Keep this deliberately
+    conservative so a single accidental heading is not treated like a structured
+    handoff.
+    """
+    return sum(bool(body.strip()) for body in sections.values()) >= 2
+
+
 @dataclass
 class IngestStats:
     processed: int = 0

--- a/tests/test_handoff_cmd.py
+++ b/tests/test_handoff_cmd.py
@@ -2037,6 +2037,29 @@ def test_handoff_lint_does_not_suggest_migrate_for_unextractable_note(tmp_path, 
     assert "handoff migrate" not in capsys.readouterr().out
 
 
+def test_handoff_lint_distinguishes_structured_homegrown_note_from_garbage(tmp_path):
+    structured = tmp_path / "structured.md"
+    structured.write_text(
+        "# Project note\n\n"
+        "## What happened\n\nThe cache was rebuilt after stale results appeared.\n\n"
+        "## Why it matters\n\nFuture runs now use current inputs.\n\n"
+        "## Decisions\n\nKeep the validation step.\n\n"
+        "## Next steps\n\nDocument the recovery command.\n"
+    )
+    garbage = tmp_path / "garbage.md"
+    garbage.write_text("random unstructured note, nothing usable\n")
+
+    structured_result = handoff_cmd.lint_file(structured)
+    garbage_result = handoff_cmd.lint_file(garbage)
+
+    assert not structured_result.valid
+    assert structured_result.salvageable
+    assert any("structured note detected" in hint for hint in structured_result.hints)
+    assert not garbage_result.valid
+    assert not garbage_result.salvageable
+    assert not garbage_result.hints
+
+
 def test_handoff_migrate_dry_run_plans_homegrown_note(tmp_path, capsys):
     inbox = tmp_path / ".claude" / "memory-handoffs"
     note = _homegrown_note(inbox)


### PR DESCRIPTION
Lint now uses the same structural boundary as ingest (has_salvageable_structure), so a real engineering note with non-Brigade headings gets hints and a salvageable signal instead of being indistinguishable from garbage. Diagnostics-only: hard-failure exit codes unchanged.

Verified: tests/test_handoff_cmd.py green locally (verify receipt 20260809-015400-work-verify-1b3ebc).

Origin: Codex Cloud task applied locally and reviewed.

Fixes #680