### PR TITLE
fix(release): require matching base_ref for readiness receipt reuse

### DIFF
--- a/src/brigade/release_cmd/candidate.py
+++ b/src/brigade/release_cmd/candidate.py
@@ -112,17 +112,17 @@ def _changelog_unreleased(path: Path) -> list[str]:
     return items
 
 
-def _release_receipt_matches_head(receipt: dict[str, Any], target: Path) -> bool:
+def _release_receipt_matches_head(receipt: dict[str, Any], target: Path, *, base_ref: str | None) -> bool:
     evidence = receipt.get("evidence") if isinstance(receipt.get("evidence"), dict) else {}
     git = evidence.get("git") if isinstance(evidence.get("git"), dict) else {}
     receipt_head = git.get("head")
     current_head = _git_value(target, "rev-parse", "HEAD")
-    return bool(receipt_head and current_head and receipt_head == current_head)
+    return bool(receipt_head and current_head and receipt_head == current_head and receipt.get("base_ref") == base_ref)
 
 
 def _latest_release_or_payload(target: Path, *, base_ref: str | None) -> dict[str, Any]:
     latest = _latest_release_receipt(target)
-    if latest is not None and _release_receipt_matches_head(latest, target):
+    if latest is not None and _release_receipt_matches_head(latest, target, base_ref=base_ref):
         return latest
     payload = _payload(target, base_ref=base_ref, run_checks=True)
     return {

--- a/src/brigade/release_cmd/candidate.py
+++ b/src/brigade/release_cmd/candidate.py
@@ -117,7 +117,10 @@ def _release_receipt_matches_head(receipt: dict[str, Any], target: Path, *, base
     git = evidence.get("git") if isinstance(evidence.get("git"), dict) else {}
     receipt_head = git.get("head")
     current_head = _git_value(target, "rev-parse", "HEAD")
-    return bool(receipt_head and current_head and receipt_head == current_head and receipt.get("base_ref") == base_ref)
+    # Require an explicit top-level base_ref; legacy receipts omit it and must refresh.
+    if "base_ref" not in receipt or receipt["base_ref"] != base_ref:
+        return False
+    return bool(receipt_head and current_head and receipt_head == current_head)
 
 
 def _latest_release_or_payload(target: Path, *, base_ref: str | None) -> dict[str, Any]:

--- a/tests/test_release_cmd.py
+++ b/tests/test_release_cmd.py
@@ -1248,6 +1248,26 @@ def test_release_candidate_build_reuses_fresh_readiness_receipt(tmp_path, monkey
     assert candidate["git"]["head"] == release_receipt["evidence"]["git"]["head"]
 
 
+def test_release_candidate_build_does_not_reuse_receipt_for_different_base_ref(tmp_path, monkeypatch, capsys):
+    _init_repo(tmp_path)
+    _seed_ready_evidence(tmp_path)
+    _patch_clean_health(monkeypatch)
+    _patch_content_guard(monkeypatch)
+    subprocess.run(["git", "tag", "base-a"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "tag", "base-b"], cwd=tmp_path, check=True)
+
+    assert release_cmd.run(target=tmp_path, base_ref="base-a", json_output=True) == 0
+    release_receipt = json.loads(capsys.readouterr().out)
+
+    assert release_cmd.candidate_build(target=tmp_path, base_ref="base-b", json_output=True) == 0
+    candidate = json.loads(capsys.readouterr().out)
+
+    assert release_receipt["base_ref"] == "base-a"
+    assert candidate["base_ref"] == "base-b"
+    assert candidate["release_readiness_receipt"]["run_id"] == "inline-readiness"
+    assert candidate["release_readiness_receipt"]["run_id"] != release_receipt["run_id"]
+
+
 @pytest.mark.parametrize(
     ("check_name",),
     [

--- a/tests/test_release_cmd.py
+++ b/tests/test_release_cmd.py
@@ -1248,6 +1248,37 @@ def test_release_candidate_build_reuses_fresh_readiness_receipt(tmp_path, monkey
     assert candidate["git"]["head"] == release_receipt["evidence"]["git"]["head"]
 
 
+def test_release_candidate_build_refreshes_legacy_receipt_missing_base_ref(tmp_path, monkeypatch, capsys):
+    _init_repo(tmp_path)
+    _seed_ready_evidence(tmp_path)
+    _patch_clean_health(monkeypatch)
+    _patch_content_guard(monkeypatch)
+
+    head = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=tmp_path, text=True).strip()
+    legacy_run_id = "legacy-readiness-no-base-ref"
+    _write_json(
+        tmp_path / ".brigade" / "release" / "runs" / legacy_run_id / "receipt.json",
+        {
+            "run_id": legacy_run_id,
+            "status": "ready",
+            "ready": True,
+            "started_at": "2026-05-30T00:00:00+00:00",
+            "completed_at": "2026-05-30T00:01:00+00:00",
+            "blockers": [],
+            "warnings": [],
+            "checks": [],
+            "evidence": {"git": {"head": head}},
+        },
+    )
+
+    assert release_cmd.candidate_build(target=tmp_path, base_ref=None, json_output=True) == 0
+    candidate = json.loads(capsys.readouterr().out)
+
+    assert candidate["base_ref"] is None
+    assert candidate["release_readiness_receipt"]["run_id"] == "inline-readiness"
+    assert candidate["release_readiness_receipt"]["run_id"] != legacy_run_id
+
+
 def test_release_candidate_build_does_not_reuse_receipt_for_different_base_ref(tmp_path, monkeypatch, capsys):
     _init_repo(tmp_path)
     _seed_ready_evidence(tmp_path)


### PR DESCRIPTION
Base-relative evidence (changed files, content_guard_introduced) can no longer ride a receipt gathered against a different base_ref: reuse requires HEAD and base_ref to both match, and receipts without a recorded base_ref conservatively refresh.

Verified: tests/test_release_cmd.py green locally (verify receipt in PR branch worktree).

Origin: Codex Cloud task applied locally and reviewed.

Fixes #757