### PR TITLE
fix(release): refresh readiness when the tracked working tree is dirty

### DIFF
--- a/src/brigade/release_cmd/candidate.py
+++ b/src/brigade/release_cmd/candidate.py
@@ -120,7 +120,19 @@ def _release_receipt_matches_head(receipt: dict[str, Any], target: Path, *, base
     # Require an explicit top-level base_ref; legacy receipts omit it and must refresh.
     if "base_ref" not in receipt or receipt["base_ref"] != base_ref:
         return False
-    return bool(receipt_head and current_head and receipt_head == current_head)
+    receipt_tracked_dirty = git.get("tracked_dirty_files")
+    if not isinstance(receipt_tracked_dirty, list):
+        return False
+    status = _git(target, "status", "--porcelain=v1", "--untracked-files=no")
+    if status.returncode != 0:
+        return False
+    current_tracked_dirty = [line for line in status.stdout.splitlines() if line]
+    return bool(
+        receipt_head
+        and current_head
+        and receipt_head == current_head
+        and receipt_tracked_dirty == current_tracked_dirty
+    )
 
 
 def _latest_release_or_payload(target: Path, *, base_ref: str | None) -> dict[str, Any]:

--- a/tests/test_release_cmd.py
+++ b/tests/test_release_cmd.py
@@ -1299,6 +1299,24 @@ def test_release_candidate_build_does_not_reuse_receipt_for_different_base_ref(t
     assert candidate["release_readiness_receipt"]["run_id"] != release_receipt["run_id"]
 
 
+def test_latest_release_refreshes_clean_receipt_when_tracked_file_becomes_dirty(tmp_path, monkeypatch, capsys):
+    _init_repo(tmp_path)
+    _seed_ready_evidence(tmp_path)
+    _patch_clean_health(monkeypatch)
+    _patch_content_guard(monkeypatch)
+
+    assert release_cmd.run(target=tmp_path, base_ref=None, json_output=True) == 0
+    clean_receipt = json.loads(capsys.readouterr().out)
+    assert clean_receipt["evidence"]["git"]["tracked_dirty_files"] == []
+
+    (tmp_path / "README.md").write_text("uncommitted change\n")
+    readiness = release_cmd._latest_release_or_payload(tmp_path, base_ref=None)
+
+    assert readiness["run_id"] == "inline-readiness"
+    assert readiness["run_id"] != clean_receipt["run_id"]
+    assert "tracked files are dirty: 1" in readiness["blockers"]
+
+
 @pytest.mark.parametrize(
     ("check_name",),
     [


### PR DESCRIPTION
Candidate construction no longer reuses a clean readiness receipt over a dirty tracked tree; the freshness check now covers working-tree state, not just HEAD. Regression test reproduces the clean-receipt-then-dirty-file case.

Note: overlaps #774 in candidate.py - whichever merges second gets rebased.

Verified: tests/test_release_cmd.py green locally.

Origin: Codex Cloud task applied locally and reviewed.

Fixes #758