### PR TITLE
fix(release): scope content_guard_tip to tracked files

### DIFF
--- a/src/brigade/guard/audit.py
+++ b/src/brigade/guard/audit.py
@@ -130,7 +130,7 @@ def run_audit(
 def _enumerate(target: Path, *, scope: str, exclude_dirs: frozenset[str]) -> list[Path]:
     if scope == "tracked":
         rel_paths = _tracked_paths(all_tracked=True, cwd=target)
-        return [target / rel for rel in rel_paths]
+        return [target / rel for rel in rel_paths if not exclude_dirs.intersection(rel.parts)]
 
     # scope == "tree"
     paths: list[Path] = []

--- a/src/brigade/guard/audit.py
+++ b/src/brigade/guard/audit.py
@@ -6,8 +6,9 @@ The `audit` command is reporting-oriented. It runs the same engine as
 
 Two enumeration modes:
 - `tracked` (default): use git's `ls-files` from inside the target directory.
-  Only files Git already knows about. This matches what the pre-push hook
-  scans and is the right default for "what could leak out of this repo".
+  Only files Git already knows about, filtered by audit directory exclusions
+  (for example `.claude`, `node_modules`, `.venv`). This is the right default
+  for "what could leak out of this repo".
 - `tree`: walk the filesystem with `Path.rglob("*")`, skipping the standard
   excluded dirs (node_modules, .git, dist, etc.) and binary files. This is
   the "what's lurking on disk" mode useful for local lint reviews.

--- a/src/brigade/release_cmd/ci.py
+++ b/src/brigade/release_cmd/ci.py
@@ -344,7 +344,7 @@ def _run_content_guard_check(
         policy_path = Path(argv[argv.index("--policy") + 1])
         try:
             report = run_audit(target, policy=load_policy(policy_path), scope="tracked")
-        except (OSError, SystemExit) as exc:
+        except (OSError, SystemExit, ValueError) as exc:
             return {
                 "name": f"content_guard_{name}",
                 "status": WARN,

--- a/src/brigade/release_cmd/ci.py
+++ b/src/brigade/release_cmd/ci.py
@@ -30,6 +30,8 @@ from .. import (
     work_cmd,
 )
 from ..selection import KNOWN_HARNESSES
+from ..guard.audit import run_audit
+from ..guard.policy import load_policy
 from ..localio import (
     read_json_dict as _read_json,
     read_jsonl_dicts as _read_jsonl,
@@ -307,6 +309,23 @@ def _content_guard_command(
             env,
             None,
         )
+    if module == "brigade.guard":
+        return (
+            [
+                sys.executable,
+                "-m",
+                module,
+                "audit",
+                str(target),
+                "--scope",
+                "tracked",
+                "--strict",
+                "--policy",
+                str(policy_path),
+            ],
+            env,
+            None,
+        )
     return [sys.executable, "-m", module, "scan", str(target), "--policy", str(policy_path)], env, None
 
 
@@ -321,17 +340,49 @@ def _run_content_guard_check(
     argv, env_updates, error = _content_guard_command(target, policy=policy, introduced=introduced, base_ref=base_ref)
     if error or argv is None:
         return {"name": f"content_guard_{name}", "status": WARN, "detail": error or "not available", "available": False}
+    if not introduced and scrub.scanner_module() == "brigade.guard":
+        policy_path = Path(argv[argv.index("--policy") + 1])
+        try:
+            report = run_audit(target, policy=load_policy(policy_path), scope="tracked")
+        except (OSError, SystemExit) as exc:
+            return {
+                "name": f"content_guard_{name}",
+                "status": WARN,
+                "detail": f"content guard unavailable: {exc}",
+                "available": False,
+                "argv": argv,
+            }
+        status = FAIL if report.blocked else OK
+        return {
+            "name": f"content_guard_{name}",
+            "status": status,
+            "available": True,
+            "exit_code": 1 if report.blocked else 0,
+            "argv": argv,
+            "stdout_summary": f"{report.files_scanned} tracked file(s) checked",
+            "stderr_summary": "",
+            "detail": "content-guard reported findings" if report.blocked else "clean",
+        }
     env = os.environ.copy()
     env.update(env_updates)
-    result = subprocess.run(
-        argv,
-        cwd=target,
-        env=env,
-        check=False,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            argv,
+            cwd=target,
+            env=env,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except OSError as exc:
+        return {
+            "name": f"content_guard_{name}",
+            "status": WARN,
+            "detail": f"content guard unavailable: {exc}",
+            "available": False,
+            "argv": argv,
+        }
     status = OK if result.returncode == 0 else FAIL
     return {
         "name": f"content_guard_{name}",

--- a/tests/guard/test_audit.py
+++ b/tests/guard/test_audit.py
@@ -43,6 +43,22 @@ class AuditCliTests(unittest.TestCase):
         offenders = {entry["path"] for entry in payload["top_offenders"]}
         self.assertEqual(offenders, {"tracked.md"})
 
+    def test_audit_tracked_scope_preserves_directory_exclusions(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            self._init_repo(repo)
+            excluded = repo / ".claude" / "notes.md"
+            excluded.parent.mkdir()
+            excluded.write_text("Service runs on 192.168.99.10.\n")
+            subprocess.run(["git", "add", "-f", ".claude/notes.md"], cwd=repo, check=True)
+
+            proc = self._audit(repo, str(repo), "--scope", "tracked", "--json")
+
+        self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+        payload = json.loads(proc.stdout)
+        self.assertEqual(payload["summary"]["files_scanned"], 1)
+        self.assertEqual(payload["summary"]["files_with_findings"], 0)
+
     def test_audit_tree_scope_counts_all_files(self) -> None:
         with TemporaryDirectory() as tmp:
             repo = Path(tmp)

--- a/tests/test_release_cmd.py
+++ b/tests/test_release_cmd.py
@@ -184,6 +184,18 @@ def test_release_guard_broken_external_scanner_is_unavailable_warning(tmp_path, 
     assert "unavailable" in check["detail"]
 
 
+def test_release_guard_malformed_embedded_policy_is_unavailable_warning(tmp_path, monkeypatch):
+    monkeypatch.delenv("CONTENT_GUARD_DIR", raising=False)
+    policy_path = tmp_path / "broken-policy.json"
+    policy_path.write_text("{ not valid json\n")
+
+    check = release_cmd._run_content_guard_check(tmp_path, name="tip", policy=str(policy_path))
+
+    assert check["status"] == "warn"
+    assert check["available"] is False
+    assert "unavailable" in check["detail"]
+
+
 def test_release_guard_external_checkout_requires_explicit_override(tmp_path, monkeypatch):
     checkout = tmp_path / "content-guard"
     (checkout / "src").mkdir(parents=True)

--- a/tests/test_release_cmd.py
+++ b/tests/test_release_cmd.py
@@ -144,9 +144,44 @@ def test_release_guard_defaults_to_embedded_brigade_modules(tmp_path, monkeypatc
     )
     assert tip_error is None
     assert tip[:3] == [release_cmd.sys.executable, "-m", "brigade.guard"]
+    assert tip[3:7] == ["audit", str(tmp_path), "--scope", "tracked"]
+    assert "--strict" in tip
     assert history[:3] == [release_cmd.sys.executable, "-m", "brigade.guard.git_scan"]
     assert tip_env == history_env == {}
     assert "CONTENT_GUARD_DIR" not in " ".join(tip + history)
+
+
+def test_release_guard_tip_ignores_gitignored_scratch(tmp_path, monkeypatch):
+    monkeypatch.delenv("CONTENT_GUARD_DIR", raising=False)
+    _init_repo(tmp_path)
+    (tmp_path / ".gitignore").write_text("scratch.md\n")
+    subprocess.run(["git", "add", ".gitignore"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-m", "ignore scratch"], cwd=tmp_path, check=True, capture_output=True)
+    (tmp_path / "scratch.md").write_text("Service runs on 192.168.99.10.\n")
+
+    check = release_cmd._run_content_guard_check(tmp_path, name="tip", policy="public-repo")
+
+    assert check["status"] == "ok"
+    assert check["available"] is True
+
+
+def test_release_guard_broken_external_scanner_is_unavailable_warning(tmp_path, monkeypatch):
+    checkout = tmp_path / "content-guard"
+    (checkout / "src").mkdir(parents=True)
+    (checkout / "policies").mkdir()
+    (checkout / "policies" / "public-repo.json").write_text("{}")
+    monkeypatch.setenv("CONTENT_GUARD_DIR", str(checkout))
+
+    def unavailable(*args, **kwargs):
+        raise OSError("scanner executable is broken")
+
+    monkeypatch.setattr(release_cmd.subprocess, "run", unavailable)
+
+    check = release_cmd._run_content_guard_check(tmp_path, name="tip", policy="public-repo")
+
+    assert check["status"] == "warn"
+    assert check["available"] is False
+    assert "unavailable" in check["detail"]
 
 
 def test_release_guard_external_checkout_requires_explicit_override(tmp_path, monkeypatch):


### PR DESCRIPTION
Gitignored scratch can no longer block a release: the gate scans tracked files only, preserving the guard's directory exclusions (the gap that failed the previous attempt's review), and a broken external scanner degrades to an unavailable warning instead of raising from release doctor. Tests cover both review gaps plus the scratch-does-not-block case.

Verified: tests/test_release_cmd.py and tests/guard/test_audit.py green locally.

Origin: Codex Cloud task applied locally and reviewed.

Fixes #694