### PR TITLE
fix(run): fair FIFO run-lock wait queue without 600s starvation (#768)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `brigade run --wait` now joins a fair per-worktree wait queue instead of
+  timing out after 600 seconds while a legitimate run still holds the lock.
+  Waiters proceed in arrival order; stale holders and dead queue tickets are
+  reclaimed during the wait. Bare `--wait` waits without a fixed ceiling;
+  `--wait=SECONDS` keeps an optional bound. Workspace default wait is
+  configurable via `run_lock_wait_seconds` in `.brigade/config.json`; use
+  `--wait=0` to fail fast when that default is set.
+
 ## [0.26.0] - 2026-08-05
 
 ### Added

--- a/src/brigade/cli/run.py
+++ b/src/brigade/cli/run.py
@@ -14,7 +14,7 @@ from typing import Callable, Iterator
 
 _DETACH_START_TIMEOUT_SECONDS = 30.0
 _DETACH_POLL_INTERVAL_SECONDS = 0.05
-_DEFAULT_RUN_LOCK_WAIT_SECONDS = 600.0
+_UNBOUNDED_RUN_LOCK_WAIT = math.inf
 
 
 @contextmanager
@@ -101,6 +101,26 @@ def _non_negative_seconds(value: str) -> float:
     return parsed
 
 
+def _run_lock_wait_arg(value: str) -> float:
+    if value.lower() in ("inf", "infinity", "unbounded"):
+        return _UNBOUNDED_RUN_LOCK_WAIT
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a number of seconds or 'inf'") from exc
+    if not math.isfinite(parsed) or parsed < 0:
+        raise argparse.ArgumentTypeError("must be a finite non-negative number of seconds or 'inf'")
+    return parsed
+
+
+def _resolved_run_lock_wait_seconds(args, run_cwd: Path) -> float:
+    from .. import config as config_mod
+
+    if args.wait is not None:
+        return args.wait
+    return config_mod.resolve_run_lock_wait_seconds(run_cwd)
+
+
 def register(sub: argparse._SubParsersAction) -> None:
     # run
     p_run = sub.add_parser("run", help="Run a bounded cross-model orchestration task.")
@@ -142,13 +162,15 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_run.add_argument(
         "--wait",
         nargs="?",
-        const=_DEFAULT_RUN_LOCK_WAIT_SECONDS,
-        default=0.0,
-        type=_non_negative_seconds,
+        const=_UNBOUNDED_RUN_LOCK_WAIT,
+        default=None,
+        type=_run_lock_wait_arg,
         metavar="SECONDS",
         help=(
-            "Wait up to SECONDS for an active run lock instead of failing immediately "
-            f"(default with no value: {_DEFAULT_RUN_LOCK_WAIT_SECONDS:g}s)."
+            "Wait for an active run lock in arrival order instead of failing immediately. "
+            "A bare --wait waits until the lock is available with no fixed ceiling; "
+            "pass SECONDS to bound the wait. Use --wait=0 to fail fast even when "
+            ".brigade/config.json sets run_lock_wait_seconds."
         ),
     )
     p_run.add_argument(
@@ -453,7 +475,13 @@ def dispatch(args) -> int:
                         "output_warnings": output_warnings,
                     },
                 )
-            lifecycle.enter_context(runguard.run_lock(run_cwd, run_dir=output_dir, wait_seconds=args.wait))
+            lifecycle.enter_context(
+                runguard.run_lock(
+                    run_cwd,
+                    run_dir=output_dir,
+                    wait_seconds=_resolved_run_lock_wait_seconds(args, run_cwd),
+                )
+            )
             if args.worktree:
                 worktree_cwd = _worktree_checkout_path(runguard.git_root(run_cwd), output_dir)
                 effective_cwd = runguard.create_detached_worktree(run_cwd, worktree_cwd)
@@ -827,8 +855,11 @@ def _detached_child_argv(args, *, run_cwd: Path, roster_resolution, output_dir: 
         argv.append("--read-only")
     if args.worker is not None:
         argv.extend(["--worker", args.worker])
-    if args.wait > 0:
-        argv.extend(["--wait", f"{args.wait:g}"])
+    if args.wait is not None:
+        if math.isinf(args.wait):
+            argv.append("--wait")
+        else:
+            argv.extend(["--wait", f"{args.wait:g}"])
     if args.no_code_graph:
         argv.append("--no-code-graph")
     if args.no_evidence:

--- a/src/brigade/config.py
+++ b/src/brigade/config.py
@@ -21,6 +21,7 @@ DEFAULT_CAPTURE_BEFORE_RETRY = "warn"
 DEFAULT_VERIFY_RUNS_KEEP = 50
 DEFAULT_VERIFY_ARCHIVE_ENABLED = True
 DEFAULT_VERIFY_ARCHIVE_DIR = ".brigade/work/verify-archive"
+DEFAULT_RUN_LOCK_WAIT_SECONDS = 0.0
 
 
 @dataclass
@@ -32,6 +33,7 @@ class Config:
     verify_runs_keep: int = DEFAULT_VERIFY_RUNS_KEEP
     verify_archive_enabled: bool = DEFAULT_VERIFY_ARCHIVE_ENABLED
     verify_archive_dir: str = DEFAULT_VERIFY_ARCHIVE_DIR
+    run_lock_wait_seconds: float = DEFAULT_RUN_LOCK_WAIT_SECONDS
 
 
 def validate_graphtrail_delta_timeout(value: Any) -> float:
@@ -89,6 +91,22 @@ def validate_verify_archive_dir(value: Any) -> str:
     return value.strip()
 
 
+def validate_run_lock_wait_seconds(value: Any) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError("run_lock_wait_seconds must be a non-negative number")
+    timeout = float(value)
+    if not math.isfinite(timeout) or timeout < 0:
+        raise ValueError("run_lock_wait_seconds must be a non-negative number")
+    return timeout
+
+
+def resolve_run_lock_wait_seconds(target: Path) -> float:
+    cfg = load_config(target)
+    if cfg is not None:
+        return cfg.run_lock_wait_seconds
+    return DEFAULT_RUN_LOCK_WAIT_SECONDS
+
+
 def resolve_verify_runs_keep(target: Path) -> int:
     cfg = load_config(target)
     if cfg is not None:
@@ -137,6 +155,9 @@ def write_config(target: Path, cfg: Config) -> None:
     verify_archive_dir = validate_verify_archive_dir(cfg.verify_archive_dir)
     if verify_archive_dir != DEFAULT_VERIFY_ARCHIVE_DIR:
         payload["verify_archive_dir"] = verify_archive_dir
+    run_lock_wait_seconds = validate_run_lock_wait_seconds(cfg.run_lock_wait_seconds)
+    if run_lock_wait_seconds != DEFAULT_RUN_LOCK_WAIT_SECONDS:
+        payload["run_lock_wait_seconds"] = run_lock_wait_seconds
     path.write_text(json.dumps(payload, indent=2) + "\n")
 
 
@@ -169,6 +190,9 @@ def load_config(target: Path) -> Optional[Config]:
         data.get("verify_archive_enabled", DEFAULT_VERIFY_ARCHIVE_ENABLED)
     )
     verify_archive_dir = validate_verify_archive_dir(data.get("verify_archive_dir", DEFAULT_VERIFY_ARCHIVE_DIR))
+    run_lock_wait_seconds = validate_run_lock_wait_seconds(
+        data.get("run_lock_wait_seconds", DEFAULT_RUN_LOCK_WAIT_SECONDS)
+    )
     return Config(
         version=version,
         selection=sel,
@@ -177,4 +201,5 @@ def load_config(target: Path) -> Optional[Config]:
         verify_runs_keep=verify_runs_keep,
         verify_archive_enabled=verify_archive_enabled,
         verify_archive_dir=verify_archive_dir,
+        run_lock_wait_seconds=run_lock_wait_seconds,
     )

--- a/src/brigade/runguard.py
+++ b/src/brigade/runguard.py
@@ -6,6 +6,7 @@ import contextlib
 import errno
 import hashlib
 import json
+import math
 import os
 import shutil
 import stat
@@ -14,6 +15,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from time import monotonic as _monotonic
+from time import monotonic_ns as _monotonic_ns
 from time import sleep as _sleep
 from uuid import uuid4
 
@@ -35,6 +37,7 @@ _NONTERMINAL_RUN_STATUSES = frozenset(
 
 class _RunLockClock:
     monotonic = staticmethod(_monotonic)
+    monotonic_ns = staticmethod(_monotonic_ns)
     sleep = staticmethod(_sleep)
 
 
@@ -752,6 +755,113 @@ def _lock_path_is_directory(path: Path) -> bool | None:
     return True
 
 
+def _wait_queue_dir(lock_path: Path) -> Path:
+    return lock_path.parent / f"{lock_path.name}.wait-queue"
+
+
+def _list_wait_tickets(queue_dir: Path) -> list[Path]:
+    if not queue_dir.is_dir():
+        return []
+    return sorted(queue_dir.glob("*.wait"))
+
+
+def _wait_ticket_is_live(ticket: Path) -> bool:
+    try:
+        payload = json.loads(ticket.read_text())
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError, RecursionError):
+        return False
+    pid = payload.get("pid") if isinstance(payload, dict) else None
+    return isinstance(pid, int) and _pid_is_active(pid)
+
+
+def _prune_stale_wait_tickets(queue_dir: Path) -> None:
+    for ticket in _list_wait_tickets(queue_dir):
+        if _wait_ticket_is_live(ticket):
+            continue
+        try:
+            ticket.unlink()
+        except OSError:
+            pass
+
+
+def _enroll_wait_ticket(queue_dir: Path) -> Path:
+    queue_dir.mkdir(parents=True, exist_ok=True)
+    token = uuid4().hex
+    ticket = queue_dir / f"{time.monotonic_ns():020d}-{os.getpid():08d}-{token}.wait"
+    payload = {
+        "schema": "brigade.run_lock_wait.v1",
+        "pid": os.getpid(),
+        "enrolled_at": datetime.now(timezone.utc).isoformat(),
+    }
+    fd = os.open(ticket, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        os.write(fd, json.dumps(payload).encode())
+    finally:
+        os.close(fd)
+    return ticket
+
+
+def _leave_wait_ticket(ticket: Path) -> None:
+    try:
+        ticket.unlink()
+    except FileNotFoundError:
+        return
+    except OSError:
+        return
+
+
+def _is_wait_queue_head(ticket: Path, queue_dir: Path) -> bool:
+    _prune_stale_wait_tickets(queue_dir)
+    tickets = _list_wait_tickets(queue_dir)
+    return bool(tickets) and tickets[0] == ticket
+
+
+def _lock_held_by_live_process(path: Path) -> bool:
+    try:
+        if _lock_path_is_directory(path) is None:
+            return False
+    except RunLockError:
+        return False
+    return not _lock_is_stale(path)
+
+
+def _wait_to_acquire_lock(
+    path: Path,
+    *,
+    run_dir: Path | None = None,
+    wait_seconds: float,
+    poll_interval: float,
+) -> _LockOwnership:
+    if wait_seconds == 0:
+        return _acquire_lock(path, run_dir=run_dir)
+
+    queue_dir = _wait_queue_dir(path)
+    ticket = _enroll_wait_ticket(queue_dir)
+    unbounded = math.isinf(wait_seconds)
+    deadline = time.monotonic() + wait_seconds if not unbounded else 0.0
+    try:
+        while True:
+            if _is_wait_queue_head(ticket, queue_dir):
+                try:
+                    return _acquire_lock(path, run_dir=run_dir)
+                except RunLockError as exc:
+                    if not _lock_held_by_live_process(path):
+                        raise
+                    if not unbounded:
+                        remaining = deadline - time.monotonic()
+                        if remaining <= 0:
+                            raise RunLockError(
+                                f"timed out after {wait_seconds:g}s waiting for run lock: {path}"
+                            ) from exc
+            elif not unbounded:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise RunLockError(f"timed out after {wait_seconds:g}s waiting for run lock: {path}")
+            time.sleep(poll_interval)
+    finally:
+        _leave_wait_ticket(ticket)
+
+
 def _acquire_lock(path: Path, *, run_dir: Path | None = None) -> _LockOwnership:
     for _ in range(8):
         try:
@@ -808,25 +918,18 @@ def run_lock(
     wait_seconds: float = 0.0,
     poll_interval: float = 0.1,
 ):
-    if wait_seconds < 0:
-        raise ValueError("run lock wait_seconds must be non-negative")
+    if wait_seconds < 0 or (not math.isinf(wait_seconds) and not math.isfinite(wait_seconds)):
+        raise ValueError("run lock wait_seconds must be zero, positive, or unbounded")
     if poll_interval <= 0:
         raise ValueError("run lock poll_interval must be positive")
     path = lock_path(cwd)
     path.parent.mkdir(parents=True, exist_ok=True)
-    deadline = time.monotonic() + wait_seconds
-    ownership: _LockOwnership | None = None
-    while True:
-        try:
-            ownership = _acquire_lock(path, run_dir=run_dir)
-            break
-        except RunLockError as exc:
-            if wait_seconds == 0:
-                raise
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                raise RunLockError(f"timed out after {wait_seconds:g}s waiting for run lock: {path}") from exc
-            time.sleep(min(poll_interval, remaining))
+    ownership = _wait_to_acquire_lock(
+        path,
+        run_dir=run_dir,
+        wait_seconds=wait_seconds,
+        poll_interval=poll_interval,
+    )
     retain_lock = False
     try:
         yield path

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -296,3 +296,30 @@ def test_resolve_verify_archive_honors_absolute_dir(tmp_path):
     enabled, root = resolve_verify_archive(tmp_path)
     assert enabled is True
     assert root == destination
+
+
+def test_load_config_defaults_run_lock_wait_seconds(tmp_path):
+    _write_config_json(tmp_path)
+    loaded = load_config(tmp_path)
+    assert loaded is not None
+    assert loaded.run_lock_wait_seconds == 0.0
+
+
+def test_load_config_reads_run_lock_wait_seconds(tmp_path):
+    _write_config_json(tmp_path, run_lock_wait_seconds=120)
+    loaded = load_config(tmp_path)
+    assert loaded is not None
+    assert loaded.run_lock_wait_seconds == 120.0
+
+
+@pytest.mark.parametrize("value", [-1, "slow", True])
+def test_load_config_rejects_invalid_run_lock_wait_seconds(tmp_path, value):
+    _write_config_json(tmp_path, run_lock_wait_seconds=value)
+    with pytest.raises(ValueError, match="run_lock_wait_seconds must be a non-negative number"):
+        load_config(tmp_path)
+
+
+def test_resolve_run_lock_wait_seconds_defaults_without_config(tmp_path):
+    from brigade.config import resolve_run_lock_wait_seconds
+
+    assert resolve_run_lock_wait_seconds(tmp_path) == 0.0

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -1,4 +1,5 @@
 import json
+import math
 import os
 import signal
 import subprocess
@@ -1213,8 +1214,11 @@ def test_run_cli_lock_conflict_errors(tmp_path, monkeypatch, capsys):
     assert "another brigade run appears active" in capsys.readouterr().err
 
 
-@pytest.mark.parametrize(("wait_arg", "expected"), [("--wait=0.25", 0.25), ("--wait", 600.0)])
-def test_run_cli_passes_bounded_wait_to_run_lock(tmp_path, monkeypatch, wait_arg, expected):
+@pytest.mark.parametrize(
+    ("wait_arg", "expected"),
+    [("--wait=0.25", 0.25), ("--wait", math.inf), ("--wait=0", 0.0)],
+)
+def test_run_cli_passes_wait_seconds_to_run_lock(tmp_path, monkeypatch, wait_arg, expected):
     repo = _git_repo_with_roster(tmp_path)
     seen = {}
 
@@ -1253,6 +1257,68 @@ def test_run_cli_records_output_dir_in_run_lock(tmp_path, monkeypatch):
 
     assert rc == 0
     assert seen == {"cwd": repo, "run_dir": output_dir, "wait_seconds": 0.0}
+
+
+def test_run_cli_uses_config_run_lock_wait_seconds_default(tmp_path, monkeypatch):
+    repo = _git_repo_with_roster(tmp_path)
+    (repo / ".brigade" / "config.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "depth": "repo",
+                "harnesses": ["claude"],
+                "owner": "claude",
+                "includes": [],
+                "run_lock_wait_seconds": 45,
+            }
+        )
+        + "\n"
+    )
+    seen = {}
+
+    @contextmanager
+    def fake_lock(cwd, *, run_dir=None, wait_seconds=0.0):
+        seen["wait_seconds"] = wait_seconds
+        yield
+
+    monkeypatch.setattr(runguard, "run_lock", fake_lock)
+    monkeypatch.setattr(aboyeur, "run", lambda *args, **kwargs: 0)
+
+    rc = cli.main(["run", "x", "--cwd", str(repo), "--no-artifacts"])
+
+    assert rc == 0
+    assert seen == {"wait_seconds": 45.0}
+
+
+def test_run_cli_wait_zero_overrides_config_default_wait(tmp_path, monkeypatch):
+    repo = _git_repo_with_roster(tmp_path)
+    (repo / ".brigade" / "config.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "depth": "repo",
+                "harnesses": ["claude"],
+                "owner": "claude",
+                "includes": [],
+                "run_lock_wait_seconds": 45,
+            }
+        )
+        + "\n"
+    )
+    seen = {}
+
+    @contextmanager
+    def fake_lock(cwd, *, run_dir=None, wait_seconds=0.0):
+        seen["wait_seconds"] = wait_seconds
+        yield
+
+    monkeypatch.setattr(runguard, "run_lock", fake_lock)
+    monkeypatch.setattr(aboyeur, "run", lambda *args, **kwargs: 0)
+
+    rc = cli.main(["run", "x", "--cwd", str(repo), "--wait=0", "--no-artifacts"])
+
+    assert rc == 0
+    assert seen == {"wait_seconds": 0.0}
 
 
 def test_run_cli_terminalizes_roster_snapshot_write_failure(tmp_path, monkeypatch):

--- a/tests/test_runguard.py
+++ b/tests/test_runguard.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 import shutil
 import threading
@@ -326,6 +327,68 @@ def test_run_lock_timeout_clock_is_isolated_from_process_clock(tmp_path, monkeyp
 
     assert sleeps == [0.05]
     assert lock_path.is_dir()
+
+
+def test_run_lock_fair_queue_long_holder_multiple_waiters_proceed_in_order(tmp_path):
+    repo = _repo(tmp_path)
+    order: list[str] = []
+    holder_done = threading.Event()
+
+    def holder() -> None:
+        with runguard.run_lock(repo):
+            order.append("holder-start")
+            assert holder_done.wait(timeout=5)
+            order.append("holder-end")
+
+    def waiter(name: str) -> None:
+        with runguard.run_lock(repo, wait_seconds=math.inf, poll_interval=0.02):
+            order.append(name)
+
+    holder_thread = threading.Thread(target=holder)
+    holder_thread.start()
+    stdlib_time.sleep(0.1)
+
+    waiter_threads = []
+    for index in range(3):
+        thread = threading.Thread(target=waiter, args=(f"waiter-{index}",))
+        thread.start()
+        waiter_threads.append(thread)
+        stdlib_time.sleep(0.05)
+
+    stdlib_time.sleep(0.2)
+    holder_done.set()
+
+    for thread in waiter_threads:
+        thread.join(timeout=10)
+        assert not thread.is_alive()
+    holder_thread.join(timeout=10)
+    assert not holder_thread.is_alive()
+
+    assert order == ["holder-start", "holder-end", "waiter-0", "waiter-1", "waiter-2"]
+
+
+def test_run_lock_wait_reclaims_stale_holder(tmp_path):
+    repo = _repo(tmp_path)
+    lock_path = runguard.lock_path(repo)
+    lock_path.mkdir(parents=True)
+    (lock_path / "pid").write_text("99999999\n")
+
+    with runguard.run_lock(repo, wait_seconds=1.0, poll_interval=0.05):
+        assert (lock_path / "pid").read_text().strip() == str(os.getpid())
+
+    assert not lock_path.exists()
+
+
+def test_run_lock_prunes_stale_wait_tickets_before_queue_head(tmp_path):
+    repo = _repo(tmp_path)
+    queue_dir = runguard._wait_queue_dir(runguard.lock_path(repo))
+    queue_dir.mkdir(parents=True)
+    dead_ticket = queue_dir / "00000000000000000001-00000001-dead.wait"
+    dead_ticket.write_text(json.dumps({"pid": 99999999}))
+    live_ticket = runguard._enroll_wait_ticket(queue_dir)
+
+    assert runguard._is_wait_queue_head(live_ticket, queue_dir)
+    assert not dead_ticket.exists()
 
 
 def test_run_lock_replaces_lock_with_dead_pid(tmp_path):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

Fixes #768: concurrent `brigade run --wait` lanes were starving because each waiter polled with a fixed 600s ceiling and could time out while a legitimate run still held `.brigade/run.lock`.

This replaces bounded polling with a fair per-worktree FIFO wait queue (`.brigade/run.lock.wait-queue/`). Waiters enroll with monotonic tickets, only the queue head attempts acquisition, and dead wait tickets are pruned so a crashed waiter cannot block the queue. Stale lock holders are still reclaimed via the existing `_lock_is_stale` path during waits.

## Behavior changes

| Invocation | Before | After |
|---|---|---|
| (no flag) | fail-fast | fail-fast (or config default; see below) |
| `--wait` | bounded 600s poll | **unbounded** fair-queue wait |
| `--wait=N` | bounded Ns poll | bounded Ns **fair-queue** wait |
| `--wait=0` | bounded 0s (fail-fast) | fail-fast |

## Config: `run_lock_wait_seconds`

Optional key in `.brigade/config.json` sets the workspace default wait when `--wait` is omitted (`0` = fail-fast, unchanged). Lets operators default to waiting without repeating the flag.

## Why no `--no-wait` flag

The 0.26.x stability promise (per issue guidance and CONTRIBUTING surface discipline) disallows new CLI flags and exit-code changes. Instead of adding `--no-wait`, workspaces that set `run_lock_wait_seconds` can opt out per invocation with the **existing** `--wait=0` flag. No new surface; same exit codes.

## Tests

- Long holder + three waiters proceed in FIFO order
- Stale holder reclaimed while waiting
- Dead queue tickets pruned before head selection
- Config default + `--wait=0` override
- Existing bounded-timeout and fail-fast tests still pass

## Verification

```
./scripts/verify
# 6065 passed, 3 skipped
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b743ac94-224b-48d5-9a54-d410ffd02170?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b743ac94-224b-48d5-9a54-d410ffd02170&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

