### PR TITLE
fix(release): split stable and dev publish channels

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -1,0 +1,33 @@
+name: publish-dev
+
+on:
+  schedule:
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-publish-dev-wheel:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Derive and stamp the development wheel version
+        run: python scripts/prepare_dev_wheel.py --date-suffix "$(date -u +%Y%m%d)"
+      - name: Install build tooling
+        run: python -m pip install --upgrade pip build
+      - name: Build wheel only
+        run: python -m build --wheel
+      - name: Publish development wheel to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+        with:
+          skip-existing: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,13 +3,31 @@ name: publish
 on:
   push:
     tags:
-      - 'v*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 permissions:
   contents: read
 
 jobs:
+  validate-stable-tag:
+    if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject prerelease and development tags
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          python - <<'EOF'
+          import os, re, sys
+
+          tag = os.environ["TAG"]
+          if not re.fullmatch(r"v\d+\.\d+\.\d+", tag):
+              print(f"::error::stable publish requires an exact vX.Y.Z tag, got {tag!r}")
+              sys.exit(1)
+          EOF
+
   validate-release:
+    needs: validate-stable-tag
     if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
     runs-on: ubuntu-latest
     steps:

--- a/docs/update-channels.md
+++ b/docs/update-channels.md
@@ -12,6 +12,24 @@ components, then publishes its state only after both commands succeed.
 | Production or operator | `stable` | Default. Pins the latest published non-prerelease Brigade release. |
 | Brigade development | `beta` | Intentional development-machine opt-in. Pins a full `main` SHA only when every GitHub check run is terminal and successful, neutral, or skipped. |
 
+Daily development wheels are built from `main` on a schedule and published as PyPI
+prereleases with versions of the form `X.Y.Z.devYYYYMMDD` (for example
+`0.27.0.dev20260808`). That delivery channel is separate from stable `vX.Y.Z` releases:
+it builds only the wheel, does not create a GitHub release or native assets, and does not require
+the development version to be committed into Brigade's stable version declarations. Stable tags
+continue to require every declared version to match before the native release matrix can run.
+Development wheels are not promoted to stable and PyPI's default resolver does not select them.
+
+Install a chosen daily build with an exact version pin:
+
+```bash
+pipx install 'brigade-cli==0.27.0.dev20260808'
+```
+
+The same pin works with `pip install 'brigade-cli==0.27.0.dev20260808'`. Bare
+`pipx install brigade-cli` or `pip install brigade-cli` resolves the latest stable
+release only; prerelease wheels are never selected as `latest`.
+
 Run `brigade update` for the production default. `brigade update --channel beta` is not a general preview channel. A machine already owned by the other channel fails until the operator supplies `--switch-channel`; a command never transfers ownership implicitly. `--dry-run` resolves and prints the exact commands without changing pipx, managed components, or state.
 
 ## State, lock, and native components
@@ -19,6 +37,11 @@ Run `brigade update` for the production default. `brigade update --channel beta`
 The user-global state is `<Brigade data root>/brigade/update-state.json`, separate from component `installed.json`. Its strict schema records the selected channel, owner, exact CLI version or beta SHA, release id and tag, manifest URL and digest, and timestamp. The shared sibling lock `update.lock` covers both channels. A live owner causes a clear failure. Stale metadata is removed only after its recorded process is confirmed dead.
 
 Stable resolves `releases/latest` once, verifies the exact `component-manifest-v1.json` release asset by GitHub digest and size, and accepts only exact `escoffier-labs/brigade` release URLs at the resolved tag. Beta pins the CLI to a checked full `main` SHA but uses the same verified stable component manifest, so beta and stable cannot install different native bytes. During the pre-pin window before a new component such as `agent-notify` first ships on stable, beta may run newer Brigade Python from `main` while native setup still follows the last verified stable manifest; components omitted there are skipped until stable publishes their assets.
+
+The daily wheel channel does not change that beta/pre-pin contract. Its build stamps only the
+wheel's Python distribution and runtime version; bundled template and component pins remain the
+committed stable values. Operators who use `brigade update --channel beta` still receive the
+checked `main` SHA plus native bytes from the latest verified stable manifest.
 
 The updater runs `pipx install --force` with an exact requirement, then calls the newly installed absolute `brigade` executable with `setup --manifest <verified-cache-path>`. It does not use the prior executable for setup. This sequence is not an atomic installation transaction: pipx replacement happens before component setup. State publication is transactional, so a failed pipx install or setup leaves the prior update state untouched; rerun the same update to repair components.
 

--- a/scripts/prepare_dev_wheel.py
+++ b/scripts/prepare_dev_wheel.py
@@ -5,17 +5,20 @@ from __future__ import annotations
 
 import argparse
 import re
-import tomllib
 from pathlib import Path
 
 
 DEV_VERSION = re.compile(r"^\d+\.\d+\.\d+\.dev\d+$")
 DATE_SUFFIX = re.compile(r"^\d{8}$")
 STABLE_VERSION = re.compile(r"^\d+\.\d+\.\d+$")
+PYPROJECT_VERSION = re.compile(r'(?m)^version = "(\d+\.\d+\.\d+)"$')
 
 
 def read_stable_version(root: Path) -> str:
-    return tomllib.loads((root / "pyproject.toml").read_text())["project"]["version"]
+    versions = PYPROJECT_VERSION.findall((root / "pyproject.toml").read_text())
+    if len(versions) != 1:
+        raise ValueError("could not find exactly one strict numeric X.Y.Z version declaration in pyproject.toml")
+    return versions[0]
 
 
 def next_minor_version(stable_version: str) -> str:

--- a/scripts/prepare_dev_wheel.py
+++ b/scripts/prepare_dev_wheel.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Stamp the Python package metadata for an ephemeral development wheel."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import tomllib
+from pathlib import Path
+
+
+DEV_VERSION = re.compile(r"^\d+\.\d+\.\d+\.dev\d+$")
+DATE_SUFFIX = re.compile(r"^\d{8}$")
+STABLE_VERSION = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+def read_stable_version(root: Path) -> str:
+    return tomllib.loads((root / "pyproject.toml").read_text())["project"]["version"]
+
+
+def next_minor_version(stable_version: str) -> str:
+    if not STABLE_VERSION.fullmatch(stable_version):
+        raise ValueError(f"stable version must be strict numeric X.Y.Z, got {stable_version!r}")
+    major, minor, _patch = (int(part) for part in stable_version.split("."))
+    return f"{major}.{minor + 1}.0"
+
+
+def derive_dev_version(stable_version: str, date_suffix: str) -> str:
+    if not DATE_SUFFIX.fullmatch(date_suffix):
+        raise ValueError(f"date suffix must match YYYYMMDD, got {date_suffix!r}")
+    version = f"{next_minor_version(stable_version)}.dev{date_suffix}"
+    if not DEV_VERSION.fullmatch(version):
+        raise ValueError(f"derived development version is invalid: {version!r}")
+    return version
+
+
+def prepare_dev_wheel(root: Path, version: str) -> None:
+    """Stamp only Python package metadata, leaving stable template pins intact."""
+    if not DEV_VERSION.fullmatch(version):
+        raise ValueError(f"development version must match X.Y.Z.devN, got {version!r}")
+
+    replacements = (
+        (root / "pyproject.toml", r'(?m)^version = "[^"]+"$', f'version = "{version}"'),
+        (
+            root / "src" / "brigade" / "__init__.py",
+            r'(?m)^__version__ = "[^"]+"$',
+            f'__version__ = "{version}"',
+        ),
+    )
+    for path, pattern, replacement in replacements:
+        original = path.read_text()
+        stamped, count = re.subn(pattern, replacement, original, count=1)
+        if count != 1:
+            raise ValueError(f"could not find exactly one version declaration in {path}")
+        path.write_text(stamped)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "version",
+        nargs="?",
+        help="PEP 440 development version (X.Y.Z.devN); omit when using --date-suffix",
+    )
+    parser.add_argument(
+        "--date-suffix",
+        help="UTC build date suffix (YYYYMMDD) used to derive the next minor X.Y.Z.devYYYYMMDD from pyproject.toml",
+    )
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[1])
+    args = parser.parse_args()
+    if args.version and args.date_suffix:
+        parser.error("pass either version or --date-suffix, not both")
+    if not args.version and not args.date_suffix:
+        parser.error("version or --date-suffix is required")
+    try:
+        version = args.version or derive_dev_version(read_stable_version(args.root), args.date_suffix)
+        prepare_dev_wheel(args.root, version)
+    except ValueError as exc:
+        parser.error(str(exc))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_publish_workflow.py
+++ b/tests/test_publish_workflow.py
@@ -1,8 +1,16 @@
 from pathlib import Path
+import re
 import subprocess
 import sys
 
+import pytest
+
+from scripts.prepare_dev_wheel import derive_dev_version, next_minor_version, prepare_dev_wheel
+
 ROOT = Path(__file__).resolve().parents[1]
+
+STABLE_PUBLISH_TAG_FILTER = "v[0-9]+.[0-9]+.[0-9]+"
+STABLE_PUBLISH_TAG_GUARD = re.compile(r"v\d+\.\d+\.\d+")
 
 
 def test_publish_job_is_gated_by_matching_version_tag_before_environment():
@@ -233,6 +241,116 @@ def _load_workflow_yaml(path: Path):
 
 def test_publish_workflow_yaml_is_valid():
     _load_workflow_yaml(ROOT / ".github" / "workflows" / "publish.yml")
+    _load_workflow_yaml(ROOT / ".github" / "workflows" / "publish-dev.yml")
+
+
+def test_publish_workflow_tag_filter_is_narrower_than_v_star():
+    text = (ROOT / ".github" / "workflows" / "publish.yml").read_text()
+    trigger = text[text.index("on:") : text.index("permissions:")]
+    assert f"- '{STABLE_PUBLISH_TAG_FILTER}'" in trigger
+    assert "- 'v*'" not in trigger
+
+
+def test_publish_workflow_rejects_prerelease_and_development_tags():
+    text = (ROOT / ".github" / "workflows" / "publish.yml").read_text()
+
+    guard = text.index("  validate-stable-tag:")
+    validate = text.index("  validate-release:")
+    assert guard < validate
+    section = text[guard:validate]
+    assert STABLE_PUBLISH_TAG_GUARD.pattern in section
+    assert "stable publish requires an exact vX.Y.Z tag" in section
+    validate_section = text[validate : text.index("  build-rust-native:")]
+    assert "needs: validate-stable-tag" in validate_section
+
+
+@pytest.mark.parametrize("tag", ["v0.27.0", "v10.20.300"])
+def test_stable_publish_tag_guard_accepts_exact_release_tags(tag):
+    assert STABLE_PUBLISH_TAG_GUARD.fullmatch(tag)
+
+
+@pytest.mark.parametrize("tag", ["v0.27.0.dev20260804", "v0.27.0b1", "v0.27.0-rc1"])
+def test_stable_publish_tag_guard_rejects_prerelease_and_development_tags(tag):
+    assert STABLE_PUBLISH_TAG_GUARD.fullmatch(tag) is None
+
+
+def test_dev_publish_channel_builds_only_a_wheel_without_stable_release_gates():
+    text = (ROOT / ".github" / "workflows" / "publish-dev.yml").read_text()
+
+    assert "schedule:" in text
+    assert "workflow_dispatch" in text
+    assert "refs/heads/main" in text
+    assert 'prepare_dev_wheel.py --date-suffix "$(date -u +%Y%m%d)"' in text
+    assert "python -m build --wheel" in text
+    assert "gh-action-pypi-publish" in text
+    assert "skip-existing: true" in text
+    assert "dev-v" not in text
+    for stable_only_step in (
+        "validate-release",
+        "build-rust-native",
+        "build-go-native",
+        "build-agent-notify-native",
+        "version_sync.py --check",
+        "gh release create",
+        "published-artifact-acceptance",
+    ):
+        assert stable_only_step not in text
+
+
+def test_next_minor_version_advances_the_minor_line():
+    assert next_minor_version("0.26.0") == "0.27.0"
+    assert next_minor_version("1.9.4") == "1.10.0"
+
+
+@pytest.mark.parametrize(
+    "stable_version",
+    ["0.26", "v0.26.0", "0.26.0.1", "0.26.0b1", "not-a-version"],
+)
+def test_next_minor_version_rejects_invalid_stable_bases(stable_version):
+    with pytest.raises(ValueError, match="strict numeric X.Y.Z"):
+        next_minor_version(stable_version)
+
+
+def test_derive_dev_version_builds_pep440_dev_from_next_minor_line():
+    assert derive_dev_version("0.26.0", "20260808") == "0.27.0.dev20260808"
+
+
+@pytest.mark.parametrize(
+    "stable_version",
+    ["0.26", "v0.26.0", "0.26.0.1", "0.26.0b1", "not-a-version"],
+)
+def test_derive_dev_version_rejects_invalid_stable_bases(stable_version):
+    with pytest.raises(ValueError, match="strict numeric X.Y.Z"):
+        derive_dev_version(stable_version, "20260808")
+
+
+def test_update_channels_documents_exact_dev_wheel_install():
+    text = (ROOT / "docs" / "update-channels.md").read_text()
+
+    assert "pipx install 'brigade-cli==0.27.0.dev20260808'" in text
+    assert "pip install 'brigade-cli==0.27.0.dev20260808'" in text
+    assert "default resolver does not select them" in text
+
+
+def test_prepare_dev_wheel_stamps_python_versions_and_preserves_template_pins(tmp_path):
+    (tmp_path / "src" / "brigade").mkdir(parents=True)
+    (tmp_path / "src" / "brigade" / "templates").mkdir()
+    (tmp_path / "pyproject.toml").write_text('[project]\nversion = "0.26.1"\n')
+    (tmp_path / "src" / "brigade" / "__init__.py").write_text('__version__ = "0.26.1"\n')
+    template = tmp_path / "src" / "brigade" / "templates" / "profile.json"
+    template.write_text('{"_brigade_version": "0.26.1"}\n')
+
+    prepare_dev_wheel(tmp_path, "0.26.1.dev20260809")
+
+    assert 'version = "0.26.1.dev20260809"' in (tmp_path / "pyproject.toml").read_text()
+    assert '__version__ = "0.26.1.dev20260809"' in (tmp_path / "src" / "brigade" / "__init__.py").read_text()
+    assert template.read_text() == '{"_brigade_version": "0.26.1"}\n'
+
+
+@pytest.mark.parametrize("version", ["0.26.1", "v0.26.1.dev1", "0.26.1-dev1", "0.26.dev1"])
+def test_prepare_dev_wheel_rejects_non_dev_versions(tmp_path, version):
+    with pytest.raises(ValueError, match="must match X.Y.Z.devN"):
+        prepare_dev_wheel(tmp_path, version)
 
 
 def test_publish_workflow_verifies_version_check_endpoint_after_pypi_upload():

--- a/tests/test_publish_workflow.py
+++ b/tests/test_publish_workflow.py
@@ -5,7 +5,7 @@ import sys
 
 import pytest
 
-from scripts.prepare_dev_wheel import derive_dev_version, next_minor_version, prepare_dev_wheel
+from scripts.prepare_dev_wheel import derive_dev_version, next_minor_version, prepare_dev_wheel, read_stable_version
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -330,6 +330,28 @@ def test_update_channels_documents_exact_dev_wheel_install():
     assert "pipx install 'brigade-cli==0.27.0.dev20260808'" in text
     assert "pip install 'brigade-cli==0.27.0.dev20260808'" in text
     assert "default resolver does not select them" in text
+
+
+def test_read_stable_version_accepts_exactly_one_numeric_project_version(tmp_path):
+    (tmp_path / "pyproject.toml").write_text('[project]\nversion = "0.26.1"\n')
+
+    assert read_stable_version(tmp_path) == "0.26.1"
+
+
+@pytest.mark.parametrize(
+    "pyproject_text",
+    [
+        '[project]\nname = "pkg"\n',
+        '[project]\nversion = "0.26.1.dev1"\n',
+        '[project]\nversion = "v0.26.1"\n',
+        '[project]\nversion = "0.26.1"\nversion = "0.26.2"\n',
+    ],
+)
+def test_read_stable_version_rejects_malformed_or_ambiguous_pyproject(tmp_path, pyproject_text):
+    (tmp_path / "pyproject.toml").write_text(pyproject_text)
+
+    with pytest.raises(ValueError, match="exactly one strict numeric X.Y.Z"):
+        read_stable_version(tmp_path)
 
 
 def test_prepare_dev_wheel_stamps_python_versions_and_preserves_template_pins(tmp_path):


### PR DESCRIPTION
## Summary

- Restrict the stable publish workflow to exact `vX.Y.Z` tags and reject prerelease forms before the PyPI environment gate.
- Add a daily main-branch workflow that derives the next-minor `X.Y.0.devYYYYMMDD` version, builds one Python wheel, and publishes it without committing version stamps or creating a GitHub Release.
- Document exact prerelease pins for pip and pipx, and make same-day workflow reruns skip an existing wheel.

## Deployment prerequisite

Before the first dev publish, register a PyPI trusted publisher for `.github/workflows/publish-dev.yml` with environment `pypi`. Confirm that the GitHub `pypi` environment permits deployments from `main`, not only tags.

## Verification

`brigade work verify run --target . --command "python -m pytest -q tests/test_publish_workflow.py" --capture brigade-work`

39 passed. Receipt: `20260809-032126-work-verify-e26def`.

Fixes #684
