### PR TITLE
docs: document execution model and external-scheduler boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,15 @@
 <h1 align="center">Brigade</h1>
 
 <p align="center">
-  <strong>Your agents run loops. Brigade keeps the receipts.</strong>
+  <strong>One command to start. One command to keep it maintained.</strong>
 </p>
 
 <p align="center">
   <strong>Built for coding agents to run end to end</strong> (install, setup, verify, handoffs), not as a human day-to-day terminal app.
   When an agent says tests passed, you get a file with the real exit code, a <strong>code graph</strong> of what changed (<code>brigade code</code>), and an <strong>evidence log</strong> you can search later (<code>brigade evidence</code>).
   Optional: one MCP and tools catalog across agents, and shared notes with a review gate.
-  Local files. No daemon. No lock-in.
+  Brigade owns the memory-care primitives and runbooks. An external scheduler (cron, systemd, CI, your agent cron) invokes them. Local files. No daemon. No lock-in.
+  Boundary: <a href="docs/execution-model.md">execution model</a>.
 </p>
 
 <p align="center">
@@ -242,7 +243,7 @@ Beyond the daily loop, the same review-and-receipt pattern covers cross-model ru
 - **Native harness memory** is a per-tool silo. It does not cross harnesses, and it writes without review. Brigade gives every tool one shared format and one canonical owner, with a review gate in between.
 - **Already running Hermes, or any self-improving agent?** Keep it. Brigade is the verification layer on top: it promotes a skill only when a real signal confirms it, keeps every learned skill as portable markdown in your git, and runs one loop across your whole fleet.
 - **A plain CLAUDE.md / AGENTS.md** works great until it bloats past the context budget and goes stale. Brigade keeps bootstrap files slim, moves detail into indexed cards, and flags staleness instead of trusting last month's facts forever.
-- **A daemon or hosted service** would be simpler to demo and worse to trust. Brigade writes local files when you run a command, and that is all it does.
+- **A daemon or hosted service** would be simpler to demo and worse to trust. Brigade writes local files when you run a command, and that is all it does. See the [execution model](docs/execution-model.md).
 
 | | Across harnesses | MCP, tools, and memory in one source | Review gate + receipts | Local files, no daemon |
 |---|:---:|:---:|:---:|:---:|
@@ -253,7 +254,7 @@ Beyond the daily loop, the same review-and-receipt pattern covers cross-model ru
 
 ## What Brigade is not
 
-Brigade is not a hosted memory service, a daemon, or an automatic release bot. It does not run in the background or install schedulers (one scoped exception: `brigade tools runtime start` launches a local runtime process, only when you start it, until you stop it). It does not push to GitHub, publish packages, save every note automatically, or skip review for ambiguous, risky, or failed notes. `brigade work brief` and related status surfaces may report notification readiness or suggest installing the notifications station, but Brigade never sends a message unless the operator uses an explicit send action such as `brigade pantry expiry-alert --send`. That pause is the point: agent memory should be useful, not noisy.
+Brigade is not a hosted memory service, a daemon, or an automatic release bot. It does not run in the background. Scheduling stays with the operator (see the [execution model](docs/execution-model.md)). It does not push to GitHub, publish packages, save every note automatically, or skip review for ambiguous, risky, or failed notes. `brigade work brief` and related status surfaces may report notification readiness or suggest installing the notifications station, but Brigade never sends a message unless the operator uses an explicit send action such as `brigade pantry expiry-alert --send`. That pause is the point: agent memory should be useful, not noisy.
 
 And it is not the other projects that share the name. This Brigade is the AI-agent operator CLI from [`escoffier-labs/brigade`](https://github.com/escoffier-labs/brigade), installed with `pipx install brigade-cli`. It is not the CNCF/Microsoft Brigade for Kubernetes event scripting (archived 2022), the Spinabot Brigade agent crew, or the 2017 `brigade` Python package that became Nornir.
 
@@ -289,7 +290,8 @@ Nineteen harnesses get handoff inboxes and ingest coverage, from Codex, Claude C
 ## Docs
 
 - [First 10 minutes](docs/first-10-minutes.md) · [Overview](docs/overview.md) · [Technical guide](docs/technical-guide.md)
-- [MCP sync](docs/mcp-sync.md) · [Security and Content Guard](docs/security.md) · [Handoff promotion](docs/handoff-promotion.md)
+- [Execution model](docs/execution-model.md) · [Memory care](docs/memory-care.md) · [MCP sync](docs/mcp-sync.md)
+- [Security and Content Guard](docs/security.md) · [Handoff promotion](docs/handoff-promotion.md)
 - [Command inventory](docs/command-inventory.md) · [Station contract](docs/station-contract.md)
 - [Maintainers](MAINTAINERS.md) · [Governance](GOVERNANCE.md) · [Security](SECURITY.md) · [Contributing](CONTRIBUTING.md) · [Roadmap](ROADMAP.md)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,7 +17,7 @@ This file is direction-only. The full per-feature completion detail through v0.8
 - **station**: an optional sidecar tool Brigade installs and health-checks (pantry, tokens, content guard, …) without folding its runtime into the Python package. The Code and Evidence engines are not stations: they ship inside Brigade under `engines/`.
 - **dogfood**: Brigade being used on itself or the maintainer's real setup.
 
-The one rule behind all of it: Brigade writes local files and queues, but it never publishes, edits canonical memory, runs background daemons, or touches remote servers on its own. Everything waits for an explicit command.
+Execution model: Brigade runs only on explicit invocation. An external scheduler may call its primitives and runbooks. Brigade is not a daemon. Details: [docs/execution-model.md](docs/execution-model.md).
 
 ## Where things stand
 

--- a/docs/agents-guide.md
+++ b/docs/agents-guide.md
@@ -10,7 +10,7 @@ Brigade is a **local control plane for coding agents**, not a human day-to-day t
 
 - **Agents run:** install, `setup`, `operator quickstart`, `work verify`, handoffs, `code`, `evidence`.
 - **Humans own:** policy and review when a gate is ambiguous or risky (or when they explicitly ask for a destructive or remote action).
-- **Artifacts:** plain files on the machine (receipts, memory cards, configs). No daemon. No lock-in.
+- **Artifacts:** plain files on the machine (receipts, memory cards, configs). No daemon. No lock-in. See [`docs/execution-model.md`](execution-model.md).
 
 Public names for the built-in engines:
 
@@ -137,7 +137,7 @@ Do not commit generated local state unless the user explicitly asks and the docs
 
 ## Safety boundaries
 
-Do not start daemons, install schedulers, publish, push, tag, deploy, mutate remotes, install hooks, or run destructive commands as part of Brigade setup unless the user explicitly asks.
+Do not start daemons, install schedulers, publish, push, tag, deploy, mutate remotes, install hooks, or run destructive commands as part of Brigade setup unless the user explicitly asks. Brigade is not a scheduler. An external trigger may call its commands later. Boundary: [`docs/execution-model.md`](execution-model.md).
 
 Do not paste raw scanner output, session text, tokens, API keys, private hostnames, private repo names, or unredacted absolute paths into public issues or docs.
 

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -1,0 +1,32 @@
+# Execution Model
+
+Brigade runs only when something invokes it. There is no Brigade daemon, no background supervisor, and no built-in timer that wakes the CLI on its own.
+
+That boundary is load-bearing for trust. Every local write, every queue change, and every receipt traces to an explicit command (or to a step inside an approved runbook that you started). If nothing called Brigade, nothing happened.
+
+## What Brigade owns
+
+Brigade ships deterministic memory-care and maintenance primitives (scan, import, lint, ingest, outcome rank/reconcile, doctor, status, center report build) plus approved runbooks that sequence those commands. Mutating commands write local artifacts under the workspace; some also write receipts. Read-only surfaces such as `memory care status`, `memory care doctor`, and `outcome rank` inspect existing artifacts without creating new work. Brigade does not decide *when* any of them run.
+
+## What an external scheduler owns
+
+Cron, systemd timers, CI schedules, OpenClaw cron, Task Scheduler, or any other operator-owned trigger sits outside Brigade. That trigger's job is to call Brigade (often one `brigade runbook run --approved ...` line, or a short shell sequence of Brigade commands). The schedule, host, and restart policy belong to the operator. Brigade is the thing the schedule calls, not the scheduler.
+
+## Receipts and provenance
+
+A scheduled invocation is still an explicit invocation: the same command runs whether you typed it or a timer did. Mutating commands leave local evidence under `.brigade/` (scan outputs, import queues, verify receipts, runbook run folders, and similar). Not every command writes a receipt; for example, `memory care scan` updates `scan-latest.json` and `refresh-queue.json` but does not emit a receipt file. Runbook receipts record runbook metadata and per-step `run` strings with exit codes and log paths, not a top-level `argv` field. Memory-care `status` and `doctor` read the latest scan and queue artifacts; they do not read runbook receipts.
+
+## Scoped exception
+
+`brigade tools runtime start` can launch a local MCP runtime process that you started and that you stop. That process is not a Brigade scheduler and does not run memory care, ingest, or outcome reconcile on its own.
+
+## Future work (not shipped)
+
+Issue [#759](https://github.com/escoffier-labs/brigade/issues/759) tracks an opt-in care scaffold that would write managed entries into the operator's own scheduler (install / status / uninstall), still without Brigade owning a daemon. Until that lands, schedule Brigade yourself with crontab, systemd timers, CI, or your existing agent cron. That scaffold is not shipped in the current release.
+
+## Related
+
+- [Memory care](memory-care.md): card scan, refresh queue, and import boundaries
+- [Scanner registry](scanner-registry.md): explicit foreground sweeps, not a scheduler
+- [Technical guide](technical-guide.md): full command surface and deliberate-friction rules
+- [Roadmap](../ROADMAP.md): direction, with this page as the execution-model source of truth

--- a/docs/memory-care.md
+++ b/docs/memory-care.md
@@ -73,4 +73,4 @@ Queue entries include card identity, issue type, severity, priority, safe summar
 
 ## Boundary
 
-Memory care never edits cards, runs a scheduler, mutates canonical memory, performs remote sync, or promotes imports automatically. Refreshes stay explicit through reviewed work tasks or the existing Memory Handoff flow.
+Memory care does not run a scheduler, mutate canonical memory, perform remote sync, or promote imports automatically. Card edits stay explicit: routine scan and plan commands never write card files; only `brigade memory care backfill --apply` may add derived frontmatter, with a receipt. Refreshes stay explicit through reviewed work tasks or the existing Memory Handoff flow. Scheduling those care commands is the operator's job: see the [execution model](execution-model.md).

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,6 +1,6 @@
 # Brigade Overview
 
-The full tour: every station, diagram, and workflow. The [README](../README.md) covers the core memory loop and install; this document goes deeper. The detailed command walkthrough is in the [technical guide](technical-guide.md).
+The full tour: every station, diagram, and workflow. The [README](../README.md) covers the core memory loop and install. This document goes deeper. The detailed command walkthrough is in the [technical guide](technical-guide.md). Brigade runs only on explicit invocation: [execution model](execution-model.md).
 
 ## Stack At A Glance
 

--- a/docs/scanner-registry.md
+++ b/docs/scanner-registry.md
@@ -1,6 +1,6 @@
 # Brigade Scanner Registry
 
-`brigade work scanners` describes local scanner producers, plans safe run windows, and explicitly runs configured local producers when asked. `brigade work sweep` is the daily review action that runs configured scanner producers and writes one local report. These commands do not install cron jobs, start a daemon, mutate remotes, run scanners from `brief` or `doctor`, or promote imports automatically.
+`brigade work scanners` describes local scanner producers, plans safe run windows, and explicitly runs configured local producers when asked. `brigade work sweep` is the daily review action that runs configured scanner producers and writes one local report. These commands do not install cron jobs, start a daemon, mutate remotes, run scanners from `brief` or `doctor`, or promote imports automatically. An external scheduler may call them later. Boundary: [execution model](execution-model.md).
 
 The local config is gitignored:
 

--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -61,7 +61,7 @@ This README is dense, and a handful of words carry most of the weight. Learn the
 | **AFK** | Away from keyboard, a long unattended run the agent does solo. |
 | **station** | A subsystem of Brigade (memory, security, tokens, pantry) with its own commands. |
 
-The one rule behind all of it: Brigade writes local files and review queues, but it does not publish, edit canonical memory, run background daemons, run arbitrary commands, or touch remote servers on its own. Everything waits for an explicit operator command. That is the "deliberate friction" the rest of this doc keeps repeating.
+Execution model: explicit invocation only. Brigade writes local files and review queues when asked. It does not publish, edit canonical memory, run a scheduler or daemon, run arbitrary commands, or touch remote servers on its own. Full boundary: [`docs/execution-model.md`](execution-model.md). That deliberate friction is what the rest of this doc keeps repeating.
 
 ## The design
 
@@ -106,7 +106,7 @@ Brigade has grown from a bootstrap kit into a local control plane for agent work
 - Operator notifications: optional `agent-notify` status and setup planning for private Discord, Telegram, or Signal notifications. `brigade work brief` and related status surfaces may report readiness or suggest the station; no command sends unless the operator uses an explicit send action.
 - Security and publish guards: content-guard integration, template audit, SARIF output, suppressions, accepted-risk closeouts, policy presets, prompt and instruction checks, MCP checks, supply-chain checks, and redacted reports.
 
-The common rule is deliberate friction: Brigade writes local receipts and review queues, but it does not start daemons, mutate remotes, edit canonical memory, run arbitrary commands, publish releases, or auto-promote findings without an explicit operator command.
+The common rule is deliberate friction: Brigade writes local receipts and review queues, but it does not start daemons, mutate remotes, edit canonical memory, run arbitrary commands, publish releases, or auto-promote findings without an explicit operator command. See [`docs/execution-model.md`](execution-model.md).
 
 Browse the public template index in [`templates/`](../templates/).
 The installable source files live under `src/brigade/templates/`; root workspace files are local dogfood state and stay ignored.
@@ -1636,6 +1636,7 @@ Each subsystem has a companion doc under [`docs/`]() with the full local contrac
 - [`docs/tool-catalog.md`](tool-catalog.md) - the portable tool catalog, call review, runtimes, and policy
 - [`docs/backup-health.md`](backup-health.md) - read-only backup health summaries and issue routing
 - [`docs/memory-care.md`](memory-care.md) - memory card decay scanning and refresh imports
+- [`docs/execution-model.md`](execution-model.md) - explicit-invocation boundary and external-scheduler ownership
 - [`docs/security.md`](security.md) - the agent workspace security scanner and evidence bundles
 - [`docs/inspiration-patterns.md`](inspiration-patterns.md) - neutral pattern families and source-pattern decisions
 - [`docs/roadmap-completion-plan.md`](roadmap-completion-plan.md) - the large-roadmap completion plan and phase boundaries


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

Adds `docs/execution-model.md` as the source of truth for Brigade's explicit-invocation boundary and external-scheduler ownership. Reframes README/ROADMAP taglines and cross-links from overview, agents-guide, scanner registry, technical guide, and memory-care boundary sections.

Addresses the three accuracy findings from the prior #761 attempt:

1. **Roadmap audit** — removed backticked `brigade care` references (nonexistent command); #759 is described as a future care scaffold without naming a CLI surface.
2. **Receipts** — corrected claims: `memory care scan` writes scan/queue artifacts but no receipt; `status`/`doctor`/`outcome rank` are read-only and inspect artifacts (not runbook receipts); runbook receipts use per-step `run` strings, not top-level `argv`.
3. **Memory-care boundary** — clarified that only `memory care backfill --apply` may write derived card frontmatter (with a receipt); routine scan/plan commands do not edit cards.

`GOVERNANCE.md` and `SAFETY_RULES.md` untouched. Docs-only diff (8 markdown files).

Fixes #761

## Type of change

- [x] Docs

## Checklist

- [x] `pytest -q` passes locally (6053 passed, 3 skipped)
- [ ] Added or updated tests covering the change (docs-only)
- [ ] Updated the `Unreleased` section of `CHANGELOG.md` for user-visible effect (docs-only; no CLI change)
- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths
- [x] No new runtime dependencies
- [x] Conventional commit messages
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6fcc2f7f-96b3-4225-9e4f-d0222b90f37f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6fcc2f7f-96b3-4225-9e4f-d0222b90f37f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

