### PR TITLE
feat(memory): ship pinned memory-care runbook templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   readiness-affecting edges (`blocks` and `parent-child`) are rejected at
   edge-add and graph-apply time with a machine-readable `dependency_cycle`
   reason; `discovered-from` never participates in cycle detection.
+- `brigade memory care init --with-runbooks` writes three mechanical,
+  model-free memory-care runbook templates (`daily-care-pass`, `ingest-sweep`,
+  `weekly-outcome-ratchet`) under `.brigade/memory-care/runbooks/`. Each
+  template restricts execution to `brigade` via `allowed_commands` and gets
+  binary pins materialized at write time from the resolved `brigade` path.
+  (#760)
 
 ### Fixed
 - `brigade run --wait` now joins a fair per-worktree wait queue instead of

--- a/src/brigade/cli/memory.py
+++ b/src/brigade/cli/memory.py
@@ -17,6 +17,11 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_memory_care_init = memory_care_sub.add_parser("init", help="Write local memory-care config.")
     p_memory_care_init.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to update.")
     p_memory_care_init.add_argument("--force", action="store_true", help="Overwrite an existing memory-care config.")
+    p_memory_care_init.add_argument(
+        "--with-runbooks",
+        action="store_true",
+        help="Write pinned memory-care runbook templates under .brigade/memory-care/runbooks/.",
+    )
     p_memory_care_init.add_argument("--no-gitignore", action="store_true", help="Do not update the target .gitignore.")
     p_memory_care_scan = memory_care_sub.add_parser("scan", help="Scan local memory cards without editing them.")
     p_memory_care_scan.add_argument(
@@ -132,6 +137,7 @@ def dispatch(args) -> int:
                 target=args.target,
                 force=args.force,
                 update_gitignore=not args.no_gitignore,
+                with_runbooks=args.with_runbooks,
             )
         if args.memory_care_command == "scan":
             return memory_cmd.scan(target=args.target, json_output=args.json)

--- a/src/brigade/memory_cmd.py
+++ b/src/brigade/memory_cmd.py
@@ -19,6 +19,7 @@ from .budgets import MEMORY_CARD_BUDGET_BYTES
 from .install import apply_gitignore
 from .selection import Selection
 from .localio import write_json as _write_json, utc_now_iso_z as _utc_iso
+from .memory_doctor.safety import atomic_write_text
 from .templates import template_root
 
 CONFIG_REL_PATH = ".brigade/memory-care.toml"
@@ -276,6 +277,8 @@ def _write_memory_care_runbooks(target: Path) -> int:
                 return 2
             validated["pins"] = pins
             _write_json(dest, validated)
+        # Narrow crash window: after rmtree the old tree is gone; if replace fails
+        # before publishing temp_dir, neither directory remains at dest_dir.
         if dest_dir.exists():
             shutil.rmtree(dest_dir)
         temp_dir.replace(dest_dir)
@@ -305,7 +308,7 @@ def init(
         if rc != 0:
             return rc
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(_format_config(), encoding="utf-8")
+    atomic_write_text(path, _format_config())
     if update_gitignore:
         apply_gitignore(target, Selection(depth="repo", harnesses=[], owner="this-repo", includes=[]))
     print(f"memory_care_config: {path}")

--- a/src/brigade/memory_cmd.py
+++ b/src/brigade/memory_cmd.py
@@ -7,20 +7,28 @@ import hashlib
 import json
 import os
 import re
+import shutil
 import sys
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from . import mcp_server, toml_compat as tomllib, work_cmd
+from . import mcp_server, runbook_cmd, toml_compat as tomllib, work_cmd
 from .budgets import MEMORY_CARD_BUDGET_BYTES
 from .install import apply_gitignore
 from .selection import Selection
-from .localio import utc_now_iso_z as _utc_iso
+from .localio import write_json as _write_json, utc_now_iso_z as _utc_iso
+from .templates import template_root
 
 CONFIG_REL_PATH = ".brigade/memory-care.toml"
 DEFAULT_OUTPUT_PATH = ".brigade/memory-care/decay"
+MEMORY_CARE_RUNBOOKS_REL = ".brigade/memory-care/runbooks"
+MEMORY_CARE_RUNBOOK_NAMES = (
+    "daily-care-pass.json",
+    "ingest-sweep.json",
+    "weekly-outcome-ratchet.json",
+)
 # Pre-0.9.1 scans wrote into the user's card tree. Readers fall back to this
 # location when the default is in effect and no new-style output exists yet.
 LEGACY_OUTPUT_PATH = "memory/cards/decay"
@@ -220,7 +228,70 @@ def _config_or_default(target: Path) -> MemoryCareConfig:
     return load_config(target) or MemoryCareConfig()
 
 
-def init(*, target: Path, force: bool = False, update_gitignore: bool = True) -> int:
+def _memory_care_runbooks_dir(target: Path) -> Path:
+    return target / MEMORY_CARE_RUNBOOKS_REL
+
+
+def _write_memory_care_runbooks(target: Path) -> int:
+    """Copy pinned mechanical memory-care runbook templates into the target.
+
+    Templates ship without pins; pins are materialized from the resolved
+    ``brigade`` binary at write time so ``brigade runbook run --approved``
+    can enforce the binary hash without a separate pin step.
+
+    Writes into a sibling temp directory first so pin-resolution failures do
+    not leave a partial runbook tree behind.
+    """
+    template_dir = template_root() / "memory-care" / "runbooks"
+    dest_dir = _memory_care_runbooks_dir(target)
+    temp_dir = dest_dir.parent / f".{dest_dir.name}.init-tmp"
+    if temp_dir.exists():
+        shutil.rmtree(temp_dir)
+    temp_dir.mkdir(parents=True)
+    try:
+        for name in MEMORY_CARE_RUNBOOK_NAMES:
+            src = template_dir / name
+            if not src.is_file():
+                print(f"error: memory-care runbook template missing: {src}", file=sys.stderr)
+                return 4
+            try:
+                payload = json.loads(src.read_text(encoding="utf-8"))
+            except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+                print(f"error: invalid memory-care runbook template {src}: {exc}", file=sys.stderr)
+                return 2
+            if not isinstance(payload, dict):
+                print(f"error: memory-care runbook template must be a JSON object: {src}", file=sys.stderr)
+                return 2
+            # Validate shape through the same reader runbook execution uses, then
+            # materialize pins without echoing pin() stdout into care init output.
+            dest = temp_dir / name
+            _write_json(dest, payload)
+            validated, error = runbook_cmd._read_runbook(dest, require_pin_hashes=False)
+            if validated is None:
+                print(f"error: {error}", file=sys.stderr)
+                return 2
+            pins, pin_error = runbook_cmd._pin_payload_from_runbook(target, validated)
+            if pins is None:
+                print(f"error: {pin_error}", file=sys.stderr)
+                return 2
+            validated["pins"] = pins
+            _write_json(dest, validated)
+        if dest_dir.exists():
+            shutil.rmtree(dest_dir)
+        temp_dir.replace(dest_dir)
+        return 0
+    finally:
+        if temp_dir.exists():
+            shutil.rmtree(temp_dir)
+
+
+def init(
+    *,
+    target: Path,
+    force: bool = False,
+    update_gitignore: bool = True,
+    with_runbooks: bool = False,
+) -> int:
     target = target.expanduser().resolve()
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
@@ -229,12 +300,18 @@ def init(*, target: Path, force: bool = False, update_gitignore: bool = True) ->
     if path.exists() and not force:
         print(f"error: memory-care config already exists: {path}", file=sys.stderr)
         return 1
+    if with_runbooks:
+        rc = _write_memory_care_runbooks(target)
+        if rc != 0:
+            return rc
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(_format_config(), encoding="utf-8")
     if update_gitignore:
         apply_gitignore(target, Selection(depth="repo", harnesses=[], owner="this-repo", includes=[]))
     print(f"memory_care_config: {path}")
     print(f"output_path: {DEFAULT_OUTPUT_PATH}")
+    if with_runbooks:
+        print(f"memory_care_runbooks: {_memory_care_runbooks_dir(target)}")
     print("next_command: brigade memory care scan")
     return 0
 

--- a/src/brigade/templates/memory-care/runbooks/daily-care-pass.json
+++ b/src/brigade/templates/memory-care/runbooks/daily-care-pass.json
@@ -1,0 +1,15 @@
+{
+  "id": "daily-care-pass",
+  "description": "Daily memory-care scan and inbox import. Run from the repo or workspace root: brigade runbook run --approved .brigade/memory-care/runbooks/daily-care-pass.json",
+  "allowed_commands": ["brigade"],
+  "steps": [
+    {
+      "id": "scan",
+      "run": "brigade memory care scan --target ."
+    },
+    {
+      "id": "import-issues",
+      "run": "brigade memory care import-issues --target ."
+    }
+  ]
+}

--- a/src/brigade/templates/memory-care/runbooks/ingest-sweep.json
+++ b/src/brigade/templates/memory-care/runbooks/ingest-sweep.json
@@ -1,0 +1,15 @@
+{
+  "id": "ingest-sweep",
+  "description": "Handoff lint and ingest sweep for writer inboxes. Run from the repo or workspace root: brigade runbook run --approved .brigade/memory-care/runbooks/ingest-sweep.json",
+  "allowed_commands": ["brigade"],
+  "steps": [
+    {
+      "id": "lint",
+      "run": "brigade handoff lint --strict --target ."
+    },
+    {
+      "id": "ingest",
+      "run": "brigade ingest --promote-cards --route-documents --target ."
+    }
+  ]
+}

--- a/src/brigade/templates/memory-care/runbooks/weekly-outcome-ratchet.json
+++ b/src/brigade/templates/memory-care/runbooks/weekly-outcome-ratchet.json
@@ -1,0 +1,15 @@
+{
+  "id": "weekly-outcome-ratchet",
+  "description": "Weekly outcome rank and reconcile (dry-run by default). Run from the repo or workspace root: brigade runbook run --approved .brigade/memory-care/runbooks/weekly-outcome-ratchet.json",
+  "allowed_commands": ["brigade"],
+  "steps": [
+    {
+      "id": "rank",
+      "run": "brigade outcome rank --target ."
+    },
+    {
+      "id": "reconcile",
+      "run": "brigade outcome reconcile --target ."
+    }
+  ]
+}

--- a/tests/test_memory_cmd.py
+++ b/tests/test_memory_cmd.py
@@ -1247,6 +1247,32 @@ def test_memory_care_init_with_runbooks_pin_failure_leaves_no_config_or_partial_
     assert not runbook_dir.exists() or list(runbook_dir.glob("*.json")) == []
 
 
+def test_memory_care_force_reinit_pin_failure_preserves_existing_runbooks_and_config(
+    tmp_path, monkeypatch, capsys
+):
+    assert memory_cmd.init(target=tmp_path, force=True, with_runbooks=True) == 0
+    capsys.readouterr()
+
+    config_path = tmp_path / ".brigade" / "memory-care.toml"
+    config_path.write_text(config_path.read_text(encoding="utf-8") + "# user marker\n", encoding="utf-8")
+    saved_config = config_path.read_bytes()
+    saved_runbooks = {
+        name: (_memory_care_runbook_dir(tmp_path) / name).read_bytes() for name in MEMORY_CARE_RUNBOOK_NAMES
+    }
+
+    def _fail_pin(_target, _payload):
+        return None, "runbook step 1 argv[0] could not be resolved: brigade"
+
+    monkeypatch.setattr(runbook_cmd, "_pin_payload_from_runbook", _fail_pin)
+
+    assert memory_cmd.init(target=tmp_path, force=True, with_runbooks=True) == 2
+    assert "could not be resolved" in capsys.readouterr().err
+
+    assert config_path.read_bytes() == saved_config
+    for name, payload in saved_runbooks.items():
+        assert (_memory_care_runbook_dir(tmp_path) / name).read_bytes() == payload
+
+
 def test_memory_care_init_with_runbooks_writes_three_pinned_templates(tmp_path, capsys):
     assert memory_cmd.init(target=tmp_path, force=True, with_runbooks=True) == 0
     captured = capsys.readouterr()

--- a/tests/test_memory_cmd.py
+++ b/tests/test_memory_cmd.py
@@ -1,10 +1,93 @@
 import json
+import shlex
 from datetime import date, datetime, timezone
+from pathlib import Path
+
+import pytest
 
 from brigade import cli
 from brigade import dogfood_cmd
 from brigade import memory_cmd
+from brigade import runbook_cmd
 from brigade import work_cmd
+from brigade.templates import template_root
+
+MEMORY_CARE_RUNBOOK_NAMES = memory_cmd.MEMORY_CARE_RUNBOOK_NAMES
+
+EXPECTED_RUNBOOK_STEP_FRAGMENTS = {
+    "daily-care-pass.json": ("memory care scan", "memory care import-issues"),
+    "ingest-sweep.json": ("handoff lint", "ingest"),
+    "weekly-outcome-ratchet.json": ("outcome rank", "outcome reconcile"),
+}
+
+_MODEL_DISPATCH_KEYS = frozenset(
+    {
+        "model",
+        "model_dispatch",
+        "model_seat",
+        "worker",
+        "worker_dispatch",
+        "worker_seat",
+        "seat",
+        "roster",
+        "agent",
+        "harness",
+        "budget_gate",
+        "dispatch",
+    }
+)
+
+_SCHEDULER_KEYS = frozenset(
+    {
+        "scheduler",
+        "schedule",
+        "cron",
+        "crontab",
+        "timer",
+        "systemd",
+    }
+)
+
+
+def _memory_care_runbook_dir(target):
+    return target / ".brigade" / "memory-care" / "runbooks"
+
+
+def _load_memory_care_runbooks(target):
+    runbook_dir = _memory_care_runbook_dir(target)
+    return {name: json.loads((runbook_dir / name).read_text()) for name in MEMORY_CARE_RUNBOOK_NAMES}
+
+
+def _bundled_memory_care_runbook_dir() -> Path:
+    return template_root() / "memory-care" / "runbooks"
+
+
+def _assert_mechanical_template_shape(payload: dict, *, expect_pins: bool) -> None:
+    forbidden = _MODEL_DISPATCH_KEYS | _SCHEDULER_KEYS
+    for key in forbidden:
+        assert key not in payload
+    assert payload.get("allowed_commands") == ["brigade"]
+    steps = payload.get("steps")
+    assert isinstance(steps, list) and steps
+    for step in steps:
+        assert isinstance(step, dict)
+        for key in forbidden:
+            assert key not in step
+        tokens = shlex.split(step["run"])
+        assert tokens and Path(tokens[0]).name == "brigade"
+    if expect_pins:
+        pins = payload.get("pins")
+        assert isinstance(pins, list) and pins
+        brigade_pins = [pin for pin in pins if pin.get("command") == "brigade"]
+        assert brigade_pins
+        for pin in brigade_pins:
+            assert isinstance(pin.get("sha256"), str) and pin["sha256"].strip()
+    else:
+        assert "pins" not in payload
+
+
+def _assert_mechanical_brigade_only_runbook(payload):
+    _assert_mechanical_template_shape(payload, expect_pins=True)
 
 
 def _write_card(path, frontmatter, body="Body.\n"):
@@ -444,14 +527,28 @@ def test_memory_care_cli(tmp_path, monkeypatch):
     monkeypatch.setattr(memory_cmd, "status", fake_status)
     monkeypatch.setattr(memory_cmd, "doctor", fake_doctor)
     monkeypatch.setattr(memory_cmd, "import_issues", fake_import)
-    assert cli.main(["memory", "care", "init", "--target", str(tmp_path), "--force", "--no-gitignore"]) == 0
+    assert (
+        cli.main(
+            [
+                "memory",
+                "care",
+                "init",
+                "--target",
+                str(tmp_path),
+                "--force",
+                "--no-gitignore",
+                "--with-runbooks",
+            ]
+        )
+        == 0
+    )
     assert cli.main(["memory", "care", "scan", "--target", str(tmp_path), "--json"]) == 0
     assert cli.main(["memory", "care", "plan-fixes", "--target", str(tmp_path), "--json"]) == 0
     assert cli.main(["memory", "care", "status", "--target", str(tmp_path), "--json"]) == 0
     assert cli.main(["memory", "care", "doctor", "--target", str(tmp_path), "--json"]) == 0
     assert cli.main(["memory", "care", "import-issues", "--target", str(tmp_path), "--dry-run", "--json"]) == 0
     assert seen == [
-        ("init", {"target": tmp_path, "force": True, "update_gitignore": False}),
+        ("init", {"target": tmp_path, "force": True, "update_gitignore": False, "with_runbooks": True}),
         ("scan", {"target": tmp_path, "json_output": True}),
         ("plan-fixes", {"target": tmp_path, "json_output": True}),
         ("status", {"target": tmp_path, "json_output": True}),
@@ -1106,3 +1203,88 @@ def test_memory_care_archive_candidates_from_legacy_scan_without_evidence_pointe
     assert candidate["age_days"] == 61
     assert candidate["evidence_pointers"] == []
     assert candidate["approval_required"] is True
+
+
+def test_memory_care_bundled_runbook_templates_are_valid():
+    """Packaged templates must stay mechanical, brigade-only, and model-free (#760)."""
+    template_dir = _bundled_memory_care_runbook_dir()
+    assert sorted(path.name for path in template_dir.glob("*.json")) == sorted(MEMORY_CARE_RUNBOOK_NAMES)
+
+    for name in MEMORY_CARE_RUNBOOK_NAMES:
+        path = template_dir / name
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        assert payload.get("id") == Path(name).stem
+        _assert_mechanical_template_shape(payload, expect_pins=False)
+
+        validated, error = runbook_cmd._read_runbook(path, require_pin_hashes=False)
+        assert validated is not None, error
+        assert error is None
+
+        runs = [step["run"] for step in payload["steps"]]
+        for fragment in EXPECTED_RUNBOOK_STEP_FRAGMENTS[name]:
+            assert any(fragment in run for run in runs), f"{name} missing step containing {fragment!r}"
+
+
+def test_memory_care_init_without_runbooks_writes_no_templates(tmp_path):
+    assert memory_cmd.init(target=tmp_path, force=True) == 0
+    runbook_dir = _memory_care_runbook_dir(tmp_path)
+    assert not runbook_dir.exists() or list(runbook_dir.glob("*.json")) == []
+
+
+def test_memory_care_init_with_runbooks_pin_failure_leaves_no_config_or_partial_runbooks(
+    tmp_path, monkeypatch, capsys
+):
+    def _fail_pin(_target, _payload):
+        return None, "runbook step 1 argv[0] could not be resolved: brigade"
+
+    monkeypatch.setattr(runbook_cmd, "_pin_payload_from_runbook", _fail_pin)
+
+    assert memory_cmd.init(target=tmp_path, with_runbooks=True) == 2
+    assert "could not be resolved" in capsys.readouterr().err
+
+    assert not (tmp_path / ".brigade" / "memory-care.toml").exists()
+    runbook_dir = _memory_care_runbook_dir(tmp_path)
+    assert not runbook_dir.exists() or list(runbook_dir.glob("*.json")) == []
+
+
+def test_memory_care_init_with_runbooks_writes_three_pinned_templates(tmp_path, capsys):
+    assert memory_cmd.init(target=tmp_path, force=True, with_runbooks=True) == 0
+    captured = capsys.readouterr()
+    assert "memory_care_runbooks:" in captured.out
+
+    runbook_dir = _memory_care_runbook_dir(tmp_path)
+    assert sorted(path.name for path in runbook_dir.glob("*.json")) == sorted(MEMORY_CARE_RUNBOOK_NAMES)
+
+    runbooks = _load_memory_care_runbooks(tmp_path)
+    for name, payload in runbooks.items():
+        _assert_mechanical_brigade_only_runbook(payload)
+        for fragment in EXPECTED_RUNBOOK_STEP_FRAGMENTS[name]:
+            assert any(fragment in step["run"] for step in payload["steps"])
+
+    for name in MEMORY_CARE_RUNBOOK_NAMES:
+        assert runbook_cmd.plan(target=tmp_path, runbook=runbook_dir / name, json_output=True) == 0
+        plan = json.loads(capsys.readouterr().out)
+        assert plan["policy_valid"] is True
+
+
+def test_memory_care_init_with_runbooks_is_idempotent(tmp_path):
+    assert memory_cmd.init(target=tmp_path, force=True, with_runbooks=True) == 0
+    first = {name: (_memory_care_runbook_dir(tmp_path) / name).read_bytes() for name in MEMORY_CARE_RUNBOOK_NAMES}
+
+    assert memory_cmd.init(target=tmp_path, force=True, with_runbooks=True) == 0
+    second = {name: (_memory_care_runbook_dir(tmp_path) / name).read_bytes() for name in MEMORY_CARE_RUNBOOK_NAMES}
+
+    assert first == second
+
+
+def test_memory_care_init_parser_exposes_with_runbooks_flag(capsys):
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["memory", "care", "init", "--help"])
+    assert exc.value.code == 0
+    assert "--with-runbooks" in capsys.readouterr().out
+
+    parser = cli._build_parser()
+    ns = parser.parse_args(["memory", "care", "init", "--with-runbooks"])
+    assert ns.with_runbooks is True
+    ns_default = parser.parse_args(["memory", "care", "init"])
+    assert ns_default.with_runbooks is False

--- a/tests/test_memory_cmd.py
+++ b/tests/test_memory_cmd.py
@@ -1231,9 +1231,7 @@ def test_memory_care_init_without_runbooks_writes_no_templates(tmp_path):
     assert not runbook_dir.exists() or list(runbook_dir.glob("*.json")) == []
 
 
-def test_memory_care_init_with_runbooks_pin_failure_leaves_no_config_or_partial_runbooks(
-    tmp_path, monkeypatch, capsys
-):
+def test_memory_care_init_with_runbooks_pin_failure_leaves_no_config_or_partial_runbooks(tmp_path, monkeypatch, capsys):
     def _fail_pin(_target, _payload):
         return None, "runbook step 1 argv[0] could not be resolved: brigade"
 
@@ -1247,9 +1245,7 @@ def test_memory_care_init_with_runbooks_pin_failure_leaves_no_config_or_partial_
     assert not runbook_dir.exists() or list(runbook_dir.glob("*.json")) == []
 
 
-def test_memory_care_force_reinit_pin_failure_preserves_existing_runbooks_and_config(
-    tmp_path, monkeypatch, capsys
-):
+def test_memory_care_force_reinit_pin_failure_preserves_existing_runbooks_and_config(tmp_path, monkeypatch, capsys):
     assert memory_cmd.init(target=tmp_path, force=True, with_runbooks=True) == 0
     capsys.readouterr()
 

--- a/tests/test_roadmap_cmd.py
+++ b/tests/test_roadmap_cmd.py
@@ -1,6 +1,8 @@
 import json
 from pathlib import Path
 
+import pytest
+
 from brigade import cli
 from brigade import roadmap_cmd
 
@@ -300,3 +302,14 @@ def test_command_inventory_marks_extras_gated_commands(tmp_path):
     assert "- `brigade work brief`\n" in inventory
     # the marker is explained once in the header
     assert "brigade extras on" in inventory
+
+
+def test_command_inventory_includes_memory_care_init_with_runbooks_flag(tmp_path, capsys):
+    payload = roadmap_cmd.command_contract_payload(tmp_path)
+    assert "brigade memory care init" in payload["cli_commands"]
+    assert "- `brigade memory care init`" in payload["expected_inventory"]
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["memory", "care", "init", "--help"])
+    assert exc.value.code == 0
+    assert "--with-runbooks" in capsys.readouterr().out


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

Ship the mechanical memory-care runbook pack so a fresh workspace can install scheduled, model-free maintenance jobs without inventing them.

`brigade memory care init --with-runbooks` writes three pinned templates under `.brigade/memory-care/runbooks/`:

- `daily-care-pass.json` — `memory care scan` + `import-issues`
- `ingest-sweep.json` — `handoff lint --strict` + `ingest --promote-cards --route-documents`
- `weekly-outcome-ratchet.json` — `outcome rank` + `outcome reconcile` (dry-run by default)

Each template is restricted via `allowed_commands: ["brigade"]` and gets binary pins materialized at write time from the resolved `brigade` path. Judgment jobs (inbox drain, card refresh) stay in #766 as registry skills.

Fixes #760

## Type of change

- [x] Surface change (new harness, depth, include, or breaking template/ingester change) — opened an issue first per CONTRIBUTING.md

(Issue #760 already scoped this pack; no new top-level harness/depth/include.)

## Checklist

- [x] `pytest -q` passes locally (`./scripts/verify`: 6059 passed, 3 skipped; coverage 83.13%)
- [x] Added or updated tests covering the change
- [x] Updated the `Unreleased` section of `CHANGELOG.md` for any user-visible effect
- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths in code, templates, tests, or this PR
- [x] No new runtime dependencies
- [x] Conventional commit messages

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fcdfd5a7-e0ee-42c4-a31f-00421b1b4f62?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fcdfd5a7-e0ee-42c4-a31f-00421b1b4f62&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

