### PR TITLE
fix(roadmap): ignore rejected command alternatives

### DIFF
--- a/src/brigade/roadmap_cmd.py
+++ b/src/brigade/roadmap_cmd.py
@@ -419,6 +419,20 @@ def _commands_from_text(text: str) -> set[str]:
     commands: set[str] = set()
     command_re = re.compile(r"\bbrigade\b(?P<tail>\s+[^\n`]*)")
 
+    def is_rejected_design_section(headings: list[str]) -> bool:
+        """Return whether headings frame commands as rejected design ideas."""
+        for heading in headings:
+            if not heading:
+                continue
+            lowered = heading.casefold()
+            if any(marker in lowered for marker in ("considered and cut", "rejected", "discarded")):
+                return True
+            if re.match(r"alternative\s+[a-z](?:\s*[—\-–:]|\b)", lowered) and not any(
+                marker in lowered for marker in ("recommended", "selected", "chosen")
+            ):
+                return True
+        return False
+
     def add_command(raw_command: str, *, require_known_head: bool = False) -> None:
         match = command_re.search(raw_command)
         if not match:
@@ -438,16 +452,31 @@ def _commands_from_text(text: str) -> set[str]:
                 return
             commands.add(" ".join(["brigade", *words]))
 
-    for match in re.finditer(r"`([^\n`]*\bbrigade\b[^\n`]*)`", text):
-        add_command(match.group(1))
     in_fence = False
+    headings: list[str] = []
     for raw_line in text.splitlines():
         stripped = raw_line.strip()
+        heading_match = re.match(r"^(#{1,6})\s+(.+)$", stripped)
+        if heading_match and not in_fence:
+            level = len(heading_match.group(1))
+            while len(headings) < level - 1:
+                headings.append("")
+            headings[level - 1 :] = [heading_match.group(2).strip()]
+        rejected_design = is_rejected_design_section(headings)
         if stripped.startswith("```"):
             in_fence = not in_fence
             continue
-        if in_fence and stripped.startswith("brigade "):
-            add_command(stripped, require_known_head=True)
+        if rejected_design:
+            continue
+        if in_fence:
+            if stripped.startswith("brigade "):
+                add_command(stripped, require_known_head=True)
+            else:
+                for match in re.finditer(r"`([^\n`]*\bbrigade\b[^\n`]*)`", raw_line):
+                    add_command(match.group(1), require_known_head=True)
+        else:
+            for match in re.finditer(r"`([^\n`]*\bbrigade\b[^\n`]*)`", raw_line):
+                add_command(match.group(1))
     return commands
 
 

--- a/tests/test_roadmap_cmd.py
+++ b/tests/test_roadmap_cmd.py
@@ -87,8 +87,7 @@ def test_roadmap_audit_rejected_section_does_not_poison_later_sibling_headings(t
 def test_roadmap_audit_accepts_alternative_configuration_heading(tmp_path):
     (tmp_path / "ROADMAP.md").write_text("# Roadmap\n")
     (tmp_path / "README.md").write_text(
-        "## Alternative configuration\n\n"
-        "Use `brigade doctor` when wiring optional settings.\n"
+        "## Alternative configuration\n\nUse `brigade doctor` when wiring optional settings.\n"
     )
 
     payload = roadmap_cmd.audit_payload(tmp_path)
@@ -99,11 +98,7 @@ def test_roadmap_audit_accepts_alternative_configuration_heading(tmp_path):
 
 def test_roadmap_audit_extracts_inline_backtick_commands_inside_fenced_blocks(tmp_path):
     (tmp_path / "ROADMAP.md").write_text("# Roadmap\n")
-    (tmp_path / "README.md").write_text(
-        "```bash\n"
-        "prefix `brigade doctor` suffix\n"
-        "```\n"
-    )
+    (tmp_path / "README.md").write_text("```bash\nprefix `brigade doctor` suffix\n```\n")
 
     payload = roadmap_cmd.audit_payload(tmp_path)
 

--- a/tests/test_roadmap_cmd.py
+++ b/tests/test_roadmap_cmd.py
@@ -49,6 +49,68 @@ def test_roadmap_audit_normalizes_parameterized_and_parent_commands(tmp_path):
     assert "brigade chat surfaces show surface-one" not in payload["missing_cli_commands"]
 
 
+def test_roadmap_audit_ignores_rejected_brigade_components_alternative(tmp_path):
+    (tmp_path / "ROADMAP.md").write_text("# Roadmap\n")
+    (tmp_path / "README.md").write_text(
+        "## Command Alternatives (Scouting)\n\n"
+        "### Alternative A — Top-level `brigade setup` (recommended)\n\n"
+        "Add `brigade setup` as a first-class top-level command.\n\n"
+        "### Alternative C — `brigade components` command group\n\n"
+        "Expose `brigade components install`, `status`, and `rollback` backed by the same engine.\n\n"
+        "Tradeoffs: adds CLI surface area before the current phase needs it.\n\n"
+        "**Recommendation:** Alternative A.\n"
+    )
+
+    payload = roadmap_cmd.audit_payload(tmp_path)
+
+    assert "brigade setup" in payload["documented_commands"]
+    assert not any(command.startswith("brigade components") for command in payload["documented_commands"])
+    assert not any(command.startswith("brigade components") for command in payload["missing_cli_commands"])
+
+
+def test_roadmap_audit_rejected_section_does_not_poison_later_sibling_headings(tmp_path):
+    (tmp_path / "ROADMAP.md").write_text("# Roadmap\n")
+    (tmp_path / "README.md").write_text(
+        "## Rejected design ideas\n\n"
+        "### Alternative B — discarded `brigade junk` path\n\n"
+        "This section names a rejected command.\n\n"
+        "## Documented commands\n\n"
+        "Run `brigade doctor` for health checks.\n"
+    )
+
+    payload = roadmap_cmd.audit_payload(tmp_path)
+
+    assert "brigade doctor" in payload["documented_commands"]
+    assert "brigade junk" not in payload["documented_commands"]
+
+
+def test_roadmap_audit_accepts_alternative_configuration_heading(tmp_path):
+    (tmp_path / "ROADMAP.md").write_text("# Roadmap\n")
+    (tmp_path / "README.md").write_text(
+        "## Alternative configuration\n\n"
+        "Use `brigade doctor` when wiring optional settings.\n"
+    )
+
+    payload = roadmap_cmd.audit_payload(tmp_path)
+
+    assert "brigade doctor" in payload["documented_commands"]
+    assert "brigade doctor" not in payload["missing_cli_commands"]
+
+
+def test_roadmap_audit_extracts_inline_backtick_commands_inside_fenced_blocks(tmp_path):
+    (tmp_path / "ROADMAP.md").write_text("# Roadmap\n")
+    (tmp_path / "README.md").write_text(
+        "```bash\n"
+        "prefix `brigade doctor` suffix\n"
+        "```\n"
+    )
+
+    payload = roadmap_cmd.audit_payload(tmp_path)
+
+    assert "brigade doctor" in payload["documented_commands"]
+    assert "brigade doctor" not in payload["missing_cli_commands"]
+
+
 def test_roadmap_audit_json_and_imports(tmp_path, capsys):
     (tmp_path / "ROADMAP.md").write_text("# Roadmap\n")
     (tmp_path / "README.md").write_text("Run `brigade missing localcommand`.\n")


### PR DESCRIPTION
## Summary

- Ignore documented Brigade commands inside rejected design alternatives.
- Preserve commands in accepted prose, examples, code fences, and sibling sections in documents without a Markdown H1.
- Avoid suppressing legitimate sections such as `Alternative configuration`.

Fixes #681

## Verification

`brigade work verify run --target . --command ".venv/bin/python -m pytest -q tests/test_roadmap_cmd.py tests/test_roadmap_inventory_cmd.py" --capture brigade-work`

Result: 16 passed. The Opus follow-up review approved the heading-context and fenced-command behavior.
