### PR TITLE
docs: scheduled memory care recipes (cron, systemd, CI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   configurable via `run_lock_wait_seconds` in `.brigade/config.json`; use
   `--wait=0` to fail fast when that default is set.
 
+### Added
+- `docs/scheduled-care.md`: copy-paste cron, systemd timer, and GitHub Actions recipes for the memory-care loop (daily care, ingest sweep, weekly outcome ratchet, daily observability, nightly ops). (#764)
+
 ## [0.26.0] - 2026-08-05
 
 ### Added

--- a/docs/memory-care.md
+++ b/docs/memory-care.md
@@ -74,3 +74,5 @@ Queue entries include card identity, issue type, severity, priority, safe summar
 ## Boundary
 
 Memory care does not run a scheduler, mutate canonical memory, perform remote sync, or promote imports automatically. Card edits stay explicit: routine scan and plan commands never write card files; only `brigade memory care backfill --apply` may add derived frontmatter, with a receipt. Refreshes stay explicit through reviewed work tasks or the existing Memory Handoff flow. Scheduling those care commands is the operator's job: see the [execution model](execution-model.md).
+
+For operator-owned cron, systemd, and CI recipes, see [scheduled care](scheduled-care.md).

--- a/docs/memory-care.md
+++ b/docs/memory-care.md
@@ -12,6 +12,7 @@ brigade memory care backfill
 brigade memory care status
 brigade memory care doctor
 brigade memory care import-issues
+brigade memory care closeout
 ```
 
 `init` writes `.brigade/memory-care.toml`. The config is host-local and should stay gitignored.
@@ -48,11 +49,11 @@ Memory care can emit:
 
 Contradiction detection is deliberately conservative. Brigade only flags explicit duplicate card identities or metadata hints, not LLM-inferred factual conflicts.
 
-`status` and JSON output summarize freshness metadata coverage: reviewed dates present, missing, and stale; freshness dates present, missing, and expired; confidence distribution; and evidence metadata present or missing. These checks only explain review needs. Brigade does not edit memory cards automatically.
+`status` and JSON output summarize freshness metadata coverage: reviewed dates present, missing, and stale, freshness dates present, missing, and expired, confidence distribution, and evidence metadata present or missing. These checks only explain review needs. Brigade does not edit memory cards automatically.
 
 ## Safe Fix Planning
 
-`brigade memory care backfill` handles the bulk version of the same repair for setups whose cards predate the freshness convention. It finds cards with frontmatter but no reviewed or freshness dates, derives `last_reviewed` from each card file's last git commit date (the last time anyone touched the fact; file mtime outside git, labeled as the lower-confidence source), and proposes `fresh_until` as the reviewed date plus the configured stale window. It is dry-run by default and prints the full plan; `--apply` writes the derived values into card frontmatter, never overwrites an existing value, and records a receipt under `.brigade/memory-care/backfills/`. Backfilled dates are honest rather than flattering: an old card lands as stale immediately, which is the point, since the scan then ranks the refresh queue by real age instead of reporting unknowable gaps.
+`brigade memory care backfill` handles the bulk version of the same repair for setups whose cards predate the freshness convention. It finds cards with frontmatter but no reviewed or freshness dates, derives `last_reviewed` from each card file's last git commit date (the last time anyone touched the fact, or file mtime outside git, labeled as the lower-confidence source), and proposes `fresh_until` as the reviewed date plus the configured stale window. It is dry-run by default and prints the full plan. `--apply` writes the derived values into card frontmatter, never overwrites an existing value, and records a receipt under `.brigade/memory-care/backfills/`. Backfilled dates are honest rather than flattering: an old card lands as stale immediately, which is the point, since the scan then ranks the refresh queue by real age instead of reporting unknowable gaps.
 
 `brigade memory care plan-fixes` reads the latest scan and builds a planning-only view for low-risk metadata repairs such as missing reviewed dates or missing freshness dates. The command never writes card files. Plan items include candidate metadata fields, source fingerprints, blockers, and the next review command. Reviewed-date plans are blocked until the operator checks current evidence. Freshness-date plans are blocked until the operator chooses an appropriate date or documents why the card should not expire.
 
@@ -73,6 +74,6 @@ Queue entries include card identity, issue type, severity, priority, safe summar
 
 ## Boundary
 
-Memory care does not run a scheduler, mutate canonical memory, perform remote sync, or promote imports automatically. Card edits stay explicit: routine scan and plan commands never write card files; only `brigade memory care backfill --apply` may add derived frontmatter, with a receipt. Refreshes stay explicit through reviewed work tasks or the existing Memory Handoff flow. Scheduling those care commands is the operator's job: see the [execution model](execution-model.md).
+Memory care does not run a scheduler, mutate canonical memory, perform remote sync, or promote imports automatically. Card edits stay explicit: routine scan and plan commands never write card files. Only `brigade memory care backfill --apply` may add derived frontmatter, with a receipt. Refreshes stay explicit through reviewed work tasks or the existing Memory Handoff flow. Scheduling those care commands is the operator's job: see the [execution model](execution-model.md).
 
 For operator-owned cron, systemd, and CI recipes, see [scheduled care](scheduled-care.md).

--- a/docs/scheduled-care.md
+++ b/docs/scheduled-care.md
@@ -1,0 +1,613 @@
+# Scheduled Memory Care
+
+The schedule belongs to the operator; Brigade only runs when invoked. Brigade does not install cron jobs, systemd timers, GitHub Actions workflows, or any other scheduler. Copy one of the recipes below into your own crontab, user timer, or CI job after `brigade init` wires the target.
+
+Prerequisites:
+
+```bash
+pipx install brigade-cli
+pipx ensurepath   # open a new shell, or set PATH manually (see Scheduler wiring)
+brigade init --depth repo --harnesses codex --target .
+brigade memory care init --target .
+brigade daily init --target .
+brigade extras on   # once per machine; required for center report and runbook commands
+```
+
+Replace `WORKSPACE` with the absolute path to your Brigade-wired repo or operator workspace. Every `brigade` command below assumes `cd WORKSPACE` first, so `--target .` resolves correctly.
+
+Related docs: [memory care](memory-care.md), [scanner registry](scanner-registry.md), [operator center](operator-center.md), [agents guide](agents-guide.md).
+
+## Scheduler wiring
+
+### PATH
+
+Cron and systemd user units do not load your shell profile. After `pipx install brigade-cli`, resolve the binary once:
+
+```bash
+command -v brigade   # typically ~/.local/bin/brigade
+```
+
+Put that directory on `PATH` in every scheduled invocation.
+
+Crontab header (once per crontab file):
+
+```cron
+PATH=/home/you/.local/bin:/usr/local/bin:/usr/bin:/bin
+```
+
+systemd `[Service]` block (on every Brigade unit):
+
+```ini
+Environment=PATH=/home/you/.local/bin:/usr/local/bin:/usr/bin:/bin
+```
+
+Replace `/home/you` with your account home directory. Cron cannot expand `$HOME`.
+
+### Tracked runbooks
+
+`brigade init` gitignores `.brigade/` by default. Nightly runbooks referenced from CI must be committed. Inside the managed brigade gitignore block, add:
+
+```gitignore
+!.brigade/runbooks/
+!.brigade/runbooks/**
+```
+
+Then commit `.brigade/runbooks/nightly-maintenance.json`. Runtime receipts under `.brigade/runbooks/runs/` stay gitignored.
+
+## GitHub Actions bootstrap
+
+Fresh checkouts have no `.brigade/` runtime state. Scheduled workflows need a bootstrap on every run and a cache when you want scan queues, receipts, or reports to accumulate across runs.
+
+Use this step block before the recipe commands in each workflow below:
+
+```yaml
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: python -m pip install --upgrade pip pipx
+      - run: pipx install brigade-cli
+      - run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Bootstrap Brigade
+        run: |
+          brigade init --depth repo --harnesses codex --target .
+          brigade memory care init --target .
+          brigade daily init --target .
+          brigade extras on
+      - uses: actions/cache@v4
+        with:
+          path: .brigade
+          key: brigade-${{ github.workflow }}-${{ github.ref_name }}-${{ hashFiles('.gitignore') }}
+          restore-keys: |
+            brigade-${{ github.workflow }}-${{ github.ref_name }}-
+```
+
+Adjust `--depth` and `--harnesses` to match your repo. `brigade init` is idempotent on an already-wired checkout.
+
+## Daily care pass
+
+Scan local memory cards for decay, import flagged items into the work inbox, and read the daily brief.
+
+```bash
+brigade memory care scan --target .
+brigade memory care import-issues --target .
+brigade work brief --target .
+```
+
+Optional follow-ups when the scan surfaces metadata gaps or stale review queues:
+
+```bash
+brigade memory care plan-fixes --target .
+brigade memory care backfill --target .
+brigade memory care backfill --apply --target .
+brigade memory care closeout --target .
+```
+
+Foreground batch alternative when scanner producers are configured in `.brigade/scanners.toml`:
+
+```bash
+brigade work scanners init --target .
+brigade work scanners run handoff-ingest --target .
+brigade work sweep --scanner handoff-ingest --target .
+```
+
+On a workspace with several enabled producers, `brigade work scanners run --due --target .` and `brigade work sweep --target .` run the full due batch. Disable scanners in `.brigade/scanners.toml` until their output paths exist.
+
+### Crontab
+
+```cron
+PATH=/home/you/.local/bin:/usr/local/bin:/usr/bin:/bin
+15 6 * * * cd WORKSPACE && brigade memory care scan --target . && brigade memory care import-issues --target . && brigade work brief --target .
+```
+
+### systemd user timer
+
+`~/.config/systemd/user/brigade-daily-care.service`:
+
+```ini
+[Unit]
+Description=Brigade daily memory care pass
+
+[Service]
+Type=oneshot
+WorkingDirectory=WORKSPACE
+Environment=PATH=/home/you/.local/bin:/usr/local/bin:/usr/bin:/bin
+ExecStart=/bin/sh -c 'brigade memory care scan --target . && brigade memory care import-issues --target . && brigade work brief --target .'
+```
+
+`~/.config/systemd/user/brigade-daily-care.timer`:
+
+```ini
+[Unit]
+Description=Run Brigade daily memory care at 06:15 local time
+
+[Timer]
+OnCalendar=*-*-* 06:15:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+Enable with `systemctl --user daemon-reload`, then `systemctl --user enable --now brigade-daily-care.timer`.
+
+### GitHub Actions
+
+`.github/workflows/brigade-daily-care.yml`:
+
+```yaml
+name: brigade-daily-care
+on:
+  schedule:
+    - cron: '15 6 * * *'
+  workflow_dispatch:
+jobs:
+  daily-care:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: python -m pip install --upgrade pip pipx
+      - run: pipx install brigade-cli
+      - run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Bootstrap Brigade
+        run: |
+          brigade init --depth repo --harnesses codex --target .
+          brigade memory care init --target .
+          brigade daily init --target .
+          brigade extras on
+      - uses: actions/cache@v4
+        with:
+          path: .brigade
+          key: brigade-${{ github.workflow }}-${{ github.ref_name }}-${{ hashFiles('.gitignore') }}
+          restore-keys: |
+            brigade-${{ github.workflow }}-${{ github.ref_name }}-
+      - run: brigade memory care scan --target .
+      - run: brigade memory care import-issues --target .
+      - run: brigade work brief --target .
+```
+
+## Ingest sweep
+
+Lint pending handoffs, then ingest safe notes into durable memory.
+
+```bash
+brigade handoff lint --strict --target .
+brigade ingest --promote-cards --route-documents --target .
+```
+
+Run this on a shorter cadence when writer harnesses produce handoffs throughout the day. A runbook with `allowed_commands` restricted to `brigade` is the one-line cron shape once you pin the sequence (see [technical guide](technical-guide.md)).
+
+### Crontab
+
+```cron
+PATH=/home/you/.local/bin:/usr/local/bin:/usr/bin:/bin
+*/30 * * * * cd WORKSPACE && brigade handoff lint --strict --target . && brigade ingest --promote-cards --route-documents --target .
+```
+
+### systemd user timer
+
+`~/.config/systemd/user/brigade-ingest-sweep.service`:
+
+```ini
+[Unit]
+Description=Brigade handoff ingest sweep
+
+[Service]
+Type=oneshot
+WorkingDirectory=WORKSPACE
+Environment=PATH=/home/you/.local/bin:/usr/local/bin:/usr/bin:/bin
+ExecStart=/bin/sh -c 'brigade handoff lint --strict --target . && brigade ingest --promote-cards --route-documents --target .'
+```
+
+`~/.config/systemd/user/brigade-ingest-sweep.timer`:
+
+```ini
+[Unit]
+Description=Run Brigade ingest sweep every 30 minutes
+
+[Timer]
+OnCalendar=*:0/30
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+### GitHub Actions
+
+`.github/workflows/brigade-ingest-sweep.yml`:
+
+```yaml
+name: brigade-ingest-sweep
+on:
+  schedule:
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
+jobs:
+  ingest-sweep:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: python -m pip install --upgrade pip pipx
+      - run: pipx install brigade-cli
+      - run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Bootstrap Brigade
+        run: |
+          brigade init --depth repo --harnesses codex --target .
+          brigade memory care init --target .
+          brigade daily init --target .
+          brigade extras on
+      - uses: actions/cache@v4
+        with:
+          path: .brigade
+          key: brigade-${{ github.workflow }}-${{ github.ref_name }}-${{ hashFiles('.gitignore') }}
+          restore-keys: |
+            brigade-${{ github.workflow }}-${{ github.ref_name }}-
+      - run: brigade handoff lint --strict --target .
+      - run: brigade ingest --promote-cards --route-documents --target .
+```
+
+## Weekly outcome ratchet
+
+Rank verified-learning outcomes, then reconcile skill promotion state. `reconcile` is dry-run by default; pass `--apply` only when you intend to install or roll back registry skills.
+
+```bash
+brigade outcome rank --target .
+brigade outcome reconcile --target .
+```
+
+Deliberate promotion or rollback:
+
+```bash
+brigade outcome reconcile --apply --target .
+```
+
+Schedule rank first, then reconcile 30 to 60 minutes later so new verify receipts land before decisions run.
+
+### Crontab
+
+```cron
+PATH=/home/you/.local/bin:/usr/local/bin:/usr/bin:/bin
+0 7 * * 1 cd WORKSPACE && brigade outcome rank --target .
+30 7 * * 1 cd WORKSPACE && brigade outcome reconcile --target .
+```
+
+To apply promotions automatically after review:
+
+```cron
+30 7 * * 1 cd WORKSPACE && brigade outcome reconcile --apply --target .
+```
+
+### systemd user timer
+
+`~/.config/systemd/user/brigade-outcome-rank.service`:
+
+```ini
+[Unit]
+Description=Brigade weekly outcome rank
+
+[Service]
+Type=oneshot
+WorkingDirectory=WORKSPACE
+Environment=PATH=/home/you/.local/bin:/usr/local/bin:/usr/bin:/bin
+ExecStart=brigade outcome rank --target .
+```
+
+`~/.config/systemd/user/brigade-outcome-rank.timer`:
+
+```ini
+[Unit]
+Description=Run Brigade outcome rank Monday 07:00 local time
+
+[Timer]
+OnCalendar=Mon *-*-* 07:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+`~/.config/systemd/user/brigade-outcome-reconcile.service`:
+
+```ini
+[Unit]
+Description=Brigade weekly outcome reconcile
+
+[Service]
+Type=oneshot
+WorkingDirectory=WORKSPACE
+Environment=PATH=/home/you/.local/bin:/usr/local/bin:/usr/bin:/bin
+ExecStart=brigade outcome reconcile --target .
+```
+
+`~/.config/systemd/user/brigade-outcome-reconcile.timer`:
+
+```ini
+[Unit]
+Description=Run Brigade outcome reconcile Monday 07:30 local time
+
+[Timer]
+OnCalendar=Mon *-*-* 07:30:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+Add `--apply` to the reconcile `ExecStart` line only after you accept automatic skill install and rollback.
+
+### GitHub Actions
+
+`.github/workflows/brigade-outcome-ratchet.yml`:
+
+```yaml
+name: brigade-outcome-ratchet
+on:
+  schedule:
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+jobs:
+  outcome-rank:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: python -m pip install --upgrade pip pipx
+      - run: pipx install brigade-cli
+      - run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Bootstrap Brigade
+        run: |
+          brigade init --depth repo --harnesses codex --target .
+          brigade memory care init --target .
+          brigade daily init --target .
+          brigade extras on
+      - uses: actions/cache@v4
+        with:
+          path: .brigade
+          key: brigade-${{ github.workflow }}-${{ github.ref_name }}-${{ hashFiles('.gitignore') }}
+          restore-keys: |
+            brigade-${{ github.workflow }}-${{ github.ref_name }}-
+      - run: brigade outcome rank --target .
+  outcome-reconcile:
+    needs: outcome-rank
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: python -m pip install --upgrade pip pipx
+      - run: pipx install brigade-cli
+      - run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Bootstrap Brigade
+        run: |
+          brigade init --depth repo --harnesses codex --target .
+          brigade memory care init --target .
+          brigade daily init --target .
+          brigade extras on
+      - uses: actions/cache@v4
+        with:
+          path: .brigade
+          key: brigade-${{ github.workflow }}-${{ github.ref_name }}-${{ hashFiles('.gitignore') }}
+          restore-keys: |
+            brigade-${{ github.workflow }}-${{ github.ref_name }}-
+      - run: brigade outcome reconcile --target .
+```
+
+## Daily observability
+
+Check handoff pipeline health, read the daily driver snapshot, and build the local operator report bundle. `center report build` is extras-gated; run `brigade extras on` once per machine or prefix with `BRIGADE_EXTRAS=1`.
+
+```bash
+brigade handoff doctor --target .
+brigade daily status --target .
+brigade center report build --target .
+```
+
+### Crontab
+
+```cron
+PATH=/home/you/.local/bin:/usr/local/bin:/usr/bin:/bin
+0 8 * * * cd WORKSPACE && brigade handoff doctor --target . && brigade daily status --target . && brigade center report build --target .
+```
+
+### systemd user timer
+
+`~/.config/systemd/user/brigade-daily-observability.service`:
+
+```ini
+[Unit]
+Description=Brigade daily observability pass
+
+[Service]
+Type=oneshot
+WorkingDirectory=WORKSPACE
+Environment=PATH=/home/you/.local/bin:/usr/local/bin:/usr/bin:/bin
+ExecStart=/bin/sh -c 'brigade handoff doctor --target . && brigade daily status --target . && brigade center report build --target .'
+```
+
+`~/.config/systemd/user/brigade-daily-observability.timer`:
+
+```ini
+[Unit]
+Description=Run Brigade daily observability at 08:00 local time
+
+[Timer]
+OnCalendar=*-*-* 08:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+### GitHub Actions
+
+`.github/workflows/brigade-daily-observability.yml`:
+
+```yaml
+name: brigade-daily-observability
+on:
+  schedule:
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+jobs:
+  observability:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: python -m pip install --upgrade pip pipx
+      - run: pipx install brigade-cli
+      - run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Bootstrap Brigade
+        run: |
+          brigade init --depth repo --harnesses codex --target .
+          brigade memory care init --target .
+          brigade daily init --target .
+          brigade extras on
+      - uses: actions/cache@v4
+        with:
+          path: .brigade
+          key: brigade-${{ github.workflow }}-${{ github.ref_name }}-${{ hashFiles('.gitignore') }}
+          restore-keys: |
+            brigade-${{ github.workflow }}-${{ github.ref_name }}-
+      - run: brigade handoff doctor --target .
+      - run: brigade daily status --target .
+      - run: brigade center report build --target .
+```
+
+## Nightly ops pass
+
+Run an approved maintenance runbook. Pin the steps you trust, restrict `allowed_commands` to `brigade`, and keep the JSON under `.brigade/runbooks/`. Commit the runbook and add the gitignore exceptions from [Tracked runbooks](#tracked-runbooks) when CI should run the same file.
+
+Example runbook at `.brigade/runbooks/nightly-maintenance.json`:
+
+```json
+{
+  "id": "nightly-maintenance",
+  "description": "Operator nightly maintenance pass.",
+  "approved": true,
+  "allowed_commands": ["brigade"],
+  "steps": [
+    {
+      "id": "daily-status",
+      "run": "brigade daily status --target .",
+      "timeout_seconds": 120
+    }
+  ]
+}
+```
+
+Run it (`runbook` is extras-gated; run `brigade extras on` once per machine or prefix with `BRIGADE_EXTRAS=1`):
+
+```bash
+brigade runbook run --approved --target . .brigade/runbooks/nightly-maintenance.json
+```
+
+### Crontab
+
+```cron
+PATH=/home/you/.local/bin:/usr/local/bin:/usr/bin:/bin
+0 4 * * * cd WORKSPACE && brigade runbook run --approved --target . .brigade/runbooks/nightly-maintenance.json
+```
+
+### systemd user timer
+
+`~/.config/systemd/user/brigade-nightly-ops.service`:
+
+```ini
+[Unit]
+Description=Brigade nightly maintenance runbook
+
+[Service]
+Type=oneshot
+WorkingDirectory=WORKSPACE
+Environment=PATH=/home/you/.local/bin:/usr/local/bin:/usr/bin:/bin
+ExecStart=brigade runbook run --approved --target . .brigade/runbooks/nightly-maintenance.json
+```
+
+`~/.config/systemd/user/brigade-nightly-ops.timer`:
+
+```ini
+[Unit]
+Description=Run Brigade nightly ops at 04:00 local time
+
+[Timer]
+OnCalendar=*-*-* 04:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+### GitHub Actions
+
+`.github/workflows/brigade-nightly-ops.yml`:
+
+```yaml
+name: brigade-nightly-ops
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+jobs:
+  nightly-ops:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: python -m pip install --upgrade pip pipx
+      - run: pipx install brigade-cli
+      - run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Bootstrap Brigade
+        run: |
+          brigade init --depth repo --harnesses codex --target .
+          brigade memory care init --target .
+          brigade daily init --target .
+          brigade extras on
+      - uses: actions/cache@v4
+        with:
+          path: .brigade
+          key: brigade-${{ github.workflow }}-${{ github.ref_name }}-${{ hashFiles('.gitignore') }}
+          restore-keys: |
+            brigade-${{ github.workflow }}-${{ github.ref_name }}-
+      - run: brigade runbook run --approved --target . .brigade/runbooks/nightly-maintenance.json
+```
+
+Commit the runbook JSON when you want CI to execute the same pinned steps as your laptop.
+
+## More recipes
+
+Add new sections here as adapters land. Future candidates include a beads reconcile pass once a `bd` adapter ships; follow the same crontab, systemd, and GitHub Actions shape as the recipes above.

--- a/docs/scheduled-care.md
+++ b/docs/scheduled-care.md
@@ -1,6 +1,6 @@
 # Scheduled Memory Care
 
-The schedule belongs to the operator; Brigade only runs when invoked. Brigade does not install cron jobs, systemd timers, GitHub Actions workflows, or any other scheduler. Copy one of the recipes below into your own crontab, user timer, or CI job after `brigade init` wires the target.
+The schedule belongs to the operator. Brigade only runs when invoked. Brigade does not install cron jobs, systemd timers, GitHub Actions workflows, or any other scheduler. Copy one of the recipes below into your own crontab, user timer, or CI job after `brigade init` wires the target.
 
 Prerequisites:
 
@@ -13,7 +13,7 @@ brigade daily init --target .
 brigade extras on   # once per machine; required for center report and runbook commands
 ```
 
-Replace `WORKSPACE` with the absolute path to your Brigade-wired repo or operator workspace. Every `brigade` command below assumes `cd WORKSPACE` first, so `--target .` resolves correctly.
+Replace `WORKSPACE` with the absolute path to your Brigade-wired repo or operator workspace. Every `brigade` command below assumes `cd` into that directory first, so `--target .` resolves correctly. In crontab lines, quote the path (`cd "WORKSPACE"`) so spaces and shell metacharacters do not break the job.
 
 Related docs: [memory care](memory-care.md), [scanner registry](scanner-registry.md), [operator center](operator-center.md), [agents guide](agents-guide.md).
 
@@ -43,6 +43,16 @@ Environment=PATH=/home/you/.local/bin:/usr/local/bin:/usr/bin:/bin
 
 Replace `/home/you` with your account home directory. Cron cannot expand `$HOME`.
 
+### systemd user timers
+
+User timers stop when you log out unless lingering is enabled. Run once per account:
+
+```bash
+sudo loginctl enable-linger "$USER"
+```
+
+Then `systemctl --user daemon-reload`, `systemctl --user enable --now <timer>.timer`, and `systemctl --user list-timers` to confirm the next fire time.
+
 ### Tracked runbooks
 
 `brigade init` gitignores `.brigade/` by default. Nightly runbooks referenced from CI must be committed. Inside the managed brigade gitignore block, add:
@@ -50,15 +60,16 @@ Replace `/home/you` with your account home directory. Cron cannot expand `$HOME`
 ```gitignore
 !.brigade/runbooks/
 !.brigade/runbooks/**
+.brigade/runbooks/runs/
 ```
 
-Then commit `.brigade/runbooks/nightly-maintenance.json`. Runtime receipts under `.brigade/runbooks/runs/` stay gitignored.
+The final line re-ignores runtime receipts after the `**` un-ignore. Then commit `.brigade/runbooks/nightly-maintenance.json`. Receipts under `.brigade/runbooks/runs/` stay out of git.
 
 ## GitHub Actions bootstrap
 
 Fresh checkouts have no `.brigade/` runtime state. Scheduled workflows need a bootstrap on every run and a cache when you want scan queues, receipts, or reports to accumulate across runs.
 
-Use this step block before the recipe commands in each workflow below:
+Use this step block before the recipe commands in each workflow below. Restore the `.brigade` cache before bootstrap so scan queues, receipts, and reports survive across runs:
 
 ```yaml
       - uses: actions/checkout@v4
@@ -68,19 +79,21 @@ Use this step block before the recipe commands in each workflow below:
       - run: python -m pip install --upgrade pip pipx
       - run: pipx install brigade-cli
       - run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - uses: actions/cache@v4
+        with:
+          path: .brigade
+          key: brigade-${{ github.workflow }}-${{ github.ref_name }}-${{ github.run_id }}
+          restore-keys: |
+            brigade-${{ github.workflow }}-${{ github.ref_name }}-
       - name: Bootstrap Brigade
         run: |
           brigade init --depth repo --harnesses codex --target .
           brigade memory care init --target .
           brigade daily init --target .
           brigade extras on
-      - uses: actions/cache@v4
-        with:
-          path: .brigade
-          key: brigade-${{ github.workflow }}-${{ github.ref_name }}-${{ hashFiles('.gitignore') }}
-          restore-keys: |
-            brigade-${{ github.workflow }}-${{ github.ref_name }}-
 ```
+
+The cache `key` includes `${{ github.run_id }}` so each run writes a fresh entry. `restore-keys` keeps the stable workflow/ref prefix so the latest prior `.brigade` state restores on the next run.
 
 Adjust `--depth` and `--harnesses` to match your repo. `brigade init` is idempotent on an already-wired checkout.
 
@@ -92,6 +105,7 @@ Scan local memory cards for decay, import flagged items into the work inbox, and
 brigade memory care scan --target .
 brigade memory care import-issues --target .
 brigade work brief --target .
+brigade memory care closeout --target .
 ```
 
 Optional follow-ups when the scan surfaces metadata gaps or stale review queues:
@@ -100,7 +114,6 @@ Optional follow-ups when the scan surfaces metadata gaps or stale review queues:
 brigade memory care plan-fixes --target .
 brigade memory care backfill --target .
 brigade memory care backfill --apply --target .
-brigade memory care closeout --target .
 ```
 
 Foreground batch alternative when scanner producers are configured in `.brigade/scanners.toml`:
@@ -117,7 +130,7 @@ On a workspace with several enabled producers, `brigade work scanners run --due 
 
 ```cron
 PATH=/home/you/.local/bin:/usr/local/bin:/usr/bin:/bin
-15 6 * * * cd WORKSPACE && brigade memory care scan --target . && brigade memory care import-issues --target . && brigade work brief --target .
+15 6 * * * cd "WORKSPACE" && brigade memory care scan --target . && brigade memory care import-issues --target . && brigade work brief --target . && brigade memory care closeout --target .
 ```
 
 ### systemd user timer
@@ -132,7 +145,7 @@ Description=Brigade daily memory care pass
 Type=oneshot
 WorkingDirectory=WORKSPACE
 Environment=PATH=/home/you/.local/bin:/usr/local/bin:/usr/bin:/bin
-ExecStart=/bin/sh -c 'brigade memory care scan --target . && brigade memory care import-issues --target . && brigade work brief --target .'
+ExecStart=/bin/sh -c 'brigade memory care scan --target . && brigade memory care import-issues --target . && brigade work brief --target . && brigade memory care closeout --target .'
 ```
 
 `~/.config/systemd/user/brigade-daily-care.timer`:
@@ -149,7 +162,7 @@ Persistent=true
 WantedBy=timers.target
 ```
 
-Enable with `systemctl --user daemon-reload`, then `systemctl --user enable --now brigade-daily-care.timer`.
+Enable with `systemctl --user daemon-reload`, then `systemctl --user enable --now brigade-daily-care.timer`. See [systemd user timers](#systemd-user-timers) for `loginctl enable-linger`.
 
 ### GitHub Actions
 
@@ -172,21 +185,22 @@ jobs:
       - run: python -m pip install --upgrade pip pipx
       - run: pipx install brigade-cli
       - run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - uses: actions/cache@v4
+        with:
+          path: .brigade
+          key: brigade-${{ github.workflow }}-${{ github.ref_name }}-${{ github.run_id }}
+          restore-keys: |
+            brigade-${{ github.workflow }}-${{ github.ref_name }}-
       - name: Bootstrap Brigade
         run: |
           brigade init --depth repo --harnesses codex --target .
           brigade memory care init --target .
           brigade daily init --target .
           brigade extras on
-      - uses: actions/cache@v4
-        with:
-          path: .brigade
-          key: brigade-${{ github.workflow }}-${{ github.ref_name }}-${{ hashFiles('.gitignore') }}
-          restore-keys: |
-            brigade-${{ github.workflow }}-${{ github.ref_name }}-
       - run: brigade memory care scan --target .
       - run: brigade memory care import-issues --target .
       - run: brigade work brief --target .
+      - run: brigade memory care closeout --target .
 ```
 
 ## Ingest sweep
@@ -204,7 +218,7 @@ Run this on a shorter cadence when writer harnesses produce handoffs throughout 
 
 ```cron
 PATH=/home/you/.local/bin:/usr/local/bin:/usr/bin:/bin
-*/30 * * * * cd WORKSPACE && brigade handoff lint --strict --target . && brigade ingest --promote-cards --route-documents --target .
+*/30 * * * * cd "WORKSPACE" && brigade handoff lint --strict --target . && brigade ingest --promote-cards --route-documents --target .
 ```
 
 ### systemd user timer
@@ -257,25 +271,25 @@ jobs:
       - run: python -m pip install --upgrade pip pipx
       - run: pipx install brigade-cli
       - run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - uses: actions/cache@v4
+        with:
+          path: .brigade
+          key: brigade-${{ github.workflow }}-${{ github.ref_name }}-${{ github.run_id }}
+          restore-keys: |
+            brigade-${{ github.workflow }}-${{ github.ref_name }}-
       - name: Bootstrap Brigade
         run: |
           brigade init --depth repo --harnesses codex --target .
           brigade memory care init --target .
           brigade daily init --target .
           brigade extras on
-      - uses: actions/cache@v4
-        with:
-          path: .brigade
-          key: brigade-${{ github.workflow }}-${{ github.ref_name }}-${{ hashFiles('.gitignore') }}
-          restore-keys: |
-            brigade-${{ github.workflow }}-${{ github.ref_name }}-
       - run: brigade handoff lint --strict --target .
       - run: brigade ingest --promote-cards --route-documents --target .
 ```
 
 ## Weekly outcome ratchet
 
-Rank verified-learning outcomes, then reconcile skill promotion state. `reconcile` is dry-run by default; pass `--apply` only when you intend to install or roll back registry skills.
+Rank verified-learning outcomes, then reconcile skill promotion state. `reconcile` is dry-run by default. Pass `--apply` only when you intend to install or roll back registry skills.
 
 ```bash
 brigade outcome rank --target .
@@ -294,14 +308,14 @@ Schedule rank first, then reconcile 30 to 60 minutes later so new verify receipt
 
 ```cron
 PATH=/home/you/.local/bin:/usr/local/bin:/usr/bin:/bin
-0 7 * * 1 cd WORKSPACE && brigade outcome rank --target .
-30 7 * * 1 cd WORKSPACE && brigade outcome reconcile --target .
+0 7 * * 1 cd "WORKSPACE" && brigade outcome rank --target .
+30 7 * * 1 cd "WORKSPACE" && brigade outcome reconcile --target .
 ```
 
 To apply promotions automatically after review:
 
 ```cron
-30 7 * * 1 cd WORKSPACE && brigade outcome reconcile --apply --target .
+30 7 * * 1 cd "WORKSPACE" && brigade outcome reconcile --apply --target .
 ```
 
 ### systemd user timer
@@ -383,18 +397,18 @@ jobs:
       - run: python -m pip install --upgrade pip pipx
       - run: pipx install brigade-cli
       - run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - uses: actions/cache@v4
+        with:
+          path: .brigade
+          key: brigade-${{ github.workflow }}-${{ github.ref_name }}-${{ github.run_id }}
+          restore-keys: |
+            brigade-${{ github.workflow }}-${{ github.ref_name }}-
       - name: Bootstrap Brigade
         run: |
           brigade init --depth repo --harnesses codex --target .
           brigade memory care init --target .
           brigade daily init --target .
           brigade extras on
-      - uses: actions/cache@v4
-        with:
-          path: .brigade
-          key: brigade-${{ github.workflow }}-${{ github.ref_name }}-${{ hashFiles('.gitignore') }}
-          restore-keys: |
-            brigade-${{ github.workflow }}-${{ github.ref_name }}-
       - run: brigade outcome rank --target .
   outcome-reconcile:
     needs: outcome-rank
@@ -407,24 +421,26 @@ jobs:
       - run: python -m pip install --upgrade pip pipx
       - run: pipx install brigade-cli
       - run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - uses: actions/cache@v4
+        with:
+          path: .brigade
+          key: brigade-${{ github.workflow }}-${{ github.ref_name }}-${{ github.run_id }}
+          restore-keys: |
+            brigade-${{ github.workflow }}-${{ github.ref_name }}-
       - name: Bootstrap Brigade
         run: |
           brigade init --depth repo --harnesses codex --target .
           brigade memory care init --target .
           brigade daily init --target .
           brigade extras on
-      - uses: actions/cache@v4
-        with:
-          path: .brigade
-          key: brigade-${{ github.workflow }}-${{ github.ref_name }}-${{ hashFiles('.gitignore') }}
-          restore-keys: |
-            brigade-${{ github.workflow }}-${{ github.ref_name }}-
       - run: brigade outcome reconcile --target .
 ```
 
+The GitHub Actions recipe runs reconcile immediately after rank in the same workflow (`needs: outcome-rank`), not 30 to 60 minutes later. That is fine for CI: both jobs share the same restored `.brigade` cache and rank only reads receipts already on disk. On a laptop, keep the cron or timer gap so verify runs between rank and reconcile can finish first.
+
 ## Daily observability
 
-Check handoff pipeline health, read the daily driver snapshot, and build the local operator report bundle. `center report build` is extras-gated; run `brigade extras on` once per machine or prefix with `BRIGADE_EXTRAS=1`.
+Check handoff pipeline health, read the daily driver snapshot, and build the local operator report bundle. `center report build` is extras-gated. Run `brigade extras on` once per machine or prefix with `BRIGADE_EXTRAS=1`.
 
 ```bash
 brigade handoff doctor --target .
@@ -436,7 +452,7 @@ brigade center report build --target .
 
 ```cron
 PATH=/home/you/.local/bin:/usr/local/bin:/usr/bin:/bin
-0 8 * * * cd WORKSPACE && brigade handoff doctor --target . && brigade daily status --target . && brigade center report build --target .
+0 8 * * * cd "WORKSPACE" && brigade handoff doctor --target . && brigade daily status --target . && brigade center report build --target .
 ```
 
 ### systemd user timer
@@ -489,18 +505,18 @@ jobs:
       - run: python -m pip install --upgrade pip pipx
       - run: pipx install brigade-cli
       - run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - uses: actions/cache@v4
+        with:
+          path: .brigade
+          key: brigade-${{ github.workflow }}-${{ github.ref_name }}-${{ github.run_id }}
+          restore-keys: |
+            brigade-${{ github.workflow }}-${{ github.ref_name }}-
       - name: Bootstrap Brigade
         run: |
           brigade init --depth repo --harnesses codex --target .
           brigade memory care init --target .
           brigade daily init --target .
           brigade extras on
-      - uses: actions/cache@v4
-        with:
-          path: .brigade
-          key: brigade-${{ github.workflow }}-${{ github.ref_name }}-${{ hashFiles('.gitignore') }}
-          restore-keys: |
-            brigade-${{ github.workflow }}-${{ github.ref_name }}-
       - run: brigade handoff doctor --target .
       - run: brigade daily status --target .
       - run: brigade center report build --target .
@@ -528,7 +544,7 @@ Example runbook at `.brigade/runbooks/nightly-maintenance.json`:
 }
 ```
 
-Run it (`runbook` is extras-gated; run `brigade extras on` once per machine or prefix with `BRIGADE_EXTRAS=1`):
+Run it (`runbook` is extras-gated. Run `brigade extras on` once per machine or prefix with `BRIGADE_EXTRAS=1`):
 
 ```bash
 brigade runbook run --approved --target . .brigade/runbooks/nightly-maintenance.json
@@ -538,7 +554,7 @@ brigade runbook run --approved --target . .brigade/runbooks/nightly-maintenance.
 
 ```cron
 PATH=/home/you/.local/bin:/usr/local/bin:/usr/bin:/bin
-0 4 * * * cd WORKSPACE && brigade runbook run --approved --target . .brigade/runbooks/nightly-maintenance.json
+0 4 * * * cd "WORKSPACE" && brigade runbook run --approved --target . .brigade/runbooks/nightly-maintenance.json
 ```
 
 ### systemd user timer
@@ -591,18 +607,18 @@ jobs:
       - run: python -m pip install --upgrade pip pipx
       - run: pipx install brigade-cli
       - run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - uses: actions/cache@v4
+        with:
+          path: .brigade
+          key: brigade-${{ github.workflow }}-${{ github.ref_name }}-${{ github.run_id }}
+          restore-keys: |
+            brigade-${{ github.workflow }}-${{ github.ref_name }}-
       - name: Bootstrap Brigade
         run: |
           brigade init --depth repo --harnesses codex --target .
           brigade memory care init --target .
           brigade daily init --target .
           brigade extras on
-      - uses: actions/cache@v4
-        with:
-          path: .brigade
-          key: brigade-${{ github.workflow }}-${{ github.ref_name }}-${{ hashFiles('.gitignore') }}
-          restore-keys: |
-            brigade-${{ github.workflow }}-${{ github.ref_name }}-
       - run: brigade runbook run --approved --target . .brigade/runbooks/nightly-maintenance.json
 ```
 
@@ -610,4 +626,4 @@ Commit the runbook JSON when you want CI to execute the same pinned steps as you
 
 ## More recipes
 
-Add new sections here as adapters land. Future candidates include a beads reconcile pass once a `bd` adapter ships; follow the same crontab, systemd, and GitHub Actions shape as the recipes above.
+Add new sections here as adapters land. Future candidates include a beads reconcile pass once a `bd` adapter ships. Follow the same crontab, systemd, and GitHub Actions shape as the recipes above.

--- a/docs/scheduled-care.md
+++ b/docs/scheduled-care.md
@@ -55,7 +55,7 @@ Then `systemctl --user daemon-reload`, `systemctl --user enable --now <timer>.ti
 
 ### Tracked runbooks
 
-`brigade init` gitignores `.brigade/` by default. Nightly runbooks referenced from CI must be committed. Inside the managed brigade gitignore block, add:
+`brigade init` adds a managed gitignore block that keeps `.brigade/*` out of git by default. Nightly runbooks referenced from CI must be committed. Inside that block, add:
 
 ```gitignore
 !.brigade/runbooks/
@@ -547,14 +547,14 @@ Example runbook at `.brigade/runbooks/nightly-maintenance.json`:
 Run it (`runbook` is extras-gated. Run `brigade extras on` once per machine or prefix with `BRIGADE_EXTRAS=1`):
 
 ```bash
-brigade runbook run --approved --target . .brigade/runbooks/nightly-maintenance.json
+brigade runbook run .brigade/runbooks/nightly-maintenance.json --target . --approved
 ```
 
 ### Crontab
 
 ```cron
 PATH=/home/you/.local/bin:/usr/local/bin:/usr/bin:/bin
-0 4 * * * cd "WORKSPACE" && brigade runbook run --approved --target . .brigade/runbooks/nightly-maintenance.json
+0 4 * * * cd "WORKSPACE" && brigade runbook run .brigade/runbooks/nightly-maintenance.json --target . --approved
 ```
 
 ### systemd user timer
@@ -569,7 +569,7 @@ Description=Brigade nightly maintenance runbook
 Type=oneshot
 WorkingDirectory=WORKSPACE
 Environment=PATH=/home/you/.local/bin:/usr/local/bin:/usr/bin:/bin
-ExecStart=brigade runbook run --approved --target . .brigade/runbooks/nightly-maintenance.json
+ExecStart=brigade runbook run .brigade/runbooks/nightly-maintenance.json --target . --approved
 ```
 
 `~/.config/systemd/user/brigade-nightly-ops.timer`:
@@ -619,7 +619,7 @@ jobs:
           brigade memory care init --target .
           brigade daily init --target .
           brigade extras on
-      - run: brigade runbook run --approved --target . .brigade/runbooks/nightly-maintenance.json
+      - run: brigade runbook run .brigade/runbooks/nightly-maintenance.json --target . --approved
 ```
 
 Commit the runbook JSON when you want CI to execute the same pinned steps as your laptop.

--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -1637,6 +1637,7 @@ Each subsystem has a companion doc under [`docs/`]() with the full local contrac
 - [`docs/backup-health.md`](backup-health.md) - read-only backup health summaries and issue routing
 - [`docs/memory-care.md`](memory-care.md) - memory card decay scanning and refresh imports
 - [`docs/execution-model.md`](execution-model.md) - explicit-invocation boundary and external-scheduler ownership
+- [`docs/scheduled-care.md`](scheduled-care.md) - operator-owned cron, systemd, and CI recipes for the memory-care loop
 - [`docs/security.md`](security.md) - the agent workspace security scanner and evidence bundles
 - [`docs/inspiration-patterns.md`](inspiration-patterns.md) - neutral pattern families and source-pattern decisions
 - [`docs/roadmap-completion-plan.md`](roadmap-completion-plan.md) - the large-roadmap completion plan and phase boundaries


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

Adds `docs/scheduled-care.md` so operators can copy cron, systemd timer, and GitHub Actions recipes for the living-memory loop without an external agent platform. The page opens with the boundary sentence (schedule belongs to the operator) and covers daily care, ingest sweep, weekly outcome ratchet, daily observability, and nightly ops.

Fixes the four release-blocking gaps from the prior attempt:
- cron `PATH` for pipx installs (`~/.local/bin`)
- systemd `Environment=PATH` for bare `brigade` invocations
- tracked runbook gitignore exceptions so nightly JSON reaches CI
- GitHub Actions bootstrap (`init`, `memory care init`, `daily init`, `extras on`) plus `.brigade` cache for persisted state

Fixes #764

## Type of change

- [x] Docs

## Checklist

- [x] `pytest -q` passes locally (`6053 passed, 3 skipped`; `./scripts/verify` green)
- [ ] Added or updated tests covering the change (docs-only)
- [x] Updated the `Unreleased` section of `CHANGELOG.md` for any user-visible effect
- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths in code, templates, tests, or this PR
- [x] No new runtime dependencies
- [x] Conventional commit messages

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12d49b9b-08ae-47ed-8c31-691e10ea9c23?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12d49b9b-08ae-47ed-8c31-691e10ea9c23&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

