### PR TITLE
fix(run): retry lock acquisition after stale handoff

### DIFF
--- a/src/brigade/runguard.py
+++ b/src/brigade/runguard.py
@@ -914,6 +914,8 @@ def _wait_to_acquire_lock(
                     remaining = deadline - time.monotonic()
                     if remaining <= 0:
                         raise RunLockError(f"timed out after {wait_seconds:g}s waiting for run lock: {path}")
+                else:
+                    time.sleep(poll_interval)
                 continue
             if not unbounded:
                 remaining = deadline - time.monotonic()

--- a/src/brigade/runguard.py
+++ b/src/brigade/runguard.py
@@ -768,10 +768,24 @@ def _list_wait_tickets(queue_dir: Path) -> list[Path]:
 def _wait_ticket_is_live(ticket: Path) -> bool:
     try:
         payload = json.loads(ticket.read_text())
-    except (OSError, json.JSONDecodeError, UnicodeDecodeError, RecursionError):
+    except OSError:
+        # A transient unreadable ticket is not proof the waiter died; skip pruning.
+        return True
+    except (json.JSONDecodeError, UnicodeDecodeError, RecursionError):
         return False
     pid = payload.get("pid") if isinstance(payload, dict) else None
     return isinstance(pid, int) and _pid_is_active(pid)
+
+
+def _remove_empty_wait_queue_dir(queue_dir: Path) -> None:
+    try:
+        if not queue_dir.is_dir():
+            return
+        if any(queue_dir.glob("*.wait")):
+            return
+        queue_dir.rmdir()
+    except OSError:
+        pass
 
 
 def _prune_stale_wait_tickets(queue_dir: Path) -> None:
@@ -782,32 +796,45 @@ def _prune_stale_wait_tickets(queue_dir: Path) -> None:
             ticket.unlink()
         except OSError:
             pass
+    _remove_empty_wait_queue_dir(queue_dir)
 
 
 def _enroll_wait_ticket(queue_dir: Path) -> Path:
-    queue_dir.mkdir(parents=True, exist_ok=True)
+    # Cross-process FIFO ordering sorts ticket filenames by the monotonic_ns prefix.
+    # This assumes a system-wide monotonic clock (e.g. Linux CLOCK_MONOTONIC), not
+    # per-process views that can diverge across hosts or after suspend.
     token = uuid4().hex
-    ticket = queue_dir / f"{time.monotonic_ns():020d}-{os.getpid():08d}-{token}.wait"
     payload = {
         "schema": "brigade.run_lock_wait.v1",
         "pid": os.getpid(),
         "enrolled_at": datetime.now(timezone.utc).isoformat(),
     }
-    fd = os.open(ticket, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-    try:
-        os.write(fd, json.dumps(payload).encode())
-    finally:
-        os.close(fd)
-    return ticket
+    encoded = json.dumps(payload).encode()
+    for _ in range(4):
+        queue_dir.mkdir(parents=True, exist_ok=True)
+        ticket = queue_dir / f"{time.monotonic_ns():020d}-{os.getpid():08d}-{token}.wait"
+        try:
+            fd = os.open(ticket, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        except FileNotFoundError:
+            # Another waiter removed the empty queue dir between mkdir and create.
+            continue
+        try:
+            os.write(fd, encoded)
+        finally:
+            os.close(fd)
+        return ticket
+    raise RunLockError(f"could not enroll for run lock wait queue: {queue_dir}")
 
 
-def _leave_wait_ticket(ticket: Path) -> None:
+def _leave_wait_ticket(ticket: Path, queue_dir: Path | None = None) -> None:
     try:
         ticket.unlink()
     except FileNotFoundError:
         return
     except OSError:
         return
+    if queue_dir is not None:
+        _remove_empty_wait_queue_dir(queue_dir)
 
 
 def _is_wait_queue_head(ticket: Path, queue_dir: Path) -> bool:
@@ -847,14 +874,17 @@ def _wait_to_acquire_lock(
     try:
         while True:
             timed_out_acquire_exc: RunLockError | None = None
+            immediately_retryable = False
             if _is_wait_queue_head(ticket, queue_dir):
                 try:
                     return _acquire_lock(path, run_dir=run_dir)
                 except RunLockError as exc:
                     if _wait_retry_after_acquire_error(path):
-                        pass
+                        immediately_retryable = True
                     else:
                         timed_out_acquire_exc = exc
+            if immediately_retryable:
+                continue
             if not unbounded:
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
@@ -867,7 +897,7 @@ def _wait_to_acquire_lock(
             else:
                 time.sleep(poll_interval)
     finally:
-        _leave_wait_ticket(ticket)
+        _leave_wait_ticket(ticket, queue_dir)
 
 
 def _acquire_lock(path: Path, *, run_dir: Path | None = None) -> _LockOwnership:

--- a/src/brigade/runguard.py
+++ b/src/brigade/runguard.py
@@ -816,13 +816,18 @@ def _is_wait_queue_head(ticket: Path, queue_dir: Path) -> bool:
     return bool(tickets) and tickets[0] == ticket
 
 
-def _lock_held_by_live_process(path: Path) -> bool:
+def _wait_retry_after_acquire_error(path: Path) -> bool:
+    """Return True when a failed acquire should retry instead of aborting.
+
+    A structurally malformed non-directory lock still raises ``RunLockError``.
+    """
     try:
-        if _lock_path_is_directory(path) is None:
-            return False
+        lock_is_directory = _lock_path_is_directory(path)
     except RunLockError:
-        return False
-    return not _lock_is_stale(path)
+        raise
+    if lock_is_directory is None:
+        return True
+    return _lock_is_stale(path)
 
 
 def _wait_to_acquire_lock(
@@ -841,23 +846,26 @@ def _wait_to_acquire_lock(
     deadline = time.monotonic() + wait_seconds if not unbounded else 0.0
     try:
         while True:
+            timed_out_acquire_exc: RunLockError | None = None
             if _is_wait_queue_head(ticket, queue_dir):
                 try:
                     return _acquire_lock(path, run_dir=run_dir)
                 except RunLockError as exc:
-                    if not _lock_held_by_live_process(path):
-                        raise
-                    if not unbounded:
-                        remaining = deadline - time.monotonic()
-                        if remaining <= 0:
-                            raise RunLockError(
-                                f"timed out after {wait_seconds:g}s waiting for run lock: {path}"
-                            ) from exc
-            elif not unbounded:
+                    if _wait_retry_after_acquire_error(path):
+                        pass
+                    else:
+                        timed_out_acquire_exc = exc
+            if not unbounded:
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
+                    if timed_out_acquire_exc is not None:
+                        raise RunLockError(
+                            f"timed out after {wait_seconds:g}s waiting for run lock: {path}"
+                        ) from timed_out_acquire_exc
                     raise RunLockError(f"timed out after {wait_seconds:g}s waiting for run lock: {path}")
-            time.sleep(poll_interval)
+                time.sleep(min(poll_interval, remaining))
+            else:
+                time.sleep(poll_interval)
     finally:
         _leave_wait_ticket(ticket)
 

--- a/src/brigade/runguard.py
+++ b/src/brigade/runguard.py
@@ -10,6 +10,7 @@ import math
 import os
 import shutil
 import stat
+import tempfile
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -799,6 +800,31 @@ def _prune_stale_wait_tickets(queue_dir: Path) -> None:
     _remove_empty_wait_queue_dir(queue_dir)
 
 
+def _publish_wait_ticket_exclusive(ticket: Path, encoded: bytes) -> None:
+    """Publish a complete wait ticket without exposing partial *.wait files."""
+    queue_dir = ticket.parent
+    fd, tmp_name = tempfile.mkstemp(
+        dir=queue_dir,
+        prefix=f".{ticket.name}.",
+        suffix=".enrolling",
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        try:
+            os.write(fd, encoded)
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+        if ticket.exists():
+            raise FileExistsError(errno.EEXIST, os.strerror(errno.EEXIST), str(ticket))
+        os.replace(tmp_path, ticket)
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
+    else:
+        tmp_path.unlink(missing_ok=True)
+
+
 def _enroll_wait_ticket(queue_dir: Path) -> Path:
     # Cross-process FIFO ordering sorts ticket filenames by the monotonic_ns prefix.
     # This assumes a system-wide monotonic clock (e.g. Linux CLOCK_MONOTONIC), not
@@ -814,14 +840,14 @@ def _enroll_wait_ticket(queue_dir: Path) -> Path:
         queue_dir.mkdir(parents=True, exist_ok=True)
         ticket = queue_dir / f"{time.monotonic_ns():020d}-{os.getpid():08d}-{token}.wait"
         try:
-            fd = os.open(ticket, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-        except FileNotFoundError:
-            # Another waiter removed the empty queue dir between mkdir and create.
+            _publish_wait_ticket_exclusive(ticket, encoded)
+        except FileExistsError:
             continue
-        try:
-            os.write(fd, encoded)
-        finally:
-            os.close(fd)
+        except FileNotFoundError:
+            # Another waiter removed the empty queue dir between mkdir and publish.
+            continue
+        except OSError:
+            continue
         return ticket
     raise RunLockError(f"could not enroll for run lock wait queue: {queue_dir}")
 
@@ -884,6 +910,10 @@ def _wait_to_acquire_lock(
                     else:
                         timed_out_acquire_exc = exc
             if immediately_retryable:
+                if not unbounded:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise RunLockError(f"timed out after {wait_seconds:g}s waiting for run lock: {path}")
                 continue
             if not unbounded:
                 remaining = deadline - time.monotonic()

--- a/tests/test_runguard.py
+++ b/tests/test_runguard.py
@@ -597,6 +597,33 @@ def test_wait_to_acquire_lock_retries_immediately_without_poll_sleep(tmp_path, m
     assert sleeps == []
 
 
+def test_wait_to_acquire_lock_unbounded_immediate_retry_sleeps_between_retries(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    lock_path = runguard.lock_path(repo)
+    lock_path.mkdir(parents=True)
+    (lock_path / "pid").write_text(f"{os.getpid()}\n")
+    original_acquire = runguard._acquire_lock
+    acquire_calls = 0
+    sleeps: list[float] = []
+    monkeypatch.setattr(runguard.time, "sleep", sleeps.append)
+
+    def fail_twice_then_succeed(path, *, run_dir=None):
+        nonlocal acquire_calls
+        acquire_calls += 1
+        if acquire_calls <= 2:
+            if lock_path.exists():
+                shutil.rmtree(lock_path)
+            raise runguard.RunLockError("another brigade run appears active")
+        return original_acquire(path, run_dir=run_dir)
+
+    monkeypatch.setattr(runguard, "_acquire_lock", fail_twice_then_succeed)
+
+    with runguard.run_lock(repo, wait_seconds=math.inf, poll_interval=0.05):
+        assert acquire_calls == 3
+
+    assert sleeps == [0.05, 0.05]
+
+
 def test_run_lock_replaces_lock_with_dead_pid(tmp_path):
     repo = _repo(tmp_path)
     lock_path = runguard.lock_path(repo)

--- a/tests/test_runguard.py
+++ b/tests/test_runguard.py
@@ -495,6 +495,82 @@ def test_wait_ticket_transient_read_error_is_not_pruned(tmp_path, monkeypatch):
     assert runguard._wait_ticket_is_live(ticket)
 
 
+def test_wait_ticket_enroll_survives_concurrent_prune_before_publish(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    queue_dir = runguard._wait_queue_dir(runguard.lock_path(repo))
+    publish_ready = threading.Event()
+    publish_gate = threading.Event()
+    enrolling_files: list[Path] = []
+    real_replace = os.replace
+
+    def gated_replace(src, dst):
+        if str(dst).endswith(".wait"):
+            enrolling_files.append(Path(src))
+            publish_ready.set()
+            assert publish_gate.wait(timeout=5)
+            listed = runguard._list_wait_tickets(queue_dir)
+            assert listed == []
+            runguard._prune_stale_wait_tickets(queue_dir)
+            assert Path(src).exists()
+            assert not Path(dst).exists()
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(os, "replace", gated_replace)
+
+    enrolled: dict[str, object] = {}
+    errors: list[BaseException] = []
+
+    def enroll() -> None:
+        try:
+            ticket = runguard._enroll_wait_ticket(queue_dir)
+        except BaseException as exc:
+            errors.append(exc)
+            return
+        enrolled["ticket"] = ticket
+
+    enroll_thread = threading.Thread(target=enroll)
+    enroll_thread.start()
+    assert publish_ready.wait(timeout=5)
+    publish_gate.set()
+    enroll_thread.join(timeout=5)
+    assert not enroll_thread.is_alive()
+    assert errors == []
+
+    ticket = enrolled["ticket"]
+    assert isinstance(ticket, Path)
+    assert ticket.exists()
+    assert runguard._wait_ticket_is_live(ticket)
+    assert runguard._is_wait_queue_head(ticket, queue_dir)
+    assert not any(queue_dir.glob("*.enrolling"))
+    assert not enrolling_files or not enrolling_files[0].exists()
+
+    runguard._leave_wait_ticket(ticket, queue_dir)
+
+
+def test_wait_to_acquire_lock_timeout_before_immediate_retry_churn(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    lock_path = runguard.lock_path(repo)
+    lock_path.mkdir(parents=True)
+    (lock_path / "pid").write_text(f"{os.getpid()}\n")
+    monotonic = iter((0.0, 0.0, 0.21))
+    sleeps: list[float] = []
+    monkeypatch.setattr(runguard.time, "monotonic", lambda: next(monotonic))
+    monkeypatch.setattr(runguard.time, "sleep", sleeps.append)
+    monkeypatch.setattr(runguard, "_is_wait_queue_head", lambda *_args, **_kwargs: True)
+
+    def always_retry_acquire(*_args, **_kwargs):
+        raise runguard.RunLockError("another brigade run appears active")
+
+    monkeypatch.setattr(runguard, "_acquire_lock", always_retry_acquire)
+    monkeypatch.setattr(runguard, "_wait_retry_after_acquire_error", lambda *_args, **_kwargs: True)
+
+    with pytest.raises(runguard.RunLockError, match=r"timed out after 0.2s waiting for run lock"):
+        with runguard.run_lock(repo, wait_seconds=0.2, poll_interval=0.05):
+            pass
+
+    assert sleeps == []
+
+
 def test_wait_to_acquire_lock_retries_immediately_without_poll_sleep(tmp_path, monkeypatch):
     repo = _repo(tmp_path)
     lock_path = runguard.lock_path(repo)

--- a/tests/test_runguard.py
+++ b/tests/test_runguard.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import errno
 import json
 import math
 import os
@@ -448,6 +449,76 @@ def test_run_lock_prunes_stale_wait_tickets_before_queue_head(tmp_path):
 
     assert runguard._is_wait_queue_head(live_ticket, queue_dir)
     assert not dead_ticket.exists()
+    assert queue_dir.is_dir()
+
+
+def test_run_lock_removes_empty_wait_queue_dir_when_last_ticket_leaves(tmp_path):
+    repo = _repo(tmp_path)
+    queue_dir = runguard._wait_queue_dir(runguard.lock_path(repo))
+    ticket = runguard._enroll_wait_ticket(queue_dir)
+    assert queue_dir.is_dir()
+
+    runguard._leave_wait_ticket(ticket, queue_dir)
+    assert not queue_dir.exists()
+
+
+def test_run_lock_prune_removes_empty_wait_queue_dir(tmp_path):
+    repo = _repo(tmp_path)
+    queue_dir = runguard._wait_queue_dir(runguard.lock_path(repo))
+    queue_dir.mkdir(parents=True)
+    dead_ticket = queue_dir / "00000000000000000001-00000001-dead.wait"
+    dead_ticket.write_text(json.dumps({"pid": 99999999}))
+
+    runguard._prune_stale_wait_tickets(queue_dir)
+    assert not dead_ticket.exists()
+    assert not queue_dir.exists()
+
+
+def test_wait_ticket_transient_read_error_is_not_pruned(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    queue_dir = runguard._wait_queue_dir(runguard.lock_path(repo))
+    ticket = runguard._enroll_wait_ticket(queue_dir)
+    original_read_text = Path.read_text
+    calls = 0
+
+    def flaky_read_text(self, *args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if self == ticket and calls == 1:
+            raise OSError(errno.EIO, "simulated transient read")
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", flaky_read_text)
+
+    runguard._prune_stale_wait_tickets(queue_dir)
+    assert ticket.exists()
+    assert runguard._wait_ticket_is_live(ticket)
+
+
+def test_wait_to_acquire_lock_retries_immediately_without_poll_sleep(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    lock_path = runguard.lock_path(repo)
+    lock_path.mkdir(parents=True)
+    (lock_path / "pid").write_text(f"{os.getpid()}\n")
+    original_acquire = runguard._acquire_lock
+    acquire_calls = 0
+    sleeps = []
+    monkeypatch.setattr(runguard.time, "sleep", sleeps.append)
+
+    def acquire_then_clear(path, *, run_dir=None):
+        nonlocal acquire_calls
+        acquire_calls += 1
+        if acquire_calls == 1:
+            shutil.rmtree(lock_path)
+            raise runguard.RunLockError("another brigade run appears active")
+        return original_acquire(path, run_dir=run_dir)
+
+    monkeypatch.setattr(runguard, "_acquire_lock", acquire_then_clear)
+
+    with runguard.run_lock(repo, wait_seconds=1.0, poll_interval=0.05):
+        assert acquire_calls == 2
+
+    assert sleeps == []
 
 
 def test_run_lock_replaces_lock_with_dead_pid(tmp_path):

--- a/tests/test_runguard.py
+++ b/tests/test_runguard.py
@@ -329,15 +329,31 @@ def test_run_lock_timeout_clock_is_isolated_from_process_clock(tmp_path, monkeyp
     assert lock_path.is_dir()
 
 
-def test_run_lock_fair_queue_long_holder_multiple_waiters_proceed_in_order(tmp_path):
+def test_run_lock_fair_queue_long_holder_multiple_waiters_proceed_in_order(tmp_path, monkeypatch):
     repo = _repo(tmp_path)
     order: list[str] = []
-    holder_done = threading.Event()
+    holder_release = threading.Event()
+    holder_acquired = threading.Event()
+    enrollment_signals = [threading.Event() for _ in range(3)]
+    enroll_index = 0
+    enroll_lock = threading.Lock()
+    original_enroll = runguard._enroll_wait_ticket
+
+    def counting_enroll(queue_dir):
+        nonlocal enroll_index
+        ticket = original_enroll(queue_dir)
+        with enroll_lock:
+            enrollment_signals[enroll_index].set()
+            enroll_index += 1
+        return ticket
+
+    monkeypatch.setattr(runguard, "_enroll_wait_ticket", counting_enroll)
 
     def holder() -> None:
         with runguard.run_lock(repo):
             order.append("holder-start")
-            assert holder_done.wait(timeout=5)
+            holder_acquired.set()
+            assert holder_release.wait(timeout=5)
             order.append("holder-end")
 
     def waiter(name: str) -> None:
@@ -346,17 +362,16 @@ def test_run_lock_fair_queue_long_holder_multiple_waiters_proceed_in_order(tmp_p
 
     holder_thread = threading.Thread(target=holder)
     holder_thread.start()
-    stdlib_time.sleep(0.1)
+    assert holder_acquired.wait(timeout=5)
 
-    waiter_threads = []
+    waiter_threads: list[threading.Thread] = []
     for index in range(3):
         thread = threading.Thread(target=waiter, args=(f"waiter-{index}",))
         thread.start()
+        assert enrollment_signals[index].wait(timeout=5)
         waiter_threads.append(thread)
-        stdlib_time.sleep(0.05)
 
-    stdlib_time.sleep(0.2)
-    holder_done.set()
+    holder_release.set()
 
     for thread in waiter_threads:
         thread.join(timeout=10)
@@ -365,6 +380,50 @@ def test_run_lock_fair_queue_long_holder_multiple_waiters_proceed_in_order(tmp_p
     assert not holder_thread.is_alive()
 
     assert order == ["holder-start", "holder-end", "waiter-0", "waiter-1", "waiter-2"]
+
+
+def test_wait_to_acquire_lock_retries_when_lock_clears_after_failed_acquire(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    lock_path = runguard.lock_path(repo)
+    lock_path.mkdir(parents=True)
+    (lock_path / "pid").write_text(f"{os.getpid()}\n")
+    original_acquire = runguard._acquire_lock
+    acquire_calls = 0
+
+    def acquire_then_clear(path, *, run_dir=None):
+        nonlocal acquire_calls
+        acquire_calls += 1
+        if acquire_calls == 1:
+            shutil.rmtree(lock_path)
+            raise runguard.RunLockError("another brigade run appears active")
+        return original_acquire(path, run_dir=run_dir)
+
+    monkeypatch.setattr(runguard, "_acquire_lock", acquire_then_clear)
+
+    with runguard.run_lock(repo, wait_seconds=1.0, poll_interval=0.05):
+        assert acquire_calls == 2
+        assert (lock_path / "pid").read_text().strip() == str(os.getpid())
+
+    assert not lock_path.exists()
+
+
+def test_wait_to_acquire_lock_still_surfaces_malformed_lock_after_failed_acquire(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    lock_path = runguard.lock_path(repo)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.write_text("malformed lock\n")
+
+    def fail_acquire(path, *, run_dir=None):
+        raise runguard.RunLockError("could not acquire run lock")
+
+    monkeypatch.setattr(runguard, "_acquire_lock", fail_acquire)
+
+    with pytest.raises(runguard.RunLockError, match="malformed run lock"):
+        with runguard.run_lock(repo, wait_seconds=1.0, poll_interval=0.05):
+            pass
+
+    assert lock_path.is_file()
+    assert lock_path.read_text() == "malformed lock\n"
 
 
 def test_run_lock_wait_reclaims_stale_holder(tmp_path):


### PR DESCRIPTION
## Summary

- retry the FIFO head waiter when the lock disappears or becomes stale after a failed acquire
- keep malformed lock files as hard errors
- make the multi-waiter regression deterministic by ordering holder acquisition and waiter enrollment

Follow-up to #781 and #768.

## Verification

- `pytest -q tests/test_runguard.py tests/test_config.py tests/test_run_cli.py`
- `ruff check src/brigade/runguard.py tests/test_runguard.py`

