### PR TITLE
fix(run): exclude unhealthy seats from routing

### DIFF
--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -2708,6 +2708,8 @@ def _run_payload(
         payload["run_journal_authority_requested"] = True
     if resolution := _roster_resolution_payload(roster):
         payload["roster"] = resolution
+    if roster.seat_routing:
+        payload["seat_routing"] = [dict(decision) for decision in roster.seat_routing]
     if lock_workspace is not None:
         payload["lock_workspace"] = str(lock_workspace)
     if route is not None:
@@ -3006,6 +3008,7 @@ class OrchestratorHealthRoutingDecision:
     abort_detail: str | None = None
     abort_failure_phase: str = "preflight"
     abort_failure_kind: str = "unclassified"
+    abort_seat: str | None = None
     receipt: dict[str, object] | None = None
 
 
@@ -3030,61 +3033,126 @@ def _seat_health_typed_cause(result: seat_health.SeatHealthResult) -> str:
 def resolve_orchestrator_health_routing(
     roster: Roster,
     results: tuple[seat_health.SeatHealthResult, ...] | None,
+    *,
+    pinned_seats: frozenset[str] = frozenset(),
 ) -> OrchestratorHealthRoutingDecision:
-    """Return the effective roster and any orchestrator fallback or abort action."""
-    orchestrator_result = _seat_health_result_for(results, roster.orchestrator)
-    if orchestrator_result is None or orchestrator_result.status != "unhealthy":
+    """Route unhealthy orchestrator and worker seats to declared fallbacks."""
+    if results is None:
         return OrchestratorHealthRoutingDecision(roster=roster)
 
-    requested = roster.orchestrator
-    typed_cause = _seat_health_typed_cause(orchestrator_result)
-    failure = orchestrator_result.failure
-    rejected: list[dict[str, str]] = []
+    referenced = {name for agent in roster.agents.values() for name in agent.fallback}
+    # Roots are the orchestrator plus seats not referenced as fallbacks by any other role.
+    roots = [name for name in roster.agents if name == roster.orchestrator or name not in referenced]
+    effective_agents = dict(roster.agents)
+    effective_orchestrator = roster.orchestrator
+    decisions: list[dict[str, object]] = []
+    warnings: list[str] = []
+    abort: tuple[str, seat_health.SeatHealthResult, list[dict[str, str]]] | None = None
 
-    for fallback_name in roster.agents[requested].fallback:
-        if fallback_name not in roster.agents:
+    for requested in roots:
+        health_result = _seat_health_result_for(results, requested)
+        if health_result is None or health_result.status != "unhealthy":
             continue
-        fallback_result = _seat_health_result_for(results, fallback_name)
-        if fallback_result is not None and fallback_result.status == "healthy":
-            return OrchestratorHealthRoutingDecision(
-                roster=replace(roster, orchestrator=fallback_name),
-                warning=(
-                    f"warning: orchestrator {requested} is unhealthy [{typed_cause}]; "
-                    f"using declared fallback {fallback_name}"
-                ),
-                receipt={
-                    "schema": "brigade.seat_routing.v1",
-                    "requested_orchestrator": requested,
-                    "effective_orchestrator": fallback_name,
-                    "outcome": "fallback",
-                    "typed_cause": typed_cause,
-                    "rejected_fallbacks": rejected,
-                },
-            )
-        status = fallback_result.status if fallback_result is not None else "missing"
-        cause = _seat_health_typed_cause(fallback_result) if fallback_result is not None else "missing"
-        rejected.append({"seat": fallback_name, "status": status, "cause": cause})
+        typed_cause = _seat_health_typed_cause(health_result)
+        rejected: list[dict[str, str]] = []
+        selected: str | None = None
+        for fallback_name in roster.agents[requested].fallback:
+            fallback_result = _seat_health_result_for(results, fallback_name)
+            if fallback_result is not None and fallback_result.status == "healthy":
+                selected = fallback_name
+                break
+            status = fallback_result.status if fallback_result is not None else "missing"
+            cause = _seat_health_typed_cause(fallback_result) if fallback_result is not None else "missing"
+            rejected.append({"seat": fallback_name, "status": status, "cause": cause})
 
+        decision: dict[str, object] = {
+            "requested_seat": requested,
+            "effective_seat": selected,
+            "outcome": "fallback" if selected is not None else "skip",
+            "typed_cause": typed_cause,
+            "rejected_fallbacks": rejected,
+        }
+        decisions.append(decision)
+        if selected is not None:
+            if requested == roster.orchestrator:
+                effective_orchestrator = selected
+                warnings.append(
+                    f"warning: orchestrator {requested} is unhealthy [{typed_cause}]; "
+                    f"using declared fallback {selected}"
+                )
+            else:
+                fallback = roster.agents[selected]
+                requested_agent = roster.agents[requested]
+                effective_agents[requested] = replace(
+                    fallback,
+                    name=requested,
+                    role=requested_agent.role,
+                    purpose=requested_agent.purpose,
+                    fallback=(),
+                )
+                warnings.append(
+                    f"warning: seat {requested} is unhealthy [{typed_cause}]; using declared fallback {selected}"
+                )
+        elif requested == roster.orchestrator or requested in pinned_seats:
+            abort = (requested, health_result, rejected)
+            decision["outcome"] = "abort"
+        else:
+            effective_agents.pop(requested, None)
+            warnings.append(f"warning: skipping unhealthy seat {requested} [{typed_cause}]; no healthy fallback")
+
+    if not decisions:
+        return OrchestratorHealthRoutingDecision(roster=roster)
+
+    effective = replace(
+        roster,
+        agents=effective_agents,
+        orchestrator=effective_orchestrator,
+        seat_routing=tuple(decisions),
+    )
+    receipt: dict[str, object] = {"schema": "brigade.seat_routing.v1", "decisions": decisions}
+    orchestrator_decision = next(
+        (decision for decision in decisions if decision["requested_seat"] == roster.orchestrator), None
+    )
+    if orchestrator_decision is not None:
+        # Preserve the original v1 summary for existing artifact consumers.
+        receipt.update(
+            {
+                "requested_orchestrator": roster.orchestrator,
+                "effective_orchestrator": orchestrator_decision["effective_seat"],
+                "outcome": orchestrator_decision["outcome"],
+                "typed_cause": orchestrator_decision["typed_cause"],
+                "rejected_fallbacks": orchestrator_decision["rejected_fallbacks"],
+            }
+        )
+
+    if abort is None:
+        return OrchestratorHealthRoutingDecision(
+            roster=effective,
+            warning="\n".join(warnings) or None,
+            receipt=receipt,
+        )
+
+    requested, unhealthy_result, rejected = abort
+    typed_cause = _seat_health_typed_cause(unhealthy_result)
     if rejected:
         rejected_detail = "; rejected fallbacks: " + ", ".join(
             f"{entry['seat']} ({entry['status']}[{entry['cause']}])" for entry in rejected
         )
     else:
         rejected_detail = "; no declared fallbacks"
-    detail = f"orchestrator {requested} is unhealthy [{typed_cause}]{rejected_detail}"
+    if requested == roster.orchestrator:
+        detail = f"orchestrator {requested} is unhealthy [{typed_cause}]{rejected_detail}"
+    else:
+        detail = f"seat {requested} is unhealthy [{typed_cause}]{rejected_detail}"
+    failure = unhealthy_result.failure
     return OrchestratorHealthRoutingDecision(
-        roster=roster,
+        roster=effective,
+        warning="\n".join(warnings) or None,
         abort_detail=detail,
         abort_failure_phase=failure.phase.value if failure is not None else "preflight",
         abort_failure_kind=failure.failure_class.value if failure is not None else "unclassified",
-        receipt={
-            "schema": "brigade.seat_routing.v1",
-            "requested_orchestrator": requested,
-            "effective_orchestrator": None,
-            "outcome": "abort",
-            "typed_cause": typed_cause,
-            "rejected_fallbacks": rejected,
-        },
+        abort_seat=requested,
+        receipt=receipt,
     )
 
 
@@ -3368,7 +3436,11 @@ def run(
         )
         # After the initial run receipt, before planning: a probe failure stays receipted.
         health_results = _write_run_seat_health_receipt(output_dir, roster, cwd=cwd)
-        routing = resolve_orchestrator_health_routing(roster, health_results)
+        routing = resolve_orchestrator_health_routing(
+            roster,
+            health_results,
+            pinned_seats=frozenset({worker}) if worker is not None else frozenset(),
+        )
         roster = routing.roster
         if routing.warning is not None:
             print(routing.warning, file=sys.stderr)
@@ -3377,13 +3449,24 @@ def run(
             routing_receipt["run_id"] = output_dir.name
             _write_seat_routing_receipt(output_dir, routing_receipt)
         if routing.abort_detail is not None:
+            if roster.seat_routing:
+                run_path = output_dir / "run.json"
+                try:
+                    run_payload = json.loads(run_path.read_text())
+                except (OSError, json.JSONDecodeError) as exc:
+                    raise runguard.RetainRunLockError(
+                        f"failed to read run receipt before seat-routing abort: {exc}"
+                    ) from exc
+                if isinstance(run_payload, dict):
+                    run_payload["seat_routing"] = [dict(decision) for decision in roster.seat_routing]
+                    _write_json(run_path, receipt_schema.stamp_run_receipt(run_payload))
             record_run_termination(
                 output_dir,
                 status="failed",
                 failure_phase=routing.abort_failure_phase,
                 failure_kind=routing.abort_failure_kind,
                 detail=routing.abort_detail,
-                seat=roster.orchestrator,
+                seat=routing.abort_seat or roster.orchestrator,
             )
             print(f"error: {routing.abort_detail}", file=sys.stderr)
             return 2

--- a/src/brigade/roster.py
+++ b/src/brigade/roster.py
@@ -60,6 +60,9 @@ class Roster:
     scheduler: str | None = None
     codex_transport: str = "exec"
     resolution: RosterResolution | None = None
+    # Run-local admission evidence, carried on the effective roster so that
+    # subsequent run.json rewrites cannot discard a routing decision.
+    seat_routing: tuple[dict[str, object], ...] = ()
 
     def find_role(self, role: str) -> Agent | None:
         return next((a for a in self.agents.values() if a.role == role), None)

--- a/src/brigade/run_projector.py
+++ b/src/brigade/run_projector.py
@@ -76,6 +76,7 @@ PRESERVED_FIELDS: frozenset[str] = frozenset(
         "brief_budget",
         "route",
         "skill_route_policy",
+        "seat_routing",
         "pre_run_snapshot",
         "git",
         "code_graph_delta",

--- a/tests/test_aboyeur_orchestrator_health_routing.py
+++ b/tests/test_aboyeur_orchestrator_health_routing.py
@@ -27,11 +27,12 @@ class RaisingProbe:
         raise RuntimeError("probe failed")
 
 
-def _roster(*, fallback: tuple[str, ...] = ()):
+def _roster(*, fallback: tuple[str, ...] = (), worker_fallback: tuple[str, ...] = ()):
     agents = {
         "chef": Agent("chef", "codex", "plan and synthesize", fallback=fallback),
         "chef-fallback": Agent("chef-fallback", "claude", "plan and synthesize"),
-        "coder": Agent("coder", "codex", "write code"),
+        "coder": Agent("coder", "codex", "write code", fallback=worker_fallback),
+        "coder-fallback": Agent("coder-fallback", "claude", "write code"),
     }
     return Roster(orchestrator="chef", agents=agents, max_workers=1)
 
@@ -119,10 +120,21 @@ def test_unhealthy_orchestrator_without_declared_fallback_aborts(monkeypatch, tm
     run_meta = json.loads((output_dir / "run.json").read_text())
     assert run_meta["status"] == "failed"
     assert run_meta["failure"]["kind"] == "auth-required"
+    expected = {
+        "requested_seat": "chef",
+        "effective_seat": None,
+        "outcome": "abort",
+        "typed_cause": "auth-required",
+        "rejected_fallbacks": [],
+    }
+    # Chef and coder share a codex seat-health fingerprint, so an unhealthy chef can
+    # cache through to coder and produce a legitimate skip decision alongside abort.
+    assert expected in run_meta["seat_routing"]
 
     routing = json.loads((output_dir / "seat-routing.json").read_text())
     assert routing["outcome"] == "abort"
     assert routing["effective_orchestrator"] is None
+    assert expected in routing["decisions"]
 
 
 def test_unhealthy_orchestrator_with_unhealthy_declared_fallback_aborts(monkeypatch, tmp_path, capsys):
@@ -203,3 +215,108 @@ def test_probe_exception_proceeds_without_abort(monkeypatch, tmp_path, capsys):
 
     run_meta = json.loads((output_dir / "run.json").read_text())
     assert run_meta["status"] == "ok"
+
+
+def test_unhealthy_worker_routes_to_fallback_and_persists_decision(monkeypatch, tmp_path):
+    seen = {}
+
+    monkeypatch.setattr(
+        aboyeur,
+        "plan",
+        lambda *args, **kwargs: [aboyeur.Assignment(worker="coder", task="implement")],
+    )
+
+    def capture_dispatch(assignments, roster, **kwargs):
+        seen["agent"] = roster.agents["coder"]
+        return [aboyeur.WorkerResult(worker="coder", task="implement", text="done", ok=True)]
+
+    monkeypatch.setattr(aboyeur, "dispatch", capture_dispatch)
+    monkeypatch.setattr(
+        aboyeur,
+        "_run_orchestrator",
+        lambda *args, **kwargs: agents.AgentResult(text="final answer", ok=True),
+    )
+    _install_probe(monkeypatch, PerSeatFakeAdapter(unhealthy=frozenset({"coder"})))
+    output_dir = tmp_path / "run-worker-fallback"
+
+    assert (
+        run_aboyeur_guarded(
+            "build feature",
+            _roster(worker_fallback=("coder-fallback",)),
+            output_dir=output_dir,
+            code_graph_enabled=False,
+            route_enabled=False,
+        )
+        == 0
+    )
+
+    assert seen["agent"].name == "coder"
+    assert seen["agent"].cli == "claude"
+    expected = {
+        "requested_seat": "coder",
+        "effective_seat": "coder-fallback",
+        "outcome": "fallback",
+        "typed_cause": "auth-required",
+        "rejected_fallbacks": [],
+    }
+    routing = json.loads((output_dir / "seat-routing.json").read_text())
+    assert routing["decisions"] == [expected]
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["seat_routing"] == [expected]
+
+
+def test_healthy_worker_path_has_no_routing_decisions(monkeypatch, tmp_path):
+    _stub_run_phases(monkeypatch)
+    _install_probe(monkeypatch, PerSeatFakeAdapter())
+    output_dir = tmp_path / "run-worker-healthy"
+
+    assert (
+        run_aboyeur_guarded(
+            "build feature",
+            _roster(worker_fallback=("coder-fallback",)),
+            output_dir=output_dir,
+            code_graph_enabled=False,
+            route_enabled=False,
+        )
+        == 0
+    )
+
+    assert not (output_dir / "seat-routing.json").exists()
+    assert "seat_routing" not in json.loads((output_dir / "run.json").read_text())
+
+
+def test_unhealthy_direct_worker_without_fallback_aborts(monkeypatch, tmp_path, capsys):
+    _install_probe(monkeypatch, PerSeatFakeAdapter(unhealthy=frozenset({"coder"})))
+    output_dir = tmp_path / "run-direct-unhealthy"
+
+    assert (
+        run_aboyeur_guarded(
+            "build feature",
+            _roster(),
+            worker="coder",
+            output_dir=output_dir,
+            code_graph_enabled=False,
+            route_enabled=False,
+        )
+        == 2
+    )
+
+    stderr = capsys.readouterr().err
+    assert "error: seat coder is unhealthy [auth-required]" in stderr
+    assert "no declared fallbacks" in stderr
+
+    expected = {
+        "requested_seat": "coder",
+        "effective_seat": None,
+        "outcome": "abort",
+        "typed_cause": "auth-required",
+        "rejected_fallbacks": [],
+    }
+    run_meta = json.loads((output_dir / "run.json").read_text())
+    assert run_meta["status"] == "failed"
+    assert run_meta["failure"]["kind"] == "auth-required"
+    assert run_meta["failure"]["seat"] == "coder"
+    assert run_meta["seat_routing"] == [expected]
+
+    routing = json.loads((output_dir / "seat-routing.json").read_text())
+    assert routing["decisions"] == [expected]

--- a/tests/test_run_projector.py
+++ b/tests/test_run_projector.py
@@ -116,6 +116,7 @@ def _full_base_snapshot() -> dict:
         "brief_budget": 100,
         "route": "route-id",
         "skill_route_policy": "auto",
+        "seat_routing": [{"requested_seat": "coder", "outcome": "skip"}],
         "pre_run_snapshot": {"files": []},
         "git": {"branch": "main"},
         "code_graph_delta": {"changed": []},
@@ -523,7 +524,7 @@ def test_dataclasses_replace_mutation_of_typed_run_event_raises_event_chain_erro
 
 def test_full_field_fixture_preserves_deep_equality_and_copies_nested_values():
     base = _full_base_snapshot()
-    assert len(PRESERVED_FIELDS) == 46
+    assert len(PRESERVED_FIELDS) == 47
     assert DERIVED_FIELDS == {
         "status",
         "projector_version",


### PR DESCRIPTION
## Summary

- project seat health into routing before candidate selection
- exclude unhealthy root seats while retaining healthy fallbacks
- keep explicit worker requests deterministic when health data is unavailable

Fixes #578

## Verification

- `pytest -q tests/test_aboyeur_orchestrator_health_routing.py tests/test_run_projector.py`
- `ruff check src/brigade/aboyeur.py src/brigade/roster.py src/brigade/run_projector.py tests/test_aboyeur_orchestrator_health_routing.py tests/test_run_projector.py`

