### PR TITLE
fix(security): coalesce overlapping scan findings

### DIFF
--- a/src/brigade/security_cmd/models.py
+++ b/src/brigade/security_cmd/models.py
@@ -250,6 +250,45 @@ def _secrets_title_rank(title: str) -> int:
     return SECRETS_TITLE_RANK.get(title, 0)
 
 
+_INTERNAL_FINDING_KEYS = frozenset({"_coalesce_group", "_fingerprint_content"})
+
+
+def _strip_internal_finding_keys(finding: dict[str, Any]) -> dict[str, Any]:
+    for key in _INTERNAL_FINDING_KEYS:
+        finding.pop(key, None)
+    return finding
+
+
+def _finding_coalesce_rank(finding: dict[str, Any]) -> tuple[int, int]:
+    """Rank coalesce-group members: severity first, then secrets title tie-break.
+
+    Scanner-defined coalesce groups currently emit uniform severity; title rank
+    breaks ties within the same severity so the most specific secret label wins.
+    """
+    severity = SEVERITY_ORDER.get(str(finding.get("severity") or ""), 0)
+    return severity, _secrets_title_rank(str(finding.get("title") or ""))
+
+
+def _coalesce_findings(findings: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Select the strongest remaining member of each scanner-defined group."""
+    selected: list[tuple[int, dict[str, Any]]] = []
+    grouped: dict[tuple[str, str, int], tuple[int, dict[str, Any]]] = {}
+    for index, finding in enumerate(findings):
+        group = finding.pop("_coalesce_group", None)
+        if not group:
+            selected.append((index, finding))
+            continue
+        key = (str(group), str(finding.get("path") or ""), int(finding.get("line") or 0))
+        current = grouped.get(key)
+        if current is None or _finding_coalesce_rank(finding) > _finding_coalesce_rank(current[1]):
+            grouped[key] = (index, finding)
+    selected.extend(grouped.values())
+    coalesced = [finding for _, finding in sorted(selected, key=lambda item: item[0])]
+    for finding in coalesced:
+        _strip_internal_finding_keys(finding)
+    return coalesced
+
+
 def _is_security_scanner_literal(path: Path, line: str, target: Path) -> bool:
     try:
         rel = path.relative_to(target).as_posix()

--- a/src/brigade/security_cmd/scan_engine.py
+++ b/src/brigade/security_cmd/scan_engine.py
@@ -655,12 +655,10 @@ def _scan_line(
     file_classification = classification or _classification_for(path, target)
     if _is_security_scanner_literal(path, line, target):
         return
-    best_secret: tuple[str, str] | None = None
+    secret_candidates: dict[str, str] = {}
 
     def consider_secret(title: str, suggestion: str) -> None:
-        nonlocal best_secret
-        if best_secret is None or _secrets_title_rank(title) > _secrets_title_rank(best_secret[0]):
-            best_secret = (title, suggestion)
+        secret_candidates.setdefault(title, suggestion)
 
     try:
         rel_path = path.relative_to(target).as_posix()
@@ -697,8 +695,7 @@ def _scan_line(
                 if session_chat
                 else "Remove secret material from the repo and rotate the credential if it was real.",
             )
-    if best_secret is not None:
-        title, suggestion = best_secret
+    for title, suggestion in secret_candidates.items():
         _finding(
             findings,
             target=target,
@@ -712,6 +709,7 @@ def _scan_line(
             classification=file_classification,
             response_options=_secret_response_options(path, target),
         )
+        findings[-1]["_coalesce_group"] = "secrets-line"
     if "danger-full-access" in line or "sandbox_permissions" in line and "require_escalated" in line:
         _finding(
             findings,
@@ -981,10 +979,13 @@ def scan_target(
     open_findings = []
     for finding in findings:
         if _finding_matches_fingerprints(finding, suppression_set, migration_map=migration_map):
+            finding.pop("_coalesce_group", None)
             suppressed.append(finding)
         else:
             open_findings.append(finding)
-    findings = open_findings
+    findings = _coalesce_findings(open_findings)
+    for finding in suppressed:
+        _strip_internal_finding_keys(finding)
     counts: dict[str, int] = {}
     for finding in findings:
         severity = str(finding["severity"])
@@ -1277,6 +1278,10 @@ def write_evidence_bundle(report: dict[str, Any], output_dir: Path) -> Path:
     output_dir = output_dir.expanduser().resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
     report = dict(report)
+    for bucket in ("findings", "suppressed_findings"):
+        for finding in report.get(bucket) or []:
+            if isinstance(finding, dict):
+                _strip_internal_finding_keys(finding)
     report["artifacts"] = str(output_dir)
     (output_dir / "security-report.json").write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
     (output_dir / "security-report.md").write_text(_render_markdown_report(report))

--- a/src/brigade/security_cmd/scan_engine.py
+++ b/src/brigade/security_cmd/scan_engine.py
@@ -995,6 +995,7 @@ def scan_target(
         "scanned_files": scanned_files,
         "scanned_file_count": len(scanned_files),
         "finding_count": len(findings),
+        # suppressed_count is per fingerprint; open findings are coalesced first.
         "suppressed_count": len(suppressed),
         "severity_counts": dict(sorted(counts.items())),
         "findings": findings,

--- a/tests/test_security_cmd.py
+++ b/tests/test_security_cmd.py
@@ -285,6 +285,66 @@ def test_security_scan_secret_fingerprints_are_pinned(tmp_path):
     }
 
 
+def _coalesced_secret_candidates(tmp_path):
+    path = tmp_path / "secrets.env"
+    line = "TOKEN=abc123abc123abc123abc123abc123"
+    path.write_text(line + "\n")
+    candidates = []
+    security_cmd._scan_line(candidates, target=tmp_path, path=path, line_number=1, line=line)
+    security_cmd._assign_fingerprints(candidates)
+    return candidates
+
+
+def test_security_scan_partly_suppressed_group_reports_only_unsuppressed_member(tmp_path):
+    candidates = _coalesced_secret_candidates(tmp_path)
+    assert [item["title"] for item in candidates] == [
+        "Possible hardcoded credential",
+        "Possible sensitive secret material",
+    ]
+
+    report = security_cmd.scan_target(tmp_path, suppressions=(candidates[0]["fingerprint"],))
+
+    assert report["finding_count"] == 1
+    assert report["suppressed_count"] == 1
+    assert report["findings"][0]["title"] == "Possible sensitive secret material"
+    assert report["suppressed_findings"][0]["title"] == "Possible hardcoded credential"
+
+
+def test_security_scan_fully_suppressed_group_disappears(tmp_path):
+    candidates = _coalesced_secret_candidates(tmp_path)
+
+    report = security_cmd.scan_target(
+        tmp_path,
+        suppressions=tuple(item["fingerprint"] for item in candidates),
+    )
+
+    assert report["finding_count"] == 0
+    assert report["suppressed_count"] == 2
+    assert report["findings"] == []
+
+
+def test_security_scan_coalesces_single_secret_without_marker_leak(tmp_path, capsys):
+    path = tmp_path / "secrets.env"
+    line = "TOKEN=abc123abc123abc123abc123abc123"
+    path.write_text(line + "\n")
+
+    report = security_cmd.scan_target(tmp_path)
+
+    assert report["finding_count"] == 1
+    assert report["suppressed_count"] == 0
+    assert report["findings"][0]["title"] == "Possible hardcoded credential"
+    for bucket in ("findings", "suppressed_findings"):
+        for finding in report.get(bucket) or []:
+            assert "_coalesce_group" not in finding
+            assert "_fingerprint_content" not in finding
+
+    assert security_cmd.scan(target=tmp_path, fail_on="none", json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    serialized = json.dumps(payload)
+    assert "_coalesce_group" not in serialized
+    assert payload["finding_count"] == 1
+
+
 def test_security_policy_presets_and_template_inclusion(tmp_path, capsys):
     template_dir = tmp_path / "src" / "brigade" / "templates" / "workspace"
     template_dir.mkdir(parents=True)

--- a/tests/test_security_cmd.py
+++ b/tests/test_security_cmd.py
@@ -285,6 +285,12 @@ def test_security_scan_secret_fingerprints_are_pinned(tmp_path):
     }
 
 
+def test_finding_coalesce_rank_severity_outranks_title():
+    high_low_title = {"severity": "high", "title": "Possible sensitive secret material"}
+    low_high_title = {"severity": "low", "title": "Session chat contains exposed credential"}
+    assert security_cmd._finding_coalesce_rank(high_low_title) > security_cmd._finding_coalesce_rank(low_high_title)
+
+
 def _coalesced_secret_candidates(tmp_path):
     path = tmp_path / "secrets.env"
     line = "TOKEN=abc123abc123abc123abc123abc123"
@@ -305,6 +311,7 @@ def test_security_scan_partly_suppressed_group_reports_only_unsuppressed_member(
     report = security_cmd.scan_target(tmp_path, suppressions=(candidates[0]["fingerprint"],))
 
     assert report["finding_count"] == 1
+    # Two coalesce-group members; one suppressed fingerprint leaves one open finding.
     assert report["suppressed_count"] == 1
     assert report["findings"][0]["title"] == "Possible sensitive secret material"
     assert report["suppressed_findings"][0]["title"] == "Possible hardcoded credential"
@@ -319,6 +326,7 @@ def test_security_scan_fully_suppressed_group_disappears(tmp_path):
     )
 
     assert report["finding_count"] == 0
+    # Both group members suppressed individually even though open findings coalesce.
     assert report["suppressed_count"] == 2
     assert report["findings"] == []
 
@@ -343,6 +351,12 @@ def test_security_scan_coalesces_single_secret_without_marker_leak(tmp_path, cap
     serialized = json.dumps(payload)
     assert "_coalesce_group" not in serialized
     assert payload["finding_count"] == 1
+
+    output_dir = tmp_path / ".brigade" / "security" / "latest"
+    assert security_cmd.scan(target=tmp_path, fail_on="none", output_dir=output_dir) == 0
+    capsys.readouterr()
+    sarif = json.loads((output_dir / "security-report.sarif").read_text())
+    assert "_coalesce_group" not in json.dumps(sarif)
 
 
 def test_security_policy_presets_and_template_inclusion(tmp_path, capsys):


### PR DESCRIPTION
## Summary

- coalesce overlapping security findings before suppression matching
- choose the representative finding by severity and stable title rank
- prevent internal coalescing metadata from reaching JSON, SARIF, or evidence bundles

Fixes #705

## Verification

- `pytest -q tests/test_security_cmd.py`
- `ruff check src/brigade/security_cmd/models.py src/brigade/security_cmd/scan_engine.py tests/test_security_cmd.py`

