### PR TITLE
fix(run): reject mutual-wait plan cycles at build; honest one-node dag reporting

### DIFF
--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -44,7 +44,7 @@ from .run_receipts import (
     write_agent_logs as _write_agent_logs,
     write_worker_logs as _write_worker_logs,
 )
-from .run_transport import Assignment, WorkerResult
+from .run_transport import Assignment, WorkerResult, dag_cycle_members
 from .roster import Agent, Roster, is_cli_allowed, read_only_capability_error, timeout_for, workers
 from .route_catalog import RouteBrief, route_brief, uncovered_stages, unknown_covers
 from .route_policy import (
@@ -1329,6 +1329,14 @@ def _unknown_covers(route: RouteBrief | None, assignments: list[Assignment]) -> 
     return unknown_covers(route, assignments)
 
 
+def _validate_plan_dependencies(route: RouteBrief | None, assignments: list[Assignment]) -> None:
+    if route is None or not route.attached:
+        return
+    members = dag_cycle_members(assignments, route.dependencies)
+    if members:
+        raise ValueError(f"plan has a dependency cycle involving: {', '.join(members)}")
+
+
 def _orchestrator_hides_write_tools(
     roster: Roster,
     *,
@@ -1394,6 +1402,7 @@ def plan(
         raise RuntimeError(f"orchestrator failed during plan: {first.detail}")
     try:
         assignments = parse_plan(first.text, roster, read_only=read_only, skill_policy=skill_policy)
+        _validate_plan_dependencies(route, assignments)
         _record_plan_attempt(
             attempts,
             stage="initial",
@@ -1433,6 +1442,7 @@ def plan(
             raise RuntimeError(f"orchestrator failed during plan correction: {second.detail}") from exc
         try:
             assignments = parse_plan(second.text, roster, read_only=read_only, skill_policy=skill_policy)
+            _validate_plan_dependencies(route, assignments)
             _record_plan_attempt(
                 attempts,
                 stage="correction",
@@ -1487,6 +1497,7 @@ def plan(
         return assignments
     try:
         revised = parse_plan(revised_result.text, roster, read_only=read_only, skill_policy=skill_policy)
+        _validate_plan_dependencies(route, revised)
     except ValueError as exc:
         _record_plan_attempt(attempts, stage="coverage-correction", result=revised_result, parse_error=str(exc))
         return assignments

--- a/src/brigade/run_transport.py
+++ b/src/brigade/run_transport.py
@@ -707,7 +707,7 @@ def dispatch(
         placement_error = _dag_placement_error(assignments, route_dependencies)
         if placement_error is None:
             if on_scheduler_resolved is not None:
-                on_scheduler_resolved("dag", None)
+                on_scheduler_resolved("single-node" if len(assignments) == 1 else "dag", None)
             return _dag_dispatch(
                 assignments,
                 roster,
@@ -804,6 +804,65 @@ def _dag_placement_error(
         if assignment.covers and not set(assignment.covers) <= known:
             return "plan not fully covered"
     return None
+
+
+def dag_cycle_members(
+    assignments: list[Assignment],
+    route_dependencies: dict[str, tuple[str, ...]],
+) -> tuple[str, ...]:
+    """Return workers in mutual-wait components of an assignment plan.
+
+    This uses the same covers-set semantics as the ready queue: a dependency
+    covered by the assignment itself is satisfied locally, while a stage with
+    multiple coverers needs any one of them to finish.  Nodes that can become
+    ready are peeled first so an optional cyclic coverer does not make an
+    otherwise runnable plan look cyclic.
+    """
+    coverers: dict[str, tuple[int, ...]] = {}
+    for stage_name in route_dependencies:
+        coverers[stage_name] = tuple(i for i, assignment in enumerate(assignments) if stage_name in assignment.covers)
+
+    groups: list[tuple[tuple[int, ...], ...]] = []
+    for i, assignment in enumerate(assignments):
+        dependencies: dict[str, tuple[int, ...]] = {}
+        for stage_name in assignment.covers:
+            for dependency in route_dependencies.get(stage_name, ()):
+                stage_coverers = coverers.get(dependency, ())
+                if i in stage_coverers:
+                    continue
+                others = tuple(index for index in stage_coverers if index != i)
+                if others:
+                    dependencies[dependency] = others
+        groups.append(tuple(dependencies.values()))
+
+    runnable: set[int] = set()
+    changed = True
+    while changed:
+        changed = False
+        for i, prerequisites in enumerate(groups):
+            if i not in runnable and all(set(group) & runnable for group in prerequisites):
+                runnable.add(i)
+                changed = True
+
+    blocked = set(range(len(assignments))) - runnable
+    edges = {i: {member for group in groups[i] for member in group if member in blocked} for i in blocked}
+    cycle_nodes: set[int] = set()
+
+    # Small plans make a direct reachability test clearer than a full SCC
+    # implementation: an edge is cyclic exactly when its target reaches back.
+    def reaches(start: int, target: int, seen: set[int]) -> bool:
+        if start == target:
+            return True
+        if start in seen:
+            return False
+        seen.add(start)
+        return any(reaches(next_node, target, seen) for next_node in edges.get(start, ()))
+
+    for source, targets in edges.items():
+        for target in targets:
+            if reaches(target, source, set()):
+                cycle_nodes.update((source, target))
+    return tuple(assignments[i].worker for i in sorted(cycle_nodes))
 
 
 def _dag_dispatch(

--- a/tests/test_aboyeur.py
+++ b/tests/test_aboyeur.py
@@ -4529,6 +4529,32 @@ def test_plan_covered_first_try_makes_one_call(monkeypatch):
     assert assignments[0].covers == ("implement", "correctness-review", "verify")
 
 
+def test_plan_rejects_mutual_wait_cycle_with_named_members(monkeypatch):
+    from brigade.route_catalog import RouteBrief
+
+    route = RouteBrief(
+        attached=True,
+        route=("first", "second", "third"),
+        dependencies={"first": (), "second": ("first",), "third": ("second",)},
+    )
+    plan_json = json.dumps(
+        {
+            "assignments": [
+                {"worker": "coder", "task": "first and third", "covers": ["first", "third"]},
+                {"worker": "reviewer", "task": "second", "covers": ["second"]},
+            ]
+        }
+    )
+
+    monkeypatch.setattr(
+        aboyeur.agents,
+        "run_agent",
+        lambda *args, **kwargs: agents.AgentResult(text=plan_json, ok=True),
+    )
+    with pytest.raises(RuntimeError, match=r"dependency cycle involving: coder, reviewer"):
+        aboyeur.plan("build it", _roster(), route=route)
+
+
 def test_plan_coverage_retry_falls_back_to_first_plan_on_bad_revision(monkeypatch):
     from brigade.route_catalog import route_brief
 

--- a/tests/test_run_transport_dag.py
+++ b/tests/test_run_transport_dag.py
@@ -197,6 +197,17 @@ def test_scheduler_resolution_reported_when_dag_engages(dag_harness):
     assert resolved == [("dag", None)]
 
 
+def test_scheduler_resolution_distinguishes_single_node_plan(dag_harness):
+    resolved = []
+    results = dag_harness(
+        assignments=[_a("p", 1, ["plan"])],
+        dependencies=DEPS,
+        on_scheduler_resolved=lambda used, reason: resolved.append((used, reason)),
+    )
+    assert resolved == [("single-node", None)]
+    assert results[0].ok is True
+
+
 def test_scheduler_resolution_reports_wave_fallback(dag_harness):
     resolved = []
     dag_harness(


### PR DESCRIPTION
Closes both defects from the DAG trial receipt analysis: mutual-wait cycles (the shape #742's self-coverage check misses) are rejected at plan build with named members at all three plan points, and scheduler metadata now distinguishes one-node plans from genuine DAG execution.

Verified: tests/test_run_transport_dag.py and tests/test_aboyeur.py green locally.

Origin: Codex Cloud task applied locally and reviewed.

Fixes #780