### PR TITLE
feat(skills): forward-plan registry skill (#779)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (open blockers, wrong status) fail closed. `work release` / `work reassign`
   compare claim identity; empty filter values match nothing. `work status`
   lists stale claims (default 24h).
+- `forward-plan` bundled registry skill (#779): turns the native ready set,
+  `brigade outcome rank`, and repo `ROADMAP.md` into a dependency-filed plan
+  artifact under `.brigade/work/plans/`. Proposes GraphTrail-derived edges
+  (`blocks` from def/use, `conflicts-with` from write overlap) marked derived
+  and confirmation-gated; degrades to zero proposed edges when GraphTrail is
+   unavailable. Ships `plan.template.json` as the artifact contract. Skill only,
+   with no new CLI subcommand.
 - Work task ledger dependency edges and a computed ready set (#737): typed
   edges (`blocks`, `parent-child`, `discovered-from`) live as a normalized
   top-level `edges` array in `.brigade/work/tasks.json` (schema version 2).

--- a/src/brigade/templates/skills/forward-plan/CHANGELOG.md
+++ b/src/brigade/templates/skills/forward-plan/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## 0.1.0
+
+- Initial bundled forward-plan skill: ready set + outcome rank + ROADMAP.md to a
+  dependency-filed plan artifact under `.brigade/work/plans/`.
+- Propose GraphTrail-derived edges (`blocks` from def/use, `conflicts-with` from
+  write overlap), marked derived and requiring confirmation; degrade to zero
+  proposed edges when GraphTrail is unavailable.
+- Ship `plan.template.json` as the mechanical plan-artifact contract.
+- Scope Bash to named Brigade ready/rank/task/plans/code commands; Write only
+  under `.brigade/work/plans/`.

--- a/src/brigade/templates/skills/forward-plan/SKILL.md
+++ b/src/brigade/templates/skills/forward-plan/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: forward-plan
+description: Use when turning Brigade's native ready set, outcome rank, and ROADMAP.md into a dependency-filed plan artifact under .brigade/work/plans/ - propose GraphTrail-derived edges (blocks from def/use, conflicts-with from write overlap) marked derived and requiring confirmation. Degrade cleanly when GraphTrail is unavailable. Never a subcommand.
+allowed-tools: Read, Grep, Write, Bash(brigade work ready:*), Bash(brigade outcome rank:*), Bash(brigade work task:*), Bash(brigade work plans:*), Bash(brigade code:*)
+compatibility: Brigade-wired workspaces with a work ledger. GraphTrail optional (degrades to no proposed edges).
+---
+
+# forward-plan
+
+Turn the native ready set, outcome ranking, and the repo ROADMAP into one
+dependency-filed plan artifact. Brigade stays invoke-only. This skill is the
+allowlist-bound agent recipe. It is a registry skill, never a CLI subcommand -
+the planning sequence stays inspectable.
+
+## When this applies
+
+- You need a forward plan that joins what is ready now with roadmap direction.
+- An operator schedules a headless harness against this skill for planning.
+- The workspace has (or can create) `.brigade/work/` and may or may not have
+  GraphTrail installed.
+
+## Allowlist
+
+Work only through this allowlist:
+
+- `brigade work ready --json` (add `--explain` when blocked items matter)
+- `brigade outcome rank --json` (optional `--by-capability` / `--recency`)
+- Read of repo-root `ROADMAP.md` under the parse contract below
+- `brigade code …` for GraphTrail footprint / impact / doctor checks
+- `brigade work task edge …` / `brigade work task add --graph …` only after an
+  operator confirms derived edges (never auto-apply. See Safety gates)
+- `brigade work plans` to list existing plan artifacts
+- Write only under `.brigade/work/plans/` (the plan JSON + plan.md pair)
+- Read/Grep of on-disk task ledgers, existing plans, and code paths named by
+  GraphTrail output
+
+Bash is scoped to those `brigade …` commands only. Do not expand into arbitrary
+shell, remote APIs, or writes outside `.brigade/work/plans/`. Stay inside the
+target workspace. Do not follow `..` or symlinks out of it.
+
+## Safety gates
+
+**Plan draft is not graph-ingest input.** A forward-plan draft under
+`.brigade/work/plans/` (the `.json` / `.plan.md` pair) is **not** valid input
+to `brigade work task add --graph`. That command expects a graph-ingest file
+shaped for task creation with edges. Feeding it a plan draft can create task
+nodes while applying **zero** proposed edges from `proposed_edges`.
+
+**Confirmation is procedural, not enforced by the allowlist.** Derived-edge
+confirmation is an operator-in-the-loop gate. The broad
+`Bash(brigade work task:*)` allowed-tool pattern does not enforce it, so this
+recipe must not run any mutating `brigade work task …` or
+`brigade work task edge …` command before the operator gives explicit
+confirmation.
+
+## Inputs
+
+1. **Native ready set** - `brigade work ready --json` (from the work ledger
+   dependency edges / ready resolver). Prefer `--explain` when the ready set is
+   empty so blocked paths are visible.
+2. **Outcome rank** - `brigade outcome rank --json`. Use ranking only as a
+   soft priority signal for ordering proposed work, never as a substitute for
+   readiness.
+3. **ROADMAP.md** - repo-root roadmap, parsed with the contract below.
+
+## ROADMAP.md parse contract
+
+Read only the repo-root file `ROADMAP.md` (or the path the operator names as
+that roadmap). Heading shapes:
+
+| Heading shape | Action |
+|---|---|
+| `# …` (document title) | Ignore for item extraction. Context only. |
+| `## Now…` / `## Current…` | **Read.** Collect `-` / `*` bullets as active candidates. |
+| `## Next…` | **Read.** Collect bullets as near-term candidates (below Now). |
+| `## Later…` | **Read.** Collect bullets as deferred candidates (lowest priority). |
+| `## Vocabulary` / `## How items move` / archive / process sections | **Ignore.** |
+| `## Where things stand` / status snapshot sections | **Ignore** for new plan nodes (background only). |
+| Any other `##` / `###` | Ignore unless the operator explicitly names it in scope. |
+
+Bullet rules:
+
+- Only lines starting with `- ` or `* ` under an included section become
+  candidates. Nested prose paragraphs, tables, and fenced code are ignored.
+- Bold lead-ins (`- **Title.** rest`) keep the title as the candidate label.
+  The rest is supporting detail.
+- Links, archive pointers, and "Status: implemented" closure notes do not
+  create new plan nodes on their own.
+- Do not invent roadmap items that are not on-disk bullets under an included
+  heading.
+
+## Output: dependency-filed plan artifact
+
+Write a paired artifact under `.brigade/work/plans/`:
+
+- `.brigade/work/plans/<plan-id>.json`
+- `.brigade/work/plans/<plan-id>.plan.md`
+
+Choose `<plan-id>` as `forward-plan-<UTC-YYYYMMDDTHHMMSSZ>` (filesystem-safe).
+Use the shipped `plan.template.json` shape in this skill directory as the JSON
+contract. Required fields:
+
+- `kind`: `"forward-plan"`
+- `status`: `"draft"` until an operator accepts. Never auto-accept
+- `inputs`: records of ready-set, outcome-rank, and roadmap sources used
+- `nodes`: proposed or existing work items (ready tasks first, then Now/Next
+  roadmap candidates not already covered)
+- `proposed_edges`: dependency proposals (see below)
+- `graphtrail`: availability, snapshot identity when known, and degradation note
+- `next_command`: a safe next step (default review the draft. Never a mutating
+  apply)
+
+The `.plan.md` mirrors the JSON: summary, nodes, proposed edges (calling out
+derived + unconfirmed), GraphTrail status, and next safe command.
+
+## Derived dependency edges (GraphTrail impact intersection)
+
+When GraphTrail is available (`brigade code doctor` / impact / neighbors work):
+
+1. Build a footprint per candidate node (files + symbol ids) from GraphTrail
+   context/impact, stamped with the graph snapshot you queried.
+2. Pairwise impact intersection over open / proposed nodes:
+   - **def/use ordering** → directed `blocks` (definer/source blocks
+     consumer/target)
+   - **write overlap** (same files written) → unordered `conflicts-with`
+3. Every such edge is **derived**: set `derived: true`, record `rule`
+   (`def-use` or `write-overlap`), and a `snapshot_hash` (or graph identity).
+   Set `confirmed: false`.
+4. Derived edges **require confirmation** before they become real ledger edges.
+   Do not call `work task edge add` or `--graph` apply for derived edges until
+   an operator confirms them.
+5. Only derived edges may be auto-retracted by a later reconcile recipe (see
+   scheduled-care / outcome reconcile docs). Authored (human-confirmed) edges
+   are never auto-deleted by this skill. If GraphTrail later contradicts them,
+   flag the contradiction in the plan, do not silently remove them.
+
+`conflicts-with` is proposal-only in the plan artifact today (the native ledger
+edge types are `blocks`, `parent-child`, `discovered-from`). On confirmation,
+file native `blocks` edges that the operator accepts. Keep confirmed
+`conflicts-with` in the plan as parallel-safety advisories unless a native type
+exists.
+
+### GraphTrail unavailable (degrade cleanly)
+
+If GraphTrail is missing, the DB is absent, or `brigade code …` fails:
+
+- Propose **no** derived edges (`proposed_edges: []`).
+- Set `graphtrail.available` to `false` and state plainly in both JSON and
+  plan.md: "GraphTrail unavailable. No derived dependency edges proposed."
+- Still write the plan from the ready set, outcome rank, and ROADMAP parse.
+- Do not invent edges from prose guesswork.
+
+## Process
+
+1. Run `brigade work ready --json` (and `--explain` if ready is empty).
+2. Run `brigade outcome rank --json`.
+3. Read `ROADMAP.md` under the parse contract. Collect Now / Next / Later
+   bullets.
+4. Probe GraphTrail (`brigade code doctor` or a cheap `brigade code stats`).
+   If unavailable, skip to step 6 with empty proposed edges and say so.
+5. Otherwise compute footprints and propose derived edges from impact
+   intersection. Mark each derived + unconfirmed.
+6. Soft-order nodes: ready set first, then outcome-rank hints, then Now, Next,
+   Later roadmap candidates.
+7. Write `.brigade/work/plans/<plan-id>.json` and `.plan.md` from the template
+   contract. Leave `status: draft`.
+8. Stop. Present the artifact paths and wait for confirmation before filing any
+   ledger edges. Capture outcomes against `forward-plan` when verification is
+   part of the run.
+
+## Failure paths
+
+- Missing `.brigade/` / work ledger / target: stop. Report the missing path.
+  Do not invent a ledger or run against the operator home.
+- Empty ready set and no includable ROADMAP bullets: exit cleanly with
+  "nothing to plan". Write no artifact (or write a draft that says so and lists
+  zero nodes - prefer no artifact when both inputs are empty).
+- Missing `ROADMAP.md`: continue with ready set + outcome rank only. Note the
+  missing roadmap in `inputs` and do not invent roadmap nodes.
+- Malformed ready / rank JSON or unreadable ROADMAP: skip the bad input, say
+  so, continue with what remains. Never rewrite ledger or roadmap files to
+  "fix" parse errors.
+- GraphTrail errors mid-probe: degrade as above (no derived edges, say so).
+
+## Out of scope
+
+- New CLI subcommands or changing the work ledger schema
+- Auto-applying derived edges without confirmation
+- Scheduler or model-dispatch integration
+- Auto-retracting authored edges

--- a/src/brigade/templates/skills/forward-plan/plan.template.json
+++ b/src/brigade/templates/skills/forward-plan/plan.template.json
@@ -1,0 +1,70 @@
+{
+  "kind": "forward-plan",
+  "plan_id": "forward-plan-YYYYMMDDTHHMMSSZ",
+  "title": "Forward plan",
+  "status": "draft",
+  "created_at": "YYYY-MM-DDTHH:MM:SS+00:00",
+  "updated_at": "YYYY-MM-DDTHH:MM:SS+00:00",
+  "inputs": {
+    "ready": {
+      "command": "brigade work ready --json",
+      "ready_count": 0,
+      "source": ".brigade/work/tasks.json"
+    },
+    "outcome_rank": {
+      "command": "brigade outcome rank --json",
+      "ranking_count": 0
+    },
+    "roadmap": {
+      "path": "ROADMAP.md",
+      "sections_read": ["Now", "Next", "Later"],
+      "sections_ignored": ["Vocabulary", "Where things stand", "How items move"]
+    }
+  },
+  "nodes": [
+    {
+      "key": "example-ready-task",
+      "text": "Example node text",
+      "origin": "ready|roadmap-now|roadmap-next|roadmap-later|proposed",
+      "task_id": null,
+      "priority_hint": "ready-first then outcome-rank then roadmap Now/Next/Later"
+    }
+  ],
+  "proposed_edges": [
+    {
+      "source": "example-a",
+      "target": "example-b",
+      "type": "blocks",
+      "derived": true,
+      "confirmed": false,
+      "rule": "def-use",
+      "snapshot_hash": null,
+      "notes": "Derived from GraphTrail impact intersection; requires confirmation before ledger filing."
+    },
+    {
+      "source": "example-a",
+      "target": "example-c",
+      "type": "conflicts-with",
+      "derived": true,
+      "confirmed": false,
+      "rule": "write-overlap",
+      "snapshot_hash": null,
+      "notes": "Proposal-only parallel-safety advisory until a native conflicts-with edge exists."
+    }
+  ],
+  "graphtrail": {
+    "available": false,
+    "snapshot_hash": null,
+    "degradation": "GraphTrail unavailable; no derived dependency edges proposed."
+  },
+  "confirmation": {
+    "required_for_derived_edges": true,
+    "auto_apply_forbidden": true,
+    "only_derived_may_be_auto_retracted": true
+  },
+  "next_command": "brigade work plans",
+  "receipt_paths": [
+    ".brigade/work/plans/forward-plan-YYYYMMDDTHHMMSSZ.json",
+    ".brigade/work/plans/forward-plan-YYYYMMDDTHHMMSSZ.plan.md"
+  ]
+}

--- a/src/brigade/templates/skills/forward-plan/skill.json
+++ b/src/brigade/templates/skills/forward-plan/skill.json
@@ -1,0 +1,17 @@
+{
+  "id": "forward-plan",
+  "title": "forward-plan",
+  "version": "0.1.0",
+  "description": "Allowlist-bound forward planner: ready set + outcome rank + ROADMAP.md to a dependency-filed plan under .brigade/work/plans/, with GraphTrail-derived edges marked derived and confirmation-gated.",
+  "required_tools": [
+    "Read",
+    "Grep",
+    "Write",
+    "Bash(brigade work ready:*)",
+    "Bash(brigade outcome rank:*)",
+    "Bash(brigade work task:*)",
+    "Bash(brigade work plans:*)",
+    "Bash(brigade code:*)"
+  ],
+  "tests": ["brigade skills lint forward-plan"]
+}

--- a/tests/test_forward_plan_skill.py
+++ b/tests/test_forward_plan_skill.py
@@ -1,0 +1,228 @@
+"""Contract tests for the forward-plan registry skill (#779).
+
+Ships as a bundled registry skill (memory-care pack pattern), never a CLI
+subcommand. Mechanical pieces: SKILL.md / skill.json / CHANGELOG.md plus
+plan.template.json validity.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from brigade import agent_skill_format, skills_cmd
+from brigade.templates import template_root
+
+FORWARD_PLAN = "forward-plan"
+PERMITTED_BASE_TOOLS = frozenset({"Read", "Grep", "Write"})
+SCOPED_BRIGADE_BASH_RE = re.compile(r"^Bash\(brigade .+:\*\)$")
+EXPECTED_SCOPED_BASH = frozenset(
+    {
+        "Bash(brigade work ready:*)",
+        "Bash(brigade outcome rank:*)",
+        "Bash(brigade work task:*)",
+        "Bash(brigade work plans:*)",
+        "Bash(brigade code:*)",
+    }
+)
+REQUIRED_TEMPLATE_KEYS = frozenset(
+    {
+        "kind",
+        "plan_id",
+        "status",
+        "inputs",
+        "nodes",
+        "proposed_edges",
+        "graphtrail",
+        "confirmation",
+        "next_command",
+        "receipt_paths",
+    }
+)
+
+
+def _bundled_skill_dir(skill_id: str = FORWARD_PLAN) -> Path:
+    return template_root() / "skills" / skill_id
+
+
+def _skill_text() -> str:
+    path = _bundled_skill_dir() / "SKILL.md"
+    assert path.is_file(), "missing bundled SKILL.md for forward-plan"
+    return path.read_text(encoding="utf-8")
+
+
+def _skill_metadata() -> dict:
+    path = _bundled_skill_dir() / "skill.json"
+    assert path.is_file(), "missing bundled skill.json for forward-plan"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _tool_is_permitted(tool: str) -> bool:
+    if tool in PERMITTED_BASE_TOOLS:
+        return True
+    return SCOPED_BRIGADE_BASH_RE.fullmatch(tool) is not None
+
+
+def test_forward_plan_is_present_in_bundled_registry(tmp_path, capsys):
+    source = _bundled_skill_dir()
+    assert (source / "SKILL.md").is_file()
+    assert (source / "skill.json").is_file()
+    assert (source / "CHANGELOG.md").is_file()
+    assert (source / "plan.template.json").is_file()
+
+    metadata = _skill_metadata()
+    assert metadata.get("id") == FORWARD_PLAN
+
+    assert skills_cmd.lint(target=tmp_path, skill=FORWARD_PLAN, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["valid"] is True
+    assert payload["skill_id"] == FORWARD_PLAN
+    assert payload["source"]["kind"] == "brigade-bundle"
+    assert payload["source"]["identity"] == f"brigade://bundled-skills/{FORWARD_PLAN}"
+
+    assert skills_cmd.import_skill(target=tmp_path, source=source, json_output=True) == 0
+    capsys.readouterr()
+    assert skills_cmd.search(target=tmp_path, query=FORWARD_PLAN, json_output=True) == 0
+    search = json.loads(capsys.readouterr().out)
+    assert search["count"] >= 1
+    assert any(row["metadata"].get("id") == FORWARD_PLAN for row in search["skills"])
+
+
+def test_forward_plan_is_allowlist_bound():
+    source = _bundled_skill_dir()
+    format_result = agent_skill_format.validate(source, mode="strict")
+    assert format_result.errors == ()
+    allowed = format_result.fields.get("allowed-tools")
+    assert isinstance(allowed, tuple) and allowed
+    assert "Bash" not in allowed, f"must not grant unscoped Bash: {allowed}"
+    assert all(_tool_is_permitted(str(tool)) for tool in allowed), f"allowed-tools outside closed permit set: {allowed}"
+    assert PERMITTED_BASE_TOOLS.issubset(set(allowed))
+    assert EXPECTED_SCOPED_BASH.issubset(set(allowed))
+    assert set(allowed) == PERMITTED_BASE_TOOLS | EXPECTED_SCOPED_BASH
+
+    metadata = _skill_metadata()
+    required_tools = metadata.get("required_tools")
+    assert isinstance(required_tools, list) and required_tools
+    assert "Bash" not in required_tools
+    assert set(required_tools) == set(allowed)
+
+    text = _skill_text()
+    assert re.search(r"(?i)\ballowlist\b", text)
+    assert re.search(r"(?i)failure paths?", text)
+    assert re.search(r"(?i)missing", text)
+    assert re.search(r"(?i)\bempty\b", text)
+    assert re.search(r"(?i)malformed", text)
+
+
+def test_forward_plan_defines_roadmap_parse_contract():
+    text = _skill_text()
+    assert re.search(r"(?i)ROADMAP\.md parse contract", text)
+    for heading in ("Now", "Next", "Later", "Vocabulary", "How items move"):
+        assert heading in text, f"parse contract must name heading shape {heading!r}"
+    assert re.search(r"(?i)\bignore\b", text)
+    assert re.search(r"(?i)(read|collect).{0,40}bullet", text, flags=re.DOTALL)
+
+
+def test_forward_plan_safety_gates_graph_input_and_confirmation():
+    """Pin safety-clarity contract: plan draft != --graph input; confirmation is procedural."""
+    text = _skill_text()
+    assert re.search(r"(?i)safety gates?", text)
+    # Pin plan-draft vs --graph ingest; SKILL.md bolds key negations (**not**, **zero**).
+    normalized = re.sub(r"\*+", "", text)
+    assert re.search(r"(?i)plan draft is not graph-ingest input", normalized)
+    assert re.search(r"(?i)forward-plan draft", normalized)
+    assert "brigade work task add --graph" in normalized
+    assert re.search(
+        r"(?i)not valid input.{0,200}brigade work task add --graph",
+        normalized,
+        flags=re.DOTALL,
+    )
+    assert re.search(
+        r"(?i)(zero|0).{0,60}proposed edge",
+        text,
+        flags=re.DOTALL,
+    )
+    assert re.search(
+        r"(?i)operator-in-the-loop",
+        text,
+    )
+    assert re.search(
+        r"(?i)Bash\(brigade work task:\*\).{0,120}does not enforce",
+        text,
+        flags=re.DOTALL,
+    )
+    assert re.search(
+        r"(?i)must not run any mutating.{0,120}before.{0,80}explicit\s+confirmation",
+        text,
+        flags=re.DOTALL,
+    )
+
+
+def test_forward_plan_graphtrail_edge_rules_and_degradation():
+    text = _skill_text()
+    assert re.search(r"(?i)GraphTrail", text)
+    assert re.search(r"(?i)def/?use", text)
+    assert re.search(r"(?i)conflicts-with", text)
+    assert re.search(r"(?i)write overlap", text)
+    assert re.search(r"(?i)\bderived\b", text)
+    assert re.search(r"(?i)confirm", text)
+    assert re.search(r"(?i)(unavailable|degrade)", text)
+    assert re.search(
+        r"(?i)(propose\s+no|no\s+derived).{0,60}edge",
+        text,
+        flags=re.DOTALL,
+    )
+    assert re.search(r"(?i)auto-retract", text)
+
+
+def test_forward_plan_output_contract_under_work_plans():
+    text = _skill_text()
+    assert ".brigade/work/plans/" in text
+    assert re.search(r"(?i)work ready", text)
+    assert re.search(r"(?i)outcome rank", text)
+    assert "never a CLI subcommand" in text or re.search(r"(?i)never a subcommand", text)
+
+
+def test_forward_plan_template_manifest_validity():
+    template_path = _bundled_skill_dir() / "plan.template.json"
+    payload = json.loads(template_path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    missing = REQUIRED_TEMPLATE_KEYS - set(payload)
+    assert not missing, f"plan.template.json missing keys: {sorted(missing)}"
+    assert payload["kind"] == "forward-plan"
+    assert payload["status"] == "draft"
+    assert isinstance(payload["nodes"], list)
+    assert isinstance(payload["proposed_edges"], list)
+    assert payload["proposed_edges"], "template should illustrate derived edge shape"
+    for edge in payload["proposed_edges"]:
+        assert edge.get("derived") is True
+        assert edge.get("confirmed") is False
+        assert edge.get("type") in {"blocks", "conflicts-with"}
+        assert edge.get("rule") in {"def-use", "write-overlap"}
+    graphtrail = payload["graphtrail"]
+    assert isinstance(graphtrail, dict)
+    assert graphtrail.get("available") is False
+    assert "unavailable" in str(graphtrail.get("degradation") or "").casefold()
+    confirmation = payload["confirmation"]
+    assert confirmation.get("required_for_derived_edges") is True
+    assert confirmation.get("auto_apply_forbidden") is True
+    assert confirmation.get("only_derived_may_be_auto_retracted") is True
+    inputs = payload["inputs"]
+    assert "ready" in inputs and "outcome_rank" in inputs and "roadmap" in inputs
+    roadmap = inputs["roadmap"]
+    assert "Now" in roadmap.get("sections_read", [])
+    assert "Vocabulary" in roadmap.get("sections_ignored", [])
+
+
+def test_forward_plan_is_not_a_cli_subcommand():
+    """Regression guard: #779 ships a skill, never a brigade forward-plan command."""
+    import argparse
+
+    from brigade import cli
+
+    parser = cli._build_parser()
+    subparsers_action = next(action for action in parser._actions if isinstance(action, argparse._SubParsersAction))
+    choices = set(subparsers_action.choices or {})
+    assert FORWARD_PLAN not in choices
+    assert "forward" not in choices

--- a/tests/test_skill_templates_metadata.py
+++ b/tests/test_skill_templates_metadata.py
@@ -13,6 +13,7 @@ BUNDLED_TEMPLATES = (
     "ultra-work-scout",
     "handoff-inbox-drain",
     "card-refresh",
+    "forward-plan",
 )
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

Ships the `forward-plan` bundled registry skill so agents can turn the native ready set, `outcome rank`, and `ROADMAP.md` into a dependency-filed plan under `.brigade/work/plans/` — with GraphTrail-derived edges confirmation-gated, and clean degradation when GraphTrail is missing. Skill only; no new subcommand.

Closes #779

## Type of change

- [x] Refactor with no command-surface change (new bundled skill + tests; no CLI surface)

## Checklist

- [x] `pytest -q` passes locally (`./scripts/verify`: 6187 passed, 3 skipped, coverage 83.16%)
- [x] Added or updated tests covering the change
- [x] Updated the `Unreleased` section of `CHANGELOG.md` for any user-visible effect
- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths
- [x] No new runtime dependencies
- [x] Conventional commit messages

## Skill contract (brief)

- **Inputs:** `brigade work ready --json`, `brigade outcome rank --json`, repo `ROADMAP.md`
- **Output:** `.brigade/work/plans/<forward-plan-…>.json` + `.plan.md` (see `plan.template.json`)
- **Derived edges:** def/use → `blocks`; write overlap → `conflicts-with`; `derived: true`, require confirmation
- **Degrade:** GraphTrail unavailable → propose no edges and say so
- **ROADMAP parse:** read Now/Next/Later bullets; ignore Vocabulary / Where things stand / How items move
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1797aec-07fa-4248-950a-256692ed4ece?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1797aec-07fa-4248-950a-256692ed4ece&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

