### PR TITLE
fix(work): attribute concurrent Bash writes by time window (#704)

### DIFF
--- a/src/brigade/claude_hooks/runtime.py
+++ b/src/brigade/claude_hooks/runtime.py
@@ -1605,10 +1605,14 @@ def _bash_write_detected(
     started = localio.parse_iso_datetime(started_at)
     if started is None:
         return True
+    # Attribute by concurrent write window, not exact fingerprint equality.
+    # Another live session may have written again (or a third write may have
+    # interleaved) after recording an older repo_fingerprint; requiring an
+    # exact match re-arms this session's closeout gate (#704 / #380 follow-up).
     for other_state in iter_session_states(target, limit=MAX_RECENT_SESSION_STATES):
         if other_state.get("session_id") == session_id:
             continue
-        if other_state.get("write_observed") is not True or other_state.get("repo_fingerprint") != current:
+        if other_state.get("write_observed") is not True:
             continue
         other_write = localio.parse_iso_datetime(other_state.get("last_write_at"))
         if other_write is not None and other_write >= started:

--- a/tests/test_claude_hooks_runtime.py
+++ b/tests/test_claude_hooks_runtime.py
@@ -442,6 +442,144 @@ def test_posttooluse_ignores_concurrent_session_write_during_read_only_bash(tmp_
     )
 
 
+def test_posttooluse_ignores_interleaved_concurrent_write_with_stale_fingerprint(tmp_path: Path):
+    """Issue #704: foreign writes must not re-arm closeout when the writer's
+    recorded repo_fingerprint lags the live tree (second write on disk before
+    that writer's next PostToolUse). Exact fingerprint equality is the escape
+    the #395/#380 fix missed.
+    """
+    target = _wired_claude(tmp_path)
+    reader_session = "reader-stale-fp"
+    writer_session = "writer-stale-fp"
+    pretool = _payload(
+        target,
+        "PreToolUse",
+        session_id=reader_session,
+        tool_name="Bash",
+        tool_input={"command": f"{sys.executable} -c \"print('noop')\""},
+    )
+    assert runtime.handle_payload("PreToolUse", pretool) is None
+
+    first = target / "first.py"
+    first.write_text("first\n")
+    assert (
+        runtime.handle_payload(
+            "PostToolUse",
+            _payload(
+                target,
+                "PostToolUse",
+                session_id=writer_session,
+                tool_name="Write",
+                tool_input={"file_path": str(first)},
+            ),
+        )
+        is None
+    )
+    writer_state = runtime.read_session_state(target, writer_session)
+    assert writer_state["write_observed"] is True
+    recorded_fp = writer_state["repo_fingerprint"]
+
+    # Second concurrent write lands before the writer records the new fingerprint.
+    second = target / "second.py"
+    second.write_text("second\n")
+    live_fp = runtime.repo_worktree_fingerprint(target)
+    assert live_fp is not None
+    assert recorded_fp != live_fp
+
+    assert runtime.handle_payload("PostToolUse", {**pretool, "hook_event_name": "PostToolUse"}) is None
+    reader_state = runtime.read_session_state(target, reader_session)
+    assert reader_state["write_observed"] is False
+    assert "last_write_at" not in reader_state
+    assert "pending_bash_fingerprint" not in reader_state
+    assert (
+        runtime.handle_payload("Stop", _payload(target, "Stop", session_id=reader_session, stop_hook_active=False))
+        is None
+    )
+
+
+def test_stop_keeps_prior_receipt_when_interleaved_foreign_write_lags_fingerprint(tmp_path: Path, monkeypatch):
+    """Issue #704 receipt treadmill: a session that already verified must not
+    have last_write_at raised by a concurrent session whose recorded fingerprint
+    is no longer current.
+    """
+    target = _wired_claude(tmp_path)
+    reader_session = "verified-reader"
+    writer_session = "active-writer"
+    monkeypatch.setattr(runtime, "_run_brief", lambda repo: "brief")
+    runtime.handle_payload("SessionStart", _payload(target, "SessionStart", session_id=reader_session))
+    runtime.handle_payload(
+        "PostToolUse",
+        _payload(
+            target,
+            "PostToolUse",
+            session_id=reader_session,
+            tool_name="Write",
+            tool_input={"file_path": str(target / "own.py")},
+        ),
+    )
+    state = runtime.read_session_state(target, reader_session)
+    write_at = state["last_verification_write_at"]
+    run_dir = target / ".brigade" / "work" / "verify-runs" / "run-1"
+    run_dir.mkdir(parents=True)
+    (run_dir / "receipt.json").write_text(
+        json.dumps(
+            {
+                "run_id": "run-1",
+                "status": "completed",
+                "started_at": write_at,
+                "harness_session": {
+                    "harness": "claude",
+                    "fingerprint": state["session_fingerprint"],
+                },
+            }
+        )
+        + "\n"
+    )
+
+    pretool = _payload(
+        target,
+        "PreToolUse",
+        session_id=reader_session,
+        tool_name="Bash",
+        tool_input={"command": f"{sys.executable} -c \"print('noop')\""},
+    )
+    assert runtime.handle_payload("PreToolUse", pretool) is None
+
+    first = target / "foreign-a.py"
+    first.write_text("foreign-a\n")
+    assert (
+        runtime.handle_payload(
+            "PostToolUse",
+            _payload(
+                target,
+                "PostToolUse",
+                session_id=writer_session,
+                tool_name="Write",
+                tool_input={"file_path": str(first)},
+            ),
+        )
+        is None
+    )
+    (target / "foreign-b.py").write_text("foreign-b\n")
+    assert (
+        runtime.repo_worktree_fingerprint(target)
+        != runtime.read_session_state(target, writer_session)["repo_fingerprint"]
+    )
+
+    assert runtime.handle_payload("PostToolUse", {**pretool, "hook_event_name": "PostToolUse"}) is None
+    updated = runtime.read_session_state(target, reader_session)
+    assert updated["last_verification_write_at"] == write_at
+    assert updated["last_write_at"] == write_at
+
+    handoff = target / ".claude" / "memory-handoffs" / "handoff.md"
+    handoff.parent.mkdir(parents=True, exist_ok=True)
+    handoff.write_text("durable finding\n")
+    assert (
+        runtime.handle_payload("Stop", _payload(target, "Stop", session_id=reader_session, stop_hook_active=False))
+        is None
+    )
+
+
 def test_posttooluse_snapshot_fails_closed_when_state_cannot_be_inspected(tmp_path: Path, monkeypatch):
     target = _wired_claude(tmp_path)
     session_id = "snapshot-unavailable"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Stop charging a Claude session for worktree fingerprint changes when another live session recorded a write during the pending Bash window, even if that session's recorded `repo_fingerprint` is stale.
- Keep fail-closed behavior when no concurrent write falls in the window or the fingerprint is unavailable.
- Add regression coverage for the interleaved-write escape that #395 missed, including the receipt-treadmill Stop path.

## Root cause

`_bash_write_detected` (from #395 / #380) only treated a fingerprint change as foreign when another session's recorded `repo_fingerprint` exactly matched the live tree. If that writer landed another file on disk before its next PostToolUse, equality failed, the read-only session got `write_observed` / a raised `last_write_at`, and Stop re-armed despite a fresh session receipt.

## Verification

- `./scripts/verify`
- Result: 6181 passed, 3 skipped, coverage 83.17% (floor 78%)

Fixes #704

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-042e4bd3-4759-4990-ac42-05ff7a7b588e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-042e4bd3-4759-4990-ac42-05ff7a7b588e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

