### PR TITLE
fix(runs): resume interrupted app-server threads

### DIFF
--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -414,6 +414,20 @@ checkpoint before replacing `run.json`. If rollback leaves an older Brigade
 unable to interpret a journal event or projector version, stop that writer and
 roll forward. The append-only journal format is a one-way storage boundary.
 
+`brigade runs resume <run>` also handles an app-server run whose owner exited
+after dispatch began but before `worker-results.json` was aggregated. After it
+acquires the normal run lock, Brigade reconstructs only the active-stage worker
+thread coordinates from the already-flushed app-server event streams, records
+the missing terminal failure through the lifecycle journal, and resumes those
+threads. If no durable thread coordinates exist, resume fails cleanly without
+calling the provider. It never guesses a thread or treats a live run as
+interrupted. Multi-stage app-server runs interrupted while `active_stage` is
+greater than 1 cannot be salvaged this way when earlier-stage worker results
+were never persisted. Resume fails closed before provider construction instead
+of synthesizing from partial stage output. A successful resume refreshes
+`finished_at` and `duration_seconds` to the post-resume completion time rather
+than retaining the pre-resume owner-exit timestamp.
+
 If the approved action completed but the process exited before recording
 `approval.consumed` and `run.resumed`, run `brigade runs resume <run>` again.
 Brigade verifies that the redeemed claim belongs to the same run and still

--- a/src/brigade/run_resume.py
+++ b/src/brigade/run_resume.py
@@ -227,7 +227,11 @@ def resume(run_dir: Path) -> int:
         with runguard.run_lock(workspace, run_dir=run_dir):
             run_meta = _load_json(run_dir, "run.json")
             status = run_meta.get("status") if run_meta is not None else None
-            if isinstance(status, str) and status in _NONTERMINAL_RUN_STATUSES:
+            if (
+                run_meta is not None
+                and isinstance(status, str)
+                and status in _NONTERMINAL_RUN_STATUSES
+            ):
                 interrupted = _interrupted_appserver_results(run_dir)
                 if interrupted is None:
                     print(

--- a/src/brigade/run_resume.py
+++ b/src/brigade/run_resume.py
@@ -41,6 +41,137 @@ def _load_json(run_dir: Path, name: str) -> dict | None:
     return data if isinstance(data, dict) else None
 
 
+def _interrupted_appserver_results(run_dir: Path) -> dict | None:
+    """Rebuild the minimal resume handoff left by an interrupted dispatch.
+
+    App-server notifications are flushed as they arrive, before the aggregate
+    worker-results sidecar is written.  They are therefore the durable source
+    of thread coordinates when the run owner exits in the dispatch gate.
+    """
+    run_meta = _load_json(run_dir, "run.json")
+    plan = _load_json(run_dir, "plan.json")
+    if run_meta is None or plan is None or run_meta.get("codex_transport") != "app-server":
+        return None
+    assignments = plan.get("assignments")
+    if not isinstance(assignments, list):
+        return None
+    active_stage = run_meta.get("active_stage")
+    active_seats = run_meta.get("active_seats")
+    active_seat_set = (
+        frozenset(seat for seat in active_seats if isinstance(seat, str)) if isinstance(active_seats, list) else None
+    )
+    recovered: list[dict[str, object]] = []
+    for assignment in assignments:
+        if not isinstance(assignment, dict):
+            continue
+        worker = assignment.get("worker")
+        task = assignment.get("task")
+        if not isinstance(worker, str) or not isinstance(task, str):
+            continue
+        if isinstance(active_stage, int) and assignment.get("stage", 1) != active_stage:
+            continue
+        if active_seat_set is not None and worker not in active_seat_set:
+            continue
+        event_path = run_dir / "events" / f"{aboyeur._slug(worker)}.jsonl"
+        thread_id: str | None = None
+        try:
+            lines = event_path.read_text().splitlines()
+        except OSError:
+            continue
+        for line in lines:
+            try:
+                event = json.loads(line)
+            except (json.JSONDecodeError, RecursionError):
+                continue
+            params = event.get("params") if isinstance(event, dict) else None
+            candidate = params.get("threadId") if isinstance(params, dict) else None
+            if isinstance(candidate, str) and candidate:
+                thread_id = candidate
+        if thread_id is not None:
+            recovered.append(
+                {
+                    "worker": worker,
+                    "task": task,
+                    "ok": False,
+                    "detail": "run owner exited during app-server dispatch",
+                    "thread_id": thread_id,
+                    "status": "interrupted",
+                    "transport": "codex-app-server",
+                }
+            )
+    if not recovered:
+        return None
+    return receipt_schema.worker_results_document(recovered)
+
+
+def _interrupted_salvage_blocked(
+    run_dir: Path,
+    run_meta: dict,
+    *,
+    worker_data: dict | None,
+    interrupted_data: dict | None,
+) -> str | None:
+    """Return a user-facing error when multi-stage salvage cannot re-synthesize."""
+    if interrupted_data is None:
+        return None
+    active_stage = run_meta.get("active_stage")
+    if not isinstance(active_stage, int) or active_stage <= 1:
+        return None
+    if worker_data is not None:
+        plan = _load_json(run_dir, "plan.json")
+        assignments = plan.get("assignments") if plan is not None else None
+        if not isinstance(assignments, list):
+            return (
+                f"interrupted app-server dispatch at stage {active_stage} cannot be resumed; "
+                "earlier-stage worker results were not persisted"
+            )
+        prior_workers = {
+            assignment.get("worker")
+            for assignment in assignments
+            if isinstance(assignment, dict)
+            and isinstance(assignment.get("worker"), str)
+            and assignment.get("stage", 1) < active_stage
+        }
+        if not prior_workers:
+            return None
+        results = worker_data.get("results")
+        if not isinstance(results, list):
+            results = []
+        represented = {entry.get("worker") for entry in results if isinstance(entry, dict)}
+        if prior_workers.issubset(represented):
+            return None
+    return (
+        f"interrupted app-server dispatch at stage {active_stage} cannot be resumed; "
+        "earlier-stage worker results were not persisted"
+    )
+
+
+def _archive_failure(run_meta: dict) -> None:
+    recovered_failure = run_meta.pop("failure", None)
+    run_meta.pop("failure_phase", None)
+    if not isinstance(recovered_failure, dict):
+        return
+    history = run_meta.get("recovery_history")
+    if not isinstance(history, list):
+        history = []
+        run_meta["recovery_history"] = history
+    history.append(recovered_failure)
+
+
+def _refresh_run_timing(run_meta: dict, *, finished_at: datetime | None = None) -> None:
+    finished = finished_at or datetime.now(timezone.utc)
+    run_meta["status_started_at"] = aboyeur._utc_iso(finished)
+    run_meta["finished_at"] = aboyeur._utc_iso(finished)
+    started_at = run_meta.get("started_at")
+    if isinstance(started_at, str):
+        started = aboyeur._parse_iso_datetime(started_at)
+        if started is not None:
+            run_meta["duration_seconds"] = max(
+                0.0,
+                round((finished - started).total_seconds(), 3),
+            )
+
+
 def _roster_from_snapshot(snapshot: dict) -> Roster:
     agents_map = {}
     for name, raw in (snapshot.get("agents") or {}).items():
@@ -87,10 +218,6 @@ def resume(run_dir: Path) -> int:
             file=sys.stderr,
         )
         return 2
-    status = run_meta.get("status")
-    if not isinstance(status, str) or status in _NONTERMINAL_RUN_STATUSES:
-        print("error: run is not terminal; recover or wait for the active run before resuming", file=sys.stderr)
-        return 2
     workspace = runguard.resolve_run_lock_workspace(run_meta, run_dir)
     if workspace is None:
         print("error: run artifact has no workspace cwd; cannot verify lock ownership", file=sys.stderr)
@@ -98,6 +225,37 @@ def resume(run_dir: Path) -> int:
     try:
         runguard.recover_stale_run(workspace, run_dir, required=False)
         with runguard.run_lock(workspace, run_dir=run_dir):
+            run_meta = _load_json(run_dir, "run.json")
+            status = run_meta.get("status") if run_meta is not None else None
+            if isinstance(status, str) and status in _NONTERMINAL_RUN_STATUSES:
+                interrupted = _interrupted_appserver_results(run_dir)
+                if interrupted is None:
+                    print(
+                        "error: run is not terminal; no durable app-server thread coordinates are available",
+                        file=sys.stderr,
+                    )
+                    return 2
+                salvage_error = _interrupted_salvage_blocked(
+                    run_dir,
+                    run_meta,
+                    worker_data=_load_json(run_dir, "worker-results.json"),
+                    interrupted_data=interrupted,
+                )
+                if salvage_error is not None:
+                    print(f"error: {salvage_error}", file=sys.stderr)
+                    return 2
+                # A live owner cannot coexist with this lock.  Reaching here
+                # means an earlier owner disappeared without terminalizing the
+                # snapshot (for example between a gate and its exception
+                # handler).  Commit the missing terminal journal fact before
+                # deciding whether app-server coordinates make it resumable.
+                aboyeur.record_run_termination(
+                    run_dir,
+                    status="failed",
+                    failure_phase=status,
+                    failure_kind="owner-process-exited",
+                    detail="run owner exited before recording a terminal state",
+                )
             return _resume_locked(run_dir)
     except runguard.RunLockError as exc:
         print(f"error: {exc}", file=sys.stderr)
@@ -113,7 +271,34 @@ def _resume_locked(
     run_dir = run_dir.expanduser().resolve()
     run_meta = _load_json(run_dir, "run.json")
     roster_snapshot = _load_json(run_dir, "roster.json")
-    worker_data = _load_json(run_dir, "worker-results.json")
+    worker_data_snapshot = _load_json(run_dir, "worker-results.json")
+    interrupted_data = _interrupted_appserver_results(run_dir)
+    salvage_error = (
+        None
+        if run_meta is None
+        else _interrupted_salvage_blocked(
+            run_dir,
+            run_meta,
+            worker_data=worker_data_snapshot,
+            interrupted_data=interrupted_data,
+        )
+    )
+    if salvage_error is not None:
+        print(f"error: {salvage_error}", file=sys.stderr)
+        return 2
+    worker_data = worker_data_snapshot
+    if worker_data is None:
+        worker_data = interrupted_data
+    elif interrupted_data is not None:
+        results = worker_data.get("results")
+        interrupted = interrupted_data.get("results")
+        if isinstance(results, list) and isinstance(interrupted, list):
+            represented = {entry.get("worker") for entry in results if isinstance(entry, dict)}
+            worker_data = dict(worker_data)
+            worker_data["results"] = [
+                *results,
+                *(entry for entry in interrupted if entry.get("worker") not in represented),
+            ]
     if run_meta is None or roster_snapshot is None or worker_data is None:
         print(
             f"error: missing run artifacts in {run_dir} (need run.json, roster.json, worker-results.json)",
@@ -279,8 +464,18 @@ def _resume_locked(
     now = datetime.now(timezone.utc).isoformat()
     run_meta.setdefault("resumed_at", []).append(now)
     if not final.ok:
+        bounded_detail = (final.detail or "orchestrator failed during synthesis")[:2000]
+        _archive_failure(run_meta)
         run_meta["status"] = "failed"
-        run_meta["error"] = final.detail
+        run_meta["error"] = bounded_detail
+        run_meta["failure_phase"] = "synthesis"
+        run_meta["failure"] = {
+            "phase": "synthesis",
+            "kind": "agent-error",
+            "detail": bounded_detail,
+            "seat": roster.orchestrator,
+        }
+        _refresh_run_timing(run_meta)
         try:
             aboyeur._write_json(run_dir / "run.json", receipt_schema.stamp_run_receipt(run_meta))
         except run_lifecycle.LifecycleJournalError as exc:
@@ -290,14 +485,8 @@ def _resume_locked(
     (run_dir / "final.txt").write_text(final.text + "\n")
     run_meta["status"] = "ok"
     run_meta.pop("error", None)
-    recovered_failure = run_meta.pop("failure", None)
-    run_meta.pop("failure_phase", None)
-    if isinstance(recovered_failure, dict):
-        history = run_meta.get("recovery_history")
-        if not isinstance(history, list):
-            history = []
-            run_meta["recovery_history"] = history
-        history.append(recovered_failure)
+    _archive_failure(run_meta)
+    _refresh_run_timing(run_meta)
     try:
         aboyeur._write_json(run_dir / "run.json", receipt_schema.stamp_run_receipt(run_meta))
     except run_lifecycle.LifecycleJournalError as exc:

--- a/src/brigade/run_resume.py
+++ b/src/brigade/run_resume.py
@@ -227,11 +227,7 @@ def resume(run_dir: Path) -> int:
         with runguard.run_lock(workspace, run_dir=run_dir):
             run_meta = _load_json(run_dir, "run.json")
             status = run_meta.get("status") if run_meta is not None else None
-            if (
-                run_meta is not None
-                and isinstance(status, str)
-                and status in _NONTERMINAL_RUN_STATUSES
-            ):
+            if run_meta is not None and isinstance(status, str) and status in _NONTERMINAL_RUN_STATUSES:
                 interrupted = _interrupted_appserver_results(run_dir)
                 if interrupted is None:
                     print(

--- a/tests/test_run_resume.py
+++ b/tests/test_run_resume.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+from contextlib import nullcontext
 from pathlib import Path
 
 import pytest
@@ -184,6 +185,8 @@ def test_resume_reattaches_and_resynthesizes(tmp_path, monkeypatch, capsys):
                 "kind": "owner-process-exited",
                 "owner_pid": 99999999,
             },
+            "finished_at": "2026-07-03T00:05:00+00:00",
+            "duration_seconds": 300.0,
         }
     )
     (run_dir / "run.json").write_text(json.dumps(recovered))
@@ -205,6 +208,8 @@ def test_resume_reattaches_and_resynthesizes(tmp_path, monkeypatch, capsys):
     assert run_json["recovery_history"] == [recovered["failure"]]
     assert "failure_phase" not in run_json
     assert "failure" not in run_json
+    assert run_json["finished_at"] != recovered["finished_at"]
+    assert run_json["duration_seconds"] != recovered["duration_seconds"]
     worker_revisions = sorted((run_dir / "revisions" / "worker-results").glob("*.json"))
     synthesis_revisions = sorted((run_dir / "revisions" / "synthesis").glob("*.json"))
     assert [path.name for path in worker_revisions] == ["000001.json", "000002.json"]
@@ -225,6 +230,183 @@ def test_resume_with_nothing_resumable_reports_and_exits_2(tmp_path, capsys):
     err = capsys.readouterr().err
     assert "no resumable workers" in err
     assert "cook" in err  # names the non-resumable failure
+
+
+def test_resume_recovers_appserver_thread_from_interrupted_dispatch_events(tmp_path, monkeypatch):
+    run_dir = _write_run_dir(tmp_path, results=[])
+    (run_dir / "worker-results.json").unlink()
+    meta = json.loads((run_dir / "run.json").read_text())
+    meta.update({"status": "dispatching", "codex_transport": "app-server"})
+    (run_dir / "run.json").write_text(json.dumps(meta))
+    events = run_dir / "events"
+    events.mkdir()
+    (events / "cook.jsonl").write_text(
+        json.dumps({"method": "turn/started", "params": {"threadId": "t-recovered", "turnId": "turn-1"}}) + "\n"
+    )
+
+    def recover_stale(workspace, candidate, *, required):
+        assert candidate == run_dir
+        assert required is False
+        return False
+
+    monkeypatch.setattr(run_resume.runguard, "recover_stale_run", recover_stale)
+    monkeypatch.setattr(run_resume.runguard, "run_lock", lambda *args, **kwargs: nullcontext())
+    monkeypatch.setattr(run_resume.codex_appserver, "AppServer", _StubServer)
+    monkeypatch.setattr(
+        run_resume.agents,
+        "run_agent",
+        lambda *args, **kwargs: agents.AgentResult(text="recovered synthesis", ok=True),
+    )
+
+    assert run_resume.resume(run_dir) == 0
+    results = json.loads((run_dir / "worker-results.json").read_text())["results"]
+    assert results[0]["thread_id"] == "t-recovered"
+    assert results[0]["ok"] is True
+    final_meta = json.loads((run_dir / "run.json").read_text())
+    assert final_meta["recovery_history"][0]["kind"] == "owner-process-exited"
+
+
+def test_resume_refuses_interrupted_multistage_appserver_salvage(tmp_path, monkeypatch, capsys):
+    run_dir = _write_run_dir(tmp_path, results=[])
+    (run_dir / "worker-results.json").unlink()
+    meta = json.loads((run_dir / "run.json").read_text())
+    meta.update({"status": "dispatching", "codex_transport": "app-server", "active_stage": 2})
+    (run_dir / "run.json").write_text(json.dumps(meta))
+    (run_dir / "plan.json").write_text(
+        json.dumps(
+            {
+                "assignments": [
+                    {"stage": 1, "worker": "cook", "task": "stage one"},
+                    {"stage": 2, "worker": "cook", "task": "stage two"},
+                ]
+            }
+        )
+    )
+    events = run_dir / "events"
+    events.mkdir()
+    (events / "cook.jsonl").write_text(
+        json.dumps({"method": "turn/started", "params": {"threadId": "t-stage-two", "turnId": "turn-2"}}) + "\n"
+    )
+    provider_calls: list[str] = []
+
+    class GuardServer:
+        def __init__(self, *args, **kwargs):
+            provider_calls.append("constructed")
+
+        def start(self):
+            provider_calls.append("started")
+
+    monkeypatch.setattr(run_resume.runguard, "recover_stale_run", lambda *args, **kwargs: False)
+    monkeypatch.setattr(run_resume.runguard, "run_lock", lambda *args, **kwargs: nullcontext())
+    monkeypatch.setattr(run_resume.codex_appserver, "AppServer", GuardServer)
+    monkeypatch.setattr(
+        run_resume.agents,
+        "run_agent",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("synthesis must not run")),
+    )
+
+    assert run_resume.resume(run_dir) == 2
+    assert provider_calls == []
+    err = capsys.readouterr().err
+    assert "stage 2" in err
+    assert "earlier-stage worker results were not persisted" in err
+
+
+@pytest.mark.parametrize("malformed_results", [None, {"worker": "cook"}])
+def test_resume_refuses_multistage_salvage_with_malformed_worker_results(
+    tmp_path, monkeypatch, capsys, malformed_results
+):
+    run_dir = _write_run_dir(tmp_path, results=[])
+    (run_dir / "worker-results.json").write_text(json.dumps({"results": malformed_results, "ground_truth": {}}))
+    meta = json.loads((run_dir / "run.json").read_text())
+    meta.update({"status": "dispatching", "codex_transport": "app-server", "active_stage": 2})
+    (run_dir / "run.json").write_text(json.dumps(meta))
+    (run_dir / "plan.json").write_text(
+        json.dumps(
+            {
+                "assignments": [
+                    {"stage": 1, "worker": "cook", "task": "stage one"},
+                    {"stage": 2, "worker": "cook", "task": "stage two"},
+                ]
+            }
+        )
+    )
+    events = run_dir / "events"
+    events.mkdir()
+    (events / "cook.jsonl").write_text(
+        json.dumps({"method": "turn/started", "params": {"threadId": "t-stage-two", "turnId": "turn-2"}}) + "\n"
+    )
+    provider_calls: list[str] = []
+
+    class GuardServer:
+        def __init__(self, *args, **kwargs):
+            provider_calls.append("constructed")
+
+        def start(self):
+            provider_calls.append("started")
+
+    monkeypatch.setattr(run_resume.runguard, "recover_stale_run", lambda *args, **kwargs: False)
+    monkeypatch.setattr(run_resume.runguard, "run_lock", lambda *args, **kwargs: nullcontext())
+    monkeypatch.setattr(run_resume.codex_appserver, "AppServer", GuardServer)
+    monkeypatch.setattr(
+        run_resume.agents,
+        "run_agent",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("synthesis must not run")),
+    )
+
+    assert run_resume.resume(run_dir) == 2
+    assert provider_calls == []
+    err = capsys.readouterr().err
+    assert "stage 2" in err
+    assert "earlier-stage worker results were not persisted" in err
+
+
+def test_resume_synthesis_failure_replaces_owner_exit_attribution(tmp_path, monkeypatch):
+    run_dir = _write_run_dir(
+        tmp_path,
+        results=[
+            {
+                "worker": "cook",
+                "task": "write code",
+                "ok": False,
+                "detail": "timeout",
+                "text": "part",
+                "thread_id": "t-1",
+                "status": "interrupted",
+            },
+        ],
+    )
+    recovered = json.loads((run_dir / "run.json").read_text())
+    recovered.update(
+        {
+            "status": "failed",
+            "error": "run owner exited before recording a terminal state",
+            "failure_phase": "dispatching",
+            "failure": {
+                "phase": "dispatching",
+                "kind": "owner-process-exited",
+                "detail": "run owner exited before recording a terminal state",
+            },
+            "finished_at": "2026-07-03T00:05:00+00:00",
+            "duration_seconds": 300.0,
+        }
+    )
+    (run_dir / "run.json").write_text(json.dumps(recovered))
+    monkeypatch.setattr(run_resume.codex_appserver, "AppServer", _StubServer)
+    monkeypatch.setattr(
+        run_resume.agents,
+        "run_agent",
+        lambda *a, **k: agents.AgentResult(text="synthesis failed", ok=False, detail="orchestrator timeout"),
+    )
+
+    assert run_resume.resume(run_dir) == 2
+    run_json = json.loads((run_dir / "run.json").read_text())
+    assert run_json["status"] == "failed"
+    assert run_json["failure"]["kind"] == "agent-error"
+    assert run_json["failure"]["phase"] == "synthesis"
+    assert run_json["failure"]["seat"] == "chef"
+    assert run_json["recovery_history"] == [recovered["failure"]]
+    assert run_json["finished_at"] != recovered["finished_at"]
 
 
 def test_approval_resume_requires_reserved_snapshot_before_provider_start(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- Recover durable app-server thread coordinates when a run owner exits before `worker-results.json` is aggregated.
- Record the missing owner-exit terminal state through the lifecycle journal before resuming.
- Refuse multi-stage salvage when earlier-stage outputs are unavailable, so partial synthesis cannot be marked successful.
- Refresh completion timing after resume and preserve prior failure attribution in `recovery_history`.

## Why

An app-server run could leave usable thread coordinates in its event streams while its artifact directory still looked nonterminal. `brigade runs resume` rejected that state before checking the run lock or the durable coordinates, so the existing provider threads could not be recovered after the owner process exited.

The recovery path remains app-server-only. It does not guess thread IDs, resume a live owner, or synthesize a multi-stage run from only its active stage.

## Verification

- `pytest tests/test_run_resume.py tests/test_run_lifecycle.py tests/test_run_cli.py -q`
- `ruff check src/brigade/run_resume.py tests/test_run_resume.py`
- `ruff format --check src/brigade/run_resume.py tests/test_run_resume.py`
- Baseline-aware Vale comparison: 0 new findings

Fixes #489
