### PR TITLE
feat(harness): hash-stamp managed instruction blocks (#732)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and confirmation-gated; degrades to zero proposed edges when GraphTrail is
   unavailable. Ships `plan.template.json` as the artifact contract. Skill only,
   with no new CLI subcommand.
+- Hash-stamped managed instruction blocks (#732): Brigade frames harness
+  instruction spans with `BEGIN/END BRIGADE INTEGRATION` markers that carry
+  marker-format version, profile, and a full SHA-256 of the body. Install is a
+  true no-op when recorded, actual, and desired digests match; check
+  (`brigade harness sync --check` / `harness doctor`) classifies
+  missing/stale/locally_modified/malformed/current and prints the fix command;
+  removal is surgical. Locally modified or malformed spans fail closed unless
+  `--force`. Symlinked targets are skipped (including a post-`lstat` symlink
+  swap). Legacy `brigade:user-profile` markers are recognized and upgraded in
+  place.
 
 ### Fixed
 - DAG runs no longer deadlock on shared cover sets, accept mutual-wait cycles, misreport one-node execution, route to unhealthy seats, or miss shared-checkout isolation breaches. (#742, #788, #791, #794)

--- a/src/brigade/cli/harness.py
+++ b/src/brigade/cli/harness.py
@@ -11,11 +11,17 @@ from .. import harness_profiles
 USER_SCOPE_TARGETS = harness_profiles.USER_SCOPE_TARGETS
 
 
-def _write_mode(parser: argparse.ArgumentParser, *, default_dry: bool = True) -> None:
+def _write_mode(parser: argparse.ArgumentParser, *, default_dry: bool = True, allow_check: bool = False) -> None:
     mode = parser.add_mutually_exclusive_group()
     if default_dry:
         mode.add_argument("--dry-run", action="store_true", help="Preview changes without writing (default).")
         mode.add_argument("--write", action="store_true", help="Apply the planned changes.")
+        if allow_check:
+            mode.add_argument(
+                "--check",
+                action="store_true",
+                help="Classify managed instruction blocks as missing/stale/current and exit nonzero unless current.",
+            )
     else:
         mode.add_argument("--write", action="store_true", help="Apply the planned changes.")
         mode.add_argument("--dry-run", action="store_true", help="Preview changes without writing (default).")
@@ -51,7 +57,7 @@ def register(sub: argparse._SubParsersAction) -> None:
 
     sync = commands.add_parser("sync", help="Plan or apply user-scope harness onboarding (dry-run default).")
     _common_slice1(sync)
-    _write_mode(sync)
+    _write_mode(sync, allow_check=True)
     sync.add_argument(
         "--allow-global-stdio",
         action="store_true",
@@ -61,6 +67,11 @@ def register(sub: argparse._SubParsersAction) -> None:
         "--adopt",
         action="store_true",
         help="Adopt a foreign managed block or generated file instead of reporting a conflict.",
+    )
+    sync.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite a locally modified or recoverable managed instruction block.",
     )
 
     uninstall = commands.add_parser("uninstall", help="Remove only Brigade-owned harness configuration.")
@@ -84,6 +95,11 @@ def register(sub: argparse._SubParsersAction) -> None:
         help="Workspace the profile is bound to (default: current directory).",
     )
     uninstall.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    uninstall.add_argument(
+        "--force",
+        action="store_true",
+        help="Remove a locally modified managed instruction block.",
+    )
     _write_mode(uninstall)
 
     doctor = commands.add_parser("doctor", help="Check a harness onboarding profile.")
@@ -142,6 +158,8 @@ def dispatch(args) -> int:
             write=bool(args.write),
             allow_global_stdio=bool(getattr(args, "allow_global_stdio", False)),
             adopt=bool(getattr(args, "adopt", False)),
+            force=bool(getattr(args, "force", False)),
+            check=bool(getattr(args, "check", False)),
             json_output=args.json,
         )
 
@@ -151,6 +169,7 @@ def dispatch(args) -> int:
                 harness=args.target,
                 workspace=args.workspace,
                 write=bool(args.write),
+                force=bool(getattr(args, "force", False)),
                 json_output=args.json,
             )
         return cursor_user_cmd.uninstall(write=args.write, json_output=args.json)

--- a/src/brigade/harness_profile_cmd.py
+++ b/src/brigade/harness_profile_cmd.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from . import __version__ as BRIGADE_VERSION
-from . import harness_profiles, localio, mcp_adapters, mcp_cmd, skills_cmd
+from . import harness_profiles, localio, managed_block, mcp_adapters, mcp_cmd, skills_cmd
 from .toml_compat import TOMLDecodeError as _TOMLDecodeError
 from .toml_compat import loads as _toml_loads
 
@@ -166,109 +166,190 @@ def load_profile_state(*, state_path: Path, workspace: Path, harness: str) -> Lo
     return LoadedProfileState(state, None)
 
 
-def _block(body: str) -> str:
-    return f"{harness_profiles.INSTRUCTION_START}\n{body}\n{harness_profiles.INSTRUCTION_END}\n"
-
-
-def _split_components(text: str) -> tuple[str, str, str] | None:
-    start, end = harness_profiles.INSTRUCTION_START, harness_profiles.INSTRUCTION_END
-    if text.count(start) != 1 or text.count(end) != 1:
-        return None
-    start_pos, end_pos = text.find(start), text.find(end)
-    after_start = start_pos + len(start)
-    if end_pos <= start_pos or after_start >= len(text) or text[after_start] != "\n" or text[end_pos - 1] != "\n":
-        return None
-    before = text[:start_pos]
-    body = text[after_start + 1 : end_pos - 1]
-    after = text[end_pos + len(end) :]
-    if after.startswith("\n"):
-        after = after[1:]
-    return before, body, after
-
-
-def plan_instruction(*, path: Path, desired: str, state: dict[str, Any], adopt: bool = False) -> SurfacePlan:
-    instruction_state = state.get("instructions", {}) if isinstance(state.get("instructions"), dict) else {}
-    owned = instruction_state.get("digest")
-    if not path.exists():
-        return SurfacePlan("instruction", path, "missing", "create", digest_text(desired), _block(desired))
-    try:
-        text = path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError) as exc:
-        return SurfacePlan("instruction", path, "conflict", "preserve", detail=str(exc))
-    parts = _split_components(text)
-    if parts is None:
-        if harness_profiles.INSTRUCTION_START not in text and harness_profiles.INSTRUCTION_END not in text:
-            return SurfacePlan(
-                "instruction",
-                path,
-                "missing",
-                "create",
-                digest_text(desired),
-                text + ("\n" if text else "") + _block(desired),
-            )
-        return SurfacePlan(
-            "instruction", path, "conflict", "preserve", detail="managed instruction markers are malformed"
-        )
-    before, live, after = parts
-    live_digest, desired_digest = digest_text(live), digest_text(desired)
-    if live_digest == desired_digest:
-        if owned == live_digest:
-            return SurfacePlan("instruction", path, "current", "none", desired_digest)
-        if adopt:
-            return SurfacePlan("instruction", path, "adopted", "none", desired_digest)
-        return SurfacePlan(
-            "instruction",
-            path,
-            "conflict",
-            "preserve",
-            desired_digest,
-            detail=f"matching managed instruction block is unowned; recover with: {_RECOVERY_COMMAND}",
-        )
-    if owned == live_digest or adopt:
-        return SurfacePlan("instruction", path, "stale", "update", desired_digest, before + _block(desired) + after)
-    return SurfacePlan(
-        "instruction",
-        path,
-        "conflict",
-        "preserve",
-        detail=f"foreign managed instruction block; recover with: {_RECOVERY_COMMAND}",
+def _block(body: str, *, profile: str = managed_block.DEFAULT_PROFILE) -> str:
+    return managed_block.render_block(
+        body,
+        kind=managed_block.DEFAULT_KIND,
+        profile=profile,
     )
 
 
-def plan_instruction_removal(*, path: Path, state: dict[str, Any]) -> SurfacePlan:
+def _split_components(text: str) -> tuple[str, str, str] | None:
+    parsed = managed_block.parse_blocks(text, kind=managed_block.DEFAULT_KIND)
+    if parsed.status != "ok":
+        return None
+    return parsed.before, parsed.body, parsed.after
+
+
+def _instruction_fix_command(harness: str | None = None) -> str:
+    target = harness or "<harness>"
+    return managed_block.default_fix_command(harness=target)
+
+
+def _plan_from_block_plan(path: Path, plan: managed_block.BlockPlan, *, harness: str | None = None) -> SurfacePlan:
+    """Map managed-block plans onto the harness SurfacePlan vocabulary."""
+    status = plan.status
+    action = plan.action
+    detail = plan.detail
+    if plan.fix_command and status in {
+        managed_block.STATUS_MISSING,
+        managed_block.STATUS_STALE,
+        managed_block.STATUS_LOCALLY_MODIFIED,
+        managed_block.STATUS_MALFORMED,
+    }:
+        fix = plan.fix_command
+        if harness and "<harness>" in fix:
+            fix = _instruction_fix_command(harness)
+        detail = f"{detail}; fix with: {fix}" if detail else f"fix with: {fix}"
+    # Preserve legacy conflict wording for fail-closed local edits so existing
+    # recovery messaging and tests keep a stable surface.
+    if status == managed_block.STATUS_LOCALLY_MODIFIED and action == managed_block.ACTION_PRESERVE:
+        status = "conflict"
+        if not detail or "fix with:" not in (detail or ""):
+            detail = detail or f"foreign managed instruction block; recover with: {_RECOVERY_COMMAND}"
+    elif status == managed_block.STATUS_MALFORMED and action == managed_block.ACTION_PRESERVE:
+        status = "conflict"
+        detail = detail or "managed instruction markers are malformed"
+    elif status == "symlink":
+        status = "conflict"
+        action = "preserve"
+    return SurfacePlan(
+        "instruction",
+        path,
+        status,
+        action if action != managed_block.ACTION_PRESERVE else "preserve",
+        plan.desired_hash,
+        plan.rendered,
+        detail,
+    )
+
+
+def plan_instruction(
+    *,
+    path: Path,
+    desired: str,
+    state: dict[str, Any],
+    adopt: bool = False,
+    force: bool = False,
+    profile: str = managed_block.DEFAULT_PROFILE,
+    harness: str | None = None,
+) -> SurfacePlan:
+    instruction_state = state.get("instructions", {}) if isinstance(state.get("instructions"), dict) else {}
+    owned = instruction_state.get("digest")
+    owned_digest = owned if isinstance(owned, str) else None
+    fix = _instruction_fix_command(harness)
+    desired_digest = managed_block.body_hash(desired)
+    if not path.exists():
+        block_plan = managed_block.plan_install(
+            None,
+            desired=desired,
+            owned_digest=owned_digest,
+            force=force,
+            adopt=adopt,
+            profile=profile,
+            fix_command=fix,
+        )
+        return _plan_from_block_plan(path, block_plan, harness=harness)
+    try:
+        text = managed_block.normalize_newlines(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError) as exc:
+        return SurfacePlan("instruction", path, "conflict", "preserve", detail=str(exc))
+
+    assessment = managed_block.assess_block(
+        text,
+        desired=desired,
+        owned_digest=owned_digest,
+        profile=profile,
+        fix_command=fix,
+    )
+
+    # Ownership ledger gate: identical content with no Brigade ownership still
+    # requires --adopt before sync will claim it (stamped or legacy).
+    if assessment.status in {managed_block.STATUS_CURRENT, managed_block.STATUS_STALE}:
+        if assessment.actual_hash == desired_digest and owned_digest is None and not adopt and not force:
+            return SurfacePlan(
+                "instruction",
+                path,
+                "conflict",
+                "preserve",
+                desired_digest,
+                detail=f"matching managed instruction block is unowned; recover with: {_RECOVERY_COMMAND}",
+            )
+        if (
+            assessment.actual_hash == desired_digest
+            and owned_digest is None
+            and adopt
+            and assessment.status == managed_block.STATUS_CURRENT
+        ):
+            return SurfacePlan("instruction", path, "adopted", "none", desired_digest)
+        if assessment.actual_hash == desired_digest and owned_digest is None and adopt and assessment.legacy:
+            # Adopt + upgrade legacy markers to hash-stamped form.
+            block_plan = managed_block.plan_install(
+                text,
+                desired=desired,
+                owned_digest=owned_digest,
+                force=True,
+                adopt=True,
+                profile=profile,
+                fix_command=fix,
+            )
+            surface = _plan_from_block_plan(path, block_plan, harness=harness)
+            return SurfacePlan(
+                "instruction",
+                path,
+                "adopted",
+                surface.action,
+                desired_digest,
+                surface.rendered,
+                surface.detail,
+            )
+
+    block_plan = managed_block.plan_install(
+        text,
+        desired=desired,
+        owned_digest=owned_digest,
+        force=force,
+        adopt=adopt,
+        profile=profile,
+        fix_command=fix,
+    )
+    return _plan_from_block_plan(path, block_plan, harness=harness)
+
+
+def plan_instruction_removal(
+    *, path: Path, state: dict[str, Any], force: bool = False, harness: str | None = None
+) -> SurfacePlan:
     if not path.exists():
         return SurfacePlan("instruction", path, "absent", "none")
     try:
-        text = path.read_text(encoding="utf-8")
+        text = managed_block.normalize_newlines(path.read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError) as exc:
         return SurfacePlan("instruction", path, "conflict", "preserve", detail=str(exc))
-    parts = _split_components(text)
-    if parts is None:
-        return SurfacePlan(
-            "instruction",
-            path,
-            "absent"
-            if harness_profiles.INSTRUCTION_START not in text and harness_profiles.INSTRUCTION_END not in text
-            else "conflict",
-            "none"
-            if harness_profiles.INSTRUCTION_START not in text and harness_profiles.INSTRUCTION_END not in text
-            else "preserve",
-            detail="managed instruction markers are malformed",
-        )
-    before, body, after = parts
     instruction_state = state.get("instructions", {}) if isinstance(state.get("instructions"), dict) else {}
     owned = instruction_state.get("digest")
-    if owned == digest_text(body):
-        if instruction_state.get("created_file") and not before and not after:
-            return SurfacePlan("instruction", path, "managed", "remove")
-        return SurfacePlan(
-            "instruction",
-            path,
-            "managed",
-            "remove",
-            rendered=(before[:-1] if before.endswith("\n") else before) + after,
-        )
-    return SurfacePlan("instruction", path, "conflict", "preserve", detail="owned instruction block was edited")
+    owned_digest = owned if isinstance(owned, str) else None
+    block_plan = managed_block.plan_remove(
+        text,
+        owned_digest=owned_digest,
+        force=force,
+        fix_command=_instruction_fix_command(harness),
+    )
+    if block_plan.action == managed_block.ACTION_NONE and block_plan.status == managed_block.STATUS_MISSING:
+        return SurfacePlan("instruction", path, "absent", "none")
+    if block_plan.action == managed_block.ACTION_PRESERVE:
+        detail = block_plan.detail or "owned instruction block was edited"
+        if block_plan.status == managed_block.STATUS_MALFORMED:
+            detail = block_plan.detail or "managed instruction markers are malformed"
+        return SurfacePlan("instruction", path, "conflict", "preserve", detail=detail)
+    if instruction_state.get("created_file") and block_plan.rendered == "":
+        return SurfacePlan("instruction", path, "managed", "remove")
+    return SurfacePlan(
+        "instruction",
+        path,
+        "managed",
+        "remove",
+        rendered=block_plan.rendered if block_plan.rendered is not None else "",
+    )
 
 
 def plan_managed_instruction(*, path: Path, desired: str, state: dict[str, Any], adopt: bool = False) -> SurfacePlan:
@@ -320,17 +401,24 @@ def plan_managed_instruction_removal(*, path: Path, state: dict[str, Any]) -> Su
     return SurfacePlan("instruction", path, "conflict", "preserve", detail="owned instruction file was edited")
 
 
-def _instruction_plan(profile, state: dict[str, Any], *, adopt: bool) -> SurfacePlan:
+def _instruction_plan(profile, state: dict[str, Any], *, adopt: bool, force: bool = False) -> SurfacePlan:
     desired = profile.instruction_text or harness_profiles.managed_instruction_text()
     if profile.instruction_mode == "managed-file":
         return plan_managed_instruction(path=profile.instruction_path, desired=desired, state=state, adopt=adopt)
-    return plan_instruction(path=profile.instruction_path, desired=desired, state=state, adopt=adopt)
+    return plan_instruction(
+        path=profile.instruction_path,
+        desired=desired,
+        state=state,
+        adopt=adopt,
+        force=force,
+        harness=profile.harness,
+    )
 
 
-def _instruction_removal_plan(profile, state: dict[str, Any]) -> SurfacePlan:
+def _instruction_removal_plan(profile, state: dict[str, Any], *, force: bool = False) -> SurfacePlan:
     if profile.instruction_mode == "managed-file":
         return plan_managed_instruction_removal(path=profile.instruction_path, state=state)
-    return plan_instruction_removal(path=profile.instruction_path, state=state)
+    return plan_instruction_removal(path=profile.instruction_path, state=state, force=force, harness=profile.harness)
 
 
 def _lstat_conflict(path: Path, *, directory: bool) -> str | None:
@@ -1254,7 +1342,7 @@ def _prune_created_directories(paths: list[Path], root: Path) -> list[str]:
 
 
 def _sync_profile(
-    profile, workspace: Path, *, write: bool, allow_global_stdio: bool, adopt: bool
+    profile, workspace: Path, *, write: bool, allow_global_stdio: bool, adopt: bool, force: bool = False
 ) -> tuple[dict[str, Any], bool]:
     surface_conflicts = _native_surface_conflicts(profile, workspace)
     if surface_conflicts:
@@ -1283,15 +1371,16 @@ def _sync_profile(
         ), False
     state = json.loads(json.dumps(loaded.state))
     instruction_existed = profile.instruction_path.exists()
-    instruction = _instruction_plan(profile, state, adopt=adopt)
-    items = [
-        {
-            "surface": "instruction",
-            "path": str(instruction.path),
-            "status": instruction.status,
-            "action": instruction.action,
-        }
-    ]
+    instruction = _instruction_plan(profile, state, adopt=adopt, force=force)
+    item = {
+        "surface": "instruction",
+        "path": str(instruction.path),
+        "status": instruction.status,
+        "action": instruction.action,
+    }
+    if instruction.detail:
+        item["detail"] = instruction.detail
+    items = [item]
     conflicts = (
         []
         if instruction.status != "conflict"
@@ -1350,7 +1439,50 @@ def _sync_profile(
                 if profile.instruction_mode == "managed-file"
                 else []
             )
-            localio.write_text_atomic(instruction.path, instruction.rendered or "")
+            if profile.instruction_mode == "managed-file":
+                localio.write_text_atomic(instruction.path, instruction.rendered or "")
+            else:
+                outcome = managed_block.write_text_nofollow_atomic(instruction.path, instruction.rendered or "")
+                if outcome.status == managed_block.WRITE_SKIPPED_SYMLINK:
+                    conflict = {
+                        "surface": "instruction",
+                        "path": str(instruction.path),
+                        "status": "conflict",
+                        "action": "preserve",
+                        "detail": outcome.detail or "symlinked instruction path",
+                    }
+                    return _result(
+                        profile,
+                        status="conflict",
+                        ready=False,
+                        items=items,
+                        conflicts=[conflict],
+                        files_written=[],
+                        files_removed=[],
+                        mcp={"status": "pending", "items": []},
+                        receipt_path=profile.receipt_path,
+                        receipt_state="missing",
+                    ), False
+                if outcome.status not in {managed_block.WRITE_WRITTEN, managed_block.WRITE_NOOP}:
+                    conflict = {
+                        "surface": "instruction",
+                        "path": str(instruction.path),
+                        "status": "conflict",
+                        "action": "preserve",
+                        "detail": outcome.detail or "instruction write refused",
+                    }
+                    return _result(
+                        profile,
+                        status="conflict",
+                        ready=False,
+                        items=items,
+                        conflicts=[conflict],
+                        files_written=[],
+                        files_removed=[],
+                        mcp={"status": "pending", "items": []},
+                        receipt_path=profile.receipt_path,
+                        receipt_state="missing",
+                    ), False
             files_written.append(str(instruction.path))
             changed = True
             if profile.instruction_mode == "managed-file":
@@ -1443,7 +1575,7 @@ def _sync_profile(
     ), False
 
 
-def _uninstall_profile(profile, workspace: Path, *, write: bool) -> tuple[dict[str, Any], bool]:
+def _uninstall_profile(profile, workspace: Path, *, write: bool, force: bool = False) -> tuple[dict[str, Any], bool]:
     surface_conflicts = _native_surface_conflicts(profile, workspace)
     if surface_conflicts:
         return _surface_conflict_result(profile, surface_conflicts)
@@ -1483,8 +1615,10 @@ def _uninstall_profile(profile, workspace: Path, *, write: bool) -> tuple[dict[s
             receipt_path=profile.receipt_path,
             receipt_state="present" if profile.receipt_path.exists() else "missing",
         ), False
-    plan = _instruction_removal_plan(profile, state)
+    plan = _instruction_removal_plan(profile, state, force=force)
     items = [{"surface": "instruction", "path": str(plan.path), "status": plan.status, "action": plan.action}]
+    if plan.detail:
+        items[0]["detail"] = plan.detail
     conflicts = [] if plan.status != "conflict" else [items[0] | {"detail": plan.detail or "instruction conflict"}]
     skill_plan = _skill_uninstall_plan(profile, state)
     items.extend(skill_plan["items"])
@@ -1514,7 +1648,51 @@ def _uninstall_profile(profile, workspace: Path, *, write: bool) -> tuple[dict[s
             if plan.rendered is None:
                 plan.path.unlink(missing_ok=True)
             else:
-                localio.write_text_atomic(plan.path, plan.rendered)
+                outcome = managed_block.write_text_nofollow_atomic(plan.path, plan.rendered)
+                if outcome.status == managed_block.WRITE_SKIPPED_SYMLINK:
+                    conflicts.append(
+                        {
+                            "surface": "instruction",
+                            "path": str(plan.path),
+                            "status": "conflict",
+                            "action": "preserve",
+                            "detail": outcome.detail or "symlinked instruction path",
+                        }
+                    )
+                    return _result(
+                        profile,
+                        status="conflict",
+                        ready=False,
+                        items=items,
+                        conflicts=conflicts,
+                        files_written=[],
+                        files_removed=[],
+                        mcp={"status": "pending", "items": []},
+                        receipt_path=profile.receipt_path,
+                        receipt_state="present" if profile.receipt_path.exists() else "missing",
+                    ), False
+                if outcome.status not in {managed_block.WRITE_WRITTEN, managed_block.WRITE_NOOP}:
+                    conflicts.append(
+                        {
+                            "surface": "instruction",
+                            "path": str(plan.path),
+                            "status": "conflict",
+                            "action": "preserve",
+                            "detail": outcome.detail or "instruction write refused",
+                        }
+                    )
+                    return _result(
+                        profile,
+                        status="conflict",
+                        ready=False,
+                        items=items,
+                        conflicts=conflicts,
+                        files_written=[],
+                        files_removed=[],
+                        mcp={"status": "pending", "items": []},
+                        receipt_path=profile.receipt_path,
+                        receipt_state="present" if profile.receipt_path.exists() else "missing",
+                    ), False
             files_removed.append(str(plan.path))
         instruction_dirs = state.get("instructions", {})
         instruction_dirs = (
@@ -1599,6 +1777,14 @@ def _doctor_profile(profile, workspace: Path, *, verify_mcp: bool) -> tuple[dict
         "status": instruction.status,
         "action": instruction.action,
     }
+    if instruction.detail:
+        item["detail"] = instruction.detail
+    elif instruction.status == managed_block.STATUS_STALE:
+        item["detail"] = f"fix with: {_instruction_fix_command(profile.harness)}"
+    elif instruction.status == managed_block.STATUS_MISSING:
+        item["detail"] = f"fix with: {_instruction_fix_command(profile.harness)}"
+    # Doctor --check semantics: anything not current is actionable. Preserve
+    # distinct stale / missing / conflict statuses on the item itself.
     conflicts = [item] if instruction.status != "current" else []
     skill_plan = _skill_plans(profile, state, workspace)
     skill_issues = [entry for entry in skill_plan["items"] if entry["status"] != "current"]
@@ -1635,6 +1821,8 @@ def _run(
     write: bool = False,
     allow_global_stdio: bool = False,
     adopt: bool = False,
+    force: bool = False,
+    check: bool = False,
     verify_mcp: bool = False,
     json_output: bool = False,
     home: Path | None = None,
@@ -1643,11 +1831,19 @@ def _run(
 
     def run_profile(profile, *, profile_write: bool) -> tuple[dict[str, Any], bool]:
         if operation == "sync":
+            if check:
+                # --check is doctor-style classification for instruction freshness.
+                return _doctor_profile(profile, workspace, verify_mcp=False)
             return _sync_profile(
-                profile, workspace, write=profile_write, allow_global_stdio=allow_global_stdio, adopt=adopt
+                profile,
+                workspace,
+                write=profile_write,
+                allow_global_stdio=allow_global_stdio,
+                adopt=adopt,
+                force=force,
             )
         elif operation == "uninstall":
-            return _uninstall_profile(profile, workspace, write=profile_write)
+            return _uninstall_profile(profile, workspace, write=profile_write, force=force)
         return _doctor_profile(profile, workspace, verify_mcp=verify_mcp)
 
     if write and len(profiles) > 1 and operation in {"sync", "uninstall"}:
@@ -1676,6 +1872,18 @@ def _run(
             print(
                 f"{result['harness']}: {result['status']} receipt={result['receipt_path']} ({result['receipt_state']})"
             )
+            for item in result.get("items", []):
+                if item.get("surface") != "instruction":
+                    continue
+                if item.get("status") in {
+                    managed_block.STATUS_STALE,
+                    managed_block.STATUS_MISSING,
+                    managed_block.STATUS_LOCALLY_MODIFIED,
+                    managed_block.STATUS_MALFORMED,
+                    "conflict",
+                }:
+                    detail = item.get("detail") or item.get("status")
+                    print(f"  instruction {item.get('status')}: {detail}")
     return 0 if payload["ready"] else 1
 
 
@@ -1686,6 +1894,8 @@ def sync(
     write: bool = False,
     allow_global_stdio: bool = False,
     adopt: bool = False,
+    force: bool = False,
+    check: bool = False,
     json_output: bool = False,
     home: Path | None = None,
 ) -> int:
@@ -1696,15 +1906,31 @@ def sync(
         write=write,
         allow_global_stdio=allow_global_stdio,
         adopt=adopt,
+        force=force,
+        check=check,
         json_output=json_output,
         home=home,
     )
 
 
 def uninstall(
-    *, harness: str, workspace: Path, write: bool = False, json_output: bool = False, home: Path | None = None
+    *,
+    harness: str,
+    workspace: Path,
+    write: bool = False,
+    force: bool = False,
+    json_output: bool = False,
+    home: Path | None = None,
 ) -> int:
-    return _run("uninstall", harness=harness, workspace=workspace, write=write, json_output=json_output, home=home)
+    return _run(
+        "uninstall",
+        harness=harness,
+        workspace=workspace,
+        write=write,
+        force=force,
+        json_output=json_output,
+        home=home,
+    )
 
 
 def doctor(

--- a/src/brigade/harness_profile_cmd.py
+++ b/src/brigade/harness_profile_cmd.py
@@ -15,7 +15,7 @@ from . import harness_profiles, localio, managed_block, mcp_adapters, mcp_cmd, s
 from .toml_compat import TOMLDecodeError as _TOMLDecodeError
 from .toml_compat import loads as _toml_loads
 
-_RECOVERY_COMMAND = "brigade harness sync --target <harness> --scope user --adopt --write"
+_RECOVERY_COMMAND = "brigade harness sync --target <harness> --scope user --help"
 _SECTIONS = ("instructions", "skills", "generated", "mcp")
 _HOOK_STATE_KEY = "hooks.json#sessionStart"
 _LEGACY_MIGRATED = "legacy_migrated"
@@ -181,7 +181,12 @@ def _split_components(text: str) -> tuple[str, str, str] | None:
     return parsed.before, parsed.body, parsed.after
 
 
-def _instruction_fix_command(harness: str | None = None) -> str:
+def _instruction_help_command(harness: str | None = None) -> str:
+    target = harness or "<harness>"
+    return _RECOVERY_COMMAND.replace("<harness>", target)
+
+
+def _instruction_write_fix_command(harness: str | None = None) -> str:
     target = harness or "<harness>"
     return managed_block.default_fix_command(harness=target)
 
@@ -191,22 +196,24 @@ def _plan_from_block_plan(path: Path, plan: managed_block.BlockPlan, *, harness:
     status = plan.status
     action = plan.action
     detail = plan.detail
-    if plan.fix_command and status in {
+    if status in {
         managed_block.STATUS_MISSING,
         managed_block.STATUS_STALE,
         managed_block.STATUS_LOCALLY_MODIFIED,
         managed_block.STATUS_MALFORMED,
     }:
-        fix = plan.fix_command
-        if harness and "<harness>" in fix:
-            fix = _instruction_fix_command(harness)
-        detail = f"{detail}; fix with: {fix}" if detail else f"fix with: {fix}"
+        if status in {managed_block.STATUS_LOCALLY_MODIFIED, managed_block.STATUS_MALFORMED}:
+            help_cmd = _instruction_help_command(harness)
+            detail = f"{detail}; see: {help_cmd}" if detail else f"see: {help_cmd}"
+        else:
+            write_cmd = _instruction_write_fix_command(harness)
+            detail = f"{detail}; fix with: {write_cmd}" if detail else f"fix with: {write_cmd}"
     # Preserve legacy conflict wording for fail-closed local edits so existing
     # recovery messaging and tests keep a stable surface.
     if status == managed_block.STATUS_LOCALLY_MODIFIED and action == managed_block.ACTION_PRESERVE:
         status = "conflict"
-        if not detail or "fix with:" not in (detail or ""):
-            detail = detail or f"foreign managed instruction block; recover with: {_RECOVERY_COMMAND}"
+        if not detail or "see:" not in (detail or ""):
+            detail = detail or f"foreign managed instruction block; see: {_instruction_help_command(harness)}"
     elif status == managed_block.STATUS_MALFORMED and action == managed_block.ACTION_PRESERVE:
         status = "conflict"
         detail = detail or "managed instruction markers are malformed"
@@ -237,7 +244,7 @@ def plan_instruction(
     instruction_state = state.get("instructions", {}) if isinstance(state.get("instructions"), dict) else {}
     owned = instruction_state.get("digest")
     owned_digest = owned if isinstance(owned, str) else None
-    fix = _instruction_fix_command(harness)
+    fix = _instruction_write_fix_command(harness)
     desired_digest = managed_block.body_hash(desired)
     if not path.exists():
         block_plan = managed_block.plan_install(
@@ -251,7 +258,7 @@ def plan_instruction(
         )
         return _plan_from_block_plan(path, block_plan, harness=harness)
     try:
-        text = managed_block.normalize_newlines(path.read_text(encoding="utf-8"))
+        text = managed_block.read_text_nofollow(path)
     except (OSError, UnicodeDecodeError) as exc:
         return SurfacePlan("instruction", path, "conflict", "preserve", detail=str(exc))
 
@@ -273,7 +280,7 @@ def plan_instruction(
                 "conflict",
                 "preserve",
                 desired_digest,
-                detail=f"matching managed instruction block is unowned; recover with: {_RECOVERY_COMMAND}",
+                detail=f"matching managed instruction block is unowned; see: {_instruction_help_command(harness)}",
             )
         if (
             assessment.actual_hash == desired_digest
@@ -322,7 +329,7 @@ def plan_instruction_removal(
     if not path.exists():
         return SurfacePlan("instruction", path, "absent", "none")
     try:
-        text = managed_block.normalize_newlines(path.read_text(encoding="utf-8"))
+        text = managed_block.read_text_nofollow(path)
     except (OSError, UnicodeDecodeError) as exc:
         return SurfacePlan("instruction", path, "conflict", "preserve", detail=str(exc))
     instruction_state = state.get("instructions", {}) if isinstance(state.get("instructions"), dict) else {}
@@ -332,7 +339,7 @@ def plan_instruction_removal(
         text,
         owned_digest=owned_digest,
         force=force,
-        fix_command=_instruction_fix_command(harness),
+        fix_command=_instruction_write_fix_command(harness),
     )
     if block_plan.action == managed_block.ACTION_NONE and block_plan.status == managed_block.STATUS_MISSING:
         return SurfacePlan("instruction", path, "absent", "none")
@@ -375,7 +382,7 @@ def plan_managed_instruction(*, path: Path, desired: str, state: dict[str, Any],
             "conflict",
             "preserve",
             desired_digest,
-            detail=f"matching managed instruction file is unowned; recover with: {_RECOVERY_COMMAND}",
+            detail=f"matching managed instruction file is unowned; see: {_instruction_help_command()}",
         )
     if owned == live_digest or adopt:
         return SurfacePlan("instruction", path, "stale", "update", desired_digest, desired)
@@ -384,7 +391,7 @@ def plan_managed_instruction(*, path: Path, desired: str, state: dict[str, Any],
         path,
         "conflict",
         "preserve",
-        detail=f"foreign managed instruction file; recover with: {_RECOVERY_COMMAND}",
+        detail=f"foreign managed instruction file; see: {_instruction_help_command()}",
     )
 
 
@@ -1780,9 +1787,9 @@ def _doctor_profile(profile, workspace: Path, *, verify_mcp: bool) -> tuple[dict
     if instruction.detail:
         item["detail"] = instruction.detail
     elif instruction.status == managed_block.STATUS_STALE:
-        item["detail"] = f"fix with: {_instruction_fix_command(profile.harness)}"
+        item["detail"] = f"fix with: {_instruction_write_fix_command(profile.harness)}"
     elif instruction.status == managed_block.STATUS_MISSING:
-        item["detail"] = f"fix with: {_instruction_fix_command(profile.harness)}"
+        item["detail"] = f"fix with: {_instruction_write_fix_command(profile.harness)}"
     # Doctor --check semantics: anything not current is actionable. Preserve
     # distinct stale / missing / conflict statuses on the item itself.
     conflicts = [item] if instruction.status != "current" else []

--- a/src/brigade/harness_profiles.py
+++ b/src/brigade/harness_profiles.py
@@ -13,8 +13,11 @@ USER_SCOPE_HARNESS_IDS = (*SLICE1_HARNESS_IDS, *SLICE2_HARNESS_IDS)
 USER_SCOPE_SLICE1_TARGETS = (*SLICE1_HARNESS_IDS, "all")
 USER_SCOPE_TARGETS = (*USER_SCOPE_HARNESS_IDS, "all")
 PROFILE_STATE_VERSION = 2
+# Legacy user-profile markers (pre hash-stamp). Recognized and upgraded in place.
 INSTRUCTION_START = "<!-- brigade:user-profile:start -->"
 INSTRUCTION_END = "<!-- brigade:user-profile:end -->"
+INSTRUCTION_KIND = "INTEGRATION"
+INSTRUCTION_PROFILE = "full"
 
 
 @dataclass(frozen=True)

--- a/src/brigade/managed_block.py
+++ b/src/brigade/managed_block.py
@@ -151,6 +151,37 @@ def normalize_newlines(text: str) -> str:
     return text.replace("\r\n", "\n").replace("\r", "\n")
 
 
+def _normalized_offset_starts(text: str) -> list[int]:
+    """Map each normalized-text index to its start offset in ``text``."""
+    starts: list[int] = []
+    index = 0
+    length = len(text)
+    while index < length:
+        starts.append(index)
+        if text.startswith("\r\n", index):
+            index += 2
+        elif text[index] == "\r":
+            index += 1
+        else:
+            index += 1
+    starts.append(length)
+    return starts
+
+
+def _slice_by_normalized_range(text: str, offsets: list[int], start: int, end: int) -> str:
+    return text[offsets[start] : offsets[end]]
+
+
+def _file_newline(text: str) -> str:
+    return "\r\n" if "\r\n" in text else "\n"
+
+
+def _with_file_newlines(block: str, newline: str) -> str:
+    if newline == "\n":
+        return block
+    return block.replace("\n", "\r\n")
+
+
 def begin_marker(*, kind: str, profile: str, digest: str, version: int = MARKER_FORMAT_VERSION) -> str:
     if version != MARKER_FORMAT_VERSION:
         raise ValueError(f"unsupported managed-block marker version: {version}")
@@ -223,11 +254,12 @@ def _extract_framed_body(text: str, start_pos: int, start_len: int, end_pos: int
 
 def parse_blocks(text: str, *, kind: str = DEFAULT_KIND) -> ParsedBlock:
     """Parse the managed span for ``kind`` into a structured block state."""
-    text = normalize_newlines(text)
-    begins, ends, loose_details = _marker_hits(text, kind=kind)
+    offsets = _normalized_offset_starts(text)
+    normalized = normalize_newlines(text)
+    begins, ends, loose_details = _marker_hits(normalized, kind=kind)
     legacy = _legacy_pair_for_kind(kind)
-    legacy_starts = text.count(legacy[0]) if legacy else 0
-    legacy_ends = text.count(legacy[1]) if legacy else 0
+    legacy_starts = normalized.count(legacy[0]) if legacy else 0
+    legacy_ends = normalized.count(legacy[1]) if legacy else 0
 
     if loose_details and not begins and not ends and legacy_starts == 0 and legacy_ends == 0:
         return ParsedBlock(STATUS_MALFORMED, kind, detail=loose_details[0])
@@ -258,7 +290,7 @@ def parse_blocks(text: str, *, kind: str = DEFAULT_KIND) -> ParsedBlock:
         if end.start() <= begin.start():
             return ParsedBlock(STATUS_MALFORMED, kind, detail="orphan managed marker")
         # Nested / overlapping: another begin or end inside the span.
-        inner = text[begin.end() : end.start()]
+        inner = normalized[begin.end() : end.start()]
         if _BEGIN_LOOSE_RE.search(inner) or _END_LOOSE_RE.search(inner):
             return ParsedBlock(STATUS_MALFORMED, kind, detail="nested managed markers")
         if legacy and (legacy[0] in inner or legacy[1] in inner):
@@ -270,13 +302,21 @@ def parse_blocks(text: str, *, kind: str = DEFAULT_KIND) -> ParsedBlock:
             return ParsedBlock(STATUS_MALFORMED, kind, detail=f"unsupported marker version: {version}")
         if not re.fullmatch(r"[0-9a-f]{64}", recorded):
             return ParsedBlock(STATUS_MALFORMED, kind, detail="begin marker hash must be a full sha256 digest")
-        framed = _extract_framed_body(text, begin.start(), len(begin.group(0)), end.start())
+        framed = _extract_framed_body(normalized, begin.start(), len(begin.group(0)), end.start())
         if framed is None:
             return ParsedBlock(STATUS_MALFORMED, kind, detail="managed instruction markers are malformed")
         before, body, after_with_end = framed
         after = after_with_end[len(end.group(0)) :]
         if after.startswith("\n"):
             after = after[1:]
+        before = _slice_by_normalized_range(text, offsets, 0, begin.start())
+        body_start = begin.start() + len(begin.group(0)) + 1
+        body_end = end.start() - 1
+        body = normalize_newlines(_slice_by_normalized_range(text, offsets, body_start, body_end))
+        after_start = end.start() + len(end.group(0))
+        if after_start < len(normalized) and normalized[after_start] == "\n":
+            after_start += 1
+        after = _slice_by_normalized_range(text, offsets, after_start, len(normalized))
         meta = BlockMeta(kind=kind, version=version, profile=profile, recorded_hash=recorded, legacy=False)
         return ParsedBlock(
             "ok",
@@ -294,19 +334,27 @@ def parse_blocks(text: str, *, kind: str = DEFAULT_KIND) -> ParsedBlock:
     if legacy_starts != 1 or legacy_ends != 1:
         detail = "duplicate managed blocks" if legacy_starts > 1 or legacy_ends > 1 else "orphan managed marker"
         return ParsedBlock(STATUS_MALFORMED, kind, detail=detail)
-    start_pos, end_pos = text.find(legacy_start), text.find(legacy_end)
+    start_pos, end_pos = normalized.find(legacy_start), normalized.find(legacy_end)
     if end_pos <= start_pos:
         return ParsedBlock(STATUS_MALFORMED, kind, detail="orphan managed marker")
-    inner = text[start_pos + len(legacy_start) : end_pos]
+    inner = normalized[start_pos + len(legacy_start) : end_pos]
     if legacy_start in inner or legacy_end in inner or _BEGIN_LOOSE_RE.search(inner) or _END_LOOSE_RE.search(inner):
         return ParsedBlock(STATUS_MALFORMED, kind, detail="nested managed markers")
-    framed = _extract_framed_body(text, start_pos, len(legacy_start), end_pos)
+    framed = _extract_framed_body(normalized, start_pos, len(legacy_start), end_pos)
     if framed is None:
         return ParsedBlock(STATUS_MALFORMED, kind, detail="managed instruction markers are malformed")
     before, body, after_with_end = framed
     after = after_with_end[len(legacy_end) :]
     if after.startswith("\n"):
         after = after[1:]
+    before = _slice_by_normalized_range(text, offsets, 0, start_pos)
+    body_start = start_pos + len(legacy_start) + 1
+    body_end = end_pos - 1
+    body = normalize_newlines(_slice_by_normalized_range(text, offsets, body_start, body_end))
+    after_start = end_pos + len(legacy_end)
+    if after_start < len(normalized) and normalized[after_start] == "\n":
+        after_start += 1
+    after = _slice_by_normalized_range(text, offsets, after_start, len(normalized))
     meta = BlockMeta(kind=kind, version=None, profile=None, recorded_hash=None, legacy=True)
     return ParsedBlock(
         "ok",
@@ -497,12 +545,13 @@ def plan_install(
     parsed = assessment.parsed
 
     if assessment.status == STATUS_MISSING:
-        prefix = text if (not text or text.endswith("\n")) else text + "\n"
+        newline = _file_newline(text)
+        prefix = text if (not text or text.endswith(newline)) else text + newline
         return BlockPlan(
             STATUS_MISSING,
             ACTION_CREATE,
             kind,
-            rendered=prefix + block,
+            rendered=prefix + _with_file_newlines(block, newline),
             desired_hash=desired_digest,
             fix_command=fix,
             detail=assessment.detail,
@@ -520,7 +569,8 @@ def plan_install(
 
     if assessment.status == STATUS_STALE:
         assert parsed.status == "ok"
-        rendered = parsed.before + block + parsed.after
+        newline = _file_newline(text)
+        rendered = parsed.before + _with_file_newlines(block, newline) + parsed.after
         return BlockPlan(
             STATUS_STALE,
             ACTION_UPDATE,
@@ -534,11 +584,12 @@ def plan_install(
     if assessment.status in {STATUS_LOCALLY_MODIFIED, STATUS_MALFORMED}:
         can_force = force or (adopt and assessment.status == STATUS_LOCALLY_MODIFIED and parsed.status == "ok")
         if can_force and parsed.status == "ok":
+            newline = _file_newline(text)
             return BlockPlan(
                 assessment.status,
                 ACTION_UPDATE,
                 kind,
-                rendered=parsed.before + block + parsed.after,
+                rendered=parsed.before + _with_file_newlines(block, newline) + parsed.after,
                 desired_hash=desired_digest,
                 fix_command=fix,
                 detail=assessment.detail,
@@ -758,7 +809,7 @@ def install_block(
         text = None
     else:
         try:
-            text = normalize_newlines(read_text_nofollow(path))
+            text = read_text_nofollow(path)
         except (OSError, UnicodeDecodeError) as exc:
             plan = BlockPlan(
                 STATUS_MALFORMED,
@@ -828,7 +879,7 @@ def remove_block(
         return plan, WriteOutcome(WRITE_NOOP)
 
     try:
-        text = normalize_newlines(read_text_nofollow(path))
+        text = read_text_nofollow(path)
     except (OSError, UnicodeDecodeError) as exc:
         plan = BlockPlan(STATUS_MALFORMED, ACTION_PRESERVE, kind, detail=str(exc), fix_command=fix_command)
         return plan, WriteOutcome(WRITE_ERROR, detail=str(exc))

--- a/src/brigade/managed_block.py
+++ b/src/brigade/managed_block.py
@@ -1,0 +1,893 @@
+"""Hash-stamped managed instruction blocks for foreign harness files.
+
+Brigade injects guidance into files it does not own. Every managed span is
+framed by a marker pair that records marker-format version, instruction
+profile, and the full SHA-256 of the body so install/check/remove can share
+one honest parser:
+
+    <!-- BEGIN BRIGADE INTEGRATION v:1 profile:full hash:<sha256> -->
+    ...body...
+    <!-- END BRIGADE INTEGRATION -->
+
+Statuses compare three digests when a desired body is supplied:
+
+- recorded: hash embedded in the begin marker (absent on legacy markers)
+- actual: hash of the bytes currently between the markers
+- desired: hash of a freshly rendered body
+
+``current`` requires recorded == actual == desired with stamped v1 markers.
+``stale`` means the installed span still matches its recorded hash (or is a
+clean legacy span Brigade may upgrade) but differs from desired.
+``locally_modified`` means the body no longer matches the recorded hash, or a
+legacy/unowned span does not match desired.
+``malformed`` covers duplicate, orphan, nested, or unparseable markers.
+
+Writes use an atomic same-directory replace and refuse to follow a symlinked
+final path component (including a symlink swapped in after the initial
+``lstat``). Unchanged content is a true no-op: no write, no mtime churn.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import stat
+import tempfile
+import warnings
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+MARKER_FORMAT_VERSION = 1
+DEFAULT_KIND = "INTEGRATION"
+DEFAULT_PROFILE = "full"
+HASH_ABBREV_LEN = 8
+
+# Legacy user-profile markers (issue #438) — recognized and upgraded in place.
+LEGACY_USER_PROFILE_START = "<!-- brigade:user-profile:start -->"
+LEGACY_USER_PROFILE_END = "<!-- brigade:user-profile:end -->"
+
+_BEGIN_RE = re.compile(
+    r"<!--\s*BEGIN BRIGADE\s+([A-Za-z][A-Za-z0-9_-]*)\s+"
+    r"v:(\d+)\s+profile:([^\s]+)\s+hash:([0-9a-fA-F]+)\s*-->"
+)
+_END_RE = re.compile(r"<!--\s*END BRIGADE\s+([A-Za-z][A-Za-z0-9_-]*)\s*-->")
+_BEGIN_LOOSE_RE = re.compile(r"<!--\s*BEGIN BRIGADE\b")
+_END_LOOSE_RE = re.compile(r"<!--\s*END BRIGADE\b")
+
+STATUS_MISSING = "missing"
+STATUS_CURRENT = "current"
+STATUS_STALE = "stale"
+STATUS_LOCALLY_MODIFIED = "locally_modified"
+STATUS_MALFORMED = "malformed"
+
+ACTION_NONE = "none"
+ACTION_CREATE = "create"
+ACTION_UPDATE = "update"
+ACTION_REMOVE = "remove"
+ACTION_PRESERVE = "preserve"
+
+WRITE_WRITTEN = "written"
+WRITE_NOOP = "noop"
+WRITE_SKIPPED_SYMLINK = "skipped_symlink"
+WRITE_REFUSED = "refused"
+WRITE_ERROR = "error"
+
+
+@dataclass(frozen=True)
+class BlockMeta:
+    kind: str
+    version: int | None
+    profile: str | None
+    recorded_hash: str | None
+    legacy: bool
+
+
+@dataclass(frozen=True)
+class ParsedBlock:
+    """Structured parse of one managed-block kind inside a file's text."""
+
+    status: str  # ok | missing | malformed
+    kind: str
+    before: str = ""
+    body: str = ""
+    after: str = ""
+    meta: BlockMeta | None = None
+    actual_hash: str | None = None
+    detail: str | None = None
+
+
+@dataclass(frozen=True)
+class BlockAssessment:
+    status: str
+    kind: str
+    parsed: ParsedBlock
+    desired_hash: str | None = None
+    recorded_hash: str | None = None
+    actual_hash: str | None = None
+    profile: str | None = None
+    legacy: bool = False
+    fix_command: str | None = None
+    detail: str | None = None
+
+    @property
+    def abbreviated_hash(self) -> str | None:
+        digest = self.actual_hash or self.recorded_hash or self.desired_hash
+        return abbreviate_hash(digest) if digest else None
+
+
+@dataclass(frozen=True)
+class BlockPlan:
+    status: str
+    action: str
+    kind: str
+    rendered: str | None = None
+    desired_hash: str | None = None
+    detail: str | None = None
+    fix_command: str | None = None
+    warning: str | None = None
+
+
+@dataclass(frozen=True)
+class WriteOutcome:
+    status: str
+    detail: str | None = None
+    warning: str | None = None
+
+
+def body_hash(body: str) -> str:
+    """Full SHA-256 hex digest of a managed body (UTF-8)."""
+    return hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+
+def abbreviate_hash(digest: str) -> str:
+    """Shorten a digest for status output; stored markers keep the full value."""
+    return digest[:HASH_ABBREV_LEN]
+
+
+def normalize_newlines(text: str) -> str:
+    """Define CRLF behavior: hashes and markers operate on LF-normalized text."""
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def begin_marker(*, kind: str, profile: str, digest: str, version: int = MARKER_FORMAT_VERSION) -> str:
+    if version != MARKER_FORMAT_VERSION:
+        raise ValueError(f"unsupported managed-block marker version: {version}")
+    if not re.fullmatch(r"[A-Za-z][A-Za-z0-9_-]*", kind):
+        raise ValueError(f"invalid managed-block kind: {kind!r}")
+    if any(ch.isspace() for ch in profile) or not profile:
+        raise ValueError(f"invalid managed-block profile: {profile!r}")
+    if not re.fullmatch(r"[0-9a-f]{64}", digest):
+        raise ValueError("managed-block hash must be a full lowercase sha256 hex digest")
+    return f"<!-- BEGIN BRIGADE {kind} v:{version} profile:{profile} hash:{digest} -->"
+
+
+def end_marker(*, kind: str) -> str:
+    if not re.fullmatch(r"[A-Za-z][A-Za-z0-9_-]*", kind):
+        raise ValueError(f"invalid managed-block kind: {kind!r}")
+    return f"<!-- END BRIGADE {kind} -->"
+
+
+def render_block(body: str, *, kind: str = DEFAULT_KIND, profile: str = DEFAULT_PROFILE) -> str:
+    """Render a stamped block including the trailing newline after the end marker."""
+    digest = body_hash(body)
+    return f"{begin_marker(kind=kind, profile=profile, digest=digest)}\n{body}\n{end_marker(kind=kind)}\n"
+
+
+def default_fix_command(*, harness: str = "<harness>") -> str:
+    return f"brigade harness sync --target {harness} --scope user --write"
+
+
+def _legacy_pair_for_kind(kind: str) -> tuple[str, str] | None:
+    if kind == DEFAULT_KIND:
+        return LEGACY_USER_PROFILE_START, LEGACY_USER_PROFILE_END
+    return None
+
+
+def _marker_hits(text: str, *, kind: str) -> tuple[list[re.Match[str]], list[re.Match[str]], list[str]]:
+    """Return begin matches, end matches, and malformed loose-marker details for kind."""
+    begins = [m for m in _BEGIN_RE.finditer(text) if m.group(1) == kind]
+    ends = [m for m in _END_RE.finditer(text) if m.group(1) == kind]
+    details: list[str] = []
+    for match in _BEGIN_LOOSE_RE.finditer(text):
+        close = text.find("-->", match.start())
+        window = text[match.start() : close + 3] if close != -1 else text[match.start() : match.start() + 120]
+        if _BEGIN_RE.fullmatch(window):
+            continue
+        kind_token = re.match(r"<!--\s*BEGIN BRIGADE\s+(\S+)", window)
+        token = kind_token.group(1) if kind_token else ""
+        if not token or token == kind or not re.fullmatch(r"[A-Za-z][A-Za-z0-9_-]*", token):
+            details.append("begin marker metadata cannot be parsed")
+    for match in _END_LOOSE_RE.finditer(text):
+        close = text.find("-->", match.start())
+        window = text[match.start() : close + 3] if close != -1 else text[match.start() : match.start() + 80]
+        if _END_RE.fullmatch(window):
+            continue
+        kind_token = re.match(r"<!--\s*END BRIGADE\s+([A-Za-z][A-Za-z0-9_-]*)\s*-->", window)
+        if kind_token is None or kind_token.group(1) == kind:
+            details.append("end marker cannot be parsed")
+    return begins, ends, details
+
+
+def _extract_framed_body(text: str, start_pos: int, start_len: int, end_pos: int) -> tuple[str, str, str] | None:
+    after_start = start_pos + start_len
+    if end_pos <= start_pos or after_start >= len(text) or text[after_start] != "\n":
+        return None
+    if end_pos == 0 or text[end_pos - 1] != "\n":
+        return None
+    before = text[:start_pos]
+    body = text[after_start + 1 : end_pos - 1]
+    return before, body, text[end_pos:]
+
+
+def parse_blocks(text: str, *, kind: str = DEFAULT_KIND) -> ParsedBlock:
+    """Parse the managed span for ``kind`` into a structured block state."""
+    text = normalize_newlines(text)
+    begins, ends, loose_details = _marker_hits(text, kind=kind)
+    legacy = _legacy_pair_for_kind(kind)
+    legacy_starts = text.count(legacy[0]) if legacy else 0
+    legacy_ends = text.count(legacy[1]) if legacy else 0
+
+    if loose_details and not begins and not ends and legacy_starts == 0 and legacy_ends == 0:
+        return ParsedBlock(STATUS_MALFORMED, kind, detail=loose_details[0])
+
+    stamped_present = bool(begins or ends)
+    legacy_present = bool(legacy_starts or legacy_ends)
+
+    if stamped_present and legacy_present:
+        return ParsedBlock(
+            STATUS_MALFORMED,
+            kind,
+            detail="stamped and legacy managed markers both present",
+        )
+
+    if not stamped_present and not legacy_present:
+        # Loose unparseable markers for this kind still count as malformed.
+        if loose_details:
+            return ParsedBlock(STATUS_MALFORMED, kind, detail=loose_details[0])
+        return ParsedBlock(STATUS_MISSING, kind)
+
+    if stamped_present:
+        if loose_details:
+            return ParsedBlock(STATUS_MALFORMED, kind, detail=loose_details[0])
+        if len(begins) != 1 or len(ends) != 1:
+            detail = "duplicate managed blocks" if len(begins) > 1 or len(ends) > 1 else "orphan managed marker"
+            return ParsedBlock(STATUS_MALFORMED, kind, detail=detail)
+        begin, end = begins[0], ends[0]
+        if end.start() <= begin.start():
+            return ParsedBlock(STATUS_MALFORMED, kind, detail="orphan managed marker")
+        # Nested / overlapping: another begin or end inside the span.
+        inner = text[begin.end() : end.start()]
+        if _BEGIN_LOOSE_RE.search(inner) or _END_LOOSE_RE.search(inner):
+            return ParsedBlock(STATUS_MALFORMED, kind, detail="nested managed markers")
+        if legacy and (legacy[0] in inner or legacy[1] in inner):
+            return ParsedBlock(STATUS_MALFORMED, kind, detail="nested managed markers")
+        version = int(begin.group(2))
+        profile = begin.group(3)
+        recorded = begin.group(4).lower()
+        if version != MARKER_FORMAT_VERSION:
+            return ParsedBlock(STATUS_MALFORMED, kind, detail=f"unsupported marker version: {version}")
+        if not re.fullmatch(r"[0-9a-f]{64}", recorded):
+            return ParsedBlock(STATUS_MALFORMED, kind, detail="begin marker hash must be a full sha256 digest")
+        framed = _extract_framed_body(text, begin.start(), len(begin.group(0)), end.start())
+        if framed is None:
+            return ParsedBlock(STATUS_MALFORMED, kind, detail="managed instruction markers are malformed")
+        before, body, after_with_end = framed
+        after = after_with_end[len(end.group(0)) :]
+        if after.startswith("\n"):
+            after = after[1:]
+        meta = BlockMeta(kind=kind, version=version, profile=profile, recorded_hash=recorded, legacy=False)
+        return ParsedBlock(
+            "ok",
+            kind,
+            before=before,
+            body=body,
+            after=after,
+            meta=meta,
+            actual_hash=body_hash(body),
+        )
+
+    # Legacy path.
+    assert legacy is not None
+    legacy_start, legacy_end = legacy
+    if legacy_starts != 1 or legacy_ends != 1:
+        detail = "duplicate managed blocks" if legacy_starts > 1 or legacy_ends > 1 else "orphan managed marker"
+        return ParsedBlock(STATUS_MALFORMED, kind, detail=detail)
+    start_pos, end_pos = text.find(legacy_start), text.find(legacy_end)
+    if end_pos <= start_pos:
+        return ParsedBlock(STATUS_MALFORMED, kind, detail="orphan managed marker")
+    inner = text[start_pos + len(legacy_start) : end_pos]
+    if legacy_start in inner or legacy_end in inner or _BEGIN_LOOSE_RE.search(inner) or _END_LOOSE_RE.search(inner):
+        return ParsedBlock(STATUS_MALFORMED, kind, detail="nested managed markers")
+    framed = _extract_framed_body(text, start_pos, len(legacy_start), end_pos)
+    if framed is None:
+        return ParsedBlock(STATUS_MALFORMED, kind, detail="managed instruction markers are malformed")
+    before, body, after_with_end = framed
+    after = after_with_end[len(legacy_end) :]
+    if after.startswith("\n"):
+        after = after[1:]
+    meta = BlockMeta(kind=kind, version=None, profile=None, recorded_hash=None, legacy=True)
+    return ParsedBlock(
+        "ok",
+        kind,
+        before=before,
+        body=body,
+        after=after,
+        meta=meta,
+        actual_hash=body_hash(body),
+    )
+
+
+def assess_block(
+    text: str,
+    *,
+    desired: str | None,
+    kind: str = DEFAULT_KIND,
+    profile: str = DEFAULT_PROFILE,
+    owned_digest: str | None = None,
+    fix_command: str | None = None,
+) -> BlockAssessment:
+    """Classify a file's managed span against an optional desired body."""
+    parsed = parse_blocks(text, kind=kind)
+    fix = fix_command or default_fix_command()
+    if parsed.status == STATUS_MISSING:
+        return BlockAssessment(
+            STATUS_MISSING if desired is not None else STATUS_MISSING,
+            kind,
+            parsed,
+            desired_hash=body_hash(desired) if desired is not None else None,
+            fix_command=fix,
+            detail="managed block is missing",
+        )
+    if parsed.status == STATUS_MALFORMED:
+        return BlockAssessment(
+            STATUS_MALFORMED,
+            kind,
+            parsed,
+            desired_hash=body_hash(desired) if desired is not None else None,
+            fix_command=fix,
+            detail=parsed.detail,
+        )
+    assert parsed.meta is not None
+    recorded = parsed.meta.recorded_hash
+    actual = parsed.actual_hash
+    desired_digest = body_hash(desired) if desired is not None else None
+    legacy = parsed.meta.legacy
+
+    if desired is None:
+        # Check without a desired body: report integrity of the installed span.
+        if legacy:
+            return BlockAssessment(
+                STATUS_STALE,
+                kind,
+                parsed,
+                recorded_hash=recorded,
+                actual_hash=actual,
+                profile=parsed.meta.profile,
+                legacy=True,
+                fix_command=fix,
+                detail="legacy managed markers need hash-stamped upgrade",
+            )
+        if recorded == actual:
+            return BlockAssessment(
+                STATUS_CURRENT,
+                kind,
+                parsed,
+                recorded_hash=recorded,
+                actual_hash=actual,
+                profile=parsed.meta.profile,
+                fix_command=fix,
+            )
+        return BlockAssessment(
+            STATUS_LOCALLY_MODIFIED,
+            kind,
+            parsed,
+            recorded_hash=recorded,
+            actual_hash=actual,
+            profile=parsed.meta.profile,
+            fix_command=fix,
+            detail="managed block body does not match recorded hash",
+        )
+
+    assert desired_digest is not None
+    if not legacy and recorded == actual == desired_digest:
+        return BlockAssessment(
+            STATUS_CURRENT,
+            kind,
+            parsed,
+            desired_hash=desired_digest,
+            recorded_hash=recorded,
+            actual_hash=actual,
+            profile=parsed.meta.profile or profile,
+            fix_command=fix,
+        )
+
+    if legacy:
+        if actual == desired_digest:
+            return BlockAssessment(
+                STATUS_STALE,
+                kind,
+                parsed,
+                desired_hash=desired_digest,
+                recorded_hash=recorded,
+                actual_hash=actual,
+                legacy=True,
+                fix_command=fix,
+                detail="legacy managed markers need hash-stamped upgrade",
+            )
+        if owned_digest is not None and owned_digest == actual:
+            return BlockAssessment(
+                STATUS_STALE,
+                kind,
+                parsed,
+                desired_hash=desired_digest,
+                recorded_hash=recorded,
+                actual_hash=actual,
+                legacy=True,
+                fix_command=fix,
+                detail="owned legacy managed block is stale",
+            )
+        return BlockAssessment(
+            STATUS_LOCALLY_MODIFIED,
+            kind,
+            parsed,
+            desired_hash=desired_digest,
+            recorded_hash=recorded,
+            actual_hash=actual,
+            legacy=True,
+            fix_command=fix,
+            detail="legacy managed block does not match desired content",
+        )
+
+    if recorded == actual and actual != desired_digest:
+        return BlockAssessment(
+            STATUS_STALE,
+            kind,
+            parsed,
+            desired_hash=desired_digest,
+            recorded_hash=recorded,
+            actual_hash=actual,
+            profile=parsed.meta.profile,
+            fix_command=fix,
+            detail="managed block hash is stale",
+        )
+
+    return BlockAssessment(
+        STATUS_LOCALLY_MODIFIED,
+        kind,
+        parsed,
+        desired_hash=desired_digest,
+        recorded_hash=recorded,
+        actual_hash=actual,
+        profile=parsed.meta.profile,
+        fix_command=fix,
+        detail="managed block body does not match recorded hash",
+    )
+
+
+def plan_install(
+    text: str | None,
+    *,
+    desired: str,
+    kind: str = DEFAULT_KIND,
+    profile: str = DEFAULT_PROFILE,
+    owned_digest: str | None = None,
+    force: bool = False,
+    adopt: bool = False,
+    fix_command: str | None = None,
+) -> BlockPlan:
+    """Plan create/update/no-op/preserve for a managed block inside ``text``."""
+    desired_digest = body_hash(desired)
+    block = render_block(desired, kind=kind, profile=profile)
+    fix = fix_command or default_fix_command()
+    if text is None:
+        return BlockPlan(
+            STATUS_MISSING, ACTION_CREATE, kind, rendered=block, desired_hash=desired_digest, fix_command=fix
+        )
+
+    assessment = assess_block(
+        text,
+        desired=desired,
+        kind=kind,
+        profile=profile,
+        owned_digest=owned_digest,
+        fix_command=fix,
+    )
+    parsed = assessment.parsed
+
+    if assessment.status == STATUS_MISSING:
+        prefix = text if (not text or text.endswith("\n")) else text + "\n"
+        return BlockPlan(
+            STATUS_MISSING,
+            ACTION_CREATE,
+            kind,
+            rendered=prefix + block,
+            desired_hash=desired_digest,
+            fix_command=fix,
+            detail=assessment.detail,
+        )
+
+    if assessment.status == STATUS_CURRENT:
+        # Matching stamped content with no ownership record: adopt refreshes state only.
+        if owned_digest is None and not adopt:
+            # Stamped current block is self-attesting; treat as current.
+            return BlockPlan(STATUS_CURRENT, ACTION_NONE, kind, desired_hash=desired_digest, fix_command=fix)
+        if owned_digest is not None and owned_digest != desired_digest and not adopt:
+            # Content is current per markers; ownership drift is repaired on write of state.
+            return BlockPlan(STATUS_CURRENT, ACTION_NONE, kind, desired_hash=desired_digest, fix_command=fix)
+        return BlockPlan(STATUS_CURRENT, ACTION_NONE, kind, desired_hash=desired_digest, fix_command=fix)
+
+    if assessment.status == STATUS_STALE:
+        assert parsed.status == "ok"
+        rendered = parsed.before + block + parsed.after
+        return BlockPlan(
+            STATUS_STALE,
+            ACTION_UPDATE,
+            kind,
+            rendered=rendered,
+            desired_hash=desired_digest,
+            fix_command=fix,
+            detail=assessment.detail,
+        )
+
+    if assessment.status in {STATUS_LOCALLY_MODIFIED, STATUS_MALFORMED}:
+        can_force = force or (adopt and assessment.status == STATUS_LOCALLY_MODIFIED and parsed.status == "ok")
+        if can_force and parsed.status == "ok":
+            return BlockPlan(
+                assessment.status,
+                ACTION_UPDATE,
+                kind,
+                rendered=parsed.before + block + parsed.after,
+                desired_hash=desired_digest,
+                fix_command=fix,
+                detail=assessment.detail,
+            )
+        detail = assessment.detail
+        if force and parsed.status != "ok":
+            detail = (detail or "malformed managed block") + "; refuse overwrite of unrecoverable malformed span"
+        return BlockPlan(
+            assessment.status,
+            ACTION_PRESERVE,
+            kind,
+            desired_hash=desired_digest,
+            fix_command=fix,
+            detail=detail,
+        )
+
+    return BlockPlan(
+        STATUS_MALFORMED,
+        ACTION_PRESERVE,
+        kind,
+        desired_hash=desired_digest,
+        fix_command=fix,
+        detail=assessment.detail or "unhandled managed block state",
+    )
+
+
+def plan_remove(
+    text: str | None,
+    *,
+    kind: str = DEFAULT_KIND,
+    owned_digest: str | None = None,
+    force: bool = False,
+    fix_command: str | None = None,
+) -> BlockPlan:
+    """Plan surgical removal of the managed span (plus one trailing newline)."""
+    fix = fix_command or default_fix_command()
+    if text is None:
+        return BlockPlan(STATUS_MISSING, ACTION_NONE, kind, fix_command=fix, detail="managed block is absent")
+
+    assessment = assess_block(text, desired=None, kind=kind, owned_digest=owned_digest, fix_command=fix)
+    parsed = assessment.parsed
+
+    if assessment.status == STATUS_MISSING:
+        return BlockPlan(STATUS_MISSING, ACTION_NONE, kind, fix_command=fix, detail="managed block is absent")
+
+    if assessment.status == STATUS_MALFORMED:
+        if not force:
+            return BlockPlan(
+                STATUS_MALFORMED,
+                ACTION_PRESERVE,
+                kind,
+                fix_command=fix,
+                detail=assessment.detail,
+            )
+        return BlockPlan(
+            STATUS_MALFORMED,
+            ACTION_PRESERVE,
+            kind,
+            fix_command=fix,
+            detail=(assessment.detail or "malformed") + "; refuse removal of unrecoverable malformed span",
+        )
+
+    assert parsed.status == "ok" and parsed.actual_hash is not None
+    if assessment.status == STATUS_LOCALLY_MODIFIED and not force:
+        return BlockPlan(
+            STATUS_LOCALLY_MODIFIED,
+            ACTION_PRESERVE,
+            kind,
+            fix_command=fix,
+            detail=assessment.detail or "owned instruction block was edited",
+        )
+
+    # Ownership ledger still gates removal unless --force: a stamped span whose
+    # body matches its recorded hash is only removed when Brigade owns it (or
+    # force is set). Legacy spans use the same rule.
+    if not force and owned_digest is not None and owned_digest != parsed.actual_hash:
+        return BlockPlan(
+            STATUS_LOCALLY_MODIFIED,
+            ACTION_PRESERVE,
+            kind,
+            fix_command=fix,
+            detail="owned instruction block was edited",
+        )
+    if not force and owned_digest is None:
+        return BlockPlan(
+            STATUS_LOCALLY_MODIFIED,
+            ACTION_PRESERVE,
+            kind,
+            fix_command=fix,
+            detail="owned instruction block was edited",
+        )
+
+    rendered = parsed.before + parsed.after
+    return BlockPlan(
+        assessment.status if assessment.status != STATUS_LOCALLY_MODIFIED else STATUS_LOCALLY_MODIFIED,
+        ACTION_REMOVE,
+        kind,
+        rendered=rendered,
+        desired_hash=None,
+        fix_command=fix,
+        detail="remove managed span",
+    )
+
+
+def _lstat_mode(path: Path) -> int | None:
+    try:
+        return os.lstat(path).st_mode
+    except FileNotFoundError:
+        return None
+
+
+def path_is_symlink(path: Path) -> bool:
+    mode = _lstat_mode(path)
+    return mode is not None and stat.S_ISLNK(mode)
+
+
+def read_text_nofollow(path: Path) -> str:
+    """Read UTF-8 text without following a symlinked final component."""
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(path, flags)
+    except OSError as exc:
+        if getattr(exc, "errno", None) in {getattr(os, "ELOOP", 62), getattr(os, "EMLINK", 31)} or path_is_symlink(
+            path
+        ):
+            raise OSError(f"refusing symlinked path: {path}") from exc
+        raise
+    try:
+        st = os.fstat(fd)
+        if stat.S_ISLNK(st.st_mode):
+            raise OSError(f"refusing symlinked path: {path}")
+        if not stat.S_ISREG(st.st_mode):
+            raise OSError(f"managed-block path is not a regular file: {path}")
+        data = os.read(fd, st.st_size)
+    finally:
+        os.close(fd)
+    return data.decode("utf-8")
+
+
+def write_text_nofollow_atomic(
+    path: Path,
+    data: str,
+    *,
+    lstat_probe: Callable[[Path], int | None] | None = None,
+) -> WriteOutcome:
+    """Atomically replace ``path`` without following a symlinked final component.
+
+    ``lstat_probe`` is a test seam for the symlink-swap race between the
+    preflight check and the publish step.
+    """
+    probe = lstat_probe or _lstat_mode
+    mode = probe(path)
+    if mode is not None and stat.S_ISLNK(mode):
+        warning = f"skipping symlinked managed-block target: {path}"
+        warnings.warn(warning, stacklevel=2)
+        return WriteOutcome(WRITE_SKIPPED_SYMLINK, detail=warning, warning=warning)
+    if mode is not None and not stat.S_ISREG(mode):
+        detail = f"managed-block target is not a regular file: {path}"
+        return WriteOutcome(WRITE_REFUSED, detail=detail)
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp")
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        # Re-check immediately before publish to catch a symlink swap.
+        mode_after = probe(path)
+        if mode_after is not None and stat.S_ISLNK(mode_after):
+            warning = f"skipping symlinked managed-block target after swap: {path}"
+            warnings.warn(warning, stacklevel=2)
+            tmp_path.unlink(missing_ok=True)
+            return WriteOutcome(WRITE_SKIPPED_SYMLINK, detail=warning, warning=warning)
+        if mode_after is not None and not stat.S_ISREG(mode_after):
+            tmp_path.unlink(missing_ok=True)
+            return WriteOutcome(WRITE_REFUSED, detail=f"managed-block target is not a regular file: {path}")
+        os.replace(tmp_path, path)
+    except BaseException as exc:
+        tmp_path.unlink(missing_ok=True)
+        return WriteOutcome(WRITE_ERROR, detail=str(exc))
+    return WriteOutcome(WRITE_WRITTEN)
+
+
+def install_block(
+    path: Path,
+    desired: str,
+    *,
+    kind: str = DEFAULT_KIND,
+    profile: str = DEFAULT_PROFILE,
+    owned_digest: str | None = None,
+    force: bool = False,
+    adopt: bool = False,
+    fix_command: str | None = None,
+    lstat_probe: Callable[[Path], int | None] | None = None,
+) -> tuple[BlockPlan, WriteOutcome]:
+    """Install or update a managed block with symlink-safe atomic publish."""
+    probe = lstat_probe or _lstat_mode
+    mode = probe(path)
+    if mode is not None and stat.S_ISLNK(mode):
+        warning = f"skipping symlinked managed-block target: {path}"
+        warnings.warn(warning, stacklevel=2)
+        plan = BlockPlan(
+            "symlink",
+            ACTION_PRESERVE,
+            kind,
+            desired_hash=body_hash(desired),
+            detail=warning,
+            warning=warning,
+            fix_command=fix_command or default_fix_command(),
+        )
+        return plan, WriteOutcome(WRITE_SKIPPED_SYMLINK, detail=warning, warning=warning)
+
+    text: str | None
+    if not path.exists():
+        text = None
+    else:
+        try:
+            text = normalize_newlines(read_text_nofollow(path))
+        except (OSError, UnicodeDecodeError) as exc:
+            plan = BlockPlan(
+                STATUS_MALFORMED,
+                ACTION_PRESERVE,
+                kind,
+                desired_hash=body_hash(desired),
+                detail=str(exc),
+                fix_command=fix_command or default_fix_command(),
+            )
+            return plan, WriteOutcome(WRITE_ERROR, detail=str(exc))
+
+    plan = plan_install(
+        text,
+        desired=desired,
+        kind=kind,
+        profile=profile,
+        owned_digest=owned_digest,
+        force=force,
+        adopt=adopt,
+        fix_command=fix_command,
+    )
+    if plan.action == ACTION_NONE:
+        return plan, WriteOutcome(WRITE_NOOP)
+    if plan.action == ACTION_PRESERVE or plan.rendered is None:
+        return plan, WriteOutcome(WRITE_REFUSED, detail=plan.detail)
+
+    # Byte-identical no-op even when the planner said update (defensive).
+    if text is not None and text == plan.rendered:
+        return BlockPlan(
+            STATUS_CURRENT,
+            ACTION_NONE,
+            kind,
+            desired_hash=plan.desired_hash,
+            fix_command=plan.fix_command,
+        ), WriteOutcome(WRITE_NOOP)
+
+    outcome = write_text_nofollow_atomic(path, plan.rendered, lstat_probe=lstat_probe)
+    return plan, outcome
+
+
+def remove_block(
+    path: Path,
+    *,
+    kind: str = DEFAULT_KIND,
+    owned_digest: str | None = None,
+    force: bool = False,
+    fix_command: str | None = None,
+    lstat_probe: Callable[[Path], int | None] | None = None,
+) -> tuple[BlockPlan, WriteOutcome]:
+    """Remove a managed block surgically with symlink-safe atomic publish."""
+    probe = lstat_probe or _lstat_mode
+    mode = probe(path)
+    if mode is not None and stat.S_ISLNK(mode):
+        warning = f"skipping symlinked managed-block target: {path}"
+        warnings.warn(warning, stacklevel=2)
+        plan = BlockPlan(
+            "symlink",
+            ACTION_PRESERVE,
+            kind,
+            detail=warning,
+            warning=warning,
+            fix_command=fix_command or default_fix_command(),
+        )
+        return plan, WriteOutcome(WRITE_SKIPPED_SYMLINK, detail=warning, warning=warning)
+    if mode is None:
+        plan = plan_remove(None, kind=kind, owned_digest=owned_digest, force=force, fix_command=fix_command)
+        return plan, WriteOutcome(WRITE_NOOP)
+
+    try:
+        text = normalize_newlines(read_text_nofollow(path))
+    except (OSError, UnicodeDecodeError) as exc:
+        plan = BlockPlan(STATUS_MALFORMED, ACTION_PRESERVE, kind, detail=str(exc), fix_command=fix_command)
+        return plan, WriteOutcome(WRITE_ERROR, detail=str(exc))
+
+    plan = plan_remove(text, kind=kind, owned_digest=owned_digest, force=force, fix_command=fix_command)
+    if plan.action == ACTION_NONE:
+        return plan, WriteOutcome(WRITE_NOOP)
+    if plan.action == ACTION_PRESERVE or plan.rendered is None:
+        return plan, WriteOutcome(WRITE_REFUSED, detail=plan.detail)
+    if text == plan.rendered:
+        return plan, WriteOutcome(WRITE_NOOP)
+    outcome = write_text_nofollow_atomic(path, plan.rendered, lstat_probe=lstat_probe)
+    return plan, outcome
+
+
+def check_block(
+    path: Path,
+    *,
+    desired: str | None,
+    kind: str = DEFAULT_KIND,
+    profile: str = DEFAULT_PROFILE,
+    owned_digest: str | None = None,
+    fix_command: str | None = None,
+) -> BlockAssessment:
+    """Classify a path's managed block; missing file is ``missing``."""
+    if path_is_symlink(path):
+        return BlockAssessment(
+            STATUS_MALFORMED,
+            kind,
+            ParsedBlock(STATUS_MALFORMED, kind, detail=f"managed-block target is a symlink: {path}"),
+            desired_hash=body_hash(desired) if desired is not None else None,
+            fix_command=fix_command or default_fix_command(),
+            detail=f"managed-block target is a symlink: {path}",
+        )
+    if not path.exists():
+        return BlockAssessment(
+            STATUS_MISSING,
+            kind,
+            ParsedBlock(STATUS_MISSING, kind),
+            desired_hash=body_hash(desired) if desired is not None else None,
+            fix_command=fix_command or default_fix_command(),
+            detail="managed block is missing",
+        )
+    try:
+        text = normalize_newlines(read_text_nofollow(path))
+    except (OSError, UnicodeDecodeError) as exc:
+        return BlockAssessment(
+            STATUS_MALFORMED,
+            kind,
+            ParsedBlock(STATUS_MALFORMED, kind, detail=str(exc)),
+            desired_hash=body_hash(desired) if desired is not None else None,
+            fix_command=fix_command or default_fix_command(),
+            detail=str(exc),
+        )
+    return assess_block(
+        text,
+        desired=desired,
+        kind=kind,
+        profile=profile,
+        owned_digest=owned_digest,
+        fix_command=fix_command,
+    )

--- a/tests/test_harness_profile_cmd.py
+++ b/tests/test_harness_profile_cmd.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 
 from brigade import __version__ as BRIGADE_VERSION
-from brigade import harness_profile_cmd, harness_profiles
+from brigade import harness_profile_cmd, harness_profiles, managed_block
 
 
 def _state(workspace: Path) -> dict:
@@ -40,6 +40,84 @@ def test_instruction_plans_preserve_unmanaged_content_and_reject_foreign_block(t
     path.write_text(f"{harness_profiles.INSTRUCTION_START}\nforeign\n{harness_profiles.INSTRUCTION_END}\n")
     conflict = harness_profile_cmd.plan_instruction(path=path, desired=desired, state={})
     assert conflict.status == "conflict"
+
+
+def test_locally_modified_instruction_detail_points_at_sync_help(tmp_path):
+    path = tmp_path / "AGENTS.md"
+    desired = harness_profiles.managed_instruction_text()
+    digest = harness_profile_cmd.digest_text(desired)
+    stamped = harness_profile_cmd._block(desired)
+    path.write_text(stamped.replace("brigade run", "brigade dispatch", 1), encoding="utf-8")
+
+    plan = harness_profile_cmd.plan_instruction(
+        path=path,
+        desired=desired,
+        state={"instructions": {"digest": digest}},
+        harness="codex",
+    )
+    assert plan.status == "conflict"
+    assert plan.detail is not None
+    assert "brigade harness sync --target codex --scope user --help" in plan.detail
+    assert "--adopt" not in plan.detail
+    assert "--force" not in plan.detail
+    assert "fix with:" not in plan.detail
+
+
+def test_plan_instruction_stale_update_preserves_crlf_neighbors(tmp_path):
+    path = tmp_path / "AGENTS.md"
+    desired = harness_profiles.managed_instruction_text()
+    old_body = "old instruction body\n"
+    crlf_prefix = "# above\r\nkeep\r\n"
+    crlf_suffix = "# below\r\nalso keep\r\n"
+    crlf_block = harness_profile_cmd._block(old_body).replace("\n", "\r\n")
+    path.write_bytes((crlf_prefix + crlf_block + crlf_suffix).encode("utf-8"))
+
+    plan = harness_profile_cmd.plan_instruction(
+        path=path,
+        desired=desired,
+        state={"instructions": {"digest": managed_block.body_hash(old_body)}},
+    )
+    assert plan.status == "stale"
+    assert plan.action == "update"
+    assert plan.rendered is not None
+    assert plan.rendered.startswith(crlf_prefix)
+    assert plan.rendered.endswith(crlf_suffix)
+    assert "\r\n" in plan.rendered
+    assert "\n" not in plan.rendered.replace("\r\n", "")
+
+
+def test_plan_instruction_removal_preserves_crlf_neighbors(tmp_path):
+    path = tmp_path / "AGENTS.md"
+    desired = harness_profiles.managed_instruction_text()
+    digest = managed_block.body_hash(desired)
+    crlf_prefix = "# above\r\nkeep\r\n"
+    crlf_suffix = "# below\r\nalso keep\r\n"
+    crlf_block = harness_profile_cmd._block(desired).replace("\n", "\r\n")
+    path.write_bytes((crlf_prefix + crlf_block + crlf_suffix).encode("utf-8"))
+
+    plan = harness_profile_cmd.plan_instruction_removal(
+        path=path,
+        state={"instructions": {"digest": digest}},
+    )
+    assert plan.action == "remove"
+    assert plan.rendered == crlf_prefix + crlf_suffix
+
+
+def test_malformed_instruction_detail_points_at_sync_help(tmp_path):
+    path = tmp_path / "AGENTS.md"
+    desired = harness_profiles.managed_instruction_text()
+    path.write_text(
+        "<!-- BEGIN BRIGADE INTEGRATION broken -->\nbody\n<!-- END BRIGADE INTEGRATION -->\n",
+        encoding="utf-8",
+    )
+
+    plan = harness_profile_cmd.plan_instruction(path=path, desired=desired, state={}, harness="codex")
+    assert plan.status == "conflict"
+    assert plan.detail is not None
+    assert "brigade harness sync --target codex --scope user --help" in plan.detail
+    assert "--adopt" not in plan.detail
+    assert "--force" not in plan.detail
+    assert "fix with:" not in plan.detail
 
 
 def test_load_state_is_read_only_when_package_version_is_stale(tmp_path):

--- a/tests/test_harness_user_scope.py
+++ b/tests/test_harness_user_scope.py
@@ -149,7 +149,7 @@ def test_hand_authored_agents_section_survives_sync(tmp_path, monkeypatch, capsy
     text = agents.read_text()
     assert "# My notes" in text
     assert "Keep this paragraph." in text
-    assert harness_profiles.INSTRUCTION_START in text
+    assert "BEGIN BRIGADE INTEGRATION" in text
     assert harness_profiles.managed_instruction_text().strip() in text
 
 
@@ -166,7 +166,7 @@ def test_claude_hand_authored_section_survives_sync(tmp_path, monkeypatch, capsy
     capsys.readouterr()
     text = claude_md.read_text()
     assert "Personal routing" in text
-    assert harness_profiles.INSTRUCTION_START in text
+    assert "BEGIN BRIGADE INTEGRATION" in text
 
 
 def test_foreign_managed_block_reports_conflict(tmp_path, monkeypatch, capsys):
@@ -413,6 +413,62 @@ def test_skill_root_symlink_is_conflict_and_does_not_escape_home(tmp_path, monke
     payload = json.loads(capsys.readouterr().out)["results"][0]
     assert payload["status"] == "conflict"
     assert not any(outside.rglob("*"))
+
+
+def test_doctor_and_check_report_stale_block_with_fix_command(tmp_path, monkeypatch, capsys):
+    from brigade import cli
+
+    home = _use_home(monkeypatch, tmp_path)
+    workspace = _workspace(tmp_path)
+    assert cli.main(_sync_base(workspace) + ["--write", "--json"]) == 0
+    capsys.readouterr()
+
+    agents = home / ".codex" / "AGENTS.md"
+    old_body = "old managed body\n"
+    agents.write_text(harness_profile_cmd._block(old_body))
+    state_path = home / ".codex" / "brigade" / "install-state.json"
+    state = json.loads(state_path.read_text())
+    state["instructions"]["digest"] = harness_profile_cmd.digest_text(old_body)
+    state_path.write_text(json.dumps(state))
+
+    assert (
+        cli.main(["harness", "doctor", "--target", "codex", "--scope", "user", "--workspace", str(workspace), "--json"])
+        == 1
+    )
+    doctor = json.loads(capsys.readouterr().out)["results"][0]
+    instruction = next(item for item in doctor["items"] if item["surface"] == "instruction")
+    assert instruction["status"] == "stale"
+    assert "brigade harness sync --target codex --scope user --write" in instruction["detail"]
+
+    assert cli.main(_sync_base(workspace) + ["--check", "--json"]) == 1
+    checked = json.loads(capsys.readouterr().out)["results"][0]
+    assert checked["ready"] is False
+    check_instruction = next(item for item in checked["items"] if item["surface"] == "instruction")
+    assert check_instruction["status"] == "stale"
+
+
+def test_force_overwrites_locally_modified_instruction_block(tmp_path, monkeypatch, capsys):
+    from brigade import cli
+
+    home = _use_home(monkeypatch, tmp_path)
+    workspace = _workspace(tmp_path)
+    assert cli.main(_sync_base(workspace) + ["--write", "--json"]) == 0
+    capsys.readouterr()
+    agents = home / ".codex" / "AGENTS.md"
+    text = agents.read_text()
+    agents.write_text(text.replace("brigade run", "brigade dispatch", 1))
+
+    assert cli.main(_sync_base(workspace) + ["--write", "--json"]) == 1
+    assert "brigade dispatch" in agents.read_text()
+    capsys.readouterr()
+
+    assert cli.main(_sync_base(workspace) + ["--force", "--write", "--json"]) == 0
+    capsys.readouterr()
+    restored = agents.read_text()
+    assert "brigade run" in restored
+    assert "brigade dispatch" not in restored
+    assert "BEGIN BRIGADE INTEGRATION" in restored
+    assert "hash:" in restored
 
 
 def test_doctor_reports_drift_without_mutating(tmp_path, monkeypatch, capsys):

--- a/tests/test_harness_user_scope_slice2.py
+++ b/tests/test_harness_user_scope_slice2.py
@@ -214,7 +214,7 @@ def test_hand_authored_instruction_section_survives_sync(tmp_path, monkeypatch, 
     text = instruction.read_text()
     assert "# My notes" in text
     assert "Keep this paragraph." in text
-    assert harness_profiles.INSTRUCTION_START in text
+    assert "BEGIN BRIGADE INTEGRATION" in text
     assert harness_profiles.managed_instruction_text().strip() in text
 
 

--- a/tests/test_managed_block.py
+++ b/tests/test_managed_block.py
@@ -166,6 +166,52 @@ def test_crlf_input_normalizes_for_hash_and_parse():
     assert assessment.status == managed_block.STATUS_CURRENT
 
 
+def test_crlf_neighbors_preserved_on_stale_update():
+    body = _desired()
+    old = "old body\n"
+    crlf_prefix = "# above\r\nkeep\r\n"
+    crlf_suffix = "# below\r\nalso keep\r\n"
+    crlf_block = managed_block.render_block(old).replace("\n", "\r\n")
+    text = crlf_prefix + crlf_block + crlf_suffix
+
+    plan = managed_block.plan_install(text, desired=body, owned_digest=managed_block.body_hash(old))
+    assert plan.status == managed_block.STATUS_STALE
+    assert plan.action == managed_block.ACTION_UPDATE
+    assert plan.rendered is not None
+    assert plan.rendered.startswith(crlf_prefix)
+    assert plan.rendered.endswith(crlf_suffix)
+    assert "\r\n" in plan.rendered
+    assert "\n" not in plan.rendered.replace("\r\n", "")
+
+
+def test_crlf_neighbors_preserved_on_managed_span_removal():
+    body = _desired()
+    crlf_prefix = "# above\r\nkeep\r\n"
+    crlf_suffix = "# below\r\nalso keep\r\n"
+    crlf_block = managed_block.render_block(body).replace("\n", "\r\n")
+    text = crlf_prefix + crlf_block + crlf_suffix
+
+    plan = managed_block.plan_remove(text, owned_digest=managed_block.body_hash(body))
+    assert plan.action == managed_block.ACTION_REMOVE
+    assert plan.rendered == crlf_prefix + crlf_suffix
+
+
+def test_remove_block_preserves_crlf_neighbors_on_disk(tmp_path):
+    body = _desired()
+    crlf_prefix = "# above\r\nkeep\r\n"
+    crlf_suffix = "# below\r\nalso keep\r\n"
+    crlf_block = managed_block.render_block(body).replace("\n", "\r\n")
+    expected_neighbors = (crlf_prefix + crlf_suffix).encode("utf-8")
+    path = tmp_path / "AGENTS.md"
+    path.write_bytes((crlf_prefix + crlf_block + crlf_suffix).encode("utf-8"))
+
+    plan, outcome = managed_block.remove_block(path, owned_digest=managed_block.body_hash(body))
+    assert plan.action == managed_block.ACTION_REMOVE
+    assert outcome.status == managed_block.WRITE_WRITTEN
+    assert path.read_bytes() == expected_neighbors
+    assert b"\r\n" in path.read_bytes()
+
+
 def test_legacy_markers_upgrade_in_place():
     body = _desired()
     legacy = (

--- a/tests/test_managed_block.py
+++ b/tests/test_managed_block.py
@@ -1,0 +1,236 @@
+"""Hash-stamped managed instruction blocks (issue #732)."""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from brigade import managed_block
+
+
+def _desired() -> str:
+    return "## Brigade work loop\n\nUse the brief.\n"
+
+
+def test_render_stores_full_sha256_and_status_abbreviates():
+    body = _desired()
+    block = managed_block.render_block(body, profile="full")
+    digest = managed_block.body_hash(body)
+    assert f"hash:{digest}" in block
+    assert f"hash:{digest[:8]} " not in block
+    assert len(digest) == 64
+    assessment = managed_block.assess_block(block, desired=body)
+    assert assessment.status == managed_block.STATUS_CURRENT
+    assert assessment.abbreviated_hash == digest[:8]
+    assert assessment.recorded_hash == digest
+    assert assessment.actual_hash == digest
+
+
+def test_three_installs_are_byte_identical_without_duplication(tmp_path):
+    path = tmp_path / "AGENTS.md"
+    path.write_text("# notes\nkeep me\n", encoding="utf-8")
+    desired = _desired()
+    for _ in range(3):
+        plan, outcome = managed_block.install_block(path, desired, owned_digest=managed_block.body_hash(desired))
+        assert plan.status in {managed_block.STATUS_MISSING, managed_block.STATUS_CURRENT, managed_block.STATUS_STALE}
+    text = path.read_text(encoding="utf-8")
+    assert text.count("BEGIN BRIGADE INTEGRATION") == 1
+    assert text.count("END BRIGADE INTEGRATION") == 1
+    assert "# notes" in text
+    assert "keep me" in text
+    # Final reinstall is a true no-op.
+    before = path.read_bytes()
+    mtime = path.stat().st_mtime_ns
+    time.sleep(0.01)
+    plan, outcome = managed_block.install_block(path, desired, owned_digest=managed_block.body_hash(desired))
+    assert plan.action == managed_block.ACTION_NONE
+    assert outcome.status == managed_block.WRITE_NOOP
+    assert path.read_bytes() == before
+    assert path.stat().st_mtime_ns == mtime
+
+
+@pytest.mark.parametrize(
+    ("builder", "expected"),
+    [
+        (lambda body: None, managed_block.STATUS_MISSING),
+        (
+            lambda body: (
+                f"{managed_block.LEGACY_USER_PROFILE_START}\n{body}\n{managed_block.LEGACY_USER_PROFILE_END}\n"
+            ),
+            managed_block.STATUS_STALE,
+        ),
+        (lambda body: managed_block.render_block(body), managed_block.STATUS_CURRENT),
+        (
+            lambda body: managed_block.render_block(body).replace(body, body + "edited\n", 1),
+            managed_block.STATUS_LOCALLY_MODIFIED,
+        ),
+    ],
+)
+def test_check_classifies_missing_legacy_current_and_hand_edited(builder, expected):
+    body = _desired()
+    text = builder(body)
+    if text is None:
+        assessment = managed_block.assess_block("", desired=body)
+        # empty file with no markers
+        assert assessment.status == managed_block.STATUS_MISSING
+        return
+    assessment = managed_block.assess_block(text, desired=body)
+    assert assessment.status == expected
+    assert assessment.fix_command
+
+
+def test_hand_edited_body_with_unchanged_marker_is_locally_modified_not_current():
+    body = _desired()
+    stamped = managed_block.render_block(body)
+    # Keep the recorded hash, change only the body bytes.
+    tampered = stamped.replace("Use the brief.", "Use the brief.\nuser edit", 1)
+    assessment = managed_block.assess_block(tampered, desired=body)
+    assert assessment.status == managed_block.STATUS_LOCALLY_MODIFIED
+    assert assessment.recorded_hash != assessment.actual_hash
+    plan = managed_block.plan_install(tampered, desired=body)
+    assert plan.action == managed_block.ACTION_PRESERVE
+    forced = managed_block.plan_install(tampered, desired=body, force=True)
+    assert forced.action == managed_block.ACTION_UPDATE
+
+
+def test_stale_content_updates_without_force_but_local_mod_does_not():
+    body = _desired()
+    old = "old body\n"
+    stamped_old = managed_block.render_block(old)
+    stale = managed_block.plan_install(stamped_old, desired=body)
+    assert stale.status == managed_block.STATUS_STALE
+    assert stale.action == managed_block.ACTION_UPDATE
+    local = managed_block.render_block(body).replace(body, "tampered\n", 1)
+    refused = managed_block.plan_install(local, desired=body)
+    assert refused.status == managed_block.STATUS_LOCALLY_MODIFIED
+    assert refused.action == managed_block.ACTION_PRESERVE
+
+
+def test_remove_preserves_user_content_above_and_below():
+    body = _desired()
+    text = f"# above\nkeep\n{managed_block.render_block(body)}# below\nalso keep\n"
+    plan = managed_block.plan_remove(text, owned_digest=managed_block.body_hash(body))
+    assert plan.action == managed_block.ACTION_REMOVE
+    assert plan.rendered == "# above\nkeep\n# below\nalso keep\n"
+    assert "BEGIN BRIGADE" not in (plan.rendered or "")
+
+
+def test_remove_refuses_locally_modified_without_force():
+    body = _desired()
+    text = managed_block.render_block(body).replace(body, "edited\n", 1)
+    plan = managed_block.plan_remove(text, owned_digest=managed_block.body_hash(body))
+    assert plan.status == managed_block.STATUS_LOCALLY_MODIFIED
+    assert plan.action == managed_block.ACTION_PRESERVE
+    forced = managed_block.plan_remove(text, owned_digest=managed_block.body_hash(body), force=True)
+    assert forced.action == managed_block.ACTION_REMOVE
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "<!-- BEGIN BRIGADE INTEGRATION v:1 profile:full hash:deadbeef -->\nbody\n<!-- END BRIGADE INTEGRATION -->\n",
+        (f"{managed_block.render_block('a')}{managed_block.render_block('b')}"),
+        (
+            "<!-- BEGIN BRIGADE INTEGRATION v:1 profile:full hash:"
+            + ("a" * 64)
+            + " -->body\n<!-- END BRIGADE INTEGRATION -->\n"
+        ),
+        "<!-- END BRIGADE INTEGRATION -->\nbody\n<!-- BEGIN BRIGADE INTEGRATION v:1 profile:full hash:"
+        + ("b" * 64)
+        + " -->\n",
+        (
+            "<!-- BEGIN BRIGADE INTEGRATION v:1 profile:full hash:" + ("c" * 64) + " -->\n"
+            "outer\n<!-- BEGIN BRIGADE INTEGRATION v:1 profile:full hash:"
+            + ("d" * 64)
+            + " -->\ninner\n<!-- END BRIGADE INTEGRATION -->\n"
+            "<!-- END BRIGADE INTEGRATION -->\n"
+        ),
+        "<!-- BEGIN BRIGADE INTEGRATION broken -->\nbody\n<!-- END BRIGADE INTEGRATION -->\n",
+    ],
+)
+def test_malformed_markers_fail_closed(text):
+    assessment = managed_block.assess_block(text, desired=_desired())
+    assert assessment.status == managed_block.STATUS_MALFORMED
+    plan = managed_block.plan_install(text, desired=_desired())
+    assert plan.action == managed_block.ACTION_PRESERVE
+
+
+def test_crlf_input_normalizes_for_hash_and_parse():
+    body = _desired()
+    lf = managed_block.render_block(body)
+    crlf = lf.replace("\n", "\r\n")
+    assessment = managed_block.assess_block(crlf, desired=body)
+    assert assessment.status == managed_block.STATUS_CURRENT
+
+
+def test_legacy_markers_upgrade_in_place():
+    body = _desired()
+    legacy = (
+        f"# top\n{managed_block.LEGACY_USER_PROFILE_START}\n{body}\n{managed_block.LEGACY_USER_PROFILE_END}\n# bottom\n"
+    )
+    plan = managed_block.plan_install(legacy, desired=body, owned_digest=managed_block.body_hash(body))
+    assert plan.status == managed_block.STATUS_STALE
+    assert plan.action == managed_block.ACTION_UPDATE
+    assert plan.rendered is not None
+    assert "BEGIN BRIGADE INTEGRATION" in plan.rendered
+    assert managed_block.LEGACY_USER_PROFILE_START not in plan.rendered
+    assert "# top" in plan.rendered and "# bottom" in plan.rendered
+
+
+def test_symlink_target_is_skipped_with_warning(tmp_path):
+    real = tmp_path / "real.md"
+    real.write_text("# real\n", encoding="utf-8")
+    link = tmp_path / "AGENTS.md"
+    link.symlink_to(real)
+    with pytest.warns(UserWarning, match="symlinked"):
+        plan, outcome = managed_block.install_block(link, _desired())
+    assert outcome.status == managed_block.WRITE_SKIPPED_SYMLINK
+    assert plan.action == managed_block.ACTION_PRESERVE
+    assert real.read_text(encoding="utf-8") == "# real\n"
+
+
+def test_symlink_swap_between_lstat_and_write_is_skipped(tmp_path):
+    path = tmp_path / "AGENTS.md"
+    path.write_text("# before\n", encoding="utf-8")
+    target = tmp_path / "elsewhere.md"
+    target.write_text("secret\n", encoding="utf-8")
+    calls = {"n": 0}
+
+    def probe(candidate: Path) -> int | None:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return os.lstat(candidate).st_mode
+        # Swap to a symlink before publish.
+        if candidate == path and path.exists() and not path.is_symlink():
+            path.unlink()
+            path.symlink_to(target)
+        mode = os.lstat(candidate).st_mode
+        return mode
+
+    with pytest.warns(UserWarning, match="symlink"):
+        outcome = managed_block.write_text_nofollow_atomic(
+            path,
+            managed_block.render_block(_desired()),
+            lstat_probe=probe,
+        )
+    assert outcome.status == managed_block.WRITE_SKIPPED_SYMLINK
+    assert target.read_text(encoding="utf-8") == "secret\n"
+    assert path.is_symlink()
+
+
+def test_other_kind_block_is_left_alone():
+    body = _desired()
+    other = managed_block.render_block("security notes\n", kind="SECURITY", profile="full")
+    text = f"# head\n{other}"
+    plan = managed_block.plan_install(text, desired=body, kind="INTEGRATION")
+    assert plan.action == managed_block.ACTION_CREATE
+    assert "BEGIN BRIGADE SECURITY" in (plan.rendered or "")
+    assert "BEGIN BRIGADE INTEGRATION" in (plan.rendered or "")
+    removed = managed_block.plan_remove(
+        plan.rendered or "", kind="INTEGRATION", owned_digest=managed_block.body_hash(body)
+    )
+    assert "BEGIN BRIGADE SECURITY" in (removed.rendered or "")
+    assert "BEGIN BRIGADE INTEGRATION" not in (removed.rendered or "")


### PR DESCRIPTION
## Summary

Adds hash-stamped managed instruction blocks with current, stale, and missing checks plus surgical removal.

## Verification

Pending CI and shepherd review.

Fixes #732