### PR TITLE
feat(claude-hooks): enforce hook output contract (#735)

### DIFF
--- a/src/brigade/claude_hooks/envelope.py
+++ b/src/brigade/claude_hooks/envelope.py
@@ -1,0 +1,342 @@
+"""Versioned Claude hook output envelope (issue #735).
+
+Limits count Unicode code points (``len(str)`` in Python 3), not UTF-8 bytes.
+The anti-truncation preamble and elision banner both count against ``max_chars``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from .. import localio
+
+ENVELOPE_VERSION = 1
+DEFAULT_MAX_CHARS = 8_000
+DEFAULT_MAX_ITEMS = 32
+HOOK_TIMEOUT_SECONDS = 12
+MAX_INJECTION_FILES = 64
+MAX_LOG_BYTES = 256_000
+LOG_NAME = "hook.log"
+INJECTIONS_DIRNAME = "injections"
+DOCTOR_POINTER = "Brigade hook degraded; run `brigade doctor --target .` for details."
+CapName = Literal["items", "chars", "oversized"]
+
+_HOME_PATH_RE = re.compile(re.escape(str(Path.home().expanduser().resolve())))
+
+
+def empty_envelope(event: str) -> dict[str, Any]:
+    """Return the schema-valid empty payload for a Claude hook event.
+
+    Claude Code treats ``{}`` as success with no changes for every managed event.
+    Each event pins the same object so tests can assert the contract per hook.
+    """
+    del event  # event-specific empty shapes are identical under the host schema
+    return {}
+
+
+def degraded_envelope(event: str) -> dict[str, Any]:
+    """One-line doctor pointer used when the hook fails open."""
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": event,
+            "additionalContext": DOCTOR_POINTER,
+        }
+    }
+
+
+def hooks_state_root(target: Path) -> Path:
+    return target.expanduser().resolve() / ".brigade" / "work" / "claude-hooks"
+
+
+def injections_root(target: Path) -> Path:
+    return hooks_state_root(target) / INJECTIONS_DIRNAME
+
+
+def log_path(target: Path) -> Path:
+    return hooks_state_root(target) / LOG_NAME
+
+
+def injection_path(target: Path, *, session_id: str, event: str) -> Path:
+    slug = localio.slugify(session_id, fallback="session")[:48]
+    suffix = localio.stable_hash(session_id)[:8]
+    event_slug = localio.slugify(event, fallback="event")
+    return injections_root(target) / f"{slug}-{suffix}-{event_slug}.txt"
+
+
+def relative_injection_path(target: Path, path: Path) -> str:
+    try:
+        return path.resolve().relative_to(target.expanduser().resolve()).as_posix()
+    except ValueError:
+        return path.name
+
+
+def redact_paths(text: str) -> str:
+    """Replace the operator home prefix in diagnostics so logs stay shareable."""
+    home = str(Path.home().expanduser().resolve())
+    redacted = text.replace(home, "~")
+    if home != str(Path.home()):
+        redacted = redacted.replace(str(Path.home()), "~")
+    return _HOME_PATH_RE.sub("~", redacted)
+
+
+def _chmod_private(path: Path) -> None:
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        return
+
+
+def write_private_text(path: Path, data: str) -> None:
+    """Atomically publish text and enforce mode ``0600`` on the final file."""
+    localio.write_text_atomic(path, data)
+    _chmod_private(path)
+
+
+def append_log(target: Path, message: str) -> None:
+    """Append one redacted diagnostic line; bound file growth by truncation."""
+    root = hooks_state_root(target)
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+        os.chmod(root, 0o700)
+    except OSError:
+        return
+    path = log_path(target)
+    line = f"{localio.utc_now_iso()} {redact_paths(message.rstrip())}\n"
+    try:
+        if path.is_file() and path.stat().st_size + len(line.encode("utf-8")) > MAX_LOG_BYTES:
+            existing = path.read_text(encoding="utf-8")
+            keep = existing[-MAX_LOG_BYTES // 2 :]
+            cut = keep.find("\n")
+            if cut >= 0:
+                keep = keep[cut + 1 :]
+            write_private_text(path, keep + line)
+        else:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with path.open("a", encoding="utf-8") as handle:
+                handle.write(line)
+            _chmod_private(path)
+    except OSError:
+        return
+
+
+def cleanup_injections(target: Path, *, keep: int = MAX_INJECTION_FILES) -> None:
+    root = injections_root(target)
+    if not root.is_dir():
+        return
+    try:
+        entries = sorted(root.glob("*.txt"), key=lambda item: item.stat().st_mtime, reverse=True)
+    except OSError:
+        return
+    for stale in entries[max(keep, 0) :]:
+        try:
+            stale.unlink()
+        except OSError:
+            continue
+
+
+def anti_truncation_line(rel_path: str) -> str:
+    return f"[Brigade] If this context appears truncated, read the full copy before continuing: cat {rel_path}"
+
+
+def elision_banner(*, dropped: int, total: int, cap: CapName, rel_path: str) -> str:
+    return f"[Brigade] Elided {dropped} of {total} records ({cap} cap); full copy: cat {rel_path}"
+
+
+def oversized_stub(*, code_points: int, rel_path: str) -> str:
+    return f"[Brigade] Record exceeds injection budget ({code_points} code points); full copy: cat {rel_path}"
+
+
+@dataclass(frozen=True)
+class RenderedInjection:
+    text: str
+    persisted_path: Path
+    relative_path: str
+    selected_count: int
+    dropped_count: int
+    cap_fired: CapName | None
+    envelope_version: int = ENVELOPE_VERSION
+
+
+def _join(parts: list[str]) -> str:
+    return "\n".join(part for part in parts if part is not None)
+
+
+def _oversized_body(preamble: str, record: str, rel_path: str, max_chars: int) -> str:
+    stub = oversized_stub(code_points=len(record), rel_path=rel_path)
+    body = _join([preamble, stub])
+    if len(body) > max_chars:
+        return body[: max(0, max_chars - 1)] + "…"
+    return body
+
+
+def render_records(
+    records: list[str],
+    *,
+    target: Path,
+    session_id: str,
+    event: str,
+    max_chars: int = DEFAULT_MAX_CHARS,
+    max_items: int = DEFAULT_MAX_ITEMS,
+) -> RenderedInjection:
+    """Persist the full payload, then emit a capped whole-record injection body.
+
+    Character limits are Unicode code points. The preamble and elision banner
+    reserve budget before any record is considered. A single record that cannot
+    fit emits a bounded metadata stub instead of overflowing the host cap.
+    """
+    if max_chars < 1:
+        raise ValueError("max_chars must be positive")
+    if max_items < 1:
+        raise ValueError("max_items must be positive")
+
+    normalized = [str(item) for item in records if str(item)]
+    path = injection_path(target, session_id=session_id, event=event)
+    full_text = "\n".join(normalized)
+    write_private_text(path, full_text if full_text.endswith("\n") or not full_text else full_text + "\n")
+    cleanup_injections(target)
+    rel = relative_injection_path(target, path)
+    preamble = anti_truncation_line(rel)
+
+    if not normalized:
+        return RenderedInjection(
+            text=preamble,
+            persisted_path=path,
+            relative_path=rel,
+            selected_count=0,
+            dropped_count=0,
+            cap_fired=None,
+        )
+
+    total = len(normalized)
+    item_limited = normalized[:max_items]
+    item_dropped = total - len(item_limited)
+
+    def select(candidates: list[str], *, reserved_extra: int) -> tuple[list[str], CapName | None]:
+        budget = max_chars - len(preamble) - (1 if preamble else 0) - reserved_extra
+        if budget < 0:
+            budget = 0
+        chosen: list[str] = []
+        fired: CapName | None = None
+        for record in candidates:
+            extra = len(record) if not chosen else len(record) + 1
+            if not chosen and len(record) > budget:
+                return [], "oversized"
+            if extra > budget:
+                fired = "chars"
+                break
+            chosen.append(record)
+            budget -= extra
+        return chosen, fired
+
+    selected, first_cap = select(item_limited, reserved_extra=0)
+    if first_cap == "oversized":
+        return RenderedInjection(
+            text=_oversized_body(preamble, normalized[0], rel, max_chars),
+            persisted_path=path,
+            relative_path=rel,
+            selected_count=0,
+            dropped_count=total,
+            cap_fired="oversized",
+        )
+
+    dropped = total - len(selected)
+    if dropped == 0:
+        return RenderedInjection(
+            text=_join([preamble, *selected]),
+            persisted_path=path,
+            relative_path=rel,
+            selected_count=len(selected),
+            dropped_count=0,
+            cap_fired=None,
+        )
+
+    if item_dropped and len(selected) == len(item_limited):
+        fired: CapName = "items"
+    else:
+        fired = "chars"
+
+    for _ in range(5):
+        dropped = total - len(selected)
+        banner = elision_banner(dropped=dropped, total=total, cap=fired, rel_path=rel)
+        body = _join([preamble, banner, *selected])
+        if len(body) <= max_chars:
+            return RenderedInjection(
+                text=body,
+                persisted_path=path,
+                relative_path=rel,
+                selected_count=len(selected),
+                dropped_count=dropped,
+                cap_fired=fired,
+            )
+        selected, again = select(item_limited, reserved_extra=len(banner) + 1)
+        if not selected or again == "oversized":
+            break
+        if item_dropped and len(selected) == len(item_limited):
+            fired = "items"
+        else:
+            fired = "chars"
+
+    return RenderedInjection(
+        text=_oversized_body(preamble, normalized[0], rel, max_chars),
+        persisted_path=path,
+        relative_path=rel,
+        selected_count=0,
+        dropped_count=total,
+        cap_fired="oversized",
+    )
+
+
+def additional_context_envelope(
+    event: str,
+    records: list[str],
+    *,
+    target: Path,
+    session_id: str,
+    max_chars: int = DEFAULT_MAX_CHARS,
+    max_items: int = DEFAULT_MAX_ITEMS,
+) -> dict[str, Any]:
+    rendered = render_records(
+        records,
+        target=target,
+        session_id=session_id,
+        event=event,
+        max_chars=max_chars,
+        max_items=max_items,
+    )
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": event,
+            "additionalContext": rendered.text,
+        }
+    }
+
+
+def emit_stdout(payload: dict[str, Any]) -> None:
+    """Print one compact JSON line; never pretty-print (async hosts parse line-wise)."""
+    print(json.dumps(payload, separators=(",", ":"), sort_keys=True), flush=True)
+
+
+def resolve_caps(
+    *,
+    max_chars: int | None = None,
+    max_items: int | None = None,
+) -> tuple[int, int]:
+    chars = max_chars if max_chars is not None else _env_int("BRIGADE_HOOK_MAX_CHARS", DEFAULT_MAX_CHARS)
+    items = max_items if max_items is not None else _env_int("BRIGADE_HOOK_MAX_ITEMS", DEFAULT_MAX_ITEMS)
+    return max(chars, 1), max(items, 1)
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default

--- a/src/brigade/claude_hooks/runtime.py
+++ b/src/brigade/claude_hooks/runtime.py
@@ -3,14 +3,15 @@
 from __future__ import annotations
 
 import json
+import multiprocessing as mp
 import os
 import re
 import shlex
 import subprocess
 import sys
-from concurrent.futures import ThreadPoolExecutor
-from concurrent.futures import TimeoutError as FuturesTimeoutError
+import time
 from datetime import datetime
+from queue import Empty
 from pathlib import Path
 from typing import Any, Iterator
 
@@ -22,6 +23,12 @@ from .package import PACKAGE_REF
 BRIEF_TIMEOUT_SECONDS = 10
 MAX_RECENT_SESSION_STATES = 512
 CLAUDE_SESSION_ENV = "BRIGADE_CLAUDE_SESSION"
+_HOOK_WORKER_EVENT_ENV = "BRIGADE_HOOK_WORKER_EVENT"
+_HOOK_TEST_HANG_ENV = "BRIGADE_HOOK_TEST_HANG_SECONDS"
+_HOOK_TIMEOUT_ENV = "BRIGADE_HOOK_TIMEOUT_SECONDS"
+_HOOK_WORKER_COMMAND = (
+    "import json, os, sys, time; from brigade.claude_hooks.runtime import _hook_worker_main; _hook_worker_main()"
+)
 
 
 class HookDegraded(Exception):
@@ -2093,6 +2100,139 @@ def handle_payload(event: str, payload: dict[str, Any]) -> dict[str, Any] | None
     return None
 
 
+def _hook_timeout_seconds() -> float:
+    raw = os.environ.get(_HOOK_TIMEOUT_ENV)
+    if raw is not None and raw.strip():
+        try:
+            value = float(raw)
+        except ValueError:
+            value = 0.0
+        if value > 0:
+            return value
+    return float(envelope.HOOK_TIMEOUT_SECONDS)
+
+
+def _maybe_test_hang() -> None:
+    raw = os.environ.get(_HOOK_TEST_HANG_ENV)
+    if raw is None or not raw.strip():
+        return
+    try:
+        seconds = float(raw)
+    except ValueError:
+        return
+    if seconds > 0:
+        time.sleep(seconds)
+
+
+def _isolated_handle_payload(event: str, payload: dict[str, Any]) -> dict[str, Any] | None:
+    _maybe_test_hang()
+    return handle_payload(event, payload)
+
+
+def _hook_worker_main() -> None:
+    """Run ``handle_payload`` in an isolated child process (issue #735)."""
+    event = os.environ.get(_HOOK_WORKER_EVENT_ENV, "")
+    raw = sys.stdin.read()
+    payload = json.loads(raw)
+    if not isinstance(payload, dict):
+        raise TypeError("hook stdin must be a JSON object")
+    result = _isolated_handle_payload(event, payload)
+    sys.stdout.write(json.dumps(result))
+
+
+def _terminate_process(proc: mp.Process | mp.context.ForkProcess) -> None:
+    if not proc.is_alive():
+        return
+    proc.terminate()
+    proc.join(timeout=1)
+    if proc.is_alive():
+        proc.kill()
+        proc.join()
+
+
+def _recv_timed_handle_payload_result(
+    queue: mp.Queue,
+    proc: mp.Process | mp.context.ForkProcess,
+    *,
+    timeout: float,
+) -> dict[str, Any] | None:
+    try:
+        status, value = queue.get(timeout=timeout)
+    except Empty as exc:
+        _terminate_process(proc)
+        raise HookDegraded("hook operation timed out") from exc
+    proc.join(timeout=1)
+    if proc.is_alive():
+        _terminate_process(proc)
+    if status == "ok":
+        return value if isinstance(value, dict) else None
+    if isinstance(value, BaseException):
+        raise value
+    raise RuntimeError(str(value))
+
+
+def _fork_timed_handle_payload_target(event: str, payload: dict[str, Any], queue: mp.Queue) -> None:
+    try:
+        result = _isolated_handle_payload(event, payload)
+        queue.put(("ok", result))
+    except Exception as exc:  # noqa: BLE001 - marshal failure back to parent
+        queue.put(("err", exc))
+
+
+def _fork_timed_handle_payload_worker(event: str, raw: str, *, timeout: float) -> dict[str, Any] | None:
+    payload = json.loads(raw)
+    if not isinstance(payload, dict):
+        raise HookDegraded("hook stdin must be a JSON object")
+
+    ctx = mp.get_context("fork")
+    queue: mp.Queue = ctx.Queue()
+    proc = ctx.Process(
+        target=_fork_timed_handle_payload_target,
+        args=(event, payload, queue),
+        daemon=True,
+    )
+    try:
+        proc.start()
+        return _recv_timed_handle_payload_result(queue, proc, timeout=timeout)
+    finally:
+        if proc.is_alive():
+            _terminate_process(proc)
+        queue.close()
+        queue.join_thread()
+
+
+def _subprocess_timed_handle_payload(event: str, raw: str, *, timeout: float) -> dict[str, Any] | None:
+    env = os.environ.copy()
+    env[_HOOK_WORKER_EVENT_ENV] = event
+    try:
+        completed = subprocess.run(
+            [sys.executable, "-c", _HOOK_WORKER_COMMAND],
+            input=raw,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=env,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise HookDegraded("hook operation timed out") from exc
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or f"exit {completed.returncode}"
+        raise RuntimeError(detail)
+    stdout = completed.stdout.strip()
+    if not stdout or stdout == "null":
+        return None
+    parsed = json.loads(stdout)
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _run_timed_handle_payload(event: str, raw: str) -> dict[str, Any] | None:
+    timeout = _hook_timeout_seconds()
+    if sys.platform == "win32":
+        return _subprocess_timed_handle_payload(event, raw, timeout=timeout)
+    return _fork_timed_handle_payload_worker(event, raw, timeout=timeout)
+
+
 def _emit_result(event: str, result: dict[str, Any] | None, *, target: Path | None) -> None:
     payload = result if result is not None else envelope.empty_envelope(event)
     envelope.emit_stdout(payload)
@@ -2137,20 +2277,7 @@ def hook_run(*, event: str, package: str, stdin_text: str | None = None) -> int:
             raise HookDegraded("hook stdin must be a JSON object")
         payload = parsed
         log_target = _resolve_log_target(payload)
-
-        def _invoke() -> dict[str, Any] | None:
-            return handle_payload(event, payload)
-
-        pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="claude-hook")
-        try:
-            future = pool.submit(_invoke)
-            try:
-                result = future.result(timeout=envelope.HOOK_TIMEOUT_SECONDS)
-            except FuturesTimeoutError as exc:
-                future.cancel()
-                raise HookDegraded("hook operation timed out") from exc
-        finally:
-            pool.shutdown(wait=False, cancel_futures=True)
+        result = _run_timed_handle_payload(event, raw)
     except HookDegraded as exc:
         if log_target is not None:
             envelope.append_log(log_target, f"{event}: degraded: {exc}")

--- a/src/brigade/claude_hooks/runtime.py
+++ b/src/brigade/claude_hooks/runtime.py
@@ -8,18 +8,26 @@ import re
 import shlex
 import subprocess
 import sys
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Iterator
 
 from .. import localio
 from ..wiring import resolve_wired_target
+from . import envelope
 from .package import PACKAGE_REF
 
 BRIEF_TIMEOUT_SECONDS = 10
-BRIEF_MAX_CHARS = 8_000
 MAX_RECENT_SESSION_STATES = 512
 CLAUDE_SESSION_ENV = "BRIGADE_CLAUDE_SESSION"
+
+
+class HookDegraded(Exception):
+    """Internal hook failure that must fail open with a doctor pointer."""
+
+
 _SHELL_SEPARATORS = {"&&", "||", ";", "|", "|&", "&", "\n"}
 _PIPELINE_SEPARATORS = {"|", "|&"}
 _SHELL_WRAPPERS = {"bash", "dash", "ksh", "sh", "zsh"}
@@ -581,20 +589,20 @@ def _run_brief(target: Path) -> str:
             text=True,
             timeout=BRIEF_TIMEOUT_SECONDS,
         )
-    except (OSError, subprocess.TimeoutExpired):
-        return (
-            "Brigade is wired for this repo. Run `brigade work brief --target "
-            f"{shlex.quote(str(target))}` before real work."
-        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise HookDegraded(f"brief unavailable: {exc}") from exc
     text = result.stdout.strip()
     if result.returncode != 0 or not text:
-        return (
-            "Brigade is wired for this repo. Run `brigade work brief --target "
-            f"{shlex.quote(str(target))}` before real work."
-        )
-    if len(text) > BRIEF_MAX_CHARS:
-        text = text[:BRIEF_MAX_CHARS] + "\n[Brigade brief truncated]"
+        detail = (result.stderr or "").strip() or f"exit {result.returncode}"
+        raise HookDegraded(f"brief failed: {detail}")
     return text
+
+
+def _brief_records(text: str) -> list[str]:
+    """Split a work brief into whole-record units for capped injection."""
+    lines = [line.rstrip() for line in text.splitlines()]
+    records = [line for line in lines if line.strip()]
+    return records if records else [text]
 
 
 def _is_env_assignment(token: str) -> bool:
@@ -1824,8 +1832,24 @@ def _handoff_since(target: Path, started_at: object) -> bool:
     return False
 
 
-def _additional_context(event: str, text: str) -> dict[str, Any]:
-    return {"hookSpecificOutput": {"hookEventName": event, "additionalContext": text}}
+def _additional_context(
+    event: str,
+    text: str,
+    *,
+    target: Path,
+    session_id: str,
+    records: list[str] | None = None,
+) -> dict[str, Any]:
+    max_chars, max_items = envelope.resolve_caps()
+    payload_records = records if records is not None else [text]
+    return envelope.additional_context_envelope(
+        event,
+        payload_records,
+        target=target,
+        session_id=session_id,
+        max_chars=max_chars,
+        max_items=max_items,
+    )
 
 
 def _unwired_init_hint(payload: dict[str, Any]) -> dict[str, Any] | None:
@@ -1848,11 +1872,19 @@ def _unwired_init_hint(payload: dict[str, Any]) -> dict[str, Any] | None:
     command = (
         f"brigade init --target {shlex.quote(str(cwd))} --depth repo --harnesses claude --owner claude --git-exclude"
     )
+    session_id = payload.get("session_id")
+    if not isinstance(session_id, str) or not session_id:
+        session_id = "unwired"
     return _additional_context(
         "SessionStart",
-        "This git repository is not Brigade-wired. Configure it before real work so "
-        f"verification and memory are captured: {command}\n"
-        "Then start with: brigade work brief --target .",
+        "",
+        target=cwd,
+        session_id=session_id,
+        records=[
+            "This git repository is not Brigade-wired. Configure it before real work so "
+            f"verification and memory are captured: {command}",
+            "Then start with: brigade work brief --target .",
+        ],
     )
 
 
@@ -1875,9 +1907,16 @@ def handle_payload(event: str, payload: dict[str, Any]) -> dict[str, Any] | None
     if event == "SessionStart":
         if state.get("briefed"):
             return None
+        brief_text = _run_brief(target)
         state["briefed"] = True
         write_session_state(target, session_id, state)
-        return _additional_context("SessionStart", _run_brief(target))
+        return _additional_context(
+            "SessionStart",
+            brief_text,
+            target=target,
+            session_id=session_id,
+            records=_brief_records(brief_text),
+        )
 
     if event == "PreToolUse":
         tool_name = payload.get("tool_name")
@@ -1990,8 +2029,14 @@ def handle_payload(event: str, payload: dict[str, Any]) -> dict[str, Any] | None
             )
             return _additional_context(
                 "PostToolUseFailure",
-                "The failed or rejected verification must remain recorded in Brigade before retrying. Inspect the receipt, fix the cause, then rerun through "
-                f"`brigade work verify run --capture {capture_id}`.",
+                "",
+                target=target,
+                session_id=session_id,
+                records=[
+                    "The failed or rejected verification must remain recorded in Brigade before retrying. "
+                    "Inspect the receipt, fix the cause, then rerun through "
+                    f"`brigade work verify run --capture {capture_id}`.",
+                ],
             )
         return None
 
@@ -2037,22 +2082,99 @@ def handle_payload(event: str, payload: dict[str, Any]) -> dict[str, Any] | None
         if handoff_target is not None:
             return _additional_context(
                 "Stop",
-                "Verification is recorded. If this work produced durable knowledge, write a Memory Handoff in `.claude/memory-handoffs/` before finishing.",
+                "",
+                target=handoff_target,
+                session_id=session_id,
+                records=[
+                    "Verification is recorded. If this work produced durable knowledge, write a Memory Handoff in "
+                    "`.claude/memory-handoffs/` before finishing.",
+                ],
             )
     return None
 
 
+def _emit_result(event: str, result: dict[str, Any] | None, *, target: Path | None) -> None:
+    payload = result if result is not None else envelope.empty_envelope(event)
+    envelope.emit_stdout(payload)
+    if target is not None and result is None:
+        envelope.append_log(target, f"{event}: empty envelope")
+
+
+def _resolve_log_target(payload: dict[str, Any] | None) -> Path | None:
+    if not isinstance(payload, dict):
+        return None
+    wired = resolve_wired_target(payload.get("cwd"))
+    if wired is not None:
+        return wired
+    raw = payload.get("cwd")
+    if isinstance(raw, str) and raw:
+        try:
+            return Path(raw).expanduser().resolve(strict=False)
+        except OSError:
+            return None
+    return None
+
+
 def hook_run(*, event: str, package: str, stdin_text: str | None = None) -> int:
+    """Run one managed Claude hook under the #735 output contract.
+
+    Always exits 0. Stdout is exactly one schema-valid JSON object (empty
+    envelope, degraded doctor pointer, or a rendered decision/injection).
+    Diagnostics go to the local hook log, never to the session stream.
+    """
     if package != PACKAGE_REF:
         return 0
+
+    log_target: Path | None = None
+    raw = ""
     try:
         raw = sys.stdin.read() if stdin_text is None else stdin_text
-        payload = json.loads(raw)
-        if not isinstance(payload, dict):
-            return 0
-        result = handle_payload(event, payload)
-    except Exception:  # noqa: BLE001 - hooks must fail open instead of breaking the harness
+        try:
+            parsed = json.loads(raw) if raw.strip() else {}
+        except json.JSONDecodeError as exc:
+            raise HookDegraded(f"malformed hook stdin: {exc}") from None
+        if not isinstance(parsed, dict):
+            raise HookDegraded("hook stdin must be a JSON object")
+        payload = parsed
+        log_target = _resolve_log_target(payload)
+
+        def _invoke() -> dict[str, Any] | None:
+            return handle_payload(event, payload)
+
+        pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="claude-hook")
+        try:
+            future = pool.submit(_invoke)
+            try:
+                result = future.result(timeout=envelope.HOOK_TIMEOUT_SECONDS)
+            except FuturesTimeoutError as exc:
+                future.cancel()
+                raise HookDegraded("hook operation timed out") from exc
+        finally:
+            pool.shutdown(wait=False, cancel_futures=True)
+    except HookDegraded as exc:
+        if log_target is not None:
+            envelope.append_log(log_target, f"{event}: degraded: {exc}")
+        else:
+            # Best-effort log under cwd when the repo is not yet wired.
+            try:
+                envelope.append_log(Path.cwd(), f"{event}: degraded: {exc}")
+            except OSError:
+                pass
+        envelope.emit_stdout(envelope.degraded_envelope(event))
         return 0
-    if result is not None:
-        print(json.dumps(result, separators=(",", ":"), sort_keys=True))
+    except Exception as exc:  # noqa: BLE001 - hooks must fail open instead of breaking the harness
+        if log_target is not None:
+            envelope.append_log(log_target, f"{event}: error: {type(exc).__name__}: {exc}")
+        envelope.emit_stdout(envelope.degraded_envelope(event))
+        return 0
+
+    try:
+        _emit_result(event, result, target=log_target)
+    except Exception as exc:  # noqa: BLE001 - stdout failure still fails open
+        if log_target is not None:
+            envelope.append_log(log_target, f"{event}: emit failed: {exc}")
+        try:
+            envelope.emit_stdout(envelope.degraded_envelope(event))
+        except Exception:  # noqa: BLE001
+            pass
     return 0

--- a/tests/test_claude_hooks_envelope.py
+++ b/tests/test_claude_hooks_envelope.py
@@ -1,0 +1,248 @@
+"""Claude hook output contract (issue #735)."""
+
+from __future__ import annotations
+
+import json
+import stat
+from pathlib import Path
+
+import pytest
+
+from brigade.claude_hooks import envelope, runtime
+from brigade.claude_hooks.package import MANAGED_EVENTS, PACKAGE_REF
+from brigade.install import install_selection
+from brigade.selection import Selection
+
+
+def _wired_claude(tmp_path: Path) -> Path:
+    target = tmp_path / "repo"
+    selection = Selection(depth="repo", harnesses=["claude"], owner="claude", includes=[])
+    assert install_selection(target, selection) == 0
+    return target
+
+
+def _payload(target: Path, event: str, *, session_id: str = "session-1", **extra):
+    return {
+        "session_id": session_id,
+        "cwd": str(target),
+        "hook_event_name": event,
+        **extra,
+    }
+
+
+@pytest.mark.parametrize("event", MANAGED_EVENTS)
+def test_empty_envelope_is_pinned_per_event(event: str):
+    assert envelope.empty_envelope(event) == {}
+
+
+@pytest.mark.parametrize("event", MANAGED_EVENTS)
+def test_hook_run_emits_empty_envelope_outside_wired_repo(tmp_path: Path, event: str, capsys):
+    payload = _payload(tmp_path, event)
+    capsys.readouterr()
+    assert runtime.hook_run(event=event, package=PACKAGE_REF, stdin_text=json.dumps(payload)) == 0
+    assert json.loads(capsys.readouterr().out) == envelope.empty_envelope(event)
+
+
+def test_hook_run_malformed_stdin_emits_doctor_pointer(capsys, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    capsys.readouterr()
+    assert runtime.hook_run(event="SessionStart", package=PACKAGE_REF, stdin_text="{not-json") == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out == envelope.degraded_envelope("SessionStart")
+    assert envelope.DOCTOR_POINTER in out["hookSpecificOutput"]["additionalContext"]
+    log = (tmp_path / ".brigade" / "work" / "claude-hooks" / "hook.log").read_text(encoding="utf-8")
+    assert "malformed hook stdin" in log
+
+
+def test_induced_store_failure_emits_doctor_pointer_and_log(tmp_path: Path, monkeypatch, capsys):
+    target = _wired_claude(tmp_path)
+
+    def boom(_target: Path) -> str:
+        raise runtime.HookDegraded("store unreadable")
+
+    monkeypatch.setattr(runtime, "_run_brief", boom)
+    payload = _payload(target, "SessionStart")
+    capsys.readouterr()
+    assert runtime.hook_run(event="SessionStart", package=PACKAGE_REF, stdin_text=json.dumps(payload)) == 0
+    captured = capsys.readouterr()
+    out = json.loads(captured.out)
+    assert out == envelope.degraded_envelope("SessionStart")
+    assert captured.err == ""
+    log = envelope.log_path(target).read_text(encoding="utf-8")
+    assert "store unreadable" in log
+
+
+def test_injection_begins_with_anti_truncation_and_persists_full_copy(tmp_path: Path, monkeypatch):
+    target = _wired_claude(tmp_path)
+    monkeypatch.setattr(runtime, "_run_brief", lambda _repo: "alpha\nbeta\ngamma")
+    result = runtime.handle_payload("SessionStart", _payload(target, "SessionStart"))
+    context = result["hookSpecificOutput"]["additionalContext"]
+    assert context.startswith("[Brigade] If this context appears truncated")
+    assert "cat .brigade/work/claude-hooks/injections/" in context
+    assert "alpha" in context and "beta" in context and "gamma" in context
+    persisted = list(envelope.injections_root(target).glob("*.txt"))
+    assert len(persisted) == 1
+    assert persisted[0].read_text(encoding="utf-8") == "alpha\nbeta\ngamma\n"
+    assert stat.S_IMODE(persisted[0].stat().st_mode) == 0o600
+
+
+def test_item_cap_emits_elision_banner_naming_items_cap(tmp_path: Path):
+    target = _wired_claude(tmp_path)
+    records = [f"record-{index}" for index in range(6)]
+    rendered = envelope.render_records(
+        records,
+        target=target,
+        session_id="cap-items",
+        event="SessionStart",
+        max_chars=4000,
+        max_items=2,
+    )
+    assert "Elided 4 of 6 records (items cap)" in rendered.text
+    assert rendered.cap_fired == "items"
+    assert rendered.selected_count == 2
+    assert "record-0" in rendered.text and "record-1" in rendered.text
+    assert "record-5" not in rendered.text
+    assert "record-5" in rendered.persisted_path.read_text(encoding="utf-8")
+
+
+def test_char_cap_emits_elision_banner_naming_chars_cap(tmp_path: Path):
+    target = _wired_claude(tmp_path)
+    records = [
+        "one-short-record-" + ("a" * 200),
+        "two-short-record-" + ("b" * 200),
+        "three-short-record-" + ("c" * 200),
+    ]
+    rendered = envelope.render_records(
+        records,
+        target=target,
+        session_id="cap-chars",
+        event="SessionStart",
+        max_chars=600,
+        max_items=32,
+    )
+    assert rendered.cap_fired == "chars"
+    assert "chars cap" in rendered.text
+    assert rendered.selected_count >= 1
+    assert rendered.dropped_count >= 1
+    assert rendered.text.startswith("[Brigade] If this context appears truncated")
+    assert len(rendered.text) <= 600
+
+
+def test_single_oversized_record_emits_metadata_stub(tmp_path: Path):
+    target = _wired_claude(tmp_path)
+    huge = "文" * 5000  # multibyte code points at the boundary
+    rendered = envelope.render_records(
+        [huge],
+        target=target,
+        session_id="cap-oversize",
+        event="SessionStart",
+        max_chars=400,
+        max_items=8,
+    )
+    assert rendered.cap_fired == "oversized"
+    assert "Record exceeds injection budget (5000 code points)" in rendered.text
+    assert "full copy: cat " in rendered.text
+    assert huge not in rendered.text
+    assert huge in rendered.persisted_path.read_text(encoding="utf-8")
+    assert len(rendered.text) <= 400
+
+
+def test_record_larger_than_entire_budget_stays_bounded(tmp_path: Path):
+    target = _wired_claude(tmp_path)
+    rendered = envelope.render_records(
+        ["x" * 10_000],
+        target=target,
+        session_id="cap-huge",
+        event="PostToolUseFailure",
+        max_chars=80,
+        max_items=1,
+    )
+    assert len(rendered.text) <= 80
+    assert rendered.cap_fired == "oversized"
+    assert "full copy" in rendered.text
+
+
+def test_multibyte_boundary_counts_code_points_not_bytes(tmp_path: Path):
+    target = _wired_claude(tmp_path)
+    records = ["你", "好", "吗", "啊"]
+    rendered = envelope.render_records(
+        records,
+        target=target,
+        session_id="cap-unicode",
+        event="SessionStart",
+        max_chars=4000,
+        max_items=2,
+    )
+    assert rendered.selected_count == 2
+    assert rendered.cap_fired == "items"
+    assert "Elided 2 of 4 records (items cap)" in rendered.text
+    assert len("你好".encode("utf-8")) > len("你好")
+
+
+def test_persisted_copy_is_atomic_private_and_cleaned(tmp_path: Path):
+    target = _wired_claude(tmp_path)
+    for index in range(envelope.MAX_INJECTION_FILES + 5):
+        envelope.render_records(
+            [f"payload-{index}"],
+            target=target,
+            session_id=f"session-{index}",
+            event="SessionStart",
+            max_chars=2000,
+            max_items=8,
+        )
+    files = list(envelope.injections_root(target).glob("*.txt"))
+    assert len(files) <= envelope.MAX_INJECTION_FILES
+    for path in files:
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+def test_hook_timeout_covers_whole_operation(tmp_path: Path, monkeypatch, capsys):
+    target = _wired_claude(tmp_path)
+    monkeypatch.setattr(envelope, "HOOK_TIMEOUT_SECONDS", 0.01)
+
+    def hang(_event: str, _payload: dict) -> dict | None:
+        import time
+
+        time.sleep(1)
+        return None
+
+    monkeypatch.setattr(runtime, "handle_payload", hang)
+    capsys.readouterr()
+    assert (
+        runtime.hook_run(
+            event="PreToolUse",
+            package=PACKAGE_REF,
+            stdin_text=json.dumps(_payload(target, "PreToolUse")),
+        )
+        == 0
+    )
+    assert json.loads(capsys.readouterr().out) == envelope.degraded_envelope("PreToolUse")
+    assert "timed out" in envelope.log_path(target).read_text(encoding="utf-8")
+
+
+def test_preamble_and_banner_count_against_budget(tmp_path: Path):
+    target = _wired_claude(tmp_path)
+    records = [f"r{i}" for i in range(10)]
+    rendered = envelope.render_records(
+        records,
+        target=target,
+        session_id="budget",
+        event="SessionStart",
+        max_chars=260,
+        max_items=10,
+    )
+    assert len(rendered.text) <= 260
+    assert rendered.text.startswith("[Brigade] If this context appears truncated")
+    if rendered.dropped_count:
+        assert "Elided" in rendered.text
+
+
+def test_env_caps_are_honored(monkeypatch):
+    monkeypatch.setenv("BRIGADE_HOOK_MAX_CHARS", "500")
+    monkeypatch.setenv("BRIGADE_HOOK_MAX_ITEMS", "3")
+    assert envelope.resolve_caps() == (500, 3)
+
+
+def test_path_redaction_strips_home_prefix():
+    home = str(Path.home().expanduser().resolve())
+    assert envelope.redact_paths(f"{home}/secret/log") == "~/secret/log"

--- a/tests/test_claude_hooks_runtime.py
+++ b/tests/test_claude_hooks_runtime.py
@@ -66,7 +66,9 @@ def test_session_start_injects_brief_once_per_repo(tmp_path: Path, monkeypatch):
     second = runtime.handle_payload("SessionStart", _payload(target, "SessionStart"))
 
     assert first["hookSpecificOutput"]["hookEventName"] == "SessionStart"
-    assert "work brief: test" in first["hookSpecificOutput"]["additionalContext"]
+    context = first["hookSpecificOutput"]["additionalContext"]
+    assert context.startswith("[Brigade] If this context appears truncated")
+    assert "work brief: test" in context
     assert second is None
     assert calls == [target.resolve()]
 
@@ -92,6 +94,7 @@ def test_session_start_hints_init_for_unwired_git_repo(tmp_path: Path):
     assert f"brigade init --target {repo.resolve()}" in context
     assert "--harnesses claude" in context
     assert "brigade work brief" in context
+    assert context.startswith("[Brigade] If this context appears truncated")
 
 
 def test_session_start_stays_silent_for_home_directory(tmp_path: Path, monkeypatch):

--- a/tests/test_claude_hooks_runtime.py
+++ b/tests/test_claude_hooks_runtime.py
@@ -3,15 +3,19 @@
 from __future__ import annotations
 
 import json
+import os
 import shlex
 import subprocess
 import sys
+import time
 from datetime import timedelta
 from pathlib import Path
 
 import pytest
 
 from brigade import cli, localio
+from brigade.claude_hooks import envelope
+from brigade.claude_hooks.package import PACKAGE_REF
 from brigade.claude_hooks import runtime
 from brigade.install import install_selection
 from brigade.selection import Selection
@@ -1405,6 +1409,49 @@ def test_hook_run_rejects_stale_package_without_output(capsys):
         == 0
     )
     assert capsys.readouterr().out == ""
+
+
+def test_hook_run_process_exits_within_timeout_when_operation_hangs(tmp_path: Path):
+    target = _wired_claude(tmp_path)
+    payload = _payload(
+        target,
+        "PreToolUse",
+        tool_name="Bash",
+        tool_input={"command": "pytest -q"},
+    )
+    env = os.environ.copy()
+    repo_root = Path(__file__).resolve().parents[1]
+    env["PYTHONPATH"] = os.pathsep.join(filter(None, (str(repo_root / "src"), env.get("PYTHONPATH"))))
+    env[runtime._HOOK_TEST_HANG_ENV] = "30"
+    env[runtime._HOOK_TIMEOUT_ENV] = "0.25"
+    started = time.monotonic()
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "brigade",
+            "work",
+            "hook-run",
+            "--event",
+            "PreToolUse",
+            "--package",
+            PACKAGE_REF,
+        ],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        cwd=target,
+        env=env,
+        timeout=5,
+        check=False,
+    )
+    elapsed = time.monotonic() - started
+
+    assert completed.returncode == 0
+    assert elapsed < 2.0
+    assert json.loads(completed.stdout) == envelope.degraded_envelope("PreToolUse")
+    assert "timed out" in envelope.log_path(target).read_text(encoding="utf-8")
+    assert "resource_tracker" not in completed.stderr
 
 
 def test_posttool_failure_keeps_routed_failure_in_the_loop(tmp_path: Path):


### PR DESCRIPTION
## Summary

Enforces the Claude hook output envelope, bounded injection, persisted full context, and graceful failure behavior.

## Verification

Pending CI and shepherd review.

Fixes #735