### PR TITLE
fix(cli): treat error and refusal copy as an agent-facing API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Error and refusal copy is treated as an agent-facing API (#739): destructive
+  and gate-bypassing flags (`--force`, `--allow-*`, `--operator-confirm`,
+  `--allow-dirty`) are no longer named as remediations; wrong or platform-only
+  advice (init `--force` for missing templates, redundant sweep `--force`,
+  `chmod +x` hook guidance) is corrected. Convention lives in CONTRIBUTING;
+  audit table in `docs/audit/2026-08-09-error-refusal-copy.md`; contracts in
+  `tests/test_error_refusal_copy.py`.
+
 ### Added
 - Work task ledger dependency edges and a computed ready set (#737): typed
   edges (`blocks`, `parent-child`, `discovered-from`) live as a normalized

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,41 @@ The Hermes adapter is currently marked experimental. To graduate it (or any futu
 
 Open a PR with all three and we'll land it.
 
+## Agent-facing error and refusal copy
+
+Most Brigade invocations are made by agents. Agents pattern-match remediation
+commands out of error strings and automate them. Treat refusal text as a public
+API surface.
+
+When writing or changing a user-facing error, refusal, blocker, hint, or
+`suggested_next_command`:
+
+1. **State what happened**, then **state what is true now** (left unchanged,
+   gated, corrupt, missing, …).
+2. **Name a next step only if automating that step unattended is acceptable.**
+   Classify the remediation before you inline it:
+   - **Safe-to-automate** - copy-pasteable command that is correct on every
+     supported platform and does not overwrite, bypass a gate, or mutate shared
+     operator state. Name it.
+   - **Judgment-required** - describe the situation and point at `doctor`,
+     `--help`, or docs. Do **not** inline the mutating command.
+   - **Destructive or gate-bypassing** - never name `--force`,
+     `--allow-*` overrides, `--operator-confirm`, `--no-verify`, bulk release
+     overrides, or similar flags as the remediation. Operators already know
+     those flags from `--help`; agents must not learn them from refusals.
+3. **Structured before textual.** When a caller might branch on the failure,
+   put machine-readable fields on the JSON payload (`reason`, ids, holders,
+   expected/observed). Keep the text form from becoming a second parser
+   surface (no stable ``by <name>`` suffixes when a typed field exists).
+4. **Stay platform-portable.** Do not suggest `chmod`, shell-only paths, or
+     other host-specific recipes unless the message is already gated to that
+     platform (see verify's high-risk command copy). Prefer describing the
+     required end state ("mark the hook executable for your Git hook host").
+
+The audit table for the #739 sweep lives at
+[`docs/audit/2026-08-09-error-refusal-copy.md`](docs/audit/2026-08-09-error-refusal-copy.md).
+High-traffic contracts are pinned in `tests/test_error_refusal_copy.py`.
+
 ## Filing issues
 
 Please use the templates under `.github/ISSUE_TEMPLATE/` - they exist to save you from re-typing the version and install shape every time.

--- a/docs/audit/2026-08-09-error-refusal-copy.md
+++ b/docs/audit/2026-08-09-error-refusal-copy.md
@@ -28,6 +28,9 @@ Sweep date: 2026-08-09. Classification keys:
 | `install.py` kept-files note | `run with --force to overwrite` | judgment-required | Describe intent to replace templates; no force flag. |
 | `runguard.py` DirtyWorktreeError | `pass --allow-dirty to run anyway` | gate-bypassing | Ask to commit/stash/clean only. |
 | `doctor.py` publish hook | `run chmod +x hooks/pre-push` | platform-specific | Describe required end state for any Git hook host. |
+| `scrub.py` (`hook_status` missing hook) | `brigade init ... --force` in `suggested_commands` | destructive/bypassing | Safe init: `brigade init --target . --depth repo`. |
+| `operator_cmd/lifecycle.py` (quickstart install failure) | `brigade init ... --force` in `next_commands` | destructive/bypassing | Point at `brigade doctor --target TARGET`. |
+| `runbook_cmd.py` (text approval refusal) | names `--approved` | gate-bypassing | Point at `brigade runbook run --help`; JSON keeps `status`/`runbook_id`. |
 
 ## Left intentionally
 

--- a/docs/audit/2026-08-09-error-refusal-copy.md
+++ b/docs/audit/2026-08-09-error-refusal-copy.md
@@ -1,0 +1,44 @@
+# Error and refusal copy audit (#739)
+
+Sweep date: 2026-08-09. Classification keys:
+
+| Class | Meaning |
+|---|---|
+| safe-to-automate | Inline a copy-pasteable command; automating it unattended is acceptable. |
+| judgment-required | Describe the situation; point at doctor/docs/`--help`; do not inline the mutating command. |
+| destructive/bypassing | Never name the override/bypass flag in the refusal. |
+
+## Flagged messages and changes
+
+| Location | Was | Class | Change |
+|---|---|---|---|
+| `work_cmd/session/task_ops.py` (`task_done` open children) | `pass --force to close anyway` | judgment-required | Text: `parent has open children`; keep `reason` + `open_children` structured. |
+| `work_cmd/session/briefing.py` (workflow_rules) | `brigade init ... --force` for *missing* templates | wrong remediation | Drop `--force`; missing files install without overwrite. |
+| `dogfood_cmd.py` / `roster_cmd.py` / `mcp_cmd.py` init | `pass`/`use --force` to overwrite | destructive | Refuse with "leaving it unchanged"; MCP JSON adds `reason=already_exists`. |
+| `roster_cmd.py` (fallback shadow) | `Pass --force to scaffold ... anyway` | judgment-required | Describe shadowing risk; no force flag. |
+| `receipts_cmd.py` keygen | `hint: pass --force to overwrite` | destructive | Hint that the existing key is left unchanged. |
+| `research_cmd.py` export | `pass --force to replace` | destructive | "leaving it unchanged". |
+| `learn_cmd.py` propose-skill | `use --force to refresh` | destructive | "leaving it unchanged". |
+| `mcp_cmd.py` conflict detail | `--force to overwrite` | destructive | "leaving the live config unchanged". |
+| `mcp_cmd.py` / `harness_profile_cmd.py` stdio gate | name `--allow-global-stdio` | gate-bypassing | Describe user-wide stdio risk; require operator acknowledgement without naming the flag. |
+| `center_cmd/actions.py`, `repos_cmd/fleet_health.py`, `repos_cmd/release_train.py` | `or pass --allow-unreviewed` | gate-bypassing | Require reviewed/deferred closeout only. |
+| `repos_cmd/sweeps.py` health suggestions | `--force` / `--all --force` | wrong remediation | `--repo X` already refreshes; `--all` already implies force. Drop redundant `--force`. |
+| `outcome_cmd.py` ledger corrupt / doctor | inline `outcome repair --operator-confirm` | judgment-required | Point at `outcome doctor`; JSON keeps `repair_command` without the confirm flag plus `repair_requires_operator_confirm`. |
+| `outcome_repair.py` (own confirm gate) | names `--operator-confirm` | judgment-required | Point at `--help` instead of teaching the flag in the refusal. |
+| `install.py` kept-files note | `run with --force to overwrite` | judgment-required | Describe intent to replace templates; no force flag. |
+| `runguard.py` DirtyWorktreeError | `pass --allow-dirty to run anyway` | gate-bypassing | Ask to commit/stash/clean only. |
+| `doctor.py` publish hook | `run chmod +x hooks/pre-push` | platform-specific | Describe required end state for any Git hook host. |
+
+## Left intentionally
+
+| Location | Why |
+|---|---|
+| CLI `add_argument(--force / --allow-* / --operator-confirm)` help text | Documents the flag surface; not a refusal remediation. |
+| `work_cmd/verification.py` POSIX high-risk remedy naming `chmod +x` | Already gated behind `_verification_is_windows() == False`. |
+| `templates/workspace/SAFETY_RULES.md` / `TOOLS.md` `--no-verify` guidance | Operator safety policy, not CLI refusal copy. |
+| Safe remediations (`brigade setup`, `brigade security init`, …) | Safe-to-automate; kept. |
+
+## Contract pin
+
+`tests/test_error_refusal_copy.py` pins the highest-traffic refusal strings and
+rejects bypass-flag tokens in those payloads.

--- a/src/brigade/center_cmd/actions.py
+++ b/src/brigade/center_cmd/actions.py
@@ -376,7 +376,7 @@ def actions_build(
     review_status = _report_review_status(report)
     if review_status not in {"reviewed", "deferred"} and not allow_unreviewed:
         print(
-            "error: source report must be closed out as reviewed or deferred, or pass --allow-unreviewed",
+            "error: source report must be closed out as reviewed or deferred before building actions",
             file=sys.stderr,
         )
         return 2

--- a/src/brigade/doctor.py
+++ b/src/brigade/doctor.py
@@ -1306,7 +1306,11 @@ def _check_publish_gate(target: Path) -> List[CheckResult]:
         results.append((OK, "publish: hooks/pre-push", str(hook)))
         if not os.access(hook, os.X_OK):
             results.append(
-                (WARN, "publish: hooks/pre-push", "exists but not executable; run `chmod +x hooks/pre-push`")
+                (
+                    WARN,
+                    "publish: hooks/pre-push",
+                    "exists but is not executable for this process; mark hooks/pre-push executable for your Git hook host",
+                )
             )
     else:
         results.append((WARN, "publish: hooks/pre-push", f"missing at {hook}"))

--- a/src/brigade/dogfood_cmd.py
+++ b/src/brigade/dogfood_cmd.py
@@ -437,7 +437,7 @@ def init(
 
     path = config_path(target)
     if path.exists() and not force:
-        print(f"error: dogfood config already exists at {path}; pass --force to overwrite", file=sys.stderr)
+        print(f"error: dogfood config already exists at {path}; leaving it unchanged", file=sys.stderr)
         return 2
 
     chosen_artifacts_dir = artifacts_dir.expanduser() if artifacts_dir is not None else target / ".brigade" / "runs"

--- a/src/brigade/harness_profile_cmd.py
+++ b/src/brigade/harness_profile_cmd.py
@@ -921,7 +921,7 @@ def _mcp_plan(
             "path": str(path),
             "status": "conflict",
             "action": "preserve",
-            "detail": "stdio MCP servers require --allow-global-stdio",
+            "detail": "stdio MCP servers in user-wide config need explicit operator acknowledgement",
         }
         return {
             "items": [item],

--- a/src/brigade/install.py
+++ b/src/brigade/install.py
@@ -344,7 +344,7 @@ def install_selection(
         for entry in files:
             dst = target / entry["dst"]
             if dst.exists():
-                print(f"  file  {dst} (exists; kept unless --force)")
+                print(f"  file  {dst} (exists; kept)")
             else:
                 print(f"  file  {dst}")
         return 0
@@ -447,7 +447,8 @@ def install_selection(
     print(f"brigade: memory owner -> {owner_label}")
     if kept_files:
         print(
-            f"brigade: kept {len(kept_files)} existing file(s); run with --force to overwrite "
+            f"brigade: kept {len(kept_files)} existing file(s); re-run init only if you intend "
+            "to replace them with current templates "
             "(e.g. to refresh AGENTS.md / CLAUDE.md with the latest directives)."
         )
     if wired_skills:

--- a/src/brigade/learn_cmd.py
+++ b/src/brigade/learn_cmd.py
@@ -898,7 +898,7 @@ def propose_skill(
     try:
         skill_source = _write_skill_candidate_source(target, candidate, force=force)
     except FileExistsError as exc:
-        print(f"error: generated skill source already exists: {exc.args[0]} (use --force to refresh)", file=sys.stderr)
+        print(f"error: generated skill source already exists: {exc.args[0]}; leaving it unchanged", file=sys.stderr)
         return 2
     from . import skills_cmd
 

--- a/src/brigade/mcp_cmd.py
+++ b/src/brigade/mcp_cmd.py
@@ -277,7 +277,7 @@ def _plan_for_harness(
                         "conflict",
                         canon_fp,
                         desired_fp,
-                        detail="server was edited outside Brigade; --force to overwrite",
+                        detail="server was edited outside Brigade; leaving the live config unchanged",
                     )
                 )
         elif live_fp != desired_fp or record.get("canonical_fingerprint") != canon_fp:
@@ -409,7 +409,7 @@ def _stdio_exposure_lines(exposures: list[dict[str, Any]]) -> list[str]:
         )
     lines.append(
         "  prefer project-scoped config or a shared HTTP/SSE transport where the client supports it; "
-        "pass --allow-global-stdio to acknowledge"
+        "user-wide stdio writes need explicit operator acknowledgement after review"
     )
     return lines
 
@@ -481,9 +481,14 @@ def init(*, target: Path, force: bool = False, update_gitignore: bool = True, js
     created = not path.exists()
     if path.exists() and not force:
         return _emit(
-            {"canonical_path": str(path), "created": False, "error": "already exists (use --force)"},
+            {
+                "canonical_path": str(path),
+                "created": False,
+                "error": "already exists; leaving it unchanged",
+                "reason": "already_exists",
+            },
             json_output,
-            [f"error: {path} already exists (use --force)"],
+            [f"error: {path} already exists; leaving it unchanged"],
             3,
         )
     localio.write_json(path, {"version": 1, "servers": {}})
@@ -778,8 +783,8 @@ def sync(
                 gated = {e["harness"] for e in exposures}
                 gate_error = (
                     "user-scoped sync would write stdio MCP servers into a user-wide client config; "
-                    "re-run with --allow-global-stdio to acknowledge, or use project scope / an "
-                    "HTTP-SSE transport"
+                    "use project scope or an HTTP/SSE transport, or acknowledge the user-scope "
+                    "stdio risk only after operator review"
                 )
             else:
                 for line in warning_lines:

--- a/src/brigade/operator_cmd/lifecycle.py
+++ b/src/brigade/operator_cmd/lifecycle.py
@@ -445,7 +445,7 @@ def quickstart(
             "steps": steps,
             "status": "blocked",
             "next_commands": [
-                f"brigade init --target {target} --depth {depth} --harnesses {','.join(selected_harnesses) or 'none'} --force"
+                f"brigade doctor --target {target}",
             ],
             "local_only_notes": _quickstart_local_notes(),
         }

--- a/src/brigade/outcome_cmd.py
+++ b/src/brigade/outcome_cmd.py
@@ -641,7 +641,9 @@ def _last_record_digest(path: Path) -> str | None:
 def _ledger_corrupt_message(line_no: int, kind: str, path: Path, *, detail: str = "") -> str:
     """Bounded capture/append error that points operators at ``outcome repair``."""
     suffix = f" ({detail})" if detail else ""
-    return f"ledger corrupt at line {line_no}: {kind}{suffix}; run `brigade outcome repair --operator-confirm`: {path}"
+    return (
+        f"ledger corrupt at line {line_no}: {kind}{suffix}; inspect with `brigade outcome doctor` before repair: {path}"
+    )
 
 
 def _validate_completed_ledger_bytes(raw: bytes, path: Path) -> str | None:
@@ -2329,7 +2331,8 @@ def doctor(*, target: Path, json_output: bool = False) -> int:
             "suspected_cause": break_info.suspected_cause,
             "invalid_segment_start": break_info.invalid_segment_start,
             "invalid_segment_end": break_info.invalid_segment_end,
-            "repair_command": "brigade outcome repair --operator-confirm",
+            "repair_command": "brigade outcome repair",
+            "repair_requires_operator_confirm": True,
         }
     payload["completed_ledger"] = completed_ledger
     if json_output:
@@ -2345,7 +2348,7 @@ def doctor(*, target: Path, json_output: bool = False) -> int:
             f"expected_prev={break_info.expected_prev!r} actual_prev={break_info.actual_prev!r}"
         )
         print(f"suspected_cause: {break_info.suspected_cause}")
-        print("repair: brigade outcome repair --operator-confirm")
+        print("repair: brigade outcome repair (requires explicit operator confirmation)")
     return 0
 
 

--- a/src/brigade/outcome_repair.py
+++ b/src/brigade/outcome_repair.py
@@ -414,7 +414,7 @@ def repair_ledger(
 ) -> int:
     """Quarantine a broken completed ledger, keep the valid prefix, append a repair record."""
     if operator_confirmed is not True:
-        print("error: operator confirmation is required (--operator-confirm)", file=sys.stderr)
+        print("error: operator confirmation is required; see `brigade outcome repair --help`", file=sys.stderr)
         return 2
     target = target.expanduser().resolve()
     path = outcome_cmd._records_path(target)

--- a/src/brigade/receipts_cmd.py
+++ b/src/brigade/receipts_cmd.py
@@ -53,7 +53,7 @@ def keygen(*, target: Path, force: bool = False) -> int:
         path, key_id = receipt_signing.generate_key(target, force=force)
     except FileExistsError:
         print(f"error: receipt signing key already exists: {receipt_signing.key_path(target)}", file=sys.stderr)
-        print("hint: pass --force to overwrite it", file=sys.stderr)
+        print("hint: leaving the existing key unchanged", file=sys.stderr)
         return 1
     print(f"receipt signing key: {path}")
     print(f"key_id: {key_id}")

--- a/src/brigade/repos_cmd/fleet_health.py
+++ b/src/brigade/repos_cmd/fleet_health.py
@@ -354,7 +354,7 @@ def actions_build(
     review_status = _report_review_status(report)
     if review_status not in {"reviewed", "deferred"} and not allow_unreviewed:
         print(
-            "error: source fleet report must be closed out as reviewed or deferred, or pass --allow-unreviewed",
+            "error: source fleet report must be closed out as reviewed or deferred before building actions",
             file=sys.stderr,
         )
         return 2

--- a/src/brigade/repos_cmd/release_train.py
+++ b/src/brigade/repos_cmd/release_train.py
@@ -773,7 +773,7 @@ def release_actions_build(
     review_status = _train_closeout_status(train)
     if review_status not in {"reviewed", "deferred"} and not allow_unreviewed:
         print(
-            "error: source fleet release train must be closed out as reviewed or deferred, or pass --allow-unreviewed",
+            "error: source fleet release train must be closed out as reviewed or deferred before building actions",
             file=sys.stderr,
         )
         return 2

--- a/src/brigade/repos_cmd/sweeps.py
+++ b/src/brigade/repos_cmd/sweeps.py
@@ -311,7 +311,7 @@ def _health_command_registry_payload(
                             "repo_id": entry.repo_id,
                             "command_label": command.label,
                             "age_hours": age_hours,
-                            "suggested_next_command": f"brigade repos sweep run --repo {entry.repo_id} --force",
+                            "suggested_next_command": f"brigade repos sweep run --repo {entry.repo_id}",
                         }
                     )
                 if receipt.get("status") != "completed":
@@ -373,7 +373,7 @@ def _health_command_registry_payload(
         "issues": issues,
         "issue_count": len(issues),
         "top_issue": issues[0] if issues else None,
-        "suggested_next_commands": ["brigade repos sweep run --all --force"] if issues else [],
+        "suggested_next_commands": ["brigade repos sweep run --all"] if issues else [],
         "privacy": {
             "argv_redacted": True,
             "safe_labels_only": True,

--- a/src/brigade/research_cmd.py
+++ b/src/brigade/research_cmd.py
@@ -370,7 +370,7 @@ def export_handoff(
             "destination": str(destination),
             "path": str(out_path),
             "inbox": inbox_label,
-            "blockers": ["export path already exists with different content; pass --force to replace"],
+            "blockers": ["export path already exists with different content; leaving it unchanged"],
         }
     out_path.write_text(export_text, encoding="utf-8")
 

--- a/src/brigade/roster_cmd.py
+++ b/src/brigade/roster_cmd.py
@@ -304,7 +304,7 @@ def init(
     target = target.expanduser()
     path = target / DEFAULT_ROSTER_REL
     if path.exists() and not force:
-        print(f"error: roster already exists at {path}; pass --force to overwrite", file=sys.stderr)
+        print(f"error: roster already exists at {path}; leaving it unchanged", file=sys.stderr)
         return 2
     if not path.exists() and not force:
         try:
@@ -315,7 +315,7 @@ def init(
             print(
                 f"error: {fallback.source} roster {fallback.path} already applies here via fallback; "
                 f"a starter at {path} would shadow it with codex+ollama-only seats. "
-                "Pass --force to scaffold a workspace roster anyway.",
+                "Refusing to scaffold a workspace roster that would hide the active fallback.",
                 file=sys.stderr,
             )
             return 2

--- a/src/brigade/runbook_cmd.py
+++ b/src/brigade/runbook_cmd.py
@@ -447,8 +447,9 @@ def _execute_plan(
             )
         else:
             print(
-                "error: runbook execution requires the operator to pass --approved; "
-                "approved=true inside the runbook file is ignored",
+                "error: runbook execution requires explicit operator approval on the command line; "
+                "approved=true inside the runbook file is ignored. "
+                "See: brigade runbook run --help",
                 file=sys.stderr,
             )
         return 1

--- a/src/brigade/runguard.py
+++ b/src/brigade/runguard.py
@@ -60,9 +60,7 @@ class DirtyWorktreeError(RunGuardError):
         shown = ", ".join(paths[:8])
         if len(paths) > 8:
             shown += f", ... ({len(paths)} total)"
-        super().__init__(
-            f"dirty worktree: {shown}. Commit, stash, clean the tree, or pass --allow-dirty to run anyway."
-        )
+        super().__init__(f"dirty worktree: {shown}. Commit, stash, or clean the tree before running.")
 
 
 class RunLockError(RunGuardError):

--- a/src/brigade/scrub.py
+++ b/src/brigade/scrub.py
@@ -114,7 +114,7 @@ def hook_status(target: Path, policy: str = "public-repo") -> dict[str, Any]:
         if hook.is_file():
             suggestions.append("git config core.hooksPath hooks")
         else:
-            suggestions.append("brigade init --target . --force")
+            suggestions.append("brigade init --target . --depth repo")
     if not checks:
         checks.append(
             {

--- a/src/brigade/work_cmd/session/briefing.py
+++ b/src/brigade/work_cmd/session/briefing.py
@@ -49,7 +49,7 @@ def _workflow_rule_health(target: Path) -> dict[str, Any]:
         "detail": (
             "repo-shareable workflow rules installed"
             if not missing
-            else f"missing {', '.join(missing)}; run `brigade init --target {target} --depth repo --force` to refresh templates"
+            else f"missing {', '.join(missing)}; run `brigade init --target {target} --depth repo` to install the missing templates"
         ),
         "missing": missing,
     }

--- a/src/brigade/work_cmd/session/task_ops.py
+++ b/src/brigade/work_cmd/session/task_ops.py
@@ -411,7 +411,7 @@ def task_done(*, target: Path, task_id: str, force: bool = False, json_output: b
         open_children = edges_mod.open_children_for_parent(ledger, resolved_id)
         if open_children and not force:
             payload = {
-                "error": "parent has open children; pass --force to close anyway",
+                "error": "parent has open children",
                 "reason": edges_mod.REASON_OPEN_CHILDREN,
                 "task_id": resolved_id,
                 "open_children": open_children,

--- a/tests/test_error_refusal_copy.py
+++ b/tests/test_error_refusal_copy.py
@@ -13,7 +13,8 @@ from pathlib import Path
 
 import pytest
 
-from brigade import center_cmd, cli, mcp_cmd, outcome_cmd, runguard, scrub, work_cmd
+from brigade import center_cmd, cli, mcp_cmd, outcome_cmd, runbook_cmd, runguard, scrub, work_cmd
+from brigade.operator_cmd import lifecycle as operator_lifecycle
 from brigade.work_cmd import edges as edges_mod
 from brigade.work_cmd.session import briefing as briefing_mod
 
@@ -26,6 +27,7 @@ _BYPASS_TOKENS = (
     "--allow-unreviewed",
     "--allow-global-stdio",
     "--operator-confirm",
+    "--approved",
     "--no-verify",
     "chmod +x",
 )
@@ -183,6 +185,74 @@ def test_publish_hook_doctor_advice_is_platform_portable(tmp_path, monkeypatch):
     joined = "\n".join(details)
     assert any("not executable" in detail for detail in details)
     _assert_no_bypass_tokens(joined)
+
+
+def test_scrub_missing_hook_suggested_commands_omit_force(tmp_path, monkeypatch):
+    target = tmp_path / "repo"
+    target.mkdir()
+
+    def fake_run(argv, **kwargs):
+        if argv[:3] == ["git", "-C", str(target)] and argv[-1] == "core.hooksPath":
+
+            class Result:
+                returncode = 1
+                stdout = ""
+
+            return Result()
+        if argv[:3] == ["git", "-C", str(target)] and argv[-1] == "--git-dir":
+
+            class Result:
+                returncode = 0
+                stdout = ".git"
+
+            return Result()
+        raise AssertionError(argv)
+
+    monkeypatch.setattr(scrub.subprocess, "run", fake_run)
+    status = scrub.hook_status(target, policy="public-repo")
+    assert any(check["name"] == "content_guard_hook_not_enabled" for check in status["checks"])
+    joined = "\n".join(status["suggested_commands"])
+    assert "brigade init --target . --depth repo" in joined
+    _assert_no_bypass_tokens(joined)
+
+
+def test_quickstart_install_failure_next_commands_point_at_doctor(tmp_path, monkeypatch, capsys):
+    def fail_install(**kwargs):
+        return 1, ["error: simulated install failure"]
+
+    monkeypatch.setattr(operator_lifecycle, "install_selection", fail_install)
+    assert operator_lifecycle.quickstart(target=tmp_path, json_output=True) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "blocked"
+    joined = "\n".join(payload["next_commands"])
+    assert f"brigade doctor --target {tmp_path}" in joined
+    _assert_no_bypass_tokens(joined)
+
+
+def test_runbook_approval_refusal_omits_approved_flag(tmp_path, capsys):
+    runbook = tmp_path / "needs-approval.json"
+    runbook.write_text(
+        json.dumps(
+            {
+                "id": "needs-approval",
+                "approved": True,
+                "allowed_commands": ["true"],
+                "steps": [{"id": "noop", "run": "true"}],
+            }
+        )
+    )
+
+    assert runbook_cmd.run(target=tmp_path, runbook=runbook, json_output=True) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "approval-required"
+    assert payload["runbook_id"] == "needs-approval"
+    _assert_no_bypass_tokens(json.dumps(payload))
+
+    assert runbook_cmd.run(target=tmp_path, runbook=runbook, json_output=False) == 1
+    err = capsys.readouterr().err
+    assert "approved=true inside the runbook file is ignored" in err
+    assert "brigade runbook run --help" in err
+    _assert_no_bypass_tokens(err)
 
 
 def test_cli_open_children_and_mcp_init_contracts_via_main(tmp_path, monkeypatch, capsys):

--- a/tests/test_error_refusal_copy.py
+++ b/tests/test_error_refusal_copy.py
@@ -1,0 +1,214 @@
+"""Pin agent-facing refusal copy for the highest-traffic CLI errors (#739).
+
+These strings are an API surface: agents pattern-match remediations out of them.
+Bypass / overwrite flags must not appear in the refusal text; structured fields
+carry machine-readable detail instead.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from brigade import center_cmd, cli, mcp_cmd, outcome_cmd, runguard, scrub, work_cmd
+from brigade.work_cmd import edges as edges_mod
+from brigade.work_cmd.session import briefing as briefing_mod
+
+from tests.work_cmd_test_helpers import _init_git_repo
+
+
+_BYPASS_TOKENS = (
+    "--force",
+    "--allow-dirty",
+    "--allow-unreviewed",
+    "--allow-global-stdio",
+    "--operator-confirm",
+    "--no-verify",
+    "chmod +x",
+)
+
+
+def _assert_no_bypass_tokens(text: str) -> None:
+    for token in _BYPASS_TOKENS:
+        assert token not in text, f"refusal copy must not name {token!r}: {text!r}"
+
+
+def _add(target: Path, text: str) -> dict:
+    task, created = work_cmd._add_task(target, text)
+    assert created
+    return task
+
+
+def _seed_mcp(target: Path) -> None:
+    mcp_cmd.init(target=target, json_output=True)
+    mcp_cmd.add(
+        target=target,
+        name="github",
+        command="npx",
+        args=["-y", "@modelcontextprotocol/server-github"],
+        env=["GITHUB_TOKEN=ref:GITHUB_TOKEN"],
+        timeout=60,
+        json_output=True,
+    )
+
+
+def test_task_done_open_children_refusal_is_structured_without_force(tmp_path, monkeypatch, capsys):
+    _init_git_repo(tmp_path)
+    monkeypatch.setattr(
+        work_cmd.helpers,
+        "_now",
+        lambda: datetime(2026, 8, 9, 14, 0, 0, tzinfo=timezone.utc),
+    )
+    parent = _add(tmp_path, "Parent epic")
+    child = _add(tmp_path, "Open child")
+    assert (
+        work_cmd.task_edge_add(target=tmp_path, edge_type="parent-child", source=parent["id"], target_id=child["id"])
+        == 0
+    )
+    capsys.readouterr()
+
+    assert work_cmd.task_done(target=tmp_path, task_id=parent["id"], json_output=True) == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error"] == "parent has open children"
+    assert payload["reason"] == edges_mod.REASON_OPEN_CHILDREN
+    assert payload["task_id"] == parent["id"]
+    assert any(item["id"] == child["id"] for item in payload["open_children"])
+    _assert_no_bypass_tokens(json.dumps(payload))
+
+    assert work_cmd.task_done(target=tmp_path, task_id=parent["id"], json_output=False) == 2
+    err = capsys.readouterr().err
+    assert "parent has open children" in err
+    _assert_no_bypass_tokens(err)
+
+
+def test_workflow_rules_missing_templates_remediation_omits_force(tmp_path):
+    detail = briefing_mod._workflow_rule_health(tmp_path)["detail"]
+    assert "brigade init --target" in detail
+    assert "--depth repo" in detail
+    assert "missing" in detail
+    _assert_no_bypass_tokens(detail)
+
+
+def test_mcp_user_scope_stdio_gate_omits_allow_flag(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _seed_mcp(repo)
+    capsys.readouterr()
+
+    rc = mcp_cmd.sync(target=repo, harness="cursor", user_scope=True, write=True, json_output=True)
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 2
+    joined = "\n".join(payload.get("errors") or [])
+    assert "user-scoped sync would write stdio MCP servers" in joined
+    _assert_no_bypass_tokens(joined)
+    _assert_no_bypass_tokens(json.dumps(payload.get("errors") or []))
+
+
+def test_center_actions_build_refuses_unreviewed_without_bypass_flag(tmp_path, capsys):
+    inbox = tmp_path / ".brigade" / "work" / "imports" / "inbox.jsonl"
+    inbox.parent.mkdir(parents=True)
+    inbox.write_text(
+        json.dumps(
+            {
+                "id": "import-high",
+                "text": "Fix high risk finding",
+                "kind": "task",
+                "source": "security-scan",
+                "status": "pending",
+                "priority": "high",
+                "metadata": {"source_fingerprint": "fp-high"},
+                "created_at": "2026-05-29T12:01:00+00:00",
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    assert center_cmd.report_build(target=tmp_path, json_output=True) == 0
+    report = json.loads(capsys.readouterr().out)
+
+    assert center_cmd.actions_build(target=tmp_path, report_id=report["report_id"], json_output=True) == 2
+    err = capsys.readouterr().err
+    assert "must be closed out as reviewed or deferred" in err
+    _assert_no_bypass_tokens(err)
+
+
+def test_outcome_ledger_corrupt_points_at_doctor_not_confirm_flag(tmp_path):
+    path = tmp_path / "records.jsonl"
+    path.write_text("{}\n", encoding="utf-8")
+    message = outcome_cmd._ledger_corrupt_message(1, "invalid_json", path)
+    assert "brigade outcome doctor" in message
+    _assert_no_bypass_tokens(message)
+
+
+def test_dirty_worktree_refusal_omits_allow_dirty(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    import subprocess
+
+    subprocess.run(["git", "init"], cwd=repo, check=True, stdout=subprocess.DEVNULL)
+    subprocess.run(["git", "config", "user.email", "test@example.invalid"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo, check=True)
+    (repo / "tracked.txt").write_text("base\n", encoding="utf-8")
+    subprocess.run(["git", "add", "tracked.txt"], cwd=repo, check=True, stdout=subprocess.DEVNULL)
+    subprocess.run(["git", "commit", "-m", "initial"], cwd=repo, check=True, stdout=subprocess.DEVNULL)
+    (repo / "tracked.txt").write_text("dirty\n", encoding="utf-8")
+
+    with pytest.raises(runguard.DirtyWorktreeError) as exc:
+        runguard.require_clean_worktree(repo)
+    text = str(exc.value)
+    assert "dirty worktree" in text
+    assert "Commit, stash, or clean the tree" in text
+    _assert_no_bypass_tokens(text)
+
+
+def test_publish_hook_doctor_advice_is_platform_portable(tmp_path, monkeypatch):
+    from brigade import doctor as doctor_mod
+
+    hook = tmp_path / "hooks" / "pre-push"
+    hook.parent.mkdir(parents=True)
+    hook.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    hook.chmod(0o644)
+    assert not (hook.stat().st_mode & 0o111)
+    monkeypatch.setattr(scrub, "scanner_dir", lambda: tmp_path / "missing-guard")
+
+    results = doctor_mod._check_publish_gate(tmp_path)
+    details = [item[2] for item in results]
+    joined = "\n".join(details)
+    assert any("not executable" in detail for detail in details)
+    _assert_no_bypass_tokens(joined)
+
+
+def test_cli_open_children_and_mcp_init_contracts_via_main(tmp_path, monkeypatch, capsys):
+    """Smoke the argv path for two of the highest-traffic refusals."""
+    _init_git_repo(tmp_path)
+    monkeypatch.setattr(
+        work_cmd.helpers,
+        "_now",
+        lambda: datetime(2026, 8, 9, 16, 0, 0, tzinfo=timezone.utc),
+    )
+    parent = _add(tmp_path, "Epic")
+    child = _add(tmp_path, "Child")
+    assert (
+        work_cmd.task_edge_add(target=tmp_path, edge_type="parent-child", source=parent["id"], target_id=child["id"])
+        == 0
+    )
+    capsys.readouterr()
+    assert cli.main(["work", "task", "done", parent["id"], "--target", str(tmp_path), "--json"]) == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error"] == "parent has open children"
+    _assert_no_bypass_tokens(json.dumps(payload))
+
+    assert mcp_cmd.init(target=tmp_path, json_output=True) == 0
+    capsys.readouterr()
+    assert cli.main(["mcp", "init", "--target", str(tmp_path), "--json"]) == 3
+    mcp_payload = json.loads(capsys.readouterr().out)
+    assert mcp_payload["reason"] == "already_exists"
+    assert "leaving it unchanged" in mcp_payload["error"]
+    _assert_no_bypass_tokens(json.dumps(mcp_payload))

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -490,7 +490,8 @@ def test_user_scope_stdio_sync_blocks_non_interactively(tmp_path, monkeypatch, c
 
     assert rc == 2
     assert not (home / ".cursor" / "mcp.json").exists()
-    assert any("--allow-global-stdio" in e for e in payload["errors"])
+    assert any("user-scoped sync would write stdio MCP servers" in e for e in payload["errors"])
+    assert all("--allow-global-stdio" not in e for e in payload["errors"])
     assert payload["stdio_exposures"][0]["stdio_writes"] == 1
     assert payload["stdio_exposures"][0]["harness"] == "cursor-user"
 
@@ -620,7 +621,8 @@ def test_operator_sync_mcp_non_tty_requires_allow_flag(tmp_path, monkeypatch, ca
     payload = json.loads(capsys.readouterr().out)
 
     assert rc == 1
-    assert any("--allow-global-stdio" in e for e in payload["sync"]["errors"])
+    assert any("user-scoped sync would write stdio MCP servers" in e for e in payload["sync"]["errors"])
+    assert all("--allow-global-stdio" not in e for e in payload["sync"]["errors"])
     assert not (home / ".gemini/config/mcp_config.json").exists()
 
 

--- a/tests/test_outcome_repair.py
+++ b/tests/test_outcome_repair.py
@@ -81,11 +81,14 @@ def test_doctor_reports_completed_ledger_chain_break(tmp_path, capsys):
     assert payload["completed_ledger"]["line_no"] == 3
     assert payload["completed_ledger"]["kind"] == "digest_chain_break"
     assert "outcome repair" in payload["completed_ledger"]["repair_command"]
+    assert "--operator-confirm" not in payload["completed_ledger"]["repair_command"]
+    assert payload["completed_ledger"]["repair_requires_operator_confirm"] is True
 
     assert cli.main(["outcome", "doctor", "--target", str(tmp_path)]) == 0
     text = capsys.readouterr().out
     assert "completed_ledger: CORRUPT line=3" in text
-    assert "repair: brigade outcome repair --operator-confirm" in text
+    assert "repair: brigade outcome repair (requires explicit operator confirmation)" in text
+    assert "--operator-confirm" not in text
 
 
 def test_repair_requires_operator_confirmation(tmp_path, capsys):
@@ -310,7 +313,8 @@ def test_capture_degrades_with_bounded_error_and_writes_nothing(tmp_path, capsys
     captured = capsys.readouterr()
     assert rc == 1
     assert "ledger corrupt at line 3" in captured.err
-    assert "brigade outcome repair --operator-confirm" in captured.err
+    assert "brigade outcome doctor" in captured.err
+    assert "--operator-confirm" not in captured.err
     assert path.read_bytes() == before
 
 

--- a/tests/test_roster_cmd.py
+++ b/tests/test_roster_cmd.py
@@ -109,7 +109,8 @@ def test_roster_init_refuses_to_shadow_user_roster(_hermetic_home, tmp_target, c
     assert not (tmp_target / ".brigade" / "roster.toml").exists()
     assert str(user) in err
     assert "shadow" in err
-    assert "--force" in err
+    assert "Refusing to scaffold" in err
+    assert "--force" not in err
 
 
 def test_roster_init_refuses_to_shadow_worktree_parent_roster(_hermetic_home, tmp_path, capsys):
@@ -131,7 +132,8 @@ def test_roster_init_refuses_to_shadow_worktree_parent_roster(_hermetic_home, tm
     assert not (worktree / ".brigade" / "roster.toml").exists()
     assert str(parent_roster.resolve()) in err
     assert "worktree-parent" in err
-    assert "--force" in err
+    assert "Refusing to scaffold" in err
+    assert "--force" not in err
 
 
 def test_roster_init_force_scaffolds_despite_user_roster(_hermetic_home, tmp_target):

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -1099,7 +1099,8 @@ def test_run_cli_dirty_guard_blocks_by_default(tmp_path, monkeypatch, capsys):
     err = capsys.readouterr().err
     assert "dirty worktree" in err
     assert "tracked.txt" in err
-    assert "--allow-dirty" in err
+    assert "Commit, stash, or clean the tree" in err
+    assert "--allow-dirty" not in err
 
 
 def test_run_cli_dirty_guard_does_not_allocate_artifact_directory(tmp_path, monkeypatch):

--- a/tests/test_runguard.py
+++ b/tests/test_runguard.py
@@ -60,7 +60,8 @@ def test_require_clean_worktree_blocks_dirty_repo(tmp_path):
         runguard.require_clean_worktree(repo)
 
     assert exc.value.paths == ["tracked.txt"]
-    assert "--allow-dirty" in str(exc.value)
+    assert "Commit, stash, or clean the tree" in str(exc.value)
+    assert "--allow-dirty" not in str(exc.value)
 
 
 def test_run_lock_rejects_lock_held_by_live_process(tmp_path):

--- a/tests/test_work_cmd_edges.py
+++ b/tests/test_work_cmd_edges.py
@@ -382,6 +382,8 @@ def test_close_parent_refuses_open_children_unless_forced(tmp_path, monkeypatch,
     assert work_cmd.task_done(target=tmp_path, task_id=parent["id"], json_output=True) == 2
     payload = json.loads(capsys.readouterr().out)
     assert payload["reason"] == edges_mod.REASON_OPEN_CHILDREN
+    assert payload["error"] == "parent has open children"
+    assert "--force" not in payload["error"]
     assert work_cmd.task_done(target=tmp_path, task_id=parent["id"], force=True, json_output=True) == 0
     forced = json.loads(capsys.readouterr().out)
     assert forced["status"] == "done"


### PR DESCRIPTION
## Summary

Audits and updates CLI error and refusal copy for safe agent-facing remediation.

## Verification

Pending CI and shepherd review.

Fixes #739