### PR TITLE
feat(evidence): stamp provenance envelopes on imported evidence

### DIFF
--- a/engines/evidence-ledger/internal/ingest/importer.go
+++ b/engines/evidence-ledger/internal/ingest/importer.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/escoffier-labs/miseledger/internal/adapter"
+	"github.com/escoffier-labs/miseledger/internal/provenance"
 	"github.com/escoffier-labs/miseledger/internal/sources"
 	"github.com/escoffier-labs/miseledger/internal/textnorm"
 )
@@ -460,7 +461,13 @@ on conflict(source_id, external_id) do update set type=excluded.type, name=exclu
 			return false, err
 		}
 	}
-	itemMeta := itemMetadataJSON(rec)
+	capturedAt := optionalString(rec.Item.CreatedAt)
+	itemLocator := fmt.Sprintf("miseledger://%s/%s/%s", rec.Source.Kind, rec.Collection.ExternalID, rec.Item.ExternalID)
+	envelope, err := buildIngestEnvelope(rec, now, capturedAt, rec.Item.Text, raw, rec.Collection.ExternalID, rec.Item.ExternalID, "uri", itemLocator)
+	if err != nil {
+		return false, fmt.Errorf("build provenance envelope: %w", err)
+	}
+	itemMeta := itemMetadataJSON(rec, envelope)
 	res, err := tx.Exec(`insert or ignore into items(id, source_id, collection_id, actor_id, external_id, kind, created_at, updated_at, text, summary, content_hash, raw_json, raw_hash, raw_path, raw_ordinal, metadata_json)
 values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, itemID, sourceID, collectionID, nullIfEmpty(actorID), rec.Item.ExternalID, rec.Item.Kind, rec.Item.CreatedAt, rec.Item.UpdatedAt, rec.Item.Text, summary, contentHash, string(raw), rawHash, rawPath, rawOrdinal, string(itemMeta))
 	if err != nil {
@@ -481,7 +488,13 @@ values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, itemID, sourceID, collectionID, nullIf
 		if artifactHash == "" && art.Text != "" {
 			artifactHash = "sha256:" + hashString(textnorm.Normalize(art.Text))
 		}
-		if _, err := tx.Exec(`insert or ignore into artifacts(id, source_id, item_id, external_id, kind, path, url, mime_type, text, content_hash, metadata_json) values(?,?,?,?,?,?,?,?,?,?,?)`, artifactID, sourceID, itemID, art.ExternalID, art.Kind, art.Path, art.URL, art.MimeType, art.Text, artifactHash, rawOrEmptyObject(art.Metadata)); err != nil {
+		artLocatorKind, artLocatorValue := artifactLocator(rec, art)
+		artEnvelope, err := buildIngestEnvelope(rec, now, capturedAt, art.Text, nil, rec.Collection.ExternalID, art.ExternalID, artLocatorKind, artLocatorValue)
+		if err != nil {
+			return false, fmt.Errorf("build artifact provenance envelope: %w", err)
+		}
+		artMeta := mergeMetadataJSON(art.Metadata, artEnvelope, nil)
+		if _, err := tx.Exec(`insert or ignore into artifacts(id, source_id, item_id, external_id, kind, path, url, mime_type, text, content_hash, metadata_json) values(?,?,?,?,?,?,?,?,?,?,?)`, artifactID, sourceID, itemID, art.ExternalID, art.Kind, art.Path, art.URL, art.MimeType, art.Text, artifactHash, string(artMeta)); err != nil {
 			return false, err
 		}
 		if art.Text != "" {
@@ -493,8 +506,13 @@ values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, itemID, sourceID, collectionID, nullIf
 			continue
 		}
 		artifactID := stableID("artifact", itemID, "link", link.URL)
-		meta, _ := json.Marshal(map[string]any{"link_text": link.Text})
-		if _, err := tx.Exec(`insert or ignore into artifacts(id, source_id, item_id, external_id, kind, path, url, mime_type, text, content_hash, metadata_json) values(?,?,?,?,?,?,?,?,?,?,?)`, artifactID, sourceID, itemID, link.URL, "url", "", link.URL, "text/uri-list", link.Text, "sha256:"+hashString(link.URL), string(meta)); err != nil {
+		linkLocator := linkProvenanceLocator(rec, link.URL)
+		linkEnvelope, err := buildIngestEnvelope(rec, now, capturedAt, link.Text, nil, rec.Collection.ExternalID, link.URL, "uri", linkLocator)
+		if err != nil {
+			return false, fmt.Errorf("build link provenance envelope: %w", err)
+		}
+		linkMeta := mergeMetadataJSON(nil, linkEnvelope, map[string]any{"link_text": link.Text})
+		if _, err := tx.Exec(`insert or ignore into artifacts(id, source_id, item_id, external_id, kind, path, url, mime_type, text, content_hash, metadata_json) values(?,?,?,?,?,?,?,?,?,?,?)`, artifactID, sourceID, itemID, link.URL, "url", "", link.URL, "text/uri-list", link.Text, "sha256:"+hashString(link.URL), string(linkMeta)); err != nil {
 			return false, err
 		}
 		body += "\n" + textnorm.Normalize(link.URL+" "+link.Text)
@@ -519,20 +537,65 @@ values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, itemID, sourceID, collectionID, nullIf
 	return true, nil
 }
 
-func itemMetadataJSON(rec adapter.Record) []byte {
-	meta := map[string]any{"tags": rec.Item.Tags}
-	if len(rec.Item.Metadata) > 0 {
+func buildIngestEnvelope(rec adapter.Record, ingestedAt string, capturedAt *string, text string, raw []byte, collectionID, itemID, locatorKind, locatorValue string) (provenance.Envelope, error) {
+	at := ingestedAt
+	return provenance.NewEvidenceEnvelope(provenance.EvidenceInput{
+		SourceSystem: "miseledger", SourceKind: rec.Source.Kind, SourceProducer: "ingest.upsertRecord",
+		Origin: "external-service", RepositoryID: "unknown",
+		CollectionID: collectionID, ItemID: itemID,
+		LocatorKind: locatorKind, LocatorValue: locatorValue,
+		Attribution: "observed",
+		// Modality tool-output classifies the ingest channel, not human authorship.
+		Modality: "tool-output",
+		TrustLabel: "quarantined", TrustAssignedBy: "ingest:ingest.upsertRecord", TrustAssignedAt: &at,
+		InjectionStatus: "pending", InjectionRules: []string{},
+		Text: text, RawBytes: raw, CapturedAt: capturedAt, IngestedAt: &at,
+	})
+}
+
+func artifactLocator(rec adapter.Record, art adapter.Artifact) (string, string) {
+	return "uri", artifactProvenanceLocator(rec, art)
+}
+
+func artifactProvenanceLocator(rec adapter.Record, art adapter.Artifact) string {
+	return fmt.Sprintf("miseledger://%s/%s/%s/artifact/%s", rec.Source.Kind, rec.Collection.ExternalID, rec.Item.ExternalID, art.ExternalID)
+}
+
+func linkProvenanceLocator(rec adapter.Record, linkURL string) string {
+	return fmt.Sprintf("miseledger://%s/%s/%s/link/%s", rec.Source.Kind, rec.Collection.ExternalID, rec.Item.ExternalID, stableID("link", linkURL))
+}
+
+func itemMetadataJSON(rec adapter.Record, envelope provenance.Envelope) []byte {
+	return mergeMetadataJSON(rec.Item.Metadata, envelope, map[string]any{"tags": rec.Item.Tags})
+}
+
+func mergeMetadataJSON(inbound json.RawMessage, envelope provenance.Envelope, seed map[string]any) []byte {
+	meta := map[string]any{}
+	for k, v := range seed {
+		meta[k] = v
+	}
+	if len(inbound) > 0 {
 		var parsed map[string]any
-		if json.Unmarshal(rec.Item.Metadata, &parsed) == nil {
+		if json.Unmarshal(inbound, &parsed) == nil {
 			for k, v := range parsed {
 				meta[k] = v
 			}
 		} else {
-			meta["adapter_metadata_raw"] = string(rec.Item.Metadata)
+			meta["adapter_metadata_raw"] = string(inbound)
 		}
 	}
+	// Inbound metadata is evidence, not authority. Always stamp the locally
+	// assigned envelope after merging it so an adapter cannot replace trust.
+	meta["provenance"] = envelope
 	b, _ := json.Marshal(meta)
 	return b
+}
+
+func optionalString(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return &value
 }
 
 func indexItemMetadata(tx *sql.Tx, itemID string, tags []string, metaJSON []byte) error {

--- a/engines/evidence-ledger/internal/ingest/importer_test.go
+++ b/engines/evidence-ledger/internal/ingest/importer_test.go
@@ -12,6 +12,7 @@ import (
 	"testing/iotest"
 
 	"github.com/escoffier-labs/miseledger/internal/archive"
+	"github.com/escoffier-labs/miseledger/internal/provenance"
 	"github.com/escoffier-labs/miseledger/internal/sources"
 	"github.com/escoffier-labs/miseledger/internal/sources/opencode"
 )
@@ -25,7 +26,7 @@ func TestImportAdapterReaderIdempotent(t *testing.T) {
 	if err := archive.Migrate(db); err != nil {
 		t.Fatal(err)
 	}
-	jsonl := `{"schema":"miseledger.adapter.v1","source":{"kind":"reader-test","name":"Reader Test"},"collection":{"external_id":"reader:collection","kind":"agent_session","name":"reader"},"item":{"external_id":"reader:item:1","kind":"message","created_at":"2026-06-03T00:00:00Z","text":"streaming adapter reader import","tags":["reader"]},"actor":{"external_id":"reader:actor","type":"human","name":"reader"},"artifacts":[],"links":[],"relations":[],"raw":{"format":"json","path":"reader.jsonl","ordinal":1}}` + "\n"
+	jsonl := `{"schema":"miseledger.adapter.v1","source":{"kind":"reader-test","name":"Reader Test"},"collection":{"external_id":"reader:collection","kind":"agent_session","name":"reader"},"item":{"external_id":"reader:item:1","kind":"message","created_at":"2026-06-03T00:00:00Z","text":"streaming adapter reader import","tags":["reader"],"metadata":{"provenance":{"trust":{"label":"verified"}}}},"actor":{"external_id":"reader:actor","type":"human","name":"reader"},"artifacts":[],"links":[],"relations":[],"raw":{"format":"json","path":"reader.jsonl","ordinal":1}}` + "\n"
 	first, err := ImportAdapterReader(db, strings.NewReader(jsonl), "reader://fixture", "reader-test")
 	if err != nil {
 		t.Fatal(err)
@@ -46,6 +47,342 @@ func TestImportAdapterReaderIdempotent(t *testing.T) {
 	}
 	if items != 1 {
 		t.Fatalf("items = %d, want 1", items)
+	}
+	var metadataJSON string
+	if err := db.QueryRow(`select metadata_json from items limit 1`).Scan(&metadataJSON); err != nil {
+		t.Fatal(err)
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal([]byte(metadataJSON), &metadata); err != nil {
+		t.Fatal(err)
+	}
+	envelope, ok := metadata["provenance"].(map[string]any)
+	if !ok {
+		t.Fatalf("metadata provenance = %#v, want object", metadata["provenance"])
+	}
+	if envelope["schema"] != "brigade.provenance-envelope.v1" || envelope["schema_version"] != float64(1) {
+		t.Fatalf("provenance version = %#v/%#v", envelope["schema"], envelope["schema_version"])
+	}
+	hashes := envelope["hashes"].(map[string]any)
+	if hashes["content"] != "af346a2a033680308bcaa2534b8a798d8641e40a29df2b9a4f822c81ee2508ed" {
+		t.Fatalf("content digest = %v, want exact item text digest", hashes["content"])
+	}
+	trust := envelope["trust"].(map[string]any)
+	if trust["label"] != "quarantined" {
+		t.Fatalf("adapter metadata replaced local trust assignment: %v", trust["label"])
+	}
+}
+
+func TestImportAdapterReaderLongExternalIDsSucceed(t *testing.T) {
+	db, err := archive.Open(t.TempDir() + "/miseledger.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := archive.Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	longCollection := strings.Repeat("collection:", 800)
+	longItem := strings.Repeat("item:", 800)
+	record := map[string]any{
+		"schema":     "miseledger.adapter.v1",
+		"source":     map[string]any{"kind": "long-id-test", "name": "Long ID Test"},
+		"collection": map[string]any{"external_id": longCollection, "kind": "agent_session", "name": "long"},
+		"item": map[string]any{
+			"external_id": longItem,
+			"kind":        "message",
+			"created_at":  "2026-06-03T00:00:00Z",
+			"text":        "long external ids must not drop import",
+			"tags":        []string{"long-id"},
+		},
+		"actor":     map[string]any{"external_id": "long-id:actor", "type": "human", "name": "reader"},
+		"artifacts": []any{}, "links": []any{}, "relations": []any{},
+		"raw": map[string]any{"format": "json", "path": "long-id.jsonl", "ordinal": 1},
+	}
+	line, err := json.Marshal(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := ImportAdapterReader(db, strings.NewReader(string(line)+"\n"), "long-id://fixture", "long-id-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Inserted != 1 {
+		t.Fatalf("import result = %+v, want one inserted item", result)
+	}
+	for _, warning := range result.Warnings {
+		if strings.Contains(warning, "build provenance envelope") {
+			t.Fatalf("long external ids must not fail envelope build: %s", warning)
+		}
+	}
+	var metadataJSON string
+	if err := db.QueryRow(`select metadata_json from items limit 1`).Scan(&metadataJSON); err != nil {
+		t.Fatal(err)
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal([]byte(metadataJSON), &metadata); err != nil {
+		t.Fatal(err)
+	}
+	envelope, ok := metadata["provenance"].(map[string]any)
+	if !ok {
+		t.Fatalf("metadata provenance = %#v, want object", metadata["provenance"])
+	}
+	itemID, _ := envelope["item_id"].(string)
+	if len(itemID) > provenance.MaxEnvelopeIdentityBytes {
+		t.Fatalf("stored item_id length = %d, want bounded <= %d", len(itemID), provenance.MaxEnvelopeIdentityBytes)
+	}
+}
+
+func TestImportAdapterReaderStampsArtifactAndLinkProvenance(t *testing.T) {
+	db, err := archive.Open(t.TempDir() + "/miseledger.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := archive.Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	record := map[string]any{
+		"schema":     "miseledger.adapter.v1",
+		"source":     map[string]any{"kind": "artifact-prov-test", "name": "Artifact Provenance"},
+		"collection": map[string]any{"external_id": "artifact-prov:collection", "kind": "agent_session", "name": "artifact-prov"},
+		"item": map[string]any{
+			"external_id": "artifact-prov:item:1",
+			"kind":        "message",
+			"created_at":  "2026-06-03T00:00:00Z",
+			"text":        "parent item text",
+			"tags":        []string{"artifact-prov"},
+		},
+		"actor": map[string]any{"external_id": "artifact-prov:actor", "type": "human", "name": "reader"},
+		"artifacts": []map[string]any{{
+			"external_id": "artifact-prov:file:1",
+			"kind":        "file",
+			"path":        "notes/readme.md",
+			"text":        "artifact body text",
+			"metadata":    map[string]any{"source_field": "kept"},
+		}},
+		"links": []map[string]any{{
+			"url":  "https://example.test/docs/artifact-prov",
+			"text": "example docs",
+		}},
+		"relations": []any{},
+		"raw":       map[string]any{"format": "json", "path": "artifact-prov.jsonl", "ordinal": 1},
+	}
+	line, err := json.Marshal(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ImportAdapterReader(db, strings.NewReader(string(line)+"\n"), "artifact-prov://fixture", "artifact-prov-test"); err != nil {
+		t.Fatal(err)
+	}
+	var artifactMeta, linkMeta string
+	if err := db.QueryRow(`select metadata_json from artifacts where external_id = 'artifact-prov:file:1'`).Scan(&artifactMeta); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`select metadata_json from artifacts where kind = 'url'`).Scan(&linkMeta); err != nil {
+		t.Fatal(err)
+	}
+	for name, raw := range map[string]string{"artifact": artifactMeta, "link": linkMeta} {
+		var stored map[string]any
+		if err := json.Unmarshal([]byte(raw), &stored); err != nil {
+			t.Fatalf("%s metadata unmarshal: %v", name, err)
+		}
+		envelope, ok := stored["provenance"].(map[string]any)
+		if !ok {
+			t.Fatalf("%s provenance = %#v, want object", name, stored["provenance"])
+		}
+		if envelope["schema"] != "brigade.provenance-envelope.v1" {
+			t.Fatalf("%s provenance schema = %#v", name, envelope["schema"])
+		}
+		trust := envelope["trust"].(map[string]any)
+		if trust["label"] != "quarantined" {
+			t.Fatalf("%s trust label = %v, want quarantined", name, trust["label"])
+		}
+	}
+	var artifactStored map[string]any
+	if err := json.Unmarshal([]byte(artifactMeta), &artifactStored); err != nil {
+		t.Fatal(err)
+	}
+	if artifactStored["source_field"] != "kept" {
+		t.Fatalf("artifact metadata merge dropped inbound field: %#v", artifactStored)
+	}
+	var linkStored map[string]any
+	if err := json.Unmarshal([]byte(linkMeta), &linkStored); err != nil {
+		t.Fatal(err)
+	}
+	if linkStored["link_text"] != "example docs" {
+		t.Fatalf("link metadata link_text = %#v", linkStored["link_text"])
+	}
+}
+
+func TestImportAdapterReaderUnsafeArtifactAndLinkLocatorsImportFully(t *testing.T) {
+	db, err := archive.Open(t.TempDir() + "/miseledger.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := archive.Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	absolutePath := "/var/tmp/project/../notes/readme.md"
+	fileLink := "file:///var/tmp/project/doc.txt"
+	record := map[string]any{
+		"schema":     "miseledger.adapter.v1",
+		"source":     map[string]any{"kind": "unsafe-locator-test", "name": "Unsafe Locator"},
+		"collection": map[string]any{"external_id": "unsafe-locator:collection", "kind": "agent_session", "name": "unsafe-locator"},
+		"item": map[string]any{
+			"external_id": "unsafe-locator:item:1",
+			"kind":        "message",
+			"created_at":  "2026-06-03T00:00:00Z",
+			"text":        "parent item with unsafe artifact and link locators",
+			"tags":        []string{"unsafe-locator"},
+			"metadata":    map[string]any{"provenance": map[string]any{"trust": map[string]any{"label": "verified"}}},
+		},
+		"actor": map[string]any{"external_id": "unsafe-locator:actor", "type": "human", "name": "reader"},
+		"artifacts": []map[string]any{{
+			"external_id": "unsafe-locator:file:1",
+			"kind":        "file",
+			"path":        absolutePath,
+			"text":        "artifact body from absolute path",
+		}},
+		"links": []map[string]any{{
+			"url":  fileLink,
+			"text": "local file link",
+		}},
+		"relations": []any{},
+		"raw":       map[string]any{"format": "json", "path": "unsafe-locator.jsonl", "ordinal": 1},
+	}
+	line, err := json.Marshal(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := ImportAdapterReader(db, strings.NewReader(string(line)+"\n"), "unsafe-locator://fixture", "unsafe-locator-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Inserted != 1 {
+		t.Fatalf("import result = %+v, want one inserted item", result)
+	}
+	for _, warning := range result.Warnings {
+		if strings.Contains(warning, "build provenance envelope") || strings.Contains(warning, "build artifact provenance envelope") || strings.Contains(warning, "build link provenance envelope") {
+			t.Fatalf("unsafe locators must not fail envelope build: %s", warning)
+		}
+	}
+	var itemCount, artifactCount, ftsCount int
+	if err := db.QueryRow(`select count(*) from items where external_id = 'unsafe-locator:item:1'`).Scan(&itemCount); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`select count(*) from artifacts where item_id in (select id from items where external_id = 'unsafe-locator:item:1')`).Scan(&artifactCount); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`select count(*) from item_fts where item_id in (select id from items where external_id = 'unsafe-locator:item:1')`).Scan(&ftsCount); err != nil {
+		t.Fatal(err)
+	}
+	if itemCount != 1 || artifactCount != 2 || ftsCount != 1 {
+		t.Fatalf("item=%d artifact=%d fts=%d, want 1/2/1", itemCount, artifactCount, ftsCount)
+	}
+	var itemMetaJSON string
+	if err := db.QueryRow(`select metadata_json from items where external_id = 'unsafe-locator:item:1'`).Scan(&itemMetaJSON); err != nil {
+		t.Fatal(err)
+	}
+	var itemMeta map[string]any
+	if err := json.Unmarshal([]byte(itemMetaJSON), &itemMeta); err != nil {
+		t.Fatal(err)
+	}
+	itemTrust := itemMeta["provenance"].(map[string]any)["trust"].(map[string]any)
+	if itemTrust["label"] != "quarantined" {
+		t.Fatalf("item trust label = %v, want quarantined", itemTrust["label"])
+	}
+	var artifactPath, artifactMetaJSON string
+	if err := db.QueryRow(`select path, metadata_json from artifacts where external_id = 'unsafe-locator:file:1'`).Scan(&artifactPath, &artifactMetaJSON); err != nil {
+		t.Fatal(err)
+	}
+	if artifactPath != absolutePath {
+		t.Fatalf("artifact path = %q, want original %q", artifactPath, absolutePath)
+	}
+	var artifactMeta map[string]any
+	if err := json.Unmarshal([]byte(artifactMetaJSON), &artifactMeta); err != nil {
+		t.Fatal(err)
+	}
+	artifactLocator := artifactMeta["provenance"].(map[string]any)["locator"].(map[string]any)
+	if artifactLocator["kind"] != "uri" || artifactLocator["value"] != "miseledger://unsafe-locator-test/unsafe-locator:collection/unsafe-locator:item:1/artifact/unsafe-locator:file:1" {
+		t.Fatalf("artifact provenance locator = %#v, want synthetic miseledger uri", artifactLocator)
+	}
+	artifactTrust := artifactMeta["provenance"].(map[string]any)["trust"].(map[string]any)
+	if artifactTrust["label"] != "quarantined" {
+		t.Fatalf("artifact trust label = %v, want quarantined", artifactTrust["label"])
+	}
+	var linkURL, linkMetaJSON string
+	if err := db.QueryRow(`select url, metadata_json from artifacts where kind = 'url'`).Scan(&linkURL, &linkMetaJSON); err != nil {
+		t.Fatal(err)
+	}
+	if linkURL != fileLink {
+		t.Fatalf("link url = %q, want original %q", linkURL, fileLink)
+	}
+	var linkMeta map[string]any
+	if err := json.Unmarshal([]byte(linkMetaJSON), &linkMeta); err != nil {
+		t.Fatal(err)
+	}
+	linkLocator := linkMeta["provenance"].(map[string]any)["locator"].(map[string]any)
+	if linkLocator["kind"] != "uri" || !strings.HasPrefix(linkLocator["value"].(string), "miseledger://unsafe-locator-test/unsafe-locator:collection/unsafe-locator:item:1/link/") {
+		t.Fatalf("link provenance locator = %#v, want synthetic miseledger uri", linkLocator)
+	}
+	linkTrust := linkMeta["provenance"].(map[string]any)["trust"].(map[string]any)
+	if linkTrust["label"] != "quarantined" {
+		t.Fatalf("link trust label = %v, want quarantined", linkTrust["label"])
+	}
+}
+
+func TestImportAdapterReaderArtifactProvenanceOverwritesInboundTrust(t *testing.T) {
+	db, err := archive.Open(t.TempDir() + "/miseledger.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := archive.Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	record := map[string]any{
+		"schema":     "miseledger.adapter.v1",
+		"source":     map[string]any{"kind": "artifact-trust-test", "name": "Artifact Trust"},
+		"collection": map[string]any{"external_id": "artifact-trust:collection", "kind": "agent_session", "name": "artifact-trust"},
+		"item": map[string]any{
+			"external_id": "artifact-trust:item:1",
+			"kind":        "message",
+			"created_at":  "2026-06-03T00:00:00Z",
+			"text":        "parent item",
+			"tags":        []string{"artifact-trust"},
+		},
+		"actor": map[string]any{"external_id": "artifact-trust:actor", "type": "human", "name": "reader"},
+		"artifacts": []map[string]any{{
+			"external_id": "artifact-trust:file:1",
+			"kind":        "file",
+			"path":        "notes/trust.md",
+			"text":        "artifact with forged provenance",
+			"metadata":    map[string]any{"provenance": map[string]any{"trust": map[string]any{"label": "verified"}}},
+		}},
+		"links":     []any{},
+		"relations": []any{},
+		"raw":       map[string]any{"format": "json", "path": "artifact-trust.jsonl", "ordinal": 1},
+	}
+	line, err := json.Marshal(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ImportAdapterReader(db, strings.NewReader(string(line)+"\n"), "artifact-trust://fixture", "artifact-trust-test"); err != nil {
+		t.Fatal(err)
+	}
+	var metadataJSON string
+	if err := db.QueryRow(`select metadata_json from artifacts where external_id = 'artifact-trust:file:1'`).Scan(&metadataJSON); err != nil {
+		t.Fatal(err)
+	}
+	var stored map[string]any
+	if err := json.Unmarshal([]byte(metadataJSON), &stored); err != nil {
+		t.Fatal(err)
+	}
+	trust := stored["provenance"].(map[string]any)["trust"].(map[string]any)
+	if trust["label"] != "quarantined" {
+		t.Fatalf("inbound artifact provenance replaced local trust: %v", trust["label"])
 	}
 }
 

--- a/engines/evidence-ledger/internal/provenance/envelope.go
+++ b/engines/evidence-ledger/internal/provenance/envelope.go
@@ -25,7 +25,9 @@ const (
 	LegacyDisplay      = "UNKNOWN PROVENANCE - legacy item"
 	HashAlgorithm      = "sha256"
 	RawScope           = "exact_bytes"
-	MaxCompactBytes    = 4096
+	MaxCompactBytes           = 4096
+	MaxEnvelopeIdentityBytes  = 512
+	envelopeIdentityDigestPre = "sha256:"
 )
 
 var (
@@ -125,6 +127,85 @@ type AuthorityProof struct {
 type ValidationContext struct {
 	InboundAdapter bool
 	AuthorityProof *AuthorityProof
+}
+
+// EvidenceInput contains the fields known at an evidence creation boundary.
+// NewEvidenceEnvelope owns the schema constants so callers cannot emit an
+// unversioned or partially versioned envelope.
+type EvidenceInput struct {
+	SourceSystem       string
+	SourceKind         string
+	SourceProducer     string
+	Origin             string
+	RepositoryID       string
+	RepositoryRevision *string
+	SessionID          *string
+	SessionHarness     *string
+	CollectionID       string
+	ItemID             string
+	LocatorKind        string
+	LocatorValue       string
+	Attribution        string
+	Modality           string
+	TrustLabel         string
+	TrustAssignedBy    string
+	TrustAssignedAt    *string
+	InjectionStatus    string
+	InjectionRules     []string
+	Text               string
+	RawBytes           []byte
+	CapturedAt         *string
+	IngestedAt         *string
+}
+
+// BoundEnvelopeIdentity returns s when it fits the provenance identity budget,
+// otherwise a deterministic sha256: digest of the exact UTF-8 bytes.
+func BoundEnvelopeIdentity(s string) string {
+	if len(s) <= MaxEnvelopeIdentityBytes {
+		return s
+	}
+	return envelopeIdentityDigestPre + SHA256Bytes([]byte(s))
+}
+
+// NewEvidenceEnvelope builds and validates a v1 envelope for persisted item
+// text. Content covers exact UTF-8 bytes; RawBytes is hashed independently.
+func NewEvidenceEnvelope(in EvidenceInput) (Envelope, error) {
+	content := ContentSHA256(in.Text)
+	var rawAlgorithm, rawScope, rawDigest *string
+	if in.RawBytes != nil {
+		algorithm, scope, digest := HashAlgorithm, RawScope, SHA256Bytes(in.RawBytes)
+		rawAlgorithm, rawScope, rawDigest = &algorithm, &scope, &digest
+	}
+	collectionID := BoundEnvelopeIdentity(in.CollectionID)
+	itemID := BoundEnvelopeIdentity(in.ItemID)
+	locatorValue := BoundEnvelopeIdentity(in.LocatorValue)
+	repositoryID := BoundEnvelopeIdentity(in.RepositoryID)
+	var sessionID *string
+	if in.SessionID != nil {
+		bounded := BoundEnvelopeIdentity(*in.SessionID)
+		sessionID = &bounded
+	}
+	env := Envelope{
+		Schema: Schema, SchemaVersion: SchemaVersion,
+		Source:       Source{System: in.SourceSystem, Kind: in.SourceKind, Producer: in.SourceProducer},
+		Origin:       in.Origin,
+		Repository:   &Repository{ID: repositoryID, Revision: in.RepositoryRevision},
+		Session:      &Session{ID: sessionID, Harness: in.SessionHarness},
+		CollectionID: &collectionID, ItemID: &itemID,
+		Locator:     &Locator{Kind: in.LocatorKind, Value: locatorValue},
+		Attribution: in.Attribution, Modality: in.Modality,
+		Trust: Trust{
+			Label: in.TrustLabel, AssignedBy: in.TrustAssignedBy, AssignedAt: in.TrustAssignedAt,
+			TrustPolicy: TrustPolicy{Schema: TrustPolicySchema, SchemaVersion: TrustPolicyVersion},
+			Injection:   Injection{Status: in.InjectionStatus, Count: len(in.InjectionRules), Rules: append([]string{}, in.InjectionRules...)},
+		},
+		Hashes:     Hashes{ContentAlgorithm: HashAlgorithm, ContentScope: "item.text.utf8.v1", Content: &content, RawAlgorithm: rawAlgorithm, RawScope: rawScope, Raw: rawDigest},
+		CapturedAt: in.CapturedAt, IngestedAt: in.IngestedAt,
+	}
+	if err := Validate(env, ValidationContext{}); err != nil {
+		return Envelope{}, err
+	}
+	return env, nil
 }
 
 // SHA256Bytes returns the bare lowercase 64-char hex SHA-256 digest of data.

--- a/engines/evidence-ledger/internal/provenance/envelope_test.go
+++ b/engines/evidence-ledger/internal/provenance/envelope_test.go
@@ -3,6 +3,7 @@ package provenance_test
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -328,5 +329,53 @@ func TestValidateAcceptsEnvelopeUnder4096CompactBytes(t *testing.T) {
 	env := validEnvelope(t)
 	if err := provenance.Validate(env, provenance.ValidationContext{}); err != nil {
 		t.Fatalf("compact envelope rejected: %v", err)
+	}
+}
+
+func TestBoundEnvelopeIdentityPreservesShortValues(t *testing.T) {
+	const short = "reader:item:1"
+	if got := provenance.BoundEnvelopeIdentity(short); got != short {
+		t.Fatalf("BoundEnvelopeIdentity(%q) = %q, want unchanged", short, got)
+	}
+}
+
+func TestBoundEnvelopeIdentityHashSubstitutesLongValues(t *testing.T) {
+	long := strings.Repeat("x", provenance.MaxEnvelopeIdentityBytes+1)
+	got := provenance.BoundEnvelopeIdentity(long)
+	want := "sha256:" + provenance.SHA256Bytes([]byte(long))
+	if got != want {
+		t.Fatalf("BoundEnvelopeIdentity long value = %q, want %q", got, want)
+	}
+	if got == long {
+		t.Fatal("expected hash substitution for oversized identity")
+	}
+}
+
+func TestNewEvidenceEnvelopeBoundsLongExternalIDs(t *testing.T) {
+	longCollection := strings.Repeat("c", 4000)
+	longItem := strings.Repeat("i", 4000)
+	longLocator := fmt.Sprintf("miseledger://adapter/%s/%s", longCollection, longItem)
+	ingestedAt := "2026-06-03T00:00:00Z"
+	env, err := provenance.NewEvidenceEnvelope(provenance.EvidenceInput{
+		SourceSystem: "miseledger", SourceKind: "adapter", SourceProducer: "ingest.upsertRecord",
+		Origin: "external-service", RepositoryID: "unknown",
+		CollectionID: longCollection, ItemID: longItem,
+		LocatorKind: "uri", LocatorValue: longLocator,
+		Attribution: "observed", Modality: "tool-output",
+		TrustLabel: "quarantined", TrustAssignedBy: "ingest:ingest.upsertRecord", TrustAssignedAt: &ingestedAt,
+		InjectionStatus: "pending", InjectionRules: []string{},
+		Text: "bounded ids still validate", IngestedAt: &ingestedAt,
+	})
+	if err != nil {
+		t.Fatalf("NewEvidenceEnvelope with long external ids: %v", err)
+	}
+	if len(*env.CollectionID) > provenance.MaxEnvelopeIdentityBytes {
+		t.Fatalf("collection_id length = %d, want <= %d", len(*env.CollectionID), provenance.MaxEnvelopeIdentityBytes)
+	}
+	if len(*env.ItemID) > provenance.MaxEnvelopeIdentityBytes {
+		t.Fatalf("item_id length = %d, want <= %d", len(*env.ItemID), provenance.MaxEnvelopeIdentityBytes)
+	}
+	if len(env.Locator.Value) > provenance.MaxEnvelopeIdentityBytes {
+		t.Fatalf("locator.value length = %d, want <= %d", len(env.Locator.Value), provenance.MaxEnvelopeIdentityBytes)
 	}
 }


### PR DESCRIPTION
## Summary

- stamp locally assigned provenance envelopes on imported items, artifacts, and links
- quarantine inbound trust claims and preserve original adapter metadata
- bound long provenance identities and use safe synthetic artifact locators

## Verification

- `go -C engines/evidence-ledger test ./...`
- `go -C engines/evidence-ledger vet ./...`
- `env GOFLAGS=-buildvcs=false engines/evidence-ledger/scripts/smoke_archive.sh`

Fixes #505