### PR TITLE
feat(skills): audit declared obligations against receipts (#499)

### DIFF
--- a/.grok/memory-handoffs/2026-08-10-1142-skills-audit-path-redaction.md
+++ b/.grok/memory-handoffs/2026-08-10-1142-skills-audit-path-redaction.md
@@ -1,0 +1,32 @@
+# Memory Handoff
+
+## Type
+bugfix
+
+## Title
+skills audit public path redaction (#818 / #499)
+
+## Summary
+`brigade skills audit` was emitting host-private absolute paths in JSON `target`/`run_dir`, receipt evidence paths (including unattributed), path-based skill `source.identity`, and text `target`/`run`. Public output now uses repo-relative labels under the audited target and `external:<name>` outside it, without changing producer_run_id matching or advisory semantics.
+
+## Durable facts
+- Public path helper lives in `src/brigade/skill_obligations.py`: under-target → repo-relative posix; outside → `external:<basename>`; audit `target` is always `.`.
+- Path-kind skill source identities are rewritten only in the audit payload (`path:external:<name>` / `path:.brigade/...`); `_source_identity` in `skills_cmd` is unchanged.
+- Exact `producer_run_id` attribution, advisory exit 0, and legacy unattributed receipt compatibility remain as approved on PR #818.
+- GraphTrail pre-edit impact set for this repair: primary `src/brigade/skill_obligations.py` (`build_audit_payload` / `audit` / `_evidence_ref`); direct CLI caller `src/brigade/cli/skills.py`; skill load via `skills_cmd._load_skill` / `_source_identity`; receipt collectors `scorecard.discover_verify_receipt_paths`, `work_cmd.reviews._review_receipts`, `handoff_cmd.drafts._ingest_receipts`. Focused tests: `tests/test_skill_obligations_audit.py`, `tests/test_producer_run_id.py`.
+
+## Evidence
+- files changed: `src/brigade/skill_obligations.py`, `tests/test_skill_obligations_audit.py`, `tests/test_producer_run_id.py`, `CHANGELOG.md`
+- commands run: `brigade work verify run --target . --command ".venv/bin/pytest -q tests/test_skill_obligations_audit.py tests/test_producer_run_id.py::test_skills_audit_text_output_labels_unattributed_without_secrets" --capture brigade-work` (run `20260810-114225-work-verify-1492db`, exit 0)
+- earlier verify runs: `20260810-114153-work-verify-ffb7a5`, `20260810-114202-work-verify-787abb`
+- error strings: none after fix
+
+## Recommended memory action
+no-card
+
+## Target document
+.learnings/LEARNINGS.md
+
+## Suggested document content
+### skills audit path labels
+Public `brigade skills audit` JSON/text must never print absolute host paths. Use repo-relative paths under the audited target and `external:<name>` for outside paths; keep matching logic on real filesystem paths internally.

--- a/.grok/memory-handoffs/2026-08-10-1147-skills-audit-path-label-sendback.md
+++ b/.grok/memory-handoffs/2026-08-10-1147-skills-audit-path-label-sendback.md
@@ -1,0 +1,31 @@
+# Memory Handoff
+
+## Type
+bugfix
+
+## Title
+skills audit load_error redaction and collision-resistant external labels (#818)
+
+## Summary
+Independent review of PR #818 found two remaining output-safety defects after the first path-redaction repair: missing path-based skill selectors were echoed raw into `load_error`/`load_warnings`, and `_public_path` basename-only `external:<name>` labels collided for distinct outside paths. Both are fixed without changing producer_run_id matching, advisory semantics, or transport behavior.
+
+## Durable facts
+- `_load_skill_metadata` must emit public skill selectors in error text (`skill not found: <public>`; loadable exceptions scrub known path spellings via `_public_load_error_text`).
+- Outside-target public labels are now `external:<basename>-<sha256[:12]>` of the resolved posix path (or raw text on resolve failure): deterministic, collision-resistant, non-revealing.
+- GraphTrail impact (post-edit): `_external_public_label` ← `_public_path` ← `_public_skill_id` / `_public_source` / `_evidence_ref` / `build_audit_payload`; `_public_load_error_text` ← `_load_skill_metadata` ← `build_audit_payload`. No new callers outside `src/brigade/skill_obligations.py`.
+- Prior basename-only `external:<name>` contract is superseded; tests assert distinct labels for same-basename `/a/foo` vs `/b/foo`.
+
+## Evidence
+- files changed: `src/brigade/skill_obligations.py`, `tests/test_skill_obligations_audit.py`, `CHANGELOG.md`
+- commands run: final GREEN `brigade work verify run ... pytest ...` run `20260810-114735-work-verify-8df36c` (exit 0); ruff check `20260810-114716-work-verify-f90ddd` (exit 0); ruff format check `20260810-114724-work-verify-4b7e3f` (exit 0)
+- error strings: pre-fix `skill not found: /.../missing-skill` and colliding `external:foo`
+
+## Recommended memory action
+no-card
+
+## Target document
+.learnings/LEARNINGS.md
+
+## Suggested document content
+### skills audit external path labels
+Public `brigade skills audit` labels outside the audited target as `external:<basename>-<12-hex digest>` of the resolved path key. Missing path-based skill selectors must use the same public label inside `load_error` and `load_warnings.detail`; never echo the absolute selector.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   receipts (#499). Missing required evidence is reported as findings with
   exit 0; verify commands may stamp `obligation_id` for precise matching.
   Bundled `brigade-work` declares `verify-through-brigade` and
-  `session-handoff` obligations.
+  `session-handoff` obligations. Orchestrator run identity is exported to
+  workers as `BRIGADE_RUN_ID`; verify, review, and handoff producers stamp
+  optional `producer_run_id`. Per-run obligation matching requires exact
+  `producer_run_id` equality (never timestamp proximity); legacy unstamped
+  receipts are labeled unattributed and cannot satisfy.
 
 ## [0.26.1] - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,8 +97,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   optional `producer_run_id`. Per-run obligation matching requires exact
   `producer_run_id` equality (never timestamp proximity); legacy unstamped
   receipts are labeled unattributed and cannot satisfy. Public JSON/text
-  output uses repo-relative or `external:<name>` path labels and never
-  prints host-private absolute paths.
+  output uses repo-relative or collision-resistant `external:<name>-<digest>`
+  path labels and never prints host-private absolute paths, including in
+  `load_error` / `load_warnings` text for missing path-based skill selectors.
 
 ## [0.26.1] - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,7 +96,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   workers as `BRIGADE_RUN_ID`; verify, review, and handoff producers stamp
   optional `producer_run_id`. Per-run obligation matching requires exact
   `producer_run_id` equality (never timestamp proximity); legacy unstamped
-  receipts are labeled unattributed and cannot satisfy.
+  receipts are labeled unattributed and cannot satisfy. Public JSON/text
+  output uses repo-relative or `external:<name>` path labels and never
+  prints host-private absolute paths.
 
 ## [0.26.1] - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   recall (#736). A one-shot marker still backs `UserPromptSubmit` when compact
   reinjection is unavailable; the compact path clears stale markers so prompt
   submit does not double-inject.
+- Advisory `brigade skills audit <run>` compares skill.json process
+  obligations (`check` / `review` / `handoff`) declared by a run's
+  `selected_skill_ids` against captured verify, review, and handoff ingest
+  receipts (#499). Missing required evidence is reported as findings with
+  exit 0; verify commands may stamp `obligation_id` for precise matching.
+  Bundled `brigade-work` declares `verify-through-brigade` and
+  `session-handoff` obligations.
 
 ## [0.26.1] - 2026-08-09
 

--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -62,7 +62,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade search`: 6 command path(s)
 - `brigade security`: 15 command path(s)
 - `brigade setup`: 1 command path(s)
-- `brigade skills`: 29 command path(s)
+- `brigade skills`: 30 command path(s)
 - `brigade stations`: 3 command path(s)
 - `brigade status`: 1 command path(s)
 - `brigade tokens`: 3 command path(s)
@@ -486,6 +486,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade skills adapters init`
 - `brigade skills adapters list`
 - `brigade skills adapters show`
+- `brigade skills audit`
 - `brigade skills compatibility`
 - `brigade skills diff`
 - `brigade skills doctor`

--- a/docs/receipt-schemas.md
+++ b/docs/receipt-schemas.md
@@ -568,6 +568,11 @@ instead of letting the worker improvise tools.
 | `risk_class` | string \| null | Tool risk class |
 | `reasons` | array of string | Match / reject reasons |
 
+`brigade skills audit <run>` uses `selected_skill_ids` plus each skill's
+additive `skill.json` `obligations` to report missing check / review / handoff
+receipts as advisory findings (`brigade.skill_obligations_audit.v1`). See
+`docs/skill-registry.md`.
+
 ---
 
 ## `brigade.worker_results.v1`: `schema_version: 1`

--- a/docs/receipt-schemas.md
+++ b/docs/receipt-schemas.md
@@ -50,6 +50,7 @@ JSON Schema files.
 | `duration_seconds` | number | no | Wall time |
 | `timeout` | integer | no | Per-command timeout seconds |
 | `path` | string | yes | Run directory path |
+| `producer_run_id` | string | no | Orchestrator run id from `BRIGADE_RUN_ID` when the producer ran under a Brigade run (#499). Omitted when unset; legacy receipts without it remain readable |
 | `commands` | array of object | yes | See command object below |
 | `planned_commands` | array of string | no | Display argv joined |
 | `evidence` | object | no | Workspace evidence snapshot |
@@ -570,8 +571,12 @@ instead of letting the worker improvise tools.
 
 `brigade skills audit <run>` uses `selected_skill_ids` plus each skill's
 additive `skill.json` `obligations` to report missing check / review / handoff
-receipts as advisory findings (`brigade.skill_obligations_audit.v1`). See
-`docs/skill-registry.md`.
+receipts as advisory findings (`brigade.skill_obligations_audit.v1`). Per-run
+matching requires exact `producer_run_id` equality with the audited
+orchestrator run id; timestamp proximity never satisfies. Legacy receipts
+without `producer_run_id` are reported as unattributed and cannot satisfy.
+Workers receive the orchestrator id as `BRIGADE_RUN_ID` through the run
+transport env path. See `docs/skill-registry.md`.
 
 ---
 

--- a/docs/skill-registry.md
+++ b/docs/skill-registry.md
@@ -69,3 +69,21 @@ One markdown file per skill, byte-identical to its source in
 [escoffier-labs/skillet](https://github.com/escoffier-labs/skillet). No
 dependencies, no code execution, no config changes. Read the file before you
 adopt it, like anything else that instructs an agent.
+
+## Process obligations (advisory)
+
+Registry `skill.json` may declare an additive `obligations` list. Each entry
+has `id`, `kind` (`check` | `review` | `handoff`), optional `required`
+(default `true`), and optional `description`.
+
+```bash
+brigade skills audit latest --target . --json
+```
+
+`brigade skills audit` reads `selected_skill_ids` from a run's `plan.json`,
+loads each skill's obligations, and compares them to captured verify, review,
+and handoff ingest receipts. Missing required evidence is reported as advisory
+findings (exit 0). Verify receipt commands may stamp `obligation_id` for
+precise check matching; when no stamp exists, a completed verify receipt
+satisfies a `check` obligation at the kind level. This audit never blocks
+verify or promotion (see #499 / skill scorecards).

--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -1962,6 +1962,7 @@ def dispatch(
     quarantine_state: seat_health_policy.SeatQuarantineState | None = None,
     reprobe_seat: Callable[[Agent], bool] | None = None,
     on_failed_attempt_persisted: Callable[[WorkerResult], None] | None = None,
+    run_id: str | None = None,
 ) -> list[WorkerResult]:
     from . import run_transport
 
@@ -1999,6 +2000,7 @@ def dispatch(
         quarantine_state=quarantine_state,
         reprobe_seat=reprobe_seat,
         on_failed_attempt_persisted=on_failed_attempt_persisted,
+        run_id=run_id,
     )
 
 
@@ -4259,6 +4261,7 @@ def run(
                 quarantine_state=quarantine_state,
                 reprobe_seat=reprobe_seat_for_retry,
                 on_failed_attempt_persisted=persist_failed_attempt,
+                run_id=output_dir.name if output_dir is not None else None,
             )
         except runguard.RetainRunLockError:
             raise

--- a/src/brigade/aboyeur.py
+++ b/src/brigade/aboyeur.py
@@ -4070,10 +4070,22 @@ def run(
     try:
         if effective_transport == "app-server":
             try:
+                # BRIGADE_RUN_ID is run-scoped process identity, not per-seat env.
+                # AppServer already accepts process env; seat.env stays forbidden
+                # on the shared app-server session (roster + dispatch force direct).
+                appserver_kwargs: dict[str, Any] = {"cwd": cwd}
+                if output_dir is not None:
+                    appserver_params = inspect.signature(codex_appserver.AppServer).parameters.values()
+                    accepts_env = any(
+                        parameter.name == "env" or parameter.kind is inspect.Parameter.VAR_KEYWORD
+                        for parameter in appserver_params
+                    )
+                    if accepts_env:
+                        appserver_kwargs["env"] = {receipt_schema.BRIGADE_RUN_ID_ENV: output_dir.name}
                 appserver = _call_with_process_registry(
                     codex_appserver.AppServer,
-                    cwd=cwd,
                     process_registry=process_registry,
+                    **appserver_kwargs,
                 )
                 appserver.start()
             except codex_appserver.AppServerError as exc:

--- a/src/brigade/acpx_adapter.py
+++ b/src/brigade/acpx_adapter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import inspect
 import json
+import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -366,6 +367,7 @@ def run_cursor(
     read_only: bool,
     writable_worktree: bool = False,
     process_registry: proc.ProcessRegistry | None = None,
+    env: dict[str, str] | None = None,
 ) -> AgentResult:
     if version != SUPPORTED_VERSION:
         return AgentResult(
@@ -459,10 +461,15 @@ def run_cursor(
             acpx_version=installed,
             safe_events=(auth_event,),
         )
+    child_env = None
+    if env is not None:
+        child_env = dict(os.environ)
+        child_env.update(env)
     result = proc.run(
         argv,
         timeout=timeout + 5.0,
         cwd=cwd,
+        env=child_env,
         process_registry=process_registry,
     )
     if result.decode_failed:

--- a/src/brigade/cli/skills.py
+++ b/src/brigade/cli/skills.py
@@ -32,6 +32,31 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_skills_doctor = skills_sub.add_parser("doctor", help="Check reviewed skill registry health.")
     p_skills_doctor.add_argument("--target", "-t", type=Path, default=Path("."), help="Workspace registry to inspect.")
     p_skills_doctor.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_skills_audit = skills_sub.add_parser(
+        "audit",
+        help=(
+            "Advisory audit: compare declared skill process obligations "
+            "(checks, reviews, handoffs) against captured receipts for one run."
+        ),
+    )
+    p_skills_audit.add_argument(
+        "run",
+        help="Run directory path, run id under --runs-dir, or 'latest'.",
+    )
+    p_skills_audit.add_argument(
+        "--target",
+        "-t",
+        type=Path,
+        default=Path("."),
+        help="Workspace whose skill registry and receipts should be audited.",
+    )
+    p_skills_audit.add_argument(
+        "--runs-dir",
+        type=Path,
+        default=None,
+        help="Explicit runs directory for run ids. Defaults to .brigade/runs under --target.",
+    )
+    p_skills_audit.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
     p_skills_import_issues = skills_sub.add_parser(
         "import-issues", help="Import skill registry issues into the work inbox."
     )
@@ -222,6 +247,15 @@ def dispatch(args) -> int:
         )
     if args.skills_command == "doctor":
         return skills_cmd.doctor(target=args.target, json_output=args.json)
+    if args.skills_command == "audit":
+        from .. import skill_obligations
+
+        return skill_obligations.audit(
+            target=args.target,
+            run=args.run,
+            runs_dir=args.runs_dir,
+            json_output=args.json,
+        )
     if args.skills_command == "import-issues":
         return skills_cmd.import_issues(target=args.target, json_output=args.json)
     if args.skills_command == "install":

--- a/src/brigade/handoff_cmd/drafts.py
+++ b/src/brigade/handoff_cmd/drafts.py
@@ -226,6 +226,9 @@ def _normalize_ingest_receipt(
         value = payload.get(key)
         if isinstance(value, str) and value.strip():
             normalized[key] = value.strip()
+    producer_run_id = payload.get("producer_run_id")
+    if isinstance(producer_run_id, str) and producer_run_id.strip():
+        normalized["producer_run_id"] = producer_run_id.strip()
     normalized["outcomes"] = _ingest_receipt_outcomes(target, normalized)
     return normalized
 

--- a/src/brigade/handoff_cmd/receipts.py
+++ b/src/brigade/handoff_cmd/receipts.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from .. import scrub
+from .. import receipt_schema, scrub
 from ..budgets import HANDOFF_BACKLOG_STALE_SECONDS
 from ..config import load_config as load_brigade_config
 from ..localio import write_json as _write_json
@@ -176,6 +176,7 @@ def _receipt_payload_for_drafts(
         "recorded_by": "brigade handoff receipt record",
         "recorded_at": now,
     }
+    receipt_schema.stamp_optional_producer_run_id(payload)
     if status == "ingested":
         for draft in drafts:
             if draft.target_card:

--- a/src/brigade/receipt_schema.py
+++ b/src/brigade/receipt_schema.py
@@ -2,7 +2,43 @@
 
 from __future__ import annotations
 
+import os
+from collections.abc import Mapping
+from typing import Any
+
 VERIFY_RECEIPT_SCHEMA_VERSION = 2
+
+# Stable env key: orchestrator run identity exported into worker environments
+# via run/transport (#499). Receipt producers may stamp the value as optional
+# ``producer_run_id``; omit the field when unset for legacy compatibility.
+BRIGADE_RUN_ID_ENV = "BRIGADE_RUN_ID"
+
+
+def producer_run_id_from_env(environ: Mapping[str, str] | None = None) -> str | None:
+    """Return the orchestrator run id from ``BRIGADE_RUN_ID``, or None when absent."""
+    source = environ if environ is not None else os.environ
+    value = source.get(BRIGADE_RUN_ID_ENV, "")
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def stamp_optional_producer_run_id(
+    payload: dict[str, Any],
+    *,
+    producer_run_id: str | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Stamp optional ``producer_run_id`` when present; omit when absent."""
+    value = producer_run_id if producer_run_id is not None else producer_run_id_from_env(environ)
+    if isinstance(value, str):
+        cleaned = value.strip()
+        if cleaned:
+            payload["producer_run_id"] = cleaned
+    return payload
+
+
 WORK_CLOSEOUT_SCHEMA_VERSION = 1
 RUN_RECEIPT_SCHEMA_VERSION = 1
 OUTCOME_RECORD_SCHEMA_VERSION = 1

--- a/src/brigade/run_transport.py
+++ b/src/brigade/run_transport.py
@@ -14,9 +14,13 @@ from pathlib import Path
 from typing import Any, Callable, Protocol
 from urllib.parse import urlparse
 
-from . import agents, proc, run_control, runguard
+from . import agents, proc, receipt_schema, run_control, runguard
 from .roster import Agent, Roster, is_cli_allowed, timeout_for
 from .seat_health_policy import SeatQuarantineState, decide_retry, failure_for_worker_result
+
+# Re-export the stable worker env key so transport tests and callers document
+# one name: BRIGADE_RUN_ID (see receipt_schema.BRIGADE_RUN_ID_ENV).
+BRIGADE_RUN_ID_ENV = receipt_schema.BRIGADE_RUN_ID_ENV
 
 _GROK_CONTINUATION_PROMPT = (
     "Return the final answer now using the required structured answer schema. "
@@ -347,6 +351,7 @@ def dispatch(
     quarantine_state: SeatQuarantineState | None = None,
     reprobe_seat: Callable[[Agent], bool] | None = None,
     on_failed_attempt_persisted: Callable[[WorkerResult], None] | None = None,
+    run_id: str | None = None,
 ) -> list[WorkerResult]:
     """Dispatch staged assignments while keeping transport policy in one module.
 
@@ -355,6 +360,10 @@ def dispatch(
     silent degrade to waves. Without it the fallback is stderr-only and the run
     record cannot tell the two apart.
 
+    ``run_id`` is the orchestrator run identity. When set, workers receive it as
+    ``BRIGADE_RUN_ID`` through the existing env transport path so receipt
+    producers can stamp optional ``producer_run_id`` (#499).
+
     ``quarantine_state`` / ``reprobe_seat`` implement the #474 same-seat-once
     retry bound: persist the failed attempt, re-probe, then allow at most one
     same-seat retry before quarantining the seat for the rest of the run.
@@ -362,6 +371,14 @@ def dispatch(
 
     process_registry = process_registry or proc.ProcessRegistry()
     quarantine_state = quarantine_state or SeatQuarantineState()
+    orchestrator_run_id = run_id.strip() if isinstance(run_id, str) and run_id.strip() else None
+
+    def _with_orchestrator_run_id(env: dict[str, str] | None) -> dict[str, str] | None:
+        if orchestrator_run_id is None:
+            return env
+        merged = dict(env) if env is not None else {}
+        merged[BRIGADE_RUN_ID_ENV] = orchestrator_run_id
+        return merged
 
     def run_direct_agent(*args: Any, **kwargs: Any) -> agents.AgentResult:
         runner = agents.run_agent
@@ -372,6 +389,8 @@ def dispatch(
         )
         if not accepts_registry:
             kwargs.pop("process_registry", None)
+        if orchestrator_run_id is not None:
+            kwargs["env"] = _with_orchestrator_run_id(kwargs.get("env"))
         return runner(*args, **kwargs)
 
     def cancel_active_work(futures: dict[Any, int]) -> None:
@@ -443,16 +462,21 @@ def dispatch(
             if selected_agent.transport == "acpx":
                 from . import acpx_adapter
 
-                return acpx_adapter.run_cursor(
-                    selected_prompt,
-                    cwd=cwd or Path.cwd(),
-                    timeout=timeout_for(selected_agent, roster),
-                    model=selected_agent.model or "",
-                    version=selected_agent.transport_version or "",
-                    read_only=effective_read_only,
-                    writable_worktree=authorized_writable_worktree,
-                    process_registry=process_registry,
+                acpx_kwargs: dict[str, Any] = {
+                    "cwd": cwd or Path.cwd(),
+                    "timeout": timeout_for(selected_agent, roster),
+                    "model": selected_agent.model or "",
+                    "version": selected_agent.transport_version or "",
+                    "read_only": effective_read_only,
+                    "writable_worktree": authorized_writable_worktree,
+                    "process_registry": process_registry,
+                }
+                worker_env = _with_orchestrator_run_id(
+                    dict(selected_agent.env) if selected_agent.env is not None else None
                 )
+                if worker_env is not None:
+                    acpx_kwargs["env"] = worker_env
+                return acpx_adapter.run_cursor(selected_prompt, **acpx_kwargs)
             if resume_session_id is not None:
                 return run_direct_agent(
                     cli_ref,

--- a/src/brigade/run_transport.py
+++ b/src/brigade/run_transport.py
@@ -360,9 +360,11 @@ def dispatch(
     silent degrade to waves. Without it the fallback is stderr-only and the run
     record cannot tell the two apart.
 
-    ``run_id`` is the orchestrator run identity. When set, workers receive it as
-    ``BRIGADE_RUN_ID`` through the existing env transport path so receipt
-    producers can stamp optional ``producer_run_id`` (#499).
+    ``run_id`` is the orchestrator run identity. When set, direct/ACPX workers
+    receive it as ``BRIGADE_RUN_ID`` through the existing env transport path so
+    receipt producers can stamp optional ``producer_run_id`` (#499). Codex
+    app-server workers receive the same identity via the AppServer process env
+    constructed by ``brigade run`` (run-scoped, not per-seat).
 
     ``quarantine_state`` / ``reprobe_seat`` implement the #474 same-seat-once
     retry bound: persist the failed attempt, re-probe, then allow at most one
@@ -383,14 +385,20 @@ def dispatch(
     def run_direct_agent(*args: Any, **kwargs: Any) -> agents.AgentResult:
         runner = agents.run_agent
         parameters = inspect.signature(runner).parameters.values()
-        accepts_registry = any(
-            parameter.name == "process_registry" or parameter.kind is inspect.Parameter.VAR_KEYWORD
-            for parameter in parameters
-        )
+        accepts_var_keyword = any(parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters)
+        accepts_registry = accepts_var_keyword or any(parameter.name == "process_registry" for parameter in parameters)
+        accepts_env = accepts_var_keyword or any(parameter.name == "env" for parameter in parameters)
         if not accepts_registry:
             kwargs.pop("process_registry", None)
         if orchestrator_run_id is not None:
-            kwargs["env"] = _with_orchestrator_run_id(kwargs.get("env"))
+            # Real agents.run_agent accepts env=; legacy fixed-signature test
+            # doubles do not. Mirror the process_registry gate so BRIGADE_RUN_ID
+            # still reaches production workers without crashing the doubles.
+            merged_env = _with_orchestrator_run_id(kwargs.get("env"))
+            if accepts_env:
+                kwargs["env"] = merged_env
+            else:
+                kwargs.pop("env", None)
         return runner(*args, **kwargs)
 
     def cancel_active_work(futures: dict[Any, int]) -> None:

--- a/src/brigade/skill_obligations.py
+++ b/src/brigade/skill_obligations.py
@@ -36,6 +36,65 @@ RESULT_WARN = "warn"
 RESULT_NO_DECLARED_SKILLS = "no_declared_skills"
 RESULT_NO_OBLIGATIONS = "no_obligations"
 
+# Public audit output never prints host-private absolute paths. Paths under the
+# audited target are repo-relative; everything else collapses to external:<name>.
+PUBLIC_TARGET = "."
+
+
+def _public_path(root: Path, value: object) -> str | None:
+    """Stable public path label: repo-relative under root, else external:<name>."""
+    if value is None:
+        return None
+    if not isinstance(value, (str, Path)):
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    root_resolved = root.expanduser().resolve()
+    path = Path(text).expanduser()
+    try:
+        resolved = path.resolve() if path.is_absolute() else (root_resolved / path).resolve()
+    except OSError:
+        name = Path(text).name or "path"
+        return f"external:{name}"
+    try:
+        relative = resolved.relative_to(root_resolved)
+    except ValueError:
+        name = resolved.name or "path"
+        return f"external:{name}"
+    rendered = relative.as_posix()
+    return rendered if rendered else PUBLIC_TARGET
+
+
+def _looks_like_filesystem_ref(value: str) -> bool:
+    if not value:
+        return False
+    if value.startswith((".", "~", "/", "\\")):
+        return True
+    if "/" in value or "\\" in value:
+        return True
+    try:
+        return Path(value).expanduser().is_absolute()
+    except OSError:
+        return False
+
+
+def _public_skill_id(root: Path, skill_id: str) -> str:
+    if not _looks_like_filesystem_ref(skill_id):
+        return skill_id
+    return _public_path(root, skill_id) or skill_id
+
+
+def _public_source(root: Path, source: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(source, dict):
+        return source
+    public = dict(source)
+    identity = public.get("identity")
+    if public.get("kind") == "path" and isinstance(identity, str):
+        raw = identity.removeprefix("path:") if identity.startswith("path:") else identity
+        public["identity"] = f"path:{_public_path(root, raw) or 'external:path'}"
+    return public
+
 
 @dataclass(frozen=True)
 class SkillObligation:
@@ -179,13 +238,14 @@ def _evidence_ref(
     *,
     kind: str,
     receipt: dict[str, Any],
+    target: Path,
     obligation_id: str | None = None,
     check_id: str | None = None,
 ) -> dict[str, Any]:
     ref: dict[str, Any] = {
         "kind": kind,
         "run_id": receipt.get("run_id"),
-        "path": receipt.get("path"),
+        "path": _public_path(target, receipt.get("path")),
         "status": receipt.get("status"),
         "started_at": receipt.get("started_at"),
         "completed_at": receipt.get("completed_at"),
@@ -228,8 +288,8 @@ def _receipt_attribution(
     return "foreign"
 
 
-def _unattributed_ref(*, kind: str, receipt: dict[str, Any]) -> dict[str, Any]:
-    ref = _evidence_ref(kind=kind, receipt=receipt)
+def _unattributed_ref(*, kind: str, receipt: dict[str, Any], target: Path) -> dict[str, Any]:
+    ref = _evidence_ref(kind=kind, receipt=receipt, target=target)
     ref["attribution"] = "unattributed"
     return ref
 
@@ -278,7 +338,7 @@ def collect_receipt_evidence(
             if attribution == "attributed":
                 attributed[kind].append(receipt)
             elif attribution == "unattributed":
-                unattributed.append(_unattributed_ref(kind=kind, receipt=receipt))
+                unattributed.append(_unattributed_ref(kind=kind, receipt=receipt, target=target))
     return {
         "attributed": attributed,
         "unattributed": unattributed,
@@ -288,6 +348,8 @@ def collect_receipt_evidence(
 def match_obligation(
     obligation: SkillObligation,
     evidence: dict[str, list[dict[str, Any]]],
+    *,
+    target: Path,
 ) -> dict[str, Any] | None:
     """Return an evidence ref when captured receipts satisfy the obligation."""
     if obligation.kind == KIND_CHECK:
@@ -302,6 +364,7 @@ def match_obligation(
                 ref = _evidence_ref(
                     kind=KIND_CHECK,
                     receipt=receipt,
+                    target=target,
                     obligation_id=obligation.id,
                     check_id=command.get("check_id") if isinstance(command.get("check_id"), str) else None,
                 )
@@ -319,19 +382,34 @@ def match_obligation(
             return None
         for receipt in verify_receipts:
             if _verify_receipt_succeeded(receipt):
-                return _evidence_ref(kind=KIND_CHECK, receipt=receipt, obligation_id=obligation.id)
+                return _evidence_ref(
+                    kind=KIND_CHECK,
+                    receipt=receipt,
+                    target=target,
+                    obligation_id=obligation.id,
+                )
         return None
 
     if obligation.kind == KIND_REVIEW:
         for receipt in evidence.get(KIND_REVIEW) or []:
             if _review_receipt_succeeded(receipt):
-                return _evidence_ref(kind=KIND_REVIEW, receipt=receipt, obligation_id=obligation.id)
+                return _evidence_ref(
+                    kind=KIND_REVIEW,
+                    receipt=receipt,
+                    target=target,
+                    obligation_id=obligation.id,
+                )
         return None
 
     if obligation.kind == KIND_HANDOFF:
         for receipt in evidence.get(KIND_HANDOFF) or []:
             if _handoff_receipt_succeeded(receipt):
-                return _evidence_ref(kind=KIND_HANDOFF, receipt=receipt, obligation_id=obligation.id)
+                return _evidence_ref(
+                    kind=KIND_HANDOFF,
+                    receipt=receipt,
+                    target=target,
+                    obligation_id=obligation.id,
+                )
         return None
 
     return None
@@ -409,13 +487,15 @@ def build_audit_payload(
     skipped: list[dict[str, Any]] = []
     load_warnings: list[dict[str, Any]] = []
 
+    public_declared = [_public_skill_id(target, skill_id) for skill_id in declared_skill_ids]
     for skill_id in declared_skill_ids:
+        public_skill_id = _public_skill_id(target, skill_id)
         metadata, source, load_error = _load_skill_metadata(target, skill_id)
         if load_error is not None:
-            load_warnings.append({"skill_id": skill_id, "detail": load_error})
+            load_warnings.append({"skill_id": public_skill_id, "detail": load_error})
             skills.append(
                 {
-                    "skill_id": skill_id,
+                    "skill_id": public_skill_id,
                     "loaded": False,
                     "load_error": load_error,
                     "obligations": [],
@@ -425,9 +505,9 @@ def build_audit_payload(
             continue
         obligations, obligation_errors = parse_obligations(metadata)
         skill_row: dict[str, Any] = {
-            "skill_id": skill_id,
+            "skill_id": public_skill_id,
             "loaded": True,
-            "source": source,
+            "source": _public_source(target, source),
             "obligations": [item.to_dict() for item in obligations],
             "obligation_errors": obligation_errors,
         }
@@ -437,7 +517,7 @@ def build_audit_payload(
                 {
                     "id": f"skill-obligation-parse-{hashlib.sha256(f'{skill_id}:{message}'.encode()).hexdigest()[:12]}",
                     "finding_id": f"skill-obligation-parse-{hashlib.sha256(f'{skill_id}:{message}'.encode()).hexdigest()[:12]}",
-                    "skill_id": skill_id,
+                    "skill_id": public_skill_id,
                     "obligation_id": None,
                     "obligation_kind": None,
                     "required": False,
@@ -447,13 +527,13 @@ def build_audit_payload(
                     "safe_summary": message,
                     "detail": message,
                     "source_fingerprint": hashlib.sha256(f"{skill_id}:{message}".encode()).hexdigest()[:16],
-                    "suggested_next_command": f"brigade skills lint {skill_id}",
+                    "suggested_next_command": f"brigade skills lint {public_skill_id}",
                 }
             )
         for obligation in obligations:
-            match = match_obligation(obligation, attributed)
+            match = match_obligation(obligation, attributed, target=target)
             row = {
-                "skill_id": skill_id,
+                "skill_id": public_skill_id,
                 "obligation": obligation.to_dict(),
                 "evidence": match,
             }
@@ -461,12 +541,12 @@ def build_audit_payload(
                 satisfied.append(row)
                 continue
             detail = (
-                f"Skill {skill_id!r} declares required {obligation.kind} obligation "
+                f"Skill {public_skill_id!r} declares required {obligation.kind} obligation "
                 f"{obligation.id!r}, but no matching {obligation.kind} receipt was captured "
                 f"with producer_run_id={audited_run_id!r}."
             )
             if obligation.required:
-                findings.append(_finding(skill_id=skill_id, obligation=obligation, detail=detail))
+                findings.append(_finding(skill_id=public_skill_id, obligation=obligation, detail=detail))
             else:
                 skipped.append({**row, "detail": detail.replace("required ", "optional ")})
 
@@ -486,15 +566,16 @@ def build_audit_payload(
             str(item.get("id") or ""),
         )
     )
+    public_run_dir = _public_path(target, run_dir) or f".brigade/runs/{audited_run_id}"
     payload: dict[str, Any] = {
         "schema": AUDIT_SCHEMA,
         "schema_version": AUDIT_SCHEMA_VERSION,
-        "target": str(target),
-        "run_dir": str(run_dir),
+        "target": PUBLIC_TARGET,
+        "run_dir": public_run_dir,
         "run_id": audited_run_id,
         "result": result,
         "status": "warn" if findings else "ok",
-        "declared_skill_ids": declared_skill_ids,
+        "declared_skill_ids": public_declared,
         "skills": skills,
         "satisfied_count": len(satisfied),
         "satisfied": satisfied,
@@ -542,7 +623,7 @@ def audit(
 
     print(f"skills audit: {payload['result']}")
     print(f"target: {payload['target']}")
-    print(f"run: {payload['run_id']}")
+    print(f"run: {payload['run_dir']}")
     print(f"declared_skills: {len(payload['declared_skill_ids'])}")
     print(f"findings: {payload['finding_count']}")
     print(f"satisfied: {payload['satisfied_count']}")

--- a/src/brigade/skill_obligations.py
+++ b/src/brigade/skill_obligations.py
@@ -37,12 +37,20 @@ RESULT_NO_DECLARED_SKILLS = "no_declared_skills"
 RESULT_NO_OBLIGATIONS = "no_obligations"
 
 # Public audit output never prints host-private absolute paths. Paths under the
-# audited target are repo-relative; everything else collapses to external:<name>.
+# audited target are repo-relative; everything else collapses to a collision-
+# resistant external:<name>-<digest> label that cannot reveal the absolute path.
 PUBLIC_TARGET = "."
 
 
+def _external_public_label(stable_key: str, *, name_hint: str | None = None) -> str:
+    """Deterministic collision-resistant public label for a path outside root."""
+    name = Path(name_hint or stable_key).name or "path"
+    digest = hashlib.sha256(stable_key.encode("utf-8")).hexdigest()[:12]
+    return f"external:{name}-{digest}"
+
+
 def _public_path(root: Path, value: object) -> str | None:
-    """Stable public path label: repo-relative under root, else external:<name>."""
+    """Stable public path label: repo-relative under root, else external:<name>-<digest>."""
     if value is None:
         return None
     if not isinstance(value, (str, Path)):
@@ -55,13 +63,11 @@ def _public_path(root: Path, value: object) -> str | None:
     try:
         resolved = path.resolve() if path.is_absolute() else (root_resolved / path).resolve()
     except OSError:
-        name = Path(text).name or "path"
-        return f"external:{name}"
+        return _external_public_label(text, name_hint=Path(text).name or "path")
     try:
         relative = resolved.relative_to(root_resolved)
     except ValueError:
-        name = resolved.name or "path"
-        return f"external:{name}"
+        return _external_public_label(resolved.as_posix(), name_hint=resolved.name or "path")
     rendered = relative.as_posix()
     return rendered if rendered else PUBLIC_TARGET
 
@@ -446,15 +452,35 @@ def _finding(
     }
 
 
+def _public_load_error_text(root: Path, skill_id: str, message: str) -> str:
+    """Rewrite known private skill-selector paths out of load-error text."""
+    public_id = _public_skill_id(root, skill_id)
+    text = message
+    candidates: list[str] = [skill_id]
+    try:
+        resolved = Path(skill_id).expanduser().resolve()
+        candidates.append(str(resolved))
+        candidates.append(resolved.as_posix())
+    except OSError:
+        pass
+    # Replace longer spellings first so partial overlaps cannot leave a leak.
+    for candidate in sorted({item for item in candidates if item}, key=len, reverse=True):
+        if candidate in text:
+            text = text.replace(candidate, public_id)
+    return text
+
+
 def _load_skill_metadata(target: Path, skill_id: str) -> tuple[dict[str, Any], dict[str, Any] | None, str | None]:
     from . import skills_cmd
 
+    public_id = _public_skill_id(target, skill_id)
     try:
         skill_dir, metadata, source = skills_cmd._load_skill(target, skill_id)
     except Exception as exc:  # noqa: BLE001 - advisory path; surface load failure
-        return {}, None, f"skill not loadable: {exc}"
+        detail = _public_load_error_text(target, skill_id, f"skill not loadable: {exc}")
+        return {}, None, detail
     if not (skill_dir / "SKILL.md").is_file() and not (skill_dir / "skill.json").is_file():
-        return {}, None, f"skill not found: {skill_id}"
+        return {}, None, f"skill not found: {public_id}"
     return metadata if isinstance(metadata, dict) else {}, source, None
 
 

--- a/src/brigade/skill_obligations.py
+++ b/src/brigade/skill_obligations.py
@@ -1,0 +1,485 @@
+"""Advisory audit of declared skill process obligations vs captured receipts (#499).
+
+Compares skill.json ``obligations`` for skills bound on a Brigade run plan
+(``selected_skill_ids``) against verify, review, and handoff ingest receipts.
+
+Hard safety boundary:
+- Read-only: never writes run dirs, receipts, or skill registries.
+- Advisory: missing required evidence is a finding with exit 0.
+- Exit 2 only when the run cannot be resolved or inputs are unusable.
+
+Standard library only. Brigade is zero-runtime-dependency.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from . import localio
+
+AUDIT_SCHEMA = "brigade.skill_obligations_audit.v1"
+AUDIT_SCHEMA_VERSION = 1
+
+OBLIGATION_KINDS = frozenset({"check", "review", "handoff"})
+
+KIND_CHECK = "check"
+KIND_REVIEW = "review"
+KIND_HANDOFF = "handoff"
+
+RESULT_OK = "ok"
+RESULT_WARN = "warn"
+RESULT_NO_DECLARED_SKILLS = "no_declared_skills"
+RESULT_NO_OBLIGATIONS = "no_obligations"
+
+
+@dataclass(frozen=True)
+class SkillObligation:
+    """One process obligation declared on a skill pack."""
+
+    id: str
+    kind: str
+    required: bool = True
+    description: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "id": self.id,
+            "kind": self.kind,
+            "required": self.required,
+        }
+        if self.description:
+            payload["description"] = self.description
+        return payload
+
+
+def parse_obligations(metadata: dict[str, Any] | None) -> tuple[list[SkillObligation], list[str]]:
+    """Parse additive ``obligations`` from skill.json metadata.
+
+    Missing or empty ``obligations`` is valid (no process contract). Malformed
+    entries produce errors and are skipped so lint/audit can surface them.
+    """
+    if not isinstance(metadata, dict) or "obligations" not in metadata:
+        return [], []
+    raw = metadata.get("obligations")
+    if raw is None:
+        return [], []
+    if not isinstance(raw, list):
+        return [], ["metadata obligations must be a list"]
+    obligations: list[SkillObligation] = []
+    errors: list[str] = []
+    seen_ids: set[str] = set()
+    for index, item in enumerate(raw):
+        if not isinstance(item, dict):
+            errors.append(f"obligations[{index}] must be an object")
+            continue
+        obligation_id = item.get("id")
+        kind = item.get("kind")
+        if not isinstance(obligation_id, str) or not obligation_id.strip():
+            errors.append(f"obligations[{index}].id is required")
+            continue
+        obligation_id = obligation_id.strip()
+        if obligation_id in seen_ids:
+            errors.append(f"obligations[{index}].id is duplicated: {obligation_id}")
+            continue
+        if not isinstance(kind, str) or kind not in OBLIGATION_KINDS:
+            errors.append(f"obligations[{index}].kind must be one of {sorted(OBLIGATION_KINDS)}")
+            continue
+        required = item.get("required", True)
+        if not isinstance(required, bool):
+            errors.append(f"obligations[{index}].required must be a boolean when set")
+            continue
+        description = item.get("description")
+        if description is not None and (not isinstance(description, str) or not description.strip()):
+            errors.append(f"obligations[{index}].description must be a non-empty string when set")
+            continue
+        seen_ids.add(obligation_id)
+        obligations.append(
+            SkillObligation(
+                id=obligation_id,
+                kind=kind,
+                required=required,
+                description=description.strip() if isinstance(description, str) else None,
+            )
+        )
+    return obligations, errors
+
+
+def declared_skill_ids_from_plan(plan: dict[str, Any] | None) -> list[str]:
+    """Ordered unique skill ids from ``plan.json`` assignment bindings."""
+    if not isinstance(plan, dict):
+        return []
+    assignments = plan.get("assignments")
+    if not isinstance(assignments, list):
+        return []
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for assignment in assignments:
+        if not isinstance(assignment, dict):
+            continue
+        raw = assignment.get("selected_skill_ids")
+        if not isinstance(raw, list):
+            continue
+        for item in raw:
+            if not isinstance(item, str) or not item.strip():
+                continue
+            skill_id = item.strip()
+            if skill_id in seen:
+                continue
+            seen.add(skill_id)
+            ordered.append(skill_id)
+    return ordered
+
+
+def _receipt_timestamp(receipt: dict[str, Any]) -> str:
+    for key in ("completed_at", "started_at", "run_id"):
+        value = receipt.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def _verify_commands(receipt: dict[str, Any]) -> list[dict[str, Any]]:
+    commands = receipt.get("commands")
+    if not isinstance(commands, list):
+        return []
+    return [command for command in commands if isinstance(command, dict)]
+
+
+def _command_succeeded(command: dict[str, Any]) -> bool:
+    status = command.get("status")
+    exit_code = command.get("exit_code")
+    if status == "completed" and exit_code in (0, None):
+        return True
+    if status is None and exit_code == 0:
+        return True
+    return False
+
+
+def _verify_receipt_succeeded(receipt: dict[str, Any]) -> bool:
+    return receipt.get("status") == "completed"
+
+
+def _review_receipt_succeeded(receipt: dict[str, Any]) -> bool:
+    return receipt.get("status") == "completed" and receipt.get("exit_code") == 0
+
+
+def _handoff_receipt_succeeded(receipt: dict[str, Any]) -> bool:
+    processed = receipt.get("processed_handoff_paths")
+    if isinstance(processed, list) and any(isinstance(path, str) and path for path in processed):
+        return True
+    return receipt.get("status") == "ingested"
+
+
+def _evidence_ref(
+    *,
+    kind: str,
+    receipt: dict[str, Any],
+    obligation_id: str | None = None,
+    check_id: str | None = None,
+) -> dict[str, Any]:
+    ref: dict[str, Any] = {
+        "kind": kind,
+        "run_id": receipt.get("run_id"),
+        "path": receipt.get("path"),
+        "status": receipt.get("status"),
+        "started_at": receipt.get("started_at"),
+        "completed_at": receipt.get("completed_at"),
+    }
+    if obligation_id is not None:
+        ref["obligation_id"] = obligation_id
+    if check_id is not None:
+        ref["check_id"] = check_id
+    return ref
+
+
+def collect_receipt_evidence(target: Path) -> dict[str, list[dict[str, Any]]]:
+    """Load workspace verify / review / handoff receipts for obligation matching."""
+    from . import scorecard
+    from .handoff_cmd import drafts as handoff_drafts
+    from .work_cmd import reviews as reviews_mod
+
+    verify_receipts: list[dict[str, Any]] = []
+    for path in scorecard.discover_verify_receipt_paths(target):
+        receipt = localio.read_json_dict(path)
+        if not isinstance(receipt, dict):
+            continue
+        receipt = dict(receipt)
+        receipt.setdefault("path", str(path.parent))
+        verify_receipts.append(receipt)
+    verify_receipts.sort(key=_receipt_timestamp, reverse=True)
+
+    review_receipts = reviews_mod._review_receipts(target)
+    handoff_receipts = handoff_drafts._ingest_receipts(target)
+    return {
+        KIND_CHECK: verify_receipts,
+        KIND_REVIEW: review_receipts,
+        KIND_HANDOFF: handoff_receipts,
+    }
+
+
+def match_obligation(
+    obligation: SkillObligation,
+    evidence: dict[str, list[dict[str, Any]]],
+) -> dict[str, Any] | None:
+    """Return an evidence ref when captured receipts satisfy the obligation."""
+    if obligation.kind == KIND_CHECK:
+        verify_receipts = evidence.get(KIND_CHECK) or []
+        stamped_match: dict[str, Any] | None = None
+        stamped_failure: dict[str, Any] | None = None
+        for receipt in verify_receipts:
+            for command in _verify_commands(receipt):
+                stamped = command.get("obligation_id")
+                if stamped != obligation.id:
+                    continue
+                ref = _evidence_ref(
+                    kind=KIND_CHECK,
+                    receipt=receipt,
+                    obligation_id=obligation.id,
+                    check_id=command.get("check_id") if isinstance(command.get("check_id"), str) else None,
+                )
+                if _command_succeeded(command) and _verify_receipt_succeeded(receipt):
+                    stamped_match = ref
+                    break
+                stamped_failure = stamped_failure or ref
+            if stamped_match is not None:
+                break
+        if stamped_match is not None:
+            return stamped_match
+        if stamped_failure is not None:
+            # A stamped obligation_id that did not succeed does not fall back
+            # to an unrelated verify receipt.
+            return None
+        for receipt in verify_receipts:
+            if _verify_receipt_succeeded(receipt):
+                return _evidence_ref(kind=KIND_CHECK, receipt=receipt, obligation_id=obligation.id)
+        return None
+
+    if obligation.kind == KIND_REVIEW:
+        for receipt in evidence.get(KIND_REVIEW) or []:
+            if _review_receipt_succeeded(receipt):
+                return _evidence_ref(kind=KIND_REVIEW, receipt=receipt, obligation_id=obligation.id)
+        return None
+
+    if obligation.kind == KIND_HANDOFF:
+        for receipt in evidence.get(KIND_HANDOFF) or []:
+            if _handoff_receipt_succeeded(receipt):
+                return _evidence_ref(kind=KIND_HANDOFF, receipt=receipt, obligation_id=obligation.id)
+        return None
+
+    return None
+
+
+def _finding(
+    *,
+    skill_id: str,
+    obligation: SkillObligation,
+    detail: str,
+) -> dict[str, Any]:
+    seed = f"{skill_id}:{obligation.id}:{obligation.kind}:{detail}"
+    fingerprint = hashlib.sha256(seed.encode()).hexdigest()[:16]
+    finding_id = hashlib.sha256(f"skill-obligation-{seed}".encode()).hexdigest()[:12]
+    suggested = {
+        KIND_CHECK: 'brigade work verify run --target . --command "<proving command>"',
+        KIND_REVIEW: "brigade work review run --target .",
+        KIND_HANDOFF: "brigade handoff receipt record --target .",
+    }.get(obligation.kind)
+    return {
+        "id": f"skill-obligation-{finding_id}",
+        "finding_id": f"skill-obligation-{finding_id}",
+        "skill_id": skill_id,
+        "obligation_id": obligation.id,
+        "obligation_kind": obligation.kind,
+        "required": obligation.required,
+        "severity": "medium" if obligation.required else "low",
+        "status": "warn",
+        "title": f"Missing {obligation.kind} evidence for obligation {obligation.id}",
+        "safe_summary": detail,
+        "detail": detail,
+        "source_fingerprint": fingerprint,
+        "suggested_next_command": suggested,
+    }
+
+
+def _load_skill_metadata(target: Path, skill_id: str) -> tuple[dict[str, Any], dict[str, Any] | None, str | None]:
+    from . import skills_cmd
+
+    try:
+        skill_dir, metadata, source = skills_cmd._load_skill(target, skill_id)
+    except Exception as exc:  # noqa: BLE001 - advisory path; surface load failure
+        return {}, None, f"skill not loadable: {exc}"
+    if not (skill_dir / "SKILL.md").is_file() and not (skill_dir / "skill.json").is_file():
+        return {}, None, f"skill not found: {skill_id}"
+    return metadata if isinstance(metadata, dict) else {}, source, None
+
+
+def build_audit_payload(
+    *,
+    target: Path,
+    run: str | Path,
+    runs_dir: Path | None = None,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Build the advisory obligations audit payload for one Brigade run."""
+    from . import runs_cmd
+
+    target = target.expanduser().resolve()
+    run_dir, error = runs_cmd._resolve_run_dir(run, cwd=target, runs_dir=runs_dir)
+    if error is not None:
+        return None, error
+    assert run_dir is not None
+
+    plan = localio.read_json_dict(run_dir / "plan.json")
+    run_meta = localio.read_json_dict(run_dir / "run.json")
+    declared_skill_ids = declared_skill_ids_from_plan(plan if isinstance(plan, dict) else None)
+    evidence = collect_receipt_evidence(target)
+
+    skills: list[dict[str, Any]] = []
+    findings: list[dict[str, Any]] = []
+    satisfied: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    load_warnings: list[dict[str, Any]] = []
+
+    for skill_id in declared_skill_ids:
+        metadata, source, load_error = _load_skill_metadata(target, skill_id)
+        if load_error is not None:
+            load_warnings.append({"skill_id": skill_id, "detail": load_error})
+            skills.append(
+                {
+                    "skill_id": skill_id,
+                    "loaded": False,
+                    "load_error": load_error,
+                    "obligations": [],
+                    "obligation_errors": [],
+                }
+            )
+            continue
+        obligations, obligation_errors = parse_obligations(metadata)
+        skill_row: dict[str, Any] = {
+            "skill_id": skill_id,
+            "loaded": True,
+            "source": source,
+            "obligations": [item.to_dict() for item in obligations],
+            "obligation_errors": obligation_errors,
+        }
+        skills.append(skill_row)
+        for message in obligation_errors:
+            findings.append(
+                {
+                    "id": f"skill-obligation-parse-{hashlib.sha256(f'{skill_id}:{message}'.encode()).hexdigest()[:12]}",
+                    "finding_id": f"skill-obligation-parse-{hashlib.sha256(f'{skill_id}:{message}'.encode()).hexdigest()[:12]}",
+                    "skill_id": skill_id,
+                    "obligation_id": None,
+                    "obligation_kind": None,
+                    "required": False,
+                    "severity": "low",
+                    "status": "warn",
+                    "title": "Malformed skill obligation declaration",
+                    "safe_summary": message,
+                    "detail": message,
+                    "source_fingerprint": hashlib.sha256(f"{skill_id}:{message}".encode()).hexdigest()[:16],
+                    "suggested_next_command": f"brigade skills lint {skill_id}",
+                }
+            )
+        for obligation in obligations:
+            match = match_obligation(obligation, evidence)
+            row = {
+                "skill_id": skill_id,
+                "obligation": obligation.to_dict(),
+                "evidence": match,
+            }
+            if match is not None:
+                satisfied.append(row)
+                continue
+            detail = (
+                f"Skill {skill_id!r} declares required {obligation.kind} obligation "
+                f"{obligation.id!r}, but no matching {obligation.kind} receipt was captured."
+            )
+            if obligation.required:
+                findings.append(_finding(skill_id=skill_id, obligation=obligation, detail=detail))
+            else:
+                skipped.append({**row, "detail": detail.replace("required ", "optional ")})
+
+    if not declared_skill_ids:
+        result = RESULT_NO_DECLARED_SKILLS
+    elif not any(skill.get("obligations") for skill in skills):
+        result = RESULT_NO_OBLIGATIONS
+    elif findings:
+        result = RESULT_WARN
+    else:
+        result = RESULT_OK
+
+    findings.sort(
+        key=lambda item: (
+            str(item.get("skill_id") or ""),
+            str(item.get("obligation_id") or ""),
+            str(item.get("id") or ""),
+        )
+    )
+    payload: dict[str, Any] = {
+        "schema": AUDIT_SCHEMA,
+        "schema_version": AUDIT_SCHEMA_VERSION,
+        "target": str(target),
+        "run_dir": str(run_dir),
+        "run_id": run_dir.name if isinstance(run_meta, dict) else run_dir.name,
+        "result": result,
+        "status": "warn" if findings else "ok",
+        "declared_skill_ids": declared_skill_ids,
+        "skills": skills,
+        "satisfied_count": len(satisfied),
+        "satisfied": satisfied,
+        "skipped_optional": skipped,
+        "finding_count": len(findings),
+        "findings": findings,
+        "load_warnings": load_warnings,
+        "evidence_counts": {
+            KIND_CHECK: len(evidence.get(KIND_CHECK) or []),
+            KIND_REVIEW: len(evidence.get(KIND_REVIEW) or []),
+            KIND_HANDOFF: len(evidence.get(KIND_HANDOFF) or []),
+        },
+        "advisory": True,
+        "blocking": False,
+    }
+    if isinstance(run_meta, dict):
+        if isinstance(run_meta.get("started_at"), str):
+            payload["run_started_at"] = run_meta.get("started_at")
+        if isinstance(run_meta.get("completed_at"), str):
+            payload["run_completed_at"] = run_meta.get("completed_at")
+        if isinstance(run_meta.get("status"), str):
+            payload["run_status"] = run_meta.get("status")
+    return payload, None
+
+
+def audit(
+    *,
+    target: Path,
+    run: str | Path,
+    runs_dir: Path | None = None,
+    json_output: bool = False,
+) -> int:
+    """CLI entry: advisory skill-obligations audit. Exit 0 on success, 2 on resolve errors."""
+    payload, error = build_audit_payload(target=target, run=run, runs_dir=runs_dir)
+    if error is not None:
+        print(error, file=sys.stderr)
+        return 2
+    assert payload is not None
+    if json_output:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+
+    print(f"skills audit: {payload['result']}")
+    print(f"target: {payload['target']}")
+    print(f"run: {payload['run_id']}")
+    print(f"declared_skills: {len(payload['declared_skill_ids'])}")
+    print(f"findings: {payload['finding_count']}")
+    print(f"satisfied: {payload['satisfied_count']}")
+    if payload["result"] == RESULT_NO_DECLARED_SKILLS:
+        print("note: plan.json has no selected_skill_ids; nothing to audit")
+    elif payload["result"] == RESULT_NO_OBLIGATIONS:
+        print("note: declared skills have no process obligations")
+    for finding in payload["findings"]:
+        print(f"- {finding['skill_id']}:{finding.get('obligation_id') or 'parse'} {finding['title']}")
+    return 0

--- a/src/brigade/skill_obligations.py
+++ b/src/brigade/skill_obligations.py
@@ -17,6 +17,7 @@ import hashlib
 import json
 import sys
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -197,8 +198,45 @@ def _evidence_ref(
     return ref
 
 
-def collect_receipt_evidence(target: Path) -> dict[str, list[dict[str, Any]]]:
-    """Load workspace verify / review / handoff receipts for obligation matching."""
+def _run_window_bounds(run_meta: dict[str, Any] | None) -> tuple[datetime | None, datetime | None]:
+    """Return UTC bounds for receipts eligible for one Brigade run audit."""
+    if not isinstance(run_meta, dict):
+        return None, None
+    started = localio.parse_iso_datetime(run_meta.get("started_at"))
+    ended = localio.parse_iso_datetime(run_meta.get("finished_at"))
+    if ended is None:
+        ended = localio.parse_iso_datetime(run_meta.get("completed_at"))
+    return started, ended
+
+
+def _receipt_started_at(receipt: dict[str, Any]) -> datetime | None:
+    return localio.parse_iso_datetime(receipt.get("started_at"))
+
+
+def _receipt_in_run_window(
+    receipt: dict[str, Any],
+    *,
+    run_started_at: datetime | None,
+    run_ended_at: datetime | None,
+) -> bool:
+    """Match receipts to the audited run using the same started_at convention as aboyeur ground truth."""
+    if run_started_at is None:
+        return False
+    receipt_started_at = _receipt_started_at(receipt)
+    if receipt_started_at is None or receipt_started_at < run_started_at:
+        return False
+    if run_ended_at is not None and receipt_started_at > run_ended_at:
+        return False
+    return True
+
+
+def collect_receipt_evidence(
+    target: Path,
+    *,
+    run_started_at: datetime | None = None,
+    run_ended_at: datetime | None = None,
+) -> dict[str, list[dict[str, Any]]]:
+    """Load verify / review / handoff receipts eligible for one Brigade run audit."""
     from . import scorecard
     from .handoff_cmd import drafts as handoff_drafts
     from .work_cmd import reviews as reviews_mod
@@ -210,11 +248,33 @@ def collect_receipt_evidence(target: Path) -> dict[str, list[dict[str, Any]]]:
             continue
         receipt = dict(receipt)
         receipt.setdefault("path", str(path.parent))
+        if not _receipt_in_run_window(
+            receipt,
+            run_started_at=run_started_at,
+            run_ended_at=run_ended_at,
+        ):
+            continue
         verify_receipts.append(receipt)
     verify_receipts.sort(key=_receipt_timestamp, reverse=True)
 
-    review_receipts = reviews_mod._review_receipts(target)
-    handoff_receipts = handoff_drafts._ingest_receipts(target)
+    review_receipts = [
+        receipt
+        for receipt in reviews_mod._review_receipts(target)
+        if _receipt_in_run_window(
+            receipt,
+            run_started_at=run_started_at,
+            run_ended_at=run_ended_at,
+        )
+    ]
+    handoff_receipts = [
+        receipt
+        for receipt in handoff_drafts._ingest_receipts(target)
+        if _receipt_in_run_window(
+            receipt,
+            run_started_at=run_started_at,
+            run_ended_at=run_ended_at,
+        )
+    ]
     return {
         KIND_CHECK: verify_receipts,
         KIND_REVIEW: review_receipts,
@@ -335,7 +395,12 @@ def build_audit_payload(
     plan = localio.read_json_dict(run_dir / "plan.json")
     run_meta = localio.read_json_dict(run_dir / "run.json")
     declared_skill_ids = declared_skill_ids_from_plan(plan if isinstance(plan, dict) else None)
-    evidence = collect_receipt_evidence(target)
+    run_started_at, run_ended_at = _run_window_bounds(run_meta if isinstance(run_meta, dict) else None)
+    evidence = collect_receipt_evidence(
+        target,
+        run_started_at=run_started_at,
+        run_ended_at=run_ended_at,
+    )
 
     skills: list[dict[str, Any]] = []
     findings: list[dict[str, Any]] = []

--- a/src/brigade/skill_obligations.py
+++ b/src/brigade/skill_obligations.py
@@ -17,7 +17,6 @@ import hashlib
 import json
 import sys
 from dataclasses import dataclass
-from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -191,6 +190,9 @@ def _evidence_ref(
         "started_at": receipt.get("started_at"),
         "completed_at": receipt.get("completed_at"),
     }
+    producer_run_id = receipt.get("producer_run_id")
+    if isinstance(producer_run_id, str) and producer_run_id:
+        ref["producer_run_id"] = producer_run_id
     if obligation_id is not None:
         ref["obligation_id"] = obligation_id
     if check_id is not None:
@@ -198,87 +200,88 @@ def _evidence_ref(
     return ref
 
 
-def _run_window_bounds(run_meta: dict[str, Any] | None) -> tuple[datetime | None, datetime | None]:
-    """Return UTC bounds for receipts eligible for one Brigade run audit."""
-    if not isinstance(run_meta, dict):
-        return None, None
-    started = localio.parse_iso_datetime(run_meta.get("started_at"))
-    ended = localio.parse_iso_datetime(run_meta.get("finished_at"))
-    if ended is None:
-        ended = localio.parse_iso_datetime(run_meta.get("completed_at"))
-    return started, ended
+def _receipt_producer_run_id(receipt: dict[str, Any]) -> str | None:
+    value = receipt.get("producer_run_id")
+    if isinstance(value, str):
+        cleaned = value.strip()
+        if cleaned:
+            return cleaned
+    return None
 
 
-def _receipt_started_at(receipt: dict[str, Any]) -> datetime | None:
-    return localio.parse_iso_datetime(receipt.get("started_at"))
-
-
-def _receipt_in_run_window(
+def _receipt_attribution(
     receipt: dict[str, Any],
     *,
-    run_started_at: datetime | None,
-    run_ended_at: datetime | None,
-) -> bool:
-    """Match receipts to the audited run using the same started_at convention as aboyeur ground truth."""
-    if run_started_at is None:
-        return False
-    receipt_started_at = _receipt_started_at(receipt)
-    if receipt_started_at is None or receipt_started_at < run_started_at:
-        return False
-    if run_ended_at is not None and receipt_started_at > run_ended_at:
-        return False
-    return True
+    audited_run_id: str,
+) -> str:
+    """Classify a receipt relative to the audited orchestrator run.
+
+    Exact ``producer_run_id`` equality attributes the receipt. Missing
+    ``producer_run_id`` is legacy/unattributed and never satisfies. A different
+    stamped id is foreign (wrong-run); timestamp proximity must not attribute.
+    """
+    producer_run_id = _receipt_producer_run_id(receipt)
+    if producer_run_id is None:
+        return "unattributed"
+    if producer_run_id == audited_run_id:
+        return "attributed"
+    return "foreign"
+
+
+def _unattributed_ref(*, kind: str, receipt: dict[str, Any]) -> dict[str, Any]:
+    ref = _evidence_ref(kind=kind, receipt=receipt)
+    ref["attribution"] = "unattributed"
+    return ref
 
 
 def collect_receipt_evidence(
     target: Path,
     *,
-    run_started_at: datetime | None = None,
-    run_ended_at: datetime | None = None,
-) -> dict[str, list[dict[str, Any]]]:
-    """Load verify / review / handoff receipts eligible for one Brigade run audit."""
+    audited_run_id: str,
+) -> dict[str, Any]:
+    """Load verify / review / handoff receipts and partition by producer_run_id.
+
+    Only receipts with ``producer_run_id`` equal to ``audited_run_id`` can
+    satisfy per-run obligations. Legacy receipts without the field are listed
+    as unattributed and remain visible without satisfying.
+    """
     from . import scorecard
     from .handoff_cmd import drafts as handoff_drafts
     from .work_cmd import reviews as reviews_mod
 
-    verify_receipts: list[dict[str, Any]] = []
+    verify_all: list[dict[str, Any]] = []
     for path in scorecard.discover_verify_receipt_paths(target):
         receipt = localio.read_json_dict(path)
         if not isinstance(receipt, dict):
             continue
         receipt = dict(receipt)
         receipt.setdefault("path", str(path.parent))
-        if not _receipt_in_run_window(
-            receipt,
-            run_started_at=run_started_at,
-            run_ended_at=run_ended_at,
-        ):
-            continue
-        verify_receipts.append(receipt)
-    verify_receipts.sort(key=_receipt_timestamp, reverse=True)
+        verify_all.append(receipt)
+    verify_all.sort(key=_receipt_timestamp, reverse=True)
 
-    review_receipts = [
-        receipt
-        for receipt in reviews_mod._review_receipts(target)
-        if _receipt_in_run_window(
-            receipt,
-            run_started_at=run_started_at,
-            run_ended_at=run_ended_at,
-        )
-    ]
-    handoff_receipts = [
-        receipt
-        for receipt in handoff_drafts._ingest_receipts(target)
-        if _receipt_in_run_window(
-            receipt,
-            run_started_at=run_started_at,
-            run_ended_at=run_ended_at,
-        )
-    ]
+    review_all = list(reviews_mod._review_receipts(target))
+    handoff_all = list(handoff_drafts._ingest_receipts(target))
+
+    attributed: dict[str, list[dict[str, Any]]] = {
+        KIND_CHECK: [],
+        KIND_REVIEW: [],
+        KIND_HANDOFF: [],
+    }
+    unattributed: list[dict[str, Any]] = []
+    for kind, receipts in (
+        (KIND_CHECK, verify_all),
+        (KIND_REVIEW, review_all),
+        (KIND_HANDOFF, handoff_all),
+    ):
+        for receipt in receipts:
+            attribution = _receipt_attribution(receipt, audited_run_id=audited_run_id)
+            if attribution == "attributed":
+                attributed[kind].append(receipt)
+            elif attribution == "unattributed":
+                unattributed.append(_unattributed_ref(kind=kind, receipt=receipt))
     return {
-        KIND_CHECK: verify_receipts,
-        KIND_REVIEW: review_receipts,
-        KIND_HANDOFF: handoff_receipts,
+        "attributed": attributed,
+        "unattributed": unattributed,
     }
 
 
@@ -395,12 +398,10 @@ def build_audit_payload(
     plan = localio.read_json_dict(run_dir / "plan.json")
     run_meta = localio.read_json_dict(run_dir / "run.json")
     declared_skill_ids = declared_skill_ids_from_plan(plan if isinstance(plan, dict) else None)
-    run_started_at, run_ended_at = _run_window_bounds(run_meta if isinstance(run_meta, dict) else None)
-    evidence = collect_receipt_evidence(
-        target,
-        run_started_at=run_started_at,
-        run_ended_at=run_ended_at,
-    )
+    audited_run_id = run_dir.name
+    evidence_bundle = collect_receipt_evidence(target, audited_run_id=audited_run_id)
+    attributed = evidence_bundle["attributed"]
+    unattributed = evidence_bundle["unattributed"]
 
     skills: list[dict[str, Any]] = []
     findings: list[dict[str, Any]] = []
@@ -450,7 +451,7 @@ def build_audit_payload(
                 }
             )
         for obligation in obligations:
-            match = match_obligation(obligation, evidence)
+            match = match_obligation(obligation, attributed)
             row = {
                 "skill_id": skill_id,
                 "obligation": obligation.to_dict(),
@@ -461,7 +462,8 @@ def build_audit_payload(
                 continue
             detail = (
                 f"Skill {skill_id!r} declares required {obligation.kind} obligation "
-                f"{obligation.id!r}, but no matching {obligation.kind} receipt was captured."
+                f"{obligation.id!r}, but no matching {obligation.kind} receipt was captured "
+                f"with producer_run_id={audited_run_id!r}."
             )
             if obligation.required:
                 findings.append(_finding(skill_id=skill_id, obligation=obligation, detail=detail))
@@ -489,7 +491,7 @@ def build_audit_payload(
         "schema_version": AUDIT_SCHEMA_VERSION,
         "target": str(target),
         "run_dir": str(run_dir),
-        "run_id": run_dir.name if isinstance(run_meta, dict) else run_dir.name,
+        "run_id": audited_run_id,
         "result": result,
         "status": "warn" if findings else "ok",
         "declared_skill_ids": declared_skill_ids,
@@ -501,12 +503,15 @@ def build_audit_payload(
         "findings": findings,
         "load_warnings": load_warnings,
         "evidence_counts": {
-            KIND_CHECK: len(evidence.get(KIND_CHECK) or []),
-            KIND_REVIEW: len(evidence.get(KIND_REVIEW) or []),
-            KIND_HANDOFF: len(evidence.get(KIND_HANDOFF) or []),
+            KIND_CHECK: len(attributed.get(KIND_CHECK) or []),
+            KIND_REVIEW: len(attributed.get(KIND_REVIEW) or []),
+            KIND_HANDOFF: len(attributed.get(KIND_HANDOFF) or []),
         },
+        "unattributed_receipt_count": len(unattributed),
+        "unattributed_receipts": unattributed,
         "advisory": True,
         "blocking": False,
+        "matching": "producer_run_id",
     }
     if isinstance(run_meta, dict):
         if isinstance(run_meta.get("started_at"), str):
@@ -541,10 +546,16 @@ def audit(
     print(f"declared_skills: {len(payload['declared_skill_ids'])}")
     print(f"findings: {payload['finding_count']}")
     print(f"satisfied: {payload['satisfied_count']}")
+    print(f"unattributed_receipts: {payload['unattributed_receipt_count']}")
     if payload["result"] == RESULT_NO_DECLARED_SKILLS:
         print("note: plan.json has no selected_skill_ids; nothing to audit")
     elif payload["result"] == RESULT_NO_OBLIGATIONS:
         print("note: declared skills have no process obligations")
     for finding in payload["findings"]:
         print(f"- {finding['skill_id']}:{finding.get('obligation_id') or 'parse'} {finding['title']}")
+    for item in payload["unattributed_receipts"]:
+        print(
+            f"- unattributed:{item.get('kind')} run_id={item.get('run_id')} "
+            "(legacy receipt lacks producer_run_id; cannot satisfy per-run obligation)"
+        )
     return 0

--- a/src/brigade/skills_cmd.py
+++ b/src/brigade/skills_cmd.py
@@ -581,6 +581,11 @@ def _lint_payload(
     for key in ("required_tools", "required_mcp_servers", "supported_harnesses", "tests"):
         if key in metadata and not isinstance(metadata[key], list):
             errors.append(f"metadata {key} must be a list")
+    if "obligations" in metadata:
+        from . import skill_obligations
+
+        _, obligation_errors = skill_obligations.parse_obligations(metadata)
+        errors.extend(obligation_errors)
     format_result = agent_skill_format.validate(skill_dir, mode=mode)
     errors.extend(format_result.errors)
     warnings.extend(format_result.diagnostics)

--- a/src/brigade/templates/skills/brigade-work/CHANGELOG.md
+++ b/src/brigade/templates/skills/brigade-work/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## 0.1.0
 
 - Initial bundled brigade-work skill: routes verification, outcomes, evidence export, and handoffs through Brigade.
+- Declares process obligations (`verify-through-brigade`, `session-handoff`) for the advisory skills audit (#499).

--- a/src/brigade/templates/skills/brigade-work/skill.json
+++ b/src/brigade/templates/skills/brigade-work/skill.json
@@ -3,5 +3,19 @@
   "title": "brigade-work",
   "version": "0.1.0",
   "description": "Route work through Brigade so verification, outcomes, evidence export, and handoffs are captured instead of leaving Brigade installed-but-dormant.",
-  "tests": ["brigade skills lint brigade-work"]
+  "tests": ["brigade skills lint brigade-work"],
+  "obligations": [
+    {
+      "id": "verify-through-brigade",
+      "kind": "check",
+      "required": true,
+      "description": "Run proving checks through brigade work verify so a signed verify receipt exists."
+    },
+    {
+      "id": "session-handoff",
+      "kind": "handoff",
+      "required": true,
+      "description": "Capture end-of-session durable knowledge via a handoff ingest receipt."
+    }
+  ]
 }

--- a/src/brigade/work_cmd/reviews.py
+++ b/src/brigade/work_cmd/reviews.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
-from .. import dogfood_cmd
+from .. import dogfood_cmd, receipt_schema
 from ..install import apply_gitignore
 from . import constants, helpers, ledger as ledger_mod, config as config_mod
 from . import scanners as scanners_mod
@@ -283,6 +283,7 @@ def _review_run_one(target: Path, reviewer: dict[str, Any]) -> dict[str, Any]:
         "supported_modes": reviewer.get("supported_modes") or [],
         "privacy_mode": reviewer.get("privacy_mode"),
     }
+    receipt_schema.stamp_optional_producer_run_id(receipt)
     helpers._write_json(receipt_path, receipt)
     if blocker is not None:
         completed = helpers._now()

--- a/src/brigade/work_cmd/verification.py
+++ b/src/brigade/work_cmd/verification.py
@@ -1538,6 +1538,7 @@ def _run_verify_commands(
             "planned_commands": _planned_commands_display(commands),
         }
         receipt.update(identity)
+        receipt_schema.stamp_optional_producer_run_id(receipt)
         _stamp_harness_session(receipt)
         _stamp_outcome_capture(receipt, capture, capture_kind)
         try:
@@ -1697,6 +1698,7 @@ def _write_reused_receipt(
         "planned_commands": planned_display,
     }
     receipt.update(identity)
+    receipt_schema.stamp_optional_producer_run_id(receipt)
     _stamp_harness_session(receipt)
     _stamp_outcome_capture(receipt, capture, capture_kind)
     reused_from = latest.get("run_id")

--- a/tests/test_codex_appserver.py
+++ b/tests/test_codex_appserver.py
@@ -247,3 +247,49 @@ def test_windows_appserver_uses_group_and_registry_tree_termination(monkeypatch)
     assert captured["creationflags"] == getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200)
     assert "start_new_session" not in captured
     assert events == [("register", 4242), ("terminate", 4242), ("unregister", 4242)]
+
+
+def test_appserver_env_reaches_child_without_seat_env(monkeypatch):
+    """Run-scoped identity can ride AppServer process env (not per-seat env)."""
+    from brigade import receipt_schema
+
+    captured = {}
+
+    class StubProcess:
+        pid = 4242
+
+    class StubRegistry:
+        def register(self, process):
+            pass
+
+        def terminate(self, process):
+            pass
+
+        def unregister(self, process):
+            pass
+
+    class StubThread:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            pass
+
+    def fake_popen(*args, **kwargs):
+        captured.update(kwargs)
+        return StubProcess()
+
+    server = codex_appserver.AppServer(
+        argv=["codex", "app-server"],
+        process_registry=StubRegistry(),
+        env={receipt_schema.BRIGADE_RUN_ID_ENV: "orch-appserver-1"},
+    )
+    monkeypatch.setattr(codex_appserver.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(codex_appserver.threading, "Thread", StubThread)
+    monkeypatch.setattr(server, "request", lambda *args, **kwargs: {})
+    monkeypatch.setattr(server, "_send", lambda *args, **kwargs: None)
+
+    server.start()
+    server.close()
+
+    assert captured["env"][receipt_schema.BRIGADE_RUN_ID_ENV] == "orch-appserver-1"

--- a/tests/test_producer_run_id.py
+++ b/tests/test_producer_run_id.py
@@ -1,0 +1,292 @@
+"""producer_run_id transport + receipt producer coverage (#499)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from brigade import acpx_adapter, agents, handoff_cmd, receipt_schema, run_transport, work_cmd
+from brigade.roster import Agent, Roster
+from brigade.run_transport import Assignment
+from brigade.work_cmd import reviews as reviews_mod
+
+
+def _roster(env=None):
+    chef = Agent(name="chef", cli="codex", role="plan")
+    worker = Agent(name="k3", cli="claude", role="worker", model="kimi-k3", env=env)
+    return Roster(orchestrator="chef", agents={"chef": chef, "k3": worker})
+
+
+def _dispatch(roster, monkeypatch, captured, *, run_id=None):
+    def fake_run(argv, **kw):
+        captured["env"] = kw.get("env")
+        return agents.proc.Result(0, "worker answer", "")
+
+    monkeypatch.setattr(agents.proc, "which", lambda c: "/x/" + c)
+    monkeypatch.setattr(agents.proc, "run", fake_run)
+    return run_transport.dispatch(
+        [Assignment(worker="k3", task="do the thing")],
+        roster,
+        build_prompt=lambda agent, assignment, **kw: assignment.task,
+        run_appserver_worker=lambda *a, **kw: agents.AgentResult(text="", ok=False, detail="unused"),
+        event_writer=lambda events_dir, worker, verbose=False: None,
+        read_only=True,
+        run_id=run_id,
+    )
+
+
+def test_worker_env_receives_brigade_run_id_without_seat_env(monkeypatch):
+    captured = {}
+    results = _dispatch(_roster(None), monkeypatch, captured, run_id="orch-run-1")
+    assert results[0].ok
+    assert captured["env"][receipt_schema.BRIGADE_RUN_ID_ENV] == "orch-run-1"
+    assert results[0].env_overrides == ()
+
+
+def test_worker_env_merges_brigade_run_id_with_seat_env(monkeypatch):
+    monkeypatch.setenv("LANE_KEY", "sk-lane-value")
+    captured = {}
+    roster = _roster(
+        {
+            "ANTHROPIC_BASE_URL": "https://api.example.com/anthropic",
+            "ANTHROPIC_AUTH_TOKEN_REF": "LANE_KEY",
+        }
+    )
+    results = _dispatch(roster, monkeypatch, captured, run_id="orch-run-2")
+    assert results[0].ok
+    env = captured["env"]
+    assert env[receipt_schema.BRIGADE_RUN_ID_ENV] == "orch-run-2"
+    assert env["ANTHROPIC_BASE_URL"] == "https://api.example.com/anthropic"
+    assert env["ANTHROPIC_AUTH_TOKEN"] == "sk-lane-value"
+    assert "sk-lane-value" not in str(results[0])
+
+
+def test_worker_without_run_id_keeps_legacy_env_none(monkeypatch):
+    captured = {}
+    results = _dispatch(_roster(None), monkeypatch, captured, run_id=None)
+    assert results[0].ok
+    assert captured["env"] is None
+
+
+def test_acpx_worker_receives_brigade_run_id(monkeypatch, tmp_path):
+    captured = {}
+    roster = Roster(
+        orchestrator="chef",
+        agents={
+            "chef": Agent(name="chef", cli="codex", role="plan"),
+            "composer": Agent(
+                name="composer",
+                cli="cursor",
+                role="worker",
+                transport="acpx",
+                transport_version="0.12.0",
+                model="composer-2.5",
+            ),
+        },
+    )
+
+    def fake_run_cursor(prompt, **kwargs):
+        captured["env"] = kwargs.get("env")
+        return agents.AgentResult(text="done", ok=True)
+
+    monkeypatch.setattr(acpx_adapter, "run_cursor", fake_run_cursor)
+    result = run_transport.dispatch(
+        [Assignment(worker="composer", task="do the thing")],
+        roster,
+        build_prompt=lambda agent, assignment, **kw: assignment.task,
+        run_appserver_worker=lambda *a, **kw: agents.AgentResult(text="", ok=False, detail="unused"),
+        event_writer=lambda events_dir, worker, verbose=False: None,
+        cwd=tmp_path,
+        read_only=True,
+        run_id="orch-acpx-1",
+    )[0]
+    assert result.ok
+    assert captured["env"][receipt_schema.BRIGADE_RUN_ID_ENV] == "orch-acpx-1"
+
+
+def _init_git(tmp_path: Path) -> None:
+    import subprocess
+
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.email", "dev@example.com"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "Dev"], cwd=tmp_path, check=True)
+    (tmp_path / "README.md").write_text("ok\n")
+    subprocess.run(["git", "add", "README.md"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=tmp_path, check=True)
+
+
+def test_verify_producer_stamps_and_omits_producer_run_id(tmp_path, monkeypatch, capsys):
+    _init_git(tmp_path)
+    monkeypatch.delenv(receipt_schema.BRIGADE_RUN_ID_ENV, raising=False)
+    assert (
+        work_cmd.verify_run(
+            target=tmp_path,
+            commands=[f"{sys.executable} -c \"print('ok')\""],
+            timeout=30,
+            json_output=True,
+        )
+        == 0
+    )
+    receipt = json.loads(capsys.readouterr().out)
+    assert "producer_run_id" not in receipt
+
+    monkeypatch.setenv(receipt_schema.BRIGADE_RUN_ID_ENV, "orch-verify-1")
+    assert (
+        work_cmd.verify_run(
+            target=tmp_path,
+            commands=[f"{sys.executable} -c \"print('ok')\""],
+            timeout=30,
+            json_output=True,
+        )
+        == 0
+    )
+    stamped = json.loads(capsys.readouterr().out)
+    assert stamped["producer_run_id"] == "orch-verify-1"
+    serialized = json.dumps(stamped)
+    assert "OPENAI_API_KEY" not in serialized
+    assert "sk-" not in serialized
+
+
+def test_review_producer_stamps_and_omits_producer_run_id(tmp_path, monkeypatch):
+    monkeypatch.delenv(receipt_schema.BRIGADE_RUN_ID_ENV, raising=False)
+    reviewer = {
+        "id": "local",
+        "name": "local",
+        "command": f"{sys.executable} -c \"print('review ok')\"",
+        "timeout": 30,
+        "cwd": str(tmp_path),
+    }
+    receipt = reviews_mod._review_run_one(tmp_path, reviewer)
+    assert "producer_run_id" not in receipt
+
+    monkeypatch.setenv(receipt_schema.BRIGADE_RUN_ID_ENV, "orch-review-1")
+    stamped = reviews_mod._review_run_one(tmp_path, reviewer)
+    assert stamped["producer_run_id"] == "orch-review-1"
+
+
+_NO_CARD_HANDOFF = """# Memory Handoff
+
+## Type
+learning
+
+## Title
+Producer run id handoff
+
+## Summary
+Handoff producer stamps optional producer_run_id.
+
+## Recommended memory action
+no-card
+
+## Target document
+.learnings/LEARNINGS.md
+
+## Suggested document content
+### Producer run id handoff
+
+Durable fact for producer_run_id coverage.
+"""
+
+
+def test_handoff_producer_stamps_and_omits_producer_run_id(tmp_path, monkeypatch, capsys):
+    inbox = tmp_path / ".hermes" / "memory-handoffs"
+    inbox.mkdir(parents=True)
+    (inbox / "demo.md").write_text(_NO_CARD_HANDOFF)
+    monkeypatch.delenv(receipt_schema.BRIGADE_RUN_ID_ENV, raising=False)
+    assert (
+        handoff_cmd.receipt_record(
+            target=tmp_path,
+            draft_ids=["demo"],
+            owner="test",
+            run_id="handoff-no-orch",
+            json_output=True,
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    receipt = json.loads(Path(payload["receipt_path"]).read_text())
+    assert "producer_run_id" not in receipt
+
+    monkeypatch.setenv(receipt_schema.BRIGADE_RUN_ID_ENV, "orch-handoff-1")
+    assert (
+        handoff_cmd.receipt_record(
+            target=tmp_path,
+            draft_ids=["demo"],
+            owner="test",
+            run_id="handoff-with-orch",
+            json_output=True,
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    stamped = json.loads(Path(payload["receipt_path"]).read_text())
+    assert stamped["producer_run_id"] == "orch-handoff-1"
+
+
+def test_skills_audit_text_output_labels_unattributed_without_secrets(tmp_path, capsys, monkeypatch):
+    from brigade import skill_obligations
+
+    def write_json(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+    skill_dir = tmp_path / ".brigade" / "skills" / "registry" / "demo-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: demo-skill\ndescription: x\n---\n\n# demo\n")
+    write_json(
+        skill_dir / "skill.json",
+        {
+            "id": "demo-skill",
+            "title": "demo",
+            "version": "0.1.0",
+            "description": "demo",
+            "tests": ["brigade skills lint demo-skill"],
+            "obligations": [{"id": "fresh-verify", "kind": "check", "required": True}],
+        },
+    )
+    run_dir = tmp_path / ".brigade" / "runs" / "20260801-audit-text"
+    run_dir.mkdir(parents=True)
+    write_json(
+        run_dir / "run.json",
+        {"run_id": run_dir.name, "status": "completed", "started_at": "2026-08-01T00:00:00Z"},
+    )
+    write_json(
+        run_dir / "plan.json",
+        {
+            "schema": "brigade.run_plan.v1",
+            "schema_version": 1,
+            "assignments": [
+                {
+                    "stage": 1,
+                    "worker": "coder",
+                    "task": "do work",
+                    "covers": ["implement"],
+                    "selected_skill_ids": ["demo-skill"],
+                }
+            ],
+        },
+    )
+    write_json(
+        tmp_path / ".brigade" / "work" / "verify-runs" / "verify-legacy" / "receipt.json",
+        {
+            "run_id": "verify-legacy",
+            "status": "completed",
+            "started_at": "2026-08-01T00:10:00Z",
+            "commands": [
+                {
+                    "command": "pytest -q",
+                    "status": "completed",
+                    "exit_code": 0,
+                    "obligation_id": "fresh-verify",
+                }
+            ],
+        },
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-secret-should-not-leak")
+    assert skill_obligations.audit(target=tmp_path, run=run_dir, json_output=False) == 0
+    out = capsys.readouterr().out
+    assert "unattributed" in out
+    assert "producer_run_id" in out
+    assert "sk-secret-should-not-leak" not in out
+    assert "OPENAI_API_KEY" not in out

--- a/tests/test_producer_run_id.py
+++ b/tests/test_producer_run_id.py
@@ -386,3 +386,6 @@ def test_skills_audit_text_output_labels_unattributed_without_secrets(tmp_path, 
     assert "producer_run_id" in out
     assert "sk-secret-should-not-leak" not in out
     assert "OPENAI_API_KEY" not in out
+    assert str(tmp_path.resolve()) not in out
+    assert f"target: {skill_obligations.PUBLIC_TARGET}" in out
+    assert f"run: .brigade/runs/{run_dir.name}" in out

--- a/tests/test_producer_run_id.py
+++ b/tests/test_producer_run_id.py
@@ -6,10 +6,11 @@ import json
 import sys
 from pathlib import Path
 
-from brigade import acpx_adapter, agents, handoff_cmd, receipt_schema, run_transport, work_cmd
+from brigade import aboyeur, acpx_adapter, agents, handoff_cmd, receipt_schema, run_transport, work_cmd
 from brigade.roster import Agent, Roster
 from brigade.run_transport import Assignment
 from brigade.work_cmd import reviews as reviews_mod
+from tests.run_test_helpers import run_aboyeur_guarded
 
 
 def _roster(env=None):
@@ -103,6 +104,101 @@ def test_acpx_worker_receives_brigade_run_id(monkeypatch, tmp_path):
     )[0]
     assert result.ok
     assert captured["env"][receipt_schema.BRIGADE_RUN_ID_ENV] == "orch-acpx-1"
+
+
+def _legacy_aboyeur_roster():
+    """Match test_aboyeur doubles: worker has cli but no seat model/env."""
+    chef = Agent(name="chef", cli="codex", role="plan")
+    coder = Agent(name="coder", cli="ollama:llama3.3", role="worker")
+    return Roster(orchestrator="chef", agents={"chef": chef, "coder": coder})
+
+
+def test_dispatch_tolerates_run_agent_without_env_kwarg(monkeypatch):
+    """GitHub job 93432928418: fixed-signature fakes must not crash on run_id."""
+
+    def fake_run_agent(cli_ref, prompt, timeout=600.0, cwd=None, read_only=False):
+        return agents.AgentResult(text="legacy-ok", ok=True)
+
+    monkeypatch.setattr(agents, "run_agent", fake_run_agent)
+    results = run_transport.dispatch(
+        [Assignment(worker="coder", task="do the thing")],
+        _legacy_aboyeur_roster(),
+        build_prompt=lambda agent, assignment, **kw: assignment.task,
+        run_appserver_worker=lambda *a, **kw: agents.AgentResult(text="", ok=False, detail="unused"),
+        event_writer=lambda events_dir, worker, verbose=False: None,
+        read_only=True,
+        run_id="orch-compat-1",
+    )
+    assert results[0].ok
+    assert results[0].text == "legacy-ok"
+
+
+def test_dispatch_still_passes_env_to_kwargs_accepting_run_agent(monkeypatch):
+    captured = {}
+
+    def fake_run_agent(cli_ref, prompt, **kwargs):
+        captured["env"] = kwargs.get("env")
+        return agents.AgentResult(text="kwargs-ok", ok=True)
+
+    monkeypatch.setattr(agents, "run_agent", fake_run_agent)
+    results = run_transport.dispatch(
+        [Assignment(worker="coder", task="do the thing")],
+        _legacy_aboyeur_roster(),
+        build_prompt=lambda agent, assignment, **kw: assignment.task,
+        run_appserver_worker=lambda *a, **kw: agents.AgentResult(text="", ok=False, detail="unused"),
+        event_writer=lambda events_dir, worker, verbose=False: None,
+        read_only=True,
+        run_id="orch-compat-2",
+    )
+    assert results[0].ok
+    assert captured["env"][receipt_schema.BRIGADE_RUN_ID_ENV] == "orch-compat-2"
+
+
+def test_appserver_run_receives_brigade_run_id_without_seat_env(monkeypatch, tmp_path):
+    """Codex app-server path must get run identity via process env, not seat.env."""
+    seen = {}
+
+    class EnvAwareAppServer:
+        def __init__(self, *, cwd, process_registry=None, env=None):
+            seen["cwd"] = cwd
+            seen["env"] = env
+
+        def start(self):
+            pass
+
+        def close(self):
+            pass
+
+    def fake_dispatch(*args, **kwargs):
+        return [aboyeur.WorkerResult(worker="cook", task="task", text="done", ok=True)]
+
+    monkeypatch.setattr(aboyeur.codex_appserver, "AppServer", EnvAwareAppServer)
+    monkeypatch.setattr(aboyeur, "dispatch", fake_dispatch)
+
+    roster = Roster(
+        orchestrator="chef",
+        agents={
+            "chef": Agent(name="chef", cli="codex", role="plan"),
+            "cook": Agent(name="cook", cli="codex", role="worker"),
+        },
+        codex_transport="app-server",
+    )
+    output_dir = tmp_path / "20260810-appserver-runid"
+    assert (
+        run_aboyeur_guarded(
+            "task",
+            roster,
+            worker="cook",
+            cwd=tmp_path,
+            output_dir=output_dir,
+            route_enabled=False,
+        )
+        == 0
+    )
+    assert seen["cwd"] == tmp_path
+    assert seen["env"] is not None
+    assert seen["env"][receipt_schema.BRIGADE_RUN_ID_ENV] == output_dir.name
+    assert "OPENAI_API_KEY" not in seen["env"]
 
 
 def _init_git(tmp_path: Path) -> None:

--- a/tests/test_skill_obligations_audit.py
+++ b/tests/test_skill_obligations_audit.py
@@ -208,6 +208,82 @@ def test_audit_satisfies_check_review_handoff_and_obligation_id(tmp_path: Path, 
     assert payload["evidence_counts"] == {"check": 1, "review": 1, "handoff": 1}
 
 
+def test_earlier_run_receipts_do_not_satisfy_audited_run_obligations(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+):
+    _write_skill(
+        tmp_path,
+        "demo-skill",
+        obligations=[
+            {"id": "fresh-verify", "kind": "check", "required": True},
+            {"id": "code-review", "kind": "review", "required": True},
+            {"id": "memory-handoff", "kind": "handoff", "required": True},
+        ],
+    )
+    run_dir = _write_run(tmp_path, "20260801-audit-window", ["demo-skill"])
+    _write_json(
+        run_dir / "run.json",
+        {
+            "run_id": "20260801-audit-window",
+            "status": "completed",
+            "started_at": "2026-08-01T02:00:00Z",
+            "completed_at": "2026-08-01T03:00:00Z",
+        },
+    )
+    _write_json(
+        tmp_path / ".brigade" / "work" / "verify-runs" / "verify-earlier" / "receipt.json",
+        {
+            "run_id": "verify-earlier",
+            "status": "completed",
+            "started_at": "2026-08-01T00:10:00Z",
+            "completed_at": "2026-08-01T00:11:00Z",
+            "commands": [
+                {
+                    "command": "pytest -q",
+                    "argv": ["pytest", "-q"],
+                    "status": "completed",
+                    "exit_code": 0,
+                    "check_id": "verify.pytest",
+                    "check_role": "effectiveness",
+                    "obligation_id": "fresh-verify",
+                }
+            ],
+        },
+    )
+    _write_json(
+        tmp_path / ".brigade" / "reviews" / "runs" / "review-earlier" / "receipt.json",
+        {
+            "run_id": "review-earlier",
+            "reviewer_id": "local",
+            "status": "completed",
+            "exit_code": 0,
+            "started_at": "2026-08-01T00:20:00Z",
+            "completed_at": "2026-08-01T00:21:00Z",
+        },
+    )
+    _write_json(
+        tmp_path / ".brigade" / "handoffs" / "ingest-runs" / "handoff-earlier.json",
+        {
+            "run_id": "handoff-earlier",
+            "status": "ingested",
+            "started_at": "2026-08-01T00:30:00Z",
+            "completed_at": "2026-08-01T00:31:00Z",
+            "processed_handoff_paths": ["memory-handoffs/demo.md"],
+            "skipped_handoff_paths": [],
+            "failed_handoff_paths": [],
+            "safe_summary": "ingested demo handoff",
+        },
+    )
+
+    assert skill_obligations.audit(target=tmp_path, run=run_dir, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["result"] == skill_obligations.RESULT_WARN
+    assert payload["finding_count"] == 3
+    assert payload["evidence_counts"] == {"check": 0, "review": 0, "handoff": 0}
+    kinds = {finding["obligation_kind"] for finding in payload["findings"]}
+    assert kinds == {"check", "review", "handoff"}
+
+
 def test_stamped_obligation_id_failure_does_not_fall_back_to_unrelated_verify(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ):

--- a/tests/test_skill_obligations_audit.py
+++ b/tests/test_skill_obligations_audit.py
@@ -2,12 +2,21 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 
 import pytest
 
 from brigade import cli, receipt_schema, skill_obligations, skills_cmd
+
+
+def _external_public_label(path: Path) -> str:
+    """Mirror the collision-resistant external label contract for assertions."""
+    resolved = path.expanduser().resolve()
+    name = resolved.name or "path"
+    digest = hashlib.sha256(resolved.as_posix().encode("utf-8")).hexdigest()[:12]
+    return f"external:{name}-{digest}"
 
 
 def _write_json(path: Path, payload: object) -> None:
@@ -457,11 +466,12 @@ def test_audit_json_and_text_never_emit_private_absolute_paths(tmp_path: Path, c
     payload = json.loads(json_out)
     _assert_no_private_absolute_paths(json_out, tmp_path, workspace, external_skill)
 
+    expected_external = _external_public_label(external_skill)
     assert payload["target"] == skill_obligations.PUBLIC_TARGET
     assert payload["run_dir"] == f".brigade/runs/{audited}"
-    assert payload["declared_skill_ids"] == ["external:path-skill"]
+    assert payload["declared_skill_ids"] == [expected_external]
     assert payload["skills"][0]["source"]["kind"] == "path"
-    assert payload["skills"][0]["source"]["identity"] == "path:external:path-skill"
+    assert payload["skills"][0]["source"]["identity"] == f"path:{expected_external}"
     assert payload["unattributed_receipt_count"] >= 1
     for item in payload["unattributed_receipts"]:
         path = item.get("path")
@@ -498,6 +508,81 @@ def test_audit_registry_source_keeps_stable_non_path_identity(tmp_path: Path, ca
     assert source["kind"] == "registry"
     assert source["identity"] == "registry://skills/demo-skill"
     _assert_no_private_absolute_paths(json.dumps(payload), tmp_path)
+
+
+def test_missing_path_skill_load_error_redacts_absolute_path_in_json_and_text(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    missing = (tmp_path / "outside" / "missing-skill").resolve()
+    assert not missing.exists()
+    run_dir = _write_run(workspace, "20260801-audit-missing-path", [str(missing)])
+    expected = _external_public_label(missing)
+
+    metadata, source, load_error = skill_obligations._load_skill_metadata(workspace, str(missing))
+    assert metadata == {}
+    assert source is None
+    assert load_error is not None
+    assert str(missing) not in load_error
+    assert load_error == f"skill not found: {expected}"
+
+    assert skill_obligations.audit(target=workspace, run=run_dir, json_output=True) == 0
+    json_out = capsys.readouterr().out
+    payload = json.loads(json_out)
+    _assert_no_private_absolute_paths(json_out, tmp_path, workspace, missing)
+    assert payload["declared_skill_ids"] == [expected]
+    assert payload["skills"][0]["loaded"] is False
+    assert payload["skills"][0]["load_error"] == f"skill not found: {expected}"
+    assert payload["load_warnings"] == [{"skill_id": expected, "detail": f"skill not found: {expected}"}]
+
+    assert skill_obligations.audit(target=workspace, run=run_dir, json_output=False) == 0
+    text_out = capsys.readouterr().out
+    _assert_no_private_absolute_paths(text_out, tmp_path, workspace, missing)
+    assert str(missing) not in text_out
+
+
+def test_external_same_basename_paths_get_distinct_stable_public_labels(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    skill_a = tmp_path / "a" / "foo"
+    skill_b = tmp_path / "b" / "foo"
+    for skill_dir, skill_id in ((skill_a, "foo-a"), (skill_b, "foo-b")):
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: {skill_id}\ndescription: Same basename external skill.\n---\n\n# {skill_id}\n"
+        )
+        _write_json(
+            skill_dir / "skill.json",
+            {
+                "id": skill_id,
+                "title": skill_id,
+                "version": "0.1.0",
+                "description": "same basename external skill",
+                "tests": [f"brigade skills lint {skill_id}"],
+                "obligations": [{"id": "fresh-verify", "kind": "check", "required": True}],
+            },
+        )
+    label_a = _external_public_label(skill_a)
+    label_b = _external_public_label(skill_b)
+    assert label_a != label_b
+    assert label_a.startswith("external:foo-")
+    assert label_b.startswith("external:foo-")
+    assert skill_obligations._public_path(workspace, skill_a) == label_a
+    assert skill_obligations._public_path(workspace, skill_b) == label_b
+    assert skill_obligations._public_path(workspace, skill_a) == label_a
+
+    run_dir = _write_run(
+        workspace, "20260801-audit-basename-collision", [str(skill_a.resolve()), str(skill_b.resolve())]
+    )
+    assert skill_obligations.audit(target=workspace, run=run_dir, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["declared_skill_ids"] == [label_a, label_b]
+    identities = [skill["source"]["identity"] for skill in payload["skills"]]
+    assert identities == [f"path:{label_a}", f"path:{label_b}"]
+    _assert_no_private_absolute_paths(json.dumps(payload), tmp_path, workspace, skill_a, skill_b)
 
 
 def test_skills_lint_rejects_malformed_obligations(tmp_path: Path, capsys: pytest.CaptureFixture[str]):

--- a/tests/test_skill_obligations_audit.py
+++ b/tests/test_skill_obligations_audit.py
@@ -414,6 +414,92 @@ def test_missing_run_exits_2(tmp_path: Path, capsys: pytest.CaptureFixture[str])
     assert "not found" in err
 
 
+def _assert_no_private_absolute_paths(text: str, *private_roots: Path) -> None:
+    for root in private_roots:
+        resolved = str(root.resolve())
+        assert resolved not in text
+        assert resolved.replace("\\", "/") not in text
+
+
+def test_audit_json_and_text_never_emit_private_absolute_paths(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    external_skill = tmp_path / "outside" / "path-skill"
+    external_skill.mkdir(parents=True)
+    (external_skill / "SKILL.md").write_text(
+        "---\nname: path-skill\ndescription: External path skill.\n---\n\n# path-skill\n"
+    )
+    _write_json(
+        external_skill / "skill.json",
+        {
+            "id": "path-skill",
+            "title": "path-skill",
+            "version": "0.1.0",
+            "description": "external path skill",
+            "tests": ["brigade skills lint path-skill"],
+            "obligations": [{"id": "fresh-verify", "kind": "check", "required": True}],
+        },
+    )
+    audited = "20260801-audit-paths"
+    run_dir = _write_run(workspace, audited, [str(external_skill.resolve())])
+    _write_verify_receipt(workspace, "verify-legacy", obligation_id="fresh-verify")
+    _write_review_receipt(workspace, "review-legacy")
+    _write_handoff_receipt(workspace, "handoff-legacy")
+    _write_verify_receipt(
+        workspace,
+        "verify-ok",
+        obligation_id="fresh-verify",
+        producer_run_id=audited,
+    )
+
+    assert skill_obligations.audit(target=workspace, run=run_dir, json_output=True) == 0
+    json_out = capsys.readouterr().out
+    payload = json.loads(json_out)
+    _assert_no_private_absolute_paths(json_out, tmp_path, workspace, external_skill)
+
+    assert payload["target"] == skill_obligations.PUBLIC_TARGET
+    assert payload["run_dir"] == f".brigade/runs/{audited}"
+    assert payload["declared_skill_ids"] == ["external:path-skill"]
+    assert payload["skills"][0]["source"]["kind"] == "path"
+    assert payload["skills"][0]["source"]["identity"] == "path:external:path-skill"
+    assert payload["unattributed_receipt_count"] >= 1
+    for item in payload["unattributed_receipts"]:
+        path = item.get("path")
+        if path is not None:
+            assert not Path(str(path)).is_absolute()
+            assert str(path).startswith((".brigade/", "external:"))
+    satisfied_paths = [
+        item["evidence"].get("path") for item in payload["satisfied"] if isinstance(item.get("evidence"), dict)
+    ]
+    assert satisfied_paths
+    assert all(
+        path is None or (not Path(str(path)).is_absolute() and str(path).startswith((".brigade/", "external:")))
+        for path in satisfied_paths
+    )
+
+    assert skill_obligations.audit(target=workspace, run=run_dir, json_output=False) == 0
+    text_out = capsys.readouterr().out
+    _assert_no_private_absolute_paths(text_out, tmp_path, workspace, external_skill)
+    assert f"target: {skill_obligations.PUBLIC_TARGET}" in text_out
+    assert f"run: .brigade/runs/{audited}" in text_out
+    assert "unattributed" in text_out
+
+
+def test_audit_registry_source_keeps_stable_non_path_identity(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    _write_skill(
+        tmp_path,
+        "demo-skill",
+        obligations=[{"id": "fresh-verify", "kind": "check", "required": True}],
+    )
+    run_dir = _write_run(tmp_path, "20260801-audit-registry-src", ["demo-skill"])
+    assert skill_obligations.audit(target=tmp_path, run=run_dir, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    source = payload["skills"][0]["source"]
+    assert source["kind"] == "registry"
+    assert source["identity"] == "registry://skills/demo-skill"
+    _assert_no_private_absolute_paths(json.dumps(payload), tmp_path)
+
+
 def test_skills_lint_rejects_malformed_obligations(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
     _write_skill(
         tmp_path,

--- a/tests/test_skill_obligations_audit.py
+++ b/tests/test_skill_obligations_audit.py
@@ -1,0 +1,324 @@
+"""Tests for advisory skill obligations vs receipts audit (#499)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from brigade import cli, skill_obligations, skills_cmd
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def _write_skill(target: Path, skill_id: str, *, obligations: list[dict] | None) -> None:
+    skill_dir = target / ".brigade" / "skills" / "registry" / skill_id
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {skill_id}\ndescription: Test skill for obligations audit.\n---\n\n# {skill_id}\n"
+    )
+    metadata: dict = {
+        "id": skill_id,
+        "title": skill_id,
+        "version": "0.1.0",
+        "description": "test skill",
+        "tests": [f"brigade skills lint {skill_id}"],
+    }
+    if obligations is not None:
+        metadata["obligations"] = obligations
+    _write_json(skill_dir / "skill.json", metadata)
+
+
+def _write_run(target: Path, run_id: str, skill_ids: list[str]) -> Path:
+    run_dir = target / ".brigade" / "runs" / run_id
+    run_dir.mkdir(parents=True)
+    _write_json(
+        run_dir / "run.json",
+        {
+            "run_id": run_id,
+            "status": "completed",
+            "started_at": "2026-08-01T00:00:00Z",
+            "completed_at": "2026-08-01T01:00:00Z",
+        },
+    )
+    assignments = []
+    if skill_ids:
+        assignments.append(
+            {
+                "stage": 1,
+                "worker": "coder",
+                "task": "do work",
+                "covers": ["implement"],
+                "selected_skill_ids": skill_ids,
+            }
+        )
+    else:
+        assignments.append({"stage": 1, "worker": "coder", "task": "do work", "covers": ["implement"]})
+    _write_json(
+        run_dir / "plan.json",
+        {"schema": "brigade.run_plan.v1", "schema_version": 1, "assignments": assignments},
+    )
+    return run_dir
+
+
+def _write_verify_receipt(
+    target: Path,
+    run_id: str,
+    *,
+    status: str = "completed",
+    obligation_id: str | None = None,
+    command_status: str = "completed",
+    exit_code: int = 0,
+) -> None:
+    command = {
+        "command": "pytest -q",
+        "argv": ["pytest", "-q"],
+        "status": command_status,
+        "exit_code": exit_code,
+        "check_id": "verify.pytest",
+        "check_role": "effectiveness",
+    }
+    if obligation_id is not None:
+        command["obligation_id"] = obligation_id
+    _write_json(
+        target / ".brigade" / "work" / "verify-runs" / run_id / "receipt.json",
+        {
+            "run_id": run_id,
+            "status": status,
+            "started_at": "2026-08-01T00:10:00Z",
+            "completed_at": "2026-08-01T00:11:00Z",
+            "commands": [command],
+        },
+    )
+
+
+def _write_review_receipt(target: Path, run_id: str, *, status: str = "completed", exit_code: int = 0) -> None:
+    _write_json(
+        target / ".brigade" / "reviews" / "runs" / run_id / "receipt.json",
+        {
+            "run_id": run_id,
+            "reviewer_id": "local",
+            "status": status,
+            "exit_code": exit_code,
+            "started_at": "2026-08-01T00:20:00Z",
+            "completed_at": "2026-08-01T00:21:00Z",
+        },
+    )
+
+
+def _write_handoff_receipt(target: Path, run_id: str, *, processed: list[str] | None = None) -> None:
+    _write_json(
+        target / ".brigade" / "handoffs" / "ingest-runs" / f"{run_id}.json",
+        {
+            "run_id": run_id,
+            "status": "ingested",
+            "started_at": "2026-08-01T00:30:00Z",
+            "completed_at": "2026-08-01T00:31:00Z",
+            "processed_handoff_paths": processed if processed is not None else ["memory-handoffs/demo.md"],
+            "skipped_handoff_paths": [],
+            "failed_handoff_paths": [],
+            "safe_summary": "ingested demo handoff",
+        },
+    )
+
+
+def test_parse_obligations_accepts_valid_and_rejects_bad_shapes():
+    obligations, errors = skill_obligations.parse_obligations(
+        {
+            "obligations": [
+                {"id": "fresh-verify", "kind": "check", "required": True},
+                {"id": "code-review", "kind": "review"},
+                {"id": "memory-handoff", "kind": "handoff", "required": False, "description": "optional note"},
+            ]
+        }
+    )
+    assert errors == []
+    assert [item.id for item in obligations] == ["fresh-verify", "code-review", "memory-handoff"]
+    assert obligations[1].required is True
+    assert obligations[2].required is False
+
+    _, bad = skill_obligations.parse_obligations({"obligations": [{"id": "x", "kind": "deploy"}]})
+    assert bad and "kind must be one of" in bad[0]
+
+    _, not_list = skill_obligations.parse_obligations({"obligations": {"id": "x"}})
+    assert not_list == ["metadata obligations must be a list"]
+
+
+def test_declared_skill_ids_from_plan_are_ordered_unique():
+    plan = {
+        "assignments": [
+            {"selected_skill_ids": ["brigade-work", "check"]},
+            {"selected_skill_ids": ["check", "taste"]},
+            {"task": "no skills"},
+        ]
+    }
+    assert skill_obligations.declared_skill_ids_from_plan(plan) == ["brigade-work", "check", "taste"]
+    assert skill_obligations.declared_skill_ids_from_plan(None) == []
+
+
+def test_audit_reports_missing_required_evidence_as_advisory(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    _write_skill(
+        tmp_path,
+        "demo-skill",
+        obligations=[
+            {"id": "fresh-verify", "kind": "check", "required": True},
+            {"id": "code-review", "kind": "review", "required": True},
+            {"id": "memory-handoff", "kind": "handoff", "required": True},
+        ],
+    )
+    run_dir = _write_run(tmp_path, "20260801-audit-demo", ["demo-skill"])
+
+    rc = cli.main(["skills", "audit", str(run_dir), "--target", str(tmp_path), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["schema"] == skill_obligations.AUDIT_SCHEMA
+    assert payload["advisory"] is True
+    assert payload["blocking"] is False
+    assert payload["result"] == skill_obligations.RESULT_WARN
+    assert payload["finding_count"] == 3
+    kinds = {finding["obligation_kind"] for finding in payload["findings"]}
+    assert kinds == {"check", "review", "handoff"}
+    assert all(finding["severity"] == "medium" for finding in payload["findings"])
+
+
+def test_audit_satisfies_check_review_handoff_and_obligation_id(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    _write_skill(
+        tmp_path,
+        "demo-skill",
+        obligations=[
+            {"id": "fresh-verify", "kind": "check", "required": True},
+            {"id": "code-review", "kind": "review", "required": True},
+            {"id": "memory-handoff", "kind": "handoff", "required": True},
+        ],
+    )
+    run_dir = _write_run(tmp_path, "20260801-audit-ok", ["demo-skill"])
+    _write_verify_receipt(tmp_path, "verify-1", obligation_id="fresh-verify")
+    _write_review_receipt(tmp_path, "review-1")
+    _write_handoff_receipt(tmp_path, "handoff-1")
+
+    assert cli.main(["skills", "audit", str(run_dir), "--target", str(tmp_path), "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["result"] == skill_obligations.RESULT_OK
+    assert payload["finding_count"] == 0
+    assert payload["satisfied_count"] == 3
+    assert payload["evidence_counts"] == {"check": 1, "review": 1, "handoff": 1}
+
+
+def test_stamped_obligation_id_failure_does_not_fall_back_to_unrelated_verify(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+):
+    _write_skill(
+        tmp_path,
+        "demo-skill",
+        obligations=[{"id": "fresh-verify", "kind": "check", "required": True}],
+    )
+    _write_run(tmp_path, "20260801-audit-stamp", ["demo-skill"])
+    _write_verify_receipt(
+        tmp_path,
+        "verify-fail",
+        obligation_id="fresh-verify",
+        status="failed",
+        command_status="failed",
+        exit_code=1,
+    )
+    _write_verify_receipt(tmp_path, "verify-other", obligation_id=None)
+
+    assert cli.main(["skills", "audit", "20260801-audit-stamp", "--target", str(tmp_path), "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["finding_count"] == 1
+    assert payload["findings"][0]["obligation_id"] == "fresh-verify"
+
+
+def test_kind_level_verify_satisfies_when_no_obligation_id_stamped(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    _write_skill(
+        tmp_path,
+        "demo-skill",
+        obligations=[{"id": "fresh-verify", "kind": "check", "required": True}],
+    )
+    run_dir = _write_run(tmp_path, "20260801-audit-kind", ["demo-skill"])
+    _write_verify_receipt(tmp_path, "verify-plain")
+
+    assert skill_obligations.audit(target=tmp_path, run=run_dir, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["finding_count"] == 0
+    assert payload["satisfied_count"] == 1
+
+
+def test_optional_obligation_missing_is_skipped_not_finding(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    _write_skill(
+        tmp_path,
+        "demo-skill",
+        obligations=[{"id": "code-review", "kind": "review", "required": False}],
+    )
+    run_dir = _write_run(tmp_path, "20260801-audit-optional", ["demo-skill"])
+
+    assert skill_obligations.audit(target=tmp_path, run=run_dir, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["result"] == skill_obligations.RESULT_OK
+    assert payload["finding_count"] == 0
+    assert len(payload["skipped_optional"]) == 1
+
+
+def test_no_declared_skills_is_ok(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    run_dir = _write_run(tmp_path, "20260801-audit-empty", [])
+    assert skill_obligations.audit(target=tmp_path, run=run_dir, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["result"] == skill_obligations.RESULT_NO_DECLARED_SKILLS
+    assert payload["finding_count"] == 0
+
+
+def test_skills_without_obligations_is_ok(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    _write_skill(tmp_path, "plain-skill", obligations=None)
+    run_dir = _write_run(tmp_path, "20260801-audit-plain", ["plain-skill"])
+    assert skill_obligations.audit(target=tmp_path, run=run_dir, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["result"] == skill_obligations.RESULT_NO_OBLIGATIONS
+    assert payload["finding_count"] == 0
+
+
+def test_audit_does_not_write_workspace(tmp_path: Path):
+    _write_skill(
+        tmp_path,
+        "demo-skill",
+        obligations=[{"id": "fresh-verify", "kind": "check", "required": True}],
+    )
+    run_dir = _write_run(tmp_path, "20260801-audit-ro", ["demo-skill"])
+    before = {path.relative_to(tmp_path): path.read_bytes() for path in tmp_path.rglob("*") if path.is_file()}
+    assert skill_obligations.audit(target=tmp_path, run=run_dir, json_output=False) == 0
+    after = {path.relative_to(tmp_path): path.read_bytes() for path in tmp_path.rglob("*") if path.is_file()}
+    assert before == after
+
+
+def test_missing_run_exits_2(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    rc = cli.main(["skills", "audit", "missing-run", "--target", str(tmp_path)])
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert "not found" in err
+
+
+def test_skills_lint_rejects_malformed_obligations(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    _write_skill(
+        tmp_path,
+        "bad-skill",
+        obligations=[{"id": "x", "kind": "not-a-kind"}],
+    )
+    assert skills_cmd.lint(target=tmp_path, skill="bad-skill", json_output=True) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["valid"] is False
+    assert any("kind must be one of" in error for error in payload["errors"])
+
+
+def test_bundled_brigade_work_declares_check_and_handoff_obligations():
+    from brigade.templates import template_root
+
+    metadata = json.loads((template_root() / "skills" / "brigade-work" / "skill.json").read_text())
+    obligations, errors = skill_obligations.parse_obligations(metadata)
+    assert errors == []
+    assert {(item.id, item.kind) for item in obligations} == {
+        ("verify-through-brigade", "check"),
+        ("session-handoff", "handoff"),
+    }

--- a/tests/test_skill_obligations_audit.py
+++ b/tests/test_skill_obligations_audit.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from brigade import cli, skill_obligations, skills_cmd
+from brigade import cli, receipt_schema, skill_obligations, skills_cmd
 
 
 def _write_json(path: Path, payload: object) -> None:
@@ -73,6 +73,8 @@ def _write_verify_receipt(
     obligation_id: str | None = None,
     command_status: str = "completed",
     exit_code: int = 0,
+    producer_run_id: str | None = None,
+    started_at: str = "2026-08-01T00:10:00Z",
 ) -> None:
     command = {
         "command": "pytest -q",
@@ -84,46 +86,61 @@ def _write_verify_receipt(
     }
     if obligation_id is not None:
         command["obligation_id"] = obligation_id
-    _write_json(
-        target / ".brigade" / "work" / "verify-runs" / run_id / "receipt.json",
-        {
-            "run_id": run_id,
-            "status": status,
-            "started_at": "2026-08-01T00:10:00Z",
-            "completed_at": "2026-08-01T00:11:00Z",
-            "commands": [command],
-        },
-    )
+    payload: dict = {
+        "run_id": run_id,
+        "status": status,
+        "started_at": started_at,
+        "completed_at": "2026-08-01T00:11:00Z",
+        "commands": [command],
+    }
+    if producer_run_id is not None:
+        payload["producer_run_id"] = producer_run_id
+    _write_json(target / ".brigade" / "work" / "verify-runs" / run_id / "receipt.json", payload)
 
 
-def _write_review_receipt(target: Path, run_id: str, *, status: str = "completed", exit_code: int = 0) -> None:
-    _write_json(
-        target / ".brigade" / "reviews" / "runs" / run_id / "receipt.json",
-        {
-            "run_id": run_id,
-            "reviewer_id": "local",
-            "status": status,
-            "exit_code": exit_code,
-            "started_at": "2026-08-01T00:20:00Z",
-            "completed_at": "2026-08-01T00:21:00Z",
-        },
-    )
+def _write_review_receipt(
+    target: Path,
+    run_id: str,
+    *,
+    status: str = "completed",
+    exit_code: int = 0,
+    producer_run_id: str | None = None,
+    started_at: str = "2026-08-01T00:20:00Z",
+) -> None:
+    payload: dict = {
+        "run_id": run_id,
+        "reviewer_id": "local",
+        "status": status,
+        "exit_code": exit_code,
+        "started_at": started_at,
+        "completed_at": "2026-08-01T00:21:00Z",
+    }
+    if producer_run_id is not None:
+        payload["producer_run_id"] = producer_run_id
+    _write_json(target / ".brigade" / "reviews" / "runs" / run_id / "receipt.json", payload)
 
 
-def _write_handoff_receipt(target: Path, run_id: str, *, processed: list[str] | None = None) -> None:
-    _write_json(
-        target / ".brigade" / "handoffs" / "ingest-runs" / f"{run_id}.json",
-        {
-            "run_id": run_id,
-            "status": "ingested",
-            "started_at": "2026-08-01T00:30:00Z",
-            "completed_at": "2026-08-01T00:31:00Z",
-            "processed_handoff_paths": processed if processed is not None else ["memory-handoffs/demo.md"],
-            "skipped_handoff_paths": [],
-            "failed_handoff_paths": [],
-            "safe_summary": "ingested demo handoff",
-        },
-    )
+def _write_handoff_receipt(
+    target: Path,
+    run_id: str,
+    *,
+    processed: list[str] | None = None,
+    producer_run_id: str | None = None,
+    started_at: str = "2026-08-01T00:30:00Z",
+) -> None:
+    payload: dict = {
+        "run_id": run_id,
+        "status": "ingested",
+        "started_at": started_at,
+        "completed_at": "2026-08-01T00:31:00Z",
+        "processed_handoff_paths": processed if processed is not None else ["memory-handoffs/demo.md"],
+        "skipped_handoff_paths": [],
+        "failed_handoff_paths": [],
+        "safe_summary": "ingested demo handoff",
+    }
+    if producer_run_id is not None:
+        payload["producer_run_id"] = producer_run_id
+    _write_json(target / ".brigade" / "handoffs" / "ingest-runs" / f"{run_id}.json", payload)
 
 
 def test_parse_obligations_accepts_valid_and_rejects_bad_shapes():
@@ -131,21 +148,19 @@ def test_parse_obligations_accepts_valid_and_rejects_bad_shapes():
         {
             "obligations": [
                 {"id": "fresh-verify", "kind": "check", "required": True},
-                {"id": "code-review", "kind": "review"},
-                {"id": "memory-handoff", "kind": "handoff", "required": False, "description": "optional note"},
+                {"id": "code-review", "kind": "review", "required": False, "description": "peer review"},
             ]
         }
     )
     assert errors == []
-    assert [item.id for item in obligations] == ["fresh-verify", "code-review", "memory-handoff"]
-    assert obligations[1].required is True
-    assert obligations[2].required is False
-
+    assert [(item.id, item.kind, item.required) for item in obligations] == [
+        ("fresh-verify", "check", True),
+        ("code-review", "review", False),
+    ]
     _, bad = skill_obligations.parse_obligations({"obligations": [{"id": "x", "kind": "deploy"}]})
-    assert bad and "kind must be one of" in bad[0]
-
+    assert bad
     _, not_list = skill_obligations.parse_obligations({"obligations": {"id": "x"}})
-    assert not_list == ["metadata obligations must be a list"]
+    assert not_list
 
 
 def test_declared_skill_ids_from_plan_are_ordered_unique():
@@ -153,7 +168,7 @@ def test_declared_skill_ids_from_plan_are_ordered_unique():
         "assignments": [
             {"selected_skill_ids": ["brigade-work", "check"]},
             {"selected_skill_ids": ["check", "taste"]},
-            {"task": "no skills"},
+            {"selected_skill_ids": "not-a-list"},
         ]
     }
     assert skill_obligations.declared_skill_ids_from_plan(plan) == ["brigade-work", "check", "taste"]
@@ -178,6 +193,7 @@ def test_audit_reports_missing_required_evidence_as_advisory(tmp_path: Path, cap
     assert payload["schema"] == skill_obligations.AUDIT_SCHEMA
     assert payload["advisory"] is True
     assert payload["blocking"] is False
+    assert payload["matching"] == "producer_run_id"
     assert payload["result"] == skill_obligations.RESULT_WARN
     assert payload["finding_count"] == 3
     kinds = {finding["obligation_kind"] for finding in payload["findings"]}
@@ -186,6 +202,7 @@ def test_audit_reports_missing_required_evidence_as_advisory(tmp_path: Path, cap
 
 
 def test_audit_satisfies_check_review_handoff_and_obligation_id(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    audited = "20260801-audit-ok"
     _write_skill(
         tmp_path,
         "demo-skill",
@@ -195,10 +212,10 @@ def test_audit_satisfies_check_review_handoff_and_obligation_id(tmp_path: Path, 
             {"id": "memory-handoff", "kind": "handoff", "required": True},
         ],
     )
-    run_dir = _write_run(tmp_path, "20260801-audit-ok", ["demo-skill"])
-    _write_verify_receipt(tmp_path, "verify-1", obligation_id="fresh-verify")
-    _write_review_receipt(tmp_path, "review-1")
-    _write_handoff_receipt(tmp_path, "handoff-1")
+    run_dir = _write_run(tmp_path, audited, ["demo-skill"])
+    _write_verify_receipt(tmp_path, "verify-1", obligation_id="fresh-verify", producer_run_id=audited)
+    _write_review_receipt(tmp_path, "review-1", producer_run_id=audited)
+    _write_handoff_receipt(tmp_path, "handoff-1", producer_run_id=audited)
 
     assert cli.main(["skills", "audit", str(run_dir), "--target", str(tmp_path), "--json"]) == 0
     payload = json.loads(capsys.readouterr().out)
@@ -206,11 +223,13 @@ def test_audit_satisfies_check_review_handoff_and_obligation_id(tmp_path: Path, 
     assert payload["finding_count"] == 0
     assert payload["satisfied_count"] == 3
     assert payload["evidence_counts"] == {"check": 1, "review": 1, "handoff": 1}
+    assert payload["unattributed_receipt_count"] == 0
 
 
-def test_earlier_run_receipts_do_not_satisfy_audited_run_obligations(
+def test_exact_producer_run_id_satisfies_wrong_run_and_timestamp_near_do_not(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ):
+    audited = "20260801-audit-exact"
     _write_skill(
         tmp_path,
         "demo-skill",
@@ -220,59 +239,35 @@ def test_earlier_run_receipts_do_not_satisfy_audited_run_obligations(
             {"id": "memory-handoff", "kind": "handoff", "required": True},
         ],
     )
-    run_dir = _write_run(tmp_path, "20260801-audit-window", ["demo-skill"])
+    run_dir = _write_run(tmp_path, audited, ["demo-skill"])
     _write_json(
         run_dir / "run.json",
         {
-            "run_id": "20260801-audit-window",
+            "run_id": audited,
             "status": "completed",
             "started_at": "2026-08-01T02:00:00Z",
             "completed_at": "2026-08-01T03:00:00Z",
         },
     )
-    _write_json(
-        tmp_path / ".brigade" / "work" / "verify-runs" / "verify-earlier" / "receipt.json",
-        {
-            "run_id": "verify-earlier",
-            "status": "completed",
-            "started_at": "2026-08-01T00:10:00Z",
-            "completed_at": "2026-08-01T00:11:00Z",
-            "commands": [
-                {
-                    "command": "pytest -q",
-                    "argv": ["pytest", "-q"],
-                    "status": "completed",
-                    "exit_code": 0,
-                    "check_id": "verify.pytest",
-                    "check_role": "effectiveness",
-                    "obligation_id": "fresh-verify",
-                }
-            ],
-        },
+    # Wrong-run receipts stamped near the audited window must not satisfy.
+    _write_verify_receipt(
+        tmp_path,
+        "verify-wrong",
+        obligation_id="fresh-verify",
+        producer_run_id="other-orchestrator-run",
+        started_at="2026-08-01T02:10:00Z",
     )
-    _write_json(
-        tmp_path / ".brigade" / "reviews" / "runs" / "review-earlier" / "receipt.json",
-        {
-            "run_id": "review-earlier",
-            "reviewer_id": "local",
-            "status": "completed",
-            "exit_code": 0,
-            "started_at": "2026-08-01T00:20:00Z",
-            "completed_at": "2026-08-01T00:21:00Z",
-        },
+    _write_review_receipt(
+        tmp_path,
+        "review-wrong",
+        producer_run_id="other-orchestrator-run",
+        started_at="2026-08-01T02:20:00Z",
     )
-    _write_json(
-        tmp_path / ".brigade" / "handoffs" / "ingest-runs" / "handoff-earlier.json",
-        {
-            "run_id": "handoff-earlier",
-            "status": "ingested",
-            "started_at": "2026-08-01T00:30:00Z",
-            "completed_at": "2026-08-01T00:31:00Z",
-            "processed_handoff_paths": ["memory-handoffs/demo.md"],
-            "skipped_handoff_paths": [],
-            "failed_handoff_paths": [],
-            "safe_summary": "ingested demo handoff",
-        },
+    _write_handoff_receipt(
+        tmp_path,
+        "handoff-wrong",
+        producer_run_id="other-orchestrator-run",
+        started_at="2026-08-01T02:30:00Z",
     )
 
     assert skill_obligations.audit(target=tmp_path, run=run_dir, json_output=True) == 0
@@ -280,19 +275,60 @@ def test_earlier_run_receipts_do_not_satisfy_audited_run_obligations(
     assert payload["result"] == skill_obligations.RESULT_WARN
     assert payload["finding_count"] == 3
     assert payload["evidence_counts"] == {"check": 0, "review": 0, "handoff": 0}
-    kinds = {finding["obligation_kind"] for finding in payload["findings"]}
+    assert payload["unattributed_receipt_count"] == 0
+
+    _write_verify_receipt(tmp_path, "verify-ok", obligation_id="fresh-verify", producer_run_id=audited)
+    _write_review_receipt(tmp_path, "review-ok", producer_run_id=audited)
+    _write_handoff_receipt(tmp_path, "handoff-ok", producer_run_id=audited)
+    assert skill_obligations.audit(target=tmp_path, run=run_dir, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["result"] == skill_obligations.RESULT_OK
+    assert payload["satisfied_count"] == 3
+
+
+def test_legacy_unstamped_receipts_are_unattributed_and_do_not_satisfy(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+):
+    audited = "20260801-audit-legacy"
+    _write_skill(
+        tmp_path,
+        "demo-skill",
+        obligations=[
+            {"id": "fresh-verify", "kind": "check", "required": True},
+            {"id": "code-review", "kind": "review", "required": True},
+            {"id": "memory-handoff", "kind": "handoff", "required": True},
+        ],
+    )
+    run_dir = _write_run(tmp_path, audited, ["demo-skill"])
+    _write_verify_receipt(tmp_path, "verify-legacy", obligation_id="fresh-verify")
+    _write_review_receipt(tmp_path, "review-legacy")
+    _write_handoff_receipt(tmp_path, "handoff-legacy")
+
+    assert skill_obligations.audit(target=tmp_path, run=run_dir, json_output=True) == 0
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert payload["result"] == skill_obligations.RESULT_WARN
+    assert payload["finding_count"] == 3
+    assert payload["evidence_counts"] == {"check": 0, "review": 0, "handoff": 0}
+    assert payload["unattributed_receipt_count"] == 3
+    kinds = {item["kind"] for item in payload["unattributed_receipts"]}
     assert kinds == {"check", "review", "handoff"}
+    assert all(item["attribution"] == "unattributed" for item in payload["unattributed_receipts"])
+    assert "sk-" not in out
+    assert "Bearer " not in out
+    assert "OPENAI_API_KEY" not in out
 
 
 def test_stamped_obligation_id_failure_does_not_fall_back_to_unrelated_verify(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ):
+    audited = "20260801-audit-stamp"
     _write_skill(
         tmp_path,
         "demo-skill",
         obligations=[{"id": "fresh-verify", "kind": "check", "required": True}],
     )
-    _write_run(tmp_path, "20260801-audit-stamp", ["demo-skill"])
+    _write_run(tmp_path, audited, ["demo-skill"])
     _write_verify_receipt(
         tmp_path,
         "verify-fail",
@@ -300,23 +336,25 @@ def test_stamped_obligation_id_failure_does_not_fall_back_to_unrelated_verify(
         status="failed",
         command_status="failed",
         exit_code=1,
+        producer_run_id=audited,
     )
-    _write_verify_receipt(tmp_path, "verify-other", obligation_id=None)
+    _write_verify_receipt(tmp_path, "verify-other", obligation_id=None, producer_run_id=audited)
 
-    assert cli.main(["skills", "audit", "20260801-audit-stamp", "--target", str(tmp_path), "--json"]) == 0
+    assert cli.main(["skills", "audit", audited, "--target", str(tmp_path), "--json"]) == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["finding_count"] == 1
     assert payload["findings"][0]["obligation_id"] == "fresh-verify"
 
 
 def test_kind_level_verify_satisfies_when_no_obligation_id_stamped(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    audited = "20260801-audit-kind"
     _write_skill(
         tmp_path,
         "demo-skill",
         obligations=[{"id": "fresh-verify", "kind": "check", "required": True}],
     )
-    run_dir = _write_run(tmp_path, "20260801-audit-kind", ["demo-skill"])
-    _write_verify_receipt(tmp_path, "verify-plain")
+    run_dir = _write_run(tmp_path, audited, ["demo-skill"])
+    _write_verify_receipt(tmp_path, "verify-plain", producer_run_id=audited)
 
     assert skill_obligations.audit(target=tmp_path, run=run_dir, json_output=True) == 0
     payload = json.loads(capsys.readouterr().out)
@@ -398,3 +436,13 @@ def test_bundled_brigade_work_declares_check_and_handoff_obligations():
         ("verify-through-brigade", "check"),
         ("session-handoff", "handoff"),
     }
+
+
+def test_producer_run_id_helpers_omit_when_absent_and_stamp_from_env(monkeypatch):
+    payload: dict = {}
+    receipt_schema.stamp_optional_producer_run_id(payload)
+    assert "producer_run_id" not in payload
+    monkeypatch.setenv(receipt_schema.BRIGADE_RUN_ID_ENV, "  run-abc  ")
+    receipt_schema.stamp_optional_producer_run_id(payload)
+    assert payload["producer_run_id"] == "run-abc"
+    assert receipt_schema.producer_run_id_from_env() == "run-abc"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

Adds an advisory `brigade skills audit` that compares process obligations declared on `skill.json` (`check` / `review` / `handoff`) for a run's `selected_skill_ids` against captured verify, review, and handoff ingest receipts, reporting missing required evidence as findings without blocking.

Closes #499

## Type of change

- [x] Surface change (additive CLI + skill metadata field; issue #499)
- Additive only: no breaking CLI changes

## Checklist

- [x] `./scripts/verify` passes locally (6310 passed, 3 skipped; coverage 83.10%)
- [x] Added or updated tests covering the change (`tests/test_skill_obligations_audit.py`)
- [x] Updated the `Unreleased` section of `CHANGELOG.md`
- [x] No personal details / secrets
- [x] No new runtime dependencies
- [x] Conventional commits; regenerated `docs/command-inventory.md`

## Notes

- New command: `brigade skills audit <run|latest> [--target PATH] [--json]`
- Verify commands may stamp `obligation_id` for precise check matching
- Bundled `brigade-work` declares `verify-through-brigade` and `session-handoff`
- Exit 0 when the audit runs (advisory); exit 2 only when the run cannot be resolved

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec93cabc-cc86-4fbe-9979-7d3011c39f06?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec93cabc-cc86-4fbe-9979-7d3011c39f06&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

