### PR TITLE
feat(wiring): make work brief the instruction SSoT (#733)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ledgers stay authoritative and unchanged when the campaign file is removed.
   `--parallel-safe` with `--campaign` leaves a deferred wave-aggregation seam
   (`partition_mode=campaign_deferred`) for a later cross-repo compositor.
+- Work brief as wiring source of truth (#733): static harness instruction
+  blocks shrink to depth profiles rendered from the same ordered brief
+  sections as `brigade work brief`. Hook-capable Claude installs default to
+  a short `minimal` pointer when SessionStart injects the live brief; file-only
+  installs keep `full`. Each integration records its required depth; shared
+  files take the richest active requirement (full-then-minimal and
+  minimal-then-full converge; uninstalling the last full consumer drops back
+  to minimal). `--profile minimal|full` overrides selection. Doctor warns when
+  a minimal profile remains after brief-injecting hooks go inactive. Live
+  `brigade work brief` opens with the session-close checklist.
 
 ## [0.26.1] - 2026-08-09
 

--- a/src/brigade/brief_sections.py
+++ b/src/brigade/brief_sections.py
@@ -1,0 +1,183 @@
+"""Ordered brief sections shared by ``brigade work brief`` and static wiring.
+
+Issue #733 makes the dynamically generated work brief the single source of truth
+for workflow guidance. Static harness instruction blocks are rendered from the
+same ordered sections:
+
+- ``minimal``: short pointer (identity, key commands, hard rules)
+- ``full``: pointer plus session-close and work-loop protocol
+
+Live ``brigade work brief`` text opens with the session-close checklist, then
+the dynamic status dump. Keeping both surfaces on one renderer prevents the
+static full profile from drifting away from the brief.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+PROFILE_MINIMAL = "minimal"
+PROFILE_FULL = "full"
+KNOWN_PROFILES = (PROFILE_MINIMAL, PROFILE_FULL)
+DEFAULT_PROFILE = PROFILE_FULL
+
+# Richness order: higher wins when multiple integrations share one file.
+PROFILE_RANK = {
+    PROFILE_MINIMAL: 1,
+    PROFILE_FULL: 2,
+}
+
+SECTION_SESSION_CLOSE = "session_close"
+SECTION_IDENTITY = "identity"
+SECTION_KEY_COMMANDS = "key_commands"
+SECTION_HARD_RULES = "hard_rules"
+SECTION_WORK_LOOP = "work_loop"
+
+MINIMAL_SECTIONS: tuple[str, ...] = (
+    SECTION_IDENTITY,
+    SECTION_KEY_COMMANDS,
+    SECTION_HARD_RULES,
+)
+FULL_SECTIONS: tuple[str, ...] = (
+    SECTION_SESSION_CLOSE,
+    SECTION_IDENTITY,
+    SECTION_KEY_COMMANDS,
+    SECTION_HARD_RULES,
+    SECTION_WORK_LOOP,
+)
+
+_SESSION_CLOSE_ITEMS: tuple[str, ...] = (
+    'Verify captured through Brigade? (`brigade work verify run --target . --command "..." --capture brigade-work`)',
+    "Outcome recorded? (`brigade outcome capture <skill-or-card-id> --run-id latest`)",
+    "Memory Handoff written when durable knowledge was produced?",
+)
+
+
+def normalize_profile(value: str | None, *, default: str = DEFAULT_PROFILE) -> str:
+    """Return a known instruction profile name, or ``default`` when unset/unknown."""
+    if value is None:
+        return default
+    normalized = value.strip().lower()
+    if normalized in PROFILE_RANK:
+        return normalized
+    raise ValueError(f"unknown instruction profile: {value!r}")
+
+
+def richer_profile(left: str, right: str) -> str:
+    """Return the richer of two profiles."""
+    left_n = normalize_profile(left)
+    right_n = normalize_profile(right)
+    return left_n if PROFILE_RANK[left_n] >= PROFILE_RANK[right_n] else right_n
+
+
+def effective_profile(requirements: Iterable[str]) -> str | None:
+    """Compute the richest active requirement, or None when nothing is required."""
+    richest: str | None = None
+    for raw in requirements:
+        candidate = normalize_profile(raw)
+        richest = candidate if richest is None else richer_profile(richest, candidate)
+    return richest
+
+
+def profiles_for_depth(profile: str) -> tuple[str, ...]:
+    """Return the ordered static section ids for an instruction profile."""
+    normalized = normalize_profile(profile)
+    if normalized == PROFILE_MINIMAL:
+        return MINIMAL_SECTIONS
+    return FULL_SECTIONS
+
+
+def session_close_items() -> tuple[str, ...]:
+    """Checklist items that lead the live brief and the full static profile."""
+    return _SESSION_CLOSE_ITEMS
+
+
+def render_session_close_section(*, heading: str = "## Session close") -> str:
+    lines = [heading, ""]
+    lines.extend(f"- [ ] {item}" for item in _SESSION_CLOSE_ITEMS)
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_identity_section() -> str:
+    return (
+        "## Brigade\n\n"
+        "Brigade is the local work loop for this workspace: briefs, verification "
+        "receipts, outcomes, and Memory Handoffs.\n"
+    )
+
+
+def render_key_commands_section() -> str:
+    return (
+        "### Start here\n\n"
+        "1. Run `brigade work brief --target .` and follow it before editing.\n"
+        "2. Run counting checks through Brigade, not raw.\n"
+        "3. After substantial work, write a Memory Handoff; never edit canonical memory directly.\n"
+    )
+
+
+def render_hard_rules_section() -> str:
+    return (
+        "### Hard rules\n\n"
+        "- Verify through Brigade when the result should count.\n"
+        "- Capture outcomes (failures included) so the ledger stays honest.\n"
+        "- Handoff at the end of substantial work.\n"
+    )
+
+
+def render_work_loop_section() -> str:
+    return (
+        "### Work loop protocol\n\n"
+        "Invoke the `using-skillet` skill and use each applicable reviewed skill "
+        "before substantive work in a Brigade-wired repository.\n\n"
+        "Run `brigade work brief --target .` when a `.brigade/` directory exists "
+        "or `brigade status --target .` succeeds, and follow the brief before editing.\n\n"
+        "Route worker-sized or parallelizable implementation through `brigade run` "
+        "and keep the frontier session on planning, dispatch, review, and synthesis.\n\n"
+        "Run counting checks through "
+        '`brigade work verify run --target . --command "<command>" --capture brigade-work`, '
+        "capturing failures as evidence so the outcome ledger stays honest.\n\n"
+        "After substantial work, create a Memory Handoff through the standard "
+        "Rocinante flow and never edit canonical memory directly.\n"
+    )
+
+
+_SECTION_RENDERERS = {
+    SECTION_SESSION_CLOSE: render_session_close_section,
+    SECTION_IDENTITY: render_identity_section,
+    SECTION_KEY_COMMANDS: render_key_commands_section,
+    SECTION_HARD_RULES: render_hard_rules_section,
+    SECTION_WORK_LOOP: render_work_loop_section,
+}
+
+
+def render_section(section_id: str) -> str:
+    """Render one named brief section."""
+    renderer = _SECTION_RENDERERS.get(section_id)
+    if renderer is None:
+        raise ValueError(f"unknown brief section: {section_id!r}")
+    return renderer()
+
+
+def render_sections(section_ids: Sequence[str]) -> str:
+    """Render ordered sections joined with a blank line between non-empty parts."""
+    parts: list[str] = []
+    for section_id in section_ids:
+        text = render_section(section_id).rstrip()
+        if text:
+            parts.append(text)
+    if not parts:
+        return ""
+    return "\n\n".join(parts) + "\n"
+
+
+def render_static_instruction(profile: str = DEFAULT_PROFILE) -> str:
+    """Render the static managed-instruction body for ``minimal`` or ``full``."""
+    return render_sections(profiles_for_depth(profile))
+
+
+def render_brief_session_close_lines() -> list[str]:
+    """Lines printed at the top of live ``brigade work brief`` text output."""
+    lines = ["session_close:"]
+    lines.extend(f"  - [ ] {item}" for item in _SESSION_CLOSE_ITEMS)
+    return lines

--- a/src/brigade/cli/harness.py
+++ b/src/brigade/cli/harness.py
@@ -73,6 +73,15 @@ def register(sub: argparse._SubParsersAction) -> None:
         action="store_true",
         help="Overwrite a locally modified or recoverable managed instruction block.",
     )
+    sync.add_argument(
+        "--profile",
+        choices=["minimal", "full"],
+        help=(
+            "Override instruction depth for this sync. Default selects minimal when "
+            "brief-injecting hooks are installed for the harness, otherwise full. "
+            "Shared-file installs still keep the richest active requirement."
+        ),
+    )
 
     uninstall = commands.add_parser("uninstall", help="Remove only Brigade-owned harness configuration.")
     uninstall_target = uninstall.add_mutually_exclusive_group(required=True)
@@ -161,6 +170,7 @@ def dispatch(args) -> int:
             force=bool(getattr(args, "force", False)),
             check=bool(getattr(args, "check", False)),
             json_output=args.json,
+            profile=getattr(args, "profile", None),
         )
 
     if args.harness_command == "uninstall":

--- a/src/brigade/harness_profile_cmd.py
+++ b/src/brigade/harness_profile_cmd.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from . import __version__ as BRIGADE_VERSION
-from . import harness_profiles, localio, managed_block, mcp_adapters, mcp_cmd, skills_cmd
+from . import brief_sections, harness_profiles, localio, managed_block, mcp_adapters, mcp_cmd, skills_cmd
 from .toml_compat import TOMLDecodeError as _TOMLDecodeError
 from .toml_compat import loads as _toml_loads
 
@@ -27,6 +27,8 @@ _LEGACY_CURSOR_GENERATED = (
 )
 _LEGACY_CURSOR_SKILL_ID = "brigade-work"
 _LEGACY_CURSOR_SKILL_PREFIX = "skills/brigade-work/"
+_INSTRUCTION_REQUIRED_PROFILE_KEY = "required_profile"
+_INSTRUCTION_EFFECTIVE_PROFILE_KEY = "effective_profile"
 
 
 @dataclass(frozen=True)
@@ -172,6 +174,148 @@ def _block(body: str, *, profile: str = managed_block.DEFAULT_PROFILE) -> str:
         kind=managed_block.DEFAULT_KIND,
         profile=profile,
     )
+
+
+def hooks_inject_brief(profile: harness_profiles.HarnessProfile) -> bool:
+    """Return True when this harness's hooks inject the live work brief.
+
+    Only Claude Code SessionStart currently injects ``brigade work brief``.
+    Cursor's sessionStart hook injects a static one-liner, so it stays file-only
+    for instruction depth selection.
+    """
+    if profile.harness not in harness_profiles.HOOK_BRIEF_HARNESSES:
+        return False
+    from .claude_hooks.install_cmd import status_payload
+
+    try:
+        status = status_payload(Path("."), scope="user")
+    except OSError:
+        return False
+    return bool(status.get("installed"))
+
+
+def required_instruction_profile(
+    profile: harness_profiles.HarnessProfile,
+    *,
+    override: str | None = None,
+) -> str:
+    """Return this integration's required instruction depth."""
+    if override is not None:
+        return brief_sections.normalize_profile(override)
+    if profile.instruction_mode != "marked-block":
+        return brief_sections.PROFILE_FULL
+    if hooks_inject_brief(profile):
+        return brief_sections.PROFILE_MINIMAL
+    return brief_sections.PROFILE_FULL
+
+
+def _instruction_path_key(path: Path) -> Path:
+    return path.expanduser().resolve()
+
+
+def _active_instruction_requirement(state: dict[str, Any]) -> str | None:
+    """Return a required profile when this state still owns an instruction span."""
+    instruction = state.get("instructions")
+    if not isinstance(instruction, dict) or not instruction:
+        return None
+    if not isinstance(instruction.get("digest"), str):
+        return None
+    raw = instruction.get(_INSTRUCTION_REQUIRED_PROFILE_KEY)
+    if isinstance(raw, str) and raw.strip():
+        try:
+            return brief_sections.normalize_profile(raw)
+        except ValueError:
+            return brief_sections.PROFILE_FULL
+    # Pre-#733 ownership: treat as a full consumer so we never silently shrink.
+    return brief_sections.PROFILE_FULL
+
+
+def collect_path_requirements(
+    *,
+    path: Path,
+    home: Path,
+    workspace: Path,
+    exclude_harness: str | None = None,
+) -> dict[str, str]:
+    """Map harness id → required profile for every active consumer of ``path``."""
+    target = _instruction_path_key(path)
+    requirements: dict[str, str] = {}
+    for other in harness_profiles.resolve_user_profiles(harness="all", home=home, workspace=workspace):
+        if exclude_harness is not None and other.harness == exclude_harness:
+            continue
+        if other.instruction_mode != "marked-block":
+            continue
+        try:
+            if _instruction_path_key(other.instruction_path) != target:
+                continue
+        except OSError:
+            continue
+        loaded = load_profile_state(state_path=other.state_path, workspace=workspace, harness=other.harness)
+        if loaded.error:
+            continue
+        required = _active_instruction_requirement(loaded.state)
+        if required is not None:
+            requirements[other.harness] = required
+    return requirements
+
+
+def resolve_effective_instruction_profile(
+    *,
+    path: Path,
+    home: Path,
+    workspace: Path,
+    self_harness: str,
+    self_required: str,
+    exclude_harness: str | None = None,
+) -> tuple[str, dict[str, str]]:
+    """Compute effective profile as the richest active requirement for ``path``."""
+    requirements = collect_path_requirements(
+        path=path,
+        home=home,
+        workspace=workspace,
+        exclude_harness=exclude_harness,
+    )
+    requirements[self_harness] = brief_sections.normalize_profile(self_required)
+    effective = brief_sections.effective_profile(requirements.values())
+    assert effective is not None
+    return effective, requirements
+
+
+def update_shared_instruction_digests(
+    *,
+    path: Path,
+    home: Path,
+    workspace: Path,
+    digest: str,
+    effective_profile: str,
+    exclude_harness: str | None = None,
+) -> list[str]:
+    """Keep co-owners' ownership digests aligned after a shared-file rewrite."""
+    target = _instruction_path_key(path)
+    updated: list[str] = []
+    for other in harness_profiles.resolve_user_profiles(harness="all", home=home, workspace=workspace):
+        if exclude_harness is not None and other.harness == exclude_harness:
+            continue
+        if other.instruction_mode != "marked-block":
+            continue
+        try:
+            if _instruction_path_key(other.instruction_path) != target:
+                continue
+        except OSError:
+            continue
+        loaded = load_profile_state(state_path=other.state_path, workspace=workspace, harness=other.harness)
+        if loaded.error:
+            continue
+        state = json.loads(json.dumps(loaded.state))
+        instruction = state.get("instructions")
+        if not isinstance(instruction, dict) or not isinstance(instruction.get("digest"), str):
+            continue
+        instruction["digest"] = digest
+        instruction[_INSTRUCTION_EFFECTIVE_PROFILE_KEY] = effective_profile
+        state["instructions"] = instruction
+        write_profile_state(state_path=other.state_path, state=state)
+        updated.append(other.harness)
+    return updated
 
 
 def _split_components(text: str) -> tuple[str, str, str] | None:
@@ -408,18 +552,54 @@ def plan_managed_instruction_removal(*, path: Path, state: dict[str, Any]) -> Su
     return SurfacePlan("instruction", path, "conflict", "preserve", detail="owned instruction file was edited")
 
 
-def _instruction_plan(profile, state: dict[str, Any], *, adopt: bool, force: bool = False) -> SurfacePlan:
-    desired = profile.instruction_text or harness_profiles.managed_instruction_text()
+def _instruction_plan(
+    profile,
+    state: dict[str, Any],
+    *,
+    adopt: bool,
+    force: bool = False,
+    home: Path | None = None,
+    workspace: Path | None = None,
+    profile_override: str | None = None,
+) -> tuple[SurfacePlan, dict[str, Any]]:
+    """Plan instruction install and return depth-resolution metadata."""
     if profile.instruction_mode == "managed-file":
-        return plan_managed_instruction(path=profile.instruction_path, desired=desired, state=state, adopt=adopt)
-    return plan_instruction(
+        desired = profile.instruction_text or harness_profiles.managed_instruction_text()
+        plan = plan_managed_instruction(path=profile.instruction_path, desired=desired, state=state, adopt=adopt)
+        return plan, {
+            "required_profile": brief_sections.PROFILE_FULL,
+            "effective_profile": brief_sections.PROFILE_FULL,
+            "requirements": {profile.harness: brief_sections.PROFILE_FULL},
+        }
+
+    home_path = home or Path.home()
+    workspace_path = workspace or Path.cwd()
+    required = required_instruction_profile(profile, override=profile_override)
+    effective, requirements = resolve_effective_instruction_profile(
+        path=profile.instruction_path,
+        home=home_path,
+        workspace=workspace_path,
+        self_harness=profile.harness,
+        self_required=required,
+    )
+    desired = harness_profiles.managed_instruction_text(profile=effective)
+    # Co-owning a shared instruction file: when another integration already
+    # stamped the desired body, claim ownership without requiring --adopt.
+    coowned = any(name != profile.harness for name in requirements)
+    plan = plan_instruction(
         path=profile.instruction_path,
         desired=desired,
         state=state,
-        adopt=adopt,
+        adopt=adopt or coowned,
         force=force,
+        profile=effective,
         harness=profile.harness,
     )
+    return plan, {
+        "required_profile": required,
+        "effective_profile": effective,
+        "requirements": requirements,
+    }
 
 
 def _instruction_removal_plan(profile, state: dict[str, Any], *, force: bool = False) -> SurfacePlan:
@@ -1349,8 +1529,17 @@ def _prune_created_directories(paths: list[Path], root: Path) -> list[str]:
 
 
 def _sync_profile(
-    profile, workspace: Path, *, write: bool, allow_global_stdio: bool, adopt: bool, force: bool = False
+    profile,
+    workspace: Path,
+    *,
+    write: bool,
+    allow_global_stdio: bool,
+    adopt: bool,
+    force: bool = False,
+    home: Path | None = None,
+    profile_override: str | None = None,
 ) -> tuple[dict[str, Any], bool]:
+    home_path = home or Path.home()
     surface_conflicts = _native_surface_conflicts(profile, workspace)
     if surface_conflicts:
         return _surface_conflict_result(profile, surface_conflicts)
@@ -1378,12 +1567,23 @@ def _sync_profile(
         ), False
     state = json.loads(json.dumps(loaded.state))
     instruction_existed = profile.instruction_path.exists()
-    instruction = _instruction_plan(profile, state, adopt=adopt, force=force)
+    instruction, depth = _instruction_plan(
+        profile,
+        state,
+        adopt=adopt,
+        force=force,
+        home=home_path,
+        workspace=workspace,
+        profile_override=profile_override,
+    )
     item = {
         "surface": "instruction",
         "path": str(instruction.path),
         "status": instruction.status,
         "action": instruction.action,
+        "required_profile": depth["required_profile"],
+        "effective_profile": depth["effective_profile"],
+        "requirements": dict(depth["requirements"]),
     }
     if instruction.detail:
         item["detail"] = instruction.detail
@@ -1418,6 +1618,8 @@ def _sync_profile(
             instruction_record: dict[str, Any] = {
                 "digest": instruction.desired_digest,
                 "created_file": created_file,
+                _INSTRUCTION_REQUIRED_PROFILE_KEY: depth["required_profile"],
+                _INSTRUCTION_EFFECTIVE_PROFILE_KEY: depth["effective_profile"],
             }
             if isinstance(old_instruction, dict) and old_instruction.get("created_directories"):
                 instruction_record["created_directories"] = list(old_instruction["created_directories"])
@@ -1495,6 +1697,15 @@ def _sync_profile(
             if profile.instruction_mode == "managed-file":
                 existing_dirs = proposed["instructions"].get("created_directories", [])
                 proposed["instructions"]["created_directories"] = sorted(set(existing_dirs) | set(instruction_dirs))
+            elif instruction.desired_digest:
+                update_shared_instruction_digests(
+                    path=profile.instruction_path,
+                    home=home_path,
+                    workspace=workspace,
+                    digest=instruction.desired_digest,
+                    effective_profile=depth["effective_profile"],
+                    exclude_harness=profile.harness,
+                )
         created_dirs: dict[str, list[str]] = {}
         for path, data, skill_id, _relative in skill_plan["writes"]:
             created_dirs.setdefault(skill_id, []).extend(_missing_skill_directories(profile, path))
@@ -1582,7 +1793,10 @@ def _sync_profile(
     ), False
 
 
-def _uninstall_profile(profile, workspace: Path, *, write: bool, force: bool = False) -> tuple[dict[str, Any], bool]:
+def _uninstall_profile(
+    profile, workspace: Path, *, write: bool, force: bool = False, home: Path | None = None
+) -> tuple[dict[str, Any], bool]:
+    home_path = home or Path.home()
     surface_conflicts = _native_surface_conflicts(profile, workspace)
     if surface_conflicts:
         return _surface_conflict_result(profile, surface_conflicts)
@@ -1622,11 +1836,71 @@ def _uninstall_profile(profile, workspace: Path, *, write: bool, force: bool = F
             receipt_path=profile.receipt_path,
             receipt_state="present" if profile.receipt_path.exists() else "missing",
         ), False
-    plan = _instruction_removal_plan(profile, state, force=force)
-    items = [{"surface": "instruction", "path": str(plan.path), "status": plan.status, "action": plan.action}]
+
+    remaining: dict[str, str] = {}
+    shared_rewrite: SurfacePlan | None = None
+    if profile.instruction_mode == "marked-block":
+        remaining = collect_path_requirements(
+            path=profile.instruction_path,
+            home=home_path,
+            workspace=workspace,
+            exclude_harness=profile.harness,
+        )
+        if remaining:
+            effective = brief_sections.effective_profile(remaining.values())
+            assert effective is not None
+            desired = harness_profiles.managed_instruction_text(profile=effective)
+            shared_rewrite = plan_instruction(
+                path=profile.instruction_path,
+                desired=desired,
+                state=state,
+                adopt=True,
+                force=force,
+                profile=effective,
+                harness=profile.harness,
+            )
+            if shared_rewrite.status == "conflict":
+                plan = shared_rewrite
+            elif shared_rewrite.action in {"create", "update"}:
+                plan = SurfacePlan(
+                    "instruction",
+                    profile.instruction_path,
+                    shared_rewrite.status,
+                    "update",
+                    shared_rewrite.desired_digest,
+                    shared_rewrite.rendered,
+                    (
+                        f"shared file retains consumers ({','.join(sorted(remaining))}); "
+                        f"rewriting to effective={effective}"
+                    ),
+                )
+            else:
+                plan = SurfacePlan(
+                    "instruction",
+                    profile.instruction_path,
+                    "managed",
+                    "none",
+                    shared_rewrite.desired_digest,
+                    detail=(
+                        f"shared file retains consumers ({','.join(sorted(remaining))}); "
+                        f"already at effective={effective}"
+                    ),
+                )
+        else:
+            plan = _instruction_removal_plan(profile, state, force=force)
+    else:
+        plan = _instruction_removal_plan(profile, state, force=force)
+
+    items: list[dict[str, Any]] = [
+        {"surface": "instruction", "path": str(plan.path), "status": plan.status, "action": plan.action}
+    ]
     if plan.detail:
         items[0]["detail"] = plan.detail
-    conflicts = [] if plan.status != "conflict" else [items[0] | {"detail": plan.detail or "instruction conflict"}]
+    if remaining:
+        items[0]["remaining_requirements"] = dict(remaining)
+    conflicts: list[dict[str, Any]] = (
+        [] if plan.status != "conflict" else [items[0] | {"detail": plan.detail or "instruction conflict"}]
+    )
     skill_plan = _skill_uninstall_plan(profile, state)
     items.extend(skill_plan["items"])
     conflicts.extend(skill_plan["conflicts"])
@@ -1651,7 +1925,65 @@ def _uninstall_profile(profile, workspace: Path, *, write: bool, force: bool = F
     files_removed: list[str] = []
     files_written: list[str] = []
     if write and not conflicts:
-        if plan.action == "remove":
+        if plan.action == "update" and remaining and plan.rendered is not None:
+            outcome = managed_block.write_text_nofollow_atomic(plan.path, plan.rendered)
+            if outcome.status == managed_block.WRITE_SKIPPED_SYMLINK:
+                conflicts.append(
+                    {
+                        "surface": "instruction",
+                        "path": str(plan.path),
+                        "status": "conflict",
+                        "action": "preserve",
+                        "detail": outcome.detail or "symlinked instruction path",
+                    }
+                )
+                return _result(
+                    profile,
+                    status="conflict",
+                    ready=False,
+                    items=items,
+                    conflicts=conflicts,
+                    files_written=[],
+                    files_removed=[],
+                    mcp={"status": "pending", "items": []},
+                    receipt_path=profile.receipt_path,
+                    receipt_state="present" if profile.receipt_path.exists() else "missing",
+                ), False
+            if outcome.status not in {managed_block.WRITE_WRITTEN, managed_block.WRITE_NOOP}:
+                conflicts.append(
+                    {
+                        "surface": "instruction",
+                        "path": str(plan.path),
+                        "status": "conflict",
+                        "action": "preserve",
+                        "detail": outcome.detail or "instruction write refused",
+                    }
+                )
+                return _result(
+                    profile,
+                    status="conflict",
+                    ready=False,
+                    items=items,
+                    conflicts=conflicts,
+                    files_written=[],
+                    files_removed=[],
+                    mcp={"status": "pending", "items": []},
+                    receipt_path=profile.receipt_path,
+                    receipt_state="present" if profile.receipt_path.exists() else "missing",
+                ), False
+            files_written.append(str(plan.path))
+            if plan.desired_digest:
+                effective = brief_sections.effective_profile(remaining.values())
+                assert effective is not None
+                update_shared_instruction_digests(
+                    path=profile.instruction_path,
+                    home=home_path,
+                    workspace=workspace,
+                    digest=plan.desired_digest,
+                    effective_profile=effective,
+                    exclude_harness=profile.harness,
+                )
+        elif plan.action == "remove":
             if plan.rendered is None:
                 plan.path.unlink(missing_ok=True)
             else:
@@ -1751,7 +2083,15 @@ def _uninstall_profile(profile, workspace: Path, *, write: bool, force: bool = F
     ), changed
 
 
-def _doctor_profile(profile, workspace: Path, *, verify_mcp: bool) -> tuple[dict[str, Any], bool]:
+def _doctor_profile(
+    profile,
+    workspace: Path,
+    *,
+    verify_mcp: bool,
+    home: Path | None = None,
+    profile_override: str | None = None,
+) -> tuple[dict[str, Any], bool]:
+    home_path = home or Path.home()
     surface_conflicts = _native_surface_conflicts(profile, workspace)
     if surface_conflicts:
         return _surface_conflict_result(profile, surface_conflicts)
@@ -1777,12 +2117,22 @@ def _doctor_profile(profile, workspace: Path, *, verify_mcp: bool) -> tuple[dict
             receipt_state="missing",
         ), False
     state = loaded.state
-    instruction = _instruction_plan(profile, state, adopt=False)
+    instruction, depth = _instruction_plan(
+        profile,
+        state,
+        adopt=False,
+        home=home_path,
+        workspace=workspace,
+        profile_override=profile_override,
+    )
     item = {
         "surface": "instruction",
         "path": str(instruction.path),
         "status": instruction.status,
         "action": instruction.action,
+        "required_profile": depth["required_profile"],
+        "effective_profile": depth["effective_profile"],
+        "requirements": dict(depth["requirements"]),
     }
     if instruction.detail:
         item["detail"] = instruction.detail
@@ -1793,6 +2143,43 @@ def _doctor_profile(profile, workspace: Path, *, verify_mcp: bool) -> tuple[dict
     # Doctor --check semantics: anything not current is actionable. Preserve
     # distinct stale / missing / conflict statuses on the item itself.
     conflicts = [item] if instruction.status != "current" else []
+
+    # Hook drift: a minimal requirement without an active brief-injecting hook
+    # means the static pointer is no longer sufficient.
+    recorded_required = None
+    instruction_state = state.get("instructions")
+    if isinstance(instruction_state, dict):
+        raw_required = instruction_state.get(_INSTRUCTION_REQUIRED_PROFILE_KEY)
+        if isinstance(raw_required, str):
+            try:
+                recorded_required = brief_sections.normalize_profile(raw_required)
+            except ValueError:
+                recorded_required = None
+    hooks_active = hooks_inject_brief(profile)
+    if (
+        profile.instruction_mode == "marked-block"
+        and profile.harness in harness_profiles.HOOK_BRIEF_HARNESSES
+        and recorded_required == brief_sections.PROFILE_MINIMAL
+        and not hooks_active
+        and profile_override is None
+    ):
+        drift = {
+            "surface": "instruction-profile",
+            "path": str(profile.instruction_path),
+            "status": "stale",
+            "action": "update",
+            "detail": (
+                "minimal instruction profile remains but brief-injecting hooks are inactive; "
+                f"fix with: {_instruction_write_fix_command(profile.harness)}"
+            ),
+            "required_profile": recorded_required,
+            "hooks_active": False,
+        }
+        items_prefix = [item, drift]
+        conflicts.append(drift)
+    else:
+        items_prefix = [item]
+
     skill_plan = _skill_plans(profile, state, workspace)
     skill_issues = [entry for entry in skill_plan["items"] if entry["status"] != "current"]
     conflicts.extend(skill_issues)
@@ -1810,7 +2197,7 @@ def _doctor_profile(profile, workspace: Path, *, verify_mcp: bool) -> tuple[dict
         profile,
         status="current" if ready else "conflict",
         ready=ready,
-        items=[item, *skill_plan["items"], *generated_plan["items"], *hook_items],
+        items=[*items_prefix, *skill_plan["items"], *generated_plan["items"], *hook_items],
         conflicts=conflicts,
         files_written=[],
         files_removed=[],
@@ -1833,14 +2220,22 @@ def _run(
     verify_mcp: bool = False,
     json_output: bool = False,
     home: Path | None = None,
+    profile_override: str | None = None,
 ) -> int:
-    profiles = harness_profiles.resolve_user_profiles(harness=harness, home=home or Path.home(), workspace=workspace)
+    home_path = home or Path.home()
+    profiles = harness_profiles.resolve_user_profiles(harness=harness, home=home_path, workspace=workspace)
 
     def run_profile(profile, *, profile_write: bool) -> tuple[dict[str, Any], bool]:
         if operation == "sync":
             if check:
                 # --check is doctor-style classification for instruction freshness.
-                return _doctor_profile(profile, workspace, verify_mcp=False)
+                return _doctor_profile(
+                    profile,
+                    workspace,
+                    verify_mcp=False,
+                    home=home_path,
+                    profile_override=profile_override,
+                )
             return _sync_profile(
                 profile,
                 workspace,
@@ -1848,10 +2243,18 @@ def _run(
                 allow_global_stdio=allow_global_stdio,
                 adopt=adopt,
                 force=force,
+                home=home_path,
+                profile_override=profile_override,
             )
         elif operation == "uninstall":
-            return _uninstall_profile(profile, workspace, write=profile_write, force=force)
-        return _doctor_profile(profile, workspace, verify_mcp=verify_mcp)
+            return _uninstall_profile(profile, workspace, write=profile_write, force=force, home=home_path)
+        return _doctor_profile(
+            profile,
+            workspace,
+            verify_mcp=verify_mcp,
+            home=home_path,
+            profile_override=profile_override,
+        )
 
     if write and len(profiles) > 1 and operation in {"sync", "uninstall"}:
         preflight = [run_profile(profile, profile_write=False) for profile in profiles]
@@ -1905,6 +2308,7 @@ def sync(
     check: bool = False,
     json_output: bool = False,
     home: Path | None = None,
+    profile: str | None = None,
 ) -> int:
     return _run(
         "sync",
@@ -1917,6 +2321,7 @@ def sync(
         check=check,
         json_output=json_output,
         home=home,
+        profile_override=profile,
     )
 
 
@@ -1941,8 +2346,20 @@ def uninstall(
 
 
 def doctor(
-    *, harness: str, workspace: Path, verify_mcp: bool = False, json_output: bool = False, home: Path | None = None
+    *,
+    harness: str,
+    workspace: Path,
+    verify_mcp: bool = False,
+    json_output: bool = False,
+    home: Path | None = None,
+    profile: str | None = None,
 ) -> int:
     return _run(
-        "doctor", harness=harness, workspace=workspace, verify_mcp=verify_mcp, json_output=json_output, home=home
+        "doctor",
+        harness=harness,
+        workspace=workspace,
+        verify_mcp=verify_mcp,
+        json_output=json_output,
+        home=home,
+        profile_override=profile,
     )

--- a/src/brigade/harness_profiles.py
+++ b/src/brigade/harness_profiles.py
@@ -17,7 +17,12 @@ PROFILE_STATE_VERSION = 2
 INSTRUCTION_START = "<!-- brigade:user-profile:start -->"
 INSTRUCTION_END = "<!-- brigade:user-profile:end -->"
 INSTRUCTION_KIND = "INTEGRATION"
-INSTRUCTION_PROFILE = "full"
+INSTRUCTION_PROFILE_MINIMAL = "minimal"
+INSTRUCTION_PROFILE_FULL = "full"
+INSTRUCTION_PROFILE = INSTRUCTION_PROFILE_FULL
+# Harnesses whose SessionStart (or equivalent) injects the live work brief.
+# Their static block defaults to the minimal pointer when hooks are active.
+HOOK_BRIEF_HARNESSES = frozenset({"claude"})
 
 
 @dataclass(frozen=True)
@@ -172,13 +177,13 @@ def resolve_profiles(
     return resolve_slice1_profiles(harness=harness, home=home, workspace=workspace)
 
 
-def managed_instruction_text() -> str:
-    """Return the common managed user-profile instruction body."""
-    return (
-        "## Brigade work loop\n\n"
-        "Invoke the `using-skillet` skill and use each applicable reviewed skill before substantive work in a Brigade-wired repository.\n\n"
-        "Run `brigade work brief --target .` when a `.brigade/` directory exists or `brigade status --target .` succeeds, and follow the brief before editing.\n\n"
-        "Route worker-sized or parallelizable implementation through `brigade run` and keep the frontier session on planning, dispatch, review, and synthesis.\n\n"
-        'Run counting checks through `brigade work verify run --target . --command "<command>" --capture brigade-work`, capturing failures as evidence so the outcome ledger stays honest.\n\n'
-        "After substantial work, create a Memory Handoff through the standard Rocinante flow and never edit canonical memory directly.\n"
-    )
+def managed_instruction_text(*, profile: str = INSTRUCTION_PROFILE_FULL) -> str:
+    """Return the managed user-profile instruction body for a depth profile.
+
+    Bodies are rendered from the same ordered brief sections used by
+    ``brigade work brief`` (see ``brief_sections``). ``minimal`` is a short
+    pointer; ``full`` adds session-close and work-loop protocol.
+    """
+    from . import brief_sections
+
+    return brief_sections.render_static_instruction(profile)

--- a/src/brigade/managed_block.py
+++ b/src/brigade/managed_block.py
@@ -563,6 +563,19 @@ def assess_block(
 
     assert desired_digest is not None
     if not legacy and recorded == actual == desired_digest:
+        stamped_profile = parsed.meta.profile
+        if stamped_profile is not None and stamped_profile != profile:
+            return BlockAssessment(
+                STATUS_STALE,
+                kind,
+                parsed,
+                desired_hash=desired_digest,
+                recorded_hash=recorded,
+                actual_hash=actual,
+                profile=stamped_profile,
+                fix_command=fix,
+                detail=f"managed block profile is stale ({stamped_profile} != {profile})",
+            )
         return BlockAssessment(
             STATUS_CURRENT,
             kind,
@@ -570,7 +583,7 @@ def assess_block(
             desired_hash=desired_digest,
             recorded_hash=recorded,
             actual_hash=actual,
-            profile=parsed.meta.profile or profile,
+            profile=stamped_profile or profile,
             fix_command=fix,
         )
 

--- a/src/brigade/work_cmd/session/briefing.py
+++ b/src/brigade/work_cmd/session/briefing.py
@@ -310,8 +310,13 @@ def _brief_payload(target: Path, *, limit: int = 3, include_code_graph: bool = F
     known_handoff_issue_ids = handoff_cmd._known_local_issue_ids(target)
     new_handoff_issues = [issue for issue in handoff_issues if issue.id not in known_handoff_issue_ids]
     handoff_drafts = handoff_cmd.draft_queue_payload(target)
+    from ... import brief_sections
+
     return {
         "target": str(target),
+        "session_close": {
+            "items": list(brief_sections.session_close_items()),
+        },
         "git": git,
         "active_session": active,
         "latest_session": latest_session,
@@ -546,6 +551,10 @@ def brief(*, target: Path, limit: int = 3, json_output: bool = False) -> int:
         return 0
 
     print(f"work brief: {target}")
+    from ... import brief_sections
+
+    for line in brief_sections.render_brief_session_close_lines():
+        print(line)
     update = payload.get("update")
     if isinstance(update, dict):
         print(f'update_available: {update.get("latest")} (installed {update.get("installed")}); run "brigade update"')

--- a/tests/test_instruction_profiles.py
+++ b/tests/test_instruction_profiles.py
@@ -1,0 +1,240 @@
+"""Instruction depth profiles and brief-as-SSoT wiring (issue #733)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from brigade import brief_sections, harness_profile_cmd, harness_profiles, managed_block
+
+
+def _use_home(monkeypatch, tmp_path: Path) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setenv("HOME", str(home))
+    return home
+
+
+def _workspace(tmp_path: Path) -> Path:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    return workspace
+
+
+def test_minimal_profile_is_short_pointer_without_command_tables():
+    body = harness_profiles.managed_instruction_text(profile="minimal")
+    lines = [line for line in body.splitlines() if line.strip()]
+    assert len(lines) <= 15
+    assert "Work loop protocol" not in body
+    assert "| Command |" not in body
+    assert "brigade work brief" in body
+    assert "Memory Handoff" in body
+    assert body == brief_sections.render_static_instruction("minimal")
+
+
+def test_full_profile_uses_same_sections_as_brief_renderer():
+    full = harness_profiles.managed_instruction_text(profile="full")
+    assert full == brief_sections.render_sections(brief_sections.FULL_SECTIONS)
+    assert "## Session close" in full
+    assert "Work loop protocol" in full
+    for item in brief_sections.session_close_items():
+        assert item in full
+
+
+def test_effective_profile_is_richest_active_requirement():
+    assert brief_sections.effective_profile(["minimal", "full"]) == "full"
+    assert brief_sections.effective_profile(["full", "minimal"]) == "full"
+    assert brief_sections.effective_profile(["minimal"]) == "minimal"
+    assert brief_sections.effective_profile([]) is None
+
+
+def test_shared_file_full_then_minimal_keeps_full(tmp_path, monkeypatch):
+    home = _use_home(monkeypatch, tmp_path)
+    workspace = _workspace(tmp_path)
+    shared = home / "shared" / "AGENTS.md"
+    shared.parent.mkdir(parents=True)
+
+    def _profiles(*, harness: str, home: Path, workspace: Path):
+        selected = ("claude", "codex") if harness == "all" else (harness,)
+        out = []
+        for name in selected:
+            root = home / f".{name}"
+            out.append(
+                harness_profiles.HarnessProfile(
+                    harness=name,
+                    user_root=root,
+                    instruction_path=shared,
+                    skills_root=root / "skills",
+                    state_path=root / "brigade" / "install-state.json",
+                    receipt_path=root / "brigade" / "profile-receipt.json",
+                    mcp_harness=f"{name}-user" if name != "claude" else "claude-user",
+                    reload_hint=f"restart {name}",
+                )
+            )
+        return tuple(out)
+
+    monkeypatch.setattr(harness_profiles, "resolve_user_profiles", _profiles)
+
+    assert (
+        harness_profile_cmd.sync(
+            harness="codex", workspace=workspace, write=True, profile="full", json_output=True, home=home
+        )
+        == 0
+    )
+    text = shared.read_text(encoding="utf-8")
+    assert "profile:full" in text
+    assert "Work loop protocol" in text
+
+    assert (
+        harness_profile_cmd.sync(
+            harness="claude", workspace=workspace, write=True, profile="minimal", json_output=True, home=home
+        )
+        == 0
+    )
+    text = shared.read_text(encoding="utf-8")
+    assert "profile:full" in text
+    assert "Work loop protocol" in text
+    assert text.count("BEGIN BRIGADE INTEGRATION") == 1
+
+
+def test_shared_file_minimal_then_full_converges(tmp_path, monkeypatch):
+    home = _use_home(monkeypatch, tmp_path)
+    workspace = _workspace(tmp_path)
+    shared = home / "shared" / "AGENTS.md"
+    shared.parent.mkdir(parents=True)
+
+    def _profiles(*, harness: str, home: Path, workspace: Path):
+        selected = ("claude", "codex") if harness == "all" else (harness,)
+        out = []
+        for name in selected:
+            root = home / f".{name}"
+            out.append(
+                harness_profiles.HarnessProfile(
+                    harness=name,
+                    user_root=root,
+                    instruction_path=shared,
+                    skills_root=root / "skills",
+                    state_path=root / "brigade" / "install-state.json",
+                    receipt_path=root / "brigade" / "profile-receipt.json",
+                    mcp_harness=f"{name}-user" if name != "claude" else "claude-user",
+                    reload_hint=f"restart {name}",
+                )
+            )
+        return tuple(out)
+
+    monkeypatch.setattr(harness_profiles, "resolve_user_profiles", _profiles)
+
+    assert (
+        harness_profile_cmd.sync(
+            harness="claude", workspace=workspace, write=True, profile="minimal", json_output=True, home=home
+        )
+        == 0
+    )
+    assert "profile:minimal" in shared.read_text(encoding="utf-8")
+
+    assert (
+        harness_profile_cmd.sync(
+            harness="codex", workspace=workspace, write=True, profile="full", json_output=True, home=home
+        )
+        == 0
+    )
+    text = shared.read_text(encoding="utf-8")
+    assert "profile:full" in text
+    assert "Work loop protocol" in text
+
+
+def test_uninstall_last_full_consumer_drops_shared_file_to_minimal(tmp_path, monkeypatch):
+    home = _use_home(monkeypatch, tmp_path)
+    workspace = _workspace(tmp_path)
+    shared = home / "shared" / "AGENTS.md"
+    shared.parent.mkdir(parents=True)
+
+    def _profiles(*, harness: str, home: Path, workspace: Path):
+        selected = ("claude", "codex") if harness == "all" else (harness,)
+        out = []
+        for name in selected:
+            root = home / f".{name}"
+            out.append(
+                harness_profiles.HarnessProfile(
+                    harness=name,
+                    user_root=root,
+                    instruction_path=shared,
+                    skills_root=root / "skills",
+                    state_path=root / "brigade" / "install-state.json",
+                    receipt_path=root / "brigade" / "profile-receipt.json",
+                    mcp_harness=f"{name}-user" if name != "claude" else "claude-user",
+                    reload_hint=f"restart {name}",
+                )
+            )
+        return tuple(out)
+
+    monkeypatch.setattr(harness_profiles, "resolve_user_profiles", _profiles)
+
+    assert (
+        harness_profile_cmd.sync(
+            harness="claude", workspace=workspace, write=True, profile="minimal", json_output=True, home=home
+        )
+        == 0
+    )
+    assert (
+        harness_profile_cmd.sync(
+            harness="codex", workspace=workspace, write=True, profile="full", json_output=True, home=home
+        )
+        == 0
+    )
+    assert "profile:full" in shared.read_text(encoding="utf-8")
+
+    assert (
+        harness_profile_cmd.uninstall(harness="codex", workspace=workspace, write=True, json_output=True, home=home)
+        == 0
+    )
+    text = shared.read_text(encoding="utf-8")
+    assert "profile:minimal" in text
+    assert "Work loop protocol" not in text
+    assert (home / ".claude" / "brigade" / "install-state.json").is_file()
+    assert not (home / ".codex" / "brigade" / "install-state.json").exists()
+
+
+def test_profile_override_beats_hook_default(tmp_path, monkeypatch):
+    home = _use_home(monkeypatch, tmp_path)
+    workspace = _workspace(tmp_path)
+    monkeypatch.setattr(harness_profile_cmd, "hooks_inject_brief", lambda profile: True)
+
+    assert (
+        harness_profile_cmd.sync(
+            harness="claude", workspace=workspace, write=True, profile="full", json_output=True, home=home
+        )
+        == 0
+    )
+    text = (home / ".claude" / "CLAUDE.md").read_text(encoding="utf-8")
+    assert "profile:full" in text
+    state = json.loads((home / ".claude" / "brigade" / "install-state.json").read_text(encoding="utf-8"))
+    assert state["instructions"]["required_profile"] == "full"
+    assert state["instructions"]["effective_profile"] == "full"
+
+
+def test_doctor_flags_minimal_when_hooks_inactive(tmp_path, monkeypatch, capsys):
+    home = _use_home(monkeypatch, tmp_path)
+    workspace = _workspace(tmp_path)
+    monkeypatch.setattr(harness_profile_cmd, "hooks_inject_brief", lambda profile: True)
+    assert harness_profile_cmd.sync(harness="claude", workspace=workspace, write=True, json_output=True, home=home) == 0
+    text = (home / ".claude" / "CLAUDE.md").read_text(encoding="utf-8")
+    assert "profile:minimal" in text
+
+    monkeypatch.setattr(harness_profile_cmd, "hooks_inject_brief", lambda profile: False)
+    assert harness_profile_cmd.doctor(harness="claude", workspace=workspace, json_output=True, home=home) == 1
+    out = capsys.readouterr().out.strip().splitlines()[-1]
+    payload = json.loads(out)
+    result = payload["results"][0]
+    assert result["ready"] is False
+    surfaces = {item["surface"] for item in result["conflicts"]}
+    assert "instruction-profile" in surfaces or "instruction" in surfaces
+
+
+def test_marker_profile_mismatch_is_stale_even_when_body_matches():
+    body = harness_profiles.managed_instruction_text(profile="minimal")
+    stamped_full = managed_block.render_block(body, profile="full")
+    assessment = managed_block.assess_block(stamped_full, desired=body, profile="minimal")
+    assert assessment.status == managed_block.STATUS_STALE
+    assert "profile is stale" in (assessment.detail or "")

--- a/tests/test_update_notify.py
+++ b/tests/test_update_notify.py
@@ -335,7 +335,8 @@ def test_work_brief_prints_update_line_when_newer(tmp_path, tmp_path_factory, mo
     _write_state(cache_home, checked_at=100.0, latest="99.0.0")
     lines = _run_brief(tmp_path, cache_home, monkeypatch, capsys).splitlines()
     assert lines[0].startswith("work brief: ")
-    assert lines[1] == f'update_available: 99.0.0 (installed {__version__}); run "brigade update"'
+    assert lines[1] == "session_close:"
+    assert f'update_available: 99.0.0 (installed {__version__}); run "brigade update"' in lines
 
 
 def test_main_invokes_notify_after_command(monkeypatch):

--- a/tests/test_work_cmd_session.py
+++ b/tests/test_work_cmd_session.py
@@ -635,6 +635,10 @@ def test_work_brief_reports_morning_entrypoint(tmp_path, monkeypatch, capsys):
     assert work_cmd.brief(target=tmp_path, limit=2) == 0
     out = capsys.readouterr().out
     assert "work brief:" in out
+    assert out.index("session_close:") < out.index("active_session:")
+    assert "Verify captured through Brigade?" in out
+    assert "Outcome recorded?" in out
+    assert "Memory Handoff written" in out
     assert "active_session: none" in out
     assert "latest_session:" in out
     assert "latest_session_title: Ended Work" in out
@@ -664,6 +668,8 @@ def test_work_brief_json_reports_recent_sessions(tmp_path, monkeypatch, capsys):
 
     assert work_cmd.brief(target=tmp_path, json_output=True) == 0
     payload = json.loads(capsys.readouterr().out)
+    assert payload["session_close"]["items"]
+    assert any("Verify captured" in item for item in payload["session_close"]["items"])
     assert payload["active_session"]["title"] == "Active Work"
     assert payload["latest_session"]["title"] == "Active Work"
     assert payload["recent_sessions"][0]["status"] == "active"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements #733 on top of the hash-stamped managed blocks from #806/#732.

- Static harness instruction bodies come from shared `brief_sections` (same ordered sections as `brigade work brief`)
- `minimal` pointer for brief-injecting Claude hooks; `full` for file-only installs
- Per-integration `required_profile` ownership; shared files keep the richest active requirement
- Uninstalling the last full consumer rewrites the shared file down to minimal
- `--profile minimal|full` override; doctor flags minimal installs after hook drift
- Live `brigade work brief` opens with the session-close checklist

## Verification

```text
./scripts/verify
6336 passed, 3 skipped, 68 subtests passed
Required test coverage of 78% reached. Total coverage: 83.09%
```

Fixes #733

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-335f3249-e0da-4d1e-8382-a02710e25213?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-335f3249-e0da-4d1e-8382-a02710e25213&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

