### PR TITLE
feat(care): scaffold operator-owned scheduled care entries (#759)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   are recorded in `candidate-set.json` and stamped onto the plan; an empty
   required set fails closed with typed `no-admissible-tool` and one bounded
   replan instead of letting the model improvise tools.
+- `brigade care install|status|uninstall` (#759): opt-in scaffold that writes
+  hash-stamped managed entries into the operator's crontab (or systemd user
+  units), matching `docs/scheduled-care.md`. Memory-care recipes invoke the
+  shipped runbooks so scheduled fires write normal receipts; Windows prints
+  Task Scheduler equivalents instead of silently no-oping; tampered blocks are
+  reported and not clobbered without `--adopt`.
 - Work verify plan ranks candidate verification commands from GraphTrail
   affected-test impact (#486): `brigade work verify plan` attaches
   `graph_impact` / `ranked_candidates` with hop-distance confidence and

--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -17,6 +17,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 
 - `brigade add`: 1 command path(s)
 - `brigade budgets` (extras): 2 command path(s)
+- `brigade care`: 3 command path(s)
 - `brigade center` (extras): 30 command path(s)
 - `brigade chat` (extras): 7 command path(s)
 - `brigade code`: 16 command path(s)
@@ -77,6 +78,9 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade add`
 - `brigade budgets check` (extras)
 - `brigade budgets show` (extras)
+- `brigade care install`
+- `brigade care status`
+- `brigade care uninstall`
 - `brigade center actions archive` (extras)
 - `brigade center actions build` (extras)
 - `brigade center actions defer` (extras)

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -20,13 +20,20 @@ A scheduled invocation is still an explicit invocation: the same command runs wh
 
 `brigade tools runtime start` can launch a local MCP runtime process that you started and that you stop. That process is not a Brigade scheduler and does not run memory care, ingest, or outcome reconcile on its own.
 
-## Future work (not shipped)
+## Opt-in care scaffold
 
-Issue [#759](https://github.com/escoffier-labs/brigade/issues/759) tracks an opt-in care scaffold that would write managed entries into the operator's own scheduler (install / status / uninstall), still without Brigade owning a daemon. Until that lands, schedule Brigade yourself with crontab, systemd timers, CI, or your existing agent cron. That scaffold is not shipped in the current release.
+`brigade care install --target .` writes managed entries into the operator's
+own scheduler (crontab by default; `--backend systemd` writes user units).
+`brigade care status` audits those entries and shows the latest runbook
+receipt for each recipe. `brigade care uninstall` removes only the
+hash-stamped Brigade block. The schedule still belongs to the operator:
+Brigade does not run a daemon, and Windows prints Task Scheduler
+equivalents instead of writing them. See [scheduled care](scheduled-care.md).
 
 ## Related
 
 - [Memory care](memory-care.md): card scan, refresh queue, and import boundaries
+- [Scheduled care](scheduled-care.md): crontab, systemd, CI recipes and `brigade care`
 - [Scanner registry](scanner-registry.md): explicit foreground sweeps, not a scheduler
 - [Technical guide](technical-guide.md): full command surface and deliberate-friction rules
 - [Roadmap](../ROADMAP.md): direction, with this page as the execution-model source of truth

--- a/docs/memory-care.md
+++ b/docs/memory-care.md
@@ -76,6 +76,6 @@ Queue entries include card identity, issue type, severity, priority, safe summar
 
 ## Boundary
 
-Memory care does not run a scheduler, mutate canonical memory, perform remote sync, or promote imports automatically. Card edits stay explicit: routine scan and plan commands never write card files. Only `brigade memory care backfill --apply` may add derived frontmatter, with a receipt. Refreshes stay explicit through reviewed work tasks or the existing Memory Handoff flow. Scheduling those care commands is the operator's job: see the [execution model](execution-model.md).
+Memory care does not run a scheduler, mutate canonical memory, perform remote sync, or promote imports automatically. Card edits stay explicit: routine scan and plan commands never write card files. Only `brigade memory care backfill --apply` may add derived frontmatter, with a receipt. Refreshes stay explicit through reviewed work tasks or the existing Memory Handoff flow. Scheduling those care commands is the operator's job: see the [execution model](execution-model.md). Opt-in `brigade care install` can scaffold the operator's own crontab or systemd user timers without Brigade owning a daemon.
 
-For operator-owned cron, systemd, and CI recipes, see [scheduled care](scheduled-care.md).
+For operator-owned cron, systemd, and CI recipes (and `brigade care`), see [scheduled care](scheduled-care.md).

--- a/docs/scheduled-care.md
+++ b/docs/scheduled-care.md
@@ -37,7 +37,9 @@ weekly outcome ratchet invoke the shipped memory-care runbooks under
 `.brigade/memory-care/runbooks/` so each fire writes a runbook receipt. Weekly
 outcome uses the combined runbook at Monday 07:00 (rank then reconcile in one
 approved run) instead of the 30-minute gap in the hand-written crontab below.
-Daily observability stays a shell sequence; nightly ops calls
+Daily observability uses the shipped runbook at
+`.brigade/memory-care/runbooks/daily-observability.json` so each fire writes a
+receipt; nightly ops calls
 `.brigade/runbooks/nightly-maintenance.json` (operator-authored). Entries live
 inside a `# BEGIN BRIGADE CARE ... hash:...` managed block so status can detect
 drift and uninstall can remove only Brigade's span.
@@ -469,6 +471,14 @@ The GitHub Actions recipe runs reconcile immediately after rank in the same work
 
 Check handoff pipeline health, read the daily driver snapshot, and build the local operator report bundle. `center report build` is extras-gated. Run `brigade extras on` once per machine or prefix with `BRIGADE_EXTRAS=1`.
 
+`brigade care install` materializes `.brigade/memory-care/runbooks/daily-observability.json` and schedules it as a runbook so each fire writes a normal runbook receipt.
+
+```bash
+brigade runbook run --approved .brigade/memory-care/runbooks/daily-observability.json --target .
+```
+
+The runbook steps are:
+
 ```bash
 brigade handoff doctor --target .
 brigade daily status --target .
@@ -479,7 +489,7 @@ brigade center report build --target .
 
 ```cron
 PATH=/home/you/.local/bin:/usr/local/bin:/usr/bin:/bin
-0 8 * * * cd "WORKSPACE" && brigade handoff doctor --target . && brigade daily status --target . && brigade center report build --target .
+0 8 * * * cd "WORKSPACE" && brigade runbook run --approved ".brigade/memory-care/runbooks/daily-observability.json" --target .
 ```
 
 ### systemd user timer
@@ -494,7 +504,7 @@ Description=Brigade daily observability pass
 Type=oneshot
 WorkingDirectory=WORKSPACE
 Environment=PATH=/home/you/.local/bin:/usr/local/bin:/usr/bin:/bin
-ExecStart=/bin/sh -c 'brigade handoff doctor --target . && brigade daily status --target . && brigade center report build --target .'
+ExecStart=brigade runbook run --approved .brigade/memory-care/runbooks/daily-observability.json --target .
 ```
 
 `~/.config/systemd/user/brigade-daily-observability.timer`:

--- a/docs/scheduled-care.md
+++ b/docs/scheduled-care.md
@@ -1,6 +1,13 @@
 # Scheduled Memory Care
 
-The schedule belongs to the operator. Brigade only runs when invoked. Brigade does not install cron jobs, systemd timers, GitHub Actions workflows, or any other scheduler. Copy one of the recipes below into your own crontab, user timer, or CI job after `brigade init` wires the target.
+The schedule belongs to the operator. Brigade only runs when invoked. Copy one
+of the recipes below into your own crontab, user timer, or CI job after
+`brigade init` wires the target, or let `brigade care install --target .`
+scaffold the same recipes as a hash-stamped managed block in your crontab
+(systemd user units with `--backend systemd`). `care status` audits the block
+and latest runbook receipts; `care uninstall` removes only that block. On
+Windows, `care install` prints Task Scheduler equivalents and does not write
+tasks. Brigade still does not own a daemon or background supervisor.
 
 Prerequisites:
 
@@ -15,7 +22,27 @@ brigade extras on   # once per machine; required for center report and runbook c
 
 Replace `WORKSPACE` with the absolute path to your Brigade-wired repo or operator workspace. Every `brigade` command below assumes `cd` into that directory first, so `--target .` resolves correctly. In crontab lines, quote the path (`cd "WORKSPACE"`) so spaces and shell metacharacters do not break the job.
 
-Related docs: [memory care](memory-care.md), [scanner registry](scanner-registry.md), [operator center](operator-center.md), [agents guide](agents-guide.md).
+### brigade care (opt-in scaffold)
+
+```bash
+brigade memory care init --with-runbooks --target .
+brigade extras on   # runbook + center report are extras-gated
+brigade care install --target .
+brigade care status --target .
+# brigade care uninstall --target .
+```
+
+`care install` scaffolds the recipes on this page. Daily care, ingest sweep, and
+weekly outcome ratchet invoke the shipped memory-care runbooks under
+`.brigade/memory-care/runbooks/` so each fire writes a runbook receipt. Weekly
+outcome uses the combined runbook at Monday 07:00 (rank then reconcile in one
+approved run) instead of the 30-minute gap in the hand-written crontab below.
+Daily observability stays a shell sequence; nightly ops calls
+`.brigade/runbooks/nightly-maintenance.json` (operator-authored). Entries live
+inside a `# BEGIN BRIGADE CARE ... hash:...` managed block so status can detect
+drift and uninstall can remove only Brigade's span.
+
+Related docs: [memory care](memory-care.md), [scanner registry](scanner-registry.md), [operator center](operator-center.md), [agents guide](agents-guide.md), [execution model](execution-model.md).
 
 ## Scheduler wiring
 

--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -1670,7 +1670,7 @@ Each subsystem has a companion doc under [`docs/`]() with the full local contrac
 - [`docs/backup-health.md`](backup-health.md) - read-only backup health summaries and issue routing
 - [`docs/memory-care.md`](memory-care.md) - memory card decay scanning and refresh imports
 - [`docs/execution-model.md`](execution-model.md) - explicit-invocation boundary and external-scheduler ownership
-- [`docs/scheduled-care.md`](scheduled-care.md) - operator-owned cron, systemd, and CI recipes for the memory-care loop
+- [`docs/scheduled-care.md`](scheduled-care.md) - operator-owned cron, systemd, and CI recipes plus `brigade care` scaffold for the memory-care loop
 - [`docs/security.md`](security.md) - the agent workspace security scanner and evidence bundles
 - [`docs/inspiration-patterns.md`](inspiration-patterns.md) - neutral pattern families and source-pattern decisions
 - [`docs/roadmap-completion-plan.md`](roadmap-completion-plan.md) - the large-roadmap completion plan and phase boundaries

--- a/src/brigade/care_cmd.py
+++ b/src/brigade/care_cmd.py
@@ -23,6 +23,7 @@ from . import managed_block, memory_cmd, runbook_cmd
 
 CARE_KIND = "CARE"
 CARE_MARKER_VERSION = 1
+CARE_MARKER_STYLE = managed_block.MARKER_STYLE_HASH
 DEFAULT_BACKEND: Literal["crontab", "systemd"] = "crontab"
 SUPPORTED_BACKENDS = ("crontab", "systemd")
 
@@ -30,8 +31,24 @@ MEMORY_CARE_RUNBOOK_REL = {
     "daily-care": ".brigade/memory-care/runbooks/daily-care-pass.json",
     "ingest-sweep": ".brigade/memory-care/runbooks/ingest-sweep.json",
     "weekly-outcome-ratchet": ".brigade/memory-care/runbooks/weekly-outcome-ratchet.json",
+    "daily-observability": ".brigade/memory-care/runbooks/daily-observability.json",
 }
 NIGHTLY_RUNBOOK_REL = ".brigade/runbooks/nightly-maintenance.json"
+DAILY_OBSERVABILITY_RUNBOOK_NAME = "daily-observability.json"
+DAILY_OBSERVABILITY_RUNBOOK_PAYLOAD: dict[str, Any] = {
+    "id": "daily-observability",
+    "description": (
+        "Daily handoff health, daily driver snapshot, and operator report bundle. "
+        "Run from the repo or workspace root: "
+        "brigade runbook run --approved .brigade/memory-care/runbooks/daily-observability.json"
+    ),
+    "allowed_commands": ["brigade"],
+    "steps": [
+        {"id": "handoff-doctor", "run": "brigade handoff doctor --target ."},
+        {"id": "daily-status", "run": "brigade daily status --target ."},
+        {"id": "center-report", "run": "brigade center report build --target ."},
+    ],
+}
 
 
 @dataclass(frozen=True)
@@ -83,12 +100,9 @@ CARE_ENTRIES: tuple[CareEntry, ...] = (
         schedule="0 8 * * *",
         on_calendar="*-*-* 08:00:00",
         description="Brigade daily observability pass",
-        kind="shell",
-        shell=(
-            "brigade handoff doctor --target . && "
-            "brigade daily status --target . && "
-            "brigade center report build --target ."
-        ),
+        kind="runbook",
+        runbook_rel=MEMORY_CARE_RUNBOOK_REL["daily-observability"],
+        runbook_id="daily-observability",
     ),
     CareEntry(
         entry_id="nightly-ops",
@@ -112,15 +126,60 @@ def _path_prefix(home: Path | None = None) -> str:
     return f"{local_bin}:/usr/local/bin:/usr/bin:/bin"
 
 
+def _public_block_status(status: str) -> str:
+    if status == managed_block.STATUS_LOCALLY_MODIFIED:
+        return "tampered"
+    return status
+
+
+def _block_body_from_rendered(text: str) -> str:
+    parsed = managed_block.parse_blocks(text, kind=CARE_KIND, style=CARE_MARKER_STYLE)
+    return parsed.body if parsed.status == "ok" else ""
+
+
+def _owned_digest_from_text(text: str) -> str | None:
+    parsed = managed_block.parse_blocks(text, kind=CARE_KIND, style=CARE_MARKER_STYLE)
+    return parsed.actual_hash if parsed.status == "ok" else None
+
+
+def _systemd_quote_value(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"').replace("%", "%%")
+    if value and all(ch not in ' \t\n\r"\\%' for ch in value):
+        return value
+    return f'"{escaped}"'
+
+
+def _systemd_environment_path(path_value: str) -> str:
+    inner = path_value.replace("\\", "\\\\").replace('"', '\\"').replace("%", "%%")
+    if any(ch in ' \t\n\r"\\%' for ch in path_value):
+        return f'Environment="PATH={inner}"'
+    return f"Environment=PATH={path_value}"
+
+
+def _systemd_exec_start_runbook(runbook_rel: str) -> str:
+    argv = ["/usr/bin/env", "brigade", "runbook", "run", "--approved", runbook_rel, "--target", "."]
+    return "ExecStart=" + " ".join(_systemd_quote_value(arg) for arg in argv)
+
+
+def _systemd_working_directory(workspace: Path) -> str:
+    return f"WorkingDirectory={_systemd_quote_value(str(workspace))}"
+
+
+def _cron_escape_path(value: str) -> str:
+    """Escape cron metacharacters in a path embedded in a double-quoted shell fragment."""
+    return value.replace("\\", "\\\\").replace('"', '\\"').replace("$", "\\$").replace("`", "\\`").replace("%", "\\%")
+
+
 def _cron_command(entry: CareEntry, *, workspace: Path) -> str:
-    quoted = str(workspace).replace('"', '\\"')
+    quoted_workspace = _cron_escape_path(str(workspace))
     if entry.kind == "runbook":
         assert entry.runbook_rel is not None
-        body = f"brigade runbook run --approved {entry.runbook_rel} --target ."
+        quoted_rel = _cron_escape_path(entry.runbook_rel)
+        body = f'brigade runbook run --approved "{quoted_rel}" --target .'
     else:
         assert entry.shell is not None
         body = entry.shell
-    return f'cd "{quoted}" && {body}'
+    return f'cd "{quoted_workspace}" && {body}'
 
 
 def _crontab_body(*, workspace: Path, home: Path | None = None) -> str:
@@ -132,11 +191,11 @@ def _crontab_body(*, workspace: Path, home: Path | None = None) -> str:
 
 def render_crontab_block(*, workspace: Path, home: Path | None = None) -> str:
     """Render the managed crontab block including markers."""
-    return managed_block.wrap_block(
+    return managed_block.render_block(
+        _crontab_body(workspace=workspace, home=home),
         kind=CARE_KIND,
         profile="crontab",
-        body=_crontab_body(workspace=workspace, home=home),
-        style="hash",
+        style=CARE_MARKER_STYLE,
     )
 
 
@@ -196,6 +255,40 @@ def _ensure_memory_care_runbooks(target: Path) -> int:
     return memory_cmd._write_memory_care_runbooks(target)
 
 
+def _write_daily_observability_runbook(target: Path) -> int:
+    """Materialize the daily-observability runbook with binary pins when missing."""
+    dest = memory_cmd._memory_care_runbooks_dir(target) / DAILY_OBSERVABILITY_RUNBOOK_NAME
+    if dest.is_file():
+        return 0
+    temp = dest.parent / f".{DAILY_OBSERVABILITY_RUNBOOK_NAME}.init-tmp"
+    try:
+        from .localio import write_json as _write_json
+
+        temp.parent.mkdir(parents=True, exist_ok=True)
+        _write_json(temp, dict(DAILY_OBSERVABILITY_RUNBOOK_PAYLOAD))
+        validated, error = runbook_cmd._read_runbook(temp, require_pin_hashes=False)
+        if validated is None:
+            print(f"error: {error}", file=sys.stderr)
+            return 2
+        pins, pin_error = runbook_cmd._pin_payload_from_runbook(target, validated)
+        if pins is None:
+            print(f"error: {pin_error}", file=sys.stderr)
+            return 2
+        validated["pins"] = pins
+        _write_json(dest, validated)
+        return 0
+    finally:
+        if temp.is_file():
+            temp.unlink()
+
+
+def _ensure_care_runbooks(target: Path) -> int:
+    rc = _ensure_memory_care_runbooks(target)
+    if rc != 0:
+        return rc
+    return _write_daily_observability_runbook(target)
+
+
 def _latest_runbook_receipt(target: Path, runbook_id: str) -> dict[str, Any] | None:
     for receipt in runbook_cmd._run_receipts(target):
         if str(receipt.get("runbook_id") or "") == runbook_id:
@@ -211,29 +304,23 @@ def _entry_status(target: Path, entry: CareEntry) -> dict[str, Any]:
         "kind": entry.kind,
         "description": entry.description,
     }
-    if entry.kind == "runbook":
-        assert entry.runbook_rel is not None
-        path = target / entry.runbook_rel
-        payload["runbook"] = entry.runbook_rel
-        payload["runbook_id"] = entry.runbook_id
-        payload["runbook_present"] = path.is_file()
-        receipt = _latest_runbook_receipt(target, entry.runbook_id or "")
-        if receipt is None:
-            payload["last_receipt"] = None
-        else:
-            payload["last_receipt"] = {
-                "run_id": receipt.get("run_id"),
-                "status": receipt.get("status"),
-                "started_at": receipt.get("started_at"),
-                "completed_at": receipt.get("completed_at"),
-                "receipt_path": receipt.get("receipt_path"),
-            }
-    else:
-        payload["shell"] = entry.shell
+    assert entry.kind == "runbook"
+    assert entry.runbook_rel is not None
+    path = target / entry.runbook_rel
+    payload["runbook"] = entry.runbook_rel
+    payload["runbook_id"] = entry.runbook_id
+    payload["runbook_present"] = path.is_file()
+    receipt = _latest_runbook_receipt(target, entry.runbook_id or "")
+    if receipt is None:
         payload["last_receipt"] = None
-        payload["receipt_note"] = (
-            "shell recipes do not write a runbook receipt; inspect local artifacts under .brigade/"
-        )
+    else:
+        payload["last_receipt"] = {
+            "run_id": receipt.get("run_id"),
+            "status": receipt.get("status"),
+            "started_at": receipt.get("started_at"),
+            "completed_at": receipt.get("completed_at"),
+            "receipt_path": receipt.get("receipt_path"),
+        }
     return payload
 
 
@@ -311,7 +398,7 @@ def install(
     if _is_windows():
         return _windows_print(workspace=target)
 
-    rc = _ensure_memory_care_runbooks(target)
+    rc = _ensure_care_runbooks(target)
     if rc != 0:
         return rc
 
@@ -333,59 +420,95 @@ def _install_crontab(
         print(f"error: failed to read crontab: {error}", file=sys.stderr)
         return 2
     desired_body = _crontab_body(workspace=target, home=home)
-    plan = managed_block.classify_block(current, kind=CARE_KIND, desired_body=desired_body)
-    if plan.status == "current":
+    assessment = managed_block.assess_block(
+        current,
+        desired=desired_body,
+        kind=CARE_KIND,
+        profile="crontab",
+        style=CARE_MARKER_STYLE,
+    )
+    if assessment.status == managed_block.STATUS_CURRENT:
         payload = {
             "target": str(target),
             "backend": "crontab",
             "status": "current",
-            "action": "none",
-            "hash": plan.desired_hash,
+            "action": managed_block.ACTION_NONE,
+            "hash": assessment.desired_hash,
             "dry_run": dry_run,
             "entries": [_entry_status(target, entry) for entry in CARE_ENTRIES],
         }
         _print_payload(payload, json_output=json_output)
         return 0
-    if plan.status == "tampered" and not adopt:
+    if assessment.status == managed_block.STATUS_LOCALLY_MODIFIED and not adopt:
         payload = {
             "target": str(target),
             "backend": "crontab",
             "status": "tampered",
-            "action": "preserve",
-            "recorded_hash": plan.recorded_hash,
-            "live_hash": plan.live_hash,
-            "desired_hash": plan.desired_hash,
-            "detail": plan.detail,
+            "action": managed_block.ACTION_PRESERVE,
+            "recorded_hash": assessment.recorded_hash,
+            "live_hash": assessment.actual_hash,
+            "desired_hash": assessment.desired_hash,
+            "detail": assessment.detail,
             "fix_command": "brigade care install --target . --adopt",
             "entries": [_entry_status(target, entry) for entry in CARE_ENTRIES],
         }
         _print_payload(payload, json_output=json_output)
         print("error: care crontab block was hand-edited; refusing to clobber without --adopt", file=sys.stderr)
         return 1
+    if assessment.status == managed_block.STATUS_MALFORMED:
+        payload = {
+            "target": str(target),
+            "backend": "crontab",
+            "status": managed_block.STATUS_MALFORMED,
+            "action": managed_block.ACTION_PRESERVE,
+            "desired_hash": assessment.desired_hash,
+            "detail": assessment.detail,
+            "entries": [_entry_status(target, entry) for entry in CARE_ENTRIES],
+        }
+        _print_payload(payload, json_output=json_output)
+        print("error: care crontab block has malformed markers; refusing to install", file=sys.stderr)
+        return 1
 
-    rendered, apply_plan = managed_block.apply_block(
+    plan = managed_block.plan_install(
         current,
+        desired=desired_body,
         kind=CARE_KIND,
         profile="crontab",
-        desired_body=desired_body,
-        style="hash",
         adopt=adopt,
+        style=CARE_MARKER_STYLE,
     )
+    rendered = plan.rendered if plan.rendered is not None else current
     payload = {
         "target": str(target),
         "backend": "crontab",
-        "status": apply_plan.status,
-        "action": apply_plan.action,
-        "hash": apply_plan.desired_hash,
+        "status": _public_block_status(plan.status),
+        "action": plan.action,
+        "hash": plan.desired_hash,
         "dry_run": dry_run,
         "entries": [_entry_status(target, entry) for entry in CARE_ENTRIES],
     }
     if dry_run:
-        payload["rendered_block"] = managed_block.wrap_block(
-            kind=CARE_KIND, profile="crontab", body=desired_body, style="hash"
+        payload["rendered_block"] = managed_block.render_block(
+            desired_body,
+            kind=CARE_KIND,
+            profile="crontab",
+            style=CARE_MARKER_STYLE,
         )
         _print_payload(payload, json_output=json_output)
         return 0
+    if plan.action == managed_block.ACTION_NONE:
+        _print_payload(payload, json_output=json_output)
+        if not json_output:
+            print("next_command: brigade care status --target .")
+        return 0
+    if plan.action == managed_block.ACTION_PRESERVE:
+        payload["detail"] = plan.detail
+        _print_payload(payload, json_output=json_output)
+        if plan.status == managed_block.STATUS_MALFORMED:
+            print("error: care crontab block has malformed markers; refusing to install", file=sys.stderr)
+        else:
+            print("error: care crontab block was hand-edited; refusing to clobber without --adopt", file=sys.stderr)
+        return 1
     write_error = _write_crontab(rendered)
     if write_error:
         print(f"error: failed to write crontab: {write_error}", file=sys.stderr)
@@ -412,12 +535,8 @@ def _systemd_unit_bodies(*, workspace: Path, home: Path | None = None) -> dict[s
     for entry in CARE_ENTRIES:
         service_name = f"brigade-{entry.entry_id}.service"
         timer_name = f"brigade-{entry.entry_id}.timer"
-        if entry.kind == "runbook":
-            assert entry.runbook_rel is not None
-            exec_start = f"ExecStart=brigade runbook run --approved {entry.runbook_rel} --target ."
-        else:
-            assert entry.shell is not None
-            exec_start = f"ExecStart=/bin/sh -c '{entry.shell}'"
+        assert entry.kind == "runbook" and entry.runbook_rel is not None
+        exec_start = _systemd_exec_start_runbook(entry.runbook_rel)
         service_body = "\n".join(
             [
                 "[Unit]",
@@ -425,8 +544,8 @@ def _systemd_unit_bodies(*, workspace: Path, home: Path | None = None) -> dict[s
                 "",
                 "[Service]",
                 "Type=oneshot",
-                f"WorkingDirectory={workspace}",
-                f"Environment=PATH={path_value}",
+                _systemd_working_directory(workspace),
+                _systemd_environment_path(path_value),
                 exec_start,
             ]
         )
@@ -443,10 +562,12 @@ def _systemd_unit_bodies(*, workspace: Path, home: Path | None = None) -> dict[s
                 "WantedBy=timers.target",
             ]
         )
-        units[service_name] = managed_block.wrap_block(
-            kind=CARE_KIND, profile="systemd", body=service_body, style="hash"
+        units[service_name] = managed_block.render_block(
+            service_body, kind=CARE_KIND, profile="systemd", style=CARE_MARKER_STYLE
         )
-        units[timer_name] = managed_block.wrap_block(kind=CARE_KIND, profile="systemd", body=timer_body, style="hash")
+        units[timer_name] = managed_block.render_block(
+            timer_body, kind=CARE_KIND, profile="systemd", style=CARE_MARKER_STYLE
+        )
     return units
 
 
@@ -464,44 +585,78 @@ def _install_systemd(
     blocked = False
     for name, desired_text in units.items():
         path = unit_dir / name
-        existing = path.read_text(encoding="utf-8") if path.is_file() else ""
-        desired_match = managed_block.find_block(desired_text, kind=CARE_KIND)
-        assert desired_match is not None
-        plan = managed_block.classify_block(existing, kind=CARE_KIND, desired_body=desired_match.body)
-        if plan.status == "tampered" and not adopt:
+        desired_body = _block_body_from_rendered(desired_text)
+        existing_text: str | None
+        if path.is_file():
+            if path.is_symlink():
+                print(f"error: refusing to follow symlink unit: {path}", file=sys.stderr)
+                return 2
+            try:
+                existing_text = managed_block.read_text_nofollow(path)
+            except (OSError, UnicodeDecodeError) as exc:
+                print(f"error: failed to read unit {path}: {exc}", file=sys.stderr)
+                return 2
+        else:
+            existing_text = None
+        plan = managed_block.plan_install(
+            existing_text,
+            desired=desired_body,
+            kind=CARE_KIND,
+            profile="systemd",
+            adopt=adopt,
+            style=CARE_MARKER_STYLE,
+        )
+        public_status = _public_block_status(plan.status)
+        if plan.action == managed_block.ACTION_PRESERVE:
             blocked = True
             results.append(
                 {
                     "name": name,
                     "path": str(path),
-                    "status": "tampered",
-                    "action": "preserve",
+                    "status": public_status,
+                    "action": managed_block.ACTION_PRESERVE,
                     "detail": plan.detail,
                 }
             )
             continue
-        if plan.status == "current":
-            results.append({"name": name, "path": str(path), "status": "current", "action": "none"})
+        if plan.status == managed_block.STATUS_CURRENT and plan.action == managed_block.ACTION_NONE:
+            results.append({"name": name, "path": str(path), "status": "current", "action": managed_block.ACTION_NONE})
             continue
         results.append(
             {
                 "name": name,
                 "path": str(path),
-                "status": plan.status,
-                "action": "create" if plan.status == "missing" else "update",
+                "status": public_status,
+                "action": plan.action,
             }
         )
         if dry_run:
             continue
         unit_dir.mkdir(parents=True, exist_ok=True)
-        if path.exists() or path.is_symlink():
-            try:
-                if path.is_symlink():
-                    print(f"error: refusing to follow symlink unit: {path}", file=sys.stderr)
-                    return 2
-            except OSError:
-                pass
-        path.write_text(desired_text, encoding="utf-8")
+        _, outcome = managed_block.install_block(
+            path,
+            desired_body,
+            kind=CARE_KIND,
+            profile="systemd",
+            adopt=adopt,
+            style=CARE_MARKER_STYLE,
+        )
+        if outcome.status == managed_block.WRITE_ERROR:
+            print(f"error: failed to write unit {path}: {outcome.detail}", file=sys.stderr)
+            return 2
+        if outcome.status == managed_block.WRITE_SKIPPED_SYMLINK:
+            print(f"error: refusing to follow symlink unit: {path}", file=sys.stderr)
+            return 2
+        if outcome.status == managed_block.WRITE_REFUSED:
+            blocked = True
+            results[-1] = {
+                "name": name,
+                "path": str(path),
+                "status": public_status,
+                "action": managed_block.ACTION_PRESERVE,
+                "detail": outcome.detail or plan.detail,
+            }
+            continue
     payload = {
         "target": str(target),
         "backend": "systemd",
@@ -518,7 +673,10 @@ def _install_systemd(
     }
     _print_payload(payload, json_output=json_output)
     if blocked:
-        print("error: one or more systemd units were hand-edited; refusing without --adopt", file=sys.stderr)
+        if any(unit.get("status") == managed_block.STATUS_MALFORMED for unit in results):
+            print("error: one or more systemd units have malformed markers; refusing to install", file=sys.stderr)
+        else:
+            print("error: one or more systemd units were hand-edited; refusing without --adopt", file=sys.stderr)
         return 1
     if not json_output and not dry_run:
         print("note: Brigade wrote unit files only; enable timers with systemctl --user.")
@@ -557,28 +715,42 @@ def status(
             print(f"error: failed to read crontab: {error}", file=sys.stderr)
             return 2
         desired_body = _crontab_body(workspace=target, home=home)
-        plan = managed_block.classify_block(current, kind=CARE_KIND, desired_body=desired_body)
-        match = managed_block.find_block(current, kind=CARE_KIND)
+        assessment = managed_block.assess_block(
+            current,
+            desired=desired_body,
+            kind=CARE_KIND,
+            profile="crontab",
+            style=CARE_MARKER_STYLE,
+        )
+        plan = managed_block.plan_install(
+            current,
+            desired=desired_body,
+            kind=CARE_KIND,
+            profile="crontab",
+            style=CARE_MARKER_STYLE,
+        )
+        parsed = managed_block.parse_blocks(current, kind=CARE_KIND, style=CARE_MARKER_STYLE)
+        public_status = _public_block_status(assessment.status)
         crontab_payload: dict[str, Any] = {
             "target": str(target),
             "backend": "crontab",
-            "status": plan.status,
+            "status": public_status,
             "action": plan.action,
-            "recorded_hash": plan.recorded_hash,
-            "live_hash": plan.live_hash,
-            "desired_hash": plan.desired_hash,
-            "detail": plan.detail,
-            "profile": match.profile if match else None,
+            "recorded_hash": assessment.recorded_hash,
+            "live_hash": assessment.actual_hash,
+            "desired_hash": assessment.desired_hash,
+            "detail": assessment.detail,
+            "profile": parsed.meta.profile if parsed.meta else None,
             "entries": [_entry_status(target, entry) for entry in CARE_ENTRIES],
         }
-        if plan.status == "tampered":
+        if public_status == "tampered":
             crontab_payload["fix_command"] = "brigade care install --target . --adopt"
-        elif plan.status == "stale":
+        elif public_status == "stale":
             crontab_payload["fix_command"] = "brigade care install --target ."
-        elif plan.status == "missing":
+        elif public_status == managed_block.STATUS_MISSING:
             crontab_payload["fix_command"] = "brigade care install --target ."
         _print_payload(crontab_payload, json_output=json_output)
-        return 0 if plan.status in {"current", "missing"} else 1
+        return 0 if public_status in {"current", managed_block.STATUS_MISSING} else 1
 
     unit_dir = _systemd_user_dir(home)
     units = _systemd_unit_bodies(workspace=target, home=home)
@@ -586,26 +758,53 @@ def status(
     worst = "current"
     for name, desired_text in units.items():
         path = unit_dir / name
-        existing = path.read_text(encoding="utf-8") if path.is_file() else ""
-        desired_match = managed_block.find_block(desired_text, kind=CARE_KIND)
-        assert desired_match is not None
-        plan = managed_block.classify_block(existing, kind=CARE_KIND, desired_body=desired_match.body)
+        if path.is_symlink():
+            existing_text = ""
+            public_status = managed_block.STATUS_MALFORMED
+            results.append(
+                {
+                    "name": name,
+                    "path": str(path),
+                    "status": public_status,
+                    "recorded_hash": None,
+                    "live_hash": None,
+                    "desired_hash": None,
+                }
+            )
+            worst = public_status if worst == "current" else worst
+            continue
+        if not path.is_file():
+            existing_text = ""
+        else:
+            try:
+                existing_text = managed_block.read_text_nofollow(path)
+            except OSError:
+                existing_text = ""
+        desired_body = _block_body_from_rendered(desired_text)
+        assessment = managed_block.assess_block(
+            existing_text,
+            desired=desired_body,
+            kind=CARE_KIND,
+            profile="systemd",
+            style=CARE_MARKER_STYLE,
+        )
+        public_status = _public_block_status(assessment.status)
         results.append(
             {
                 "name": name,
                 "path": str(path),
-                "status": plan.status,
-                "recorded_hash": plan.recorded_hash,
-                "live_hash": plan.live_hash,
-                "desired_hash": plan.desired_hash,
+                "status": public_status,
+                "recorded_hash": assessment.recorded_hash,
+                "live_hash": assessment.actual_hash,
+                "desired_hash": assessment.desired_hash,
             }
         )
-        if plan.status == "tampered":
+        if public_status == "tampered":
             worst = "tampered"
-        elif plan.status == "stale" and worst != "tampered":
+        elif public_status == managed_block.STATUS_STALE and worst != "tampered":
             worst = "stale"
-        elif plan.status == "missing" and worst == "current":
-            worst = "missing"
+        elif public_status == managed_block.STATUS_MISSING and worst == "current":
+            worst = managed_block.STATUS_MISSING
     payload = {
         "target": str(target),
         "backend": "systemd",
@@ -615,7 +814,7 @@ def status(
         "entries": [_entry_status(target, entry) for entry in CARE_ENTRIES],
     }
     _print_payload(payload, json_output=json_output)
-    return 0 if worst in {"current", "missing"} else 1
+    return 0 if worst in {"current", managed_block.STATUS_MISSING} else 1
 
 
 def uninstall(
@@ -646,17 +845,28 @@ def uninstall(
         if error:
             print(f"error: failed to read crontab: {error}", file=sys.stderr)
             return 2
-        rendered, plan = managed_block.remove_block(current, kind=CARE_KIND)
+        owned_digest = _owned_digest_from_text(current)
+        plan = managed_block.plan_remove(current, kind=CARE_KIND, owned_digest=owned_digest, style=CARE_MARKER_STYLE)
+        public_status = _public_block_status(plan.status)
         payload = {
             "target": str(target),
             "backend": "crontab",
-            "status": plan.status,
+            "status": public_status,
             "action": plan.action,
             "dry_run": dry_run,
+            "detail": plan.detail,
         }
-        if plan.action == "none":
+        if plan.action == managed_block.ACTION_PRESERVE:
+            _print_payload(payload, json_output=json_output)
+            print(
+                "error: care crontab block was hand-edited; refusing to remove without repair",
+                file=sys.stderr,
+            )
+            return 1
+        if plan.action == managed_block.ACTION_NONE:
             _print_payload(payload, json_output=json_output)
             return 0
+        rendered = plan.rendered if plan.rendered is not None else ""
         if dry_run:
             payload["would_write"] = True
             _print_payload(payload, json_output=json_output)
@@ -671,6 +881,8 @@ def uninstall(
     unit_dir = _systemd_user_dir(home)
     removed: list[str] = []
     skipped: list[str] = []
+    refused: list[str] = []
+    blocked = False
     for entry in CARE_ENTRIES:
         for suffix in (".service", ".timer"):
             name = f"brigade-{entry.entry_id}{suffix}"
@@ -681,15 +893,41 @@ def uninstall(
             if path.is_symlink():
                 print(f"error: refusing to remove symlink unit: {path}", file=sys.stderr)
                 return 2
-            text = path.read_text(encoding="utf-8")
-            match = managed_block.find_block(text, kind=CARE_KIND)
-            if match is None:
+            try:
+                text = managed_block.read_text_nofollow(path)
+            except OSError as exc:
+                print(f"error: failed to read unit {path}: {exc}", file=sys.stderr)
+                return 2
+            owned_digest = _owned_digest_from_text(text)
+            plan = managed_block.plan_remove(text, kind=CARE_KIND, owned_digest=owned_digest, style=CARE_MARKER_STYLE)
+            if plan.action == managed_block.ACTION_PRESERVE:
+                blocked = True
+                refused.append(name)
+                continue
+            if plan.action == managed_block.ACTION_NONE:
                 skipped.append(name)
                 continue
             if dry_run:
                 removed.append(name)
                 continue
-            path.unlink()
+            remove_plan, outcome = managed_block.remove_block(
+                path,
+                kind=CARE_KIND,
+                owned_digest=owned_digest,
+                style=CARE_MARKER_STYLE,
+            )
+            if remove_plan.action == managed_block.ACTION_PRESERVE:
+                blocked = True
+                refused.append(name)
+                continue
+            if outcome.status == managed_block.WRITE_ERROR:
+                print(f"error: failed to update unit {path}: {outcome.detail}", file=sys.stderr)
+                return 2
+            if outcome.status == managed_block.WRITE_SKIPPED_SYMLINK:
+                print(f"error: refusing to remove symlink unit: {path}", file=sys.stderr)
+                return 2
+            if path.exists() and not managed_block.read_text_nofollow(path).strip():
+                path.unlink()
             removed.append(name)
     payload = {
         "target": str(target),
@@ -697,7 +935,14 @@ def uninstall(
         "dry_run": dry_run,
         "removed": removed,
         "skipped": skipped,
+        "refused": refused,
         "next_commands": ["systemctl --user daemon-reload"],
     }
     _print_payload(payload, json_output=json_output)
+    if blocked:
+        print(
+            "error: one or more systemd units were hand-edited; refusing to remove without repair",
+            file=sys.stderr,
+        )
+        return 1
     return 0

--- a/src/brigade/care_cmd.py
+++ b/src/brigade/care_cmd.py
@@ -1,0 +1,703 @@
+"""Opt-in scheduler scaffold for scheduled memory care (issue #759).
+
+``brigade care install|status|uninstall`` writes and audits user-owned
+scheduler entries. Brigade never runs a daemon; the operator's crontab,
+systemd user timers, or Task Scheduler remains the trigger.
+
+Default entries match ``docs/scheduled-care.md``. Recipes that ship as
+memory-care runbooks invoke those runbooks so each scheduled fire writes a
+normal runbook receipt.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from . import managed_block, memory_cmd, runbook_cmd
+
+CARE_KIND = "CARE"
+CARE_MARKER_VERSION = 1
+DEFAULT_BACKEND: Literal["crontab", "systemd"] = "crontab"
+SUPPORTED_BACKENDS = ("crontab", "systemd")
+
+MEMORY_CARE_RUNBOOK_REL = {
+    "daily-care": ".brigade/memory-care/runbooks/daily-care-pass.json",
+    "ingest-sweep": ".brigade/memory-care/runbooks/ingest-sweep.json",
+    "weekly-outcome-ratchet": ".brigade/memory-care/runbooks/weekly-outcome-ratchet.json",
+}
+NIGHTLY_RUNBOOK_REL = ".brigade/runbooks/nightly-maintenance.json"
+
+
+@dataclass(frozen=True)
+class CareEntry:
+    """One scheduled care recipe from docs/scheduled-care.md."""
+
+    entry_id: str
+    schedule: str  # crontab five-field expression
+    on_calendar: str  # systemd OnCalendar=
+    description: str
+    kind: Literal["runbook", "shell"]
+    runbook_rel: str | None = None
+    shell: str | None = None  # multi-command shell body without cd/PATH
+    runbook_id: str | None = None
+
+
+# Schedules and recipes mirror docs/scheduled-care.md. Where a shipped
+# memory-care runbook covers the recipe, invoke that runbook for receipts.
+CARE_ENTRIES: tuple[CareEntry, ...] = (
+    CareEntry(
+        entry_id="daily-care",
+        schedule="15 6 * * *",
+        on_calendar="*-*-* 06:15:00",
+        description="Brigade daily memory care pass",
+        kind="runbook",
+        runbook_rel=MEMORY_CARE_RUNBOOK_REL["daily-care"],
+        runbook_id="daily-care-pass",
+    ),
+    CareEntry(
+        entry_id="ingest-sweep",
+        schedule="*/30 * * * *",
+        on_calendar="*:0/30",
+        description="Brigade handoff ingest sweep",
+        kind="runbook",
+        runbook_rel=MEMORY_CARE_RUNBOOK_REL["ingest-sweep"],
+        runbook_id="ingest-sweep",
+    ),
+    CareEntry(
+        entry_id="weekly-outcome-ratchet",
+        schedule="0 7 * * 1",
+        on_calendar="Mon *-*-* 07:00:00",
+        description="Brigade weekly outcome ratchet",
+        kind="runbook",
+        runbook_rel=MEMORY_CARE_RUNBOOK_REL["weekly-outcome-ratchet"],
+        runbook_id="weekly-outcome-ratchet",
+    ),
+    CareEntry(
+        entry_id="daily-observability",
+        schedule="0 8 * * *",
+        on_calendar="*-*-* 08:00:00",
+        description="Brigade daily observability pass",
+        kind="shell",
+        shell=(
+            "brigade handoff doctor --target . && "
+            "brigade daily status --target . && "
+            "brigade center report build --target ."
+        ),
+    ),
+    CareEntry(
+        entry_id="nightly-ops",
+        schedule="0 4 * * *",
+        on_calendar="*-*-* 04:00:00",
+        description="Brigade nightly maintenance runbook",
+        kind="runbook",
+        runbook_rel=NIGHTLY_RUNBOOK_REL,
+        runbook_id="nightly-maintenance",
+    ),
+)
+
+
+def _is_windows() -> bool:
+    return sys.platform == "win32"
+
+
+def _path_prefix(home: Path | None = None) -> str:
+    root = home if home is not None else Path.home()
+    local_bin = root / ".local" / "bin"
+    return f"{local_bin}:/usr/local/bin:/usr/bin:/bin"
+
+
+def _cron_command(entry: CareEntry, *, workspace: Path) -> str:
+    quoted = str(workspace).replace('"', '\\"')
+    if entry.kind == "runbook":
+        assert entry.runbook_rel is not None
+        body = f"brigade runbook run --approved {entry.runbook_rel} --target ."
+    else:
+        assert entry.shell is not None
+        body = entry.shell
+    return f'cd "{quoted}" && {body}'
+
+
+def _crontab_body(*, workspace: Path, home: Path | None = None) -> str:
+    lines = [f"PATH={_path_prefix(home)}"]
+    for entry in CARE_ENTRIES:
+        lines.append(f"{entry.schedule} {_cron_command(entry, workspace=workspace)}")
+    return "\n".join(lines)
+
+
+def render_crontab_block(*, workspace: Path, home: Path | None = None) -> str:
+    """Render the managed crontab block including markers."""
+    return managed_block.wrap_block(
+        kind=CARE_KIND,
+        profile="crontab",
+        body=_crontab_body(workspace=workspace, home=home),
+        style="hash",
+    )
+
+
+def _read_crontab() -> tuple[str, str | None]:
+    """Return (text, error). Empty crontab is success with empty text."""
+    try:
+        result = subprocess.run(
+            ["crontab", "-l"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+            timeout=15,
+        )
+    except FileNotFoundError:
+        return "", "crontab command not found"
+    except subprocess.TimeoutExpired:
+        return "", "crontab -l timed out"
+    stderr = (result.stderr or "").strip()
+    if result.returncode == 0:
+        return result.stdout, None
+    # Common empty-crontab messages across implementations.
+    lowered = stderr.lower()
+    if "no crontab" in lowered or result.returncode == 1 and not (result.stdout or "").strip():
+        return "", None
+    return "", stderr or f"crontab -l exited {result.returncode}"
+
+
+def _write_crontab(text: str) -> str | None:
+    payload = text if text.endswith("\n") or text == "" else text + "\n"
+    try:
+        result = subprocess.run(
+            ["crontab", "-"],
+            input=payload,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+            timeout=15,
+        )
+    except FileNotFoundError:
+        return "crontab command not found"
+    except subprocess.TimeoutExpired:
+        return "crontab - timed out"
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        return detail or f"crontab - exited {result.returncode}"
+    return None
+
+
+def _ensure_memory_care_runbooks(target: Path) -> int:
+    """Write shipped memory-care runbooks when any are missing."""
+    runbook_dir = memory_cmd._memory_care_runbooks_dir(target)
+    missing = [name for name in memory_cmd.MEMORY_CARE_RUNBOOK_NAMES if not (runbook_dir / name).is_file()]
+    if not missing:
+        return 0
+    return memory_cmd._write_memory_care_runbooks(target)
+
+
+def _latest_runbook_receipt(target: Path, runbook_id: str) -> dict[str, Any] | None:
+    for receipt in runbook_cmd._run_receipts(target):
+        if str(receipt.get("runbook_id") or "") == runbook_id:
+            return receipt
+    return None
+
+
+def _entry_status(target: Path, entry: CareEntry) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "id": entry.entry_id,
+        "schedule": entry.schedule,
+        "on_calendar": entry.on_calendar,
+        "kind": entry.kind,
+        "description": entry.description,
+    }
+    if entry.kind == "runbook":
+        assert entry.runbook_rel is not None
+        path = target / entry.runbook_rel
+        payload["runbook"] = entry.runbook_rel
+        payload["runbook_id"] = entry.runbook_id
+        payload["runbook_present"] = path.is_file()
+        receipt = _latest_runbook_receipt(target, entry.runbook_id or "")
+        if receipt is None:
+            payload["last_receipt"] = None
+        else:
+            payload["last_receipt"] = {
+                "run_id": receipt.get("run_id"),
+                "status": receipt.get("status"),
+                "started_at": receipt.get("started_at"),
+                "completed_at": receipt.get("completed_at"),
+                "receipt_path": receipt.get("receipt_path"),
+            }
+    else:
+        payload["shell"] = entry.shell
+        payload["last_receipt"] = None
+        payload["receipt_note"] = (
+            "shell recipes do not write a runbook receipt; inspect local artifacts under .brigade/"
+        )
+    return payload
+
+
+def _windows_print(*, workspace: Path) -> int:
+    """Print Task Scheduler equivalents; never silently no-op on Windows."""
+    print("care install: Windows Task Scheduler is not written automatically.")
+    print("Print the equivalent schtasks commands below, then create the tasks yourself.")
+    print(f"workspace: {workspace}")
+    print("")
+    for entry in CARE_ENTRIES:
+        task_name = f"BrigadeCare-{entry.entry_id}"
+        command = _cron_command(entry, workspace=workspace)
+        # schtasks /SC requires a schedule family; print a reviewable template.
+        print(f":: {entry.description}")
+        print(f'schtasks /Create /TN "{task_name}" /SC DAILY /ST 06:15 /TR "cmd /c {command}" /F')
+        print(f"schedule_hint: cron '{entry.schedule}' / OnCalendar={entry.on_calendar}")
+        print("")
+    print("next: create the tasks above in Task Scheduler, then re-run care status after the first fire.")
+    print("error: care install does not mutate the Windows scheduler in this release", file=sys.stderr)
+    return 3
+
+
+def _print_payload(payload: dict[str, Any], *, json_output: bool) -> None:
+    if json_output:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    for key, value in payload.items():
+        if key == "entries" and isinstance(value, list):
+            print(f"entries: {len(value)}")
+            for entry in value:
+                if not isinstance(entry, dict):
+                    continue
+                receipt = entry.get("last_receipt")
+                receipt_bit = "none"
+                if isinstance(receipt, dict):
+                    receipt_bit = f"{receipt.get('status')}@{receipt.get('started_at')}"
+                present = entry.get("runbook_present")
+                present_bit = ""
+                if present is False:
+                    present_bit = " runbook=missing"
+                elif present is True:
+                    present_bit = " runbook=present"
+                print(
+                    f"  - {entry.get('id')}: schedule={entry.get('schedule')} last_receipt={receipt_bit}{present_bit}"
+                )
+            continue
+        if key == "units" and isinstance(value, list):
+            print(f"units: {len(value)}")
+            for unit in value:
+                if isinstance(unit, dict):
+                    print(f"  - {unit.get('name')}: {unit.get('path')} ({unit.get('status')})")
+            continue
+        if isinstance(value, (dict, list)):
+            print(f"{key}: {json.dumps(value, sort_keys=True)}")
+        else:
+            print(f"{key}: {value}")
+
+
+def install(
+    *,
+    target: Path,
+    backend: str = DEFAULT_BACKEND,
+    dry_run: bool = False,
+    adopt: bool = False,
+    json_output: bool = False,
+    home: Path | None = None,
+) -> int:
+    target = target.expanduser().resolve()
+    if not target.is_dir():
+        print(f"error: --target is not a directory: {target}", file=sys.stderr)
+        return 2
+    if backend not in SUPPORTED_BACKENDS:
+        print(f"error: unsupported care backend: {backend}", file=sys.stderr)
+        return 2
+    if _is_windows():
+        return _windows_print(workspace=target)
+
+    rc = _ensure_memory_care_runbooks(target)
+    if rc != 0:
+        return rc
+
+    if backend == "crontab":
+        return _install_crontab(target=target, dry_run=dry_run, adopt=adopt, json_output=json_output, home=home)
+    return _install_systemd(target=target, dry_run=dry_run, adopt=adopt, json_output=json_output, home=home)
+
+
+def _install_crontab(
+    *,
+    target: Path,
+    dry_run: bool,
+    adopt: bool,
+    json_output: bool,
+    home: Path | None,
+) -> int:
+    current, error = _read_crontab()
+    if error:
+        print(f"error: failed to read crontab: {error}", file=sys.stderr)
+        return 2
+    desired_body = _crontab_body(workspace=target, home=home)
+    plan = managed_block.classify_block(current, kind=CARE_KIND, desired_body=desired_body)
+    if plan.status == "current":
+        payload = {
+            "target": str(target),
+            "backend": "crontab",
+            "status": "current",
+            "action": "none",
+            "hash": plan.desired_hash,
+            "dry_run": dry_run,
+            "entries": [_entry_status(target, entry) for entry in CARE_ENTRIES],
+        }
+        _print_payload(payload, json_output=json_output)
+        return 0
+    if plan.status == "tampered" and not adopt:
+        payload = {
+            "target": str(target),
+            "backend": "crontab",
+            "status": "tampered",
+            "action": "preserve",
+            "recorded_hash": plan.recorded_hash,
+            "live_hash": plan.live_hash,
+            "desired_hash": plan.desired_hash,
+            "detail": plan.detail,
+            "fix_command": "brigade care install --target . --adopt",
+            "entries": [_entry_status(target, entry) for entry in CARE_ENTRIES],
+        }
+        _print_payload(payload, json_output=json_output)
+        print("error: care crontab block was hand-edited; refusing to clobber without --adopt", file=sys.stderr)
+        return 1
+
+    rendered, apply_plan = managed_block.apply_block(
+        current,
+        kind=CARE_KIND,
+        profile="crontab",
+        desired_body=desired_body,
+        style="hash",
+        adopt=adopt,
+    )
+    payload = {
+        "target": str(target),
+        "backend": "crontab",
+        "status": apply_plan.status,
+        "action": apply_plan.action,
+        "hash": apply_plan.desired_hash,
+        "dry_run": dry_run,
+        "entries": [_entry_status(target, entry) for entry in CARE_ENTRIES],
+    }
+    if dry_run:
+        payload["rendered_block"] = managed_block.wrap_block(
+            kind=CARE_KIND, profile="crontab", body=desired_body, style="hash"
+        )
+        _print_payload(payload, json_output=json_output)
+        return 0
+    write_error = _write_crontab(rendered)
+    if write_error:
+        print(f"error: failed to write crontab: {write_error}", file=sys.stderr)
+        return 2
+    _print_payload(payload, json_output=json_output)
+    if not json_output:
+        print("next_command: brigade care status --target .")
+        print("note: scheduled runbook entries require `brigade extras on` (or BRIGADE_EXTRAS=1).")
+    return 0
+
+
+def _systemd_user_dir(home: Path | None = None) -> Path:
+    if home is not None:
+        return home / ".config" / "systemd" / "user"
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    if xdg:
+        return Path(xdg).expanduser() / "systemd" / "user"
+    return Path.home() / ".config" / "systemd" / "user"
+
+
+def _systemd_unit_bodies(*, workspace: Path, home: Path | None = None) -> dict[str, str]:
+    path_value = _path_prefix(home)
+    units: dict[str, str] = {}
+    for entry in CARE_ENTRIES:
+        service_name = f"brigade-{entry.entry_id}.service"
+        timer_name = f"brigade-{entry.entry_id}.timer"
+        if entry.kind == "runbook":
+            assert entry.runbook_rel is not None
+            exec_start = f"ExecStart=brigade runbook run --approved {entry.runbook_rel} --target ."
+        else:
+            assert entry.shell is not None
+            exec_start = f"ExecStart=/bin/sh -c '{entry.shell}'"
+        service_body = "\n".join(
+            [
+                "[Unit]",
+                f"Description={entry.description}",
+                "",
+                "[Service]",
+                "Type=oneshot",
+                f"WorkingDirectory={workspace}",
+                f"Environment=PATH={path_value}",
+                exec_start,
+            ]
+        )
+        timer_body = "\n".join(
+            [
+                "[Unit]",
+                f"Description={entry.description} timer",
+                "",
+                "[Timer]",
+                f"OnCalendar={entry.on_calendar}",
+                "Persistent=true",
+                "",
+                "[Install]",
+                "WantedBy=timers.target",
+            ]
+        )
+        units[service_name] = managed_block.wrap_block(
+            kind=CARE_KIND, profile="systemd", body=service_body, style="hash"
+        )
+        units[timer_name] = managed_block.wrap_block(kind=CARE_KIND, profile="systemd", body=timer_body, style="hash")
+    return units
+
+
+def _install_systemd(
+    *,
+    target: Path,
+    dry_run: bool,
+    adopt: bool,
+    json_output: bool,
+    home: Path | None,
+) -> int:
+    unit_dir = _systemd_user_dir(home)
+    units = _systemd_unit_bodies(workspace=target, home=home)
+    results: list[dict[str, Any]] = []
+    blocked = False
+    for name, desired_text in units.items():
+        path = unit_dir / name
+        existing = path.read_text(encoding="utf-8") if path.is_file() else ""
+        desired_match = managed_block.find_block(desired_text, kind=CARE_KIND)
+        assert desired_match is not None
+        plan = managed_block.classify_block(existing, kind=CARE_KIND, desired_body=desired_match.body)
+        if plan.status == "tampered" and not adopt:
+            blocked = True
+            results.append(
+                {
+                    "name": name,
+                    "path": str(path),
+                    "status": "tampered",
+                    "action": "preserve",
+                    "detail": plan.detail,
+                }
+            )
+            continue
+        if plan.status == "current":
+            results.append({"name": name, "path": str(path), "status": "current", "action": "none"})
+            continue
+        results.append(
+            {
+                "name": name,
+                "path": str(path),
+                "status": plan.status,
+                "action": "create" if plan.status == "missing" else "update",
+            }
+        )
+        if dry_run:
+            continue
+        unit_dir.mkdir(parents=True, exist_ok=True)
+        if path.exists() or path.is_symlink():
+            try:
+                if path.is_symlink():
+                    print(f"error: refusing to follow symlink unit: {path}", file=sys.stderr)
+                    return 2
+            except OSError:
+                pass
+        path.write_text(desired_text, encoding="utf-8")
+    payload = {
+        "target": str(target),
+        "backend": "systemd",
+        "unit_dir": str(unit_dir),
+        "dry_run": dry_run,
+        "blocked": blocked,
+        "units": results,
+        "entries": [_entry_status(target, entry) for entry in CARE_ENTRIES],
+        "next_commands": [
+            "systemctl --user daemon-reload",
+            "systemctl --user enable --now brigade-daily-care.timer",
+            "systemctl --user list-timers 'brigade-*.timer'",
+        ],
+    }
+    _print_payload(payload, json_output=json_output)
+    if blocked:
+        print("error: one or more systemd units were hand-edited; refusing without --adopt", file=sys.stderr)
+        return 1
+    if not json_output and not dry_run:
+        print("note: Brigade wrote unit files only; enable timers with systemctl --user.")
+        print("note: scheduled runbook entries require `brigade extras on` (or BRIGADE_EXTRAS=1).")
+    return 0
+
+
+def status(
+    *,
+    target: Path,
+    backend: str = DEFAULT_BACKEND,
+    json_output: bool = False,
+    home: Path | None = None,
+) -> int:
+    target = target.expanduser().resolve()
+    if not target.is_dir():
+        print(f"error: --target is not a directory: {target}", file=sys.stderr)
+        return 2
+    if backend not in SUPPORTED_BACKENDS:
+        print(f"error: unsupported care backend: {backend}", file=sys.stderr)
+        return 2
+    if _is_windows():
+        windows_payload: dict[str, Any] = {
+            "target": str(target),
+            "backend": "windows",
+            "status": "unsupported-backend",
+            "detail": "care status does not read Task Scheduler in this release; use schtasks /Query",
+            "entries": [_entry_status(target, entry) for entry in CARE_ENTRIES],
+        }
+        _print_payload(windows_payload, json_output=json_output)
+        return 3
+
+    if backend == "crontab":
+        current, error = _read_crontab()
+        if error:
+            print(f"error: failed to read crontab: {error}", file=sys.stderr)
+            return 2
+        desired_body = _crontab_body(workspace=target, home=home)
+        plan = managed_block.classify_block(current, kind=CARE_KIND, desired_body=desired_body)
+        match = managed_block.find_block(current, kind=CARE_KIND)
+        crontab_payload: dict[str, Any] = {
+            "target": str(target),
+            "backend": "crontab",
+            "status": plan.status,
+            "action": plan.action,
+            "recorded_hash": plan.recorded_hash,
+            "live_hash": plan.live_hash,
+            "desired_hash": plan.desired_hash,
+            "detail": plan.detail,
+            "profile": match.profile if match else None,
+            "entries": [_entry_status(target, entry) for entry in CARE_ENTRIES],
+        }
+        if plan.status == "tampered":
+            crontab_payload["fix_command"] = "brigade care install --target . --adopt"
+        elif plan.status == "stale":
+            crontab_payload["fix_command"] = "brigade care install --target ."
+        elif plan.status == "missing":
+            crontab_payload["fix_command"] = "brigade care install --target ."
+        _print_payload(crontab_payload, json_output=json_output)
+        return 0 if plan.status in {"current", "missing"} else 1
+
+    unit_dir = _systemd_user_dir(home)
+    units = _systemd_unit_bodies(workspace=target, home=home)
+    results: list[dict[str, Any]] = []
+    worst = "current"
+    for name, desired_text in units.items():
+        path = unit_dir / name
+        existing = path.read_text(encoding="utf-8") if path.is_file() else ""
+        desired_match = managed_block.find_block(desired_text, kind=CARE_KIND)
+        assert desired_match is not None
+        plan = managed_block.classify_block(existing, kind=CARE_KIND, desired_body=desired_match.body)
+        results.append(
+            {
+                "name": name,
+                "path": str(path),
+                "status": plan.status,
+                "recorded_hash": plan.recorded_hash,
+                "live_hash": plan.live_hash,
+                "desired_hash": plan.desired_hash,
+            }
+        )
+        if plan.status == "tampered":
+            worst = "tampered"
+        elif plan.status == "stale" and worst != "tampered":
+            worst = "stale"
+        elif plan.status == "missing" and worst == "current":
+            worst = "missing"
+    payload = {
+        "target": str(target),
+        "backend": "systemd",
+        "status": worst,
+        "unit_dir": str(unit_dir),
+        "units": results,
+        "entries": [_entry_status(target, entry) for entry in CARE_ENTRIES],
+    }
+    _print_payload(payload, json_output=json_output)
+    return 0 if worst in {"current", "missing"} else 1
+
+
+def uninstall(
+    *,
+    target: Path,
+    backend: str = DEFAULT_BACKEND,
+    dry_run: bool = False,
+    json_output: bool = False,
+    home: Path | None = None,
+) -> int:
+    target = target.expanduser().resolve()
+    if not target.is_dir():
+        print(f"error: --target is not a directory: {target}", file=sys.stderr)
+        return 2
+    if backend not in SUPPORTED_BACKENDS:
+        print(f"error: unsupported care backend: {backend}", file=sys.stderr)
+        return 2
+    if _is_windows():
+        print("care uninstall: Windows Task Scheduler is not mutated automatically.")
+        print("Remove BrigadeCare-* tasks with schtasks /Delete, or Task Scheduler UI.")
+        for entry in CARE_ENTRIES:
+            print(f'schtasks /Delete /TN "BrigadeCare-{entry.entry_id}" /F')
+        print("error: care uninstall does not mutate the Windows scheduler in this release", file=sys.stderr)
+        return 3
+
+    if backend == "crontab":
+        current, error = _read_crontab()
+        if error:
+            print(f"error: failed to read crontab: {error}", file=sys.stderr)
+            return 2
+        rendered, plan = managed_block.remove_block(current, kind=CARE_KIND)
+        payload = {
+            "target": str(target),
+            "backend": "crontab",
+            "status": plan.status,
+            "action": plan.action,
+            "dry_run": dry_run,
+        }
+        if plan.action == "none":
+            _print_payload(payload, json_output=json_output)
+            return 0
+        if dry_run:
+            payload["would_write"] = True
+            _print_payload(payload, json_output=json_output)
+            return 0
+        write_error = _write_crontab(rendered)
+        if write_error:
+            print(f"error: failed to write crontab: {write_error}", file=sys.stderr)
+            return 2
+        _print_payload(payload, json_output=json_output)
+        return 0
+
+    unit_dir = _systemd_user_dir(home)
+    removed: list[str] = []
+    skipped: list[str] = []
+    for entry in CARE_ENTRIES:
+        for suffix in (".service", ".timer"):
+            name = f"brigade-{entry.entry_id}{suffix}"
+            path = unit_dir / name
+            if not path.exists():
+                skipped.append(name)
+                continue
+            if path.is_symlink():
+                print(f"error: refusing to remove symlink unit: {path}", file=sys.stderr)
+                return 2
+            text = path.read_text(encoding="utf-8")
+            match = managed_block.find_block(text, kind=CARE_KIND)
+            if match is None:
+                skipped.append(name)
+                continue
+            if dry_run:
+                removed.append(name)
+                continue
+            path.unlink()
+            removed.append(name)
+    payload = {
+        "target": str(target),
+        "backend": "systemd",
+        "dry_run": dry_run,
+        "removed": removed,
+        "skipped": skipped,
+        "next_commands": ["systemctl --user daemon-reload"],
+    }
+    _print_payload(payload, json_output=json_output)
+    return 0

--- a/src/brigade/cli/__init__.py
+++ b/src/brigade/cli/__init__.py
@@ -31,6 +31,7 @@ from . import (
     profiles as _profiles_group,
     receipts as _receipts_group,
     daily as _daily_group,
+    care as _care_group,
     add as _add_group,
     setup as _setup_group,
     update as _update_group,
@@ -145,6 +146,7 @@ def _build_parser() -> argparse.ArgumentParser:
     _profiles_group.register(sub)
     _receipts_group.register(sub)
     _daily_group.register(sub)
+    _care_group.register(sub)
     _add_group.register(sub)
     _setup_group.register(sub)
     _update_group.register(sub)

--- a/src/brigade/cli/_common.py
+++ b/src/brigade/cli/_common.py
@@ -29,7 +29,18 @@ COMMAND_GROUPS: list[tuple[str, list[str]]] = [
     ),
     (
         "Daily operator loop",
-        ["operator", "daily", "work", "friction", "workflow", "center", "runbook", "budgets", "notifications"],
+        [
+            "operator",
+            "daily",
+            "care",
+            "work",
+            "friction",
+            "workflow",
+            "center",
+            "runbook",
+            "budgets",
+            "notifications",
+        ],
     ),
     (
         "Stations and tools",

--- a/src/brigade/cli/care.py
+++ b/src/brigade/cli/care.py
@@ -1,0 +1,91 @@
+"""brigade care command group."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p_care = sub.add_parser(
+        "care",
+        help="Install, audit, and remove operator-owned scheduled care entries.",
+    )
+    care_sub = p_care.add_subparsers(dest="care_command", metavar="<care-command>")
+    care_sub.required = True
+
+    p_install = care_sub.add_parser(
+        "install",
+        help="Write managed scheduler entries for the scheduled-care recipes.",
+    )
+    p_install.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace to schedule against."
+    )
+    p_install.add_argument(
+        "--backend",
+        choices=["crontab", "systemd"],
+        default="crontab",
+        help="Scheduler backend to write (default: crontab). Windows prints Task Scheduler equivalents.",
+    )
+    p_install.add_argument("--dry-run", action="store_true", help="Show the plan without writing.")
+    p_install.add_argument(
+        "--adopt",
+        action="store_true",
+        help="Replace a hand-edited managed block instead of reporting a conflict.",
+    )
+    p_install.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+
+    p_status = care_sub.add_parser(
+        "status",
+        help="List installed care entries and the latest receipt for each runbook recipe.",
+    )
+    p_status.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to inspect.")
+    p_status.add_argument(
+        "--backend",
+        choices=["crontab", "systemd"],
+        default="crontab",
+        help="Scheduler backend to inspect (default: crontab).",
+    )
+    p_status.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+
+    p_uninstall = care_sub.add_parser(
+        "uninstall",
+        help="Remove Brigade-managed care scheduler entries only.",
+    )
+    p_uninstall.add_argument(
+        "--target", "-t", type=Path, default=Path("."), help="Repo or workspace the entries reference."
+    )
+    p_uninstall.add_argument(
+        "--backend",
+        choices=["crontab", "systemd"],
+        default="crontab",
+        help="Scheduler backend to clean (default: crontab).",
+    )
+    p_uninstall.add_argument("--dry-run", action="store_true", help="Show the plan without writing.")
+    p_uninstall.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+
+    p_care.set_defaults(func=dispatch)
+
+
+def dispatch(args) -> int:
+    from .. import care_cmd
+
+    if args.care_command == "install":
+        return care_cmd.install(
+            target=args.target,
+            backend=args.backend,
+            dry_run=args.dry_run,
+            adopt=args.adopt,
+            json_output=args.json,
+        )
+    if args.care_command == "status":
+        return care_cmd.status(target=args.target, backend=args.backend, json_output=args.json)
+    if args.care_command == "uninstall":
+        return care_cmd.uninstall(
+            target=args.target,
+            backend=args.backend,
+            dry_run=args.dry_run,
+            json_output=args.json,
+        )
+    args._brigade_parser.error(f"unknown care command: {args.care_command}")
+    return 2

--- a/src/brigade/managed_block.py
+++ b/src/brigade/managed_block.py
@@ -37,7 +37,11 @@ import tempfile
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Literal
+
+MarkerStyle = Literal["html", "hash"]
+MARKER_STYLE_HTML: MarkerStyle = "html"
+MARKER_STYLE_HASH: MarkerStyle = "hash"
 
 MARKER_FORMAT_VERSION = 1
 DEFAULT_KIND = "INTEGRATION"
@@ -55,6 +59,14 @@ _BEGIN_RE = re.compile(
 _END_RE = re.compile(r"<!--\s*END BRIGADE\s+([A-Za-z][A-Za-z0-9_-]*)\s*-->")
 _BEGIN_LOOSE_RE = re.compile(r"<!--\s*BEGIN BRIGADE\b")
 _END_LOOSE_RE = re.compile(r"<!--\s*END BRIGADE\b")
+_HASH_BEGIN_RE = re.compile(
+    r"^#\s*BEGIN BRIGADE\s+([A-Za-z][A-Za-z0-9_-]*)\s+"
+    r"v:(\d+)\s+profile:([^\s]+)\s+hash:([0-9a-fA-F]+)\s*$",
+    re.MULTILINE,
+)
+_HASH_END_RE = re.compile(r"^#\s*END BRIGADE\s+([A-Za-z][A-Za-z0-9_-]*)\s*$", re.MULTILINE)
+_HASH_BEGIN_LOOSE_RE = re.compile(r"^#\s*BEGIN BRIGADE\b", re.MULTILINE)
+_HASH_END_LOOSE_RE = re.compile(r"^#\s*END BRIGADE\b", re.MULTILINE)
 
 STATUS_MISSING = "missing"
 STATUS_CURRENT = "current"
@@ -82,6 +94,7 @@ class BlockMeta:
     profile: str | None
     recorded_hash: str | None
     legacy: bool
+    style: MarkerStyle = MARKER_STYLE_HTML
 
 
 @dataclass(frozen=True)
@@ -182,28 +195,53 @@ def _with_file_newlines(block: str, newline: str) -> str:
     return block.replace("\n", "\r\n")
 
 
-def begin_marker(*, kind: str, profile: str, digest: str, version: int = MARKER_FORMAT_VERSION) -> str:
+def begin_marker(
+    *,
+    kind: str,
+    profile: str,
+    digest: str,
+    version: int = MARKER_FORMAT_VERSION,
+    style: MarkerStyle = MARKER_STYLE_HTML,
+) -> str:
     if version != MARKER_FORMAT_VERSION:
         raise ValueError(f"unsupported managed-block marker version: {version}")
+    if style not in {MARKER_STYLE_HTML, MARKER_STYLE_HASH}:
+        raise ValueError(f"unsupported managed-block marker style: {style}")
     if not re.fullmatch(r"[A-Za-z][A-Za-z0-9_-]*", kind):
         raise ValueError(f"invalid managed-block kind: {kind!r}")
     if any(ch.isspace() for ch in profile) or not profile:
         raise ValueError(f"invalid managed-block profile: {profile!r}")
     if not re.fullmatch(r"[0-9a-f]{64}", digest):
         raise ValueError("managed-block hash must be a full lowercase sha256 hex digest")
+    if style == MARKER_STYLE_HASH:
+        return f"# BEGIN BRIGADE {kind} v:{version} profile:{profile} hash:{digest}"
     return f"<!-- BEGIN BRIGADE {kind} v:{version} profile:{profile} hash:{digest} -->"
 
 
-def end_marker(*, kind: str) -> str:
+def end_marker(*, kind: str, style: MarkerStyle = MARKER_STYLE_HTML) -> str:
+    if style not in {MARKER_STYLE_HTML, MARKER_STYLE_HASH}:
+        raise ValueError(f"unsupported managed-block marker style: {style}")
     if not re.fullmatch(r"[A-Za-z][A-Za-z0-9_-]*", kind):
         raise ValueError(f"invalid managed-block kind: {kind!r}")
+    if style == MARKER_STYLE_HASH:
+        return f"# END BRIGADE {kind}"
     return f"<!-- END BRIGADE {kind} -->"
 
 
-def render_block(body: str, *, kind: str = DEFAULT_KIND, profile: str = DEFAULT_PROFILE) -> str:
+def render_block(
+    body: str,
+    *,
+    kind: str = DEFAULT_KIND,
+    profile: str = DEFAULT_PROFILE,
+    style: MarkerStyle = MARKER_STYLE_HTML,
+) -> str:
     """Render a stamped block including the trailing newline after the end marker."""
     digest = body_hash(body)
-    return f"{begin_marker(kind=kind, profile=profile, digest=digest)}\n{body}\n{end_marker(kind=kind)}\n"
+    return (
+        f"{begin_marker(kind=kind, profile=profile, digest=digest, style=style)}\n"
+        f"{body}\n"
+        f"{end_marker(kind=kind, style=style)}\n"
+    )
 
 
 def default_fix_command(*, harness: str = "<harness>") -> str:
@@ -216,29 +254,96 @@ def _legacy_pair_for_kind(kind: str) -> tuple[str, str] | None:
     return None
 
 
-def _marker_hits(text: str, *, kind: str) -> tuple[list[re.Match[str]], list[re.Match[str]], list[str]]:
+def _marker_hits(
+    text: str,
+    *,
+    kind: str,
+    style: MarkerStyle,
+) -> tuple[list[re.Match[str]], list[re.Match[str]], list[str]]:
     """Return begin matches, end matches, and malformed loose-marker details for kind."""
-    begins = [m for m in _BEGIN_RE.finditer(text) if m.group(1) == kind]
-    ends = [m for m in _END_RE.finditer(text) if m.group(1) == kind]
+    if style == MARKER_STYLE_HASH:
+        begin_re, end_re, begin_loose_re, end_loose_re = (
+            _HASH_BEGIN_RE,
+            _HASH_END_RE,
+            _HASH_BEGIN_LOOSE_RE,
+            _HASH_END_LOOSE_RE,
+        )
+    else:
+        begin_re, end_re, begin_loose_re, end_loose_re = (
+            _BEGIN_RE,
+            _END_RE,
+            _BEGIN_LOOSE_RE,
+            _END_LOOSE_RE,
+        )
+    begins = [m for m in begin_re.finditer(text) if m.group(1) == kind]
+    ends = [m for m in end_re.finditer(text) if m.group(1) == kind]
     details: list[str] = []
-    for match in _BEGIN_LOOSE_RE.finditer(text):
+    if style == MARKER_STYLE_HASH:
+        for match in begin_loose_re.finditer(text):
+            line_end = text.find("\n", match.start())
+            window = text[match.start() : line_end if line_end != -1 else len(text)]
+            if begin_re.fullmatch(window):
+                continue
+            kind_token = re.match(r"^#\s*BEGIN BRIGADE\s+(\S+)", window)
+            token = kind_token.group(1) if kind_token else ""
+            if not token or token == kind or not re.fullmatch(r"[A-Za-z][A-Za-z0-9_-]*", token):
+                details.append("begin marker metadata cannot be parsed")
+        for match in end_loose_re.finditer(text):
+            line_end = text.find("\n", match.start())
+            window = text[match.start() : line_end if line_end != -1 else len(text)]
+            if end_re.fullmatch(window):
+                continue
+            kind_token = re.match(r"^#\s*END BRIGADE\s+([A-Za-z][A-Za-z0-9_-]*)\s*$", window)
+            if kind_token is None or kind_token.group(1) == kind:
+                details.append("end marker cannot be parsed")
+        return begins, ends, details
+
+    for match in begin_loose_re.finditer(text):
         close = text.find("-->", match.start())
         window = text[match.start() : close + 3] if close != -1 else text[match.start() : match.start() + 120]
-        if _BEGIN_RE.fullmatch(window):
+        if begin_re.fullmatch(window):
             continue
         kind_token = re.match(r"<!--\s*BEGIN BRIGADE\s+(\S+)", window)
         token = kind_token.group(1) if kind_token else ""
         if not token or token == kind or not re.fullmatch(r"[A-Za-z][A-Za-z0-9_-]*", token):
             details.append("begin marker metadata cannot be parsed")
-    for match in _END_LOOSE_RE.finditer(text):
+    for match in end_loose_re.finditer(text):
         close = text.find("-->", match.start())
         window = text[match.start() : close + 3] if close != -1 else text[match.start() : match.start() + 80]
-        if _END_RE.fullmatch(window):
+        if end_re.fullmatch(window):
             continue
         kind_token = re.match(r"<!--\s*END BRIGADE\s+([A-Za-z][A-Za-z0-9_-]*)\s*-->", window)
         if kind_token is None or kind_token.group(1) == kind:
             details.append("end marker cannot be parsed")
     return begins, ends, details
+
+
+def _stamped_marker_styles(text: str, *, kind: str) -> set[MarkerStyle]:
+    styles: set[MarkerStyle] = set()
+    if any(m.group(1) == kind for m in _BEGIN_RE.finditer(text)) or any(
+        m.group(1) == kind for m in _END_RE.finditer(text)
+    ):
+        styles.add(MARKER_STYLE_HTML)
+    if any(m.group(1) == kind for m in _HASH_BEGIN_RE.finditer(text)) or any(
+        m.group(1) == kind for m in _HASH_END_RE.finditer(text)
+    ):
+        styles.add(MARKER_STYLE_HASH)
+    return styles
+
+
+def _resolve_marker_style(text: str, *, kind: str, style: MarkerStyle | None) -> MarkerStyle | None:
+    stamped = _stamped_marker_styles(text, kind=kind)
+    if style is not None:
+        if len(stamped) > 1:
+            return None
+        if stamped and next(iter(stamped)) != style:
+            return None
+        return style
+    if len(stamped) > 1:
+        return None
+    if stamped:
+        return next(iter(stamped))
+    return MARKER_STYLE_HTML
 
 
 def _extract_framed_body(text: str, start_pos: int, start_len: int, end_pos: int) -> tuple[str, str, str] | None:
@@ -252,11 +357,19 @@ def _extract_framed_body(text: str, start_pos: int, start_len: int, end_pos: int
     return before, body, text[end_pos:]
 
 
-def parse_blocks(text: str, *, kind: str = DEFAULT_KIND) -> ParsedBlock:
+def parse_blocks(text: str, *, kind: str = DEFAULT_KIND, style: MarkerStyle | None = None) -> ParsedBlock:
     """Parse the managed span for ``kind`` into a structured block state."""
     offsets = _normalized_offset_starts(text)
     normalized = normalize_newlines(text)
-    begins, ends, loose_details = _marker_hits(normalized, kind=kind)
+    resolved_style = _resolve_marker_style(normalized, kind=kind, style=style)
+    if resolved_style is None:
+        stamped = _stamped_marker_styles(normalized, kind=kind)
+        if style is not None and stamped and len(stamped) == 1 and next(iter(stamped)) != style:
+            detail = "stamped managed markers do not match requested marker style"
+        else:
+            detail = "stamped html and hash-comment managed markers both present"
+        return ParsedBlock(STATUS_MALFORMED, kind, detail=detail)
+    begins, ends, loose_details = _marker_hits(normalized, kind=kind, style=resolved_style)
     legacy = _legacy_pair_for_kind(kind)
     legacy_starts = normalized.count(legacy[0]) if legacy else 0
     legacy_ends = normalized.count(legacy[1]) if legacy else 0
@@ -291,7 +404,9 @@ def parse_blocks(text: str, *, kind: str = DEFAULT_KIND) -> ParsedBlock:
             return ParsedBlock(STATUS_MALFORMED, kind, detail="orphan managed marker")
         # Nested / overlapping: another begin or end inside the span.
         inner = normalized[begin.end() : end.start()]
-        if _BEGIN_LOOSE_RE.search(inner) or _END_LOOSE_RE.search(inner):
+        inner_loose_begin = _HASH_BEGIN_LOOSE_RE if resolved_style == MARKER_STYLE_HASH else _BEGIN_LOOSE_RE
+        inner_loose_end = _HASH_END_LOOSE_RE if resolved_style == MARKER_STYLE_HASH else _END_LOOSE_RE
+        if inner_loose_begin.search(inner) or inner_loose_end.search(inner):
             return ParsedBlock(STATUS_MALFORMED, kind, detail="nested managed markers")
         if legacy and (legacy[0] in inner or legacy[1] in inner):
             return ParsedBlock(STATUS_MALFORMED, kind, detail="nested managed markers")
@@ -317,7 +432,14 @@ def parse_blocks(text: str, *, kind: str = DEFAULT_KIND) -> ParsedBlock:
         if after_start < len(normalized) and normalized[after_start] == "\n":
             after_start += 1
         after = _slice_by_normalized_range(text, offsets, after_start, len(normalized))
-        meta = BlockMeta(kind=kind, version=version, profile=profile, recorded_hash=recorded, legacy=False)
+        meta = BlockMeta(
+            kind=kind,
+            version=version,
+            profile=profile,
+            recorded_hash=recorded,
+            legacy=False,
+            style=resolved_style,
+        )
         return ParsedBlock(
             "ok",
             kind,
@@ -375,9 +497,10 @@ def assess_block(
     profile: str = DEFAULT_PROFILE,
     owned_digest: str | None = None,
     fix_command: str | None = None,
+    style: MarkerStyle | None = None,
 ) -> BlockAssessment:
     """Classify a file's managed span against an optional desired body."""
-    parsed = parse_blocks(text, kind=kind)
+    parsed = parse_blocks(text, kind=kind, style=style)
     fix = fix_command or default_fix_command()
     if parsed.status == STATUS_MISSING:
         return BlockAssessment(
@@ -524,10 +647,12 @@ def plan_install(
     force: bool = False,
     adopt: bool = False,
     fix_command: str | None = None,
+    style: MarkerStyle | None = None,
 ) -> BlockPlan:
     """Plan create/update/no-op/preserve for a managed block inside ``text``."""
+    resolved_style = style or MARKER_STYLE_HTML
     desired_digest = body_hash(desired)
-    block = render_block(desired, kind=kind, profile=profile)
+    block = render_block(desired, kind=kind, profile=profile, style=resolved_style)
     fix = fix_command or default_fix_command()
     if text is None:
         return BlockPlan(
@@ -541,6 +666,7 @@ def plan_install(
         profile=profile,
         owned_digest=owned_digest,
         fix_command=fix,
+        style=resolved_style,
     )
     parsed = assessment.parsed
 
@@ -623,13 +749,14 @@ def plan_remove(
     owned_digest: str | None = None,
     force: bool = False,
     fix_command: str | None = None,
+    style: MarkerStyle | None = None,
 ) -> BlockPlan:
     """Plan surgical removal of the managed span (plus one trailing newline)."""
     fix = fix_command or default_fix_command()
     if text is None:
         return BlockPlan(STATUS_MISSING, ACTION_NONE, kind, fix_command=fix, detail="managed block is absent")
 
-    assessment = assess_block(text, desired=None, kind=kind, owned_digest=owned_digest, fix_command=fix)
+    assessment = assess_block(text, desired=None, kind=kind, owned_digest=owned_digest, fix_command=fix, style=style)
     parsed = assessment.parsed
 
     if assessment.status == STATUS_MISSING:
@@ -786,6 +913,7 @@ def install_block(
     adopt: bool = False,
     fix_command: str | None = None,
     lstat_probe: Callable[[Path], int | None] | None = None,
+    style: MarkerStyle | None = None,
 ) -> tuple[BlockPlan, WriteOutcome]:
     """Install or update a managed block with symlink-safe atomic publish."""
     probe = lstat_probe or _lstat_mode
@@ -830,6 +958,7 @@ def install_block(
         force=force,
         adopt=adopt,
         fix_command=fix_command,
+        style=style,
     )
     if plan.action == ACTION_NONE:
         return plan, WriteOutcome(WRITE_NOOP)
@@ -858,6 +987,7 @@ def remove_block(
     force: bool = False,
     fix_command: str | None = None,
     lstat_probe: Callable[[Path], int | None] | None = None,
+    style: MarkerStyle | None = None,
 ) -> tuple[BlockPlan, WriteOutcome]:
     """Remove a managed block surgically with symlink-safe atomic publish."""
     probe = lstat_probe or _lstat_mode
@@ -875,7 +1005,9 @@ def remove_block(
         )
         return plan, WriteOutcome(WRITE_SKIPPED_SYMLINK, detail=warning, warning=warning)
     if mode is None:
-        plan = plan_remove(None, kind=kind, owned_digest=owned_digest, force=force, fix_command=fix_command)
+        plan = plan_remove(
+            None, kind=kind, owned_digest=owned_digest, force=force, fix_command=fix_command, style=style
+        )
         return plan, WriteOutcome(WRITE_NOOP)
 
     try:
@@ -884,7 +1016,7 @@ def remove_block(
         plan = BlockPlan(STATUS_MALFORMED, ACTION_PRESERVE, kind, detail=str(exc), fix_command=fix_command)
         return plan, WriteOutcome(WRITE_ERROR, detail=str(exc))
 
-    plan = plan_remove(text, kind=kind, owned_digest=owned_digest, force=force, fix_command=fix_command)
+    plan = plan_remove(text, kind=kind, owned_digest=owned_digest, force=force, fix_command=fix_command, style=style)
     if plan.action == ACTION_NONE:
         return plan, WriteOutcome(WRITE_NOOP)
     if plan.action == ACTION_PRESERVE or plan.rendered is None:
@@ -903,6 +1035,7 @@ def check_block(
     profile: str = DEFAULT_PROFILE,
     owned_digest: str | None = None,
     fix_command: str | None = None,
+    style: MarkerStyle | None = None,
 ) -> BlockAssessment:
     """Classify a path's managed block; missing file is ``missing``."""
     if path_is_symlink(path):
@@ -941,4 +1074,5 @@ def check_block(
         profile=profile,
         owned_digest=owned_digest,
         fix_command=fix_command,
+        style=style,
     )

--- a/tests/test_care_cmd.py
+++ b/tests/test_care_cmd.py
@@ -5,47 +5,68 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from brigade import care_cmd, cli, managed_block, memory_cmd
 
 
-def test_managed_block_round_trip_preserves_neighbor_content():
+def test_care_managed_block_round_trip_preserves_neighbor_content():
     host = "# personal crontab\n0 1 * * * /usr/bin/true\n"
     body = "PATH=/home/you/.local/bin:/usr/bin\n15 6 * * * cd /tmp && brigade doctor\n"
-    desired = managed_block._normalize_body(body)
-    rendered, plan = managed_block.apply_block(host, kind="CARE", profile="crontab", desired_body=body, style="hash")
-    assert plan.action == "create"
+    plan = managed_block.plan_install(
+        host, desired=body, kind="CARE", profile="crontab", style=managed_block.MARKER_STYLE_HASH
+    )
+    assert plan.action == managed_block.ACTION_CREATE
+    rendered = plan.rendered
+    assert rendered is not None
     assert "# personal crontab" in rendered
     assert "0 1 * * * /usr/bin/true" in rendered
-    match = managed_block.find_block(rendered, kind="CARE")
-    assert match is not None
-    assert match.recorded_hash == managed_block.body_hash(desired)
-    assert match.body == desired
+    assert "# BEGIN BRIGADE CARE" in rendered
+    assert "<!-- BEGIN" not in rendered
+    parsed = managed_block.parse_blocks(rendered, kind="CARE", style=managed_block.MARKER_STYLE_HASH)
+    assert parsed.status == "ok"
+    assert parsed.meta is not None
+    assert parsed.meta.recorded_hash == managed_block.body_hash(body)
+    assert parsed.body == body
 
-    again, plan2 = managed_block.apply_block(rendered, kind="CARE", profile="crontab", desired_body=body, style="hash")
-    assert plan2.status == "current"
-    assert again == rendered
+    plan2 = managed_block.plan_install(
+        rendered, desired=body, kind="CARE", profile="crontab", style=managed_block.MARKER_STYLE_HASH
+    )
+    assert plan2.status == managed_block.STATUS_CURRENT
+    assert plan2.action == managed_block.ACTION_NONE
 
-    removed, removal = managed_block.remove_block(rendered, kind="CARE")
-    assert removal.action == "remove"
-    assert removed == host
+    removal = managed_block.plan_remove(
+        rendered,
+        kind="CARE",
+        owned_digest=managed_block.body_hash(body),
+        style=managed_block.MARKER_STYLE_HASH,
+    )
+    assert removal.action == managed_block.ACTION_REMOVE
+    assert removal.rendered == host
 
 
-def test_managed_block_reports_tampered_and_refuses_clobber_without_adopt():
+def test_care_managed_block_reports_tampered_and_refuses_clobber_without_adopt():
     body = "line-a\nline-b"
-    wrapped = managed_block.wrap_block(kind="CARE", profile="crontab", body=body, style="hash")
+    wrapped = managed_block.render_block(body, kind="CARE", profile="crontab", style=managed_block.MARKER_STYLE_HASH)
     tampered = wrapped.replace("line-a", "line-EDITED")
-    plan = managed_block.classify_block(tampered, kind="CARE", desired_body=body)
-    assert plan.status == "tampered"
-    unchanged, apply_plan = managed_block.apply_block(
-        tampered, kind="CARE", profile="crontab", desired_body=body, style="hash", adopt=False
+    assessment = managed_block.assess_block(
+        tampered, desired=body, kind="CARE", profile="crontab", style=managed_block.MARKER_STYLE_HASH
     )
-    assert unchanged == tampered
-    assert apply_plan.status == "tampered"
-    replaced, adopted = managed_block.apply_block(
-        tampered, kind="CARE", profile="crontab", desired_body=body, style="hash", adopt=True
+    assert assessment.status == managed_block.STATUS_LOCALLY_MODIFIED
+    apply_plan = managed_block.plan_install(
+        tampered, desired=body, kind="CARE", profile="crontab", adopt=False, style=managed_block.MARKER_STYLE_HASH
     )
-    assert adopted.action == "update"
-    assert managed_block.classify_block(replaced, kind="CARE", desired_body=body).status == "current"
+    assert apply_plan.status == managed_block.STATUS_LOCALLY_MODIFIED
+    assert apply_plan.action == managed_block.ACTION_PRESERVE
+    adopted = managed_block.plan_install(
+        tampered, desired=body, kind="CARE", profile="crontab", adopt=True, style=managed_block.MARKER_STYLE_HASH
+    )
+    assert adopted.action == managed_block.ACTION_UPDATE
+    assert adopted.rendered is not None
+    replaced = adopted.rendered
+    assert managed_block.assess_block(
+        replaced, desired=body, kind="CARE", profile="crontab", style=managed_block.MARKER_STYLE_HASH
+    ).status == (managed_block.STATUS_CURRENT)
 
 
 def test_care_crontab_install_status_uninstall_round_trip(tmp_path, monkeypatch):
@@ -61,7 +82,7 @@ def test_care_crontab_install_status_uninstall_round_trip(tmp_path, monkeypatch)
 
     monkeypatch.setattr(care_cmd, "_read_crontab", fake_read)
     monkeypatch.setattr(care_cmd, "_write_crontab", fake_write)
-    monkeypatch.setattr(care_cmd, "_ensure_memory_care_runbooks", lambda target: 0)
+    monkeypatch.setattr(care_cmd, "_ensure_care_runbooks", lambda target: 0)
     monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
 
     target = tmp_path / "ws"
@@ -70,18 +91,23 @@ def test_care_crontab_install_status_uninstall_round_trip(tmp_path, monkeypatch)
     assert memory_cmd._write_memory_care_runbooks(target) == 0
 
     assert care_cmd.install(target=target, json_output=True) == 0
-    assert "BEGIN BRIGADE CARE" in store["text"]
+    assert "# BEGIN BRIGADE CARE" in store["text"]
+    assert "<!-- BEGIN" not in store["text"]
     assert "keep-me" in store["text"]
     assert "daily-care-pass.json" in store["text"]
     assert "ingest-sweep.json" in store["text"]
     assert "weekly-outcome-ratchet.json" in store["text"]
+    assert "daily-observability.json" in store["text"]
     assert "15 6 * * *" in store["text"]
     assert "*/30 * * * *" in store["text"]
     assert "0 7 * * 1" in store["text"]
     assert "0 8 * * *" in store["text"]
     assert "0 4 * * *" in store["text"]
-    assert "handoff doctor" in store["text"]
     assert "nightly-maintenance.json" in store["text"]
+    digest = managed_block.parse_blocks(store["text"], kind=care_cmd.CARE_KIND, style=care_cmd.CARE_MARKER_STYLE)
+    assert digest.status == "ok"
+    assert digest.meta is not None
+    assert len(digest.meta.recorded_hash or "") == 64
 
     # Idempotent reinstall is a no-op write path (status current).
     assert care_cmd.install(target=target, json_output=True) == 0
@@ -94,7 +120,9 @@ def test_care_crontab_install_status_uninstall_round_trip(tmp_path, monkeypatch)
 
 def test_care_status_reports_tampered_block_without_clobber(tmp_path, monkeypatch, capsys):
     body = care_cmd._crontab_body(workspace=tmp_path)
-    wrapped = managed_block.wrap_block(kind="CARE", profile="crontab", body=body, style="hash")
+    wrapped = managed_block.render_block(
+        body, kind=care_cmd.CARE_KIND, profile="crontab", style=care_cmd.CARE_MARKER_STYLE
+    )
     store = {"text": wrapped.replace("15 6 * * *", "16 6 * * *")}
 
     monkeypatch.setattr(care_cmd, "_read_crontab", lambda: (store["text"], None))
@@ -103,7 +131,7 @@ def test_care_status_reports_tampered_block_without_clobber(tmp_path, monkeypatc
         "_write_crontab",
         lambda text: (_ for _ in ()).throw(AssertionError("must not write")),
     )
-    monkeypatch.setattr(care_cmd, "_ensure_memory_care_runbooks", lambda target: 0)
+    monkeypatch.setattr(care_cmd, "_ensure_care_runbooks", lambda target: 0)
     monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
 
     assert care_cmd.status(target=tmp_path, json_output=True) == 1
@@ -112,6 +140,43 @@ def test_care_status_reports_tampered_block_without_clobber(tmp_path, monkeypatc
 
     assert care_cmd.install(target=tmp_path, json_output=True) == 1
     assert "16 6 * * *" in store["text"]  # unchanged
+
+
+def test_care_uninstall_refuses_tampered_crontab_block(tmp_path, monkeypatch, capsys):
+    body = care_cmd._crontab_body(workspace=tmp_path)
+    wrapped = managed_block.render_block(
+        body, kind=care_cmd.CARE_KIND, profile="crontab", style=care_cmd.CARE_MARKER_STYLE
+    )
+    store = {"text": wrapped.replace("15 6 * * *", "16 6 * * *")}
+
+    monkeypatch.setattr(care_cmd, "_read_crontab", lambda: (store["text"], None))
+    monkeypatch.setattr(
+        care_cmd,
+        "_write_crontab",
+        lambda text: (_ for _ in ()).throw(AssertionError("must not write")),
+    )
+    monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
+
+    assert care_cmd.uninstall(target=tmp_path, json_output=True) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "tampered"
+    assert payload["action"] == managed_block.ACTION_PRESERVE
+    assert "16 6 * * *" in store["text"]
+
+
+def test_care_daily_observability_is_runbook_with_receipt_path(tmp_path, monkeypatch):
+    monkeypatch.setattr(care_cmd, "_read_crontab", lambda: ("", None))
+    monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
+
+    assert care_cmd._write_daily_observability_runbook(tmp_path) == 0
+    entry = next(item for item in care_cmd.CARE_ENTRIES if item.entry_id == "daily-observability")
+    assert entry.kind == "runbook"
+    assert entry.runbook_id == "daily-observability"
+    runbook_path = tmp_path / entry.runbook_rel
+    assert runbook_path.is_file()
+    payload = json.loads(runbook_path.read_text(encoding="utf-8"))
+    assert payload["id"] == "daily-observability"
+    assert any("handoff doctor" in step.get("run", "") for step in payload["steps"])
 
 
 def test_care_status_includes_latest_runbook_receipt(tmp_path, monkeypatch, capsys):
@@ -134,6 +199,80 @@ def test_care_status_includes_latest_runbook_receipt(tmp_path, monkeypatch, caps
     daily = next(entry for entry in payload["entries"] if entry["id"] == "daily-care")
     assert daily["last_receipt"]["run_id"] == receipt["run_id"]
     assert daily["last_receipt"]["status"] == "completed"
+
+
+def test_care_crontab_install_refuses_malformed_markers_without_write(tmp_path, monkeypatch, capsys):
+    body = care_cmd._crontab_body(workspace=tmp_path)
+    valid = managed_block.render_block(
+        body, kind=care_cmd.CARE_KIND, profile="crontab", style=care_cmd.CARE_MARKER_STYLE
+    )
+    html = managed_block.render_block(
+        "orphan-body\n",
+        kind=care_cmd.CARE_KIND,
+        profile="crontab",
+        style=managed_block.MARKER_STYLE_HTML,
+    )
+    store = {"text": valid + html}
+
+    monkeypatch.setattr(care_cmd, "_read_crontab", lambda: (store["text"], None))
+    monkeypatch.setattr(
+        care_cmd,
+        "_write_crontab",
+        lambda text: (_ for _ in ()).throw(AssertionError("must not write")),
+    )
+    monkeypatch.setattr(care_cmd, "_ensure_care_runbooks", lambda target: 0)
+    monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
+
+    assert care_cmd.install(target=tmp_path, json_output=True) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == managed_block.STATUS_MALFORMED
+    assert payload["action"] == managed_block.ACTION_PRESERVE
+    assert payload["detail"]
+    assert store["text"] == valid + html
+
+
+def test_care_crontab_percent_in_path_is_escaped(tmp_path, monkeypatch):
+    target = tmp_path / "ws%pct"
+    target.mkdir()
+    monkeypatch.setattr(care_cmd, "_read_crontab", lambda: ("", None))
+    monkeypatch.setattr(care_cmd, "_write_crontab", lambda text: None)
+    monkeypatch.setattr(care_cmd, "_ensure_care_runbooks", lambda t: 0)
+    monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
+
+    assert care_cmd.install(target=target, json_output=True) == 0
+    body = care_cmd._crontab_body(workspace=target)
+    assert r'cd "ws\%pct"' in body or rf'cd "{target}"'.replace("%", "\\%") in body
+    assert "\\%" in body
+
+
+def test_care_systemd_install_refuses_malformed_unit_without_write(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "home"
+    monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
+    monkeypatch.setattr(care_cmd, "_ensure_care_runbooks", lambda target: 0)
+    target = tmp_path / "ws"
+    target.mkdir()
+
+    assert care_cmd.install(target=target, backend="systemd", home=home) == 0
+    service = home / ".config" / "systemd" / "user" / "brigade-daily-care.service"
+    before = service.read_text(encoding="utf-8")
+    html = managed_block.render_block(
+        "tampered-body\n",
+        kind=care_cmd.CARE_KIND,
+        profile="systemd",
+        style=managed_block.MARKER_STYLE_HTML,
+    )
+    service.write_text(html, encoding="utf-8")
+
+    capsys.readouterr()
+    assert care_cmd.install(target=target, backend="systemd", home=home, json_output=True) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["blocked"] is True
+    unit = next(item for item in payload["units"] if item["name"] == "brigade-daily-care.service")
+    assert unit["status"] == managed_block.STATUS_MALFORMED
+    assert unit["action"] == managed_block.ACTION_PRESERVE
+    assert unit["detail"]
+    assert service.read_text(encoding="utf-8") == html
+    assert service.read_text(encoding="utf-8") != before
 
 
 def test_care_windows_install_prints_schtasks_and_does_not_claim_success(tmp_path, monkeypatch, capsys):
@@ -186,7 +325,7 @@ def test_care_cli_dispatch(monkeypatch, tmp_path):
 def test_care_systemd_install_writes_hash_stamped_units(tmp_path, monkeypatch):
     home = tmp_path / "home"
     monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
-    monkeypatch.setattr(care_cmd, "_ensure_memory_care_runbooks", lambda target: 0)
+    monkeypatch.setattr(care_cmd, "_ensure_care_runbooks", lambda target: 0)
     target = tmp_path / "ws"
     target.mkdir()
 
@@ -197,12 +336,90 @@ def test_care_systemd_install_writes_hash_stamped_units(tmp_path, monkeypatch):
     assert service.is_file()
     assert timer.is_file()
     text = service.read_text(encoding="utf-8")
-    assert "BEGIN BRIGADE CARE" in text
+    assert "# BEGIN BRIGADE CARE" in text
+    assert "<!-- BEGIN" not in text
     assert "daily-care-pass.json" in text
+    parsed = managed_block.parse_blocks(text, kind=care_cmd.CARE_KIND, style=care_cmd.CARE_MARKER_STYLE)
+    assert parsed.status == "ok"
+    assert parsed.meta is not None
+    assert len(parsed.meta.recorded_hash or "") == 64
     assert care_cmd.status(target=target, backend="systemd", home=home, json_output=True) == 0
     assert care_cmd.uninstall(target=target, backend="systemd", home=home, json_output=True) == 0
     assert not service.exists()
     assert not timer.exists()
+
+
+def test_care_systemd_unit_quotes_workspace_paths_with_spaces(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
+    monkeypatch.setattr(care_cmd, "_ensure_care_runbooks", lambda target: 0)
+    target = tmp_path / "my workspace"
+    target.mkdir()
+
+    assert care_cmd.install(target=target, backend="systemd", home=home, json_output=True) == 0
+    service = home / ".config" / "systemd" / "user" / "brigade-daily-care.service"
+    text = service.read_text(encoding="utf-8")
+    parsed = managed_block.parse_blocks(text, kind=care_cmd.CARE_KIND, style=care_cmd.CARE_MARKER_STYLE)
+    assert parsed.status == "ok"
+    assert f'WorkingDirectory="{target}"' in parsed.body
+    assert (
+        "ExecStart=/usr/bin/env brigade runbook run --approved "
+        ".brigade/memory-care/runbooks/daily-care-pass.json --target ."
+    ) in parsed.body
+
+
+def test_care_systemd_environment_path_quotes_home_with_spaces(tmp_path, monkeypatch):
+    home = tmp_path / "my home"
+    monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
+    monkeypatch.setattr(care_cmd, "_ensure_care_runbooks", lambda target: 0)
+    target = tmp_path / "ws"
+    target.mkdir()
+
+    assert care_cmd.install(target=target, backend="systemd", home=home, json_output=True) == 0
+    service = home / ".config" / "systemd" / "user" / "brigade-daily-care.service"
+    parsed = managed_block.parse_blocks(
+        service.read_text(encoding="utf-8"),
+        kind=care_cmd.CARE_KIND,
+        style=care_cmd.CARE_MARKER_STYLE,
+    )
+    assert parsed.status == "ok"
+    assert 'Environment="PATH=' in parsed.body
+    assert str(home / ".local" / "bin") in parsed.body
+
+
+def test_care_systemd_percent_in_path_is_escaped(tmp_path, monkeypatch):
+    home = tmp_path / "pct%home"
+    monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
+    monkeypatch.setattr(care_cmd, "_ensure_care_runbooks", lambda target: 0)
+    target = tmp_path / "ws"
+    target.mkdir()
+
+    assert care_cmd.install(target=target, backend="systemd", home=home, json_output=True) == 0
+    service = home / ".config" / "systemd" / "user" / "brigade-daily-care.service"
+    parsed = managed_block.parse_blocks(
+        service.read_text(encoding="utf-8"),
+        kind=care_cmd.CARE_KIND,
+        style=care_cmd.CARE_MARKER_STYLE,
+    )
+    assert parsed.status == "ok"
+    assert "%%" in parsed.body
+    assert 'Environment="PATH=' in parsed.body
+
+
+def test_care_systemd_uninstall_refuses_tampered_unit(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
+    monkeypatch.setattr(care_cmd, "_ensure_care_runbooks", lambda target: 0)
+    target = tmp_path / "ws"
+    target.mkdir()
+
+    assert care_cmd.install(target=target, backend="systemd", home=home) == 0
+    service = home / ".config" / "systemd" / "user" / "brigade-daily-care.service"
+    tampered = service.read_text(encoding="utf-8").replace("daily-care-pass", "daily-care-TAMPERED")
+    service.write_text(tampered, encoding="utf-8")
+
+    assert care_cmd.uninstall(target=target, backend="systemd", home=home) == 1
+    assert service.is_file()
 
 
 def test_care_entries_match_scheduled_care_doc_schedules():
@@ -215,3 +432,135 @@ def test_care_entries_match_scheduled_care_doc_schedules():
     assert by_id["daily-care"].runbook_rel.endswith("daily-care-pass.json")
     assert by_id["ingest-sweep"].runbook_rel.endswith("ingest-sweep.json")
     assert by_id["weekly-outcome-ratchet"].runbook_rel.endswith("weekly-outcome-ratchet.json")
+    assert by_id["daily-observability"].runbook_rel.endswith("daily-observability.json")
+    assert by_id["daily-observability"].kind == "runbook"
+
+
+def test_care_crontab_block_passes_crontab_syntax_check(tmp_path):
+    import shutil
+    import subprocess
+
+    if shutil.which("crontab") is None:
+        pytest.skip("crontab not available")
+
+    probe = subprocess.run(
+        ["crontab", "-n", "/dev/null"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if probe.returncode != 0 and "invalid option" in (probe.stderr or "").lower():
+        pytest.skip("crontab dry-run validation (-n) is unavailable on this host")
+
+    host = "# neighbor\n0 2 * * * /usr/bin/true\n"
+    body = care_cmd._crontab_body(workspace=tmp_path)
+    plan = managed_block.plan_install(
+        host,
+        desired=body,
+        kind=care_cmd.CARE_KIND,
+        profile="crontab",
+        style=care_cmd.CARE_MARKER_STYLE,
+    )
+    assert plan.rendered is not None
+    crontab_file = tmp_path / "probe.crontab"
+    crontab_file.write_text(plan.rendered, encoding="utf-8")
+    result = subprocess.run(
+        ["crontab", "-n", str(crontab_file)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (result.stdout or "") + (result.stderr or "")
+
+
+def test_care_crontab_dollar_and_backtick_path_remains_literal(tmp_path):
+    workspace = tmp_path / "ws$dollar`tick"
+    workspace.mkdir()
+    body = care_cmd._crontab_body(workspace=workspace)
+    assert "\\$" in body
+    assert "\\`" in body
+    command = care_cmd._cron_command(care_cmd.CARE_ENTRIES[0], workspace=workspace)
+    escaped_workspace = care_cmd._cron_escape_path(str(workspace))
+    assert command.startswith(f'cd "{escaped_workspace}" && ')
+
+
+def test_care_crontab_percent_path_passes_crontab_syntax_check(tmp_path):
+    import shutil
+    import subprocess
+
+    if shutil.which("crontab") is None:
+        pytest.skip("crontab not available")
+
+    probe = subprocess.run(
+        ["crontab", "-n", "/dev/null"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if probe.returncode != 0 and "invalid option" in (probe.stderr or "").lower():
+        pytest.skip("crontab dry-run validation (-n) is unavailable on this host")
+
+    workspace = tmp_path / "ws%pct"
+    workspace.mkdir()
+    host = "# neighbor\n0 2 * * * /usr/bin/true\n"
+    body = care_cmd._crontab_body(workspace=workspace)
+    assert "\\%" in body
+    plan = managed_block.plan_install(
+        host,
+        desired=body,
+        kind=care_cmd.CARE_KIND,
+        profile="crontab",
+        style=care_cmd.CARE_MARKER_STYLE,
+    )
+    assert plan.rendered is not None
+    crontab_file = tmp_path / "probe.crontab"
+    crontab_file.write_text(plan.rendered, encoding="utf-8")
+    result = subprocess.run(
+        ["crontab", "-n", str(crontab_file)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (result.stdout or "") + (result.stderr or "")
+
+
+def test_care_systemd_status_reports_broken_symlink_as_malformed(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "home"
+    monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
+    monkeypatch.setattr(care_cmd, "_ensure_care_runbooks", lambda target: 0)
+    target = tmp_path / "ws"
+    target.mkdir()
+
+    assert care_cmd.install(target=target, backend="systemd", home=home) == 0
+    service = home / ".config" / "systemd" / "user" / "brigade-daily-care.service"
+    service.unlink()
+    service.symlink_to(home / "missing.service")
+    capsys.readouterr()
+
+    assert care_cmd.status(target=target, backend="systemd", home=home, json_output=True) == 1
+    payload = json.loads(capsys.readouterr().out)
+    unit = next(item for item in payload["units"] if item["name"] == "brigade-daily-care.service")
+    assert unit["status"] == managed_block.STATUS_MALFORMED
+
+
+def test_care_systemd_uninstall_skips_symlink_swap(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
+    monkeypatch.setattr(care_cmd, "_ensure_care_runbooks", lambda target: 0)
+    target = tmp_path / "ws"
+    target.mkdir()
+
+    assert care_cmd.install(target=target, backend="systemd", home=home) == 0
+    service = home / ".config" / "systemd" / "user" / "brigade-daily-care.service"
+    secret = tmp_path / "secret.service"
+    secret.write_text("[Unit]\nDescription=secret\n", encoding="utf-8")
+    service.unlink()
+    service.symlink_to(secret)
+
+    assert care_cmd.uninstall(target=target, backend="systemd", home=home) == 2
+    assert secret.read_text(encoding="utf-8").startswith("[Unit]")
+    assert service.is_symlink()

--- a/tests/test_care_cmd.py
+++ b/tests/test_care_cmd.py
@@ -1,0 +1,217 @@
+"""Tests for hash-stamped managed blocks and brigade care scheduler scaffold."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from brigade import care_cmd, cli, managed_block, memory_cmd
+
+
+def test_managed_block_round_trip_preserves_neighbor_content():
+    host = "# personal crontab\n0 1 * * * /usr/bin/true\n"
+    body = "PATH=/home/you/.local/bin:/usr/bin\n15 6 * * * cd /tmp && brigade doctor\n"
+    desired = managed_block._normalize_body(body)
+    rendered, plan = managed_block.apply_block(host, kind="CARE", profile="crontab", desired_body=body, style="hash")
+    assert plan.action == "create"
+    assert "# personal crontab" in rendered
+    assert "0 1 * * * /usr/bin/true" in rendered
+    match = managed_block.find_block(rendered, kind="CARE")
+    assert match is not None
+    assert match.recorded_hash == managed_block.body_hash(desired)
+    assert match.body == desired
+
+    again, plan2 = managed_block.apply_block(rendered, kind="CARE", profile="crontab", desired_body=body, style="hash")
+    assert plan2.status == "current"
+    assert again == rendered
+
+    removed, removal = managed_block.remove_block(rendered, kind="CARE")
+    assert removal.action == "remove"
+    assert removed == host
+
+
+def test_managed_block_reports_tampered_and_refuses_clobber_without_adopt():
+    body = "line-a\nline-b"
+    wrapped = managed_block.wrap_block(kind="CARE", profile="crontab", body=body, style="hash")
+    tampered = wrapped.replace("line-a", "line-EDITED")
+    plan = managed_block.classify_block(tampered, kind="CARE", desired_body=body)
+    assert plan.status == "tampered"
+    unchanged, apply_plan = managed_block.apply_block(
+        tampered, kind="CARE", profile="crontab", desired_body=body, style="hash", adopt=False
+    )
+    assert unchanged == tampered
+    assert apply_plan.status == "tampered"
+    replaced, adopted = managed_block.apply_block(
+        tampered, kind="CARE", profile="crontab", desired_body=body, style="hash", adopt=True
+    )
+    assert adopted.action == "update"
+    assert managed_block.classify_block(replaced, kind="CARE", desired_body=body).status == "current"
+
+
+def test_care_crontab_install_status_uninstall_round_trip(tmp_path, monkeypatch):
+    store = {"text": "# keep-me\n0 2 * * * /usr/bin/true\n"}
+    before = store["text"]
+
+    def fake_read():
+        return store["text"], None
+
+    def fake_write(text: str):
+        store["text"] = text
+        return None
+
+    monkeypatch.setattr(care_cmd, "_read_crontab", fake_read)
+    monkeypatch.setattr(care_cmd, "_write_crontab", fake_write)
+    monkeypatch.setattr(care_cmd, "_ensure_memory_care_runbooks", lambda target: 0)
+    monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
+
+    target = tmp_path / "ws"
+    target.mkdir()
+    # Seed memory-care runbooks so status can report presence.
+    assert memory_cmd._write_memory_care_runbooks(target) == 0
+
+    assert care_cmd.install(target=target, json_output=True) == 0
+    assert "BEGIN BRIGADE CARE" in store["text"]
+    assert "keep-me" in store["text"]
+    assert "daily-care-pass.json" in store["text"]
+    assert "ingest-sweep.json" in store["text"]
+    assert "weekly-outcome-ratchet.json" in store["text"]
+    assert "15 6 * * *" in store["text"]
+    assert "*/30 * * * *" in store["text"]
+    assert "0 7 * * 1" in store["text"]
+    assert "0 8 * * *" in store["text"]
+    assert "0 4 * * *" in store["text"]
+    assert "handoff doctor" in store["text"]
+    assert "nightly-maintenance.json" in store["text"]
+
+    # Idempotent reinstall is a no-op write path (status current).
+    assert care_cmd.install(target=target, json_output=True) == 0
+
+    assert care_cmd.status(target=target, json_output=True) == 0
+    # Uninstall restores prior crontab bytes.
+    assert care_cmd.uninstall(target=target, json_output=True) == 0
+    assert store["text"] == before
+
+
+def test_care_status_reports_tampered_block_without_clobber(tmp_path, monkeypatch, capsys):
+    body = care_cmd._crontab_body(workspace=tmp_path)
+    wrapped = managed_block.wrap_block(kind="CARE", profile="crontab", body=body, style="hash")
+    store = {"text": wrapped.replace("15 6 * * *", "16 6 * * *")}
+
+    monkeypatch.setattr(care_cmd, "_read_crontab", lambda: (store["text"], None))
+    monkeypatch.setattr(
+        care_cmd,
+        "_write_crontab",
+        lambda text: (_ for _ in ()).throw(AssertionError("must not write")),
+    )
+    monkeypatch.setattr(care_cmd, "_ensure_memory_care_runbooks", lambda target: 0)
+    monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
+
+    assert care_cmd.status(target=tmp_path, json_output=True) == 1
+    out = json.loads(capsys.readouterr().out)
+    assert out["status"] == "tampered"
+
+    assert care_cmd.install(target=tmp_path, json_output=True) == 1
+    assert "16 6 * * *" in store["text"]  # unchanged
+
+
+def test_care_status_includes_latest_runbook_receipt(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(care_cmd, "_read_crontab", lambda: ("", None))
+    monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
+    runs = tmp_path / ".brigade" / "runbooks" / "runs" / "20260101T000000Z-daily-care-pass"
+    runs.mkdir(parents=True)
+    receipt = {
+        "run_id": "20260101T000000Z-daily-care-pass",
+        "runbook_id": "daily-care-pass",
+        "status": "completed",
+        "started_at": "2026-01-01T00:00:00+00:00",
+        "completed_at": "2026-01-01T00:00:01+00:00",
+        "receipt_path": str(runs / "receipt.json"),
+    }
+    (runs / "receipt.json").write_text(json.dumps(receipt), encoding="utf-8")
+
+    assert care_cmd.status(target=tmp_path, json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    daily = next(entry for entry in payload["entries"] if entry["id"] == "daily-care")
+    assert daily["last_receipt"]["run_id"] == receipt["run_id"]
+    assert daily["last_receipt"]["status"] == "completed"
+
+
+def test_care_windows_install_prints_schtasks_and_does_not_claim_success(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(care_cmd, "_is_windows", lambda: True)
+    calls = []
+
+    def boom(*_a, **_k):
+        calls.append(True)
+        raise AssertionError("must not touch crontab on Windows")
+
+    monkeypatch.setattr(care_cmd, "_read_crontab", boom)
+    monkeypatch.setattr(care_cmd, "_write_crontab", boom)
+
+    rc = care_cmd.install(target=tmp_path)
+    assert rc == 3
+    out = capsys.readouterr().out
+    assert "schtasks" in out
+    assert "BrigadeCare-daily-care" in out
+    assert calls == []
+
+
+def test_care_cli_dispatch(monkeypatch, tmp_path):
+    seen: dict[str, dict] = {}
+
+    def fake_install(**kwargs):
+        seen["install"] = kwargs
+        return 0
+
+    def fake_status(**kwargs):
+        seen["status"] = kwargs
+        return 0
+
+    def fake_uninstall(**kwargs):
+        seen["uninstall"] = kwargs
+        return 0
+
+    monkeypatch.setattr("brigade.care_cmd.install", fake_install)
+    monkeypatch.setattr("brigade.care_cmd.status", fake_status)
+    monkeypatch.setattr("brigade.care_cmd.uninstall", fake_uninstall)
+
+    assert cli.main(["care", "install", "--target", str(tmp_path), "--backend", "systemd", "--dry-run"]) == 0
+    assert seen["install"]["backend"] == "systemd"
+    assert seen["install"]["dry_run"] is True
+    assert cli.main(["care", "status", "--target", str(tmp_path), "--json"]) == 0
+    assert seen["status"]["json_output"] is True
+    assert cli.main(["care", "uninstall", "--target", str(tmp_path)]) == 0
+    assert seen["uninstall"]["target"] == Path(tmp_path)
+
+
+def test_care_systemd_install_writes_hash_stamped_units(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setattr(care_cmd, "_is_windows", lambda: False)
+    monkeypatch.setattr(care_cmd, "_ensure_memory_care_runbooks", lambda target: 0)
+    target = tmp_path / "ws"
+    target.mkdir()
+
+    assert care_cmd.install(target=target, backend="systemd", home=home, json_output=True) == 0
+    unit_dir = home / ".config" / "systemd" / "user"
+    service = unit_dir / "brigade-daily-care.service"
+    timer = unit_dir / "brigade-daily-care.timer"
+    assert service.is_file()
+    assert timer.is_file()
+    text = service.read_text(encoding="utf-8")
+    assert "BEGIN BRIGADE CARE" in text
+    assert "daily-care-pass.json" in text
+    assert care_cmd.status(target=target, backend="systemd", home=home, json_output=True) == 0
+    assert care_cmd.uninstall(target=target, backend="systemd", home=home, json_output=True) == 0
+    assert not service.exists()
+    assert not timer.exists()
+
+
+def test_care_entries_match_scheduled_care_doc_schedules():
+    by_id = {entry.entry_id: entry for entry in care_cmd.CARE_ENTRIES}
+    assert by_id["daily-care"].schedule == "15 6 * * *"
+    assert by_id["ingest-sweep"].schedule == "*/30 * * * *"
+    assert by_id["weekly-outcome-ratchet"].schedule == "0 7 * * 1"
+    assert by_id["daily-observability"].schedule == "0 8 * * *"
+    assert by_id["nightly-ops"].schedule == "0 4 * * *"
+    assert by_id["daily-care"].runbook_rel.endswith("daily-care-pass.json")
+    assert by_id["ingest-sweep"].runbook_rel.endswith("ingest-sweep.json")
+    assert by_id["weekly-outcome-ratchet"].runbook_rel.endswith("weekly-outcome-ratchet.json")

--- a/tests/test_managed_block.py
+++ b/tests/test_managed_block.py
@@ -280,3 +280,112 @@ def test_other_kind_block_is_left_alone():
     )
     assert "BEGIN BRIGADE SECURITY" in (removed.rendered or "")
     assert "BEGIN BRIGADE INTEGRATION" not in (removed.rendered or "")
+
+
+def test_hash_comment_markers_round_trip_with_full_sha256():
+    body = "PATH=/bin\n0 1 * * * true\n"
+    block = managed_block.render_block(body, kind="CARE", profile="crontab", style=managed_block.MARKER_STYLE_HASH)
+    digest = managed_block.body_hash(body)
+    assert block.startswith(f"# BEGIN BRIGADE CARE v:1 profile:crontab hash:{digest}\n")
+    assert "# END BRIGADE CARE\n" in block
+    assert "<!--" not in block
+    assessment = managed_block.assess_block(
+        block, desired=body, kind="CARE", profile="crontab", style=managed_block.MARKER_STYLE_HASH
+    )
+    assert assessment.status == managed_block.STATUS_CURRENT
+    assert assessment.recorded_hash == digest
+
+
+def test_html_default_style_unchanged_for_integration_blocks():
+    body = _desired()
+    block = managed_block.render_block(body)
+    assert block.startswith("<!-- BEGIN BRIGADE INTEGRATION")
+    assessment = managed_block.assess_block(block, desired=body)
+    assert assessment.status == managed_block.STATUS_CURRENT
+
+
+def test_remove_block_skips_symlink_swap(tmp_path):
+    body = _desired()
+    path = tmp_path / "AGENTS.md"
+    path.write_text(f"# keep\n{managed_block.render_block(body)}", encoding="utf-8")
+    target = tmp_path / "elsewhere.md"
+    target.write_text("secret\n", encoding="utf-8")
+    calls = {"n": 0}
+
+    def probe(candidate: Path) -> int | None:
+        calls["n"] += 1
+        if calls["n"] <= 2:
+            return os.lstat(candidate).st_mode
+        if candidate == path and path.exists() and not path.is_symlink():
+            path.unlink()
+            path.symlink_to(target)
+        return os.lstat(candidate).st_mode
+
+    with pytest.warns(UserWarning, match="symlink"):
+        plan, outcome = managed_block.remove_block(path, owned_digest=managed_block.body_hash(body), lstat_probe=probe)
+    assert outcome.status == managed_block.WRITE_SKIPPED_SYMLINK
+    assert target.read_text(encoding="utf-8") == "secret\n"
+
+
+def test_mixed_html_and_hash_markers_are_malformed():
+    body = _desired()
+    html = managed_block.render_block(body, kind="CARE", profile="full", style=managed_block.MARKER_STYLE_HTML)
+    hybrid = html + managed_block.render_block(
+        "other\n", kind="CARE", profile="crontab", style=managed_block.MARKER_STYLE_HASH
+    )
+    assessment = managed_block.assess_block(hybrid, desired=body, kind="CARE", profile="full")
+    assert assessment.status == managed_block.STATUS_MALFORMED
+
+
+def test_explicit_hash_style_rejects_html_stamped_markers():
+    body = _desired()
+    html = managed_block.render_block(body, kind="CARE", profile="full", style=managed_block.MARKER_STYLE_HTML)
+    parsed = managed_block.parse_blocks(html, kind="CARE", style=managed_block.MARKER_STYLE_HASH)
+    assert parsed.status == managed_block.STATUS_MALFORMED
+    assert parsed.detail == "stamped managed markers do not match requested marker style"
+    assessment = managed_block.assess_block(
+        html, desired=body, kind="CARE", profile="full", style=managed_block.MARKER_STYLE_HASH
+    )
+    assert assessment.status == managed_block.STATUS_MALFORMED
+    plan = managed_block.plan_install(
+        html, desired=body, kind="CARE", profile="full", style=managed_block.MARKER_STYLE_HASH
+    )
+    assert plan.status == managed_block.STATUS_MALFORMED
+    assert plan.action == managed_block.ACTION_PRESERVE
+
+
+def test_explicit_html_style_rejects_hash_stamped_markers():
+    body = _desired()
+    hashed = managed_block.render_block(body, kind="CARE", profile="crontab", style=managed_block.MARKER_STYLE_HASH)
+    parsed = managed_block.parse_blocks(hashed, kind="CARE", style=managed_block.MARKER_STYLE_HTML)
+    assert parsed.status == managed_block.STATUS_MALFORMED
+    assert parsed.detail == "stamped managed markers do not match requested marker style"
+    assessment = managed_block.assess_block(
+        hashed, desired=body, kind="CARE", profile="crontab", style=managed_block.MARKER_STYLE_HTML
+    )
+    assert assessment.status == managed_block.STATUS_MALFORMED
+    plan = managed_block.plan_install(
+        hashed, desired=body, kind="CARE", profile="crontab", style=managed_block.MARKER_STYLE_HTML
+    )
+    assert plan.status == managed_block.STATUS_MALFORMED
+    assert plan.action == managed_block.ACTION_PRESERVE
+
+
+def test_explicit_style_rejects_mixed_stamped_markers():
+    body = _desired()
+    html = managed_block.render_block(body, kind="CARE", profile="full", style=managed_block.MARKER_STYLE_HTML)
+    hybrid = html + managed_block.render_block(
+        "other\n", kind="CARE", profile="crontab", style=managed_block.MARKER_STYLE_HASH
+    )
+    parsed = managed_block.parse_blocks(hybrid, kind="CARE", style=managed_block.MARKER_STYLE_HASH)
+    assert parsed.status == managed_block.STATUS_MALFORMED
+    assert parsed.detail == "stamped html and hash-comment managed markers both present"
+    assessment = managed_block.assess_block(
+        hybrid, desired=body, kind="CARE", profile="full", style=managed_block.MARKER_STYLE_HASH
+    )
+    assert assessment.status == managed_block.STATUS_MALFORMED
+    plan = managed_block.plan_install(
+        hybrid, desired=body, kind="CARE", profile="full", style=managed_block.MARKER_STYLE_HASH
+    )
+    assert plan.status == managed_block.STATUS_MALFORMED
+    assert plan.action == managed_block.ACTION_PRESERVE


### PR DESCRIPTION
Summary:\n- adds opt-in install, status, and uninstall flows for scheduled care\n- keeps scheduler ownership explicit and daemon-free\n- adds care command and scheduling coverage\n\nVerification will be rerun after rebasing onto current main.\n\nFixes #759