### PR TITLE
feat(runs): classify and scrub app-server worker event streams (#592)

### DIFF
--- a/.grok/memory-handoffs/2026-08-09-worker-event-streams-592.md
+++ b/.grok/memory-handoffs/2026-08-09-worker-event-streams-592.md
@@ -1,0 +1,38 @@
+# Memory Handoff
+
+## Type
+
+project-context
+
+## Title
+
+Worker event stream classification and fail-closed scrubbing (#592)
+
+## Summary
+
+Issue #592 first slice adds a closed field-classification matrix and fail-closed scrubber for Codex app-server worker streams under `events/<worker>.jsonl`. Scrubbed projections keep public metadata, stable IDs, safe operation names, schema versions, and source digests; private/secret/prohibited fields are omitted. Audit/replay reject raw streams unless `policy=local-only`; resume uses local-only. Legacy raw NDJSON stays inspectable and marked unclassified until scrubbed.
+
+## Durable facts
+
+- Module: `src/brigade/worker_events.py`; docs: `docs/worker-event-streams.md`; goldens: `src/brigade/fixtures/worker-events-appserver.v1.golden.json`
+- Media types: raw `application/vnd.brigade.worker-events.appserver+jsonl` vs scrubbed `...scrubbed+jsonl`
+- Consumer APIs: `scrub_event` / `scrub_stream_file`, `inspect_stream_file`, `load_stream_for_consumer`, `run_audit.reject_raw_worker_stream_evidence`
+- First slice excludes legacy backfill and archive export wiring; unknown methods/fields fail closed with bounded diagnostics
+
+## Evidence
+
+- files changed: `src/brigade/worker_events.py`, `src/brigade/run_audit.py`, `src/brigade/run_resume.py`, `tests/test_worker_events.py`, `docs/worker-event-streams.md`, `CHANGELOG.md`, golden fixture
+- commands run: `pytest -q tests/test_worker_events.py`, `./scripts/verify`
+- error strings: `rejects unclassified worker event stream`; `unknown event method`; `unknown field`
+
+## Recommended memory action
+
+no-card
+
+## Target document
+
+.learnings/FEATURE_REQUESTS.md
+
+## Suggested document content
+
+Worker event scrubbing (#592) landed as library-first: no new CLI. Follow-ups are scrubbed sidecar write path, archive role/media-type wiring, and enabling `worker_event_streams` audit coverage once fixtures are scrubbed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   shipped runbooks so scheduled fires write normal receipts; Windows prints
   Task Scheduler equivalents instead of silently no-oping; tampered blocks are
   reported and not clobbered without `--adopt`.
+- Worker event stream field classification and fail-closed scrubbed projections
+  for the Codex app-server transport (#592): closed classification matrix,
+  scrubber with adversarial golden fixtures, distinct raw/scrubbed media types
+  and artifact classes, and audit/replay rejection of raw streams unless an
+  explicit local-only policy allows salvage. Legacy raw streams stay locally
+  inspectable and marked unclassified until scrubbed.
 - Work verify plan ranks candidate verification commands from GraphTrail
   affected-test impact (#486): `brigade work verify plan` attaches
   `graph_impact` / `ranked_candidates` with hop-distance confidence and

--- a/docs/worker-event-streams.md
+++ b/docs/worker-event-streams.md
@@ -1,0 +1,91 @@
+# Worker event streams: field classification and scrubbed projections
+
+Status: implemented for issue #592 (first slice).
+
+## Boundary
+
+Brigade's Codex app-server transport records worker notifications under
+`events/<worker>.jsonl`. Those files can contain provider notifications, model
+text, tool metadata, absolute paths, and transport diagnostics.
+
+This contract:
+
+- classifies each recorded field as `public_metadata`, `private_content`,
+  `secret`, or `prohibited`
+- keeps raw streams local and access-controlled by default
+- produces a bounded scrubbed projection for inspection, replay evidence,
+  export, or attachment
+- fails closed when an unknown event type or field cannot be classified
+
+Raw streams and scrubbed projections use distinct media types and artifact
+classes:
+
+| Kind | Media type | Artifact class |
+| --- | --- | --- |
+| Raw | `application/vnd.brigade.worker-events.appserver+jsonl` | `worker-event-stream-raw` |
+| Scrubbed | `application/vnd.brigade.worker-events.appserver.scrubbed+jsonl` | `worker-event-stream-scrubbed` |
+| Legacy / not yet scrubbed | raw media type | `worker-event-stream-unclassified` |
+
+Legacy on-disk NDJSON remains locally inspectable and is marked
+`unclassified` until a scrubbed projection exists.
+
+## Consumer policy
+
+| Policy | Consumers | Behavior |
+| --- | --- | --- |
+| `scrubbed-only` (default) | audit, replay, export | reject raw/unclassified streams |
+| `local-only` | resume, local watch/salvage | may read raw streams in place |
+
+Library entry points live in `brigade.worker_events` (`scrub_event`,
+`scrub_stream_file`, `inspect_stream_file`, `load_stream_for_consumer`,
+`require_consumer_policy`). `brigade.run_audit.reject_raw_worker_stream_evidence`
+is the audit/replay gate.
+
+## Field-classification matrix
+
+Source of truth: `worker_events.FIELD_CLASSIFICATION_MATRIX` /
+`worker_events.classification_matrix()`.
+
+### Envelope
+
+| Field | Class |
+| --- | --- |
+| `jsonrpc` | public_metadata |
+| `method` | public_metadata |
+| `params` | public_metadata (nested matrix below) |
+
+### Methods recorded by the app-server transport
+
+| Method | Public params | Stripped (private/secret/prohibited) |
+| --- | --- | --- |
+| `turn/started` | `threadId`, `turn.id`, `turn.status`, scrubbed `turn.items` | `turn.error`, private item payloads |
+| `turn/completed` | same as started | provider `turn.error` bodies |
+| `item/started` | `threadId`, `turnId`, `item.id`, `item.type`, safe item public fields | prompts, text, commands, cwd, diffs, tool args/results |
+| `item/completed` | same as started, plus `completedAtMs` | same as started |
+| `*#auto-declined` | `threadId`, `turnId`, `itemId`, `availableDecisions` | `command`, `cwd`, `reason`, headers, cookies, env, credentials, prompts, grant roots |
+
+Delta methods (`item/*/delta`, …) are never recorded by Brigade and are
+intentionally absent. Unknown methods or fields fail scrubbing with a bounded
+diagnostic.
+
+### Item types
+
+Every supported item type keeps `id` and `type` as public metadata. Content
+fields (`text`, `content`, `command`, `cwd`, `changes`, `arguments`, `result`,
+`query`, `path`, `review`, `prompt`, …) are private or prohibited. See
+`classification_matrix()["item_types"]` for the closed per-type key set.
+
+## Schemas
+
+- Scrubbed event: `brigade.worker_event_scrubbed.v1`
+- Scrubbed stream document: `brigade.worker_event_stream_scrubbed.v1`
+
+Golden adversarial fixtures:
+`src/brigade/fixtures/worker-events-appserver.v1.golden.json`.
+
+## Non-goals (first slice)
+
+- Legacy backfill of historical streams
+- Export/archive wiring for scrubbed sidecars
+- Treating redaction as a substitute for access control
+- Replacing the ProvenanceEnvelope trust contract (#498)

--- a/docs/worker-event-streams.md
+++ b/docs/worker-event-streams.md
@@ -62,7 +62,10 @@ Source of truth: `worker_events.FIELD_CLASSIFICATION_MATRIX` /
 | `turn/completed` | same as started | provider `turn.error` bodies |
 | `item/started` | `threadId`, `turnId`, `item.id`, `item.type`, safe item public fields | prompts, text, commands, cwd, diffs, tool args/results |
 | `item/completed` | same as started, plus `completedAtMs` | same as started |
-| `*#auto-declined` | `threadId`, `turnId`, `itemId`, `availableDecisions` | `command`, `cwd`, `reason`, headers, cookies, env, credentials, prompts, grant roots |
+| `item/commandExecution/requestApproval#auto-declined` | `threadId`, `turnId`, `itemId`, `availableDecisions` | `command`, `cwd`, `reason`, headers, cookies, env, credentials, prompts, grant roots |
+
+Only the recorded approval auto-decline method above is accepted. Other
+`*#auto-declined` bases fail closed.
 
 Delta methods (`item/*/delta`, …) are never recorded by Brigade and are
 intentionally absent. Unknown methods or fields fail scrubbing with a bounded

--- a/src/brigade/fixtures/worker-events-appserver.v1.golden.json
+++ b/src/brigade/fixtures/worker-events-appserver.v1.golden.json
@@ -1,0 +1,474 @@
+{
+  "artifact_classes": {
+    "raw": "worker-event-stream-raw",
+    "scrubbed": "worker-event-stream-scrubbed",
+    "unclassified": "worker-event-stream-unclassified"
+  },
+  "cases": [
+    {
+      "name": "turn_started_public",
+      "raw": {
+        "jsonrpc": "2.0",
+        "method": "turn/started",
+        "params": {
+          "threadId": "thread-demo-1",
+          "turn": {
+            "id": "turn-1",
+            "items": [],
+            "status": "inProgress"
+          }
+        }
+      },
+      "scrubbed": {
+        "classification_status": "scrubbed",
+        "jsonrpc": "2.0",
+        "method": "turn/started",
+        "params": {
+          "threadId": "thread-demo-1",
+          "turn": {
+            "id": "turn-1",
+            "items": [],
+            "status": "inProgress"
+          }
+        },
+        "schema": "brigade.worker_event_scrubbed.v1",
+        "schema_version": 1,
+        "source_digest": "ca0a8ede21b98133b959a5b127154a46d6020a1ab212d892ed42ff05aa137194",
+        "transport": "codex-app-server"
+      },
+      "source_digest": "ca0a8ede21b98133b959a5b127154a46d6020a1ab212d892ed42ff05aa137194"
+    },
+    {
+      "name": "item_started_command",
+      "raw": {
+        "jsonrpc": "2.0",
+        "method": "item/started",
+        "params": {
+          "item": {
+            "command": "cat /home/example-user/.ssh/id_rsa",
+            "cwd": "/home/example-user/project",
+            "id": "cmd-1",
+            "status": "inProgress",
+            "type": "commandExecution"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        }
+      },
+      "scrubbed": {
+        "classification_status": "scrubbed",
+        "jsonrpc": "2.0",
+        "method": "item/started",
+        "params": {
+          "item": {
+            "id": "cmd-1",
+            "status": "inProgress",
+            "type": "commandExecution"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        },
+        "schema": "brigade.worker_event_scrubbed.v1",
+        "schema_version": 1,
+        "source_digest": "da9be19fb9b6d4a423847bd7ddcb42f7156d2d1bd88a89a7fd341f4b1de4bab2",
+        "transport": "codex-app-server"
+      },
+      "source_digest": "da9be19fb9b6d4a423847bd7ddcb42f7156d2d1bd88a89a7fd341f4b1de4bab2"
+    },
+    {
+      "name": "item_completed_agent_message_private",
+      "raw": {
+        "jsonrpc": "2.0",
+        "method": "item/completed",
+        "params": {
+          "completedAtMs": 1234,
+          "item": {
+            "id": "msg-1",
+            "phase": "final_answer",
+            "text": "Secret plan: exfiltrate token=sk-live-EXAMPLESECRETVALUE99",
+            "type": "agentMessage"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        }
+      },
+      "scrubbed": {
+        "classification_status": "scrubbed",
+        "jsonrpc": "2.0",
+        "method": "item/completed",
+        "params": {
+          "completedAtMs": 1234,
+          "item": {
+            "id": "msg-1",
+            "phase": "final_answer",
+            "type": "agentMessage"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        },
+        "schema": "brigade.worker_event_scrubbed.v1",
+        "schema_version": 1,
+        "source_digest": "2d0b3975ae86adb0ccbf88fd3ad99a8d7a3713f38c7c2a8b490fd7980e228c48",
+        "transport": "codex-app-server"
+      },
+      "source_digest": "2d0b3975ae86adb0ccbf88fd3ad99a8d7a3713f38c7c2a8b490fd7980e228c48"
+    },
+    {
+      "name": "turn_completed_with_provider_error",
+      "raw": {
+        "jsonrpc": "2.0",
+        "method": "turn/completed",
+        "params": {
+          "threadId": "thread-demo-1",
+          "turn": {
+            "error": {
+              "additionalDetails": "cookie=session=abc; path=/",
+              "codexErrorInfo": "Unauthorized",
+              "message": "upstream 401 Authorization: Bearer sk-live-EXAMPLESECRETVALUE99"
+            },
+            "id": "turn-1",
+            "items": [
+              {
+                "id": "msg-1",
+                "text": "internal provider dump",
+                "type": "agentMessage"
+              }
+            ],
+            "status": "failed"
+          }
+        }
+      },
+      "scrubbed": {
+        "classification_status": "scrubbed",
+        "jsonrpc": "2.0",
+        "method": "turn/completed",
+        "params": {
+          "threadId": "thread-demo-1",
+          "turn": {
+            "id": "turn-1",
+            "items": [
+              {
+                "id": "msg-1",
+                "type": "agentMessage"
+              }
+            ],
+            "status": "failed"
+          }
+        },
+        "schema": "brigade.worker_event_scrubbed.v1",
+        "schema_version": 1,
+        "source_digest": "4a560dd74f13f9861cd76f0acbfffa0c6312db80ad4e7aeef874281a673f19f1",
+        "transport": "codex-app-server"
+      },
+      "source_digest": "4a560dd74f13f9861cd76f0acbfffa0c6312db80ad4e7aeef874281a673f19f1"
+    },
+    {
+      "name": "auto_declined_with_secrets",
+      "raw": {
+        "method": "item/commandExecution/requestApproval#auto-declined",
+        "params": {
+          "availableDecisions": [
+            "accept",
+            "decline"
+          ],
+          "command": "curl https://example.invalid -H 'Authorization: Bearer sk-live-EXAMPLESECRETVALUE99'",
+          "credentials": {
+            "token": "sk-live-EXAMPLESECRETVALUE99"
+          },
+          "cwd": "/home/example-user/project",
+          "env": {
+            "HOME": "/home/example-user",
+            "OPENAI_API_KEY": "sk-live-EXAMPLESECRETVALUE99"
+          },
+          "headers": {
+            "Authorization": "Bearer sk-live-EXAMPLESECRETVALUE99",
+            "Cookie": "session=abc"
+          },
+          "itemId": "cmd-1",
+          "prompt": "raw user prompt with private content",
+          "reason": "needs network",
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        }
+      },
+      "scrubbed": {
+        "classification_status": "scrubbed",
+        "method": "item/commandExecution/requestApproval#auto-declined",
+        "params": {
+          "availableDecisions": [
+            "accept",
+            "decline"
+          ],
+          "itemId": "cmd-1",
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        },
+        "schema": "brigade.worker_event_scrubbed.v1",
+        "schema_version": 1,
+        "source_digest": "2e039f1e09b76ea65dccd2b08c1c09edb091c408d7c431d8936482d0309f272f",
+        "transport": "codex-app-server"
+      },
+      "source_digest": "2e039f1e09b76ea65dccd2b08c1c09edb091c408d7c431d8936482d0309f272f"
+    },
+    {
+      "expect_diagnostic_substring": null,
+      "expect_error_category": "unknown-method",
+      "name": "unknown_method_fails_closed",
+      "raw": {
+        "jsonrpc": "2.0",
+        "method": "totally/unknown",
+        "params": {
+          "mystery": true,
+          "threadId": "thread-demo-1"
+        }
+      }
+    },
+    {
+      "expect_diagnostic_substring": null,
+      "expect_error_category": "unknown-field",
+      "name": "unknown_field_fails_closed",
+      "raw": {
+        "jsonrpc": "2.0",
+        "method": "item/completed",
+        "params": {
+          "item": {
+            "id": "x",
+            "text": "hi",
+            "type": "agentMessage"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1",
+          "unexpectedSecret": "sk-live-EXAMPLESECRETVALUE99"
+        }
+      }
+    },
+    {
+      "expect_diagnostic_substring": null,
+      "expect_error_category": "unknown-field",
+      "name": "unknown_item_type_fails_closed",
+      "raw": {
+        "jsonrpc": "2.0",
+        "method": "item/started",
+        "params": {
+          "item": {
+            "id": "x",
+            "payload": "nope",
+            "type": "alienPayload"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        }
+      }
+    }
+  ],
+  "classification_matrix_version": 1,
+  "media_types": {
+    "raw": "application/vnd.brigade.worker-events.appserver+jsonl",
+    "scrubbed": "application/vnd.brigade.worker-events.appserver.scrubbed+jsonl"
+  },
+  "schema": "brigade.worker-events-appserver-fixtures.v1",
+  "schema_version": 1,
+  "stream": {
+    "raw_events": [
+      {
+        "jsonrpc": "2.0",
+        "method": "turn/started",
+        "params": {
+          "threadId": "thread-demo-1",
+          "turn": {
+            "id": "turn-1",
+            "items": [],
+            "status": "inProgress"
+          }
+        }
+      },
+      {
+        "jsonrpc": "2.0",
+        "method": "item/started",
+        "params": {
+          "item": {
+            "command": "cat /home/example-user/.ssh/id_rsa",
+            "cwd": "/home/example-user/project",
+            "id": "cmd-1",
+            "status": "inProgress",
+            "type": "commandExecution"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        }
+      },
+      {
+        "jsonrpc": "2.0",
+        "method": "item/completed",
+        "params": {
+          "completedAtMs": 1234,
+          "item": {
+            "id": "msg-1",
+            "phase": "final_answer",
+            "text": "Secret plan: exfiltrate token=sk-live-EXAMPLESECRETVALUE99",
+            "type": "agentMessage"
+          },
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        }
+      },
+      {
+        "jsonrpc": "2.0",
+        "method": "turn/completed",
+        "params": {
+          "threadId": "thread-demo-1",
+          "turn": {
+            "error": {
+              "additionalDetails": "cookie=session=abc; path=/",
+              "codexErrorInfo": "Unauthorized",
+              "message": "upstream 401 Authorization: Bearer sk-live-EXAMPLESECRETVALUE99"
+            },
+            "id": "turn-1",
+            "items": [
+              {
+                "id": "msg-1",
+                "text": "internal provider dump",
+                "type": "agentMessage"
+              }
+            ],
+            "status": "failed"
+          }
+        }
+      },
+      {
+        "method": "item/commandExecution/requestApproval#auto-declined",
+        "params": {
+          "availableDecisions": [
+            "accept",
+            "decline"
+          ],
+          "command": "curl https://example.invalid -H 'Authorization: Bearer sk-live-EXAMPLESECRETVALUE99'",
+          "credentials": {
+            "token": "sk-live-EXAMPLESECRETVALUE99"
+          },
+          "cwd": "/home/example-user/project",
+          "env": {
+            "HOME": "/home/example-user",
+            "OPENAI_API_KEY": "sk-live-EXAMPLESECRETVALUE99"
+          },
+          "headers": {
+            "Authorization": "Bearer sk-live-EXAMPLESECRETVALUE99",
+            "Cookie": "session=abc"
+          },
+          "itemId": "cmd-1",
+          "prompt": "raw user prompt with private content",
+          "reason": "needs network",
+          "threadId": "thread-demo-1",
+          "turnId": "turn-1"
+        }
+      }
+    ],
+    "scrubbed": {
+      "artifact_class": "worker-event-stream-scrubbed",
+      "classification_matrix_version": 1,
+      "classification_status": "scrubbed",
+      "event_count": 5,
+      "events": [
+        {
+          "classification_status": "scrubbed",
+          "jsonrpc": "2.0",
+          "method": "turn/started",
+          "params": {
+            "threadId": "thread-demo-1",
+            "turn": {
+              "id": "turn-1",
+              "items": [],
+              "status": "inProgress"
+            }
+          },
+          "schema": "brigade.worker_event_scrubbed.v1",
+          "schema_version": 1,
+          "source_digest": "ca0a8ede21b98133b959a5b127154a46d6020a1ab212d892ed42ff05aa137194",
+          "transport": "codex-app-server"
+        },
+        {
+          "classification_status": "scrubbed",
+          "jsonrpc": "2.0",
+          "method": "item/started",
+          "params": {
+            "item": {
+              "id": "cmd-1",
+              "status": "inProgress",
+              "type": "commandExecution"
+            },
+            "threadId": "thread-demo-1",
+            "turnId": "turn-1"
+          },
+          "schema": "brigade.worker_event_scrubbed.v1",
+          "schema_version": 1,
+          "source_digest": "da9be19fb9b6d4a423847bd7ddcb42f7156d2d1bd88a89a7fd341f4b1de4bab2",
+          "transport": "codex-app-server"
+        },
+        {
+          "classification_status": "scrubbed",
+          "jsonrpc": "2.0",
+          "method": "item/completed",
+          "params": {
+            "completedAtMs": 1234,
+            "item": {
+              "id": "msg-1",
+              "phase": "final_answer",
+              "type": "agentMessage"
+            },
+            "threadId": "thread-demo-1",
+            "turnId": "turn-1"
+          },
+          "schema": "brigade.worker_event_scrubbed.v1",
+          "schema_version": 1,
+          "source_digest": "2d0b3975ae86adb0ccbf88fd3ad99a8d7a3713f38c7c2a8b490fd7980e228c48",
+          "transport": "codex-app-server"
+        },
+        {
+          "classification_status": "scrubbed",
+          "jsonrpc": "2.0",
+          "method": "turn/completed",
+          "params": {
+            "threadId": "thread-demo-1",
+            "turn": {
+              "id": "turn-1",
+              "items": [
+                {
+                  "id": "msg-1",
+                  "type": "agentMessage"
+                }
+              ],
+              "status": "failed"
+            }
+          },
+          "schema": "brigade.worker_event_scrubbed.v1",
+          "schema_version": 1,
+          "source_digest": "4a560dd74f13f9861cd76f0acbfffa0c6312db80ad4e7aeef874281a673f19f1",
+          "transport": "codex-app-server"
+        },
+        {
+          "classification_status": "scrubbed",
+          "method": "item/commandExecution/requestApproval#auto-declined",
+          "params": {
+            "availableDecisions": [
+              "accept",
+              "decline"
+            ],
+            "itemId": "cmd-1",
+            "threadId": "thread-demo-1",
+            "turnId": "turn-1"
+          },
+          "schema": "brigade.worker_event_scrubbed.v1",
+          "schema_version": 1,
+          "source_digest": "2e039f1e09b76ea65dccd2b08c1c09edb091c408d7c431d8936482d0309f272f",
+          "transport": "codex-app-server"
+        }
+      ],
+      "media_type": "application/vnd.brigade.worker-events.appserver.scrubbed+jsonl",
+      "schema": "brigade.worker_event_stream_scrubbed.v1",
+      "schema_version": 1,
+      "source_digest": "d15470bade397ca60083e14139243253c3e5c0db234267c36abf34247843cc0f",
+      "transport": "codex-app-server"
+    }
+  },
+  "transport": "codex-app-server"
+}

--- a/src/brigade/run_audit.py
+++ b/src/brigade/run_audit.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 from brigade import __version__ as BRIGADE_VERSION
-from brigade import run_events, run_journal, run_projector
+from brigade import run_events, run_journal, run_projector, worker_events
 from brigade.run_events import CanonicalizationError, canonical_bytes
 
 AUDIT_SCHEMA = "brigade.run_audit.v1"
@@ -88,9 +88,11 @@ NORMALIZATION_EXCLUSIONS: frozenset[str] = frozenset(
     }
 )
 
-# First-slice audit coverage by transport. Structured app-server response
-# fixture comparison is a follow-up (#592); unsupported transports must state
-# coverage instead of claiming full replay.
+# First-slice audit coverage by transport. Structured app-server worker-stream
+# fixture comparison requires scrubbed projections from #592; raw
+# events/<worker>.jsonl is rejected unless an explicit local-only policy allows
+# local salvage. Unsupported transports must state coverage instead of claiming
+# full replay.
 TRANSPORT_COVERAGE: dict[str, dict[str, Any]] = {
     "app-server": {
         "coordinator_decisions": True,
@@ -98,7 +100,10 @@ TRANSPORT_COVERAGE: dict[str, dict[str, Any]] = {
         "composed_prompt_fingerprints": True,
         "provider_response_fixtures": False,
         "worker_event_streams": False,
-        "note": "coordinator-only slice; provider response fixtures deferred",
+        "note": (
+            "coordinator-only slice; raw worker streams rejected without local-only "
+            "policy; scrubbed projections required for portable stream evidence (#592)"
+        ),
     },
     "exec": {
         "coordinator_decisions": True,
@@ -754,6 +759,11 @@ def audit_run(
     enables golden / regression comparison; when omitted, the audit checks
     internal consistency (projection, approval, routing) against archived
     artifacts and returns the normalized event sequence for byte-stable replay.
+
+    Raw ``events/<worker>.jsonl`` streams are never treated as portable audit
+    evidence. Call ``reject_raw_worker_stream_evidence`` (default scrubbed-only
+    policy) before loading stream fixtures; pass ``policy=local-only`` only for
+    explicit local salvage that must not export stream bytes (#592).
     """
     run_dir = Path(run_dir)
     revision = code_revision if code_revision is not None else BRIGADE_VERSION
@@ -779,6 +789,10 @@ def audit_run(
                 detail=_bound(f"run directory not found: {run_dir.name}"),
             ),
         )
+
+    # Worker event streams (#592): coordinator-only audits never load raw
+    # events/<worker>.jsonl as portable evidence. Use
+    # reject_raw_worker_stream_evidence() when a caller needs the explicit gate.
 
     source_run_id = run_dir.name
     journal_path = run_dir / JOURNAL_REL
@@ -1106,6 +1120,27 @@ def _error_report(
         not_auditable_reason=_bound(detail)
         if divergence_class in {CLASS_MISSING_OR_CORRUPT_FIXTURE, CLASS_UNSUPPORTED_SCHEMA}
         else None,
+    )
+
+
+def reject_raw_worker_stream_evidence(
+    run_dir: Path,
+    *,
+    policy: str = worker_events.POLICY_SCRUBBED_ONLY,
+) -> list[worker_events.StreamArtifactInfo]:
+    """Reject raw worker streams as audit/replay evidence unless local-only.
+
+    Coordinator-only ``audit_run`` does not load worker streams as fixtures.
+    Callers that compare or export stream evidence must go through this gate
+    (or ``worker_events.load_stream_for_consumer``) so raw NDJSON cannot become
+    portable evidence under the default scrubbed-only policy (#592).
+    """
+    if policy not in worker_events.CONSUMER_POLICIES:
+        raise AuditError(_bound(f"unknown worker_stream_policy {policy!r}"))
+    return worker_events.assert_audit_rejects_raw_streams(
+        Path(run_dir) / "events",
+        policy=policy,
+        consumer="run_audit",
     )
 
 

--- a/src/brigade/run_resume.py
+++ b/src/brigade/run_resume.py
@@ -12,7 +12,7 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-from . import aboyeur, agents, codex_appserver, receipt_schema, run_lifecycle, runguard
+from . import aboyeur, agents, codex_appserver, receipt_schema, run_lifecycle, runguard, worker_events
 from .roster import Agent, Roster, _as_bool, _as_env
 
 _RESUMABLE_STATUSES = ("interrupted", "failed")
@@ -75,15 +75,24 @@ def _interrupted_appserver_results(run_dir: Path) -> dict | None:
         event_path = run_dir / "events" / f"{aboyeur._slug(worker)}.jsonl"
         thread_id: str | None = None
         try:
-            lines = event_path.read_text().splitlines()
-        except OSError:
+            # Resume is a local salvage path: raw worker streams are admissible
+            # only under the explicit local-only consumer policy (#592).
+            loaded = worker_events.load_stream_for_consumer(
+                event_path,
+                consumer="run_resume",
+                policy=worker_events.POLICY_LOCAL_ONLY,
+            )
+        except (worker_events.WorkerEventError, worker_events.WorkerEventPolicyError, OSError):
             continue
-        for line in lines:
-            try:
-                event = json.loads(line)
-            except (json.JSONDecodeError, RecursionError):
+        if isinstance(loaded, dict):
+            maybe_events = loaded.get("events")
+            events: list[object] = maybe_events if isinstance(maybe_events, list) else []
+        else:
+            events = list(loaded)
+        for event in events:
+            if not isinstance(event, dict):
                 continue
-            params = event.get("params") if isinstance(event, dict) else None
+            params = event.get("params")
             candidate = params.get("threadId") if isinstance(params, dict) else None
             if isinstance(candidate, str) and candidate:
                 thread_id = candidate

--- a/src/brigade/worker_events.py
+++ b/src/brigade/worker_events.py
@@ -1,0 +1,888 @@
+"""Worker event stream field classification and fail-closed scrubbed projections.
+
+Implements the privacy boundary for Codex app-server worker streams recorded
+under ``events/<worker>.jsonl`` (issue #592, first slice).
+
+Raw streams stay local. Scrubbed projections keep only public metadata, stable
+IDs, safe operation names, schema versions, and source digests. Unknown event
+types or fields fail closed with bounded diagnostics. Legacy raw streams remain
+inspectable locally but are marked unclassified until successfully scrubbed.
+
+Standard library only. Brigade is zero-runtime-dependency.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Iterator, Mapping
+
+TRANSPORT = "codex-app-server"
+SCHEMA = "brigade.worker_event_scrubbed.v1"
+SCHEMA_VERSION = 1
+STREAM_SCHEMA = "brigade.worker_event_stream_scrubbed.v1"
+STREAM_SCHEMA_VERSION = 1
+CLASSIFICATION_MATRIX_VERSION = 1
+
+RAW_MEDIA_TYPE = "application/vnd.brigade.worker-events.appserver+jsonl"
+SCRUBBED_MEDIA_TYPE = "application/vnd.brigade.worker-events.appserver.scrubbed+jsonl"
+RAW_ARTIFACT_CLASS = "worker-event-stream-raw"
+SCRUBBED_ARTIFACT_CLASS = "worker-event-stream-scrubbed"
+UNCLASSIFIED_ARTIFACT_CLASS = "worker-event-stream-unclassified"
+
+FIELD_PUBLIC = "public_metadata"
+FIELD_PRIVATE = "private_content"
+FIELD_SECRET = "secret"
+FIELD_PROHIBITED = "prohibited"
+
+FIELD_CLASSES = frozenset({FIELD_PUBLIC, FIELD_PRIVATE, FIELD_SECRET, FIELD_PROHIBITED})
+
+STATUS_SCRUBBED = "scrubbed"
+STATUS_UNCLASSIFIED = "unclassified"
+STATUS_RAW = "raw"
+
+POLICY_SCRUBBED_ONLY = "scrubbed-only"
+POLICY_LOCAL_ONLY = "local-only"
+CONSUMER_POLICIES = frozenset({POLICY_SCRUBBED_ONLY, POLICY_LOCAL_ONLY})
+
+MAX_DIAGNOSTIC_LEN = 240
+MAX_LINE_BYTES = 1_048_576
+_HEX64 = re.compile(r"^[0-9a-f]{64}$")
+_AUTO_DECLINED_SUFFIX = "#auto-declined"
+
+# Top-level JSON-RPC notification envelope keys only.
+_ENVELOPE_FIELDS: dict[str, str] = {
+    "jsonrpc": FIELD_PUBLIC,
+    "method": FIELD_PUBLIC,
+    "params": FIELD_PUBLIC,  # nested classification is method-specific
+}
+
+# ---------------------------------------------------------------------------
+# Field-classification matrix (Codex app-server notification envelope)
+# ---------------------------------------------------------------------------
+#
+# Classes:
+#   public_metadata  - safe to retain in scrubbed projections
+#   private_content  - prompts, model text, tool args/output, paths, diffs
+#   secret           - credentials, auth headers, cookies, env values
+#   prohibited       - provider error bodies and other never-export payloads
+#
+# Unknown methods or fields fail closed. Delta methods are never recorded by
+# Brigade's app-server transport and are therefore absent from this matrix.
+
+_TURN_FIELDS: dict[str, str] = {
+    "id": FIELD_PUBLIC,
+    "status": FIELD_PUBLIC,
+    "items": FIELD_PUBLIC,  # each element classified via item matrix
+    "error": FIELD_PROHIBITED,
+}
+
+_ITEM_TYPE_FIELDS: dict[str, dict[str, str]] = {
+    "userMessage": {
+        "id": FIELD_PUBLIC,
+        "type": FIELD_PUBLIC,
+        "content": FIELD_PRIVATE,
+        "clientId": FIELD_PUBLIC,
+    },
+    "agentMessage": {
+        "id": FIELD_PUBLIC,
+        "type": FIELD_PUBLIC,
+        "text": FIELD_PRIVATE,
+        "phase": FIELD_PUBLIC,
+    },
+    "plan": {
+        "id": FIELD_PUBLIC,
+        "type": FIELD_PUBLIC,
+        "text": FIELD_PRIVATE,
+    },
+    "reasoning": {
+        "id": FIELD_PUBLIC,
+        "type": FIELD_PUBLIC,
+        "summary": FIELD_PRIVATE,
+        "content": FIELD_PRIVATE,
+    },
+    "commandExecution": {
+        "id": FIELD_PUBLIC,
+        "type": FIELD_PUBLIC,
+        "command": FIELD_PRIVATE,
+        "cwd": FIELD_PRIVATE,  # absolute paths incl. home
+        "status": FIELD_PUBLIC,
+        "commandActions": FIELD_PRIVATE,
+        "aggregatedOutput": FIELD_PRIVATE,
+        "exitCode": FIELD_PUBLIC,
+        "durationMs": FIELD_PUBLIC,
+    },
+    "fileChange": {
+        "id": FIELD_PUBLIC,
+        "type": FIELD_PUBLIC,
+        "changes": FIELD_PRIVATE,
+        "status": FIELD_PUBLIC,
+    },
+    "mcpToolCall": {
+        "id": FIELD_PUBLIC,
+        "type": FIELD_PUBLIC,
+        "server": FIELD_PUBLIC,
+        "tool": FIELD_PUBLIC,
+        "status": FIELD_PUBLIC,
+        "arguments": FIELD_PRIVATE,
+        "appContext": FIELD_PRIVATE,
+        "pluginId": FIELD_PUBLIC,
+        "result": FIELD_PRIVATE,
+        "error": FIELD_PROHIBITED,
+        "mcpAppResourceUri": FIELD_PRIVATE,
+    },
+    "dynamicToolCall": {
+        "id": FIELD_PUBLIC,
+        "type": FIELD_PUBLIC,
+        "tool": FIELD_PUBLIC,
+        "arguments": FIELD_PRIVATE,
+        "status": FIELD_PUBLIC,
+        "contentItems": FIELD_PRIVATE,
+        "success": FIELD_PUBLIC,
+        "durationMs": FIELD_PUBLIC,
+    },
+    "collabToolCall": {
+        "id": FIELD_PUBLIC,
+        "type": FIELD_PUBLIC,
+        "tool": FIELD_PUBLIC,
+        "status": FIELD_PUBLIC,
+        "senderThreadId": FIELD_PUBLIC,
+        "receiverThreadId": FIELD_PUBLIC,
+        "newThreadId": FIELD_PUBLIC,
+        "prompt": FIELD_PRIVATE,
+        "agentStatus": FIELD_PUBLIC,
+    },
+    "webSearch": {
+        "id": FIELD_PUBLIC,
+        "type": FIELD_PUBLIC,
+        "query": FIELD_PRIVATE,
+        "action": FIELD_PRIVATE,
+    },
+    "imageView": {
+        "id": FIELD_PUBLIC,
+        "type": FIELD_PUBLIC,
+        "path": FIELD_PRIVATE,
+    },
+    "enteredReviewMode": {
+        "id": FIELD_PUBLIC,
+        "type": FIELD_PUBLIC,
+        "review": FIELD_PRIVATE,
+    },
+    "exitedReviewMode": {
+        "id": FIELD_PUBLIC,
+        "type": FIELD_PUBLIC,
+        "review": FIELD_PRIVATE,
+    },
+    "contextCompaction": {
+        "id": FIELD_PUBLIC,
+        "type": FIELD_PUBLIC,
+    },
+}
+
+_METHOD_PARAM_FIELDS: dict[str, dict[str, str]] = {
+    "turn/started": {
+        "threadId": FIELD_PUBLIC,
+        "turn": FIELD_PUBLIC,
+    },
+    "turn/completed": {
+        "threadId": FIELD_PUBLIC,
+        "turn": FIELD_PUBLIC,
+    },
+    "item/started": {
+        "threadId": FIELD_PUBLIC,
+        "turnId": FIELD_PUBLIC,
+        "item": FIELD_PUBLIC,
+    },
+    "item/completed": {
+        "threadId": FIELD_PUBLIC,
+        "turnId": FIELD_PUBLIC,
+        "completedAtMs": FIELD_PUBLIC,
+        "item": FIELD_PUBLIC,
+    },
+}
+
+# Synthetic Brigade notification emitted when app-server approvals are
+# auto-declined (see codex_appserver._handle_server_request).
+_AUTO_DECLINED_PARAM_FIELDS: dict[str, str] = {
+    "threadId": FIELD_PUBLIC,
+    "turnId": FIELD_PUBLIC,
+    "itemId": FIELD_PUBLIC,
+    "reason": FIELD_PRIVATE,
+    "command": FIELD_PRIVATE,
+    "cwd": FIELD_PRIVATE,
+    "commandActions": FIELD_PRIVATE,
+    "proposedExecpolicyAmendment": FIELD_PRIVATE,
+    "networkApprovalContext": FIELD_PRIVATE,
+    "availableDecisions": FIELD_PUBLIC,
+    "additionalPermissions": FIELD_PRIVATE,
+    "grantRoot": FIELD_PRIVATE,
+    "headers": FIELD_SECRET,
+    "authorization": FIELD_SECRET,
+    "cookie": FIELD_SECRET,
+    "cookies": FIELD_SECRET,
+    "credentials": FIELD_SECRET,
+    "env": FIELD_SECRET,
+    "environment": FIELD_SECRET,
+    "prompt": FIELD_PRIVATE,
+    "apiKey": FIELD_SECRET,
+    "token": FIELD_SECRET,
+}
+
+# Keys that are always secret/prohibited wherever they appear under params.
+_GLOBAL_SECRET_KEYS: dict[str, str] = {
+    "authorization": FIELD_SECRET,
+    "Authorization": FIELD_SECRET,
+    "cookie": FIELD_SECRET,
+    "Cookie": FIELD_SECRET,
+    "cookies": FIELD_SECRET,
+    "set-cookie": FIELD_SECRET,
+    "Set-Cookie": FIELD_SECRET,
+    "credentials": FIELD_SECRET,
+    "apiKey": FIELD_SECRET,
+    "api_key": FIELD_SECRET,
+    "token": FIELD_SECRET,
+    "accessToken": FIELD_SECRET,
+    "refreshToken": FIELD_SECRET,
+    "password": FIELD_SECRET,
+    "secret": FIELD_SECRET,
+    "env": FIELD_SECRET,
+    "environment": FIELD_SECRET,
+    "headers": FIELD_SECRET,
+}
+
+# Documented matrix export for tests and docs generation.
+FIELD_CLASSIFICATION_MATRIX: dict[str, Any] = {
+    "version": CLASSIFICATION_MATRIX_VERSION,
+    "transport": TRANSPORT,
+    "field_classes": sorted(FIELD_CLASSES),
+    "envelope": dict(_ENVELOPE_FIELDS),
+    "methods": {name: {"params": dict(fields)} for name, fields in sorted(_METHOD_PARAM_FIELDS.items())},
+    "auto_declined_params": dict(_AUTO_DECLINED_PARAM_FIELDS),
+    "turn_fields": dict(_TURN_FIELDS),
+    "item_types": {name: dict(fields) for name, fields in sorted(_ITEM_TYPE_FIELDS.items())},
+    "global_secret_keys": dict(_GLOBAL_SECRET_KEYS),
+    "notes": (
+        "Delta methods are never recorded by Brigade and are intentionally absent. "
+        "Unknown methods or fields fail closed. Absolute home paths travel in cwd/path/"
+        "grantRoot and are classified private_content. Provider error bodies are prohibited."
+    ),
+}
+
+
+class WorkerEventError(ValueError):
+    """Fail-closed scrub or policy error with a bounded diagnostic."""
+
+    def __init__(self, message: str, *, category: str = "scrub") -> None:
+        super().__init__(_bound(message))
+        self.category = category
+        self.diagnostic = _bound(message)
+
+
+class WorkerEventPolicyError(WorkerEventError):
+    """Consumer policy rejected a raw or unclassified worker stream."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message, category="policy")
+
+
+@dataclass(frozen=True)
+class StreamArtifactInfo:
+    """Classification of a worker-event stream artifact on disk."""
+
+    path: Path
+    status: str
+    media_type: str
+    artifact_class: str
+    transport: str
+    event_count: int
+    source_digest: str | None
+    diagnostic: str | None = None
+
+
+def _bound(msg: str) -> str:
+    if len(msg) <= MAX_DIAGNOSTIC_LEN:
+        return msg
+    return msg[: MAX_DIAGNOSTIC_LEN - 1] + "\u2026"
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def canonical_event_bytes(obj: Any) -> bytes:
+    """Canonical UTF-8 JSON for source digests: sorted keys, compact separators."""
+    try:
+        return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    except (TypeError, ValueError, OverflowError, RecursionError) as exc:
+        raise WorkerEventError(_bound(f"event cannot be canonicalized: {exc}")) from exc
+
+
+def source_digest_for_event(raw: Mapping[str, Any]) -> str:
+    return _sha256_hex(canonical_event_bytes(dict(raw)))
+
+
+def source_digest_for_stream_bytes(raw_bytes: bytes) -> str:
+    return _sha256_hex(raw_bytes)
+
+
+def classification_matrix() -> dict[str, Any]:
+    """Return a deep copy of the documented field-classification matrix."""
+    return json.loads(json.dumps(FIELD_CLASSIFICATION_MATRIX))
+
+
+def _is_auto_declined(method: str) -> bool:
+    return method.endswith(_AUTO_DECLINED_SUFFIX) and len(method) > len(_AUTO_DECLINED_SUFFIX)
+
+
+def _param_matrix_for_method(method: str) -> dict[str, str]:
+    if method in _METHOD_PARAM_FIELDS:
+        return _METHOD_PARAM_FIELDS[method]
+    if _is_auto_declined(method):
+        return _AUTO_DECLINED_PARAM_FIELDS
+    raise WorkerEventError(_bound(f"unknown event method {method!r}"), category="unknown-method")
+
+
+def _scrub_scalar_public(key: str, value: Any) -> Any:
+    if value is None or isinstance(value, (str, int)) and not isinstance(value, bool):
+        return value
+    if isinstance(value, float):
+        # Duration-like numbers occasionally appear as floats; refuse rather than coerce.
+        raise WorkerEventError(_bound(f"public field {key!r} must not be float"), category="type")
+    if isinstance(value, bool):
+        # JSON-RPC sometimes carries booleans (e.g. success). Allow only for known public bools.
+        return value
+    if isinstance(value, list):
+        return [_scrub_scalar_public(f"{key}[]", item) for item in value]
+    raise WorkerEventError(
+        _bound(f"public field {key!r} has unsupported type {type(value).__name__}"),
+        category="type",
+    )
+
+
+def _scrub_item(item: Any, *, path: str) -> dict[str, Any]:
+    if not isinstance(item, Mapping):
+        raise WorkerEventError(_bound(f"{path} must be an object"), category="type")
+    item_type = item.get("type")
+    if not isinstance(item_type, str) or not item_type:
+        raise WorkerEventError(_bound(f"{path}.type must be a non-empty string"), category="type")
+    matrix = _ITEM_TYPE_FIELDS.get(item_type)
+    if matrix is None:
+        raise WorkerEventError(_bound(f"unknown item type {item_type!r}"), category="unknown-field")
+    return _scrub_object(item, matrix, path=path)
+
+
+def _scrub_turn(turn: Any, *, path: str) -> dict[str, Any]:
+    if not isinstance(turn, Mapping):
+        raise WorkerEventError(_bound(f"{path} must be an object"), category="type")
+    out: dict[str, Any] = {}
+    for key, value in turn.items():
+        if not isinstance(key, str):
+            raise WorkerEventError(_bound(f"{path} has non-string key"), category="unknown-field")
+        classification = _TURN_FIELDS.get(key)
+        if classification is None:
+            raise WorkerEventError(_bound(f"unknown field {path}.{key}"), category="unknown-field")
+        if classification in (FIELD_PRIVATE, FIELD_SECRET, FIELD_PROHIBITED):
+            continue
+        if key == "items":
+            if not isinstance(value, list):
+                raise WorkerEventError(_bound(f"{path}.items must be an array"), category="type")
+            out["items"] = [_scrub_item(entry, path=f"{path}.items[]") for entry in value]
+            continue
+        out[key] = _scrub_scalar_public(f"{path}.{key}", value)
+    return out
+
+
+def _scrub_object(obj: Mapping[str, Any], matrix: Mapping[str, str], *, path: str) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for key, value in obj.items():
+        if not isinstance(key, str):
+            raise WorkerEventError(_bound(f"{path} has non-string key"), category="unknown-field")
+        global_class = _GLOBAL_SECRET_KEYS.get(key)
+        classification = global_class or matrix.get(key)
+        if classification is None:
+            raise WorkerEventError(_bound(f"unknown field {path}.{key}"), category="unknown-field")
+        if classification in (FIELD_PRIVATE, FIELD_SECRET, FIELD_PROHIBITED):
+            continue
+        if key == "item":
+            out[key] = _scrub_item(value, path=f"{path}.{key}")
+            continue
+        if key == "turn":
+            out[key] = _scrub_turn(value, path=f"{path}.{key}")
+            continue
+        out[key] = _scrub_scalar_public(f"{path}.{key}", value)
+    return out
+
+
+def scrub_event(raw: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a scrubbed projection of one app-server notification event.
+
+    Raises ``WorkerEventError`` when the event method or any field cannot be
+    classified. Private, secret, and prohibited fields are omitted.
+    """
+    if not isinstance(raw, Mapping):
+        raise WorkerEventError("event must be a JSON object", category="type")
+
+    unknown_envelope = sorted(set(raw.keys()) - set(_ENVELOPE_FIELDS))
+    if unknown_envelope:
+        shown = ", ".join(unknown_envelope[:8])
+        raise WorkerEventError(_bound(f"unknown envelope keys: {shown}"), category="unknown-field")
+
+    method = raw.get("method")
+    if not isinstance(method, str) or not method:
+        raise WorkerEventError("method must be a non-empty string", category="type")
+
+    params = raw.get("params")
+    if params is None:
+        params = {}
+    if not isinstance(params, Mapping):
+        raise WorkerEventError("params must be an object", category="type")
+
+    matrix = _param_matrix_for_method(method)
+    scrubbed_params = _scrub_object(params, matrix, path="params")
+
+    digest = source_digest_for_event(raw)
+    projection: dict[str, Any] = {
+        "schema": SCHEMA,
+        "schema_version": SCHEMA_VERSION,
+        "transport": TRANSPORT,
+        "classification_status": STATUS_SCRUBBED,
+        "method": method,
+        "source_digest": digest,
+        "params": scrubbed_params,
+    }
+    if "jsonrpc" in raw:
+        jsonrpc = raw["jsonrpc"]
+        if jsonrpc != "2.0":
+            raise WorkerEventError(_bound(f"unsupported jsonrpc {jsonrpc!r}"), category="type")
+        projection["jsonrpc"] = jsonrpc
+    return projection
+
+
+def _iter_raw_lines(raw_text: str) -> Iterator[tuple[int, str]]:
+    for index, line in enumerate(raw_text.splitlines(), start=1):
+        if not line.strip():
+            continue
+        yield index, line
+
+
+def scrub_stream_text(raw_text: str) -> dict[str, Any]:
+    """Scrub an entire NDJSON worker stream into a bounded projection document."""
+    raw_bytes = raw_text.encode("utf-8")
+    if len(raw_bytes) > MAX_LINE_BYTES * 4096:
+        raise WorkerEventError("worker event stream exceeds bounded size", category="bound")
+
+    events: list[dict[str, Any]] = []
+    for line_no, line in _iter_raw_lines(raw_text):
+        line_bytes = line.encode("utf-8")
+        if len(line_bytes) > MAX_LINE_BYTES:
+            raise WorkerEventError(_bound(f"line {line_no} exceeds {MAX_LINE_BYTES} bytes"), category="bound")
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise WorkerEventError(_bound(f"line {line_no} is not valid JSON: {exc}"), category="parse") from exc
+        if not isinstance(parsed, Mapping):
+            raise WorkerEventError(_bound(f"line {line_no} must be a JSON object"), category="type")
+        try:
+            events.append(scrub_event(parsed))
+        except WorkerEventError as exc:
+            raise WorkerEventError(
+                _bound(f"line {line_no}: {exc.diagnostic}"),
+                category=exc.category,
+            ) from exc
+
+    return {
+        "schema": STREAM_SCHEMA,
+        "schema_version": STREAM_SCHEMA_VERSION,
+        "transport": TRANSPORT,
+        "classification_status": STATUS_SCRUBBED,
+        "media_type": SCRUBBED_MEDIA_TYPE,
+        "artifact_class": SCRUBBED_ARTIFACT_CLASS,
+        "classification_matrix_version": CLASSIFICATION_MATRIX_VERSION,
+        "source_digest": source_digest_for_stream_bytes(raw_bytes),
+        "event_count": len(events),
+        "events": events,
+    }
+
+
+def scrub_stream_lines(lines: Iterable[str | Mapping[str, Any]]) -> dict[str, Any]:
+    """Scrub an iterable of NDJSON lines or already-parsed event objects."""
+    text_parts: list[str] = []
+    for item in lines:
+        if isinstance(item, Mapping):
+            text_parts.append(json.dumps(item, sort_keys=True, separators=(",", ":")))
+        elif isinstance(item, str):
+            text_parts.append(item.rstrip("\n"))
+        else:
+            raise WorkerEventError(
+                _bound(f"stream line has unsupported type {type(item).__name__}"),
+                category="type",
+            )
+    return scrub_stream_text("\n".join(text_parts) + ("\n" if text_parts else ""))
+
+
+def scrub_stream_file(path: Path) -> dict[str, Any]:
+    """Scrub a worker event JSONL file into a scrubbed projection document."""
+    path = Path(path)
+    try:
+        raw_text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise WorkerEventError(_bound(f"cannot read worker event stream: {exc}"), category="io") from exc
+    except UnicodeDecodeError as exc:
+        raise WorkerEventError("worker event stream is not valid UTF-8", category="parse") from exc
+    return scrub_stream_text(raw_text)
+
+
+def _looks_like_scrubbed_document(payload: Any) -> bool:
+    return (
+        isinstance(payload, Mapping)
+        and payload.get("schema") in {SCHEMA, STREAM_SCHEMA}
+        and payload.get("classification_status") == STATUS_SCRUBBED
+    )
+
+
+def _looks_like_raw_notification(payload: Any) -> bool:
+    return isinstance(payload, Mapping) and isinstance(payload.get("method"), str)
+
+
+def inspect_stream_file(path: Path) -> StreamArtifactInfo:
+    """Classify a worker-event file without requiring a successful scrub.
+
+    Legacy raw streams are marked ``unclassified`` until scrubbing succeeds.
+    Already-scrubbed projection documents are marked ``scrubbed``.
+    """
+    path = Path(path)
+    try:
+        raw_text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return StreamArtifactInfo(
+            path=path,
+            status=STATUS_UNCLASSIFIED,
+            media_type=RAW_MEDIA_TYPE,
+            artifact_class=UNCLASSIFIED_ARTIFACT_CLASS,
+            transport=TRANSPORT,
+            event_count=0,
+            source_digest=None,
+            diagnostic=_bound(f"unreadable worker event stream: {exc}"),
+        )
+    except UnicodeDecodeError:
+        return StreamArtifactInfo(
+            path=path,
+            status=STATUS_UNCLASSIFIED,
+            media_type=RAW_MEDIA_TYPE,
+            artifact_class=UNCLASSIFIED_ARTIFACT_CLASS,
+            transport=TRANSPORT,
+            event_count=0,
+            source_digest=None,
+            diagnostic="worker event stream is not valid UTF-8",
+        )
+
+    raw_bytes = raw_text.encode("utf-8")
+    digest = source_digest_for_stream_bytes(raw_bytes)
+
+    # Whole-file scrubbed projection document (JSON object, not NDJSON).
+    stripped = raw_text.lstrip()
+    if stripped.startswith("{"):
+        try:
+            payload = json.loads(raw_text)
+        except json.JSONDecodeError:
+            payload = None
+        if _looks_like_scrubbed_document(payload):
+            assert isinstance(payload, Mapping)
+            event_count = payload.get("event_count")
+            if not isinstance(event_count, int):
+                events = payload.get("events")
+                event_count = len(events) if isinstance(events, list) else 0
+            return StreamArtifactInfo(
+                path=path,
+                status=STATUS_SCRUBBED,
+                media_type=SCRUBBED_MEDIA_TYPE,
+                artifact_class=SCRUBBED_ARTIFACT_CLASS,
+                transport=str(payload.get("transport") or TRANSPORT),
+                event_count=event_count,
+                source_digest=str(payload.get("source_digest") or digest),
+            )
+
+    lines = [line for _, line in _iter_raw_lines(raw_text)]
+    if not lines:
+        return StreamArtifactInfo(
+            path=path,
+            status=STATUS_UNCLASSIFIED,
+            media_type=RAW_MEDIA_TYPE,
+            artifact_class=UNCLASSIFIED_ARTIFACT_CLASS,
+            transport=TRANSPORT,
+            event_count=0,
+            source_digest=digest,
+            diagnostic="empty worker event stream",
+        )
+
+    # Attempt classification. Success still leaves the on-disk raw NDJSON
+    # unclassified until a distinct scrubbed projection exists; failure keeps
+    # the stream locally inspectable with a bounded diagnostic.
+    try:
+        for line in lines:
+            parsed = json.loads(line)
+            scrub_event(parsed)
+    except (json.JSONDecodeError, WorkerEventError) as exc:
+        detail = exc.diagnostic if isinstance(exc, WorkerEventError) else str(exc)
+        return StreamArtifactInfo(
+            path=path,
+            status=STATUS_UNCLASSIFIED,
+            media_type=RAW_MEDIA_TYPE,
+            artifact_class=UNCLASSIFIED_ARTIFACT_CLASS,
+            transport=TRANSPORT,
+            event_count=len(lines),
+            source_digest=digest,
+            diagnostic=_bound(detail),
+        )
+
+    return StreamArtifactInfo(
+        path=path,
+        status=STATUS_UNCLASSIFIED,
+        media_type=RAW_MEDIA_TYPE,
+        artifact_class=UNCLASSIFIED_ARTIFACT_CLASS,
+        transport=TRANSPORT,
+        event_count=len(lines),
+        source_digest=digest,
+        diagnostic="raw worker stream; unclassified until scrubbed projection exists",
+    )
+
+
+def require_consumer_policy(
+    info: StreamArtifactInfo,
+    *,
+    consumer: str,
+    policy: str = POLICY_SCRUBBED_ONLY,
+) -> None:
+    """Reject raw/unclassified streams as portable evidence unless local-only.
+
+    Replay and audit must pass ``policy=scrubbed-only`` (the default) and only
+    accept already-scrubbed artifacts (or scrub into one before use). Local
+    salvage paths such as resume may pass ``policy=local-only``.
+    """
+    if policy not in CONSUMER_POLICIES:
+        raise WorkerEventPolicyError(_bound(f"unknown consumer policy {policy!r}"))
+    if policy == POLICY_LOCAL_ONLY:
+        return
+    if info.status == STATUS_SCRUBBED and info.artifact_class == SCRUBBED_ARTIFACT_CLASS:
+        return
+    raise WorkerEventPolicyError(
+        _bound(
+            f"{consumer} rejects {info.status} worker event stream "
+            f"({info.artifact_class}); scrub or set policy={POLICY_LOCAL_ONLY}"
+        )
+    )
+
+
+def load_stream_for_consumer(
+    path: Path,
+    *,
+    consumer: str,
+    policy: str = POLICY_SCRUBBED_ONLY,
+) -> dict[str, Any] | list[dict[str, Any]]:
+    """Load a worker stream under a consumer policy.
+
+    ``scrubbed-only`` never returns raw notifications: it loads an existing
+    scrubbed document or fails closed while scrubbing NDJSON into one.
+    ``local-only`` may return the parsed raw notification list for salvage.
+    """
+    path = Path(path)
+    if policy not in CONSUMER_POLICIES:
+        raise WorkerEventPolicyError(_bound(f"unknown consumer policy {policy!r}"))
+
+    info = inspect_stream_file(path)
+
+    if policy == POLICY_LOCAL_ONLY:
+        if info.status == STATUS_SCRUBBED and _file_is_scrubbed_document(path):
+            return dict(json.loads(path.read_text(encoding="utf-8")))
+        try:
+            raw_text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            raise WorkerEventError(_bound(f"cannot read worker event stream: {exc}"), category="io") from exc
+        events: list[dict[str, Any]] = []
+        for line_no, line in _iter_raw_lines(raw_text):
+            try:
+                parsed = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise WorkerEventError(_bound(f"line {line_no} is not valid JSON"), category="parse") from exc
+            if not _looks_like_raw_notification(parsed):
+                raise WorkerEventError(_bound(f"line {line_no} is not a notification"), category="type")
+            events.append(dict(parsed))
+        return events
+
+    # scrubbed-only: portable consumers must not receive raw notifications.
+    if info.status == STATUS_SCRUBBED and _file_is_scrubbed_document(path):
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if not _looks_like_scrubbed_document(payload):
+            raise WorkerEventError("scrubbed document failed validation", category="schema")
+        return dict(payload)
+
+    # Raw NDJSON is not admissible as audit/replay evidence. Scrub into a
+    # distinct scrubbed artifact via scrub_stream_file first, or pass
+    # policy=local-only for local salvage.
+    require_consumer_policy(info, consumer=consumer, policy=policy)
+    raise AssertionError("require_consumer_policy must reject non-scrubbed streams")  # pragma: no cover
+
+
+def _file_is_scrubbed_document(path: Path) -> bool:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return False
+    if not text.lstrip().startswith("{"):
+        return False
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        return False
+    return _looks_like_scrubbed_document(payload)
+
+
+def list_worker_event_streams(events_dir: Path) -> list[Path]:
+    """Return worker event JSONL paths under an events directory (excludes lifecycle)."""
+    events_dir = Path(events_dir)
+    if not events_dir.is_dir():
+        return []
+    out: list[Path] = []
+    for path in sorted(events_dir.glob("*.jsonl")):
+        if path.name == "lifecycle.jsonl":
+            continue
+        out.append(path)
+    return out
+
+
+def assert_audit_rejects_raw_streams(
+    events_dir: Path,
+    *,
+    policy: str = POLICY_SCRUBBED_ONLY,
+    consumer: str = "run_audit",
+) -> list[StreamArtifactInfo]:
+    """Gate used by audit/replay: raw streams are rejected under scrubbed-only.
+
+    Inspects each worker JSONL under ``events_dir``. Under the default policy,
+    any raw or unclassified stream raises ``WorkerEventPolicyError``. Local-only
+    policy allows inspection without treating the bytes as portable evidence.
+    """
+    infos: list[StreamArtifactInfo] = []
+    for path in list_worker_event_streams(events_dir):
+        info = inspect_stream_file(path)
+        infos.append(info)
+        require_consumer_policy(info, consumer=consumer, policy=policy)
+    return infos
+
+
+def validate_scrubbed_event(event: Mapping[str, Any]) -> list[str]:
+    """Return bounded diagnostics for a scrubbed event projection. Empty = valid."""
+    errors: list[str] = []
+    if not isinstance(event, Mapping):
+        return ["scrubbed event must be a JSON object"]
+    if event.get("schema") != SCHEMA:
+        errors.append(_bound(f"schema must be {SCHEMA!r}"))
+    if event.get("schema_version") != SCHEMA_VERSION:
+        errors.append(_bound(f"schema_version must be {SCHEMA_VERSION}"))
+    if event.get("transport") != TRANSPORT:
+        errors.append(_bound(f"transport must be {TRANSPORT!r}"))
+    if event.get("classification_status") != STATUS_SCRUBBED:
+        errors.append("classification_status must be scrubbed")
+    method = event.get("method")
+    if not isinstance(method, str) or not method:
+        errors.append("method must be a non-empty string")
+    digest = event.get("source_digest")
+    if not (isinstance(digest, str) and _HEX64.fullmatch(digest)):
+        errors.append("source_digest must be a 64-char lowercase hex string")
+    params = event.get("params")
+    if not isinstance(params, Mapping):
+        errors.append("params must be an object")
+    errors.extend(scrubbed_projection_omits_sensitive_material(event))
+    return errors
+
+
+def scrubbed_projection_omits_sensitive_material(event: Mapping[str, Any]) -> list[str]:
+    """Return diagnostics if scrubbed projection still contains sensitive material."""
+    errors: list[str] = []
+    blob = json.dumps(event, sort_keys=True, ensure_ascii=False)
+
+    patterns = [
+        (re.compile(r"(?i)authorization\s*[:=]"), "authorization material"),
+        (re.compile(r"(?i)bearer\s+[a-z0-9._\-]+"), "bearer token"),
+        (re.compile(r"(?i)(api[_-]?key|password|secret)\s*[:=]\s*\S+"), "credential material"),
+        (re.compile(r"(?i)set-cookie\s*:"), "cookie material"),
+        (re.compile(r"(?i)cookie\s*[:=]\s*\S+"), "cookie material"),
+        (re.compile(r"/home/[^\s\"']+"), "absolute home path"),
+        (re.compile(r"/Users/[^\s\"']+"), "absolute home path"),
+        (re.compile(r"(?i)sk-[a-z0-9]{8,}"), "provider API key"),
+        (re.compile(r"(?i)\"text\"\s*:\s*\"[^\"]+\""), "private text content"),
+        (re.compile(r"(?i)\"command\"\s*:\s*\"[^\"]+\""), "private command content"),
+        (re.compile(r"(?i)\"prompt\"\s*:\s*\"[^\"]+\""), "raw prompt"),
+        (re.compile(r"(?i)\"message\"\s*:\s*\"[^\"]+\""), "provider error body"),
+        (re.compile(r"(?i)\"aggregatedOutput\"\s*:"), "retrieved private content"),
+        (re.compile(r"(?i)\"env\"\s*:\s*\{"), "environment values"),
+    ]
+    for pattern, label in patterns:
+        if pattern.search(blob):
+            errors.append(_bound(f"scrubbed projection retains {label}"))
+    return errors
+
+
+def media_types() -> dict[str, str]:
+    return {
+        "raw": RAW_MEDIA_TYPE,
+        "scrubbed": SCRUBBED_MEDIA_TYPE,
+    }
+
+
+def artifact_classes() -> dict[str, str]:
+    return {
+        "raw": RAW_ARTIFACT_CLASS,
+        "scrubbed": SCRUBBED_ARTIFACT_CLASS,
+        "unclassified": UNCLASSIFIED_ARTIFACT_CLASS,
+    }
+
+
+__all__ = [
+    "CLASSIFICATION_MATRIX_VERSION",
+    "CONSUMER_POLICIES",
+    "FIELD_CLASSIFICATION_MATRIX",
+    "FIELD_CLASSES",
+    "FIELD_PRIVATE",
+    "FIELD_PROHIBITED",
+    "FIELD_PUBLIC",
+    "FIELD_SECRET",
+    "POLICY_LOCAL_ONLY",
+    "POLICY_SCRUBBED_ONLY",
+    "RAW_ARTIFACT_CLASS",
+    "RAW_MEDIA_TYPE",
+    "SCHEMA",
+    "SCHEMA_VERSION",
+    "SCRUBBED_ARTIFACT_CLASS",
+    "SCRUBBED_MEDIA_TYPE",
+    "STATUS_RAW",
+    "STATUS_SCRUBBED",
+    "STATUS_UNCLASSIFIED",
+    "STREAM_SCHEMA",
+    "STREAM_SCHEMA_VERSION",
+    "TRANSPORT",
+    "UNCLASSIFIED_ARTIFACT_CLASS",
+    "StreamArtifactInfo",
+    "WorkerEventError",
+    "WorkerEventPolicyError",
+    "assert_audit_rejects_raw_streams",
+    "artifact_classes",
+    "canonical_event_bytes",
+    "classification_matrix",
+    "inspect_stream_file",
+    "list_worker_event_streams",
+    "load_stream_for_consumer",
+    "media_types",
+    "require_consumer_policy",
+    "scrub_event",
+    "scrub_stream_file",
+    "scrub_stream_lines",
+    "scrub_stream_text",
+    "scrubbed_projection_omits_sensitive_material",
+    "source_digest_for_event",
+    "source_digest_for_stream_bytes",
+    "validate_scrubbed_event",
+]

--- a/src/brigade/worker_events.py
+++ b/src/brigade/worker_events.py
@@ -1051,7 +1051,7 @@ def validate_scrubbed_event(event: Mapping[str, Any]) -> list[str]:
         errors.append("source_digest must be a 64-char lowercase hex string")
     jsonrpc = event.get("jsonrpc")
     if jsonrpc is not None and jsonrpc != "2.0":
-        errors.append(_bound(f"jsonrpc must be '2.0'"))
+        errors.append(_bound("jsonrpc must be '2.0'"))
     params = event.get("params")
     if not isinstance(params, Mapping):
         errors.append("params must be an object")

--- a/src/brigade/worker_events.py
+++ b/src/brigade/worker_events.py
@@ -61,6 +61,34 @@ _SECRET_LIKE_PUBLIC_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"(?i)authorization\s*[:=]"), "authorization material"),
 )
 _AUTO_DECLINED_SUFFIX = "#auto-declined"
+_AUTO_DECLINED_METHOD_BASES = frozenset({"item/commandExecution/requestApproval"})
+
+_SCRUBBED_EVENT_TOP_LEVEL_KEYS = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "transport",
+        "classification_status",
+        "method",
+        "source_digest",
+        "params",
+        "jsonrpc",
+    }
+)
+_SCRUBBED_STREAM_TOP_LEVEL_KEYS = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "transport",
+        "classification_status",
+        "media_type",
+        "artifact_class",
+        "classification_matrix_version",
+        "source_digest",
+        "event_count",
+        "events",
+    }
+)
 
 # Top-level JSON-RPC notification envelope keys only.
 _ENVELOPE_FIELDS: dict[str, str] = {
@@ -332,7 +360,7 @@ def _validate_public_string(value: str, *, field: str, kind: str = "identifier")
             raise WorkerEventError(_bound(f"{field} retains {label}"), category="secret")
 
 
-def _validate_scrubbed_public_strings(value: Any, *, path: str) -> list[str]:
+def _validate_scrubbed_scalar_public(path: str, value: Any) -> list[str]:
     errors: list[str] = []
     if isinstance(value, str):
         try:
@@ -340,22 +368,101 @@ def _validate_scrubbed_public_strings(value: Any, *, path: str) -> list[str]:
             _validate_public_string(value, field=path, kind=kind)
         except WorkerEventError as exc:
             errors.append(exc.diagnostic)
+    elif value is None or isinstance(value, int) and not isinstance(value, bool):
         return errors
-    if isinstance(value, Mapping):
-        for key, nested in value.items():
-            if not isinstance(key, str):
-                errors.append(_bound(f"{path} has non-string key"))
-                continue
-            errors.extend(_validate_scrubbed_public_strings(nested, path=f"{path}.{key}"))
+    elif isinstance(value, bool):
         return errors
-    if isinstance(value, list):
+    elif isinstance(value, list):
         for index, nested in enumerate(value):
-            errors.extend(_validate_scrubbed_public_strings(nested, path=f"{path}[{index}]"))
+            errors.extend(_validate_scrubbed_scalar_public(f"{path}[{index}]", nested))
+    else:
+        errors.append(_bound(f"{path} has unsupported type {type(value).__name__}"))
     return errors
 
 
-def _scrubbed_document_validation_errors(payload: Mapping[str, Any]) -> list[str]:
+def _validate_scrubbed_object(obj: Mapping[str, Any], matrix: Mapping[str, str], *, path: str) -> list[str]:
     errors: list[str] = []
+    for key, value in obj.items():
+        if not isinstance(key, str):
+            errors.append(_bound(f"{path} has non-string key"))
+            continue
+        global_class = _GLOBAL_SECRET_KEYS.get(key)
+        classification = global_class or matrix.get(key)
+        if classification is None:
+            errors.append(_bound(f"unknown field {path}.{key}"))
+            continue
+        if classification != FIELD_PUBLIC:
+            errors.append(_bound(f"scrubbed projection retains private field {path}.{key}"))
+            continue
+        if key == "item":
+            errors.extend(_validate_scrubbed_item(value, path=f"{path}.{key}"))
+        elif key == "turn":
+            errors.extend(_validate_scrubbed_turn(value, path=f"{path}.{key}"))
+        else:
+            errors.extend(_validate_scrubbed_scalar_public(f"{path}.{key}", value))
+    return errors
+
+
+def _validate_scrubbed_item(item: Any, *, path: str) -> list[str]:
+    if not isinstance(item, Mapping):
+        return [_bound(f"{path} must be an object")]
+    item_type = item.get("type")
+    if not isinstance(item_type, str) or not item_type:
+        return [_bound(f"{path}.type must be a non-empty string")]
+    matrix = _ITEM_TYPE_FIELDS.get(item_type)
+    if matrix is None:
+        return [_bound(f"unknown item type {item_type!r}")]
+    return _validate_scrubbed_object(item, matrix, path=path)
+
+
+def _validate_scrubbed_turn(turn: Any, *, path: str) -> list[str]:
+    if not isinstance(turn, Mapping):
+        return [_bound(f"{path} must be an object")]
+    errors: list[str] = []
+    for key, value in turn.items():
+        if not isinstance(key, str):
+            errors.append(_bound(f"{path} has non-string key"))
+            continue
+        classification = _TURN_FIELDS.get(key)
+        if classification is None:
+            errors.append(_bound(f"unknown field {path}.{key}"))
+            continue
+        if classification != FIELD_PUBLIC:
+            errors.append(_bound(f"scrubbed projection retains private field {path}.{key}"))
+            continue
+        if key == "items":
+            if not isinstance(value, list):
+                errors.append(_bound(f"{path}.items must be an array"))
+                continue
+            for index, entry in enumerate(value):
+                errors.extend(_validate_scrubbed_item(entry, path=f"{path}.items[{index}]"))
+            continue
+        errors.extend(_validate_scrubbed_scalar_public(f"{path}.{key}", value))
+    return errors
+
+
+def _validate_scrubbed_params_structure(method: str, params: Mapping[str, Any], *, path: str) -> list[str]:
+    try:
+        matrix = _param_matrix_for_method(method)
+    except WorkerEventError as exc:
+        return [exc.diagnostic]
+    return _validate_scrubbed_object(params, matrix, path=path)
+
+
+def _scrubbed_single_event_document_validation_errors(payload: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    unknown_keys = sorted(set(payload.keys()) - _SCRUBBED_EVENT_TOP_LEVEL_KEYS)
+    if unknown_keys:
+        errors.append(_bound(f"unknown scrubbed event keys: {', '.join(unknown_keys[:8])}"))
+    errors.extend(validate_scrubbed_event(payload))
+    return errors
+
+
+def _scrubbed_stream_document_validation_errors(payload: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    unknown_keys = sorted(set(payload.keys()) - _SCRUBBED_STREAM_TOP_LEVEL_KEYS)
+    if unknown_keys:
+        errors.append(_bound(f"unknown scrubbed stream keys: {', '.join(unknown_keys[:8])}"))
     if payload.get("schema") != STREAM_SCHEMA:
         errors.append(_bound(f"schema must be {STREAM_SCHEMA!r}"))
     if payload.get("schema_version") != STREAM_SCHEMA_VERSION:
@@ -389,6 +496,15 @@ def _scrubbed_document_validation_errors(payload: Mapping[str, Any]) -> list[str
     return errors
 
 
+def _scrubbed_document_validation_errors(payload: Mapping[str, Any]) -> list[str]:
+    schema = payload.get("schema")
+    if schema == SCHEMA:
+        return _scrubbed_single_event_document_validation_errors(payload)
+    if schema == STREAM_SCHEMA:
+        return _scrubbed_stream_document_validation_errors(payload)
+    return [_bound(f"schema must be {SCHEMA!r} or {STREAM_SCHEMA!r}")]
+
+
 def _sha256_hex(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
@@ -415,7 +531,10 @@ def classification_matrix() -> dict[str, Any]:
 
 
 def _is_auto_declined(method: str) -> bool:
-    return method.endswith(_AUTO_DECLINED_SUFFIX) and len(method) > len(_AUTO_DECLINED_SUFFIX)
+    if not method.endswith(_AUTO_DECLINED_SUFFIX):
+        return False
+    base = method[: -len(_AUTO_DECLINED_SUFFIX)]
+    return base in _AUTO_DECLINED_METHOD_BASES
 
 
 def _param_matrix_for_method(method: str) -> dict[str, str]:
@@ -691,6 +810,16 @@ def inspect_stream_file(path: Path) -> StreamArtifactInfo:
                     source_digest=digest,
                     diagnostic=validation_errors[0],
                 )
+            if payload.get("schema") == SCHEMA:
+                return StreamArtifactInfo(
+                    path=path,
+                    status=STATUS_SCRUBBED,
+                    media_type=SCRUBBED_MEDIA_TYPE,
+                    artifact_class=SCRUBBED_ARTIFACT_CLASS,
+                    transport=str(payload.get("transport") or TRANSPORT),
+                    event_count=1,
+                    source_digest=str(payload.get("source_digest") or digest),
+                )
             event_count = payload.get("event_count")
             if not isinstance(event_count, int):
                 events = payload.get("events")
@@ -887,6 +1016,9 @@ def validate_scrubbed_event(event: Mapping[str, Any]) -> list[str]:
     errors: list[str] = []
     if not isinstance(event, Mapping):
         return ["scrubbed event must be a JSON object"]
+    unknown_keys = sorted(set(event.keys()) - _SCRUBBED_EVENT_TOP_LEVEL_KEYS)
+    if unknown_keys:
+        errors.append(_bound(f"unknown scrubbed event keys: {', '.join(unknown_keys[:8])}"))
     if event.get("schema") != SCHEMA:
         errors.append(_bound(f"schema must be {SCHEMA!r}"))
     if event.get("schema_version") != SCHEMA_VERSION:
@@ -909,8 +1041,8 @@ def validate_scrubbed_event(event: Mapping[str, Any]) -> list[str]:
     params = event.get("params")
     if not isinstance(params, Mapping):
         errors.append("params must be an object")
-    else:
-        errors.extend(_validate_scrubbed_public_strings(params, path="params"))
+    elif isinstance(method, str) and method:
+        errors.extend(_validate_scrubbed_params_structure(method, params, path="params"))
     errors.extend(scrubbed_projection_omits_sensitive_material(event))
     return errors
 

--- a/src/brigade/worker_events.py
+++ b/src/brigade/worker_events.py
@@ -297,13 +297,16 @@ FIELD_CLASSIFICATION_MATRIX: dict[str, Any] = {
     "field_classes": sorted(FIELD_CLASSES),
     "envelope": dict(_ENVELOPE_FIELDS),
     "methods": {name: {"params": dict(fields)} for name, fields in sorted(_METHOD_PARAM_FIELDS.items())},
+    "auto_declined_methods": sorted(_AUTO_DECLINED_METHOD_BASES),
     "auto_declined_params": dict(_AUTO_DECLINED_PARAM_FIELDS),
     "turn_fields": dict(_TURN_FIELDS),
     "item_types": {name: dict(fields) for name, fields in sorted(_ITEM_TYPE_FIELDS.items())},
     "global_secret_keys": dict(_GLOBAL_SECRET_KEYS),
     "notes": (
         "Delta methods are never recorded by Brigade and are intentionally absent. "
-        "Unknown methods or fields fail closed. Absolute home paths travel in cwd/path/"
+        "Unknown methods or fields fail closed. Only "
+        "item/commandExecution/requestApproval#auto-declined is accepted; other "
+        "*#auto-declined bases fail closed. Absolute home paths travel in cwd/path/"
         "grantRoot and are classified private_content. Provider error bodies are prohibited."
     ),
 }

--- a/src/brigade/worker_events.py
+++ b/src/brigade/worker_events.py
@@ -50,7 +50,16 @@ CONSUMER_POLICIES = frozenset({POLICY_SCRUBBED_ONLY, POLICY_LOCAL_ONLY})
 
 MAX_DIAGNOSTIC_LEN = 240
 MAX_LINE_BYTES = 1_048_576
+MAX_PUBLIC_STRING_LEN = 256
 _HEX64 = re.compile(r"^[0-9a-f]{64}$")
+_PUBLIC_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+_PUBLIC_METHOD_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/:#-]*$")
+_SECRET_LIKE_PUBLIC_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"(?i)sk-[a-z0-9][a-z0-9._-]{7,}"), "provider API key"),
+    (re.compile(r"(?i)bearer\s+[a-z0-9._\-]+"), "bearer token"),
+    (re.compile(r"(?i)(api[_-]?key|password|secret)\s*[:=]"), "credential material"),
+    (re.compile(r"(?i)authorization\s*[:=]"), "authorization material"),
+)
 _AUTO_DECLINED_SUFFIX = "#auto-declined"
 
 # Top-level JSON-RPC notification envelope keys only.
@@ -308,6 +317,78 @@ def _bound(msg: str) -> str:
     return msg[: MAX_DIAGNOSTIC_LEN - 1] + "\u2026"
 
 
+def _validate_public_string(value: str, *, field: str, kind: str = "identifier") -> None:
+    if not isinstance(value, str) or not value:
+        raise WorkerEventError(_bound(f"{field} must be a non-empty string"), category="type")
+    if len(value) > MAX_PUBLIC_STRING_LEN:
+        raise WorkerEventError(_bound(f"{field} exceeds {MAX_PUBLIC_STRING_LEN} characters"), category="bound")
+    if any(ch in value for ch in ("\n", "\r", "\0")):
+        raise WorkerEventError(_bound(f"{field} contains invalid control characters"), category="type")
+    pattern = _PUBLIC_METHOD_RE if kind == "method" else _PUBLIC_IDENTIFIER_RE
+    if not pattern.fullmatch(value):
+        raise WorkerEventError(_bound(f"{field} has invalid public format"), category="type")
+    for secret_pattern, label in _SECRET_LIKE_PUBLIC_PATTERNS:
+        if secret_pattern.search(value):
+            raise WorkerEventError(_bound(f"{field} retains {label}"), category="secret")
+
+
+def _validate_scrubbed_public_strings(value: Any, *, path: str) -> list[str]:
+    errors: list[str] = []
+    if isinstance(value, str):
+        try:
+            kind = "method" if path.endswith(".method") or path == "method" else "identifier"
+            _validate_public_string(value, field=path, kind=kind)
+        except WorkerEventError as exc:
+            errors.append(exc.diagnostic)
+        return errors
+    if isinstance(value, Mapping):
+        for key, nested in value.items():
+            if not isinstance(key, str):
+                errors.append(_bound(f"{path} has non-string key"))
+                continue
+            errors.extend(_validate_scrubbed_public_strings(nested, path=f"{path}.{key}"))
+        return errors
+    if isinstance(value, list):
+        for index, nested in enumerate(value):
+            errors.extend(_validate_scrubbed_public_strings(nested, path=f"{path}[{index}]"))
+    return errors
+
+
+def _scrubbed_document_validation_errors(payload: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if payload.get("schema") != STREAM_SCHEMA:
+        errors.append(_bound(f"schema must be {STREAM_SCHEMA!r}"))
+    if payload.get("schema_version") != STREAM_SCHEMA_VERSION:
+        errors.append(_bound(f"schema_version must be {STREAM_SCHEMA_VERSION}"))
+    if payload.get("transport") != TRANSPORT:
+        errors.append(_bound(f"transport must be {TRANSPORT!r}"))
+    if payload.get("classification_status") != STATUS_SCRUBBED:
+        errors.append("classification_status must be scrubbed")
+    if payload.get("media_type") != SCRUBBED_MEDIA_TYPE:
+        errors.append(_bound(f"media_type must be {SCRUBBED_MEDIA_TYPE!r}"))
+    if payload.get("artifact_class") != SCRUBBED_ARTIFACT_CLASS:
+        errors.append(_bound(f"artifact_class must be {SCRUBBED_ARTIFACT_CLASS!r}"))
+    digest = payload.get("source_digest")
+    if not (isinstance(digest, str) and _HEX64.fullmatch(digest)):
+        errors.append("source_digest must be a 64-char lowercase hex string")
+    events = payload.get("events")
+    if not isinstance(events, list):
+        errors.append("events must be an array")
+        return errors
+    event_count = payload.get("event_count")
+    if not isinstance(event_count, int):
+        errors.append("event_count must be an integer")
+    elif event_count != len(events):
+        errors.append("event_count must match events length")
+    for index, event in enumerate(events):
+        if not isinstance(event, Mapping):
+            errors.append(_bound(f"events[{index}] must be an object"))
+            continue
+        for diagnostic in validate_scrubbed_event(event):
+            errors.append(_bound(f"events[{index}]: {diagnostic}"))
+    return errors
+
+
 def _sha256_hex(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
@@ -346,7 +427,10 @@ def _param_matrix_for_method(method: str) -> dict[str, str]:
 
 
 def _scrub_scalar_public(key: str, value: Any) -> Any:
-    if value is None or isinstance(value, (str, int)) and not isinstance(value, bool):
+    if isinstance(value, str):
+        _validate_public_string(value, field=key)
+        return value
+    if value is None or isinstance(value, int) and not isinstance(value, bool):
         return value
     if isinstance(value, float):
         # Duration-like numbers occasionally appear as floats; refuse rather than coerce.
@@ -433,6 +517,7 @@ def scrub_event(raw: Mapping[str, Any]) -> dict[str, Any]:
     method = raw.get("method")
     if not isinstance(method, str) or not method:
         raise WorkerEventError("method must be a non-empty string", category="type")
+    _validate_public_string(method, field="method", kind="method")
 
     params = raw.get("params")
     if params is None:
@@ -458,6 +543,9 @@ def scrub_event(raw: Mapping[str, Any]) -> dict[str, Any]:
         if jsonrpc != "2.0":
             raise WorkerEventError(_bound(f"unsupported jsonrpc {jsonrpc!r}"), category="type")
         projection["jsonrpc"] = jsonrpc
+    validation_errors = validate_scrubbed_event(projection)
+    if validation_errors:
+        raise WorkerEventError(validation_errors[0], category="schema")
     return projection
 
 
@@ -591,6 +679,18 @@ def inspect_stream_file(path: Path) -> StreamArtifactInfo:
             payload = None
         if _looks_like_scrubbed_document(payload):
             assert isinstance(payload, Mapping)
+            validation_errors = _scrubbed_document_validation_errors(payload)
+            if validation_errors:
+                return StreamArtifactInfo(
+                    path=path,
+                    status=STATUS_UNCLASSIFIED,
+                    media_type=RAW_MEDIA_TYPE,
+                    artifact_class=UNCLASSIFIED_ARTIFACT_CLASS,
+                    transport=TRANSPORT,
+                    event_count=0,
+                    source_digest=digest,
+                    diagnostic=validation_errors[0],
+                )
             event_count = payload.get("event_count")
             if not isinstance(event_count, int):
                 events = payload.get("events")
@@ -696,7 +796,13 @@ def load_stream_for_consumer(
 
     if policy == POLICY_LOCAL_ONLY:
         if info.status == STATUS_SCRUBBED and _file_is_scrubbed_document(path):
-            return dict(json.loads(path.read_text(encoding="utf-8")))
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            if not isinstance(payload, Mapping):
+                raise WorkerEventError("scrubbed document must be a JSON object", category="schema")
+            validation_errors = _scrubbed_document_validation_errors(payload)
+            if validation_errors:
+                raise WorkerEventError(validation_errors[0], category="schema")
+            return dict(payload)
         try:
             raw_text = path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError) as exc:
@@ -715,8 +821,11 @@ def load_stream_for_consumer(
     # scrubbed-only: portable consumers must not receive raw notifications.
     if info.status == STATUS_SCRUBBED and _file_is_scrubbed_document(path):
         payload = json.loads(path.read_text(encoding="utf-8"))
-        if not _looks_like_scrubbed_document(payload):
-            raise WorkerEventError("scrubbed document failed validation", category="schema")
+        if not isinstance(payload, Mapping):
+            raise WorkerEventError("scrubbed document must be a JSON object", category="schema")
+        validation_errors = _scrubbed_document_validation_errors(payload)
+        if validation_errors:
+            raise WorkerEventError(validation_errors[0], category="schema")
         return dict(payload)
 
     # Raw NDJSON is not admissible as audit/replay evidence. Scrub into a
@@ -789,12 +898,19 @@ def validate_scrubbed_event(event: Mapping[str, Any]) -> list[str]:
     method = event.get("method")
     if not isinstance(method, str) or not method:
         errors.append("method must be a non-empty string")
+    else:
+        try:
+            _validate_public_string(method, field="method", kind="method")
+        except WorkerEventError as exc:
+            errors.append(exc.diagnostic)
     digest = event.get("source_digest")
     if not (isinstance(digest, str) and _HEX64.fullmatch(digest)):
         errors.append("source_digest must be a 64-char lowercase hex string")
     params = event.get("params")
     if not isinstance(params, Mapping):
         errors.append("params must be an object")
+    else:
+        errors.extend(_validate_scrubbed_public_strings(params, path="params"))
     errors.extend(scrubbed_projection_omits_sensitive_material(event))
     return errors
 
@@ -812,7 +928,7 @@ def scrubbed_projection_omits_sensitive_material(event: Mapping[str, Any]) -> li
         (re.compile(r"(?i)cookie\s*[:=]\s*\S+"), "cookie material"),
         (re.compile(r"/home/[^\s\"']+"), "absolute home path"),
         (re.compile(r"/Users/[^\s\"']+"), "absolute home path"),
-        (re.compile(r"(?i)sk-[a-z0-9]{8,}"), "provider API key"),
+        (re.compile(r"(?i)sk-[a-z0-9][a-z0-9._-]{7,}"), "provider API key"),
         (re.compile(r"(?i)\"text\"\s*:\s*\"[^\"]+\""), "private text content"),
         (re.compile(r"(?i)\"command\"\s*:\s*\"[^\"]+\""), "private command content"),
         (re.compile(r"(?i)\"prompt\"\s*:\s*\"[^\"]+\""), "raw prompt"),

--- a/src/brigade/worker_events.py
+++ b/src/brigade/worker_events.py
@@ -51,6 +51,7 @@ CONSUMER_POLICIES = frozenset({POLICY_SCRUBBED_ONLY, POLICY_LOCAL_ONLY})
 MAX_DIAGNOSTIC_LEN = 240
 MAX_LINE_BYTES = 1_048_576
 MAX_PUBLIC_STRING_LEN = 256
+MAX_PUBLIC_LIST_DEPTH = 64
 _HEX64 = re.compile(r"^[0-9a-f]{64}$")
 _PUBLIC_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 _PUBLIC_METHOD_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/:#-]*$")
@@ -363,8 +364,10 @@ def _validate_public_string(value: str, *, field: str, kind: str = "identifier")
             raise WorkerEventError(_bound(f"{field} retains {label}"), category="secret")
 
 
-def _validate_scrubbed_scalar_public(path: str, value: Any) -> list[str]:
+def _validate_scrubbed_scalar_public(path: str, value: Any, *, depth: int = 0) -> list[str]:
     errors: list[str] = []
+    if depth > MAX_PUBLIC_LIST_DEPTH:
+        return [_bound(f"{path} public list nesting exceeds {MAX_PUBLIC_LIST_DEPTH}")]
     if isinstance(value, str):
         try:
             kind = "method" if path.endswith(".method") or path == "method" else "identifier"
@@ -377,7 +380,7 @@ def _validate_scrubbed_scalar_public(path: str, value: Any) -> list[str]:
         return errors
     elif isinstance(value, list):
         for index, nested in enumerate(value):
-            errors.extend(_validate_scrubbed_scalar_public(f"{path}[{index}]", nested))
+            errors.extend(_validate_scrubbed_scalar_public(f"{path}[{index}]", nested, depth=depth + 1))
     else:
         errors.append(_bound(f"{path} has unsupported type {type(value).__name__}"))
     return errors
@@ -548,7 +551,12 @@ def _param_matrix_for_method(method: str) -> dict[str, str]:
     raise WorkerEventError(_bound(f"unknown event method {method!r}"), category="unknown-method")
 
 
-def _scrub_scalar_public(key: str, value: Any) -> Any:
+def _scrub_scalar_public(key: str, value: Any, *, depth: int = 0) -> Any:
+    if depth > MAX_PUBLIC_LIST_DEPTH:
+        raise WorkerEventError(
+            _bound(f"public field {key!r} list nesting exceeds {MAX_PUBLIC_LIST_DEPTH}"),
+            category="bound",
+        )
     if isinstance(value, str):
         _validate_public_string(value, field=key)
         return value
@@ -561,7 +569,7 @@ def _scrub_scalar_public(key: str, value: Any) -> Any:
         # JSON-RPC sometimes carries booleans (e.g. success). Allow only for known public bools.
         return value
     if isinstance(value, list):
-        return [_scrub_scalar_public(f"{key}[]", item) for item in value]
+        return [_scrub_scalar_public(f"{key}[]", item, depth=depth + 1) for item in value]
     raise WorkerEventError(
         _bound(f"public field {key!r} has unsupported type {type(value).__name__}"),
         category="type",
@@ -1041,6 +1049,9 @@ def validate_scrubbed_event(event: Mapping[str, Any]) -> list[str]:
     digest = event.get("source_digest")
     if not (isinstance(digest, str) and _HEX64.fullmatch(digest)):
         errors.append("source_digest must be a 64-char lowercase hex string")
+    jsonrpc = event.get("jsonrpc")
+    if jsonrpc is not None and jsonrpc != "2.0":
+        errors.append(_bound(f"jsonrpc must be '2.0'"))
     params = event.get("params")
     if not isinstance(params, Mapping):
         errors.append("params must be an object")

--- a/tests/test_worker_events.py
+++ b/tests/test_worker_events.py
@@ -1,0 +1,190 @@
+"""Tests for worker event field classification and fail-closed scrubbing (#592)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from brigade import run_audit, worker_events
+
+FIXTURES = Path(__file__).resolve().parents[1] / "src" / "brigade" / "fixtures"
+GOLDEN_PATH = FIXTURES / "worker-events-appserver.v1.golden.json"
+
+
+def _golden():
+    return json.loads(GOLDEN_PATH.read_text(encoding="utf-8"))
+
+
+def _case(name: str) -> dict:
+    return next(c for c in _golden()["cases"] if c["name"] == name)
+
+
+def test_media_types_and_artifact_classes_are_distinct():
+    media = worker_events.media_types()
+    classes = worker_events.artifact_classes()
+    assert media["raw"] != media["scrubbed"]
+    assert classes["raw"] != classes["scrubbed"]
+    assert classes["unclassified"] != classes["scrubbed"]
+    assert media["raw"].startswith("application/vnd.brigade.")
+    assert media["scrubbed"].startswith("application/vnd.brigade.")
+
+
+def test_classification_matrix_covers_recorded_app_server_methods():
+    matrix = worker_events.classification_matrix()
+    assert matrix["transport"] == "codex-app-server"
+    assert matrix["version"] == worker_events.CLASSIFICATION_MATRIX_VERSION
+    methods = set(matrix["methods"])
+    assert methods == {"turn/started", "turn/completed", "item/started", "item/completed"}
+    assert "auto_declined_params" in matrix
+    for item_type, fields in matrix["item_types"].items():
+        assert "id" in fields and fields["id"] == worker_events.FIELD_PUBLIC
+        assert "type" in fields and fields["type"] == worker_events.FIELD_PUBLIC
+        for classification in fields.values():
+            assert classification in worker_events.FIELD_CLASSES
+        assert item_type  # non-empty
+
+
+def test_golden_scrubbed_projections_match_and_omit_sensitive_material():
+    for case in _golden()["cases"]:
+        if "expect_error_category" in case:
+            with pytest.raises(worker_events.WorkerEventError) as excinfo:
+                worker_events.scrub_event(case["raw"])
+            assert excinfo.value.category == case["expect_error_category"]
+            assert len(excinfo.value.diagnostic) <= worker_events.MAX_DIAGNOSTIC_LEN
+            continue
+        scrubbed = worker_events.scrub_event(case["raw"])
+        assert scrubbed == case["scrubbed"]
+        assert scrubbed["source_digest"] == case["source_digest"]
+        assert scrubbed["schema"] == worker_events.SCHEMA
+        assert scrubbed["schema_version"] == worker_events.SCHEMA_VERSION
+        assert scrubbed["classification_status"] == worker_events.STATUS_SCRUBBED
+        assert not worker_events.scrubbed_projection_omits_sensitive_material(scrubbed)
+        assert not worker_events.validate_scrubbed_event(scrubbed)
+
+
+def test_scrubbed_stream_preserves_order_ids_methods_and_source_digest():
+    stream = _golden()["stream"]
+    projection = worker_events.scrub_stream_lines(stream["raw_events"])
+    assert projection == stream["scrubbed"]
+    assert projection["event_count"] == len(stream["raw_events"])
+    assert [event["method"] for event in projection["events"]] == [raw["method"] for raw in stream["raw_events"]]
+    for raw, scrubbed in zip(stream["raw_events"], projection["events"], strict=True):
+        assert scrubbed["source_digest"] == worker_events.source_digest_for_event(raw)
+        params = scrubbed["params"]
+        raw_params = raw["params"]
+        if "threadId" in raw_params:
+            assert params["threadId"] == raw_params["threadId"]
+        if "turnId" in raw_params:
+            assert params["turnId"] == raw_params["turnId"]
+        if "item" in raw_params:
+            assert params["item"]["id"] == raw_params["item"]["id"]
+            assert params["item"]["type"] == raw_params["item"]["type"]
+        if "turn" in raw_params:
+            assert params["turn"]["id"] == raw_params["turn"]["id"]
+            assert params["turn"]["status"] == raw_params["turn"]["status"]
+
+
+def test_adversarial_secrets_absent_from_scrubbed_auto_declined_case():
+    case = _case("auto_declined_with_secrets")
+    scrubbed = worker_events.scrub_event(case["raw"])
+    blob = json.dumps(scrubbed)
+    for needle in (
+        "sk-live-EXAMPLESECRETVALUE99",
+        "Authorization",
+        "Bearer",
+        "/home/example-user",
+        "OPENAI_API_KEY",
+        "raw user prompt",
+        "session=abc",
+        "cat /home",
+    ):
+        assert needle not in blob
+    assert scrubbed["params"]["threadId"] == "thread-demo-1"
+    assert scrubbed["params"]["itemId"] == "cmd-1"
+    assert scrubbed["params"]["availableDecisions"] == ["accept", "decline"]
+    assert scrubbed["method"].endswith("#auto-declined")
+
+
+def test_provider_error_bodies_and_agent_text_absent():
+    case = _case("turn_completed_with_provider_error")
+    scrubbed = worker_events.scrub_event(case["raw"])
+    blob = json.dumps(scrubbed)
+    assert "upstream 401" not in blob
+    assert "Bearer" not in blob
+    assert "internal provider dump" not in blob
+    assert "error" not in scrubbed["params"]["turn"]
+    assert scrubbed["params"]["turn"]["items"][0] == {"id": "msg-1", "type": "agentMessage"}
+
+
+def test_unknown_method_and_field_diagnostics_are_bounded():
+    for name in ("unknown_method_fails_closed", "unknown_field_fails_closed", "unknown_item_type_fails_closed"):
+        case = _case(name)
+        with pytest.raises(worker_events.WorkerEventError) as excinfo:
+            worker_events.scrub_event(case["raw"])
+        assert len(str(excinfo.value)) <= worker_events.MAX_DIAGNOSTIC_LEN
+        assert case["expect_error_category"] == excinfo.value.category
+
+
+def test_legacy_raw_stream_is_unclassified_until_scrubbed(tmp_path: Path):
+    path = tmp_path / "coder.jsonl"
+    path.write_text(json.dumps(_case("turn_started_public")["raw"]) + "\n", encoding="utf-8")
+    info = worker_events.inspect_stream_file(path)
+    assert info.status == worker_events.STATUS_UNCLASSIFIED
+    assert info.artifact_class == worker_events.UNCLASSIFIED_ARTIFACT_CLASS
+    assert info.media_type == worker_events.RAW_MEDIA_TYPE
+    assert info.diagnostic is not None
+
+    scrubbed_path = tmp_path / "coder.scrubbed.json"
+    scrubbed_path.write_text(json.dumps(worker_events.scrub_stream_file(path)), encoding="utf-8")
+    scrubbed_info = worker_events.inspect_stream_file(scrubbed_path)
+    assert scrubbed_info.status == worker_events.STATUS_SCRUBBED
+    assert scrubbed_info.artifact_class == worker_events.SCRUBBED_ARTIFACT_CLASS
+    assert scrubbed_info.media_type == worker_events.SCRUBBED_MEDIA_TYPE
+
+
+def test_audit_and_replay_consumers_reject_raw_unless_local_only(tmp_path: Path):
+    events_dir = tmp_path / "events"
+    events_dir.mkdir()
+    raw_path = events_dir / "coder.jsonl"
+    raw_path.write_text(json.dumps(_case("item_started_command")["raw"]) + "\n", encoding="utf-8")
+
+    with pytest.raises(worker_events.WorkerEventPolicyError):
+        worker_events.load_stream_for_consumer(raw_path, consumer="run_audit")
+    with pytest.raises(worker_events.WorkerEventPolicyError):
+        worker_events.assert_audit_rejects_raw_streams(events_dir)
+    with pytest.raises(worker_events.WorkerEventPolicyError):
+        run_audit.reject_raw_worker_stream_evidence(tmp_path)
+
+    local = worker_events.load_stream_for_consumer(
+        raw_path,
+        consumer="run_resume",
+        policy=worker_events.POLICY_LOCAL_ONLY,
+    )
+    assert isinstance(local, list)
+    assert local[0]["params"]["threadId"] == "thread-demo-1"
+
+    infos = run_audit.reject_raw_worker_stream_evidence(
+        tmp_path,
+        policy=worker_events.POLICY_LOCAL_ONLY,
+    )
+    assert len(infos) == 1
+    assert infos[0].status == worker_events.STATUS_UNCLASSIFIED
+
+
+def test_scrubbed_document_is_admissible_for_audit_consumer(tmp_path: Path):
+    raw_path = tmp_path / "coder.jsonl"
+    raw_path.write_text(json.dumps(_case("turn_started_public")["raw"]) + "\n", encoding="utf-8")
+    doc = worker_events.scrub_stream_file(raw_path)
+    scrubbed_path = tmp_path / "coder.scrubbed.json"
+    scrubbed_path.write_text(json.dumps(doc), encoding="utf-8")
+    loaded = worker_events.load_stream_for_consumer(scrubbed_path, consumer="run_audit")
+    assert loaded["schema"] == worker_events.STREAM_SCHEMA
+    assert loaded["media_type"] == worker_events.SCRUBBED_MEDIA_TYPE
+    assert loaded["artifact_class"] == worker_events.SCRUBBED_ARTIFACT_CLASS
+
+
+def test_reject_raw_worker_stream_evidence_unknown_policy(tmp_path: Path):
+    with pytest.raises(run_audit.AuditError):
+        run_audit.reject_raw_worker_stream_evidence(tmp_path, policy="export-everything")

--- a/tests/test_worker_events.py
+++ b/tests/test_worker_events.py
@@ -288,7 +288,9 @@ def test_deeply_nested_public_list_in_scrubbed_stream_is_bounded(tmp_path: Path)
     raw_path = tmp_path / "coder.jsonl"
     raw_path.write_text(json.dumps(_case("auto_declined_with_secrets")["raw"]) + "\n", encoding="utf-8")
     doc = worker_events.scrub_stream_file(raw_path)
-    doc["events"][0]["params"]["availableDecisions"] = _nested_public_list(5000)
+    doc["events"][0]["params"]["availableDecisions"] = _nested_public_list(
+        worker_events.MAX_PUBLIC_LIST_DEPTH + 1
+    )
     path = tmp_path / "coder.scrubbed.json"
     path.write_text(json.dumps(doc), encoding="utf-8")
 

--- a/tests/test_worker_events.py
+++ b/tests/test_worker_events.py
@@ -288,9 +288,7 @@ def test_deeply_nested_public_list_in_scrubbed_stream_is_bounded(tmp_path: Path)
     raw_path = tmp_path / "coder.jsonl"
     raw_path.write_text(json.dumps(_case("auto_declined_with_secrets")["raw"]) + "\n", encoding="utf-8")
     doc = worker_events.scrub_stream_file(raw_path)
-    doc["events"][0]["params"]["availableDecisions"] = _nested_public_list(
-        worker_events.MAX_PUBLIC_LIST_DEPTH + 1
-    )
+    doc["events"][0]["params"]["availableDecisions"] = _nested_public_list(worker_events.MAX_PUBLIC_LIST_DEPTH + 1)
     path = tmp_path / "coder.scrubbed.json"
     path.write_text(json.dumps(doc), encoding="utf-8")
 

--- a/tests/test_worker_events.py
+++ b/tests/test_worker_events.py
@@ -191,6 +191,13 @@ def test_reject_raw_worker_stream_evidence_unknown_policy(tmp_path: Path):
         run_audit.reject_raw_worker_stream_evidence(tmp_path, policy="export-everything")
 
 
+def _nested_public_list(depth: int) -> object:
+    value: object = "accept"
+    for _ in range(depth):
+        value = [value]
+    return value
+
+
 def _write_fake_scrubbed_document(tmp_path: Path, *, mutate) -> Path:
     raw_path = tmp_path / "coder.jsonl"
     raw_path.write_text(json.dumps(_case("turn_started_public")["raw"]) + "\n", encoding="utf-8")
@@ -275,6 +282,44 @@ def test_arbitrary_auto_declined_method_prefix_fails_closed():
     valid = worker_events.scrub_event(case["raw"])
     assert valid["method"] == "item/commandExecution/requestApproval#auto-declined"
     assert not worker_events.validate_scrubbed_event(valid)
+
+
+def test_deeply_nested_public_list_in_scrubbed_stream_is_bounded(tmp_path: Path):
+    raw_path = tmp_path / "coder.jsonl"
+    raw_path.write_text(json.dumps(_case("auto_declined_with_secrets")["raw"]) + "\n", encoding="utf-8")
+    doc = worker_events.scrub_stream_file(raw_path)
+    doc["events"][0]["params"]["availableDecisions"] = _nested_public_list(5000)
+    path = tmp_path / "coder.scrubbed.json"
+    path.write_text(json.dumps(doc), encoding="utf-8")
+
+    info = worker_events.inspect_stream_file(path)
+    assert info.status == worker_events.STATUS_UNCLASSIFIED
+    assert info.artifact_class == worker_events.UNCLASSIFIED_ARTIFACT_CLASS
+    assert info.diagnostic is not None
+    assert len(info.diagnostic) <= worker_events.MAX_DIAGNOSTIC_LEN
+
+    with pytest.raises(worker_events.WorkerEventError) as excinfo:
+        worker_events.load_stream_for_consumer(path, consumer="run_audit")
+    assert len(str(excinfo.value)) <= worker_events.MAX_DIAGNOSTIC_LEN
+
+
+def test_scrubbed_event_with_invalid_jsonrpc_is_not_admissible(tmp_path: Path):
+    scrubbed = json.loads(json.dumps(_case("turn_started_public")["scrubbed"]))
+    scrubbed["jsonrpc"] = "1.0"
+
+    errors = worker_events.validate_scrubbed_event(scrubbed)
+    assert errors
+    assert "jsonrpc" in errors[0].lower()
+    assert len(errors[0]) <= worker_events.MAX_DIAGNOSTIC_LEN
+
+    path = tmp_path / "bad-jsonrpc.scrubbed.json"
+    path.write_text(json.dumps(scrubbed), encoding="utf-8")
+    info = worker_events.inspect_stream_file(path)
+    assert info.status == worker_events.STATUS_UNCLASSIFIED
+    assert info.diagnostic is not None
+
+    with pytest.raises(worker_events.WorkerEventError):
+        worker_events.load_stream_for_consumer(path, consumer="run_audit")
 
 
 def test_forged_scrubbed_event_unknown_params_field_is_rejected(tmp_path: Path):

--- a/tests/test_worker_events.py
+++ b/tests/test_worker_events.py
@@ -38,6 +38,7 @@ def test_classification_matrix_covers_recorded_app_server_methods():
     methods = set(matrix["methods"])
     assert methods == {"turn/started", "turn/completed", "item/started", "item/completed"}
     assert "auto_declined_params" in matrix
+    assert matrix["auto_declined_methods"] == ["item/commandExecution/requestApproval"]
     for item_type, fields in matrix["item_types"].items():
         assert "id" in fields and fields["id"] == worker_events.FIELD_PUBLIC
         assert "type" in fields and fields["type"] == worker_events.FIELD_PUBLIC

--- a/tests/test_worker_events.py
+++ b/tests/test_worker_events.py
@@ -242,3 +242,53 @@ def test_auto_declined_method_shape_still_scrubs_after_public_string_validation(
     scrubbed = worker_events.scrub_event(case["raw"])
     assert scrubbed["method"].endswith("#auto-declined")
     assert not worker_events.validate_scrubbed_event(scrubbed)
+
+
+def test_single_scrubbed_event_document_is_supported(tmp_path: Path):
+    scrubbed = _case("turn_started_public")["scrubbed"]
+    path = tmp_path / "turn.scrubbed.json"
+    path.write_text(json.dumps(scrubbed), encoding="utf-8")
+
+    info = worker_events.inspect_stream_file(path)
+    assert info.status == worker_events.STATUS_SCRUBBED
+    assert info.artifact_class == worker_events.SCRUBBED_ARTIFACT_CLASS
+    assert info.media_type == worker_events.SCRUBBED_MEDIA_TYPE
+    assert info.event_count == 1
+    assert info.diagnostic is None
+
+    loaded = worker_events.load_stream_for_consumer(path, consumer="run_audit")
+    assert loaded == scrubbed
+    assert loaded["schema"] == worker_events.SCHEMA
+    assert not worker_events.validate_scrubbed_event(loaded)
+
+
+def test_arbitrary_auto_declined_method_prefix_fails_closed():
+    case = _case("auto_declined_with_secrets")
+    raw = json.loads(json.dumps(case["raw"]))
+    raw["method"] = "unknown/request#auto-declined"
+    with pytest.raises(worker_events.WorkerEventError) as excinfo:
+        worker_events.scrub_event(raw)
+    assert excinfo.value.category == "unknown-method"
+    assert len(str(excinfo.value)) <= worker_events.MAX_DIAGNOSTIC_LEN
+
+    valid = worker_events.scrub_event(case["raw"])
+    assert valid["method"] == "item/commandExecution/requestApproval#auto-declined"
+    assert not worker_events.validate_scrubbed_event(valid)
+
+
+def test_forged_scrubbed_event_unknown_params_field_is_rejected(tmp_path: Path):
+    scrubbed = json.loads(json.dumps(_case("turn_started_public")["scrubbed"]))
+    scrubbed["params"]["harmlessExtra"] = "looks-fine"
+
+    errors = worker_events.validate_scrubbed_event(scrubbed)
+    assert errors
+    assert len(errors[0]) <= worker_events.MAX_DIAGNOSTIC_LEN
+
+    path = tmp_path / "forged.scrubbed.json"
+    path.write_text(json.dumps(scrubbed), encoding="utf-8")
+    info = worker_events.inspect_stream_file(path)
+    assert info.status == worker_events.STATUS_UNCLASSIFIED
+    assert info.diagnostic is not None
+
+    with pytest.raises(worker_events.WorkerEventError):
+        worker_events.load_stream_for_consumer(path, consumer="run_audit")

--- a/tests/test_worker_events.py
+++ b/tests/test_worker_events.py
@@ -188,3 +188,57 @@ def test_scrubbed_document_is_admissible_for_audit_consumer(tmp_path: Path):
 def test_reject_raw_worker_stream_evidence_unknown_policy(tmp_path: Path):
     with pytest.raises(run_audit.AuditError):
         run_audit.reject_raw_worker_stream_evidence(tmp_path, policy="export-everything")
+
+
+def _write_fake_scrubbed_document(tmp_path: Path, *, mutate) -> Path:
+    raw_path = tmp_path / "coder.jsonl"
+    raw_path.write_text(json.dumps(_case("turn_started_public")["raw"]) + "\n", encoding="utf-8")
+    doc = worker_events.scrub_stream_file(raw_path)
+    mutate(doc)
+    scrubbed_path = tmp_path / "coder.scrubbed.json"
+    scrubbed_path.write_text(json.dumps(doc), encoding="utf-8")
+    return scrubbed_path
+
+
+def test_self_declared_scrubbed_document_with_embedded_secrets_is_not_admissible(tmp_path: Path):
+    def inject_private_prompt(document: dict) -> None:
+        event = document["events"][0]
+        event["params"]["prompt"] = "leaked private prompt with sk-live-EXAMPLESECRETVALUE99"
+
+    path = _write_fake_scrubbed_document(tmp_path, mutate=inject_private_prompt)
+
+    info = worker_events.inspect_stream_file(path)
+    assert info.status == worker_events.STATUS_UNCLASSIFIED
+    assert info.artifact_class == worker_events.UNCLASSIFIED_ARTIFACT_CLASS
+    assert info.diagnostic is not None
+
+    with pytest.raises(worker_events.WorkerEventError):
+        worker_events.load_stream_for_consumer(path, consumer="run_audit")
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("threadId", "sk-live-EXAMPLESECRETVALUE99"),
+        ("threadId", "thread\ninject"),
+        ("threadId", "t" * 300),
+        ("method", "turn/started\n"),
+        ("method", "Bearer sk-live-EXAMPLESECRETVALUE99"),
+    ],
+)
+def test_public_identifier_and_method_strings_fail_closed_during_projection(field: str, value: str):
+    raw = json.loads(json.dumps(_case("turn_started_public")["raw"]))
+    if field == "method":
+        raw["method"] = value
+    else:
+        raw["params"][field] = value
+    with pytest.raises(worker_events.WorkerEventError) as excinfo:
+        worker_events.scrub_event(raw)
+    assert len(str(excinfo.value)) <= worker_events.MAX_DIAGNOSTIC_LEN
+
+
+def test_auto_declined_method_shape_still_scrubs_after_public_string_validation():
+    case = _case("auto_declined_with_secrets")
+    scrubbed = worker_events.scrub_event(case["raw"])
+    assert scrubbed["method"].endswith("#auto-declined")
+    assert not worker_events.validate_scrubbed_event(scrubbed)


### PR DESCRIPTION
Summary:\n- classifies app-server worker event fields\n- emits fail-closed scrubbed projections for audit and resume paths\n- adds worker-event fixtures and regression coverage\n\nVerification will be rerun after rebasing onto current main.\n\nFixes #592