### PR TITLE
feat(center): add work-graph dashboard views over ready JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `brigade center serve` gains work-graph views over existing `--json` contracts:
+  an SVG ready/blocked dependency graph, parallel-safe dispatch-wave swim-lanes
+  (seam-ready for `work ready --parallel-safe` when #803 lands), and per-task
+  claim state with three-phase footprint stale indicators. Read-only; no new
+  write surfaces.
+
 ## [0.26.1] - 2026-08-09
 
 ### Changed

--- a/src/brigade/center_cmd/dashboard/views/__init__.py
+++ b/src/brigade/center_cmd/dashboard/views/__init__.py
@@ -18,11 +18,14 @@ from typing import Protocol
 from brigade.center_cmd.dashboard import render
 from brigade.center_cmd.dashboard.views import (
     activity_heatmap,
+    dispatch_waves,
     handoff_inbox,
     memory_cards,
     outcome_rank,
+    ready_graph,
     run_timeline,
     status_grid,
+    task_claims,
 )
 
 _VIEW_MODULES: tuple[ModuleType, ...] = (
@@ -32,6 +35,9 @@ _VIEW_MODULES: tuple[ModuleType, ...] = (
     outcome_rank,
     run_timeline,
     activity_heatmap,
+    ready_graph,
+    dispatch_waves,
+    task_claims,
 )
 
 

--- a/src/brigade/center_cmd/dashboard/views/dispatch_waves.py
+++ b/src/brigade/center_cmd/dashboard/views/dispatch_waves.py
@@ -1,0 +1,205 @@
+"""Dispatch-wave swim-lane dashboard view.
+
+Renders parallel-safe waves from the additive ready JSON shape introduced by
+#803 (``waves``, ``wave_count``, ``partition_mode``, …). When that flag is not
+yet on main, ``work_graph.fetch_ready`` leaves a seam and this view shows an
+explicit unavailable panel plus the unpartitioned ready set as a single lane
+preview — never invents a partition client-side.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from brigade.center_cmd.dashboard import render as html
+from brigade.center_cmd.dashboard import work_graph as wg
+
+NAME = "waves"
+TITLE = "Waves"
+ORDER = 8
+
+
+def fetch(target: Path) -> dict:
+    return wg.fetch_ready(target)
+
+
+def render(payload: dict, nonce: str) -> str:
+    if payload.get("error"):
+        return html.error_panel(TITLE, str(payload["error"]))
+
+    waves = payload.get("waves")
+    has_waves = isinstance(waves, list)
+
+    parts = [_stylesheet(nonce)]
+    if has_waves:
+        parts.append(_partition_summary(payload))
+        parts.append(_swim_lanes(waves))
+    else:
+        parts.append(_unavailable_panel(payload))
+        parts.append(_preview_lane(payload))
+    return "".join(parts)
+
+
+def _unavailable_panel(payload: dict) -> str:
+    ready_count = payload.get("ready_count")
+    if ready_count is None:
+        ready = payload.get("ready")
+        ready_count = len(ready) if isinstance(ready, list) else 0
+    message = (
+        "Dispatch waves are not in this ready JSON yet. "
+        "They appear when brigade work ready --parallel-safe is available "
+        "(PR #803). Showing the unpartitioned ready set as a single lane."
+    )
+    detail = f"{ready_count} ready task(s)."
+    return html.panel(
+        html.esc("Waves unavailable"),
+        f"<p>{html.esc(message)}</p><p>{html.esc(detail)}</p>",
+    )
+
+
+def _partition_summary(payload: dict) -> str:
+    degraded = payload.get("partition_degraded") is True
+    mode = payload.get("partition_mode") or "-"
+    reason = payload.get("partition_degraded_reason") or ""
+    rows = [
+        [html.esc("Wave count"), html.esc(payload.get("wave_count", len(payload.get("waves") or [])))],
+        [html.esc("Partition mode"), html.esc(mode)],
+        [html.esc("Degraded"), html.esc("yes" if degraded else "no")],
+    ]
+    if degraded and reason:
+        rows.append([html.esc("Degrade reason"), html.esc(reason)])
+    return html.panel(
+        html.esc("Parallel-safe partition"),
+        html.table([html.esc("Signal"), html.esc("Value")], rows),
+    )
+
+
+def _preview_lane(payload: dict) -> str:
+    ready = payload.get("ready")
+    tasks = [item for item in ready if isinstance(item, dict)] if isinstance(ready, list) else []
+    wave = {
+        "index": 0,
+        "exclusive": False,
+        "task_ids": [str(item.get("id") or "") for item in tasks],
+        "tasks": tasks,
+    }
+    return html.panel(
+        html.esc("Ready set (unpartitioned)"),
+        _lane_markup(wave, preview=True),
+    )
+
+
+def _swim_lanes(waves: list) -> str:
+    lanes = []
+    for wave in waves:
+        if not isinstance(wave, dict):
+            continue
+        lanes.append(_lane_markup(wave, preview=False))
+    if not lanes:
+        return html.panel(html.esc(TITLE), f"<p>{html.esc('Nothing here.')}</p>")
+    return html.panel(html.esc(TITLE), f'<div class="wg-swimlanes">{"".join(lanes)}</div>')
+
+
+def _lane_markup(wave: dict, *, preview: bool) -> str:
+    index = wave.get("index", 0)
+    exclusive = wave.get("exclusive") is True
+    tasks = wave.get("tasks")
+    if not isinstance(tasks, list):
+        task_ids = wave.get("task_ids") if isinstance(wave.get("task_ids"), list) else []
+        tasks = [{"id": task_id} for task_id in task_ids if isinstance(task_id, str)]
+
+    chips = []
+    for item in tasks:
+        if not isinstance(item, dict):
+            continue
+        task_id = str(item.get("id") or "")
+        title = str(item.get("text") or item.get("title") or "")
+        tip = task_id
+        label = task_id if len(task_id) <= 22 else f"{task_id[:10]}…{task_id[-6:]}"
+        chips.append(
+            f'<li class="wg-chip" title="{html.esc(tip)}">'
+            f'<span class="wg-chip-id">{html.esc(label)}</span>'
+            f'<span class="wg-chip-title">{html.esc(_clip(title))}</span>'
+            f"</li>"
+        )
+    if not chips:
+        chips.append(f'<li class="wg-chip wg-chip-empty">{html.esc("empty wave")}</li>')
+
+    exclusive_mark = ' data-exclusive="1"' if exclusive else ""
+    lane_class = "wg-lane wg-lane-preview" if preview else "wg-lane"
+    if exclusive:
+        lane_class += " wg-lane-exclusive"
+    heading = "Preview lane" if preview else f"Wave {index}"
+    if exclusive:
+        heading = f"{heading} (exclusive)"
+    return (
+        f'<section class="{lane_class}"{exclusive_mark}>'
+        f'<h3 class="wg-lane-title">{html.esc(heading)}</h3>'
+        f'<ol class="wg-lane-tasks">{"".join(chips)}</ol>'
+        f"</section>"
+    )
+
+
+def _clip(text: str, limit: int = 40) -> str:
+    cleaned = " ".join(text.split())
+    if len(cleaned) <= limit:
+        return cleaned
+    return f"{cleaned[: limit - 1]}…"
+
+
+def _stylesheet(nonce: str) -> str:
+    return f"""<style nonce="{html.esc(nonce)}">
+.wg-swimlanes {{
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}}
+.wg-lane {{
+  border: 1px solid #c5d4e8;
+  border-left: 4px solid #0066cc;
+  background: #f5f9fd;
+  padding: 0.75rem 1rem;
+}}
+.wg-lane-exclusive {{
+  border-left-color: #8b0000;
+  background: #fdf5f5;
+}}
+.wg-lane-preview {{
+  border-left-color: #888;
+  background: #f7f7f7;
+}}
+.wg-lane-title {{
+  margin: 0 0 0.5rem;
+  font-size: 0.95rem;
+}}
+.wg-lane-tasks {{
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}}
+.wg-chip {{
+  border: 1px solid #bbb;
+  border-radius: 0.2rem;
+  background: #fff;
+  padding: 0.35rem 0.55rem;
+  min-width: 8rem;
+  max-width: 16rem;
+}}
+.wg-chip-empty {{
+  color: #666;
+  font-style: italic;
+}}
+.wg-chip-id {{
+  display: block;
+  font-weight: 700;
+  font-size: 0.8rem;
+}}
+.wg-chip-title {{
+  display: block;
+  font-size: 0.8rem;
+  color: #333;
+}}
+</style>"""

--- a/src/brigade/center_cmd/dashboard/views/ready_graph.py
+++ b/src/brigade/center_cmd/dashboard/views/ready_graph.py
@@ -1,0 +1,231 @@
+"""Ready-set dependency graph dashboard view.
+
+Renders an SVG dependency graph from ``brigade work ready --explain --json``:
+ready nodes, blocked nodes with blocker edges, and parent-child edges as a
+secondary stroke. No frontend framework — layered layout plus inline SVG,
+styled through a nonced ``<style>`` block (CSP has no ``unsafe-inline``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from brigade.center_cmd.dashboard import render as html
+from brigade.center_cmd.dashboard import work_graph as wg
+
+NAME = "graph"
+TITLE = "Graph"
+ORDER = 7
+
+_NODE_WIDTH = 160
+_NODE_HEIGHT = 52
+_COL_GAP = 72
+_ROW_GAP = 28
+_PAD_X = 24
+_PAD_Y = 24
+
+
+def fetch(target: Path) -> dict:
+    return wg.fetch_ready(target)
+
+
+def render(payload: dict, nonce: str) -> str:
+    if payload.get("error"):
+        return html.error_panel(TITLE, str(payload["error"]))
+
+    nodes = wg.graph_nodes(payload)
+    if not nodes:
+        return html.panel(html.esc(TITLE), f"<p>{html.esc('Nothing here.')}</p>")
+
+    edges = wg.dependency_edges(payload)
+    layers = wg.layout_layers(nodes, edges)
+    svg = _render_svg(layers, edges)
+    summary = _summary_panel(payload, nodes, edges)
+    legend = _legend()
+    return f"{_stylesheet(nonce)}{summary}{html.panel(html.esc(TITLE), f'{legend}{svg}')}"
+
+
+def _summary_panel(payload: dict, nodes: list[dict], edges: list[dict]) -> str:
+    ready_count = payload.get("ready_count")
+    if ready_count is None:
+        ready_count = sum(1 for node in nodes if node.get("kind") == "ready")
+    blocked_count = payload.get("blocked_count")
+    if blocked_count is None:
+        blocked_count = sum(1 for node in nodes if node.get("kind") == "blocked")
+    rows = [
+        [html.esc("Ready"), html.esc(ready_count)],
+        [html.esc("Blocked"), html.esc(blocked_count)],
+        [html.esc("Cycles"), html.esc(payload.get("cycle_count", 0))],
+        [html.esc("Drawn edges"), html.esc(len(edges))],
+        [html.esc("Nodes"), html.esc(len(nodes))],
+    ]
+    return html.panel(
+        html.esc("Ready set"),
+        html.table([html.esc("Signal"), html.esc("Value")], rows),
+    )
+
+
+def _legend() -> str:
+    return (
+        '<ul class="wg-legend">'
+        f'<li><span class="wg-swatch wg-swatch-ready"></span>{html.esc("Ready")}</li>'
+        f'<li><span class="wg-swatch wg-swatch-blocked"></span>{html.esc("Blocked")}</li>'
+        f'<li><span class="wg-swatch wg-swatch-other"></span>{html.esc("Related")}</li>'
+        f'<li><span class="wg-edge-sample wg-edge-blocks"></span>{html.esc("blocks")}</li>'
+        f'<li><span class="wg-edge-sample wg-edge-parent"></span>{html.esc("parent-child")}</li>'
+        "</ul>"
+    )
+
+
+def _stylesheet(nonce: str) -> str:
+    return f"""<style nonce="{html.esc(nonce)}">
+.wg-legend {{
+  list-style: none;
+  margin: 0 0 1rem;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.25rem;
+  font-size: 0.85rem;
+}}
+.wg-legend li {{
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}}
+.wg-swatch {{
+  display: inline-block;
+  width: 0.9rem;
+  height: 0.9rem;
+  border: 1px solid #333;
+  border-radius: 0.15rem;
+}}
+.wg-swatch-ready {{ background: #d9f2e3; }}
+.wg-swatch-blocked {{ background: #f8e0e0; }}
+.wg-swatch-other {{ background: #ececec; }}
+.wg-edge-sample {{
+  display: inline-block;
+  width: 1.4rem;
+  height: 0;
+  border-top: 2px solid #333;
+}}
+.wg-edge-blocks {{ border-top-color: #8b0000; }}
+.wg-edge-parent {{
+  border-top-style: dashed;
+  border-top-color: #666;
+}}
+svg.wg-graph {{
+  display: block;
+  max-width: 100%;
+  height: auto;
+  background: #fafafa;
+  border: 1px solid #ddd;
+}}
+.wg-node-ready rect {{ fill: #d9f2e3; stroke: #1a7f4b; }}
+.wg-node-blocked rect {{ fill: #f8e0e0; stroke: #8b0000; }}
+.wg-node-other rect {{ fill: #ececec; stroke: #666; }}
+.wg-node text {{
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 11px;
+  fill: #111;
+}}
+.wg-node .wg-id {{
+  font-weight: 700;
+  font-size: 10px;
+}}
+.wg-edge-blocks {{
+  stroke: #8b0000;
+  stroke-width: 1.75;
+  fill: none;
+}}
+.wg-edge-parent-child {{
+  stroke: #666;
+  stroke-width: 1.25;
+  stroke-dasharray: 4 3;
+  fill: none;
+}}
+</style>"""
+
+
+def _short_id(task_id: str) -> str:
+    if len(task_id) <= 18:
+        return task_id
+    return f"{task_id[:8]}…{task_id[-6:]}"
+
+
+def _short_title(title: str, limit: int = 28) -> str:
+    text = " ".join(title.split())
+    if len(text) <= limit:
+        return text
+    return f"{text[: limit - 1]}…"
+
+
+def _positions(layers: list[list[dict]]) -> dict[str, tuple[float, float]]:
+    positions: dict[str, tuple[float, float]] = {}
+    for col, layer in enumerate(layers):
+        for row, node in enumerate(layer):
+            x = _PAD_X + col * (_NODE_WIDTH + _COL_GAP)
+            y = _PAD_Y + row * (_NODE_HEIGHT + _ROW_GAP)
+            positions[str(node["id"])] = (x, y)
+    return positions
+
+
+def _render_svg(layers: list[list[dict]], edges: list[dict[str, str]]) -> str:
+    positions = _positions(layers)
+    cols = max(len(layers), 1)
+    rows = max((len(layer) for layer in layers), default=1)
+    width = _PAD_X * 2 + cols * _NODE_WIDTH + max(cols - 1, 0) * _COL_GAP
+    height = _PAD_Y * 2 + rows * _NODE_HEIGHT + max(rows - 1, 0) * _ROW_GAP
+
+    edge_parts: list[str] = []
+    for edge in edges:
+        source = positions.get(edge["source"])
+        target = positions.get(edge["target"])
+        if source is None or target is None:
+            continue
+        x1 = source[0] + _NODE_WIDTH
+        y1 = source[1] + _NODE_HEIGHT / 2
+        x2 = target[0]
+        y2 = target[1] + _NODE_HEIGHT / 2
+        # Straight when same row-ish; gentle cubic otherwise.
+        mid = (x1 + x2) / 2
+        path = f"M {x1:.1f} {y1:.1f} C {mid:.1f} {y1:.1f}, {mid:.1f} {y2:.1f}, {x2:.1f} {y2:.1f}"
+        edge_class = "wg-edge-blocks" if edge["type"] == "blocks" else "wg-edge-parent-child"
+        marker = "url(#wg-arrow-blocks)" if edge["type"] == "blocks" else "url(#wg-arrow-parent)"
+        edge_parts.append(f'<path class="{edge_class}" d="{path}" marker-end="{marker}" />')
+
+    node_parts: list[str] = []
+    for node in (item for layer in layers for item in layer):
+        task_id = str(node["id"])
+        x, y = positions[task_id]
+        kind = str(node.get("kind") or "other")
+        title = _short_title(str(node.get("title") or ""))
+        label_id = _short_id(task_id)
+        tip = f"{task_id}: {node.get('title') or ''}".strip()
+        # SVG <title> is a text child, not an attribute — still escape.
+        node_parts.append(
+            f'<g class="wg-node wg-node-{html.esc(kind)}" transform="translate({x:.1f} {y:.1f})">'
+            f"<title>{html.esc(tip)}</title>"
+            f'<rect width="{_NODE_WIDTH}" height="{_NODE_HEIGHT}" rx="4" ry="4" />'
+            f'<text class="wg-id" x="8" y="18">{html.esc(label_id)}</text>'
+            f'<text x="8" y="36">{html.esc(title or "—")}</text>'
+            f"</g>"
+        )
+
+    return (
+        f'<svg class="wg-graph" viewBox="0 0 {width} {height}" '
+        f'width="{width}" height="{height}" role="img" '
+        f'aria-label="{html.esc("Work dependency graph")}">'
+        "<defs>"
+        '<marker id="wg-arrow-blocks" viewBox="0 0 10 10" refX="9" refY="5" '
+        'markerWidth="7" markerHeight="7" orient="auto-start-reverse">'
+        '<path d="M 0 0 L 10 5 L 0 10 z" fill="#8b0000" />'
+        "</marker>"
+        '<marker id="wg-arrow-parent" viewBox="0 0 10 10" refX="9" refY="5" '
+        'markerWidth="7" markerHeight="7" orient="auto-start-reverse">'
+        '<path d="M 0 0 L 10 5 L 0 10 z" fill="#666666" />'
+        "</marker>"
+        "</defs>"
+        f"{''.join(edge_parts)}{''.join(node_parts)}"
+        "</svg>"
+    )

--- a/src/brigade/center_cmd/dashboard/views/task_claims.py
+++ b/src/brigade/center_cmd/dashboard/views/task_claims.py
@@ -1,0 +1,149 @@
+"""Claim state and three-phase footprint dashboard view.
+
+Sourced from ``brigade work tasks --all --json`` (full task records carry
+``claim`` and ``metadata.footprint``). Marks stale claims (age ≥ claim stale
+hours) and footprint/lifecycle mismatches without introducing write surfaces.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from brigade.center_cmd.dashboard import render as html
+from brigade.center_cmd.dashboard import work_graph as wg
+from brigade.work_cmd import constants as work_constants
+
+NAME = "claims"
+TITLE = "Claims"
+ORDER = 9
+
+
+def fetch(target: Path) -> dict:
+    return wg.fetch_tasks(target)
+
+
+def render(payload: dict, nonce: str) -> str:
+    if payload.get("error"):
+        return html.error_panel(TITLE, str(payload["error"]))
+
+    tasks = payload.get("tasks")
+    if not isinstance(tasks, list) or not tasks:
+        return html.panel(html.esc(TITLE), f"<p>{html.esc('Nothing here.')}</p>")
+
+    now = datetime.now(timezone.utc)
+    rows: list[list[str]] = []
+    stale_claim_count = 0
+    stale_footprint_count = 0
+
+    for task in tasks:
+        if not isinstance(task, dict):
+            continue
+        claim = wg.claim_record(task)
+        footprint = wg.footprint_of(task)
+        claim_stale = wg.claim_is_stale(claim, now=now)
+        footprint_stale = wg.footprint_staleness(task, footprint)
+        if claim_stale:
+            stale_claim_count += 1
+        if footprint_stale:
+            stale_footprint_count += 1
+        rows.append(_row(task, claim, footprint, claim_stale, footprint_stale, now=now))
+
+    if not rows:
+        return html.panel(html.esc(TITLE), f"<p>{html.esc('Nothing here.')}</p>")
+
+    summary_rows = [
+        [html.esc("Tasks"), html.esc(len(rows))],
+        [html.esc("Stale claims"), html.esc(stale_claim_count)],
+        [html.esc("Stale footprints"), html.esc(stale_footprint_count)],
+        [html.esc("Claim stale after (h)"), html.esc(work_constants.CLAIM_STALE_HOURS)],
+    ]
+    table = html.table(
+        [
+            html.esc("Task"),
+            html.esc("Status"),
+            html.esc("Claim"),
+            html.esc("Claim age"),
+            html.esc("Footprint"),
+            html.esc("Files"),
+            html.esc("Symbols"),
+            html.esc("Flags"),
+        ],
+        rows,
+    )
+    return (
+        f"{_stylesheet(nonce)}"
+        f"{html.panel(html.esc('Claim & footprint summary'), html.table([html.esc('Signal'), html.esc('Value')], summary_rows))}"
+        f"{html.panel(html.esc(TITLE), table)}"
+    )
+
+
+def _row(
+    task: dict,
+    claim: dict | None,
+    footprint: dict | None,
+    claim_stale: bool,
+    footprint_stale: str | None,
+    *,
+    now: datetime,
+) -> list[str]:
+    task_id = str(task.get("id") or "-")
+    status = str(task.get("status") or "pending")
+
+    if claim is None:
+        claim_cell = html.esc("unclaimed")
+        age_cell = html.esc("-")
+    else:
+        actor = claim.get("actor") or task.get("assignee") or "-"
+        claim_id = claim.get("claim_id") or "-"
+        claim_cell = html.esc(f"{actor} / {claim_id}")
+        age = wg.claim_age_hours(claim, now=now)
+        age_cell = html.esc("-" if age is None else f"{age:.1f}h")
+
+    if footprint is None:
+        phase_cell = html.esc("none")
+        files_cell = html.esc("-")
+        symbols_cell = html.esc("-")
+    else:
+        phase = str(footprint.get("phase") or "predicted")
+        files = footprint.get("files") if isinstance(footprint.get("files"), list) else []
+        symbols = footprint.get("symbol_ids") if isinstance(footprint.get("symbol_ids"), list) else []
+        phase_cell = html.esc(phase)
+        files_cell = html.esc(len(files))
+        symbols_cell = html.esc(len(symbols))
+
+    flags: list[str] = []
+    if claim_stale:
+        flags.append("stale-claim")
+    if footprint_stale:
+        flags.append(f"stale-footprint: {footprint_stale}")
+    flag_cell = html.esc(", ".join(flags) if flags else "ok")
+
+    # render.table does not accept row classes; mark staleness on the Flags cell.
+    if claim_stale or footprint_stale:
+        flag_cell = f'<span class="wg-flag-stale">{flag_cell}</span>'
+    else:
+        flag_cell = f'<span class="wg-flag-ok">{flag_cell}</span>'
+
+    return [
+        html.esc(task_id),
+        html.esc(status),
+        claim_cell,
+        age_cell,
+        phase_cell,
+        files_cell,
+        symbols_cell,
+        flag_cell,
+    ]
+
+
+def _stylesheet(nonce: str) -> str:
+    return f"""<style nonce="{html.esc(nonce)}">
+.wg-flag-stale {{
+  color: #8b0000;
+  font-weight: 600;
+}}
+.wg-flag-ok {{
+  color: #1a7f4b;
+}}
+</style>"""

--- a/src/brigade/center_cmd/dashboard/work_graph.py
+++ b/src/brigade/center_cmd/dashboard/work_graph.py
@@ -1,0 +1,277 @@
+"""Shared helpers for work-graph dashboard views.
+
+Views stay presentation-only: they consume ``work ready --json`` and
+``work tasks --json`` via ``data.run_json``, never open ``.brigade/``.
+
+The waves seam understands the additive #803 shape (``waves``,
+``wave_count``, ``partition_mode``, ``partition_degraded``) when present.
+Until ``--parallel-safe`` lands on main, fetch falls back to explain-only
+ready JSON and the waves panel renders an explicit unavailable state.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from brigade.center_cmd.dashboard import data
+from brigade.work_cmd import constants as work_constants
+from brigade.work_cmd import footprint as footprint_mod
+
+TERMINAL_STATUSES = frozenset({"completed", "done", "cancelled", "canceled"})
+
+
+def fetch_ready(target: Path) -> dict[str, Any]:
+    """Load readiness JSON, preferring ``--parallel-safe`` when the CLI has it."""
+    preferred = data.run_json(target, ["work", "ready", "--explain", "--parallel-safe"])
+    if not preferred.get("error"):
+        return preferred
+
+    error_text = str(preferred.get("error") or "").casefold()
+    # Seam: flag not yet on main (or rejected by an older parser).
+    if "parallel-safe" in error_text or "unrecognized arguments" in error_text:
+        fallback = data.run_json(target, ["work", "ready", "--explain"])
+        if not fallback.get("error"):
+            enriched = dict(fallback)
+            enriched["parallel_safe"] = False
+            enriched["waves_unavailable"] = True
+            return enriched
+        return fallback
+    return preferred
+
+
+def fetch_tasks(target: Path) -> dict[str, Any]:
+    """Load the full task ledger view (includes claims and footprints)."""
+    return data.run_json(target, ["work", "tasks", "--all"])
+
+
+def task_index(tasks_payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    tasks = tasks_payload.get("tasks")
+    if not isinstance(tasks, list):
+        return {}
+    indexed: dict[str, dict[str, Any]] = {}
+    for task in tasks:
+        if isinstance(task, dict) and isinstance(task.get("id"), str):
+            indexed[task["id"]] = task
+    return indexed
+
+
+def claim_record(task: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(task, dict):
+        return None
+    claim = task.get("claim")
+    if isinstance(claim, dict) and isinstance(claim.get("claim_id"), str) and claim["claim_id"].strip():
+        return claim
+    return None
+
+
+def footprint_of(task: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(task, dict):
+        return None
+    raw = footprint_mod.task_footprint(task)
+    if raw is None:
+        return None
+    # Preserve degrade markers from the stored object (normalize drops them).
+    metadata = task.get("metadata") if isinstance(task.get("metadata"), dict) else {}
+    stored = metadata.get("footprint") if isinstance(metadata, dict) else None
+    if isinstance(stored, dict) and stored.get("degraded") is True:
+        raw = dict(raw)
+        raw["degraded"] = True
+        reason = stored.get("degraded_reason")
+        if isinstance(reason, str) and reason.strip():
+            raw["degraded_reason"] = reason.strip()
+    return raw
+
+
+def _parse_timestamp(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def claim_age_hours(claim: dict[str, Any] | None, *, now: datetime | None = None) -> float | None:
+    if not isinstance(claim, dict):
+        return None
+    claimed_at = _parse_timestamp(claim.get("claimed_at"))
+    if claimed_at is None:
+        return None
+    current = now or datetime.now(timezone.utc)
+    return max(0.0, (current - claimed_at).total_seconds() / 3600.0)
+
+
+def claim_is_stale(claim: dict[str, Any] | None, *, now: datetime | None = None) -> bool:
+    age = claim_age_hours(claim, now=now)
+    if age is None:
+        return False
+    return age >= float(work_constants.CLAIM_STALE_HOURS)
+
+
+def footprint_staleness(
+    task: dict[str, Any],
+    footprint: dict[str, Any] | None,
+) -> str | None:
+    """Return a short stale reason, or None when the footprint matches task state.
+
+    Presentation rules (derived from the three-phase lifecycle, not a new
+    CLI contract):
+
+    - ``in_progress`` still on ``predicted`` → should have refined at claim
+    - terminal status not yet ``reconciled`` → completion join pending
+    - stored ``degraded`` predicted footprint → oracle miss, still empty
+    """
+    if footprint is None:
+        status = str(task.get("status") or "pending")
+        if status == "in_progress" or status in TERMINAL_STATUSES:
+            return "missing footprint"
+        return None
+
+    phase = str(footprint.get("phase") or footprint_mod.PHASE_PREDICTED)
+    status = str(task.get("status") or "pending")
+
+    if footprint.get("degraded") is True and phase == footprint_mod.PHASE_PREDICTED:
+        reason = footprint.get("degraded_reason")
+        if isinstance(reason, str) and reason.strip():
+            return f"degraded: {reason.strip()}"
+        return "degraded predicted footprint"
+
+    if status == "in_progress" and phase == footprint_mod.PHASE_PREDICTED:
+        return "still predicted after claim"
+
+    if status in TERMINAL_STATUSES and phase != footprint_mod.PHASE_RECONCILED:
+        return f"not reconciled ({phase})"
+
+    return None
+
+
+def graph_nodes(ready_payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Build display nodes from ready + blocked entries (and edge endpoints)."""
+    nodes: dict[str, dict[str, Any]] = {}
+
+    def _ensure(task_id: str, *, kind: str, title: str = "", status: str = "") -> None:
+        existing = nodes.get(task_id)
+        if existing is None:
+            nodes[task_id] = {
+                "id": task_id,
+                "title": title,
+                "kind": kind,
+                "status": status,
+            }
+            return
+        if title and not existing.get("title"):
+            existing["title"] = title
+        if status and not existing.get("status"):
+            existing["status"] = status
+        # Prefer ready/blocked kinds over generic edge endpoints.
+        if existing.get("kind") == "other" and kind != "other":
+            existing["kind"] = kind
+
+    for item in ready_payload.get("ready") or []:
+        if not isinstance(item, dict) or not isinstance(item.get("id"), str):
+            continue
+        _ensure(
+            item["id"],
+            kind="ready",
+            title=str(item.get("text") or item.get("title") or ""),
+            status=str(item.get("status") or "pending"),
+        )
+
+    for item in ready_payload.get("blocked") or []:
+        if not isinstance(item, dict) or not isinstance(item.get("id"), str):
+            continue
+        _ensure(
+            item["id"],
+            kind="blocked",
+            title=str(item.get("title") or item.get("text") or ""),
+            status=str(item.get("status") or "pending"),
+        )
+        for blocker in item.get("blockers") or []:
+            if isinstance(blocker, dict) and isinstance(blocker.get("id"), str):
+                _ensure(
+                    blocker["id"],
+                    kind="other",
+                    title="",
+                    status=str(blocker.get("status") or ""),
+                )
+
+    for edge in ready_payload.get("edges") or []:
+        if not isinstance(edge, dict):
+            continue
+        edge_type = str(edge.get("type") or "")
+        if edge_type not in {"blocks", "parent-child"}:
+            continue
+        for key in ("source", "target"):
+            value = edge.get(key)
+            if isinstance(value, str) and value.strip():
+                _ensure(value.strip(), kind="other")
+
+    ordered = sorted(nodes.values(), key=lambda item: str(item["id"]))
+    return ordered
+
+
+def dependency_edges(ready_payload: dict[str, Any]) -> list[dict[str, str]]:
+    """Return edges that should draw on the dependency graph."""
+    drawn: list[dict[str, str]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for edge in ready_payload.get("edges") or []:
+        if not isinstance(edge, dict):
+            continue
+        edge_type = str(edge.get("type") or "")
+        if edge_type not in {"blocks", "parent-child"}:
+            # discovered-from is provenance-only and never gates readiness.
+            continue
+        source = edge.get("source")
+        target = edge.get("target")
+        if not isinstance(source, str) or not isinstance(target, str):
+            continue
+        key = (source, target, edge_type)
+        if key in seen:
+            continue
+        seen.add(key)
+        drawn.append({"source": source, "target": target, "type": edge_type})
+    return drawn
+
+
+def layout_layers(nodes: list[dict[str, Any]], edges: list[dict[str, str]]) -> list[list[dict[str, Any]]]:
+    """Assign nodes to columns by longest path through ``blocks`` edges."""
+    by_id = {str(node["id"]): node for node in nodes}
+    blockers: dict[str, set[str]] = {node_id: set() for node_id in by_id}
+    for edge in edges:
+        if edge.get("type") != "blocks":
+            continue
+        source = edge["source"]
+        target = edge["target"]
+        if source in by_id and target in by_id:
+            blockers[target].add(source)
+
+    depth: dict[str, int] = {}
+
+    def _depth(node_id: str, stack: set[str]) -> int:
+        if node_id in depth:
+            return depth[node_id]
+        if node_id in stack:
+            return 0
+        stack.add(node_id)
+        parents = blockers.get(node_id) or set()
+        value = 0 if not parents else 1 + max(_depth(parent, stack) for parent in parents)
+        stack.remove(node_id)
+        depth[node_id] = value
+        return value
+
+    for node_id in by_id:
+        _depth(node_id, set())
+
+    max_depth = max(depth.values()) if depth else 0
+    layers: list[list[dict[str, Any]]] = [[] for _ in range(max_depth + 1)]
+    for node in sorted(nodes, key=lambda item: (depth.get(str(item["id"]), 0), str(item["id"]))):
+        layers[depth.get(str(node["id"]), 0)].append(node)
+    return layers

--- a/tests/test_center_dashboard.py
+++ b/tests/test_center_dashboard.py
@@ -82,6 +82,15 @@ def test_get_view_status_returns_200(dashboard_server):
     assert _status_code(response) == "200"
 
 
+@pytest.mark.parametrize("view_name", [module.NAME for module in all_views()])
+def test_get_each_registered_view_returns_200(dashboard_server, view_name):
+    host, port = dashboard_server.server_address
+    response = _raw_request(dashboard_server, f"{host}:{port}", path=f"/view/{view_name}")
+    assert _status_code(response) == "200"
+    _, body = _headers_and_body(response)
+    assert "failed to render" not in body
+
+
 def test_get_unknown_view_returns_404(dashboard_server):
     host, port = dashboard_server.server_address
     response = _raw_request(dashboard_server, f"{host}:{port}", path="/view/nope")

--- a/tests/test_dashboard_claims.py
+++ b/tests/test_dashboard_claims.py
@@ -1,0 +1,206 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+from brigade.center_cmd.dashboard.views import task_claims
+from brigade.center_cmd.dashboard import work_graph as wg
+
+
+def test_fetch_uses_tasks_all_json(monkeypatch, tmp_path):
+    expected = {"tasks": []}
+    calls: list[tuple[Path, list[str]]] = []
+
+    def fake_run_json(target: Path, args: list[str]) -> dict:
+        calls.append((target, list(args)))
+        return expected
+
+    monkeypatch.setattr("brigade.center_cmd.dashboard.data.run_json", fake_run_json)
+    assert task_claims.fetch(tmp_path) == expected
+    assert calls == [(tmp_path, ["work", "tasks", "--all"])]
+
+
+def test_render_claim_and_footprint_rows_with_stale_flags(monkeypatch):
+    fixed_now = datetime(2026, 8, 9, 18, 0, 0, tzinfo=timezone.utc)
+
+    class _FixedDateTime:
+        @staticmethod
+        def now(tz=None):
+            return fixed_now
+
+    monkeypatch.setattr(task_claims, "datetime", _FixedDateTime)
+
+    payload = {
+        "tasks": [
+            {
+                "id": "task-fresh",
+                "text": "Fresh claim",
+                "status": "in_progress",
+                "assignee": "alice",
+                "claim": {
+                    "claim_id": "claim-fresh",
+                    "actor": "alice",
+                    "claimed_at": "2026-08-09T12:00:00+00:00",
+                    "item_revision": 1,
+                },
+                "metadata": {
+                    "footprint": {
+                        "phase": "refined",
+                        "files": ["src/a.py"],
+                        "symbol_ids": ["sym.a"],
+                        "snapshot_hash": "abc",
+                    }
+                },
+            },
+            {
+                "id": "task-stale-claim",
+                "text": "Old claim",
+                "status": "in_progress",
+                "claim": {
+                    "claim_id": "claim-old",
+                    "actor": "bob",
+                    "claimed_at": "2026-08-01T12:00:00+00:00",
+                    "item_revision": 1,
+                },
+                "metadata": {
+                    "footprint": {
+                        "phase": "predicted",
+                        "files": [],
+                        "symbol_ids": [],
+                        "snapshot_hash": "",
+                    }
+                },
+            },
+            {
+                "id": "task-done",
+                "text": "Done without reconcile",
+                "status": "completed",
+                "metadata": {
+                    "footprint": {
+                        "phase": "refined",
+                        "files": ["src/b.py"],
+                        "symbol_ids": [],
+                        "snapshot_hash": "def",
+                    }
+                },
+            },
+            {
+                "id": "task-degraded",
+                "text": "Degraded predicted",
+                "status": "pending",
+                "metadata": {
+                    "footprint": {
+                        "phase": "predicted",
+                        "files": [],
+                        "symbol_ids": [],
+                        "snapshot_hash": "",
+                        "degraded": True,
+                        "degraded_reason": "graphtrail binary not found",
+                    }
+                },
+            },
+        ]
+    }
+
+    fragment = task_claims.render(payload, "claim-nonce")
+
+    assert '<style nonce="claim-nonce">' in fragment
+    assert "task-fresh" in fragment
+    assert "alice / claim-fresh" in fragment
+    assert "refined" in fragment
+    assert "stale-claim" in fragment
+    assert "still predicted after claim" in fragment
+    assert "not reconciled (refined)" in fragment
+    assert "degraded: graphtrail binary not found" in fragment
+    assert "wg-flag-stale" in fragment
+    assert "wg-flag-ok" in fragment
+    assert "Stale claims" in fragment
+    assert "Stale footprints" in fragment
+
+
+def test_footprint_staleness_helpers():
+    assert (
+        wg.footprint_staleness(
+            {"status": "in_progress"},
+            {"phase": "predicted", "files": [], "symbol_ids": [], "snapshot_hash": ""},
+        )
+        == "still predicted after claim"
+    )
+    assert (
+        wg.footprint_staleness(
+            {"status": "completed"},
+            {"phase": "refined", "files": ["a.py"], "symbol_ids": [], "snapshot_hash": ""},
+        )
+        == "not reconciled (refined)"
+    )
+    assert (
+        wg.footprint_staleness(
+            {"status": "pending"},
+            {
+                "phase": "predicted",
+                "files": [],
+                "symbol_ids": [],
+                "snapshot_hash": "",
+                "degraded": True,
+                "degraded_reason": "graphtrail index not found",
+            },
+        )
+        == "degraded: graphtrail index not found"
+    )
+    assert (
+        wg.footprint_staleness(
+            {"status": "in_progress"},
+            {"phase": "refined", "files": ["a.py"], "symbol_ids": [], "snapshot_hash": ""},
+        )
+        is None
+    )
+
+
+def test_render_escapes_hostile_task_fields():
+    payload = {
+        "tasks": [
+            {
+                "id": "evil",
+                "text": "<script>alert(1)</script>",
+                "status": "pending",
+                "claim": {
+                    "claim_id": "<img src=x onerror=alert(2)>",
+                    "actor": "<b>bad</b>",
+                    "claimed_at": "2026-08-09T12:00:00+00:00",
+                },
+                "metadata": {
+                    "footprint": {
+                        "phase": "predicted",
+                        "files": [],
+                        "symbol_ids": [],
+                        "snapshot_hash": "",
+                        "degraded": True,
+                        "degraded_reason": "<svg onload=alert(3)>",
+                    }
+                },
+            }
+        ]
+    }
+
+    fragment = task_claims.render(payload, "unused")
+
+    # XSS boundary: no tag may form from attacker text. Escaped substrings
+    # like onerror= in text nodes are inert.
+    assert "<script" not in fragment
+    assert "<img" not in fragment
+    assert "<svg" not in fragment
+    assert "&lt;b&gt;bad&lt;/b&gt;" in fragment
+    assert "&lt;img src=x onerror=alert(2)&gt;" in fragment
+    assert "&lt;svg onload=alert(3)&gt;" in fragment
+
+    import re
+
+    for tag in re.findall(r"<[^>]*>", fragment):
+        assert "alert(" not in tag
+        assert "<script" not in tag
+        assert "<img" not in tag
+        assert "<svg" not in tag
+
+
+def test_render_error_and_empty_payloads_degrade_safely():
+    assert "boom" in task_claims.render({"error": "boom"}, "unused")
+    assert "Nothing here." in task_claims.render({}, "unused")
+    assert "Nothing here." in task_claims.render({"tasks": []}, "unused")

--- a/tests/test_dashboard_graph.py
+++ b/tests/test_dashboard_graph.py
@@ -1,0 +1,117 @@
+from pathlib import Path
+
+from brigade.center_cmd.dashboard.views import ready_graph
+
+
+def test_fetch_uses_ready_json_with_parallel_safe_seam(monkeypatch, tmp_path):
+    calls: list[list[str]] = []
+
+    def fake_run_json(target: Path, args: list[str]) -> dict:
+        calls.append(list(args))
+        if "--parallel-safe" in args:
+            return {"error": "unrecognized arguments: --parallel-safe"}
+        return {
+            "ready": [{"id": "t-ready", "text": "Ready task", "status": "pending"}],
+            "ready_count": 1,
+            "blocked_count": 0,
+            "edges": [],
+        }
+
+    monkeypatch.setattr("brigade.center_cmd.dashboard.data.run_json", fake_run_json)
+
+    payload = ready_graph.fetch(tmp_path)
+    assert calls[0] == ["work", "ready", "--explain", "--parallel-safe"]
+    assert calls[1] == ["work", "ready", "--explain"]
+    assert payload["ready_count"] == 1
+    assert payload.get("waves_unavailable") is True
+    assert payload.get("parallel_safe") is False
+
+
+def test_fetch_keeps_parallel_safe_payload_when_available(monkeypatch, tmp_path):
+    def fake_run_json(target: Path, args: list[str]) -> dict:
+        assert "--parallel-safe" in args
+        return {
+            "ready": [],
+            "ready_count": 0,
+            "blocked_count": 0,
+            "edges": [],
+            "parallel_safe": True,
+            "waves": [],
+            "wave_count": 0,
+        }
+
+    monkeypatch.setattr("brigade.center_cmd.dashboard.data.run_json", fake_run_json)
+    payload = ready_graph.fetch(tmp_path)
+    assert payload["parallel_safe"] is True
+    assert "waves_unavailable" not in payload
+
+
+def test_render_builds_svg_graph_with_ready_and_blocked():
+    payload = {
+        "ready_count": 1,
+        "blocked_count": 1,
+        "cycle_count": 0,
+        "ready": [{"id": "task-a", "text": "Ready alpha", "status": "pending"}],
+        "blocked": [
+            {
+                "id": "task-b",
+                "title": "Blocked beta",
+                "status": "pending",
+                "reason": "open_blockers",
+                "blockers": [{"id": "task-a", "status": "pending", "via": ["blocks"]}],
+            }
+        ],
+        "edges": [
+            {"source": "task-a", "target": "task-b", "type": "blocks"},
+            {"source": "task-parent", "target": "task-b", "type": "parent-child"},
+            {"source": "task-b", "target": "task-c", "type": "discovered-from"},
+        ],
+    }
+
+    fragment = ready_graph.render(payload, "graph-nonce")
+
+    assert '<style nonce="graph-nonce">' in fragment
+    assert 'style="' not in fragment
+    assert 'svg class="wg-graph"' in fragment
+    assert "task-a" in fragment
+    assert "task-b" in fragment
+    assert "wg-node-ready" in fragment
+    assert "wg-node-blocked" in fragment
+    assert "wg-edge-blocks" in fragment
+    assert "wg-edge-parent-child" in fragment
+    # discovered-from must not draw and must not invent a node
+    assert "task-c" not in fragment
+    assert "task-parent" in fragment
+    assert ">1<" in fragment  # ready/blocked counts
+
+
+def test_render_escapes_hostile_task_titles():
+    payload = {
+        "ready": [
+            {
+                "id": "evil",
+                "text": "<script>alert(1)</script><img src=x onerror=alert(2)>",
+                "status": "pending",
+            }
+        ],
+        "blocked": [],
+        "edges": [],
+        "ready_count": 1,
+        "blocked_count": 0,
+        "cycle_count": 0,
+    }
+
+    fragment = ready_graph.render(payload, "unused")
+    assert "<script" not in fragment
+    assert "<img" not in fragment
+    assert "&lt;script&gt;" in fragment
+
+    import re
+
+    for tag in re.findall(r"<[^>]*>", fragment):
+        assert "alert(" not in tag
+
+
+def test_render_error_and_empty_payloads_degrade_safely():
+    assert "boom" in ready_graph.render({"error": "boom"}, "unused")
+    assert "Nothing here." in ready_graph.render({"ready": [], "blocked": [], "edges": []}, "unused")

--- a/tests/test_dashboard_waves.py
+++ b/tests/test_dashboard_waves.py
@@ -1,0 +1,109 @@
+from pathlib import Path
+
+from brigade.center_cmd.dashboard.views import dispatch_waves
+
+
+def test_fetch_uses_ready_json(monkeypatch, tmp_path):
+    expected = {"ready": [], "ready_count": 0, "waves_unavailable": True}
+
+    def fake_run_json(target: Path, args: list[str]) -> dict:
+        if "--parallel-safe" in args:
+            return {"error": "unrecognized arguments: --parallel-safe"}
+        return expected
+
+    monkeypatch.setattr("brigade.center_cmd.dashboard.data.run_json", fake_run_json)
+    assert dispatch_waves.fetch(tmp_path)["ready_count"] == 0
+
+
+def test_render_shows_seam_when_waves_absent():
+    payload = {
+        "ready_count": 2,
+        "ready": [
+            {"id": "task-a", "text": "Alpha work"},
+            {"id": "task-b", "text": "Beta work"},
+        ],
+        "waves_unavailable": True,
+        "parallel_safe": False,
+    }
+
+    fragment = dispatch_waves.render(payload, "wave-nonce")
+
+    assert '<style nonce="wave-nonce">' in fragment
+    assert "Waves unavailable" in fragment
+    assert "parallel-safe" in fragment
+    assert "Ready set (unpartitioned)" in fragment
+    assert "task-a" in fragment
+    assert "task-b" in fragment
+    assert "wg-lane-preview" in fragment
+
+
+def test_render_swim_lanes_from_parallel_safe_shape():
+    payload = {
+        "parallel_safe": True,
+        "wave_count": 2,
+        "partition_mode": "file_overlap",
+        "partition_degraded": True,
+        "partition_degraded_reason": "graphtrail binary not found",
+        "waves": [
+            {
+                "index": 0,
+                "exclusive": False,
+                "task_ids": ["task-a", "task-b"],
+                "tasks": [
+                    {"id": "task-a", "text": "Alpha"},
+                    {"id": "task-b", "text": "Beta"},
+                ],
+            },
+            {
+                "index": 1,
+                "exclusive": True,
+                "task_ids": ["task-c"],
+                "tasks": [{"id": "task-c", "text": "Exclusive empty footprint"}],
+            },
+        ],
+    }
+
+    fragment = dispatch_waves.render(payload, "unused")
+
+    assert "Parallel-safe partition" in fragment
+    assert "file_overlap" in fragment
+    assert "graphtrail binary not found" in fragment
+    assert "Wave 0" in fragment
+    assert "Wave 1 (exclusive)" in fragment
+    assert "wg-lane-exclusive" in fragment
+    assert "task-a" in fragment
+    assert "task-c" in fragment
+    assert "Waves unavailable" not in fragment
+
+
+def test_render_escapes_hostile_wave_task_text():
+    payload = {
+        "parallel_safe": True,
+        "wave_count": 1,
+        "waves": [
+            {
+                "index": 0,
+                "exclusive": False,
+                "tasks": [
+                    {
+                        "id": "evil",
+                        "text": "<script>alert(1)</script><img src=x onerror=alert(2)>",
+                    }
+                ],
+            }
+        ],
+    }
+
+    fragment = dispatch_waves.render(payload, "unused")
+    assert "<script" not in fragment
+    assert "<img" not in fragment
+    assert "&lt;script&gt;" in fragment
+
+    import re
+
+    for tag in re.findall(r"<[^>]*>", fragment):
+        assert "alert(" not in tag
+
+
+def test_render_error_payload_degrades_safely():
+    assert "boom" in dispatch_waves.render({"error": "boom"}, "unused")


### PR DESCRIPTION
Summary:\n- adds read-only Graph, Waves, and Claims dashboard views\n- consumes the PR #803 waves shape when available\n- follows the PR #744 view-module pattern and issue #721 security floor\n\nVerification will be run after PR #803 lands and this branch is rebased onto current main.\n\nDepends on #803. Follows #744 and #721.