### PR TITLE
chore: use union merge driver for CHANGELOG.md

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md merge=union

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,19 @@ Those CLI fields do not expose unresolved review conversations. Separately check
 
 Dispatched sessions should open the pull request, run local verification, and push commits. After the final push, comment `@coderabbitai full review`. The `coderabbitai[bot]` identity records the formal GitHub review. Wait for its current `APPROVED` review before merging. A green CodeRabbit commit status alone does not satisfy this gate.
 
+## Changelog
+
+`CHANGELOG.md` uses Git's `merge=union` driver so parallel pull requests can each append an
+`[Unreleased]` bullet without manual conflict resolution. Union merge keeps every added line
+from both sides; it only conflicts when one side deletes or rewrites content the other left
+alone. Write each entry as a single self-contained line (issue reference, user-visible
+effect, no commit-subject phrasing). Do not wrap entries across multiple lines or edit
+released sections in feature branches — multi-line bullets can interleave badly, and edits
+outside `[Unreleased]` still conflict normally. Prefer an existing subsection (`Added`,
+`Changed`, `Fixed`, …) under `[Unreleased]`; if two branches both introduce the same
+subsection header, union merge folds their bullets under one header (maintainers may reorder
+for readability after merge).
+
 ## Adding a harness
 
 A harness is a manifest under `src/brigade/templates/harnesses/<id>.json` plus any template files it references. The manifest declares `role: "writer"` (gets an inbox) or `role: "reader"` (gets adapter fragments).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

Parallel PRs constantly conflict on `CHANGELOG.md` because every branch appends a bullet under `[Unreleased]`. This adds `merge=union` via `.gitattributes` and documents the single-line entry convention in `CONTRIBUTING.md`.

## Type of change

- [x] Docs
- [ ] Bug fix
- [ ] New harness adapter / doctor check
- [ ] Refactor with no command-surface change
- [ ] Surface change

## Checklist

- [x] `pytest -q` passes locally — **6442 passed, 3 skipped, 68 subtests passed** in ~35m
- [ ] Added or updated tests covering the change (N/A — git attribute + docs only)
- [ ] Updated the `Unreleased` section of `CHANGELOG.md` (contributor workflow only; no CLI/user-visible effect)
- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths
- [x] No new runtime dependencies
- [x] Conventional commit messages

## Union merge test evidence

Simulated a three-way merge in a scratch repo (`git init`, base commit with empty `### Added` under `[Unreleased]`, two branches each appending one bullet, merge both into an integration branch).

**With `merge=union` (this PR):**

```
=== Parallel Unreleased bullets (typical PR conflict) (merge=union: yes) exit=0 ===
Auto-merging CHANGELOG.md
Merge made by the 'ort' strategy.
 CHANGELOG.md | 1 +
 1 file changed, 1 insertion(+)
RESULT: clean merge
--- merged CHANGELOG.md ---
# Changelog

## [Unreleased]

### Added
- PR A: add feature foo (#100)
- PR B: fix bar handling (#101)

## [0.26.1] - 2026-08-09

### Changed
- released entry
--- end ---
```

**Without union driver (status quo):**

```
=== Same scenario without union driver (merge=union: no) exit=1 ===
Auto-merging CHANGELOG.md
CONFLICT (content): Merge conflict in CHANGELOG.md
Automatic merge failed; fix conflicts and then commit the result.
RESULT: conflict markers
--- merged CHANGELOG.md ---
# Changelog

## [Unreleased]

### Added
<<<<<<< HEAD
- PR A: add feature foo (#100)
=======
- PR B: fix bar handling (#101)
>>>>>>> pr-b
```

Additional scenarios exercised:

| Scenario | Union | Default |
|---|---|---|
| Append after existing bullet | Clean — both bullets kept | Conflict |
| Both branches add `### Fixed` subsection | Clean — bullets folded under one header | Conflict |

**Choice:** Union merge is appropriate for our append-only `[Unreleased]` bullet pattern. The duplicate-subsection-header footgun does **not** materialize — union folds parallel `### Fixed` (etc.) headers into one section with both bullets. The real footgun is **multi-line bullets** (continuation lines can interleave); `CONTRIBUTING.md` now requires single self-contained lines. Edits outside `[Unreleased]` still conflict normally, which is desired.

## Files changed

- `.gitattributes` — `CHANGELOG.md merge=union`
- `CONTRIBUTING.md` — new **Changelog** section (single-line entry convention)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-71f385b0-19ee-48c2-b55f-959e32aabf85?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71f385b0-19ee-48c2-b55f-959e32aabf85&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

