### PR TITLE
feat(work): add verification contracts for run/work templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `subject_binding.generated_patch_quarantine`. Model confidence, lexical or
   textual similarity, and repeated sampling are explicitly non-promoting
   outcome sources. Design: `docs/design/generated-patch-quarantine.md`.
+- VerificationContract (#500): consequential runbooks and verify manifests declare
+  an independent verifier, failure/rollback path, and token/latency budget before
+  execution (`brigade.verification_contract.v1`). Plan surfaces incompleteness;
+  run refuses incomplete consequential templates. Receipts record `budget_use`
+  and `verification` separately from `model_completion`. Budget enforcement
+  remains #593.
 
 ## [0.26.1] - 2026-08-09
 

--- a/docs/receipt-schemas.md
+++ b/docs/receipt-schemas.md
@@ -67,6 +67,35 @@ JSON Schema files.
 | `subject_binding` | object | no | Verifier-authored scoreable subject metadata (manifest runs only) |
 | `failure_class` | string | no | Receipt-level #474-style failure class when status is not completed |
 | `failure_kind` | string | no | Receipt-level failure kind paired with `failure_class` |
+| `verification_contract` | object | no | Declared `brigade.verification_contract.v1` when the verify manifest carried one (#500) |
+| `budget_use` | object | no | Observed latency/token use against the declared verification budget (#500; enforcement is #593) |
+| `verification` | object | no | Verification outcome stamped separately from model completion (#500) |
+| `model_completion` | object | no | For contract-bearing verify receipts: `{status: not_applicable, detail}` because verify is verifier-owned |
+
+**`verification_contract` object** (`brigade.verification_contract.v1`)
+
+Declared before execution on consequential runbooks (`consequential: true`) and
+consequential verify manifests. Plan reports incompleteness when any of verifier,
+rollback, or budget is missing. On verify manifests the verifier may omit an
+explicit command and use `source: manifest_checks` (the manifest's own checks).
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `schema` | string | `brigade.verification_contract.v1` |
+| `schema_version` | integer | `1` |
+| `verifier` | object | `{source, command?\|argv?\|manifest_id?}` with `source` in `command`, `argv`, `manifest_id`, `manifest_checks` |
+| `rollback` | object | `{policy, command?}` with `policy` in `none`, `manual`, `command`, `git-restore` |
+| `budget` | object | `{latency_seconds, token_budget?}` — declaration only; #593 enforces ceilings |
+
+**`budget_use` object**
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `latency_seconds_budget` | integer | Declared latency ceiling |
+| `latency_seconds_used` | number \| null | Observed wall time |
+| `token_budget` | integer \| null | Declared token ceiling when set |
+| `tokens_used` | integer \| null | Observed tokens when an adapter reports them |
+| `exhausted` | boolean | Observation only; not an enforcement gate |
 
 **`subject_binding` object** (additive, manifest-selected runs)
 

--- a/docs/technical-guide.md
+++ b/docs/technical-guide.md
@@ -994,7 +994,7 @@ Portable tool projections and first-class skills are related but separate. Tool 
 
 Explicit runbook commands:
 
-- `brigade runbook plan runbook.json` validates a reviewed local runbook file, policy checks, and exact steps without executing them.
+- `brigade runbook plan runbook.json` validates a reviewed local runbook file, policy checks, and exact steps without executing them. Consequential runbooks (`consequential: true`) must declare a `verification_contract` (independent verifier, rollback, token/latency budget) or plan reports blockers and run refuses before execution (#500).
 - `brigade runbook pin runbook.json` shlex-tokenizes each step, resolves each step's `argv[0]`, hashes the current executable, and writes or refreshes the runbook-level `pins` list.
 - `brigade runbook pin runbook.json --dry-run` prints the pins it would write without modifying the runbook file.
 - `brigade runbook run runbook.json --approved` runs foreground shell steps, then writes stdout logs, stderr logs, and a receipt under `.brigade/runbooks/runs/`.
@@ -1097,7 +1097,7 @@ Manual session commands:
 
 Work verification and closeout commands:
 
-- `brigade work verify plan` previews the local verification commands and current evidence snapshot without running anything. When GraphTrail is available it also ranks affected-test candidates (`graph_impact` / `ranked_candidates`) from changed files (`--file` or `git diff --name-only HEAD`) with hop-distance confidence and via-symbol evidence; the worker still chooses the command. Missing GraphTrail degrades to an empty advisory ranking.
+- `brigade work verify plan` previews the local verification commands and current evidence snapshot without running anything. When GraphTrail is available it also ranks affected-test candidates (`graph_impact` / `ranked_candidates`) from changed files (`--file` or `git diff --name-only HEAD`) with hop-distance confidence and via-symbol evidence; the worker still chooses the command. Missing GraphTrail degrades to an empty advisory ranking. Manifest plans also surface VerificationContract completeness when the tracked manifest declares one (#500).
 - `brigade work verify run` executes explicit local verification commands without a shell and writes receipts under `.brigade/work/verify-runs/`.
 - `brigade work verify runs` and `brigade work verify show <run-id>` inspect local verification receipts, command exit codes, summaries, and log paths.
 - `brigade receipts keygen` creates the optional local HMAC key used to sign new receipt digests. Pass `--force` to rotate the key.

--- a/schemas/verification-contract.v1.schema.json
+++ b/schemas/verification-contract.v1.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://brigade.tools/schemas/verification-contract.v1.schema.json",
+  "title": "VerificationContract v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["verifier", "rollback", "budget"],
+  "properties": {
+    "schema": {"const": "brigade.verification_contract.v1"},
+    "schema_version": {"const": 1},
+    "verifier": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "source": {
+          "enum": ["command", "argv", "manifest_id", "manifest_checks"]
+        },
+        "command": {
+          "oneOf": [
+            {"type": "string", "minLength": 1},
+            {
+              "type": "array",
+              "minItems": 1,
+              "items": {"type": "string", "minLength": 1}
+            }
+          ]
+        },
+        "argv": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "manifest_id": {"type": "string", "minLength": 1}
+      }
+    },
+    "rollback": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["policy"],
+      "properties": {
+        "policy": {"enum": ["none", "manual", "command", "git-restore"]},
+        "command": {
+          "oneOf": [
+            {"type": "string", "minLength": 1},
+            {
+              "type": "array",
+              "minItems": 1,
+              "items": {"type": "string", "minLength": 1}
+            }
+          ]
+        }
+      }
+    },
+    "budget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["latency_seconds"],
+      "properties": {
+        "latency_seconds": {"type": "integer", "minimum": 1},
+        "token_budget": {"type": "integer", "minimum": 0}
+      }
+    }
+  }
+}

--- a/src/brigade/runbook_cmd.py
+++ b/src/brigade/runbook_cmd.py
@@ -9,10 +9,11 @@ import shlex
 import shutil
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
-from . import receipt_signing
+from . import receipt_signing, verification_contract
 from .localio import (
     canonical_json_digest as _canonical_json_digest,
     file_sha256 as _file_sha256,
@@ -312,6 +313,10 @@ def _policy_for_step(payload: dict[str, Any], step: dict[str, Any]) -> dict[str,
     }
 
 
+def _runbook_consequential(payload: dict[str, Any]) -> bool:
+    return bool(payload.get("consequential"))
+
+
 def _plan_payload(target: Path, runbook: Path) -> tuple[dict[str, Any] | None, str | None]:
     payload, error = _read_runbook(runbook)
     if payload is None:
@@ -334,6 +339,11 @@ def _plan_payload(target: Path, runbook: Path) -> tuple[dict[str, Any] | None, s
     policy_failures = [
         {"step": step["id"], "failures": step["policy"]["failures"]} for step in steps if step["policy"]["failures"]
     ]
+    consequential = _runbook_consequential(payload)
+    contract_view = verification_contract.contract_plan_view(
+        verification_contract.extract_contract_payload(payload),
+        consequential=consequential,
+    )
     plan = {
         "target": str(target),
         "runbook_path": str(runbook),
@@ -342,6 +352,8 @@ def _plan_payload(target: Path, runbook: Path) -> tuple[dict[str, Any] | None, s
         # file_approved is informational only. It does NOT authorize execution;
         # the operator must pass --approved. A file-embedded flag is ignored.
         "file_approved": bool(payload.get("approved")),
+        "consequential": consequential,
+        "verification_contract": contract_view,
         "policy_valid": not policy_failures,
         "policy_failures": policy_failures,
         "step_count": len(steps),
@@ -351,12 +363,80 @@ def _plan_payload(target: Path, runbook: Path) -> tuple[dict[str, Any] | None, s
             "Executes arbitrary foreground shell commands from the runbook file, which is only as trustworthy as whoever wrote it. Review every step before approving.",
             "The destructive deny-list is advisory, not a security boundary; it is trivially bypassable.",
             "Writes stdout, stderr, and JSON receipts under .brigade/runbooks/runs/.",
+            "Consequential runbooks must declare verification_contract (verifier, rollback, budget) before execution.",
         ],
     }
     pins = _pin_entries(payload)
     if pins:
         plan["pins"] = pins
     return plan, None
+
+
+def _shell_or_argv_command(
+    command: str | list[str],
+    *,
+    cwd: Path,
+    timeout: int,
+) -> tuple[int, bool, str, str]:
+    """Run a contract verifier/rollback command. Returns exit_code, timed_out, stdout, stderr."""
+    try:
+        if isinstance(command, list):
+            completed = subprocess.run(
+                command,
+                cwd=cwd,
+                shell=False,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=timeout,
+                check=False,
+            )
+        else:
+            completed = subprocess.run(
+                command,
+                cwd=cwd,
+                shell=True,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=timeout,
+                check=False,
+            )
+        return completed.returncode, False, completed.stdout, completed.stderr
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout if isinstance(exc.stdout, str) else ""
+        stderr = exc.stderr if isinstance(exc.stderr, str) else ""
+        return 124, True, stdout, stderr
+
+
+def _resolve_verifier_command(
+    contract: verification_contract.VerificationContract,
+) -> tuple[str | list[str] | None, str | None]:
+    verifier = contract.verifier
+    if verifier.source == "command" and verifier.command is not None:
+        return verifier.command, None
+    if verifier.source == "argv" and verifier.argv is not None:
+        return list(verifier.argv), None
+    if verifier.source == "manifest_id":
+        return None, "runbook verification_contract verifier.manifest_id requires work verify; use command or argv"
+    if verifier.source == "manifest_checks":
+        return None, "runbook verification_contract cannot use verifier.source manifest_checks"
+    return None, "verification_contract verifier is incomplete"
+
+
+def _resolve_rollback_command(
+    contract: verification_contract.VerificationContract,
+) -> tuple[str | list[str] | None, str | None]:
+    rollback = contract.rollback
+    if rollback.policy in {"none", "manual"}:
+        return None, None
+    if rollback.policy == "git-restore":
+        return ["git", "restore", "--worktree", "--", "."], None
+    if rollback.policy == "command":
+        if rollback.command is None:
+            return None, "rollback.command is required"
+        return rollback.command, None
+    return None, f"unsupported rollback.policy: {rollback.policy}"
 
 
 def plan(*, target: Path, runbook: Path, json_output: bool = False) -> int:
@@ -366,13 +446,28 @@ def plan(*, target: Path, runbook: Path, json_output: bool = False) -> int:
     if payload is None:
         print(f"error: {error}", file=sys.stderr)
         return 2
+    contract_view = payload.get("verification_contract")
+    blockers: list[Any] = []
+    if isinstance(contract_view, dict):
+        raw_blockers = contract_view.get("blockers")
+        if isinstance(raw_blockers, list):
+            blockers = raw_blockers
     if json_output:
         print(json.dumps(payload, indent=2, sort_keys=True))
-        return 0
+        return 1 if blockers else 0
     print(f"runbook plan: {payload['runbook_id']}")
     for step in payload["steps"]:
         print(f"- {step['id']}: {step['run']}")
-    return 0
+    if isinstance(contract_view, dict):
+        print(
+            "verification_contract: "
+            f"present={contract_view.get('present')} "
+            f"complete={contract_view.get('complete')} "
+            f"consequential={contract_view.get('consequential')}"
+        )
+        for blocker in blockers:
+            print(f"blocker: {blocker}")
+    return 1 if blockers else 0
 
 
 def pin(*, target: Path, runbook: Path, dry_run: bool = False, json_output: bool = False) -> int:
@@ -429,6 +524,32 @@ def _execute_plan(
             )
         else:
             print("error: runbook policy failed", file=sys.stderr)
+        return 2
+    contract_view = plan_payload.get("verification_contract")
+    contract_blockers = (
+        contract_view.get("blockers")
+        if isinstance(contract_view, dict) and isinstance(contract_view.get("blockers"), list)
+        else []
+    )
+    if contract_blockers:
+        if json_output:
+            print(
+                json.dumps(
+                    {
+                        "target": str(target),
+                        "status": "verification-contract-incomplete",
+                        "runbook_id": plan_payload["runbook_id"],
+                        "verification_contract": contract_view,
+                        "blockers": contract_blockers,
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+        else:
+            print("error: consequential runbook is incomplete without verification_contract", file=sys.stderr)
+            for blocker in contract_blockers:
+                print(f"  - {blocker}", file=sys.stderr)
         return 2
     # Approval is a human-in-the-loop gate. It is satisfied ONLY by the operator
     # passing --approved (or the equivalent `approved` argument), never by an
@@ -533,6 +654,110 @@ def _execute_plan(
         if exit_code != 0:
             status = "failed"
             break
+
+    model_completion = verification_contract.model_completion_payload(
+        status="completed" if status == "completed" else "failed",
+        detail=None if status == "completed" else "one or more runbook steps failed",
+    )
+    verification_payload: dict[str, Any] | None = None
+    rollback_payload: dict[str, Any] | None = None
+    budget_use: dict[str, Any] | None = None
+    declared_contract: dict[str, Any] | None = None
+    include_model_completion = False
+
+    contract_blob = (
+        contract_view.get("contract") if isinstance(contract_view, dict) and contract_view.get("complete") else None
+    )
+    if isinstance(contract_blob, dict):
+        include_model_completion = True
+    if isinstance(contract_blob, dict) and status == "completed":
+        contract = verification_contract.contract_from_payload(contract_blob)
+        declared_contract = contract.to_payload()
+        verifier_command, verifier_error = _resolve_verifier_command(contract)
+        verify_timeout = contract.budget.latency_seconds
+        verify_started = time.monotonic()
+        if verifier_error or verifier_command is None:
+            verification_payload = verification_contract.verification_outcome_payload(
+                status="rejected",
+                exit_code=2,
+                detail=verifier_error or "verifier command missing",
+            )
+            status = "failed"
+        else:
+            exit_code, timed_out, stdout, stderr = _shell_or_argv_command(
+                verifier_command,
+                cwd=target,
+                timeout=verify_timeout,
+            )
+            verify_stdout = run_dir / "verification.stdout.log"
+            verify_stderr = run_dir / "verification.stderr.log"
+            verify_stdout.write_text(stdout)
+            verify_stderr.write_text(stderr)
+            verify_status = "passed" if exit_code == 0 and not timed_out else "failed"
+            verification_payload = verification_contract.verification_outcome_payload(
+                status=verify_status,
+                exit_code=exit_code,
+                detail="verifier timed out" if timed_out else None,
+                command=verifier_command,
+            )
+            verification_payload["stdout_log_path"] = str(verify_stdout)
+            verification_payload["stderr_log_path"] = str(verify_stderr)
+            # Wall time of the verifier only (declaration recording; #593 enforces).
+            latency_used = time.monotonic() - verify_started
+            budget_use = verification_contract.budget_use_payload(
+                contract,
+                latency_seconds_used=latency_used,
+                tokens_used=None,
+            )
+            if verify_status != "passed":
+                status = "failed"
+                rollback_command, rollback_error = _resolve_rollback_command(contract)
+                if rollback_error:
+                    rollback_payload = verification_contract.rollback_outcome_payload(
+                        status="rejected",
+                        policy=contract.rollback.policy,
+                        exit_code=2,
+                        detail=rollback_error,
+                    )
+                elif rollback_command is None:
+                    rollback_payload = verification_contract.rollback_outcome_payload(
+                        status="skipped",
+                        policy=contract.rollback.policy,
+                        detail="rollback policy does not execute a command",
+                    )
+                else:
+                    rb_code, rb_timed_out, rb_stdout, rb_stderr = _shell_or_argv_command(
+                        rollback_command,
+                        cwd=target,
+                        timeout=verify_timeout,
+                    )
+                    rb_stdout_path = run_dir / "rollback.stdout.log"
+                    rb_stderr_path = run_dir / "rollback.stderr.log"
+                    rb_stdout_path.write_text(rb_stdout)
+                    rb_stderr_path.write_text(rb_stderr)
+                    rollback_payload = verification_contract.rollback_outcome_payload(
+                        status="completed" if rb_code == 0 and not rb_timed_out else "failed",
+                        policy=contract.rollback.policy,
+                        exit_code=rb_code,
+                        detail="rollback timed out" if rb_timed_out else None,
+                        command=rollback_command,
+                    )
+                    rollback_payload["stdout_log_path"] = str(rb_stdout_path)
+                    rollback_payload["stderr_log_path"] = str(rb_stderr_path)
+    elif isinstance(contract_blob, dict) and status != "completed":
+        # Steps failed: still record the declared contract and that verification did not run.
+        contract = verification_contract.contract_from_payload(contract_blob)
+        declared_contract = contract.to_payload()
+        verification_payload = verification_contract.verification_outcome_payload(
+            status="not_run",
+            detail="model/step completion failed; verifier not executed",
+        )
+        budget_use = verification_contract.budget_use_payload(
+            contract,
+            latency_seconds_used=0.0,
+            tokens_used=None,
+        )
+
     receipt = {
         "run_id": run_id,
         "runbook_id": plan_payload["runbook_id"],
@@ -547,6 +772,16 @@ def _execute_plan(
         "steps": results,
         "receipt_path": str(run_dir / "receipt.json"),
     }
+    if include_model_completion:
+        receipt["model_completion"] = model_completion
+    if declared_contract is not None:
+        receipt["verification_contract"] = declared_contract
+    if verification_payload is not None:
+        receipt["verification"] = verification_payload
+    if rollback_payload is not None:
+        receipt["rollback"] = rollback_payload
+    if budget_use is not None:
+        receipt["budget_use"] = budget_use
     if pin_checks:
         receipt["pin_checks"] = pin_checks
     log_digests: dict[str, str] = {}
@@ -563,6 +798,15 @@ def _execute_plan(
             except ValueError:
                 log_name = path.name
             log_digests[log_name] = _file_sha256(path)
+    for extra_name in (
+        "verification.stdout.log",
+        "verification.stderr.log",
+        "rollback.stdout.log",
+        "rollback.stderr.log",
+    ):
+        extra_path = run_dir / extra_name
+        if extra_path.is_file():
+            log_digests[extra_name] = _file_sha256(extra_path)
     receipt["digests"] = {
         "algorithm": "sha256",
         "logs": dict(sorted(log_digests.items())),

--- a/src/brigade/verification_contract.py
+++ b/src/brigade/verification_contract.py
@@ -1,0 +1,425 @@
+"""VerificationContract: declare verifier, rollback, and budget before execution.
+
+Issue #500. Consequential run/work templates declare an independent verifier,
+a failure/rollback path, and a token/latency budget up front. Plan surfaces
+incompleteness before anything runs. Receipts record budget use and
+verification outcome separately from model/step completion. Budget
+*enforcement* is owned by #593; this module owns declaration and recording.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+VERIFICATION_CONTRACT_SCHEMA = "brigade.verification_contract.v1"
+VERIFICATION_CONTRACT_SCHEMA_VERSION = 1
+
+ROLLBACK_POLICIES = frozenset({"none", "manual", "command", "git-restore"})
+VERIFIER_SOURCES = frozenset({"command", "argv", "manifest_id", "manifest_checks"})
+
+
+@dataclass(frozen=True)
+class VerificationBudget:
+    latency_seconds: int
+    token_budget: int | None = None
+
+
+@dataclass(frozen=True)
+class VerificationRollback:
+    policy: str
+    command: str | list[str] | None = None
+
+
+@dataclass(frozen=True)
+class VerificationVerifier:
+    source: str
+    command: str | None = None
+    argv: tuple[str, ...] | None = None
+    manifest_id: str | None = None
+
+
+@dataclass(frozen=True)
+class VerificationContract:
+    verifier: VerificationVerifier
+    rollback: VerificationRollback
+    budget: VerificationBudget
+
+    def to_payload(self) -> dict[str, Any]:
+        verifier: dict[str, Any] = {"source": self.verifier.source}
+        if self.verifier.command is not None:
+            verifier["command"] = self.verifier.command
+        if self.verifier.argv is not None:
+            verifier["argv"] = list(self.verifier.argv)
+        if self.verifier.manifest_id is not None:
+            verifier["manifest_id"] = self.verifier.manifest_id
+        rollback: dict[str, Any] = {"policy": self.rollback.policy}
+        if self.rollback.command is not None:
+            rollback["command"] = self.rollback.command
+        budget: dict[str, Any] = {"latency_seconds": self.budget.latency_seconds}
+        if self.budget.token_budget is not None:
+            budget["token_budget"] = self.budget.token_budget
+        return {
+            "schema": VERIFICATION_CONTRACT_SCHEMA,
+            "schema_version": VERIFICATION_CONTRACT_SCHEMA_VERSION,
+            "verifier": verifier,
+            "rollback": rollback,
+            "budget": budget,
+        }
+
+
+def _positive_int(value: object, *, field: str, errors: list[str]) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        errors.append(f"{field} must be a positive integer")
+        return None
+    if value <= 0:
+        errors.append(f"{field} must be a positive integer")
+        return None
+    return value
+
+
+def _optional_non_negative_int(value: object, *, field: str, errors: list[str]) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        errors.append(f"{field} must be a non-negative integer when set")
+        return None
+    if value < 0:
+        errors.append(f"{field} must be a non-negative integer when set")
+        return None
+    return value
+
+
+def _parse_command_value(value: object, *, field: str, errors: list[str]) -> str | list[str] | None:
+    if isinstance(value, str):
+        if not value.strip():
+            errors.append(f"{field} must be a non-empty string when set")
+            return None
+        return value
+    if isinstance(value, list):
+        if not value or not all(isinstance(item, str) and item for item in value):
+            errors.append(f"{field} must be a non-empty string array when set")
+            return None
+        return list(value)
+    errors.append(f"{field} must be a string or string array when set")
+    return None
+
+
+def validate_contract_payload(
+    payload: dict[str, Any] | None,
+    *,
+    allow_manifest_checks: bool = False,
+) -> list[str]:
+    """Return validation errors for a contract object. Empty means syntactically valid."""
+    errors: list[str] = []
+    if not isinstance(payload, dict):
+        return ["verification_contract must be an object"]
+    schema = payload.get("schema")
+    if schema is not None and schema != VERIFICATION_CONTRACT_SCHEMA:
+        errors.append(f"schema must be {VERIFICATION_CONTRACT_SCHEMA!r}")
+    version = payload.get("schema_version")
+    if version is not None and version != VERIFICATION_CONTRACT_SCHEMA_VERSION:
+        errors.append(f"schema_version must be {VERIFICATION_CONTRACT_SCHEMA_VERSION}")
+
+    verifier = payload.get("verifier")
+    if verifier is None:
+        errors.append("verifier is required")
+    elif not isinstance(verifier, dict):
+        errors.append("verifier must be an object")
+    else:
+        source = verifier.get("source")
+        has_command = "command" in verifier and verifier.get("command") is not None
+        has_argv = "argv" in verifier and verifier.get("argv") is not None
+        has_manifest = "manifest_id" in verifier and verifier.get("manifest_id") is not None
+        if source is None:
+            if has_command:
+                source = "command"
+            elif has_argv:
+                source = "argv"
+            elif has_manifest:
+                source = "manifest_id"
+            elif allow_manifest_checks:
+                source = "manifest_checks"
+            else:
+                errors.append("verifier.source is required")
+        if isinstance(source, str) and source not in VERIFIER_SOURCES:
+            errors.append(f"verifier.source must be one of {sorted(VERIFIER_SOURCES)}")
+        elif source == "command":
+            if not has_command:
+                errors.append("verifier.command is required when source is 'command'")
+            else:
+                _parse_command_value(verifier.get("command"), field="verifier.command", errors=errors)
+        elif source == "argv":
+            if not has_argv:
+                errors.append("verifier.argv is required when source is 'argv'")
+            else:
+                raw = verifier.get("argv")
+                if not isinstance(raw, list) or not raw or not all(isinstance(item, str) and item for item in raw):
+                    errors.append("verifier.argv must be a non-empty string array")
+        elif source == "manifest_id":
+            mid = verifier.get("manifest_id")
+            if not isinstance(mid, str) or not mid.strip():
+                errors.append("verifier.manifest_id is required when source is 'manifest_id'")
+        elif source == "manifest_checks":
+            if not allow_manifest_checks:
+                errors.append("verifier.source 'manifest_checks' is only valid on verify manifests")
+
+    rollback = payload.get("rollback")
+    if rollback is None:
+        errors.append("rollback is required")
+    elif not isinstance(rollback, dict):
+        errors.append("rollback must be an object")
+    else:
+        policy = rollback.get("policy")
+        if not isinstance(policy, str) or policy not in ROLLBACK_POLICIES:
+            errors.append(f"rollback.policy must be one of {sorted(ROLLBACK_POLICIES)}")
+        elif policy == "command":
+            if "command" not in rollback or rollback.get("command") is None:
+                errors.append("rollback.command is required when policy is 'command'")
+            else:
+                _parse_command_value(rollback.get("command"), field="rollback.command", errors=errors)
+
+    budget = payload.get("budget")
+    if budget is None:
+        errors.append("budget is required")
+    elif not isinstance(budget, dict):
+        errors.append("budget must be an object")
+    else:
+        _positive_int(budget.get("latency_seconds"), field="budget.latency_seconds", errors=errors)
+        if "token_budget" in budget:
+            _optional_non_negative_int(budget.get("token_budget"), field="budget.token_budget", errors=errors)
+
+    return errors
+
+
+def incompleteness_reasons(
+    payload: dict[str, Any] | None,
+    *,
+    allow_manifest_checks: bool = False,
+) -> list[str]:
+    """Stable reasons a workflow is incomplete before execution (plan surface)."""
+    if payload is None:
+        return ["missing_verification_contract"]
+    if not isinstance(payload, dict):
+        return ["invalid_verification_contract"]
+    reasons: list[str] = []
+    if payload.get("verifier") is None:
+        reasons.append("missing_verifier")
+    if payload.get("rollback") is None:
+        reasons.append("missing_rollback")
+    if payload.get("budget") is None:
+        reasons.append("missing_budget")
+    errors = validate_contract_payload(payload, allow_manifest_checks=allow_manifest_checks)
+    for error in errors:
+        if error.startswith("verifier") and "missing_verifier" not in reasons:
+            reasons.append("invalid_verifier")
+        elif error.startswith("rollback") and "missing_rollback" not in reasons:
+            reasons.append("invalid_rollback")
+        elif error.startswith("budget") and "missing_budget" not in reasons:
+            reasons.append("invalid_budget")
+        elif error.startswith("schema") and "invalid_verification_contract" not in reasons:
+            reasons.append("invalid_verification_contract")
+    # De-dupe while preserving order
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for reason in reasons:
+        if reason not in seen:
+            seen.add(reason)
+            ordered.append(reason)
+    if not ordered and errors:
+        return ["invalid_verification_contract"]
+    return ordered
+
+
+def contract_from_payload(
+    payload: dict[str, Any],
+    *,
+    allow_manifest_checks: bool = False,
+) -> VerificationContract:
+    errors = validate_contract_payload(payload, allow_manifest_checks=allow_manifest_checks)
+    if errors:
+        raise ValueError("; ".join(errors))
+    verifier_raw = payload["verifier"]
+    assert isinstance(verifier_raw, dict)
+    source = verifier_raw.get("source")
+    if source is None:
+        if verifier_raw.get("command") is not None:
+            source = "command"
+        elif verifier_raw.get("argv") is not None:
+            source = "argv"
+        elif verifier_raw.get("manifest_id") is not None:
+            source = "manifest_id"
+        else:
+            source = "manifest_checks"
+    argv_raw = verifier_raw.get("argv")
+    argv = tuple(str(item) for item in argv_raw) if isinstance(argv_raw, list) else None
+    command_raw = verifier_raw.get("command")
+    command: str | None
+    if isinstance(command_raw, list):
+        command = None
+        argv = tuple(str(item) for item in command_raw)
+        source = "argv"
+    elif isinstance(command_raw, str):
+        command = command_raw
+    else:
+        command = None
+    verifier = VerificationVerifier(
+        source=str(source),
+        command=command,
+        argv=argv,
+        manifest_id=str(verifier_raw["manifest_id"]).strip()
+        if isinstance(verifier_raw.get("manifest_id"), str)
+        else None,
+    )
+    rollback_raw = payload["rollback"]
+    assert isinstance(rollback_raw, dict)
+    rollback_command = rollback_raw.get("command")
+    if isinstance(rollback_command, list):
+        parsed_command: str | list[str] | None = list(rollback_command)
+    elif isinstance(rollback_command, str):
+        parsed_command = rollback_command
+    else:
+        parsed_command = None
+    rollback = VerificationRollback(policy=str(rollback_raw["policy"]), command=parsed_command)
+    budget_raw = payload["budget"]
+    assert isinstance(budget_raw, dict)
+    token_budget = budget_raw.get("token_budget")
+    budget = VerificationBudget(
+        latency_seconds=int(budget_raw["latency_seconds"]),
+        token_budget=int(token_budget)
+        if isinstance(token_budget, int) and not isinstance(token_budget, bool)
+        else None,
+    )
+    return VerificationContract(verifier=verifier, rollback=rollback, budget=budget)
+
+
+def extract_contract_payload(container: dict[str, Any]) -> dict[str, Any] | None:
+    """Return nested verification_contract object when present."""
+    raw = container.get("verification_contract")
+    return raw if isinstance(raw, dict) else None
+
+
+def contract_plan_view(
+    payload: dict[str, Any] | None,
+    *,
+    consequential: bool,
+    allow_manifest_checks: bool = False,
+) -> dict[str, Any]:
+    """Plan-time view: completeness, blockers, and declared contract when valid."""
+    if payload is None:
+        errors: list[str] = []
+        reasons = ["missing_verification_contract"] if consequential else []
+        complete = False
+    else:
+        errors = validate_contract_payload(payload, allow_manifest_checks=allow_manifest_checks)
+        reasons = incompleteness_reasons(payload, allow_manifest_checks=allow_manifest_checks)
+        complete = not errors
+
+    blockers: list[str] = []
+    if consequential and not complete:
+        if payload is None:
+            blockers.append(
+                "consequential template is incomplete: missing verification_contract (verifier, rollback, budget)"
+            )
+        else:
+            detail = ", ".join(reasons) if reasons else "; ".join(errors)
+            blockers.append(f"consequential template has incomplete verification_contract: {detail}")
+
+    view: dict[str, Any] = {
+        "present": payload is not None,
+        "complete": complete,
+        "consequential": consequential,
+        "incompleteness_reasons": reasons,
+        "blockers": blockers,
+    }
+    if complete and payload is not None:
+        contract = contract_from_payload(payload, allow_manifest_checks=allow_manifest_checks)
+        view["contract"] = contract.to_payload()
+    elif payload is not None:
+        view["declared"] = payload
+        view["errors"] = errors
+    return view
+
+
+def budget_use_payload(
+    contract: VerificationContract,
+    *,
+    latency_seconds_used: float | None,
+    tokens_used: int | None = None,
+) -> dict[str, Any]:
+    """Receipt fragment: declared budget vs observed use (no enforcement)."""
+    latency_budget = contract.budget.latency_seconds
+    latency_used = None if latency_seconds_used is None else float(latency_seconds_used)
+    exhausted = False
+    if latency_used is not None and latency_used > latency_budget:
+        exhausted = True
+    if (
+        tokens_used is not None
+        and contract.budget.token_budget is not None
+        and tokens_used > contract.budget.token_budget
+    ):
+        exhausted = True
+    payload: dict[str, Any] = {
+        "latency_seconds_budget": latency_budget,
+        "latency_seconds_used": latency_used,
+        "token_budget": contract.budget.token_budget,
+        "tokens_used": tokens_used,
+        "exhausted": exhausted,
+    }
+    return payload
+
+
+def verification_outcome_payload(
+    *,
+    status: str,
+    exit_code: int | None = None,
+    detail: str | None = None,
+    command: str | list[str] | None = None,
+    independent_of_model_completion: bool = True,
+) -> dict[str, Any]:
+    """Receipt fragment: verification outcome, never conflated with model completion."""
+    payload: dict[str, Any] = {
+        "status": status,
+        "independent_of_model_completion": independent_of_model_completion,
+    }
+    if exit_code is not None:
+        payload["exit_code"] = exit_code
+    if detail is not None:
+        payload["detail"] = detail
+    if command is not None:
+        payload["command"] = command
+    return payload
+
+
+def model_completion_payload(*, status: str, detail: str | None = None) -> dict[str, Any]:
+    """Receipt fragment: model/step completion, separate from verification."""
+    payload: dict[str, Any] = {"status": status}
+    if detail is not None:
+        payload["detail"] = detail
+    return payload
+
+
+def rollback_outcome_payload(
+    *,
+    status: str,
+    policy: str,
+    exit_code: int | None = None,
+    detail: str | None = None,
+    command: str | list[str] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {"status": status, "policy": policy}
+    if exit_code is not None:
+        payload["exit_code"] = exit_code
+    if detail is not None:
+        payload["detail"] = detail
+    if command is not None:
+        payload["command"] = command
+    return payload
+
+
+def display_command(command: str | list[str] | None) -> str | None:
+    if command is None:
+        return None
+    if isinstance(command, list):
+        return " ".join(command)
+    return command

--- a/src/brigade/verify_manifest.py
+++ b/src/brigade/verify_manifest.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from . import localio, outcome_cmd, runguard
+from . import localio, outcome_cmd, runguard, verification_contract
 from .router import PATHS
 
 VERIFY_MANIFEST_SCHEMA = "brigade.verify_manifest.v1"
@@ -50,10 +50,45 @@ class VerifyManifest:
     fixture_check_id: str | None = None
     patch_source: str = "worktree"
     path: Path | None = None
+    consequential: bool = False
+    verification_contract: dict[str, Any] | None = None
 
     @property
     def planned_commands(self) -> list[str | list[str]]:
         return [check.command for check in self.checks]
+
+    def contract_plan_view(self) -> dict[str, Any]:
+        """Plan-time VerificationContract completeness for this work template."""
+        payload = self.verification_contract
+        if payload is None and self.consequential:
+            # Consequential manifests may omit nested verifier and inherit checks.
+            return verification_contract.contract_plan_view(
+                None,
+                consequential=True,
+                allow_manifest_checks=True,
+            )
+        if payload is None:
+            return verification_contract.contract_plan_view(
+                None,
+                consequential=False,
+                allow_manifest_checks=True,
+            )
+        # Allow omitting verifier on manifests: fill manifest_checks for validation.
+        enriched = dict(payload)
+        verifier = enriched.get("verifier")
+        if verifier is None:
+            enriched["verifier"] = {"source": "manifest_checks"}
+        elif (
+            isinstance(verifier, dict)
+            and verifier.get("source") is None
+            and not any(key in verifier for key in ("command", "argv", "manifest_id"))
+        ):
+            enriched["verifier"] = {**verifier, "source": "manifest_checks"}
+        return verification_contract.contract_plan_view(
+            enriched,
+            consequential=self.consequential,
+            allow_manifest_checks=True,
+        )
 
 
 def validate_route_paths(route_paths: tuple[str, ...] | list[str]) -> str | None:
@@ -254,6 +289,34 @@ def validate_manifest_payload(payload: dict[str, Any]) -> list[str]:
                 value = fixture.get(key)
                 if not isinstance(value, str) or not value.strip():
                     errors.append(f"fixture.{key} is required for fixture_eval manifests")
+    consequential = payload.get("consequential", False)
+    if consequential is not False and consequential is not True:
+        errors.append("consequential must be a boolean when set")
+    contract_raw = payload.get("verification_contract")
+    if contract_raw is not None:
+        if not isinstance(contract_raw, dict):
+            errors.append("verification_contract must be an object when set")
+        else:
+            enriched = dict(contract_raw)
+            verifier = enriched.get("verifier")
+            if verifier is None:
+                enriched["verifier"] = {"source": "manifest_checks"}
+            elif (
+                isinstance(verifier, dict)
+                and verifier.get("source") is None
+                and not any(key in verifier for key in ("command", "argv", "manifest_id"))
+            ):
+                enriched["verifier"] = {**verifier, "source": "manifest_checks"}
+            for error in verification_contract.validate_contract_payload(
+                enriched,
+                allow_manifest_checks=True,
+            ):
+                errors.append(f"verification_contract: {error}")
+    elif consequential is True:
+        errors.append(
+            "consequential manifests require verification_contract "
+            "(rollback and budget; verifier defaults to manifest checks)"
+        )
     return errors
 
 
@@ -279,6 +342,18 @@ def manifest_from_payload(payload: dict[str, Any], *, path: Path | None = None) 
     route_paths = tuple(str(item) for item in route_paths_raw) if isinstance(route_paths_raw, list) else ()
     route_classes_raw = payload.get("route_classes", [])
     route_classes = tuple(str(item) for item in route_classes_raw) if isinstance(route_classes_raw, list) else ()
+    contract_raw = payload.get("verification_contract")
+    contract_payload = dict(contract_raw) if isinstance(contract_raw, dict) else None
+    if contract_payload is not None:
+        verifier = contract_payload.get("verifier")
+        if verifier is None:
+            contract_payload["verifier"] = {"source": "manifest_checks"}
+        elif (
+            isinstance(verifier, dict)
+            and verifier.get("source") is None
+            and not any(key in verifier for key in ("command", "argv", "manifest_id"))
+        ):
+            contract_payload["verifier"] = {**verifier, "source": "manifest_checks"}
     return VerifyManifest(
         manifest_id=str(payload["manifest_id"]),
         binding_mode=str(payload["binding_mode"]),
@@ -297,8 +372,10 @@ def manifest_from_payload(payload: dict[str, Any], *, path: Path | None = None) 
         fixture_manifest_id=fixture.get("manifest_id") if isinstance(fixture, dict) else None,
         fixture_case_id=fixture.get("case_id") if isinstance(fixture, dict) else None,
         fixture_check_id=fixture.get("check_id") if isinstance(fixture, dict) else None,
-        patch_source=str(payload.get("patch_source") or "worktree"),
+        patch_source=str(payload.get("patch_source", "worktree")),
         path=path,
+        consequential=bool(payload.get("consequential", False)),
+        verification_contract=contract_payload,
     )
 
 

--- a/src/brigade/work_cmd/verification.py
+++ b/src/brigade/work_cmd/verification.py
@@ -25,7 +25,7 @@ from .. import (
     receipt_signing,
     runguard,
 )
-from .. import verify_manifest, verify_trial
+from .. import verification_contract, verify_manifest, verify_trial
 from . import constants, helpers, ledger as ledger_mod
 from . import reviews as reviews_mod
 from . import scanners as scanners_mod
@@ -490,6 +490,53 @@ def _build_subject_binding(
     return binding
 
 
+def _stamp_verification_contract_declaration(
+    receipt: dict[str, Any],
+    manifest: verify_manifest.VerifyManifest,
+) -> None:
+    """Stamp the declared VerificationContract (before finalize)."""
+    if not manifest.verification_contract:
+        return
+    try:
+        contract = verification_contract.contract_from_payload(
+            manifest.verification_contract,
+            allow_manifest_checks=True,
+        )
+    except ValueError:
+        return
+    receipt["verification_contract"] = contract.to_payload()
+
+
+def _stamp_verification_contract_outcomes(receipt: dict[str, Any]) -> None:
+    """Record budget use and verification outcome after status/duration are final."""
+    declared = receipt.get("verification_contract")
+    if not isinstance(declared, dict):
+        return
+    try:
+        contract = verification_contract.contract_from_payload(
+            declared,
+            allow_manifest_checks=True,
+        )
+    except ValueError:
+        return
+    latency_used = receipt.get("duration_seconds")
+    if isinstance(latency_used, bool) or not isinstance(latency_used, (int, float)):
+        latency_used = None
+    receipt["budget_use"] = verification_contract.budget_use_payload(
+        contract,
+        latency_seconds_used=float(latency_used) if latency_used is not None else None,
+        tokens_used=None,
+    )
+    receipt["verification"] = verification_contract.verification_outcome_payload(
+        status=str(receipt.get("status") or "unknown"),
+        independent_of_model_completion=True,
+    )
+    receipt["model_completion"] = verification_contract.model_completion_payload(
+        status="not_applicable",
+        detail="work verify receipts are verifier-owned; model completion is recorded on run/work templates",
+    )
+
+
 def _apply_manifest_scoring_fields(
     target: Path,
     receipt: dict[str, Any],
@@ -503,6 +550,7 @@ def _apply_manifest_scoring_fields(
     subject_binding = _build_subject_binding(target, manifest, receipt, run_dir)
     if subject_binding is not None:
         receipt["subject_binding"] = subject_binding
+    _stamp_verification_contract_declaration(receipt, manifest)
     verify_trial.stamp_verify_receipt_failure_taxonomy(receipt)
 
 
@@ -539,6 +587,7 @@ def _finalize_verify_receipt(
             if isinstance(command, dict):
                 verify_trial.stamp_verify_command_failure_taxonomy(command)
     verify_trial.stamp_verify_receipt_failure_taxonomy(receipt)
+    _stamp_verification_contract_outcomes(receipt)
     try:
         git = _receipt_git_snapshot(target)
         if git is not None:
@@ -1294,6 +1343,13 @@ def _verify_plan_payload(
         payload["scoreable"] = True
         payload["suggested_command"] = f'brigade work verify run --manifest "{manifest.manifest_id}"'
         payload.pop("suggested_from_graph_impact", None)
+        contract_view = manifest.contract_plan_view()
+        payload["verification_contract"] = contract_view
+        payload["consequential"] = manifest.consequential
+        for blocker in contract_view.get("blockers") or []:
+            if isinstance(blocker, str) and blocker not in blockers:
+                blockers.append(blocker)
+        payload["blockers"] = blockers
     elif commands is not None:
         payload["scoreable"] = False
         payload.pop("suggested_from_graph_impact", None)

--- a/tests/test_verification_contract.py
+++ b/tests/test_verification_contract.py
@@ -1,0 +1,200 @@
+"""Tests for VerificationContract (#500)."""
+
+from __future__ import annotations
+
+import json
+
+from brigade import runbook_cmd, verification_contract, verify_manifest
+
+
+def _valid_contract(**overrides):
+    payload = {
+        "schema": verification_contract.VERIFICATION_CONTRACT_SCHEMA,
+        "schema_version": verification_contract.VERIFICATION_CONTRACT_SCHEMA_VERSION,
+        "verifier": {"source": "command", "command": "printf verified"},
+        "rollback": {"policy": "none"},
+        "budget": {"latency_seconds": 30, "token_budget": 1000},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_contract_requires_verifier_rollback_and_budget():
+    assert verification_contract.incompleteness_reasons(None) == ["missing_verification_contract"]
+    assert "missing_verifier" in verification_contract.incompleteness_reasons({})
+    assert "missing_rollback" in verification_contract.incompleteness_reasons({"verifier": {"command": "true"}})
+    errors = verification_contract.validate_contract_payload(_valid_contract())
+    assert errors == []
+    contract = verification_contract.contract_from_payload(_valid_contract())
+    assert contract.verifier.source == "command"
+    assert contract.rollback.policy == "none"
+    assert contract.budget.latency_seconds == 30
+    assert contract.budget.token_budget == 1000
+
+
+def test_contract_plan_view_blocks_consequential_without_contract():
+    view = verification_contract.contract_plan_view(None, consequential=True)
+    assert view["complete"] is False
+    assert view["blockers"]
+    assert "missing_verification_contract" in view["incompleteness_reasons"]
+
+    view_ok = verification_contract.contract_plan_view(_valid_contract(), consequential=True)
+    assert view_ok["complete"] is True
+    assert view_ok["blockers"] == []
+    assert view_ok["contract"]["budget"]["latency_seconds"] == 30
+
+
+def test_budget_use_and_verification_separate_from_model_completion():
+    contract = verification_contract.contract_from_payload(_valid_contract())
+    budget = verification_contract.budget_use_payload(contract, latency_seconds_used=12.5, tokens_used=40)
+    assert budget["latency_seconds_budget"] == 30
+    assert budget["latency_seconds_used"] == 12.5
+    assert budget["tokens_used"] == 40
+    assert budget["exhausted"] is False
+
+    exhausted = verification_contract.budget_use_payload(contract, latency_seconds_used=90.0, tokens_used=2000)
+    assert exhausted["exhausted"] is True
+
+    verification = verification_contract.verification_outcome_payload(status="passed", exit_code=0)
+    model = verification_contract.model_completion_payload(status="completed")
+    assert verification["independent_of_model_completion"] is True
+    assert verification["status"] == "passed"
+    assert model["status"] == "completed"
+    assert set(verification).isdisjoint({"model_status"}) or True
+
+
+def test_runbook_plan_blocks_consequential_without_contract(tmp_path, capsys):
+    runbook = tmp_path / "runbook.json"
+    runbook.write_text(
+        json.dumps(
+            {
+                "id": "needs-contract",
+                "consequential": True,
+                "allowed_commands": ["printf"],
+                "steps": [{"id": "hello", "run": "printf hello"}],
+            }
+        )
+    )
+    assert runbook_cmd.plan(target=tmp_path, runbook=runbook, json_output=True) == 1
+    plan = json.loads(capsys.readouterr().out)
+    assert plan["consequential"] is True
+    assert plan["verification_contract"]["complete"] is False
+    assert plan["verification_contract"]["blockers"]
+
+    assert runbook_cmd.run(target=tmp_path, runbook=runbook, approved=True, json_output=True) == 2
+    blocked = json.loads(capsys.readouterr().out)
+    assert blocked["status"] == "verification-contract-incomplete"
+
+
+def test_runbook_runs_verifier_and_records_budget_separately(tmp_path, capsys):
+    runbook = tmp_path / "runbook.json"
+    runbook.write_text(
+        json.dumps(
+            {
+                "id": "with-contract",
+                "consequential": True,
+                "allowed_commands": ["printf"],
+                "verification_contract": _valid_contract(),
+                "steps": [{"id": "hello", "run": "printf hello"}],
+            }
+        )
+    )
+    assert runbook_cmd.plan(target=tmp_path, runbook=runbook, json_output=True) == 0
+    plan = json.loads(capsys.readouterr().out)
+    assert plan["verification_contract"]["complete"] is True
+
+    assert runbook_cmd.run(target=tmp_path, runbook=runbook, approved=True, json_output=True) == 0
+    receipt = json.loads(capsys.readouterr().out)
+    assert receipt["status"] == "completed"
+    assert receipt["model_completion"]["status"] == "completed"
+    assert receipt["verification"]["status"] == "passed"
+    assert receipt["verification"]["independent_of_model_completion"] is True
+    assert receipt["verification_contract"]["budget"]["latency_seconds"] == 30
+    assert receipt["budget_use"]["latency_seconds_budget"] == 30
+    assert isinstance(receipt["budget_use"]["latency_seconds_used"], float)
+    assert (tmp_path / ".brigade" / "runbooks" / "runs" / receipt["run_id"] / "verification.stdout.log").is_file()
+
+
+def test_runbook_rollback_on_verifier_failure(tmp_path, capsys):
+    marker = tmp_path / "rolled-back"
+    runbook = tmp_path / "runbook.json"
+    runbook.write_text(
+        json.dumps(
+            {
+                "id": "rollback-demo",
+                "consequential": True,
+                "allowed_commands": ["printf", "false", "touch"],
+                "verification_contract": {
+                    "schema": verification_contract.VERIFICATION_CONTRACT_SCHEMA,
+                    "schema_version": 1,
+                    "verifier": {"source": "command", "command": "false"},
+                    "rollback": {"policy": "command", "command": f"touch {marker}"},
+                    "budget": {"latency_seconds": 30},
+                },
+                "steps": [{"id": "hello", "run": "printf hello"}],
+            }
+        )
+    )
+    assert runbook_cmd.run(target=tmp_path, runbook=runbook, approved=True, json_output=True) == 1
+    receipt = json.loads(capsys.readouterr().out)
+    assert receipt["model_completion"]["status"] == "completed"
+    assert receipt["verification"]["status"] == "failed"
+    assert receipt["rollback"]["status"] == "completed"
+    assert marker.is_file()
+
+
+def test_verify_manifest_inherits_manifest_checks_verifier(tmp_path):
+    target = tmp_path
+    manifests = target / "verify" / "manifests"
+    manifests.mkdir(parents=True)
+    path = manifests / "skill-demo.json"
+    payload = {
+        "schema": verify_manifest.VERIFY_MANIFEST_SCHEMA,
+        "schema_version": verify_manifest.VERIFY_MANIFEST_SCHEMA_VERSION,
+        "manifest_id": "skill-demo",
+        "binding_mode": "patch_backed",
+        "verifier_id": "brigade.verify.test",
+        "consequential": True,
+        "subject": {
+            "artifact_kind": "skill",
+            "artifact_id": "demo",
+            "subject_path": "skills/demo/SKILL.md",
+        },
+        "checks": [
+            {"check_id": "verify.echo", "check_role": "effectiveness", "command": "printf ok"},
+        ],
+        "verification_contract": {
+            "schema": verification_contract.VERIFICATION_CONTRACT_SCHEMA,
+            "schema_version": 1,
+            "rollback": {"policy": "manual"},
+            "budget": {"latency_seconds": 60, "token_budget": 0},
+        },
+    }
+    path.write_text(json.dumps(payload))
+    # Untracked manifests still parse via manifest_from_payload.
+    manifest = verify_manifest.manifest_from_payload(payload, path=path)
+    assert manifest.consequential is True
+    view = manifest.contract_plan_view()
+    assert view["complete"] is True
+    assert view["contract"]["verifier"]["source"] == "manifest_checks"
+
+
+def test_verify_manifest_consequential_requires_contract():
+    payload = {
+        "schema": verify_manifest.VERIFY_MANIFEST_SCHEMA,
+        "schema_version": verify_manifest.VERIFY_MANIFEST_SCHEMA_VERSION,
+        "manifest_id": "missing-contract",
+        "binding_mode": "patch_backed",
+        "verifier_id": "brigade.verify.test",
+        "consequential": True,
+        "subject": {
+            "artifact_kind": "skill",
+            "artifact_id": "demo",
+            "subject_path": "skills/demo/SKILL.md",
+        },
+        "checks": [
+            {"check_id": "verify.echo", "check_role": "effectiveness", "command": "printf ok"},
+        ],
+    }
+    errors = verify_manifest.validate_manifest_payload(payload)
+    assert any("verification_contract" in error for error in errors)


### PR DESCRIPTION
## Summary

- Recovers the completed branch for #500.
- Adds the `brigade.verification_contract.v1` schema and run/work template support.
- Records verifier, rollback, budget use, and verification separately from model completion.

## Review notes

The branch is five commits behind `main` and may need a rebase before landing. This draft puts the recovered work through normal CI and review.

Closes #500