### PR TITLE
fix(git): section-aware changelog merge (supersedes #828)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md merge=union

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-CHANGELOG.md merge=union
+CHANGELOG.md merge=changelog-unreleased

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,8 @@ Thumbs.db
 !/scripts/generate_component_manifest.py
 !/scripts/verify_version_check_endpoint.py
 !/scripts/hyper-v-native-acceptance.ps1
+!/scripts/git_merge_changelog_unreleased.py
+!/scripts/configure_changelog_merge_driver.sh
 /skills/
 
 # Local plan/spec scratch dirs only. Reviewed planning artifacts ARE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Contributor changelog merges use a section-aware Git merge driver that unions `[Unreleased]` bullets while still conflicting on released sections; configure with `./scripts/configure_changelog_merge_driver.sh` (see CONTRIBUTING.md).
+
 ### Added
 - `brigade center serve` gains work-graph views over existing `--json` contracts:
   an SVG ready/blocked dependency graph, parallel-safe dispatch-wave swim-lanes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,19 @@ Those CLI fields do not expose unresolved review conversations. Separately check
 
 Dispatched sessions should open the pull request, run local verification, and push commits. After the final push, comment `@coderabbitai full review`. The `coderabbitai[bot]` identity records the formal GitHub review. Wait for its current `APPROVED` review before merging. A green CodeRabbit commit status alone does not satisfy this gate.
 
+## Changelog
+
+`CHANGELOG.md` uses Git's `merge=union` driver so parallel pull requests can each append an
+`[Unreleased]` bullet without manual conflict resolution. Union merge keeps every added line
+from both sides; it only conflicts when one side deletes or rewrites content the other left
+alone. Write each entry as a single self-contained line (issue reference, user-visible
+effect, no commit-subject phrasing). Do not wrap entries across multiple lines or edit
+released sections in feature branches — multi-line bullets can interleave badly, and edits
+outside `[Unreleased]` still conflict normally. Prefer an existing subsection (`Added`,
+`Changed`, `Fixed`, …) under `[Unreleased]`; if two branches both introduce the same
+subsection header, union merge folds their bullets under one header (maintainers may reorder
+for readability after merge).
+
 ## Adding a harness
 
 A harness is a manifest under `src/brigade/templates/harnesses/<id>.json` plus any template files it references. The manifest declares `role: "writer"` (gets an inbox) or `role: "reader"` (gets adapter fragments).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,16 +77,40 @@ Dispatched sessions should open the pull request, run local verification, and pu
 
 ## Changelog
 
-`CHANGELOG.md` uses Git's `merge=union` driver so parallel pull requests can each append an
-`[Unreleased]` bullet without manual conflict resolution. Union merge keeps every added line
-from both sides; it only conflicts when one side deletes or rewrites content the other left
-alone. Write each entry as a single self-contained line (issue reference, user-visible
-effect, no commit-subject phrasing). Do not wrap entries across multiple lines or edit
-released sections in feature branches — multi-line bullets can interleave badly, and edits
-outside `[Unreleased]` still conflict normally. Prefer an existing subsection (`Added`,
-`Changed`, `Fixed`, …) under `[Unreleased]`; if two branches both introduce the same
-subsection header, union merge folds their bullets under one header (maintainers may reorder
-for readability after merge).
+Parallel pull requests often append one bullet under `[Unreleased]`. Whole-file
+`merge=union` would auto-keep **every** conflicting line in `CHANGELOG.md`,
+including edits to released/versioned sections, which is unsafe for a public
+changelog. This repository instead uses a **section-aware** merge driver:
+
+| Region | Behavior |
+|---|---|
+| `## [Unreleased]` (and its `###` subsections) | Union of bullets; parallel new subsections with the same name fold into one |
+| Preamble and every released `## [x.y.z]` section | Strict 3-way region merge — diverging edits conflict |
+
+Wire the driver once per clone (not inherited from the remote):
+
+```bash
+./scripts/configure_changelog_merge_driver.sh
+```
+
+That registers `merge.changelog-unreleased` so local `git merge` / `git pull`
+use `scripts/git_merge_changelog_unreleased.py`. `.gitattributes` names the
+driver; without local config Git falls back to the default text merge (conflicts
+everywhere, including Unreleased), which is the safe failure mode.
+
+**Limits (read these):**
+
+- GitHub's server-side merge button does **not** run custom merge drivers. PR
+  merges on github.com still conflict on overlapping Unreleased edits; resolve
+  locally with the driver configured, or resolve the conflict markers by hand.
+- Write each Unreleased entry as a **single self-contained line** (issue
+  reference, user-visible effect, no commit-subject phrasing). Multi-line
+  bullets can still interleave badly under union.
+- Prefer an existing subsection (`Added`, `Changed`, `Fixed`, …). The driver
+  folds parallel same-named subsections; maintainers may still reorder for
+  readability after merge.
+- Do not edit released sections in feature branches. If you must, expect a
+  real conflict — that is intentional.
 
 ## Adding a harness
 

--- a/scripts/configure_changelog_merge_driver.sh
+++ b/scripts/configure_changelog_merge_driver.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Register the Keep-a-Changelog Unreleased merge driver for this clone.
+# Safe to re-run. See CONTRIBUTING.md (Changelog).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+git config merge.changelog-unreleased.name \
+  "Union-merge CHANGELOG [Unreleased]; conflict released sections"
+git config merge.changelog-unreleased.driver \
+  "python3 scripts/git_merge_changelog_unreleased.py %O %A %B"
+
+echo "Configured merge.changelog-unreleased for $(pwd)"

--- a/scripts/git_merge_changelog_unreleased.py
+++ b/scripts/git_merge_changelog_unreleased.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Git merge driver for Keep-a-Changelog files.
+
+Union-merge only the ``## [Unreleased]`` section (subsection-aware). Everything
+else — preamble and released/versioned sections — uses a strict region merge that
+conflicts when both sides diverge from the base. That avoids the silent
+corruption risk of whole-file ``merge=union``.
+
+Git invokes this as::
+
+    python3 scripts/git_merge_changelog_unreleased.py %O %A %B
+
+``%A`` is overwritten with the merge result. Exit 0 on a clean merge, 1 when
+conflict markers were written (or on I/O / usage errors).
+
+Register once per clone (see CONTRIBUTING.md)::
+
+    git config merge.changelog-unreleased.driver \\
+      'python3 scripts/git_merge_changelog_unreleased.py %O %A %B'
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+_UNRELEASED_RE = re.compile(r"^## \[Unreleased\]\s*$")
+_VERSION_HEADING_RE = re.compile(r"^## \[.+\]")
+_SUBSECTION_RE = re.compile(r"^### (.+?)\s*$")
+_CONFLICT_START = "<<<<<<< ours"
+_CONFLICT_MID = "======="
+_CONFLICT_END = ">>>>>>> theirs"
+
+
+@dataclass
+class ChangelogParts:
+    """A Keep-a-Changelog file split around ``## [Unreleased]``."""
+
+    preamble: str
+    unreleased: str | None
+    remainder: str
+    has_unreleased: bool
+
+
+@dataclass
+class UnreleasedSection:
+    """Parsed ``## [Unreleased]`` body with optional ``###`` subsections."""
+
+    subsections: dict[str, list[str]] = field(default_factory=dict)
+    section_order: list[str] = field(default_factory=list)
+    loose_lines: list[str] = field(default_factory=list)
+
+
+def split_changelog(text: str) -> ChangelogParts:
+    """Split ``text`` into preamble, unreleased block, and remainder."""
+    lines = text.splitlines(keepends=True)
+    unreleased_idx: int | None = None
+    for i, line in enumerate(lines):
+        if _UNRELEASED_RE.match(line.rstrip("\n")):
+            unreleased_idx = i
+            break
+    if unreleased_idx is None:
+        return ChangelogParts(preamble=text, unreleased=None, remainder="", has_unreleased=False)
+
+    remainder_idx: int | None = None
+    for i in range(unreleased_idx + 1, len(lines)):
+        stripped = lines[i].rstrip("\n")
+        if _VERSION_HEADING_RE.match(stripped) and not _UNRELEASED_RE.match(stripped):
+            remainder_idx = i
+            break
+
+    preamble = "".join(lines[:unreleased_idx])
+    if remainder_idx is None:
+        unreleased = "".join(lines[unreleased_idx:])
+        remainder = ""
+    else:
+        unreleased = "".join(lines[unreleased_idx:remainder_idx])
+        remainder = "".join(lines[remainder_idx:])
+    return ChangelogParts(
+        preamble=preamble,
+        unreleased=unreleased,
+        remainder=remainder,
+        has_unreleased=True,
+    )
+
+
+def parse_unreleased(block: str | None) -> UnreleasedSection:
+    """Parse an Unreleased block into subsections and loose lines."""
+    parsed = UnreleasedSection()
+    if not block:
+        return parsed
+
+    lines = block.splitlines()
+    # Drop the ## [Unreleased] heading; callers re-emit it.
+    if lines and _UNRELEASED_RE.match(lines[0]):
+        lines = lines[1:]
+
+    current: str | None = None
+    for raw in lines:
+        subsection = _SUBSECTION_RE.match(raw)
+        if subsection:
+            current = subsection.group(1)
+            if current not in parsed.subsections:
+                parsed.subsections[current] = []
+                parsed.section_order.append(current)
+            continue
+        if current is None:
+            if raw.strip() == "":
+                continue
+            parsed.loose_lines.append(raw)
+            continue
+        if raw.strip() == "":
+            continue
+        parsed.subsections[current].append(raw)
+    return parsed
+
+
+def _union_preserve_order(primary: list[str], secondary: list[str]) -> list[str]:
+    """Return ``primary`` lines then any ``secondary`` lines not already present."""
+    seen = set(primary)
+    out = list(primary)
+    for line in secondary:
+        if line not in seen:
+            out.append(line)
+            seen.add(line)
+    return out
+
+
+def merge_unreleased(base: str | None, ours: str | None, theirs: str | None) -> str:
+    """Subsection-aware union merge of the Unreleased section."""
+    base_p = parse_unreleased(base)
+    ours_p = parse_unreleased(ours)
+    theirs_p = parse_unreleased(theirs)
+
+    # Section order: base, then ours-only additions, then theirs-only additions.
+    order: list[str] = []
+    for name in base_p.section_order + ours_p.section_order + theirs_p.section_order:
+        if name not in order:
+            order.append(name)
+
+    # Tip union is the source of truth for append-only Unreleased workflows:
+    # a base bullet deleted on both tips stays gone; deleted on only one tip is
+    # kept when the other tip still has it (because that tip's list still carries it).
+    loose = _union_preserve_order(ours_p.loose_lines, theirs_p.loose_lines)
+
+    chunks: list[str] = ["## [Unreleased]", ""]
+    if loose:
+        chunks.extend(loose)
+        chunks.append("")
+
+    for name in order:
+        if name not in ours_p.subsections and name not in theirs_p.subsections:
+            continue
+        ours_items = ours_p.subsections.get(name, [])
+        theirs_items = theirs_p.subsections.get(name, [])
+        items = _union_preserve_order(ours_items, theirs_items)
+        chunks.append(f"### {name}")
+        chunks.extend(items)
+        chunks.append("")
+
+    text = "\n".join(chunks)
+    if not text.endswith("\n"):
+        text += "\n"
+    return text
+
+
+def _ensure_trailing_newline(text: str) -> str:
+    if text == "" or text.endswith("\n"):
+        return text
+    return text + "\n"
+
+
+def merge_region(base: str, ours: str, theirs: str) -> tuple[str, bool]:
+    """Strict 3-way region merge. Returns ``(text, clean)``."""
+    if ours == theirs:
+        return ours, True
+    if ours == base:
+        return theirs, True
+    if theirs == base:
+        return ours, True
+    conflicted = (
+        f"{_CONFLICT_START}\n"
+        f"{_ensure_trailing_newline(ours)}"
+        f"{_CONFLICT_MID}\n"
+        f"{_ensure_trailing_newline(theirs)}"
+        f"{_CONFLICT_END}\n"
+    )
+    return conflicted, False
+
+
+def merge_changelog(base_text: str, ours_text: str, theirs_text: str) -> tuple[str, bool]:
+    """Merge three changelog versions. Returns ``(result, clean)``."""
+    base = split_changelog(base_text)
+    ours = split_changelog(ours_text)
+    theirs = split_changelog(theirs_text)
+
+    preamble, preamble_clean = merge_region(base.preamble, ours.preamble, theirs.preamble)
+    remainder, remainder_clean = merge_region(base.remainder, ours.remainder, theirs.remainder)
+
+    # If any side lacks [Unreleased], fall back to treating the whole file as one
+    # strict region so we never invent structure or silently union released text.
+    if not (base.has_unreleased and ours.has_unreleased and theirs.has_unreleased):
+        whole, clean = merge_region(base_text, ours_text, theirs_text)
+        return whole, clean
+
+    unreleased = merge_unreleased(base.unreleased, ours.unreleased, theirs.unreleased)
+    result = preamble + unreleased + remainder
+    return result, preamble_clean and remainder_clean
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _write(path: Path, text: str) -> None:
+    path.write_text(text, encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("base", type=Path, help="%%O ancestor file")
+    parser.add_argument("ours", type=Path, help="%%A current branch file (also output)")
+    parser.add_argument("theirs", type=Path, help="%%B other branch file")
+    args = parser.parse_args(argv)
+
+    try:
+        result, clean = merge_changelog(_read(args.base), _read(args.ours), _read(args.theirs))
+        _write(args.ours, result)
+    except OSError as exc:
+        print(f"changelog merge driver failed: {exc}", file=sys.stderr)
+        return 1
+    return 0 if clean else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_changelog_merge_driver.py
+++ b/tests/test_changelog_merge_driver.py
@@ -1,0 +1,340 @@
+"""Reproducible tests for the Keep-a-Changelog section-aware merge driver.
+
+Covers the pure merge function and a real ``git merge`` with the driver
+configured — including the unsafe whole-file ``merge=union`` footgun that #828
+claimed did not exist (released-section edits must conflict).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+DRIVER = ROOT / "scripts" / "git_merge_changelog_unreleased.py"
+CONFIGURE = ROOT / "scripts" / "configure_changelog_merge_driver.sh"
+
+
+def _load_driver():
+    spec = importlib.util.spec_from_file_location("git_merge_changelog_unreleased", DRIVER)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+driver = _load_driver()
+
+BASE_CHANGELOG = """\
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+## [0.26.1] - 2026-08-09
+
+### Changed
+- released entry
+"""
+
+
+def _git(
+    cwd: Path, *args: str, check: bool = True, env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    full_env = os.environ.copy()
+    full_env.update(
+        {
+            "GIT_AUTHOR_NAME": "Test User",
+            "GIT_AUTHOR_EMAIL": "test@example.invalid",
+            "GIT_COMMITTER_NAME": "Test User",
+            "GIT_COMMITTER_EMAIL": "test@example.invalid",
+        }
+    )
+    if env:
+        full_env.update(env)
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=check,
+        capture_output=True,
+        text=True,
+        env=full_env,
+    )
+
+
+def _init_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(path, "init", "-q", "-b", "main")
+    _git(path, "config", "user.name", "Test User")
+    _git(path, "config", "user.email", "test@example.invalid")
+
+
+def test_parallel_unreleased_bullets_union_cleanly() -> None:
+    ours = BASE_CHANGELOG.replace(
+        "### Added\n",
+        "### Added\n- PR A: add feature foo (#100)\n",
+    )
+    theirs = BASE_CHANGELOG.replace(
+        "### Added\n",
+        "### Added\n- PR B: fix bar handling (#101)\n",
+    )
+    result, clean = driver.merge_changelog(BASE_CHANGELOG, ours, theirs)
+    assert clean is True
+    assert "- PR A: add feature foo (#100)" in result
+    assert "- PR B: fix bar handling (#101)" in result
+    assert result.count("### Added") == 1
+    assert "## [0.26.1]" in result
+    assert result.index("### Added") < result.index("## [0.26.1]")
+
+
+def test_parallel_new_subsections_fold_under_one_header() -> None:
+    ours = BASE_CHANGELOG.replace(
+        "### Added\n\n",
+        "### Added\n\n### Fixed\n- PR A: fix z (#102)\n\n",
+    )
+    theirs = BASE_CHANGELOG.replace(
+        "### Added\n\n",
+        "### Added\n\n### Fixed\n- PR B: fix y (#103)\n\n",
+    )
+    result, clean = driver.merge_changelog(BASE_CHANGELOG, ours, theirs)
+    assert clean is True
+    assert result.count("### Fixed") == 1
+    assert "- PR A: fix z (#102)" in result
+    assert "- PR B: fix y (#103)" in result
+
+
+def test_released_section_edits_conflict() -> None:
+    ours = BASE_CHANGELOG.replace("- released entry", "- released entry from A")
+    theirs = BASE_CHANGELOG.replace("- released entry", "- released entry from B")
+    result, clean = driver.merge_changelog(BASE_CHANGELOG, ours, theirs)
+    assert clean is False
+    assert "<<<<<<< ours" in result
+    assert "- released entry from A" in result
+    assert "- released entry from B" in result
+    assert ">>>>>>> theirs" in result
+
+
+def test_released_conflict_still_unions_unreleased() -> None:
+    ours = (
+        "# Changelog\n\n## [Unreleased]\n\n### Added\n- A bullet\n\n"
+        "## [0.26.1] - 2026-08-09\n\n### Changed\n- released entry from A\n"
+    )
+    theirs = (
+        "# Changelog\n\n## [Unreleased]\n\n### Added\n- B bullet\n\n"
+        "## [0.26.1] - 2026-08-09\n\n### Changed\n- released entry from B\n"
+    )
+    result, clean = driver.merge_changelog(BASE_CHANGELOG, ours, theirs)
+    assert clean is False
+    assert "- A bullet" in result
+    assert "- B bullet" in result
+    assert result.count("### Added") == 1
+    assert "<<<<<<< ours" in result
+    assert "- released entry from A" in result
+    assert "- released entry from B" in result
+
+
+def test_whole_file_union_silently_merges_released_sections(tmp_path: Path) -> None:
+    """Document the #828 footgun: built-in merge=union keeps both released lines."""
+    repo = tmp_path / "union-footgun"
+    _init_repo(repo)
+    (repo / ".gitattributes").write_text("CHANGELOG.md merge=union\n", encoding="utf-8")
+    (repo / "CHANGELOG.md").write_text(BASE_CHANGELOG, encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "base")
+
+    _git(repo, "checkout", "-qb", "pr-a")
+    (repo / "CHANGELOG.md").write_text(
+        BASE_CHANGELOG.replace("- released entry", "- released entry from A").replace(
+            "### Added\n", "### Added\n- PR A\n"
+        ),
+        encoding="utf-8",
+    )
+    _git(repo, "add", "CHANGELOG.md")
+    _git(repo, "commit", "-qm", "a")
+
+    _git(repo, "checkout", "-qb", "pr-b", "main")
+    (repo / "CHANGELOG.md").write_text(
+        BASE_CHANGELOG.replace("- released entry", "- released entry from B").replace(
+            "### Added\n", "### Added\n- PR B\n"
+        ),
+        encoding="utf-8",
+    )
+    _git(repo, "add", "CHANGELOG.md")
+    _git(repo, "commit", "-qm", "b")
+
+    _git(repo, "checkout", "-qb", "integrate", "main")
+    _git(repo, "merge", "pr-a", "-qm", "merge a")
+    merged = _git(repo, "merge", "pr-b", "-m", "merge b", check=False)
+    assert merged.returncode == 0, merged.stderr
+    text = (repo / "CHANGELOG.md").read_text(encoding="utf-8")
+    # Silent dual keep — the unsafe behavior this corrective change rejects.
+    assert "- released entry from A" in text
+    assert "- released entry from B" in text
+
+
+def test_git_merge_with_driver_unions_unreleased_and_conflicts_released(tmp_path: Path) -> None:
+    repo = tmp_path / "driver-repo"
+    _init_repo(repo)
+    (repo / ".gitattributes").write_text("CHANGELOG.md merge=changelog-unreleased\n", encoding="utf-8")
+    # Copy driver into the scratch repo so the configured relative path resolves.
+    scripts = repo / "scripts"
+    scripts.mkdir()
+    scripts.joinpath("git_merge_changelog_unreleased.py").write_text(
+        DRIVER.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    _git(
+        repo,
+        "config",
+        "merge.changelog-unreleased.driver",
+        "python3 scripts/git_merge_changelog_unreleased.py %O %A %B",
+    )
+    (repo / "CHANGELOG.md").write_text(BASE_CHANGELOG, encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "base")
+
+    _git(repo, "checkout", "-qb", "pr-a")
+    (repo / "CHANGELOG.md").write_text(
+        "# Changelog\n\n## [Unreleased]\n\n### Added\n- PR A: add feature foo (#100)\n\n"
+        "## [0.26.1] - 2026-08-09\n\n### Changed\n- released entry from A\n",
+        encoding="utf-8",
+    )
+    _git(repo, "add", "CHANGELOG.md")
+    _git(repo, "commit", "-qm", "a")
+
+    _git(repo, "checkout", "-qb", "pr-b", "main")
+    (repo / "CHANGELOG.md").write_text(
+        "# Changelog\n\n## [Unreleased]\n\n### Added\n- PR B: fix bar (#101)\n\n"
+        "## [0.26.1] - 2026-08-09\n\n### Changed\n- released entry from B\n",
+        encoding="utf-8",
+    )
+    _git(repo, "add", "CHANGELOG.md")
+    _git(repo, "commit", "-qm", "b")
+
+    _git(repo, "checkout", "-qb", "integrate", "main")
+    _git(repo, "merge", "pr-a", "-qm", "merge a")
+    conflicted = _git(repo, "merge", "pr-b", "-m", "merge b", check=False)
+    assert conflicted.returncode != 0
+    text = (repo / "CHANGELOG.md").read_text(encoding="utf-8")
+    assert "- PR A: add feature foo (#100)" in text
+    assert "- PR B: fix bar (#101)" in text
+    assert "<<<<<<< ours" in text
+    assert "- released entry from A" in text
+    assert "- released entry from B" in text
+
+
+def test_git_merge_with_driver_clean_when_only_unreleased_diverges(tmp_path: Path) -> None:
+    repo = tmp_path / "driver-clean"
+    _init_repo(repo)
+    (repo / ".gitattributes").write_text("CHANGELOG.md merge=changelog-unreleased\n", encoding="utf-8")
+    scripts = repo / "scripts"
+    scripts.mkdir()
+    scripts.joinpath("git_merge_changelog_unreleased.py").write_text(
+        DRIVER.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    _git(
+        repo,
+        "config",
+        "merge.changelog-unreleased.driver",
+        "python3 scripts/git_merge_changelog_unreleased.py %O %A %B",
+    )
+    (repo / "CHANGELOG.md").write_text(BASE_CHANGELOG, encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "base")
+
+    _git(repo, "checkout", "-qb", "pr-a")
+    (repo / "CHANGELOG.md").write_text(
+        BASE_CHANGELOG.replace("### Added\n", "### Added\n- PR A: add feature foo (#100)\n"),
+        encoding="utf-8",
+    )
+    _git(repo, "add", "CHANGELOG.md")
+    _git(repo, "commit", "-qm", "a")
+
+    _git(repo, "checkout", "-qb", "pr-b", "main")
+    (repo / "CHANGELOG.md").write_text(
+        BASE_CHANGELOG.replace("### Added\n", "### Added\n- PR B: fix bar (#101)\n"),
+        encoding="utf-8",
+    )
+    _git(repo, "add", "CHANGELOG.md")
+    _git(repo, "commit", "-qm", "b")
+
+    _git(repo, "checkout", "-qb", "integrate", "main")
+    _git(repo, "merge", "pr-a", "-qm", "merge a")
+    merged = _git(repo, "merge", "pr-b", "-m", "merge b", check=False)
+    assert merged.returncode == 0, merged.stderr + merged.stdout
+    text = (repo / "CHANGELOG.md").read_text(encoding="utf-8")
+    assert "- PR A: add feature foo (#100)" in text
+    assert "- PR B: fix bar (#101)" in text
+    assert "<<<<<<<" not in text
+    assert text.count("- released entry") == 1
+
+
+def test_repo_gitattributes_names_custom_driver_not_union() -> None:
+    text = (ROOT / ".gitattributes").read_text(encoding="utf-8")
+    assert "CHANGELOG.md merge=changelog-unreleased" in text
+    assert "merge=union" not in text
+
+
+def test_configure_script_registers_driver(tmp_path: Path) -> None:
+    repo = tmp_path / "configure"
+    _init_repo(repo)
+    # Script expects to run from a tree that contains scripts/; mirror layout.
+    scripts = repo / "scripts"
+    scripts.mkdir()
+    scripts.joinpath("configure_changelog_merge_driver.sh").write_text(
+        CONFIGURE.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    scripts.joinpath("git_merge_changelog_unreleased.py").write_bytes(DRIVER.read_bytes())
+    result = subprocess.run(
+        ["bash", "scripts/configure_changelog_merge_driver.sh"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert "Configured merge.changelog-unreleased" in result.stdout
+    driver_cfg = _git(repo, "config", "--get", "merge.changelog-unreleased.driver")
+    assert "git_merge_changelog_unreleased.py" in driver_cfg.stdout
+
+
+def test_cli_writes_ours_path(tmp_path: Path) -> None:
+    base = tmp_path / "base.md"
+    ours = tmp_path / "ours.md"
+    theirs = tmp_path / "theirs.md"
+    base.write_text(BASE_CHANGELOG, encoding="utf-8")
+    ours.write_text(
+        BASE_CHANGELOG.replace("### Added\n", "### Added\n- A\n"),
+        encoding="utf-8",
+    )
+    theirs.write_text(
+        BASE_CHANGELOG.replace("### Added\n", "### Added\n- B\n"),
+        encoding="utf-8",
+    )
+    code = driver.main([str(base), str(ours), str(theirs)])
+    assert code == 0
+    text = ours.read_text(encoding="utf-8")
+    assert "- A" in text and "- B" in text
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "# Changelog\n\n## [0.1.0]\n\n- only released\n",
+        "",
+    ],
+)
+def test_missing_unreleased_falls_back_to_strict_region(body: str) -> None:
+    ours = body + ("\n# ours\n" if body else "# ours\n")
+    theirs = body + ("\n# theirs\n" if body else "# theirs\n")
+    result, clean = driver.merge_changelog(body, ours, theirs)
+    assert clean is False
+    assert "<<<<<<< ours" in result


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

**Supersedes #828.** That PR applied Git’s built-in `merge=union` to all of `CHANGELOG.md` and claimed edits outside `[Unreleased]` still conflict. That claim is false: whole-file union silently keeps both sides of released/versioned section edits, which is unsafe for a public changelog. Parallel `###` subsection headers are also not reliably folded under line-union.

This PR keeps the goal (fewer parallel `[Unreleased]` bullet conflicts) with accurate, safer behavior:

| Region | Behavior |
|---|---|
| `## [Unreleased]` (+ `###` subsections) | Subsection-aware union of bullets |
| Preamble + released `## [x.y.z]` sections | Strict 3-way region merge — diverging edits conflict |

Wire once per clone: `./scripts/configure_changelog_merge_driver.sh`

## Selected behavior and remaining limits

- `.gitattributes` names `merge=changelog-unreleased` (not `merge=union`).
- Without local `git config`, Git falls back to the default text merge (conflicts everywhere) — the safe failure mode.
- **GitHub’s server-side merge button does not run custom merge drivers.** Overlapping Unreleased edits can still conflict on github.com; resolve locally with the driver configured, or fix markers by hand.
- Single-line Unreleased bullets remain required; multi-line bullets can interleave under union.
- Do not edit released sections in feature branches; conflicts there are intentional.
- No release/tag. Scope is changelog collision handling only (does not touch operator PRs #744 / #750).

## Type of change

- [x] Bug fix
- [x] Docs
- [ ] New harness adapter / doctor check
- [ ] Refactor with no command-surface change
- [ ] Surface change

## Checklist

- [x] `./scripts/verify` passes locally — **6454 passed, 3 skipped, 68 subtests passed**; coverage **83.19%** (floor 78%)
- [x] Added or updated tests covering the change (`tests/test_changelog_merge_driver.py`)
- [x] Updated the `Unreleased` section of `CHANGELOG.md` (contributor merge-driver note)
- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths
- [x] No new runtime dependencies
- [x] Conventional commit messages

## Files changed

- `.gitattributes` — `CHANGELOG.md merge=changelog-unreleased`
- `scripts/git_merge_changelog_unreleased.py` — section-aware merge driver
- `scripts/configure_changelog_merge_driver.sh` — per-clone registration
- `CONTRIBUTING.md` — accurate Changelog docs + limits
- `tests/test_changelog_merge_driver.py` — pure + real `git merge` coverage (includes regression that documents the #828 union footgun)
- `.gitignore` — allowlist the new scripts under `/scripts/*`
- `CHANGELOG.md` — Unreleased contributor note

Please close #828 in favor of this PR when ready.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-32264bb9-800d-428a-a37e-6f01707983f0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32264bb9-800d-428a-a37e-6f01707983f0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

