### PR TITLE
feat(memory): bounded session-start recall + Claude SessionStart (#466 Slice 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Bounded session-start memory recall (#466 Slice 1): `brigade memory recall
+  --target <hub-or-mirror> --cwd <session-cwd> --limit 5 [--json]` derives query
+  terms from the cwd basename, returns title/tags/path only (max 5 matches /
+  10 lines), and reads a machine-local `memory_recall_target`. Workspace depth
+  may default to the current target; repo depth stays unconfigured until an
+  explicit hub or mirror is set. The managed Claude `SessionStart` hook merges
+  recall beside the work brief once per session and fails open on missing or
+  broken targets. Operator smoke steps live in `docs/memory-care.md`.
 - `brigade center serve` gains work-graph views over existing `--json` contracts:
   an SVG ready/blocked dependency graph, parallel-safe dispatch-wave swim-lanes
   (seam-ready for `work ready --parallel-safe` when #803 lands), and per-task

--- a/docs/command-inventory.md
+++ b/docs/command-inventory.md
@@ -38,7 +38,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade init`: 1 command path(s)
 - `brigade learn` (extras): 13 command path(s)
 - `brigade mcp`: 12 command path(s)
-- `brigade memory`: 14 command path(s)
+- `brigade memory`: 15 command path(s)
 - `brigade model`: 7 command path(s)
 - `brigade notifications` (extras): 4 command path(s)
 - `brigade openclaw-fragments` (extras): 1 command path(s)
@@ -248,6 +248,7 @@ enabled: run `brigade extras on` once, or set `BRIGADE_EXTRAS=1`.
 - `brigade memory compact`
 - `brigade memory init-git`
 - `brigade memory lint`
+- `brigade memory recall`
 - `brigade memory search`
 - `brigade memory serve-mcp`
 - `brigade memory status`

--- a/docs/memory-care.md
+++ b/docs/memory-care.md
@@ -82,4 +82,40 @@ Queue entries include card identity, issue type, severity, priority, safe summar
 
 Memory care does not run a scheduler, mutate canonical memory, perform remote sync, or promote imports automatically. Card edits stay explicit: routine scan and plan commands never write card files. Only `brigade memory care backfill --apply` may add derived frontmatter, with a receipt. Refreshes stay explicit through reviewed work tasks or the existing Memory Handoff flow. Scheduling those care commands is the operator's job: see the [execution model](execution-model.md). Opt-in `brigade care install` can scaffold the operator's own crontab or systemd user timers without Brigade owning a daemon.
 
+## Session-start recall (#466 Slice 1)
+
+`brigade memory recall --target <hub-or-mirror> --cwd <session-cwd> --limit 5`
+runs the deterministic card search with terms derived from the cwd basename
+(split on `-` and `_`). Output is index-level only: title, tags, and card path
+(at most 5 matches / 10 lines). Card bodies never appear.
+
+Machine-local config key: `memory_recall_target` in `.brigade/config.json`.
+
+- Workspace-depth installs may omit the key; recall defaults to the current target.
+- Repo-depth installs stay unconfigured until an explicit hub or mirror path is set.
+- Claude's managed `SessionStart` hook merges recall beside the work brief once per
+  session and fails open when the target is missing, empty, or unreadable.
+
+### Operator smoke (before merge)
+
+Use a temp target, never the real home directory:
+
+```bash
+target="$(mktemp -d)"
+hub="$(mktemp -d)"
+git init -q -b main "$target"
+python -m brigade init --target "$target" --depth repo --harnesses claude
+# Point the repo at a local hub/mirror (edit .brigade/config.json):
+#   "memory_recall_target": "<hub>"
+mkdir -p "$hub/memory/cards"
+printf '%s\n' '---' 'title: Smoke Card' 'tags: ["smoke"]' '---' 'fixture body' \
+  > "$hub/memory/cards/smoke.md"
+python -m brigade memory recall --target "$hub" --cwd "$target/astro-portfolio" --limit 5
+# Expect title/tags/path only; no card body.
+python -m brigade work hooks install --target "$target"
+# In a real Claude Code session on $target (or a nested cwd named like
+# astro-portfolio): confirm SessionStart injects the work brief plus recall
+# exactly once, then a second SessionStart in the same session injects nothing.
+```
+
 For operator-owned cron, systemd, and CI recipes (and `brigade care`), see [scheduled care](scheduled-care.md).

--- a/src/brigade/claude_hooks/package.py
+++ b/src/brigade/claude_hooks/package.py
@@ -7,13 +7,15 @@ from pathlib import Path
 from typing import Any
 
 PACKAGE_ID = "brigade-claude-work-loop"
-PACKAGE_VERSION = "1.0.0"
+PACKAGE_VERSION = "1.1.0"
 PACKAGE_REF = f"{PACKAGE_ID}@{PACKAGE_VERSION}"
 COMMAND_PREFIX = "brigade work hook-run"
 MANAGED_EVENTS = ("SessionStart", "PreToolUse", "PostToolUse", "PostToolUseFailure", "Stop")
 LEGACY_SCRIPT_NAME = "brigade-work-loop.py"
 MANAGED_MARKER_KEY = "_brigade"
 HOOK_SCRIPT_NAME = "brigade-claude-work-loop.sh"
+SESSION_START_TIMEOUT_SECONDS = 20
+DEFAULT_HOOK_TIMEOUT_SECONDS = 15
 
 
 def managed_command(event: str) -> str:
@@ -21,7 +23,8 @@ def managed_command(event: str) -> str:
 
 
 def managed_handler(event: str) -> dict[str, Any]:
-    return {"type": "command", "command": managed_command(event), "timeout": 15}
+    timeout = SESSION_START_TIMEOUT_SECONDS if event == "SessionStart" else DEFAULT_HOOK_TIMEOUT_SECONDS
+    return {"type": "command", "command": managed_command(event), "timeout": timeout}
 
 
 def managed_groups() -> dict[str, list[dict[str, Any]]]:
@@ -70,10 +73,11 @@ def managed_user_command(event: str, script_path: Path) -> str:
 
 
 def managed_user_handler(event: str, script_path: Path) -> dict[str, Any]:
+    timeout = SESSION_START_TIMEOUT_SECONDS if event == "SessionStart" else DEFAULT_HOOK_TIMEOUT_SECONDS
     return {
         "type": "command",
         "command": managed_user_command(event, script_path),
-        "timeout": 15,
+        "timeout": timeout,
         MANAGED_MARKER_KEY: PACKAGE_REF,
     }
 

--- a/src/brigade/claude_hooks/runtime.py
+++ b/src/brigade/claude_hooks/runtime.py
@@ -605,6 +605,25 @@ def _run_brief(target: Path) -> str:
     return text
 
 
+def _run_recall(target: Path, payload: dict[str, Any]) -> str:
+    """Bounded memory recall for SessionStart; empty string on any failure."""
+    from .. import memory_hooks
+
+    raw_cwd = payload.get("cwd")
+    cwd: Path | None
+    if isinstance(raw_cwd, str) and raw_cwd.strip():
+        try:
+            cwd = Path(raw_cwd).expanduser().resolve(strict=False)
+        except OSError:
+            cwd = None
+    else:
+        cwd = None
+    try:
+        return memory_hooks.recall_text_for_hook(wired_target=target, cwd=cwd)
+    except Exception:  # noqa: BLE001 - recall must never block session start
+        return ""
+
+
 def _brief_records(text: str) -> list[str]:
     """Split a work brief into whole-record units for capped injection."""
     lines = [line.rstrip() for line in text.splitlines()]
@@ -1919,14 +1938,18 @@ def handle_payload(event: str, payload: dict[str, Any]) -> dict[str, Any] | None
         if state.get("briefed"):
             return None
         brief_text = _run_brief(target)
+        recall_text = _run_recall(target, payload)
         state["briefed"] = True
         write_session_state(target, session_id, state)
+        records = _brief_records(brief_text)
+        if recall_text.strip():
+            records.extend(_brief_records(recall_text))
         return _additional_context(
             "SessionStart",
-            brief_text,
+            brief_text if not recall_text.strip() else f"{brief_text}\n{recall_text}",
             target=target,
             session_id=session_id,
-            records=_brief_records(brief_text),
+            records=records,
         )
 
     if event == "PreToolUse":

--- a/src/brigade/cli/memory.py
+++ b/src/brigade/cli/memory.py
@@ -80,6 +80,30 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_memory_search.add_argument("--target", "-t", type=Path, default=Path("."), help="Repo or workspace to search.")
     p_memory_search.add_argument("--limit", type=int, default=20, help="Maximum matches to show.")
     p_memory_search.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    p_memory_recall = memory_sub.add_parser(
+        "recall",
+        help="Bounded session-start recall: cwd-derived search returning title, tags, and card path only.",
+    )
+    p_memory_recall.add_argument(
+        "--target",
+        "-t",
+        type=Path,
+        required=True,
+        help="Memory hub or local read-only mirror to search.",
+    )
+    p_memory_recall.add_argument(
+        "--cwd",
+        type=Path,
+        required=True,
+        help="Session working directory (basename terms drive the query).",
+    )
+    p_memory_recall.add_argument(
+        "--limit",
+        type=int,
+        default=5,
+        help="Maximum matches to show (capped at 5).",
+    )
+    p_memory_recall.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
     p_memory_serve_mcp = memory_sub.add_parser(
         "serve-mcp", help="Expose memory cards over a read-only MCP stdio server (card:// scheme)."
     )
@@ -169,6 +193,8 @@ def dispatch(args) -> int:
         return 2
     if args.memory_command == "search":
         return memory_cmd.search(target=args.target, query=args.query, limit=args.limit, json_output=args.json)
+    if args.memory_command == "recall":
+        return memory_cmd.recall(target=args.target, cwd=args.cwd, limit=args.limit, json_output=args.json)
     if args.memory_command == "serve-mcp":
         return memory_cmd.serve_mcp(target=args.target, stdio=args.stdio, json_output=args.json)
 

--- a/src/brigade/config.py
+++ b/src/brigade/config.py
@@ -34,6 +34,9 @@ class Config:
     verify_archive_enabled: bool = DEFAULT_VERIFY_ARCHIVE_ENABLED
     verify_archive_dir: str = DEFAULT_VERIFY_ARCHIVE_DIR
     run_lock_wait_seconds: float = DEFAULT_RUN_LOCK_WAIT_SECONDS
+    # Machine-local hub or read-only mirror for session-start recall (#466).
+    # Absent on repo installs until the operator sets an explicit path.
+    memory_recall_target: str | None = None
 
 
 def validate_graphtrail_delta_timeout(value: Any) -> float:
@@ -100,6 +103,14 @@ def validate_run_lock_wait_seconds(value: Any) -> float:
     return timeout
 
 
+def validate_memory_recall_target(value: Any) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("memory_recall_target must be a non-empty string when set")
+    return value.strip()
+
+
 def resolve_run_lock_wait_seconds(target: Path) -> float:
     cfg = load_config(target)
     if cfg is not None:
@@ -158,6 +169,9 @@ def write_config(target: Path, cfg: Config) -> None:
     run_lock_wait_seconds = validate_run_lock_wait_seconds(cfg.run_lock_wait_seconds)
     if run_lock_wait_seconds != DEFAULT_RUN_LOCK_WAIT_SECONDS:
         payload["run_lock_wait_seconds"] = run_lock_wait_seconds
+    memory_recall_target = validate_memory_recall_target(cfg.memory_recall_target)
+    if memory_recall_target is not None:
+        payload["memory_recall_target"] = memory_recall_target
     path.write_text(json.dumps(payload, indent=2) + "\n")
 
 
@@ -193,6 +207,7 @@ def load_config(target: Path) -> Optional[Config]:
     run_lock_wait_seconds = validate_run_lock_wait_seconds(
         data.get("run_lock_wait_seconds", DEFAULT_RUN_LOCK_WAIT_SECONDS)
     )
+    memory_recall_target = validate_memory_recall_target(data.get("memory_recall_target"))
     return Config(
         version=version,
         selection=sel,
@@ -202,4 +217,5 @@ def load_config(target: Path) -> Optional[Config]:
         verify_archive_enabled=verify_archive_enabled,
         verify_archive_dir=verify_archive_dir,
         run_lock_wait_seconds=run_lock_wait_seconds,
+        memory_recall_target=memory_recall_target,
     )

--- a/src/brigade/memory_cmd.py
+++ b/src/brigade/memory_cmd.py
@@ -1760,6 +1760,13 @@ def search(*, target: Path, query: str, limit: int = 20, json_output: bool = Fal
     return 0
 
 
+def recall(*, target: Path, cwd: Path, limit: int = 5, json_output: bool = False) -> int:
+    """Bounded session-start recall over deterministic card search (#466 Slice 1)."""
+    from . import memory_hooks
+
+    return memory_hooks.recall(target=target, cwd=cwd, limit=limit, json_output=json_output)
+
+
 # --- read-only MCP server exposing memory cards over card:// ---
 
 _CARD_URI_PREFIX = "card://"

--- a/src/brigade/memory_hooks.py
+++ b/src/brigade/memory_hooks.py
@@ -8,8 +8,11 @@ suitable for harness SessionStart injection. Failures stay fail-open.
 from __future__ import annotations
 
 import json
+import os
 import re
+import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
@@ -18,6 +21,8 @@ RECALL_MAX_LINES = 10
 RECALL_TIMEOUT_SECONDS = 5
 GENERIC_WORKSPACE_QUERY = "workspace"
 _TERM_SPLIT = re.compile(r"[-_]+")
+_RECALL_TEST_HANG_ENV = "BRIGADE_RECALL_TEST_HANG_SECONDS"
+_RECALL_WORKER_COMMAND = "from brigade.memory_hooks import _recall_worker_main; _recall_worker_main()"
 
 
 def split_cwd_terms(basename: str) -> list[str]:
@@ -111,30 +116,60 @@ def format_recall_text(payload: dict[str, Any]) -> str:
     return "\n".join(lines[:RECALL_MAX_LINES])
 
 
-def recall_cards_payload(
+def _empty_recall_payload(
+    *,
+    target: Path,
+    cwd: Path,
+    query: str,
+    limit: int,
+    status: str,
+) -> dict[str, Any]:
+    return {
+        "target": str(target),
+        "cwd": str(cwd),
+        "query": query,
+        "match_count": 0,
+        "matches": [],
+        "limit": limit,
+        "status": status,
+    }
+
+
+def _maybe_recall_test_hang() -> None:
+    raw = os.environ.get(_RECALL_TEST_HANG_ENV)
+    if raw is None or not raw.strip():
+        return
+    try:
+        seconds = float(raw)
+    except ValueError:
+        return
+    if seconds > 0:
+        time.sleep(seconds)
+
+
+def _recall_cards_payload_impl(
     *,
     target: Path,
     cwd: Path,
     limit: int = DEFAULT_RECALL_LIMIT,
 ) -> dict[str, Any]:
-    """Run bounded recall against ``target`` using terms derived from ``cwd``."""
+    """In-process recall body (runs in a killable child when timed)."""
     from .memory_cmd import search_cards_payload
 
+    _maybe_recall_test_hang()
     capped = _clamp_limit(limit)
     try:
         memory_root = target.expanduser().resolve(strict=False)
     except OSError:
         memory_root = target
     query = query_from_cwd(cwd, memory_root=memory_root)
-    empty: dict[str, Any] = {
-        "target": str(target),
-        "cwd": str(cwd),
-        "query": query,
-        "match_count": 0,
-        "matches": [],
-        "limit": capped,
-        "status": "ok",
-    }
+    empty = _empty_recall_payload(
+        target=target,
+        cwd=cwd,
+        query=query,
+        limit=capped,
+        status="ok",
+    )
     try:
         raw = search_cards_payload(memory_root, query, limit=capped)
     except (OSError, ValueError):
@@ -163,6 +198,80 @@ def recall_cards_payload(
         "limit": capped,
         "status": "ok",
     }
+
+
+def _recall_worker_main() -> None:
+    """Child entry for timed recall; stdin request JSON, stdout payload JSON."""
+    req = json.loads(sys.stdin.read())
+    if not isinstance(req, dict):
+        raise TypeError("recall worker stdin must be a JSON object")
+    payload = _recall_cards_payload_impl(
+        target=Path(str(req["target"])),
+        cwd=Path(str(req["cwd"])),
+        limit=int(req["limit"]),
+    )
+    sys.stdout.write(json.dumps(payload, sort_keys=True))
+
+
+def recall_cards_payload(
+    *,
+    target: Path,
+    cwd: Path,
+    limit: int = DEFAULT_RECALL_LIMIT,
+) -> dict[str, Any]:
+    """Run bounded recall against ``target`` using terms derived from ``cwd``.
+
+    Card search runs in a killable child process so a stalled scan cannot block
+    SessionStart past ``RECALL_TIMEOUT_SECONDS``. Timeout and child failures
+    return an empty fail-open payload.
+    """
+    capped = _clamp_limit(limit)
+    try:
+        memory_root = target.expanduser().resolve(strict=False)
+    except OSError:
+        memory_root = target
+    query = query_from_cwd(cwd, memory_root=memory_root)
+    empty = _empty_recall_payload(
+        target=target,
+        cwd=cwd,
+        query=query,
+        limit=capped,
+        status="error",
+    )
+    request = json.dumps(
+        {
+            "target": str(target),
+            "cwd": str(cwd),
+            "limit": capped,
+        },
+        sort_keys=True,
+    )
+    try:
+        completed = subprocess.run(
+            [sys.executable, "-c", _RECALL_WORKER_COMMAND],
+            input=request,
+            capture_output=True,
+            text=True,
+            timeout=RECALL_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        empty["status"] = "timeout"
+        return empty
+    except OSError:
+        return empty
+    if completed.returncode != 0:
+        return empty
+    stdout = completed.stdout.strip()
+    if not stdout:
+        return empty
+    try:
+        parsed = json.loads(stdout)
+    except json.JSONDecodeError:
+        return empty
+    if not isinstance(parsed, dict):
+        return empty
+    return parsed
 
 
 def recall_text_for_hook(

--- a/src/brigade/memory_hooks.py
+++ b/src/brigade/memory_hooks.py
@@ -8,11 +8,9 @@ suitable for harness SessionStart injection. Failures stay fail-open.
 from __future__ import annotations
 
 import json
-import os
 import re
 import subprocess
 import sys
-import time
 from pathlib import Path
 from typing import Any
 
@@ -21,7 +19,6 @@ RECALL_MAX_LINES = 10
 RECALL_TIMEOUT_SECONDS = 5
 GENERIC_WORKSPACE_QUERY = "workspace"
 _TERM_SPLIT = re.compile(r"[-_]+")
-_RECALL_TEST_HANG_ENV = "BRIGADE_RECALL_TEST_HANG_SECONDS"
 _RECALL_WORKER_COMMAND = "from brigade.memory_hooks import _recall_worker_main; _recall_worker_main()"
 
 
@@ -135,18 +132,6 @@ def _empty_recall_payload(
     }
 
 
-def _maybe_recall_test_hang() -> None:
-    raw = os.environ.get(_RECALL_TEST_HANG_ENV)
-    if raw is None or not raw.strip():
-        return
-    try:
-        seconds = float(raw)
-    except ValueError:
-        return
-    if seconds > 0:
-        time.sleep(seconds)
-
-
 def _recall_cards_payload_impl(
     *,
     target: Path,
@@ -156,7 +141,6 @@ def _recall_cards_payload_impl(
     """In-process recall body (runs in a killable child when timed)."""
     from .memory_cmd import search_cards_payload
 
-    _maybe_recall_test_hang()
     capped = _clamp_limit(limit)
     try:
         memory_root = target.expanduser().resolve(strict=False)

--- a/src/brigade/memory_hooks.py
+++ b/src/brigade/memory_hooks.py
@@ -1,0 +1,254 @@
+"""Bounded session-start memory recall primitive (#466 Slice 1).
+
+Derives cwd-based search terms, runs the deterministic card search against a
+machine-local hub or mirror, and formats index-level output (title, tags, path)
+suitable for harness SessionStart injection. Failures stay fail-open.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+DEFAULT_RECALL_LIMIT = 5
+RECALL_MAX_LINES = 10
+RECALL_TIMEOUT_SECONDS = 5
+GENERIC_WORKSPACE_QUERY = "workspace"
+_TERM_SPLIT = re.compile(r"[-_]+")
+
+
+def split_cwd_terms(basename: str) -> list[str]:
+    """Split a directory basename on hyphens and underscores into query terms."""
+    return [part.lower() for part in _TERM_SPLIT.split(basename.strip()) if part]
+
+
+def query_from_cwd(cwd: Path, *, memory_root: Path | None = None) -> str:
+    """Build the recall query from a session cwd.
+
+    When the session starts at the configured memory root, use the generic
+    workspace fallback instead of the hub directory's basename.
+    """
+    try:
+        cwd_resolved = cwd.expanduser().resolve(strict=False)
+    except OSError:
+        return GENERIC_WORKSPACE_QUERY
+    if memory_root is not None:
+        try:
+            root_resolved = memory_root.expanduser().resolve(strict=False)
+        except OSError:
+            root_resolved = None
+        if root_resolved is not None and cwd_resolved == root_resolved:
+            return GENERIC_WORKSPACE_QUERY
+    terms = split_cwd_terms(cwd_resolved.name)
+    return " ".join(terms) if terms else GENERIC_WORKSPACE_QUERY
+
+
+def resolve_memory_recall_target(wired_target: Path) -> tuple[Path | None, str]:
+    """Resolve the machine-local recall hub/mirror for a wired Brigade target.
+
+    Returns ``(path, status)`` where status is ``active`` or ``unconfigured``.
+    Workspace-depth installs may default to the current target when the config
+    key is absent. Repo-depth installs stay unconfigured until an explicit hub
+    or mirror path is set.
+    """
+    from .config import load_config, validate_memory_recall_target
+
+    try:
+        target = wired_target.expanduser().resolve(strict=False)
+    except OSError:
+        return None, "unconfigured"
+    try:
+        cfg = load_config(target)
+    except (OSError, ValueError, json.JSONDecodeError):
+        return None, "unconfigured"
+    if cfg is None:
+        return None, "unconfigured"
+    configured = validate_memory_recall_target(cfg.memory_recall_target)
+    if configured:
+        try:
+            return Path(configured).expanduser().resolve(strict=False), "active"
+        except OSError:
+            return None, "unconfigured"
+    if cfg.selection.depth == "workspace":
+        return target, "active"
+    return None, "unconfigured"
+
+
+def _clamp_limit(limit: int) -> int:
+    if limit < 1:
+        return 1
+    return min(limit, DEFAULT_RECALL_LIMIT)
+
+
+def _format_tags(tags: list[str]) -> str:
+    return ", ".join(tags) if tags else "-"
+
+
+def format_recall_match_line(match: dict[str, Any]) -> str:
+    title = str(match.get("title") or "")
+    path = str(match.get("path") or "")
+    raw_tags = match.get("tags")
+    tags = [str(t) for t in raw_tags] if isinstance(raw_tags, list) else []
+    return f"- {title} | tags: {_format_tags(tags)} | {path}"
+
+
+def format_recall_text(payload: dict[str, Any]) -> str:
+    """Render recall output: at most 5 matches and 10 lines; no bodies/summaries."""
+    query = str(payload.get("query") or "")
+    matches = payload.get("matches")
+    if not isinstance(matches, list) or not matches:
+        return ""
+    lines = [f"memory recall: {query}"]
+    for match in matches[:DEFAULT_RECALL_LIMIT]:
+        if not isinstance(match, dict):
+            continue
+        lines.append(format_recall_match_line(match))
+        if len(lines) >= RECALL_MAX_LINES:
+            break
+    return "\n".join(lines[:RECALL_MAX_LINES])
+
+
+def recall_cards_payload(
+    *,
+    target: Path,
+    cwd: Path,
+    limit: int = DEFAULT_RECALL_LIMIT,
+) -> dict[str, Any]:
+    """Run bounded recall against ``target`` using terms derived from ``cwd``."""
+    from .memory_cmd import search_cards_payload
+
+    capped = _clamp_limit(limit)
+    try:
+        memory_root = target.expanduser().resolve(strict=False)
+    except OSError:
+        memory_root = target
+    query = query_from_cwd(cwd, memory_root=memory_root)
+    empty: dict[str, Any] = {
+        "target": str(target),
+        "cwd": str(cwd),
+        "query": query,
+        "match_count": 0,
+        "matches": [],
+        "limit": capped,
+        "status": "ok",
+    }
+    try:
+        raw = search_cards_payload(memory_root, query, limit=capped)
+    except (OSError, ValueError):
+        empty["status"] = "error"
+        return empty
+    matches: list[dict[str, Any]] = []
+    for item in raw.get("matches") or []:
+        if not isinstance(item, dict):
+            continue
+        tags_raw = item.get("tags")
+        tags = [str(t) for t in tags_raw] if isinstance(tags_raw, list) else []
+        matches.append(
+            {
+                "path": str(item.get("path") or ""),
+                "title": str(item.get("title") or ""),
+                "tags": tags,
+                "score": item.get("score"),
+            }
+        )
+    return {
+        "target": str(raw.get("target") or memory_root),
+        "cwd": str(cwd),
+        "query": query,
+        "match_count": len(matches),
+        "matches": matches,
+        "limit": capped,
+        "status": "ok",
+    }
+
+
+def recall_text_for_hook(
+    *,
+    wired_target: Path,
+    cwd: Path | None = None,
+    limit: int = DEFAULT_RECALL_LIMIT,
+) -> str:
+    """Hook-facing recall: empty string on any failure (fail open, no leak)."""
+    try:
+        recall_target, status = resolve_memory_recall_target(wired_target)
+        if status != "active" or recall_target is None:
+            return ""
+        session_cwd = cwd if cwd is not None else wired_target
+        if not recall_target.exists():
+            return ""
+        payload = recall_cards_payload(target=recall_target, cwd=session_cwd, limit=limit)
+        if payload.get("status") != "ok":
+            return ""
+        return format_recall_text(payload)
+    except Exception:  # noqa: BLE001 - session-start recall must never block the harness
+        return ""
+
+
+def recall(
+    *,
+    target: Path,
+    cwd: Path,
+    limit: int = DEFAULT_RECALL_LIMIT,
+    json_output: bool = False,
+) -> int:
+    """CLI entry for ``brigade memory recall``. Always exits 0 (fail open)."""
+    try:
+        if not target.expanduser().resolve(strict=False).exists():
+            payload = {
+                "target": str(target),
+                "cwd": str(cwd),
+                "query": query_from_cwd(cwd, memory_root=None),
+                "match_count": 0,
+                "matches": [],
+                "limit": _clamp_limit(limit),
+                "status": "missing-target",
+            }
+            if json_output:
+                print(json.dumps(payload, indent=2, sort_keys=True))
+            return 0
+        payload = recall_cards_payload(target=target, cwd=cwd, limit=limit)
+    except Exception:  # noqa: BLE001 - keep the session-start contract fail-open
+        if json_output:
+            print(
+                json.dumps(
+                    {
+                        "target": str(target),
+                        "cwd": str(cwd),
+                        "query": "",
+                        "match_count": 0,
+                        "matches": [],
+                        "limit": _clamp_limit(limit),
+                        "status": "error",
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+        return 0
+    if json_output:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+    text = format_recall_text(payload)
+    if text:
+        print(text)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Minimal argv entry used by subprocess fixtures."""
+    import argparse
+
+    parser = argparse.ArgumentParser(prog="brigade memory recall")
+    parser.add_argument("--target", "-t", type=Path, required=True)
+    parser.add_argument("--cwd", type=Path, required=True)
+    parser.add_argument("--limit", type=int, default=DEFAULT_RECALL_LIMIT)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    return recall(target=args.target, cwd=args.cwd, limit=args.limit, json_output=args.json)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_claude_hooks_runtime.py
+++ b/tests/test_claude_hooks_runtime.py
@@ -77,6 +77,80 @@ def test_session_start_injects_brief_once_per_repo(tmp_path: Path, monkeypatch):
     assert calls == [target.resolve()]
 
 
+def test_session_start_merges_recall_with_brief_once(tmp_path: Path, monkeypatch):
+    target = _wired_claude(tmp_path)
+    hub = tmp_path / "hub"
+    hub.mkdir()
+    cards = hub / "memory" / "cards"
+    cards.mkdir(parents=True)
+    (cards / "astro.md").write_text(
+        '---\ntitle: Astro Notes\ntags: ["astro"]\n---\nSECRET_BODY_TOKEN\n',
+        encoding="utf-8",
+    )
+    from brigade.config import Config, load_config, write_config
+
+    cfg = load_config(target)
+    assert cfg is not None
+    write_config(
+        target,
+        Config(
+            version=cfg.version,
+            selection=cfg.selection,
+            memory_recall_target=str(hub),
+            graphtrail_delta_timeout_seconds=cfg.graphtrail_delta_timeout_seconds,
+            capture_before_retry=cfg.capture_before_retry,
+            verify_runs_keep=cfg.verify_runs_keep,
+            verify_archive_enabled=cfg.verify_archive_enabled,
+            verify_archive_dir=cfg.verify_archive_dir,
+            run_lock_wait_seconds=cfg.run_lock_wait_seconds,
+        ),
+    )
+    monkeypatch.setattr(runtime, "_run_brief", lambda repo: "work brief: test")
+    session_cwd = target / "astro-portfolio"
+    session_cwd.mkdir()
+    first = runtime.handle_payload(
+        "SessionStart",
+        _payload(target, "SessionStart", cwd=str(session_cwd)),
+    )
+    second = runtime.handle_payload(
+        "SessionStart",
+        _payload(target, "SessionStart", cwd=str(session_cwd)),
+    )
+    context = first["hookSpecificOutput"]["additionalContext"]
+    assert "work brief: test" in context
+    assert "memory recall: astro portfolio" in context
+    assert "Astro Notes" in context
+    assert "SECRET_BODY_TOKEN" not in context
+    assert second is None
+
+
+def test_session_start_recall_fail_open_keeps_brief(tmp_path: Path, monkeypatch):
+    target = _wired_claude(tmp_path)
+    from brigade.config import Config, load_config, write_config
+
+    cfg = load_config(target)
+    assert cfg is not None
+    write_config(
+        target,
+        Config(
+            version=cfg.version,
+            selection=cfg.selection,
+            memory_recall_target=str(tmp_path / "missing-hub"),
+            graphtrail_delta_timeout_seconds=cfg.graphtrail_delta_timeout_seconds,
+            capture_before_retry=cfg.capture_before_retry,
+            verify_runs_keep=cfg.verify_runs_keep,
+            verify_archive_enabled=cfg.verify_archive_enabled,
+            verify_archive_dir=cfg.verify_archive_dir,
+            run_lock_wait_seconds=cfg.run_lock_wait_seconds,
+        ),
+    )
+    monkeypatch.setattr(runtime, "_run_brief", lambda repo: "work brief: only")
+    result = runtime.handle_payload("SessionStart", _payload(target, "SessionStart"))
+    context = result["hookSpecificOutput"]["additionalContext"]
+    assert "work brief: only" in context
+    assert "memory recall:" not in context
+
+
 def test_all_events_are_inert_for_unwired_repo(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(runtime, "_run_brief", lambda target: (_ for _ in ()).throw(AssertionError(target)))
     assert runtime.handle_payload("SessionStart", _payload(tmp_path, "SessionStart")) is None
@@ -1151,8 +1225,8 @@ def test_cli_accepts_managed_posttooluse_event(monkeypatch):
 
     monkeypatch.setattr(runtime, "hook_run", fake_hook_run)
 
-    assert cli.main(["work", "hook-run", "--event", "PostToolUse", "--package", "brigade-claude-work-loop@1.0.0"]) == 0
-    assert calls == [("PostToolUse", "brigade-claude-work-loop@1.0.0")]
+    assert cli.main(["work", "hook-run", "--event", "PostToolUse", "--package", PACKAGE_REF]) == 0
+    assert calls == [("PostToolUse", PACKAGE_REF)]
 
 
 def test_posttooluse_records_only_successful_confident_bash_writes(tmp_path: Path):
@@ -1445,7 +1519,7 @@ def test_hook_run_normalizes_malformed_persisted_state_before_denial(tmp_path: P
     assert (
         runtime.hook_run(
             event="PreToolUse",
-            package="brigade-claude-work-loop@1.0.0",
+            package=PACKAGE_REF,
             stdin_text=json.dumps(payload),
         )
         == 0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -323,3 +323,30 @@ def test_resolve_run_lock_wait_seconds_defaults_without_config(tmp_path):
     from brigade.config import resolve_run_lock_wait_seconds
 
     assert resolve_run_lock_wait_seconds(tmp_path) == 0.0
+
+
+def test_memory_recall_target_round_trip(tmp_path):
+    sel = Selection(depth="repo", harnesses=["claude"], owner="claude", includes=[])
+    cfg = Config(version=1, selection=sel, memory_recall_target="/tmp/fake-memory-hub")
+    write_config(tmp_path, cfg)
+    loaded = load_config(tmp_path)
+    assert loaded is not None
+    assert loaded.memory_recall_target == "/tmp/fake-memory-hub"
+    text = (tmp_path / ".brigade" / "config.json").read_text()
+    assert '"memory_recall_target": "/tmp/fake-memory-hub"' in text
+
+
+def test_memory_recall_target_defaults_absent(tmp_path):
+    sel = Selection(depth="workspace", harnesses=["claude"], owner="claude", includes=[])
+    write_config(tmp_path, Config(version=1, selection=sel))
+    loaded = load_config(tmp_path)
+    assert loaded is not None
+    assert loaded.memory_recall_target is None
+    assert "memory_recall_target" not in (tmp_path / ".brigade" / "config.json").read_text()
+
+
+@pytest.mark.parametrize("value", ["", "   ", 12, True])
+def test_load_config_rejects_invalid_memory_recall_target(tmp_path, value):
+    _write_config_json(tmp_path, memory_recall_target=value)
+    with pytest.raises(ValueError, match="memory_recall_target must be a non-empty string"):
+        load_config(tmp_path)

--- a/tests/test_memory_hooks.py
+++ b/tests/test_memory_hooks.py
@@ -1,0 +1,168 @@
+"""Tests for bounded session-start memory recall (#466 Slice 1)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from brigade import cli, config, memory_hooks
+from brigade.config import Config
+from brigade.selection import Selection
+
+
+def _write_card(target: Path, name: str, title: str, body: str, tags: list[str] | None = None) -> None:
+    cards = target / "memory" / "cards"
+    cards.mkdir(parents=True, exist_ok=True)
+    tags = tags or []
+    tag_line = ""
+    if tags:
+        rendered = "[" + ", ".join(f'"{t}"' for t in tags) + "]"
+        tag_line = f"tags: {rendered}\n"
+    (cards / name).write_text(f"---\ntitle: {title}\n{tag_line}---\n{body}\n", encoding="utf-8")
+
+
+def _write_brigade_config(target: Path, *, depth: str = "repo", memory_recall_target: str | None = None) -> None:
+    cfg = Config(
+        version=1,
+        selection=Selection(depth=depth, harnesses=["claude"], owner="claude", includes=[]),
+        memory_recall_target=memory_recall_target,
+    )
+    config.write_config(target, cfg)
+
+
+def test_astro_portfolio_cwd_becomes_astro_portfolio_terms():
+    assert memory_hooks.query_from_cwd(Path("/tmp/astro-portfolio")) == "astro portfolio"
+    assert memory_hooks.split_cwd_terms("astro_portfolio") == ["astro", "portfolio"]
+    assert memory_hooks.split_cwd_terms("Astro-Portfolio") == ["astro", "portfolio"]
+
+
+def test_memory_root_cwd_uses_generic_workspace_fallback(tmp_path: Path):
+    hub = tmp_path / "agent-workspace"
+    hub.mkdir()
+    assert memory_hooks.query_from_cwd(hub, memory_root=hub) == "workspace"
+
+
+def test_recall_output_has_title_tags_path_only_no_body(tmp_path: Path, capsys):
+    hub = tmp_path / "hub"
+    session = tmp_path / "astro-portfolio"
+    hub.mkdir()
+    session.mkdir()
+    card_body = "UNIQUE_BODY_TOKEN_SHOULD_NOT_LEAK"
+    _write_card(hub, "astro.md", "Astro Notes", card_body, tags=["astro"])
+    _write_card(hub, "other.md", "Unrelated", "no match here", tags=["other"])
+
+    rc = memory_hooks.recall(target=hub, cwd=session, limit=5, json_output=False)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "memory recall: astro portfolio" in out
+    assert "Astro Notes" in out
+    assert "astro.md" in out
+    assert "tags: astro" in out
+    assert card_body not in out
+    assert "UNIQUE_BODY" not in out
+    assert out.count("\n") <= memory_hooks.RECALL_MAX_LINES
+
+
+def test_recall_json_omits_body_and_summary(tmp_path: Path, capsys):
+    hub = tmp_path / "hub"
+    session = tmp_path / "astro-portfolio"
+    hub.mkdir()
+    session.mkdir()
+    _write_card(hub, "astro.md", "Astro Notes", "body text must stay out of json", tags=["astro"])
+    rc = memory_hooks.recall(target=hub, cwd=session, json_output=True)
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["query"] == "astro portfolio"
+    assert payload["matches"]
+    for match in payload["matches"]:
+        assert set(match) <= {"path", "title", "tags", "score"}
+        assert "summary" not in match
+        assert "body" not in match
+        assert "body text" not in json.dumps(match)
+
+
+def test_recall_caps_matches_and_stable_equal_score_order(tmp_path: Path):
+    hub = tmp_path / "hub"
+    session = tmp_path / "demo-repo"
+    hub.mkdir()
+    session.mkdir()
+    for name in ("zeta.md", "alpha.md", "mid.md", "beta.md", "gamma.md", "delta.md"):
+        _write_card(hub, name, f"Demo {name}", f"mentions demo in body for {name}", tags=["demo"])
+    payload = memory_hooks.recall_cards_payload(target=hub, cwd=session, limit=99)
+    assert len(payload["matches"]) == memory_hooks.DEFAULT_RECALL_LIMIT
+    scores = [m["score"] for m in payload["matches"]]
+    assert scores == sorted(scores, reverse=True)
+    # Equal scores order by path for stability.
+    equal = [m for m in payload["matches"] if m["score"] == scores[0]]
+    assert [m["path"] for m in equal] == sorted(m["path"] for m in equal)
+
+
+def test_missing_and_broken_targets_exit_zero_without_output(tmp_path: Path, capsys):
+    missing = tmp_path / "no-such-hub"
+    cwd = tmp_path / "astro-portfolio"
+    cwd.mkdir()
+    assert memory_hooks.recall(target=missing, cwd=cwd) == 0
+    assert capsys.readouterr().out == ""
+
+    broken = tmp_path / "broken-hub"
+    broken.mkdir()
+    (broken / "memory").mkdir()
+    # Unreadable cards dir is still fail-open with no rendered matches required.
+    assert memory_hooks.recall(target=broken, cwd=cwd) == 0
+    # No matches means no text output.
+    assert capsys.readouterr().out == ""
+
+
+def test_cli_memory_recall_json(tmp_path: Path, capsys):
+    hub = tmp_path / "hub"
+    session = tmp_path / "astro-portfolio"
+    hub.mkdir()
+    session.mkdir()
+    _write_card(hub, "astro.md", "Astro Notes", "secret-body", tags=["astro"])
+    assert (
+        cli.main(
+            [
+                "memory",
+                "recall",
+                "--target",
+                str(hub),
+                "--cwd",
+                str(session),
+                "--limit",
+                "5",
+                "--json",
+            ]
+        )
+        == 0
+    )
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert payload["query"] == "astro portfolio"
+    assert payload["matches"][0]["title"] == "Astro Notes"
+    assert "secret-body" not in out
+
+
+def test_resolve_memory_recall_target_workspace_defaults(tmp_path: Path):
+    _write_brigade_config(tmp_path, depth="workspace")
+    path, status = memory_hooks.resolve_memory_recall_target(tmp_path)
+    assert status == "active"
+    assert path == tmp_path.resolve()
+
+
+def test_resolve_memory_recall_target_repo_unconfigured(tmp_path: Path):
+    _write_brigade_config(tmp_path, depth="repo")
+    path, status = memory_hooks.resolve_memory_recall_target(tmp_path)
+    assert status == "unconfigured"
+    assert path is None
+    assert memory_hooks.recall_text_for_hook(wired_target=tmp_path, cwd=tmp_path / "astro-portfolio") == ""
+
+
+def test_resolve_memory_recall_target_explicit_mirror(tmp_path: Path):
+    repo = tmp_path / "repo"
+    mirror = tmp_path / "mirror"
+    repo.mkdir()
+    mirror.mkdir()
+    _write_brigade_config(repo, depth="repo", memory_recall_target=str(mirror))
+    path, status = memory_hooks.resolve_memory_recall_target(repo)
+    assert status == "active"
+    assert path == mirror.resolve()

--- a/tests/test_memory_hooks.py
+++ b/tests/test_memory_hooks.py
@@ -203,9 +203,7 @@ def test_recall_cards_payload_enforces_timeout_and_fail_open(tmp_path: Path, mon
     assert payload["cwd"] == str(session)
 
 
-def test_recall_cards_payload_nonzero_exit_and_malformed_stdout_fail_open(
-    tmp_path: Path, monkeypatch
-):
+def test_recall_cards_payload_nonzero_exit_and_malformed_stdout_fail_open(tmp_path: Path, monkeypatch):
     hub = tmp_path / "hub"
     session = tmp_path / "astro-portfolio"
     hub.mkdir()

--- a/tests/test_memory_hooks.py
+++ b/tests/test_memory_hooks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
 
 from brigade import cli, config, memory_hooks
@@ -166,3 +167,52 @@ def test_resolve_memory_recall_target_explicit_mirror(tmp_path: Path):
     path, status = memory_hooks.resolve_memory_recall_target(repo)
     assert status == "active"
     assert path == mirror.resolve()
+
+
+def test_recall_cards_payload_enforces_timeout_and_fail_open(tmp_path: Path, monkeypatch):
+    hub = tmp_path / "hub"
+    session = tmp_path / "astro-portfolio"
+    hub.mkdir()
+    session.mkdir()
+    _write_card(hub, "astro.md", "Astro Notes", "body", tags=["astro"])
+    monkeypatch.setenv(memory_hooks._RECALL_TEST_HANG_ENV, "30")
+    monkeypatch.setattr(memory_hooks, "RECALL_TIMEOUT_SECONDS", 0.25)
+    started = time.monotonic()
+    payload = memory_hooks.recall_cards_payload(target=hub, cwd=session)
+    elapsed = time.monotonic() - started
+    assert payload["status"] == "timeout"
+    assert payload["matches"] == []
+    assert payload["match_count"] == 0
+    assert elapsed < 2.0
+
+
+def test_recall_text_for_hook_timeout_returns_empty(tmp_path: Path, monkeypatch):
+    repo = tmp_path / "repo"
+    hub = tmp_path / "hub"
+    session = tmp_path / "astro-portfolio"
+    repo.mkdir()
+    hub.mkdir()
+    session.mkdir()
+    _write_brigade_config(repo, depth="repo", memory_recall_target=str(hub))
+    _write_card(hub, "astro.md", "Astro Notes", "body", tags=["astro"])
+    monkeypatch.setenv(memory_hooks._RECALL_TEST_HANG_ENV, "30")
+    monkeypatch.setattr(memory_hooks, "RECALL_TIMEOUT_SECONDS", 0.25)
+    started = time.monotonic()
+    text = memory_hooks.recall_text_for_hook(wired_target=repo, cwd=session)
+    elapsed = time.monotonic() - started
+    assert text == ""
+    assert elapsed < 2.0
+
+
+def test_recall_cli_timeout_json_is_fail_open(tmp_path: Path, monkeypatch, capsys):
+    hub = tmp_path / "hub"
+    session = tmp_path / "astro-portfolio"
+    hub.mkdir()
+    session.mkdir()
+    monkeypatch.setenv(memory_hooks._RECALL_TEST_HANG_ENV, "30")
+    monkeypatch.setattr(memory_hooks, "RECALL_TIMEOUT_SECONDS", 0.25)
+    rc = memory_hooks.recall(target=hub, cwd=session, json_output=True)
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["status"] == "timeout"
+    assert payload["matches"] == []

--- a/tests/test_memory_hooks.py
+++ b/tests/test_memory_hooks.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import json
-import time
+import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 
 from brigade import cli, config, memory_hooks
 from brigade.config import Config
@@ -169,21 +170,68 @@ def test_resolve_memory_recall_target_explicit_mirror(tmp_path: Path):
     assert path == mirror.resolve()
 
 
+def _stub_recall_subprocess(
+    monkeypatch,
+    *,
+    timeout: bool = False,
+    returncode: int = 0,
+    stdout: str = "",
+) -> None:
+    def fake_run(*args, **kwargs):
+        if timeout:
+            raise subprocess.TimeoutExpired(
+                cmd=kwargs.get("args") or (args[0] if args else []),
+                timeout=kwargs.get("timeout") or 0.0,
+            )
+        return SimpleNamespace(returncode=returncode, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(memory_hooks.subprocess, "run", fake_run)
+
+
 def test_recall_cards_payload_enforces_timeout_and_fail_open(tmp_path: Path, monkeypatch):
     hub = tmp_path / "hub"
     session = tmp_path / "astro-portfolio"
     hub.mkdir()
     session.mkdir()
     _write_card(hub, "astro.md", "Astro Notes", "body", tags=["astro"])
-    monkeypatch.setenv(memory_hooks._RECALL_TEST_HANG_ENV, "30")
-    monkeypatch.setattr(memory_hooks, "RECALL_TIMEOUT_SECONDS", 0.25)
-    started = time.monotonic()
+    _stub_recall_subprocess(monkeypatch, timeout=True)
     payload = memory_hooks.recall_cards_payload(target=hub, cwd=session)
-    elapsed = time.monotonic() - started
     assert payload["status"] == "timeout"
     assert payload["matches"] == []
     assert payload["match_count"] == 0
-    assert elapsed < 2.0
+    assert payload["target"] == str(hub)
+    assert payload["cwd"] == str(session)
+
+
+def test_recall_cards_payload_nonzero_exit_and_malformed_stdout_fail_open(
+    tmp_path: Path, monkeypatch
+):
+    hub = tmp_path / "hub"
+    session = tmp_path / "astro-portfolio"
+    hub.mkdir()
+    session.mkdir()
+
+    _stub_recall_subprocess(monkeypatch, returncode=1)
+    failed = memory_hooks.recall_cards_payload(target=hub, cwd=session)
+    assert failed["status"] == "error"
+    assert failed["matches"] == []
+
+    _stub_recall_subprocess(monkeypatch, stdout="not-json")
+    malformed = memory_hooks.recall_cards_payload(target=hub, cwd=session)
+    assert malformed["status"] == "error"
+    assert malformed["matches"] == []
+
+
+def test_recall_ignores_legacy_hang_env_variable(tmp_path: Path, monkeypatch):
+    hub = tmp_path / "hub"
+    session = tmp_path / "astro-portfolio"
+    hub.mkdir()
+    session.mkdir()
+    _write_card(hub, "astro.md", "Astro Notes", "body", tags=["astro"])
+    monkeypatch.setenv("BRIGADE_RECALL_TEST_HANG_SECONDS", "30")
+    payload = memory_hooks.recall_cards_payload(target=hub, cwd=session)
+    assert payload["status"] == "ok"
+    assert payload["matches"]
 
 
 def test_recall_text_for_hook_timeout_returns_empty(tmp_path: Path, monkeypatch):
@@ -195,13 +243,9 @@ def test_recall_text_for_hook_timeout_returns_empty(tmp_path: Path, monkeypatch)
     session.mkdir()
     _write_brigade_config(repo, depth="repo", memory_recall_target=str(hub))
     _write_card(hub, "astro.md", "Astro Notes", "body", tags=["astro"])
-    monkeypatch.setenv(memory_hooks._RECALL_TEST_HANG_ENV, "30")
-    monkeypatch.setattr(memory_hooks, "RECALL_TIMEOUT_SECONDS", 0.25)
-    started = time.monotonic()
+    _stub_recall_subprocess(monkeypatch, timeout=True)
     text = memory_hooks.recall_text_for_hook(wired_target=repo, cwd=session)
-    elapsed = time.monotonic() - started
     assert text == ""
-    assert elapsed < 2.0
 
 
 def test_recall_cli_timeout_json_is_fail_open(tmp_path: Path, monkeypatch, capsys):
@@ -209,8 +253,7 @@ def test_recall_cli_timeout_json_is_fail_open(tmp_path: Path, monkeypatch, capsy
     session = tmp_path / "astro-portfolio"
     hub.mkdir()
     session.mkdir()
-    monkeypatch.setenv(memory_hooks._RECALL_TEST_HANG_ENV, "30")
-    monkeypatch.setattr(memory_hooks, "RECALL_TIMEOUT_SECONDS", 0.25)
+    _stub_recall_subprocess(monkeypatch, timeout=True)
     rc = memory_hooks.recall(target=hub, cwd=session, json_output=True)
     payload = json.loads(capsys.readouterr().out)
     assert rc == 0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

Slice 1 of #466 only: productize bounded session-start memory recall as a shared Brigade primitive, then merge it into the managed Claude `SessionStart` hook beside the existing work brief.

Fixes #466

**Scope (this PR):** Slice 1 only. Deferred: handoff enforcement (Slice 2), operator status checks (Slice 3), non-Claude adapters, worker-boundary capture, fleet/remote/VPN transport, nightly session-sweep.

## What landed

- New `brigade memory recall --target <hub-or-mirror> --cwd <session-cwd> --limit 5 [--json]`
- Cwd basename terms split on `-`/`_`; generic `workspace` fallback at the memory root
- Output: title + tags + card path only (max 5 matches / 10 lines); no bodies/summaries
- Machine-local `memory_recall_target` in `.brigade/config.json`
  - workspace depth may default to the current target
  - repo depth stays unconfigured until an explicit hub/mirror is set
- Claude `SessionStart` merges brief + recall once per session (`briefed` gate preserved)
- Fail open on missing/broken targets, config errors, timeouts, and bad input
- Operator smoke steps documented in `docs/memory-care.md`
- Managed Claude hook package bumped to `1.1.0` (SessionStart timeout 20s)

## Blast radius

GraphTrail/MiseLedger not installed in this cloud VM (`brigade code *` → install required). Proceeded with import/call-site inventory of Slice 1 surfaces. Re-inventoried open PRs after #825 merge; no active PR overlapped these files.

## Verify

```text
./scripts/verify
# ruff check/format, mypy, version sync, managed snapshot: ok
# 6535 passed, 5 skipped, 68 subtests passed
# Required coverage of 78% reached. Total coverage: 83.13%
```

## Checklist

- [x] `./scripts/verify` passes locally
- [x] Added or updated tests covering the change
- [x] Updated the `Unreleased` section of `CHANGELOG.md`
- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths
- [x] No new runtime dependencies
- [x] Conventional commit messages

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2b31c5c-69dc-4a68-8788-cc0991d7c2eb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2b31c5c-69dc-4a68-8788-cc0991d7c2eb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

