### PR TITLE
feat(claude-hooks): restore work brief after compaction (#736)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   valid; malformed non-list `decisions` or invalid entries fail closed instead
   of being dropped. `--evidence-ref` stores an opaque receipt path or external
   evidence id (no local-file existence check).
+- Claude compaction restores the work brief on `SessionStart` with
+  `source=compact`, reinjecting the live brief beside bounded session-start
+  recall (#736). A one-shot marker still backs `UserPromptSubmit` when compact
+  reinjection is unavailable; the compact path clears stale markers so prompt
+  submit does not double-inject.
 
 ## [0.26.1] - 2026-08-09
 

--- a/src/brigade/claude_hooks/compaction_marker.py
+++ b/src/brigade/claude_hooks/compaction_marker.py
@@ -1,0 +1,358 @@
+"""One-shot compaction restore markers (issue #736).
+
+Markers live under the user cache directory (never the repo), keyed by a hash of
+session id plus workspace path. Lifecycle:
+
+1. Compaction (``PreCompact``) writes a versioned ``pending`` record.
+2. A later inject-capable event atomically renames ``pending`` to a per-process
+   ``claimed`` file, renders the #735 envelope, then deletes the claim after a
+   successful stdout write.
+3. Rendering or stdout failure returns the claim to ``pending`` so the next
+   event retries.
+4. True ``SessionStart`` (and Claude's inject-capable ``source=compact`` path)
+   clears both states for the session-workspace key.
+
+Hot path: callers ``stat`` for presence; absent markers skip store opens and
+subprocesses.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .. import localio
+from ..component_paths import cache_root
+
+SCHEMA = "brigade.claude-hooks.compaction-marker.v1"
+SCHEMA_VERSION = 1
+MARKER_DIRNAME = "compaction"
+STALE_CLAIM_SECONDS = 60
+CLAIM_KEY = "_brigade_compaction_claim"
+RESTORE_PREFIX = "[Brigade] Context was compacted; the workflow rules below are restored."
+
+
+@dataclass(frozen=True)
+class CompactionClaim:
+    """A process-exclusive claim on a pending compaction marker."""
+
+    key: str
+    path: Path
+    record: dict[str, Any]
+
+
+def markers_root(*, env: dict[str, str] | None = None) -> Path:
+    """Return ``$cache/brigade/claude-hooks/compaction`` (never under a repo)."""
+    root = Path(cache_root(env=env)) / "brigade" / "claude-hooks" / MARKER_DIRNAME
+    return root
+
+
+def marker_key(session_id: str, workspace: Path) -> str:
+    """Stable key distinguishing concurrent sessions and workspaces."""
+    workspace_key = str(workspace.expanduser().resolve(strict=False))
+    return localio.stable_hash({"session_id": session_id, "workspace": workspace_key})
+
+
+def key_dir(key: str, *, env: dict[str, str] | None = None) -> Path:
+    return markers_root(env=env) / key
+
+
+def pending_path(key: str, *, env: dict[str, str] | None = None) -> Path:
+    return key_dir(key, env=env) / "pending.json"
+
+
+def cheap_workspace_root(cwd: object) -> Path | None:
+    """Locate a Brigade-wired root with stats only (no config parse, no store)."""
+    if not isinstance(cwd, str) or not cwd.strip():
+        return None
+    try:
+        current = Path(cwd).expanduser().resolve(strict=False)
+    except OSError:
+        return None
+    if not current.is_dir():
+        current = current.parent
+    for candidate in (current, *current.parents):
+        try:
+            if (candidate / ".brigade" / "config.json").is_file():
+                return candidate
+        except OSError:
+            continue
+    return None
+
+
+def marker_present(key: str, *, env: dict[str, str] | None = None) -> bool:
+    """Fast presence check: pending or any claim file under the key directory."""
+    root = key_dir(key, env=env)
+    try:
+        if not root.is_dir() or root.is_symlink():
+            return False
+        if pending_path(key, env=env).is_file():
+            return True
+        return any(root.glob("claimed-*.json"))
+    except OSError:
+        return False
+
+
+def _chmod_private(path: Path) -> None:
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        return
+
+
+def _ensure_key_dir(key: str, *, env: dict[str, str] | None = None) -> Path:
+    root = markers_root(env=env)
+    _reject_symlink(root.parent.parent)  # brigade/
+    _reject_symlink(root.parent)  # claude-hooks/
+    _reject_symlink(root)
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+        os.chmod(root, 0o700)
+    except OSError:
+        pass
+    _reject_symlink(root)
+    path = key_dir(key, env=env)
+    _reject_symlink(path)
+    path.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(path, 0o700)
+    except OSError:
+        pass
+    _reject_symlink(path)
+    return path
+
+
+def _reject_symlink(path: Path) -> None:
+    if path.exists() and path.is_symlink():
+        raise OSError(f"compaction marker path must not be a symlink: {path}")
+
+
+def _record(
+    *,
+    session_id: str,
+    workspace: Path,
+    trigger: str,
+    trigger_detail: str | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "schema": SCHEMA,
+        "schema_version": SCHEMA_VERSION,
+        "session_id": session_id,
+        "workspace": str(workspace.expanduser().resolve(strict=False)),
+        "created_at": localio.utc_now_iso(),
+        "trigger": trigger,
+    }
+    if trigger_detail:
+        payload["trigger_detail"] = trigger_detail
+    return payload
+
+
+def write_pending(
+    session_id: str,
+    workspace: Path,
+    *,
+    trigger: str = "PreCompact",
+    trigger_detail: str | None = None,
+    env: dict[str, str] | None = None,
+) -> Path:
+    """Publish or replace the pending marker for this session-workspace key."""
+    key = marker_key(session_id, workspace)
+    _ensure_key_dir(key, env=env)
+    path = pending_path(key, env=env)
+    localio.write_text_atomic(
+        path,
+        json.dumps(
+            _record(
+                session_id=session_id,
+                workspace=workspace,
+                trigger=trigger,
+                trigger_detail=trigger_detail,
+            ),
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+    )
+    _chmod_private(path)
+    return path
+
+
+def clear_markers(session_id: str, workspace: Path, *, env: dict[str, str] | None = None) -> None:
+    """Remove pending and claimed markers for the session-workspace key."""
+    key = marker_key(session_id, workspace)
+    root = key_dir(key, env=env)
+    if not root.exists():
+        return
+    if root.is_symlink():
+        return
+    for path in (pending_path(key, env=env), *sorted(root.glob("claimed-*.json"))):
+        try:
+            if path.is_symlink():
+                continue
+            path.unlink(missing_ok=True)
+        except OSError:
+            continue
+    try:
+        root.rmdir()
+    except OSError:
+        return
+
+
+def _read_record(path: Path) -> dict[str, Any] | None:
+    payload = localio.read_json_dict(path)
+    if payload is None:
+        return None
+    if payload.get("schema") != SCHEMA:
+        return None
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        return None
+    return payload
+
+
+def _claim_age_seconds(record: dict[str, Any]) -> float | None:
+    claimed_at = localio.parse_iso_datetime(record.get("claimed_at"))
+    if claimed_at is None:
+        return None
+    return max(0.0, time.time() - claimed_at.timestamp())
+
+
+def _recover_stale_claims(key: str, *, env: dict[str, str] | None = None) -> None:
+    root = key_dir(key, env=env)
+    if not root.is_dir() or root.is_symlink():
+        return
+    pending = pending_path(key, env=env)
+    for path in sorted(root.glob("claimed-*.json")):
+        if path.is_symlink():
+            continue
+        record = _read_record(path)
+        if record is None:
+            try:
+                path.unlink(missing_ok=True)
+            except OSError:
+                continue
+            continue
+        age = _claim_age_seconds(record)
+        if age is None or age < STALE_CLAIM_SECONDS:
+            continue
+        if pending.exists():
+            try:
+                path.unlink(missing_ok=True)
+            except OSError:
+                continue
+            continue
+        try:
+            os.rename(path, pending)
+            _chmod_private(pending)
+        except OSError:
+            continue
+
+
+def try_claim(
+    session_id: str,
+    workspace: Path,
+    *,
+    env: dict[str, str] | None = None,
+    pid: int | None = None,
+) -> CompactionClaim | None:
+    """Atomically claim a pending marker, recovering abandoned claims first."""
+    key = marker_key(session_id, workspace)
+    _recover_stale_claims(key, env=env)
+    pending = pending_path(key, env=env)
+    if not pending.is_file():
+        # A stale claim may have been the only remnant; recovery can restore it.
+        _recover_stale_claims(key, env=env)
+        if not pending.is_file():
+            return None
+    record = _read_record(pending)
+    if record is None:
+        try:
+            pending.unlink(missing_ok=True)
+        except OSError:
+            pass
+        return None
+    claimer = os.getpid() if pid is None else pid
+    nonce = secrets.token_hex(4)
+    claimed = key_dir(key, env=env) / f"claimed-{claimer}-{nonce}.json"
+    try:
+        # Rename first so only one process can own the marker; writers that lose
+        # the race see ENOENT and leave without creating a second claim.
+        os.rename(pending, claimed)
+    except OSError:
+        return None
+    if claimed.is_symlink():
+        try:
+            claimed.unlink(missing_ok=True)
+        except OSError:
+            pass
+        return None
+    claimed_record = dict(record)
+    claimed_record["claimed_at"] = localio.utc_now_iso()
+    claimed_record["claimer_pid"] = claimer
+    try:
+        localio.write_text_atomic(
+            claimed,
+            json.dumps(claimed_record, indent=2, sort_keys=True) + "\n",
+        )
+        _chmod_private(claimed)
+    except OSError:
+        # Ownership already held; keep the claim file so stale recovery can run.
+        return CompactionClaim(key=key, path=claimed, record=record)
+    return CompactionClaim(key=key, path=claimed, record=claimed_record)
+
+
+def release_claim(claim: CompactionClaim, *, env: dict[str, str] | None = None) -> None:
+    """Return a claim to pending so a later event can retry injection."""
+    release_claim_path(claim.path, env=env)
+
+
+def release_claim_path(path: Path, *, env: dict[str, str] | None = None) -> None:
+    """Return a claim file at ``path`` to pending (best-effort)."""
+    del env  # key directory is derived from the claim path
+    if not path.is_file() or path.is_symlink():
+        return
+    pending = path.parent / "pending.json"
+    record = _read_record(path)
+    if record is not None:
+        cleaned = {key: value for key, value in record.items() if key not in {"claimed_at", "claimer_pid"}}
+        try:
+            localio.write_text_atomic(
+                path,
+                json.dumps(cleaned, indent=2, sort_keys=True) + "\n",
+            )
+            _chmod_private(path)
+        except OSError:
+            return
+    if pending.exists():
+        try:
+            path.unlink(missing_ok=True)
+        except OSError:
+            return
+        return
+    try:
+        os.rename(path, pending)
+        _chmod_private(pending)
+    except OSError:
+        return
+
+
+def complete_claim(claim: CompactionClaim) -> None:
+    """Drop a claim after the #735 envelope was written to stdout successfully."""
+    complete_claim_path(claim.path)
+
+
+def complete_claim_path(path: Path) -> None:
+    try:
+        if path.is_symlink():
+            return
+        path.unlink(missing_ok=True)
+    except OSError:
+        return
+    try:
+        path.parent.rmdir()
+    except OSError:
+        return

--- a/src/brigade/claude_hooks/package.py
+++ b/src/brigade/claude_hooks/package.py
@@ -10,7 +10,15 @@ PACKAGE_ID = "brigade-claude-work-loop"
 PACKAGE_VERSION = "1.1.0"
 PACKAGE_REF = f"{PACKAGE_ID}@{PACKAGE_VERSION}"
 COMMAND_PREFIX = "brigade work hook-run"
-MANAGED_EVENTS = ("SessionStart", "PreToolUse", "PostToolUse", "PostToolUseFailure", "Stop")
+MANAGED_EVENTS = (
+    "SessionStart",
+    "UserPromptSubmit",
+    "PreToolUse",
+    "PostToolUse",
+    "PostToolUseFailure",
+    "PreCompact",
+    "Stop",
+)
 LEGACY_SCRIPT_NAME = "brigade-work-loop.py"
 MANAGED_MARKER_KEY = "_brigade"
 HOOK_SCRIPT_NAME = "brigade-claude-work-loop.sh"
@@ -36,9 +44,11 @@ def managed_groups() -> dict[str, list[dict[str, Any]]]:
 
     return {
         "SessionStart": [group("SessionStart")],
+        "UserPromptSubmit": [group("UserPromptSubmit")],
         "PreToolUse": [group("PreToolUse", "Bash"), group("PreToolUse", "Edit|Write|NotebookEdit")],
         "PostToolUse": [group("PostToolUse", "Bash|Edit|Write|NotebookEdit")],
         "PostToolUseFailure": [group("PostToolUseFailure", "Bash")],
+        "PreCompact": [group("PreCompact")],
         "Stop": [group("Stop")],
     }
 
@@ -91,9 +101,11 @@ def managed_user_groups(script_path: Path) -> dict[str, list[dict[str, Any]]]:
 
     return {
         "SessionStart": [group("SessionStart")],
+        "UserPromptSubmit": [group("UserPromptSubmit")],
         "PreToolUse": [group("PreToolUse", "Bash"), group("PreToolUse", "Edit|Write|NotebookEdit")],
         "PostToolUse": [group("PostToolUse", "Bash|Edit|Write|NotebookEdit")],
         "PostToolUseFailure": [group("PostToolUseFailure", "Bash")],
+        "PreCompact": [group("PreCompact")],
         "Stop": [group("Stop")],
     }
 

--- a/src/brigade/claude_hooks/package.py
+++ b/src/brigade/claude_hooks/package.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 
 PACKAGE_ID = "brigade-claude-work-loop"
-PACKAGE_VERSION = "1.1.0"
+PACKAGE_VERSION = "1.2.0"
 PACKAGE_REF = f"{PACKAGE_ID}@{PACKAGE_VERSION}"
 COMMAND_PREFIX = "brigade work hook-run"
 MANAGED_EVENTS = (

--- a/src/brigade/claude_hooks/runtime.py
+++ b/src/brigade/claude_hooks/runtime.py
@@ -2026,15 +2026,22 @@ def handle_payload(event: str, payload: dict[str, Any]) -> dict[str, Any] | None
             pass
         source = payload.get("source")
         if source == "compact":
+            # Compaction restart: restore the work brief (#736) and keep #834
+            # bounded recall on the same SessionStart injection.
             brief_text = _run_brief(target)
+            recall_text = _run_recall(target, payload)
             state["briefed"] = True
             write_session_state(target, session_id, state)
+            records = _restore_brief_records(brief_text)
+            if recall_text.strip():
+                records.extend(_brief_records(recall_text))
+            combined = brief_text if not recall_text.strip() else f"{brief_text}\n{recall_text}"
             return _additional_context(
                 "SessionStart",
-                brief_text,
+                combined,
                 target=target,
                 session_id=session_id,
-                records=_restore_brief_records(brief_text),
+                records=records,
             )
         if state.get("briefed"):
             return None

--- a/src/brigade/claude_hooks/runtime.py
+++ b/src/brigade/claude_hooks/runtime.py
@@ -17,7 +17,7 @@ from typing import Any, Iterator
 
 from .. import localio
 from ..wiring import resolve_wired_target
-from . import envelope
+from . import compaction_marker, envelope
 from .package import PACKAGE_REF
 
 BRIEF_TIMEOUT_SECONDS = 10
@@ -1918,7 +1918,90 @@ def _unwired_init_hint(payload: dict[str, Any]) -> dict[str, Any] | None:
     )
 
 
+def _restore_brief_records(brief_text: str) -> list[str]:
+    return [compaction_marker.RESTORE_PREFIX, *_brief_records(brief_text)]
+
+
+def _attach_claim(result: dict[str, Any], claim: compaction_marker.CompactionClaim) -> dict[str, Any]:
+    attached = dict(result)
+    attached[compaction_marker.CLAIM_KEY] = str(claim.path)
+    return attached
+
+
+def _strip_claim(result: dict[str, Any] | None) -> tuple[dict[str, Any] | None, Path | None]:
+    if not isinstance(result, dict) or compaction_marker.CLAIM_KEY not in result:
+        return result, None
+    cleaned = dict(result)
+    raw = cleaned.pop(compaction_marker.CLAIM_KEY)
+    if not isinstance(raw, str) or not raw:
+        return cleaned, None
+    return cleaned, Path(raw)
+
+
+def _handle_pre_compact(payload: dict[str, Any]) -> dict[str, Any] | None:
+    """Record a pending restore marker; PreCompact cannot inject context."""
+    session_id = payload.get("session_id")
+    if not isinstance(session_id, str) or not session_id:
+        return None
+    target = wired_target_from_payload(payload)
+    if target is None:
+        return None
+    trigger_detail = payload.get("trigger")
+    detail = trigger_detail if isinstance(trigger_detail, str) and trigger_detail.strip() else None
+    try:
+        compaction_marker.write_pending(
+            session_id,
+            target,
+            trigger="PreCompact",
+            trigger_detail=detail,
+        )
+    except OSError as exc:
+        raise HookDegraded(f"compaction marker write failed: {exc}") from exc
+    return None
+
+
+def _handle_user_prompt_submit(payload: dict[str, Any]) -> dict[str, Any] | None:
+    """Restore the brief once after compaction; absent markers stay near-free."""
+    session_id = payload.get("session_id")
+    if not isinstance(session_id, str) or not session_id:
+        return None
+    workspace = compaction_marker.cheap_workspace_root(payload.get("cwd"))
+    if workspace is None:
+        return None
+    key = compaction_marker.marker_key(session_id, workspace)
+    if not compaction_marker.marker_present(key):
+        return None
+    # Confirm the workspace is still a Claude-wired Brigade repo before claiming.
+    target = resolve_wired_target(str(workspace))
+    if target is None:
+        return None
+    try:
+        claim = compaction_marker.try_claim(session_id, target)
+    except OSError as exc:
+        raise HookDegraded(f"compaction marker claim failed: {exc}") from exc
+    if claim is None:
+        return None
+    try:
+        brief_text = _run_brief(target)
+        result = _additional_context(
+            "UserPromptSubmit",
+            brief_text,
+            target=target,
+            session_id=session_id,
+            records=_restore_brief_records(brief_text),
+        )
+        return _attach_claim(result, claim)
+    except Exception:
+        compaction_marker.release_claim(claim)
+        raise
+
+
 def handle_payload(event: str, payload: dict[str, Any]) -> dict[str, Any] | None:
+    if event == "PreCompact":
+        return _handle_pre_compact(payload)
+    if event == "UserPromptSubmit":
+        return _handle_user_prompt_submit(payload)
+
     target = wired_target_from_payload(payload)
     if target is None:
         if event == "SessionStart":
@@ -1935,6 +2018,24 @@ def handle_payload(event: str, payload: dict[str, Any]) -> dict[str, Any] | None
     if event != "Stop":
         _touch_session_targets(session_id, target, payload)
     if event == "SessionStart":
+        # True starts and Claude's inject-capable compact source both clear any
+        # leftover marker so UserPromptSubmit does not double-inject.
+        try:
+            compaction_marker.clear_markers(session_id, target)
+        except OSError:
+            pass
+        source = payload.get("source")
+        if source == "compact":
+            brief_text = _run_brief(target)
+            state["briefed"] = True
+            write_session_state(target, session_id, state)
+            return _additional_context(
+                "SessionStart",
+                brief_text,
+                target=target,
+                session_id=session_id,
+                records=_restore_brief_records(brief_text),
+            )
         if state.get("briefed"):
             return None
         brief_text = _run_brief(target)
@@ -2294,6 +2395,7 @@ def hook_run(*, event: str, package: str, stdin_text: str | None = None) -> int:
 
     log_target: Path | None = None
     raw = ""
+    claim_path: Path | None = None
     try:
         raw = sys.stdin.read() if stdin_text is None else stdin_text
         try:
@@ -2305,7 +2407,11 @@ def hook_run(*, event: str, package: str, stdin_text: str | None = None) -> int:
         payload = parsed
         log_target = _resolve_log_target(payload)
         result = _run_timed_handle_payload(event, raw)
+        result, claim_path = _strip_claim(result)
     except HookDegraded as exc:
+        if claim_path is not None:
+            compaction_marker.release_claim_path(claim_path)
+            claim_path = None
         if log_target is not None:
             envelope.append_log(log_target, f"{event}: degraded: {exc}")
         else:
@@ -2317,6 +2423,9 @@ def hook_run(*, event: str, package: str, stdin_text: str | None = None) -> int:
         envelope.emit_stdout(envelope.degraded_envelope(event))
         return 0
     except Exception as exc:  # noqa: BLE001 - hooks must fail open instead of breaking the harness
+        if claim_path is not None:
+            compaction_marker.release_claim_path(claim_path)
+            claim_path = None
         if log_target is not None:
             envelope.append_log(log_target, f"{event}: error: {type(exc).__name__}: {exc}")
         envelope.emit_stdout(envelope.degraded_envelope(event))
@@ -2325,10 +2434,16 @@ def hook_run(*, event: str, package: str, stdin_text: str | None = None) -> int:
     try:
         _emit_result(event, result, target=log_target)
     except Exception as exc:  # noqa: BLE001 - stdout failure still fails open
+        if claim_path is not None:
+            compaction_marker.release_claim_path(claim_path)
+            claim_path = None
         if log_target is not None:
             envelope.append_log(log_target, f"{event}: emit failed: {exc}")
         try:
             envelope.emit_stdout(envelope.degraded_envelope(event))
         except Exception:  # noqa: BLE001
             pass
+        return 0
+    if claim_path is not None:
+        compaction_marker.complete_claim_path(claim_path)
     return 0

--- a/src/brigade/cli/work/registration.py
+++ b/src/brigade/cli/work/registration.py
@@ -8,6 +8,7 @@ import json
 from pathlib import Path
 
 from ... import extras as _extras_mod
+from ...claude_hooks.package import MANAGED_EVENTS as _CLAUDE_HOOK_EVENTS
 from ...dogfood_cmd import DEFAULT_TIMEOUT_SECONDS
 from ...work_cmd import TASK_PRIORITIES, TASK_SEAT_CLASSES, TASK_TYPES
 from .. import extras as _extras_cli
@@ -81,7 +82,7 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_work_hook_run.add_argument(
         "--event",
         required=True,
-        choices=["SessionStart", "PreToolUse", "PostToolUse", "PostToolUseFailure", "Stop"],
+        choices=list(_CLAUDE_HOOK_EVENTS),
         help="Claude hook event to handle.",
     )
     p_work_hook_run.add_argument("--package", required=True, help="Managed hook package id and version.")

--- a/tests/test_claude_hooks_compaction_marker.py
+++ b/tests/test_claude_hooks_compaction_marker.py
@@ -1,0 +1,258 @@
+"""Claude compaction restore marker (issue #736)."""
+
+from __future__ import annotations
+
+import json
+import stat
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from brigade.claude_hooks import compaction_marker, envelope, runtime
+from brigade.claude_hooks.package import MANAGED_EVENTS, PACKAGE_REF
+from brigade.install import install_selection
+from brigade.selection import Selection
+
+
+def _wired_claude(tmp_path: Path) -> Path:
+    target = tmp_path / "repo"
+    selection = Selection(depth="repo", harnesses=["claude"], owner="claude", includes=[])
+    assert install_selection(target, selection) == 0
+    return target
+
+
+def _cache_env(tmp_path: Path) -> dict[str, str]:
+    cache = tmp_path / "xdg-cache"
+    cache.mkdir(parents=True, exist_ok=True)
+    return {"XDG_CACHE_HOME": str(cache), "HOME": str(tmp_path / "home")}
+
+
+def _payload(target: Path, event: str, *, session_id: str = "session-1", **extra):
+    return {
+        "session_id": session_id,
+        "cwd": str(target),
+        "hook_event_name": event,
+        **extra,
+    }
+
+
+@pytest.fixture
+def marker_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
+    env = _cache_env(tmp_path)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    (tmp_path / "home").mkdir(parents=True, exist_ok=True)
+    return env
+
+
+def test_managed_events_include_compaction_hooks():
+    assert "PreCompact" in MANAGED_EVENTS
+    assert "UserPromptSubmit" in MANAGED_EVENTS
+
+
+def test_marker_lives_in_cache_not_repo(tmp_path: Path, marker_env: dict[str, str]):
+    target = _wired_claude(tmp_path)
+    path = compaction_marker.write_pending("sess-a", target, env=marker_env)
+    assert path.is_file()
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    assert ".brigade" not in path.parts or path.parts[path.parts.index(".brigade") - 1] != "repo"
+    assert str(path).startswith(str(Path(marker_env["XDG_CACHE_HOME"])))
+    assert not any(target.rglob("pending.json"))
+
+
+def test_marker_keys_separate_workspaces_sharing_session_id(tmp_path: Path, marker_env: dict[str, str]):
+    left = _wired_claude(tmp_path / "left")
+    right_root = tmp_path / "right"
+    right = _wired_claude(right_root)
+    session_id = "shared-session"
+    compaction_marker.write_pending(session_id, left, env=marker_env)
+    compaction_marker.write_pending(session_id, right, env=marker_env)
+    assert compaction_marker.marker_key(session_id, left) != compaction_marker.marker_key(session_id, right)
+    assert compaction_marker.marker_present(compaction_marker.marker_key(session_id, left), env=marker_env)
+    assert compaction_marker.marker_present(compaction_marker.marker_key(session_id, right), env=marker_env)
+
+
+def test_concurrent_claims_only_one_winner(tmp_path: Path, marker_env: dict[str, str]):
+    target = _wired_claude(tmp_path)
+    compaction_marker.write_pending("race", target, env=marker_env)
+
+    def claim(_index: int):
+        return compaction_marker.try_claim("race", target, env=marker_env)
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(claim, range(8)))
+    winners = [item for item in results if item is not None]
+    assert len(winners) == 1
+    pending = compaction_marker.pending_path(compaction_marker.marker_key("race", target), env=marker_env)
+    assert not pending.exists()
+    assert winners[0].path.is_file()
+
+
+def test_stale_claim_returns_to_pending(tmp_path: Path, marker_env: dict[str, str], monkeypatch):
+    target = _wired_claude(tmp_path)
+    compaction_marker.write_pending("stale", target, env=marker_env)
+    claim = compaction_marker.try_claim("stale", target, env=marker_env)
+    assert claim is not None
+    # Backdate claimed_at beyond the stale window.
+    record = dict(claim.record)
+    record["claimed_at"] = "2000-01-01T00:00:00+00:00"
+    claim.path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    monkeypatch.setattr(compaction_marker, "STALE_CLAIM_SECONDS", 1)
+    time.sleep(0.01)
+    recovered = compaction_marker.try_claim("stale", target, env=marker_env)
+    assert recovered is not None
+    assert recovered.path != claim.path
+    assert not claim.path.exists()
+
+
+def test_cache_directory_symlink_is_rejected(tmp_path: Path, marker_env: dict[str, str]):
+    target = _wired_claude(tmp_path)
+    root = compaction_marker.markers_root(env=marker_env)
+    root.parent.mkdir(parents=True, exist_ok=True)
+    real = tmp_path / "elsewhere"
+    real.mkdir()
+    if root.exists():
+        root.rmdir()
+    root.symlink_to(real)
+    with pytest.raises(OSError, match="symlink"):
+        compaction_marker.write_pending("sym", target, env=marker_env)
+
+
+def test_precompact_writes_marker_and_empty_envelope(tmp_path: Path, marker_env: dict[str, str], capsys):
+    target = _wired_claude(tmp_path)
+    payload = _payload(target, "PreCompact", trigger="auto")
+    assert runtime.handle_payload("PreCompact", payload) is None
+    key = compaction_marker.marker_key("session-1", target)
+    assert compaction_marker.marker_present(key)
+    capsys.readouterr()
+    assert runtime.hook_run(event="PreCompact", package=PACKAGE_REF, stdin_text=json.dumps(payload)) == 0
+    assert json.loads(capsys.readouterr().out) == envelope.empty_envelope("PreCompact")
+
+
+def test_user_prompt_hot_path_skips_brief_when_marker_absent(tmp_path: Path, marker_env: dict[str, str], monkeypatch):
+    target = _wired_claude(tmp_path)
+    calls: list[Path] = []
+
+    def boom(repo: Path) -> str:
+        calls.append(repo)
+        raise AssertionError("brief must not run on hot path")
+
+    monkeypatch.setattr(runtime, "_run_brief", boom)
+    assert runtime.handle_payload("UserPromptSubmit", _payload(target, "UserPromptSubmit")) is None
+    assert calls == []
+
+
+def test_user_prompt_restores_brief_once_then_clears_marker(
+    tmp_path: Path, marker_env: dict[str, str], monkeypatch, capsys
+):
+    target = _wired_claude(tmp_path)
+    monkeypatch.setattr(runtime, "_run_brief", lambda repo: "rule-one\nrule-two")
+    assert runtime.handle_payload("PreCompact", _payload(target, "PreCompact", trigger="manual")) is None
+    payload = _payload(target, "UserPromptSubmit")
+    capsys.readouterr()
+    assert runtime.hook_run(event="UserPromptSubmit", package=PACKAGE_REF, stdin_text=json.dumps(payload)) == 0
+    out = json.loads(capsys.readouterr().out)
+    context = out["hookSpecificOutput"]["additionalContext"]
+    assert context.startswith("[Brigade] If this context appears truncated")
+    assert compaction_marker.RESTORE_PREFIX in context
+    assert "rule-one" in context and "rule-two" in context
+    assert compaction_marker.CLAIM_KEY not in out
+    key = compaction_marker.marker_key("session-1", target)
+    assert not compaction_marker.marker_present(key)
+    # Second submit is a no-op hot path.
+    assert runtime.handle_payload("UserPromptSubmit", payload) is None
+
+
+def test_injection_failure_leaves_marker_for_retry(tmp_path: Path, marker_env: dict[str, str], monkeypatch, capsys):
+    target = _wired_claude(tmp_path)
+    compaction_marker.write_pending("session-1", target)
+
+    def boom(_repo: Path) -> str:
+        raise runtime.HookDegraded("store unreadable")
+
+    monkeypatch.setattr(runtime, "_run_brief", boom)
+    payload = _payload(target, "UserPromptSubmit")
+    capsys.readouterr()
+    assert runtime.hook_run(event="UserPromptSubmit", package=PACKAGE_REF, stdin_text=json.dumps(payload)) == 0
+    assert json.loads(capsys.readouterr().out) == envelope.degraded_envelope("UserPromptSubmit")
+    key = compaction_marker.marker_key("session-1", target)
+    assert compaction_marker.marker_present(key)
+    pending = compaction_marker.pending_path(key)
+    assert pending.is_file()
+
+
+def test_emit_failure_returns_claim_to_pending(tmp_path: Path, marker_env: dict[str, str], monkeypatch, capsys):
+    target = _wired_claude(tmp_path)
+    monkeypatch.setattr(runtime, "_run_brief", lambda repo: "brief-body")
+    compaction_marker.write_pending("session-1", target)
+
+    def boom(_payload: dict) -> None:
+        raise OSError("stdout broken")
+
+    monkeypatch.setattr(envelope, "emit_stdout", boom)
+    payload = _payload(target, "UserPromptSubmit")
+    capsys.readouterr()
+    assert runtime.hook_run(event="UserPromptSubmit", package=PACKAGE_REF, stdin_text=json.dumps(payload)) == 0
+    key = compaction_marker.marker_key("session-1", target)
+    assert compaction_marker.pending_path(key).is_file()
+
+
+def test_session_start_clears_stale_markers(tmp_path: Path, marker_env: dict[str, str], monkeypatch):
+    target = _wired_claude(tmp_path)
+    monkeypatch.setattr(runtime, "_run_brief", lambda repo: "brief")
+    compaction_marker.write_pending("session-1", target)
+    # Already briefed: silent, but still clears markers.
+    runtime.handle_payload("SessionStart", _payload(target, "SessionStart", source="startup"))
+    runtime.handle_payload("SessionStart", _payload(target, "SessionStart", source="startup"))
+    key = compaction_marker.marker_key("session-1", target)
+    assert not compaction_marker.marker_present(key)
+
+
+def test_session_start_compact_reinjects_without_marker(tmp_path: Path, marker_env: dict[str, str], monkeypatch):
+    target = _wired_claude(tmp_path)
+    monkeypatch.setattr(runtime, "_run_brief", lambda repo: "compact-brief")
+    first = runtime.handle_payload("SessionStart", _payload(target, "SessionStart", source="startup"))
+    assert "compact-brief" in first["hookSpecificOutput"]["additionalContext"]
+    # Leave a marker as if PreCompact raced ahead; compact source clears it.
+    compaction_marker.write_pending("session-1", target)
+    restored = runtime.handle_payload(
+        "SessionStart",
+        _payload(target, "SessionStart", source="compact"),
+    )
+    context = restored["hookSpecificOutput"]["additionalContext"]
+    assert compaction_marker.RESTORE_PREFIX in context
+    assert "compact-brief" in context
+    assert not compaction_marker.marker_present(compaction_marker.marker_key("session-1", target))
+    # Marker path stays silent after Claude's preferred compact reinjection.
+    assert runtime.handle_payload("UserPromptSubmit", _payload(target, "UserPromptSubmit")) is None
+
+
+def test_two_prompt_events_do_not_double_inject(tmp_path: Path, marker_env: dict[str, str], monkeypatch):
+    target = _wired_claude(tmp_path)
+    calls: list[str] = []
+
+    def brief(repo: Path) -> str:
+        calls.append(str(repo))
+        return "once-only"
+
+    monkeypatch.setattr(runtime, "_run_brief", brief)
+    compaction_marker.write_pending("session-1", target)
+    payload = _payload(target, "UserPromptSubmit")
+
+    def run_once(_index: int) -> dict:
+        # Use handle_payload + manual claim completion to race at claim time.
+        return runtime.handle_payload("UserPromptSubmit", payload)  # type: ignore[return-value]
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        results = list(pool.map(run_once, range(4)))
+    injected = [item for item in results if item is not None]
+    assert len(injected) == 1
+    assert len(calls) == 1
+    # Complete the winning claim the way hook_run would.
+    cleaned, claim_path = runtime._strip_claim(injected[0])
+    assert claim_path is not None
+    assert compaction_marker.CLAIM_KEY not in cleaned
+    compaction_marker.complete_claim_path(claim_path)
+    assert runtime.handle_payload("UserPromptSubmit", payload) is None

--- a/tests/test_claude_hooks_runtime.py
+++ b/tests/test_claude_hooks_runtime.py
@@ -151,6 +151,51 @@ def test_session_start_recall_fail_open_keeps_brief(tmp_path: Path, monkeypatch)
     assert "memory recall:" not in context
 
 
+def test_session_start_compact_source_restores_brief_and_recall_once(tmp_path: Path, monkeypatch):
+    from brigade.claude_hooks import compaction_marker
+
+    target = _wired_claude(tmp_path)
+    session_cwd = target / "astro-portfolio"
+    session_cwd.mkdir()
+    recall_text = "memory recall: astro portfolio\n- Astro Notes | tags: astro | memory/cards/astro.md"
+    recall_calls: list[str | None] = []
+
+    def fake_recall(_target: Path, payload: dict) -> str:
+        recall_calls.append(payload.get("source") if isinstance(payload.get("source"), str) else None)
+        return recall_text
+
+    monkeypatch.setattr(runtime, "_run_brief", lambda repo: "compact-restored-brief")
+    monkeypatch.setattr(runtime, "_run_recall", fake_recall)
+
+    startup = runtime.handle_payload(
+        "SessionStart",
+        _payload(target, "SessionStart", source="startup", cwd=str(session_cwd)),
+    )
+    assert startup is not None
+    assert "compact-restored-brief" in startup["hookSpecificOutput"]["additionalContext"]
+    assert recall_calls == ["startup"]
+
+    recall_calls.clear()
+    compact = runtime.handle_payload(
+        "SessionStart",
+        _payload(target, "SessionStart", source="compact", cwd=str(session_cwd)),
+    )
+    assert compact is not None
+    context = compact["hookSpecificOutput"]["additionalContext"]
+    assert compaction_marker.RESTORE_PREFIX in context
+    assert "compact-restored-brief" in context
+    assert "memory recall: astro portfolio" in context
+    assert context.count("memory recall: astro portfolio") == 1
+    assert recall_calls == ["compact"]
+    assert (
+        runtime.handle_payload(
+            "SessionStart",
+            _payload(target, "SessionStart", source="startup", cwd=str(session_cwd)),
+        )
+        is None
+    )
+
+
 def test_all_events_are_inert_for_unwired_repo(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(runtime, "_run_brief", lambda target: (_ for _ in ()).throw(AssertionError(target)))
     assert runtime.handle_payload("SessionStart", _payload(tmp_path, "SessionStart")) is None

--- a/tests/test_claude_hooks_settings_merge.py
+++ b/tests/test_claude_hooks_settings_merge.py
@@ -120,7 +120,15 @@ def test_hooks_status_reports_complete_stale_package_as_installed(tmp_path: Path
 
     assert status["installed"] is True
     assert status["current"] is False
-    assert status["managed_events"] == ["SessionStart", "PreToolUse", "PostToolUse", "PostToolUseFailure", "Stop"]
+    assert status["managed_events"] == [
+        "SessionStart",
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PostToolUse",
+        "PostToolUseFailure",
+        "PreCompact",
+        "Stop",
+    ]
     assert status["missing_events"] == []
 
 


### PR DESCRIPTION
## Summary

- Restore the Brigade work brief after Claude context compaction using cache-local markers keyed by session and workspace.
- Record pending restoration on `PreCompact`, then claim and inject it once on `UserPromptSubmit`, with stale-claim recovery and retry after failed injection.
- Preserve the existing compact-source memory recall path and clear stale markers on a true session start.

## Verification

- `20260810-075538-work-verify-b334c5`: focused hook tests passed after rebase.
- `20260810-080156-work-verify-295da7`: 137 compact-marker, runtime, settings-merge, and user-scope tests passed.
- `20260810-080212-work-verify-4e3ccd`: Ruff check passed.
- `20260810-080222-work-verify-c0239a`: Ruff format check passed.

## Review focus

Check marker claim recovery and the compact-source brief-plus-recall composition. Marker records stay in the user cache and the hook fails open.

Closes #736