### PR TITLE
fix(handoff): preserve salvageable lint state in JSON (#798)

### DIFF
--- a/src/brigade/handoff_cmd/linting.py
+++ b/src/brigade/handoff_cmd/linting.py
@@ -148,6 +148,7 @@ def lint(
                 warnings=result.warnings + injection_messages,
                 hints=result.hints,
                 readability=result.readability,
+                salvageable=result.salvageable,
             )
         )
     if strict:
@@ -166,6 +167,7 @@ def lint(
                     warnings=result.warnings,
                     hints=result.hints,
                     readability=result.readability,
+                    salvageable=result.salvageable,
                 )
             )
         enriched_results = strict_results

--- a/tests/test_handoff_cmd.py
+++ b/tests/test_handoff_cmd.py
@@ -2060,6 +2060,26 @@ def test_handoff_lint_distinguishes_structured_homegrown_note_from_garbage(tmp_p
     assert not garbage_result.hints
 
 
+def test_handoff_lint_text_and_json_agree_on_salvageable_verdict(tmp_path, capsys):
+    structured = tmp_path / "structured.md"
+    structured.write_text(
+        "# Project note\n\n"
+        "## What happened\n\nThe cache was rebuilt after stale results appeared.\n\n"
+        "## Why it matters\n\nFuture runs now use current inputs.\n\n"
+        "## Decisions\n\nKeep the validation step.\n\n"
+        "## Next steps\n\nDocument the recovery command.\n"
+    )
+
+    for strict in (False, True):
+        assert handoff_cmd.lint(target=tmp_path, paths=[structured], strict=strict) == 1
+        text_output = capsys.readouterr().out
+        assert "hint: structured note detected" in text_output
+
+        assert handoff_cmd.lint(target=tmp_path, paths=[structured], json_output=True, strict=strict) == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["results"][0]["salvageable"] is True
+
+
 def test_handoff_migrate_dry_run_plans_homegrown_note(tmp_path, capsys):
     inbox = tmp_path / ".claude" / "memory-handoffs"
     note = _homegrown_note(inbox)


### PR DESCRIPTION
## Summary

- Preserve the `salvageable` classification when normal and strict lint results are reconstructed.
- Add text and JSON regressions for both strict modes.

## Verification

- `20260810-104413-work-verify-adf29b`: 87 focused handoff tests passed.
- `20260810-104518-work-verify-17e269`: Ruff lint and format checks passed.

## Review note

The local pre-push scan reported existing-history findings outside this two-file diff. Independent changed-file leak review was clean, and GitHub Actions remains the final gate.

Closes #798