### PR TITLE
docs(contributing): make the first PR path visible (Refs #763)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,51 @@
 
 Brigade is the local-first operator CLI for agent memory, handoffs, and reviewable work receipts. It grew out of [Solomon's Cookbook](https://github.com/escoffier-labs/solos-cookbook), and patches are welcome. Before you start, please skim this file so we both spend our time on the right things.
 
+## Your first PR
+
+External contributions are welcome. This section is the short path; **Pull requests** below lists the full merge gates.
+
+1. **Pick work.** Look for issues labeled `good first issue` or `help wanted`. If nothing fits, comment on an existing issue or open one before you spend time on a surprise scope.
+2. **Claim it.** Comment on the issue that you are working on it. The maintainer holds off internal lanes for **48 hours** so your branch is not steamrolled.
+3. **Install and test locally.** From a repo clone with Python 3.10+:
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev]" && pytest -q
+```
+
+That is the minimal loop for a docs-only change. Code changes should pass `./scripts/verify` before you push (see **Local dev** below).
+4. **Open a pull request.** Required CI checks run automatically on the branch. You do not need to dispatch all 22 jobs yourself.
+5. **Review turnaround.** Target an initial review within a few business days once required checks are green. Merge still waits on the formal review and gate rules in **Pull requests**.
+
+## Pull requests
+
+`main` is branch-protected. A dispatched session cannot supply the review artifact required by its own pull request, and GitHub enforces the gate regardless of the dispatch prompt.
+
+The current rule set requires all of the following before a pull request can merge:
+
+- All 22 required GitHub Actions checks pass. The checks are pinned to GitHub Actions app id 15368, and the branch must be up to date with `main`.
+- A current formal `APPROVED` review exists from a non-author reviewer.
+- All review conversations are resolved.
+- The approval was recorded after the last push. New commits dismiss stale approvals.
+
+The pull request author cannot approve their own pull request. `gh pr review --approve` fails with "Can not approve your own pull request" when the author and reviewer share one GitHub identity.
+
+CodeRabbit is the current external review identity. Its green commit status is not the grading artifact because the status can be green while the formal GitHub review is still `CHANGES_REQUESTED`. The artifacts that count are a current formal non-author `APPROVED` review and all required checks passing.
+
+Inspect the gate before attempting a merge:
+
+```bash
+gh pr checks <number> --required
+gh pr view <number> --json reviewDecision,mergeStateStatus
+```
+
+`reviewDecision` reports `REVIEW_REQUIRED`, `CHANGES_REQUESTED`, or `APPROVED`. `mergeStateStatus` reports states such as `CLEAN`, `BLOCKED`, and `BEHIND`.
+
+Those CLI fields do not expose unresolved review conversations. Separately check the pull request's **Files changed** review panel in GitHub and confirm that no conversation remains unresolved.
+
+Dispatched sessions should open the pull request, run local verification, and push commits. After the final push, comment `@coderabbitai full review`. The `coderabbitai[bot]` identity records the formal GitHub review. Wait for its current `APPROVED` review before merging. A green CodeRabbit commit status alone does not satisfy this gate.
+
 ## What kinds of changes land easily
 
 - **Bug fixes** for `brigade init`, `doctor`, `scrub`, quickstart, security scanning, or the ingester.
@@ -46,34 +91,6 @@ git init -q -b main "$target"
 python -m brigade init --target "$target" --depth workspace --harnesses claude,codex,openclaw
 python -m brigade doctor --target "$target"
 ```
-
-## Pull requests
-
-`main` is branch-protected. A dispatched session cannot supply the review artifact required by its own pull request, and GitHub enforces the gate regardless of the dispatch prompt.
-
-The current rule set requires all of the following before a pull request can merge:
-
-- All 22 required GitHub Actions checks pass. The checks are pinned to GitHub Actions app id 15368, and the branch must be up to date with `main`.
-- A current formal `APPROVED` review exists from a non-author reviewer.
-- All review conversations are resolved.
-- The approval was recorded after the last push. New commits dismiss stale approvals.
-
-The pull request author cannot approve their own pull request. `gh pr review --approve` fails with "Can not approve your own pull request" when the author and reviewer share one GitHub identity.
-
-CodeRabbit is the current external review identity. Its green commit status is not the grading artifact because the status can be green while the formal GitHub review is still `CHANGES_REQUESTED`. The artifacts that count are a current formal non-author `APPROVED` review and all required checks passing.
-
-Inspect the gate before attempting a merge:
-
-```bash
-gh pr checks <number> --required
-gh pr view <number> --json reviewDecision,mergeStateStatus
-```
-
-`reviewDecision` reports `REVIEW_REQUIRED`, `CHANGES_REQUESTED`, or `APPROVED`. `mergeStateStatus` reports states such as `CLEAN`, `BLOCKED`, and `BEHIND`.
-
-Those CLI fields do not expose unresolved review conversations. Separately check the pull request's **Files changed** review panel in GitHub and confirm that no conversation remains unresolved.
-
-Dispatched sessions should open the pull request, run local verification, and push commits. After the final push, comment `@coderabbitai full review`. The `coderabbitai[bot]` identity records the formal GitHub review. Wait for its current `APPROVED` review before merging. A green CodeRabbit commit status alone does not satisfy this gate.
 
 ## Adding a harness
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ rules, and when to use `brigade update` are in
 
 Per-OS setup (apt, Homebrew, Scoop, PowerShell), workspace depth, and multi-harness installs: [install guide](https://brigade.tools/docs/getting-started/install), [QUICKSTART.md](QUICKSTART.md), [first 10 minutes](docs/first-10-minutes.md). Homegrown setup already? `brigade operator adopt plan`.
 
+**Contributing?** See [CONTRIBUTING.md](CONTRIBUTING.md) for starter issues, the 48-hour claim convention, and the minimal local test command (`pip install -e ".[dev]" && pytest -q`).
+
 ## Auditable agents: every action leaves a receipt
 
 An agent that reports "tests pass, nothing else changed" is making a claim. Brigade turns the claim into a record. Run any check through Brigade and it writes a receipt: the command, the real exit code, the graph delta, the git state.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

Contributors landing from PyPI or a clone could not find the claim convention, minimal local test loop, or merge gates without reading maintainer shorthand scattered across the backlog. This slice adds a short **Your first PR** section near the top of CONTRIBUTING and moves the full pull-request enforcement rules directly below it without weakening policy. README install guidance now links to that path in one line.

Refs #763

## Type of change

- [x] Docs

## Checklist

- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths in this PR
- [x] No new runtime dependencies
- [x] Conventional commit message

## Label seeding shortlist (read-only, for landing shepherd)

No GitHub labels or issue bodies were changed in this PR. After merge, the shepherd should verify fit, add plain-language summaries to issue bodies where noted, and apply `good first issue` or `help wanted` as appropriate. All listed issues are currently unassigned and have no open pull request referencing them.

| Issue | Why it may fit | Body work needed |
|-------|----------------|------------------|
| [#494](https://github.com/escoffier-labs/brigade/issues/494) | Templates and install-metadata docs; bounded enhancement with a clear What / Why | One-line plain summary at top (issue notes low priority relative to the batch) |
| [#495](https://github.com/escoffier-labs/brigade/issues/495) | Evidence brief UX with testable acceptance; single-feature scope | One-line plain summary at top |
| [#498](https://github.com/escoffier-labs/brigade/issues/498) | Security-adjacent ingestion policy with explicit redaction contract | One-line plain summary at top |
| [#493](https://github.com/escoffier-labs/brigade/issues/493) | Well-scoped schema slice with checklist acceptance; larger than typical good-first | One-line plain summary at top (complex; shepherd should confirm size label) |

Note: the open backlog is mostly assigned; these are the unowned issues in the current queue that appear closest to docs, test coverage, or small scoped fixes. Issues #762 and #759 are also unowned but are maintainer dogfood or scheduler work and are poorer external starter fits.

## Verification

- `brigade security template-audit --target .` (no new findings in README or CONTRIBUTING)
- content-guard scan via CI policy (local run, no blocked findings in changed files)
- Vale: no `.vale.ini` in repo; attempted with generic config only (pre-existing README spelling noise); blocked on missing repository Vale config
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1a6e583b-a7a4-4054-afeb-a8108e014e04?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a6e583b-a7a4-4054-afeb-a8108e014e04&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

