### PR TITLE
feat(templates): bundled template-profile registry metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ Thumbs.db
 !/scripts/windows-native-acceptance.ps1
 !/scripts/published-artifact-acceptance.py
 !/scripts/generate_component_manifest.py
+!/scripts/template_registry.py
 !/scripts/verify_version_check_endpoint.py
 !/scripts/hyper-v-native-acceptance.ps1
 /skills/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Bundled template-profile registry (`brigade.template_registry.v1`): named
+  profiles expose supported harness versions and deterministic rendered-file
+  hashes, and `brigade init --profile <name>` selects a bundled preset without
+  changing profile-less `--depth` / `--harnesses` installs. Refs #494.
 - Bounded session-start memory recall (#466 Slice 1): `brigade memory recall
   --target <hub-or-mirror> --cwd <session-cwd> --limit 5 [--json]` derives query
   terms from the cwd basename, returns title/tags/path only (max 5 matches /

--- a/scripts/template_registry.py
+++ b/scripts/template_registry.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Generate or validate Brigade's bundled template-profile registry."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from brigade import localio, template_registry  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--write", action="store_true", help="write the bundled template registry")
+    mode.add_argument("--check", action="store_true", help="validate the committed template registry")
+    args = parser.parse_args()
+
+    path = template_registry.registry_path()
+    if args.write:
+        payload = template_registry.build_registry()
+        localio.write_text_atomic(path, template_registry.render_registry(payload))
+        print(f"template registry: wrote {path} ({len(payload['profiles'])} profiles)")
+        return 0
+
+    try:
+        payload = template_registry.load_registry(path)
+    except ValueError as exc:
+        print(f"template registry: {exc}", file=sys.stderr)
+        return 1
+    expected = template_registry.render_registry(payload)
+    actual = path.read_text(encoding="utf-8")
+    if actual != expected:
+        print(f"template registry: non-canonical JSON at {path}", file=sys.stderr)
+        return 1
+    print(f"template registry: ok ({len(payload['profiles'])} profiles)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify
+++ b/scripts/verify
@@ -13,4 +13,5 @@ PY=${PY:-.venv/bin}
 # Run `python scripts/version_sync.py --write` to fix drift in one shot.
 "$PY/python" scripts/version_sync.py --check
 "$PY/python" scripts/managed_snapshot.py --check
+"$PY/python" scripts/template_registry.py --check
 "$PY/pytest" -q --cov=brigade --cov-report=term --cov-fail-under=78

--- a/src/brigade/cli/init.py
+++ b/src/brigade/cli/init.py
@@ -40,6 +40,11 @@ def register(sub: argparse._SubParsersAction) -> None:
     )
     p_init.add_argument("--dry-run", action="store_true", help="Show what would happen.")
     p_init.add_argument(
+        "--profile",
+        default=None,
+        help="Named bundled template profile (e.g. repo-claude). Mutually exclusive with --depth and --harnesses.",
+    )
+    p_init.add_argument(
         "--depth",
         choices=["repo", "workspace"],
         default=None,
@@ -73,8 +78,59 @@ def register(sub: argparse._SubParsersAction) -> None:
 
 
 def dispatch(args) -> int:
+    profile = getattr(args, "profile", None)
+    depth_arg = getattr(args, "depth", None)
+    harnesses_arg = getattr(args, "harnesses", None)
+    if profile is not None:
+        if depth_arg is not None or harnesses_arg is not None:
+            print(
+                "error: --profile cannot be combined with --depth or --harnesses",
+                file=sys.stderr,
+            )
+            return 2
+        from ..template_registry import UnknownTemplateProfile, resolve_profile
+        from ..install import install_selection
+        from ..selection import resolve_owner
+
+        try:
+            sel = resolve_profile(profile)
+        except UnknownTemplateProfile as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        except ValueError as exc:
+            print(f"error: template registry invalid: {exc}", file=sys.stderr)
+            return 2
+        includes = list(sel.includes)
+        if getattr(args, "full", False) and sel.depth == "repo" and "repo-extras" not in includes:
+            includes.append("repo-extras")
+        if args.owner is not None:
+            try:
+                owner = resolve_owner(sel.harnesses, override=args.owner)
+            except ValueError as exc:
+                print(f"error: {exc}", file=sys.stderr)
+                return 2
+        else:
+            owner = sel.owner
+        sel = type(sel)(
+            depth=sel.depth,
+            harnesses=list(sel.harnesses),
+            owner=owner,
+            includes=includes,
+            surfaces=list(sel.surfaces),
+        )
+        return install_selection(
+            target=args.target,
+            selection=sel,
+            force=getattr(args, "force", False),
+            dry_run=getattr(args, "dry_run", False),
+            allow_home=getattr(args, "allow_home", False),
+            use_git_exclude=getattr(args, "git_exclude", False),
+            update_gitignore=getattr(args, "update_gitignore", True),
+            wire_skills=getattr(args, "wire_skills", True),
+        )
+
     # New v0.3.0 path: --depth/--harnesses build a Selection directly.
-    if getattr(args, "depth", None) is not None or getattr(args, "harnesses", None) is not None:
+    if depth_arg is not None or harnesses_arg is not None:
         from ..selection import Selection, KNOWN_HARNESSES, resolve_owner
         from ..install import install_selection
 

--- a/src/brigade/install.py
+++ b/src/brigade/install.py
@@ -237,6 +237,24 @@ def _replace_managed_gitignore_blocks(
     return "".join(output), True
 
 
+def build_render_context(selection: Selection) -> dict[str, str]:
+    """Build the placeholder context used when rendering text templates."""
+    owner_label = harness_memory_owner(selection.owner, selection.owner)
+    writer_inboxes = [WRITER_INBOXES[h] for h in selection.harnesses if h in WRITER_INBOXES]
+    owner_inbox = WRITER_INBOXES.get(selection.owner)
+    if owner_inbox:
+        writer_inboxes = [owner_inbox] + [p for p in writer_inboxes if p != owner_inbox]
+    if not writer_inboxes:
+        writer_inboxes = [WRITER_INBOXES["claude"]]
+    return {
+        "memory_owner": selection.owner,
+        "memory_owner_name": owner_label,
+        "harness": selection.owner,
+        "handoff_inbox": f"{writer_inboxes[0]}/",
+        "handoff_inboxes": ", ".join(f"`{p}/`" for p in writer_inboxes),
+    }
+
+
 def resolve_manifests(selection: Selection) -> Tuple[List[dict], List[str], List[str]]:
     """Return (files, dirs, post_install_notes) for a Selection.
 
@@ -355,20 +373,7 @@ def install_selection(
     for d in dirs:
         (target / d).mkdir(parents=True, exist_ok=True)
 
-    owner_label = harness_memory_owner(selection.owner, selection.owner)
-    writer_inboxes = [WRITER_INBOXES[h] for h in selection.harnesses if h in WRITER_INBOXES]
-    owner_inbox = WRITER_INBOXES.get(selection.owner)
-    if owner_inbox:
-        writer_inboxes = [owner_inbox] + [p for p in writer_inboxes if p != owner_inbox]
-    if not writer_inboxes:
-        writer_inboxes = [WRITER_INBOXES["claude"]]
-    context = {
-        "memory_owner": selection.owner,
-        "memory_owner_name": owner_label,
-        "harness": selection.owner,
-        "handoff_inbox": f"{writer_inboxes[0]}/",
-        "handoff_inboxes": ", ".join(f"`{p}/`" for p in writer_inboxes),
-    }
+    context = build_render_context(selection)
 
     root = template_root()
     kept_files: list[Path] = []
@@ -445,7 +450,7 @@ def install_selection(
     print(
         f"brigade: installed depth={selection.depth} harnesses={','.join(selection.harnesses) or '(none)'} -> {target}"
     )
-    print(f"brigade: memory owner -> {owner_label}")
+    print(f"brigade: memory owner -> {context['memory_owner_name']}")
     if kept_files:
         print(
             f"brigade: kept {len(kept_files)} existing file(s); re-run init only if you intend "

--- a/src/brigade/template_registry.py
+++ b/src/brigade/template_registry.py
@@ -1,0 +1,324 @@
+"""Bundled template-profile registry: selection presets, harness versions, render hashes."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from . import __version__
+from .install import build_render_context, resolve_manifests
+from .selection import Selection
+from .templates import is_text, render, template_root
+from .update_notify import parse_version
+
+SCHEMA = "brigade.template_registry.v1"
+PROFILE_IDENTITY_PREFIX = "brigade://template-profiles/"
+
+
+class UnknownTemplateProfile(ValueError):
+    """A named template profile is not in the bundled registry."""
+
+    def __init__(self, profile_name: str) -> None:
+        self.profile_name = profile_name
+        super().__init__(f"unknown template profile: {profile_name!r}")
+
+
+class UnsupportedHarnessVersion(ValueError):
+    """A harness version is below the profile's supported minimum."""
+
+    def __init__(self, harness_id: str, version: str, minimum: str) -> None:
+        self.harness_id = harness_id
+        self.version = version
+        self.minimum = minimum
+        super().__init__(f"harness {harness_id!r} version {version!r} is below profile minimum {minimum!r}")
+
+
+BUILTIN_PROFILES: dict[str, dict[str, Any]] = {
+    "repo-claude": {
+        "description": "Minimal repo install with Claude Code bridge.",
+        "selection": {
+            "depth": "repo",
+            "harnesses": ["claude"],
+            "owner": "claude",
+            "includes": [],
+        },
+        "supported_harness_versions": {
+            "claude": {"min": "0.0.0", "tested": "0.0.0"},
+        },
+    },
+    "workspace-claude-codex": {
+        "description": "Full workspace with Claude and Codex bridges.",
+        "selection": {
+            "depth": "workspace",
+            "harnesses": ["claude", "codex"],
+            "owner": "claude",
+            "includes": [],
+        },
+        "supported_harness_versions": {
+            "claude": {"min": "0.0.0", "tested": "0.0.0"},
+            "codex": {"min": "0.0.0", "tested": "0.0.0"},
+        },
+    },
+    "repo-claude-full": {
+        "description": "Repo depth with Claude and the full kit (repo-extras).",
+        "selection": {
+            "depth": "repo",
+            "harnesses": ["claude"],
+            "owner": "claude",
+            "includes": ["repo-extras"],
+        },
+        "supported_harness_versions": {
+            "claude": {"min": "0.0.0", "tested": "0.0.0"},
+        },
+    },
+}
+
+
+def registry_path() -> Path:
+    return template_root() / "template-registry.json"
+
+
+def _version_at_least(version: str, minimum: str) -> bool:
+    parsed_version = parse_version(version)
+    parsed_minimum = parse_version(minimum)
+    if parsed_version is None or parsed_minimum is None:
+        return False
+    width = max(len(parsed_version), len(parsed_minimum))
+    return tuple(parsed_version + (0,) * (width - len(parsed_version))) >= tuple(
+        parsed_minimum + (0,) * (width - len(parsed_minimum))
+    )
+
+
+def _validate_harness_version_spec(harness_id: str, spec: Any) -> dict[str, str]:
+    if not isinstance(spec, dict):
+        raise ValueError(f"supported_harness_versions[{harness_id!r}] must be an object")
+    minimum = spec.get("min")
+    tested = spec.get("tested")
+    if not isinstance(minimum, str) or parse_version(minimum) is None:
+        raise ValueError(f"supported_harness_versions[{harness_id!r}].min must be a semver string")
+    if not isinstance(tested, str) or parse_version(tested) is None:
+        raise ValueError(f"supported_harness_versions[{harness_id!r}].tested must be a semver string")
+    return {"min": minimum, "tested": tested}
+
+
+def _selection_from_mapping(raw: Mapping[str, Any]) -> Selection:
+    depth = raw.get("depth")
+    harnesses = raw.get("harnesses")
+    owner = raw.get("owner", "this-repo")
+    includes = raw.get("includes", [])
+    if not isinstance(depth, str):
+        raise ValueError("profile selection.depth must be a string")
+    if not isinstance(harnesses, list) or not all(isinstance(item, str) for item in harnesses):
+        raise ValueError("profile selection.harnesses must be a string list")
+    if not isinstance(owner, str):
+        raise ValueError("profile selection.owner must be a string")
+    if not isinstance(includes, list) or not all(isinstance(item, str) for item in includes):
+        raise ValueError("profile selection.includes must be a string list")
+    selection = Selection(
+        depth=depth,
+        harnesses=list(harnesses),
+        owner=owner,
+        includes=list(includes),
+    )
+    selection.validate()
+    return selection
+
+
+def _profile_record(name: str, raw: Mapping[str, Any]) -> dict[str, Any]:
+    description = raw.get("description")
+    selection_raw = raw.get("selection")
+    versions_raw = raw.get("supported_harness_versions")
+    if not isinstance(description, str) or not description:
+        raise ValueError(f"profile {name!r} needs a non-empty description")
+    if not isinstance(selection_raw, dict):
+        raise ValueError(f"profile {name!r} selection must be an object")
+    selection = _selection_from_mapping(selection_raw)
+    if not isinstance(versions_raw, dict):
+        raise ValueError(f"profile {name!r} supported_harness_versions must be an object")
+    versions: dict[str, dict[str, str]] = {}
+    for harness_id in selection.harnesses:
+        if harness_id not in versions_raw:
+            raise ValueError(f"profile {name!r} must declare supported_harness_versions for harness {harness_id!r}")
+        versions[harness_id] = _validate_harness_version_spec(harness_id, versions_raw[harness_id])
+    extra = set(versions_raw) - set(selection.harnesses)
+    if extra:
+        raise ValueError(
+            f"profile {name!r} supported_harness_versions has entries for unselected harnesses: {sorted(extra)}"
+        )
+    return {
+        "description": description,
+        "identity": f"{PROFILE_IDENTITY_PREFIX}{name}",
+        "selection": {
+            "depth": selection.depth,
+            "harnesses": selection.harnesses,
+            "owner": selection.owner,
+            "includes": selection.includes,
+        },
+        "supported_harness_versions": versions,
+    }
+
+
+def compute_profile_renders(selection: Selection) -> list[dict[str, Any]]:
+    """Return deterministic rendered-file hashes for a selection."""
+    files, _, _ = resolve_manifests(selection)
+    context = build_render_context(selection)
+    root = template_root()
+    renders: list[dict[str, Any]] = []
+    for entry in sorted(files, key=lambda item: item["dst"]):
+        src = root / entry["src"]
+        if not src.is_file():
+            raise FileNotFoundError(f"template missing for render hash: {src}")
+        if is_text(entry["src"]):
+            content = render(src.read_text(encoding="utf-8"), context).encode("utf-8")
+            rendered = True
+        else:
+            content = src.read_bytes()
+            rendered = False
+        renders.append(
+            {
+                "dst": entry["dst"],
+                "sha256": hashlib.sha256(content).hexdigest(),
+                "byte_size": len(content),
+                "rendered": rendered,
+            }
+        )
+    return renders
+
+
+def build_registry(profile_names: Sequence[str] | None = None) -> dict[str, Any]:
+    names = sorted(profile_names or BUILTIN_PROFILES)
+    profiles: dict[str, dict[str, Any]] = {}
+    renders: dict[str, list[dict[str, Any]]] = {}
+    for name in names:
+        raw = BUILTIN_PROFILES.get(name)
+        if raw is None:
+            raise ValueError(f"unknown built-in profile: {name!r}")
+        profile = _profile_record(name, raw)
+        profiles[name] = profile
+        selection = _selection_from_mapping(profile["selection"])
+        renders[name] = compute_profile_renders(selection)
+    return {
+        "schema": SCHEMA,
+        "brigade_version": __version__,
+        "profiles": profiles,
+        "renders": renders,
+    }
+
+
+def render_registry(payload: Mapping[str, Any]) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def _validate_render_records(records: Any) -> list[dict[str, Any]]:
+    if not isinstance(records, list):
+        raise ValueError("render records must be a list")
+    seen: set[str] = set()
+    normalized: list[dict[str, Any]] = []
+    for record in records:
+        if not isinstance(record, dict):
+            raise ValueError("render record must be an object")
+        dst = record.get("dst")
+        sha256 = record.get("sha256")
+        byte_size = record.get("byte_size")
+        rendered = record.get("rendered")
+        if not isinstance(dst, str) or not dst or dst in seen:
+            raise ValueError(f"invalid or duplicate render dst: {dst!r}")
+        if not isinstance(sha256, str) or len(sha256) != 64:
+            raise ValueError(f"render dst {dst!r} needs a sha256 digest")
+        if not isinstance(byte_size, int) or byte_size < 0:
+            raise ValueError(f"render dst {dst!r} needs a non-negative byte_size")
+        if not isinstance(rendered, bool):
+            raise ValueError(f"render dst {dst!r} needs a rendered boolean")
+        seen.add(dst)
+        normalized.append(
+            {
+                "dst": dst,
+                "sha256": sha256,
+                "byte_size": byte_size,
+                "rendered": rendered,
+            }
+        )
+    return normalized
+
+
+def load_registry(path: Path | None = None) -> dict[str, Any]:
+    source_path = path or registry_path()
+    try:
+        payload = json.loads(source_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"template registry could not be loaded: {source_path}") from exc
+    if not isinstance(payload, dict) or payload.get("schema") != SCHEMA:
+        raise ValueError(f"template registry schema must be {SCHEMA}")
+    brigade_version = payload.get("brigade_version")
+    if not isinstance(brigade_version, str) or not brigade_version:
+        raise ValueError("template registry brigade_version must be a non-empty string")
+    profiles_raw = payload.get("profiles")
+    renders_raw = payload.get("renders")
+    if not isinstance(profiles_raw, dict):
+        raise ValueError("template registry profiles must be an object")
+    if not isinstance(renders_raw, dict):
+        raise ValueError("template registry renders must be an object")
+    profiles: dict[str, dict[str, Any]] = {}
+    for name in sorted(profiles_raw):
+        profile = _profile_record(name, profiles_raw[name])
+        profiles[name] = profile
+        expected_renders = compute_profile_renders(_selection_from_mapping(profile["selection"]))
+        actual_renders = _validate_render_records(renders_raw.get(name))
+        if actual_renders != expected_renders:
+            raise ValueError(f"template registry render digest mismatch for profile {name!r}")
+    extra_renders = set(renders_raw) - set(profiles)
+    if extra_renders:
+        raise ValueError(f"template registry renders has unknown profiles: {sorted(extra_renders)}")
+    return {
+        "schema": SCHEMA,
+        "brigade_version": brigade_version,
+        "profiles": profiles,
+        "renders": {name: renders_raw[name] for name in sorted(profiles)},
+    }
+
+
+def list_profile_names(path: Path | None = None) -> list[str]:
+    return sorted(load_registry(path)["profiles"])
+
+
+def resolve_profile(profile_name: str, path: Path | None = None) -> Selection:
+    """Resolve a named bundled profile to a validated Selection."""
+    registry = load_registry(path)
+    profile = registry["profiles"].get(profile_name)
+    if profile is None:
+        raise UnknownTemplateProfile(profile_name)
+    selection = _selection_from_mapping(profile["selection"])
+    return selection
+
+
+def check_harness_version(
+    profile_name: str,
+    harness_id: str,
+    version: str,
+    *,
+    path: Path | None = None,
+) -> None:
+    """Raise UnsupportedHarnessVersion when version is below the profile minimum."""
+    registry = load_registry(path)
+    profile = registry["profiles"].get(profile_name)
+    if profile is None:
+        raise UnknownTemplateProfile(profile_name)
+    versions = profile.get("supported_harness_versions", {})
+    spec = versions.get(harness_id)
+    if not isinstance(spec, dict):
+        raise ValueError(f"profile {profile_name!r} does not select harness {harness_id!r}")
+    minimum = spec["min"]
+    if not _version_at_least(version, minimum):
+        raise UnsupportedHarnessVersion(harness_id, version, minimum)
+
+
+def profile_metadata(profile_name: str, *, path: Path | None = None) -> dict[str, Any]:
+    registry = load_registry(path)
+    profile = registry["profiles"].get(profile_name)
+    if profile is None:
+        raise UnknownTemplateProfile(profile_name)
+    return deepcopy(profile)

--- a/src/brigade/templates/template-registry.json
+++ b/src/brigade/templates/template-registry.json
@@ -1,0 +1,393 @@
+{
+  "brigade_version": "0.26.1",
+  "profiles": {
+    "repo-claude": {
+      "description": "Minimal repo install with Claude Code bridge.",
+      "identity": "brigade://template-profiles/repo-claude",
+      "selection": {
+        "depth": "repo",
+        "harnesses": [
+          "claude"
+        ],
+        "includes": [],
+        "owner": "claude"
+      },
+      "supported_harness_versions": {
+        "claude": {
+          "min": "0.0.0",
+          "tested": "0.0.0"
+        }
+      }
+    },
+    "repo-claude-full": {
+      "description": "Repo depth with Claude and the full kit (repo-extras).",
+      "identity": "brigade://template-profiles/repo-claude-full",
+      "selection": {
+        "depth": "repo",
+        "harnesses": [
+          "claude"
+        ],
+        "includes": [
+          "repo-extras"
+        ],
+        "owner": "claude"
+      },
+      "supported_harness_versions": {
+        "claude": {
+          "min": "0.0.0",
+          "tested": "0.0.0"
+        }
+      }
+    },
+    "workspace-claude-codex": {
+      "description": "Full workspace with Claude and Codex bridges.",
+      "identity": "brigade://template-profiles/workspace-claude-codex",
+      "selection": {
+        "depth": "workspace",
+        "harnesses": [
+          "claude",
+          "codex"
+        ],
+        "includes": [],
+        "owner": "claude"
+      },
+      "supported_harness_versions": {
+        "claude": {
+          "min": "0.0.0",
+          "tested": "0.0.0"
+        },
+        "codex": {
+          "min": "0.0.0",
+          "tested": "0.0.0"
+        }
+      }
+    }
+  },
+  "renders": {
+    "repo-claude": [
+      {
+        "byte_size": 1108,
+        "dst": ".brigade/handoff-sources.example.json",
+        "rendered": false,
+        "sha256": "4d32bfa7dfa7816841aadf1c2efa6a049198c1face8bf721e6203c0333701a58"
+      },
+      {
+        "byte_size": 872,
+        "dst": ".brigade/policies/personal.json",
+        "rendered": false,
+        "sha256": "bb4e59151a0d8822ea7eeb4d11e9f77154d7748b9f87a15c714e9ebbe080b436"
+      },
+      {
+        "byte_size": 754,
+        "dst": ".brigade/policies/public-repo.json",
+        "rendered": false,
+        "sha256": "c54518f4cff1f04817f2b497e7d6bc1870699b60caf181185045541ff0af8c92"
+      },
+      {
+        "byte_size": 1424,
+        "dst": ".claude/memory-handoffs/TEMPLATE.md",
+        "rendered": true,
+        "sha256": "f9cd9806d987f85f43ad7a7450593cfb1ee0649c9a1c50d28df8cf013608f23c"
+      },
+      {
+        "byte_size": 4847,
+        "dst": "AGENTS.md",
+        "rendered": true,
+        "sha256": "0f23a2bd6467ed7b29711d438ad3fc0042d62a9aa34c9c42a3b6fd4eac58631c"
+      },
+      {
+        "byte_size": 2216,
+        "dst": "CLAUDE.md",
+        "rendered": true,
+        "sha256": "e33b63334b7ca776b5a41b47f7d4be16303a27147dd10e61053260a4e1efe8ff"
+      },
+      {
+        "byte_size": 6331,
+        "dst": "SAFETY_RULES.md",
+        "rendered": true,
+        "sha256": "d133ba8fdb2a580d44b896aaaf744c9d1516ce8b2019fbc1aab8a3a351000bcc"
+      }
+    ],
+    "repo-claude-full": [
+      {
+        "byte_size": 1108,
+        "dst": ".brigade/handoff-sources.example.json",
+        "rendered": false,
+        "sha256": "4d32bfa7dfa7816841aadf1c2efa6a049198c1face8bf721e6203c0333701a58"
+      },
+      {
+        "byte_size": 872,
+        "dst": ".brigade/policies/personal.json",
+        "rendered": false,
+        "sha256": "bb4e59151a0d8822ea7eeb4d11e9f77154d7748b9f87a15c714e9ebbe080b436"
+      },
+      {
+        "byte_size": 754,
+        "dst": ".brigade/policies/public-repo.json",
+        "rendered": false,
+        "sha256": "c54518f4cff1f04817f2b497e7d6bc1870699b60caf181185045541ff0af8c92"
+      },
+      {
+        "byte_size": 1424,
+        "dst": ".claude/memory-handoffs/TEMPLATE.md",
+        "rendered": true,
+        "sha256": "f9cd9806d987f85f43ad7a7450593cfb1ee0649c9a1c50d28df8cf013608f23c"
+      },
+      {
+        "byte_size": 4847,
+        "dst": "AGENTS.md",
+        "rendered": true,
+        "sha256": "0f23a2bd6467ed7b29711d438ad3fc0042d62a9aa34c9c42a3b6fd4eac58631c"
+      },
+      {
+        "byte_size": 2216,
+        "dst": "CLAUDE.md",
+        "rendered": true,
+        "sha256": "e33b63334b7ca776b5a41b47f7d4be16303a27147dd10e61053260a4e1efe8ff"
+      },
+      {
+        "byte_size": 2210,
+        "dst": "INSTALL_FOR_AGENTS.md",
+        "rendered": true,
+        "sha256": "92630c7db302eeea5993187d9a9772972f2d569284a66e1ef98ea46449f3756b"
+      },
+      {
+        "byte_size": 6331,
+        "dst": "SAFETY_RULES.md",
+        "rendered": true,
+        "sha256": "d133ba8fdb2a580d44b896aaaf744c9d1516ce8b2019fbc1aab8a3a351000bcc"
+      },
+      {
+        "byte_size": 8148,
+        "dst": "hooks/pre-push",
+        "rendered": false,
+        "sha256": "556efbc045adef273a9ff3c03bc703e35a326f95a6d90157bc6173437924bd99"
+      },
+      {
+        "byte_size": 1121,
+        "dst": "rules/acceptance-driven-work.md",
+        "rendered": true,
+        "sha256": "531a3b30619029b01ea7ffefb118638eea2fcc858ae9cfbd634e34723e9f2b9e"
+      },
+      {
+        "byte_size": 1194,
+        "dst": "rules/issue-tdd-loop.md",
+        "rendered": true,
+        "sha256": "79bb1c9ed0b14c235614193fb26e2e15aaef971a0d9c9ff89b37e7ea3d09ba8b"
+      }
+    ],
+    "workspace-claude-codex": [
+      {
+        "byte_size": 3414,
+        "dst": ".brigade/chat-memory-sweep.example.json",
+        "rendered": false,
+        "sha256": "5d29c607824c03e156eb522491903ab2aa5874f6138804d86ec20f9831b74c79"
+      },
+      {
+        "byte_size": 1108,
+        "dst": ".brigade/handoff-sources.example.json",
+        "rendered": false,
+        "sha256": "4d32bfa7dfa7816841aadf1c2efa6a049198c1face8bf721e6203c0333701a58"
+      },
+      {
+        "byte_size": 511,
+        "dst": ".brigade/memory-care.example.json",
+        "rendered": false,
+        "sha256": "bdfb973a6225b16ddf26d0e6d66947723cf3039052c36644dc9380ec501d42e7"
+      },
+      {
+        "byte_size": 872,
+        "dst": ".brigade/policies/personal.json",
+        "rendered": false,
+        "sha256": "bb4e59151a0d8822ea7eeb4d11e9f77154d7748b9f87a15c714e9ebbe080b436"
+      },
+      {
+        "byte_size": 754,
+        "dst": ".brigade/policies/public-repo.json",
+        "rendered": false,
+        "sha256": "c54518f4cff1f04817f2b497e7d6bc1870699b60caf181185045541ff0af8c92"
+      },
+      {
+        "byte_size": 1424,
+        "dst": ".claude/memory-handoffs/TEMPLATE.md",
+        "rendered": true,
+        "sha256": "f9cd9806d987f85f43ad7a7450593cfb1ee0649c9a1c50d28df8cf013608f23c"
+      },
+      {
+        "byte_size": 1424,
+        "dst": ".codex/memory-handoffs/TEMPLATE.md",
+        "rendered": true,
+        "sha256": "f9cd9806d987f85f43ad7a7450593cfb1ee0649c9a1c50d28df8cf013608f23c"
+      },
+      {
+        "byte_size": 11823,
+        "dst": "AGENTS.md",
+        "rendered": true,
+        "sha256": "87dd1344f69c9c78075fcac94c62b9f032b98ecef3c79c44d28fb2985c106253"
+      },
+      {
+        "byte_size": 3226,
+        "dst": "CLAUDE.md",
+        "rendered": true,
+        "sha256": "2ab6e4d9a8dcd24d5c063eac56439f61c29bffedbe6102f2057cde66e3b0664a"
+      },
+      {
+        "byte_size": 1578,
+        "dst": "HEARTBEAT.md",
+        "rendered": true,
+        "sha256": "3a3ff123f454c9d9eed6591d162a026b744fb555524acccf5a161599243b5833"
+      },
+      {
+        "byte_size": 735,
+        "dst": "IDENTITY.md",
+        "rendered": true,
+        "sha256": "f9d92ede54fd60564cb2b39dc776491111498f2b2f45ebbb0c5de759c6f8bd02"
+      },
+      {
+        "byte_size": 4431,
+        "dst": "INSTALL_FOR_AGENTS.md",
+        "rendered": true,
+        "sha256": "3a7e9a3aa2677f0c2d5bcff46a3e7b65414deaa3fffb397b41dd5cb015bc6d0d"
+      },
+      {
+        "byte_size": 4873,
+        "dst": "MEMORY.md",
+        "rendered": true,
+        "sha256": "d08485c9c00bb4e6d3811e71d49871a76372a8c4b960d89492cab2e2b814c2db"
+      },
+      {
+        "byte_size": 6331,
+        "dst": "SAFETY_RULES.md",
+        "rendered": true,
+        "sha256": "d133ba8fdb2a580d44b896aaaf744c9d1516ce8b2019fbc1aab8a3a351000bcc"
+      },
+      {
+        "byte_size": 5122,
+        "dst": "SOUL.md",
+        "rendered": true,
+        "sha256": "3f4509bc1f269eccfe4303ecc41204ff78cf670d480d451fa1ec0f4003c19279"
+      },
+      {
+        "byte_size": 4749,
+        "dst": "TOOLS.md",
+        "rendered": true,
+        "sha256": "53fe19ed20ad8fe8cc754f135d588ad489af559a59990b3b6b5b32d080bc7d20"
+      },
+      {
+        "byte_size": 2062,
+        "dst": "USER.md",
+        "rendered": true,
+        "sha256": "76d5b8da982a7907d78967456ce2ad6c86069e8e55578c861ed3d7aab8d1a9ae"
+      },
+      {
+        "byte_size": 8148,
+        "dst": "hooks/pre-push",
+        "rendered": false,
+        "sha256": "556efbc045adef273a9ff3c03bc703e35a326f95a6d90157bc6173437924bd99"
+      },
+      {
+        "byte_size": 5259,
+        "dst": "memory/cards/backup-restic.md",
+        "rendered": true,
+        "sha256": "0eda477da2526d337c5589f1b143c2cbe60be63ad70dfaca4194f64956c0d136"
+      },
+      {
+        "byte_size": 6264,
+        "dst": "memory/cards/chat-surface-crawlers.md",
+        "rendered": true,
+        "sha256": "6f5d6e8eda5c8d6537b05283838c21250ebb0063be239db96d36e9b1609eaec0"
+      },
+      {
+        "byte_size": 1967,
+        "dst": "memory/cards/content-safety.md",
+        "rendered": true,
+        "sha256": "094d37f8e9f9e3abf8883fbc412e18bfa4de6fdff5528a2afb5d9bfbddcecafa"
+      },
+      {
+        "byte_size": 3258,
+        "dst": "memory/cards/handoff-flow.md",
+        "rendered": true,
+        "sha256": "996140feb4a54265732c01c0b8f37e14479d4df14ecf938122b0a9901fae5ca1"
+      },
+      {
+        "byte_size": 2080,
+        "dst": "memory/cards/memory-architecture.md",
+        "rendered": true,
+        "sha256": "0fb656c0b51505fff201b47260e69aac4ce6165be9ab4c480ea5fe44f2e52908"
+      },
+      {
+        "byte_size": 3009,
+        "dst": "memory/cards/memory-care-staleness.md",
+        "rendered": true,
+        "sha256": "b9e91694892da5fe81597ac9ae19bb28467a0186d7251de7bd71d64befb31988"
+      },
+      {
+        "byte_size": 6537,
+        "dst": "memory/cards/memory-scanner.md",
+        "rendered": true,
+        "sha256": "b35f4904693402364a24831e24d0f3286180410dc5b5249ca427883a26125137"
+      },
+      {
+        "byte_size": 2772,
+        "dst": "memory/cards/multi-workspace-handoff-admin.md",
+        "rendered": true,
+        "sha256": "a0d3afbd184bacb4aeba1ba436f8382c838a407ae07b4a044cce7d715f827f29"
+      },
+      {
+        "byte_size": 3834,
+        "dst": "memory/cards/obsidian-notes.md",
+        "rendered": true,
+        "sha256": "ba1e8ce25bdfea76d981673165c7a901799bc30b5d054af47545ad0579278b3b"
+      },
+      {
+        "byte_size": 3906,
+        "dst": "memory/cards/pipeline-standups.md",
+        "rendered": true,
+        "sha256": "67ba2c28b119cd32cc24cd836248dd10be3b5d9b2f369bdfd5b3a51ba5809c61"
+      },
+      {
+        "byte_size": 4080,
+        "dst": "memory/cards/token-glace-output-compaction.md",
+        "rendered": true,
+        "sha256": "5f8898d45696a8186ab2cf756553e9d3d655ce1da46d633c5fd5c6844883a43c"
+      },
+      {
+        "byte_size": 1121,
+        "dst": "rules/acceptance-driven-work.md",
+        "rendered": true,
+        "sha256": "531a3b30619029b01ea7ffefb118638eea2fcc858ae9cfbd634e34723e9f2b9e"
+      },
+      {
+        "byte_size": 1194,
+        "dst": "rules/issue-tdd-loop.md",
+        "rendered": true,
+        "sha256": "79bb1c9ed0b14c235614193fb26e2e15aaef971a0d9c9ff89b37e7ea3d09ba8b"
+      },
+      {
+        "byte_size": 5238,
+        "dst": "scripts/backup-restic.sh",
+        "rendered": false,
+        "sha256": "b2cf1874706813d40114192884450c374589b2b26fdb819f44aedd5008166970"
+      },
+      {
+        "byte_size": 7094,
+        "dst": "skills/brigade-work/SKILL.md",
+        "rendered": true,
+        "sha256": "822ce10efce89c14964cacba6627728104f167bae0f065465bf5ff49af018261"
+      },
+      {
+        "byte_size": 5347,
+        "dst": "skills/note/SKILL.md",
+        "rendered": true,
+        "sha256": "457078ef56f4143910ba68729198285e204645d66ababc557e17b80496fe4cb1"
+      },
+      {
+        "byte_size": 2376,
+        "dst": "skills/ultra-work-scout/SKILL.md",
+        "rendered": true,
+        "sha256": "dcac8b8a66195a861cb62d563b8f18a5b868b9d070d288e75f53d026d81445b5"
+      }
+    ]
+  },
+  "schema": "brigade.template_registry.v1"
+}

--- a/tests/test_template_registry.py
+++ b/tests/test_template_registry.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+
+from brigade import cli, template_registry
+from brigade.install import build_render_context, install_selection, resolve_manifests
+from brigade.selection import Selection
+
+
+def test_bundled_registry_schema_and_render_digests():
+    payload = template_registry.load_registry()
+    assert payload["schema"] == template_registry.SCHEMA
+    assert set(payload["profiles"]) == set(template_registry.BUILTIN_PROFILES)
+    for name, profile in payload["profiles"].items():
+        assert profile["identity"] == f"brigade://template-profiles/{name}"
+        selection = Selection(**profile["selection"])
+        selection.validate()
+        assert payload["renders"][name] == template_registry.compute_profile_renders(selection)
+
+
+def test_build_registry_matches_committed_snapshot():
+    built = template_registry.build_registry()
+    committed = template_registry.load_registry()
+    assert built["profiles"] == committed["profiles"]
+    assert built["renders"] == committed["renders"]
+
+
+def test_resolve_profile_returns_valid_selection():
+    selection = template_registry.resolve_profile("repo-claude")
+    assert selection.depth == "repo"
+    assert selection.harnesses == ["claude"]
+    assert selection.owner == "claude"
+    assert selection.includes == []
+
+
+def test_unknown_profile_raises():
+    with pytest.raises(template_registry.UnknownTemplateProfile, match="missing-profile"):
+        template_registry.resolve_profile("missing-profile")
+
+
+def test_check_harness_version_accepts_supported_minimum():
+    template_registry.check_harness_version("repo-claude", "claude", "1.2.3")
+
+
+@pytest.fixture()
+def strict_profile_registry(tmp_path):
+    selection = Selection(depth="repo", harnesses=["claude"], owner="claude", includes=[])
+    payload = {
+        "schema": template_registry.SCHEMA,
+        "brigade_version": "0.0.0",
+        "profiles": {
+            "test": {
+                "description": "test profile",
+                "identity": "brigade://template-profiles/test",
+                "selection": {
+                    "depth": "repo",
+                    "harnesses": ["claude"],
+                    "owner": "claude",
+                    "includes": [],
+                },
+                "supported_harness_versions": {
+                    "claude": {"min": "2.0.0", "tested": "2.1.0"},
+                },
+            }
+        },
+        "renders": {"test": template_registry.compute_profile_renders(selection)},
+    }
+    path = tmp_path / "template-registry.json"
+    path.write_text(template_registry.render_registry(payload), encoding="utf-8")
+    return path
+
+
+def test_check_harness_version_rejects_below_minimum(strict_profile_registry):
+    with pytest.raises(template_registry.UnsupportedHarnessVersion, match="below profile minimum"):
+        template_registry.check_harness_version(
+            "test",
+            "claude",
+            "1.9.9",
+            path=strict_profile_registry,
+        )
+
+
+def test_render_hashes_are_deterministic_for_same_selection():
+    selection = template_registry.resolve_profile("workspace-claude-codex")
+    first = template_registry.compute_profile_renders(selection)
+    second = template_registry.compute_profile_renders(selection)
+    assert first == second
+    assert first
+    assert all(len(item["sha256"]) == 64 for item in first)
+
+
+def test_render_hash_matches_installed_bytes(tmp_path):
+    selection = template_registry.resolve_profile("repo-claude")
+    renders = {item["dst"]: item for item in template_registry.compute_profile_renders(selection)}
+    assert install_selection(tmp_path, selection) == 0
+    for dst, record in renders.items():
+        content = (tmp_path / dst).read_bytes()
+        assert hashlib.sha256(content).hexdigest() == record["sha256"]
+        assert len(content) == record["byte_size"]
+
+
+def test_build_render_context_uses_owner_inbox_first():
+    selection = Selection(
+        depth="workspace",
+        harnesses=["claude", "codex"],
+        owner="codex",
+        includes=[],
+    )
+    context = build_render_context(selection)
+    assert context["handoff_inbox"] == ".codex/memory-handoffs/"
+
+
+def test_init_profile_installs_named_selection(tmp_path, capsys):
+    rc = cli.main(["init", "--target", str(tmp_path), "--profile", "repo-claude", "--no-wire"])
+    assert rc == 0
+    assert (tmp_path / "CLAUDE.md").is_file()
+    capsys.readouterr()
+
+
+def test_init_profile_unknown_returns_error(tmp_path, capsys):
+    rc = cli.main(["init", "--target", str(tmp_path), "--profile", "missing-profile"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "unknown template profile" in err
+
+
+def test_init_profile_conflicts_with_depth(tmp_path, capsys):
+    rc = cli.main(
+        [
+            "init",
+            "--target",
+            str(tmp_path),
+            "--profile",
+            "repo-claude",
+            "--depth",
+            "repo",
+        ]
+    )
+    assert rc == 2
+    assert "--profile cannot be combined" in capsys.readouterr().err
+
+
+def test_init_legacy_default_without_profile_unchanged(tmp_path):
+    """Profile-less installs keep the existing depth/harness default path."""
+    rc = cli.main(
+        [
+            "init",
+            "--target",
+            str(tmp_path),
+            "--depth",
+            "repo",
+            "--harnesses",
+            "claude",
+            "--no-wire",
+        ]
+    )
+    assert rc == 0
+    files, _, _ = resolve_manifests(Selection(depth="repo", harnesses=["claude"], owner="claude"))
+    for entry in files:
+        assert (tmp_path / entry["dst"]).is_file()
+
+
+def test_registry_rejects_stale_render_digest(tmp_path):
+    payload = template_registry.build_registry(["repo-claude"])
+    payload["renders"]["repo-claude"][0]["sha256"] = "0" * 64
+    path = tmp_path / "template-registry.json"
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="render digest mismatch"):
+        template_registry.load_registry(path)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the smallest registry-style distribution metadata slice for issue #494:

- **`brigade.template_registry.v1`** bundled snapshot at `src/brigade/templates/template-registry.json`
- Named profiles (`repo-claude`, `workspace-claude-codex`, `repo-claude-full`) expose:
  - `selection` (depth, harnesses, owner, includes)
  - `supported_harness_versions` (`min` / `tested` semver strings per selected harness)
  - deterministic `renders` records (`dst`, `sha256`, `byte_size`, `rendered`) computed from the same `resolve_manifests` + `build_render_context` + `render()` pipeline as `install_selection`
- **`brigade init --profile <name>`** resolves a bundled preset; mutually exclusive with `--depth` / `--harnesses`
- Profile-less installs are unchanged (legacy default path preserved)

## Implementation notes

- `build_render_context()` extracted from `install.py` so install and registry hashing share one code path
- `scripts/template_registry.py --check` wired into `./scripts/verify` (pattern mirrors `managed_snapshot.py`)
- `check_harness_version()` raises `UnsupportedHarnessVersion` when a version is below the profile minimum

## GraphTrail / MiseLedger

- **GraphTrail:** binary unavailable in cloud VM; planned impact on new `template_registry` module, extracted `install.build_render_context`, and `cli.init` `--profile` dispatch branch
- **MiseLedger:** no queryable evidence for cited research run `20260724-032852-93c729b8` (`miseledger` not installed)

## Verification

```bash
pytest -q tests/test_template_registry.py   # 14 passed
./scripts/verify                            # 6691 passed, 5 skipped; coverage 83.09%
```

## Scope boundaries

- Does not touch protected #750 or active #840 surfaces
- No parallel registry service or new runtime dependencies
- Does not overload station profiles (`profiles.py`) or user-scope harness profiles (`harness_profiles.py`)

Refs #494
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e01d1c01-e1dd-4dd5-aa13-829b43728631?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e01d1c01-e1dd-4dd5-aa13-829b43728631&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

