### PR TITLE
docs(work-store): #846 R1 characterization report, fixtures, and harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ Thumbs.db
 !/scripts/generate_component_manifest.py
 !/scripts/verify_version_check_endpoint.py
 !/scripts/hyper-v-native-acceptance.ps1
+!/scripts/measure_work_store.py
 /skills/
 
 # Local plan/spec scratch dirs only. Reviewed planning artifacts ARE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Issue #846 R1 work-store characterization: research report, synthetic
+  chain/diamond/wide fixtures, and `scripts/measure_work_store.py` measurement
+  harness with diffable JSON output. Characterization only; no backend or
+  runtime dependency.
 - Bounded session-start memory recall (#466 Slice 1): `brigade memory recall
   --target <hub-or-mirror> --cwd <session-cwd> --limit 5 [--json]` derives query
   terms from the cwd basename, returns title/tags/path only (max 5 matches /

--- a/docs/measurements/issue-846-work-store-r1.json
+++ b/docs/measurements/issue-846-work-store-r1.json
@@ -1,0 +1,909 @@
+{
+  "anonymous_metrics": "disabled_in_harness",
+  "capability_notes": {
+    "dolt_cli_per_command": {
+      "branch_diff_merge": "native_candidate",
+      "concurrent_cross_machine_claim": "not_by_cli_alone",
+      "concurrent_same_store_claim": "unmeasured_r1",
+      "dolt_commit_policy": "candidate mapping: claim CAS / graph apply / release / reassign would need an explicit CALL DOLT_COMMIT after SQL commit; readiness queries would not create Dolt commits",
+      "portable_sync": "clone_push_pull_candidate",
+      "row_locks": "unsupported_select_for_update",
+      "runtime_dependency": "forbidden_unless_later_issue_approves",
+      "sql_tx_vs_claim_cas": "SQL transaction success is not Brigade claim-CAS proof; cell-level merge can allow lost updates vs row-lock DBs"
+    },
+    "dolt_sql_server": {
+      "branch_diff_merge": "native_candidate",
+      "concurrent_cross_machine_claim": "possible_but_not_current_need",
+      "eligibility_gate": "eligible only if a later concurrent-claim requirement cannot meet measured correctness through file or replica candidates",
+      "extra_ops": "users_grants_backup_version_lifecycle_listener",
+      "listener_policy": "loopback_only_with_approval_or_no_listener",
+      "portable_sync": "central_service_candidate",
+      "row_locks": "unsupported_select_for_update",
+      "runtime_dependency": "forbidden_unless_later_issue_approves",
+      "status": "blocked_no_listener_in_r1"
+    },
+    "embedded_dolt": {
+      "branch_diff_merge": "native_candidate",
+      "concurrent_cross_machine_claim": "not_by_embed_alone",
+      "portable_sync": "local_replica_candidate",
+      "row_locks": "unsupported_select_for_update",
+      "runtime_dependency": "forbidden_unless_later_issue_approves",
+      "server_lifecycle": "none",
+      "status": "blocked_no_boundary_in_repo"
+    },
+    "json_ledger": {
+      "branch_diff_merge": "absent",
+      "concurrent_cross_machine_claim": "not_supported",
+      "concurrent_same_store_claim": "supported_via_dir_lock",
+      "dolt_commit_policy": "n/a",
+      "portable_sync": "absent_first_class",
+      "row_locks": "n/a_file_cas"
+    },
+    "sources": [
+      "https://www.dolthub.com/docs/sql-reference/sql-support/supported-statements/",
+      "https://www.dolthub.com/blog/2026-02-17-dolt-concurrency/",
+      "https://www.dolthub.com/docs/introduction/installation/application-server/",
+      "https://www.dolthub.com/docs/sql-reference/server/backups/",
+      "https://www.dolthub.com/docs/other/versioning/"
+    ],
+    "sqlite_wal": {
+      "branch_diff_merge": "absent",
+      "concurrent_cross_machine_claim": "not_safe_on_shared_network_fs",
+      "concurrent_same_store_claim": "supported_via_begin_immediate",
+      "dolt_commit_policy": "n/a",
+      "portable_sync": "file_copy_only",
+      "row_locks": "sqlite_transaction_locks",
+      "runtime_dependency": "forbidden_for_brigade_runtime"
+    }
+  },
+  "datasets": [
+    "chain_50",
+    "diamond_200",
+    "wide_500_1000"
+  ],
+  "decision": {
+    "backend_adoption": false,
+    "beads": "excluded_under_770",
+    "brigade_workstore_v1": false,
+    "concurrent_cross_machine_claims": "not_current_requirement",
+    "current_need": "sequential_portable_sync_plus_reviewable_branch_merge_proposals",
+    "dolt": "characterization_candidate_not_banned_not_selected",
+    "portable_sync": "adopt_as_follow_up_requirement_not_implemented_in_r1",
+    "shared_service_eligibility": "only_if_later_concurrent_claim_requirement_fails_file_or_replica_candidates",
+    "shared_store_conformance_fixture": "not_approved",
+    "sqlite": "optional_local_characterization_only_not_runtime_dependency",
+    "store_decision": "keep_machine_local_json_ledger"
+  },
+  "environment": {
+    "directory_fsync_supported": true,
+    "dolt_on_path": false,
+    "filesystem_type": "overlay",
+    "platform": "Linux-6.12.94+-x86_64-with-glibc2.39",
+    "python_version": "3.12.3 (main, Jun 19 2026, 12:46:00) [GCC 13.3.0]",
+    "sqlite_version": "3.45.1"
+  },
+  "fixtures": {
+    "chain_50": {
+      "blocks_edges": 49,
+      "contains_hostnames": false,
+      "digest_sha256": "518f57a67a3e48a7c0d5b8cbc23b569d60fd2b22998a37859c0e2878c5fb366b",
+      "edge_count": 49,
+      "expected": {
+        "blocks_edges": 49,
+        "edge_count": 49,
+        "parent_child_edges": 0,
+        "provenance_edges": 0,
+        "ready_count": 1,
+        "task_count": 50
+      },
+      "machine_neutral": true,
+      "name": "chain_50",
+      "parent_child_edges": 0,
+      "provenance_edges": 0,
+      "ready_count": 1,
+      "task_count": 50
+    },
+    "diamond_200": {
+      "blocks_edges": 396,
+      "contains_hostnames": false,
+      "digest_sha256": "931215cbde02d9c3942bea3cd752c83e0048cbc4b1e32b98dc85da56bd623e8a",
+      "edge_count": 396,
+      "expected": {
+        "blocks_edges": 396,
+        "edge_count": 396,
+        "parent_child_edges": 0,
+        "provenance_edges": 0,
+        "ready_count": 1,
+        "task_count": 200
+      },
+      "machine_neutral": true,
+      "name": "diamond_200",
+      "parent_child_edges": 0,
+      "provenance_edges": 0,
+      "ready_count": 1,
+      "task_count": 200
+    },
+    "wide_500_1000": {
+      "blocks_edges": 0,
+      "contains_hostnames": false,
+      "digest_sha256": "91f344bb7e7c951e1b8542a25d5f8153b11ccdfb1194f2f6593261571c63531c",
+      "edge_count": 1000,
+      "expected": {
+        "blocks_edges": 0,
+        "edge_count": 1000,
+        "parent_child_edges": 0,
+        "provenance_edges": 1000,
+        "ready_count": 500,
+        "task_count": 500
+      },
+      "machine_neutral": true,
+      "name": "wide_500_1000",
+      "parent_child_edges": 0,
+      "provenance_edges": 1000,
+      "ready_count": 500,
+      "task_count": 500
+    }
+  },
+  "issue": 846,
+  "kind": "work-store-characterization",
+  "normative_anchors": {
+    "issue_737": "graph ready-set, chains, diamonds, cycles, provenance-only edges",
+    "issue_738": "claim CAS with one winner and exit 13 on lost race",
+    "issue_770": "BUILD native; Beads excluded"
+  },
+  "protocol_version": 1,
+  "results": [
+    {
+      "branch_diff_merge": {
+        "detail": "JSON ledger has no first-class branch/diff/merge path",
+        "status": "unsupported"
+      },
+      "claim_race": {
+        "codes": [
+          0,
+          13
+        ],
+        "exit_13_count": 1,
+        "loser_holder": "lane-b",
+        "loser_reason": "already_claimed",
+        "pass": true,
+        "winner_actor": "lane-b",
+        "winner_count": 1
+      },
+      "crash_consistency": {
+        "mode": "before_replace",
+        "original_intact": true,
+        "pass": true
+      },
+      "dataset": "chain_50",
+      "export_import": {
+        "digest_after": "518f57a67a3e48a7c0d5b8cbc23b569d60fd2b22998a37859c0e2878c5fb366b",
+        "digest_before": "518f57a67a3e48a7c0d5b8cbc23b569d60fd2b22998a37859c0e2878c5fb366b",
+        "pass": true
+      },
+      "gates": {
+        "crash_consistency": true,
+        "issue_737_graph": true,
+        "issue_738_claim": true,
+        "lossless_export": true,
+        "metrics_state": true,
+        "restore": true,
+        "secret_history_handling": true
+      },
+      "graph_conformance": {
+        "blocked_count": 49,
+        "cycle_count": 0,
+        "pass": true,
+        "provenance_ignored_for_readiness": true,
+        "ready_count": 1
+      },
+      "mutation_latency": {
+        "max_ns": 3700338,
+        "min_ns": 1560196,
+        "p50_ns": 2573392,
+        "p95_ns": 3410443,
+        "samples": 100
+      },
+      "offline_divergence": {
+        "detail": "No portable sync primitive in current JSON ledger",
+        "status": "unsupported"
+      },
+      "pass": true,
+      "relative_to_json": {
+        "p50_vs_json": 1.0,
+        "p95_vs_json": 1.0
+      },
+      "shape": "json_ledger",
+      "status": "measured"
+    },
+    {
+      "branch_diff_merge": {
+        "detail": "SQLite WAL adapter has no branch/diff/merge",
+        "status": "unsupported"
+      },
+      "claim_race": {
+        "codes": [
+          0,
+          13
+        ],
+        "exit_13_count": 1,
+        "loser_holder": "lane-b",
+        "loser_reason": "already_claimed",
+        "pass": true,
+        "winner_actor": "lane-b",
+        "winner_count": 1
+      },
+      "crash_consistency": {
+        "mode": "before_commit",
+        "original_intact": true,
+        "pass": true
+      },
+      "dataset": "chain_50",
+      "export_import": {
+        "digest_after": "518f57a67a3e48a7c0d5b8cbc23b569d60fd2b22998a37859c0e2878c5fb366b",
+        "digest_before": "518f57a67a3e48a7c0d5b8cbc23b569d60fd2b22998a37859c0e2878c5fb366b",
+        "pass": true
+      },
+      "gates": {
+        "crash_consistency": true,
+        "issue_737_graph": true,
+        "issue_738_claim": true,
+        "lossless_export": true,
+        "metrics_state": true,
+        "restore": true,
+        "secret_history_handling": true
+      },
+      "graph_conformance": {
+        "blocked_count": 49,
+        "cycle_count": 0,
+        "pass": true,
+        "provenance_ignored_for_readiness": true,
+        "ready_count": 1
+      },
+      "mutation_latency": {
+        "max_ns": 3145834,
+        "min_ns": 932545,
+        "p50_ns": 1057736,
+        "p95_ns": 2527593,
+        "samples": 100
+      },
+      "note": "stdlib sqlite3 characterization only; not a Brigade runtime dependency",
+      "offline_divergence": {
+        "detail": "File copy only; no merge protocol in this adapter",
+        "status": "unsupported"
+      },
+      "pass": true,
+      "relative_to_json": {
+        "p50_vs_json": 0.41102793511443264,
+        "p95_vs_json": 0.7411333366369119
+      },
+      "shape": "sqlite_wal",
+      "status": "measured"
+    },
+    {
+      "branch_diff_merge": {
+        "status": "unmeasured"
+      },
+      "claim_race": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "crash_consistency": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "dataset": "chain_50",
+      "export_import": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "gates": {
+        "crash_consistency": null,
+        "issue_737_graph": null,
+        "issue_738_claim": null,
+        "lossless_export": null,
+        "metrics_state": null,
+        "restore": null,
+        "secret_history_handling": null
+      },
+      "graph_conformance": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "mutation_latency": null,
+      "offline_divergence": {
+        "status": "unmeasured"
+      },
+      "pass": null,
+      "reason": "dolt binary not available on PATH; optional temporary CLI not supplied (--dolt-bin). Cell left unmeasured rather than fabricated",
+      "relative_to_json": null,
+      "shape": "dolt_cli_per_command",
+      "status": "blocked"
+    },
+    {
+      "branch_diff_merge": {
+        "status": "unmeasured"
+      },
+      "claim_race": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "crash_consistency": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "dataset": "chain_50",
+      "export_import": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "gates": {
+        "crash_consistency": null,
+        "issue_737_graph": null,
+        "issue_738_claim": null,
+        "lossless_export": null,
+        "metrics_state": null,
+        "restore": null,
+        "secret_history_handling": null
+      },
+      "graph_conformance": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "mutation_latency": null,
+      "offline_divergence": {
+        "status": "unmeasured"
+      },
+      "pass": null,
+      "reason": "No embedded Dolt boundary is checked into this repo; R1 does not build or persist a Go/Dolt dependency",
+      "relative_to_json": null,
+      "shape": "embedded_dolt",
+      "status": "blocked"
+    },
+    {
+      "branch_diff_merge": {
+        "status": "unmeasured"
+      },
+      "claim_race": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "crash_consistency": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "dataset": "chain_50",
+      "export_import": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "gates": {
+        "crash_consistency": null,
+        "issue_737_graph": null,
+        "issue_738_claim": null,
+        "lossless_export": null,
+        "metrics_state": null,
+        "restore": null,
+        "secret_history_handling": null
+      },
+      "graph_conformance": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "mutation_latency": null,
+      "offline_divergence": {
+        "status": "unmeasured"
+      },
+      "pass": null,
+      "reason": "R1 policy: harness must not start a network listener; operator-owned server characterization requires separate approval",
+      "relative_to_json": null,
+      "shape": "dolt_sql_server",
+      "status": "blocked"
+    },
+    {
+      "branch_diff_merge": {
+        "detail": "JSON ledger has no first-class branch/diff/merge path",
+        "status": "unsupported"
+      },
+      "claim_race": {
+        "codes": [
+          0,
+          13
+        ],
+        "exit_13_count": 1,
+        "loser_holder": "lane-b",
+        "loser_reason": "already_claimed",
+        "pass": true,
+        "winner_actor": "lane-b",
+        "winner_count": 1
+      },
+      "crash_consistency": {
+        "mode": "before_replace",
+        "original_intact": true,
+        "pass": true
+      },
+      "dataset": "diamond_200",
+      "export_import": {
+        "digest_after": "931215cbde02d9c3942bea3cd752c83e0048cbc4b1e32b98dc85da56bd623e8a",
+        "digest_before": "931215cbde02d9c3942bea3cd752c83e0048cbc4b1e32b98dc85da56bd623e8a",
+        "pass": true
+      },
+      "gates": {
+        "crash_consistency": true,
+        "issue_737_graph": true,
+        "issue_738_claim": true,
+        "lossless_export": true,
+        "metrics_state": true,
+        "restore": true,
+        "secret_history_handling": true
+      },
+      "graph_conformance": {
+        "blocked_count": 199,
+        "cycle_count": 0,
+        "pass": true,
+        "provenance_ignored_for_readiness": true,
+        "ready_count": 1
+      },
+      "mutation_latency": {
+        "max_ns": 10797211,
+        "min_ns": 5051450,
+        "p50_ns": 6220153,
+        "p95_ns": 7052445,
+        "samples": 100
+      },
+      "offline_divergence": {
+        "detail": "No portable sync primitive in current JSON ledger",
+        "status": "unsupported"
+      },
+      "pass": true,
+      "relative_to_json": {
+        "p50_vs_json": 1.0,
+        "p95_vs_json": 1.0
+      },
+      "shape": "json_ledger",
+      "status": "measured"
+    },
+    {
+      "branch_diff_merge": {
+        "detail": "SQLite WAL adapter has no branch/diff/merge",
+        "status": "unsupported"
+      },
+      "claim_race": {
+        "codes": [
+          0,
+          13
+        ],
+        "exit_13_count": 1,
+        "loser_holder": "lane-b",
+        "loser_reason": "already_claimed",
+        "pass": true,
+        "winner_actor": "lane-b",
+        "winner_count": 1
+      },
+      "crash_consistency": {
+        "mode": "before_commit",
+        "original_intact": true,
+        "pass": true
+      },
+      "dataset": "diamond_200",
+      "export_import": {
+        "digest_after": "931215cbde02d9c3942bea3cd752c83e0048cbc4b1e32b98dc85da56bd623e8a",
+        "digest_before": "931215cbde02d9c3942bea3cd752c83e0048cbc4b1e32b98dc85da56bd623e8a",
+        "pass": true
+      },
+      "gates": {
+        "crash_consistency": true,
+        "issue_737_graph": true,
+        "issue_738_claim": true,
+        "lossless_export": true,
+        "metrics_state": true,
+        "restore": true,
+        "secret_history_handling": true
+      },
+      "graph_conformance": {
+        "blocked_count": 199,
+        "cycle_count": 0,
+        "pass": true,
+        "provenance_ignored_for_readiness": true,
+        "ready_count": 1
+      },
+      "mutation_latency": {
+        "max_ns": 2976028,
+        "min_ns": 776509,
+        "p50_ns": 1670392,
+        "p95_ns": 2586598,
+        "samples": 100
+      },
+      "note": "stdlib sqlite3 characterization only; not a Brigade runtime dependency",
+      "offline_divergence": {
+        "detail": "File copy only; no merge protocol in this adapter",
+        "status": "unsupported"
+      },
+      "pass": true,
+      "relative_to_json": {
+        "p50_vs_json": 0.2685451627958348,
+        "p95_vs_json": 0.3667661357160531
+      },
+      "shape": "sqlite_wal",
+      "status": "measured"
+    },
+    {
+      "branch_diff_merge": {
+        "status": "unmeasured"
+      },
+      "claim_race": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "crash_consistency": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "dataset": "diamond_200",
+      "export_import": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "gates": {
+        "crash_consistency": null,
+        "issue_737_graph": null,
+        "issue_738_claim": null,
+        "lossless_export": null,
+        "metrics_state": null,
+        "restore": null,
+        "secret_history_handling": null
+      },
+      "graph_conformance": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "mutation_latency": null,
+      "offline_divergence": {
+        "status": "unmeasured"
+      },
+      "pass": null,
+      "reason": "dolt binary not available on PATH; optional temporary CLI not supplied (--dolt-bin). Cell left unmeasured rather than fabricated",
+      "relative_to_json": null,
+      "shape": "dolt_cli_per_command",
+      "status": "blocked"
+    },
+    {
+      "branch_diff_merge": {
+        "status": "unmeasured"
+      },
+      "claim_race": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "crash_consistency": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "dataset": "diamond_200",
+      "export_import": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "gates": {
+        "crash_consistency": null,
+        "issue_737_graph": null,
+        "issue_738_claim": null,
+        "lossless_export": null,
+        "metrics_state": null,
+        "restore": null,
+        "secret_history_handling": null
+      },
+      "graph_conformance": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "mutation_latency": null,
+      "offline_divergence": {
+        "status": "unmeasured"
+      },
+      "pass": null,
+      "reason": "No embedded Dolt boundary is checked into this repo; R1 does not build or persist a Go/Dolt dependency",
+      "relative_to_json": null,
+      "shape": "embedded_dolt",
+      "status": "blocked"
+    },
+    {
+      "branch_diff_merge": {
+        "status": "unmeasured"
+      },
+      "claim_race": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "crash_consistency": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "dataset": "diamond_200",
+      "export_import": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "gates": {
+        "crash_consistency": null,
+        "issue_737_graph": null,
+        "issue_738_claim": null,
+        "lossless_export": null,
+        "metrics_state": null,
+        "restore": null,
+        "secret_history_handling": null
+      },
+      "graph_conformance": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "mutation_latency": null,
+      "offline_divergence": {
+        "status": "unmeasured"
+      },
+      "pass": null,
+      "reason": "R1 policy: harness must not start a network listener; operator-owned server characterization requires separate approval",
+      "relative_to_json": null,
+      "shape": "dolt_sql_server",
+      "status": "blocked"
+    },
+    {
+      "branch_diff_merge": {
+        "detail": "JSON ledger has no first-class branch/diff/merge path",
+        "status": "unsupported"
+      },
+      "claim_race": {
+        "codes": [
+          0,
+          13
+        ],
+        "exit_13_count": 1,
+        "loser_holder": "lane-b",
+        "loser_reason": "already_claimed",
+        "pass": true,
+        "winner_actor": "lane-b",
+        "winner_count": 1
+      },
+      "crash_consistency": {
+        "mode": "before_replace",
+        "original_intact": true,
+        "pass": true
+      },
+      "dataset": "wide_500_1000",
+      "export_import": {
+        "digest_after": "91f344bb7e7c951e1b8542a25d5f8153b11ccdfb1194f2f6593261571c63531c",
+        "digest_before": "91f344bb7e7c951e1b8542a25d5f8153b11ccdfb1194f2f6593261571c63531c",
+        "pass": true
+      },
+      "gates": {
+        "crash_consistency": true,
+        "issue_737_graph": true,
+        "issue_738_claim": true,
+        "lossless_export": true,
+        "metrics_state": true,
+        "restore": true,
+        "secret_history_handling": true
+      },
+      "graph_conformance": {
+        "blocked_count": 0,
+        "cycle_count": 0,
+        "pass": true,
+        "provenance_ignored_for_readiness": true,
+        "ready_count": 500
+      },
+      "mutation_latency": {
+        "max_ns": 17363516,
+        "min_ns": 10193128,
+        "p50_ns": 11482529,
+        "p95_ns": 12698486,
+        "samples": 100
+      },
+      "offline_divergence": {
+        "detail": "No portable sync primitive in current JSON ledger",
+        "status": "unsupported"
+      },
+      "pass": true,
+      "relative_to_json": {
+        "p50_vs_json": 1.0,
+        "p95_vs_json": 1.0
+      },
+      "shape": "json_ledger",
+      "status": "measured"
+    },
+    {
+      "branch_diff_merge": {
+        "detail": "SQLite WAL adapter has no branch/diff/merge",
+        "status": "unsupported"
+      },
+      "claim_race": {
+        "codes": [
+          0,
+          13
+        ],
+        "exit_13_count": 1,
+        "loser_holder": "lane-b",
+        "loser_reason": "already_claimed",
+        "pass": true,
+        "winner_actor": "lane-b",
+        "winner_count": 1
+      },
+      "crash_consistency": {
+        "mode": "before_commit",
+        "original_intact": true,
+        "pass": true
+      },
+      "dataset": "wide_500_1000",
+      "export_import": {
+        "digest_after": "91f344bb7e7c951e1b8542a25d5f8153b11ccdfb1194f2f6593261571c63531c",
+        "digest_before": "91f344bb7e7c951e1b8542a25d5f8153b11ccdfb1194f2f6593261571c63531c",
+        "pass": true
+      },
+      "gates": {
+        "crash_consistency": true,
+        "issue_737_graph": true,
+        "issue_738_claim": true,
+        "lossless_export": true,
+        "metrics_state": true,
+        "restore": true,
+        "secret_history_handling": true
+      },
+      "graph_conformance": {
+        "blocked_count": 0,
+        "cycle_count": 0,
+        "pass": true,
+        "provenance_ignored_for_readiness": true,
+        "ready_count": 500
+      },
+      "mutation_latency": {
+        "max_ns": 2900870,
+        "min_ns": 817923,
+        "p50_ns": 2134305,
+        "p95_ns": 2585722,
+        "samples": 100
+      },
+      "note": "stdlib sqlite3 characterization only; not a Brigade runtime dependency",
+      "offline_divergence": {
+        "detail": "File copy only; no merge protocol in this adapter",
+        "status": "unsupported"
+      },
+      "pass": true,
+      "relative_to_json": {
+        "p50_vs_json": 0.18587412232967146,
+        "p95_vs_json": 0.20362443207796582
+      },
+      "shape": "sqlite_wal",
+      "status": "measured"
+    },
+    {
+      "branch_diff_merge": {
+        "status": "unmeasured"
+      },
+      "claim_race": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "crash_consistency": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "dataset": "wide_500_1000",
+      "export_import": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "gates": {
+        "crash_consistency": null,
+        "issue_737_graph": null,
+        "issue_738_claim": null,
+        "lossless_export": null,
+        "metrics_state": null,
+        "restore": null,
+        "secret_history_handling": null
+      },
+      "graph_conformance": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "mutation_latency": null,
+      "offline_divergence": {
+        "status": "unmeasured"
+      },
+      "pass": null,
+      "reason": "dolt binary not available on PATH; optional temporary CLI not supplied (--dolt-bin). Cell left unmeasured rather than fabricated",
+      "relative_to_json": null,
+      "shape": "dolt_cli_per_command",
+      "status": "blocked"
+    },
+    {
+      "branch_diff_merge": {
+        "status": "unmeasured"
+      },
+      "claim_race": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "crash_consistency": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "dataset": "wide_500_1000",
+      "export_import": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "gates": {
+        "crash_consistency": null,
+        "issue_737_graph": null,
+        "issue_738_claim": null,
+        "lossless_export": null,
+        "metrics_state": null,
+        "restore": null,
+        "secret_history_handling": null
+      },
+      "graph_conformance": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "mutation_latency": null,
+      "offline_divergence": {
+        "status": "unmeasured"
+      },
+      "pass": null,
+      "reason": "No embedded Dolt boundary is checked into this repo; R1 does not build or persist a Go/Dolt dependency",
+      "relative_to_json": null,
+      "shape": "embedded_dolt",
+      "status": "blocked"
+    },
+    {
+      "branch_diff_merge": {
+        "status": "unmeasured"
+      },
+      "claim_race": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "crash_consistency": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "dataset": "wide_500_1000",
+      "export_import": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "gates": {
+        "crash_consistency": null,
+        "issue_737_graph": null,
+        "issue_738_claim": null,
+        "lossless_export": null,
+        "metrics_state": null,
+        "restore": null,
+        "secret_history_handling": null
+      },
+      "graph_conformance": {
+        "pass": null,
+        "status": "unmeasured"
+      },
+      "mutation_latency": null,
+      "offline_divergence": {
+        "status": "unmeasured"
+      },
+      "pass": null,
+      "reason": "R1 policy: harness must not start a network listener; operator-owned server characterization requires separate approval",
+      "relative_to_json": null,
+      "shape": "dolt_sql_server",
+      "status": "blocked"
+    }
+  ],
+  "shapes": [
+    "json_ledger",
+    "sqlite_wal",
+    "dolt_cli_per_command",
+    "embedded_dolt",
+    "dolt_sql_server"
+  ],
+  "slice": "R1",
+  "timebox": "R1 timebox: automate JSON baseline first; SQLite WAL is an optional stdlib characterization adapter; Dolt shapes stay optional and must not enter Brigade runtime dependencies. Server listeners require separate operator approval and are never started here.",
+  "trials": 100,
+  "warmups": 10
+}

--- a/docs/research/fixtures/work-store-r1/chain_50.json
+++ b/docs/research/fixtures/work-store-r1/chain_50.json
@@ -1,0 +1,900 @@
+{
+  "edges": [
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0000",
+      "source": "synth-chain-0000",
+      "target": "synth-chain-0001",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0001",
+      "source": "synth-chain-0001",
+      "target": "synth-chain-0002",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0002",
+      "source": "synth-chain-0002",
+      "target": "synth-chain-0003",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0003",
+      "source": "synth-chain-0003",
+      "target": "synth-chain-0004",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0004",
+      "source": "synth-chain-0004",
+      "target": "synth-chain-0005",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0005",
+      "source": "synth-chain-0005",
+      "target": "synth-chain-0006",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0006",
+      "source": "synth-chain-0006",
+      "target": "synth-chain-0007",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0007",
+      "source": "synth-chain-0007",
+      "target": "synth-chain-0008",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0008",
+      "source": "synth-chain-0008",
+      "target": "synth-chain-0009",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0009",
+      "source": "synth-chain-0009",
+      "target": "synth-chain-0010",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0010",
+      "source": "synth-chain-0010",
+      "target": "synth-chain-0011",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0011",
+      "source": "synth-chain-0011",
+      "target": "synth-chain-0012",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0012",
+      "source": "synth-chain-0012",
+      "target": "synth-chain-0013",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0013",
+      "source": "synth-chain-0013",
+      "target": "synth-chain-0014",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0014",
+      "source": "synth-chain-0014",
+      "target": "synth-chain-0015",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0015",
+      "source": "synth-chain-0015",
+      "target": "synth-chain-0016",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0016",
+      "source": "synth-chain-0016",
+      "target": "synth-chain-0017",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0017",
+      "source": "synth-chain-0017",
+      "target": "synth-chain-0018",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0018",
+      "source": "synth-chain-0018",
+      "target": "synth-chain-0019",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0019",
+      "source": "synth-chain-0019",
+      "target": "synth-chain-0020",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0020",
+      "source": "synth-chain-0020",
+      "target": "synth-chain-0021",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0021",
+      "source": "synth-chain-0021",
+      "target": "synth-chain-0022",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0022",
+      "source": "synth-chain-0022",
+      "target": "synth-chain-0023",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0023",
+      "source": "synth-chain-0023",
+      "target": "synth-chain-0024",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0024",
+      "source": "synth-chain-0024",
+      "target": "synth-chain-0025",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0025",
+      "source": "synth-chain-0025",
+      "target": "synth-chain-0026",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0026",
+      "source": "synth-chain-0026",
+      "target": "synth-chain-0027",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0027",
+      "source": "synth-chain-0027",
+      "target": "synth-chain-0028",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0028",
+      "source": "synth-chain-0028",
+      "target": "synth-chain-0029",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0029",
+      "source": "synth-chain-0029",
+      "target": "synth-chain-0030",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0030",
+      "source": "synth-chain-0030",
+      "target": "synth-chain-0031",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0031",
+      "source": "synth-chain-0031",
+      "target": "synth-chain-0032",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0032",
+      "source": "synth-chain-0032",
+      "target": "synth-chain-0033",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0033",
+      "source": "synth-chain-0033",
+      "target": "synth-chain-0034",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0034",
+      "source": "synth-chain-0034",
+      "target": "synth-chain-0035",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0035",
+      "source": "synth-chain-0035",
+      "target": "synth-chain-0036",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0036",
+      "source": "synth-chain-0036",
+      "target": "synth-chain-0037",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0037",
+      "source": "synth-chain-0037",
+      "target": "synth-chain-0038",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0038",
+      "source": "synth-chain-0038",
+      "target": "synth-chain-0039",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0039",
+      "source": "synth-chain-0039",
+      "target": "synth-chain-0040",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0040",
+      "source": "synth-chain-0040",
+      "target": "synth-chain-0041",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0041",
+      "source": "synth-chain-0041",
+      "target": "synth-chain-0042",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0042",
+      "source": "synth-chain-0042",
+      "target": "synth-chain-0043",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0043",
+      "source": "synth-chain-0043",
+      "target": "synth-chain-0044",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0044",
+      "source": "synth-chain-0044",
+      "target": "synth-chain-0045",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0045",
+      "source": "synth-chain-0045",
+      "target": "synth-chain-0046",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0046",
+      "source": "synth-chain-0046",
+      "target": "synth-chain-0047",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0047",
+      "source": "synth-chain-0047",
+      "target": "synth-chain-0048",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-edge-0048",
+      "source": "synth-chain-0048",
+      "target": "synth-chain-0049",
+      "type": "blocks"
+    }
+  ],
+  "tasks": [
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0000",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 0",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0001",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 1",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0002",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 2",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0003",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 3",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0004",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 4",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0005",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 5",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0006",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 6",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0007",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 7",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0008",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 8",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0009",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 9",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0010",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 10",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0011",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 11",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0012",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 12",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0013",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 13",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0014",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 14",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0015",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 15",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0016",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 16",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0017",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 17",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0018",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 18",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0019",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 19",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0020",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 20",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0021",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 21",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0022",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 22",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0023",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 23",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0024",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 24",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0025",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 25",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0026",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 26",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0027",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 27",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0028",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 28",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0029",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 29",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0030",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 30",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0031",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 31",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0032",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 32",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0033",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 33",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0034",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 34",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0035",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 35",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0036",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 36",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0037",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 37",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0038",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 38",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0039",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 39",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0040",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 40",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0041",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 41",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0042",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 42",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0043",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 43",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0044",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 44",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0045",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 45",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0046",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 46",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0047",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 47",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0048",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 48",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-chain-0049",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Chain task 49",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    }
+  ],
+  "version": 2
+}

--- a/docs/research/fixtures/work-store-r1/diamond_200.json
+++ b/docs/research/fixtures/work-store-r1/diamond_200.json
@@ -1,0 +1,4979 @@
+{
+  "edges": [
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0001",
+      "source": "synth-diamond-0001",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0002",
+      "source": "synth-diamond-0002",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0003",
+      "source": "synth-diamond-0003",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0004",
+      "source": "synth-diamond-0004",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0005",
+      "source": "synth-diamond-0005",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0006",
+      "source": "synth-diamond-0006",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0007",
+      "source": "synth-diamond-0007",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0008",
+      "source": "synth-diamond-0008",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0009",
+      "source": "synth-diamond-0009",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0010",
+      "source": "synth-diamond-0010",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0011",
+      "source": "synth-diamond-0011",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0012",
+      "source": "synth-diamond-0012",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0013",
+      "source": "synth-diamond-0013",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0014",
+      "source": "synth-diamond-0014",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0015",
+      "source": "synth-diamond-0015",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0016",
+      "source": "synth-diamond-0016",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0017",
+      "source": "synth-diamond-0017",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0018",
+      "source": "synth-diamond-0018",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0019",
+      "source": "synth-diamond-0019",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0020",
+      "source": "synth-diamond-0020",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0021",
+      "source": "synth-diamond-0021",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0022",
+      "source": "synth-diamond-0022",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0023",
+      "source": "synth-diamond-0023",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0024",
+      "source": "synth-diamond-0024",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0025",
+      "source": "synth-diamond-0025",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0026",
+      "source": "synth-diamond-0026",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0027",
+      "source": "synth-diamond-0027",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0028",
+      "source": "synth-diamond-0028",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0029",
+      "source": "synth-diamond-0029",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0030",
+      "source": "synth-diamond-0030",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0031",
+      "source": "synth-diamond-0031",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0032",
+      "source": "synth-diamond-0032",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0033",
+      "source": "synth-diamond-0033",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0034",
+      "source": "synth-diamond-0034",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0035",
+      "source": "synth-diamond-0035",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0036",
+      "source": "synth-diamond-0036",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0037",
+      "source": "synth-diamond-0037",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0038",
+      "source": "synth-diamond-0038",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0039",
+      "source": "synth-diamond-0039",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0040",
+      "source": "synth-diamond-0040",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0041",
+      "source": "synth-diamond-0041",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0042",
+      "source": "synth-diamond-0042",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0043",
+      "source": "synth-diamond-0043",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0044",
+      "source": "synth-diamond-0044",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0045",
+      "source": "synth-diamond-0045",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0046",
+      "source": "synth-diamond-0046",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0047",
+      "source": "synth-diamond-0047",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0048",
+      "source": "synth-diamond-0048",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0049",
+      "source": "synth-diamond-0049",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0050",
+      "source": "synth-diamond-0050",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0051",
+      "source": "synth-diamond-0051",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0052",
+      "source": "synth-diamond-0052",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0053",
+      "source": "synth-diamond-0053",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0054",
+      "source": "synth-diamond-0054",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0055",
+      "source": "synth-diamond-0055",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0056",
+      "source": "synth-diamond-0056",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0057",
+      "source": "synth-diamond-0057",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0058",
+      "source": "synth-diamond-0058",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0059",
+      "source": "synth-diamond-0059",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0060",
+      "source": "synth-diamond-0060",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0061",
+      "source": "synth-diamond-0061",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0062",
+      "source": "synth-diamond-0062",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0063",
+      "source": "synth-diamond-0063",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0064",
+      "source": "synth-diamond-0064",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0065",
+      "source": "synth-diamond-0065",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0066",
+      "source": "synth-diamond-0066",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0067",
+      "source": "synth-diamond-0067",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0068",
+      "source": "synth-diamond-0068",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0069",
+      "source": "synth-diamond-0069",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0070",
+      "source": "synth-diamond-0070",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0071",
+      "source": "synth-diamond-0071",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0072",
+      "source": "synth-diamond-0072",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0073",
+      "source": "synth-diamond-0073",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0074",
+      "source": "synth-diamond-0074",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0075",
+      "source": "synth-diamond-0075",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0076",
+      "source": "synth-diamond-0076",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0077",
+      "source": "synth-diamond-0077",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0078",
+      "source": "synth-diamond-0078",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0079",
+      "source": "synth-diamond-0079",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0080",
+      "source": "synth-diamond-0080",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0081",
+      "source": "synth-diamond-0081",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0082",
+      "source": "synth-diamond-0082",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0083",
+      "source": "synth-diamond-0083",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0084",
+      "source": "synth-diamond-0084",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0085",
+      "source": "synth-diamond-0085",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0086",
+      "source": "synth-diamond-0086",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0087",
+      "source": "synth-diamond-0087",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0088",
+      "source": "synth-diamond-0088",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0089",
+      "source": "synth-diamond-0089",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0090",
+      "source": "synth-diamond-0090",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0091",
+      "source": "synth-diamond-0091",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0092",
+      "source": "synth-diamond-0092",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0093",
+      "source": "synth-diamond-0093",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0094",
+      "source": "synth-diamond-0094",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0095",
+      "source": "synth-diamond-0095",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0096",
+      "source": "synth-diamond-0096",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0097",
+      "source": "synth-diamond-0097",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0098",
+      "source": "synth-diamond-0098",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0099",
+      "source": "synth-diamond-0099",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0100",
+      "source": "synth-diamond-0100",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0101",
+      "source": "synth-diamond-0101",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0102",
+      "source": "synth-diamond-0102",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0103",
+      "source": "synth-diamond-0103",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0104",
+      "source": "synth-diamond-0104",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0105",
+      "source": "synth-diamond-0105",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0106",
+      "source": "synth-diamond-0106",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0107",
+      "source": "synth-diamond-0107",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0108",
+      "source": "synth-diamond-0108",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0109",
+      "source": "synth-diamond-0109",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0110",
+      "source": "synth-diamond-0110",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0111",
+      "source": "synth-diamond-0111",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0112",
+      "source": "synth-diamond-0112",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0113",
+      "source": "synth-diamond-0113",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0114",
+      "source": "synth-diamond-0114",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0115",
+      "source": "synth-diamond-0115",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0116",
+      "source": "synth-diamond-0116",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0117",
+      "source": "synth-diamond-0117",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0118",
+      "source": "synth-diamond-0118",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0119",
+      "source": "synth-diamond-0119",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0120",
+      "source": "synth-diamond-0120",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0121",
+      "source": "synth-diamond-0121",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0122",
+      "source": "synth-diamond-0122",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0123",
+      "source": "synth-diamond-0123",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0124",
+      "source": "synth-diamond-0124",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0125",
+      "source": "synth-diamond-0125",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0126",
+      "source": "synth-diamond-0126",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0127",
+      "source": "synth-diamond-0127",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0128",
+      "source": "synth-diamond-0128",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0129",
+      "source": "synth-diamond-0129",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0130",
+      "source": "synth-diamond-0130",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0131",
+      "source": "synth-diamond-0131",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0132",
+      "source": "synth-diamond-0132",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0133",
+      "source": "synth-diamond-0133",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0134",
+      "source": "synth-diamond-0134",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0135",
+      "source": "synth-diamond-0135",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0136",
+      "source": "synth-diamond-0136",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0137",
+      "source": "synth-diamond-0137",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0138",
+      "source": "synth-diamond-0138",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0139",
+      "source": "synth-diamond-0139",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0140",
+      "source": "synth-diamond-0140",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0141",
+      "source": "synth-diamond-0141",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0142",
+      "source": "synth-diamond-0142",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0143",
+      "source": "synth-diamond-0143",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0144",
+      "source": "synth-diamond-0144",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0145",
+      "source": "synth-diamond-0145",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0146",
+      "source": "synth-diamond-0146",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0147",
+      "source": "synth-diamond-0147",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0148",
+      "source": "synth-diamond-0148",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0149",
+      "source": "synth-diamond-0149",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0150",
+      "source": "synth-diamond-0150",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0151",
+      "source": "synth-diamond-0151",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0152",
+      "source": "synth-diamond-0152",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0153",
+      "source": "synth-diamond-0153",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0154",
+      "source": "synth-diamond-0154",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0155",
+      "source": "synth-diamond-0155",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0156",
+      "source": "synth-diamond-0156",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0157",
+      "source": "synth-diamond-0157",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0158",
+      "source": "synth-diamond-0158",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0159",
+      "source": "synth-diamond-0159",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0160",
+      "source": "synth-diamond-0160",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0161",
+      "source": "synth-diamond-0161",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0162",
+      "source": "synth-diamond-0162",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0163",
+      "source": "synth-diamond-0163",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0164",
+      "source": "synth-diamond-0164",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0165",
+      "source": "synth-diamond-0165",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0166",
+      "source": "synth-diamond-0166",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0167",
+      "source": "synth-diamond-0167",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0168",
+      "source": "synth-diamond-0168",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0169",
+      "source": "synth-diamond-0169",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0170",
+      "source": "synth-diamond-0170",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0171",
+      "source": "synth-diamond-0171",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0172",
+      "source": "synth-diamond-0172",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0173",
+      "source": "synth-diamond-0173",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0174",
+      "source": "synth-diamond-0174",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0175",
+      "source": "synth-diamond-0175",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0176",
+      "source": "synth-diamond-0176",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0177",
+      "source": "synth-diamond-0177",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0178",
+      "source": "synth-diamond-0178",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0179",
+      "source": "synth-diamond-0179",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0180",
+      "source": "synth-diamond-0180",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0181",
+      "source": "synth-diamond-0181",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0182",
+      "source": "synth-diamond-0182",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0183",
+      "source": "synth-diamond-0183",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0184",
+      "source": "synth-diamond-0184",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0185",
+      "source": "synth-diamond-0185",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0186",
+      "source": "synth-diamond-0186",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0187",
+      "source": "synth-diamond-0187",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0188",
+      "source": "synth-diamond-0188",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0189",
+      "source": "synth-diamond-0189",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0190",
+      "source": "synth-diamond-0190",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0191",
+      "source": "synth-diamond-0191",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0192",
+      "source": "synth-diamond-0192",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0193",
+      "source": "synth-diamond-0193",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0194",
+      "source": "synth-diamond-0194",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0195",
+      "source": "synth-diamond-0195",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0196",
+      "source": "synth-diamond-0196",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0197",
+      "source": "synth-diamond-0197",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-snk-0198",
+      "source": "synth-diamond-0198",
+      "target": "synth-diamond-0199",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0001",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0001",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0002",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0002",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0003",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0003",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0004",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0004",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0005",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0005",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0006",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0006",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0007",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0007",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0008",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0008",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0009",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0009",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0010",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0010",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0011",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0011",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0012",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0012",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0013",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0013",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0014",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0014",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0015",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0015",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0016",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0016",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0017",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0017",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0018",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0018",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0019",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0019",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0020",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0020",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0021",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0021",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0022",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0022",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0023",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0023",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0024",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0024",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0025",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0025",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0026",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0026",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0027",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0027",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0028",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0028",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0029",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0029",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0030",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0030",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0031",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0031",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0032",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0032",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0033",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0033",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0034",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0034",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0035",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0035",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0036",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0036",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0037",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0037",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0038",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0038",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0039",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0039",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0040",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0040",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0041",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0041",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0042",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0042",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0043",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0043",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0044",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0044",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0045",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0045",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0046",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0046",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0047",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0047",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0048",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0048",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0049",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0049",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0050",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0050",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0051",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0051",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0052",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0052",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0053",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0053",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0054",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0054",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0055",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0055",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0056",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0056",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0057",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0057",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0058",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0058",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0059",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0059",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0060",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0060",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0061",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0061",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0062",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0062",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0063",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0063",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0064",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0064",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0065",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0065",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0066",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0066",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0067",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0067",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0068",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0068",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0069",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0069",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0070",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0070",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0071",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0071",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0072",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0072",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0073",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0073",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0074",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0074",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0075",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0075",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0076",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0076",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0077",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0077",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0078",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0078",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0079",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0079",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0080",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0080",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0081",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0081",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0082",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0082",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0083",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0083",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0084",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0084",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0085",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0085",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0086",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0086",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0087",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0087",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0088",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0088",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0089",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0089",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0090",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0090",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0091",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0091",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0092",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0092",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0093",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0093",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0094",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0094",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0095",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0095",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0096",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0096",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0097",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0097",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0098",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0098",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0099",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0099",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0100",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0100",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0101",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0101",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0102",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0102",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0103",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0103",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0104",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0104",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0105",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0105",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0106",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0106",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0107",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0107",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0108",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0108",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0109",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0109",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0110",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0110",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0111",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0111",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0112",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0112",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0113",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0113",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0114",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0114",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0115",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0115",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0116",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0116",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0117",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0117",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0118",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0118",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0119",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0119",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0120",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0120",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0121",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0121",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0122",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0122",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0123",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0123",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0124",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0124",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0125",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0125",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0126",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0126",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0127",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0127",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0128",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0128",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0129",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0129",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0130",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0130",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0131",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0131",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0132",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0132",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0133",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0133",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0134",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0134",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0135",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0135",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0136",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0136",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0137",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0137",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0138",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0138",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0139",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0139",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0140",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0140",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0141",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0141",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0142",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0142",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0143",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0143",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0144",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0144",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0145",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0145",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0146",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0146",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0147",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0147",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0148",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0148",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0149",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0149",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0150",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0150",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0151",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0151",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0152",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0152",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0153",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0153",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0154",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0154",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0155",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0155",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0156",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0156",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0157",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0157",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0158",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0158",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0159",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0159",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0160",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0160",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0161",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0161",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0162",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0162",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0163",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0163",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0164",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0164",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0165",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0165",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0166",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0166",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0167",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0167",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0168",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0168",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0169",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0169",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0170",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0170",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0171",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0171",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0172",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0172",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0173",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0173",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0174",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0174",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0175",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0175",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0176",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0176",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0177",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0177",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0178",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0178",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0179",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0179",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0180",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0180",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0181",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0181",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0182",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0182",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0183",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0183",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0184",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0184",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0185",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0185",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0186",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0186",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0187",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0187",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0188",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0188",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0189",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0189",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0190",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0190",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0191",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0191",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0192",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0192",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0193",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0193",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0194",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0194",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0195",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0195",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0196",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0196",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0197",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0197",
+      "type": "blocks"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-src-0198",
+      "source": "synth-diamond-0000",
+      "target": "synth-diamond-0198",
+      "type": "blocks"
+    }
+  ],
+  "tasks": [
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0000",
+      "priority": "high",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond source",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0001",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 1",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0002",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 2",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0003",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 3",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0004",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 4",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0005",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 5",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0006",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 6",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0007",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 7",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0008",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 8",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0009",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 9",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0010",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 10",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0011",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 11",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0012",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 12",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0013",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 13",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0014",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 14",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0015",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 15",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0016",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 16",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0017",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 17",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0018",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 18",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0019",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 19",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0020",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 20",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0021",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 21",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0022",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 22",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0023",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 23",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0024",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 24",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0025",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 25",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0026",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 26",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0027",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 27",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0028",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 28",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0029",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 29",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0030",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 30",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0031",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 31",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0032",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 32",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0033",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 33",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0034",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 34",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0035",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 35",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0036",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 36",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0037",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 37",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0038",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 38",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0039",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 39",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0040",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 40",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0041",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 41",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0042",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 42",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0043",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 43",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0044",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 44",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0045",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 45",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0046",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 46",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0047",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 47",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0048",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 48",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0049",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 49",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0050",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 50",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0051",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 51",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0052",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 52",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0053",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 53",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0054",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 54",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0055",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 55",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0056",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 56",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0057",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 57",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0058",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 58",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0059",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 59",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0060",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 60",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0061",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 61",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0062",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 62",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0063",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 63",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0064",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 64",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0065",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 65",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0066",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 66",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0067",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 67",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0068",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 68",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0069",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 69",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0070",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 70",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0071",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 71",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0072",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 72",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0073",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 73",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0074",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 74",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0075",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 75",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0076",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 76",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0077",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 77",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0078",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 78",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0079",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 79",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0080",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 80",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0081",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 81",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0082",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 82",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0083",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 83",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0084",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 84",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0085",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 85",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0086",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 86",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0087",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 87",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0088",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 88",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0089",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 89",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0090",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 90",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0091",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 91",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0092",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 92",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0093",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 93",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0094",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 94",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0095",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 95",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0096",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 96",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0097",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 97",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0098",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 98",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0099",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 99",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0100",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 100",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0101",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 101",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0102",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 102",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0103",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 103",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0104",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 104",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0105",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 105",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0106",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 106",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0107",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 107",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0108",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 108",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0109",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 109",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0110",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 110",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0111",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 111",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0112",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 112",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0113",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 113",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0114",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 114",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0115",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 115",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0116",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 116",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0117",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 117",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0118",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 118",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0119",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 119",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0120",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 120",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0121",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 121",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0122",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 122",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0123",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 123",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0124",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 124",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0125",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 125",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0126",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 126",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0127",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 127",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0128",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 128",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0129",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 129",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0130",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 130",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0131",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 131",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0132",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 132",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0133",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 133",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0134",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 134",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0135",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 135",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0136",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 136",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0137",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 137",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0138",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 138",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0139",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 139",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0140",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 140",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0141",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 141",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0142",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 142",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0143",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 143",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0144",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 144",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0145",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 145",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0146",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 146",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0147",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 147",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0148",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 148",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0149",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 149",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0150",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 150",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0151",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 151",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0152",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 152",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0153",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 153",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0154",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 154",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0155",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 155",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0156",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 156",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0157",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 157",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0158",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 158",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0159",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 159",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0160",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 160",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0161",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 161",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0162",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 162",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0163",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 163",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0164",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 164",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0165",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 165",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0166",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 166",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0167",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 167",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0168",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 168",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0169",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 169",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0170",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 170",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0171",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 171",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0172",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 172",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0173",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 173",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0174",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 174",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0175",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 175",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0176",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 176",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0177",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 177",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0178",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 178",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0179",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 179",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0180",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 180",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0181",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 181",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0182",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 182",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0183",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 183",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0184",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 184",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0185",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 185",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0186",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 186",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0187",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 187",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0188",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 188",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0189",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 189",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0190",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 190",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0191",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 191",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0192",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 192",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0193",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 193",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0194",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 194",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0195",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 195",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0196",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 196",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0197",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 197",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0198",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond middle 198",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-diamond-0199",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Diamond sink",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    }
+  ],
+  "version": 2
+}

--- a/docs/research/fixtures/work-store-r1/manifest.json
+++ b/docs/research/fixtures/work-store-r1/manifest.json
@@ -1,0 +1,68 @@
+{
+  "fixtures": {
+    "chain_50": {
+      "blocks_edges": 49,
+      "contains_hostnames": false,
+      "digest_sha256": "518f57a67a3e48a7c0d5b8cbc23b569d60fd2b22998a37859c0e2878c5fb366b",
+      "edge_count": 49,
+      "expected": {
+        "blocks_edges": 49,
+        "edge_count": 49,
+        "parent_child_edges": 0,
+        "provenance_edges": 0,
+        "ready_count": 1,
+        "task_count": 50
+      },
+      "machine_neutral": true,
+      "name": "chain_50",
+      "parent_child_edges": 0,
+      "provenance_edges": 0,
+      "ready_count": 1,
+      "task_count": 50
+    },
+    "diamond_200": {
+      "blocks_edges": 396,
+      "contains_hostnames": false,
+      "digest_sha256": "931215cbde02d9c3942bea3cd752c83e0048cbc4b1e32b98dc85da56bd623e8a",
+      "edge_count": 396,
+      "expected": {
+        "blocks_edges": 396,
+        "edge_count": 396,
+        "parent_child_edges": 0,
+        "provenance_edges": 0,
+        "ready_count": 1,
+        "task_count": 200
+      },
+      "machine_neutral": true,
+      "name": "diamond_200",
+      "parent_child_edges": 0,
+      "provenance_edges": 0,
+      "ready_count": 1,
+      "task_count": 200
+    },
+    "wide_500_1000": {
+      "blocks_edges": 0,
+      "contains_hostnames": false,
+      "digest_sha256": "91f344bb7e7c951e1b8542a25d5f8153b11ccdfb1194f2f6593261571c63531c",
+      "edge_count": 1000,
+      "expected": {
+        "blocks_edges": 0,
+        "edge_count": 1000,
+        "parent_child_edges": 0,
+        "provenance_edges": 1000,
+        "ready_count": 500,
+        "task_count": 500
+      },
+      "machine_neutral": true,
+      "name": "wide_500_1000",
+      "parent_child_edges": 0,
+      "provenance_edges": 1000,
+      "ready_count": 500,
+      "task_count": 500
+    }
+  },
+  "issue": 846,
+  "kind": "work-store-fixture-manifest",
+  "protocol_version": 1,
+  "slice": "R1"
+}

--- a/docs/research/fixtures/work-store-r1/wide_500_1000.json
+++ b/docs/research/fixtures/work-store-r1/wide_500_1000.json
@@ -1,0 +1,12507 @@
+{
+  "edges": [
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0000",
+      "source": "synth-wide-0000",
+      "target": "synth-wide-0001",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0001",
+      "source": "synth-wide-0001",
+      "target": "synth-wide-0002",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0002",
+      "source": "synth-wide-0002",
+      "target": "synth-wide-0003",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0003",
+      "source": "synth-wide-0003",
+      "target": "synth-wide-0004",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0004",
+      "source": "synth-wide-0004",
+      "target": "synth-wide-0005",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0005",
+      "source": "synth-wide-0005",
+      "target": "synth-wide-0006",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0006",
+      "source": "synth-wide-0006",
+      "target": "synth-wide-0007",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0007",
+      "source": "synth-wide-0007",
+      "target": "synth-wide-0008",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0008",
+      "source": "synth-wide-0008",
+      "target": "synth-wide-0009",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0009",
+      "source": "synth-wide-0009",
+      "target": "synth-wide-0010",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0010",
+      "source": "synth-wide-0010",
+      "target": "synth-wide-0011",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0011",
+      "source": "synth-wide-0011",
+      "target": "synth-wide-0012",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0012",
+      "source": "synth-wide-0012",
+      "target": "synth-wide-0013",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0013",
+      "source": "synth-wide-0013",
+      "target": "synth-wide-0014",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0014",
+      "source": "synth-wide-0014",
+      "target": "synth-wide-0015",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0015",
+      "source": "synth-wide-0015",
+      "target": "synth-wide-0016",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0016",
+      "source": "synth-wide-0016",
+      "target": "synth-wide-0017",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0017",
+      "source": "synth-wide-0017",
+      "target": "synth-wide-0018",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0018",
+      "source": "synth-wide-0018",
+      "target": "synth-wide-0019",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0019",
+      "source": "synth-wide-0019",
+      "target": "synth-wide-0020",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0020",
+      "source": "synth-wide-0020",
+      "target": "synth-wide-0021",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0021",
+      "source": "synth-wide-0021",
+      "target": "synth-wide-0022",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0022",
+      "source": "synth-wide-0022",
+      "target": "synth-wide-0023",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0023",
+      "source": "synth-wide-0023",
+      "target": "synth-wide-0024",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0024",
+      "source": "synth-wide-0024",
+      "target": "synth-wide-0025",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0025",
+      "source": "synth-wide-0025",
+      "target": "synth-wide-0026",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0026",
+      "source": "synth-wide-0026",
+      "target": "synth-wide-0027",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0027",
+      "source": "synth-wide-0027",
+      "target": "synth-wide-0028",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0028",
+      "source": "synth-wide-0028",
+      "target": "synth-wide-0029",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0029",
+      "source": "synth-wide-0029",
+      "target": "synth-wide-0030",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0030",
+      "source": "synth-wide-0030",
+      "target": "synth-wide-0031",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0031",
+      "source": "synth-wide-0031",
+      "target": "synth-wide-0032",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0032",
+      "source": "synth-wide-0032",
+      "target": "synth-wide-0033",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0033",
+      "source": "synth-wide-0033",
+      "target": "synth-wide-0034",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0034",
+      "source": "synth-wide-0034",
+      "target": "synth-wide-0035",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0035",
+      "source": "synth-wide-0035",
+      "target": "synth-wide-0036",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0036",
+      "source": "synth-wide-0036",
+      "target": "synth-wide-0037",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0037",
+      "source": "synth-wide-0037",
+      "target": "synth-wide-0038",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0038",
+      "source": "synth-wide-0038",
+      "target": "synth-wide-0039",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0039",
+      "source": "synth-wide-0039",
+      "target": "synth-wide-0040",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0040",
+      "source": "synth-wide-0040",
+      "target": "synth-wide-0041",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0041",
+      "source": "synth-wide-0041",
+      "target": "synth-wide-0042",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0042",
+      "source": "synth-wide-0042",
+      "target": "synth-wide-0043",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0043",
+      "source": "synth-wide-0043",
+      "target": "synth-wide-0044",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0044",
+      "source": "synth-wide-0044",
+      "target": "synth-wide-0045",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0045",
+      "source": "synth-wide-0045",
+      "target": "synth-wide-0046",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0046",
+      "source": "synth-wide-0046",
+      "target": "synth-wide-0047",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0047",
+      "source": "synth-wide-0047",
+      "target": "synth-wide-0048",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0048",
+      "source": "synth-wide-0048",
+      "target": "synth-wide-0049",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0049",
+      "source": "synth-wide-0049",
+      "target": "synth-wide-0050",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0050",
+      "source": "synth-wide-0050",
+      "target": "synth-wide-0051",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0051",
+      "source": "synth-wide-0051",
+      "target": "synth-wide-0052",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0052",
+      "source": "synth-wide-0052",
+      "target": "synth-wide-0053",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0053",
+      "source": "synth-wide-0053",
+      "target": "synth-wide-0054",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0054",
+      "source": "synth-wide-0054",
+      "target": "synth-wide-0055",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0055",
+      "source": "synth-wide-0055",
+      "target": "synth-wide-0056",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0056",
+      "source": "synth-wide-0056",
+      "target": "synth-wide-0057",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0057",
+      "source": "synth-wide-0057",
+      "target": "synth-wide-0058",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0058",
+      "source": "synth-wide-0058",
+      "target": "synth-wide-0059",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0059",
+      "source": "synth-wide-0059",
+      "target": "synth-wide-0060",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0060",
+      "source": "synth-wide-0060",
+      "target": "synth-wide-0061",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0061",
+      "source": "synth-wide-0061",
+      "target": "synth-wide-0062",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0062",
+      "source": "synth-wide-0062",
+      "target": "synth-wide-0063",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0063",
+      "source": "synth-wide-0063",
+      "target": "synth-wide-0064",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0064",
+      "source": "synth-wide-0064",
+      "target": "synth-wide-0065",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0065",
+      "source": "synth-wide-0065",
+      "target": "synth-wide-0066",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0066",
+      "source": "synth-wide-0066",
+      "target": "synth-wide-0067",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0067",
+      "source": "synth-wide-0067",
+      "target": "synth-wide-0068",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0068",
+      "source": "synth-wide-0068",
+      "target": "synth-wide-0069",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0069",
+      "source": "synth-wide-0069",
+      "target": "synth-wide-0070",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0070",
+      "source": "synth-wide-0070",
+      "target": "synth-wide-0071",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0071",
+      "source": "synth-wide-0071",
+      "target": "synth-wide-0072",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0072",
+      "source": "synth-wide-0072",
+      "target": "synth-wide-0073",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0073",
+      "source": "synth-wide-0073",
+      "target": "synth-wide-0074",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0074",
+      "source": "synth-wide-0074",
+      "target": "synth-wide-0075",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0075",
+      "source": "synth-wide-0075",
+      "target": "synth-wide-0076",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0076",
+      "source": "synth-wide-0076",
+      "target": "synth-wide-0077",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0077",
+      "source": "synth-wide-0077",
+      "target": "synth-wide-0078",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0078",
+      "source": "synth-wide-0078",
+      "target": "synth-wide-0079",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0079",
+      "source": "synth-wide-0079",
+      "target": "synth-wide-0080",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0080",
+      "source": "synth-wide-0080",
+      "target": "synth-wide-0081",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0081",
+      "source": "synth-wide-0081",
+      "target": "synth-wide-0082",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0082",
+      "source": "synth-wide-0082",
+      "target": "synth-wide-0083",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0083",
+      "source": "synth-wide-0083",
+      "target": "synth-wide-0084",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0084",
+      "source": "synth-wide-0084",
+      "target": "synth-wide-0085",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0085",
+      "source": "synth-wide-0085",
+      "target": "synth-wide-0086",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0086",
+      "source": "synth-wide-0086",
+      "target": "synth-wide-0087",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0087",
+      "source": "synth-wide-0087",
+      "target": "synth-wide-0088",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0088",
+      "source": "synth-wide-0088",
+      "target": "synth-wide-0089",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0089",
+      "source": "synth-wide-0089",
+      "target": "synth-wide-0090",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0090",
+      "source": "synth-wide-0090",
+      "target": "synth-wide-0091",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0091",
+      "source": "synth-wide-0091",
+      "target": "synth-wide-0092",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0092",
+      "source": "synth-wide-0092",
+      "target": "synth-wide-0093",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0093",
+      "source": "synth-wide-0093",
+      "target": "synth-wide-0094",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0094",
+      "source": "synth-wide-0094",
+      "target": "synth-wide-0095",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0095",
+      "source": "synth-wide-0095",
+      "target": "synth-wide-0096",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0096",
+      "source": "synth-wide-0096",
+      "target": "synth-wide-0097",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0097",
+      "source": "synth-wide-0097",
+      "target": "synth-wide-0098",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0098",
+      "source": "synth-wide-0098",
+      "target": "synth-wide-0099",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0099",
+      "source": "synth-wide-0099",
+      "target": "synth-wide-0100",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0100",
+      "source": "synth-wide-0100",
+      "target": "synth-wide-0101",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0101",
+      "source": "synth-wide-0101",
+      "target": "synth-wide-0102",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0102",
+      "source": "synth-wide-0102",
+      "target": "synth-wide-0103",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0103",
+      "source": "synth-wide-0103",
+      "target": "synth-wide-0104",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0104",
+      "source": "synth-wide-0104",
+      "target": "synth-wide-0105",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0105",
+      "source": "synth-wide-0105",
+      "target": "synth-wide-0106",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0106",
+      "source": "synth-wide-0106",
+      "target": "synth-wide-0107",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0107",
+      "source": "synth-wide-0107",
+      "target": "synth-wide-0108",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0108",
+      "source": "synth-wide-0108",
+      "target": "synth-wide-0109",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0109",
+      "source": "synth-wide-0109",
+      "target": "synth-wide-0110",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0110",
+      "source": "synth-wide-0110",
+      "target": "synth-wide-0111",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0111",
+      "source": "synth-wide-0111",
+      "target": "synth-wide-0112",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0112",
+      "source": "synth-wide-0112",
+      "target": "synth-wide-0113",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0113",
+      "source": "synth-wide-0113",
+      "target": "synth-wide-0114",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0114",
+      "source": "synth-wide-0114",
+      "target": "synth-wide-0115",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0115",
+      "source": "synth-wide-0115",
+      "target": "synth-wide-0116",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0116",
+      "source": "synth-wide-0116",
+      "target": "synth-wide-0117",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0117",
+      "source": "synth-wide-0117",
+      "target": "synth-wide-0118",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0118",
+      "source": "synth-wide-0118",
+      "target": "synth-wide-0119",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0119",
+      "source": "synth-wide-0119",
+      "target": "synth-wide-0120",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0120",
+      "source": "synth-wide-0120",
+      "target": "synth-wide-0121",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0121",
+      "source": "synth-wide-0121",
+      "target": "synth-wide-0122",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0122",
+      "source": "synth-wide-0122",
+      "target": "synth-wide-0123",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0123",
+      "source": "synth-wide-0123",
+      "target": "synth-wide-0124",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0124",
+      "source": "synth-wide-0124",
+      "target": "synth-wide-0125",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0125",
+      "source": "synth-wide-0125",
+      "target": "synth-wide-0126",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0126",
+      "source": "synth-wide-0126",
+      "target": "synth-wide-0127",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0127",
+      "source": "synth-wide-0127",
+      "target": "synth-wide-0128",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0128",
+      "source": "synth-wide-0128",
+      "target": "synth-wide-0129",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0129",
+      "source": "synth-wide-0129",
+      "target": "synth-wide-0130",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0130",
+      "source": "synth-wide-0130",
+      "target": "synth-wide-0131",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0131",
+      "source": "synth-wide-0131",
+      "target": "synth-wide-0132",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0132",
+      "source": "synth-wide-0132",
+      "target": "synth-wide-0133",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0133",
+      "source": "synth-wide-0133",
+      "target": "synth-wide-0134",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0134",
+      "source": "synth-wide-0134",
+      "target": "synth-wide-0135",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0135",
+      "source": "synth-wide-0135",
+      "target": "synth-wide-0136",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0136",
+      "source": "synth-wide-0136",
+      "target": "synth-wide-0137",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0137",
+      "source": "synth-wide-0137",
+      "target": "synth-wide-0138",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0138",
+      "source": "synth-wide-0138",
+      "target": "synth-wide-0139",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0139",
+      "source": "synth-wide-0139",
+      "target": "synth-wide-0140",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0140",
+      "source": "synth-wide-0140",
+      "target": "synth-wide-0141",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0141",
+      "source": "synth-wide-0141",
+      "target": "synth-wide-0142",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0142",
+      "source": "synth-wide-0142",
+      "target": "synth-wide-0143",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0143",
+      "source": "synth-wide-0143",
+      "target": "synth-wide-0144",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0144",
+      "source": "synth-wide-0144",
+      "target": "synth-wide-0145",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0145",
+      "source": "synth-wide-0145",
+      "target": "synth-wide-0146",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0146",
+      "source": "synth-wide-0146",
+      "target": "synth-wide-0147",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0147",
+      "source": "synth-wide-0147",
+      "target": "synth-wide-0148",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0148",
+      "source": "synth-wide-0148",
+      "target": "synth-wide-0149",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0149",
+      "source": "synth-wide-0149",
+      "target": "synth-wide-0150",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0150",
+      "source": "synth-wide-0150",
+      "target": "synth-wide-0151",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0151",
+      "source": "synth-wide-0151",
+      "target": "synth-wide-0152",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0152",
+      "source": "synth-wide-0152",
+      "target": "synth-wide-0153",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0153",
+      "source": "synth-wide-0153",
+      "target": "synth-wide-0154",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0154",
+      "source": "synth-wide-0154",
+      "target": "synth-wide-0155",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0155",
+      "source": "synth-wide-0155",
+      "target": "synth-wide-0156",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0156",
+      "source": "synth-wide-0156",
+      "target": "synth-wide-0157",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0157",
+      "source": "synth-wide-0157",
+      "target": "synth-wide-0158",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0158",
+      "source": "synth-wide-0158",
+      "target": "synth-wide-0159",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0159",
+      "source": "synth-wide-0159",
+      "target": "synth-wide-0160",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0160",
+      "source": "synth-wide-0160",
+      "target": "synth-wide-0161",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0161",
+      "source": "synth-wide-0161",
+      "target": "synth-wide-0162",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0162",
+      "source": "synth-wide-0162",
+      "target": "synth-wide-0163",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0163",
+      "source": "synth-wide-0163",
+      "target": "synth-wide-0164",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0164",
+      "source": "synth-wide-0164",
+      "target": "synth-wide-0165",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0165",
+      "source": "synth-wide-0165",
+      "target": "synth-wide-0166",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0166",
+      "source": "synth-wide-0166",
+      "target": "synth-wide-0167",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0167",
+      "source": "synth-wide-0167",
+      "target": "synth-wide-0168",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0168",
+      "source": "synth-wide-0168",
+      "target": "synth-wide-0169",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0169",
+      "source": "synth-wide-0169",
+      "target": "synth-wide-0170",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0170",
+      "source": "synth-wide-0170",
+      "target": "synth-wide-0171",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0171",
+      "source": "synth-wide-0171",
+      "target": "synth-wide-0172",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0172",
+      "source": "synth-wide-0172",
+      "target": "synth-wide-0173",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0173",
+      "source": "synth-wide-0173",
+      "target": "synth-wide-0174",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0174",
+      "source": "synth-wide-0174",
+      "target": "synth-wide-0175",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0175",
+      "source": "synth-wide-0175",
+      "target": "synth-wide-0176",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0176",
+      "source": "synth-wide-0176",
+      "target": "synth-wide-0177",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0177",
+      "source": "synth-wide-0177",
+      "target": "synth-wide-0178",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0178",
+      "source": "synth-wide-0178",
+      "target": "synth-wide-0179",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0179",
+      "source": "synth-wide-0179",
+      "target": "synth-wide-0180",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0180",
+      "source": "synth-wide-0180",
+      "target": "synth-wide-0181",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0181",
+      "source": "synth-wide-0181",
+      "target": "synth-wide-0182",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0182",
+      "source": "synth-wide-0182",
+      "target": "synth-wide-0183",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0183",
+      "source": "synth-wide-0183",
+      "target": "synth-wide-0184",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0184",
+      "source": "synth-wide-0184",
+      "target": "synth-wide-0185",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0185",
+      "source": "synth-wide-0185",
+      "target": "synth-wide-0186",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0186",
+      "source": "synth-wide-0186",
+      "target": "synth-wide-0187",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0187",
+      "source": "synth-wide-0187",
+      "target": "synth-wide-0188",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0188",
+      "source": "synth-wide-0188",
+      "target": "synth-wide-0189",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0189",
+      "source": "synth-wide-0189",
+      "target": "synth-wide-0190",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0190",
+      "source": "synth-wide-0190",
+      "target": "synth-wide-0191",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0191",
+      "source": "synth-wide-0191",
+      "target": "synth-wide-0192",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0192",
+      "source": "synth-wide-0192",
+      "target": "synth-wide-0193",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0193",
+      "source": "synth-wide-0193",
+      "target": "synth-wide-0194",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0194",
+      "source": "synth-wide-0194",
+      "target": "synth-wide-0195",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0195",
+      "source": "synth-wide-0195",
+      "target": "synth-wide-0196",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0196",
+      "source": "synth-wide-0196",
+      "target": "synth-wide-0197",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0197",
+      "source": "synth-wide-0197",
+      "target": "synth-wide-0198",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0198",
+      "source": "synth-wide-0198",
+      "target": "synth-wide-0199",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0199",
+      "source": "synth-wide-0199",
+      "target": "synth-wide-0200",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0200",
+      "source": "synth-wide-0200",
+      "target": "synth-wide-0201",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0201",
+      "source": "synth-wide-0201",
+      "target": "synth-wide-0202",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0202",
+      "source": "synth-wide-0202",
+      "target": "synth-wide-0203",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0203",
+      "source": "synth-wide-0203",
+      "target": "synth-wide-0204",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0204",
+      "source": "synth-wide-0204",
+      "target": "synth-wide-0205",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0205",
+      "source": "synth-wide-0205",
+      "target": "synth-wide-0206",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0206",
+      "source": "synth-wide-0206",
+      "target": "synth-wide-0207",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0207",
+      "source": "synth-wide-0207",
+      "target": "synth-wide-0208",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0208",
+      "source": "synth-wide-0208",
+      "target": "synth-wide-0209",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0209",
+      "source": "synth-wide-0209",
+      "target": "synth-wide-0210",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0210",
+      "source": "synth-wide-0210",
+      "target": "synth-wide-0211",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0211",
+      "source": "synth-wide-0211",
+      "target": "synth-wide-0212",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0212",
+      "source": "synth-wide-0212",
+      "target": "synth-wide-0213",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0213",
+      "source": "synth-wide-0213",
+      "target": "synth-wide-0214",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0214",
+      "source": "synth-wide-0214",
+      "target": "synth-wide-0215",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0215",
+      "source": "synth-wide-0215",
+      "target": "synth-wide-0216",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0216",
+      "source": "synth-wide-0216",
+      "target": "synth-wide-0217",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0217",
+      "source": "synth-wide-0217",
+      "target": "synth-wide-0218",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0218",
+      "source": "synth-wide-0218",
+      "target": "synth-wide-0219",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0219",
+      "source": "synth-wide-0219",
+      "target": "synth-wide-0220",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0220",
+      "source": "synth-wide-0220",
+      "target": "synth-wide-0221",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0221",
+      "source": "synth-wide-0221",
+      "target": "synth-wide-0222",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0222",
+      "source": "synth-wide-0222",
+      "target": "synth-wide-0223",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0223",
+      "source": "synth-wide-0223",
+      "target": "synth-wide-0224",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0224",
+      "source": "synth-wide-0224",
+      "target": "synth-wide-0225",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0225",
+      "source": "synth-wide-0225",
+      "target": "synth-wide-0226",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0226",
+      "source": "synth-wide-0226",
+      "target": "synth-wide-0227",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0227",
+      "source": "synth-wide-0227",
+      "target": "synth-wide-0228",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0228",
+      "source": "synth-wide-0228",
+      "target": "synth-wide-0229",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0229",
+      "source": "synth-wide-0229",
+      "target": "synth-wide-0230",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0230",
+      "source": "synth-wide-0230",
+      "target": "synth-wide-0231",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0231",
+      "source": "synth-wide-0231",
+      "target": "synth-wide-0232",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0232",
+      "source": "synth-wide-0232",
+      "target": "synth-wide-0233",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0233",
+      "source": "synth-wide-0233",
+      "target": "synth-wide-0234",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0234",
+      "source": "synth-wide-0234",
+      "target": "synth-wide-0235",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0235",
+      "source": "synth-wide-0235",
+      "target": "synth-wide-0236",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0236",
+      "source": "synth-wide-0236",
+      "target": "synth-wide-0237",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0237",
+      "source": "synth-wide-0237",
+      "target": "synth-wide-0238",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0238",
+      "source": "synth-wide-0238",
+      "target": "synth-wide-0239",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0239",
+      "source": "synth-wide-0239",
+      "target": "synth-wide-0240",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0240",
+      "source": "synth-wide-0240",
+      "target": "synth-wide-0241",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0241",
+      "source": "synth-wide-0241",
+      "target": "synth-wide-0242",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0242",
+      "source": "synth-wide-0242",
+      "target": "synth-wide-0243",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0243",
+      "source": "synth-wide-0243",
+      "target": "synth-wide-0244",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0244",
+      "source": "synth-wide-0244",
+      "target": "synth-wide-0245",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0245",
+      "source": "synth-wide-0245",
+      "target": "synth-wide-0246",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0246",
+      "source": "synth-wide-0246",
+      "target": "synth-wide-0247",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0247",
+      "source": "synth-wide-0247",
+      "target": "synth-wide-0248",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0248",
+      "source": "synth-wide-0248",
+      "target": "synth-wide-0249",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0249",
+      "source": "synth-wide-0249",
+      "target": "synth-wide-0250",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0250",
+      "source": "synth-wide-0250",
+      "target": "synth-wide-0251",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0251",
+      "source": "synth-wide-0251",
+      "target": "synth-wide-0252",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0252",
+      "source": "synth-wide-0252",
+      "target": "synth-wide-0253",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0253",
+      "source": "synth-wide-0253",
+      "target": "synth-wide-0254",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0254",
+      "source": "synth-wide-0254",
+      "target": "synth-wide-0255",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0255",
+      "source": "synth-wide-0255",
+      "target": "synth-wide-0256",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0256",
+      "source": "synth-wide-0256",
+      "target": "synth-wide-0257",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0257",
+      "source": "synth-wide-0257",
+      "target": "synth-wide-0258",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0258",
+      "source": "synth-wide-0258",
+      "target": "synth-wide-0259",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0259",
+      "source": "synth-wide-0259",
+      "target": "synth-wide-0260",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0260",
+      "source": "synth-wide-0260",
+      "target": "synth-wide-0261",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0261",
+      "source": "synth-wide-0261",
+      "target": "synth-wide-0262",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0262",
+      "source": "synth-wide-0262",
+      "target": "synth-wide-0263",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0263",
+      "source": "synth-wide-0263",
+      "target": "synth-wide-0264",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0264",
+      "source": "synth-wide-0264",
+      "target": "synth-wide-0265",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0265",
+      "source": "synth-wide-0265",
+      "target": "synth-wide-0266",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0266",
+      "source": "synth-wide-0266",
+      "target": "synth-wide-0267",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0267",
+      "source": "synth-wide-0267",
+      "target": "synth-wide-0268",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0268",
+      "source": "synth-wide-0268",
+      "target": "synth-wide-0269",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0269",
+      "source": "synth-wide-0269",
+      "target": "synth-wide-0270",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0270",
+      "source": "synth-wide-0270",
+      "target": "synth-wide-0271",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0271",
+      "source": "synth-wide-0271",
+      "target": "synth-wide-0272",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0272",
+      "source": "synth-wide-0272",
+      "target": "synth-wide-0273",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0273",
+      "source": "synth-wide-0273",
+      "target": "synth-wide-0274",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0274",
+      "source": "synth-wide-0274",
+      "target": "synth-wide-0275",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0275",
+      "source": "synth-wide-0275",
+      "target": "synth-wide-0276",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0276",
+      "source": "synth-wide-0276",
+      "target": "synth-wide-0277",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0277",
+      "source": "synth-wide-0277",
+      "target": "synth-wide-0278",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0278",
+      "source": "synth-wide-0278",
+      "target": "synth-wide-0279",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0279",
+      "source": "synth-wide-0279",
+      "target": "synth-wide-0280",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0280",
+      "source": "synth-wide-0280",
+      "target": "synth-wide-0281",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0281",
+      "source": "synth-wide-0281",
+      "target": "synth-wide-0282",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0282",
+      "source": "synth-wide-0282",
+      "target": "synth-wide-0283",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0283",
+      "source": "synth-wide-0283",
+      "target": "synth-wide-0284",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0284",
+      "source": "synth-wide-0284",
+      "target": "synth-wide-0285",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0285",
+      "source": "synth-wide-0285",
+      "target": "synth-wide-0286",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0286",
+      "source": "synth-wide-0286",
+      "target": "synth-wide-0287",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0287",
+      "source": "synth-wide-0287",
+      "target": "synth-wide-0288",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0288",
+      "source": "synth-wide-0288",
+      "target": "synth-wide-0289",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0289",
+      "source": "synth-wide-0289",
+      "target": "synth-wide-0290",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0290",
+      "source": "synth-wide-0290",
+      "target": "synth-wide-0291",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0291",
+      "source": "synth-wide-0291",
+      "target": "synth-wide-0292",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0292",
+      "source": "synth-wide-0292",
+      "target": "synth-wide-0293",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0293",
+      "source": "synth-wide-0293",
+      "target": "synth-wide-0294",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0294",
+      "source": "synth-wide-0294",
+      "target": "synth-wide-0295",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0295",
+      "source": "synth-wide-0295",
+      "target": "synth-wide-0296",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0296",
+      "source": "synth-wide-0296",
+      "target": "synth-wide-0297",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0297",
+      "source": "synth-wide-0297",
+      "target": "synth-wide-0298",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0298",
+      "source": "synth-wide-0298",
+      "target": "synth-wide-0299",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0299",
+      "source": "synth-wide-0299",
+      "target": "synth-wide-0300",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0300",
+      "source": "synth-wide-0300",
+      "target": "synth-wide-0301",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0301",
+      "source": "synth-wide-0301",
+      "target": "synth-wide-0302",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0302",
+      "source": "synth-wide-0302",
+      "target": "synth-wide-0303",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0303",
+      "source": "synth-wide-0303",
+      "target": "synth-wide-0304",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0304",
+      "source": "synth-wide-0304",
+      "target": "synth-wide-0305",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0305",
+      "source": "synth-wide-0305",
+      "target": "synth-wide-0306",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0306",
+      "source": "synth-wide-0306",
+      "target": "synth-wide-0307",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0307",
+      "source": "synth-wide-0307",
+      "target": "synth-wide-0308",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0308",
+      "source": "synth-wide-0308",
+      "target": "synth-wide-0309",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0309",
+      "source": "synth-wide-0309",
+      "target": "synth-wide-0310",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0310",
+      "source": "synth-wide-0310",
+      "target": "synth-wide-0311",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0311",
+      "source": "synth-wide-0311",
+      "target": "synth-wide-0312",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0312",
+      "source": "synth-wide-0312",
+      "target": "synth-wide-0313",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0313",
+      "source": "synth-wide-0313",
+      "target": "synth-wide-0314",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0314",
+      "source": "synth-wide-0314",
+      "target": "synth-wide-0315",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0315",
+      "source": "synth-wide-0315",
+      "target": "synth-wide-0316",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0316",
+      "source": "synth-wide-0316",
+      "target": "synth-wide-0317",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0317",
+      "source": "synth-wide-0317",
+      "target": "synth-wide-0318",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0318",
+      "source": "synth-wide-0318",
+      "target": "synth-wide-0319",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0319",
+      "source": "synth-wide-0319",
+      "target": "synth-wide-0320",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0320",
+      "source": "synth-wide-0320",
+      "target": "synth-wide-0321",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0321",
+      "source": "synth-wide-0321",
+      "target": "synth-wide-0322",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0322",
+      "source": "synth-wide-0322",
+      "target": "synth-wide-0323",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0323",
+      "source": "synth-wide-0323",
+      "target": "synth-wide-0324",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0324",
+      "source": "synth-wide-0324",
+      "target": "synth-wide-0325",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0325",
+      "source": "synth-wide-0325",
+      "target": "synth-wide-0326",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0326",
+      "source": "synth-wide-0326",
+      "target": "synth-wide-0327",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0327",
+      "source": "synth-wide-0327",
+      "target": "synth-wide-0328",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0328",
+      "source": "synth-wide-0328",
+      "target": "synth-wide-0329",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0329",
+      "source": "synth-wide-0329",
+      "target": "synth-wide-0330",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0330",
+      "source": "synth-wide-0330",
+      "target": "synth-wide-0331",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0331",
+      "source": "synth-wide-0331",
+      "target": "synth-wide-0332",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0332",
+      "source": "synth-wide-0332",
+      "target": "synth-wide-0333",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0333",
+      "source": "synth-wide-0333",
+      "target": "synth-wide-0334",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0334",
+      "source": "synth-wide-0334",
+      "target": "synth-wide-0335",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0335",
+      "source": "synth-wide-0335",
+      "target": "synth-wide-0336",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0336",
+      "source": "synth-wide-0336",
+      "target": "synth-wide-0337",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0337",
+      "source": "synth-wide-0337",
+      "target": "synth-wide-0338",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0338",
+      "source": "synth-wide-0338",
+      "target": "synth-wide-0339",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0339",
+      "source": "synth-wide-0339",
+      "target": "synth-wide-0340",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0340",
+      "source": "synth-wide-0340",
+      "target": "synth-wide-0341",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0341",
+      "source": "synth-wide-0341",
+      "target": "synth-wide-0342",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0342",
+      "source": "synth-wide-0342",
+      "target": "synth-wide-0343",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0343",
+      "source": "synth-wide-0343",
+      "target": "synth-wide-0344",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0344",
+      "source": "synth-wide-0344",
+      "target": "synth-wide-0345",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0345",
+      "source": "synth-wide-0345",
+      "target": "synth-wide-0346",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0346",
+      "source": "synth-wide-0346",
+      "target": "synth-wide-0347",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0347",
+      "source": "synth-wide-0347",
+      "target": "synth-wide-0348",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0348",
+      "source": "synth-wide-0348",
+      "target": "synth-wide-0349",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0349",
+      "source": "synth-wide-0349",
+      "target": "synth-wide-0350",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0350",
+      "source": "synth-wide-0350",
+      "target": "synth-wide-0351",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0351",
+      "source": "synth-wide-0351",
+      "target": "synth-wide-0352",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0352",
+      "source": "synth-wide-0352",
+      "target": "synth-wide-0353",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0353",
+      "source": "synth-wide-0353",
+      "target": "synth-wide-0354",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0354",
+      "source": "synth-wide-0354",
+      "target": "synth-wide-0355",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0355",
+      "source": "synth-wide-0355",
+      "target": "synth-wide-0356",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0356",
+      "source": "synth-wide-0356",
+      "target": "synth-wide-0357",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0357",
+      "source": "synth-wide-0357",
+      "target": "synth-wide-0358",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0358",
+      "source": "synth-wide-0358",
+      "target": "synth-wide-0359",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0359",
+      "source": "synth-wide-0359",
+      "target": "synth-wide-0360",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0360",
+      "source": "synth-wide-0360",
+      "target": "synth-wide-0361",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0361",
+      "source": "synth-wide-0361",
+      "target": "synth-wide-0362",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0362",
+      "source": "synth-wide-0362",
+      "target": "synth-wide-0363",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0363",
+      "source": "synth-wide-0363",
+      "target": "synth-wide-0364",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0364",
+      "source": "synth-wide-0364",
+      "target": "synth-wide-0365",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0365",
+      "source": "synth-wide-0365",
+      "target": "synth-wide-0366",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0366",
+      "source": "synth-wide-0366",
+      "target": "synth-wide-0367",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0367",
+      "source": "synth-wide-0367",
+      "target": "synth-wide-0368",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0368",
+      "source": "synth-wide-0368",
+      "target": "synth-wide-0369",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0369",
+      "source": "synth-wide-0369",
+      "target": "synth-wide-0370",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0370",
+      "source": "synth-wide-0370",
+      "target": "synth-wide-0371",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0371",
+      "source": "synth-wide-0371",
+      "target": "synth-wide-0372",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0372",
+      "source": "synth-wide-0372",
+      "target": "synth-wide-0373",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0373",
+      "source": "synth-wide-0373",
+      "target": "synth-wide-0374",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0374",
+      "source": "synth-wide-0374",
+      "target": "synth-wide-0375",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0375",
+      "source": "synth-wide-0375",
+      "target": "synth-wide-0376",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0376",
+      "source": "synth-wide-0376",
+      "target": "synth-wide-0377",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0377",
+      "source": "synth-wide-0377",
+      "target": "synth-wide-0378",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0378",
+      "source": "synth-wide-0378",
+      "target": "synth-wide-0379",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0379",
+      "source": "synth-wide-0379",
+      "target": "synth-wide-0380",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0380",
+      "source": "synth-wide-0380",
+      "target": "synth-wide-0381",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0381",
+      "source": "synth-wide-0381",
+      "target": "synth-wide-0382",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0382",
+      "source": "synth-wide-0382",
+      "target": "synth-wide-0383",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0383",
+      "source": "synth-wide-0383",
+      "target": "synth-wide-0384",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0384",
+      "source": "synth-wide-0384",
+      "target": "synth-wide-0385",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0385",
+      "source": "synth-wide-0385",
+      "target": "synth-wide-0386",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0386",
+      "source": "synth-wide-0386",
+      "target": "synth-wide-0387",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0387",
+      "source": "synth-wide-0387",
+      "target": "synth-wide-0388",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0388",
+      "source": "synth-wide-0388",
+      "target": "synth-wide-0389",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0389",
+      "source": "synth-wide-0389",
+      "target": "synth-wide-0390",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0390",
+      "source": "synth-wide-0390",
+      "target": "synth-wide-0391",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0391",
+      "source": "synth-wide-0391",
+      "target": "synth-wide-0392",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0392",
+      "source": "synth-wide-0392",
+      "target": "synth-wide-0393",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0393",
+      "source": "synth-wide-0393",
+      "target": "synth-wide-0394",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0394",
+      "source": "synth-wide-0394",
+      "target": "synth-wide-0395",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0395",
+      "source": "synth-wide-0395",
+      "target": "synth-wide-0396",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0396",
+      "source": "synth-wide-0396",
+      "target": "synth-wide-0397",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0397",
+      "source": "synth-wide-0397",
+      "target": "synth-wide-0398",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0398",
+      "source": "synth-wide-0398",
+      "target": "synth-wide-0399",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0399",
+      "source": "synth-wide-0399",
+      "target": "synth-wide-0400",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0400",
+      "source": "synth-wide-0400",
+      "target": "synth-wide-0401",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0401",
+      "source": "synth-wide-0401",
+      "target": "synth-wide-0402",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0402",
+      "source": "synth-wide-0402",
+      "target": "synth-wide-0403",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0403",
+      "source": "synth-wide-0403",
+      "target": "synth-wide-0404",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0404",
+      "source": "synth-wide-0404",
+      "target": "synth-wide-0405",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0405",
+      "source": "synth-wide-0405",
+      "target": "synth-wide-0406",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0406",
+      "source": "synth-wide-0406",
+      "target": "synth-wide-0407",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0407",
+      "source": "synth-wide-0407",
+      "target": "synth-wide-0408",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0408",
+      "source": "synth-wide-0408",
+      "target": "synth-wide-0409",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0409",
+      "source": "synth-wide-0409",
+      "target": "synth-wide-0410",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0410",
+      "source": "synth-wide-0410",
+      "target": "synth-wide-0411",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0411",
+      "source": "synth-wide-0411",
+      "target": "synth-wide-0412",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0412",
+      "source": "synth-wide-0412",
+      "target": "synth-wide-0413",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0413",
+      "source": "synth-wide-0413",
+      "target": "synth-wide-0414",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0414",
+      "source": "synth-wide-0414",
+      "target": "synth-wide-0415",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0415",
+      "source": "synth-wide-0415",
+      "target": "synth-wide-0416",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0416",
+      "source": "synth-wide-0416",
+      "target": "synth-wide-0417",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0417",
+      "source": "synth-wide-0417",
+      "target": "synth-wide-0418",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0418",
+      "source": "synth-wide-0418",
+      "target": "synth-wide-0419",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0419",
+      "source": "synth-wide-0419",
+      "target": "synth-wide-0420",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0420",
+      "source": "synth-wide-0420",
+      "target": "synth-wide-0421",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0421",
+      "source": "synth-wide-0421",
+      "target": "synth-wide-0422",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0422",
+      "source": "synth-wide-0422",
+      "target": "synth-wide-0423",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0423",
+      "source": "synth-wide-0423",
+      "target": "synth-wide-0424",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0424",
+      "source": "synth-wide-0424",
+      "target": "synth-wide-0425",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0425",
+      "source": "synth-wide-0425",
+      "target": "synth-wide-0426",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0426",
+      "source": "synth-wide-0426",
+      "target": "synth-wide-0427",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0427",
+      "source": "synth-wide-0427",
+      "target": "synth-wide-0428",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0428",
+      "source": "synth-wide-0428",
+      "target": "synth-wide-0429",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0429",
+      "source": "synth-wide-0429",
+      "target": "synth-wide-0430",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0430",
+      "source": "synth-wide-0430",
+      "target": "synth-wide-0431",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0431",
+      "source": "synth-wide-0431",
+      "target": "synth-wide-0432",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0432",
+      "source": "synth-wide-0432",
+      "target": "synth-wide-0433",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0433",
+      "source": "synth-wide-0433",
+      "target": "synth-wide-0434",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0434",
+      "source": "synth-wide-0434",
+      "target": "synth-wide-0435",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0435",
+      "source": "synth-wide-0435",
+      "target": "synth-wide-0436",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0436",
+      "source": "synth-wide-0436",
+      "target": "synth-wide-0437",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0437",
+      "source": "synth-wide-0437",
+      "target": "synth-wide-0438",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0438",
+      "source": "synth-wide-0438",
+      "target": "synth-wide-0439",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0439",
+      "source": "synth-wide-0439",
+      "target": "synth-wide-0440",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0440",
+      "source": "synth-wide-0440",
+      "target": "synth-wide-0441",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0441",
+      "source": "synth-wide-0441",
+      "target": "synth-wide-0442",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0442",
+      "source": "synth-wide-0442",
+      "target": "synth-wide-0443",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0443",
+      "source": "synth-wide-0443",
+      "target": "synth-wide-0444",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0444",
+      "source": "synth-wide-0444",
+      "target": "synth-wide-0445",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0445",
+      "source": "synth-wide-0445",
+      "target": "synth-wide-0446",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0446",
+      "source": "synth-wide-0446",
+      "target": "synth-wide-0447",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0447",
+      "source": "synth-wide-0447",
+      "target": "synth-wide-0448",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0448",
+      "source": "synth-wide-0448",
+      "target": "synth-wide-0449",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0449",
+      "source": "synth-wide-0449",
+      "target": "synth-wide-0450",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0450",
+      "source": "synth-wide-0450",
+      "target": "synth-wide-0451",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0451",
+      "source": "synth-wide-0451",
+      "target": "synth-wide-0452",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0452",
+      "source": "synth-wide-0452",
+      "target": "synth-wide-0453",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0453",
+      "source": "synth-wide-0453",
+      "target": "synth-wide-0454",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0454",
+      "source": "synth-wide-0454",
+      "target": "synth-wide-0455",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0455",
+      "source": "synth-wide-0455",
+      "target": "synth-wide-0456",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0456",
+      "source": "synth-wide-0456",
+      "target": "synth-wide-0457",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0457",
+      "source": "synth-wide-0457",
+      "target": "synth-wide-0458",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0458",
+      "source": "synth-wide-0458",
+      "target": "synth-wide-0459",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0459",
+      "source": "synth-wide-0459",
+      "target": "synth-wide-0460",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0460",
+      "source": "synth-wide-0460",
+      "target": "synth-wide-0461",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0461",
+      "source": "synth-wide-0461",
+      "target": "synth-wide-0462",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0462",
+      "source": "synth-wide-0462",
+      "target": "synth-wide-0463",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0463",
+      "source": "synth-wide-0463",
+      "target": "synth-wide-0464",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0464",
+      "source": "synth-wide-0464",
+      "target": "synth-wide-0465",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0465",
+      "source": "synth-wide-0465",
+      "target": "synth-wide-0466",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0466",
+      "source": "synth-wide-0466",
+      "target": "synth-wide-0467",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0467",
+      "source": "synth-wide-0467",
+      "target": "synth-wide-0468",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0468",
+      "source": "synth-wide-0468",
+      "target": "synth-wide-0469",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0469",
+      "source": "synth-wide-0469",
+      "target": "synth-wide-0470",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0470",
+      "source": "synth-wide-0470",
+      "target": "synth-wide-0471",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0471",
+      "source": "synth-wide-0471",
+      "target": "synth-wide-0472",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0472",
+      "source": "synth-wide-0472",
+      "target": "synth-wide-0473",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0473",
+      "source": "synth-wide-0473",
+      "target": "synth-wide-0474",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0474",
+      "source": "synth-wide-0474",
+      "target": "synth-wide-0475",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0475",
+      "source": "synth-wide-0475",
+      "target": "synth-wide-0476",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0476",
+      "source": "synth-wide-0476",
+      "target": "synth-wide-0477",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0477",
+      "source": "synth-wide-0477",
+      "target": "synth-wide-0478",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0478",
+      "source": "synth-wide-0478",
+      "target": "synth-wide-0479",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0479",
+      "source": "synth-wide-0479",
+      "target": "synth-wide-0480",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0480",
+      "source": "synth-wide-0480",
+      "target": "synth-wide-0481",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0481",
+      "source": "synth-wide-0481",
+      "target": "synth-wide-0482",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0482",
+      "source": "synth-wide-0482",
+      "target": "synth-wide-0483",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0483",
+      "source": "synth-wide-0483",
+      "target": "synth-wide-0484",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0484",
+      "source": "synth-wide-0484",
+      "target": "synth-wide-0485",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0485",
+      "source": "synth-wide-0485",
+      "target": "synth-wide-0486",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0486",
+      "source": "synth-wide-0486",
+      "target": "synth-wide-0487",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0487",
+      "source": "synth-wide-0487",
+      "target": "synth-wide-0488",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0488",
+      "source": "synth-wide-0488",
+      "target": "synth-wide-0489",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0489",
+      "source": "synth-wide-0489",
+      "target": "synth-wide-0490",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0490",
+      "source": "synth-wide-0490",
+      "target": "synth-wide-0491",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0491",
+      "source": "synth-wide-0491",
+      "target": "synth-wide-0492",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0492",
+      "source": "synth-wide-0492",
+      "target": "synth-wide-0493",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0493",
+      "source": "synth-wide-0493",
+      "target": "synth-wide-0494",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0494",
+      "source": "synth-wide-0494",
+      "target": "synth-wide-0495",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0495",
+      "source": "synth-wide-0495",
+      "target": "synth-wide-0496",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0496",
+      "source": "synth-wide-0496",
+      "target": "synth-wide-0497",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0497",
+      "source": "synth-wide-0497",
+      "target": "synth-wide-0498",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0498",
+      "source": "synth-wide-0498",
+      "target": "synth-wide-0499",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0499",
+      "source": "synth-wide-0499",
+      "target": "synth-wide-0000",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0500",
+      "source": "synth-wide-0000",
+      "target": "synth-wide-0002",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0501",
+      "source": "synth-wide-0001",
+      "target": "synth-wide-0003",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0502",
+      "source": "synth-wide-0002",
+      "target": "synth-wide-0004",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0503",
+      "source": "synth-wide-0003",
+      "target": "synth-wide-0005",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0504",
+      "source": "synth-wide-0004",
+      "target": "synth-wide-0006",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0505",
+      "source": "synth-wide-0005",
+      "target": "synth-wide-0007",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0506",
+      "source": "synth-wide-0006",
+      "target": "synth-wide-0008",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0507",
+      "source": "synth-wide-0007",
+      "target": "synth-wide-0009",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0508",
+      "source": "synth-wide-0008",
+      "target": "synth-wide-0010",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0509",
+      "source": "synth-wide-0009",
+      "target": "synth-wide-0011",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0510",
+      "source": "synth-wide-0010",
+      "target": "synth-wide-0012",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0511",
+      "source": "synth-wide-0011",
+      "target": "synth-wide-0013",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0512",
+      "source": "synth-wide-0012",
+      "target": "synth-wide-0014",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0513",
+      "source": "synth-wide-0013",
+      "target": "synth-wide-0015",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0514",
+      "source": "synth-wide-0014",
+      "target": "synth-wide-0016",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0515",
+      "source": "synth-wide-0015",
+      "target": "synth-wide-0017",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0516",
+      "source": "synth-wide-0016",
+      "target": "synth-wide-0018",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0517",
+      "source": "synth-wide-0017",
+      "target": "synth-wide-0019",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0518",
+      "source": "synth-wide-0018",
+      "target": "synth-wide-0020",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0519",
+      "source": "synth-wide-0019",
+      "target": "synth-wide-0021",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0520",
+      "source": "synth-wide-0020",
+      "target": "synth-wide-0022",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0521",
+      "source": "synth-wide-0021",
+      "target": "synth-wide-0023",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0522",
+      "source": "synth-wide-0022",
+      "target": "synth-wide-0024",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0523",
+      "source": "synth-wide-0023",
+      "target": "synth-wide-0025",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0524",
+      "source": "synth-wide-0024",
+      "target": "synth-wide-0026",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0525",
+      "source": "synth-wide-0025",
+      "target": "synth-wide-0027",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0526",
+      "source": "synth-wide-0026",
+      "target": "synth-wide-0028",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0527",
+      "source": "synth-wide-0027",
+      "target": "synth-wide-0029",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0528",
+      "source": "synth-wide-0028",
+      "target": "synth-wide-0030",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0529",
+      "source": "synth-wide-0029",
+      "target": "synth-wide-0031",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0530",
+      "source": "synth-wide-0030",
+      "target": "synth-wide-0032",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0531",
+      "source": "synth-wide-0031",
+      "target": "synth-wide-0033",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0532",
+      "source": "synth-wide-0032",
+      "target": "synth-wide-0034",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0533",
+      "source": "synth-wide-0033",
+      "target": "synth-wide-0035",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0534",
+      "source": "synth-wide-0034",
+      "target": "synth-wide-0036",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0535",
+      "source": "synth-wide-0035",
+      "target": "synth-wide-0037",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0536",
+      "source": "synth-wide-0036",
+      "target": "synth-wide-0038",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0537",
+      "source": "synth-wide-0037",
+      "target": "synth-wide-0039",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0538",
+      "source": "synth-wide-0038",
+      "target": "synth-wide-0040",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0539",
+      "source": "synth-wide-0039",
+      "target": "synth-wide-0041",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0540",
+      "source": "synth-wide-0040",
+      "target": "synth-wide-0042",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0541",
+      "source": "synth-wide-0041",
+      "target": "synth-wide-0043",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0542",
+      "source": "synth-wide-0042",
+      "target": "synth-wide-0044",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0543",
+      "source": "synth-wide-0043",
+      "target": "synth-wide-0045",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0544",
+      "source": "synth-wide-0044",
+      "target": "synth-wide-0046",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0545",
+      "source": "synth-wide-0045",
+      "target": "synth-wide-0047",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0546",
+      "source": "synth-wide-0046",
+      "target": "synth-wide-0048",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0547",
+      "source": "synth-wide-0047",
+      "target": "synth-wide-0049",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0548",
+      "source": "synth-wide-0048",
+      "target": "synth-wide-0050",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0549",
+      "source": "synth-wide-0049",
+      "target": "synth-wide-0051",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0550",
+      "source": "synth-wide-0050",
+      "target": "synth-wide-0052",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0551",
+      "source": "synth-wide-0051",
+      "target": "synth-wide-0053",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0552",
+      "source": "synth-wide-0052",
+      "target": "synth-wide-0054",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0553",
+      "source": "synth-wide-0053",
+      "target": "synth-wide-0055",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0554",
+      "source": "synth-wide-0054",
+      "target": "synth-wide-0056",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0555",
+      "source": "synth-wide-0055",
+      "target": "synth-wide-0057",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0556",
+      "source": "synth-wide-0056",
+      "target": "synth-wide-0058",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0557",
+      "source": "synth-wide-0057",
+      "target": "synth-wide-0059",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0558",
+      "source": "synth-wide-0058",
+      "target": "synth-wide-0060",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0559",
+      "source": "synth-wide-0059",
+      "target": "synth-wide-0061",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0560",
+      "source": "synth-wide-0060",
+      "target": "synth-wide-0062",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0561",
+      "source": "synth-wide-0061",
+      "target": "synth-wide-0063",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0562",
+      "source": "synth-wide-0062",
+      "target": "synth-wide-0064",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0563",
+      "source": "synth-wide-0063",
+      "target": "synth-wide-0065",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0564",
+      "source": "synth-wide-0064",
+      "target": "synth-wide-0066",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0565",
+      "source": "synth-wide-0065",
+      "target": "synth-wide-0067",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0566",
+      "source": "synth-wide-0066",
+      "target": "synth-wide-0068",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0567",
+      "source": "synth-wide-0067",
+      "target": "synth-wide-0069",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0568",
+      "source": "synth-wide-0068",
+      "target": "synth-wide-0070",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0569",
+      "source": "synth-wide-0069",
+      "target": "synth-wide-0071",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0570",
+      "source": "synth-wide-0070",
+      "target": "synth-wide-0072",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0571",
+      "source": "synth-wide-0071",
+      "target": "synth-wide-0073",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0572",
+      "source": "synth-wide-0072",
+      "target": "synth-wide-0074",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0573",
+      "source": "synth-wide-0073",
+      "target": "synth-wide-0075",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0574",
+      "source": "synth-wide-0074",
+      "target": "synth-wide-0076",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0575",
+      "source": "synth-wide-0075",
+      "target": "synth-wide-0077",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0576",
+      "source": "synth-wide-0076",
+      "target": "synth-wide-0078",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0577",
+      "source": "synth-wide-0077",
+      "target": "synth-wide-0079",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0578",
+      "source": "synth-wide-0078",
+      "target": "synth-wide-0080",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0579",
+      "source": "synth-wide-0079",
+      "target": "synth-wide-0081",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0580",
+      "source": "synth-wide-0080",
+      "target": "synth-wide-0082",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0581",
+      "source": "synth-wide-0081",
+      "target": "synth-wide-0083",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0582",
+      "source": "synth-wide-0082",
+      "target": "synth-wide-0084",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0583",
+      "source": "synth-wide-0083",
+      "target": "synth-wide-0085",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0584",
+      "source": "synth-wide-0084",
+      "target": "synth-wide-0086",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0585",
+      "source": "synth-wide-0085",
+      "target": "synth-wide-0087",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0586",
+      "source": "synth-wide-0086",
+      "target": "synth-wide-0088",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0587",
+      "source": "synth-wide-0087",
+      "target": "synth-wide-0089",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0588",
+      "source": "synth-wide-0088",
+      "target": "synth-wide-0090",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0589",
+      "source": "synth-wide-0089",
+      "target": "synth-wide-0091",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0590",
+      "source": "synth-wide-0090",
+      "target": "synth-wide-0092",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0591",
+      "source": "synth-wide-0091",
+      "target": "synth-wide-0093",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0592",
+      "source": "synth-wide-0092",
+      "target": "synth-wide-0094",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0593",
+      "source": "synth-wide-0093",
+      "target": "synth-wide-0095",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0594",
+      "source": "synth-wide-0094",
+      "target": "synth-wide-0096",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0595",
+      "source": "synth-wide-0095",
+      "target": "synth-wide-0097",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0596",
+      "source": "synth-wide-0096",
+      "target": "synth-wide-0098",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0597",
+      "source": "synth-wide-0097",
+      "target": "synth-wide-0099",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0598",
+      "source": "synth-wide-0098",
+      "target": "synth-wide-0100",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0599",
+      "source": "synth-wide-0099",
+      "target": "synth-wide-0101",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0600",
+      "source": "synth-wide-0100",
+      "target": "synth-wide-0102",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0601",
+      "source": "synth-wide-0101",
+      "target": "synth-wide-0103",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0602",
+      "source": "synth-wide-0102",
+      "target": "synth-wide-0104",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0603",
+      "source": "synth-wide-0103",
+      "target": "synth-wide-0105",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0604",
+      "source": "synth-wide-0104",
+      "target": "synth-wide-0106",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0605",
+      "source": "synth-wide-0105",
+      "target": "synth-wide-0107",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0606",
+      "source": "synth-wide-0106",
+      "target": "synth-wide-0108",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0607",
+      "source": "synth-wide-0107",
+      "target": "synth-wide-0109",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0608",
+      "source": "synth-wide-0108",
+      "target": "synth-wide-0110",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0609",
+      "source": "synth-wide-0109",
+      "target": "synth-wide-0111",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0610",
+      "source": "synth-wide-0110",
+      "target": "synth-wide-0112",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0611",
+      "source": "synth-wide-0111",
+      "target": "synth-wide-0113",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0612",
+      "source": "synth-wide-0112",
+      "target": "synth-wide-0114",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0613",
+      "source": "synth-wide-0113",
+      "target": "synth-wide-0115",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0614",
+      "source": "synth-wide-0114",
+      "target": "synth-wide-0116",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0615",
+      "source": "synth-wide-0115",
+      "target": "synth-wide-0117",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0616",
+      "source": "synth-wide-0116",
+      "target": "synth-wide-0118",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0617",
+      "source": "synth-wide-0117",
+      "target": "synth-wide-0119",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0618",
+      "source": "synth-wide-0118",
+      "target": "synth-wide-0120",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0619",
+      "source": "synth-wide-0119",
+      "target": "synth-wide-0121",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0620",
+      "source": "synth-wide-0120",
+      "target": "synth-wide-0122",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0621",
+      "source": "synth-wide-0121",
+      "target": "synth-wide-0123",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0622",
+      "source": "synth-wide-0122",
+      "target": "synth-wide-0124",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0623",
+      "source": "synth-wide-0123",
+      "target": "synth-wide-0125",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0624",
+      "source": "synth-wide-0124",
+      "target": "synth-wide-0126",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0625",
+      "source": "synth-wide-0125",
+      "target": "synth-wide-0127",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0626",
+      "source": "synth-wide-0126",
+      "target": "synth-wide-0128",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0627",
+      "source": "synth-wide-0127",
+      "target": "synth-wide-0129",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0628",
+      "source": "synth-wide-0128",
+      "target": "synth-wide-0130",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0629",
+      "source": "synth-wide-0129",
+      "target": "synth-wide-0131",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0630",
+      "source": "synth-wide-0130",
+      "target": "synth-wide-0132",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0631",
+      "source": "synth-wide-0131",
+      "target": "synth-wide-0133",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0632",
+      "source": "synth-wide-0132",
+      "target": "synth-wide-0134",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0633",
+      "source": "synth-wide-0133",
+      "target": "synth-wide-0135",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0634",
+      "source": "synth-wide-0134",
+      "target": "synth-wide-0136",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0635",
+      "source": "synth-wide-0135",
+      "target": "synth-wide-0137",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0636",
+      "source": "synth-wide-0136",
+      "target": "synth-wide-0138",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0637",
+      "source": "synth-wide-0137",
+      "target": "synth-wide-0139",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0638",
+      "source": "synth-wide-0138",
+      "target": "synth-wide-0140",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0639",
+      "source": "synth-wide-0139",
+      "target": "synth-wide-0141",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0640",
+      "source": "synth-wide-0140",
+      "target": "synth-wide-0142",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0641",
+      "source": "synth-wide-0141",
+      "target": "synth-wide-0143",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0642",
+      "source": "synth-wide-0142",
+      "target": "synth-wide-0144",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0643",
+      "source": "synth-wide-0143",
+      "target": "synth-wide-0145",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0644",
+      "source": "synth-wide-0144",
+      "target": "synth-wide-0146",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0645",
+      "source": "synth-wide-0145",
+      "target": "synth-wide-0147",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0646",
+      "source": "synth-wide-0146",
+      "target": "synth-wide-0148",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0647",
+      "source": "synth-wide-0147",
+      "target": "synth-wide-0149",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0648",
+      "source": "synth-wide-0148",
+      "target": "synth-wide-0150",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0649",
+      "source": "synth-wide-0149",
+      "target": "synth-wide-0151",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0650",
+      "source": "synth-wide-0150",
+      "target": "synth-wide-0152",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0651",
+      "source": "synth-wide-0151",
+      "target": "synth-wide-0153",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0652",
+      "source": "synth-wide-0152",
+      "target": "synth-wide-0154",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0653",
+      "source": "synth-wide-0153",
+      "target": "synth-wide-0155",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0654",
+      "source": "synth-wide-0154",
+      "target": "synth-wide-0156",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0655",
+      "source": "synth-wide-0155",
+      "target": "synth-wide-0157",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0656",
+      "source": "synth-wide-0156",
+      "target": "synth-wide-0158",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0657",
+      "source": "synth-wide-0157",
+      "target": "synth-wide-0159",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0658",
+      "source": "synth-wide-0158",
+      "target": "synth-wide-0160",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0659",
+      "source": "synth-wide-0159",
+      "target": "synth-wide-0161",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0660",
+      "source": "synth-wide-0160",
+      "target": "synth-wide-0162",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0661",
+      "source": "synth-wide-0161",
+      "target": "synth-wide-0163",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0662",
+      "source": "synth-wide-0162",
+      "target": "synth-wide-0164",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0663",
+      "source": "synth-wide-0163",
+      "target": "synth-wide-0165",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0664",
+      "source": "synth-wide-0164",
+      "target": "synth-wide-0166",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0665",
+      "source": "synth-wide-0165",
+      "target": "synth-wide-0167",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0666",
+      "source": "synth-wide-0166",
+      "target": "synth-wide-0168",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0667",
+      "source": "synth-wide-0167",
+      "target": "synth-wide-0169",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0668",
+      "source": "synth-wide-0168",
+      "target": "synth-wide-0170",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0669",
+      "source": "synth-wide-0169",
+      "target": "synth-wide-0171",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0670",
+      "source": "synth-wide-0170",
+      "target": "synth-wide-0172",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0671",
+      "source": "synth-wide-0171",
+      "target": "synth-wide-0173",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0672",
+      "source": "synth-wide-0172",
+      "target": "synth-wide-0174",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0673",
+      "source": "synth-wide-0173",
+      "target": "synth-wide-0175",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0674",
+      "source": "synth-wide-0174",
+      "target": "synth-wide-0176",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0675",
+      "source": "synth-wide-0175",
+      "target": "synth-wide-0177",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0676",
+      "source": "synth-wide-0176",
+      "target": "synth-wide-0178",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0677",
+      "source": "synth-wide-0177",
+      "target": "synth-wide-0179",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0678",
+      "source": "synth-wide-0178",
+      "target": "synth-wide-0180",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0679",
+      "source": "synth-wide-0179",
+      "target": "synth-wide-0181",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0680",
+      "source": "synth-wide-0180",
+      "target": "synth-wide-0182",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0681",
+      "source": "synth-wide-0181",
+      "target": "synth-wide-0183",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0682",
+      "source": "synth-wide-0182",
+      "target": "synth-wide-0184",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0683",
+      "source": "synth-wide-0183",
+      "target": "synth-wide-0185",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0684",
+      "source": "synth-wide-0184",
+      "target": "synth-wide-0186",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0685",
+      "source": "synth-wide-0185",
+      "target": "synth-wide-0187",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0686",
+      "source": "synth-wide-0186",
+      "target": "synth-wide-0188",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0687",
+      "source": "synth-wide-0187",
+      "target": "synth-wide-0189",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0688",
+      "source": "synth-wide-0188",
+      "target": "synth-wide-0190",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0689",
+      "source": "synth-wide-0189",
+      "target": "synth-wide-0191",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0690",
+      "source": "synth-wide-0190",
+      "target": "synth-wide-0192",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0691",
+      "source": "synth-wide-0191",
+      "target": "synth-wide-0193",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0692",
+      "source": "synth-wide-0192",
+      "target": "synth-wide-0194",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0693",
+      "source": "synth-wide-0193",
+      "target": "synth-wide-0195",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0694",
+      "source": "synth-wide-0194",
+      "target": "synth-wide-0196",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0695",
+      "source": "synth-wide-0195",
+      "target": "synth-wide-0197",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0696",
+      "source": "synth-wide-0196",
+      "target": "synth-wide-0198",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0697",
+      "source": "synth-wide-0197",
+      "target": "synth-wide-0199",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0698",
+      "source": "synth-wide-0198",
+      "target": "synth-wide-0200",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0699",
+      "source": "synth-wide-0199",
+      "target": "synth-wide-0201",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0700",
+      "source": "synth-wide-0200",
+      "target": "synth-wide-0202",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0701",
+      "source": "synth-wide-0201",
+      "target": "synth-wide-0203",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0702",
+      "source": "synth-wide-0202",
+      "target": "synth-wide-0204",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0703",
+      "source": "synth-wide-0203",
+      "target": "synth-wide-0205",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0704",
+      "source": "synth-wide-0204",
+      "target": "synth-wide-0206",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0705",
+      "source": "synth-wide-0205",
+      "target": "synth-wide-0207",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0706",
+      "source": "synth-wide-0206",
+      "target": "synth-wide-0208",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0707",
+      "source": "synth-wide-0207",
+      "target": "synth-wide-0209",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0708",
+      "source": "synth-wide-0208",
+      "target": "synth-wide-0210",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0709",
+      "source": "synth-wide-0209",
+      "target": "synth-wide-0211",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0710",
+      "source": "synth-wide-0210",
+      "target": "synth-wide-0212",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0711",
+      "source": "synth-wide-0211",
+      "target": "synth-wide-0213",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0712",
+      "source": "synth-wide-0212",
+      "target": "synth-wide-0214",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0713",
+      "source": "synth-wide-0213",
+      "target": "synth-wide-0215",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0714",
+      "source": "synth-wide-0214",
+      "target": "synth-wide-0216",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0715",
+      "source": "synth-wide-0215",
+      "target": "synth-wide-0217",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0716",
+      "source": "synth-wide-0216",
+      "target": "synth-wide-0218",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0717",
+      "source": "synth-wide-0217",
+      "target": "synth-wide-0219",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0718",
+      "source": "synth-wide-0218",
+      "target": "synth-wide-0220",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0719",
+      "source": "synth-wide-0219",
+      "target": "synth-wide-0221",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0720",
+      "source": "synth-wide-0220",
+      "target": "synth-wide-0222",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0721",
+      "source": "synth-wide-0221",
+      "target": "synth-wide-0223",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0722",
+      "source": "synth-wide-0222",
+      "target": "synth-wide-0224",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0723",
+      "source": "synth-wide-0223",
+      "target": "synth-wide-0225",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0724",
+      "source": "synth-wide-0224",
+      "target": "synth-wide-0226",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0725",
+      "source": "synth-wide-0225",
+      "target": "synth-wide-0227",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0726",
+      "source": "synth-wide-0226",
+      "target": "synth-wide-0228",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0727",
+      "source": "synth-wide-0227",
+      "target": "synth-wide-0229",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0728",
+      "source": "synth-wide-0228",
+      "target": "synth-wide-0230",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0729",
+      "source": "synth-wide-0229",
+      "target": "synth-wide-0231",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0730",
+      "source": "synth-wide-0230",
+      "target": "synth-wide-0232",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0731",
+      "source": "synth-wide-0231",
+      "target": "synth-wide-0233",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0732",
+      "source": "synth-wide-0232",
+      "target": "synth-wide-0234",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0733",
+      "source": "synth-wide-0233",
+      "target": "synth-wide-0235",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0734",
+      "source": "synth-wide-0234",
+      "target": "synth-wide-0236",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0735",
+      "source": "synth-wide-0235",
+      "target": "synth-wide-0237",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0736",
+      "source": "synth-wide-0236",
+      "target": "synth-wide-0238",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0737",
+      "source": "synth-wide-0237",
+      "target": "synth-wide-0239",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0738",
+      "source": "synth-wide-0238",
+      "target": "synth-wide-0240",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0739",
+      "source": "synth-wide-0239",
+      "target": "synth-wide-0241",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0740",
+      "source": "synth-wide-0240",
+      "target": "synth-wide-0242",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0741",
+      "source": "synth-wide-0241",
+      "target": "synth-wide-0243",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0742",
+      "source": "synth-wide-0242",
+      "target": "synth-wide-0244",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0743",
+      "source": "synth-wide-0243",
+      "target": "synth-wide-0245",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0744",
+      "source": "synth-wide-0244",
+      "target": "synth-wide-0246",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0745",
+      "source": "synth-wide-0245",
+      "target": "synth-wide-0247",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0746",
+      "source": "synth-wide-0246",
+      "target": "synth-wide-0248",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0747",
+      "source": "synth-wide-0247",
+      "target": "synth-wide-0249",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0748",
+      "source": "synth-wide-0248",
+      "target": "synth-wide-0250",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0749",
+      "source": "synth-wide-0249",
+      "target": "synth-wide-0251",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0750",
+      "source": "synth-wide-0250",
+      "target": "synth-wide-0252",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0751",
+      "source": "synth-wide-0251",
+      "target": "synth-wide-0253",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0752",
+      "source": "synth-wide-0252",
+      "target": "synth-wide-0254",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0753",
+      "source": "synth-wide-0253",
+      "target": "synth-wide-0255",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0754",
+      "source": "synth-wide-0254",
+      "target": "synth-wide-0256",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0755",
+      "source": "synth-wide-0255",
+      "target": "synth-wide-0257",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0756",
+      "source": "synth-wide-0256",
+      "target": "synth-wide-0258",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0757",
+      "source": "synth-wide-0257",
+      "target": "synth-wide-0259",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0758",
+      "source": "synth-wide-0258",
+      "target": "synth-wide-0260",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0759",
+      "source": "synth-wide-0259",
+      "target": "synth-wide-0261",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0760",
+      "source": "synth-wide-0260",
+      "target": "synth-wide-0262",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0761",
+      "source": "synth-wide-0261",
+      "target": "synth-wide-0263",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0762",
+      "source": "synth-wide-0262",
+      "target": "synth-wide-0264",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0763",
+      "source": "synth-wide-0263",
+      "target": "synth-wide-0265",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0764",
+      "source": "synth-wide-0264",
+      "target": "synth-wide-0266",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0765",
+      "source": "synth-wide-0265",
+      "target": "synth-wide-0267",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0766",
+      "source": "synth-wide-0266",
+      "target": "synth-wide-0268",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0767",
+      "source": "synth-wide-0267",
+      "target": "synth-wide-0269",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0768",
+      "source": "synth-wide-0268",
+      "target": "synth-wide-0270",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0769",
+      "source": "synth-wide-0269",
+      "target": "synth-wide-0271",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0770",
+      "source": "synth-wide-0270",
+      "target": "synth-wide-0272",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0771",
+      "source": "synth-wide-0271",
+      "target": "synth-wide-0273",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0772",
+      "source": "synth-wide-0272",
+      "target": "synth-wide-0274",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0773",
+      "source": "synth-wide-0273",
+      "target": "synth-wide-0275",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0774",
+      "source": "synth-wide-0274",
+      "target": "synth-wide-0276",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0775",
+      "source": "synth-wide-0275",
+      "target": "synth-wide-0277",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0776",
+      "source": "synth-wide-0276",
+      "target": "synth-wide-0278",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0777",
+      "source": "synth-wide-0277",
+      "target": "synth-wide-0279",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0778",
+      "source": "synth-wide-0278",
+      "target": "synth-wide-0280",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0779",
+      "source": "synth-wide-0279",
+      "target": "synth-wide-0281",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0780",
+      "source": "synth-wide-0280",
+      "target": "synth-wide-0282",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0781",
+      "source": "synth-wide-0281",
+      "target": "synth-wide-0283",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0782",
+      "source": "synth-wide-0282",
+      "target": "synth-wide-0284",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0783",
+      "source": "synth-wide-0283",
+      "target": "synth-wide-0285",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0784",
+      "source": "synth-wide-0284",
+      "target": "synth-wide-0286",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0785",
+      "source": "synth-wide-0285",
+      "target": "synth-wide-0287",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0786",
+      "source": "synth-wide-0286",
+      "target": "synth-wide-0288",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0787",
+      "source": "synth-wide-0287",
+      "target": "synth-wide-0289",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0788",
+      "source": "synth-wide-0288",
+      "target": "synth-wide-0290",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0789",
+      "source": "synth-wide-0289",
+      "target": "synth-wide-0291",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0790",
+      "source": "synth-wide-0290",
+      "target": "synth-wide-0292",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0791",
+      "source": "synth-wide-0291",
+      "target": "synth-wide-0293",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0792",
+      "source": "synth-wide-0292",
+      "target": "synth-wide-0294",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0793",
+      "source": "synth-wide-0293",
+      "target": "synth-wide-0295",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0794",
+      "source": "synth-wide-0294",
+      "target": "synth-wide-0296",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0795",
+      "source": "synth-wide-0295",
+      "target": "synth-wide-0297",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0796",
+      "source": "synth-wide-0296",
+      "target": "synth-wide-0298",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0797",
+      "source": "synth-wide-0297",
+      "target": "synth-wide-0299",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0798",
+      "source": "synth-wide-0298",
+      "target": "synth-wide-0300",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0799",
+      "source": "synth-wide-0299",
+      "target": "synth-wide-0301",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0800",
+      "source": "synth-wide-0300",
+      "target": "synth-wide-0302",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0801",
+      "source": "synth-wide-0301",
+      "target": "synth-wide-0303",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0802",
+      "source": "synth-wide-0302",
+      "target": "synth-wide-0304",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0803",
+      "source": "synth-wide-0303",
+      "target": "synth-wide-0305",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0804",
+      "source": "synth-wide-0304",
+      "target": "synth-wide-0306",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0805",
+      "source": "synth-wide-0305",
+      "target": "synth-wide-0307",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0806",
+      "source": "synth-wide-0306",
+      "target": "synth-wide-0308",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0807",
+      "source": "synth-wide-0307",
+      "target": "synth-wide-0309",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0808",
+      "source": "synth-wide-0308",
+      "target": "synth-wide-0310",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0809",
+      "source": "synth-wide-0309",
+      "target": "synth-wide-0311",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0810",
+      "source": "synth-wide-0310",
+      "target": "synth-wide-0312",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0811",
+      "source": "synth-wide-0311",
+      "target": "synth-wide-0313",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0812",
+      "source": "synth-wide-0312",
+      "target": "synth-wide-0314",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0813",
+      "source": "synth-wide-0313",
+      "target": "synth-wide-0315",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0814",
+      "source": "synth-wide-0314",
+      "target": "synth-wide-0316",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0815",
+      "source": "synth-wide-0315",
+      "target": "synth-wide-0317",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0816",
+      "source": "synth-wide-0316",
+      "target": "synth-wide-0318",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0817",
+      "source": "synth-wide-0317",
+      "target": "synth-wide-0319",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0818",
+      "source": "synth-wide-0318",
+      "target": "synth-wide-0320",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0819",
+      "source": "synth-wide-0319",
+      "target": "synth-wide-0321",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0820",
+      "source": "synth-wide-0320",
+      "target": "synth-wide-0322",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0821",
+      "source": "synth-wide-0321",
+      "target": "synth-wide-0323",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0822",
+      "source": "synth-wide-0322",
+      "target": "synth-wide-0324",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0823",
+      "source": "synth-wide-0323",
+      "target": "synth-wide-0325",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0824",
+      "source": "synth-wide-0324",
+      "target": "synth-wide-0326",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0825",
+      "source": "synth-wide-0325",
+      "target": "synth-wide-0327",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0826",
+      "source": "synth-wide-0326",
+      "target": "synth-wide-0328",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0827",
+      "source": "synth-wide-0327",
+      "target": "synth-wide-0329",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0828",
+      "source": "synth-wide-0328",
+      "target": "synth-wide-0330",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0829",
+      "source": "synth-wide-0329",
+      "target": "synth-wide-0331",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0830",
+      "source": "synth-wide-0330",
+      "target": "synth-wide-0332",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0831",
+      "source": "synth-wide-0331",
+      "target": "synth-wide-0333",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0832",
+      "source": "synth-wide-0332",
+      "target": "synth-wide-0334",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0833",
+      "source": "synth-wide-0333",
+      "target": "synth-wide-0335",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0834",
+      "source": "synth-wide-0334",
+      "target": "synth-wide-0336",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0835",
+      "source": "synth-wide-0335",
+      "target": "synth-wide-0337",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0836",
+      "source": "synth-wide-0336",
+      "target": "synth-wide-0338",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0837",
+      "source": "synth-wide-0337",
+      "target": "synth-wide-0339",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0838",
+      "source": "synth-wide-0338",
+      "target": "synth-wide-0340",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0839",
+      "source": "synth-wide-0339",
+      "target": "synth-wide-0341",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0840",
+      "source": "synth-wide-0340",
+      "target": "synth-wide-0342",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0841",
+      "source": "synth-wide-0341",
+      "target": "synth-wide-0343",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0842",
+      "source": "synth-wide-0342",
+      "target": "synth-wide-0344",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0843",
+      "source": "synth-wide-0343",
+      "target": "synth-wide-0345",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0844",
+      "source": "synth-wide-0344",
+      "target": "synth-wide-0346",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0845",
+      "source": "synth-wide-0345",
+      "target": "synth-wide-0347",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0846",
+      "source": "synth-wide-0346",
+      "target": "synth-wide-0348",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0847",
+      "source": "synth-wide-0347",
+      "target": "synth-wide-0349",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0848",
+      "source": "synth-wide-0348",
+      "target": "synth-wide-0350",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0849",
+      "source": "synth-wide-0349",
+      "target": "synth-wide-0351",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0850",
+      "source": "synth-wide-0350",
+      "target": "synth-wide-0352",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0851",
+      "source": "synth-wide-0351",
+      "target": "synth-wide-0353",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0852",
+      "source": "synth-wide-0352",
+      "target": "synth-wide-0354",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0853",
+      "source": "synth-wide-0353",
+      "target": "synth-wide-0355",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0854",
+      "source": "synth-wide-0354",
+      "target": "synth-wide-0356",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0855",
+      "source": "synth-wide-0355",
+      "target": "synth-wide-0357",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0856",
+      "source": "synth-wide-0356",
+      "target": "synth-wide-0358",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0857",
+      "source": "synth-wide-0357",
+      "target": "synth-wide-0359",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0858",
+      "source": "synth-wide-0358",
+      "target": "synth-wide-0360",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0859",
+      "source": "synth-wide-0359",
+      "target": "synth-wide-0361",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0860",
+      "source": "synth-wide-0360",
+      "target": "synth-wide-0362",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0861",
+      "source": "synth-wide-0361",
+      "target": "synth-wide-0363",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0862",
+      "source": "synth-wide-0362",
+      "target": "synth-wide-0364",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0863",
+      "source": "synth-wide-0363",
+      "target": "synth-wide-0365",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0864",
+      "source": "synth-wide-0364",
+      "target": "synth-wide-0366",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0865",
+      "source": "synth-wide-0365",
+      "target": "synth-wide-0367",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0866",
+      "source": "synth-wide-0366",
+      "target": "synth-wide-0368",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0867",
+      "source": "synth-wide-0367",
+      "target": "synth-wide-0369",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0868",
+      "source": "synth-wide-0368",
+      "target": "synth-wide-0370",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0869",
+      "source": "synth-wide-0369",
+      "target": "synth-wide-0371",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0870",
+      "source": "synth-wide-0370",
+      "target": "synth-wide-0372",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0871",
+      "source": "synth-wide-0371",
+      "target": "synth-wide-0373",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0872",
+      "source": "synth-wide-0372",
+      "target": "synth-wide-0374",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0873",
+      "source": "synth-wide-0373",
+      "target": "synth-wide-0375",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0874",
+      "source": "synth-wide-0374",
+      "target": "synth-wide-0376",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0875",
+      "source": "synth-wide-0375",
+      "target": "synth-wide-0377",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0876",
+      "source": "synth-wide-0376",
+      "target": "synth-wide-0378",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0877",
+      "source": "synth-wide-0377",
+      "target": "synth-wide-0379",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0878",
+      "source": "synth-wide-0378",
+      "target": "synth-wide-0380",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0879",
+      "source": "synth-wide-0379",
+      "target": "synth-wide-0381",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0880",
+      "source": "synth-wide-0380",
+      "target": "synth-wide-0382",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0881",
+      "source": "synth-wide-0381",
+      "target": "synth-wide-0383",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0882",
+      "source": "synth-wide-0382",
+      "target": "synth-wide-0384",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0883",
+      "source": "synth-wide-0383",
+      "target": "synth-wide-0385",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0884",
+      "source": "synth-wide-0384",
+      "target": "synth-wide-0386",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0885",
+      "source": "synth-wide-0385",
+      "target": "synth-wide-0387",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0886",
+      "source": "synth-wide-0386",
+      "target": "synth-wide-0388",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0887",
+      "source": "synth-wide-0387",
+      "target": "synth-wide-0389",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0888",
+      "source": "synth-wide-0388",
+      "target": "synth-wide-0390",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0889",
+      "source": "synth-wide-0389",
+      "target": "synth-wide-0391",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0890",
+      "source": "synth-wide-0390",
+      "target": "synth-wide-0392",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0891",
+      "source": "synth-wide-0391",
+      "target": "synth-wide-0393",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0892",
+      "source": "synth-wide-0392",
+      "target": "synth-wide-0394",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0893",
+      "source": "synth-wide-0393",
+      "target": "synth-wide-0395",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0894",
+      "source": "synth-wide-0394",
+      "target": "synth-wide-0396",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0895",
+      "source": "synth-wide-0395",
+      "target": "synth-wide-0397",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0896",
+      "source": "synth-wide-0396",
+      "target": "synth-wide-0398",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0897",
+      "source": "synth-wide-0397",
+      "target": "synth-wide-0399",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0898",
+      "source": "synth-wide-0398",
+      "target": "synth-wide-0400",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0899",
+      "source": "synth-wide-0399",
+      "target": "synth-wide-0401",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0900",
+      "source": "synth-wide-0400",
+      "target": "synth-wide-0402",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0901",
+      "source": "synth-wide-0401",
+      "target": "synth-wide-0403",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0902",
+      "source": "synth-wide-0402",
+      "target": "synth-wide-0404",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0903",
+      "source": "synth-wide-0403",
+      "target": "synth-wide-0405",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0904",
+      "source": "synth-wide-0404",
+      "target": "synth-wide-0406",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0905",
+      "source": "synth-wide-0405",
+      "target": "synth-wide-0407",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0906",
+      "source": "synth-wide-0406",
+      "target": "synth-wide-0408",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0907",
+      "source": "synth-wide-0407",
+      "target": "synth-wide-0409",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0908",
+      "source": "synth-wide-0408",
+      "target": "synth-wide-0410",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0909",
+      "source": "synth-wide-0409",
+      "target": "synth-wide-0411",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0910",
+      "source": "synth-wide-0410",
+      "target": "synth-wide-0412",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0911",
+      "source": "synth-wide-0411",
+      "target": "synth-wide-0413",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0912",
+      "source": "synth-wide-0412",
+      "target": "synth-wide-0414",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0913",
+      "source": "synth-wide-0413",
+      "target": "synth-wide-0415",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0914",
+      "source": "synth-wide-0414",
+      "target": "synth-wide-0416",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0915",
+      "source": "synth-wide-0415",
+      "target": "synth-wide-0417",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0916",
+      "source": "synth-wide-0416",
+      "target": "synth-wide-0418",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0917",
+      "source": "synth-wide-0417",
+      "target": "synth-wide-0419",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0918",
+      "source": "synth-wide-0418",
+      "target": "synth-wide-0420",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0919",
+      "source": "synth-wide-0419",
+      "target": "synth-wide-0421",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0920",
+      "source": "synth-wide-0420",
+      "target": "synth-wide-0422",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0921",
+      "source": "synth-wide-0421",
+      "target": "synth-wide-0423",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0922",
+      "source": "synth-wide-0422",
+      "target": "synth-wide-0424",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0923",
+      "source": "synth-wide-0423",
+      "target": "synth-wide-0425",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0924",
+      "source": "synth-wide-0424",
+      "target": "synth-wide-0426",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0925",
+      "source": "synth-wide-0425",
+      "target": "synth-wide-0427",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0926",
+      "source": "synth-wide-0426",
+      "target": "synth-wide-0428",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0927",
+      "source": "synth-wide-0427",
+      "target": "synth-wide-0429",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0928",
+      "source": "synth-wide-0428",
+      "target": "synth-wide-0430",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0929",
+      "source": "synth-wide-0429",
+      "target": "synth-wide-0431",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0930",
+      "source": "synth-wide-0430",
+      "target": "synth-wide-0432",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0931",
+      "source": "synth-wide-0431",
+      "target": "synth-wide-0433",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0932",
+      "source": "synth-wide-0432",
+      "target": "synth-wide-0434",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0933",
+      "source": "synth-wide-0433",
+      "target": "synth-wide-0435",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0934",
+      "source": "synth-wide-0434",
+      "target": "synth-wide-0436",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0935",
+      "source": "synth-wide-0435",
+      "target": "synth-wide-0437",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0936",
+      "source": "synth-wide-0436",
+      "target": "synth-wide-0438",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0937",
+      "source": "synth-wide-0437",
+      "target": "synth-wide-0439",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0938",
+      "source": "synth-wide-0438",
+      "target": "synth-wide-0440",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0939",
+      "source": "synth-wide-0439",
+      "target": "synth-wide-0441",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0940",
+      "source": "synth-wide-0440",
+      "target": "synth-wide-0442",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0941",
+      "source": "synth-wide-0441",
+      "target": "synth-wide-0443",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0942",
+      "source": "synth-wide-0442",
+      "target": "synth-wide-0444",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0943",
+      "source": "synth-wide-0443",
+      "target": "synth-wide-0445",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0944",
+      "source": "synth-wide-0444",
+      "target": "synth-wide-0446",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0945",
+      "source": "synth-wide-0445",
+      "target": "synth-wide-0447",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0946",
+      "source": "synth-wide-0446",
+      "target": "synth-wide-0448",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0947",
+      "source": "synth-wide-0447",
+      "target": "synth-wide-0449",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0948",
+      "source": "synth-wide-0448",
+      "target": "synth-wide-0450",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0949",
+      "source": "synth-wide-0449",
+      "target": "synth-wide-0451",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0950",
+      "source": "synth-wide-0450",
+      "target": "synth-wide-0452",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0951",
+      "source": "synth-wide-0451",
+      "target": "synth-wide-0453",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0952",
+      "source": "synth-wide-0452",
+      "target": "synth-wide-0454",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0953",
+      "source": "synth-wide-0453",
+      "target": "synth-wide-0455",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0954",
+      "source": "synth-wide-0454",
+      "target": "synth-wide-0456",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0955",
+      "source": "synth-wide-0455",
+      "target": "synth-wide-0457",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0956",
+      "source": "synth-wide-0456",
+      "target": "synth-wide-0458",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0957",
+      "source": "synth-wide-0457",
+      "target": "synth-wide-0459",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0958",
+      "source": "synth-wide-0458",
+      "target": "synth-wide-0460",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0959",
+      "source": "synth-wide-0459",
+      "target": "synth-wide-0461",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0960",
+      "source": "synth-wide-0460",
+      "target": "synth-wide-0462",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0961",
+      "source": "synth-wide-0461",
+      "target": "synth-wide-0463",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0962",
+      "source": "synth-wide-0462",
+      "target": "synth-wide-0464",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0963",
+      "source": "synth-wide-0463",
+      "target": "synth-wide-0465",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0964",
+      "source": "synth-wide-0464",
+      "target": "synth-wide-0466",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0965",
+      "source": "synth-wide-0465",
+      "target": "synth-wide-0467",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0966",
+      "source": "synth-wide-0466",
+      "target": "synth-wide-0468",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0967",
+      "source": "synth-wide-0467",
+      "target": "synth-wide-0469",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0968",
+      "source": "synth-wide-0468",
+      "target": "synth-wide-0470",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0969",
+      "source": "synth-wide-0469",
+      "target": "synth-wide-0471",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0970",
+      "source": "synth-wide-0470",
+      "target": "synth-wide-0472",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0971",
+      "source": "synth-wide-0471",
+      "target": "synth-wide-0473",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0972",
+      "source": "synth-wide-0472",
+      "target": "synth-wide-0474",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0973",
+      "source": "synth-wide-0473",
+      "target": "synth-wide-0475",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0974",
+      "source": "synth-wide-0474",
+      "target": "synth-wide-0476",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0975",
+      "source": "synth-wide-0475",
+      "target": "synth-wide-0477",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0976",
+      "source": "synth-wide-0476",
+      "target": "synth-wide-0478",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0977",
+      "source": "synth-wide-0477",
+      "target": "synth-wide-0479",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0978",
+      "source": "synth-wide-0478",
+      "target": "synth-wide-0480",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0979",
+      "source": "synth-wide-0479",
+      "target": "synth-wide-0481",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0980",
+      "source": "synth-wide-0480",
+      "target": "synth-wide-0482",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0981",
+      "source": "synth-wide-0481",
+      "target": "synth-wide-0483",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0982",
+      "source": "synth-wide-0482",
+      "target": "synth-wide-0484",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0983",
+      "source": "synth-wide-0483",
+      "target": "synth-wide-0485",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0984",
+      "source": "synth-wide-0484",
+      "target": "synth-wide-0486",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0985",
+      "source": "synth-wide-0485",
+      "target": "synth-wide-0487",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0986",
+      "source": "synth-wide-0486",
+      "target": "synth-wide-0488",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0987",
+      "source": "synth-wide-0487",
+      "target": "synth-wide-0489",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0988",
+      "source": "synth-wide-0488",
+      "target": "synth-wide-0490",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0989",
+      "source": "synth-wide-0489",
+      "target": "synth-wide-0491",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0990",
+      "source": "synth-wide-0490",
+      "target": "synth-wide-0492",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0991",
+      "source": "synth-wide-0491",
+      "target": "synth-wide-0493",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0992",
+      "source": "synth-wide-0492",
+      "target": "synth-wide-0494",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0993",
+      "source": "synth-wide-0493",
+      "target": "synth-wide-0495",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0994",
+      "source": "synth-wide-0494",
+      "target": "synth-wide-0496",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0995",
+      "source": "synth-wide-0495",
+      "target": "synth-wide-0497",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0996",
+      "source": "synth-wide-0496",
+      "target": "synth-wide-0498",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0997",
+      "source": "synth-wide-0497",
+      "target": "synth-wide-0499",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0998",
+      "source": "synth-wide-0498",
+      "target": "synth-wide-0000",
+      "type": "discovered-from"
+    },
+    {
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-prov-0999",
+      "source": "synth-wide-0499",
+      "target": "synth-wide-0001",
+      "type": "discovered-from"
+    }
+  ],
+  "tasks": [
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0000",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 0",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0001",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 1",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0002",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 2",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0003",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 3",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0004",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 4",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0005",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 5",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0006",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 6",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0007",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 7",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0008",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 8",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0009",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 9",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0010",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 10",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0011",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 11",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0012",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 12",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0013",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 13",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0014",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 14",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0015",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 15",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0016",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 16",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0017",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 17",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0018",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 18",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0019",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 19",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0020",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 20",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0021",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 21",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0022",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 22",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0023",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 23",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0024",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 24",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0025",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 25",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0026",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 26",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0027",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 27",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0028",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 28",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0029",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 29",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0030",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 30",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0031",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 31",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0032",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 32",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0033",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 33",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0034",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 34",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0035",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 35",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0036",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 36",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0037",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 37",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0038",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 38",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0039",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 39",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0040",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 40",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0041",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 41",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0042",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 42",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0043",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 43",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0044",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 44",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0045",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 45",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0046",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 46",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0047",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 47",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0048",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 48",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0049",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 49",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0050",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 50",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0051",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 51",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0052",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 52",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0053",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 53",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0054",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 54",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0055",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 55",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0056",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 56",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0057",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 57",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0058",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 58",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0059",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 59",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0060",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 60",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0061",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 61",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0062",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 62",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0063",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 63",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0064",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 64",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0065",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 65",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0066",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 66",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0067",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 67",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0068",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 68",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0069",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 69",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0070",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 70",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0071",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 71",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0072",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 72",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0073",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 73",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0074",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 74",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0075",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 75",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0076",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 76",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0077",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 77",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0078",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 78",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0079",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 79",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0080",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 80",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0081",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 81",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0082",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 82",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0083",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 83",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0084",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 84",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0085",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 85",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0086",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 86",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0087",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 87",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0088",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 88",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0089",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 89",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0090",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 90",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0091",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 91",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0092",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 92",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0093",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 93",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0094",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 94",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0095",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 95",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0096",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 96",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0097",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 97",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0098",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 98",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0099",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 99",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0100",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 100",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0101",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 101",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0102",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 102",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0103",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 103",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0104",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 104",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0105",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 105",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0106",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 106",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0107",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 107",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0108",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 108",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0109",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 109",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0110",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 110",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0111",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 111",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0112",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 112",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0113",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 113",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0114",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 114",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0115",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 115",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0116",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 116",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0117",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 117",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0118",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 118",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0119",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 119",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0120",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 120",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0121",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 121",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0122",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 122",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0123",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 123",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0124",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 124",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0125",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 125",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0126",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 126",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0127",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 127",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0128",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 128",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0129",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 129",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0130",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 130",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0131",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 131",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0132",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 132",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0133",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 133",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0134",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 134",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0135",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 135",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0136",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 136",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0137",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 137",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0138",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 138",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0139",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 139",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0140",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 140",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0141",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 141",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0142",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 142",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0143",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 143",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0144",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 144",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0145",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 145",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0146",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 146",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0147",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 147",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0148",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 148",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0149",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 149",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0150",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 150",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0151",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 151",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0152",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 152",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0153",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 153",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0154",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 154",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0155",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 155",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0156",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 156",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0157",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 157",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0158",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 158",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0159",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 159",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0160",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 160",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0161",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 161",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0162",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 162",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0163",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 163",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0164",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 164",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0165",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 165",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0166",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 166",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0167",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 167",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0168",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 168",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0169",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 169",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0170",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 170",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0171",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 171",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0172",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 172",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0173",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 173",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0174",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 174",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0175",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 175",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0176",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 176",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0177",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 177",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0178",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 178",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0179",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 179",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0180",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 180",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0181",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 181",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0182",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 182",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0183",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 183",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0184",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 184",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0185",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 185",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0186",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 186",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0187",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 187",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0188",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 188",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0189",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 189",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0190",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 190",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0191",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 191",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0192",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 192",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0193",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 193",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0194",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 194",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0195",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 195",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0196",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 196",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0197",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 197",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0198",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 198",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0199",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 199",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0200",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 200",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0201",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 201",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0202",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 202",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0203",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 203",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0204",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 204",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0205",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 205",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0206",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 206",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0207",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 207",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0208",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 208",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0209",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 209",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0210",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 210",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0211",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 211",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0212",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 212",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0213",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 213",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0214",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 214",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0215",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 215",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0216",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 216",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0217",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 217",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0218",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 218",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0219",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 219",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0220",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 220",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0221",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 221",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0222",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 222",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0223",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 223",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0224",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 224",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0225",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 225",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0226",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 226",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0227",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 227",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0228",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 228",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0229",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 229",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0230",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 230",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0231",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 231",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0232",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 232",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0233",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 233",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0234",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 234",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0235",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 235",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0236",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 236",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0237",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 237",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0238",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 238",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0239",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 239",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0240",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 240",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0241",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 241",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0242",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 242",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0243",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 243",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0244",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 244",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0245",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 245",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0246",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 246",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0247",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 247",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0248",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 248",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0249",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 249",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0250",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 250",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0251",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 251",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0252",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 252",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0253",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 253",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0254",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 254",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0255",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 255",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0256",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 256",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0257",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 257",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0258",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 258",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0259",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 259",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0260",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 260",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0261",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 261",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0262",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 262",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0263",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 263",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0264",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 264",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0265",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 265",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0266",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 266",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0267",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 267",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0268",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 268",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0269",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 269",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0270",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 270",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0271",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 271",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0272",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 272",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0273",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 273",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0274",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 274",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0275",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 275",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0276",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 276",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0277",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 277",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0278",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 278",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0279",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 279",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0280",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 280",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0281",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 281",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0282",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 282",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0283",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 283",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0284",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 284",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0285",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 285",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0286",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 286",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0287",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 287",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0288",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 288",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0289",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 289",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0290",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 290",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0291",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 291",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0292",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 292",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0293",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 293",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0294",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 294",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0295",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 295",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0296",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 296",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0297",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 297",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0298",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 298",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0299",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 299",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0300",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 300",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0301",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 301",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0302",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 302",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0303",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 303",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0304",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 304",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0305",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 305",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0306",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 306",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0307",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 307",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0308",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 308",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0309",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 309",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0310",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 310",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0311",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 311",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0312",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 312",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0313",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 313",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0314",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 314",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0315",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 315",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0316",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 316",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0317",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 317",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0318",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 318",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0319",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 319",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0320",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 320",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0321",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 321",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0322",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 322",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0323",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 323",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0324",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 324",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0325",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 325",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0326",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 326",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0327",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 327",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0328",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 328",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0329",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 329",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0330",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 330",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0331",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 331",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0332",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 332",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0333",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 333",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0334",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 334",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0335",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 335",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0336",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 336",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0337",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 337",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0338",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 338",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0339",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 339",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0340",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 340",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0341",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 341",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0342",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 342",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0343",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 343",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0344",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 344",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0345",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 345",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0346",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 346",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0347",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 347",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0348",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 348",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0349",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 349",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0350",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 350",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0351",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 351",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0352",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 352",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0353",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 353",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0354",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 354",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0355",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 355",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0356",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 356",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0357",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 357",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0358",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 358",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0359",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 359",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0360",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 360",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0361",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 361",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0362",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 362",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0363",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 363",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0364",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 364",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0365",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 365",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0366",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 366",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0367",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 367",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0368",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 368",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0369",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 369",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0370",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 370",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0371",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 371",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0372",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 372",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0373",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 373",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0374",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 374",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0375",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 375",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0376",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 376",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0377",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 377",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0378",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 378",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0379",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 379",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0380",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 380",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0381",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 381",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0382",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 382",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0383",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 383",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0384",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 384",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0385",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 385",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0386",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 386",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0387",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 387",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0388",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 388",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0389",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 389",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0390",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 390",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0391",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 391",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0392",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 392",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0393",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 393",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0394",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 394",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0395",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 395",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0396",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 396",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0397",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 397",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0398",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 398",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0399",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 399",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0400",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 400",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0401",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 401",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0402",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 402",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0403",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 403",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0404",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 404",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0405",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 405",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0406",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 406",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0407",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 407",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0408",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 408",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0409",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 409",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0410",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 410",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0411",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 411",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0412",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 412",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0413",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 413",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0414",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 414",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0415",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 415",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0416",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 416",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0417",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 417",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0418",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 418",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0419",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 419",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0420",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 420",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0421",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 421",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0422",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 422",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0423",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 423",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0424",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 424",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0425",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 425",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0426",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 426",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0427",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 427",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0428",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 428",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0429",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 429",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0430",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 430",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0431",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 431",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0432",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 432",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0433",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 433",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0434",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 434",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0435",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 435",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0436",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 436",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0437",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 437",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0438",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 438",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0439",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 439",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0440",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 440",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0441",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 441",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0442",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 442",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0443",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 443",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0444",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 444",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0445",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 445",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0446",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 446",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0447",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 447",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0448",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 448",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0449",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 449",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0450",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 450",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0451",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 451",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0452",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 452",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0453",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 453",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0454",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 454",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0455",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 455",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0456",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 456",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0457",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 457",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0458",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 458",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0459",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 459",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0460",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 460",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0461",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 461",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0462",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 462",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0463",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 463",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0464",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 464",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0465",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 465",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0466",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 466",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0467",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 467",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0468",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 468",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0469",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 469",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0470",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 470",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0471",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 471",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0472",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 472",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0473",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 473",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0474",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 474",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0475",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 475",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0476",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 476",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0477",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 477",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0478",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 478",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0479",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 479",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0480",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 480",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0481",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 481",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0482",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 482",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0483",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 483",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0484",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 484",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0485",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 485",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0486",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 486",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0487",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 487",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0488",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 488",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0489",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 489",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0490",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 490",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0491",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 491",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0492",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 492",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0493",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 493",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0494",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 494",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0495",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 495",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0496",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 496",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0497",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 497",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0498",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 498",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    },
+    {
+      "acceptance": [],
+      "created_at": "2026-01-01T00:00:00+00:00",
+      "id": "synth-wide-0499",
+      "priority": "normal",
+      "source": "synthetic",
+      "status": "pending",
+      "text": "Wide open task 499",
+      "type": "task",
+      "updated_at": "2026-01-01T00:00:00+00:00"
+    }
+  ],
+  "version": 2
+}

--- a/docs/research/issue-846-work-store-characterization-r1.md
+++ b/docs/research/issue-846-work-store-characterization-r1.md
@@ -1,0 +1,244 @@
+# Issue #846 R1 — work-store system characterization
+
+Refs #846. Slice R1 only: one timeboxed research report, synthetic
+machine-neutral fixtures, and a measurement harness. This document does not
+approve a backend, add a runtime dependency, start a listener, migrate source
+of truth, or close #846.
+
+GraphTrail impact lookup was skipped for this slice: `brigade code doctor`
+reported GraphTrail not installed in this cloud VM (`run brigade setup`).
+
+## Contract
+
+Normative inputs:
+
+- GitHub issue #846
+- The single 0.27.0 scoping comment on that issue
+
+Normative behavioral anchors:
+
+- #737 graph / ready-set semantics (chains, diamonds, cycles, parent
+  propagation, provenance-only edges, atomic graph apply)
+- #738 claim CAS (one winner, exit `13` on the lost same-store race, retry and
+  rejection rules)
+- #770 BUILD native; Beads excluded
+
+## Current single-operator multi-machine workflow
+
+Brigade work state today is a machine-local, gitignored
+`.brigade/work/tasks.json` ledger. Mutations take a sibling directory lock,
+read/CAS/write under that lock, write a temporary file with fsync, atomically
+replace, and fsync the parent directory (`brigade.localio.write_text_atomic`
+via the work helpers).
+
+Observed topology for one operator across machines:
+
+1. Each machine keeps its own `.brigade/work/` tree.
+2. There is no first-class portable sync, shared-write path, or
+   branch-and-merge work-store command.
+3. Same-store concurrency is proven by the existing claim race test and by this
+   harness: one winner and one exit `13`. That does not prove cross-machine
+   claim CAS.
+4. Moving task state between machines today is operator-driven file copy or
+   equivalent out-of-band transfer, not a Brigade protocol.
+
+Private hostnames, fleet inventories, and live paths are intentionally omitted.
+
+## Requirement separation
+
+| Need | Current? | Notes |
+|---|---|---|
+| Sequential portable sync | **Yes — confirmed current need** | One operator, machines in sequence, store remains local |
+| Reviewable branch-and-merge proposals | **Yes — confirmed current need** | Proposal review, not silent shared writes |
+| Concurrent cross-machine claims | **No — not a current requirement** | Same-store races remain in scope; cross-machine CAS does not |
+| Operator-owned shared SQL service | Eligible only later | Only if a later concurrent-claim requirement cannot meet measured correctness through file or replica candidates |
+
+## Candidates (shapes)
+
+Measured or recorded as separate shapes:
+
+1. `json_ledger` — current JSON ledger (measured)
+2. `sqlite_wal` — stdlib SQLite WAL characterization adapter (measured; not a
+   Brigade runtime dependency)
+3. `dolt_cli_per_command` — blocked / unmeasured in R1 (no `dolt` on PATH;
+   optional runner timeboxed out)
+4. `embedded_dolt` — blocked (no embedded boundary in-repo; R1 does not build
+   or persist a Go/Dolt dependency)
+5. `dolt_sql_server` — blocked by policy (harness must not start a network
+   listener; any server test needs separate operator approval and
+   loopback-only proof)
+
+Dolt remains a characterization candidate. It is not banned, selected, or
+approved as a runtime dependency by this issue.
+
+## Synthetic fixtures
+
+Machine-neutral datasets live under
+`docs/research/fixtures/work-store-r1/`:
+
+| Fixture | Tasks | Edges | Ready | Role |
+|---|---:|---:|---:|---|
+| `chain_50` | 50 | 49 blocks | 1 | Linear #737 chain |
+| `diamond_200` | 200 | 396 blocks | 1 | Fan-out / fan-in diamond |
+| `wide_500_1000` | 500 | 1000 `discovered-from` | 500 | Wide open set + provenance-only edges |
+
+Digests and counts are recorded in `manifest.json`. Fixtures contain no
+hostnames or personal details. Generators in
+`scripts/measure_work_store.py` rebuild them deterministically.
+
+## Measurement harness
+
+`scripts/measure_work_store.py` emits one diffable JSON artifact per run
+(indent-2, sorted keys). Default protocol:
+
+- 10 warmups and 100 measured trials
+- nearest-rank p50 / p95 and values relative to JSON
+- two claimers behind one barrier; require codes `[0, 13]`
+- crash before atomic replace (JSON) or before SQL commit (SQLite)
+- export/import digest equality
+- anonymous metrics disabled in the harness configuration
+- Dolt server shape never opens a listener
+
+Tests: `tests/test_work_store_measurement.py`.
+
+Checked measurement artifact:
+`docs/measurements/issue-846-work-store-r1.json`.
+
+### Measured gate summary (this VM)
+
+Platform class: Linux x86_64, filesystem `overlay`, directory fsync supported,
+SQLite 3.45.1, `dolt` absent from PATH.
+
+| Shape | Datasets | #737 | #738 (0 + 13) | Crash | Export | Status |
+|---|---|---|---|---|---|---|
+| json_ledger | all three | pass | pass | pass | pass | measured |
+| sqlite_wal | all three | pass | pass | pass | pass | measured |
+| dolt_cli_per_command | all three | — | — | — | — | blocked |
+| embedded_dolt | all three | — | — | — | — | blocked |
+| dolt_sql_server | all three | — | — | — | — | blocked |
+
+Latency is descriptive only. Example claim-mutation p50 on this host
+(nanoseconds, from the checked artifact):
+
+| Dataset | JSON p50 | SQLite p50 | SQLite / JSON |
+|---|---:|---:|---:|
+| chain_50 | ~2.6e6 | ~1.1e6 | ~0.41 |
+| diamond_200 | ~6.2e6 | ~1.7e6 | ~0.27 |
+| wide_500_1000 | ~1.1e7 | ~2.1e6 | ~0.19 |
+
+Exact integers are in the measurement JSON. Do not treat these ratios as an
+adoption gate.
+
+## Capability matrix
+
+Legend: `Y` supported by the shape today or by the measured adapter, `N`
+absent, `C` documentation-backed candidate, `U` unmeasured / blocked in R1,
+`n/a` not applicable.
+
+| Dimension | JSON | SQLite WAL | Dolt CLI | Embedded Dolt | Dolt SQL server |
+|---|---|---|---|---|---|
+| #737 chains / diamonds | Y | Y* | U | U | U |
+| #737 cycles rejected | Y | Y* | U | U | U |
+| #737 provenance-only edges | Y | Y* | U | U | U |
+| #737 parent propagation | Y | Y* | U | U | U |
+| Atomic graph apply | Y (single file) | Y (one txn) | U | U | U |
+| #738 claim race 0+13 | Y | Y | U | U | U |
+| Same-claim retry | Y | Y (adapter) | U | U | U |
+| Crash before commit/replace | Y | Y | U | U | U |
+| Crash after SQL commit before VC commit | n/a | n/a | U | U | U |
+| Offline A/B divergence reconcile | N | N | C | C | C |
+| Branch / diff / merge | N | N | C | C | C |
+| Same-cell conflict model | file CAS | row/txn locks | cell merge† | cell merge† | cell merge† |
+| Row locks / `SELECT FOR UPDATE` | n/a | SQLite locks | N† | N† | N† |
+| Migration / downgrade policy | ledger version field | adapter-local | U | U | U |
+| Lossless export/import | Y | Y | U | U | U |
+| Backup / restore digests | file copy | file copy | C | C | C‡ |
+| Credential references | file perms only | file perms only | C | C | C‡ users/grants |
+| Retained deleted secrets in history | N (no VC history) | N | C risk | C risk | C risk |
+| Anonymous metrics disabled in tests | Y | Y | U | U | U |
+| Cold start / p50 / p95 / memory / disk | measured latency | measured latency | U | U | U |
+| Install size / backup time | n/a (in-tree) | stdlib | U | U | U |
+| Listener | N | N | N | N | blocked in R1 |
+| Brigade runtime dependency | already present | **forbidden** | **forbidden** | **forbidden** | **forbidden** |
+
+\* SQLite adapter reuses the Brigade readiness resolver on export for #737
+checks; claim CAS is exercised inside `BEGIN IMMEDIATE`.
+
+† Dolt primary docs: row-level locks and `SELECT FOR UPDATE` unsupported;
+concurrency uses SQL transactions plus cell-level merge/conflict behavior.
+SQL transaction success is not Brigade claim-CAS proof
+([supported statements](https://www.dolthub.com/docs/sql-reference/sql-support/supported-statements/),
+[concurrency](https://www.dolthub.com/blog/2026-02-17-dolt-concurrency/)).
+
+‡ Server shape adds long-running process, users/grants, backup, and version
+lifecycle beyond CLI/embedded
+([server deployment](https://www.dolthub.com/docs/introduction/installation/application-server/),
+[backups](https://www.dolthub.com/docs/sql-reference/server/backups/),
+[versioning](https://www.dolthub.com/docs/other/versioning/)).
+
+### Mapping Dolt commits to Brigade mutations
+
+If a later issue revisits Dolt, candidate commit policy (not implemented here):
+
+| Mutation | SQL transaction | `CALL DOLT_COMMIT` |
+|---|---|---|
+| Claim CAS / release / reassign | required | candidate yes — durable actor-visible history |
+| Atomic graph apply | required | candidate yes |
+| Ready-set / status reads | optional / none | no |
+| Branch proposal create / update | required | yes |
+| Merge of reviewed proposal | merge + commit | yes |
+
+Working-set SQL commits without Dolt commits would leave branch heads and
+reviewable history unclear. Claim CAS must still enforce one winner and exit
+`13` semantics above any cell-merge success.
+
+## Decision record (R1)
+
+1. **Keep the machine-local JSON ledger** as the Brigade work store.
+2. The **current need** is sequential portable sync plus reviewable
+   branch-and-merge proposals for one operator — not concurrent cross-machine
+   claims.
+3. **Do not approve** a shared-store conformance fixture, backend interface,
+   daemon, or `brigade.workstore.v1` in this issue.
+4. SQLite WAL remains an **optional local characterization** control; it must
+   not become a runtime dependency from this work.
+5. Dolt CLI / embedded / server remain **characterization candidates only**.
+6. An operator-owned shared service becomes eligible **only if** a later
+   concurrent-claim requirement cannot meet measured correctness through file
+   or replica candidates.
+7. Beads stays excluded under #770.
+
+## Explicit non-goals preserved
+
+No backend adoption, daemon, listener, Beads path, source-of-truth migration,
+multi-user tenancy, production schema change, or production work-store
+refactor landed in R1. Production work-store modules were not edited.
+
+## Follow-ups (out of R1)
+
+- Portable sync design / import-export protocol (separate issue)
+- Reviewable branch-and-merge proposal surface (separate issue)
+- Optional Dolt CLI runner behind an explicit enable flag, still without a
+  runtime dependency
+- Shared-store conformance fixture only after a concurrent-claim requirement
+  appears and file/replica candidates fail measured gates
+
+## Verification
+
+Baseline and post-change normative anchors:
+
+```bash
+brigade work verify run --target . --command \
+  ".venv/bin/python -m pytest -q tests/test_work_cmd_edges.py tests/test_work_cmd_claim.py" \
+  --capture brigade-work
+```
+
+Harness:
+
+```bash
+brigade work verify run --target . --command \
+  ".venv/bin/python -m pytest -q tests/test_work_store_measurement.py" \
+  --capture brigade-work
+```
+
+Cite exact Brigade receipt IDs in the draft PR body.

--- a/scripts/measure_work_store.py
+++ b/scripts/measure_work_store.py
@@ -1,0 +1,1243 @@
+#!/usr/bin/env python3
+"""Issue #846 R1 work-store characterization harness.
+
+Measures candidate store *shapes* against synthetic, machine-neutral graph
+fixtures. This script is research-only: it does not edit production work-store
+code, add runtime dependencies, start network listeners, or select a backend.
+
+Shapes:
+
+- ``json_ledger`` — current Brigade ``.brigade/work/tasks.json`` path (measured)
+- ``sqlite_wal`` — optional stdlib ``sqlite3`` WAL characterization adapter
+- ``dolt_cli_per_command`` / ``embedded_dolt`` / ``dolt_sql_server`` — recorded
+  as blocked or unmeasured unless a temporary local binary is supplied; the
+  SQL-server shape never starts a listener from this harness
+
+Protocol defaults match the #846 scoping comment: 10 warmups and 100 measured
+trials, nearest-rank p50/p95, two-claimer barrier race requiring one success
+and one exit 13, and pass/fail gates for #737/#738 anchors where exercised.
+Latency remains descriptive (no absolute service level).
+
+Standard library plus the in-repo ``brigade`` package only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import platform
+import re
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from brigade import localio
+from brigade.work_cmd import claiming as claim_mod
+from brigade.work_cmd import edges as edges_mod
+from brigade.work_cmd import helpers as work_helpers
+from brigade.work_cmd import ledger as ledger_mod
+
+ISSUE = 846
+SLICE = "R1"
+KIND = "work-store-characterization"
+PROTOCOL_VERSION = 1
+TIMEBOX_NOTE = (
+    "R1 timebox: automate JSON baseline first; SQLite WAL is an optional "
+    "stdlib characterization adapter; Dolt shapes stay optional and must not "
+    "enter Brigade runtime dependencies. Server listeners require separate "
+    "operator approval and are never started here."
+)
+
+DEFAULT_WARMUPS = 10
+DEFAULT_TRIALS = 100
+EXIT_CLAIM_BUSY = claim_mod.EXIT_GUARD_MISMATCH
+
+SHAPES = (
+    "json_ledger",
+    "sqlite_wal",
+    "dolt_cli_per_command",
+    "embedded_dolt",
+    "dolt_sql_server",
+)
+
+DATASETS = (
+    "chain_50",
+    "diamond_200",
+    "wide_500_1000",
+)
+
+_MOUNTPOINT_ESCAPE_RE = re.compile(r"\\([0-7]{3})")
+_FIXED_CREATED_AT = "2026-01-01T00:00:00+00:00"
+
+
+class MeasurementInputError(RuntimeError):
+    """Measurement input or scenario state is missing, unreadable, or incomplete."""
+
+
+@dataclass(frozen=True)
+class FixtureSpec:
+    name: str
+    task_count: int
+    edge_count: int
+    blocks_edges: int
+    provenance_edges: int
+    parent_child_edges: int
+    ready_count: int
+
+
+FIXTURE_SPECS: dict[str, FixtureSpec] = {
+    "chain_50": FixtureSpec(
+        name="chain_50",
+        task_count=50,
+        edge_count=49,
+        blocks_edges=49,
+        provenance_edges=0,
+        parent_child_edges=0,
+        ready_count=1,
+    ),
+    "diamond_200": FixtureSpec(
+        name="diamond_200",
+        task_count=200,
+        edge_count=396,
+        blocks_edges=396,
+        provenance_edges=0,
+        parent_child_edges=0,
+        ready_count=1,
+    ),
+    "wide_500_1000": FixtureSpec(
+        name="wide_500_1000",
+        task_count=500,
+        edge_count=1000,
+        blocks_edges=0,
+        provenance_edges=1000,
+        parent_child_edges=0,
+        ready_count=500,
+    ),
+}
+
+
+def _percentile_nearest_rank(sorted_values: list[int], percentile: float) -> int:
+    """Deterministic nearest-rank percentile on an ascending-sorted nonempty list."""
+    n = len(sorted_values)
+    if n == 0:
+        raise ValueError("percentile requires a nonempty sample")
+    rank = math.ceil(percentile / 100 * n)
+    index = max(0, min(n - 1, rank - 1))
+    return int(sorted_values[index])
+
+
+def _decode_mountpoint(raw: str) -> str:
+    return _MOUNTPOINT_ESCAPE_RE.sub(lambda match: chr(int(match.group(1), 8)), raw)
+
+
+def _filesystem_type(root: Path) -> str:
+    mountinfo = Path("/proc/self/mountinfo")
+    try:
+        lines = mountinfo.read_text().splitlines()
+    except OSError:
+        return "unknown"
+    resolved = root.expanduser().resolve()
+    best_fs: str | None = None
+    best_depth = -1
+    for line in lines:
+        fields, separator, tail = line.partition(" - ")
+        if not separator:
+            continue
+        parts = fields.split()
+        if len(parts) < 5:
+            continue
+        mountpoint = Path(_decode_mountpoint(parts[4]))
+        try:
+            resolved.relative_to(mountpoint)
+        except ValueError:
+            continue
+        depth = len(mountpoint.parts)
+        if depth > best_depth:
+            best_depth = depth
+            best_fs = tail.split(maxsplit=1)[0] if tail.split() else None
+    return best_fs if best_fs is not None else "unknown"
+
+
+def _directory_fsync_supported(root: Path) -> bool:
+    probe = Path(tempfile.mkdtemp(prefix="dir-fsync-probe-", dir=root))
+    try:
+        fd = os.open(probe, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+        try:
+            os.fsync(fd)
+        except OSError:
+            return False
+        finally:
+            os.close(fd)
+        return True
+    except OSError:
+        return False
+    finally:
+        shutil.rmtree(probe, ignore_errors=True)
+
+
+def environment_metadata(root: Path) -> dict[str, Any]:
+    """Platform and filesystem class without hostnames."""
+    return {
+        "python_version": sys.version,
+        "platform": platform.platform(),
+        "filesystem_type": _filesystem_type(root),
+        "directory_fsync_supported": _directory_fsync_supported(root),
+        "sqlite_version": sqlite3.sqlite_version,
+        "dolt_on_path": bool(shutil.which("dolt")),
+    }
+
+
+def _task(
+    task_id: str,
+    text: str,
+    *,
+    status: str = "pending",
+    priority: str = "normal",
+) -> dict[str, Any]:
+    return {
+        "id": task_id,
+        "text": text,
+        "status": status,
+        "source": "synthetic",
+        "type": "task",
+        "priority": priority,
+        "acceptance": [],
+        "created_at": _FIXED_CREATED_AT,
+        "updated_at": _FIXED_CREATED_AT,
+    }
+
+
+def _edge(edge_id: str, source: str, target: str, edge_type: str) -> dict[str, Any]:
+    return {
+        "id": edge_id,
+        "source": source,
+        "target": target,
+        "type": edge_type,
+        "created_at": _FIXED_CREATED_AT,
+    }
+
+
+def build_fixture(name: str) -> dict[str, Any]:
+    """Build one synthetic ledger fixture. Raises ValueError for unknown names."""
+    if name == "chain_50":
+        tasks = [_task(f"synth-chain-{i:04d}", f"Chain task {i}") for i in range(50)]
+        edges = [
+            _edge(
+                f"synth-chain-edge-{i:04d}",
+                f"synth-chain-{i:04d}",
+                f"synth-chain-{i + 1:04d}",
+                "blocks",
+            )
+            for i in range(49)
+        ]
+    elif name == "diamond_200":
+        # 1 source, 198 middles, 1 sink. Source blocks each middle; each middle
+        # blocks the sink. Only the source is ready.
+        source = "synth-diamond-0000"
+        sink = "synth-diamond-0199"
+        tasks = [_task(source, "Diamond source", priority="high")]
+        tasks.extend(_task(f"synth-diamond-{i:04d}", f"Diamond middle {i}") for i in range(1, 199))
+        tasks.append(_task(sink, "Diamond sink"))
+        edges = []
+        for i in range(1, 199):
+            middle = f"synth-diamond-{i:04d}"
+            edges.append(_edge(f"synth-diamond-src-{i:04d}", source, middle, "blocks"))
+            edges.append(_edge(f"synth-diamond-snk-{i:04d}", middle, sink, "blocks"))
+    elif name == "wide_500_1000":
+        tasks = [_task(f"synth-wide-{i:04d}", f"Wide open task {i}") for i in range(500)]
+        edges = []
+        # 1000 distinct provenance-only edges; identity is (source, target, type).
+        for index in range(1000):
+            source_i = index % 500
+            # offsets 1..2 cover 1000 unique directed pairs on 500 nodes
+            offset = 1 + (index // 500)
+            target_i = (source_i + offset) % 500
+            edges.append(
+                _edge(
+                    f"synth-wide-prov-{index:04d}",
+                    f"synth-wide-{source_i:04d}",
+                    f"synth-wide-{target_i:04d}",
+                    "discovered-from",
+                )
+            )
+    else:
+        raise ValueError(f"unknown fixture: {name}")
+
+    ledger = {
+        "version": edges_mod.TASK_LEDGER_VERSION,
+        "tasks": tasks,
+        "edges": edges,
+    }
+    edges_mod.ensure_ledger_edges(ledger)
+    return ledger
+
+
+def canonicalize_ledger(ledger: dict[str, Any]) -> dict[str, Any]:
+    """Return a ledger with tasks/edges stably ordered for digest comparison."""
+    tasks = sorted(
+        (task for task in ledger.get("tasks", []) if isinstance(task, dict)),
+        key=lambda item: str(item.get("id") or ""),
+    )
+    edges = sorted(
+        (edge for edge in ledger.get("edges", []) if isinstance(edge, dict)),
+        key=lambda item: (
+            str(item.get("id") or ""),
+            str(item.get("source") or ""),
+            str(item.get("target") or ""),
+            str(item.get("type") or ""),
+        ),
+    )
+    return {
+        "version": ledger.get("version", edges_mod.TASK_LEDGER_VERSION),
+        "tasks": tasks,
+        "edges": edges,
+    }
+
+
+def fixture_digest(ledger: dict[str, Any]) -> str:
+    payload = json.dumps(canonicalize_ledger(ledger), sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def describe_fixture(name: str) -> dict[str, Any]:
+    ledger = build_fixture(name)
+    spec = FIXTURE_SPECS[name]
+    resolution = edges_mod.resolve_readiness(ledger)
+    blocks = sum(1 for edge in ledger["edges"] if edge["type"] == "blocks")
+    provenance = sum(1 for edge in ledger["edges"] if edge["type"] == "discovered-from")
+    parent_child = sum(1 for edge in ledger["edges"] if edge["type"] == "parent-child")
+    return {
+        "name": name,
+        "task_count": len(ledger["tasks"]),
+        "edge_count": len(ledger["edges"]),
+        "blocks_edges": blocks,
+        "provenance_edges": provenance,
+        "parent_child_edges": parent_child,
+        "ready_count": len(resolution.ready),
+        "expected": {
+            "task_count": spec.task_count,
+            "edge_count": spec.edge_count,
+            "blocks_edges": spec.blocks_edges,
+            "provenance_edges": spec.provenance_edges,
+            "parent_child_edges": spec.parent_child_edges,
+            "ready_count": spec.ready_count,
+        },
+        "digest_sha256": fixture_digest(ledger),
+        "machine_neutral": True,
+        "contains_hostnames": False,
+    }
+
+
+def write_fixture_manifest(output: Path) -> dict[str, Any]:
+    fixtures = {name: describe_fixture(name) for name in DATASETS}
+    manifest = {
+        "issue": ISSUE,
+        "slice": SLICE,
+        "kind": "work-store-fixture-manifest",
+        "protocol_version": PROTOCOL_VERSION,
+        "fixtures": fixtures,
+    }
+    write_report(manifest, output)
+    return manifest
+
+
+def _init_git_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q", "-b", "main", str(path)], check=True)
+
+
+def _write_json_ledger(target: Path, ledger: dict[str, Any]) -> None:
+    work_helpers._work_root(target).mkdir(parents=True, exist_ok=True)
+    localio.write_json(work_helpers._tasks_path(target), ledger)
+
+
+def _clone_ledger(ledger: dict[str, Any]) -> dict[str, Any]:
+    return json.loads(json.dumps(ledger))
+
+
+def _claim_target_id(ledger: dict[str, Any]) -> str:
+    resolution = edges_mod.resolve_readiness(ledger)
+    if not resolution.ready:
+        raise MeasurementInputError("fixture has no ready task to claim")
+    ordered = sorted(resolution.ready, key=claim_mod.ready_sort_key)
+    return str(ordered[0]["id"])
+
+
+def _latency_stats(samples_ns: list[int]) -> dict[str, Any]:
+    ordered = sorted(samples_ns)
+    return {
+        "samples": len(ordered),
+        "p50_ns": _percentile_nearest_rank(ordered, 50),
+        "p95_ns": _percentile_nearest_rank(ordered, 95),
+        "max_ns": ordered[-1],
+        "min_ns": ordered[0],
+    }
+
+
+def _relative_to_json(stats: dict[str, Any], baseline: dict[str, Any] | None) -> dict[str, Any]:
+    if baseline is None:
+        return {"p50_vs_json": 1.0, "p95_vs_json": 1.0}
+    p50_base = baseline["p50_ns"]
+    p95_base = baseline["p95_ns"]
+    return {
+        "p50_vs_json": (stats["p50_ns"] / p50_base) if p50_base else None,
+        "p95_vs_json": (stats["p95_ns"] / p95_base) if p95_base else None,
+    }
+
+
+# --- JSON ledger shape (current Brigade store) ---------------------------------
+
+
+def _json_load_target(root: Path, ledger: dict[str, Any], *, with_git: bool = False) -> Path:
+    target = Path(tempfile.mkdtemp(prefix="ws-json-", dir=root))
+    if with_git:
+        _init_git_repo(target)
+    _write_json_ledger(target, _clone_ledger(ledger))
+    return target
+
+
+def _json_measure_mutation(
+    root: Path,
+    ledger: dict[str, Any],
+    *,
+    warmups: int,
+    trials: int,
+) -> dict[str, Any]:
+    samples: list[int] = []
+    task_id = _claim_target_id(ledger)
+    total = warmups + trials
+    for index in range(total):
+        target = _json_load_target(root, ledger, with_git=False)
+        try:
+            start = time.perf_counter_ns()
+            result = ledger_mod._claim_task(
+                target,
+                task_id,
+                actor=f"actor-{index}",
+                claim_id=f"claim-{index}",
+            )
+            elapsed = time.perf_counter_ns() - start
+            if not result.get("created"):
+                raise MeasurementInputError(f"json claim did not create: {result}")
+            if index >= warmups:
+                samples.append(elapsed)
+        finally:
+            shutil.rmtree(target, ignore_errors=True)
+    return _latency_stats(samples)
+
+
+def _json_claim_race(root: Path, ledger: dict[str, Any]) -> dict[str, Any]:
+    target = _json_load_target(root, ledger, with_git=True)
+    task_id = _claim_target_id(ledger)
+    barrier = threading.Barrier(2)
+    results: list[tuple[str, int, str]] = []
+    lock = threading.Lock()
+
+    def worker(actor: str, claim_id: str) -> None:
+        barrier.wait(timeout=30)
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "brigade",
+                "work",
+                "claim",
+                task_id,
+                "--actor",
+                actor,
+                "--claim-id",
+                claim_id,
+                "--target",
+                str(target),
+                "--json",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        with lock:
+            results.append((actor, proc.returncode, proc.stdout))
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [
+                executor.submit(worker, "lane-a", "claim-a"),
+                executor.submit(worker, "lane-b", "claim-b"),
+            ]
+            for future in futures:
+                future.result(timeout=60)
+        codes = sorted(code for _actor, code, _out in results)
+        winners = [item for item in results if item[1] == 0]
+        losers = [item for item in results if item[1] == 13]
+        ok = codes == [0, 13] and len(winners) == 1 and len(losers) == 1
+        detail: dict[str, Any] = {
+            "codes": codes,
+            "winner_count": len(winners),
+            "exit_13_count": len(losers),
+            "pass": ok,
+        }
+        if winners:
+            detail["winner_actor"] = winners[0][0]
+        if losers:
+            payload = json.loads(losers[0][2]) if losers[0][2].strip() else {}
+            detail["loser_reason"] = payload.get("reason")
+            detail["loser_holder"] = payload.get("holder")
+        return detail
+    finally:
+        shutil.rmtree(target, ignore_errors=True)
+
+
+def _json_graph_conformance(ledger: dict[str, Any]) -> dict[str, Any]:
+    resolution = edges_mod.resolve_readiness(_clone_ledger(ledger))
+    # Provenance-only edges must not create readiness cycles.
+    provenance_only = all(
+        edge["type"] == "discovered-from" or edge["type"] in {"blocks", "parent-child"} for edge in ledger["edges"]
+    )
+    return {
+        "ready_count": len(resolution.ready),
+        "blocked_count": len(resolution.blocked),
+        "cycle_count": len(resolution.cycles),
+        "provenance_ignored_for_readiness": provenance_only,
+        "pass": len(resolution.cycles) == 0,
+    }
+
+
+def _json_export_import(root: Path, ledger: dict[str, Any]) -> dict[str, Any]:
+    target = _json_load_target(root, ledger, with_git=False)
+    try:
+        exported = ledger_mod._read_task_ledger(target)
+        digest_before = fixture_digest(exported)
+        roundtrip = Path(tempfile.mkdtemp(prefix="ws-json-rt-", dir=root))
+        try:
+            _write_json_ledger(roundtrip, exported)
+            imported = ledger_mod._read_task_ledger(roundtrip)
+            digest_after = fixture_digest(imported)
+            return {
+                "digest_before": digest_before,
+                "digest_after": digest_after,
+                "pass": digest_before == digest_after,
+            }
+        finally:
+            shutil.rmtree(roundtrip, ignore_errors=True)
+    finally:
+        shutil.rmtree(target, ignore_errors=True)
+
+
+def _json_crash_before_replace(root: Path, ledger: dict[str, Any]) -> dict[str, Any]:
+    """Crash before atomic replace: original ledger must remain intact."""
+    target = _json_load_target(root, ledger, with_git=False)
+    path = work_helpers._tasks_path(target)
+    before = path.read_bytes()
+    try:
+        fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp")
+        tmp_path = Path(tmp_name)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write("{corrupt")
+                handle.flush()
+                os.fsync(handle.fileno())
+            # Injected crash: abandon before os.replace.
+            tmp_path.unlink(missing_ok=True)
+            after = path.read_bytes()
+            return {
+                "mode": "before_replace",
+                "original_intact": before == after,
+                "pass": before == after,
+            }
+        except Exception as exc:  # noqa: BLE001 - record exact failure
+            return {"mode": "before_replace", "pass": False, "error": str(exc)}
+    finally:
+        shutil.rmtree(target, ignore_errors=True)
+
+
+def measure_json_ledger(
+    root: Path,
+    dataset: str,
+    *,
+    warmups: int,
+    trials: int,
+) -> dict[str, Any]:
+    ledger = build_fixture(dataset)
+    mutation = _json_measure_mutation(root, ledger, warmups=warmups, trials=trials)
+    claim_race = _json_claim_race(root, ledger)
+    graph = _json_graph_conformance(ledger)
+    export_import = _json_export_import(root, ledger)
+    crash = _json_crash_before_replace(root, ledger)
+    gates = {
+        "issue_737_graph": graph["pass"],
+        "issue_738_claim": claim_race["pass"],
+        "crash_consistency": crash["pass"],
+        "lossless_export": export_import["pass"],
+        "metrics_state": True,  # harness disables anonymous metrics by not enabling any
+        "secret_history_handling": True,  # JSON ledger has no retained VC history
+        "restore": export_import["pass"],
+    }
+    return {
+        "shape": "json_ledger",
+        "status": "measured",
+        "dataset": dataset,
+        "mutation_latency": mutation,
+        "relative_to_json": {"p50_vs_json": 1.0, "p95_vs_json": 1.0},
+        "claim_race": claim_race,
+        "graph_conformance": graph,
+        "export_import": export_import,
+        "crash_consistency": crash,
+        "branch_diff_merge": {
+            "status": "unsupported",
+            "detail": "JSON ledger has no first-class branch/diff/merge path",
+        },
+        "offline_divergence": {
+            "status": "unsupported",
+            "detail": "No portable sync primitive in current JSON ledger",
+        },
+        "gates": gates,
+        "pass": all(gates.values()),
+    }
+
+
+# --- SQLite WAL optional characterization adapter ------------------------------
+
+
+_SQLITE_SCHEMA = """
+PRAGMA journal_mode=WAL;
+PRAGMA synchronous=FULL;
+CREATE TABLE IF NOT EXISTS meta (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS tasks (
+  id TEXT PRIMARY KEY,
+  payload TEXT NOT NULL,
+  status TEXT NOT NULL,
+  assignee TEXT,
+  claim_id TEXT,
+  item_revision INTEGER NOT NULL DEFAULT 0
+);
+CREATE TABLE IF NOT EXISTS edges (
+  id TEXT PRIMARY KEY,
+  source TEXT NOT NULL,
+  target TEXT NOT NULL,
+  type TEXT NOT NULL,
+  payload TEXT NOT NULL
+);
+"""
+
+
+def _sqlite_connect(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(path, timeout=30.0, isolation_level=None)
+    conn.execute("PRAGMA busy_timeout=30000")
+    return conn
+
+
+def _sqlite_load(path: Path, ledger: dict[str, Any]) -> None:
+    if path.exists():
+        path.unlink()
+    conn = _sqlite_connect(path)
+    try:
+        conn.executescript(_SQLITE_SCHEMA)
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute(
+            "INSERT INTO meta(key, value) VALUES (?, ?)",
+            ("version", str(ledger.get("version", edges_mod.TASK_LEDGER_VERSION))),
+        )
+        for task in ledger["tasks"]:
+            conn.execute(
+                "INSERT INTO tasks(id, payload, status, assignee, claim_id, item_revision) VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    task["id"],
+                    json.dumps(task, sort_keys=True),
+                    task.get("status") or "pending",
+                    task.get("assignee"),
+                    (task.get("claim") or {}).get("claim_id") if isinstance(task.get("claim"), dict) else None,
+                    int((task.get("claim") or {}).get("item_revision") or 0)
+                    if isinstance(task.get("claim"), dict)
+                    else 0,
+                ),
+            )
+        for edge in ledger["edges"]:
+            conn.execute(
+                "INSERT INTO edges(id, source, target, type, payload) VALUES (?, ?, ?, ?, ?)",
+                (
+                    edge["id"],
+                    edge["source"],
+                    edge["target"],
+                    edge["type"],
+                    json.dumps(edge, sort_keys=True),
+                ),
+            )
+        conn.execute("COMMIT")
+    finally:
+        conn.close()
+
+
+def _sqlite_export_ledger(path: Path) -> dict[str, Any]:
+    conn = _sqlite_connect(path)
+    try:
+        tasks = []
+        for row in conn.execute("SELECT payload FROM tasks ORDER BY id"):
+            tasks.append(json.loads(row[0]))
+        edges = []
+        for row in conn.execute("SELECT payload FROM edges ORDER BY id"):
+            edges.append(json.loads(row[0]))
+        version_row = conn.execute("SELECT value FROM meta WHERE key='version'").fetchone()
+        version = int(version_row[0]) if version_row else edges_mod.TASK_LEDGER_VERSION
+        ledger = {"version": version, "tasks": tasks, "edges": edges}
+        edges_mod.ensure_ledger_edges(ledger)
+        return ledger
+    finally:
+        conn.close()
+
+
+def _sqlite_claim(path: Path, task_id: str, *, actor: str, claim_id: str) -> tuple[int, dict[str, Any]]:
+    """CAS claim under BEGIN IMMEDIATE. Returns (exit_code, payload)."""
+    conn = _sqlite_connect(path)
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        row = conn.execute(
+            "SELECT status, assignee, claim_id, item_revision, payload FROM tasks WHERE id=?",
+            (task_id,),
+        ).fetchone()
+        if row is None:
+            conn.execute("ROLLBACK")
+            return 2, {"reason": claim_mod.REASON_UNKNOWN_TASK}
+        status, assignee, existing_claim, revision, payload_raw = row
+        task = json.loads(payload_raw)
+        if existing_claim == claim_id and status == "in_progress" and assignee == actor:
+            conn.execute("COMMIT")
+            return 0, {"created": False, "reason": "idempotent_retry"}
+        if status == "in_progress" or existing_claim:
+            holder = assignee or "unknown"
+            conn.execute("ROLLBACK")
+            return EXIT_CLAIM_BUSY, {
+                "reason": claim_mod.REASON_ALREADY_CLAIMED,
+                "holder": holder,
+                "exit_code": EXIT_CLAIM_BUSY,
+            }
+        if status != "pending":
+            conn.execute("ROLLBACK")
+            return EXIT_CLAIM_BUSY, {
+                "reason": claim_mod.REASON_NOT_READY,
+                "exit_code": EXIT_CLAIM_BUSY,
+            }
+        claimed_at = _FIXED_CREATED_AT
+        task["status"] = "in_progress"
+        task["assignee"] = actor
+        task["claim"] = {
+            "claim_id": claim_id,
+            "actor": actor,
+            "claimed_at": claimed_at,
+            "item_revision": int(revision) + 1,
+        }
+        task["updated_at"] = claimed_at
+        conn.execute(
+            "UPDATE tasks SET status=?, assignee=?, claim_id=?, item_revision=?, payload=? WHERE id=?",
+            (
+                "in_progress",
+                actor,
+                claim_id,
+                int(revision) + 1,
+                json.dumps(task, sort_keys=True),
+                task_id,
+            ),
+        )
+        conn.execute("COMMIT")
+        return 0, {"created": True, "holder": actor, "claim_id": claim_id}
+    except Exception:
+        try:
+            conn.execute("ROLLBACK")
+        except sqlite3.Error:
+            pass
+        raise
+    finally:
+        conn.close()
+
+
+def _sqlite_measure_mutation(
+    root: Path,
+    ledger: dict[str, Any],
+    *,
+    warmups: int,
+    trials: int,
+) -> dict[str, Any]:
+    samples: list[int] = []
+    task_id = _claim_target_id(ledger)
+    for index in range(warmups + trials):
+        db_path = Path(tempfile.mkstemp(prefix="ws-sqlite-", suffix=".db", dir=root)[1])
+        try:
+            _sqlite_load(db_path, ledger)
+            start = time.perf_counter_ns()
+            code, payload = _sqlite_claim(
+                db_path,
+                task_id,
+                actor=f"actor-{index}",
+                claim_id=f"claim-{index}",
+            )
+            elapsed = time.perf_counter_ns() - start
+            if code != 0 or not payload.get("created"):
+                raise MeasurementInputError(f"sqlite claim failed: {code} {payload}")
+            if index >= warmups:
+                samples.append(elapsed)
+        finally:
+            for suffix in ("", "-wal", "-shm"):
+                Path(str(db_path) + suffix).unlink(missing_ok=True)
+    return _latency_stats(samples)
+
+
+def _sqlite_claim_race(root: Path, ledger: dict[str, Any]) -> dict[str, Any]:
+    db_path = Path(tempfile.mkstemp(prefix="ws-sqlite-race-", suffix=".db", dir=root)[1])
+    _sqlite_load(db_path, ledger)
+    task_id = _claim_target_id(ledger)
+    barrier = threading.Barrier(2)
+    results: list[tuple[str, int, dict[str, Any]]] = []
+    lock = threading.Lock()
+
+    def worker(actor: str, claim_id: str) -> None:
+        barrier.wait(timeout=30)
+        code, payload = _sqlite_claim(db_path, task_id, actor=actor, claim_id=claim_id)
+        with lock:
+            results.append((actor, code, payload))
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [
+                executor.submit(worker, "lane-a", "claim-a"),
+                executor.submit(worker, "lane-b", "claim-b"),
+            ]
+            for future in futures:
+                future.result(timeout=60)
+        codes = sorted(code for _actor, code, _payload in results)
+        winners = [item for item in results if item[1] == 0]
+        losers = [item for item in results if item[1] == 13]
+        ok = codes == [0, 13] and len(winners) == 1 and len(losers) == 1
+        detail: dict[str, Any] = {
+            "codes": codes,
+            "winner_count": len(winners),
+            "exit_13_count": len(losers),
+            "pass": ok,
+        }
+        if winners:
+            detail["winner_actor"] = winners[0][0]
+        if losers:
+            detail["loser_reason"] = losers[0][2].get("reason")
+            detail["loser_holder"] = losers[0][2].get("holder")
+        return detail
+    finally:
+        for suffix in ("", "-wal", "-shm"):
+            Path(str(db_path) + suffix).unlink(missing_ok=True)
+
+
+def _sqlite_crash_before_commit(root: Path, ledger: dict[str, Any]) -> dict[str, Any]:
+    db_path = Path(tempfile.mkstemp(prefix="ws-sqlite-crash-", suffix=".db", dir=root)[1])
+    try:
+        _sqlite_load(db_path, ledger)
+        before = _sqlite_export_ledger(db_path)
+        task_id = _claim_target_id(before)
+        conn = _sqlite_connect(db_path)
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                "UPDATE tasks SET status=?, assignee=?, claim_id=? WHERE id=?",
+                ("in_progress", "crash-actor", "crash-claim", task_id),
+            )
+            # Injected crash: rollback instead of commit.
+            conn.execute("ROLLBACK")
+        finally:
+            conn.close()
+        after = _sqlite_export_ledger(db_path)
+        return {
+            "mode": "before_commit",
+            "original_intact": fixture_digest(before) == fixture_digest(after),
+            "pass": fixture_digest(before) == fixture_digest(after),
+        }
+    finally:
+        for suffix in ("", "-wal", "-shm"):
+            Path(str(db_path) + suffix).unlink(missing_ok=True)
+
+
+def measure_sqlite_wal(
+    root: Path,
+    dataset: str,
+    *,
+    warmups: int,
+    trials: int,
+    json_baseline: dict[str, Any] | None,
+) -> dict[str, Any]:
+    ledger = build_fixture(dataset)
+    mutation = _sqlite_measure_mutation(root, ledger, warmups=warmups, trials=trials)
+    claim_race = _sqlite_claim_race(root, ledger)
+    # Graph readiness still evaluated by Brigade resolver on exported form.
+    db_path = Path(tempfile.mkstemp(prefix="ws-sqlite-graph-", suffix=".db", dir=root)[1])
+    try:
+        _sqlite_load(db_path, ledger)
+        exported = _sqlite_export_ledger(db_path)
+        graph = _json_graph_conformance(exported)
+        export_import = {
+            "digest_before": fixture_digest(ledger),
+            "digest_after": fixture_digest(exported),
+            "pass": fixture_digest(ledger) == fixture_digest(exported),
+        }
+    finally:
+        for suffix in ("", "-wal", "-shm"):
+            Path(str(db_path) + suffix).unlink(missing_ok=True)
+    crash = _sqlite_crash_before_commit(root, ledger)
+    baseline_stats = None if json_baseline is None else json_baseline.get("mutation_latency")
+    gates = {
+        "issue_737_graph": graph["pass"],
+        "issue_738_claim": claim_race["pass"],
+        "crash_consistency": crash["pass"],
+        "lossless_export": export_import["pass"],
+        "metrics_state": True,
+        "secret_history_handling": True,  # no retained VC history in this adapter
+        "restore": export_import["pass"],
+    }
+    return {
+        "shape": "sqlite_wal",
+        "status": "measured",
+        "dataset": dataset,
+        "mutation_latency": mutation,
+        "relative_to_json": _relative_to_json(mutation, baseline_stats),
+        "claim_race": claim_race,
+        "graph_conformance": graph,
+        "export_import": export_import,
+        "crash_consistency": crash,
+        "branch_diff_merge": {
+            "status": "unsupported",
+            "detail": "SQLite WAL adapter has no branch/diff/merge",
+        },
+        "offline_divergence": {
+            "status": "unsupported",
+            "detail": "File copy only; no merge protocol in this adapter",
+        },
+        "gates": gates,
+        "pass": all(gates.values()),
+        "note": "stdlib sqlite3 characterization only; not a Brigade runtime dependency",
+    }
+
+
+# --- Dolt shapes (blocked / unmeasured in R1 unless explicitly enabled) --------
+
+
+def _dolt_blocked_result(shape: str, dataset: str, reason: str) -> dict[str, Any]:
+    return {
+        "shape": shape,
+        "status": "blocked",
+        "dataset": dataset,
+        "reason": reason,
+        "mutation_latency": None,
+        "relative_to_json": None,
+        "claim_race": {"pass": None, "status": "unmeasured"},
+        "graph_conformance": {"pass": None, "status": "unmeasured"},
+        "export_import": {"pass": None, "status": "unmeasured"},
+        "crash_consistency": {"pass": None, "status": "unmeasured"},
+        "branch_diff_merge": {"status": "unmeasured"},
+        "offline_divergence": {"status": "unmeasured"},
+        "gates": {
+            "issue_737_graph": None,
+            "issue_738_claim": None,
+            "crash_consistency": None,
+            "lossless_export": None,
+            "metrics_state": None,
+            "secret_history_handling": None,
+            "restore": None,
+        },
+        "pass": None,
+    }
+
+
+def measure_dolt_shape(shape: str, dataset: str, *, dolt_bin: str | None) -> dict[str, Any]:
+    if shape == "dolt_sql_server":
+        return _dolt_blocked_result(
+            shape,
+            dataset,
+            "R1 policy: harness must not start a network listener; "
+            "operator-owned server characterization requires separate approval",
+        )
+    if shape == "embedded_dolt":
+        return _dolt_blocked_result(
+            shape,
+            dataset,
+            "No embedded Dolt boundary is checked into this repo; R1 does not build or persist a Go/Dolt dependency",
+        )
+    # dolt_cli_per_command
+    resolved = dolt_bin or shutil.which("dolt")
+    if not resolved:
+        return _dolt_blocked_result(
+            shape,
+            dataset,
+            "dolt binary not available on PATH; optional temporary CLI not supplied "
+            "(--dolt-bin). Cell left unmeasured rather than fabricated",
+        )
+    # A binary may be present for future optional runners; R1 still does not
+    # auto-run Dolt mutations without an explicit enable flag.
+    return _dolt_blocked_result(
+        shape,
+        dataset,
+        f"dolt binary observed at {Path(resolved).name} but R1 timebox keeps "
+        "CLI mutation runner disabled; documentation-only characterization applies",
+    )
+
+
+def measure_shape(
+    shape: str,
+    dataset: str,
+    root: Path,
+    *,
+    warmups: int,
+    trials: int,
+    json_baseline: dict[str, Any] | None = None,
+    dolt_bin: str | None = None,
+) -> dict[str, Any]:
+    if shape not in SHAPES:
+        raise ValueError(f"unknown shape: {shape}")
+    if dataset not in DATASETS:
+        raise ValueError(f"unknown dataset: {dataset}")
+    if shape == "json_ledger":
+        return measure_json_ledger(root, dataset, warmups=warmups, trials=trials)
+    if shape == "sqlite_wal":
+        return measure_sqlite_wal(
+            root,
+            dataset,
+            warmups=warmups,
+            trials=trials,
+            json_baseline=json_baseline,
+        )
+    return measure_dolt_shape(shape, dataset, dolt_bin=dolt_bin)
+
+
+def measure_matrix(
+    root: Path,
+    *,
+    shapes: list[str] | None = None,
+    datasets: list[str] | None = None,
+    warmups: int = DEFAULT_WARMUPS,
+    trials: int = DEFAULT_TRIALS,
+    dolt_bin: str | None = None,
+) -> dict[str, Any]:
+    if warmups < 0:
+        raise ValueError("warmups must be >= 0")
+    if trials <= 0:
+        raise ValueError("trials must be > 0")
+    selected_shapes = list(shapes or SHAPES)
+    selected_datasets = list(datasets or DATASETS)
+    for shape in selected_shapes:
+        if shape not in SHAPES:
+            raise ValueError(f"unknown shape: {shape}")
+    for dataset in selected_datasets:
+        if dataset not in DATASETS:
+            raise ValueError(f"unknown dataset: {dataset}")
+
+    work = Path(tempfile.mkdtemp(prefix="brigade-work-store-measure-", dir=root))
+    try:
+        environment = environment_metadata(work)
+        fixtures = {name: describe_fixture(name) for name in selected_datasets}
+        results: list[dict[str, Any]] = []
+        json_baselines: dict[str, dict[str, Any]] = {}
+
+        # Always measure json first when present so relatives resolve.
+        ordered_shapes = [s for s in selected_shapes if s == "json_ledger"] + [
+            s for s in selected_shapes if s != "json_ledger"
+        ]
+        for dataset in selected_datasets:
+            for shape in ordered_shapes:
+                baseline = json_baselines.get(dataset)
+                result = measure_shape(
+                    shape,
+                    dataset,
+                    work,
+                    warmups=warmups,
+                    trials=trials,
+                    json_baseline=baseline,
+                    dolt_bin=dolt_bin,
+                )
+                if shape == "json_ledger":
+                    json_baselines[dataset] = result
+                results.append(result)
+
+        capability_notes = capability_matrix_notes()
+        decision = decision_record()
+        return {
+            "issue": ISSUE,
+            "slice": SLICE,
+            "kind": KIND,
+            "protocol_version": PROTOCOL_VERSION,
+            "timebox": TIMEBOX_NOTE,
+            "warmups": warmups,
+            "trials": trials,
+            "shapes": selected_shapes,
+            "datasets": selected_datasets,
+            "fixtures": fixtures,
+            "environment": environment,
+            "results": results,
+            "capability_notes": capability_notes,
+            "decision": decision,
+            "normative_anchors": {
+                "issue_737": "graph ready-set, chains, diamonds, cycles, provenance-only edges",
+                "issue_738": "claim CAS with one winner and exit 13 on lost race",
+                "issue_770": "BUILD native; Beads excluded",
+            },
+            "anonymous_metrics": "disabled_in_harness",
+        }
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
+def capability_matrix_notes() -> dict[str, Any]:
+    """Documentation-backed capability notes. Unmeasured cells stay explicit."""
+    return {
+        "json_ledger": {
+            "portable_sync": "absent_first_class",
+            "concurrent_same_store_claim": "supported_via_dir_lock",
+            "concurrent_cross_machine_claim": "not_supported",
+            "branch_diff_merge": "absent",
+            "row_locks": "n/a_file_cas",
+            "dolt_commit_policy": "n/a",
+        },
+        "sqlite_wal": {
+            "portable_sync": "file_copy_only",
+            "concurrent_same_store_claim": "supported_via_begin_immediate",
+            "concurrent_cross_machine_claim": "not_safe_on_shared_network_fs",
+            "branch_diff_merge": "absent",
+            "row_locks": "sqlite_transaction_locks",
+            "dolt_commit_policy": "n/a",
+            "runtime_dependency": "forbidden_for_brigade_runtime",
+        },
+        "dolt_cli_per_command": {
+            "portable_sync": "clone_push_pull_candidate",
+            "concurrent_same_store_claim": "unmeasured_r1",
+            "concurrent_cross_machine_claim": "not_by_cli_alone",
+            "branch_diff_merge": "native_candidate",
+            "row_locks": "unsupported_select_for_update",
+            "sql_tx_vs_claim_cas": (
+                "SQL transaction success is not Brigade claim-CAS proof; "
+                "cell-level merge can allow lost updates vs row-lock DBs"
+            ),
+            "dolt_commit_policy": (
+                "candidate mapping: claim CAS / graph apply / release / reassign "
+                "would need an explicit CALL DOLT_COMMIT after SQL commit; "
+                "readiness queries would not create Dolt commits"
+            ),
+            "runtime_dependency": "forbidden_unless_later_issue_approves",
+        },
+        "embedded_dolt": {
+            "portable_sync": "local_replica_candidate",
+            "concurrent_cross_machine_claim": "not_by_embed_alone",
+            "branch_diff_merge": "native_candidate",
+            "row_locks": "unsupported_select_for_update",
+            "server_lifecycle": "none",
+            "runtime_dependency": "forbidden_unless_later_issue_approves",
+            "status": "blocked_no_boundary_in_repo",
+        },
+        "dolt_sql_server": {
+            "portable_sync": "central_service_candidate",
+            "concurrent_cross_machine_claim": "possible_but_not_current_need",
+            "branch_diff_merge": "native_candidate",
+            "row_locks": "unsupported_select_for_update",
+            "extra_ops": "users_grants_backup_version_lifecycle_listener",
+            "listener_policy": "loopback_only_with_approval_or_no_listener",
+            "eligibility_gate": (
+                "eligible only if a later concurrent-claim requirement cannot "
+                "meet measured correctness through file or replica candidates"
+            ),
+            "runtime_dependency": "forbidden_unless_later_issue_approves",
+            "status": "blocked_no_listener_in_r1",
+        },
+        "sources": [
+            "https://www.dolthub.com/docs/sql-reference/sql-support/supported-statements/",
+            "https://www.dolthub.com/blog/2026-02-17-dolt-concurrency/",
+            "https://www.dolthub.com/docs/introduction/installation/application-server/",
+            "https://www.dolthub.com/docs/sql-reference/server/backups/",
+            "https://www.dolthub.com/docs/other/versioning/",
+        ],
+    }
+
+
+def decision_record() -> dict[str, Any]:
+    return {
+        "current_need": "sequential_portable_sync_plus_reviewable_branch_merge_proposals",
+        "concurrent_cross_machine_claims": "not_current_requirement",
+        "store_decision": "keep_machine_local_json_ledger",
+        "portable_sync": "adopt_as_follow_up_requirement_not_implemented_in_r1",
+        "sqlite": "optional_local_characterization_only_not_runtime_dependency",
+        "shared_store_conformance_fixture": "not_approved",
+        "shared_service_eligibility": ("only_if_later_concurrent_claim_requirement_fails_file_or_replica_candidates"),
+        "dolt": "characterization_candidate_not_banned_not_selected",
+        "beads": "excluded_under_770",
+        "backend_adoption": False,
+        "brigade_workstore_v1": False,
+    }
+
+
+def write_report(report: dict[str, Any], output: Path) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(tempfile.gettempdir()),
+        help="Parent directory for ephemeral measurement workspaces",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Diffable measurement JSON output path",
+    )
+    parser.add_argument("--warmups", type=int, default=DEFAULT_WARMUPS)
+    parser.add_argument("--trials", type=int, default=DEFAULT_TRIALS)
+    parser.add_argument(
+        "--shapes",
+        default=",".join(SHAPES),
+        help="Comma-separated shapes to measure",
+    )
+    parser.add_argument(
+        "--datasets",
+        default=",".join(DATASETS),
+        help="Comma-separated datasets to measure",
+    )
+    parser.add_argument(
+        "--fixture-manifest",
+        type=Path,
+        help="Optional path to write the fixture manifest JSON",
+    )
+    parser.add_argument(
+        "--dolt-bin",
+        type=Path,
+        help="Optional temporary dolt binary path (never persisted as a dependency)",
+    )
+    args = parser.parse_args(argv)
+
+    shapes = [item.strip() for item in args.shapes.split(",") if item.strip()]
+    datasets = [item.strip() for item in args.datasets.split(",") if item.strip()]
+    if args.fixture_manifest is not None:
+        write_fixture_manifest(args.fixture_manifest)
+
+    report = measure_matrix(
+        args.root,
+        shapes=shapes,
+        datasets=datasets,
+        warmups=args.warmups,
+        trials=args.trials,
+        dolt_bin=str(args.dolt_bin) if args.dolt_bin else None,
+    )
+    write_report(report, args.output)
+    print(f"wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_work_store_measurement.py
+++ b/tests/test_work_store_measurement.py
@@ -1,0 +1,191 @@
+"""Tests for scripts/measure_work_store.py (#846 R1 characterization harness)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "measure_work_store.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("measure_work_store_test", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_fixture_specs_match_generated_ledgers():
+    module = _load_module()
+    for name, spec in module.FIXTURE_SPECS.items():
+        description = module.describe_fixture(name)
+        assert description["task_count"] == spec.task_count
+        assert description["edge_count"] == spec.edge_count
+        assert description["blocks_edges"] == spec.blocks_edges
+        assert description["provenance_edges"] == spec.provenance_edges
+        assert description["ready_count"] == spec.ready_count
+        assert description["contains_hostnames"] is False
+        assert len(description["digest_sha256"]) == 64
+
+
+def test_wide_fixture_provenance_does_not_block_readiness():
+    module = _load_module()
+    ledger = module.build_fixture("wide_500_1000")
+    from brigade.work_cmd import edges as edges_mod
+
+    resolution = edges_mod.resolve_readiness(ledger)
+    assert len(resolution.ready) == 500
+    assert len(resolution.cycles) == 0
+    assert all(edge["type"] == "discovered-from" for edge in ledger["edges"])
+
+
+def test_chain_and_diamond_ready_counts():
+    module = _load_module()
+    from brigade.work_cmd import edges as edges_mod
+
+    chain = module.build_fixture("chain_50")
+    diamond = module.build_fixture("diamond_200")
+    assert len(edges_mod.resolve_readiness(chain).ready) == 1
+    assert len(edges_mod.resolve_readiness(diamond).ready) == 1
+
+
+def test_percentile_nearest_rank():
+    module = _load_module()
+    values = [10, 20, 30, 40, 50]
+    assert module._percentile_nearest_rank(values, 50) == 30
+    assert module._percentile_nearest_rank(values, 95) == 50
+    with pytest.raises(ValueError):
+        module._percentile_nearest_rank([], 50)
+
+
+def test_measure_matrix_json_and_sqlite_report_shape(tmp_path):
+    module = _load_module()
+    report = module.measure_matrix(
+        tmp_path,
+        shapes=["json_ledger", "sqlite_wal"],
+        datasets=["chain_50"],
+        warmups=0,
+        trials=2,
+    )
+    assert report["issue"] == 846
+    assert report["slice"] == "R1"
+    assert report["kind"] == "work-store-characterization"
+    assert report["anonymous_metrics"] == "disabled_in_harness"
+    assert {"environment", "fixtures", "results", "decision", "capability_notes"} <= set(report)
+    assert report["environment"]["filesystem_type"]
+    assert isinstance(report["environment"]["directory_fsync_supported"], bool)
+    assert len(report["results"]) == 2
+    for result in report["results"]:
+        assert result["status"] == "measured"
+        assert result["pass"] is True
+        assert result["gates"]["issue_737_graph"] is True
+        assert result["gates"]["issue_738_claim"] is True
+        latency = result["mutation_latency"]
+        for key in ("p50_ns", "p95_ns", "max_ns", "min_ns", "samples"):
+            assert isinstance(latency[key], int)
+        assert result["claim_race"]["codes"] == [0, 13]
+        assert result["claim_race"]["winner_count"] == 1
+        assert result["claim_race"]["exit_13_count"] == 1
+
+
+def test_measure_matrix_marks_dolt_shapes_blocked(tmp_path):
+    module = _load_module()
+    report = module.measure_matrix(
+        tmp_path,
+        shapes=["dolt_cli_per_command", "embedded_dolt", "dolt_sql_server"],
+        datasets=["chain_50"],
+        warmups=0,
+        trials=1,
+    )
+    assert len(report["results"]) == 3
+    for result in report["results"]:
+        assert result["status"] == "blocked"
+        assert result["mutation_latency"] is None
+        assert result["pass"] is None
+        assert result["gates"]["issue_738_claim"] is None
+        assert "reason" in result
+
+
+def test_decision_record_keeps_json_and_excludes_shared_service():
+    module = _load_module()
+    decision = module.decision_record()
+    assert decision["store_decision"] == "keep_machine_local_json_ledger"
+    assert decision["backend_adoption"] is False
+    assert decision["brigade_workstore_v1"] is False
+    assert decision["beads"] == "excluded_under_770"
+    assert decision["shared_store_conformance_fixture"] == "not_approved"
+    assert "portable_sync" in decision["current_need"]
+
+
+def test_write_report_is_canonical_and_diffable(tmp_path):
+    module = _load_module()
+    report = {"b": 1, "a": {"z": [1, 2], "y": True}}
+    output = tmp_path / "nested" / "out.json"
+    module.write_report(report, output)
+    assert output.read_text() == json.dumps(report, indent=2, sort_keys=True) + "\n"
+
+
+def test_cli_writes_measurement_and_fixture_manifest(tmp_path):
+    output = tmp_path / "measurements" / "report.json"
+    manifest = tmp_path / "fixtures" / "manifest.json"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--root",
+            str(tmp_path),
+            "--output",
+            str(output),
+            "--fixture-manifest",
+            str(manifest),
+            "--shapes",
+            "json_ledger,sqlite_wal,dolt_sql_server",
+            "--datasets",
+            "chain_50",
+            "--warmups",
+            "0",
+            "--trials",
+            "1",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(output.read_text())
+    assert payload["issue"] == 846
+    assert len(payload["results"]) == 3
+    statuses = {item["shape"]: item["status"] for item in payload["results"]}
+    assert statuses["json_ledger"] == "measured"
+    assert statuses["sqlite_wal"] == "measured"
+    assert statuses["dolt_sql_server"] == "blocked"
+    fixture_payload = json.loads(manifest.read_text())
+    assert "chain_50" in fixture_payload["fixtures"]
+    assert fixture_payload["fixtures"]["chain_50"]["task_count"] == 50
+
+
+def test_measure_matrix_rejects_nonpositive_trials(tmp_path):
+    module = _load_module()
+    with pytest.raises(ValueError):
+        module.measure_matrix(tmp_path, shapes=["json_ledger"], datasets=["chain_50"], trials=0)
+
+
+def test_no_leftover_measurement_dirs(tmp_path):
+    module = _load_module()
+    module.measure_matrix(
+        tmp_path,
+        shapes=["json_ledger"],
+        datasets=["chain_50"],
+        warmups=0,
+        trials=1,
+    )
+    leftovers = [path.name for path in tmp_path.iterdir() if path.name.startswith("brigade-work-store-measure-")]
+    assert leftovers == []


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

Issue #846 slice R1 only: one timeboxed research report, synthetic machine-neutral fixtures, and a measurement harness that characterizes work-store candidates without adopting a backend or editing production work-store code.

Refs #846

## Type of change

- [x] Docs
- [x] Research / characterization harness (no command-surface change)

## Decision (R1)

- Keep the machine-local JSON ledger.
- Confirmed current need: sequential portable sync plus reviewable branch-and-merge proposals for one operator.
- Concurrent cross-machine claims are not a current requirement.
- Shared service remains ineligible unless a later concurrent-claim requirement cannot meet measured correctness through file or replica candidates.
- Dolt stays a characterization candidate (not banned, not selected). Beads remains excluded under #770.
- No backend, daemon, listener, runtime dependency, or `brigade.workstore.v1`.

## Artifacts

- Report: `docs/research/issue-846-work-store-characterization-r1.md`
- Fixtures: `docs/research/fixtures/work-store-r1/` (`chain_50`, `diamond_200`, `wide_500_1000`)
- Harness: `scripts/measure_work_store.py`
- Tests: `tests/test_work_store_measurement.py`
- Measurement JSON: `docs/measurements/issue-846-work-store-r1.json`

## Measurement summary

- JSON ledger and stdlib SQLite WAL adapters: measured; #737 graph and #738 claim gates passed (one winner + exit 13).
- Dolt CLI / embedded / SQL server: blocked or unmeasured cells recorded explicitly (no `dolt` on PATH; no embedded boundary; no listener started).
- GraphTrail impact lookup skipped: GraphTrail not installed in this VM.

## Brigade receipts

- Baseline anchors: `20260810-162909-work-verify-7825ef`
- Post-change harness + anchors: `20260810-163620-work-verify-0b8b85`

```bash
brigade work verify run --target . --command \
  ".venv/bin/python -m pytest -q tests/test_work_store_measurement.py tests/test_work_cmd_edges.py tests/test_work_cmd_claim.py" \
  --capture brigade-work
```

## Checklist

- [x] Focused pytest + #737/#738 anchors via `brigade work verify run`
- [x] Added harness tests (red-to-green; not weakened)
- [x] Updated `Unreleased` in `CHANGELOG.md`
- [x] No personal details / hostnames in fixtures or report
- [x] No new runtime dependencies
- [x] Does not close #846 (dependent slices remain); uses Refs
- [x] Does not merge or change issue state

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-15a1b564-06cb-4f3c-93e3-6cf050c17427?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-15a1b564-06cb-4f3c-93e3-6cf050c17427&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

