### PR TITLE
feat(evidence-ledger): memory projection E1 namespace and failure-preserving rebuild

### DIFF
--- a/engines/evidence-ledger/CHANGELOG.md
+++ b/engines/evidence-ledger/CHANGELOG.md
@@ -24,8 +24,9 @@ Releases before this changelog was started are on the [releases page](https://gi
   artifacts, post-resolution `unresolved_relations`, #724 content fingerprint
   for duplicate detection only, duplicate explicit-id fail-closed, empty-
   namespace status/doctor dual-read across all `brigade-memory` collections,
-  and legacy `memory:cards` scoped-rebuild (never tombstoned by namespaced
-  crawl).
+  legacy `memory:cards` scoped-rebuild (never tombstoned by namespaced
+  crawl), and latest-version selection for relation resolution plus live
+  health after content-addressed card edits.
 
 ## [0.6.0] - 2026-07-18
 

--- a/engines/evidence-ledger/CHANGELOG.md
+++ b/engines/evidence-ledger/CHANGELOG.md
@@ -17,12 +17,15 @@ Releases before this changelog was started are on the [releases page](https://gi
 
 ### Changed
 
-- Memory projection E1 hardening (#843): operator-declared `memory-<uuid4>`
-  namespace from `memory/NAMESPACE`, namespace-scoped collection/scan/rebuild,
-  failure-preserving rebuild (walk/stage before replace), post-resolution
-  `unresolved_relations`, #724 content fingerprint for duplicate detection only,
-  duplicate explicit-id fail-closed, and legacy `memory:cards` scoped-rebuild
-  dual-read rule.
+- Memory projection E1 hardening (#843): operator-declared RFC 4122
+  `memory-<uuid4>` (version 4 + variant bits) from `memory/NAMESPACE`,
+  namespace-scoped collection/scan/rebuild, detach/remap failure-preserving
+  rebuild that restores prior live IDs/hashes/relations/metadata/events/
+  artifacts, post-resolution `unresolved_relations`, #724 content fingerprint
+  for duplicate detection only, duplicate explicit-id fail-closed, empty-
+  namespace status/doctor dual-read across all `brigade-memory` collections,
+  and legacy `memory:cards` scoped-rebuild (never tombstoned by namespaced
+  crawl).
 
 ## [0.6.0] - 2026-07-18
 

--- a/engines/evidence-ledger/CHANGELOG.md
+++ b/engines/evidence-ledger/CHANGELOG.md
@@ -28,6 +28,8 @@ Releases before this changelog was started are on the [releases page](https://gi
   crawl), and latest-version selection via monotonic ingest `updated_at`
   stamps for relation resolution plus live health after content-addressed
   card edits (including ignoring stale outbound unresolved on prior versions).
+  Re-ingesting known content refreshes the ingest stamp so a restored prior
+  version becomes live again without minting a duplicate item or event.
 
 ## [0.6.0] - 2026-07-18
 

--- a/engines/evidence-ledger/CHANGELOG.md
+++ b/engines/evidence-ledger/CHANGELOG.md
@@ -29,7 +29,9 @@ Releases before this changelog was started are on the [releases page](https://gi
   stamps for relation resolution plus live health after content-addressed
   card edits (including ignoring stale outbound unresolved on prior versions).
   Re-ingesting known content refreshes the ingest stamp so a restored prior
-  version becomes live again without minting a duplicate item or event.
+  version becomes live again without minting a duplicate item or event; direct
+  adapter AlreadyKnown re-imports also re-resolve inbound relations onto that
+  restored version.
 
 ## [0.6.0] - 2026-07-18
 

--- a/engines/evidence-ledger/CHANGELOG.md
+++ b/engines/evidence-ledger/CHANGELOG.md
@@ -25,12 +25,15 @@ Releases before this changelog was started are on the [releases page](https://gi
   for duplicate detection only, duplicate explicit-id fail-closed, empty-
   namespace status/doctor dual-read across all `brigade-memory` collections,
   legacy `memory:cards` scoped-rebuild (never tombstoned by namespaced
-  crawl), and latest-version selection via monotonic ingest `updated_at`
-  stamps for relation resolution plus live health after content-addressed
-  card edits (including ignoring stale outbound unresolved on prior versions).
-  Re-ingesting known content refreshes the ingest stamp so a restored prior
-  version becomes live again without minting a duplicate item or event; direct
-  adapter AlreadyKnown re-imports also re-resolve inbound relations onto that
+  crawl), and latest-version selection via database-monotonic
+  `items.ingest_seq` for relation resolution plus live health after
+  content-addressed card edits (including equal/backward wall-clock
+  `updated_at` and ignoring stale outbound unresolved on prior versions).
+  Re-ingesting known Text+Summary identity advances `ingest_seq` and
+  reconciles metadata/tags/provenance/artifacts/relations so same-text
+  frontmatter edits (including receipt-A → receipt-B retargets) project
+  correctly without minting a duplicate item or event; direct adapter
+  AlreadyKnown re-imports also re-resolve inbound relations onto that
   restored version.
 
 ## [0.6.0] - 2026-07-18

--- a/engines/evidence-ledger/CHANGELOG.md
+++ b/engines/evidence-ledger/CHANGELOG.md
@@ -29,12 +29,14 @@ Releases before this changelog was started are on the [releases page](https://gi
   `items.ingest_seq` for relation resolution plus live health after
   content-addressed card edits (including equal/backward wall-clock
   `updated_at` and ignoring stale outbound unresolved on prior versions).
-  Re-ingesting known Text+Summary identity advances `ingest_seq` and
-  reconciles metadata/tags/provenance/artifacts/relations so same-text
-  frontmatter edits (including receipt-A → receipt-B retargets) project
-  correctly without minting a duplicate item or event; direct adapter
-  AlreadyKnown re-imports also re-resolve inbound relations onto that
-  restored version.
+  v2→v3 migration deterministically backfills `ingest_seq` from prior
+  `updated_at` order (stable `id` fallback) so existing multi-version cards
+  keep the previously live winner before any crawl. Re-ingesting known
+  Text+Summary identity advances `ingest_seq` and reconciles
+  metadata/tags/provenance/artifacts/relations so same-text frontmatter
+  edits (including receipt-A → receipt-B retargets) project correctly
+  without minting a duplicate item or event; direct adapter AlreadyKnown
+  re-imports also re-resolve inbound relations onto that restored version.
 
 ## [0.6.0] - 2026-07-18
 

--- a/engines/evidence-ledger/CHANGELOG.md
+++ b/engines/evidence-ledger/CHANGELOG.md
@@ -15,6 +15,15 @@ Releases before this changelog was started are on the [releases page](https://gi
   `miseledger.adapter.v1`, completed-scan soft tombstones scoped to memory,
   source-local `--rebuild`, scan receipts, and doctor/status memory health.
 
+### Changed
+
+- Memory projection E1 hardening (#843): operator-declared `memory-<uuid4>`
+  namespace from `memory/NAMESPACE`, namespace-scoped collection/scan/rebuild,
+  failure-preserving rebuild (walk/stage before replace), post-resolution
+  `unresolved_relations`, #724 content fingerprint for duplicate detection only,
+  duplicate explicit-id fail-closed, and legacy `memory:cards` scoped-rebuild
+  dual-read rule.
+
 ## [0.6.0] - 2026-07-18
 
 ### Added

--- a/engines/evidence-ledger/CHANGELOG.md
+++ b/engines/evidence-ledger/CHANGELOG.md
@@ -25,8 +25,9 @@ Releases before this changelog was started are on the [releases page](https://gi
   for duplicate detection only, duplicate explicit-id fail-closed, empty-
   namespace status/doctor dual-read across all `brigade-memory` collections,
   legacy `memory:cards` scoped-rebuild (never tombstoned by namespaced
-  crawl), and latest-version selection for relation resolution plus live
-  health after content-addressed card edits.
+  crawl), and latest-version selection via monotonic ingest `updated_at`
+  stamps for relation resolution plus live health after content-addressed
+  card edits (including ignoring stale outbound unresolved on prior versions).
 
 ## [0.6.0] - 2026-07-18
 

--- a/engines/evidence-ledger/docs/ADAPTER_CONTRACT.md
+++ b/engines/evidence-ledger/docs/ADAPTER_CONTRACT.md
@@ -168,8 +168,11 @@ Completed-scan reconciliation:
   id; latest selection uses the database-monotonic `items.ingest_seq` (not
   wall-clock `updated_at` or content-hash id order) so relation resolution and
   live/unresolved health pick the current version even when clocks are equal or
-  move backward. Stale outbound unresolved relations on prior versions do not
-  contaminate live health. Re-ingesting known Text+Summary identity advances
+  move backward. Existing archives upgraded to schema v3 backfill `ingest_seq`
+  from prior `updated_at` order (stable `id` fallback) so multi-version cards
+  keep the previously live winner before any crawl. Stale outbound unresolved
+  relations on prior versions do not contaminate live health. Re-ingesting known
+  Text+Summary identity advances
   `ingest_seq` and atomically reconciles canonical metadata, tags, provenance,
   artifacts, and outbound relations without minting a duplicate item or
   provenance event, so same-text frontmatter edits (including receipt-A →

--- a/engines/evidence-ledger/docs/ADAPTER_CONTRACT.md
+++ b/engines/evidence-ledger/docs/ADAPTER_CONTRACT.md
@@ -125,7 +125,8 @@ Every memory root must declare an opaque namespace id in `memory/NAMESPACE`:
 memory-<uuid4>
 ```
 
-Rules:
+The UUID must be RFC 4122 version 4 with variant bits `8`/`9`/`a`/`b`. Other
+UUID versions and invalid variants are rejected.
 
 - Generated once by the canonical memory owner, copied with the canonical store,
   and never derived from basenames, absolute paths, gitignored aliases, or clone
@@ -135,9 +136,10 @@ Rules:
 - Two roots that share the same explicit card id remain isolated when their
   namespaces differ.
 - Legacy pre-namespace rows use `collection.external_id=memory:cards`. Namespaced
-  crawls dual-read them for diagnostics and never tombstone or rebuild them
-  (scoped-rebuild rule). Migration onto a namespace is an explicit operator step
-  outside the crawl path.
+  crawls never tombstone or rebuild them (scoped-rebuild rule). Empty-namespace
+  status/doctor health dual-reads live counts and unresolved relations across
+  every `brigade-memory` collection, including legacy `memory:cards`. Migration
+  onto a namespace is an explicit operator step outside the crawl path.
 - The engine does not mint or backfill card ids. Markdown remains canonical.
 
 Identity rules:
@@ -163,9 +165,12 @@ Completed-scan reconciliation:
   the active namespace collection.
 - Failed or interrupted scans tombstone nothing and mark the prior completed
   snapshot for that namespace stale.
-- `--rebuild` validates/walks first, then replaces the derived projection for the
-  active namespace. A failed rebuild restores prior live ids/hashes, keeps the
-  prior completed-scan record, and marks health stale or partial.
+- `--rebuild` validates/walks first, then detaches the live namespace collection
+  aside and imports into a fresh collection. Success finalizes by dropping the
+  backup; failure aborts by deleting the partial import and restoring the backup
+  collection name so prior live ids/hashes, inbound and outbound relations,
+  item_metadata, events, artifacts, and the completed-scan record remain intact
+  while health is marked stale or partial.
 - A transaction failure between observation and reconciliation creates no
   tombstones.
 - Default retention tiers must never match `memory_card` items.

--- a/engines/evidence-ledger/docs/ADAPTER_CONTRACT.md
+++ b/engines/evidence-ledger/docs/ADAPTER_CONTRACT.md
@@ -169,7 +169,9 @@ Completed-scan reconciliation:
   relation resolution and live/unresolved health select that latest version
   even when `created_at` is empty or tied (including re-pointing previously
   resolved inbound edges). Stale outbound unresolved relations on prior
-  versions do not contaminate live health.
+  versions do not contaminate live health. Re-ingesting byte-identical prior
+  content refreshes that ingest stamp so the restored version becomes current
+  without minting a duplicate item or provenance event.
 - Failed or interrupted scans tombstone nothing and mark the prior completed
   snapshot for that namespace stale.
 - `--rebuild` validates/walks first, then detaches the live namespace collection

--- a/engines/evidence-ledger/docs/ADAPTER_CONTRACT.md
+++ b/engines/evidence-ledger/docs/ADAPTER_CONTRACT.md
@@ -171,7 +171,9 @@ Completed-scan reconciliation:
   resolved inbound edges). Stale outbound unresolved relations on prior
   versions do not contaminate live health. Re-ingesting byte-identical prior
   content refreshes that ingest stamp so the restored version becomes current
-  without minting a duplicate item or provenance event.
+  without minting a duplicate item or provenance event. Direct adapter
+  AlreadyKnown re-imports re-resolve inbound relations onto that restored
+  version (crawl CompletesMemoryScan already did).
 - Failed or interrupted scans tombstone nothing and mark the prior completed
   snapshot for that namespace stale.
 - `--rebuild` validates/walks first, then detaches the live namespace collection

--- a/engines/evidence-ledger/docs/ADAPTER_CONTRACT.md
+++ b/engines/evidence-ledger/docs/ADAPTER_CONTRACT.md
@@ -165,15 +165,17 @@ Completed-scan reconciliation:
   the active namespace collection.
 - Live identity for a card is the latest non-tombstoned item for
   `(source, collection, external_id)`. Content-addressed edits mint a new item
-  id; ingest always stamps `updated_at` with a monotonic ingestion time so
-  relation resolution and live/unresolved health select that latest version
-  even when `created_at` is empty or tied (including re-pointing previously
-  resolved inbound edges). Stale outbound unresolved relations on prior
-  versions do not contaminate live health. Re-ingesting byte-identical prior
-  content refreshes that ingest stamp so the restored version becomes current
-  without minting a duplicate item or provenance event. Direct adapter
-  AlreadyKnown re-imports re-resolve inbound relations onto that restored
-  version (`CompleteMemoryScan` already did for crawls).
+  id; latest selection uses the database-monotonic `items.ingest_seq` (not
+  wall-clock `updated_at` or content-hash id order) so relation resolution and
+  live/unresolved health pick the current version even when clocks are equal or
+  move backward. Stale outbound unresolved relations on prior versions do not
+  contaminate live health. Re-ingesting known Text+Summary identity advances
+  `ingest_seq` and atomically reconciles canonical metadata, tags, provenance,
+  artifacts, and outbound relations without minting a duplicate item or
+  provenance event, so same-text frontmatter edits (including receipt-A →
+  receipt-B relation retargets) project correctly. Direct adapter AlreadyKnown
+  re-imports also re-resolve inbound relations onto that restored version
+  (`CompleteMemoryScan` already did for crawls).
 - Failed or interrupted scans tombstone nothing and mark the prior completed
   snapshot for that namespace stale.
 - `--rebuild` validates/walks first, then detaches the live namespace collection

--- a/engines/evidence-ledger/docs/ADAPTER_CONTRACT.md
+++ b/engines/evidence-ledger/docs/ADAPTER_CONTRACT.md
@@ -165,8 +165,11 @@ Completed-scan reconciliation:
   the active namespace collection.
 - Live identity for a card is the latest non-tombstoned item for
   `(source, collection, external_id)`. Content-addressed edits mint a new item
-  id; relation resolution and live/unresolved health select that latest version
-  (including re-pointing previously resolved inbound edges).
+  id; ingest always stamps `updated_at` with a monotonic ingestion time so
+  relation resolution and live/unresolved health select that latest version
+  even when `created_at` is empty or tied (including re-pointing previously
+  resolved inbound edges). Stale outbound unresolved relations on prior
+  versions do not contaminate live health.
 - Failed or interrupted scans tombstone nothing and mark the prior completed
   snapshot for that namespace stale.
 - `--rebuild` validates/walks first, then detaches the live namespace collection

--- a/engines/evidence-ledger/docs/ADAPTER_CONTRACT.md
+++ b/engines/evidence-ledger/docs/ADAPTER_CONTRACT.md
@@ -173,7 +173,7 @@ Completed-scan reconciliation:
   content refreshes that ingest stamp so the restored version becomes current
   without minting a duplicate item or provenance event. Direct adapter
   AlreadyKnown re-imports re-resolve inbound relations onto that restored
-  version (crawl CompletesMemoryScan already did).
+  version (`CompleteMemoryScan` already did for crawls).
 - Failed or interrupted scans tombstone nothing and mark the prior completed
   snapshot for that namespace stale.
 - `--rebuild` validates/walks first, then detaches the live namespace collection

--- a/engines/evidence-ledger/docs/ADAPTER_CONTRACT.md
+++ b/engines/evidence-ledger/docs/ADAPTER_CONTRACT.md
@@ -163,6 +163,10 @@ Completed-scan reconciliation:
 
 - Only a completed memory scan may soft-tombstone missing cards, and only within
   the active namespace collection.
+- Live identity for a card is the latest non-tombstoned item for
+  `(source, collection, external_id)`. Content-addressed edits mint a new item
+  id; relation resolution and live/unresolved health select that latest version
+  (including re-pointing previously resolved inbound edges).
 - Failed or interrupted scans tombstone nothing and mark the prior completed
   snapshot for that namespace stale.
 - `--rebuild` validates/walks first, then detaches the live namespace collection

--- a/engines/evidence-ledger/docs/ADAPTER_CONTRACT.md
+++ b/engines/evidence-ledger/docs/ADAPTER_CONTRACT.md
@@ -117,27 +117,72 @@ The native `brigade-memory` source walks `memory/cards/**/*.md`, parses the flat
 Brigade frontmatter subset (not full YAML), and emits `miseledger.adapter.v1`
 records with `item.kind=memory_card`.
 
+### Operator-declared memory namespace
+
+Every memory root must declare an opaque namespace id in `memory/NAMESPACE`:
+
+```text
+memory-<uuid4>
+```
+
+Rules:
+
+- Generated once by the canonical memory owner, copied with the canonical store,
+  and never derived from basenames, absolute paths, gitignored aliases, or clone
+  paths.
+- `collection.external_id` is the namespace id itself. Item identity, tombstones,
+  relation health, and rebuild are scoped to that collection.
+- Two roots that share the same explicit card id remain isolated when their
+  namespaces differ.
+- Legacy pre-namespace rows use `collection.external_id=memory:cards`. Namespaced
+  crawls dual-read them for diagnostics and never tombstone or rebuild them
+  (scoped-rebuild rule). Migration onto a namespace is an explicit operator step
+  outside the crawl path.
+- The engine does not mint or backfill card ids. Markdown remains canonical.
+
 Identity rules:
 
 - Explicit opaque `id` / `card_id` frontmatter wins (`identity_source=explicit_id`).
 - Otherwise the normalized workspace-relative path is used (`identity_source=path`,
   external id `path:<rel>`).
 - Explicit-id renames preserve identity. Path-fallback renames are remove+create.
-- `topic`, title, filename stem, and body text are not canonical identity.
+- `topic`, title, filename stem, body text, and the #724 content fingerprint are
+  not canonical identity.
+- Duplicate explicit ids fail the scan before reconciliation (no last-wins).
+
+Duplicate detection:
+
+- The engine reuses Brigade #724 `content_fingerprint` (normalize: strip
+  frontmatter, lowercase, strip punctuation, collapse whitespace, SHA-256).
+- Fingerprints are stored in item metadata for duplicate detection only and are
+  never used as `item.external_id`.
 
 Completed-scan reconciliation:
 
 - Only a completed memory scan may soft-tombstone missing cards, and only within
-  the `brigade-memory` source.
+  the active namespace collection.
 - Failed or interrupted scans tombstone nothing and mark the prior completed
-  snapshot stale.
-- `--rebuild` deletes only the derived memory projection, then reimports it.
+  snapshot for that namespace stale.
+- `--rebuild` validates/walks first, then replaces the derived projection for the
+  active namespace. A failed rebuild restores prior live ids/hashes, keeps the
+  prior completed-scan record, and marks health stale or partial.
+- A transaction failure between observation and reconciliation creates no
+  tombstones.
 - Default retention tiers must never match `memory_card` items.
+- Observable projection states: live, removed after completed scan, stale, and
+  partial scan.
 
-Scan receipts expose `scan_id`, `created`, `updated`, `unchanged`, `removed`,
-`skipped`, and `failed`. Doctor/status expose capability/version, last completed
-scan, canonical/live counts, hash divergence, unresolved relations,
+Scan receipts expose `scan_id`, `memory_namespace`, `created`, `updated`,
+`unchanged`, `removed`, `skipped`, and `failed`. `unresolved_relations` is
+counted after the final relation-resolution pass and must agree across crawl
+JSON, the scan record, and health. Doctor/status expose capability/version, last
+completed scan, canonical/live counts, hash divergence, unresolved relations,
 malformed/skipped counts, and stale/partial state.
+
+Size bounds:
+
+- Cards larger than 2 MiB are skipped.
+- Item text longer than 256 KiB is truncated with a trailing `[truncated]` marker.
 
 ## Built-In Crawlers
 

--- a/engines/evidence-ledger/docs/SCHEMA.md
+++ b/engines/evidence-ledger/docs/SCHEMA.md
@@ -19,9 +19,10 @@ The MVP uses one SQLite migration with these concepts:
 
 Items may carry `tombstoned_at` for soft removal. Live memory cards are the
 latest non-tombstoned row per external id within a `brigade-memory` namespace
-collection (`collection.external_id = memory-<uuid4>`). Legacy pre-namespace
-rows may still exist under `memory:cards` and are never rebuilt or tombstoned by
-a namespaced crawl.
+collection (`collection.external_id = memory-<uuid4>`), ordered by the
+monotonic ingest stamp on `items.updated_at`. Legacy pre-namespace rows may
+still exist under `memory:cards` and are never rebuilt or tombstoned by a
+namespaced crawl.
 
 Raw adapter lines are preserved in `items.raw_json`. Raw source references are stored in `raw_hash`, `raw_path`, and `raw_ordinal`.
 

--- a/engines/evidence-ledger/docs/SCHEMA.md
+++ b/engines/evidence-ledger/docs/SCHEMA.md
@@ -18,7 +18,10 @@ The MVP uses one SQLite migration with these concepts:
 - `item_fts`: SQLite FTS5 index for item and artifact text
 
 Items may carry `tombstoned_at` for soft removal. Live memory cards are the
-latest non-tombstoned row per external id within `brigade-memory`.
+latest non-tombstoned row per external id within a `brigade-memory` namespace
+collection (`collection.external_id = memory-<uuid4>`). Legacy pre-namespace
+rows may still exist under `memory:cards` and are never rebuilt or tombstoned by
+a namespaced crawl.
 
 Raw adapter lines are preserved in `items.raw_json`. Raw source references are stored in `raw_hash`, `raw_path`, and `raw_ordinal`.
 

--- a/engines/evidence-ledger/docs/SCHEMA.md
+++ b/engines/evidence-ledger/docs/SCHEMA.md
@@ -21,8 +21,11 @@ Items may carry `tombstoned_at` for soft removal. Live memory cards are the
 latest non-tombstoned row per external id within a `brigade-memory` namespace
 collection (`collection.external_id = memory-<uuid4>`), ordered by the
 database-monotonic `items.ingest_seq` (schema v3; `id` is only a tie-break).
-Legacy pre-namespace rows may still exist under `memory:cards` and are never
-rebuilt or tombstoned by a namespaced crawl.
+Upgrading a v2 archive deterministically backfills `ingest_seq` from prior
+`updated_at` order (stable `id` fallback) so multi-version cards keep the
+previously live winner before any crawl. Legacy pre-namespace rows may still
+exist under `memory:cards` and are never rebuilt or tombstoned by a namespaced
+crawl.
 
 Raw adapter lines are preserved in `items.raw_json`. Raw source references are stored in `raw_hash`, `raw_path`, and `raw_ordinal`.
 

--- a/engines/evidence-ledger/docs/SCHEMA.md
+++ b/engines/evidence-ledger/docs/SCHEMA.md
@@ -20,9 +20,9 @@ The MVP uses one SQLite migration with these concepts:
 Items may carry `tombstoned_at` for soft removal. Live memory cards are the
 latest non-tombstoned row per external id within a `brigade-memory` namespace
 collection (`collection.external_id = memory-<uuid4>`), ordered by the
-monotonic ingest stamp on `items.updated_at`. Legacy pre-namespace rows may
-still exist under `memory:cards` and are never rebuilt or tombstoned by a
-namespaced crawl.
+database-monotonic `items.ingest_seq` (schema v3; `id` is only a tie-break).
+Legacy pre-namespace rows may still exist under `memory:cards` and are never
+rebuilt or tombstoned by a namespaced crawl.
 
 Raw adapter lines are preserved in `items.raw_json`. Raw source references are stored in `raw_hash`, `raw_path`, and `raw_ordinal`.
 

--- a/engines/evidence-ledger/internal/app/app.go
+++ b/engines/evidence-ledger/internal/app/app.go
@@ -223,7 +223,7 @@ func collectStatus(db *sql.DB, paths Paths) (Status, error) {
 		"engine_version": Version,
 		"memory":         ingest.MemoryCapability,
 	}
-	if health, herr := ingest.CollectMemoryHealth(db, Version); herr == nil && health.Status != "absent" {
+	if health, herr := ingest.CollectMemoryHealth(db, Version, ""); herr == nil && health.Status != "absent" {
 		st.MemoryHealth = &health
 	}
 	return st, nil
@@ -267,7 +267,7 @@ func cmdDoctor(args []string, out, errw io.Writer) int {
 			add(check.Name, check.OK, check.Detail)
 		}
 	}
-	memoryHealth, memoryErr := ingest.CollectMemoryHealth(db, Version)
+	memoryHealth, memoryErr := ingest.CollectMemoryHealth(db, Version, "")
 	if memoryErr != nil {
 		add("memory_projection", false, memoryErr.Error())
 	} else if memoryHealth.Status != "absent" {

--- a/engines/evidence-ledger/internal/app/memory.go
+++ b/engines/evidence-ledger/internal/app/memory.go
@@ -48,17 +48,17 @@ func cmdCrawlMemory(args []string, out, errw io.Writer) int {
 		}
 		ns, _ := memory.ResolveNamespace(workspace)
 		writeJSON(out, map[string]any{
-			"source_kind":        ingest.MemorySourceKind,
-			"capability":         ingest.MemoryCapability,
-			"engine_version":     Version,
-			"memory_namespace":   ns,
-			"dry_run":            true,
-			"generated_records":  generated.Records,
-			"canonical_count":    countMemoryRecords(outcomes),
-			"skipped":            skipped,
-			"failed":             failed,
-			"warnings":           generated.Warnings,
-			"files":              generated.Files,
+			"source_kind":       ingest.MemorySourceKind,
+			"capability":        ingest.MemoryCapability,
+			"engine_version":    Version,
+			"memory_namespace":  ns,
+			"dry_run":           true,
+			"generated_records": generated.Records,
+			"canonical_count":   countMemoryRecords(outcomes),
+			"skipped":           skipped,
+			"failed":            failed,
+			"warnings":          generated.Warnings,
+			"files":             generated.Files,
 		})
 		return 0
 	}
@@ -84,7 +84,6 @@ func cmdCrawlMemory(args []string, out, errw io.Writer) int {
 			return fatalf(errw, "crawl memory: %s", err)
 		}
 	} else {
-		// Best-effort namespace for failure receipts when the root still has the file.
 		namespace, _ = memory.ResolveNamespace(workspace)
 		if namespace == "" {
 			namespace = ingest.LastMemoryNamespace(db)
@@ -103,7 +102,6 @@ func cmdCrawlMemory(args []string, out, errw io.Writer) int {
 		if beginErr == nil && scanID != "" {
 			_ = ingest.FailMemoryScan(db, scanID, "failed", receipt)
 		} else if namespace != "" {
-			// Still mark prior completed snapshot stale even if begin failed.
 			_ = ingest.FailMemoryScan(db, "", "failed", receipt)
 		}
 		return fatalf(errw, "crawl memory: %s", walkErr)
@@ -121,28 +119,48 @@ func cmdCrawlMemory(args []string, out, errw io.Writer) int {
 		return fatalf(errw, "crawl memory: duplicate explicit id(s) %v; refusing reconciliation", dups)
 	}
 
+	if err := ingest.RecoverMemoryRebuildState(db, namespace); err != nil {
+		return fatalf(errw, "crawl memory: %s", err)
+	}
+
 	before, err := ingest.PriorLiveHashes(db, namespace)
 	if err != nil {
 		return fatalf(errw, "crawl memory: %s", err)
 	}
 
-	var snap *ingest.MemoryNamespaceSnapshot
+	detached := false
+	abortRebuild := func() {
+		if detached {
+			_ = ingest.AbortMemoryRebuild(db, namespace)
+			detached = false
+		}
+	}
+
 	if bools["rebuild"] {
-		snap, err = ingest.SnapshotMemoryNamespace(db, namespace)
-		if err != nil {
+		if err := ingest.DetachMemoryNamespace(db, namespace); err != nil {
+			receipt := &ingest.MemoryScanReceipt{
+				SourcePath: workspace, EngineVersion: Version, Namespace: namespace, Failed: 1,
+			}
+			scanID, beginErr := ingest.BeginMemoryScan(db, workspace, Version, namespace)
+			if beginErr == nil {
+				_ = ingest.FailMemoryScan(db, scanID, "failed", receipt)
+			} else {
+				_ = ingest.FailMemoryScan(db, "", "failed", receipt)
+			}
 			return fatalf(errw, "crawl memory rebuild: %s", err)
 		}
-		if err := ingest.RebuildMemoryProjection(db, namespace); err != nil {
-			return fatalf(errw, "crawl memory rebuild: %s", err)
-		}
-		// After a successful staging delete, prior live hashes for classify are empty.
+		detached = true
 		before = map[string]string{}
 	}
 
 	scanID, err := ingest.BeginMemoryScan(db, workspace, Version, namespace)
 	if err != nil {
-		if snap != nil {
-			_ = ingest.RestoreMemoryNamespace(db, snap)
+		abortRebuild()
+		if bools["rebuild"] {
+			receipt := &ingest.MemoryScanReceipt{
+				SourcePath: workspace, EngineVersion: Version, Namespace: namespace, Failed: 1,
+			}
+			_ = ingest.FailMemoryScan(db, "", "failed", receipt)
 		}
 		return fatalf(errw, "crawl memory: %s", err)
 	}
@@ -211,9 +229,7 @@ func cmdCrawlMemory(args []string, out, errw io.Writer) int {
 		if errMsg == nil {
 			errMsg = gen.err
 		}
-		if snap != nil {
-			_ = ingest.RestoreMemoryNamespace(db, snap)
-		}
+		abortRebuild()
 		receipt := &ingest.MemoryScanReceipt{
 			SourcePath: workspace, EngineVersion: Version, Namespace: namespace,
 			Skipped: skipped, Failed: failed + 1,
@@ -245,11 +261,17 @@ func cmdCrawlMemory(args []string, out, errw io.Writer) int {
 		Warnings:      append(generated.Warnings, result.Warnings...),
 	}
 	if err := ingest.CompleteMemoryScan(db, scanID, observedForReconcile(classified), receipt); err != nil {
-		if snap != nil {
-			_ = ingest.RestoreMemoryNamespace(db, snap)
-		}
+		abortRebuild()
 		_ = ingest.FailMemoryScan(db, scanID, "failed", receipt)
 		return fatalf(errw, "crawl memory: %s", err)
+	}
+	if detached {
+		if err := ingest.FinalizeMemoryRebuild(db, namespace); err != nil {
+			abortRebuild()
+			_ = ingest.FailMemoryScan(db, scanID, "failed", receipt)
+			return fatalf(errw, "crawl memory rebuild finalize: %s", err)
+		}
+		detached = false
 	}
 	_ = archive.Checkpoint(db, paths.DBPath)
 
@@ -294,8 +316,6 @@ func observedForReconcile(cards []ingest.ObservedCard) []ingest.ObservedCard {
 		if card.ExternalID == "" {
 			continue
 		}
-		// Skipped/failed cards that still exist keep their prior live row by
-		// remaining in the completed-scan manifest; they are not live imports.
 		out = append(out, card)
 	}
 	return out

--- a/engines/evidence-ledger/internal/app/memory.go
+++ b/engines/evidence-ledger/internal/app/memory.go
@@ -46,10 +46,12 @@ func cmdCrawlMemory(args []string, out, errw io.Writer) int {
 				failed++
 			}
 		}
+		ns, _ := memory.ResolveNamespace(workspace)
 		writeJSON(out, map[string]any{
 			"source_kind":        ingest.MemorySourceKind,
 			"capability":         ingest.MemoryCapability,
 			"engine_version":     Version,
+			"memory_namespace":   ns,
 			"dry_run":            true,
 			"generated_records":  generated.Records,
 			"canonical_count":    countMemoryRecords(outcomes),
@@ -67,31 +69,82 @@ func cmdCrawlMemory(args []string, out, errw io.Writer) int {
 	}
 	defer db.Close()
 
-	if bools["rebuild"] {
-		if err := ingest.RebuildMemoryProjection(db); err != nil {
-			return fatalf(errw, "crawl memory rebuild: %s", err)
-		}
-	}
-
-	before, err := ingest.PriorLiveHashes(db)
-	if err != nil {
-		return fatalf(errw, "crawl memory: %s", err)
-	}
-
-	scanID, err := ingest.BeginMemoryScan(db, workspace, Version)
-	if err != nil {
-		return fatalf(errw, "crawl memory: %s", err)
-	}
-
+	// Validate/walk before any destructive rebuild so a missing root cannot
+	// wipe the prior projection.
 	opts := sources.Options{Limit: limit}
 	if bools["full"] || bools["rebuild"] {
 		opts.Skip = func(string, int64, string) bool { return false }
 	}
 	outcomes, generated, walkErr := memory.Walk(workspace, opts)
+
+	namespace := ""
+	if walkErr == nil {
+		namespace, err = memory.ResolveNamespace(workspace)
+		if err != nil {
+			return fatalf(errw, "crawl memory: %s", err)
+		}
+	} else {
+		// Best-effort namespace for failure receipts when the root still has the file.
+		namespace, _ = memory.ResolveNamespace(workspace)
+		if namespace == "" {
+			namespace = ingest.LastMemoryNamespace(db)
+		}
+	}
+
 	if walkErr != nil {
-		receipt := &ingest.MemoryScanReceipt{SourcePath: workspace, EngineVersion: Version, Failed: 1}
-		_ = ingest.FailMemoryScan(db, scanID, "failed", receipt)
+		scanID := ""
+		var beginErr error
+		if namespace != "" {
+			scanID, beginErr = ingest.BeginMemoryScan(db, workspace, Version, namespace)
+		}
+		receipt := &ingest.MemoryScanReceipt{
+			SourcePath: workspace, EngineVersion: Version, Namespace: namespace, Failed: 1,
+		}
+		if beginErr == nil && scanID != "" {
+			_ = ingest.FailMemoryScan(db, scanID, "failed", receipt)
+		} else if namespace != "" {
+			// Still mark prior completed snapshot stale even if begin failed.
+			_ = ingest.FailMemoryScan(db, "", "failed", receipt)
+		}
 		return fatalf(errw, "crawl memory: %s", walkErr)
+	}
+
+	if dups := memory.DuplicateExplicitIDs(outcomes); len(dups) > 0 {
+		scanID, beginErr := ingest.BeginMemoryScan(db, workspace, Version, namespace)
+		receipt := &ingest.MemoryScanReceipt{
+			SourcePath: workspace, EngineVersion: Version, Namespace: namespace,
+			Failed: 1, Warnings: append([]string{}, generated.Warnings...),
+		}
+		if beginErr == nil {
+			_ = ingest.FailMemoryScan(db, scanID, "failed", receipt)
+		}
+		return fatalf(errw, "crawl memory: duplicate explicit id(s) %v; refusing reconciliation", dups)
+	}
+
+	before, err := ingest.PriorLiveHashes(db, namespace)
+	if err != nil {
+		return fatalf(errw, "crawl memory: %s", err)
+	}
+
+	var snap *ingest.MemoryNamespaceSnapshot
+	if bools["rebuild"] {
+		snap, err = ingest.SnapshotMemoryNamespace(db, namespace)
+		if err != nil {
+			return fatalf(errw, "crawl memory rebuild: %s", err)
+		}
+		if err := ingest.RebuildMemoryProjection(db, namespace); err != nil {
+			return fatalf(errw, "crawl memory rebuild: %s", err)
+		}
+		// After a successful staging delete, prior live hashes for classify are empty.
+		before = map[string]string{}
+	}
+
+	scanID, err := ingest.BeginMemoryScan(db, workspace, Version, namespace)
+	if err != nil {
+		if snap != nil {
+			_ = ingest.RestoreMemoryNamespace(db, snap)
+		}
+		return fatalf(errw, "crawl memory: %s", err)
 	}
 
 	skipped, failed := 0, 0
@@ -158,8 +211,11 @@ func cmdCrawlMemory(args []string, out, errw io.Writer) int {
 		if errMsg == nil {
 			errMsg = gen.err
 		}
+		if snap != nil {
+			_ = ingest.RestoreMemoryNamespace(db, snap)
+		}
 		receipt := &ingest.MemoryScanReceipt{
-			SourcePath: workspace, EngineVersion: Version,
+			SourcePath: workspace, EngineVersion: Version, Namespace: namespace,
 			Skipped: skipped, Failed: failed + 1,
 			Warnings: append(generated.Warnings, result.Warnings...),
 		}
@@ -176,10 +232,10 @@ func cmdCrawlMemory(args []string, out, errw io.Writer) int {
 		})
 	}
 	created, updated, unchanged, classified := ingest.ClassifyMemoryOutcomes(before, observed)
-	_ = classified
 
 	receipt := &ingest.MemoryScanReceipt{
 		SourcePath:    workspace,
+		Namespace:     namespace,
 		EngineVersion: Version,
 		Created:       created,
 		Updated:       updated,
@@ -189,41 +245,45 @@ func cmdCrawlMemory(args []string, out, errw io.Writer) int {
 		Warnings:      append(generated.Warnings, result.Warnings...),
 	}
 	if err := ingest.CompleteMemoryScan(db, scanID, observedForReconcile(classified), receipt); err != nil {
+		if snap != nil {
+			_ = ingest.RestoreMemoryNamespace(db, snap)
+		}
 		_ = ingest.FailMemoryScan(db, scanID, "failed", receipt)
 		return fatalf(errw, "crawl memory: %s", err)
 	}
 	_ = archive.Checkpoint(db, paths.DBPath)
 
-	health, _ := ingest.CollectMemoryHealth(db, Version)
+	health, _ := ingest.CollectMemoryHealth(db, Version, namespace)
 	payload := map[string]any{
-		"scan_id":               receipt.ScanID,
-		"source_kind":           ingest.MemorySourceKind,
-		"capability":            ingest.MemoryCapability,
-		"engine_version":        Version,
-		"status":                receipt.Status,
-		"stale":                 receipt.Stale,
-		"partial":               receipt.Partial,
-		"created":               receipt.Created,
-		"updated":               receipt.Updated,
-		"unchanged":             receipt.Unchanged,
-		"removed":               receipt.Removed,
-		"skipped":               receipt.Skipped,
-		"failed":                receipt.Failed,
-		"canonical_count":       receipt.CanonicalCount,
-		"live_count":            receipt.LiveCount,
-		"hash_divergence":       receipt.HashDivergence,
-		"unresolved_relations":  receipt.UnresolvedRelations,
-		"malformed_skipped":     receipt.MalformedSkipped,
-		"inserted_items":        result.Inserted,
-		"warnings":              receipt.Warnings,
-		"memory_health":         health,
-		"rebuild":               bools["rebuild"],
+		"scan_id":              receipt.ScanID,
+		"source_kind":          ingest.MemorySourceKind,
+		"capability":           ingest.MemoryCapability,
+		"engine_version":       Version,
+		"memory_namespace":     namespace,
+		"status":               receipt.Status,
+		"stale":                receipt.Stale,
+		"partial":              receipt.Partial,
+		"created":              receipt.Created,
+		"updated":              receipt.Updated,
+		"unchanged":            receipt.Unchanged,
+		"removed":              receipt.Removed,
+		"skipped":              receipt.Skipped,
+		"failed":               receipt.Failed,
+		"canonical_count":      receipt.CanonicalCount,
+		"live_count":           receipt.LiveCount,
+		"hash_divergence":      receipt.HashDivergence,
+		"unresolved_relations": receipt.UnresolvedRelations,
+		"malformed_skipped":    receipt.MalformedSkipped,
+		"inserted_items":       result.Inserted,
+		"warnings":             receipt.Warnings,
+		"memory_health":        health,
+		"rebuild":              bools["rebuild"],
 	}
 	if bools["json"] {
 		writeJSON(out, payload)
 	} else {
-		fmt.Fprintf(out, "scan=%s created=%d updated=%d unchanged=%d removed=%d skipped=%d failed=%d live=%d\n",
-			receipt.ScanID, receipt.Created, receipt.Updated, receipt.Unchanged, receipt.Removed, receipt.Skipped, receipt.Failed, receipt.LiveCount)
+		fmt.Fprintf(out, "scan=%s namespace=%s created=%d updated=%d unchanged=%d removed=%d skipped=%d failed=%d live=%d\n",
+			receipt.ScanID, namespace, receipt.Created, receipt.Updated, receipt.Unchanged, receipt.Removed, receipt.Skipped, receipt.Failed, receipt.LiveCount)
 	}
 	return 0
 }

--- a/engines/evidence-ledger/internal/app/memory.go
+++ b/engines/evidence-ledger/internal/app/memory.go
@@ -128,6 +128,14 @@ func cmdCrawlMemory(args []string, out, errw io.Writer) int {
 		return fatalf(errw, "crawl memory: %s", err)
 	}
 
+	// Begin the scan before a rebuild detaches the live projection. This row is
+	// the durable journal that lets recovery mark a crash between detach and
+	// import as interrupted instead of silently restoring a healthy snapshot.
+	scanID, err := ingest.BeginMemoryScan(db, workspace, Version, namespace)
+	if err != nil {
+		return fatalf(errw, "crawl memory: %s", err)
+	}
+
 	detached := false
 	abortRebuild := func() {
 		if detached {
@@ -141,28 +149,11 @@ func cmdCrawlMemory(args []string, out, errw io.Writer) int {
 			receipt := &ingest.MemoryScanReceipt{
 				SourcePath: workspace, EngineVersion: Version, Namespace: namespace, Failed: 1,
 			}
-			scanID, beginErr := ingest.BeginMemoryScan(db, workspace, Version, namespace)
-			if beginErr == nil {
-				_ = ingest.FailMemoryScan(db, scanID, "failed", receipt)
-			} else {
-				_ = ingest.FailMemoryScan(db, "", "failed", receipt)
-			}
+			_ = ingest.FailMemoryScan(db, scanID, "failed", receipt)
 			return fatalf(errw, "crawl memory rebuild: %s", err)
 		}
 		detached = true
 		before = map[string]string{}
-	}
-
-	scanID, err := ingest.BeginMemoryScan(db, workspace, Version, namespace)
-	if err != nil {
-		abortRebuild()
-		if bools["rebuild"] {
-			receipt := &ingest.MemoryScanReceipt{
-				SourcePath: workspace, EngineVersion: Version, Namespace: namespace, Failed: 1,
-			}
-			_ = ingest.FailMemoryScan(db, "", "failed", receipt)
-		}
-		return fatalf(errw, "crawl memory: %s", err)
 	}
 
 	skipped, failed := 0, 0

--- a/engines/evidence-ledger/internal/app/memory.go
+++ b/engines/evidence-ledger/internal/app/memory.go
@@ -86,7 +86,7 @@ func cmdCrawlMemory(args []string, out, errw io.Writer) int {
 	} else {
 		namespace, _ = memory.ResolveNamespace(workspace)
 		if namespace == "" {
-			namespace = ingest.LastMemoryNamespace(db)
+			namespace = ingest.LastMemoryNamespace(db, workspace)
 		}
 	}
 

--- a/engines/evidence-ledger/internal/app/memory_test.go
+++ b/engines/evidence-ledger/internal/app/memory_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/escoffier-labs/miseledger/internal/ingest"
 )
 
+const testMemoryNamespace = "memory-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+
 func TestCrawlMemorySlice1a(t *testing.T) {
 	withTempHome(t)
 	runOK(t, "init")
@@ -24,6 +26,9 @@ func TestCrawlMemorySlice1a(t *testing.T) {
 	first := runJSON(t, "crawl", "memory", ws, "--json")
 	if first["status"] != "completed" {
 		t.Fatalf("first crawl = %v", first)
+	}
+	if first["memory_namespace"] != testMemoryNamespace {
+		t.Fatalf("namespace = %v", first["memory_namespace"])
 	}
 	if first["created"].(float64) < 1 {
 		t.Fatalf("expected creates: %v", first)
@@ -104,6 +109,7 @@ func TestCrawlMemoryExplicitRenameAndPathRemoveCreate(t *testing.T) {
 	withTempHome(t)
 	runOK(t, "init")
 	ws := t.TempDir()
+	writeTestNamespace(t, ws, testMemoryNamespace)
 	cards := filepath.Join(ws, "memory", "cards")
 	if err := os.MkdirAll(cards, 0o755); err != nil {
 		t.Fatal(err)
@@ -198,41 +204,14 @@ where s.kind = ? and i.kind = 'memory_card' and i.tombstoned_at is null`, ingest
 	db = openTestDB(t)
 	defer db.Close()
 
-	var failedScanID, status string
-	var failedCount, scanStale int
+	var liveAfter int
 	if err := db.QueryRow(`
-select id, status, failed_count, stale from source_scan_runs
-where source_kind = ? order by started_at desc limit 1`, ingest.MemorySourceKind).Scan(&failedScanID, &status, &failedCount, &scanStale); err != nil {
+select count(*) from items i join sources s on s.id = i.source_id
+where s.kind = ? and i.kind = 'memory_card' and i.tombstoned_at is null`, ingest.MemorySourceKind).Scan(&liveAfter); err != nil {
 		t.Fatal(err)
 	}
-	if status != "failed" {
-		t.Fatalf("latest scan status = %q", status)
-	}
-	if failedScanID == "" || failedScanID == completedScanID {
-		t.Fatalf("failed scan_id = %q prior completed = %q", failedScanID, completedScanID)
-	}
-	if failedCount < 1 {
-		t.Fatalf("failed_count = %d", failedCount)
-	}
-	if scanStale != 1 {
-		t.Fatalf("failed scan stale = %d", scanStale)
-	}
-
-	var priorCompleted int
-	if err := db.QueryRow(`
-select count(*) from source_scan_runs
-where id = ? and status = 'completed'`, completedScanID).Scan(&priorCompleted); err != nil {
-		t.Fatal(err)
-	}
-	if priorCompleted != 1 {
-		t.Fatalf("prior completed snapshot missing for %s", completedScanID)
-	}
-	var priorStale int
-	if err := db.QueryRow(`select stale from source_scan_runs where id = ?`, completedScanID).Scan(&priorStale); err != nil {
-		t.Fatal(err)
-	}
-	if priorStale != 1 {
-		t.Fatalf("prior completed snapshot stale = %d", priorStale)
+	if liveAfter != liveBefore {
+		t.Fatalf("live count changed: before=%d after=%d", liveBefore, liveAfter)
 	}
 
 	var tombstoned int
@@ -244,17 +223,8 @@ where s.kind = ? and i.tombstoned_at is not null`, ingest.MemorySourceKind).Scan
 	if tombstoned != 0 {
 		t.Fatalf("failed crawl tombstoned %d rows", tombstoned)
 	}
-	var liveAfter int
-	if err := db.QueryRow(`
-select count(*) from items i join sources s on s.id = i.source_id
-where s.kind = ? and i.kind = 'memory_card' and i.tombstoned_at is null`, ingest.MemorySourceKind).Scan(&liveAfter); err != nil {
-		t.Fatal(err)
-	}
-	if liveAfter != liveBefore {
-		t.Fatalf("live count changed: before=%d after=%d", liveBefore, liveAfter)
-	}
 
-	health, err := ingest.CollectMemoryHealth(db, Version)
+	health, err := ingest.CollectMemoryHealth(db, Version, testMemoryNamespace)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -264,24 +234,13 @@ where s.kind = ? and i.kind = 'memory_card' and i.tombstoned_at is null`, ingest
 	if health.LastCompletedScanID != completedScanID {
 		t.Fatalf("last_completed_scan_id = %q want %q", health.LastCompletedScanID, completedScanID)
 	}
-
-	statusJSON := runJSON(t, "status", "--json")
-	memHealth, _ := statusJSON["memory_health"].(map[string]any)
-	if memHealth == nil {
-		t.Fatalf("status missing memory_health: %v", statusJSON)
-	}
-	if memHealth["stale"] != true || memHealth["partial"] != true {
-		t.Fatalf("status memory_health = %v", memHealth)
-	}
-	if memHealth["last_completed_scan_id"] != completedScanID {
-		t.Fatalf("status last_completed_scan_id = %v", memHealth["last_completed_scan_id"])
-	}
 }
 
 func TestCrawlMemoryInterruptedDoesNotTombstone(t *testing.T) {
 	withTempHome(t)
 	runOK(t, "init")
 	ws := t.TempDir()
+	writeTestNamespace(t, ws, testMemoryNamespace)
 	cards := filepath.Join(ws, "memory", "cards")
 	if err := os.MkdirAll(cards, 0o755); err != nil {
 		t.Fatal(err)
@@ -296,11 +255,11 @@ func TestCrawlMemoryInterruptedDoesNotTombstone(t *testing.T) {
 
 	db := openTestDB(t)
 	defer db.Close()
-	scanID, err := ingest.BeginMemoryScan(db, ws, Version)
+	scanID, err := ingest.BeginMemoryScan(db, ws, Version, testMemoryNamespace)
 	if err != nil {
 		t.Fatal(err)
 	}
-	receipt := &ingest.MemoryScanReceipt{SourcePath: ws, EngineVersion: Version, Failed: 1}
+	receipt := &ingest.MemoryScanReceipt{SourcePath: ws, EngineVersion: Version, Namespace: testMemoryNamespace, Failed: 1}
 	if err := ingest.FailMemoryScan(db, scanID, "interrupted", receipt); err != nil {
 		t.Fatal(err)
 	}
@@ -320,7 +279,7 @@ where s.kind = ? and i.tombstoned_at is not null`, ingest.MemorySourceKind).Scan
 	if stale != 1 {
 		t.Fatalf("prior completed snapshot stale count = %d", stale)
 	}
-	health, err := ingest.CollectMemoryHealth(db, Version)
+	health, err := ingest.CollectMemoryHealth(db, Version, testMemoryNamespace)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -335,7 +294,7 @@ func TestCrawlMemoryRebuildDeterminism(t *testing.T) {
 	ws := copyEngineMemoryFixtures(t)
 	runJSON(t, "crawl", "memory", ws, "--json")
 	db := openTestDB(t)
-	before, err := ingest.LiveMemoryProjection(db)
+	before, err := ingest.LiveMemoryProjection(db, testMemoryNamespace)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -347,7 +306,7 @@ func TestCrawlMemoryRebuildDeterminism(t *testing.T) {
 	}
 	db = openTestDB(t)
 	defer db.Close()
-	after, err := ingest.LiveMemoryProjection(db)
+	after, err := ingest.LiveMemoryProjection(db, testMemoryNamespace)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -361,10 +320,329 @@ func TestCrawlMemoryRebuildDeterminism(t *testing.T) {
 	}
 }
 
+func TestCrawlMemoryFailedRebuildPreservesPriorProjection(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+	ws := copyEngineMemoryFixtures(t)
+	completed := runJSON(t, "crawl", "memory", ws, "--json")
+	completedScanID, _ := completed["scan_id"].(string)
+	db := openTestDB(t)
+	before, err := ingest.LiveMemoryProjection(db, testMemoryNamespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.Close()
+	if len(before) < 1 {
+		t.Fatal("expected prior live projection")
+	}
+
+	// Remove workspace after a completed scan so rebuild walk fails; prior
+	// projection must remain intact (failure-preserving rebuild).
+	if err := os.RemoveAll(ws); err != nil {
+		t.Fatal(err)
+	}
+	code, _, stderr := run("crawl", "memory", ws, "--rebuild", "--json")
+	if code == 0 {
+		t.Fatalf("expected failed rebuild, stderr=%s", stderr)
+	}
+
+	db = openTestDB(t)
+	defer db.Close()
+	after, err := ingest.LiveMemoryProjection(db, testMemoryNamespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after) != len(before) {
+		t.Fatalf("live ids changed after failed rebuild: before=%d after=%d", len(before), len(after))
+	}
+	for id, hash := range before {
+		if after[id] != hash {
+			t.Fatalf("hash changed for %s", id)
+		}
+	}
+	var priorCompleted int
+	if err := db.QueryRow(`select count(*) from source_scan_runs where id = ? and status = 'completed'`, completedScanID).Scan(&priorCompleted); err != nil {
+		t.Fatal(err)
+	}
+	if priorCompleted != 1 {
+		t.Fatalf("completed-scan record missing after failed rebuild")
+	}
+	health, err := ingest.CollectMemoryHealth(db, Version, testMemoryNamespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !health.Stale || !health.Partial {
+		t.Fatalf("health after failed rebuild = %+v", health)
+	}
+	if health.LastCompletedScanID != completedScanID {
+		t.Fatalf("last_completed_scan_id = %q want %q", health.LastCompletedScanID, completedScanID)
+	}
+}
+
+func TestCrawlMemoryTwoRootNamespaceIsolation(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+	nsA := "memory-11111111-2222-4333-8444-aaaaaaaaaaaa"
+	nsB := "memory-99999999-8888-4777-8666-bbbbbbbbbbbb"
+	wsA := t.TempDir()
+	wsB := t.TempDir()
+	writeTestNamespace(t, wsA, nsA)
+	writeTestNamespace(t, wsB, nsB)
+	cardID := "card-shared0-1111-4222-8333-444444444444"
+	for _, ws := range []string{wsA, wsB} {
+		cards := filepath.Join(ws, "memory", "cards")
+		if err := os.MkdirAll(cards, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		body := "---\nid: " + cardID + "\ntopic: shared\n---\n\n# Shared\nbody for " + filepath.Base(ws) + "\n"
+		if err := os.WriteFile(filepath.Join(cards, "shared.md"), []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	runJSON(t, "crawl", "memory", wsA, "--json")
+	runJSON(t, "crawl", "memory", wsB, "--json")
+
+	db := openTestDB(t)
+	defer db.Close()
+	liveA, err := ingest.LiveMemoryProjection(db, nsA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	liveB, err := ingest.LiveMemoryProjection(db, nsB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if liveA[cardID] == "" || liveB[cardID] == "" {
+		t.Fatalf("both namespaces should have the shared card id: A=%v B=%v", liveA, liveB)
+	}
+	if liveA[cardID] == liveB[cardID] {
+		t.Fatalf("distinct roots should keep distinct content hashes for same card id")
+	}
+
+	// Reconcile removal in A must not tombstone B.
+	if err := os.Remove(filepath.Join(wsA, "memory", "cards", "shared.md")); err != nil {
+		t.Fatal(err)
+	}
+	out := runJSON(t, "crawl", "memory", wsA, "--json")
+	if out["removed"].(float64) < 1 {
+		t.Fatalf("expected removal in A: %v", out)
+	}
+	liveA, _ = ingest.LiveMemoryProjection(db, nsA)
+	liveB, _ = ingest.LiveMemoryProjection(db, nsB)
+	if _, ok := liveA[cardID]; ok {
+		t.Fatal("A should have removed shared card")
+	}
+	if liveB[cardID] == "" {
+		t.Fatal("B must remain isolated from A's reconciliation")
+	}
+}
+
+func TestCrawlMemoryDuplicateExplicitIDFailsBeforeReconcile(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+	ws := t.TempDir()
+	writeTestNamespace(t, ws, testMemoryNamespace)
+	cards := filepath.Join(ws, "memory", "cards")
+	if err := os.MkdirAll(cards, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "---\nid: card-dup00000-1111-4222-8333-444444444444\ntopic: d\n---\n\n# Dup\n"
+	if err := os.WriteFile(filepath.Join(cards, "one.md"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cards, "two.md"), []byte(body+"extra\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	code, _, stderr := run("crawl", "memory", ws, "--json")
+	if code == 0 {
+		t.Fatal("expected duplicate explicit id failure")
+	}
+	if !strings.Contains(stderr, "duplicate explicit id") {
+		t.Fatalf("stderr=%q", stderr)
+	}
+	db := openTestDB(t)
+	defer db.Close()
+	var live int
+	if err := db.QueryRow(`
+select count(*) from items i join sources s on s.id = i.source_id
+where s.kind = ? and i.kind = 'memory_card'`, ingest.MemorySourceKind).Scan(&live); err != nil {
+		t.Fatal(err)
+	}
+	if live != 0 {
+		t.Fatalf("duplicate id scan must not import rows, got %d", live)
+	}
+	var tombstoned int
+	if err := db.QueryRow(`select count(*) from items where tombstoned_at is not null`).Scan(&tombstoned); err != nil {
+		t.Fatal(err)
+	}
+	if tombstoned != 0 {
+		t.Fatalf("duplicate id failure must not reconcile/tombstone, got %d", tombstoned)
+	}
+}
+
+func TestCrawlMemoryMoveDeleteReplay(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+	ws := t.TempDir()
+	writeTestNamespace(t, ws, testMemoryNamespace)
+	cards := filepath.Join(ws, "memory", "cards")
+	subdir := filepath.Join(cards, "nested")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(cards, "move-me.md")
+	if err := os.WriteFile(path, []byte("---\nid: card-move000-1111-4222-8333-444444444444\ntopic: move\n---\n\n# Move\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runJSON(t, "crawl", "memory", ws, "--json")
+
+	// Cross-directory move with explicit id preserves identity.
+	dest := filepath.Join(subdir, "moved.md")
+	if err := os.Rename(path, dest); err != nil {
+		t.Fatal(err)
+	}
+	moved := runJSON(t, "crawl", "memory", ws, "--json")
+	if moved["removed"].(float64) != 0 {
+		t.Fatalf("explicit move must not remove identity: %v", moved)
+	}
+
+	// Pure deletion.
+	if err := os.Remove(dest); err != nil {
+		t.Fatal(err)
+	}
+	deleted := runJSON(t, "crawl", "memory", ws, "--json")
+	if deleted["removed"].(float64) < 1 {
+		t.Fatalf("delete should remove: %v", deleted)
+	}
+
+	// Interrupted-then-successful replay: fail a scan, then complete again.
+	db := openTestDB(t)
+	scanID, err := ingest.BeginMemoryScan(db, ws, Version, testMemoryNamespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ingest.FailMemoryScan(db, scanID, "interrupted", &ingest.MemoryScanReceipt{
+		SourcePath: ws, Namespace: testMemoryNamespace, EngineVersion: Version, Failed: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	db.Close()
+	if err := os.WriteFile(filepath.Join(cards, "replay.md"), []byte("---\nid: card-replay0-1111-4222-8333-444444444444\ntopic: replay\n---\n\n# Replay\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	replay := runJSON(t, "crawl", "memory", ws, "--json")
+	if replay["status"] != "completed" || replay["created"].(float64) < 1 {
+		t.Fatalf("replay = %v", replay)
+	}
+}
+
+func TestCrawlMemoryUnresolvedRelationsPostResolutionAgree(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+	ws := t.TempDir()
+	writeTestNamespace(t, ws, testMemoryNamespace)
+	cards := filepath.Join(ws, "memory", "cards")
+	if err := os.MkdirAll(cards, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := strings.Join([]string{
+		"---",
+		"id: card-rel00000-1111-4222-8333-444444444444",
+		"topic: rel",
+		"derived_from: receipt:handoff-demo-1",
+		"derived_from_target_source: brigade",
+		"derived_from_target_collection: brigade:receipts",
+		"---",
+		"",
+		"# Rel",
+		"",
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(cards, "rel.md"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	first := runJSON(t, "crawl", "memory", ws, "--json")
+	unresolvedFirst := int(first["unresolved_relations"].(float64))
+	if unresolvedFirst < 1 {
+		t.Fatalf("expected unresolved before receipt import: %v", first)
+	}
+	health1, _ := first["memory_health"].(map[string]any)
+	if int(health1["unresolved_relations"].(float64)) != unresolvedFirst {
+		t.Fatalf("crawl/health disagree: crawl=%d health=%v", unresolvedFirst, health1["unresolved_relations"])
+	}
+
+	receiptFixture := repoPath(t, "testdata/adapters/memory/brigade-receipt.fixture.jsonl")
+	runOK(t, "import", "adapter", receiptFixture, "--json")
+	second := runJSON(t, "crawl", "memory", ws, "--json")
+	unresolvedSecond := int(second["unresolved_relations"].(float64))
+	if unresolvedSecond >= unresolvedFirst {
+		t.Fatalf("re-crawl should resolve newly available target: first=%d second=%d %v", unresolvedFirst, unresolvedSecond, second)
+	}
+	health2, _ := second["memory_health"].(map[string]any)
+	if int(health2["unresolved_relations"].(float64)) != unresolvedSecond {
+		t.Fatalf("crawl/health disagree after resolve: crawl=%d health=%v", unresolvedSecond, health2["unresolved_relations"])
+	}
+	db := openTestDB(t)
+	defer db.Close()
+	var stored int
+	if err := db.QueryRow(`select unresolved_relation_count from source_scan_runs where id = ?`, second["scan_id"]).Scan(&stored); err != nil {
+		t.Fatal(err)
+	}
+	if stored != unresolvedSecond {
+		t.Fatalf("scan record unresolved=%d crawl=%d", stored, unresolvedSecond)
+	}
+}
+
+func TestCrawlMemoryTransactionFailureCreatesNoTombstones(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+	ws := t.TempDir()
+	writeTestNamespace(t, ws, testMemoryNamespace)
+	cards := filepath.Join(ws, "memory", "cards")
+	if err := os.MkdirAll(cards, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cards, "keep.md"), []byte("---\nid: card-tx000000-1111-4222-8333-444444444444\ntopic: keep\n---\n\n# Keep\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runJSON(t, "crawl", "memory", ws, "--json")
+
+	db := openTestDB(t)
+	defer db.Close()
+	// Simulate observation-then-failure before reconciliation commit by failing
+	// a scan after Begin without CompleteMemoryScan.
+	scanID, err := ingest.BeginMemoryScan(db, ws, Version, testMemoryNamespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ingest.FailMemoryScan(db, scanID, "failed", &ingest.MemoryScanReceipt{
+		SourcePath: ws, Namespace: testMemoryNamespace, EngineVersion: Version, Failed: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var tombstoned int
+	if err := db.QueryRow(`
+select count(*) from items i join sources s on s.id = i.source_id
+where s.kind = ? and i.tombstoned_at is not null`, ingest.MemorySourceKind).Scan(&tombstoned); err != nil {
+		t.Fatal(err)
+	}
+	if tombstoned != 0 {
+		t.Fatalf("transaction failure created tombstones: %d", tombstoned)
+	}
+	live, err := ingest.LiveMemoryProjection(db, testMemoryNamespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if live["card-tx000000-1111-4222-8333-444444444444"] == "" {
+		t.Fatal("prior live id must survive transaction failure")
+	}
+}
+
 func TestMemoryCardRetentionSafety(t *testing.T) {
 	withTempHome(t)
 	runOK(t, "init")
 	ws := t.TempDir()
+	writeTestNamespace(t, ws, testMemoryNamespace)
 	cards := filepath.Join(ws, "memory", "cards")
 	if err := os.MkdirAll(cards, 0o755); err != nil {
 		t.Fatal(err)
@@ -413,10 +691,73 @@ func TestQualifiedRelationAdapterCompatibility(t *testing.T) {
 	}
 }
 
+func TestMemoryScanReceiptJSONShape(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+	ws := t.TempDir()
+	writeTestNamespace(t, ws, testMemoryNamespace)
+	cards := filepath.Join(ws, "memory", "cards")
+	if err := os.MkdirAll(cards, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cards, "only.md"), []byte("---\nid: card-receipt-000-4000-8000-000000000001\ntopic: only\n---\n\n# Only\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	raw := runJSON(t, "crawl", "memory", ws, "--json")
+	for _, key := range []string{"scan_id", "created", "updated", "unchanged", "removed", "skipped", "failed", "capability", "engine_version", "memory_namespace", "unresolved_relations"} {
+		if _, ok := raw[key]; !ok {
+			t.Fatalf("receipt missing %s: %v", key, raw)
+		}
+	}
+	b, _ := json.Marshal(raw)
+	if !strings.Contains(string(b), ingest.MemoryCapability) {
+		t.Fatalf("capability missing from %s", b)
+	}
+}
+
+func TestLegacyMemoryCardsScopedRebuildRule(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+	db := openTestDB(t)
+	defer db.Close()
+	// Seed a legacy memory:cards row and ensure namespaced rebuild does not touch it.
+	legacyJSONL := `{"schema":"miseledger.adapter.v1","source":{"kind":"brigade-memory","name":"Memory","version":"1.0.0"},"collection":{"external_id":"memory:cards","kind":"memory_cards","name":"cards"},"item":{"external_id":"card-legacy0-1111-4222-8333-444444444444","kind":"memory_card","created_at":"2026-01-01T00:00:00Z","text":"legacy"},"relations":[],"raw":{"format":"markdown","path":"memory/cards/legacy.md","ordinal":1}}` + "\n"
+	dir := t.TempDir()
+	path := filepath.Join(dir, "legacy.jsonl")
+	if err := os.WriteFile(path, []byte(legacyJSONL), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	db.Close()
+	runOK(t, "import", "adapter", path, "--json")
+
+	ws := t.TempDir()
+	writeTestNamespace(t, ws, testMemoryNamespace)
+	cards := filepath.Join(ws, "memory", "cards")
+	if err := os.MkdirAll(cards, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cards, "new.md"), []byte("---\nid: card-new00000-1111-4222-8333-444444444444\ntopic: new\n---\n\n# New\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runJSON(t, "crawl", "memory", ws, "--json")
+	runJSON(t, "crawl", "memory", ws, "--rebuild", "--json")
+
+	db = openTestDB(t)
+	defer db.Close()
+	legacy, err := ingest.LegacyMemoryExternalIDs(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if legacy["card-legacy0-1111-4222-8333-444444444444"] == "" {
+		t.Fatal("scoped rebuild must leave legacy memory:cards rows intact")
+	}
+}
+
 func copyEngineMemoryFixtures(t *testing.T) string {
 	t.Helper()
 	src := repoPath(t, "testdata/adapters/memory/cards")
 	ws := t.TempDir()
+	writeTestNamespace(t, ws, testMemoryNamespace)
 	dst := filepath.Join(ws, "memory", "cards")
 	if err := os.MkdirAll(dst, 0o755); err != nil {
 		t.Fatal(err)
@@ -437,6 +778,17 @@ func copyEngineMemoryFixtures(t *testing.T) string {
 	return ws
 }
 
+func writeTestNamespace(t *testing.T, ws, ns string) {
+	t.Helper()
+	dir := filepath.Join(ws, "memory")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "NAMESPACE"), []byte(ns+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func openTestDB(t *testing.T) *sql.DB {
 	t.Helper()
 	paths := ResolvePaths()
@@ -445,27 +797,4 @@ func openTestDB(t *testing.T) *sql.DB {
 		t.Fatal(err)
 	}
 	return db
-}
-
-func TestMemoryScanReceiptJSONShape(t *testing.T) {
-	withTempHome(t)
-	runOK(t, "init")
-	ws := t.TempDir()
-	cards := filepath.Join(ws, "memory", "cards")
-	if err := os.MkdirAll(cards, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(cards, "only.md"), []byte("---\nid: card-receipt-000-4000-8000-000000000001\ntopic: only\n---\n\n# Only\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	raw := runJSON(t, "crawl", "memory", ws, "--json")
-	for _, key := range []string{"scan_id", "created", "updated", "unchanged", "removed", "skipped", "failed", "capability", "engine_version"} {
-		if _, ok := raw[key]; !ok {
-			t.Fatalf("receipt missing %s: %v", key, raw)
-		}
-	}
-	b, _ := json.Marshal(raw)
-	if !strings.Contains(string(b), ingest.MemoryCapability) {
-		t.Fatalf("capability missing from %s", b)
-	}
 }

--- a/engines/evidence-ledger/internal/app/memory_test.go
+++ b/engines/evidence-ledger/internal/app/memory_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -300,10 +301,7 @@ func TestCrawlMemoryRebuildDeterminism(t *testing.T) {
 	}
 	db.Close()
 
-	rebuild := runJSON(t, "crawl", "memory", ws, "--rebuild", "--json")
-	if rebuild["rebuild"] != true || rebuild["status"] != "completed" {
-		t.Fatalf("rebuild = %v", rebuild)
-	}
+	runOK(t, "crawl", "memory", ws, "--rebuild", "--json")
 	db = openTestDB(t)
 	defer db.Close()
 	after, err := ingest.LiveMemoryProjection(db, testMemoryNamespace)
@@ -446,7 +444,14 @@ func TestCrawlMemoryDuplicateExplicitIDFailsBeforeReconcile(t *testing.T) {
 	if err := os.MkdirAll(cards, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	body := "---\nid: card-dup00000-1111-4222-8333-444444444444\ntopic: d\n---\n\n# Dup\n"
+	existing := "---\nid: card-exist00-1111-4222-8333-444444444444\ntopic: exist\n---\n\n# Exist\n"
+	if err := os.WriteFile(filepath.Join(cards, "exist.md"), []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runJSON(t, "crawl", "memory", ws, "--json")
+
+	dupID := "card-dup00000-1111-4222-8333-444444444444"
+	body := "---\nid: " + dupID + "\ntopic: d\n---\n\n# Dup\n"
 	if err := os.WriteFile(filepath.Join(cards, "one.md"), []byte(body), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -462,21 +467,98 @@ func TestCrawlMemoryDuplicateExplicitIDFailsBeforeReconcile(t *testing.T) {
 	}
 	db := openTestDB(t)
 	defer db.Close()
-	var live int
-	if err := db.QueryRow(`
-select count(*) from items i join sources s on s.id = i.source_id
-where s.kind = ? and i.kind = 'memory_card'`, ingest.MemorySourceKind).Scan(&live); err != nil {
+	live, err := ingest.LiveMemoryProjection(db, testMemoryNamespace)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if live != 0 {
-		t.Fatalf("duplicate id scan must not import rows, got %d", live)
+	if live["card-exist00-1111-4222-8333-444444444444"] == "" {
+		t.Fatal("existing projection must survive duplicate-id fail-closed")
+	}
+	if _, ok := live[dupID]; ok {
+		t.Fatal("duplicate id must not import last-wins rows")
 	}
 	var tombstoned int
-	if err := db.QueryRow(`select count(*) from items where tombstoned_at is not null`).Scan(&tombstoned); err != nil {
+	if err := db.QueryRow(`
+select count(*) from items i join sources s on s.id = i.source_id
+where s.kind = ? and i.tombstoned_at is not null`, ingest.MemorySourceKind).Scan(&tombstoned); err != nil {
 		t.Fatal(err)
 	}
 	if tombstoned != 0 {
 		t.Fatalf("duplicate id failure must not reconcile/tombstone, got %d", tombstoned)
+	}
+}
+
+func TestCrawlMemoryTransactionFailureAfterObservation(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+	ws := t.TempDir()
+	writeTestNamespace(t, ws, testMemoryNamespace)
+	cards := filepath.Join(ws, "memory", "cards")
+	if err := os.MkdirAll(cards, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	keepID := "card-tx000000-1111-4222-8333-444444444444"
+	if err := os.WriteFile(filepath.Join(cards, "keep.md"), []byte("---\nid: "+keepID+"\ntopic: keep\n---\n\n# Keep\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cards, "gone.md"), []byte("---\nid: card-txgone00-1111-4222-8333-444444444444\ntopic: gone\n---\n\n# Gone\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runJSON(t, "crawl", "memory", ws, "--json")
+	if err := os.Remove(filepath.Join(cards, "gone.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	db := openTestDB(t)
+	defer db.Close()
+	before, err := ingest.LiveMemoryProjection(db, testMemoryNamespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(before) != 2 {
+		t.Fatalf("before live=%d", len(before))
+	}
+
+	ingest.SetMemoryScanAfterObserveHookForTest(func(tx *sql.Tx) error {
+		return fmt.Errorf("injected observation-to-reconcile failure")
+	})
+	t.Cleanup(func() { ingest.SetMemoryScanAfterObserveHookForTest(nil) })
+
+	scanID, err := ingest.BeginMemoryScan(db, ws, Version, testMemoryNamespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt := &ingest.MemoryScanReceipt{SourcePath: ws, Namespace: testMemoryNamespace, EngineVersion: Version}
+	err = ingest.CompleteMemoryScan(db, scanID, []ingest.ObservedCard{
+		{ExternalID: keepID, ContentHash: before[keepID], RawPath: "memory/cards/keep.md", Outcome: "unchanged"},
+	}, receipt)
+	if err == nil || !strings.Contains(err.Error(), "injected observation-to-reconcile failure") {
+		t.Fatalf("expected injected failure, got %v", err)
+	}
+	_ = ingest.FailMemoryScan(db, scanID, "failed", receipt)
+
+	after, err := ingest.LiveMemoryProjection(db, testMemoryNamespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after) != 2 || after[keepID] == "" || after["card-txgone00-1111-4222-8333-444444444444"] == "" {
+		t.Fatalf("transaction failure after observation must not tombstone: %v", after)
+	}
+	var tombstoned int
+	if err := db.QueryRow(`
+select count(*) from items i join sources s on s.id = i.source_id
+where s.kind = ? and i.tombstoned_at is not null`, ingest.MemorySourceKind).Scan(&tombstoned); err != nil {
+		t.Fatal(err)
+	}
+	if tombstoned != 0 {
+		t.Fatalf("tombstones=%d", tombstoned)
+	}
+	health, err := ingest.CollectMemoryHealth(db, Version, testMemoryNamespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !health.Stale || !health.Partial {
+		t.Fatalf("health=%+v", health)
 	}
 }
 
@@ -593,51 +675,6 @@ func TestCrawlMemoryUnresolvedRelationsPostResolutionAgree(t *testing.T) {
 	}
 }
 
-func TestCrawlMemoryTransactionFailureCreatesNoTombstones(t *testing.T) {
-	withTempHome(t)
-	runOK(t, "init")
-	ws := t.TempDir()
-	writeTestNamespace(t, ws, testMemoryNamespace)
-	cards := filepath.Join(ws, "memory", "cards")
-	if err := os.MkdirAll(cards, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(cards, "keep.md"), []byte("---\nid: card-tx000000-1111-4222-8333-444444444444\ntopic: keep\n---\n\n# Keep\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	runJSON(t, "crawl", "memory", ws, "--json")
-
-	db := openTestDB(t)
-	defer db.Close()
-	// Simulate observation-then-failure before reconciliation commit by failing
-	// a scan after Begin without CompleteMemoryScan.
-	scanID, err := ingest.BeginMemoryScan(db, ws, Version, testMemoryNamespace)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := ingest.FailMemoryScan(db, scanID, "failed", &ingest.MemoryScanReceipt{
-		SourcePath: ws, Namespace: testMemoryNamespace, EngineVersion: Version, Failed: 1,
-	}); err != nil {
-		t.Fatal(err)
-	}
-	var tombstoned int
-	if err := db.QueryRow(`
-select count(*) from items i join sources s on s.id = i.source_id
-where s.kind = ? and i.tombstoned_at is not null`, ingest.MemorySourceKind).Scan(&tombstoned); err != nil {
-		t.Fatal(err)
-	}
-	if tombstoned != 0 {
-		t.Fatalf("transaction failure created tombstones: %d", tombstoned)
-	}
-	live, err := ingest.LiveMemoryProjection(db, testMemoryNamespace)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if live["card-tx000000-1111-4222-8333-444444444444"] == "" {
-		t.Fatal("prior live id must survive transaction failure")
-	}
-}
-
 func TestMemoryCardRetentionSafety(t *testing.T) {
 	withTempHome(t)
 	runOK(t, "init")
@@ -750,6 +787,196 @@ func TestLegacyMemoryCardsScopedRebuildRule(t *testing.T) {
 	}
 	if legacy["card-legacy0-1111-4222-8333-444444444444"] == "" {
 		t.Fatal("scoped rebuild must leave legacy memory:cards rows intact")
+	}
+
+	// Empty-namespace health dual-reads legacy + namespaced live counts.
+	agg, err := ingest.CollectMemoryHealth(db, Version, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	scoped, err := ingest.CollectMemoryHealth(db, Version, testMemoryNamespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if agg.LiveCount < scoped.LiveCount+1 {
+		t.Fatalf("aggregate live=%d scoped=%d (expected legacy included)", agg.LiveCount, scoped.LiveCount)
+	}
+	if agg.MemoryNamespace != "" {
+		t.Fatalf("aggregate health must not claim a single namespace, got %q", agg.MemoryNamespace)
+	}
+}
+
+func TestCollectMemoryHealthEmptyAggregatesAllCollections(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+	nsA := "memory-11111111-2222-4333-8444-aaaaaaaaaaaa"
+	nsB := "memory-99999999-8888-4777-8666-bbbbbbbbbbbb"
+	for i, ns := range []string{nsA, nsB} {
+		ws := t.TempDir()
+		writeTestNamespace(t, ws, ns)
+		cards := filepath.Join(ws, "memory", "cards")
+		if err := os.MkdirAll(cards, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		cardID := []string{
+			"card-aaaaaaa0-1111-4222-8333-444444444444",
+			"card-bbbbbbb0-1111-4222-8333-444444444444",
+		}[i]
+		body := "---\nid: " + cardID + "\ntopic: t\n---\n\n# Card\n"
+		if err := os.WriteFile(filepath.Join(cards, "card.md"), []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		runJSON(t, "crawl", "memory", ws, "--json")
+	}
+	db := openTestDB(t)
+	defer db.Close()
+	agg, err := ingest.CollectMemoryHealth(db, Version, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	a, err := ingest.CollectMemoryHealth(db, Version, nsA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := ingest.CollectMemoryHealth(db, Version, nsB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.LiveCount != 1 || b.LiveCount != 1 {
+		t.Fatalf("scoped live A=%d B=%d", a.LiveCount, b.LiveCount)
+	}
+	if agg.LiveCount != a.LiveCount+b.LiveCount {
+		t.Fatalf("aggregate live=%d want %d", agg.LiveCount, a.LiveCount+b.LiveCount)
+	}
+	if a.MemoryNamespace != nsA || b.MemoryNamespace != nsB {
+		t.Fatalf("scoped namespaces A=%q B=%q", a.MemoryNamespace, b.MemoryNamespace)
+	}
+}
+
+func TestRebuildFailureAfterDetachPreservesProjectionGraph(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+	ws := t.TempDir()
+	writeTestNamespace(t, ws, testMemoryNamespace)
+	cards := filepath.Join(ws, "memory", "cards")
+	if err := os.MkdirAll(cards, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cardID := "card-rb000000-1111-4222-8333-444444444444"
+	if err := os.WriteFile(filepath.Join(cards, "keep.md"), []byte("---\nid: "+cardID+"\ntopic: keep\n---\n\n# Keep\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	completed := runJSON(t, "crawl", "memory", ws, "--json")
+	completedScanID, _ := completed["scan_id"].(string)
+
+	db := openTestDB(t)
+	var itemID string
+	if err := db.QueryRow(`
+select i.id from items i
+join sources s on s.id = i.source_id
+join collections c on c.id = i.collection_id
+where s.kind = ? and c.external_id = ? and i.external_id = ? and i.tombstoned_at is null`,
+		ingest.MemorySourceKind, testMemoryNamespace, cardID).Scan(&itemID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`insert into item_metadata(item_id, key, value) values(?,?,?)`, itemID, "fixture_key", "fixture_value"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`insert into events(id, source_id, collection_id, actor_id, item_id, kind, occurred_at, metadata_json)
+select 'evt-memory-1', i.source_id, i.collection_id, i.actor_id, i.id, 'memory_test', i.created_at, '{}' from items i where i.id = ?`, itemID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`insert into artifacts(id, source_id, item_id, external_id, kind, path, url, mime_type, text, content_hash, metadata_json)
+select 'art-memory-1', i.source_id, i.id, 'art:1', 'note', 'memory/cards/keep.md', '', 'text/plain', 'artifact', i.content_hash, '{}' from items i where i.id = ?`, itemID); err != nil {
+		t.Fatal(err)
+	}
+	// Outbound relation from a non-memory item targeting the memory card.
+	supportJSONL := `{"schema":"miseledger.adapter.v1","source":{"kind":"brigade","name":"Brigade"},"collection":{"external_id":"brigade:receipts","kind":"brigade_receipt","name":"receipts"},"item":{"external_id":"receipt:rebuild-support","kind":"receipt","created_at":"2026-01-01T00:00:00Z","text":"support"},"relations":[{"type":"supports","target":{"source":"brigade-memory","collection":"` + testMemoryNamespace + `","external_id":"` + cardID + `"}}],"raw":{"format":"json","path":"r.json","ordinal":1}}` + "\n"
+	db.Close()
+	supportPath := filepath.Join(t.TempDir(), "support.jsonl")
+	if err := os.WriteFile(supportPath, []byte(supportJSONL), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runOK(t, "import", "adapter", supportPath, "--json")
+
+	db = openTestDB(t)
+	before, err := ingest.LiveMemoryProjection(db, testMemoryNamespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var metaBefore, eventsBefore, artsBefore, inboundBefore int
+	if err := db.QueryRow(`select count(*) from item_metadata where item_id = ?`, itemID).Scan(&metaBefore); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`select count(*) from events where item_id = ?`, itemID).Scan(&eventsBefore); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`select count(*) from artifacts where item_id = ?`, itemID).Scan(&artsBefore); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`select count(*) from relations where target_item_id = ?`, itemID).Scan(&inboundBefore); err != nil {
+		t.Fatal(err)
+	}
+	if metaBefore < 1 || eventsBefore < 1 || artsBefore < 1 || inboundBefore < 1 {
+		t.Fatalf("fixture graph incomplete meta=%d events=%d arts=%d inbound=%d", metaBefore, eventsBefore, artsBefore, inboundBefore)
+	}
+	db.Close()
+
+	ingest.MemoryRebuildTestHookAfterDetach = func() error {
+		return fmt.Errorf("injected post-detach rebuild failure")
+	}
+	t.Cleanup(func() { ingest.MemoryRebuildTestHookAfterDetach = nil })
+
+	code, _, stderr := run("crawl", "memory", ws, "--rebuild", "--json")
+	if code == 0 {
+		t.Fatalf("expected rebuild failure, stderr=%s", stderr)
+	}
+	if !strings.Contains(stderr, "injected post-detach rebuild failure") {
+		t.Fatalf("stderr=%q", stderr)
+	}
+
+	db = openTestDB(t)
+	defer db.Close()
+	after, err := ingest.LiveMemoryProjection(db, testMemoryNamespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after[cardID] != before[cardID] {
+		t.Fatalf("live hash changed: before=%v after=%v", before, after)
+	}
+	var metaAfter, eventsAfter, artsAfter, inboundAfter int
+	if err := db.QueryRow(`select count(*) from item_metadata where item_id = ?`, itemID).Scan(&metaAfter); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`select count(*) from events where item_id = ?`, itemID).Scan(&eventsAfter); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`select count(*) from artifacts where item_id = ?`, itemID).Scan(&artsAfter); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`select count(*) from relations where target_item_id = ?`, itemID).Scan(&inboundAfter); err != nil {
+		t.Fatal(err)
+	}
+	if metaAfter != metaBefore || eventsAfter != eventsBefore || artsAfter != artsBefore || inboundAfter != inboundBefore {
+		t.Fatalf("graph not preserved meta %d/%d events %d/%d arts %d/%d inbound %d/%d",
+			metaAfter, metaBefore, eventsAfter, eventsBefore, artsAfter, artsBefore, inboundAfter, inboundBefore)
+	}
+	var priorCompleted int
+	if err := db.QueryRow(`select count(*) from source_scan_runs where id = ? and status = 'completed'`, completedScanID).Scan(&priorCompleted); err != nil {
+		t.Fatal(err)
+	}
+	if priorCompleted != 1 {
+		t.Fatal("completed-scan record must survive rebuild failure")
+	}
+	health, err := ingest.CollectMemoryHealth(db, Version, testMemoryNamespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !health.Stale || !health.Partial {
+		t.Fatalf("health=%+v", health)
+	}
+	if health.LastCompletedScanID != completedScanID {
+		t.Fatalf("last_completed=%q want %q", health.LastCompletedScanID, completedScanID)
 	}
 }
 

--- a/engines/evidence-ledger/internal/app/memory_test.go
+++ b/engines/evidence-ledger/internal/app/memory_test.go
@@ -910,7 +910,7 @@ select i.id, i.content_hash from items i
 join sources s on s.id = i.source_id
 join collections c on c.id = i.collection_id
 where s.kind = ? and c.external_id = ? and i.external_id = ? and i.tombstoned_at is null
-order by i.updated_at desc, i.id desc`, ingest.MemorySourceKind, testMemoryNamespace, cardID).Scan(&v2ID, &v2Hash); err != nil {
+order by i.ingest_seq desc, i.id desc`, ingest.MemorySourceKind, testMemoryNamespace, cardID).Scan(&v2ID, &v2Hash); err != nil {
 		t.Fatal(err)
 	}
 	if v2ID == v1ID || v2Hash == v1Hash {
@@ -960,7 +960,7 @@ select i.id, i.content_hash, i.updated_at from items i
 join sources s on s.id = i.source_id
 join collections c on c.id = i.collection_id
 where s.kind = ? and c.external_id = ? and i.external_id = ? and i.tombstoned_at is null
-order by i.updated_at desc, i.id desc`, ingest.MemorySourceKind, testMemoryNamespace, cardID).Scan(&liveID, &liveHash, &liveStamp); err != nil {
+order by i.ingest_seq desc, i.id desc`, ingest.MemorySourceKind, testMemoryNamespace, cardID).Scan(&liveID, &liveHash, &liveStamp); err != nil {
 		t.Fatal(err)
 	}
 	if liveID != v1ID || liveHash != v1Hash {
@@ -1096,7 +1096,7 @@ select i.id, i.content_hash, i.updated_at from items i
 join sources s on s.id = i.source_id
 join collections c on c.id = i.collection_id
 where s.kind = ? and c.external_id = ? and i.external_id = ? and i.tombstoned_at is null
-order by i.updated_at desc, i.id desc`, ingest.MemorySourceKind, testMemoryNamespace, cardID).Scan(&v1ID, &v1Hash, &v1Updated); err != nil {
+order by i.ingest_seq desc, i.id desc`, ingest.MemorySourceKind, testMemoryNamespace, cardID).Scan(&v1ID, &v1Hash, &v1Updated); err != nil {
 		t.Fatal(err)
 	}
 	if v1Updated == "" {
@@ -1159,7 +1159,7 @@ select i.id, i.content_hash, i.updated_at from items i
 join sources s on s.id = i.source_id
 join collections c on c.id = i.collection_id
 where s.kind = ? and c.external_id = ? and i.external_id = ? and i.tombstoned_at is null
-order by i.updated_at desc, i.id desc`, ingest.MemorySourceKind, testMemoryNamespace, cardID).Scan(&v2ID, &v2Hash, &v2Updated); err != nil {
+order by i.ingest_seq desc, i.id desc`, ingest.MemorySourceKind, testMemoryNamespace, cardID).Scan(&v2ID, &v2Hash, &v2Updated); err != nil {
 		t.Fatal(err)
 	}
 	if v2ID == v1ID || v2Hash == v1Hash {

--- a/engines/evidence-ledger/internal/app/memory_test.go
+++ b/engines/evidence-ledger/internal/app/memory_test.go
@@ -954,6 +954,58 @@ where target_item_id = ? and target_source_kind = ? and target_collection_extern
 	}
 }
 
+func TestCrawlMemoryRebuildRepointsInboundRelationWithoutTargetCollection(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+	ws := t.TempDir()
+	writeTestNamespace(t, ws, testMemoryNamespace)
+	cards := filepath.Join(ws, "memory", "cards")
+	if err := os.MkdirAll(cards, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cardID := "card-unscoped111-1111-4222-8333-444444444444"
+	cardPath := filepath.Join(cards, "card.md")
+	initial := "---\nid: " + cardID + "\ntopic: rebuild\n---\n\n# Initial\n"
+	if err := os.WriteFile(cardPath, []byte(initial), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runJSON(t, "crawl", "memory", ws, "--json")
+
+	// The adapter contract permits a source-qualified target without a collection.
+	supportJSONL := `{"schema":"miseledger.adapter.v1","source":{"kind":"brigade","name":"Brigade"},"collection":{"external_id":"brigade:receipts","kind":"brigade_receipt","name":"receipts"},"item":{"external_id":"receipt:unscoped-rebuild","kind":"receipt","created_at":"2026-01-01T00:00:00Z","text":"support"},"relations":[{"type":"supports","target":{"source":"brigade-memory","external_id":"` + cardID + `"}}],"raw":{"format":"json","path":"r.json","ordinal":1}}` + "\n"
+	supportPath := filepath.Join(t.TempDir(), "support.jsonl")
+	if err := os.WriteFile(supportPath, []byte(supportJSONL), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runOK(t, "import", "adapter", supportPath, "--json")
+
+	changed := "---\nid: " + cardID + "\ntopic: rebuild\n---\n\n# Changed\n"
+	if err := os.WriteFile(cardPath, []byte(changed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runJSON(t, "crawl", "memory", ws, "--rebuild", "--json")
+
+	db := openTestDB(t)
+	defer db.Close()
+	var liveID string
+	if err := db.QueryRow(`select i.id from items i
+join sources s on s.id = i.source_id
+join collections c on c.id = i.collection_id
+where s.kind = ? and c.external_id = ? and i.external_id = ? and i.tombstoned_at is null`,
+		ingest.MemorySourceKind, testMemoryNamespace, cardID).Scan(&liveID); err != nil {
+		t.Fatal(err)
+	}
+	var inbound int
+	if err := db.QueryRow(`select count(*) from relations
+where target_item_id = ? and target_source_kind = ? and target_collection_external_id is null and target_external_id = ?`,
+		liveID, ingest.MemorySourceKind, cardID).Scan(&inbound); err != nil {
+		t.Fatal(err)
+	}
+	if inbound != 1 {
+		t.Fatalf("changed-content rebuild lost or mispointed unscoped inbound relation: target=%q count=%d", liveID, inbound)
+	}
+}
+
 func TestRebuildFailureAfterDetachPreservesProjectionGraph(t *testing.T) {
 	withTempHome(t)
 	runOK(t, "init")

--- a/engines/evidence-ledger/internal/app/memory_test.go
+++ b/engines/evidence-ledger/internal/app/memory_test.go
@@ -435,6 +435,54 @@ func TestCrawlMemoryTwoRootNamespaceIsolation(t *testing.T) {
 	}
 }
 
+func TestCrawlMemoryFailedUnknownPathDoesNotBorrowAnotherNamespace(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+	nsA := "memory-11111111-2222-4333-8444-aaaaaaaaaaaa"
+	nsB := "memory-99999999-8888-4777-8666-bbbbbbbbbbbb"
+	for _, fixture := range []struct {
+		namespace string
+		cardID    string
+	}{
+		{nsA, "card-path-a-1111-4222-8333-444444444444"},
+		{nsB, "card-path-b-1111-4222-8333-444444444444"},
+	} {
+		ws := t.TempDir()
+		writeTestNamespace(t, ws, fixture.namespace)
+		cards := filepath.Join(ws, "memory", "cards")
+		if err := os.MkdirAll(cards, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(cards, "card.md"), []byte("---\nid: "+fixture.cardID+"\ntopic: path\n---\n\n# Card\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		runJSON(t, "crawl", "memory", ws, "--json")
+	}
+
+	missing := filepath.Join(t.TempDir(), "vanished-workspace")
+	code, _, stderr := run("crawl", "memory", missing, "--json")
+	if code == 0 {
+		t.Fatalf("missing workspace crawl unexpectedly succeeded: %s", stderr)
+	}
+
+	db := openTestDB(t)
+	defer db.Close()
+	var failedForB, staleB int
+	if err := db.QueryRow(`select count(*) from source_scan_runs
+where source_kind = ? and status in ('failed', 'interrupted')
+  and json_extract(metadata_json, '$.memory_namespace') = ?`, ingest.MemorySourceKind, nsB).Scan(&failedForB); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`select count(*) from source_scan_runs
+where source_kind = ? and status = 'completed' and stale = 1
+  and json_extract(metadata_json, '$.memory_namespace') = ?`, ingest.MemorySourceKind, nsB).Scan(&staleB); err != nil {
+		t.Fatal(err)
+	}
+	if failedForB != 0 || staleB != 0 {
+		t.Fatalf("unknown path borrowed namespace B: failed=%d stale=%d", failedForB, staleB)
+	}
+}
+
 func TestCrawlMemoryDuplicateExplicitIDFailsBeforeReconcile(t *testing.T) {
 	withTempHome(t)
 	runOK(t, "init")

--- a/engines/evidence-ledger/internal/app/memory_test.go
+++ b/engines/evidence-ledger/internal/app/memory_test.go
@@ -822,14 +822,33 @@ func TestCollectMemoryHealthEmptyAggregatesAllCollections(t *testing.T) {
 			"card-aaaaaaa0-1111-4222-8333-444444444444",
 			"card-bbbbbbb0-1111-4222-8333-444444444444",
 		}[i]
-		body := "---\nid: " + cardID + "\ntopic: t\n---\n\n# Card\n"
+		body := "---\nid: " + cardID + "\ntopic: t\n"
+		if i == 0 {
+			body += "supported_by: missing\nsupported_by_target_source: brigade-memory\n"
+		}
+		body += "---\n\n# Card\n"
 		if err := os.WriteFile(filepath.Join(cards, "card.md"), []byte(body), 0o600); err != nil {
 			t.Fatal(err)
+		}
+		if i == 1 {
+			if err := os.WriteFile(filepath.Join(cards, "second.md"), []byte("---\nid: card-ccccccc0-1111-4222-8333-444444444444\ntopic: t\n---\n\n# Second\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
 		}
 		runJSON(t, "crawl", "memory", ws, "--json")
 	}
 	db := openTestDB(t)
 	defer db.Close()
+	if _, err := db.Exec(`update source_scan_runs set canonical_count = ?, hash_divergence_count = ?, malformed_skipped_count = ?, completed_at = ?
+where source_kind = ? and json_extract(metadata_json, '$.memory_namespace') = ?`,
+		4, 3, 2, "2026-01-01T00:00:00Z", ingest.MemorySourceKind, nsA); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`update source_scan_runs set canonical_count = ?, hash_divergence_count = ?, malformed_skipped_count = ?, completed_at = ?
+where source_kind = ? and json_extract(metadata_json, '$.memory_namespace') = ?`,
+		7, 5, 6, "2026-01-02T00:00:00Z", ingest.MemorySourceKind, nsB); err != nil {
+		t.Fatal(err)
+	}
 	agg, err := ingest.CollectMemoryHealth(db, Version, "")
 	if err != nil {
 		t.Fatal(err)
@@ -842,7 +861,7 @@ func TestCollectMemoryHealthEmptyAggregatesAllCollections(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if a.LiveCount != 1 || b.LiveCount != 1 {
+	if a.LiveCount != 1 || b.LiveCount != 2 {
 		t.Fatalf("scoped live A=%d B=%d", a.LiveCount, b.LiveCount)
 	}
 	if agg.LiveCount != a.LiveCount+b.LiveCount {
@@ -850,6 +869,15 @@ func TestCollectMemoryHealthEmptyAggregatesAllCollections(t *testing.T) {
 	}
 	if a.MemoryNamespace != nsA || b.MemoryNamespace != nsB {
 		t.Fatalf("scoped namespaces A=%q B=%q", a.MemoryNamespace, b.MemoryNamespace)
+	}
+	if agg.CanonicalCount != a.CanonicalCount+b.CanonicalCount || agg.HashDivergence != a.HashDivergence+b.HashDivergence || agg.MalformedSkipped != a.MalformedSkipped+b.MalformedSkipped || agg.UnresolvedRelations != a.UnresolvedRelations+b.UnresolvedRelations {
+		t.Fatalf("aggregate scan fields = %+v; scoped A=%+v B=%+v", agg, a, b)
+	}
+	if agg.Status != "completed" || agg.Stale || agg.Partial {
+		t.Fatalf("aggregate completed health = %+v", agg)
+	}
+	if agg.LastCompletedScanID != b.LastCompletedScanID || agg.LastCompletedAt == nil || *agg.LastCompletedAt != "2026-01-02T00:00:00Z" {
+		t.Fatalf("aggregate completion = id %q at %v; want newest namespace B completion", agg.LastCompletedScanID, agg.LastCompletedAt)
 	}
 }
 
@@ -1003,6 +1031,105 @@ where target_item_id = ? and target_source_kind = ? and target_collection_extern
 	}
 	if inbound != 1 {
 		t.Fatalf("changed-content rebuild lost or mispointed unscoped inbound relation: target=%q count=%d", liveID, inbound)
+	}
+}
+
+func TestCrawlMemoryRebuildDoesNotRepointAmbiguousUnscopedRelationAcrossNamespaces(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+	const sharedID = "card-ambiguous-1111-4222-8333-444444444444"
+	nsA := "memory-11111111-2222-4333-8444-aaaaaaaaaaaa"
+	nsB := "memory-99999999-8888-4777-8666-bbbbbbbbbbbb"
+	workspaces := make([]string, 0, 2)
+	for _, ns := range []string{nsA, nsB} {
+		ws := t.TempDir()
+		writeTestNamespace(t, ws, ns)
+		cards := filepath.Join(ws, "memory", "cards")
+		if err := os.MkdirAll(cards, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(cards, "shared.md"), []byte("---\nid: "+sharedID+"\ntopic: shared\n---\n\n# Initial "+ns+"\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		runJSON(t, "crawl", "memory", ws, "--json")
+		workspaces = append(workspaces, ws)
+	}
+	supportPath := filepath.Join(t.TempDir(), "support.jsonl")
+	supportJSONL := `{"schema":"miseledger.adapter.v1","source":{"kind":"brigade","name":"Brigade"},"collection":{"external_id":"brigade:receipts","kind":"brigade_receipt","name":"receipts"},"item":{"external_id":"receipt:ambiguous-rebuild","kind":"receipt","created_at":"2026-01-01T00:00:00Z","text":"support"},"relations":[{"type":"supports","target":{"source":"brigade-memory","external_id":"` + sharedID + `"}}],"raw":{"format":"json","path":"r.json","ordinal":1}}` + "\n"
+	if err := os.WriteFile(supportPath, []byte(supportJSONL), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runOK(t, "import", "adapter", supportPath, "--json")
+
+	changedPath := filepath.Join(workspaces[0], "memory", "cards", "shared.md")
+	if err := os.WriteFile(changedPath, []byte("---\nid: "+sharedID+"\ntopic: shared\n---\n\n# Changed A\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runJSON(t, "crawl", "memory", workspaces[0], "--rebuild", "--json")
+
+	db := openTestDB(t)
+	defer db.Close()
+	var target sql.NullString
+	if err := db.QueryRow(`select target_item_id from relations where relation_type = 'supports'`).Scan(&target); err != nil {
+		t.Fatal(err)
+	}
+	if target.Valid && target.String != "" {
+		t.Fatalf("ambiguous unscoped rebuild relation repointed to %q", target.String)
+	}
+}
+
+func TestRecoverMemoryRebuildAfterDetachMarksJournalInterrupted(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+	ws := t.TempDir()
+	writeTestNamespace(t, ws, testMemoryNamespace)
+	cards := filepath.Join(ws, "memory", "cards")
+	if err := os.MkdirAll(cards, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const cardID = "card-recover0-1111-4222-8333-444444444444"
+	if err := os.WriteFile(filepath.Join(cards, "card.md"), []byte("---\nid: "+cardID+"\ntopic: recover\n---\n\n# Keep\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runJSON(t, "crawl", "memory", ws, "--json")
+
+	db := openTestDB(t)
+	journalID, err := ingest.BeginMemoryScan(db, ws, Version, testMemoryNamespace)
+	if err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	if err := ingest.DetachMemoryNamespace(db, testMemoryNamespace); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	db.Close() // Simulate process death after detach and before the next rebuild step.
+
+	db = openTestDB(t)
+	defer db.Close()
+	if err := ingest.RecoverMemoryRebuildState(db, testMemoryNamespace); err != nil {
+		t.Fatal(err)
+	}
+	projection, err := ingest.LiveMemoryProjection(db, testMemoryNamespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if projection[cardID] == "" {
+		t.Fatalf("recovery did not restore %q: %v", cardID, projection)
+	}
+	var status string
+	if err := db.QueryRow(`select status from source_scan_runs where id = ?`, journalID).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != "interrupted" {
+		t.Fatalf("rebuild recovery journal status = %q; want interrupted", status)
+	}
+	health, err := ingest.CollectMemoryHealth(db, Version, testMemoryNamespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !health.Stale || !health.Partial || health.Status != "interrupted" {
+		t.Fatalf("recovered rebuild health = %+v", health)
 	}
 }
 

--- a/engines/evidence-ledger/internal/app/memory_test.go
+++ b/engines/evidence-ledger/internal/app/memory_test.go
@@ -854,6 +854,79 @@ func TestLegacyMemoryCardsScopedRebuildRule(t *testing.T) {
 	}
 }
 
+
+
+func TestCrawlMemoryLatestVersionUsesIngestStampNotHashOrder(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+	ws := t.TempDir()
+	writeTestNamespace(t, ws, testMemoryNamespace)
+	cards := filepath.Join(ws, "memory", "cards")
+	if err := os.MkdirAll(cards, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cardID := "card-ctime000-1111-4222-8333-444444444444"
+	path := filepath.Join(cards, "c.md")
+	v1 := "---\nid: " + cardID + "\ntopic: c\nsupported_by: [missing-target-v1]\n---\n\n# Original body ZZZ\n"
+	v2 := "---\nid: " + cardID + "\ntopic: c\n---\n\n# Edited body AAA latest\n"
+	if err := os.WriteFile(path, []byte(v1), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	first := runJSON(t, "crawl", "memory", ws, "--json")
+	if first["unresolved_relations"].(float64) < 1 {
+		t.Fatalf("v1 should record unresolved outbound: %v", first)
+	}
+	if err := os.WriteFile(path, []byte(v2), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	second := runJSON(t, "crawl", "memory", ws, "--json")
+	if second["updated"].(float64) < 1 {
+		t.Fatalf("expected edit update: %v", second)
+	}
+
+	db := openTestDB(t)
+	defer db.Close()
+	var v1ID, v2ID, v2Hash, v1Updated, v2Updated string
+	if err := db.QueryRow(`
+select i.id, i.updated_at from items i
+join sources s on s.id = i.source_id join collections c on c.id = i.collection_id
+where s.kind=? and c.external_id=? and i.external_id=? and i.text like '%Original%'`,
+		ingest.MemorySourceKind, testMemoryNamespace, cardID).Scan(&v1ID, &v1Updated); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`
+select i.id, i.content_hash, i.updated_at from items i
+join sources s on s.id = i.source_id join collections c on c.id = i.collection_id
+where s.kind=? and c.external_id=? and i.external_id=? and i.text like '%Edited%'`,
+		ingest.MemorySourceKind, testMemoryNamespace, cardID).Scan(&v2ID, &v2Hash, &v2Updated); err != nil {
+		t.Fatal(err)
+	}
+	if v1Updated == "" || v2Updated == "" || v2Updated <= v1Updated {
+		t.Fatalf("ingest stamps missing/non-monotonic v1=%q v2=%q", v1Updated, v2Updated)
+	}
+	// Reproduce Terra condition: empty created_at ties; hash/id order may disagree.
+	if _, err := db.Exec(`update items set created_at = '' where external_id = ?`, cardID); err != nil {
+		t.Fatal(err)
+	}
+	live, err := ingest.LiveMemoryProjection(db, testMemoryNamespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if live[cardID] != v2Hash {
+		t.Fatalf("live selection ignored ingest stamp after empty created_at: got %s want %s (v1ID=%s v2ID=%s)", live[cardID], v2Hash, v1ID, v2ID)
+	}
+	health, err := ingest.CollectMemoryHealth(db, Version, testMemoryNamespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if health.UnresolvedRelations != 0 {
+		t.Fatalf("stale outbound unresolved on prior version contaminated health: %+v", health)
+	}
+	if health.LiveCount != 1 {
+		t.Fatalf("live_count=%d", health.LiveCount)
+	}
+}
+
 func TestCrawlMemoryEditRepointsInboundRelationsToLatestVersion(t *testing.T) {
 	withTempHome(t)
 	runOK(t, "init")
@@ -865,20 +938,33 @@ func TestCrawlMemoryEditRepointsInboundRelationsToLatestVersion(t *testing.T) {
 	}
 	cardID := "card-edit0000-1111-4222-8333-444444444444"
 	cardPath := filepath.Join(cards, "edit.md")
-	if err := os.WriteFile(cardPath, []byte("---\nid: "+cardID+"\ntopic: edit\n---\n\n# Original\n"), 0o600); err != nil {
+	if err := os.WriteFile(cardPath, []byte("---\nid: "+cardID+"\ntopic: edit\nsupported_by: [missing-outbound-v1]\n---\n\n# Original\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	runJSON(t, "crawl", "memory", ws, "--json")
+	first := runJSON(t, "crawl", "memory", ws, "--json")
+	if first["unresolved_relations"].(float64) < 1 {
+		t.Fatalf("expected v1 unresolved outbound: %v", first)
+	}
 
 	db := openTestDB(t)
-	var v1ID, v1Hash string
+	var v1ID, v1Hash, v1Updated string
 	if err := db.QueryRow(`
-select i.id, i.content_hash from items i
+select i.id, i.content_hash, i.updated_at from items i
 join sources s on s.id = i.source_id
 join collections c on c.id = i.collection_id
 where s.kind = ? and c.external_id = ? and i.external_id = ? and i.tombstoned_at is null
-order by i.created_at desc, i.id desc`, ingest.MemorySourceKind, testMemoryNamespace, cardID).Scan(&v1ID, &v1Hash); err != nil {
+order by i.updated_at desc, i.id desc`, ingest.MemorySourceKind, testMemoryNamespace, cardID).Scan(&v1ID, &v1Hash, &v1Updated); err != nil {
 		t.Fatal(err)
+	}
+	if v1Updated == "" {
+		t.Fatal("ingest must persist non-empty updated_at version stamp")
+	}
+	healthV1, err := ingest.CollectMemoryHealth(db, Version, testMemoryNamespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if healthV1.UnresolvedRelations < 1 {
+		t.Fatalf("v1 health should count outbound unresolved, got %+v", healthV1)
 	}
 	supportJSONL := `{"schema":"miseledger.adapter.v1","source":{"kind":"brigade","name":"Brigade"},"collection":{"external_id":"brigade:receipts","kind":"brigade_receipt","name":"receipts"},"item":{"external_id":"receipt:edit-support","kind":"receipt","created_at":"2026-01-01T00:00:00Z","text":"support"},"relations":[{"type":"supports","target":{"source":"brigade-memory","collection":"` + testMemoryNamespace + `","external_id":"` + cardID + `"}}],"raw":{"format":"json","path":"r.json","ordinal":1}}` + "\n"
 	db.Close()
@@ -901,6 +987,7 @@ order by i.created_at desc, i.id desc`, ingest.MemorySourceKind, testMemoryNames
 
 	// Non-rebuild edit: content-addressed import creates a second item id while
 	// the prior version stays untombstoned (same external id still observed).
+	// Drop the unresolved outbound relation on v2.
 	if err := os.WriteFile(cardPath, []byte("---\nid: "+cardID+"\ntopic: edit\n---\n\n# Edited body\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -923,17 +1010,24 @@ where s.kind = ? and c.external_id = ? and i.external_id = ? and i.tombstoned_at
 	if versionCount < 2 {
 		t.Fatalf("expected prior+latest content-addressed versions, got %d", versionCount)
 	}
-	var v2ID, v2Hash string
+	var v2ID, v2Hash, v2Updated string
 	if err := db.QueryRow(`
-select i.id, i.content_hash from items i
+select i.id, i.content_hash, i.updated_at from items i
 join sources s on s.id = i.source_id
 join collections c on c.id = i.collection_id
 where s.kind = ? and c.external_id = ? and i.external_id = ? and i.tombstoned_at is null
-order by i.created_at desc, i.id desc`, ingest.MemorySourceKind, testMemoryNamespace, cardID).Scan(&v2ID, &v2Hash); err != nil {
+order by i.updated_at desc, i.id desc`, ingest.MemorySourceKind, testMemoryNamespace, cardID).Scan(&v2ID, &v2Hash, &v2Updated); err != nil {
 		t.Fatal(err)
 	}
 	if v2ID == v1ID || v2Hash == v1Hash {
 		t.Fatalf("edit must mint a new content-addressed item id/hash (v1=%s/%s v2=%s/%s)", v1ID, v1Hash, v2ID, v2Hash)
+	}
+	if v2Updated == "" || v2Updated <= v1Updated {
+		t.Fatalf("updated_at ingest stamp must advance for edited version v1=%q v2=%q", v1Updated, v2Updated)
+	}
+	// Empty created_at must not change latest selection.
+	if _, err := db.Exec(`update items set created_at = '' where external_id = ?`, cardID); err != nil {
+		t.Fatal(err)
 	}
 	if err := db.QueryRow(`select target_item_id from relations where target_external_id = ? and target_source_kind = ?`,
 		cardID, ingest.MemorySourceKind).Scan(&inboundTarget); err != nil {
@@ -957,7 +1051,7 @@ order by i.created_at desc, i.id desc`, ingest.MemorySourceKind, testMemoryNames
 		t.Fatalf("live_count should count latest external ids once, got %d", health.LiveCount)
 	}
 	if health.UnresolvedRelations != 0 {
-		t.Fatalf("resolved inbound must not leave unresolved_relations=%d", health.UnresolvedRelations)
+		t.Fatalf("stale v1 outbound unresolved must not contaminate live health: %+v", health)
 	}
 }
 

--- a/engines/evidence-ledger/internal/app/memory_test.go
+++ b/engines/evidence-ledger/internal/app/memory_test.go
@@ -856,6 +856,149 @@ func TestLegacyMemoryCardsScopedRebuildRule(t *testing.T) {
 
 
 
+func TestCrawlMemoryReingestPriorContentBecomesLiveAgain(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+	ws := t.TempDir()
+	writeTestNamespace(t, ws, testMemoryNamespace)
+	cards := filepath.Join(ws, "memory", "cards")
+	if err := os.MkdirAll(cards, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cardID := "card-revisit0-1111-4222-8333-444444444444"
+	path := filepath.Join(cards, "revisit.md")
+	v1Body := "---\nid: " + cardID + "\ntopic: revisit\nsupported_by: [missing-outbound-v1]\n---\n\n# Version one body\n"
+	v2Body := "---\nid: " + cardID + "\ntopic: revisit\n---\n\n# Version two body\n"
+	if err := os.WriteFile(path, []byte(v1Body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	first := runJSON(t, "crawl", "memory", ws, "--json")
+	if first["unresolved_relations"].(float64) < 1 {
+		t.Fatalf("v1 unresolved outbound expected: %v", first)
+	}
+
+	db := openTestDB(t)
+	var v1ID, v1Hash, v1Stamp string
+	if err := db.QueryRow(`
+select i.id, i.content_hash, i.updated_at from items i
+join sources s on s.id = i.source_id
+join collections c on c.id = i.collection_id
+where s.kind = ? and c.external_id = ? and i.external_id = ? and i.tombstoned_at is null`,
+		ingest.MemorySourceKind, testMemoryNamespace, cardID).Scan(&v1ID, &v1Hash, &v1Stamp); err != nil {
+		t.Fatal(err)
+	}
+	supportJSONL := `{"schema":"miseledger.adapter.v1","source":{"kind":"brigade","name":"Brigade"},"collection":{"external_id":"brigade:receipts","kind":"brigade_receipt","name":"receipts"},"item":{"external_id":"receipt:revisit-support","kind":"receipt","created_at":"2026-01-01T00:00:00Z","text":"support"},"relations":[{"type":"supports","target":{"source":"brigade-memory","collection":"` + testMemoryNamespace + `","external_id":"` + cardID + `"}}],"raw":{"format":"json","path":"r.json","ordinal":1}}` + "\n"
+	db.Close()
+	supportPath := filepath.Join(t.TempDir(), "support.jsonl")
+	if err := os.WriteFile(supportPath, []byte(supportJSONL), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runOK(t, "import", "adapter", supportPath, "--json")
+
+	if err := os.WriteFile(path, []byte(v2Body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	second := runJSON(t, "crawl", "memory", ws, "--json")
+	if second["updated"].(float64) < 1 {
+		t.Fatalf("expected v2 update: %v", second)
+	}
+
+	db = openTestDB(t)
+	var v2ID, v2Hash string
+	if err := db.QueryRow(`
+select i.id, i.content_hash from items i
+join sources s on s.id = i.source_id
+join collections c on c.id = i.collection_id
+where s.kind = ? and c.external_id = ? and i.external_id = ? and i.tombstoned_at is null
+order by i.updated_at desc, i.id desc`, ingest.MemorySourceKind, testMemoryNamespace, cardID).Scan(&v2ID, &v2Hash); err != nil {
+		t.Fatal(err)
+	}
+	if v2ID == v1ID || v2Hash == v1Hash {
+		t.Fatalf("v2 must be a distinct content-addressed row")
+	}
+	var inbound string
+	if err := db.QueryRow(`select target_item_id from relations where target_external_id = ? and target_source_kind = ?`,
+		cardID, ingest.MemorySourceKind).Scan(&inbound); err != nil {
+		t.Fatal(err)
+	}
+	if inbound != v2ID {
+		t.Fatalf("inbound should track live v2=%s, got %s", v2ID, inbound)
+	}
+	var eventsBefore int
+	if err := db.QueryRow(`select count(*) from events where item_id = ?`, v1ID).Scan(&eventsBefore); err != nil {
+		t.Fatal(err)
+	}
+	db.Close()
+
+	// Restore byte-identical v1: known-content early return must refresh the
+	// ingest stamp so v1 becomes live again without minting a duplicate row/event.
+	if err := os.WriteFile(path, []byte(v1Body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	third := runJSON(t, "crawl", "memory", ws, "--json")
+	if third["inserted_items"].(float64) != 0 {
+		t.Fatalf("re-ingest of known v1 must not mint a duplicate item: %v", third)
+	}
+
+	db = openTestDB(t)
+	defer db.Close()
+	var versionCount int
+	if err := db.QueryRow(`
+select count(*) from items i
+join sources s on s.id = i.source_id
+join collections c on c.id = i.collection_id
+where s.kind = ? and c.external_id = ? and i.external_id = ? and i.tombstoned_at is null`,
+		ingest.MemorySourceKind, testMemoryNamespace, cardID).Scan(&versionCount); err != nil {
+		t.Fatal(err)
+	}
+	if versionCount != 2 {
+		t.Fatalf("expected exactly two content versions, got %d", versionCount)
+	}
+	var liveID, liveHash, liveStamp string
+	if err := db.QueryRow(`
+select i.id, i.content_hash, i.updated_at from items i
+join sources s on s.id = i.source_id
+join collections c on c.id = i.collection_id
+where s.kind = ? and c.external_id = ? and i.external_id = ? and i.tombstoned_at is null
+order by i.updated_at desc, i.id desc`, ingest.MemorySourceKind, testMemoryNamespace, cardID).Scan(&liveID, &liveHash, &liveStamp); err != nil {
+		t.Fatal(err)
+	}
+	if liveID != v1ID || liveHash != v1Hash {
+		t.Fatalf("restored v1 must be live: got id=%s hash=%s want id=%s hash=%s", liveID, liveHash, v1ID, v1Hash)
+	}
+	if liveStamp <= v1Stamp {
+		t.Fatalf("known-content re-ingest must refresh ingest stamp: before=%q after=%q", v1Stamp, liveStamp)
+	}
+	live, err := ingest.LiveMemoryProjection(db, testMemoryNamespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if live[cardID] != v1Hash {
+		t.Fatalf("projection live hash=%s want v1 %s", live[cardID], v1Hash)
+	}
+	if err := db.QueryRow(`select target_item_id from relations where target_external_id = ? and target_source_kind = ?`,
+		cardID, ingest.MemorySourceKind).Scan(&inbound); err != nil {
+		t.Fatal(err)
+	}
+	if inbound != v1ID {
+		t.Fatalf("inbound relation must re-point to restored v1=%s, got %s", v1ID, inbound)
+	}
+	health, err := ingest.CollectMemoryHealth(db, Version, testMemoryNamespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if health.UnresolvedRelations < 1 {
+		t.Fatalf("live health must count v1 outgoing unresolved relations: %+v", health)
+	}
+	var eventsAfter int
+	if err := db.QueryRow(`select count(*) from events where item_id = ?`, v1ID).Scan(&eventsAfter); err != nil {
+		t.Fatal(err)
+	}
+	if eventsAfter != eventsBefore {
+		t.Fatalf("re-ingest must not mint provenance events: before=%d after=%d", eventsBefore, eventsAfter)
+	}
+}
+
 func TestCrawlMemoryLatestVersionUsesIngestStampNotHashOrder(t *testing.T) {
 	withTempHome(t)
 	runOK(t, "init")

--- a/engines/evidence-ledger/internal/app/memory_test.go
+++ b/engines/evidence-ledger/internal/app/memory_test.go
@@ -853,6 +853,107 @@ func TestCollectMemoryHealthEmptyAggregatesAllCollections(t *testing.T) {
 	}
 }
 
+func TestCollectMemoryHealthEmptyReportsStaleNamespaceAfterNewerCompletion(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+	nsA := "memory-11111111-2222-4333-8444-aaaaaaaaaaaa"
+	nsB := "memory-99999999-8888-4777-8666-bbbbbbbbbbbb"
+	for i, ns := range []string{nsA, nsB} {
+		ws := t.TempDir()
+		writeTestNamespace(t, ws, ns)
+		cards := filepath.Join(ws, "memory", "cards")
+		if err := os.MkdirAll(cards, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		cardID := []string{
+			"card-aaaaaaa0-1111-4222-8333-444444444444",
+			"card-bbbbbbb0-1111-4222-8333-444444444444",
+		}[i]
+		body := "---\nid: " + cardID + "\ntopic: t\n---\n\n# Card\n"
+		if err := os.WriteFile(filepath.Join(cards, "card.md"), []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if i == 0 {
+			runJSON(t, "crawl", "memory", ws, "--json")
+			db := openTestDB(t)
+			scanID, err := ingest.BeginMemoryScan(db, ws, Version, ns)
+			if err != nil {
+				db.Close()
+				t.Fatal(err)
+			}
+			receipt := &ingest.MemoryScanReceipt{SourcePath: ws, EngineVersion: Version, Namespace: ns, Failed: 1}
+			if err := ingest.FailMemoryScan(db, scanID, "interrupted", receipt); err != nil {
+				db.Close()
+				t.Fatal(err)
+			}
+			db.Close()
+			continue
+		}
+		runJSON(t, "crawl", "memory", ws, "--json")
+	}
+
+	db := openTestDB(t)
+	defer db.Close()
+	agg, err := ingest.CollectMemoryHealth(db, Version, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !agg.Stale || !agg.Partial {
+		t.Fatalf("aggregate health must retain stale namespace state after newer completion: %+v", agg)
+	}
+}
+
+func TestCrawlMemoryRebuildRepointsInboundRelationForChangedContent(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+	ws := t.TempDir()
+	writeTestNamespace(t, ws, testMemoryNamespace)
+	cards := filepath.Join(ws, "memory", "cards")
+	if err := os.MkdirAll(cards, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cardID := "card-rebuild0-1111-4222-8333-444444444444"
+	cardPath := filepath.Join(cards, "card.md")
+	initial := "---\nid: " + cardID + "\ntopic: rebuild\n---\n\n# Initial\n"
+	if err := os.WriteFile(cardPath, []byte(initial), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runJSON(t, "crawl", "memory", ws, "--json")
+
+	supportJSONL := `{"schema":"miseledger.adapter.v1","source":{"kind":"brigade","name":"Brigade"},"collection":{"external_id":"brigade:receipts","kind":"brigade_receipt","name":"receipts"},"item":{"external_id":"receipt:changed-rebuild","kind":"receipt","created_at":"2026-01-01T00:00:00Z","text":"support"},"relations":[{"type":"supports","target":{"source":"brigade-memory","collection":"` + testMemoryNamespace + `","external_id":"` + cardID + `"}}],"raw":{"format":"json","path":"r.json","ordinal":1}}` + "\n"
+	supportPath := filepath.Join(t.TempDir(), "support.jsonl")
+	if err := os.WriteFile(supportPath, []byte(supportJSONL), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runOK(t, "import", "adapter", supportPath, "--json")
+
+	changed := "---\nid: " + cardID + "\ntopic: rebuild\n---\n\n# Changed\n"
+	if err := os.WriteFile(cardPath, []byte(changed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runJSON(t, "crawl", "memory", ws, "--rebuild", "--json")
+
+	db := openTestDB(t)
+	defer db.Close()
+	var liveID string
+	if err := db.QueryRow(`select i.id from items i
+join sources s on s.id = i.source_id
+join collections c on c.id = i.collection_id
+where s.kind = ? and c.external_id = ? and i.external_id = ? and i.tombstoned_at is null`,
+		ingest.MemorySourceKind, testMemoryNamespace, cardID).Scan(&liveID); err != nil {
+		t.Fatal(err)
+	}
+	var inbound int
+	if err := db.QueryRow(`select count(*) from relations
+where target_item_id = ? and target_source_kind = ? and target_collection_external_id = ? and target_external_id = ?`,
+		liveID, ingest.MemorySourceKind, testMemoryNamespace, cardID).Scan(&inbound); err != nil {
+		t.Fatal(err)
+	}
+	if inbound != 1 {
+		t.Fatalf("changed-content rebuild lost or mispointed inbound relation: target=%q count=%d", liveID, inbound)
+	}
+}
+
 func TestRebuildFailureAfterDetachPreservesProjectionGraph(t *testing.T) {
 	withTempHome(t)
 	runOK(t, "init")

--- a/engines/evidence-ledger/internal/app/memory_test.go
+++ b/engines/evidence-ledger/internal/app/memory_test.go
@@ -854,6 +854,113 @@ func TestLegacyMemoryCardsScopedRebuildRule(t *testing.T) {
 	}
 }
 
+func TestCrawlMemoryEditRepointsInboundRelationsToLatestVersion(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+	ws := t.TempDir()
+	writeTestNamespace(t, ws, testMemoryNamespace)
+	cards := filepath.Join(ws, "memory", "cards")
+	if err := os.MkdirAll(cards, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cardID := "card-edit0000-1111-4222-8333-444444444444"
+	cardPath := filepath.Join(cards, "edit.md")
+	if err := os.WriteFile(cardPath, []byte("---\nid: "+cardID+"\ntopic: edit\n---\n\n# Original\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runJSON(t, "crawl", "memory", ws, "--json")
+
+	db := openTestDB(t)
+	var v1ID, v1Hash string
+	if err := db.QueryRow(`
+select i.id, i.content_hash from items i
+join sources s on s.id = i.source_id
+join collections c on c.id = i.collection_id
+where s.kind = ? and c.external_id = ? and i.external_id = ? and i.tombstoned_at is null
+order by i.created_at desc, i.id desc`, ingest.MemorySourceKind, testMemoryNamespace, cardID).Scan(&v1ID, &v1Hash); err != nil {
+		t.Fatal(err)
+	}
+	supportJSONL := `{"schema":"miseledger.adapter.v1","source":{"kind":"brigade","name":"Brigade"},"collection":{"external_id":"brigade:receipts","kind":"brigade_receipt","name":"receipts"},"item":{"external_id":"receipt:edit-support","kind":"receipt","created_at":"2026-01-01T00:00:00Z","text":"support"},"relations":[{"type":"supports","target":{"source":"brigade-memory","collection":"` + testMemoryNamespace + `","external_id":"` + cardID + `"}}],"raw":{"format":"json","path":"r.json","ordinal":1}}` + "\n"
+	db.Close()
+	supportPath := filepath.Join(t.TempDir(), "support.jsonl")
+	if err := os.WriteFile(supportPath, []byte(supportJSONL), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runOK(t, "import", "adapter", supportPath, "--json")
+
+	db = openTestDB(t)
+	var inboundTarget string
+	if err := db.QueryRow(`select target_item_id from relations where target_external_id = ? and target_source_kind = ?`,
+		cardID, ingest.MemorySourceKind).Scan(&inboundTarget); err != nil {
+		t.Fatal(err)
+	}
+	if inboundTarget != v1ID {
+		t.Fatalf("inbound should resolve to v1=%s, got %s", v1ID, inboundTarget)
+	}
+	db.Close()
+
+	// Non-rebuild edit: content-addressed import creates a second item id while
+	// the prior version stays untombstoned (same external id still observed).
+	if err := os.WriteFile(cardPath, []byte("---\nid: "+cardID+"\ntopic: edit\n---\n\n# Edited body\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	edited := runJSON(t, "crawl", "memory", ws, "--json")
+	if edited["updated"].(float64) < 1 {
+		t.Fatalf("expected non-rebuild update: %v", edited)
+	}
+
+	db = openTestDB(t)
+	defer db.Close()
+	var versionCount int
+	if err := db.QueryRow(`
+select count(*) from items i
+join sources s on s.id = i.source_id
+join collections c on c.id = i.collection_id
+where s.kind = ? and c.external_id = ? and i.external_id = ? and i.tombstoned_at is null`,
+		ingest.MemorySourceKind, testMemoryNamespace, cardID).Scan(&versionCount); err != nil {
+		t.Fatal(err)
+	}
+	if versionCount < 2 {
+		t.Fatalf("expected prior+latest content-addressed versions, got %d", versionCount)
+	}
+	var v2ID, v2Hash string
+	if err := db.QueryRow(`
+select i.id, i.content_hash from items i
+join sources s on s.id = i.source_id
+join collections c on c.id = i.collection_id
+where s.kind = ? and c.external_id = ? and i.external_id = ? and i.tombstoned_at is null
+order by i.created_at desc, i.id desc`, ingest.MemorySourceKind, testMemoryNamespace, cardID).Scan(&v2ID, &v2Hash); err != nil {
+		t.Fatal(err)
+	}
+	if v2ID == v1ID || v2Hash == v1Hash {
+		t.Fatalf("edit must mint a new content-addressed item id/hash (v1=%s/%s v2=%s/%s)", v1ID, v1Hash, v2ID, v2Hash)
+	}
+	if err := db.QueryRow(`select target_item_id from relations where target_external_id = ? and target_source_kind = ?`,
+		cardID, ingest.MemorySourceKind).Scan(&inboundTarget); err != nil {
+		t.Fatal(err)
+	}
+	if inboundTarget != v2ID {
+		t.Fatalf("inbound relation must repoint to latest version %s, still on %s", v2ID, inboundTarget)
+	}
+	live, err := ingest.LiveMemoryProjection(db, testMemoryNamespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if live[cardID] != v2Hash {
+		t.Fatalf("live health hash for %s = %q want latest %q", cardID, live[cardID], v2Hash)
+	}
+	health, err := ingest.CollectMemoryHealth(db, Version, testMemoryNamespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if health.LiveCount != 1 {
+		t.Fatalf("live_count should count latest external ids once, got %d", health.LiveCount)
+	}
+	if health.UnresolvedRelations != 0 {
+		t.Fatalf("resolved inbound must not leave unresolved_relations=%d", health.UnresolvedRelations)
+	}
+}
+
 func TestCollectMemoryHealthEmptyAggregatesAllCollections(t *testing.T) {
 	withTempHome(t)
 	runOK(t, "init")

--- a/engines/evidence-ledger/internal/archive/db.go
+++ b/engines/evidence-ledger/internal/archive/db.go
@@ -10,7 +10,7 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-const SchemaVersion = 2
+const SchemaVersion = 3
 
 func Open(path string) (*sql.DB, error) {
 	if err := security.EnsurePrivateParent(path); err != nil {
@@ -84,6 +84,9 @@ func Migrate(db *sql.DB) error {
 	if err := ensureSchemaV2(db); err != nil {
 		return err
 	}
+	if err := ensureSchemaV3(db); err != nil {
+		return err
+	}
 	if _, err := db.Exec("PRAGMA user_version = " + fmt.Sprint(SchemaVersion)); err != nil {
 		return err
 	}
@@ -137,6 +140,18 @@ create table if not exists source_scan_observed(
   primary key(scan_id, external_id)
 );
 `)
+	return err
+}
+
+// ensureSchemaV3 adds a database-monotonic ingest sequence for latest-version
+// selection that does not depend on wall-clock updated_at.
+func ensureSchemaV3(db *sql.DB) error {
+	if _, err := db.Exec(`alter table items add column ingest_seq integer not null default 0`); err != nil {
+		if !strings.Contains(strings.ToLower(err.Error()), "duplicate column") {
+			return err
+		}
+	}
+	_, err := db.Exec(`create index if not exists idx_items_ingest_seq on items(ingest_seq)`)
 	return err
 }
 
@@ -204,6 +219,7 @@ create table if not exists items(
   raw_path text,
   raw_ordinal integer,
   metadata_json text not null default '{}',
+  ingest_seq integer not null default 0,
   unique(source_id, collection_id, external_id, content_hash)
 );
 

--- a/engines/evidence-ledger/internal/archive/db.go
+++ b/engines/evidence-ledger/internal/archive/db.go
@@ -144,14 +144,45 @@ create table if not exists source_scan_observed(
 }
 
 // ensureSchemaV3 adds a database-monotonic ingest sequence for latest-version
-// selection that does not depend on wall-clock updated_at.
+// selection that does not depend on wall-clock updated_at. Pre-existing rows
+// are deterministically backfilled from prior updated_at order (id fallback)
+// so multi-version memory cards keep the previously live winner across upgrade.
 func ensureSchemaV3(db *sql.DB) error {
 	if _, err := db.Exec(`alter table items add column ingest_seq integer not null default 0`); err != nil {
 		if !strings.Contains(strings.ToLower(err.Error()), "duplicate column") {
 			return err
 		}
 	}
-	_, err := db.Exec(`create index if not exists idx_items_ingest_seq on items(ingest_seq)`)
+	if _, err := db.Exec(`create index if not exists idx_items_ingest_seq on items(ingest_seq)`); err != nil {
+		return err
+	}
+	return backfillIngestSeqIfNeeded(db)
+}
+
+// backfillIngestSeqIfNeeded assigns ingest_seq for archives that still carry the
+// migration default (all zeros). Ordering mirrors the pre-v3 live selector:
+// updated_at ascending then id ascending, so ORDER BY ingest_seq DESC, id DESC
+// preserves the same winner. Safe to re-run: once any row has a non-zero seq,
+// existing assignments are left untouched.
+func backfillIngestSeqIfNeeded(db *sql.DB) error {
+	var maxSeq, n int64
+	if err := db.QueryRow(`select coalesce(max(ingest_seq), 0), count(*) from items`).Scan(&maxSeq, &n); err != nil {
+		return err
+	}
+	if n == 0 || maxSeq > 0 {
+		return nil
+	}
+	_, err := db.Exec(`
+with ranked as (
+  select id,
+         row_number() over (
+           order by coalesce(updated_at, '') asc, id asc
+         ) as seq
+  from items
+)
+update items
+set ingest_seq = (select seq from ranked where ranked.id = items.id)
+`)
 	return err
 }
 

--- a/engines/evidence-ledger/internal/archive/db_test.go
+++ b/engines/evidence-ledger/internal/archive/db_test.go
@@ -254,3 +254,173 @@ func TestCheckpointTruncatesWALAndKeepsSidecarsPrivate(t *testing.T) {
 		}
 	}
 }
+
+func TestMigrateV2ToV3BackfillsIngestSeqFromUpdatedAt(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "v2.db")
+	db, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := seedPreV3MultiVersionArchive(db); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = reopened.Close() })
+	if err := Migrate(reopened); err != nil {
+		t.Fatalf("migrate v2 archive: %v", err)
+	}
+	got, err := UserVersion(reopened)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != SchemaVersion {
+		t.Fatalf("user_version=%d want %d", got, SchemaVersion)
+	}
+
+	var olderSeq, newerSeq int64
+	if err := reopened.QueryRow(`select ingest_seq from items where id = ?`, "zzzz-older-content-hash-id").Scan(&olderSeq); err != nil {
+		t.Fatal(err)
+	}
+	if err := reopened.QueryRow(`select ingest_seq from items where id = ?`, "aaaa-newer-content-hash-id").Scan(&newerSeq); err != nil {
+		t.Fatal(err)
+	}
+	if !(newerSeq > olderSeq && olderSeq > 0) {
+		t.Fatalf("backfill must preserve updated_at order: older=%d newer=%d", olderSeq, newerSeq)
+	}
+
+	// Equal updated_at falls back to id ordering so the pre-v3
+	// `updated_at desc, id desc` winner (lexicographically greater id) keeps
+	// the higher ingest_seq.
+	var equalGreaterID, equalLesserID int64
+	if err := reopened.QueryRow(`select ingest_seq from items where id = ?`, "zzzz-equal-clock-older").Scan(&equalGreaterID); err != nil {
+		t.Fatal(err)
+	}
+	if err := reopened.QueryRow(`select ingest_seq from items where id = ?`, "aaaa-equal-clock-newer").Scan(&equalLesserID); err != nil {
+		t.Fatal(err)
+	}
+	if !(equalGreaterID > equalLesserID) {
+		t.Fatalf("equal updated_at id fallback: greater-id seq=%d lesser-id seq=%d", equalGreaterID, equalLesserID)
+	}
+
+	if err := Migrate(reopened); err != nil {
+		t.Fatalf("idempotent migrate: %v", err)
+	}
+	var newerAgain int64
+	if err := reopened.QueryRow(`select ingest_seq from items where id = ?`, "aaaa-newer-content-hash-id").Scan(&newerAgain); err != nil {
+		t.Fatal(err)
+	}
+	if newerAgain != newerSeq {
+		t.Fatalf("second migrate reshuffled ingest_seq %d -> %d", newerSeq, newerAgain)
+	}
+}
+
+func TestMigrateBackfillsZeroIngestSeqWhenColumnAlreadyPresent(t *testing.T) {
+	// Simulates archives upgraded by the pre-backfill schema v3 (all zeros).
+	db := openMigrated(t)
+	now := "2026-08-10T00:00:00Z"
+	if _, err := db.Exec(`insert into sources(id, kind, name, version, created_at, updated_at) values(?,?,?,?,?,?)`,
+		"src", "brigade-memory", "Memory", "1.0.0", now, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`insert into collections(id, source_id, external_id, kind, name, metadata_json, created_at, updated_at) values(?,?,?,?,?,?,?,?)`,
+		"col", "src", "memory-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee", "memory_cards", "cards", "{}", now, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`insert into items(id, source_id, collection_id, external_id, kind, created_at, updated_at, text, content_hash, raw_json, metadata_json, ingest_seq)
+values(?,?,?,?,?,?,?,?,?,?,?,0)`, "zzzz-zero-older", "src", "col", "card-zero", "memory_card", "", "2026-08-10T01:00:00Z", "older", "sha256:older", "{}", "{}"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`insert into items(id, source_id, collection_id, external_id, kind, created_at, updated_at, text, content_hash, raw_json, metadata_json, ingest_seq)
+values(?,?,?,?,?,?,?,?,?,?,?,0)`, "aaaa-zero-newer", "src", "col", "card-zero", "memory_card", "", "2026-08-10T02:00:00Z", "newer", "sha256:newer", "{}", "{}"); err != nil {
+		t.Fatal(err)
+	}
+	if err := Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	var olderSeq, newerSeq int64
+	if err := db.QueryRow(`select ingest_seq from items where id = ?`, "zzzz-zero-older").Scan(&olderSeq); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`select ingest_seq from items where id = ?`, "aaaa-zero-newer").Scan(&newerSeq); err != nil {
+		t.Fatal(err)
+	}
+	if !(newerSeq > olderSeq && olderSeq > 0) {
+		t.Fatalf("zero-column repair backfill failed older=%d newer=%d", olderSeq, newerSeq)
+	}
+}
+
+// seedPreV3MultiVersionArchive builds a schema-v2 shaped archive (no ingest_seq)
+// with multi-version memory cards whose pre-v3 live winner is the later updated_at
+// row (and, for equal clocks, the lexicographically greater id).
+func seedPreV3MultiVersionArchive(db *sql.DB) error {
+	stmts := []string{
+		`create table sources(
+  id text primary key, kind text not null, name text, version text,
+  created_at text not null, updated_at text not null)`,
+		`create table collections(
+  id text primary key, source_id text not null references sources(id),
+  external_id text not null, kind text not null, name text,
+  metadata_json text not null default '{}', created_at text, updated_at text,
+  unique(source_id, external_id))`,
+		`create table items(
+  id text primary key, source_id text not null references sources(id),
+  collection_id text not null references collections(id),
+  actor_id text, external_id text not null, kind text not null,
+  created_at text, updated_at text, text text, summary text,
+  content_hash text not null, raw_json text not null, raw_hash text,
+  raw_path text, raw_ordinal integer, metadata_json text not null default '{}',
+  unique(source_id, collection_id, external_id, content_hash))`,
+		`create table relations(
+  id text primary key, source_item_id text not null, target_item_id text,
+  target_external_id text, relation_type text not null,
+  confidence real not null default 1.0, metadata_json text not null default '{}')`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			return err
+		}
+	}
+	if err := ensureSchemaV2(db); err != nil {
+		return err
+	}
+	if _, err := db.Exec(`PRAGMA user_version = 2`); err != nil {
+		return err
+	}
+	now := "2026-08-10T00:00:00Z"
+	ns := "memory-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+	if _, err := db.Exec(`insert into sources(id, kind, name, version, created_at, updated_at) values(?,?,?,?,?,?)`,
+		"src-memory", "brigade-memory", "Memory", "1.0.0", now, now); err != nil {
+		return err
+	}
+	if _, err := db.Exec(`insert into collections(id, source_id, external_id, kind, name, metadata_json, created_at, updated_at) values(?,?,?,?,?,?,?,?)`,
+		"col-memory", "src-memory", ns, "memory_cards", "cards", "{}", now, now); err != nil {
+		return err
+	}
+	rows := []struct {
+		id, updated, text, hash string
+	}{
+		{"zzzz-older-content-hash-id", "2026-08-10T01:00:00Z", "older", "sha256:older"},
+		{"aaaa-newer-content-hash-id", "2026-08-10T02:00:00Z", "newer", "sha256:newer"},
+		{"zzzz-equal-clock-older", "2026-08-10T03:00:00Z", "equal-older", "sha256:equal-older"},
+		{"aaaa-equal-clock-newer", "2026-08-10T03:00:00Z", "equal-newer", "sha256:equal-newer"},
+	}
+	for i, row := range rows {
+		ext := "card-order"
+		if i >= 2 {
+			ext = "card-equal"
+		}
+		if _, err := db.Exec(`insert into items(id, source_id, collection_id, external_id, kind, created_at, updated_at, text, content_hash, raw_json, metadata_json)
+values(?,?,?,?,?,?,?,?,?,?,?)`, row.id, "src-memory", "col-memory", ext, "memory_card", "", row.updated, row.text, row.hash, "{}", "{}"); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/engines/evidence-ledger/internal/ingest/importer.go
+++ b/engines/evidence-ledger/internal/ingest/importer.go
@@ -298,6 +298,16 @@ set target_item_id = (
     and (relations.target_collection_external_id is null
          or relations.target_collection_external_id = ''
          or tc.external_id = relations.target_collection_external_id)
+    and (coalesce(relations.target_collection_external_id, '') != ''
+         or 1 = (
+           select count(*)
+           from items candidate
+           join sources cs on cs.id = candidate.source_id
+           left join collections cc on cc.id = candidate.collection_id
+           where cs.kind = relations.target_source_kind
+             and candidate.external_id = relations.target_external_id
+             and candidate.tombstoned_at is null
+         ))
     and target.tombstoned_at is null
   order by target.created_at, target.id
   limit 1
@@ -315,6 +325,16 @@ where target_item_id is null
       and (relations.target_collection_external_id is null
            or relations.target_collection_external_id = ''
            or tc.external_id = relations.target_collection_external_id)
+      and (coalesce(relations.target_collection_external_id, '') != ''
+           or 1 = (
+             select count(*)
+             from items candidate
+             join sources cs on cs.id = candidate.source_id
+             left join collections cc on cc.id = candidate.collection_id
+             where cs.kind = relations.target_source_kind
+               and candidate.external_id = relations.target_external_id
+               and candidate.tombstoned_at is null
+           ))
       and target.tombstoned_at is null
   )`)
 	if err != nil {

--- a/engines/evidence-ledger/internal/ingest/importer.go
+++ b/engines/evidence-ledger/internal/ingest/importer.go
@@ -287,6 +287,9 @@ func BackfillRelations(db *sql.DB) (int64, error) {
 func resolveRelations(tx *sql.Tx) (int64, error) {
 	// Qualified targets (target_source_kind set) resolve across sources using
 	// source.kind + optional collection.external_id + item.external_id.
+	// Always select the latest non-tombstoned version for that identity so an
+	// edit that mints a new content-addressed item id repoints existing edges.
+	const backupCollectionLike = "__miseledger_memory_backup__:%"
 	qualified, err := tx.Exec(`update relations
 set target_item_id = (
   select target.id
@@ -312,11 +315,10 @@ set target_item_id = (
              and coalesce(cc.external_id, '') not like ?
          ))
     and target.tombstoned_at is null
-  order by target.created_at, target.id
+  order by target.created_at desc, target.id desc
   limit 1
 )
-where target_item_id is null
-  and coalesce(target_source_kind, '') != ''
+where coalesce(target_source_kind, '') != ''
   and coalesce(target_external_id, '') != ''
   and exists (
     select 1
@@ -342,7 +344,37 @@ where target_item_id is null
                and coalesce(cc.external_id, '') not like ?
            ))
       and target.tombstoned_at is null
-  )`, "__miseledger_memory_backup__:%", "__miseledger_memory_backup__:%", "__miseledger_memory_backup__:%", "__miseledger_memory_backup__:%")
+  )
+  and (
+    target_item_id is null
+    or target_item_id != (
+      select target.id
+      from items target
+      join sources ts on ts.id = target.source_id
+      left join collections tc on tc.id = target.collection_id
+      where ts.kind = relations.target_source_kind
+        and target.external_id = relations.target_external_id
+        and (relations.target_collection_external_id is null
+             or relations.target_collection_external_id = ''
+             or tc.external_id = relations.target_collection_external_id)
+        and (coalesce(relations.target_collection_external_id, '') != ''
+             or coalesce(tc.external_id, '') not like ?)
+        and (coalesce(relations.target_collection_external_id, '') != ''
+             or 1 = (
+               select count(*)
+               from items candidate
+               join sources cs on cs.id = candidate.source_id
+               left join collections cc on cc.id = candidate.collection_id
+               where cs.kind = relations.target_source_kind
+                 and candidate.external_id = relations.target_external_id
+                 and candidate.tombstoned_at is null
+                 and coalesce(cc.external_id, '') not like ?
+             ))
+        and target.tombstoned_at is null
+      order by target.created_at desc, target.id desc
+      limit 1
+    )
+  )`, backupCollectionLike, backupCollectionLike, backupCollectionLike, backupCollectionLike, backupCollectionLike, backupCollectionLike)
 	if err != nil {
 		return 0, err
 	}
@@ -350,6 +382,8 @@ where target_item_id is null
 
 	// Legacy same-source resolution: target_external_id only, matching the
 	// source item's source_id. Preserves pre-Slice-1a adapter compatibility.
+	// Memory cards stay collection-scoped so cross-namespace same-id edges do
+	// not collide; always prefer the latest non-tombstoned version.
 	legacy, err := tx.Exec(`update relations
 set target_item_id = (
   select target.id
@@ -359,11 +393,10 @@ set target_item_id = (
   where source.id = relations.source_item_id
     and (source_kind.kind != ? or target.collection_id = source.collection_id)
     and target.tombstoned_at is null
-  order by target.created_at, target.id
+  order by target.created_at desc, target.id desc
   limit 1
 )
-where target_item_id is null
-  and coalesce(target_source_kind, '') = ''
+where coalesce(target_source_kind, '') = ''
   and target_external_id is not null
   and target_external_id != ''
   and exists (
@@ -374,7 +407,21 @@ where target_item_id is null
     where source.id = relations.source_item_id
       and (source_kind.kind != ? or target.collection_id = source.collection_id)
       and target.tombstoned_at is null
-  )`, MemorySourceKind, MemorySourceKind)
+  )
+  and (
+    target_item_id is null
+    or target_item_id != (
+      select target.id
+      from items source
+      join sources source_kind on source_kind.id = source.source_id
+      join items target on target.source_id = source.source_id and target.external_id = relations.target_external_id
+      where source.id = relations.source_item_id
+        and (source_kind.kind != ? or target.collection_id = source.collection_id)
+        and target.tombstoned_at is null
+      order by target.created_at desc, target.id desc
+      limit 1
+    )
+  )`, MemorySourceKind, MemorySourceKind, MemorySourceKind)
 	if err != nil {
 		return 0, err
 	}

--- a/engines/evidence-ledger/internal/ingest/importer.go
+++ b/engines/evidence-ledger/internal/ingest/importer.go
@@ -354,8 +354,10 @@ where target_item_id is null
 set target_item_id = (
   select target.id
   from items source
+  join sources source_kind on source_kind.id = source.source_id
   join items target on target.source_id = source.source_id and target.external_id = relations.target_external_id
   where source.id = relations.source_item_id
+    and (source_kind.kind != ? or target.collection_id = source.collection_id)
     and target.tombstoned_at is null
   order by target.created_at, target.id
   limit 1
@@ -367,10 +369,12 @@ where target_item_id is null
   and exists (
     select 1
     from items source
+    join sources source_kind on source_kind.id = source.source_id
     join items target on target.source_id = source.source_id and target.external_id = relations.target_external_id
     where source.id = relations.source_item_id
+      and (source_kind.kind != ? or target.collection_id = source.collection_id)
       and target.tombstoned_at is null
-  )`)
+  )`, MemorySourceKind, MemorySourceKind)
 	if err != nil {
 		return 0, err
 	}

--- a/engines/evidence-ledger/internal/ingest/importer.go
+++ b/engines/evidence-ledger/internal/ingest/importer.go
@@ -223,9 +223,13 @@ func importAdapterReaderProgress(db *sql.DB, r io.Reader, sourcePath, sourceOver
 		return AdapterResult{}, err
 	}
 	if exists > 0 {
-		// Same content already fully imported. The batches above only re-ran
-		// idempotent INSERT OR IGNOREs (no-ops), so committing the final empty
-		// tx is harmless and we skip writing a duplicate import row.
+		// Same content already fully imported. Batches above may still have
+		// refreshed known-item ingest stamps (v1 -> v2 -> identical v1), so
+		// resolve relations before returning without writing a duplicate import
+		// row or minting items/events.
+		if _, err := resolveRelations(tx); err != nil {
+			return AdapterResult{}, err
+		}
 		result.AlreadyKnown = true
 		committed = true
 		return result, tx.Commit()

--- a/engines/evidence-ledger/internal/ingest/importer.go
+++ b/engines/evidence-ledger/internal/ingest/importer.go
@@ -299,6 +299,8 @@ set target_item_id = (
          or relations.target_collection_external_id = ''
          or tc.external_id = relations.target_collection_external_id)
     and (coalesce(relations.target_collection_external_id, '') != ''
+         or coalesce(tc.external_id, '') not like ?)
+    and (coalesce(relations.target_collection_external_id, '') != ''
          or 1 = (
            select count(*)
            from items candidate
@@ -307,6 +309,7 @@ set target_item_id = (
            where cs.kind = relations.target_source_kind
              and candidate.external_id = relations.target_external_id
              and candidate.tombstoned_at is null
+             and coalesce(cc.external_id, '') not like ?
          ))
     and target.tombstoned_at is null
   order by target.created_at, target.id
@@ -326,6 +329,8 @@ where target_item_id is null
            or relations.target_collection_external_id = ''
            or tc.external_id = relations.target_collection_external_id)
       and (coalesce(relations.target_collection_external_id, '') != ''
+           or coalesce(tc.external_id, '') not like ?)
+      and (coalesce(relations.target_collection_external_id, '') != ''
            or 1 = (
              select count(*)
              from items candidate
@@ -334,9 +339,10 @@ where target_item_id is null
              where cs.kind = relations.target_source_kind
                and candidate.external_id = relations.target_external_id
                and candidate.tombstoned_at is null
+               and coalesce(cc.external_id, '') not like ?
            ))
       and target.tombstoned_at is null
-  )`)
+  )`, "__miseledger_memory_backup__:%", "__miseledger_memory_backup__:%", "__miseledger_memory_backup__:%", "__miseledger_memory_backup__:%")
 	if err != nil {
 		return 0, err
 	}
@@ -610,7 +616,7 @@ func buildIngestEnvelope(rec adapter.Record, ingestedAt string, capturedAt *stri
 		LocatorKind: locatorKind, LocatorValue: locatorValue,
 		Attribution: "observed",
 		// Modality tool-output classifies the ingest channel, not human authorship.
-		Modality: "tool-output",
+		Modality:   "tool-output",
 		TrustLabel: "quarantined", TrustAssignedBy: "ingest:ingest.upsertRecord", TrustAssignedAt: &at,
 		InjectionStatus: "pending", InjectionRules: []string{},
 		Text: text, RawBytes: raw, CapturedAt: capturedAt, IngestedAt: &at,

--- a/engines/evidence-ledger/internal/ingest/importer.go
+++ b/engines/evidence-ledger/internal/ingest/importer.go
@@ -319,7 +319,7 @@ set target_item_id = (
              and coalesce(cc.external_id, '') not like ?
          ))
     and target.tombstoned_at is null
-  order by target.updated_at desc, target.id desc
+  order by target.ingest_seq desc, target.id desc
   limit 1
 )
 where coalesce(target_source_kind, '') != ''
@@ -375,7 +375,7 @@ where coalesce(target_source_kind, '') != ''
                  and coalesce(cc.external_id, '') not like ?
              ))
         and target.tombstoned_at is null
-      order by target.updated_at desc, target.id desc
+      order by target.ingest_seq desc, target.id desc
       limit 1
     )
   )`, backupCollectionLike, backupCollectionLike, backupCollectionLike, backupCollectionLike, backupCollectionLike, backupCollectionLike)
@@ -397,7 +397,7 @@ set target_item_id = (
   where source.id = relations.source_item_id
     and (source_kind.kind != ? or target.collection_id = source.collection_id)
     and target.tombstoned_at is null
-  order by target.updated_at desc, target.id desc
+  order by target.ingest_seq desc, target.id desc
   limit 1
 )
 where coalesce(target_source_kind, '') = ''
@@ -422,7 +422,7 @@ where coalesce(target_source_kind, '') = ''
       where source.id = relations.source_item_id
         and (source_kind.kind != ? or target.collection_id = source.collection_id)
         and target.tombstoned_at is null
-      order by target.updated_at desc, target.id desc
+      order by target.ingest_seq desc, target.id desc
       limit 1
     )
   )`, MemorySourceKind, MemorySourceKind, MemorySourceKind)
@@ -556,15 +556,12 @@ func upsertRecord(tx *sql.Tx, rec adapter.Record, sourcePath string, ordinal int
 	}
 	collectionMeta := rawOrEmptyObject(rec.Collection.Metadata)
 
-	// Fast-path already-imported items. Items are content-addressed (itemID
-	// includes the content hash), so an existing row means this exact record is
-	// already stored. Still refresh the monotonic ingest/version stamp so a
-	// restore of prior content (v1 -> v2 -> v1) becomes live again without
-	// minting a duplicate item or provenance event. Skip sources/collections/
-	// actors upserts: those bump updated_at on every call and can stall retries.
+	// Fast-path already-imported text/summary identity. Refresh the DB-monotonic
+	// ingest_seq and reconcile canonical side tables (metadata/tags/provenance/
+	// artifacts/relations) without minting a duplicate item or provenance event.
 	var known int
 	if err := tx.QueryRow(`select 1 from items where id = ?`, itemID).Scan(&known); err == nil {
-		if _, err := tx.Exec(`update items set updated_at = ? where id = ?`, now, itemID); err != nil {
+		if err := reconcileKnownItem(tx, rec, itemID, sourceID, collectionID, actorID, contentHash, rawHash, rawPath, rawOrdinal, raw, body, now); err != nil {
 			return false, err
 		}
 		return false, nil
@@ -587,14 +584,15 @@ on conflict(source_id, external_id) do update set type=excluded.type, name=exclu
 			return false, err
 		}
 	}
-	// Content-addressed item ids do not encode time. Persist a real monotonic
-	// ingestion stamp on updated_at so latest-version selection cannot fall back
-	// to lexicographic content-hash order when created_at is empty or tied.
 	createdAt := strings.TrimSpace(rec.Item.CreatedAt)
 	if createdAt == "" {
 		createdAt = now
 	}
 	updatedAt := now
+	ingestSeq, err := nextIngestSeq(tx)
+	if err != nil {
+		return false, err
+	}
 	capturedAt := optionalString(createdAt)
 	itemLocator := fmt.Sprintf("miseledger://%s/%s/%s", rec.Source.Kind, rec.Collection.ExternalID, rec.Item.ExternalID)
 	envelope, err := buildIngestEnvelope(rec, now, capturedAt, rec.Item.Text, raw, rec.Collection.ExternalID, rec.Item.ExternalID, "uri", itemLocator)
@@ -602,25 +600,109 @@ on conflict(source_id, external_id) do update set type=excluded.type, name=exclu
 		return false, fmt.Errorf("build provenance envelope: %w", err)
 	}
 	itemMeta := itemMetadataJSON(rec, envelope)
-	res, err := tx.Exec(`insert or ignore into items(id, source_id, collection_id, actor_id, external_id, kind, created_at, updated_at, text, summary, content_hash, raw_json, raw_hash, raw_path, raw_ordinal, metadata_json)
-values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, itemID, sourceID, collectionID, nullIfEmpty(actorID), rec.Item.ExternalID, rec.Item.Kind, createdAt, updatedAt, rec.Item.Text, summary, contentHash, string(raw), rawHash, rawPath, rawOrdinal, string(itemMeta))
+	res, err := tx.Exec(`insert or ignore into items(id, source_id, collection_id, actor_id, external_id, kind, created_at, updated_at, text, summary, content_hash, raw_json, raw_hash, raw_path, raw_ordinal, metadata_json, ingest_seq)
+values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, itemID, sourceID, collectionID, nullIfEmpty(actorID), rec.Item.ExternalID, rec.Item.Kind, createdAt, updatedAt, rec.Item.Text, summary, contentHash, string(raw), rawHash, rawPath, rawOrdinal, string(itemMeta), ingestSeq)
 	if err != nil {
 		return false, err
 	}
 	insertedRows, _ := res.RowsAffected()
 	if insertedRows == 0 {
-		// Concurrent insert or race with the known-item probe: refresh the
-		// ingest stamp only; do not mint events/artifacts again.
-		if _, err := tx.Exec(`update items set updated_at = ? where id = ?`, now, itemID); err != nil {
+		if err := reconcileKnownItem(tx, rec, itemID, sourceID, collectionID, actorID, contentHash, rawHash, rawPath, rawOrdinal, raw, body, now); err != nil {
 			return false, err
 		}
 		return false, nil
 	}
 	eventID := stableID("event", itemID, createdAt, rec.Item.Kind)
 	_, _ = tx.Exec(`insert or ignore into events(id, source_id, collection_id, actor_id, item_id, kind, occurred_at) values(?,?,?,?,?,?,?)`, eventID, sourceID, collectionID, nullIfEmpty(actorID), itemID, rec.Item.Kind, createdAt)
-	if err := indexItemMetadata(tx, itemID, rec.Item.Tags, itemMeta); err != nil {
+	if err := replaceItemSideTables(tx, rec, itemID, sourceID, collectionID, capturedAt, raw, body, now, false); err != nil {
 		return false, err
 	}
+	return true, nil
+}
+
+func nextIngestSeq(tx *sql.Tx) (int64, error) {
+	var next int64
+	if err := tx.QueryRow(`select coalesce(max(ingest_seq), 0) + 1 from items`).Scan(&next); err != nil {
+		return 0, err
+	}
+	return next, nil
+}
+
+// reconcileKnownItem advances the DB-monotonic ingest_seq and rewrites canonical
+// side fields for an existing content-addressed item without minting events.
+func reconcileKnownItem(tx *sql.Tx, rec adapter.Record, itemID, sourceID, collectionID, actorID, contentHash, rawHash, rawPath string, rawOrdinal int64, raw []byte, body, now string) error {
+	// Ensure parent rows exist for FK safety without rewriting source/collection
+	// timestamps on every known-item hit (keeps retry fast-path cheap).
+	if _, err := tx.Exec(`insert into sources(id, kind, name, version, created_at, updated_at) values(?,?,?,?,?,?)
+on conflict(id) do nothing`, sourceID, rec.Source.Kind, rec.Source.Name, rec.Source.Version, now, now); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`insert into collections(id, source_id, external_id, kind, name, metadata_json, created_at, updated_at) values(?,?,?,?,?,?,?,?)
+on conflict(source_id, external_id) do nothing`, collectionID, sourceID, rec.Collection.ExternalID, rec.Collection.Kind, rec.Collection.Name, rawOrEmptyObject(rec.Collection.Metadata), now, now); err != nil {
+		return err
+	}
+	if actorID != "" {
+		actorMeta := rawOrEmptyObject(rec.Actor.Metadata)
+		if _, err := tx.Exec(`insert into actors(id, source_id, external_id, type, name, metadata_json) values(?,?,?,?,?,?)
+on conflict(source_id, external_id) do update set type=excluded.type, name=excluded.name, metadata_json=excluded.metadata_json`, actorID, sourceID, rec.Actor.ExternalID, rec.Actor.Type, rec.Actor.Name, actorMeta); err != nil {
+			return err
+		}
+	}
+	ingestSeq, err := nextIngestSeq(tx)
+	if err != nil {
+		return err
+	}
+	createdAt := strings.TrimSpace(rec.Item.CreatedAt)
+	if createdAt == "" {
+		createdAt = now
+	}
+	capturedAt := optionalString(createdAt)
+	itemLocator := fmt.Sprintf("miseledger://%s/%s/%s", rec.Source.Kind, rec.Collection.ExternalID, rec.Item.ExternalID)
+	envelope, err := buildIngestEnvelope(rec, now, capturedAt, rec.Item.Text, raw, rec.Collection.ExternalID, rec.Item.ExternalID, "uri", itemLocator)
+	if err != nil {
+		return fmt.Errorf("build provenance envelope: %w", err)
+	}
+	itemMeta := itemMetadataJSON(rec, envelope)
+	summary := ""
+	if rec.Item.Summary != nil {
+		summary = *rec.Item.Summary
+	}
+	if _, err := tx.Exec(`update items set actor_id = ?, updated_at = ?, summary = ?, raw_json = ?, raw_hash = ?, raw_path = ?, raw_ordinal = ?, metadata_json = ?, ingest_seq = ?
+where id = ?`, nullIfEmpty(actorID), now, summary, string(raw), rawHash, rawPath, rawOrdinal, string(itemMeta), ingestSeq, itemID); err != nil {
+		return err
+	}
+	return replaceItemSideTables(tx, rec, itemID, sourceID, collectionID, capturedAt, raw, body, now, true)
+}
+
+func replaceItemSideTables(tx *sql.Tx, rec adapter.Record, itemID, sourceID, collectionID string, capturedAt *string, raw []byte, body, now string, replaceExisting bool) error {
+	if replaceExisting {
+		if _, err := tx.Exec(`delete from item_tags where item_id = ?`, itemID); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(`delete from item_metadata where item_id = ?`, itemID); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(`delete from artifacts where item_id = ?`, itemID); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(`delete from relations where source_item_id = ?`, itemID); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(`delete from item_fts where item_id = ?`, itemID); err != nil {
+			return err
+		}
+	}
+	itemLocator := fmt.Sprintf("miseledger://%s/%s/%s", rec.Source.Kind, rec.Collection.ExternalID, rec.Item.ExternalID)
+	_ = itemLocator
+	envelope, err := buildIngestEnvelope(rec, now, capturedAt, rec.Item.Text, raw, rec.Collection.ExternalID, rec.Item.ExternalID, "uri", itemLocator)
+	if err != nil {
+		return err
+	}
+	itemMeta := itemMetadataJSON(rec, envelope)
+	if err := indexItemMetadata(tx, itemID, rec.Item.Tags, itemMeta); err != nil {
+		return err
+	}
+	ftsBody := body
 	for _, art := range rec.Artifacts {
 		artifactID := stableID("artifact", itemID, art.ExternalID, art.Kind, art.Path, art.URL, art.Hash)
 		artifactHash := art.Hash
@@ -630,14 +712,14 @@ values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, itemID, sourceID, collectionID, nullIf
 		artLocatorKind, artLocatorValue := artifactLocator(rec, art)
 		artEnvelope, err := buildIngestEnvelope(rec, now, capturedAt, art.Text, nil, rec.Collection.ExternalID, art.ExternalID, artLocatorKind, artLocatorValue)
 		if err != nil {
-			return false, fmt.Errorf("build artifact provenance envelope: %w", err)
+			return fmt.Errorf("build artifact provenance envelope: %w", err)
 		}
 		artMeta := mergeMetadataJSON(art.Metadata, artEnvelope, nil)
 		if _, err := tx.Exec(`insert or ignore into artifacts(id, source_id, item_id, external_id, kind, path, url, mime_type, text, content_hash, metadata_json) values(?,?,?,?,?,?,?,?,?,?,?)`, artifactID, sourceID, itemID, art.ExternalID, art.Kind, art.Path, art.URL, art.MimeType, art.Text, artifactHash, string(artMeta)); err != nil {
-			return false, err
+			return err
 		}
 		if art.Text != "" {
-			body += "\n" + textnorm.Normalize(art.Text)
+			ftsBody += "\n" + textnorm.Normalize(art.Text)
 		}
 	}
 	for _, link := range rec.Links {
@@ -648,13 +730,13 @@ values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, itemID, sourceID, collectionID, nullIf
 		linkLocator := linkProvenanceLocator(rec, link.URL)
 		linkEnvelope, err := buildIngestEnvelope(rec, now, capturedAt, link.Text, nil, rec.Collection.ExternalID, link.URL, "uri", linkLocator)
 		if err != nil {
-			return false, fmt.Errorf("build link provenance envelope: %w", err)
+			return fmt.Errorf("build link provenance envelope: %w", err)
 		}
 		linkMeta := mergeMetadataJSON(nil, linkEnvelope, map[string]any{"link_text": link.Text})
 		if _, err := tx.Exec(`insert or ignore into artifacts(id, source_id, item_id, external_id, kind, path, url, mime_type, text, content_hash, metadata_json) values(?,?,?,?,?,?,?,?,?,?,?)`, artifactID, sourceID, itemID, link.URL, "url", "", link.URL, "text/uri-list", link.Text, "sha256:"+hashString(link.URL), string(linkMeta)); err != nil {
-			return false, err
+			return err
 		}
-		body += "\n" + textnorm.Normalize(link.URL+" "+link.Text)
+		ftsBody += "\n" + textnorm.Normalize(link.URL+" "+link.Text)
 	}
 	for _, rel := range rec.Relations {
 		confidence := 1.0
@@ -665,17 +747,17 @@ values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, itemID, sourceID, collectionID, nullIf
 		relID := stableID("relation", itemID, rel.TargetItemID, targetSource, targetCollection, targetExternal, rel.Type)
 		if _, err := tx.Exec(`insert or ignore into relations(id, source_item_id, target_item_id, target_external_id, target_source_kind, target_collection_external_id, relation_type, confidence, metadata_json) values(?,?,?,?,?,?,?,?,?)`,
 			relID, itemID, nullIfEmpty(rel.TargetItemID), nullIfEmpty(targetExternal), nullIfEmpty(targetSource), nullIfEmpty(targetCollection), rel.Type, confidence, rawOrEmptyObject(rel.Metadata)); err != nil {
-			return false, err
+			return err
 		}
 	}
 	actorType := ""
 	if rec.Actor != nil {
 		actorType = rec.Actor.Type
 	}
-	if _, err := tx.Exec(`insert into item_fts(item_id, source_kind, collection_kind, item_kind, actor_type, body) values(?,?,?,?,?,?)`, itemID, rec.Source.Kind, rec.Collection.Kind, rec.Item.Kind, actorType, body); err != nil {
-		return false, err
+	if _, err := tx.Exec(`insert into item_fts(item_id, source_kind, collection_kind, item_kind, actor_type, body) values(?,?,?,?,?,?)`, itemID, rec.Source.Kind, rec.Collection.Kind, rec.Item.Kind, actorType, ftsBody); err != nil {
+		return err
 	}
-	return true, nil
+	return nil
 }
 
 func buildIngestEnvelope(rec adapter.Record, ingestedAt string, capturedAt *string, text string, raw []byte, collectionID, itemID, locatorKind, locatorValue string) (provenance.Envelope, error) {

--- a/engines/evidence-ledger/internal/ingest/importer.go
+++ b/engines/evidence-ledger/internal/ingest/importer.go
@@ -554,12 +554,15 @@ func upsertRecord(tx *sql.Tx, rec adapter.Record, sourcePath string, ordinal int
 
 	// Fast-path already-imported items. Items are content-addressed (itemID
 	// includes the content hash), so an existing row means this exact record is
-	// already stored. Short-circuit before the sources/collections/actors
-	// upserts: those bump updated_at on every call, so without this probe a
-	// re-run (or a retry after a timeout) rewrites the whole committed prefix
-	// row by row and makes no forward progress within a time budget.
+	// already stored. Still refresh the monotonic ingest/version stamp so a
+	// restore of prior content (v1 -> v2 -> v1) becomes live again without
+	// minting a duplicate item or provenance event. Skip sources/collections/
+	// actors upserts: those bump updated_at on every call and can stall retries.
 	var known int
 	if err := tx.QueryRow(`select 1 from items where id = ?`, itemID).Scan(&known); err == nil {
+		if _, err := tx.Exec(`update items set updated_at = ? where id = ?`, now, itemID); err != nil {
+			return false, err
+		}
 		return false, nil
 	} else if err != sql.ErrNoRows {
 		return false, err
@@ -602,6 +605,11 @@ values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, itemID, sourceID, collectionID, nullIf
 	}
 	insertedRows, _ := res.RowsAffected()
 	if insertedRows == 0 {
+		// Concurrent insert or race with the known-item probe: refresh the
+		// ingest stamp only; do not mint events/artifacts again.
+		if _, err := tx.Exec(`update items set updated_at = ? where id = ?`, now, itemID); err != nil {
+			return false, err
+		}
 		return false, nil
 	}
 	eventID := stableID("event", itemID, createdAt, rec.Item.Kind)

--- a/engines/evidence-ledger/internal/ingest/importer.go
+++ b/engines/evidence-ledger/internal/ingest/importer.go
@@ -315,7 +315,7 @@ set target_item_id = (
              and coalesce(cc.external_id, '') not like ?
          ))
     and target.tombstoned_at is null
-  order by target.created_at desc, target.id desc
+  order by target.updated_at desc, target.id desc
   limit 1
 )
 where coalesce(target_source_kind, '') != ''
@@ -371,7 +371,7 @@ where coalesce(target_source_kind, '') != ''
                  and coalesce(cc.external_id, '') not like ?
              ))
         and target.tombstoned_at is null
-      order by target.created_at desc, target.id desc
+      order by target.updated_at desc, target.id desc
       limit 1
     )
   )`, backupCollectionLike, backupCollectionLike, backupCollectionLike, backupCollectionLike, backupCollectionLike, backupCollectionLike)
@@ -393,7 +393,7 @@ set target_item_id = (
   where source.id = relations.source_item_id
     and (source_kind.kind != ? or target.collection_id = source.collection_id)
     and target.tombstoned_at is null
-  order by target.created_at desc, target.id desc
+  order by target.updated_at desc, target.id desc
   limit 1
 )
 where coalesce(target_source_kind, '') = ''
@@ -418,7 +418,7 @@ where coalesce(target_source_kind, '') = ''
       where source.id = relations.source_item_id
         and (source_kind.kind != ? or target.collection_id = source.collection_id)
         and target.tombstoned_at is null
-      order by target.created_at desc, target.id desc
+      order by target.updated_at desc, target.id desc
       limit 1
     )
   )`, MemorySourceKind, MemorySourceKind, MemorySourceKind)
@@ -580,7 +580,15 @@ on conflict(source_id, external_id) do update set type=excluded.type, name=exclu
 			return false, err
 		}
 	}
-	capturedAt := optionalString(rec.Item.CreatedAt)
+	// Content-addressed item ids do not encode time. Persist a real monotonic
+	// ingestion stamp on updated_at so latest-version selection cannot fall back
+	// to lexicographic content-hash order when created_at is empty or tied.
+	createdAt := strings.TrimSpace(rec.Item.CreatedAt)
+	if createdAt == "" {
+		createdAt = now
+	}
+	updatedAt := now
+	capturedAt := optionalString(createdAt)
 	itemLocator := fmt.Sprintf("miseledger://%s/%s/%s", rec.Source.Kind, rec.Collection.ExternalID, rec.Item.ExternalID)
 	envelope, err := buildIngestEnvelope(rec, now, capturedAt, rec.Item.Text, raw, rec.Collection.ExternalID, rec.Item.ExternalID, "uri", itemLocator)
 	if err != nil {
@@ -588,7 +596,7 @@ on conflict(source_id, external_id) do update set type=excluded.type, name=exclu
 	}
 	itemMeta := itemMetadataJSON(rec, envelope)
 	res, err := tx.Exec(`insert or ignore into items(id, source_id, collection_id, actor_id, external_id, kind, created_at, updated_at, text, summary, content_hash, raw_json, raw_hash, raw_path, raw_ordinal, metadata_json)
-values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, itemID, sourceID, collectionID, nullIfEmpty(actorID), rec.Item.ExternalID, rec.Item.Kind, rec.Item.CreatedAt, rec.Item.UpdatedAt, rec.Item.Text, summary, contentHash, string(raw), rawHash, rawPath, rawOrdinal, string(itemMeta))
+values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, itemID, sourceID, collectionID, nullIfEmpty(actorID), rec.Item.ExternalID, rec.Item.Kind, createdAt, updatedAt, rec.Item.Text, summary, contentHash, string(raw), rawHash, rawPath, rawOrdinal, string(itemMeta))
 	if err != nil {
 		return false, err
 	}
@@ -596,8 +604,8 @@ values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, itemID, sourceID, collectionID, nullIf
 	if insertedRows == 0 {
 		return false, nil
 	}
-	eventID := stableID("event", itemID, rec.Item.CreatedAt, rec.Item.Kind)
-	_, _ = tx.Exec(`insert or ignore into events(id, source_id, collection_id, actor_id, item_id, kind, occurred_at) values(?,?,?,?,?,?,?)`, eventID, sourceID, collectionID, nullIfEmpty(actorID), itemID, rec.Item.Kind, rec.Item.CreatedAt)
+	eventID := stableID("event", itemID, createdAt, rec.Item.Kind)
+	_, _ = tx.Exec(`insert or ignore into events(id, source_id, collection_id, actor_id, item_id, kind, occurred_at) values(?,?,?,?,?,?,?)`, eventID, sourceID, collectionID, nullIfEmpty(actorID), itemID, rec.Item.Kind, createdAt)
 	if err := indexItemMetadata(tx, itemID, rec.Item.Tags, itemMeta); err != nil {
 		return false, err
 	}

--- a/engines/evidence-ledger/internal/ingest/memory.go
+++ b/engines/evidence-ledger/internal/ingest/memory.go
@@ -53,14 +53,16 @@ type ObservedCard struct {
 	Outcome     string // created | updated | unchanged | skipped | failed
 }
 
-// LastMemoryNamespace returns the most recent memory_namespace recorded on a
-// source_scan_runs row, used when a failed crawl cannot re-read memory/NAMESPACE.
-func LastMemoryNamespace(db *sql.DB) string {
+// LastMemoryNamespace returns the latest namespace for sourcePath, used when a
+// failed crawl cannot re-read memory/NAMESPACE. A failed unknown path must not
+// borrow another workspace's namespace or change its health.
+func LastMemoryNamespace(db *sql.DB, sourcePath string) string {
 	var ns sql.NullString
 	_ = db.QueryRow(`select json_extract(metadata_json, '$.memory_namespace')
 from source_scan_runs
-where source_kind = ? and coalesce(json_extract(metadata_json, '$.memory_namespace'), '') != ''
-order by started_at desc limit 1`, MemorySourceKind).Scan(&ns)
+where source_kind = ? and source_path = ?
+  and coalesce(json_extract(metadata_json, '$.memory_namespace'), '') != ''
+order by started_at desc limit 1`, MemorySourceKind, sourcePath).Scan(&ns)
 	if ns.Valid {
 		return ns.String
 	}
@@ -257,18 +259,12 @@ func scanNamespace(tx *sql.Tx, scanID string) (string, error) {
 }
 
 func markPriorMemorySnapshotStale(tx *sql.Tx, namespace string) (bool, error) {
-	// Prefer namespace-scoped stale marking; fall back to source-kind when
-	// namespace is unknown so interrupted scans still leave a stale prior.
-	var res sql.Result
-	var err error
-	if namespace != "" {
-		res, err = tx.Exec(`update source_scan_runs set stale = 1
+	if namespace == "" {
+		return false, nil
+	}
+	res, err := tx.Exec(`update source_scan_runs set stale = 1
 where source_kind = ? and status = 'completed' and stale = 0
   and json_extract(metadata_json, '$.memory_namespace') = ?`, MemorySourceKind, namespace)
-	} else {
-		res, err = tx.Exec(`update source_scan_runs set stale = 1
-where source_kind = ? and status = 'completed' and stale = 0`, MemorySourceKind)
-	}
 	if err != nil {
 		return false, err
 	}
@@ -472,6 +468,9 @@ where source_kind = ? and status = 'running'
 order by started_at desc limit 1`, MemorySourceKind, namespace).Scan(&journalID); err != nil && err != sql.ErrNoRows {
 		return err
 	}
+	if err := restoreLiveRelationsToBackupTx(tx, namespace); err != nil {
+		return err
+	}
 	if err := deleteMemoryNamespaceTx(tx, namespace); err != nil {
 		return err
 	}
@@ -587,6 +586,9 @@ func AbortMemoryRebuild(db *sql.DB, namespace string) error {
 		return err
 	}
 	defer tx.Rollback()
+	if err := restoreLiveRelationsToBackupTx(tx, namespace); err != nil {
+		return err
+	}
 	if err := deleteMemoryNamespaceTx(tx, namespace); err != nil {
 		return err
 	}
@@ -743,32 +745,24 @@ func deleteItemGraph(tx *sql.Tx, itemID string) error {
 }
 
 func repointBackupItemRelations(tx *sql.Tx, namespace string) error {
-	rows, err := tx.Query(`select id, target_item_id, target_external_id from relations
-where target_item_id like ? and target_source_kind = ?
-  and (target_collection_external_id = ? or (
-    coalesce(target_collection_external_id, '') = ''
-    and 1 = (
-      select count(*)
-      from items candidate
-      join sources cs on cs.id = candidate.source_id
-      join collections cc on cc.id = candidate.collection_id
-      where cs.kind = ?
-        and candidate.external_id = relations.target_external_id
-        and candidate.tombstoned_at is null
-        and cc.external_id not like ?
-    )
-  ))`, memoryItemBackupPrefix+"%", MemorySourceKind, namespace, MemorySourceKind, memoryBackupPrefix+"%")
+	rows, err := tx.Query(`select r.id, r.target_external_id,
+coalesce(r.target_source_kind, ''), coalesce(r.target_collection_external_id, ''),
+coalesce(ss.kind, '')
+from relations r
+left join items source on source.id = r.source_item_id
+left join sources ss on ss.id = source.source_id
+where r.target_item_id like ?`, memoryItemBackupPrefix+"%")
 	if err != nil {
 		return err
 	}
 	type rel struct {
-		id, target string
-		externalID sql.NullString
+		id, targetSource, targetCollection, sourceKind string
+		externalID                                     sql.NullString
 	}
 	var pending []rel
 	for rows.Next() {
 		var r rel
-		if err := rows.Scan(&r.id, &r.target, &r.externalID); err != nil {
+		if err := rows.Scan(&r.id, &r.externalID, &r.targetSource, &r.targetCollection, &r.sourceKind); err != nil {
 			rows.Close()
 			return err
 		}
@@ -779,29 +773,100 @@ where target_item_id like ? and target_source_kind = ?
 		return err
 	}
 	for _, r := range pending {
-		liveID := originalItemID(r.target)
-		if r.externalID.Valid && r.externalID.String != "" {
-			err := tx.QueryRow(`select i.id from items i
+		if !r.externalID.Valid || r.externalID.String == "" {
+			continue
+		}
+		qualified := r.targetSource == MemorySourceKind
+		legacySameSource := r.targetSource == "" && r.sourceKind == MemorySourceKind
+		if !qualified && !legacySameSource {
+			continue
+		}
+		if qualified && r.targetCollection != "" && r.targetCollection != namespace {
+			continue
+		}
+		if r.targetCollection == "" {
+			var candidates int
+			if err := tx.QueryRow(`select count(*) from items i
 join sources s on s.id = i.source_id
 join collections c on c.id = i.collection_id
-where s.kind = ? and c.external_id = ? and i.external_id = ? and i.tombstoned_at is null`,
-				MemorySourceKind, namespace, r.externalID.String).Scan(&liveID)
-			if err == sql.ErrNoRows {
-				continue
-			}
-			if err != nil {
+where s.kind = ? and i.external_id = ? and i.tombstoned_at is null
+  and c.external_id not like ?`, MemorySourceKind, r.externalID.String, memoryBackupPrefix+"%").Scan(&candidates); err != nil {
 				return err
 			}
-		} else {
-			var exists int
-			if err := tx.QueryRow(`select count(*) from items where id = ?`, liveID).Scan(&exists); err != nil {
-				return err
-			}
-			if exists == 0 {
+			if candidates != 1 {
 				continue
 			}
 		}
+		var liveID string
+		err := tx.QueryRow(`select i.id from items i
+join sources s on s.id = i.source_id
+join collections c on c.id = i.collection_id
+where s.kind = ? and c.external_id = ? and i.external_id = ? and i.tombstoned_at is null`,
+			MemorySourceKind, namespace, r.externalID.String).Scan(&liveID)
+		if err == sql.ErrNoRows {
+			continue
+		}
+		if err != nil {
+			return err
+		}
 		if _, err := tx.Exec(`update relations set target_item_id = ? where id = ?`, liveID, r.id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// restoreLiveRelationsToBackupTx restores relation targets before a failed
+// rebuild removes its partial live collection. The collection move then maps
+// backup item ids back to their original live ids.
+func restoreLiveRelationsToBackupTx(tx *sql.Tx, namespace string) error {
+	backup := backupCollectionExternalID(namespace)
+	rows, err := tx.Query(`select r.id, i.external_id from relations r
+join items i on i.id = r.target_item_id
+join sources s on s.id = i.source_id
+join collections c on c.id = i.collection_id
+where s.kind = ? and c.external_id = ?`, MemorySourceKind, namespace)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	type rel struct{ id, externalID string }
+	var pending []rel
+	for rows.Next() {
+		var r rel
+		if err := rows.Scan(&r.id, &r.externalID); err != nil {
+			return err
+		}
+		pending = append(pending, r)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for _, r := range pending {
+		var candidates int
+		if err := tx.QueryRow(`select count(*) from items i
+join sources s on s.id = i.source_id
+join collections c on c.id = i.collection_id
+where s.kind = ? and c.external_id = ? and i.external_id = ? and i.tombstoned_at is null`,
+			MemorySourceKind, backup, r.externalID).Scan(&candidates); err != nil {
+			return err
+		}
+		if candidates != 1 {
+			continue
+		}
+		var backupID string
+		err := tx.QueryRow(`select i.id from items i
+join sources s on s.id = i.source_id
+join collections c on c.id = i.collection_id
+where s.kind = ? and c.external_id = ? and i.external_id = ? and i.tombstoned_at is null`,
+			MemorySourceKind, backup, r.externalID).Scan(&backupID)
+		if err == sql.ErrNoRows {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if _, err := tx.Exec(`update relations set target_item_id = ? where id = ?`, backupID, r.id); err != nil {
 			return err
 		}
 	}
@@ -848,10 +913,11 @@ where s.kind = ? and c.external_id = ?`, MemorySourceKind, namespace)
 		return err
 	}
 	for _, id := range ids {
-		if err := deleteItemGraph(tx, id); err != nil {
+		if _, err := tx.Exec(`update relations set target_item_id = null
+where target_item_id = ? and source_item_id != ?`, id, id); err != nil {
 			return err
 		}
-		if _, err := tx.Exec(`delete from relations where target_item_id = ?`, id); err != nil {
+		if err := deleteItemGraph(tx, id); err != nil {
 			return err
 		}
 	}

--- a/engines/evidence-ledger/internal/ingest/memory.go
+++ b/engines/evidence-ledger/internal/ingest/memory.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/escoffier-labs/miseledger/internal/sources/memory"
@@ -169,6 +170,12 @@ func CompleteMemoryScan(db *sql.DB, scanID string, observed []ObservedCard, rece
 		}
 		if _, err := tx.Exec(`insert or replace into source_scan_observed(scan_id, external_id, content_hash, raw_path) values(?,?,?,?)`,
 			scanID, obsID, card.ContentHash, card.RawPath); err != nil {
+			return err
+		}
+	}
+
+	if memoryScanAfterObserveHook != nil {
+		if err := memoryScanAfterObserveHook(tx); err != nil {
 			return err
 		}
 	}
@@ -401,188 +408,351 @@ func LiveMemoryProjection(db *sql.DB, namespace string) (map[string]string, erro
 	return liveMemoryExternalIDs(tx, namespace)
 }
 
-// MemoryNamespaceSnapshot holds derived projection rows for failure-preserving rebuild.
-type MemoryNamespaceSnapshot struct {
-	Namespace string
-	Items     []memoryItemSnapshot
+// SetMemoryScanAfterObserveHookForTest injects a failure after observation rows
+// are written and before reconciliation. Tests must clear it with a nil argument.
+func SetMemoryScanAfterObserveHookForTest(fn func(tx *sql.Tx) error) {
+	memoryScanAfterObserveHook = fn
 }
 
-type memoryItemSnapshot struct {
-	ID           string
-	ActorID      sql.NullString
-	ExternalID   string
-	Kind         string
-	CreatedAt    sql.NullString
-	UpdatedAt    sql.NullString
-	Text         sql.NullString
-	Summary      sql.NullString
-	ContentHash  string
-	RawJSON      string
-	RawHash      sql.NullString
-	RawPath      sql.NullString
-	RawOrdinal   sql.NullInt64
-	MetadataJSON string
-	TombstonedAt sql.NullString
-	Tags         []string
-	FTSBody      sql.NullString
-	Relations    []memoryRelationSnapshot
+// memoryScanAfterObserveHook is set by tests to inject a failure after
+// observation rows are written and before reconciliation/tombstones.
+var memoryScanAfterObserveHook func(tx *sql.Tx) error
+
+// MemoryRebuildTestHookAfterDetach is set by tests to fail after the live
+// namespace collection has been detached aside for rebuild.
+var MemoryRebuildTestHookAfterDetach func() error
+
+const memoryBackupPrefix = "__miseledger_memory_backup__:"
+const memoryItemBackupPrefix = "__miseledger_item_backup__:"
+
+func backupCollectionExternalID(namespace string) string {
+	return memoryBackupPrefix + namespace
 }
 
-type memoryRelationSnapshot struct {
-	ID                         string
-	SourceItemID               string
-	TargetItemID               sql.NullString
-	TargetExternalID           sql.NullString
-	TargetSourceKind           sql.NullString
-	TargetCollectionExternalID sql.NullString
-	RelationType               string
-	Confidence                 float64
-	MetadataJSON               string
+func isBackupCollectionExternalID(externalID string) bool {
+	return strings.HasPrefix(externalID, memoryBackupPrefix)
 }
 
-// SnapshotMemoryNamespace captures live+tombstoned derived rows for one namespace.
-func SnapshotMemoryNamespace(db *sql.DB, namespace string) (*MemoryNamespaceSnapshot, error) {
-	tx, err := db.Begin()
-	if err != nil {
-		return nil, err
+func backupItemID(id string) string {
+	if strings.HasPrefix(id, memoryItemBackupPrefix) {
+		return id
 	}
-	defer tx.Rollback()
-	rows, err := tx.Query(`
-select i.id, i.actor_id, i.external_id, i.kind, i.created_at, i.updated_at,
-  i.text, i.summary, i.content_hash, i.raw_json, i.raw_hash, i.raw_path, i.raw_ordinal,
-  i.metadata_json, i.tombstoned_at
-from items i
-join sources s on s.id = i.source_id
-join collections c on c.id = i.collection_id
-where s.kind = ? and c.external_id = ?`, MemorySourceKind, namespace)
-	if err != nil {
-		return nil, err
-	}
-	snap := &MemoryNamespaceSnapshot{Namespace: namespace}
-	for rows.Next() {
-		var item memoryItemSnapshot
-		if err := rows.Scan(&item.ID, &item.ActorID, &item.ExternalID, &item.Kind,
-			&item.CreatedAt, &item.UpdatedAt, &item.Text, &item.Summary, &item.ContentHash,
-			&item.RawJSON, &item.RawHash, &item.RawPath, &item.RawOrdinal, &item.MetadataJSON, &item.TombstonedAt); err != nil {
-			rows.Close()
-			return nil, err
-		}
-		snap.Items = append(snap.Items, item)
-	}
-	rows.Close()
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	for i := range snap.Items {
-		tagRows, err := tx.Query(`select tag from item_tags where item_id = ?`, snap.Items[i].ID)
-		if err != nil {
-			return nil, err
-		}
-		for tagRows.Next() {
-			var tag string
-			if err := tagRows.Scan(&tag); err != nil {
-				tagRows.Close()
-				return nil, err
-			}
-			snap.Items[i].Tags = append(snap.Items[i].Tags, tag)
-		}
-		tagRows.Close()
-		_ = tx.QueryRow(`select body from item_fts where item_id = ?`, snap.Items[i].ID).Scan(&snap.Items[i].FTSBody)
-		relRows, err := tx.Query(`
-select id, source_item_id, target_item_id, target_external_id, target_source_kind,
-  target_collection_external_id, relation_type, confidence, metadata_json
-from relations where source_item_id = ?`, snap.Items[i].ID)
-		if err != nil {
-			return nil, err
-		}
-		for relRows.Next() {
-			var rel memoryRelationSnapshot
-			if err := relRows.Scan(&rel.ID, &rel.SourceItemID, &rel.TargetItemID, &rel.TargetExternalID,
-				&rel.TargetSourceKind, &rel.TargetCollectionExternalID, &rel.RelationType, &rel.Confidence, &rel.MetadataJSON); err != nil {
-				relRows.Close()
-				return nil, err
-			}
-			snap.Items[i].Relations = append(snap.Items[i].Relations, rel)
-		}
-		relRows.Close()
-	}
-	return snap, nil
+	return memoryItemBackupPrefix + id
 }
 
-// RestoreMemoryNamespace restores a previously snapshotted namespace projection.
-func RestoreMemoryNamespace(db *sql.DB, snap *MemoryNamespaceSnapshot) error {
-	if snap == nil {
+func originalItemID(id string) string {
+	return strings.TrimPrefix(id, memoryItemBackupPrefix)
+}
+
+// RecoverMemoryRebuildState restores a backup collection left by a crashed
+// rebuild before any new crawl observes live hashes.
+func RecoverMemoryRebuildState(db *sql.DB, namespace string) error {
+	if namespace == "" || namespace == memory.LegacyCollectionID || isBackupCollectionExternalID(namespace) {
 		return nil
 	}
+	backup := backupCollectionExternalID(namespace)
 	tx, err := db.Begin()
 	if err != nil {
 		return err
 	}
 	defer tx.Rollback()
-	if err := deleteMemoryNamespaceTx(tx, snap.Namespace); err != nil {
+	var backupCount int
+	if err := tx.QueryRow(`select count(*) from collections c
+join sources s on s.id = c.source_id
+where s.kind = ? and c.external_id = ?`, MemorySourceKind, backup).Scan(&backupCount); err != nil {
 		return err
 	}
-	sourceID := stableID("source", MemorySourceKind)
-	now := time.Now().UTC().Format(time.RFC3339Nano)
-	if _, err := tx.Exec(`insert into sources(id, kind, name, version, created_at, updated_at) values(?,?,?,?,?,?)
-on conflict(id) do update set updated_at=excluded.updated_at`, sourceID, MemorySourceKind, "Brigade Memory Cards", "1.0.0", now, now); err != nil {
+	if backupCount == 0 {
+		return tx.Commit()
+	}
+	if err := deleteMemoryNamespaceTx(tx, namespace); err != nil {
 		return err
 	}
-	collectionID := stableID("collection", MemorySourceKind, snap.Namespace)
-	meta := map[string]any{"memory_namespace": snap.Namespace}
-	metaJSON, _ := json.Marshal(meta)
-	if _, err := tx.Exec(`insert into collections(id, source_id, external_id, kind, name, metadata_json, created_at, updated_at) values(?,?,?,?,?,?,?,?)
-on conflict(source_id, external_id) do update set updated_at=excluded.updated_at`,
-		collectionID, sourceID, snap.Namespace, "memory_cards", "Memory cards", string(metaJSON), now, now); err != nil {
+	if err := moveCollectionExternalID(tx, backup, namespace, true); err != nil {
 		return err
 	}
-	for _, item := range snap.Items {
-		if _, err := tx.Exec(`insert into items(id, source_id, collection_id, actor_id, external_id, kind, created_at, updated_at, text, summary, content_hash, raw_json, raw_hash, raw_path, raw_ordinal, metadata_json, tombstoned_at)
-values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
-			item.ID, sourceID, collectionID, nullString(item.ActorID), item.ExternalID, item.Kind,
-			nullString(item.CreatedAt), nullString(item.UpdatedAt), nullString(item.Text), nullString(item.Summary),
-			item.ContentHash, item.RawJSON, nullString(item.RawHash), nullString(item.RawPath),
-			nullInt64(item.RawOrdinal), item.MetadataJSON, nullString(item.TombstonedAt)); err != nil {
+	return tx.Commit()
+}
+
+// DetachMemoryNamespace moves the live namespace collection to a backup
+// collection id so a rebuild can import into a fresh live collection without
+// deleting prior rows. Item primary keys are remapped with a backup prefix so
+// re-import can recreate the original content-addressed ids.
+func DetachMemoryNamespace(db *sql.DB, namespace string) error {
+	if namespace == "" || namespace == memory.LegacyCollectionID || isBackupCollectionExternalID(namespace) {
+		return fmt.Errorf("refusing to detach legacy or invalid memory namespace %q", namespace)
+	}
+	backup := backupCollectionExternalID(namespace)
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	var backupCount int
+	if err := tx.QueryRow(`select count(*) from collections c
+join sources s on s.id = c.source_id
+where s.kind = ? and c.external_id = ?`, MemorySourceKind, backup).Scan(&backupCount); err != nil {
+		return err
+	}
+	var liveCount int
+	if err := tx.QueryRow(`select count(*) from collections c
+join sources s on s.id = c.source_id
+where s.kind = ? and c.external_id = ?`, MemorySourceKind, namespace).Scan(&liveCount); err != nil {
+		return err
+	}
+	if backupCount > 0 && liveCount == 0 {
+		if err := moveCollectionExternalID(tx, backup, namespace, true); err != nil {
 			return err
 		}
-		for _, tag := range item.Tags {
-			if _, err := tx.Exec(`insert or ignore into item_tags(item_id, tag) values(?,?)`, item.ID, tag); err != nil {
-				return err
-			}
+		liveCount = 1
+	}
+	if backupCount > 0 && liveCount > 0 {
+		if err := deleteMemoryNamespaceTx(tx, backup); err != nil {
+			return err
 		}
-		if item.FTSBody.Valid {
-			if _, err := tx.Exec(`insert into item_fts(item_id, source_kind, collection_kind, item_kind, actor_type, body) values(?,?,?,?,?,?)`,
-				item.ID, MemorySourceKind, "memory_cards", item.Kind, "system", item.FTSBody.String); err != nil {
-				return err
-			}
+	}
+	if liveCount == 0 {
+		return tx.Commit()
+	}
+	if err := moveCollectionExternalID(tx, namespace, backup, false); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	if MemoryRebuildTestHookAfterDetach != nil {
+		if err := MemoryRebuildTestHookAfterDetach(); err != nil {
+			_ = AbortMemoryRebuild(db, namespace)
+			return err
 		}
-		for _, rel := range item.Relations {
-			if _, err := tx.Exec(`insert into relations(id, source_item_id, target_item_id, target_external_id, target_source_kind, target_collection_external_id, relation_type, confidence, metadata_json)
-values(?,?,?,?,?,?,?,?,?)`, rel.ID, rel.SourceItemID, nullString(rel.TargetItemID), nullString(rel.TargetExternalID),
-				nullString(rel.TargetSourceKind), nullString(rel.TargetCollectionExternalID), rel.RelationType, rel.Confidence, rel.MetadataJSON); err != nil {
-				return err
-			}
+	}
+	return nil
+}
+
+// FinalizeMemoryRebuild repoints inbound relations onto the new live items and
+// drops the backup collection.
+func FinalizeMemoryRebuild(db *sql.DB, namespace string) error {
+	backup := backupCollectionExternalID(namespace)
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if err := repointBackupItemRelations(tx); err != nil {
+		return err
+	}
+	if err := deleteMemoryNamespaceTx(tx, backup); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// AbortMemoryRebuild deletes any partial new live collection and restores the
+// backup collection so prior live IDs, hashes, relations, metadata, events,
+// and artifacts remain intact.
+func AbortMemoryRebuild(db *sql.DB, namespace string) error {
+	if namespace == "" || namespace == memory.LegacyCollectionID {
+		return fmt.Errorf("refusing to abort rebuild for invalid namespace %q", namespace)
+	}
+	backup := backupCollectionExternalID(namespace)
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if err := deleteMemoryNamespaceTx(tx, namespace); err != nil {
+		return err
+	}
+	var backupCount int
+	if err := tx.QueryRow(`select count(*) from collections c
+join sources s on s.id = c.source_id
+where s.kind = ? and c.external_id = ?`, MemorySourceKind, backup).Scan(&backupCount); err != nil {
+		return err
+	}
+	if backupCount > 0 {
+		if err := moveCollectionExternalID(tx, backup, namespace, true); err != nil {
+			return err
 		}
 	}
 	return tx.Commit()
 }
 
-func nullString(v sql.NullString) any {
-	if !v.Valid {
-		return nil
+func moveCollectionExternalID(tx *sql.Tx, fromExternal, toExternal string, restoreOriginalIDs bool) error {
+	sourceID := stableID("source", MemorySourceKind)
+	fromID := stableID("collection", MemorySourceKind, fromExternal)
+	toID := stableID("collection", MemorySourceKind, toExternal)
+	var kind, name, meta sql.NullString
+	var created, updated sql.NullString
+	if err := tx.QueryRow(`select kind, name, metadata_json, created_at, updated_at from collections where id = ?`, fromID).Scan(
+		&kind, &name, &meta, &created, &updated); err != nil {
+		return err
 	}
-	return v.String
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	kindVal := "memory_cards"
+	if kind.Valid && kind.String != "" {
+		kindVal = kind.String
+	}
+	nameVal := "Memory cards"
+	if name.Valid && name.String != "" {
+		nameVal = name.String
+	}
+	metaVal := "{}"
+	if meta.Valid && meta.String != "" {
+		metaVal = meta.String
+	}
+	createdVal := now
+	if created.Valid && created.String != "" {
+		createdVal = created.String
+	}
+	if _, err := tx.Exec(`insert into collections(id, source_id, external_id, kind, name, metadata_json, created_at, updated_at)
+values(?,?,?,?,?,?,?,?)
+on conflict(id) do update set external_id=excluded.external_id, kind=excluded.kind, name=excluded.name,
+  metadata_json=excluded.metadata_json, updated_at=excluded.updated_at`,
+		toID, sourceID, toExternal, kindVal, nameVal, metaVal, createdVal, now); err != nil {
+		return err
+	}
+
+	rows, err := tx.Query(`select id from items where collection_id = ?`, fromID)
+	if err != nil {
+		return err
+	}
+	var itemIDs []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return err
+		}
+		itemIDs = append(itemIDs, id)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	for _, oldID := range itemIDs {
+		newID := backupItemID(oldID)
+		if restoreOriginalIDs {
+			newID = originalItemID(oldID)
+		}
+		if newID == oldID {
+			if _, err := tx.Exec(`update items set collection_id = ? where id = ?`, toID, oldID); err != nil {
+				return err
+			}
+			if _, err := tx.Exec(`update events set collection_id = ? where item_id = ?`, toID, oldID); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := cloneItemWithNewID(tx, oldID, newID, toID); err != nil {
+			return err
+		}
+		if err := deleteItemGraph(tx, oldID); err != nil {
+			return err
+		}
+	}
+	if _, err := tx.Exec(`delete from collections where id = ?`, fromID); err != nil {
+		return err
+	}
+	return nil
 }
 
-func nullInt64(v sql.NullInt64) any {
-	if !v.Valid {
-		return nil
+func cloneItemWithNewID(tx *sql.Tx, oldID, newID, collectionID string) error {
+	if _, err := tx.Exec(`insert into items(id, source_id, collection_id, actor_id, external_id, kind, created_at, updated_at, text, summary, content_hash, raw_json, raw_hash, raw_path, raw_ordinal, metadata_json, tombstoned_at)
+select ?, source_id, ?, actor_id, external_id, kind, created_at, updated_at, text, summary, content_hash, raw_json, raw_hash, raw_path, raw_ordinal, metadata_json, tombstoned_at
+from items where id = ?`, newID, collectionID, oldID); err != nil {
+		return err
 	}
-	return v.Int64
+	if _, err := tx.Exec(`insert into item_tags(item_id, tag) select ?, tag from item_tags where item_id = ?`, newID, oldID); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`insert into item_metadata(item_id, key, value) select ?, key, value from item_metadata where item_id = ?`, newID, oldID); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`insert into events(id, source_id, collection_id, actor_id, item_id, kind, occurred_at, metadata_json)
+select printf('bakevt:%s:%s', ?, id), source_id, ?, actor_id, ?, kind, occurred_at, metadata_json from events where item_id = ?`, newID, collectionID, newID, oldID); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`insert into artifacts(id, source_id, item_id, external_id, kind, path, url, mime_type, text, content_hash, metadata_json)
+select printf('bakart:%s:%s', ?, id), source_id, ?, external_id, kind, path, url, mime_type, text, content_hash, metadata_json from artifacts where item_id = ?`, newID, newID, oldID); err != nil {
+		return err
+	}
+	_, _ = tx.Exec(`insert into item_fts(item_id, source_kind, collection_kind, item_kind, actor_type, body)
+select ?, source_kind, collection_kind, item_kind, actor_type, body from item_fts where item_id = ?`, newID, oldID)
+	if _, err := tx.Exec(`insert into relations(id, source_item_id, target_item_id, target_external_id, target_source_kind, target_collection_external_id, relation_type, confidence, metadata_json)
+select printf('bakrel:%s:%s', ?, id), ?, target_item_id, target_external_id, target_source_kind, target_collection_external_id, relation_type, confidence, metadata_json
+from relations where source_item_id = ?`, newID, newID, oldID); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`update relations set target_item_id = ? where target_item_id = ?`, newID, oldID); err != nil {
+		return err
+	}
+	return nil
 }
 
-// DeleteMemoryNamespace removes only the derived projection for one namespace.
-// Legacy memory:cards rows are never touched.
+func deleteItemGraph(tx *sql.Tx, itemID string) error {
+	if _, err := tx.Exec(`delete from item_tags where item_id = ?`, itemID); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`delete from item_metadata where item_id = ?`, itemID); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`delete from events where item_id = ?`, itemID); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`delete from artifacts where item_id = ?`, itemID); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`delete from item_fts where item_id = ?`, itemID); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`delete from relations where source_item_id = ?`, itemID); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`delete from items where id = ?`, itemID); err != nil {
+		return err
+	}
+	return nil
+}
+
+func repointBackupItemRelations(tx *sql.Tx) error {
+	rows, err := tx.Query(`select id, target_item_id from relations where target_item_id like ?`, memoryItemBackupPrefix+"%")
+	if err != nil {
+		return err
+	}
+	type rel struct{ id, target string }
+	var pending []rel
+	for rows.Next() {
+		var r rel
+		if err := rows.Scan(&r.id, &r.target); err != nil {
+			rows.Close()
+			return err
+		}
+		pending = append(pending, r)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for _, r := range pending {
+		liveID := originalItemID(r.target)
+		var exists int
+		if err := tx.QueryRow(`select count(*) from items where id = ?`, liveID).Scan(&exists); err != nil {
+			return err
+		}
+		if exists == 0 {
+			continue
+		}
+		if _, err := tx.Exec(`update relations set target_item_id = ? where id = ?`, liveID, r.id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// DeleteMemoryNamespace removes only the derived projection for one namespace
+// collection external id (live or backup). Legacy memory:cards rows are never touched.
 func DeleteMemoryNamespace(db *sql.DB, namespace string) error {
 	tx, err := db.Begin()
 	if err != nil {
@@ -621,30 +791,13 @@ where s.kind = ? and c.external_id = ?`, MemorySourceKind, namespace)
 		return err
 	}
 	for _, id := range ids {
-		if _, err := tx.Exec(`delete from item_tags where item_id = ?`, id); err != nil {
+		if err := deleteItemGraph(tx, id); err != nil {
 			return err
 		}
-		if _, err := tx.Exec(`delete from item_metadata where item_id = ?`, id); err != nil {
-			return err
-		}
-		if _, err := tx.Exec(`delete from events where item_id = ?`, id); err != nil {
-			return err
-		}
-		if _, err := tx.Exec(`delete from artifacts where item_id = ?`, id); err != nil {
-			return err
-		}
-		if _, err := tx.Exec(`delete from item_fts where item_id = ?`, id); err != nil {
-			return err
-		}
-		if _, err := tx.Exec(`delete from relations where source_item_id = ? or target_item_id = ?`, id, id); err != nil {
-			return err
-		}
-		if _, err := tx.Exec(`delete from items where id = ?`, id); err != nil {
+		if _, err := tx.Exec(`delete from relations where target_item_id = ?`, id); err != nil {
 			return err
 		}
 	}
-	// Completed scan records are intentionally retained so a failed rebuild can
-	// mark the prior snapshot stale without losing last_completed_scan_id.
 	if _, err := tx.Exec(`delete from collections where source_id in (select id from sources where kind = ?) and external_id = ?`,
 		MemorySourceKind, namespace); err != nil {
 		return err
@@ -652,10 +805,10 @@ where s.kind = ? and c.external_id = ?`, MemorySourceKind, namespace)
 	return nil
 }
 
-// RebuildMemoryProjection deletes only the named namespace's derived projection.
-// Prefer Snapshot+Delete+Restore around import for failure-preserving rebuilds.
+// RebuildMemoryProjection detaches the live namespace for a staged rebuild.
+// Callers must FinalizeMemoryRebuild on success or AbortMemoryRebuild on failure.
 func RebuildMemoryProjection(db *sql.DB, namespace string) error {
-	return DeleteMemoryNamespace(db, namespace)
+	return DetachMemoryNamespace(db, namespace)
 }
 
 // MemoryHealth summarizes doctor/status fields for the memory projection.
@@ -675,8 +828,10 @@ type MemoryHealth struct {
 	Status              string  `json:"status"`
 }
 
-// CollectMemoryHealth reads the latest scan run plus live counts for a namespace.
-// When namespace is empty it reports the latest memory scan across namespaces.
+// CollectMemoryHealth reads the latest scan run plus live counts.
+// When namespace is non-empty, live/unresolved counts are scoped to that
+// collection. When namespace is empty, status/doctor aggregation covers every
+// brigade-memory collection including legacy memory:cards (dual-read).
 func CollectMemoryHealth(db *sql.DB, engineVersion, namespace string) (MemoryHealth, error) {
 	h := MemoryHealth{
 		Capability:      MemoryCapability,
@@ -684,28 +839,33 @@ func CollectMemoryHealth(db *sql.DB, engineVersion, namespace string) (MemoryHea
 		MemoryNamespace: namespace,
 		Status:          "absent",
 	}
+	scoped := namespace
 	var scanID, status string
 	var completed sql.NullString
 	var stale, canonical, live, divergence, unresolved, malformed int
 	var err error
-	if namespace != "" {
+	if scoped != "" {
 		err = db.QueryRow(`select id, status, completed_at, stale, canonical_count, live_count,
   hash_divergence_count, unresolved_relation_count, malformed_skipped_count
 from source_scan_runs
 where source_kind = ? and json_extract(metadata_json, '$.memory_namespace') = ?
-order by started_at desc limit 1`, MemorySourceKind, namespace).Scan(
+order by started_at desc limit 1`, MemorySourceKind, scoped).Scan(
 			&scanID, &status, &completed, &stale, &canonical, &live, &divergence, &unresolved, &malformed)
 	} else {
 		err = db.QueryRow(`select id, status, completed_at, stale, canonical_count, live_count,
-  hash_divergence_count, unresolved_relation_count, malformed_skipped_count,
-  coalesce(json_extract(metadata_json, '$.memory_namespace'), '')
+  hash_divergence_count, unresolved_relation_count, malformed_skipped_count
 from source_scan_runs
 where source_kind = ?
 order by started_at desc limit 1`, MemorySourceKind).Scan(
-			&scanID, &status, &completed, &stale, &canonical, &live, &divergence, &unresolved, &malformed, &namespace)
-		h.MemoryNamespace = namespace
+			&scanID, &status, &completed, &stale, &canonical, &live, &divergence, &unresolved, &malformed)
 	}
 	if err == sql.ErrNoRows {
+		// Still surface live dual-read aggregates when cards exist without scans.
+		if scoped == "" {
+			if aggErr := refreshAggregateMemoryHealth(db, &h); aggErr != nil {
+				return h, aggErr
+			}
+		}
 		return h, nil
 	}
 	if err != nil {
@@ -725,10 +885,10 @@ order by started_at desc limit 1`, MemorySourceKind).Scan(
 	} else {
 		var lastID string
 		var lastAt sql.NullString
-		if namespace != "" {
+		if scoped != "" {
 			_ = db.QueryRow(`select id, completed_at from source_scan_runs
 where source_kind = ? and status = 'completed' and json_extract(metadata_json, '$.memory_namespace') = ?
-order by completed_at desc limit 1`, MemorySourceKind, namespace).Scan(&lastID, &lastAt)
+order by completed_at desc limit 1`, MemorySourceKind, scoped).Scan(&lastID, &lastAt)
 		} else {
 			_ = db.QueryRow(`select id, completed_at from source_scan_runs
 where source_kind = ? and status = 'completed'
@@ -740,24 +900,91 @@ order by completed_at desc limit 1`, MemorySourceKind).Scan(&lastID, &lastAt)
 		}
 	}
 
-	if namespace != "" {
-		tx, err := db.Begin()
-		if err != nil {
-			return h, err
-		}
-		defer tx.Rollback()
-		liveMap, err := liveMemoryExternalIDs(tx, namespace)
+	tx, err := db.Begin()
+	if err != nil {
+		return h, err
+	}
+	defer tx.Rollback()
+	if scoped != "" {
+		liveMap, err := liveMemoryExternalIDs(tx, scoped)
 		if err != nil {
 			return h, err
 		}
 		h.LiveCount = len(liveMap)
-		unresolved, err = memoryUnresolvedRelationCount(tx, namespace)
+		unresolved, err = memoryUnresolvedRelationCount(tx, scoped)
 		if err != nil {
 			return h, err
 		}
 		h.UnresolvedRelations = unresolved
+		return h, nil
 	}
+	liveCount, unresolvedCount, err := aggregateLiveMemoryHealth(tx)
+	if err != nil {
+		return h, err
+	}
+	h.LiveCount = liveCount
+	h.UnresolvedRelations = unresolvedCount
+	h.MemoryNamespace = ""
 	return h, nil
+}
+
+func refreshAggregateMemoryHealth(db *sql.DB, h *MemoryHealth) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	liveCount, unresolvedCount, err := aggregateLiveMemoryHealth(tx)
+	if err != nil {
+		return err
+	}
+	if liveCount > 0 {
+		h.LiveCount = liveCount
+		h.UnresolvedRelations = unresolvedCount
+		if h.Status == "absent" {
+			h.Status = "present"
+		}
+	}
+	return nil
+}
+
+func aggregateLiveMemoryHealth(tx *sql.Tx) (liveCount, unresolvedCount int, err error) {
+	rows, err := tx.Query(`
+select c.external_id
+from collections c
+join sources s on s.id = c.source_id
+where s.kind = ?
+  and c.kind = 'memory_cards'
+  and c.external_id not like ?`, MemorySourceKind, memoryBackupPrefix+"%")
+	if err != nil {
+		return 0, 0, err
+	}
+	var collections []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return 0, 0, err
+		}
+		collections = append(collections, id)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, 0, err
+	}
+	for _, collection := range collections {
+		live, err := liveMemoryExternalIDs(tx, collection)
+		if err != nil {
+			return 0, 0, err
+		}
+		liveCount += len(live)
+		unresolved, err := memoryUnresolvedRelationCount(tx, collection)
+		if err != nil {
+			return 0, 0, err
+		}
+		unresolvedCount += unresolved
+	}
+	return liveCount, unresolvedCount, nil
 }
 
 // ClassifyMemoryOutcomes compares pre-import live hashes to observed cards.

--- a/engines/evidence-ledger/internal/ingest/memory.go
+++ b/engines/evidence-ledger/internal/ingest/memory.go
@@ -342,8 +342,8 @@ where target_item_id = ? and source_item_id != ?`, r.id, r.id); err != nil {
 }
 
 func liveMemoryExternalIDs(tx *sql.Tx, namespace string) (map[string]string, error) {
-	// Latest non-tombstoned version wins per external_id (content-addressed
-	// edits keep prior rows; live health selects the newest).
+	// Latest non-tombstoned version wins per external_id. Ordering uses the
+	// monotonic ingest stamp on updated_at (not content-hash item ids).
 	rows, err := tx.Query(`
 select i.external_id, i.content_hash
 from items i
@@ -353,7 +353,7 @@ where s.kind = ?
   and i.kind = 'memory_card'
   and i.tombstoned_at is null
   and c.external_id = ?
-order by i.created_at desc, i.id desc`, MemorySourceKind, namespace)
+order by i.updated_at desc, i.id desc`, MemorySourceKind, namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -404,7 +404,7 @@ where s.kind = ?
       and i2.collection_id = i.collection_id
       and i2.external_id = i.external_id
       and i2.tombstoned_at is null
-    order by i2.created_at desc, i2.id desc
+    order by i2.updated_at desc, i2.id desc
     limit 1
   )`, MemorySourceKind, namespace).Scan(&n)
 	return n, err

--- a/engines/evidence-ledger/internal/ingest/memory.go
+++ b/engines/evidence-ledger/internal/ingest/memory.go
@@ -465,13 +465,39 @@ where s.kind = ? and c.external_id = ?`, MemorySourceKind, backup).Scan(&backupC
 	if backupCount == 0 {
 		return tx.Commit()
 	}
+	var journalID sql.NullString
+	if err := tx.QueryRow(`select id from source_scan_runs
+where source_kind = ? and status = 'running'
+  and json_extract(metadata_json, '$.memory_namespace') = ?
+order by started_at desc limit 1`, MemorySourceKind, namespace).Scan(&journalID); err != nil && err != sql.ErrNoRows {
+		return err
+	}
 	if err := deleteMemoryNamespaceTx(tx, namespace); err != nil {
 		return err
 	}
 	if err := moveCollectionExternalID(tx, backup, namespace, true); err != nil {
 		return err
 	}
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	// A durable journal exists for current rebuilds because cmdCrawlMemory
+	// starts the scan before detaching. Older interrupted rebuilds can lack one;
+	// create an interrupted record during recovery so the restored snapshot is
+	// never reported healthy before a successful new rebuild completes.
+	scanID := journalID.String
+	if scanID == "" {
+		var err error
+		scanID, err = BeginMemoryScan(db, "", "", namespace)
+		if err != nil {
+			return err
+		}
+	}
+	return FailMemoryScan(db, scanID, "interrupted", &MemoryScanReceipt{
+		SourceKind: MemorySourceKind,
+		Namespace:  namespace,
+		Failed:     1,
+	})
 }
 
 // DetachMemoryNamespace moves the live namespace collection to a backup
@@ -719,8 +745,19 @@ func deleteItemGraph(tx *sql.Tx, itemID string) error {
 func repointBackupItemRelations(tx *sql.Tx, namespace string) error {
 	rows, err := tx.Query(`select id, target_item_id, target_external_id from relations
 where target_item_id like ? and target_source_kind = ?
-  and (target_collection_external_id = ? or coalesce(target_collection_external_id, '') = '')`,
-		memoryItemBackupPrefix+"%", MemorySourceKind, namespace)
+  and (target_collection_external_id = ? or (
+    coalesce(target_collection_external_id, '') = ''
+    and 1 = (
+      select count(*)
+      from items candidate
+      join sources cs on cs.id = candidate.source_id
+      join collections cc on cc.id = candidate.collection_id
+      where cs.kind = ?
+        and candidate.external_id = relations.target_external_id
+        and candidate.tombstoned_at is null
+        and cc.external_id not like ?
+    )
+  ))`, memoryItemBackupPrefix+"%", MemorySourceKind, namespace, MemorySourceKind, memoryBackupPrefix+"%")
 	if err != nil {
 		return err
 	}
@@ -860,32 +897,20 @@ func CollectMemoryHealth(db *sql.DB, engineVersion, namespace string) (MemoryHea
 		Status:          "absent",
 	}
 	scoped := namespace
+	if scoped == "" {
+		return collectAggregateMemoryHealth(db, &h)
+	}
 	var scanID, status string
 	var completed sql.NullString
 	var stale, canonical, live, divergence, unresolved, malformed int
 	var err error
-	if scoped != "" {
-		err = db.QueryRow(`select id, status, completed_at, stale, canonical_count, live_count,
+	err = db.QueryRow(`select id, status, completed_at, stale, canonical_count, live_count,
   hash_divergence_count, unresolved_relation_count, malformed_skipped_count
 from source_scan_runs
 where source_kind = ? and json_extract(metadata_json, '$.memory_namespace') = ?
 order by started_at desc limit 1`, MemorySourceKind, scoped).Scan(
-			&scanID, &status, &completed, &stale, &canonical, &live, &divergence, &unresolved, &malformed)
-	} else {
-		err = db.QueryRow(`select id, status, completed_at, stale, canonical_count, live_count,
-  hash_divergence_count, unresolved_relation_count, malformed_skipped_count
-from source_scan_runs
-where source_kind = ?
-order by started_at desc limit 1`, MemorySourceKind).Scan(
-			&scanID, &status, &completed, &stale, &canonical, &live, &divergence, &unresolved, &malformed)
-	}
+		&scanID, &status, &completed, &stale, &canonical, &live, &divergence, &unresolved, &malformed)
 	if err == sql.ErrNoRows {
-		// Still surface live dual-read aggregates when cards exist without scans.
-		if scoped == "" {
-			if aggErr := refreshAggregateMemoryHealth(db, &h); aggErr != nil {
-				return h, aggErr
-			}
-		}
 		return h, nil
 	}
 	if err != nil {
@@ -899,26 +924,15 @@ order by started_at desc limit 1`, MemorySourceKind).Scan(
 	h.HashDivergence = divergence
 	h.UnresolvedRelations = unresolved
 	h.MalformedSkipped = malformed
-	if scoped == "" {
-		if err := refreshAggregateMemoryScanHealth(db, &h); err != nil {
-			return h, err
-		}
-	}
 	if status == "completed" && completed.Valid {
 		h.LastCompletedScanID = scanID
 		h.LastCompletedAt = &completed.String
 	} else {
 		var lastID string
 		var lastAt sql.NullString
-		if scoped != "" {
-			_ = db.QueryRow(`select id, completed_at from source_scan_runs
+		_ = db.QueryRow(`select id, completed_at from source_scan_runs
 where source_kind = ? and status = 'completed' and json_extract(metadata_json, '$.memory_namespace') = ?
 order by completed_at desc limit 1`, MemorySourceKind, scoped).Scan(&lastID, &lastAt)
-		} else {
-			_ = db.QueryRow(`select id, completed_at from source_scan_runs
-where source_kind = ? and status = 'completed'
-order by completed_at desc limit 1`, MemorySourceKind).Scan(&lastID, &lastAt)
-		}
 		h.LastCompletedScanID = lastID
 		if lastAt.Valid {
 			h.LastCompletedAt = &lastAt.String
@@ -930,34 +944,27 @@ order by completed_at desc limit 1`, MemorySourceKind).Scan(&lastID, &lastAt)
 		return h, err
 	}
 	defer tx.Rollback()
-	if scoped != "" {
-		liveMap, err := liveMemoryExternalIDs(tx, scoped)
-		if err != nil {
-			return h, err
-		}
-		h.LiveCount = len(liveMap)
-		unresolved, err = memoryUnresolvedRelationCount(tx, scoped)
-		if err != nil {
-			return h, err
-		}
-		h.UnresolvedRelations = unresolved
-		return h, nil
-	}
-	liveCount, unresolvedCount, err := aggregateLiveMemoryHealth(tx)
+	liveMap, err := liveMemoryExternalIDs(tx, scoped)
 	if err != nil {
 		return h, err
 	}
-	h.LiveCount = liveCount
-	h.UnresolvedRelations = unresolvedCount
-	h.MemoryNamespace = ""
+	h.LiveCount = len(liveMap)
+	unresolved, err = memoryUnresolvedRelationCount(tx, scoped)
+	if err != nil {
+		return h, err
+	}
+	h.UnresolvedRelations = unresolved
 	return h, nil
 }
 
-// refreshAggregateMemoryScanHealth folds the latest scan state from every
-// memory namespace into empty-namespace doctor/status health. A newer healthy
-// namespace must not conceal a failed or stale scan in another namespace.
-func refreshAggregateMemoryScanHealth(db *sql.DB, h *MemoryHealth) error {
-	rows, err := db.Query(`
+// collectAggregateMemoryHealth folds independently scoped projections for
+// empty-namespace status and doctor views. Count fields come from each
+// namespace's latest completed scan; status, stale, and partial come from each
+// namespace's latest scan so a newer interrupted scan cannot be hidden by a
+// healthy completion elsewhere. Status uses failed > interrupted > running >
+// completed > absent, and LastCompletedAt/ID come from the newest completion.
+func collectAggregateMemoryHealth(db *sql.DB, h *MemoryHealth) (MemoryHealth, error) {
+	states, err := db.Query(`
 select status, stale from source_scan_runs current
 where source_kind = ?
   and not exists (
@@ -969,70 +976,122 @@ where source_kind = ?
            (newer.started_at = current.started_at and newer.id > current.id))
   )`, MemorySourceKind)
 	if err != nil {
-		return err
+		return *h, err
 	}
-	defer rows.Close()
-	for rows.Next() {
+	defer states.Close()
+	for states.Next() {
 		var status string
 		var stale int
-		if err := rows.Scan(&status, &stale); err != nil {
-			return err
+		if err := states.Scan(&status, &stale); err != nil {
+			return *h, err
 		}
-		if stale != 0 || status != "completed" {
-			h.Stale = true
+		if memoryHealthStatusRank(status) > memoryHealthStatusRank(h.Status) {
+			h.Status = status
 		}
-		if status != "completed" {
-			h.Partial = true
+		h.Stale = h.Stale || stale != 0 || status != "completed"
+		h.Partial = h.Partial || status != "completed"
+	}
+	if err := states.Err(); err != nil {
+		return *h, err
+	}
+
+	completed, err := db.Query(`
+select id, completed_at, canonical_count, live_count, hash_divergence_count,
+  unresolved_relation_count, malformed_skipped_count
+from source_scan_runs current
+where source_kind = ? and status = 'completed' and completed_at is not null
+  and not exists (
+    select 1 from source_scan_runs newer
+    where newer.source_kind = current.source_kind and newer.status = 'completed'
+      and coalesce(json_extract(newer.metadata_json, '$.memory_namespace'), '') =
+          coalesce(json_extract(current.metadata_json, '$.memory_namespace'), '')
+      and (newer.completed_at > current.completed_at or
+           (newer.completed_at = current.completed_at and newer.id > current.id))
+  )`, MemorySourceKind)
+	if err != nil {
+		return *h, err
+	}
+	defer completed.Close()
+	var newestAt string
+	for completed.Next() {
+		var id, at string
+		var canonical, live, divergence, unresolved, malformed int
+		if err := completed.Scan(&id, &at, &canonical, &live, &divergence, &unresolved, &malformed); err != nil {
+			return *h, err
+		}
+		h.CanonicalCount += canonical
+		h.LiveCount += live
+		h.HashDivergence += divergence
+		h.UnresolvedRelations += unresolved
+		h.MalformedSkipped += malformed
+		if at > newestAt {
+			newestAt = at
+			h.LastCompletedScanID = id
 		}
 	}
-	return rows.Err()
+	if err := completed.Err(); err != nil {
+		return *h, err
+	}
+	if newestAt != "" {
+		h.LastCompletedAt = &newestAt
+	}
+	// Legacy memory:cards rows can predate scan receipts. Preserve the
+	// documented empty-namespace dual-read without double-counting collections
+	// represented by a completed scan above.
+	legacyLive, legacyUnresolved, err := aggregateUnscannedMemoryHealth(db)
+	if err != nil {
+		return *h, err
+	}
+	h.LiveCount += legacyLive
+	h.UnresolvedRelations += legacyUnresolved
+	if h.Status == "absent" && legacyLive > 0 {
+		h.Status = "present"
+	}
+	return *h, nil
 }
 
-func refreshAggregateMemoryHealth(db *sql.DB, h *MemoryHealth) error {
+func memoryHealthStatusRank(status string) int {
+	switch status {
+	case "failed":
+		return 4
+	case "interrupted":
+		return 3
+	case "running":
+		return 2
+	case "completed":
+		return 1
+	default:
+		return 0
+	}
+}
+
+func aggregateUnscannedMemoryHealth(db *sql.DB) (liveCount, unresolvedCount int, err error) {
 	tx, err := db.Begin()
 	if err != nil {
-		return err
+		return 0, 0, err
 	}
 	defer tx.Rollback()
-	liveCount, unresolvedCount, err := aggregateLiveMemoryHealth(tx)
-	if err != nil {
-		return err
-	}
-	if liveCount > 0 {
-		h.LiveCount = liveCount
-		h.UnresolvedRelations = unresolvedCount
-		if h.Status == "absent" {
-			h.Status = "present"
-		}
-	}
-	return nil
-}
-
-func aggregateLiveMemoryHealth(tx *sql.Tx) (liveCount, unresolvedCount int, err error) {
 	rows, err := tx.Query(`
 select c.external_id
 from collections c
 join sources s on s.id = c.source_id
 where s.kind = ?
   and c.kind = 'memory_cards'
-  and c.external_id not like ?`, MemorySourceKind, memoryBackupPrefix+"%")
+  and c.external_id not like ?
+  and not exists (
+    select 1 from source_scan_runs scan
+    where scan.source_kind = ? and scan.status = 'completed'
+      and coalesce(json_extract(scan.metadata_json, '$.memory_namespace'), '') = c.external_id
+  )`, MemorySourceKind, memoryBackupPrefix+"%", MemorySourceKind)
 	if err != nil {
 		return 0, 0, err
 	}
-	var collections []string
+	defer rows.Close()
 	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil {
-			rows.Close()
+		var collection string
+		if err := rows.Scan(&collection); err != nil {
 			return 0, 0, err
 		}
-		collections = append(collections, id)
-	}
-	rows.Close()
-	if err := rows.Err(); err != nil {
-		return 0, 0, err
-	}
-	for _, collection := range collections {
 		live, err := liveMemoryExternalIDs(tx, collection)
 		if err != nil {
 			return 0, 0, err
@@ -1044,7 +1103,7 @@ where s.kind = ?
 		}
 		unresolvedCount += unresolved
 	}
-	return liveCount, unresolvedCount, nil
+	return liveCount, unresolvedCount, rows.Err()
 }
 
 // ClassifyMemoryOutcomes compares pre-import live hashes to observed cards.

--- a/engines/evidence-ledger/internal/ingest/memory.go
+++ b/engines/evidence-ledger/internal/ingest/memory.go
@@ -370,8 +370,8 @@ order by i.created_at desc, i.id desc`, MemorySourceKind, namespace)
 }
 
 // LegacyMemoryExternalIDs returns live rows still under the pre-namespace
-// collection memory:cards. Namespaced crawls dual-read these for diagnostics
-// and never tombstone or rebuild them (scoped-rebuild rule).
+// collection memory:cards. Empty-namespace status/doctor health dual-reads
+// these; namespaced crawls never tombstone or rebuild them (scoped-rebuild).
 func LegacyMemoryExternalIDs(db *sql.DB) (map[string]string, error) {
 	tx, err := db.Begin()
 	if err != nil {

--- a/engines/evidence-ledger/internal/ingest/memory.go
+++ b/engines/evidence-ledger/internal/ingest/memory.go
@@ -332,6 +332,10 @@ where s.kind = ?
 		if _, err := tx.Exec(`delete from item_fts where item_id = ?`, r.id); err != nil {
 			return 0, err
 		}
+		if _, err := tx.Exec(`update relations set target_item_id = null
+where target_item_id = ? and source_item_id != ?`, r.id, r.id); err != nil {
+			return 0, err
+		}
 		removedIDs[r.externalID] = true
 	}
 	return len(removedIDs), nil
@@ -543,6 +547,11 @@ where s.kind = ? and c.external_id = ?`, MemorySourceKind, namespace).Scan(&live
 	if err := moveCollectionExternalID(tx, namespace, backup, false); err != nil {
 		return err
 	}
+	if _, err := tx.Exec(`update relations
+set metadata_json = json_set(coalesce(metadata_json, '{}'), '$._memory_rebuild_backup_target_id', target_item_id)
+where target_item_id like ?`, memoryItemBackupPrefix+"%"); err != nil {
+		return err
+	}
 	if err := tx.Commit(); err != nil {
 		return err
 	}
@@ -747,22 +756,23 @@ func deleteItemGraph(tx *sql.Tx, itemID string) error {
 func repointBackupItemRelations(tx *sql.Tx, namespace string) error {
 	rows, err := tx.Query(`select r.id, r.target_external_id,
 coalesce(r.target_source_kind, ''), coalesce(r.target_collection_external_id, ''),
-coalesce(ss.kind, '')
+coalesce(ss.kind, ''), coalesce(sc.external_id, '')
 from relations r
 left join items source on source.id = r.source_item_id
 left join sources ss on ss.id = source.source_id
+left join collections sc on sc.id = source.collection_id
 where r.target_item_id like ?`, memoryItemBackupPrefix+"%")
 	if err != nil {
 		return err
 	}
 	type rel struct {
-		id, targetSource, targetCollection, sourceKind string
-		externalID                                     sql.NullString
+		id, targetSource, targetCollection, sourceKind, sourceCollection string
+		externalID                                                       sql.NullString
 	}
 	var pending []rel
 	for rows.Next() {
 		var r rel
-		if err := rows.Scan(&r.id, &r.externalID, &r.targetSource, &r.targetCollection, &r.sourceKind); err != nil {
+		if err := rows.Scan(&r.id, &r.externalID, &r.targetSource, &r.targetCollection, &r.sourceKind, &r.sourceCollection); err != nil {
 			rows.Close()
 			return err
 		}
@@ -781,16 +791,25 @@ where r.target_item_id like ?`, memoryItemBackupPrefix+"%")
 		if !qualified && !legacySameSource {
 			continue
 		}
+		if legacySameSource && r.sourceCollection != namespace && r.sourceCollection != backupCollectionExternalID(namespace) {
+			continue
+		}
 		if qualified && r.targetCollection != "" && r.targetCollection != namespace {
 			continue
 		}
 		if r.targetCollection == "" {
 			var candidates int
-			if err := tx.QueryRow(`select count(*) from items i
+			countQuery := `select count(*) from items i
 join sources s on s.id = i.source_id
 join collections c on c.id = i.collection_id
 where s.kind = ? and i.external_id = ? and i.tombstoned_at is null
-  and c.external_id not like ?`, MemorySourceKind, r.externalID.String, memoryBackupPrefix+"%").Scan(&candidates); err != nil {
+	  and c.external_id not like ?`
+			args := []any{MemorySourceKind, r.externalID.String, memoryBackupPrefix + "%"}
+			if legacySameSource {
+				countQuery += " and c.external_id = ?"
+				args = append(args, namespace)
+			}
+			if err := tx.QueryRow(countQuery, args...).Scan(&candidates); err != nil {
 				return err
 			}
 			if candidates != 1 {
@@ -821,7 +840,8 @@ where s.kind = ? and c.external_id = ? and i.external_id = ? and i.tombstoned_at
 // backup item ids back to their original live ids.
 func restoreLiveRelationsToBackupTx(tx *sql.Tx, namespace string) error {
 	backup := backupCollectionExternalID(namespace)
-	rows, err := tx.Query(`select r.id, i.external_id from relations r
+	rows, err := tx.Query(`select r.id, i.external_id,
+coalesce(json_extract(r.metadata_json, '$._memory_rebuild_backup_target_id'), '') from relations r
 join items i on i.id = r.target_item_id
 join sources s on s.id = i.source_id
 join collections c on c.id = i.collection_id
@@ -830,11 +850,11 @@ where s.kind = ? and c.external_id = ?`, MemorySourceKind, namespace)
 		return err
 	}
 	defer rows.Close()
-	type rel struct{ id, externalID string }
+	type rel struct{ id, externalID, recordedBackupID string }
 	var pending []rel
 	for rows.Next() {
 		var r rel
-		if err := rows.Scan(&r.id, &r.externalID); err != nil {
+		if err := rows.Scan(&r.id, &r.externalID, &r.recordedBackupID); err != nil {
 			return err
 		}
 		pending = append(pending, r)
@@ -843,6 +863,18 @@ where s.kind = ? and c.external_id = ?`, MemorySourceKind, namespace)
 		return err
 	}
 	for _, r := range pending {
+		if r.recordedBackupID != "" {
+			var exists int
+			if err := tx.QueryRow(`select count(*) from items where id = ?`, r.recordedBackupID).Scan(&exists); err != nil {
+				return err
+			}
+			if exists == 1 {
+				if _, err := tx.Exec(`update relations set target_item_id = ? where id = ?`, r.recordedBackupID, r.id); err != nil {
+					return err
+				}
+				continue
+			}
+		}
 		var candidates int
 		if err := tx.QueryRow(`select count(*) from items i
 join sources s on s.id = i.source_id
@@ -1144,11 +1176,12 @@ join sources s on s.id = c.source_id
 where s.kind = ?
   and c.kind = 'memory_cards'
   and c.external_id not like ?
-  and not exists (
+	and not exists (
     select 1 from source_scan_runs scan
     where scan.source_kind = ? and scan.status = 'completed'
-      and coalesce(json_extract(scan.metadata_json, '$.memory_namespace'), '') = c.external_id
-  )`, MemorySourceKind, memoryBackupPrefix+"%", MemorySourceKind)
+      and (coalesce(json_extract(scan.metadata_json, '$.memory_namespace'), '') = c.external_id
+           or (c.external_id = ? and coalesce(json_extract(scan.metadata_json, '$.memory_namespace'), '') = ''))
+	)`, MemorySourceKind, memoryBackupPrefix+"%", MemorySourceKind, memory.LegacyCollectionID)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/engines/evidence-ledger/internal/ingest/memory.go
+++ b/engines/evidence-ledger/internal/ingest/memory.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
+
+	"github.com/escoffier-labs/miseledger/internal/sources/memory"
 )
 
 // MemorySourceKind is the native source kind for canonical Markdown memory cards.
@@ -18,6 +20,7 @@ type MemoryScanReceipt struct {
 	ScanID                   string   `json:"scan_id"`
 	SourceKind               string   `json:"source_kind"`
 	SourcePath               string   `json:"source_path"`
+	Namespace                string   `json:"memory_namespace,omitempty"`
 	Status                   string   `json:"status"`
 	Stale                    bool     `json:"stale"`
 	Capability               string   `json:"capability"`
@@ -49,13 +52,28 @@ type ObservedCard struct {
 	Outcome     string // created | updated | unchanged | skipped | failed
 }
 
+// LastMemoryNamespace returns the most recent memory_namespace recorded on a
+// source_scan_runs row, used when a failed crawl cannot re-read memory/NAMESPACE.
+func LastMemoryNamespace(db *sql.DB) string {
+	var ns sql.NullString
+	_ = db.QueryRow(`select json_extract(metadata_json, '$.memory_namespace')
+from source_scan_runs
+where source_kind = ? and coalesce(json_extract(metadata_json, '$.memory_namespace'), '') != ''
+order by started_at desc limit 1`, MemorySourceKind).Scan(&ns)
+	if ns.Valid {
+		return ns.String
+	}
+	return ""
+}
+
 // BeginMemoryScan inserts a running scan row and returns its id.
-func BeginMemoryScan(db *sql.DB, sourcePath, engineVersion string) (string, error) {
+func BeginMemoryScan(db *sql.DB, sourcePath, engineVersion, namespace string) (string, error) {
 	now := time.Now().UTC().Format(time.RFC3339Nano)
-	id := stableID("memory-scan", MemorySourceKind, sourcePath, now)
+	id := stableID("memory-scan", MemorySourceKind, namespace, sourcePath, now)
 	meta, _ := json.Marshal(map[string]any{
-		"capability":     MemoryCapability,
-		"engine_version": engineVersion,
+		"capability":       MemoryCapability,
+		"engine_version":   engineVersion,
+		"memory_namespace": namespace,
 	})
 	_, err := db.Exec(`insert into source_scan_runs(
   id, source_kind, source_path, started_at, status, stale, metadata_json
@@ -64,7 +82,7 @@ func BeginMemoryScan(db *sql.DB, sourcePath, engineVersion string) (string, erro
 }
 
 // FailMemoryScan marks the scan failed/interrupted, tombstones nothing, and
-// marks the prior completed snapshot stale.
+// marks the prior completed snapshot for the same namespace stale.
 func FailMemoryScan(db *sql.DB, scanID, status string, receipt *MemoryScanReceipt) error {
 	if status == "" {
 		status = "failed"
@@ -75,35 +93,46 @@ func FailMemoryScan(db *sql.DB, scanID, status string, receipt *MemoryScanReceip
 		return err
 	}
 	defer tx.Rollback()
-	staleMarked, err := markPriorMemorySnapshotStale(tx)
+	namespace := ""
+	if receipt != nil {
+		namespace = receipt.Namespace
+	}
+	if namespace == "" && scanID != "" {
+		namespace, _ = scanNamespace(tx, scanID)
+	}
+	staleMarked, err := markPriorMemorySnapshotStale(tx, namespace)
 	if err != nil {
 		return err
 	}
 	if receipt == nil {
 		receipt = &MemoryScanReceipt{}
 	}
-	receipt.ScanID = scanID
 	receipt.SourceKind = MemorySourceKind
+	receipt.Namespace = namespace
 	receipt.Status = status
 	receipt.Stale = true
 	receipt.Partial = true
 	receipt.Capability = MemoryCapability
 	receipt.PriorSnapshotMarkedStale = staleMarked
-	if _, err := tx.Exec(`update source_scan_runs set status = ?, completed_at = ?, stale = 1,
+	if scanID != "" {
+		receipt.ScanID = scanID
+		if _, err := tx.Exec(`update source_scan_runs set status = ?, completed_at = ?, stale = 1,
   created_count=?, updated_count=?, unchanged_count=?, removed_count=?, skipped_count=?, failed_count=?,
   canonical_count=?, live_count=?, hash_divergence_count=?, unresolved_relation_count=?, malformed_skipped_count=?
   where id = ?`,
-		status, now,
-		receipt.Created, receipt.Updated, receipt.Unchanged, receipt.Removed, receipt.Skipped, receipt.Failed,
-		receipt.CanonicalCount, receipt.LiveCount, receipt.HashDivergence, receipt.UnresolvedRelations, receipt.MalformedSkipped,
-		scanID); err != nil {
-		return err
+			status, now,
+			receipt.Created, receipt.Updated, receipt.Unchanged, receipt.Removed, receipt.Skipped, receipt.Failed,
+			receipt.CanonicalCount, receipt.LiveCount, receipt.HashDivergence, receipt.UnresolvedRelations, receipt.MalformedSkipped,
+			scanID); err != nil {
+			return err
+		}
 	}
 	return tx.Commit()
 }
 
 // CompleteMemoryScan records observed ids, soft-tombstones missing memory_card
-// items scoped to brigade-memory only, and writes the receipt counts.
+// items scoped to the active namespace only, resolves relations, then stores
+// the post-resolution unresolved count.
 func CompleteMemoryScan(db *sql.DB, scanID string, observed []ObservedCard, receipt *MemoryScanReceipt) error {
 	if receipt == nil {
 		receipt = &MemoryScanReceipt{}
@@ -114,6 +143,15 @@ func CompleteMemoryScan(db *sql.DB, scanID string, observed []ObservedCard, rece
 		return err
 	}
 	defer tx.Rollback()
+
+	namespace := receipt.Namespace
+	if namespace == "" {
+		namespace, err = scanNamespace(tx, scanID)
+		if err != nil {
+			return err
+		}
+		receipt.Namespace = namespace
+	}
 
 	seen := map[string]ObservedCard{}
 	pathSet := map[string]bool{}
@@ -135,13 +173,13 @@ func CompleteMemoryScan(db *sql.DB, scanID string, observed []ObservedCard, rece
 		}
 	}
 
-	removed, err := softTombstoneMissingMemoryCards(tx, seen, now)
+	removed, err := softTombstoneMissingMemoryCards(tx, namespace, seen, now)
 	if err != nil {
 		return err
 	}
 	receipt.Removed = removed
 
-	live, err := liveMemoryExternalIDs(tx)
+	live, err := liveMemoryExternalIDs(tx, namespace)
 	if err != nil {
 		return err
 	}
@@ -162,17 +200,18 @@ func CompleteMemoryScan(db *sql.DB, scanID string, observed []ObservedCard, rece
 		}
 	}
 	receipt.HashDivergence = divergence
+	receipt.MalformedSkipped = receipt.Skipped + receipt.Failed
 
-	unresolved, err := memoryUnresolvedRelationCount(tx)
+	// Resolve first, then record the post-resolution unresolved count so crawl
+	// JSON, the scan row, and health share one meaning.
+	if _, err := resolveRelations(tx); err != nil {
+		return err
+	}
+	unresolved, err := memoryUnresolvedRelationCount(tx, namespace)
 	if err != nil {
 		return err
 	}
 	receipt.UnresolvedRelations = unresolved
-	receipt.MalformedSkipped = receipt.Skipped + receipt.Failed
-
-	if _, err := resolveRelations(tx); err != nil {
-		return err
-	}
 
 	if _, err := tx.Exec(`update source_scan_runs set status = ?, completed_at = ?, stale = 0,
   created_count=?, updated_count=?, unchanged_count=?, removed_count=?, skipped_count=?, failed_count=?,
@@ -197,9 +236,32 @@ func CompleteMemoryScan(db *sql.DB, scanID string, observed []ObservedCard, rece
 	return tx.Commit()
 }
 
-func markPriorMemorySnapshotStale(tx *sql.Tx) (bool, error) {
-	res, err := tx.Exec(`update source_scan_runs set stale = 1
+func scanNamespace(tx *sql.Tx, scanID string) (string, error) {
+	var meta string
+	if err := tx.QueryRow(`select coalesce(metadata_json, '{}') from source_scan_runs where id = ?`, scanID).Scan(&meta); err != nil {
+		return "", err
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(meta), &parsed); err != nil {
+		return "", nil
+	}
+	ns, _ := parsed["memory_namespace"].(string)
+	return ns, nil
+}
+
+func markPriorMemorySnapshotStale(tx *sql.Tx, namespace string) (bool, error) {
+	// Prefer namespace-scoped stale marking; fall back to source-kind when
+	// namespace is unknown so interrupted scans still leave a stale prior.
+	var res sql.Result
+	var err error
+	if namespace != "" {
+		res, err = tx.Exec(`update source_scan_runs set stale = 1
+where source_kind = ? and status = 'completed' and stale = 0
+  and json_extract(metadata_json, '$.memory_namespace') = ?`, MemorySourceKind, namespace)
+	} else {
+		res, err = tx.Exec(`update source_scan_runs set stale = 1
 where source_kind = ? and status = 'completed' and stale = 0`, MemorySourceKind)
+	}
 	if err != nil {
 		return false, err
 	}
@@ -207,7 +269,7 @@ where source_kind = ? and status = 'completed' and stale = 0`, MemorySourceKind)
 	return n > 0, nil
 }
 
-func softTombstoneMissingMemoryCards(tx *sql.Tx, seen map[string]ObservedCard, now string) (int, error) {
+func softTombstoneMissingMemoryCards(tx *sql.Tx, namespace string, seen map[string]ObservedCard, now string) (int, error) {
 	presentPaths := map[string]bool{}
 	presentIDs := map[string]bool{}
 	for _, card := range seen {
@@ -227,9 +289,11 @@ func softTombstoneMissingMemoryCards(tx *sql.Tx, seen map[string]ObservedCard, n
 select i.id, i.external_id, coalesce(i.raw_path, ''), coalesce(json_extract(i.metadata_json, '$.relative_path'), '')
 from items i
 join sources s on s.id = i.source_id
+join collections c on c.id = i.collection_id
 where s.kind = ?
   and i.kind = 'memory_card'
-  and i.tombstoned_at is null`, MemorySourceKind)
+  and i.tombstoned_at is null
+  and c.external_id = ?`, MemorySourceKind, namespace)
 	if err != nil {
 		return 0, err
 	}
@@ -270,15 +334,17 @@ where s.kind = ?
 	return len(removedIDs), nil
 }
 
-func liveMemoryExternalIDs(tx *sql.Tx) (map[string]string, error) {
+func liveMemoryExternalIDs(tx *sql.Tx, namespace string) (map[string]string, error) {
 	rows, err := tx.Query(`
 select i.external_id, i.content_hash
 from items i
 join sources s on s.id = i.source_id
+join collections c on c.id = i.collection_id
 where s.kind = ?
   and i.kind = 'memory_card'
   and i.tombstoned_at is null
-order by i.created_at desc, i.id desc`, MemorySourceKind)
+  and c.external_id = ?
+order by i.created_at desc, i.id desc`, MemorySourceKind, namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -296,40 +362,248 @@ order by i.created_at desc, i.id desc`, MemorySourceKind)
 	return out, rows.Err()
 }
 
-func memoryUnresolvedRelationCount(tx *sql.Tx) (int, error) {
+// LegacyMemoryExternalIDs returns live rows still under the pre-namespace
+// collection memory:cards. Namespaced crawls dual-read these for diagnostics
+// and never tombstone or rebuild them (scoped-rebuild rule).
+func LegacyMemoryExternalIDs(db *sql.DB) (map[string]string, error) {
+	tx, err := db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+	return liveMemoryExternalIDs(tx, memory.LegacyCollectionID)
+}
+
+func memoryUnresolvedRelationCount(tx *sql.Tx, namespace string) (int, error) {
 	var n int
 	err := tx.QueryRow(`
 select count(*)
 from relations r
 join items i on i.id = r.source_item_id
 join sources s on s.id = i.source_id
+join collections c on c.id = i.collection_id
 where s.kind = ?
   and i.kind = 'memory_card'
   and i.tombstoned_at is null
+  and c.external_id = ?
   and r.target_item_id is null
-  and coalesce(r.target_external_id, '') != ''`, MemorySourceKind).Scan(&n)
+  and coalesce(r.target_external_id, '') != ''`, MemorySourceKind, namespace).Scan(&n)
 	return n, err
 }
 
-// LiveMemoryProjection returns live external_id -> content_hash for rebuild checks.
-func LiveMemoryProjection(db *sql.DB) (map[string]string, error) {
+// LiveMemoryProjection returns live external_id -> content_hash for a namespace.
+func LiveMemoryProjection(db *sql.DB, namespace string) (map[string]string, error) {
 	tx, err := db.Begin()
 	if err != nil {
 		return nil, err
 	}
 	defer tx.Rollback()
-	return liveMemoryExternalIDs(tx)
+	return liveMemoryExternalIDs(tx, namespace)
 }
 
-// RebuildMemoryProjection deletes only the brigade-memory derived projection.
-func RebuildMemoryProjection(db *sql.DB) error {
+// MemoryNamespaceSnapshot holds derived projection rows for failure-preserving rebuild.
+type MemoryNamespaceSnapshot struct {
+	Namespace string
+	Items     []memoryItemSnapshot
+}
+
+type memoryItemSnapshot struct {
+	ID           string
+	ActorID      sql.NullString
+	ExternalID   string
+	Kind         string
+	CreatedAt    sql.NullString
+	UpdatedAt    sql.NullString
+	Text         sql.NullString
+	Summary      sql.NullString
+	ContentHash  string
+	RawJSON      string
+	RawHash      sql.NullString
+	RawPath      sql.NullString
+	RawOrdinal   sql.NullInt64
+	MetadataJSON string
+	TombstonedAt sql.NullString
+	Tags         []string
+	FTSBody      sql.NullString
+	Relations    []memoryRelationSnapshot
+}
+
+type memoryRelationSnapshot struct {
+	ID                         string
+	SourceItemID               string
+	TargetItemID               sql.NullString
+	TargetExternalID           sql.NullString
+	TargetSourceKind           sql.NullString
+	TargetCollectionExternalID sql.NullString
+	RelationType               string
+	Confidence                 float64
+	MetadataJSON               string
+}
+
+// SnapshotMemoryNamespace captures live+tombstoned derived rows for one namespace.
+func SnapshotMemoryNamespace(db *sql.DB, namespace string) (*MemoryNamespaceSnapshot, error) {
+	tx, err := db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+	rows, err := tx.Query(`
+select i.id, i.actor_id, i.external_id, i.kind, i.created_at, i.updated_at,
+  i.text, i.summary, i.content_hash, i.raw_json, i.raw_hash, i.raw_path, i.raw_ordinal,
+  i.metadata_json, i.tombstoned_at
+from items i
+join sources s on s.id = i.source_id
+join collections c on c.id = i.collection_id
+where s.kind = ? and c.external_id = ?`, MemorySourceKind, namespace)
+	if err != nil {
+		return nil, err
+	}
+	snap := &MemoryNamespaceSnapshot{Namespace: namespace}
+	for rows.Next() {
+		var item memoryItemSnapshot
+		if err := rows.Scan(&item.ID, &item.ActorID, &item.ExternalID, &item.Kind,
+			&item.CreatedAt, &item.UpdatedAt, &item.Text, &item.Summary, &item.ContentHash,
+			&item.RawJSON, &item.RawHash, &item.RawPath, &item.RawOrdinal, &item.MetadataJSON, &item.TombstonedAt); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		snap.Items = append(snap.Items, item)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	for i := range snap.Items {
+		tagRows, err := tx.Query(`select tag from item_tags where item_id = ?`, snap.Items[i].ID)
+		if err != nil {
+			return nil, err
+		}
+		for tagRows.Next() {
+			var tag string
+			if err := tagRows.Scan(&tag); err != nil {
+				tagRows.Close()
+				return nil, err
+			}
+			snap.Items[i].Tags = append(snap.Items[i].Tags, tag)
+		}
+		tagRows.Close()
+		_ = tx.QueryRow(`select body from item_fts where item_id = ?`, snap.Items[i].ID).Scan(&snap.Items[i].FTSBody)
+		relRows, err := tx.Query(`
+select id, source_item_id, target_item_id, target_external_id, target_source_kind,
+  target_collection_external_id, relation_type, confidence, metadata_json
+from relations where source_item_id = ?`, snap.Items[i].ID)
+		if err != nil {
+			return nil, err
+		}
+		for relRows.Next() {
+			var rel memoryRelationSnapshot
+			if err := relRows.Scan(&rel.ID, &rel.SourceItemID, &rel.TargetItemID, &rel.TargetExternalID,
+				&rel.TargetSourceKind, &rel.TargetCollectionExternalID, &rel.RelationType, &rel.Confidence, &rel.MetadataJSON); err != nil {
+				relRows.Close()
+				return nil, err
+			}
+			snap.Items[i].Relations = append(snap.Items[i].Relations, rel)
+		}
+		relRows.Close()
+	}
+	return snap, nil
+}
+
+// RestoreMemoryNamespace restores a previously snapshotted namespace projection.
+func RestoreMemoryNamespace(db *sql.DB, snap *MemoryNamespaceSnapshot) error {
+	if snap == nil {
+		return nil
+	}
 	tx, err := db.Begin()
 	if err != nil {
 		return err
 	}
 	defer tx.Rollback()
+	if err := deleteMemoryNamespaceTx(tx, snap.Namespace); err != nil {
+		return err
+	}
+	sourceID := stableID("source", MemorySourceKind)
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	if _, err := tx.Exec(`insert into sources(id, kind, name, version, created_at, updated_at) values(?,?,?,?,?,?)
+on conflict(id) do update set updated_at=excluded.updated_at`, sourceID, MemorySourceKind, "Brigade Memory Cards", "1.0.0", now, now); err != nil {
+		return err
+	}
+	collectionID := stableID("collection", MemorySourceKind, snap.Namespace)
+	meta := map[string]any{"memory_namespace": snap.Namespace}
+	metaJSON, _ := json.Marshal(meta)
+	if _, err := tx.Exec(`insert into collections(id, source_id, external_id, kind, name, metadata_json, created_at, updated_at) values(?,?,?,?,?,?,?,?)
+on conflict(source_id, external_id) do update set updated_at=excluded.updated_at`,
+		collectionID, sourceID, snap.Namespace, "memory_cards", "Memory cards", string(metaJSON), now, now); err != nil {
+		return err
+	}
+	for _, item := range snap.Items {
+		if _, err := tx.Exec(`insert into items(id, source_id, collection_id, actor_id, external_id, kind, created_at, updated_at, text, summary, content_hash, raw_json, raw_hash, raw_path, raw_ordinal, metadata_json, tombstoned_at)
+values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+			item.ID, sourceID, collectionID, nullString(item.ActorID), item.ExternalID, item.Kind,
+			nullString(item.CreatedAt), nullString(item.UpdatedAt), nullString(item.Text), nullString(item.Summary),
+			item.ContentHash, item.RawJSON, nullString(item.RawHash), nullString(item.RawPath),
+			nullInt64(item.RawOrdinal), item.MetadataJSON, nullString(item.TombstonedAt)); err != nil {
+			return err
+		}
+		for _, tag := range item.Tags {
+			if _, err := tx.Exec(`insert or ignore into item_tags(item_id, tag) values(?,?)`, item.ID, tag); err != nil {
+				return err
+			}
+		}
+		if item.FTSBody.Valid {
+			if _, err := tx.Exec(`insert into item_fts(item_id, source_kind, collection_kind, item_kind, actor_type, body) values(?,?,?,?,?,?)`,
+				item.ID, MemorySourceKind, "memory_cards", item.Kind, "system", item.FTSBody.String); err != nil {
+				return err
+			}
+		}
+		for _, rel := range item.Relations {
+			if _, err := tx.Exec(`insert into relations(id, source_item_id, target_item_id, target_external_id, target_source_kind, target_collection_external_id, relation_type, confidence, metadata_json)
+values(?,?,?,?,?,?,?,?,?)`, rel.ID, rel.SourceItemID, nullString(rel.TargetItemID), nullString(rel.TargetExternalID),
+				nullString(rel.TargetSourceKind), nullString(rel.TargetCollectionExternalID), rel.RelationType, rel.Confidence, rel.MetadataJSON); err != nil {
+				return err
+			}
+		}
+	}
+	return tx.Commit()
+}
 
-	rows, err := tx.Query(`select i.id from items i join sources s on s.id = i.source_id where s.kind = ?`, MemorySourceKind)
+func nullString(v sql.NullString) any {
+	if !v.Valid {
+		return nil
+	}
+	return v.String
+}
+
+func nullInt64(v sql.NullInt64) any {
+	if !v.Valid {
+		return nil
+	}
+	return v.Int64
+}
+
+// DeleteMemoryNamespace removes only the derived projection for one namespace.
+// Legacy memory:cards rows are never touched.
+func DeleteMemoryNamespace(db *sql.DB, namespace string) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if err := deleteMemoryNamespaceTx(tx, namespace); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func deleteMemoryNamespaceTx(tx *sql.Tx, namespace string) error {
+	if namespace == "" || namespace == memory.LegacyCollectionID {
+		return fmt.Errorf("refusing to delete legacy or empty memory namespace %q", namespace)
+	}
+	rows, err := tx.Query(`
+select i.id from items i
+join sources s on s.id = i.source_id
+join collections c on c.id = i.collection_id
+where s.kind = ? and c.external_id = ?`, MemorySourceKind, namespace)
 	if err != nil {
 		return err
 	}
@@ -369,31 +643,26 @@ func RebuildMemoryProjection(db *sql.DB) error {
 			return err
 		}
 	}
-	if _, err := tx.Exec(`delete from source_scans where source_kind = ?`, MemorySourceKind); err != nil {
+	// Completed scan records are intentionally retained so a failed rebuild can
+	// mark the prior snapshot stale without losing last_completed_scan_id.
+	if _, err := tx.Exec(`delete from collections where source_id in (select id from sources where kind = ?) and external_id = ?`,
+		MemorySourceKind, namespace); err != nil {
 		return err
 	}
-	if _, err := tx.Exec(`delete from source_scan_observed where scan_id in (select id from source_scan_runs where source_kind = ?)`, MemorySourceKind); err != nil {
-		return err
-	}
-	if _, err := tx.Exec(`delete from source_scan_runs where source_kind = ?`, MemorySourceKind); err != nil {
-		return err
-	}
-	if _, err := tx.Exec(`delete from collections where source_id in (select id from sources where kind = ?)`, MemorySourceKind); err != nil {
-		return err
-	}
-	if _, err := tx.Exec(`delete from actors where source_id in (select id from sources where kind = ?)`, MemorySourceKind); err != nil {
-		return err
-	}
-	if _, err := tx.Exec(`delete from sources where kind = ?`, MemorySourceKind); err != nil {
-		return err
-	}
-	return tx.Commit()
+	return nil
+}
+
+// RebuildMemoryProjection deletes only the named namespace's derived projection.
+// Prefer Snapshot+Delete+Restore around import for failure-preserving rebuilds.
+func RebuildMemoryProjection(db *sql.DB, namespace string) error {
+	return DeleteMemoryNamespace(db, namespace)
 }
 
 // MemoryHealth summarizes doctor/status fields for the memory projection.
 type MemoryHealth struct {
 	Capability          string  `json:"capability"`
 	EngineVersion       string  `json:"engine_version"`
+	MemoryNamespace     string  `json:"memory_namespace,omitempty"`
 	LastCompletedScanID string  `json:"last_completed_scan_id"`
 	LastCompletedAt     *string `json:"last_completed_at"`
 	CanonicalCount      int     `json:"canonical_count"`
@@ -406,22 +675,36 @@ type MemoryHealth struct {
 	Status              string  `json:"status"`
 }
 
-// CollectMemoryHealth reads the latest scan run plus live counts.
-func CollectMemoryHealth(db *sql.DB, engineVersion string) (MemoryHealth, error) {
+// CollectMemoryHealth reads the latest scan run plus live counts for a namespace.
+// When namespace is empty it reports the latest memory scan across namespaces.
+func CollectMemoryHealth(db *sql.DB, engineVersion, namespace string) (MemoryHealth, error) {
 	h := MemoryHealth{
-		Capability:    MemoryCapability,
-		EngineVersion: engineVersion,
-		Status:        "absent",
+		Capability:      MemoryCapability,
+		EngineVersion:   engineVersion,
+		MemoryNamespace: namespace,
+		Status:          "absent",
 	}
 	var scanID, status string
 	var completed sql.NullString
 	var stale, canonical, live, divergence, unresolved, malformed int
-	err := db.QueryRow(`select id, status, completed_at, stale, canonical_count, live_count,
+	var err error
+	if namespace != "" {
+		err = db.QueryRow(`select id, status, completed_at, stale, canonical_count, live_count,
   hash_divergence_count, unresolved_relation_count, malformed_skipped_count
+from source_scan_runs
+where source_kind = ? and json_extract(metadata_json, '$.memory_namespace') = ?
+order by started_at desc limit 1`, MemorySourceKind, namespace).Scan(
+			&scanID, &status, &completed, &stale, &canonical, &live, &divergence, &unresolved, &malformed)
+	} else {
+		err = db.QueryRow(`select id, status, completed_at, stale, canonical_count, live_count,
+  hash_divergence_count, unresolved_relation_count, malformed_skipped_count,
+  coalesce(json_extract(metadata_json, '$.memory_namespace'), '')
 from source_scan_runs
 where source_kind = ?
 order by started_at desc limit 1`, MemorySourceKind).Scan(
-		&scanID, &status, &completed, &stale, &canonical, &live, &divergence, &unresolved, &malformed)
+			&scanID, &status, &completed, &stale, &canonical, &live, &divergence, &unresolved, &malformed, &namespace)
+		h.MemoryNamespace = namespace
+	}
 	if err == sql.ErrNoRows {
 		return h, nil
 	}
@@ -442,31 +725,38 @@ order by started_at desc limit 1`, MemorySourceKind).Scan(
 	} else {
 		var lastID string
 		var lastAt sql.NullString
-		_ = db.QueryRow(`select id, completed_at from source_scan_runs
+		if namespace != "" {
+			_ = db.QueryRow(`select id, completed_at from source_scan_runs
+where source_kind = ? and status = 'completed' and json_extract(metadata_json, '$.memory_namespace') = ?
+order by completed_at desc limit 1`, MemorySourceKind, namespace).Scan(&lastID, &lastAt)
+		} else {
+			_ = db.QueryRow(`select id, completed_at from source_scan_runs
 where source_kind = ? and status = 'completed'
 order by completed_at desc limit 1`, MemorySourceKind).Scan(&lastID, &lastAt)
+		}
 		h.LastCompletedScanID = lastID
 		if lastAt.Valid {
 			h.LastCompletedAt = &lastAt.String
 		}
 	}
 
-	// Prefer live counts from the archive when present.
-	tx, err := db.Begin()
-	if err != nil {
-		return h, err
+	if namespace != "" {
+		tx, err := db.Begin()
+		if err != nil {
+			return h, err
+		}
+		defer tx.Rollback()
+		liveMap, err := liveMemoryExternalIDs(tx, namespace)
+		if err != nil {
+			return h, err
+		}
+		h.LiveCount = len(liveMap)
+		unresolved, err = memoryUnresolvedRelationCount(tx, namespace)
+		if err != nil {
+			return h, err
+		}
+		h.UnresolvedRelations = unresolved
 	}
-	defer tx.Rollback()
-	liveMap, err := liveMemoryExternalIDs(tx)
-	if err != nil {
-		return h, err
-	}
-	h.LiveCount = len(liveMap)
-	unresolved, err = memoryUnresolvedRelationCount(tx)
-	if err != nil {
-		return h, err
-	}
-	h.UnresolvedRelations = unresolved
 	return h, nil
 }
 
@@ -496,13 +786,13 @@ func ClassifyMemoryOutcomes(before map[string]string, observed []ObservedCard) (
 }
 
 // PriorLiveHashes is a convenience wrapper around LiveMemoryProjection.
-func PriorLiveHashes(db *sql.DB) (map[string]string, error) {
-	return LiveMemoryProjection(db)
+func PriorLiveHashes(db *sql.DB, namespace string) (map[string]string, error) {
+	return LiveMemoryProjection(db, namespace)
 }
 
 // SoftTombstoneCount returns how many live memory_card rows would be removed
 // for the given observed set without writing. Used by interrupted-scan tests.
-func SoftTombstoneCount(db *sql.DB, observedExternalIDs []string) (int, error) {
+func SoftTombstoneCount(db *sql.DB, namespace string, observedExternalIDs []string) (int, error) {
 	seen := map[string]ObservedCard{}
 	for _, id := range observedExternalIDs {
 		seen[id] = ObservedCard{ExternalID: id}
@@ -516,7 +806,8 @@ func SoftTombstoneCount(db *sql.DB, observedExternalIDs []string) (int, error) {
 select i.external_id
 from items i
 join sources s on s.id = i.source_id
-where s.kind = ? and i.kind = 'memory_card' and i.tombstoned_at is null`, MemorySourceKind)
+join collections c on c.id = i.collection_id
+where s.kind = ? and i.kind = 'memory_card' and i.tombstoned_at is null and c.external_id = ?`, MemorySourceKind, namespace)
 	if err != nil {
 		return 0, err
 	}

--- a/engines/evidence-ledger/internal/ingest/memory.go
+++ b/engines/evidence-ledger/internal/ingest/memory.go
@@ -539,7 +539,7 @@ func FinalizeMemoryRebuild(db *sql.DB, namespace string) error {
 		return err
 	}
 	defer tx.Rollback()
-	if err := repointBackupItemRelations(tx); err != nil {
+	if err := repointBackupItemRelations(tx, namespace); err != nil {
 		return err
 	}
 	if err := deleteMemoryNamespaceTx(tx, backup); err != nil {
@@ -716,16 +716,21 @@ func deleteItemGraph(tx *sql.Tx, itemID string) error {
 	return nil
 }
 
-func repointBackupItemRelations(tx *sql.Tx) error {
-	rows, err := tx.Query(`select id, target_item_id from relations where target_item_id like ?`, memoryItemBackupPrefix+"%")
+func repointBackupItemRelations(tx *sql.Tx, namespace string) error {
+	rows, err := tx.Query(`select id, target_item_id, target_external_id from relations
+where target_item_id like ? and target_source_kind = ? and target_collection_external_id = ?`,
+		memoryItemBackupPrefix+"%", MemorySourceKind, namespace)
 	if err != nil {
 		return err
 	}
-	type rel struct{ id, target string }
+	type rel struct {
+		id, target string
+		externalID sql.NullString
+	}
 	var pending []rel
 	for rows.Next() {
 		var r rel
-		if err := rows.Scan(&r.id, &r.target); err != nil {
+		if err := rows.Scan(&r.id, &r.target, &r.externalID); err != nil {
 			rows.Close()
 			return err
 		}
@@ -737,12 +742,26 @@ func repointBackupItemRelations(tx *sql.Tx) error {
 	}
 	for _, r := range pending {
 		liveID := originalItemID(r.target)
-		var exists int
-		if err := tx.QueryRow(`select count(*) from items where id = ?`, liveID).Scan(&exists); err != nil {
-			return err
-		}
-		if exists == 0 {
-			continue
+		if r.externalID.Valid && r.externalID.String != "" {
+			err := tx.QueryRow(`select i.id from items i
+join sources s on s.id = i.source_id
+join collections c on c.id = i.collection_id
+where s.kind = ? and c.external_id = ? and i.external_id = ? and i.tombstoned_at is null`,
+				MemorySourceKind, namespace, r.externalID.String).Scan(&liveID)
+			if err == sql.ErrNoRows {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+		} else {
+			var exists int
+			if err := tx.QueryRow(`select count(*) from items where id = ?`, liveID).Scan(&exists); err != nil {
+				return err
+			}
+			if exists == 0 {
+				continue
+			}
 		}
 		if _, err := tx.Exec(`update relations set target_item_id = ? where id = ?`, liveID, r.id); err != nil {
 			return err
@@ -879,6 +898,11 @@ order by started_at desc limit 1`, MemorySourceKind).Scan(
 	h.HashDivergence = divergence
 	h.UnresolvedRelations = unresolved
 	h.MalformedSkipped = malformed
+	if scoped == "" {
+		if err := refreshAggregateMemoryScanHealth(db, &h); err != nil {
+			return h, err
+		}
+	}
 	if status == "completed" && completed.Valid {
 		h.LastCompletedScanID = scanID
 		h.LastCompletedAt = &completed.String
@@ -926,6 +950,41 @@ order by completed_at desc limit 1`, MemorySourceKind).Scan(&lastID, &lastAt)
 	h.UnresolvedRelations = unresolvedCount
 	h.MemoryNamespace = ""
 	return h, nil
+}
+
+// refreshAggregateMemoryScanHealth folds the latest scan state from every
+// memory namespace into empty-namespace doctor/status health. A newer healthy
+// namespace must not conceal a failed or stale scan in another namespace.
+func refreshAggregateMemoryScanHealth(db *sql.DB, h *MemoryHealth) error {
+	rows, err := db.Query(`
+select status, stale from source_scan_runs current
+where source_kind = ?
+  and not exists (
+    select 1 from source_scan_runs newer
+    where newer.source_kind = current.source_kind
+      and coalesce(json_extract(newer.metadata_json, '$.memory_namespace'), '') =
+          coalesce(json_extract(current.metadata_json, '$.memory_namespace'), '')
+      and (newer.started_at > current.started_at or
+           (newer.started_at = current.started_at and newer.id > current.id))
+  )`, MemorySourceKind)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var status string
+		var stale int
+		if err := rows.Scan(&status, &stale); err != nil {
+			return err
+		}
+		if stale != 0 || status != "completed" {
+			h.Stale = true
+		}
+		if status != "completed" {
+			h.Partial = true
+		}
+	}
+	return rows.Err()
 }
 
 func refreshAggregateMemoryHealth(db *sql.DB, h *MemoryHealth) error {

--- a/engines/evidence-ledger/internal/ingest/memory.go
+++ b/engines/evidence-ledger/internal/ingest/memory.go
@@ -342,6 +342,8 @@ where target_item_id = ? and source_item_id != ?`, r.id, r.id); err != nil {
 }
 
 func liveMemoryExternalIDs(tx *sql.Tx, namespace string) (map[string]string, error) {
+	// Latest non-tombstoned version wins per external_id (content-addressed
+	// edits keep prior rows; live health selects the newest).
 	rows, err := tx.Query(`
 select i.external_id, i.content_hash
 from items i
@@ -394,7 +396,17 @@ where s.kind = ?
   and i.tombstoned_at is null
   and c.external_id = ?
   and r.target_item_id is null
-  and coalesce(r.target_external_id, '') != ''`, MemorySourceKind, namespace).Scan(&n)
+  and coalesce(r.target_external_id, '') != ''
+  and i.id = (
+    select i2.id
+    from items i2
+    where i2.source_id = i.source_id
+      and i2.collection_id = i.collection_id
+      and i2.external_id = i.external_id
+      and i2.tombstoned_at is null
+    order by i2.created_at desc, i2.id desc
+    limit 1
+  )`, MemorySourceKind, namespace).Scan(&n)
 	return n, err
 }
 

--- a/engines/evidence-ledger/internal/ingest/memory.go
+++ b/engines/evidence-ledger/internal/ingest/memory.go
@@ -718,7 +718,8 @@ func deleteItemGraph(tx *sql.Tx, itemID string) error {
 
 func repointBackupItemRelations(tx *sql.Tx, namespace string) error {
 	rows, err := tx.Query(`select id, target_item_id, target_external_id from relations
-where target_item_id like ? and target_source_kind = ? and target_collection_external_id = ?`,
+where target_item_id like ? and target_source_kind = ?
+  and (target_collection_external_id = ? or coalesce(target_collection_external_id, '') = '')`,
 		memoryItemBackupPrefix+"%", MemorySourceKind, namespace)
 	if err != nil {
 		return err

--- a/engines/evidence-ledger/internal/ingest/memory.go
+++ b/engines/evidence-ledger/internal/ingest/memory.go
@@ -343,7 +343,7 @@ where target_item_id = ? and source_item_id != ?`, r.id, r.id); err != nil {
 
 func liveMemoryExternalIDs(tx *sql.Tx, namespace string) (map[string]string, error) {
 	// Latest non-tombstoned version wins per external_id. Ordering uses the
-	// monotonic ingest stamp on updated_at (not content-hash item ids).
+	// DB-monotonic ingest_seq (not content-hash item ids).
 	rows, err := tx.Query(`
 select i.external_id, i.content_hash
 from items i
@@ -353,7 +353,7 @@ where s.kind = ?
   and i.kind = 'memory_card'
   and i.tombstoned_at is null
   and c.external_id = ?
-order by i.updated_at desc, i.id desc`, MemorySourceKind, namespace)
+order by i.ingest_seq desc, i.id desc`, MemorySourceKind, namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -404,7 +404,7 @@ where s.kind = ?
       and i2.collection_id = i.collection_id
       and i2.external_id = i.external_id
       and i2.tombstoned_at is null
-    order by i2.updated_at desc, i2.id desc
+    order by i2.ingest_seq desc, i2.id desc
     limit 1
   )`, MemorySourceKind, namespace).Scan(&n)
 	return n, err
@@ -708,8 +708,8 @@ on conflict(id) do update set external_id=excluded.external_id, kind=excluded.ki
 }
 
 func cloneItemWithNewID(tx *sql.Tx, oldID, newID, collectionID string) error {
-	if _, err := tx.Exec(`insert into items(id, source_id, collection_id, actor_id, external_id, kind, created_at, updated_at, text, summary, content_hash, raw_json, raw_hash, raw_path, raw_ordinal, metadata_json, tombstoned_at)
-select ?, source_id, ?, actor_id, external_id, kind, created_at, updated_at, text, summary, content_hash, raw_json, raw_hash, raw_path, raw_ordinal, metadata_json, tombstoned_at
+	if _, err := tx.Exec(`insert into items(id, source_id, collection_id, actor_id, external_id, kind, created_at, updated_at, text, summary, content_hash, raw_json, raw_hash, raw_path, raw_ordinal, metadata_json, tombstoned_at, ingest_seq)
+select ?, source_id, ?, actor_id, external_id, kind, created_at, updated_at, text, summary, content_hash, raw_json, raw_hash, raw_path, raw_ordinal, metadata_json, tombstoned_at, ingest_seq
 from items where id = ?`, newID, collectionID, oldID); err != nil {
 		return err
 	}

--- a/engines/evidence-ledger/internal/ingest/memory_lifecycle_test.go
+++ b/engines/evidence-ledger/internal/ingest/memory_lifecycle_test.go
@@ -261,6 +261,60 @@ func openMemoryLifecycleDB(t *testing.T) *sql.DB {
 	return db
 }
 
+func TestUpsertRecordRestampsKnownContentWithoutDuplicateEvent(t *testing.T) {
+	db := openMemoryLifecycleDB(t)
+	defer db.Close()
+	const ns = "memory-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+	const cardID = "card-restamp0-1111-4222-8333-444444444444"
+	v1 := memoryRecord(ns, cardID, "body-one")
+	v2 := memoryRecord(ns, cardID, "body-two")
+	if _, err := ImportAdapterReader(db, strings.NewReader(v1+"\n"), "v1.jsonl", ""); err != nil {
+		t.Fatal(err)
+	}
+	var v1ID, v1Stamp string
+	if err := db.QueryRow(`select id, updated_at from items where external_id = ?`, cardID).Scan(&v1ID, &v1Stamp); err != nil {
+		t.Fatal(err)
+	}
+	var eventsBefore int
+	if err := db.QueryRow(`select count(*) from events where item_id = ?`, v1ID).Scan(&eventsBefore); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ImportAdapterReader(db, strings.NewReader(v2+"\n"), "v2.jsonl", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ImportAdapterReader(db, strings.NewReader(v1+"\n"), "v1-again.jsonl", ""); err != nil {
+		t.Fatal(err)
+	}
+	var versionCount int
+	if err := db.QueryRow(`select count(*) from items where external_id = ?`, cardID).Scan(&versionCount); err != nil {
+		t.Fatal(err)
+	}
+	if versionCount != 2 {
+		t.Fatalf("versions=%d want 2", versionCount)
+	}
+	live, err := LiveMemoryProjection(db, ns)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var v1Hash, v1StampAfter string
+	if err := db.QueryRow(`select content_hash, updated_at from items where id = ?`, v1ID).Scan(&v1Hash, &v1StampAfter); err != nil {
+		t.Fatal(err)
+	}
+	if live[cardID] != v1Hash {
+		t.Fatalf("live=%s want restored v1 hash %s", live[cardID], v1Hash)
+	}
+	if v1StampAfter <= v1Stamp {
+		t.Fatalf("known re-ingest must refresh stamp before=%q after=%q", v1Stamp, v1StampAfter)
+	}
+	var eventsAfter int
+	if err := db.QueryRow(`select count(*) from events where item_id = ?`, v1ID).Scan(&eventsAfter); err != nil {
+		t.Fatal(err)
+	}
+	if eventsAfter != eventsBefore {
+		t.Fatalf("events before=%d after=%d", eventsBefore, eventsAfter)
+	}
+}
+
 func TestLiveMemoryLatestVersionUsesUpdatedAtNotEmptyCreatedAtHashOrder(t *testing.T) {
 	db := openMemoryLifecycleDB(t)
 	defer db.Close()

--- a/engines/evidence-ledger/internal/ingest/memory_lifecycle_test.go
+++ b/engines/evidence-ledger/internal/ingest/memory_lifecycle_test.go
@@ -644,3 +644,192 @@ func TestKnownItemSameTextFrontmatterReconcilesCanonicalFieldsReceiptAToB(t *tes
 		t.Fatalf("health unresolved after receipt-B reconcile: %d", unresolved)
 	}
 }
+
+func TestV2ToV3UpgradePreservesLiveVersionRelationsAndHealth(t *testing.T) {
+	// Explicit multi-version v2 archive → Migrate to v3, then assert live
+	// projection / relations / health with no crawl or import in between.
+	path := filepath.Join(t.TempDir(), "v2-memory.db")
+	db, err := archive.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const ns = "memory-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+	const cardID = "card-upgrade0-1111-4222-8333-444444444444"
+	olderID := "zzzz-upgrade-older-hash-id"
+	newerID := "aaaa-upgrade-newer-hash-id"
+	olderHash := "sha256:upgrade-older"
+	newerHash := "sha256:upgrade-newer"
+	if err := seedV2MultiVersionMemoryArchive(db, ns, cardID, olderID, newerID, olderHash, newerHash); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	upgraded, err := archive.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer upgraded.Close()
+	if err := archive.Migrate(upgraded); err != nil {
+		t.Fatalf("v2→v3 migrate: %v", err)
+	}
+
+	// Precondition of the defect: content-hash id order alone would revive older.
+	var byID string
+	if err := upgraded.QueryRow(`select id from items where external_id = ? order by id desc`, cardID).Scan(&byID); err != nil {
+		t.Fatal(err)
+	}
+	if byID != olderID {
+		t.Fatalf("precondition failed: id order should prefer older %s, got %s", olderID, byID)
+	}
+	var olderSeq, newerSeq int64
+	if err := upgraded.QueryRow(`select ingest_seq from items where id = ?`, olderID).Scan(&olderSeq); err != nil {
+		t.Fatal(err)
+	}
+	if err := upgraded.QueryRow(`select ingest_seq from items where id = ?`, newerID).Scan(&newerSeq); err != nil {
+		t.Fatal(err)
+	}
+	if !(newerSeq > olderSeq && olderSeq > 0) {
+		t.Fatalf("migration backfill older=%d newer=%d", olderSeq, newerSeq)
+	}
+
+	live, err := LiveMemoryProjection(upgraded, ns)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if live[cardID] != newerHash {
+		t.Fatalf("live projection after upgrade=%q want previously live %q", live[cardID], newerHash)
+	}
+
+	var inboundTarget string
+	if err := upgraded.QueryRow(`select target_item_id from relations where relation_type = 'upgrade_inbound'`).Scan(&inboundTarget); err != nil {
+		t.Fatal(err)
+	}
+	if inboundTarget != newerID {
+		t.Fatalf("inbound relation target=%s want previously live %s", inboundTarget, newerID)
+	}
+
+	tx, err := upgraded.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback()
+	unresolved, err := memoryUnresolvedRelationCount(tx, ns)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unresolved != 0 {
+		t.Fatalf("stale outbound on older version contaminated live health: %d", unresolved)
+	}
+	health, err := CollectMemoryHealth(upgraded, "test", ns)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// No crawl yet: status stays absent, but dual-read must not invent unresolved
+	// from the pre-upgrade stale outbound edge.
+	if health.UnresolvedRelations != 0 {
+		t.Fatalf("health unresolved=%d want 0 before crawl", health.UnresolvedRelations)
+	}
+}
+
+func seedV2MultiVersionMemoryArchive(db *sql.DB, ns, cardID, olderID, newerID, olderHash, newerHash string) error {
+	stmts := []string{
+		`create table sources(
+  id text primary key, kind text not null, name text, version text,
+  created_at text not null, updated_at text not null)`,
+		`create table collections(
+  id text primary key, source_id text not null references sources(id),
+  external_id text not null, kind text not null, name text,
+  metadata_json text not null default '{}', created_at text, updated_at text,
+  unique(source_id, external_id))`,
+		`create table items(
+  id text primary key, source_id text not null references sources(id),
+  collection_id text not null references collections(id),
+  actor_id text, external_id text not null, kind text not null,
+  created_at text, updated_at text, text text, summary text,
+  content_hash text not null, raw_json text not null, raw_hash text,
+  raw_path text, raw_ordinal integer, metadata_json text not null default '{}',
+  unique(source_id, collection_id, external_id, content_hash))`,
+		`create table relations(
+  id text primary key, source_item_id text not null, target_item_id text,
+  target_external_id text, relation_type text not null,
+  confidence real not null default 1.0, metadata_json text not null default '{}')`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			return err
+		}
+	}
+	// Reuse Migrate's v2 path by invoking through a throwaway migrate of empty
+	// companion objects: call ensure via archive.Migrate after inserts would add
+	// ingest_seq too early, so apply the v2 alters inline to match production v2.
+	for _, alter := range []string{
+		`alter table items add column tombstoned_at text`,
+		`alter table relations add column target_source_kind text`,
+		`alter table relations add column target_collection_external_id text`,
+	} {
+		if _, err := db.Exec(alter); err != nil {
+			return err
+		}
+	}
+	if _, err := db.Exec(`
+create table if not exists source_scan_runs(
+  id text primary key, source_kind text not null, source_path text,
+  started_at text not null, completed_at text, status text not null,
+  stale integer not null default 0, created_count integer not null default 0,
+  updated_count integer not null default 0, unchanged_count integer not null default 0,
+  removed_count integer not null default 0, skipped_count integer not null default 0,
+  failed_count integer not null default 0, canonical_count integer not null default 0,
+  live_count integer not null default 0, hash_divergence_count integer not null default 0,
+  unresolved_relation_count integer not null default 0,
+  malformed_skipped_count integer not null default 0,
+  metadata_json text not null default '{}'
+)`); err != nil {
+		return err
+	}
+	if _, err := db.Exec(`PRAGMA user_version = 2`); err != nil {
+		return err
+	}
+	now := "2026-08-10T00:00:00Z"
+	if _, err := db.Exec(`insert into sources(id, kind, name, version, created_at, updated_at) values(?,?,?,?,?,?)`,
+		"src-memory", MemorySourceKind, "Memory", "1.0.0", now, now); err != nil {
+		return err
+	}
+	if _, err := db.Exec(`insert into collections(id, source_id, external_id, kind, name, metadata_json, created_at, updated_at) values(?,?,?,?,?,?,?,?)`,
+		"col-memory", "src-memory", ns, "memory_cards", "cards", "{}", now, now); err != nil {
+		return err
+	}
+	if _, err := db.Exec(`insert into items(id, source_id, collection_id, external_id, kind, created_at, updated_at, text, content_hash, raw_json, metadata_json)
+values(?,?,?,?,?,?,?,?,?,?,?)`, olderID, "src-memory", "col-memory", cardID, "memory_card", "", "2026-08-10T01:00:00Z", "older", olderHash, "{}", "{}"); err != nil {
+		return err
+	}
+	if _, err := db.Exec(`insert into items(id, source_id, collection_id, external_id, kind, created_at, updated_at, text, content_hash, raw_json, metadata_json)
+values(?,?,?,?,?,?,?,?,?,?,?)`, newerID, "src-memory", "col-memory", cardID, "memory_card", "", "2026-08-10T02:00:00Z", "newer", newerHash, "{}", "{}"); err != nil {
+		return err
+	}
+	// Stale unresolved outbound on the older version must not affect live health.
+	if _, err := db.Exec(`insert into relations(id, source_item_id, target_item_id, target_external_id, target_source_kind, target_collection_external_id, relation_type, confidence, metadata_json)
+values(?,?,?,?,?,?,?,?,?)`, "rel-stale-out", olderID, nil, "missing-target", "", "", "supported_by", 1.0, "{}"); err != nil {
+		return err
+	}
+	// Inbound edge already resolved onto the previously live (newer) version.
+	if _, err := db.Exec(`insert into sources(id, kind, name, version, created_at, updated_at) values(?,?,?,?,?,?)`,
+		"src-brigade", "brigade", "Brigade", "1.0.0", now, now); err != nil {
+		return err
+	}
+	if _, err := db.Exec(`insert into collections(id, source_id, external_id, kind, name, metadata_json, created_at, updated_at) values(?,?,?,?,?,?,?,?)`,
+		"col-receipts", "src-brigade", "brigade:receipts", "brigade_receipt", "receipts", "{}", now, now); err != nil {
+		return err
+	}
+	if _, err := db.Exec(`insert into items(id, source_id, collection_id, external_id, kind, created_at, updated_at, text, content_hash, raw_json, metadata_json)
+values(?,?,?,?,?,?,?,?,?,?,?)`, "receipt-upgrade", "src-brigade", "col-receipts", "receipt:upgrade", "receipt", now, now, "support", "sha256:receipt", "{}", "{}"); err != nil {
+		return err
+	}
+	if _, err := db.Exec(`insert into relations(id, source_item_id, target_item_id, target_external_id, target_source_kind, target_collection_external_id, relation_type, confidence, metadata_json)
+values(?,?,?,?,?,?,?,?,?)`, "rel-inbound", "receipt-upgrade", newerID, cardID, MemorySourceKind, ns, "upgrade_inbound", 1.0, "{}"); err != nil {
+		return err
+	}
+	return nil
+}

--- a/engines/evidence-ledger/internal/ingest/memory_lifecycle_test.go
+++ b/engines/evidence-ledger/internal/ingest/memory_lifecycle_test.go
@@ -2,12 +2,140 @@ package ingest
 
 import (
 	"database/sql"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/escoffier-labs/miseledger/internal/archive"
 )
+
+func TestAggregateMemoryHealthCountsLegacyCompletedScanOnce(t *testing.T) {
+	db := openMemoryLifecycleDB(t)
+	defer db.Close()
+	const ns = "memory-11111111-2222-4333-8444-aaaaaaaaaaaa"
+	legacy := `{"schema":"miseledger.adapter.v1","source":{"kind":"brigade-memory","name":"Memory"},"collection":{"external_id":"memory:cards","kind":"memory_cards","name":"legacy"},"item":{"external_id":"card-legacy-health","kind":"memory_card","created_at":"2026-01-01T00:00:00Z","text":"legacy"},"relations":[{"type":"missing","target_external_id":"missing"}],"raw":{"format":"json","path":"legacy.json","ordinal":1}}`
+	if _, err := ImportAdapterReader(db, strings.NewReader(legacy+"\n"+memoryRecord(ns, "card-new-health", "new")+"\n"), "seed.jsonl", ""); err != nil {
+		t.Fatal(err)
+	}
+	for _, scan := range []struct {
+		id, meta   string
+		unresolved int
+	}{{"legacy-completed", "{}", 1}, {"namespaced-completed", `{"memory_namespace":"` + ns + `"}`, 0}} {
+		if _, err := db.Exec(`insert into source_scan_runs(id, source_kind, source_path, started_at, completed_at, status, stale, canonical_count, live_count, hash_divergence_count, unresolved_relation_count, malformed_skipped_count, metadata_json)
+values(?,?,?, ?, ?, 'completed', 0, 1, 1, 0, ?, 0, ?)`, scan.id, MemorySourceKind, scan.id, scan.id, scan.id, scan.unresolved, scan.meta); err != nil {
+			t.Fatal(err)
+		}
+	}
+	health, err := CollectMemoryHealth(db, "test", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if health.LiveCount != 2 || health.UnresolvedRelations != 1 {
+		t.Fatalf("legacy health double-counted: %+v", health)
+	}
+}
+
+func TestLegacyMemoryRelationStaysInSourceNamespaceAcrossRebuild(t *testing.T) {
+	db := openMemoryLifecycleDB(t)
+	defer db.Close()
+	const nsA = "memory-11111111-2222-4333-8444-aaaaaaaaaaaa"
+	const nsB = "memory-99999999-8888-4777-8666-bbbbbbbbbbbb"
+	const cardID = "card-bare000-1111-4222-8333-444444444444"
+	records := strings.Join([]string{
+		memoryRecordAt(nsB, cardID, "B", "2026-01-01T00:00:00Z"),
+		memoryRecordAt(nsA, cardID, "A", "2026-01-01T00:00:02Z"),
+		memoryBareRelationRecord(nsA, "card-bare-source", cardID, "2026-01-01T00:00:03Z"),
+	}, "\n") + "\n"
+	if _, err := ImportAdapterReader(db, strings.NewReader(records), "seed.jsonl", ""); err != nil {
+		t.Fatal(err)
+	}
+	assertRelationTargetCollection(t, db, "bare", nsA)
+	if err := DetachMemoryNamespace(db, nsA); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ImportAdapterReader(db, strings.NewReader(memoryRecordAt(nsA, cardID, "A rebuilt", "2026-01-01T00:00:04Z")+"\n"+memoryBareRelationRecord(nsA, "card-bare-source", cardID, "2026-01-01T00:00:05Z")+"\n"), "rebuild.jsonl", ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := FinalizeMemoryRebuild(db, nsA); err != nil {
+		t.Fatal(err)
+	}
+	assertRelationTargetCollection(t, db, "bare", nsA)
+}
+
+func TestCompleteMemoryScanTombstoneKeepsExternalInboundUnresolved(t *testing.T) {
+	db := openMemoryLifecycleDB(t)
+	defer db.Close()
+	const ns = "memory-11111111-2222-4333-8444-aaaaaaaaaaaa"
+	const cardID = "card-tombstone-1111-4222-8333-444444444444"
+	if _, err := ImportAdapterReader(db, strings.NewReader(memoryRecord(ns, cardID, "live")+"\n"+supportRelationRecord("tombstone-inbound", cardID)+"\n"), "seed.jsonl", ""); err != nil {
+		t.Fatal(err)
+	}
+	scanID, err := BeginMemoryScan(db, "workspace", "test", ns)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := CompleteMemoryScan(db, scanID, nil, &MemoryScanReceipt{Namespace: ns}); err != nil {
+		t.Fatal(err)
+	}
+	var target sql.NullString
+	if err := db.QueryRow(`select target_item_id from relations where relation_type = 'tombstone-inbound'`).Scan(&target); err != nil {
+		t.Fatal(err)
+	}
+	if target.Valid && target.String != "" {
+		t.Fatalf("tombstoned target remained resolved to %q", target.String)
+	}
+}
+
+func TestAbortMemoryRebuildRestoresRecordedBackupVersion(t *testing.T) {
+	db := openMemoryLifecycleDB(t)
+	defer db.Close()
+	const ns = "memory-11111111-2222-4333-8444-aaaaaaaaaaaa"
+	const cardID = "card-versioned-1111-4222-8333-444444444444"
+	if _, err := ImportAdapterReader(db, strings.NewReader(memoryRecord(ns, cardID, "original")+"\n"+supportRelationRecord("versioned-inbound", cardID)+"\n"), "seed.jsonl", ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := DetachMemoryNamespace(db, ns); err != nil {
+		t.Fatal(err)
+	}
+	backup := backupCollectionExternalID(ns)
+	if _, err := ImportAdapterReader(db, strings.NewReader(memoryRecord(backup, cardID, "older retained version")+"\n"), "backup-version.jsonl", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ImportAdapterReader(db, strings.NewReader(memoryRecord(ns, cardID, "new partial")+"\n"), "new.jsonl", ""); err != nil {
+		t.Fatal(err)
+	}
+	var partialID string
+	if err := db.QueryRow(`select i.id from items i join collections c on c.id = i.collection_id where c.external_id = ? and i.external_id = ?`, ns, cardID).Scan(&partialID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`update relations set target_item_id = ? where relation_type = 'versioned-inbound'`, partialID); err != nil {
+		t.Fatal(err)
+	}
+	if err := AbortMemoryRebuild(db, ns); err != nil {
+		t.Fatal(err)
+	}
+	assertRelationTargetCollection(t, db, "versioned-inbound", ns)
+}
+
+func memoryRecordAt(collection, externalID, text, createdAt string) string {
+	return fmt.Sprintf(`{"schema":"miseledger.adapter.v1","source":{"kind":"brigade-memory","name":"Memory"},"collection":{"external_id":%q,"kind":"memory_cards","name":"cards"},"item":{"external_id":%q,"kind":"memory_card","created_at":%q,"text":%q},"relations":[],"raw":{"format":"json","path":%q,"ordinal":1}}`, collection, externalID, createdAt, text, externalID+".json")
+}
+
+func memoryBareRelationRecord(collection, sourceID, targetID, createdAt string) string {
+	return fmt.Sprintf(`{"schema":"miseledger.adapter.v1","source":{"kind":"brigade-memory","name":"Memory"},"collection":{"external_id":%q,"kind":"memory_cards","name":"cards"},"item":{"external_id":%q,"kind":"memory_card","created_at":%q,"text":"source"},"relations":[{"type":"bare","target_external_id":%q}],"raw":{"format":"json","path":%q,"ordinal":1}}`, collection, sourceID, createdAt, targetID, sourceID+".json")
+}
+
+func assertRelationTargetCollection(t *testing.T, db *sql.DB, relationType, want string) {
+	t.Helper()
+	var got string
+	if err := db.QueryRow(`select c.external_id from relations r join items i on i.id = r.target_item_id join collections c on c.id = i.collection_id where r.relation_type = ?`, relationType).Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("relation %s target collection = %q, want %q", relationType, got, want)
+	}
+}
 
 func TestFinalizeMemoryRebuildKeepsExternalInboundRelationsWhenTargetIsGoneOrAmbiguous(t *testing.T) {
 	for _, tc := range []struct {
@@ -58,14 +186,14 @@ func TestFinalizeMemoryRebuildRepointsUniqueLegacySameSourceRelation(t *testing.
 	defer db.Close()
 	const ns = "memory-11111111-2222-4333-8444-aaaaaaaaaaaa"
 	const cardID = "card-legacy00-1111-4222-8333-444444444444"
-	legacySource := `{"schema":"miseledger.adapter.v1","source":{"kind":"brigade-memory","name":"Memory"},"collection":{"external_id":"memory:cards","kind":"memory_cards","name":"legacy"},"item":{"external_id":"card-legacy-source","kind":"memory_card","created_at":"2026-01-01T00:00:01Z","text":"legacy source"},"relations":[{"type":"legacy_inbound","target_external_id":"` + cardID + `"}],"raw":{"format":"json","path":"legacy.json","ordinal":1}}`
+	legacySource := memoryBareRelationRecord(ns, "card-legacy-source", cardID, "2026-01-01T00:00:01Z")
 	if _, err := ImportAdapterReader(db, strings.NewReader(memoryRecord(ns, cardID, "original")+"\n"+legacySource+"\n"), "seed.jsonl", ""); err != nil {
 		t.Fatal(err)
 	}
 	if err := DetachMemoryNamespace(db, ns); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := ImportAdapterReader(db, strings.NewReader(memoryRecord(ns, cardID, "changed")+"\n"), "rebuilt.jsonl", ""); err != nil {
+	if _, err := ImportAdapterReader(db, strings.NewReader(memoryRecord(ns, cardID, "changed")+"\n"+legacySource+"\n"), "rebuilt.jsonl", ""); err != nil {
 		t.Fatal(err)
 	}
 	if err := FinalizeMemoryRebuild(db, ns); err != nil {
@@ -75,7 +203,7 @@ func TestFinalizeMemoryRebuildRepointsUniqueLegacySameSourceRelation(t *testing.
 	if err := db.QueryRow(`select c.external_id from relations r
 join items i on i.id = r.target_item_id
 join collections c on c.id = i.collection_id
-where r.relation_type = 'legacy_inbound'`).Scan(&collection); err != nil {
+where r.relation_type = 'bare'`).Scan(&collection); err != nil {
 		t.Fatalf("legacy same-source relation was not remapped: %v", err)
 	}
 	if collection != ns {

--- a/engines/evidence-ledger/internal/ingest/memory_lifecycle_test.go
+++ b/engines/evidence-ledger/internal/ingest/memory_lifecycle_test.go
@@ -1,0 +1,134 @@
+package ingest
+
+import (
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/escoffier-labs/miseledger/internal/archive"
+)
+
+func TestFinalizeMemoryRebuildKeepsExternalInboundRelationsWhenTargetIsGoneOrAmbiguous(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		addSecond bool
+	}{
+		{name: "gone"},
+		{name: "ambiguous", addSecond: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db := openMemoryLifecycleDB(t)
+			defer db.Close()
+			const nsA = "memory-11111111-2222-4333-8444-aaaaaaaaaaaa"
+			const nsB = "memory-99999999-8888-4777-8666-bbbbbbbbbbbb"
+			const cardID = "card-inbound0-1111-4222-8333-444444444444"
+			if _, err := ImportAdapterReader(db, strings.NewReader(memoryRecord(nsA, cardID, "original")+"\n"+supportRelationRecord("inbound", cardID)+"\n"), "seed.jsonl", ""); err != nil {
+				t.Fatal(err)
+			}
+			if tc.addSecond {
+				if _, err := ImportAdapterReader(db, strings.NewReader(memoryRecord(nsB, cardID, "other namespace")+"\n"), "second.jsonl", ""); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := DetachMemoryNamespace(db, nsA); err != nil {
+				t.Fatal(err)
+			}
+			if tc.addSecond {
+				if _, err := ImportAdapterReader(db, strings.NewReader(memoryRecord(nsA, cardID, "rebuilt A")+"\n"), "rebuilt.jsonl", ""); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := FinalizeMemoryRebuild(db, nsA); err != nil {
+				t.Fatal(err)
+			}
+			var target sql.NullString
+			if err := db.QueryRow(`select target_item_id from relations where relation_type = 'inbound'`).Scan(&target); err != nil {
+				t.Fatalf("external inbound relation was deleted: %v", err)
+			}
+			if target.Valid && target.String != "" {
+				t.Fatalf("unrepointable relation stayed resolved to %q", target.String)
+			}
+		})
+	}
+}
+
+func TestFinalizeMemoryRebuildRepointsUniqueLegacySameSourceRelation(t *testing.T) {
+	db := openMemoryLifecycleDB(t)
+	defer db.Close()
+	const ns = "memory-11111111-2222-4333-8444-aaaaaaaaaaaa"
+	const cardID = "card-legacy00-1111-4222-8333-444444444444"
+	legacySource := `{"schema":"miseledger.adapter.v1","source":{"kind":"brigade-memory","name":"Memory"},"collection":{"external_id":"memory:cards","kind":"memory_cards","name":"legacy"},"item":{"external_id":"card-legacy-source","kind":"memory_card","created_at":"2026-01-01T00:00:01Z","text":"legacy source"},"relations":[{"type":"legacy_inbound","target_external_id":"` + cardID + `"}],"raw":{"format":"json","path":"legacy.json","ordinal":1}}`
+	if _, err := ImportAdapterReader(db, strings.NewReader(memoryRecord(ns, cardID, "original")+"\n"+legacySource+"\n"), "seed.jsonl", ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := DetachMemoryNamespace(db, ns); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ImportAdapterReader(db, strings.NewReader(memoryRecord(ns, cardID, "changed")+"\n"), "rebuilt.jsonl", ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := FinalizeMemoryRebuild(db, ns); err != nil {
+		t.Fatal(err)
+	}
+	var collection string
+	if err := db.QueryRow(`select c.external_id from relations r
+join items i on i.id = r.target_item_id
+join collections c on c.id = i.collection_id
+where r.relation_type = 'legacy_inbound'`).Scan(&collection); err != nil {
+		t.Fatalf("legacy same-source relation was not remapped: %v", err)
+	}
+	if collection != ns {
+		t.Fatalf("legacy relation remapped to %q, want %q", collection, ns)
+	}
+}
+
+func TestAbortMemoryRebuildPreservesExternalInboundRelationAfterNewTargetResolution(t *testing.T) {
+	db := openMemoryLifecycleDB(t)
+	defer db.Close()
+	const ns = "memory-11111111-2222-4333-8444-aaaaaaaaaaaa"
+	const cardID = "card-abort000-1111-4222-8333-444444444444"
+	if _, err := ImportAdapterReader(db, strings.NewReader(memoryRecord(ns, cardID, "original")+"\n"+supportRelationRecord("abort_inbound", cardID)+"\n"), "seed.jsonl", ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := DetachMemoryNamespace(db, ns); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ImportAdapterReader(db, strings.NewReader(memoryRecord(ns, cardID, "new")+"\n"), "new.jsonl", ""); err != nil {
+		t.Fatal(err)
+	}
+	var newID string
+	if err := db.QueryRow(`select i.id from items i join collections c on c.id = i.collection_id where c.external_id = ? and i.external_id = ?`, ns, cardID).Scan(&newID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`update relations set target_item_id = ? where relation_type = 'abort_inbound'`, newID); err != nil {
+		t.Fatal(err)
+	}
+	if err := AbortMemoryRebuild(db, ns); err != nil {
+		t.Fatal(err)
+	}
+	var restored string
+	if err := db.QueryRow(`select target_item_id from relations where relation_type = 'abort_inbound'`).Scan(&restored); err != nil {
+		t.Fatalf("external inbound relation was deleted during abort: %v", err)
+	}
+	var collection string
+	if err := db.QueryRow(`select c.external_id from items i join collections c on c.id = i.collection_id where i.id = ?`, restored).Scan(&collection); err != nil {
+		t.Fatal(err)
+	}
+	if collection != ns {
+		t.Fatalf("abort relation restored to %q, want %q", collection, ns)
+	}
+}
+
+func openMemoryLifecycleDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := archive.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := archive.Migrate(db); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	return db
+}

--- a/engines/evidence-ledger/internal/ingest/memory_lifecycle_test.go
+++ b/engines/evidence-ledger/internal/ingest/memory_lifecycle_test.go
@@ -260,3 +260,65 @@ func openMemoryLifecycleDB(t *testing.T) *sql.DB {
 	}
 	return db
 }
+
+func TestLiveMemoryLatestVersionUsesUpdatedAtNotEmptyCreatedAtHashOrder(t *testing.T) {
+	db := openMemoryLifecycleDB(t)
+	defer db.Close()
+	const ns = "memory-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+	const cardID = "card-order000-1111-4222-8333-444444444444"
+	now := "2026-08-10T00:00:00Z"
+	if _, err := db.Exec(`insert into sources(id, kind, name, version, created_at, updated_at) values(?,?,?,?,?,?)`,
+		"src-memory", MemorySourceKind, "Memory", "1.0.0", now, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`insert into collections(id, source_id, external_id, kind, name, metadata_json, created_at, updated_at) values(?,?,?,?,?,?,?,?)`,
+		"col-memory", "src-memory", ns, "memory_cards", "cards", "{}", now, now); err != nil {
+		t.Fatal(err)
+	}
+	// Lexicographically greater id is the older version; smaller id is newer.
+	// Empty created_at would make ORDER BY created_at,id prefer the older row.
+	olderID := "zzzz-older-content-hash-id"
+	newerID := "aaaa-newer-content-hash-id"
+	olderHash := "sha256:older"
+	newerHash := "sha256:newer"
+	if _, err := db.Exec(`insert into items(id, source_id, collection_id, external_id, kind, created_at, updated_at, text, content_hash, raw_json, metadata_json)
+values(?,?,?,?,?,?,?,?,?,?,?)`, olderID, "src-memory", "col-memory", cardID, "memory_card", "", "2026-08-10T01:00:00Z", "older", olderHash, "{}", "{}"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`insert into items(id, source_id, collection_id, external_id, kind, created_at, updated_at, text, content_hash, raw_json, metadata_json)
+values(?,?,?,?,?,?,?,?,?,?,?)`, newerID, "src-memory", "col-memory", cardID, "memory_card", "", "2026-08-10T02:00:00Z", "newer", newerHash, "{}", "{}"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`insert into relations(id, source_item_id, target_item_id, target_external_id, target_source_kind, target_collection_external_id, relation_type, confidence, metadata_json)
+values(?,?,?,?,?,?,?,?,?)`, "rel-stale-out", olderID, nil, "missing-target", "", "", "supported_by", 1.0, "{}"); err != nil {
+		t.Fatal(err)
+	}
+
+	var byCreated string
+	if err := db.QueryRow(`select id from items where external_id = ? order by created_at desc, id desc`, cardID).Scan(&byCreated); err != nil {
+		t.Fatal(err)
+	}
+	if byCreated != olderID {
+		t.Fatalf("precondition failed: empty created_at+id order should pick older %s, got %s", olderID, byCreated)
+	}
+
+	live, err := LiveMemoryProjection(db, ns)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if live[cardID] != newerHash {
+		t.Fatalf("live projection selected %q, want newer hash %q", live[cardID], newerHash)
+	}
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback()
+	unresolved, err := memoryUnresolvedRelationCount(tx, ns)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unresolved != 0 {
+		t.Fatalf("stale outbound unresolved on older version contaminated count: %d", unresolved)
+	}
+}

--- a/engines/evidence-ledger/internal/ingest/memory_lifecycle_test.go
+++ b/engines/evidence-ledger/internal/ingest/memory_lifecycle_test.go
@@ -261,6 +261,101 @@ func openMemoryLifecycleDB(t *testing.T) *sql.DB {
 	return db
 }
 
+func TestDirectImportReingestRepointsInboundToRestoredVersion(t *testing.T) {
+	db := openMemoryLifecycleDB(t)
+	defer db.Close()
+	const ns = "memory-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+	const cardID = "card-direct00-1111-4222-8333-444444444444"
+	v1 := memoryRecord(ns, cardID, "direct-body-one")
+	v2 := memoryRecord(ns, cardID, "direct-body-two")
+	inboundRec := fmt.Sprintf(`{"schema":"miseledger.adapter.v1","source":{"kind":"brigade","name":"Brigade"},"collection":{"external_id":"brigade:receipts","kind":"brigade_receipt","name":"receipts"},"item":{"external_id":"receipt:direct-inbound","kind":"receipt","created_at":"2026-01-01T00:00:00Z","text":"support"},"relations":[{"type":"direct_inbound","target":{"source":"brigade-memory","collection":%q,"external_id":%q}}],"raw":{"format":"json","path":"r.json","ordinal":1}}`, ns, cardID)
+
+	// Import v1 alone first so a later identical v1 re-import hits AlreadyKnown.
+	if _, err := ImportAdapterReader(db, strings.NewReader(v1+"\n"), "direct-v1.jsonl", ""); err != nil {
+		t.Fatal(err)
+	}
+	var v1ID string
+	if err := db.QueryRow(`select id from items where external_id = ?`, cardID).Scan(&v1ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ImportAdapterReader(db, strings.NewReader(inboundRec+"\n"), "direct-inbound.jsonl", ""); err != nil {
+		t.Fatal(err)
+	}
+	var inbound string
+	if err := db.QueryRow(`select target_item_id from relations where relation_type = 'direct_inbound'`).Scan(&inbound); err != nil {
+		t.Fatal(err)
+	}
+	if inbound != v1ID {
+		t.Fatalf("inbound should start on v1=%s, got %s", v1ID, inbound)
+	}
+	var eventsBefore int
+	if err := db.QueryRow(`select count(*) from events where item_id = ?`, v1ID).Scan(&eventsBefore); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := ImportAdapterReader(db, strings.NewReader(v2+"\n"), "direct-v2.jsonl", ""); err != nil {
+		t.Fatal(err)
+	}
+	var v2ID string
+	if err := db.QueryRow(`
+select i.id from items i
+join collections c on c.id = i.collection_id
+where c.external_id = ? and i.external_id = ? and i.tombstoned_at is null
+order by i.updated_at desc, i.id desc`, ns, cardID).Scan(&v2ID); err != nil {
+		t.Fatal(err)
+	}
+	if v2ID == v1ID {
+		t.Fatal("v2 must mint a distinct content-addressed item")
+	}
+	if err := db.QueryRow(`select target_item_id from relations where relation_type = 'direct_inbound'`).Scan(&inbound); err != nil {
+		t.Fatal(err)
+	}
+	if inbound != v2ID {
+		t.Fatalf("after v2 import inbound should be v2=%s, got %s", v2ID, inbound)
+	}
+
+	// Identical v1 bytes take the AlreadyKnown source-hash return; restamp alone
+	// is not enough — resolveRelations must run before that return.
+	again, err := ImportAdapterReader(db, strings.NewReader(v1+"\n"), "direct-v1-again.jsonl", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !again.AlreadyKnown || again.Inserted != 0 {
+		t.Fatalf("expected AlreadyKnown identical re-import, got %+v", again)
+	}
+	var versionCount int
+	if err := db.QueryRow(`select count(*) from items where external_id = ?`, cardID).Scan(&versionCount); err != nil {
+		t.Fatal(err)
+	}
+	if versionCount != 2 {
+		t.Fatalf("versions=%d want 2", versionCount)
+	}
+	live, err := LiveMemoryProjection(db, ns)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var v1Hash string
+	if err := db.QueryRow(`select content_hash from items where id = ?`, v1ID).Scan(&v1Hash); err != nil {
+		t.Fatal(err)
+	}
+	if live[cardID] != v1Hash {
+		t.Fatalf("live projection=%s want restored v1 %s", live[cardID], v1Hash)
+	}
+	if err := db.QueryRow(`select target_item_id from relations where relation_type = 'direct_inbound'`).Scan(&inbound); err != nil {
+		t.Fatal(err)
+	}
+	if inbound != v1ID {
+		t.Fatalf("direct-import AlreadyKnown path must repoint inbound to v1=%s, got %s", v1ID, inbound)
+	}
+	var eventsAfter int
+	if err := db.QueryRow(`select count(*) from events where item_id = ?`, v1ID).Scan(&eventsAfter); err != nil {
+		t.Fatal(err)
+	}
+	if eventsAfter != eventsBefore {
+		t.Fatalf("must not mint events on known re-import: before=%d after=%d", eventsBefore, eventsAfter)
+	}
+}
+
 func TestUpsertRecordRestampsKnownContentWithoutDuplicateEvent(t *testing.T) {
 	db := openMemoryLifecycleDB(t)
 	defer db.Close()

--- a/engines/evidence-ledger/internal/ingest/memory_lifecycle_test.go
+++ b/engines/evidence-ledger/internal/ingest/memory_lifecycle_test.go
@@ -301,7 +301,7 @@ func TestDirectImportReingestRepointsInboundToRestoredVersion(t *testing.T) {
 select i.id from items i
 join collections c on c.id = i.collection_id
 where c.external_id = ? and i.external_id = ? and i.tombstoned_at is null
-order by i.updated_at desc, i.id desc`, ns, cardID).Scan(&v2ID); err != nil {
+order by i.ingest_seq desc, i.id desc`, ns, cardID).Scan(&v2ID); err != nil {
 		t.Fatal(err)
 	}
 	if v2ID == v1ID {
@@ -366,8 +366,9 @@ func TestUpsertRecordRestampsKnownContentWithoutDuplicateEvent(t *testing.T) {
 	if _, err := ImportAdapterReader(db, strings.NewReader(v1+"\n"), "v1.jsonl", ""); err != nil {
 		t.Fatal(err)
 	}
-	var v1ID, v1Stamp string
-	if err := db.QueryRow(`select id, updated_at from items where external_id = ?`, cardID).Scan(&v1ID, &v1Stamp); err != nil {
+	var v1ID string
+	var v1Seq int64
+	if err := db.QueryRow(`select id, ingest_seq from items where external_id = ?`, cardID).Scan(&v1ID, &v1Seq); err != nil {
 		t.Fatal(err)
 	}
 	var eventsBefore int
@@ -391,15 +392,16 @@ func TestUpsertRecordRestampsKnownContentWithoutDuplicateEvent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var v1Hash, v1StampAfter string
-	if err := db.QueryRow(`select content_hash, updated_at from items where id = ?`, v1ID).Scan(&v1Hash, &v1StampAfter); err != nil {
+	var v1Hash string
+	var v1SeqAfter int64
+	if err := db.QueryRow(`select content_hash, ingest_seq from items where id = ?`, v1ID).Scan(&v1Hash, &v1SeqAfter); err != nil {
 		t.Fatal(err)
 	}
 	if live[cardID] != v1Hash {
 		t.Fatalf("live=%s want restored v1 hash %s", live[cardID], v1Hash)
 	}
-	if v1StampAfter <= v1Stamp {
-		t.Fatalf("known re-ingest must refresh stamp before=%q after=%q", v1Stamp, v1StampAfter)
+	if v1SeqAfter <= v1Seq {
+		t.Fatalf("known re-ingest must advance ingest_seq before=%d after=%d", v1Seq, v1SeqAfter)
 	}
 	var eventsAfter int
 	if err := db.QueryRow(`select count(*) from events where item_id = ?`, v1ID).Scan(&eventsAfter); err != nil {
@@ -410,7 +412,7 @@ func TestUpsertRecordRestampsKnownContentWithoutDuplicateEvent(t *testing.T) {
 	}
 }
 
-func TestLiveMemoryLatestVersionUsesUpdatedAtNotEmptyCreatedAtHashOrder(t *testing.T) {
+func TestLiveMemoryLatestVersionUsesIngestSeqNotWallClockOrHashOrder(t *testing.T) {
 	db := openMemoryLifecycleDB(t)
 	defer db.Close()
 	const ns = "memory-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
@@ -424,18 +426,18 @@ func TestLiveMemoryLatestVersionUsesUpdatedAtNotEmptyCreatedAtHashOrder(t *testi
 		"col-memory", "src-memory", ns, "memory_cards", "cards", "{}", now, now); err != nil {
 		t.Fatal(err)
 	}
-	// Lexicographically greater id is the older version; smaller id is newer.
-	// Empty created_at would make ORDER BY created_at,id prefer the older row.
+	// Lexicographically greater id is older; smaller id is newer by ingest_seq.
+	// Equal/backward wall-clock updated_at must not beat the DB-monotonic seq.
 	olderID := "zzzz-older-content-hash-id"
 	newerID := "aaaa-newer-content-hash-id"
 	olderHash := "sha256:older"
 	newerHash := "sha256:newer"
-	if _, err := db.Exec(`insert into items(id, source_id, collection_id, external_id, kind, created_at, updated_at, text, content_hash, raw_json, metadata_json)
-values(?,?,?,?,?,?,?,?,?,?,?)`, olderID, "src-memory", "col-memory", cardID, "memory_card", "", "2026-08-10T01:00:00Z", "older", olderHash, "{}", "{}"); err != nil {
+	if _, err := db.Exec(`insert into items(id, source_id, collection_id, external_id, kind, created_at, updated_at, text, content_hash, raw_json, metadata_json, ingest_seq)
+values(?,?,?,?,?,?,?,?,?,?,?,?)`, olderID, "src-memory", "col-memory", cardID, "memory_card", "", "2026-08-10T03:00:00Z", "older", olderHash, "{}", "{}", 1); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := db.Exec(`insert into items(id, source_id, collection_id, external_id, kind, created_at, updated_at, text, content_hash, raw_json, metadata_json)
-values(?,?,?,?,?,?,?,?,?,?,?)`, newerID, "src-memory", "col-memory", cardID, "memory_card", "", "2026-08-10T02:00:00Z", "newer", newerHash, "{}", "{}"); err != nil {
+	if _, err := db.Exec(`insert into items(id, source_id, collection_id, external_id, kind, created_at, updated_at, text, content_hash, raw_json, metadata_json, ingest_seq)
+values(?,?,?,?,?,?,?,?,?,?,?,?)`, newerID, "src-memory", "col-memory", cardID, "memory_card", "", "2026-08-10T01:00:00Z", "newer", newerHash, "{}", "{}", 2); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := db.Exec(`insert into relations(id, source_item_id, target_item_id, target_external_id, target_source_kind, target_collection_external_id, relation_type, confidence, metadata_json)
@@ -443,12 +445,18 @@ values(?,?,?,?,?,?,?,?,?)`, "rel-stale-out", olderID, nil, "missing-target", "",
 		t.Fatal(err)
 	}
 
-	var byCreated string
-	if err := db.QueryRow(`select id from items where external_id = ? order by created_at desc, id desc`, cardID).Scan(&byCreated); err != nil {
+	var byClock, byID string
+	if err := db.QueryRow(`select id from items where external_id = ? order by updated_at desc, id desc`, cardID).Scan(&byClock); err != nil {
 		t.Fatal(err)
 	}
-	if byCreated != olderID {
-		t.Fatalf("precondition failed: empty created_at+id order should pick older %s, got %s", olderID, byCreated)
+	if byClock != olderID {
+		t.Fatalf("precondition failed: wall-clock order should pick older %s, got %s", olderID, byClock)
+	}
+	if err := db.QueryRow(`select id from items where external_id = ? order by id desc`, cardID).Scan(&byID); err != nil {
+		t.Fatal(err)
+	}
+	if byID != olderID {
+		t.Fatalf("precondition failed: id tie-break should pick older %s, got %s", olderID, byID)
 	}
 
 	live, err := LiveMemoryProjection(db, ns)
@@ -469,5 +477,170 @@ values(?,?,?,?,?,?,?,?,?)`, "rel-stale-out", olderID, nil, "missing-target", "",
 	}
 	if unresolved != 0 {
 		t.Fatalf("stale outbound unresolved on older version contaminated count: %d", unresolved)
+	}
+}
+
+func TestLiveMemoryLatestVersionEqualWallClockUsesIngestSeq(t *testing.T) {
+	db := openMemoryLifecycleDB(t)
+	defer db.Close()
+	const ns = "memory-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+	const cardID = "card-equalclk-1111-4222-8333-444444444444"
+	now := "2026-08-10T00:00:00Z"
+	stamp := "2026-08-10T02:00:00Z"
+	if _, err := db.Exec(`insert into sources(id, kind, name, version, created_at, updated_at) values(?,?,?,?,?,?)`,
+		"src-memory", MemorySourceKind, "Memory", "1.0.0", now, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`insert into collections(id, source_id, external_id, kind, name, metadata_json, created_at, updated_at) values(?,?,?,?,?,?,?,?)`,
+		"col-memory", "src-memory", ns, "memory_cards", "cards", "{}", now, now); err != nil {
+		t.Fatal(err)
+	}
+	olderID := "zzzz-equal-clock-older"
+	newerID := "aaaa-equal-clock-newer"
+	olderHash := "sha256:equal-older"
+	newerHash := "sha256:equal-newer"
+	if _, err := db.Exec(`insert into items(id, source_id, collection_id, external_id, kind, created_at, updated_at, text, content_hash, raw_json, metadata_json, ingest_seq)
+values(?,?,?,?,?,?,?,?,?,?,?,?)`, olderID, "src-memory", "col-memory", cardID, "memory_card", "", stamp, "older", olderHash, "{}", "{}", 10); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`insert into items(id, source_id, collection_id, external_id, kind, created_at, updated_at, text, content_hash, raw_json, metadata_json, ingest_seq)
+values(?,?,?,?,?,?,?,?,?,?,?,?)`, newerID, "src-memory", "col-memory", cardID, "memory_card", "", stamp, "newer", newerHash, "{}", "{}", 11); err != nil {
+		t.Fatal(err)
+	}
+	var byClockID string
+	if err := db.QueryRow(`select id from items where external_id = ? order by updated_at desc, id desc`, cardID).Scan(&byClockID); err != nil {
+		t.Fatal(err)
+	}
+	if byClockID != olderID {
+		t.Fatalf("precondition failed: equal clock + id desc should pick older %s, got %s", olderID, byClockID)
+	}
+	live, err := LiveMemoryProjection(db, ns)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if live[cardID] != newerHash {
+		t.Fatalf("equal wall-clock must still prefer ingest_seq; got %q want %q", live[cardID], newerHash)
+	}
+}
+
+func TestKnownItemSameTextFrontmatterReconcilesCanonicalFieldsReceiptAToB(t *testing.T) {
+	db := openMemoryLifecycleDB(t)
+	defer db.Close()
+	const ns = "memory-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+	const cardID = "card-front000-1111-4222-8333-444444444444"
+	const body = "same-text-frontmatter-body"
+	receiptA := `{"schema":"miseledger.adapter.v1","source":{"kind":"brigade","name":"Brigade"},"collection":{"external_id":"brigade:receipts","kind":"brigade_receipt","name":"receipts"},"item":{"external_id":"receipt:front-a","kind":"receipt","created_at":"2026-01-01T00:00:00Z","text":"receipt-a"},"relations":[],"raw":{"format":"json","path":"a.json","ordinal":1}}`
+	receiptB := `{"schema":"miseledger.adapter.v1","source":{"kind":"brigade","name":"Brigade"},"collection":{"external_id":"brigade:receipts","kind":"brigade_receipt","name":"receipts"},"item":{"external_id":"receipt:front-b","kind":"receipt","created_at":"2026-01-01T00:00:01Z","text":"receipt-b"},"relations":[],"raw":{"format":"json","path":"b.json","ordinal":1}}`
+	cardA := fmt.Sprintf(`{"schema":"miseledger.adapter.v1","source":{"kind":"brigade-memory","name":"Memory"},"collection":{"external_id":%q,"kind":"memory_cards","name":"cards"},"item":{"external_id":%q,"kind":"memory_card","created_at":"2026-01-01T00:00:02Z","text":%q,"tags":["tag-a"],"metadata":{"topic":"alpha","status":"draft"}},"artifacts":[{"external_id":"art-a","kind":"note","text":"artifact-a"}],"relations":[{"type":"derived_from","target":{"source":"brigade","collection":"brigade:receipts","external_id":"receipt:front-a"}}],"raw":{"format":"json","path":"card.json","ordinal":1}}`, ns, cardID, body)
+	cardB := fmt.Sprintf(`{"schema":"miseledger.adapter.v1","source":{"kind":"brigade-memory","name":"Memory"},"collection":{"external_id":%q,"kind":"memory_cards","name":"cards"},"item":{"external_id":%q,"kind":"memory_card","created_at":"2026-01-01T00:00:02Z","text":%q,"tags":["tag-b"],"metadata":{"topic":"beta","status":"ready"}},"artifacts":[{"external_id":"art-b","kind":"note","text":"artifact-b"}],"relations":[{"type":"derived_from","target":{"source":"brigade","collection":"brigade:receipts","external_id":"receipt:front-b"}}],"raw":{"format":"json","path":"card.json","ordinal":1}}`, ns, cardID, body)
+
+	if _, err := ImportAdapterReader(db, strings.NewReader(receiptA+"\n"+receiptB+"\n"+cardA+"\n"), "front-a.jsonl", ""); err != nil {
+		t.Fatal(err)
+	}
+	var cardItemID, receiptAID, receiptBID string
+	var seqBefore int64
+	if err := db.QueryRow(`select id, ingest_seq from items where external_id = ?`, cardID).Scan(&cardItemID, &seqBefore); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`select id from items where external_id = 'receipt:front-a'`).Scan(&receiptAID); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`select id from items where external_id = 'receipt:front-b'`).Scan(&receiptBID); err != nil {
+		t.Fatal(err)
+	}
+	var targetA string
+	if err := db.QueryRow(`select target_item_id from relations where source_item_id = ? and relation_type = 'derived_from'`, cardItemID).Scan(&targetA); err != nil {
+		t.Fatal(err)
+	}
+	if targetA != receiptAID {
+		t.Fatalf("initial relation target=%s want receipt A %s", targetA, receiptAID)
+	}
+	var eventsBefore int
+	if err := db.QueryRow(`select count(*) from events where item_id = ?`, cardItemID).Scan(&eventsBefore); err != nil {
+		t.Fatal(err)
+	}
+
+	again, err := ImportAdapterReader(db, strings.NewReader(cardB+"\n"), "front-b.jsonl", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// New source path/hash is not whole-file AlreadyKnown; item identity is Text+Summary.
+	if again.Inserted != 0 {
+		t.Fatalf("same-text frontmatter edit must not mint a new item, got %+v", again)
+	}
+	var versionCount int
+	if err := db.QueryRow(`select count(*) from items where external_id = ?`, cardID).Scan(&versionCount); err != nil {
+		t.Fatal(err)
+	}
+	if versionCount != 1 {
+		t.Fatalf("same-text must keep one content-addressed row, got %d", versionCount)
+	}
+	var seqAfter int64
+	var metaJSON string
+	if err := db.QueryRow(`select ingest_seq, metadata_json from items where id = ?`, cardItemID).Scan(&seqAfter, &metaJSON); err != nil {
+		t.Fatal(err)
+	}
+	if seqAfter <= seqBefore {
+		t.Fatalf("ingest_seq must advance on known reconcile before=%d after=%d", seqBefore, seqAfter)
+	}
+	if !strings.Contains(metaJSON, `"topic":"beta"`) || !strings.Contains(metaJSON, `"status":"ready"`) {
+		t.Fatalf("metadata_json missing receipt-B frontmatter fields: %s", metaJSON)
+	}
+	if !strings.Contains(metaJSON, `"provenance"`) {
+		t.Fatalf("provenance envelope missing after reconcile: %s", metaJSON)
+	}
+	var tagCount int
+	var tag string
+	if err := db.QueryRow(`select count(*), min(tag) from item_tags where item_id = ?`, cardItemID).Scan(&tagCount, &tag); err != nil {
+		t.Fatal(err)
+	}
+	if tagCount != 1 || tag != "tag-b" {
+		t.Fatalf("tags after reconcile count=%d tag=%q want only tag-b", tagCount, tag)
+	}
+	var artCount int
+	var artExt string
+	if err := db.QueryRow(`select count(*), min(external_id) from artifacts where item_id = ?`, cardItemID).Scan(&artCount, &artExt); err != nil {
+		t.Fatal(err)
+	}
+	if artCount != 1 || artExt != "art-b" {
+		t.Fatalf("artifacts after reconcile count=%d ext=%q want only art-b", artCount, artExt)
+	}
+	var relCount int
+	var targetB string
+	if err := db.QueryRow(`select count(*), min(target_item_id) from relations where source_item_id = ? and relation_type = 'derived_from'`, cardItemID).Scan(&relCount, &targetB); err != nil {
+		t.Fatal(err)
+	}
+	if relCount != 1 || targetB != receiptBID {
+		t.Fatalf("relation after reconcile count=%d target=%s want receipt B %s", relCount, targetB, receiptBID)
+	}
+	var eventsAfter int
+	if err := db.QueryRow(`select count(*) from events where item_id = ?`, cardItemID).Scan(&eventsAfter); err != nil {
+		t.Fatal(err)
+	}
+	if eventsAfter != eventsBefore {
+		t.Fatalf("must not mint events on known reconcile: before=%d after=%d", eventsBefore, eventsAfter)
+	}
+	live, err := LiveMemoryProjection(db, ns)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cardHash string
+	if err := db.QueryRow(`select content_hash from items where id = ?`, cardItemID).Scan(&cardHash); err != nil {
+		t.Fatal(err)
+	}
+	if live[cardID] != cardHash {
+		t.Fatalf("live projection=%s want %s", live[cardID], cardHash)
+	}
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback()
+	unresolved, err := memoryUnresolvedRelationCount(tx, ns)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unresolved != 0 {
+		t.Fatalf("health unresolved after receipt-B reconcile: %d", unresolved)
 	}
 }

--- a/engines/evidence-ledger/internal/ingest/relations_test.go
+++ b/engines/evidence-ledger/internal/ingest/relations_test.go
@@ -1,6 +1,8 @@
 package ingest
 
 import (
+	"database/sql"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -49,6 +51,53 @@ func TestResolveRelationsQualifiedAndLegacy(t *testing.T) {
 	if legacyResolved != 1 || qualifiedResolved != 1 || unresolved != 1 {
 		t.Fatalf("legacy=%d qualified=%d unresolved=%d", legacyResolved, qualifiedResolved, unresolved)
 	}
+}
+
+func TestResolveRelationsOptionalTargetIgnoresDetachedBackups(t *testing.T) {
+	dir := t.TempDir()
+	db, err := archive.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := archive.Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	const backup = "__miseledger_memory_backup__:memory-a"
+	records := strings.Join([]string{
+		memoryRecord("memory-a", "live-unique", "live unique"),
+		memoryRecord(backup, "live-unique", "backup duplicate"),
+		memoryRecord(backup, "backup-only", "backup only"),
+		memoryRecord("memory-a", "ambiguous", "A ambiguous"),
+		memoryRecord("memory-b", "ambiguous", "B ambiguous"),
+		supportRelationRecord("unique-live", "live-unique"),
+		supportRelationRecord("only-backup", "backup-only"),
+		supportRelationRecord("ambiguous-live", "ambiguous"),
+	}, "\n") + "\n"
+	if _, err := ImportAdapterReader(db, strings.NewReader(records), "optional-backup.jsonl", ""); err != nil {
+		t.Fatal(err)
+	}
+	for relationType, wantResolved := range map[string]bool{
+		"unique-live":    true,
+		"only-backup":    false,
+		"ambiguous-live": false,
+	} {
+		var target sql.NullString
+		if err := db.QueryRow(`select target_item_id from relations where relation_type = ?`, relationType).Scan(&target); err != nil {
+			t.Fatal(err)
+		}
+		if wantResolved != (target.Valid && target.String != "") {
+			t.Fatalf("%s resolved=%v target=%q", relationType, wantResolved, target.String)
+		}
+	}
+}
+
+func memoryRecord(collection, externalID, text string) string {
+	return fmt.Sprintf(`{"schema":"miseledger.adapter.v1","source":{"kind":"brigade-memory","name":"Memory"},"collection":{"external_id":%q,"kind":"memory_cards","name":"cards"},"item":{"external_id":%q,"kind":"memory_card","created_at":"2026-01-01T00:00:00Z","text":%q},"relations":[],"raw":{"format":"json","path":%q,"ordinal":1}}`, collection, externalID, text, externalID+".json")
+}
+
+func supportRelationRecord(relationType, targetID string) string {
+	return fmt.Sprintf(`{"schema":"miseledger.adapter.v1","source":{"kind":"support","name":"Support"},"collection":{"external_id":"support:records","kind":"support","name":"support"},"item":{"external_id":%q,"kind":"record","created_at":"2026-01-01T00:00:00Z","text":"support"},"relations":[{"type":%q,"target":{"source":"brigade-memory","external_id":%q}}],"raw":{"format":"json","path":%q,"ordinal":1}}`, relationType, relationType, targetID, relationType+".json")
 }
 
 func TestResolveRelationsQualifiedWithoutCollectionRequiresUniqueLiveTarget(t *testing.T) {

--- a/engines/evidence-ledger/internal/ingest/relations_test.go
+++ b/engines/evidence-ledger/internal/ingest/relations_test.go
@@ -50,3 +50,51 @@ func TestResolveRelationsQualifiedAndLegacy(t *testing.T) {
 		t.Fatalf("legacy=%d qualified=%d unresolved=%d", legacyResolved, qualifiedResolved, unresolved)
 	}
 }
+
+func TestResolveRelationsQualifiedWithoutCollectionRequiresUniqueLiveTarget(t *testing.T) {
+	dir := t.TempDir()
+	db, err := archive.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := archive.Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+
+	records := strings.Join([]string{
+		`{"schema":"miseledger.adapter.v1","source":{"kind":"brigade-memory","name":"Memory"},"collection":{"external_id":"memory-a","kind":"memory_cards","name":"A"},"item":{"external_id":"card-shared","kind":"memory_card","created_at":"2026-01-01T00:00:00Z","text":"A shared"},"relations":[],"raw":{"format":"json","path":"a-shared.json","ordinal":1}}`,
+		`{"schema":"miseledger.adapter.v1","source":{"kind":"brigade-memory","name":"Memory"},"collection":{"external_id":"memory-b","kind":"memory_cards","name":"B"},"item":{"external_id":"card-shared","kind":"memory_card","created_at":"2026-01-01T00:00:01Z","text":"B shared"},"relations":[],"raw":{"format":"json","path":"b-shared.json","ordinal":2}}`,
+		`{"schema":"miseledger.adapter.v1","source":{"kind":"brigade-memory","name":"Memory"},"collection":{"external_id":"memory-a","kind":"memory_cards","name":"A"},"item":{"external_id":"card-unique","kind":"memory_card","created_at":"2026-01-01T00:00:02Z","text":"unique"},"relations":[],"raw":{"format":"json","path":"a-unique.json","ordinal":3}}`,
+		`{"schema":"miseledger.adapter.v1","source":{"kind":"support","name":"Support"},"collection":{"external_id":"support:records","kind":"support","name":"support"},"item":{"external_id":"support:ambiguous","kind":"record","created_at":"2026-01-01T00:00:03Z","text":"ambiguous"},"relations":[{"type":"ambiguous","target":{"source":"brigade-memory","external_id":"card-shared"}}],"raw":{"format":"json","path":"ambiguous.json","ordinal":4}}`,
+		`{"schema":"miseledger.adapter.v1","source":{"kind":"support","name":"Support"},"collection":{"external_id":"support:records","kind":"support","name":"support"},"item":{"external_id":"support:unique","kind":"record","created_at":"2026-01-01T00:00:04Z","text":"unique"},"relations":[{"type":"unique","target":{"source":"brigade-memory","external_id":"card-unique"}}],"raw":{"format":"json","path":"unique.json","ordinal":5}}`,
+		`{"schema":"miseledger.adapter.v1","source":{"kind":"support","name":"Support"},"collection":{"external_id":"support:records","kind":"support","name":"support"},"item":{"external_id":"support:explicit","kind":"record","created_at":"2026-01-01T00:00:05Z","text":"explicit"},"relations":[{"type":"explicit","target":{"source":"brigade-memory","collection":"memory-b","external_id":"card-shared"}}],"raw":{"format":"json","path":"explicit.json","ordinal":6}}`,
+	}, "\n") + "\n"
+	if _, err := ImportAdapterReader(db, strings.NewReader(records), "qualified-unique.jsonl", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	var ambiguous, unique, explicit string
+	if err := db.QueryRow(`select coalesce(target_item_id, '') from relations where relation_type = 'ambiguous'`).Scan(&ambiguous); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`select coalesce(target_item_id, '') from relations where relation_type = 'unique'`).Scan(&unique); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`select coalesce(target_item_id, '') from relations where relation_type = 'explicit'`).Scan(&explicit); err != nil {
+		t.Fatal(err)
+	}
+	if ambiguous != "" {
+		t.Fatalf("collection-omitted shared target resolved to %q; want unresolved", ambiguous)
+	}
+	if unique == "" {
+		t.Fatal("collection-omitted unique target stayed unresolved")
+	}
+	var explicitCollection string
+	if err := db.QueryRow(`select c.external_id from items i join collections c on c.id = i.collection_id where i.id = ?`, explicit).Scan(&explicitCollection); err != nil {
+		t.Fatal(err)
+	}
+	if explicitCollection != "memory-b" {
+		t.Fatalf("explicit collection target resolved to %q; want memory-b", explicitCollection)
+	}
+}

--- a/engines/evidence-ledger/internal/sources/memory/memory.go
+++ b/engines/evidence-ledger/internal/sources/memory/memory.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"unicode"
@@ -20,15 +21,21 @@ const (
 	SourceKind       = "brigade-memory"
 	SourceName       = "Brigade Memory Cards"
 	SourceVersion    = "1.0.0"
-	CollectionID     = "memory:cards"
-	CollectionKind   = "memory_cards"
-	ItemKind         = "memory_card"
-	IdentityExplicit = "explicit_id"
-	IdentityPath     = "path"
-	MaxCardBytes     = 2 * 1024 * 1024
-	MaxTextBytes     = 256 * 1024
-	MaxUnknownKeys   = 32
+	// LegacyCollectionID is the pre-namespace collection. Namespaced crawls
+	// never tombstone or rebuild these rows (scoped-rebuild + dual-read rule).
+	LegacyCollectionID = "memory:cards"
+	CollectionKind     = "memory_cards"
+	ItemKind           = "memory_card"
+	IdentityExplicit   = "explicit_id"
+	IdentityPath       = "path"
+	MaxCardBytes       = 2 * 1024 * 1024
+	MaxTextBytes       = 256 * 1024
+	MaxUnknownKeys     = 32
+	NamespaceFileRel   = "memory/NAMESPACE"
 )
+
+// namespacePattern matches operator-declared opaque memory-<uuid4> identifiers.
+var namespacePattern = regexp.MustCompile(`^memory-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
 
 // CardRoots are the default relative directories scanned under a workspace.
 var CardRoots = []string{"memory/cards"}
@@ -47,11 +54,38 @@ var RelationKinds = []string{
 type CardOutcome struct {
 	ExternalID     string
 	ContentHash    string
+	Fingerprint    string
 	RawPath        string
 	IdentitySource string
 	Outcome        string // created/updated/unchanged filled by crawl; skipped/failed here
 	Warning        string
 	Record         *adapter.Record
+}
+
+// ResolveNamespace reads the operator-declared opaque memory-<uuid4> from
+// memory/NAMESPACE. The engine never derives this from a clone path.
+func ResolveNamespace(workspace string) (string, error) {
+	path := filepath.Join(workspace, filepath.FromSlash(NamespaceFileRel))
+	body, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("missing operator-declared memory namespace at %s (expected opaque memory-<uuid4>)", NamespaceFileRel)
+		}
+		return "", err
+	}
+	ns := strings.TrimSpace(string(body))
+	if ns == "" {
+		return "", fmt.Errorf("empty memory namespace in %s", NamespaceFileRel)
+	}
+	if !namespacePattern.MatchString(ns) {
+		return "", fmt.Errorf("invalid memory namespace %q in %s (want memory-<uuid4>)", ns, NamespaceFileRel)
+	}
+	return ns, nil
+}
+
+// CollectionExternalID returns the namespaced collection id for a memory root.
+func CollectionExternalID(namespace string) string {
+	return namespace
 }
 
 // Generate walks workspace memory cards and emits miseledger.adapter.v1 records.
@@ -99,6 +133,10 @@ func Walk(root string, opts sources.Options) ([]CardOutcome, sources.Result, err
 	}
 	if !info.IsDir() {
 		return nil, sources.Result{}, fmt.Errorf("memory crawl path must be a workspace directory: %s", abs)
+	}
+	namespace, err := ResolveNamespace(abs)
+	if err != nil {
+		return nil, sources.Result{}, err
 	}
 
 	var outcomes []CardOutcome
@@ -152,7 +190,7 @@ func Walk(root string, opts sources.Options) ([]CardOutcome, sources.Result, err
 				result.Warnings = append(result.Warnings, rel+": "+readErr.Error())
 				continue
 			}
-			card, warn := buildCard(abs, rel, body)
+			card, warn := buildCard(abs, namespace, rel, body)
 			if card.Outcome == "failed" || card.Outcome == "skipped" {
 				outcomes = append(outcomes, card)
 				if warn != "" {
@@ -174,7 +212,7 @@ func Walk(root string, opts sources.Options) ([]CardOutcome, sources.Result, err
 		}
 		hash := "sha256:" + hex.EncodeToString(hashBytes(body))
 		scan.ContentHash = hash
-		card, warn := buildCard(abs, rel, body)
+		card, warn := buildCard(abs, namespace, rel, body)
 		card.ContentHash = contentHashForRecord(card.Record)
 		if card.ContentHash == "" {
 			card.ContentHash = hash
@@ -192,7 +230,63 @@ func Walk(root string, opts sources.Options) ([]CardOutcome, sources.Result, err
 		outcomes = append(outcomes, card)
 		result.Files = append(result.Files, scan)
 	}
+
+	if dupWarns := detectDuplicateExplicitIDs(outcomes); len(dupWarns) > 0 {
+		result.Warnings = append(result.Warnings, dupWarns...)
+	}
+	if fpWarns := detectDuplicateFingerprints(outcomes); len(fpWarns) > 0 {
+		result.Warnings = append(result.Warnings, fpWarns...)
+	}
 	return outcomes, result, nil
+}
+
+// DuplicateExplicitIDs returns external IDs that appear more than once among
+// successfully parsed cards. Callers must fail the scan before reconciliation.
+func DuplicateExplicitIDs(outcomes []CardOutcome) []string {
+	counts := map[string]int{}
+	for _, o := range outcomes {
+		if o.Record == nil || o.ExternalID == "" {
+			continue
+		}
+		if o.IdentitySource != IdentityExplicit {
+			continue
+		}
+		counts[o.ExternalID]++
+	}
+	var dups []string
+	for id, n := range counts {
+		if n > 1 {
+			dups = append(dups, id)
+		}
+	}
+	return dups
+}
+
+func detectDuplicateExplicitIDs(outcomes []CardOutcome) []string {
+	dups := DuplicateExplicitIDs(outcomes)
+	var warns []string
+	for _, id := range dups {
+		warns = append(warns, "duplicate explicit id "+id+": scan must fail before reconciliation")
+	}
+	return warns
+}
+
+func detectDuplicateFingerprints(outcomes []CardOutcome) []string {
+	byFP := map[string][]string{}
+	for _, o := range outcomes {
+		if o.Record == nil || o.Fingerprint == "" {
+			continue
+		}
+		byFP[o.Fingerprint] = append(byFP[o.Fingerprint], o.ExternalID)
+	}
+	var warns []string
+	for fp, ids := range byFP {
+		if len(ids) < 2 {
+			continue
+		}
+		warns = append(warns, fmt.Sprintf("duplicate content fingerprint %s across identities %s (fingerprint is not card identity)", fp, strings.Join(ids, ", ")))
+	}
+	return warns
 }
 
 func countEmitted(outcomes []CardOutcome) int {
@@ -245,7 +339,7 @@ func listCardFiles(root string) ([]string, error) {
 	return files, nil
 }
 
-func buildCard(workspace, rel string, body []byte) (CardOutcome, string) {
+func buildCard(workspace, namespace, rel string, body []byte) (CardOutcome, string) {
 	text := string(body)
 	meta, hasFrontmatter, malformed := parseFrontmatter(text)
 	if malformed {
@@ -260,6 +354,7 @@ func buildCard(workspace, rel string, body []byte) (CardOutcome, string) {
 	}
 
 	externalID, identitySource := cardIdentity(meta, rel)
+	fingerprint := textnorm.ContentFingerprint(text)
 	markdownBody := bodyAfterFrontmatter(text, hasFrontmatter)
 	summary := firstNonEmpty(stringField(meta, "summary"), stringField(meta, "description"), stringField(meta, "title"), stringField(meta, "topic"))
 	tags := stringList(meta, "tags")
@@ -278,15 +373,17 @@ func buildCard(workspace, rel string, body []byte) (CardOutcome, string) {
 
 	unknown := unknownFrontmatter(meta)
 	itemMeta := map[string]any{
-		"identity_source":    identitySource,
-		"relative_path":      rel,
-		"workspace":          filepath.Base(workspace),
-		"has_frontmatter":    hasFrontmatter,
-		"topic":              stringField(meta, "topic"),
-		"title":              stringField(meta, "title"),
-		"category":           stringField(meta, "category"),
-		"card_id":            stringField(meta, "id", "card_id"),
-		"truncated_text":     truncated,
+		"identity_source":     identitySource,
+		"relative_path":       rel,
+		"workspace":           filepath.Base(workspace),
+		"memory_namespace":    namespace,
+		"has_frontmatter":     hasFrontmatter,
+		"topic":               stringField(meta, "topic"),
+		"title":               stringField(meta, "title"),
+		"category":            stringField(meta, "category"),
+		"card_id":             stringField(meta, "id", "card_id"),
+		"truncated_text":      truncated,
+		"content_fingerprint": fingerprint,
 		"unknown_frontmatter": unknown,
 	}
 	for _, key := range []string{"confidence", "last_reviewed", "fresh_until", "status"} {
@@ -304,10 +401,13 @@ func buildCard(workspace, rel string, body []byte) (CardOutcome, string) {
 		Schema: adapter.SchemaV1,
 		Source: adapter.Source{Kind: SourceKind, Name: SourceName, Version: SourceVersion},
 		Collection: adapter.Collection{
-			ExternalID: CollectionID,
+			ExternalID: CollectionExternalID(namespace),
 			Kind:       CollectionKind,
 			Name:       "Memory cards",
-			Metadata:   sources.Metadata(map[string]any{"workspace": filepath.Base(workspace)}),
+			Metadata: sources.Metadata(map[string]any{
+				"workspace":        filepath.Base(workspace),
+				"memory_namespace": namespace,
+			}),
 		},
 		Item: adapter.Item{
 			ExternalID: externalID,
@@ -334,6 +434,7 @@ func buildCard(workspace, rel string, body []byte) (CardOutcome, string) {
 		ExternalID:     externalID,
 		RawPath:        rel,
 		IdentitySource: identitySource,
+		Fingerprint:    fingerprint,
 		Record:         &rec,
 		ContentHash:    contentHashForRecord(&rec),
 	}
@@ -537,6 +638,7 @@ func unknownFrontmatter(meta map[string]any) map[string]any {
 		"summary": true, "category": true, "tags": true, "confidence": true,
 		"last_reviewed": true, "fresh_until": true, "status": true,
 		"evidence": true, "sources": true, "source": true, "refs": true, "links": true,
+		"fingerprint": true, "reinforcements": true,
 	}
 	for _, kind := range RelationKinds {
 		known[kind] = true

--- a/engines/evidence-ledger/internal/sources/memory/memory.go
+++ b/engines/evidence-ledger/internal/sources/memory/memory.go
@@ -22,7 +22,9 @@ const (
 	SourceName       = "Brigade Memory Cards"
 	SourceVersion    = "1.0.0"
 	// LegacyCollectionID is the pre-namespace collection. Namespaced crawls
-	// never tombstone or rebuild these rows (scoped-rebuild + dual-read rule).
+	// never tombstone or rebuild these rows (scoped-rebuild). Empty-namespace
+	// status/doctor health dual-reads live counts across all collections,
+	// including this legacy id.
 	LegacyCollectionID = "memory:cards"
 	CollectionKind     = "memory_cards"
 	ItemKind           = "memory_card"
@@ -34,8 +36,9 @@ const (
 	NamespaceFileRel   = "memory/NAMESPACE"
 )
 
-// namespacePattern matches operator-declared opaque memory-<uuid4> identifiers.
-var namespacePattern = regexp.MustCompile(`^memory-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+// namespacePattern matches operator-declared opaque memory-<uuid4> identifiers
+// with RFC 4122 version 4 and variant bits (8/9/a/b).
+var namespacePattern = regexp.MustCompile(`^memory-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$`)
 
 // CardRoots are the default relative directories scanned under a workspace.
 var CardRoots = []string{"memory/cards"}
@@ -78,7 +81,7 @@ func ResolveNamespace(workspace string) (string, error) {
 		return "", fmt.Errorf("empty memory namespace in %s", NamespaceFileRel)
 	}
 	if !namespacePattern.MatchString(ns) {
-		return "", fmt.Errorf("invalid memory namespace %q in %s (want memory-<uuid4>)", ns, NamespaceFileRel)
+		return "", fmt.Errorf("invalid memory namespace %q in %s (want memory-<uuid4> with version 4 and RFC variant 8/9/a/b)", ns, NamespaceFileRel)
 	}
 	return ns, nil
 }

--- a/engines/evidence-ledger/internal/sources/memory/memory.go
+++ b/engines/evidence-ledger/internal/sources/memory/memory.go
@@ -18,9 +18,9 @@ import (
 )
 
 const (
-	SourceKind       = "brigade-memory"
-	SourceName       = "Brigade Memory Cards"
-	SourceVersion    = "1.0.0"
+	SourceKind    = "brigade-memory"
+	SourceName    = "Brigade Memory Cards"
+	SourceVersion = "1.0.0"
 	// LegacyCollectionID is the pre-namespace collection. Namespaced crawls
 	// never tombstone or rebuild these rows (scoped-rebuild). Empty-namespace
 	// status/doctor health dual-reads live counts across all collections,
@@ -359,7 +359,7 @@ func buildCard(workspace, namespace, rel string, body []byte) (CardOutcome, stri
 	externalID, identitySource := cardIdentity(meta, rel)
 	fingerprint := textnorm.ContentFingerprint(text)
 	markdownBody := bodyAfterFrontmatter(text, hasFrontmatter)
-	summary := firstNonEmpty(stringField(meta, "summary"), stringField(meta, "description"), stringField(meta, "title"), stringField(meta, "topic"))
+	summary := truncateText(firstNonEmpty(stringField(meta, "summary"), stringField(meta, "description"), stringField(meta, "title"), stringField(meta, "topic")), MaxTextBytes)
 	tags := stringList(meta, "tags")
 	if len(tags) == 0 {
 		tags = []string{"memory-card"}
@@ -370,7 +370,7 @@ func buildCard(workspace, namespace, rel string, body []byte) (CardOutcome, stri
 	itemText := strings.TrimSpace(markdownBody)
 	truncated := false
 	if len(itemText) > MaxTextBytes {
-		itemText = itemText[:MaxTextBytes] + "\n[truncated]"
+		itemText = truncateText(itemText, MaxTextBytes)
 		truncated = true
 	}
 
@@ -442,6 +442,22 @@ func buildCard(workspace, namespace, rel string, body []byte) (CardOutcome, stri
 		ContentHash:    contentHashForRecord(&rec),
 	}
 	return outcome, ""
+}
+
+const truncationMarker = "\n[truncated]"
+
+func truncateText(text string, limit int) string {
+	if len(text) <= limit {
+		return text
+	}
+	if limit <= len(truncationMarker) {
+		return truncationMarker[:limit]
+	}
+	cut := limit - len(truncationMarker)
+	for cut > 0 && (text[cut]&0xc0) == 0x80 {
+		cut--
+	}
+	return text[:cut] + truncationMarker
 }
 
 func cardIdentity(meta map[string]any, rel string) (string, string) {

--- a/engines/evidence-ledger/internal/sources/memory/memory.go
+++ b/engines/evidence-ledger/internal/sources/memory/memory.go
@@ -193,7 +193,7 @@ func Walk(root string, opts sources.Options) ([]CardOutcome, sources.Result, err
 				result.Warnings = append(result.Warnings, rel+": "+readErr.Error())
 				continue
 			}
-			card, warn := buildCard(abs, namespace, rel, body)
+			card, warn := buildCard(abs, namespace, rel, body, scan.MTime)
 			if card.Outcome == "failed" || card.Outcome == "skipped" {
 				outcomes = append(outcomes, card)
 				if warn != "" {
@@ -215,15 +215,12 @@ func Walk(root string, opts sources.Options) ([]CardOutcome, sources.Result, err
 		}
 		hash := "sha256:" + hex.EncodeToString(hashBytes(body))
 		scan.ContentHash = hash
-		card, warn := buildCard(abs, namespace, rel, body)
+		card, warn := buildCard(abs, namespace, rel, body, scan.MTime)
 		card.ContentHash = contentHashForRecord(card.Record)
 		if card.ContentHash == "" {
 			card.ContentHash = hash
 		}
 		if card.Record != nil {
-			card.Record.Item.CreatedAt = scan.MTime
-			card.Record.Item.UpdatedAt = scan.MTime
-			card.ContentHash = contentHashForRecord(card.Record)
 			scan.Records = 1
 		}
 		if warn != "" {
@@ -342,7 +339,7 @@ func listCardFiles(root string) ([]string, error) {
 	return files, nil
 }
 
-func buildCard(workspace, namespace, rel string, body []byte) (CardOutcome, string) {
+func buildCard(workspace, namespace, rel string, body []byte, mtime string) (CardOutcome, string) {
 	text := string(body)
 	meta, hasFrontmatter, malformed := parseFrontmatter(text)
 	if malformed {
@@ -415,6 +412,8 @@ func buildCard(workspace, namespace, rel string, body []byte) (CardOutcome, stri
 		Item: adapter.Item{
 			ExternalID: externalID,
 			Kind:       ItemKind,
+			CreatedAt:  mtime,
+			UpdatedAt:  mtime,
 			Text:       itemText,
 			Summary:    summaryPtr,
 			Tags:       tags,

--- a/engines/evidence-ledger/internal/sources/memory/memory_test.go
+++ b/engines/evidence-ledger/internal/sources/memory/memory_test.go
@@ -86,7 +86,7 @@ func TestWalkValidMissingMalformedUnknownLargeInjection(t *testing.T) {
 func TestBuildCardTruncatesUTF8WithinBudget(t *testing.T) {
 	marker := "\n[truncated]"
 	body := "---\nid: card-utf80000-1111-4222-8333-444444444444\nsummary: " + strings.Repeat("界", MaxTextBytes) + "\n---\n\n" + strings.Repeat("界", MaxTextBytes)
-	card, warning := buildCard("workspace", fixtureNamespace, "memory/cards/utf8.md", []byte(body))
+	card, warning := buildCard("workspace", fixtureNamespace, "memory/cards/utf8.md", []byte(body), "2026-01-01T00:00:00Z")
 	if warning != "" || card.Record == nil {
 		t.Fatalf("card=%+v warning=%q", card, warning)
 	}
@@ -99,7 +99,7 @@ func TestBuildCardTruncatesUTF8WithinBudget(t *testing.T) {
 	if len(*card.Record.Item.Summary) > MaxTextBytes || !strings.HasSuffix(*card.Record.Item.Summary, marker) {
 		t.Fatalf("summary bytes=%d suffix=%v", len(*card.Record.Item.Summary), strings.HasSuffix(*card.Record.Item.Summary, marker))
 	}
-	ascii, _ := buildCard("workspace", fixtureNamespace, "memory/cards/ascii.md", []byte("---\nid: card-ascii000-1111-4222-8333-444444444444\n---\n\n"+strings.Repeat("a", MaxTextBytes+1)))
+	ascii, _ := buildCard("workspace", fixtureNamespace, "memory/cards/ascii.md", []byte("---\nid: card-ascii000-1111-4222-8333-444444444444\n---\n\n"+strings.Repeat("a", MaxTextBytes+1)), "2026-01-01T00:00:00Z")
 	if ascii.Record == nil || len(ascii.Record.Item.Text) != MaxTextBytes || !strings.HasSuffix(ascii.Record.Item.Text, marker) {
 		t.Fatalf("ascii truncation = %+v", ascii)
 	}

--- a/engines/evidence-ledger/internal/sources/memory/memory_test.go
+++ b/engines/evidence-ledger/internal/sources/memory/memory_test.go
@@ -96,6 +96,51 @@ func TestWalkRequiresOperatorNamespace(t *testing.T) {
 	}
 }
 
+func TestResolveNamespaceRejectsNonV4AndInvalidVariant(t *testing.T) {
+	cases := []struct {
+		name string
+		ns   string
+	}{
+		{"version1", "memory-aaaaaaaa-bbbb-1ccc-8ddd-eeeeeeeeeeee"},
+		{"version5", "memory-aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeeee"},
+		{"variant_c", "memory-aaaaaaaa-bbbb-4ccc-cddd-eeeeeeeeeeee"},
+		{"variant_0", "memory-aaaaaaaa-bbbb-4ccc-0ddd-eeeeeeeeeeee"},
+		{"not_uuid", "memory-not-a-uuid"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ws := t.TempDir()
+			writeNamespace(t, ws, tc.ns)
+			if err := os.MkdirAll(filepath.Join(ws, "memory", "cards"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			_, err := ResolveNamespace(ws)
+			if err == nil {
+				t.Fatalf("expected rejection for %s", tc.ns)
+			}
+			if !strings.Contains(err.Error(), "invalid memory namespace") {
+				t.Fatalf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestResolveNamespaceAcceptsUUIDV4Variants(t *testing.T) {
+	for _, ns := range []string{
+		"memory-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+		"memory-aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee",
+		"memory-aaaaaaaa-bbbb-4ccc-addd-eeeeeeeeeeee",
+		"memory-aaaaaaaa-bbbb-4ccc-bddd-eeeeeeeeeeee",
+	} {
+		ws := t.TempDir()
+		writeNamespace(t, ws, ns)
+		got, err := ResolveNamespace(ws)
+		if err != nil || got != ns {
+			t.Fatalf("ns=%s got=%s err=%v", ns, got, err)
+		}
+	}
+}
+
 func TestWalkOversizeSkipAndTextTruncation(t *testing.T) {
 	ws := t.TempDir()
 	writeNamespace(t, ws, fixtureNamespace)

--- a/engines/evidence-ledger/internal/sources/memory/memory_test.go
+++ b/engines/evidence-ledger/internal/sources/memory/memory_test.go
@@ -7,7 +7,10 @@ import (
 	"testing"
 
 	"github.com/escoffier-labs/miseledger/internal/sources"
+	"github.com/escoffier-labs/miseledger/internal/textnorm"
 )
+
+const fixtureNamespace = "memory-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
 
 func TestWalkValidMissingMalformedUnknownLargeInjection(t *testing.T) {
 	root := copyMemoryFixtureWorkspace(t)
@@ -27,11 +30,17 @@ func TestWalkValidMissingMalformedUnknownLargeInjection(t *testing.T) {
 	if explicit.ExternalID != "card-11111111-2222-4333-8444-555555555555" {
 		t.Fatalf("explicit id = %q", explicit.ExternalID)
 	}
+	if explicit.Record.Collection.ExternalID != fixtureNamespace {
+		t.Fatalf("collection = %q want namespace %q", explicit.Record.Collection.ExternalID, fixtureNamespace)
+	}
 	if len(explicit.Record.Relations) != 1 || explicit.Record.Relations[0].Target == nil {
 		t.Fatalf("expected qualified relation, got %+v", explicit.Record.Relations)
 	}
 	if explicit.Record.Relations[0].Target.Source != "brigade" {
 		t.Fatalf("relation target = %+v", explicit.Record.Relations[0].Target)
+	}
+	if explicit.Fingerprint == "" || explicit.Fingerprint == explicit.ExternalID {
+		t.Fatalf("fingerprint must be present and not identity: fp=%q id=%q", explicit.Fingerprint, explicit.ExternalID)
 	}
 
 	pathCard := byPath["memory/cards/valid-path.md"]
@@ -73,6 +82,121 @@ func TestWalkValidMissingMalformedUnknownLargeInjection(t *testing.T) {
 	}
 }
 
+func TestWalkRequiresOperatorNamespace(t *testing.T) {
+	ws := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(ws, "memory", "cards"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(ws, "memory", "cards", "x.md"), []byte("---\ntopic: x\n---\n\n# X\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := Walk(ws, sources.Options{})
+	if err == nil || !strings.Contains(err.Error(), "memory namespace") {
+		t.Fatalf("expected namespace error, got %v", err)
+	}
+}
+
+func TestWalkOversizeSkipAndTextTruncation(t *testing.T) {
+	ws := t.TempDir()
+	writeNamespace(t, ws, fixtureNamespace)
+	cards := filepath.Join(ws, "memory", "cards")
+	if err := os.MkdirAll(cards, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oversize := make([]byte, MaxCardBytes+1)
+	for i := range oversize {
+		oversize[i] = 'A'
+	}
+	if err := os.WriteFile(filepath.Join(cards, "oversize.md"), oversize, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	body := strings.Repeat(" truncation-body-word ", (MaxTextBytes/20)+50)
+	truncCard := "---\nid: card-trunc000-1111-4222-8333-444444444444\ntopic: trunc\n---\n\n# Trunc\n\n" + body + "\n"
+	if err := os.WriteFile(filepath.Join(cards, "trunc.md"), []byte(truncCard), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	outcomes, _, err := Walk(ws, sources.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	byPath := map[string]CardOutcome{}
+	for _, o := range outcomes {
+		byPath[o.RawPath] = o
+	}
+	if byPath["memory/cards/oversize.md"].Outcome != "skipped" || byPath["memory/cards/oversize.md"].Record != nil {
+		t.Fatalf("oversize = %+v", byPath["memory/cards/oversize.md"])
+	}
+	trunc := byPath["memory/cards/trunc.md"]
+	if trunc.Record == nil || !strings.HasSuffix(trunc.Record.Item.Text, "[truncated]") {
+		t.Fatalf("truncation missing: %+v", trunc)
+	}
+	if len(trunc.Record.Item.Text) < MaxTextBytes {
+		t.Fatalf("truncated text too short: %d", len(trunc.Record.Item.Text))
+	}
+}
+
+func TestFingerprintDuplicateDetectionOnly(t *testing.T) {
+	ws := t.TempDir()
+	writeNamespace(t, ws, fixtureNamespace)
+	cards := filepath.Join(ws, "memory", "cards")
+	if err := os.MkdirAll(cards, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	a := "---\nid: card-fp000000-1111-4222-8333-444444444444\ntopic: a\n---\n\nFlush the cache after migrations.\n"
+	b := "---\nid: card-fp000000-1111-4222-8333-444444444445\ntopic: b\n---\n\nflush the cache after migrations!\n"
+	if err := os.WriteFile(filepath.Join(cards, "a.md"), []byte(a), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cards, "b.md"), []byte(b), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	outcomes, result, err := Walk(ws, sources.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(outcomes) != 2 {
+		t.Fatalf("outcomes=%d", len(outcomes))
+	}
+	if outcomes[0].Fingerprint != outcomes[1].Fingerprint {
+		t.Fatalf("fingerprints differ: %s vs %s", outcomes[0].Fingerprint, outcomes[1].Fingerprint)
+	}
+	want := textnorm.ContentFingerprint(a)
+	if outcomes[0].Fingerprint != want {
+		t.Fatalf("fingerprint = %s want %s", outcomes[0].Fingerprint, want)
+	}
+	if outcomes[0].ExternalID == outcomes[0].Fingerprint {
+		t.Fatal("fingerprint must not be card identity")
+	}
+	joined := strings.Join(result.Warnings, "\n")
+	if !strings.Contains(joined, "duplicate content fingerprint") {
+		t.Fatalf("expected fingerprint duplicate warning, got %v", result.Warnings)
+	}
+}
+
+func TestDuplicateExplicitIDsDetected(t *testing.T) {
+	ws := t.TempDir()
+	writeNamespace(t, ws, fixtureNamespace)
+	cards := filepath.Join(ws, "memory", "cards")
+	if err := os.MkdirAll(cards, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "---\nid: card-dup00000-1111-4222-8333-444444444444\ntopic: d\n---\n\n# Dup\n"
+	if err := os.WriteFile(filepath.Join(cards, "one.md"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cards, "two.md"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	outcomes, _, err := Walk(ws, sources.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dups := DuplicateExplicitIDs(outcomes)
+	if len(dups) != 1 {
+		t.Fatalf("dups=%v", dups)
+	}
+}
+
 func TestParseFrontmatterMatchesBrigadeFlatSubset(t *testing.T) {
 	meta, has, malformed := parseFrontmatter("---\ntopic: demo\ntags: [a, b]\nflag: true\n---\nbody\n")
 	if !has || malformed {
@@ -98,6 +222,7 @@ func copyMemoryFixtureWorkspace(t *testing.T) string {
 	t.Helper()
 	src := filepath.Join("..", "..", "..", "testdata", "adapters", "memory", "cards")
 	ws := t.TempDir()
+	writeNamespace(t, ws, fixtureNamespace)
 	dst := filepath.Join(ws, "memory", "cards")
 	if err := os.MkdirAll(dst, 0o755); err != nil {
 		t.Fatal(err)
@@ -116,4 +241,15 @@ func copyMemoryFixtureWorkspace(t *testing.T) string {
 		}
 	}
 	return ws
+}
+
+func writeNamespace(t *testing.T, ws, ns string) {
+	t.Helper()
+	dir := filepath.Join(ws, "memory")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "NAMESPACE"), []byte(ns+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/engines/evidence-ledger/internal/sources/memory/memory_test.go
+++ b/engines/evidence-ledger/internal/sources/memory/memory_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/escoffier-labs/miseledger/internal/sources"
 	"github.com/escoffier-labs/miseledger/internal/textnorm"
@@ -79,6 +80,28 @@ func TestWalkValidMissingMalformedUnknownLargeInjection(t *testing.T) {
 
 	if len(result.Warnings) == 0 {
 		t.Fatal("expected malformed warning")
+	}
+}
+
+func TestBuildCardTruncatesUTF8WithinBudget(t *testing.T) {
+	marker := "\n[truncated]"
+	body := "---\nid: card-utf80000-1111-4222-8333-444444444444\nsummary: " + strings.Repeat("界", MaxTextBytes) + "\n---\n\n" + strings.Repeat("界", MaxTextBytes)
+	card, warning := buildCard("workspace", fixtureNamespace, "memory/cards/utf8.md", []byte(body))
+	if warning != "" || card.Record == nil {
+		t.Fatalf("card=%+v warning=%q", card, warning)
+	}
+	if !utf8.ValidString(card.Record.Item.Text) || !utf8.ValidString(*card.Record.Item.Summary) {
+		t.Fatal("truncation split a UTF-8 rune")
+	}
+	if len(card.Record.Item.Text) > MaxTextBytes || !strings.HasSuffix(card.Record.Item.Text, marker) {
+		t.Fatalf("text bytes=%d suffix=%v", len(card.Record.Item.Text), strings.HasSuffix(card.Record.Item.Text, marker))
+	}
+	if len(*card.Record.Item.Summary) > MaxTextBytes || !strings.HasSuffix(*card.Record.Item.Summary, marker) {
+		t.Fatalf("summary bytes=%d suffix=%v", len(*card.Record.Item.Summary), strings.HasSuffix(*card.Record.Item.Summary, marker))
+	}
+	ascii, _ := buildCard("workspace", fixtureNamespace, "memory/cards/ascii.md", []byte("---\nid: card-ascii000-1111-4222-8333-444444444444\n---\n\n"+strings.Repeat("a", MaxTextBytes+1)))
+	if ascii.Record == nil || len(ascii.Record.Item.Text) != MaxTextBytes || !strings.HasSuffix(ascii.Record.Item.Text, marker) {
+		t.Fatalf("ascii truncation = %+v", ascii)
 	}
 }
 

--- a/engines/evidence-ledger/internal/textnorm/fingerprint.go
+++ b/engines/evidence-ledger/internal/textnorm/fingerprint.go
@@ -1,0 +1,61 @@
+package textnorm
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"unicode"
+)
+
+// NormalizeCardContent mirrors brigade.card_fingerprint.normalize_card_content (#724):
+// strip leading frontmatter, lowercase, replace punctuation with spaces, collapse
+// whitespace. Used for duplicate detection only — never as card identity.
+func NormalizeCardContent(text string) string {
+	body := stripLeadingFrontmatter(text)
+	var b strings.Builder
+	b.Grow(len(body))
+	space := false
+	for _, r := range strings.ToLower(body) {
+		if unicode.IsSpace(r) {
+			space = true
+			continue
+		}
+		if !isFingerprintWord(r) {
+			space = true
+			continue
+		}
+		if space && b.Len() > 0 {
+			b.WriteByte(' ')
+		}
+		space = false
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// ContentFingerprint returns the #724 hex SHA-256 of NormalizeCardContent(text).
+func ContentFingerprint(text string) string {
+	normalized := NormalizeCardContent(text)
+	sum := sha256.Sum256([]byte(normalized))
+	return hex.EncodeToString(sum[:])
+}
+
+func isFingerprintWord(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_'
+}
+
+func stripLeadingFrontmatter(text string) string {
+	if !strings.HasPrefix(text, "---\n") && !strings.HasPrefix(text, "---\r\n") && text != "---" {
+		return text
+	}
+	lines := strings.Split(strings.ReplaceAll(text, "\r\n", "\n"), "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return text
+	}
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "---" {
+			return strings.Join(lines[i+1:], "\n")
+		}
+	}
+	return text
+}

--- a/engines/evidence-ledger/internal/textnorm/fingerprint_test.go
+++ b/engines/evidence-ledger/internal/textnorm/fingerprint_test.go
@@ -1,0 +1,35 @@
+package textnorm
+
+import "testing"
+
+func TestContentFingerprintMatchesBrigade724(t *testing.T) {
+	a := "---\ntopic: t\n---\n\nFlush the cache after migrations.\n"
+	b := "---\ntopic: other\n---\n\nflush the cache after migrations!\n"
+	if got := NormalizeCardContent(a); got != "flush the cache after migrations" {
+		t.Fatalf("normalize = %q", got)
+	}
+	want := "31500e3247257e8401e3efbd63154b95731294f97ebf8131fc725daea648ab60"
+	fpA := ContentFingerprint(a)
+	fpB := ContentFingerprint(b)
+	if fpA != want {
+		t.Fatalf("fingerprint a = %s want %s", fpA, want)
+	}
+	if fpA != fpB {
+		t.Fatalf("punctuation variants must share fingerprint: %s vs %s", fpA, fpB)
+	}
+}
+
+func TestContentFingerprintNeverUsedAsIdentityShape(t *testing.T) {
+	body := "---\nid: card-11111111-2222-4333-8444-555555555555\n---\n\nSame body text.\n"
+	fp := ContentFingerprint(body)
+	if stringsHasPrefix(fp, "card-") || stringsHasPrefix(fp, "path:") || stringsHasPrefix(fp, "memory-") {
+		t.Fatalf("fingerprint looks like identity: %s", fp)
+	}
+	if len(fp) != 64 {
+		t.Fatalf("fingerprint length = %d", len(fp))
+	}
+}
+
+func stringsHasPrefix(s, prefix string) bool {
+	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+}

--- a/engines/evidence-ledger/testdata/adapters/memory/NAMESPACE
+++ b/engines/evidence-ledger/testdata/adapters/memory/NAMESPACE
@@ -1,0 +1,1 @@
+memory-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee


### PR DESCRIPTION
Refs #843

## Summary

Engine-only E1 memory projection for MiseLedger (`engines/evidence-ledger`): namespace-scoped crawl/rebuild, failure-preserving detach/remap, health dual-read, and latest-version / known-item contracts.

## Maintainer repairs

Consolidated review scope through comment `5247021742`:

1. Latest-version ordering uses database-monotonic `items.ingest_seq` (schema v3), not wall-clock `updated_at` or content-hash ID order. Equal and backward clock regressions are included.
2. v2-to-v3 migration backfill deterministically assigns `ingest_seq` from prior `updated_at` order with stable ID fallback, so multi-version cards keep the prior live winner before any crawl. The upgrade regression covers live projection, relations, and health.
3. The same-text frontmatter known-item path advances `ingest_seq` and reconciles metadata, tags, provenance, artifacts, and outbound relations without minting duplicate items/events. Direct adapter already-known re-resolves inbound edges.

Prior E1 fixes retained: empty-namespace health aggregation, detach/remap rebuild preservation, UUID v4 and variant, truthful legacy `memory:cards` docs, inbound repoint on edit, UTF-8/idempotency/tombstone/namespace contracts.

## Out of scope

E2, #844, #845, and #498 are not entered.