### PR TITLE
feat(evidence-ledger): persist provenance projections and backfill (#583)

### DIFF
--- a/engines/evidence-ledger/CHANGELOG.md
+++ b/engines/evidence-ledger/CHANGELOG.md
@@ -10,6 +10,10 @@ Releases before this changelog was started are on the [releases page](https://gi
 
 ### Added
 
+- Provenance persistence Slice 2: ingest stamps indexed `provenance.*` projections,
+  append-only `provenance_events`, resumable `miseledger doctor provenance backfill`,
+  on-read legacy show synthesis, and search/SQL filters for origin, modality, and
+  trust label without nested JSON parsing.
 - Engine Slice 1a memory projection: native `miseledger crawl memory <workspace>`
   source (`brigade-memory`), qualified cross-source relation targets on
   `miseledger.adapter.v1`, completed-scan soft tombstones scoped to memory,

--- a/engines/evidence-ledger/docs/SCHEMA.md
+++ b/engines/evidence-ledger/docs/SCHEMA.md
@@ -15,7 +15,7 @@ The MVP uses one SQLite migration with these concepts:
 - `item_metadata`: indexed project, workspace, harness, event type, session, model, file-path, and provenance scalar metadata
 - `source_scans`: source-file scan manifests for native imports
 - `source_scan_runs` / `source_scan_observed`: memory projection scan receipts and manifests
-- `provenance_events`: append-only trust transition events keyed by item id
+- `provenance_events`: append-only trust transition events keyed by item id (schema v4; after #850 ingest_seq v3)
 - `item_fts`: SQLite FTS5 index for item and artifact text
 
 Items may carry `tombstoned_at` for soft removal. Live memory cards are the
@@ -41,7 +41,7 @@ New MiseLedger `items` rows carry a `brigade.provenance-envelope.v1` envelope un
 - MiseLedger: `items.metadata_json.provenance` (embedded sorted-key JSON, no document newline).
 - Go mirror package: `internal/provenance` (`Envelope`, `Validate`, `SynthesizeLegacyProvenance`).
 - Indexed projections in `item_metadata`: `provenance.origin`, `provenance.modality`, `provenance.trust_label`, `provenance.content_scope`, `provenance.content_digest`.
-- Trust transitions: append-only `provenance_events` rows (`brigade.provenance-event.v1`) with `ON DELETE CASCADE` so prune and rebuild remain safe.
+- Trust transitions: append-only `provenance_events` rows (`brigade.provenance-event.v1`, schema v4) with `ON DELETE CASCADE` so prune and rebuild remain safe.
 - Legacy show: when `metadata.provenance` is absent, `show` synthesizes an unknown envelope and surfaces `provenance_display = UNKNOWN PROVENANCE - legacy item`. When provenance is present but malformed, `show` keeps the raw value and sets `provenance_warning`.
 - Operator backfill: `miseledger doctor provenance backfill [--batch N] [--after ID]` is batched, resumable, and idempotent; inferred rows use `trust.label=unknown`. Structurally valid existing envelopes are preserved even when `hashes.content` is nil or differs (projections only). Malformed provenance is isolated per row with bounded `evidence` and does not abort the batch.
 

--- a/engines/evidence-ledger/docs/SCHEMA.md
+++ b/engines/evidence-ledger/docs/SCHEMA.md
@@ -42,8 +42,8 @@ New MiseLedger `items` rows carry a `brigade.provenance-envelope.v1` envelope un
 - Go mirror package: `internal/provenance` (`Envelope`, `Validate`, `SynthesizeLegacyProvenance`).
 - Indexed projections in `item_metadata`: `provenance.origin`, `provenance.modality`, `provenance.trust_label`, `provenance.content_scope`, `provenance.content_digest`.
 - Trust transitions: append-only `provenance_events` rows (`brigade.provenance-event.v1`) with `ON DELETE CASCADE` so prune and rebuild remain safe.
-- Legacy show: when `metadata.provenance` is absent, `show` synthesizes an unknown envelope and surfaces `provenance_display = UNKNOWN PROVENANCE - legacy item`.
-- Operator backfill: `miseledger doctor provenance backfill [--batch N] [--after ID]` is batched, resumable, and idempotent; inferred rows use `trust.label=unknown`.
+- Legacy show: when `metadata.provenance` is absent, `show` synthesizes an unknown envelope and surfaces `provenance_display = UNKNOWN PROVENANCE - legacy item`. When provenance is present but malformed, `show` keeps the raw value and sets `provenance_warning`.
+- Operator backfill: `miseledger doctor provenance backfill [--batch N] [--after ID]` is batched, resumable, and idempotent; inferred rows use `trust.label=unknown`. Structurally valid existing envelopes are preserved even when `hashes.content` is nil or differs (projections only). Malformed provenance is isolated per row with bounded `evidence` and does not abort the batch.
 
 ### Field sets
 

--- a/engines/evidence-ledger/docs/SCHEMA.md
+++ b/engines/evidence-ledger/docs/SCHEMA.md
@@ -12,9 +12,10 @@ The MVP uses one SQLite migration with these concepts:
   columns `target_source_kind` and `target_collection_external_id`
 - `imports` and `import_warnings`: import run metadata
 - `item_tags`: indexed item tags from adapter records
-- `item_metadata`: indexed project, workspace, harness, event type, session, model, and file-path metadata
+- `item_metadata`: indexed project, workspace, harness, event type, session, model, file-path, and provenance scalar metadata
 - `source_scans`: source-file scan manifests for native imports
 - `source_scan_runs` / `source_scan_observed`: memory projection scan receipts and manifests
+- `provenance_events`: append-only trust transition events keyed by item id
 - `item_fts`: SQLite FTS5 index for item and artifact text
 
 Items may carry `tombstoned_at` for soft removal. Live memory cards are the
@@ -33,12 +34,16 @@ The migration lives in `internal/archive/db.go`.
 
 ## Provenance Envelope
 
-New MiseLedger `items` rows will carry a `brigade.provenance-envelope.v1` envelope under `metadata_json.provenance`. Slice 1 ships the typed Go mirror, validator, and legacy read synthesis in `internal/provenance/envelope.go`. Persistence, ingest stamping, and consumer enforcement land in later slices.
+New MiseLedger `items` rows carry a `brigade.provenance-envelope.v1` envelope under `metadata_json.provenance`. Slice 1 ships the typed Go mirror, validator, and legacy read synthesis in `internal/provenance/envelope.go`. Slice 2 persists envelopes at ingest, indexes scalar projections, appends `provenance_events`, and backfills legacy rows via `miseledger doctor provenance backfill`.
 
 ### Location
 
 - MiseLedger: `items.metadata_json.provenance` (embedded sorted-key JSON, no document newline).
 - Go mirror package: `internal/provenance` (`Envelope`, `Validate`, `SynthesizeLegacyProvenance`).
+- Indexed projections in `item_metadata`: `provenance.origin`, `provenance.modality`, `provenance.trust_label`, `provenance.content_scope`, `provenance.content_digest`.
+- Trust transitions: append-only `provenance_events` rows (`brigade.provenance-event.v1`) with `ON DELETE CASCADE` so prune and rebuild remain safe.
+- Legacy show: when `metadata.provenance` is absent, `show` synthesizes an unknown envelope and surfaces `provenance_display = UNKNOWN PROVENANCE - legacy item`.
+- Operator backfill: `miseledger doctor provenance backfill [--batch N] [--after ID]` is batched, resumable, and idempotent; inferred rows use `trust.label=unknown`.
 
 ### Field sets
 

--- a/engines/evidence-ledger/internal/app/app.go
+++ b/engines/evidence-ledger/internal/app/app.go
@@ -24,6 +24,7 @@ import (
 	"github.com/escoffier-labs/miseledger/internal/adapter"
 	"github.com/escoffier-labs/miseledger/internal/archive"
 	"github.com/escoffier-labs/miseledger/internal/ingest"
+	"github.com/escoffier-labs/miseledger/internal/provenance"
 	"github.com/escoffier-labs/miseledger/internal/security"
 	"github.com/escoffier-labs/miseledger/internal/sources"
 	"github.com/escoffier-labs/miseledger/internal/sources/claude"
@@ -232,7 +233,11 @@ func collectStatus(db *sql.DB, paths Paths) (Status, error) {
 func cmdDoctor(args []string, out, errw io.Writer) int {
 	if len(args) == 1 && (args[0] == "--help" || args[0] == "-h") {
 		fmt.Fprintln(out, "usage: miseledger doctor [--json] [--mcp] [--archive]")
+		fmt.Fprintln(out, "       miseledger doctor provenance backfill [--json] [--batch N] [--after ID]")
 		return 0
+	}
+	if len(args) > 0 && args[0] == "provenance" {
+		return cmdDoctorProvenance(args[1:], out, errw)
 	}
 	_, bools, rest, err := splitFlags(args, nil, map[string]bool{"json": true, "mcp": true, "archive": true})
 	if err != nil {
@@ -308,6 +313,59 @@ func cmdDoctor(args []string, out, errw io.Writer) int {
 	}
 	if result["ok"] == false {
 		return 1
+	}
+	return 0
+}
+
+func cmdDoctorProvenance(args []string, out, errw io.Writer) int {
+	if len(args) == 0 {
+		return fatalf(errw, "usage: miseledger doctor provenance backfill [--json] [--batch N] [--after ID]")
+	}
+	switch args[0] {
+	case "backfill":
+		return cmdDoctorProvenanceBackfill(args[1:], out, errw)
+	default:
+		return fatalf(errw, "usage: miseledger doctor provenance backfill [--json] [--batch N] [--after ID]")
+	}
+}
+
+func cmdDoctorProvenanceBackfill(args []string, out, errw io.Writer) int {
+	values, bools, rest, err := splitFlags(args, map[string]bool{"batch": true, "after": true}, map[string]bool{"json": true})
+	if err != nil {
+		return fatalf(errw, "doctor provenance backfill: %s", err)
+	}
+	if len(rest) != 0 {
+		return fatalf(errw, "usage: miseledger doctor provenance backfill [--json] [--batch N] [--after ID]")
+	}
+	batch := 100
+	if values["batch"] != "" {
+		if _, err := fmt.Sscan(values["batch"], &batch); err != nil || batch <= 0 {
+			return fatalf(errw, "doctor provenance backfill: invalid --batch")
+		}
+	}
+	db, _, err := openMigrated()
+	if err != nil {
+		return fatalf(errw, "doctor provenance backfill: %s", err)
+	}
+	defer db.Close()
+	result, err := ingest.BackfillProvenance(db, batch, values["after"])
+	if err != nil {
+		return fatalf(errw, "doctor provenance backfill: %s", err)
+	}
+	payload := map[string]any{
+		"ok":        true,
+		"scanned":   result.Scanned,
+		"updated":   result.Updated,
+		"skipped":   result.Skipped,
+		"events":    result.Events,
+		"cursor":    result.Cursor,
+		"remaining": result.Remaining,
+	}
+	if bools["json"] {
+		writeJSON(out, payload)
+	} else {
+		fmt.Fprintf(out, "scanned=%d updated=%d skipped=%d events=%d cursor=%s remaining=%d\n",
+			result.Scanned, result.Updated, result.Skipped, result.Events, result.Cursor, result.Remaining)
 	}
 	return 0
 }
@@ -1558,7 +1616,7 @@ func parseRedactions(raw string) (map[string]bool, error) {
 }
 
 func cmdSearch(args []string, out, errw io.Writer) int {
-	values, bools, rest, err := splitFlags(args, map[string]bool{"source": true, "collection": true, "kind": true, "actor-type": true, "project": true, "tags": true, "from": true, "to": true, "limit": true, "code-reference": true}, map[string]bool{"json": true})
+	values, bools, rest, err := splitFlags(args, map[string]bool{"source": true, "collection": true, "kind": true, "actor-type": true, "project": true, "tags": true, "from": true, "to": true, "limit": true, "code-reference": true, "origin": true, "modality": true, "trust-label": true}, map[string]bool{"json": true})
 	if err != nil {
 		return fatalf(errw, "search: %s", err)
 	}
@@ -1581,7 +1639,7 @@ func cmdSearch(args []string, out, errw io.Writer) int {
 		return fatalf(errw, "search: %s", err)
 	}
 	defer db.Close()
-	results, err := search(db, SearchOpts{Query: query, Source: values["source"], Collection: values["collection"], Kind: values["kind"], ActorType: values["actor-type"], From: values["from"], To: values["to"], Project: values["project"], Tags: values["tags"], Limit: limit, CodeReference: codeReference})
+	results, err := search(db, SearchOpts{Query: query, Source: values["source"], Collection: values["collection"], Kind: values["kind"], ActorType: values["actor-type"], From: values["from"], To: values["to"], Project: values["project"], Tags: values["tags"], Origin: values["origin"], Modality: values["modality"], TrustLabel: values["trust-label"], Limit: limit, CodeReference: codeReference})
 	if err != nil {
 		return fatalf(errw, "search: %s", err)
 	}
@@ -1597,6 +1655,7 @@ func cmdSearch(args []string, out, errw io.Writer) int {
 
 type SearchOpts struct {
 	Query, Source, Collection, Kind, ActorType, From, To, Project, Tags string
+	Origin, Modality, TrustLabel                                        string
 	Limit                                                               int
 	IncludeRelated                                                      bool
 	IncludeArtifactText                                                 bool
@@ -1903,6 +1962,18 @@ func appendSearchResultFilters(opts SearchOpts, where []string, params []any) ([
 	if opts.Project != "" {
 		where = append(where, `exists(select 1 from item_metadata im where im.item_id = i.id and im.key in ('project','workspace','workspace_dir','cwd') and (im.value = ? or im.value like ?))`)
 		params = append(params, opts.Project, "%"+opts.Project+"%")
+	}
+	if opts.Origin != "" {
+		where = append(where, `exists(select 1 from item_metadata im where im.item_id = i.id and im.key = ? and im.value = ?)`)
+		params = append(params, ingest.MetaKeyProvenanceOrigin, opts.Origin)
+	}
+	if opts.Modality != "" {
+		where = append(where, `exists(select 1 from item_metadata im where im.item_id = i.id and im.key = ? and im.value = ?)`)
+		params = append(params, ingest.MetaKeyProvenanceModality, opts.Modality)
+	}
+	if opts.TrustLabel != "" {
+		where = append(where, `exists(select 1 from item_metadata im where im.item_id = i.id and im.key = ? and im.value = ?)`)
+		params = append(params, ingest.MetaKeyProvenanceTrustLabel, opts.TrustLabel)
 	}
 	if opts.Tags != "" {
 		for _, tag := range strings.Split(opts.Tags, ",") {
@@ -2430,9 +2501,11 @@ where i.id = ?`, id)
 	relations := queryMaps(db, `select id, target_item_id, target_external_id, relation_type, confidence from relations where source_item_id = ? order by id`, id)
 	var raw any
 	_ = json.Unmarshal([]byte(rawJSON), &raw)
-	var metadata any
-	_ = json.Unmarshal([]byte(metadataJSON), &metadata)
-	return map[string]any{
+	var metadata map[string]any
+	if err := json.Unmarshal([]byte(metadataJSON), &metadata); err != nil || metadata == nil {
+		metadata = map[string]any{}
+	}
+	out := map[string]any{
 		"id":           itemID,
 		"external_id":  externalID,
 		"kind":         kind,
@@ -2448,7 +2521,14 @@ where i.id = ?`, id)
 		"relations":    relations,
 		"raw_ref":      map[string]any{"hash": rawHash, "path": rawPath, "ordinal": rawOrdinal},
 		"raw":          raw,
-	}, nil
+	}
+	if _, has := metadata["provenance"]; !has {
+		env, banner := provenance.SynthesizeLegacyProvenance()
+		metadata["provenance"] = env
+		out["metadata"] = metadata
+		out["provenance_display"] = banner
+	}
+	return out, nil
 }
 
 func queryMaps(db *sql.DB, sqlText string, args ...any) []map[string]any {

--- a/engines/evidence-ledger/internal/app/app.go
+++ b/engines/evidence-ledger/internal/app/app.go
@@ -353,19 +353,21 @@ func cmdDoctorProvenanceBackfill(args []string, out, errw io.Writer) int {
 		return fatalf(errw, "doctor provenance backfill: %s", err)
 	}
 	payload := map[string]any{
-		"ok":        true,
-		"scanned":   result.Scanned,
-		"updated":   result.Updated,
-		"skipped":   result.Skipped,
-		"events":    result.Events,
-		"cursor":    result.Cursor,
-		"remaining": result.Remaining,
+		"ok":         true,
+		"scanned":    result.Scanned,
+		"updated":    result.Updated,
+		"skipped":    result.Skipped,
+		"malformed":  result.Malformed,
+		"events":     result.Events,
+		"cursor":     result.Cursor,
+		"remaining":  result.Remaining,
+		"evidence":   result.Evidence,
 	}
 	if bools["json"] {
 		writeJSON(out, payload)
 	} else {
-		fmt.Fprintf(out, "scanned=%d updated=%d skipped=%d events=%d cursor=%s remaining=%d\n",
-			result.Scanned, result.Updated, result.Skipped, result.Events, result.Cursor, result.Remaining)
+		fmt.Fprintf(out, "scanned=%d updated=%d skipped=%d malformed=%d events=%d cursor=%s remaining=%d\n",
+			result.Scanned, result.Updated, result.Skipped, result.Malformed, result.Events, result.Cursor, result.Remaining)
 	}
 	return 0
 }
@@ -2522,13 +2524,22 @@ where i.id = ?`, id)
 		"raw_ref":      map[string]any{"hash": rawHash, "path": rawPath, "ordinal": rawOrdinal},
 		"raw":          raw,
 	}
-	if _, has := metadata["provenance"]; !has {
+	attachShowProvenance(out, metadata)
+	return out, nil
+}
+
+func attachShowProvenance(out map[string]any, metadata map[string]any) {
+	rawEnv, has := metadata["provenance"]
+	if !has || rawEnv == nil {
 		env, banner := provenance.SynthesizeLegacyProvenance()
 		metadata["provenance"] = env
 		out["metadata"] = metadata
 		out["provenance_display"] = banner
+		return
 	}
-	return out, nil
+	if _, err := ingest.ParseRetainableEnvelope(rawEnv); err != nil {
+		out["provenance_warning"] = "malformed provenance: " + err.Error()
+	}
 }
 
 func queryMaps(db *sql.DB, sqlText string, args ...any) []map[string]any {

--- a/engines/evidence-ledger/internal/app/app_test.go
+++ b/engines/evidence-ledger/internal/app/app_test.go
@@ -281,6 +281,42 @@ values('legacy-item','legacy-src','legacy-col','legacy:item','message',?,?,?,'',
 	}
 }
 
+func TestShowWarnsOnPresentMalformedProvenance(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+	paths := ResolvePaths()
+	db, err := archive.Open(paths.DBPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	now := "2026-06-03T00:00:00Z"
+	if _, err := db.Exec(`insert into sources(id, kind, name, version, created_at, updated_at) values('legacy-src','legacy','Legacy','1',?,?)`, now, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`insert into collections(id, source_id, external_id, kind, name, metadata_json, created_at, updated_at) values('legacy-col','legacy-src','legacy:col','agent_session','legacy','{}',?,?)`, now, now); err != nil {
+		t.Fatal(err)
+	}
+	bad := `{"provenance":{"schema":"brigade.provenance-envelope.v1","schema_version":1,"origin":"not-a-real-origin","modality":"tool-output","attribution":"observed","trust":{"label":"quarantined","assigned_by":"x","trust_policy":{"schema":"brigade.trust-policy.v1","schema_version":1},"injection":{"status":"pending","count":0,"rules":[]}},"hashes":{"content_algorithm":"sha256","content_scope":"item.text.utf8.v1","content":null},"source":{"system":"miseledger","kind":"legacy","producer":"x"},"repository":{"id":"unknown"},"session":{},"collection_id":"c","item_id":"i","locator":{"kind":"uri","value":"miseledger://legacy/c/i"}}}`
+	if _, err := db.Exec(`insert into items(id, source_id, collection_id, external_id, kind, created_at, updated_at, text, summary, content_hash, raw_json, raw_hash, raw_path, raw_ordinal, metadata_json)
+values('malformed-item','legacy-src','legacy-col','legacy:malformed','message',?,?,'body','','sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa','{}','sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb','legacy.jsonl',1,?)`, now, now, bad); err != nil {
+		t.Fatal(err)
+	}
+	show := runJSON(t, "show", "malformed-item", "--json")
+	warning, _ := show["provenance_warning"].(string)
+	if warning == "" || !strings.Contains(warning, "malformed provenance") {
+		t.Fatalf("expected provenance_warning, got %#v", show["provenance_warning"])
+	}
+	if _, ok := show["provenance_display"]; ok {
+		t.Fatalf("malformed present provenance must not synthesize legacy display: %#v", show["provenance_display"])
+	}
+	meta := show["metadata"].(map[string]any)
+	env := meta["provenance"].(map[string]any)
+	if env["origin"] != "not-a-real-origin" {
+		t.Fatalf("show rewrote malformed provenance: %#v", env)
+	}
+}
+
 func TestImportWarningsForInvalidRecords(t *testing.T) {
 	withTempHome(t)
 	runOK(t, "init")

--- a/engines/evidence-ledger/internal/app/app_test.go
+++ b/engines/evidence-ledger/internal/app/app_test.go
@@ -19,6 +19,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/escoffier-labs/miseledger/internal/archive"
 )
 
 func TestInitCreatesPrivateDirsAndDoctorJSON(t *testing.T) {
@@ -214,6 +216,68 @@ func TestAdapterImportSearchShowExportAndIdempotency(t *testing.T) {
 	status = runJSON(t, "status", "--json")
 	if status["items"].(float64) != 4 {
 		t.Fatalf("items after reimport = %v, want 4", status["items"])
+	}
+}
+
+func TestProvenanceSearchSQLFiltersAndLegacyShowSynthesis(t *testing.T) {
+	withTempHome(t)
+	runOK(t, "init")
+	fixture := repoPath(t, "testdata/adapters/discrawl.fixture.jsonl")
+	runOK(t, "import", "adapter", fixture, "--source", "discrawl")
+
+	filtered := runJSON(t, "search", "adapter", "--origin", "external-service", "--modality", "tool-output", "--trust-label", "quarantined", "--json")
+	if len(filtered["results"].([]any)) == 0 {
+		t.Fatalf("search with provenance filters returned no hits: %v", filtered)
+	}
+	miss := runJSON(t, "search", "adapter", "--origin", "workspace", "--json")
+	if len(miss["results"].([]any)) != 0 {
+		t.Fatalf("search with wrong origin should be empty: %v", miss)
+	}
+
+	sqlOut := runJSON(t, "sql", `select count(*) as n from item_metadata where key = 'provenance.trust_label' and value = 'quarantined'`, "--json")
+	if sqlOut["rows"].([]any)[0].(map[string]any)["n"].(float64) == 0 {
+		t.Fatalf("sql provenance projection missing: %v", sqlOut)
+	}
+
+	// Seed a legacy row with no provenance for on-read synthesis.
+	paths := ResolvePaths()
+	db, err := archive.Open(paths.DBPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	now := "2026-06-03T00:00:00Z"
+	if _, err := db.Exec(`insert into sources(id, kind, name, version, created_at, updated_at) values('legacy-src','legacy','Legacy','1',?,?)`, now, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`insert into collections(id, source_id, external_id, kind, name, metadata_json, created_at, updated_at) values('legacy-col','legacy-src','legacy:col','agent_session','legacy','{}',?,?)`, now, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`insert into items(id, source_id, collection_id, external_id, kind, created_at, updated_at, text, summary, content_hash, raw_json, raw_hash, raw_path, raw_ordinal, metadata_json)
+values('legacy-item','legacy-src','legacy-col','legacy:item','message',?,?,?,'','sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa','{}','sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb','legacy.jsonl',1,'{}')`, now, now, "legacy body"); err != nil {
+		t.Fatal(err)
+	}
+	show := runJSON(t, "show", "legacy-item", "--json")
+	if show["provenance_display"] != "UNKNOWN PROVENANCE - legacy item" {
+		t.Fatalf("provenance_display = %v", show["provenance_display"])
+	}
+	meta := show["metadata"].(map[string]any)
+	env := meta["provenance"].(map[string]any)
+	if env["origin"] != "unknown" || env["modality"] != "unknown" {
+		t.Fatalf("synthesized envelope = %#v", env)
+	}
+	trust := env["trust"].(map[string]any)
+	if trust["label"] != "unknown" {
+		t.Fatalf("synthesized trust = %#v, want unknown (never implicit trust)", trust)
+	}
+
+	first := runJSON(t, "doctor", "provenance", "backfill", "--batch", "10", "--json")
+	if first["updated"].(float64) < 1 {
+		t.Fatalf("backfill updated = %v, want at least legacy row", first["updated"])
+	}
+	second := runJSON(t, "doctor", "provenance", "backfill", "--batch", "10", "--json")
+	if second["updated"].(float64) != 0 {
+		t.Fatalf("idempotent backfill updated = %v, want 0", second["updated"])
 	}
 }
 

--- a/engines/evidence-ledger/internal/archive/db.go
+++ b/engines/evidence-ledger/internal/archive/db.go
@@ -10,7 +10,7 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-const SchemaVersion = 3
+const SchemaVersion = 4
 
 func Open(path string) (*sql.DB, error) {
 	if err := security.EnsurePrivateParent(path); err != nil {
@@ -85,6 +85,9 @@ func Migrate(db *sql.DB) error {
 		return err
 	}
 	if err := ensureSchemaV3(db); err != nil {
+		return err
+	}
+	if err := ensureSchemaV4(db); err != nil {
 		return err
 	}
 	if _, err := db.Exec("PRAGMA user_version = " + fmt.Sprint(SchemaVersion)); err != nil {
@@ -182,6 +185,27 @@ with ranked as (
 )
 update items
 set ingest_seq = (select seq from ranked where ranked.id = items.id)
+`)
+	return err
+}
+
+// ensureSchemaV4 adds append-only provenance_events for trust transitions.
+// Safe to re-run. Kept after #850 ingest_seq (v3).
+func ensureSchemaV4(db *sql.DB) error {
+	_, err := db.Exec(`
+create table if not exists provenance_events(
+  id text primary key,
+  item_id text not null references items(id) on delete cascade,
+  at text not null,
+  from_label text,
+  to_label text not null,
+  envelope_content_hash text,
+  content_scope text,
+  operator_command text,
+  evidence_json text not null default '{}',
+  event_json text not null
+);
+create index if not exists idx_provenance_events_item_at on provenance_events(item_id, at);
 `)
 	return err
 }

--- a/engines/evidence-ledger/internal/archive/db_test.go
+++ b/engines/evidence-ledger/internal/archive/db_test.go
@@ -158,7 +158,72 @@ func TestMigrateCreatesProvenanceEventsOnExistingArchive(t *testing.T) {
 	}
 	var name string
 	if err := reopened.QueryRow(`select name from sqlite_master where type = 'table' and name = 'provenance_events'`).Scan(&name); err != nil {
-		t.Fatalf("provenance_events missing after v3 migrate: %v", err)
+		t.Fatalf("provenance_events missing after v4 migrate: %v", err)
+	}
+	var ingestSeqCol int
+	if err := reopened.QueryRow(`select count(*) from pragma_table_info('items') where name = 'ingest_seq'`).Scan(&ingestSeqCol); err != nil || ingestSeqCol != 1 {
+		t.Fatalf("ingest_seq column missing after migrate through v3: %v count=%d", err, ingestSeqCol)
+	}
+}
+
+func TestMigrateV3ToV4AddsProvenanceEventsPreservingIngestSeq(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "v3.db")
+	db, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(schemaSQL); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureSchemaV2(db); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureSchemaV3(db); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec("PRAGMA user_version = 3"); err != nil {
+		t.Fatal(err)
+	}
+	now := "2026-06-03T00:00:00Z"
+	if _, err := db.Exec(`insert into sources(id, kind, name, version, created_at, updated_at) values('src1','legacy','Legacy','1',?,?)`, now, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`insert into collections(id, source_id, external_id, kind, name, metadata_json, created_at, updated_at) values('col1','src1','legacy:col','agent_session','legacy','{}',?,?)`, now, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`insert into items(id, source_id, collection_id, external_id, kind, created_at, updated_at, text, content_hash, raw_json, metadata_json, ingest_seq)
+values('item-v3','src1','col1','legacy:item','message',?,?,?,'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa','{}','{}',7)`, now, now, "v3 body"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = reopened.Close() })
+	if err := Migrate(reopened); err != nil {
+		t.Fatalf("migrate v3->v4: %v", err)
+	}
+	version, err := UserVersion(reopened)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version != 4 {
+		t.Fatalf("user_version=%d want 4", version)
+	}
+	var name string
+	if err := reopened.QueryRow(`select name from sqlite_master where type='table' and name='provenance_events'`).Scan(&name); err != nil {
+		t.Fatalf("provenance_events missing after v3->v4: %v", err)
+	}
+	var seq int64
+	if err := reopened.QueryRow(`select ingest_seq from items where id='item-v3'`).Scan(&seq); err != nil {
+		t.Fatal(err)
+	}
+	if seq != 7 {
+		t.Fatalf("ingest_seq reshuffled across v4 migrate: got %d want 7", seq)
 	}
 }
 

--- a/engines/evidence-ledger/internal/archive/db_test.go
+++ b/engines/evidence-ledger/internal/archive/db_test.go
@@ -111,7 +111,7 @@ func TestMigrateAddsCollectionItemsIndexToExistingArchive(t *testing.T) {
 
 func TestCoreTablesExist(t *testing.T) {
 	db := openMigrated(t)
-	for _, table := range []string{"sources", "collections", "actors", "items", "events", "artifacts", "relations", "imports", "item_fts"} {
+	for _, table := range []string{"sources", "collections", "actors", "items", "events", "artifacts", "relations", "imports", "item_fts", "provenance_events"} {
 		var name string
 		err := db.QueryRow(
 			"select name from sqlite_master where type in ('table','view') and name = ?",
@@ -120,6 +120,45 @@ func TestCoreTablesExist(t *testing.T) {
 		if err != nil {
 			t.Fatalf("table %q not found after migrate: %v", table, err)
 		}
+	}
+}
+
+func TestMigrateCreatesProvenanceEventsOnExistingArchive(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "miseledger.db")
+	db, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if _, err := db.Exec(schemaSQL); err != nil {
+		t.Fatalf("baseline schema: %v", err)
+	}
+	if err := ensureSchemaV2(db); err != nil {
+		t.Fatalf("ensureSchemaV2: %v", err)
+	}
+	if _, err := db.Exec("PRAGMA user_version = 2"); err != nil {
+		t.Fatalf("set v2: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	reopened, err := Open(path)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	t.Cleanup(func() { _ = reopened.Close() })
+	if err := Migrate(reopened); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	version, err := UserVersion(reopened)
+	if err != nil {
+		t.Fatalf("UserVersion: %v", err)
+	}
+	if version != SchemaVersion {
+		t.Fatalf("user_version = %d, want %d", version, SchemaVersion)
+	}
+	var name string
+	if err := reopened.QueryRow(`select name from sqlite_master where type = 'table' and name = 'provenance_events'`).Scan(&name); err != nil {
+		t.Fatalf("provenance_events missing after v3 migrate: %v", err)
 	}
 }
 

--- a/engines/evidence-ledger/internal/ingest/importer.go
+++ b/engines/evidence-ledger/internal/ingest/importer.go
@@ -702,6 +702,23 @@ func replaceItemSideTables(tx *sql.Tx, rec adapter.Record, itemID, sourceID, col
 	if err := indexItemMetadata(tx, itemID, rec.Item.Tags, itemMeta); err != nil {
 		return err
 	}
+	if err := indexProvenanceProjections(tx, itemID, envelope); err != nil {
+		return err
+	}
+	// Fresh inserts append one initial trust event. Known-item reconcile
+	// (replaceExisting) must not mint duplicate provenance events.
+	if !replaceExisting {
+		contentDigest := ""
+		if envelope.Hashes.Content != nil {
+			contentDigest = *envelope.Hashes.Content
+		}
+		if err := AppendProvenanceEvent(tx, itemID, "", envelope.Trust.Label, contentDigest, envelope.Hashes.ContentScope, envelope.Trust.AssignedBy, map[string]any{
+			"source_kind": rec.Source.Kind,
+			"path":        "ingest.upsertRecord",
+		}); err != nil {
+			return err
+		}
+	}
 	ftsBody := body
 	for _, art := range rec.Artifacts {
 		artifactID := stableID("artifact", itemID, art.ExternalID, art.Kind, art.Path, art.URL, art.Hash)

--- a/engines/evidence-ledger/internal/ingest/importer.go
+++ b/engines/evidence-ledger/internal/ingest/importer.go
@@ -712,7 +712,7 @@ func replaceItemSideTables(tx *sql.Tx, rec adapter.Record, itemID, sourceID, col
 		if envelope.Hashes.Content != nil {
 			contentDigest = *envelope.Hashes.Content
 		}
-		if err := AppendProvenanceEvent(tx, itemID, "", envelope.Trust.Label, contentDigest, envelope.Hashes.ContentScope, envelope.Trust.AssignedBy, map[string]any{
+		if err := AppendIdempotentProvenanceEvent(tx, itemID, "", envelope.Trust.Label, contentDigest, envelope.Hashes.ContentScope, envelope.Trust.AssignedBy, map[string]any{
 			"source_kind": rec.Source.Kind,
 			"path":        "ingest.upsertRecord",
 		}); err != nil {

--- a/engines/evidence-ledger/internal/ingest/provenance.go
+++ b/engines/evidence-ledger/internal/ingest/provenance.go
@@ -106,10 +106,21 @@ func replaceProvenanceProjections(tx *sql.Tx, itemID string, env provenance.Enve
 	return indexProvenanceProjections(tx, itemID, env)
 }
 
-// AppendProvenanceEvent inserts one immutable provenance_events row.
-// Event IDs are stable across wall-clock time so concurrent inferred backfills
-// that race on the same transition collapse via INSERT OR IGNORE.
+// AppendProvenanceEvent inserts one immutable provenance_events row for a real
+// trust transition. The event id includes the occurrence timestamp so cycles
+// such as quarantined -> untrusted -> quarantined -> untrusted each append.
 func AppendProvenanceEvent(tx *sql.Tx, itemID string, fromLabel, toLabel, contentHash, contentScope, operatorCommand string, evidence map[string]any) error {
+	return appendProvenanceEvent(tx, itemID, fromLabel, toLabel, contentHash, contentScope, operatorCommand, evidence, false)
+}
+
+// AppendIdempotentProvenanceEvent inserts a repair/backfill provenance event
+// with a deterministic id (no wall-clock component) so concurrent identical
+// repairs collapse via INSERT OR IGNORE.
+func AppendIdempotentProvenanceEvent(tx *sql.Tx, itemID string, fromLabel, toLabel, contentHash, contentScope, operatorCommand string, evidence map[string]any) error {
+	return appendProvenanceEvent(tx, itemID, fromLabel, toLabel, contentHash, contentScope, operatorCommand, evidence, true)
+}
+
+func appendProvenanceEvent(tx *sql.Tx, itemID string, fromLabel, toLabel, contentHash, contentScope, operatorCommand string, evidence map[string]any, idempotent bool) error {
 	if evidence == nil {
 		evidence = map[string]any{}
 	}
@@ -134,9 +145,25 @@ func AppendProvenanceEvent(tx *sql.Tx, itemID string, fromLabel, toLabel, conten
 	if err != nil {
 		return err
 	}
-	eventID := stableID("provenance-event", itemID, fromLabel, toLabel, contentHash, contentScope, operatorCommand)
-	_, err = tx.Exec(`insert or ignore into provenance_events(id, item_id, at, from_label, to_label, envelope_content_hash, content_scope, operator_command, evidence_json, event_json)
-values(?,?,?,?,?,?,?,?,?,?)`,
+	var eventID string
+	if idempotent {
+		eventID = stableID("provenance-event", itemID, fromLabel, toLabel, contentHash, contentScope, operatorCommand)
+	} else {
+		var prior int64
+		if err := tx.QueryRow(`select count(*) from provenance_events where item_id = ?`, itemID).Scan(&prior); err != nil {
+			return err
+		}
+		// Occurrence identity: wall-clock at plus per-item sequence so cycles
+		// with identical labels/content/operator each append a distinct row.
+		eventID = stableID("provenance-event", itemID, at, fromLabel, toLabel, contentHash, contentScope, operatorCommand, fmt.Sprintf("%d", prior+1))
+	}
+	stmt := `insert into provenance_events(id, item_id, at, from_label, to_label, envelope_content_hash, content_scope, operator_command, evidence_json, event_json)
+values(?,?,?,?,?,?,?,?,?,?)`
+	if idempotent {
+		stmt = `insert or ignore into provenance_events(id, item_id, at, from_label, to_label, envelope_content_hash, content_scope, operator_command, evidence_json, event_json)
+values(?,?,?,?,?,?,?,?,?,?)`
+	}
+	_, err = tx.Exec(stmt,
 		eventID, itemID, at, nullIfEmpty(fromLabel), toLabel, nullIfEmpty(contentHash), nullIfEmpty(contentScope), nullIfEmpty(operatorCommand), string(evidenceRaw), string(raw))
 	return err
 }
@@ -363,7 +390,7 @@ func backfillOneItem(tx *sql.Tx, itemID, text, metadataJSON, rawHash, rawPath, s
 	if env.Hashes.Content != nil {
 		contentHash = *env.Hashes.Content
 	}
-	if err := AppendProvenanceEvent(tx, itemID, "", "unknown", contentHash, env.Hashes.ContentScope, "ingest:ingest.BackfillProvenance", map[string]any{
+	if err := AppendIdempotentProvenanceEvent(tx, itemID, "", "unknown", contentHash, env.Hashes.ContentScope, "ingest:ingest.BackfillProvenance", map[string]any{
 		"attribution": "inferred",
 		"raw_path":    rawPath,
 	}); err != nil {

--- a/engines/evidence-ledger/internal/ingest/provenance.go
+++ b/engines/evidence-ledger/internal/ingest/provenance.go
@@ -1,0 +1,389 @@
+package ingest
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/escoffier-labs/miseledger/internal/provenance"
+)
+
+// Indexed provenance projections in item_metadata. Search and SQL filter these
+// keys without parsing nested metadata_json.provenance.
+const (
+	MetaKeyProvenanceOrigin        = "provenance.origin"
+	MetaKeyProvenanceModality      = "provenance.modality"
+	MetaKeyProvenanceTrustLabel    = "provenance.trust_label"
+	MetaKeyProvenanceContentScope  = "provenance.content_scope"
+	MetaKeyProvenanceContentDigest = "provenance.content_digest"
+)
+
+// ProvenanceEventSchema is the append-only trust-transition event schema.
+const ProvenanceEventSchema = "brigade.provenance-event.v1"
+
+// ProvenanceEvent is an immutable trust transition row.
+type ProvenanceEvent struct {
+	Schema               string         `json:"schema"`
+	SchemaVersion        int            `json:"schema_version"`
+	At                   string         `json:"at"`
+	ItemRef              string         `json:"item_ref"`
+	FromLabel            string         `json:"from_label"`
+	ToLabel              string         `json:"to_label"`
+	EnvelopeContentHash  string         `json:"envelope_content_hash"`
+	ContentScope         string         `json:"content_scope"`
+	OperatorCommand      string         `json:"operator_command"`
+	Evidence             map[string]any `json:"evidence"`
+}
+
+// BackfillProvenanceResult reports one resumable backfill batch.
+type BackfillProvenanceResult struct {
+	Scanned   int    `json:"scanned"`
+	Updated   int    `json:"updated"`
+	Skipped   int    `json:"skipped"`
+	Events    int    `json:"events"`
+	Cursor    string `json:"cursor"`
+	Remaining int    `json:"remaining"`
+}
+
+func indexProvenanceProjections(tx *sql.Tx, itemID string, env provenance.Envelope) error {
+	pairs := []struct {
+		key   string
+		value string
+	}{
+		{MetaKeyProvenanceOrigin, env.Origin},
+		{MetaKeyProvenanceModality, env.Modality},
+		{MetaKeyProvenanceTrustLabel, env.Trust.Label},
+		{MetaKeyProvenanceContentScope, env.Hashes.ContentScope},
+	}
+	if env.Hashes.Content != nil {
+		pairs = append(pairs, struct {
+			key   string
+			value string
+		}{MetaKeyProvenanceContentDigest, *env.Hashes.Content})
+	}
+	for _, pair := range pairs {
+		if pair.value == "" {
+			continue
+		}
+		if _, err := tx.Exec(`insert or ignore into item_metadata(item_id, key, value) values(?,?,?)`, itemID, pair.key, pair.value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func replaceProvenanceProjections(tx *sql.Tx, itemID string, env provenance.Envelope) error {
+	if _, err := tx.Exec(`delete from item_metadata where item_id = ? and key in (?,?,?,?,?)`,
+		itemID,
+		MetaKeyProvenanceOrigin,
+		MetaKeyProvenanceModality,
+		MetaKeyProvenanceTrustLabel,
+		MetaKeyProvenanceContentScope,
+		MetaKeyProvenanceContentDigest,
+	); err != nil {
+		return err
+	}
+	return indexProvenanceProjections(tx, itemID, env)
+}
+
+// AppendProvenanceEvent inserts one immutable provenance_events row.
+func AppendProvenanceEvent(tx *sql.Tx, itemID string, fromLabel, toLabel, contentHash, contentScope, operatorCommand string, evidence map[string]any) error {
+	if evidence == nil {
+		evidence = map[string]any{}
+	}
+	at := time.Now().UTC().Format(time.RFC3339Nano)
+	event := ProvenanceEvent{
+		Schema:              ProvenanceEventSchema,
+		SchemaVersion:       1,
+		At:                  at,
+		ItemRef:             "miseledger:item:" + itemID,
+		FromLabel:           fromLabel,
+		ToLabel:             toLabel,
+		EnvelopeContentHash: contentHash,
+		ContentScope:        contentScope,
+		OperatorCommand:     operatorCommand,
+		Evidence:            evidence,
+	}
+	raw, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+	evidenceRaw, err := json.Marshal(evidence)
+	if err != nil {
+		return err
+	}
+	eventID := stableID("provenance-event", itemID, at, fromLabel, toLabel, contentHash, operatorCommand)
+	_, err = tx.Exec(`insert into provenance_events(id, item_id, at, from_label, to_label, envelope_content_hash, content_scope, operator_command, evidence_json, event_json)
+values(?,?,?,?,?,?,?,?,?,?)`,
+		eventID, itemID, at, nullIfEmpty(fromLabel), toLabel, nullIfEmpty(contentHash), nullIfEmpty(contentScope), nullIfEmpty(operatorCommand), string(evidenceRaw), string(raw))
+	return err
+}
+
+// TransitionTrustLabel updates an item's embedded envelope trust label, refreshes
+// indexed projections, and appends an immutable provenance_events row. Events
+// are never deleted or rewritten.
+func TransitionTrustLabel(db *sql.DB, itemID, toLabel, operatorCommand string, evidence map[string]any) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	var metadataJSON, text string
+	if err := tx.QueryRow(`select metadata_json, coalesce(text,'') from items where id = ?`, itemID).Scan(&metadataJSON, &text); err != nil {
+		return err
+	}
+	meta := map[string]any{}
+	if err := json.Unmarshal([]byte(metadataJSON), &meta); err != nil {
+		return err
+	}
+	rawEnv, ok := meta["provenance"]
+	if !ok {
+		return fmt.Errorf("item %s has no provenance envelope", itemID)
+	}
+	envBytes, err := json.Marshal(rawEnv)
+	if err != nil {
+		return err
+	}
+	var env provenance.Envelope
+	if err := json.Unmarshal(envBytes, &env); err != nil {
+		return err
+	}
+	fromLabel := env.Trust.Label
+	if fromLabel == toLabel {
+		return nil
+	}
+	at := time.Now().UTC().Format(time.RFC3339Nano)
+	env.Trust.Label = toLabel
+	env.Trust.AssignedBy = operatorCommand
+	env.Trust.AssignedAt = &at
+	if err := provenance.Validate(env, provenance.ValidationContext{}); err != nil {
+		return err
+	}
+	contentHash := ""
+	if env.Hashes.Content != nil {
+		contentHash = *env.Hashes.Content
+	} else {
+		contentHash = provenance.ContentSHA256(text)
+	}
+	meta["provenance"] = env
+	updated, err := json.Marshal(meta)
+	if err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`update items set metadata_json = ? where id = ?`, string(updated), itemID); err != nil {
+		return err
+	}
+	if err := replaceProvenanceProjections(tx, itemID, env); err != nil {
+		return err
+	}
+	if err := AppendProvenanceEvent(tx, itemID, fromLabel, toLabel, contentHash, env.Hashes.ContentScope, operatorCommand, evidence); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// BackfillProvenance walks items after afterID in batches, writing inferred
+// envelopes for rows missing provenance and ensuring indexed projections exist.
+// Inferred rows always use trust.label=unknown. Idempotent when the stored
+// envelope content digest already matches the item text.
+func BackfillProvenance(db *sql.DB, batchSize int, afterID string) (BackfillProvenanceResult, error) {
+	if batchSize <= 0 {
+		batchSize = 100
+	}
+	result := BackfillProvenanceResult{Cursor: afterID}
+	rows, err := db.Query(`select id, coalesce(text,''), metadata_json, coalesce(raw_hash,''), coalesce(raw_path,''), source_id, collection_id, external_id
+from items
+where id > ?
+order by id
+limit ?`, afterID, batchSize)
+	if err != nil {
+		return result, err
+	}
+	defer rows.Close()
+
+	type itemRow struct {
+		id, text, metadataJSON, rawHash, rawPath, sourceID, collectionID, externalID string
+	}
+	var batch []itemRow
+	for rows.Next() {
+		var row itemRow
+		if err := rows.Scan(&row.id, &row.text, &row.metadataJSON, &row.rawHash, &row.rawPath, &row.sourceID, &row.collectionID, &row.externalID); err != nil {
+			return result, err
+		}
+		batch = append(batch, row)
+	}
+	if err := rows.Err(); err != nil {
+		return result, err
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		return result, err
+	}
+	defer tx.Rollback()
+
+	for _, row := range batch {
+		result.Scanned++
+		result.Cursor = row.id
+		changed, events, err := backfillOneItem(tx, row.id, row.text, row.metadataJSON, row.rawHash, row.rawPath, row.sourceID, row.collectionID, row.externalID)
+		if err != nil {
+			return result, err
+		}
+		if changed {
+			result.Updated++
+		} else {
+			result.Skipped++
+		}
+		result.Events += events
+	}
+	if err := tx.Commit(); err != nil {
+		return result, err
+	}
+	if err := db.QueryRow(`select count(*) from items where id > ?`, result.Cursor).Scan(&result.Remaining); err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+func backfillOneItem(tx *sql.Tx, itemID, text, metadataJSON, rawHash, rawPath, sourceID, collectionID, externalID string) (changed bool, events int, err error) {
+	meta := map[string]any{}
+	if strings.TrimSpace(metadataJSON) != "" {
+		if err := json.Unmarshal([]byte(metadataJSON), &meta); err != nil {
+			meta = map[string]any{}
+		}
+	}
+	exactDigest := provenance.ContentSHA256(text)
+	if rawEnv, ok := meta["provenance"]; ok && rawEnv != nil {
+		envBytes, marshalErr := json.Marshal(rawEnv)
+		if marshalErr != nil {
+			return false, 0, marshalErr
+		}
+		var env provenance.Envelope
+		if unmarshalErr := json.Unmarshal(envBytes, &env); unmarshalErr != nil {
+			return false, 0, unmarshalErr
+		}
+		if env.Hashes.Content != nil && *env.Hashes.Content == exactDigest {
+			if projectionsComplete(tx, itemID, env) {
+				return false, 0, nil
+			}
+			if err := replaceProvenanceProjections(tx, itemID, env); err != nil {
+				return false, 0, err
+			}
+			return true, 0, nil
+		}
+	}
+
+	var sourceKind, collectionExternalID string
+	_ = tx.QueryRow(`select kind from sources where id = ?`, sourceID).Scan(&sourceKind)
+	_ = tx.QueryRow(`select external_id from collections where id = ?`, collectionID).Scan(&collectionExternalID)
+	if sourceKind == "" {
+		sourceKind = "unknown"
+	}
+	if collectionExternalID == "" {
+		collectionExternalID = collectionID
+	}
+	if collectionExternalID == "" {
+		collectionExternalID = "unknown"
+	}
+	if externalID == "" {
+		externalID = itemID
+	}
+	locator := fmt.Sprintf("miseledger://%s/%s/%s", sourceKind, collectionExternalID, externalID)
+	at := time.Now().UTC().Format(time.RFC3339Nano)
+	origin, modality := inferOriginModality(sourceKind)
+	in := provenance.EvidenceInput{
+		SourceSystem:    "miseledger",
+		SourceKind:      sourceKind,
+		SourceProducer:  "ingest.BackfillProvenance",
+		Origin:          origin,
+		RepositoryID:    "unknown",
+		CollectionID:    collectionExternalID,
+		ItemID:          externalID,
+		LocatorKind:     "uri",
+		LocatorValue:    locator,
+		Attribution:     "inferred",
+		Modality:        modality,
+		TrustLabel:      "unknown",
+		TrustAssignedBy: "ingest:ingest.BackfillProvenance",
+		TrustAssignedAt: &at,
+		InjectionStatus: "pending",
+		InjectionRules:  []string{},
+		Text:            text,
+		IngestedAt:      &at,
+		CapturedAt:      &at,
+	}
+	env, err := provenance.NewEvidenceEnvelope(in)
+	if err != nil {
+		return false, 0, err
+	}
+	// Prefer legacy raw_hash digest when already a prefixed sha256; do not invent
+	// raw bytes. Keep hashes.raw null unless we have a digest string.
+	if strings.HasPrefix(rawHash, "sha256:") && len(strings.TrimPrefix(rawHash, "sha256:")) == 64 {
+		digest := strings.TrimPrefix(rawHash, "sha256:")
+		algo, scope := provenance.HashAlgorithm, provenance.RawScope
+		env.Hashes.RawAlgorithm = &algo
+		env.Hashes.RawScope = &scope
+		env.Hashes.Raw = &digest
+		if err := provenance.Validate(env, provenance.ValidationContext{}); err != nil {
+			return false, 0, err
+		}
+	}
+	meta["provenance"] = env
+	updated, err := json.Marshal(meta)
+	if err != nil {
+		return false, 0, err
+	}
+	if _, err := tx.Exec(`update items set metadata_json = ? where id = ?`, string(updated), itemID); err != nil {
+		return false, 0, err
+	}
+	if err := replaceProvenanceProjections(tx, itemID, env); err != nil {
+		return false, 0, err
+	}
+	contentHash := ""
+	if env.Hashes.Content != nil {
+		contentHash = *env.Hashes.Content
+	}
+	if err := AppendProvenanceEvent(tx, itemID, "", "unknown", contentHash, env.Hashes.ContentScope, "ingest:ingest.BackfillProvenance", map[string]any{
+		"attribution": "inferred",
+		"raw_path":    rawPath,
+	}); err != nil {
+		return false, 0, err
+	}
+	return true, 1, nil
+}
+
+func projectionsComplete(tx *sql.Tx, itemID string, env provenance.Envelope) bool {
+	want := map[string]string{
+		MetaKeyProvenanceOrigin:       env.Origin,
+		MetaKeyProvenanceModality:     env.Modality,
+		MetaKeyProvenanceTrustLabel:   env.Trust.Label,
+		MetaKeyProvenanceContentScope: env.Hashes.ContentScope,
+	}
+	if env.Hashes.Content != nil {
+		want[MetaKeyProvenanceContentDigest] = *env.Hashes.Content
+	}
+	for key, value := range want {
+		if value == "" {
+			continue
+		}
+		var found int
+		if err := tx.QueryRow(`select 1 from item_metadata where item_id = ? and key = ? and value = ?`, itemID, key, value).Scan(&found); err != nil {
+			return false
+		}
+	}
+	return true
+}
+
+func inferOriginModality(sourceKind string) (origin, modality string) {
+	switch strings.ToLower(strings.TrimSpace(sourceKind)) {
+	case "codex", "claude", "cursor", "opencode", "openclaw", "hermes", "pi", "grok", "brigade-memory":
+		return "agent-session", "tool-output"
+	case "discrawl", "gitcrawl", "slacrawl", "graincrawl", "notcrawl", "mailcrawl", "telecrawl":
+		return "external-service", "tool-output"
+	default:
+		return "unknown", "unknown"
+	}
+}

--- a/engines/evidence-ledger/internal/ingest/provenance.go
+++ b/engines/evidence-ledger/internal/ingest/provenance.go
@@ -39,13 +39,31 @@ type ProvenanceEvent struct {
 
 // BackfillProvenanceResult reports one resumable backfill batch.
 type BackfillProvenanceResult struct {
-	Scanned   int    `json:"scanned"`
-	Updated   int    `json:"updated"`
-	Skipped   int    `json:"skipped"`
-	Events    int    `json:"events"`
-	Cursor    string `json:"cursor"`
-	Remaining int    `json:"remaining"`
+	Scanned    int                       `json:"scanned"`
+	Updated    int                       `json:"updated"`
+	Skipped    int                       `json:"skipped"`
+	Malformed  int                       `json:"malformed"`
+	Events     int                       `json:"events"`
+	Cursor     string                    `json:"cursor"`
+	Remaining  int                       `json:"remaining"`
+	Evidence   []BackfillItemEvidence    `json:"evidence,omitempty"`
 }
+
+// BackfillItemEvidence is bounded per-item evidence for isolated malformed rows.
+type BackfillItemEvidence struct {
+	ItemID string `json:"item_id"`
+	Reason string `json:"reason"`
+}
+
+const maxBackfillEvidence = 32
+
+type backfillOutcome int
+
+const (
+	backfillSkipped backfillOutcome = iota
+	backfillUpdated
+	backfillMalformed
+)
 
 func indexProvenanceProjections(tx *sql.Tx, itemID string, env provenance.Envelope) error {
 	pairs := []struct {
@@ -187,8 +205,10 @@ func TransitionTrustLabel(db *sql.DB, itemID, toLabel, operatorCommand string, e
 
 // BackfillProvenance walks items after afterID in batches, writing inferred
 // envelopes for rows missing provenance and ensuring indexed projections exist.
-// Inferred rows always use trust.label=unknown. Idempotent when the stored
-// envelope content digest already matches the item text.
+// Structurally valid existing envelopes are preserved regardless of content
+// digest match; only projections are repaired. Malformed provenance is isolated
+// per row with bounded evidence so the batch stays resumable. Inferred rows
+// always use trust.label=unknown.
 func BackfillProvenance(db *sql.DB, batchSize int, afterID string) (BackfillProvenanceResult, error) {
 	if batchSize <= 0 {
 		batchSize = 100
@@ -228,13 +248,19 @@ limit ?`, afterID, batchSize)
 	for _, row := range batch {
 		result.Scanned++
 		result.Cursor = row.id
-		changed, events, err := backfillOneItem(tx, row.id, row.text, row.metadataJSON, row.rawHash, row.rawPath, row.sourceID, row.collectionID, row.externalID)
+		outcome, events, evidence, err := backfillOneItem(tx, row.id, row.text, row.metadataJSON, row.rawHash, row.rawPath, row.sourceID, row.collectionID, row.externalID)
 		if err != nil {
 			return result, err
 		}
-		if changed {
+		switch outcome {
+		case backfillUpdated:
 			result.Updated++
-		} else {
+		case backfillMalformed:
+			result.Malformed++
+			if evidence != nil && len(result.Evidence) < maxBackfillEvidence {
+				result.Evidence = append(result.Evidence, *evidence)
+			}
+		default:
 			result.Skipped++
 		}
 		result.Events += events
@@ -248,34 +274,59 @@ limit ?`, afterID, batchSize)
 	return result, nil
 }
 
-func backfillOneItem(tx *sql.Tx, itemID, text, metadataJSON, rawHash, rawPath, sourceID, collectionID, externalID string) (changed bool, events int, err error) {
+func backfillOneItem(tx *sql.Tx, itemID, text, metadataJSON, rawHash, rawPath, sourceID, collectionID, externalID string) (outcome backfillOutcome, events int, evidence *BackfillItemEvidence, err error) {
 	meta := map[string]any{}
 	if strings.TrimSpace(metadataJSON) != "" {
 		if err := json.Unmarshal([]byte(metadataJSON), &meta); err != nil {
 			meta = map[string]any{}
 		}
 	}
-	exactDigest := provenance.ContentSHA256(text)
 	if rawEnv, ok := meta["provenance"]; ok && rawEnv != nil {
-		envBytes, marshalErr := json.Marshal(rawEnv)
-		if marshalErr != nil {
-			return false, 0, marshalErr
+		env, parseErr := parseRetainableEnvelope(rawEnv)
+		if parseErr != nil {
+			return backfillMalformed, 0, &BackfillItemEvidence{
+				ItemID: itemID,
+				Reason: "malformed provenance: " + parseErr.Error(),
+			}, nil
 		}
-		var env provenance.Envelope
-		if unmarshalErr := json.Unmarshal(envBytes, &env); unmarshalErr != nil {
-			return false, 0, unmarshalErr
+		if projectionsComplete(tx, itemID, env) {
+			return backfillSkipped, 0, nil, nil
 		}
-		if env.Hashes.Content != nil && *env.Hashes.Content == exactDigest {
-			if projectionsComplete(tx, itemID, env) {
-				return false, 0, nil
-			}
-			if err := replaceProvenanceProjections(tx, itemID, env); err != nil {
-				return false, 0, err
-			}
-			return true, 0, nil
+		if err := replaceProvenanceProjections(tx, itemID, env); err != nil {
+			return backfillSkipped, 0, nil, err
 		}
+		return backfillUpdated, 0, nil, nil
 	}
 
+	env, err := buildInferredBackfillEnvelope(tx, itemID, text, rawHash, sourceID, collectionID, externalID)
+	if err != nil {
+		return backfillSkipped, 0, nil, err
+	}
+	meta["provenance"] = env
+	updated, err := json.Marshal(meta)
+	if err != nil {
+		return backfillSkipped, 0, nil, err
+	}
+	if _, err := tx.Exec(`update items set metadata_json = ? where id = ?`, string(updated), itemID); err != nil {
+		return backfillSkipped, 0, nil, err
+	}
+	if err := replaceProvenanceProjections(tx, itemID, env); err != nil {
+		return backfillSkipped, 0, nil, err
+	}
+	contentHash := ""
+	if env.Hashes.Content != nil {
+		contentHash = *env.Hashes.Content
+	}
+	if err := AppendProvenanceEvent(tx, itemID, "", "unknown", contentHash, env.Hashes.ContentScope, "ingest:ingest.BackfillProvenance", map[string]any{
+		"attribution": "inferred",
+		"raw_path":    rawPath,
+	}); err != nil {
+		return backfillSkipped, 0, nil, err
+	}
+	return backfillUpdated, 1, nil, nil
+}
+
+func buildInferredBackfillEnvelope(tx *sql.Tx, itemID, text, rawHash, sourceID, collectionID, externalID string) (provenance.Envelope, error) {
 	var sourceKind, collectionExternalID string
 	_ = tx.QueryRow(`select kind from sources where id = ?`, sourceID).Scan(&sourceKind)
 	_ = tx.QueryRow(`select external_id from collections where id = ?`, collectionID).Scan(&collectionExternalID)
@@ -317,10 +368,8 @@ func backfillOneItem(tx *sql.Tx, itemID, text, metadataJSON, rawHash, rawPath, s
 	}
 	env, err := provenance.NewEvidenceEnvelope(in)
 	if err != nil {
-		return false, 0, err
+		return provenance.Envelope{}, err
 	}
-	// Prefer legacy raw_hash digest when already a prefixed sha256; do not invent
-	// raw bytes. Keep hashes.raw null unless we have a digest string.
 	if strings.HasPrefix(rawHash, "sha256:") && len(strings.TrimPrefix(rawHash, "sha256:")) == 64 {
 		digest := strings.TrimPrefix(rawHash, "sha256:")
 		algo, scope := provenance.HashAlgorithm, provenance.RawScope
@@ -328,31 +377,54 @@ func backfillOneItem(tx *sql.Tx, itemID, text, metadataJSON, rawHash, rawPath, s
 		env.Hashes.RawScope = &scope
 		env.Hashes.Raw = &digest
 		if err := provenance.Validate(env, provenance.ValidationContext{}); err != nil {
-			return false, 0, err
+			return provenance.Envelope{}, err
 		}
 	}
-	meta["provenance"] = env
-	updated, err := json.Marshal(meta)
+	return env, nil
+}
+
+// ParseRetainableEnvelope unmarshals and validates an existing provenance value
+// for retention. Content digest may be nil; other structural rules still apply.
+func ParseRetainableEnvelope(raw any) (provenance.Envelope, error) {
+	return parseRetainableEnvelope(raw)
+}
+
+// ValidateRetainableEnvelope reports whether env can be retained without
+// rewriting trust history. Nil hashes.content is allowed when the rest is valid.
+func ValidateRetainableEnvelope(env provenance.Envelope) error {
+	return validateRetainableEnvelope(env)
+}
+
+func parseRetainableEnvelope(raw any) (provenance.Envelope, error) {
+	envBytes, err := json.Marshal(raw)
 	if err != nil {
-		return false, 0, err
+		return provenance.Envelope{}, err
 	}
-	if _, err := tx.Exec(`update items set metadata_json = ? where id = ?`, string(updated), itemID); err != nil {
-		return false, 0, err
+	var env provenance.Envelope
+	if err := json.Unmarshal(envBytes, &env); err != nil {
+		return provenance.Envelope{}, err
 	}
-	if err := replaceProvenanceProjections(tx, itemID, env); err != nil {
-		return false, 0, err
+	if err := validateRetainableEnvelope(env); err != nil {
+		return provenance.Envelope{}, err
 	}
-	contentHash := ""
-	if env.Hashes.Content != nil {
-		contentHash = *env.Hashes.Content
+	return env, nil
+}
+
+func validateRetainableEnvelope(env provenance.Envelope) error {
+	if err := provenance.Validate(env, provenance.ValidationContext{}); err == nil {
+		return nil
+	} else if env.Hashes.Content != nil {
+		return err
 	}
-	if err := AppendProvenanceEvent(tx, itemID, "", "unknown", contentHash, env.Hashes.ContentScope, "ingest:ingest.BackfillProvenance", map[string]any{
-		"attribution": "inferred",
-		"raw_path":    rawPath,
-	}); err != nil {
-		return false, 0, err
+	// Historical rows may omit hashes.content. Probe structural validity with a
+	// temporary well-formed digest without mutating the retained envelope.
+	probe := env
+	placeholder := strings.Repeat("a", 64)
+	probe.Hashes.Content = &placeholder
+	if err := provenance.Validate(probe, provenance.ValidationContext{}); err != nil {
+		return err
 	}
-	return true, 1, nil
+	return nil
 }
 
 func projectionsComplete(tx *sql.Tx, itemID string, env provenance.Envelope) bool {

--- a/engines/evidence-ledger/internal/ingest/provenance.go
+++ b/engines/evidence-ledger/internal/ingest/provenance.go
@@ -107,6 +107,8 @@ func replaceProvenanceProjections(tx *sql.Tx, itemID string, env provenance.Enve
 }
 
 // AppendProvenanceEvent inserts one immutable provenance_events row.
+// Event IDs are stable across wall-clock time so concurrent inferred backfills
+// that race on the same transition collapse via INSERT OR IGNORE.
 func AppendProvenanceEvent(tx *sql.Tx, itemID string, fromLabel, toLabel, contentHash, contentScope, operatorCommand string, evidence map[string]any) error {
 	if evidence == nil {
 		evidence = map[string]any{}
@@ -132,8 +134,8 @@ func AppendProvenanceEvent(tx *sql.Tx, itemID string, fromLabel, toLabel, conten
 	if err != nil {
 		return err
 	}
-	eventID := stableID("provenance-event", itemID, at, fromLabel, toLabel, contentHash, operatorCommand)
-	_, err = tx.Exec(`insert into provenance_events(id, item_id, at, from_label, to_label, envelope_content_hash, content_scope, operator_command, evidence_json, event_json)
+	eventID := stableID("provenance-event", itemID, fromLabel, toLabel, contentHash, contentScope, operatorCommand)
+	_, err = tx.Exec(`insert or ignore into provenance_events(id, item_id, at, from_label, to_label, envelope_content_hash, content_scope, operator_command, evidence_json, event_json)
 values(?,?,?,?,?,?,?,?,?,?)`,
 		eventID, itemID, at, nullIfEmpty(fromLabel), toLabel, nullIfEmpty(contentHash), nullIfEmpty(contentScope), nullIfEmpty(operatorCommand), string(evidenceRaw), string(raw))
 	return err
@@ -275,6 +277,17 @@ limit ?`, afterID, batchSize)
 }
 
 func backfillOneItem(tx *sql.Tx, itemID, text, metadataJSON, rawHash, rawPath, sourceID, collectionID, externalID string) (outcome backfillOutcome, events int, evidence *BackfillItemEvidence, err error) {
+	// Re-read inside the write transaction so concurrent backfills observe the
+	// latest provenance state rather than a stale pre-tx snapshot.
+	var liveMetadataJSON, liveText string
+	if err := tx.QueryRow(`select metadata_json, coalesce(text,'') from items where id = ?`, itemID).Scan(&liveMetadataJSON, &liveText); err != nil {
+		return backfillSkipped, 0, nil, err
+	}
+	if liveText != "" {
+		text = liveText
+	}
+	metadataJSON = liveMetadataJSON
+
 	meta := map[string]any{}
 	if strings.TrimSpace(metadataJSON) != "" {
 		if err := json.Unmarshal([]byte(metadataJSON), &meta); err != nil {
@@ -307,8 +320,41 @@ func backfillOneItem(tx *sql.Tx, itemID, text, metadataJSON, rawHash, rawPath, s
 	if err != nil {
 		return backfillSkipped, 0, nil, err
 	}
-	if _, err := tx.Exec(`update items set metadata_json = ? where id = ?`, string(updated), itemID); err != nil {
+	// Conditional write: only stamp inferred provenance when still absent.
+	res, err := tx.Exec(`update items set metadata_json = ? where id = ? and json_extract(metadata_json, '$.provenance') is null`, string(updated), itemID)
+	if err != nil {
 		return backfillSkipped, 0, nil, err
+	}
+	affected, _ := res.RowsAffected()
+	if affected == 0 {
+		// Another writer filled provenance between our read and conditional
+		// update. Re-read once and take the retain/repair path without looping.
+		var refreshed string
+		if err := tx.QueryRow(`select metadata_json from items where id = ?`, itemID).Scan(&refreshed); err != nil {
+			return backfillSkipped, 0, nil, err
+		}
+		meta = map[string]any{}
+		if err := json.Unmarshal([]byte(refreshed), &meta); err != nil {
+			meta = map[string]any{}
+		}
+		rawEnv, ok := meta["provenance"]
+		if !ok || rawEnv == nil {
+			return backfillSkipped, 0, nil, nil
+		}
+		env, parseErr := parseRetainableEnvelope(rawEnv)
+		if parseErr != nil {
+			return backfillMalformed, 0, &BackfillItemEvidence{
+				ItemID: itemID,
+				Reason: "malformed provenance: " + parseErr.Error(),
+			}, nil
+		}
+		if projectionsComplete(tx, itemID, env) {
+			return backfillSkipped, 0, nil, nil
+		}
+		if err := replaceProvenanceProjections(tx, itemID, env); err != nil {
+			return backfillSkipped, 0, nil, err
+		}
+		return backfillUpdated, 0, nil, nil
 	}
 	if err := replaceProvenanceProjections(tx, itemID, env); err != nil {
 		return backfillSkipped, 0, nil, err
@@ -436,6 +482,12 @@ func projectionsComplete(tx *sql.Tx, itemID string, env provenance.Envelope) boo
 	}
 	if env.Hashes.Content != nil {
 		want[MetaKeyProvenanceContentDigest] = *env.Hashes.Content
+	} else {
+		// Null envelope content digest must not leave a stale projected digest.
+		var stale int
+		if err := tx.QueryRow(`select count(*) from item_metadata where item_id = ? and key = ?`, itemID, MetaKeyProvenanceContentDigest).Scan(&stale); err != nil || stale != 0 {
+			return false
+		}
 	}
 	for key, value := range want {
 		if value == "" {

--- a/engines/evidence-ledger/internal/ingest/provenance_test.go
+++ b/engines/evidence-ledger/internal/ingest/provenance_test.go
@@ -126,6 +126,77 @@ func TestTransitionTrustLabelAppendsImmutableEvent(t *testing.T) {
 	}
 }
 
+func TestTransitionTrustLabelCycleRecordsEveryOccurrence(t *testing.T) {
+	db, err := archive.Open(t.TempDir() + "/miseledger.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := archive.Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	jsonl := `{"schema":"miseledger.adapter.v1","source":{"kind":"reader-test","name":"Reader Test"},"collection":{"external_id":"reader:collection","kind":"agent_session","name":"reader"},"item":{"external_id":"reader:item:cycle","kind":"message","created_at":"2026-06-03T00:00:00Z","text":"trust cycle fixture","tags":["reader"]},"actor":{"external_id":"reader:actor","type":"human","name":"reader"},"artifacts":[],"links":[],"relations":[],"raw":{"format":"json","path":"reader.jsonl","ordinal":1}}` + "\n"
+	if _, err := ImportAdapterReader(db, strings.NewReader(jsonl), "reader://fixture", "reader-test"); err != nil {
+		t.Fatal(err)
+	}
+	var itemID string
+	if err := db.QueryRow(`select id from items limit 1`).Scan(&itemID); err != nil {
+		t.Fatal(err)
+	}
+	op := "operator:brigade evidence trust review"
+	// quarantined (ingest) -> untrusted -> quarantined -> untrusted
+	for _, to := range []string{"untrusted", "quarantined", "untrusted"} {
+		if err := TransitionTrustLabel(db, itemID, to, op, map[string]any{"cycle": true}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var count int
+	if err := db.QueryRow(`select count(*) from provenance_events where item_id = ?`, itemID).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	// initial ingest + three real transitions
+	if count != 4 {
+		t.Fatalf("events = %d, want 4 (initial + three cycle transitions)", count)
+	}
+	rows, err := db.Query(`select coalesce(from_label,''), to_label from provenance_events where item_id = ? order by at, id`, itemID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	var got [][2]string
+	for rows.Next() {
+		var fromLabel, toLabel string
+		if err := rows.Scan(&fromLabel, &toLabel); err != nil {
+			t.Fatal(err)
+		}
+		got = append(got, [2]string{fromLabel, toLabel})
+	}
+	want := [][2]string{
+		{"", "quarantined"},
+		{"quarantined", "untrusted"},
+		{"untrusted", "quarantined"},
+		{"quarantined", "untrusted"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("transitions = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("transition[%d] = %v, want %v (full=%v)", i, got[i], want[i], got)
+		}
+	}
+	// unchanged-label remains a no-op
+	if err := TransitionTrustLabel(db, itemID, "untrusted", op, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`select count(*) from provenance_events where item_id = ?`, itemID).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 4 {
+		t.Fatalf("same-label no-op changed event count to %d", count)
+	}
+}
+
 func TestBackfillProvenanceBatchedResumableIdempotent(t *testing.T) {
 	db, err := archive.Open(t.TempDir() + "/miseledger.db")
 	if err != nil {
@@ -506,7 +577,7 @@ values('item-stable','src1','col1','legacy:item:stable','message',?,?,'text','',
 	}
 	digest := strings.Repeat("d", 64)
 	for i := 0; i < 3; i++ {
-		if err := AppendProvenanceEvent(tx, "item-stable", "", "unknown", digest, "item.text.utf8.v1", "ingest:ingest.BackfillProvenance", map[string]any{"n": i}); err != nil {
+		if err := AppendIdempotentProvenanceEvent(tx, "item-stable", "", "unknown", digest, "item.text.utf8.v1", "ingest:ingest.BackfillProvenance", map[string]any{"n": i}); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/engines/evidence-ledger/internal/ingest/provenance_test.go
+++ b/engines/evidence-ledger/internal/ingest/provenance_test.go
@@ -1,0 +1,201 @@
+package ingest
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/escoffier-labs/miseledger/internal/archive"
+	"github.com/escoffier-labs/miseledger/internal/provenance"
+)
+
+func TestImportProjectsProvenanceScalarsAndAppendsEvent(t *testing.T) {
+	db, err := archive.Open(t.TempDir() + "/miseledger.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := archive.Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	jsonl := `{"schema":"miseledger.adapter.v1","source":{"kind":"reader-test","name":"Reader Test"},"collection":{"external_id":"reader:collection","kind":"agent_session","name":"reader"},"item":{"external_id":"reader:item:proj","kind":"message","created_at":"2026-06-03T00:00:00Z","text":"project   provenance\nscalars","summary":"extra summary","tags":["reader"]},"actor":{"external_id":"reader:actor","type":"human","name":"reader"},"artifacts":[],"links":[],"relations":[],"raw":{"format":"json","path":"reader.jsonl","ordinal":1}}` + "\n"
+	if _, err := ImportAdapterReader(db, strings.NewReader(jsonl), "reader://fixture", "reader-test"); err != nil {
+		t.Fatal(err)
+	}
+	var itemID, contentHash, metadataJSON string
+	if err := db.QueryRow(`select id, content_hash, metadata_json from items limit 1`).Scan(&itemID, &contentHash, &metadataJSON); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(contentHash, "sha256:") {
+		t.Fatalf("items.content_hash = %q, want normalized sha256: prefix preserved", contentHash)
+	}
+	var meta map[string]any
+	if err := json.Unmarshal([]byte(metadataJSON), &meta); err != nil {
+		t.Fatal(err)
+	}
+	env := meta["provenance"].(map[string]any)
+	exact := provenance.ContentSHA256("project   provenance\nscalars")
+	if env["hashes"].(map[string]any)["content"] != exact {
+		t.Fatalf("envelope content digest mismatch")
+	}
+	if contentHash == "sha256:"+exact {
+		t.Fatalf("envelope exact digest must not equal normalized items.content_hash")
+	}
+	want := map[string]string{
+		MetaKeyProvenanceOrigin:        "external-service",
+		MetaKeyProvenanceModality:      "tool-output",
+		MetaKeyProvenanceTrustLabel:    "quarantined",
+		MetaKeyProvenanceContentScope:  "item.text.utf8.v1",
+		MetaKeyProvenanceContentDigest: exact,
+	}
+	for key, value := range want {
+		var got string
+		if err := db.QueryRow(`select value from item_metadata where item_id = ? and key = ?`, itemID, key).Scan(&got); err != nil {
+			t.Fatalf("missing projection %s: %v", key, err)
+		}
+		if got != value {
+			t.Fatalf("projection %s = %q, want %q", key, got, value)
+		}
+	}
+	var events int
+	if err := db.QueryRow(`select count(*) from provenance_events where item_id = ?`, itemID).Scan(&events); err != nil {
+		t.Fatal(err)
+	}
+	if events != 1 {
+		t.Fatalf("provenance_events = %d, want 1 initial assignment", events)
+	}
+	var toLabel string
+	if err := db.QueryRow(`select to_label from provenance_events where item_id = ?`, itemID).Scan(&toLabel); err != nil {
+		t.Fatal(err)
+	}
+	if toLabel != "quarantined" {
+		t.Fatalf("to_label = %q, want quarantined", toLabel)
+	}
+}
+
+func TestTransitionTrustLabelAppendsImmutableEvent(t *testing.T) {
+	db, err := archive.Open(t.TempDir() + "/miseledger.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := archive.Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	jsonl := `{"schema":"miseledger.adapter.v1","source":{"kind":"reader-test","name":"Reader Test"},"collection":{"external_id":"reader:collection","kind":"agent_session","name":"reader"},"item":{"external_id":"reader:item:trust","kind":"message","created_at":"2026-06-03T00:00:00Z","text":"trust transition fixture","tags":["reader"]},"actor":{"external_id":"reader:actor","type":"human","name":"reader"},"artifacts":[],"links":[],"relations":[],"raw":{"format":"json","path":"reader.jsonl","ordinal":1}}` + "\n"
+	if _, err := ImportAdapterReader(db, strings.NewReader(jsonl), "reader://fixture", "reader-test"); err != nil {
+		t.Fatal(err)
+	}
+	var itemID string
+	if err := db.QueryRow(`select id from items limit 1`).Scan(&itemID); err != nil {
+		t.Fatal(err)
+	}
+	if err := TransitionTrustLabel(db, itemID, "untrusted", "scanner:demo.release", map[string]any{"reason": "clean-scan"}); err != nil {
+		t.Fatal(err)
+	}
+	var count int
+	if err := db.QueryRow(`select count(*) from provenance_events where item_id = ?`, itemID).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Fatalf("events = %d, want 2 (initial + transition)", count)
+	}
+	var fromLabel, toLabel, trustProj string
+	if err := db.QueryRow(`select from_label, to_label from provenance_events where item_id = ? order by at desc limit 1`, itemID).Scan(&fromLabel, &toLabel); err != nil {
+		t.Fatal(err)
+	}
+	if fromLabel != "quarantined" || toLabel != "untrusted" {
+		t.Fatalf("transition = %q -> %q, want quarantined -> untrusted", fromLabel, toLabel)
+	}
+	if err := db.QueryRow(`select value from item_metadata where item_id = ? and key = ?`, itemID, MetaKeyProvenanceTrustLabel).Scan(&trustProj); err != nil {
+		t.Fatal(err)
+	}
+	if trustProj != "untrusted" {
+		t.Fatalf("trust projection = %q, want untrusted", trustProj)
+	}
+	// Events are immutable: transition never deletes prior rows.
+	if err := TransitionTrustLabel(db, itemID, "untrusted", "scanner:demo.release", nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`select count(*) from provenance_events where item_id = ?`, itemID).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Fatalf("idempotent same-label transition changed event count to %d", count)
+	}
+}
+
+func TestBackfillProvenanceBatchedResumableIdempotent(t *testing.T) {
+	db, err := archive.Open(t.TempDir() + "/miseledger.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := archive.Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	now := "2026-06-03T00:00:00Z"
+	if _, err := db.Exec(`insert into sources(id, kind, name, version, created_at, updated_at) values('src1','legacy-source','Legacy','1',?,?)`, now, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`insert into collections(id, source_id, external_id, kind, name, metadata_json, created_at, updated_at) values('col1','src1','legacy:collection','agent_session','legacy','{}',?,?)`, now, now); err != nil {
+		t.Fatal(err)
+	}
+	texts := []string{"legacy item one", "legacy item two", "legacy item three"}
+	for i, text := range texts {
+		id := "item" + string(rune('a'+i))
+		bodyHash := "sha256:" + hashString(text+"\n")
+		if _, err := db.Exec(`insert into items(id, source_id, collection_id, external_id, kind, created_at, updated_at, text, summary, content_hash, raw_json, raw_hash, raw_path, raw_ordinal, metadata_json)
+values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+			id, "src1", "col1", "legacy:item:"+id, "message", now, now, text, "", bodyHash, `{"legacy":true}`, "sha256:"+hashString("raw"+id), "legacy.jsonl", i+1, `{}`); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	first, err := BackfillProvenance(db, 2, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Scanned != 2 || first.Updated != 2 || first.Remaining != 1 {
+		t.Fatalf("first batch = %+v, want scanned=2 updated=2 remaining=1", first)
+	}
+	second, err := BackfillProvenance(db, 2, first.Cursor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Scanned != 1 || second.Updated != 1 || second.Remaining != 0 {
+		t.Fatalf("second batch = %+v, want scanned=1 updated=1 remaining=0", second)
+	}
+	var unknownTrust int
+	if err := db.QueryRow(`select count(*) from item_metadata where key = ? and value = 'unknown'`, MetaKeyProvenanceTrustLabel).Scan(&unknownTrust); err != nil {
+		t.Fatal(err)
+	}
+	if unknownTrust != 3 {
+		t.Fatalf("unknown trust projections = %d, want 3", unknownTrust)
+	}
+	for _, id := range []string{"itema", "itemb", "itemc"} {
+		var metadataJSON string
+		if err := db.QueryRow(`select metadata_json from items where id = ?`, id).Scan(&metadataJSON); err != nil {
+			t.Fatal(err)
+		}
+		var meta map[string]any
+		if err := json.Unmarshal([]byte(metadataJSON), &meta); err != nil {
+			t.Fatal(err)
+		}
+		trust := meta["provenance"].(map[string]any)["trust"].(map[string]any)
+		if trust["label"] != "unknown" {
+			t.Fatalf("%s trust label = %v, want unknown", id, trust["label"])
+		}
+		attr := meta["provenance"].(map[string]any)["attribution"]
+		if attr != "inferred" {
+			t.Fatalf("%s attribution = %v, want inferred", id, attr)
+		}
+	}
+	third, err := BackfillProvenance(db, 10, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if third.Updated != 0 || third.Skipped != 3 {
+		t.Fatalf("idempotent pass = %+v, want updated=0 skipped=3", third)
+	}
+}

--- a/engines/evidence-ledger/internal/ingest/provenance_test.go
+++ b/engines/evidence-ledger/internal/ingest/provenance_test.go
@@ -199,3 +199,219 @@ values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
 		t.Fatalf("idempotent pass = %+v, want updated=0 skipped=3", third)
 	}
 }
+
+func validHistoricalEnvelope(trustLabel string, contentDigest *string) map[string]any {
+	at := "2026-06-03T00:00:00Z"
+	hashes := map[string]any{
+		"content_algorithm": "sha256",
+		"content_scope":     "item.text.utf8.v1",
+		"content":           nil,
+		"raw_algorithm":     nil,
+		"raw_scope":         nil,
+		"raw":               nil,
+	}
+	if contentDigest != nil {
+		hashes["content"] = *contentDigest
+	}
+	return map[string]any{
+		"schema":         "brigade.provenance-envelope.v1",
+		"schema_version": 1,
+		"source":         map[string]any{"system": "miseledger", "kind": "legacy-source", "producer": "historical"},
+		"origin":         "external-service",
+		"repository":     map[string]any{"id": "unknown", "revision": nil},
+		"session":        map[string]any{"id": nil, "harness": nil},
+		"collection_id":  "legacy:collection",
+		"item_id":        "legacy:item",
+		"locator":        map[string]any{"kind": "uri", "value": "miseledger://legacy-source/legacy:collection/legacy:item"},
+		"attribution":    "observed",
+		"modality":       "tool-output",
+		"trust": map[string]any{
+			"label":       trustLabel,
+			"assigned_by": "ingest:historical",
+			"assigned_at": at,
+			"trust_policy": map[string]any{
+				"schema":         "brigade.trust-policy.v1",
+				"schema_version": 1,
+			},
+			"injection": map[string]any{"status": "pending", "count": 0, "rules": []any{}},
+		},
+		"hashes":      hashes,
+		"captured_at": at,
+		"ingested_at": at,
+	}
+}
+
+func TestBackfillPreservesValidEnvelopeWithNilOrMismatchedDigest(t *testing.T) {
+	db, err := archive.Open(t.TempDir() + "/miseledger.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := archive.Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	now := "2026-06-03T00:00:00Z"
+	if _, err := db.Exec(`insert into sources(id, kind, name, version, created_at, updated_at) values('src1','legacy-source','Legacy','1',?,?)`, now, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`insert into collections(id, source_id, external_id, kind, name, metadata_json, created_at, updated_at) values('col1','src1','legacy:collection','agent_session','legacy','{}',?,?)`, now, now); err != nil {
+		t.Fatal(err)
+	}
+	wrong := strings.Repeat("b", 64)
+	cases := []struct {
+		id       string
+		text     string
+		envelope map[string]any
+	}{
+		{"item-nil", "nil digest body", validHistoricalEnvelope("reviewed", nil)},
+		{"item-mismatch", "mismatch digest body", validHistoricalEnvelope("verified", &wrong)},
+	}
+	for i, tc := range cases {
+		meta, _ := json.Marshal(map[string]any{"provenance": tc.envelope})
+		if _, err := db.Exec(`insert into items(id, source_id, collection_id, external_id, kind, created_at, updated_at, text, summary, content_hash, raw_json, raw_hash, raw_path, raw_ordinal, metadata_json)
+values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+			tc.id, "src1", "col1", "legacy:item:"+tc.id, "message", now, now, tc.text, "", "sha256:"+hashString(tc.text+"\n"), `{}`, "sha256:"+hashString("raw"+tc.id), "legacy.jsonl", i+1, string(meta)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	result, err := BackfillProvenance(db, 10, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Malformed != 0 {
+		t.Fatalf("malformed = %d evidence=%v, want 0", result.Malformed, result.Evidence)
+	}
+	if result.Updated != 2 {
+		t.Fatalf("updated = %d, want 2 projection repairs", result.Updated)
+	}
+	for _, tc := range cases {
+		var metadataJSON string
+		if err := db.QueryRow(`select metadata_json from items where id = ?`, tc.id).Scan(&metadataJSON); err != nil {
+			t.Fatal(err)
+		}
+		var meta map[string]any
+		if err := json.Unmarshal([]byte(metadataJSON), &meta); err != nil {
+			t.Fatal(err)
+		}
+		trust := meta["provenance"].(map[string]any)["trust"].(map[string]any)
+		want := tc.envelope["trust"].(map[string]any)["label"]
+		if trust["label"] != want {
+			t.Fatalf("%s trust reset to %v, want preserved %v", tc.id, trust["label"], want)
+		}
+		var events int
+		if err := db.QueryRow(`select count(*) from provenance_events where item_id = ?`, tc.id).Scan(&events); err != nil {
+			t.Fatal(err)
+		}
+		if events != 0 {
+			t.Fatalf("%s grew provenance_events = %d, want 0 (no trust rewrite)", tc.id, events)
+		}
+		var trustProj string
+		if err := db.QueryRow(`select value from item_metadata where item_id = ? and key = ?`, tc.id, MetaKeyProvenanceTrustLabel).Scan(&trustProj); err != nil {
+			t.Fatal(err)
+		}
+		if trustProj != want {
+			t.Fatalf("%s trust projection = %q, want %v", tc.id, trustProj, want)
+		}
+	}
+}
+
+func TestBackfillIsolatesMalformedProvenanceAndRemainsResumable(t *testing.T) {
+	db, err := archive.Open(t.TempDir() + "/miseledger.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := archive.Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	now := "2026-06-03T00:00:00Z"
+	if _, err := db.Exec(`insert into sources(id, kind, name, version, created_at, updated_at) values('src1','legacy-source','Legacy','1',?,?)`, now, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`insert into collections(id, source_id, external_id, kind, name, metadata_json, created_at, updated_at) values('col1','src1','legacy:collection','agent_session','legacy','{}',?,?)`, now, now); err != nil {
+		t.Fatal(err)
+	}
+	insert := func(id, text, metadataJSON string, ordinal int) {
+		t.Helper()
+		if _, err := db.Exec(`insert into items(id, source_id, collection_id, external_id, kind, created_at, updated_at, text, summary, content_hash, raw_json, raw_hash, raw_path, raw_ordinal, metadata_json)
+values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+			id, "src1", "col1", "legacy:item:"+id, "message", now, now, text, "", "sha256:"+hashString(text+"\n"), `{}`, "sha256:"+hashString("raw"+id), "legacy.jsonl", ordinal, metadataJSON); err != nil {
+			t.Fatal(err)
+		}
+	}
+	insert("itema", "good before", `{}`, 1)
+	badExact := provenance.ContentSHA256("matching but malformed")
+	badEnv := validHistoricalEnvelope("quarantined", &badExact)
+	badEnv["origin"] = "not-a-real-origin"
+	badMeta, _ := json.Marshal(map[string]any{"provenance": badEnv})
+	insert("itemb", "matching but malformed", string(badMeta), 2)
+	insert("itemc", "good after", `{}`, 3)
+
+	first, err := BackfillProvenance(db, 10, "")
+	if err != nil {
+		t.Fatalf("batch aborted on malformed row: %v", err)
+	}
+	if first.Malformed != 1 || first.Updated != 2 || first.Skipped != 0 {
+		t.Fatalf("first = %+v, want malformed=1 updated=2 skipped=0", first)
+	}
+	if len(first.Evidence) != 1 || first.Evidence[0].ItemID != "itemb" {
+		t.Fatalf("evidence = %#v, want itemb", first.Evidence)
+	}
+	var badMetaAfter string
+	if err := db.QueryRow(`select metadata_json from items where id = 'itemb'`).Scan(&badMetaAfter); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(badMetaAfter, "not-a-real-origin") {
+		t.Fatalf("malformed envelope was rewritten: %s", badMetaAfter)
+	}
+	// Retry from start must still advance: malformed stays isolated, goods skip.
+	second, err := BackfillProvenance(db, 10, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Malformed != 1 || second.Updated != 0 || second.Skipped != 2 {
+		t.Fatalf("retry = %+v, want malformed=1 updated=0 skipped=2", second)
+	}
+	// Resume after malformed cursor progresses past the bad row.
+	third, err := BackfillProvenance(db, 10, "itemb")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if third.Scanned != 1 || third.Cursor != "itemc" || third.Malformed != 0 {
+		t.Fatalf("resume after malformed = %+v, want progress past itemb", third)
+	}
+}
+
+func TestBackfillValidatesMatchingDigestBeforeRetain(t *testing.T) {
+	db, err := archive.Open(t.TempDir() + "/miseledger.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := archive.Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	now := "2026-06-03T00:00:00Z"
+	if _, err := db.Exec(`insert into sources(id, kind, name, version, created_at, updated_at) values('src1','legacy-source','Legacy','1',?,?)`, now, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`insert into collections(id, source_id, external_id, kind, name, metadata_json, created_at, updated_at) values('col1','src1','legacy:collection','agent_session','legacy','{}',?,?)`, now, now); err != nil {
+		t.Fatal(err)
+	}
+	text := "matching digest malformed trust"
+	digest := provenance.ContentSHA256(text)
+	env := validHistoricalEnvelope("trusted", &digest) // closed-set violation
+	meta, _ := json.Marshal(map[string]any{"provenance": env})
+	if _, err := db.Exec(`insert into items(id, source_id, collection_id, external_id, kind, created_at, updated_at, text, summary, content_hash, raw_json, raw_hash, raw_path, raw_ordinal, metadata_json)
+values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		"item-match-bad", "src1", "col1", "legacy:item:match-bad", "message", now, now, text, "", "sha256:"+hashString(text+"\n"), `{}`, "sha256:"+hashString("raw"), "legacy.jsonl", 1, string(meta)); err != nil {
+		t.Fatal(err)
+	}
+	result, err := BackfillProvenance(db, 10, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Malformed != 1 || result.Updated != 0 {
+		t.Fatalf("result = %+v, want matching-but-invalid treated as malformed", result)
+	}
+}

--- a/engines/evidence-ledger/internal/ingest/provenance_test.go
+++ b/engines/evidence-ledger/internal/ingest/provenance_test.go
@@ -3,6 +3,7 @@ package ingest
 import (
 	"encoding/json"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/escoffier-labs/miseledger/internal/archive"
@@ -413,5 +414,169 @@ values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
 	}
 	if result.Malformed != 1 || result.Updated != 0 {
 		t.Fatalf("result = %+v, want matching-but-invalid treated as malformed", result)
+	}
+}
+
+func TestBackfillConcurrentInferredEventsAreIdempotent(t *testing.T) {
+	db, err := archive.Open(t.TempDir() + "/miseledger.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := archive.Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	now := "2026-06-03T00:00:00Z"
+	if _, err := db.Exec(`insert into sources(id, kind, name, version, created_at, updated_at) values('src1','legacy-source','Legacy','1',?,?)`, now, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`insert into collections(id, source_id, external_id, kind, name, metadata_json, created_at, updated_at) values('col1','src1','legacy:collection','agent_session','legacy','{}',?,?)`, now, now); err != nil {
+		t.Fatal(err)
+	}
+	text := "concurrent backfill body"
+	if _, err := db.Exec(`insert into items(id, source_id, collection_id, external_id, kind, created_at, updated_at, text, summary, content_hash, raw_json, raw_hash, raw_path, raw_ordinal, metadata_json)
+values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		"item-concurrent", "src1", "col1", "legacy:item:concurrent", "message", now, now, text, "", "sha256:"+hashString(text+"\n"), `{}`, "sha256:"+hashString("raw"), "legacy.jsonl", 1, `{}`); err != nil {
+		t.Fatal(err)
+	}
+
+	const workers = 8
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var err error
+			for attempt := 0; attempt < 32; attempt++ {
+				_, err = BackfillProvenance(db, 10, "")
+				if err == nil || !strings.Contains(err.Error(), "SQLITE_BUSY") {
+					break
+				}
+			}
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent backfill error: %v", err)
+		}
+	}
+	var events int
+	if err := db.QueryRow(`select count(*) from provenance_events where item_id = 'item-concurrent'`).Scan(&events); err != nil {
+		t.Fatal(err)
+	}
+	if events != 1 {
+		t.Fatalf("provenance_events = %d, want 1 idempotent inferred event", events)
+	}
+	var trust string
+	if err := db.QueryRow(`select json_extract(metadata_json, '$.provenance.trust.label') from items where id = 'item-concurrent'`).Scan(&trust); err != nil {
+		t.Fatal(err)
+	}
+	if trust != "unknown" {
+		t.Fatalf("trust label = %q, want unknown", trust)
+	}
+}
+
+func TestAppendProvenanceEventStableIDIsIdempotent(t *testing.T) {
+	db, err := archive.Open(t.TempDir() + "/miseledger.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := archive.Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	now := "2026-06-03T00:00:00Z"
+	if _, err := db.Exec(`insert into sources(id, kind, name, version, created_at, updated_at) values('src1','legacy-source','Legacy','1',?,?)`, now, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`insert into collections(id, source_id, external_id, kind, name, metadata_json, created_at, updated_at) values('col1','src1','legacy:collection','agent_session','legacy','{}',?,?)`, now, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`insert into items(id, source_id, collection_id, external_id, kind, created_at, updated_at, text, summary, content_hash, raw_json, metadata_json)
+values('item-stable','src1','col1','legacy:item:stable','message',?,?,'text','','sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa','{}','{}')`, now, now); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := strings.Repeat("d", 64)
+	for i := 0; i < 3; i++ {
+		if err := AppendProvenanceEvent(tx, "item-stable", "", "unknown", digest, "item.text.utf8.v1", "ingest:ingest.BackfillProvenance", map[string]any{"n": i}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	var events int
+	if err := db.QueryRow(`select count(*) from provenance_events where item_id = 'item-stable'`).Scan(&events); err != nil {
+		t.Fatal(err)
+	}
+	if events != 1 {
+		t.Fatalf("events = %d, want 1 from INSERT OR IGNORE stable id", events)
+	}
+}
+
+func TestBackfillRepairsStaleContentDigestWhenEnvelopeHashNull(t *testing.T) {
+	db, err := archive.Open(t.TempDir() + "/miseledger.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := archive.Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	now := "2026-06-03T00:00:00Z"
+	if _, err := db.Exec(`insert into sources(id, kind, name, version, created_at, updated_at) values('src1','legacy-source','Legacy','1',?,?)`, now, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`insert into collections(id, source_id, external_id, kind, name, metadata_json, created_at, updated_at) values('col1','src1','legacy:collection','agent_session','legacy','{}',?,?)`, now, now); err != nil {
+		t.Fatal(err)
+	}
+	text := "null content digest with stale projection"
+	env := validHistoricalEnvelope("reviewed", nil)
+	meta, _ := json.Marshal(map[string]any{"provenance": env})
+	if _, err := db.Exec(`insert into items(id, source_id, collection_id, external_id, kind, created_at, updated_at, text, summary, content_hash, raw_json, raw_hash, raw_path, raw_ordinal, metadata_json)
+values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		"item-stale-digest", "src1", "col1", "legacy:item:stale", "message", now, now, text, "", "sha256:"+hashString(text+"\n"), `{}`, "sha256:"+hashString("raw"), "legacy.jsonl", 1, string(meta)); err != nil {
+		t.Fatal(err)
+	}
+	// Seed complete-looking projections including a stale content digest.
+	for _, pair := range [][2]string{
+		{MetaKeyProvenanceOrigin, "external-service"},
+		{MetaKeyProvenanceModality, "tool-output"},
+		{MetaKeyProvenanceTrustLabel, "reviewed"},
+		{MetaKeyProvenanceContentScope, "item.text.utf8.v1"},
+		{MetaKeyProvenanceContentDigest, strings.Repeat("c", 64)},
+	} {
+		if _, err := db.Exec(`insert into item_metadata(item_id, key, value) values(?,?,?)`, "item-stale-digest", pair[0], pair[1]); err != nil {
+			t.Fatal(err)
+		}
+	}
+	result, err := BackfillProvenance(db, 10, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Updated != 1 {
+		t.Fatalf("result = %+v, want updated=1 to clear stale digest", result)
+	}
+	var digestCount int
+	if err := db.QueryRow(`select count(*) from item_metadata where item_id = ? and key = ?`, "item-stale-digest", MetaKeyProvenanceContentDigest).Scan(&digestCount); err != nil {
+		t.Fatal(err)
+	}
+	if digestCount != 0 {
+		t.Fatalf("stale provenance.content_digest still present (count=%d)", digestCount)
+	}
+	var trust string
+	if err := db.QueryRow(`select json_extract(metadata_json, '$.provenance.trust.label') from items where id = 'item-stale-digest'`).Scan(&trust); err != nil {
+		t.Fatal(err)
+	}
+	if trust != "reviewed" {
+		t.Fatalf("trust reset to %q, want preserved reviewed", trust)
 	}
 }


### PR DESCRIPTION
## Summary

Implements issue **#583** (proposal Slice 2) on current main (`fee34326` / #850):

- Persist `brigade.provenance-envelope.v1` at Go ingest fan-in with indexed `provenance.*` projections and append-only trust events
- `#850` `ingest_seq` remains **schema v3**; `provenance_events` is **schema v4**
- Resumable `miseledger doctor provenance backfill` with malformed-row isolation, valid-envelope retention, and concurrent inferred-event idempotency
- `show` synthesizes unknown when provenance is absent and sets `provenance_warning` when present-but-malformed
- Search/SQL filter origin, modality, and trust label via `item_metadata` without nested JSON parsing
- `items.content_hash` name and normalized dedupe algorithm are unchanged

## Repair (comment 5247426458)

1. Semantically rebased onto main `fee34326`; kept #850 `ensureSchemaV3` (`ingest_seq`); moved provenance to `ensureSchemaV4` / `SchemaVersion = 4` with post-#850 migration coverage
2. Concurrent backfill is conditional inside the write transaction (`json_extract(...provenance) is null`) and events use stable `INSERT OR IGNORE` IDs
3. `projectionsComplete` treats a stale `provenance.content_digest` as incomplete when envelope `hashes.content` is null, so repair clears it without resetting trust

## Repair (comment 5247494070)

1. Split event identity: `AppendIdempotentProvenanceEvent` keeps deterministic stable IDs + `INSERT OR IGNORE` for backfill/ingest repair; `AppendProvenanceEvent` gives normal trust transitions an occurrence identity (`at` + per-item sequence)
2. `TransitionTrustLabel` uses the occurrence path so `quarantined -> untrusted -> quarantined -> untrusted` with the same operator/content records all three transitions
3. Added `TestTransitionTrustLabelCycleRecordsEveryOccurrence`; unchanged-label no-op preserved

Preserved prior contracts: v3→v4 coexistence, concurrent backfill idempotency, nil-digest projection repair, malformed-row isolation, resumable cursor, show warnings, valid-envelope retention. Duplicate re-ingest path unchanged.

## Out of scope

- #584 / #585 / #586
- Work-store characterization (#842/#848/#849)
- Further #850 memory rebuild behavior beyond coexistence

## GraphTrail

Skipped: `graphtrail` binary not on PATH. Impact set: `archive.Migrate` / `ensureSchemaV3` / `ensureSchemaV4`, `replaceItemSideTables`, `BackfillProvenance` / `AppendProvenanceEvent` / `AppendIdempotentProvenanceEvent` / `projectionsComplete`, `showItem` / `attachShowProvenance`.

## Migration / backfill safety

- Additive only: v2 → v3 (`ingest_seq`) → v4 (`provenance_events`)
- Post-#850 v3→v4 migrate preserves existing `ingest_seq` values
- Inferred rows stay `trust.label=unknown`; valid historical envelopes are retained even when `hashes.content` is nil/mismatched
- Malformed rows do not abort the batch; evidence is bounded
- Concurrent inferred events collapse to one row via stable event IDs
- Real trust transitions keep occurrence-unique event IDs so label cycles never drop

## Verification (Brigade `--capture brigade-work`)

| Stage | Receipt ID | Result |
|---|---|---|
| `go vet -C engines/evidence-ledger ./...` | `20260811-001340-work-verify-5e6c9e` | completed / exit 0 |
| `go test -C engines/evidence-ledger ./... -count=1` | `20260811-001345-work-verify-e29ddf` | completed / exit 0 |
| `./engines/evidence-ledger/scripts/smoke_archive.sh` | `20260811-001355-work-verify-158bc4` | completed / exit 0 |

Exact head: `ce0cdd09752cab6362c6176e15baead9421406c1`

## Acceptance

- [x] Fresh imports include `metadata_json.provenance` and indexed projections
- [x] Search/SQL filter origin, modality, trust without nested JSON
- [x] `items.content_hash` unchanged; envelope hashes separate
- [x] Backfill batched/resumable/idempotent; inferred `trust.label=unknown`
- [x] Legacy show synthesizes unknown; malformed present provenance warns
- [x] Trust transitions append immutable occurrence-unique events (cycle regression)
- [x] Unchanged-label trust transition remains a no-op
- [x] Schema coexistence with #850 (`ingest_seq` v3, provenance v4)
- [x] Concurrent backfill events idempotent; stale null-hash digest repaired
- [x] Go tests, `go vet`, and `scripts/smoke_archive.sh` pass via Brigade receipts

## Memory Handoff

Linted: `.claude/memory-handoffs/20260811-001243-2026-08-11-provenance-transition-occurrence.md`

Closes #583