### PR TITLE
feat(update): install daily 0.27 beta wheels through pipx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `brigade update --channel beta` installs the newest non-yanked
+  `brigade-cli==0.27.0.devYYYYMMDD` wheel from PyPI into the existing
+  user-global pipx environment, migrates prior Git-main-SHA beta state to that
+  exact wheel pin, supports dry-run without mutation, and rolls back to stable
+  through `--channel stable --switch-channel`. (#852)
 - Issue #846 R1 work-store characterization: research report, synthetic
   chain/diamond/wide fixtures, and `scripts/measure_work_store.py` measurement
   harness with diffable JSON output. Characterization only; no backend or

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -51,10 +51,16 @@ pipx install brigade-cli
 brigade setup
 ```
 
-For an intentional Brigade development machine tracking CI-green `main`:
+For an intentional Brigade development machine on the `0.27` preview line:
 
 ```bash
 brigade update --channel beta
+```
+
+Rollback to stable:
+
+```bash
+brigade update --channel stable --switch-channel
 ```
 
 ## First install

--- a/README.md
+++ b/README.md
@@ -91,12 +91,13 @@ disable it. Details are in [docs/update-channels.md](docs/update-channels.md).
 
 Two update channels exist and they are not interchangeable. **Stable** is the
 default: immutable, PyPI-published releases like `0.26.0`, pinned exactly -
-what production and operator machines should run. **Beta** is the development
-channel: it tracks CI-green `main` daily and is an intentional opt-in for
-machines working on Brigade itself, not a preview program. Stable pinners may
+what production and operator machines should run. **Beta** is the intentional
+development-machine channel for the `0.27` preview line: it pins the newest
+non-yanked `brigade-cli==0.27.0.devYYYYMMDD` wheel from PyPI into the existing
+user-global pipx environment, not a mutable Git `main` SHA. Stable pinners may
 deliberately install an exact release with `pipx install brigade-cli==X.Y.Z`
 or refresh through `brigade update --channel stable`. Channel ownership, beta
-rules, and when to use `brigade update` are in
+selection and rollback rules, and when to use `brigade update` are in
 [docs/update-channels.md](docs/update-channels.md).
 
 `brigade operator doctor --target ./my-repo --profile local-operator` prints `ready: yes` when the wiring is healthy (without the profile flag, doctor runs the stricter internal-dogfood checks and a fresh repo reports not ready). The default footprint is small: `AGENTS.md`, `SAFETY_RULES.md`, a handoff template, and `.brigade/` state. Add `--dry-run` to preview anything before it writes. Nothing leaves your machine.

--- a/docs/component-manifest-policy.md
+++ b/docs/component-manifest-policy.md
@@ -83,9 +83,10 @@ attestation verify` in the release workflow rather than represented by an API bo
 Stable validation remains strict: every published component on a stable manifest must carry the full
 five-platform matrix with matching digests and provenance.
 
-Beta is the development channel for CI-green `main`. It installs the checked `main` Brigade wheel
-but reuses the last verified stable component manifest for native bytes, so beta and stable cannot
-install different native assets from two manifests at once.
+Beta is the intentional development channel for the `0.27` preview line. It installs the newest
+non-yanked `brigade-cli==0.27.0.devYYYYMMDD` wheel from PyPI into the existing user-global pipx
+environment, but reuses the last verified stable component manifest for native bytes, so beta and
+stable cannot install different native assets from two manifests at once.
 
 During the pre-pin window before `agent-notify` first appears on a stable manifest, main may list
 `agent-notify` as a known component with empty assets in the bundled compatibility manifest.

--- a/docs/component-manifest-policy.md
+++ b/docs/component-manifest-policy.md
@@ -123,7 +123,7 @@ Brigade does not relocate `.graphtrail/graphtrail.db` or MiseLedger archive path
 
 This policy owns one release and update contract. `brigade update --channel stable` resolves the
 latest immutable Brigade release, installs that exact CLI version, and runs setup against its
-verified manifest. Beta uses the validated main commit while retaining the verified stable release
-manifest. `brigade setup` resolves the running CLI's exact release manifest; offline automatic
-setup requires a verified exact-release cache. The bundled legacy manifest is available only with
-`--manifest-source standalone`.
+verified manifest. Beta resolves the exact non-yanked PyPI `0.27.0.devYYYYMMDD` wheel while
+retaining the verified stable release manifest. `brigade setup` resolves the running CLI's exact
+release manifest; offline automatic setup requires a verified exact-release cache. The bundled
+legacy manifest is available only with `--manifest-source standalone`.

--- a/docs/update-channels.md
+++ b/docs/update-channels.md
@@ -1,16 +1,17 @@
 # Brigade update channels
 
-`stable` is the immutable release and pinner channel. `beta` is the development channel for
-CI-green `main`. `brigade update` is the supported user-global mutation path for a pipx-managed
-Brigade installation once you want channel-managed upgrades. Deliberate initial or manual exact
-pins such as `pipx install brigade-cli==X.Y.Z` are valid and do not require `brigade update`
-until you choose to move. It resolves immutable coordinates before changing pipx or native
-components, then publishes its state only after both commands succeed.
+`stable` is the immutable release and pinner channel. `beta` is the intentional
+development-machine channel for the `0.27` preview line. `brigade update` is the
+supported user-global mutation path for a pipx-managed Brigade installation once
+you want channel-managed upgrades. Deliberate initial or manual exact pins such
+as `pipx install brigade-cli==X.Y.Z` are valid and do not require `brigade update`
+until you choose to move. It resolves immutable coordinates before changing pipx
+or native components, then publishes its state only after both commands succeed.
 
 | Machine profile | Channel | Use |
 | --- | --- | --- |
 | Production or operator | `stable` | Default. Pins the latest published non-prerelease Brigade release. |
-| Brigade development | `beta` | Intentional development-machine opt-in. Pins a full `main` SHA only when every GitHub check run is terminal and successful, neutral, or skipped. |
+| Brigade development | `beta` | Intentional development-machine opt-in. Pins the newest non-yanked `brigade-cli==0.27.0.devYYYYMMDD` wheel from PyPI. |
 
 Daily development wheels are built from `main` on a schedule and published as PyPI
 prereleases with versions of the form `X.Y.Z.devYYYYMMDD` (for example
@@ -30,18 +31,40 @@ The same pin works with `pip install 'brigade-cli==0.27.0.dev20260808'`. Bare
 `pipx install brigade-cli` or `pip install brigade-cli` resolves the latest stable
 release only; prerelease wheels are never selected as `latest`.
 
-Run `brigade update` for the production default. `brigade update --channel beta` is not a general preview channel. A machine already owned by the other channel fails until the operator supplies `--switch-channel`; a command never transfers ownership implicitly. `--dry-run` resolves and prints the exact commands without changing pipx, managed components, or state.
+Run `brigade update` for the production default. `brigade update --channel beta`
+selects the newest non-yanked exact `0.27.0.devYYYYMMDD` wheel for the `0.27`
+preview line from PyPI, ignores yanked uploads, unrelated preview lines,
+unrelated prereleases, Git refs, and native release assets, and force-reinstalls
+that pin into the existing user-global pipx Brigade environment (one active CLI
+environment; no second installer). A machine already owned by the other channel
+fails until the operator supplies `--switch-channel`; a command never transfers
+ownership implicitly. `--dry-run` resolves and prints the exact planned global
+pipx and setup commands without changing pipx, managed components, or state.
+
+Rollback from beta to stable is explicit:
+
+```bash
+brigade update --channel stable --switch-channel
+```
+
+That path uses the existing stable resolution, native component setup, and state
+publication semantics unchanged.
 
 ## State, lock, and native components
 
-The user-global state is `<Brigade data root>/brigade/update-state.json`, separate from component `installed.json`. Its strict schema records the selected channel, owner, exact CLI version or beta SHA, release id and tag, manifest URL and digest, and timestamp. The shared sibling lock `update.lock` covers both channels. A live owner causes a clear failure. Stale metadata is removed only after its recorded process is confirmed dead.
+The user-global state is `<Brigade data root>/brigade/update-state.json`, separate from component `installed.json`. Its strict schema records the selected channel, owner, exact CLI version (stable release or beta `0.27.0.devYYYYMMDD`), release id and tag, manifest URL and digest, and timestamp. The shared sibling lock `update.lock` covers both channels. A live owner causes a clear failure. Stale metadata is removed only after its recorded process is confirmed dead.
 
-Stable resolves `releases/latest` once, verifies the exact `component-manifest-v1.json` release asset by GitHub digest and size, and accepts only exact `escoffier-labs/brigade` release URLs at the resolved tag. Beta pins the CLI to a checked full `main` SHA but uses the same verified stable component manifest, so beta and stable cannot install different native bytes. During the pre-pin window before a new component such as `agent-notify` first ships on stable, beta may run newer Brigade Python from `main` while native setup still follows the last verified stable manifest; components omitted there are skipped until stable publishes their assets.
+Prior beta state that recorded a full Git `main` SHA is migrated on the next
+successful `brigade update --channel beta` to the selected wheel version and
+wheel-backed pipx pin. Dry-run reports the planned migration actions without
+writing that state.
 
-The daily wheel channel does not change that beta/pre-pin contract. Its build stamps only the
+Stable resolves `releases/latest` once, verifies the exact `component-manifest-v1.json` release asset by GitHub digest and size, and accepts only exact `escoffier-labs/brigade` release URLs at the resolved tag. Beta pins the CLI to the selected PyPI wheel but uses the same verified stable component manifest, so beta and stable cannot install different native bytes. During the pre-pin window before a new component such as `agent-notify` first ships on stable, beta may run newer Brigade Python from a daily wheel while native setup still follows the last verified stable manifest; components omitted there are skipped until stable publishes their assets.
+
+The daily wheel channel does not change that beta/pre-pin native contract. Its build stamps only the
 wheel's Python distribution and runtime version; bundled template and component pins remain the
-committed stable values. Operators who use `brigade update --channel beta` still receive the
-checked `main` SHA plus native bytes from the latest verified stable manifest.
+committed stable values. Operators who use `brigade update --channel beta` receive the
+selected `0.27.0.devYYYYMMDD` wheel plus native bytes from the latest verified stable manifest.
 
 The updater runs `pipx install --force` with an exact requirement, then calls the newly installed absolute `brigade` executable with `setup --manifest <verified-cache-path>`. It does not use the prior executable for setup. This sequence is not an atomic installation transaction: pipx replacement happens before component setup. State publication is transactional, so a failed pipx install or setup leaves the prior update state untouched; rerun the same update to repair components.
 

--- a/docs/update-channels.md
+++ b/docs/update-channels.md
@@ -33,13 +33,14 @@ release only; prerelease wheels are never selected as `latest`.
 
 Run `brigade update` for the production default. `brigade update --channel beta`
 selects the newest non-yanked exact `0.27.0.devYYYYMMDD` wheel for the `0.27`
-preview line from PyPI, ignores yanked uploads, unrelated preview lines,
-unrelated prereleases, Git refs, and native release assets, and force-reinstalls
-that pin into the existing user-global pipx Brigade environment (one active CLI
-environment; no second installer). A machine already owned by the other channel
-fails until the operator supplies `--switch-channel`; a command never transfers
-ownership implicitly. `--dry-run` resolves and prints the exact planned global
-pipx and setup commands without changing pipx, managed components, or state.
+preview line from PyPI release records (never from `info.version`, which stays
+on the latest stable release such as `0.26.1`), ignores yanked uploads, unrelated
+preview lines, unrelated prereleases, Git refs, and native release assets, and
+force-reinstalls that pin into the existing user-global pipx Brigade environment
+(one active CLI environment; no second installer). A machine already owned by the
+other channel fails until the operator supplies `--switch-channel`; a command never
+transfers ownership implicitly. `--dry-run` resolves and prints the exact planned
+global pipx and setup commands without changing pipx, managed components, or state.
 
 Rollback from beta to stable is explicit:
 

--- a/src/brigade/update_cmd.py
+++ b/src/brigade/update_cmd.py
@@ -483,6 +483,11 @@ def _beta_version_has_installable_wheel(files: Any) -> bool:
 def resolve_beta_cli_version(http: UpdateHttp) -> str:
     """Select the newest non-yanked ``0.27.0.devYYYYMMDD`` wheel from PyPI.
 
+    Resolution scans the project JSON ``releases`` map only. PyPI's
+    ``info.version`` field reports the latest *stable* release (for example
+    ``0.26.1`` while a ``0.27.0.devYYYYMMDD`` wheel is present) and is never
+    used as the beta candidate.
+
     Unrelated preview lines, malformed versions, yanked files, sdists-only
     uploads, and Git refs are ignored. Native GitHub release assets are never
     consulted for beta CLI resolution.

--- a/src/brigade/update_cmd.py
+++ b/src/brigade/update_cmd.py
@@ -22,12 +22,14 @@ from brigade import component_manifest, component_paths, localio
 REPOSITORY = "escoffier-labs/brigade"
 STATE_SCHEMA_VERSION = 1
 MANIFEST_ASSET = "component-manifest-v1.json"
+PYPI_PROJECT = "brigade-cli"
+PYPI_PROJECT_JSON_URL = f"https://pypi.org/pypi/{PYPI_PROJECT}/json"
+BETA_PREVIEW_BASE = "0.27.0"
 _SHA256 = re.compile(r"^[0-9a-f]{64}$")
 _SHA = re.compile(r"^[0-9a-f]{40}$")
 _SEMVER = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
 _DIGEST = re.compile(r"^sha256:([0-9a-f]{64})$")
-_CHECK_RUN_PAGE_SIZE = 100
-_MAX_CHECK_RUN_PAGES = 100
+_BETA_DEV_VERSION = re.compile(rf"^{re.escape(BETA_PREVIEW_BASE)}\.dev([0-9]{{8}})$")
 MAX_TAG_DEREFERENCE_DEPTH = 5
 _GITHUB_RELEASE_CDN_HOSTS = frozenset({"release-assets.githubusercontent.com", "objects.githubusercontent.com"})
 _STATE_KEYS = frozenset(
@@ -95,12 +97,14 @@ class _DefaultHttp:
         self,
         url: str,
         *,
+        accept: str,
         final_url_is_allowed: Callable[[str], bool],
         redirect_error: str,
+        request_error: str,
     ) -> bytes:
         request = urllib.request.Request(
             url,
-            headers={"Accept": "application/vnd.github+json", "User-Agent": "brigade-update/1"},
+            headers={"Accept": accept, "User-Agent": "brigade-update/1"},
         )
         try:
             with urllib.request.urlopen(request, timeout=30) as response:
@@ -109,31 +113,57 @@ class _DefaultHttp:
                     raise UpdateError(f"{redirect_error}: {final}")
                 return response.read()
         except urllib.error.HTTPError as exc:
-            raise UpdateError(f"GitHub request failed: {url} HTTP {exc.code}") from exc
+            raise UpdateError(f"{request_error}: {url} HTTP {exc.code}") from exc
         except urllib.error.URLError as exc:
-            raise UpdateError(f"GitHub request failed: {url}") from exc
+            raise UpdateError(f"{request_error}: {url}") from exc
 
     def json(self, url: str) -> Any:
-        if not _is_github_api_url(url):
-            raise UpdateError(f"GitHub API request is not an expected API URL: {url}")
+        if _is_github_api_url(url):
+            accept = "application/vnd.github+json"
+
+            def final_url_is_allowed(final: str) -> bool:
+                return final == url and _is_github_api_url(final)
+
+            redirect_error = "GitHub API request redirected outside its exact expected URL"
+            request_error = "GitHub request failed"
+            invalid_json = f"GitHub request returned invalid JSON: {url}"
+        elif _is_pypi_project_json_url(url):
+            accept = "application/json"
+
+            def final_url_is_allowed(final: str) -> bool:
+                return final == url and _is_pypi_project_json_url(final)
+
+            redirect_error = "PyPI project JSON request redirected outside its exact expected URL"
+            request_error = "PyPI request failed"
+            invalid_json = f"PyPI request returned invalid JSON: {url}"
+        else:
+            raise UpdateError(f"JSON request is not an expected GitHub API or PyPI project URL: {url}")
         try:
             return json.loads(
                 self._read(
                     url,
-                    final_url_is_allowed=lambda final: final == url and _is_github_api_url(final),
-                    redirect_error="GitHub API request redirected outside its exact expected URL",
+                    accept=accept,
+                    final_url_is_allowed=final_url_is_allowed,
+                    redirect_error=redirect_error,
+                    request_error=request_error,
                 ).decode("utf-8")
             )
         except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-            raise UpdateError(f"GitHub request returned invalid JSON: {url}") from exc
+            raise UpdateError(invalid_json) from exc
 
     def bytes(self, url: str) -> bytes:
         if not _is_manifest_release_url(url):
             raise UpdateError(f"GitHub release asset is not an exact manifest URL: {url}")
+
+        def final_url_is_allowed(final: str) -> bool:
+            return _is_release_asset_redirect(final, original=url)
+
         return self._read(
             url,
-            final_url_is_allowed=lambda final: _is_release_asset_redirect(final, original=url),
+            accept="application/octet-stream",
+            final_url_is_allowed=final_url_is_allowed,
             redirect_error="GitHub release asset redirected outside trusted HTTPS CDN hosts",
+            request_error="GitHub request failed",
         )
 
 
@@ -245,7 +275,7 @@ def _is_github_api_url(url: Any) -> bool:
     ):
         return False
     prefix = f"/repos/{REPOSITORY}/"
-    if parsed.path in {f"{prefix}releases/latest", f"{prefix}commits/main"}:
+    if parsed.path == f"{prefix}releases/latest":
         return not parsed.query
     tag = parsed.path.removeprefix(f"{prefix}releases/tags/")
     if parsed.path == f"{prefix}releases/tags/{tag}" and _parse_tag(tag) is not None:
@@ -256,16 +286,21 @@ def _is_github_api_url(url: Any) -> bool:
     tag_object = parsed.path.removeprefix(f"{prefix}git/tags/")
     if parsed.path == f"{prefix}git/tags/{tag_object}" and _SHA.fullmatch(tag_object) is not None:
         return not parsed.query
-    check_prefix = f"{prefix}commits/"
-    if not parsed.path.startswith(check_prefix) or not parsed.path.endswith("/check-runs"):
+    return False
+
+
+def _is_pypi_project_json_url(url: Any) -> bool:
+    if not isinstance(url, str):
         return False
-    sha = parsed.path[len(check_prefix) : -len("/check-runs")]
-    if not _SHA.fullmatch(sha):
-        return False
+    parsed = urlparse(url)
     return (
-        parsed.query.startswith(f"per_page={_CHECK_RUN_PAGE_SIZE}&page=")
-        and parsed.query.removeprefix(f"per_page={_CHECK_RUN_PAGE_SIZE}&page=").isdigit()
-        and int(parsed.query.removeprefix(f"per_page={_CHECK_RUN_PAGE_SIZE}&page=")) > 0
+        parsed.scheme == "https"
+        and parsed.netloc == "pypi.org"
+        and parsed.path == f"/pypi/{PYPI_PROJECT}/json"
+        and not parsed.query
+        and not parsed.fragment
+        and parsed.username is None
+        and parsed.password is None
     )
 
 
@@ -423,52 +458,56 @@ def _cache_manifest(paths: UpdatePaths, release: ResolvedRelease) -> Path:
     return target
 
 
-def _check_beta(http: UpdateHttp) -> str:
-    commit = http.json(f"https://api.github.com/repos/{REPOSITORY}/commits/main")
-    sha = commit.get("sha") if isinstance(commit, dict) else None
-    if not isinstance(sha, str) or not _SHA.fullmatch(sha):
-        raise UpdateError("GitHub main resolution did not return a full commit SHA")
-    all_runs: list[dict[str, Any]] = []
-    seen_ids: set[int] = set()
-    total_count: int | None = None
-    for page in range(1, _MAX_CHECK_RUN_PAGES + 1):
-        checks = http.json(
-            f"https://api.github.com/repos/{REPOSITORY}/commits/{sha}/check-runs?per_page={_CHECK_RUN_PAGE_SIZE}&page={page}"
+def _parse_beta_dev_version(version: Any) -> str | None:
+    """Return YYYYMMDD when version is exactly ``0.27.0.devYYYYMMDD``."""
+    if not isinstance(version, str):
+        return None
+    match = _BETA_DEV_VERSION.fullmatch(version)
+    return match.group(1) if match is not None else None
+
+
+def _is_installable_wheel_file(entry: Any) -> bool:
+    if not isinstance(entry, dict) or entry.get("yanked") is True:
+        return False
+    filename = entry.get("filename")
+    packagetype = entry.get("packagetype")
+    if not isinstance(filename, str) or not filename.endswith(".whl"):
+        return False
+    return packagetype in {None, "bdist_wheel"}
+
+
+def _beta_version_has_installable_wheel(files: Any) -> bool:
+    return isinstance(files, list) and any(_is_installable_wheel_file(entry) for entry in files)
+
+
+def resolve_beta_cli_version(http: UpdateHttp) -> str:
+    """Select the newest non-yanked ``0.27.0.devYYYYMMDD`` wheel from PyPI.
+
+    Unrelated preview lines, malformed versions, yanked files, sdists-only
+    uploads, and Git refs are ignored. Native GitHub release assets are never
+    consulted for beta CLI resolution.
+    """
+    raw = http.json(PYPI_PROJECT_JSON_URL)
+    releases = raw.get("releases") if isinstance(raw, dict) else None
+    if not isinstance(releases, dict):
+        raise UpdateError("PyPI project JSON is missing its releases map; beta fails closed")
+    candidates: list[str] = []
+    for version, files in releases.items():
+        if _parse_beta_dev_version(version) is None:
+            continue
+        if not _beta_version_has_installable_wheel(files):
+            continue
+        candidates.append(version)
+    if not candidates:
+        raise UpdateError(
+            f"no non-yanked {BETA_PREVIEW_BASE}.devYYYYMMDD {PYPI_PROJECT} wheel on PyPI; beta fails closed"
         )
-        page_total = checks.get("total_count") if isinstance(checks, dict) else None
-        runs = checks.get("check_runs") if isinstance(checks, dict) else None
-        if (
-            not isinstance(page_total, int)
-            or isinstance(page_total, bool)
-            or page_total <= 0
-            or not isinstance(runs, list)
-        ):
-            raise UpdateError("GitHub main check-runs payload is incomplete or malformed; beta fails closed")
-        if total_count is None:
-            total_count = page_total
-            if total_count > _MAX_CHECK_RUN_PAGES * _CHECK_RUN_PAGE_SIZE:
-                raise UpdateError("GitHub main has too many check runs to validate; beta fails closed")
-        elif page_total != total_count:
-            raise UpdateError("GitHub main check-runs pages disagree on total_count; beta fails closed")
-        expected_count = min(_CHECK_RUN_PAGE_SIZE, total_count - len(all_runs))
-        if len(runs) != expected_count:
-            raise UpdateError("GitHub main check-runs page is incomplete; beta fails closed")
-        for run in runs:
-            run_id = run.get("id") if isinstance(run, dict) else None
-            if (
-                not isinstance(run_id, int)
-                or isinstance(run_id, bool)
-                or run_id <= 0
-                or run_id in seen_ids
-                or run.get("status") != "completed"
-                or run.get("conclusion") not in {"success", "neutral", "skipped"}
-            ):
-                raise UpdateError("GitHub main has a non-successful or malformed check run; beta fails closed")
-            seen_ids.add(run_id)
-            all_runs.append(run)
-        if len(all_runs) == total_count:
-            return sha
-    raise UpdateError("GitHub main check-runs pagination exceeded validation limit; beta fails closed")
+    return max(candidates)
+
+
+def is_legacy_beta_git_sha(coordinate: str) -> bool:
+    """True when prior beta state pinned a full Git main SHA instead of a wheel."""
+    return bool(_SHA.fullmatch(coordinate))
 
 
 class _UpdateLock:
@@ -574,7 +613,7 @@ def run_update(
                 release,
                 allow_compatible_stable_manifest=channel == "beta",
             )
-            coordinate = release.version if channel == "stable" else _check_beta(selected_http)
+            coordinate = release.version if channel == "stable" else resolve_beta_cli_version(selected_http)
             compatible_manifest_version = manifest.brigade_version if channel == "beta" else None
             if compatible_manifest_version is not None and compatible_manifest_version != release.version:
                 raise UpdateError("beta stable manifest compatibility handoff is internally inconsistent")
@@ -593,11 +632,9 @@ def run_update(
             if current is not None and _same_coordinates(current, next_state):
                 print(f"brigade update: {channel} already owns {coordinate}; no changes")
                 return 0
-            pipx_spec = (
-                f"brigade-cli=={coordinate}"
-                if channel == "stable"
-                else f"git+https://github.com/{REPOSITORY}@{coordinate}"
-            )
+            # Stable and beta both force-reinstall the one user-global pipx app
+            # with an exact package pin. Beta never uses a mutable Git main SHA.
+            pipx_spec = f"{PYPI_PROJECT}=={coordinate}"
             cached_manifest_path = Path(
                 component_paths.verified_manifest_path(str(selected_paths.cache_root), release.manifest_sha256)
             )

--- a/tests/test_update_cmd.py
+++ b/tests/test_update_cmd.py
@@ -139,28 +139,46 @@ class _Http:
         return self.manifest
 
 
-class _BetaHttp(_Http):
-    def __init__(self, release, manifest, *, sha="b" * 40, pages=None):
-        super().__init__(release, manifest)
-        self.sha = sha
-        self.pages = pages or {
-            1: {"total_count": 1, "check_runs": [{"id": 1, "status": "completed", "conclusion": "success"}]}
-        }
+def _wheel_file(version: str, *, yanked: bool = False, packagetype: str = "bdist_wheel") -> dict:
+    return {
+        "filename": f"brigade_cli-{version}-py3-none-any.whl",
+        "packagetype": packagetype,
+        "yanked": yanked,
+    }
+
+
+def _sdist_file(version: str, *, yanked: bool = False) -> dict:
+    return {
+        "filename": f"brigade_cli-{version}.tar.gz",
+        "packagetype": "sdist",
+        "yanked": yanked,
+    }
+
+
+class _PypiHttp(_Http):
+    def __init__(self, release, manifest, *, pypi_releases=None, tag_ref=None, tag_objects=None):
+        super().__init__(release, manifest, tag_ref=tag_ref, tag_objects=tag_objects)
+        self.pypi_releases = pypi_releases if pypi_releases is not None else _default_beta_releases()
 
     def json(self, url):
         self.urls.append(url)
+        if url == update_cmd.PYPI_PROJECT_JSON_URL:
+            return {"releases": self.pypi_releases}
         if url.endswith("/releases/latest"):
             return self.release
         if url == REF_URL:
             return self.tag_ref
         if url.startswith(TAG_OBJECT_URL):
             return self.tag_objects[url.removeprefix(TAG_OBJECT_URL)]
-        if url.endswith("/commits/main"):
-            return {"sha": self.sha}
-        prefix = f"https://api.github.com/repos/escoffier-labs/brigade/commits/{self.sha}/check-runs?per_page=100&page="
-        if url.startswith(prefix):
-            return self.pages[int(url.removeprefix(prefix))]
         raise AssertionError(url)
+
+
+def _default_beta_releases() -> dict:
+    version = "0.27.0.dev20260808"
+    return {version: [_wheel_file(version)]}
+
+
+BETA_VERSION = "0.27.0.dev20260808"
 
 
 class _Response:
@@ -264,66 +282,89 @@ def test_cache_manifest_rejects_existing_bytes_for_the_same_digest_path(tmp_path
         update_cmd._cache_manifest(paths, release)
 
 
-def test_beta_check_runs_paginate_and_require_every_run_to_pass():
-    sha = "b" * 40
-    pages = {
-        1: {
-            "total_count": 101,
-            "check_runs": [{"id": index, "status": "completed", "conclusion": "success"} for index in range(1, 101)],
-        },
-        2: {"total_count": 101, "check_runs": [{"id": 101, "status": "completed", "conclusion": "neutral"}]},
+def test_resolve_beta_cli_version_selects_newest_non_yanked_0_27_dev_wheel():
+    releases = {
+        "0.27.0.dev20260801": [_wheel_file("0.27.0.dev20260801")],
+        "0.27.0.dev20260810": [_wheel_file("0.27.0.dev20260810", yanked=True)],
+        "0.27.0.dev20260809": [_wheel_file("0.27.0.dev20260809")],
+        "0.27.0.dev20260808": [_sdist_file("0.27.0.dev20260808")],
+        "0.26.0.dev20260811": [_wheel_file("0.26.0.dev20260811")],
+        "0.28.0.dev20260811": [_wheel_file("0.28.0.dev20260811")],
+        "0.27.0.dev2026080": [_wheel_file("0.27.0.dev2026080")],
+        "0.27.0.dev202608091": [_wheel_file("0.27.0.dev202608091")],
+        "0.27.0a1": [_wheel_file("0.27.0a1")],
+        "0.27.0rc1": [_wheel_file("0.27.0rc1")],
+        "0.27.0.dev20260809.post1": [_wheel_file("0.27.0.dev20260809.post1")],
+        "0.27.1.dev20260811": [_wheel_file("0.27.1.dev20260811")],
+        "1.2.3": [_wheel_file("1.2.3")],
+        "main": [_wheel_file("main")],
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": [_wheel_file("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")],
     }
-    http = _BetaHttp(_release(_manifest()), _manifest(), sha=sha, pages=pages)
-    assert update_cmd._check_beta(http) == sha
-    assert http.urls[-2:] == [
-        f"https://api.github.com/repos/escoffier-labs/brigade/commits/{sha}/check-runs?per_page=100&page=1",
-        f"https://api.github.com/repos/escoffier-labs/brigade/commits/{sha}/check-runs?per_page=100&page=2",
-    ]
+    http = _PypiHttp(_release(_manifest()), _manifest(), pypi_releases=releases)
+
+    assert update_cmd.resolve_beta_cli_version(http) == "0.27.0.dev20260809"
+    assert update_cmd.PYPI_PROJECT_JSON_URL in http.urls
 
 
 @pytest.mark.parametrize(
-    "payload",
+    "releases",
     (
-        {"total_count": 0, "check_runs": []},
-        {"total_count": 1, "check_runs": [{"id": 1, "status": "in_progress", "conclusion": None}]},
-        {"total_count": 1, "check_runs": [{"id": 1, "status": "completed", "conclusion": "failure"}]},
-        {"total_count": 1, "check_runs": [{"id": 1, "status": "completed", "conclusion": "cancelled"}]},
-        {"total_count": 1, "check_runs": [{"id": 1, "status": "completed", "conclusion": "timed_out"}]},
-        {"total_count": "1", "check_runs": []},
-        {"total_count": 1, "check_runs": [{"status": "completed", "conclusion": "success"}]},
+        {},
+        {"0.27.0.dev20260808": []},
+        {"0.27.0.dev20260808": [_wheel_file("0.27.0.dev20260808", yanked=True)]},
+        {"0.27.0.dev20260808": [_sdist_file("0.27.0.dev20260808")]},
+        {"0.27.0.dev20260808": "not-a-list"},
+        {"0.27.0.dev2026080": [_wheel_file("0.27.0.dev2026080")]},
+        {"0.28.0.dev20260808": [_wheel_file("0.28.0.dev20260808")]},
+        {"0.27.0a1": [_wheel_file("0.27.0a1")]},
     ),
 )
-def test_beta_check_runs_fail_closed_for_missing_pending_failed_or_malformed_runs(payload):
-    http = _BetaHttp(_release(_manifest()), _manifest(), pages={1: payload})
+def test_resolve_beta_cli_version_fails_closed_without_installable_preview_wheel(releases):
+    http = _PypiHttp(_release(_manifest()), _manifest(), pypi_releases=releases)
     with pytest.raises(update_cmd.UpdateError, match="beta fails closed"):
-        update_cmd._check_beta(http)
+        update_cmd.resolve_beta_cli_version(http)
 
 
-def test_beta_check_runs_reject_truncated_or_inconsistent_pages():
-    http = _BetaHttp(
-        _release(_manifest()),
-        _manifest(),
-        pages={
-            1: {"total_count": 101, "check_runs": [{"id": 1, "status": "completed", "conclusion": "success"}]},
-        },
-    )
-    with pytest.raises(update_cmd.UpdateError, match="beta fails closed"):
-        update_cmd._check_beta(http)
+def test_resolve_beta_cli_version_fails_closed_when_releases_map_missing():
+    class _MissingReleases:
+        urls: list[str]
+
+        def __init__(self) -> None:
+            self.urls = []
+
+        def json(self, url: str):
+            self.urls.append(url)
+            assert url == update_cmd.PYPI_PROJECT_JSON_URL
+            return {"info": {"version": "1.2.3"}}
+
+        def bytes(self, url: str) -> bytes:
+            raise AssertionError(url)
+
+    with pytest.raises(update_cmd.UpdateError, match="releases map"):
+        update_cmd.resolve_beta_cli_version(_MissingReleases())
 
 
-def test_beta_check_runs_reject_inconsistent_or_duplicate_later_pages():
-    successful_runs = [{"id": index, "status": "completed", "conclusion": "success"} for index in range(1, 101)]
-    for second_page in (
-        {"total_count": 100, "check_runs": []},
-        {"total_count": 101, "check_runs": [{"id": 1, "status": "completed", "conclusion": "success"}]},
-    ):
-        http = _BetaHttp(
-            _release(_manifest()),
-            _manifest(),
-            pages={1: {"total_count": 101, "check_runs": successful_runs}, 2: second_page},
-        )
-        with pytest.raises(update_cmd.UpdateError, match="beta fails closed"):
-            update_cmd._check_beta(http)
+def test_resolve_beta_cli_version_ignores_yanked_sibling_and_keeps_older_wheel():
+    releases = {
+        "0.27.0.dev20260810": [_wheel_file("0.27.0.dev20260810", yanked=True)],
+        "0.27.0.dev20260809": [
+            _wheel_file("0.27.0.dev20260809", yanked=True),
+            _wheel_file("0.27.0.dev20260809"),
+        ],
+        "0.27.0.dev20260801": [_wheel_file("0.27.0.dev20260801")],
+    }
+    http = _PypiHttp(_release(_manifest()), _manifest(), pypi_releases=releases)
+    assert update_cmd.resolve_beta_cli_version(http) == "0.27.0.dev20260809"
+
+
+def test_parse_beta_dev_version_accepts_only_exact_0_27_daily_form():
+    assert update_cmd._parse_beta_dev_version("0.27.0.dev20260808") == "20260808"
+    assert update_cmd._parse_beta_dev_version("0.27.0.dev2026080") is None
+    assert update_cmd._parse_beta_dev_version("0.28.0.dev20260808") is None
+    assert update_cmd._parse_beta_dev_version("0.27.0a1") is None
+    assert update_cmd._parse_beta_dev_version("b" * 40) is None
+    assert update_cmd.is_legacy_beta_git_sha("b" * 40)
+    assert not update_cmd.is_legacy_beta_git_sha(BETA_VERSION)
 
 
 def test_stable_update_installs_exact_release_then_new_binary_setup(tmp_path):
@@ -425,11 +466,23 @@ def test_github_api_url_allowlist_only_adds_exact_tag_ref_and_tag_object_endpoin
 
     assert update_cmd._is_github_api_url(REF_URL)
     assert update_cmd._is_github_api_url(TAG_OBJECT_URL + sha)
+    assert update_cmd._is_github_api_url("https://api.github.com/repos/escoffier-labs/brigade/releases/latest")
+    assert not update_cmd._is_github_api_url("https://api.github.com/repos/escoffier-labs/brigade/commits/main")
+    assert not update_cmd._is_github_api_url(
+        f"https://api.github.com/repos/escoffier-labs/brigade/commits/{sha}/check-runs?per_page=100&page=1"
+    )
     assert not update_cmd._is_github_api_url(f"https://api.github.com/repos/other/brigade/git/ref/tags/{TAG}")
     assert not update_cmd._is_github_api_url(
         f"https://api.github.com/repos/escoffier-labs/brigade/git/ref/tags/{TAG}?x=1"
     )
     assert not update_cmd._is_github_api_url(f"https://api.github.com/repos/escoffier-labs/brigade/git/tags/{sha}?x=1")
+
+
+def test_pypi_project_json_url_allowlist_is_exact():
+    assert update_cmd._is_pypi_project_json_url(update_cmd.PYPI_PROJECT_JSON_URL)
+    assert not update_cmd._is_pypi_project_json_url("https://pypi.org/pypi/brigade-cli/json?foo=1")
+    assert not update_cmd._is_pypi_project_json_url("https://pypi.org/pypi/other/json")
+    assert not update_cmd._is_pypi_project_json_url("http://pypi.org/pypi/brigade-cli/json")
 
 
 def test_default_paths_uses_configured_pipx_bin_dir(monkeypatch, tmp_path):
@@ -461,9 +514,8 @@ def test_release_manifest_rejects_component_revision_mismatched_to_target_commit
         update_cmd.validate_release_manifest_bytes(release)
 
 
-def test_beta_update_installs_full_main_sha_and_reuses_verified_stable_manifest(tmp_path):
+def test_beta_update_installs_exact_dev_wheel_and_reuses_verified_stable_manifest(tmp_path):
     manifest = _manifest()
-    sha = "b" * 40
     commands = []
     installed_binary = tmp_path / "bin" / "brigade"
     paths = update_cmd.UpdatePaths(tmp_path / "data", tmp_path / "cache", installed_binary)
@@ -472,7 +524,7 @@ def test_beta_update_installs_full_main_sha_and_reuses_verified_stable_manifest(
         update_cmd.run_update(
             channel="beta",
             paths=paths,
-            http=_BetaHttp(_release(manifest), manifest, sha=sha),
+            http=_PypiHttp(_release(manifest), manifest),
             runner=lambda argv: commands.append(argv) or 0,
             now=lambda: "2026-07-20T12:00:00+00:00",
         )
@@ -481,7 +533,7 @@ def test_beta_update_installs_full_main_sha_and_reuses_verified_stable_manifest(
     cache_path = paths.cache_root / "brigade" / "release-manifests" / f"{hashlib.sha256(manifest).hexdigest()}.json"
     assert cache_path.read_bytes() == manifest
     assert commands == [
-        ["pipx", "install", "--force", f"git+https://github.com/escoffier-labs/brigade@{sha}"],
+        ["pipx", "install", "--force", f"brigade-cli=={BETA_VERSION}"],
         [
             str(installed_binary),
             "setup",
@@ -494,7 +546,7 @@ def test_beta_update_installs_full_main_sha_and_reuses_verified_stable_manifest(
     state = update_cmd.load_update_state(paths.data_root / "brigade" / "update-state.json")
     assert state is not None
     assert state.channel == "beta"
-    assert state.cli_coordinate == sha
+    assert state.cli_coordinate == BETA_VERSION
     assert (state.component_release_id, state.component_tag) == (42, TAG)
 
 
@@ -504,7 +556,6 @@ def test_beta_update_accepts_pre_agent_notify_stable_manifest(tmp_path):
     # KNOWN_COMPONENT_IDS on main but before the first stable release publishing
     # it downloads the last stable manifest, which has no agent-notify entry.
     manifest = _pre_agent_notify_manifest()
-    sha = "b" * 40
     commands = []
     installed_binary = tmp_path / "bin" / "brigade"
     paths = update_cmd.UpdatePaths(tmp_path / "data", tmp_path / "cache", installed_binary)
@@ -513,7 +564,7 @@ def test_beta_update_accepts_pre_agent_notify_stable_manifest(tmp_path):
         update_cmd.run_update(
             channel="beta",
             paths=paths,
-            http=_BetaHttp(_release(manifest), manifest, sha=sha),
+            http=_PypiHttp(_release(manifest), manifest),
             runner=lambda argv: commands.append(argv) or 0,
             now=lambda: "2026-07-20T12:00:00+00:00",
         )
@@ -522,7 +573,7 @@ def test_beta_update_accepts_pre_agent_notify_stable_manifest(tmp_path):
     cache_path = paths.cache_root / "brigade" / "release-manifests" / f"{hashlib.sha256(manifest).hexdigest()}.json"
     assert cache_path.read_bytes() == manifest
     assert commands == [
-        ["pipx", "install", "--force", f"git+https://github.com/escoffier-labs/brigade@{sha}"],
+        ["pipx", "install", "--force", f"brigade-cli=={BETA_VERSION}"],
         [
             str(installed_binary),
             "setup",
@@ -535,7 +586,7 @@ def test_beta_update_accepts_pre_agent_notify_stable_manifest(tmp_path):
     state = update_cmd.load_update_state(paths.data_root / "brigade" / "update-state.json")
     assert state is not None
     assert state.channel == "beta"
-    assert state.cli_coordinate == sha
+    assert state.cli_coordinate == BETA_VERSION
     assert (state.component_release_id, state.component_tag) == (42, TAG)
 
 
@@ -585,7 +636,6 @@ def test_release_manifest_compatibility_mode_rejects_missing_published_component
 
 def test_beta_same_coordinates_are_a_noop(tmp_path):
     manifest = _manifest()
-    sha = "b" * 40
     paths = update_cmd.UpdatePaths(tmp_path / "data", tmp_path / "cache", tmp_path / "bin" / "brigade")
     update_cmd.write_update_state(
         paths.data_root / "brigade" / "update-state.json",
@@ -593,7 +643,7 @@ def test_beta_same_coordinates_are_a_noop(tmp_path):
             1,
             "beta",
             "brigade update",
-            sha,
+            BETA_VERSION,
             42,
             TAG,
             "a" * 40,
@@ -607,12 +657,52 @@ def test_beta_same_coordinates_are_a_noop(tmp_path):
         update_cmd.run_update(
             channel="beta",
             paths=paths,
-            http=_BetaHttp(_release(manifest), manifest, sha=sha),
+            http=_PypiHttp(_release(manifest), manifest),
             runner=calls.append,
         )
         == 0
     )
     assert calls == []
+
+
+def test_beta_update_migrates_git_sha_state_to_exact_wheel_version(tmp_path):
+    manifest = _manifest()
+    sha = "b" * 40
+    paths = update_cmd.UpdatePaths(tmp_path / "data", tmp_path / "cache", tmp_path / "bin" / "brigade")
+    state_path = paths.data_root / "brigade" / "update-state.json"
+    update_cmd.write_update_state(
+        state_path,
+        update_cmd.UpdateState(
+            1,
+            "beta",
+            "brigade update",
+            sha,
+            41,
+            "v1.2.2",
+            "a" * 40,
+            "https://github.com/escoffier-labs/brigade/releases/download/v1.2.2/component-manifest-v1.json",
+            "a" * 64,
+            "2026-07-20T12:00:00+00:00",
+        ),
+    )
+    assert update_cmd.is_legacy_beta_git_sha(sha)
+    commands = []
+    assert (
+        update_cmd.run_update(
+            channel="beta",
+            paths=paths,
+            http=_PypiHttp(_release(manifest), manifest),
+            runner=lambda argv: commands.append(argv) or 0,
+            now=lambda: "2026-07-20T12:05:00+00:00",
+        )
+        == 0
+    )
+    assert commands[0] == ["pipx", "install", "--force", f"brigade-cli=={BETA_VERSION}"]
+    state = update_cmd.load_update_state(state_path)
+    assert state is not None
+    assert state.channel == "beta"
+    assert state.cli_coordinate == BETA_VERSION
+    assert not update_cmd.is_legacy_beta_git_sha(state.cli_coordinate)
 
 
 def test_beta_setup_failure_leaves_prior_update_state_unchanged(tmp_path):
@@ -625,7 +715,7 @@ def test_beta_setup_failure_leaves_prior_update_state_unchanged(tmp_path):
             1,
             "beta",
             "brigade update",
-            "a" * 40,
+            "0.27.0.dev20260701",
             41,
             "v1.2.2",
             "a" * 40,
@@ -640,12 +730,110 @@ def test_beta_setup_failure_leaves_prior_update_state_unchanged(tmp_path):
         update_cmd.run_update(
             channel="beta",
             paths=paths,
-            http=_BetaHttp(_release(manifest), manifest),
+            http=_PypiHttp(_release(manifest), manifest),
             runner=lambda _argv: next(returns),
         )
         == 1
     )
     assert state_path.read_bytes() == before
+
+
+def test_beta_dry_run_prints_exact_pipx_pin_and_mutates_nothing(tmp_path, capsys):
+    manifest = _manifest()
+    paths = update_cmd.UpdatePaths(tmp_path / "data", tmp_path / "cache", tmp_path / "bin" / "brigade")
+    state_path = paths.data_root / "brigade" / "update-state.json"
+    update_cmd.write_update_state(
+        state_path,
+        update_cmd.UpdateState(
+            1,
+            "beta",
+            "brigade update",
+            "b" * 40,
+            41,
+            "v1.2.2",
+            "a" * 40,
+            "https://github.com/escoffier-labs/brigade/releases/download/v1.2.2/component-manifest-v1.json",
+            "a" * 64,
+            "2026-07-20T12:00:00+00:00",
+        ),
+    )
+    before = state_path.read_bytes()
+    calls = []
+
+    assert (
+        update_cmd.run_update(
+            channel="beta",
+            dry_run=True,
+            paths=paths,
+            http=_PypiHttp(_release(manifest), manifest),
+            runner=calls.append,
+        )
+        == 0
+    )
+    captured = capsys.readouterr().out
+    assert f"pipx install --force brigade-cli=={BETA_VERSION}" in captured
+    assert str(paths.brigade_executable) in captured
+    assert calls == []
+    assert state_path.read_bytes() == before
+    assert not paths.cache_root.exists()
+
+
+def test_rollback_from_beta_to_stable_uses_stable_path_and_state(tmp_path):
+    manifest = _manifest()
+    paths = update_cmd.UpdatePaths(tmp_path / "data", tmp_path / "cache", tmp_path / "bin" / "brigade")
+    update_cmd.write_update_state(
+        paths.data_root / "brigade" / "update-state.json",
+        update_cmd.UpdateState(
+            1,
+            "beta",
+            "brigade update",
+            BETA_VERSION,
+            41,
+            "v1.2.2",
+            "a" * 40,
+            "https://github.com/escoffier-labs/brigade/releases/download/v1.2.2/component-manifest-v1.json",
+            "a" * 64,
+            "2026-07-20T12:00:00+00:00",
+        ),
+    )
+    commands = []
+    assert (
+        update_cmd.run_update(
+            channel="stable",
+            switch_channel=True,
+            paths=paths,
+            http=_Http(_release(manifest), manifest),
+            runner=lambda argv: commands.append(argv) or 0,
+            now=lambda: "2026-07-20T12:10:00+00:00",
+        )
+        == 0
+    )
+    assert commands[0] == ["pipx", "install", "--force", "brigade-cli==1.2.3"]
+    assert "--allow-compatible-stable-manifest" not in commands[1]
+    state = update_cmd.load_update_state(paths.data_root / "brigade" / "update-state.json")
+    assert state is not None
+    assert state.channel == "stable"
+    assert state.cli_coordinate == "1.2.3"
+    assert state.component_tag == TAG
+
+
+def test_stable_update_regression_still_pins_exact_release_without_pypi_lookup(tmp_path):
+    manifest = _manifest()
+    commands = []
+    http = _Http(_release(manifest), manifest)
+    assert (
+        update_cmd.run_update(
+            channel="stable",
+            paths=update_cmd.UpdatePaths(tmp_path / "data", tmp_path / "cache", tmp_path / "bin" / "brigade"),
+            http=http,
+            runner=lambda argv: commands.append(argv) or 0,
+            now=lambda: "2026-07-20T12:00:00+00:00",
+        )
+        == 0
+    )
+    assert commands[0] == ["pipx", "install", "--force", "brigade-cli==1.2.3"]
+    assert update_cmd.PYPI_PROJECT_JSON_URL not in http.urls
+    assert all("/commits/main" not in url and "check-runs" not in url for url in http.urls)
 
 
 def test_update_refuses_channel_takeover_without_switch_flag(tmp_path):

--- a/tests/test_update_cmd.py
+++ b/tests/test_update_cmd.py
@@ -156,14 +156,26 @@ def _sdist_file(version: str, *, yanked: bool = False) -> dict:
 
 
 class _PypiHttp(_Http):
-    def __init__(self, release, manifest, *, pypi_releases=None, tag_ref=None, tag_objects=None):
+    def __init__(
+        self,
+        release,
+        manifest,
+        *,
+        pypi_releases=None,
+        info_version: str = "0.26.1",
+        tag_ref=None,
+        tag_objects=None,
+    ):
         super().__init__(release, manifest, tag_ref=tag_ref, tag_objects=tag_objects)
         self.pypi_releases = pypi_releases if pypi_releases is not None else _default_beta_releases()
+        self.info_version = info_version
 
     def json(self, url):
         self.urls.append(url)
         if url == update_cmd.PYPI_PROJECT_JSON_URL:
-            return {"releases": self.pypi_releases}
+            # Mirror live PyPI: info.version stays on the latest stable release
+            # even when releases contains 0.27.0.devYYYYMMDD wheels.
+            return {"info": {"version": self.info_version}, "releases": self.pypi_releases}
         if url.endswith("/releases/latest"):
             return self.release
         if url == REF_URL:
@@ -325,6 +337,38 @@ def test_resolve_beta_cli_version_fails_closed_without_installable_preview_wheel
         update_cmd.resolve_beta_cli_version(http)
 
 
+def test_resolve_beta_cli_version_scans_releases_not_info_version():
+    """Live PyPI shape after workflow 31422458576: info.version stays stable."""
+    releases = {
+        "0.26.1": [_wheel_file("0.26.1")],
+        "0.27.0.dev20260810": [_wheel_file("0.27.0.dev20260810")],
+    }
+    http = _PypiHttp(
+        _release(_manifest()),
+        _manifest(),
+        pypi_releases=releases,
+        info_version="0.26.1",
+    )
+
+    assert update_cmd.resolve_beta_cli_version(http) == "0.27.0.dev20260810"
+    assert http.info_version == "0.26.1"
+
+
+def test_resolve_beta_cli_version_ignores_info_version_even_when_it_looks_like_a_dev_wheel():
+    releases = {
+        "0.26.1": [_wheel_file("0.26.1")],
+        "0.27.0.dev20260810": [_wheel_file("0.27.0.dev20260810")],
+    }
+    http = _PypiHttp(
+        _release(_manifest()),
+        _manifest(),
+        pypi_releases=releases,
+        info_version="0.27.0.dev20991231",
+    )
+
+    assert update_cmd.resolve_beta_cli_version(http) == "0.27.0.dev20260810"
+
+
 def test_resolve_beta_cli_version_fails_closed_when_releases_map_missing():
     class _MissingReleases:
         urls: list[str]
@@ -335,7 +379,7 @@ def test_resolve_beta_cli_version_fails_closed_when_releases_map_missing():
         def json(self, url: str):
             self.urls.append(url)
             assert url == update_cmd.PYPI_PROJECT_JSON_URL
-            return {"info": {"version": "1.2.3"}}
+            return {"info": {"version": "0.26.1"}}
 
         def bytes(self, url: str) -> bytes:
             raise AssertionError(url)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements #852: `brigade update --channel beta` now installs the newest non-yanked exact `brigade-cli==0.27.0.devYYYYMMDD` wheel for the 0.27 preview line from PyPI into the existing user-global pipx environment. Prior beta state that recorded a Git `main` SHA migrates to that wheel pin. Stable resolution, native component handling, dry-run non-mutation, and explicit rollback via `--channel stable --switch-channel` stay on the existing stable path.

Protected parallel-work files were not touched (`src/brigade/install.py`, `.github/workflows/publish.yml`, `scripts/verify_version_check_endpoint.py`, `tests/test_publish_workflow.py`). No code was added to defend against arbitrary out-of-band pipx installs.

## Docs repair (comment 5245616181)

Head `a8654129012bbd20d3d7e3626d9e66c1c688b916` corrects `docs/component-manifest-policy.md` Current boundaries so beta resolves the exact non-yanked PyPI `0.27.0.devYYYYMMDD` wheel while retaining the verified stable manifest (no longer “validated main commit”).

Fresh checks on that repair:
- `brigade guard scan docs/component-manifest-policy.md --policy src/brigade/guard/policies/public-content.json` → clean; Brigade receipt `20260810-211116-work-verify-f1e7ab`
- `brigade scrub --policy public-content --target docs/component-manifest-policy.md --dry-run` → would run the same clean scan
- `BRIGADE_EXTRAS=1 brigade release plan/doctor --base-ref origin/main` → docs changed_files include the policy doc; no new docs/prose finding on the repaired sentence (pre-existing release readiness blockers unrelated to this docs-only change)
- `brigade handoff lint --strict` and `--content-guard --strict` on the local #852 handoff → ok / content_guard clean

## Contract

- Beta resolves `https://pypi.org/pypi/brigade-cli/json` and selects `max(0.27.0.devYYYYMMDD)` among versions with at least one non-yanked `.whl`
- Selection scans the project JSON **`releases` map only**; PyPI `info.version` (stable latest, currently `0.26.1`) is never treated as the beta candidate — matching the live shape after workflow [`31422458576`](https://github.com/escoffier-labs/brigade/actions/runs/31422458576) which published non-yanked `brigade-cli==0.27.0.dev20260810`
- Ignores yanked uploads, sdist-only versions, malformed versions, unrelated preview lines, unrelated prereleases, Git refs, and native release assets
- pipx action is always `pipx install --force brigade-cli==<exact>` against the one existing CLI environment
- `--dry-run` prints the planned global pipx/setup commands and mutates nothing
- Rollback: `brigade update --channel stable --switch-channel`

## Verification receipts

Full gate:

```bash
brigade work verify run --target . --command './scripts/verify' --capture brigade-work --timeout 7200 --no-reuse
```

- Receipt: `20260810-192239-work-verify-e059f8`
- Status: `completed`, command exit `0`
- Tests: **6703 passed, 5 skipped, 68 subtests passed** in 2375.63s
- Coverage: **83.10%** (floor 78%)

Follow-up acceptance coverage (`info.version` vs `releases`):

- Receipt: `20260810-200434-work-verify-652c30` — **52 passed**, exit 0
- Live smoke: `resolve_beta_cli_version(_DefaultHttp())` → `0.27.0.dev20260810` while PyPI `info.version` remains `0.26.1`

Closes #852

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f622635-655b-42b4-a609-6343f455ad2f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f622635-655b-42b4-a609-6343f455ad2f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

