### PR TITLE
fix(work): bind task claim to CAS claim records (#856)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   public CLI command.
 
 ### Fixed
+- `brigade work task claim` now atomically creates a CAS `claim_id` that guarded
+  reassign and release recognize, rejects foreign-holder footprint refine with
+  exit 13, and rolls back blocked claims instead of leaving `in_progress` rows
+  without a usable claim record. (#856)
 - DAG runs no longer deadlock on shared cover sets, accept mutual-wait cycles, misreport one-node execution, route to unhealthy seats, or miss shared-checkout isolation breaches. (#742, #788, #791, #794)
 - `brigade run --wait` uses a fair FIFO queue, reclaims dead or stale holders, and retries the head waiter after a failed handoff instead of starving or timing out at 600 seconds. (#781, #790)
 - Release and security checks now reject stale readiness receipts across HEAD, base-ref, or tracked-tree changes, limit release content scans to tracked files, tolerate broken external scanners, point failures to `brigade scrub`, and coalesce overlapping open security findings while preserving per-fingerprint suppression and hiding internal metadata. (#753, #756, #774, #775, #776, #793)

--- a/src/brigade/work_cmd/session/task_ops.py
+++ b/src/brigade/work_cmd/session/task_ops.py
@@ -545,56 +545,106 @@ def task_claim(
 ) -> int:
     """Claim a task and refine its footprint from plan-named files.
 
-    This is the footprint refine seam (#777). Atomic compare-and-set claim
-    guards land in #738; this command is the additive lifecycle write that
-    claim will call.
+    Footprint refine (#777) shares the CAS claim surface (#738): pending tasks
+    gain a real claim record, and a different actor cannot steal a live claim
+    under the guise of footprint refinement.
     """
     target = target.expanduser().resolve()
     if not target.is_dir():
         print(f"error: --target is not a directory: {target}", file=sys.stderr)
         return 2
+    from .. import claiming as claim_mod
     from .. import footprint as footprint_mod
 
-    with ledger_mod._task_ledger_lock(target):
-        task, ledger = ledger_mod._find_task(target, task_id)
-        if task is None:
-            print(f"error: task not found: {task_id}", file=sys.stderr)
-            return 1
-        status = str(task.get("status") or "pending")
-        if status in edges_mod.TERMINAL_TASK_STATUSES:
-            print(f"error: task is already {status}: {task.get('id')}", file=sys.stderr)
-            return 2
-        try:
-            unresolved = ledger_mod._unresolved_plan_decisions(target, str(task.get("id")))
-        except ledger_mod.PlanDecisionError as exc:
-            print(f"error: {exc}", file=sys.stderr)
-            return int(exc.exit_code)
-        if unresolved:
-            print(f"error: {ledger_mod._decision_gate_message(unresolved)}", file=sys.stderr)
-            return 2
-        plan_files: list[str] = []
-        if files:
-            plan_files = list(files)
-        elif from_plan:
-            plan = ledger_mod._read_plan_receipt(target, str(task.get("id")), kind="plan")
-            plan_files = footprint_mod.extract_plan_files(plan)
-        footprint = footprint_mod.refine_footprint(
-            files=plan_files,
-            prior=footprint_mod.task_footprint(task),
-        )
-        footprint_mod.set_task_footprint(task, footprint)
-        now = helpers._now().isoformat()
-        task["status"] = "in_progress"
-        task["updated_at"] = now
-        task["claimed_at"] = now
-        if actor and actor.strip():
-            task["assignee"] = actor.strip()
-        ledger_mod._write_task_ledger(target, ledger)
+    try:
+        with ledger_mod._task_ledger_lock(target):
+            task, ledger = ledger_mod._find_task(target, task_id)
+            if task is None:
+                print(f"error: task not found: {task_id}", file=sys.stderr)
+                return 1
+            status = str(task.get("status") or "pending")
+            if status in edges_mod.TERMINAL_TASK_STATUSES:
+                print(f"error: task is already {status}: {task.get('id')}", file=sys.stderr)
+                return 2
+            try:
+                unresolved = ledger_mod._unresolved_plan_decisions(target, str(task.get("id")))
+            except ledger_mod.PlanDecisionError as exc:
+                print(f"error: {exc}", file=sys.stderr)
+                return int(exc.exit_code)
+            if unresolved:
+                print(f"error: {ledger_mod._decision_gate_message(unresolved)}", file=sys.stderr)
+                return 2
+
+            existing = claim_mod.claim_record(task)
+            actor_text = actor.strip() if isinstance(actor, str) and actor.strip() else None
+            if existing is not None:
+                if actor_text is not None and existing["actor"] != actor_text:
+                    raise claim_mod.ClaimError(
+                        claim_mod.conflict_message(task),
+                        reason=claim_mod.REASON_ALREADY_CLAIMED,
+                        details=claim_mod.holder_payload(task),
+                    )
+            elif status == "pending":
+                # Keep --actor optional for the footprint claim CLI (additive),
+                # but always write a CAS claim record so release can find it.
+                claim_actor = actor_text or "local"
+                claim_mod.apply_claim_to_task(
+                    ledger,
+                    task,
+                    actor=claim_actor,
+                    claim_id=claim_mod.generate_claim_id(),
+                    require_ready=True,
+                )
+            elif status == "in_progress" and actor_text is not None:
+                # Legacy footprint-only in_progress rows (no claim record): adopt
+                # into CAS when assignee is empty or already this actor.
+                current_assignee = claim_mod._string_or_none(task.get("assignee"))
+                if current_assignee is not None and current_assignee != actor_text:
+                    raise claim_mod.ClaimError(
+                        f"task {task.get('id')} is held by {current_assignee}",
+                        reason=claim_mod.REASON_ALREADY_CLAIMED,
+                        details={
+                            "task_id": task.get("id"),
+                            "status": status,
+                            "holder": current_assignee,
+                            "assignee": current_assignee,
+                        },
+                    )
+                claim_mod._set_claim(
+                    task,
+                    actor=actor_text,
+                    claim_id=claim_mod.generate_claim_id(),
+                    claimed_at=helpers._now().isoformat(),
+                )
+            elif status != "in_progress":
+                raise claim_mod.ClaimError(
+                    f"task {task.get('id')} is not ready for claim (status={status})",
+                    reason=claim_mod.REASON_NOT_READY,
+                    details={"task_id": task.get("id"), "status": status},
+                )
+
+            plan_files: list[str] = []
+            if files:
+                plan_files = list(files)
+            elif from_plan:
+                plan = ledger_mod._read_plan_receipt(target, str(task.get("id")), kind="plan")
+                plan_files = footprint_mod.extract_plan_files(plan)
+            footprint = footprint_mod.refine_footprint(
+                files=plan_files,
+                prior=footprint_mod.task_footprint(task),
+            )
+            footprint_mod.set_task_footprint(task, footprint)
+            ledger_mod._write_task_ledger(target, ledger)
+    except claim_mod.ClaimError as exc:
+        return _emit_claim_error(exc, json_output=json_output)
+
+    record = claim_mod.claim_record(task)
     payload = {
         "task": task.get("id"),
         "status": task.get("status"),
         "assignee": task.get("assignee"),
-        "claimed_at": task.get("claimed_at"),
+        "claimed_at": (record or {}).get("claimed_at") or task.get("claimed_at"),
+        "claim": record,
         "footprint": footprint,
     }
     if json_output:
@@ -604,6 +654,8 @@ def task_claim(
     print("status: in_progress")
     if task.get("assignee"):
         print(f"assignee: {task['assignee']}")
+    if record is not None:
+        print(f"claim_id: {record.get('claim_id')}")
     print(f"footprint.phase: {footprint.get('phase')}")
     print(f"footprint.files: {len(footprint.get('files') or [])}")
     for path in footprint.get("files") or []:

--- a/src/brigade/work_cmd/session/task_ops.py
+++ b/src/brigade/work_cmd/session/task_ops.py
@@ -595,11 +595,11 @@ def task_claim(
                     claim_id=claim_mod.generate_claim_id(),
                     require_ready=True,
                 )
-            elif status == "in_progress" and actor_text is not None:
+            elif status == "in_progress":
                 # Legacy footprint-only in_progress rows (no claim record): adopt
-                # into CAS when assignee is empty or already this actor.
+                # into CAS using the provided actor, existing assignee, or local.
                 current_assignee = claim_mod._string_or_none(task.get("assignee"))
-                if current_assignee is not None and current_assignee != actor_text:
+                if actor_text is not None and current_assignee is not None and current_assignee != actor_text:
                     raise claim_mod.ClaimError(
                         f"task {task.get('id')} is held by {current_assignee}",
                         reason=claim_mod.REASON_ALREADY_CLAIMED,
@@ -610,9 +610,10 @@ def task_claim(
                             "assignee": current_assignee,
                         },
                     )
+                claim_actor = actor_text or current_assignee or "local"
                 claim_mod._set_claim(
                     task,
-                    actor=actor_text,
+                    actor=claim_actor,
                     claim_id=claim_mod.generate_claim_id(),
                     claimed_at=helpers._now().isoformat(),
                 )

--- a/tests/test_work_cmd_claim.py
+++ b/tests/test_work_cmd_claim.py
@@ -629,3 +629,75 @@ def test_task_claim_text_output_includes_claim_id(tmp_path, monkeypatch, capsys)
     text_out = capsys.readouterr().out
     assert f"claim_id: {claim_id}" in text_out
     assert "status: in_progress" in text_out
+
+
+def test_task_claim_adopts_legacy_in_progress_without_actor(tmp_path, monkeypatch, capsys):
+    """#857: omitted --actor must still CAS-adopt legacy in_progress rows."""
+    _init_git_repo(tmp_path)
+    monkeypatch.setattr(
+        work_cmd.helpers,
+        "_now",
+        lambda: datetime(2026, 8, 10, 20, 0, 0, tzinfo=timezone.utc),
+    )
+    task = _add(tmp_path, "Legacy footprint-only claim")
+    ledger = work_cmd._read_task_ledger(tmp_path)
+    for item in ledger["tasks"]:
+        if item["id"] == task["id"]:
+            item["status"] = "in_progress"
+            item["assignee"] = "lane-a"
+            item["claimed_at"] = "2026-08-10T12:00:00+00:00"
+    work_cmd._write_task_ledger(tmp_path, ledger)
+
+    assert (
+        work_cmd.task_claim(
+            target=tmp_path,
+            task_id=task["id"],
+            files=["src/brigade/work_cmd/claiming.py"],
+            from_plan=False,
+            json_output=True,
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "in_progress"
+    assert payload["claim"]["claim_id"]
+    assert payload["claim"]["actor"] == "lane-a"
+
+    ledger = work_cmd._read_task_ledger(tmp_path)
+    stored = next(item for item in ledger["tasks"] if item["id"] == task["id"])
+    assert stored["claim"]["claim_id"] == payload["claim"]["claim_id"]
+    assert stored["claim"]["actor"] == "lane-a"
+
+    claim_id = payload["claim"]["claim_id"]
+    assert (
+        work_cmd.release(
+            target=tmp_path,
+            task=[task["id"]],
+            claim_id=[claim_id],
+            json_output=True,
+        )
+        == 0
+    )
+    release_payload = json.loads(capsys.readouterr().out)
+    assert release_payload["released_count"] == 1
+
+    unassigned = _add(tmp_path, "Legacy without assignee")
+    ledger = work_cmd._read_task_ledger(tmp_path)
+    for item in ledger["tasks"]:
+        if item["id"] == unassigned["id"]:
+            item["status"] = "in_progress"
+            item.pop("assignee", None)
+    work_cmd._write_task_ledger(tmp_path, ledger)
+
+    assert (
+        work_cmd.task_claim(
+            target=tmp_path,
+            task_id=unassigned["id"],
+            files=["src/a.py"],
+            from_plan=False,
+            json_output=True,
+        )
+        == 0
+    )
+    local_payload = json.loads(capsys.readouterr().out)
+    assert local_payload["claim"]["actor"] == "local"

--- a/tests/test_work_cmd_claim.py
+++ b/tests/test_work_cmd_claim.py
@@ -15,7 +15,7 @@ import pytest
 from brigade import work_cmd
 from brigade.work_cmd import claiming as claim_mod
 
-from tests.work_cmd_test_helpers import _init_git_repo
+from tests.work_cmd_test_helpers import _accepted_plan_task_id, _init_git_repo
 
 
 def _add(target: Path, text: str, **kwargs):
@@ -452,3 +452,180 @@ def test_stale_claims_listed_by_age(tmp_path, monkeypatch):
     payload = work_cmd._stale_claim_payload(tmp_path, stale_after_hours=24)
     assert payload["stale_count"] == 1
     assert payload["stale"][0]["claim_id"] == "stale-1"
+
+
+def test_task_claim_returns_and_persists_claim_id(tmp_path, monkeypatch, capsys):
+    """#856: task claim must atomically create a CAS claim record."""
+    _init_git_repo(tmp_path)
+    monkeypatch.setattr(
+        work_cmd.helpers,
+        "_now",
+        lambda: datetime(2026, 8, 10, 19, 0, 0, tzinfo=timezone.utc),
+    )
+    task_id = _accepted_plan_task_id(tmp_path, capsys)
+
+    assert work_cmd.task_claim(target=tmp_path, task_id=task_id[:12], actor="lane-a", json_output=True) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "in_progress"
+    assert payload["assignee"] == "lane-a"
+    assert payload["claim"]["claim_id"]
+    assert payload["claim"]["actor"] == "lane-a"
+    assert payload["claim"]["claimed_at"]
+
+    ledger = work_cmd._read_task_ledger(tmp_path)
+    stored = next(item for item in ledger["tasks"] if item["id"] == task_id)
+    assert stored["status"] == "in_progress"
+    assert stored["claim"]["claim_id"] == payload["claim"]["claim_id"]
+    assert stored["claim"]["actor"] == "lane-a"
+
+
+def test_task_claim_enables_guarded_reassign_and_release(tmp_path, monkeypatch, capsys):
+    """#856: guarded reassign and release must recognize task-claim identity."""
+    _init_git_repo(tmp_path)
+    monkeypatch.setattr(
+        work_cmd.helpers,
+        "_now",
+        lambda: datetime(2026, 8, 10, 19, 0, 0, tzinfo=timezone.utc),
+    )
+    task_id = _accepted_plan_task_id(tmp_path, capsys)
+    assert work_cmd.task_claim(target=tmp_path, task_id=task_id, actor="lane-a", json_output=True) == 0
+    claim_payload = json.loads(capsys.readouterr().out)
+    claim_id = claim_payload["claim"]["claim_id"]
+
+    assert (
+        work_cmd.reassign(
+            target=tmp_path,
+            task_id=task_id,
+            to_actor="lane-b",
+            claim_id=claim_id,
+            json_output=True,
+        )
+        == 0
+    )
+    reassign_payload = json.loads(capsys.readouterr().out)
+    assert reassign_payload["assignee"] == "lane-b"
+    new_claim_id = reassign_payload["claim"]["claim_id"]
+    assert new_claim_id != claim_id
+
+    assert (
+        work_cmd.release(
+            target=tmp_path,
+            task=[task_id],
+            claim_id=[new_claim_id],
+            json_output=True,
+        )
+        == 0
+    )
+    release_payload = json.loads(capsys.readouterr().out)
+    assert release_payload["released_count"] == 1
+
+    ledger = work_cmd._read_task_ledger(tmp_path)
+    stored = next(item for item in ledger["tasks"] if item["id"] == task_id)
+    assert stored["status"] == "pending"
+    assert "claim" not in stored
+
+
+def test_task_claim_foreign_holder_rejects_without_stranding(tmp_path, monkeypatch, capsys):
+    """#856: footprint refine cannot steal a live CAS claim."""
+    _init_git_repo(tmp_path)
+    monkeypatch.setattr(
+        work_cmd.helpers,
+        "_now",
+        lambda: datetime(2026, 8, 10, 19, 0, 0, tzinfo=timezone.utc),
+    )
+    task_id = _accepted_plan_task_id(tmp_path, capsys)
+    assert (
+        work_cmd.claim(target=tmp_path, task_id=task_id[:12], actor="lane-a", claim_id="cas-1", json_output=True) == 0
+    )
+    capsys.readouterr()
+
+    rc = work_cmd.task_claim(target=tmp_path, task_id=task_id[:12], actor="lane-b", json_output=True)
+    assert rc == claim_mod.EXIT_GUARD_MISMATCH
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["reason"] == claim_mod.REASON_ALREADY_CLAIMED
+    assert payload["holder"] == "lane-a"
+
+    ledger = work_cmd._read_task_ledger(tmp_path)
+    stored = next(item for item in ledger["tasks"] if item["id"] == task_id)
+    assert stored["status"] == "in_progress"
+    assert stored["claim"]["claim_id"] == "cas-1"
+    assert stored["claim"]["actor"] == "lane-a"
+
+
+def test_task_claim_same_actor_refine_keeps_claim_id(tmp_path, monkeypatch, capsys):
+    """#856: same-actor footprint refine must not rotate claim_id."""
+    _init_git_repo(tmp_path)
+    monkeypatch.setattr(
+        work_cmd.helpers,
+        "_now",
+        lambda: datetime(2026, 8, 10, 19, 0, 0, tzinfo=timezone.utc),
+    )
+    task_id = _accepted_plan_task_id(tmp_path, capsys)
+    assert work_cmd.task_claim(target=tmp_path, task_id=task_id[:12], actor="lane-a", json_output=True) == 0
+    first = json.loads(capsys.readouterr().out)
+    first_claim_id = first["claim"]["claim_id"]
+
+    assert (
+        work_cmd.task_claim(
+            target=tmp_path,
+            task_id=task_id[:12],
+            actor="lane-a",
+            files=["src/brigade/work_cmd/claiming.py"],
+            from_plan=False,
+            json_output=True,
+        )
+        == 0
+    )
+    second = json.loads(capsys.readouterr().out)
+    assert second["claim"]["claim_id"] == first_claim_id
+
+
+def test_task_claim_blocked_task_rolls_back(tmp_path, monkeypatch, capsys):
+    """#856: failed claim must not leave in_progress without a usable claim."""
+    _init_git_repo(tmp_path)
+    monkeypatch.setattr(
+        work_cmd.helpers,
+        "_now",
+        lambda: datetime(2026, 8, 10, 19, 0, 0, tzinfo=timezone.utc),
+    )
+    blocker = _add(tmp_path, "Blocker")
+    blocked = _add(tmp_path, "Blocked work")
+    assert (
+        work_cmd.task_edge_add(
+            target=tmp_path,
+            edge_type="blocks",
+            source=blocker["id"],
+            target_id=blocked["id"],
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    rc = work_cmd.task_claim(target=tmp_path, task_id=blocked["id"], actor="lane-a", json_output=True)
+    assert rc == claim_mod.EXIT_GUARD_MISMATCH
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["reason"] == claim_mod.REASON_NOT_READY
+
+    ledger = work_cmd._read_task_ledger(tmp_path)
+    stored = next(item for item in ledger["tasks"] if item["id"] == blocked["id"])
+    assert stored["status"] == "pending"
+    assert "claim" not in stored
+
+
+def test_task_claim_text_output_includes_claim_id(tmp_path, monkeypatch, capsys):
+    """#856: text and JSON outputs must agree on claim_id."""
+    _init_git_repo(tmp_path)
+    monkeypatch.setattr(
+        work_cmd.helpers,
+        "_now",
+        lambda: datetime(2026, 8, 10, 19, 0, 0, tzinfo=timezone.utc),
+    )
+    task_id = _accepted_plan_task_id(tmp_path, capsys)
+    assert work_cmd.task_claim(target=tmp_path, task_id=task_id[:12], actor="lane-a", json_output=True) == 0
+    json_payload = json.loads(capsys.readouterr().out)
+    claim_id = json_payload["claim"]["claim_id"]
+
+    assert work_cmd.task_claim(target=tmp_path, task_id=task_id[:12], actor="lane-a") == 0
+    text_out = capsys.readouterr().out
+    assert f"claim_id: {claim_id}" in text_out
+    assert "status: in_progress" in text_out


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

`brigade work task claim` moved tasks to `in_progress` without creating a nested CAS `claim` record, so guarded `work reassign` returned `not_claimed` and `work release` could not address the row. This PR recovers orphan commit `81085625` (only that commit's semantics; not the full `cursor/brigade-work-graph-hardening-5764` branch) adapted to current `main`.

Closes #856

## Type of change

- [x] Bug fix

## Changes

- `task_claim` now calls `claim_mod.apply_claim_to_task` for pending tasks, rejects foreign holders with exit 13, preserves `claim_id` on same-actor footprint refine, and includes `claim` / `claim_id` in JSON and text output.
- Six red-to-green regression tests in `tests/test_work_cmd_claim.py`.
- `CHANGELOG.md` Unreleased entry.

## Verification

### Red (pre-fix, on `main`)

```bash
pytest tests/test_work_cmd_claim.py::test_task_claim_returns_and_persists_claim_id \
  tests/test_work_cmd_claim.py::test_task_claim_enables_guarded_reassign_and_release \
  tests/test_work_cmd_claim.py::test_task_claim_foreign_holder_rejects_without_stranding \
  tests/test_work_cmd_claim.py::test_task_claim_same_actor_refine_keeps_claim_id \
  tests/test_work_cmd_claim.py::test_task_claim_blocked_task_rolls_back \
  tests/test_work_cmd_claim.py::test_task_claim_text_output_includes_claim_id -q
```

Result: **6 failed** — `KeyError: 'claim'` on JSON payloads; foreign holder `task_claim` returned `0` instead of `13`.

### Green (this branch)

```bash
pytest tests/test_work_cmd_claim.py::test_task_claim_returns_and_persists_claim_id \
  tests/test_work_cmd_claim.py::test_task_claim_enables_guarded_reassign_and_release \
  tests/test_work_cmd_claim.py::test_task_claim_foreign_holder_rejects_without_stranding \
  tests/test_work_cmd_claim.py::test_task_claim_same_actor_refine_keeps_claim_id \
  tests/test_work_cmd_claim.py::test_task_claim_blocked_task_rolls_back \
  tests/test_work_cmd_claim.py::test_task_claim_text_output_includes_claim_id -q
```

Result: **6 passed in 0.25s**

```bash
pytest tests/test_work_cmd_claim.py tests/test_work_cmd_footprint.py -q
```

Result: **29 passed in 1.20s**

```bash
ruff check src/brigade/work_cmd/session/task_ops.py tests/test_work_cmd_claim.py
ruff format --check src/brigade/work_cmd/session/task_ops.py tests/test_work_cmd_claim.py
```

Result: **All checks passed** / **2 files already formatted**

```bash
brigade work verify run --target . \
  --command "pytest -q tests/test_work_cmd_claim.py tests/test_work_cmd_footprint.py" --json
```

Result: receipt `20260810-201908-work-verify-974c9f`, **status: completed**

## Checklist

- [x] Added regression tests covering claim, guarded reassign, release, foreign-holder rejection, same-actor refine, blocked rollback, and text/JSON agreement
- [x] Updated `CHANGELOG.md` Unreleased
- [x] No new runtime dependencies
- [x] Conventional commit with Cursor co-author trailer
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66d2c1a1-de16-43a7-ad21-c68b6d88bf16?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66d2c1a1-de16-43a7-ad21-c68b6d88bf16&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

