### PR TITLE
fix(operator): block Claude readiness when handoff template is shadowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   path labels and never prints host-private absolute paths, including in
   `load_error` / `load_warnings` text for missing path-based skill selectors.
 
+### Fixed
+- Claude harness readiness now fails when a global `core.excludesFile` rule
+  such as `.claude/` hides the managed handoff `TEMPLATE.md`.
+  `operator verify-harness --harness claude` returns `ready: no` with a nonzero
+  exit, and `operator quickstart` propagates a non-ok status plus the exact
+  non-mutating recovery command `git check-ignore -v
+  .claude/memory-handoffs/TEMPLATE.md`. Brigade never edits global Git
+  configuration; docs/new-user-quickstart.md documents narrow repo-local
+  un-ignore rules. Codex-only onboarding keeps the warning-only contract.
+  (#855)
+
 ## [0.26.1] - 2026-08-09
 
 ### Changed

--- a/docs/new-user-quickstart.md
+++ b/docs/new-user-quickstart.md
@@ -147,6 +147,38 @@ brigade skills doctor --target ./my-repo --json
 brigade security scan --target ./my-repo --fail-on none --json
 ```
 
+### Claude handoff template hidden by a global Git exclude
+
+If Claude verification reports `ready: no` with `handoff_template_shadowed`, a
+global `core.excludesFile` rule such as `.claude/` is hiding the managed
+handoff template. Brigade does not edit global Git configuration. Diagnose with
+the exact recovery command from verify-harness or quickstart `next_commands`:
+
+```bash
+git check-ignore -v .claude/memory-handoffs/TEMPLATE.md
+```
+
+Then add narrow repo-local un-ignore rules to the target `.gitignore` (keep them
+outside the managed Brigade block so re-init does not drop them):
+
+```gitignore
+!.claude/
+.claude/*
+!.claude/memory-handoffs/
+.claude/memory-handoffs/*
+!.claude/memory-handoffs/TEMPLATE.md
+```
+
+Re-run `git check-ignore -v .claude/memory-handoffs/TEMPLATE.md` until it no
+longer reports the template as ignored, then:
+
+```bash
+brigade operator verify-harness --target ./my-repo --harness claude
+```
+
+Codex-only onboarding keeps its warning-only contract: a shadowed Codex
+template stays an advisory warning and does not block readiness.
+
 Open a quickstart issue here:
 
 ```text

--- a/src/brigade/operator_cmd/health.py
+++ b/src/brigade/operator_cmd/health.py
@@ -389,22 +389,29 @@ def verify_harness_payload(target: Path, *, harness: str) -> dict[str, Any]:
         )
 
     # The managed .gitignore un-ignores each inbox's TEMPLATE.md so the format
-    # travels with the repo. Git cannot re-include a file whose parent dir is
-    # excluded by another source (commonly a global gitignore with a bare
-    # `.claude/` or `.codex/` entry), and that shadowing is otherwise silent.
+    # travels with the repo. A global core.excludesFile entry like `.claude/`
+    # can still hide it; Claude treats that as a readiness blocker because the
+    # required handoff template cannot be committed. Other writer harnesses
+    # keep the advisory warn so Codex-only onboarding stays unchanged.
     template_path = inbox_path / "TEMPLATE.md"
+    template_shadowed = False
     if template_path.is_file():
         template_ignored = localio.check_git_ignored(target, template_path)
         if template_ignored == "yes":
+            template_shadowed = True
             inbox_root = inbox_rel.split("/")[0]
+            shadow_status = "fail" if harness == "claude" else "warn"
             checks.append(
                 {
-                    "status": "warn",
+                    "status": shadow_status,
                     "name": "handoff_template_shadowed",
                     "detail": (
                         f"{inbox_rel}/TEMPLATE.md is gitignored despite the managed un-ignore rule; "
                         f"an external ignore source (often a global gitignore entry like `{inbox_root}/`) "
-                        "is shadowing it, so the template will not travel with the repo"
+                        "is shadowing it, so the template will not travel with the repo. "
+                        "Do not edit global Git config from Brigade; diagnose with "
+                        f"`git check-ignore -v {inbox_rel}/TEMPLATE.md` and add narrow "
+                        "repo-local un-ignore rules (see docs/new-user-quickstart.md)."
                     ),
                 }
             )
@@ -438,9 +445,8 @@ def verify_harness_payload(target: Path, *, harness: str) -> dict[str, Any]:
     else:
         checks.append({"status": "ok", "name": "handoff_lint", "detail": f"no pending {harness} handoffs"})
 
-    # Fails block readiness; warns are advisories (host conditions like a
-    # global gitignore shadowing an inbox template) and stay visible without
-    # flipping ready to no.
+    # Fails block readiness. Warns stay advisory (including non-Claude template
+    # shadowing) and do not flip ready to no.
     issue_count = sum(1 for item in checks if item.get("status") == "fail")
     warning_count = sum(1 for item in checks if item.get("status") == "warn")
     hermes_adapter_issues = [
@@ -449,7 +455,9 @@ def verify_harness_payload(target: Path, *, harness: str) -> dict[str, Any]:
         if str(item.get("name", "")).startswith("hermes_adapter_") and item.get("status") in {"fail", "warn"}
     ]
     if issue_count:
-        if harness == "hermes" and hermes_adapter_issues and not (inbox_health and inbox_health.exists):
+        if harness == "claude" and template_shadowed:
+            next_command = f"git check-ignore -v {inbox_rel}/TEMPLATE.md"
+        elif harness == "hermes" and hermes_adapter_issues and not (inbox_health and inbox_health.exists):
             next_command = "brigade init --target . --depth workspace --harnesses hermes"
         elif harness == "hermes" and hermes_adapter_issues:
             next_command = "brigade hermes-fragments --out .brigade/hermes"

--- a/src/brigade/operator_cmd/lifecycle.py
+++ b/src/brigade/operator_cmd/lifecycle.py
@@ -535,11 +535,24 @@ def quickstart(
             if verify_rc == 0 and advisories:
                 step["advisory_count"] = advisories
                 step["advisory_next_command"] = f"brigade operator verify-harness --harness {harness} --target ."
+            if verify_rc != 0 and isinstance(verify_payload, dict):
+                recovery = verify_payload.get("next_command")
+                if isinstance(recovery, str) and recovery.strip():
+                    step["recovery_command"] = recovery.strip()
             steps.append(step)
 
     ok = all(step.get("return_code", 0) == 0 for step in steps if step.get("status") not in {"skipped", "planned"})
     if dry_run:
         ok = install_rc == 0 and init_rc == 0 and portable_rc == 0
+    next_commands = _quickstart_next_commands(selected_harnesses, dry_run=dry_run)
+    if not dry_run and not ok:
+        recoveries = [
+            step.get("recovery_command")
+            for step in steps
+            if isinstance(step.get("recovery_command"), str) and step.get("recovery_command")
+        ]
+        # Exact non-mutating recovery first when a harness verify blocked readiness.
+        next_commands = list(dict.fromkeys([*recoveries, *next_commands]))
     payload = {
         "target": str(target),
         "depth": depth,
@@ -550,7 +563,7 @@ def quickstart(
         "force": force,
         "steps": steps,
         "status": "ok" if ok else "warn",
-        "next_commands": _quickstart_next_commands(selected_harnesses, dry_run=dry_run),
+        "next_commands": next_commands,
         "local_only_notes": _quickstart_local_notes(),
     }
     payload["issue_report"] = _quickstart_issue_report(payload)

--- a/tests/test_operator_cmd.py
+++ b/tests/test_operator_cmd.py
@@ -1610,10 +1610,63 @@ def test_verify_harness_warns_when_inbox_template_shadowed_by_external_ignore(tm
     shadow = [c for c in payload["checks"] if c["name"] == "handoff_template_shadowed"]
     assert shadow and shadow[0]["status"] == "warn"
     assert "shadow" in shadow[0]["detail"] or "global" in shadow[0]["detail"]
-    # A portability advisory must not flip readiness: warns inform, fails block.
+    # Codex keeps the warning-only contract: warns inform, fails block.
     assert payload["ready"] is True
     assert payload["issue_count"] == 0
     assert payload["warning_count"] >= 1
+
+
+def test_claude_handoff_template_shadowed_by_core_excludes_file_blocks_readiness(tmp_path, capsys, monkeypatch):
+    """Global core.excludesFile hiding .claude/ must block Claude readiness (#855).
+
+    Uses an isolated GIT_CONFIG_GLOBAL so the worker's real excludesFile is never
+    read or mutated.
+    """
+    import os
+    import subprocess
+
+    excludes = tmp_path / "isolated-excludes"
+    excludes.write_text(".claude/\n")
+    gitconfig = tmp_path / "isolated-gitconfig"
+    gitconfig.write_text(f"[core]\n\texcludesFile = {excludes}\n")
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(gitconfig))
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", os.devnull)
+    monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "main", str(repo)], check=True)
+
+    # Codex-only onboarding stays unchanged under a .claude/ exclude.
+    assert cli.main(["operator", "quickstart", "--target", str(repo), "--harnesses", "codex", "--json"]) == 0
+    codex_qs = json.loads(capsys.readouterr().out)
+    assert codex_qs["status"] == "ok"
+
+    # Re-run with Claude selected: quickstart must not report ok while the
+    # managed Claude handoff template remains hidden from Git.
+    qs_rc = cli.main(["operator", "quickstart", "--target", str(repo), "--harnesses", "codex,claude", "--json"])
+    qs_payload = json.loads(capsys.readouterr().out)
+    assert qs_rc != 0
+    assert qs_payload["status"] != "ok"
+    verify_claude = next(step for step in qs_payload["steps"] if step.get("id") == "verify-claude")
+    assert verify_claude.get("return_code") != 0
+    assert "git check-ignore -v .claude/memory-handoffs/TEMPLATE.md" in (qs_payload.get("next_commands") or [])
+
+    verify_rc = cli.main(["operator", "verify-harness", "--target", str(repo), "--harness", "claude", "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert verify_rc == 1
+    assert payload["ready"] is False
+    assert payload["issue_count"] >= 1
+    shadow = [c for c in payload["checks"] if c["name"] == "handoff_template_shadowed"]
+    assert shadow and shadow[0]["status"] == "fail"
+    assert payload["next_command"] == "git check-ignore -v .claude/memory-handoffs/TEMPLATE.md"
+
+    # Text output must agree with JSON readiness.
+    assert cli.main(["operator", "verify-harness", "--target", str(repo), "--harness", "claude"]) == 1
+    text = capsys.readouterr().out
+    assert "ready: no" in text
+    assert "[fail] handoff_template_shadowed:" in text
+    assert "git check-ignore -v .claude/memory-handoffs/TEMPLATE.md" in text
 
 
 def test_local_operator_doctor_does_not_block_on_inactive_content_guard_hook(tmp_path, capsys, monkeypatch):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

Claude quickstart and `verify-harness` could report ready while a global `core.excludesFile` rule such as `.claude/` still hid the managed handoff `TEMPLATE.md`. This makes `handoff_template_shadowed` blocking for Claude, keeps Codex warning-only, and returns an exact non-mutating recovery command (never edits global Git configuration).

Closes #855

## Type of change

- [x] Bug fix
- [ ] New harness adapter / doctor check
- [x] Docs
- [ ] Refactor with no command-surface change
- [ ] Surface change (new harness, depth, include, or breaking template/ingester change) — opened an issue first per CONTRIBUTING.md

## Acceptance mapping

- Isolated `core.excludesFile` regression ignores `.claude/` without touching the worker global config (`GIT_CONFIG_GLOBAL` / `GIT_CONFIG_SYSTEM` / `GIT_CONFIG_NOSYSTEM`).
- Claude verify returns `ready: false`, nonzero exit, `[fail] handoff_template_shadowed`, and `next_command: git check-ignore -v .claude/memory-handoffs/TEMPLATE.md`.
- Quickstart with Claude selected propagates non-ok status and prepends that recovery command in `next_commands`.
- Codex-only onboarding stays on the warning-only contract.
- Docs: `docs/new-user-quickstart.md` recovery path with narrow repo-local un-ignore rules.

## Red / green evidence

Red (test only, before production fix):

```console
$ python -m pytest tests/test_operator_cmd.py::test_claude_handoff_template_shadowed_by_core_excludes_file_blocks_readiness -q --tb=short
F
...
assert qs_rc != 0
E   assert 0 != 0
1 failed in 0.68s
```

Green (after fix):

```console
$ brigade work verify run --target /workspace \
    --command "ruff check src/brigade/operator_cmd/health.py src/brigade/operator_cmd/lifecycle.py tests/test_operator_cmd.py" \
    --command "ruff format --check src/brigade/operator_cmd/health.py src/brigade/operator_cmd/lifecycle.py tests/test_operator_cmd.py" \
    --command "python -m pytest tests/test_operator_cmd.py::test_claude_handoff_template_shadowed_by_core_excludes_file_blocks_readiness tests/test_operator_cmd.py::test_verify_harness_warns_when_inbox_template_shadowed_by_external_ignore -q --tb=short"
status: completed
run_id: 20260810-202454-work-verify-19e6d5

$ python -m pytest \
    tests/test_operator_cmd.py::test_claude_handoff_template_shadowed_by_core_excludes_file_blocks_readiness \
    tests/test_operator_cmd.py::test_verify_harness_warns_when_inbox_template_shadowed_by_external_ignore \
    -q --tb=short
..  2 passed
```

Vale (new prose): `docs/new-user-quickstart.md` new section clean; CHANGELOG excerpt clean. Pre-existing write-good warnings elsewhere in the quickstart doc were left untouched.

## Checklist

- [ ] `pytest -q` passes locally (focused operator tests + work verify above; full suite not rerun here)
- [x] Added or updated tests covering the change
- [x] Updated the `Unreleased` section of `CHANGELOG.md` for any user-visible effect
- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths
- [x] No new runtime dependencies
- [x] Conventional commit messages (Cursor co-author trailer per AGENTS.md / requested workflow)

## Out of scope

Did not edit `src/brigade/install.py`, `QUICKSTART.md`, `README.md`, update-channel docs, or updater code (#854).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4acfdc34-9c0d-4b01-98a1-713abe17dcdc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4acfdc34-9c0d-4b01-98a1-713abe17dcdc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

