### PR TITLE
docs(contributing): make the first PR path visible — repair supersedes #841 (Refs #763)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,18 +14,21 @@ External contributions are welcome. This section is the short path; [Pull reques
 
 ## Pull requests
 
-`main` is branch-protected. A dispatched session cannot supply the review artifact required by its own pull request, and GitHub enforces the gate regardless of the dispatch prompt.
+`main` is branch-protected. A dispatched session cannot supply the review artifact required by its own pull request. GitHub enforces required checks; formal review is maintainer merge policy (branch protection does not currently require approving reviews).
 
-The current rule set requires all of the following before a pull request can merge:
+**GitHub-enforced gates** on `main`:
 
 - All required GitHub Actions checks pass. The checks are pinned to GitHub Actions app id 15368, and the branch must be up to date with `main`.
+
+**Maintainer merge policy** (required before merge; not enforced by GitHub branch protection today):
+
 - A current formal `APPROVED` review exists from a non-author reviewer.
 - All review conversations are resolved.
 - The approval was recorded after the last push. New commits dismiss stale approvals.
 
 The pull request author cannot approve their own pull request. `gh pr review --approve` fails with "Can not approve your own pull request" when the author and reviewer share one GitHub identity.
 
-CodeRabbit is the current external review identity. Its green commit status is not the grading artifact because the status can be green while the formal GitHub review is still `CHANGES_REQUESTED`. The artifacts that count are a current formal non-author `APPROVED` review and all required checks passing.
+CodeRabbit is the current external review identity. Its green commit status is not the grading artifact because the status can be green while the formal GitHub review is still `CHANGES_REQUESTED`. Under maintainer policy, merge waits on a current formal non-author `APPROVED` review and all required checks passing.
 
 Inspect the gate before attempting a merge:
 
@@ -79,7 +82,8 @@ python -m venv .venv
 Activate the environment before installing:
 
 - **POSIX (macOS, Linux):** `source .venv/bin/activate`
-- **Windows:** `.venv\Scripts\activate`
+- **Windows PowerShell:** `.\.venv\Scripts\Activate.ps1`
+- **Windows cmd:** `.venv\Scripts\activate.bat`
 
 Then install dev dependencies:
 
@@ -89,7 +93,13 @@ pip install -e ".[dev]"
 
 On PEP 668-managed Python (many Linux distributions), installing into the system interpreter fails; a virtual environment avoids that.
 
-**Docs-only changes:** CI runs the `content-guard` job on the repo. Locally, scan each edited markdown file before you push:
+**Docs-only changes:** CI runs the `content-guard` job on the repo. Locally, scan each edited markdown file before you push (one path per invocation):
+
+```bash
+brigade guard scan <edited-file>.md --policy src/brigade/guard/policies/public-repo.json
+```
+
+Example when only `CONTRIBUTING.md` and `README.md` changed:
 
 ```bash
 brigade guard scan CONTRIBUTING.md --policy src/brigade/guard/policies/public-repo.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,12 +11,11 @@ External contributions are welcome. This section is the short path; **Pull reque
 3. **Install and test locally.** From a repo clone with Python 3.10+:
 
 ```bash
-python -m venv .venv && source .venv/bin/activate
 pip install -e ".[dev]" && pytest -q
 ```
 
 That is the minimal loop for a docs-only change. Code changes should pass `./scripts/verify` before you push (see **Local dev** below).
-4. **Open a pull request.** Required CI checks run automatically on the branch. You do not need to dispatch all 22 jobs yourself.
+4. **Open a pull request.** Required CI checks run automatically on the branch. You do not need to dispatch all required checks yourself.
 5. **Review turnaround.** Target an initial review within a few business days once required checks are green. Merge still waits on the formal review and gate rules in **Pull requests**.
 
 ## Pull requests
@@ -25,7 +24,7 @@ That is the minimal loop for a docs-only change. Code changes should pass `./scr
 
 The current rule set requires all of the following before a pull request can merge:
 
-- All 22 required GitHub Actions checks pass. The checks are pinned to GitHub Actions app id 15368, and the branch must be up to date with `main`.
+- All required GitHub Actions checks pass. The checks are pinned to GitHub Actions app id 15368, and the branch must be up to date with `main`.
 - A current formal `APPROVED` review exists from a non-author reviewer.
 - All review conversations are resolved.
 - The approval was recorded after the last push. New commits dismiss stale approvals.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,19 +4,13 @@ Brigade is the local-first operator CLI for agent memory, handoffs, and reviewab
 
 ## Your first PR
 
-External contributions are welcome. This section is the short path; **Pull requests** below lists the full merge gates.
+External contributions are welcome. This section is the short path; [Pull requests](#pull-requests) below lists the full merge gates.
 
 1. **Pick work.** Look for issues labeled `good first issue` or `help wanted`. If nothing fits, comment on an existing issue or open one before you spend time on a surprise scope.
 2. **Claim it.** Comment on the issue that you are working on it. The maintainer holds off internal lanes for **48 hours** so your branch is not steamrolled.
-3. **Install and test locally.** From a repo clone with Python 3.10+:
-
-```bash
-pip install -e ".[dev]" && pytest -q
-```
-
-That is the minimal loop for a docs-only change. Code changes should pass `./scripts/verify` before you push (see **Local dev** below).
+3. **Install and verify locally.** Clone with Python 3.10+, then follow [Local dev](#local-dev): use a virtual environment (required on PEP 668-managed Python and on Windows), install dev dependencies, and run the verification path that matches your change (content-guard scan for docs-only; `./scripts/verify` for code).
 4. **Open a pull request.** Required CI checks run automatically on the branch. You do not need to dispatch all required checks yourself.
-5. **Review turnaround.** Target an initial review within a few business days once required checks are green. Merge still waits on the formal review and gate rules in **Pull requests**.
+5. **Review turnaround.** Target an initial review within a few business days once required checks are green. Merge still waits on the formal review and gate rules in [Pull requests](#pull-requests).
 
 ## Pull requests
 
@@ -74,12 +68,38 @@ Reviewed planning docs are public and tracked: the phase plans (`docs/phase-*.md
 
 ## Local dev
 
+From a repo clone with Python 3.10+:
+
 ```bash
 git clone https://github.com/escoffier-labs/brigade.git
 cd brigade
-python -m venv .venv && source .venv/bin/activate
+python -m venv .venv
+```
+
+Activate the environment before installing:
+
+- **POSIX (macOS, Linux):** `source .venv/bin/activate`
+- **Windows:** `.venv\Scripts\activate`
+
+Then install dev dependencies:
+
+```bash
 pip install -e ".[dev]"
-pytest -q
+```
+
+On PEP 668-managed Python (many Linux distributions), installing into the system interpreter fails; a virtual environment avoids that.
+
+**Docs-only changes:** CI runs the `content-guard` job on the repo. Locally, scan each edited markdown file before you push:
+
+```bash
+brigade guard scan CONTRIBUTING.md --policy src/brigade/guard/policies/public-repo.json
+brigade guard scan README.md --policy src/brigade/guard/policies/public-repo.json
+```
+
+**Code or test changes:** run the full local gate before you push:
+
+```bash
+./scripts/verify
 ```
 
 To smoke-test an install end-to-end the same way CI does:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,51 @@
 
 Brigade is the local-first operator CLI for agent memory, handoffs, and reviewable work receipts. It grew out of [Solomon's Cookbook](https://github.com/escoffier-labs/solos-cookbook), and patches are welcome. Before you start, please skim this file so we both spend our time on the right things.
 
+## Your first PR
+
+External contributions are welcome. This section is the short path; **Pull requests** below lists the full merge gates.
+
+1. **Pick work.** Look for issues labeled `good first issue` or `help wanted`. If nothing fits, comment on an existing issue or open one before you spend time on a surprise scope.
+2. **Claim it.** Comment on the issue that you are working on it. The maintainer holds off internal lanes for **48 hours** so your branch is not steamrolled.
+3. **Install and test locally.** From a repo clone with Python 3.10+:
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev]" && pytest -q
+```
+
+That is the minimal loop for a docs-only change. Code changes should pass `./scripts/verify` before you push (see **Local dev** below).
+4. **Open a pull request.** Required CI checks run automatically on the branch. You do not need to dispatch all 22 jobs yourself.
+5. **Review turnaround.** Target an initial review within a few business days once required checks are green. Merge still waits on the formal review and gate rules in **Pull requests**.
+
+## Pull requests
+
+`main` is branch-protected. A dispatched session cannot supply the review artifact required by its own pull request, and GitHub enforces the gate regardless of the dispatch prompt.
+
+The current rule set requires all of the following before a pull request can merge:
+
+- All 22 required GitHub Actions checks pass. The checks are pinned to GitHub Actions app id 15368, and the branch must be up to date with `main`.
+- A current formal `APPROVED` review exists from a non-author reviewer.
+- All review conversations are resolved.
+- The approval was recorded after the last push. New commits dismiss stale approvals.
+
+The pull request author cannot approve their own pull request. `gh pr review --approve` fails with "Can not approve your own pull request" when the author and reviewer share one GitHub identity.
+
+CodeRabbit is the current external review identity. Its green commit status is not the grading artifact because the status can be green while the formal GitHub review is still `CHANGES_REQUESTED`. The artifacts that count are a current formal non-author `APPROVED` review and all required checks passing.
+
+Inspect the gate before attempting a merge:
+
+```bash
+gh pr checks <number> --required
+gh pr view <number> --json reviewDecision,mergeStateStatus
+```
+
+`reviewDecision` reports `REVIEW_REQUIRED`, `CHANGES_REQUESTED`, or `APPROVED`. `mergeStateStatus` reports states such as `CLEAN`, `BLOCKED`, and `BEHIND`.
+
+Those CLI fields do not expose unresolved review conversations. Separately check the pull request's **Files changed** review panel in GitHub and confirm that no conversation remains unresolved.
+
+Dispatched sessions should open the pull request, run local verification, and push commits. After the final push, comment `@coderabbitai full review`. The `coderabbitai[bot]` identity records the formal GitHub review. Wait for its current `APPROVED` review before merging. A green CodeRabbit commit status alone does not satisfy this gate.
+
 ## What kinds of changes land easily
 
 - **Bug fixes** for `brigade init`, `doctor`, `scrub`, quickstart, security scanning, or the ingester.
@@ -46,34 +91,6 @@ git init -q -b main "$target"
 python -m brigade init --target "$target" --depth workspace --harnesses claude,codex,openclaw
 python -m brigade doctor --target "$target"
 ```
-
-## Pull requests
-
-`main` is branch-protected. A dispatched session cannot supply the review artifact required by its own pull request, and GitHub enforces the gate regardless of the dispatch prompt.
-
-The current rule set requires all of the following before a pull request can merge:
-
-- All 22 required GitHub Actions checks pass. The checks are pinned to GitHub Actions app id 15368, and the branch must be up to date with `main`.
-- A current formal `APPROVED` review exists from a non-author reviewer.
-- All review conversations are resolved.
-- The approval was recorded after the last push. New commits dismiss stale approvals.
-
-The pull request author cannot approve their own pull request. `gh pr review --approve` fails with "Can not approve your own pull request" when the author and reviewer share one GitHub identity.
-
-CodeRabbit is the current external review identity. Its green commit status is not the grading artifact because the status can be green while the formal GitHub review is still `CHANGES_REQUESTED`. The artifacts that count are a current formal non-author `APPROVED` review and all required checks passing.
-
-Inspect the gate before attempting a merge:
-
-```bash
-gh pr checks <number> --required
-gh pr view <number> --json reviewDecision,mergeStateStatus
-```
-
-`reviewDecision` reports `REVIEW_REQUIRED`, `CHANGES_REQUESTED`, or `APPROVED`. `mergeStateStatus` reports states such as `CLEAN`, `BLOCKED`, and `BEHIND`.
-
-Those CLI fields do not expose unresolved review conversations. Separately check the pull request's **Files changed** review panel in GitHub and confirm that no conversation remains unresolved.
-
-Dispatched sessions should open the pull request, run local verification, and push commits. After the final push, comment `@coderabbitai full review`. The `coderabbitai[bot]` identity records the formal GitHub review. Wait for its current `APPROVED` review before merging. A green CodeRabbit commit status alone does not satisfy this gate.
 
 ## Adding a harness
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,17 +14,18 @@ External contributions are welcome. This section is the short path; [Pull reques
 
 ## Pull requests
 
-`main` is branch-protected. A dispatched session cannot supply the review artifact required by its own pull request. GitHub enforces required checks; formal review is maintainer merge policy (branch protection does not currently require approving reviews).
+`main` is branch-protected. A dispatched session cannot supply the review artifact required by its own pull request. GitHub enforces required checks and conversation resolution; formal review is maintainer merge policy (branch protection does not currently require approving reviews).
 
 **GitHub-enforced gates** on `main`:
 
-- All required GitHub Actions checks pass. The checks are pinned to GitHub Actions app id 15368, and the branch must be up to date with `main`.
+- All required GitHub Actions checks pass. The checks are pinned to GitHub Actions app id 15368.
+- All review conversations are resolved.
 
 **Maintainer merge policy** (required before merge; not enforced by GitHub branch protection today):
 
 - A current formal `APPROVED` review exists from a non-author reviewer.
-- All review conversations are resolved.
 - The approval was recorded after the last push. New commits dismiss stale approvals.
+- Keep the branch current with `main` before merge when practical (branch protection does not require strict status checks, so GitHub does not block merge solely for being behind `main`).
 
 The pull request author cannot approve their own pull request. `gh pr review --approve` fails with "Can not approve your own pull request" when the author and reviewer share one GitHub identity.
 
@@ -37,9 +38,7 @@ gh pr checks <number> --required
 gh pr view <number> --json reviewDecision,mergeStateStatus
 ```
 
-`reviewDecision` reports `REVIEW_REQUIRED`, `CHANGES_REQUESTED`, or `APPROVED`. `mergeStateStatus` reports states such as `CLEAN`, `BLOCKED`, and `BEHIND`.
-
-Those CLI fields do not expose unresolved review conversations. Separately check the pull request's **Files changed** review panel in GitHub and confirm that no conversation remains unresolved.
+`reviewDecision` reports `REVIEW_REQUIRED`, `CHANGES_REQUESTED`, or `APPROVED`. `mergeStateStatus` reports states such as `CLEAN`, `BLOCKED`, and `BEHIND`. Neither field exposes unresolved review conversations; GitHub still blocks merge when any remain.
 
 Dispatched sessions should open the pull request, run local verification, and push commits. After the final push, comment `@coderabbitai full review`. The `coderabbitai[bot]` identity records the formal GitHub review. Wait for its current `APPROVED` review before merging. A green CodeRabbit commit status alone does not satisfy this gate.
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ rules, and when to use `brigade update` are in
 
 Per-OS setup (apt, Homebrew, Scoop, PowerShell), workspace depth, and multi-harness installs: [install guide](https://brigade.tools/docs/getting-started/install), [QUICKSTART.md](QUICKSTART.md), [first 10 minutes](docs/first-10-minutes.md). Homegrown setup already? `brigade operator adopt plan`.
 
+**Contributing?** See [CONTRIBUTING.md](CONTRIBUTING.md) for starter issues, the 48-hour claim convention, and the minimal local test command (`pip install -e ".[dev]" && pytest -q`).
+
 ## Auditable agents: every action leaves a receipt
 
 An agent that reports "tests pass, nothing else changed" is making a claim. Brigade turns the claim into a record. Run any check through Brigade and it writes a receipt: the command, the real exit code, the graph delta, the git state.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ rules, and when to use `brigade update` are in
 
 Per-OS setup (apt, Homebrew, Scoop, PowerShell), workspace depth, and multi-harness installs: [install guide](https://brigade.tools/docs/getting-started/install), [QUICKSTART.md](QUICKSTART.md), [first 10 minutes](docs/first-10-minutes.md). Homegrown setup already? `brigade operator adopt plan`.
 
-**Contributing?** See [CONTRIBUTING.md](CONTRIBUTING.md) for starter issues, the 48-hour claim convention, and the minimal local test command (`pip install -e ".[dev]" && pytest -q`).
+**Contributing?** See [Your first PR](CONTRIBUTING.md#your-first-pr) in [CONTRIBUTING.md](CONTRIBUTING.md) for starter issues, the 48-hour claim convention, and local verification ([Local dev](CONTRIBUTING.md#local-dev): content-guard scan for docs-only changes; `./scripts/verify` for code).
 
 ## Auditable agents: every action leaves a receipt
 


### PR DESCRIPTION
Supersedes #841. Applies the maintainer prose-gate fixes from https://github.com/escoffier-labs/brigade/pull/841#issuecomment-5242237660 without broadening the contributor contract or touching source code.

## What and why

Contributors landing from PyPI or a clone could not find the claim convention, minimal local test loop, or merge gates without reading maintainer shorthand scattered across the backlog. This slice adds a short **Your first PR** section near the top of CONTRIBUTING and moves the full pull-request enforcement rules directly below it without weakening policy. README install guidance now links to that path in one line.

Issue #763 stays open after merge: starter issues still need `good first issue` / `help wanted` labels and reviewed plain-language opening summaries (see shortlist below).

Refs #763

## Repair vs #841

- Replaced stale numeric required-check claims (`22`) with **all required checks** so docs do not drift with branch protection.
- Dropped POSIX-only `source .venv/bin/activate` from the quick-path install example; full virtualenv setup remains in **Local dev**.
- Removed hidden agent markers and Cursor footer from this PR body.
- Replaced **maintainer dogfood** with **internal maintenance work** in the label-seeding note.

## Type of change

- [x] Docs

## Checklist

- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths in this PR
- [x] No new runtime dependencies
- [x] Conventional commit message

## Label seeding shortlist (read-only, for landing shepherd)

No GitHub labels or issue bodies were changed in this PR. After merge, the shepherd should verify fit, add plain-language summaries to issue bodies where noted, and apply `good first issue` or `help wanted` as appropriate. Review current assignment and pull-request state immediately before applying newcomer labels.

| Issue | Why it may fit | Body work needed |
|-------|----------------|------------------|
| [#494](https://github.com/escoffier-labs/brigade/issues/494) | Templates and install-metadata docs; bounded enhancement with a clear What / Why | One-line plain summary at top (issue notes low priority relative to the batch) |
| [#495](https://github.com/escoffier-labs/brigade/issues/495) | Evidence brief UX with testable acceptance; single-feature scope | One-line plain summary at top |
| [#498](https://github.com/escoffier-labs/brigade/issues/498) | Security-adjacent ingestion policy with explicit redaction contract | One-line plain summary at top |
| [#493](https://github.com/escoffier-labs/brigade/issues/493) | Well-scoped schema slice with checklist acceptance; larger than typical good-first | One-line plain summary at top (complex; shepherd should confirm size label) |

Note: the open backlog is mostly assigned; these are the unowned issues in the current queue that appear closest to docs, test coverage, or small scoped fixes. Issues #762 and #759 are also unowned but are internal maintenance work or scheduler work and are poorer external starter fits.

## Verification

- `brigade security template-audit --target .` (no new findings in README or CONTRIBUTING; pre-existing findings remain in unrelated phase docs)
- `brigade guard scan CONTRIBUTING.md --policy src/brigade/guard/policies/public-repo.json` (clean)
- `brigade guard scan README.md --policy src/brigade/guard/policies/public-repo.json` (clean)
- `brigade handoff lint .claude/memory-handoffs/2026-08-10-contributor-first-pr-docs-repair.md` (clean)