### PR TITLE
fix(release): authenticate published-artifact GitHub release lookup (#819)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -453,6 +453,7 @@ jobs:
         if: matrix.kind == 'unix'
         env:
           BRIGADE_VERSION: ${{ github.ref_name }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: python scripts/published-artifact-acceptance.py --brigade-version "${BRIGADE_VERSION#v}" ${{ matrix.extra }}
       - name: Run Windows native acceptance (published CLI)
         if: matrix.kind == 'windows'

--- a/scripts/published-artifact-acceptance.py
+++ b/scripts/published-artifact-acceptance.py
@@ -14,6 +14,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import urllib.error
 import urllib.request
 from pathlib import Path
 from typing import Any, Callable, Mapping, Sequence
@@ -25,6 +26,10 @@ REPOSITORY = "escoffier-labs/brigade"
 PYPI_PROJECT_URL = "https://pypi.org/pypi/brigade-cli/json"
 PYPI_AVAILABILITY_TIMEOUT_SECONDS = 6 * 60
 PYPI_POLL_INTERVAL_SECONDS = 5
+USER_AGENT = "brigade-published-artifact-acceptance/1.0"
+GITHUB_RELEASE_TAG_MAX_ATTEMPTS = 6
+GITHUB_RELEASE_TAG_INITIAL_BACKOFF_SECONDS = 2.0
+GITHUB_RELEASE_TAG_MAX_BACKOFF_SECONDS = 30.0
 # agent-notify ldflags inject main.version, main.commit, and main.buildDate.
 # A bare `go build` leaves "dev" / "unknown" / "unknown"; published release
 # assets must report the exact Brigade release version, a hex git SHA (the
@@ -36,6 +41,7 @@ _BUILD_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
 Runner = Callable[..., subprocess.CompletedProcess[str]]
 JsonFetcher = Callable[[str], Any]
 BytesFetcher = Callable[[str], bytes]
+GithubStatusFetcher = Callable[[str], tuple[int, Any]]
 
 
 class AcceptanceError(RuntimeError):
@@ -66,6 +72,74 @@ def fetch_pypi_json(url: str) -> Any:
 def fetch_bytes(url: str) -> bytes:
     with urllib.request.urlopen(url, timeout=60) as response:
         return response.read()
+
+
+def _github_release_tag_url(tag: str) -> str:
+    return f"https://api.github.com/repos/{REPOSITORY}/releases/tags/{tag}"
+
+
+def _github_request_headers() -> dict[str, str]:
+    headers = {"Accept": "application/vnd.github+json", "User-Agent": USER_AGENT}
+    if token := os.environ.get("GITHUB_TOKEN"):
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _is_transient_github_http_status(status: int) -> bool:
+    return status in {403, 429}
+
+
+def _fetch_github_json_once(url: str) -> tuple[int, Any]:
+    request = urllib.request.Request(url, headers=_github_request_headers())
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return response.status, json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        try:
+            payload: Any = json.loads(body)
+        except json.JSONDecodeError:
+            payload = body
+        return exc.code, payload
+
+
+def wait_for_github_release_tag(
+    version: str,
+    *,
+    fetch: GithubStatusFetcher = _fetch_github_json_once,
+    sleep: Callable[[float], None] = time.sleep,
+    max_attempts: int = GITHUB_RELEASE_TAG_MAX_ATTEMPTS,
+    initial_backoff_seconds: float = GITHUB_RELEASE_TAG_INITIAL_BACKOFF_SECONDS,
+    max_backoff_seconds: float = GITHUB_RELEASE_TAG_MAX_BACKOFF_SECONDS,
+) -> dict[str, Any]:
+    """Confirm the Brigade release tag is visible through the GitHub API.
+
+    Uses ``GITHUB_TOKEN`` when present and retries transient 403/429 responses
+    with bounded exponential backoff so macOS runner rate/abuse blocks do not fail
+    an otherwise healthy publish.
+    """
+    tag = f"v{version}"
+    url = _github_release_tag_url(tag)
+    backoff = initial_backoff_seconds
+    detail = f"GitHub release lookup for {REPOSITORY}@{tag} failed"
+    for attempt in range(max_attempts):
+        status, payload = fetch(url)
+        if status == 200:
+            if not isinstance(payload, dict) or payload.get("tag_name") != tag:
+                raise AcceptanceError(f"GitHub release lookup did not report tag {tag!r}")
+            if payload.get("draft") is not False or payload.get("prerelease") is not False:
+                raise AcceptanceError("GitHub release must be a published non-prerelease")
+            return payload
+        if not _is_transient_github_http_status(status):
+            raise AcceptanceError(f"GitHub release lookup failed for {REPOSITORY}@{tag}: HTTP {status}")
+        detail = f"GitHub release lookup for {REPOSITORY}@{tag} returned HTTP {status}"
+        if attempt + 1 >= max_attempts:
+            break
+        sleep(min(backoff, max_backoff_seconds))
+        backoff = min(backoff * 2, max_backoff_seconds)
+    raise AcceptanceError(
+        f"GitHub release lookup for {REPOSITORY}@{tag} was not available after {max_attempts} attempts: {detail}"
+    )
 
 
 def _sha256_bytes(value: bytes) -> str:
@@ -440,7 +514,9 @@ def run_acceptance(version: str, *, runner: Runner = subprocess.run, rosetta_dar
         for directory in (profile, data_home, pipx_home, pipx_bin, root / "xdg-config", root / "xdg-cache"):
             directory.mkdir(parents=True)
         _write_poison_binaries(poison_dir, marker)
+        wait_for_github_release_tag(version)
         release = verify_release_assets(version, root)
+        manifest_path = root / "release-assets" / "component-manifest-v1.json"
 
         env = os.environ.copy()
         env.update(
@@ -466,8 +542,16 @@ def run_acceptance(version: str, *, runner: Runner = subprocess.run, rosetta_dar
             if version_output != f"brigade {version}":
                 raise AcceptanceError(f"installed brigade version mismatch: expected {version}, got {version_output}")
             assert_go_unavailable(env=env)
-            run_checked([managed_brigade, "setup"], runner=runner, env=env)
-            run_checked([managed_brigade, "setup", "--offline"], runner=runner, env=env)
+            run_checked(
+                [managed_brigade, "setup", "--manifest", str(manifest_path)],
+                runner=runner,
+                env=env,
+            )
+            run_checked(
+                [managed_brigade, "setup", "--offline", "--manifest", str(manifest_path)],
+                runner=runner,
+                env=env,
+            )
             report_output = run_checked([managed_brigade, "version", "--components", "--json"], runner=runner, env=env)
             try:
                 report = json.loads(report_output.stdout)

--- a/scripts/published-artifact-acceptance.py
+++ b/scripts/published-artifact-acceptance.py
@@ -18,11 +18,13 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 from typing import Any, Callable, Mapping, Sequence
+from urllib.parse import urlparse
 
 
 COMPONENT_IDS = ("agent-notify", "graphtrail", "graphtrail-mcp", "miseledger", "sessionfind")
 SUPPORTED_PLATFORMS = ("linux-amd64", "linux-arm64", "darwin-amd64", "darwin-arm64", "windows-amd64")
 REPOSITORY = "escoffier-labs/brigade"
+GITHUB_API_HOST = "api.github.com"
 PYPI_PROJECT_URL = "https://pypi.org/pypi/brigade-cli/json"
 PYPI_AVAILABILITY_TIMEOUT_SECONDS = 6 * 60
 PYPI_POLL_INTERVAL_SECONDS = 5
@@ -75,7 +77,25 @@ def fetch_bytes(url: str) -> bytes:
 
 
 def _github_release_tag_url(tag: str) -> str:
-    return f"https://api.github.com/repos/{REPOSITORY}/releases/tags/{tag}"
+    return f"https://{GITHUB_API_HOST}/repos/{REPOSITORY}/releases/tags/{tag}"
+
+
+def _is_allowed_github_api_url(url: str) -> bool:
+    parsed = urlparse(url)
+    return parsed.scheme == "https" and parsed.netloc == GITHUB_API_HOST
+
+
+class _GithubApiRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Follow redirects only when the target remains on https://api.github.com."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[no-untyped-def]
+        if not _is_allowed_github_api_url(newurl):
+            return None
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+def _github_api_opener() -> urllib.request.OpenerDirector:
+    return urllib.request.build_opener(_GithubApiRedirectHandler())
 
 
 def _github_request_headers() -> dict[str, str]:
@@ -90,9 +110,13 @@ def _is_transient_github_http_status(status: int) -> bool:
 
 
 def _fetch_github_json_once(url: str) -> tuple[int, Any]:
+    if not _is_allowed_github_api_url(url):
+        raise AcceptanceError(f"GitHub release lookup must target https://{GITHUB_API_HOST}: {url}")
     request = urllib.request.Request(url, headers=_github_request_headers())
     try:
-        with urllib.request.urlopen(request, timeout=30) as response:
+        with _github_api_opener().open(request, timeout=30) as response:
+            if not _is_allowed_github_api_url(response.geturl()):
+                raise AcceptanceError("GitHub release lookup redirected outside api.github.com")
             return response.status, json.loads(response.read().decode("utf-8"))
     except urllib.error.HTTPError as exc:
         body = exc.read().decode("utf-8", errors="replace")

--- a/tests/test_publish_workflow.py
+++ b/tests/test_publish_workflow.py
@@ -375,6 +375,25 @@ def test_prepare_dev_wheel_rejects_non_dev_versions(tmp_path, version):
         prepare_dev_wheel(tmp_path, version)
 
 
+def test_published_artifact_acceptance_unix_step_passes_github_token_from_github_token():
+    """Workflow contract: the Unix acceptance step must wire github.token into GITHUB_TOKEN.
+
+    published-artifact-acceptance.py only attaches Authorization when GITHUB_TOKEN is
+    set; github.token is not a default runner environment variable (issue #819).
+    """
+    text = (ROOT / ".github" / "workflows" / "publish.yml").read_text()
+    section = text[
+        text.index("      - name: Run published artifact acceptance (Unix)") : text.index(
+            "      - name: Run Windows native acceptance (published CLI)"
+        )
+    ]
+
+    assert "if: matrix.kind == 'unix'" in section
+    assert "BRIGADE_VERSION: ${{ github.ref_name }}" in section
+    assert "GITHUB_TOKEN: ${{ github.token }}" in section
+    assert "scripts/published-artifact-acceptance.py" in section
+
+
 def test_publish_workflow_verifies_version_check_endpoint_after_pypi_upload():
     text = (ROOT / ".github" / "workflows" / "publish.yml").read_text()
     publish = text.index("      - name: Publish to PyPI")

--- a/tests/test_published_artifact_acceptance.py
+++ b/tests/test_published_artifact_acceptance.py
@@ -128,6 +128,126 @@ def test_command_failure_preserves_installer_or_asset_error(acceptance_module):
         acceptance_module.run_checked(["pipx", "install", "brigade-cli==1.2.3"], runner=failing_runner)
 
 
+def test_github_request_headers_attach_bearer_token_when_present(acceptance_module, monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "ghs_example_token_value")
+    headers = acceptance_module._github_request_headers()
+    assert headers["Authorization"] == "Bearer ghs_example_token_value"
+    assert headers["Accept"] == "application/vnd.github+json"
+    assert headers["User-Agent"] == acceptance_module.USER_AGENT
+
+
+def test_wait_for_github_release_tag_returns_immediately_when_release_is_visible(acceptance_module):
+    calls = []
+
+    def fetch(url):
+        calls.append(url)
+        return 200, {"tag_name": "v1.2.3", "draft": False, "prerelease": False}
+
+    payload = acceptance_module.wait_for_github_release_tag(
+        "1.2.3",
+        fetch=fetch,
+        sleep=lambda _: pytest.fail("visible release should not sleep"),
+    )
+
+    assert payload["tag_name"] == "v1.2.3"
+    assert calls == [
+        "https://api.github.com/repos/escoffier-labs/brigade/releases/tags/v1.2.3",
+    ]
+
+
+def test_wait_for_github_release_tag_retries_transient_403_then_succeeds(acceptance_module):
+    sleeps = []
+    responses = iter(
+        (
+            (403, {"message": "rate limit"}),
+            (403, {"message": "abuse detection"}),
+            (200, {"tag_name": "v1.2.3", "draft": False, "prerelease": False}),
+        )
+    )
+
+    acceptance_module.wait_for_github_release_tag(
+        "1.2.3",
+        fetch=lambda _: next(responses),
+        sleep=lambda seconds: sleeps.append(seconds),
+        max_attempts=3,
+        initial_backoff_seconds=2,
+        max_backoff_seconds=8,
+    )
+
+    assert sleeps == [2, 4]
+
+
+def test_wait_for_github_release_tag_retries_429_with_bounded_backoff(acceptance_module):
+    sleeps = []
+    responses = iter(
+        (
+            (429, {"message": "rate limit"}),
+            (200, {"tag_name": "v1.2.3", "draft": False, "prerelease": False}),
+        )
+    )
+
+    acceptance_module.wait_for_github_release_tag(
+        "1.2.3",
+        fetch=lambda _: next(responses),
+        sleep=lambda seconds: sleeps.append(seconds),
+        max_attempts=2,
+        initial_backoff_seconds=3,
+        max_backoff_seconds=3,
+    )
+
+    assert sleeps == [3]
+
+
+def test_wait_for_github_release_tag_fails_after_max_attempts_on_persistent_403(acceptance_module):
+    sleeps = []
+
+    with pytest.raises(acceptance_module.AcceptanceError, match="not available after 3 attempts"):
+        acceptance_module.wait_for_github_release_tag(
+            "1.2.3",
+            fetch=lambda _: (403, {"message": "rate limit"}),
+            sleep=lambda seconds: sleeps.append(seconds),
+            max_attempts=3,
+            initial_backoff_seconds=1,
+            max_backoff_seconds=4,
+        )
+
+    assert sleeps == [1, 2]
+
+
+def test_wait_for_github_release_tag_does_not_retry_permanent_404(acceptance_module):
+    with pytest.raises(acceptance_module.AcceptanceError, match="HTTP 404"):
+        acceptance_module.wait_for_github_release_tag(
+            "1.2.3",
+            fetch=lambda _: (404, {"message": "Not Found"}),
+            sleep=lambda _: pytest.fail("permanent HTTP errors should not sleep"),
+            max_attempts=3,
+        )
+
+
+def test_wait_for_github_release_tag_rejects_tag_name_mismatch(acceptance_module):
+    with pytest.raises(acceptance_module.AcceptanceError, match="did not report tag"):
+        acceptance_module.wait_for_github_release_tag(
+            "1.2.3",
+            fetch=lambda _: (200, {"tag_name": "v9.9.9", "draft": False, "prerelease": False}),
+            sleep=lambda _: pytest.fail("tag mismatch should not sleep"),
+        )
+
+
+def test_wait_for_github_release_tag_error_messages_never_include_token(acceptance_module, monkeypatch):
+    secret = "ghs_super_secret_example_token"
+    monkeypatch.setenv("GITHUB_TOKEN", secret)
+
+    with pytest.raises(acceptance_module.AcceptanceError) as excinfo:
+        acceptance_module.wait_for_github_release_tag(
+            "1.2.3",
+            fetch=lambda _: (403, {"message": "rate limit"}),
+            sleep=lambda _: None,
+            max_attempts=1,
+        )
+
+    assert secret not in str(excinfo.value)
+
+
 def test_wait_for_pypi_version_returns_when_exact_version_is_immediately_available(acceptance_module):
     calls = []
 
@@ -612,7 +732,9 @@ def test_run_acceptance_proves_go_unavailable_immediately_before_setup_and_smoke
     that excludes Go."""
     source = SCRIPT.read_text()
     run_acceptance_body = source[source.index("def run_acceptance(") :]
-    setup_call = run_acceptance_body.index('run_checked([managed_brigade, "setup"], runner=runner, env=env)')
+    setup_call = run_acceptance_body.index(
+        'run_checked(\n                [managed_brigade, "setup", "--manifest", str(manifest_path)],'
+    )
     smoke_call = run_acceptance_body.index(
         "smoke_managed_components(managed_paths, version=version, runner=runner, env=env)"
     )
@@ -632,3 +754,12 @@ def test_run_acceptance_proves_go_unavailable_immediately_before_setup_and_smoke
     assert "smoke_managed_components" not in between_smoke
     # The PATH used in run_acceptance is built through build_go_free_path so Go is excluded.
     assert "build_go_free_path(" in run_acceptance_body
+    assert "wait_for_github_release_tag(version)" in run_acceptance_body
+    assert (
+        'run_checked(\n                [managed_brigade, "setup", "--manifest", str(manifest_path)],'
+        in run_acceptance_body
+    )
+    assert (
+        'run_checked(\n                [managed_brigade, "setup", "--offline", "--manifest", str(manifest_path)],'
+        in run_acceptance_body
+    )

--- a/tests/test_published_artifact_acceptance.py
+++ b/tests/test_published_artifact_acceptance.py
@@ -4,6 +4,10 @@ import json
 import os
 import stat
 import subprocess
+import threading
+import urllib.error
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 import pytest
@@ -134,6 +138,69 @@ def test_github_request_headers_attach_bearer_token_when_present(acceptance_modu
     assert headers["Authorization"] == "Bearer ghs_example_token_value"
     assert headers["Accept"] == "application/vnd.github+json"
     assert headers["User-Agent"] == acceptance_module.USER_AGENT
+
+
+def test_github_api_redirect_handler_blocks_cross_origin_targets(acceptance_module):
+    handler = acceptance_module._GithubApiRedirectHandler()
+    request = urllib.request.Request(
+        f"https://{acceptance_module.GITHUB_API_HOST}/repos/escoffier-labs/brigade/releases/tags/v1.2.3",
+        headers={"Authorization": "Bearer ghs_example_token_value"},
+    )
+
+    assert handler.redirect_request(request, None, 302, "Found", {}, "https://evil.example/steal") is None
+    assert (
+        handler.redirect_request(
+            request,
+            None,
+            302,
+            "Found",
+            {},
+            f"http://{acceptance_module.GITHUB_API_HOST}/repos/escoffier-labs/brigade/releases/tags/v1.2.3",
+        )
+        is None
+    )
+
+
+def test_github_api_opener_does_not_forward_authorization_on_cross_origin_redirect(acceptance_module):
+    stolen_auth: list[str | None] = []
+
+    class RedirectHandler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            if self.path == "/redirect":
+                port = self.server.server_address[1]
+                self.send_response(302)
+                self.send_header("Location", f"http://127.0.0.1:{port}/steal")
+                self.end_headers()
+                return
+            if self.path == "/steal":
+                stolen_auth.append(self.headers.get("Authorization"))
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b"{}")
+                return
+            self.send_response(404)
+            self.end_headers()
+
+        def log_message(self, format, *args):
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), RedirectHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        opener = acceptance_module._github_api_opener()
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{server.server_address[1]}/redirect",
+            headers={"Authorization": "Bearer ghs_example_token_value"},
+        )
+        with pytest.raises(urllib.error.HTTPError) as excinfo:
+            opener.open(request, timeout=2)
+        assert excinfo.value.code == 302
+        assert stolen_auth == []
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
 
 
 def test_wait_for_github_release_tag_returns_immediately_when_release_is_visible(acceptance_module):


### PR DESCRIPTION
## What and why

The v0.26.1 publish workflow failed only on `published-artifact-acceptance (darwin-arm64)` because `brigade setup` hit the unauthenticated GitHub `releases/tags` API and received HTTP 403 from runner rate/abuse detection. This change adds an authenticated release-tag preflight with bounded retry on transient 403/429 responses, drives managed setup through the already verified release manifest, wires `GITHUB_TOKEN: ${{ github.token }}` into the Unix acceptance workflow step, and blocks cross-origin urllib redirects so `Authorization` cannot leak to another host.

Closes #819

## Type of change

- [x] Bug fix
- [ ] New harness adapter / doctor check
- [ ] Docs
- [ ] Refactor with no command-surface change
- [ ] Surface change (new harness, depth, include, or breaking template/ingester change) — opened an issue first per CONTRIBUTING.md

## Checklist

- [x] `pytest -q` passes locally (`./scripts/verify`: 6707 passed, 5 skipped; 83.10% coverage)
- [x] Added or updated tests covering the change
- [ ] Updated the `Unreleased` section of `CHANGELOG.md` for any user-visible effect (entries describe effects, not commit subjects)
- [x] No personal details, hostnames, IPs, account names, tokens, or unredacted absolute paths in code, templates, tests, or this PR (the `content-guard` CI job will fail otherwise)
- [x] No new runtime dependencies (Brigade is zero-runtime-dep on purpose)
- [x] Conventional commit messages; in-house Cursor co-author trailers on substantial coding commits

## Verification

- `pytest -q tests/test_published_artifact_acceptance.py tests/test_publish_workflow.py::test_published_artifact_acceptance_unix_step_passes_github_token_from_github_token` (47 passed)
- `./scripts/verify` (full gate)
- `brigade work verify run --target . --command "pytest -q tests/test_published_artifact_acceptance.py tests/test_publish_workflow.py::test_published_artifact_acceptance_unix_step_passes_github_token_from_github_token" --capture brigade-work`
- `brigade handoff lint .claude/memory-handoffs/20260810-2100-issue-819-published-artifact-github-auth.md`

## Notes

- Scoped to `scripts/published-artifact-acceptance.py`, `tests/test_published_artifact_acceptance.py`, and the Unix published-artifact acceptance step in `.github/workflows/publish.yml`; PR #750 behavior preserved.
- `GITHUB_TOKEN` is attached as `Authorization: Bearer` when present, never logged, and not forwarded on cross-origin redirects.